### PR TITLE
Documentation link in app page

### DIFF
--- a/front/pages/w/[wId]/a/[aId]/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/index.tsx
@@ -398,18 +398,6 @@ export default function AppView({
                 <p className="mt-4">To get started:</p>
                 <p className="mt-2">
                   <Link
-                    href="https://docs.dust.tt"
-                    target="_blank"
-                    className="mr-2"
-                  >
-                    <Button>
-                      <ArrowRightCircleIcon className="-ml-1 mr-2 h-4 w-4" />
-                      View Documentation
-                    </Button>
-                  </Link>
-                </p>
-                <p className="mt-2">
-                  <Link
                     href="https://docs.dust.tt/quickstart"
                     target="_blank"
                     className="mr-2"

--- a/front/pages/w/[wId]/a/[aId]/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/index.tsx
@@ -350,6 +350,20 @@ export default function AppView({
                 </div>
               ) : null}
               <div className="flex-1"></div>
+              {!readOnly ? (
+                <div className="hidden flex-initial sm:block">
+                  <Link
+                    href="https://docs.dust.tt"
+                    target="_blank"
+                    className="mr-2"
+                  >
+                    <Button>
+                      <ArrowRightCircleIcon className="-ml-1 mr-2 h-4 w-4" />
+                      Documentation
+                    </Button>
+                  </Link>
+                </div>
+              ) : null}
               {!readOnly && run ? (
                 <div className="flex-initial">
                   <Deploy


### PR DESCRIPTION
Adds a Documentation button next to deploy when not on mobile to access documentation while developing
![Screenshot from 2023-07-03 15-23-40](https://github.com/dust-tt/dust/assets/15067/a81109cf-6f43-410a-9690-2f8430883570)
