### PR TITLE
fix: query notion page before deleting

### DIFF
--- a/connectors/src/connectors/notion/lib/notion_api.ts
+++ b/connectors/src/connectors/notion/lib/notion_api.ts
@@ -181,6 +181,48 @@ export async function getPagesEditedSince(
   };
 }
 
+export async function isPageAccessibleAndUnarchived(
+  notionAccessToken: string,
+  pageId: string,
+  localLogger?: Logger
+) {
+  const notionClient = new Client({ auth: notionAccessToken });
+  const maxTries = 5;
+  let tries = 0;
+
+  while (tries < maxTries) {
+    const tryLogger = (localLogger || logger).child({
+      tries,
+      maxTries,
+      pageId,
+    });
+    try {
+      tryLogger.info("Checking if page is accessible and unarchived.");
+      const page = await notionClient.pages.retrieve({ page_id: pageId });
+      if (!isFullPage(page)) {
+        return false;
+      }
+      return !page.archived;
+    } catch (e) {
+      if (APIResponseError.isAPIResponseError(e)) {
+        if (["rate_limited", "internal_server_error"].includes(e.code)) {
+          const waitTime = 500 * 2 ** tries;
+          tryLogger.info(
+            { waitTime },
+            "Got potentially transient error. Trying again."
+          );
+          await new Promise((resolve) => setTimeout(resolve, 500 * 2 ** tries));
+          tries += 1;
+          continue;
+        }
+      }
+      return false;
+    }
+  }
+
+  return false;
+}
+
 export async function getParsedPage(
   notionAccessToken: string,
   pageId: string,

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -372,7 +372,11 @@ export async function garbageCollectActivity(
   );
   for (const page of pagesToDelete) {
     if (
-      await isPageAccessibleAndUnarchived(notionAccessToken, page.notionPageId)
+      await isPageAccessibleAndUnarchived(
+        notionAccessToken,
+        page.notionPageId,
+        localLogger
+      )
     ) {
       localLogger.info(
         { pageId: page.notionPageId },

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -7,6 +7,7 @@ import {
 import {
   getPagesEditedSince,
   getParsedPage,
+  isPageAccessibleAndUnarchived,
 } from "@connectors/connectors/notion/lib/notion_api";
 import { getTagsForPage } from "@connectors/connectors/notion/lib/tags";
 import { syncStarted, syncSucceeded } from "@connectors/connectors/sync_status";
@@ -18,7 +19,6 @@ import {
   Connector,
   NotionConnectorState,
   NotionPage,
-  sequelize_conn,
 } from "@connectors/lib/models";
 import { nango_client } from "@connectors/lib/nango_client";
 import mainLogger from "@connectors/logger/logger";
@@ -259,25 +259,15 @@ async function shouldGarbageCollect(
 
   // If we have never done a garbage collection, we should start one
   // if it has been more than GARBAGE_COLLECTION_INTERVAL_HOURS since the first successful sync
-  if (!notionConnectorState.lastGarbageCollectionStartTime) {
+  if (!notionConnectorState.lastGarbageCollectionFinishTime) {
     return (
       now - firstSuccessfulSyncTime.getTime() >=
       GARBAGE_COLLECTION_INTERVAL_HOURS * 60 * 60 * 1000
     );
   }
 
-  const lastGarbageCollectionStartTime =
-    notionConnectorState.lastGarbageCollectionStartTime.getTime();
-
-  // If we have started a garbage collection, we should not start another one
-  if (!notionConnectorState.lastGarbageCollectionFinishTime) {
-    return false;
-  }
   const lastGarbageCollectionFinishTime =
     notionConnectorState.lastGarbageCollectionFinishTime.getTime();
-  if (lastGarbageCollectionStartTime > lastGarbageCollectionFinishTime) {
-    return false;
-  }
 
   // if we garbage collected less than GARBAGE_COLLECTION_INTERVAL_HOURS ago, we should not start another one
   if (
@@ -288,45 +278,6 @@ async function shouldGarbageCollect(
   }
 
   return true;
-}
-
-export async function saveStartGarbageCollectionActivity(
-  dataSourceConfig: DataSourceConfig
-) {
-  const transaction = await sequelize_conn.transaction();
-
-  try {
-    const connector = await Connector.findOne({
-      where: {
-        type: "notion",
-        workspaceId: dataSourceConfig.workspaceId,
-        dataSourceName: dataSourceConfig.dataSourceName,
-      },
-    });
-
-    if (!connector) {
-      throw new Error("Could not find connector");
-    }
-
-    const notionConnectorState = await NotionConnectorState.findOne({
-      where: {
-        connectorId: connector.id,
-      },
-    });
-
-    if (!notionConnectorState) {
-      throw new Error("Could not find notionConnectorState");
-    }
-
-    await notionConnectorState.update({
-      lastGarbageCollectionStartTime: new Date(),
-    });
-
-    await transaction.commit();
-  } catch (e) {
-    await transaction.rollback();
-    throw e;
-  }
 }
 
 export async function syncGarbageCollectorPagesActivity(
@@ -373,7 +324,11 @@ export async function syncGarbageCollectorPagesActivity(
   return newPageIds;
 }
 
-export async function deletePagesNotVisitedInRunActivity(
+// - look at pages that have a lastSeenTs < runTimestamp
+// - for each page, query notion API and check if the page still exists
+// - if the page does not exist, delete it from the database
+// - update the lastGarbageCollectionFinishTime
+export async function garbageCollectActivity(
   dataSourceConfig: DataSourceConfig,
   runTimestamp: number
 ) {
@@ -392,6 +347,14 @@ export async function deletePagesNotVisitedInRunActivity(
   if (!connector) {
     throw new Error("Could not find connector");
   }
+  const notionConnectorState = await NotionConnectorState.findOne({
+    where: {
+      connectorId: connector.id,
+    },
+  });
+  if (!notionConnectorState) {
+    throw new Error("Could not find notionConnectorState");
+  }
   const pagesToDelete = await NotionPage.findAll({
     where: {
       connectorId: connector.id,
@@ -404,33 +367,22 @@ export async function deletePagesNotVisitedInRunActivity(
     { pagesToDeleteCount: pagesToDelete.length },
     "Found pages to delete."
   );
+  const notionAccessToken = await getNotionAccessToken(
+    connector.nangoConnectionId
+  );
   for (const page of pagesToDelete) {
+    if (
+      await isPageAccessibleAndUnarchived(notionAccessToken, page.notionPageId)
+    ) {
+      localLogger.info(
+        { pageId: page.notionPageId },
+        "Page is still accessible, not deleting."
+      );
+      continue;
+    }
     localLogger.info({ pageId: page.notionPageId }, "Deleting page.");
     await deleteFromDataSource(dataSourceConfig, `notion-${page.notionPageId}`);
     await page.destroy();
-  }
-}
-
-export async function saveSuccessGarbageCollectionActivity(
-  dataSourceInfo: DataSourceInfo
-) {
-  const connector = await Connector.findOne({
-    where: {
-      type: "notion",
-      workspaceId: dataSourceInfo.workspaceId,
-      dataSourceName: dataSourceInfo.dataSourceName,
-    },
-  });
-  if (!connector) {
-    throw new Error("Could not find connector");
-  }
-  const notionConnectorState = await NotionConnectorState.findOne({
-    where: {
-      connectorId: connector.id,
-    },
-  });
-  if (!notionConnectorState) {
-    throw new Error("Could not find notionConnectorState");
   }
   await notionConnectorState.update({
     lastGarbageCollectionFinishTime: new Date(),

--- a/connectors/src/connectors/notion/temporal/config.ts
+++ b/connectors/src/connectors/notion/temporal/config.ts
@@ -1,2 +1,2 @@
-export const WORKFLOW_VERSION = 12;
+export const WORKFLOW_VERSION = 13;
 export const QUEUE_NAME = `notion-queue-v${WORKFLOW_VERSION}`;

--- a/connectors/src/connectors/notion/temporal/workflows.ts
+++ b/connectors/src/connectors/notion/temporal/workflows.ts
@@ -14,24 +14,21 @@ import { DataSourceConfig } from "@connectors/types/data_source_config";
 
 import { getWorkflowId } from "./utils";
 
-const { notionUpsertPageActivity } = proxyActivities<typeof activities>({
+const { notionUpsertPageActivity, garbageCollectActivity } = proxyActivities<
+  typeof activities
+>({
   startToCloseTimeout: "60 minute",
 });
 
-const {
-  notionGetPagesToSyncActivity,
-  syncGarbageCollectorPagesActivity,
-  deletePagesNotVisitedInRunActivity,
-  saveSuccessGarbageCollectionActivity,
-} = proxyActivities<typeof activities>({
-  startToCloseTimeout: "10 minute",
-});
+const { notionGetPagesToSyncActivity, syncGarbageCollectorPagesActivity } =
+  proxyActivities<typeof activities>({
+    startToCloseTimeout: "10 minute",
+  });
 
 const {
   saveSuccessSyncActivity,
   saveStartSyncActivity,
   getInitialWorkflowParamsActivity,
-  saveStartGarbageCollectionActivity,
 } = proxyActivities<typeof activities>({
   startToCloseTimeout: "1 minute",
 });
@@ -80,8 +77,6 @@ export async function notionSyncWorkflow(
   do {
     if (!isGargageCollectionRun) {
       await saveStartSyncActivity(dataSourceConfig);
-    } else {
-      await saveStartGarbageCollectionActivity(dataSourceConfig);
     }
 
     const runTimestamp = Date.now();
@@ -165,15 +160,9 @@ export async function notionSyncWorkflow(
       await saveSuccessSyncActivity(dataSourceConfig);
       lastSyncedPeriodTs = preProcessTimestampForNotion(runTimestamp);
     } else {
-      // garbage collect the pages -- can be done non-blocking
-      void executeChild(notionGarbageCollectWorkflow.name, {
-        workflowId: `${getWorkflowId(dataSourceConfig)}-garbage-collection`,
-        args: [dataSourceConfig, runTimestamp],
-        // we don't want to wait for the garbage collection to finish
-        // and we don't want the child workflow to be terminated if the parent
-        // is cont'd as new
-        parentClosePolicy: ParentClosePolicy.PARENT_CLOSE_POLICY_ABANDON,
-      });
+      // look at pages that were not visited in this run, check with the notion API
+      // if they were really deleted and delete them from the database if they were
+      await garbageCollectActivity(dataSourceConfig, runTimestamp);
     }
 
     iterations += 1;
@@ -224,12 +213,4 @@ export async function notionSyncResultPageWorkflow(
   }
 
   await Promise.all(promises);
-}
-
-export async function notionGarbageCollectWorkflow(
-  dataSourceConfig: DataSourceConfig,
-  runTimestamp: number
-) {
-  await deletePagesNotVisitedInRunActivity(dataSourceConfig, runTimestamp);
-  await saveSuccessGarbageCollectionActivity(dataSourceConfig);
 }

--- a/connectors/src/connectors/notion/temporal/workflows.ts
+++ b/connectors/src/connectors/notion/temporal/workflows.ts
@@ -41,7 +41,7 @@ const MAX_ITERATIONS_PER_WORKFLOW = 50;
 const SYNC_PERIOD_DURATION_MS = 60_000;
 
 // How long to wait before checking for new pages again
-const INTERVAL_BETWEEN_SYNCS_MS = 10_000;
+const INTERVAL_BETWEEN_SYNCS_MS = 60_000; // 1 minute
 
 const MAX_CONCURRENT_CHILD_WORKFLOWS = 1;
 const MAX_PAGE_IDS_PER_CHILD_WORKFLOW = 100;

--- a/connectors/src/lib/models.ts
+++ b/connectors/src/lib/models.ts
@@ -162,7 +162,6 @@ export class NotionConnectorState extends Model<
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
-  declare lastGarbageCollectionStartTime?: Date;
   declare lastGarbageCollectionFinishTime?: Date;
 
   declare connectorId: ForeignKey<Connector["id"]>;
@@ -184,10 +183,6 @@ NotionConnectorState.init(
       type: DataTypes.DATE,
       allowNull: false,
       defaultValue: DataTypes.NOW,
-    },
-    lastGarbageCollectionStartTime: {
-      type: DataTypes.DATE,
-      allowNull: true,
     },
     lastGarbageCollectionFinishTime: {
       type: DataTypes.DATE,


### PR DESCRIPTION
change a bit the GC flow:
    - drop the `lastGarbageCollectionStartTime`  column, and instead only rely on finish time
    - wait for the deletion process to be completed before starting the syncing again
    - query the notion page before deleting it, and make sure that it either errors (we don't have the rights or page is fully deleted even from the garbage) or returns an archived page (the page is still technically visible on the API, but it's in the garbage)