### PR TITLE
fix: `connectors-edge` fixes

### DIFF
--- a/connectors/Dockerfile
+++ b/connectors/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.15.0-alpine as connectors
+FROM node:18.15.0 as connectors
 
 WORKDIR /app
 

--- a/connectors/src/api_server.ts
+++ b/connectors/src/api_server.ts
@@ -14,11 +14,12 @@ import { authMiddleware } from "@connectors/middleware/auth";
 export function startServer(port: number) {
   const app = express();
 
-  app.use(authMiddleware);
-  app.use(bodyParser.json());
   app.get("/", (req, res) => {
     res.status(200).send("OK");
   });
+
+  app.use(authMiddleware);
+  app.use(bodyParser.json());
   app.post("/connectors/create/:connector_provider", createConnectorAPIHandler);
   app.post("/connectors/stop/:connector_id", stopConnectorAPIHandler);
   app.post("/connectors/resume/:connector_id", resumeConnectorAPIHandler);

--- a/connectors/src/api_server.ts
+++ b/connectors/src/api_server.ts
@@ -16,7 +16,9 @@ export function startServer(port: number) {
 
   app.use(authMiddleware);
   app.use(bodyParser.json());
-
+  app.get("/", (req, res) => {
+    res.status(200).send("OK");
+  });
   app.post("/connectors/create/:connector_provider", createConnectorAPIHandler);
   app.post("/connectors/stop/:connector_id", stopConnectorAPIHandler);
   app.post("/connectors/resume/:connector_id", resumeConnectorAPIHandler);


### PR DESCRIPTION
- `temporal` dependency doesn't work with the `alpine` base image
- GCP requires that we 200 on `/` (healthcheck)