### PR TITLE
Serialize Pino log levels as strings

### DIFF
--- a/connectors/src/logger/logger.ts
+++ b/connectors/src/logger/logger.ts
@@ -1,19 +1,28 @@
-import pino from "pino";
+import pino, { LoggerOptions } from "pino";
 
 const NODE_ENV = process.env.NODE_ENV;
+const defaultPinoOptions: LoggerOptions = {
+  formatters: {
+    level(level) {
+      return { level };
+    },
+  },
+};
 
-const pinoOtions =
-  NODE_ENV === "development"
-    ? {
-        transport: {
-          target: "pino-pretty",
-          options: {
-            errorLikeObjectKeys: ["err", "error", "error_stack", "stack"],
-          },
-        },
-      }
-    : {};
-const logger = pino(pinoOtions);
+const devOptions = {
+  transport: {
+    target: "pino-pretty",
+    options: {
+      errorLikeObjectKeys: ["err", "error", "error_stack", "stack"],
+    },
+  },
+};
+let pinoOptions = defaultPinoOptions;
+if (NODE_ENV === "development") {
+  pinoOptions = { ...defaultPinoOptions, ...devOptions };
+}
+
+const logger = pino(pinoOptions);
 
 export default logger;
 export type { Logger } from "pino";

--- a/front/logger/logger.ts
+++ b/front/logger/logger.ts
@@ -1,5 +1,28 @@
-import pino from "pino";
+import pino, { LoggerOptions } from "pino";
 
-const logger = pino();
+const NODE_ENV = process.env.NODE_ENV;
+const defaultPinoOptions: LoggerOptions = {
+  formatters: {
+    level(level) {
+      return { level };
+    },
+  },
+};
+
+const devOptions = {
+  transport: {
+    target: "pino-pretty",
+    options: {
+      errorLikeObjectKeys: ["err", "error", "error_stack", "stack"],
+    },
+  },
+};
+let pinoOptions = defaultPinoOptions;
+if (NODE_ENV === "development") {
+  pinoOptions = { ...defaultPinoOptions, ...devOptions };
+}
+
+const logger = pino(pinoOptions);
 
 export default logger;
+export type { Logger } from "pino";

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -26,6 +26,7 @@
         "pg": "^8.8.0",
         "pg-hstore": "^2.3.4",
         "pino": "^8.11.0",
+        "pino-pretty": "^10.0.0",
         "react": "^18.2.0",
         "react-accessible-treeview": "^2.6.0",
         "react-beforeunload": "^2.5.3",
@@ -4110,6 +4111,11 @@
         "color-support": "bin.js"
       }
     },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="
+    },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
       "license": "MIT",
@@ -4184,6 +4190,14 @@
       "version": "1.0.8",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/dateformat": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/dd-trace": {
       "version": "3.16.0",
@@ -4474,6 +4488,14 @@
       "optional": true,
       "dependencies": {
         "iconv-lite": "^0.6.2"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/enhanced-resolve": {
@@ -5381,6 +5403,11 @@
       "version": "3.0.2",
       "license": "MIT"
     },
+    "node_modules/fast-copy": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.1.tgz",
+      "integrity": "sha512-Knr7NOtK3HWRYGtHoJrjkaWepqT8thIVGAwt0p0aUs1zqkAzXZV4vo9fFNwyb5fcqK1GKYFYxldQdIDVKhUAfA=="
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "license": "MIT"
@@ -5425,6 +5452,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
     },
     "node_modules/fastq": {
       "version": "1.15.0",
@@ -6000,6 +6032,52 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/help-me": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-4.2.0.tgz",
+      "integrity": "sha512-TAOnTB8Tz5Dw8penUuzHVrKNKlCIbwwbHnXraNJxPwf8LRtE2HlM84RYuezMFcwOJmoYOCWVDyJ8TQGxn9PgxA==",
+      "dependencies": {
+        "glob": "^8.0.0",
+        "readable-stream": "^3.6.0"
+      }
+    },
+    "node_modules/help-me/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/help-me/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/help-me/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/hot-shots": {
@@ -8482,6 +8560,14 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/js-sdsl": {
       "version": "4.3.0",
       "dev": true,
@@ -9963,6 +10049,44 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/pino-pretty": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-10.0.0.tgz",
+      "integrity": "sha512-zKFjYXBzLaLTEAN1ayKpHXtL5UeRQC7R3lvhKe7fWs7hIVEjKGG/qIXwQt9HmeUp71ogUd/YcW+LmMwRp4KT6Q==",
+      "dependencies": {
+        "colorette": "^2.0.7",
+        "dateformat": "^4.6.3",
+        "fast-copy": "^3.0.0",
+        "fast-safe-stringify": "^2.1.1",
+        "help-me": "^4.0.1",
+        "joycon": "^3.1.1",
+        "minimist": "^1.2.6",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^1.0.0",
+        "pump": "^3.0.0",
+        "readable-stream": "^4.0.0",
+        "secure-json-parse": "^2.4.0",
+        "sonic-boom": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "bin": {
+        "pino-pretty": "bin.js"
+      }
+    },
+    "node_modules/pino-pretty/node_modules/readable-stream": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.0.tgz",
+      "integrity": "sha512-kDMOq0qLtxV9f/SQv522h8cxZBqNZXuXNyjyezmfAAuribMyVXziljpQ/uQhfE1XLg2/TLTW2DsnoE4VAi/krg==",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
     "node_modules/pino-std-serializers": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.1.0.tgz",
@@ -10332,6 +10456,15 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "node_modules/punycode": {
@@ -10798,6 +10931,11 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/secure-json-parse": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
+      "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw=="
     },
     "node_modules/semver": {
       "version": "6.3.0",
@@ -11292,7 +11430,6 @@
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"

--- a/front/package.json
+++ b/front/package.json
@@ -33,6 +33,7 @@
     "pg": "^8.8.0",
     "pg-hstore": "^2.3.4",
     "pino": "^8.11.0",
+    "pino-pretty": "^10.0.0",
     "react": "^18.2.0",
     "react-accessible-treeview": "^2.6.0",
     "react-beforeunload": "^2.5.3",


### PR DESCRIPTION
Output Pino log levels as string, which makes them readable by Datadog.

Before:
```
//test.ts
import logger from "@connectors/logger/logger";

logger.error("error1");
{"level":"40","time":1687772868805,"pid":96891,"hostname":"ARICs-MacBook-Pro.local","msg":"error1"}
```

After:
```
//test.ts
import logger from "@connectors/logger/logger";

logger.error("error1");
{"level":"error","time":1687772868805,"pid":96891,"hostname":"ARICs-MacBook-Pro.local","msg":"error1"}
```