### PR TITLE
Log differently unhandled errors for introspection

### DIFF
--- a/connectors/src/lib/temporal_monitoring.ts
+++ b/connectors/src/lib/temporal_monitoring.ts
@@ -74,7 +74,7 @@ export class ActivityInboundLogInterceptor
               error_stack: error?.stack,
               durationMs: durationMs,
             },
-            "Activity failed"
+            "Unhandled activity error"
           );
         }
 


### PR DESCRIPTION
There was new unhandled activity error during the slack resync this weekend:
https://app.datadoghq.eu/dashboard/4vq-e7g-k8g/connectors-status?from_ts=1683926704491&to_ts=1683983761094&live=false

But the logging makes it hard (not possible) to find them easily. This PR changes the log message when this is an unhandled activity error for easier introspection