### PR TITLE
Handling 503 errors from Slack

### DIFF
--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -602,8 +602,11 @@ export function getSlackClient(slackAccessToken: string): WebClient {
   const handler: ProxyHandler<WebClient> = {
     get: function (target, prop, receiver) {
       const value = Reflect.get(target, prop, receiver);
+      if (["function", "object"].indexOf(typeof value) > -1) {
+        return new Proxy(value, handler);
+      }
 
-      return new Proxy(value, handler);
+      return Reflect.get(target, prop, receiver);
     },
     apply: async function (target, thisArg, argumentsList) {
       try {

--- a/connectors/src/lib/error.ts
+++ b/connectors/src/lib/error.ts
@@ -25,7 +25,10 @@ export function errorFromAny(e: any): Error {
   };
 }
 
-export type WorkflowErrorType = "unhandled_internal_activity_error";
+export type SlackWorkflowErrorType = "slack_is_down";
+export type WorkflowErrorType =
+  | "unhandled_internal_activity_error"
+  | SlackWorkflowErrorType;
 
 export type WorkflowError = {
   type: WorkflowErrorType;


### PR DESCRIPTION
This is my take on handling error from the Slack SDK. 
It uses a Javascript Proxy to catch all exception thrown by the SDK and send the ones we want as "dust handled errors".

Let me know what you think.