### PR TITLE
Catch and properly report run poll errors

### DIFF
--- a/front/pages/api/v1/w/[wId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/v1/w/[wId]/apps/[aId]/runs/index.ts
@@ -40,16 +40,6 @@ const poll = async ({
   let attempts = 0;
 
   const executePoll = async (resolve: any, reject: any) => {
-    logger.info(
-      {
-        attempts,
-        maxAttempts,
-        interval,
-        increment,
-        maxInterval,
-      },
-      "Executing poll"
-    );
     let result = null;
     try {
       result = await fn();


### PR DESCRIPTION
This prevents `unhandled_internal_server_error` (which are expected to be critical) when the simply fails because the run is too long to complete when `blocking=true`. Also cleans up the log we added a week ago.