### PR TITLE
Minimal DataSource views tweaks for Managed DataSources

### DIFF
--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
@@ -102,6 +102,16 @@ async function handler(
         });
       }
 
+      if (dataSource.connector && !keyRes.value.isSystem) {
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "data_source_auth_error",
+            message: "You cannot upsert a document on a managed data source.",
+          },
+        });
+      }
+
       if (!req.body || !(typeof req.body.text == "string")) {
         return apiError(req, res, {
           status_code: 400,
@@ -272,6 +282,16 @@ async function handler(
             type: "data_source_auth_error",
             message:
               "You can only alter the data souces of the workspaces for which you are a builder.",
+          },
+        });
+      }
+
+      if (dataSource.connector && !keyRes.value.isSystem) {
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "data_source_auth_error",
+            message: "You cannot delete a document from a managed data source.",
           },
         });
       }

--- a/front/pages/api/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
@@ -248,6 +248,16 @@ async function handler(
         });
       }
 
+      if (dataSource.connector) {
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "data_source_auth_error",
+            message: "You cannot delete a document from a managed data source.",
+          },
+        });
+      }
+
       const deleteRes = await DustAPI.deleteDataSourceDocument(
         dataSource.dustAPIProjectId,
         dataSource.name,

--- a/front/pages/api/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
@@ -60,6 +60,16 @@ async function handler(
         });
       }
 
