### PR TITLE
feat: github issues connector webhooks

### DIFF
--- a/connectors/src/admin/db.ts
+++ b/connectors/src/admin/db.ts
@@ -1,5 +1,7 @@
 import {
   Connector,
+  GithubConnectorState,
+  GithubIssue,
   NotionConnectorState,
   NotionPage,
   SlackConfiguration,
@@ -13,6 +15,8 @@ async function main(): Promise<void> {
   await SlackMessages.sync({ alter: true });
   await NotionPage.sync({ alter: true });
   await NotionConnectorState.sync({ alter: true });
+  await GithubConnectorState.sync({ alter: true });
+  await GithubIssue.sync({ alter: true });
   return;
 }
 

--- a/connectors/src/api/webhooks/webhook_github.ts
+++ b/connectors/src/api/webhooks/webhook_github.ts
@@ -9,6 +9,7 @@ import {
   isRepositoriesRemovedPayload,
 } from "@connectors/connectors/github/lib/github_webhooks";
 import {
+  launchGithubIssueGarbageCollectWorkflow,
   launchGithubIssueSyncWorkflow,
   launchGithubRepoGarbageCollectWorkflow,
   launchGithubReposSyncWorkflow,
@@ -58,7 +59,7 @@ const _webhookGithubAPIHandler = async (
       },
       "Ignoring webhook event"
     );
-    res.status(200).end();
+    return res.status(200).end();
   }
 
   logger.info(
@@ -78,7 +79,7 @@ const _webhookGithubAPIHandler = async (
       },
       "Could not process webhook"
     );
