### PR TITLE
Aric connectors db

### DIFF
--- a/connectors/package-lock.json
+++ b/connectors/package-lock.json
@@ -8,13 +8,11 @@
       "name": "dust-connectors",
       "version": "0.1.2",
       "dependencies": {
-        "@nangohq/node": "^0.9.0",
         "@slack/web-api": "^6.8.1",
         "@temporalio/activity": "1.7.0",
         "@temporalio/client": "1.7.0",
         "@temporalio/worker": "1.7.0",
         "@temporalio/workflow": "1.7.0",
-        "nanoid": "3.x",
         "pg": "^8.10.0",
         "sequelize": "^6.31.0"
       },
@@ -677,40 +675,6 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
-      }
-    },
-    "node_modules/@nangohq/node": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@nangohq/node/-/node-0.9.0.tgz",
-      "integrity": "sha512-qUGtjn27Gf4ANSuEm8mS0NhVbEkgErc8qArSO7RB3Z2OHhyqxAepqMH0GC3BUr++Y8rpIyKRUpZMy7kp0WFElg==",
-      "dependencies": {
-        "axios": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=16.7"
-      }
-    },
-    "node_modules/@nangohq/node/node_modules/axios": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.6.tgz",
-      "integrity": "sha512-PEcdkk7JcdPiMDkvM4K6ZBRYq9keuVJsToxm2zQIM70Qqo2WHTdJZMXcG9X+RmRp2VPNUQC8W1RAGbgt6b1yMg==",
-      "dependencies": {
-        "follow-redirects": "^1.15.0",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
-    "node_modules/@nangohq/node/node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -3010,23 +2974,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
-    "node_modules/nanoid": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -3453,11 +3400,6 @@
       "engines": {
         "node": ">=12.0.0"
       }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/pstree.remy": {
       "version": "1.1.8",

--- a/connectors/package-lock.json
+++ b/connectors/package-lock.json
@@ -8,12 +8,15 @@
       "name": "dust-connectors",
       "version": "0.1.2",
       "dependencies": {
+        "@nangohq/node": "^0.9.0",
         "@slack/web-api": "^6.8.1",
         "@temporalio/activity": "1.7.0",
         "@temporalio/client": "1.7.0",
         "@temporalio/worker": "1.7.0",
         "@temporalio/workflow": "1.7.0",
-        "nanoid": "3.x"
+        "nanoid": "3.x",
+        "pg": "^8.10.0",
+        "sequelize": "^6.31.0"
       },
       "devDependencies": {
         "@tsconfig/node16": "^1.0.0",
@@ -26,8 +29,8 @@
         "eslint-plugin-simple-import-sort": "^10.0.0",
         "nodemon": "^2.0.12",
         "prettier": "^2.3.2",
-        "ts-node": "^10.8.1",
         "tsconfig-paths": "^4.2.0",
+        "tsx": "^3.12.6",
         "typescript": "^4.4.2"
       }
     },
@@ -134,14 +137,384 @@
         "node": ">=4"
       }
     },
