### PR TITLE
google drive: message when no shared drive

### DIFF
--- a/front/components/GoogleDriveFoldersPickerModal.tsx
+++ b/front/components/GoogleDriveFoldersPickerModal.tsx
@@ -107,7 +107,7 @@ export default function GoogleDriveFoldersPickerModal(props: {
               leaveFrom="opacity-100 translate-y-0 sm:scale-100"
               leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
             >
-              <Dialog.Panel className="sm:max-w-3/4 relative w-1/2 transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:p-6">
+              <Dialog.Panel className="relative max-w-2xl transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:p-6 lg:w-1/2">
                 <div>
                   <div className="mx-auto flex h-12 w-12 items-center justify-center ">
                     <img src="/static/google_drive_64x64.png" />
@@ -138,9 +138,10 @@ export default function GoogleDriveFoldersPickerModal(props: {
                       </div>
                     )}
                     {!isLoading && folders.length === 0 && (
-                      <div className="mt-2 flex h-[500px] items-center justify-center overflow-y-auto rounded border-2 border-x-gray-100 text-gray-500">
+                      <div className="mt-2 flex h-[500px] items-center justify-center overflow-y-auto rounded border-2 border-x-gray-100 px-4 text-gray-500">
                         <div>
-                          Only shared drives are supported at the moment.
+                          No folder available for synchronization (only shared
+                          drives are supported at the moment)
                         </div>
                       </div>
                     )}

--- a/front/components/GoogleDriveFoldersPickerModal.tsx
+++ b/front/components/GoogleDriveFoldersPickerModal.tsx
@@ -121,12 +121,12 @@ export default function GoogleDriveFoldersPickerModal(props: {
                     </Dialog.Title>
 
                     {isLoading && (
-                      <div className="mt-2 flex h-[500px] items-center  justify-center overflow-y-auto	rounded border-2 border-x-gray-100">
+                      <div className="mt-2 flex h-[500px] items-center justify-center overflow-y-auto rounded border-2 border-x-gray-100 text-gray-500">
                         <div>Loading...</div>
                       </div>
                     )}
                     {!isLoading && folders.length > 0 && (
-                      <div className="mt-2  h-[500px] overflow-y-auto	rounded border-2 border-x-gray-100">
+                      <div className="mt-2 h-[500px] overflow-y-auto rounded border-2 border-x-gray-100">
                         <GoogleDriveFoldersPicker
                           folders={initialFolders}
                           owner={props.owner}
@@ -135,6 +135,13 @@ export default function GoogleDriveFoldersPickerModal(props: {
                             setSelectedFoldersToSave(folders);
                           }}
                         />
+                      </div>
+                    )}
+                    {!isLoading && folders.length === 0 && (
+                      <div className="mt-2 flex h-[500px] items-center justify-center overflow-y-auto rounded border-2 border-x-gray-100 text-gray-500">
+                        <div>
+                          Only shared drives are supported at the moment.
+                        </div>
                       </div>
                     )}
                   </div>
@@ -157,6 +164,7 @@ export default function GoogleDriveFoldersPickerModal(props: {
                         }
                         props.setOpen(false);
                       }}
+                      disabled={!selectedFoldersToSave}
                     >
                       Save
                     </ActionButton>


### PR DESCRIPTION
Adds a message (and disable the Save button (only cancel activated)) when there is no shared drive available on the connected Google drive account
![Screenshot from 2023-07-03 17-03-32](https://github.com/dust-tt/dust/assets/15067/1ae6cbb6-fb8a-4229-baeb-18f28bb0afc2)
![Screenshot from 2023-07-03 17-03-37](https://github.com/dust-tt/dust/assets/15067/bb5d7ab1-4aa5-4ae0-b794-bd8e1f18888e)


cc @lasryaric 