### PR TITLE
inclusion/exclusion of docs and style improvements for gens

### DIFF
--- a/front/pages/w/[wId]/u/gens/index.tsx
+++ b/front/pages/w/[wId]/u/gens/index.tsx
@@ -1,11 +1,11 @@
 import { Dialog, Transition } from "@headlessui/react";
 import { PlusIcon, TrashIcon } from "@heroicons/react/20/solid";
 import {
+  BookmarkIcon,
   DocumentDuplicateIcon,
   MagnifyingGlassIcon,
   PencilIcon,
   SparklesIcon,
-  BookmarkIcon,
 } from "@heroicons/react/24/outline";
 import { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import { Fragment, useEffect, useRef, useState } from "react";
@@ -880,7 +880,7 @@ export default function AppGens({
       // TODO: make this more efficient by just moving that doc around
       // we can also re-rank a document that was pinned
       // TODO: should make this cleaner
-      let index = retrieved.findIndex((d) => d.documentId == documentId);
+      const index = retrieved.findIndex((d) => d.documentId == documentId);
       retrieved[index].llm_score = score;
       retrieved[index].pinned = false;
       retrieved.sort((a, b) => {

--- a/front/pages/w/[wId]/u/gens/index.tsx
+++ b/front/pages/w/[wId]/u/gens/index.tsx
@@ -598,7 +598,7 @@ export function TemplatesView({
   };
 
   return (
-    <div className="w-48 flex-initial flex-shrink-0 px-2">
+    <div className="flex-initial flex-shrink-0 px-2">
       <div>
         <div className="justify-items flex space-x-2"></div>
         <Transition.Root show={formExpanded} as={Fragment}>
@@ -716,13 +716,13 @@ export function TemplatesView({
           </Dialog>
         </Transition.Root>
 
-        <div className="mt-2 flex flex-col space-y-2">
+        <div className="mt-2 flex justify-start items-center space-x-2">
           {templates.map((t, i) => {
             return (
               // round circle div with given color
               <div
                 key={i}
-                className="align-items group ml-1 mt-2 flex items-center space-x-2"
+                className="align-items group flex items-center space-x-2"
                 onClick={() => {
                   setSelectedTemplate(i);
                   onTemplateSelect(t);
@@ -734,7 +734,7 @@ export function TemplatesView({
                   className={classNames(
                     "rounded py-1",
                     "text-xs font-bold text-gray-700",
-                    "h-5 w-5 rounded-full",
+                    "h-5 w-5 rounded-full flex-shrink-0",
                     t.color,
                     // make opacity lower for unselected
                     selectedTemplate === i ? "opacity-100" : "opacity-30"
@@ -742,18 +742,18 @@ export function TemplatesView({
                 />
                 {hover === i && (
                   <>
-                    <span className="text-xs text-gray-600">
+                    <span className="text-xs text-gray-600 flex-shrink-0">
                       <span className="font-semibold">{t.name}</span>
                     </span>
 
-                    <PencilIcon
+                    <PencilIcon 
                       onClick={() => {
                         setSelectedTemplate(i);
                         setNewTemplateInstructions(t.instructions);
                         setNewTemplateTitle(t.name);
                         setFormExpanded(true);
                       }}
-                      className="h-3 w-3"
+                      className="h-3 w-3 flex-shrink-0"
                     />
                   </>
                 )}
@@ -1077,6 +1077,9 @@ export default function AppGens({
           <div className="mx-auto mt-8 max-w-4xl divide-y px-6">
             <div className="flex flex-col">
               <div className="flex flex-col space-y-3 text-sm font-medium leading-8 text-gray-700">
+                <TemplatesView
+                  onTemplateSelect={(t) => (template.current = t)}
+                />
                 <div className="w-70 flex font-normal">
                   <TextareaAutosize
                     minRows={8}
@@ -1098,9 +1101,6 @@ export default function AppGens({
                     }}
                   />
 
-                  <TemplatesView
-                    onTemplateSelect={(t) => (template.current = t)}
-                  />
                 </div>
                 <div className="flex-rows flex space-x-2">
                   <div className="flex flex-initial">

--- a/front/pages/w/[wId]/u/gens/index.tsx
+++ b/front/pages/w/[wId]/u/gens/index.tsx
@@ -757,7 +757,7 @@ export function TemplatesView({
           </Dialog>
         </Transition.Root>
 
-        <div className="mt-2 flex justify-start items-center space-x-2">
+        <div className="mt-2 flex items-center justify-start space-x-2">
           {templates.map((t, i) => {
             return (
               // round circle div with given color
@@ -775,7 +775,7 @@ export function TemplatesView({
                   className={classNames(
                     "rounded py-1",
                     "text-xs font-bold text-gray-700",
-                    "h-5 w-5 rounded-full flex-shrink-0",
+                    "h-5 w-5 flex-shrink-0 rounded-full",
                     t.color,
                     // make opacity lower for unselected
                     selectedTemplate === i ? "opacity-100" : "opacity-30"
@@ -783,11 +783,11 @@ export function TemplatesView({
                 />
                 {hover === i && (
                   <>
-                    <span className="text-xs text-gray-600 flex-shrink-0">
+                    <span className="flex-shrink-0 text-xs text-gray-600">
                       <span className="font-semibold">{t.name}</span>
                     </span>
 
-                    <PencilIcon 
+                    <PencilIcon
                       onClick={() => {
                         setSelectedTemplate(i);
                         setNewTemplateInstructions(t.instructions);
@@ -1177,7 +1177,6 @@ export default function AppGens({
                       setGenCursorPosition(e.target.selectionStart);
                     }}
                   />
-
                 </div>
                 <div className="flex-rows flex space-x-2">
                   <div className="flex flex-initial">

--- a/front/types/gens.ts
+++ b/front/types/gens.ts
@@ -12,4 +12,5 @@ export type GensRetrievedDocumentType = {
     score: number;
   }[];
   tokenCount: number;
+  pinned: boolean | null;
 };


### PR DESCRIPTION
- Adds the ability to pin documents persistently across Gens searches, using an onPin event and a `pinned` attribute
- puts the template view above the textarea
- unresolved: I need to explain somewhere what the templates actually are