-    "node_modules/@cspotcode/source-map-support": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+    "node_modules/@esbuild-kit/cjs-loader": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@esbuild-kit/cjs-loader/-/cjs-loader-2.4.2.tgz",
+      "integrity": "sha512-BDXFbYOJzT/NBEtp71cvsrGPwGAMGRB/349rwKuoxNSiKjPraNNnlK6MIIabViCjqZugu6j+xeMDlEkWdHHJSg==",
       "dev": true,
       "dependencies": {
-        "@jridgewell/trace-mapping": "0.3.9"
-      },
+        "@esbuild-kit/core-utils": "^3.0.0",
+        "get-tsconfig": "^4.4.0"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@esbuild-kit/core-utils/-/core-utils-3.1.0.tgz",
+      "integrity": "sha512-Uuk8RpCg/7fdHSceR1M6XbSZFSuMrxcePFuGgyvsBn+u339dk5OeL4jv2EojwTN2st/unJGsVm4qHWjWNmJ/tw==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "~0.17.6",
+        "source-map-support": "^0.5.21"
+      }
+    },
+    "node_modules/@esbuild-kit/esm-loader": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/@esbuild-kit/esm-loader/-/esm-loader-2.5.5.tgz",
+      "integrity": "sha512-Qwfvj/qoPbClxCRNuac1Du01r9gvNOT+pMYtJDapfB1eoGN1YlJ1BixLyL9WVENRx5RXgNLdfYdx/CuswlGhMw==",
+      "dev": true,
+      "dependencies": {
+        "@esbuild-kit/core-utils": "^3.0.0",
+        "get-tsconfig": "^4.4.0"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.17.tgz",
+      "integrity": "sha512-E6VAZwN7diCa3labs0GYvhEPL2M94WLF8A+czO8hfjREXxba8Ng7nM5VxV+9ihNXIY1iQO1XxUU4P7hbqbICxg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.17.tgz",
+      "integrity": "sha512-jaJ5IlmaDLFPNttv0ofcwy/cfeY4bh/n705Tgh+eLObbGtQBK3EPAu+CzL95JVE4nFAliyrnEu0d32Q5foavqg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.17.tgz",
+      "integrity": "sha512-446zpfJ3nioMC7ASvJB1pszHVskkw4u/9Eu8s5yvvsSDTzYh4p4ZIRj0DznSl3FBF0Z/mZfrKXTtt0QCoFmoHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.17.tgz",
+      "integrity": "sha512-m/gwyiBwH3jqfUabtq3GH31otL/0sE0l34XKpSIqR7NjQ/XHQ3lpmQHLHbG8AHTGCw8Ao059GvV08MS0bhFIJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.17.tgz",
+      "integrity": "sha512-4utIrsX9IykrqYaXR8ob9Ha2hAY2qLc6ohJ8c0CN1DR8yWeMrTgYFjgdeQ9LIoTOfLetXjuCu5TRPHT9yKYJVg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.17.tgz",
+      "integrity": "sha512-4PxjQII/9ppOrpEwzQ1b0pXCsFLqy77i0GaHodrmzH9zq2/NEhHMAMJkJ635Ns4fyJPFOlHMz4AsklIyRqFZWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.17.tgz",
+      "integrity": "sha512-lQRS+4sW5S3P1sv0z2Ym807qMDfkmdhUYX30GRBURtLTrJOPDpoU0kI6pVz1hz3U0+YQ0tXGS9YWveQjUewAJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.17.tgz",
+      "integrity": "sha512-biDs7bjGdOdcmIk6xU426VgdRUpGg39Yz6sT9Xp23aq+IEHDb/u5cbmu/pAANpDB4rZpY/2USPhCA+w9t3roQg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.17.tgz",
+      "integrity": "sha512-2+pwLx0whKY1/Vqt8lyzStyda1v0qjJ5INWIe+d8+1onqQxHLLi3yr5bAa4gvbzhZqBztifYEu8hh1La5+7sUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.17.tgz",
+      "integrity": "sha512-IBTTv8X60dYo6P2t23sSUYym8fGfMAiuv7PzJ+0LcdAndZRzvke+wTVxJeCq4WgjppkOpndL04gMZIFvwoU34Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.17.tgz",
+      "integrity": "sha512-WVMBtcDpATjaGfWfp6u9dANIqmU9r37SY8wgAivuKmgKHE+bWSuv0qXEFt/p3qXQYxJIGXQQv6hHcm7iWhWjiw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.17.tgz",
+      "integrity": "sha512-2kYCGh8589ZYnY031FgMLy0kmE4VoGdvfJkxLdxP4HJvWNXpyLhjOvxVsYjYZ6awqY4bgLR9tpdYyStgZZhi2A==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.17.tgz",
+      "integrity": "sha512-KIdG5jdAEeAKogfyMTcszRxy3OPbZhq0PPsW4iKKcdlbk3YE4miKznxV2YOSmiK/hfOZ+lqHri3v8eecT2ATwQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.17.tgz",
+      "integrity": "sha512-Cj6uWLBR5LWhcD/2Lkfg2NrkVsNb2sFM5aVEfumKB2vYetkA/9Uyc1jVoxLZ0a38sUhFk4JOVKH0aVdPbjZQeA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.17.tgz",
+      "integrity": "sha512-lK+SffWIr0XsFf7E0srBjhpkdFVJf3HEgXCwzkm69kNbRar8MhezFpkIwpk0qo2IOQL4JE4mJPJI8AbRPLbuOQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.17.tgz",
+      "integrity": "sha512-XcSGTQcWFQS2jx3lZtQi7cQmDYLrpLRyz1Ns1DzZCtn898cWfm5Icx/DEWNcTU+T+tyPV89RQtDnI7qL2PObPg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.17.tgz",
+      "integrity": "sha512-RNLCDmLP5kCWAJR+ItLM3cHxzXRTe4N00TQyQiimq+lyqVqZWGPAvcyfUBM0isE79eEZhIuGN09rAz8EL5KdLA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.17.tgz",
+      "integrity": "sha512-PAXswI5+cQq3Pann7FNdcpSUrhrql3wKjj3gVkmuz6OHhqqYxKvi6GgRBoaHjaG22HV/ZZEgF9TlS+9ftHVigA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.17.tgz",
+      "integrity": "sha512-V63egsWKnx/4V0FMYkr9NXWrKTB5qFftKGKuZKFIrAkO/7EWLFnbBZNM1CvJ6Sis+XBdPws2YQSHF1Gqf1oj/Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.17.tgz",
+      "integrity": "sha512-YtUXLdVnd6YBSYlZODjWzH+KzbaubV0YVd6UxSfoFfa5PtNJNaW+1i+Hcmjpg2nEe0YXUCNF5bkKy1NnBv1y7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.17.tgz",
+      "integrity": "sha512-yczSLRbDdReCO74Yfc5tKG0izzm+lPMYyO1fFTcn0QNwnKmc3K+HdxZWLGKg4pZVte7XVgcFku7TIZNbWEJdeQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.17.tgz",
+      "integrity": "sha512-FNZw7H3aqhF9OyRQbDDnzUApDXfC1N6fgBhkqEO2jvYCJ+DxMTfZVqg3AX0R1khg1wHTBRD5SdcibSJ+XF6bFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
       "engines": {
         "node": ">=12"
       }
@@ -304,6 +677,40 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@nangohq/node": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@nangohq/node/-/node-0.9.0.tgz",
+      "integrity": "sha512-qUGtjn27Gf4ANSuEm8mS0NhVbEkgErc8qArSO7RB3Z2OHhyqxAepqMH0GC3BUr++Y8rpIyKRUpZMy7kp0WFElg==",
+      "dependencies": {
+        "axios": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "node_modules/@nangohq/node/node_modules/axios": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.6.tgz",
+      "integrity": "sha512-PEcdkk7JcdPiMDkvM4K6ZBRYq9keuVJsToxm2zQIM70Qqo2WHTdJZMXcG9X+RmRp2VPNUQC8W1RAGbgt6b1yMg==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/@nangohq/node/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -724,29 +1131,19 @@
         "@temporalio/proto": "1.7.0"
       }
     },
