### PR TITLE
Enable pressing Esc to dismiss provider setup dialogs

### DIFF
--- a/front/components/providers/AI21Setup.jsx
+++ b/front/components/providers/AI21Setup.jsx
@@ -61,7 +61,7 @@ export default function AI21Setup({ open, setOpen, config, enabled }) {
 
   return (
     <Transition.Root show={open} as={Fragment}>
-      <Dialog as="div" className="relative z-10" onClose={() => {}}>
+      <Dialog as="div" className="relative z-10" onClose={() => setOpen(false)}>
         <Transition.Child
           as={Fragment}
           enter="ease-out duration-300"

--- a/front/components/providers/BrowserlessAPISetup.jsx
+++ b/front/components/providers/BrowserlessAPISetup.jsx
@@ -66,7 +66,7 @@ export default function BrowserlessAPISetup({
 
   return (
     <Transition.Root show={open} as={Fragment}>
-      <Dialog as="div" className="relative z-10" onClose={() => {}}>
+      <Dialog as="div" className="relative z-10" onClose={() => setOpen(false)}>
         <Transition.Child
           as={Fragment}
           enter="ease-out duration-300"

--- a/front/components/providers/CohereSetup.jsx
+++ b/front/components/providers/CohereSetup.jsx
@@ -66,7 +66,7 @@ export default function CohereSetup({
 
   return (
     <Transition.Root show={open} as={Fragment}>
-      <Dialog as="div" className="relative z-10" onClose={() => {}}>
+      <Dialog as="div" className="relative z-10" onClose={() => setOpen(false)}>
         <Transition.Child
           as={Fragment}
           enter="ease-out duration-300"

--- a/front/components/providers/OpenAISetup.jsx
+++ b/front/components/providers/OpenAISetup.jsx
@@ -61,7 +61,7 @@ export default function OpenAISetup({ open, setOpen, config, enabled }) {
 
   return (
     <Transition.Root show={open} as={Fragment}>
-      <Dialog as="div" className="relative z-10" onClose={() => {}}>
+      <Dialog as="div" className="relative z-10" onClose={() => setOpen(false)}>
         <Transition.Child
           as={Fragment}
           enter="ease-out duration-300"

--- a/front/components/providers/SerpAPISetup.jsx
+++ b/front/components/providers/SerpAPISetup.jsx
@@ -61,7 +61,7 @@ export default function SerpAPISetup({ open, setOpen, config, enabled }) {
 
   return (
     <Transition.Root show={open} as={Fragment}>
-      <Dialog as="div" className="relative z-10" onClose={() => {}}>
+      <Dialog as="div" className="relative z-10" onClose={() => setOpen(false)}>
         <Transition.Child
           as={Fragment}
           enter="ease-out duration-300"

--- a/front/lib/providers.js
+++ b/front/lib/providers.js
@@ -19,7 +19,7 @@ export const modelProviders = [
   },
   {
     providerId: "hugging_face",
-    name: "HuggingFace",
+    name: "Hugging Face",
     built: false,
     enabled: false,
   },
@@ -34,7 +34,7 @@ export const modelProviders = [
 export const serviceProviders = [
   {
     providerId: "serpapi",
-    name: "SerpAPI (Google) Search",
+    name: "SerpApi (Google Search)",
     built: true,
     enabled: false,
   },
@@ -46,12 +46,12 @@ export const serviceProviders = [
   },
   {
     providerId: "youtube",
-    name: "Youtube Search",
+    name: "YouTube Search",
     built: false,
     enabled: false,
   },
   { providerId: "notion", name: "Notion", built: false, enabled: false },
-  { providerId: "gmail", name: "GMail", built: false, enabled: false },
+  { providerId: "gmail", name: "Gmail", built: false, enabled: false },
 ];
 
 export async function checkProvider(providerId, config) {


### PR DESCRIPTION
Updated `onClose` on the provider setup `Dialog` components to properly set their open status, which automatically dismisses the modals when pressing `Esc` or clicking outside.

Also fixed a few provider names to match their official version.