### PR TITLE
feat: add garbage collection to notion workflow

### DIFF
--- a/connectors/migrations/20230505_add_notion_connector_state.ts
+++ b/connectors/migrations/20230505_add_notion_connector_state.ts
@@ -1,0 +1,39 @@
+import { Connector, NotionConnectorState } from "@connectors/lib/models";
+
+async function main() {
+  const connectors = await Connector.findAll({
+    include: { model: NotionConnectorState, as: "notionConnectorState" },
+  });
+  console.log("Found ${connectors.length} connectors");
+  for (const connector of connectors) {
+    console.log("Processing connector ${connector.id} (${connector.type})...");
+    if (
+      connector.lastSyncSuccessfulTime &&
+      !connector.firstSuccessfulSyncTime
+    ) {
+      console.log(
+        "Backfilling firstSuccessfulSyncTime for connector ${connector.id}..."
+      );
+      await connector.update({
+        firstSuccessfulSyncTime: connector.lastSyncSuccessfulTime,
+      });
+    }
+
+    if (connector.type === "notion" && !connector.notionConnectorState) {
+      console.log(
+        "Creating NotionConnectorState for connector ${connector.id}..."
+      );
+      await NotionConnectorState.create({ connectorId: connector.id });
+    }
+  }
+}
+
+main()
+  .then(() => {
+    console.log("Done");
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/connectors/src/admin/db.ts
+++ b/connectors/src/admin/db.ts
@@ -1,5 +1,6 @@
 import {
   Connector,
+  NotionConnectorState,
   NotionPage,
   SlackConfiguration,
 } from "@connectors/lib/models";
@@ -9,6 +10,7 @@ async function main(): Promise<void> {
   await Connector.sync({ alter: true });
   await SlackConfiguration.sync({ alter: true });
   await NotionPage.sync({ alter: true });
+  await NotionConnectorState.sync({ alter: true });
   return;
 }
 

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -250,30 +250,10 @@ export async function saveStartGarbageCollectionActivity(
   }
 }
 
-export async function markExistingPagesAsVisitedDuringRunActivity(
+export async function syncGarbageCollectorPagesActivity(
   dataSourceInfo: DataSourceInfo,
   pageIds: string[],
   runTimestamp: number
-) {
-  const connector = await Connector.findOne({
-    where: {
-      type: "notion",
-      workspaceId: dataSourceInfo.workspaceId,
-      dataSourceName: dataSourceInfo.dataSourceName,
-    },
-  });
-  if (!connector) {
-    throw new Error("Could not find connector");
-  }
-  await NotionPage.update(
-    { lastSeenTs: new Date(runTimestamp) },
-    { where: { notionPageId: pageIds, connectorId: connector.id } }
-  );
-}
-
-export async function filterOutExistingPagesActivity(
-  dataSourceInfo: DataSourceInfo,
-  pageIds: string[]
 ): Promise<string[]> {
   const localLogger = logger.child({
     dataSourceName: dataSourceInfo.dataSourceName,
@@ -290,6 +270,12 @@ export async function filterOutExistingPagesActivity(
   if (!connector) {
     throw new Error("Could not find connector");
   }
+
+  await NotionPage.update(
+    { lastSeenTs: new Date(runTimestamp) },
+    { where: { notionPageId: pageIds, connectorId: connector.id } }
+  );
+
   const existingPageIds = new Set(
     (
       await NotionPage.findAll({

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -259,12 +259,15 @@ async function shouldGarbageCollect(
       workspaceId: dataSourceConfig.workspaceId,
       dataSourceName: dataSourceConfig.dataSourceName,
     },
-    include: { model: NotionConnectorState, as: "notionConnectorState" },
   });
   if (!connector) {
     throw new Error("Could not find connector");
   }
-  const notionConnectorState = connector.notionConnectorState;
+  const notionConnectorState = await NotionConnectorState.findOne({
+    where: {
+      connectorId: connector.id,
+    },
+  });
   if (!notionConnectorState) {
     throw new Error("Could not find notionConnectorState");
   }
@@ -322,18 +325,23 @@ export async function saveStartGarbageCollectionActivity(
         workspaceId: dataSourceConfig.workspaceId,
         dataSourceName: dataSourceConfig.dataSourceName,
       },
-      include: { model: NotionConnectorState, as: "notionConnectorState" },
     });
 
     if (!connector) {
       throw new Error("Could not find connector");
     }
 
-    if (!connector.notionConnectorState) {
+    const notionConnectorState = await NotionConnectorState.findOne({
+      where: {
+        connectorId: connector.id,
+      },
+    });
+
+    if (!notionConnectorState) {
       throw new Error("Could not find notionConnectorState");
     }
 
-    await connector.notionConnectorState.update({
+    await notionConnectorState.update({
       lastGarbageCollectionStartTime: new Date(),
     });
 
@@ -435,15 +443,19 @@ export async function saveSuccessGarbageCollectionActivity(
       workspaceId: dataSourceInfo.workspaceId,
       dataSourceName: dataSourceInfo.dataSourceName,
     },
-    include: { model: NotionConnectorState, as: "notionConnectorState" },
   });
   if (!connector) {
     throw new Error("Could not find connector");
   }
-  if (!connector.notionConnectorState) {
+  const notionConnectorState = await NotionConnectorState.findOne({
+    where: {
+      connectorId: connector.id,
+    },
+  });
+  if (!notionConnectorState) {
     throw new Error("Could not find notionConnectorState");
   }
-  await connector.notionConnectorState.update({
+  await notionConnectorState.update({
     lastGarbageCollectionFinishTime: new Date(),
   });
 }

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -326,15 +326,8 @@ export async function deletePagesNotVisitedInRunActivity(
     "Found pages to delete."
   );
   for (const page of pagesToDelete) {
-    localLogger.info(
-      { pageId: page.notionPageId },
-      "Deleting page from data source."
-    );
+    localLogger.info({ pageId: page.notionPageId }, "Deleting page.");
     await deleteFromDataSource(dataSourceConfig, `notion-${page.notionPageId}`);
-    localLogger.info(
-      { pageId: page.notionPageId },
-      "Deleting page from database."
-    );
     await page.destroy();
   }
 }

--- a/connectors/src/connectors/notion/temporal/config.ts
+++ b/connectors/src/connectors/notion/temporal/config.ts
@@ -1,2 +1,2 @@
-export const WORKFLOW_VERSION = 11;
+export const WORKFLOW_VERSION = 12;
 export const QUEUE_NAME = `notion-queue-v${WORKFLOW_VERSION}`;

--- a/connectors/src/connectors/notion/temporal/workflows.ts
+++ b/connectors/src/connectors/notion/temporal/workflows.ts
@@ -20,8 +20,7 @@ const { notionUpsertPageActivity } = proxyActivities<typeof activities>({
 
 const {
   notionGetPagesToSyncActivity,
-  markExistingPagesAsVisitedDuringRunActivity,
-  filterOutExistingPagesActivity,
+  syncGarbageCollectorPagesActivity,
   deletePagesNotVisitedInRunActivity,
   saveSuccessGarbageCollectionActivity,
 } = proxyActivities<typeof activities>({
@@ -123,17 +122,12 @@ export async function notionSyncWorkflow(
       let pagesToSync: string[] = [];
 
       if (isGargageCollectionRun) {
-        // mark pages as visited to avoid deleting them
-        await markExistingPagesAsVisitedDuringRunActivity(
+        // mark pages as visited to avoid deleting them and return
+        // pages that are new
+        pagesToSync = await syncGarbageCollectorPagesActivity(
           dataSourceConfig,
           pageIds,
           runTimestamp
-        );
-
-        // sync the pages found that haven't been synced yet
-        pagesToSync = await filterOutExistingPagesActivity(
-          dataSourceConfig,
-          pageIds
         );
       } else {
         pagesToSync = pageIds;

--- a/connectors/src/connectors/notion/temporal/workflows.ts
+++ b/connectors/src/connectors/notion/temporal/workflows.ts
@@ -91,7 +91,7 @@ export async function notionSyncWorkflow(
       await saveStartGarbageCollectionActivity(dataSourceConfig);
     }
 
-    const runTimestamp = preProcessTimestampForNotion(Date.now());
+    const runTimestamp = Date.now();
 
     let cursor: string | null = null;
     let pageIndex = 0;
@@ -173,7 +173,7 @@ export async function notionSyncWorkflow(
 
     if (!isGargageCollectionRun) {
       await saveSuccessSyncActivity(dataSourceConfig);
-      lastSyncedPeriodTs = runTimestamp;
+      lastSyncedPeriodTs = preProcessTimestampForNotion(runTimestamp);
     } else {
       // garbage collect the pages -- can be done non-blocking
       void executeChild(notionGarbageCollectWorkflow.name, {

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -9,8 +9,8 @@ import { ConversationsRepliesResponse } from "@slack/web-api/dist/response/Conve
 
 import { syncSucceeded } from "@connectors/connectors/sync_status";
 import { cacheGet, cacheSet } from "@connectors/lib/cache";
+import { upsertToDatasource } from "@connectors/lib/data_sources";
 import { nango_client } from "@connectors/lib/nango_client";
-import { upsertToDatasource } from "@connectors/lib/upsert";
 import mainLogger from "@connectors/logger/logger";
 import { DataSourceConfig } from "@connectors/types/data_source_config";
 

--- a/connectors/src/connectors/sync_status.ts
+++ b/connectors/src/connectors/sync_status.ts
@@ -14,6 +14,9 @@ async function syncFinished(
   connector.lastSyncStatus = status;
   connector.lastSyncFinishTime = finishedAt;
   if (status === "succeeded") {
+    if (!connector.firstSuccessfulSyncTime) {
+      connector.firstSuccessfulSyncTime = finishedAt;
+    }
     connector.lastSyncSuccessfulTime = finishedAt;
   }
 

--- a/connectors/src/lib/models.ts
+++ b/connectors/src/lib/models.ts
@@ -41,6 +41,10 @@ export class Connector extends Model<
   declare lastSyncStartTime?: Date;
   declare lastSyncFinishTime?: Date;
   declare lastSyncSuccessfulTime?: Date;
+  declare firstSuccessfulSyncTime?: Date;
+
+  declare lastGarbageCollectionStartTime?: Date;
+  declare lastGarbageCollectionFinishTime?: Date;
 }
 
 Connector.init(
@@ -93,6 +97,18 @@ Connector.init(
       allowNull: true,
     },
     lastSyncSuccessfulTime: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    },
+    lastGarbageCollectionStartTime: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    },
+    lastGarbageCollectionFinishTime: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    },
+    firstSuccessfulSyncTime: {
       type: DataTypes.DATE,
       allowNull: true,
     },
@@ -160,7 +176,6 @@ export class NotionPage extends Model<
   declare notionPageId: string;
   declare lastSeenTs: Date;
   declare lastUpsertedTs?: Date;
-  declare dustDatasourceDocumentId?: string;
 
   declare connectorId: ForeignKey<Connector["id"]>;
 }

--- a/connectors/src/lib/models.ts
+++ b/connectors/src/lib/models.ts
@@ -42,8 +42,6 @@ export class Connector extends Model<
   declare lastSyncFinishTime?: Date;
   declare lastSyncSuccessfulTime?: Date;
   declare firstSuccessfulSyncTime?: Date;
-
-  declare notionConnectorState?: NotionConnectorState;
 }
 
 Connector.init(
@@ -203,10 +201,7 @@ NotionConnectorState.init(
   }
 );
 
-Connector.hasOne(NotionConnectorState, {
-  as: "notionConnectorState",
-  foreignKey: "connectorId",
-});
+Connector.hasOne(NotionConnectorState);
 
 export class NotionPage extends Model<
   InferAttributes<NotionPage>,

--- a/connectors/src/lib/models.ts
+++ b/connectors/src/lib/models.ts
@@ -43,8 +43,7 @@ export class Connector extends Model<
   declare lastSyncSuccessfulTime?: Date;
   declare firstSuccessfulSyncTime?: Date;
 
-  declare lastGarbageCollectionStartTime?: Date;
-  declare lastGarbageCollectionFinishTime?: Date;
+  declare notionConnectorState?: NotionConnectorState;
 }
 
 Connector.init(
@@ -97,14 +96,6 @@ Connector.init(
       allowNull: true,
     },
     lastSyncSuccessfulTime: {
-      type: DataTypes.DATE,
-      allowNull: true,
-    },
-    lastGarbageCollectionStartTime: {
-      type: DataTypes.DATE,
-      allowNull: true,
-    },
-    lastGarbageCollectionFinishTime: {
       type: DataTypes.DATE,
       allowNull: true,
     },
@@ -164,6 +155,58 @@ SlackConfiguration.init(
   }
 );
 Connector.hasOne(SlackConfiguration);
+
+export class NotionConnectorState extends Model<
+  InferAttributes<NotionConnectorState>,
+  InferCreationAttributes<NotionConnectorState>
+> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare lastGarbageCollectionStartTime?: Date;
+  declare lastGarbageCollectionFinishTime?: Date;
+
+  declare connectorId: ForeignKey<Connector["id"]>;
+}
+
+NotionConnectorState.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    lastGarbageCollectionStartTime: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    },
+    lastGarbageCollectionFinishTime: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    },
+  },
+  {
+    sequelize: sequelize_conn,
+    modelName: "notion_connector_states",
+    indexes: [{ fields: ["connectorId"], unique: true }],
+  }
+);
+
+Connector.hasOne(NotionConnectorState, {
+  as: "notionConnectorState",
+  foreignKey: "connectorId",
+});
 
 export class NotionPage extends Model<
   InferAttributes<NotionPage>,


### PR DESCRIPTION
- Every 24 hours, run a "garbage collection" process (from the main workflow)
- we go through every page in the notion workspace, mark them as "visited"
- at the end, spawn a child workflow (in fire and forget mode) to delete all the pages that were not "visited" (we no longer have the rights on them or they were deleted upstream)
- while running this process, we may encounter pages that we never saw before: it can happen if the user granted permissions to more pages directly from the notion UI. In this case, we process them (using the same flow as usual)

notes for deploy:
- `npm run initdb` in connectors
- deploy the worker
- `npm run cli -- notion restart-all`