### PR TITLE
fix: bug when deleting a data source with > 1 doc on SQLITE

### DIFF
--- a/core/src/stores/sqlite.rs
+++ b/core/src/stores/sqlite.rs
@@ -1325,22 +1325,10 @@ impl Store for SQLiteStore {
             {
                 let mut stmt =
                     tx.prepare_cached("DELETE FROM data_sources_documents WHERE data_source = ?1")?;
-                match stmt.insert(params![data_source_row_id]) {
-                    Ok(_) => {}
-                    Err(e) => match e {
-                        rusqlite::Error::StatementChangedRows(0) => {}
-                        _ => Err(e)?,
-                    },
-                }
+                stmt.execute(params![data_source_row_id])?;
 
                 let mut stmt = tx.prepare_cached("DELETE FROM data_sources WHERE id = ?1")?;
-                match stmt.insert(params![data_source_row_id]) {
-                    Ok(_) => {}
-                    Err(e) => match e {
-                        rusqlite::Error::StatementChangedRows(0) => {}
-                        _ => Err(e)?,
-                    },
-                }
+                stmt.execute(params![data_source_row_id])?;
             }
             tx.commit()?;
             Ok(())


### PR DESCRIPTION
rusqlite's `insert` is a wrapper around `execute` that errors if the number of affected rows != 1.
this prevented deleting a DS that has > 1 doc.

