### PR TITLE
Polish a few UI elements on the app design screen

### DIFF
--- a/front/components/app/ModelPicker.jsx
+++ b/front/components/app/ModelPicker.jsx
@@ -69,11 +69,6 @@ export default function ModelPicker({ user, model, readOnly, onModelUpdate }) {
   return (
     <div className="flex items-center">
       <div className="flex items-center">
-        <div className="font-bold text-gray-700 text-sm">
-          {(model.provider_id && model.provider_id.length) > 0
-            ? model.provider_id
-            : ""}
-        </div>
         <Menu as="div" className="relative inline-block text-left">
           <div>
             {modelProviders.length == 0 &&
@@ -82,7 +77,7 @@ export default function ModelPicker({ user, model, readOnly, onModelUpdate }) {
               <Link href={`/${user}/providers`}>
                 <a
                   className={classNames(
-                    "inline-flex items-center rounded-md py-1 text-sm font-normal",
+                    "inline-flex items-center rounded-md py-1 text-sm font-bold",
                     (model.provider_id && model.provider_id.length) > 0
                       ? "px-1"
                       : "border px-3",
@@ -95,10 +90,16 @@ export default function ModelPicker({ user, model, readOnly, onModelUpdate }) {
                   {isProvidersLoading ? "Loading..." : "Setup provider"}
                 </a>
               </Link>
-            ) : readOnly ? null : (
+            ) : readOnly ? (
+              <div className="font-bold text-gray-700 text-sm">
+                {model.provider_id && model.provider_id.length > 0
+                  ? model.provider_id
+                  : ""}
+              </div>
+            ) : (
               <Menu.Button
                 className={classNames(
-                  "inline-flex items-center rounded-md py-1 text-sm font-normal",
+                  "inline-flex items-center rounded-md py-1 text-sm font-bold",
                   model.provider_id && model.provider_id.length > 0
                     ? "px-0"
                     : "border px-3",
@@ -111,7 +112,7 @@ export default function ModelPicker({ user, model, readOnly, onModelUpdate }) {
               >
                 {model.provider_id && model.provider_id.length > 0 ? (
                   <>
-                    &nbsp;
+                    {model.provider_id}&nbsp;
                     <ChevronDownIcon className="h-4 w-4 hover:text-gray-700 mt-0.5" />
                   </>
                 ) : (
@@ -126,7 +127,7 @@ export default function ModelPicker({ user, model, readOnly, onModelUpdate }) {
               className={classNames(
                 "absolute shadow left-1 z-10 mt-1 origin-top-left rounded-md bg-white ring-1 ring-black ring-opacity-5 focus:outline-none",
                 model.provider_id && model.provider_id.length > 0
-                  ? "-left-12"
+                  ? "-left-4"
                   : "left-1"
               )}
             >
@@ -166,17 +167,18 @@ export default function ModelPicker({ user, model, readOnly, onModelUpdate }) {
 
       {model.provider_id && model.provider_id.length > 0 ? (
         <div className="flex items-center ml-2">
-          <div className="font-bold text-gray-700 text-sm">
-            {(model.model_id && model.model_id.length) > 0
-              ? model.model_id
-              : ""}
-          </div>
-          {readOnly ? null : (
+          {readOnly ? (
+            <div className="font-bold text-gray-700 text-sm">
+              {(model.model_id && model.model_id.length) > 0
+                ? model.model_id
+                : ""}
+            </div>
+          ) : (
             <Menu as="div" className="relative inline-block text-left">
               <div>
                 <Menu.Button
                   className={classNames(
-                    "inline-flex items-center rounded-md py-1 text-sm font-normal",
+                    "inline-flex items-center rounded-md py-1 font-bold text-gray-700 text-sm",
                     model.model_id && model.model_id.length > 0
                       ? "px-0"
                       : "border px-3",
@@ -189,7 +191,7 @@ export default function ModelPicker({ user, model, readOnly, onModelUpdate }) {
                 >
                   {model.model_id && model.model_id.length > 0 ? (
                     <>
-                      &nbsp;
+                      {model.model_id}&nbsp;
                       <ChevronDownIcon className="h-4 w-4 hover:text-gray-700 mt-0.5" />
                     </>
                   ) : (
@@ -200,9 +202,9 @@ export default function ModelPicker({ user, model, readOnly, onModelUpdate }) {
 
               <Menu.Items
                 className={classNames(
-                  "absolute shadow z-10 mt-1 origin-top-left rounded-md bg-white ring-1 ring-black ring-opacity-5 focus:outline-none",
+                  "absolute w-max shadow z-10 mt-1 origin-top-left rounded-md bg-white ring-1 ring-black ring-opacity-5 focus:outline-none",
                   model.model_id && model.model_id.length > 0
-                    ? "-left-24"
+                    ? "-left-4"
                     : "left-1"
                 )}
               >
@@ -224,7 +226,7 @@ export default function ModelPicker({ user, model, readOnly, onModelUpdate }) {
                               active
                                 ? "bg-gray-50 text-gray-900"
                                 : "text-gray-700",
-                              "block px-4 py-2 text-sm w-40 cursor-pointer"
+                              "block px-4 py-2 text-sm cursor-pointer"
                             )}
                           >
                             {m.id}

--- a/front/components/app/NewBlock.jsx
+++ b/front/components/app/NewBlock.jsx
@@ -103,8 +103,8 @@ export default function NewBlock({
       </div>
       <Menu.Items
         className={classNames(
-          "absolute w-96 block shadow z-10 my-2 rounded-md bg-white ring-1 ring-black ring-opacity-5 focus:outline-none",
-          small ? "-right-16" : "-left-1",
+          "absolute w-max block shadow z-10 my-2 rounded-md bg-white ring-1 ring-black ring-opacity-5 focus:outline-none",
+          small ? "-right-16" : "",
           direction === "up" ? "bottom-9" : ""
         )}
       >
@@ -133,7 +133,7 @@ export default function NewBlock({
                     ))}
                   </div>
                 </div>
-                <div className="col-span-8 sm:col-span-9 text-sm sm:pl-3 pr-2">
+                <div className="col-span-8 sm:col-span-9 text-sm text-gray-700 sm:pl-3 pr-2">
                   {block.description}
                 </div>
               </div>

--- a/front/components/app/blocks/LLM.jsx
+++ b/front/components/app/blocks/LLM.jsx
@@ -363,7 +363,7 @@ export default function LLM({
             <div className="ml-6 flex flex-col">
               <div className="flex flex-col space-y-1 text-sm font-medium text-gray-700 leading-8">
                 <div className="flex flex-initial items-center">
-                  introduction :
+                  introduction:
                 </div>
                 <div className="flex w-full font-normal">
                   <TextareaAutosize
@@ -384,7 +384,7 @@ export default function LLM({
               </div>
 
               <div className="flex flex-col space-y-1 text-sm font-medium text-gray-700 leading-8">
-                <div className="flex flex-initial items-center">examples :</div>
+                <div className="flex flex-initial items-center">examples:</div>
                 <div className="flex w-full font-normal">
                   <TextareaAutosize
                     minRows={1}
@@ -424,7 +424,7 @@ export default function LLM({
         </div>
 
         <div className="flex flex-col space-y-1 text-sm font-medium text-gray-700 leading-8">
-          <div className="flex flex-initial items-center">prompt :</div>
+          <div className="flex flex-initial items-center">prompt:</div>
           <div className="flex w-full font-normal">
             <TextareaAutosize
               placeholder=""

--- a/front/components/app/blocks/Output.jsx
+++ b/front/components/app/blocks/Output.jsx
@@ -241,7 +241,9 @@ export default function Output({ user, block, runId, status, app }) {
         {traces.map((trace, i) => {
           return (
             <div key={i} className="flex flex-row flex-auto ml-1">
-              <div className="flex text-sm text-gray-300 mr-2">{i}:</div>
+              <div className="flex text-sm text-gray-300 font-mono mr-2">
+                {i}:
+              </div>
               <div className="flex flex-auto flex-col overflow-hidden">
                 {trace.map((t, i) => {
                   return (


### PR DESCRIPTION
This PR makes a few small UI tweaks on the app design screen (see before/after screens below for comparison):

* Improve the layout, display, and alignment of the block list overlay:
<img width="910" alt="Screenshot 2023-01-05 at 4 00 23 PM" src="https://user-images.githubusercontent.com/27232/210811451-79be8760-2be2-48e5-9dd8-ef06b81cfe25.png">

* Make it possible to change provider or model in the LLM block by clicking on its name (not just the chevron icon):
<img width="760" alt="Screenshot 2023-01-05 at 4 03 30 PM" src="https://user-images.githubusercontent.com/27232/210811577-4c3fd856-dd58-4177-9e7c-58a41ccf9bb9.png">

* Fix the misalignment of run output objects and misc tiny changes on words/spaces:
<img width="620" alt="Screenshot 2023-01-05 at 4 02 24 PM" src="https://user-images.githubusercontent.com/27232/210811476-708bf364-4bbf-4f21-827b-8d4314f4be97.png">