### PR TITLE
distrubtion metric for duration of front requests

### DIFF
--- a/connectors/src/logger/withlogging.ts
+++ b/connectors/src/logger/withlogging.ts
@@ -57,6 +57,7 @@ export const withLogging = (handler: any) => {
 
     statsDClient.increment("requests.count", 1, tags);
     statsDClient.histogram("requests.duration", elapsed, tags);
+    statsDClient.distribution("requests.duration.distribution", elapsed, tags);
 
     logger.info(
       {

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -539,17 +539,11 @@ impl DataSource {
         // Embed chunks with max concurrency of 24.
         let e = futures::stream::iter(splits.into_iter().enumerate())
             .map(|(i, s)| {
-                let data_source_id = self.data_source_id.clone();
-                let document_id = document_id.to_string();
                 let provider_id = self.config.provider_id.clone();
                 let model_id = self.config.model_id.clone();
                 let credentials = credentials.clone();
                 let extras = self.config.extras.clone();
                 tokio::spawn(async move {
-                    utils::info(&format!(
-                        "Embedding chunk: data_source_id={} document_id={}",
-                        data_source_id, document_id,
-                    ));
                     let r = EmbedderRequest::new(provider_id, &model_id, &s, extras);
                     let v = r.execute(credentials).await?;
                     Ok::<(usize, std::string::String, EmbedderVector), anyhow::Error>((i, s, v))


### PR DESCRIPTION
Also removes a bit of extra logging in `core`