### PR TITLE
pass docHash to post upsert hooks

### DIFF
--- a/front/lib/extract_events.ts
+++ b/front/lib/extract_events.ts
@@ -78,6 +78,7 @@ async function _processExtractEvent(data: {
     documentId,
     documentText,
   } = data;
+
   const schema: EventSchema | null = await EventSchema.findOne({
     where: {
       workspaceId: auth.workspace()?.id,

--- a/front/lib/extract_events.ts
+++ b/front/lib/extract_events.ts
@@ -78,7 +78,6 @@ async function _processExtractEvent(data: {
     documentId,
     documentText,
   } = data;
-
   const schema: EventSchema | null = await EventSchema.findOne({
     where: {
       workspaceId: auth.workspace()?.id,

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
@@ -286,19 +286,22 @@ async function handler(
         data_source: dataSource,
       });
 
-      const postUpsertHooksToRun = await getPostUpsertHooksToRun(
-        dataSource.name,
-        owner.sId,
-        req.query.documentId as string,
-        req.body.text,
-        dataSource.connectorProvider || null
-      );
+      const postUpsertHooksToRun = await getPostUpsertHooksToRun({
+        dataSourceName: dataSource.name,
+        workspaceId: owner.sId,
+        documentId: req.query.documentId as string,
+        documentText: req.body.text,
+        documentHash: upsertRes.value.document.hash,
+        dataSourceConnectorProvider: dataSource.connectorProvider || null,
+      });
+
       // TODO: parallel.
       for (const { type: hookType, debounceMs } of postUpsertHooksToRun) {
         await launchRunPostUpsertHooksWorkflow(
           dataSource.name,
           owner.sId,
           req.query.documentId as string,
+          upsertRes.value.document.hash,
           dataSource.connectorProvider || null,
           hookType,
           debounceMs

--- a/front/post_upsert_hooks/hooks/document_tracker/index.ts
+++ b/front/post_upsert_hooks/hooks/document_tracker/index.ts
@@ -23,7 +23,12 @@ export const documentTrackerUpdateTrackedDocumentsPostUpsertHook: PostUpsertHook
     getDebounceMs: async () => {
       return 1000;
     },
-    filter: async (dataSourceName, workspaceId, documentId, documentText) => {
+    filter: async ({
+      dataSourceName,
+      workspaceId,
+      documentId,
+      documentText,
+    }) => {
       const localLogger = logger.child({
         workspaceId,
         dataSourceName,
@@ -76,7 +81,7 @@ export const documentTrackerUpdateTrackedDocumentsPostUpsertHook: PostUpsertHook
 
       return false;
     },
-    fn: async (dataSourceName, workspaceId, documentId, documentText) => {
+    fn: async ({ dataSourceName, workspaceId, documentId, documentText }) => {
       logger.info(
         {
           workspaceId,
@@ -100,13 +105,7 @@ export const documentTrackerUpdateTrackedDocumentsPostUpsertHook: PostUpsertHook
 
 export const documentTrackerSuggestChangesPostUpsertHook: PostUpsertHook = {
   type: "document_tracker_suggest_changes",
-  getDebounceMs: async (
-    _dataSourceName,
-    _workspaceId,
-    _documentId,
-    _documentText,
-    dataSourceConnectorProvider
-  ) => {
+  getDebounceMs: async ({ dataSourceConnectorProvider }) => {
     if (!dataSourceConnectorProvider) {
       return 10000; // 10 seconds
     }
@@ -115,13 +114,12 @@ export const documentTrackerSuggestChangesPostUpsertHook: PostUpsertHook = {
     }
     return 3600000; // 1 hour
   },
-  filter: async (
+  filter: async ({
     dataSourceName,
     workspaceId,
     documentId,
-    _documentText,
-    dataSourceConnectorProvider
-  ) => {
+    dataSourceConnectorProvider,
+  }) => {
     const localLogger = logger.child({
       workspaceId,
       dataSourceName,
@@ -203,7 +201,7 @@ export const documentTrackerSuggestChangesPostUpsertHook: PostUpsertHook = {
     return false;
   },
 
-  fn: async (dataSourceName, workspaceId, documentId, documentText) => {
+  fn: async ({ dataSourceName, workspaceId, documentId, documentText }) => {
     logger.info(
       {
         workspaceId,

--- a/front/post_upsert_hooks/hooks/extract_event/index.ts
+++ b/front/post_upsert_hooks/hooks/extract_event/index.ts
@@ -1,5 +1,5 @@
-import { processExtractEvents } from "@app/lib/extract_events";
 import { hasExtractEventMarker } from "@app/lib/extract_event_markers";
+import { processExtractEvents } from "@app/lib/extract_events";
 import mainLogger from "@app/logger/logger";
 import { PostUpsertHook } from "@app/post_upsert_hooks/hooks";
 

--- a/front/post_upsert_hooks/hooks/extract_event/index.ts
+++ b/front/post_upsert_hooks/hooks/extract_event/index.ts
@@ -1,7 +1,10 @@
 import { hasExtractEventMarker } from "@app/lib/extract_event_markers";
 import { processExtractEvents } from "@app/lib/extract_events";
 import mainLogger from "@app/logger/logger";
-import { PostUpsertHook } from "@app/post_upsert_hooks/hooks";
+import {
+  PostUpsertHook,
+  PostUpsertHookParams,
+} from "@app/post_upsert_hooks/hooks";
 
 const logger = mainLogger.child({
   postUpsertHook: "extract_event",
@@ -13,12 +16,12 @@ export const extractEventPostUpsertHook: PostUpsertHook = {
   fn: processDocument,
 };
 
-async function shouldProcessDocument(
-  dataSourceName: string,
-  workspaceId: string,
-  documentId: string,
-  documentText: string
-) {
+async function shouldProcessDocument({
+  dataSourceName,
+  workspaceId,
+  documentId,
+  documentText,
+}: PostUpsertHookParams) {
   const localLogger = logger.child({ workspaceId, dataSourceName, documentId });
   const hasMarker = hasExtractEventMarker(documentText);
   localLogger.info(
@@ -27,12 +30,12 @@ async function shouldProcessDocument(
   return hasMarker;
 }
 
-async function processDocument(
-  dataSourceName: string,
-  workspaceId: string,
-  documentId: string,
-  documentText: string
-) {
+async function processDocument({
+  dataSourceName,
+  workspaceId,
+  documentId,
+  documentText,
+}: PostUpsertHookParams) {
   const localLogger = logger.child({ workspaceId, dataSourceName, documentId });
   localLogger.info("[Extract event] Processing doc.");
   await processExtractEvents({

--- a/front/post_upsert_hooks/hooks/index.ts
+++ b/front/post_upsert_hooks/hooks/index.ts
@@ -13,7 +13,7 @@ export const POST_UPSERT_HOOK_TYPES = [
 ] as const;
 export type PostUpsertHookType = (typeof POST_UPSERT_HOOK_TYPES)[number];
 
-type PostUpsertHookParams = {
+export type PostUpsertHookParams = {
   dataSourceName: string;
   workspaceId: string;
   documentId: string;

--- a/front/post_upsert_hooks/hooks/index.ts
+++ b/front/post_upsert_hooks/hooks/index.ts
@@ -13,35 +13,32 @@ export const POST_UPSERT_HOOK_TYPES = [
 ] as const;
 export type PostUpsertHookType = (typeof POST_UPSERT_HOOK_TYPES)[number];
 
-// async function that will run in a temporal workflow
+type PostUpsertHookParams = {
+  dataSourceName: string;
+  workspaceId: string;
+  documentId: string;
+  documentText: string;
+  documentHash: string;
+  dataSourceConnectorProvider: ConnectorProvider | null;
+};
+
+// asyc function that will run in a temporal workflow
 // can be expensive to runs
 export type PostUpsertHookFunction = (
-  dataSourceName: string,
-  workspaceId: string,
-  documentId: string,
-  documentText: string,
-  dataSourceConnectorProvider: ConnectorProvider | null
+  params: PostUpsertHookParams
 ) => Promise<void>;
 
 // returns true if the post upsert hook should run for this document
 // returns false if the post upsert hook should not run for this document
 // needs to be relatively quick to run, will run in the same process as calling code
 export type PostUpsertHookFilter = (
-  dataSourceName: string,
-  workspaceId: string,
-  documentId: string,
-  documentText: string,
-  dataSourceConnectorProvider: ConnectorProvider | null
+  params: PostUpsertHookParams
 ) => Promise<boolean>;
 
 // How long should the hook sleep before running (debouncing)
 // ran in the same process as calling code (no retries, needs to be quick to run)
 export type PostUpsertHookDebounceMs = (
-  dataSourceName: string,
-  workspaceId: string,
-  documentId: string,
-  documentText: string,
-  dataSourceConnectorProvider: ConnectorProvider | null
+  params: PostUpsertHookParams
 ) => Promise<number>;
 
 export type PostUpsertHook = {
@@ -66,11 +63,7 @@ export const POST_UPSERT_HOOK_BY_TYPE: Record<
 }, {} as Record<PostUpsertHookType, PostUpsertHook>);
 
 export async function getPostUpsertHooksToRun(
-  dataSourceName: string,
-  workspaceId: string,
-  documentId: string,
-  documentText: string,
-  dataSourceConnectorProvider: ConnectorProvider | null
+  params: PostUpsertHookParams
 ): Promise<Array<{ type: PostUpsertHookType; debounceMs: number }>> {
   if (!process.env.POST_UPSERT_HOOKS_ENABLED) {
     return [];
@@ -78,23 +71,9 @@ export async function getPostUpsertHooksToRun(
   // TODO: parallel
   const hooksToRun: { type: PostUpsertHookType; debounceMs: number }[] = [];
   for (const hook of POST_UPSERT_HOOKS) {
-    if (
-      await hook.filter(
-        dataSourceName,
-        workspaceId,
-        documentId,
-        documentText,
-        dataSourceConnectorProvider
-      )
-    ) {
+    if (await hook.filter(params)) {
       const debounceMs = hook.getDebounceMs
-        ? await hook.getDebounceMs(
-            dataSourceName,
-            workspaceId,
-            documentId,
-            documentText,
-            dataSourceConnectorProvider
-          )
+        ? await hook.getDebounceMs(params)
         : DEFAULT_POST_UPSERT_HOOKS_DEBOUNCE_MS;
       hooksToRun.push({ type: hook.type, debounceMs });
     }

--- a/front/post_upsert_hooks/temporal/activities.ts
+++ b/front/post_upsert_hooks/temporal/activities.ts
@@ -11,6 +11,7 @@ export async function runPostUpsertHookActivity(
   dataSourceName: string,
   workspaceId: string,
   documentId: string,
+  documentHash: string,
   dataSourceConnectorProvider: ConnectorProvider | null,
   hookType: PostUpsertHookType
 ) {
@@ -29,14 +30,19 @@ export async function runPostUpsertHookActivity(
   }
 
   localLogger.info("Running post upsert hook function.");
-  const docText = await getDocText(dataSourceName, workspaceId, documentId);
-  await hook.fn(
+  const documentText = await getDocText(
+    dataSourceName,
+    workspaceId,
+    documentId
+  );
+  await hook.fn({
     dataSourceName,
     workspaceId,
     documentId,
-    docText,
-    dataSourceConnectorProvider
-  );
+    documentText,
+    documentHash,
+    dataSourceConnectorProvider,
+  });
   localLogger.info("Ran post upsert hook function.");
 }
 

--- a/front/post_upsert_hooks/temporal/activities.ts
+++ b/front/post_upsert_hooks/temporal/activities.ts
@@ -7,7 +7,47 @@ import {
   PostUpsertHookType,
 } from "@app/post_upsert_hooks/hooks";
 
+// TODO: delete
+// We need to keep until all pending workflows are finished
 export async function runPostUpsertHookActivity(
+  dataSourceName: string,
+  workspaceId: string,
+  documentId: string,
+  dataSourceConnectorProvider: ConnectorProvider | null,
+  hookType: PostUpsertHookType
+) {
+  const localLogger = logger.child({
+    workspaceId,
+    dataSourceName,
+    documentId,
+    dataSourceConnectorProvider,
+    hookType,
+  });
+
+  const hook = POST_UPSERT_HOOK_BY_TYPE[hookType];
+  if (!hook) {
+    localLogger.error("Unknown post upsert hook type");
+    throw new Error(`Unknown post upsert hook type ${hookType}`);
+  }
+
+  localLogger.info("Running post upsert hook function.");
+  const documentText = await getDocText(
+    dataSourceName,
+    workspaceId,
+    documentId
+  );
+  await hook.fn({
+    dataSourceName,
+    workspaceId,
+    documentId,
+    documentText,
+    documentHash: "No Hash",
+    dataSourceConnectorProvider,
+  });
+  localLogger.info("Ran post upsert hook function.");
+}
+
+export async function runPostUpsertHookActivityV2(
   dataSourceName: string,
   workspaceId: string,
   documentId: string,

--- a/front/post_upsert_hooks/temporal/client.ts
+++ b/front/post_upsert_hooks/temporal/client.ts
@@ -9,6 +9,7 @@ export async function launchRunPostUpsertHooksWorkflow(
   dataSourceName: string,
   workspaceId: string,
   documentId: string,
+  documentHash: string,
   dataSourceConnectorProvider: ConnectorProvider | null,
   hookType: PostUpsertHookType,
   debounceMs: number
@@ -20,6 +21,7 @@ export async function launchRunPostUpsertHooksWorkflow(
       dataSourceName,
       workspaceId,
       documentId,
+      documentHash,
       dataSourceConnectorProvider,
       hookType,
       debounceMs,

--- a/front/post_upsert_hooks/temporal/workflows.ts
+++ b/front/post_upsert_hooks/temporal/workflows.ts
@@ -6,7 +6,7 @@ import type * as activities from "@app/post_upsert_hooks/temporal/activities";
 
 import { newUpsertSignal } from "./signals";
 
-const { runPostUpsertHookActivity } = proxyActivities<typeof activities>({
+const { runPostUpsertHookActivityV2 } = proxyActivities<typeof activities>({
   startToCloseTimeout: "60 minute",
 });
 
@@ -33,7 +33,7 @@ export async function runPostUpsertHooksWorkflow(
       continue;
     }
 
-    await runPostUpsertHookActivity(
+    await runPostUpsertHookActivityV2(
       dataSourceName,
       workspaceId,
       documentId,

--- a/front/post_upsert_hooks/temporal/workflows.ts
+++ b/front/post_upsert_hooks/temporal/workflows.ts
@@ -14,6 +14,7 @@ export async function runPostUpsertHooksWorkflow(
   dataSourceName: string,
   workspaceId: string,
   documentId: string,
+  documentHash: string,
   dataSourceConnectorProvider: ConnectorProvider | null,
   hookType: PostUpsertHookType,
   debounceMs: number
@@ -36,6 +37,7 @@ export async function runPostUpsertHooksWorkflow(
       dataSourceName,
       workspaceId,
       documentId,
+      documentHash,
       dataSourceConnectorProvider,
       hookType
     );


### PR DESCRIPTION
- post upsert hooks now receive the document hash as part of their parameters
- post upsert hooks now receive an object instead of separate parameters (better readability)