### PR TITLE
Added default of null for GA_TRACKING_ID so if it's undefined in .env.local, there's no error.

### DIFF
--- a/front/pages/[user]/a/[sId]/datasets/[name]/index.jsx
+++ b/front/pages/[user]/a/[sId]/datasets/[name]/index.jsx
@@ -10,7 +10,7 @@ import Router, { useRouter } from "next/router";
 import DatasetView from "../../../../../../components/app/DatasetView";
 import { useBeforeunload } from "react-beforeunload";
 
-const { URL, GA_TRACKING_ID } = process.env;
+const { URL, GA_TRACKING_ID = null } = process.env;
 
 export default function ViewDatasetView({
   app,

--- a/front/pages/[user]/a/[sId]/datasets/index.jsx
+++ b/front/pages/[user]/a/[sId]/datasets/index.jsx
@@ -9,7 +9,7 @@ import { useSession } from "next-auth/react";
 import { classNames } from "../../../../../lib/utils";
 import Router from "next/router";
 
-const { URL, GA_TRACKING_ID } = process.env;
+const { URL, GA_TRACKING_ID = null } = process.env;
 
 export default function DatasetsView({
   app,

--- a/front/pages/[user]/a/[sId]/datasets/new.jsx
+++ b/front/pages/[user]/a/[sId]/datasets/new.jsx
@@ -9,9 +9,14 @@ import "@uiw/react-textarea-code-editor/dist.css";
 import Router from "next/router";
 import DatasetView from "../../../../../components/app/DatasetView";
 
-const { URL, GA_TRACKING_ID } = process.env;
+const { URL, GA_TRACKING_ID = null } = process.env;
 
-export default function NewDatasetView({ app, datasets, user, ga_tracking_id }) {
+export default function NewDatasetView({
+  app,
+  datasets,
+  user,
+  ga_tracking_id,
+}) {
   const { data: session } = useSession();
 
   const [disable, setDisabled] = useState(true);

--- a/front/pages/[user]/a/[sId]/index.jsx
+++ b/front/pages/[user]/a/[sId]/index.jsx
@@ -25,7 +25,7 @@ import { useSavedRunStatus } from "../../../../lib/swr";
 import { mutate } from "swr";
 import { useSession } from "next-auth/react";
 
-const { URL, GA_TRACKING_ID } = process.env;
+const { URL, GA_TRACKING_ID = null } = process.env;
 
 let saveTimeout = null;
 

--- a/front/pages/[user]/a/[sId]/settings.jsx
+++ b/front/pages/[user]/a/[sId]/settings.jsx
@@ -9,7 +9,7 @@ import { useState, useRef } from "react";
 import { useSession } from "next-auth/react";
 import { useEffect } from "react";
 
-const { URL, GA_TRACKING_ID } = process.env;
+const { URL, GA_TRACKING_ID = null } = process.env;
 
 export default function DatasetsView({ app, user, readOnly, ga_tracking_id }) {
   const { data: session } = useSession();

--- a/front/pages/[user]/apps/index.jsx
+++ b/front/pages/[user]/apps/index.jsx
@@ -8,7 +8,7 @@ import Link from "next/link";
 import { useSession } from "next-auth/react";
 import { classNames, communityApps } from "../../../lib/utils";
 
-const { URL, GA_TRACKING_ID } = process.env;
+const { URL, GA_TRACKING_ID = null } = process.env;
 
 export default function Home({ apps, readOnly, user, ga_tracking_id }) {
   const { data: session } = useSession();

--- a/front/pages/[user]/apps/new.jsx
+++ b/front/pages/[user]/apps/new.jsx
@@ -8,7 +8,7 @@ import React, { useState, useEffect, useRef } from "react";
 import { classNames } from "../../../lib/utils";
 import { ChevronRightIcon } from "@heroicons/react/20/solid";
 
-const { URL, GA_TRACKING_ID } = process.env;
+const { URL, GA_TRACKING_ID = null } = process.env;
 
 export default function New({ apps, ga_tracking_id }) {
   const { data: session } = useSession();

--- a/front/pages/[user]/providers/index.jsx
+++ b/front/pages/[user]/providers/index.jsx
@@ -13,7 +13,7 @@ import { useState } from "react";
 import { useProviders } from "../../../lib/swr";
 import { modelProviders, serviceProviders } from "../../../lib/providers";
 
-const { URL, GA_TRACKING_ID } = process.env;
+const { URL, GA_TRACKING_ID = null } = process.env;
 
 export default function ProfileProviders({ ga_tracking_id }) {
   const { data: session } = useSession();

--- a/front/pages/index.jsx
+++ b/front/pages/index.jsx
@@ -10,7 +10,7 @@ import { CheckIcon } from "@heroicons/react/24/outline";
 import Link from "next/link";
 import { classNames, communityApps } from "../lib/utils";
 
-const { GA_TRACKING_ID } = process.env;
+const { GA_TRACKING_ID = null } = process.env;
 
 const features = [
   {

--- a/front/pages/readme.jsx
+++ b/front/pages/readme.jsx
@@ -4,7 +4,7 @@ import { unstable_getServerSession } from "next-auth/next";
 import { authOptions } from "./api/auth/[...nextauth]";
 import { Logo } from "../components/Logo";
 
-const { GA_TRACKING_ID } = process.env;
+const { GA_TRACKING_ID = null } = process.env;
 
 function Block({ type }) {
   return (


### PR DESCRIPTION
In `main`, if you don't define `GA_TRACKING_ID`, then there's a runtime error because Next.js won't serialize an undefined server prop. I added a default of null, and this seems to make Next happy.