### PR TITLE
POC for Events

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -6,6 +6,8 @@ import {
   Clone,
   Dataset,
   DataSource,
+  EventSchema,
+  ExtractedEvent,
   GensTemplate,
   Key,
   Membership,
@@ -38,6 +40,8 @@ async function main() {
   await ChatRetrievedDocument.sync({ alter: true });
   await TrackedDocument.sync({ alter: true });
   await GensTemplate.sync({ alter: true });
+  await EventSchema.sync({ alter: true });
+  await ExtractedEvent.sync({ alter: true });
 
   await XP1User.sync({ alter: true });
   await XP1Run.sync({ alter: true });

--- a/front/lib/actions/registry.ts
+++ b/front/lib/actions/registry.ts
@@ -193,6 +193,22 @@ export const DustProdActionRegistry: {
       },
     },
   },
+  "extract-events": {
+    app: {
+      workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
+      appId: "edf70ecf98",
+      appHash:
+        "093b3466de48a8c6a70b12aaf88404219038a01462341d3b628819d39fa5ca07",
+    },
+    config: {
+      MODEL: {
+        provider_id: "openai",
+        model_id: "gpt-4-0613",
+        use_cache: false,
+        function_call: "extract_events",
+      },
+    },
+  },
 };
 
 export function cloneBaseConfig(config: { [model: string]: any }) {

--- a/front/lib/actions/registry.ts
+++ b/front/lib/actions/registry.ts
@@ -198,7 +198,7 @@ export const DustProdActionRegistry: {
       workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
       appId: "edf70ecf98",
       appHash:
-        "093b3466de48a8c6a70b12aaf88404219038a01462341d3b628819d39fa5ca07",
+        "c7ba630f14bd8f54a95e84b887bdb8a888fb911e4cf945ea017e3d877e332c16",
     },
     config: {
       MODEL: {

--- a/front/lib/extract_event_markers.ts
+++ b/front/lib/extract_event_markers.ts
@@ -1,0 +1,47 @@
+const EXTRACT_EVENT_PATTERN = /\[\[(.*?)\]\]/; // Ex: [[event]]
+type ExtractedMarkersType = { [key: string]: string[] };
+
+/**
+ * Check if a text contains an extract event marker
+ * @param text string
+ * @returns boolean
+ */
+export function hasExtractEventMarker(text: string) {
+  return EXTRACT_EVENT_PATTERN.test(text);
+}
+
+/**
+ * Extract the markers from a text
+ * @param text
+ * @returns an array of markers
+ */
+export function getRawExtractEventMarkersFromText(text: string) {
+  const regex = new RegExp(EXTRACT_EVENT_PATTERN, "g"); // global matching
+  const matches = text.match(regex);
+  if (matches) {
+    return matches.map((match) => match.slice(2, -2).trim());
+  } else {
+    return [];
+  }
+}
+
+/**
+ * We can use [[idea]] or [[idea:2]] in a document to mark 2 events of the same type.
+ * This function will return a dict of markers with the same name.
+ * @param rawMarkers string[]
+ * @returns ExtractedMarkersType
+ * @example ["idea", "idea:2", "idea:3", "goals"] returns { "idea": ["idea", "idea:2", "idea:3"], "goals": ["goals"] }
+ */
+export function sanitizeRawExtractEventMarkers(
+  rawMarkers: string[]
+): ExtractedMarkersType {
+  const markers: { [key: string]: string[] } = {};
+  rawMarkers.map((m) => {
+    const [key] = m.split(":");
+    if (!markers[key]) {
+      markers[key] = [];
+    }
+    markers[key].push(m);
+  });
+  return markers;
+}

--- a/front/lib/extract_event_markers.ts
+++ b/front/lib/extract_event_markers.ts
@@ -15,7 +15,7 @@ export function hasExtractEventMarker(text: string) {
  * @param text
  * @returns an array of markers
  */
-export function getRawExtractEventMarkersFromText(text: string) {
+export function getRawExtractEventMarkersFromText(text: string): string[] {
   const regex = new RegExp(EXTRACT_EVENT_PATTERN, "g"); // global matching
   const matches = text.match(regex);
   if (matches) {

--- a/front/lib/extract_events.ts
+++ b/front/lib/extract_events.ts
@@ -1,0 +1,122 @@
+import {
+  cloneBaseConfig,
+  DustProdActionRegistry,
+} from "@app/lib/actions/registry";
+import { runAction } from "@app/lib/actions/server";
+import { getInternalBuilderOwner } from "@app/lib/auth";
+import {
+  getRawExtractEventMarkersFromText,
+  sanitizeRawExtractEventMarkers,
+} from "@app/lib/extract_event_markers";
+import { EventSchema, ExtractedEvent } from "@app/lib/models";
+import logger from "@app/logger/logger";
+import { WorkspaceType } from "@app/types/user";
+
+/**
+ * Gets the markers from the doc and calls _processExtractEvent for each of them
+ */
+export async function processExtractEvents(
+  workspaceId: string,
+  documentId: string,
+  documentText: string
+) {
+  const owner = await getInternalBuilderOwner(workspaceId);
+  const rawMarkers = getRawExtractEventMarkersFromText(documentText);
+  const markers = sanitizeRawExtractEventMarkers(rawMarkers);
+
+  await Promise.all(
+    Object.keys(markers).map(async (marker) => {
+      await _processExtractEvent(
+        owner,
+        marker,
+        markers[marker],
+        documentText,
+        documentId
+      );
+    })
+  );
+}
+
+/**
+ * Gets the schema for the marker, runs the Dust app to extract properties, and saves the event(s)
+ */
+async function _processExtractEvent(
+  owner: WorkspaceType,
+  sanitizedMarker: string,
+  markers: string[],
+  documentText: string,
+  documentId: string
+) {
+  const schema: EventSchema | null = await EventSchema.findOne({
+    where: {
+      workspaceId: owner.id,
+      marker: sanitizedMarker,
+      status: "active",
+    },
+  });
+  if (!schema) {
+    return null;
+  }
+
+  const inputsForApp = [
+    {
+      document_text: documentText,
+      markers: markers,
+      schema_properties: schema.properties,
+    },
+  ];
+
+  const results = await _runExtractEventApp(owner, inputsForApp);
+
+  if (results) {
+    results.map(async (result: string) => {
+      // @todo be smarter
+      // check that this event is not already in the database
+      // check the properties match what's expected (json is typed on model)
+      // handle errors
+
+      const properties = JSON.parse(result);
+
+      logger.info(
+        { properties, marker: schema.marker },
+        "[Extract Event] Saving event"
+      );
+      await ExtractedEvent.create({
+        documentId: documentId,
+        properties: properties,
+        eventSchemaId: schema.id,
+      });
+    });
+  }
+}
+
+type ExtractEventAppResponseResults = {
+  value: {
+    results: { value: string[] }[][];
+  };
+};
+
+/**
+ * Runs the Extract event app and returns just only the results in which extracted events are found
+ * @param owner
+ * @param inputs
+ */
+async function _runExtractEventApp(
+  owner: WorkspaceType,
+  inputs: { document_text: string; markers: string[]; schema_properties: any }[]
+) {
+  const ACTION_NAME = "extract-events";
+  const config = cloneBaseConfig(DustProdActionRegistry[ACTION_NAME]?.config);
+  const response = await runAction(owner, ACTION_NAME, config, inputs);
+
+  if (response.isErr()) {
+    logger.error(
+      { error: response.error },
+      `api_error: ${JSON.stringify(response.error)}`
+    );
+    return null;
+  }
+
+  const successResponse = response as ExtractEventAppResponseResults;
+  return successResponse.value.results[0][0].value;
+}

--- a/front/lib/models.ts
+++ b/front/lib/models.ts
@@ -1016,6 +1016,126 @@ User.hasMany(TrackedDocument, {
   onDelete: "CASCADE",
 });
 
+// Events
+export class EventSchema extends Model<
+  InferAttributes<EventSchema>,
+  InferCreationAttributes<EventSchema>
+> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare marker: string;
+  declare description?: string;
+  declare status: "active" | "disabled";
+  declare properties: {
+    name: string;
+    type: number[] | Date[] | string[];
+    description: string;
+  }[];
+  declare userId: ForeignKey<User["id"]>;
+  declare workspaceId: ForeignKey<Workspace["id"]>;
+}
+EventSchema.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    marker: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    description: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
+    status: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      defaultValue: "active",
+    },
+    properties: {
+      type: DataTypes.JSONB,
+      allowNull: false,
+    },
+  },
+  {
+    modelName: "event_schema",
+    sequelize: front_sequelize,
+    indexes: [{ fields: ["workspaceId", "marker"], unique: true }],
+  }
+);
+Workspace.hasMany(EventSchema, {
+  foreignKey: { allowNull: false },
+  onDelete: "CASCADE",
+});
+User.hasMany(EventSchema, {
+  foreignKey: { allowNull: false },
+  onDelete: "CASCADE",
+});
+
+export class ExtractedEvent extends Model<
+  InferAttributes<ExtractedEvent>,
+  InferCreationAttributes<ExtractedEvent>
+> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare properties: any;
+
+  declare eventSchemaId: ForeignKey<EventSchema["id"]>;
+  declare documentId: string;
+}
+ExtractedEvent.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    properties: {
+      type: DataTypes.JSONB,
+      allowNull: false,
+    },
+    documentId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+  },
+  {
+    modelName: "extracted_event",
+    sequelize: front_sequelize,
+    indexes: [{ fields: ["eventSchemaId"] }, { fields: ["documentId"] }],
+  }
+);
+EventSchema.hasMany(ExtractedEvent, {
+  foreignKey: { allowNull: false },
+  onDelete: "CASCADE", // @todo daph define if we really want to delete the extracted event when the schema is deleted
+});
+
 // XP1
 
 const { XP1_DATABASE_URI } = process.env;

