### PR TITLE
Better error management for front and connectors

### DIFF
--- a/connectors/src/logger/withlogging.ts
+++ b/connectors/src/logger/withlogging.ts
@@ -74,14 +74,16 @@ export const withLogging = (handler: any) => {
 export function apiError(
   req: Request,
   res: Response,
-  error: APIErrorWithStatusCode
+  apiError: APIErrorWithStatusCode,
+  error?: Error
 ): void {
   logger.error(
     {
       method: req.method,
       url: req.url,
-      statusCode: error.status_code,
-      error,
+      statusCode: apiError.status_code,
+      apiError: apiError,
+      error: error,
     },
     "API Error"
   );
@@ -90,13 +92,13 @@ export function apiError(
     `method:${req.method}`,
     `url:${req.url}`,
     `status_code:${res.statusCode}`,
-    `error_type:${error.api_error.type}`,
+    `error_type:${apiError.api_error.type}`,
   ];
 
   statsDClient.increment("api_errors.count", 1, tags);
 
-  res.status(error.status_code).json({
-    error: error.api_error,
+  res.status(apiError.status_code).json({
+    error: apiError.api_error,
   });
   return;
 }

--- a/front/logger/logger.ts
+++ b/front/logger/logger.ts
@@ -2,6 +2,9 @@ import pino, { LoggerOptions } from "pino";
 
 const NODE_ENV = process.env.NODE_ENV;
 const defaultPinoOptions: LoggerOptions = {
+  serializers: {
+    error: pino.stdSerializers.err,
+  },
   formatters: {
     level(level) {
       return { level };

--- a/front/logger/withlogging.ts
+++ b/front/logger/withlogging.ts
@@ -71,14 +71,16 @@ export const withLogging = (handler: any) => {
 export function apiError(
   req: NextApiRequest,
   res: NextApiResponse,
-  error: APIErrorWithStatusCode
+  apiError: APIErrorWithStatusCode,
+  error?: Error
 ): void {
   logger.error(
     {
       method: req.method,
       url: req.url,
-      statusCode: error.status_code,
-      error,
+      statusCode: apiError.status_code,
+      apiError: apiError,
+      error: error,
     },
     "API Error"
   );
@@ -87,13 +89,13 @@ export function apiError(
     `method:${req.method}`,
     `url:${req.url}`,
     `status_code:${res.statusCode}`,
-    `error_type:${error.api_error.type}`,
+    `error_type:${apiError.api_error.type}`,
   ];
 
   statsDClient.increment("api_errors.count", 1, tags);
 
-  res.status(error.status_code).json({
-    error: error.api_error,
+  res.status(apiError.status_code).json({
+    error: apiError.api_error,
   });
   return;
 }


### PR DESCRIPTION
Adding a serializer for error objects named `error` (vs `err`, which is the default) in `front`.

Also adding the possibility for apiError (both in front and connectors) to log an actual error object.
That way, we don't have to decide between returning a "hardcoded" error message with the risk of completely loosing the information from the error object, or returning the `error.message` with the risk of leaking sensitive information or returning a non user friendly error.