### PR TITLE
UserMetadata + `sticky_path` 

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -13,6 +13,7 @@ import {
   Run,
   TrackedDocument,
   User,
+  UserMetadata,
   Workspace,
   XP1Run,
   XP1User,
@@ -20,6 +21,7 @@ import {
 
 async function main() {
   await User.sync({ alter: true });
+  await UserMetadata.sync({ alter: true });
   await Workspace.sync({ alter: true });
   await Membership.sync({ alter: true });
   await MembershipInvitation.sync({ alter: true });

--- a/front/lib/api/user.ts
+++ b/front/lib/api/user.ts
@@ -1,6 +1,12 @@
 import { UserMetadata } from "@app/lib/models";
 import { UserMetadataType, UserType } from "@app/types/user";
 
+/**
+ * Server-side interface to get user metadata.
+ * @param user UserType the user to get metadata for.
+ * @param key string the key of the metadata to get.
+ * @returns UserMetadataType | null
+ */
 export async function getUserMetadata(
   user: UserType,
   key: string
@@ -22,6 +28,12 @@ export async function getUserMetadata(
   };
 }
 
+/**
+ * Server-side interface to set user metadata.
+ * @param user UserType the user to get metadata for.
+ * @param update UserMetadata the metadata to set for the user.
+ * @returns UserMetadataType | null
+ */
 export async function setUserMetadata(
   user: UserType,
   update: UserMetadataType

--- a/front/lib/api/user.ts
+++ b/front/lib/api/user.ts
@@ -1,0 +1,47 @@
+import { UserMetadata } from "@app/lib/models";
+import { UserMetadataType, UserType } from "@app/types/user";
+
+export async function getUserMetadata(
+  user: UserType,
+  key: string
+): Promise<UserMetadataType | null> {
+  const metadata = await UserMetadata.findOne({
+    where: {
+      userId: user.id,
+      key,
+    },
+  });
+
+  if (!metadata) {
+    return null;
+  }
+
+  return {
+    key: metadata.key,
+    value: metadata.value,
+  };
+}
+
+export async function setUserMetadata(
+  user: UserType,
+  update: UserMetadataType
+): Promise<void> {
+  const metadata = await UserMetadata.findOne({
+    where: {
+      userId: user.id,
+      key: update.key,
+    },
+  });
+
+  if (!metadata) {
+    await UserMetadata.create({
+      userId: user.id,
+      key: update.key,
+      value: update.value,
+    });
+    return;
+  }
+
+  metadata.value = update.value;
+  await metadata.save();
+}

--- a/front/lib/models.ts
+++ b/front/lib/models.ts
@@ -117,7 +117,10 @@ UserMetadata.init(
     indexes: [{ fields: ["userId", "key"], unique: true }],
   }
 );
-User.hasMany(UserMetadata);
+User.hasMany(UserMetadata, {
+  foreignKey: { allowNull: false },
+  onDelete: "CASCADE",
+});
 
 export class Workspace extends Model<
   InferAttributes<Workspace>,

--- a/front/lib/models.ts
+++ b/front/lib/models.ts
@@ -74,6 +74,51 @@ User.init(
   }
 );
 
+export class UserMetadata extends Model<
+  InferAttributes<UserMetadata>,
+  InferCreationAttributes<UserMetadata>
+> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+  declare key: string;
+  declare value: string;
+  declare userId: ForeignKey<User["id"]>;
+}
+UserMetadata.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    key: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    value: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+    },
+  },
+  {
+    modelName: "user_metadata",
+    sequelize: front_sequelize,
+    indexes: [{ fields: ["userId"] }],
+  }
+);
+User.hasMany(UserMetadata);
+
 export class Workspace extends Model<
   InferAttributes<Workspace>,
   InferCreationAttributes<Workspace>

--- a/front/lib/models.ts
+++ b/front/lib/models.ts
@@ -114,7 +114,7 @@ UserMetadata.init(
   {
     modelName: "user_metadata",
     sequelize: front_sequelize,
-    indexes: [{ fields: ["userId", "key"] }],
+    indexes: [{ fields: ["userId", "key"], unique: true }],
   }
 );
 User.hasMany(UserMetadata);

