### PR TITLE
Adds support for retrying retryable server_error issues from OpenAI

### DIFF
--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -137,6 +137,10 @@ impl Error {
     pub fn retryable(&self) -> bool {
         match self.error._type.as_str() {
             "requests" => true,
+            "server_error" => match &self.error.internal_message {
+                Some(message) if message.contains("retry") => true,
+                _ => false,
+            },
             _ => false,
         }
     }


### PR DESCRIPTION
Simple matching for errors like:

`Error querying `openai:gpt-3.5-turbo`: error=[model_error(retryable=false)] OpenAIAPIError: [server_error] That model is currently overloaded with other requests. You can retry your request, or contact us through our help center at help.openai.com if the error persists. (Please include the request ID 5abefc12b164aadd9829e7f8c0e2dc23 in your message.)`