### PR TITLE
qdrant logging in `core` + bump worker_threads

### DIFF
--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -950,6 +950,7 @@ async fn runs_retrieve_block(
     )>,
     extract::Extension(state): extract::Extension<Arc<APIState>>,
 ) -> (StatusCode, Json<APIResponse>) {
+    utils::info(&format!("RETRIEVE API_ENTRY {}", utils::now()));
     let project = project::Project::new_from_id(project_id);
     match state
         .store
@@ -977,15 +978,18 @@ async fn runs_retrieve_block(
                     response: None,
                 }),
             ),
-            Some(run) => (
-                StatusCode::OK,
-                Json(APIResponse {
-                    error: None,
-                    response: Some(json!({
-                        "run": run,
-                    })),
-                }),
-            ),
+            Some(run) => {
+                utils::info(&format!("RETRIEVE API_RESPONSE {}", utils::now()));
+                (
+                    StatusCode::OK,
+                    Json(APIResponse {
+                        error: None,
+                        response: Some(json!({
+                            "run": run,
+                        })),
+                    }),
+                )
+            }
         },
     }
 }

--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -950,7 +950,6 @@ async fn runs_retrieve_block(
     )>,
     extract::Extension(state): extract::Extension<Arc<APIState>>,
 ) -> (StatusCode, Json<APIResponse>) {
-    utils::info(&format!("RETRIEVE API_ENTRY {}", utils::now()));
     let project = project::Project::new_from_id(project_id);
     match state
         .store
@@ -978,18 +977,15 @@ async fn runs_retrieve_block(
                     response: None,
                 }),
             ),
-            Some(run) => {
-                utils::info(&format!("RETRIEVE API_RESPONSE {}", utils::now()));
-                (
-                    StatusCode::OK,
-                    Json(APIResponse {
-                        error: None,
-                        response: Some(json!({
-                            "run": run,
-                        })),
-                    }),
-                )
-            }
+            Some(run) => (
+                StatusCode::OK,
+                Json(APIResponse {
+                    error: None,
+                    response: Some(json!({
+                        "run": run,
+                    })),
+                }),
+            ),
         },
     }
 }

