### PR TITLE
Disable gdrive CSV support

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -228,7 +228,9 @@ async function syncOneFile(
     "application/vnd.google-apps.document": "text/plain",
     "application/vnd.google-apps.presentation": "text/plain",
   };
-  const mimeTypesToDownload = ["text/plain", "text/csv"];
+  // Deactivated CSV for now 20230721 (spolu)
+  // const mimeTypesToDownload = ["text/plain", "text/csv"];
+  const mimeTypesToDownload = ["text/plain"];
 
   let documentContent: string | undefined = undefined;
   if (mimeTypesToExport[file.mimeType]) {


### PR DESCRIPTION
Disable CSV download for Gdrive by not downloading mime-type text/csv

CSV file lead to a lot of tokens and many small chunks. This is not desirable for now and likely not useful to the product

cc @dust-tt/product-team 