### PR TITLE
Remove `js_sandbox` and integrate directly to Deno

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -829,13 +829,13 @@ dependencies = [
 
 [[package]]
 name = "deno_core"
-version = "0.179.0"
+version = "0.181.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9307ca2299cb7b0bdaa345cbdc82a252a8e4e5a4463e28f44c715d55e460fb"
+checksum = "e6d512a601e07e65440e481523326439425cc1c614b7c346abe2ffa2575a3468"
 dependencies = [
  "anyhow",
  "bytes",
- "deno_ops 0.57.0",
+ "deno_ops 0.59.0",
  "futures",
  "indexmap",
  "libc",
@@ -845,7 +845,7 @@ dependencies = [
  "pin-project",
  "serde",
  "serde_json",
- "serde_v8 0.90.0",
+ "serde_v8 0.92.0",
  "smallvec",
  "sourcemap",
  "url",
@@ -869,10 +869,11 @@ dependencies = [
 
 [[package]]
 name = "deno_ops"
-version = "0.57.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04610f07342fbb33a2b7ea7aa16a95ab71adb13a0ce858a8d1a1414660a83e3e"
+checksum = "8724e792ab5e493902fb31d1ae8b5e93a1b471d52da5d3bfa18f51a1cbe9809a"
 dependencies = [
+ "lazy-regex",
  "once_cell",
  "pmutil",
  "proc-macro-crate",
@@ -969,7 +970,7 @@ dependencies = [
  "clap",
  "cloud-storage",
  "colored",
- "deno_core 0.179.0",
+ "deno_core 0.181.0",
  "dns-lookup",
  "eventsource-client",
  "fancy-regex",
@@ -1697,6 +1698,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
 dependencies = [
  "log",
+]
+
+[[package]]
+name = "lazy-regex"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff63c423c68ea6814b7da9e88ce585f793c87ddd9e78f646970891769c8235d4"
+dependencies = [
+ "lazy-regex-proc_macros",
+ "once_cell",
+ "regex",
+]
+
+[[package]]
+name = "lazy-regex-proc_macros"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8edfc11b8f56ce85e207e62ea21557cfa09bb24a8f6b04ae181b086ff8611c22"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2834,9 +2858,9 @@ dependencies = [
 
 [[package]]
 name = "serde_v8"
-version = "0.90.0"
+version = "0.92.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916ca7852a4c5f0ba59ce4a46301bf7c7ad573c2c89a0fe67e90fe30dcbd6f7d"
+checksum = "57d2fb8b104d897bb6f58e65f6512b7d7c95b70b589649bc9e19333defbb1a4e"
 dependencies = [
  "bytes",
  "derive_more",
@@ -2844,6 +2868,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "smallvec",
+ "thiserror",
  "v8",
 ]
 
@@ -3060,22 +3085,22 @@ checksum = "b7b3e525a49ec206798b40326a44121291b530c963cfb01018f63e135bac543d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.40"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.40"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.8",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -389,7 +389,7 @@ dependencies = [
  "async-trait",
  "futures-channel",
  "futures-util",
- "parking_lot 0.12.1",
+ "parking_lot",
  "tokio",
 ]
 
@@ -675,6 +675,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13418e745008f7349ec7e449155f419a61b92b58a99cc3616942b926825ec76b"
 
 [[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -791,24 +797,102 @@ dependencies = [
 ]
 
 [[package]]
-name = "deno_core"
-version = "0.114.0"
+name = "data-encoding"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8ddd27161918d0d0cc44ee5ff3b817b4c87e868922d63ee026f3e7c24f36131"
+checksum = "23d8666cb01533c39dde32bcbab8e227b4ed6679b2c925eba05feabea39508fb"
+
+[[package]]
+name = "deno_core"
+version = "0.178.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d58bd9e43979857fd26f4696f8e9f39fb645539ef3e604264521b408daf1d92b"
 dependencies = [
  "anyhow",
+ "bytes",
+ "deno_ops 0.56.0",
  "futures",
  "indexmap",
  "libc",
  "log",
  "once_cell",
- "parking_lot 0.11.2",
+ "parking_lot",
  "pin-project",
  "serde",
  "serde_json",
- "serde_v8",
+ "serde_v8 0.89.0",
+ "smallvec",
+ "sourcemap",
  "url",
  "v8",
+]
+
+[[package]]
+name = "deno_core"
+version = "0.179.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9307ca2299cb7b0bdaa345cbdc82a252a8e4e5a4463e28f44c715d55e460fb"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "deno_ops 0.57.0",
+ "futures",
+ "indexmap",
+ "libc",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "serde_v8 0.90.0",
+ "smallvec",
+ "sourcemap",
+ "url",
+ "v8",
+]
+
+[[package]]
+name = "deno_ops"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f494a90671467e3de74b557b3c1fe805aad87c7239580d2be8f2dddde971824"
+dependencies = [
+ "once_cell",
+ "pmutil",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "deno_ops"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04610f07342fbb33a2b7ea7aa16a95ab71adb13a0ce858a8d1a1414660a83e3e"
+dependencies = [
+ "once_cell",
+ "pmutil",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_more"
+version = "0.99.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version 0.4.0",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -885,6 +969,7 @@ dependencies = [
  "clap",
  "cloud-storage",
  "colored",
+ "deno_core 0.179.0",
  "dns-lookup",
  "eventsource-client",
  "fancy-regex",
@@ -894,7 +979,7 @@ dependencies = [
  "itertools",
  "js-sandbox",
  "lazy_static",
- "parking_lot 0.12.1",
+ "parking_lot",
  "pest",
  "pest_derive",
  "qdrant-client",
@@ -1467,6 +1552,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "if_chain"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb56e1aa765b4b4f3aadfab769793b7087bb03a4ea4920644a6d238e2df5b9ed"
+
+[[package]]
 name = "ignore"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1555,11 +1646,11 @@ dependencies = [
 
 [[package]]
 name = "js-sandbox"
-version = "0.2.0-rc.0"
+version = "0.2.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23703227a796151063b14e733acfa83d79c09a755159296a59bfa5eebafbf4ce"
+checksum = "0931d68d496d96cbfbdff2c8325e59d361d0b5b2f7b4c8bf6f7412a35e096c93"
 dependencies = [
- "deno_core",
+ "deno_core 0.178.0",
  "js-sandbox-macros",
  "serde",
  "serde_json",
@@ -1567,13 +1658,13 @@ dependencies = [
 
 [[package]]
 name = "js-sandbox-macros"
-version = "0.2.0-rc.0"
+version = "0.2.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8ec78dc63c615a7829c096f5c5ff7395331574ea26290821f8321ec8725aef"
+checksum = "e0445474069bad4c2b01856976d83c796521ae9298ba718ecf26041767eb68b2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.8",
 ]
 
 [[package]]
@@ -1787,6 +1878,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+ "rand",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1817,9 +1920,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.9.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "openssl"
@@ -1880,37 +1983,12 @@ checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.6",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.7",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
-dependencies = [
- "cfg-if",
- "instant",
- "libc",
- "redox_syscall",
- "smallvec",
- "winapi",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -2102,6 +2180,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
+name = "pmutil"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3894e5d549cccbe44afecf72922f277f603cd4bb0219c8342631ef18fffbe004"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "polling"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2160,6 +2249,16 @@ checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
 dependencies = [
  "proc-macro2",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+dependencies = [
+ "once_cell",
+ "toml_edit",
 ]
 
 [[package]]
@@ -2280,7 +2379,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51de85fb3fb6524929c8a2eb85e6b6d363de4e8c48f9e2c2eac4944abc181c93"
 dependencies = [
  "log",
- "parking_lot 0.12.1",
+ "parking_lot",
  "scheduled-thread-pool",
 ]
 
@@ -2447,6 +2546,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver 0.9.0",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver 1.0.17",
+]
+
+[[package]]
 name = "rustix"
 version = "0.36.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2568,7 +2685,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
 dependencies = [
- "parking_lot 0.12.1",
+ "parking_lot",
 ]
 
 [[package]]
@@ -2627,6 +2744,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+
+[[package]]
 name = "serde"
 version = "1.0.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2681,12 +2819,31 @@ dependencies = [
 
 [[package]]
 name = "serde_v8"
-version = "0.25.0"
+version = "0.89.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f393dfbff517625ec0d87f449c8778f5645ebff9408f70988cf9a9ac33525934"
+checksum = "9541cff99b1b9da15461aada44f09577af1f614add71f2fedc250c7e650a0383"
 dependencies = [
+ "bytes",
+ "derive_more",
+ "num-bigint 0.4.3",
  "serde",
  "serde_bytes",
+ "smallvec",
+ "v8",
+]
+
+[[package]]
+name = "serde_v8"
+version = "0.90.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "916ca7852a4c5f0ba59ce4a46301bf7c7ad573c2c89a0fe67e90fe30dcbd6f7d"
+dependencies = [
+ "bytes",
+ "derive_more",
+ "num-bigint 0.4.3",
+ "serde",
+ "serde_bytes",
+ "smallvec",
  "v8",
 ]
 
@@ -2735,7 +2892,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692ca13de57ce0613a363c8c2f1de925adebc81b04c923ac60c5488bb44abe4b"
 dependencies = [
  "chrono",
- "num-bigint",
+ "num-bigint 0.2.6",
  "num-traits",
 ]
 
@@ -2777,6 +2934,21 @@ checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "sourcemap"
+version = "6.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed16231c92d0a6f0388f56e0ab2be24ecff1173f8e22f0ea5e074d0525631cb"
+dependencies = [
+ "data-encoding",
+ "if_chain",
+ "rustc_version 0.2.3",
+ "serde",
+ "serde_json",
+ "unicode-id",
+ "url",
 ]
 
 [[package]]
@@ -2953,7 +3125,7 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
- "parking_lot 0.12.1",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -3005,7 +3177,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "log",
- "parking_lot 0.12.1",
+ "parking_lot",
  "percent-encoding",
  "phf 0.11.1",
  "pin-project-lite",
@@ -3061,6 +3233,23 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+
+[[package]]
+name = "toml_edit"
+version = "0.19.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "239410c8609e8125456927e6707163a3b1fdb40561e4b803bc041f466ccfdc13"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -3358,6 +3547,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
+name = "unicode-id"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d70b6494226b36008c8366c288d77190b3fad2eb4c10533139c1c1f461127f1a"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3413,14 +3608,13 @@ dependencies = [
 
 [[package]]
 name = "v8"
-version = "0.36.0"
+version = "0.68.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "506523e86ccc15982be412bdde87a142771c139e94a8ecedda1da051a079b81d"
+checksum = "81c69410b7435f1b74e82e243ba906d71e8b9bb350828291418b9311dbd77222"
 dependencies = [
  "bitflags",
  "fslock",
  "lazy_static",
- "libc",
  "which",
 ]
 
@@ -3730,6 +3924,15 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "winnow"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae8970b36c66498d8ff1d66685dc86b91b29db0c7739899012f63a63814b4b28"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winreg"

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -804,38 +804,13 @@ checksum = "23d8666cb01533c39dde32bcbab8e227b4ed6679b2c925eba05feabea39508fb"
 
 [[package]]
 name = "deno_core"
-version = "0.178.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d58bd9e43979857fd26f4696f8e9f39fb645539ef3e604264521b408daf1d92b"
-dependencies = [
- "anyhow",
- "bytes",
- "deno_ops 0.56.0",
- "futures",
- "indexmap",
- "libc",
- "log",
- "once_cell",
- "parking_lot",
- "pin-project",
- "serde",
- "serde_json",
- "serde_v8 0.89.0",
- "smallvec",
- "sourcemap",
- "url",
- "v8",
-]
-
-[[package]]
-name = "deno_core"
 version = "0.181.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d512a601e07e65440e481523326439425cc1c614b7c346abe2ffa2575a3468"
 dependencies = [
  "anyhow",
  "bytes",
- "deno_ops 0.59.0",
+ "deno_ops",
  "futures",
  "indexmap",
  "libc",
@@ -845,26 +820,11 @@ dependencies = [
  "pin-project",
  "serde",
  "serde_json",
- "serde_v8 0.92.0",
+ "serde_v8",
  "smallvec",
  "sourcemap",
  "url",
  "v8",
-]
-
-[[package]]
-name = "deno_ops"
-version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f494a90671467e3de74b557b3c1fe805aad87c7239580d2be8f2dddde971824"
-dependencies = [
- "once_cell",
- "pmutil",
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "regex",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -970,7 +930,7 @@ dependencies = [
  "clap",
  "cloud-storage",
  "colored",
- "deno_core 0.181.0",
+ "deno_core",
  "dns-lookup",
  "eventsource-client",
  "fancy-regex",
@@ -978,7 +938,6 @@ dependencies = [
  "hyper",
  "hyper-tls",
  "itertools",
- "js-sandbox",
  "lazy_static",
  "parking_lot",
  "pest",
@@ -1643,29 +1602,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "js-sandbox"
-version = "0.2.0-rc.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0931d68d496d96cbfbdff2c8325e59d361d0b5b2f7b4c8bf6f7412a35e096c93"
-dependencies = [
- "deno_core 0.178.0",
- "js-sandbox-macros",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "js-sandbox-macros"
-version = "0.2.0-rc.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0445474069bad4c2b01856976d83c796521ae9298ba718ecf26041767eb68b2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.8",
 ]
 
 [[package]]
@@ -2839,21 +2775,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_v8"
-version = "0.89.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9541cff99b1b9da15461aada44f09577af1f614add71f2fedc250c7e650a0383"
-dependencies = [
- "bytes",
- "derive_more",
- "num-bigint 0.4.3",
- "serde",
- "serde_bytes",
- "smallvec",
- "v8",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -58,4 +58,4 @@ qdrant-client = "1.0"
 tower-http = {version = "0.4", features = ["full"]}
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-deno_core = "0.179"
+deno_core = "0.181"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -55,6 +55,7 @@ bstr = "0.2"
 base64 = "0.21"
 cloud-storage = { version = "0.11", features = ["global-client"] }
 qdrant-client = "1.0"
-tower-http = {version = "0.4.0", features = ["full"]}
+tower-http = {version = "0.4", features = ["full"]}
 tracing = "0.1"
-tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+deno_core = "0.179"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -17,7 +17,6 @@ serde = { version = "1.0", features = ["rc", "derive"] }
 serde_json = "1.0"
 pest = "2.0"
 pest_derive = "2.0"
-js-sandbox = "0.2.0-rc.0"
 clap = { version = "3.2", features = ["derive"] }
 colored = "2.0"
 shellexpand = "2.1"

--- a/core/src/blocks/chat.rs
+++ b/core/src/blocks/chat.rs
@@ -1,10 +1,10 @@
 use crate::blocks::block::{parse_pair, replace_variables_in_string, Block, BlockType, Env};
+use crate::deno::script::Script;
 use crate::providers::llm::{ChatMessage, ChatMessageRole, LLMChatRequest};
 use crate::providers::provider::ProviderID;
 use crate::Rule;
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
-use js_sandbox::Script;
 use pest::iterators::Pair;
 use serde::Serialize;
 use serde_json::{json, Value};
@@ -254,7 +254,7 @@ impl Block for Chat {
         let messages_value: Value = match tokio::task::spawn_blocking(move || {
             let mut script = Script::from_string(messages_code.as_str())?
                 .with_timeout(std::time::Duration::from_secs(10));
-            script.call("_fun", (&e,))
+            script.call("_fun", &e)
         })
         .await?
         {

--- a/core/src/blocks/code.rs
+++ b/core/src/blocks/code.rs
@@ -2,7 +2,8 @@ use crate::blocks::block::{parse_pair, Block, BlockType, Env};
 use crate::Rule;
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
-use js_sandbox::Script;
+//use js_sandbox::Script;
+use crate::deno::script::Script;
 use pest::iterators::Pair;
 use serde_json::Value;
 use tokio::sync::mpsc::UnboundedSender;
@@ -66,7 +67,7 @@ impl Block for Code {
         let result = tokio::task::spawn_blocking(move || {
             let mut script = Script::from_string(code.as_str())?
                 .with_timeout(std::time::Duration::from_secs(10));
-            script.call("_fun", (&env,))
+            script.call("_fun", &env)
         })
         .await??;
 

--- a/core/src/blocks/code.rs
+++ b/core/src/blocks/code.rs
@@ -1,9 +1,8 @@
 use crate::blocks::block::{parse_pair, Block, BlockType, Env};
+use crate::deno::script::Script;
 use crate::Rule;
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
-//use js_sandbox::Script;
-use crate::deno::script::Script;
 use pest::iterators::Pair;
 use serde_json::Value;
 use tokio::sync::mpsc::UnboundedSender;

--- a/core/src/blocks/curl.rs
+++ b/core/src/blocks/curl.rs
@@ -1,9 +1,9 @@
 use crate::blocks::block::{parse_pair, replace_variables_in_string, Block, BlockType, Env};
+use crate::deno::script::Script;
 use crate::http::request::HttpRequest;
 use crate::Rule;
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
-use js_sandbox::Script;
 use pest::iterators::Pair;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -115,7 +115,7 @@ impl Block for Curl {
         let headers_value: Value = match tokio::task::spawn_blocking(move || {
             let mut script = Script::from_string(headers_code.as_str())?
                 .with_timeout(std::time::Duration::from_secs(10));
-            script.call("_fun", (&e,))
+            script.call("_fun", &e)
         })
         .await?
         {
@@ -128,7 +128,7 @@ impl Block for Curl {
         let body_value: Value = match tokio::task::spawn_blocking(move || {
             let mut script = Script::from_string(body_code.as_str())?
                 .with_timeout(std::time::Duration::from_secs(10));
-            script.call("_fun", (&e,))
+            script.call("_fun", &e)
         })
         .await?
         {

--- a/core/src/blocks/while.rs
+++ b/core/src/blocks/while.rs
@@ -1,8 +1,8 @@
 use crate::blocks::block::{parse_pair, Block, BlockType, Env};
+use crate::deno::script::Script;
 use crate::Rule;
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
-use js_sandbox::Script;
 use pest::iterators::Pair;
 use serde_json::Value;
 use tokio::sync::mpsc::UnboundedSender;
@@ -101,7 +101,7 @@ impl Block for While {
         let condition_value: Value = match tokio::task::spawn_blocking(move || {
             let mut script = Script::from_string(condition_code.as_str())?
                 .with_timeout(std::time::Duration::from_secs(10));
-            script.call("_fun", (&e,))
+            script.call("_fun", &e)
         })
         .await?
         {

--- a/core/src/deno/script.rs
+++ b/core/src/deno/script.rs
@@ -1,0 +1,142 @@
+use anyhow::Result;
+use deno_core::{op, Extension, JsRuntime, OpState, ZeroCopyBuf};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use std::borrow::Cow;
+use std::rc::Rc;
+use std::{thread, time::Duration};
+
+pub struct Script {
+    runtime: JsRuntime,
+    last_rid: u32,
+    timeout: Option<Duration>,
+}
+
+impl Script {
+    const DEFAULT_FILENAME: &'static str = "code_block.js";
+
+    pub fn from_string(js_code: &str) -> Result<Self> {
+        // console.log() is not available by default -- add the most basic version with single argument (and no warn/info/... variants)
+        let all_code =
+            "const console = { log: function(expr) { Deno.core.print(expr + '\\n', false); } };"
+                .to_string()
+                + js_code;
+
+        Self::create_script(all_code)
+    }
+
+    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+        assert!(self.timeout.is_none());
+        assert!(timeout > Duration::ZERO);
+
+        self.timeout = Some(timeout);
+        self
+    }
+
+    fn create_script(js_code: String) -> Result<Self> {
+        let ext = Extension::builder("script")
+            .ops(vec![(op_return::decl())])
+            .build();
+
+        let mut runtime = JsRuntime::new(deno_core::RuntimeOptions {
+            module_loader: Some(Rc::new(deno_core::FsModuleLoader)),
+            extensions: vec![ext],
+            ..Default::default()
+        });
+
+        // We cannot provide a dynamic filename because execute_script() requires a &'static str
+        runtime.execute_script(Self::DEFAULT_FILENAME, js_code)?;
+
+        Ok(Script {
+            runtime,
+            last_rid: 0,
+            timeout: None,
+        })
+    }
+
+    pub fn call<A, R>(&mut self, fn_name: &str, arg: A) -> Result<R>
+    where
+        A: Serialize,
+        R: DeserializeOwned,
+    {
+        let json_arg = serde_json::to_value(arg)?.to_string();
+        let json_result = self.call_impl(fn_name, json_arg)?;
+        let result: R = serde_json::from_value(json_result)?;
+
+        Ok(result)
+    }
+
+    fn call_impl(&mut self, fn_name: &str, json_args: String) -> Result<serde_json::Value> {
+        // Note: ops() is required to initialize internal state
+        // Wrap everything in scoped block
+
+        // 'undefined' will cause JSON serialization error, so it needs to be treated as null
+        let js_code = format!(
+            "(async () => {{
+				let __rust_result = {fn_name}.constructor.name === 'AsyncFunction'
+					? await {fn_name}({json_args})
+					: {fn_name}({json_args});
+
+				if (typeof __rust_result === 'undefined')
+					__rust_result = null;
+
+				Deno.core.ops.op_return(__rust_result);
+			}})()"
+        );
+
+        if let Some(timeout) = self.timeout {
+            let handle = self.runtime.v8_isolate().thread_safe_handle();
+
+            thread::spawn(move || {
+                thread::sleep(timeout);
+                handle.terminate_execution();
+            });
+        }
+
+        // syncing ops is required cause they sometimes change while preparing the engine
+        // self.runtime.sync_ops_cache();
+
+        // TODO use strongly typed JsError here (downcast)
+        self.runtime
+            .execute_script(Self::DEFAULT_FILENAME, js_code)?;
+        deno_core::futures::executor::block_on(self.runtime.run_event_loop(false))?;
+
+        let state_rc = self.runtime.op_state();
+        let mut state = state_rc.borrow_mut();
+        let table = &mut state.resource_table;
+
+        // Get resource, and free slot (no longer needed)
+        let entry: Rc<ResultResource> = table
+            .take(self.last_rid)
+            .expect("Resource entry must be present");
+        let extracted =
+            Rc::try_unwrap(entry).expect("Rc must hold single strong ref to resource entry");
+        self.last_rid += 1;
+
+        Ok(extracted.json_value)
+    }
+}
+
+#[derive(Debug)]
+struct ResultResource {
+    json_value: serde_json::Value,
+}
+
+// Type that is stored inside Deno's resource table
+impl deno_core::Resource for ResultResource {
+    fn name(&self) -> Cow<str> {
+        "__rust_Result".into()
+    }
+}
+
+#[op]
+fn op_return(
+    state: &mut OpState,
+    args: serde_json::Value,
+    _buf: Option<ZeroCopyBuf>,
+) -> Result<serde_json::Value, deno_core::error::AnyError> {
+    let entry = ResultResource { json_value: args };
+    let resource_table = &mut state.resource_table;
+    let _rid = resource_table.add(entry);
+    Ok(serde_json::Value::Null)
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -52,3 +52,7 @@ pub mod blocks {
     pub mod search;
     pub mod r#while;
 }
+
+pub mod deno {
+    pub mod script;
+}


### PR DESCRIPTION
Allows us to bump `deno_core` which in turns resolved the GC OOM problem

(was able to reproduce locally with current `main` on my machine with 64 concurrent API calls to an app similar to the team's app. Was able to scale up to 512 parallel calls post this PR without issue).

This will also open the path to exposing a `dust.run` function in code blocks (as well as potentially enabling `fetch`).