### PR TITLE
feat: store notion page URL and title

### DIFF
--- a/connectors/src/connectors/notion/lib/connectors_db_helpers.ts
+++ b/connectors/src/connectors/notion/lib/connectors_db_helpers.ts
@@ -7,6 +7,8 @@ export async function upsertNotionPageInConnectorsDb(
   lastSeenTs: number,
   parentType?: string | null,
   parentId?: string | null,
+  title?: string | null,
+  notionUrl?: string | null,
   lastUpsertedTs?: number,
   skipReason?: string
 ): Promise<NotionPage> {
@@ -31,10 +33,13 @@ export async function upsertNotionPageInConnectorsDb(
     lastSeenTs: Date;
     parentType?: string;
     parentId?: string;
+    title?: string;
+    notionUrl?: string;
     lastUpsertedTs?: Date;
     skipReason?: string;
   } = {
     lastSeenTs: new Date(lastSeenTs),
+    skipReason,
   };
   if (lastUpsertedTs) {
     updateParams.lastUpsertedTs = new Date(lastUpsertedTs);
@@ -47,6 +52,12 @@ export async function upsertNotionPageInConnectorsDb(
   }
   if (parentId) {
     updateParams.parentId = parentId;
+  }
+  if (title) {
+    updateParams.title = title;
+  }
+  if (notionUrl) {
+    updateParams.notionUrl = notionUrl;
   }
 
   if (page) {

--- a/connectors/src/connectors/notion/lib/notion_api.ts
+++ b/connectors/src/connectors/notion/lib/notion_api.ts
@@ -30,6 +30,7 @@ type PropertyTypes = PageObjectProperties[PropertyKeys]["type"];
 export interface ParsedPage {
   id: string;
   url: string;
+  title?: string;
   properties: ParsedProperty[];
   blocks: ParsedBlock[];
   rendered: string;
@@ -393,9 +394,12 @@ export async function getParsedPage(
       break;
   }
 
+  const titleProperty = properties.find((p) => p.type === "title")?.text;
+
   return {
     id: page.id,
     url: page.url,
+    title: titleProperty || undefined,
     properties,
     blocks: parsedBlocks,
     rendered: renderedPage,

--- a/connectors/src/connectors/notion/lib/tags.ts
+++ b/connectors/src/connectors/notion/lib/tags.ts
@@ -2,9 +2,8 @@ import type { ParsedPage } from "@connectors/connectors/notion/lib/notion_api";
 
 export function getTagsForPage(page: ParsedPage): string[] {
   const tags: string[] = [];
-  const titleProperty = page.properties.find((p) => p.type === "title")?.text;
-  if (titleProperty) {
-    tags.push(`title:${titleProperty}`);
+  if (page.title) {
+    tags.push(`title:${page.title}`);
   }
 
   return tags.concat([

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -233,6 +233,8 @@ export async function notionUpsertPageActivity(
     runTimestamp,
     parsedPage ? parsedPage.parentType : null,
     parsedPage ? parsedPage.parentId : null,
+    parsedPage ? parsedPage.title : null,
+    parsedPage ? parsedPage.url : null,
     upsertTs
   );
 }

--- a/connectors/src/lib/models.ts
+++ b/connectors/src/lib/models.ts
@@ -365,6 +365,8 @@ export class NotionPage extends Model<
 
   declare parentType?: string | null;
   declare parentId?: string | null;
+  declare title?: string | null;
+  declare notionUrl?: string | null;
 
   declare connectorId: ForeignKey<Connector["id"]>;
 }
@@ -410,6 +412,14 @@ NotionPage.init(
       type: DataTypes.STRING,
       allowNull: true,
     },
+    title: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
+    notionUrl: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
   },
   {
     sequelize: sequelize_conn,
@@ -417,6 +427,8 @@ NotionPage.init(
       { fields: ["notionPageId", "connectorId"], unique: true },
       { fields: ["connectorId"] },
       { fields: ["lastSeenTs"] },
+      { fields: ["parentId"] },
+      { fields: ["parentType"] },
     ],
     modelName: "notion_pages",
   }


### PR DESCRIPTION
Stores in the `NotionPage` table the `notionUrl` (user friendly notion page URL) and `title` (text of the `title` property, if any).