### PR TITLE
feat: allow to suppress doc output when upserting

### DIFF
--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -90,6 +90,7 @@ async function _upsertToDatasource(
     source_url: documentUrl,
     timestamp,
     tags,
+    suppressDocumentOutput: true,
   };
   const dustRequestConfig: AxiosRequestConfig = {
     headers: {

--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -1333,6 +1333,7 @@ struct DataSourcesDocumentsUpsertPayload {
     source_url: Option<String>,
     text: String,
     credentials: run::Credentials,
+    suppress_document_output: Option<bool>,
 }
 
 async fn data_sources_documents_upsert(
@@ -1341,6 +1342,10 @@ async fn data_sources_documents_upsert(
     extract::Extension(state): extract::Extension<Arc<APIState>>,
 ) -> (StatusCode, Json<APIResponse>) {
     let project = project::Project::new_from_id(project_id);
+    let suppress_document_output = match payload.suppress_document_output {
+        Some(v) => v,
+        None => false,
+    };
     match state
         .store
         .load_data_source(&project, &data_source_id)
@@ -1392,20 +1397,25 @@ async fn data_sources_documents_upsert(
                             response: None,
                         }),
                     ),
-                    Ok(d) => (
-                        StatusCode::OK,
-                        Json(APIResponse {
-                            error: None,
-                            response: Some(json!({
-                                "document": d,
-                                "data_source": {
-                                    "created": ds.created(),
-                                    "data_source_id": ds.data_source_id(),
-                                    "config": ds.config(),
-                                },
-                            })),
-                        }),
-                    ),
+                    Ok(d) => {
+                        let mut response_data = json!({
+                            "data_source": {
+                                "created": ds.created(),
+                                "data_source_id": ds.data_source_id(),
+                                "config": ds.config(),
+                            },
+                        });
+                        if !suppress_document_output {
+                            response_data["document"] = json!(d);
+                        }
+                        (
+                            StatusCode::OK,
+                            Json(APIResponse {
+                                error: None,
+                                response: Some(response_data),
+                            }),
+                        )
+                    }
                 }
             }
         },

--- a/docs/src/pages/documents.mdx
+++ b/docs/src/pages/documents.mdx
@@ -121,6 +121,10 @@ The Document model represents a [Data Source](/data-sources-overview) document.
       <Property name="source_url" type="string">
         The source URL for the document to upsert.
       </Property>
+      <Property name="suppress_document_output" type="boolean">
+        Whether or not to suppress the document output. If set to `true`, the response will not
+        include the document's text, chunk and vectors (defaults to `false`).
+      </Property>
     </Properties>
 
     ### Optional JSON body attributes

--- a/front/lib/core_api.ts
+++ b/front/lib/core_api.ts
@@ -603,6 +603,7 @@ export const CoreAPI = {
     sourceUrl,
     text,
     credentials,
+    suppressDocumentOutput = false,
   }: {
     projectId: string;
     dataSourceName: string;
@@ -612,6 +613,7 @@ export const CoreAPI = {
     sourceUrl?: string | null;
     text: string;
     credentials: CredentialsType;
+    suppressDocumentOutput?: boolean;
   }): Promise<
     CoreAPIResponse<{
       document: CoreAPIDocument;
@@ -632,6 +634,7 @@ export const CoreAPI = {
           tags: tags,
           source_url: sourceUrl,
           credentials: credentials,
+          suppress_document_output: suppressDocumentOutput,
         }),
       }
     );

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
@@ -276,6 +276,7 @@ async function handler(
         sourceUrl,
         text: req.body.text,
         credentials,
+        suppressDocumentOutput: req.body.suppress_document_output === true,
       });
 
       if (upsertRes.isErr()) {


### PR DESCRIPTION
Doc output can be huge, sometimes several times larger than the doc itself due to the vectors (i.e multiple megabytes). This is often wasteful, especially in connectors where we don't do anything with the return value