### PR TITLE
fix: allow skipping faulty notion DBs

### DIFF
--- a/connectors/src/admin/db.ts
+++ b/connectors/src/admin/db.ts
@@ -8,6 +8,7 @@ import {
   GoogleDriveSyncToken,
   GoogleDriveWebhook,
   NotionConnectorState,
+  NotionDatabase,
   NotionPage,
   SlackConfiguration,
   SlackMessages,
@@ -19,6 +20,7 @@ async function main(): Promise<void> {
   await SlackConfiguration.sync({ alter: true });
   await SlackMessages.sync({ alter: true });
   await NotionPage.sync({ alter: true });
+  await NotionDatabase.sync({ alter: true });
   await NotionConnectorState.sync({ alter: true });
   await GithubConnectorState.sync({ alter: true });
   await GithubIssue.sync({ alter: true });

--- a/connectors/src/connectors/notion/lib/notion_api.ts
+++ b/connectors/src/connectors/notion/lib/notion_api.ts
@@ -67,6 +67,7 @@ export async function getPagesEditedSince(
   sinceTs: number | null,
   cursor: string | null,
   loggerArgs: Record<string, string | number> = {},
+  skippedDatabaseIds: Set<string> = new Set(),
   retry: { retries: number; backoffFactor: number } = {
     retries: 5,
     backoffFactor: 2,
@@ -145,6 +146,13 @@ export async function getPagesEditedSince(
         editedPages[pageOrDb.id] = lastEditedTime;
       }
     } else if (pageOrDb.object === "database") {
+      if (skippedDatabaseIds.has(pageOrDb.id)) {
+        localLogger.info(
+          { databaseId: pageOrDb.id },
+          "Skipping database that is marked as skipped."
+        );
+        continue;
+      }
       if (isFullDatabase(pageOrDb)) {
         const lastEditedTime = new Date(pageOrDb.last_edited_time).getTime();
         // skip databases that have a `lastEditedTime` in the future

--- a/connectors/src/lib/models.ts
+++ b/connectors/src/lib/models.ts
@@ -324,6 +324,58 @@ NotionPage.init(
 );
 Connector.hasMany(NotionPage);
 
+export class NotionDatabase extends Model<
+  InferAttributes<NotionDatabase>,
+  InferCreationAttributes<NotionDatabase>
+> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare notionDatabaseId: string;
+  declare skipReason?: string | null;
+
+  declare connectorId: ForeignKey<Connector["id"]>;
+}
+
+NotionDatabase.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    notionDatabaseId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    skipReason: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
+  },
+  {
+    sequelize: sequelize_conn,
+    indexes: [
+      { fields: ["notionDatabaseId", "connectorId"], unique: true },
+      { fields: ["connectorId"] },
+    ],
+    modelName: "notion_databases",
+  }
+);
+
+Connector.hasMany(NotionDatabase);
+
 export class GithubConnectorState extends Model<
   InferAttributes<GithubConnectorState>,
   InferCreationAttributes<GithubConnectorState>


### PR DESCRIPTION
A notion connector is stuck due to a faulty DB

remediation:
- merge this
- run `initdb` for connectors
- deploy this
- run ` npm run cli -- notion skip-database --databaseId 'THE_DATABASE_ID' --wId THE_WORKSPACE_ID --reason notion-internal-server-error`