### PR TITLE
Display tabs for Gens & Extract in dev mode or Dust workspace?

### DIFF
--- a/front/components/use/MainTab.tsx
+++ b/front/components/use/MainTab.tsx
@@ -1,10 +1,15 @@
 import { Menu } from "@headlessui/react";
-import { ChatBubbleLeftIcon } from "@heroicons/react/24/outline";
+import {
+  ArrowUpTrayIcon,
+  ChatBubbleLeftIcon,
+  PencilSquareIcon,
+} from "@heroicons/react/24/outline";
 import { ChevronDownIcon } from "@heroicons/react/24/solid";
 import Link from "next/link";
 
 import { classNames } from "@app/lib/utils";
 import { WorkspaceType } from "@app/types/user";
+import { isDevelopmentOrDustWorkspace } from "@app/lib/development";
 
 export default function MainTab({
   currentTab,
@@ -13,7 +18,7 @@ export default function MainTab({
   currentTab: string;
   owner: WorkspaceType;
 }) {
-  const tabs: { name: string; href: string; icon: JSX.Element }[] = [
+  const publicTabs: { name: string; href: string; icon: JSX.Element }[] = [
     {
       name: "Chat",
       href: `/w/${owner.sId}/u/chat`,
@@ -25,7 +30,31 @@ export default function MainTab({
       ),
     },
   ];
+  const developmentTabs: { name: string; href: string; icon: JSX.Element }[] = [
+    {
+      name: "Gens",
+      href: `/w/${owner.sId}/u/gens`,
+      icon: (
+        <PencilSquareIcon
+          className="mr-2 mt-0.5 h-4 w-4 flex-shrink-0"
+          aria-hidden="true"
+        />
+      ),
+    },
+    {
+      name: "Extract data",
+      href: `/w/${owner.sId}/u/extract`,
+      icon: (
+        <ArrowUpTrayIcon
+          className="mr-2 mt-0.5 h-4 w-4 flex-shrink-0"
+          aria-hidden="true"
+        />
+      ),
+    },
+  ];
 
+  const displayDevTabs = isDevelopmentOrDustWorkspace(owner);
+  const tabs = displayDevTabs ? publicTabs.concat(developmentTabs) : publicTabs;
   const currTab = tabs.find((tab) => tab.name == currentTab);
 
   return (

--- a/front/components/use/MainTab.tsx
+++ b/front/components/use/MainTab.tsx
@@ -7,9 +7,9 @@ import {
 import { ChevronDownIcon } from "@heroicons/react/24/solid";
 import Link from "next/link";
 
+import { isDevelopmentOrDustWorkspace } from "@app/lib/development";
 import { classNames } from "@app/lib/utils";
 import { WorkspaceType } from "@app/types/user";
-import { isDevelopmentOrDustWorkspace } from "@app/lib/development";
 
 export default function MainTab({
   currentTab,

--- a/front/lib/development.ts
+++ b/front/lib/development.ts
@@ -1,0 +1,10 @@
+import { WorkspaceType } from "@app/types/user";
+
+const PRODUCTION_DUST_WORKSPACE_ID = "0ec9852c2f";
+export function isDevelopment() {
+  return process.env.NODE_ENV === "development";
+}
+
+export function isDevelopmentOrDustWorkspace(owner: WorkspaceType) {
+  return isDevelopment() || owner.sId === PRODUCTION_DUST_WORKSPACE_ID;
+}

--- a/front/pages/w/[wId]/u/extract/index.tsx
+++ b/front/pages/w/[wId]/u/extract/index.tsx
@@ -1,0 +1,71 @@
+import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+
+import AppLayout from "@app/components/AppLayout";
+import MainTab from "@app/components/use/MainTab";
+import {
+  Authenticator,
+  getSession,
+  getUserFromSession,
+} from "@app/lib/auth";
+import { UserType, WorkspaceType } from "@app/types/user";
+
+const { GA_TRACKING_ID = "" } = process.env;
+export const getServerSideProps: GetServerSideProps<{
+  user: UserType | null;
+  owner: WorkspaceType;
+  gaTrackingId: string;
+}> = async (context) => {
+  const session = await getSession(context.req, context.res);
+  const user = await getUserFromSession(session);
+  const auth = await Authenticator.fromSession(
+    session,
+    context.params?.wId as string
+  );
+  const owner = auth.workspace();
+  if (!owner) {
+    return {
+      notFound: true,
+    };
+  }
+
+  return {
+    props: {
+      user,
+      owner,
+      gaTrackingId: GA_TRACKING_ID,
+    },
+  };
+};
+
+export default function AppExtractEvents({
+  user,
+  owner,
+  gaTrackingId,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  return (
+    <AppLayout
+      user={user}
+      owner={owner}
+      gaTrackingId={gaTrackingId}
+      app={undefined}
+      dataSource={undefined}
+    >
+      <div className="flex h-full flex-col">
+        <div className="mt-2">
+          <MainTab currentTab="Extract data" owner={owner} />
+        </div>
+
+        <div className="">
+          <div className="mx-auto mt-8 max-w-2xl divide-y divide-gray-200 px-6">
+            <div className="mt-16 flex flex-col items-center justify-center text-sm text-gray-500">
+              <p>📤 Welcome to Extract Events!</p>
+              <p className="mt-8">
+                [This page is under construction, please come back later! 😬]
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </AppLayout>
+  );
+}

--- a/front/pages/w/[wId]/u/extract/index.tsx
+++ b/front/pages/w/[wId]/u/extract/index.tsx
@@ -2,11 +2,7 @@ import { GetServerSideProps, InferGetServerSidePropsType } from "next";
 
 import AppLayout from "@app/components/AppLayout";
 import MainTab from "@app/components/use/MainTab";
-import {
-  Authenticator,
-  getSession,
-  getUserFromSession,
-} from "@app/lib/auth";
+import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
 import { UserType, WorkspaceType } from "@app/types/user";
 
 const { GA_TRACKING_ID = "" } = process.env;


### PR DESCRIPTION
Small PR just to display tabs for explorations in development mode or if it's Dust workspace.
Goal is to make it easier to access those products. Are we okay with that? 

<img width="786" alt="Capture d’écran 2023-07-17 à 15 25 22" src="https://github.com/dust-tt/dust/assets/3803406/2bc13fc3-8fd3-4083-865d-a1fb512c1542">

