### PR TITLE
enh(github connector): dont render null bodies

### DIFF
--- a/connectors/src/connectors/github/temporal/activities.ts
+++ b/connectors/src/connectors/github/temporal/activities.ts
@@ -94,7 +94,10 @@ export async function githubUpsertIssueActivity(
 
   localLogger.info("Upserting GitHub issue.");
   const issue = await getIssue(installationId, repoName, login, issueNumber);
-  let renderedIssue = `# ${issue.title}||\n${issue.body}||\n`;
+  let renderedIssue = `# ${issue.title}||\n`;
+  if (issue.body) {
+    renderedIssue += `${issue.body}||\n`;
+  }
   let resultPage = 1;
   for (;;) {
     const resultPageLogger = localLogger.child({


### PR DESCRIPTION
- we currently render `null` in the upserted doc when a GH PR/issue doesn't have an OP
- this commit changes the behaviour to not render anything if the body is null