### PR TITLE
enh: increase notion upsert concurrency

### DIFF
--- a/connectors/src/connectors/notion/temporal/config.ts
+++ b/connectors/src/connectors/notion/temporal/config.ts
@@ -1,2 +1,2 @@
-export const WORKFLOW_VERSION = 8;
+export const WORKFLOW_VERSION = 9;
 export const QUEUE_NAME = `notion-queue-v${WORKFLOW_VERSION}`;

--- a/connectors/src/connectors/notion/temporal/workflows.ts
+++ b/connectors/src/connectors/notion/temporal/workflows.ts
@@ -39,7 +39,7 @@ const SYNC_PERIOD_DURATION_MS = 60_000;
 const INTERVAL_BETWEEN_SYNCS_MS = 10_000;
 
 const MAX_CONCURRENT_CHILD_WORKFLOWS = 1;
-const MAX_PENDING_UPSERT_ACTIVITIES = 3;
+const MAX_PENDING_UPSERT_ACTIVITIES = 5;
 const MAX_PENDING_DB_ACTIVITIES = 10;
 
 export const getLastSyncPeriodTsQuery = defineQuery<number | null, []>(


### PR DESCRIPTION
From testing locally, it seems that 5 allows to not hit Notion's rate limit and increases performance