### PR TITLE
feat: allow adding/removing tags from DS docs (core)

### DIFF
--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -1180,31 +1180,7 @@ async fn data_sources_documents_update_tags(
         None => vec![],
     };
     let add_tags_set: HashSet<String> = add_tags.iter().cloned().collect();
-    if add_tags.len() != add_tags_set.len() {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(APIResponse {
-                error: Some(APIError {
-                    code: String::from("bad_request"),
-                    message: String::from("The `add_tags` parameter contains duplicates."),
-                }),
-                response: None,
-            }),
-        );
-    }
     let remove_tags_set: HashSet<String> = remove_tags.iter().cloned().collect();
-    if remove_tags.len() != remove_tags_set.len() {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(APIResponse {
-                error: Some(APIError {
-                    code: String::from("bad_request"),
-                    message: String::from("The `remove_tags` parameter contains duplicates."),
-                }),
-                response: None,
-            }),
-        );
-    }
     if add_tags_set.intersection(&remove_tags_set).count() > 0 {
         return (
             StatusCode::BAD_REQUEST,
@@ -1212,7 +1188,7 @@ async fn data_sources_documents_update_tags(
                 error: Some(APIError {
                     code: String::from("bad_request"),
                     message: String::from(
-                        "The `add_tags` and `remove_tags` parameters contain duplicates.",
+                        "The `add_tags` and `remove_tags` lists have a non-empty intersection.",
                     ),
                 }),
                 response: None,
@@ -1246,7 +1222,12 @@ async fn data_sources_documents_update_tags(
                 }),
             ),
             Some(ds) => match ds
-                .update_tags(state.store.clone(), document_id, add_tags, remove_tags)
+                .update_tags(
+                    state.store.clone(),
+                    document_id,
+                    add_tags_set.into_iter().collect(),
+                    remove_tags_set.into_iter().collect(),
+                )
                 .await
             {
                 Err(e) => (

--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -7,14 +7,15 @@ use axum::{
         sse::{Event, KeepAlive, Sse},
         Json,
     },
-    routing::{delete, get, post},
+    routing::{delete, get, patch, post},
     Router,
 };
 use dust::{
     app,
     blocks::block::BlockType,
     data_sources::data_source::{self, SearchFilter},
-    dataset, project, run,
+    dataset, project,
+    run::{self},
     stores::store,
     stores::{postgres, sqlite},
     utils,
@@ -24,7 +25,7 @@ use hyper::http::StatusCode;
 use parking_lot::Mutex;
 use serde::Serialize;
 use serde_json::{json, Value};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::convert::Infallible;
 use std::sync::Arc;
 use tokio::sync::mpsc::unbounded_channel;
@@ -1156,6 +1157,126 @@ async fn data_sources_search(
     }
 }
 
+/// Update tags of a document in a data source.
+
+#[derive(serde::Deserialize)]
+struct DataSourcesDocumentsUpdateTagsPayload {
+    add_tags: Option<Vec<String>>,
+    remove_tags: Option<Vec<String>>,
+}
+
+async fn data_sources_documents_update_tags(
+    extract::Path((project_id, data_source_id, document_id)): extract::Path<(i64, String, String)>,
+    extract::Json(payload): extract::Json<DataSourcesDocumentsUpdateTagsPayload>,
+    extract::Extension(state): extract::Extension<Arc<APIState>>,
+) -> (StatusCode, Json<APIResponse>) {
+    let project = project::Project::new_from_id(project_id);
+    let add_tags = match payload.add_tags {
+        Some(tags) => tags,
+        None => vec![],
+    };
+    let remove_tags = match payload.remove_tags {
+        Some(tags) => tags,
+        None => vec![],
+    };
+    let add_tags_set: HashSet<String> = add_tags.iter().cloned().collect();
+    if add_tags.len() != add_tags_set.len() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(APIResponse {
+                error: Some(APIError {
+                    code: String::from("bad_request"),
+                    message: String::from("The `add_tags` parameter contains duplicates."),
+                }),
+                response: None,
+            }),
+        );
+    }
+    let remove_tags_set: HashSet<String> = remove_tags.iter().cloned().collect();
+    if remove_tags.len() != remove_tags_set.len() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(APIResponse {
+                error: Some(APIError {
+                    code: String::from("bad_request"),
+                    message: String::from("The `remove_tags` parameter contains duplicates."),
+                }),
+                response: None,
+            }),
+        );
+    }
+    if add_tags_set.intersection(&remove_tags_set).count() > 0 {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(APIResponse {
+                error: Some(APIError {
+                    code: String::from("bad_request"),
+                    message: String::from(
+                        "The `add_tags` and `remove_tags` parameters contain duplicates.",
+                    ),
+                }),
+                response: None,
+            }),
+        );
+    }
+    match state
+        .store
+        .load_data_source(&project, &data_source_id)
+        .await
+    {
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(APIResponse {
+                error: Some(APIError {
+                    code: String::from("internal_server_error"),
+                    message: format!("Failed to retrieve Data Source: {}", e),
+                }),
+                response: None,
+            }),
+        ),
+        Ok(ds) => match ds {
+            None => (
+                StatusCode::NOT_FOUND,
+                Json(APIResponse {
+                    error: Some(APIError {
+                        code: String::from("data_source_not_found"),
+                        message: format!("No Data Source found for id `{}`", data_source_id),
+                    }),
+                    response: None,
+                }),
+            ),
+            Some(ds) => match ds
+                .update_tags(state.store.clone(), document_id, add_tags, remove_tags)
+                .await
+            {
+                Err(e) => (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(APIResponse {
+                        error: Some(APIError {
+                            code: String::from("internal_server_error"),
+                            message: format!("Failed to update document tags: {}", e),
+                        }),
+                        response: None,
+                    }),
+                ),
+                Ok(_) => (
+                    StatusCode::OK,
+                    Json(APIResponse {
+                        error: None,
+                        response: Some(json!({
+                            "data_source": {
+                                "created": ds.created(),
+                                "data_source_id": ds.data_source_id(),
+                                "config": ds.config(),
+                            },
+                        })),
+                    }),
+                ),
+            },
+        },
+    }
+}
+
 /// Upsert a document in a data source.
 
 #[derive(serde::Deserialize)]
