### PR TITLE
enh(front): make DustProdActionRegistry be strongly typed

### DIFF
--- a/front/lib/actions/registry.ts
+++ b/front/lib/actions/registry.ts
@@ -7,9 +7,11 @@ export type Action = {
   config: { [key: string]: unknown };
 };
 
-export const DustProdActionRegistry: {
-  [key: string]: Action;
-} = {
+const createActionRegistry = <K extends string, R extends Record<K, Action>>(
+  registry: R
+) => registry;
+
+export const DustProdActionRegistry = createActionRegistry({
   "chat-retrieval": {
     app: {
       workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
@@ -225,7 +227,15 @@ export const DustProdActionRegistry: {
       },
     },
   },
-};
+});
+
+export type DustRegistryActionName = keyof typeof DustProdActionRegistry;
+
+export function isDustRegistryActionName(
+  name: string
+): name is DustRegistryActionName {
+  return !!DustProdActionRegistry[name as DustRegistryActionName];
+}
 
 export function cloneBaseConfig(config: { [model: string]: any }) {
   return JSON.parse(JSON.stringify(config));

--- a/front/lib/actions/server.ts
+++ b/front/lib/actions/server.ts
@@ -1,11 +1,9 @@
-import { DustProdActionRegistry } from "@app/lib/actions/registry";
-import { Authenticator, prodAPICredentialsForOwner } from "@app/lib/auth";
 import {
-  DustAPI,
-  DustAPIErrorResponse,
-  DustAppConfigType,
-  DustAppType,
-} from "@app/lib/dust_api";
+  DustProdActionRegistry,
+  DustRegistryActionName,
+} from "@app/lib/actions/registry";
+import { Authenticator, prodAPICredentialsForOwner } from "@app/lib/auth";
+import { DustAPI, DustAppConfigType, DustAppType } from "@app/lib/dust_api";
 import { Err, Ok } from "@app/lib/result";
 import logger from "@app/logger/logger";
 import { statsDClient } from "@app/logger/withlogging";
@@ -47,7 +45,7 @@ const logActionError = (
  */
 export async function runActionStreamed(
   auth: Authenticator,
-  actionName: string,
+  actionName: DustRegistryActionName,
   config: DustAppConfigType,
   inputs: Array<unknown>
 ) {
@@ -56,13 +54,6 @@ export async function runActionStreamed(
     return new Err({
       type: "workspace_not_found",
       message: "The workspace you're trying to access was not found.",
-    });
-  }
-
-  if (!DustProdActionRegistry[actionName]) {
-    return new Err({
-      type: "action_unknown_error",
-      message: `Unknown action: ${actionName}`,
     });
   }
 
@@ -128,7 +119,7 @@ export async function runActionStreamed(
  */
 export async function runAction(
   auth: Authenticator,
-  actionName: string,
+  actionName: DustRegistryActionName,
   config: DustAppConfigType,
   inputs: Array<unknown>
 ) {
@@ -138,13 +129,6 @@ export async function runAction(
       type: "workspace_not_found",
       message: "The workspace you're trying to access was not found.",
     });
-  }
-
-  if (!DustProdActionRegistry[actionName]) {
-    return new Err({
-      type: "action_unknown_error",
-      message: `Unknown action: ${actionName}`,
-    } as DustAPIErrorResponse);
   }
 
   const action = DustProdActionRegistry[actionName];

--- a/front/pages/api/w/[wId]/use/actions/[action]/index.ts
+++ b/front/pages/api/w/[wId]/use/actions/[action]/index.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from "next";
 
-import { DustProdActionRegistry } from "@app/lib/actions/registry";
+import { isDustRegistryActionName } from "@app/lib/actions/registry";
 import { runActionStreamed } from "@app/lib/actions/server";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { DustAppConfigType } from "@app/lib/dust_api";
@@ -71,7 +71,7 @@ async function handler(
         });
       }
 
-      if (!DustProdActionRegistry[req.query.action]) {
+      if (!isDustRegistryActionName(req.query.action)) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {


### PR DESCRIPTION
- currently, typescript has no idea what are the valid keys of `DustProdActionRegistry` (it just knows it's a string)
- you can write `DustProdActionRegistry.foobar` and TS will let you do it
- if you rename an action in the registry but forget to update your code, you don't get an error
- this change fixes that
- `isDustRegistryActionName` is a type guard, so when in a code branch where it returned true for a string X, X is considered a valid action name
