### PR TITLE
fix: don't set max-old-space-size for edge deployments

### DIFF
--- a/k8s/deployments/connectors-edge-deployment.yaml
+++ b/k8s/deployments/connectors-edge-deployment.yaml
@@ -31,6 +31,11 @@ spec:
 
           # override env vars from configmap/secret
           env:
+            # we don't want to set --max-old-space-size for edge as pods
+            # don't have the same memory limits as the regular connectors pods
+            - name: NODE_OPTIONS
+              value: "-r dd-trace/init"
+
             - name: FRONT_API
               value: http://front-edge-service
 

--- a/k8s/deployments/front-edge-deployment.yaml
+++ b/k8s/deployments/front-edge-deployment.yaml
@@ -30,6 +30,11 @@ spec:
 
           # override env vars from configmap/secret
           env:
+            # we don't want to set --max-old-space-size for edge as pods
+            # don't have the same memory limits as the regular front pods
+            - name: NODE_OPTIONS
+              value: "-r dd-trace/init"
+
             - name: CONNECTORS_API
               value: http://connectors-edge-service
             - name: NEXTAUTH_URL


### PR DESCRIPTION
`front-edge` and `connectors-edge` share their respective configmaps with their non-edge counterparts. We define `NODE_OPTIONS` in those configmaps, and `NODE_OPTIONS` includes our setting for V8's `max-old-space-size` option, which has to be set to ~80% of the pod's allocated memory. However, this value is way too large for the edge deployment pods. For some reason, this hasn't been a problem for `front-edge` (but `connectors-edge` was in Crashloop Backoff) 