### PR TITLE
Add Slack garbage collector

### DIFF
--- a/connectors/src/admin/db.ts
+++ b/connectors/src/admin/db.ts
@@ -3,12 +3,14 @@ import {
   NotionConnectorState,
   NotionPage,
   SlackConfiguration,
+  SlackMessages,
 } from "@connectors/lib/models";
 import logger from "@connectors/logger/logger";
 
 async function main(): Promise<void> {
   await Connector.sync({ alter: true });
   await SlackConfiguration.sync({ alter: true });
+  await SlackMessages.sync({ alter: true });
   await NotionPage.sync({ alter: true });
   await NotionConnectorState.sync({ alter: true });
   return;

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -315,7 +315,7 @@ export async function syncNonThreaded(
   }
 
   const tags = getTagsForPage(channelId, channelName);
-  await SlackMessages.create({
+  await SlackMessages.upsert({
     connectorId: parseInt(connectorId),
     channelId: channelId,
     messageTs: undefined,
@@ -415,7 +415,7 @@ export async function syncThread(
 
   const tags = getTagsForPage(channelId, channelName, threadTs);
 
-  await SlackMessages.create({
+  await SlackMessages.upsert({
     connectorId: parseInt(connectorId),
     channelId: channelId,
     messageTs: threadTs,
@@ -660,6 +660,8 @@ export async function deleteChannel(
       limit: maxMessages,
     });
     for (const slackMessage of slackMessages) {
+      // We delete from the remote datasource first because we would rather double delete remotely
+      // than miss one.
       await deleteFromDataSource(dataSourceConfig, slackMessage.documentId);
       await slackMessage.destroy();
       nbDeleted++;

--- a/connectors/src/connectors/slack/temporal/workflows.ts
+++ b/connectors/src/connectors/slack/temporal/workflows.ts
@@ -25,7 +25,7 @@ const {
   fetchUsers,
   saveSuccessSyncActivity,
   reportInitialSyncProgressActivity,
-  getChannelsGargabeCollect,
+  getChannelsToGarbageCollect,
   deleteChannel,
 } = proxyActivities<typeof activities>({
   startToCloseTimeout: "10 minutes",
@@ -247,7 +247,7 @@ export async function slackGarbageCollectorWorkflow(
 ): Promise<void> {
   const slackAccessToken = await getAccessToken(nangoConnectionId);
 
-  const channelIds = await getChannelsGargabeCollect(
+  const channelIds = await getChannelsToGarbageCollect(
     slackAccessToken,
     connectorId
   );

--- a/connectors/src/connectors/slack/temporal/workflows.ts
+++ b/connectors/src/connectors/slack/temporal/workflows.ts
@@ -25,6 +25,8 @@ const {
   fetchUsers,
   saveSuccessSyncActivity,
   reportInitialSyncProgressActivity,
+  getChannelsGargabeCollect,
+  deleteChannel,
 } = proxyActivities<typeof activities>({
   startToCloseTimeout: "10 minutes",
 });
@@ -238,6 +240,22 @@ export async function memberJoinedChannel(
   // call here, which will allow the signal handler to be executed by the nodejs event loop. /!\
 }
 
+export async function slackGarbageCollectorWorkflow(
+  connectorId: string,
+  dataSourceConfig: DataSourceConfig,
+  nangoConnectionId: string
+): Promise<void> {
+  const slackAccessToken = await getAccessToken(nangoConnectionId);
+
+  const channelIds = await getChannelsGargabeCollect(
+    slackAccessToken,
+    connectorId
+  );
+  for (const channelId of channelIds) {
+    await deleteChannel(channelId, dataSourceConfig, connectorId);
+  }
+}
+
 export function workspaceFullSyncWorkflowId(connectorId: string) {
   return `slack-workspaceFullSync-${connectorId}`;
 }
@@ -267,4 +285,8 @@ export function syncOneMessageDebouncedWorkflowId(
 
 export function botJoinedChannelWorkflowId(connectorId: string) {
   return `slack-botJoinedChannel-${connectorId}`;
+}
+
+export function slackGarbageCollectorWorkflowId(connectorId: string) {
+  return `slack-GarbageCollector-${connectorId}`;
 }

--- a/connectors/src/lib/models.ts
+++ b/connectors/src/lib/models.ts
@@ -159,6 +159,64 @@ SlackConfiguration.init(
 );
 Connector.hasOne(SlackConfiguration);
 
+export class SlackMessages extends Model<
+  InferAttributes<SlackMessages>,
+  InferCreationAttributes<SlackMessages>
+> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+  declare connectorId: ForeignKey<Connector["id"]>;
+  declare channelId: string;
+  declare messageTs?: string;
+  declare documentId: string;
+}
+
+SlackMessages.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    connectorId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+    channelId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    messageTs: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
+    documentId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+  },
+  {
+    sequelize: sequelize_conn,
+    modelName: "slack_messages",
+    indexes: [
+      { fields: ["connectorId", "channelId", "messageTs"], unique: true },
+    ],
+  }
+);
+
+Connector.hasOne(SlackMessages);
+
 export class NotionConnectorState extends Model<
   InferAttributes<NotionConnectorState>,
   InferCreationAttributes<NotionConnectorState>


### PR DESCRIPTION
What it does:
Deletes all documents from a channel when we don't have access to the given channel anymore.

How it works:
Saves in the database all documents ID upserted to the data source, along with the channel ID.
When we get a webhook "channel_left" or "channel_deleted", we start the garbage process collector, which does the following:
- Diff the channels we have seen in the past vs the channels we have access to today.
- delete all the channels from the diff.