### PR TITLE
upgrade prettier-plugin-tailwindcss

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -5098,9 +5098,9 @@
       }
     },
     "node_modules/prettier-plugin-tailwindcss": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.2.6.tgz",
-      "integrity": "sha512-F+7XCl9RLF/LPrGdUMHWpsT6TM31JraonAUyE6eBmpqymFvDwyl0ETHsKFHP1NG+sEfv8bmKqnTxEbWQbHPlBA==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.2.7.tgz",
+      "integrity": "sha512-jQopIOgjLpX+y8HeD56XZw7onupRTC0cw7eKKUimI7vhjkPF5/1ltW5LyqaPtSyc8HvEpvNZsvvsGFa2qpa59w==",
       "dev": true,
       "engines": {
         "node": ">=12.17.0"

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -53,7 +53,7 @@
         "jest": "^29.5.0",
         "postcss": "^8.4.21",
         "prettier": "^2.8.7",
-        "prettier-plugin-tailwindcss": "^0.2.5",
+        "prettier-plugin-tailwindcss": "^0.2.7",
         "ts-jest": "^29.0.5",
         "tsx": "^3.12.6",
         "typescript": "^5.0.3"
@@ -9986,9 +9986,10 @@
       }
     },
     "node_modules/prettier-plugin-tailwindcss": {
-      "version": "0.2.5",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.2.7.tgz",
+      "integrity": "sha512-jQopIOgjLpX+y8HeD56XZw7onupRTC0cw7eKKUimI7vhjkPF5/1ltW5LyqaPtSyc8HvEpvNZsvvsGFa2qpa59w==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=12.17.0"
       },

--- a/front/package.json
+++ b/front/package.json
@@ -59,7 +59,7 @@
     "jest": "^29.5.0",
     "postcss": "^8.4.21",
     "prettier": "^2.8.7",
-    "prettier-plugin-tailwindcss": "^0.2.5",
+    "prettier-plugin-tailwindcss": "^0.2.7",
     "ts-jest": "^29.0.5",
     "tsx": "^3.12.6",
     "typescript": "^5.0.3"

--- a/xp1/package-lock.json
+++ b/xp1/package-lock.json
@@ -9581,9 +9581,10 @@
       }
     },
     "node_modules/prettier-plugin-tailwindcss": {
-      "version": "0.2.5",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.2.7.tgz",
+      "integrity": "sha512-jQopIOgjLpX+y8HeD56XZw7onupRTC0cw7eKKUimI7vhjkPF5/1ltW5LyqaPtSyc8HvEpvNZsvvsGFa2qpa59w==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=12.17.0"
       },


### PR DESCRIPTION
One you pull this, restart VSCode and your tailwind classes should be automatically sorted again