### PR TITLE
Made the map block slightly more user friendly

### DIFF
--- a/front/components/app/blocks/MapReduce.jsx
+++ b/front/components/app/blocks/MapReduce.jsx
@@ -20,8 +20,23 @@ export function Map({
   };
 
   const handleRepeatChange = (repeat) => {
+    // filter out any non-digits
+    repeat = parseInt(repeat);
+    // if it's the blank string, then use the special value 0, which
+    // means "blank" for the repeat input.
+    if (isNaN(repeat)) repeat = 0;
     let b = shallowBlockClone(block);
-    b.spec.repeat = repeat;
+    b.spec.repeat = repeat.toString();
+    onBlockUpdate(b);
+  };
+
+  const handleLoopModeChange = (mode) => {
+    let b = shallowBlockClone(block);
+    if (mode === "array") {
+      b.spec.repeat = "";
+    } else {
+      b.spec.repeat = "3";
+    }
     onBlockUpdate(b);
   };
 
@@ -41,14 +56,35 @@ export function Map({
       <div className="flex flex-col mx-4 w-full">
         <div className="flex flex-col lg:flex-row lg:space-x-4">
           <div className="flex-initial flex flex-row items-center space-x-1 text-sm font-medium text-gray-700 leading-8">
-            <div className="flex flex-initial">from:</div>
+            <div className="flex flex-initial">
+              <select
+                className={classNames(
+                  "block text-right flex-1 rounded-md px-1 text-gray-700 text-sm bg-slate-100 py-1 pr-8",
+                  readOnly
+                    ? "border-white ring-0 focus:ring-0 focus:border-white"
+                    : "border-white focus:border-gray-300 focus:ring-0"
+                )}
+                value={block.spec.repeat === "" ? "array" : "output"}
+                onChange={(e) => handleLoopModeChange(e.target.value)}
+              >
+                <option value="array">
+                  Loop over the array output of block:
+                </option>
+                <option value="output">
+                  Loop N times over the full output of block:
+                </option>
+              </select>
+            </div>
             <div className="flex flex-initial font-normal">
               <input
                 type="text"
+                placeholder="BLOCK_NAME"
                 className={classNames(
-                  "block flex-1 rounded-md px-1 font-bold text-gray-700 uppercase text-sm py-1 w-48",
+                  "block flex-1 rounded-md px-1 font-bold text-gray-700 uppercase text-sm bg-slate-100 py-1 w-48",
                   readOnly
                     ? "border-white ring-0 focus:ring-0 focus:border-white"
+                    : block.spec.from?.trim() === ""
+                    ? "border-orange-400 focus:border-orange-400 focus:ring-0"
                     : "border-white focus:border-gray-300 focus:ring-0"
                 )}
                 readOnly={readOnly}
@@ -57,24 +93,30 @@ export function Map({
               />
             </div>
           </div>
-          <div className="flex-initial flex flex-row items-center space-x-1 text-sm font-medium text-gray-700 leading-8">
-            <div className="flex flex-initial">repeat:</div>
-            <div className="flex flex-initial font-normal">
-              <input
-                type="text"
-                className={classNames(
-                  "block flex-1 rounded-md px-1 font-normal text-sm py-1 w-8",
-                  readOnly
-                    ? "border-white ring-0 focus:ring-0 focus:border-white"
-                    : "border-white focus:border-gray-300 focus:ring-0"
-                )}
-                spellCheck={false}
-                readOnly={readOnly}
-                value={block.spec.repeat}
-                onChange={(e) => handleRepeatChange(e.target.value)}
-              />
+
+          {block.spec.repeat !== "" ? (
+            <div className="flex-initial flex flex-row items-center space-x-1 text-sm font-medium text-gray-700 leading-8">
+              <div className="flex flex-initial">Loop</div>
+              <div className="flex flex-initial font-normal">
+                <input
+                  type="text"
+                  className={classNames(
+                    "block flex-1 rounded-md px-1 font-normal bg-slate-100 text-sm py-1 w-12",
+                    readOnly
+                      ? "border-white ring-0 focus:ring-0 focus:border-white"
+                      : block.spec.repeat === "0"
+                      ? "border-orange-400 focus:border-orange-400 focus:ring-0"
+                      : "border-white focus:border-gray-300 focus:ring-0"
+                  )}
+                  spellCheck={false}
+                  readOnly={readOnly}
+                  value={block.spec.repeat === "0" ? "" : block.spec.repeat}
+                  onChange={(e) => handleRepeatChange(e.target.value)}
+                />
+              </div>
+              <div className="flex flex-initial">times</div>
             </div>
-          </div>
+          ) : null}
         </div>
       </div>
     </Block>

--- a/front/pages/[user]/a/[sId]/index.jsx
+++ b/front/pages/[user]/a/[sId]/index.jsx
@@ -52,6 +52,16 @@ const isRunnable = (readOnly, spec, config) => {
         if (!block.spec.dataset || block.spec.dataset.length == 0) {
           return false;
         }
+      case "map":
+        // Should we also make it so that it can't run if the from block doesn't exist?
+        if (!block.spec.from) {
+          return false;
+        }
+        // repeat as 0 is a special case that is displayed in the UI as
+        // "Loop N times over the full output of block:" but with a blank repeat input.
+        if (block.spec.repeat === 0) {
+          return false;
+        }
       default:
         if (
           !block.name ||


### PR DESCRIPTION
I tried to make the map block a little more user friendly with this PR, not sure I did it entirely correctly so would love a second pair of eyes.

By my read of `map.rs`, the map block has two different modes, depending on the value of `repeat`. If `repeat` is a blank string, then the map block loops over the items in an array that is output by the block specified in `from`. If `repeat` is a number, however, then it loops `repeat` times over the entire output of the block `from`. This behavior change based on the value of repeat was not really expressed in the UI, so I took a stab at doing so.

Now there are two modes: "Loop over the array output of block:" and "Loop N times over the full output of block:", which are selectable by a `<select>`. The `repeat` input only shows up when you select "Loop N times over the full output of block:".

Other changes I did here:
* I gave the `from` and `repeat` inputs a gray background so you can tell that they are inputs when they don't have focus.
* I made the app un-runnable when `from` or `repeat` are blank. I also gave those inputs an orange outline when they are blocking run.

I did not validate that `from` is a valid block name, which we might want to consider in the future. It gets a little complicated when you rename the block that the map block is referencing, so I wanted to leave it be for now.

Pics: 
<img width="575" alt="Screen Shot 2022-10-31 at 5 22 10 PM" src="https://user-images.githubusercontent.com/44199/199059977-ed2b75c4-ee5e-481a-aa1a-89b0695e4f74.png">
map block in "Loop over the array output of block:" mode

<img width="714" alt="Screen Shot 2022-10-31 at 5 22 19 PM" src="https://user-images.githubusercontent.com/44199/199060011-729793d8-e2fb-49f0-99ce-45ad2be7d2e9.png">
map block in "Loop N times over the full output of block:" mode

<img width="720" alt="Screen Shot 2022-10-31 at 5 23 03 PM" src="https://user-images.githubusercontent.com/44199/199060029-5271939b-0840-4490-b30c-7215abdd0ab8.png">
Orange outlines and run button disabled when inputs are blank