### PR TITLE
feat(core): allow specifying hash of latest version to retrieve

### DIFF
--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -1263,6 +1263,8 @@ async fn data_sources_documents_update_tags(
 struct DataSourcesDocumentsVersionsListQuery {
     offset: usize,
     limit: usize,
+    // hash of the latest version to retrieve
+    latest_hash: Option<String>,
 }
 
 async fn data_sources_documents_versions_list(
@@ -1278,6 +1280,7 @@ async fn data_sources_documents_versions_list(
             &data_source_id,
             &document_id,
             Some((query.limit, query.offset)),
+            &query.latest_hash,
         )
         .await
     {

--- a/core/src/stores/sqlite.rs
+++ b/core/src/stores/sqlite.rs
@@ -1203,6 +1203,7 @@ impl Store for SQLiteStore {
         _data_source_id: &str,
         _document_id: &str,
         _limit_offset: Option<(usize, usize)>,
+        _latest_hash_created: &Option<String>,
     ) -> Result<(Vec<DocumentVersion>, usize)> {
         // not implemented for SQLite
         Err(anyhow!(

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -113,6 +113,7 @@ pub trait Store {
         data_source_id: &str,
         document_id: &str,
         limit_offset: Option<(usize, usize)>,
+        latest_hash: &Option<String>,
     ) -> Result<(Vec<DocumentVersion>, usize)>;
     async fn list_data_source_documents(
         &self,

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -404,7 +404,7 @@ pub const POSTGRES_TABLES: [&'static str; 11] = [
     );",
 ];
 
-pub const SQL_INDEXES: [&'static str; 13] = [
+pub const SQL_INDEXES: [&'static str; 16] = [
     "CREATE INDEX IF NOT EXISTS
        idx_specifications_project_created ON specifications (project, created);",
     "CREATE INDEX IF NOT EXISTS
@@ -434,4 +434,13 @@ pub const SQL_INDEXES: [&'static str; 13] = [
     "CREATE INDEX IF NOT EXISTS
        idx_data_sources_documents_data_source_status_timestamp
        ON data_sources_documents (data_source, status, timestamp);",
+    "CREATE INDEX IF NOT EXISTS
+       idx_data_sources_documents_data_source_document_id_hash
+       ON data_sources_documents (data_source, document_id, hash);",
+    "CREATE INDEX IF NOT EXISTS
+       idx_data_sources_documents_data_source_document_id_status
+       ON data_sources_documents (data_source, document_id, status);",
+    "CREATE INDEX IF NOT EXISTS
+       idx_data_sources_documents_data_source_document_id_created
+       ON data_sources_documents (data_source, document_id, created DESC);",
 ];

--- a/front/lib/core_api.ts
+++ b/front/lib/core_api.ts
@@ -508,16 +508,26 @@ export const CoreAPI = {
     dataSourceName: string,
     documentId: string,
     limit = 10,
-    offset = 0
+    offset = 0,
+    latest_hash?: string | null
   ): Promise<
     CoreAPIResponse<{
       document_versions: { hash: string; created: number }[];
     }>
   > {
+    const params = new URLSearchParams({
+      limit: String(limit),
+      offset: String(offset),
+    });
+
+    if (latest_hash) {
+      params.append("latest_hash", latest_hash);
+    }
+
     const response = await fetch(
       `${CORE_API}/projects/${projectId}/data_sources/${dataSourceName}/documents/${encodeURIComponent(
         documentId
-      )}/versions?limit=${limit}&offset=${offset}`,
+      )}/versions?${params.toString()}`,
       {
         method: "GET",
       }


### PR DESCRIPTION
When listing the versions of a document (in reverse-chron order), it can be useful to specify the hash of the latest version to retrieve.
This allows to:
- not have broken pagination if a new version is added while iterating on result pages
- quickly obtain the version right before a given hash (use case required for Doc Tracker and Events post upsert hooks)