### PR TITLE
Introduce Workspace and Membership objects

### DIFF
--- a/front/init/db.ts
+++ b/front/init/db.ts
@@ -6,12 +6,16 @@ import {
   Key,
   Provider,
   User,
+  Workspace,
+  Membership,
   XP1Run,
   XP1User,
 } from "@app/lib/models";
 
 async function main() {
   await User.sync({ alter: true });
+  await Workspace.sync({ alter: true });
+  await Membership.sync({ alter: true });
   await App.sync({ alter: true });
   await Dataset.sync({ alter: true });
   await Provider.sync({ alter: true });

--- a/front/lib/models.ts
+++ b/front/lib/models.ts
@@ -79,6 +79,111 @@ User.init(
   }
 );
 
+export class Workspace extends Model<
+  InferAttributes<Workspace>,
+  InferCreationAttributes<Workspace>
+> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare uId: string;
+  declare sId: string;
+  declare name: string;
+  declare description?: string;
+  declare type: "personal" | "team";
+  declare plan?: string;
+}
+Workspace.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    uId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    sId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    name: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    description: {
+      type: DataTypes.STRING,
+    },
+    type: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    plan: {
+      type: DataTypes.STRING,
+    },
+  },
+  {
+    modelName: "workspace",
+    sequelize: front_sequelize,
+    indexes: [{ fields: ["sId"] }],
+  }
+);
+
+export class Membership extends Model<
+  InferAttributes<Membership>,
+  InferCreationAttributes<Membership>
+> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare role: "admin" | "builder" | "user" | "revoked";
+
+  declare userId: ForeignKey<User["id"]>;
+  declare workspaceId: ForeignKey<Workspace["id"]>;
+}
+Membership.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    role: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+  },
+  {
+    modelName: "membership",
+    sequelize: front_sequelize,
+  }
+);
+User.hasMany(Membership);
+Workspace.hasMany(Membership);
+
 export class App extends Model<
   InferAttributes<App>,
   InferCreationAttributes<App>
@@ -98,6 +203,7 @@ export class App extends Model<
   declare dustAPIProjectId: string;
 
   declare userId: ForeignKey<User["id"]>;
+  declare workspaceId: ForeignKey<Workspace["id"]>;
 }
 App.init(
   {
@@ -159,6 +265,7 @@ App.init(
   }
 );
 User.hasMany(App);
+Workspace.hasMany(App);
 
 export class Provider extends Model<
   InferAttributes<Provider>,
@@ -172,6 +279,7 @@ export class Provider extends Model<
   declare config: string;
 
   declare userId: ForeignKey<User["id"]>;
+  declare workspaceId: ForeignKey<Workspace["id"]>;
 }
 Provider.init(
   {
@@ -206,6 +314,7 @@ Provider.init(
   }
 );
 User.hasMany(Provider);
+Workspace.hasMany(Provider);
 
 export class Dataset extends Model<
   InferAttributes<Dataset>,
@@ -219,6 +328,7 @@ export class Dataset extends Model<
   declare description?: string;
 
   declare userId: ForeignKey<User["id"]>;
+  declare workspaceId: ForeignKey<Workspace["id"]>;
   declare appId: ForeignKey<App["id"]>;
 }
 Dataset.init(
@@ -254,6 +364,7 @@ Dataset.init(
 );
 User.hasMany(Dataset);
 App.hasMany(Dataset);
+Workspace.hasMany(Dataset);
 
 export class Clone extends Model<
   InferAttributes<Clone>,
@@ -320,6 +431,7 @@ export class Key extends Model<
   declare status: string;
 
   declare userId: ForeignKey<User["id"]>;
+  declare workspaceId: ForeignKey<Workspace["id"]>;
 }
 Key.init(
   {
@@ -354,6 +466,7 @@ Key.init(
   }
 );
 User.hasMany(Key);
+Workspace.hasMany(Key);
 
 export class DataSource extends Model<
   InferAttributes<DataSource>,
@@ -370,6 +483,7 @@ export class DataSource extends Model<
   declare dustAPIProjectId: string;
 
   declare userId: ForeignKey<User["id"]>;
+  declare workspaceId: ForeignKey<Workspace["id"]>;
 }
 
 DataSource.init(
@@ -418,6 +532,7 @@ DataSource.init(
   }
 );
 User.hasMany(DataSource);
+Workspace.hasMany(DataSource);
 
 // XP1
 

--- a/front/migrations/20230413_workspaces_memberships.ts
+++ b/front/migrations/20230413_workspaces_memberships.ts
@@ -1,0 +1,57 @@
+import { User, Workspace, Membership } from "@app/lib/models";
+import { new_id } from "@app/lib/utils";
+
+async function main() {
+  let users = await User.findAll();
+
+  const chunks = [];
+  for (let i = 0; i < users.length; i += 16) {
+    chunks.push(users.slice(i, i + 16));
+  }
+
+  for (let i = 0; i < chunks.length; i++) {
+    console.log(`Processing chunk ${i}/${chunks.length}...`);
+    const chunk = chunks[i];
+    await Promise.all(
+      chunk.map((u) => {
+        return (async () => {
+          let m = await Membership.findOne({
+            where: {
+              userId: u.id,
+            },
+          });
+
+          if (!m) {
+            let uId = new_id();
+
+            const w = await Workspace.create({
+              uId,
+              sId: uId.slice(0, 10),
+              name: u.username,
+              type: "personal",
+            });
+
+            const m = await Membership.create({
+              role: "admin",
+              userId: u.id,
+              workspaceId: w.id,
+            });
+            console.log(`+ ${u.id}`);
+          } else {
+            console.log(`o ${u.id}`);
+          }
+        })();
+      })
+    );
+  }
+}
+
+main()
+  .then(() => {
+    console.log("Done");
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });


### PR DESCRIPTION
Rollout/Deploy:

- run `init/init.sh` (checked that the service can run with previous code on new DB schema)
- re-deploy `front`
- from `front/`, run `FRONT_DATABASE_URI=xxx npx tsx migrations/20230413_workspaces_memberships.ts`

I tested:
- Creating a new user, checked that Workspace and Membership were created
- Running on `main` post schema changes 
- Running with null values for future workspaceId on all objects

Follow-up PR will be writing workspaceId on all objects being created: `App`, `Dataset`, `DataSource`, `Provider`, `Key` along with a backfill migration for these values.
