### PR TITLE
Events: Process only once a marker on a given doc

### DIFF
--- a/front/lib/actions/registry.ts
+++ b/front/lib/actions/registry.ts
@@ -214,7 +214,7 @@ export const DustProdActionRegistry: {
       workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
       appId: "edf70ecf98",
       appHash:
-        "c7ba630f14bd8f54a95e84b887bdb8a888fb911e4cf945ea017e3d877e332c16",
+        "49746ffd67d44cfd1ed836011c1c947c2541d1e7035164639fffe218811b568e",
     },
     config: {
       MODEL: {

--- a/front/lib/models.ts
+++ b/front/lib/models.ts
@@ -1100,6 +1100,7 @@ export class ExtractedEvent extends Model<
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
+  declare marker: string;
   declare properties: any;
 
   declare eventSchemaId: ForeignKey<EventSchema["id"]>;
@@ -1122,6 +1123,11 @@ ExtractedEvent.init(
       type: DataTypes.DATE,
       allowNull: false,
       defaultValue: DataTypes.NOW,
+    },
+    marker: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      defaultValue: "",
     },
     properties: {
       type: DataTypes.JSONB,


### PR DESCRIPTION
Following this PR that we decided to close: https://github.com/dust-tt/dust/pull/817

We decided to extract only once a given marker on a given doc: 
if [[idea:12]] is used on a Notion doc, it will be processed once and then it will be ignored.

To do so: 
- [x] Add a new field marker on ExtractedEvents
- [x] Update the Dust app to always return the marker
- [x] When processing the markers on the content of a doc, exclude the ones for which we already have an extracted event and do not call the Dust app for those.