### PR TITLE
fix: use lastSyncStartTime when resuming connector

### DIFF
--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -116,7 +116,9 @@ export async function resumeNotionConnector(
     await launchNotionSyncWorkflow(
       dataSourceConfig,
       nangoConnectionId,
-      connector?.lastSyncSuccessfulTime?.getTime()
+      connector.lastSyncSuccessfulTime
+        ? connector.lastSyncStartTime?.getTime()
+        : null
     );
   } catch (e) {
     logger.error(


### PR DESCRIPTION
- If the connector was never succesfully synced, then we should resume from scratch
- otherwise, we should use the last sync's start time instead of success time, as syncs can be very long (and we would miss the changes that occurred during the last sync)