### PR TITLE
Rationalize run action streamed

### DIFF
--- a/front/lib/actions/client.ts
+++ b/front/lib/actions/client.ts
@@ -1,0 +1,35 @@
+import { WorkspaceType } from "@app/types/user";
+
+import { DustAppConfigType, processStreamedRunResponse } from "../dust_api";
+
+/**
+ * This function is intended to be used by the client directly. It proxies through the local
+ * `front` instance to execute an action while injecting the system API key of the owner. This is
+ * required as we can't push the system API key to the client to talk direclty to Dust production.
+ *
+ * See /front/pages/api/w/[wId]/use/actions/[action]/index.ts
+ *
+ * @param owner WorkspaceType the owner workspace running the action
+ * @param action string the action name
+ * @param config DustAppConfigType the action config
+ * @param inputs any[] the action inputs
+ */
+export async function runActionStreamed(
+  owner: WorkspaceType,
+  action: string,
+  config: DustAppConfigType,
+  inputs: any[]
+) {
+  const res = await fetch(`/api/w/${owner.sId}/use/actions/${action}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      config: config,
+      inputs: inputs,
+    }),
+  });
+
+  return processStreamedRunResponse(res);
+}

--- a/front/lib/actions/client.ts
+++ b/front/lib/actions/client.ts
@@ -1,6 +1,8 @@
+import {
+  DustAppConfigType,
+  processStreamedRunResponse,
+} from "@app/lib/dust_api";
 import { WorkspaceType } from "@app/types/user";
-
-import { DustAppConfigType, processStreamedRunResponse } from "../dust_api";
 
 /**
  * This function is intended to be used by the client directly. It proxies through the local

--- a/front/lib/actions/registry.ts
+++ b/front/lib/actions/registry.ts
@@ -1,4 +1,4 @@
-import { DustAppType } from "@app/lib/dust_api";
+import { DustAppType } from "../dust_api";
 
 const PRODUCTION_DUST_APPS_WORKSPACE_ID = "78bda07b39";
 

--- a/front/lib/actions/registry.ts
+++ b/front/lib/actions/registry.ts
@@ -1,4 +1,4 @@
-import { DustAppType } from "../dust_api";
+import { DustAppType } from "@app/lib/dust_api";
 
 const PRODUCTION_DUST_APPS_WORKSPACE_ID = "78bda07b39";
 

--- a/front/lib/actions/server.ts
+++ b/front/lib/actions/server.ts
@@ -1,0 +1,99 @@
+import logger from "@app/logger/logger";
+import { statsDClient } from "@app/logger/withlogging";
+import { WorkspaceType } from "@app/types/user";
+
+import { prodAPICredentialsForOwner } from "../auth";
+import { DustAPI, DustAppConfigType } from "../dust_api";
+import { Err, Ok } from "../result";
+import { DustProdActionRegistry } from "./registry";
+
+/**
+ * This function is intended to be used server side to run an action. Logs and monitors the
+ * execution and actions as well as any error happening while running the action.
+ * @param owner WorkspaceType
+ * @param actionName string Action name as per DustProdActionRegistry
+ * @param config DustAppConfigType
+ * @param inputs Array<any> the action inputs
+ * @returns an eventStream and a dustRunId promise
+ */
+export async function runActionStreamed(
+  owner: WorkspaceType,
+  actionName: string,
+  config: DustAppConfigType,
+  inputs: Array<any>
+) {
+  if (!DustProdActionRegistry[actionName]) {
+    return new Err({
+      type: "action_unknown_error",
+      message: `Unknown action: ${actionName}`,
+    });
+  }
+
+  const action = DustProdActionRegistry[actionName];
+
+  const loggerArgs = {
+    workspace: {
+      sId: owner.sId,
+      name: owner.name,
+    },
+    action: actionName,
+    app: action.app,
+  };
+
+  logger.info(loggerArgs, "Action run creation");
+
+  const tags = [
+    `action:${actionName}`,
+    `workspace:${owner.sId}`,
+    `workspace_name:${owner.name}`,
+  ];
+
+  statsDClient.increment("use_actions.count", 1, tags);
+
+  const prodCredentials = await prodAPICredentialsForOwner(owner);
+  const api = new DustAPI(prodCredentials);
+
+  const res = await api.runAppStreamed(action.app, config, inputs);
+  if (res.isErr()) {
+    return new Err(res.error);
+  }
+
+  const { eventStream, dustRunId } = res.value;
+
+  // Record an event and a log for the action error.
+  const logActionError = (
+    errorType: string,
+    errorArgs: Record<string, any>
+  ) => {
+    statsDClient.increment("use_actions_error.count", 1, [
+      `error_type:${errorType}`,
+      ...tags,
+    ]);
+
+    logger.error(
+      {
+        error_type: errorType,
+        ...errorArgs,
+        ...loggerArgs,
+      },
+      "Action run error"
+    );
+  };
+
+  const streamEvents = async function* () {
+    for await (const event of eventStream) {
+      if (event.type === "error") {
+        logActionError("run_error", { error: event.content });
+      }
+      if (event.type === "block_execution") {
+        const e = event.content.execution[0][0];
+        if (e.error) {
+          logActionError("block_execution_error", { error: e.error });
+        }
+      }
+      yield event;
+    }
+  };
+
+  return new Ok({ eventStream: streamEvents(), dustRunId });
+}

--- a/front/lib/actions/server.ts
+++ b/front/lib/actions/server.ts
@@ -1,11 +1,10 @@
+import { DustProdActionRegistry } from "@app/lib/actions/registry";
+import { prodAPICredentialsForOwner } from "@app/lib/auth";
+import { DustAPI, DustAppConfigType } from "@app/lib/dust_api";
+import { Err, Ok } from "@app/lib/result";
 import logger from "@app/logger/logger";
 import { statsDClient } from "@app/logger/withlogging";
 import { WorkspaceType } from "@app/types/user";
-
-import { prodAPICredentialsForOwner } from "../auth";
-import { DustAPI, DustAppConfigType } from "../dust_api";
-import { Err, Ok } from "../result";
-import { DustProdActionRegistry } from "./registry";
 
 /**
  * This function is intended to be used server side to run an action. Logs and monitors the

--- a/front/pages/w/[wId]/u/chat/[cId]/index.tsx
+++ b/front/pages/w/[wId]/u/chat/[cId]/index.tsx
@@ -791,20 +791,15 @@ export default function AppChat({
         timestamp: { gt: Date.now() - selectedTimeRange.ms },
       };
     }
-    const res = await runActionStreamed(
-      owner,
-      "chat-retrieval",
-      config,
-      [
-        {
-          messages: [{ role: "query", message: query }],
-          userContext: {
-            timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-            localeString: navigator.language,
-          },
+    const res = await runActionStreamed(owner, "chat-retrieval", config, [
+      {
+        messages: [{ role: "query", message: query }],
+        userContext: {
+          timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+          localeString: navigator.language,
         },
-      ]
-    );
+      },
+    ]);
     if (res.isErr()) throw new Error(res.error.message);
 
     const { eventStream } = res.value;
@@ -876,12 +871,9 @@ export default function AppChat({
       date_today: new Date().toISOString().split("T")[0],
     };
 
-    const res = await runActionStreamed(
-      owner,
-      "chat-assistant-wfn",
-      config,
-      [{ messages: filterMessagesForModel(m), context }]
-    );
+    const res = await runActionStreamed(owner, "chat-assistant-wfn", config, [
+      { messages: filterMessagesForModel(m), context },
+    ]);
     if (res.isErr()) throw new Error(res.error.message);
     const { eventStream } = res.value;
     for await (const event of eventStream) {

--- a/front/pages/w/[wId]/u/gens/index.tsx
+++ b/front/pages/w/[wId]/u/gens/index.tsx
@@ -1,5 +1,5 @@
 import { Dialog, Transition } from "@headlessui/react";
-import { PlusIcon, TrashIcon } from "@heroicons/react/20/solid";
+import { PlusIcon } from "@heroicons/react/20/solid";
 import {
   DocumentDuplicateIcon,
   MagnifyingGlassIcon,
@@ -19,10 +19,11 @@ import GensTimeRangePicker, {
   msForTimeRange,
 } from "@app/components/use/GensTimeRangePicker";
 import MainTab from "@app/components/use/MainTab";
+import { runActionStreamed } from "@app/lib/actions/client";
 import {
   cloneBaseConfig,
   DustProdActionRegistry,
-} from "@app/lib/actions_registry";
+} from "@app/lib/actions/registry";
 import {
   Authenticator,
   getSession,
@@ -30,11 +31,7 @@ import {
   prodAPICredentialsForOwner,
 } from "@app/lib/auth";
 import { ConnectorProvider } from "@app/lib/connectors_api";
-import {
-  DustAPI,
-  DustAPICredentials,
-  runActionStreamed,
-} from "@app/lib/dust_api";
+import { DustAPI, DustAPICredentials } from "@app/lib/dust_api";
 import { classNames } from "@app/lib/utils";
 import { GensRetrievedDocumentType } from "@app/types/gens";
 import { UserType, WorkspaceType } from "@app/types/user";
@@ -240,7 +237,12 @@ export function DocumentView({
       },
     ];
 
-    runActionStreamed(owner, "gens-summary", extract_config, extractInput)
+    runActionStreamed(
+      owner,
+      "gens-summary",
+      extract_config,
+      extractInput
+    )
       .then((res) => {
         console.log("Summarizing...");
         if (res.isErr()) {
@@ -943,7 +945,12 @@ export default function AppGens({
       },
     ];
 
-    const res = await runActionStreamed(owner, "gens-generate", config, inputs);
+    const res = await runActionStreamed(
+      owner,
+      "gens-generate",
+      config,
+      inputs
+    );
     if (res.isErr()) {
       console.log("ERROR", res.error);
       setGenLoading(false);
@@ -1045,9 +1052,12 @@ export default function AppGens({
       };
     }
 
-    const res = await runActionStreamed(owner, "gens-retrieval", config, [
-      { text: genContent, userContext },
-    ]);
+    const res = await runActionStreamed(
+      owner,
+      "gens-retrieval",
+      config,
+      [{ text: genContent, userContext }]
+    );
     if (res.isErr()) {
       window.alert("Error runing `gens-retrieval`: " + res.error);
       return;

--- a/front/pages/w/[wId]/u/gens/index.tsx
+++ b/front/pages/w/[wId]/u/gens/index.tsx
@@ -237,12 +237,7 @@ export function DocumentView({
       },
     ];
 
-    runActionStreamed(
-      owner,
-      "gens-summary",
-      extract_config,
-      extractInput
-    )
+    runActionStreamed(owner, "gens-summary", extract_config, extractInput)
       .then((res) => {
         console.log("Summarizing...");
         if (res.isErr()) {
@@ -945,12 +940,7 @@ export default function AppGens({
       },
     ];
 
-    const res = await runActionStreamed(
-      owner,
-      "gens-generate",
-      config,
-      inputs
-    );
+    const res = await runActionStreamed(owner, "gens-generate", config, inputs);
     if (res.isErr()) {
       console.log("ERROR", res.error);
       setGenLoading(false);
@@ -1052,12 +1042,9 @@ export default function AppGens({
       };
     }
 
-    const res = await runActionStreamed(
-      owner,
-      "gens-retrieval",
-      config,
-      [{ text: genContent, userContext }]
-    );
+    const res = await runActionStreamed(owner, "gens-retrieval", config, [
+      { text: genContent, userContext },
+    ]);
     if (res.isErr()) {
       window.alert("Error runing `gens-retrieval`: " + res.error);
       return;

--- a/front/post_upsert_hooks/hooks/document_tracker/lib.ts
+++ b/front/post_upsert_hooks/hooks/document_tracker/lib.ts
@@ -1,7 +1,7 @@
 import {
   cloneBaseConfig,
   DustProdActionRegistry,
-} from "@app/lib/actions_registry";
+} from "@app/lib/actions/registry";
 import {
   getInternalBuilderOwner,
   prodAPICredentialsForOwner,


### PR DESCRIPTION
This PR introduces a server side `runActionStreamed` method to replace the `/actions/[action]` internal API route implementation so that we can use it server side (we'll need it to implement the slack bot v0).

Next step will be to add a non-streamed version of it as runAction/runActionStreamed provide better observability than directly running the dust app (errors are logged, counters are updated with errors and success so that we can track "actions" usage which are basically our use of our own `dust-apps`) cc @fontanierh @PopDaph 

I've tested it and it works as expected but will make sure that errors are properly captured and logged

Note: both runActionStreamed have the same type server side and client side (pretty complex type something something `Promise<Result<DustAPIResponse<AsyncGenerator<...>, Promise<RunId>>>`)