-    "node_modules/@tsconfig/node10": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
-      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
-      "dev": true
-    },
-    "node_modules/@tsconfig/node12": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "dev": true
-    },
-    "node_modules/@tsconfig/node14": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "dev": true
-    },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
       "dev": true
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
+      "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
+      "dependencies": {
+        "@types/ms": "*"
+      }
     },
     "node_modules/@types/eslint": {
       "version": "8.37.0",
@@ -789,6 +1186,11 @@
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
       "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
     },
+    "node_modules/@types/ms": {
+      "version": "0.7.31",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
+      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
+    },
     "node_modules/@types/node": {
       "version": "16.18.23",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.23.tgz",
@@ -804,6 +1206,11 @@
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
       "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
       "dev": true
+    },
+    "node_modules/@types/validator": {
+      "version": "13.7.15",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.7.15.tgz",
+      "integrity": "sha512-yeinDVQunb03AEP8luErFcyf/7Lf7AzKCD0NXfgVoGCCQDNpZET8Jgq74oBgqKld3hafLbfzt/3inUdQvaFeXQ=="
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.59.0",
@@ -1177,15 +1584,6 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/acorn-walk": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -1381,6 +1779,14 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
+    "node_modules/buffer-writer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
+      "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -1516,12 +1922,6 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
-    "node_modules/create-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "dev": true
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -1540,7 +1940,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -1556,8 +1955,7 @@
     "node_modules/debug/node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -1571,15 +1969,6 @@
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.3.1"
       }
     },
     "node_modules/dir-glob": {
@@ -1605,6 +1994,11 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/dottie": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dottie/-/dottie-2.0.3.tgz",
+      "integrity": "sha512-4liA0PuRkZWQFQjwBypdxPfZaRWiv5tkhMXY2hzsa2pNf5s7U3m9cwUchfNKe8wZQxdGPQQzO6Rm2uGe0rvohQ=="
     },
     "node_modules/electron-to-chromium": {
       "version": "1.4.366",
@@ -1644,6 +2038,43 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.2.1.tgz",
       "integrity": "sha512-9978wrXM50Y4rTMmW5kXIC09ZdXQZqkE4mxhwkd8VbzsGkXGPgV4zWuqQJgCEzYngdo2dYDa0l8xhX4fkSwJSg=="
+    },
+    "node_modules/esbuild": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.17.tgz",
+      "integrity": "sha512-/jUywtAymR8jR4qsa2RujlAF7Krpt5VWi72Q2yuLD4e/hvtNcFQ0I1j8m/bxq238pf3/0KO5yuXNpuLx8BE1KA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.17.17",
+        "@esbuild/android-arm64": "0.17.17",
+        "@esbuild/android-x64": "0.17.17",
+        "@esbuild/darwin-arm64": "0.17.17",
+        "@esbuild/darwin-x64": "0.17.17",
+        "@esbuild/freebsd-arm64": "0.17.17",
+        "@esbuild/freebsd-x64": "0.17.17",
+        "@esbuild/linux-arm": "0.17.17",
+        "@esbuild/linux-arm64": "0.17.17",
+        "@esbuild/linux-ia32": "0.17.17",
+        "@esbuild/linux-loong64": "0.17.17",
+        "@esbuild/linux-mips64el": "0.17.17",
+        "@esbuild/linux-ppc64": "0.17.17",
+        "@esbuild/linux-riscv64": "0.17.17",
+        "@esbuild/linux-s390x": "0.17.17",
+        "@esbuild/linux-x64": "0.17.17",
+        "@esbuild/netbsd-x64": "0.17.17",
+        "@esbuild/openbsd-x64": "0.17.17",
+        "@esbuild/sunos-x64": "0.17.17",
+        "@esbuild/win32-arm64": "0.17.17",
+        "@esbuild/win32-ia32": "0.17.17",
+        "@esbuild/win32-x64": "0.17.17"
+      }
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -2093,6 +2524,15 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.5.0.tgz",
+      "integrity": "sha512-MjhiaIWCJ1sAU4pIQ5i5OfOuHHxVo1oYeNsWTON7jxYkod8pHocXeh+SSbmu5OZZZK73B6cbJ2XADzXehLyovQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -2242,6 +2682,14 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/inflection": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.13.4.tgz",
+      "integrity": "sha512-6I/HUDeYFfuNCVS3td055BaXBwKYuzw7K3ExVMStBowKo9oOAMJIXIHvdyR3iboTCp1b+1i5DSkIZTcwIktuDw==",
+      "engines": [
+        "node >= 0.4.0"
+      ]
     },
     "node_modules/inflight": {
       "version": "1.0.6",
@@ -2422,6 +2870,11 @@
         "node": ">=6.11.5"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
@@ -2448,19 +2901,12 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/make-error": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true
     },
     "node_modules/memfs": {
       "version": "3.5.0",
@@ -2538,6 +2984,25 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment-timezone": {
+      "version": "0.5.43",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.43.tgz",
+      "integrity": "sha512-72j3aNyuIsDxdF1i7CEgV2FfxM1r6aaqJyLB2vwb33mXYyoyLly+F1zbWqhA3/bVIoJ4szlUoMbUnVdid32NUQ==",
+      "dependencies": {
+        "moment": "^2.29.4"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/ms": {
@@ -2752,6 +3217,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/packet-reader": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
+      "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ=="
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -2791,6 +3261,80 @@
         "node": ">=8"
       }
     },
