### PR TITLE
Continued work on Authenticator + TypeScript : Datasets

### DIFF
--- a/front/components/app/DatasetView.jsx
+++ b/front/components/app/DatasetView.jsx
@@ -599,14 +599,16 @@ export default function DatasetView({
               </ul>
             </div>
             <div className="mt-6 flex flex-row">
-              <Button
-                onClick={() => {
-                  handleNewEntry(datasetData.length - 1);
-                }}
-              >
-                <PlusIcon className="-ml-1 mr-1 h-5 w-5" />
-                New Entry
-              </Button>
+              {!readOnly ? (
+                <Button
+                  onClick={() => {
+                    handleNewEntry(datasetData.length - 1);
+                  }}
+                >
+                  <PlusIcon className="-ml-1 mr-1 h-5 w-5" />
+                  New Entry
+                </Button>
+              ) : null}
               <div className="flex-1"></div>
               <div className="ml-2 flex-initial">
                 <Button

--- a/front/lib/swr.ts
+++ b/front/lib/swr.ts
@@ -1,4 +1,4 @@
-import { GetDatasetResponseBody } from "@app/pages/api/apps/[user]/[sId]/datasets";
+import { GetDatasetsResponseBody } from "@app/pages/api/apps/[user]/[sId]/datasets";
 import { GetRunsResponseBody } from "@app/pages/api/apps/[user]/[sId]/runs";
 import { GetRunBlockResponseBody } from "@app/pages/api/apps/[user]/[sId]/runs/[runId]/blocks/[type]/[name]";
 import { GetRunStatusResponseBody } from "@app/pages/api/apps/[user]/[sId]/runs/[runId]/status";
@@ -12,7 +12,7 @@ export const fetcher = (...args: Parameters<typeof fetch>) =>
   fetch(...args).then((res) => res.json());
 
 export function useDatasets(user: string, app: { sId: string }) {
-  const datasetsFetcher: Fetcher<GetDatasetResponseBody> = fetcher;
+  const datasetsFetcher: Fetcher<GetDatasetsResponseBody> = fetcher;
 
   const { data, error } = useSWR(
     `/api/apps/${user}/${app.sId}/datasets`,

--- a/front/lib/types.ts
+++ b/front/lib/types.ts
@@ -13,10 +13,11 @@ export type DocumentType = {
     vector: Array<number> | null;
     score: number | null;
   }>;
+  text?: string;
 };
 
 export type DatasetType = {
   name: string;
   description: string;
-  data: Array<any>;
+  data?: Array<any>;
 };

--- a/front/lib/types.ts
+++ b/front/lib/types.ts
@@ -1,4 +1,4 @@
-export type Document = {
+export type DocumentType = {
   created: number;
   document_id: string;
   timestamp: number;
@@ -13,4 +13,10 @@ export type Document = {
     vector: Array<number> | null;
     score: number | null;
   }>;
+};
+
+export type DatasetType = {
+  name: string;
+  description: string;
+  data: Array<any>;
 };

--- a/front/pages/api/apps/[user]/[sId]/datasets/[name]/[hash]/index.ts
+++ b/front/pages/api/apps/[user]/[sId]/datasets/[name]/[hash]/index.ts
@@ -6,11 +6,11 @@ import { DatasetType } from "@app/lib/types";
 
 const { DUST_API } = process.env;
 
-export type GetDatasetResponseBody = { dataset: DatasetType };
+type GetDatasetByHashResponseBody = { dataset: DatasetType };
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<GetDatasetResponseBody>
+  res: NextApiResponse<GetDatasetByHashResponseBody>
 ) {
   let [authRes, appUser] = await Promise.all([
     auth_user(req, res),
@@ -27,8 +27,7 @@ async function handler(
   let auth = authRes.value();
 
   if (!appUser) {
-    res.status(404).end();
-    return;
+    return res.status(404).end();
   }
 
   let [app] = await Promise.all([
@@ -41,8 +40,7 @@ async function handler(
   ]);
 
   if (!app) {
-    res.status(404).end();
-    return;
+    return res.status(404).end();
   }
 
   let [dataset] = await Promise.all([
@@ -56,8 +54,7 @@ async function handler(
   ]);
 
   if (!dataset) {
-    res.status(404).end();
-    return;
+    return res.status(404).end();
   }
 
   switch (req.method) {
@@ -112,8 +109,7 @@ async function handler(
       break;
 
     default:
-      res.status(405).end();
-      break;
+      return res.status(405).end();
   }
 }
 

--- a/front/pages/api/apps/[user]/[sId]/datasets/[name]/[hash]/index.ts
+++ b/front/pages/api/apps/[user]/[sId]/datasets/[name]/[hash]/index.ts
@@ -11,7 +11,7 @@ type GetDatasetByHashResponseBody = { dataset: DatasetType };
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<GetDatasetByHashResponseBody>
-) {
+): Promise<void> {
   let [authRes, appUser] = await Promise.all([
     auth_user(req, res),
     User.findOne({
@@ -22,12 +22,14 @@ async function handler(
   ]);
 
   if (authRes.isErr()) {
-    return res.status(authRes.error().status_code).end();
+    res.status(authRes.error().status_code).end();
+    return;
   }
   let auth = authRes.value();
 
   if (!appUser) {
-    return res.status(404).end();
+    res.status(404).end();
+    return;
   }
 
   let [app] = await Promise.all([
@@ -40,7 +42,8 @@ async function handler(
   ]);
 
   if (!app) {
-    return res.status(404).end();
+    res.status(404).end();
+    return;
   }
 
   let [dataset] = await Promise.all([
@@ -54,13 +57,15 @@ async function handler(
   ]);
 
   if (!dataset) {
-    return res.status(404).end();
+    res.status(404).end();
+    return;
   }
 
   switch (req.method) {
     case "GET":
       if (!auth.canReadApp(app)) {
-        return res.status(404).end();
+        res.status(404).end();
+        return;
       }
 
       let hash = req.query.hash;
@@ -79,10 +84,12 @@ async function handler(
         const apiDatasets = await apiDatasetsRes.json();
 
         if (!(dataset.name in apiDatasets.response.datasets)) {
-          return res.status(404).end();
+          res.status(404).end();
+          return;
         }
         if (apiDatasets.response.datasets[dataset.name].lenght == 0) {
-          return res.status(400).end();
+          res.status(400).end();
+          return;
         }
 
         hash = apiDatasets.response.datasets[dataset.name][0].hash;
@@ -106,10 +113,11 @@ async function handler(
           data: apiDataset.response.dataset.data,
         },
       });
-      break;
+      return;
 
     default:
-      return res.status(405).end();
+      res.status(405).end();
+      return;
   }
 }
 

--- a/front/pages/api/data_sources/[user]/[name]/documents/index.ts
+++ b/front/pages/api/data_sources/[user]/[name]/documents/index.ts
@@ -4,12 +4,12 @@ import { NextApiRequest, NextApiResponse } from "next";
 import { unstable_getServerSession } from "next-auth/next";
 import { Op } from "sequelize";
 import withLogging from "@app/logger/withlogging";
-import { Document } from "@app/lib/types";
+import { DocumentType } from "@app/lib/types";
 
 const { DUST_API } = process.env;
 
 export type GetDocumentsResponseBody = {
-  documents: Array<Document>;
+  documents: Array<DocumentType>;
   total: number;
 };
 

--- a/front/pages/api/v1/data_sources/[user]/[name]/search.ts
+++ b/front/pages/api/v1/data_sources/[user]/[name]/search.ts
@@ -3,9 +3,9 @@ import { auth_api_user } from "@app/lib/api/auth";
 import { APIError } from "@app/lib/api/error";
 import { JSONSchemaType } from "ajv";
 import { User, DataSource, Provider } from "@app/lib/models";
-import { Op } from "sequelize";
 import { credentialsFromProviders } from "@app/lib/providers";
 import { parse_payload } from "@app/lib/http_utils";
+import { DocumentType } from "@app/lib/types";
 
 type TagsFilter = {
   in?: string[];
@@ -49,7 +49,7 @@ const searchQuerySchema: JSONSchemaType<DatasourceSearchQuery> = {
 const { DUST_API } = process.env;
 
 type DatasourceSearchResponseBody = {
-  documents: Array<Document>;
+  documents: Array<DocumentType>;
 };
 
 export default async function handler(


### PR DESCRIPTION
This PR applies the new Authenticator pattern to all `Dataset` related internal API routes

Process is the following, for each route:
- Move to TypeScript
- Type `NextResponse<...>`
- Add return `Promise<void>` to enforce convention
- Move to `auth_user`
- Remove `readOnly`
- Add `can***App()` calls instead
- Fix anything remaining
- Test live