### PR TITLE
When a feedback is chosen (e.g. +), the other stays visible too

### DIFF
--- a/front/components/use/MessageFeedback.tsx
+++ b/front/components/use/MessageFeedback.tsx
@@ -35,9 +35,7 @@ export function MessageFeedback({
           message.feedback === "positive"
             ? "text-violet-800"
             : "hover:text-violet-800",
-          message.feedback !== "positive" && hover
-            ? "invisible group-hover:visible"
-            : ""
+          !message.feedback && hover ? "invisible group-hover:visible" : ""
         )}
       >
         {message.feedback === "positive" ? (
@@ -53,9 +51,7 @@ export function MessageFeedback({
           message.feedback === "negative"
             ? "text-violet-800"
             : "hover:text-violet-800",
-          message.feedback !== "negative" && hover
-            ? "invisible group-hover:visible"
-            : ""
+          !message.feedback && hover ? "invisible group-hover:visible" : ""
         )}
       >
         {message.feedback === "negative" ? (


### PR DESCRIPTION
When a feedback is chosen (e.g. +), the other stays visible too #763
![image](https://github.com/dust-tt/dust/assets/5437393/fac918ce-a725-4190-8697-3afa36a3b497)
