### PR TITLE
Use spawn blocking for encoding/decoding

### DIFF
--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -28,6 +28,7 @@ use tokio::sync::mpsc::UnboundedSender;
 use tokio::time::timeout;
 
 use super::llm::{ChatFunction, ChatFunctionCall};
+use super::tiktoken::tiktoken::{decode_async, encode_async};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Usage {
@@ -1152,13 +1153,11 @@ impl LLM for OpenAILLM {
     }
 
     async fn encode(&self, text: &str) -> Result<Vec<usize>> {
-        let tokens = { self.tokenizer().lock().encode_with_special_tokens(text) };
-        Ok(tokens)
+        encode_async(self.tokenizer(), text).await
     }
 
     async fn decode(&self, tokens: Vec<usize>) -> Result<String> {
-        let str = { self.tokenizer().lock().decode(tokens)? };
-        Ok(str)
+        decode_async(self.tokenizer(), tokens).await
     }
 
     async fn generate(


### PR DESCRIPTION
This moves encoding/decoding to being async based on a spawn::blocking so that the CPU-bound work is scheduled on separate threads.