--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -1698,7 +1698,7 @@ async fn qdrant_client() -> Result<QdrantClient> {
 
 fn main() {
     let rt = tokio::runtime::Builder::new_multi_thread()
-        //.worker_threads(64)
+        .worker_threads(64)
         //.thread_name("dust-api-server")
         //.thread_stack_size(32 * 1024 * 1024)
         .enable_all()

--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -1698,7 +1698,7 @@ async fn qdrant_client() -> Result<QdrantClient> {
 
 fn main() {
     let rt = tokio::runtime::Builder::new_multi_thread()
-        //.worker_threads(8)
+        .worker_threads(64)
         //.thread_name("dust-api-server")
         //.thread_stack_size(32 * 1024 * 1024)
         .enable_all()

--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -1698,7 +1698,7 @@ async fn qdrant_client() -> Result<QdrantClient> {
 
 fn main() {
     let rt = tokio::runtime::Builder::new_multi_thread()
-        .worker_threads(64)
+        //.worker_threads(64)
         //.thread_name("dust-api-server")
         //.thread_stack_size(32 * 1024 * 1024)
         .enable_all()

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -648,20 +648,21 @@ impl DataSource {
                 chunked_points.push(chunk);
             }
 
-            let now = utils::now();
-            let chunk_len = chunk.len();
-
             for chunk in chunked_points {
+                let now = utils::now();
+                let chunk_len = chunk.len();
+
                 let _ = qdrant_client
                     .upsert_points(self.qdrant_collection(), chunk, None)
                     .await?;
+
+                utils::done(&format!(
+                    "Success upserting chunk in qdrant: points_count={} duration={}ms",
+                    chunk_len,
+                    utils::now() - now
+                ));
             }
 
-            utils::done(&format!(
-                "Success upserting chunk in qdrant: points_count={} duration={}ms",
-                chunk_len,
-                utils::now() - now
-            ));
             // let _ = qdrant_client
             //     .upsert_points(self.qdrant_collection(), points, None)
             //     .await?;

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -516,6 +516,7 @@ impl DataSource {
             self.data_source_id, document_id,
         ));
 
+        let now = utils::now();
         // Split text in chunks.
         let splits = splitter(self.config.splitter_id)
             .split(
@@ -526,7 +527,15 @@ impl DataSource {
                 text,
             )
             .await?;
+        utils::done(&format!(
+            "Splitted document: data_source_id={} document_id={} split_counts={} duration={}ms",
+            self.data_source_id,
+            document_id,
+            splits.len(),
+            utils::now() - now
+        ));
 
+        let now = utils::now();
         // Embed chunks with max concurrency of 24.
         let e = futures::stream::iter(splits.into_iter().enumerate())
             .map(|(i, s)| {
@@ -549,10 +558,11 @@ impl DataSource {
             .await?;
 
         utils::done(&format!(
-            "Finished embedding chunks: data_source_id={} document_id={} chunk_count={}",
+            "Finished embedding chunks: data_source_id={} document_id={} chunk_count={} duration={}ms",
             self.data_source_id,
             document_id,
             e.len(),
+            utils::now() - now
         ));
 
         document.chunks = e
@@ -575,6 +585,7 @@ impl DataSource {
         document.chunk_count = document.chunks.len();
         document.token_count = Some(document.chunks.len() * self.config.max_chunk_size);
 
+        let now = utils::now();
         // Clean-up previous document chunks (vector search db).
         let _ = qdrant_client
             .delete_points(
@@ -597,6 +608,12 @@ impl DataSource {
                 None,
             )
             .await?;
+        utils::done(&format!(
+            "Deleted previous document in Qdrant: data_source_id={} document_id={} duration={}ms",
+            self.data_source_id,
+            document_id,
+            utils::now() - now
+        ));
 
         // Insert new chunks (vector search db).
         let points = document

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -539,11 +539,17 @@ impl DataSource {
         // Embed chunks with max concurrency of 24.
         let e = futures::stream::iter(splits.into_iter().enumerate())
             .map(|(i, s)| {
+                let data_source_id = self.data_source_id.clone();
+                let document_id = document_id.to_string();
                 let provider_id = self.config.provider_id.clone();
                 let model_id = self.config.model_id.clone();
                 let credentials = credentials.clone();
                 let extras = self.config.extras.clone();
                 tokio::spawn(async move {
+                    utils::info(&format!(
+                        "Embedding chunk: data_source_id={} document_id={}",
+                        data_source_id, document_id,
+                    ));
                     let r = EmbedderRequest::new(provider_id, &model_id, &s, extras);
                     let v = r.execute(credentials).await?;
                     Ok::<(usize, std::string::String, EmbedderVector), anyhow::Error>((i, s, v))

--- a/core/src/stores/postgres.rs
+++ b/core/src/stores/postgres.rs
@@ -737,15 +737,12 @@ impl Store for PostgresStore {
         run_id: &str,
         block: Option<Option<(BlockType, String)>>,
     ) -> Result<Option<Run>> {
-        utils::info(&format!("RETRIEVE LOAD_RUN_ENTRY {}", utils::now()));
         let project_id = project.project_id();
         let run_id = run_id.to_string();
         let block = block.clone();
 
         let pool = self.pool.clone();
-        utils::info(&format!("RETRIEVE LOAD_RUN_POOL_CLONE {}", utils::now()));
         let c = pool.get().await?;
-        utils::info(&format!("RETRIEVE LOAD_RUN_POOL_AWAIT {}", utils::now()));
 
         // Check that the run_id exists
         let r = c
@@ -755,7 +752,6 @@ impl Store for PostgresStore {
                 &[&project_id, &run_id],
             )
             .await?;
-        utils::info(&format!("RETRIEVE LOAD_RUN_QUERY_RUNS {}", utils::now()));
 
         let d: Option<(i64, i64, String, String, String, String)> = match r.len() {
             0 => None,
@@ -836,10 +832,6 @@ impl Store for PostgresStore {
                     None => (),
                     Some((block_type, block_name)) => {
                         // Retrieve data points through datasets_joins for one block
-                        utils::info(&format!(
-                            "RETRIEVE LOAD_RUN_PRE_PREPARE_BLOCK {}",
-                            utils::now()
-                        ));
                         let stmt = c
                             .prepare(
                                 "SELECT \
@@ -851,11 +843,9 @@ impl Store for PostgresStore {
                             WHERE runs_joins.run = $1 AND block_type = $2 AND block_name = $3",
                             )
                             .await?;
-                        utils::info(&format!("RETRIEVE LOAD_RUN_PREPARE_BLOCK {}", utils::now()));
                         let rows = c
                             .query(&stmt, &[&row_id, &block_type.to_string(), &block_name])
                             .await?;
-                        utils::info(&format!("RETRIEVE LOAD_RUN_QUERY_BLOCK {}", utils::now()));
                         rows.iter()
                             .map(|row| {
                                 let block_idx: i64 = row.get(0);
@@ -885,10 +875,6 @@ impl Store for PostgresStore {
                 }
             }
         }
-        utils::info(&format!(
-            "RETRIEVE LOAD_RUN_PRE_POSTPROCESS {}",
-            utils::now()
-        ));
 
         let mut input_counts: Vec<usize> = vec![0; block_count as usize];
         data.iter().for_each(|(block_idx, _, _, input_idx, _, _)| {
@@ -957,10 +943,6 @@ impl Store for PostgresStore {
                 )
             })
             .collect::<Vec<_>>();
-        utils::info(&format!(
-            "RETRIEVE LOAD_RUN_POSTPROCESS_DONE {}",
-            utils::now()
-        ));
 
         Ok(Some(Run::new_from_store(
             &run_id,


### PR DESCRIPTION
This PR adds logging around upsertion in data sources and bumps the worker threads to 64 workers.

Our upsertion is CPU bound (mix of parallelization talking to OpenAI + tokenization + upsertion in Qdrant), so we were very easily exhausting the 4 worker threads creating delays in all other queries.

Bumping the worker_threads to 64 allows parallelization of upsertion work + serving other queries.