### PR TITLE
Event: process doc only if marker and active schema

### DIFF
--- a/front/post_upsert_hooks/hooks/extract_event/index.ts
+++ b/front/post_upsert_hooks/hooks/extract_event/index.ts
@@ -1,5 +1,8 @@
 import { hasExtractEventMarker } from "@app/lib/extract_event_markers";
-import { processExtractEvents } from "@app/lib/extract_events";
+import {
+  processExtractEvents,
+  shouldProcessExtractEvents,
+} from "@app/lib/extract_events";
 import mainLogger from "@app/logger/logger";
 import {
   PostUpsertHook,
@@ -16,18 +19,8 @@ export const extractEventPostUpsertHook: PostUpsertHook = {
   fn: processDocument,
 };
 
-async function shouldProcessDocument({
-  dataSourceName,
-  workspaceId,
-  documentId,
-  documentText,
-}: PostUpsertHookParams) {
-  const localLogger = logger.child({ workspaceId, dataSourceName, documentId });
-  const hasMarker = hasExtractEventMarker(documentText);
-  localLogger.info(
-    `[Extract event] Doc contains marker: ${hasMarker ? "yes" : "no"}`
-  );
-  return hasMarker;
+async function shouldProcessDocument(params: PostUpsertHookParams) {
+  return await shouldProcessExtractEvents(params);
 }
 
 async function processDocument({


### PR DESCRIPTION
Extract events hooks filter was returning yes if there was a marker in the processed doc.

This PR adds a tiny bit of logic to check that at least one of these markers is related to an active schema for this workspace, otherwise no need to process the doc :) 
