### PR TITLE
Log duration distribution of actions runs

### DIFF
--- a/front/lib/actions/server.ts
+++ b/front/lib/actions/server.ts
@@ -77,6 +77,7 @@ export async function runActionStreamed(
   ];
 
   statsDClient.increment("use_actions.count", 1, tags);
+  const now = new Date();
 
   const prodCredentials = await prodAPICredentialsForOwner(owner);
   const api = new DustAPI(prodCredentials);
@@ -104,6 +105,14 @@ export async function runActionStreamed(
       }
       yield event;
     }
+
+    // By now we have finished streaming the action so we can log the run duration.
+    const elapsed = new Date().getTime() - now.getTime();
+    statsDClient.distribution(
+      "run_action.duration.distribution",
+      elapsed,
+      tags
+    );
   };
 
   return new Ok({ eventStream: streamEvents(), dustRunId });


### PR DESCRIPTION
This adds a ditribution log of the elapsed time running an action so that we can track the latency per action type with p50/70/90 statistics