### PR TITLE
doc tracker fixes

### DIFF
--- a/front/post_upsert_hooks/hooks/document_tracker/index.ts
+++ b/front/post_upsert_hooks/hooks/document_tracker/index.ts
@@ -56,7 +56,7 @@ export const documentTrackerPostUpsertHook: PostUpsertHook = {
 
     const workspaceDataSourceIds = (
       await DataSource.findAll({
-        where: { workspaceId },
+        where: { workspaceId: dataSource.workspaceId },
         attributes: ["id"],
       })
     ).map((ds) => ds.id);

--- a/k8s/deployments/front-deployment.yaml
+++ b/k8s/deployments/front-deployment.yaml
@@ -34,6 +34,10 @@ spec:
                 fieldRef:
                   fieldPath: status.hostIP
 
+          volumeMounts:
+            - name: cert-volume
+              mountPath: /etc/certs
+
           resources:
             requests:
               cpu: 2000m
@@ -42,3 +46,8 @@ spec:
             limits:
               cpu: 2000m
               memory: 8Gi
+
+      volumes:
+        - name: cert-volume
+          secret:
+            secretName: temporal-front-cert


### PR DESCRIPTION
fix:
- use the right workspace ID (the pkey, not the sId)
- mount the temporal cert on front deployment