### PR TITLE
Improve the Dataset View

### DIFF
--- a/front/components/app/DatasetView.jsx
+++ b/front/components/app/DatasetView.jsx
@@ -114,6 +114,7 @@ export default function DatasetView({
   }
   const [datasetKeys, setDatasetKeys] = useState(dataset.keys);
   const [datasetTypes, setDatasetTypes] = useState([]);
+  const [datasetInitializing, setDatasetInitializing] = useState(true);
 
   const datasetNameValidation = () => {
     let valid = true;
@@ -219,6 +220,11 @@ export default function DatasetView({
       datasetTypes.push(type);
     }
     setDatasetTypes(datasetTypes);
+    if (datasetInitializing) {
+      setTimeout(() => {
+        setDatasetInitializing(false);
+      }, 10);
+    }
   };
 
   const handleKeyUpdate = (i, newKey) => {
@@ -345,7 +351,7 @@ export default function DatasetView({
     setDatasetKeys(keys);
     setDatasetData(data);
     setDatasetTypes([]);
-    onUpdate(datasetTypesValidation(), {
+    onUpdate(datasetInitializing, datasetTypesValidation(), {
       name: datasetName,
       keys: datasetKeys,
       description: datasetDescription || "",
@@ -369,7 +375,7 @@ export default function DatasetView({
 
     if (onUpdate) {
       // TODO(spolu): Optimize, as it might not be great to send the entire data on each update.
-      onUpdate(valid, {
+      onUpdate(datasetInitializing, valid, {
         name: datasetName,
         keys: datasetKeys,
         description: datasetDescription || "",
@@ -490,6 +496,7 @@ export default function DatasetView({
                     <div className="inline-flex" role="group">
                       {["string", "number", "boolean", "object"].map((type) => (
                         <button
+                          key={type}
                           type="button"
                           disabled={readOnly}
                           className={classNames(

--- a/front/pages/[user]/a/[sId]/clone.jsx
+++ b/front/pages/[user]/a/[sId]/clone.jsx
@@ -119,7 +119,7 @@ export default function CloneView({ app, user, ga_tracking_id }) {
                         htmlFor="appName"
                         className="block text-sm font-medium text-gray-700"
                       >
-                        App name
+                        App Name
                       </label>
                       <div className="mt-1 flex rounded-md shadow-sm">
                         <span className="inline-flex items-center rounded-l-md border border-r-0 border-gray-300 bg-gray-50 pl-3 pr-1 text-gray-500 text-sm">

--- a/front/pages/[user]/a/[sId]/datasets/[name]/index.jsx
+++ b/front/pages/[user]/a/[sId]/datasets/[name]/index.jsx
@@ -41,13 +41,14 @@ export default function ViewDatasetView({
     }
   }, [isFinishedEditing]);
 
-  const onUpdate = (valid, currentDatasetInEditor) => {
+  const onUpdate = (initializing, valid, currentDatasetInEditor) => {
     setDisabled(!valid);
     if (
-      currentDatasetInEditor.data !== dataset.data ||
-      currentDatasetInEditor.name !== dataset.name ||
-      (currentDatasetInEditor.description !== dataset.description &&
-        (currentDatasetInEditor.description || dataset.description))
+      !initializing &&
+      (currentDatasetInEditor.data !== dataset.data ||
+        currentDatasetInEditor.name !== dataset.name ||
+        (currentDatasetInEditor.description !== dataset.description &&
+          (currentDatasetInEditor.description || dataset.description)))
     ) {
       setEditorDirty(true);
     } else {

--- a/front/pages/[user]/a/[sId]/datasets/new.jsx
+++ b/front/pages/[user]/a/[sId]/datasets/new.jsx
@@ -39,9 +39,11 @@ export default function NewDatasetView({
     }
   }, [isFinishedEditing]);
 
-  const onUpdate = (valid, currentDatasetInEditor) => {
+  const onUpdate = (initializing, valid, currentDatasetInEditor) => {
     setDisabled(!valid);
-    setEditorDirty(true);
+    if (!initializing) {
+      setEditorDirty(true);
+    }
     if (valid) {
       setDataset(currentDatasetInEditor);
     }

--- a/front/pages/[user]/a/[sId]/runs/index.jsx
+++ b/front/pages/[user]/a/[sId]/runs/index.jsx
@@ -117,9 +117,11 @@ export default function RunsView({ app, user, readOnly, ga_tracking_id }) {
               </div>
             </div>
 
-            <div className="flex flex-auto text-gray-700 text-sm mt-3 pl-1">
-              Showing runs {offset + 1} - {last} of {total} runs
-            </div>
+            {runs.length > 0 ? (
+              <div className="flex flex-auto text-gray-700 text-sm mt-3 pl-1">
+                Showing runs {offset + 1} - {last} of {total} runs
+              </div>
+            ) : null}
 
             <div className="mt-4">
               <ul role="list" className="space-y-4">

--- a/front/pages/[user]/a/[sId]/settings.jsx
+++ b/front/pages/[user]/a/[sId]/settings.jsx
@@ -86,7 +86,7 @@ export default function SettingsView({ app, user, ga_tracking_id }) {
                         htmlFor="appName"
                         className="block text-sm font-medium text-gray-700"
                       >
-                        App name
+                        App Name
                       </label>
                       <div className="mt-1 flex rounded-md shadow-sm">
                         <span className="inline-flex items-center rounded-l-md border border-r-0 border-gray-300 bg-gray-50 pl-3 pr-1 text-gray-500 text-sm">

--- a/front/pages/[user]/apps/new.jsx
+++ b/front/pages/[user]/apps/new.jsx
@@ -72,7 +72,7 @@ export default function New({ apps, ga_tracking_id }) {
                         htmlFor="appName"
                         className="block text-sm font-medium text-gray-700"
                       >
-                        App name
+                        App Name
                       </label>
                       <div className="mt-1 flex rounded-md shadow-sm">
                         <span className="inline-flex items-center rounded-l-md border border-r-0 border-gray-300 bg-gray-50 pl-3 pr-1 text-gray-500 text-sm">


### PR DESCRIPTION
This pull request makes a few changes to the dataset view:

* Add a new “Schema” section at the top to define properties and types for the dataset separately from data entries
* Guess the types of properties automatically when opening a dataset or uploading a JSONL file using the first entry
* Validate types when editing with visual feedback to make sure the dataset is valid before saving it
* Provide a code editor for JSON properties to improve autocompletion and syntax highlighting when editing objects
* Add hints/instructions to edit the schema and data when the dataaset isn’t in read-only mode
* Add a “New Entry” button at the bottom left to make it easier to append new entries

<img width="1420" alt="Dust Dataset View" src="https://user-images.githubusercontent.com/27232/212961550-64e1c2bb-f762-473b-8115-a5a76d27b52e.png">

It also fixes a small bug on the Runs page to avoid writing “Showing runs 1-0 of 0.”