### PR TITLE
`while` block

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,8 @@
       "./front",
       "./docs",
       "./xp1",
+    ],
+    "rust-analyzer.linkedProjects": [
+      "./core/Cargo.toml"
     ]
   }

--- a/core/src/blocks/block.rs
+++ b/core/src/blocks/block.rs
@@ -1,6 +1,6 @@
 use crate::blocks::{
     browser::Browser, chat::Chat, code::Code, curl::Curl, data::Data, data_source::DataSource,
-    input::Input, llm::LLM, map::Map, reduce::Reduce, search::Search,
+    end::End, input::Input, llm::LLM, map::Map, r#while::While, reduce::Reduce, search::Search,
 };
 use crate::project::Project;
 use crate::run::{Credentials, RunConfig};
@@ -68,6 +68,8 @@ pub enum BlockType {
     Search,
     Curl,
     Browser,
+    While,
+    End,
 }
 
 impl ToString for BlockType {
@@ -84,6 +86,8 @@ impl ToString for BlockType {
             BlockType::Search => String::from("search"),
             BlockType::Curl => String::from("curl"),
             BlockType::Browser => String::from("browser"),
+            BlockType::While => String::from("while"),
+            BlockType::End => String::from("end"),
         }
     }
 }
@@ -103,6 +107,8 @@ impl FromStr for BlockType {
             "search" => Ok(BlockType::Search),
             "curl" => Ok(BlockType::Curl),
             "browser" => Ok(BlockType::Browser),
+            "while" => Ok(BlockType::While),
+            "end" => Ok(BlockType::End),
             _ => Err(ParseError::with_message("Unknown BlockType"))?,
         }
     }
@@ -175,6 +181,8 @@ pub fn parse_block(t: BlockType, block_pair: Pair<Rule>) -> Result<Box<dyn Block
         BlockType::Search => Ok(Box::new(Search::parse(block_pair)?)),
         BlockType::Curl => Ok(Box::new(Curl::parse(block_pair)?)),
         BlockType::Browser => Ok(Box::new(Browser::parse(block_pair)?)),
+        BlockType::While => Ok(Box::new(While::parse(block_pair)?)),
+        BlockType::End => Ok(Box::new(End::parse(block_pair)?)),
     }
 }
 

