### PR TITLE
Events: very basic handling of duplicates

### DIFF
--- a/front/post_upsert_hooks/hooks/extract_event/index.ts
+++ b/front/post_upsert_hooks/hooks/extract_event/index.ts
@@ -1,4 +1,3 @@
-import { hasExtractEventMarker } from "@app/lib/extract_event_markers";
 import {
   processExtractEvents,
   shouldProcessExtractEvents,


### PR DESCRIPTION
Very very basic handling of duplicates, to start with: 
We loop on properties extracted by the Dust app, and if we find the exact same properties we log it at duplicate. 

Right now, it's bad: if a Slack thread contains a marker, each time there is a new message on this thread we re-extract the event, and it spams the Slack debug channel 😬 