### PR TITLE
Fix validation_error in Notion user retrieval

### DIFF
--- a/connectors/src/connectors/notion/lib/notion_api.ts
+++ b/connectors/src/connectors/notion/lib/notion_api.ts
@@ -523,7 +523,7 @@ async function getUserName(
   } catch (e) {
     if (
       APIResponseError.isAPIResponseError(e) &&
-      e.code === "object_not_found"
+      (e.code === "object_not_found" || e.code === "validation_error")
     ) {
       pageLogger.info({ user_id: userId }, "Couln't find user.");
       return null;


### PR DESCRIPTION
Started from: https://app.datadoghq.eu/logs?query=%22Unhandled%20Activity%20Error%22%20&cols=host%2Cservice&index=%2A&messageDisplay=inline&stream_sort=desc&viz=stream&from_ts=1686746353167&to_ts=1686749953167&live=true

Struggled a bit to find the page in question. Had to zoom in on one of these errors and remove the filter to look at messages coming right before.

Eventually found it but we should probably as a remediation add an easy wait to find the pageId (probably have the activity Id or workflow Id shown in the notion_api.ts logs) ?

Then reproduced locally according to runbook