### PR TITLE
fix: show `value` / `error`  in use tab final output

### DIFF
--- a/front/pages/w/[wId]/a/[aId]/execute/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/execute/index.tsx
@@ -236,9 +236,15 @@ function ExecuteFinalOutput({
   value: unknown;
   errored: boolean;
 }) {
-  let cleanedValue = value;
+  let cleanedValue = value as any;
   if (Array.isArray(value) && value.length === 1) {
     cleanedValue = value[0];
+  }
+
+  if (cleanedValue && "value" in cleanedValue && cleanedValue.value) {
+    cleanedValue = cleanedValue.value;
+  } else if (cleanedValue && "error" in cleanedValue && cleanedValue.error) {
+    cleanedValue = cleanedValue.error;
   }
 
   return (


### PR DESCRIPTION
if there is a truthy `value`, display that, otherwise if there is a truthy `error`, display it (with a red outline around the text box)