### PR TITLE
Move all data sources to `dustManagedCredentials`

### DIFF
--- a/front/pages/api/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
@@ -1,11 +1,10 @@
 import { NextApiRequest, NextApiResponse } from "next";
 
-import { credentialsFromProviders } from "@app/lib/api/credentials";
+import { dustManagedCredentials } from "@app/lib/api/credentials";
 import { getDataSource } from "@app/lib/api/data_sources";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { CoreAPI } from "@app/lib/core_api";
 import { ReturnedAPIErrorType } from "@app/lib/error";
-import { Provider } from "@app/lib/models";
 import { validateUrl } from "@app/lib/utils";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import { DocumentType } from "@app/types/document";
@@ -69,14 +68,6 @@ async function handler(
           },
         });
       }
-
-      const [providers] = await Promise.all([
-        Provider.findAll({
-          where: {
-            workspaceId: owner.id,
-          },
-        }),
-      ]);
 
       if (!req.body || !(typeof req.body.text == "string")) {
         return apiError(req, res, {
@@ -182,7 +173,8 @@ async function handler(
         });
       }
 
-      const credentials = credentialsFromProviders(providers);
+      // Dust managed credentials: all data sources.
+      const credentials = dustManagedCredentials();
 
       // Create document with the Dust internal API.
       const data = await CoreAPI.upsertDataSourceDocument(

--- a/front/pages/api/w/[wId]/data_sources/[name]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/index.ts
@@ -93,6 +93,7 @@ async function handler(
       if (
         !req.body ||
         !(typeof req.body.description == "string") ||
+        !(typeof req.body.userUpsertable == "boolean") ||
         !["public", "private"].includes(req.body.visibility)
       ) {
         return apiError(req, res, {
@@ -110,6 +111,7 @@ async function handler(
       const ds = await dataSource.update({
         description,
         visibility: req.body.visibility,
+        userUpsertable: req.body.userUpsertable,
       });
 
       return res.status(200).json({

--- a/front/pages/api/w/[wId]/data_sources/[name]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/index.ts
@@ -90,6 +90,16 @@ async function handler(
         });
       }
 
+      if (dataSource.connectorId) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Managed data sources cannot be updated.",
+          },
+        });
+      }
+
       if (
         !req.body ||
         !(typeof req.body.description == "string") ||
@@ -135,6 +145,16 @@ async function handler(
             type: "data_source_auth_error",
             message:
               "Only the users that are `builders` for the current workspace can delete a Data Source.",
+          },
+        });
+      }
+
+      if (dataSource.connectorId) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Managed data sources cannot be deleted.",
           },
         });
       }

--- a/front/pages/api/w/[wId]/data_sources/[name]/search.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/search.ts
@@ -1,17 +1,12 @@
 import { JSONSchemaType } from "ajv";
 import { NextApiRequest, NextApiResponse } from "next";
 
-import {
-  credentialsFromProviders,
-  dustManagedCredentials,
-} from "@app/lib/api/credentials";
+import { dustManagedCredentials } from "@app/lib/api/credentials";
 import { getDataSource } from "@app/lib/api/data_sources";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { CoreAPI } from "@app/lib/core_api";
 import { parse_payload } from "@app/lib/http_utils";
-import { Provider } from "@app/lib/models";
 import { DocumentType } from "@app/types/document";
