### PR TITLE
enh: do not disconnect slack if >1 slack configurations on cleanupSlackConnector

### DIFF
--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -13,6 +13,7 @@ import {
   nangoDeleteConnection,
 } from "@connectors/lib/nango_client.js";
 import { Err, Ok, type Result } from "@connectors/lib/result.js";
+import logger from "@connectors/logger/logger";
 import type { DataSourceConfig } from "@connectors/types/data_source_config.js";
 import { NangoConnectionId } from "@connectors/types/nango_connection_id";
 
@@ -161,6 +162,18 @@ export async function cleanupSlackConnector(
     if (nangoRes.isErr()) {
       return nangoRes;
     }
+    logger.info(
+      { slackTeamId: configuration.slackTeamId },
+      `Deactivated the Slack app`
+    );
+  } else {
+    logger.info(
+      {
+        slackTeamId: configuration.slackTeamId,
+        activeConfigurations: configurations.length - 1,
+      },
+      `Skipping deactivation of the Slack app`
+    );
   }
 
   await SlackMessages.destroy({

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -147,8 +147,15 @@ export async function syncChannel(
       const threadTs = parseInt(message.thread_ts, 10) * 1000;
       if (fromTs && threadTs < fromTs) {
         skip = true;
-        console.log(
-          `SKIPPING THREAD: messaage.thred_ts=${message.thread_ts} threadTs=${threadTs} fromTs=${fromTs}`
+        logger.info(
+          {
+            workspaceId: dataSourceConfig.workspaceId,
+            channelId,
+            channelName,
+            threadTs,
+            fromTs,
+          },
+          "FromTs Skipping thread"
         );
       }
       if (!skip && threadsToSync.indexOf(message.thread_ts) === -1) {
@@ -162,8 +169,17 @@ export async function syncChannel(
       const weekEndTsMs = getWeekEnd(new Date(messageTs)).getTime();
       if (fromTs && weekEndTsMs < fromTs) {
         skip = true;
-        console.log(
-          `SKIPPING NON-THREAD: messageTs=${messageTs} fromTs=${fromTs} weekEndTsMs=${weekEndTsMs} weekStartTsMs=${weekStartTsMs}`
+        logger.info(
+          {
+            workspaceId: dataSourceConfig.workspaceId,
+            channelId,
+            channelName,
+            messageTs,
+            fromTs,
+            weekEndTsMs,
+            weekStartTsMs,
+          },
+          "FromTs Skipping non-thread"
         );
       }
       if (!skip && unthreadedTimeframesToSync.indexOf(weekStartTsMs) === -1) {


### PR DESCRIPTION
We can have multiple data sources pointing to the same slack team

When we delete a managed data source we want to clean-up the slack connection to the slack team only if the managed data source is the only one for this slack team.

This PR makes sure that we clean up the connection only if the managed data source being deleted is the only one.