### PR TITLE
Do not capitalize data source in error messages

### DIFF
--- a/connectors/src/connectors/github/temporal/activities.ts
+++ b/connectors/src/connectors/github/temporal/activities.ts
@@ -486,7 +486,7 @@ async function deleteIssue(
   const documentId = getIssueDocumentId(repoId.toString(), issueNumber);
   localLogger.info(
     { documentId },
-    "Deleting GitHub issue from Dust Data Source."
+    "Deleting GitHub issue from Dust data source."
   );
   await deleteFromDataSource(dataSourceConfig, documentId);
 
@@ -538,7 +538,7 @@ async function deleteDiscussion(
   );
   localLogger.info(
     { documentId },
-    "Deleting GitHub discussion from Dust Data Source."
+    "Deleting GitHub discussion from Dust data source."
   );
   await deleteFromDataSource(dataSourceConfig, documentId);
 

--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -1057,7 +1057,7 @@ async fn data_sources_register(
             Json(APIResponse {
                 error: Some(APIError {
                     code: String::from("internal_server_error"),
-                    message: format!("Failed to register Data Source: {}", e),
+                    message: format!("Failed to register data source: {}", e),
                 }),
                 response: None,
             }),
@@ -1068,7 +1068,7 @@ async fn data_sources_register(
                 Json(APIResponse {
                     error: Some(APIError {
                         code: String::from("internal_server_error"),
-                        message: format!("Failed to register Data Source: {}", e),
+                        message: format!("Failed to register data source: {}", e),
                     }),
                     response: None,
                 }),
@@ -1118,7 +1118,7 @@ async fn data_sources_search(
             Json(APIResponse {
                 error: Some(APIError {
                     code: String::from("internal_server_error"),
-                    message: format!("Failed to retrieve Data Source: {}", e),
+                    message: format!("Failed to retrieve data source: {}", e),
                 }),
                 response: None,
             }),
@@ -1129,7 +1129,7 @@ async fn data_sources_search(
                 Json(APIResponse {
                     error: Some(APIError {
                         code: String::from("data_source_not_found"),
-                        message: format!("No Data Source found for id `{}`", data_source_id),
+                        message: format!("No data source found for id `{}`", data_source_id),
                     }),
                     response: None,
                 }),
@@ -1219,7 +1219,7 @@ async fn data_sources_documents_update_tags(
             Json(APIResponse {
                 error: Some(APIError {
                     code: String::from("internal_server_error"),
-                    message: format!("Failed to retrieve Data Source: {}", e),
+                    message: format!("Failed to retrieve data source: {}", e),
                 }),
                 response: None,
             }),
@@ -1230,7 +1230,7 @@ async fn data_sources_documents_update_tags(
                 Json(APIResponse {
                     error: Some(APIError {
                         code: String::from("data_source_not_found"),
-                        message: format!("No Data Source found for id `{}`", data_source_id),
+                        message: format!("No data source found for id `{}`", data_source_id),
                     }),
                     response: None,
                 }),
@@ -1358,7 +1358,7 @@ async fn data_sources_documents_upsert(
             Json(APIResponse {
                 error: Some(APIError {
                     code: String::from("internal_server_error"),
-                    message: format!("Failed to retrieve Data Source: {}", e),
+                    message: format!("Failed to retrieve data source: {}", e),
                 }),
                 response: None,
             }),
@@ -1369,7 +1369,7 @@ async fn data_sources_documents_upsert(
                 Json(APIResponse {
                     error: Some(APIError {
                         code: String::from("data_source_not_found"),
-                        message: format!("No Data Source found for id `{}`", data_source_id),
+                        message: format!("No data source found for id `{}`", data_source_id),
                     }),
                     response: None,
                 }),
@@ -1461,7 +1461,7 @@ async fn data_sources_documents_list(
             Json(APIResponse {
                 error: Some(APIError {
                     code: String::from("internal_server_error"),
-                    message: format!("Failed to list Data Source: {}", e),
+                    message: format!("Failed to list data source: {}", e),
                 }),
                 response: None,
             }),
@@ -1503,7 +1503,7 @@ async fn data_sources_documents_retrieve(
             Json(APIResponse {
                 error: Some(APIError {
                     code: String::from("internal_server_error"),
-                    message: format!("Failed to retrieve Data Source: {}", e),
+                    message: format!("Failed to retrieve data source: {}", e),
                 }),
                 response: None,
             }),
@@ -1514,7 +1514,7 @@ async fn data_sources_documents_retrieve(
                 Json(APIResponse {
                     error: Some(APIError {
                         code: String::from("data_source_not_found"),
-                        message: format!("No Data Source found for id `{}`", data_source_id),
+                        message: format!("No data source found for id `{}`", data_source_id),
                     }),
                     response: None,
                 }),
@@ -1579,7 +1579,7 @@ async fn data_sources_documents_delete(
             Json(APIResponse {
                 error: Some(APIError {
                     code: String::from("internal_server_error"),
-                    message: format!("Failed to retrieve Data Source: {}", e),
+                    message: format!("Failed to retrieve data source: {}", e),
                 }),
                 response: None,
             }),
@@ -1590,7 +1590,7 @@ async fn data_sources_documents_delete(
                 Json(APIResponse {
                     error: Some(APIError {
                         code: String::from("data_source_not_found"),
-                        message: format!("No Data Source found for id `{}`", data_source_id),
+                        message: format!("No data source found for id `{}`", data_source_id),
                     }),
                     response: None,
                 }),
@@ -1648,7 +1648,7 @@ async fn data_sources_delete(
             Json(APIResponse {
                 error: Some(APIError {
                     code: String::from("internal_server_error"),
-                    message: format!("Failed to retrieve Data Source: {}", e),
+                    message: format!("Failed to retrieve data source: {}", e),
                 }),
                 response: None,
             }),
@@ -1659,7 +1659,7 @@ async fn data_sources_delete(
                 Json(APIResponse {
                     error: Some(APIError {
                         code: String::from("data_source_not_found"),
-                        message: format!("No Data Source found for id `{}`", data_source_id),
+                        message: format!("No data source found for id `{}`", data_source_id),
                     }),
                     response: None,
                 }),
@@ -1673,7 +1673,7 @@ async fn data_sources_delete(
                     Json(APIResponse {
                         error: Some(APIError {
                             code: String::from("internal_server_error"),
-                            message: format!("Failed to delete Data Source: {}", e),
+                            message: format!("Failed to delete data source: {}", e),
                         }),
                         response: None,
                     }),

--- a/core/src/blocks/data_source.rs
+++ b/core/src/blocks/data_source.rs
@@ -75,7 +75,7 @@ impl DataSource {
         Ok(query)
     }
 
-    /// This helper searches one Data Source (multiple can be searched in parallel) and return the
+    /// This helper searches one data source (multiple can be searched in parallel) and return the
     /// documents retrieved from the search.
     async fn search_data_source(
         &self,

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -1152,7 +1152,7 @@ impl DataSource {
         });
 
         utils::done(&format!(
-            "Searched Data Source: data_source_id={} document_count={} chunk_count={}",
+            "Searched sata source: data_source_id={} document_count={} chunk_count={}",
             self.data_source_id,
             documents.len(),
             documents.iter().map(|d| d.chunks.len()).sum::<usize>(),
@@ -1280,13 +1280,13 @@ impl DataSource {
             self.data_source_id,
         ));
 
-        // Delete Data Source and documents (SQL)
+        // Delete data source and documents (SQL)
         store
             .delete_data_source(&self.project, &self.data_source_id)
             .await?;
 
         utils::done(&format!(
-            "Deleted Data Source records: data_source_id={}",
+            "Deleted data source records: data_source_id={}",
             self.data_source_id,
         ));
 

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
@@ -69,7 +69,7 @@ async function handler(
       status_code: 404,
       api_error: {
         type: "data_source_not_found",
-        message: "The Data Source you requested was not found.",
+        message: "The data source you requested was not found.",
       },
     });
   }
@@ -81,7 +81,7 @@ async function handler(
       status_code: 404,
       api_error: {
         type: "data_source_not_found",
-        message: "The Data Source you requested was not found.",
+        message: "The data source you requested was not found.",
       },
     });
   }
@@ -99,7 +99,7 @@ async function handler(
           status_code: 400,
           api_error: {
             type: "data_source_error",
-            message: "There was an error retrieving the Data Source document.",
+            message: "There was an error retrieving the data source document.",
             data_source_error: docRes.error,
           },
         });
@@ -127,7 +127,7 @@ async function handler(
           status_code: 403,
           api_error: {
             type: "data_source_auth_error",
-            message: "You cannot upsert a document on a managed Data Source.",
+            message: "You cannot upsert a document on a managed data source.",
           },
         });
       }
@@ -217,7 +217,7 @@ async function handler(
             status_code: 400,
             api_error: {
               type: "data_source_error",
-              message: "There was an error retrieving the Data Source.",
+              message: "There was an error retrieving the data source.",
               data_source_error: documents.error,
             },
           });
@@ -336,7 +336,7 @@ async function handler(
           status_code: 403,
           api_error: {
             type: "data_source_auth_error",
-            message: "You cannot delete a document from a managed Data Source.",
+            message: "You cannot delete a document from a managed data source.",
           },
         });
       }

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/index.ts
@@ -32,7 +32,7 @@ async function handler(
       status_code: 404,
       api_error: {
         type: "data_source_not_found",
-        message: "The Data Source you requested was not found.",
+        message: "The data source you requested was not found.",
       },
     });
   }
@@ -55,7 +55,7 @@ async function handler(
           status_code: 400,
           api_error: {
             type: "data_source_error",
-            message: "There was an error retrieving the Data Source documents.",
+            message: "There was an error retrieving the data source documents.",
             data_source_error: documents.error,
           },
         });

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/search.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/search.ts
@@ -65,7 +65,7 @@ export default async function handler(
       status_code: 404,
       api_error: {
         type: "data_source_not_found",
-        message: "The Data Source you requested was not found.",
+        message: "The data source you requested was not found.",
       },
     });
   }
@@ -81,7 +81,7 @@ export default async function handler(
 
       let credentials: CredentialsType | null = null;
       if (keyRes.value.isSystem) {
-        // Dust managed credentials: system API key (managed Data Source).
+        // Dust managed credentials: system API key (managed data source).
         credentials = dustManagedCredentials();
       } else {
         const providers = await Provider.findAll({
@@ -132,7 +132,7 @@ export default async function handler(
           status_code: 400,
           api_error: {
             type: "data_source_error",
-            message: "There was an error performing the Data Source search.",
+            message: "There was an error performing the data source search.",
             data_source_error: data.error,
           },
         });

--- a/front/pages/api/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
@@ -29,7 +29,7 @@ async function handler(
       status_code: 404,
       api_error: {
         type: "data_source_not_found",
-        message: "The Data Source you requested was not found.",
+        message: "The data source you requested was not found.",
       },
     });
   }
@@ -41,7 +41,7 @@ async function handler(
       status_code: 404,
       api_error: {
         type: "data_source_not_found",
-        message: "The Data Source you requested was not found.",
+        message: "The data source you requested was not found.",
       },
     });
   }
@@ -64,7 +64,7 @@ async function handler(
           status_code: 403,
           api_error: {
             type: "data_source_auth_error",
-            message: "You cannot upsert a document on a managed Data Source.",
+            message: "You cannot upsert a document on a managed data source.",
           },
         });
       }
