### PR TITLE
fix: use TEXT instead of STRING for notion title column

### DIFF
--- a/connectors/src/lib/models.ts
+++ b/connectors/src/lib/models.ts
@@ -413,7 +413,7 @@ NotionPage.init(
       allowNull: true,
     },
     title: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     notionUrl: {


### PR DESCRIPTION
title can be long