### PR TITLE
enh: rollout-restart deployment if set image is no-op

### DIFF
--- a/.github/workflows/deploy-blog.yml
+++ b/.github/workflows/deploy-blog.yml
@@ -41,8 +41,8 @@ jobs:
 
       - name: Deploy the image on Kubernetes
         run: |
-          kubectl set image deployment/blog-deployment web=gcr.io/$GCLOUD_PROJECT_ID/blog-image:${{ steps.short_sha.outputs.short_sha }}
-          echo "Updated blog image to: gcr.io/$GCLOUD_PROJECT_ID/blog-image:${{ steps.short_sha.outputs.short_sha }}"
+          chmod +x ./k8s/deploy-image.sh
+          ./deploy-image gcr.io/$GCLOUD_PROJECT_ID/blog-image:${{ steps.short_sha.outputs.short_sha }} blog-deployment
 
       - name: Wait for rollout to complete
         run: kubectl rollout status deployment/blog-deployment --timeout=10m

--- a/.github/workflows/deploy-connectors-edge.yml
+++ b/.github/workflows/deploy-connectors-edge.yml
@@ -41,8 +41,8 @@ jobs:
 
       - name: Deploy the image on Kubernetes
         run: |
-          kubectl set image deployment/connectors-edge-deployment web=gcr.io/$GCLOUD_PROJECT_ID/connectors-image:${{ steps.short_sha.outputs.short_sha }}
-          echo "Updated connectors image to: gcr.io/$GCLOUD_PROJECT_ID/connectors-image:${{ steps.short_sha.outputs.short_sha }}"
+          chmod +x ./k8s/deploy-image.sh
+          ./deploy-image gcr.io/$GCLOUD_PROJECT_ID/connectors-image:${{ steps.short_sha.outputs.short_sha }} connectors-edge-deployment
 
       - name: Wait for rollout to complete
         run: kubectl rollout status deployment/connectors-edge-deployment --timeout=10m

--- a/.github/workflows/deploy-connectors.yml
+++ b/.github/workflows/deploy-connectors.yml
@@ -41,10 +41,10 @@ jobs:
 
       - name: Deploy the image on Kubernetes
         run: |
-          kubectl set image deployment/connectors-deployment web=gcr.io/$GCLOUD_PROJECT_ID/connectors-image:${{ steps.short_sha.outputs.short_sha }}
-          echo "Updated connectors image to: gcr.io/$GCLOUD_PROJECT_ID/connectors-image:${{ steps.short_sha.outputs.short_sha }}"
-          kubectl set image deployment/connectors-worker-deployment web=gcr.io/$GCLOUD_PROJECT_ID/connectors-image:${{ steps.short_sha.outputs.short_sha }}
-          echo "Updated connectors-worker image to: gcr.io/$GCLOUD_PROJECT_ID/connectors-image:${{ steps.short_sha.outputs.short_sha }}"
+          chmod +x ./k8s/deploy-image.sh
+
+          ./deploy-image gcr.io/$GCLOUD_PROJECT_ID/connectors-image:${{ steps.short_sha.outputs.short_sha }} connectors-deployment
+          ./deploy-image gcr.io/$GCLOUD_PROJECT_ID/connectors-image:${{ steps.short_sha.outputs.short_sha }} connectors-worker-deployment
 
       - name: Wait for rollout to complete
         run: |

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -41,8 +41,8 @@ jobs:
 
       - name: Deploy the image on Kubernetes
         run: |
-          kubectl set image deployment/docs-deployment web=gcr.io/$GCLOUD_PROJECT_ID/docs-image:${{ steps.short_sha.outputs.short_sha }}
-          echo "Updated docs image to: gcr.io/$GCLOUD_PROJECT_ID/docs-image:${{ steps.short_sha.outputs.short_sha }}"
+          chmod +x ./k8s/deploy-image.sh
+          ./deploy-image gcr.io/$GCLOUD_PROJECT_ID/docs-image:${{ steps.short_sha.outputs.short_sha }} docs-deployment
 
       - name: Wait for rollout to complete
         run: kubectl rollout status deployment/docs-deployment --timeout=10m

--- a/.github/workflows/deploy-front-edge.yml
+++ b/.github/workflows/deploy-front-edge.yml
@@ -41,8 +41,8 @@ jobs:
 
       - name: Deploy the image on Kubernetes
         run: |
-          kubectl set image deployment/front-edge-deployment web=gcr.io/$GCLOUD_PROJECT_ID/front-image:${{ steps.short_sha.outputs.short_sha }}
-          echo "Updated front image to: gcr.io/$GCLOUD_PROJECT_ID/front-image:${{ steps.short_sha.outputs.short_sha }}"
+          chmod +x ./k8s/deploy-image.sh
+          ./deploy-image gcr.io/$GCLOUD_PROJECT_ID/front-image:${{ steps.short_sha.outputs.short_sha }} front-edge-deployment
 
       - name: Wait for rollout to complete
         run: kubectl rollout status deployment/front-edge-deployment --timeout=10m

--- a/.github/workflows/deploy-front.yml
+++ b/.github/workflows/deploy-front.yml
@@ -41,8 +41,8 @@ jobs:
 
       - name: Deploy the image on Kubernetes
         run: |
-          kubectl set image deployment/front-deployment web=gcr.io/$GCLOUD_PROJECT_ID/front-image:${{ steps.short_sha.outputs.short_sha }}
-          echo "Updated front image to: gcr.io/$GCLOUD_PROJECT_ID/front-image:${{ steps.short_sha.outputs.short_sha }}"
+          chmod +x ./k8s/deploy-image.sh
+          ./deploy-image gcr.io/$GCLOUD_PROJECT_ID/front-image:${{ steps.short_sha.outputs.short_sha }} front-deployment
 
       - name: Wait for rollout to complete
         run: kubectl rollout status deployment/front-deployment --timeout=10m

--- a/k8s/deploy-image.sh
+++ b/k8s/deploy-image.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# first arg : image
+# second arg : deployment name
+# third arg : container name (default=web)
+set -e
+
+kubectl set image deployment/$2 ${3:-web}=$1 && kubectl rollout status deployment/$2 --watch=false  | grep Waiting || kubectl rollout restart deployment/$2
+echo "Updated $2 image to: $1"


### PR DESCRIPTION
When we use the deploy actions a second time on the same commit hash, `kubectl set image` ends up being a no-op and doesn't trigger a rollout restart, which is not obvious for the dev running it. 
People may want to use the deploy action after updating a secret value, expecting the deployment's pods to be restarted with the new env var value.

This patch changes the actions to force a rollout restart when `kubectl set image` is a no-op.