### PR TITLE
Extract templates: read only for users non builder

### DIFF
--- a/front/pages/w/[wId]/u/extract/[marker]/index.tsx
+++ b/front/pages/w/[wId]/u/extract/[marker]/index.tsx
@@ -12,6 +12,7 @@ export const getServerSideProps: GetServerSideProps<{
   user: UserType | null;
   owner: WorkspaceType;
   schema: EventSchemaType;
+  readOnly: boolean;
   gaTrackingId: string;
 }> = async (context) => {
   const session = await getSession(context.req, context.res);
@@ -21,7 +22,7 @@ export const getServerSideProps: GetServerSideProps<{
     context.params?.wId as string
   );
   const owner = auth.workspace();
-  if (!owner || !auth.isBuilder()) {
+  if (!owner) {
     return {
       notFound: true,
     };
@@ -39,6 +40,7 @@ export const getServerSideProps: GetServerSideProps<{
       user,
       owner,
       schema,
+      readOnly: !auth.isBuilder(),
       gaTrackingId: GA_TRACKING_ID,
     },
   };
@@ -48,6 +50,7 @@ export default function AppExtractEventsUpdate({
   user,
   owner,
   schema,
+  readOnly,
   gaTrackingId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   return (
@@ -55,6 +58,7 @@ export default function AppExtractEventsUpdate({
       user={user}
       owner={owner}
       schema={schema}
+      readOnly={readOnly}
       gaTrackingId={gaTrackingId}
     />
   );

--- a/front/pages/w/[wId]/u/extract/_shared_schema_form.tsx
+++ b/front/pages/w/[wId]/u/extract/_shared_schema_form.tsx
@@ -24,11 +24,13 @@ export function ExtractEventSchemaForm({
   user,
   owner,
   schema,
+  readOnly = false,
   gaTrackingId,
 }: {
   user: UserType | null;
   owner: WorkspaceType;
   schema?: EventSchemaType;
+  readOnly: boolean;
   gaTrackingId: string;
 }) {
   const { schemas } = useEventSchemas(owner);
@@ -156,6 +158,19 @@ export function ExtractEventSchemaForm({
         </div>
 
         <div className="mx-auto mb-10 sm:max-w-3xl lg:max-w-4xl xl:max-w-5xl">
+          {readOnly && (
+            <div
+              className="mb-10 rounded-md border-l-4 border-violet-500 bg-violet-100 p-4 text-violet-700"
+              role="alert"
+            >
+              <p className="font-bold">Read-only view</p>
+              <p className="text-sm">
+                Only users with the role Builder or Admin in the workspace can
+                edit templates.
+              </p>
+            </div>
+          )}
+
           {/* Template main infos */}
           <div className="mb-24 divide-y divide-gray-200">
             <div>
@@ -183,6 +198,7 @@ export function ExtractEventSchemaForm({
                   setMarker(e.target.value);
                 }}
                 error={errorMarker}
+                disabled={readOnly}
                 className="sm:col-span-2"
               />
               <TextField
@@ -195,6 +211,7 @@ export function ExtractEventSchemaForm({
                   setDescription(e.target.value);
                 }}
                 error={errorDescription}
+                disabled={readOnly}
                 className="sm:col-span-4"
               />
             </div>
@@ -218,6 +235,7 @@ export function ExtractEventSchemaForm({
                 setProperties={setProperties}
                 error={errorProperties}
                 setError={setErrorProperties}
+                readOnly={readOnly}
               />
             </div>
           </div>
@@ -228,7 +246,7 @@ export function ExtractEventSchemaForm({
             <div className="col-span-6 flex justify-end sm:col-span-4">
               <Button
                 type="submit"
-                disabled={isProcessing}
+                disabled={isProcessing || readOnly}
                 onClick={async () => {
                   await onSubmit();
                 }}
@@ -251,7 +269,8 @@ function TextField({
   value,
   onChange,
   error,
-  className,
+  disabled,
+  className = "",
 }: {
   name: string;
   label: string;
@@ -259,10 +278,11 @@ function TextField({
   value?: string;
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   error?: string;
-  className?: string;
+  disabled?: boolean;
+  className: string;
 }) {
   return (
-    <div className={className}>
+    <div className={classNames(className, disabled ? "text-gray-400" : "")}>
       <div className="flex justify-between">
         <label
           htmlFor={name}
@@ -284,6 +304,7 @@ function TextField({
           )}
           value={value}
           onChange={onChange}
+          disabled={disabled}
         />
       </div>
       {description && (
@@ -299,11 +320,13 @@ function PropertiesFields({
   setProperties,
   error,
   setError,
+  readOnly,
 }: {
   properties: EventSchemaPropertyType[];
   setProperties: (properties: EventSchemaPropertyType[]) => void;
   error: string;
   setError: (message: string) => void;
+  readOnly?: boolean;
 }) {
   function handlePropertyChange(
     index: number,
@@ -347,6 +370,7 @@ function PropertiesFields({
                 setError("");
                 handlePropertyChange(index, "name", e.target.value);
               }}
+              disabled={readOnly}
               className="sm:col-span-2"
             />
             <div className="sm:col-span-2">
@@ -362,7 +386,10 @@ function PropertiesFields({
                 <select
                   name={`type-${index}`}
                   id={`type-${index}`}
-                  className="w-full rounded-md border-gray-300 text-sm focus:border-violet-500 focus:ring-violet-500"
+                  className={classNames(
+                    "w-full rounded-md border-gray-300 text-sm focus:border-violet-500 focus:ring-violet-500",
+                    readOnly ? "text-gray-400" : ""
+                  )}
                   onChange={(e) => {
                     setError("");
                     handlePropertyChange(index, "type", e.target.value);
@@ -373,6 +400,7 @@ function PropertiesFields({
                       key={option}
                       value={option}
                       selected={option === prop["type"]}
+                      disabled={readOnly && option !== prop["type"]}
                     >
                       {option}
                     </option>
@@ -388,11 +416,13 @@ function PropertiesFields({
                 setError("");
                 handlePropertyChange(index, "description", e.target.value);
               }}
+              disabled={readOnly}
               className="sm:col-span-7"
             />
             <div className="flex items-end  sm:col-span-1">
               <div className="rounded-md shadow-sm">
                 <Button
+                  disabled={readOnly}
                   onClick={() => {
                     removeProperty(index);
                   }}
@@ -408,7 +438,7 @@ function PropertiesFields({
         <p className="text-sm font-bold text-red-400 sm:col-span-6">{error}</p>
       )}
       <div className="sm:col-span-6">
-        <Button onClick={addProperty}>
+        <Button onClick={addProperty} disabled={readOnly}>
           <PlusIcon className="-ml-1 mr-1 h-5 w-5" />
           Add property
         </Button>

--- a/front/pages/w/[wId]/u/extract/index.tsx
+++ b/front/pages/w/[wId]/u/extract/index.tsx
@@ -15,7 +15,7 @@ const { GA_TRACKING_ID = "" } = process.env;
 export const getServerSideProps: GetServerSideProps<{
   user: UserType | null;
   owner: WorkspaceType;
-  isBuilder: boolean;
+  readOnly: boolean;
   gaTrackingId: string;
 }> = async (context) => {
   const session = await getSession(context.req, context.res);
@@ -35,7 +35,7 @@ export const getServerSideProps: GetServerSideProps<{
     props: {
       user,
       owner,
-      isBuilder: auth.isBuilder(),
+      readOnly: !auth.isBuilder(),
       gaTrackingId: GA_TRACKING_ID,
     },
   };
@@ -44,7 +44,7 @@ export const getServerSideProps: GetServerSideProps<{
 export default function AppExtractEvents({
   user,
   owner,
-  isBuilder,
+  readOnly,
   gaTrackingId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const { schemas, isSchemasLoading } = useEventSchemas(owner);
@@ -63,6 +63,19 @@ export default function AppExtractEvents({
         </div>
 
         <div className="container mx-auto my-10 sm:max-w-3xl lg:max-w-4xl xl:max-w-5xl">
+          {readOnly && (
+            <div
+              className="mb-10 rounded-md border-l-4 border-violet-500 bg-violet-100 p-4 text-violet-700"
+              role="alert"
+            >
+              <p className="font-bold">Read-only view</p>
+              <p className="text-sm">
+                Only users with the role Builder or Admin in the workspace can
+                edit templates.
+              </p>
+            </div>
+          )}
+
           <h3 className="text-base font-medium leading-6 text-gray-900">
             Extract events Templates
           </h3>
@@ -88,7 +101,7 @@ export default function AppExtractEvents({
                           Status
                         </th>
                         <th scope="col" className="px-3 py-4">
-                          {isBuilder ? "Manage" : "View"}
+                          {readOnly ? "Manage" : "View"}
                         </th>
                       </tr>
                     </thead>
@@ -115,9 +128,9 @@ export default function AppExtractEvents({
                                 }
                               >
                                 <div>
-                                  {isBuilder
-                                    ? "Manage template"
-                                    : "View template"}
+                                  {readOnly
+                                    ? "View template"
+                                    : "Manage template"}
                                 </div>
                               </Button>
                             </td>
@@ -128,7 +141,7 @@ export default function AppExtractEvents({
 
                   <div className="my-10">
                     <Link href={`/w/${owner.sId}/u/extract/new`}>
-                      <Button>
+                      <Button disabled={readOnly}>
                         <PlusIcon className="-ml-1 mr-1 h-5 w-5" />
                         Create Template
                       </Button>

--- a/front/pages/w/[wId]/u/extract/new.tsx
+++ b/front/pages/w/[wId]/u/extract/new.tsx
@@ -9,6 +9,7 @@ const { GA_TRACKING_ID = "" } = process.env;
 export const getServerSideProps: GetServerSideProps<{
   user: UserType | null;
   owner: WorkspaceType;
+  readOnly: boolean;
   gaTrackingId: string;
 }> = async (context) => {
   const session = await getSession(context.req, context.res);
@@ -28,6 +29,7 @@ export const getServerSideProps: GetServerSideProps<{
     props: {
       user,
       owner,
+      readOnly: !auth.isBuilder(),
       gaTrackingId: GA_TRACKING_ID,
     },
   };
@@ -36,12 +38,14 @@ export const getServerSideProps: GetServerSideProps<{
 export default function AppExtractEventsCreate({
   user,
   owner,
+  readOnly,
   gaTrackingId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   return (
     <ExtractEventSchemaForm
       user={user}
       owner={owner}
+      readOnly={readOnly}
       gaTrackingId={gaTrackingId}
     />
   );


### PR DESCRIPTION
Reusing the same UI, just setting all buttons & fields to read only + adding a banner to make it clear only Builder or admins can edit. 

### List view
<img width="1402" alt="Capture d’écran 2023-07-20 à 11 29 11" src="https://github.com/dust-tt/dust/assets/3803406/b453a334-433b-4351-96d2-c2f10b740abf">


### Edit view
<img width="1419" alt="Capture d’écran 2023-07-20 à 11 29 25" src="https://github.com/dust-tt/dust/assets/3803406/ace737b0-4afc-44b6-b138-05154be360ea">
