### PR TITLE
enh: prevent creating 2 DS w/ the same name in a WS

### DIFF
--- a/front/lib/models.ts
+++ b/front/lib/models.ts
@@ -537,6 +537,7 @@ DataSource.init(
     indexes: [
       { fields: ["workspaceId", "visibility"] },
       { fields: ["workspaceId", "name", "visibility"] },
+      { fields: ["workspaceId", "name"], unique: true },
     ],
   }
 );

--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -166,6 +166,19 @@ async function handler(
           },
           "Failed to create the connector"
         );
+        await dataSource.destroy();
+        const deleteRes = await DustAPI.deleteDataSource(
+          dustProject.value.project.project_id.toString(),
+          dustDataSource.value.data_source.data_source_id
+        );
+        if (deleteRes.isErr()) {
+          logger.error(
+            {
+              error: deleteRes.error,
+            },
+            "Failed to delete the data source"
+          );
+        }
         return apiError(req, res, {
           status_code: 500,
           api_error: {

--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -1,9 +1,6 @@
 import { NextApiRequest, NextApiResponse } from "next";
 
-import {
-  credentialsFromProviders,
-  dustManagedCredentials,
-} from "@app/lib/api/credentials";
+import { dustManagedCredentials } from "@app/lib/api/credentials";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { getOrCreateSystemApiKey } from "@app/lib/auth";
 import { ConnectorProvider, ConnectorsAPI } from "@app/lib/connectors_api";
@@ -105,30 +102,6 @@ async function handler(
         });
       }
 
-      const connectorsRes = await ConnectorsAPI.createConnector(
-        provider,
-        owner.sId,
-        systemAPIKeyRes.value.secret,
-        dataSourceName,
-        req.body.nangoConnectionId
-      );
-      if (connectorsRes.isErr()) {
-        logger.error(
-          {
-            error: connectorsRes.error,
-          },
-          "Failed to create the connector"
-        );
-        return apiError(req, res, {
-          status_code: 500,
-          api_error: {
-            type: "internal_server_error",
-            message: "Failed to create the connector.",
-            connectors_error: connectorsRes.error,
-          },
-        });
-      }
-
       const dustProject = await DustAPI.createProject();
       if (dustProject.isErr()) {
         return apiError(req, res, {
@@ -170,13 +143,40 @@ async function handler(
         });
       }
 
-      const dataSource = await DataSource.create({
+      let dataSource = await DataSource.create({
         name: dataSourceName,
         description: dataSourceDescription,
         visibility: "private",
         config: JSON.stringify(dustDataSource.value.data_source.config),
         dustAPIProjectId: dustProject.value.project.project_id.toString(),
         workspaceId: owner.id,
+      });
+
+      const connectorsRes = await ConnectorsAPI.createConnector(
+        provider,
+        owner.sId,
+        systemAPIKeyRes.value.secret,
+        dataSourceName,
+        req.body.nangoConnectionId
+      );
+      if (connectorsRes.isErr()) {
+        logger.error(
+          {
+            error: connectorsRes.error,
+          },
+          "Failed to create the connector"
+        );
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "Failed to create the connector.",
+            connectors_error: connectorsRes.error,
+          },
+        });
+      }
+
+      dataSource = await dataSource.update({
         connectorId: connectorsRes.value.connectorId,
         connectorProvider: provider,
       });


### PR DESCRIPTION
- add a unique constraint on (workspaceId, dataSourceName)
- create the DataSource before creating the connector (avoids a potential race condition where a connector could try to upsert to a DataSource that hasn't been committed to the front DB yet)