### PR TITLE
Redesign the API endpoint dialog and add runnable cURL ready to copy

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -8,6 +8,7 @@
     "@headlessui/react": "^1.7.2",
     "@heroicons/react": "^2.0.11",
     "@tailwindcss/forms": "^0.5.3",
+    "@uiw/copy-to-clipboard": "^1.0.12",
     "@uiw/react-textarea-code-editor": "^2.0.3",
     "blake3": "^2.1.7",
     "next": "^12.2.5",


### PR DESCRIPTION
I did a first pass to redesign the “Deploy” dialog:

* Fetch keys to use the first active API key if it exists in the cURL request (unrevealed for display)
* Add a button to copy the cURL command with the revealed API key directly to the clipboard
* Move the cURL to a read-only code editor to make it easier to maintain and have syntax highlighting
* Reformat the Parameters and Response sections to improve readability and tweak wording

<img width="910" alt="Screenshot 2023-01-05 at 11 16 14 AM" src="https://user-images.githubusercontent.com/27232/210757020-b1dca87d-a9f9-424f-ab50-09434e93c66a.png">
