### PR TITLE
enh(post process hooks): make them take authenticators

### DIFF
--- a/front/documents_post_process_hooks/hooks/document_tracker/suggest_changes/lib.ts
+++ b/front/documents_post_process_hooks/hooks/document_tracker/suggest_changes/lib.ts
@@ -35,8 +35,8 @@ const logger = mainLogger.child({
 });
 
 export async function shouldDocumentTrackerSuggestChangesRun({
+  auth,
   dataSourceName,
-  workspaceId,
   documentId,
   dataSourceConnectorProvider,
   verb,
@@ -46,6 +46,11 @@ export async function shouldDocumentTrackerSuggestChangesRun({
       "document_tracker_suggest_changes post process hook should only run for upsert."
     );
     return false;
+  }
+
+  const workspaceId = auth.workspace()?.sId;
+  if (!workspaceId) {
+    throw new Error("Workspace not found.");
   }
 
   const localLogger = logger.child({
@@ -130,12 +135,17 @@ export async function shouldDocumentTrackerSuggestChangesRun({
 }
 
 export async function documentTrackerSuggestChangesOnUpsert({
+  auth,
   dataSourceName,
-  workspaceId,
   documentId,
   documentHash,
   documentSourceUrl,
 }: DocumentsPostProcessHookOnUpsertParams): Promise<void> {
+  const workspaceId = auth.workspace()?.sId;
+  if (!workspaceId) {
+    throw new Error("Workspace not found.");
+  }
+
   const localLogger = logger.child({
     workspaceId,
     dataSourceName,

--- a/front/documents_post_process_hooks/hooks/extract_event/index.ts
+++ b/front/documents_post_process_hooks/hooks/extract_event/index.ts
@@ -26,8 +26,13 @@ async function shouldProcessDocument(
 }
 
 async function processDocument(params: DocumentsPostProcessHookOnUpsertParams) {
+  const workspaceId = params.auth.workspace()?.sId;
+  if (!workspaceId) {
+    throw new Error("Workspace not found.");
+  }
+
   const localLogger = logger.child({
-    workspaceId: params.workspaceId,
+    workspaceId,
     dataSourceName: params.dataSourceName,
     documentId: params.documentId,
   });

--- a/front/documents_post_process_hooks/hooks/index.ts
+++ b/front/documents_post_process_hooks/hooks/index.ts
@@ -4,6 +4,7 @@ import {
   documentTrackerUpdateTrackedDocumentsPostProcessHook,
 } from "@app/documents_post_process_hooks/hooks/document_tracker";
 import { extractEventPostProcessHook } from "@app/documents_post_process_hooks/hooks/extract_event";
+import { Authenticator } from "@app/lib/auth";
 import { ConnectorProvider } from "@app/lib/connectors_api";
 
 export const DOCUMENTS_POST_PROCESS_HOOK_TYPES = [
@@ -18,8 +19,8 @@ export type DocumentsPostProcessHookType =
 export type DocumentsPostProcessHookVerb = "upsert" | "delete";
 
 export type DocumentsPostProcessHookOnUpsertParams = {
+  auth: Authenticator;
   dataSourceName: string;
-  workspaceId: string;
   documentId: string;
   documentSourceUrl?: string; // @todo Daph remove optional when all jobs without it have been processed
   documentText: string;
@@ -28,8 +29,8 @@ export type DocumentsPostProcessHookOnUpsertParams = {
 };
 
 export type DocumentsPostProcessHookOnDeleteParams = {
+  auth: Authenticator;
   dataSourceName: string;
-  workspaceId: string;
   documentId: string;
   dataSourceConnectorProvider: ConnectorProvider | null;
 };

--- a/front/documents_post_process_hooks/temporal/activities.ts
+++ b/front/documents_post_process_hooks/temporal/activities.ts
@@ -2,6 +2,7 @@ import {
   DOCUMENTS_POST_PROCESS_HOOK_BY_TYPE,
   DocumentsPostProcessHookType,
 } from "@app/documents_post_process_hooks/hooks";
+import { Authenticator } from "@app/lib/auth";
 import { ConnectorProvider } from "@app/lib/connectors_api";
 import { CoreAPI, CoreAPIDataSource, CoreAPIDocument } from "@app/lib/core_api";
 import { DataSource, Workspace } from "@app/lib/models";
@@ -46,7 +47,7 @@ export async function runPostUpsertHookActivity(
 
   await hook.onUpsert({
     dataSourceName,
-    workspaceId,
+    auth: await Authenticator.internalBuilderForWorkspace(workspaceId),
     documentId,
     documentText,
     documentSourceUrl,
@@ -86,7 +87,7 @@ export async function runPostDeleteHookActivity(
 
   await hook.onDelete({
     dataSourceName,
-    workspaceId,
+    auth: await Authenticator.internalBuilderForWorkspace(workspaceId),
     documentId,
     dataSourceConnectorProvider,
   });

--- a/front/lib/extract_events.ts
+++ b/front/lib/extract_events.ts
@@ -30,7 +30,14 @@ export async function shouldProcessExtractEvents(
     return false;
   }
 
-  const { workspaceId, dataSourceName, documentId, documentText } = params;
+  const { auth, dataSourceName, documentId, documentText } = params;
+  const workspaceId = auth.workspace()?.sId;
+  if (!workspaceId) {
+    logger.error(
+      "Could not get workspace id to process extract events. Skipping."
+    );
+    return false;
+  }
 
   const localLogger = logger.child({ workspaceId, dataSourceName, documentId });
   const hasMarker = hasExtractEventMarker(documentText);
@@ -62,17 +69,15 @@ export async function shouldProcessExtractEvents(
  * Gets the markers from the doc and calls _processExtractEvent for each of them
  */
 export async function processExtractEvents({
-  workspaceId,
+  auth,
   dataSourceName,
   documentId,
   documentSourceUrl,
   documentText,
 }: DocumentsPostProcessHookOnUpsertParams) {
-  const auth = await Authenticator.internalBuilderForWorkspace(workspaceId);
-  if (!auth.workspace()) {
-    logger.error(
-      `Could not get internal auth for workspace ${workspaceId} to process extract events.`
-    );
+  const workspaceId = auth.workspace()?.sId;
+  if (!workspaceId) {
+    logger.error(`Could not get workspace to process extract events.`);
     return;
   }
 

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
@@ -297,8 +297,8 @@ async function handler(
       });
 
       const postUpsertHooksToRun = await getDocumentsPostUpsertHooksToRun({
+        auth: await Authenticator.internalBuilderForWorkspace(owner.sId),
         dataSourceName: dataSource.name,
-        workspaceId: owner.sId,
         documentId: req.query.documentId as string,
         documentText: req.body.text,
         documentHash: upsertRes.value.document.hash,
@@ -365,8 +365,8 @@ async function handler(
       });
 
       const postDeleteHooksToRun = await getDocumentsPostDeleteHooksToRun({
+        auth: await Authenticator.internalBuilderForWorkspace(owner.sId),
         dataSourceName: dataSource.name,
-        workspaceId: owner.sId,
         documentId: req.query.documentId as string,
         dataSourceConnectorProvider: dataSource.connectorProvider || null,
       });


### PR DESCRIPTION
- So it's more unified
- I'll be able to use `getDatasource` and `runAction`