### PR TITLE
Made search block UI a little more self-descriptive

### DIFF
--- a/front/components/app/blocks/Search.jsx
+++ b/front/components/app/blocks/Search.jsx
@@ -75,9 +75,11 @@ export default function Search({
       <div className="flex flex-col mx-4 w-full">
         <div className="flex flex-col space-y-1 text-sm font-medium text-gray-700 leading-8">
           <div className="flex-initial flex flex-row items-center space-x-1">
-            <div className="flex flex-initial items-center">query :</div>
             {!isProvidersLoading && !serpAPIProvider && !readOnly ? (
-              <div className="px-2">
+              <div className="px-2 flex flex-row">
+                <div className="pr-2">
+                  Click here to set up your SerpAPI key:
+                </div>
                 <Link href={`/${user}/providers`}>
                   <a
                     className={classNames(
@@ -93,21 +95,27 @@ export default function Search({
                   </a>
                 </Link>
               </div>
-            ) : null}
-          </div>
-          <div className="flex w-full font-normal">
-            <TextareaAutosize
-              placeholder=""
-              className={classNames(
-                "block w-full resize-none rounded-md px-1 font-normal text-sm py-1 font-mono bg-slate-100",
-                readOnly
-                  ? "border-white ring-0 focus:ring-0 focus:border-white"
-                  : "border-white focus:border-gray-300 focus:ring-0"
-              )}
-              readOnly={readOnly}
-              value={block.spec.query}
-              onChange={(e) => handleQueryChange(e.target.value)}
-            />
+            ) : (
+              <div className="flex flex-row w-full">
+                <div className="flex-initial whitespace-nowrap pr-2">
+                  Search Google for:
+                </div>
+                <div className="flex w-full font-normal">
+                  <TextareaAutosize
+                    placeholder=""
+                    className={classNames(
+                      "block w-full resize-none rounded-md px-1 font-normal text-sm py-1 font-mono bg-slate-100",
+                      readOnly
+                        ? "border-white ring-0 focus:ring-0 focus:border-white"
+                        : "border-white focus:border-gray-300 focus:ring-0"
+                    )}
+                    readOnly={readOnly}
+                    value={block.spec.query}
+                    onChange={(e) => handleQueryChange(e.target.value)}
+                  />
+                </div>
+              </div>
+            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
Modified the search block UI:
1. Changed the text from "query:" to "Search Google for:".
2. Put the text box and the prompt on the same line.
3. Added some text about setting up SerpAPI api key in the provider not set up case.

Pics:
<img width="604" alt="Screen Shot 2022-10-31 at 4 04 20 PM" src="https://user-images.githubusercontent.com/44199/199041233-b6f0b630-b128-433d-9957-64c1feb5b3d0.png">
<img width="606" alt="Screen Shot 2022-10-31 at 4 03 23 PM" src="https://user-images.githubusercontent.com/44199/199041259-26e2386d-5b6e-4b04-95f3-a5f051ca2590.png">
