### PR TITLE
`core`: Batch embed 8 by 8

### DIFF
--- a/core/src/providers/ai21.rs
+++ b/core/src/providers/ai21.rs
@@ -385,7 +385,7 @@ impl Embedder for AI21Embedder {
         Err(anyhow!("Encode/Decode not implemented for provider `ai21`"))
     }
 
-    async fn embed(&self, _text: &str, _extras: Option<Value>) -> Result<EmbedderVector> {
+    async fn embed(&self, _text: Vec<&str>, _extras: Option<Value>) -> Result<Vec<EmbedderVector>> {
         Err(anyhow!("Embeddings not available for provider `ai21`"))
     }
 }

--- a/core/src/providers/anthropic.rs
+++ b/core/src/providers/anthropic.rs
@@ -611,7 +611,7 @@ impl Embedder for AnthropicEmbedder {
         ))
     }
 
-    async fn embed(&self, _text: &str, _extras: Option<Value>) -> Result<EmbedderVector> {
+    async fn embed(&self, _text: Vec<&str>, _extras: Option<Value>) -> Result<Vec<EmbedderVector>> {
         Err(anyhow!("Embeddings not available for provider `anthropic`"))
     }
 }

--- a/core/src/providers/azure_openai.rs
+++ b/core/src/providers/azure_openai.rs
@@ -600,7 +600,7 @@ impl Embedder for AzureOpenAIEmbedder {
         Ok(str)
     }
 
-    async fn embed(&self, text: &str, extras: Option<Value>) -> Result<EmbedderVector> {
+    async fn embed(&self, text: Vec<&str>, extras: Option<Value>) -> Result<Vec<EmbedderVector>> {
         let e = embed(
             self.uri()?,
             self.api_key.clone().unwrap(),
@@ -619,15 +619,18 @@ impl Embedder for AzureOpenAIEmbedder {
 
         assert!(e.data.len() > 0);
 
-        Ok(EmbedderVector {
-            created: utils::now(),
-            provider: ProviderID::OpenAI.to_string(),
-            model: match self.model_id {
-                Some(ref model_id) => model_id.clone(),
-                None => unimplemented!(),
-            },
-            vector: e.data[0].embedding.clone(),
-        })
+        Ok(e.data
+            .into_iter()
+            .map(|v| EmbedderVector {
+                created: utils::now(),
+                provider: ProviderID::OpenAI.to_string(),
+                model: match self.model_id {
+                    Some(ref model_id) => model_id.clone(),
+                    None => unimplemented!(),
+                },
+                vector: v.embedding,
+            })
+            .collect::<Vec<_>>())
     }
 }
 

--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -1009,7 +1009,7 @@ pub async fn embed(
     api_key: String,
     organization_id: Option<String>,
     model_id: Option<String>,
-    text: &str,
+    text: Vec<&str>,
     user: Option<String>,
 ) -> Result<Embeddings> {
     let https = HttpsConnector::new();
@@ -1575,7 +1575,7 @@ impl Embedder for OpenAIEmbedder {
         decode_async(self.tokenizer(), tokens).await
     }
 
-    async fn embed(&self, text: &str, extras: Option<Value>) -> Result<EmbedderVector> {
+    async fn embed(&self, text: Vec<&str>, extras: Option<Value>) -> Result<Vec<EmbedderVector>> {
         let e = embed(
             self.uri()?,
             self.api_key.clone().unwrap(),
@@ -1601,12 +1601,15 @@ impl Embedder for OpenAIEmbedder {
         assert!(e.data.len() > 0);
         // println!("EMBEDDING: {:?}", e);
 
-        Ok(EmbedderVector {
-            created: utils::now(),
-            provider: ProviderID::OpenAI.to_string(),
-            model: self.id.clone(),
-            vector: e.data[0].embedding.clone(),
-        })
+        Ok(e.data
+            .into_iter()
+            .map(|v| EmbedderVector {
+                created: utils::now(),
+                provider: ProviderID::OpenAI.to_string(),
+                model: self.id.clone(),
+                vector: v.embedding.clone(),
+            })
+            .collect::<Vec<_>>())
     }
 }
 


### PR DESCRIPTION
```
[✓] Success querying `openai:text-embedding-ada-002`: chunk_count=7 total_text_length=6529
[✓] Finished embedding chunks: data_source_id=ff document_id=Foo chunk_count=7 duration=826ms
```

This will likely largely increase the speed of our embedding pipeline :fire: and also reduce the number of open connections we have to OpenAI

I checked that the chunk order is well preserved and that we do get the right vector for the right chunk by adding a large document with a few sentences separated by a lot of lorem ipsum

Retrieving for each sentence return as first chunk the right one