--- a/core/src/blocks/end.rs
+++ b/core/src/blocks/end.rs
@@ -1,0 +1,61 @@
+use crate::blocks::block::{parse_pair, Block, BlockType, Env};
+use crate::Rule;
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use pest::iterators::Pair;
+use serde_json::Value;
+use tokio::sync::mpsc::UnboundedSender;
+
+#[derive(Clone)]
+pub struct End {}
+
+impl End {
+    pub fn parse(block_pair: Pair<Rule>) -> Result<Self> {
+        for pair in block_pair.into_inner() {
+            match pair.as_rule() {
+                Rule::pair => {
+                    let (key, _) = parse_pair(pair)?;
+                    match key.as_str() {
+                        _ => Err(anyhow!("Unexpected `{}` in `end` block", key))?,
+                    }
+                }
+                Rule::expected => Err(anyhow!("`expected` is not yet supported in `end` block"))?,
+                _ => unreachable!(),
+            }
+        }
+
+        Ok(End {})
+    }
+}
+
+#[async_trait]
+impl Block for End {
+    fn block_type(&self) -> BlockType {
+        BlockType::End
+    }
+
+    fn inner_hash(&self) -> String {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update("end".as_bytes());
+        format!("{}", hasher.finalize().to_hex())
+    }
+
+    async fn execute(
+        &self,
+        _name: &str,
+        _env: &Env,
+        _event_sender: Option<UnboundedSender<Value>>,
+    ) -> Result<Value> {
+        // No-op the block outputs within the while|if/end are coallesced, the output of end is
+        // ignored and not stored in the environment as it has the same name as the while|if block.
+        Ok(Value::Null)
+    }
+
+    fn clone_box(&self) -> Box<dyn Block + Sync + Send> {
+        Box::new(self.clone())
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}

--- a/core/src/blocks/while.rs
+++ b/core/src/blocks/while.rs
@@ -1,0 +1,127 @@
+use crate::blocks::block::{parse_pair, Block, BlockType, Env};
+use crate::Rule;
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use js_sandbox::Script;
+use pest::iterators::Pair;
+use serde_json::Value;
+use tokio::sync::mpsc::UnboundedSender;
+
+#[derive(Clone)]
+pub struct While {
+    condition_code: String,
+    max_iterations: usize,
+}
+
+impl While {
+    pub fn parse(block_pair: Pair<Rule>) -> Result<Self> {
+        let mut condition_code: Option<String> = None;
+        let mut max_iterations: Option<usize> = None;
+
+        for pair in block_pair.into_inner() {
+            match pair.as_rule() {
+                Rule::pair => {
+                    let (key, value) = parse_pair(pair)?;
+                    match key.as_str() {
+                        "condition_code" => condition_code = Some(value),
+                        "max_iterations" => match value.parse::<usize>() {
+                            Ok(n) => max_iterations = Some(n),
+                            Err(_) => Err(anyhow!(
+                                "Invalid `max_iterations` in `while` block, \
+                                  expecting unsigned integer"
+                            ))?,
+                        },
+                        _ => Err(anyhow!("Unexpected `{}` in `while` block", key))?,
+                    }
+                }
+                Rule::expected => Err(anyhow!("`expected` is not yet supported in `while` block"))?,
+                _ => unreachable!(),
+            }
+        }
+
+        if !condition_code.is_some() {
+            Err(anyhow!(
+                "Missing required `condition_code` in `while` block"
+            ))?;
+        }
+        if !max_iterations.is_some() {
+            Err(anyhow!(
+                "Missing required `max_iterations` in `while` block"
+            ))?;
+        }
+
+        if max_iterations.unwrap() >= 32 {
+            Err(anyhow!("`max_iterations` cannot be greater than 32"))?;
+        }
+
+        Ok(While {
+            condition_code: condition_code.unwrap(),
+            max_iterations: max_iterations.unwrap(),
+        })
+    }
+}
+
+#[async_trait]
+impl Block for While {
+    fn block_type(&self) -> BlockType {
+        BlockType::While
+    }
+
+    fn inner_hash(&self) -> String {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update("while".as_bytes());
+        hasher.update(self.condition_code.as_bytes());
+        hasher.update(self.max_iterations.to_string().as_bytes());
+        format!("{}", hasher.finalize().to_hex())
+    }
+
+    async fn execute(
+        &self,
+        _name: &str,
+        env: &Env,
+        _event_sender: Option<UnboundedSender<Value>>,
+    ) -> Result<Value> {
+        let e = env.clone();
+
+        // Directly return false if we have reached max_iterations
+        match env.map.as_ref() {
+            None => unreachable!(),
+            Some(w) => {
+                if w.iteration >= self.max_iterations {
+                    return Ok(Value::Bool(false));
+                }
+            }
+        }
+
+        // replace <DUST_TRIPLE_BACKTICKS> with ```
+        let condition_code = self
+            .condition_code
+            .replace("<DUST_TRIPLE_BACKTICKS>", "```");
+
+        let condition_value: Value = match tokio::task::spawn_blocking(move || {
+            let mut script = Script::from_string(condition_code.as_str())?
+                .with_timeout(std::time::Duration::from_secs(10));
+            script.call("_fun", (&e,))
+        })
+        .await?
+        {
+            Ok(v) => v,
+            Err(e) => Err(anyhow!("Error in `condition_code`: {}", e))?,
+        };
+
+        match condition_value {
+            Value::Bool(b) => Ok(Value::Bool(b)),
+            _ => Err(anyhow!(
+                "Invalid return value from `condition_code`, expecting boolean"
+            ))?,
+        }
+    }
+
+    fn clone_box(&self) -> Box<dyn Block + Sync + Send> {
+        Box::new(self.clone())
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -43,9 +43,11 @@ pub mod blocks {
     pub mod curl;
     pub mod data;
     pub mod data_source;
+    pub mod end;
     pub mod input;
     pub mod llm;
     pub mod map;
     pub mod reduce;
     pub mod search;
+    pub mod r#while;
 }

--- a/core/src/run.rs
+++ b/core/src/run.rs
@@ -55,6 +55,8 @@ impl RunConfig {
             BlockType::Search => 8,
             BlockType::Curl => 8,
             BlockType::Browser => 8,
+            BlockType::While => 64,
+            BlockType::End => 64,
         }
     }
 }

--- a/front/components/app/NewBlock.jsx
+++ b/front/components/app/NewBlock.jsx
@@ -73,6 +73,12 @@ export default function NewBlock({
       description:
         "Map over an array and execute a sequence of blocks in parallel.",
     },
+    {
+      type: "while_end",
+      typeNames: ["while", "end"],
+      name: "While End",
+      description: "Loop over a set of blocks until a condition is met.",
+    },
   ];
   if (!containsInput) {
     blocks.splice(0, 0, {

--- a/front/components/app/SpecRunView.jsx
+++ b/front/components/app/SpecRunView.jsx
@@ -9,6 +9,7 @@ import Search from "./blocks/Search";
 import Curl from "./blocks/Curl";
 import Browser from "./blocks/Browser";
 import { Map, Reduce } from "./blocks/MapReduce";
+import { While, End } from "./blocks/WhileEnd";
 
 export default function SpecRunView({
   owner,
@@ -218,6 +219,48 @@ export default function SpecRunView({
                   onBlockNew={(blockType) => handleNewBlock(idx, blockType)}
                 />
               );
+
+            case "while":
+              return (
+                <While
+                  key={idx}
+                  block={block}
+                  owner={owner}
+                  app={app}
+                  spec={spec}
+                  run={run}
+                  status={status}
+                  running={runRequested || run?.status.run == "running"}
+                  readOnly={readOnly}
+                  onBlockUpdate={(block) => handleSetBlock(idx, block)}
+                  onBlockDelete={() => handleDeleteBlock(idx)}
+                  onBlockUp={() => handleMoveBlockUp(idx)}
+                  onBlockDown={() => handleMoveBlockDown(idx)}
+                  onBlockNew={(blockType) => handleNewBlock(idx, blockType)}
+                />
+              );
+              break;
+
+            case "end":
+              return (
+                <End
+                  key={idx}
+                  block={block}
+                  owner={owner}
+                  app={app}
+                  spec={spec}
+                  run={run}
+                  status={status}
+                  running={runRequested || run?.status.run == "running"}
+                  readOnly={readOnly}
+                  onBlockUpdate={(block) => handleSetBlock(idx, block)}
+                  onBlockDelete={() => handleDeleteBlock(idx)}
+                  onBlockUp={() => handleMoveBlockUp(idx)}
+                  onBlockDown={() => handleMoveBlockDown(idx)}
+                  onBlockNew={(blockType) => handleNewBlock(idx, blockType)}
+                />
+              );
+
             case "search":
               return (
                 <Search

--- a/front/components/app/blocks/Block.jsx
+++ b/front/components/app/blocks/Block.jsx
@@ -169,7 +169,7 @@ export default function Block({
       <div className={classNames(block.indent == 1 ? "ml-8" : "ml-0", "py-1")}>
         {status &&
         status.status == "running" &&
-        !["map", "reduce"].includes(block.type) ? (
+        !["map", "reduce", "end"].includes(block.type) ? (
           <div className="flex flex-row items-center text-sm text-gray-400">
             <div className="mr-2 ml-2">
               <Spinner />
@@ -179,23 +179,9 @@ export default function Block({
         ) : running && !(status && status.status != "running") ? (
           <div className="flex flex-row items-center text-sm text-gray-400">
             <div role="status">
-              <svg
-                aria-hidden="true"
-                className="ml-2 mr-2 h-3 w-3 animate-spin fill-violet-600 text-gray-200 dark:text-gray-300"
-                viewBox="0 0 100 101"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908ZM9.08144 50.5908C9.08144 73.1895 27.4013 91.5094 50 91.5094C72.5987 91.5094 90.9186 73.1895 90.9186 50.5908C90.9186 27.9921 72.5987 9.67226 50 9.67226C27.4013 9.67226 9.08144 27.9921 9.08144 50.5908Z"
-                  fill="currentColor"
-                />
-                <path
-                  d="M93.9676 39.0409C96.393 38.4038 97.8624 35.9116 97.0079 33.5539C95.2932 28.8227 92.871 24.3692 89.8167 20.348C85.8452 15.1192 80.8826 10.7238 75.2124 7.41289C69.5422 4.10194 63.2754 1.94025 56.7698 1.05124C51.7666 0.367541 46.6976 0.446843 41.7345 1.27873C39.2613 1.69328 37.813 4.19778 38.4501 6.62326C39.0873 9.04874 41.5694 10.4717 44.0505 10.1071C47.8511 9.54855 51.7191 9.52689 55.5402 10.0491C60.8642 10.7766 65.9928 12.5457 70.6331 15.2552C75.2735 17.9648 79.3347 21.5619 82.5849 25.841C84.9175 28.9121 86.7997 32.2913 88.1811 35.8758C89.083 38.2158 91.5421 39.6781 93.9676 39.0409Z"
-                  fill="currentFill"
-                />
-              </svg>
-              <span className="sr-only">Running...</span>
+              <div className="mr-2 ml-2">
+                <Spinner />
+              </div>
             </div>
             {` 0 successes 0 errors`}
           </div>

--- a/front/components/app/blocks/Output.jsx
+++ b/front/components/app/blocks/Output.jsx
@@ -247,7 +247,7 @@ export default function Output({ owner, block, runId, status, app }) {
     run.traces.length > 0 &&
     run.traces[0].length > 0 &&
     run.traces[0][1].length > 0 &&
-    !["reduce"].includes(block.type)
+    !["reduce", "end"].includes(block.type)
   ) {
     let traces = run.traces[0][1];
 

--- a/front/components/app/blocks/Output.jsx
+++ b/front/components/app/blocks/Output.jsx
@@ -117,12 +117,22 @@ function ValueViewer({ block, value, k, topLevel }) {
           ) : null}
         </>
       ) : (
-        <div className="ml-4 flex text-sm text-gray-600">
+        <div className="ml-2 flex text-sm text-gray-600">
           {k != null ? (
-            <span className="mr-1 font-bold text-gray-700">{k}:</span>
+            <span className="ml-2 mr-1 font-bold text-gray-700">{k}:</span>
           ) : null}
           <span className="whitespace-pre-wrap">
-            {typeof value === "string" ? <StringViewer value={value} /> : value}
+            {typeof value === "string" ? (
+              <StringViewer value={value} />
+            ) : typeof value === "boolean" ? (
+              value ? (
+                <span className="italic">true</span>
+              ) : (
+                <span className="italic">false</span>
+              )
+            ) : (
+              value
+            )}
           </span>
         </div>
       )}

--- a/front/components/app/blocks/Output.jsx
+++ b/front/components/app/blocks/Output.jsx
@@ -202,7 +202,7 @@ function Error({ error }) {
   );
 }
 
-function Execution({ block, trace }) {
+export function Execution({ block, trace }) {
   return (
     <div className="flex flex-auto flex-col overflow-hidden">
       {trace.map((t, i) => {

--- a/front/components/app/blocks/WhileEnd.jsx
+++ b/front/components/app/blocks/WhileEnd.jsx
@@ -1,0 +1,140 @@
+import Block from "./Block";
+import { classNames, shallowBlockClone } from "@app/lib/utils";
+import dynamic from "next/dynamic";
+import "@uiw/react-textarea-code-editor/dist.css";
+
+const CodeEditor = dynamic(
+  () => import("@uiw/react-textarea-code-editor").then((mod) => mod.default),
+  { ssr: false }
+);
+
+export function While({
+  owner,
+  app,
+  spec,
+  run,
+  block,
+  status,
+  running,
+  readOnly,
+  onBlockUpdate,
+  onBlockDelete,
+  onBlockUp,
+  onBlockDown,
+  onBlockNew,
+}) {
+  const handleConditionCodeChange = (conditionCode) => {
+    let b = shallowBlockClone(block);
+    b.spec.condition_code = conditionCode;
+    onBlockUpdate(b);
+  };
+
+  const handleMaxIterationsChange = (maxIterations) => {
+    let b = shallowBlockClone(block);
+    b.spec.max_iterations = maxIterations;
+    onBlockUpdate(b);
+  };
+
+  return (
+    <Block
+      owner={owner}
+      app={app}
+      spec={spec}
+      run={run}
+      block={block}
+      status={status}
+      running={running}
+      readOnly={readOnly}
+      onBlockUpdate={onBlockUpdate}
+      onBlockDelete={onBlockDelete}
+      onBlockUp={onBlockUp}
+      onBlockDown={onBlockDown}
+      onBlockNew={onBlockNew}
+    >
+      <div className="mx-4 flex w-full flex-col">
+        <div className="flex flex-col lg:flex-row lg:space-x-4">
+          <div className="flex flex-initial flex-row items-center space-x-1 text-sm font-medium leading-8 text-gray-700">
+            <div className="flex flex-initial">max_iterations:</div>
+            <div className="flex flex-initial font-normal">
+              <input
+                type="text"
+                className={classNames(
+                  "block w-8 flex-1 rounded-md px-1 py-1 text-sm font-normal",
+                  readOnly
+                    ? "border-white ring-0 focus:border-white focus:ring-0"
+                    : "border-white focus:border-gray-300 focus:ring-0"
+                )}
+                spellCheck={false}
+                readOnly={readOnly}
+                value={block.spec.max_iterations}
+                onChange={(e) => handleMaxIterationsChange(e.target.value)}
+              />
+            </div>
+          </div>
+        </div>
+        <div className="flex flex-col space-y-1 text-sm font-medium leading-8 text-gray-700">
+          <div className="flex flex-initial items-center">condition :</div>
+          <div className="flex w-full font-normal">
+            <div className="w-full leading-4">
+              <div
+                className={classNames(
+                  "border bg-slate-100",
+                  false ? "border-red-500" : "border-slate-100"
+                )}
+              >
+                <CodeEditor
+                  readOnly={readOnly}
+                  value={block.spec.condition_code}
+                  language="js"
+                  placeholder=""
+                  onChange={(e) => handleConditionCodeChange(e.target.value)}
+                  padding={15}
+                  style={{
+                    fontSize: 12,
+                    fontFamily:
+                      "ui-monospace, SFMono-Regular, SF Mono, Consolas, Liberation Mono, Menlo, monospace",
+                    backgroundColor: "rgb(241 245 249)",
+                  }}
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Block>
+  );
+}
+
+export function End({
+  owner,
+  app,
+  spec,
+  run,
+  block,
+  status,
+  running,
+  readOnly,
+  onBlockUpdate,
+  onBlockDelete,
+  onBlockUp,
+  onBlockDown,
+  onBlockNew,
+}) {
+  return (
+    <Block
+      owner={owner}
+      app={app}
+      spec={spec}
+      run={run}
+      block={block}
+      status={status}
+      running={running}
+      readOnly={readOnly}
+      onBlockUpdate={onBlockUpdate}
+      onBlockDelete={onBlockDelete}
+      onBlockUp={onBlockUp}
+      onBlockDown={onBlockDown}
+      onBlockNew={onBlockNew}
+    ></Block>
+  );
+}

--- a/front/pages/[user]/a/[sId]/execute/index.jsx
+++ b/front/pages/[user]/a/[sId]/execute/index.jsx
@@ -1,8 +1,3 @@
-import {
-  ArrayViewer,
-  ObjectViewer,
-  StringViewer,
-} from "@app/components/app/blocks/Output";
 import MainTab from "@app/components/app/MainTab";
 import AppLayout from "@app/components/AppLayout";
 import { ActionButton } from "@app/components/Button";
@@ -27,6 +22,7 @@ import { useEffect, useState } from "react";
 import TextareaAutosize from "react-textarea-autosize";
 import { SSE } from "sse.js";
 import { auth_user } from "@app/lib/auth";
+import { Execution } from "@app/components/app/blocks/Output";
 
 const { URL, GA_TRACKING_ID = null } = process.env;
 
@@ -35,28 +31,34 @@ const CodeEditor = dynamic(
   { ssr: false }
 );
 
-function preProcessOutput(output) {
-  if (Array.isArray(output) && output.length === 1) {
-    return preProcessOutput(output[0]);
+function getTraceFromEvents(data) {
+  const events = Array.isArray(data) ? data : [data];
+
+  let traces = events
+    .map((o) => {
+      const t = o?.content?.execution;
+      if (t) {
+        return t[0];
+      }
+      return null;
+    })
+    .filter((x) => x !== null);
+
+  traces = traces.map((trace) =>
+    Array.isArray(trace) && trace.length === 1 ? trace[0] : trace
+  );
+
+  if (traces.length === 1 && Array.isArray(traces[0])) {
+    traces = traces[0];
   }
-  if (Array.isArray(output)) {
-    return output.map(preProcessOutput);
-  }
-  if (output.value && output.error === null) {
-    return preProcessOutput(output.value);
-  }
-  if (output.error) {
-    return { error: output.error };
-  }
-  if (
-    Object.keys(output).length === 2 &&
-    output.value === null &&
-    output.error === null
-  ) {
+
+  traces = traces.filter((t) => t.value !== null || t.error !== null);
+
+  if (traces.length === 0) {
     return null;
   }
 
-  return output;
+  return traces;
 }
 
 function ExecuteOutputLine({
@@ -67,30 +69,16 @@ function ExecuteOutputLine({
   expanded,
   onToggleExpand,
 }) {
-  let preprocessedOutput = outputForBlock
-    ? preProcessOutput(outputForBlock.content.execution[0])
-    : null;
+  let traces = outputForBlock ? getTraceFromEvents(outputForBlock) : null;
 
   return (
     <div className="leading-none">
       <button
-        disabled={!preprocessedOutput}
+        disabled={!traces}
         onClick={() => onToggleExpand()}
-        className={classNames(
-          "border-none",
-          preprocessedOutput ? null : "text-gray-400"
-        )}
+        className={classNames("border-none", traces ? null : "text-gray-400")}
       >
         <div className="flex flex-row items-center">
-          {lastEventForBlock.content.status === "running" ? (
-            <div className="mr-1">
-              <Spinner />
-            </div>
-          ) : lastEventForBlock.content.status === "errored" ? (
-            <ExclamationCircleIcon className="h-4 w-4 text-red-500" />
-          ) : (
-            <CheckCircleIcon className="min-w-4 h-4 w-4 text-emerald-300" />
-          )}
           {!expanded ? (
             <ChevronRightIcon className="h-4 w-4 text-gray-400" />
           ) : (
@@ -102,17 +90,20 @@ function ExecuteOutputLine({
             </span>
             <span className="ml-1 font-bold text-gray-700">{blockName}</span>
           </div>
+          <div>
+            {lastEventForBlock.content.status === "running" ? (
+              <div className="ml-1">
+                <Spinner />
+              </div>
+            ) : lastEventForBlock.content.status === "errored" ? (
+              <ExclamationCircleIcon className="ml-1 h-4 w-4 text-red-500" />
+            ) : null}
+          </div>
         </div>
       </button>
       {expanded ? (
         <div className="ml-8 mb-2 flex text-sm text-gray-600">
-          {Array.isArray(preprocessedOutput) ? (
-            <ArrayViewer value={preprocessedOutput} />
-          ) : typeof preprocessedOutput == "string" ? (
-            <StringViewer value={preprocessedOutput} />
-          ) : typeof outputForBlock.content.execution == "object" ? (
-            <ObjectViewer value={preprocessedOutput} />
-          ) : null}
+          <Execution block={null} trace={traces} />
         </div>
       ) : null}
     </div>
@@ -390,12 +381,10 @@ export default function ExecuteView({
               const blockTypeName = `${blockType}-${blockName}`;
 
               if (parsedEvent.type === "block_status") {
-                const lastBlock = blockOrder[blockOrder.length - 1];
-                if (
-                  !lastBlock ||
-                  lastBlock.name !== blockName ||
-                  lastBlock.type !== blockType
-                ) {
+                const existingBlock = blockOrder.find(
+                  ({ name, type }) => name === blockName && type === blockType
+                );
+                if (!existingBlock) {
                   blockOrder.push({ name: blockName, type: blockType });
                 }
                 lastEventByBlockTypeName[blockTypeName] = parsedEvent;
@@ -405,7 +394,15 @@ export default function ExecuteView({
                   setIsErrored(true);
                 }
               } else {
-                outputByBlockTypeName[blockTypeName] = parsedEvent;
+                if (outputByBlockTypeName[blockTypeName]) {
+                  if (!Array.isArray(outputByBlockTypeName[blockTypeName])) {
+                    const existingOutput = outputByBlockTypeName[blockTypeName];
+                    outputByBlockTypeName[blockTypeName] = [existingOutput];
+                  }
+                } else {
+                  outputByBlockTypeName[blockTypeName] = [];
+                }
+                outputByBlockTypeName[blockTypeName].push(parsedEvent);
               }
               return {
                 blockOrder,
@@ -533,10 +530,10 @@ export default function ExecuteView({
                   Output
                 </h3>
                 <ExecuteFinalOutput
-                  value={preProcessOutput(
+                  value={getTraceFromEvents(
                     executionLogs.outputByBlockTypeName[
                       finalOutputBlockTypeName
-                    ].content.execution[0]
+                    ]
                   )}
                   errored={isErrored}
                 />

--- a/front/pages/[user]/a/[sId]/execute/index.jsx
+++ b/front/pages/[user]/a/[sId]/execute/index.jsx
@@ -307,7 +307,7 @@ export default function ExecuteView({
       setIsRunning(false);
       const candidates = executionLogs.blockOrder.filter(
         // Don't treat reduce blocks as output as they don't have output
-        ({ type: blockType }) => blockType !== "reduce"
+        ({ type: blockType }) => !["reduce", "end"].includes(blockType)
       );
       const lastBlock = candidates[candidates.length - 1];
 

--- a/front/pages/api/apps/[user]/[sId]/runs/[runId]/index.ts
+++ b/front/pages/api/apps/[user]/[sId]/runs/[runId]/index.ts
@@ -132,11 +132,18 @@ async function handler(
               spec[i].spec.instructions = restoreTripleBackticks(
                 spec[i].spec.instructions
               );
-              if (spec[i].spec.messages_code) {
-                spec[i].spec.messages_code = restoreTripleBackticks(
-                  spec[i].spec.messages_code
-                );
-              }
+            }
+            if (spec[i].spec.messages_code) {
+              spec[i].spec.messages_code = restoreTripleBackticks(
+                spec[i].spec.messages_code
+              );
+            }
+          }
+          if (spec[i].type === "while") {
+            if (spec[i].spec.condition_code) {
+              spec[i].spec.condition_code = restoreTripleBackticks(
+                spec[i].spec.condition_code
+              );
             }
           }
           if (spec[i].type === "data_source") {

--- a/front/types/run.ts
+++ b/front/types/run.ts
@@ -7,6 +7,8 @@ export type BlockType =
   | "chat"
   | "map"
   | "reduce"
+  | "while"
+  | "end"
   | "search"
   | "curl"
   | "browser";


### PR DESCRIPTION
In `core`, introduces a `while` and `end` block. The `while` block takes `condition_code` string that represents code to be executed to decide whether to continue looping as well as a `max_iteration` unsigned argument capping the number of iterations.

The overall logic is the following, when passing through a `while` block for the first time, record that we're in a loop (index of the `while` block to loop back, current iteration and an array of "skips", booleans associated with each input stream keeping track of whether the loop is still active or not for that input stream of execution. Once all are skips we exit at the `end` block instead of looping back to the while block.

There's a lot of meddling with both the `env.state` for the blocks in the `while` / `end` block and the traces.
- For the `env.state` we store an array of value that grows at each iteration instead of the value of the block. 
- For the traces we emit a trace event with the last execution state (block execution value and error are None if the input was skipped) and we append the last execution trace to the current run traces (removing the block execution for which we had a skip so that at the end we have one block execution along the map_idx dimension per iteration for each input).

This all works nicely. Only catch 22 is that we're closing the door to allow running `map` in `while` or `while` in `map` (abusing the last dimension weirdly) 