### PR TITLE
fix: add forceResync param to notion sync workflow

### DIFF
--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -150,11 +150,6 @@ export async function fullResyncNotionConnector(
     logger.error({ connectorId }, "Notion connector not found.");
     return new Err(new Error("Connector not found"));
   }
-  if (fromTs) {
-    return new Err(
-      new Error("Notion connector does not support partial resync")
-    );
-  }
 
   try {
     await stopNotionConnector(connector.id.toString());
@@ -173,7 +168,11 @@ export async function fullResyncNotionConnector(
   }
 
   try {
-    await launchNotionSyncWorkflow(connector.id.toString(), null);
+    await launchNotionSyncWorkflow(
+      connector.id.toString(),
+      fromTs,
+      true //forceResync
+    );
   } catch (e) {
     logger.error(
       {

--- a/connectors/src/connectors/notion/temporal/client.ts
+++ b/connectors/src/connectors/notion/temporal/client.ts
@@ -17,7 +17,8 @@ const logger = mainLogger.child({ provider: "notion" });
 
 export async function launchNotionSyncWorkflow(
   connectorId: string,
-  startFromTs: number | null = null
+  startFromTs: number | null = null,
+  forceResync = false
 ) {
   const client = await getTemporalClient();
   const connector = await Connector.findByPk(connectorId);
@@ -41,7 +42,12 @@ export async function launchNotionSyncWorkflow(
   }
 
   await client.workflow.start(notionSyncWorkflow, {
-    args: [dataSourceConfig, nangoConnectionId, startFromTs || undefined],
+    args: [
+      dataSourceConfig,
+      nangoConnectionId,
+      startFromTs || undefined,
+      forceResync,
+    ],
     taskQueue: QUEUE_NAME,
     workflowId: getWorkflowId(dataSourceConfig),
   });

--- a/connectors/src/connectors/notion/temporal/config.ts
+++ b/connectors/src/connectors/notion/temporal/config.ts
@@ -1,2 +1,2 @@
-export const WORKFLOW_VERSION = 14;
+export const WORKFLOW_VERSION = 15;
 export const QUEUE_NAME = `notion-queue-v${WORKFLOW_VERSION}`;


### PR DESCRIPTION
notion sync workflow skips updating pages that are already up-to-date, which breaks the full resync feature (as it is usually meant to re-embed pages that may be up to date).
This commit adds a `forceResync` boolean parameter that makes the workflow re-embed every page, even if up-to-date

Also enabled partial resyncs for notion (the parameter already existed)