### PR TITLE
Allow visualizing apps runs from other workspace (with access to them)

### DIFF
--- a/front/lib/swr.ts
+++ b/front/lib/swr.ts
@@ -109,13 +109,15 @@ export function useRuns(
   app: AppType,
   limit: number,
   offset: number,
-  runType: RunRunType
+  runType: RunRunType,
+  wIdTarget: string | null
 ) {
   const runsFetcher: Fetcher<GetRunsResponseBody> = fetcher;
-  const { data, error } = useSWR(
-    `/api/w/${owner.sId}/apps/${app.sId}/runs?limit=${limit}&offset=${offset}&runType=${runType}`,
-    runsFetcher
-  );
+  let url = `/api/w/${owner.sId}/apps/${app.sId}/runs?limit=${limit}&offset=${offset}&runType=${runType}`;
+  if (wIdTarget) {
+    url += `&wIdTarget=${wIdTarget}`;
+  }
+  const { data, error } = useSWR(url, runsFetcher);
 
   return {
     runs: data ? data.runs : [],

--- a/front/pages/w/[wId]/a/[aId]/runs/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/runs/index.tsx
@@ -20,6 +20,7 @@ export const getServerSideProps: GetServerSideProps<{
   owner: WorkspaceType;
   readOnly: boolean;
   app: AppType;
+  wIdTarget: string | null;
   gaTrackingId: string;
 }> = async (context) => {
   const session = await getSession(context.req, context.res);
@@ -46,12 +47,17 @@ export const getServerSideProps: GetServerSideProps<{
     };
   }
 
+  // get get query params "wIdTarget"
+  const wIdTarget = (context.query?.wIdTarget as string) || null;
+  console.log("WIDTARGET", wIdTarget);
+
   return {
     props: {
       user,
       owner,
       readOnly,
       app,
+      wIdTarget,
       gaTrackingId: GA_TRACKING_ID,
     },
   };
@@ -79,6 +85,7 @@ export default function RunsView({
   owner,
   readOnly,
   app,
+  wIdTarget,
   gaTrackingId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const [runType, setRunType] = useState("local" as RunRunType);
@@ -96,7 +103,14 @@ export default function RunsView({
     );
   }, [readOnly]);
 
-  const { runs, total } = useRuns(owner, app, limit, offset, runType);
+  const { runs, total } = useRuns(
+    owner,
+    app,
+    limit,
+    offset,
+    runType,
+    wIdTarget
+  );
 
   let last = offset + limit;
   if (offset + limit > total) {

--- a/front/pages/w/[wId]/a/[aId]/runs/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/runs/index.tsx
@@ -47,7 +47,8 @@ export const getServerSideProps: GetServerSideProps<{
     };
   }
 
-  // get get query params "wIdTarget"
+  // `wIdTarget` is used to change the workspace owning the runs of the apps we're looking at.
+  // Mostly useful for debugging as an example our use of `dust-apps` as `dust`.
   const wIdTarget = (context.query?.wIdTarget as string) || null;
   console.log("WIDTARGET", wIdTarget);
 


### PR DESCRIPTION
This allows a user to visualize the runs of an app they don't own (but have access to) that were run by their workspace.

In practice this will let us introspect in the Dust UI the runs of our `dust-apps` workspace (backing our packaged products in production) that were executed by our `dust` workspace (or design partner workspace if the user requesting them has access to them).

How to achieve that:
- Take the /runs URL of a given app (eg `/w/bc9d30067b/a/a7afa24ae4/runs`)
- Add the query parameter `wIdTarget` to it (eg `/w/bc9d30067b/a/a7afa24ae4/runs?wIdTarget=b809011d32`)

If you have access to the app `/w/bc9d30067b/a/a7afa24ae4` (unlisted or public) and if you have access to workspace `b809011d32` then you'll the runs by `b809011d32` of the app.