+      if (dataSource.connector) {
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "data_source_auth_error",
+            message: "You cannot upsert a document on a managed data source.",
+          },
+        });
+      }
+
       let [providers] = await Promise.all([
         Provider.findAll({
           where: {

--- a/front/pages/w/[wId]/ds/[name]/index.tsx
+++ b/front/pages/w/[wId]/ds/[name]/index.tsx
@@ -19,8 +19,8 @@ const { GA_TRACKING_ID = "" } = process.env;
 export const getServerSideProps: GetServerSideProps<{
   user: UserType | null;
   owner: WorkspaceType;
-  dataSource: DataSourceType;
   readOnly: boolean;
+  dataSource: DataSourceType;
   gaTrackingId: string;
 }> = async (context) => {
   const session = await getSession(context.req, context.res);
@@ -45,14 +45,14 @@ export const getServerSideProps: GetServerSideProps<{
   }
 
   // Managed data sources are read-only (you can't add a document).
-  const readOnly = !auth.isBuilder() || dataSource.connector;
+  const readOnly = !auth.isBuilder() || !!dataSource.connector;
 
   return {
     props: {
       user,
       owner,
-      dataSource,
       readOnly,
+      dataSource,
       gaTrackingId: GA_TRACKING_ID,
     },
   };

--- a/front/pages/w/[wId]/ds/[name]/index.tsx
+++ b/front/pages/w/[wId]/ds/[name]/index.tsx
@@ -37,14 +37,15 @@ export const getServerSideProps: GetServerSideProps<{
     };
   }
 
-  const readOnly = !auth.isBuilder();
-
   let dataSource = await getDataSource(auth, context.params?.name as string);
   if (!dataSource) {
     return {
       notFound: true,
     };
   }
+
+  // Managed data sources are read-only (you can't add a document).
+  const readOnly = !auth.isBuilder() || dataSource.connector;
 
   return {
     props: {

--- a/front/pages/w/[wId]/ds/[name]/settings.tsx
+++ b/front/pages/w/[wId]/ds/[name]/settings.tsx
@@ -67,6 +67,8 @@ export default function DataSourceSettings({
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   let dataSourceConfig = JSON.parse(dataSource.config || "{}");
 
+  const managed = !!dataSource.connector;
+
   const [dataSourceDescription, setDataSourceDescription] = useState(
     dataSource.description || ""
   );
@@ -201,6 +203,7 @@ export default function DataSourceSettings({
                           id="dataSourceDescription"
                           className="block w-full min-w-0 flex-1 rounded-md border-gray-300 text-sm focus:border-violet-500 focus:ring-violet-500"
                           value={dataSourceDescription}
+                          readOnly={managed}
                           onChange={(e) =>
                             setDataSourceDescription(e.target.value)
                           }
@@ -212,68 +215,70 @@ export default function DataSourceSettings({
                       </p>
                     </div>
 
-                    <div className="sm:col-span-6">
-                      <fieldset className="mt-2">
-                        <legend className="contents text-sm font-medium text-gray-700">
-                          Visibility
-                        </legend>
-                        <div className="mt-4 space-y-4">
-                          <div className="flex items-center">
-                            <input
-                              id="dataSourceVisibilityPublic"
-                              name="visibility"
-                              type="radio"
-                              className="h-4 w-4 cursor-pointer border-gray-300 text-violet-600 focus:ring-violet-500"
-                              value="public"
-                              checked={dataSourceVisibility == "public"}
-                              onChange={(e) => {
-                                if (e.target.value != dataSourceVisibility) {
-                                  setDataSourceVisibility(
-                                    e.target.value as DataSourceVisibility
-                                  );
-                                }
-                              }}
-                            />
-                            <label
-                              htmlFor="dataSourceVisibilityPublic"
-                              className="ml-3 block text-sm font-medium text-gray-700"
-                            >
-                              Public
-                              <p className="mt-0 text-sm font-normal text-gray-500">
-                                Anyone on the Internet can discover and access
-                                your DataSource. Only you can edit.
-                              </p>
-                            </label>
+                    {!managed ? (
+                      <div className="sm:col-span-6">
+                        <fieldset className="mt-2">
+                          <legend className="contents text-sm font-medium text-gray-700">
+                            Visibility
+                          </legend>
+                          <div className="mt-4 space-y-4">
+                            <div className="flex items-center">
+                              <input
+                                id="dataSourceVisibilityPublic"
+                                name="visibility"
+                                type="radio"
+                                className="h-4 w-4 cursor-pointer border-gray-300 text-violet-600 focus:ring-violet-500"
+                                value="public"
+                                checked={dataSourceVisibility == "public"}
+                                onChange={(e) => {
+                                  if (e.target.value != dataSourceVisibility) {
+                                    setDataSourceVisibility(
+                                      e.target.value as DataSourceVisibility
+                                    );
+                                  }
+                                }}
+                              />
+                              <label
+                                htmlFor="dataSourceVisibilityPublic"
+                                className="ml-3 block text-sm font-medium text-gray-700"
+                              >
+                                Public
+                                <p className="mt-0 text-sm font-normal text-gray-500">
+                                  Anyone on the Internet can discover and access
+                                  your DataSource. Only you can edit.
+                                </p>
+                              </label>
+                            </div>
+                            <div className="flex items-center">
+                              <input
+                                id="dataSourceVisibilityPrivate"
+                                name="visibility"
+                                type="radio"
+                                value="private"
+                                className="h-4 w-4 cursor-pointer border-gray-300 text-violet-600 focus:ring-violet-500"
+                                checked={dataSourceVisibility == "private"}
+                                onChange={(e) => {
+                                  if (e.target.value != dataSourceVisibility) {
+                                    setDataSourceVisibility(
+                                      e.target.value as DataSourceVisibility
+                                    );
+                                  }
+                                }}
+                              />
+                              <label
+                                htmlFor="dataSourceVisibilityPrivate"
+                                className="ml-3 block text-sm font-medium text-gray-700"
+                              >
+                                Private
+                                <p className="mt-0 text-sm font-normal text-gray-500">
+                                  Only you can see and edit the DataSource.
+                                </p>
+                              </label>
+                            </div>
                           </div>
-                          <div className="flex items-center">
-                            <input
-                              id="dataSourceVisibilityPrivate"
-                              name="visibility"
-                              type="radio"
-                              value="private"
-                              className="h-4 w-4 cursor-pointer border-gray-300 text-violet-600 focus:ring-violet-500"
-                              checked={dataSourceVisibility == "private"}
-                              onChange={(e) => {
-                                if (e.target.value != dataSourceVisibility) {
-                                  setDataSourceVisibility(
-                                    e.target.value as DataSourceVisibility
-                                  );
-                                }
-                              }}
-                            />
-                            <label
-                              htmlFor="dataSourceVisibilityPrivate"
-                              className="ml-3 block text-sm font-medium text-gray-700"
-                            >
-                              Private
-                              <p className="mt-0 text-sm font-normal text-gray-500">
-                                Only you can see and edit the DataSource.
-                              </p>
-                            </label>
-                          </div>
-                        </div>
-                      </fieldset>
-                    </div>
+                        </fieldset>
+                      </div>
+                    ) : null}
                   </div>
                 </div>
 
@@ -325,25 +330,27 @@ export default function DataSourceSettings({
                 </div>
               </div>
 
-              <div className="flex pt-6">
-                <div className="flex">
-                  <Button
-                    onClick={handleUpdate}
-                    disabled={isDeleting || isUpdating}
-                  >
-                    {isUpdating ? "Updating..." : "Update"}
-                  </Button>
+              {!managed ? (
+                <div className="flex pt-6">
+                  <div className="flex">
+                    <Button
+                      onClick={handleUpdate}
+                      disabled={isDeleting || isUpdating}
+                    >
+                      {isUpdating ? "Updating..." : "Update"}
+                    </Button>
+                  </div>
+                  <div className="flex-1"></div>
+                  <div className="ml-2 flex">
+                    <Button
+                      onClick={handleDelete}
+                      disabled={isDeleting || isUpdating}
+                    >
+                      {isDeleting ? "Deleting..." : "Delete"}
+                    </Button>
+                  </div>
                 </div>
-                <div className="flex-1"></div>
-                <div className="ml-2 flex">
-                  <Button
-                    onClick={handleDelete}
-                    disabled={isDeleting || isUpdating}
-                  >
-                    {isDeleting ? "Deleting..." : "Delete"}
-                  </Button>
-                </div>
-              </div>
+              ) : null}
             </div>
           </div>
         </div>


### PR DESCRIPTION
- Deactivate UploadDocument in the UI
- Make the settings read-only
- Prevent internal API upsert and delete
- Prevent external API upsert and delate

More TODO later:
- Display status of DataSource in documents list and settings
- Ability to disconnect / delete managed DataSource in the settings