### PR TITLE
Fix README for first time setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,15 @@ See the [video demo](https://demo.dust.tt) for an explanation of the commands.
 
 ### Start core API on SQLite
 
-- `cd $DUST_PATH/core`
-- `cargo run --bin dust-api`
+1. `cd $DUST_PATH/core`
+2. `cargo run --bin dust-api`
 
 ### Start front on SQLite
 
-- `cd $DUST_PATH/front`
-- Create `.env.local` with the following content:
-```
+1. `cd $DUST_PATH/front`
+2. Create `.env.local` by running the command below:
+```sh
+cat <<EOF >> .env.local
 URL=http://localhost:3000
 
 NEXTAUTH_URL=$URL
@@ -47,10 +48,11 @@ DUST_API=http://localhost:3001
 
 THUM_IO_KEY=0-Foo
 GA_TRACKING_ID=Foo
+EOF
 ```
-- Run `DATABASE_URI=sqlite:front_store.sqlite ./init/init.sh`
-- Run `npm install`
-- Start server with `npm run dev`
+3. Run `npm install`
+4. Run `DATABASE_URI=sqlite:front_store.sqlite ./init/init.sh`
+5. Start server with `npm run dev`
 
 ## Questions / Help
 


### PR DESCRIPTION
Reorder steps and streamline setup for the front-end app

Feel free to update these steps as needed.

The main issue here is that if we run
`DATABASE_URI=sqlite:front_store.sqlite ./init/init.sh`
before we run 
`npm install`
we see the following error on a fresh git clone.

```
DATABASE_URI=sqlite:front_store.sqlite ./init/init.sh
node:internal/errors:490
    ErrorCaptureStackTrace(err);
    ^

Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'sequelize' imported from /Users/roger/Projects/dust/front/lib/models.js
    at new NodeError (node:internal/errors:399:5)
    at packageResolve (node:internal/modules/esm/resolve:794:9)
    at moduleResolve (node:internal/modules/esm/resolve:843:20)
    at defaultResolve (node:internal/modules/esm/resolve:1058:11)
    at nextResolve (node:internal/modules/esm/loader:164:28)
    at ESMLoader.resolve (node:internal/modules/esm/loader:838:30)
    at ESMLoader.getModuleJob (node:internal/modules/esm/loader:419:18)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:77:40)
    at link (node:internal/modules/esm/module_job:76:36) {
  code: 'ERR_MODULE_NOT_FOUND'
}

Node.js v19.4.0
```