### PR TITLE
UI for managed DS

### DIFF
--- a/connectors/src/api/syncStatus.ts
+++ b/connectors/src/api/syncStatus.ts
@@ -36,7 +36,7 @@ const _getConnectorStatusAPIHandler = async (
       });
     }
     return res.status(200).send({
-      lastSyncStatus: "failed",
+      lastSyncStatus: connector.lastSyncStatus,
       lastSyncStartTime: connector.lastSyncStartTime?.getTime(),
       lastSuccessfulSyncTime: connector.lastSyncSuccessfulTime?.getTime(),
     });

--- a/connectors/src/api/syncStatus.ts
+++ b/connectors/src/api/syncStatus.ts
@@ -36,7 +36,7 @@ const _getConnectorStatusAPIHandler = async (
       });
     }
     return res.status(200).send({
-      lastSyncStatus: connector.lastSyncStatus,
+      lastSyncStatus: "failed",
       lastSyncStartTime: connector.lastSyncStartTime?.getTime(),
       lastSuccessfulSyncTime: connector.lastSyncSuccessfulTime?.getTime(),
     });

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -7,6 +7,7 @@
       "dependencies": {
         "@headlessui/react": "^1.7.7",
         "@heroicons/react": "^2.0.11",
+        "@nangohq/frontend": "^0.15.0",
         "@sendgrid/mail": "^7.7.0",
         "@tailwindcss/forms": "^0.5.3",
         "@uiw/react-textarea-code-editor": "^2.0.6",
@@ -1963,6 +1964,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/@nangohq/frontend": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@nangohq/frontend/-/frontend-0.15.0.tgz",
+      "integrity": "sha512-pAmLA+FbxQcwx90MB8dHUF7NmQGM+ifSWvwUo7Jn8WKyqpdj2BQ1nHKD3g0OIstOF48b3NpfDcGlp8x1Xg2ivQ==",
+      "hasInstallScript": true
     },
     "node_modules/@next/env": {
       "version": "13.2.4",

--- a/front/package.json
+++ b/front/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@headlessui/react": "^1.7.7",
     "@heroicons/react": "^2.0.11",
+    "@nangohq/frontend": "^0.15.0",
     "@sendgrid/mail": "^7.7.0",
     "@tailwindcss/forms": "^0.5.3",
     "@uiw/react-textarea-code-editor": "^2.0.6",

--- a/front/pages/api/w/[wId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/index.ts
@@ -80,6 +80,16 @@ async function handler(
         });
       }
 
+      if (req.body.name.startsWith("managed-")) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "The data source name cannot start with `managed-`.",
+          },
+        });
+      }
+
       // Enforce plan limits: DataSources count.
       if (
         owner.plan.limits.dataSources.count != -1 &&

--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -52,12 +52,6 @@ async function handler(
         });
       }
 
