### PR TITLE
Use channelId instead of channelName in Slack Data Sources documentIds

### DIFF
--- a/connectors/migrations/20230522_slack_documents_rename_and_tags.ts
+++ b/connectors/migrations/20230522_slack_documents_rename_and_tags.ts
@@ -1,4 +1,3 @@
-import { channel } from "diagnostics_channel";
 import { Sequelize } from "sequelize";
 
 const { CORE_DATABASE_URI, LIVE = false } = process.env;

--- a/connectors/migrations/20230522_slack_documents_rename_and_tags.ts
+++ b/connectors/migrations/20230522_slack_documents_rename_and_tags.ts
@@ -1,0 +1,174 @@
+import { channel } from "diagnostics_channel";
+import { Sequelize } from "sequelize";
+
+const { CORE_DATABASE_URI, LIVE = false } = process.env;
+
+async function main() {
+  const core_sequelize = new Sequelize(CORE_DATABASE_URI as string, {
+    logging: false,
+  });
+  console.log("Retrieving core runs");
+  const data = await core_sequelize.query(
+    "SELECT id, document_id, tags_json, source_url FROM data_sources_documents"
+  );
+
+  const documents = data[0] as {
+    id: string;
+    document_id: string;
+    tags_json: string;
+    source_url: string;
+  }[];
+  console.log(`Chunking ${documents.length}`);
+
+  console.log("Chunking");
+  const chunkSize = 16;
+  const chunks = [];
+  for (let i = 0; i < documents.length; i += chunkSize) {
+    chunks.push(documents.slice(i, i + chunkSize));
+  }
+
+  for (let i = 0; i < chunks.length; i++) {
+    console.log(`Processing chunk ${i}/${chunks.length}...`);
+    const chunk = chunks[i];
+    if (!chunk) {
+      continue;
+    }
+    await Promise.all(
+      chunk.map((d) => {
+        return (async () => {
+          const tags = JSON.parse(d.tags_json) as string[];
+          if (tags.length === 0) {
+            if (!LIVE) {
+              console.log(`Skipping (no tags): ${d.document_id}`);
+            }
+            return;
+          }
+          let channelId: string | null = null;
+          let channelName: string | null = null;
+          let title: string | null = null;
+          let threadId: string | null = null;
+          for (const i in tags) {
+            const t = tags[i];
+            if (!t) {
+              continue;
+            }
+            if (t.startsWith("channelId:")) {
+              const cId = t.split(":")[1];
+              if (cId) {
+                channelId = cId;
+              }
+            }
+            if (t.startsWith("channelName:")) {
+              const cName = t.split(":")[1];
+              if (cName) {
+                channelName = cName;
+              }
+            }
+            if (t.startsWith("title:")) {
+              const tt = t.split(":")[1];
+              if (tt) {
+                title = tt;
+              }
+            }
+            if (t.startsWith("threadId:")) {
+              const tId = t.split(":")[1];
+              if (tId) {
+                threadId = tId;
+              }
+            }
+          }
+
+          if (!channelId || !channelName) {
+            if (!LIVE) {
+              console.log(`Skipping (no channel): ${d.document_id}`);
+            }
+            return;
+          }
+
+          if (threadId) {
+            if (d.document_id.startsWith("slack-")) {
+              if (!LIVE) {
+                console.log(`Skipping (already updated): ${d.document_id}`);
+              }
+              return;
+            }
+            // Threaded slack document update.
+            console.log(`Updating (thread) ${d.document_id}`);
+            const parts = d.document_id.split("-");
+            parts[0] = channelId;
+            parts.splice(0, 0, "slack");
+            const newDocumentId = parts.join("-");
+            console.log(`  document_id: ${newDocumentId}`);
+            const newTags = [
+              `channelId:${channelId}`,
+              `channelName:${channelName}`,
+              `title:${title}`,
+              `threadId:${threadId}`,
+            ];
+            console.log(`  tags: ${JSON.stringify(newTags)}`);
+
+            if (LIVE) {
+              return core_sequelize.query(
+                `UPDATE data_sources_documents SET "document_id" = :documentId, "tags_json" = :tagsJson WHERE id = :id`,
+                {
+                  replacements: {
+                    documentId: newDocumentId,
+                    tagsJson: JSON.stringify(newTags),
+                    id: d.id,
+                  },
+                }
+              );
+            }
+          } else {
+            if (d.document_id.startsWith("slack-")) {
+              if (!LIVE) {
+                console.log(`Skipping (already updated): ${d.document_id}`);
+              }
+              return;
+            }
+            // Non-threaded slack document update.
+            console.log(`Updating (non-thread) ${d.document_id}`);
+            const parts = d.document_id.split("-");
+            parts[0] = channelId;
+            parts.splice(0, 0, "slack");
+            const newDocumentId = parts.join("-");
+            console.log(`  document_id: ${newDocumentId}`);
+            if (!title) {
+              title = d.document_id;
+              console.log(`  title: ${title}`);
+            }
+            const newTags = [
+              `channelId:${channelId}`,
+              `channelName:${channelName}`,
+              `title:${title}`,
+            ];
+            console.log(`  tags: ${JSON.stringify(newTags)}`);
+
+            if (LIVE) {
+              return core_sequelize.query(
+                `UPDATE data_sources_documents SET "document_id" = :documentId, "tags_json" = :tagsJson WHERE id = :id`,
+                {
+                  replacements: {
+                    documentId: newDocumentId,
+                    tagsJson: JSON.stringify(newTags),
+                    id: d.id,
+                  },
+                }
+              );
+            }
+          }
+        })();
+      })
+    );
+  }
+}
+
+main()
+  .then(() => {
+    console.log("Done");
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -298,7 +298,7 @@ export async function syncNonThreaded(
   const endDate = new Date(endTsMs);
   const startDateStr = `${startDate.getFullYear()}-${startDate.getMonth()}-${startDate.getDate()}`;
   const endDateStr = `${endDate.getFullYear()}-${endDate.getMonth()}-${endDate.getDate()}`;
-  const documentId = `${channelName}-messages-${startDateStr}-${endDateStr}`;
+  const documentId = `slack-${channelId}-messages-${startDateStr}-${endDateStr}`;
   const firstMessage = messages[0];
   let sourceUrl: string | undefined = undefined;
   const createdAt = firstMessage?.ts
@@ -396,7 +396,7 @@ export async function syncThread(
     connectorId,
     client
   );
-  const documentId = `${channelName}-thread-${threadTs}`;
+  const documentId = `slack-${channelId}-thread-${threadTs}`;
 
   const firstMessage = allMessages[0];
   let sourceUrl: string | undefined = undefined;
@@ -608,8 +608,13 @@ function getTagsForPage(
     const dateForTitle = formatDateForThreadTitle(threadDate);
     tags.push(`title:${channelName}-thread-${dateForTitle}`);
   } else {
-    // For non-threaded message, the documentId is human-friendly, we copy it as title tag.
-    tags.push(`title:${documentId}`);
+    // replace `slack-${channelId}` by `${channelName}` in documentId (to have a human readable
+    // title with non-threaded time boundaries present in the documentId, but the channelName
+    // instead of the channelId).
+    const parts = documentId.split("-").slice(1);
+    parts[1] = channelName;
+    const title = parts.join("-");
+    tags.push(`title:${title}`);
   }
   return tags;
 }

--- a/front/migrations/20230427_runs_creation_time.ts
+++ b/front/migrations/20230427_runs_creation_time.ts
@@ -18,8 +18,8 @@ async function main() {
     [key: string]: {
       run_id: string;
       run_type: string;
-      project: number;
-      created: number;
+      project: string;
+      created: string;
     };
   };
   core_runs_rows.forEach((r) => {
@@ -47,7 +47,7 @@ async function main() {
             `UPDATE runs SET "createdAt" = :createdAt WHERE id = :id`,
             {
               replacements: {
-                createdAt: new Date(dustRun.created),
+                createdAt: new Date(parseInt(dustRun.created)),
                 id: r.id,
               },
             }


### PR DESCRIPTION
- Behavior update: use channelId instead of name in data sources documentIds (to avoid problems in case of channel name change)
- Migration to update all slack documentIds and add a `title:` tag for non threaded documents

Deploy:
- Kill all connectors
- Pull code
- Run migration
- Restart connectors