### PR TITLE
bump qdrant to 1.3.0

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -2222,9 +2222,9 @@ dependencies = [
 
 [[package]]
 name = "qdrant-client"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3e980bbbbe3895f11d788a3297d5b1946e29b1a7ef60a8a698a10a2100c8b02"
+checksum = "94dc0c49ac6893463bd32f5adfe9e503c3d83fac7ee58534e1c0e1c76842dac8"
 dependencies = [
  "anyhow",
  "futures-util",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -53,7 +53,7 @@ rustc-hash = "1.1"
 bstr = "0.2"
 base64 = "0.21"
 cloud-storage = { version = "0.11", features = ["global-client"] }
-qdrant-client = "1.2"
+qdrant-client = "1.3"
 tower-http = {version = "0.4", features = ["full"]}
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }


### PR DESCRIPTION
Bumps the qdrant library to 1.3.0
Tested against a local 1.2.0 cluster

Will then attempt an upgrade of our prod cluster to 1.3.0