### PR TITLE
Add replit support

### DIFF
--- a/core/src/blocks/block.rs
+++ b/core/src/blocks/block.rs
@@ -1,5 +1,5 @@
 use crate::blocks::{
-    code::Code, data::Data, input::Input, llm::LLM, map::Map, reduce::Reduce, search::Search,
+    code::Code, data::Data, input::Input, llm::LLM, map::Map, reduce::Reduce, search::Search, replit::Replit,
 };
 use crate::project::Project;
 use crate::run::{Credentials, RunConfig};
@@ -59,6 +59,7 @@ pub enum BlockType {
     Map,
     Reduce,
     Search,
+    Replit,
 }
 
 impl ToString for BlockType {
@@ -71,6 +72,7 @@ impl ToString for BlockType {
             BlockType::Map => String::from("map"),
             BlockType::Reduce => String::from("reduce"),
             BlockType::Search => String::from("search"),
+            BlockType::Replit => String::from("replit"),
         }
     }
 }
@@ -86,6 +88,7 @@ impl FromStr for BlockType {
             "map" => Ok(BlockType::Map),
             "reduce" => Ok(BlockType::Reduce),
             "search" => Ok(BlockType::Search),
+            "replit" => Ok(BlockType::Replit),
             _ => Err(ParseError::with_message("Unknown BlockType"))?,
         }
     }
@@ -149,6 +152,7 @@ pub fn parse_block(t: BlockType, block_pair: Pair<Rule>) -> Result<Box<dyn Block
         BlockType::Map => Ok(Box::new(Map::parse(block_pair)?)),
         BlockType::Reduce => Ok(Box::new(Reduce::parse(block_pair)?)),
         BlockType::Search => Ok(Box::new(Search::parse(block_pair)?)),
+        BlockType::Replit => Ok(Box::new(Replit::parse(block_pair)?)),
     }
 }
 

