### PR TITLE
Allow viewing/running unlisted apps

### DIFF
--- a/front/lib/api/app.ts
+++ b/front/lib/api/app.ts
@@ -24,8 +24,7 @@ export async function getApp(
         }
       : {
           workspaceId: owner.id,
-          // Do not include 'unlisted' here.
-          visibility: "public",
+          visibility: ["public", "unlisted"],
           sId: aId,
         },
   });


### PR DESCRIPTION
I believe this restriction was copied from `getApps` where we should not return unlisted, but once we have an appId we should be able to retrieve an unlisted app (and possibly run it by API) as is the case for public apps