### PR TITLE
fix: check for error in `detail` and add fallback

### DIFF
--- a/front/components/providers/AnthropicSetup.tsx
+++ b/front/components/providers/AnthropicSetup.tsx
@@ -44,7 +44,7 @@ export default function AnthropicSetup({
     });
 
     if (!check.ok) {
-      setTestError(check.error);
+      setTestError(check.error || "Unknown error");
       setTestSuccessful(false);
       setTestRunning(false);
     } else {

--- a/front/pages/api/w/[wId]/providers/[pId]/check.ts
+++ b/front/pages/api/w/[wId]/providers/[pId]/check.ts
@@ -134,7 +134,9 @@ async function handler(
 
           if (!testGenerate.ok) {
             let err = await testGenerate.json();
-            res.status(400).json({ ok: false, error: err.message });
+            res
+              .status(400)
+              .json({ ok: false, error: err.message || err.detail });
           } else {
             let test = await testGenerate.json();
             res.status(200).json({ ok: true });


### PR DESCRIPTION
Anthropic errors look like this: `{ err: { detail: 'Invalid API Key' } }`