### PR TITLE
limit concurrency of GH deploy actions

### DIFF
--- a/.github/workflows/deploy-blog.yml
+++ b/.github/workflows/deploy-blog.yml
@@ -3,6 +3,10 @@ name: Deploy Blog
 on:
   workflow_dispatch:
 
+concurrency:
+  group: deploy_blog
+  cancel-in-progress: false
+
 env:
   GCLOUD_PROJECT_ID: ${{ secrets.GCLOUD_PROJECT_ID }}
 

--- a/.github/workflows/deploy-connectors-edge.yml
+++ b/.github/workflows/deploy-connectors-edge.yml
@@ -3,6 +3,10 @@ name: Deploy Connectors Edge
 on:
   workflow_dispatch:
 
+concurrency:
+  group: deploy_connectors_edge
+  cancel-in-progress: false
+
 env:
   GCLOUD_PROJECT_ID: ${{ secrets.GCLOUD_PROJECT_ID }}
 

--- a/.github/workflows/deploy-connectors.yml
+++ b/.github/workflows/deploy-connectors.yml
@@ -3,6 +3,10 @@ name: Deploy Connectors
 on:
   workflow_dispatch:
 
+concurrency:
+  group: deploy_connectors
+  cancel-in-progress: false
+
 env:
   GCLOUD_PROJECT_ID: ${{ secrets.GCLOUD_PROJECT_ID }}
 

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -3,6 +3,10 @@ name: Deploy docs
 on:
   workflow_dispatch:
 
+concurrency:
+  group: deploy_docs
+  cancel-in-progress: false
+
 env:
   GCLOUD_PROJECT_ID: ${{ secrets.GCLOUD_PROJECT_ID }}
 

--- a/.github/workflows/deploy-front-edge.yml
+++ b/.github/workflows/deploy-front-edge.yml
@@ -3,6 +3,10 @@ name: Deploy Front Edge
 on:
   workflow_dispatch:
 
+concurrency:
+  group: deploy_front_edge
+  cancel-in-progress: false
+
 env:
   GCLOUD_PROJECT_ID: ${{ secrets.GCLOUD_PROJECT_ID }}
 

--- a/.github/workflows/deploy-front.yml
+++ b/.github/workflows/deploy-front.yml
@@ -3,6 +3,10 @@ name: Deploy Front
 on:
   workflow_dispatch:
 
+concurrency:
+  group: deploy_front
+  cancel-in-progress: false
+
 env:
   GCLOUD_PROJECT_ID: ${{ secrets.GCLOUD_PROJECT_ID }}
 


### PR DESCRIPTION
Avoids having more than 1 of a deploy GH action running at the same time.
The action will stay in a "pending" state until all other actions in the same concurrency group are done running (we have 1 concurrency group per service to deploy)