--- a/core/src/blocks/replit.rs
+++ b/core/src/blocks/replit.rs
@@ -1,0 +1,158 @@
+use crate::blocks::block::{parse_pair, Block, BlockType, Env};
+use crate::Rule;
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use hyper::{body::Buf, Body, Client, Method, Request};
+use hyper_tls::HttpsConnector;
+use pest::iterators::Pair;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::io::prelude::*;
+use std::collections::HashMap;
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Error {
+    pub error: String,
+}
+
+#[derive(Clone)]
+pub struct Replit {
+    replit_user: String,
+    repl: String,
+    path: String,
+}
+
+impl Replit {
+    pub fn parse(block_pair: Pair<Rule>) -> Result<Self> {
+        let mut replit_user: Option<String> = None;
+        let mut repl: Option<String> = None;
+        let mut path: Option<String> = None;
+
+        for pair in block_pair.into_inner() {
+            match pair.as_rule() {
+                Rule::pair => {
+                    let (key, value) = parse_pair(pair)?;
+                    match key.as_str() {
+                        "replit_user" => replit_user = Some(value),
+                        "repl" => repl = Some(value),
+                        "path" => path = Some(value),
+                        _ => Err(anyhow!("Unexpected `{}` in `replit` block", key))?,
+                    }
+                }
+                Rule::expected => {
+                    Err(anyhow!("`expected` is not yet supported in `replit` block"))?
+                }
+                _ => unreachable!(),
+            }
+        }
+
+        if !replit_user.is_some() {
+            Err(anyhow!("Missing required `replit_user` in `replit` block"))?;
+        }
+
+        if !repl.is_some() {
+            Err(anyhow!("Missing required `repl` in `replit` block"))?;
+        }
+
+        Ok(Replit {
+            replit_user: replit_user.unwrap(),
+            repl: repl.unwrap(),
+            path: match path {
+                Some(path) => path,
+                None => "/".to_string(),
+            },
+        })
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+struct ReplitResult {
+    result: Option<serde_json::Value>,
+    error: Option<String>,
+}
+
+
+#[async_trait]
+impl Block for Replit {
+    fn block_type(&self) -> BlockType {
+        BlockType::Replit
+    }
+
+    fn inner_hash(&self) -> String {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update("replit".as_bytes());
+        hasher.update(self.replit_user.as_bytes());
+        hasher.update(self.repl.as_bytes());
+        hasher.update(self.path.as_bytes());
+        format!("{}", hasher.finalize().to_hex())
+    }
+
+    async fn execute(&self, _name: &str, env: &Env) -> Result<Value> {
+        let https = HttpsConnector::new();
+        let cli = Client::builder().build::<_, hyper::Body>(https);
+
+        let path_with_leading_slash =  match self.path.chars().nth(0) {
+            None => "/".to_string(),
+            Some('/') => self.path.clone(),
+            _ => "/".to_owned() + &self.path,
+        };
+
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri(format!(
+                "https://{}.{}.repl.co{}",
+                self.repl.replace(" ", "-").to_lowercase(),
+                self.replit_user,
+                path_with_leading_slash
+            ))
+            .header("Content-Type", "application/json")
+            .body(Body::from(
+                json!(HashMap::from([
+                    ("env", env),
+                ]))
+                .to_string(),
+            ))?;
+
+        let res = cli.request(req).await?;
+
+        let status = res.status();
+
+        let body = hyper::body::aggregate(res).await?;
+        let mut b: Vec<u8> = vec![];
+        body.reader().read_to_end(&mut b)?;
+        let c: &[u8] = &b;
+
+        match status {
+            hyper::StatusCode::OK => {
+                let raw: ReplitResult = serde_json::from_slice(c)?;
+                match raw.error {
+                    Some(msg) => Err(anyhow!(msg)),
+                    None => match raw.result {
+                        None => Err(anyhow!("The Repl returned neither a result, nor an error.")),
+                        Some(result) => Ok(result),
+                    }
+                }
+            }
+            s => {
+                let raw: Result<ReplitResult, serde_json::Error> = serde_json::from_slice(c);
+                match raw {
+                    Ok(api_result) => match api_result.error {
+                        None => Err(anyhow!("Unexpected error with HTTP status {} and no error message", s)),
+                        Some(err) => Err(anyhow!(err)),
+                    },
+                    Err(_) => {
+                        Err(anyhow!("Unexpected error with HTTP status {}", s))
+                    }
+                }
+            }
+        }
+    }
+
+    fn clone_box(&self) -> Box<dyn Block + Sync + Send> {
+        Box::new(self.clone())
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}

--- a/core/src/blocks/replit.rs
+++ b/core/src/blocks/replit.rs
@@ -108,7 +108,8 @@ impl Block for Replit {
             .header("Content-Type", "application/json")
             .body(Body::from(
                 json!(HashMap::from([
-                    ("env", env),
+                    ("version", json!("1.0.0")),
+                    ("env", json!(env)),
                 ]))
                 .to_string(),
             ))?;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -33,4 +33,5 @@ pub mod blocks {
     pub mod map;
     pub mod reduce;
     pub mod search;
+    pub mod replit;
 }

--- a/core/src/run.rs
+++ b/core/src/run.rs
@@ -51,6 +51,7 @@ impl RunConfig {
             BlockType::Map => 64,
             BlockType::Reduce => 64,
             BlockType::Search => 8,
+            BlockType::Replit => 8,
         }
     }
 }

--- a/front/components/app/NewBlock.jsx
+++ b/front/components/app/NewBlock.jsx
@@ -10,6 +10,7 @@ export default function NewBlock({ spec, disabled, onClick }) {
     { type: "llm", display: ["llm"] },
     { type: "code", display: ["code"] },
     { type: "search", display: ["search"] },
+    { type: "replit", display: ["replit"] },
     { type: "map_reduce", display: ["map", "reduce"] },
   ];
   if (!containsInput) {

--- a/front/components/app/blocks/Replit.jsx
+++ b/front/components/app/blocks/Replit.jsx
@@ -1,0 +1,106 @@
+import Block from "./Block";
+import { classNames, shallowBlockClone } from "../../../lib/utils";
+import TextareaAutosize from "react-textarea-autosize";
+import { useProviders } from "../../../lib/swr";
+import { filterServiceProviders } from "../../../lib/providers";
+import Link from "next/link";
+
+export default function Replit({
+  user,
+  app,
+  block,
+  status,
+  running,
+  readOnly,
+  onBlockUpdate,
+  onBlockDelete,
+  onBlockUp,
+  onBlockDown,
+}) {
+  const handleReplChange = (repl) => {
+    repl = repl.replace(/\s/g, "-");
+    console.log(repl);
+    let b = shallowBlockClone(block);
+    b.spec.repl = repl;
+    onBlockUpdate(b);
+  };
+
+  const handleReplitUserChange = (replit_user) => {
+    replit_user = replit_user.replace(/\s/g, "");
+    let b = shallowBlockClone(block);
+    b.spec.replit_user = replit_user;
+    onBlockUpdate(b);
+  };
+
+  const handlePathChange = (path) => {
+    path = path.replace(/\s/g, "");
+    let b = shallowBlockClone(block);
+    b.spec.path = path;
+    onBlockUpdate(b);
+  };
+
+  const inputClasses = classNames(
+    "block w-full resize-none w-auto rounded-md px-1 font-normal text-sm py-1 font-mono bg-slate-100",
+    readOnly
+      ? "border-white ring-0 focus:ring-0 focus:border-white"
+      : "border-white focus:border-gray-300 focus:ring-0"
+  );
+
+  return (
+    <Block
+      user={user}
+      app={app}
+      block={block}
+      status={status}
+      running={running}
+      readOnly={readOnly}
+      onBlockUpdate={onBlockUpdate}
+      onBlockDelete={onBlockDelete}
+      onBlockUp={onBlockUp}
+      onBlockDown={onBlockDown}
+    >
+      <div className="flex flex-col mx-4 w-full">
+        <div className="flex flex-col space-y-1 text-sm font-medium text-gray-700 leading-8">
+          <div className="flex-initial flex flex-row items-center space-x-1">
+            <div className="flex flex-initial items-center">
+              Enter the Repl name, Replit user, and path to an API endpoint:
+            </div>
+          </div>
+          <div className="flex w-full font-normal">
+            https://
+            <input
+              placeholder="Repl name"
+              value={block.spec.repl}
+              className={inputClasses}
+              onChange={(e) => handleReplChange(e.target.value)}
+            ></input>
+            .
+            <input
+              placeholder="Replit username"
+              value={block.spec.replit_user}
+              className={inputClasses}
+              onChange={(e) => handleReplitUserChange(e.target.value)}
+            ></input>
+            .repl.co/
+            <input
+              placeholder="path/to/api/endpoint"
+              value={block.spec.path}
+              className={inputClasses}
+              onChange={(e) => handlePathChange(e.target.value)}
+            ></input>
+          </div>
+          <div className="flex flex-initial items-center">
+            Don't know where to get started? Check out and fork our{" "}
+            <a
+              className="text-violet-600 font-bold"
+              href="https://replit.com/@aickin/Dust-with-Nextjs?v=1"
+            >
+              Next.js-based template on Replit
+            </a>
+            .
+          </div>
+        </div>
+      </div>
+    </Block>
+  );
+}

--- a/front/lib/config.js
+++ b/front/lib/config.js
@@ -21,6 +21,13 @@ export function extractConfig(spec) {
           provider_id: spec[i].config ? spec[i].config.provider_id : "",
         };
         break;
+      case "replit":
+        c[spec[i].name] = {
+          type: "replit",
+          repl: spec[i].spec ? spec[i].spec.repl : "",
+          replit_user: spec[i].spec ? spec[i].spec.replit_user : "",
+        };
+        break;
     }
   }
   return c;

--- a/front/lib/specification.js
+++ b/front/lib/specification.js
@@ -87,6 +87,21 @@ export function addBlock(spec, blockType) {
         },
       });
       break;
