### PR TITLE
Slack empty replies: better error message

### DIFF
--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -426,6 +426,12 @@ export async function syncThread(
         cursor: next_cursor,
         limit: 100,
       });
+    // Despite the typing, in practice `replies` can be undefined at times.
+    if (!replies) {
+      throw new Error(
+        "Received undefined replies from Slack API in syncThread"
+      );
+    }
     if (replies.error) {
       throw new Error(replies.error);
     }

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -429,7 +429,7 @@ export async function syncThread(
     // Despite the typing, in practice `replies` can be undefined at times.
     if (!replies) {
       throw new Error(
-        "Received undefined replies from Slack API in syncThread"
+        "Received unexpected undefined replies from Slack API in syncThread (generally transient)"
       );
     }
     if (replies.error) {


### PR DESCRIPTION
Context: https://dust4ai.slack.com/archives/C050SM8NSPK/p1688409395649149

Sometime, the slack library returns an undefined replies object here (despite their typing): https://github.com/dust-tt/dust/blob/main/connectors/src/connectors/slack/temporal/activities.ts#L429

This PR tests for that and produce a more human understandable error. This error is unhandled so it will trigger a monitor if it appears transiently for long enough as is generally the case, but at least it'll be easier to understand.