### PR TITLE
Log create Membership to get stats

### DIFF
--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -302,7 +302,7 @@ async function _createAndLogMembership(data: {
     `role:${data.role}`,
     `invitation_flow:${data.invitationFlow}`,
   ];
-  statsDClient.increment("user.membership_created", 1, tags);
+  statsDClient.increment("workspace.membership_created", 1, tags);
 
   return m;
 }


### PR DESCRIPTION
Add tracking data for DD to get info about new users joining workspaces. 
Source of request: [Slack thread](https://dust4ai.slack.com/archives/C050A0S2Z7F/p1688647377091499).


Note. I used an object instead of params following this [Slack discussion](https://dust4ai.slack.com/archives/C050SM8NSPK/p1688373846493809) cc @fontanierh  😊 