### PR TITLE
Handle error Slack conversation info empty response

### DIFF
--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -239,6 +239,12 @@ export async function getMessagesForChannel(
     limit: limit,
     cursor: nextCursor,
   });
+  // Despite the typing, in practice `conversations.history` can be undefined at times.
+  if (!c) {
+    throw new Error(
+      "Received unexpected conversations.history replies from Slack API in getMessagesForChannel (generally transient)"
+    );
+  }
   if (c.error) {
     throw new Error(
       `Failed getting messages for channel ${channelId}: ${c.error}`

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -96,7 +96,7 @@ export async function getChannel(
   // Despite the typing, in practice `conversations.info` can be undefined at times.
   if (!res) {
     throw new Error(
-        "Received unexpected conversations.info replies from Slack API in getChannel (generally transient)"
+      "Received unexpected conversations.info replies from Slack API in getChannel (generally transient)"
     );
   }
   if (res.error) {

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -93,6 +93,12 @@ export async function getChannel(
 ): Promise<Channel> {
   const client = getSlackClient(slackAccessToken);
   const res = await client.conversations.info({ channel: channelId });
+  // Despite the typing, in practice `conversations.info` can be undefined at times.
+  if (!res) {
+    throw new Error(
+        "Received unexpected conversations.info replies from Slack API in getChannel (generally transient)"
+    );
+  }
   if (res.error) {
     throw new Error(res.error);
   }


### PR DESCRIPTION
Handling this error: https://app.datadoghq.eu/logs?query=%22Unhandled%20activity%20error%22%20&cols=host%2Cservice&event=AgAAAYkgxH4FkbB5iAAAAAAAAAAYAAAAAEFZa2d4SWJaQUFCTm4wT1BhM2hvTndBTwAAACQAAAAAMDE4OTIwYzQtYjBlZi00NDBjLTg4MTktODRlZDkwMjQ3MGE0&index=%2A&messageDisplay=inline&stream_sort=desc&viz=stream&from_ts=1688471082841&to_ts=1688471982841&live=true

```
TypeError: Cannot read properties of undefined (reading 'error')
    at Activity.getChannel (/app/src/connectors/slack/temporal/activities.ts:96:11)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at Activity.execute (/app/node_modules/@temporalio/worker/lib/activity.js:37:16)
    at ActivityInboundLogInterceptor.execute (/app/src/lib/temporal_monitoring.ts:55:14)
    at <anonymous> (/app/node_modules/@temporalio/worker/lib/activity.js:43:32)
    at <anonymous> (/app/node_modules/@temporalio/worker/lib/worker.js:624:34)
    at <anonymous> (/app/node_modules/@temporalio/worker/lib/tracing.js:65:20)
    at <anonymous> (/app/node_modules/@temporalio/worker/lib/worker.js:620:24)
```


And this one: 

```
TypeError: Cannot read properties of undefined (reading 'error')
    at getMessagesForChannel (/app/src/connectors/slack/temporal/activities.ts:236:9)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at Activity.syncChannel (/app/src/connectors/slack/temporal/activities.ts:123:20)
    at Activity.execute (/app/node_modules/@temporalio/worker/lib/activity.js:37:16)
    at ActivityInboundLogInterceptor.execute (/app/src/lib/temporal_monitoring.ts:55:14)
    at <anonymous> (/app/node_modules/@temporalio/worker/lib/activity.js:43:32)
    at <anonymous> (/app/node_modules/@temporalio/worker/lib/worker.js:624:34)
    at <anonymous> (/app/node_modules/@temporalio/worker/lib/tracing.js:65:20)
    at <anonymous> (/app/node_modules/@temporalio/worker/lib/worker.js:620:24)
```