### PR TITLE
enh: partial resync (`full-resync` `fromTs` argument) + slack implementation

### DIFF
--- a/connectors/src/admin/cli.ts
+++ b/connectors/src/admin/cli.ts
@@ -49,8 +49,12 @@ const connectors = async (command: string, args: parseArgs.ParsedArgs) => {
       return;
     }
     case "full-resync": {
+      let fromTs: number | null = null;
+      if (args.fromTs) {
+        fromTs = parseInt(args.fromTs as string, 10);
+      }
       await throwOnError(
-        SYNC_CONNECTOR_BY_TYPE[provider](connector.id.toString())
+        SYNC_CONNECTOR_BY_TYPE[provider](connector.id.toString(), fromTs)
       );
       return;
     }

--- a/connectors/src/api/sync_connector.ts
+++ b/connectors/src/api/sync_connector.ts
@@ -31,7 +31,8 @@ const _syncConnectorAPIHandler = async (
     return;
   }
   const launchRes = await SYNC_CONNECTOR_BY_TYPE[connector.type](
-    connector.id.toString()
+    connector.id.toString(),
+    null
   );
   if (launchRes.isErr()) {
     res.status(500).send({

--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -134,8 +134,15 @@ export async function resumeGithubConnector(
 }
 
 export async function fullResyncGithubConnector(
-  connectorId: string
+  connectorId: string,
+  fromTs: number | null
 ): Promise<Result<string, Error>> {
+  if (fromTs) {
+    return new Err(
+      new Error("Github connector does not support partial resync")
+    );
+  }
+
   try {
     await launchGithubFullSyncWorkflow(connectorId);
     return new Ok(connectorId);

--- a/connectors/src/connectors/google_drive/temporal/client.ts
+++ b/connectors/src/connectors/google_drive/temporal/client.ts
@@ -18,12 +18,20 @@ import {
 const logger = mainLogger.child({ provider: "google" });
 
 export async function launchGoogleDriveFullSyncWorkflow(
-  connectorId: string
+  connectorId: string,
+  fromTs: number | null
 ): Promise<Result<string, Error>> {
   const connector = await Connector.findByPk(connectorId);
   if (!connector) {
     return new Err(new Error(`Connector ${connectorId} not found`));
   }
+
+  if (fromTs) {
+    return new Err(
+      new Error("Github connector does not support partial resync")
+    );
+  }
+
   const client = await getTemporalClient();
   const connectorIdModelId = parseInt(connectorId, 10) as ModelId;
 

--- a/connectors/src/connectors/index.ts
+++ b/connectors/src/connectors/index.ts
@@ -102,7 +102,10 @@ export const RESUME_CONNECTOR_BY_TYPE: Record<
   },
 };
 
-type SyncConnector = (connectorId: string) => Promise<Result<string, Error>>;
+type SyncConnector = (
+  connectorId: string,
+  fromTs: number | null
+) => Promise<Result<string, Error>>;
 
 export const SYNC_CONNECTOR_BY_TYPE: Record<ConnectorProvider, SyncConnector> =
   {

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -138,7 +138,10 @@ export async function resumeNotionConnector(
   return new Ok(connector.id.toString());
 }
 
-export async function fullResyncNotionConnector(connectorId: string) {
+export async function fullResyncNotionConnector(
+  connectorId: string,
+  fromTs: number | null
+) {
   const connector = await Connector.findOne({
     where: { type: "notion", id: connectorId },
   });
@@ -146,6 +149,11 @@ export async function fullResyncNotionConnector(connectorId: string) {
   if (!connector) {
     logger.error({ connectorId }, "Notion connector not found.");
     return new Err(new Error("Connector not found"));
+  }
+  if (fromTs) {
+    return new Err(
+      new Error("Notion connector does not support partial resync")
+    );
   }
 
   try {

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -86,7 +86,10 @@ export async function createSlackConnector(
     return res;
   }
 
-  const launchRes = await launchSlackSyncWorkflow(res.value.id.toString());
+  const launchRes = await launchSlackSyncWorkflow(
+    res.value.id.toString(),
+    null
+  );
   if (launchRes.isErr()) {
     return new Err(launchRes.error);
   }

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -114,6 +114,7 @@ export async function syncChannel(
   channelName: string,
   dataSourceConfig: DataSourceConfig,
   connectorId: string,
+  fromTs: number | null,
   weeksSynced: Record<number, boolean>,
   messagesCursor?: string
 ): Promise<SyncChannelRes | undefined> {
@@ -133,13 +134,22 @@ export async function syncChannel(
       weeksSynced: weeksSynced,
     };
   }
+  let all_skip = true;
   for (const message of messages.messages) {
     if (!message.user) {
       // We do not support messages not posted by users for now
       continue;
     }
+    let skip = false;
     if (message.thread_ts) {
-      if (threadsToSync.indexOf(message.thread_ts) === -1) {
+      const threadTs = parseInt(message.thread_ts, 10) * 1000;
+      if (fromTs && threadTs < fromTs) {
+        skip = true;
+        console.log(
+          `SKIPPING THREAD: messaage.thred_ts=${message.thread_ts} threadTs=${threadTs} fromTs=${fromTs}`
+        );
+      }
+      if (!skip && threadsToSync.indexOf(message.thread_ts) === -1) {
         // We can end up getting two messages from the same thread if a message from a thread
         // has also been "posted to channel".
         threadsToSync.push(message.thread_ts);
@@ -147,10 +157,19 @@ export async function syncChannel(
     } else {
       const messageTs = parseInt(message.ts as string, 10) * 1000;
       const weekStartTsMs = getWeekStart(new Date(messageTs)).getTime();
-      // const weekEndTsMss = getWeekEnd(new Date(messageTs)).getTime();
-      if (unthreadedTimeframesToSync.indexOf(weekStartTsMs) === -1) {
+      const weekEndTsMs = getWeekEnd(new Date(messageTs)).getTime();
+      if (fromTs && weekEndTsMs < fromTs) {
+        skip = true;
+        console.log(
+          `SKIPPING NON-THREAD: messageTs=${messageTs} fromTs=${fromTs} weekEndTsMs=${weekEndTsMs} weekStartTsMs=${weekStartTsMs}`
+        );
+      }
+      if (!skip && unthreadedTimeframesToSync.indexOf(weekStartTsMs) === -1) {
         unthreadedTimeframesToSync.push(weekStartTsMs);
       }
+    }
+    if (!skip) {
+      all_skip = false;
     }
   }
   await syncThreads(

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -134,6 +134,8 @@ export async function syncChannel(
       weeksSynced: weeksSynced,
     };
   }
+  // `allSkip` and `skip` logic assumes that the messages are returned in recency order (newest
+  // first).
   let allSkip = true;
   for (const message of messages.messages) {
     if (!message.user) {

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -134,7 +134,7 @@ export async function syncChannel(
       weeksSynced: weeksSynced,
     };
   }
-  let all_skip = true;
+  let allSkip = true;
   for (const message of messages.messages) {
     if (!message.user) {
       // We do not support messages not posted by users for now
@@ -169,9 +169,10 @@ export async function syncChannel(
       }
     }
     if (!skip) {
-      all_skip = false;
+      allSkip = false;
     }
   }
+
   await syncThreads(
     dataSourceConfig,
     slackAccessToken,
@@ -196,7 +197,7 @@ export async function syncChannel(
   unthreadedTimeframesToSync.forEach((t) => (weeksSynced[t] = true));
 
   return {
-    nextCursor: messages.response_metadata?.next_cursor,
+    nextCursor: allSkip ? undefined : messages.response_metadata?.next_cursor,
     weeksSynced: weeksSynced,
   };
 }

--- a/connectors/src/connectors/slack/temporal/client.ts
+++ b/connectors/src/connectors/slack/temporal/client.ts
@@ -6,6 +6,7 @@ import mainLogger from "@connectors/logger/logger";
 import { DataSourceConfig } from "@connectors/types/data_source_config";
 
 import { getWeekStart } from "../lib/utils";
+import { QUEUE_NAME } from "./config";
 import { botJoinedChanelSignal, newWebhookSignal } from "./signals";
 import {
   botJoinedChannelWorkflowId,
@@ -43,7 +44,7 @@ export async function launchSlackSyncWorkflow(
   try {
     await client.workflow.start(workspaceFullSync, {
       args: [connectorId, dataSourceConfig, nangoConnectionId, fromTs],
-      taskQueue: "slack-queue",
+      taskQueue: QUEUE_NAME,
       workflowId: workflowId,
     });
     logger.info(
@@ -100,7 +101,7 @@ export async function launchSlackSyncOneThreadWorkflow(
           channelId,
           threadTs,
         ],
-        taskQueue: "slack-queue",
+        taskQueue: QUEUE_NAME,
         workflowId: workflowId,
         signal: newWebhookSignal,
         signalArgs: undefined,
@@ -149,7 +150,7 @@ export async function launchSlackSyncOneMessageWorkflow(
           channelId,
           threadTs,
         ],
-        taskQueue: "slack-queue",
+        taskQueue: QUEUE_NAME,
         workflowId: workflowId,
         signal: newWebhookSignal,
         signalArgs: undefined,
@@ -183,7 +184,7 @@ export async function launchSlackBotJoinedWorkflow(
   try {
     await client.workflow.signalWithStart(memberJoinedChannel, {
       args: [connectorId, nangoConnectionId, dataSourceConfig],
-      taskQueue: "slack-queue",
+      taskQueue: QUEUE_NAME,
       workflowId: workflowId,
       signal: botJoinedChanelSignal,
       signalArgs: [{ channelId: channelId }],
@@ -224,7 +225,7 @@ export async function launchSlackGarbageCollectWorkflow(connectorId: string) {
   try {
     await client.workflow.start(slackGarbageCollectorWorkflow, {
       args: [connectorId, dataSourceConfig, nangoConnectionId],
-      taskQueue: "slack-queue",
+      taskQueue: QUEUE_NAME,
       workflowId: workflowId,
     });
     logger.info(

--- a/connectors/src/connectors/slack/temporal/client.ts
+++ b/connectors/src/connectors/slack/temporal/client.ts
@@ -22,7 +22,10 @@ import {
 
 const logger = mainLogger.child({ provider: "slack" });
 
-export async function launchSlackSyncWorkflow(connectorId: string) {
+export async function launchSlackSyncWorkflow(
+  connectorId: string,
+  fromTs: number | null
+) {
   const connector = await Connector.findByPk(connectorId);
   if (!connector) {
     return new Err(new Error(`Connector ${connectorId} not found`));
@@ -36,10 +39,10 @@ export async function launchSlackSyncWorkflow(connectorId: string) {
   };
   const nangoConnectionId = connector.connectionId;
 
-  const workflowId = workspaceFullSyncWorkflowId(connectorId);
+  const workflowId = workspaceFullSyncWorkflowId(connectorId, fromTs);
   try {
     await client.workflow.start(workspaceFullSync, {
-      args: [connectorId, dataSourceConfig, nangoConnectionId],
+      args: [connectorId, dataSourceConfig, nangoConnectionId, fromTs],
       taskQueue: "slack-queue",
       workflowId: workflowId,
     });

--- a/connectors/src/connectors/slack/temporal/config.ts
+++ b/connectors/src/connectors/slack/temporal/config.ts
@@ -1,0 +1,2 @@
+export const WORKFLOW_VERSION = 1;
+export const QUEUE_NAME = `slack-queue-v${WORKFLOW_VERSION}`;

--- a/connectors/src/connectors/slack/temporal/worker.ts
+++ b/connectors/src/connectors/slack/temporal/worker.ts
@@ -6,12 +6,14 @@ import { getTemporalWorkerConnection } from "@connectors/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@connectors/lib/temporal_monitoring";
 import logger from "@connectors/logger/logger";
 
+import { QUEUE_NAME } from "./config";
+
 export async function runSlackWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();
   const worker = await Worker.create({
     workflowsPath: require.resolve("./workflows"),
     activities,
-    taskQueue: "slack-queue",
+    taskQueue: QUEUE_NAME,
     connection,
     namespace,
     interceptors: {

--- a/connectors/src/connectors/slack/temporal/workflows.ts
+++ b/connectors/src/connectors/slack/temporal/workflows.ts
@@ -260,7 +260,13 @@ export async function slackGarbageCollectorWorkflow(
   }
 }
 
-export function workspaceFullSyncWorkflowId(connectorId: string) {
+export function workspaceFullSyncWorkflowId(
+  connectorId: string,
+  fromTs: number | null
+) {
+  if (fromTs) {
+    return `slack-workspaceFullSync-${connectorId}-fromTs-${fromTs}`;
+  }
   return `slack-workspaceFullSync-${connectorId}`;
 }
 

--- a/connectors/src/connectors/slack/temporal/workflows.ts
+++ b/connectors/src/connectors/slack/temporal/workflows.ts
@@ -46,7 +46,8 @@ const {
 export async function workspaceFullSync(
   connectorId: string,
   dataSourceConfig: DataSourceConfig,
-  nangoConnectionId: string
+  nangoConnectionId: string,
+  fromTs: number | null
 ): Promise<void> {
   const slackAccessToken = await getAccessToken(nangoConnectionId);
   await fetchUsers(slackAccessToken, connectorId);
@@ -65,6 +66,7 @@ export async function workspaceFullSync(
         channel.id,
         channel.name,
         false,
+        fromTs,
       ],
     });
     i++;
@@ -81,7 +83,8 @@ export async function syncOneChannel(
   dataSourceConfig: DataSourceConfig,
   channelId: string,
   channelName: string,
-  updateSyncStatus: boolean
+  updateSyncStatus: boolean,
+  fromTs: number | null
 ) {
   console.log(`Syncing channel ${channelName} (${channelId})`);
 
@@ -96,6 +99,7 @@ export async function syncOneChannel(
       channelName,
       dataSourceConfig,
       connectorId,
+      fromTs,
       weeksSynced,
       messagesCursor
     );


### PR DESCRIPTION
This PR introduces an optional `fromTs` argument to the connectors admin client `full-resync` command to perform a partial resync all the way to an epoch:
```
./admin/cli.sh connectors full-resync --provider slack --wId <WORKSPACE_ID> --fromTs <MS_SINCE_EPOCH>
```

It currently only works for the `slack` connector.