### PR TITLE
Delete Slack Connector

### DIFF
--- a/connectors/src/connectors/index.ts
+++ b/connectors/src/connectors/index.ts
@@ -1,3 +1,5 @@
+import { Transaction } from "sequelize";
+
 import {
   cleanupNotionConnector,
   createNotionConnector,
@@ -5,6 +7,7 @@ import {
   resumeNotionConnector,
   stopNotionConnector,
 } from "@connectors/connectors/notion";
+import { cleanupSlackConnector } from "@connectors/connectors/slack";
 import { createSlackConnector } from "@connectors/connectors/slack";
 import { launchSlackSyncWorkflow } from "@connectors/connectors/slack/temporal/client";
 import { Ok, Result } from "@connectors/lib/result";
@@ -41,15 +44,16 @@ export const STOP_CONNECTOR_BY_TYPE: Record<
 };
 
 // Should cleanup any state/resources associated with the connector
-type ConnectorCleaner = (connectorId: string) => Promise<Result<void, Error>>;
+type ConnectorCleaner = (
+  connectorId: string,
+  transaction: Transaction
+) => Promise<Result<void, Error>>;
+
 export const CLEAN_CONNECTOR_BY_TYPE: Record<
   ConnectorProvider,
   ConnectorCleaner
 > = {
-  slack: async () => {
-    // no-op
-    return new Ok(undefined);
-  },
+  slack: cleanupSlackConnector,
   notion: cleanupNotionConnector,
 };
 

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -1,3 +1,5 @@
+import { Transaction } from "sequelize";
+
 import { validateAccessToken } from "@connectors/connectors/notion/lib/notion_api";
 import {
   launchNotionSyncWorkflow,
@@ -177,10 +179,12 @@ export async function fullResyncNotionConnector(connectorId: string) {
 }
 
 export async function cleanupNotionConnector(
-  connectorId: string
+  connectorId: string,
+  transaction: Transaction
 ): Promise<Result<void, Error>> {
   const connector = await Connector.findOne({
     where: { type: "notion", id: connectorId },
+    transaction: transaction,
   });
 
   if (!connector) {
@@ -192,6 +196,13 @@ export async function cleanupNotionConnector(
     where: {
       connectorId: connector.id,
     },
+    transaction: transaction,
+  });
+  await NotionConnectorState.destroy({
+    where: {
+      connectorId: connector.id,
+    },
+    transaction: transaction,
   });
 
   return new Ok(undefined);


### PR DESCRIPTION
Implement the delete Slack connector logic.
Also Added the opportunity for the connector clean up function to use a database transaction.
Also added the transaction logic for Notion and a missing call to `NotionConnectorState.destroy()`