### PR TITLE
Made the code block prompt slightly friendlier

### DIFF
--- a/front/components/app/blocks/Code.jsx
+++ b/front/components/app/blocks/Code.jsx
@@ -41,7 +41,11 @@ export default function Code({
     >
       <div className="flex flex-col mx-4 w-full">
         <div className="flex flex-col space-y-1 text-sm font-medium text-gray-700 leading-8">
-          <div className="flex flex-initial items-center">code :</div>
+          <div className="flex flex-initial items-center">
+            Run the JavaScript
+            <span className="font-mono whitespace-pre"> _fun </span>
+            function defined here:
+          </div>
           <div className="flex w-full font-normal">
             <div className="w-full leading-4">
               <div


### PR DESCRIPTION
Just changed the text from "code: " to "Run the JavaScript `_fun` function defined here:"

Pics:

<img width="652" alt="Screen Shot 2022-10-31 at 4 15 08 PM" src="https://user-images.githubusercontent.com/44199/199042929-8e701ca6-d26f-4822-96b3-1ee68d615179.png">
