### PR TITLE
docker files

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -1,0 +1,12 @@
+FROM rust:1.64.0
+ 
+WORKDIR /dust-api
+COPY . .
+ 
+# todo, split deps and dust build per https://stackoverflow.com/questions/58473606/cache-rust-dependencies-with-docker-build
+ 
+RUN cargo build --release
+
+EXPOSE 3001
+
+CMD ["target/release/dust-api"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+# docker compose up
+version: '3.4'
+services:
+  dust-front:
+    container_name: dust-front
+    build: ./front
+    ports:
+      - 3000:3000
+    depends_on:
+      - 'dust-api'
+    environment:
+      - URL=http://localhost:3000
+      - NEXTAUTH_URL=http://localhost:3000
+      - NEXTAUTH_SECRET=25da29db5485fcd27d2f671c5e28d5df8f325e9470c36cb6bf0a9d19c662255a
+      - DATABASE_URL=sqlite://localhost/:memory:?synchronize=true
+      - GITHUB_ID=47ec837fcbac1c6f1690
+      - GITHUB_SECRET=d59af0da231fc697d7dd8d3002ed1d9765e11c7f
+      - DUST_API=http://dust-api:3001
+  dust-api:
+    container_name: dust-api
+    build: ./core
+    ports:
+      - 3001:3001

--- a/front/Dockerfile
+++ b/front/Dockerfile
@@ -1,0 +1,10 @@
+from node:16
+
+WORKDIR /dust-front
+COPY package*.json ./
+
+RUN npm install
+COPY . .
+
+EXPOSE 3000
+CMD ["npm", "run", "dev"]


### PR DESCRIPTION
This lets one get going with a single command:
```
docker compose  --env-file .env.local up
```

Only thing that's different is that .env.local needs to point to api via container name instead of localhost: eg `DUST_API=http://dust-api:3001`