### PR TITLE
Added a warning for when the user has edited a dataset and attempts to navigate away without saving

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -16,6 +16,7 @@
     "pg": "^8.8.0",
     "pg-hstore": "^2.3.4",
     "react": "^18.2.0",
+    "react-beforeunload": "^2.5.3",
     "react-dom": "^18.2.0",
     "react-textarea-autosize": "^8.3.4",
     "sequelize": "^6.23.1",

--- a/front/pages/[user]/a/[sId]/datasets/[name]/index.jsx
+++ b/front/pages/[user]/a/[sId]/datasets/[name]/index.jsx
@@ -30,7 +30,7 @@ export default function ViewDatasetView({
 
   useRegisterUnloadHandlers(editorDirty);
 
-  // this is a little wonky, but in order to redirect to the datasets main page and not
+  // This is a little wonky, but in order to redirect to the dataset's main page and not
   // pop up the "You have unsaved changes" dialog, we need to set editorDirty to false
   // and then do the router redirect in the next render cycle. We use the isFinishedEditing
   // state variable to tell us when this should happen.
@@ -122,17 +122,17 @@ function useRegisterUnloadHandlers(
   editorDirty,
   unloadWarning = "You have edited your dataset but not saved your changes. Do you really want to leave this page?"
 ) {
-  // add handlers for browser navigation (typing in address bar, refresh, back button)
+  // Add handlers for browser navigation (typing in address bar, refresh, back button).
   useBeforeunload((event) => {
     if (editorDirty) {
       event.preventDefault();
-      // most browsers no longer support custom messages, but for those
-      // that do:
+      // Most browsers no longer support custom messages, but for those
+      // that do, we return the warning.
       return unloadWarning;
     }
   });
 
-  // add handler for next.js router events that don't load a new page in the browser.
+  // Add handler for next.js router events that don't load a new page in the browser.
   const router = useRouter();
   useEffect(
     (e) => {


### PR DESCRIPTION
I handled both browser-level `onbeforeunload` events and next.js router events where the browser doesn't think the page has reloaded but the URL changes. The edit dataset page should now give a warning if you edit the description or data without hitting "Update" and you try to navigate away, either by clicking an in-app link or by typing in a new address to the browser bar. It will not pop up the warning if you click "Update".

(Note that I added an existing npm package `react-beforeunload`. I did a cursory read of the code in github, and it seems small and correct, and it's offered under MIT. I did not do any kind of security audit to make sure that the npm module has the same code as the github repo.)