### PR TITLE
Use `auth` in lib/api

### DIFF
--- a/front/lib/api/chat.ts
+++ b/front/lib/api/chat.ts
@@ -93,7 +93,7 @@ export async function upsertChatSession(
 ): Promise<ChatSessionType> {
   const owner = auth.workspace();
   if (!owner) {
-    throw new Error("Unexpected auth without workspace in upsertChatSession.");
+    throw new Error("Unexpected `auth` without `workspace`.");
   }
 
   // User can be null if we are calling from API.

--- a/front/lib/api/gens.ts
+++ b/front/lib/api/gens.ts
@@ -3,12 +3,18 @@ import { Op } from "sequelize";
 import { GensTemplateType } from "@app/types/gens";
 import { UserType, WorkspaceType } from "@app/types/user";
 
+import { Authenticator } from "../auth";
 import { GensTemplate } from "../models";
 
 export async function getGensTemplates(
-  owner: WorkspaceType,
+  auth: Authenticator,
   user: UserType
 ): Promise<GensTemplateType[]> {
+  const owner = auth.workspace();
+  if (!owner) {
+    return [];
+  }
+
   const templates = await GensTemplate.findAll({
     where: {
       workspaceId: owner.id,
@@ -37,10 +43,15 @@ export async function getGensTemplates(
 }
 
 export async function getTemplate(
-  owner: WorkspaceType,
+  auth: Authenticator,
   user: UserType,
   sId: string
 ): Promise<GensTemplateType | null> {
+  const owner = auth.workspace();
+  if (!owner) {
+    return null;
+  }
+
   const template = await GensTemplate.findOne({
     where: {
       workspaceId: owner.id,
@@ -69,9 +80,14 @@ export async function getTemplate(
 }
 
 export async function updateTemplate(
-  template: GensTemplateType,
-  owner: WorkspaceType
+  auth: Authenticator,
+  template: GensTemplateType
 ) {
+  const owner = auth.workspace();
+  if (!owner) {
+    throw new Error("Unexpected `auth` without `workspace`.");
+  }
+
   if (template.visibility == "workspace" || template.visibility == "user") {
     return await GensTemplate.update(
       {

--- a/front/pages/api/w/[wId]/use/gens/templates/[tId]/index.ts
+++ b/front/pages/api/w/[wId]/use/gens/templates/[tId]/index.ts
@@ -90,7 +90,7 @@ async function handler(
         });
       }
 
-      template = await getTemplate(owner, user, req.query.tId as string);
+      template = await getTemplate(auth, user, req.query.tId as string);
       if (template) {
         if (template.userId !== user.id && !isBuilder) {
           return apiError(req, res, {
@@ -103,7 +103,7 @@ async function handler(
           });
         }
 
-        result = await updateTemplate(pRes.value, owner);
+        result = await updateTemplate(auth, pRes.value);
         if (!result) {
           return apiError(req, res, {
             status_code: 404,

--- a/front/pages/w/[wId]/u/gens/index.tsx
+++ b/front/pages/w/[wId]/u/gens/index.tsx
@@ -100,7 +100,7 @@ export const getServerSideProps: GetServerSideProps<{
     user;
   }
 
-  const templates = await getGensTemplates(owner, user);
+  const templates = await getGensTemplates(auth, user);
 
   const dataSources: DataSource[] = dsRes.value.map((ds) => {
     return {


### PR DESCRIPTION
Try to use as much as possible `auth` instead of `owner` in `lib/api/*`

cc @Uzay-G 