### PR TITLE
Add log event when Chat session is upserted

### DIFF
--- a/front/lib/api/chat.ts
+++ b/front/lib/api/chat.ts
@@ -12,6 +12,7 @@ import {
   ChatSession,
   front_sequelize,
 } from "../models";
+import logger from "@app/logger/logger";
 
 export async function getChatSessions(
   owner: WorkspaceType,
@@ -93,6 +94,18 @@ export async function upsertChatSession(
         { transaction: t }
       );
     }
+
+    const loggerArgs = {
+      workspace: {
+        sId: owner.sId,
+        name: owner.name,
+      },
+      userId: user.id,
+      chatSessionId: chatSession.id,
+      chatSessionCreated: created,
+    };
+    logger.info(loggerArgs, "Chat Session upserted");
+
     return {
       id: chatSession.id,
       userId: chatSession.userId,


### PR DESCRIPTION
Adding a new log to be able to monitor chat sessions from Datadog. 
Source: [Slack Thread](https://dust4ai.slack.com/archives/C050A0S2Z7F/p1688647377091499)