### PR TITLE
auto mode for chat timerange picker

### DIFF
--- a/front/components/use/ChatTimeRangePicker.tsx
+++ b/front/components/use/ChatTimeRangePicker.tsx
@@ -4,7 +4,7 @@ import { Fragment, useState } from "react";
 
 import { classNames } from "@app/lib/utils";
 
-export const timeRanges : ChatTimeRange[] = [
+export const timeRanges: ChatTimeRange[] = [
   // { name: "1 day", id: "day", ms: 86400000},
   { name: "1 week", id: "week", ms: 604800000 },
   // 31 days in ms, and 366 days in ms so that we do not miss any documents
@@ -20,7 +20,7 @@ export type ChatTimeRange = {
   id: TimeRangeId;
   ms: number;
 };
-export const defaultTimeRange : ChatTimeRange = timeRanges[3];
+export const defaultTimeRange: ChatTimeRange = timeRanges[3];
 
 export default function TimeRangePicker({
   timeRange,

--- a/front/components/use/ChatTimeRangePicker.tsx
+++ b/front/components/use/ChatTimeRangePicker.tsx
@@ -3,6 +3,7 @@ import { ClockIcon } from "@heroicons/react/24/outline";
 import { Fragment, useState } from "react";
 
 import { classNames } from "@app/lib/utils";
+import { TimeRangeId } from "@app/types/chat";
 
 export const timeRanges: ChatTimeRange[] = [
   // { name: "1 day", id: "day", ms: 86400000},
@@ -14,7 +15,6 @@ export const timeRanges: ChatTimeRange[] = [
   { name: "auto", id: "auto", ms: 0 },
 ];
 
-export type TimeRangeId = "week" | "month" | "year" | "all" | "auto";
 export type ChatTimeRange = {
   name: string;
   id: TimeRangeId;

--- a/front/components/use/ChatTimeRangePicker.tsx
+++ b/front/components/use/ChatTimeRangePicker.tsx
@@ -4,21 +4,23 @@ import { Fragment, useState } from "react";
 
 import { classNames } from "@app/lib/utils";
 
-export const timeRanges = [
+export const timeRanges : ChatTimeRange[] = [
   // { name: "1 day", id: "day", ms: 86400000},
   { name: "1 week", id: "week", ms: 604800000 },
   // 31 days in ms, and 366 days in ms so that we do not miss any documents
   { name: "1 month", id: "month", ms: 2678400000 },
   { name: "1 year", id: "year", ms: 31622400000 },
   { name: "all time", id: "all", ms: 0 },
+  { name: "auto", id: "auto", ms: 0 },
 ];
 
+export type TimeRangeId = "week" | "month" | "year" | "all" | "auto";
 export type ChatTimeRange = {
   name: string;
-  id: string;
+  id: TimeRangeId;
   ms: number;
 };
-export const defaultTimeRange = timeRanges[3];
+export const defaultTimeRange : ChatTimeRange = timeRanges[3];
 
 export default function TimeRangePicker({
   timeRange,

--- a/front/lib/actions_registry.ts
+++ b/front/lib/actions_registry.ts
@@ -42,7 +42,7 @@ export const DustProdActionRegistry: {
       workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
       appId: "0052be4be7",
       appHash:
-        "2e9a8dbea83076c23d235f1dce273570542c4f11e9a0e7decefa9c26c78654e9",
+        "11dd46ca38cb79d8a7916ce17f6a4735d2def736fb9aa42bcc9377dd33adcfd4",
     },
     config: {
       MODEL: {

--- a/front/migrations/20230614_timetttamp.ts
+++ b/front/migrations/20230614_timetttamp.ts
@@ -24,7 +24,7 @@ async function migrateCollection(
   let currentTime = Date.now(),
     points,
     updated = 0;
-  let nb_points = await client.count(collectionName);
+  const nb_points = await client.count(collectionName);
   console.log(
     "Migrating Collection ",
     collectionName,

--- a/front/pages/api/w/[wId]/use/chats/[cId]/index.ts
+++ b/front/pages/api/w/[wId]/use/chats/[cId]/index.ts
@@ -55,7 +55,15 @@ const chatMessageSchema: JSONSchemaType<ChatMessageType> = {
       items: chatRetrievedDocumentSchema,
       nullable: true,
     },
-    query: { type: "string", nullable: true },
+    query: {
+      type: "object",
+      properties: {
+        text: { type: "string" },
+        timeRangeId: { type: "string" },
+      },
+      nullable: true,
+      required: ["text"],
+    },
   },
   required: ["role"],
 };

--- a/front/pages/w/[wId]/u/chat/[cId]/index.tsx
+++ b/front/pages/w/[wId]/u/chat/[cId]/index.tsx
@@ -18,7 +18,6 @@ import { Spinner } from "@app/components/Spinner";
 import TimeRangePicker, {
   ChatTimeRange,
   defaultTimeRange,
-  TimeRangeId,
   timeRanges,
 } from "@app/components/use/ChatTimeRangePicker";
 import MainTab from "@app/components/use/MainTab";
@@ -46,6 +45,7 @@ import {
   ChatMessageType,
   ChatQueryType,
   ChatRetrievedDocumentType,
+  TimeRangeId,
 } from "@app/types/chat";
 import { UserType, WorkspaceType } from "@app/types/user";
 

--- a/front/pages/w/[wId]/u/chat/[cId]/index.tsx
+++ b/front/pages/w/[wId]/u/chat/[cId]/index.tsx
@@ -17,8 +17,8 @@ import { PulseLogo } from "@app/components/Logo";
 import { Spinner } from "@app/components/Spinner";
 import TimeRangePicker, {
   ChatTimeRange,
-  TimeRangeId,
   defaultTimeRange,
+  TimeRangeId,
   timeRanges,
 } from "@app/components/use/ChatTimeRangePicker";
 import MainTab from "@app/components/use/MainTab";
@@ -48,7 +48,6 @@ import {
   ChatRetrievedDocumentType,
 } from "@app/types/chat";
 import { UserType, WorkspaceType } from "@app/types/user";
-import { time } from "console";
 
 const { GA_TRACKING_ID = "" } = process.env;
 

--- a/front/types/chat.ts
+++ b/front/types/chat.ts
@@ -23,7 +23,7 @@ export type ChatMessageType = {
   role: "user" | "retrieval" | "assistant" | "error";
   message?: string; // for `user`, `assistant` and `error` messages
   retrievals?: ChatRetrievedDocumentType[]; // for `retrieval` messages
-  query?: ChatQueryType;  // for `retrieval` messages (not persisted)
+  query?: ChatQueryType; // for `retrieval` messages (not persisted)
 };
 
 export type ChatSessionType = {

--- a/front/types/chat.ts
+++ b/front/types/chat.ts
@@ -1,3 +1,5 @@
+import { TimeRangeId } from "@app/components/use/ChatTimeRangePicker";
+
 export type ChatRetrievedDocumentType = {
   dataSourceId: string;
   sourceUrl: string;
@@ -12,11 +14,16 @@ export type ChatRetrievedDocumentType = {
   }[];
 };
 
+export type ChatQueryType = {
+  text: string;
+  timeRangeId: TimeRangeId;
+};
+
 export type ChatMessageType = {
   role: "user" | "retrieval" | "assistant" | "error";
   message?: string; // for `user`, `assistant` and `error` messages
   retrievals?: ChatRetrievedDocumentType[]; // for `retrieval` messages
-  query?: string; // for `retrieval` messages (not persisted)
+  query?: ChatQueryType;  // for `retrieval` messages (not persisted)
 };
 
 export type ChatSessionType = {

--- a/front/types/chat.ts
+++ b/front/types/chat.ts
@@ -1,5 +1,3 @@
-import { TimeRangeId } from "@app/components/use/ChatTimeRangePicker";
-
 export type ChatRetrievedDocumentType = {
   dataSourceId: string;
   sourceUrl: string;
@@ -14,6 +12,7 @@ export type ChatRetrievedDocumentType = {
   }[];
 };
 
+export type TimeRangeId = "week" | "month" | "year" | "all" | "auto";
 export type ChatQueryType = {
   text: string;
   timeRangeId: TimeRangeId;


### PR DESCRIPTION
Draft PR for sharing / experimentation
Screenshots below

Current issues whose path to improvement are unclear:
- Falls back on "all time" often. Fine, but the user sees it in the query loading so a bit dissapointing
- might encourage users to ask "what did I say about XX 3 weeks ago?" --- which is not handled at present and cannot be handled simply on a UX perspective
- Examples of okayish behaviour
  - "company roadmap Q1 2023?" => "all"
- Examples of wrong behaviour
  - "In january, was there a meeting in which we discussed the hiring targets?" => "month" (question asked with date 31 may)
  - "Describe the incident in production that happened 3 weeks ago" => "3 weeks" (invalid value)
  - "What was the revenue target for last year?" => "year" ( asked with date 31/05; the targets were probably set Q1 last year or even Q4 of the preceding year so they will likely be missed)
