### PR TITLE
enh: skip pages already seen in run

### DIFF
--- a/connectors/src/connectors/notion/lib/register_page_seen.ts
+++ b/connectors/src/connectors/notion/lib/register_page_seen.ts
@@ -1,0 +1,62 @@
+import { Connector, NotionPage, sequelize_conn } from "@connectors/lib/models";
+import { DataSourceInfo } from "@connectors/types/data_source_config";
+
+export async function registerPageSeen(
+  dataSourceInfo: DataSourceInfo,
+  notionPageId: string,
+  ts: number
+): Promise<boolean> {
+  const transaction = await sequelize_conn.transaction();
+  const connector = await Connector.findOne({
+    where: {
+      type: "notion",
+      workspaceId: dataSourceInfo.workspaceId,
+      dataSourceName: dataSourceInfo.dataSourceName,
+    },
+    transaction,
+  });
+
+  if (!connector) {
+    await transaction.rollback();
+    throw new Error("Could not find connector");
+  }
+
+  try {
+    const existingPage = await NotionPage.findOne({
+      where: {
+        notionPageId,
+        connectorId: connector?.id,
+      },
+      transaction,
+    });
+
+    if (existingPage) {
+      if (existingPage.lastSeenTs?.getTime() === ts) {
+        await transaction.rollback();
+        return false;
+      }
+
+      await existingPage.update(
+        {
+          lastSeenTs: new Date(ts),
+        },
+        { transaction }
+      );
+    } else {
+      await NotionPage.create(
+        {
+          notionPageId,
+          connectorId: connector?.id,
+          lastSeenTs: new Date(ts),
+        },
+        { transaction }
+      );
+    }
+
+    await transaction.commit();
+    return true;
+  } catch (e) {
+    await transaction.rollback();
+    throw e;
+  }
+}

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -2,15 +2,13 @@ import {
   getPagesEditedSince,
   getParsedPage,
 } from "@connectors/connectors/notion/lib/notion_api";
+import { registerPageSeen } from "@connectors/connectors/notion/lib/register_page_seen";
 import { getTagsForPage } from "@connectors/connectors/notion/lib/tags";
 import { Connector, NotionPage, sequelize_conn } from "@connectors/lib/models";
 import { nango_client } from "@connectors/lib/nango_client";
 import { upsertToDatasource } from "@connectors/lib/upsert";
 import mainLogger from "@connectors/logger/logger";
-import {
-  DataSourceConfig,
-  DataSourceInfo,
-} from "@connectors/types/data_source_config";
+import { DataSourceConfig } from "@connectors/types/data_source_config";
 
 const logger = mainLogger.child({ provider: "notion" });
 
@@ -27,10 +25,23 @@ export async function notionUpsertPageActivity(
   accessToken: string,
   pageId: string,
   dataSourceConfig: DataSourceConfig,
+  runTimestamp: number,
   loggerArgs: Record<string, string | number>
 ) {
   const parsedPage = await getParsedPage(accessToken, pageId, loggerArgs);
   const localLogger = logger.child({ ...loggerArgs, pageId });
+
+  const alreadySeenInRun = !(await registerPageSeen(
+    dataSourceConfig,
+    pageId,
+    runTimestamp
+  ));
+
+  if (alreadySeenInRun) {
+    localLogger.info("Skipping page already seen in this run");
+    return;
+  }
+
   if (!parsedPage || !parsedPage.hasBody) {
     localLogger.info("Skipping page without body");
     return;
@@ -145,58 +156,4 @@ export async function getNotionAccessTokenActivity(
   )) as string;
 
   return notionAccessToken;
-}
-
-export async function registerPageSeenActivity(
-  dataSourceInfo: DataSourceInfo,
-  notionPageId: string,
-  ts: number
-) {
-  const transaction = await sequelize_conn.transaction();
-  const connector = await Connector.findOne({
-    where: {
-      type: "notion",
-      workspaceId: dataSourceInfo.workspaceId,
-      dataSourceName: dataSourceInfo.dataSourceName,
-    },
-    transaction,
-  });
-
-  if (!connector) {
-    await transaction.rollback();
-    throw new Error("Could not find connector");
-  }
-
-  try {
-    const existingPage = await NotionPage.findOne({
-      where: {
-        notionPageId,
-        connectorId: connector?.id,
-      },
-      transaction,
-    });
-
-    if (existingPage) {
-      await existingPage.update(
-        {
-          lastSeenTs: new Date(ts),
-        },
-        { transaction }
-      );
-    } else {
-      await NotionPage.create(
-        {
-          notionPageId,
-          connectorId: connector?.id,
-          lastSeenTs: new Date(ts),
-        },
-        { transaction }
-      );
-    }
-
-    await transaction.commit();
-  } catch (e) {
-    await transaction.rollback();
-    throw e;
-  }
 }

--- a/connectors/src/connectors/notion/temporal/config.ts
+++ b/connectors/src/connectors/notion/temporal/config.ts
@@ -1,2 +1,2 @@
-export const WORKFLOW_VERSION = 9;
+export const WORKFLOW_VERSION = 10;
 export const QUEUE_NAME = `notion-queue-v${WORKFLOW_VERSION}`;

--- a/connectors/src/connectors/notion/temporal/workflows.ts
+++ b/connectors/src/connectors/notion/temporal/workflows.ts
@@ -116,9 +116,10 @@ export async function notionSyncWorkflow(
         i += MAX_PAGE_IDS_PER_CHILD_WORKFLOW
       ) {
         const batch = pagesToSync.slice(i, i + MAX_PAGE_IDS_PER_CHILD_WORKFLOW);
+        const batchIndex = Math.floor(i / MAX_PAGE_IDS_PER_CHILD_WORKFLOW);
         const workflowId = `${getWorkflowId(
           dataSourceConfig
-        )}-result-page-${pageIndex}-${i}`;
+        )}-result-page-${pageIndex}-${batchIndex}`;
         promises.push(
           childWorkflowQueue.add(() =>
             executeChild(notionSyncResultPageWorkflow.name, {


### PR DESCRIPTION
When we get the pages to process from the notion API, we also get all child pages from databases: some pages are only ever seen through their parent DB. But it turns out some of these pages are also returned by the search endpoint, so we may be visiting them 2+ times.

- set a max number of page IDs (100) for each child workflow, so they all take roughly the same amount of time to complete
- prevent upserting the same page again if we previously seen that page within the same run