### PR TITLE
Add the ability to clone and delete an app (fix #100 #105)

### DIFF
--- a/front/lib/models.js
+++ b/front/lib/models.js
@@ -63,16 +63,10 @@ export const App = sequelize.define(
       type: DataTypes.STRING,
       allowNull: false,
     },
-    isDeleted: {
-      type: DataTypes.BOOLEAN,
-      defaultValue: false,
-      allowNull: false,
-    },
   },
   {
     indexes: [
       { fields: ["userId", "visibility"] },
-      { fields: ["userId", "visibility", "isDeleted"] },
       { fields: ["userId", "sId", "visibility"] },
     ],
   }

--- a/front/lib/models.js
+++ b/front/lib/models.js
@@ -63,10 +63,16 @@ export const App = sequelize.define(
       type: DataTypes.STRING,
       allowNull: false,
     },
+    isDeleted: {
+      type: DataTypes.BOOLEAN,
+      defaultValue: false,
+      allowNull: false,
+    },
   },
   {
     indexes: [
       { fields: ["userId", "visibility"] },
+      { fields: ["userId", "visibility", "isDeleted"] },
       { fields: ["userId", "sId", "visibility"] },
     ],
   }

--- a/front/pages/[user]/a/[sId]/clone.jsx
+++ b/front/pages/[user]/a/[sId]/clone.jsx
@@ -66,27 +66,51 @@ export default function CloneView({ app, user, ga_tracking_id }) {
             >
               <div className="space-y-8 divide-y divide-gray-200">
                 <div>
-                  <h3 className="text-base font-medium leading-6 text-gray-900">
-                    Clone <span className="font-bold ml-1">{user}</span>
-                    <ChevronRightIcon
-                      className="inline h-5 w-5 text-gray-500 pt-0.5 ml-0.5"
-                      aria-hidden="true"
-                    />
-                    <Link href={`/${user}/a/${app.sId}`}>
-                      <a
-                        href="#"
-                        className="text-base font-bold w-22 sm:w-auto truncate text-violet-600 mr-1"
-                      >
-                        {app.name}
-                      </a>
-                    </Link>{" "}
-                    to your account
-                  </h3>
-                  <p className="mt-1 text-sm text-gray-500">
-                    This will clone the app (specification along with associated
-                    datasets) to your account. You can pick a new name and
-                    description for the app in the process.
-                  </p>
+                  {user !== session.user.username ? (
+                    <div>
+                      <h3 className="text-base font-medium leading-6 text-gray-900">
+                        Clone <span className="font-bold ml-1">{user}</span>
+                        <ChevronRightIcon
+                          className="inline h-5 w-5 text-gray-500 pt-0.5 ml-0.5"
+                          aria-hidden="true"
+                        />
+                        <Link href={`/${user}/a/${app.sId}`}>
+                          <a
+                            href="#"
+                            className="text-base font-bold w-22 sm:w-auto truncate text-violet-600 mr-1"
+                          >
+                            {app.name}
+                          </a>
+                        </Link>{" "}
+                        to your account
+                      </h3>
+                      <p className="mt-1 text-sm text-gray-500">
+                        This will clone the app (specification along with
+                        associated datasets) to your account. You can pick a new
+                        name and description for the app in the process.
+                      </p>
+                    </div>
+                  ) : (
+                    <div>
+                      <h3 className="text-base font-medium leading-6 text-gray-900">
+                        Clone your app{" "}
+                        <Link href={`/${user}/a/${app.sId}`}>
+                          <a
+                            href="#"
+                            className="text-base font-bold w-22 sm:w-auto truncate text-violet-600 mr-1"
+                          >
+                            {app.name}
+                          </a>
+                        </Link>
+                      </h3>
+                      <p className="mt-1 text-sm text-gray-500">
+                        This will clone your app (specification along with
+                        associated datasets) without affecting the existing one.
+                        You can pick a new name and description for the app in
+                        the process.
+                      </p>
+                    </div>
+                  )}
                 </div>
                 <div>
                   <div className="mt-6 grid grid-cols-1 gap-y-6 gap-x-4 sm:grid-cols-6">

--- a/front/pages/[user]/a/[sId]/settings.jsx
+++ b/front/pages/[user]/a/[sId]/settings.jsx
@@ -162,7 +162,7 @@ export default function SettingsView({ app, user, ga_tracking_id }) {
                               }}
                             />
                             <label
-                              htmlFor="app-visibility-public"
+                              htmlFor="appVisibilityPublic"
                               className="ml-3 block text-sm font-medium text-gray-700"
                             >
                               Public
@@ -187,7 +187,7 @@ export default function SettingsView({ app, user, ga_tracking_id }) {
                               }}
                             />
                             <label
-                              htmlFor="app-visibility-private"
+                              htmlFor="appVisibilityPrivate"
                               className="ml-3 block text-sm font-medium text-gray-700"
                             >
                               Private