--- a/front/lib/models.ts
+++ b/front/lib/models.ts
@@ -114,7 +114,7 @@ UserMetadata.init(
   {
     modelName: "user_metadata",
     sequelize: front_sequelize,
-    indexes: [{ fields: ["userId"] }],
+    indexes: [{ fields: ["userId", "key"] }],
   }
 );
 User.hasMany(UserMetadata);

--- a/front/lib/swr.ts
+++ b/front/lib/swr.ts
@@ -1,5 +1,6 @@
 import useSWR, { Fetcher } from "swr";
 
+import { GetUserMetadataResponseBody } from "@app/pages/api/user/metadata/[key]";
 import { GetDatasetsResponseBody } from "@app/pages/api/w/[wId]/apps/[aId]/datasets";
 import { GetRunsResponseBody } from "@app/pages/api/w/[wId]/apps/[aId]/runs";
 import { GetRunBlockResponseBody } from "@app/pages/api/w/[wId]/apps/[aId]/runs/[runId]/blocks/[type]/[name]";
@@ -202,5 +203,20 @@ export function useChatSessions(
     sessions: data ? data.sessions : [],
     isChatSessionsLoading: !error && !data,
     isChatSessionsError: error,
+  };
+}
+
+export function useUserMetadata(key: string) {
+  const userMetadataFetcher: Fetcher<GetUserMetadataResponseBody> = fetcher;
+
+  const { data, error } = useSWR(
+    `/api/user/metadata/${encodeURIComponent(key)}`,
+    userMetadataFetcher
+  );
+
+  return {
+    metadata: data ? data.metadata : null,
+    isMetadataLoading: !error && !data,
+    isMetadataError: error,
   };
 }

--- a/front/lib/user.ts
+++ b/front/lib/user.ts
@@ -4,11 +4,11 @@ import { GetUserMetadataResponseBody } from "@app/pages/api/user/metadata/[key]"
 import { UserMetadataType } from "@app/types/user";
 
 /**
- * Retrieves a metadata value for the current user. See also `useUserMetadata` for an SWR version of
- * it. This function never errors and is best effort.
+ * Client-side: retrieves a metadata value for the current user. See also `useUserMetadata` for an
+ * SWR version of it. This function never errors and is best effort.
  * @param key string the key of the metadata to retrieve.
  */
