### PR TITLE
feat: add support for DS docs system tags

### DIFF
--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -1312,6 +1312,7 @@ async fn data_sources_documents_upsert(
                         &payload.tags,
                         &payload.source_url,
                         &payload.text,
+                        true, // preserve system tags
                     )
                     .await
                 {
@@ -1361,7 +1362,12 @@ async fn data_sources_documents_list(
     let project = project::Project::new_from_id(project_id);
     match state
         .store
-        .list_data_source_documents(&project, &data_source_id, Some((query.limit, query.offset)))
+        .list_data_source_documents(
+            &project,
+            &data_source_id,
+            Some((query.limit, query.offset)),
+            true, // remove system tags
+        )
         .await
     {
         Err(e) => (
@@ -1422,7 +1428,7 @@ async fn data_sources_documents_retrieve(
                     response: None,
                 }),
             ),
-            Some(ds) => match ds.retrieve(state.store.clone(), &document_id).await {
+            Some(ds) => match ds.retrieve(state.store.clone(), &document_id, true).await {
                 Err(e) => (
                     StatusCode::INTERNAL_SERVER_ERROR,
                     Json(APIResponse {

--- a/core/src/consts.rs
+++ b/core/src/consts.rs
@@ -1,0 +1,1 @@
+pub const DATA_SOURCE_DOCUMENT_SYSTEM_TAG_PREFIX: &str = "__DUST";

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -396,6 +396,7 @@ impl DataSource {
         preserve_system_tags: bool,
     ) -> Result<Document> {
         // disallow preserve_system_tags=true if tags contains a string starting with the system tag prefix
+        // prevents having duplicate system tags or have users accidentally add system tags (from UI/API)
         if preserve_system_tags
             && tags
                 .iter()
@@ -409,7 +410,7 @@ impl DataSource {
 
         let store = store.clone();
 
-        let additional_tags = if preserve_system_tags {
+        let current_system_tags = if preserve_system_tags {
             let current_doc = store
                 .load_data_source_document(
                     &self.project,
@@ -434,7 +435,7 @@ impl DataSource {
 
         let tags: Vec<String> = tags
             .iter()
-            .chain(additional_tags.iter())
+            .chain(current_system_tags.iter())
             .map(|tag| tag.to_string())
             .collect();
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -56,3 +56,5 @@ pub mod blocks {
 pub mod deno {
     pub mod script;
 }
+
+pub mod consts;

--- a/core/src/stores/sqlite.rs
+++ b/core/src/stores/sqlite.rs
@@ -1,4 +1,5 @@
 use crate::blocks::block::BlockType;
+use crate::consts::DATA_SOURCE_DOCUMENT_SYSTEM_TAG_PREFIX;
 use crate::data_sources::data_source::{DataSource, DataSourceConfig, Document};
 use crate::dataset::Dataset;
 use crate::http::request::{HttpRequest, HttpResponse};
@@ -1271,6 +1272,7 @@ impl Store for SQLiteStore {
         project: &Project,
         data_source_id: &str,
         limit_offset: Option<(usize, usize)>,
+        remove_system_tags: bool,
     ) -> Result<(Vec<Document>, usize)> {
         let project_id = project.project_id();
         let data_source_id = data_source_id.to_string();
@@ -1327,6 +1329,13 @@ impl Store for SQLiteStore {
                 let chunk_count: u64 = row.get(8)?;
 
                 let tags: Vec<String> = serde_json::from_str(&tags_data)?;
+                let tags = if remove_system_tags {
+                    tags.into_iter()
+                        .filter(|t| !t.starts_with(DATA_SOURCE_DOCUMENT_SYSTEM_TAG_PREFIX))
+                        .collect()
+                } else {
+                    tags
+                };
 
                 documents.push(Document {
                     data_source_id: data_source_id.clone(),

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -111,6 +111,7 @@ pub trait Store {
         project: &Project,
         data_source_id: &str,
         limit_offset: Option<(usize, usize)>,
+        remove_system_tags: bool,
     ) -> Result<(Vec<Document>, usize)>;
     async fn delete_data_source_document(
         &self,


### PR DESCRIPTION
- add the concept of "system tags"
- "system tags" are transparent to users, excluded from core API responses
- "upsert" by default does not modify system tags
- "system tags" are prefixed by `__DUST`