### PR TITLE
fix: use the managed DS suffix in the nango connection ID

### DIFF
--- a/front/pages/w/[wId]/ds/index.tsx
+++ b/front/pages/w/[wId]/ds/index.tsx
@@ -284,8 +284,12 @@ export default function DataSourcesView({
         const nango = new Nango({ publicKey: nangoConfig.publicKey });
         const {
           connectionId: nangoConnectionId,
-        }: { providerConfigKey: string; connectionId: string } =
-          await nango.auth(nangoConnectorId, `${provider}-${owner.sId}`);
+        }: { providerConfigKey: string; connectionId: string } = suffix
+          ? await nango.auth(
+              nangoConnectorId,
+              `${provider}-${owner.sId}-${suffix}`
+            )
+          : await nango.auth(nangoConnectorId, `${provider}-${owner.sId}`);
         connectionId = nangoConnectionId;
       } else if (provider === "github") {
         const installationId = await githubAuth(githubAppUrl);


### PR DESCRIPTION
Otherwise, it mixes up the nangos and the DS get mixed up