-export async function getUserMetadata(key: string) {
+export async function getUserMetadataFromClient(key: string) {
   try {
     const res = await fetch(`/api/user/metadata/${encodeURIComponent(key)}`);
     if (!res.ok) {
@@ -26,10 +26,11 @@ export async function getUserMetadata(key: string) {
 }
 
 /**
- * Sets the metadata for the current user. This function is best effort, and never errors.
+ * Client-side: sets the metadata for the current user. This function is best effort, and never
+ * errors.
  * @param metadata MetadataType the metadata to set for the current user.
  */
-export function setUserMetadata(metadata: UserMetadataType) {
+export function setUserMetadataFromClient(metadata: UserMetadataType) {
   void (async () => {
     try {
       const res = await fetch(

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -263,10 +263,8 @@ async function handler(
 
       const m = await getUserMetadata(u, "sticky_path");
       if (m) {
-        console.log("LOGIN STICKY PATH", m.value);
         res.redirect(m.value);
       } else {
-        console.log("LOGIN STICKY PATH NOT FOUND");
         res.redirect(`/w/${u.workspaces[0].sId}`);
       }
       return;

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -2,6 +2,7 @@ import { verify } from "jsonwebtoken";
 import { NextApiRequest, NextApiResponse } from "next";
 import { getServerSession } from "next-auth/next";
 
+import { getUserMetadata } from "@app/lib/api/user";
 import { upgradeWorkspace } from "@app/lib/api/workspace";
 import { getUserFromSession } from "@app/lib/auth";
 import { ReturnedAPIErrorType } from "@app/lib/error";
@@ -257,8 +258,15 @@ async function handler(
 
       if (targetWorkspace) {
         res.redirect(`/w/${targetWorkspace.sId}`);
+        return;
+      }
+
+      const m = await getUserMetadata(u, "sticky_path");
+      if (m) {
+        console.log("LOGIN STICKY PATH", m.value);
+        res.redirect(m.value);
       } else {
-        // TODO(spolu): persist latest workspace in session?
+        console.log("LOGIN STICKY PATH NOT FOUND");
         res.redirect(`/w/${u.workspaces[0].sId}`);
       }
       return;

--- a/front/pages/api/user/metadata/[key]/index.ts
+++ b/front/pages/api/user/metadata/[key]/index.ts
@@ -1,0 +1,92 @@
+import { NextApiRequest, NextApiResponse } from "next";
+
+import { getUserMetadata, setUserMetadata } from "@app/lib/api/user";
+import { getSession, getUserFromSession } from "@app/lib/auth";
+import { ReturnedAPIErrorType } from "@app/lib/error";
+import { apiError, withLogging } from "@app/logger/withlogging";
+import { UserMetadataType } from "@app/types/user";
+
+export type PostUserMetadataResponseBody = {
+  metadata: UserMetadataType;
+};
+export type GetUserMetadataResponseBody = {
+  metadata: UserMetadataType | null;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    | PostUserMetadataResponseBody
+    | GetUserMetadataResponseBody
+    | ReturnedAPIErrorType
+  >
+): Promise<void> {
+  const session = await getSession(req, res);
+  const user = await getUserFromSession(session);
+
+  if (!user) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "user_not_found",
+        message: "The user was not found.",
+      },
+    });
+  }
+
+  if (typeof req.query.key != "string") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "The query parameter `key` is not a string.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET":
+      const metadata = await getUserMetadata(user, req.query.key as string);
+
+      res.status(200).json({
+        metadata,
+      });
+      return;
+
+    case "POST":
+      if (!req.body || !(typeof req.body.value == "string")) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "The request body is invalid, expects { value: string }.",
+          },
+        });
+      }
+
+      await setUserMetadata(user, {
+        key: req.query.key as string,
+        value: req.body.value,
+      });
+
+      res.status(200).json({
+        metadata: {
+          key: req.query.key as string,
+          value: req.body.value,
+        },
+      });
+      return;
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message:
+            "The method passed is not supported, GET or POST is expected.",
+        },
+      });
+  }
+}
+
+export default withLogging(handler);

