### PR TITLE
Add support for "validation_error" at the page level

### DIFF
--- a/connectors/src/connectors/notion/lib/notion_api.ts
+++ b/connectors/src/connectors/notion/lib/notion_api.ts
@@ -301,10 +301,18 @@ export async function getParsedPage(
   } catch (e) {
     if (
       APIResponseError.isAPIResponseError(e) &&
-      e.code === "object_not_found"
+      (e.code === "object_not_found" || e.code === "validation_error")
     ) {
       blocks = [];
-      pageLogger.info("Couldn't get page blocks.");
+      pageLogger.info(
+        {
+          notion_error: {
+            code: e.code,
+            message: e.message,
+          },
+        },
+        "Couldn't get page blocks."
+      );
     } else {
       throw e;
     }


### PR DESCRIPTION
Fixes the following unhandled activity errors:
https://app.datadoghq.eu/logs?query=%22Unhandled%20Activity%20Error%22%20&cols=host%2Cservice&event=AgAAAYi5jkgSkLAEJAAAAAAAAAAYAAAAAEFZaTVqa3Q4QUFEbno4eTVvcGFwNkFBSAAAACQAAAAAMDE4OGI5OGUtNjc1My00YzBlLWI0ODAtNzliMWE5ZGRhMTc2&index=%2A&messageDisplay=inline&stream_sort=desc&viz=stream&from_ts=1686738667085&to_ts=1686739567085&live=true

I pulled the notion pages by searching for this string: "Fetching page from Notion API." and filtering on the same workspaceId

https://app.datadoghq.eu/logs?query=service%3Aconnectors-worker%20%22Fetching%20page%20from%20Notion%20API.%22%20%40workspaceId%3A2ddbc0204d&cols=host%2Cservice&event=AgAAAYi5gWdFiTY0EAAAAAAAAAAYAAAAAEFZaTVnWFRnQUFEaWZXZHgwWVh4MWdBQgAAACQAAAAAMDE4OGI5ODEtODg1Ny00ZmU4LWI3NWEtNzViYmE2YTEzOGE2&index=%2A&messageDisplay=inline&stream_sort=desc&viz=stream&from_ts=1686738639172&to_ts=1686739539172&live=true

From there I extracted the failing pageIds

I also pulled the Notion access token for this workspace and then followed the runbook to execute locally the retrieval of the page: https://www.notion.so/dust-tt/Runbook-Notion-connector-b3b082e3f8a94ad9b4d42dfa89748582?pvs=4

Notion returns an error when listing the blocks children given the pageId. Adding support for validation_errors and returning an empty list of blocks (see https://github.com/dust-tt/dust/blob/main/connectors/src/connectors/notion/lib/notion_api.ts#L304)

We still get the description of the page as part of the final rendering which still contains useful information
