### PR TITLE
Better reporting of errors at upsert in the UI

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -79,6 +79,7 @@
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-deprecation": "^1.2.1",
+        "eslint-plugin-simple-import-sort": "^10.0.0",
         "nodemon": "^2.0.12",
         "prettier": "^2.3.2",
         "ts-node": "^10.8.1",

--- a/front/pages/api/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
@@ -3,11 +3,11 @@ import { NextApiRequest, NextApiResponse } from "next";
 import { getDataSource } from "@app/lib/api/data_sources";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { DustAPI } from "@app/lib/dust_api";
+import { APIError } from "@app/lib/error";
 import { Provider } from "@app/lib/models";
 import { credentialsFromProviders } from "@app/lib/providers";
 import { withLogging } from "@app/logger/withlogging";
 import { DocumentType } from "@app/types/document";
-import { APIError } from "@app/lib/error";
 
 export type GetDocumentResponseBody = {
   document: DocumentType;

--- a/front/pages/w/[wId]/ds/[name]/upsert.tsx
+++ b/front/pages/w/[wId]/ds/[name]/upsert.tsx
@@ -142,7 +142,15 @@ export default function DataSourceUpsert({
         }),
       }
     );
-    router.push(`/w/${owner.sId}/ds/${dataSource.name}`);
+
+    if (res.ok) {
+      router.push(`/w/${owner.sId}/ds/${dataSource.name}`);
+    } else {
+      let data = await res.json();
+      console.log("UPSERT Error", data.error);
+      window.alert(`Error upserting document: ${data.error.message}`);
+      setLoading(false);
+    }
   };
 
   const handleTagUpdate = (index: number, value: string) => {


### PR DESCRIPTION
We have had reports of users not able to upsert documents, but our error reporting is bad there.

This PR adds APIError to the internal API upsert route and display the error message to the user and logs in the console the full error object including the error that comes from Rust.

We probably want to move to returning APIError everywhere in the app but we can do so progressively.