### PR TITLE
Authenticator refactor

### DIFF
--- a/front/pages/api/w/[wId]/use/actions/[action]/index.ts
+++ b/front/pages/api/w/[wId]/use/actions/[action]/index.ts
@@ -29,7 +29,7 @@ async function handler(
       status_code: 404,
       api_error: {
         type: "workspace_not_found",
-        message: "The workspace you're trying to modify was not found.",
+        message: "The workspace you're trying to access was not found.",
       },
     });
   }
@@ -85,7 +85,7 @@ async function handler(
       const inputs = req.body.inputs as Array<any>;
 
       const actionRes = await runActionStreamed(
-        owner,
+        auth,
         req.query.action,
         config,
         inputs

--- a/front/post_upsert_hooks/hooks/document_tracker/lib.ts
+++ b/front/post_upsert_hooks/hooks/document_tracker/lib.ts
@@ -2,10 +2,7 @@ import {
   cloneBaseConfig,
   DustProdActionRegistry,
 } from "@app/lib/actions/registry";
-import {
-  getInternalBuilderOwner,
-  prodAPICredentialsForOwner,
-} from "@app/lib/auth";
+import { Authenticator, prodAPICredentialsForOwner } from "@app/lib/auth";
 import { DustAPI } from "@app/lib/dust_api";
 import { TRACKABLE_CONNECTOR_TYPES } from "@app/post_upsert_hooks/hooks/document_tracker/consts";
 
@@ -62,7 +59,14 @@ export async function callDocTrackerAction(
   const config = cloneBaseConfig(action.config);
   const app = cloneBaseConfig(action.app);
 
-  const owner = await getInternalBuilderOwner(workspaceId);
+  const owner = (
+    await Authenticator.internalBuilderForWorkspace(workspaceId)
+  ).workspace();
+  if (!owner) {
+    throw new Error(
+      `Could not get internal builder for workspace ${workspaceId}`
+    );
+  }
   const prodCredentials = await prodAPICredentialsForOwner(owner);
 
   const prodAPI = new DustAPI(prodCredentials);


### PR DESCRIPTION
Adds user information to authenticator so that it can be used as go-to object to represent workspace, user, role everywhere.

Moved `getInternalBuilderOwner` to be instead a static method on `Authenticator` to get an authenticator in the case it was covering

cc @PopDaph @fontanierh @Uzay-G 

r? @philipperolet 