### PR TITLE
fix: chat sessions: ensure messages are created in right order in psql

### DIFF
--- a/front/lib/api/chat.ts
+++ b/front/lib/api/chat.ts
@@ -698,13 +698,9 @@ export async function* newChat(
   const session = await upsertChatSession(auth, sId, null);
   yield { type: "chat_session_create", session } as ChatSessionCreateEvent;
 
-  await Promise.all(
-    messages.map((m) => {
-      return (async () => {
-        await upsertChatMessage(session, m);
-      })();
-    })
-  );
+  for (const m of messages) {
+    await upsertChatMessage(session, m);
+  }
 
   // Update session title.
   const configTitle = cloneBaseConfig(


### PR DESCRIPTION
As detailed on [this slack thread](https://dust4ai.slack.com/archives/C050A0S2Z7F/p1689761072468429?thread_ts=1689757238.557799&cid=C050A0S2Z7F)

A retrieval message was saved in psql before the user message that triggered it. When users go back to the chat session, they see the retrieval before their message.

Fixed by storing sequentially rather than concurrently; since messages are few (max 3) I expect this won't be an issue. Two other solutions if this turns out false:
1. small 2ms timeout before sending  => a bit hacky, no guarantees
2. check whether we can batch send the message with an order garantee and sort by id => safer solution but maybe not needed

cc @gabhubert FYI