### PR TITLE
Fix to input in map reduce

### DIFF
--- a/core/src/app.rs
+++ b/core/src/app.rs
@@ -108,6 +108,13 @@ impl App {
                         name
                     ))?;
                 }
+                if current_map.is_some() {
+                    Err(anyhow!(
+                        "Block `input {}` is nested in `map {}` which is invalid.",
+                        name,
+                        current_map.as_ref().unwrap()
+                    ))?;
+                }
                 input_found = true;
             }
             if block.block_type() == BlockType::Map {

--- a/front/lib/specification.js
+++ b/front/lib/specification.js
@@ -241,7 +241,6 @@ export function moveBlockUp(spec, index) {
   let s = spec.map((b) => b);
   if (index > 0 && index < spec.length) {
     switch (s[index].type) {
-      case "input":
       case "map":
       case "reduce":
         if (["map", "reduce"].includes(s[index - 1].type)) {
@@ -261,7 +260,6 @@ export function moveBlockDown(spec, index) {
   let s = spec.map((b) => b);
   if (index > -1 && index < spec.length - 1) {
     switch (s[index].type) {
-      case "input":
       case "map":
       case "reduce":
         if (["map", "reduce"].includes(s[index + 1].type)) {


### PR DESCRIPTION
If `input` was nested in `map`/`reduce` the app execution would assert! leaving the run pending.

A quick frontend fix was made a few days ago, this is a proper fix in `code`.