### PR TITLE
save notion page parent ID

### DIFF
--- a/connectors/src/connectors/notion/lib/connectors_db_helpers.ts
+++ b/connectors/src/connectors/notion/lib/connectors_db_helpers.ts
@@ -5,6 +5,8 @@ export async function upsertNotionPageInConnectorsDb(
   dataSourceInfo: DataSourceInfo,
   notionPageId: string,
   lastSeenTs: number,
+  parentType?: string | null,
+  parentId?: string | null,
   lastUpsertedTs?: number,
   skipReason?: string
 ): Promise<NotionPage> {
@@ -27,6 +29,8 @@ export async function upsertNotionPageInConnectorsDb(
 
   const updateParams: {
     lastSeenTs: Date;
+    parentType?: string;
+    parentId?: string;
     lastUpsertedTs?: Date;
     skipReason?: string;
   } = {
@@ -37,6 +41,12 @@ export async function upsertNotionPageInConnectorsDb(
   }
   if (skipReason) {
     updateParams.skipReason = skipReason;
+  }
+  if (parentType) {
+    updateParams.parentType = parentType;
+  }
+  if (parentId) {
+    updateParams.parentId = parentId;
   }
 
   if (page) {

--- a/connectors/src/connectors/notion/lib/notion_api.ts
+++ b/connectors/src/connectors/notion/lib/notion_api.ts
@@ -38,6 +38,8 @@ export interface ParsedPage {
   author: string;
   lastEditor: string;
   hasBody: boolean;
+  parentType: "database" | "page" | "block" | "workspace";
+  parentId: string;
 }
 
 export type ParsedProperty = {
@@ -361,6 +363,36 @@ export async function getParsedPage(
   // remove base64 images from rendered page
   renderedPage = renderedPage.replace(/data:image\/[^;]+;base64,[^\n]+/g, "");
 
+  const pageParent = page.parent;
+  let parentId: string;
+  let parentType: string;
+
+  switch (pageParent.type) {
+    case "database_id":
+      parentId = pageParent.database_id;
+      parentType = "database";
+      break;
+    case "page_id":
+      parentId = pageParent.page_id;
+      parentType = "page";
+      break;
+    case "block_id":
+      parentId = pageParent.block_id;
+      parentType = "block";
+      break;
+    case "workspace":
+      parentId = "workspace";
+      parentType = "workspace";
+      break;
+    default:
+      ((pageParent: never) => {
+        logger.warn({ pageParent }, "Unknown page parent type.");
+      })(pageParent);
+      parentId = "unknown";
+      parentType = "unknown";
+      break;
+  }
+
   return {
     id: page.id,
     url: page.url,
@@ -372,6 +404,8 @@ export async function getParsedPage(
     author,
     lastEditor,
     hasBody: pageHasBody,
+    parentId,
+    parentType: parentType as ParsedPage["parentType"],
   };
 }
 

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -200,6 +200,8 @@ export async function notionUpsertPageActivity(
       dataSourceConfig,
       pageId,
       runTimestamp,
+      parsedPage.parentType,
+      parsedPage.parentId,
       upsertTs,
       "body_too_large"
     );
@@ -229,6 +231,8 @@ export async function notionUpsertPageActivity(
     dataSourceConfig,
     pageId,
     runTimestamp,
+    parsedPage ? parsedPage.parentType : null,
+    parsedPage ? parsedPage.parentId : null,
     upsertTs
   );
 }

--- a/connectors/src/lib/models.ts
+++ b/connectors/src/lib/models.ts
@@ -275,6 +275,9 @@ export class NotionPage extends Model<
 
   declare skipReason?: string | null;
 
+  declare parentType?: string | null;
+  declare parentId?: string | null;
+
   declare connectorId: ForeignKey<Connector["id"]>;
 }
 
@@ -308,6 +311,14 @@ NotionPage.init(
       allowNull: true,
     },
     skipReason: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
+    parentType: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
+    parentId: {
       type: DataTypes.STRING,
       allowNull: true,
     },


### PR DESCRIPTION
- add `parentType` and `parentId` (nullable) fields to the `NotionPage` model
- return the value for these fields from the Notion API module
- save these values in the DB from the `upsertNotionPageInConnectorsDb` method

Should allow recreating the structure of the notion WS and most importantly enable listing top-level pages