### PR TITLE
Move to distributions everywhere (along with histogram)

### DIFF
--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -111,6 +111,11 @@ async function _upsertToDatasource(
       elapsed,
       statsDTags
     );
+    statsDClient.distribution(
+      "data_source_upserts_error.duration.distribution",
+      elapsed,
+      statsDTags
+    );
     localLogger.error({ error: e }, "Error uploading document to Dust.");
     throw e;
   }
@@ -124,11 +129,21 @@ async function _upsertToDatasource(
       elapsed,
       statsDTags
     );
+    statsDClient.distribution(
+      "data_source_upserts_success.duration.distribution",
+      elapsed,
+      statsDTags
+    );
     localLogger.info("Successfully uploaded document to Dust.");
   } else {
     statsDClient.increment("data_source_upserts_error.count", 1, statsDTags);
     statsDClient.histogram(
       "data_source_upserts_error.duration",
+      elapsed,
+      statsDTags
+    );
+    statsDClient.distribution(
+      "data_source_upserts_error.duration.distribution",
       elapsed,
       statsDTags
     );

--- a/connectors/src/lib/temporal_monitoring.ts
+++ b/connectors/src/lib/temporal_monitoring.ts
@@ -87,6 +87,11 @@ export class ActivityInboundLogInterceptor
         this.logger.info({ durationMs: durationMs }, "Activity completed.");
         statsDClient.increment("activities_success.count", 1, tags);
         statsDClient.histogram("activities.duration", durationMs, tags);
+        statsDClient.distribution(
+          "activities.duration.distribution",
+          durationMs,
+          tags
+        );
       }
     }
   }

--- a/front/lib/temporal_monitoring.ts
+++ b/front/lib/temporal_monitoring.ts
@@ -88,6 +88,11 @@ export class ActivityInboundLogInterceptor
         this.logger.info({ durationMs: durationMs }, "Activity completed.");
         statsDClient.increment("activities_success.count", 1, tags);
         statsDClient.histogram("activities.duration", durationMs, tags);
+        statsDClient.distribution(
+          "activities.duration.distribution",
+          durationMs,
+          tags
+        );
       }
     }
   }


### PR DESCRIPTION
After we transition all our monitors in Datadog to distributions we can remove the histograms