### PR TITLE
doc tracker: track doc by adding DUST_TRACK() tag

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -11,6 +11,7 @@ import {
   MembershipInvitation,
   Provider,
   Run,
+  TrackedDocument,
   User,
   Workspace,
   XP1Run,
@@ -32,6 +33,7 @@ async function main() {
   await ChatSession.sync({ alter: true });
   await ChatMessage.sync({ alter: true });
   await ChatRetrievedDocument.sync({ alter: true });
+  await TrackedDocument.sync({ alter: true });
 
   await XP1User.sync({ alter: true });
   await XP1Run.sync({ alter: true });

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -35,6 +35,7 @@ export async function getDataSource(
   }
 
   return {
+    id: dataSource.id,
     name: dataSource.name,
     description: dataSource.description,
     visibility: dataSource.visibility,
@@ -72,6 +73,7 @@ export async function getDataSources(
 
   return dataSources.map((dataSource): DataSourceType => {
     return {
+      id: dataSource.id,
       name: dataSource.name,
       description: dataSource.description,
       visibility: dataSource.visibility,

--- a/front/lib/document_tracker.ts
+++ b/front/lib/document_tracker.ts
@@ -1,0 +1,102 @@
+import { Op } from "sequelize";
+
+import { TrackedDocument, User } from "@app/lib/models";
+import logger from "@app/logger/logger";
+
+export async function updateTrackedDocuments(
+  dataSourceId: number,
+  documentId: string,
+  documentContent: string
+) {
+  const emailPattern = "\\S+@\\S+\\.\\S+";
+
+  const dustTrackTagRegex = new RegExp(
+    "DUST_TRACK\\(\\s*((?:" + emailPattern + "\\s*,?\\s*)+)\\)",
+    "g"
+  );
+
+  const dustTrackTags = documentContent.match(dustTrackTagRegex);
+  if (!dustTrackTags) {
+    return;
+  }
+  const allEmails: Set<string> = new Set();
+  for (const dustTrackTag of dustTrackTags) {
+    // remove 'DUST_TRACK(' and ')' from the tag
+    const emailsInTag = dustTrackTag
+      .replace(/DUST_TRACK\(/, "")
+      .replace(/\)/, "");
+
+    // split emails by comma and map over them to remove any trailing or leading spaces
+    const emails = emailsInTag
+      .split(",")
+      .map((email) => email.trim().toLowerCase());
+    for (const email of emails) {
+      allEmails.add(email);
+    }
+  }
+
+  const emails = Array.from(allEmails);
+  const users = await User.findAll({
+    where: {
+      email: {
+        [Op.in]: emails,
+      },
+    },
+  });
+  const userByEmail: Map<string, User> = new Map();
+  for (const user of users) {
+    userByEmail.set(user.email.toLowerCase(), user);
+  }
+  const upsertTrackedDoc = async (email: string) => {
+    const user = userByEmail.get(email);
+    if (!user) {
+      // TODO: email user to let them know they need to
+      // sign up to dust before they can track docs
+      logger.warn(
+        {
+          email,
+          dataSourceId,
+          documentId,
+        },
+        "User not found for tracked document"
+      );
+      return;
+    }
+    const exists = !!(await TrackedDocument.count({
+      where: {
+        dataSourceId,
+        documentId,
+        userId: user.id,
+      },
+    }));
+    if (exists) {
+      return;
+    }
+    logger.info(
+      {
+        email,
+        dataSourceId,
+        documentId,
+      },
+      "Creating tracked document"
+    );
+    await TrackedDocument.create({
+      dataSourceId,
+      documentId,
+      userId: user.id,
+      trackingEnabledAt: new Date(),
+    });
+  };
+
+  // TODO: not very efficient
+  await Promise.all(emails.map(upsertTrackedDoc));
+  await TrackedDocument.destroy({
+    where: {
+      dataSourceId,
+      documentId,
+      userId: {
+        [Op.notIn]: users.map((user) => user.id),
+      },
+    },
+  });
+}

--- a/front/lib/models.ts
+++ b/front/lib/models.ts
@@ -832,6 +832,67 @@ ChatRetrievedDocument.init(
 
 ChatMessage.hasMany(ChatRetrievedDocument);
 
+export class TrackedDocument extends Model<
+  InferAttributes<TrackedDocument>,
+  InferCreationAttributes<TrackedDocument>
+> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare documentId: string;
+  declare trackingEnabledAt: Date | null;
+
+  declare userId: ForeignKey<User["id"]>;
+  declare dataSourceId: ForeignKey<DataSource["id"]>;
+}
+
+TrackedDocument.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    documentId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    trackingEnabledAt: {
+      type: DataTypes.DATE,
+      allowNull: true,
+      defaultValue: DataTypes.NOW,
+    },
+  },
+  {
+    modelName: "tracked_document",
+    sequelize: front_sequelize,
+    indexes: [
+      { fields: ["userId", "dataSourceId", "documentId"], unique: true },
+      { fields: ["dataSourceId"] },
+    ],
+  }
+);
+
+DataSource.hasMany(TrackedDocument, {
+  foreignKey: { allowNull: false },
+  onDelete: "CASCADE",
+});
+User.hasMany(TrackedDocument, {
+  foreignKey: { allowNull: false },
+  onDelete: "CASCADE",
+});
+
 // XP1
 
 const { XP1_DATABASE_URI } = process.env;

--- a/front/pages/api/w/[wId]/data_sources/[name]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/index.ts
@@ -66,6 +66,7 @@ async function handler(
     case "GET":
       res.status(200).json({
         dataSource: {
+          id: dataSource.id,
           name: dataSource.name,
           description: dataSource.description,
           visibility: dataSource.visibility,
@@ -114,6 +115,7 @@ async function handler(
 
       return res.status(200).json({
         dataSource: {
+          id: ds.id,
           name: ds.name,
           description: ds.description,
           visibility: ds.visibility,

--- a/front/pages/api/w/[wId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/index.ts
@@ -176,6 +176,7 @@ async function handler(
 
       res.status(201).json({
         dataSource: {
+          id: ds.id,
           name: ds.name,
           description: ds.description,
           visibility: ds.visibility,

--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -222,6 +222,7 @@ async function handler(
 
       return res.status(201).json({
         dataSource: {
+          id: dataSource.id,
           name: dataSource.name,
           description: dataSource.description,
           visibility: dataSource.visibility,

--- a/front/types/data_source.ts
+++ b/front/types/data_source.ts
@@ -3,6 +3,7 @@ import { ConnectorProvider } from "@app/lib/connectors_api";
 export type DataSourceVisibility = "public" | "private";
 
 export type DataSourceType = {
+  id: number;
   name: string;
   description?: string;
   visibility: DataSourceVisibility;


### PR DESCRIPTION
includes:
- new model for front, to keep track of which docs are tracked
- some code that runs post-upsert (on front side) that checks for `DUST_TRACK` tags in the doc body and syncs with the new table

does not include:
- the actual post upsert hook (that runs on temporal and calls OAI)
- mailing when we cannot find the user by email