### PR TITLE
enh: add npm run build to .github/workflows/build-and-lint-front.yml

### DIFF
--- a/.github/workflows/build-and-lint-front.yml
+++ b/.github/workflows/build-and-lint-front.yml
@@ -17,4 +17,4 @@ jobs:
           cache: "npm"
           cache-dependency-path: ./front/package-lock.json
       - working-directory: front
-        run: npm install && npm run tsc && npm run lint && npm run format:check
+        run: FRONT_DATABASE_URI="sqlite:foo.sqlite" XP1_DATABASE_URI="sqlite:bar.sqlite" npm ci && npm run build && npm run tsc && npm run lint && npm run format:check


### PR DESCRIPTION
Some things can fail at `next build` step (eg `tsx` file in `/pages` that don't have a React component default export)