### PR TITLE
use canEditApp instead of isAppOwner and get rid of the latter

### DIFF
--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -4,7 +4,7 @@ import { authOptions } from "@app/pages/api/auth/[...nextauth]";
 import { UserType } from "@app/types/user";
 import { NextApiRequest, NextApiResponse } from "next";
 import { getServerSession } from "next-auth/next";
-import { App, DataSource, Key, User, Workspace, Membership } from "./models";
+import { App, DataSource, Key, Membership, User, Workspace } from "./models";
 
 export enum Role {
   Owner = "owner",
@@ -96,22 +96,6 @@ export class Authenticator {
    * @returns true if the user can edit the app, false otherwise.
    */
   canEditApp(app: App): boolean {
-    return this._authUser?.id === app.userId;
-  }
-
-  /**
-   * Only the owner of an app can run it. This is an artificial restriction due to the fact that we
-   * don't have `front` side `Run` objects. If we allowed anyone to run an app, the "Logs" panel of
-   * a user would see `Runs` from other user which is not desirable.
-   *
-   * Once we introduce a `front` side `Run` object, we can remove this restriction and allow anyone
-   * to run a public app with their own credentials. This will enable use to have the "Use" and
-   * "Logs" panels available to any logged-in user.
-   *
-   * @param app the app for which we check the run rights
-   * @returns true if the user can run the app, false otherwise.
-   */
-  isAppOwner(app: App): boolean {
     return this._authUser?.id === app.userId;
   }
 

--- a/front/pages/api/apps/[user]/[sId]/runs/index.ts
+++ b/front/pages/api/apps/[user]/[sId]/runs/index.ts
@@ -161,8 +161,8 @@ async function handler(
 
         // Run creation as part of the app design process (Specification pane).
         case "design":
-          // Only the app owner is allowed to create runs in design mode.
-          if (!auth.isAppOwner(app)) {
+          // Edit rights are required to run the app from the specification page.
+          if (!auth.canEditApp(app)) {
             res.status(404).end();
             return;
           }


### PR DESCRIPTION
More consistent + not useful to have 2 functions that do the exact same thing