@@ -1556,6 +1677,10 @@ async fn main() -> Result<()> {
         .route(
             "/projects/:project_id/data_sources/:data_source_id/documents",
             post(data_sources_documents_upsert),
+        )
+        .route(
+            "/projects/:project_id/data_sources/:data_source_id/documents/:document_id/tags",
+            patch(data_sources_documents_update_tags),
         )
         // Provided by the data_source block.
         .route(

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -98,6 +98,14 @@ pub trait Store {
         data_source_id: &str,
         document: &Document,
     ) -> Result<()>;
+    async fn update_data_source_document_tags(
+        &self,
+        project: &Project,
+        data_source_id: &str,
+        document_id: &str,
+        add_tags: &Vec<String>,
+        remove_tags: &Vec<String>,
+    ) -> Result<Vec<String>>;
     async fn list_data_source_documents(
         &self,
         project: &Project,

--- a/front/lib/core_api.ts
+++ b/front/lib/core_api.ts
@@ -527,6 +527,38 @@ export const CoreAPI = {
     return _resultFromResponse(response);
   },
 
+  async updateDataSourceDocumentTags(
+    projectId: string,
+    dataSourceName: string,
+    payload: {
+      documentId: string;
+      add_tags?: string[];
+      remove_tags?: string[];
+    }
+  ): Promise<
+    CoreAPIResponse<{
+      data_source: CoreAPIDataSource;
+    }>
+  > {
+    const response = await fetch(
+      `${CORE_API}/projects/${projectId}/data_sources/${dataSourceName}/documents/${encodeURIComponent(
+        payload.documentId
+      )}/tags`,
+      {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          add_tags: payload.add_tags,
+          remove_tags: payload.remove_tags,
+        }),
+      }
+    );
+
+    return _resultFromResponse(response);
+  },
+
   async deleteDataSourceDocument(
     projectId: string,
     dataSourceName: string,


### PR DESCRIPTION
adds a new endpoint allowing to update a `data_sources_document`'s tags (specifying `add_tags` and `remove_tags`)

to keep in mind:
- QDrant update happens after DB update, so technically if QDrant is down we'll end up out of sync
- `add_tags` will add the tags to the existing ones, while `remove_tags` will remove those tags from the exisitng ones. There's no "replace_tags"
- I need this to implement the `__DUST_TRACK` (system) tag for the document_tracker exploration