### PR TITLE
Workspace to all objects + backfill

### DIFF
--- a/front/lib/error.ts
+++ b/front/lib/error.ts
@@ -17,7 +17,8 @@ export type APIErrorType =
   | "app_user_mismatch_error"
   | "run_error"
   | "app_not_found"
-  | "method_not_supported_error";
+  | "method_not_supported_error"
+  | "personal_workspace_not_found";
 
 type _APIError = {
   type: APIErrorType;

--- a/front/migrations/20230413_objects_workspaces.ts
+++ b/front/migrations/20230413_objects_workspaces.ts
@@ -1,9 +1,16 @@
-import { User, App, Dataset, Provider, Key, DataSource } from "@app/lib/models";
+import {
+  User,
+  App,
+  Dataset,
+  Provider,
+  Key,
+  DataSource,
+  Run,
+} from "@app/lib/models";
 import { personalWorkspace } from "@app/lib/auth";
-import { new_id } from "@app/lib/utils";
 
 async function addWorkspaceToObject(
-  object: App | Dataset | Provider | Key | DataSource
+  object: App | Dataset | Provider | Key | DataSource | Run
 ) {
   if (object.workspaceId) {
     console.log(`o ${object.id} ${object.userId} ${object.workspaceId}`);
@@ -33,7 +40,7 @@ async function addWorkspaceToObject(
 }
 
 async function updateObjects(
-  objects: App[] | Dataset[] | Provider[] | Key[] | DataSource[]
+  objects: App[] | Dataset[] | Provider[] | Key[] | DataSource[] | Run[]
 ) {
   const chunks = [];
   for (let i = 0; i < objects.length; i += 16) {
@@ -76,6 +83,11 @@ async function updateDataSources() {
   await updateObjects(dataSources);
 }
 
+async function updateRuns() {
+  let runs = await Run.findAll();
+  await updateObjects(runs);
+}
+
 async function main() {
   console.log(`Update Apps...`);
   await updateApps();
@@ -87,6 +99,8 @@ async function main() {
   await updateKeys();
   console.log(`Update DataSources...`);
   await updateDataSources();
+  console.log(`Update Runs...`);
+  await updateRuns();
 }
 
 main()

--- a/front/migrations/20230413_objects_workspaces.ts
+++ b/front/migrations/20230413_objects_workspaces.ts
@@ -1,0 +1,100 @@
+import { User, App, Dataset, Provider, Key, DataSource } from "@app/lib/models";
+import { personalWorkspace } from "@app/lib/auth";
+import { new_id } from "@app/lib/utils";
+
+async function addWorkspaceToObject(
+  object: App | Dataset | Provider | Key | DataSource
+) {
+  if (object.workspaceId) {
+    console.log(`o ${object.id} ${object.userId} ${object.workspaceId}`);
+    return;
+  }
+
+  const user = await User.findOne({
+    where: {
+      id: object.userId,
+    },
+  });
+  if (!user) {
+    throw new Error(`User id=${object.userId} not found`);
+  }
+  const ownerRes = await personalWorkspace(user);
+
+  if (ownerRes.isErr()) {
+    throw new Error(`Workspace not found for user id=${object.userId}`);
+  }
+
+  const owner = ownerRes.value;
+
+  await (object as any).update({
+    workspaceId: owner.id,
+  });
+  console.log(`+ ${object.id} ${user.id} ${owner.id}`);
+}
+
+async function updateObjects(
+  objects: App[] | Dataset[] | Provider[] | Key[] | DataSource[]
+) {
+  const chunks = [];
+  for (let i = 0; i < objects.length; i += 16) {
+    chunks.push(objects.slice(i, i + 16));
+  }
+
+  for (let i = 0; i < chunks.length; i++) {
+    console.log(`Processing chunk ${i}/${chunks.length}...`);
+    const chunk = chunks[i];
+    await Promise.all(
+      chunk.map((o) => {
+        return addWorkspaceToObject(o);
+      })
+    );
+  }
+}
+
+async function updateApps() {
+  let apps = await App.findAll();
+  await updateObjects(apps);
+}
+
+async function updateDatasets() {
+  let datasets = await Dataset.findAll();
+  await updateObjects(datasets);
+}
+
+async function updateProviders() {
+  let providers = await Provider.findAll();
+  await updateObjects(providers);
+}
+
+async function updateKeys() {
+  let keys = await Key.findAll();
+  await updateObjects(keys);
+}
+
+async function updateDataSources() {
+  let dataSources = await DataSource.findAll();
+  await updateObjects(dataSources);
+}
+
+async function main() {
+  console.log(`Update Apps...`);
+  await updateApps();
+  console.log(`Update Datasets...`);
+  await updateDatasets();
+  console.log(`Update Providers...`);
+  await updateProviders();
+  console.log(`Update Keys...`);
+  await updateKeys();
+  console.log(`Update DataSources...`);
+  await updateDataSources();
+}
+
+main()
+  .then(() => {
+    console.log("Done");
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/front/pages/api/apps/[user]/[sId]/datasets/index.ts
+++ b/front/pages/api/apps/[user]/[sId]/datasets/index.ts
@@ -1,4 +1,4 @@
-import { auth_user } from "@app/lib/auth";
+import { auth_user, personalWorkspace } from "@app/lib/auth";
 import { checkDatasetData } from "@app/lib/datasets";
 import { DustAPI } from "@app/lib/dust_api";
 import { App, Dataset, User } from "@app/lib/models";
@@ -144,11 +144,19 @@ async function handler(
 
       let description = req.body.description ? req.body.description : null;
 
+      let ownerRes = await personalWorkspace(appUser);
+      if (ownerRes.isErr()) {
+        res.status(ownerRes.error.status_code).end();
+        return;
+      }
+      let owner = ownerRes.value;
+
       await Dataset.create({
         name: req.body.name,
         description,
-        userId: appUser.id,
         appId: app.id,
+        userId: appUser.id,
+        workspaceId: owner.id,
       });
 
       res.status(201).json({

--- a/front/pages/api/apps/[user]/index.ts
+++ b/front/pages/api/apps/[user]/index.ts
@@ -1,4 +1,4 @@
-import { auth_user, Role } from "@app/lib/auth";
+import { auth_user, Role, personalWorkspace } from "@app/lib/auth";
 import { DustAPI } from "@app/lib/dust_api";
 import { App, User } from "@app/lib/models";
 import { new_id } from "@app/lib/utils";
@@ -85,14 +85,22 @@ async function handler(
       let description = req.body.description ? req.body.description : null;
       let uId = new_id();
 
+      let ownerRes = await personalWorkspace(appUser);
+      if (ownerRes.isErr()) {
+        res.status(ownerRes.error.status_code).end();
+        return;
+      }
+      let owner = ownerRes.value;
+
       let app = await App.create({
         uId,
         sId: uId.slice(0, 10),
         name: req.body.name,
         description,
         visibility: req.body.visibility,
-        userId: appUser.id,
         dustAPIProjectId: p.value.project.project_id.toString(),
+        userId: appUser.id,
+        workspaceId: owner.id,
       });
 
       res.redirect(`/${appUser.username}/a/${app.sId}`);

--- a/front/pages/api/data_sources/[user]/index.ts
+++ b/front/pages/api/data_sources/[user]/index.ts
@@ -1,4 +1,4 @@
-import { Role, auth_user } from "@app/lib/auth";
+import { Role, auth_user, personalWorkspace } from "@app/lib/auth";
 import { DustAPI } from "@app/lib/dust_api";
 import { DataSource, Provider, User } from "@app/lib/models";
 import { credentialsFromProviders } from "@app/lib/providers";
@@ -138,6 +138,13 @@ async function handler(
         return;
       }
 
+      let ownerRes = await personalWorkspace(dataSourceUser);
+      if (ownerRes.isErr()) {
+        res.status(ownerRes.error.status_code).end();
+        return;
+      }
+      let owner = ownerRes.value;
+
       await DataSource.create({
         name: req.body.name,
         description: description,
@@ -145,6 +152,7 @@ async function handler(
         config: JSON.stringify(dustDataSource.value.data_source.config),
         dustAPIProjectId: dustProject.value.project.project_id.toString(),
         userId: dataSourceUser.id,
+        workspaceId: owner.id,
       });
 
       res.redirect(`/${dataSourceUser.username}/ds/${req.body.name}`);

--- a/front/pages/api/providers/[pId]/index.ts
+++ b/front/pages/api/providers/[pId]/index.ts
@@ -1,4 +1,4 @@
-import { auth_user } from "@app/lib/auth";
+import { auth_user, personalWorkspace } from "@app/lib/auth";
 import { Provider } from "@app/lib/models";
 import withLogging from "@app/logger/withlogging";
 import { ProviderType } from "@app/types/provider";
@@ -52,11 +52,19 @@ async function handler(
         return;
       }
 
+      let authOwnerRes = await personalWorkspace(auth.dbUser());
+      if (authOwnerRes.isErr()) {
+        res.status(authOwnerRes.error.status_code).end();
+        return;
+      }
+      let authOwner = authOwnerRes.value;
+
       if (!provider) {
         provider = await Provider.create({
           providerId: req.query.pId,
           config: req.body.config,
           userId: auth.user().id,
+          workspaceId: authOwner.id,
         });
         res.status(201).json({
           provider: {


### PR DESCRIPTION
This PR pulls the appropriate user workspace before writing any object to DB.

For App, DataSource, Dataset (except in the context of Clone) this is the `appUser`'s personal workspace.
When cloning or for Key or Provider, this is implied by the authenticated user, so this is the `auth.dbUsrer`'s workspace.

The internal API routes for Key/Provider/Clone don't have the user in them so we will have to migrate them as we move to workspace based URLs to routes where the current workspace is present. 

As context, (not covered in this PR) we'll move from `dust.tt/spolu/...` to `dust.tt/w/[worskace.sId]/...` this is a bit less aesthetic and less convenient in the context of the upcoming `dust.run` in `code` blocks, but that's not our core product priority. The internal API routes will be moved as well and we'll reroute for the external API automatically.

The PR also contains a backfill for all objects in DB. After this is merged / deployed / backfilled we can start working on relying on `Workspaces` instead of `Users` for authentication, authorization and routing.

Rollout/Deploy:

- re-deploy front
- from `front/`, run `FRONT_DATABASE_URI=xxx npx tsx migrations/20230413_objects_workspaces.ts`

Also note that the way that we pull the workspace when editing these objects will be removed eventually as the appropriate workspace will be part of the future Authenticator object.