### PR TITLE
[Connector] Quadratic backoff for upserting to a Data Source.

### DIFF
--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -64,7 +64,7 @@ async function upsertToDatasourceWithRetries(
       );
     } catch (e) {
       await new Promise((resolve) =>
-        setTimeout(resolve, delayBetweenRetriesMs)
+        setTimeout(resolve, delayBetweenRetriesMs * (i + 1) ** 2)
       );
       errors.push(e);
     }

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -17,7 +17,7 @@ export async function upsertToDatasource(
   documentUrl?: string,
   timestampMs?: number,
   tags?: string[],
-  retries = 3,
+  retries = 10,
   delayBetweenRetriesMs = 500,
   loggerArgs: Record<string, string | number> = {}
 ) {
@@ -43,7 +43,7 @@ async function upsertToDatasourceWithRetries(
   documentUrl?: string,
   timestampMs?: number,
   tags?: string[],
-  retries = 3,
+  retries = 10,
   delayBetweenRetriesMs = 500,
   loggerArgs: Record<string, string | number> = {}
 ) {
@@ -63,9 +63,17 @@ async function upsertToDatasourceWithRetries(
         loggerArgs
       );
     } catch (e) {
-      await new Promise((resolve) =>
-        setTimeout(resolve, delayBetweenRetriesMs * (i + 1) ** 2)
+      const sleepTime = delayBetweenRetriesMs * (i + 1) ** 2;
+      logger.warn(
+        {
+          error: e,
+          attempt: i + 1,
+          retries: retries,
+          sleepTime: sleepTime,
+        },
+        "Error upserting to data source. Retrying..."
       );
+      await new Promise((resolve) => setTimeout(resolve, sleepTime));
       errors.push(e);
     }
   }


### PR DESCRIPTION
Smarter retry for documents upserting in Connectors.
Here is the graph to visualize the timing (in seconds).
`x` is the attempt number. `y` is the number of seconds to sleep for.
<img width="1479" alt="Screen Shot 2023-06-26 at 18 03 23" src="https://github.com/dust-tt/dust/assets/358965/6227c142-b9be-419d-bedc-4c2ecdccd3df">
