### PR TITLE
enh: improve display of errors in run tab

### DIFF
--- a/front/pages/[user]/a/[sId]/execute/index.jsx
+++ b/front/pages/[user]/a/[sId]/execute/index.jsx
@@ -16,6 +16,7 @@ import {
 import { useSavedRunStatus } from "@app/lib/swr";
 import { classNames } from "@app/lib/utils";
 import {
+  ExclamationCircleIcon,
   CheckCircleIcon,
   ChevronDownIcon,
   ChevronRightIcon,
@@ -45,7 +46,7 @@ function preProcessOutput(output) {
     return preProcessOutput(output.value);
   }
   if (output.error) {
-    return preProcessOutput(output.error);
+    return { error: output.error };
   }
   if (
     Object.keys(output).length === 2 &&
@@ -85,6 +86,8 @@ function ExecuteOutputLine({
             <div className="mr-1">
               <Spinner />
             </div>
+          ) : lastEventForBlock.content.status === 'errored' ? (
+            <ExclamationCircleIcon className="text-red-500 h-4 w-4" />
           ) : (
             <CheckCircleIcon className="text-emerald-300 h-4 w-4 min-w-4" />
           )}


### PR DESCRIPTION
- When the output is JSON with an error key, display the key to make it even more obvious it's an error
- When the status of a block is "errored", use a red `ExclamationCircleIcon` instead of the green tick one in execution trace