### PR TITLE
Add errors on unused imports for /front

### DIFF
--- a/front/.eslintrc.json
+++ b/front/.eslintrc.json
@@ -12,7 +12,7 @@
     "plugin:@typescript-eslint/recommended"
     */
   ],
-  "plugins": ["simple-import-sort"],
+  "plugins": ["simple-import-sort", "unused-imports"],
   "rules": {
     /**
     "@typescript-eslint/naming-convention": [
@@ -23,6 +23,7 @@
       }
     ],
     */
+    "unused-imports/no-unused-imports": "error",
     "react/no-unescaped-entities": 0,
     "react-hooks/rules-of-hooks": 0,
     "react-hooks/exhaustive-deps": 0,

--- a/front/lib/error.ts
+++ b/front/lib/error.ts
@@ -1,6 +1,4 @@
-import { NextApiResponse } from "next";
 
-import logger from "@app/logger/logger";
 
 import { ConnectorsAPIErrorResponse } from "./connectors_api";
 import { CoreAPIErrorResponse } from "./core_api";

--- a/front/lib/error.ts
+++ b/front/lib/error.ts
@@ -1,5 +1,3 @@
-
-
 import { ConnectorsAPIErrorResponse } from "./connectors_api";
 import { CoreAPIErrorResponse } from "./core_api";
 

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -50,6 +50,7 @@
         "eslint-config-next": "^13.2.4",
         "eslint-config-prettier": "^8.8.0",
         "eslint-plugin-simple-import-sort": "^10.0.0",
+        "eslint-plugin-unused-imports": "^2.0.0",
         "jest": "^29.5.0",
         "postcss": "^8.4.21",
         "prettier": "^2.8.7",
@@ -4943,6 +4944,36 @@
       "dev": true,
       "peerDependencies": {
         "eslint": ">=5.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-unused-imports": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-2.0.0.tgz",
+      "integrity": "sha512-3APeS/tQlTrFa167ThtP0Zm0vctjr4M44HMpeg1P4bK6wItarumq0Ma82xorMKdFsWpphQBlRPzw/pxiVELX1A==",
+      "dev": true,
+      "dependencies": {
+        "eslint-rule-composer": "^0.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^5.0.0",
+        "eslint": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-rule-composer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz",
+      "integrity": "sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/eslint-scope": {

--- a/front/package.json
+++ b/front/package.json
@@ -57,6 +57,7 @@
     "eslint-config-next": "^13.2.4",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-simple-import-sort": "^10.0.0",
+    "eslint-plugin-unused-imports": "^2.0.0",
     "jest": "^29.5.0",
     "postcss": "^8.4.21",
     "prettier": "^2.8.7",

--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -6,7 +6,7 @@ import { getOrCreateSystemApiKey } from "@app/lib/auth";
 import { ConnectorProvider, ConnectorsAPI } from "@app/lib/connectors_api";
 import { CoreAPI } from "@app/lib/core_api";
 import { ReturnedAPIErrorType } from "@app/lib/error";
-import { DataSource, Key, Provider } from "@app/lib/models";
+import { DataSource } from "@app/lib/models";
 import logger from "@app/logger/logger";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import { DataSourceType } from "@app/types/data_source";

--- a/front/pages/api/w/[wId]/members/[userId]/index.ts
+++ b/front/pages/api/w/[wId]/members/[userId]/index.ts
@@ -1,7 +1,6 @@
 import { NextApiRequest, NextApiResponse } from "next";
 
-import { getMembers } from "@app/lib/api/workspace";
-import { Authenticator, getSession, RoleType } from "@app/lib/auth";
+import { Authenticator, getSession } from "@app/lib/auth";
 import { Membership, User } from "@app/lib/models";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import { UserType } from "@app/types/user";

--- a/front/pages/demo/answers-phrack.jsx
+++ b/front/pages/demo/answers-phrack.jsx
@@ -1,18 +1,14 @@
-import { Disclosure, Menu } from "@headlessui/react";
+import { Disclosure } from "@headlessui/react";
 import {
-  ArrowDownIcon,
   ArrowRightIcon,
   ChevronDownIcon,
   ChevronRightIcon,
-  ComputerDesktopIcon,
 } from "@heroicons/react/20/solid";
 import Head from "next/head";
 import Link from "next/link";
-import Script from "next/script";
 import { useState } from "react";
 import { useEffect } from "react";
 
-import { ActionButton } from "@app/components/Button";
 import { classNames } from "@app/lib/utils";
 import { timeAgoFrom } from "@app/lib/utils";
 

--- a/front/pages/w/[wId]/a/[aId]/runs/[runId]/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/runs/[runId]/index.tsx
@@ -8,7 +8,6 @@ import { useState } from "react";
 import MainTab from "@app/components/app/MainTab";
 import SpecRunView from "@app/components/app/SpecRunView";
 import AppLayout from "@app/components/AppLayout";
-import { Button } from "@app/components/Button";
 import { ActionButton } from "@app/components/Button";
 import { getApp } from "@app/lib/api/app";
 import { getRun } from "@app/lib/api/run";

--- a/front/pages/w/[wId]/ds/[name]/settings.tsx
+++ b/front/pages/w/[wId]/ds/[name]/settings.tsx
@@ -1,7 +1,7 @@
 import { ChevronRightIcon } from "@heroicons/react/20/solid";
 import { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
-import { isValidElement, useState } from "react";
+import { useState } from "react";
 
 import ModelPicker from "@app/components/app/ModelPicker";
 import AppLayout from "@app/components/AppLayout";

--- a/front/pages/w/[wId]/workspace/index.tsx
+++ b/front/pages/w/[wId]/workspace/index.tsx
@@ -1,4 +1,4 @@
-import { Listbox, Transition } from "@headlessui/react";
+import { Listbox } from "@headlessui/react";
 import { CheckIcon, ChevronUpDownIcon } from "@heroicons/react/20/solid";
 import { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import React, { useEffect, useState } from "react";
@@ -7,7 +7,6 @@ import { mutate } from "swr";
 import AppLayout from "@app/components/AppLayout";
 import { Button } from "@app/components/Button";
 import MainTab from "@app/components/profile/MainTab";
-import { getMembers } from "@app/lib/api/workspace";
 import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
 import { useMembers } from "@app/lib/swr";
 import { classNames } from "@app/lib/utils";


### PR DESCRIPTION
This could have been taken care of by the `eslint:recommended` config, but we have commented for now because it reports 300+ errors.
We should take care of that at some point and get ride of this rule