@@ -197,6 +197,12 @@ export default function SettingsView({ app, user, ga_tracking_id }) {
                             </label>
                           </div>
                         </div>
+                        {appVisibility == "deleted" ? (
+                          <p className="mt-4 text-sm font-normal text-gray-500">
+                            This app is currently marked as deleted. Change its
+                            visibility above to restore it.
+                          </p>
+                        ) : null}
                       </fieldset>
                     </div>
                   </div>

--- a/front/pages/[user]/a/[sId]/settings.jsx
+++ b/front/pages/[user]/a/[sId]/settings.jsx
@@ -8,6 +8,7 @@ import { classNames } from "../../../../lib/utils";
 import { useState, useRef } from "react";
 import { useSession } from "next-auth/react";
 import { useEffect } from "react";
+import Link from "next/link";
 
 const { URL, GA_TRACKING_ID = null } = process.env;
 
@@ -34,6 +35,20 @@ export default function SettingsView({ app, user, ga_tracking_id }) {
     } else {
       setAppNameError(null);
       return true;
+    }
+  };
+
+  const handleDelete = async () => {
+    if (window.confirm("Are you sure you want to delete this app?")) {
+      let res = await fetch(`/api/apps/${user}/${app.sId}`, {
+        method: "DELETE",
+      });
+      if (res.ok) {
+        window.location = "/";
+      }
+      return true;
+    } else {
+      return false;
     }
   };
 
@@ -187,12 +202,18 @@ export default function SettingsView({ app, user, ga_tracking_id }) {
                   </div>
                 </div>
               </div>
-
-              <div className="pt-6">
-                <div className="flex">
-                  <Button disabled={disable} type="submit">
-                    Update
-                  </Button>
+              <div className="flex pt-6">
+                <Button disabled={disable} type="submit">
+                  Update
+                </Button>
+                <span className="flex-1"></span>
+                <Link href={`/${user}/a/${app.sId}/clone`}>
+                  <a>
+                    <Button>Clone</Button>
+                  </a>
+                </Link>
+                <div className="flex ml-2">
+                  <Button onClick={handleDelete}>Delete</Button>
                 </div>
               </div>
             </form>

--- a/front/pages/[user]/apps/new.jsx
+++ b/front/pages/[user]/apps/new.jsx
@@ -151,7 +151,7 @@ export default function New({ apps, ga_tracking_id }) {
                               }}
                             />
                             <label
-                              htmlFor="app-visibility-public"
+                              htmlFor="appVisibilityPublic"
                               className="ml-3 block text-sm font-medium text-gray-700"
                             >
                               Public
@@ -176,7 +176,7 @@ export default function New({ apps, ga_tracking_id }) {
                               }}
                             />
                             <label
-                              htmlFor="app-visibility-private"
+                              htmlFor="appVisibilityPrivate"
                               className="ml-3 block text-sm font-medium text-gray-700"
                             >
                               Private

--- a/front/pages/api/apps/[user]/[sId]/index.js
+++ b/front/pages/api/apps/[user]/[sId]/index.js
@@ -87,7 +87,7 @@ export default async function handler(req, res) {
       }
 
       await app.update({
-        isDeleted: true,
+        visibility: "deleted",
       });
 
       res.status(200).end();

--- a/front/pages/api/apps/[user]/[sId]/index.js
+++ b/front/pages/api/apps/[user]/[sId]/index.js
@@ -80,6 +80,19 @@ export default async function handler(req, res) {
       res.redirect(`/${session.user.username}/a/${app.sId}`);
       break;
 
+    case "DELETE":
+      if (readOnly) {
+        res.status(401).end();
+        return;
+      }
+
+      await app.update({
+        isDeleted: true,
+      });
+
+      res.status(200).end();
+      break;
+
     default:
       res.status(405).end();
       break;

--- a/front/pages/api/apps/[user]/index.js
+++ b/front/pages/api/apps/[user]/index.js
@@ -27,9 +27,11 @@ export default async function handler(req, res) {
         ? {
             userId: user.id,
             visibility: "public",
+            isDeleted: false,
           }
         : {
             userId: user.id,
+            isDeleted: false,
           };
       let apps = await App.findAll({
         where,

--- a/front/pages/api/apps/[user]/index.js
+++ b/front/pages/api/apps/[user]/index.js
@@ -3,6 +3,7 @@ import { authOptions } from "../../auth/[...nextauth]";
 import { User, App } from "../../../../lib/models";
 import { new_id } from "../../../../lib/utils";
 
+const { Op } = require("sequelize");
 const { DUST_API } = process.env;
 
 export default async function handler(req, res) {
@@ -27,11 +28,12 @@ export default async function handler(req, res) {
         ? {
             userId: user.id,
             visibility: "public",
-            isDeleted: false,
           }
         : {
             userId: user.id,
-            isDeleted: false,
+            visibility: {
+              [Op.or]: ["public", "private"],
+            },
           };
       let apps = await App.findAll({
         where,


### PR DESCRIPTION
This PR addresses feature requests #100 and #105 and adds the ability to clone and delete an app from the settings panel.

* The “Clone” button uses the existing cloning functionality, tweaking the wording when the user is cloning their own app instead of a public community one.
* The “Delete” button marks the app as deleted and invisible in the list of user apps. Currently, this doesn’t affect accessing the app directly via its URL or API endpoint. Note: This makes it possible to revisit what’s best in the future, including viewing deleted apps, undeleting an app, or addressing what needs to happen if it’s permanently deleted while runs are still active.