### PR TITLE
Add esbuild/linux-x64 to package-lock.json

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -710,6 +710,21 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.17.14",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.3.0",
       "dev": true,
@@ -13506,6 +13521,7 @@
     },
     "node_modules/unix-dgram": {
       "version": "2.0.6",
+      "hasInstallScript": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {


### PR DESCRIPTION
This PR adds the dependency to @esbuild/linux-x64 to avoid the errors described in https://dust4ai.slack.com/archives/C050SM8NSPK/p1689264952354609