+    "node_modules/pg": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.10.0.tgz",
+      "integrity": "sha512-ke7o7qSTMb47iwzOSaZMfeR7xToFdkE71ifIipOAAaLIM0DYzfOAXlgFFmYUIE2BcJtvnVlGCID84ZzCegE8CQ==",
+      "dependencies": {
+        "buffer-writer": "2.0.0",
+        "packet-reader": "1.0.0",
+        "pg-connection-string": "^2.5.0",
+        "pg-pool": "^3.6.0",
+        "pg-protocol": "^1.6.0",
+        "pg-types": "^2.1.0",
+        "pgpass": "1.x"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
+      "integrity": "sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ=="
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.6.0.tgz",
+      "integrity": "sha512-clFRf2ksqd+F497kWFyM21tMjeikn60oGDmqMT8UBrynEwVEX/5R5xd2sdvdo1cZCFlguORNpVuqxIj+aK4cfQ==",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.6.0.tgz",
+      "integrity": "sha512-M+PDm637OY5WM307051+bsDia5Xej6d9IR4GwJse1qA1DIhiKlksvrneZOYQq42OM+spubpcNYEo2FcKQrDk+Q=="
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -2806,6 +3350,41 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/prelude-ls": {
@@ -2874,6 +3453,11 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/pstree.remy": {
       "version": "1.1.8",
@@ -2974,6 +3558,11 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/retry-as-promised": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-7.0.4.tgz",
+      "integrity": "sha512-XgmCoxKWkDofwH8WddD0w85ZfqYz+ZHlr5yo+3YUCfycWawU56T5ckWXsScsj5B8tqUcIG67DxXByo3VUgiAdA=="
     },
     "node_modules/reusify": {
       "version": "1.0.4",
@@ -3076,7 +3665,6 @@
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
       "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
-      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -3085,6 +3673,75 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/sequelize": {
+      "version": "6.31.0",
+      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.31.0.tgz",
+      "integrity": "sha512-nCPVtv+QydBmb3Us2jCNAr1Dx3gST83VZxxrUQn/JAVFCOrmYOgUaPUz5bevummyNf30zfHsZhIKYAOD3ULfTA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/sequelize"
+        }
+      ],
+      "dependencies": {
+        "@types/debug": "^4.1.7",
+        "@types/validator": "^13.7.1",
+        "debug": "^4.3.3",
+        "dottie": "^2.0.2",
+        "inflection": "^1.13.2",
+        "lodash": "^4.17.21",
+        "moment": "^2.29.1",
+        "moment-timezone": "^0.5.35",
+        "pg-connection-string": "^2.5.0",
+        "retry-as-promised": "^7.0.3",
+        "semver": "^7.3.5",
+        "sequelize-pool": "^7.1.0",
+        "toposort-class": "^1.0.1",
+        "uuid": "^8.3.2",
+        "validator": "^13.7.0",
+        "wkx": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ibm_db": {
+          "optional": true
+        },
+        "mariadb": {
+          "optional": true
+        },
+        "mysql2": {
+          "optional": true
+        },
+        "oracledb": {
+          "optional": true
+        },
+        "pg": {
+          "optional": true
+        },
+        "pg-hstore": {
+          "optional": true
+        },
+        "snowflake-sdk": {
+          "optional": true
+        },
+        "sqlite3": {
+          "optional": true
+        },
+        "tedious": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/sequelize-pool": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/sequelize-pool/-/sequelize-pool-7.1.0.tgz",
+      "integrity": "sha512-G9c0qlIWQSK29pR/5U2JF5dDQeqqHRragoyahj/Nx4KOOQ3CPPfzxnfqFPCSB7x5UgjOgnZ61nSxz+fjDpRlJg==",
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/serialize-javascript": {
@@ -3214,6 +3871,14 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/sprintf-js": {
@@ -3435,6 +4100,11 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toposort-class": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toposort-class/-/toposort-class-1.0.1.tgz",
+      "integrity": "sha512-OsLcGGbYF3rMjPUf8oKktyvCiUxSbqMMS39m33MAjLTC1DVIH6x3WSt63/M77ihI09+Sdfk1AXvfhCEeUmC7mg=="
+    },
     "node_modules/touch": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
@@ -3446,67 +4116,6 @@
       "bin": {
         "nodetouch": "bin/nodetouch.js"
       }