@@ -140,7 +140,7 @@ async function handler(
             status_code: 400,
             api_error: {
               type: "data_source_error",
-              message: "There was an error retrieving the Data Source.",
+              message: "There was an error retrieving the data source.",
               data_source_error: documents.error,
             },
           });
@@ -219,7 +219,7 @@ async function handler(
           api_error: {
             type: "data_source_error",
             message:
-              "There was an error retrieving the Data Source's document.",
+              "There was an error retrieving the data source's document.",
             data_source_error: document.error,
           },
         });
@@ -247,7 +247,7 @@ async function handler(
           status_code: 403,
           api_error: {
             type: "data_source_auth_error",
-            message: "You cannot delete a document from a managed Data Source.",
+            message: "You cannot delete a document from a managed data source.",
           },
         });
       }

--- a/front/pages/api/w/[wId]/data_sources/[name]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/index.ts
@@ -30,7 +30,7 @@ async function handler(
       status_code: 404,
       api_error: {
         type: "data_source_not_found",
-        message: "The Data Source you requested was not found.",
+        message: "The data source you requested was not found.",
       },
     });
   }
@@ -40,7 +40,7 @@ async function handler(
       status_code: 404,
       api_error: {
         type: "data_source_not_found",
-        message: "The Data Source you requested was not found.",
+        message: "The data source you requested was not found.",
       },
     });
   }
