### PR TITLE
Fix for CSS selectors with special characters.

### DIFF
--- a/front/lib/specification.js
+++ b/front/lib/specification.js
@@ -321,7 +321,7 @@ export function dumpSpecification(spec, latestDatasets) {
       case "browser": {
         out += `browser ${block.name} {\n`;
         out += `  url: \n\`\`\`\n${block.spec.url}\n\`\`\`\n`;
-        out += `  selector: ${block.spec.selector}\n`;
+        out += `  selector: \n\`\`\`\n${block.spec.selector}\n\`\`\`\n`;
         out += `}\n`;
         out += "\n";
         break;


### PR DESCRIPTION
Fixes #69. The issue was that the Dust spec doesn't allow special characters in <name>: <value> lines. It does allow them in multiline strings, though, so I changed it so that selector is always stored in a multiline.

