### PR TITLE
Chat /commands

### DIFF
--- a/front/lib/actions_registry.ts
+++ b/front/lib/actions_registry.ts
@@ -27,6 +27,38 @@ export const DustProdActionRegistry: {
       },
     },
   },
+  "chat-retrieval": {
+    app: {
+      workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
+      appId: "0d7ab66fd2",
+      appHash:
+        "3f64c7b8d4bad05db5d880ca5ffb66f7107a5c178ed43e360fd31634269bc01f",
+    },
+    config: {
+      DATASOURCE: {
+        data_sources: [],
+        top_k: 8,
+        filter: { tags: null, timestamp: null },
+        use_cache: false,
+      },
+    },
+  },
+  "chat-assistant": {
+    app: {
+      workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
+      appId: "ab43ff2450",
+      appHash:
+        "02a6d6d9194f732aa6e666f39384d7ccf7fbc2d18a7c1b411d732f2316169bfd",
+    },
+    config: {
+      MODEL: {
+        provider_id: "openai",
+        model_id: "gpt-3.5-turbo",
+        use_cache: true,
+        use_stream: true,
+      },
+    },
+  },
 };
 
 export function cloneBaseConfig(config: { [model: string]: any }) {

--- a/front/lib/actions_registry.ts
+++ b/front/lib/actions_registry.ts
@@ -5,28 +5,6 @@ const PRODUCTION_DUST_APPS_WORKSPACE_ID = "78bda07b39";
 export const DustProdActionRegistry: {
   [key: string]: { app: DustAppType; config: { [model: string]: any } };
 } = {
-  "chat-main": {
-    app: {
-      workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
-      appId: "6fe1383f11",
-      appHash:
-        "14751b358fee71615debe3a367e4f7426f902e91b6248025c5b474b37cb9302b",
-    },
-    config: {
-      MODEL: {
-        provider_id: "openai",
-        model_id: "gpt-3.5-turbo",
-        use_cache: true,
-        use_stream: true,
-      },
-      DATASOURCE: {
-        data_sources: [],
-        top_k: 8,
-        filter: { tags: null, timestamp: null },
-        use_cache: false,
-      },
-    },
-  },
   "chat-retrieval": {
     app: {
       workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,

--- a/front/pages/w/[wId]/u/chat/index.tsx
+++ b/front/pages/w/[wId]/u/chat/index.tsx
@@ -757,6 +757,37 @@ export default function AppChat({
                             team@dust.tt
                           </a>
                         </p>
+                        <div className="mt-8 w-full">
+                          ⚙️ Available commands:
+                          <div className="pt-2">
+                            {COMMANDS.map((c, i) => {
+                              return (
+                                <div
+                                  key={i}
+                                  className={classNames("flex px-2 py-1")}
+                                >
+                                  <div className="flex w-24 flex-row">
+                                    <div className="flex flex-initial flex-col">
+                                      <div
+                                        className={classNames(
+                                          "flex flex-initial",
+                                          "rounded bg-gray-200 px-2 py-0.5 text-xs font-bold text-slate-800"
+                                        )}
+                                      >
+                                        {c.cmd}
+                                      </div>
+                                      <div className="flex flex-1"></div>
+                                    </div>
+                                    <div className="flex flex-1"></div>
+                                  </div>
+                                  <div className="ml-2 w-64 sm:w-max">
+                                    {c.description}
+                                  </div>
+                                </div>
+                              );
+                            })}
+                          </div>
+                        </div>
                       </div>
                     )}
                   </div>

--- a/front/pages/w/[wId]/u/chat/index.tsx
+++ b/front/pages/w/[wId]/u/chat/index.tsx
@@ -358,6 +358,21 @@ export function MessageView({
   );
 }
 
+const COMMANDS: { cmd: string; description: string }[] = [
+  {
+    cmd: "/new",
+    description: "start a new conversation",
+  },
+  {
+    cmd: "/search",
+    description: "perform a document retrieval without querying the agent",
+  },
+  {
+    cmd: "/msg",
+    description: "message the agent without performing a document retrieval",
+  },
+];
+
 export default function AppChat({
   user,
   owner,
@@ -377,6 +392,9 @@ export default function AppChat({
   const [input, setInput] = useState("");
   const [loading, setLoading] = useState(false);
   const [response, setResponse] = useState<Message | null>(null);
+  const [commands, setCommands] = useState<
+    { cmd: string; description: string }[]
+  >([]);
 
   const scrollRef = useRef<HTMLDivElement>(null);
 
@@ -385,6 +403,15 @@ export default function AppChat({
       scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
     }
   }, [messages, response]);
+
+  const handleInputUpdate = (input: string) => {
+    setInput(input);
+    if (input.startsWith("/") && input.split(" ").length === 1) {
+      setCommands(COMMANDS.filter((c) => c.cmd.startsWith(input)));
+    } else {
+      setCommands([]);
+    }
+  };
 
   const handleSwitchDataSourceSelection = (name: string) => {
     const newSelection = dataSources.map((ds) => {
@@ -619,6 +646,35 @@ export default function AppChat({
                       alpha
                     </div>
                     <div className="flex flex-1 flex-row items-end">
+                      {commands.length > 0 && (
+                        <div className="absolute mb-12 pr-7">
+                          <div className="flex flex-col rounded-sm border bg-white px-2 py-2">
+                            {commands.map((c, i) => {
+                              return (
+                                <div
+                                  key={i}
+                                  className="flex cursor-pointer flex-row rounded-sm px-2 py-2 hover:bg-gray-100"
+                                >
+                                  <div className="flex w-16 flex-row">
+                                    <div
+                                      className={classNames(
+                                        "flex flex-initial",
+                                        "rounded bg-gray-200 px-2 py-0.5 text-xs font-bold text-slate-800"
+                                      )}
+                                    >
+                                      {c.cmd}
+                                    </div>
+                                    <div className="flex flex-1"></div>
+                                  </div>
+                                  <div className="italic text-gray-500">
+                                    {c.description}
+                                  </div>
+                                </div>
+                              );
+                            })}
+                          </div>
+                        </div>
+                      )}
                       <TextareaAutosize
                         minRows={1}
                         placeholder={`Ask anything about \`${owner.name}\``}
@@ -632,7 +688,7 @@ export default function AppChat({
                         )}
                         value={input}
                         onChange={(e) => {
-                          setInput(e.target.value);
+                          handleInputUpdate(e.target.value);
                         }}
                         onKeyDown={(e) => {
                           if (e.ctrlKey || e.metaKey) {

--- a/front/pages/w/[wId]/u/chat/index.tsx
+++ b/front/pages/w/[wId]/u/chat/index.tsx
@@ -369,7 +369,7 @@ const COMMANDS: { cmd: string; description: string }[] = [
       "Follow-up with the agent without performing a document retrieval",
   },
   {
-    cmd: "/retrieve-only",
+    cmd: "/retrieve",
     description: "Perform a document retrieval without querying the agent",
   },
 ];
@@ -441,7 +441,7 @@ export default function AppChat({
     setDataSources(newSelection);
   };
 
-  const handleSubmitMessage = async () => {
+  const handleSubmit = async () => {
     // clone messages add new message to the end
     const m = [...messages];
     m.push({
@@ -741,7 +741,7 @@ export default function AppChat({
                           }
                           if (e.ctrlKey || e.metaKey) {
                             if (e.key === "Enter" && !loading) {
-                              void handleSubmitMessage();
+                              void handleSubmit();
                               e.preventDefault();
                             }
                           }
@@ -757,7 +757,7 @@ export default function AppChat({
                           <ArrowRightCircleIcon
                             className="h-5 w-5 cursor-pointer text-violet-500"
                             onClick={() => {
-                              void handleSubmitMessage();
+                              void handleSubmit();
                             }}
                           />
                         ) : (

--- a/front/pages/w/[wId]/u/chat/index.tsx
+++ b/front/pages/w/[wId]/u/chat/index.tsx
@@ -361,11 +361,11 @@ const COMMANDS: { cmd: string; description: string }[] = [
   {
     cmd: "/follow-up",
     description:
-      "Follow-up with the agent without performing a document retrieval",
+      "Follow-up with the assistant without performing a document retrieval",
   },
   {
     cmd: "/retrieve",
-    description: "Perform a document retrieval without querying the agent",
+    description: "Perform a document retrieval without querying the assistant",
   },
 ];
 
@@ -802,7 +802,7 @@ export default function AppChat({
                                     </div>
                                     <div className="flex flex-1"></div>
                                   </div>
-                                  <div className="ml-2 w-48 truncate italic text-gray-500 sm:w-max">
+                                  <div className="ml-2 w-48 truncate pr-2 italic text-gray-500 sm:w-max">
                                     {c.description}
                                   </div>
                                 </div>


### PR DESCRIPTION
Introduces 3 commands:
```
{
    cmd: "/new",
    description: "Start a new conversation",
  },
  {
    cmd: "/follow-up",
    description:
      "Follow-up with the assistant without performing a document retrieval",
  },
  {
    cmd: "/retrieve",
    description: "Perform a document retrieval without querying the assistant",
  },
  ```
  
  Separates the Chat app in 2 sub-apps, also cleans-up the message structure to prepare for SQLization.