### PR TITLE
Extract: support list types

### DIFF
--- a/front/components/use/EventSchemaForm.tsx
+++ b/front/components/use/EventSchemaForm.tsx
@@ -9,7 +9,7 @@ import { APIError } from "@app/lib/error";
 import { useEventSchemas } from "@app/lib/swr";
 import { classNames } from "@app/lib/utils";
 import {
-  eventSchemaPropertyTypeOptions,
+  eventSchemaPropertyAllTypes,
   EventSchemaType,
 } from "@app/types/extract";
 import { UserType, WorkspaceType } from "@app/types/user";
@@ -224,8 +224,9 @@ export function ExtractEventSchemaForm({
                 Template properties
               </h3>
               <p className="mt-1 text-sm text-gray-500">
-                Define the properties that you want to extract for this
-                template. The description field is key to ensure the LLM model
+                Define the properties to extract for this template. Picking a
+                list as Type allows to extract multiple values for this
+                property. The Description field is key to ensure the LLM model
                 is able to extract the right information from your documents.
               </p>
             </div>
@@ -395,7 +396,7 @@ function PropertiesFields({
                     handlePropertyChange(index, "type", e.target.value);
                   }}
                 >
-                  {eventSchemaPropertyTypeOptions.map((option) => (
+                  {eventSchemaPropertyAllTypes.map((option) => (
                     <option
                       key={option}
                       value={option}

--- a/front/lib/extract_events.ts
+++ b/front/lib/extract_events.ts
@@ -17,6 +17,7 @@ import {
   hasExtractEventMarker,
   sanitizeRawExtractEventMarkers,
 } from "@app/lib/extract_event_markers";
+import { formatPropertiesForModel } from "@app/lib/extract_events_properties";
 import { DataSource, EventSchema, ExtractedEvent } from "@app/lib/models";
 import logger from "@app/logger/logger";
 import { logOnSlack } from "@app/logger/slack_debug_logger";
@@ -140,21 +141,11 @@ async function _processExtractEvent(data: {
     return;
   }
 
-  const propertiesAsObject = {} as {
-    [key: string]: { type: string; description: string };
-  };
-  schema.properties.map((prop) => {
-    propertiesAsObject[prop.name] = {
-      type: prop.type,
-      description: prop.description,
-    };
-  });
-
   const inputsForApp = [
     {
       document_text: documentText,
       markers: markers,
-      schema_properties: propertiesAsObject,
+      schema_properties: formatPropertiesForModel(schema.properties),
     },
   ];
 

--- a/front/lib/extract_events_properties.ts
+++ b/front/lib/extract_events_properties.ts
@@ -1,0 +1,67 @@
+import {
+  EventSchemaPropertiesTypeForModel,
+  eventSchemaPropertyAllTypes,
+  EventSchemaPropertyType,
+} from "@app/types/extract";
+
+/**
+ * We start with: 
+ * [
+    {
+      name: "owner",
+      type: "string",
+      description: "The owner of the tasks",
+    },
+    {
+      name: "tasks",
+      type: "string[]",
+      description: "The tasks of the day",
+    },
+  ]
+ * And we want: 
+  {
+    owner: {
+      type: "string",
+      description: "The owner of the tasks",
+    },
+    tasks: {
+      type: "array",
+      items: {
+        type: "string",
+      },
+      description: "The tasks of the day",
+    },
+  }
+ * 
+ */
+export function formatPropertiesForModel(
+  properties: EventSchemaPropertyType[]
+) {
+  const result: EventSchemaPropertiesTypeForModel = {};
+  properties.forEach((property) => {
+    const { name, type, description }: EventSchemaPropertyType = property;
+
+    if (!eventSchemaPropertyAllTypes.includes(type)) {
+      return;
+    }
+
+    // Split the type to check if it's an array
+    const isArray = type.endsWith("[]");
+    const itemType = isArray ? type.slice(0, -2) : type;
+
+    // Create the property object based on whether it's an array or not
+    result[name] = isArray
+      ? {
+          type: "array",
+          items: {
+            type: itemType,
+          },
+          description,
+        }
+      : {
+          type,
+          description,
+        };
+  });
+  return result;
+}

--- a/front/types/extract.ts
+++ b/front/types/extract.ts
@@ -7,18 +7,25 @@ export type EventSchemaType = {
   properties: EventSchemaPropertyType[];
 };
 
-export const eventSchemaPropertyTypeOptions = [
-  "boolean",
-  "number",
-  "string",
-  "Date",
-  "number[]",
-  "string[]",
-  "Date[]",
+export const eventSchemaPrimitiveTypes = ["string", "number", "boolean"];
+export const eventSchemaListTypes = ["string[]", "number[]", "boolean[]"];
+export const eventSchemaPropertyAllTypes = [
+  ...eventSchemaPrimitiveTypes,
+  ...eventSchemaListTypes,
 ] as const;
 
+// Properties in the EventSchema table are stored as an array of objects
 export type EventSchemaPropertyType = {
   name: string;
-  type: (typeof eventSchemaPropertyTypeOptions)[number];
+  type: (typeof eventSchemaPropertyAllTypes)[number];
   description: string;
+};
+
+// Properties to send to the Dust must be as an object
+export type EventSchemaPropertiesTypeForModel = {
+  [key: string]: {
+    type: "array" | (typeof eventSchemaPropertyAllTypes)[number];
+    description: string;
+    items?: { type: (typeof eventSchemaPropertyAllTypes)[number] };
+  };
 };


### PR DESCRIPTION
- Fixing the properties types supported by GPT: `["string", "number", "boolean", "string[]", "number[]", "boolean[]"]`
- Reworking the function to transform properties into an object with the valid format expected for the function call.