### PR TITLE
revert feature: also revert the input block config

### DIFF
--- a/front/pages/w/[wId]/a/[aId]/runs/[runId]/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/runs/[runId]/index.tsx
@@ -93,6 +93,18 @@ export default function AppRun({
 
     setIsLoading(true);
 
+    const inputBlockConfigEntry = Object.entries(run.config.blocks).find(
+      ([_name, value]) => value.type === "input"
+    );
+    if (inputBlockConfigEntry) {
+      const [_inputBlockName, inputBlockConfig] = inputBlockConfigEntry;
+      for (const block of spec) {
+        if (block.type === "input") {
+          block.config = inputBlockConfig;
+        }
+      }
+    }
+
     await fetch(`/api/w/${owner.sId}/apps/${app.sId}/state`, {
       method: "POST",
       headers: {


### PR DESCRIPTION
Input block config is getting lost when using the revert feature (it is not the case for other block types that have config, such as LLM).
This changes updates the spec to fill-in the input block config before reverting the app.