-import { CredentialsType } from "@app/types/provider";
 
 export type DatasourceSearchQuery = {
   query: string;
@@ -83,18 +78,9 @@ export default async function handler(
       }
       const requestPayload = req.query;
 
-      let credentials: CredentialsType | null = null;
-      if (dataSource.connectorId) {
-        // Dust managed credentials: managed data source.
-        credentials = dustManagedCredentials();
-      } else {
-        const providers = await Provider.findAll({
-          where: {
-            workspaceId: owner.id,
-          },
-        });
-        credentials = credentialsFromProviders(providers);
-      }
+      // Dust managed credentials: all data sources.
+      const credentials = dustManagedCredentials();
+
       const searchQueryRes = parse_payload(searchQuerySchema, requestPayload);
 
       if (searchQueryRes.isErr()) {

--- a/front/pages/w/[wId]/ds/[name]/settings.tsx
+++ b/front/pages/w/[wId]/ds/[name]/settings.tsx
@@ -171,6 +171,9 @@ function StandardDataSourceSettings({
   const [dataSourceVisibility, setDataSourceVisibility] = useState(
     dataSource.visibility
   );
+  const [userUpsertable, setUserUpsertable] = useState(
+    dataSource.userUpsertable
+  );
 
   const [isDeleting, setIsDeleting] = useState(false);
   const [isUpdating, setIsUpdating] = useState(false);
@@ -214,6 +217,7 @@ function StandardDataSourceSettings({
         body: JSON.stringify({
           description: dataSourceDescription,
           visibility: dataSourceVisibility,
+          userUpsertable: userUpsertable,
         }),
       }
     );
@@ -408,6 +412,30 @@ function StandardDataSourceSettings({
                       readOnly={true}
                     />
                   </div>
+                </div>
+              </div>
+              <div className="mt-4">
+                <div className="flex justify-between">
+                  <label
+                    htmlFor="upsertable"
+                    className="block text-sm font-medium text-gray-700"
+                  >
+                    Upload Rights
+                  </label>
+                </div>
+                <div className="mt-2 flex items-center">
+                  <input
+                    id="dataSourceUpsertable"
+                    name="upsertable"
+                    type="checkbox"
+                    className="h-4 w-4 cursor-pointer border-gray-300 text-violet-600 focus:ring-violet-500"
+                    checked={userUpsertable}
+                    onChange={(e) => setUserUpsertable(e.target.checked)}
+                  />
+                  <p className="ml-3 block text-sm text-sm font-normal text-gray-500">
+                    Users (non-builders) of your workspace can upload documents
+                    to the data source
+                  </p>
                 </div>
               </div>
             </div>

--- a/front/pages/w/[wId]/ds/new.tsx
+++ b/front/pages/w/[wId]/ds/new.tsx
@@ -4,7 +4,6 @@ import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 
 import MainTab from "@app/components/admin/MainTab";
-import ModelPicker from "@app/components/app/ModelPicker";
 import AppLayout from "@app/components/AppLayout";
 import { Button } from "@app/components/Button";
 import { getDataSources } from "@app/lib/api/data_sources";
@@ -70,12 +69,6 @@ export default function DataSourceNew({
   const [dataSourceVisibility, setDataSourceVisibility] = useState(
     "public" as DataSourceVisibility
   );
-  const [dataSourceModel, setDataSourceModel] = useState({
-    provider_id: "",
-    model_id: "",
-  });
-  const [dataSourceMaxChunkSize, setDataSourceMaxChunkSize] = useState(256);
-  const [userUpsertable, setUserUpsertable] = useState(false);
 
   const formValidation = () => {
     let exists = false;
@@ -108,12 +101,8 @@ export default function DataSourceNew({
   };
 
   useEffect(() => {
-    setDisabled(
-      !formValidation() ||
-        !dataSourceModel.provider_id ||
-        !dataSourceModel.model_id
-    );
-  }, [dataSourceName, dataSourceModel]);
+    setDisabled(!formValidation());
+  }, [dataSourceName]);
 
   const router = useRouter();
 
@@ -128,10 +117,6 @@ export default function DataSourceNew({
         name: dataSourceName,
         description: dataSourceDescription,
         visibility: dataSourceVisibility,
-        provider_id: dataSourceModel.provider_id,
-        model_id: dataSourceModel.model_id,
-        max_chunk_size: `${dataSourceMaxChunkSize}`,
-        userUpsertable: userUpsertable,
       }),
     });
     if (res.ok) {
@@ -291,86 +276,6 @@ export default function DataSourceNew({
                           </div>
                         </div>
                       </fieldset>
-                    </div>
-                  </div>
-                </div>
-
-                <div>
-                  <div className="mt-6 grid grid-cols-1 gap-x-4 gap-y-6 sm:grid-cols-6">
-                    <div className="sm:col-span-6">
-                      <label
-                        htmlFor="embedder"
-                        className="block text-sm font-medium text-gray-700"
-                      >
-                        Embedder
-                      </label>
-                      <div className="mt-1 flex">
-                        <ModelPicker
-                          owner={owner}
-                          readOnly={false}
-                          model={dataSourceModel}
-                          onModelUpdate={(model) => {
-                            setDataSourceModel(model);
-                          }}
-                          chatOnly={false}
-                          embedOnly={true}
-                        />
-                      </div>
-                      <p className="mt-2 text-sm text-gray-500">
-                        The embedder is the model that will be used by the data
-                        source to embed documents' chunks and search queries.
-                      </p>
-                    </div>
-
-                    <div className="sm:col-span-6">
-                      <div className="flex justify-between">
-                        <label
-                          htmlFor="dataSourceDescription"
-                          className="block text-sm font-medium text-gray-700"
-                        >
-                          Max Chunk Size
-                        </label>
-                      </div>
-                      <div className="mt-1 flex w-32 rounded-md shadow-sm">
-                        <input
-                          type="number"
-                          name="max_chunk_size"
-                          id="dataSourceMaxChunkSize"
-                          className="block w-full min-w-0 flex-1 rounded-md border-gray-300 text-sm focus:border-violet-500 focus:ring-violet-500"
-                          value={dataSourceMaxChunkSize}
-                          onChange={(e) =>
-                            setDataSourceMaxChunkSize(parseInt(e.target.value))
-                          }
-                        />
-                      </div>
-                      <p className="mt-2 text-sm text-gray-500">
-                        The (maximum) number of tokens used to chunk the
-                        documents. 256 tokens is recommended.
-                      </p>
-                    </div>
-                  </div>
-                  <div className="mt-4">
-                    <div className="flex justify-between">
-                      <label
-                        htmlFor="upsertable"
-                        className="block text-sm font-medium text-gray-700"
-                      >
-                        Upload Rights
-                      </label>
-                    </div>
-                    <div className="mt-2 flex items-center">
-                      <input
-                        id="dataSourceUpsertable"
-                        name="upsertable"
-                        type="checkbox"
-                        className="h-4 w-4 cursor-pointer border-gray-300 text-violet-600 focus:ring-violet-500"
-                        checked={userUpsertable}
-                        onChange={(e) => setUserUpsertable(e.target.checked)}
-                      />
-                      <p className="ml-3 block text-sm text-sm font-normal text-gray-500">
-                        Users (non-builders) of your workspace can upload
-                        documents to the data source
-                      </p>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
This moves all data sources to using our own credentials instead of the users' credentials enabling anybody to create and play with a data source without having to add OpenAI as a provider.

This should greatly improve the single-player experience of "playing with Dust" with my own docs without using managed data sources.

If a data source is used from a developer App then we will use the developer credentials and would error if they haven't set their OpenAI credentials.

Last step before being able to merge, introspect all data sources and check the ones that are not based on OpenAI, but this is otherwise ready for review