### PR TITLE
remove useless transaction from createNotionConnector

### DIFF
--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -3,7 +3,7 @@ import {
   launchNotionSyncWorkflow,
   stopNotionSyncWorkflow,
 } from "@connectors/connectors/notion/temporal/client";
-import { Connector, sequelize_conn } from "@connectors/lib/models";
+import { Connector } from "@connectors/lib/models";
 import { nango_client } from "@connectors/lib/nango_client";
 import { Err, Ok, Result } from "@connectors/lib/result";
 import logger from "@connectors/logger/logger";

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -31,26 +31,18 @@ export async function createNotionConnector(
     return new Err(new Error("Notion access token is invalid"));
   }
 
-  const transaction = await sequelize_conn.transaction();
   try {
-    const connector = await Connector.create(
-      {
-        type: "notion",
-        nangoConnectionId,
-        workspaceAPIKey: dataSourceConfig.workspaceAPIKey,
-        workspaceId: dataSourceConfig.workspaceId,
-        dataSourceName: dataSourceConfig.dataSourceName,
-      },
-      { transaction }
-    );
-
+    const connector = await Connector.create({
+      type: "notion",
+      nangoConnectionId,
+      workspaceAPIKey: dataSourceConfig.workspaceAPIKey,
+      workspaceId: dataSourceConfig.workspaceId,
+      dataSourceName: dataSourceConfig.dataSourceName,
+    });
     await launchNotionSyncWorkflow(dataSourceConfig, nangoConnectionId);
-
-    await transaction.commit();
     return new Ok(connector.id.toString());
   } catch (e) {
     logger.error("Error creating notion connector", e);
-    await transaction.rollback();
     return new Err(e as Error);
   }
 }


### PR DESCRIPTION
- It's not useful since there is only one DB query
- it's actually pretty bad because the connector need the connector object in the DB