### PR TITLE
Authenticator object

### DIFF
--- a/front/lib/api/auth.ts
+++ b/front/lib/api/auth.ts
@@ -2,6 +2,7 @@ import { NextApiRequest } from "next";
 import { Result, Ok, Err } from "@app/lib/result";
 import { APIErrorWithStatusCode } from "@app/lib/api/error";
 import { Key, User } from "@app/lib/models";
+import { Authenticator } from "@app/lib/auth";
 
 /**
  * Get a user id from the Authorization Bearer header
@@ -10,7 +11,7 @@ import { Key, User } from "@app/lib/models";
  */
 export async function auth_api_user(
   req: NextApiRequest
-): Promise<Result<User, APIErrorWithStatusCode>> {
+): Promise<Result<Authenticator, APIErrorWithStatusCode>> {
   if (!req.headers.authorization) {
     return Err({
       status_code: 401,
@@ -75,5 +76,5 @@ export async function auth_api_user(
     });
   }
 
-  return Ok(authUser);
+  return Ok(new Authenticator(authUser));
 }

--- a/front/lib/api/auth.ts
+++ b/front/lib/api/auth.ts
@@ -5,9 +5,10 @@ import { Key, User } from "@app/lib/models";
 import { Authenticator } from "@app/lib/auth";
 
 /**
- * Get a user id from the Authorization Bearer header
+ * Get a an Authenticator assiciated with the authentified user from the Authorization Bearer
+ * header.
  * @param req NextApiRequest request object
- * @returns Result<number, HTTPError> Ok(User) or Err(HTTPError)
+ * @returns Result<Authenticator, HTTPError>
  */
 export async function auth_api_user(
   req: NextApiRequest

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -1,0 +1,86 @@
+import { App, User, DataSource } from "./models";
+import { InternalErrorWithStatusCode } from "./error";
+import { Result, Ok, Err } from "@app/lib/result";
+import { NextApiRequest, NextApiResponse } from "next";
+import { authOptions } from "@app/pages/api/auth/[...nextauth]";
+import { getServerSession } from "next-auth/next";
+
+type Role = "owner" | "read_only";
+
+export class Authenticator {
+  authUser: User;
+
+  constructor(authUser: User) {
+    this.authUser = authUser;
+  }
+
+  user() {
+    return this.authUser;
+  }
+
+  // There is no workspace yet but eventually we'll have a workspace model and this will be used to
+  // check if the user is a member of the workspace.
+  async roleFor(resourceOwner: User): Promise<Role> {
+    if (resourceOwner.id === this.authUser.id) {
+      return "owner";
+    } else {
+      return "read_only";
+    }
+  }
+
+  canReadApp(app: App): boolean {
+    switch (app.visibility) {
+      case "private":
+        return this.authUser.id === app.userId;
+      case "public":
+      case "unlisted":
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  canEditApp(app: App): boolean {
+    return this.authUser.id === app.userId;
+  }
+
+  canRunApp(app: App): boolean {
+    return this.authUser.id === app.userId;
+  }
+
+  canReadDataSource(dataSource: DataSource): boolean {
+    switch (dataSource.visibility) {
+      case "public":
+        return true;
+      case "private":
+        return this.authUser.id === dataSource.userId;
+      default:
+        return false;
+    }
+  }
+
+  canEditDataSource(dataSource: DataSource): boolean {
+    return this.authUser.id === dataSource.userId;
+  }
+}
+
+export async function auth_user(
+  req: NextApiRequest,
+  res: NextApiResponse
+): Promise<Result<Authenticator, InternalErrorWithStatusCode>> {
+  const session = await getServerSession(req, res, authOptions);
+
+  let authUser = await User.findOne({
+    where: {
+      username: req.query.user,
+    },
+  });
+
+  if (!authUser) {
+    return Err({
+      status_code: 404,
+    });
+  }
+
+  return Ok(new Authenticator(authUser));
+}

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -5,7 +5,10 @@ import { NextApiRequest, NextApiResponse } from "next";
 import { authOptions } from "@app/pages/api/auth/[...nextauth]";
 import { getServerSession } from "next-auth/next";
 
-type Role = "owner" | "read_only";
+export enum Role {
+  Owner = "owner",
+  ReadOnly = "read_only",
+}
 
 /**
  * This is a class that will be used to check if a user can perform an action on a resource.
@@ -43,9 +46,9 @@ export class Authenticator {
    */
   async roleFor(resourceOwner: User): Promise<Role> {
     if (resourceOwner.id === this.authUser?.id) {
-      return "owner";
+      return Role.Owner;
     } else {
-      return "read_only";
+      return Role.ReadOnly;
     }
   }
 

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -20,13 +20,26 @@ export class Authenticator {
     this.authUser = authUser;
   }
 
-  user(): User | null {
-    return this.authUser;
+  /**
+   * The caller should ensure that the user is authenticated before calling this method.
+   *
+   * @returns the authenticated user or throws an error if the user is not authenticated.
+   */
+  user(): User {
+    return this.authUser!;
+  }
+
+  isAnonymous(): boolean {
+    return this.authUser === null;
   }
 
   /**
    * There is no workspace yet but eventually we'll have a workspace model and this will be used to
    * check if the user is a member of the workspace.
+   *
+   * @param resourceOwner the owner of the resource for which we want to check the role. This will
+   * be replaced by a workspace in the future.
+   * @returns the role of the authenticated user.
    */
   async roleFor(resourceOwner: User): Promise<Role> {
     if (resourceOwner.id === this.authUser?.id) {
@@ -38,6 +51,9 @@ export class Authenticator {
 
   /**
    * Any user can run a `public` or `unlisted` app. Only the owner can read a `private` app.
+   *
+   * @param app the app for which we check the read rights
+   * @returns true if the user can read the app, false otherwise.
    */
   canReadApp(app: App): boolean {
     switch (app.visibility) {
@@ -53,6 +69,9 @@ export class Authenticator {
 
   /**
    * Only the owner can edit an app.
+   *
+   * @param app the app for which we check the edit rights
+   * @returns true if the user can edit the app, false otherwise.
    */
   canEditApp(app: App): boolean {
     return this.authUser?.id === app.userId;
@@ -66,6 +85,9 @@ export class Authenticator {
    * Once we introduce a `front` side `Run` object, we can remove this restriction and allow anyone
    * to run a public app with their own credentials. This will enable use to have the "Use" and
    * "Logs" panels available to any logged-in user.
+   *
+   * @param app the app for which we check the run rights
+   * @returns true if the user can run the app, false otherwise.
    */
   canRunApp(app: App): boolean {
     return this.authUser?.id === app.userId;
@@ -73,6 +95,9 @@ export class Authenticator {
 
   /**
    * Any user can read a `public` data source. Only the owner can read a `private` data source.
+   *
+   * @param dataSource the data source for which we check the read rights
+   * @returns true if the user can read the data source, false otherwise.
    */
   canReadDataSource(dataSource: DataSource): boolean {
     switch (dataSource.visibility) {
@@ -87,6 +112,9 @@ export class Authenticator {
 
   /**
    * Only the owner can edit a data source.
+   *
+   * @param dataSource the data source for which we check the edit rights
+   * @returns true if the user can edit the data source, false otherwise.
    */
   canEditDataSource(dataSource: DataSource): boolean {
     return this.authUser?.id === dataSource.userId;
@@ -95,6 +123,7 @@ export class Authenticator {
 
 /**
  * Get a an Authenticator assiciated with the authentified user from the nextauth session.
+ *
  * @param req NextApiRequest request object
  * @param res NextApiResponse response object
  * @returns Result<Authenticator, InternalErrorWithStatusCode>

--- a/front/lib/error.ts
+++ b/front/lib/error.ts
@@ -1,0 +1,3 @@
+export type InternalErrorWithStatusCode = {
+  status_code: number;
+};

--- a/front/lib/models.ts
+++ b/front/lib/models.ts
@@ -91,7 +91,7 @@ export class App extends Model<
   declare sId: string;
   declare name: string;
   declare description: string;
-  declare visibility: string;
+  declare visibility: "public" | "private" | "unlisted";
   declare savedSpecification: string;
   declare savedConfig: string;
   declare savedRun: string;
@@ -365,7 +365,7 @@ export class DataSource extends Model<
 
   declare name: string;
   declare description?: string;
-  declare visibility: string;
+  declare visibility: "public" | "private";
   declare config?: string;
   declare dustAPIProjectId: string;
 

--- a/front/pages/api/apps/[user]/index.js
+++ b/front/pages/api/apps/[user]/index.js
@@ -10,8 +10,6 @@ const { DUST_API } = process.env;
 async function handler(req, res) {
   const session = await unstable_getServerSession(req, res, authOptions);
 
-  console.log("session", session);
-
   let user = await User.findOne({
     where: {
       username: req.query.user,

--- a/front/pages/api/apps/[user]/index.js
+++ b/front/pages/api/apps/[user]/index.js
@@ -10,6 +10,8 @@ const { DUST_API } = process.env;
 async function handler(req, res) {
   const session = await unstable_getServerSession(req, res, authOptions);
 
+  console.log("session", session);
+
   let user = await User.findOne({
     where: {
       username: req.query.user,

--- a/front/pages/api/v1/apps/[user]/[sId]/runs/index.ts
+++ b/front/pages/api/v1/apps/[user]/[sId]/runs/index.ts
@@ -85,7 +85,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     }),
     Provider.findAll({
       where: {
-        userId: auth.user()?.id,
+        userId: auth.user()!.id,
       },
     }),
   ]);

--- a/front/pages/api/v1/apps/[user]/[sId]/runs/index.ts
+++ b/front/pages/api/v1/apps/[user]/[sId]/runs/index.ts
@@ -85,7 +85,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     }),
     Provider.findAll({
       where: {
-        userId: auth.user()!.id,
+        userId: auth.user().id,
       },
     }),
   ]);
@@ -160,7 +160,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
             method: "POST",
             headers: {
               "Content-Type": "application/json",
-              "X-Dust-User-Id": auth.user()!.id.toString(),
+              "X-Dust-User-Id": auth.user().id.toString(),
             },
             body: JSON.stringify({
               run_type: "deploy",
@@ -213,7 +213,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
-            "X-Dust-User-Id": auth.user()!.id.toString(),
+            "X-Dust-User-Id": auth.user().id.toString(),
           },
           body: JSON.stringify({
             run_type: "deploy",

--- a/front/pages/api/v1/apps/[user]/[sId]/runs/index.ts
+++ b/front/pages/api/v1/apps/[user]/[sId]/runs/index.ts
@@ -85,7 +85,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     }),
     Provider.findAll({
       where: {
-        userId: auth.user().id,
+        userId: auth.user()?.id,
       },
     }),
   ]);
@@ -160,7 +160,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
             method: "POST",
             headers: {
               "Content-Type": "application/json",
-              "X-Dust-User-Id": auth.user().id.toString(),
+              "X-Dust-User-Id": auth.user()!.id.toString(),
             },
             body: JSON.stringify({
               run_type: "deploy",
@@ -213,7 +213,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
-            "X-Dust-User-Id": auth.user().id.toString(),
+            "X-Dust-User-Id": auth.user()!.id.toString(),
           },
           body: JSON.stringify({
             run_type: "deploy",

--- a/front/pages/api/v1/apps/[user]/index.ts
+++ b/front/pages/api/v1/apps/[user]/index.ts
@@ -3,6 +3,7 @@ import { Op } from "sequelize";
 import { auth_api_user } from "@app/lib/api/auth";
 import { NextApiRequest, NextApiResponse } from "next";
 import withLogging from "@app/logger/withlogging";
+import { Role } from "@app/lib/auth";
 
 async function handler(req: NextApiRequest, res: NextApiResponse) {
   let [authRes, appOwner] = await Promise.all([
@@ -34,7 +35,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
 
   let apps = await App.findAll({
     where:
-      role === "read_only"
+      role === Role.ReadOnly
         ? {
             userId: appOwner.id,
             visibility: {

--- a/front/pages/api/v1/data_sources/[user]/[name]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/data_sources/[user]/[name]/documents/[documentId]/index.ts
@@ -124,7 +124,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       let [providers] = await Promise.all([
         Provider.findAll({
           where: {
-            userId: auth.user().id,
+            userId: auth.user()!.id,
           },
         }),
       ]);
@@ -170,7 +170,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       }
 
       // Enforce FreePlan limit: 32 documents per DataSource.
-      if (auth.user().username !== "spolu") {
+      if (auth.user()!.username !== "spolu") {
         const documentsRes = await fetch(
           `${DUST_API}/projects/${dataSource.dustAPIProjectId}/data_sources/${dataSource.name}/documents?limit=1&offset=0`,
           {

--- a/front/pages/api/v1/data_sources/[user]/[name]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/data_sources/[user]/[name]/documents/[documentId]/index.ts
@@ -124,7 +124,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       let [providers] = await Promise.all([
         Provider.findAll({
           where: {
-            userId: auth.user()!.id,
+            userId: auth.user().id,
           },
         }),
       ]);
@@ -170,7 +170,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       }
 
       // Enforce FreePlan limit: 32 documents per DataSource.
-      if (auth.user()!.username !== "spolu") {
+      if (auth.user().username !== "spolu") {
         const documentsRes = await fetch(
           `${DUST_API}/projects/${dataSource.dustAPIProjectId}/data_sources/${dataSource.name}/documents?limit=1&offset=0`,
           {

--- a/front/pages/api/v1/data_sources/[user]/[name]/search.ts
+++ b/front/pages/api/v1/data_sources/[user]/[name]/search.ts
@@ -128,7 +128,7 @@ export default async function handler(
       const [providers] = await Promise.all([
         Provider.findAll({
           where: {
-            userId: auth.user()!.id,
+            userId: auth.user().id,
           },
         }),
       ]);

--- a/front/pages/api/v1/data_sources/[user]/[name]/search.ts
+++ b/front/pages/api/v1/data_sources/[user]/[name]/search.ts
@@ -69,7 +69,7 @@ export default async function handler(
     const err = authRes.error();
     return res.status(err.status_code).json(err.api_error);
   }
-  const authUser = authRes.value();
+  const auth = authRes.value();
 
   if (!dataSourceOwner) {
     res.status(404).json({
@@ -81,43 +81,34 @@ export default async function handler(
     return;
   }
 
+  const dataSource = await DataSource.findOne({
+    where: {
+      userId: dataSourceOwner.id,
+      name: req.query.name,
+    },
+    attributes: [
+      "id",
+      "name",
+      "description",
+      "visibility",
+      "config",
+      "dustAPIProjectId",
+      "updatedAt",
+    ],
+  });
+
+  if (!dataSource) {
+    return res.status(404).json({
+      error: {
+        type: "data_source_not_found",
+        message: "Data source not found",
+      },
+    });
+  }
+
   switch (req.method) {
     case "GET": {
-      // I could not find a way to make the query params be an array if there is only one tag
-      if (req.query.tags_in && typeof req.query.tags_in === "string") {
-        req.query.tags_in = [req.query.tags_in];
-      }
-      if (req.query.tags_not && typeof req.query.tags_not === "string") {
-        req.query.tags_not = [req.query.tags_not];
-      }
-      const readOnly = authUser.id != dataSourceOwner.id;
-      const datasourceId = req.query.name;
-
-      const dataSource = await DataSource.findOne({
-        where: readOnly
-          ? {
-              userId: dataSourceOwner.id,
-              name: datasourceId,
-              visibility: {
-                [Op.or]: ["public"],
-              },
-            }
-          : {
-              userId: dataSourceOwner.id,
-              name: datasourceId,
-            },
-        attributes: [
-          "id",
-          "name",
-          "description",
-          "visibility",
-          "config",
-          "dustAPIProjectId",
-          "updatedAt",
-        ],
-      });
-
-      if (!dataSource) {
+      if (!auth.canReadDataSource(dataSource)) {
         return res.status(404).json({
           error: {
             type: "data_source_not_found",
@@ -125,16 +116,25 @@ export default async function handler(
           },
         });
       }
+
+      // I could not find a way to make the query params be an array if there is only one tag
+      if (req.query.tags_in && typeof req.query.tags_in === "string") {
+        req.query.tags_in = [req.query.tags_in];
+      }
+      if (req.query.tags_not && typeof req.query.tags_not === "string") {
+        req.query.tags_not = [req.query.tags_not];
+      }
+
       const [providers] = await Promise.all([
         Provider.findAll({
           where: {
-            userId: authUser.id,
+            userId: auth.user()!.id,
           },
         }),
       ]);
       const credentials = credentialsFromProviders(providers);
-      const searchQueryRes = parse_payload(searchQuerySchema, req.query);
 
+      const searchQueryRes = parse_payload(searchQuerySchema, req.query);
       if (searchQueryRes.isErr()) {
         const err = searchQueryRes.error();
         return res.status(400).json({
@@ -186,12 +186,14 @@ export default async function handler(
           },
         });
       }
-      const documents = await searchRes.json();
+      const data = await searchRes.json();
+
       res.status(200).json({
-        documents: documents.response.documents,
+        documents: data.response.documents,
       });
       return;
     }
+
     default:
       res.status(405).end();
       break;


### PR DESCRIPTION
The goal of the Authenticator is to abstract the permissioning logic in one central place.

Eventually, the `roleFor` will take a workspace as argument, but currently take the `resourceOwner: User`.

As we introduce the notion of workspace the overall logic of the Authenticator might change quite substantially but the idea is to start cleaning up and cenralizing on it all the permissioning logic

This PR only covers the public API for now, but if it looks reasonable I'll extend it to all internal routes as well.