### PR TITLE
Connectors permissions GET API

### DIFF
--- a/connectors/src/api/get_connector.ts
+++ b/connectors/src/api/get_connector.ts
@@ -1,7 +1,6 @@
 import { Request, Response } from "express";
 
 import { Connector } from "@connectors/lib/models";
-import logger from "@connectors/logger/logger";
 import { apiError, withLogging } from "@connectors/logger/withlogging";
 import { ConnectorType } from "@connectors/types/connector";
 import { ConnectorsAPIErrorResponse } from "@connectors/types/errors";
@@ -12,40 +11,36 @@ const _getConnector = async (
   req: Request<{ connector_id: string }, GetConnectorRes, undefined>,
   res: Response<GetConnectorRes>
 ) => {
-  try {
-    if (!req.params.connector_id) {
-      res.status(400).send({
-        error: {
-          message: `Missing required parameters. Required : connector_id`,
-        },
-      });
-      return;
-    }
-    const connector = await Connector.findByPk(req.params.connector_id);
-    if (!connector) {
-      return apiError(req, res, {
-        api_error: {
-          type: "connector_not_found",
-          message: "Connector not found",
-        },
-        status_code: 404,
-      });
-    }
-    return res.status(200).send({
-      id: connector.id,
-      type: connector.type,
-      lastSyncStatus: connector.lastSyncStatus,
-      lastSyncStartTime: connector.lastSyncStartTime?.getTime(),
-      lastSyncSuccessfulTime: connector.lastSyncSuccessfulTime?.getTime(),
-      firstSuccessfulSyncTime: connector.firstSuccessfulSyncTime?.getTime(),
-      firstSyncProgress: connector.firstSyncProgress,
-    });
-  } catch (e) {
-    logger.error({ error: e }, "Error while getting the connector.");
-    res.status(500).send({
-      error: { message: "Error while getting the connector." },
+  if (!req.params.connector_id) {
+    return apiError(req, res, {
+      api_error: {
+        type: "invalid_request_error",
+        message: "Missing required parameters. Required: connector_id",
+      },
+      status_code: 400,
     });
   }
+  const connector = await Connector.findByPk(req.params.connector_id);
+  if (!connector) {
+    return apiError(req, res, {
+      api_error: {
+        type: "connector_not_found",
+        message: "Connector not found",
+      },
+      status_code: 404,
+    });
+  }
+
+  return res.status(200).json({
+    id: connector.id,
+    type: connector.type,
+    lastSyncStatus: connector.lastSyncStatus,
+    lastSyncStartTime: connector.lastSyncStartTime?.getTime(),
+    lastSyncFinishTime: connector.lastSyncFinishTime?.getTime(),
+    lastSyncSuccessfulTime: connector.lastSyncSuccessfulTime?.getTime(),
+    firstSuccessfulSyncTime: connector.firstSuccessfulSyncTime?.getTime(),
+    firstSyncProgress: connector.firstSyncProgress,
+  });
 };
 
 export const getConnectorAPIHandler = withLogging(_getConnector);

--- a/connectors/src/api/get_connector_permissions.ts
+++ b/connectors/src/api/get_connector_permissions.ts
@@ -43,7 +43,10 @@ const _getConnectorPermissions = async (
   const connectorPermissionRetriever =
     RETRIEVE_CONNECTOR_PERMISSIONS_BY_TYPE[connector.type];
 
-  const pRes = await connectorPermissionRetriever(connector.id, parentInternalId);
+  const pRes = await connectorPermissionRetriever(
+    connector.id,
+    parentInternalId
+  );
 
   if (pRes.isErr()) {
     return apiError(req, res, {

--- a/connectors/src/api/get_connector_permissions.ts
+++ b/connectors/src/api/get_connector_permissions.ts
@@ -1,0 +1,69 @@
+import { Request, Response } from "express";
+
+import { RETRIEVE_CONNECTOR_PERMISSIONS_BY_TYPE } from "@connectors/connectors";
+import { Connector } from "@connectors/lib/models";
+import { apiError, withLogging } from "@connectors/logger/withlogging";
+import { ConnectorsAPIErrorResponse } from "@connectors/types/errors";
+import { ConnectorResource } from "@connectors/types/resources";
+
+type GetConnectorPermissionsRes =
+  | { resources: ConnectorResource[] }
+  | ConnectorsAPIErrorResponse;
+
+const _getConnectorPermissions = async (
+  req: Request<{ connector_id: string }, GetConnectorPermissionsRes, undefined>,
+  res: Response<GetConnectorPermissionsRes>
+) => {
+  if (!req.params.connector_id) {
+    return apiError(req, res, {
+      api_error: {
+        type: "invalid_request_error",
+        message: "Missing required parameters. Required: connector_id",
+      },
+      status_code: 400,
+    });
+  }
+
+  const connector = await Connector.findByPk(req.params.connector_id);
+  if (!connector) {
+    return apiError(req, res, {
+      api_error: {
+        type: "connector_not_found",
+        message: "Connector not found",
+      },
+      status_code: 404,
+    });
+  }
+
+  const connectorPermissionRetriever =
+    RETRIEVE_CONNECTOR_PERMISSIONS_BY_TYPE[connector.type];
+
+  const pRes = await connectorPermissionRetriever({
+    id: connector.id,
+    type: connector.type,
+    lastSyncStatus: connector.lastSyncStatus,
+    lastSyncStartTime: connector.lastSyncStartTime?.getTime(),
+    lastSyncFinishTime: connector.lastSyncFinishTime?.getTime(),
+    lastSyncSuccessfulTime: connector.lastSyncSuccessfulTime?.getTime(),
+    firstSuccessfulSyncTime: connector.firstSuccessfulSyncTime?.getTime(),
+    firstSyncProgress: connector.firstSyncProgress,
+  });
+
+  if (pRes.isErr()) {
+    return apiError(req, res, {
+      api_error: {
+        type: "internal_server_error",
+        message: pRes.error.message,
+      },
+      status_code: 500,
+    });
+  }
+
+  return res.status(200).json({
+    resources: pRes.value,
+  });
+};
+
+export const getConnectorPermissionsAPIHandler = withLogging(
+  _getConnectorPermissions
+);

--- a/connectors/src/api/get_connector_permissions.ts
+++ b/connectors/src/api/get_connector_permissions.ts
@@ -38,16 +38,7 @@ const _getConnectorPermissions = async (
   const connectorPermissionRetriever =
     RETRIEVE_CONNECTOR_PERMISSIONS_BY_TYPE[connector.type];
 
-  const pRes = await connectorPermissionRetriever({
-    id: connector.id,
-    type: connector.type,
-    lastSyncStatus: connector.lastSyncStatus,
-    lastSyncStartTime: connector.lastSyncStartTime?.getTime(),
-    lastSyncFinishTime: connector.lastSyncFinishTime?.getTime(),
-    lastSyncSuccessfulTime: connector.lastSyncSuccessfulTime?.getTime(),
-    firstSuccessfulSyncTime: connector.firstSuccessfulSyncTime?.getTime(),
-    firstSyncProgress: connector.firstSyncProgress,
-  });
+  const pRes = await connectorPermissionRetriever(connector.id);
 
   if (pRes.isErr()) {
     return apiError(req, res, {

--- a/connectors/src/api/get_connector_permissions.ts
+++ b/connectors/src/api/get_connector_permissions.ts
@@ -24,6 +24,11 @@ const _getConnectorPermissions = async (
     });
   }
 
+  const parentInternalId =
+    !req.query.parentId || typeof req.query.parentId !== "string"
+      ? null
+      : req.query.parentId;
+
   const connector = await Connector.findByPk(req.params.connector_id);
   if (!connector) {
     return apiError(req, res, {
@@ -38,7 +43,7 @@ const _getConnectorPermissions = async (
   const connectorPermissionRetriever =
     RETRIEVE_CONNECTOR_PERMISSIONS_BY_TYPE[connector.type];
 
-  const pRes = await connectorPermissionRetriever(connector.id);
+  const pRes = await connectorPermissionRetriever(connector.id, parentInternalId);
 
   if (pRes.isErr()) {
     return apiError(req, res, {

--- a/connectors/src/api/google_drive.ts
+++ b/connectors/src/api/google_drive.ts
@@ -90,12 +90,12 @@ type GetFoldersRes =
   | GoogleDriveSelectedFolderType[]
   | ConnectorsAPIErrorResponse;
 
-// This endpoint returns the list of all folders in the user's Google Drive (only the shared drives for now).
-// The list is returned as a flat list of nodes with their parents and children property filled out.
-// The Google Drive API only allows you to list objects, and getting the full path of a file requires
-// to make an API call for each parent. That means that we rely on the fact that Google Drive
-// is going to ultimately send us all the folders at some point when listing them to have the full path of each folder
-// defined. Otherwise, the behavior is undefined.
+// This endpoint returns the list of all folders in the user's Google Drive (only the shared drives
+// for now).  The list is returned as a flat list of nodes with their parents and children property
+// filled out.  The Google Drive API only allows you to list objects, and getting the full path of a
+// file requires to make an API call for each parent. That means that we rely on the fact that
+// Google Drive is going to ultimately send us all the folders at some point when listing them to
+// have the full path of each folder defined. Otherwise, the behavior is undefined.
 const _googleDriveGetFoldersAPIHandler = async (
   req: Request<
     { connector_id: string; parentId?: string },

--- a/connectors/src/api_server.ts
+++ b/connectors/src/api_server.ts
@@ -17,6 +17,8 @@ import { webhookSlackAPIHandler } from "@connectors/api/webhooks/webhook_slack";
 import logger from "@connectors/logger/logger";
 import { authMiddleware } from "@connectors/middleware/auth";
 
+import { getConnectorPermissionsAPIHandler } from "./api/get_connector_permissions";
+
 export function startServer(port: number) {
   const app = express();
 
@@ -43,6 +45,10 @@ export function startServer(port: number) {
   app.delete("/connectors/delete/:connector_id", deleteConnectorAPIHandler);
   app.get("/connectors/:connector_id", getConnectorAPIHandler);
   app.post("/connectors/sync/:connector_id", syncConnectorAPIHandler);
+  app.get(
+    "/connectors/:connector_id/permissions",
+    getConnectorPermissionsAPIHandler
+  );
 
   app.post("/webhooks/:webhook_secret/slack", webhookSlackAPIHandler);
   app.post(

--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -211,7 +211,7 @@ export async function retrieveGithubConnectorPermissions(
   const githubInstallationId = c.connectionId;
 
   let resources: ConnectorResource[] = [];
-  let pageNumber = 0;
+  let pageNumber = 1; // 1-indexed
   for (;;) {
     const page = await getReposPage(githubInstallationId, pageNumber);
     pageNumber += 1;

--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -237,7 +237,7 @@ export async function retrieveGithubConnectorPermissions(
         title: repo.name,
         sourceUrl: repo.url,
         expandable: false,
-        permission: "read",
+        permission: "read" as ConnectorPermission,
       }))
     );
   }

--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -9,11 +9,11 @@ import {
   Connector,
   GithubConnectorState,
   GithubIssue,
+  ModelId,
   sequelize_conn,
 } from "@connectors/lib/models";
 import { Err, Ok, Result } from "@connectors/lib/result";
 import mainLogger from "@connectors/logger/logger";
-import { ConnectorType } from "@connectors/types/connector";
 import { DataSourceConfig } from "@connectors/types/data_source_config";
 import { ConnectorResource } from "@connectors/types/resources";
 
@@ -196,15 +196,15 @@ export async function cleanupGithubConnector(
 }
 
 export async function retrieveGithubConnectorPermissions(
-  connector: ConnectorType
+  connectorId: ModelId
 ): Promise<Result<ConnectorResource[], Error>> {
   const c = await Connector.findOne({
     where: {
-      id: connector.id,
+      id: connectorId,
     },
   });
   if (!c) {
-    logger.error({ connectorId: connector.id }, "Connector not found");
+    logger.error({ connectorId }, "Connector not found");
     return new Err(new Error("Connector not found"));
   }
 
@@ -221,7 +221,7 @@ export async function retrieveGithubConnectorPermissions(
 
     resources = resources.concat(
       page.map((repo) => ({
-        provider: connector.type,
+        provider: c.type,
         internalId: repo.id.toString(),
         parentInternalId: null,
         title: repo.name,

--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -233,6 +233,7 @@ export async function retrieveGithubConnectorPermissions(
         provider: c.type,
         internalId: repo.id.toString(),
         parentInternalId: null,
+        type: "folder",
         title: repo.name,
         sourceUrl: repo.url,
         permission: "read",

--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -15,7 +15,10 @@ import {
 import { Err, Ok, Result } from "@connectors/lib/result";
 import mainLogger from "@connectors/logger/logger";
 import { DataSourceConfig } from "@connectors/types/data_source_config";
-import { ConnectorResource } from "@connectors/types/resources";
+import {
+  ConnectorPermission,
+  ConnectorResource,
+} from "@connectors/types/resources";
 
 type GithubInstallationId = string;
 

--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -236,6 +236,7 @@ export async function retrieveGithubConnectorPermissions(
         type: "folder",
         title: repo.name,
         sourceUrl: repo.url,
+        expandable: false,
         permission: "read",
       }))
     );

--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -196,8 +196,17 @@ export async function cleanupGithubConnector(
 }
 
 export async function retrieveGithubConnectorPermissions(
-  connectorId: ModelId
+  connectorId: ModelId,
+  parentInternalId: string | null
 ): Promise<Result<ConnectorResource[], Error>> {
+  if (parentInternalId) {
+    return new Err(
+      new Error(
+        "Github connector does not support permission retrieval with `parentInternalId`"
+      )
+    );
+  }
+
   const c = await Connector.findOne({
     where: {
       id: connectorId,

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -193,8 +193,17 @@ export async function cleanupGoogleDriveConnector(
 }
 
 export async function retrieveGoogleDriveConnectorPermissions(
-  connectorId: ModelId
+  connectorId: ModelId,
+  parentInternalId: string | null
 ): Promise<Result<ConnectorResource[], Error>> {
+  if (parentInternalId) {
+    return new Err(
+      new Error(
+        "GoogleDrive connector does not support permission retrieval with `parentInternalId`"
+      )
+    );
+  }
+
   const c = await Connector.findOne({
     where: {
       id: connectorId,

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -7,12 +7,18 @@ import {
   GoogleDriveFolders,
   GoogleDriveSyncToken,
   GoogleDriveWebhook,
+  ModelId,
   sequelize_conn,
 } from "@connectors/lib/models.js";
 import { nangoDeleteConnection } from "@connectors/lib/nango_client";
 import { Err, Ok, type Result } from "@connectors/lib/result.js";
 import logger from "@connectors/logger/logger";
 import type { DataSourceConfig } from "@connectors/types/data_source_config.js";
+import {
+  ConnectorPermission,
+  ConnectorResource,
+  ConnectorResourceType,
+} from "@connectors/types/resources";
 
 import { registerWebhook } from "./lib";
 import { getDriveClient, getGoogleCredentials } from "./temporal/activities";
@@ -184,4 +190,49 @@ export async function cleanupGoogleDriveConnector(
   });
 
   return new Ok(undefined);
+}
+
+export async function retrieveGoogleDriveConnectorPermissions(
+  connectorId: ModelId
+): Promise<Result<ConnectorResource[], Error>> {
+  const c = await Connector.findOne({
+    where: {
+      id: connectorId,
+    },
+  });
+  if (!c) {
+    logger.error({ connectorId }, "Connector not found");
+    return new Err(new Error("Connector not found"));
+  }
+
+  const folders = await GoogleDriveFolders.findAll({
+    where: {
+      connectorId: connectorId,
+    },
+  });
+
+  const driveClient = await getDriveClient(c.connectionId);
+
+  const resources: ConnectorResource[] = await Promise.all(
+    folders.map((f) => {
+      return (async () => {
+        const folder = await driveClient.files.get({
+          fileId: f.folderId,
+          fields: "files(id, name, webViewLink)",
+        });
+        return {
+          provider: c.type,
+          internalId: f.folderId,
+          parentInternalId: null,
+          type: "folder" as ConnectorResourceType,
+          title: folder.data.name || "",
+          sourceUrl: folder.data.webViewLink || null,
+          expandable: false,
+          permission: "read" as ConnectorPermission,
+        };
+      })();
+    })
+  );
+
+  return new Ok(resources);
 }

--- a/connectors/src/connectors/index.ts
+++ b/connectors/src/connectors/index.ts
@@ -115,7 +115,8 @@ export const SYNC_CONNECTOR_BY_TYPE: Record<ConnectorProvider, SyncConnector> =
   };
 
 type ConnectorPermissionRetriever = (
-  connectorId: ModelId
+  connectorId: ModelId,
+  parentInternalId: string | null
 ) => Promise<Result<ConnectorResource[], Error>>;
 
 export const RETRIEVE_CONNECTOR_PERMISSIONS_BY_TYPE: Record<

--- a/connectors/src/connectors/index.ts
+++ b/connectors/src/connectors/index.ts
@@ -11,6 +11,7 @@ import {
 import {
   cleanupGoogleDriveConnector,
   createGoogleDriveConnector,
+  retrieveGoogleDriveConnectorPermissions,
 } from "@connectors/connectors/google_drive";
 import { launchGoogleDriveFullSyncWorkflow } from "@connectors/connectors/google_drive/temporal/client";
 import {
@@ -28,7 +29,7 @@ import {
 } from "@connectors/connectors/slack";
 import { launchSlackSyncWorkflow } from "@connectors/connectors/slack/temporal/client";
 import { ModelId } from "@connectors/lib/models";
-import { Err, Ok, Result } from "@connectors/lib/result";
+import { Ok, Result } from "@connectors/lib/result";
 import logger from "@connectors/logger/logger";
 import { ConnectorProvider } from "@connectors/types/connector";
 import { DataSourceConfig } from "@connectors/types/data_source_config";
@@ -126,13 +127,5 @@ export const RETRIEVE_CONNECTOR_PERMISSIONS_BY_TYPE: Record<
   slack: retrieveSlackConnectorPermissions,
   github: retrieveGithubConnectorPermissions,
   notion: retrieveNotionConnectorPermissions,
-  google_drive: async (connectorId: ModelId) => {
-    logger.info(
-      { connectorId },
-      `Slack connector permissions is not implemented.`
-    );
-    return new Err(
-      new Error("Slack connector permissions retrieval is not implemented.")
-    );
-  },
+  google_drive: retrieveGoogleDriveConnectorPermissions,
 };

--- a/connectors/src/connectors/index.ts
+++ b/connectors/src/connectors/index.ts
@@ -23,6 +23,7 @@ import {
 import {
   cleanupSlackConnector,
   createSlackConnector,
+  retrieveSlackConnectorPermissions,
 } from "@connectors/connectors/slack";
 import { launchSlackSyncWorkflow } from "@connectors/connectors/slack/temporal/client";
 import { ModelId } from "@connectors/lib/models";
@@ -120,15 +121,7 @@ export const RETRIEVE_CONNECTOR_PERMISSIONS_BY_TYPE: Record<
   ConnectorProvider,
   ConnectorPermissionRetriever
 > = {
-  slack: async (connectorId: ModelId) => {
-    logger.info(
-      { connectorId },
-      `Slack connector permissions is not implemented.`
-    );
-    return new Err(
-      new Error("Slack connector permissions retrieval is not implemented.")
-    );
-  },
+  slack: retrieveSlackConnectorPermissions,
   github: retrieveGithubConnectorPermissions,
   notion: async (connectorId: ModelId) => {
     logger.info(

--- a/connectors/src/connectors/index.ts
+++ b/connectors/src/connectors/index.ts
@@ -25,9 +25,10 @@ import {
   createSlackConnector,
 } from "@connectors/connectors/slack";
 import { launchSlackSyncWorkflow } from "@connectors/connectors/slack/temporal/client";
+import { ModelId } from "@connectors/lib/models";
 import { Err, Ok, Result } from "@connectors/lib/result";
 import logger from "@connectors/logger/logger";
-import { ConnectorProvider, ConnectorType } from "@connectors/types/connector";
+import { ConnectorProvider } from "@connectors/types/connector";
 import { DataSourceConfig } from "@connectors/types/data_source_config";
 import { ConnectorResource } from "@connectors/types/resources";
 
@@ -112,16 +113,16 @@ export const SYNC_CONNECTOR_BY_TYPE: Record<ConnectorProvider, SyncConnector> =
   };
 
 type ConnectorPermissionRetriever = (
-  connector: ConnectorType
+  connectorId: ModelId
 ) => Promise<Result<ConnectorResource[], Error>>;
 
 export const RETRIEVE_CONNECTOR_PERMISSIONS_BY_TYPE: Record<
   ConnectorProvider,
   ConnectorPermissionRetriever
 > = {
-  slack: async (connector: ConnectorType) => {
+  slack: async (connectorId: ModelId) => {
     logger.info(
-      { connectorId: connector.id },
+      { connectorId },
       `Slack connector permissions is not implemented.`
     );
     return new Err(
@@ -129,18 +130,18 @@ export const RETRIEVE_CONNECTOR_PERMISSIONS_BY_TYPE: Record<
     );
   },
   github: retrieveGithubConnectorPermissions,
-  notion: async (connector: ConnectorType) => {
+  notion: async (connectorId: ModelId) => {
     logger.info(
-      { connectorId: connector.id },
+      { connectorId },
       `Slack connector permissions is not implemented.`
     );
     return new Err(
       new Error("Slack connector permissions retrieval is not implemented.")
     );
   },
-  google_drive: async (connector: ConnectorType) => {
+  google_drive: async (connectorId: ModelId) => {
     logger.info(
-      { connectorId: connector.id },
+      { connectorId },
       `Slack connector permissions is not implemented.`
     );
     return new Err(

--- a/connectors/src/connectors/index.ts
+++ b/connectors/src/connectors/index.ts
@@ -5,6 +5,7 @@ import {
   createGithubConnector,
   fullResyncGithubConnector,
   resumeGithubConnector,
+  retrieveGithubConnectorPermissions,
   stopGithubConnector,
 } from "@connectors/connectors/github";
 import {
@@ -24,10 +25,11 @@ import {
   createSlackConnector,
 } from "@connectors/connectors/slack";
 import { launchSlackSyncWorkflow } from "@connectors/connectors/slack/temporal/client";
-import { Ok, Result } from "@connectors/lib/result";
+import { Err, Ok, Result } from "@connectors/lib/result";
 import logger from "@connectors/logger/logger";
-import { ConnectorProvider } from "@connectors/types/connector";
+import { ConnectorProvider, ConnectorType } from "@connectors/types/connector";
 import { DataSourceConfig } from "@connectors/types/data_source_config";
+import { ConnectorResource } from "@connectors/types/resources";
 
 type ConnectorCreator = (
   dataSourceConfig: DataSourceConfig,
@@ -51,17 +53,13 @@ export const STOP_CONNECTOR_BY_TYPE: Record<
   ConnectorStopper
 > = {
   slack: async (connectorId: string) => {
-    logger.info(
-      `Stopping Slack connector is a no-op. ConnectorId: ${connectorId}`
-    );
+    logger.info({ connectorId }, `Stopping Slack connector is a no-op.`);
     return new Ok(connectorId);
   },
   github: stopGithubConnector,
   notion: stopNotionConnector,
   google_drive: async (connectorId: string) => {
-    logger.info(
-      `Stopping Google Drive connector is a no-op. ConnectorId: ${connectorId}`
-    );
+    logger.info({ connectorId }, `Stopping Google Drive connector is a no-op.`);
     return new Ok(connectorId);
   },
 };
@@ -90,9 +88,7 @@ export const RESUME_CONNECTOR_BY_TYPE: Record<
   ConnectorResumer
 > = {
   slack: async (connectorId: string) => {
-    logger.info(
-      `Resuming Slack connector is a no-op. ConnectorId: ${connectorId}`
-    );
+    logger.info({ connectorId }, `Resuming Slack connector is a no-op.`);
     return new Ok(connectorId);
   },
   notion: resumeNotionConnector,
@@ -114,3 +110,41 @@ export const SYNC_CONNECTOR_BY_TYPE: Record<ConnectorProvider, SyncConnector> =
     github: fullResyncGithubConnector,
     google_drive: launchGoogleDriveFullSyncWorkflow,
   };
+
+type ConnectorPermissionRetriever = (
+  connector: ConnectorType
+) => Promise<Result<ConnectorResource[], Error>>;
+
+export const RETRIEVE_CONNECTOR_PERMISSIONS_BY_TYPE: Record<
+  ConnectorProvider,
+  ConnectorPermissionRetriever
+> = {
+  slack: async (connector: ConnectorType) => {
+    logger.info(
+      { connectorId: connector.id },
+      `Slack connector permissions is not implemented.`
+    );
+    return new Err(
+      new Error("Slack connector permissions retrieval is not implemented.")
+    );
+  },
+  github: retrieveGithubConnectorPermissions,
+  notion: async (connector: ConnectorType) => {
+    logger.info(
+      { connectorId: connector.id },
+      `Slack connector permissions is not implemented.`
+    );
+    return new Err(
+      new Error("Slack connector permissions retrieval is not implemented.")
+    );
+  },
+  google_drive: async (connector: ConnectorType) => {
+    logger.info(
+      { connectorId: connector.id },
+      `Slack connector permissions is not implemented.`
+    );
+    return new Err(
+      new Error("Slack connector permissions retrieval is not implemented.")
+    );
+  },
+};

--- a/connectors/src/connectors/index.ts
+++ b/connectors/src/connectors/index.ts
@@ -18,6 +18,7 @@ import {
   createNotionConnector,
   fullResyncNotionConnector,
   resumeNotionConnector,
+  retrieveNotionConnectorPermissions,
   stopNotionConnector,
 } from "@connectors/connectors/notion";
 import {
@@ -123,15 +124,7 @@ export const RETRIEVE_CONNECTOR_PERMISSIONS_BY_TYPE: Record<
 > = {
   slack: retrieveSlackConnectorPermissions,
   github: retrieveGithubConnectorPermissions,
-  notion: async (connectorId: ModelId) => {
-    logger.info(
-      { connectorId },
-      `Slack connector permissions is not implemented.`
-    );
-    return new Err(
-      new Error("Slack connector permissions retrieval is not implemented.")
-    );
-  },
+  notion: retrieveNotionConnectorPermissions,
   google_drive: async (connectorId: ModelId) => {
     logger.info(
       { connectorId },

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -270,7 +270,8 @@ export async function retrieveNotionConnectorPermissions(
         return {
           provider: c.type,
           internalId: p.notionPageId,
-          parentInternalId: null,
+          parentInternalId:
+            !p.parentId || p.parentId === "workspace" ? null : p.parentId,
           type: "file" as ConnectorResourceType,
           title: p.title || "",
           sourceUrl: p.notionUrl || null,
@@ -284,7 +285,8 @@ export async function retrieveNotionConnectorPermissions(
   const dbResources: ConnectorResource[] = dbs.map((db) => ({
     provider: c.type,
     internalId: db.notionDatabaseId,
-    parentInternalId: null,
+    parentInternalId:
+      !db.parentId || db.parentId === "workspace" ? null : db.parentId,
     type: "database" as ConnectorResourceType,
     title: db.title || "",
     sourceUrl: db.notionUrl || null,

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -22,6 +22,7 @@ import { NangoConnectionId } from "@connectors/types/nango_connection_id";
 import {
   ConnectorPermission,
   ConnectorResource,
+  ConnectorResourceType,
 } from "@connectors/types/resources";
 
 const { NANGO_NOTION_CONNECTOR_ID } = process.env;
@@ -242,13 +243,13 @@ export async function retrieveNotionConnectorPermissions(
     NotionPage.findAll({
       where: {
         connectorId: connectorId,
-        parentType: parentInternalId || "workspace",
+        parentId: parentInternalId || "workspace",
       },
     }),
     NotionDatabase.findAll({
       where: {
         connectorId: connectorId,
-        parentType: parentInternalId || "workspace",
+        parentId: parentInternalId || "workspace",
       },
     }),
   ]);
@@ -258,6 +259,7 @@ export async function retrieveNotionConnectorPermissions(
       provider: c.type,
       internalId: p.notionPageId,
       parentInternalId: null,
+      type: "file" as ConnectorResourceType,
       title: p.title || "",
       sourceUrl: p.notionUrl || null,
       permission: "read" as ConnectorPermission,
@@ -267,6 +269,7 @@ export async function retrieveNotionConnectorPermissions(
         provider: c.type,
         internalId: db.notionDatabaseId,
         parentInternalId: null,
+        type: "database" as ConnectorResourceType,
         title: db.title || "",
         sourceUrl: db.notionUrl || null,
         permission: "read" as ConnectorPermission,

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -231,7 +231,8 @@ export async function retrieveSlackConnectorPermissions(
         provider: "slack",
         internalId: ch.id || "",
         parentInternalId: null,
-        title: `#${ch.name || ""}`,
+        type: "channel",
+        title: ch.name || "",
         sourceUrl: `https://app.slack.com/client/${ch.context_team_id}/${ch.id}`,
         permission: "read",
       };

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -234,6 +234,7 @@ export async function retrieveSlackConnectorPermissions(
         type: "channel",
         title: ch.name || "",
         sourceUrl: `https://app.slack.com/client/${ch.context_team_id}/${ch.id}`,
+        expandable: false,
         permission: "read",
       };
     });

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -235,7 +235,7 @@ export async function retrieveSlackConnectorPermissions(
         title: ch.name || "",
         sourceUrl: `https://app.slack.com/client/${ch.context_team_id}/${ch.id}`,
         expandable: false,
-        permission: "read",
+        permission: "read" as ConnectorPermission,
       };
     });
 

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -200,8 +200,17 @@ export async function cleanupSlackConnector(
 }
 
 export async function retrieveSlackConnectorPermissions(
-  connectorId: ModelId
+  connectorId: ModelId,
+  parentInternalId: string | null
 ): Promise<Result<ConnectorResource[], Error>> {
+  if (parentInternalId) {
+    return new Err(
+      new Error(
+        "Slack connector does not support permission retrieval with `parentInternalId`"
+      )
+    );
+  }
+
   const c = await Connector.findOne({
     where: {
       id: connectorId,

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -17,7 +17,10 @@ import { Err, Ok, type Result } from "@connectors/lib/result.js";
 import logger from "@connectors/logger/logger";
 import type { DataSourceConfig } from "@connectors/types/data_source_config.js";
 import { NangoConnectionId } from "@connectors/types/nango_connection_id";
-import { ConnectorResource } from "@connectors/types/resources";
+import {
+  ConnectorPermission,
+  ConnectorResource,
+} from "@connectors/types/resources";
 
 import {
   getAccessToken,

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -51,8 +51,6 @@ const NETWORK_REQUEST_TIMEOUT_MS = 30000;
  * Tier 1: ~1 request per minute
  * Tier 2: ~20 request per minute (conversations.history)
  * Tier 3: ~50 request per minute (conversations.replies)
- *
-
  */
 
 export async function getChannels(

--- a/connectors/src/lib/models.ts
+++ b/connectors/src/lib/models.ts
@@ -433,7 +433,6 @@ NotionPage.init(
       { fields: ["connectorId"] },
       { fields: ["lastSeenTs"] },
       { fields: ["parentId"] },
-      { fields: ["parentType"] },
     ],
     modelName: "notion_pages",
   }
@@ -514,7 +513,6 @@ NotionDatabase.init(
       { fields: ["connectorId", "skipReason"] },
       { fields: ["lastSeenTs"] },
       { fields: ["parentId"] },
-      { fields: ["parentType"] },
     ],
     modelName: "notion_databases",
   }

--- a/connectors/src/types/resources.ts
+++ b/connectors/src/types/resources.ts
@@ -1,0 +1,26 @@
+import { ConnectorProvider } from "./connector";
+
+/**
+ * This type represents the permission associated with a ConnectorResource. For now the only
+ * permission we handle is read. but we could have more complex permissions in the future.
+ */
+export type ConnectorPermission = "read" | null;
+
+/**
+ * A ConnectorResource represents a connector related resource. As an example:
+ * - Notion: Top-level pages (possibly manually added lower level ones)
+ * - Github: repositories
+ * - Slack: channels
+ * - GoogleDrive: shared drive or sub-folders of shared drives.
+ *
+ * `internalId` and `parentInternalId` are internal opaque identifiers that should enable
+ * reconstrcuting the tree structure of the resources.
+ */
+export type ConnectorResource = {
+  provider: ConnectorProvider;
+  internalId: string;
+  parentInternalId: string | null;
+  title: string;
+  sourceUrl: string | null;
+  permission: ConnectorPermission;
+};

--- a/connectors/src/types/resources.ts
+++ b/connectors/src/types/resources.ts
@@ -6,6 +6,8 @@ import { ConnectorProvider } from "./connector";
  */
 export type ConnectorPermission = "read" | null;
 
+export type ConnectorResourceType = "file" | "folder" | "database" | "channel";
+
 /**
  * A ConnectorResource represents a connector related resource. As an example:
  * - Notion: Top-level pages (possibly manually added lower level ones)
@@ -14,7 +16,7 @@ export type ConnectorPermission = "read" | null;
  * - GoogleDrive: shared drive or sub-folders of shared drives.
  *
  * `internalId` and `parentInternalId` are internal opaque identifiers that should enable
- * reconstrcuting the tree structure of the resources.
+ * reconstructing the tree structure of the resources.
  */
 export type ConnectorResource = {
   provider: ConnectorProvider;
@@ -22,5 +24,6 @@ export type ConnectorResource = {
   parentInternalId: string | null;
   title: string;
   sourceUrl: string | null;
+  type: ConnectorResourceType;
   permission: ConnectorPermission;
 };

--- a/connectors/src/types/resources.ts
+++ b/connectors/src/types/resources.ts
@@ -22,8 +22,9 @@ export type ConnectorResource = {
   provider: ConnectorProvider;
   internalId: string;
   parentInternalId: string | null;
+  type: ConnectorResourceType;
   title: string;
   sourceUrl: string | null;
-  type: ConnectorResourceType;
+  expandable: boolean;
   permission: ConnectorPermission;
 };


### PR DESCRIPTION
This PR adds a new API to the connectors service to retrieve the permissions of a connector. Its behavior depends on the connector:

- slack: returns the list of channels
- github: returns the list of repos
- notion: it returns the top-level pages or databases we have access and allow traversing the tree of pages/databases
- google_drive: returns the folders that were selected during the permissioning process (no traversing for now)

It relies on the following new type:
```
export type ConnectorPermission = "read" | null;
export type ConnectorResourceType = "file" | "folder" | "database" | "channel";

export type ConnectorResource = {
  provider: ConnectorProvider;
  internalId: string;
  parentInternalId: string | null;
  type: ConnectorResourceType;
  title: string;
  sourceUrl: string | null;
  expandable: boolean;
  permission: ConnectorPermission;
};
```

This API will be leveraged to provide an UI in the data source settings to introspect permissions.

The API consists in a GET endpoint `/connectors/:connector_id/permissions` with an optional `parentId` query parameter to traverse permissions when they are expandable (Notion only right now).

The ConnectorResource type will also be leveraged to set custom permissions per data source that filter the token permission as is already the case for google drive. We'll transition the google drive permission select to a standardized API based on this new type (will on-demand expand instead of 1 big load)