### PR TITLE
fixed typo in document-qa guide doc

### DIFF
--- a/docs/src/pages/guide-document-qa.mdx
+++ b/docs/src/pages/guide-document-qa.mdx
@@ -144,7 +144,7 @@ At this point you can run your app and introspect the outputs of the `data_sourc
 
 We will use `gpt-3.5-turbo` to process the chunks and generate an answer to the user.
 
-We use the following instruciton in the context of [ipcc-ar6](https://dust.tt/spolu/ds/ipcc-ar6):
+We use the following instruction in the context of [ipcc-ar6](https://dust.tt/spolu/ds/ipcc-ar6):
 
 ```txt
 You are an helpful assistant. For each user question, you'll receive 12 additional system


### PR DESCRIPTION
Fixed typo in "instruction" in document-qa guide doc