### PR TITLE
Added a show all link for text >400 characters

### DIFF
--- a/front/components/app/blocks/Output.jsx
+++ b/front/components/app/blocks/Output.jsx
@@ -105,11 +105,42 @@ function ValueViewer({ block, value, k }) {
           {k != null ? (
             <span className="text-gray-700 mr-1 font-bold">{k}:</span>
           ) : null}
-          <span className="whitespace-pre-wrap">{value}</span>
+          <span className="whitespace-pre-wrap">
+            {typeof value === "string" ? <StringViewer value={value} /> : value}
+          </span>
         </div>
       )}
     </div>
   );
+}
+
+const STRING_SHOW_MORE_LINK_LENGTH = 400;
+
+// This viewer just truncates very long strings with a show all link for
+// seeing the full value. It does not currently allow you to hide the
+// text again.
+function StringViewer({ value }) {
+  const [expanded, setExpanded] = useState(false);
+
+  if (expanded) {
+    return value;
+  }
+
+  if (value.length < STRING_SHOW_MORE_LINK_LENGTH) {
+    return value;
+  } else {
+    return (
+      <span>
+        {value.slice(0, STRING_SHOW_MORE_LINK_LENGTH)}...{" "}
+        <span
+          className="text-violet-600 hover:text-violet-500 font-bold cursor-pointer"
+          onClick={(e) => setExpanded(!expanded)}
+        >
+          show all
+        </span>
+      </span>
+    );
+  }
 }
 
 function Error({ error }) {


### PR DESCRIPTION
The current logic for auto-expansion of results is that any primitive, flat object, or flat array is auto-expanded, but other results are not. This can be annoying in Dust apps that have some very long results, especially those that use web scraping.

This is a very, VERY simple PR that truncates text to 400 characters and adds a "show all" link when it does so. Clicking that link shows the entire text of the particular field. There is no "show less" link, but when you close up and re-open the parent object, you will get the "show all" link again. There are definitely things that could be done to make this better, especially for text that has a lot of carriage returns in the first 400 chars, but this is probably a decent stopgap solution.

Pics:

Text being truncated with "show all" link:
<img width="701" alt="Screen Shot 2022-10-31 at 6 07 45 PM" src="https://user-images.githubusercontent.com/44199/199068036-d7fb1a54-4e1b-4dc2-9dea-41fb318ea567.png">


After "show all" is clicked:
<img width="718" alt="Screen Shot 2022-10-31 at 6 07 51 PM" src="https://user-images.githubusercontent.com/44199/199068112-81f52903-09e5-4a66-affd-52068d7d1d2d.png">
