### PR TITLE
Packaged apps views + DustAPI interface

### DIFF
--- a/front/components/AppLayout.tsx
+++ b/front/components/AppLayout.tsx
@@ -93,7 +93,7 @@ export default function AppLayout({
                             workspace={owner}
                             readOnly={false}
                             onWorkspaceUpdate={(workspace) => {
-                              router.push(`/w/${workspace.sId}/a`);
+                              router.push(`/w/${workspace.sId}`);
                             }}
                           />
                         ) : (

--- a/front/components/app/MainTab.tsx
+++ b/front/components/app/MainTab.tsx
@@ -22,7 +22,7 @@ export default function MainTab({
   currentTab: string;
   owner: WorkspaceType;
 }) {
-  let tabs = [
+  const tabs: { name: string; href: string; icon: JSX.Element }[] = [
     {
       name: "Specification",
       href: `/w/${owner.sId}/a/${app.sId}`,
@@ -43,7 +43,7 @@ export default function MainTab({
         />
       ),
     },
-  ] as { name: string; href: string; icon: JSX.Element }[];
+  ];
 
   if (
     owner.role === "user" ||

--- a/front/components/app/MainTab.tsx
+++ b/front/components/app/MainTab.tsx
@@ -70,6 +70,8 @@ export default function MainTab({
         />
       ),
     });
+  }
+  if (owner.role === "builder" || owner.role === "admin") {
     tabs.push({
       name: "Settings",
       href: `/w/${owner.sId}/a/${app.sId}/settings`,

--- a/front/components/data_source/MainTab.tsx
+++ b/front/components/data_source/MainTab.tsx
@@ -20,7 +20,7 @@ export default function MainTab({
   currentTab: string;
   owner: WorkspaceType;
 }) {
-  const tabs = [
+  const tabs: { name: string; href: string; icon: JSX.Element }[] = [
     {
       name: "Documents",
       href: `/w/${owner.sId}/ds/${dataSource.name}`,

--- a/front/components/profile/MainTab.tsx
+++ b/front/components/profile/MainTab.tsx
@@ -18,7 +18,7 @@ export default function MainTab({
   currentTab: string;
   owner: WorkspaceType;
 }) {
-  const tabs = [
+  const tabs: { name: string; href: string; icon: JSX.Element }[] = [
     {
       name: "Apps",
       href: `/w/${owner.sId}/a`,
@@ -39,7 +39,7 @@ export default function MainTab({
         />
       ),
     },
-  ] as { name: string; href: string; icon: JSX.Element }[];
+  ];
 
   if (owner.role === "builder" || owner.role === "admin") {
     tabs.push({

--- a/front/components/use/MainTab.tsx
+++ b/front/components/use/MainTab.tsx
@@ -17,7 +17,7 @@ export default function MainTab({
   currentTab: string;
   owner: WorkspaceType;
 }) {
-  const tabs = [
+  const tabs: { name: string; href: string; icon: JSX.Element }[] = [
     {
       name: "Chat",
       href: `/w/${owner.sId}/u/chat`,
@@ -58,7 +58,7 @@ export default function MainTab({
         />
       ),
     },
-  ] as { name: string; href: string; icon: JSX.Element }[];
+  ];
 
   let currTab = tabs.find((tab) => tab.name == currentTab);
 

--- a/front/components/use/MainTab.tsx
+++ b/front/components/use/MainTab.tsx
@@ -1,9 +1,8 @@
 import { Menu } from "@headlessui/react";
 import {
-  KeyIcon,
-  LinkIcon,
+  BellAlertIcon,
   MagnifyingGlassCircleIcon,
-  UsersIcon,
+  PencilSquareIcon,
 } from "@heroicons/react/24/outline";
 import { ChevronDownIcon, CodeBracketIcon } from "@heroicons/react/24/solid";
 import Link from "next/link";
@@ -20,8 +19,8 @@ export default function MainTab({
 }) {
   const tabs = [
     {
-      name: "Apps",
-      href: `/w/${owner.sId}/a`,
+      name: "Chat",
+      href: `/w/${owner.sId}/u/chat`,
       icon: (
         <CodeBracketIcon
           className="mr-2 mt-0.5 h-4 w-4 flex-shrink-0"
@@ -30,8 +29,8 @@ export default function MainTab({
       ),
     },
     {
-      name: "DataSources",
-      href: `/w/${owner.sId}/ds`,
+      name: "Answers",
+      href: `/w/${owner.sId}/u/answers`,
       icon: (
         <MagnifyingGlassCircleIcon
           className="mr-2 mt-0.5 h-4 w-4 flex-shrink-0"
@@ -39,45 +38,27 @@ export default function MainTab({
         />
       ),
     },
+    {
+      name: "Notes",
+      href: `/w/${owner.sId}/u/notes`,
+      icon: (
+        <PencilSquareIcon
+          className="mr-2 mt-0.5 h-4 w-4 flex-shrink-0"
+          aria-hidden="true"
+        />
+      ),
+    },
+    {
+      name: "Alerts",
+      href: `/w/${owner.sId}/u/alerts`,
+      icon: (
+        <BellAlertIcon
+          className="mr-2 mt-0.5 h-4 w-4 flex-shrink-0"
+          aria-hidden="true"
+        />
+      ),
+    },
   ] as { name: string; href: string; icon: JSX.Element }[];
-
-  if (owner.role === "builder" || owner.role === "admin") {
-    tabs.push({
-      name: "API keys",
-      href: `/w/${owner.sId}/keys`,
-      icon: (
-        <KeyIcon
-          className="mr-2 mt-0.5 h-4 w-4 flex-shrink-0"
-          aria-hidden="true"
-        />
-      ),
-    });
-  }
-
-  if (owner.role === "admin") {
-    tabs.push({
-      name: "Providers",
-      href: `/w/${owner.sId}/providers`,
-      icon: (
-        <LinkIcon
-          className="mr-2 mt-0.5 h-4 w-4 flex-shrink-0"
-          aria-hidden="true"
-        />
-      ),
-    });
-    if (owner.type === "team") {
-      tabs.push({
-        name: "Workspace",
-        href: `/w/${owner.sId}/workspace`,
-        icon: (
-          <UsersIcon
-            className="mr-2 mt-0.5 h-4 w-4 flex-shrink-0"
-            aria-hidden="true"
-          />
-        ),
-      });
-    }
-  }
 
   let currTab = tabs.find((tab) => tab.name == currentTab);
 
@@ -119,25 +100,25 @@ export default function MainTab({
             </Menu.Items>
           </Menu>
         </div>
-        {owner.type === "team" ? (
+        {owner.role === "builder" || owner.role === "admin" ? (
           <div className="flex flex-initial">
-            <Link
-              href={`/w/${owner.sId}/u`}
-              className={classNames(
-                "flex flex items-center whitespace-nowrap border-b-2 px-2 py-3 text-sm",
-                "border-transparent font-medium text-violet-600 hover:border-gray-200 hover:text-violet-700"
-              )}
-            >
-              Use
-            </Link>
             <div
               className={classNames(
                 "flex flex items-center whitespace-nowrap border-b-2 px-2 py-3 text-sm",
                 "border-gray-500 font-bold text-gray-700"
               )}
             >
-              Build
+              Use
             </div>
+            <Link
+              href={`/w/${owner.sId}/a`}
+              className={classNames(
+                "flex flex items-center whitespace-nowrap border-b-2 px-2 py-3 text-sm",
+                "border-transparent font-medium text-violet-600 hover:border-gray-200 hover:text-violet-700"
+              )}
+            >
+              Build
+            </Link>
           </div>
         ) : null}
       </div>
@@ -163,25 +144,25 @@ export default function MainTab({
               </div>
             ))}
             <div className="flex flex-1"></div>
-            {owner.type === "team" ? (
+            {owner.role === "builder" || owner.role === "admin" ? (
               <div className="flex flex-initial">
-                <Link
-                  href={`/w/${owner.sId}/u`}
-                  className={classNames(
-                    "flex flex items-center whitespace-nowrap border-b-2 px-2 py-3 text-sm",
-                    "border-transparent font-medium text-violet-600 hover:border-gray-200 hover:text-violet-700"
-                  )}
-                >
-                  Use
-                </Link>
                 <div
                   className={classNames(
                     "flex flex items-center whitespace-nowrap border-b-2 px-2 py-3 text-sm",
                     "border-gray-500 font-bold text-gray-700"
                   )}
                 >
-                  Build
+                  Use
                 </div>
+                <Link
+                  href={`/w/${owner.sId}/a`}
+                  className={classNames(
+                    "flex flex items-center whitespace-nowrap border-b-2 px-2 py-3 text-sm",
+                    "border-transparent font-medium text-violet-600 hover:border-gray-200 hover:text-violet-700"
+                  )}
+                >
+                  Build
+                </Link>
               </div>
             ) : null}
           </nav>

--- a/front/lib/dust_api.ts
+++ b/front/lib/dust_api.ts
@@ -1,0 +1,277 @@
+import { createParser } from "eventsource-parser";
+
+import { Err, Ok, Result } from "@app/lib/result";
+import logger from "@app/logger/logger";
+import { DataSourceType } from "@app/types/data_source";
+
+const { DUST_API = "http://localhost:3000" } = process.env;
+
+export type DustAPIErrorResponse = {
+  type: string;
+  message: string;
+};
+export type DustAPIResponse<T> = Result<T, DustAPIErrorResponse>;
+
+export type DustAppType = {
+  name: string;
+  workspaceId: string;
+  appId: string;
+  appHash: string;
+};
+
+export type DustAppConfigType = {
+  [key: string]: any;
+};
+
+export type DustAppRunErrorEvent = {
+  type: "error";
+  content: {
+    code: string;
+    message: string;
+  };
+};
+
+export type DustAppRunRunStatusEvent = {
+  type: "run_status";
+  content: {
+    status: "running" | "succeeded" | "errored";
+    run_id: string;
+  };
+};
+
+export type DustAppRunBlockStatusEvent = {
+  type: "block_status";
+  content: {
+    block_type: string;
+    name: string;
+    status: "running" | "succeeded" | "errored";
+    success_count: number;
+    error_count: number;
+  };
+};
+
+export type DustAppRunBlockExecutionEvent = {
+  type: "block_execution";
+  content: {
+    block_type: string;
+    block_name: string;
+    execution: { value: any | null; error: string | null }[][];
+  };
+};
+
+export type DustAppRunFinalEvent = {
+  type: "final";
+};
+
+export type DustAppRunTokensEvent = {
+  type: "tokens";
+  content: {
+    block_type: string;
+    block_name: string;
+    input_index: number;
+    map: {
+      name: string;
+      iteration: number;
+    } | null;
+    tokens: {
+      text: string;
+      tokens?: string[];
+      logprobs?: number[];
+    };
+  };
+};
+
+export class DustAPI {
+  _apiKey: string;
+
+  constructor(apiKey: string) {
+    this._apiKey = apiKey;
+  }
+
+  async runAppStreamed(
+    app: DustAppType,
+    config: DustAppConfigType,
+    inputs: any[]
+  ): Promise<
+    DustAPIResponse<{
+      eventStream: AsyncGenerator<
+        | DustAppRunErrorEvent
+        | DustAppRunRunStatusEvent
+        | DustAppRunBlockStatusEvent
+        | DustAppRunBlockExecutionEvent
+        | DustAppRunTokensEvent
+        | DustAppRunFinalEvent,
+        void,
+        unknown
+      >;
+      dustRunId: Promise<string>;
+    }>
+  > {
+    const res = await fetch(
+      `${DUST_API}/api/v1/w/${app.workspaceId}/apps/${app.appId}/runs`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${this._apiKey}`,
+        },
+        body: JSON.stringify({
+          specification_hash: app.appHash,
+          config: config,
+          stream: true,
+          blocking: false,
+          inputs: inputs,
+        }),
+      }
+    );
+
+    if (!res.ok || !res.body) {
+      return new Err({
+        type: "dust_api_error",
+        message: `Error running streamed app: status_code=${res.status}`,
+      });
+    }
+
+    let hasRunId = false;
+    let rejectDustRunIdPromise: (err: Error) => void;
+    let resolveDustRunIdPromise: (runId: string) => void;
+    const dustRunIdPromise = new Promise<string>((resolve, reject) => {
+      rejectDustRunIdPromise = reject;
+      resolveDustRunIdPromise = resolve;
+    });
+
+    let pendingEvents: (
+      | DustAppRunErrorEvent
+      | DustAppRunRunStatusEvent
+      | DustAppRunBlockStatusEvent
+      | DustAppRunBlockExecutionEvent
+      | DustAppRunTokensEvent
+      | DustAppRunFinalEvent
+    )[] = [];
+
+    const parser = createParser((event) => {
+      if (event.type === "event") {
+        if (event.data) {
+          try {
+            const data = JSON.parse(event.data);
+
+            switch (data.type) {
+              case "error": {
+                pendingEvents.push({
+                  type: "error",
+                  content: {
+                    code: data.content.code,
+                    message: data.content.message,
+                  },
+                } as DustAppRunErrorEvent);
+                break;
+              }
+              case "run_status": {
+                pendingEvents.push({
+                  type: data.type,
+                  content: data.content,
+                });
+                break;
+              }
+              case "block_status": {
+                pendingEvents.push({
+                  type: data.type,
+                  content: data.content,
+                });
+                break;
+              }
+              case "block_execution": {
+                pendingEvents.push({
+                  type: data.type,
+                  content: data.content,
+                });
+                break;
+              }
+              case "tokens": {
+                pendingEvents.push({
+                  type: "tokens",
+                  content: data.content,
+                } as DustAppRunTokensEvent);
+                break;
+              }
+              case "final": {
+                pendingEvents.push({
+                  type: "final",
+                } as DustAppRunFinalEvent);
+              }
+            }
+            if (data.content?.run_id && !hasRunId) {
+              hasRunId = true;
+              resolveDustRunIdPromise(data.content.run_id);
+            }
+          } catch (err) {
+            logger.error({ error: err }, "Failed parsing chunk from Dust API");
+          }
+        }
+      }
+    });
+
+    const reader = res.body.getReader();
+
+    const streamEvents = async function* () {
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) {
+            break;
+          }
+          parser.feed(new TextDecoder().decode(value));
+          for (const event of pendingEvents) {
+            yield event;
+          }
+          pendingEvents = [];
+        }
+        if (!hasRunId) {
+          // once the stream is entirely consumed, if we haven't received a run id, reject the promise
+          setImmediate(() => {
+            logger.error("No run id received.");
+            rejectDustRunIdPromise(new Error("No run id received"));
+          });
+        }
+      } catch (e) {
+        yield {
+          type: "error",
+          content: {
+            code: "stream_error",
+            message: "Error streaming chunks",
+          },
+        } as DustAppRunErrorEvent;
+        logger.error(
+          {
+            error: e,
+          },
+          "Error streaming chunks."
+        );
+      } finally {
+        reader.releaseLock();
+      }
+    };
+
+    return new Ok({ eventStream: streamEvents(), dustRunId: dustRunIdPromise });
+  }
+
+  async getDataSources(
+    workspaceId: string
+  ): Promise<DustAPIResponse<DataSourceType[]>> {
+    const res = await fetch(
+      `${DUST_API}/api/v1/w/${workspaceId}/data_sources`,
+      {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${this._apiKey}`,
+        },
+      }
+    );
+
+    const json = await res.json();
+    if (json.error) {
+      return new Err(json.error);
+    }
+    return new Ok(json.data_sources);
+  }
+}

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -147,10 +147,10 @@ async function handler(
       }
 
       if (invite) {
-        res.redirect(`/w/${invite.sId}/a`);
+        res.redirect(`/w/${invite.sId}`);
       } else {
         // TODO(spolu): persist latest workspace in session?
-        res.redirect(`/w/${u.workspaces[0].sId}/a`);
+        res.redirect(`/w/${u.workspaces[0].sId}`);
       }
       return;
 

--- a/front/pages/api/v1/w/[wId]/data_sources/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/index.ts
@@ -1,0 +1,43 @@
+import { NextApiRequest, NextApiResponse } from "next";
+
+import { getDataSources } from "@app/lib/api/data_sources";
+import { Authenticator, getAPIKey } from "@app/lib/auth";
+import { ReturnedAPIErrorType } from "@app/lib/error";
+import { apiError, withLogging } from "@app/logger/withlogging";
+import { DataSourceType } from "@app/types/data_source";
+
+export type GetDataSourcesResponseBody = {
+  data_sources: Array<DataSourceType>;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<GetDataSourcesResponseBody | ReturnedAPIErrorType>
+): Promise<void> {
+  let keyRes = await getAPIKey(req);
+  if (keyRes.isErr()) {
+    return apiError(req, res, keyRes.error);
+  }
+  let auth = await Authenticator.fromKey(keyRes.value, req.query.wId as string);
+
+  const dataSources = await getDataSources(auth);
+
+  switch (req.method) {
+    case "GET":
+      res.status(200).json({
+        data_sources: dataSources,
+      });
+      return;
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withLogging(handler);

--- a/front/pages/w/[wId]/a/index.tsx
+++ b/front/pages/w/[wId]/a/index.tsx
@@ -11,7 +11,7 @@ import { classNames, communityApps } from "@app/lib/utils";
 import { AppType } from "@app/types/app";
 import { UserType, WorkspaceType } from "@app/types/user";
 
-const { URL, GA_TRACKING_ID = "" } = process.env;
+const { GA_TRACKING_ID = "" } = process.env;
 
 export const getServerSideProps: GetServerSideProps<{
   user: UserType | null;

--- a/front/pages/w/[wId]/index.tsx
+++ b/front/pages/w/[wId]/index.tsx
@@ -1,6 +1,30 @@
 import { GetServerSideProps, InferGetServerSidePropsType } from "next";
 
+import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
+
 export const getServerSideProps: GetServerSideProps<{}> = async (context) => {
+  const session = await getSession(context.req, context.res);
+  const user = await getUserFromSession(session);
+  const auth = await Authenticator.fromSession(
+    session,
+    context.params?.wId as string
+  );
+
+  const owner = auth.workspace();
+  if (!owner) {
+    return {
+      notFound: true,
+    };
+  }
+
+  if (owner.role === "user") {
+    return {
+      redirect: {
+        destination: `/w/${context.query.wId}/u`,
+        permanent: false,
+      },
+    };
+  }
   return {
     redirect: {
       destination: `/w/${context.query.wId}/a`,

--- a/front/pages/w/[wId]/u/alerts/index.tsx
+++ b/front/pages/w/[wId]/u/alerts/index.tsx
@@ -1,0 +1,71 @@
+import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+
+import AppLayout from "@app/components/AppLayout";
+import MainTab from "@app/components/use/MainTab";
+import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
+import { UserType, WorkspaceType } from "@app/types/user";
+
+const { GA_TRACKING_ID = "" } = process.env;
+
+export const getServerSideProps: GetServerSideProps<{
+  user: UserType | null;
+  owner: WorkspaceType;
+  gaTrackingId: string;
+}> = async (context) => {
+  const session = await getSession(context.req, context.res);
+  const user = await getUserFromSession(session);
+  const auth = await Authenticator.fromSession(
+    session,
+    context.params?.wId as string
+  );
+
+  const owner = auth.workspace();
+  if (!owner || !auth.isUser()) {
+    return {
+      notFound: true,
+    };
+  }
+
+  return {
+    props: {
+      user,
+      owner,
+      gaTrackingId: GA_TRACKING_ID,
+    },
+  };
+};
+
+export default function AppAlerts({
+  user,
+  owner,
+  gaTrackingId,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  return (
+    <AppLayout user={user} owner={owner} gaTrackingId={gaTrackingId}>
+      <div className="flex flex-col">
+        <div className="mt-2 flex flex-initial">
+          <MainTab currentTab="Alerts" owner={owner} />
+        </div>
+        <div className="">
+          <div className="mx-auto mt-8 max-w-2xl divide-y divide-gray-200 px-6">
+            <div className="mt-16 flex flex-col items-center justify-center text-sm text-gray-500">
+              <p>🕒 Coming soon...</p>
+              <p className="mt-8 italic text-violet-700">
+                <span className="font-bold">Alerts</span> will stay on top of
+                things in real time with updates crafted for you, on topics you
+                choose, at the frequency you need.
+              </p>
+              <p className="mt-8">
+                Reach out at{" "}
+                <a href="mailto:team@dust.tt" className="font-bold">
+                  team@dust.tt
+                </a>{" "}
+                with any ideas on what you'd like to see here.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </AppLayout>
+  );
+}

--- a/front/pages/w/[wId]/u/answers/index.tsx
+++ b/front/pages/w/[wId]/u/answers/index.tsx
@@ -1,0 +1,71 @@
+import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+
+import AppLayout from "@app/components/AppLayout";
+import MainTab from "@app/components/use/MainTab";
+import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
+import { UserType, WorkspaceType } from "@app/types/user";
+
+const { GA_TRACKING_ID = "" } = process.env;
+
+export const getServerSideProps: GetServerSideProps<{
+  user: UserType | null;
+  owner: WorkspaceType;
+  gaTrackingId: string;
+}> = async (context) => {
+  const session = await getSession(context.req, context.res);
+  const user = await getUserFromSession(session);
+  const auth = await Authenticator.fromSession(
+    session,
+    context.params?.wId as string
+  );
+
+  const owner = auth.workspace();
+  if (!owner || !auth.isUser()) {
+    return {
+      notFound: true,
+    };
+  }
+
+  return {
+    props: {
+      user,
+      owner,
+      gaTrackingId: GA_TRACKING_ID,
+    },
+  };
+};
+
+export default function AppAnswers({
+  user,
+  owner,
+  gaTrackingId,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  return (
+    <AppLayout user={user} owner={owner} gaTrackingId={gaTrackingId}>
+      <div className="flex flex-col">
+        <div className="mt-2 flex flex-initial">
+          <MainTab currentTab="Answers" owner={owner} />
+        </div>
+        <div className="">
+          <div className="mx-auto mt-8 max-w-2xl divide-y divide-gray-200 px-6">
+            <div className="mt-16 flex flex-col items-center justify-center text-sm text-gray-500">
+              <p>🏗️ Under construction...</p>
+              <p className="mt-8 italic text-violet-700">
+                <span className="font-bold">Answers</span> will tackle any
+                internal question across your team's knowledge base, in a format
+                adapted to your needs.
+              </p>
+              <p className="mt-8">
+                Reach out at{" "}
+                <a href="mailto:team@dust.tt" className="font-bold">
+                  team@dust.tt
+                </a>{" "}
+                with any ideas on what you'd like to see here.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </AppLayout>
+  );
+}

--- a/front/pages/w/[wId]/u/chat/index.tsx
+++ b/front/pages/w/[wId]/u/chat/index.tsx
@@ -1,0 +1,71 @@
+import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+
+import AppLayout from "@app/components/AppLayout";
+import MainTab from "@app/components/use/MainTab";
+import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
+import { UserType, WorkspaceType } from "@app/types/user";
+
+const { GA_TRACKING_ID = "" } = process.env;
+
+export const getServerSideProps: GetServerSideProps<{
+  user: UserType | null;
+  owner: WorkspaceType;
+  gaTrackingId: string;
+}> = async (context) => {
+  const session = await getSession(context.req, context.res);
+  const user = await getUserFromSession(session);
+  const auth = await Authenticator.fromSession(
+    session,
+    context.params?.wId as string
+  );
+
+  const owner = auth.workspace();
+  if (!owner || !auth.isUser()) {
+    return {
+      notFound: true,
+    };
+  }
+
+  return {
+    props: {
+      user,
+      owner,
+      gaTrackingId: GA_TRACKING_ID,
+    },
+  };
+};
+
+export default function AppChat({
+  user,
+  owner,
+  gaTrackingId,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  return (
+    <AppLayout user={user} owner={owner} gaTrackingId={gaTrackingId}>
+      <div className="flex flex-col">
+        <div className="mt-2 flex flex-initial">
+          <MainTab currentTab="Chat" owner={owner} />
+        </div>
+        <div className="">
+          <div className="mx-auto mt-8 max-w-2xl divide-y divide-gray-200 px-6">
+            <div className="mt-16 flex flex-col items-center justify-center text-sm text-gray-500">
+              <p>🐣 Incubating...</p>
+              <p className="mt-8 italic text-violet-700">
+                <span className="font-bold">Chat</span> will let you interact
+                with a conversational agent that has full context about your
+                company.
+              </p>
+              <p className="mt-8">
+                Reach out at{" "}
+                <a href="mailto:team@dust.tt" className="font-bold">
+                  team@dust.tt
+                </a>{" "}
+                with any ideas on what you'd like to see here.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </AppLayout>
+  );
+}

--- a/front/pages/w/[wId]/u/index.tsx
+++ b/front/pages/w/[wId]/u/index.tsx
@@ -1,0 +1,16 @@
+import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+
+export const getServerSideProps: GetServerSideProps<{}> = async (context) => {
+  return {
+    redirect: {
+      destination: `/w/${context.query.wId}/u/chat`,
+      permanent: false,
+    },
+  };
+};
+
+export default function Redirect({}: InferGetServerSidePropsType<
+  typeof getServerSideProps
+>) {
+  return <></>;
+}

--- a/front/pages/w/[wId]/u/notes/index.tsx
+++ b/front/pages/w/[wId]/u/notes/index.tsx
@@ -1,0 +1,71 @@
+import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+
+import AppLayout from "@app/components/AppLayout";
+import MainTab from "@app/components/use/MainTab";
+import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
+import { UserType, WorkspaceType } from "@app/types/user";
+
+const { GA_TRACKING_ID = "" } = process.env;
+
+export const getServerSideProps: GetServerSideProps<{
+  user: UserType | null;
+  owner: WorkspaceType;
+  gaTrackingId: string;
+}> = async (context) => {
+  const session = await getSession(context.req, context.res);
+  const user = await getUserFromSession(session);
+  const auth = await Authenticator.fromSession(
+    session,
+    context.params?.wId as string
+  );
+
+  const owner = auth.workspace();
+  if (!owner || !auth.isUser()) {
+    return {
+      notFound: true,
+    };
+  }
+
+  return {
+    props: {
+      user,
+      owner,
+      gaTrackingId: GA_TRACKING_ID,
+    },
+  };
+};
+
+export default function AppNotes({
+  user,
+  owner,
+  gaTrackingId,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  return (
+    <AppLayout user={user} owner={owner} gaTrackingId={gaTrackingId}>
+      <div className="flex flex-col">
+        <div className="mt-2 flex flex-initial">
+          <MainTab currentTab="Notes" owner={owner} />
+        </div>
+        <div className="">
+          <div className="mx-auto mt-8 max-w-2xl divide-y divide-gray-200 px-6">
+            <div className="mt-16 flex flex-col items-center justify-center text-sm text-gray-500">
+              <p>🛠️ Working on it...</p>
+              <p className="mt-8 italic text-violet-700">
+                <span className="font-bold">Notes</span> will let you create
+                better content faster with the entire team's knowledge at your
+                fingertips.
+              </p>
+              <p className="mt-8">
+                Reach out at{" "}
+                <a href="mailto:team@dust.tt" className="font-bold">
+                  team@dust.tt
+                </a>{" "}
+                with any ideas on what you'd like to see here.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </AppLayout>
+  );
+}


### PR DESCRIPTION
- Introduces a `Use` view awith `Use` / `Build` switch
- Routes role users to it
- Introduces DustAPI typescript library to interface with Production Dust
- Adds a public API route to list data sources

In upcoming PRs:
- ProdDustAppRegistry for each packaged app
- Implementation of Chat app v0 (removed from this PR to make it easy to review)