### PR TITLE
Whitelist email addresses to let them use managed Data Sources without upgrading

### DIFF
--- a/front/lib/user_whitelist.ts
+++ b/front/lib/user_whitelist.ts
@@ -1,0 +1,28 @@
+import { Op } from "sequelize";
+
+import { Membership, User } from "./models";
+
+export async function isUserWhiteListed(workspaceId: number): Promise<boolean> {
+  const WHITE_LISTED_EMAILS = [
+    // Email account given by Google for the Google App verification process.
+    "oauthtest121@gmail.com",
+  ];
+  const u = await User.count({
+    where: {
+      email: {
+        [Op.in]: WHITE_LISTED_EMAILS,
+      },
+    },
+    include: [
+      {
+        model: Membership,
+        required: true,
+        where: {
+          workspaceId: workspaceId,
+        },
+      },
+    ],
+  });
+
+  return u > 0;
+}

--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -11,6 +11,7 @@ import {
 import { CoreAPI } from "@app/lib/core_api";
 import { ReturnedAPIErrorType } from "@app/lib/error";
 import { DataSource } from "@app/lib/models";
+import { isUserWhiteListed } from "@app/lib/user_whitelist";
 import logger from "@app/logger/logger";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import { DataSourceType } from "@app/types/data_source";
@@ -99,7 +100,10 @@ async function handler(
       const dataSourceMaxChunkSize = 256;
 
       // Enforce plan limits: managed DataSources.
-      if (!owner.plan.limits.dataSources.managed) {
+      if (
+        !owner.plan.limits.dataSources.managed &&
+        !(await isUserWhiteListed(owner.id))
+      ) {
         return apiError(req, res, {
           status_code: 401,
           api_error: {

--- a/front/pages/w/[wId]/ds/index.tsx
+++ b/front/pages/w/[wId]/ds/index.tsx
@@ -17,6 +17,7 @@ import {
   ConnectorType,
 } from "@app/lib/connectors_api";
 import { githubAuth } from "@app/lib/github_auth";
+import { isUserWhiteListed } from "@app/lib/user_whitelist";
 import { classNames, timeAgoFrom } from "@app/lib/utils";
 import logger from "@app/logger/logger";
 import { DataSourceType } from "@app/types/data_source";
@@ -177,7 +178,9 @@ export const getServerSideProps: GetServerSideProps<{
           };
         }
       ),
-      canUseManagedDataSources: owner.plan.limits.dataSources.managed,
+      canUseManagedDataSources:
+        owner.plan.limits.dataSources.managed ||
+        (await isUserWhiteListed(owner.id)),
       gaTrackingId: GA_TRACKING_ID,
       nangoConfig: {
         publicKey: NANGO_PUBLIC_KEY,


### PR DESCRIPTION
This let us whitelist the email address that google will use to signup on Dust when they test dust.tt as part of the Google verification process.