### PR TITLE
[WIP] Add runs delete API endpoint

### DIFF
--- a/core/src/run.rs
+++ b/core/src/run.rs
@@ -255,6 +255,19 @@ impl Run {
     pub fn set_block_status(&mut self, status: BlockStatus) {
         self.status.set_block_status(status);
     }
+
+    pub async fn delete(&self, store: Box<dyn Store + Sync + Send>) -> Result<()> {
+        let store = store.clone();
+
+        store.delete_run(&self.run_id).await?;
+
+        utils::done(&format!(
+            "Deleted run: run_id={}",
+            self.run_id,
+        ));
+
+        Ok(())
+    }
 }
 
 pub async fn cmd_inspect(run_id: &str, block_type: BlockType, block_name: &str) -> Result<()> {

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -79,6 +79,8 @@ pub trait Store {
         block: Option<Option<(BlockType, String)>>,
     ) -> Result<Option<Run>>;
 
+    async fn delete_run(&self, run_id: &str) -> Result<()>;
+
     // DataSources
     async fn register_data_source(&self, project: &Project, ds: &DataSource) -> Result<()>;
     async fn load_data_source(


### PR DESCRIPTION
* runs_delete POST handler for `/projects/:project_id/runs/:run_id`
* Run struct delete fn
* Store delete_run fn, impl for Postgres & Sqlite
  - deletes `runs`, `runs_joins` & associated `block_executions` rows
* exercise runs delete in e2e sqlite test