--- a/front/lib/models.ts
+++ b/front/lib/models.ts
@@ -1097,6 +1097,7 @@ export class ExtractedEvent extends Model<
   declare properties: any;
 
   declare eventSchemaId: ForeignKey<EventSchema["id"]>;
+  declare dataSourceId: ForeignKey<DataSource["id"]>;
   declare documentId: string;
 }
 ExtractedEvent.init(
@@ -1128,12 +1129,16 @@ ExtractedEvent.init(
   {
     modelName: "extracted_event",
     sequelize: front_sequelize,
-    indexes: [{ fields: ["eventSchemaId"] }, { fields: ["documentId"] }],
+    indexes: [{ fields: ["eventSchemaId"] }, { fields: ["dataSourceId"] }],
   }
 );
 EventSchema.hasMany(ExtractedEvent, {
   foreignKey: { allowNull: false },
   onDelete: "CASCADE", // @todo daph define if we really want to delete the extracted event when the schema is deleted
+});
+DataSource.hasMany(ExtractedEvent, {
+  foreignKey: { allowNull: false },
+  onDelete: "CASCADE",
 });
 
 // XP1

--- a/front/post_upsert_hooks/hooks/document_tracker/index.ts
+++ b/front/post_upsert_hooks/hooks/document_tracker/index.ts
@@ -366,7 +366,7 @@ The Dust team`,
   },
 };
 
-async function getDatasource(
+export async function getDatasource(
   dataSourceName: string,
   workspaceId: string
 ): Promise<DataSource> {

--- a/front/post_upsert_hooks/hooks/extract_event/index.ts
+++ b/front/post_upsert_hooks/hooks/extract_event/index.ts
@@ -37,6 +37,7 @@ async function processDocument(
   localLogger.info("[Extract event] Processing doc.");
   await processExtractEvents({
     workspaceId,
+    dataSourceName,
     documentId,
     documentText,
   });

--- a/front/post_upsert_hooks/hooks/extract_event/index.ts
+++ b/front/post_upsert_hooks/hooks/extract_event/index.ts
@@ -1,0 +1,39 @@
+import { processExtractEvents } from "@app/lib/extract_events";
+import { hasExtractEventMarker } from "@app/lib/extract_event_markers";
+import mainLogger from "@app/logger/logger";
+import { PostUpsertHook } from "@app/post_upsert_hooks/hooks";
+
+const logger = mainLogger.child({
+  postUpsertHook: "extract_event",
+});
+
+export const extractEventPostUpsertHook: PostUpsertHook = {
+  type: "extract_event",
+  filter: shouldProcessDocument,
+  fn: processDocument,
+};
+
+async function shouldProcessDocument(
+  dataSourceName: string,
+  workspaceId: string,
+  documentId: string,
+  documentText: string
+) {
+  const localLogger = logger.child({ workspaceId, dataSourceName, documentId });
+  const hasMarker = hasExtractEventMarker(documentText);
+  localLogger.info(
+    `[Extract event] Doc contains marker: ${hasMarker ? "yes" : "no"}`
+  );
+  return hasMarker;
+}
+
+async function processDocument(
+  dataSourceName: string,
+  workspaceId: string,
+  documentId: string,
+  documentText: string
+) {
+  const localLogger = logger.child({ workspaceId, dataSourceName, documentId });
+  localLogger.info("[Extract event] Processing doc.");
+  await processExtractEvents(workspaceId, documentId, documentText);
+}

--- a/front/post_upsert_hooks/hooks/extract_event/index.ts
+++ b/front/post_upsert_hooks/hooks/extract_event/index.ts
@@ -35,5 +35,9 @@ async function processDocument(
 ) {
   const localLogger = logger.child({ workspaceId, dataSourceName, documentId });
   localLogger.info("[Extract event] Processing doc.");
-  await processExtractEvents(workspaceId, documentId, documentText);
+  await processExtractEvents({
+    workspaceId,
+    documentId,
+    documentText,
+  });
 }

--- a/front/post_upsert_hooks/hooks/index.ts
+++ b/front/post_upsert_hooks/hooks/index.ts
@@ -4,14 +4,16 @@ import {
   documentTrackerSuggestChangesPostUpsertHook,
   documentTrackerUpdateTrackedDocumentsPostUpsertHook,
 } from "@app/post_upsert_hooks/hooks/document_tracker";
+import { extractEventPostUpsertHook } from "@app/post_upsert_hooks/hooks/extract_event";
 
 export const POST_UPSERT_HOOK_TYPES = [
   "document_tracker_update_tracked_documents",
   "document_tracker_suggest_changes",
+  "extract_event",
 ] as const;
 export type PostUpsertHookType = (typeof POST_UPSERT_HOOK_TYPES)[number];
 
-// asyc function that will run in a temporal workflow
+// async function that will run in a temporal workflow
 // can be expensive to runs
 export type PostUpsertHookFunction = (
   dataSourceName: string,
@@ -52,6 +54,7 @@ export type PostUpsertHook = {
 export const POST_UPSERT_HOOKS = [
   documentTrackerUpdateTrackedDocumentsPostUpsertHook,
   documentTrackerSuggestChangesPostUpsertHook,
+  extractEventPostUpsertHook,
 ];
 
 export const POST_UPSERT_HOOK_BY_TYPE: Record<

--- a/front/tests/lib/markers.test.ts
+++ b/front/tests/lib/markers.test.ts
@@ -1,0 +1,105 @@
+import {
+  getRawExtractEventMarkersFromText,
+  hasExtractEventMarker,
+  sanitizeRawExtractEventMarkers,
+} from "@app/lib/extract_event_markers";
+
+describe("Test hasExtractEventMarker", function () {
+  test("returns true if there is a match", function () {
+    expect(hasExtractEventMarker("Adopt a cat [[idea]]")).toEqual(true);
+    expect(hasExtractEventMarker("[[goal]] Explore the moon")).toEqual(true);
+    expect(hasExtractEventMarker("[[ to do ]] Watch a movie")).toEqual(true);
+  });
+
+  test("returns false when there is no match", function () {
+    expect(hasExtractEventMarker("Adopt a cat [idea]]")).toEqual(false);
+    expect(hasExtractEventMarker("[[goal] Explore the moon")).toEqual(false);
+    expect(hasExtractEventMarker("{{todo}} Watch a movie")).toEqual(false);
+  });
+});
+
+describe("Test getExtractEventMarker", function () {
+  test("returns the marker's string in a list", function () {
+    const cases = [
+      {
+        text: "Adopt a cat [[idea]]",
+        markers: ["idea"],
+      },
+      {
+        text: "[[goal]] Explore the moon",
+        markers: ["goal"],
+      },
+      {
+        text: "Watch a [[ to do ]] movie",
+        markers: ["to do"],
+      },
+    ];
+    cases.forEach((c) => {
+      expect(getRawExtractEventMarkersFromText(c.text)).toEqual(c.markers);
+    });
+  });
+
+  test("returns multiple markers if there are multiple", function () {
+    const cases = [
+      {
+        text: "Adopt a cat [[idea]]. Adopt a dog [[idea2]]",
+        markers: ["idea", "idea2"],
+      },
+      {
+        text: "Adopt a cat [[idea]]. Adopt a dog [[idea]]",
+        markers: ["idea", "idea"],
+      },
+    ];
+    cases.forEach((c) => {
+      expect(getRawExtractEventMarkersFromText(c.text)).toEqual(c.markers);
+    });
+  });
+
+  test("returns empty [] when there is no marker", function () {
+    const cases = [
+      {
+        text: "Adopt a cat [idea]]",
+        markers: [],
+      },
+      {
+        text: "[[goal] Explore the moon",
+        markers: [],
+      },
+      {
+        text: "{{todo}} Watch a movie",
+        markers: [],
+      },
+    ];
+    cases.forEach((c) => {
+      expect(getRawExtractEventMarkersFromText(c.text)).toEqual(c.markers);
+    });
+  });
+});
+
+describe("Test getExtractEventMarker", function () {
+  const cases = [
+    {
+      markers: ["idea", "goal", "to do"],
+      expected: {
+        idea: ["idea"],
+        goal: ["goal"],
+        "to do": ["to do"],
+      },
+    },
+    {
+      markers: ["idea", "goal", "to do", "idea:2"],
+      expected: {
+        idea: ["idea", "idea:2"],
+        goal: ["goal"],
+        "to do": ["to do"],
+      },
+    },
+    {
+      markers: [],
+      expected: {},
+    },
+  ];
+  cases.forEach((c) => {
+    expect(sanitizeRawExtractEventMarkers(c.markers)).toEqual(c.expected);
+  });
+});


### PR DESCRIPTION
# POC for Events

## 👩🏻‍🏫 Context

I created a new post upsert hook:  
When a doc is created/updated we parse its content:
If we find at least one marker such as `[[goal]]` or `[[goal:12]]`, we process the doc: 
- We search if the markers are defined on our workspace (model `EventSchema`)
- If yes, we call a Dust app to extract the related event(s) on the doc. 
- If we extracted something, we store it on the `ExtractedEvent` table.


([Design doc](https://www.notion.so/dust-tt/WIP-Design-doc-Events-App-67664530eea4491ba9bf9df786a9722b))

## ✅ Done

**New models**
- [x] Creates new models `EventSchema` and `ExtractedEvent`.
- [x] Add those models to our init-db script.

**New Dust app**
- [x] Create ["extract-events" Dust app](https://dust.tt/w/78bda07b39/a/edf70ecf98).

**New Post-upsert Hook**
- [x] Create "extract-event" post upsert hook (plugged on Henry's logic) with a filter and process function.
- [x] Create business logic file on lib to process the files.
- [x] Create helper lib to deal with markers, with basic tests.


## 🤡 Demo 

Content in Notion doc: 
````
# Ideas

- Permettre facilement de dupliquer une dust app pour la passer du local à la prod facilement, ou l’inverse. [[idea:0]]
- Stan: utiliser PSQL plutôt que TablePlus [[idea:1]]
- [[idea:2]] Convaincre tout le monde que Mac est mieux que Linux (Henry)
- Chanter sous la douche (Michel)
- [[idea:3]] Trouver le meilleur logo pour Dust (Ed)
- Faire suer toute l'équipe Dust (Quitterie) [[idea:8]]

````

Schema in db: 
```
{
  "name": {"type": "string", "description": "The name of this product idea"}, 
  "author": {"type": "string", "description": "The name of the person who shared this idea"}, 
  "context": {"type": "string", "description": "Anything that can explain what is this idea."}, 
   "marker_log": {"type": "string", "description": "Fill this field with the marker you used"}
}
```

Extracted events: 
```
0:
{
"name": "Permettre facilement de dupliquer une dust app pour la passer du local à la prod facilement, ou l’inverse.",
"author": null,
"context": null,
"marker_log": "idea:0",
"marker": "idea"
}
1:
{
"name": "Utiliser PSQL plutôt que TablePlus",
"author": "Stan",
"context": "Permettre facilement de dupliquer une dust app pour la passer du local à la prod facilement, ou l’inverse.",
"marker_log": "[[idea:1]]",
"marker": "idea:1"
}
2:
{
  "name": "Convaincre tout le monde que Mac est mieux que Linux",
  "author": "Henry",
  "context": null,
  "marker_log": "[[idea:2]]",
  "marker": "idea:2"
}
3:
{
  "name": "Trouver le meilleur logo pour Dust",
  "author": "Ed",
  "context": "Chanter sous la douche (Michel)",
  "marker_log": "[[idea:3]]",
  "marker": "idea:3"
}
4:
{
  "name": "Faire suer toute l'équipe Dust",
  "author": "Quitterie",
  "context": null,
  "marker_log": "[[idea:8]]",
  "marker": "idea:8"
}
```


## 🚧 Next immediate steps

Before merging, I need to make some tests with Slack and GDrive, just to make sure I'm not breaking anything. I only tested with Notion. If good and after having applied feedback, we can merge this and handle the next steps on separate PRs.

-  [ ] Test, test, test.
-  [ ] Deal with duplicates: the current code is stupid and will add forever the same event if there's a update on the doc.
-  [ ] Build a UI to manage the schemas. 
-  [ ] Build some logic to extract the `ExtractedEvents` from the db.
