### PR TITLE
Decrease max document length to 750k

### DIFF
--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -9,7 +9,9 @@ if (!FRONT_API) {
   throw new Error("FRONT_API not set");
 }
 
-export const MAX_DOCUMENT_TXT_LEN = 1000000;
+// We limit the document size we support. Beyond a certain size, upsert is simply too slow (>300s)
+// and large files are generally less useful anyway.
+export const MAX_DOCUMENT_TXT_LEN = 750000;
 
 export async function upsertToDatasource(
   dataSourceConfig: DataSourceConfig,


### PR DESCRIPTION
Context here: https://dust4ai.slack.com/archives/C05F84CFP0E/p1689830172104049

1MB is still be a bit high (>5mn upsert timing out) decreasing the maximum document size to 750KB