### PR TITLE
Doc tracker improvements

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -6,6 +6,7 @@ import {
   Clone,
   Dataset,
   DataSource,
+  DocumentTrackerChangeSuggestion,
   EventSchema,
   ExtractedEvent,
   GensTemplate,
@@ -42,6 +43,7 @@ async function main() {
   await GensTemplate.sync({ alter: true });
   await EventSchema.sync({ alter: true });
   await ExtractedEvent.sync({ alter: true });
+  await DocumentTrackerChangeSuggestion.sync({ alter: true });
 
   await XP1User.sync({ alter: true });
   await XP1Run.sync({ alter: true });

--- a/front/documents_post_process_hooks/hooks/document_tracker/suggest_changes/actions/doc_tracker_retrieval.ts
+++ b/front/documents_post_process_hooks/hooks/document_tracker/suggest_changes/actions/doc_tracker_retrieval.ts
@@ -12,7 +12,8 @@ import {
 // and returns an array of DocTrackerRetrievalActionValue as output
 export async function callDocTrackerRetrievalAction(
   workspaceId: string,
-  inputText: string
+  inputText: string,
+  targetDocumentTokens = 2000
 ): Promise<t.TypeOf<typeof DocTrackerRetrievalActionValueSchema>> {
   const action = DustProdActionRegistry["doc-tracker-retrieval"];
   const config = cloneBaseConfig(action.config);
@@ -20,6 +21,7 @@ export async function callDocTrackerRetrievalAction(
   config.SEMANTIC_SEARCH.data_sources = await getTrackableDataSources(
     workspaceId
   );
+  config.SEMANTIC_SEARCH.target_document_tokens = targetDocumentTokens;
 
   const res = await callAction({
     workspaceId,

--- a/front/documents_post_process_hooks/hooks/document_tracker/suggest_changes/actions/doc_tracker_retrieval.ts
+++ b/front/documents_post_process_hooks/hooks/document_tracker/suggest_changes/actions/doc_tracker_retrieval.ts
@@ -46,6 +46,7 @@ const DocTrackerRetrievalActionValueSchema = t.array(
     source_url: t.string,
     hash: t.string,
     text_size: t.Integer,
+    text: t.union([t.string, t.null, t.undefined]),
     chunk_count: t.Integer,
     chunks: t.array(
       t.type({

--- a/front/documents_post_process_hooks/hooks/document_tracker/suggest_changes/actions/doc_tracker_suggest_changes.ts
+++ b/front/documents_post_process_hooks/hooks/document_tracker/suggest_changes/actions/doc_tracker_suggest_changes.ts
@@ -1,0 +1,44 @@
+import * as t from "io-ts";
+
+import { callAction } from "@app/lib/actions/helpers";
+import {
+  cloneBaseConfig,
+  DustProdActionRegistry,
+} from "@app/lib/actions/registry";
+
+// Part of the new doc tracker pipeline, suggest changes  based on a "source_document" (new incoming doc)
+// and a "target_document" (the tracked doc)
+// it takes {source_document, target_document} a
+// it returns {match: false} or {match: true, suggested_changes: string}
+export async function callDocTrackerSuggestChangesAction(
+  workspaceId: string,
+  sourceDocument: string,
+  targetDocument: string
+): Promise<t.TypeOf<typeof DocTrackerSuggestChangesActionValueSchema>> {
+  const action = DustProdActionRegistry["doc-tracker-suggest-changes"];
+  const config = cloneBaseConfig(action.config);
+
+  const res = await callAction({
+    workspaceId,
+    input: { source_document: sourceDocument, target_document: targetDocument },
+    action,
+    config,
+    responseValueSchema: DocTrackerSuggestChangesActionValueSchema,
+  });
+
+  if (res.isErr()) {
+    throw res.error;
+  }
+
+  return res.value;
+}
+
+const DocTrackerSuggestChangesActionValueSchema = t.union([
+  t.type({
+    match: t.literal(false),
+  }),
+  t.type({
+    match: t.literal(true),
+    suggested_changes: t.string,
+  }),
+]);

--- a/front/documents_post_process_hooks/hooks/document_tracker/suggest_changes/lib.ts
+++ b/front/documents_post_process_hooks/hooks/document_tracker/suggest_changes/lib.ts
@@ -5,7 +5,6 @@ import {
   DocumentsPostProcessHookFilterParams,
   DocumentsPostProcessHookOnUpsertParams,
 } from "@app/documents_post_process_hooks/hooks";
-import { callLegacyDocTrackerAction } from "@app/documents_post_process_hooks/hooks/document_tracker/suggest_changes/actions/doc_tracker_legacy";
 import {
   getDatasource,
   getDocumentDiff,
@@ -14,10 +13,16 @@ import { CoreAPI } from "@app/lib/core_api";
 import { DataSource, TrackedDocument, User, Workspace } from "@app/lib/models";
 import mainLogger from "@app/logger/logger";
 
+import { callDocTrackerRetrievalAction } from "./actions/doc_tracker_retrieval";
+import { callDocTrackerSuggestChangesAction } from "./actions/doc_tracker_suggest_changes";
+
 const { RUN_DOCUMENT_TRACKER_FOR_WORKSPACE_IDS = "" } = process.env;
 const { SENDGRID_API_KEY } = process.env;
 
 const MINIMUM_POSITIVE_DIFF_LENGTH = 20;
+const MAX_DIFF_TOKENS = 4000;
+const TOTAL_TARGET_TOKENS = 6000;
+const RETRIEVAL_MIN_SCORE = 0.75;
 
 const logger = mainLogger.child({
   postProcessHook: "document_tracker_suggest_changes",
@@ -123,15 +128,26 @@ export async function documentTrackerSuggestChangesOnUpsert({
   workspaceId,
   documentId,
   documentHash,
+  documentSourceUrl,
 }: DocumentsPostProcessHookOnUpsertParams): Promise<void> {
-  logger.info(
-    {
-      workspaceId,
-      dataSourceName,
-      documentId,
-    },
+  const localLogger = logger.child({
+    workspaceId,
+    dataSourceName,
+    documentId,
+    documentHash,
+  });
+
+  localLogger.info(
     "Running document_tracker_suggest_changes post upsert hook."
   );
+
+  const workspace = await Workspace.findOne({
+    where: { sId: workspaceId },
+  });
+  if (!workspace) {
+    throw new Error(`Workspace not found: ${workspaceId}`);
+  }
+
   const dataSource = await getDatasource(dataSourceName, workspaceId);
   const isDocTracked = !!(await TrackedDocument.count({
     where: {
@@ -143,14 +159,7 @@ export async function documentTrackerSuggestChangesOnUpsert({
   // just match the document that was just upserted if it's tracked.
   // We check this in the filter, but there could be a race condition.
   if (isDocTracked) {
-    logger.info(
-      {
-        workspaceId,
-        dataSourceName,
-        documentId,
-      },
-      "Document is tracked: not searching for matches."
-    );
+    localLogger.info("Document is tracked: not searching for matches.");
     return;
   }
   const documentDiff = await getDocumentDiff({
@@ -165,11 +174,8 @@ export async function documentTrackerSuggestChangesOnUpsert({
     .map(({ value }) => value)
     .join("");
   if (positiveDiff.length < MINIMUM_POSITIVE_DIFF_LENGTH) {
-    logger.info(
+    localLogger.info(
       {
-        workspaceId,
-        dataSourceName,
-        documentId,
         positiveDiffLength: positiveDiff.length,
       },
       "Positive diff is too short, not searching for matches."
@@ -182,26 +188,81 @@ export async function documentTrackerSuggestChangesOnUpsert({
     .filter(({ type }) => type !== "equal")
     .map(({ value, type }) => `[[**${type}**:\n${value}]]`)
     .join("\n");
-  const actionResult = await callLegacyDocTrackerAction(workspaceId, diffText);
-  if (!actionResult.match) {
-    logger.info(
-      {
-        workspaceId,
-        dataSourceName,
-        documentId,
-      },
-      "No match found."
+
+  const tokensInDiff = await CoreAPI.tokenize({
+    text: diffText,
+    modelId: "text-embedding-ada-002",
+    providerId: "openai",
+  });
+  if (tokensInDiff.isErr()) {
+    throw tokensInDiff.error;
+  }
+
+  const tokensInDiffCount = tokensInDiff.value.tokens.length;
+  if (tokensInDiffCount > MAX_DIFF_TOKENS) {
+    localLogger.info(
+      { tokensInDiffCount, positiveDiffLength: positiveDiff.length },
+      "Diff is too long, not searching for matches."
     );
     return;
   }
 
-  const workspace = await Workspace.findOne({
-    where: { sId: workspaceId },
-  });
-  if (!workspace) {
-    throw new Error(`Workspace not found: ${workspaceId}`);
+  const targetDocumentTokens = TOTAL_TARGET_TOKENS - tokensInDiffCount;
+
+  localLogger.info(
+    {
+      positiveDiffLength: positiveDiff.length,
+      tokensInDiffCount,
+    },
+    "Calling doc tracker retrieval action."
+  );
+  const retrievalResult = await callDocTrackerRetrievalAction(
+    workspaceId,
+    diffText,
+    targetDocumentTokens
+  );
+
+  if (!retrievalResult.length) {
+    localLogger.warn("No documents found.");
+    return;
   }
-  const matchedDsName = actionResult.matched_data_source_id;
+  // TODO: maybe not just look at top1, look at top 3 chunks and do on multiple docs if needed
+  const top1 = retrievalResult[0];
+  const score = top1.chunks[0].score;
+
+  if (score < RETRIEVAL_MIN_SCORE) {
+    localLogger.info(
+      { score },
+      "Score is too low, not calling doc tracker suggest changes action."
+    );
+    return;
+  }
+
+  localLogger.info({ score }, "Calling doc tracker suggest changes action.");
+
+  const suggestChangesResult = await callDocTrackerSuggestChangesAction(
+    workspaceId,
+    diffText,
+    top1.chunks.map((c) => c.text).join("\n-------\n")
+  );
+
+  if (!suggestChangesResult.match) {
+    localLogger.info({ score }, "No match found.");
+    return;
+  }
+
+  const suggestedChanges = suggestChangesResult.suggested_changes;
+  const matchedDsName = top1.data_source_id;
+  const matchedDocId = top1.document_id;
+  const matchedDocUrl = top1.source_url;
+  const matchedDocTags = top1.tags;
+  const maybeMatchedDocTitleTag = matchedDocTags.find((t) =>
+    t.startsWith("title:")
+  );
+  const matchedDocTitle = maybeMatchedDocTitleTag
+    ? maybeMatchedDocTitleTag.split(":")[1]
+    : null;
+
   const matchedDs = await DataSource.findOne({
     where: {
       name: matchedDsName,
@@ -213,15 +274,12 @@ export async function documentTrackerSuggestChangesOnUpsert({
       `Could not find data source with name ${matchedDsName} and workspaceId ${workspaceId}`
     );
   }
-  const matchedDocId = actionResult.matched_doc_id;
+
   // again, checking for race condition here and skipping if the
   // matched doc is the doc that was just upserted.
   if (matchedDs.id === dataSource.id && matchedDocId === documentId) {
-    logger.info(
+    localLogger.info(
       {
-        workspaceId,
-        dataSourceName,
-        documentId,
         matchedDsName,
         matchedDocId,
       },
@@ -229,6 +287,7 @@ export async function documentTrackerSuggestChangesOnUpsert({
     );
     return;
   }
+
   const trackedDocuments = await TrackedDocument.findAll({
     where: {
       documentId: matchedDocId,
@@ -236,11 +295,8 @@ export async function documentTrackerSuggestChangesOnUpsert({
     },
   });
   if (!trackedDocuments.length) {
-    logger.warn(
+    localLogger.warn(
       {
-        workspaceId,
-        dataSourceName,
-        documentId,
         matchedDsName,
         matchedDocId,
       },
@@ -248,6 +304,7 @@ export async function documentTrackerSuggestChangesOnUpsert({
     );
     return;
   }
+
   const users = await User.findAll({
     where: {
       id: {
@@ -260,8 +317,6 @@ export async function documentTrackerSuggestChangesOnUpsert({
     throw new Error("Missing SENDGRID_API_KEY env variable");
   }
   sgMail.setApiKey(SENDGRID_API_KEY);
-  const matchedDocUrl = actionResult.matched_doc_url;
-  const suggestedChanges = actionResult.suggested_changes;
   const incomingDocument = await CoreAPI.getDataSourceDocument({
     projectId: dataSource.dustAPIProjectId,
     dataSourceName: dataSource.name,
@@ -272,13 +327,16 @@ export async function documentTrackerSuggestChangesOnUpsert({
       `Could not get document ${documentId} from data source ${dataSource.name}`
     );
   }
-  const incomingDocumentUrl = incomingDocument.value.document.source_url;
+
+  const incomingDocumentTags = incomingDocument.value.document.tags;
+  const maybeIncomingDocumentTitleTag = incomingDocumentTags.find((t) =>
+    t.startsWith("title:")
+  );
+  const incomingDocumentTitle = maybeIncomingDocumentTitleTag;
+
   const sendEmail = async (email: string) => {
-    logger.info(
+    localLogger.info(
       {
-        workspaceId,
-        dataSourceName,
-        documentId,
         matchedDsName,
         matchedDocId,
         email,
@@ -288,10 +346,16 @@ export async function documentTrackerSuggestChangesOnUpsert({
     const msg = {
       to: email,
       from: "team@dust.tt",
-      subject: "DUST: Document update suggestion",
-      text: `Hello!
-  We have a suggestion for you to update the document ${matchedDocUrl}, based on the new document ${incomingDocumentUrl}:
-  ${suggestedChanges}
+      subject: `DUST: Document update suggestion for ${
+        matchedDocTitle || matchedDocUrl
+      }`,
+      html: `Hello!<br>
+  We have a suggestion for you to update the document <a href="${matchedDocUrl}">${
+        matchedDocTitle || matchedDocUrl
+      }</a>, based on the new document <a href="${documentSourceUrl}">${
+        incomingDocumentTitle || documentSourceUrl
+      }</a>:<br>
+  ${suggestedChanges}<br>
   The Dust team`,
     };
     await sgMail.send(msg);

--- a/front/lib/actions/registry.ts
+++ b/front/lib/actions/registry.ts
@@ -216,7 +216,7 @@ export const DustProdActionRegistry = createActionRegistry({
       workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
       appId: "4180309c80",
       appHash:
-        "8adcc9ae33a63cc735c9a23a97d7bffe658c6ef2400fc997e61e8817f611a1f8",
+        "48f73c1e4edb35f7d2422b07483700dab0140ded9fc5125248c17a5df6d1db18",
     },
     config: {
       SEMANTIC_SEARCH: {
@@ -230,7 +230,7 @@ export const DustProdActionRegistry = createActionRegistry({
           timestamp: null,
         },
         use_cache: false,
-        full_text: true,
+        full_text: false,
         target_document_tokens: 2000,
       },
     },
@@ -240,7 +240,7 @@ export const DustProdActionRegistry = createActionRegistry({
       workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
       appId: "76b40f14fb",
       appHash:
-        "09bbb3c7b8618897ea59b036f773a77f3201e11df8839f31bd0823c9869dff9f",
+        "3e59e6d02fe60e120c285851a850649378c803d36e7e6e9f4cab72d291e1a258",
     },
     config: {
       SUGGEST_CHANGES: {

--- a/front/lib/actions/registry.ts
+++ b/front/lib/actions/registry.ts
@@ -235,6 +235,22 @@ export const DustProdActionRegistry = createActionRegistry({
       },
     },
   },
+  "doc-tracker-suggest-changes": {
+    app: {
+      workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
+      appId: "76b40f14fb",
+      appHash:
+        "09bbb3c7b8618897ea59b036f773a77f3201e11df8839f31bd0823c9869dff9f",
+    },
+    config: {
+      SUGGEST_CHANGES: {
+        provider_id: "openai",
+        model_id: "gpt-4-0613",
+        use_cache: false,
+        function_call: "suggest_changes",
+      },
+    },
+  },
   "extract-events": {
     app: {
       workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,

--- a/front/lib/actions/registry.ts
+++ b/front/lib/actions/registry.ts
@@ -230,7 +230,7 @@ export const DustProdActionRegistry = createActionRegistry({
           timestamp: null,
         },
         use_cache: false,
-        full_text: false,
+        full_text: true,
         target_document_tokens: 2000,
       },
     },

--- a/front/lib/models.ts
+++ b/front/lib/models.ts
@@ -1161,6 +1161,60 @@ DataSource.hasMany(ExtractedEvent, {
   onDelete: "CASCADE",
 });
 
+export class DocumentTrackerChangeSuggestion extends Model<
+  InferAttributes<DocumentTrackerChangeSuggestion>,
+  InferCreationAttributes<DocumentTrackerChangeSuggestion>
+> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare suggestion: string;
+  declare suggestionTitle?: string | null;
+  declare status: "pending" | "done" | "rejected";
+
+  declare trackedDocumentId: ForeignKey<TrackedDocument["id"]>;
+  declare sourceDataSourceId: ForeignKey<DataSource["id"]>;
+  declare sourceDocumentId: string;
+}
+
+DocumentTrackerChangeSuggestion.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    createdAt: { type: DataTypes.DATE, allowNull: false },
+    updatedAt: { type: DataTypes.DATE, allowNull: false },
+    suggestion: { type: DataTypes.TEXT, allowNull: false },
+    suggestionTitle: { type: DataTypes.TEXT, allowNull: true },
+    status: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      defaultValue: "pending",
+    },
+    sourceDocumentId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+  },
+  {
+    modelName: "document_tracker_change_suggestion",
+    sequelize: front_sequelize,
+    indexes: [{ fields: ["trackedDocumentId"] }],
+  }
+);
+
+TrackedDocument.hasMany(DocumentTrackerChangeSuggestion, {
+  foreignKey: { allowNull: false },
+  onDelete: "CASCADE",
+});
+DataSource.hasMany(DocumentTrackerChangeSuggestion, {
+  foreignKey: { allowNull: false, name: "sourceDataSourceId" },
+  onDelete: "CASCADE",
+});
+
 // XP1
 
 const { XP1_DATABASE_URI } = process.env;


### PR DESCRIPTION
- add some statefulness (record in DB everytime a change is suggested)
- move to the new pipeline (`doc-tracker-retrieval` + `doc-tracker-suggest-changes`)
- use `targetDocumentTokens` properly
- add a lot of logging
- slightly improve the email (some HTML, doc titles, links)