### PR TITLE
newChat lib API

### DIFF
--- a/front/lib/api/chat.ts
+++ b/front/lib/api/chat.ts
@@ -18,7 +18,6 @@ import {
   ChatSession,
   front_sequelize,
 } from "../models";
-import { getDataSources } from "./data_sources";
 
 export async function getChatSessions(
   auth: Authenticator,
@@ -486,7 +485,11 @@ export async function* newChat(
   //
   // So the invariant is the following: if an error occured the last message is an error message and
   // there is only one of them in messages.
-  while (messages[messages.length - 1].role !== "assistant") {
+  //
+  // We also limit this main loop to 4 iterations.
+  let iteration = 0;
+  while (messages[messages.length - 1].role !== "assistant" && iteration < 4) {
+    iteration += 1;
     const res = await runActionStreamed(
       auth,
       "chat-assistant-wfn",

--- a/front/lib/api/chat.ts
+++ b/front/lib/api/chat.ts
@@ -361,10 +361,9 @@ export type ChatSessionCreateEvent = {
   session: ChatSessionType;
 };
 
-// Event received when we know what will be the type of the next message.
-// It is sent initially when the user message is created for consistency and
-// then each time we know we're going for a retrieval or an assistant
-// response.
+// Event sent when we know what will be the type of the next message. It is sent initially when the
+// user message is created for consistency and then each time we know we're going for a retrieval or
+// an assistant response.
 export type ChatMessageTriggerEvent = {
   role: MessageRole;
   // We might want to add some data here in the future e.g including
@@ -382,33 +381,40 @@ export type ChatMessageTokensEvent = {
   text: string;
 };
 
-// Event received when the session is updated (eg title is set).
+// Event sent when the session is updated (eg title is set).
 export type ChatSessionUpdateEvent = {
   session: ChatSessionType;
 };
 
 /**
- * Function that emulates starting a new chat session.
+ * This function starts a new chat session.
  *
  * @param auth Authenticator
  * @param userMessage string
  * @param dataSources list of data sources to use for retrieval
  * @param filter filter to use for retrieval (timestamp)
- * @param timeZone timezone to use for retrieval
+ * @param timeZone timezone to use for retrieval must be valid `Intl.DateTimeFormat`
  */
 export async function* newChat(
   auth: Authenticator,
-  userMessage: string,
-  dataSources:
-    | {
-        workspace_id: string;
-        data_source_id: string;
-      }[]
-    | null,
-  filter: {
-    timestamp: { gt: number };
-  } | null,
-  timeZone: string
+  {
+    userMessage,
+    dataSources,
+    filter,
+    timeZone,
+  }: {
+    userMessage: string;
+    dataSources:
+      | {
+          workspace_id: string;
+          data_source_id: string;
+        }[]
+      | null;
+    filter: {
+      timestamp: { gt?: number; lt?: number };
+    } | null;
+    timeZone: string;
+  }
 ): AsyncGenerator<
   | ChatSessionCreateEvent
   | ChatMessageTriggerEvent

--- a/front/lib/api/chat.ts
+++ b/front/lib/api/chat.ts
@@ -487,7 +487,7 @@ export async function* newChat(
   // will exit from this loop.
   while (messages[messages.length - 1].role !== "retrieval") {
     const res = await runActionStreamed(
-      owner,
+      auth,
       "chat-assistant-wfn",
       assistantConfig,
       [{ messages: filterMessagesForModel(messages), assistantContext }]
@@ -577,7 +577,7 @@ export async function* newChat(
 
       configRetrieval.DATASOURCE.filter = filter;
 
-      const res = await runAction(owner, "chat-retrieval", configRetrieval, [
+      const res = await runAction(auth, "chat-retrieval", configRetrieval, [
         {
           messages: [{ role: "query", message: m.query }],
           userContext: {
@@ -633,7 +633,7 @@ export async function* newChat(
     date_today: new Date().toISOString().split("T")[0],
   };
 
-  const res = await runAction(owner, "chat-title", configTitle, [
+  const res = await runAction(auth, "chat-title", configTitle, [
     {
       messages: messages.filter(
         (m) => m.role === "user" || m.role === "assistant"

--- a/front/lib/api/chat.ts
+++ b/front/lib/api/chat.ts
@@ -356,6 +356,7 @@ const filterMessagesForModel = (
 
 // Event sent when the session is initially created.
 export type ChatSessionCreateEvent = {
+  type: "chat_session_create";
   session: ChatSessionType;
 };
 
@@ -363,6 +364,7 @@ export type ChatSessionCreateEvent = {
 // user message is created for consistency and then each time we know we're going for a retrieval or
 // an assistant response.
 export type ChatMessageTriggerEvent = {
+  type: "chat_message_trigger";
   role: MessageRole;
   // We might want to add some data here in the future e.g including
   // information about the query being used in the case of retrieval.
@@ -370,17 +372,20 @@ export type ChatMessageTriggerEvent = {
 
 // Event sent once the message is fully constructed.
 export type ChatMessageCreateEvent = {
+  type: "chat_message_create";
   message: ChatMessageType;
 };
 
 // Event sent when receiving streamed response from the model.
 export type ChatMessageTokensEvent = {
+  type: "chat_message_tokens";
   messageId: string;
   text: string;
 };
 
 // Event sent when the session is updated (eg title is set).
 export type ChatSessionUpdateEvent = {
+  type: "chat_session_update";
   session: ChatSessionType;
 };
 
@@ -466,7 +471,7 @@ export async function* newChat(
     } as ChatMessageCreateEvent;
   }
 
-  // Master loop that will run until the last message is not a "retrieval" request. It will call the
+  // Master loop that will run until the last message is an "assistant" response. It will call the
   // assistant and push to the `messages` array. The assistant either push an "assistant" message
   // with a response or a "retrieval" message that will contain a query, if that's the case we run
   // the retrieval and add the retrieved documents to that last message and loop back here.
@@ -476,7 +481,7 @@ export async function* newChat(
   //
   // So the invariant is the following: if an error occured the last message is an error message and
   // there is only one of them in messages.
-  while (messages[messages.length - 1].role !== "retrieval") {
+  while (messages[messages.length - 1].role !== "assistant") {
     const res = await runActionStreamed(
       auth,
       "chat-assistant-wfn",

--- a/front/pages/api/v1/w/[wId]/chats/index.ts
+++ b/front/pages/api/v1/w/[wId]/chats/index.ts
@@ -1,0 +1,138 @@
+import { JSONSchemaType } from "ajv";
+import { NextApiRequest, NextApiResponse } from "next";
+
+import { newChat } from "@app/lib/api/chat";
+import { Authenticator, getAPIKey } from "@app/lib/auth";
+import { ReturnedAPIErrorType } from "@app/lib/error";
+import { parse_payload } from "@app/lib/http_utils";
+import logger from "@app/logger/logger";
+import { apiError, withLogging } from "@app/logger/withlogging";
+
+export type ChatNewPostQuery = {
+  user_message: string;
+  time_zone: string;
+};
+
+const chat_new_scheme: JSONSchemaType<ChatNewPostQuery> = {
+  type: "object",
+  properties: {
+    user_message: { type: "string" },
+    time_zone: { type: "string" },
+  },
+  required: ["user_message"],
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<ReturnedAPIErrorType>
+): Promise<void> {
+  const keyRes = await getAPIKey(req);
+  if (keyRes.isErr()) {
+    return apiError(req, res, keyRes.error);
+  }
+
+  const { auth, keyWorkspaceId } = await Authenticator.fromKey(
+    keyRes.value,
+    req.query.wId as string
+  );
+
+  if (!keyRes.value.isSystem) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message:
+          "The Chat API is only accessible by system API Key. Ping us at team@dust.tt if you want access to it.",
+      },
+    });
+  }
+
+  if (keyWorkspaceId !== req.query.wId) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "The Chat API is only available on your own workspace.",
+      },
+    });
+  }
+
+  const owner = auth.workspace();
+  if (!owner) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "app_not_found",
+        message: "The app you're trying to run was not found",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "POST":
+      const pRes = parse_payload(chat_new_scheme, req.body);
+      if (pRes.isErr()) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid body sent: ${pRes.error.message}`,
+          },
+        });
+      }
+
+      const userMessage = pRes.value.user_message;
+      const timeZone = pRes.value.time_zone;
+
+      try {
+        Intl.DateTimeFormat(undefined, { timeZone });
+      } catch (e) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid time_zone. Time zones must be valid for javascript's Intl.DateTimeFormat.`,
+          },
+        });
+      }
+
+      logger.info(
+        {
+          workspace: {
+            sId: owner.sId,
+            name: owner.name,
+          },
+        },
+        "New chat API call"
+      );
+
+      const eventStream = newChat(auth, userMessage, null, null, timeZone);
+
+      res.writeHead(200, {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+      });
+      res.flushHeaders();
+
+      for await (const event of eventStream) {
+        res.write(`data: ${JSON.stringify(event)}\n\n`);
+        // @ts-expect-error - We need it for streaming but it does not exists in the types.
+        res.flush();
+      }
+
+      res.status(200).end();
+      return;
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, POST is expected.",
+        },
+      });
+  }
+}
+
+export default withLogging(handler);

--- a/front/pages/api/v1/w/[wId]/chats/index.ts
+++ b/front/pages/api/v1/w/[wId]/chats/index.ts
@@ -106,7 +106,12 @@ async function handler(
         "New chat API call"
       );
 
-      const eventStream = newChat(auth, userMessage, null, null, timeZone);
+      const eventStream = newChat(auth, {
+        userMessage,
+        dataSources: null,
+        filter: null,
+        timeZone,
+      });
 
       res.writeHead(200, {
         "Content-Type": "text/event-stream",

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/search.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/search.ts
@@ -99,7 +99,7 @@ export default async function handler(
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: err.message,
+            message: `Invalid body sent: ${err.message}`,
           },
         });
       }

--- a/front/pages/api/w/[wId]/use/chats/[cId]/index.ts
+++ b/front/pages/api/w/[wId]/use/chats/[cId]/index.ts
@@ -95,15 +95,6 @@ async function handler(
       const s = pRes.value;
 
       const session = await upsertChatSession(auth, cId, s.title || null);
-      if (!session) {
-        return apiError(req, res, {
-          status_code: 500,
-          api_error: {
-            type: "internal_server_error",
-            message: "Could not create the chat session.",
-          },
-        });
-      }
 
       res.status(200).json({
         session,

--- a/front/pages/api/w/[wId]/use/chats/[cId]/messages/[mId]/feedback.ts
+++ b/front/pages/api/w/[wId]/use/chats/[cId]/messages/[mId]/feedback.ts
@@ -89,7 +89,7 @@ async function handler(
     });
   }
 
-  const chatSession = await getChatSession(owner, req.query.cId as string);
+  const chatSession = await getChatSession(auth, req.query.cId as string);
 
   if (!chatSession) {
     return apiError(req, res, {

--- a/front/pages/api/w/[wId]/use/chats/[cId]/messages/[mId]/index.ts
+++ b/front/pages/api/w/[wId]/use/chats/[cId]/messages/[mId]/index.ts
@@ -134,7 +134,7 @@ async function handler(
     });
   }
 
-  const chatSession = await getChatSession(owner, req.query.cId);
+  const chatSession = await getChatSession(auth, req.query.cId);
 
   if (!chatSession) {
     return apiError(req, res, {

--- a/front/pages/api/w/[wId]/use/chats/index.ts
+++ b/front/pages/api/w/[wId]/use/chats/index.ts
@@ -59,7 +59,7 @@ async function handler(
         ? parseInt(req.query.offset as string)
         : 0;
 
-      const sessions = await getChatSessions(owner, user, limit, offset);
+      const sessions = await getChatSessions(auth, limit, offset);
 
       res.status(200).json({
         sessions,

--- a/front/pages/w/[wId]/u/chat/[cId]/index.tsx
+++ b/front/pages/w/[wId]/u/chat/[cId]/index.tsx
@@ -901,6 +901,7 @@ export default function AppChat({
     }
     throw new Error("Error: no OUTPUT block streamed.");
   };
+
   const updateMessages = async (
     messages: ChatMessageType[],
     newMessage: ChatMessageType

--- a/front/pages/w/[wId]/u/chat/[cId]/index.tsx
+++ b/front/pages/w/[wId]/u/chat/[cId]/index.tsx
@@ -135,7 +135,7 @@ export const getServerSideProps: GetServerSideProps<{
   });
 
   const cId = context.params?.cId as string;
-  const chatSession = await getChatSessionWithMessages(owner, cId);
+  const chatSession = await getChatSessionWithMessages(auth, cId);
 
   if (!chatSession) {
     return {


### PR DESCRIPTION
This PR introduces a `newChat` lib function that will start a chat from a user query (create the session, trigger retrieval if needed, store messages, etc...) generating events that will let us build the Slack bot and eventually even back the chat product

Also push towards using Authenticator instead of owner: WorkspaceType when relevant.