--- a/front/pages/index.tsx
+++ b/front/pages/index.tsx
@@ -32,10 +32,7 @@ export const getServerSideProps: GetServerSideProps<{
 
     const m = await getUserMetadata(user, "sticky_path");
     if (m) {
-      console.log("INDEX STICKY PATH", m.value);
       url = m.value;
-    } else {
-      console.log("INDEX STICKY PATH NOT FOUND");
     }
 
     if (context.query.wId) {

--- a/front/pages/index.tsx
+++ b/front/pages/index.tsx
@@ -10,6 +10,7 @@ import p5Types from "p5";
 
 import { Button, GoogleSignInButton } from "@app/components/Button";
 import { Logo } from "@app/components/Logo";
+import { getUserMetadata } from "@app/lib/api/user";
 import { getSession, getUserFromSession } from "@app/lib/auth";
 
 // Will only import `react-p5` on client-side
@@ -28,12 +29,22 @@ export const getServerSideProps: GetServerSideProps<{
   if (user && user.workspaces.length > 0) {
     // TODO(spolu): persist latest workspace in session?
     let url = `/w/${user.workspaces[0].sId}`;
+
+    const m = await getUserMetadata(user, "sticky_path");
+    if (m) {
+      console.log("INDEX STICKY PATH", m.value);
+      url = m.value;
+    } else {
+      console.log("INDEX STICKY PATH NOT FOUND");
+    }
+
     if (context.query.wId) {
       url = `/api/login?wId=${context.query.wId}`;
     }
     if (context.query.inviteToken) {
       url = `/api/login?inviteToken=${context.query.inviteToken}`;
     }
+
     return {
       redirect: {
         destination: url,

--- a/front/pages/w/[wId]/a/index.tsx
+++ b/front/pages/w/[wId]/a/index.tsx
@@ -6,6 +6,7 @@ import AppLayout from "@app/components/AppLayout";
 import { Button } from "@app/components/Button";
 import MainTab from "@app/components/profile/MainTab";
 import { getApps } from "@app/lib/api/app";
+import { setUserMetadata } from "@app/lib/api/user";
 import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
 import { classNames, communityApps } from "@app/lib/utils";
 import { AppType } from "@app/types/app";
@@ -28,11 +29,16 @@ export const getServerSideProps: GetServerSideProps<{
   );
 
   const owner = auth.workspace();
-  if (!owner) {
+  if (!owner || !user) {
     return {
       notFound: true,
     };
   }
+
+  void setUserMetadata(user, {
+    key: "sticky_path",
+    value: `/w/${context.query.wId}/a`,
+  });
 
   const readOnly = !auth.isBuilder();
 

--- a/front/pages/w/[wId]/index.tsx
+++ b/front/pages/w/[wId]/index.tsx
@@ -1,23 +1,28 @@
 import { GetServerSideProps } from "next";
 
+import { setUserMetadata } from "@app/lib/api/user";
 import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const session = await getSession(context.req, context.res);
-  await getUserFromSession(session);
+  const user = await getUserFromSession(session);
   const auth = await Authenticator.fromSession(
     session,
     context.params?.wId as string
   );
 
   const owner = auth.workspace();
-  if (!owner) {
+  if (!owner || !user) {
     return {
       notFound: true,
     };
   }
 
   if (owner.role === "user") {
+    void setUserMetadata(user, {
+      key: "sticky_path",
+      value: `/w/${context.query.wId}/u`,
+    });
     return {
       redirect: {
         destination: `/w/${context.query.wId}/u`,
@@ -25,6 +30,11 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
       },
     };
   }
+
+  void setUserMetadata(user, {
+    key: "sticky_path",
+    value: `/w/${context.query.wId}/a`,
+  });
   return {
     redirect: {
       destination: `/w/${context.query.wId}/a`,

--- a/front/pages/w/[wId]/u/index.tsx
+++ b/front/pages/w/[wId]/u/index.tsx
@@ -1,6 +1,22 @@
 import { GetServerSideProps } from "next";
 
+import { setUserMetadata } from "@app/lib/api/user";
+import { getSession, getUserFromSession } from "@app/lib/auth";
+
 export const getServerSideProps: GetServerSideProps = async (context) => {
+  const session = await getSession(context.req, context.res);
+  const user = await getUserFromSession(session);
+
+  if (!user) {
+    return {
+      notFound: true,
+    };
+  }
+
+  void setUserMetadata(user, {
+    key: "sticky_path",
+    value: `/w/${context.query.wId}/u/chat`,
+  });
   return {
     redirect: {
       destination: `/w/${context.query.wId}/u/chat`,

--- a/front/types/user.ts
+++ b/front/types/user.ts
@@ -36,3 +36,8 @@ export type UserType = {
   image: string | null;
   workspaces: WorkspaceType[];
 };
+
+export type UserMetadataType = {
+  key: string;
+  value: string;
+};


### PR DESCRIPTION
This PR introduces `UserMetadata`. It consists of a table of user metadata (mostly non-critical contextual user data that is best effort).

It introduces a server-side and client-side interface to read and write the metadata for a key for the current user.

Based on: https://www.notion.so/dust-tt/d151a5226dba4f8fbe094365da5f00d4?v=7e626ed0f3e64ea183db7930ae4678c1&p=f2ad71a1f6ae4c6e9c9e3cfcb6f0ab5f&pm=s

It also introduces a first instance of such metadata `sticky_path` which records at critical places the latest path (right now mainly when we switch workspace or switch between use and build)

r? @fontanierh 