### PR TITLE
enh: use PARENT_CLOSE_POLICY_TERMINATE for notion child WF

### DIFF
--- a/connectors/src/connectors/notion/temporal/workflows.ts
+++ b/connectors/src/connectors/notion/temporal/workflows.ts
@@ -2,6 +2,7 @@ import {
   continueAsNew,
   defineQuery,
   executeChild,
+  ParentClosePolicy,
   proxyActivities,
   setHandler,
   sleep,
@@ -116,6 +117,7 @@ export async function notionSyncWorkflow(
               pagesToSync,
               nextSyncedPeriodTs,
             ],
+            parentClosePolicy: ParentClosePolicy.PARENT_CLOSE_POLICY_TERMINATE,
           })
         )
       );


### PR DESCRIPTION
terminate the child(ren) workflow(s) when the parent is terminated

rationale: the parent WF will only update the last sync time if all children are done. If the parent is restarted, it will respawn all the children, so the orphaned children are doing useless work