### PR TITLE
enh: use actions/checkout@v3 in deploy GH actions

### DIFF
--- a/.github/workflows/deploy-connectors-edge.yml
+++ b/.github/workflows/deploy-connectors-edge.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Get short sha
         id: short_sha

--- a/.github/workflows/deploy-front-edge.yml
+++ b/.github/workflows/deploy-front-edge.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Get short sha
         id: short_sha


### PR DESCRIPTION
v2 is using node 12 (and is deprecated)