-    },
-    "node_modules/ts-node": {
-      "version": "10.9.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
-      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
-      "dev": true,
-      "dependencies": {
-        "@cspotcode/source-map-support": "^0.8.0",
-        "@tsconfig/node10": "^1.0.7",
-        "@tsconfig/node12": "^1.0.7",
-        "@tsconfig/node14": "^1.0.0",
-        "@tsconfig/node16": "^1.0.2",
-        "acorn": "^8.4.1",
-        "acorn-walk": "^8.1.1",
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.1",
-        "yn": "3.1.1"
-      },
-      "bin": {
-        "ts-node": "dist/bin.js",
-        "ts-node-cwd": "dist/bin-cwd.js",
-        "ts-node-esm": "dist/bin-esm.js",
-        "ts-node-script": "dist/bin-script.js",
-        "ts-node-transpile-only": "dist/bin-transpile.js",
-        "ts-script": "dist/bin-script-deprecated.js"
-      },
-      "peerDependencies": {
-        "@swc/core": ">=1.2.50",
-        "@swc/wasm": ">=1.2.50",
-        "@types/node": "*",
-        "typescript": ">=2.7"
-      },
-      "peerDependenciesMeta": {
-        "@swc/core": {
-          "optional": true
-        },
-        "@swc/wasm": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ts-node/node_modules/acorn": {
-      "version": "8.8.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
-      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
-      "dev": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/ts-node/node_modules/arg": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "dev": true
     },
     "node_modules/tsconfig-paths": {
       "version": "4.2.0",
@@ -3547,6 +4156,23 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
+    },
+    "node_modules/tsx": {
+      "version": "3.12.6",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-3.12.6.tgz",
+      "integrity": "sha512-q93WgS3lBdHlPgS0h1i+87Pt6n9K/qULIMNYZo07nSeu2z5QE2CellcAZfofVXBo2tQg9av2ZcRMQ2S2i5oadQ==",
+      "dev": true,
+      "dependencies": {
+        "@esbuild-kit/cjs-loader": "^2.4.2",
+        "@esbuild-kit/core-utils": "^3.0.0",
+        "@esbuild-kit/esm-loader": "^2.5.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.js"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -3650,11 +4276,13 @@
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
       "dev": true
     },
-    "node_modules/v8-compile-cache-lib": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "dev": true
+    "node_modules/validator": {
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.9.0.tgz",
+      "integrity": "sha512-B+dGG8U3fdtM0/aNK4/X8CXq/EcxU2WPrPEkJGslb47qyHsxmbggTWK0yEA4qnYVNF+nxNlN88o14hIcPmSIEA==",
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/watchpack": {
       "version": "2.4.0",
@@ -3755,6 +4383,14 @@
         "node": ">= 8"
       }
     },
+    "node_modules/wkx": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/wkx/-/wkx-0.5.0.tgz",
+      "integrity": "sha512-Xng/d4Ichh8uN4l0FToV/258EjMGU9MGcA0HV2d9B/ZpZB3lqQm7nkOdZdm5GhKtLLhAE7PiVQwN4eN+2YJJUg==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -3786,6 +4422,14 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
     },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -3797,8 +4441,7 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yargs": {
       "version": "16.2.0",
@@ -3823,15 +4466,6 @@
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/yn": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
       }
     }
   }

--- a/connectors/package.json
+++ b/connectors/package.json
@@ -21,13 +21,11 @@
     ]
   },
   "dependencies": {
-    "@nangohq/node": "^0.9.0",
     "@slack/web-api": "^6.8.1",
     "@temporalio/activity": "1.7.0",
     "@temporalio/client": "1.7.0",
     "@temporalio/worker": "1.7.0",
     "@temporalio/workflow": "1.7.0",
-    "nanoid": "3.x",
     "pg": "^8.10.0",
     "sequelize": "^6.31.0"
   },

--- a/connectors/package.json
+++ b/connectors/package.json
@@ -21,12 +21,15 @@
     ]
   },
   "dependencies": {
+    "@nangohq/node": "^0.9.0",
     "@slack/web-api": "^6.8.1",
     "@temporalio/activity": "1.7.0",
     "@temporalio/client": "1.7.0",
     "@temporalio/worker": "1.7.0",
     "@temporalio/workflow": "1.7.0",
-    "nanoid": "3.x"
+    "nanoid": "3.x",
+    "pg": "^8.10.0",
+    "sequelize": "^6.31.0"
   },
   "devDependencies": {
     "@tsconfig/node16": "^1.0.0",
@@ -39,8 +42,8 @@
     "eslint-plugin-simple-import-sort": "^10.0.0",
     "nodemon": "^2.0.12",
     "prettier": "^2.3.2",
-    "ts-node": "^10.8.1",
     "tsconfig-paths": "^4.2.0",
+    "tsx": "^3.12.6",
     "typescript": "^4.4.2"
   },
   "files": [

--- a/connectors/src/connectors/slack/init.ts
+++ b/connectors/src/connectors/slack/init.ts
@@ -1,0 +1,56 @@
+import { Connector, SlackConfiguration, sequelize_conn } from '@app/lib/models';
+import { Err, Ok, Result } from '@app/lib/result';
+import { Nango } from '@nangohq/node';
+import { WebClient } from '@slack/web-api';
+import { DustConfig } from '@app/types/dust_config';
+export type NangoConnectionId = string;
+
+const { NANGO_SECRET_KEY, NANGO_SLACK_CONNECTOR_ID } = process.env;
+
+export async function createSlackConnector(
+  dustConfig: DustConfig,
+  nangoConnectionId: NangoConnectionId
+): Promise<Result<void, Error>> {
+  await sequelize_conn.transaction(async (t): Promise<Result<[Connector, SlackConfiguration], Error>> => {
+    if (!NANGO_SECRET_KEY) {
+      throw new Error('NANGO_SECRET_KEY is not defined');
+    }
+    if (!NANGO_SLACK_CONNECTOR_ID) {
+      throw new Error('NANGO_SLACK_CONNECTOR_ID is not defined');
+    }
+    const nango = new Nango({ secretKey: NANGO_SECRET_KEY });
+    const slackAccessToken = await nango.getToken(NANGO_SLACK_CONNECTOR_ID, nangoConnectionId);
+    const client = new WebClient(slackAccessToken);
+
+    const teamInfo = await client.team.info();
+    if (teamInfo.ok !== true) {
+      return new Err(new Error(`Could not get slack team info. Error message: ${teamInfo.error}`));
+    }
+    if (!teamInfo.team?.id) {
+      return new Err(new Error(`Could not get slack team id. Error message: ${teamInfo.error}`));
+    }
+
+    const slackConfig = await SlackConfiguration.create(
+      {
+        slackTeamId: teamInfo.team.id,
+      },
+      { transaction: t }
+    );
+
+    const connector = await Connector.create(
+      {
+        type: 'slack',
+        nangoConnectionId,
+        slackConfigurationId: slackConfig.id,
+        dustAPIKey: dustConfig.systemAPIKey,
+        dustWorkspaceId: dustConfig.workspaceId,
+        dustDataSourceId: dustConfig.dataSourceId,
+      },
+      { transaction: t }
+    );
+
+    return new Ok([connector, slackConfig]);
+  });
+
+  return new Ok(undefined);
+}

--- a/connectors/src/connectors/slack/init.ts
+++ b/connectors/src/connectors/slack/init.ts
@@ -1,8 +1,8 @@
-import { Connector, SlackConfiguration, sequelize_conn } from "@app/lib/models";
+import { Connector, sequelize_conn,SlackConfiguration } from "@app/lib/models";
 import { Err, Ok, Result } from "@app/lib/result";
+import { DataSourceConfig } from "@app/types/data_source_config";
 import { Nango } from "@nangohq/node";
 import { WebClient } from "@slack/web-api";
-import { DataSourceConfig } from "@app/types/data_source_config";
 export type NangoConnectionId = string;
 
 const { NANGO_SECRET_KEY, NANGO_SLACK_CONNECTOR_ID } = process.env;
@@ -48,12 +48,12 @@ export async function createSlackConnector(
           nangoConnectionId,
           workspaceAPIKey: dataSourceConfig.systemAPIKey,
           workspaceId: dataSourceConfig.workspaceId,
-          dataSourceId: dataSourceConfig.dataSourceId,
+          dataSourceName: dataSourceConfig.dataSourceName,
         },
         { transaction: t }
       );
 
