### PR TITLE
Add optional text field to document to clean-up external API 

### DIFF
--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -1221,13 +1221,17 @@ async fn data_sources_documents_retrieve(
                         response: None,
                     }),
                 ),
-                Ok(Some((d, text))) => (
+                Ok(Some(d)) => (
                     StatusCode::OK,
                     Json(APIResponse {
                         error: None,
                         response: Some(json!({
                             "document": d,
-                            "text": text,
+                            "data_source": {
+                                "created": ds.created(),
+                                "data_source_id": ds.data_source_id(),
+                                "config": ds.config(),
+                            },
                         })),
                     }),
                 ),
@@ -1288,9 +1292,8 @@ async fn data_sources_documents_delete(
                             "data_source": {
                                 "created": ds.created(),
                                 "data_source_id": ds.data_source_id(),
-                                "internal_id": ds.internal_id(),
                                 "config": ds.config(),
-                            }
+                            },
                         })),
                     }),
                 ),
@@ -1352,7 +1355,6 @@ async fn data_sources_delete(
                             "data_source": {
                                 "created": ds.created(),
                                 "data_source_id": ds.data_source_id(),
-                                "internal_id": ds.internal_id(),
                                 "config": ds.config(),
                             }
                         })),

--- a/core/src/stores/postgres.rs
+++ b/core/src/stores/postgres.rs
@@ -1033,6 +1033,7 @@ impl Store for PostgresStore {
                 let tags: Vec<String> = serde_json::from_str(&tags_data)?;
 
                 Ok(Some(Document {
+                    data_source_id: data_source_id.clone(),
                     created: created as u64,
                     timestamp: timestamp as u64,
                     document_id,
@@ -1041,6 +1042,7 @@ impl Store for PostgresStore {
                     text_size: text_size as u64,
                     chunk_count: chunk_count as usize,
                     chunks: vec![],
+                    text: None,
                 }))
             }
         }
@@ -1189,6 +1191,7 @@ impl Store for PostgresStore {
                 let tags: Vec<String> = serde_json::from_str(&tags_data)?;
 
                 Ok(Document {
+                    data_source_id: data_source_id.clone(),
                     created: created as u64,
                     timestamp: timestamp as u64,
                     document_id,
@@ -1197,6 +1200,7 @@ impl Store for PostgresStore {
                     text_size: text_size as u64,
                     chunk_count: chunk_count as usize,
                     chunks: vec![],
+                    text: None,
                 })
             })
             .collect::<Result<Vec<_>>>()?;

--- a/core/src/stores/sqlite.rs
+++ b/core/src/stores/sqlite.rs
@@ -1011,6 +1011,7 @@ impl Store for SQLiteStore {
             let tags: Vec<String> = serde_json::from_str(&tags_data)?;
 
             Ok(Some(Document {
+                data_source_id: data_source_id.clone(),
                 created,
                 timestamp,
                 document_id,
@@ -1019,6 +1020,7 @@ impl Store for SQLiteStore {
                 text_size,
                 chunk_count: chunk_count as usize,
                 chunks: vec![],
+                text: None,
             }))
         })
         .await?
