### PR TITLE
Chat: no feedback if readOnly

### DIFF
--- a/front/pages/w/[wId]/u/chat/[cId]/index.tsx
+++ b/front/pages/w/[wId]/u/chat/[cId]/index.tsx
@@ -1152,6 +1152,7 @@ export default function AppChat({
                                   isLatestRetrieval={isLatest("retrieval", i)}
                                   readOnly={chatSession.readOnly}
                                   feedback={
+                                    !chatSession.readOnly &&
                                     m.role === "assistant" && {
                                       handler: handleFeedback,
                                       hover: response


### PR DESCRIPTION
Do not allow non owner of a chat to share feedback
Source Slack thread: https://dust4ai.slack.com/archives/C050A0S2Z7F/p1688479468569479