### PR TITLE
Properly send key workspace ID to core for interaction with registry

### DIFF
--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -89,7 +89,10 @@ export class Authenticator {
     return new Authenticator(workspace, role);
   }
 
-  static async fromKey(key: Key, wId: string): Promise<Authenticator> {
+  static async fromKey(
+    key: Key,
+    wId: string
+  ): Promise<{ auth: Authenticator; keyWorkspaceId: string }> {
     const [workspace, keyWorkspace] = await Promise.all([
       (async () => {
         return await Workspace.findOne({
@@ -109,13 +112,16 @@ export class Authenticator {
 
     let role = "none" as RoleType;
 
-    if (workspace && keyWorkspace) {
-      if (keyWorkspace.id === workspace.id) {
+    if (workspace) {
+      if (keyWorkspace!.id === workspace.id) {
         role = "builder";
       }
     }
 
-    return new Authenticator(workspace, role);
+    return {
+      auth: new Authenticator(workspace, role),
+      keyWorkspaceId: keyWorkspace!.sId,
+    };
   }
 
   role(): RoleType {

--- a/front/lib/core_api.ts
+++ b/front/lib/core_api.ts
@@ -5,7 +5,6 @@ import logger from "@app/logger/logger";
 import { Project } from "@app/types/project";
 import { CredentialsType } from "@app/types/provider";
 import { BlockType, RunConfig, RunRunType, RunStatus } from "@app/types/run";
-import { WorkspaceType } from "@app/types/user";
 
 const { CORE_API = "http://127.0.0.1:3001" } = process.env;
 
@@ -186,14 +185,14 @@ export const CoreAPI = {
 
   async createRun(
     projectId: string,
-    owner: WorkspaceType,
+    runAsWorkspaceId: string,
     payload: CoreAPICreateRunPayload
   ): Promise<CoreAPIResponse<{ run: CoreAPIRun }>> {
     const response = await fetch(`${CORE_API}/projects/${projectId}/runs`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        "X-Dust-Workspace-Id": owner.sId,
+        "X-Dust-Workspace-Id": runAsWorkspaceId,
       },
       body: JSON.stringify({
         run_type: payload.runType,
@@ -211,7 +210,7 @@ export const CoreAPI = {
 
   async createRunStream(
     projectId: string,
-    owner: WorkspaceType,
+    runAsWorkspaceId: string,
     payload: CoreAPICreateRunPayload
   ): Promise<
     CoreAPIResponse<{
@@ -225,7 +224,7 @@ export const CoreAPI = {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          "X-Dust-Workspace-Id": owner.sId,
+          "X-Dust-Workspace-Id": runAsWorkspaceId,
         },
         body: JSON.stringify({
           run_type: payload.runType,

--- a/front/pages/api/v1/w/[wId]/apps/[aId]/runs/[runId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/apps/[aId]/runs/[runId]/index.ts
@@ -26,7 +26,10 @@ async function handler(
   if (keyRes.isErr()) {
     return apiError(req, res, keyRes.error);
   }
-  let auth = await Authenticator.fromKey(keyRes.value, req.query.wId as string);
+  let { auth } = await Authenticator.fromKey(
+    keyRes.value,
+    req.query.wId as string
+  );
 
   const owner = auth.workspace();
   if (!owner) {

--- a/front/pages/api/v1/w/[wId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/v1/w/[wId]/apps/[aId]/runs/index.ts
@@ -83,7 +83,10 @@ async function handler(
   if (keyRes.isErr()) {
     return apiError(req, res, keyRes.error);
   }
-  let auth = await Authenticator.fromKey(keyRes.value, req.query.wId as string);
+  let { auth, keyWorkspaceId } = await Authenticator.fromKey(
+    keyRes.value,
+    req.query.wId as string
+  );
 
   const owner = auth.workspace();
   if (!owner) {
@@ -167,7 +170,7 @@ async function handler(
       if (req.body.stream) {
         const runRes = await CoreAPI.createRunStream(
           app.dustAPIProjectId,
-          owner,
+          keyWorkspaceId,
           {
             runType: "deploy",
             specificationHash: specificationHash,
@@ -234,13 +237,17 @@ async function handler(
         return;
       }
 
-      const runRes = await CoreAPI.createRun(app.dustAPIProjectId, owner, {
-        runType: "deploy",
-        specificationHash: specificationHash,
-        config: { blocks: config },
-        inputs,
-        credentials,
-      });
+      const runRes = await CoreAPI.createRun(
+        app.dustAPIProjectId,
+        keyWorkspaceId,
+        {
+          runType: "deploy",
+          specificationHash: specificationHash,
+          config: { blocks: config },
+          inputs,
+          credentials,
+        }
+      );
 
       if (runRes.isErr()) {
         return apiError(req, res, {

--- a/front/pages/api/v1/w/[wId]/apps/index.ts
+++ b/front/pages/api/v1/w/[wId]/apps/index.ts
@@ -18,7 +18,10 @@ async function handler(
   if (keyRes.isErr()) {
     return apiError(req, res, keyRes.error);
   }
-  let auth = await Authenticator.fromKey(keyRes.value, req.query.wId as string);
+  let { auth } = await Authenticator.fromKey(
+    keyRes.value,
+    req.query.wId as string
+  );
 
   let apps = await getApps(auth);
 

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
@@ -49,7 +49,10 @@ async function handler(
   if (keyRes.isErr()) {
     return apiError(req, res, keyRes.error);
   }
-  let auth = await Authenticator.fromKey(keyRes.value, req.query.wId as string);
+  let { auth } = await Authenticator.fromKey(
+    keyRes.value,
+    req.query.wId as string
+  );
 
   const owner = auth.workspace();
   if (!owner) {

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/index.ts
@@ -20,7 +20,10 @@ async function handler(
   if (keyRes.isErr()) {
     return apiError(req, res, keyRes.error);
   }
-  let auth = await Authenticator.fromKey(keyRes.value, req.query.wId as string);
+  let { auth } = await Authenticator.fromKey(
+    keyRes.value,
+    req.query.wId as string
+  );
 
   const dataSource = await getDataSource(auth, req.query.name as string);
 

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/search.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/search.ts
@@ -51,7 +51,10 @@ export default async function handler(
   if (keyRes.isErr()) {
     return apiError(req, res, keyRes.error);
   }
-  let auth = await Authenticator.fromKey(keyRes.value, req.query.wId as string);
+  let { auth } = await Authenticator.fromKey(
+    keyRes.value,
+    req.query.wId as string
+  );
 
   const dataSource = await getDataSource(auth, req.query.name as string);
 

--- a/front/pages/api/v1/w/[wId]/data_sources/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/index.ts
@@ -18,7 +18,10 @@ async function handler(
   if (keyRes.isErr()) {
     return apiError(req, res, keyRes.error);
   }
-  let auth = await Authenticator.fromKey(keyRes.value, req.query.wId as string);
+  let { auth } = await Authenticator.fromKey(
+    keyRes.value,
+    req.query.wId as string
+  );
 
   const dataSources = await getDataSources(auth);
 

--- a/front/pages/api/w/[wId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/runs/index.ts
@@ -119,7 +119,7 @@ async function handler(
 
           const streamRes = await CoreAPI.createRunStream(
             app.dustAPIProjectId,
-            owner,
+            owner.sId,
             {
               runType: "execute",
               specificationHash: req.body.specificationHash,
@@ -227,16 +227,20 @@ async function handler(
             ? inputConfigEntry.dataset
             : null;
 
-          const dustRun = await CoreAPI.createRun(app.dustAPIProjectId, owner, {
-            runType: "local",
-            specification: dumpSpecification(
-              JSON.parse(req.body.specification),
-              latestDatasets
-            ),
-            datasetId: inputDataset,
-            config: { blocks: config },
-            credentials: credentialsFromProviders(providers),
-          });
+          const dustRun = await CoreAPI.createRun(
+            app.dustAPIProjectId,
+            owner.sId,
+            {
+              runType: "local",
+              specification: dumpSpecification(
+                JSON.parse(req.body.specification),
+                latestDatasets
+              ),
+              datasetId: inputDataset,
+              config: { blocks: config },
+              credentials: credentialsFromProviders(providers),
+            }
+          );
 
           if (dustRun.isErr()) {
             return apiError(req, res, {


### PR DESCRIPTION
This is a bit finicky so here's the explanation. When going to core with the data source block, we send the workspaceId and dataSourceId (it's name)

When in core the dataSource exists in a projectId but we don't know it so we call back to front's registry to find it out. But we need to enforce we have the right to do so. That's the use of the X-Dust-Workspace-Id header which floats through core back to the registry to tell front which workspace is making the call.

When running an app by API we were using the workspace of the app wrongly, this fixes it to use the workspace of the key.