### PR TITLE
enh dx: remove unused-imports plugin from eslint config (front)

### DIFF
--- a/front/.eslintrc.js
+++ b/front/.eslintrc.js
@@ -5,7 +5,7 @@ module.exports = {
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
   ],
-  plugins: ["simple-import-sort", "unused-imports"],
+  plugins: ["simple-import-sort"],
   rules: {
     /**
     "@typescript-eslint/naming-convention": [
@@ -16,7 +16,6 @@ module.exports = {
       }
     ],
     */
-    "unused-imports/no-unused-imports": "error",
     "react/no-unescaped-entities": 0,
     "@typescript-eslint/no-explicit-any": 0,
     "no-case-declarations": 0,


### PR DESCRIPTION
- We don't use it in connectors
- We already get a warning from Typescript
- There is no way, afaik, to get autofix on save for VSCode import orders (given that our import sorting setup is eslint-based) without having it auto-delete unused import (and that behaviour is really painful)