### PR TITLE
Add run_type column to Dust API runs + ability to run on arbitrary inputs

### DIFF
--- a/core/bin/dust.rs
+++ b/core/bin/dust.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use clap::{Parser, Subcommand};
-use dust::{app, blocks::block::BlockType, dataset, init, providers::provider, run, stores, utils};
+use dust::{app, blocks::block::BlockType, dataset, init, providers::provider, run, utils};
 
 #[derive(Parser)]
 #[clap(author, version, about, long_about = None)]
@@ -14,7 +14,7 @@ enum Commands {
     /// Initialize a new Dust project
     Init {
         /// Path to the directory to init
-        #[clap(default_value = ".")]
+        #[clap(value_parser, default_value = ".")]
         path: String,
     },
     /// Manage versioned JSONL dataset files
@@ -45,10 +45,10 @@ enum DatasetCommands {
     /// be checked and stored in the Dust project store.
     Register {
         /// Dataset id to register or update
-        #[clap(required = true)]
+        #[clap(value_parser, required = true)]
         dataset_id: String,
         /// Path to the JSONL dataset file
-        #[clap(required = true)]
+        #[clap(value_parser, required = true)]
         jsonl_path: String,
     },
 }
@@ -58,13 +58,13 @@ enum ProviderCommands {
     /// Provides instructions to setup a new provider.
     Setup {
         /// Provider id
-        #[clap(required = true)]
+        #[clap(value_parser, required = true)]
         provider_id: provider::ProviderID,
     },
     /// Tests whether a provider is properly setup.
     Test {
         /// Provider id
-        #[clap(required = true)]
+        #[clap(value_parser, required = true)]
         provider_id: provider::ProviderID,
     },
 }
@@ -74,11 +74,11 @@ enum AppCommands {
     /// Runs an app on registered data using the specified model
     Run {
         /// Dataset id to run the app on
-        #[clap(required = true)]
+        #[clap(value_parser, required = true)]
         dataset_id: String,
 
         /// Run config path (JSON)
-        #[clap(required = true)]
+        #[clap(value_parser, required = true)]
         config_path: String,
     },
 }
@@ -90,15 +90,15 @@ enum RunCommands {
     /// Inspect data from a previous run
     Inspect {
         /// Run id to inspect
-        #[clap(required = true)]
+        #[clap(value_parser, required = true)]
         run_id: String,
 
         /// Block type to inspect
-        #[clap(required = true)]
+        #[clap(value_parser, required = true)]
         block_type: BlockType,
 
         /// Block name to inspect
-        #[clap(required = true)]
+        #[clap(value_parser, required = true)]
         block_name: String,
     },
 }

--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -444,6 +444,7 @@ async fn datasets_retrieve(
 
 #[derive(serde::Deserialize)]
 struct RunsCreatePayload {
+    run_type: run::RunType,
     specification: String,
     dataset_id: Option<String>,
     config: run::RunConfig,
@@ -573,7 +574,13 @@ async fn runs_create(
     }
 
     match app
-        .prepare_run(payload.config, project.clone(), d, state.store.clone())
+        .prepare_run(
+            payload.run_type,
+            payload.config,
+            project.clone(),
+            d,
+            state.store.clone(),
+        )
         .await
     {
         Err(e) => {

--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -447,6 +447,7 @@ struct RunsCreatePayload {
     run_type: run::RunType,
     specification: String,
     dataset_id: Option<String>,
+    inputs: Option<Vec<Value>>,
     config: run::RunConfig,
     credentials: run::Credentials,
 }
@@ -474,7 +475,7 @@ async fn runs_create(
         Ok(app) => app,
     };
 
-    let d = match payload.dataset_id.as_ref() {
+    let mut d = match payload.dataset_id.as_ref() {
         None => None,
         Some(dataset_id) => match state.store.latest_dataset_hash(&project, dataset_id).await {
             Err(e) => {
@@ -526,23 +527,38 @@ async fn runs_create(
         },
     };
 
-    if d.is_some() && d.as_ref().unwrap().len() == 0 {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(APIResponse {
-                error: Some(APIError {
-                    code: String::from("dataset_empty_error"),
-                    message: format!(
-                        "Dataset `{}` has 0 record",
-                        payload.dataset_id.as_ref().unwrap()
-                    ),
-                }),
-                response: None,
-            }),
-        );
-    }
-
     if d.is_some() {
+        if payload.run_type != run::RunType::Local {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(APIResponse {
+                    error: Some(APIError {
+                        code: String::from("invalid_run_type_error"),
+                        message: String::from(
+                            "RunType `local` is expected when a `dataset_id` is provided",
+                        ),
+                    }),
+                    response: None,
+                }),
+            );
+        }
+
+        if d.as_ref().unwrap().len() == 0 {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(APIResponse {
+                    error: Some(APIError {
+                        code: String::from("dataset_empty_error"),
+                        message: format!(
+                            "Dataset `{}` has 0 record",
+                            payload.dataset_id.as_ref().unwrap()
+                        ),
+                    }),
+                    response: None,
+                }),
+            );
+        }
+
         utils::info(
             format!(
                 "Retrieved {} records from latest data version for `{}`.",
@@ -551,6 +567,41 @@ async fn runs_create(
             )
             .as_str(),
         );
+    }
+
+    if payload.inputs.is_some() {
+        if payload.run_type != run::RunType::Deploy {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(APIResponse {
+                    error: Some(APIError {
+                        code: String::from("invalid_run_type_error"),
+                        message: String::from(
+                            "RunType `deploy` is expected when `inputs` are provided",
+                        ),
+                    }),
+                    response: None,
+                }),
+            );
+        }
+
+        d = match dataset::Dataset::new_from_jsonl("inputs", payload.inputs.unwrap()).await {
+            Err(e) => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(APIResponse {
+                        error: Some(APIError {
+                            code: String::from("invalid_inputs_error"),
+                            message: e.to_string(),
+                        }),
+                        response: None,
+                    }),
+                )
+            }
+            Ok(d) => Some(d),
+        };
+
+        utils::info(format!("Received {} inputs.", d.as_ref().unwrap().len(),).as_str());
     }
 
     match state

--- a/core/src/app.rs
+++ b/core/src/app.rs
@@ -223,7 +223,6 @@ impl App {
     ) -> Result<()> {
         assert!(self.run.is_some());
         assert!(self.run_config.is_some());
-        // assert!(self.dataset.is_some());
         assert!(self.project.is_some());
 
         let project = self.project.as_ref().unwrap().clone();

--- a/core/src/app.rs
+++ b/core/src/app.rs
@@ -1,7 +1,7 @@
 use crate::blocks::block::{parse_block, Block, BlockType, Env, InputState, MapState};
 use crate::dataset::Dataset;
 use crate::project::Project;
-use crate::run::{BlockExecution, BlockStatus, Credentials, Run, RunConfig, Status};
+use crate::run::{BlockExecution, BlockStatus, Credentials, Run, RunConfig, RunType, Status};
 use crate::stores::{sqlite::SQLiteStore, store::Store};
 use crate::utils;
 use crate::{DustParser, Rule};
@@ -185,6 +185,7 @@ impl App {
 
     pub async fn prepare_run(
         &mut self,
+        run_type: RunType,
         run_config: RunConfig,
         project: Project,
         dataset: Option<Dataset>,
@@ -202,6 +203,7 @@ impl App {
 
         let store = store.clone();
         self.run = Some(Run::new(
+            run_type,
             &self.hash,
             self.run_config.as_ref().unwrap().clone(),
         ));
@@ -657,6 +659,7 @@ pub async fn cmd_run(dataset_id: &str, config_path: &str) -> Result<()> {
         .await?;
 
     app.prepare_run(
+        RunType::Local,
         run_config,
         project.clone(),
         Some(d),

--- a/core/src/stores/migrations/20221110_run_types
+++ b/core/src/stores/migrations/20221110_run_types
@@ -1,0 +1,3 @@
+ALTER TABLE runs ADD COLUMN run_type TEXT DEFAULT 'local';
+CREATE INDEX IF NOT EXISTS idx_runs_project_run_type_created ON runs (project, run_type, created);
+DROP INDEX IF EXISTS idx_runs_project_created;

--- a/core/src/stores/migrations/20221110_run_types
+++ b/core/src/stores/migrations/20221110_run_types
@@ -1,3 +1,4 @@
 ALTER TABLE runs ADD COLUMN run_type TEXT DEFAULT 'local';
 CREATE INDEX IF NOT EXISTS idx_runs_project_run_type_created ON runs (project, run_type, created);
 DROP INDEX IF EXISTS idx_runs_project_created;
+DROP INDEX IF EXISTS idx_cache_hash;

--- a/core/src/stores/postgres.rs
+++ b/core/src/stores/postgres.rs
@@ -871,26 +871,18 @@ impl Store for PostgresStore {
         let created = generation.created as i64;
         let request_data = serde_json::to_string(&request)?;
         let generation_data = serde_json::to_string(&generation)?;
-        match c
-            .query_one(
-                &stmt,
-                &[
-                    &project_id,
-                    &created,
-                    &request.hash().to_string(),
-                    &request_data,
-                    &generation_data,
-                ],
-            )
-            .await
-        {
-            Ok(_) => Ok(()),
-            Err(e) => match e.code() {
-                // The entry was inserted concurrently.
-                Some(&SqlState::UNIQUE_VIOLATION) => Ok(()),
-                _ => Err(e.into()),
-            },
-        }
+        c.query_one(
+            &stmt,
+            &[
+                &project_id,
+                &created,
+                &request.hash().to_string(),
+                &request_data,
+                &generation_data,
+            ],
+        )
+        .await?;
+        Ok(())
     }
 
     async fn http_cache_get(
@@ -944,26 +936,18 @@ impl Store for PostgresStore {
         let created = response.created as i64;
         let request_data = serde_json::to_string(&request)?;
         let response_data = serde_json::to_string(&response)?;
-        match c
-            .query_one(
-                &stmt,
-                &[
-                    &project_id,
-                    &created,
-                    &request.hash().to_string(),
-                    &request_data,
-                    &response_data,
-                ],
-            )
-            .await
-        {
-            Ok(_) => Ok(()),
-            Err(e) => match e.code() {
-                // The entry was inserted concurrently.
-                Some(&SqlState::UNIQUE_VIOLATION) => Ok(()),
-                _ => Err(e.into()),
-            },
-        }
+        c.query_one(
+            &stmt,
+            &[
+                &project_id,
+                &created,
+                &request.hash().to_string(),
+                &request_data,
+                &response_data,
+            ],
+        )
+        .await?;
+        Ok(())
     }
 
     fn clone_box(&self) -> Box<dyn Store + Sync + Send> {

--- a/core/src/stores/postgres.rs
+++ b/core/src/stores/postgres.rs
@@ -13,7 +13,7 @@ use bb8_postgres::PostgresConnectionManager;
 use serde_json::Value;
 use std::collections::HashMap;
 use std::str::FromStr;
-use tokio_postgres::{error::SqlState, NoTls};
+use tokio_postgres::NoTls;
 
 #[derive(Clone)]
 pub struct PostgresStore {

--- a/core/src/stores/sqlite.rs
+++ b/core/src/stores/sqlite.rs
@@ -3,7 +3,7 @@ use crate::dataset::Dataset;
 use crate::http::request::{HttpRequest, HttpResponse};
 use crate::project::Project;
 use crate::providers::llm::{LLMGeneration, LLMRequest};
-use crate::run::{BlockExecution, Run, RunConfig, RunStatus};
+use crate::run::{BlockExecution, Run, RunConfig, RunStatus, RunType};
 use crate::stores::store::{Store, SQLITE_TABLES, SQL_INDEXES};
 use crate::utils;
 use anyhow::Result;
@@ -328,15 +328,16 @@ impl Store for SQLiteStore {
         .await?
     }
 
-    async fn latest_run_id(&self, project: &Project) -> Result<Option<String>> {
+    async fn latest_run_id(&self, project: &Project, run_type: RunType) -> Result<Option<String>> {
         let project_id = project.project_id();
 
         let pool = self.pool.clone();
         tokio::task::spawn_blocking(move || -> Result<Option<String>> {
             let c = pool.get()?;
             match c.query_row(
-                "SELECT run_id FROM runs WHERE project = ?1 ORDER BY created DESC LIMIT 1",
-                params![project_id],
+                "SELECT run_id FROM runs WHERE project = ?1 AND run_type = ?2
+                   ORDER BY created DESC LIMIT 1",
+                params![project_id, run_type.to_string()],
                 |row| row.get(0),
             ) {
                 Err(e) => match e {
@@ -349,7 +350,11 @@ impl Store for SQLiteStore {
         .await?
     }
 
-    async fn all_runs(&self, project: &Project) -> Result<Vec<(String, u64, String, RunConfig)>> {
+    async fn all_runs(
+        &self,
+        project: &Project,
+        run_type: RunType,
+    ) -> Result<Vec<(String, u64, String, RunConfig)>> {
         let project_id = project.project_id();
 
         let pool = self.pool.clone();
@@ -357,9 +362,11 @@ impl Store for SQLiteStore {
             let c = pool.get()?;
             // Retrieve runs.
             let mut stmt = c.prepare_cached(
-                "SELECT run_id, created, app_hash, config_json FROM runs WHERE project = ?1",
+                "SELECT run_id, created, app_hash, config_json FROM runs
+                   WHERE project = ?1 AND run_type = ?2
+                   ORDER BY created DESC",
             )?;
-            let mut rows = stmt.query(params![project_id])?;
+            let mut rows = stmt.query(params![project_id, run_type.to_string()])?;
             let mut runs: Vec<(String, u64, String, RunConfig)> = vec![];
             while let Some(row) = rows.next()? {
                 let run_id: String = row.get(0)?;
@@ -381,6 +388,7 @@ impl Store for SQLiteStore {
         let project_id = project.project_id();
         let run_id = run.run_id().to_string();
         let created = run.created();
+        let run_type = run.run_type();
         let app_hash = run.app_hash().to_string();
         let run_config = run.config().clone();
         let run_status = run.status().clone();
@@ -392,13 +400,15 @@ impl Store for SQLiteStore {
             let config_data = serde_json::to_string(&run_config)?;
             let status_data = serde_json::to_string(&run_status)?;
             let mut stmt = c.prepare_cached(
-                "INSERT INTO runs (project, created, run_id, app_hash, config_json, status_json)
-                   VALUES (?, ?, ?, ?, ?, ?)",
+                "INSERT INTO runs
+                   (project, created, run_id, run_type, app_hash, config_json, status_json)
+                   VALUES (?, ?, ?, ?, ?, ?, ?)",
             )?;
             let _ = stmt.insert(params![
                 project_id,
                 created,
                 run_id,
+                run_type.to_string(),
                 app_hash,
                 config_data,
                 status_data
@@ -586,8 +596,8 @@ impl Store for SQLiteStore {
         tokio::task::spawn_blocking(move || -> Result<Option<Run>> {
             let c = pool.get()?;
             // Check that the run_id exists
-            let d: Option<(u64, u64, String, String, String)> = match c.query_row(
-                "SELECT id, created, app_hash, config_json, status_json FROM runs
+            let d: Option<(u64, u64, String, String, String, String)> = match c.query_row(
+                "SELECT id, created, run_type, app_hash, config_json, status_json FROM runs
                    WHERE project = ?1 AND run_id = ?2",
                 params![project_id, run_id],
                 |row| {
@@ -597,6 +607,7 @@ impl Store for SQLiteStore {
                         row.get(2).unwrap(),
                         row.get(3).unwrap(),
                         row.get(4).unwrap(),
+                        row.get(5).unwrap(),
                     ))
                 },
             ) {
@@ -604,14 +615,20 @@ impl Store for SQLiteStore {
                     rusqlite::Error::QueryReturnedNoRows => None,
                     _ => Err(e)?,
                 },
-                Ok((row_id, created, app_hash, config_data, status_data)) => {
-                    Some((row_id, created, app_hash, config_data, status_data))
-                }
+                Ok((row_id, created, run_type, app_hash, config_data, status_data)) => Some((
+                    row_id,
+                    created,
+                    run_type,
+                    app_hash,
+                    config_data,
+                    status_data,
+                )),
             };
             if d.is_none() {
                 return Ok(None);
             }
-            let (row_id, created, app_hash, config_data, status_data) = d.unwrap();
+            let (row_id, created, run_type_str, app_hash, config_data, status_data) = d.unwrap();
+            let run_type = RunType::from_str(&run_type_str)?;
             let run_config: RunConfig = serde_json::from_str(&config_data)?;
             let run_status: RunStatus = serde_json::from_str(&status_data)?;
 
@@ -767,6 +784,7 @@ impl Store for SQLiteStore {
             Ok(Some(Run::new_from_store(
                 &run_id,
                 created,
+                run_type,
                 &app_hash,
                 &run_config,
                 &run_status,
@@ -993,7 +1011,7 @@ mod tests {
         store.init().await?;
         let project = store.create_project().await?;
 
-        let r = store.latest_run_id(&project).await?;
+        let r = store.latest_run_id(&project, RunType::Local).await?;
         assert!(r.is_none());
         Ok(())
     }
@@ -1042,6 +1060,7 @@ _fun = (env) => {
         assert!(r.unwrap() == app.hash());
 
         app.prepare_run(
+            RunType::Local,
             RunConfig {
                 blocks: HashMap::new(),
             },
@@ -1119,6 +1138,7 @@ _fun = (env) => {
         assert!(r.unwrap() == app.hash());
 
         app.prepare_run(
+            RunType::Local,
             RunConfig {
                 blocks: HashMap::new(),
             },

--- a/core/src/stores/sqlite.rs
+++ b/core/src/stores/sqlite.rs
@@ -845,19 +845,14 @@ impl Store for SQLiteStore {
             let created = generation.created;
             let request_data = serde_json::to_string(&request)?;
             let generation_data = serde_json::to_string(&generation)?;
-            match stmt.insert(params![
+            stmt.insert(params![
                 project_id,
                 created,
                 request.hash().to_string(),
                 request_data,
                 generation_data
-            ]) {
-                Ok(_) => Ok(()),
-                Err(e) => match e.to_string().as_str() {
-                    "UNIQUE constraint failed: cache.hash" => Ok(()),
-                    _ => Err(e.into()),
-                },
-            }
+            ])?;
+            Ok(())
         })
         .await?
     }
@@ -913,19 +908,14 @@ impl Store for SQLiteStore {
             let created = response.created;
             let request_data = serde_json::to_string(&request)?;
             let response_data = serde_json::to_string(&response)?;
-            match stmt.insert(params![
+            stmt.insert(params![
                 project_id,
                 created,
                 request.hash().to_string(),
                 request_data,
                 response_data
-            ]) {
-                Ok(_) => Ok(()),
-                Err(e) => match e.to_string().as_str() {
-                    "UNIQUE constraint failed: cache.hash" => Ok(()),
-                    _ => Err(e.into()),
-                },
-            }
+            ])?;
+            Ok(())
         })
         .await?
     }

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -264,7 +264,7 @@ pub const POSTGRES_TABLES: [&'static str; 9] = [
     );",
 ];
 
-pub const SQL_INDEXES: [&'static str; 10] = [
+pub const SQL_INDEXES: [&'static str; 9] = [
     "CREATE INDEX IF NOT EXISTS
        idx_specifications_project_created ON specifications (project, created);",
     "CREATE INDEX IF NOT EXISTS
@@ -282,8 +282,6 @@ pub const SQL_INDEXES: [&'static str; 10] = [
        idx_datasets_joins ON datasets_joins (dataset, point);",
     "CREATE INDEX IF NOT EXISTS
        idx_runs_joins ON runs_joins (run, block_execution);",
-    "CREATE UNIQUE INDEX IF NOT EXISTS
-       idx_cache_hash ON cache (hash);",
     "CREATE INDEX IF NOT EXISTS
        idx_cache_project_hash ON cache (project, hash);",
 ];

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -3,7 +3,7 @@ use crate::dataset::Dataset;
 use crate::http::request::{HttpRequest, HttpResponse};
 use crate::project::Project;
 use crate::providers::llm::{LLMGeneration, LLMRequest};
-use crate::run::{Run, RunConfig, RunStatus};
+use crate::run::{Run, RunConfig, RunStatus, RunType};
 use anyhow::Result;
 use async_trait::async_trait;
 use std::collections::HashMap;
@@ -35,8 +35,12 @@ pub trait Store {
         -> Result<()>;
 
     // Runs
-    async fn latest_run_id(&self, project: &Project) -> Result<Option<String>>;
-    async fn all_runs(&self, project: &Project) -> Result<Vec<(String, u64, String, RunConfig)>>;
+    async fn latest_run_id(&self, project: &Project, run_type: RunType) -> Result<Option<String>>;
+    async fn all_runs(
+        &self,
+        project: &Project,
+        run_type: RunType,
+    ) -> Result<Vec<(String, u64, String, RunConfig)>>;
 
     async fn create_run_empty(&self, project: &Project, run: &Run) -> Result<()>;
     async fn update_run_status(
@@ -142,6 +146,7 @@ pub const SQLITE_TABLES: [&'static str; 9] = [
        project              INTEGER NOT NULL,
        created              INTEGER NOT NULL,
        run_id               TEXT NOT NULL,
+       run_type             TEXT NOT NULL,
        app_hash             TEXT NOT NULL,
        config_json          TEXT NOT NULL,
        status_json          TEXT NOT NULL,
@@ -222,6 +227,7 @@ pub const POSTGRES_TABLES: [&'static str; 9] = [
        project              BIGINT NOT NULL,
        created              BIGINT NOT NULL,
        run_id               TEXT NOT NULL,
+       run_type             TEXT NOT NULL,
        app_hash             TEXT NOT NULL,
        config_json          TEXT NOT NULL,
        status_json          TEXT NOT NULL,
@@ -265,7 +271,7 @@ pub const SQL_INDEXES: [&'static str; 10] = [
        idx_datasets_project_dataset_id_created
        ON datasets (project, dataset_id, created);",
     "CREATE INDEX IF NOT EXISTS
-       idx_runs_project_created ON runs (project, created);",
+       idx_runs_project_run_type_created ON runs (project, run_type, created);",
     "CREATE UNIQUE INDEX IF NOT EXISTS
        idx_runs_id ON runs (run_id);",
     "CREATE UNIQUE INDEX IF NOT EXISTS

--- a/front/pages/api/apps/[user]/[sId]/runs/index.js
+++ b/front/pages/api/apps/[user]/[sId]/runs/index.js
@@ -102,6 +102,7 @@ export default async function handler(req, res) {
             "Content-Type": "application/json",
           },
           body: JSON.stringify({
+            run_type: "local",
             specification: spec,
             dataset_id: inputDataset,
             config: { blocks: config },


### PR DESCRIPTION
This will allow to distinguish "Deploy" runs from "Local" runs

Calling into Dust app will create "Deploy" runs. Code is fully shared, we'll be able to expose the run status as used by the Dust front.