### PR TITLE
Fixing the eslint parser option bug in vscode.

### DIFF
--- a/connectors/.eslintrc.js
+++ b/connectors/.eslintrc.js
@@ -1,15 +1,15 @@
-{
-  "extends": [
+module.exports = {
+  extends: [
     "prettier",
     "eslint:recommended",
-    "plugin:@typescript-eslint/recommended"
+    "plugin:@typescript-eslint/recommended",
   ],
-  "plugins": ["simple-import-sort"],
-  "rules": {
+  plugins: ["simple-import-sort"],
+  rules: {
     "simple-import-sort/imports": [
       "error",
       {
-        "groups": [
+        groups: [
           // Side effect imports.
           ["^\\u0000"],
           // Node.js builtins prefixed with `node:`.
@@ -24,23 +24,24 @@
           ["^"],
           // Relative imports.
           // Anything that starts with a dot.
-          ["^\\."]
-        ]
-      }
+          ["^\\."],
+        ],
+      },
     ],
     "simple-import-sort/exports": "error",
-    "@typescript-eslint/no-floating-promises": "error"
+    "@typescript-eslint/no-floating-promises": "error",
   },
-  "overrides": [
+  overrides: [
     {
-      "files": ["*.jsx", "*.js", "*.ts", "*.tsx"]
-    }
+      files: ["*.jsx", "*.js", "*.ts", "*.tsx"],
+    },
   ],
-  "env": {
-    "node": true,
-    "es6": true
+  env: {
+    node: true,
+    es6: true,
   },
-  "parserOptions": {
-    "project": "./tsconfig.json"
-  }
-}
+  parserOptions: {
+    project: "./tsconfig.json",
+    tsconfigRootDir: __dirname,
+  },
+};

--- a/connectors/tsconfig.json
+++ b/connectors/tsconfig.json
@@ -21,6 +21,6 @@
       "@connectors/*": ["./src/*"]
     }
   },
-  "include": ["**/*.ts"],
+  "include": ["**/*.ts", "./.eslintrc.js"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
As mentioned in all the threads I found online about this issue:
The new eslint parserOption.project included in `connectors/.eslintrc.json` by the "no more dangling promises" commit cause a bug in VSCode eslint parsing.
Basically eslint does not provide the CWD to the parser, which then fails to find the `connectors/tsconfig.json` file.
Making it a JS file allows us to provide a a root dir computed at runtime, which fixes the problem.

I found the solution here:
https://github.com/typescript-eslint/typescript-eslint/issues/251