### PR TITLE
Introduce `ModelId` in `front`

### DIFF
--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -35,6 +35,7 @@ export async function getDataSource(
   }
 
   return {
+    id: dataSource.id,
     name: dataSource.name,
     description: dataSource.description,
     visibility: dataSource.visibility,
@@ -72,6 +73,7 @@ export async function getDataSources(
 
   return dataSources.map((dataSource): DataSourceType => {
     return {
+      id: dataSource.id,
       name: dataSource.name,
       description: dataSource.description,
       visibility: dataSource.visibility,

--- a/front/lib/models.ts
+++ b/front/lib/models.ts
@@ -19,6 +19,8 @@ export const front_sequelize = new Sequelize(FRONT_DATABASE_URI as string, {
   logging: false,
 }); // TODO: type process.env
 
+export type ModelId = number;
+
 export class User extends Model<
   InferAttributes<User>,
   InferCreationAttributes<User>

--- a/front/pages/api/w/[wId]/data_sources/[name]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/index.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from "next";
-import { Op } from "sequelize";
 
+import { getDataSource } from "@app/lib/api/data_sources";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { CoreAPI } from "@app/lib/core_api";
 import { ReturnedAPIErrorType } from "@app/lib/error";
@@ -35,24 +35,28 @@ async function handler(
     });
   }
 
-  const dataSource = await DataSource.findOne({
-    where: auth.isUser()
-      ? {
-          workspaceId: owner.id,
-          visibility: {
-            [Op.or]: ["public", "private", "unlisted"],
-          },
-          name: req.query.name,
-        }
-      : {
-          workspaceId: owner.id,
-          // Do not include 'unlisted' here.
-          visibility: "public",
-          name: req.query.name,
-        },
-  });
+  if (!req.query.name || typeof req.query.name !== "string") {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "data_source_not_found",
+        message: "The Data Source you requested was not found.",
+      },
+    });
+  }
 
+  const dataSource = await getDataSource(auth, req.query.name);
   if (!dataSource) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "data_source_not_found",
+        message: "The Data Source you requested was not found.",
+      },
+    });
+  }
+  const dataSourceModel = await DataSource.findByPk(dataSource.id);
+  if (!dataSourceModel) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
@@ -66,6 +70,7 @@ async function handler(
     case "GET":
       res.status(200).json({
         dataSource: {
+          id: dataSource.id,
           name: dataSource.name,
           description: dataSource.description,
           visibility: dataSource.visibility,
@@ -118,7 +123,7 @@ async function handler(
 
       const description = req.body.description ? req.body.description : null;
 
-      const ds = await dataSource.update({
+      const ds = await dataSourceModel.update({
         description,
         visibility: req.body.visibility,
         userUpsertable: req.body.userUpsertable,
@@ -126,6 +131,7 @@ async function handler(
 
       return res.status(200).json({
         dataSource: {
+          id: ds.id,
           name: ds.name,
           description: ds.description,
           visibility: ds.visibility,
@@ -175,7 +181,7 @@ async function handler(
         });
       }
 
-      await dataSource.destroy();
+      await dataSourceModel.destroy();
 
       res.status(204).end();
       return;

--- a/front/pages/api/w/[wId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/index.ts
@@ -159,6 +159,7 @@ async function handler(
 
       res.status(201).json({
         dataSource: {
+          id: ds.id,
           name: ds.name,
           description: ds.description,
           visibility: ds.visibility,

--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -239,6 +239,7 @@ async function handler(
 
       return res.status(201).json({
         dataSource: {
+          id: dataSource.id,
           name: dataSource.name,
           description: dataSource.description,
           visibility: dataSource.visibility,

--- a/front/types/app.ts
+++ b/front/types/app.ts
@@ -1,3 +1,4 @@
+import { ModelId } from "@app/lib/models";
 import { BlockType } from "@app/types/run";
 
 export type AppVisibility = "public" | "private" | "unlisted" | "deleted";
@@ -7,7 +8,7 @@ export type BlockRunConfig = {
 };
 
 export type AppType = {
-  id: number;
+  id: ModelId;
   uId: string;
   sId: string;
   name: string;

--- a/front/types/chat.ts
+++ b/front/types/chat.ts
@@ -1,3 +1,5 @@
+import { ModelId } from "@app/lib/models";
+
 export type ChatRetrievedDocumentType = {
   dataSourceId: string;
   sourceUrl: string | null;
@@ -29,7 +31,7 @@ export type ChatMessageType = {
 };
 
 export type ChatSessionType = {
-  id: number;
+  id: ModelId;
   userId: number;
   created: number;
   sId: string;

--- a/front/types/data_source.ts
+++ b/front/types/data_source.ts
@@ -1,8 +1,10 @@
 import { ConnectorProvider } from "@app/lib/connectors_api";
+import { ModelId } from "@app/lib/models";
 
 export type DataSourceVisibility = "public" | "private";
 
 export type DataSourceType = {
+  id: ModelId;
   name: string;
   description?: string;
   visibility: DataSourceVisibility;

--- a/front/types/membership_invitation.ts
+++ b/front/types/membership_invitation.ts
@@ -1,5 +1,7 @@
+import { ModelId } from "@app/lib/models";
+
 export type MembershipInvitationType = {
-  id: number;
+  id: ModelId;
   status: "pending" | "consumed" | "revoked";
   inviteEmail: string;
 };

--- a/front/types/user.ts
+++ b/front/types/user.ts
@@ -1,4 +1,5 @@
 import { RoleType } from "@app/lib/auth";
+import { ModelId } from "@app/lib/models";
 
 /**
  *  Expresses limits for usage of the product Any positive number enforces the limit, -1 means no
@@ -17,7 +18,7 @@ export type PlanType = {
 };
 
 export type WorkspaceType = {
-  id: number;
+  id: ModelId;
   uId: string;
   sId: string;
   name: string;
@@ -28,7 +29,7 @@ export type WorkspaceType = {
 };
 
 export type UserType = {
-  id: number;
+  id: ModelId;
   provider: "github" | "google";
   providerId: string;
   username: string;


### PR DESCRIPTION
Introduce `ModelId` type (`number`) to use to store primary keys in our types instead of `number`.

We generally want to store primary keys in our types (that are shared server and client side in `front`) because at time we need to go back to the actual model object server side. To make explicit that these `id` fields on our types are model related we use this new type `ModelId`.

Also adds `ModelId` to `DataSourceType`.