### PR TITLE
reduce notion GC skip threshold

### DIFF
--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -476,7 +476,7 @@ export async function garbageCollectActivity(
       if (
         potentialNotionError.code === "internal_server_error" &&
         potentialNotionError.status === 500 &&
-        Context.current().info.attempt > 20
+        Context.current().info.attempt >= 15
       ) {
         localLogger.error(
           {


### PR DESCRIPTION
- We get a DD alert when an activity failed 15 times
- We have a condition to give up on notion errors at the 21st attempt when running the garbage collection process
- This PR reduces the skip threshold to 15, so we don't get a DD alert