### PR TITLE
Move from githubId to provider/providerId

### DIFF
--- a/front/lib/models.ts
+++ b/front/lib/models.ts
@@ -21,8 +21,8 @@ export class User extends Model<
   declare id: CreationOptional<number>;
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
-  // declare provider: string | null;
-  // declare providerId: string | null;
+  declare provider: "github" | "google" | null;
+  declare providerId: string | null;
   declare githubId: string;
   declare username: string;
   declare email: string;
@@ -45,12 +45,12 @@ User.init(
       allowNull: false,
       defaultValue: DataTypes.NOW,
     },
-    // provider: {
-    //   type: DataTypes.STRING,
-    // },
-    // providerId: {
-    //   type: DataTypes.STRING,
-    // },
+    provider: {
+      type: DataTypes.STRING,
+    },
+    providerId: {
+      type: DataTypes.STRING,
+    },
     githubId: {
       type: DataTypes.STRING,
       allowNull: false,
@@ -72,9 +72,9 @@ User.init(
     modelName: "user",
     sequelize: front_sequelize,
     indexes: [
-      { fields: ["githubId"] },
       { fields: ["username"] },
-      // { fields: ["provider", "providerId"] },
+      { fields: ["githubId"] },
+      { fields: ["provider", "providerId"] },
     ],
   }
 );

--- a/front/migrations/20230419_user_providers.ts
+++ b/front/migrations/20230419_user_providers.ts
@@ -1,0 +1,40 @@
+import { User } from "@app/lib/models";
+
+async function main() {
+  let users = await User.findAll();
+
+  const chunks = [];
+  for (let i = 0; i < users.length; i += 16) {
+    chunks.push(users.slice(i, i + 16));
+  }
+
+  for (let i = 0; i < chunks.length; i++) {
+    console.log(`Processing chunk ${i}/${chunks.length}...`);
+    const chunk = chunks[i];
+    await Promise.all(
+      chunk.map((u) => {
+        return (async () => {
+          if (!u.provider) {
+            await u.update({
+              provider: "github",
+              providerId: u.githubId,
+            });
+            console.log(`+ ${u.id}`);
+          } else {
+            console.log(`o ${u.id}`);
+          }
+        })();
+      })
+    );
+  }
+}
+
+main()
+  .then(() => {
+    console.log("Done");
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -35,6 +35,8 @@ async function handler(
 
         const [u, w] = await Promise.all([
           User.create({
+            provider: "github",
+            providerId: session.provider.id.toString(),
             githubId: session.provider.id.toString(),
             username: session.user.username,
             email: session.user.email,


### PR DESCRIPTION
DB update + migration to move to `probider`/`providerId` on the `User` model instead of `githubId` (to allow more providers, in particular `google`).

Deploy:
- run `init/init.sh`
- Deploy `front`
- run `npx tsx migrations/20230419_user_providers.ts`

Once merged and deployed (and migration run), we'll remove `githubId` in a follow-up PR.

Meta: there used to be `githubId` occurrences everywhere in the codebase, it now appears in 2 files \o/