### PR TITLE
enh: replace source.fixAll by source.fixAll.eslint in VSCode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,6 @@
 
   "editor.codeActionsOnSave": {
     "source.organizeImports": false,
-    "source.fixAll": true
+    "source.fixAll.eslint": true
   }
 }


### PR DESCRIPTION
`source.fixAll` tries to auto-fix typescript compiler errors. This is not very helpful, especially when it automatically deletes some code just because it is temporarily un-reachable (while refactoring)
I changed it with `source.fixAll.eslint` so only the eslint auto-fixable issues get fixed.