### PR TITLE
clean: comply with rustfmt, build & test project in CI

### DIFF
--- a/.github/workflows/build-and-test-core.yml
+++ b/.github/workflows/build-and-test-core.yml
@@ -1,0 +1,27 @@
+name: Build and Test (core)
+
+on:
+  push:
+    paths:
+      - core/**
+      - .github/workflows/build-and-test-core.yml
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+
+      - name: install rustup
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rustup-init.sh
+          sh rustup-init.sh -y --default-toolchain none
+          rustup target add x86_64-unknown-linux-gnu
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+
+      - name: Build and Test
+        working-directory: core
+        run: ./ci/build_and_test.sh

--- a/core/bin/dust.rs
+++ b/core/bin/dust.rs
@@ -3,12 +3,11 @@ use clap::{Parser, Subcommand};
 use dust::{
     app,
     blocks::block::BlockType,
-    dataset,
     data_sources::{
         data_source::{self, DataSourceConfig},
         splitter::SplitterID,
     },
-    init,
+    dataset, init,
     providers::provider,
     run, utils,
 };

--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -636,7 +636,6 @@ async fn run_helper(
     }
 
     if payload.inputs.is_some() {
-
         d = match dataset::Dataset::new_from_jsonl("inputs", payload.inputs.unwrap()).await {
             Err(e) => Err((
                 StatusCode::BAD_REQUEST,

--- a/core/ci/build_and_test.sh
+++ b/core/ci/build_and_test.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -euo pipefail
+
+export RUSTFLAGS="-D warnings"
+
+# Print version information
+rustc -Vv
+cargo -V
+
+# Build and test
+cargo build
+cargo test
+cargo fmt --all -- --check

--- a/core/src/init.rs
+++ b/core/src/init.rs
@@ -1,4 +1,7 @@
-use crate::{stores::{sqlite::SQLiteStore, store::Store}, utils};
+use crate::{
+    stores::{sqlite::SQLiteStore, store::Store},
+    utils,
+};
 use anyhow::Result;
 
 /// Initializing a Dust project. Consists in creating:
@@ -46,7 +49,6 @@ pub async fn cmd_init(target: &str) -> Result<()> {
 
     let project = store.create_project().await?;
     assert!(project.project_id() == 1);
-
 
     utils::done(&format!("Initialized Dust project in {}", target.display()));
 

--- a/core/src/project.rs
+++ b/core/src/project.rs
@@ -1,6 +1,5 @@
 use serde::Serialize;
 
-
 #[derive(Debug, Serialize, Clone)]
 pub struct Project {
     project_id: i64,
@@ -8,9 +7,7 @@ pub struct Project {
 
 impl Project {
     pub fn new_from_id(project_id: i64) -> Self {
-        Self {
-            project_id,
-        }
+        Self { project_id }
     }
 
     pub fn project_id(&self) -> i64 {


### PR DESCRIPTION
- reformat a few files that were not compliant with the existing `rustfmt` config (`.rustfmt.toml`)
- add a github action that builds the project, runs `cargo test` and `cargo fmt`