### PR TITLE
fix: return a null cursor when early-exiting

### DIFF
--- a/connectors/src/connectors/notion/lib/notion_api.ts
+++ b/connectors/src/connectors/notion/lib/notion_api.ts
@@ -123,7 +123,10 @@ export async function getPagesEditedSince(
       if (isFullPage(pageOrDb)) {
         const lastEditedTime = new Date(pageOrDb.last_edited_time).getTime();
         if (sinceTs && lastEditedTime < sinceTs) {
-          break;
+          return {
+            pageIds: Array.from(editedPages),
+            nextCursor: null,
+          };
         }
         editedPages.add(pageOrDb.id);
       }
@@ -131,7 +134,10 @@ export async function getPagesEditedSince(
       if (isFullDatabase(pageOrDb)) {
         const lastEditedTime = new Date(pageOrDb.last_edited_time).getTime();
         if (sinceTs && lastEditedTime < sinceTs) {
-          break;
+          return {
+            pageIds: Array.from(editedPages),
+            nextCursor: null,
+          };
         }
         try {
           for await (const child of iteratePaginatedAPI(


### PR DESCRIPTION
We go through all the result pages on each sync, the exit condition was broken when I refactored into a single result page per activity