### PR TITLE
restrict Notion GC to a specific time window

### DIFF
--- a/connectors/src/connectors/notion/lib/garbage_collect.ts
+++ b/connectors/src/connectors/notion/lib/garbage_collect.ts
@@ -5,7 +5,7 @@ const GARBAGE_COLLECT_START_TIME_OF_DAY_UTC_WINDOW = {
 };
 
 // the garbageCollect function will be stopped if it runs longer than this
-// (a bit less than 2 hours)
+// (a bit less than 2 hours). This includes retries.
 export const GARBAGE_COLLECT_MAX_DURATION_MS = Math.floor(
   1000 * 60 * 60 * 2 * 0.9
 );
@@ -13,10 +13,8 @@ export const GARBAGE_COLLECT_MAX_DURATION_MS = Math.floor(
 export function isDuringGarbageCollectStartWindow(): boolean {
   const now = new Date();
 
-  // Convert now to UTC
   now.setMinutes(now.getMinutes() + now.getTimezoneOffset());
 
-  // Create start and end dates using the day, month, year from now
   const start = new Date(
     Date.UTC(
       now.getUTCFullYear(),
@@ -40,10 +38,5 @@ export function isDuringGarbageCollectStartWindow(): boolean {
     )
   );
 
-  // If now is within the maintenance window, return true
-  if (now.getTime() >= start.getTime() && now.getTime() < end.getTime()) {
-    return true;
-  }
-
-  return false;
+  return now.getTime() >= start.getTime() && now.getTime() < end.getTime();
 }

--- a/connectors/src/connectors/notion/lib/garbage_collect.ts
+++ b/connectors/src/connectors/notion/lib/garbage_collect.ts
@@ -13,8 +13,6 @@ export const GARBAGE_COLLECT_MAX_DURATION_MS = Math.floor(
 export function isDuringGarbageCollectStartWindow(): boolean {
   const now = new Date();
 
-  now.setMinutes(now.getMinutes() + now.getTimezoneOffset());
-
   const start = new Date(
     Date.UTC(
       now.getUTCFullYear(),

--- a/connectors/src/connectors/notion/lib/garbage_collect.ts
+++ b/connectors/src/connectors/notion/lib/garbage_collect.ts
@@ -1,0 +1,49 @@
+// GC processs may start between 1am and 3am UTC
+const GARBAGE_COLLECT_START_TIME_OF_DAY_UTC_WINDOW = {
+  start: 1,
+  end: 3,
+};
+
+// the garbageCollect function will be stopped if it runs longer than this
+// (a bit less than 2 hours)
+export const GARBAGE_COLLECT_MAX_DURATION_MS = Math.floor(
+  1000 * 60 * 60 * 2 * 0.9
+);
+
+export function isDuringGarbageCollectStartWindow(): boolean {
+  const now = new Date();
+
+  // Convert now to UTC
+  now.setMinutes(now.getMinutes() + now.getTimezoneOffset());
+
+  // Create start and end dates using the day, month, year from now
+  const start = new Date(
+    Date.UTC(
+      now.getUTCFullYear(),
+      now.getUTCMonth(),
+      now.getUTCDate(),
+      GARBAGE_COLLECT_START_TIME_OF_DAY_UTC_WINDOW.start,
+      0,
+      0,
+      0
+    )
+  );
+  const end = new Date(
+    Date.UTC(
+      now.getUTCFullYear(),
+      now.getUTCMonth(),
+      now.getUTCDate(),
+      GARBAGE_COLLECT_START_TIME_OF_DAY_UTC_WINDOW.end,
+      0,
+      0,
+      0
+    )
+  );
+
+  // If now is within the maintenance window, return true
+  if (now.getTime() >= start.getTime() && now.getTime() < end.getTime()) {
+    return true;
+  }
+
+  return false;
+}

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -6,6 +6,10 @@ import {
   upsertNotionPageInConnectorsDb,
 } from "@connectors/connectors/notion/lib/connectors_db_helpers";
 import {
+  GARBAGE_COLLECT_MAX_DURATION_MS,
+  isDuringGarbageCollectStartWindow,
+} from "@connectors/connectors/notion/lib/garbage_collect";
+import {
   getPagesEditedSince,
   getParsedPage,
   isPageAccessibleAndUnarchived,
@@ -303,6 +307,11 @@ async function getNotionAccessToken(
 async function shouldGarbageCollect(
   dataSourceConfig: DataSourceConfig
 ): Promise<boolean> {
+  if (!isDuringGarbageCollectStartWindow) {
+    // Never garbage collect if we are not in the start window
+    return false;
+  }
+
   const connector = await Connector.findOne({
     where: {
       type: "notion",
@@ -407,9 +416,11 @@ export async function syncGarbageCollectorPagesActivity(
 // - for each page, query notion API and check if the page still exists
 // - if the page does not exist, delete it from the database
 // - update the lastGarbageCollectionFinishTime
+// - will give up after `GARBAGE_COLLECT_MAX_DURATION_MS` milliseconds
 export async function garbageCollectActivity(
   dataSourceConfig: DataSourceConfig,
-  runTimestamp: number
+  runTimestamp: number,
+  startTs: number
 ) {
   const localLogger = logger.child({
     workspaceId: dataSourceConfig.workspaceId,
@@ -437,10 +448,13 @@ export async function garbageCollectActivity(
   const pagesToDelete = await NotionPage.findAll({
     where: {
       connectorId: connector.id,
+      // only look at pages that have not been seen since the last garbage collection
       lastSeenTs: {
         [Op.lt]: new Date(runTimestamp),
       },
     },
+    // first handle pages that we have seen the longest time ago
+    order: [["lastSeenTs", "ASC"]],
   });
   localLogger.info(
     { pagesToDeleteCount: pagesToDelete.length },
@@ -449,12 +463,30 @@ export async function garbageCollectActivity(
 
   const notionAccessToken = await getNotionAccessToken(connector.connectionId);
 
-  for (const page of pagesToDelete) {
+  let deletedPagesCount = 0;
+  let skippedPagesCount = 0;
+  let stillAccessiblePagesCount = 0;
+
+  for (const [i, page] of pagesToDelete.entries()) {
+    const iterationLogger = localLogger.child({
+      pageId: page.notionPageId,
+      pagesToDeleteCount: pagesToDelete.length,
+      index: i,
+      deletedPagesCount,
+      skippedPagesCount,
+      stillAccessiblePagesCount,
+    });
+    if (new Date().getTime() - startTs > GARBAGE_COLLECT_MAX_DURATION_MS) {
+      iterationLogger.warn("Garbage collection is taking too long, giving up.");
+      break;
+    }
+
     if (page.skipReason) {
-      localLogger.info(
-        { pageId: page.notionPageId, skipReason: page.skipReason },
+      iterationLogger.info(
+        { skipReason: page.skipReason },
         "Page is marked as skipped, not deleting."
       );
+      skippedPagesCount++;
       continue;
     }
     let pageIsAccessible: boolean;
@@ -462,7 +494,7 @@ export async function garbageCollectActivity(
       pageIsAccessible = await isPageAccessibleAndUnarchived(
         notionAccessToken,
         page.notionPageId,
-        localLogger
+        iterationLogger
       );
     } catch (e) {
       // Sometimes a request will consistently fail with a 500
@@ -485,7 +517,7 @@ export async function garbageCollectActivity(
             potentialNotionError.status < 600)) &&
         Context.current().info.attempt >= 15
       ) {
-        localLogger.error(
+        iterationLogger.error(
           {
             error: potentialNotionError,
             attempt: Context.current().info.attempt,
@@ -498,15 +530,18 @@ export async function garbageCollectActivity(
       }
     }
     if (pageIsAccessible) {
-      localLogger.info(
-        { pageId: page.notionPageId },
-        "Page is still accessible, not deleting."
-      );
+      // mark the page as seen
+      await page.update({
+        lastSeenTs: new Date(runTimestamp),
+      });
+      iterationLogger.info("Page is still accessible, not deleting.");
+      stillAccessiblePagesCount++;
       continue;
     }
-    localLogger.info({ pageId: page.notionPageId }, "Deleting page.");
+    iterationLogger.info("Deleting page.");
     await deleteFromDataSource(dataSourceConfig, `notion-${page.notionPageId}`);
     await page.destroy();
+    deletedPagesCount++;
   }
   await notionConnectorState.update({
     lastGarbageCollectionFinishTime: new Date(),

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -307,7 +307,7 @@ async function getNotionAccessToken(
 async function shouldGarbageCollect(
   dataSourceConfig: DataSourceConfig
 ): Promise<boolean> {
-  if (!isDuringGarbageCollectStartWindow) {
+  if (!isDuringGarbageCollectStartWindow()) {
     // Never garbage collect if we are not in the start window
     return false;
   }
@@ -416,7 +416,7 @@ export async function syncGarbageCollectorPagesActivity(
 // - for each page, query notion API and check if the page still exists
 // - if the page does not exist, delete it from the database
 // - update the lastGarbageCollectionFinishTime
-// - will give up after `GARBAGE_COLLECT_MAX_DURATION_MS` milliseconds
+// - will give up after `GARBAGE_COLLECT_MAX_DURATION_MS` milliseconds (including retries if any)
 export async function garbageCollectActivity(
   dataSourceConfig: DataSourceConfig,
   runTimestamp: number,

--- a/connectors/src/connectors/notion/temporal/workflows.ts
+++ b/connectors/src/connectors/notion/temporal/workflows.ts
@@ -164,7 +164,11 @@ export async function notionSyncWorkflow(
     } else {
       // look at pages that were not visited in this run, check with the notion API
       // if they were really deleted and delete them from the database if they were
-      await garbageCollectActivity(dataSourceConfig, runTimestamp);
+      await garbageCollectActivity(
+        dataSourceConfig,
+        runTimestamp,
+        new Date().getTime()
+      );
     }
 
     iterations += 1;


### PR DESCRIPTION
- Notion GC may only start between 1 and 3 AM UTC
- The Notion GC activity (i.e the one where we actually check and delete pages, excluding the calls to the search endpoint to "scan" the Notion workspace) may take a maximum of 2 hours. This includes any potential retries.