### PR TITLE
Display "synchronizing" if the last successful sync time is null

### DIFF
--- a/front/pages/w/[wId]/ds/index.tsx
+++ b/front/pages/w/[wId]/ds/index.tsx
@@ -469,7 +469,7 @@ export default function DataSourcesView({
                           );
                         }
 
-                        if (!ds.connector?.firstSuccessfulSyncTime) {
+                        if (!ds.connector?.lastSyncSuccessfulTime) {
                           return (
                             <div className="flex-col justify-items-end text-right">
                               <p className="leading-2 inline-flex rounded-full bg-green-100 px-2 text-xs font-semibold text-green-800">
@@ -480,7 +480,7 @@ export default function DataSourcesView({
                               </p>
                             </div>
                           );
-                        } else if (ds.connector.lastSyncSuccessfulTime) {
+                        } else {
                           return (
                             <>
                               <div className="flex-col justify-items-end text-right">


### PR DESCRIPTION
A data source should be considered "synchronizing" until it has a `lastSyncSuccessfulTime`, and not a `firstSuccessfulSyncTime`. That way, it does not require to populate the `firstSuccessfulSyncTime` for all existing connetors and it makes the logic simpler.

The existing code had a bug:
if a data source had a `lastSyncSuccessfulTime` and no `firstSuccessfulSyncTime`, it would have show up as "synchronizing" in the UI.