### PR TITLE
update GET runs endpoint to only fetch user's runs

### DIFF
--- a/front/lib/dust_api.ts
+++ b/front/lib/dust_api.ts
@@ -323,7 +323,7 @@ export const DustAPI = {
   async getRunsBatch(
     projectId: string,
     dustRunIds: string[]
-  ): Promise<DustAPIResponse<{ runs: DustAPIRun[] }>> {
+  ): Promise<DustAPIResponse<{ runs: { [key: string]: DustAPIRun } }>> {
     const response = await fetch(
       `${DUST_API_URL}/projects/${projectId}/runs/batch`,
       {

--- a/front/lib/dust_api.ts
+++ b/front/lib/dust_api.ts
@@ -304,22 +304,6 @@ export const DustAPI = {
     return new Ok({ chunkStream: streamChunks(), dustRunId: dustRunIdPromise });
   },
 
-  async getRuns(
-    projectId: string,
-    limit: number,
-    offset: number,
-    runType: RunRunType
-  ): Promise<DustAPIResponse<GetRunsResponse>> {
-    const response = await fetch(
-      `${DUST_API_URL}/projects/${projectId}/runs?limit=${limit}&offset=${offset}&run_type=${runType}`,
-      {
-        method: "GET",
-      }
-    );
-
-    return _resultFromResponse(response);
-  },
-
   async getRunsBatch(
     projectId: string,
     dustRunIds: string[]


### PR DESCRIPTION
- We need to backfill the `Run` table before deploying this
- We need to merge [feat/retrieve-user-runs](https://github.com/dust-tt/dust/tree/feat/retrieve-user-runs) before this (branched off)