+    case "replit":
+      s.push({
+        type: "replit",
+        name: getNextName(spec, "REPLIT"),
+        indent: 0,
+        spec: {
+          repl: "",
+          replit_user: "",
+          path: "",
+        },
+        config: {
+          provider_id: "",
+        },
+      });
+      break;
     case "llm":
       s.push({
         type: "llm",
@@ -267,6 +282,15 @@ export function dumpSpecification(spec, latestDatasets) {
       case "search": {
         out += `search ${block.name} {\n`;
         out += `  query: \n\`\`\`\n${block.spec.query}\n\`\`\`\n`;
+        out += `}\n`;
+        out += "\n";
+        break;
+      }
+      case "replit": {
+        out += `replit ${block.name} {\n`;
+        out += `  repl: ${block.spec.repl}\n`;
+        out += `  replit_user: ${block.spec.replit_user}\n`;
+        out += `  path: ${block.spec.path}\n`;
         out += `}\n`;
         out += "\n";
         break;

--- a/front/pages/[user]/a/[sId]/index.jsx
+++ b/front/pages/[user]/a/[sId]/index.jsx
@@ -18,6 +18,7 @@ import Data from "../../../../components/app/blocks/Data";
 import LLM from "../../../../components/app/blocks/LLM";
 import Code from "../../../../components/app/blocks/Code";
 import Search from "../../../../components/app/blocks/Search";
+import Replit from "../../../../components/app/blocks/Replit";
 import { Map, Reduce } from "../../../../components/app/blocks/MapReduce";
 import { extractConfig } from "../../../../lib/config";
 import { useSavedRunStatus } from "../../../../lib/swr";
@@ -392,6 +393,24 @@ export default function App({ app, readOnly, user, ga_tracking_id }) {
                   case "search":
                     return (
                       <Search
+                        key={idx}
+                        block={block}
+                        user={user}
+                        app={app}
+                        status={status}
+                        running={runRequested || run?.status.run == "running"}
+                        readOnly={readOnly}
+                        onBlockUpdate={(block) => handleSetBlock(idx, block)}
+                        onBlockDelete={() => handleDeleteBlock(idx)}
+                        onBlockUp={() => handleMoveBlockUp(idx)}
+                        onBlockDown={() => handleMoveBlockDown(idx)}
+                      />
+                    );
+                    break;
+
+                  case "replit":
+                    return (
+                      <Replit
                         key={idx}
                         block={block}
                         user={user}


### PR DESCRIPTION
This is a PR to add very basic support for Replit. I was hoping to have a slick way to select an existing repl or create a new one, but it looks like Replit has discontinued its API support. So this one asks the product name, user, and path to the API endpoint. I made a basic template on Next.js in Replit that can answer the Dust API call here: https://replit.com/@aickin/Dust-with-Nextjs?v=1

If we want to deploy this, we should probably copy that template under an official Dust account on Replit. I'm also very unsure about the API; I just went with the simplest possible idea.