### PR TITLE
Simpler connectors API interface

### DIFF
--- a/connectors/src/admin/cli.ts
+++ b/connectors/src/admin/cli.ts
@@ -37,23 +37,13 @@ const connectors = async (command: string, args: parseArgs.ParsedArgs) => {
   switch (command) {
     case "stop": {
       await throwOnError(
-        STOP_CONNECTOR_BY_TYPE[provider]({
-          workspaceId: connector.workspaceId,
-          dataSourceName: connector.dataSourceName,
-        })
+        STOP_CONNECTOR_BY_TYPE[provider](connector.id.toString())
       );
       return;
     }
     case "resume": {
       await throwOnError(
-        RESUME_CONNECTOR_BY_TYPE[provider](
-          {
-            workspaceId: connector.workspaceId,
-            dataSourceName: connector.dataSourceName,
-            workspaceAPIKey: connector.workspaceAPIKey,
-          },
-          connector.nangoConnectionId
-        )
+        RESUME_CONNECTOR_BY_TYPE[provider](connector.id.toString())
       );
       return;
     }
@@ -66,20 +56,10 @@ const connectors = async (command: string, args: parseArgs.ParsedArgs) => {
 
     case "restart": {
       await throwOnError(
-        STOP_CONNECTOR_BY_TYPE[provider]({
-          workspaceId: connector.workspaceId,
-          dataSourceName: connector.dataSourceName,
-        })
+        STOP_CONNECTOR_BY_TYPE[provider](connector.id.toString())
       );
       await throwOnError(
-        RESUME_CONNECTOR_BY_TYPE[provider](
-          {
-            workspaceId: connector.workspaceId,
-            dataSourceName: connector.dataSourceName,
-            workspaceAPIKey: connector.workspaceAPIKey,
-          },
-          connector.nangoConnectionId
-        )
+        RESUME_CONNECTOR_BY_TYPE[provider](connector.id.toString())
       );
       return;
     }
@@ -102,20 +82,10 @@ const notion = async (command: string) => {
         promises.push(
           queue.add(async () => {
             await throwOnError(
-              STOP_CONNECTOR_BY_TYPE[connector.type]({
-                workspaceId: connector.workspaceId,
-                dataSourceName: connector.dataSourceName,
-              })
+              STOP_CONNECTOR_BY_TYPE[connector.type](connector.id.toString())
             );
             await throwOnError(
-              RESUME_CONNECTOR_BY_TYPE[connector.type](
-                {
-                  workspaceId: connector.workspaceId,
-                  dataSourceName: connector.dataSourceName,
-                  workspaceAPIKey: connector.workspaceAPIKey,
-                },
-                connector.nangoConnectionId
-              )
+              RESUME_CONNECTOR_BY_TYPE[connector.type](connector.id.toString())
             );
           })
         );

--- a/connectors/src/api/getConnector.ts
+++ b/connectors/src/api/getConnector.ts
@@ -2,7 +2,7 @@ import { Request, Response } from "express";
 
 import { Connector } from "@connectors/lib/models";
 import logger from "@connectors/logger/logger";
-import { withLogging } from "@connectors/logger/withlogging";
+import { apiError, withLogging } from "@connectors/logger/withlogging";
 import { ConnectorType } from "@connectors/types/connector";
 import { ConnectorsAPIErrorResponse } from "@connectors/types/errors";
 
@@ -23,10 +23,12 @@ const _getConnector = async (
     }
     const connector = await Connector.findByPk(req.params.connector_id);
     if (!connector) {
-      return res.status(404).send({
-        error: {
-          message: `Connector not found`,
+      return apiError(req, res, {
+        api_error: {
+          type: "connector_not_found",
+          message: "Connector not found",
         },
+        status_code: 404,
       });
     }
     return res.status(200).send({
@@ -46,4 +48,4 @@ const _getConnector = async (
   }
 };
 
-export const getConnector = withLogging(_getConnector);
+export const getConnectorAPIHandler = withLogging(_getConnector);

--- a/connectors/src/api/resumeConnector.ts
+++ b/connectors/src/api/resumeConnector.ts
@@ -2,67 +2,33 @@ import { Request, Response } from "express";
 
 import { RESUME_CONNECTOR_BY_TYPE } from "@connectors/connectors";
 import { errorFromAny } from "@connectors/lib/error";
+import { Connector } from "@connectors/lib/models";
 import logger from "@connectors/logger/logger";
 import { apiError, withLogging } from "@connectors/logger/withlogging";
-import { isConnectorProvider } from "@connectors/types/connector";
 import { ConnectorsAPIErrorResponse } from "@connectors/types/errors";
-
-type ConnectorResumeReqBody = {
-  workspaceAPIKey: string;
-  dataSourceName: string;
-  workspaceId: string;
-  nangoConnectionId: string;
-};
 
 type ConnectorResumeResBody =
   | { connectorId: string }
   | ConnectorsAPIErrorResponse;
 
 const _resumeConnectorAPIHandler = async (
-  req: Request<
-    { connector_provider: string },
-    ConnectorResumeResBody,
-    ConnectorResumeReqBody
-  >,
+  req: Request<{ connector_id: string }, ConnectorResumeResBody>,
   res: Response<ConnectorResumeResBody>
 ) => {
   try {
-    if (
-      !req.body.workspaceAPIKey ||
-      !req.body.dataSourceName ||
-      !req.body.workspaceId ||
-      !req.body.nangoConnectionId
-    ) {
+    const connector = await Connector.findByPk(req.params.connector_id);
+    if (!connector) {
       return apiError(req, res, {
         api_error: {
-          type: "invalid_request_error",
-          message: `Missing required parameters. Required : workspaceAPIKey, dataSourceName, 
-          workspaceId, nangoConnectionId`,
+          type: "connector_not_found",
+          message: "Connector not found",
         },
-        status_code: 400,
+        status_code: 404,
       });
     }
+    const connectorResumer = RESUME_CONNECTOR_BY_TYPE[connector.type];
 
-    if (!isConnectorProvider(req.params.connector_provider)) {
-      return apiError(req, res, {
-        api_error: {
-          type: "unknown_connector_provider",
-          message: `Unknown connector provider ${req.params.connector_provider}`,
-        },
-        status_code: 400,
-      });
-    }
-    const connectorResumer =
-      RESUME_CONNECTOR_BY_TYPE[req.params.connector_provider];
-
-    const resumeRes = await connectorResumer(
-      {
-        workspaceAPIKey: req.body.workspaceAPIKey,
-        dataSourceName: req.body.dataSourceName,
-        workspaceId: req.body.workspaceId,
-      },
-      req.body.nangoConnectionId
-    );
+    const resumeRes = await connectorResumer(connector.id.toString());
 
     if (resumeRes.isErr()) {
       return apiError(req, res, {

--- a/connectors/src/api/stopConnector.ts
+++ b/connectors/src/api/stopConnector.ts
@@ -2,57 +2,33 @@ import { Request, Response } from "express";
 
 import { STOP_CONNECTOR_BY_TYPE } from "@connectors/connectors";
 import { errorFromAny } from "@connectors/lib/error";
+import { Connector } from "@connectors/lib/models";
 import logger from "@connectors/logger/logger";
 import { apiError, withLogging } from "@connectors/logger/withlogging";
-import { isConnectorProvider } from "@connectors/types/connector";
 import { ConnectorsAPIErrorResponse } from "@connectors/types/errors";
-
-type ConnectorStopReqBody = {
-  dataSourceName: string;
-  workspaceId: string;
-};
 
 type ConnectorStopResBody =
   | { connectorId: string }
   | ConnectorsAPIErrorResponse;
 
 const _stopConnectorAPIHandler = async (
-  req: Request<
-    { connector_provider: string },
-    ConnectorStopResBody,
-    ConnectorStopReqBody
-  >,
+  req: Request<{ connector_id: string }, ConnectorStopResBody>,
   res: Response<ConnectorStopResBody>
 ) => {
   try {
-    if (!req.body.dataSourceName || !req.body.workspaceId) {
+    const connector = await Connector.findByPk(req.params.connector_id);
+    if (!connector) {
       return apiError(req, res, {
         api_error: {
-          type: "invalid_request_error",
-          message:
-            "Missing required parameters. Required : dataSourceName, workspaceId",
+          type: "connector_not_found",
+          message: "Connector not found",
         },
-        status_code: 400,
+        status_code: 404,
       });
     }
+    const connectorStopper = STOP_CONNECTOR_BY_TYPE[connector.type];
 
-    if (!isConnectorProvider(req.params.connector_provider)) {
-      return apiError(req, res, {
-        api_error: {
-          type: "unknown_connector_provider",
-          message: `Unknown connector provider ${req.params.connector_provider}`,
-        },
-        status_code: 400,
-      });
-    }
-
-    const connectorStopper =
-      STOP_CONNECTOR_BY_TYPE[req.params.connector_provider];
-
-    const stopRes = await connectorStopper({
-      dataSourceName: req.body.dataSourceName,
-      workspaceId: req.body.workspaceId,
-    });
+    const stopRes = await connectorStopper(connector.id.toString());
 
     if (stopRes.isErr()) {
       return apiError(req, res, {

--- a/connectors/src/api_server.ts
+++ b/connectors/src/api_server.ts
@@ -3,12 +3,12 @@ import express from "express";
 
 import { createConnectorAPIHandler } from "@connectors/api/createConnector";
 import { deleteConnectorAPIHandler } from "@connectors/api/deleteConnector";
-import { getConnector } from "@connectors/api/getConnector";
 import { resumeConnectorAPIHandler } from "@connectors/api/resumeConnector";
 import { stopConnectorAPIHandler } from "@connectors/api/stopConnector";
 import logger from "@connectors/logger/logger";
 import { authMiddleware } from "@connectors/middleware/auth";
 
+import { getConnectorAPIHandler } from "./api/getConnector";
 import { syncConnectorAPIHandler } from "./api/syncConnector";
 import { webhookSlackAPIHandler } from "./api/webhooks/webhookSlack";
 
@@ -19,13 +19,10 @@ export function startServer(port: number) {
   app.use(bodyParser.json());
 
   app.post("/connectors/create/:connector_provider", createConnectorAPIHandler);
-  app.post("/connectors/stop/:connector_provider", stopConnectorAPIHandler);
-  app.post("/connectors/resume/:connector_provider", resumeConnectorAPIHandler);
-  app.delete(
-    "/connectors/delete/:connector_provider",
-    deleteConnectorAPIHandler
-  );
-  app.get("/connectors/:connector_id", getConnector);
+  app.post("/connectors/stop/:connector_id", stopConnectorAPIHandler);
+  app.post("/connectors/resume/:connector_id", resumeConnectorAPIHandler);
+  app.delete("/connectors/delete/:connector_id", deleteConnectorAPIHandler);
+  app.get("/connectors/:connector_id", getConnectorAPIHandler);
   app.post("/connectors/sync/:connector_id", syncConnectorAPIHandler);
 
   app.post("/webhooks/:webhook_secret/slack", webhookSlackAPIHandler);

--- a/connectors/src/connectors/index.ts
+++ b/connectors/src/connectors/index.ts
@@ -8,11 +8,9 @@ import {
 import { createSlackConnector } from "@connectors/connectors/slack";
 import { launchSlackSyncWorkflow } from "@connectors/connectors/slack/temporal/client";
 import { Ok, Result } from "@connectors/lib/result";
+import logger from "@connectors/logger/logger";
 import { ConnectorProvider } from "@connectors/types/connector";
-import {
-  DataSourceConfig,
-  DataSourceInfo,
-} from "@connectors/types/data_source_config";
+import { DataSourceConfig } from "@connectors/types/data_source_config";
 
 type ConnectorCreator = (
   dataSourceConfig: DataSourceConfig,
@@ -27,16 +25,17 @@ export const CREATE_CONNECTOR_BY_TYPE: Record<
   notion: createNotionConnector,
 };
 
-type ConnectorStopper = (
-  dataSourceInfo: DataSourceInfo
-) => Promise<Result<string, Error>>;
+type ConnectorStopper = (connectorId: string) => Promise<Result<string, Error>>;
 
 export const STOP_CONNECTOR_BY_TYPE: Record<
   ConnectorProvider,
   ConnectorStopper
 > = {
-  slack: async () => {
-    throw new Error("Not implemented");
+  slack: async (connectorId: string) => {
+    logger.info(
+      `Stopping Slack connector is a no-op. ConnectorId: ${connectorId}`
+    );
+    return new Ok(connectorId);
   },
   notion: stopNotionConnector,
 };
@@ -54,17 +53,17 @@ export const CLEAN_CONNECTOR_BY_TYPE: Record<
   notion: cleanupNotionConnector,
 };
 
-type ConnectorResumer = (
-  dataSourceConfig: DataSourceConfig,
-  nangoConnectionId: string
-) => Promise<Result<string, Error>>;
+type ConnectorResumer = (connectorId: string) => Promise<Result<string, Error>>;
 
 export const RESUME_CONNECTOR_BY_TYPE: Record<
   ConnectorProvider,
   ConnectorResumer
 > = {
-  slack: async () => {
-    throw new Error("Not implemented");
+  slack: async (connectorId: string) => {
+    logger.info(
+      `Resuming Slack connector is a no-op. ConnectorId: ${connectorId}`
+    );
+    return new Ok(connectorId);
   },
   notion: resumeNotionConnector,
 };

--- a/connectors/src/lib/api/data_source_config.ts
+++ b/connectors/src/lib/api/data_source_config.ts
@@ -1,0 +1,12 @@
+import { Connector } from "@connectors/lib/models";
+import { DataSourceConfig } from "@connectors/types/data_source_config";
+
+export function dataSourceConfigFromConnector(
+  connector: Connector
+): DataSourceConfig {
+  return {
+    workspaceAPIKey: connector.workspaceAPIKey,
+    dataSourceName: connector.dataSourceName,
+    workspaceId: connector.workspaceId,
+  };
+}

--- a/connectors/src/lib/error.ts
+++ b/connectors/src/lib/error.ts
@@ -1,7 +1,9 @@
 export type APIErrorType =
   | "internal_server_error"
   | "unknown_connector_provider"
-  | "invalid_request_error";
+  | "invalid_request_error"
+  | "connector_not_found"
+  | "connector_configugration_not_found";
 
 export type APIError = {
   type: APIErrorType;

--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -347,12 +347,13 @@ const dataSource = async (command: string, args: parseArgs.ParsedArgs) => {
           `DataSource not found: wId='${args.wId}' provider='${args.provider}'`
         );
       }
+      if (!dataSource.connectorId) {
+        throw new Error(
+          `DataSource does not have a connector: wId='${args.wId}' connectorId='${args.connectorId}'`
+        );
+      }
 
-      await ConnectorsAPI.deleteConnector(
-        args.provider,
-        args.wId,
-        dataSource.name
-      );
+      await ConnectorsAPI.deleteConnector(dataSource.connectorId.toString());
       await CoreAPI.deleteDataSource(
         dataSource.dustAPIProjectId,
         dataSource.name

--- a/front/lib/connectors_api.ts
+++ b/front/lib/connectors_api.ts
@@ -49,56 +49,43 @@ export const ConnectorsAPI = {
   },
 
   async pauseConnector(
-    provider: ConnectorProvider,
-    workspaceId: string,
-    dataSourceName: string
+    connectorId: string
   ): Promise<ConnectorsAPIResponse<{ connectorId: string }>> {
-    const res = await fetch(`${CONNECTORS_API}/connectors/pause/${provider}`, {
-      method: "POST",
-      headers: getDefaultHeaders(),
-      body: JSON.stringify({
-        workspaceId,
-        dataSourceName,
-      }),
-    });
+    const res = await fetch(
+      `${CONNECTORS_API}/connectors/pause/${connectorId}`,
+      {
+        method: "POST",
+        headers: getDefaultHeaders(),
+      }
+    );
 
     return _resultFromResponse(res);
   },
 
   async resumeConnector(
-    provider: ConnectorProvider,
-    workspaceId: string,
-    workspaceAPIKey: string,
-    dataSourceName: string,
-    nangoConnectionId: string
+    connectorId: string
   ): Promise<ConnectorsAPIResponse<{ connectorId: string }>> {
-    const res = await fetch(`${CONNECTORS_API}/connectors/resume/${provider}`, {
-      method: "POST",
-      headers: getDefaultHeaders(),
-      body: JSON.stringify({
-        workspaceId,
-        workspaceAPIKey,
-        dataSourceName,
-        nangoConnectionId,
-      }),
-    });
+    const res = await fetch(
+      `${CONNECTORS_API}/connectors/resume/${connectorId}`,
+      {
+        method: "POST",
+        headers: getDefaultHeaders(),
+      }
+    );
 
     return _resultFromResponse(res);
   },
 
   async deleteConnector(
-    provider: ConnectorProvider,
-    workspaceId: string,
-    dataSourceName: string
+    connectorId: string
   ): Promise<ConnectorsAPIResponse<{ success: true }>> {
-    const res = await fetch(`${CONNECTORS_API}/connectors/delete/${provider}`, {
-      method: "DELETE",
-      headers: getDefaultHeaders(),
-      body: JSON.stringify({
-        workspaceId,
-        dataSourceName,
-      }),
-    });
+    const res = await fetch(
+      `${CONNECTORS_API}/connectors/delete/${connectorId}`,
+      {
+        method: "DELETE",
+        headers: getDefaultHeaders(),
+      }
+    );
 
     return _resultFromResponse(res);
   },


### PR DESCRIPTION
The connectors API was relying on the DataSourceConfig for all API calls, moving them to rely on the primary key connectorId.