### PR TITLE
Update context_size for anthropic models

### DIFF
--- a/core/src/providers/anthropic.rs
+++ b/core/src/providers/anthropic.rs
@@ -391,7 +391,7 @@ impl LLM for AnthropicLLM {
     }
 
     fn context_size(&self) -> usize {
-        8000
+        100000
     }
 
     async fn generate(
@@ -593,10 +593,10 @@ impl Embedder for AnthropicEmbedder {
     }
 
     fn context_size(&self) -> usize {
-        8000
+        0
     }
     fn embedding_size(&self) -> usize {
-        8000
+        0
     }
 
     async fn encode(&self, _text: &str) -> Result<Vec<usize>> {


### PR DESCRIPTION
Anthropic models `claude-2` and `claude-instant-1` https://docs.anthropic.com/claude/reference/selecting-a-model are all 100k tokens now.