### PR TITLE
add console.log support for code blocks

### DIFF
--- a/core/src/app.rs
+++ b/core/src/app.rs
@@ -439,7 +439,7 @@ impl App {
                                                         Some(v) => Ok(v.val.clone()),
                                                     })
                                                 .collect::<Result<Vec<_>>>()?),
-                                            meta: None,
+                                            meta: None 
                                         }
                                     );
                                     Ok(())
@@ -843,7 +843,7 @@ impl App {
                                                             name.clone(),
                                                             BlockResult {
                                                                 val: Value::Array(vec![v.val]),
-                                                                meta: None
+                                                                meta: v.meta
                                                             }
                                                         );
                                                     }

--- a/core/src/app.rs
+++ b/core/src/app.rs
@@ -556,7 +556,7 @@ impl App {
                                 Ok((input_idx, map_idx, e, Err(err)))
                             }
                         },
-                        true => Ok((input_idx, map_idx, e, Ok(BlockResult {val: Value::Null, meta: None}))) // what's going on here
+                        true => Ok((input_idx, map_idx, e, Ok(BlockResult {value: Value::Null, meta: None}))) // what's going on here
                             as Result<
                                 (usize, usize, Env, Result<BlockResult, anyhow::Error>),
                                 anyhow::Error,
@@ -605,7 +605,7 @@ impl App {
                                 Some(r) => match r {
                                     (_, Some(v), None) => 
                                         BlockExecution {
-                                            value: Some(v.val.clone()),
+                                            value: Some(v.value.clone()),
                                             error: None,
                                             meta: v.meta.clone()
                                         },
@@ -805,7 +805,7 @@ impl App {
                                     // the state the value for the `map` type since they have the
                                     // same name. This is fine as this is not super useful
                                     // information as it's repetitive.
-                                    e.state.insert(name.clone(), v.val);
+                                    e.state.insert(name.clone(), v.value);
                                 }
                                 // We're inside a `while` loop, accumu      late value in `env.state` as
                                 // an array.
@@ -826,7 +826,7 @@ impl App {
                                                 match e.state.get(name) {
                                                     Some(Value::Array(arr)) => {
                                                         let mut arr = arr.clone();
-                                                        arr.push(v.val.clone());
+                                                        arr.push(v.value.clone());
                                                         e.state.insert(
                                                             name.clone(),
                                                             Value::Array(arr),
@@ -835,7 +835,7 @@ impl App {
                                                     None => {
                                                         e.state.insert(
                                                             name.clone(),
-                                                            Value::Array(vec![v.val]),
+                                                            Value::Array(vec![v.value]),
                                                         );
                                                     }
                                                     _ => unreachable!(),

--- a/core/src/app.rs
+++ b/core/src/app.rs
@@ -834,7 +834,7 @@ impl App {
                                                             name.clone(),
                                                             BlockResult {
                                                                 val: Value::Array(arr),
-                                                                meta: meta.clone() // need to add them here
+                                                                meta: meta.clone()
                                                             }
                                                         );
                                                     }
@@ -910,7 +910,6 @@ impl App {
                                         name: name.clone(),
                                         iteration: i,
                                     });
-                                    // todo: mixup between old and new v here
                                     e.state.insert(name.clone(), BlockResult { val: x.clone(), meta: meta.clone()});
                                     e
                                 })

--- a/core/src/app.rs
+++ b/core/src/app.rs
@@ -604,13 +604,24 @@ impl App {
                         m.iter()
                             .map(|o| match o {
                                 Some(r) => match r {
-                                    (_, Some(v), None) => BlockExecution {
-                                        value: Some(v.clone()),
-                                        error: None,
+                                    (_, Some(v), None) => {
+                                        match block.block_type() {
+                                            BlockType::Code => BlockExecution {
+                                                value: Some(v["res"].clone()),
+                                                error: None,
+                                                meta: Some(v["logs"].clone())
+                                            },
+                                            _ => BlockExecution {
+                                                value: Some(v.clone()),
+                                                error: None,
+                                                meta: None,
+                                            }
+                                        }
                                     },
                                     (_, None, Some(err)) => BlockExecution {
                                         value: None,
                                         error: Some(err.clone()),
+                                        meta: None,
                                     },
                                     _ => unreachable!(),
                                 },

--- a/core/src/blocks/block.rs
+++ b/core/src/blocks/block.rs
@@ -37,7 +37,7 @@ pub struct InputState {
 #[derive(Serialize, Clone)]
 pub struct Env {
     pub config: RunConfig,
-    pub state: HashMap<String, BlockResult>,
+    pub state: HashMap<String, Value>,
     pub input: InputState,
     pub map: Option<MapState>,
     #[serde(skip_serializing)]
@@ -235,7 +235,7 @@ pub fn replace_variables_in_string(text: &str, field: &str, env: &Env) -> Result
                 .state
                 .get(name)
                 .ok_or_else(|| anyhow!("Block `{}` output not found", name))?;
-            if !output.val.is_object() {
+            if !output.is_object() {
                 Err(anyhow!(
                     "Block `{}` output is not an object, the output of `{}` referred to \
                      as a variable in `{}` must be an object",
@@ -244,7 +244,7 @@ pub fn replace_variables_in_string(text: &str, field: &str, env: &Env) -> Result
                     field
                 ))?;
             }
-            let output = output.val.as_object().unwrap();
+            let output = output.as_object().unwrap();
 
             if !output.contains_key(key) {
                 Err(anyhow!(

--- a/core/src/blocks/block.rs
+++ b/core/src/blocks/block.rs
@@ -116,7 +116,7 @@ impl FromStr for BlockType {
 
 #[derive(Deserialize, Serialize, PartialEq, Clone, Debug)]
 pub struct BlockResult {
-    pub val: Value,
+    pub value: Value,
     pub meta: Option<Value>,
 }
 #[async_trait]

--- a/core/src/blocks/block.rs
+++ b/core/src/blocks/block.rs
@@ -37,7 +37,7 @@ pub struct InputState {
 #[derive(Serialize, Clone)]
 pub struct Env {
     pub config: RunConfig,
-    pub state: HashMap<String, Value>,
+    pub state: HashMap<String, BlockResult>,
     pub input: InputState,
     pub map: Option<MapState>,
     #[serde(skip_serializing)]
@@ -114,6 +114,11 @@ impl FromStr for BlockType {
     }
 }
 
+#[derive(Deserialize, Serialize, PartialEq, Clone, Debug)]
+pub struct BlockResult {
+    pub val: Value,
+    pub meta: Option<Value>,
+}
 #[async_trait]
 pub trait Block {
     fn block_type(&self) -> BlockType;
@@ -125,7 +130,7 @@ pub trait Block {
         name: &str,
         env: &Env,
         event_sender: Option<UnboundedSender<Value>>,
-    ) -> Result<Value>;
+    ) -> Result<BlockResult>;
 
     fn clone_box(&self) -> Box<dyn Block + Sync + Send>;
     fn as_any(&self) -> &dyn Any;
@@ -230,7 +235,7 @@ pub fn replace_variables_in_string(text: &str, field: &str, env: &Env) -> Result
                 .state
                 .get(name)
                 .ok_or_else(|| anyhow!("Block `{}` output not found", name))?;
-            if !output.is_object() {
+            if !output.val.is_object() {
                 Err(anyhow!(
                     "Block `{}` output is not an object, the output of `{}` referred to \
                      as a variable in `{}` must be an object",
@@ -239,7 +244,7 @@ pub fn replace_variables_in_string(text: &str, field: &str, env: &Env) -> Result
                     field
                 ))?;
             }
-            let output = output.as_object().unwrap();
+            let output = output.val.as_object().unwrap();
 
             if !output.contains_key(key) {
                 Err(anyhow!(

--- a/core/src/blocks/browser.rs
+++ b/core/src/blocks/browser.rs
@@ -210,7 +210,7 @@ impl Block for Browser {
                     }
                 });
                 Ok(BlockResult {
-                    val: result,
+                    value: result,
                     meta: None
                 })
             }
@@ -228,7 +228,7 @@ impl Block for Browser {
                         },
                     });
                     Ok(BlockResult {
-                        val: result,
+                        value: result,
                         meta: None
                     })
                 }

--- a/core/src/blocks/browser.rs
+++ b/core/src/blocks/browser.rs
@@ -211,7 +211,7 @@ impl Block for Browser {
                 });
                 Ok(BlockResult {
                     value: result,
-                    meta: None
+                    meta: None,
                 })
             }
             s => match error_as_output {
@@ -229,7 +229,7 @@ impl Block for Browser {
                     });
                     Ok(BlockResult {
                         value: result,
-                        meta: None
+                        meta: None,
                     })
                 }
             },

--- a/core/src/blocks/browser.rs
+++ b/core/src/blocks/browser.rs
@@ -8,6 +8,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use tokio::sync::mpsc::UnboundedSender;
 
+use super::block::BlockResult;
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Error {
     pub error: String,
@@ -110,7 +112,7 @@ impl Block for Browser {
         name: &str,
         env: &Env,
         _event_sender: Option<UnboundedSender<Value>>,
-    ) -> Result<Value> {
+    ) -> Result<BlockResult> {
         let config = env.config.config_for_block(name);
 
         let use_cache = match config {
@@ -207,7 +209,10 @@ impl Block for Browser {
                         "port": response.headers["x-response-port"],
                     }
                 });
-                Ok(result)
+                Ok(BlockResult {
+                    val: result,
+                    meta: None
+                })
             }
             s => match error_as_output {
                 false => Err(anyhow!(
@@ -222,7 +227,10 @@ impl Block for Browser {
                             "body": response.body,
                         },
                     });
-                    Ok(result)
+                    Ok(BlockResult {
+                        val: result,
+                        meta: None
+                    })
                 }
             },
         }

--- a/core/src/blocks/chat.rs
+++ b/core/src/blocks/chat.rs
@@ -1,4 +1,4 @@
-use crate::blocks::block::{parse_pair, replace_variables_in_string, Block, BlockType, Env};
+use crate::blocks::block::{parse_pair, replace_variables_in_string, Block, BlockType, Env, BlockResult};
 use crate::deno::script::Script;
 use crate::providers::llm::{ChatMessage, ChatMessageRole, LLMChatRequest};
 use crate::providers::provider::ProviderID;
@@ -161,7 +161,7 @@ impl Block for Chat {
         name: &str,
         env: &Env,
         event_sender: Option<UnboundedSender<Value>>,
-    ) -> Result<Value> {
+    ) -> Result<BlockResult> {
         let config = env.config.config_for_block(name);
 
         let (provider_id, model_id) = match config {
@@ -364,9 +364,12 @@ impl Block for Chat {
 
         assert!(g.completions.len() == 1);
 
-        Ok(serde_json::to_value(ChatValue {
+        Ok(BlockResult { 
+            val: serde_json::to_value(ChatValue {
             message: g.completions[0].clone(),
-        })?)
+        })?,
+            meta: None
+        })
     }
 
     fn clone_box(&self) -> Box<dyn Block + Sync + Send> {

--- a/core/src/blocks/chat.rs
+++ b/core/src/blocks/chat.rs
@@ -1,4 +1,6 @@
-use crate::blocks::block::{parse_pair, replace_variables_in_string, Block, BlockType, Env, BlockResult};
+use crate::blocks::block::{
+    parse_pair, replace_variables_in_string, Block, BlockResult, BlockType, Env,
+};
 use crate::deno::script::Script;
 use crate::providers::llm::{ChatMessage, ChatMessageRole, LLMChatRequest};
 use crate::providers::provider::ProviderID;
@@ -364,11 +366,11 @@ impl Block for Chat {
 
         assert!(g.completions.len() == 1);
 
-        Ok(BlockResult { 
+        Ok(BlockResult {
             value: serde_json::to_value(ChatValue {
-            message: g.completions[0].clone(),
-        })?,
-            meta: Some(messages_result["logs"].clone())
+                message: g.completions[0].clone(),
+            })?,
+            meta: Some(messages_result["logs"].clone()),
         })
     }
 

--- a/core/src/blocks/code.rs
+++ b/core/src/blocks/code.rs
@@ -69,10 +69,9 @@ impl Block for Code {
             script.call("_fun", &env)
         })
         .await??;
-        println!("{}", &result["meta"]);
         Ok(BlockResult {
             val: result["value"].clone(),
-            meta: Some(result["meta"].clone())
+            meta: Some(result["logs"].clone())
         })
     }
 

--- a/core/src/blocks/code.rs
+++ b/core/src/blocks/code.rs
@@ -1,4 +1,4 @@
-use crate::blocks::block::{parse_pair, Block, BlockType, Env, BlockResult};
+use crate::blocks::block::{parse_pair, Block, BlockResult, BlockType, Env};
 use crate::deno::script::Script;
 use crate::Rule;
 use anyhow::{anyhow, Result};
@@ -71,7 +71,7 @@ impl Block for Code {
         .await??;
         Ok(BlockResult {
             value: result["value"].clone(),
-            meta: Some(result["logs"].clone())
+            meta: Some(result["logs"].clone()),
         })
     }
 

--- a/core/src/blocks/code.rs
+++ b/core/src/blocks/code.rs
@@ -70,7 +70,7 @@ impl Block for Code {
         })
         .await??;
         Ok(BlockResult {
-            val: result["value"].clone(),
+            value: result["value"].clone(),
             meta: Some(result["logs"].clone())
         })
     }

--- a/core/src/blocks/curl.rs
+++ b/core/src/blocks/curl.rs
@@ -1,4 +1,4 @@
-use crate::blocks::block::{parse_pair, replace_variables_in_string, Block, BlockType, Env};
+use crate::blocks::block::{parse_pair, replace_variables_in_string, Block, BlockType, Env, BlockResult};
 use crate::deno::script::Script;
 use crate::http::request::HttpRequest;
 use crate::Rule;
@@ -96,7 +96,7 @@ impl Block for Curl {
         name: &str,
         env: &Env,
         _event_sender: Option<UnboundedSender<Value>>,
-    ) -> Result<Value> {
+    ) -> Result<BlockResult> {
         let config = env.config.config_for_block(name);
 
         let use_cache = match config {
@@ -155,7 +155,10 @@ impl Block for Curl {
             .execute_with_cache(env.project.clone(), env.store.clone(), use_cache)
             .await?;
 
-        Ok(json!(response))
+        Ok(BlockResult {
+            val: json!(response), 
+            meta: None
+        })
     }
 
     fn clone_box(&self) -> Box<dyn Block + Sync + Send> {

--- a/core/src/blocks/curl.rs
+++ b/core/src/blocks/curl.rs
@@ -1,4 +1,6 @@
-use crate::blocks::block::{parse_pair, replace_variables_in_string, Block, BlockType, Env, BlockResult};
+use crate::blocks::block::{
+    parse_pair, replace_variables_in_string, Block, BlockResult, BlockType, Env,
+};
 use crate::deno::script::Script;
 use crate::http::request::HttpRequest;
 use crate::Rule;
@@ -155,9 +157,13 @@ impl Block for Curl {
             .execute_with_cache(env.project.clone(), env.store.clone(), use_cache)
             .await?;
         Ok(BlockResult {
-            value: json!(response), 
+            value: json!(response),
             // if there are meta logs, then concatenate them and return them
-            meta: Some(Value::String(headers_result["logs"].as_str().unwrap().to_owned() + "\n" + &body_result["logs"].as_str().unwrap()))
+            meta: Some(Value::String(
+                headers_result["logs"].as_str().unwrap().to_owned()
+                    + "\n"
+                    + &body_result["logs"].as_str().unwrap(),
+            )),
         })
     }
 

--- a/core/src/blocks/data.rs
+++ b/core/src/blocks/data.rs
@@ -1,4 +1,4 @@
-use crate::blocks::block::{parse_pair, Block, BlockType, Env};
+use crate::blocks::block::{parse_pair, Block, BlockType, Env, BlockResult};
 use crate::Rule;
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
@@ -65,13 +65,16 @@ impl Block for Data {
         _name: &str,
         env: &Env,
         _event_sender: Option<UnboundedSender<Value>>,
-    ) -> Result<Value> {
+    ) -> Result<BlockResult> {
         match env
             .store
             .load_dataset(&env.project, &self.dataset_id, &self.hash)
             .await?
         {
-            Some(d) => Ok(d.data_as_value()),
+            Some(d) => Ok(BlockResult {
+                val: d.data_as_value(),
+                meta: None
+            }),
             None => Err(anyhow!(
                 "Version `{}` not found for dataset `{}`",
                 self.hash,

--- a/core/src/blocks/data.rs
+++ b/core/src/blocks/data.rs
@@ -1,4 +1,4 @@
-use crate::blocks::block::{parse_pair, Block, BlockType, Env, BlockResult};
+use crate::blocks::block::{parse_pair, Block, BlockResult, BlockType, Env};
 use crate::Rule;
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
@@ -73,7 +73,7 @@ impl Block for Data {
         {
             Some(d) => Ok(BlockResult {
                 value: d.data_as_value(),
-                meta: None
+                meta: None,
             }),
             None => Err(anyhow!(
                 "Version `{}` not found for dataset `{}`",

--- a/core/src/blocks/data.rs
+++ b/core/src/blocks/data.rs
@@ -72,7 +72,7 @@ impl Block for Data {
             .await?
         {
             Some(d) => Ok(BlockResult {
-                val: d.data_as_value(),
+                value: d.data_as_value(),
                 meta: None
             }),
             None => Err(anyhow!(

--- a/core/src/blocks/data_source.rs
+++ b/core/src/blocks/data_source.rs
@@ -341,7 +341,7 @@ impl Block for DataSource {
         }
 
         Ok(BlockResult {
-            val: serde_json::to_value(Self::top_k_sorted_documents(
+            value: serde_json::to_value(Self::top_k_sorted_documents(
             top_k, &documents,
         ))?,
             meta: None

--- a/core/src/blocks/data_source.rs
+++ b/core/src/blocks/data_source.rs
@@ -1,4 +1,6 @@
-use crate::blocks::block::{parse_pair, replace_variables_in_string, Block, BlockType, Env, BlockResult};
+use crate::blocks::block::{
+    parse_pair, replace_variables_in_string, Block, BlockResult, BlockType, Env,
+};
 use crate::data_sources::data_source::{Document, SearchFilter};
 use crate::project::Project;
 use crate::Rule;
@@ -291,7 +293,7 @@ impl Block for DataSource {
                         Ok((workspace_id, data_source_id))
                     })
                     .collect::<Result<Vec<_>>>()?,
-               _ => Err(anyhow!(err_msg.clone()))?,
+                _ => Err(anyhow!(err_msg.clone()))?,
             },
             _ => Err(anyhow!(err_msg.clone()))?,
         };
@@ -341,10 +343,8 @@ impl Block for DataSource {
         }
 
         Ok(BlockResult {
-            value: serde_json::to_value(Self::top_k_sorted_documents(
-            top_k, &documents,
-        ))?,
-            meta: None
+            value: serde_json::to_value(Self::top_k_sorted_documents(top_k, &documents))?,
+            meta: None,
         })
     }
 

--- a/core/src/blocks/data_source.rs
+++ b/core/src/blocks/data_source.rs
@@ -1,4 +1,4 @@
-use crate::blocks::block::{parse_pair, replace_variables_in_string, Block, BlockType, Env};
+use crate::blocks::block::{parse_pair, replace_variables_in_string, Block, BlockType, Env, BlockResult};
 use crate::data_sources::data_source::{Document, SearchFilter};
 use crate::project::Project;
 use crate::Rule;
@@ -265,7 +265,7 @@ impl Block for DataSource {
         name: &str,
         env: &Env,
         _event_sender: Option<UnboundedSender<Value>>,
-    ) -> Result<Value> {
+    ) -> Result<BlockResult> {
         let config = env.config.config_for_block(name);
 
         let err_msg = format!(
@@ -291,7 +291,7 @@ impl Block for DataSource {
                         Ok((workspace_id, data_source_id))
                     })
                     .collect::<Result<Vec<_>>>()?,
-                _ => Err(anyhow!(err_msg.clone()))?,
+               _ => Err(anyhow!(err_msg.clone()))?,
             },
             _ => Err(anyhow!(err_msg.clone()))?,
         };
@@ -340,9 +340,12 @@ impl Block for DataSource {
             }
         }
 
-        Ok(serde_json::to_value(Self::top_k_sorted_documents(
+        Ok(BlockResult {
+            val: serde_json::to_value(Self::top_k_sorted_documents(
             top_k, &documents,
-        ))?)
+        ))?,
+            meta: None
+        })
     }
 
     fn clone_box(&self) -> Box<dyn Block + Sync + Send> {

--- a/core/src/blocks/end.rs
+++ b/core/src/blocks/end.rs
@@ -1,4 +1,4 @@
-use crate::blocks::block::{parse_pair, Block, BlockType, Env, BlockResult};
+use crate::blocks::block::{parse_pair, Block, BlockResult, BlockType, Env};
 use crate::Rule;
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
@@ -50,7 +50,7 @@ impl Block for End {
         // ignored and not stored in the environment as it has the same name as the while|if block.
         Ok(BlockResult {
             value: Value::Null,
-            meta: None
+            meta: None,
         })
     }
 

--- a/core/src/blocks/end.rs
+++ b/core/src/blocks/end.rs
@@ -49,7 +49,7 @@ impl Block for End {
         // No-op the block outputs within the while|if/end are coallesced, the output of end is
         // ignored and not stored in the environment as it has the same name as the while|if block.
         Ok(BlockResult {
-            val: Value::Null,
+            value: Value::Null,
             meta: None
         })
     }

--- a/core/src/blocks/end.rs
+++ b/core/src/blocks/end.rs
@@ -1,4 +1,4 @@
-use crate::blocks::block::{parse_pair, Block, BlockType, Env};
+use crate::blocks::block::{parse_pair, Block, BlockType, Env, BlockResult};
 use crate::Rule;
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
@@ -45,10 +45,13 @@ impl Block for End {
         _name: &str,
         _env: &Env,
         _event_sender: Option<UnboundedSender<Value>>,
-    ) -> Result<Value> {
+    ) -> Result<BlockResult> {
         // No-op the block outputs within the while|if/end are coallesced, the output of end is
         // ignored and not stored in the environment as it has the same name as the while|if block.
-        Ok(Value::Null)
+        Ok(BlockResult {
+            val: Value::Null,
+            meta: None
+        })
     }
 
     fn clone_box(&self) -> Box<dyn Block + Sync + Send> {

--- a/core/src/blocks/input.rs
+++ b/core/src/blocks/input.rs
@@ -1,4 +1,4 @@
-use crate::blocks::block::{Block, BlockType, Env};
+use crate::blocks::block::{Block, BlockType, Env, BlockResult};
 use crate::Rule;
 use anyhow::Result;
 use async_trait::async_trait;
@@ -33,9 +33,12 @@ impl Block for Input {
         _name: &str,
         env: &Env,
         _event_sender: Option<UnboundedSender<Value>>,
-    ) -> Result<Value> {
+    ) -> Result<BlockResult> {
         match env.input.value.as_ref() {
-            Some(i) => Ok(i.clone()),
+            Some(i) => Ok(BlockResult {
+                val: i.clone(), 
+                meta: None
+            }),
             None => unreachable!(),
         }
     }

--- a/core/src/blocks/input.rs
+++ b/core/src/blocks/input.rs
@@ -1,4 +1,4 @@
-use crate::blocks::block::{Block, BlockType, Env, BlockResult};
+use crate::blocks::block::{Block, BlockResult, BlockType, Env};
 use crate::Rule;
 use anyhow::Result;
 use async_trait::async_trait;
@@ -36,8 +36,8 @@ impl Block for Input {
     ) -> Result<BlockResult> {
         match env.input.value.as_ref() {
             Some(i) => Ok(BlockResult {
-                value: i.clone(), 
-                meta: None
+                value: i.clone(),
+                meta: None,
             }),
             None => unreachable!(),
         }

--- a/core/src/blocks/input.rs
+++ b/core/src/blocks/input.rs
@@ -36,7 +36,7 @@ impl Block for Input {
     ) -> Result<BlockResult> {
         match env.input.value.as_ref() {
             Some(i) => Ok(BlockResult {
-                val: i.clone(), 
+                value: i.clone(), 
                 meta: None
             }),
             None => unreachable!(),

--- a/core/src/blocks/llm.rs
+++ b/core/src/blocks/llm.rs
@@ -1,5 +1,5 @@
 use crate::blocks::block::{
-    find_variables, parse_pair, replace_variables_in_string, Block, BlockType, Env, BlockResult
+    find_variables, parse_pair, replace_variables_in_string, Block, BlockResult, BlockType, Env,
 };
 use crate::providers::llm::{ChatMessage, ChatMessageRole, LLMChatRequest, LLMRequest, Tokens};
 use crate::providers::provider::ProviderID;
@@ -491,7 +491,7 @@ impl Block for LLM {
                             top_logprobs: None,
                         },
                     })?,
-                    meta: None
+                    meta: None,
                 })
             }
             false => {
@@ -557,10 +557,10 @@ impl Block for LLM {
 
                 Ok(BlockResult {
                     value: serde_json::to_value(LLMValue {
-                    prompt: g.prompt,
-                    completion: g.completions[0].clone(),
-                })?,
-                    meta: None
+                        prompt: g.prompt,
+                        completion: g.completions[0].clone(),
+                    })?,
+                    meta: None,
                 })
             }
         }

--- a/core/src/blocks/llm.rs
+++ b/core/src/blocks/llm.rs
@@ -153,14 +153,14 @@ impl LLM {
             .state
             .get(&name)
             .ok_or_else(|| anyhow!("Block `{}` output not found", name))?;
-        if !output.val.is_array() {
+        if !output.is_array() {
             Err(anyhow!(
                 "Block `{}` output is not an array, the block output referred in \
                  `few_shot_prompt` must be an array",
                 name
             ))?;
         }
-        let output = output.val.as_array().unwrap();
+        let output = output.as_array().unwrap();
 
         // Check that the block output elements are objects.
         for o in output {
@@ -591,11 +591,11 @@ mod tests {
                 blocks: HashMap::new(),
             },
             state: serde_json::from_str(
-                r#"{"RETRIEVE": {"val": [
+                r#"{"RETRIEVE":[
                     {"question":"What is your name?"},
-                    {"question":"What is your dob"},
-                    ], "meta": None},
-                    "DATA": {val: {"answer":"John"}, meta: None}"#,
+                    {"question":"What is your dob"}
+                    ],
+                    "DATA":{"answer":"John"}}"#,
             )
             .unwrap(),
             input: InputState {

--- a/core/src/blocks/llm.rs
+++ b/core/src/blocks/llm.rs
@@ -477,7 +477,7 @@ impl Block for LLM {
                 assert!(g.completions.len() == 1);
 
                 Ok(BlockResult {
-                    val: serde_json::to_value(LLMValue {
+                    value: serde_json::to_value(LLMValue {
                         prompt: Tokens {
                             text: prompt,
                             tokens: None,
@@ -556,7 +556,7 @@ impl Block for LLM {
                 assert!(g.completions.len() == 1);
 
                 Ok(BlockResult {
-                    val: serde_json::to_value(LLMValue {
+                    value: serde_json::to_value(LLMValue {
                     prompt: g.prompt,
                     completion: g.completions[0].clone(),
                 })?,

--- a/core/src/blocks/map.rs
+++ b/core/src/blocks/map.rs
@@ -90,7 +90,7 @@ impl Block for Map {
                 self.from
             )),
             Some(v) => match self.repeat {
-                None => match v.val.as_array() {
+                None => match v.as_array() {
                     None => Err(anyhow::anyhow!(
                         "Map `from` block `{}` output must be an array, \
                             or `repeat` must be defined",
@@ -111,7 +111,7 @@ impl Block for Map {
                                 self.from
                             )),
                             _ => Ok(BlockResult {
-                                val: v.val.clone(), 
+                                val: v.clone(), 
                                 meta: None // do I need to take the meta here
                             }),
                         }
@@ -124,7 +124,7 @@ impl Block for Map {
                     _ => {
                         let mut output = Vec::new();
                         for _ in 0..repeat {
-                            output.push(v.val.clone());
+                            output.push(v.clone());
                         }
                         Ok(BlockResult {
                             val: Value::Array(output),

--- a/core/src/blocks/map.rs
+++ b/core/src/blocks/map.rs
@@ -111,7 +111,7 @@ impl Block for Map {
                                 self.from
                             )),
                             _ => Ok(BlockResult {
-                                val: v.clone(), 
+                                value: v.clone(), 
                                 meta: None // do I need to take the meta here
                             }),
                         }
@@ -127,7 +127,7 @@ impl Block for Map {
                             output.push(v.clone());
                         }
                         Ok(BlockResult {
-                            val: Value::Array(output),
+                            value: Value::Array(output),
                             meta: None
                         })
                     }

--- a/core/src/blocks/map.rs
+++ b/core/src/blocks/map.rs
@@ -1,4 +1,4 @@
-use crate::blocks::block::{parse_pair, Block, BlockType, Env, BlockResult};
+use crate::blocks::block::{parse_pair, Block, BlockResult, BlockType, Env};
 use crate::Rule;
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
@@ -111,8 +111,8 @@ impl Block for Map {
                                 self.from
                             )),
                             _ => Ok(BlockResult {
-                                value: v.clone(), 
-                                meta: None // do I need to take the meta here
+                                value: v.clone(),
+                                meta: None, // do I need to take the meta here
                             }),
                         }
                     }
@@ -128,7 +128,7 @@ impl Block for Map {
                         }
                         Ok(BlockResult {
                             value: Value::Array(output),
-                            meta: None
+                            meta: None,
                         })
                     }
                 },

--- a/core/src/blocks/map.rs
+++ b/core/src/blocks/map.rs
@@ -96,16 +96,15 @@ impl Block for Map {
                             or `repeat` must be defined",
                         self.from
                     )),
-                    Some(val) => {
-                        // match v.as_array here, look at OG code
-                        if val.len() > MAP_MAX_ITERATIONS {
+                    Some(arr) => {
+                        if arr.len() > MAP_MAX_ITERATIONS {
                             Err(anyhow::anyhow!(
                                 "Map `from` block `{}` output exceeds maximum size ({})",
                                 self.from,
                                 MAP_MAX_ITERATIONS
                             ))?;
                         }
-                        match val.len() {
+                        match arr.len() {
                             0 => Err(anyhow::anyhow!(
                                 "Map `from` block `{}` output must be a non-empty array",
                                 self.from

--- a/core/src/blocks/reduce.rs
+++ b/core/src/blocks/reduce.rs
@@ -1,4 +1,4 @@
-use crate::blocks::block::{parse_pair, Block, BlockType, Env};
+use crate::blocks::block::{parse_pair, Block, BlockType, Env, BlockResult};
 use crate::Rule;
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
@@ -47,10 +47,13 @@ impl Block for Reduce {
         _name: &str,
         _env: &Env,
         _event_sender: Option<UnboundedSender<Value>>,
-    ) -> Result<Value> {
+    ) -> Result<BlockResult> {
         // No-op the block outputs within the map/reduce will be coallesced, the output of reduce is
         // ignored and not stored in the environment as it has the same name as the map block.
-        Ok(Value::Null)
+        Ok(BlockResult {
+            val: Value::Null,
+            meta: None
+        })
     }
 
     fn clone_box(&self) -> Box<dyn Block + Sync + Send> {

--- a/core/src/blocks/reduce.rs
+++ b/core/src/blocks/reduce.rs
@@ -1,4 +1,4 @@
-use crate::blocks::block::{parse_pair, Block, BlockType, Env, BlockResult};
+use crate::blocks::block::{parse_pair, Block, BlockResult, BlockType, Env};
 use crate::Rule;
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
@@ -52,7 +52,7 @@ impl Block for Reduce {
         // ignored and not stored in the environment as it has the same name as the map block.
         Ok(BlockResult {
             value: Value::Null,
-            meta: None
+            meta: None,
         })
     }
 

--- a/core/src/blocks/reduce.rs
+++ b/core/src/blocks/reduce.rs
@@ -51,7 +51,7 @@ impl Block for Reduce {
         // No-op the block outputs within the map/reduce will be coallesced, the output of reduce is
         // ignored and not stored in the environment as it has the same name as the map block.
         Ok(BlockResult {
-            val: Value::Null,
+            value: Value::Null,
             meta: None
         })
     }

--- a/core/src/blocks/search.rs
+++ b/core/src/blocks/search.rs
@@ -1,4 +1,6 @@
-use crate::blocks::block::{parse_pair, replace_variables_in_string, Block, BlockType, Env, BlockResult};
+use crate::blocks::block::{
+    parse_pair, replace_variables_in_string, Block, BlockResult, BlockType, Env,
+};
 use crate::http::request::HttpRequest;
 use crate::utils::ParseError;
 use crate::Rule;
@@ -244,7 +246,7 @@ impl Block for Search {
         match response.status {
             200 => Ok(BlockResult {
                 value: response.body,
-                meta: None
+                meta: None,
             }),
             s => Err(anyhow!(
                 "SearchError: Unexpected error with HTTP status {}.",

--- a/core/src/blocks/search.rs
+++ b/core/src/blocks/search.rs
@@ -243,7 +243,7 @@ impl Block for Search {
 
         match response.status {
             200 => Ok(BlockResult {
-                val: response.body,
+                value: response.body,
                 meta: None
             }),
             s => Err(anyhow!(

--- a/core/src/blocks/search.rs
+++ b/core/src/blocks/search.rs
@@ -1,4 +1,4 @@
-use crate::blocks::block::{parse_pair, replace_variables_in_string, Block, BlockType, Env};
+use crate::blocks::block::{parse_pair, replace_variables_in_string, Block, BlockType, Env, BlockResult};
 use crate::http::request::HttpRequest;
 use crate::utils::ParseError;
 use crate::Rule;
@@ -129,7 +129,7 @@ impl Block for Search {
         name: &str,
         env: &Env,
         _event_sender: Option<UnboundedSender<Value>>,
-    ) -> Result<Value> {
+    ) -> Result<BlockResult> {
         let config = env.config.config_for_block(name);
 
         let provider_id = match config {
@@ -242,7 +242,10 @@ impl Block for Search {
             .await?;
 
         match response.status {
-            200 => Ok(response.body),
+            200 => Ok(BlockResult {
+                val: response.body,
+                meta: None
+            }),
             s => Err(anyhow!(
                 "SearchError: Unexpected error with HTTP status {}.",
                 s

--- a/core/src/blocks/while.rs
+++ b/core/src/blocks/while.rs
@@ -88,7 +88,7 @@ impl Block for While {
             None => unreachable!(),
             Some(w) => {
                 if w.iteration >= self.max_iterations {
-                    return Ok(BlockResult { val: Value::Bool(false), meta: None});
+                    return Ok(BlockResult { value: Value::Bool(false), meta: None});
                 }
             }
         }
@@ -98,7 +98,7 @@ impl Block for While {
             .condition_code
             .replace("<DUST_TRIPLE_BACKTICKS>", "```");
 
-        let condition_value: Value = match tokio::task::spawn_blocking(move || {
+        let result: Value = match tokio::task::spawn_blocking(move || {
             let mut script = Script::from_string(condition_code.as_str())?
                 .with_timeout(std::time::Duration::from_secs(10));
             script.call("_fun", &e)
@@ -109,10 +109,10 @@ impl Block for While {
             Err(e) => Err(anyhow!("Error in `condition_code`: {}", e))?,
         };
 
-        match condition_value {
+        match result["value"] {
             Value::Bool(b) => Ok(BlockResult {
-                val: Value::Bool(b),
-                meta: None
+                value: Value::Bool(b), 
+                meta: Some(result["logs"].clone())
             }),
             _ => Err(anyhow!(
                 "Invalid return value from `condition_code`, expecting boolean"

--- a/core/src/blocks/while.rs
+++ b/core/src/blocks/while.rs
@@ -1,4 +1,4 @@
-use crate::blocks::block::{parse_pair, Block, BlockType, Env, BlockResult};
+use crate::blocks::block::{parse_pair, Block, BlockResult, BlockType, Env};
 use crate::deno::script::Script;
 use crate::Rule;
 use anyhow::{anyhow, Result};
@@ -88,7 +88,10 @@ impl Block for While {
             None => unreachable!(),
             Some(w) => {
                 if w.iteration >= self.max_iterations {
-                    return Ok(BlockResult { value: Value::Bool(false), meta: None});
+                    return Ok(BlockResult {
+                        value: Value::Bool(false),
+                        meta: None,
+                    });
                 }
             }
         }
@@ -111,8 +114,8 @@ impl Block for While {
 
         match result["value"] {
             Value::Bool(b) => Ok(BlockResult {
-                value: Value::Bool(b), 
-                meta: Some(result["logs"].clone())
+                value: Value::Bool(b),
+                meta: Some(result["logs"].clone()),
             }),
             _ => Err(anyhow!(
                 "Invalid return value from `condition_code`, expecting boolean"

--- a/core/src/blocks/while.rs
+++ b/core/src/blocks/while.rs
@@ -1,4 +1,4 @@
-use crate::blocks::block::{parse_pair, Block, BlockType, Env};
+use crate::blocks::block::{parse_pair, Block, BlockType, Env, BlockResult};
 use crate::deno::script::Script;
 use crate::Rule;
 use anyhow::{anyhow, Result};
@@ -80,7 +80,7 @@ impl Block for While {
         _name: &str,
         env: &Env,
         _event_sender: Option<UnboundedSender<Value>>,
-    ) -> Result<Value> {
+    ) -> Result<BlockResult> {
         let e = env.clone();
 
         // Directly return false if we have reached max_iterations
@@ -88,7 +88,7 @@ impl Block for While {
             None => unreachable!(),
             Some(w) => {
                 if w.iteration >= self.max_iterations {
-                    return Ok(Value::Bool(false));
+                    return Ok(BlockResult { val: Value::Bool(false), meta: None});
                 }
             }
         }
@@ -110,7 +110,10 @@ impl Block for While {
         };
 
         match condition_value {
-            Value::Bool(b) => Ok(Value::Bool(b)),
+            Value::Bool(b) => Ok(BlockResult {
+                val: Value::Bool(b),
+                meta: None
+            }),
             _ => Err(anyhow!(
                 "Invalid return value from `condition_code`, expecting boolean"
             ))?,

--- a/core/src/deno/script.rs
+++ b/core/src/deno/script.rs
@@ -19,7 +19,11 @@ impl Script {
         // console.log() is not available by default -- add the most basic version with single
         // argument (and no warn/info/... variants)
         let all_code =
-            "const console = { log: function(expr) { Deno.core.print(expr + '\\n', false); } };"
+            "let logs = '';
+            const console = { log: function(expr) {
+                Deno.core.print(expr + '\\n', false);
+                logs = JSON.stringify(expr) + '\\n';
+            } };"
                 .to_string()
                 + js_code;
 
@@ -83,7 +87,7 @@ impl Script {
 				if (typeof __rust_result === 'undefined')
 					__rust_result = null;
 
-				Deno.core.ops.op_return(__rust_result);
+				Deno.core.ops.op_return({{res: __rust_result, logs: logs}});
 			}})()"
         );
 

--- a/core/src/deno/script.rs
+++ b/core/src/deno/script.rs
@@ -19,10 +19,9 @@ impl Script {
         // console.log() is not available by default -- add the most basic version with single
         // argument (and no warn/info/... variants)
         let all_code =
-            "let logs = '';
-            const console = { log: function(expr) {
-                Deno.core.print(expr + '\\n', false);
-                logs = JSON.stringify(expr) + '\\n';
+            "let __rust_logs = '';
+            const console = { log: function(...args) {
+                __rust_logs += args.map((expr) => JSON.stringify(expr)).join(', ') + '\\n';
             } };"
                 .to_string()
                 + js_code;
@@ -87,7 +86,7 @@ impl Script {
 				if (typeof __rust_result === 'undefined')
 					__rust_result = null;
 
-				Deno.core.ops.op_return({{res: __rust_result, logs: logs}});
+				Deno.core.ops.op_return({{value: __rust_result, logs: __rust_logs}});
 			}})()"
         );
 

--- a/core/src/run.rs
+++ b/core/src/run.rs
@@ -17,6 +17,7 @@ pub struct BlockExecution {
     // pub env: Env,
     pub value: Option<Value>,
     pub error: Option<String>,
+    pub meta: Option<Value>
 }
 
 pub type Credentials = HashMap<String, String>;

--- a/front/components/app/blocks/Output.tsx
+++ b/front/components/app/blocks/Output.tsx
@@ -239,27 +239,34 @@ export function Execution({
     <div className="flex flex-auto flex-col overflow-hidden">
       {trace.map((t, i) => {
         return (
-          <div key={i} className="flex-auto flex-col">
-            {t.error != null ? (
-              <div className="flex flex-auto flex-row">
-                <ExclamationCircleIcon className="mt-0.5 flex h-4 w-4 text-red-400" />
-                <Error error={t.error} />
-              </div>
-            ) : (
-              <div className="flex flex-row">
-                <div className="flex flex-initial">
-                  <CheckCircleIcon className="min-w-4 mt-0.5 h-4 w-4 text-emerald-300" />
+          <div>
+            <div key={i} className="flex-auto flex-col">
+              {t.error != null ? (
+                <div className="flex flex-auto flex-row">
+                  <ExclamationCircleIcon className="mt-0.5 flex h-4 w-4 text-red-400" />
+                  <Error error={t.error} />
                 </div>
-                <div className="flex flex-1">
-                  <ValueViewer
-                    block={block}
-                    value={t.value}
-                    topLevel={true}
-                    k={null}
-                  />
+              ) : (
+                <div className="flex flex-row">
+                  <div className="flex flex-initial">
+                    <CheckCircleIcon className="min-w-4 mt-0.5 h-4 w-4 text-emerald-300" />
+                  </div>
+                  <div className="flex flex-1">
+                    <ValueViewer
+                      block={block}
+                      value={t.value}
+                      topLevel={true}
+                      k={null}
+                    />
+                  </div>
                 </div>
-              </div>
-            )}
+              )}
+            </div>
+            <div>
+               {t.meta != null ? (
+                  <p>Logs: {t.meta}</p>
+               ) : null}
+            </div>
           </div>
         );
       })}

--- a/front/components/app/blocks/Output.tsx
+++ b/front/components/app/blocks/Output.tsx
@@ -239,35 +239,34 @@ export function Execution({
     <div className="flex flex-auto flex-col overflow-hidden">
       {trace.map((t, i) => {
         return (
-          <div>
-            <div key={i} className="flex-auto flex-col">
-              {t.error != null ? (
-                <div className="flex flex-auto flex-row">
-                  <ExclamationCircleIcon className="mt-0.5 flex h-4 w-4 text-red-400" />
-                  <Error error={t.error} />
+          <div key={i} className="flex-auto flex-col">
+            {t.error != null ? (
+              <div className="flex flex-auto flex-row">
+                <ExclamationCircleIcon className="mt-0.5 flex h-4 w-4 text-red-400" />
+                <Error error={t.error} />
+              </div>
+            ) : (
+              <div className="flex flex-row">
+                <div className="flex flex-initial">
+                  <CheckCircleIcon className="min-w-4 mt-0.5 h-4 w-4 text-emerald-300" />
                 </div>
-              ) : (
-                <div className="flex flex-row">
-                  <div className="flex flex-initial">
-                    <CheckCircleIcon className="min-w-4 mt-0.5 h-4 w-4 text-emerald-300" />
-                  </div>
-                  <div className="flex flex-1">
-                    <ValueViewer
-                      block={block}
-                      value={t.value}
-                      topLevel={true}
-                      k={null}
-                    />
-                  </div>
+                <div className="flex flex-1">
+                  <ValueViewer
+                    block={block}
+                    value={t.value}
+                    topLevel={true}
+                    k={null}
+                  />
                 </div>
-              )}
-            </div>
+              </div>
+            )}
           </div>
         );
       })}
     </div>
   );
 }
+
 export function Logs({
   log
 }: {
@@ -320,7 +319,7 @@ export default function Output({
     }
   );
 
-  const [expandedRes, setExpandedRes] = useState(false);
+  const [expandedResult, setExpandedResult] = useState(false);
   const [expandedLog, setExpandedLog] = useState(false);
 
 
@@ -359,9 +358,9 @@ export default function Output({
         <div className="flex flex-auto flex-col">
           <div className="flex flex-row items-center text-sm">
             <div className="flex-initial cursor-pointer text-gray-400">
-              <div onClick={() => setExpandedRes(!expandedRes)}>
+              <div onClick={() => setExpandedResult(!expandedResult)}>
                 <span className="flex flex-row items-center">
-                  {expandedRes ? (
+                  {expandedResult ? (
                     <ChevronDownIcon className="mt-0.5 h-4 w-4" />
                   ) : (
                     <ChevronRightIcon className="mt-0.5 h-4 w-4" />
@@ -385,7 +384,7 @@ export default function Output({
               </div>
             </div>
           </div>
-          {expandedRes ? (
+          {expandedResult ? (
             <>
               {traces.map((trace, i) => {
                 return (

--- a/front/components/app/blocks/Output.tsx
+++ b/front/components/app/blocks/Output.tsx
@@ -262,18 +262,34 @@ export function Execution({
                 </div>
               )}
             </div>
-            <div>
-               {t.meta != null ? (
-                  <p>Logs: {t.meta}</p>
-               ) : null}
-            </div>
           </div>
         );
       })}
     </div>
   );
 }
-
+export function Logs({
+  log
+}: {
+  log: String;
+}) {
+  return (
+    <div className="flex flex-auto flex-col overflow-hidden">
+      <div>
+        <div className="flex-auto flex-col">
+          <div className="flex flex-1">
+            <ValueViewer
+              value={log}
+              topLevel={true}
+              k={null}
+              block={null}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
 export default function Output({
   owner,
   block,
@@ -304,7 +320,9 @@ export default function Output({
     }
   );
 
-  const [expanded, setExpanded] = useState(false);
+  const [expandedRes, setExpandedRes] = useState(false);
+  const [expandedLog, setExpandedLog] = useState(false);
+
 
   if (
     run &&
@@ -337,49 +355,90 @@ export default function Output({
     }, 0);
 
     return (
-      <div className="flex flex-auto flex-col">
-        <div className="flex flex-row items-center text-sm">
-          <div className="flex-initial cursor-pointer text-gray-400">
-            <div onClick={() => setExpanded(!expanded)}>
-              <span className="flex flex-row items-center">
-                {expanded ? (
-                  <ChevronDownIcon className="mt-0.5 h-4 w-4" />
-                ) : (
-                  <ChevronRightIcon className="mt-0.5 h-4 w-4" />
-                )}
-                <span className="text-sm text-gray-400">
-                  [{" "}
-                  <span className="font-bold text-emerald-400">
-                    {successes} {successes === 1 ? "success" : "successes"}
+      <div>
+        <div className="flex flex-auto flex-col">
+          <div className="flex flex-row items-center text-sm">
+            <div className="flex-initial cursor-pointer text-gray-400">
+              <div onClick={() => setExpandedRes(!expandedRes)}>
+                <span className="flex flex-row items-center">
+                  {expandedRes ? (
+                    <ChevronDownIcon className="mt-0.5 h-4 w-4" />
+                  ) : (
+                    <ChevronRightIcon className="mt-0.5 h-4 w-4" />
+                  )}
+                  <span className="text-sm text-gray-400">
+                    [{" "}
+                    <span className="font-bold text-emerald-400">
+                      {successes} {successes === 1 ? "success" : "successes"}
+                    </span>
+                    {errors > 0 ? (
+                      <>
+                        {", "}
+                        <span className="font-bold text-red-400">
+                          {errors} {errors === 1 ? "error" : "errors"}
+                        </span>
+                      </>
+                    ) : null}{" "}
+                    ]
                   </span>
-                  {errors > 0 ? (
-                    <>
-                      {", "}
-                      <span className="font-bold text-red-400">
-                        {errors} {errors === 1 ? "error" : "errors"}
-                      </span>
-                    </>
-                  ) : null}{" "}
-                  ]
                 </span>
-              </span>
+              </div>
             </div>
           </div>
-        </div>
-        {expanded ? (
-          <>
-            {traces.map((trace, i) => {
-              return (
-                <div key={i} className="ml-1 flex flex-auto flex-row">
-                  <div className="mr-2 flex font-mono text-sm text-gray-300">
-                    {i}:
+          {expandedRes ? (
+            <>
+              {traces.map((trace, i) => {
+                return (
+                  <div key={i} className="ml-1 flex flex-auto flex-row">
+                    <div className="mr-2 flex font-mono text-sm text-gray-300">
+                      {i}:
+                    </div>
+                    <Execution trace={trace} block={block} />
                   </div>
-                  <Execution trace={trace} block={block} />
-                </div>
-              );
-            })}
-          </>
-        ) : null}
+                );
+              })}
+            </>
+          ) : null}
+        </div>
+        <div className="flex flex-auto flex-col">
+          <div className="flex flex-row items-center text-sm">
+            <div className="flex-initial cursor-pointer text-gray-400">
+              <div onClick={() => setExpandedLog(!expandedLog)}>
+                <span className="flex flex-row items-center">
+                  {expandedLog ? (
+                    <ChevronDownIcon className="mt-0.5 h-4 w-4" />
+                  ) : (
+                    <ChevronRightIcon className="mt-0.5 h-4 w-4" />
+                  )}
+                  <span className="text-sm text-gray-400">
+                    [{" "}
+                    <span className="font-bold">
+                      Logs
+                    </span>
+                    ]
+                  </span>
+                </span>
+              </div>
+            </div>
+          </div>
+          {expandedLog ? (
+            <>
+              {/* Expand all logs for the traces and then flatten,  .flat().flat() is not clean... */}
+              {traces.map((trace) => trace.map((t) => t.meta.split("\n"))).flat().flat().map((log, i) => {
+                if (log) {
+                  return (
+                    <div key={i} className="ml-1 flex flex-auto flex-row">
+                      <div className="mr-2 flex font-mono text-sm text-gray-300">
+                        {i}:
+                      </div>
+                      <Logs log={log} />
+                    </div>
+                  );
+                }
+              })}
+            </>
+          ) : null}
+        </div>
       </div>
     );
   } else {

--- a/front/lib/dust_api.ts
+++ b/front/lib/dust_api.ts
@@ -55,7 +55,7 @@ export type DustAppRunBlockExecutionEvent = {
   content: {
     block_type: string;
     block_name: string;
-    execution: { value: any | null; error: string | null }[][];
+    execution: { value: any | null; error: string | null, meta: any | null }[][];
   };
 };
 

--- a/front/pages/w/[wId]/a/[aId]/execute/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/execute/index.tsx
@@ -184,7 +184,7 @@ function ExecuteOutputLine({
           </div>
         </div>
       </button>
-      {true ? (
+      {expanded ? (
         <div className="mb-2 ml-8 flex text-sm text-gray-600">
           <Execution block={null} trace={traces} />
         </div>

--- a/front/pages/w/[wId]/a/[aId]/execute/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/execute/index.tsx
@@ -155,42 +155,40 @@ function ExecuteOutputLine({
   const traces = outputForBlock ? getTraceFromEvents(outputForBlock) : [];
 
   return (
-    <div>
-      <div className="leading-none">
-        <button
-          disabled={!traces}
-          onClick={() => onToggleExpand()}
-          className={classNames("border-none", traces ? "" : "text-gray-400")}
-        >
-          <div className="flex flex-row items-center">
-            {!expanded ? (
-              <ChevronRightIcon className="h-4 w-4 text-gray-400" />
-            ) : (
-              <ChevronDownIcon className="h-4 w-4 text-gray-400" />
-            )}{" "}
-            <div className="inline">
-              <span className="rounded-md bg-gray-200 px-1 py-0.5 text-sm font-medium">
-                {blockType}
-              </span>
-              <span className="ml-1 font-bold text-gray-700">{blockName}</span>
-            </div>
-            <div>
-              {lastEventForBlock.content.status === "running" ? (
-                <div className="ml-1">
-                  <Spinner />
-                </div>
-              ) : lastEventForBlock.content.status === "errored" ? (
-                <ExclamationCircleIcon className="ml-1 h-4 w-4 text-red-500" />
-              ) : null}
-            </div>
+    <div className="leading-none">
+      <button
+        disabled={!traces}
+        onClick={() => onToggleExpand()}
+        className={classNames("border-none", traces ? "" : "text-gray-400")}
+      >
+        <div className="flex flex-row items-center">
+          {!expanded ? (
+            <ChevronRightIcon className="h-4 w-4 text-gray-400" />
+          ) : (
+            <ChevronDownIcon className="h-4 w-4 text-gray-400" />
+          )}{" "}
+          <div className="inline">
+            <span className="rounded-md bg-gray-200 px-1 py-0.5 text-sm font-medium">
+              {blockType}
+            </span>
+            <span className="ml-1 font-bold text-gray-700">{blockName}</span>
           </div>
-        </button>
-        {true ? (
-          <div className="mb-2 ml-8 flex text-sm text-gray-600">
-            <Execution block={null} trace={traces} />
+          <div>
+            {lastEventForBlock.content.status === "running" ? (
+              <div className="ml-1">
+                <Spinner />
+              </div>
+            ) : lastEventForBlock.content.status === "errored" ? (
+              <ExclamationCircleIcon className="ml-1 h-4 w-4 text-red-500" />
+            ) : null}
           </div>
-        ) : null}
-      </div>
+        </div>
+      </button>
+      {true ? (
+        <div className="mb-2 ml-8 flex text-sm text-gray-600">
+          <Execution block={null} trace={traces} />
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/front/pages/w/[wId]/a/[aId]/execute/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/execute/index.tsx
@@ -12,7 +12,7 @@ import TextareaAutosize from "react-textarea-autosize";
 // @ts-expect-error there are no types for sse.js.
 import { SSE } from "sse.js";
 
-import { Execution } from "@app/components/app/blocks/Output";
+import { Execution, Logs } from "@app/components/app/blocks/Output";
 import MainTab from "@app/components/app/MainTab";
 import AppLayout from "@app/components/AppLayout";
 import { ActionButton } from "@app/components/Button";
@@ -155,40 +155,42 @@ function ExecuteOutputLine({
   const traces = outputForBlock ? getTraceFromEvents(outputForBlock) : [];
 
   return (
-    <div className="leading-none">
-      <button
-        disabled={!traces}
-        onClick={() => onToggleExpand()}
-        className={classNames("border-none", traces ? "" : "text-gray-400")}
-      >
-        <div className="flex flex-row items-center">
-          {!expanded ? (
-            <ChevronRightIcon className="h-4 w-4 text-gray-400" />
-          ) : (
-            <ChevronDownIcon className="h-4 w-4 text-gray-400" />
-          )}{" "}
-          <div className="inline">
-            <span className="rounded-md bg-gray-200 px-1 py-0.5 text-sm font-medium">
-              {blockType}
-            </span>
-            <span className="ml-1 font-bold text-gray-700">{blockName}</span>
+    <div>
+      <div className="leading-none">
+        <button
+          disabled={!traces}
+          onClick={() => onToggleExpand()}
+          className={classNames("border-none", traces ? "" : "text-gray-400")}
+        >
+          <div className="flex flex-row items-center">
+            {!expanded ? (
+              <ChevronRightIcon className="h-4 w-4 text-gray-400" />
+            ) : (
+              <ChevronDownIcon className="h-4 w-4 text-gray-400" />
+            )}{" "}
+            <div className="inline">
+              <span className="rounded-md bg-gray-200 px-1 py-0.5 text-sm font-medium">
+                {blockType}
+              </span>
+              <span className="ml-1 font-bold text-gray-700">{blockName}</span>
+            </div>
+            <div>
+              {lastEventForBlock.content.status === "running" ? (
+                <div className="ml-1">
+                  <Spinner />
+                </div>
+              ) : lastEventForBlock.content.status === "errored" ? (
+                <ExclamationCircleIcon className="ml-1 h-4 w-4 text-red-500" />
+              ) : null}
+            </div>
           </div>
-          <div>
-            {lastEventForBlock.content.status === "running" ? (
-              <div className="ml-1">
-                <Spinner />
-              </div>
-            ) : lastEventForBlock.content.status === "errored" ? (
-              <ExclamationCircleIcon className="ml-1 h-4 w-4 text-red-500" />
-            ) : null}
+        </button>
+        {true ? (
+          <div className="mb-2 ml-8 flex text-sm text-gray-600">
+            <Execution block={null} trace={traces} />
           </div>
-        </div>
-      </button>
-      {expanded ? (
-        <div className="mb-2 ml-8 flex text-sm text-gray-600">
-          <Execution block={null} trace={traces} />
-        </div>
-      ) : null}
+        ) : null}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Adds support for console logging. Preliminary PR, not sure how we want this to look or if the way I'm doing this on the backend is the best (just adding a log value in deno that's returned and passed to a meta attr in the BlockExecution constructor if it's a code block, and then parsing that in the frontend).

Example:

![image](https://github.com/dust-tt/dust/assets/52892257/2cc8708a-1d21-4226-b148-5b2f874d5f2b)