-      const dataSourceName = "managed-slack";
-      const dataSourceDescription = "Managed Data Source for Slack";
-      const dataSourceProviderId = "openai";
-      const dataSourceModelId = "text-embedding-ada-002";
-      const dataSourceMaxChunkSize = 256;
-
       if (
         !req.body ||
         typeof req.body.nangoConnectionId !== "string" ||
@@ -74,6 +68,12 @@ async function handler(
       }
 
       const provider = req.body.provider as ConnectorProvider;
+
+      const dataSourceName = `managed-${provider}`;
+      const dataSourceDescription = `Managed Data Source for ${provider}`;
+      const dataSourceProviderId = "openai";
+      const dataSourceModelId = "text-embedding-ada-002";
+      const dataSourceMaxChunkSize = 256;
 
       // Enforce plan limits: managed DataSources.
       if (!owner.plan.limits.dataSources.managed) {
@@ -107,7 +107,7 @@ async function handler(
 
       const connectorsRes = await ConnectorsAPI.createConnector(
         provider,
-        owner.id.toString(),
+        owner.sId.toString(),
         systemAPIKeyRes.value.secret,
         dataSourceName,
         req.body.nangoConnectionId

--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -107,7 +107,7 @@ async function handler(
 
       const connectorsRes = await ConnectorsAPI.createConnector(
         provider,
-        owner.sId.toString(),
+        owner.sId,
         systemAPIKeyRes.value.secret,
         dataSourceName,
         req.body.nangoConnectionId

--- a/front/pages/w/[wId]/ds/[name]/settings.tsx
+++ b/front/pages/w/[wId]/ds/[name]/settings.tsx
@@ -172,8 +172,8 @@ export default function DataSourceSettings({
                           name="name"
                           id="dataSourceName"
                           className={classNames(
-                            "block w-full min-w-0 flex-1 rounded-none rounded-r-md text-sm",
-                            "border-gray-300 focus:border-violet-500 focus:ring-violet-500"
+                            "block w-full min-w-0 flex-1 rounded-none rounded-r-md border-gray-300 text-sm",
+                            "focus:border-gray-300 focus:ring-0"
                           )}
                           value={dataSource.name}
                           readOnly={true}
@@ -201,7 +201,12 @@ export default function DataSourceSettings({
                           type="text"
                           name="description"
                           id="dataSourceDescription"
-                          className="block w-full min-w-0 flex-1 rounded-md border-gray-300 text-sm focus:border-violet-500 focus:ring-violet-500"
+                          className={classNames(
+                            "block w-full min-w-0 flex-1 rounded-md border-gray-300 text-sm",
+                            managed
+                              ? "focus:border-gray-300 focus:ring-0"
+                              : "focus:border-violet-500 focus:ring-violet-500"
+                          )}
                           value={dataSourceDescription}
                           readOnly={managed}
                           onChange={(e) =>
@@ -320,7 +325,7 @@ export default function DataSourceSettings({
                           type="number"
                           name="max_chunk_size"
                           id="dataSourceMaxChunkSize"
-                          className="block w-full min-w-0 flex-1 rounded-md border-gray-300 text-sm focus:border-violet-500 focus:ring-violet-500"
+                          className="block w-full min-w-0 flex-1 rounded-md border-gray-300 text-sm focus:border-gray-300 focus:ring-0"
                           value={dataSourceConfig.max_chunk_size}
                           readOnly={true}
                         />

--- a/front/pages/w/[wId]/ds/[name]/upsert.tsx
+++ b/front/pages/w/[wId]/ds/[name]/upsert.tsx
@@ -40,14 +40,15 @@ export const getServerSideProps: GetServerSideProps<{
     };
   }
 
-  const readOnly = !auth.isBuilder();
-
   let dataSource = await getDataSource(auth, context.params?.name as string);
   if (!dataSource) {
     return {
       notFound: true,
     };
   }
+
+  // if user is not builder or if datasource is managed
+  const readOnly = !auth.isBuilder() || !!dataSource.connector;
 
   return {
     props: {
@@ -205,8 +206,11 @@ export default function DataSourceUpsert({
                         id="document"
                         readOnly={readOnly}
                         className={classNames(
-                          "block w-full min-w-0 flex-1 rounded-md text-sm",
-                          "border-gray-300 focus:border-violet-500 focus:ring-violet-500"
+                          "block w-full min-w-0 flex-1 rounded-md border-gray-300 text-sm",
+                          "border-gray-300",
+                          readOnly
+                            ? "focus:border-gray-300 focus:ring-0"
+                            : "focus:border-violet-500 focus:ring-violet-500"
                         )}
                         value={documentId}
                         onChange={(e) => setDocumentId(e.target.value)}
@@ -298,12 +302,15 @@ export default function DataSourceUpsert({
                       name="text"
                       id="text"
                       rows={20}
+                      readOnly={readOnly}
                       className={classNames(
                         "block w-full min-w-0 flex-1 rounded-md font-mono text-xs",
-                        "border-gray-300 focus:border-violet-500 focus:ring-violet-500",
+                        "border-gray-300",
+                        readOnly
+                          ? "focus:border-gray-300 focus:ring-0"
+                          : "focus:border-violet-500 focus:ring-violet-500",
                         downloading ? "text-gray-300" : ""
                       )}
-                      readOnly={readOnly}
                       disabled={downloading}
                       value={downloading ? "Downloading..." : text}
                       onChange={(e) => setText(e.target.value)}

--- a/front/pages/w/[wId]/ds/index.tsx
+++ b/front/pages/w/[wId]/ds/index.tsx
@@ -392,7 +392,7 @@ export default function DataSourcesView({
                                 }
                               : () => {
                                   window.alert(
-                                    "Please reach out at team@dust.tt !"
+                                    "Managed DataSources are only available on our paid plans. Contact us at team@dust.tt to get access."
                                   );
                                   logger.info(
                                     {
@@ -407,7 +407,7 @@ export default function DataSourcesView({
                           {!ds.isBuilt
                             ? "Coming soon"
                             : !canUseManagedDataSources
-                            ? "Get early access"
+                            ? "Upgrade"
                             : !isLoadingByProvider[
                                 ds.connectorProvider as ConnectorProvider
                               ]

--- a/front/pages/w/[wId]/ds/index.tsx
+++ b/front/pages/w/[wId]/ds/index.tsx
@@ -266,55 +266,75 @@ export default function DataSourcesView({
 
         <div className="mt-8 overflow-hidden">
           <ul role="list" className="">
-            {MANAGED_DATA_SOURCES.map((ds) => (
-              <li key={`managed-${ds.connectorProvider}`} className="px-2 py-4">
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center">
-                    <p
-                      className={classNames(
-                        "truncate text-base font-bold",
-                        enabledManagedDataSources.has(
-                          ds.connectorProvider as ConnectorProvider
-                        )
-                          ? "text-violet-600"
-                          : "text-slate-400"
+            {MANAGED_DATA_SOURCES.map((ds) => {
+              const enabled = enabledManagedDataSources.has(
+                ds.connectorProvider as ConnectorProvider
+              );
+              return (
+                <li
+                  key={`managed-${ds.connectorProvider}`}
+                  className="px-2 py-4"
+                >
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center">
+                      {enabled ? (
+                        <Link
+                          href={`/w/${
+                            owner.sId
+                          }/ds/${`managed-${ds.connectorProvider}`}`}
+                          className="block"
+                        >
+                          <p
+                            className={classNames(
+                              "truncate text-base font-bold",
+                              enabled ? "text-violet-600" : "text-slate-400"
+                            )}
+                          >
+                            {ds.name}
+                          </p>
+                        </Link>
+                      ) : (
+                        <p
+                          className={classNames(
+                            "truncate text-base font-bold",
+                            enabled ? "text-violet-600" : "text-slate-400"
+                          )}
+                        >
+                          {ds.name}
+                        </p>
                       )}
-                    >
-                      {ds.name}
-                    </p>
-                  </div>
-                  <div>
-                    {!enabledManagedDataSources.has(
-                      ds.connectorProvider as ConnectorProvider
-                    ) ? (
-                      <Button
-                        disabled={!ds.isBuilt}
-                        onClick={() => {
-                          handleEnableManagedDataSource(
-                            ds.connectorProvider as ConnectorProvider
-                          );
-                        }}
-                      >
-                        {ds.isBuilt ? "Setup" : "Coming soon"}
-                      </Button>
-                    ) : (
-                      <p
-                        className={classNames(
-                          "inline-flex rounded-full px-2 text-xs font-semibold leading-5",
-                          "bg-green-100 text-green-800"
-                          // handle error:
-                          // : "bg-red-100 text-red-800"
-                        )}
-                      >
-                        enabled
-                        {/* handle error:
+                    </div>
+                    <div>
+                      {!enabled ? (
+                        <Button
+                          disabled={!ds.isBuilt}
+                          onClick={() => {
+                            handleEnableManagedDataSource(
+                              ds.connectorProvider as ConnectorProvider
+                            );
+                          }}
+                        >
+                          {ds.isBuilt ? "Setup" : "Coming soon"}
+                        </Button>
+                      ) : (
+                        <p
+                          className={classNames(
+                            "inline-flex rounded-full px-2 text-xs font-semibold leading-5",
+                            "bg-green-100 text-green-800"
+                            // handle error:
+                            // : "bg-red-100 text-red-800"
+                          )}
+                        >
+                          enabled
+                          {/* handle error:
                            errored */}
-                      </p>
-                    )}
+                        </p>
+                      )}
+                    </div>
                   </div>
-                </div>
-              </li>
-            ))}
+                </li>
+              );
+            })}
           </ul>
         </div>
       </div>

--- a/front/pages/w/[wId]/ds/new.tsx
+++ b/front/pages/w/[wId]/ds/new.tsx
@@ -89,6 +89,11 @@ export default function DataSourceNew({
     } else if (dataSourceName.length == 0) {
       setDataSourceNameError("");
       return false;
+    } else if (dataSourceName.startsWith("managed-")) {
+      setDataSourceNameError(
+        "DataSource name cannot start with the prefix `managed-`"
+      );
+      return false;
     } else if (!dataSourceName.match(/^[a-zA-Z0-9\._\-]+$/)) {
       setDataSourceNameError(
         "DataSource name must only contain letters, numbers, and the characters `._-`"


### PR DESCRIPTION
- add section in DS for managed DS
- make settings and upsert RO for managed DS
- make inputs in RO mode look unfocusable
- prevent people from creating a DS name managed-*

todo:
- [x] log requests for early access
- [x] handle nango error
- [x] display `errored` status in DS list
- [ ] display last sync in settings
- [ ] ? display more detailed error in settings
- [ ] ? allow disconnecting (and/or delete ?) the DS from settings