@@ -51,7 +51,7 @@ async function handler(
       status_code: 404,
       api_error: {
         type: "data_source_not_found",
-        message: "The Data Source you requested was not found.",
+        message: "The data source you requested was not found.",
       },
     });
   }
@@ -61,7 +61,7 @@ async function handler(
       status_code: 404,
       api_error: {
         type: "data_source_not_found",
-        message: "The Data Source you requested was not found.",
+        message: "The data source you requested was not found.",
       },
     });
   }
@@ -90,7 +90,7 @@ async function handler(
           api_error: {
             type: "data_source_auth_error",
             message:
-              "Only the users that are `builders` for the current workspace can update a Data Source.",
+              "Only the users that are `builders` for the current workspace can update a data source.",
           },
         });
       }
@@ -150,7 +150,7 @@ async function handler(
           api_error: {
             type: "data_source_auth_error",
             message:
-              "Only the users that are `builders` for the current workspace can delete a Data Source.",
+              "Only the users that are `builders` for the current workspace can delete a data source.",
           },
         });
       }
@@ -175,7 +175,7 @@ async function handler(
           status_code: 500,
           api_error: {
             type: "internal_server_error",
-            message: "Failed to delete the Data Source.",
+            message: "Failed to delete the data source.",
             data_source_error: dustDataSource.error,
           },
         });

