### PR TITLE
Data Source new UI

### DIFF
--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -1043,7 +1043,7 @@ async fn data_sources_register(
             Json(APIResponse {
                 error: Some(APIError {
                     code: String::from("internal_server_error"),
-                    message: format!("Failed to register data source: {}", e),
+                    message: format!("Failed to register Data Source: {}", e),
                 }),
                 response: None,
             }),
@@ -1054,7 +1054,7 @@ async fn data_sources_register(
                 Json(APIResponse {
                     error: Some(APIError {
                         code: String::from("internal_server_error"),
-                        message: format!("Failed to register data source: {}", e),
+                        message: format!("Failed to register Data Source: {}", e),
                     }),
                     response: None,
                 }),
@@ -1103,7 +1103,7 @@ async fn data_sources_search(
             Json(APIResponse {
                 error: Some(APIError {
                     code: String::from("internal_server_error"),
-                    message: format!("Failed to retrieve data source: {}", e),
+                    message: format!("Failed to retrieve Data Source: {}", e),
                 }),
                 response: None,
             }),
@@ -1114,7 +1114,7 @@ async fn data_sources_search(
                 Json(APIResponse {
                     error: Some(APIError {
                         code: String::from("data_source_not_found"),
-                        message: format!("No data source found for id `{}`", data_source_id),
+                        message: format!("No Data Source found for id `{}`", data_source_id),
                     }),
                     response: None,
                 }),
@@ -1182,7 +1182,7 @@ async fn data_sources_documents_upsert(
             Json(APIResponse {
                 error: Some(APIError {
                     code: String::from("internal_server_error"),
-                    message: format!("Failed to retrieve data source: {}", e),
+                    message: format!("Failed to retrieve Data Source: {}", e),
                 }),
                 response: None,
             }),
@@ -1193,7 +1193,7 @@ async fn data_sources_documents_upsert(
                 Json(APIResponse {
                     error: Some(APIError {
                         code: String::from("data_source_not_found"),
-                        message: format!("No data source found for id `{}`", data_source_id),
+                        message: format!("No Data Source found for id `{}`", data_source_id),
                     }),
                     response: None,
                 }),
@@ -1265,7 +1265,7 @@ async fn data_sources_documents_list(
             Json(APIResponse {
                 error: Some(APIError {
                     code: String::from("internal_server_error"),
-                    message: format!("Failed to list data source: {}", e),
+                    message: format!("Failed to list Data Source: {}", e),
                 }),
                 response: None,
             }),
@@ -1302,7 +1302,7 @@ async fn data_sources_documents_retrieve(
             Json(APIResponse {
                 error: Some(APIError {
                     code: String::from("internal_server_error"),
-                    message: format!("Failed to retrieve data source: {}", e),
+                    message: format!("Failed to retrieve Data Source: {}", e),
                 }),
                 response: None,
             }),
@@ -1313,7 +1313,7 @@ async fn data_sources_documents_retrieve(
                 Json(APIResponse {
                     error: Some(APIError {
                         code: String::from("data_source_not_found"),
-                        message: format!("No data source found for id `{}`", data_source_id),
+                        message: format!("No Data Source found for id `{}`", data_source_id),
                     }),
                     response: None,
                 }),
@@ -1375,7 +1375,7 @@ async fn data_sources_documents_delete(
             Json(APIResponse {
                 error: Some(APIError {
                     code: String::from("internal_server_error"),
-                    message: format!("Failed to retrieve data source: {}", e),
+                    message: format!("Failed to retrieve Data Source: {}", e),
                 }),
                 response: None,
             }),
@@ -1386,7 +1386,7 @@ async fn data_sources_documents_delete(
                 Json(APIResponse {
                     error: Some(APIError {
                         code: String::from("data_source_not_found"),
-                        message: format!("No data source found for id `{}`", data_source_id),
+                        message: format!("No Data Source found for id `{}`", data_source_id),
                     }),
                     response: None,
                 }),
@@ -1437,7 +1437,7 @@ async fn data_sources_delete(
             Json(APIResponse {
                 error: Some(APIError {
                     code: String::from("internal_server_error"),
-                    message: format!("Failed to retrieve data source: {}", e),
+                    message: format!("Failed to retrieve Data Source: {}", e),
                 }),
                 response: None,
             }),
@@ -1448,7 +1448,7 @@ async fn data_sources_delete(
                 Json(APIResponse {
                     error: Some(APIError {
                         code: String::from("data_source_not_found"),
-                        message: format!("No data source found for id `{}`", data_source_id),
+                        message: format!("No Data Source found for id `{}`", data_source_id),
                     }),
                     response: None,
                 }),
@@ -1459,7 +1459,7 @@ async fn data_sources_delete(
                     Json(APIResponse {
                         error: Some(APIError {
                             code: String::from("internal_server_error"),
-                            message: format!("Failed to delete data source: {}", e),
+                            message: format!("Failed to delete Data Source: {}", e),
                         }),
                         response: None,
                     }),

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -759,7 +759,7 @@ impl DataSource {
         });
 
         utils::done(&format!(
-            "Searched data source: data_source_id={} document_count={} chunk_count={}",
+            "Searched Data Source: data_source_id={} document_count={} chunk_count={}",
             self.data_source_id,
             documents.len(),
             documents.iter().map(|d| d.chunks.len()).sum::<usize>(),
@@ -867,13 +867,13 @@ impl DataSource {
             self.data_source_id,
         ));
 
-        // Delete data source and documents (SQL)
+        // Delete Data Source and documents (SQL)
         store
             .delete_data_source(&self.project, &self.data_source_id)
             .await?;
 
         utils::done(&format!(
-            "Deleted data source records: data_source_id={}",
+            "Deleted Data Source records: data_source_id={}",
             self.data_source_id,
         ));
 

--- a/docs/src/components/Guides.jsx
+++ b/docs/src/components/Guides.jsx
@@ -21,7 +21,7 @@ const guides = [
     href: "/guide-document-qa",
     name: "Document Q&A",
     description:
-      "Step-by-step guide to creating a document Q&A app using DataSources.",
+      "Step-by-step guide to creating a document Q&A app using Data Sources.",
   },
   // {
   //   href: '/webhooks',

--- a/docs/src/pages/core-blocks.mdx
+++ b/docs/src/pages/core-blocks.mdx
@@ -337,15 +337,15 @@ contain an array of 4 `{ "foo": "bar" }` objects.
 
 ## DataSource block
 
-The `data_source` block provides an interface to query a [data source](/data-sources-overview) and
+The `data_source` block provides an interface to query a [Data Source](/data-sources-overview) and
 return chunks that are semantically similar to the query provided. When executed, the query is
-embedded using the embedding model set on the data source and the resulting enmbedding vector
-is used to perform semantic search on the data source's chunks.
+embedded using the embedding model set on the Data Source and the resulting enmbedding vector
+is used to perform semantic search on the Data Source's chunks.
 
 The output of the `data_source` block is a list of [Document](/documents#the-document-model)
 objects. Each document may include one or more [Chunks](/documents#the-chunk-model) (only those
 that were returned from the search). The documents are sorted by decreasing order of the max of
-their retrieved chunks score. Please refer to the [data sources overview](/data-sources-overview)
+their retrieved chunks score. Please refer to the [Data Sources overview](/data-sources-overview)
 for more details about how documents are chunked to enable semantic search.
 
 ### Specification
@@ -375,11 +375,11 @@ for more details about how documents are chunked to enable semantic search.
     retrieved chunks.
   </Property>
   <Property name="data_sources" type="[]{username, data_source_id}">
-    An array of objects representing the data sources to query. Note that the
-    Dust interface currently only supports adding one data source to a block,
+    An array of objects representing the Data Sources to query. Note that the
+    Dust interface currently only supports adding one Data Source to a block,
     but you can pass many by API. The objects must have the following
-    properties: `username`, the username of the user who owns the data source,
-    and, `data_source_id`, The name of the data source.
+    properties: `username`, the username of the user who owns the Data Source,
+    and, `data_source_id`, The name of the Data Source.
   </Property>
   <Property
     name="filter"

--- a/docs/src/pages/data-sources-overview.mdx
+++ b/docs/src/pages/data-sources-overview.mdx
@@ -1,16 +1,16 @@
-export const description = "An overview of Dust's data sources.";
+export const description = "An overview of Dust's Data Sources.";
 
 # Data Sources
 
-An overview of Dust's data sources. You'll learn how to create data sources, upload documents and
+An overview of Dust's Data Sources. You'll learn how to create Data Sources, upload documents and
 leverage them to build more context-aware apps. {{ className: 'lead' }}
 
-Dust's data sources provide a fully managed semantic search solution. A data source is a managed
+Dust's Data Sources provide a fully managed semantic search solution. A Data Source is a managed
 store of documents on which semantic searches can be performed. Documents can be ingested by API or
 uploaded manually from the Dust interface.
 
 Once uploaded, documents are automatically chunked, embedded and indexed. Searches can be performed
-against the documents of a data source using the [`data_source`](core-blocks#data-source-block)
+against the documents of a Data Source using the [`data_source`](core-blocks#data-source-block)
 block which, given a query, automatically embeds it and performs a vector search operation to
 retrieve the most semantically relevant documents and associated chunks.
 
@@ -29,28 +29,28 @@ and finally performing vector search queries.
 
 ## Data Source creation
 
-Creating a data source consists in providing a name, description, an embedding model to use as well
+Creating a Data Source consists in providing a name, description, an embedding model to use as well
 as `max_chunk_size`, the targeted number of tokens for each chunks. The embedding model must be
-provided at data source creation and cannot be changed in the future (since the model used when
+provided at Data Source creation and cannot be changed in the future (since the model used when
 embedding documents chunks and search quries must be consistent).
 
 ### Parameters
 
 <Properties>
   <Property name="name" type="string">
-    The name of the new data source. It should be short and can only contain
+    The name of the new Data Source. It should be short and can only contain
     lowercase alphanumerical characters as well as `-`.
   </Property>
   <Property name="description" type="optional string">
-    A description of the content of the data source.
+    A description of the content of the Data Source.
   </Property>
   <Property name="visibility" type="string">
-    One of _public_ or _private_. Only you can edit your own data sources. If
-    _public_ other users can view the data source and query from it.
+    One of _public_ or _private_. Only you can edit your own Data Sources. If
+    _public_ other users can view the Data Source and query from it.
   </Property>
   <Property name="embedded" type="model">
-    The model to use for the data source. This is set at creation and cannot be
-    changed later (as it would require re-embedding the entire data source).
+    The model to use for the Data Source. This is set at creation and cannot be
+    changed later (as it would require re-embedding the entire Data Source).
     This is the model used to embed document chunks when they are ingested as
     well as queries when searches are peformed (the same model must be used for
     both).
@@ -86,13 +86,13 @@ best.
 
 ## Document insertion
 
-Once a data source is created, documents can be inserted from the Dust interface or by API. When
+Once a Data Source is created, documents can be inserted from the Dust interface or by API. When
 a document is inserted, the following happens automatically:
 
 - **Chunking**: The document is pre-processed to remove repeated whitespaces (helps semantic search)
   and chunked using `max_chunk_size` tokens per chunks.
 - **Embedding**: Each chunk is embedded (in parallel, with retries) using the embedding model
-  parametered on the data source.
+  parametered on the Data Source.
 - **Indexing**: Each resulting embedding vector is inserted in a vector search database along with
   metadata about the document and the original chunk text.
 
@@ -113,12 +113,12 @@ The following parameters are accepted when inserting a document:
   </Property>
   <Property name="timestamp" type="optional integer">
     User specified timestamp (epoch in ms) for the document. Can be used to
-    filter documents when querying the data source based on their timestamp. If
+    filter documents when querying the Data Source based on their timestamp. If
     not specified, defaults to the time at insertion.
   </Property>
   <Property name="tags" type="optional []string">
     User specified list of string tags. Can be used to filter the results by
-    tags when querying the data source. See the
+    tags when querying the Data Source. See the
     [`data_source`](core-blocks#data-source-block) block for more details. If
     not specified, defaults to the empty list.
   </Property>
@@ -133,7 +133,7 @@ sources need to be created from the Dust interface.
 ## Document deletion
 
 When deleting a document, all associated chunks are automatically removed from the vector search
-database of the data source. Documents can be deleted from the Dust interface or by API.
+database of the Data Source. Documents can be deleted from the Dust interface or by API.
 
 <Note>
   Data sources can be deleted from the Dust interface. When deleted, all
@@ -145,15 +145,15 @@ See the [Documents](/documents) API reference to learn how to delete documents b
 
 ## Querying a Data Source
 
-Querying a data source is done using the [`data_source`](core-blocks#data-source-block) block. The
+Querying a Data Source is done using the [`data_source`](core-blocks#data-source-block) block. The
 `data_source` block returns a list of [Document](/data-sources#the-document-model) objects. Each
 document may include one or more [Chunks](/data-sources#the-chunk-model) (the chunks returned by
 the semantic search are aggregated per document).
 
 When a query is run the following happens automatically:
 
-- **Embedding**: The query is embedded using the embedding model set on the data source.
-- **Search**: A vector search query is run against the embedding vectors of the data source's
+- **Embedding**: The query is embedded using the embedding model set on the Data Source.
+- **Search**: A vector search query is run against the embedding vectors of the Data Source's
   documents' chunks.
 - **Union**: Most relevant chunks' documents are retrieved and chunks are associated to their
   original document object.

--- a/docs/src/pages/documents.mdx
+++ b/docs/src/pages/documents.mdx
@@ -1,9 +1,9 @@
 export const description =
-  "On this page, we’ll dive into the Documents endpoints you can use to manage data sources programmatically.";
+  "On this page, we’ll dive into the Documents endpoints you can use to manage Data Sources programmatically.";
 
 # Documents
 
-On this page we'll dive into the DataSources endpoint you can use to manage data sources
+On this page we'll dive into the Data Sources endpoint you can use to manage Data Sources
 programmatically. We'll look at how to insert, retrieve, list and delete documents from a [data
 source](/data-sources-overview). {{ className: 'lead' }}
 
@@ -15,7 +15,7 @@ key in your account's **API keys** panel.
 
 ## The Chunk model
 
-The Chunk model represents a chunk from a document. See the [data sources
+The Chunk model represents a chunk from a document. See the [Data Sources
 overview](/data-sources-overview) to better understand how documents are chunked as part of a data
 source to enable semantic search.
 
@@ -41,7 +41,7 @@ source to enable semantic search.
 
 ## The Document model
 
-The Document model represents a [data source](/data-sources-overview) document.
+The Document model represents a [Data Source](/data-sources-overview) document.
 
 ### Properties
 
@@ -54,12 +54,12 @@ The Document model represents a [data source](/data-sources-overview) document.
   </Property>
   <Property name="timestamp" type="integer">
     User specified timestamp (epoch in ms) for the document. Can be used to
-    filter documents when querying the data source based on their timestamp. If
+    filter documents when querying the Data Source based on their timestamp. If
     not specified, defaults to the value of _created_.
   </Property>
   <Property name="tags" type="[]string">
     User specified list of string tags. Can be used to filter the results by
-    tags when querying the data source. See the
+    tags when querying the Data Source. See the
     [`data_source`](core-blocks#data-source-block) block for more details. If
     not specified, defaults to the empty list.{" "}
   </Property>
@@ -90,18 +90,18 @@ The Document model represents a [data source](/data-sources-overview) document.
 <Row>
   <Col>
 
-    This endpoint enables you to insert a new document to a data source. The semantic of this
+    This endpoint enables you to insert a new document to a Data Source. The semantic of this
     endpoint is an _upsert_: if the `document_id` does not exists it gets replaced, otherwise it
-    gets replaced. You can only insert documents to the data sources you own.
+    gets replaced. You can only insert documents to the Data Sources you own.
 
     ### URL attributes
 
     <Properties>
       <Property name="workspace_id" type="string">
-        The ID of the data source's workspace (can be found in the data source's URL)
+        The ID of the Data Source's workspace (can be found in the Data Source's URL)
       </Property>
       <Property name="data_source_name" type="string">
-        The name of the data source you want to insert a document to.
+        The name of the Data Source you want to insert a document to.
       </Property>
       <Property name="document_id" type="string">
         The ID of the document you want to insert or replace (upsert). This can be anything, make
@@ -204,10 +204,10 @@ The Document model represents a [data source](/data-sources-overview) document.
 
     <Properties>
       <Property name="workspace_id" type="string">
-        The ID of the data source's workspace (can be found in the data source's URL)
+        The ID of the Data Source's workspace (can be found in the Data Source's URL)
       </Property>
       <Property name="data_source_name" type="string">
-        The name of the data source you want to insert a document to.
+        The name of the Data Source you want to insert a document to.
       </Property>
       <Property name="document_id" type="string">
         The ID of the document you want to insert or replace (upsert). This can be anything, make
@@ -256,16 +256,16 @@ The Document model represents a [data source](/data-sources-overview) document.
   <Col>
 
     This endpoint enables you to delete a document by ID. All data relative to the document will be
-    deleted (and associated chunks removed from the data source vector search database).
+    deleted (and associated chunks removed from the Data Source vector search database).
 
     ### URL attributes
 
     <Properties>
       <Property name="workspace_id" type="string">
-        The ID of the data source's workspace (can be found in the data source's URL)
+        The ID of the Data Source's workspace (can be found in the Data Source's URL)
       </Property>
       <Property name="data_source_name" type="string">
-        The name of the data source you want to insert a document to.
+        The name of the Data Source you want to insert a document to.
       </Property>
       <Property name="document_id" type="string">
         The ID of the document you want to insert or replace (upsert). This can be anything, make
@@ -303,16 +303,16 @@ The Document model represents a [data source](/data-sources-overview) document.
 <Row>
   <Col>
 
-    This endpoint enables you to list the documents of a data source.
+    This endpoint enables you to list the documents of a Data Source.
 
     ### URL attributes
 
     <Properties>
       <Property name="workspace_id" type="string">
-        The ID of the data source's workspace (can be found in the data source's URL)
+        The ID of the Data Source's workspace (can be found in the Data Source's URL)
       </Property>
       <Property name="data_source_name" type="string">
-        The name of the data source you want to insert a document to.
+        The name of the Data Source you want to insert a document to.
       </Property>
     </Properties>
 
@@ -322,10 +322,10 @@ The Document model represents a [data source](/data-sources-overview) document.
 
     <Properties>
       <Property name="offset" type="integer">
-        The offset to use to retrieve the documents from the data source, for paging.
+        The offset to use to retrieve the documents from the Data Source, for paging.
       </Property>
       <Property name="limit" type="integer">
-        The maximum number of documents to retrieve from the data source, for paging.
+        The maximum number of documents to retrieve from the Data Source, for paging.
       </Property>
     </Properties>
 
@@ -381,16 +381,16 @@ The Document model represents a [data source](/data-sources-overview) document.
 <Row>
   <Col>
 
-    This endpoint enables you to perform a semantic search on your data source's documents.
+    This endpoint enables you to perform a semantic search on your Data Source's documents.
 
     ### URL attributes
 
     <Properties>
       <Property name="workspace_id" type="string">
-        The ID of the data source's workspace (can be found in the data source's URL)
+        The ID of the Data Source's workspace (can be found in the Data Source's URL)
       </Property>
       <Property name="data_source_name" type="string">
-        The name of the data source you want to perform your search against.
+        The name of the Data Source you want to perform your search against.
       </Property>
     </Properties>
 

--- a/docs/src/pages/guide-document-qa.mdx
+++ b/docs/src/pages/guide-document-qa.mdx
@@ -39,7 +39,7 @@ We will use a Data Source to automatically chunk, embed and index 4 IPCC reports
   [ipcc-ar6](https://dust.tt/w/3e26b0e764/ds/ipcc-ar6) in the rest of the guide.
 </Note>
 
-You can create your first Data Source from your Dust home page by selecting the **DataSources** tab
+You can create your first Data Source from your Dust home page by selecting the **Data Sources** tab
 and clicking on the **New DataSource** button. You'll need to provide a name and description as well
 as select OpenAI's embedding model `text-embedding-ada-002`. Finally, it is important to pick a
 `max_chunk_size` value. We decided to use `max_chunk_size=256` for this example (in tokens), to be
@@ -55,9 +55,9 @@ use case and the model you use (as an example, `gpt-4` has 8192 tokens of contex
 
 <Image
   src="/guide_document_qa_newdatasource.png"
-  alt="Dust data source creation panel"
+  alt="Dust Data Source creation panel"
 >
-  _The Dust data source creation panel. The `name` should be short and
+  _The Dust Data Source creation panel. The `name` should be short and
   memorable, lowercase without spaces._
 </Image>
 
@@ -74,21 +74,21 @@ if it already existed for the provided identifier.
 
 <Image
   src="/guide_document_qa_insertdocument.png"
-  alt="Dust data source document insertion"
+  alt="Dust Data Source document insertion"
 >
-  _The Dust data source document insertion interface. Tags are optional and
+  _The Dust Data Source document insertion interface. Tags are optional and
   arbitrary. The text content was filled here using the **Upload** button._
 </Image>
 
 Once the 4 documents are inserted, you should be able to see them in the Data Source interface. You
-can review the public [ipcc-ar6](https://dust.tt/w/3e26b0e764/ds/ipcc-ar6) data source as an
+can review the public [ipcc-ar6](https://dust.tt/w/3e26b0e764/ds/ipcc-ar6) Data Source as an
 example.
 
 <Image
   src="/guide_document_qa_datasource.png"
-  alt="Dust data source document list"
+  alt="Dust Data Source document list"
 >
-  _The Dust data source documents list. You can inspect and edit each of the
+  _The Dust Data Source documents list. You can inspect and edit each of the
   document from this interface. The size of each document and the resulting
   number of chunks that were created, embedded and indexed is also reported._
 </Image>
@@ -109,20 +109,20 @@ From your home screen create a new app by clicking the **Apps** tab and then the
 
 Assuming you've already covered our [Quickstart guide](/quickstart#add-your-first-block), add an
 input block and associate it with a new dataset with a few questions that might be relevant to the
-data source:
+Data Source:
 
 <Image
   src="/guide_document_qa_devdataset.png"
   alt="Dust dev dataset to associate to input block"
 >
-  _An example dataset with questions relative to the data source we plan to use.
+  _An example dataset with questions relative to the Data Source we plan to use.
   Each question is a different input against which we will design our app._
 </Image>
 
 ### `data_source` block
 
 Once the `input` block points to your new dataset you can add a `data_source` block and select your
-data source. If you want to use the publicly available data source
+Data Source. If you want to use the publicly available Data Source
 [ipcc-ar6](https://dust.tt/w/3e26b0e764/ds/ipcc-ar6), edit the user name to `spolu` and then select
 `ipcc-ar6`. You should set `top_k` to 12, meaning that we'll consume 3072 tokens of context to
 present chunks to the model.
@@ -135,7 +135,7 @@ value:
 ```
 
 <Image src="/guide_document_qa_ds_block.png" alt="Dust `data_source` block">
-  _The Dust `data_source` block pointing to the public `ipcc-ar6` data source.
+  _The Dust `data_source` block pointing to the public `ipcc-ar6` Data Source.
   The query is set to the input value question field using templating._
 </Image>
 

--- a/docs/src/pages/introduction.mdx
+++ b/docs/src/pages/introduction.mdx
@@ -183,19 +183,19 @@ to discuss the same concept (for example "dog" and "canine").
 The process of retrieving highly similar vectors and their associated chunks given a query (and its
 vector) is called (embedding) _vector search_ or _semantic search_.
 
-See [data sources](/data-sources-overview) to learn more about how Dust provides fully-managed
+See [Data Sources](/data-sources-overview) to learn more about how Dust provides fully-managed
 solutions to automatically embed documents and perform vector search on the resulting database.
 
 ## Large Language Model Apps
 
 A large language model app is a chain of one or multiple prompted calls to models or external
-services (such as APIs or data sources) designed to perform a particular task. Said otherwise, a
+services (such as APIs or Data Sources) designed to perform a particular task. Said otherwise, a
 large language model app is an orchestration layer that sits on top of a model in order to
 specialize its behavior to perform a specific task.
 
 <Note>
   A large language model app is a chain of one or multiple prompted calls to
-  models or external services (such as APIs or data sources) in order to achieve
+  models or external services (such as APIs or Data Sources) in order to achieve
   a particular task.
 </Note>
 

--- a/docs/src/pages/overview.mdx
+++ b/docs/src/pages/overview.mdx
@@ -149,7 +149,7 @@ execution eagearly when they are used.
 ## Data sources
 
 [Data sources](/data-sources-overview) are fully managed semantically searchable databases of
-documents. You can easily create data sources and add documents to them manually in the Dust
+documents. You can easily create Data Sources and add documents to them manually in the Dust
 interface or using our API. Data sources enable apps to perform semantic searches over large
 collections of documents, only retrieving the chunks of information that are the most relevant to
 the app's task.
@@ -162,5 +162,5 @@ is called _retrieval-augmented generation_.
 Typically, to perform semantic search, one has to chunk, embed and index the documents they desire
 to make them searchable from a vector database. When answering a query they then have to embed the
 query, perform a search in the vector database and retrieve the associated documents and relevant
-chunks of text. Dust simplifies this process by providing a data source abstraction that allows you
+chunks of text. Dust simplifies this process by providing a Data Source abstraction that allows you
 to simply upload documents and query them from the associated `data_source` block.

--- a/front/components/app/blocks/DataSource.tsx
+++ b/front/components/app/blocks/DataSource.tsx
@@ -183,7 +183,7 @@ export default function DataSource({
       <div className="mx-4 flex w-full flex-col">
         <div className="flex flex-col xl:flex-row xl:space-x-2">
           <div className="mr-2 flex flex-initial flex-row items-center space-x-1 text-sm font-medium leading-8 text-gray-700">
-            <div className="mr-1 flex flex-initial">data source:</div>
+            <div className="mr-1 flex flex-initial">Data Source:</div>
             <DataSourcePicker
               owner={owner}
               readOnly={readOnly}

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
@@ -60,7 +60,7 @@ async function handler(
       status_code: 404,
       api_error: {
         type: "data_source_not_found",
-        message: "The data source you requested was not found.",
+        message: "The Data Source you requested was not found.",
       },
     });
   }
@@ -72,7 +72,7 @@ async function handler(
       status_code: 404,
       api_error: {
         type: "data_source_not_found",
-        message: "The data source you requested was not found.",
+        message: "The Data Source you requested was not found.",
       },
     });
   }
@@ -90,7 +90,7 @@ async function handler(
           status_code: 400,
           api_error: {
             type: "data_source_error",
-            message: "There was an error retrieving the data source document.",
+            message: "There was an error retrieving the Data Source document.",
             data_source_error: docRes.error,
           },
         });
@@ -118,7 +118,7 @@ async function handler(
           status_code: 403,
           api_error: {
             type: "data_source_auth_error",
-            message: "You cannot upsert a document on a managed data source.",
+            message: "You cannot upsert a document on a managed Data Source.",
           },
         });
       }
@@ -204,7 +204,7 @@ async function handler(
           status_code: 400,
           api_error: {
             type: "data_source_error",
-            message: "There was an error retrieving the data source.",
+            message: "There was an error retrieving the Data Source.",
             data_source_error: documents.error,
           },
         });
@@ -302,7 +302,7 @@ async function handler(
           status_code: 403,
           api_error: {
             type: "data_source_auth_error",
-            message: "You cannot delete a document from a managed data source.",
+            message: "You cannot delete a document from a managed Data Source.",
           },
         });
       }

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/index.ts
@@ -32,7 +32,7 @@ async function handler(
       status_code: 404,
       api_error: {
         type: "data_source_not_found",
-        message: "The data source you requested was not found.",
+        message: "The Data Source you requested was not found.",
       },
     });
   }
@@ -53,7 +53,7 @@ async function handler(
           status_code: 400,
           api_error: {
             type: "data_source_error",
-            message: "There was an error retrieving the data source documents.",
+            message: "There was an error retrieving the Data Source documents.",
             data_source_error: documents.error,
           },
         });

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/search.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/search.ts
@@ -63,7 +63,7 @@ export default async function handler(
       status_code: 404,
       api_error: {
         type: "data_source_not_found",
-        message: "The data source you requested was not found.",
+        message: "The Data Source you requested was not found.",
       },
     });
   }
@@ -79,7 +79,7 @@ export default async function handler(
 
       let credentials: CredentialsType | null = null;
       if (keyRes.value.isSystem) {
-        // Dust managed credentials: system API key (managed data source).
+        // Dust managed credentials: system API key (managed Data Source).
         credentials = dustManagedCredentials();
       } else {
         let providers = await Provider.findAll({
@@ -129,7 +129,7 @@ export default async function handler(
           status_code: 400,
           api_error: {
             type: "data_source_error",
-            message: "There was an error performing the data source search.",
+            message: "There was an error performing the Data Source search.",
             data_source_error: data.error,
           },
         });

--- a/front/pages/api/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
@@ -30,7 +30,7 @@ async function handler(
       status_code: 404,
       api_error: {
         type: "data_source_not_found",
-        message: "The data source you requested was not found.",
+        message: "The Data Source you requested was not found.",
       },
     });
   }
@@ -42,7 +42,7 @@ async function handler(
       status_code: 404,
       api_error: {
         type: "data_source_not_found",
-        message: "The data source you requested was not found.",
+        message: "The Data Source you requested was not found.",
       },
     });
   }
@@ -65,7 +65,7 @@ async function handler(
           status_code: 403,
           api_error: {
             type: "data_source_auth_error",
-            message: "You cannot upsert a document on a managed data source.",
+            message: "You cannot upsert a document on a managed Data Source.",
           },
         });
       }
@@ -145,7 +145,7 @@ async function handler(
           status_code: 400,
           api_error: {
             type: "data_source_error",
-            message: "There was an error retrieving the data source.",
+            message: "There was an error retrieving the Data Source.",
             data_source_error: documents.error,
           },
         });
@@ -225,7 +225,7 @@ async function handler(
           api_error: {
             type: "data_source_error",
             message:
-              "There was an error retrieving the data source's document.",
+              "There was an error retrieving the Data Source's document.",
             data_source_error: document.error,
           },
         });
@@ -253,7 +253,7 @@ async function handler(
           status_code: 403,
           api_error: {
             type: "data_source_auth_error",
-            message: "You cannot delete a document from a managed data source.",
+            message: "You cannot delete a document from a managed Data Source.",
           },
         });
       }

--- a/front/pages/api/w/[wId]/data_sources/[name]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/index.ts
@@ -30,7 +30,7 @@ async function handler(
       status_code: 404,
       api_error: {
         type: "data_source_not_found",
-        message: "The data source you requested was not found.",
+        message: "The Data Source you requested was not found.",
       },
     });
   }
@@ -57,7 +57,7 @@ async function handler(
       status_code: 404,
       api_error: {
         type: "data_source_not_found",
-        message: "The data source you requested was not found.",
+        message: "The Data Source you requested was not found.",
       },
     });
   }
@@ -84,7 +84,7 @@ async function handler(
           api_error: {
             type: "data_source_auth_error",
             message:
-              "Only the users that are `builders` for the current workspace can update a data source.",
+              "Only the users that are `builders` for the current workspace can update a Data Source.",
           },
         });
       }
@@ -130,7 +130,7 @@ async function handler(
           api_error: {
             type: "data_source_auth_error",
             message:
-              "Only the users that are `builders` for the current workspace can delete a data source.",
+              "Only the users that are `builders` for the current workspace can delete a Data Source.",
           },
         });
       }
@@ -145,7 +145,7 @@ async function handler(
           status_code: 500,
           api_error: {
             type: "internal_server_error",
-            message: "Failed to delete the data source.",
+            message: "Failed to delete the Data Source.",
             data_source_error: dustDataSource.error,
           },
         });

--- a/front/pages/api/w/[wId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/index.ts
@@ -37,7 +37,7 @@ async function handler(
       status_code: 404,
       api_error: {
         type: "data_source_not_found",
-        message: "The data source you requested was not found.",
+        message: "The Data Source you requested was not found.",
       },
     });
   }
@@ -56,7 +56,7 @@ async function handler(
           api_error: {
             type: "data_source_auth_error",
             message:
-              "Only the users that are `admins` for the current workspace can create a managed data source.",
+              "Only the users that are `admins` for the current workspace can create a managed Data Source.",
           },
         });
       }
@@ -85,7 +85,7 @@ async function handler(
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "The data source name cannot start with `managed-`.",
+            message: "The Data Source name cannot start with `managed-`.",
           },
         });
       }
@@ -100,7 +100,7 @@ async function handler(
           api_error: {
             type: "plan_limit_error",
             message:
-              "Your plan does not allow you to create managed data sources.",
+              "Your plan does not allow you to create managed Data Sources.",
           },
         });
       }
@@ -111,7 +111,7 @@ async function handler(
           status_code: 500,
           api_error: {
             type: "internal_server_error",
-            message: `Failed to create internal project for the data source.`,
+            message: `Failed to create internal project for the Data Source.`,
             data_source_error: dustProject.error,
           },
         });
@@ -158,7 +158,7 @@ async function handler(
           status_code: 500,
           api_error: {
             type: "internal_server_error",
-            message: "Failed to create the data source.",
+            message: "Failed to create the Data Source.",
             data_source_error: dustDataSource.error,
           },
         });

--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -36,7 +36,7 @@ async function handler(
       status_code: 404,
       api_error: {
         type: "data_source_not_found",
-        message: "The data source you requested was not found.",
+        message: "The Data Source you requested was not found.",
       },
     });
   }
@@ -49,7 +49,7 @@ async function handler(
           api_error: {
             type: "data_source_auth_error",
             message:
-              "Only the users that are `admins` for the current workspace can create a managed data source.",
+              "Only the users that are `admins` for the current workspace can create a managed Data Source.",
           },
         });
       }
@@ -84,7 +84,7 @@ async function handler(
           api_error: {
             type: "plan_limit_error",
             message:
-              "Your plan does not allow you to create managed data sources.",
+              "Your plan does not allow you to create managed Data Sources.",
           },
         });
       }
@@ -102,7 +102,7 @@ async function handler(
           api_error: {
             type: "internal_server_error",
             message:
-              "Could not create a system API key for the managed data source.",
+              "Could not create a system API key for the managed Data Source.",
           },
         });
       }
@@ -113,13 +113,13 @@ async function handler(
           status_code: 500,
           api_error: {
             type: "internal_server_error",
-            message: `Failed to create internal project for the data source.`,
+            message: `Failed to create internal project for the Data Source.`,
             data_source_error: dustProject.error,
           },
         });
       }
 
-      // Dust managed credentials: managed data source.
+      // Dust managed credentials: managed Data Source.
       let credentials = dustManagedCredentials();
 
       const dustDataSource = await CoreAPI.createDataSource(
@@ -142,7 +142,7 @@ async function handler(
           status_code: 500,
           api_error: {
             type: "internal_server_error",
-            message: "Failed to create the data source.",
+            message: "Failed to create the Data Source.",
             data_source_error: dustDataSource.error,
           },
         });
@@ -181,7 +181,7 @@ async function handler(
             {
               error: deleteRes.error,
             },
-            "Failed to delete the data source"
+            "Failed to delete the Data Source"
           );
         }
         return apiError(req, res, {

--- a/front/pages/index.tsx
+++ b/front/pages/index.tsx
@@ -71,7 +71,7 @@ const features = [
     description: "Deploy to an API endpoint or use directly from Dust.",
   },
   {
-    name: "DataSources",
+    name: "Data Sources",
     built: true,
     description:
       "Fully managed semantic search engines you can query from your workflows.",
@@ -80,7 +80,7 @@ const features = [
     name: "Connections",
     built: false,
     description:
-      "Connect your team's Notion, Google Docs or Slack to managed DataSources that are kept up-to-date automatically.",
+      "Connect your team's Notion, Google Docs or Slack to managed Data Sources that are kept up-to-date automatically.",
   },
 ];
 

--- a/front/pages/w/[wId]/ds/[name]/index.tsx
+++ b/front/pages/w/[wId]/ds/[name]/index.tsx
@@ -194,7 +194,7 @@ export default function DataSourceView({
                         ) {
                           e.preventDefault();
                           window.alert(
-                            "DataSources are limited to 32 documents on our free plan. Contact team@dust.tt if you want to increase this limit."
+                            "Data Sources are limited to 32 documents on our free plan. Contact team@dust.tt if you want to increase this limit."
                           );
                           return;
                         }
@@ -277,14 +277,14 @@ export default function DataSourceView({
                   <div className="mt-10 flex flex-col items-center justify-center text-sm text-gray-500">
                     {readOnly ? (
                       <>
-                        <p>No documents found for this data source.</p>
+                        <p>No documents found for this Data Source.</p>
                         <p className="mt-2">
-                          Sign-in to create your own data source.
+                          Sign-in to create your own Data Source.
                         </p>
                       </>
                     ) : (
                       <>
-                        <p>No documents found for this data source.</p>
+                        <p>No documents found for this Data Source.</p>
                         <p className="mt-2">
                           You can upload documents manually or by API.
                         </p>

--- a/front/pages/w/[wId]/ds/[name]/settings.tsx
+++ b/front/pages/w/[wId]/ds/[name]/settings.tsx
@@ -167,7 +167,7 @@ function StandardDataSourceSettings({
         setIsDeleting(false);
         let err = (await res.json()) as { error: APIError };
         window.alert(
-          `Failed to delete the data source (contact team@dust.tt for assistance) (internal error: type=${err.error.type} message=${err.error.message})`
+          `Failed to delete the Data Source (contact team@dust.tt for assistance) (internal error: type=${err.error.type} message=${err.error.message})`
         );
       }
       return true;
@@ -197,7 +197,7 @@ function StandardDataSourceSettings({
       setIsUpdating(false);
       let err = (await res.json()) as { error: APIError };
       window.alert(
-        `Failed to update the data source (contact team@dust.tt for assistance) (internal error: type=${err.error.type} message=${err.error.message})`
+        `Failed to update the Data Source (contact team@dust.tt for assistance) (internal error: type=${err.error.type} message=${err.error.message})`
       );
     }
   };
@@ -268,7 +268,7 @@ function StandardDataSourceSettings({
                   </div>
                   <p className="mt-2 text-sm text-gray-500">
                     A good description will help others discover and understand
-                    the purpose of your data source.
+                    the purpose of your Data Source.
                   </p>
                 </div>
 

--- a/front/pages/w/[wId]/ds/index.tsx
+++ b/front/pages/w/[wId]/ds/index.tsx
@@ -235,13 +235,13 @@ export default function DataSourcesView({
             body: await res.text(),
             provider,
           },
-          `Failed to enable managed data source`
+          `Failed to enable managed Data Source`
         );
-        window.alert(`Failed to enable ${provider} data source`);
+        window.alert(`Failed to enable ${provider} Data Source`);
       }
     } catch (e) {
-      logger.error(e, "Failed to enable managed data source");
-      window.alert(`Failed to enable ${provider}  data source`);
+      logger.error(e, "Failed to enable managed Data Source");
+      window.alert(`Failed to enable ${provider}  Data Source`);
     } finally {
       setIsLoadingByProvider((prev) => ({ ...prev, [provider]: false }));
     }
@@ -259,37 +259,21 @@ export default function DataSourcesView({
         </div>
         <div className="">
           <div className="mx-auto mt-8 divide-y divide-gray-200 px-6 sm:max-w-2xl lg:max-w-4xl">
-            <div>
-              {readOnly ? null : (
-                <div className="sm:flex sm:items-center">
-                  <div className="sm:flex-auto"></div>
-                  <div className="mt-4 sm:ml-16 sm:mt-0 sm:flex-none">
-                    <Link
-                      href={`/w/${owner.sId}/ds/new`}
-                      onClick={(e) => {
-                        // Enforce plan limits: DataSources count.
-                        if (
-                          owner.plan.limits.dataSources.count != -1 &&
-                          dataSources.length >=
-                            owner.plan.limits.dataSources.count
-                        ) {
-                          e.preventDefault();
-                          window.alert(
-                            "You are limited to 1 DataSource on our free plan. Contact team@dust.tt if you want to increase this limit."
-                          );
-                          return;
-                        }
-                      }}
-                    >
-                      <Button>
-                        <PlusIcon className="-ml-1 mr-1 h-5 w-5" />
-                        New DataSource
-                      </Button>
-                    </Link>
-                  </div>
-                </div>
-              )}
+            <div className="mt-16 sm:flex-auto">
+              <h1 className="text-base font-medium text-gray-900">
+                Uploaded Data Sources
+              </h1>
 
+              <p className="text-sm text-gray-500">
+                You can upload documents as Data Sources to then perform
+                semantic searches on them using a{" "}
+                <span className="rounded-md bg-gray-200 px-1 py-0.5">
+                  data_source
+                </span>{" "}
+                block.
+              </p>
+            </div>
+            <div className="mt-4">
               <div className="mt-8 overflow-hidden">
                 <ul role="list" className="">
                   {dataSources.map((ds) => (
@@ -335,30 +319,46 @@ export default function DataSourcesView({
                       {readOnly ? (
                         <>
                           <p>
-                            Welcome to Dust DataSources 🔎 This user has not
-                            created any data source yet 🙃
+                            Welcome to Dust Data Sources 🔎 This user has not
+                            created any Data Source yet 🙃
                           </p>
                           <p className="mt-2">
-                            Sign-in to create your own data sources.
+                            Sign-in to create your own Data Sources.
                           </p>
                         </>
                       ) : (
-                        <>
-                          <p>Welcome to Dust DataSources 🔎</p>
-                          <p className="mt-2">
-                            Data sources let you upload documents to perform
-                            semantic searches on them (
-                            <span className="rounded-md bg-gray-200 px-1 py-0.5 font-bold">
-                              data_source
-                            </span>{" "}
-                            block).
-                          </p>
-                        </>
+                        <></>
                       )}
                     </div>
                   ) : null}
                 </ul>
               </div>
+              {!readOnly && (
+                <div className="text-center">
+                  <Link
+                    href={`/w/${owner.sId}/ds/new`}
+                    onClick={(e) => {
+                      // Enforce plan limits: DataSources count.
+                      if (
+                        owner.plan.limits.dataSources.count != -1 &&
+                        dataSources.length >=
+                          owner.plan.limits.dataSources.count
+                      ) {
+                        e.preventDefault();
+                        window.alert(
+                          "You are limited to 1 DataSource on our free plan. Contact team@dust.tt if you want to increase this limit."
+                        );
+                        return;
+                      }
+                    }}
+                  >
+                    <Button>
+                      <PlusIcon className="-ml-1 mr-1 h-5 w-5" />
+                      New Data Source
+                    </Button>
+                  </Link>
+                </div>
+              )}
             </div>
           </div>
         </div>
@@ -370,8 +370,8 @@ export default function DataSourcesView({
               Managed Data Sources
             </h1>
 
-            <p className="text-sm text-gray-500">
-              Fully managed and kept in sync in real-time with the products you
+            <p className="text-sm text-gray-500 ">
+              Managed by Dust to remain synchronized with the products you use
               use.
             </p>
           </div>
@@ -449,7 +449,7 @@ export default function DataSourcesView({
                                     }
                                   : () => {
                                       window.alert(
-                                        "Managed DataSources are only available on our paid plans. Contact us at team@dust.tt to get access."
+                                        "Managed Data Sources are only available on our paid plans. Contact us at team@dust.tt to get access."
                                       );
                                       logger.info(
                                         {

--- a/front/pages/w/[wId]/ds/new.tsx
+++ b/front/pages/w/[wId]/ds/new.tsx
@@ -155,7 +155,7 @@ export default function DataSourceNew({
                     Create a new DataSource
                   </h3>
                   <p className="mt-1 text-sm text-gray-500">
-                    A data source enables you to upload text documents (by API
+                    A Data Source enables you to upload text documents (by API
                     or manually) to perform semantic search on them. The
                     documents are automatically chunked and embedded using the
                     model you specify here.
@@ -223,7 +223,7 @@ export default function DataSourceNew({
                       </div>
                       <p className="mt-2 text-sm text-gray-500">
                         A good description will help others discover and
-                        understand the purpose of your data source.
+                        understand the purpose of your Data Source.
                       </p>
                     </div>
 

--- a/front/pages/w/[wId]/u/chat/index.tsx
+++ b/front/pages/w/[wId]/u/chat/index.tsx
@@ -319,7 +319,7 @@ export default function AppChat({
             </div>
             <div className="mb-4 flex flex-row text-xs">
               <div className="flex flex-initial text-gray-400">
-                data sources:
+                Data Sources:
               </div>
               <div className="flex flex-row">
                 {dataSources.map((ds) => {


### PR DESCRIPTION
There is two commits:
- one that implements the UI changes requested by @gabhubert (see attached screenshots) and another one that replaces all mention of "data source" by "Data Source" in the code base.
I would recommend to review them separately.

<img width="1728" alt="Screen Shot 2023-05-15 at 21 19 38" src="https://github.com/dust-tt/dust/assets/358965/be1e9168-4c03-47ed-8f1a-e7fc606ecebc">
<img width="1728" alt="Screen Shot 2023-05-15 at 21 23 35" src="https://github.com/dust-tt/dust/assets/358965/e622c357-a703-4bbf-a9ba-414402a857bc">
