### PR TITLE
Catch and report unhandled errors

### DIFF
--- a/front/lib/error.ts
+++ b/front/lib/error.ts
@@ -9,10 +9,10 @@ export type InternalErrorWithStatusCode = {
 };
 
 export type APIErrorType =
+  | "internal_server_error"
   | "missing_authorization_header_error"
   | "malformed_authorization_header_error"
   | "invalid_api_key_error"
-  | "internal_server_error"
   | "data_source_not_found"
   | "invalid_request_error"
   | "data_source_error"


### PR DESCRIPTION
If eg the core API goes down we can now see it in Datadog