### PR TITLE
Process events "bot joined channel" sequentially

### DIFF
--- a/connectors/src/api/webhooks/webhookSlack.ts
+++ b/connectors/src/api/webhooks/webhookSlack.ts
@@ -5,9 +5,9 @@ import {
   whoAmI,
 } from "@connectors/connectors/slack/temporal/activities";
 import {
+  launchSlackBotJoinedWorkflow,
   launchSlackSyncOneMessageWorkflow,
   launchSlackSyncOneThreadWorkflow,
-  launchSlackUserJoinedWorkflow,
 } from "@connectors/connectors/slack/temporal/client";
 import { Connector, SlackConfiguration } from "@connectors/lib/models";
 import logger from "@connectors/logger/logger";
@@ -130,10 +130,9 @@ const _webhookSlackAPIHandler = async (
       if (myUserId !== req.body.event.user) {
         return res.status(200).send();
       }
-      const launchRes = await launchSlackUserJoinedWorkflow(
+      const launchRes = await launchSlackBotJoinedWorkflow(
         slackConfiguration.connectorId.toString(),
-        req.body.event.channel,
-        req.body.event.user
+        req.body.event.channel
       );
       logger.info(
         {

--- a/connectors/src/connectors/slack/temporal/signals.ts
+++ b/connectors/src/connectors/slack/temporal/signals.ts
@@ -1,3 +1,9 @@
 import { defineSignal } from "@temporalio/workflow";
 
 export const newWebhookSignal = defineSignal<[void]>("new_webhook_signal");
+export interface botJoinedChanelSignalInput {
+  channelId: string;
+}
+export const botJoinedChanelSignal = defineSignal<[botJoinedChanelSignalInput]>(
+  "bot_joined_channel_signal"
+);

--- a/connectors/src/connectors/slack/temporal/workflows.ts
+++ b/connectors/src/connectors/slack/temporal/workflows.ts
@@ -216,8 +216,6 @@ export async function memberJoinedChannel(
       ],
     });
   }
-  await saveSuccessSyncActivity(connectorId);
-  console.log(`Workspace sync done for connector ${connectorId}`);
 }
 
 export function workspaceFullSyncWorkflowId(connectorId: string) {

--- a/connectors/src/connectors/slack/temporal/workflows.ts
+++ b/connectors/src/connectors/slack/temporal/workflows.ts
@@ -216,6 +216,8 @@ export async function memberJoinedChannel(
       ],
     });
   }
+  // /!\ Any signal received outside of the while loop will be lost, so don't make any async
+  // call here, which will allow the signal handler to be executed by the nodejs event loop. /!\
 }
 
 export function workspaceFullSyncWorkflowId(connectorId: string) {


### PR DESCRIPTION
Use signalWithCreate() to make sure we only sync one channel per connector at a time when our bot is invited to multiple Slack channels in a short timeframe. 


<img width="1728" alt="Screen Shot 2023-05-04 at 10 41 45" src="https://user-images.githubusercontent.com/358965/236154750-00544b75-15cb-4bbc-bb53-d1fd67de8428.png">
