### PR TITLE
Fix: Trim invite email

### DIFF
--- a/front/pages/w/[wId]/workspace/index.tsx
+++ b/front/pages/w/[wId]/workspace/index.tsx
@@ -340,7 +340,7 @@ export default function WorkspaceAdmin({
                         value={inviteEmail || ""}
                         onChange={(e) => {
                           if (e.target.value.length > 0) {
-                            setInviteEmail(e.target.value);
+                            setInviteEmail(e.target.value.trim());
                           } else {
                             setInviteEmail("");
                           }


### PR DESCRIPTION
Source: https://dust4ai.slack.com/archives/C0525Q93AEL/p1688555163864729

When you copy-paste an email with a space, the button to invite is disabled as we consider the email invalid. 
This PR simply trims the input.