-    return res.status(500).json();
+    return res.status(500).end();
   };
 
   if (!isGithubWebhookPayload(jsonBody)) {
@@ -287,9 +288,8 @@ async function garbageCollectIssue(
   issueNumber: number,
   res: Response<GithubWebhookResBody>
 ) {
-  console.log(
-    "GARBAGE COLLECT ISSUE",
-    connector.connectionId,
+  await launchGithubIssueGarbageCollectWorkflow(
+    connector.id.toString(),
     orgLogin,
     repoName,
     repoId,

--- a/connectors/src/api/webhooks/webhook_github.ts
+++ b/connectors/src/api/webhooks/webhook_github.ts
@@ -10,6 +10,7 @@ import {
 } from "@connectors/connectors/github/lib/github_webhooks";
 import {
   launchGithubIssueSyncWorkflow,
+  launchGithubRepoGarbageCollectWorkflow,
   launchGithubReposSyncWorkflow,
 } from "@connectors/connectors/github/temporal/client";
 import { assertNever } from "@connectors/lib/assert_never";
@@ -268,13 +269,12 @@ async function garbageCollectRepos(
   repos: { name: string; id: number }[],
   res: Response<GithubWebhookResBody>
 ) {
-  for (const repo of repos) {
-    console.log(
-      "GARBAGE COLLECT REPO",
-      connector.connectionId,
+  for (const { name, id } of repos) {
+    await launchGithubRepoGarbageCollectWorkflow(
+      connector.id.toString(),
       orgLogin,
-      repo.name,
-      repo.id
+      name,
+      id
     );
   }
   res.status(200).end();

--- a/connectors/src/api/webhooks/webhook_github.ts
+++ b/connectors/src/api/webhooks/webhook_github.ts
@@ -3,16 +3,104 @@ import { Request, Response } from "express";
 import { withLogging } from "@connectors/logger/withlogging";
 import { ConnectorsAPIErrorResponse } from "@connectors/types/errors";
 
+interface GithubWebhookPayload {
+  action: string;
+  installation: {
+    id: number;
+  };
+  organization: {
+    login: string;
+  };
+  repository: {
+    name: string;
+  };
+}
+
+function isGithubWebhookPayload(
+  payload: unknown
+): payload is GithubWebhookPayload {
+  return (
+    !!(payload as GithubWebhookPayload).action &&
+    typeof (payload as GithubWebhookPayload).action === "string" &&
+    !!(payload as GithubWebhookPayload).installation &&
+    typeof (payload as GithubWebhookPayload).installation.id === "number" &&
+    !!(payload as GithubWebhookPayload).organization &&
+    typeof (payload as GithubWebhookPayload).organization.login === "string" &&
+    !!(payload as GithubWebhookPayload).repository &&
+    typeof (payload as GithubWebhookPayload).repository.name === "string"
+  );
+}
+
+interface RepositoriesAddedPayload {
+  action: "added";
+  repositories_added: { name: string }[];
+}
+
+function isRepositoriesAddedPayload(
+  payload: unknown
+): payload is RepositoriesAddedPayload {
+  return (
+    !!(payload as RepositoriesAddedPayload).repositories_added &&
+    (payload as RepositoriesAddedPayload).action === "added"
+  );
+}
+
+interface RepositoriesRemovedPayload {
+  action: "removed";
+  repositories_removed: { name: string }[];
+}
+
+function isRepositoriesRemovedPayload(
+  payload: unknown
+): payload is RepositoriesRemovedPayload {
+  return (
+    !!(payload as RepositoriesRemovedPayload).repositories_removed &&
+    (payload as RepositoriesRemovedPayload).action === "removed"
+  );
+}
+
+const issuePayloadActions = ["opened", "edited", "deleted"] as const;
+
+interface IssuePayload {
+  action: (typeof issuePayloadActions)[number];
+  issue: { id: number; number: number };
+}
+
+function isIssuePayload(payload: unknown): payload is IssuePayload {
+  return (
+    !!(payload as IssuePayload).issue &&
+    issuePayloadActions.includes((payload as IssuePayload).action)
+  );
+}
+
+const commentPayloadActions = ["created", "edited", "deleted"] as const;
+
+interface CommentPayload {
+  action: (typeof commentPayloadActions)[number];
+  issue: { id: number; number: number };
+}
+
+function isCommentPayload(payload: unknown): payload is CommentPayload {
+  return (
+    !!(payload as CommentPayload).issue &&
+    commentPayloadActions.includes((payload as CommentPayload).action)
+  );
+}
+
 type GithubWebhookReqBody = {
-  // TODO: fill in
+  action: string;
+  installation: {
+    id: number;
+  };
+  organization: {
+    login: string;
+  };
+  repository: {
+    name: string;
+  };
 };
 
-type GithubWebhookResBody =
-  | {
-      // TODO: fill in
-    }
-  | null
-  | ConnectorsAPIErrorResponse;
+type GithubWebhookResBody = null | ConnectorsAPIErrorResponse;
 
 const _webhookGithubAPIHandler = async (
   req: Request<
@@ -22,8 +110,84 @@ const _webhookGithubAPIHandler = async (
   >,
   res: Response<GithubWebhookResBody>
 ) => {
-  // TODO -- webhooks ignored for now
-  return res.status(200).end();
+  const event = req.headers["x-github-event"];
+  const jsonBody = req.body;
+  const action = jsonBody.action;
+
+  if (!event || typeof event !== "string") {
+    return res.status(400).json({
+      error: {
+        message: "Missing `x-github-event` header",
+      },
+    });
+  }
+
+  if (!action) {
+    return res.status(400).json({
+      error: {
+        message: "Missing `action` in payload",
+      },
+    });
+  }
+
+  if (!isGithubWebhookPayload(jsonBody)) {
+    return res.status(400).json({
+      error: {
+        message: "Invalid payload",
+      },
+    });
+  }
+
+  switch (event) {
+    case "installation_repositories":
+      if (isRepositoriesAddedPayload(jsonBody)) {
+        // TODO: sync repo
+      } else if (isRepositoriesRemovedPayload(jsonBody)) {
+        // TODO: garbage collect repo
+      } else {
+        return res.status(400).json({
+          error: {
+            message: "Invalid payload",
+          },
+        });
+      }
+      break;
+    case "issues":
+      if (isIssuePayload(jsonBody)) {
+        if (jsonBody.action === "opened" || jsonBody.action === "edited") {
+          // TODO: sync issue
+        } else if (jsonBody.action === "deleted") {
+          // TODO: garbage collect issue
+        } else {
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          ((_action: never) => ({}))(jsonBody.action);
+          res.status(200).end();
+        }
+      } else {
+        // unhandled -- ignore
+        return res.status(200).end();
+      }
+      break;
+    case "issue_comment":
+      if (isCommentPayload(jsonBody)) {
+        if (jsonBody.action === "created" || jsonBody.action === "edited") {
+          // TODO: sync issue
+        } else if (jsonBody.action === "deleted") {
+          // TODO: garbage collect issue
+        } else {
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          ((_action: never) => ({}))(jsonBody.action);
+          res.status(200).end();
+        }
+      } else {
+        // unhandled -- ignore
+        return res.status(200).end();
+      }
+      break;
+    default:
+      // unhandled -- ignore
+      return res.status(200).end();
+  }
 };
 
 export const webhookGithubAPIHandler = withLogging(_webhookGithubAPIHandler);

--- a/connectors/src/api/webhooks/webhook_github.ts
+++ b/connectors/src/api/webhooks/webhook_github.ts
@@ -112,20 +112,11 @@ const _webhookGithubAPIHandler = async (
 ) => {
   const event = req.headers["x-github-event"];
   const jsonBody = req.body;
-  const action = jsonBody.action;
 
   if (!event || typeof event !== "string") {
     return res.status(400).json({
       error: {
         message: "Missing `x-github-event` header",
-      },
-    });
-  }
-
-  if (!action) {
-    return res.status(400).json({
-      error: {
-        message: "Missing `action` in payload",
       },
     });
   }

--- a/connectors/src/api/webhooks/webhook_github.ts
+++ b/connectors/src/api/webhooks/webhook_github.ts
@@ -51,13 +51,14 @@ const _webhookGithubAPIHandler = async (
   }
 
   if (!HANDLED_WEBHOOKS[event]?.has(action)) {
-    return ignoreEvent(
+    logger.info(
       {
         event,
         action,
       },
-      res
+      "Ignoring webhook event"
     );
+    res.status(200).end();
   }
 
   logger.info(
@@ -232,26 +233,6 @@ const _webhookGithubAPIHandler = async (
       return rejectEvent();
   }
 };
-
-function ignoreEvent(
-  {
-    event,
-    action,
-  }: {
-    event: string;
-    action: string;
-  },
-  res: Response<GithubWebhookResBody>
-) {
-  logger.info(
-    {
-      event,
-      action,
-    },
-    "Ignoring event"
-  );
-  res.status(200).end();
-}
 
 async function syncRepos(
   connector: Connector,

--- a/connectors/src/api/webhooks/webhook_github.ts
+++ b/connectors/src/api/webhooks/webhook_github.ts
@@ -138,9 +138,6 @@ const _webhookGithubAPIHandler = async (
     return res.status(200);
   }
 
-  // TODO: check connector state (paused, etc.)
-  // if connector is paused, return 200 to avoid github retrying
-
   switch (event) {
     case "installation_repositories":
       if (isRepositoriesAddedPayload(jsonBody)) {

--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -1,6 +1,10 @@
 import { validateInstallationId } from "@connectors/connectors/github/lib/github_api";
 import { launchGithubFullSyncWorkflow } from "@connectors/connectors/github/temporal/client";
-import { Connector } from "@connectors/lib/models";
+import {
+  Connector,
+  GithubConnectorState,
+  sequelize_conn,
+} from "@connectors/lib/models";
 import { Err, Ok, Result } from "@connectors/lib/result";
 import mainLogger from "@connectors/logger/logger";
 import { DataSourceConfig } from "@connectors/types/data_source_config";
@@ -19,18 +23,31 @@ export async function createGithubConnector(
     return new Err(new Error("Github installation id is invalid"));
   }
 
+  const transaction = await sequelize_conn.transaction();
   try {
-    const connector = await Connector.create({
-      type: "github",
-      connectionId: githubInstallationId,
-      workspaceAPIKey: dataSourceConfig.workspaceAPIKey,
-      workspaceId: dataSourceConfig.workspaceId,
-      dataSourceName: dataSourceConfig.dataSourceName,
-    });
+    const connector = await Connector.create(
+      {
+        type: "github",
+        connectionId: githubInstallationId,
+        workspaceAPIKey: dataSourceConfig.workspaceAPIKey,
+        workspaceId: dataSourceConfig.workspaceId,
+        dataSourceName: dataSourceConfig.dataSourceName,
+      },
+      { transaction }
+    );
+    await GithubConnectorState.create(
+      {
+        connectorId: connector.id,
+        webhooksEnabledAt: new Date(),
+      },
+      { transaction }
+    );
+    await transaction.commit();
     await launchGithubFullSyncWorkflow(connector.id.toString());
     return new Ok(connector.id.toString());
   } catch (err) {
     logger.error({ error: err }, "Error creating github connector");
+    await transaction.rollback();
     return new Err(err as Error);
   }
 }

--- a/connectors/src/connectors/github/lib/github_webhooks.ts
+++ b/connectors/src/connectors/github/lib/github_webhooks.ts
@@ -1,0 +1,182 @@
+export type GithubWebhookPayload = {
+  action: string;
+  installation: {
+    id: number;
+  };
+};
+
+export function isGithubWebhookPayload(
+  payload: unknown
+): payload is GithubWebhookPayload {
+  return (
+    !!(payload as GithubWebhookPayload).action &&
+    typeof (payload as GithubWebhookPayload).action === "string" &&
+    !!(payload as GithubWebhookPayload).installation &&
+    typeof (payload as GithubWebhookPayload).installation.id === "number"
+  );
+}
+
+export type LightRepoType = {
+  id: number;
+  name: string;
+};
+
+export type WithInstallationAccountType = {
+  installation: {
+    id: number;
+    account: {
+      login: string;
+    };
+  };
+};
+
+export function isWithInstallationAccountType(
+  payload: unknown
+): payload is WithInstallationAccountType {
+  return (
+    !!(payload as WithInstallationAccountType).installation &&
+    typeof (payload as WithInstallationAccountType).installation.id ===
+      "number" &&
+    !!(payload as WithInstallationAccountType).installation.account &&
+    typeof (payload as WithInstallationAccountType).installation.account
+      .login === "string"
+  );
+}
+
+export type RepositoriesAddedPayload = {
+  action: "added";
+  repositories_added: LightRepoType[];
+} & WithInstallationAccountType;
+
+export function isRepositoriesAddedPayload(
+  payload: unknown
+): payload is RepositoriesAddedPayload {
+  return (
+    !!(payload as RepositoriesAddedPayload).repositories_added &&
+    (payload as RepositoriesAddedPayload).action === "added" &&
+    isWithInstallationAccountType(payload)
+  );
+}
+
+export type RepositoriesRemovedPayload = {
+  action: "removed";
+  repositories_removed: LightRepoType[];
+} & WithInstallationAccountType;
+
+export function isRepositoriesRemovedPayload(
+  payload: unknown
+): payload is RepositoriesRemovedPayload {
+  return (
+    !!(payload as RepositoriesRemovedPayload).repositories_removed &&
+    (payload as RepositoriesRemovedPayload).action === "removed" &&
+    isWithInstallationAccountType(payload)
+  );
+}
+
+export type WithLightIssueType = {
+  issue: {
+    id: number;
+    number: number;
+  };
+};
+
+export function isWithLightIssueType(
+  payload: unknown
+): payload is WithLightIssueType {
+  return (
+    !!(payload as WithLightIssueType).issue &&
+    typeof (payload as WithLightIssueType).issue.id === "number" &&
+    typeof (payload as WithLightIssueType).issue.number === "number"
+  );
+}
+
+export type WithLightOrganizationType = {
+  organization: {
+    login: string;
+  };
+};
+
+export function isWithLightOrganizationType(
+  payload: unknown
+): payload is WithLightOrganizationType {
+  return (
+    !!(payload as WithLightOrganizationType).organization &&
+    typeof (payload as WithLightOrganizationType).organization.login ===
+      "string"
+  );
+}
+
+export type WithLightRepositoryType = {
+  repository: {
+    id: number;
+    name: string;
+  };
+};
+
+export function isWithLightRepositoryType(
+  payload: unknown
+): payload is WithLightRepositoryType {
+  return (
+    !!(payload as WithLightRepositoryType).repository &&
+    typeof (payload as WithLightRepositoryType).repository.id === "number" &&
+    typeof (payload as WithLightRepositoryType).repository.name === "string"
+  );
+}
+
+export const issuePayloadActions = ["opened", "edited", "deleted"] as const;
+
+export type IssuePayload = {
+  action: (typeof issuePayloadActions)[number];
+} & WithLightIssueType &
+  WithLightOrganizationType &
+  WithLightRepositoryType;
+
+export function isIssuePayload(payload: unknown): payload is IssuePayload {
+  return (
+    !!(payload as IssuePayload).issue &&
+    issuePayloadActions.includes((payload as IssuePayload).action) &&
+    isWithLightIssueType(payload) &&
+    isWithLightOrganizationType(payload) &&
+    isWithLightRepositoryType(payload)
+  );
+}
+
+export const commentPayloadActions = ["created", "edited", "deleted"] as const;
+
+export type CommentPayload = {
+  action: (typeof commentPayloadActions)[number];
+} & WithLightIssueType &
+  WithLightOrganizationType &
+  WithLightRepositoryType;
+
+export function isCommentPayload(payload: unknown): payload is CommentPayload {
+  return (
+    commentPayloadActions.includes((payload as CommentPayload).action) &&
+    isWithLightIssueType(payload) &&
+    isWithLightOrganizationType(payload) &&
+    isWithLightRepositoryType(payload)
+  );
+}
+
+export const pullRequestPayloadActions = ["opened", "edited"] as const;
+
+export type PullRequestPayload = {
+  action: (typeof pullRequestPayloadActions)[number];
+  pull_request: { id: number; number: number };
+} & WithLightOrganizationType &
+  WithLightRepositoryType;
+
+export function isPullRequestPayload(
+  payload: unknown
+): payload is PullRequestPayload {
+  return (
+    pullRequestPayloadActions.includes(
+      (payload as PullRequestPayload).action
+    ) &&
+    !!(payload as PullRequestPayload).pull_request &&
+    typeof (payload as PullRequestPayload).pull_request.id === "number" &&
+    typeof (payload as PullRequestPayload).pull_request.number === "number" &&
+    isWithLightOrganizationType(payload) &&
+    isWithLightRepositoryType(payload)
+  );
+}

--- a/connectors/src/connectors/github/temporal/activities.ts
+++ b/connectors/src/connectors/github/temporal/activities.ts
@@ -141,7 +141,7 @@ export async function githubUpsertIssueActivity(
 
   const existingIssueInDb = await GithubIssue.findOne({
     where: {
-      repoId,
+      repoId: repoId.toString(),
       issueNumber,
       connectorId: connector.id,
     },

--- a/connectors/src/connectors/github/temporal/activities.ts
+++ b/connectors/src/connectors/github/temporal/activities.ts
@@ -1,3 +1,5 @@
+import PQueue from "p-queue";
+
 import {
   getIssue,
   getIssueCommentsPage,
@@ -5,7 +7,10 @@ import {
   getReposPage,
   GithubUser,
 } from "@connectors/connectors/github/lib/github_api";
-import { upsertToDatasource } from "@connectors/lib/data_sources";
+import {
+  deleteFromDataSource,
+  upsertToDatasource,
+} from "@connectors/lib/data_sources";
 import { Connector, GithubIssue } from "@connectors/lib/models";
 import { syncStarted, syncSucceeded } from "@connectors/lib/sync_status";
 import mainLogger from "@connectors/logger/logger";
@@ -106,7 +111,7 @@ export async function githubUpsertIssueActivity(
     resultPage += 1;
   }
 
-  const documentId = `github-issue-${repoId}-${issueNumber}`;
+  const documentId = getIssueDocumentId(repoId.toString(), issueNumber);
   const issueAuthor = renderGithubUser(issue.creator);
   const tags = [`title:${issue.title}`];
   if (issueAuthor) {
@@ -193,6 +198,100 @@ export async function githubSaveSuccessSyncActivity(
   }
 }
 
+export async function githubIssueGarbageCollectActivity(
+  dataSourceConfig: DataSourceConfig,
+  installationId: string,
+  repoId: string,
+  issueNumber: number,
+  loggerArgs: Record<string, string | number>
+) {
+  await deleteIssue(
+    dataSourceConfig,
+    installationId,
+    repoId,
+    issueNumber,
+    loggerArgs
+  );
+}
+
+export async function githubRepoGarbageCollectActivity(
+  dataSourceConfig: DataSourceConfig,
+  installationId: string,
+  repoId: string,
+  loggerArgs: Record<string, string | number>
+) {
+  const connector = await Connector.findOne({
+    where: {
+      connectionId: installationId,
+    },
+  });
+
+  if (!connector) {
+    throw new Error("Connector not found");
+  }
+
+  const issuesInRepo = await GithubIssue.findAll({
+    where: {
+      repoId,
+      connectorId: connector.id,
+    },
+  });
+
+  const queue = new PQueue({ concurrency: 5 });
+  const promises = [];
+
+  for (const issue of issuesInRepo) {
+    promises.push(
+      queue.add(() =>
+        deleteIssue(
+          dataSourceConfig,
+          installationId,
+          repoId,
+          issue.issueNumber,
+          loggerArgs
+        )
+      )
+    );
+  }
+
+  await Promise.all(promises);
+}
+
+async function deleteIssue(
+  dataSourceConfig: DataSourceConfig,
+  installationId: string,
+  repoId: string,
+  issueNumber: number,
+  loggerArgs: Record<string, string | number>
+) {
+  const localLogger = logger.child(loggerArgs);
+
+  const connector = await Connector.findOne({
+    where: {
+      connectionId: installationId,
+    },
+  });
+
+  if (!connector) {
+    throw new Error("Connector not found");
+  }
+
+  localLogger.info("Deleting GitHub issue from Dust Data Source.");
+  await deleteFromDataSource(
+    dataSourceConfig,
+    getIssueDocumentId(repoId, issueNumber)
+  );
+
+  localLogger.info("Deleting GitHub issue from database.");
+  await GithubIssue.destroy({
+    where: {
+      repoId: repoId.toString(),
+      issueNumber,
+      connectorId: connector.id,
+    },
+  });
+}
+
 function renderGithubUser(user: GithubUser | null): string {
   if (!user) {
     return "";
@@ -201,4 +300,8 @@ function renderGithubUser(user: GithubUser | null): string {
     return `@${user.login}`;
   }
   return `@${user.id}`;
+}
+
+function getIssueDocumentId(repoId: string, issueNumber: number): string {
+  return `github-issue-${repoId}-${issueNumber}`;
 }

--- a/connectors/src/connectors/github/temporal/client.ts
+++ b/connectors/src/connectors/github/temporal/client.ts
@@ -96,7 +96,10 @@ export async function launchGithubReposSyncWorkflow(
 
   const workflow = await getGithubReposSyncWorkflow(connectorId);
 
-  // TODO: figure out how we want to handle more than webhook for repositories_added
+  // TODO: figure out how we want to handle more than one webhook for repositories_added
+  // If 2 come in too close from each other, we'll lose the info from the second one.
+  // If we remove the check entirely, we don't control the number of concurrent requests
+  // to the Github API (and wen coulkd hit the rate limit).
   if (workflow && workflow.executionDescription.status.name === "RUNNING") {
     logger.warn(
       {
@@ -159,6 +162,9 @@ export async function launchGithubIssueSyncWorkflow(
   const githubInstallationId = connector.connectionId;
 
   // TODO: figure out how we should handle concurrency limit here
+  // If many issues are updated at the same time, we could have a lot of
+  // concurrent workflows, which means a lot of concurrent requests to the
+  // Github API (and we could hit the rate limit).
   await client.workflow.start(githubIssueSyncWorkflow, {
     args: [
       dataSourceConfig,

--- a/connectors/src/connectors/github/temporal/client.ts
+++ b/connectors/src/connectors/github/temporal/client.ts
@@ -169,6 +169,6 @@ export async function launchGithubIssueSyncWorkflow(
       issueNumber,
     ],
     taskQueue: QUEUE_NAME,
-    workflowId: getIssueSyncWorkflowId(dataSourceConfig, issueNumber),
+    workflowId: getIssueSyncWorkflowId(dataSourceConfig, repoId, issueNumber),
   });
 }

--- a/connectors/src/connectors/github/temporal/client.ts
+++ b/connectors/src/connectors/github/temporal/client.ts
@@ -154,9 +154,7 @@ export async function launchGithubIssueGarbageCollectWorkflow(
     args: [
       dataSourceConfig,
       githubInstallationId,
-      repoName,
-      repoId,
-      repoLogin,
+      repoId.toString(),
       issueNumber,
     ],
     taskQueue: QUEUE_NAME,
@@ -181,7 +179,7 @@ export async function launchGithubRepoGarbageCollectWorkflow(
   const githubInstallationId = connector.connectionId;
 
   await client.workflow.start(githubRepoGarbageCollectWorkflow, {
-    args: [dataSourceConfig, githubInstallationId, repoName, repoId, repoLogin],
+    args: [dataSourceConfig, githubInstallationId, repoId.toString()],
     taskQueue: QUEUE_NAME,
     workflowId: getIssueSyncWorkflowId(dataSourceConfig, repoId, 0),
   });

--- a/connectors/src/connectors/github/temporal/client.ts
+++ b/connectors/src/connectors/github/temporal/client.ts
@@ -5,8 +5,16 @@ import {
 } from "@temporalio/client";
 
 import { QUEUE_NAME } from "@connectors/connectors/github/temporal/config";
-import { getFullSyncWorkflowId } from "@connectors/connectors/github/temporal/utils";
-import { githubFullSyncWorkflow } from "@connectors/connectors/github/temporal/workflows";
+import {
+  getFullSyncWorkflowId,
+  getIssueSyncWorkflowId,
+  getReposSyncWorkflowId,
+} from "@connectors/connectors/github/temporal/utils";
+import {
+  githubFullSyncWorkflow,
+  githubIssueSyncWorkflow,
+  githubReposSyncWorkflow,
+} from "@connectors/connectors/github/temporal/workflows";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { Connector } from "@connectors/lib/models";
 import { getTemporalClient } from "@connectors/lib/temporal";
@@ -70,4 +78,97 @@ export async function getGithubFullSyncWorkflow(connectorId: string): Promise<{
     }
     throw err;
   }
+}
+
+export async function launchGithubReposSyncWorkflow(
+  connectorId: string,
+  orgLogin: string,
+  repos: { name: string; id: number }[]
+) {
+  const client = await getTemporalClient();
+
+  const connector = await Connector.findByPk(connectorId);
+  if (!connector) {
+    throw new Error(`Connector not found. ConnectorId: ${connectorId}`);
+  }
+  const dataSourceConfig = dataSourceConfigFromConnector(connector);
+  const githubInstallationId = connector.connectionId;
+
+  const workflow = await getGithubReposSyncWorkflow(connectorId);
+
+  // TODO: figure out how we want to handle more than webhook for repositories_added
+  if (workflow && workflow.executionDescription.status.name === "RUNNING") {
+    logger.warn(
+      {
+        workspaceId: dataSourceConfig.workspaceId,
+      },
+      "launchGithubReposSyncWorkflow: Github repos sync workflow already running."
+    );
+    return;
+  }
+
+  await client.workflow.start(githubReposSyncWorkflow, {
+    args: [dataSourceConfig, githubInstallationId, orgLogin, repos],
+    taskQueue: QUEUE_NAME,
+    workflowId: getReposSyncWorkflowId(dataSourceConfig),
+  });
+}
+
+export async function getGithubReposSyncWorkflow(connectorId: string): Promise<{
+  executionDescription: WorkflowExecutionDescription;
+  handle: WorkflowHandle;
+} | null> {
+  const client = await getTemporalClient();
+
+  const connector = await Connector.findByPk(connectorId);
+  if (!connector) {
+    throw new Error(`Connector not found. ConnectorId: ${connectorId}`);
+  }
+  const dataSourceConfig = dataSourceConfigFromConnector(connector);
+
+  const handle: WorkflowHandle<typeof githubReposSyncWorkflow> =
+    client.workflow.getHandle(getReposSyncWorkflowId(dataSourceConfig));
+
+  try {
+    return {
+      executionDescription: await handle.describe(),
+      handle,
+    };
+  } catch (err) {
+    if (err instanceof WorkflowNotFoundError) {
+      return null;
+    }
+    throw err;
+  }
+}
+
+export async function launchGithubIssueSyncWorkflow(
+  connectorId: string,
+  repoLogin: string,
+  repoName: string,
+  repoId: number,
+  issueNumber: number
+) {
+  const client = await getTemporalClient();
+
+  const connector = await Connector.findByPk(connectorId);
+  if (!connector) {
+    throw new Error(`Connector not found. ConnectorId: ${connectorId}`);
+  }
+  const dataSourceConfig = dataSourceConfigFromConnector(connector);
+  const githubInstallationId = connector.connectionId;
+
+  // TODO: figure out how we should handle concurrency limit here
+  await client.workflow.start(githubIssueSyncWorkflow, {
+    args: [
+      dataSourceConfig,
+      githubInstallationId,
+      repoName,
+      repoId,
+      repoLogin,
+      issueNumber,
+    ],
+    taskQueue: QUEUE_NAME,
+    workflowId: getIssueSyncWorkflowId(dataSourceConfig, issueNumber),
+  });
 }

--- a/connectors/src/connectors/github/temporal/utils.ts
+++ b/connectors/src/connectors/github/temporal/utils.ts
@@ -3,3 +3,14 @@ import { DataSourceInfo } from "@connectors/types/data_source_config";
 export function getFullSyncWorkflowId(dataSourceInfo: DataSourceInfo) {
   return `workflow-github-full-sync-${dataSourceInfo.workspaceId}-${dataSourceInfo.dataSourceName}`;
 }
+
+export function getReposSyncWorkflowId(dataSourceInfo: DataSourceInfo) {
+  return `workflow-github-repos-sync-${dataSourceInfo.workspaceId}-${dataSourceInfo.dataSourceName}`;
+}
+
+export function getIssueSyncWorkflowId(
+  dataSourceInfo: DataSourceInfo,
+  issueNumber: number
+) {
+  return `workflow-github-issue-sync-${dataSourceInfo.workspaceId}-${dataSourceInfo.dataSourceName}-${issueNumber}`;
+}

--- a/connectors/src/connectors/github/temporal/utils.ts
+++ b/connectors/src/connectors/github/temporal/utils.ts
@@ -10,7 +10,8 @@ export function getReposSyncWorkflowId(dataSourceInfo: DataSourceInfo) {
 
 export function getIssueSyncWorkflowId(
   dataSourceInfo: DataSourceInfo,
+  repoId: number,
   issueNumber: number
 ) {
-  return `workflow-github-issue-sync-${dataSourceInfo.workspaceId}-${dataSourceInfo.dataSourceName}-${issueNumber}`;
+  return `workflow-github-issue-sync-${dataSourceInfo.workspaceId}-${dataSourceInfo.dataSourceName}-${repoId}-${issueNumber}`;
 }

--- a/connectors/src/connectors/github/temporal/utils.ts
+++ b/connectors/src/connectors/github/temporal/utils.ts
@@ -15,3 +15,18 @@ export function getIssueSyncWorkflowId(
 ) {
   return `workflow-github-issue-sync-${dataSourceInfo.workspaceId}-${dataSourceInfo.dataSourceName}-${repoId}-${issueNumber}`;
 }
+
+export function getIssueGarbageCollectWorkflowId(
+  dataSourceInfo: DataSourceInfo,
+  repoId: number,
+  issueNumber: number
+) {
+  return `workflow-github-issue-garbage-collect-${dataSourceInfo.workspaceId}-${dataSourceInfo.dataSourceName}-${repoId}-${issueNumber}`;
+}
+
+export function getRepoGarbageCollectWorkflowId(
+  dataSourceInfo: DataSourceInfo,
+  repoId: number
+) {
+  return `workflow-github-repo-garbage-collect-${dataSourceInfo.workspaceId}-${dataSourceInfo.dataSourceName}-${repoId}`;
+}

--- a/connectors/src/connectors/github/temporal/workflows.ts
+++ b/connectors/src/connectors/github/temporal/workflows.ts
@@ -120,6 +120,7 @@ export async function githubReposSyncWorkflow(
   }
 
   await Promise.all(promises);
+  await githubSaveSuccessSyncActivity(dataSourceConfig);
 }
 
 export async function githubRepoSyncWorkflow(
@@ -201,6 +202,7 @@ export async function githubIssueSyncWorkflow(
     dataSourceConfig,
     loggerArgs
   );
+  await githubSaveSuccessSyncActivity(dataSourceConfig);
 }
 
 export async function githubIssueGarbageCollectWorkflow(
@@ -223,6 +225,7 @@ export async function githubIssueGarbageCollectWorkflow(
     issueNumber,
     loggerArgs
   );
+  await githubSaveSuccessSyncActivity(dataSourceConfig);
 }
 
 export async function githubRepoGarbageCollectWorkflow(
@@ -242,4 +245,5 @@ export async function githubRepoGarbageCollectWorkflow(
     repoId,
     loggerArgs
   );
+  await githubSaveSuccessSyncActivity(dataSourceConfig);
 }

--- a/connectors/src/connectors/github/temporal/workflows.ts
+++ b/connectors/src/connectors/github/temporal/workflows.ts
@@ -8,7 +8,7 @@ import PQueue from "p-queue";
 import type * as activities from "@connectors/connectors/github/temporal/activities";
 import { DataSourceConfig } from "@connectors/types/data_source_config";
 
-import { getFullSyncWorkflowId } from "./utils";
+import { getFullSyncWorkflowId, getReposSyncWorkflowId } from "./utils";
 
 const { githubSaveStartSyncActivity, githubSaveSuccessSyncActivity } =
   proxyActivities<typeof activities>({
@@ -59,7 +59,7 @@ export async function githubFullSyncWorkflow(
 
     for (const repo of resultsPage) {
       const fullSyncWorkflowId = getFullSyncWorkflowId(dataSourceConfig);
-      const childWorkflowId = `${fullSyncWorkflowId}-repo-${repo.name}`;
+      const childWorkflowId = `${fullSyncWorkflowId}-repo-${repo.id}`;
       promises.push(
         queue.add(() =>
           executeChild(githubRepoSyncWorkflow.name, {
@@ -81,6 +81,38 @@ export async function githubFullSyncWorkflow(
   await Promise.all(promises);
 
   await githubSaveSuccessSyncActivity(dataSourceConfig);
+}
+
+export async function githubReposSyncWorkflow(
+  dataSourceConfig: DataSourceConfig,
+  githubInstallationId: string,
+  orgLogin: string,
+  repos: { name: string; id: number }[]
+) {
+  const queue = new PQueue({ concurrency: MAX_CONCURRENT_REPO_SYNC_WORKFLOWS });
+  const promises: Promise<void>[] = [];
+
+  for (const repo of repos) {
+    const reposSyncWorkflowId = getReposSyncWorkflowId(dataSourceConfig);
+    const childWorkflowId = `${reposSyncWorkflowId}-repo-${repo.id}`;
+    promises.push(
+      queue.add(() =>
+        executeChild(githubRepoSyncWorkflow.name, {
+          workflowId: childWorkflowId,
+          args: [
+            dataSourceConfig,
+            githubInstallationId,
+            repo.name,
+            repo.id,
+            orgLogin,
+          ],
+          parentClosePolicy: ParentClosePolicy.PARENT_CLOSE_POLICY_TERMINATE,
+        })
+      )
+    );
+  }
+
+  await Promise.all(promises);
 }
 
 export async function githubRepoSyncWorkflow(
@@ -134,4 +166,32 @@ export async function githubRepoSyncWorkflow(
   }
 
   await Promise.all(promises);
+}
+
+export async function githubIssueSyncWorkflow(
+  dataSourceConfig: DataSourceConfig,
+  githubInstallationId: string,
+  repoName: string,
+  repoId: number,
+  repoLogin: string,
+  issueNumber: number
+) {
+  const loggerArgs = {
+    dataSourceName: dataSourceConfig.dataSourceName,
+    workspaceId: dataSourceConfig.workspaceId,
+    githubInstallationId,
+    repoName,
+    repoLogin,
+    issueNumber,
+  };
+
+  await githubUpsertIssueActivity(
+    githubInstallationId,
+    repoName,
+    repoId,
+    repoLogin,
+    issueNumber,
+    dataSourceConfig,
+    loggerArgs
+  );
 }

--- a/connectors/src/connectors/github/temporal/workflows.ts
+++ b/connectors/src/connectors/github/temporal/workflows.ts
@@ -195,3 +195,41 @@ export async function githubIssueSyncWorkflow(
     loggerArgs
   );
 }
+
+export async function githubIssueGarbageCollectWorkflow(
+  dataSourceConfig: DataSourceConfig,
+  githubInstallationId: string,
+  repoName: string,
+  repoId: number,
+  repoLogin: string,
+  issueNumber: number
+) {
+  const loggerArgs = {
+    dataSourceName: dataSourceConfig.dataSourceName,
+    workspaceId: dataSourceConfig.workspaceId,
+    githubInstallationId,
+    repoName,
+    repoLogin,
+    issueNumber,
+  };
+
+  // TODO: Implement
+}
+
+export async function githubRepoGarbageCollectWorkflow(
+  dataSourceConfig: DataSourceConfig,
+  githubInstallationId: string,
+  repoName: string,
+  repoId: number,
+  repoLogin: string
+) {
+  const loggerArgs = {
+    dataSourceName: dataSourceConfig.dataSourceName,
+    workspaceId: dataSourceConfig.workspaceId,
+    githubInstallationId,
+    repoName,
+    repoLogin,
+  };
+
+  // todo: implement
+}

--- a/connectors/src/connectors/github/temporal/workflows.ts
+++ b/connectors/src/connectors/github/temporal/workflows.ts
@@ -18,9 +18,16 @@ const { githubSaveStartSyncActivity, githubSaveSuccessSyncActivity } =
 const {
   githubGetReposResultPageActivity,
   githubGetRepoIssuesResultPageActivity,
+  githubIssueGarbageCollectActivity,
 } = proxyActivities<typeof activities>({
   startToCloseTimeout: "5 minute",
 });
+
+const { githubRepoGarbageCollectActivity } = proxyActivities<typeof activities>(
+  {
+    startToCloseTimeout: "20 minute",
+  }
+);
 
 const { githubUpsertIssueActivity } = proxyActivities<typeof activities>({
   startToCloseTimeout: "60 minute",
@@ -199,37 +206,40 @@ export async function githubIssueSyncWorkflow(
 export async function githubIssueGarbageCollectWorkflow(
   dataSourceConfig: DataSourceConfig,
   githubInstallationId: string,
-  repoName: string,
-  repoId: number,
-  repoLogin: string,
+  repoId: string,
   issueNumber: number
 ) {
   const loggerArgs = {
     dataSourceName: dataSourceConfig.dataSourceName,
     workspaceId: dataSourceConfig.workspaceId,
     githubInstallationId,
-    repoName,
-    repoLogin,
     issueNumber,
   };
 
-  // TODO: Implement
+  await githubIssueGarbageCollectActivity(
+    dataSourceConfig,
+    githubInstallationId,
+    repoId,
+    issueNumber,
+    loggerArgs
+  );
 }
 
 export async function githubRepoGarbageCollectWorkflow(
   dataSourceConfig: DataSourceConfig,
   githubInstallationId: string,
-  repoName: string,
-  repoId: number,
-  repoLogin: string
+  repoId: string
 ) {
   const loggerArgs = {
     dataSourceName: dataSourceConfig.dataSourceName,
     workspaceId: dataSourceConfig.workspaceId,
     githubInstallationId,
-    repoName,
-    repoLogin,
   };
 
-  // todo: implement
+  await githubRepoGarbageCollectActivity(
+    dataSourceConfig,
+    githubInstallationId,
+    repoId,
+    loggerArgs
+  );
 }

--- a/connectors/src/connectors/index.ts
+++ b/connectors/src/connectors/index.ts
@@ -1,6 +1,11 @@
 import { Transaction } from "sequelize";
 
-import { createGithubConnector } from "@connectors/connectors/github";
+import {
+  createGithubConnector,
+  fullResyncGithubConnector,
+  resumeGithubConnector,
+  stopGithubConnector,
+} from "@connectors/connectors/github";
 import {
   cleanupNotionConnector,
   createNotionConnector,
@@ -42,12 +47,7 @@ export const STOP_CONNECTOR_BY_TYPE: Record<
     );
     return new Ok(connectorId);
   },
-  github: async (connectorId: string) => {
-    logger.info(
-      `Stopping Github connector is a no-op. ConnectorId: ${connectorId}`
-    );
-    return new Ok(connectorId);
-  },
+  github: stopGithubConnector,
   notion: stopNotionConnector,
 };
 
@@ -64,10 +64,9 @@ export const CLEAN_CONNECTOR_BY_TYPE: Record<
   slack: cleanupSlackConnector,
   notion: cleanupNotionConnector,
   github: async (connectorId: string) => {
-    logger.info(
-      `Cleaning up Github connector is a no-op. ConnectorId: ${connectorId}`
+    throw new Error(
+      "not implemented: github connector cleanup. ConnectorId: " + connectorId
     );
-    return new Ok(undefined);
   },
 };
 
@@ -84,12 +83,7 @@ export const RESUME_CONNECTOR_BY_TYPE: Record<
     return new Ok(connectorId);
   },
   notion: resumeNotionConnector,
-  github: async (connectorId: string) => {
-    logger.info(
-      `Resuming Github connector is a no-op. ConnectorId: ${connectorId}`
-    );
-    return new Ok(connectorId);
-  },
+  github: resumeGithubConnector,
 };
 
 type SyncConnector = (connectorId: string) => Promise<Result<string, Error>>;
@@ -98,10 +92,5 @@ export const SYNC_CONNECTOR_BY_TYPE: Record<ConnectorProvider, SyncConnector> =
   {
     slack: launchSlackSyncWorkflow,
     notion: fullResyncNotionConnector,
-    github: async (connectorId: string) => {
-      logger.info(
-        `Syncing Github connector is a no-op. ConnectorId: ${connectorId}`
-      );
-      return new Ok(connectorId);
-    },
+    github: fullResyncGithubConnector,
   };

--- a/connectors/src/connectors/index.ts
+++ b/connectors/src/connectors/index.ts
@@ -1,6 +1,7 @@
 import { Transaction } from "sequelize";
 
 import {
+  cleanupGithubConnector,
   createGithubConnector,
   fullResyncGithubConnector,
   resumeGithubConnector,
@@ -63,11 +64,7 @@ export const CLEAN_CONNECTOR_BY_TYPE: Record<
 > = {
   slack: cleanupSlackConnector,
   notion: cleanupNotionConnector,
-  github: async (connectorId: string) => {
-    throw new Error(
-      "not implemented: github connector cleanup. ConnectorId: " + connectorId
-    );
-  },
+  github: cleanupGithubConnector,
 };
 
 type ConnectorResumer = (connectorId: string) => Promise<Result<string, Error>>;

--- a/connectors/src/lib/assert_never.ts
+++ b/connectors/src/lib/assert_never.ts
@@ -1,0 +1,5 @@
+import logger from "@connectors/logger/logger";
+
+export function assertNever(x: never): void {
+  logger.warn({ x: x }, "should never happen");
+}

--- a/connectors/src/lib/models.ts
+++ b/connectors/src/lib/models.ts
@@ -332,7 +332,7 @@ export class GithubConnectorState extends Model<
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
-  declare webhooksEnabledAt?: Date;
+  declare webhooksEnabledAt?: Date | null;
 
   declare connectorId: ForeignKey<Connector["id"]>;
 }

--- a/connectors/src/lib/models.ts
+++ b/connectors/src/lib/models.ts
@@ -323,3 +323,99 @@ NotionPage.init(
   }
 );
 Connector.hasMany(NotionPage);
+
+export class GithubConnectorState extends Model<
+  InferAttributes<GithubConnectorState>,
+  InferCreationAttributes<GithubConnectorState>
+> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare webhooksEnabledAt?: Date;
+
+  declare connectorId: ForeignKey<Connector["id"]>;
+}
+
+GithubConnectorState.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    webhooksEnabledAt: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    },
+  },
+  {
+    sequelize: sequelize_conn,
+    modelName: "github_connector_states",
+    indexes: [{ fields: ["connectorId"], unique: true }],
+  }
+);
+
+Connector.hasOne(GithubConnectorState);
+
+export class GithubIssue extends Model<
+  InferAttributes<GithubIssue>,
+  InferCreationAttributes<GithubIssue>
+> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare repoId: string;
+  declare issueNumber: number;
+
+  declare connectorId: ForeignKey<Connector["id"]>;
+}
+
+GithubIssue.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    repoId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    issueNumber: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+  },
+  {
+    sequelize: sequelize_conn,
+    indexes: [
+      { fields: ["repoId", "issueNumber", "connectorId"], unique: true },
+      { fields: ["connectorId"] },
+      { fields: ["repoId"] },
+    ],
+    modelName: "github_issues",
+  }
+);
+Connector.hasMany(GithubIssue);

--- a/front/pages/w/[wId]/ds/index.tsx
+++ b/front/pages/w/[wId]/ds/index.tsx
@@ -58,7 +58,7 @@ const DATA_SOURCE_INTEGRATIONS: DataSourceIntegration[] = [
   {
     name: "Github",
     connectorProvider: "github",
-    isBuilt: false,
+    isBuilt: true,
     logoPath: "/static/github_black_32x32.png",
     fetchConnectorError: null,
   },


### PR DESCRIPTION
Adds:
- support for incremental syncs of issues (and PRs in "issues" mode) of GH connector (via webhooks)
- support for garbage collection of issues (and PRs in "issues" mode) of GH connector (via webhooks)
- support for stop/resume/full-resync/delete

Not done in this PR:
- "full garbage collect" -> if you stop the connector and resume it in the future, it will sync all the missing data, but it won't garbage collect what has been deleted while stopped
- PR reviews and code  -> will be done in the future using AI-generated code summaries and by integrating the PR review comments
- Github discussions -> it's an entirely different API (graphQL) that I did not yet look into
- initial sync progress report

There are probably a couple of minor improvements to make, such as better tags, maybe a different rendering of the body of issues etc.. but it will be easier to discuss once this is up and running in prod