-      const slackConfig = await SlackConfiguration.create(
+      await SlackConfiguration.create(
         {
           slackTeamId: teamInfo.team.id,
           connectorId: connector.id,

--- a/connectors/src/connectors/slack/init.ts
+++ b/connectors/src/connectors/slack/init.ts
@@ -10,9 +10,9 @@ const { NANGO_SECRET_KEY, NANGO_SLACK_CONNECTOR_ID } = process.env;
 export async function createSlackConnector(
   dataSourceConfig: DataSourceConfig,
   nangoConnectionId: NangoConnectionId
-): Promise<Result<void, Error>> {
-  await sequelize_conn.transaction(
-    async (t): Promise<Result<[Connector, SlackConfiguration], Error>> => {
+): Promise<Result<string, Error>> {
+  const res = await sequelize_conn.transaction(
+    async (t): Promise<Result<Connector, Error>> => {
       if (!NANGO_SECRET_KEY) {
         throw new Error("NANGO_SECRET_KEY is not defined");
       }
@@ -61,9 +61,13 @@ export async function createSlackConnector(
         { transaction: t }
       );
 
-      return new Ok([connector, slackConfig]);
+      return new Ok(connector);
     }
   );
 
-  return new Ok(undefined);
+  if (res.isErr()) {
+    return res;
+  }
+
+  return new Ok(res.value.id.toString());
 }

--- a/connectors/src/connectors/slack/init.ts
+++ b/connectors/src/connectors/slack/init.ts
@@ -1,56 +1,69 @@
-import { Connector, SlackConfiguration, sequelize_conn } from '@app/lib/models';
-import { Err, Ok, Result } from '@app/lib/result';
-import { Nango } from '@nangohq/node';
-import { WebClient } from '@slack/web-api';
-import { DustConfig } from '@app/types/dust_config';
+import { Connector, SlackConfiguration, sequelize_conn } from "@app/lib/models";
+import { Err, Ok, Result } from "@app/lib/result";
+import { Nango } from "@nangohq/node";
+import { WebClient } from "@slack/web-api";
+import { DataSourceConfig } from "@app/types/data_source_config";
 export type NangoConnectionId = string;
 
 const { NANGO_SECRET_KEY, NANGO_SLACK_CONNECTOR_ID } = process.env;
 
 export async function createSlackConnector(
-  dustConfig: DustConfig,
+  dataSourceConfig: DataSourceConfig,
   nangoConnectionId: NangoConnectionId
 ): Promise<Result<void, Error>> {
-  await sequelize_conn.transaction(async (t): Promise<Result<[Connector, SlackConfiguration], Error>> => {
-    if (!NANGO_SECRET_KEY) {
-      throw new Error('NANGO_SECRET_KEY is not defined');
-    }
-    if (!NANGO_SLACK_CONNECTOR_ID) {
-      throw new Error('NANGO_SLACK_CONNECTOR_ID is not defined');
-    }
-    const nango = new Nango({ secretKey: NANGO_SECRET_KEY });
-    const slackAccessToken = await nango.getToken(NANGO_SLACK_CONNECTOR_ID, nangoConnectionId);
-    const client = new WebClient(slackAccessToken);
+  await sequelize_conn.transaction(
+    async (t): Promise<Result<[Connector, SlackConfiguration], Error>> => {
+      if (!NANGO_SECRET_KEY) {
+        throw new Error("NANGO_SECRET_KEY is not defined");
+      }
+      if (!NANGO_SLACK_CONNECTOR_ID) {
+        throw new Error("NANGO_SLACK_CONNECTOR_ID is not defined");
+      }
+      const nango = new Nango({ secretKey: NANGO_SECRET_KEY });
+      const slackAccessToken = await nango.getToken(
+        NANGO_SLACK_CONNECTOR_ID,
+        nangoConnectionId
+      );
+      const client = new WebClient(slackAccessToken);
 
-    const teamInfo = await client.team.info();
-    if (teamInfo.ok !== true) {
-      return new Err(new Error(`Could not get slack team info. Error message: ${teamInfo.error}`));
+      const teamInfo = await client.team.info();
+      if (teamInfo.ok !== true) {
+        return new Err(
+          new Error(
+            `Could not get slack team info. Error message: ${teamInfo.error}`
+          )
+        );
+      }
+      if (!teamInfo.team?.id) {
+        return new Err(
+          new Error(
+            `Could not get slack team id. Error message: ${teamInfo.error}`
+          )
+        );
+      }
+
+      const connector = await Connector.create(
+        {
+          type: "slack",
+          nangoConnectionId,
+          workspaceAPIKey: dataSourceConfig.systemAPIKey,
+          workspaceId: dataSourceConfig.workspaceId,
+          dataSourceId: dataSourceConfig.dataSourceId,
+        },
+        { transaction: t }
+      );
+
+      const slackConfig = await SlackConfiguration.create(
+        {
+          slackTeamId: teamInfo.team.id,
+          connectorId: connector.id,
+        },
+        { transaction: t }
+      );
+
+      return new Ok([connector, slackConfig]);
     }
-    if (!teamInfo.team?.id) {
-      return new Err(new Error(`Could not get slack team id. Error message: ${teamInfo.error}`));
-    }
-
-    const slackConfig = await SlackConfiguration.create(
-      {
-        slackTeamId: teamInfo.team.id,
-      },
-      { transaction: t }
-    );
-
-    const connector = await Connector.create(
-      {
-        type: 'slack',
-        nangoConnectionId,
-        slackConfigurationId: slackConfig.id,
-        dustAPIKey: dustConfig.systemAPIKey,
-        dustWorkspaceId: dustConfig.workspaceId,
-        dustDataSourceId: dustConfig.dataSourceId,
-      },
-      { transaction: t }
-    );
-
-    return new Ok([connector, slackConfig]);
-  });
+  );
 
   return new Ok(undefined);
 }

--- a/connectors/src/init/db.ts
+++ b/connectors/src/init/db.ts
@@ -1,0 +1,17 @@
+import { Connector, SlackConfiguration } from '@app/lib/models';
+
+async function main() {
+await SlackConfiguration.sync({ alter: true });
+await Connector.sync({ alter: true });
+  
+  process.exit(0);
+}
+
+main()
+  .then(() => {
+    console.log('Done');
+  })
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/connectors/src/init/db.ts
+++ b/connectors/src/init/db.ts
@@ -1,15 +1,15 @@
-import { Connector, SlackConfiguration } from '@app/lib/models';
+import { Connector, SlackConfiguration } from "@app/lib/models";
 
 async function main() {
-await SlackConfiguration.sync({ alter: true });
-await Connector.sync({ alter: true });
-  
+  await Connector.sync({ alter: true });
+  await SlackConfiguration.sync({ alter: true });
+
   process.exit(0);
 }
 
 main()
   .then(() => {
-    console.log('Done');
+    console.log("Done");
   })
   .catch((err) => {
     console.error(err);

--- a/connectors/src/lib/models.ts
+++ b/connectors/src/lib/models.ts
@@ -6,61 +6,27 @@ import {
   InferCreationAttributes,
   Model,
   Sequelize,
-} from 'sequelize';
+} from "sequelize";
 
 const { CONNECTORS_DATABASE_URI } = process.env;
 
-export const sequelize_conn = new Sequelize(CONNECTORS_DATABASE_URI as string, {});
+export const sequelize_conn = new Sequelize(
+  CONNECTORS_DATABASE_URI as string,
+  {}
+);
 
-export class SlackConfiguration extends Model<
-  InferAttributes<SlackConfiguration>,
-  InferCreationAttributes<SlackConfiguration>
+export class Connector extends Model<
+  InferAttributes<Connector>,
+  InferCreationAttributes<Connector>
 > {
   declare id: CreationOptional<number>;
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
-  declare slackTeamId: string;
-}
-
-SlackConfiguration.init(
-  {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
-    createdAt: {
-      type: DataTypes.DATE,
-      allowNull: false,
-      defaultValue: DataTypes.NOW,
-    },
-    updatedAt: {
-      type: DataTypes.DATE,
-      allowNull: false,
-      defaultValue: DataTypes.NOW,
-    },
-    slackTeamId: {
-      type: DataTypes.STRING,
-      allowNull: false,
-    },
-  },
-  {
-    sequelize: sequelize_conn,
-    indexes: [{ fields: ['slackTeamId'] }],
-    modelName: 'slack_configurations',
-  }
-);
-
-export class Connector extends Model<InferAttributes<Connector>, InferCreationAttributes<Connector>> {
-  declare id: CreationOptional<number>;
-  declare createdAt: CreationOptional<Date>;
-  declare updatedAt: CreationOptional<Date>;
-  declare type: 'slack' | 'notion' | 'google';
+  declare type: "slack" | "notion" | "google";
   declare nangoConnectionId: string;
-  declare dustAPIKey: string;
-  declare dustWorkspaceId: string;
-  declare dustDataSourceId: string;
-  declare slackConfigurationId: ForeignKey<SlackConfiguration['id']>;
+  declare workspaceAPIKey: string;
+  declare workspaceId: string;
+  declare dataSourceId: string;
 }
 
 Connector.init(
@@ -88,23 +54,62 @@ Connector.init(
       type: DataTypes.STRING,
       allowNull: false,
     },
-    dustAPIKey: {
+    workspaceAPIKey: {
       type: DataTypes.STRING,
       allowNull: false,
     },
-    dustWorkspaceId: {
+    workspaceId: {
       type: DataTypes.STRING,
       allowNull: false,
     },
-    dustDataSourceId: {
+    dataSourceId: {
       type: DataTypes.STRING,
       allowNull: false,
     },
   },
   {
     sequelize: sequelize_conn,
-    modelName: 'connectors',
+    modelName: "connectors",
   }
 );
 
-SlackConfiguration.hasOne(Connector);
+export class SlackConfiguration extends Model<
+  InferAttributes<SlackConfiguration>,
+  InferCreationAttributes<SlackConfiguration>
+> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+  declare slackTeamId: string;
+  declare connectorId: ForeignKey<Connector["id"]>;
+}
+
+SlackConfiguration.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    slackTeamId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+  },
+  {
+    sequelize: sequelize_conn,
+    indexes: [{ fields: ["slackTeamId"] }, { fields: ["connectorId"] , unique: true}],
+    modelName: "slack_configurations",
+  }
+);
+Connector.hasOne(SlackConfiguration);

--- a/connectors/src/lib/models.ts
+++ b/connectors/src/lib/models.ts
@@ -1,0 +1,110 @@
+import {
+  CreationOptional,
+  DataTypes,
+  ForeignKey,
+  InferAttributes,
+  InferCreationAttributes,
+  Model,
+  Sequelize,
+} from 'sequelize';
+
+const { CONNECTORS_DATABASE_URI } = process.env;
+
+export const sequelize_conn = new Sequelize(CONNECTORS_DATABASE_URI as string, {});
+
+export class SlackConfiguration extends Model<
+  InferAttributes<SlackConfiguration>,
+  InferCreationAttributes<SlackConfiguration>
+> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+  declare slackTeamId: string;
+}
+
+SlackConfiguration.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    slackTeamId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+  },
+  {
+    sequelize: sequelize_conn,
+    indexes: [{ fields: ['slackTeamId'] }],
+    modelName: 'slack_configurations',
+  }
+);
+
+export class Connector extends Model<InferAttributes<Connector>, InferCreationAttributes<Connector>> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+  declare type: 'slack' | 'notion' | 'google';
+  declare nangoConnectionId: string;
+  declare dustAPIKey: string;
+  declare dustWorkspaceId: string;
+  declare dustDataSourceId: string;
+  declare slackConfigurationId: ForeignKey<SlackConfiguration['id']>;
+}
+
+Connector.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    type: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    nangoConnectionId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    dustAPIKey: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    dustWorkspaceId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    dustDataSourceId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+  },
+  {
+    sequelize: sequelize_conn,
+    modelName: 'connectors',
+  }
+);
+
+SlackConfiguration.hasOne(Connector);

