### PR TITLE
chore: migrate core api TS bindings to param objects

### DIFF
--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -484,10 +484,10 @@ const dataSource = async (command: string, args: parseArgs.ParsedArgs) => {
         );
       }
 
-      await CoreAPI.deleteDataSource(
-        dataSource.dustAPIProjectId,
-        dataSource.name
-      );
+      await CoreAPI.deleteDataSource({
+        projectId: dataSource.dustAPIProjectId,
+        dataSourceName: dataSource.name,
+      });
 
       await dataSource.destroy();
 

--- a/front/lib/api/datasets.ts
+++ b/front/lib/api/datasets.ts
@@ -81,7 +81,9 @@ export async function getDatasetHash(
 
   // Translate latest if needed.
   if (hash == "latest") {
-    const apiDatasets = await CoreAPI.getDatasets(app.dustAPIProjectId);
+    const apiDatasets = await CoreAPI.getDatasets({
+      projectId: app.dustAPIProjectId,
+    });
 
     if (apiDatasets.isErr()) {
       return null;
@@ -96,11 +98,11 @@ export async function getDatasetHash(
     hash = apiDatasets.value.datasets[dataset.name][0].hash;
   }
 
-  const apiDataset = await CoreAPI.getDataset(
-    app.dustAPIProjectId,
-    dataset.name,
-    hash
-  );
+  const apiDataset = await CoreAPI.getDataset({
+    projectId: app.dustAPIProjectId,
+    datasetName: dataset.name,
+    datasetHash: hash,
+  });
 
   if (apiDataset.isErr()) {
     return null;

--- a/front/lib/api/run.ts
+++ b/front/lib/api/run.ts
@@ -22,7 +22,10 @@ export async function getRun(
   config: RunConfig;
   run: RunType;
 } | null> {
-  const r = await CoreAPI.getRunStatus(app.dustAPIProjectId, runId as string);
+  const r = await CoreAPI.getRunStatus({
+    projectId: app.dustAPIProjectId,
+    runId: runId as string,
+  });
   if (r.isErr()) {
     return null;
   }
@@ -32,10 +35,10 @@ export async function getRun(
   // Retrieve specification and parse it.
   const specHash = run.app_hash;
 
-  const s = await CoreAPI.getSpecification(
-    app.dustAPIProjectId,
-    specHash as string
-  );
+  const s = await CoreAPI.getSpecification({
+    projectId: app.dustAPIProjectId,
+    specificationHash: specHash as string,
+  });
 
   if (s.isErr()) {
     return null;

--- a/front/lib/core_api.ts
+++ b/front/lib/core_api.ts
@@ -388,16 +388,16 @@ export const CoreAPI = {
   async getRunBlock({
     projectId,
     runId,
-    runType,
+    blockType,
     blockName,
   }: {
     projectId: string;
     runId: string;
-    runType: BlockType;
+    blockType: BlockType;
     blockName: string;
   }): Promise<CoreAPIResponse<{ run: CoreAPIRun }>> {
     const response = await fetch(
-      `${CORE_API}/projects/${projectId}/runs/${runId}/blocks/${runType}/${blockName}`,
+      `${CORE_API}/projects/${projectId}/runs/${runId}/blocks/${blockType}/${blockName}`,
       {
         method: "GET",
       }

--- a/front/lib/core_api.ts
+++ b/front/lib/core_api.ts
@@ -80,7 +80,9 @@ export type CoreAPIRun = {
   traces: Array<[[BlockType, string], Array<Array<TraceType>>]>;
 };
 
-type CoreAPICreateRunPayload = {
+type CoreAPICreateRunParams = {
+  projectId: string;
+  runAsWorkspaceId: string;
   runType: RunRunType;
   specification?: string | null;
   specificationHash?: string | null;
@@ -98,21 +100,6 @@ type GetDatasetsResponse = {
   datasets: { [key: string]: CoreAPIDatasetVersion[] };
 };
 
-type CoreAPICreateDataSourcePayload = {
-  dataSourceId: string;
-  config: CoreAPIDataSourceConfig;
-  credentials: CredentialsType;
-};
-
-type CoreAPIUpsertDocumentPayload = {
-  documentId: string;
-  timestamp?: number | null;
-  tags: string[];
-  sourceUrl?: string | null;
-  text: string;
-  credentials: CredentialsType;
-};
-
 export const CoreAPI = {
   async createProject(): Promise<CoreAPIResponse<{ project: Project }>> {
     const response = await fetch(`${CORE_API}/projects`, {
@@ -121,9 +108,11 @@ export const CoreAPI = {
     return _resultFromResponse(response);
   },
 
-  async getDatasets(
-    projectId: string
-  ): Promise<CoreAPIResponse<GetDatasetsResponse>> {
+  async getDatasets({
+    projectId,
+  }: {
+    projectId: string;
+  }): Promise<CoreAPIResponse<GetDatasetsResponse>> {
     const response = await fetch(`${CORE_API}/projects/${projectId}/datasets`, {
       method: "GET",
       headers: {
@@ -134,11 +123,15 @@ export const CoreAPI = {
     return _resultFromResponse(response);
   },
 
-  async getDataset(
-    projectId: string,
-    datasetName: string,
-    datasetHash: string
-  ): Promise<CoreAPIResponse<GetDatasetResponse>> {
+  async getDataset({
+    projectId,
+    datasetName,
+    datasetHash,
+  }: {
+    projectId: string;
+    datasetName: string;
+    datasetHash: string;
+  }): Promise<CoreAPIResponse<GetDatasetResponse>> {
     const response = await fetch(
       `${CORE_API}/projects/${projectId}/datasets/${datasetName}/${datasetHash}`,
       {
@@ -152,11 +145,15 @@ export const CoreAPI = {
     return _resultFromResponse(response);
   },
 
-  async createDataset(
-    projectId: string,
-    datasetId: string,
-    data: any[]
-  ): Promise<CoreAPIResponse<{ dataset: CoreAPIDatasetWithoutData }>> {
+  async createDataset({
+    projectId,
+    datasetId,
+    data,
+  }: {
+    projectId: string;
+    datasetId: string;
+    data: any[];
+  }): Promise<CoreAPIResponse<{ dataset: CoreAPIDatasetWithoutData }>> {
     const response = await fetch(`${CORE_API}/projects/${projectId}/datasets`, {
       method: "POST",
       headers: {
@@ -171,9 +168,11 @@ export const CoreAPI = {
     return _resultFromResponse(response);
   },
 
-  async cloneProject(
-    projectId: string
-  ): Promise<CoreAPIResponse<{ project: Project }>> {
+  async cloneProject({
+    projectId,
+  }: {
+    projectId: string;
+  }): Promise<CoreAPIResponse<{ project: Project }>> {
     const response = await fetch(`${CORE_API}/projects/${projectId}/clone`, {
       method: "POST",
     });
@@ -181,11 +180,17 @@ export const CoreAPI = {
     return _resultFromResponse(response);
   },
 
-  async createRun(
-    projectId: string,
-    runAsWorkspaceId: string,
-    payload: CoreAPICreateRunPayload
-  ): Promise<CoreAPIResponse<{ run: CoreAPIRun }>> {
+  async createRun({
+    projectId,
+    runAsWorkspaceId,
+    runType,
+    specification,
+    specificationHash,
+    datasetId,
+    inputs,
+    config,
+    credentials,
+  }: CoreAPICreateRunParams): Promise<CoreAPIResponse<{ run: CoreAPIRun }>> {
     const response = await fetch(`${CORE_API}/projects/${projectId}/runs`, {
       method: "POST",
       headers: {
@@ -193,24 +198,30 @@ export const CoreAPI = {
         "X-Dust-Workspace-Id": runAsWorkspaceId,
       },
       body: JSON.stringify({
-        run_type: payload.runType,
-        specification: payload.specification,
-        specification_hash: payload.specificationHash,
-        dataset_id: payload.datasetId,
-        inputs: payload.inputs,
-        config: payload.config,
-        credentials: payload.credentials,
+        run_type: runType,
+        specification: specification,
+        specification_hash: specificationHash,
+        dataset_id: datasetId,
+        inputs: inputs,
+        config: config,
+        credentials: credentials,
       }),
     });
 
     return _resultFromResponse(response);
   },
 
-  async createRunStream(
-    projectId: string,
-    runAsWorkspaceId: string,
-    payload: CoreAPICreateRunPayload
-  ): Promise<
+  async createRunStream({
+    projectId,
+    runAsWorkspaceId,
+    runType,
+    specification,
+    specificationHash,
+    datasetId,
+    inputs,
+    config,
+    credentials,
+  }: CoreAPICreateRunParams): Promise<
     CoreAPIResponse<{
       chunkStream: AsyncGenerator<Uint8Array, void, unknown>;
       dustRunId: Promise<string>;
@@ -225,13 +236,13 @@ export const CoreAPI = {
           "X-Dust-Workspace-Id": runAsWorkspaceId,
         },
         body: JSON.stringify({
-          run_type: payload.runType,
-          specification: payload.specification,
-          specification_hash: payload.specificationHash,
-          dataset_id: payload.datasetId,
-          inputs: payload.inputs,
-          config: payload.config,
-          credentials: payload.credentials,
+          run_type: runType,
+          specification: specification,
+          specification_hash: specificationHash,
+          dataset_id: datasetId,
+          inputs: inputs,
+          config: config,
+          credentials: credentials,
         }),
       }
     );
@@ -298,10 +309,13 @@ export const CoreAPI = {
     return new Ok({ chunkStream: streamChunks(), dustRunId: dustRunIdPromise });
   },
 
-  async getRunsBatch(
-    projectId: string,
-    dustRunIds: string[]
-  ): Promise<CoreAPIResponse<{ runs: { [key: string]: CoreAPIRun } }>> {
+  async getRunsBatch({
+    projectId,
+    dustRunIds,
+  }: {
+    projectId: string;
+    dustRunIds: string[];
+  }): Promise<CoreAPIResponse<{ runs: { [key: string]: CoreAPIRun } }>> {
     const response = await fetch(
       `${CORE_API}/projects/${projectId}/runs/batch`,
       {
@@ -318,10 +332,13 @@ export const CoreAPI = {
     return _resultFromResponse(response);
   },
 
-  async getRun(
-    projectId: string,
-    runId: string
-  ): Promise<CoreAPIResponse<{ run: CoreAPIRun }>> {
+  async getRun({
+    projectId,
+    runId,
+  }: {
+    projectId: string;
+    runId: string;
+  }): Promise<CoreAPIResponse<{ run: CoreAPIRun }>> {
     const response = await fetch(
       `${CORE_API}/projects/${projectId}/runs/${runId}`,
       {
@@ -332,10 +349,13 @@ export const CoreAPI = {
     return _resultFromResponse(response);
   },
 
-  async getRunStatus(
-    projectId: string,
-    runId: string
-  ): Promise<CoreAPIResponse<{ run: CoreAPIRun }>> {
+  async getRunStatus({
+    projectId,
+    runId,
+  }: {
+    projectId: string;
+    runId: string;
+  }): Promise<CoreAPIResponse<{ run: CoreAPIRun }>> {
     const response = await fetch(
       `${CORE_API}/projects/${projectId}/runs/${runId}/status`,
       {
@@ -346,10 +366,13 @@ export const CoreAPI = {
     return _resultFromResponse(response);
   },
 
-  async getSpecification(
-    projectId: string,
-    specificationHash: string
-  ): Promise<
+  async getSpecification({
+    projectId,
+    specificationHash,
+  }: {
+    projectId: string;
+    specificationHash: string;
+  }): Promise<
     CoreAPIResponse<{ specification: { created: number; data: string } }>
   > {
     const response = await fetch(
@@ -362,12 +385,17 @@ export const CoreAPI = {
     return _resultFromResponse(response);
   },
 
-  async getRunBlock(
-    projectId: string,
-    runId: string,
-    runType: BlockType,
-    blockName: string
-  ): Promise<CoreAPIResponse<{ run: CoreAPIRun }>> {
+  async getRunBlock({
+    projectId,
+    runId,
+    runType,
+    blockName,
+  }: {
+    projectId: string;
+    runId: string;
+    runType: BlockType;
+    blockName: string;
+  }): Promise<CoreAPIResponse<{ run: CoreAPIRun }>> {
     const response = await fetch(
       `${CORE_API}/projects/${projectId}/runs/${runId}/blocks/${runType}/${blockName}`,
       {
@@ -378,10 +406,17 @@ export const CoreAPI = {
     return _resultFromResponse(response);
   },
 
-  async createDataSource(
-    projectId: string,
-    payload: CoreAPICreateDataSourcePayload
-  ): Promise<CoreAPIResponse<{ data_source: CoreAPIDataSource }>> {
+  async createDataSource({
+    projectId,
+    dataSourceId,
+    config,
+    credentials,
+  }: {
+    projectId: string;
+    dataSourceId: string;
+    config: CoreAPIDataSourceConfig;
+    credentials: CredentialsType;
+  }): Promise<CoreAPIResponse<{ data_source: CoreAPIDataSource }>> {
     const response = await fetch(
       `${CORE_API}/projects/${projectId}/data_sources`,
       {
@@ -390,9 +425,9 @@ export const CoreAPI = {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          data_source_id: payload.dataSourceId,
-          config: payload.config,
-          credentials: payload.credentials,
+          data_source_id: dataSourceId,
+          config: config,
+          credentials: credentials,
         }),
       }
     );
@@ -400,10 +435,13 @@ export const CoreAPI = {
     return _resultFromResponse(response);
   },
 
-  async deleteDataSource(
-    projectId: string,
-    dataSourceName: string
-  ): Promise<CoreAPIResponse<{ data_source: CoreAPIDataSource }>> {
+  async deleteDataSource({
+    projectId,
+    dataSourceName,
+  }: {
+    projectId: string;
+    dataSourceName: string;
+  }): Promise<CoreAPIResponse<{ data_source: CoreAPIDataSource }>> {
     const response = await fetch(
       `${CORE_API}/projects/${projectId}/data_sources/${dataSourceName}`,
       {
@@ -456,12 +494,17 @@ export const CoreAPI = {
     return _resultFromResponse(response);
   },
 
-  async getDataSourceDocuments(
-    projectId: string,
-    dataSourceName: string,
-    limit: number,
-    offset: number
-  ): Promise<
+  async getDataSourceDocuments({
+    projectId,
+    dataSourceName,
+    limit,
+    offset,
+  }: {
+    projectId: string;
+    dataSourceName: string;
+    limit: number;
+    offset: number;
+  }): Promise<
     CoreAPIResponse<{
       offset: number;
       limit: number;
@@ -479,12 +522,17 @@ export const CoreAPI = {
     return _resultFromResponse(response);
   },
 
-  async getDataSourceDocument(
-    projectId: string,
-    dataSourceName: string,
-    documentId: string,
-    versionHash?: string | null
-  ): Promise<
+  async getDataSourceDocument({
+    projectId,
+    dataSourceName,
+    documentId,
+    versionHash,
+  }: {
+    projectId: string;
+    dataSourceName: string;
+    documentId: string;
+    versionHash?: string | null;
+  }): Promise<
     CoreAPIResponse<{
       document: CoreAPIDocument;
       data_source: CoreAPIDataSource;
@@ -503,14 +551,21 @@ export const CoreAPI = {
     return _resultFromResponse(response);
   },
 
-  async getDataSourceDocumentVersions(
-    projectId: string,
-    dataSourceName: string,
-    documentId: string,
+  async getDataSourceDocumentVersions({
+    projectId,
+    dataSourceName,
+    documentId,
+    latest_hash,
     limit = 10,
     offset = 0,
-    latest_hash?: string | null
-  ): Promise<
+  }: {
+    projectId: string;
+    dataSourceName: string;
+    documentId: string;
+    limit: number;
+    offset: number;
+    latest_hash?: string | null;
+  }): Promise<
     CoreAPIResponse<{
       document_versions: { hash: string; created: number }[];
     }>
@@ -536,11 +591,25 @@ export const CoreAPI = {
     return _resultFromResponse(response);
   },
 
-  async upsertDataSourceDocument(
-    projectId: string,
-    dataSourceName: string,
-    payload: CoreAPIUpsertDocumentPayload
-  ): Promise<
+  async upsertDataSourceDocument({
+    projectId,
+    dataSourceName,
+    documentId,
+    timestamp,
+    tags,
+    sourceUrl,
+    text,
+    credentials,
+  }: {
+    projectId: string;
+    dataSourceName: string;
+    documentId: string;
+    timestamp?: number | null;
+    tags: string[];
+    sourceUrl?: string | null;
+    text: string;
+    credentials: CredentialsType;
+  }): Promise<
     CoreAPIResponse<{
       document: CoreAPIDocument;
       data_source: CoreAPIDataSource;
@@ -554,12 +623,12 @@ export const CoreAPI = {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          document_id: payload.documentId,
-          timestamp: payload.timestamp,
-          text: payload.text,
-          tags: payload.tags,
-          source_url: payload.sourceUrl,
-          credentials: payload.credentials,
+          document_id: documentId,
+          timestamp: timestamp,
+          text: text,
+          tags: tags,
+          source_url: sourceUrl,
+          credentials: credentials,
         }),
       }
     );
@@ -567,22 +636,26 @@ export const CoreAPI = {
     return _resultFromResponse(response);
   },
 
-  async updateDataSourceDocumentTags(
-    projectId: string,
-    dataSourceName: string,
-    payload: {
-      documentId: string;
-      add_tags?: string[];
-      remove_tags?: string[];
-    }
-  ): Promise<
+  async updateDataSourceDocumentTags({
+    projectId,
+    dataSourceName,
+    documentId,
+    addTags,
+    removeTags,
+  }: {
+    projectId: string;
+    dataSourceName: string;
+    documentId: string;
+    addTags?: string[];
+    removeTags?: string[];
+  }): Promise<
     CoreAPIResponse<{
       data_source: CoreAPIDataSource;
     }>
   > {
     const response = await fetch(
       `${CORE_API}/projects/${projectId}/data_sources/${dataSourceName}/documents/${encodeURIComponent(
-        payload.documentId
+        documentId
       )}/tags`,
       {
         method: "PATCH",
@@ -590,8 +663,8 @@ export const CoreAPI = {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          add_tags: payload.add_tags,
-          remove_tags: payload.remove_tags,
+          add_tags: addTags,
+          remove_tags: removeTags,
         }),
       }
     );
@@ -599,11 +672,15 @@ export const CoreAPI = {
     return _resultFromResponse(response);
   },
 
-  async deleteDataSourceDocument(
-    projectId: string,
-    dataSourceName: string,
-    documentId: string
-  ): Promise<CoreAPIResponse<{ data_source: CoreAPIDataSource }>> {
+  async deleteDataSourceDocument({
+    projectId,
+    dataSourceName,
+    documentId,
+  }: {
+    projectId: string;
+    dataSourceName: string;
+    documentId: string;
+  }): Promise<CoreAPIResponse<{ data_source: CoreAPIDataSource }>> {
     const response = await fetch(
       `${CORE_API}/projects/${projectId}/data_sources/${dataSourceName}/documents/${encodeURIComponent(
         documentId

--- a/front/lib/document_tracker.ts
+++ b/front/lib/document_tracker.ts
@@ -148,22 +148,18 @@ export async function updateTrackedDocuments(
   }));
 
   if (hasExistingTrackedDocs && !hasRemainingTrackedDocs) {
-    await CoreAPI.updateDataSourceDocumentTags(
-      dataSource.dustAPIProjectId,
-      dataSource.name,
-      {
-        documentId,
-        remove_tags: ["__DUST_TRACKED"],
-      }
-    );
+    await CoreAPI.updateDataSourceDocumentTags({
+      projectId: dataSource.dustAPIProjectId,
+      dataSourceName: dataSource.name,
+      removeTags: ["__DUST_TRACKED"],
+      documentId,
+    });
   } else if (!hasExistingTrackedDocs && hasRemainingTrackedDocs) {
-    await CoreAPI.updateDataSourceDocumentTags(
-      dataSource.dustAPIProjectId,
-      dataSource.name,
-      {
-        documentId,
-        add_tags: ["__DUST_TRACKED"],
-      }
-    );
+    await CoreAPI.updateDataSourceDocumentTags({
+      projectId: dataSource.dustAPIProjectId,
+      dataSourceName: dataSource.name,
+      addTags: ["__DUST_TRACKED"],
+      documentId,
+    });
   }
 }

--- a/front/migrations/20230522_slack_doc_rename_incident.ts
+++ b/front/migrations/20230522_slack_doc_rename_incident.ts
@@ -23,10 +23,10 @@ async function main() {
           throw new Error("No connectorId found");
         }
 
-        const dds = await CoreAPI.deleteDataSource(
-          ds.dustAPIProjectId,
-          ds.name
-        );
+        const dds = await CoreAPI.deleteDataSource({
+          projectId: ds.dustAPIProjectId,
+          dataSourceName: ds.name,
+        });
 
         if (dds.isErr()) {
           throw new Error("Failed to delete the Data Source from Core");
@@ -50,20 +50,18 @@ async function main() {
         // Dust managed credentials: managed data source.
         const credentials = dustManagedCredentials();
 
-        const dustDataSource = await CoreAPI.createDataSource(
-          dustProject.value.project.project_id.toString(),
-          {
-            dataSourceId: dataSourceName,
-            config: {
-              provider_id: dataSourceProviderId,
-              model_id: dataSourceModelId,
-              splitter_id: "base_v0",
-              max_chunk_size: dataSourceMaxChunkSize,
-              use_cache: false,
-            },
-            credentials,
-          }
-        );
+        const dustDataSource = await CoreAPI.createDataSource({
+          projectId: dustProject.value.project.project_id.toString(),
+          dataSourceId: dataSourceName,
+          config: {
+            provider_id: dataSourceProviderId,
+            model_id: dataSourceModelId,
+            splitter_id: "base_v0",
+            max_chunk_size: dataSourceMaxChunkSize,
+            use_cache: false,
+          },
+          credentials,
+        });
 
         if (dustDataSource.isErr()) {
           throw new Error("Failed to create Core DataSource");

--- a/front/pages/api/v1/w/[wId]/apps/[aId]/runs/[runId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/apps/[aId]/runs/[runId]/index.ts
@@ -73,7 +73,10 @@ async function handler(
       // TODO(spolu): This is borderline security-wise as it allows to recover a full run from the
       // runId assuming the app is public. We should use getRun and also enforce in getRun that we
       // retrieve only our own runs. Basically this assumes the `runId` as a secret.
-      const runRes = await CoreAPI.getRun(app.dustAPIProjectId, runId);
+      const runRes = await CoreAPI.getRun({
+        projectId: app.dustAPIProjectId,
+        runId,
+      });
       if (runRes.isErr()) {
         return apiError(req, res, {
           status_code: 400,

--- a/front/pages/api/v1/w/[wId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/v1/w/[wId]/apps/[aId]/runs/index.ts
@@ -168,17 +168,15 @@ async function handler(
 
       // If `stream` is true, run in streaming mode.
       if (req.body.stream) {
-        const runRes = await CoreAPI.createRunStream(
-          app.dustAPIProjectId,
-          keyWorkspaceId,
-          {
-            runType: "deploy",
-            specificationHash: specificationHash,
-            config: { blocks: config },
-            inputs,
-            credentials,
-          }
-        );
+        const runRes = await CoreAPI.createRunStream({
+          projectId: app.dustAPIProjectId,
+          runAsWorkspaceId: keyWorkspaceId,
+          runType: "deploy",
+          specificationHash: specificationHash,
+          config: { blocks: config },
+          inputs,
+          credentials,
+        });
 
         if (runRes.isErr()) {
           return apiError(req, res, {
@@ -235,17 +233,15 @@ async function handler(
         return;
       }
 
-      const runRes = await CoreAPI.createRun(
-        app.dustAPIProjectId,
-        keyWorkspaceId,
-        {
-          runType: "deploy",
-          specificationHash: specificationHash,
-          config: { blocks: config },
-          inputs,
-          credentials,
-        }
-      );
+      const runRes = await CoreAPI.createRun({
+        projectId: app.dustAPIProjectId,
+        runAsWorkspaceId: keyWorkspaceId,
+        runType: "deploy",
+        specificationHash: specificationHash,
+        config: { blocks: config },
+        inputs,
+        credentials,
+      });
 
       if (runRes.isErr()) {
         return apiError(req, res, {
@@ -275,10 +271,10 @@ async function handler(
         try {
           await poll({
             fn: async () => {
-              const run = await CoreAPI.getRunStatus(
-                app.dustAPIProjectId,
-                runId
-              );
+              const run = await CoreAPI.getRunStatus({
+                projectId: app.dustAPIProjectId,
+                runId,
+              });
               if (run.isErr()) {
                 return { status: "error" };
               }
@@ -307,7 +303,10 @@ async function handler(
         }
 
         // Finally refresh the run object.
-        const runRes = await CoreAPI.getRun(app.dustAPIProjectId, runId);
+        const runRes = await CoreAPI.getRun({
+          projectId: app.dustAPIProjectId,
+          runId,
+        });
         if (runRes.isErr()) {
           return apiError(req, res, {
             status_code: 400,

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
@@ -81,11 +81,11 @@ async function handler(
 
   switch (req.method) {
     case "GET":
-      const docRes = await CoreAPI.getDataSourceDocument(
-        dataSource.dustAPIProjectId,
-        dataSource.name,
-        req.query.documentId as string
-      );
+      const docRes = await CoreAPI.getDataSourceDocument({
+        projectId: dataSource.dustAPIProjectId,
+        dataSourceName: dataSource.name,
+        documentId: req.query.documentId as string,
+      });
 
       if (docRes.isErr()) {
         return apiError(req, res, {
@@ -194,12 +194,12 @@ async function handler(
       }
 
       // Enforce plan limits.
-      const documents = await CoreAPI.getDataSourceDocuments(
-        dataSource.dustAPIProjectId,
-        dataSource.name,
-        1,
-        0
-      );
+      const documents = await CoreAPI.getDataSourceDocuments({
+        projectId: dataSource.dustAPIProjectId,
+        dataSourceName: dataSource.name,
+        limit: 1,
+        offset: 0,
+      });
 
       if (documents.isErr()) {
         return apiError(req, res, {
@@ -257,18 +257,16 @@ async function handler(
       }
 
       // Create document with the Dust internal API.
-      const upsertRes = await CoreAPI.upsertDataSourceDocument(
-        dataSource.dustAPIProjectId,
-        dataSource.name,
-        {
-          documentId: req.query.documentId as string,
-          timestamp,
-          tags,
-          sourceUrl,
-          text: req.body.text,
-          credentials,
-        }
-      );
+      const upsertRes = await CoreAPI.upsertDataSourceDocument({
+        projectId: dataSource.dustAPIProjectId,
+        dataSourceName: dataSource.name,
+        documentId: req.query.documentId as string,
+        timestamp,
+        tags,
+        sourceUrl,
+        text: req.body.text,
+        credentials,
+      });
 
       if (upsertRes.isErr()) {
         return apiError(req, res, {
@@ -331,11 +329,11 @@ async function handler(
         });
       }
 
-      const delRes = await CoreAPI.deleteDataSourceDocument(
-        dataSource.dustAPIProjectId,
-        dataSource.name,
-        req.query.documentId as string
-      );
+      const delRes = await CoreAPI.deleteDataSourceDocument({
+        projectId: dataSource.dustAPIProjectId,
+        dataSourceName: dataSource.name,
+        documentId: req.query.documentId as string,
+      });
 
       if (delRes.isErr()) {
         return apiError(req, res, {

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/index.ts
@@ -44,12 +44,12 @@ async function handler(
         ? parseInt(req.query.offset as string)
         : 0;
 
-      const documents = await CoreAPI.getDataSourceDocuments(
-        dataSource.dustAPIProjectId,
-        dataSource.name,
+      const documents = await CoreAPI.getDataSourceDocuments({
+        projectId: dataSource.dustAPIProjectId,
+        dataSourceName: dataSource.name,
         limit,
-        offset
-      );
+        offset,
+      });
       if (documents.isErr()) {
         return apiError(req, res, {
           status_code: 400,

--- a/front/pages/api/w/[wId]/apps/[aId]/clone.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/clone.ts
@@ -90,7 +90,9 @@ async function handler(
         return;
       }
 
-      const project = await CoreAPI.cloneProject(app.dustAPIProjectId);
+      const project = await CoreAPI.cloneProject({
+        projectId: app.dustAPIProjectId,
+      });
       if (project.isErr()) {
         return apiError(req, res, {
           status_code: 404,

--- a/front/pages/api/w/[wId]/apps/[aId]/datasets/[name]/index.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/datasets/[name]/index.ts
@@ -116,11 +116,11 @@ async function handler(
       });
 
       // Register dataset with the Dust internal API.
-      const d = await CoreAPI.createDataset(
-        app.dustAPIProjectId,
-        req.body.name,
-        data
-      );
+      const d = await CoreAPI.createDataset({
+        projectId: app.dustAPIProjectId,
+        datasetId: req.body.name,
+        data,
+      });
       if (d.isErr()) {
         return apiError(req, res, {
           status_code: 500,

--- a/front/pages/api/w/[wId]/apps/[aId]/datasets/index.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/datasets/index.ts
@@ -137,11 +137,11 @@ async function handler(
           }, {});
       });
 
-      const dataset = await CoreAPI.createDataset(
-        app.dustAPIProjectId,
-        req.body.name,
-        data
-      );
+      const dataset = await CoreAPI.createDataset({
+        projectId: app.dustAPIProjectId,
+        datasetId: req.body.name,
+        data,
+      });
       if (dataset.isErr()) {
         return apiError(req, res, {
           status_code: 500,

--- a/front/pages/api/w/[wId]/apps/[aId]/runs/[runId]/blocks/[type]/[name]/index.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/runs/[runId]/blocks/[type]/[name]/index.ts
@@ -50,12 +50,12 @@ async function handler(
         return;
       }
 
-      const run = await CoreAPI.getRunBlock(
-        app.dustAPIProjectId,
-        runId as string,
-        req.query.type as BlockType,
-        req.query.name as string
-      );
+      const run = await CoreAPI.getRunBlock({
+        projectId: app.dustAPIProjectId,
+        runId: runId as string,
+        blockType: req.query.type as BlockType,
+        blockName: req.query.name as string,
+      });
 
       if (run.isErr()) {
         return apiError(req, res, {

--- a/front/pages/api/w/[wId]/apps/[aId]/runs/[runId]/status.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/runs/[runId]/status.ts
@@ -44,10 +44,10 @@ async function handler(
         return;
       }
 
-      const run = await CoreAPI.getRunStatus(
-        app.dustAPIProjectId,
-        runId as string
-      );
+      const run = await CoreAPI.getRunStatus({
+        projectId: app.dustAPIProjectId,
+        runId: runId as string,
+      });
       if (run.isErr()) {
         return apiError(req, res, {
           status_code: 500,

--- a/front/pages/api/w/[wId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/runs/index.ts
@@ -95,17 +95,15 @@ async function handler(
             });
           }
 
-          const streamRes = await CoreAPI.createRunStream(
-            app.dustAPIProjectId,
-            owner.sId,
-            {
-              runType: "execute",
-              specificationHash: req.body.specificationHash,
-              inputs: req.body.inputs,
-              config: { blocks: JSON.parse(req.body.config) },
-              credentials: credentialsFromProviders(providers),
-            }
-          );
+          const streamRes = await CoreAPI.createRunStream({
+            projectId: app.dustAPIProjectId,
+            runAsWorkspaceId: owner.sId,
+            runType: "execute",
+            specificationHash: req.body.specificationHash,
+            inputs: req.body.inputs,
+            config: { blocks: JSON.parse(req.body.config) },
+            credentials: credentialsFromProviders(providers),
+          });
 
           if (streamRes.isErr()) {
             return apiError(req, res, {
@@ -180,7 +178,9 @@ async function handler(
             });
           }
 
-          const datasets = await CoreAPI.getDatasets(app.dustAPIProjectId);
+          const datasets = await CoreAPI.getDatasets({
+            projectId: app.dustAPIProjectId,
+          });
           if (datasets.isErr()) {
             return apiError(req, res, {
               status_code: 500,
@@ -205,20 +205,18 @@ async function handler(
             ? inputConfigEntry.dataset
             : null;
 
-          const dustRun = await CoreAPI.createRun(
-            app.dustAPIProjectId,
-            owner.sId,
-            {
-              runType: "local",
-              specification: dumpSpecification(
-                JSON.parse(req.body.specification),
-                latestDatasets
-              ),
-              datasetId: inputDataset,
-              config: { blocks: config },
-              credentials: credentialsFromProviders(providers),
-            }
-          );
+          const dustRun = await CoreAPI.createRun({
+            projectId: app.dustAPIProjectId,
+            runAsWorkspaceId: owner.sId,
+            runType: "local",
+            specification: dumpSpecification(
+              JSON.parse(req.body.specification),
+              latestDatasets
+            ),
+            datasetId: inputDataset,
+            config: { blocks: config },
+            credentials: credentialsFromProviders(providers),
+          });
 
           if (dustRun.isErr()) {
             return apiError(req, res, {
@@ -333,10 +331,10 @@ async function handler(
       });
       const userDustRunIds = userRuns.map((r) => r.dustRunId);
 
-      const dustRuns = await CoreAPI.getRunsBatch(
-        app.dustAPIProjectId,
-        userDustRunIds
-      );
+      const dustRuns = await CoreAPI.getRunsBatch({
+        projectId: app.dustAPIProjectId,
+        dustRunIds: userDustRunIds,
+      });
 
       if (dustRuns.isErr()) {
         return apiError(req, res, {

--- a/front/pages/api/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
@@ -125,12 +125,12 @@ async function handler(
       }
 
       // Enforce plan limits.
-      const documents = await CoreAPI.getDataSourceDocuments(
-        dataSource.dustAPIProjectId,
-        dataSource.name,
-        1,
-        0
-      );
+      const documents = await CoreAPI.getDataSourceDocuments({
+        projectId: dataSource.dustAPIProjectId,
+        dataSourceName: dataSource.name,
+        limit: 1,
+        offset: 0,
+      });
       if (documents.isErr()) {
         return apiError(req, res, {
           status_code: 400,
@@ -177,17 +177,15 @@ async function handler(
       const credentials = dustManagedCredentials();
 
       // Create document with the Dust internal API.
-      const data = await CoreAPI.upsertDataSourceDocument(
-        dataSource.dustAPIProjectId,
-        dataSource.name,
-        {
-          documentId: req.query.documentId as string,
-          tags,
-          sourceUrl,
-          credentials,
-          text: req.body.text,
-        }
-      );
+      const data = await CoreAPI.upsertDataSourceDocument({
+        projectId: dataSource.dustAPIProjectId,
+        dataSourceName: dataSource.name,
+        documentId: req.query.documentId as string,
+        tags,
+        sourceUrl,
+        credentials,
+        text: req.body.text,
+      });
       if (data.isErr()) {
         return apiError(req, res, {
           status_code: 500,
@@ -205,11 +203,11 @@ async function handler(
       return;
 
     case "GET":
-      const document = await CoreAPI.getDataSourceDocument(
-        dataSource.dustAPIProjectId,
-        dataSource.name,
-        req.query.documentId as string
-      );
+      const document = await CoreAPI.getDataSourceDocument({
+        projectId: dataSource.dustAPIProjectId,
+        dataSourceName: dataSource.name,
+        documentId: req.query.documentId as string,
+      });
 
       if (document.isErr()) {
         return apiError(req, res, {
@@ -250,11 +248,11 @@ async function handler(
         });
       }
 
-      const deleteRes = await CoreAPI.deleteDataSourceDocument(
-        dataSource.dustAPIProjectId,
-        dataSource.name,
-        req.query.documentId as string
-      );
+      const deleteRes = await CoreAPI.deleteDataSourceDocument({
+        projectId: dataSource.dustAPIProjectId,
+        dataSourceName: dataSource.name,
+        documentId: req.query.documentId as string,
+      });
 
       if (deleteRes.isErr()) {
         return apiError(req, res, {

--- a/front/pages/api/w/[wId]/data_sources/[name]/documents/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/documents/index.ts
@@ -41,12 +41,12 @@ async function handler(
         ? parseInt(req.query.offset as string)
         : 0;
 
-      const documents = await CoreAPI.getDataSourceDocuments(
-        dataSource.dustAPIProjectId,
-        dataSource.name,
+      const documents = await CoreAPI.getDataSourceDocuments({
+        projectId: dataSource.dustAPIProjectId,
+        dataSourceName: dataSource.name,
         limit,
-        offset
-      );
+        offset,
+      });
 
       if (documents.isErr()) {
         res.status(400).end();

--- a/front/pages/api/w/[wId]/data_sources/[name]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/index.ts
@@ -159,10 +159,10 @@ async function handler(
         });
       }
 
-      const dustDataSource = await CoreAPI.deleteDataSource(
-        dataSource.dustAPIProjectId,
-        dataSource.name
-      );
+      const dustDataSource = await CoreAPI.deleteDataSource({
+        projectId: dataSource.dustAPIProjectId,
+        dataSourceName: dataSource.name,
+      });
 
       if (dustDataSource.isErr()) {
         return apiError(req, res, {

--- a/front/pages/api/w/[wId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/index.ts
@@ -123,20 +123,18 @@ async function handler(
       // Dust managed credentials: all data sources.
       const credentials = dustManagedCredentials();
 
-      const dustDataSource = await CoreAPI.createDataSource(
-        dustProject.value.project.project_id.toString(),
-        {
-          dataSourceId: req.body.name as string,
-          config: {
-            provider_id: dataSourceProviderId,
-            model_id: dataSourceModelId,
-            splitter_id: "base_v0",
-            max_chunk_size: dataSourceMaxChunkSize,
-            use_cache: false,
-          },
-          credentials,
-        }
-      );
+      const dustDataSource = await CoreAPI.createDataSource({
+        projectId: dustProject.value.project.project_id.toString(),
+        dataSourceId: req.body.name as string,
+        config: {
+          provider_id: dataSourceProviderId,
+          model_id: dataSourceModelId,
+          splitter_id: "base_v0",
+          max_chunk_size: dataSourceMaxChunkSize,
+          use_cache: false,
+        },
+        credentials,
+      });
 
       if (dustDataSource.isErr()) {
         return apiError(req, res, {

--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -162,20 +162,18 @@ async function handler(
       // Dust managed credentials: managed data source.
       const credentials = dustManagedCredentials();
 
-      const dustDataSource = await CoreAPI.createDataSource(
-        dustProject.value.project.project_id.toString(),
-        {
-          dataSourceId: dataSourceName,
-          config: {
-            provider_id: dataSourceProviderId,
-            model_id: dataSourceModelId,
-            splitter_id: "base_v0",
-            max_chunk_size: dataSourceMaxChunkSize,
-            use_cache: false,
-          },
-          credentials,
-        }
-      );
+      const dustDataSource = await CoreAPI.createDataSource({
+        projectId: dustProject.value.project.project_id.toString(),
+        dataSourceId: dataSourceName,
+        config: {
+          provider_id: dataSourceProviderId,
+          model_id: dataSourceModelId,
+          splitter_id: "base_v0",
+          max_chunk_size: dataSourceMaxChunkSize,
+          use_cache: false,
+        },
+        credentials,
+      });
 
       if (dustDataSource.isErr()) {
         return apiError(req, res, {
@@ -212,10 +210,10 @@ async function handler(
           "Failed to create the connector"
         );
         await dataSource.destroy();
-        const deleteRes = await CoreAPI.deleteDataSource(
-          dustProject.value.project.project_id.toString(),
-          dustDataSource.value.data_source.data_source_id
-        );
+        const deleteRes = await CoreAPI.deleteDataSource({
+          projectId: dustProject.value.project.project_id.toString(),
+          dataSourceName: dustDataSource.value.data_source.data_source_id,
+        });
         if (deleteRes.isErr()) {
           logger.error(
             {

--- a/front/pages/w/[wId]/a/[aId]/specification.tsx
+++ b/front/pages/w/[wId]/a/[aId]/specification.tsx
@@ -43,7 +43,9 @@ export const getServerSideProps: GetServerSideProps<{
     };
   }
 
-  const datasets = await CoreAPI.getDatasets(app.dustAPIProjectId);
+  const datasets = await CoreAPI.getDatasets({
+    projectId: app.dustAPIProjectId,
+  });
   if (datasets.isErr()) {
     return {
       notFound: true,

--- a/front/post_upsert_hooks/hooks/document_tracker/index.ts
+++ b/front/post_upsert_hooks/hooks/document_tracker/index.ts
@@ -316,11 +316,11 @@ export const documentTrackerSuggestChangesPostUpsertHook: PostUpsertHook = {
       const matchedDocUrl = actionResult.matched_doc_url;
       const suggestedChanges = actionResult.suggested_changes;
 
-      const incomingDocument = await CoreAPI.getDataSourceDocument(
-        dataSource.dustAPIProjectId,
-        dataSource.name,
-        documentId
-      );
+      const incomingDocument = await CoreAPI.getDataSourceDocument({
+        projectId: dataSource.dustAPIProjectId,
+        dataSourceName: dataSource.name,
+        documentId,
+      });
 
       if (incomingDocument.isErr()) {
         throw new Error(

--- a/front/post_upsert_hooks/temporal/activities.ts
+++ b/front/post_upsert_hooks/temporal/activities.ts
@@ -69,11 +69,11 @@ async function getDocText(
   if (!dataSource) {
     throw new Error(`Could not find data source ${dataSourceName}`);
   }
-  const docText = await CoreAPI.getDataSourceDocument(
-    dataSource?.dustAPIProjectId,
-    dataSourceName,
-    documentId
-  );
+  const docText = await CoreAPI.getDataSourceDocument({
+    projectId: dataSource?.dustAPIProjectId,
+    dataSourceName: dataSourceName,
+    documentId,
+  });
   if (docText.isErr()) {
     throw new Error(`Could not get document text for ${documentId}`);
   }


### PR DESCRIPTION
**why**

- more consistent (we had a mix of `payload` and function args)
- more readable (at callsite)
- we discussed this on slack

**what**

use `fn({a, b, c}: Params){}` instead of `fn(a: X, b: Y, c: Z){}` in `CoreAPI`  