### PR TITLE
fix: use env var for GH app public URL in front

### DIFF
--- a/front/lib/github_auth.ts
+++ b/front/lib/github_auth.ts
@@ -1,6 +1,12 @@
 export async function githubAuth(): Promise<string> {
+  const { GITHUB_APP_URL = "" } = process.env;
+
+  if (!GITHUB_APP_URL.length) {
+    throw new Error("Missing GITHUB_APP_URL environment variable.");
+  }
+
   return new Promise((resolve, reject) => {
-    const ghPopup = window.open("https://github.com/apps/dust-test-app");
+    const ghPopup = window.open(GITHUB_APP_URL);
     let authComplete = false;
 
     const popupMessageEventListener = (event: MessageEvent) => {


### PR DESCRIPTION
Hard-coded test value that I forgot to replace