@@ -1161,6 +1163,7 @@ impl Store for SQLiteStore {
                 let tags: Vec<String> = serde_json::from_str(&tags_data)?;
 
                 documents.push(Document {
+                    data_source_id: data_source_id.clone(),
                     created,
                     timestamp,
                     document_id,
@@ -1169,6 +1172,7 @@ impl Store for SQLiteStore {
                     text_size,
                     chunk_count: chunk_count as usize,
                     chunks: vec![],
+                    text: None,
                 });
             }
 

--- a/docs/src/pages/documents.mdx
+++ b/docs/src/pages/documents.mdx
@@ -142,6 +142,7 @@ The Document model represents a [data source](/data-sources-overview) document.
     ```json {{ title: 'Response' }}
     {
       "document": {
+        "data_source_id": "foo",
         "created": 1679447275024,
         "document_id": "top-secret-document",
         "timestamp": 1679447275024,
@@ -215,6 +216,7 @@ The Document model represents a [data source](/data-sources-overview) document.
     ```json {{ title: 'Response' }}
     {
       "document": {
+        "data_source_id": "foo",
         "created": 1679447275024,
         "document_id": "top-secret-document",
         "timestamp": 1679447275024,
@@ -328,6 +330,7 @@ The Document model represents a [data source](/data-sources-overview) document.
     {
       "documents":[
         {
+          "data_source_id": "foo",
           "created": 1679447719555,
           "document_id": "acme-report",
           "timestamp": 1679447719555,
@@ -337,6 +340,7 @@ The Document model represents a [data source](/data-sources-overview) document.
           "chunk_count": 1,
           "chunks": []
         }, {
+          "data_source_id": "foo",
           "created": 1679447275024,
           "document_id": "top-secret-document",
           "timestamp": 1679447275024,

--- a/docs/src/pages/documents.mdx
+++ b/docs/src/pages/documents.mdx
@@ -155,7 +155,8 @@ The Document model represents a [data source](/data-sources-overview) document.
           "offset": 0,
           "vector": [ 0.0027032278, ... ],
           "score":null
-        }]
+        }],
+        text: null,
       },
       "data_source": {
         "created": 1679447230117,
@@ -221,9 +222,9 @@ The Document model represents a [data source](/data-sources-overview) document.
         "hash": "1eebbe66ac93c...47548fcd",
         "text_size": 21,
         "chunk_count": 1,
-        "chunks": []
+        "chunks": [],
+        "text": "Top secret content..."
       },
-      "text": "Top secret content..."
     }
     ```
 

--- a/front/pages/[user]/ds/[name]/upsert.jsx
+++ b/front/pages/[user]/ds/[name]/upsert.jsx
@@ -55,7 +55,7 @@ export default function DataSourceUpsert({
           const document = await res.json();
           setDisabled(false);
           setDownloading(false);
-          setText(document.text);
+          setText(document.document.text);
           setTags(document.document.tags);
         }
       });

--- a/front/pages/api/data_sources/[user]/[name]/documents/[documentId]/index.js
+++ b/front/pages/api/data_sources/[user]/[name]/documents/[documentId]/index.js
@@ -162,7 +162,6 @@ export default async function handler(req, res) {
 
       res.status(200).json({
         document: document.response.document,
-        text: document.response.text,
       });
       break;
 

--- a/front/pages/api/v1/data_sources/[user]/[name]/documents/[documentId]/index.js
+++ b/front/pages/api/v1/data_sources/[user]/[name]/documents/[documentId]/index.js
@@ -117,7 +117,9 @@ export default async function handler(req, res) {
   switch (req.method) {
     case "GET":
       const docRes = await fetch(
-        `${DUST_API}/projects/${dataSource.dustAPIProjectId}/data_sources/${dataSource.name}/documents/${req.query.documentId}`,
+        `${DUST_API}/projects/${dataSource.dustAPIProjectId}/data_sources/${
+          dataSource.name
+        }/documents/${encodeURIComponent(req.query.documentId)}`,
         {
           method: "GET",
         }
@@ -150,7 +152,6 @@ export default async function handler(req, res) {
 
       res.status(200).json({
         document: document.response.document,
-        text: document.response.text,
       });
       break;
 
@@ -309,7 +310,9 @@ export default async function handler(req, res) {
       }
 
       const delRes = await fetch(
-        `${DUST_API}/projects/${dataSource.dustAPIProjectId}/data_sources/${dataSource.name}/documents/${req.query.documentId}`,
+        `${DUST_API}/projects/${dataSource.dustAPIProjectId}/data_sources/${
+          dataSource.name
+        }/documents/${encodeURIComponent(req.query.documentId)}`,
         {
           method: "DELETE",
         }


### PR DESCRIPTION
Motivation: have the text within the doc when retrieved through the external API (cleaner)