### PR TITLE
fix: dottie high vulnerability fix

### DIFF
--- a/connectors/package-lock.json
+++ b/connectors/package-lock.json
@@ -2815,9 +2815,9 @@
       }
     },
     "node_modules/dottie": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/dottie/-/dottie-2.0.3.tgz",
-      "integrity": "sha512-4liA0PuRkZWQFQjwBypdxPfZaRWiv5tkhMXY2hzsa2pNf5s7U3m9cwUchfNKe8wZQxdGPQQzO6Rm2uGe0rvohQ=="
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/dottie/-/dottie-2.0.6.tgz",
+      "integrity": "sha512-iGCHkfUc5kFekGiqhe8B/mdaurD+lakO9txNnTvKtA6PISrw86LgqHvRzWYPyoE2Ph5aMIrCw9/uko6XHTKCwA=="
     },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",


### PR DESCRIPTION
`dottie` introduced by recent addition of libraries had a vulnerable version pinned in the `package-lock.json`

`npm audit fix` fixed it.

Let's not ignore the vulnerability alerts on `npm install`