### PR TITLE
enh: redirect http to https

### DIFF
--- a/k8s/apply_infra.sh
+++ b/k8s/apply_infra.sh
@@ -33,6 +33,24 @@ echo "-----------------------------------"
 kubectl apply -f "$(dirname "$0")/configmaps/front-edge-configmap.yaml"
 
 echo "-----------------------------------"
+echo "Applying backend configs"
+echo "-----------------------------------"
+
+kubectl apply -f "$(dirname "$0")/backend-configs/front-backend-config.yaml"
+
+echo "-----------------------------------"
+echo "Applying managed certificates"
+echo "-----------------------------------"
+
+kubectl apply -f "$(dirname "$0")/managed-certs/front-edge-managed-cert.yaml"
+
+echo "-----------------------------------"
+echo "Applying frontend configs"
+echo "-----------------------------------"
+
+kubectl apply -f "$(dirname "$0")/frontend-configs/dust-frontend-config.yaml"
+
+echo "-----------------------------------"
 echo "Applying deployments"
 echo "-----------------------------------"
 
@@ -52,14 +70,3 @@ echo "-----------------------------------"
 
 kubectl apply -f "$(dirname "$0")/ingress.yaml"
 
-echo "-----------------------------------"
-echo "Applying backend configs"
-echo "-----------------------------------"
-
-kubectl apply -f "$(dirname "$0")/backend-configs/front-backend-config.yaml"
-
-echo "-----------------------------------"
-echo "Applying managed certificates"
-echo "-----------------------------------"
-
-kubectl apply -f "$(dirname "$0")/managed-certs/front-edge-managed-cert.yaml"

--- a/k8s/frontend-configs/dust-frontend-config.yaml
+++ b/k8s/frontend-configs/dust-frontend-config.yaml
@@ -1,0 +1,8 @@
+apiVersion: networking.gke.io/v1beta1
+kind: FrontendConfig
+metadata:
+  name: dust-frontendconfig
+spec:
+  redirectToHttps:
+    enabled: true
+    responseCodeName: MOVED_PERMANENTLY_DEFAULT

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     kubernetes.io/ingress.global-static-ip-name: dust-kube-ingress-ip-address
     networking.gke.io/managed-certificates: front-edge-managed-cert
+    networking.gke.io/v1beta1.FrontendConfig: "dust-frontendconfig"
     kubernetes.io/ingress.class: "gce"
 spec:
   rules:


### PR DESCRIPTION
redirect all external HTTP ingress to HTTPS

Also moved things around, frontend/backend configs need to be applied before resources that reference them