### PR TITLE
chore: add connectionId and deprecate nangoConnectionId

### DIFF
--- a/connectors/migrations/20230606_deprecate_nango_connection_id.ts
+++ b/connectors/migrations/20230606_deprecate_nango_connection_id.ts
@@ -1,0 +1,28 @@
+import { Op } from "sequelize";
+
+import { Connector, sequelize_conn } from "@connectors/lib/models";
+
+async function main() {
+  await Connector.update(
+    {
+      connectionId: sequelize_conn.col("nangoConnectionId"),
+    },
+    {
+      where: {
+        connectionId: {
+          [Op.eq]: null,
+        },
+      },
+    }
+  );
+}
+
+main()
+  .then(() => {
+    console.log("Done");
+    process.exit(0);
+  })
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });

--- a/connectors/src/api/create_connector.ts
+++ b/connectors/src/api/create_connector.ts
@@ -13,7 +13,9 @@ type ConnectorCreateReqBody = {
   workspaceAPIKey: string;
   dataSourceName: string;
   workspaceId: string;
+  // TODO: deprecate_nango_connection_id_2023-06-06
   nangoConnectionId: string;
+  connectionId?: string;
 };
 
 type ConnectorCreateResBody = ConnectorType | ConnectorsAPIErrorResponse;
@@ -31,13 +33,14 @@ const _createConnectorAPIHandler = async (
       !req.body.workspaceAPIKey ||
       !req.body.dataSourceName ||
       !req.body.workspaceId ||
-      !req.body.nangoConnectionId
+      // TODO: deprecate_nango_connection_id_2023-06-06
+      !(req.body.connectionId || req.body.nangoConnectionId)
     ) {
       return apiError(req, res, {
         api_error: {
           type: "invalid_request_error",
           message: `Missing required parameters. Required : workspaceAPIKey,
-           dataSourceName, workspaceId, nangoConnectionId`,
+           dataSourceName, workspaceId, connectionId`,
         },
         status_code: 400,
       });
@@ -61,7 +64,8 @@ const _createConnectorAPIHandler = async (
         dataSourceName: req.body.dataSourceName,
         workspaceId: req.body.workspaceId,
       },
-      req.body.nangoConnectionId
+      // TODO: deprecate_nango_connection_id_2023-06-06
+      req.body.connectionId || req.body.nangoConnectionId
     );
 
     if (connectorRes.isErr()) {

--- a/connectors/src/api/webhooks/webhook_slack.ts
+++ b/connectors/src/api/webhooks/webhook_slack.ts
@@ -129,7 +129,8 @@ const _webhookSlackAPIHandler = async (
         });
       }
       const slackAccessToken = await getAccessToken(
-        connector.nangoConnectionId
+        // TODO: deprecate_nango_connection_id_2023-06-06
+        connector.connectionId || connector.nangoConnectionId
       );
       const myUserId = await whoAmI(slackAccessToken);
       if (myUserId !== req.body.event.user) {

--- a/connectors/src/connectors/index.ts
+++ b/connectors/src/connectors/index.ts
@@ -17,7 +17,7 @@ import { DataSourceConfig } from "@connectors/types/data_source_config";
 
 type ConnectorCreator = (
   dataSourceConfig: DataSourceConfig,
-  nangoConnectionId: string
+  connectionId: string
 ) => Promise<Result<string, Error>>;
 
 export const CREATE_CONNECTOR_BY_TYPE: Record<

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -16,14 +16,17 @@ import { nango_client } from "@connectors/lib/nango_client";
 import { Err, Ok, Result } from "@connectors/lib/result";
 import mainLogger from "@connectors/logger/logger";
 import { DataSourceConfig } from "@connectors/types/data_source_config";
+import { NangoConnectionId } from "@connectors/types/nango_connection_id";
 
 const { NANGO_NOTION_CONNECTOR_ID } = process.env;
 const logger = mainLogger.child({ provider: "notion" });
 
 export async function createNotionConnector(
   dataSourceConfig: DataSourceConfig,
-  nangoConnectionId: string
+  connectionId: NangoConnectionId
 ): Promise<Result<string, Error>> {
+  const nangoConnectionId = connectionId;
+
   if (!NANGO_NOTION_CONNECTOR_ID) {
     throw new Error("NANGO_NOTION_CONNECTOR_ID not set");
   }
@@ -43,6 +46,7 @@ export async function createNotionConnector(
       {
         type: "notion",
         nangoConnectionId,
+        connectionId: nangoConnectionId,
         workspaceAPIKey: dataSourceConfig.workspaceAPIKey,
         workspaceId: dataSourceConfig.workspaceId,
         dataSourceName: dataSourceConfig.dataSourceName,

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -45,6 +45,7 @@ export async function createNotionConnector(
     const connector = await Connector.create(
       {
         type: "notion",
+        // TODO: deprecate_nango_connection_id_2023-06-06
         nangoConnectionId,
         connectionId: nangoConnectionId,
         workspaceAPIKey: dataSourceConfig.workspaceAPIKey,

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -398,7 +398,8 @@ export async function garbageCollectActivity(
     "Found pages to delete."
   );
   const notionAccessToken = await getNotionAccessToken(
-    connector.nangoConnectionId
+    // TODO: deprecate_nango_connection_id_2023-06-06
+    connector.connectionId || connector.nangoConnectionId
   );
   for (const page of pagesToDelete) {
     if (

--- a/connectors/src/connectors/notion/temporal/client.ts
+++ b/connectors/src/connectors/notion/temporal/client.ts
@@ -25,7 +25,10 @@ export async function launchNotionSyncWorkflow(
     throw new Error(`Connector not found. ConnectorId: ${connectorId}`);
   }
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
-  const nangoConnectionId = connector.nangoConnectionId;
+
+  // TODO: deprecate_nango_connection_id_2023-06-06
+  const nangoConnectionId =
+    connector.connectionId || connector.nangoConnectionId;
 
   const workflow = await getNotionWorkflow(dataSourceConfig);
 

--- a/connectors/src/connectors/slack/temporal/client.ts
+++ b/connectors/src/connectors/slack/temporal/client.ts
@@ -34,7 +34,9 @@ export async function launchSlackSyncWorkflow(connectorId: string) {
     workspaceId: connector.workspaceId,
     dataSourceName: connector.dataSourceName,
   };
-  const nangoConnectionId = connector.nangoConnectionId;
+  // TODO: deprecate_nango_connection_id_2023-06-06
+  const nangoConnectionId =
+    connector.connectionId || connector.nangoConnectionId;
 
   const workflowId = workspaceFullSyncWorkflowId(connectorId);
   try {
@@ -79,7 +81,9 @@ export async function launchSlackSyncOneThreadWorkflow(
     workspaceId: connector.workspaceId,
     dataSourceName: connector.dataSourceName,
   };
-  const nangoConnectionId = connector.nangoConnectionId;
+  // TODO: deprecate_nango_connection_id_2023-06-06
+  const nangoConnectionId =
+    connector.connectionId || connector.nangoConnectionId;
 
   const workflowId = syncOneThreadDebouncedWorkflowId(
     connectorId,
@@ -126,7 +130,9 @@ export async function launchSlackSyncOneMessageWorkflow(
     workspaceId: connector.workspaceId,
     dataSourceName: connector.dataSourceName,
   };
-  const nangoConnectionId = connector.nangoConnectionId;
+  // TODO: deprecate_nango_connection_id_2023-06-06
+  const nangoConnectionId =
+    connector.connectionId || connector.nangoConnectionId;
 
   const messageTs = parseInt(threadTs as string) * 1000;
   const weekStartTsMs = getWeekStart(new Date(messageTs)).getTime();
@@ -174,7 +180,9 @@ export async function launchSlackBotJoinedWorkflow(
     workspaceId: connector.workspaceId,
     dataSourceName: connector.dataSourceName,
   };
-  const nangoConnectionId = connector.nangoConnectionId;
+  // TODO: deprecate_nango_connection_id_2023-06-06
+  const nangoConnectionId =
+    connector.connectionId || connector.nangoConnectionId;
 
   const workflowId = botJoinedChannelWorkflowId(connectorId);
   try {
@@ -215,7 +223,10 @@ export async function launchSlackGarbageCollectWorkflow(connectorId: string) {
 
   const dataSourceConfig: DataSourceConfig =
     dataSourceConfigFromConnector(connector);
-  const nangoConnectionId = connector.nangoConnectionId;
+
+  // TODO: deprecate_nango_connection_id_2023-06-06
+  const nangoConnectionId =
+    connector.connectionId || connector.nangoConnectionId;
 
   const workflowId = slackGarbageCollectorWorkflowId(connectorId);
   try {

--- a/connectors/src/lib/models.ts
+++ b/connectors/src/lib/models.ts
@@ -32,7 +32,9 @@ export class Connector extends Model<
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
   declare type: ConnectorProvider;
-  declare nangoConnectionId: string;
+
+  declare connectionId?: string;
+
   declare workspaceAPIKey: string;
   declare workspaceId: string;
   declare dataSourceName: string;
@@ -43,6 +45,9 @@ export class Connector extends Model<
   declare lastSyncSuccessfulTime?: Date;
   declare firstSuccessfulSyncTime?: Date;
   declare firstSyncProgress?: string;
+
+  // TODO: Deprecated
+  declare nangoConnectionId: string;
 }
 
 Connector.init(
@@ -66,9 +71,9 @@ Connector.init(
       type: DataTypes.STRING,
       allowNull: false,
     },
-    nangoConnectionId: {
+    connectionId: {
       type: DataTypes.STRING,
-      allowNull: false,
+      allowNull: true,
     },
     workspaceAPIKey: {
       type: DataTypes.STRING,
@@ -105,6 +110,12 @@ Connector.init(
     firstSyncProgress: {
       type: DataTypes.STRING,
       allowNull: true,
+    },
+
+    // TODO: deprecate_nango_connection_id_2023-06-06
+    nangoConnectionId: {
+      type: DataTypes.STRING,
+      allowNull: false,
     },
   },
   {

--- a/connectors/src/lib/models.ts
+++ b/connectors/src/lib/models.ts
@@ -33,7 +33,9 @@ export class Connector extends Model<
   declare updatedAt: CreationOptional<Date>;
   declare type: ConnectorProvider;
 
-  declare connectionId?: string;
+  // TODO: deprecate_nango_connection_id_2023-06-06
+  declare nangoConnectionId: string;
+  declare connectionId?: string | null;
 
   declare workspaceAPIKey: string;
   declare workspaceId: string;
@@ -45,9 +47,6 @@ export class Connector extends Model<
   declare lastSyncSuccessfulTime?: Date;
   declare firstSuccessfulSyncTime?: Date;
   declare firstSyncProgress?: string;
-
-  // TODO: Deprecated
-  declare nangoConnectionId: string;
 }
 
 Connector.init(
@@ -68,6 +67,11 @@ Connector.init(
       defaultValue: DataTypes.NOW,
     },
     type: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    // TODO: deprecate_nango_connection_id_2023-06-06
+    nangoConnectionId: {
       type: DataTypes.STRING,
       allowNull: false,
     },
@@ -110,12 +114,6 @@ Connector.init(
     firstSyncProgress: {
       type: DataTypes.STRING,
       allowNull: true,
-    },
-
-    // TODO: deprecate_nango_connection_id_2023-06-06
-    nangoConnectionId: {
-      type: DataTypes.STRING,
-      allowNull: false,
     },
   },
   {

--- a/connectors/src/types/nango_connection_id.ts
+++ b/connectors/src/types/nango_connection_id.ts
@@ -1,0 +1,1 @@
+export type NangoConnectionId = string;

--- a/front/lib/connectors_api.ts
+++ b/front/lib/connectors_api.ts
@@ -32,7 +32,7 @@ export const ConnectorsAPI = {
     workspaceId: string,
     workspaceAPIKey: string,
     dataSourceName: string,
-    nangoConnectionId: string
+    connectionId: string
   ): Promise<ConnectorsAPIResponse<ConnectorType>> {
     const res = await fetch(`${CONNECTORS_API}/connectors/create/${provider}`, {
       method: "POST",
@@ -41,7 +41,9 @@ export const ConnectorsAPI = {
         workspaceId,
         workspaceAPIKey,
         dataSourceName,
-        nangoConnectionId,
+        connectionId,
+        // TODO: deprecate_nango_connection_id_2023-06-06
+        nangoConnectionId: connectionId,
       }),
     });
 

--- a/front/lib/connectors_api.ts
+++ b/front/lib/connectors_api.ts
@@ -42,7 +42,7 @@ export const ConnectorsAPI = {
         workspaceAPIKey,
         dataSourceName,
         connectionId,
-        // TODO: deprecate_nango_connection_id_2023-06-06
+        // TODO: 20230606_deprecate_nango_connection_id
         nangoConnectionId: connectionId,
       }),
     });

--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -56,7 +56,7 @@ async function handler(
 
       if (
         !req.body ||
-        typeof req.body.nangoConnectionId !== "string" ||
+        typeof req.body.connectionId !== "string" ||
         !["slack", "notion"].includes(req.body.provider)
       ) {
         return apiError(req, res, {
@@ -64,7 +64,7 @@ async function handler(
           api_error: {
             type: "invalid_request_error",
             message:
-              "The request body is invalid, expects { nangoConnectionId: string, provider: string }.",
+              "The request body is invalid, expects { connectionId: string, provider: string }.",
           },
         });
       }
@@ -162,7 +162,7 @@ async function handler(
         owner.sId,
         systemAPIKeyRes.value.secret,
         dataSourceName,
-        req.body.nangoConnectionId
+        req.body.connectionId
       );
       if (connectorsRes.isErr()) {
         logger.error(

--- a/front/pages/w/[wId]/ds/index.tsx
+++ b/front/pages/w/[wId]/ds/index.tsx
@@ -204,7 +204,7 @@ export default function DataSourcesView({
 
     try {
       const {
-        connectionId: nangoConnectionId,
+        connectionId,
       }: { providerConfigKey: string; connectionId: string } = await nango.auth(
         nangoConnectorId,
         `${provider}-${owner.sId}`
@@ -219,7 +219,7 @@ export default function DataSourcesView({
         },
         body: JSON.stringify({
           provider,
-          nangoConnectionId,
+          connectionId,
         }),
       });
       if (res.ok) {


### PR DESCRIPTION
pre-PR before fully removing `nango_connection_id` in favour of `connection_id`

- run `initdb`
- deploy code (connectors and front, order independent)
- run the migration script in `connectors` (`env $(cat .env.local) npx tsx migrations/20230606_deprecate_nango_connection_id.ts`)