--- a/connectors/src/lib/models.ts
+++ b/connectors/src/lib/models.ts
@@ -26,7 +26,7 @@ export class Connector extends Model<
   declare nangoConnectionId: string;
   declare workspaceAPIKey: string;
   declare workspaceId: string;
-  declare dataSourceId: string;
+  declare dataSourceName: string;
 }
 
 Connector.init(
@@ -62,7 +62,7 @@ Connector.init(
       type: DataTypes.STRING,
       allowNull: false,
     },
-    dataSourceId: {
+    dataSourceName: {
       type: DataTypes.STRING,
       allowNull: false,
     },

--- a/connectors/src/lib/result.ts
+++ b/connectors/src/lib/result.ts
@@ -1,0 +1,41 @@
+/**
+ * A Result is a type that can be either Ok or Err.
+ * The main motivation behind this utils is to overcome the fact that Javascript does not
+ * let you check the type of an object at runtime, so you cannot know if a function returned an error type
+ * or a success type.
+ *
+ * Usage:
+ * import {Result, Ok, Err} from "@app/lib/result"
+ * function divide(numerator: number, denominator: number) : Result<number, Error> {
+ *     if (denominator === 0) {
+ *        return new Err(new Error("Cannot divide by zero"));
+ *      }
+ *     return new Ok(numerator / denominator);
+ * }
+ */
+
+export class Ok<T> {
+  constructor(public value: T) {}
+
+  isOk(): this is Ok<T> {
+    return true;
+  }
+
+  isErr(): this is Err<never> {
+    return false;
+  }
+}
+
+export class Err<E> {
+  constructor(public error: E) {}
+
+  isOk(): this is Ok<never> {
+    return false;
+  }
+
+  isErr(): this is Err<E> {
+    return true;
+  }
+}
+
+export type Result<T, E> = Ok<T> | Err<E>;

--- a/connectors/src/types/data_source_config.ts
+++ b/connectors/src/types/data_source_config.ts
@@ -2,5 +2,4 @@ export interface DataSourceConfig {
   systemAPIKey: string;
   workspaceId: string;
   dataSourceName: string;
-  dataSourceId: string;
 }

--- a/connectors/src/types/data_source_config.ts
+++ b/connectors/src/types/data_source_config.ts
@@ -1,4 +1,4 @@
-export interface DustConfig {
+export interface DataSourceConfig {
   systemAPIKey: string;
   workspaceId: string;
   dataSourceName: string;

--- a/connectors/src/types/dust_config.ts
+++ b/connectors/src/types/dust_config.ts
@@ -1,0 +1,6 @@
+export interface DustConfig {
+  systemAPIKey: string;
+  workspaceId: string;
+  dataSourceName: string;
+  dataSourceId: string;
+}


### PR DESCRIPTION
This PR adds the`Connector` model to `/connectors` and provide a function to create a Slack connector as an "example".
Here is how front would call it:
```
import { createSlackConnector } from '@app/connectors/slack/init'

async function main() {
  await createSlackConnector(
    {
      systemAPIKey: 'secret-key',
      workspaceId: '123',
      dataSourceName: 'MySuperSlackDataSource',
      dataSourceId: '456',
    },
    'slack-managed-ds-1'
  );
}

main()
  .then((result) => {console.log(result)})
  .catch((err) => {console.error(err)});

```

We also use the lib/result.ts that was duplicated from `/front`.