### PR TITLE
Extract: Dust app expects an object for the properties

### DIFF
--- a/front/lib/extract_events.ts
+++ b/front/lib/extract_events.ts
@@ -135,15 +135,26 @@ async function _processExtractEvent(data: {
       status: "active",
     },
   });
+
   if (!schema) {
     return;
   }
+
+  const propertiesAsObject = {} as {
+    [key: string]: { type: string; description: string };
+  };
+  schema.properties.map((prop) => {
+    propertiesAsObject[prop.name] = {
+      type: prop.type,
+      description: prop.description,
+    };
+  });
 
   const inputsForApp = [
     {
       document_text: documentText,
       markers: markers,
-      schema_properties: schema.properties,
+      schema_properties: propertiesAsObject,
     },
   ];
 


### PR DESCRIPTION
The Dust app expects:
```json
{
  "name": {"type": "string", "description": "The name of this product idea"}, 
  "author": {"type": "string", "description": "The name of the person who shared this idea"}, 
  "context": {"type": "string", "description": "Anything that can explain what is this idea"}
}
```

While I decided to store an array cause it was easier to process for the UI: 
```json
[
  {"name": "name", "type": "string", "description": "The name of this product idea"}, 
  {"name": "author", "type": "string", "description": "The person who shared this idea"},
  {"name": "context", "type": "string", "description": "Anything that can explain what is this idea"}
]
```

So I'm just adding a piece of code here to transform the array as object, before sending to the Dust app.