### PR TITLE
add more skips for notion GC

### DIFF
--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -474,8 +474,11 @@ export async function garbageCollectActivity(
         status: number;
       };
       if (
-        potentialNotionError.code === "internal_server_error" &&
-        potentialNotionError.status === 500 &&
+        [
+          "internal_server_error",
+          "notionhq_client_request_timeout",
+          "service_unavailable",
+        ].includes(potentialNotionError.code) &&
         Context.current().info.attempt >= 15
       ) {
         localLogger.error(


### PR DESCRIPTION
It's not alway "internal server error". Now it can also be "service unavailable" or "request timeout"