--- a/front/pages/api/w/[wId]/data_sources/[name]/search.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/search.ts
@@ -138,7 +138,7 @@ export default async function handler(
           status_code: 400,
           api_error: {
             type: "data_source_error",
-            message: "There was an error performing the Data Source search.",
+            message: "There was an error performing the data source search.",
             data_source_error: data.error,
           },
         });

--- a/front/pages/api/w/[wId]/data_sources/google_drive/folders.ts
+++ b/front/pages/api/w/[wId]/data_sources/google_drive/folders.ts
@@ -29,7 +29,7 @@ async function handler(
       status_code: 404,
       api_error: {
         type: "data_source_not_found",
-        message: "The Data Source you requested was not found.",
+        message: "The data source you requested was not found.",
       },
     });
   }

--- a/front/pages/api/w/[wId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/index.ts
@@ -37,7 +37,7 @@ async function handler(
       status_code: 404,
       api_error: {
         type: "data_source_not_found",
-        message: "The Data Source you requested was not found.",
+        message: "The data source you requested was not found.",
       },
     });
   }
@@ -56,7 +56,7 @@ async function handler(
           api_error: {
             type: "data_source_auth_error",
             message:
-              "Only the users that are `admins` for the current workspace can create a managed Data Source.",
+              "Only the users that are `admins` for the current workspace can create a managed data source.",
           },
         });
       }
@@ -82,7 +82,7 @@ async function handler(
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "The Data Source name cannot start with `managed-`.",
+            message: "The data source name cannot start with `managed-`.",
           },
         });
       }
@@ -97,7 +97,7 @@ async function handler(
           api_error: {
             type: "plan_limit_error",
             message:
-              "Your plan does not allow you to create managed Data Sources.",
+              "Your plan does not allow you to create managed data sources.",
           },
         });
       }
@@ -112,7 +112,7 @@ async function handler(
           status_code: 500,
           api_error: {
             type: "internal_server_error",
-            message: `Failed to create internal project for the Data Source.`,
+            message: `Failed to create internal project for the data source.`,
             data_source_error: dustProject.error,
           },
         });
@@ -141,7 +141,7 @@ async function handler(
           status_code: 500,
           api_error: {
             type: "internal_server_error",
-            message: "Failed to create the Data Source.",
+            message: "Failed to create the data source.",
             data_source_error: dustDataSource.error,
           },
         });

--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -36,7 +36,7 @@ async function handler(
       status_code: 404,
       api_error: {
         type: "data_source_not_found",
-        message: "The Data Source you requested was not found.",
+        message: "The data source you requested was not found.",
       },
     });
   }
@@ -49,7 +49,7 @@ async function handler(
           api_error: {
             type: "data_source_auth_error",
             message:
-              "Only the users that are `admins` for the current workspace can create a managed Data Source.",
+              "Only the users that are `admins` for the current workspace can create a managed data source.",
           },
         });
       }
@@ -124,7 +124,7 @@ async function handler(
           api_error: {
             type: "plan_limit_error",
             message:
-              "Your plan does not allow you to create managed Data Sources.",
+              "Your plan does not allow you to create managed data sources.",
           },
         });
       }
@@ -142,7 +142,7 @@ async function handler(
           api_error: {
             type: "internal_server_error",
             message:
-              "Could not create a system API key for the managed Data Source.",
+              "Could not create a system API key for the managed data source.",
           },
         });
       }
@@ -153,7 +153,7 @@ async function handler(
           status_code: 500,
           api_error: {
             type: "internal_server_error",
-            message: `Failed to create internal project for the Data Source.`,
+            message: `Failed to create internal project for the data source.`,
             data_source_error: dustProject.error,
           },
         });
@@ -180,7 +180,7 @@ async function handler(
           status_code: 500,
           api_error: {
             type: "internal_server_error",
-            message: "Failed to create the Data Source.",
+            message: "Failed to create the data source.",
             data_source_error: dustDataSource.error,
           },
         });
@@ -219,7 +219,7 @@ async function handler(
             {
               error: deleteRes.error,
             },
-            "Failed to delete the Data Source"
+            "Failed to delete the data source"
           );
         }
         return apiError(req, res, {

--- a/front/pages/w/[wId]/ds/index.tsx
+++ b/front/pages/w/[wId]/ds/index.tsx
@@ -345,7 +345,7 @@ export default function DataSourcesView({
         );
       }
     } catch (e) {
-      window.alert(`Failed to enable ${provider} Data Source: ${e}`);
+      window.alert(`Failed to enable ${provider} data source: ${e}`);
     } finally {
       setIsLoadingByProvider((prev) => ({ ...prev, [provider]: false }));
     }


### PR DESCRIPTION
We use "Data Source" in most places in the product but in error messages it's a bit weird because we're close to APIs where we generally call them `data_source`.

Moves all error messages to using `"data source"` instead of `"Data Source"`