### PR TITLE
feat(post upsert hooks): add support for `onDelete` callback

### DIFF
--- a/front/lib/extract_events.ts
+++ b/front/lib/extract_events.ts
@@ -15,7 +15,10 @@ import {
 import { DataSource, EventSchema, ExtractedEvent } from "@app/lib/models";
 import logger from "@app/logger/logger";
 import { logOnSlack } from "@app/logger/slack_debug_logger";
-import { PostUpsertHookParams } from "@app/post_upsert_hooks/hooks";
+import {
+  PostUpsertHookFilterParams,
+  PostUpsertHookParams,
+} from "@app/post_upsert_hooks/hooks";
 import { getDatasource } from "@app/post_upsert_hooks/hooks/lib/data_source_helpers";
 
 export async function shouldProcessExtractEvents({
@@ -23,9 +26,9 @@ export async function shouldProcessExtractEvents({
   workspaceId,
   documentId,
   documentText,
-}: PostUpsertHookParams) {
+}: PostUpsertHookFilterParams) {
   const localLogger = logger.child({ workspaceId, dataSourceName, documentId });
-  const hasMarker = hasExtractEventMarker(documentText);
+  const hasMarker = !!documentText && hasExtractEventMarker(documentText);
   if (!hasMarker) {
     localLogger.info("[Extract event] Doc contains no marker.");
     return false;

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
@@ -359,6 +359,7 @@ async function handler(
         },
       });
 
+      // TODO: parallel.
       for (const { type: hookType } of await getPostUpsertHooksToRun({
         dataSourceName: dataSource.name,
         workspaceId: owner.sId,

--- a/front/post_upsert_hooks/hooks/document_tracker/index.ts
+++ b/front/post_upsert_hooks/hooks/document_tracker/index.ts
@@ -55,7 +55,7 @@ export const documentTrackerUpdateTrackedDocumentsPostUpsertHook: PostUpsertHook
       const dataSource = await getDatasource(dataSourceName, workspaceId);
 
       if (
-        documentText.includes("DUST_TRACK(") &&
+        documentText && documentText.includes("DUST_TRACK(") &&
         TRACKABLE_CONNECTOR_TYPES.includes(
           dataSource.connectorProvider as ConnectorProvider
         )

--- a/front/post_upsert_hooks/hooks/document_tracker/index.ts
+++ b/front/post_upsert_hooks/hooks/document_tracker/index.ts
@@ -55,7 +55,8 @@ export const documentTrackerUpdateTrackedDocumentsPostUpsertHook: PostUpsertHook
       const dataSource = await getDatasource(dataSourceName, workspaceId);
 
       if (
-        documentText && documentText.includes("DUST_TRACK(") &&
+        documentText &&
+        documentText.includes("DUST_TRACK(") &&
         TRACKABLE_CONNECTOR_TYPES.includes(
           dataSource.connectorProvider as ConnectorProvider
         )
@@ -104,6 +105,25 @@ export const documentTrackerUpdateTrackedDocumentsPostUpsertHook: PostUpsertHook
         logger.info("Updating tracked documents.");
         await updateTrackedDocuments(dataSource.id, documentId, documentText);
       }
+    },
+    onDelete: async ({ dataSourceName, workspaceId, documentId }) => {
+      logger.info(
+        {
+          workspaceId,
+          dataSourceName,
+          documentId,
+        },
+        "Running document_tracker_update_tracked_documents onDelete."
+      );
+
+      const dataSource = await getDatasource(dataSourceName, workspaceId);
+
+      await TrackedDocument.destroy({
+        where: {
+          dataSourceId: dataSource.id,
+          documentId,
+        },
+      });
     },
   };
 

--- a/front/post_upsert_hooks/hooks/extract_event/index.ts
+++ b/front/post_upsert_hooks/hooks/extract_event/index.ts
@@ -6,6 +6,7 @@ import {
 import mainLogger from "@app/logger/logger";
 import {
   PostUpsertHook,
+  PostUpsertHookFilterParams,
   PostUpsertHookParams,
 } from "@app/post_upsert_hooks/hooks";
 
@@ -19,7 +20,7 @@ export const extractEventPostUpsertHook: PostUpsertHook = {
   fn: processDocument,
 };
 
-async function shouldProcessDocument(params: PostUpsertHookParams) {
+async function shouldProcessDocument(params: PostUpsertHookFilterParams) {
   return await shouldProcessExtractEvents(params);
 }
 

--- a/front/post_upsert_hooks/temporal/activities.ts
+++ b/front/post_upsert_hooks/temporal/activities.ts
@@ -51,7 +51,42 @@ export async function runPostUpsertHookActivity(
   localLogger.info("Ran post upsert hook function.");
 }
 
-async function getDataSourceDocument(
+export async function runOnDeleteActivity(
+  dataSourceName: string,
+  workspaceId: string,
+  documentId: string,
+  dataSourceConnectorProvider: ConnectorProvider | null,
+  hookType: PostUpsertHookType
+) {
+  const localLogger = logger.child({
+    workspaceId,
+    dataSourceName,
+    documentId,
+    dataSourceConnectorProvider,
+    hookType,
+  });
+
+  const hook = POST_UPSERT_HOOK_BY_TYPE[hookType];
+  if (!hook) {
+    localLogger.error("Unknown post upsert hook type");
+    throw new Error(`Unknown post upsert hook type ${hookType}`);
+  }
+  if (!hook.onDelete) {
+    localLogger.warn("Hook has no onDelete function.");
+    return;
+  }
+
+  localLogger.info("Running onDelete function.");
+  await hook.onDelete({
+    dataSourceName,
+    workspaceId,
+    documentId,
+    dataSourceConnectorProvider,
+  });
+  localLogger.info("Ran onDelete function.");
+}
+
+async function getDocText(
   dataSourceName: string,
   workspaceId: string,
   documentId: string

--- a/front/post_upsert_hooks/temporal/client.ts
+++ b/front/post_upsert_hooks/temporal/client.ts
@@ -1,7 +1,10 @@
 import { ConnectorProvider } from "@app/lib/connectors_api";
 import { getTemporalClient } from "@app/post_upsert_hooks/temporal/lib";
 import { newUpsertSignal } from "@app/post_upsert_hooks/temporal/signals";
-import { runPostUpsertHooksWorkflow } from "@app/post_upsert_hooks/temporal/workflows";
+import {
+  runOnDeleteWorkflow,
+  runPostUpsertHooksWorkflow,
+} from "@app/post_upsert_hooks/temporal/workflows";
 
 import { PostUpsertHookType } from "../hooks";
 
@@ -30,5 +33,27 @@ export async function launchRunPostUpsertHooksWorkflow(
     workflowId: `workflow-run-post-upsert-hooks-${hookType}-${workspaceId}-${dataSourceName}-${documentId}`,
     signal: newUpsertSignal,
     signalArgs: undefined,
+  });
+}
+
+export async function launchRunOnDeleteWorkflow(
+  dataSourceName: string,
+  workspaceId: string,
+  documentId: string,
+  dataSourceConnectorProvider: ConnectorProvider | null,
+  hookType: PostUpsertHookType
+) {
+  const client = await getTemporalClient();
+
+  await client.workflow.execute(runOnDeleteWorkflow, {
+    args: [
+      dataSourceName,
+      workspaceId,
+      documentId,
+      dataSourceConnectorProvider,
+      hookType,
+    ],
+    taskQueue: "post-upsert-hooks-queue",
+    workflowId: `workflow-run-on-delete-${hookType}-${workspaceId}-${dataSourceName}-${documentId}`,
   });
 }

--- a/front/post_upsert_hooks/temporal/workflows.ts
+++ b/front/post_upsert_hooks/temporal/workflows.ts
@@ -6,7 +6,9 @@ import type * as activities from "@app/post_upsert_hooks/temporal/activities";
 
 import { newUpsertSignal } from "./signals";
 
-const { runPostUpsertHookActivity } = proxyActivities<typeof activities>({
+const { runPostUpsertHookActivity, runOnDeleteActivity } = proxyActivities<
+  typeof activities
+>({
   startToCloseTimeout: "60 minute",
 });
 
@@ -42,4 +44,20 @@ export async function runPostUpsertHooksWorkflow(
       hookType
     );
   }
+}
+
+export async function runOnDeleteWorkflow(
+  dataSourceName: string,
+  workspaceId: string,
+  documentId: string,
+  dataSourceConnectorProvider: ConnectorProvider | null,
+  hookType: PostUpsertHookType
+) {
+  await runOnDeleteActivity(
+    dataSourceName,
+    workspaceId,
+    documentId,
+    dataSourceConnectorProvider,
+    hookType
+  );
 }


### PR DESCRIPTION
- for doc tracker we need to delete associated tracked documents when a document is deleted
- so I added an optional `onDelete` function to the `PostUpsertHook` type thati s ran in a workflow if `filter` returns `true`