### PR TITLE
Redirect Nango OAuth clients on Dust first

### DIFF
--- a/front/pages/nango-oauth-callback.ts
+++ b/front/pages/nango-oauth-callback.ts
@@ -2,8 +2,8 @@ import { useEffect } from "react";
 
 export default function NangoRedirect() {
   useEffect(() => {
-  const nangoURL = `https://api.nango.dev/oauth/callback${window.location.search}`
-  window.location.replace(nangoURL);
+    const nangoURL = `https://api.nango.dev/oauth/callback${window.location.search}`;
+    window.location.replace(nangoURL);
   }, []);
 
   return null; // Render nothing.

--- a/front/pages/nango-redirect.ts
+++ b/front/pages/nango-redirect.ts
@@ -1,0 +1,10 @@
+import { useEffect } from "react";
+
+export default function NangoRedirect() {
+  useEffect(() => {
+  const nangoURL = `https://api.nango.dev/oauth/callback${window.location.search}`
+  window.location.replace(nangoURL);
+  }, []);
+
+  return null; // Render nothing.
+}


### PR DESCRIPTION
Making our OAuth redirect URL hosted on dust.tt instead of nango.dev, while keeping Nango for the OAuth flow.

We want to change that for two reasons:
- On some OAuth screens (eg: Google), they show this domain (nango.dev), which can get our users worried.
- Google asks that we control the redirect URI for the app verification process we are going through.

So the users will be redirected to our URL `https://dust.tt/nango-oauth-callback` and we will redirect them to nango.dev.

The reason why this is a javascript redirect is that Google does not fully encode its redirect URI parameters, and Nango knows about that and exepct it to not be fully encoded. So I did not want to have one encoder per provider. I took the decision to do the redirection client side, because there is no decoding of the URI parameters at the browser level.
