### PR TITLE
FIX: bug with offsets on data source

### DIFF
--- a/front/pages/w/[wId]/ds/[name]/index.tsx
+++ b/front/pages/w/[wId]/ds/[name]/index.tsx
@@ -174,8 +174,7 @@ export default function DataSourceView({
                   </div>
 
                   <div className="mt-3 flex flex-auto pl-1 text-sm text-gray-700">
-                    Showing documents {Math.min(documents.length, offset + 1)} -{" "}
-                    {last} of {total} documents
+                    Showing documents {offset + 1} - {last} of {total} documents
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
There was a bug where when you clicked to see further documents the counter of the form `x - x + 10` would list for eg `11-40` instead of `31-40`, because of the min that was clipping at the size of currently fetched documents.