### PR TITLE
reduce notion GC interval

### DIFF
--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -35,7 +35,7 @@ import {
 
 const logger = mainLogger.child({ provider: "notion" });
 
-const GARBAGE_COLLECTION_INTERVAL_HOURS = 24;
+const GARBAGE_COLLECTION_INTERVAL_HOURS = 12;
 
 export async function notionGetPagesToSyncActivity(
   dataSourceInfo: DataSourceInfo,


### PR DESCRIPTION
- we now have a condition preventing GC to start outside of a time window
- by using 24 hour interval, we might skip GC once every 2 days if GC takes the whole window to complete
- by reducing to 12 hours, we prevent GC from happening twice in a day, but we allow it to happen every day