### PR TITLE
Fix 404 errors on Gdrive Webhooks

### DIFF
--- a/connectors/migrations/20230626_gdrive_multiple_webhooks.ts
+++ b/connectors/migrations/20230626_gdrive_multiple_webhooks.ts
@@ -1,0 +1,14 @@
+import { sequelize_conn } from "@connectors/lib/models";
+
+async function main() {
+  await sequelize_conn.query("drop index google_drive_webhooks_connector_id");
+  await sequelize_conn.query(
+    'UPDATE google_drive_webhooks SET "renewAt" = "expiresAt"'
+  );
+}
+
+main()
+  .then(() => {
+    console.log("Done");
+  })
+  .catch(console.error);

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -63,6 +63,7 @@ export async function createGoogleDriveConnector(
             {
               webhookId: webhookInfo.value.id,
               expiresAt: new Date(webhookInfo.value.expirationTsMs),
+              renewAt: new Date(webhookInfo.value.expirationTsMs),
               connectorId: connector.id,
             },
             { transaction: t }

--- a/connectors/src/connectors/google_drive/lib.ts
+++ b/connectors/src/connectors/google_drive/lib.ts
@@ -34,7 +34,7 @@ export async function registerWebhook(
         id: uuid,
         type: "web_hook",
         address: webhookURL,
-        expiration: new Date().getTime() + 60 * 60 * 5 * 1000,
+        expiration: new Date().getTime() + 60 * 60 * 7 * 1000,
       }),
     }
   );

--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -721,6 +721,10 @@ export async function renewOneWebhook(webhookId: ModelId) {
         1,
         tags
       );
+      // retry in two hours in case of failure
+      await wh.update({
+        renewAt: literal('NOW() + INTERVAL "2 hour"'),
+      });
     }
   }
 }

--- a/connectors/src/lib/models.ts
+++ b/connectors/src/lib/models.ts
@@ -685,7 +685,9 @@ export class GoogleDriveWebhook extends Model<
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
   declare webhookId: string;
+  declare renewedByWebhookId: string | null;
   declare expiresAt: Date;
+  declare renewAt: Date | null;
   declare connectorId: ForeignKey<Connector["id"]>;
 }
 
@@ -714,17 +716,27 @@ GoogleDriveWebhook.init(
       type: DataTypes.STRING,
       allowNull: false,
     },
+    renewedByWebhookId: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
     expiresAt: {
       type: DataTypes.DATE,
       allowNull: false,
+    },
+    renewAt: {
+      type: DataTypes.DATE,
+      allowNull: true,
+      defaultValue: DataTypes.NOW,
     },
   },
   {
     sequelize: sequelize_conn,
     modelName: "google_drive_webhooks",
     indexes: [
-      { fields: ["connectorId"], unique: true },
-      { fields: ["expiresAt"] },
+      { fields: ["webhookId"], unique: true },
+      { fields: ["renewAt"] },
+      { fields: ["connectorId"] },
     ],
   }
 );


### PR DESCRIPTION
Handle multiple webhooks pointers for one Gdrive connector.
Added a field `renewAt` to differentiate between the renew time and the expire time, even though they are the same in success cases. This new field is needed because failing to renew a webhook would put it in an infinite retry cycle.

The field `renewedByWebhookId` is here to make sure we never renew a webhook that has already been renewed and to clean up expired webhook only if they have been renewed.

