### PR TITLE
Automated `core` restart

### DIFF
--- a/core/start.sh
+++ b/core/start.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+export $(cat _core.env.local | xargs)
+
+until cargo run --release --bin dust-api
+do
+    echo "[DUST-CORE-CRASH] Restarting dust-api in 1 second..."
+    sleep 1
+done


### PR DESCRIPTION
New deploy command:
```
./start 2>&1 | tee /var/log/datadog/dust_core.log
```