### PR TITLE
feat: implement debouncing for github issue sync workflows

### DIFF
--- a/connectors/src/connectors/github/temporal/client.ts
+++ b/connectors/src/connectors/github/temporal/client.ts
@@ -5,6 +5,7 @@ import {
 } from "@temporalio/client";
 
 import { QUEUE_NAME } from "@connectors/connectors/github/temporal/config";
+import { newWebhookSignal } from "@connectors/connectors/github/temporal/signals";
 import {
   getFullSyncWorkflowId,
   getIssueSyncWorkflowId,
@@ -119,7 +120,13 @@ export async function launchGithubIssueSyncWorkflow(
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
   const githubInstallationId = connector.connectionId;
 
-  await client.workflow.start(githubIssueSyncWorkflow, {
+  const workflowId = getIssueSyncWorkflowId(
+    dataSourceConfig,
+    repoId,
+    issueNumber
+  );
+
+  await client.workflow.signalWithStart(githubIssueSyncWorkflow, {
     args: [
       dataSourceConfig,
       githubInstallationId,
@@ -129,7 +136,9 @@ export async function launchGithubIssueSyncWorkflow(
       issueNumber,
     ],
     taskQueue: QUEUE_NAME,
-    workflowId: getIssueSyncWorkflowId(dataSourceConfig, repoId, issueNumber),
+    workflowId,
+    signal: newWebhookSignal,
+    signalArgs: undefined,
   });
 }
 

--- a/connectors/src/connectors/github/temporal/signals.ts
+++ b/connectors/src/connectors/github/temporal/signals.ts
@@ -1,0 +1,3 @@
+import { defineSignal } from "@temporalio/workflow";
+
+export const newWebhookSignal = defineSignal<[void]>("new_webhook_signal");


### PR DESCRIPTION
Same as we do on Slack and Drive connectors. When receiving a webhook to update an issue, we signal the existing workflow (if any) to continue looping instead of exiting