### PR TITLE
Help us debug the stuck Slack worker

### DIFF
--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -536,9 +536,13 @@ export function formatDateForUpsert(date: Date) {
   return `${year}${month}${day} ${hours}:${minutes}`;
 }
 
-function getSlackClient(slackAccessToken: string): WebClient {
+export function getSlackClient(slackAccessToken: string): WebClient {
   return new WebClient(slackAccessToken, {
     timeout: NETWORK_REQUEST_TIMEOUT_MS,
+    retryConfig: {
+      retries: 1,
+      factor: 1,
+    },
   });
 }
 

--- a/connectors/src/connectors/slack/temporal/worker.ts
+++ b/connectors/src/connectors/slack/temporal/worker.ts
@@ -12,7 +12,6 @@ export async function runSlackWorker() {
     workflowsPath: require.resolve("./workflows"),
     activities,
     taskQueue: "slack-queue",
-    maxConcurrentActivityTaskExecutions: 1,
     connection,
     namespace,
     interceptors: {
@@ -24,5 +23,16 @@ export async function runSlackWorker() {
     },
   });
 
-  await worker.run();
+  const workerPromise = worker.run();
+  const statusReportInterval = setInterval(() => {
+    const status = worker.getStatus();
+
+    logger.info(
+      {
+        ...status,
+      },
+      "Worker status report"
+    );
+  }, 30000);
+  await workerPromise.finally(() => clearInterval(statusReportInterval));
 }

--- a/connectors/src/lib/temporal_monitoring.ts
+++ b/connectors/src/lib/temporal_monitoring.ts
@@ -52,6 +52,7 @@ export class ActivityInboundLogInterceptor
     ];
 
     try {
+      this.logger.info("Activity started.");
       return await next(input);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (err: any) {


### PR DESCRIPTION
- Allow only one retry by the Slack SDK
- Set back the default value (100) for `maxConcurrentActivityTaskExecutions` of the Slack worker
- Have the Slack worker report its status every 30 seconds, as recommended on the Temoral Slack channel.