### PR TITLE
`owner` abstraction + `auth_user` in `getServerSideProps` + `authUser`

### DIFF
--- a/front/components/AppLayout.jsx
+++ b/front/components/AppLayout.jsx
@@ -19,7 +19,7 @@ export default function AppLayout({
   ga_tracking_id,
   children,
 }) {
-  const { data: session } = useSession();
+  const { data: session, status } = useSession();
 
   const router = useRouter();
   let route_user = router.query.user;
@@ -225,7 +225,7 @@ export default function AppLayout({
                       </Menu.Items>
                     </Menu>
                   </div>
-                ) : (
+                ) : status !== "loading" ? (
                   <div className="static static inset-auto inset-auto right-0 hidden flex-initial items-center pr-2 sm:flex sm:pr-0">
                     <div className="-mr-2 sm:mr-0">
                       <ActionButton
@@ -238,7 +238,7 @@ export default function AppLayout({
                       </ActionButton>
                     </div>
                   </div>
-                )}
+                ) : null}
               </div>
             </div>
           </>

--- a/front/components/app/DatasetPicker.jsx
+++ b/front/components/app/DatasetPicker.jsx
@@ -5,7 +5,7 @@ import { ChevronDownIcon } from "@heroicons/react/20/solid";
 import Link from "next/link";
 
 export default function DatasetPicker({
-  user,
+  owner,
   dataset,
   readOnly,
   app,
@@ -17,7 +17,7 @@ export default function DatasetPicker({
         isDatasetsLoading: false,
         isDatasetsError: false,
       }
-    : useDatasets(user, app);
+    : useDatasets(owner.username, app);
 
   // Remove the dataset if it was suppressed.
   if (
@@ -35,7 +35,7 @@ export default function DatasetPicker({
   return (
     <div className="flex items-center">
       {dataset ? (
-        <Link href={`/${user}/a/${app.sId}/datasets/${dataset}`}>
+        <Link href={`/${owner.username}/a/${app.sId}/datasets/${dataset}`}>
           <div className="text-sm font-bold text-violet-600">{dataset}</div>
         </Link>
       ) : (
@@ -45,7 +45,7 @@ export default function DatasetPicker({
         <div>
           {datasets.length == 0 && !dataset && !readOnly ? (
             <Link
-              href={`/${user}/a/${app.sId}/datasets/new`}
+              href={`/${owner.username}/a/${app.sId}/datasets/new`}
               className={classNames(
                 "inline-flex items-center rounded-md py-1 text-sm font-normal",
                 dataset ? "px-1" : "border px-3",
@@ -110,7 +110,7 @@ export default function DatasetPicker({
               })}
               <Menu.Item key="__create_dataset" onClick={() => {}}>
                 {({ active }) => (
-                  <Link href={`/${user}/a/${app.sId}/datasets/new`}>
+                  <Link href={`/${owner.username}/a/${app.sId}/datasets/new`}>
                     <div
                       className={classNames(
                         active ? "bg-gray-50 text-gray-500" : "text-gray-400",

--- a/front/components/app/Deploy.jsx
+++ b/front/components/app/Deploy.jsx
@@ -29,7 +29,7 @@ const cleanUpConfig = (config) => {
   return JSON.stringify(c);
 };
 
-export default function Deploy({ user, app, spec, run, disabled, url }) {
+export default function Deploy({ owner, app, spec, run, disabled, url }) {
   const [open, setOpen] = useState(false);
 
   let { keys } = useKeys();
@@ -45,7 +45,7 @@ export default function Deploy({ user, app, spec, run, disabled, url }) {
         ? activeKey.secret
         : `sk-...${activeKey.secret.slice(-5)}`;
     }
-    let cURL = `curl ${url}/api/v1/apps/${user}/${app.sId}/runs \\
+    let cURL = `curl ${url}/api/v1/apps/${owner.username}/${app.sId}/runs \\
     -H "Authorization: Bearer ${cURLKey}" \\
     -H "Content-Type: application/json" \\
     -d '{
@@ -130,7 +130,7 @@ export default function Deploy({ user, app, spec, run, disabled, url }) {
                               This command is ready to copy with your first
                               active API key.{" "}
                               <Link
-                                href={`/${user}/keys`}
+                                href={`/${owner.username}/keys`}
                                 className={classNames(
                                   "inline-flex items-center rounded-md py-1 text-sm font-bold",
                                   "text-violet-600"
@@ -143,7 +143,7 @@ export default function Deploy({ user, app, spec, run, disabled, url }) {
                           ) : (
                             <p className="text-sm text-gray-500">
                               <Link
-                                href={`/${user}/keys`}
+                                href={`/${owner.username}/keys`}
                                 className={classNames(
                                   "inline-flex items-center rounded-md py-1 text-sm font-bold",
                                   "text-violet-600"

--- a/front/components/app/MainTab.jsx
+++ b/front/components/app/MainTab.jsx
@@ -10,11 +10,11 @@ import {
 } from "@heroicons/react/24/outline";
 import { ChevronDownIcon } from "@heroicons/react/20/solid";
 
-export default function MainTab({ app, currentTab, user, readOnly }) {
+export default function MainTab({ app, currentTab, owner, readOnly }) {
   let tabs = [
     {
       name: "Specification",
-      href: `/${user}/a/${app.sId}`,
+      href: `/${owner.username}/a/${app.sId}`,
       icon: (
         <CodeBracketIcon
           className="mr-2 mt-0.5 h-4 w-4 flex-shrink-0"
@@ -24,7 +24,7 @@ export default function MainTab({ app, currentTab, user, readOnly }) {
     },
     {
       name: "Datasets",
-      href: `/${user}/a/${app.sId}/datasets`,
+      href: `/${owner.username}/a/${app.sId}/datasets`,
       icon: (
         <DocumentIcon
           className="mr-2 mt-0.5 h-4 w-4 flex-shrink-0"
@@ -37,7 +37,7 @@ export default function MainTab({ app, currentTab, user, readOnly }) {
   if (!readOnly) {
     tabs.push({
       name: "Use",
-      href: `/${user}/a/${app.sId}/execute`,
+      href: `/${owner.username}/a/${app.sId}/execute`,
       icon: (
         <BoltIcon
           className="mr-2 mt-0.5 h-4 w-4 flex-shrink-0"
@@ -47,7 +47,7 @@ export default function MainTab({ app, currentTab, user, readOnly }) {
     });
     tabs.push({
       name: "Logs",
-      href: `/${user}/a/${app.sId}/runs`,
+      href: `/${owner.username}/a/${app.sId}/runs`,
       icon: (
         <ArchiveBoxIcon
           className="mr-2 mt-0.5 h-4 w-4 flex-shrink-0"
@@ -57,7 +57,7 @@ export default function MainTab({ app, currentTab, user, readOnly }) {
     });
     tabs.push({
       name: "Settings",
-      href: `/${user}/a/${app.sId}/settings`,
+      href: `/${owner.username}/a/${app.sId}/settings`,
       icon: (
         <Cog6ToothIcon
           className="mr-2 mt-0.5 h-4 w-4 flex-shrink-0"

--- a/front/components/app/ModelPicker.jsx
+++ b/front/components/app/ModelPicker.jsx
@@ -8,7 +8,7 @@ import { filterModelProviders, getProviderLLMModels } from "@app/lib/providers";
 import { useState } from "react";
 
 export default function ModelPicker({
-  user,
+  owner,
   model,
   readOnly,
   onModelUpdate,
@@ -78,7 +78,7 @@ export default function ModelPicker({
             !(model.provider_id && model.provider_id.length > 0) &&
             !readOnly ? (
               <Link
-                href={`/${user}/providers`}
+                href={`/${owner.username}/providers`}
                 className={classNames(
                   "inline-flex items-center rounded-md py-1 text-sm font-bold",
                   (model.provider_id && model.provider_id.length) > 0

--- a/front/components/app/SpecRunView.jsx
+++ b/front/components/app/SpecRunView.jsx
@@ -11,7 +11,7 @@ import Browser from "./blocks/Browser";
 import { Map, Reduce } from "./blocks/MapReduce";
 
 export default function SpecRunView({
-  user,
+  owner,
   app,
   readOnly,
   spec,
@@ -57,7 +57,7 @@ export default function SpecRunView({
                 <Input
                   key={idx}
                   block={block}
-                  user={user}
+                  owner={owner}
                   app={app}
                   spec={spec}
                   run={run}
@@ -78,7 +78,7 @@ export default function SpecRunView({
                 <Data
                   key={idx}
                   block={block}
-                  user={user}
+                  owner={owner}
                   app={app}
                   spec={spec}
                   run={run}
@@ -99,7 +99,7 @@ export default function SpecRunView({
                 <LLM
                   key={idx}
                   block={block}
-                  user={user}
+                  owner={owner}
                   app={app}
                   spec={spec}
                   run={run}
@@ -120,7 +120,7 @@ export default function SpecRunView({
                 <Chat
                   key={idx}
                   block={block}
-                  user={user}
+                  owner={owner}
                   app={app}
                   spec={spec}
                   run={run}
@@ -141,7 +141,7 @@ export default function SpecRunView({
                 <Code
                   key={idx}
                   block={block}
-                  user={user}
+                  owner={owner}
                   app={app}
                   spec={spec}
                   run={run}
@@ -162,7 +162,7 @@ export default function SpecRunView({
                 <DataSource
                   key={idx}
                   block={block}
-                  user={user}
+                  owner={owner}
                   app={app}
                   spec={spec}
                   run={run}
@@ -183,7 +183,7 @@ export default function SpecRunView({
                 <Map
                   key={idx}
                   block={block}
-                  user={user}
+                  owner={owner}
                   app={app}
                   spec={spec}
                   run={run}
@@ -204,7 +204,7 @@ export default function SpecRunView({
                 <Reduce
                   key={idx}
                   block={block}
-                  user={user}
+                  owner={owner}
                   app={app}
                   spec={spec}
                   run={run}
@@ -223,7 +223,7 @@ export default function SpecRunView({
                 <Search
                   key={idx}
                   block={block}
-                  user={user}
+                  owner={owner}
                   app={app}
                   spec={spec}
                   run={run}
@@ -244,7 +244,7 @@ export default function SpecRunView({
                 <Curl
                   key={idx}
                   block={block}
-                  user={user}
+                  owner={owner}
                   app={app}
                   spec={spec}
                   run={run}
@@ -265,7 +265,7 @@ export default function SpecRunView({
                 <Browser
                   key={idx}
                   block={block}
-                  user={user}
+                  owner={owner}
                   app={app}
                   spec={spec}
                   run={run}

--- a/front/components/app/blocks/Block.jsx
+++ b/front/components/app/blocks/Block.jsx
@@ -14,7 +14,7 @@ import NewBlock from "@app/components/app/NewBlock";
 import { Spinner } from "@app/components/Spinner";
 
 export default function Block({
-  user,
+  owner,
   app,
   spec,
   run,
@@ -202,7 +202,7 @@ export default function Block({
         ) : null}
         {status && status.status != "running" ? (
           <Output
-            user={user}
+            owner={owner}
             runId={run.run_id}
             block={block}
             status={status}

--- a/front/components/app/blocks/Browser.jsx
+++ b/front/components/app/blocks/Browser.jsx
@@ -7,7 +7,7 @@ import Link from "next/link";
 import { ChevronDownIcon, ChevronRightIcon } from "@heroicons/react/20/solid";
 
 export default function Browser({
-  user,
+  owner,
   app,
   spec,
   run,
@@ -99,7 +99,7 @@ export default function Browser({
 
   return (
     <Block
-      user={user}
+      owner={owner}
       app={app}
       spec={spec}
       run={run}
@@ -229,7 +229,7 @@ export default function Browser({
             {!isProvidersLoading && !browserlessAPIProvider && !readOnly ? (
               <div className="px-2">
                 <Link
-                  href={`/${user}/providers`}
+                  href={`/${owner.username}/providers`}
                   className={classNames(
                     "inline-flex items-center rounded-md py-1 text-sm font-normal",
                     "border px-3",

--- a/front/components/app/blocks/Chat.jsx
+++ b/front/components/app/blocks/Chat.jsx
@@ -12,7 +12,7 @@ const CodeEditor = dynamic(
 );
 
 export default function Chat({
-  user,
+  owner,
   app,
   spec,
   run,
@@ -95,7 +95,7 @@ export default function Chat({
 
   return (
     <Block
-      user={user}
+      owner={owner}
       app={app}
       spec={spec}
       run={run}
@@ -115,7 +115,7 @@ export default function Chat({
           <div className="mr-2 flex flex-initial flex-row items-center space-x-1 text-sm font-medium leading-8 text-gray-700">
             <div className="mr-1 flex flex-initial">model:</div>
             <ModelPicker
-              user={user}
+              owner={owner}
               readOnly={readOnly}
               model={
                 block.config ? block.config : { provider_id: "", model_id: "" }

--- a/front/components/app/blocks/Code.jsx
+++ b/front/components/app/blocks/Code.jsx
@@ -9,7 +9,7 @@ const CodeEditor = dynamic(
 );
 
 export default function Code({
-  user,
+  owner,
   app,
   spec,
   run,
@@ -31,7 +31,7 @@ export default function Code({
 
   return (
     <Block
-      user={user}
+      owner={owner}
       app={app}
       spec={spec}
       run={run}

--- a/front/components/app/blocks/Curl.jsx
+++ b/front/components/app/blocks/Curl.jsx
@@ -12,7 +12,7 @@ const CodeEditor = dynamic(
 );
 
 export default function Curl({
-  user,
+  owner,
   app,
   spec,
   run,
@@ -75,7 +75,7 @@ export default function Curl({
 
   return (
     <Block
-      user={user}
+      owner={owner}
       app={app}
       spec={spec}
       run={run}

--- a/front/components/app/blocks/Data.jsx
+++ b/front/components/app/blocks/Data.jsx
@@ -2,7 +2,7 @@ import Block from "./Block";
 import DatasetPicker from "@app/components/app/DatasetPicker";
 
 export default function Data({
-  user,
+  owner,
   app,
   spec,
   run,
@@ -25,7 +25,7 @@ export default function Data({
 
   return (
     <Block
-      user={user}
+      owner={owner}
       app={app}
       spec={spec}
       run={run}
@@ -51,7 +51,7 @@ export default function Data({
             </div>
           ) : (
             <DatasetPicker
-              user={user}
+              owner={owner}
               app={app}
               dataset={block.spec.dataset}
               onDatasetUpdate={handleSetDataset}

--- a/front/components/app/blocks/DataSource.jsx
+++ b/front/components/app/blocks/DataSource.jsx
@@ -14,7 +14,7 @@ const CodeEditor = dynamic(
 );
 
 export default function DataSource({
-  user,
+  owner,
   app,
   spec,
   run,
@@ -140,7 +140,7 @@ export default function DataSource({
 
   return (
     <Block
-      user={user}
+      owner={owner}
       app={app}
       spec={spec}
       run={run}
@@ -160,7 +160,7 @@ export default function DataSource({
           <div className="mr-2 flex flex-initial flex-row items-center space-x-1 text-sm font-medium leading-8 text-gray-700">
             <div className="mr-1 flex flex-initial">data source:</div>
             <DataSourcePicker
-              currentUser={user}
+              currentUser={owner.username}
               readOnly={readOnly}
               currentDataSources={block.config.data_sources || []}
               onDataSourcesUpdate={(dataSources) => {

--- a/front/components/app/blocks/Input.jsx
+++ b/front/components/app/blocks/Input.jsx
@@ -3,7 +3,7 @@ import { shallowBlockClone } from "@app/lib/utils";
 import DatasetPicker from "@app/components/app/DatasetPicker";
 
 export default function Input({
-  user,
+  owner,
   app,
   spec,
   run,
@@ -25,7 +25,7 @@ export default function Input({
 
   return (
     <Block
-      user={user}
+      owner={owner}
       app={app}
       spec={spec}
       run={run}
@@ -45,7 +45,7 @@ export default function Input({
             <>
               <div className="flex flex-initial">dataset:</div>
               <DatasetPicker
-                user={user}
+                owner={owner}
                 app={app}
                 dataset={block.config ? block.config.dataset : ""}
                 onDatasetUpdate={handleSetDataset}

--- a/front/components/app/blocks/LLM.jsx
+++ b/front/components/app/blocks/LLM.jsx
@@ -13,7 +13,7 @@ const CodeEditor = dynamic(
 );
 
 export default function LLM({
-  user,
+  owner,
   app,
   spec,
   run,
@@ -122,7 +122,7 @@ export default function LLM({
 
   return (
     <Block
-      user={user}
+      owner={owner}
       app={app}
       spec={spec}
       run={run}
@@ -142,7 +142,7 @@ export default function LLM({
           <div className="mr-2 flex flex-initial flex-row items-center space-x-1 text-sm font-medium leading-8 text-gray-700">
             <div className="mr-1 flex flex-initial">model:</div>
             <ModelPicker
-              user={user}
+              owner={owner}
               readOnly={readOnly}
               model={
                 block.config ? block.config : { provider_id: "", model_id: "" }

--- a/front/components/app/blocks/MapReduce.jsx
+++ b/front/components/app/blocks/MapReduce.jsx
@@ -2,7 +2,7 @@ import Block from "./Block";
 import { classNames, shallowBlockClone } from "@app/lib/utils";
 
 export function Map({
-  user,
+  owner,
   app,
   spec,
   run,
@@ -30,7 +30,7 @@ export function Map({
 
   return (
     <Block
-      user={user}
+      owner={owner}
       app={app}
       spec={spec}
       run={run}
@@ -88,7 +88,7 @@ export function Map({
 }
 
 export function Reduce({
-  user,
+  owner,
   app,
   spec,
   run,
@@ -104,7 +104,7 @@ export function Reduce({
 }) {
   return (
     <Block
-      user={user}
+      owner={owner}
       app={app}
       spec={spec}
       run={run}

--- a/front/components/app/blocks/Output.jsx
+++ b/front/components/app/blocks/Output.jsx
@@ -1,4 +1,3 @@
-import { classNames } from "@app/lib/utils";
 import { useRunBlock } from "@app/lib/swr";
 import {
   ExclamationCircleIcon,
@@ -6,7 +5,7 @@ import {
   ChevronRightIcon,
   ChevronDownIcon,
 } from "@heroicons/react/20/solid";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 const ENABLE_TOP_LEVEL_AUTO_EXPAND = false;
 
@@ -221,9 +220,9 @@ function Execution({ block, trace }) {
   );
 }
 
-export default function Output({ user, block, runId, status, app }) {
+export default function Output({ owner, block, runId, status, app }) {
   let { run, isRunLoading, isRunError } = useRunBlock(
-    user,
+    owner.username,
     app,
     runId,
     block.type,

--- a/front/components/app/blocks/Search.jsx
+++ b/front/components/app/blocks/Search.jsx
@@ -7,7 +7,7 @@ import { filterServiceProviders } from "@app/lib/providers";
 import Link from "next/link";
 
 export default function Search({
-  user,
+  owner,
   app,
   spec,
   run,
@@ -68,7 +68,7 @@ export default function Search({
 
   return (
     <Block
-      user={user}
+      owner={owner}
       app={app}
       spec={spec}
       run={run}
@@ -86,14 +86,14 @@ export default function Search({
       <div className="mx-4 flex w-full flex-col">
         <div className="flex flex-initial flex-row items-center space-x-1 text-sm font-medium leading-8 text-gray-700">
           <div className="flex flex-initial">provider:</div>
-          {/* User has zero search providers */}
+          {/* Owner has zero search providers */}
           {!isProvidersLoading &&
             !readOnly &&
             searchProviders?.length === 0 && (
               <div className="px-2">
                 {searchProviders?.length === 0 && (
                   <Link
-                    href={`/${user}/providers`}
+                    href={`/${owner.username}/providers`}
                     className={classNames(
                       "inline-flex items-center rounded-md py-1 text-sm font-normal",
                       "border px-3",

--- a/front/components/data_source/MainTab.jsx
+++ b/front/components/data_source/MainTab.jsx
@@ -4,11 +4,11 @@ import { Menu } from "@headlessui/react";
 import { DocumentIcon, Cog6ToothIcon } from "@heroicons/react/24/outline";
 import { ChevronDownIcon } from "@heroicons/react/20/solid";
 
-export default function MainTab({ dataSource, currentTab, user, readOnly }) {
+export default function MainTab({ dataSource, currentTab, owner, readOnly }) {
   let tabs = [
     {
       name: "Documents",
-      href: `/${user}/ds/${dataSource.name}`,
+      href: `/${owner.username}/ds/${dataSource.name}`,
       icon: (
         <DocumentIcon
           className="mr-2 mt-0.5 h-4 w-4 flex-shrink-0"
@@ -21,7 +21,7 @@ export default function MainTab({ dataSource, currentTab, user, readOnly }) {
   if (!readOnly) {
     tabs.push({
       name: "Settings",
-      href: `/${user}/ds/${dataSource.name}/settings`,
+      href: `/${owner.username}/ds/${dataSource.name}/settings`,
       icon: (
         <Cog6ToothIcon
           className="mr-2 mt-0.5 h-4 w-4 flex-shrink-0"

--- a/front/components/profile/MainTab.jsx
+++ b/front/components/profile/MainTab.jsx
@@ -1,4 +1,3 @@
-import { useSession } from "next-auth/react";
 import { classNames } from "@app/lib/utils";
 import { Menu } from "@headlessui/react";
 import Link from "next/link";
@@ -9,14 +8,12 @@ import {
   KeyIcon,
 } from "@heroicons/react/24/outline";
 
-export default function MainTab({ currentTab, user, readOnly }) {
-  const { data: session } = useSession();
-
+export default function MainTab({ currentTab, owner, readOnly }) {
   const tabs = readOnly
     ? [
         {
           name: "Apps",
-          href: `/${user}/apps`,
+          href: `/${owner.username}/apps`,
           icon: (
             <CodeBracketIcon
               className="mr-2 mt-0.5 h-4 w-4 flex-shrink-0"
@@ -26,7 +23,7 @@ export default function MainTab({ currentTab, user, readOnly }) {
         },
         {
           name: "DataSources",
-          href: `/${user}/data_sources`,
+          href: `/${owner.username}/data_sources`,
           icon: (
             <MagnifyingGlassCircleIcon
               className="mr-2 mt-0.5 h-4 w-4 flex-shrink-0"
@@ -38,7 +35,7 @@ export default function MainTab({ currentTab, user, readOnly }) {
     : [
         {
           name: "Apps",
-          href: `/${session.user.username}/apps`,
+          href: `/${owner.username}/apps`,
           icon: (
             <CodeBracketIcon
               className="mr-2 mt-0.5 h-4 w-4 flex-shrink-0"
@@ -48,7 +45,7 @@ export default function MainTab({ currentTab, user, readOnly }) {
         },
         {
           name: "DataSources",
-          href: `/${session.user.username}/data_sources`,
+          href: `/${owner.username}/data_sources`,
           icon: (
             <MagnifyingGlassCircleIcon
               className="mr-2 mt-0.5 h-4 w-4 flex-shrink-0"
@@ -58,7 +55,7 @@ export default function MainTab({ currentTab, user, readOnly }) {
         },
         {
           name: "Providers",
-          href: `/${session.user.username}/providers`,
+          href: `/${owner.username}/providers`,
           icon: (
             <LinkIcon
               className="mr-2 mt-0.5 h-4 w-4 flex-shrink-0"
@@ -68,7 +65,7 @@ export default function MainTab({ currentTab, user, readOnly }) {
         },
         {
           name: "API keys",
-          href: `/${session.user.username}/keys`,
+          href: `/${owner.username}/keys`,
           icon: (
             <KeyIcon
               className="mr-2 mt-0.5 h-4 w-4 flex-shrink-0"

--- a/front/pages/[user]/a/[sId]/clone.jsx
+++ b/front/pages/[user]/a/[sId]/clone.jsx
@@ -10,12 +10,7 @@ import { auth_user } from "@app/lib/auth";
 
 const { URL, GA_TRACKING_ID = null } = process.env;
 
-export default function CloneView({
-  authUsername,
-  appUsername,
-  app,
-  ga_tracking_id,
-}) {
+export default function CloneView({ authUser, owner, app, ga_tracking_id }) {
   const [disable, setDisabled] = useState(true);
 
   const [appName, setAppName] = useState(app.name);
@@ -53,7 +48,7 @@ export default function CloneView({
           <MainTab
             app={{ sId: app.sId, name: app.name }}
             currentTab="Specification"
-            user={appUsername}
+            owner={owner}
             readOnly={true}
           />
         </div>
@@ -61,23 +56,23 @@ export default function CloneView({
         <div className="flex flex-1">
           <div className="mx-auto max-w-4xl px-4 sm:px-6 lg:px-8">
             <form
-              action={`/api/apps/${appUsername}/${app.sId}/clone`}
+              action={`/api/apps/${owner.username}/${app.sId}/clone`}
               method="POST"
               className="mt-8 space-y-8 divide-y divide-gray-200"
             >
               <div className="space-y-8 divide-y divide-gray-200">
                 <div>
-                  {appUsername !== authUsername ? (
+                  {owner.username !== authUser.username ? (
                     <div>
                       <h3 className="text-base font-medium leading-6 text-gray-900">
                         Clone{" "}
-                        <span className="ml-1 font-bold">{appUsername}</span>
+                        <span className="ml-1 font-bold">{owner.username}</span>
                         <ChevronRightIcon
                           className="ml-0.5 inline h-5 w-5 pt-0.5 text-gray-500"
                           aria-hidden="true"
                         />
                         <Link
-                          href={`/${appUsername}/a/${app.sId}`}
+                          href={`/${owner.username}/a/${app.sId}`}
                           className="w-22 mr-1 truncate text-base font-bold text-violet-600 sm:w-auto"
                         >
                           {app.name}
@@ -95,7 +90,7 @@ export default function CloneView({
                       <h3 className="text-base font-medium leading-6 text-gray-900">
                         Clone your app{" "}
                         <Link
-                          href={`/${appUsername}/a/${app.sId}`}
+                          href={`/${owner.username}/a/${app.sId}`}
                           className="w-22 mr-1 truncate text-base font-bold text-violet-600 sm:w-auto"
                         >
                           {app.name}
@@ -121,7 +116,7 @@ export default function CloneView({
                       </label>
                       <div className="mt-1 flex rounded-md shadow-sm">
                         <span className="inline-flex items-center rounded-l-md border border-r-0 border-gray-300 bg-gray-50 pl-3 pr-1 text-sm text-gray-500">
-                          {authUsername}
+                          {authUser.username}
                           <ChevronRightIcon
                             className="h-5 w-5 flex-shrink-0 pt-0.5 text-gray-400"
                             aria-hidden="true"
@@ -309,9 +304,10 @@ export async function getServerSideProps(context) {
 
   return {
     props: {
-      authUsername: auth.user().username,
+      session: auth.session(),
+      authUser: auth.user(),
       app: app.app,
-      appUsername: context.query.user,
+      owner: { username: context.query.user },
       ga_tracking_id: GA_TRACKING_ID,
     },
   };

--- a/front/pages/[user]/a/[sId]/clone.jsx
+++ b/front/pages/[user]/a/[sId]/clone.jsx
@@ -1,20 +1,21 @@
 import AppLayout from "@app/components/AppLayout";
 import MainTab from "@app/components/app/MainTab";
 import { Button } from "@app/components/Button";
-import { unstable_getServerSession } from "next-auth/next";
-import { authOptions } from "@app/pages/api/auth/[...nextauth]";
 import { ChevronRightIcon } from "@heroicons/react/20/solid";
 import { classNames } from "@app/lib/utils";
-import { useState, useRef } from "react";
-import { useSession } from "next-auth/react";
+import { useState } from "react";
 import { useEffect } from "react";
 import Link from "next/link";
+import { auth_user } from "@app/lib/auth";
 
 const { URL, GA_TRACKING_ID = null } = process.env;
 
-export default function CloneView({ app, user, ga_tracking_id }) {
-  const { data: session } = useSession();
-
+export default function CloneView({
+  authUsername,
+  appUsername,
+  app,
+  ga_tracking_id,
+}) {
   const [disable, setDisabled] = useState(true);
 
   const [appName, setAppName] = useState(app.name);
@@ -52,7 +53,7 @@ export default function CloneView({ app, user, ga_tracking_id }) {
           <MainTab
             app={{ sId: app.sId, name: app.name }}
             currentTab="Specification"
-            user={user}
+            user={appUsername}
             readOnly={true}
           />
         </div>
@@ -60,22 +61,23 @@ export default function CloneView({ app, user, ga_tracking_id }) {
         <div className="flex flex-1">
           <div className="mx-auto max-w-4xl px-4 sm:px-6 lg:px-8">
             <form
-              action={`/api/apps/${user}/${app.sId}/clone`}
+              action={`/api/apps/${appUsername}/${app.sId}/clone`}
               method="POST"
               className="mt-8 space-y-8 divide-y divide-gray-200"
             >
               <div className="space-y-8 divide-y divide-gray-200">
                 <div>
-                  {user !== session.user.username ? (
+                  {appUsername !== authUsername ? (
                     <div>
                       <h3 className="text-base font-medium leading-6 text-gray-900">
-                        Clone <span className="ml-1 font-bold">{user}</span>
+                        Clone{" "}
+                        <span className="ml-1 font-bold">{appUsername}</span>
                         <ChevronRightIcon
                           className="ml-0.5 inline h-5 w-5 pt-0.5 text-gray-500"
                           aria-hidden="true"
                         />
                         <Link
-                          href={`/${user}/a/${app.sId}`}
+                          href={`/${appUsername}/a/${app.sId}`}
                           className="w-22 mr-1 truncate text-base font-bold text-violet-600 sm:w-auto"
                         >
                           {app.name}
@@ -93,7 +95,7 @@ export default function CloneView({ app, user, ga_tracking_id }) {
                       <h3 className="text-base font-medium leading-6 text-gray-900">
                         Clone your app{" "}
                         <Link
-                          href={`/${user}/a/${app.sId}`}
+                          href={`/${appUsername}/a/${app.sId}`}
                           className="w-22 mr-1 truncate text-base font-bold text-violet-600 sm:w-auto"
                         >
                           {app.name}
@@ -119,7 +121,7 @@ export default function CloneView({ app, user, ga_tracking_id }) {
                       </label>
                       <div className="mt-1 flex rounded-md shadow-sm">
                         <span className="inline-flex items-center rounded-l-md border border-r-0 border-gray-300 bg-gray-50 pl-3 pr-1 text-sm text-gray-500">
-                          {session.user.username}
+                          {authUsername}
                           <ChevronRightIcon
                             className="h-5 w-5 flex-shrink-0 pt-0.5 text-gray-400"
                             aria-hidden="true"
@@ -274,13 +276,13 @@ export default function CloneView({ app, user, ga_tracking_id }) {
 }
 
 export async function getServerSideProps(context) {
-  const session = await unstable_getServerSession(
-    context.req,
-    context.res,
-    authOptions
-  );
+  let authRes = await auth_user(context.req, context.res);
+  if (authRes.isErr()) {
+    return { noFound: true };
+  }
+  let auth = authRes.value();
 
-  if (!session) {
+  if (auth.isAnonymous()) {
     return {
       redirect: {
         destination: `/${context.query.user}/a/${context.query.sId}`,
@@ -300,18 +302,16 @@ export async function getServerSideProps(context) {
   ]);
 
   if (appRes.status === 404) {
-    return {
-      notFound: true,
-    };
+    return { notFound: true };
   }
 
   const [app] = await Promise.all([appRes.json()]);
 
   return {
     props: {
-      session,
+      authUsername: auth.user().username,
       app: app.app,
-      user: context.query.user,
+      appUsername: context.query.user,
       ga_tracking_id: GA_TRACKING_ID,
     },
   };

--- a/front/pages/[user]/a/[sId]/settings.jsx
+++ b/front/pages/[user]/a/[sId]/settings.jsx
@@ -1,21 +1,17 @@
 import AppLayout from "@app/components/AppLayout";
 import MainTab from "@app/components/app/MainTab";
 import { Button } from "@app/components/Button";
-import { unstable_getServerSession } from "next-auth/next";
-import { authOptions } from "@app/pages/api/auth/[...nextauth]";
 import { ChevronRightIcon } from "@heroicons/react/24/outline";
 import { classNames } from "@app/lib/utils";
-import { useState, useRef } from "react";
-import { useSession } from "next-auth/react";
+import { useState } from "react";
 import { useEffect } from "react";
 import Link from "next/link";
 import { useRouter } from "next/router";
+import { auth_user } from "@app/lib/auth";
 
 const { URL, GA_TRACKING_ID = null } = process.env;
 
-export default function SettingsView({ app, user, ga_tracking_id }) {
-  const { data: session } = useSession();
-
+export default function SettingsView({ authUser, owner, app, ga_tracking_id }) {
   const [disable, setDisabled] = useState(true);
 
   const [appName, setAppName] = useState(app.name);
@@ -43,11 +39,11 @@ export default function SettingsView({ app, user, ga_tracking_id }) {
 
   const handleDelete = async () => {
     if (window.confirm("Are you sure you want to delete this app?")) {
-      let res = await fetch(`/api/apps/${user}/${app.sId}`, {
+      let res = await fetch(`/api/apps/${owner.username}/${app.sId}`, {
         method: "DELETE",
       });
       if (res.ok) {
-        router.push(`/${session.user.username}/`);
+        router.push(`/${owner.username}/`);
       }
       return true;
     } else {
@@ -69,7 +65,7 @@ export default function SettingsView({ app, user, ga_tracking_id }) {
           <MainTab
             app={{ sId: app.sId, name: app.name }}
             currentTab="Settings"
-            user={user}
+            owner={owner}
             readOnly={false}
           />
         </div>
@@ -78,7 +74,7 @@ export default function SettingsView({ app, user, ga_tracking_id }) {
           <div className="flex flex-1">
             <div className="w-full max-w-5xl px-4 sm:px-6 lg:px-8">
               <form
-                action={`/api/apps/${session.user.username}/${app.sId}`}
+                action={`/api/apps/${owner.username}/${app.sId}`}
                 method="POST"
                 className="mt-8 space-y-8 divide-y divide-gray-200"
               >
@@ -94,7 +90,7 @@ export default function SettingsView({ app, user, ga_tracking_id }) {
                         </label>
                         <div className="mt-1 flex rounded-md shadow-sm">
                           <span className="inline-flex items-center rounded-l-md border border-r-0 border-gray-300 bg-gray-50 pl-3 pr-1 text-sm text-gray-500">
-                            {session.user.username}
+                            {owner.username}
                             <ChevronRightIcon
                               className="h-5 w-5 flex-shrink-0 pt-0.5 text-gray-400"
                               aria-hidden="true"
@@ -243,7 +239,7 @@ export default function SettingsView({ app, user, ga_tracking_id }) {
                   </Button>
                   <div className="flex-1"></div>
                   <div className="flex">
-                    <Link href={`/${user}/a/${app.sId}/clone`}>
+                    <Link href={`/${owner.username}/a/${app.sId}/clone`}>
                       <Button>Clone</Button>
                     </Link>
                   </div>
@@ -261,13 +257,14 @@ export default function SettingsView({ app, user, ga_tracking_id }) {
 }
 
 export async function getServerSideProps(context) {
-  const session = await unstable_getServerSession(
-    context.req,
-    context.res,
-    authOptions
-  );
+  let authRes = await auth_user(context.req, context.res);
+  if (authRes.isErr()) {
+    return { noFound: true };
+  }
+  let auth = authRes.value();
 
-  let readOnly = !session || context.query.user !== session.user.username;
+  let readOnly =
+    auth.isAnonymous() || context.query.user !== auth.user().username;
 
   if (readOnly) {
     return {
@@ -289,18 +286,17 @@ export async function getServerSideProps(context) {
   ]);
 
   if (appRes.status === 404) {
-    return {
-      notFound: true,
-    };
+    return { notFound: true };
   }
 
   const [app] = await Promise.all([appRes.json()]);
 
   return {
     props: {
-      session,
+      session: auth.session(),
+      authUser: auth.isAnonymous() ? null : auth.user(),
+      owner: { username: context.query.user },
       app: app.app,
-      user: context.query.user,
       ga_tracking_id: GA_TRACKING_ID,
     },
   };

--- a/front/types/user.ts
+++ b/front/types/user.ts
@@ -1,0 +1,8 @@
+export type UserType = {
+  id: number;
+  provider: string;
+  providerId: string;
+  username: string;
+  email: string;
+  name: string;
+};


### PR DESCRIPTION
This PR cleans up the mix and match usage of `session.user.username` (who is authenticated) a ambiguous `user` parameter that was passed around (that was really the username of the owner for the resource).

It removes all calls to `unstable_getServerSession` and replace them by a call to our new `auth_user`.

All pages are now standardly passed:
-  a `authUser: UserType` which is the authenticated user. It replaces `useSession` but its usage has been removed from ~everywhere.
- a `owner : { username: string }` which is the owner of the resource being operated on (an app, a dataSource). It will be replaced by a workspace eventually and this refactor will help that transition.

All pages have been tested both logged in, signed out, and logged in as a different owner of the resource being viewed.