### PR TITLE
Adding .DS_Store to .gitignore for OSX users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /core/target
 *.sqlite
 Cargo.lock
+.DS_Store


### PR DESCRIPTION
Truly tiny change. OSX Finder adds .DS_Store files to folders to record info about how the folder is displayed; this change ignores those files for git. Thanks!