### PR TITLE
docker-compose file to run postgres and Qdrant.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+services:
+
+  db:
+    image: postgres:14.1-alpine
+    restart: always
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: mysecretpassword
+    volumes:
+          - dustvolume:/postgres
+    ports:
+      - 5432:5432
+  qdrant:
+    image: qdrant/qdrant
+    volumes:
+      - dustvolume:/qdrant
+    ports:
+      - 6334:6334
+
+
+volumes:
+  dustvolume:
+    
+    


### PR DESCRIPTION
Here is a little docker-compose file to run Postgres and Qdrant locally.
I did not update any documentation yet because I don't know if we want to push the users to use this docker-compose file or not.

LMK.

Usage is very simple:
```
# spawn postgres and qdrant
dust>docker-compose up -d

# stop the container without loosing the data:
docker-compose stop

# erase all the data:
docker-compose down

# up again without empty data volumes:
docker-compose up -d
```