### PR TITLE
Extract: basic UI extracted events

### DIFF
--- a/front/components/use/EventSchemaForm.tsx
+++ b/front/components/use/EventSchemaForm.tsx
@@ -153,11 +153,11 @@ export function ExtractEventSchemaForm({
       dataSource={undefined}
     >
       <div className="flex h-full flex-col">
-        <div className="mb-10">
+        <div className="mt-2 flex flex-initial">
           <MainTab currentTab="Extract data" owner={owner} />
         </div>
 
-        <div className="mx-auto mb-10 sm:max-w-3xl lg:max-w-4xl xl:max-w-5xl">
+        <div className="container mx-auto my-10 sm:max-w-3xl lg:max-w-4xl xl:max-w-5xl">
           {readOnly && (
             <div
               className="mb-10 rounded-md border-l-4 border-violet-500 bg-violet-100 p-4 text-violet-700"
@@ -175,7 +175,7 @@ export function ExtractEventSchemaForm({
           <div className="mb-24 divide-y divide-gray-200">
             <div>
               <h3 className="text-base font-medium leading-6 text-gray-900">
-                Template information
+                Marker configuration
               </h3>
               <p className="mt-1 text-sm text-gray-500">
                 Define the marker and the description for your template. Once
@@ -221,7 +221,7 @@ export function ExtractEventSchemaForm({
           <div className="mb-6 divide-y divide-gray-200">
             <div>
               <h3 className="text-base font-medium leading-6 text-gray-900">
-                Template properties
+                Template configuration
               </h3>
               <p className="mt-1 text-sm text-gray-500">
                 Define the properties to extract for this template. Picking a

--- a/front/components/use/MainTab.tsx
+++ b/front/components/use/MainTab.tsx
@@ -43,7 +43,7 @@ export default function MainTab({
       ),
     },
     {
-      name: "Extract data",
+      name: "Extract",
       href: `/w/${owner.sId}/u/extract`,
       icon: (
         <ArrowUpTrayIcon

--- a/front/lib/api/extract.ts
+++ b/front/lib/api/extract.ts
@@ -1,7 +1,7 @@
 import { Authenticator } from "@app/lib/auth";
 import { isDevelopmentOrDustWorkspace } from "@app/lib/development";
-import { EventSchema } from "@app/lib/models";
-import { EventSchemaType } from "@app/types/extract";
+import { EventSchema, ExtractedEvent } from "@app/lib/models";
+import { EventSchemaType, ExtractedEventType } from "@app/types/extract";
 
 export async function getEventSchemas(
   auth: Authenticator
@@ -20,6 +20,7 @@ export async function getEventSchemas(
 
   return schemas.map((schema): EventSchemaType => {
     return {
+      id: schema.id,
       marker: schema.marker,
       description: schema.description,
       status: schema.status,
@@ -49,6 +50,7 @@ export async function getEventSchema(
   }
 
   return {
+    id: schema.id,
     marker: schema.marker,
     description: schema.description,
     status: schema.status,
@@ -79,6 +81,7 @@ export async function createEventSchema(
   });
 
   return {
+    id: schema.id,
     marker: schema.marker,
     description: schema.description,
     status: schema.status,
@@ -116,9 +119,37 @@ export async function updateEventSchema(
   });
 
   return {
+    id: schema.id,
     marker: schema.marker,
     description: schema.description,
     status: schema.status,
     properties: schema.properties,
   };
+}
+
+export async function getExtractedEvents(
+  auth: Authenticator,
+  schemaId: number
+): Promise<ExtractedEventType[]> {
+  const owner = auth.workspace();
+  if (!owner) {
+    return [];
+  }
+
+  const events = await ExtractedEvent.findAll({
+    where: {
+      eventSchemaId: schemaId,
+    },
+    order: [["createdAt", "DESC"]],
+  });
+
+  return events.map((event): ExtractedEventType => {
+    return {
+      id: event.id,
+      marker: event.marker,
+      properties: event.properties,
+      dataSourceId: event.dataSourceId,
+      documentId: event.documentId,
+    };
+  });
 }

--- a/front/pages/w/[wId]/u/extract/[marker]/data.tsx
+++ b/front/pages/w/[wId]/u/extract/[marker]/data.tsx
@@ -1,0 +1,177 @@
+import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import React from "react";
+
+import AppLayout from "@app/components/AppLayout";
+import MainTab from "@app/components/use/MainTab";
+import { getEventSchema, getExtractedEvents } from "@app/lib/api/extract";
+import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
+import { EventSchemaType, ExtractedEventType } from "@app/types/extract";
+import { UserType, WorkspaceType } from "@app/types/user";
+
+const { GA_TRACKING_ID = "" } = process.env;
+export const getServerSideProps: GetServerSideProps<{
+  user: UserType | null;
+  owner: WorkspaceType;
+  schema: EventSchemaType;
+  events: ExtractedEventType[];
+  readOnly: boolean;
+  gaTrackingId: string;
+}> = async (context) => {
+  const session = await getSession(context.req, context.res);
+  const user = await getUserFromSession(session);
+  const auth = await Authenticator.fromSession(
+    session,
+    context.params?.wId as string
+  );
+  const owner = auth.workspace();
+  if (!owner) {
+    return {
+      notFound: true,
+    };
+  }
+
+  const schema = await getEventSchema(auth, context.params?.marker as string);
+  if (!schema) {
+    return {
+      notFound: true,
+    };
+  }
+
+  const events = await getExtractedEvents(auth, schema.id);
+  if (!schema) {
+    return {
+      notFound: true,
+    };
+  }
+
+  return {
+    props: {
+      user,
+      owner,
+      schema,
+      events,
+      readOnly: !auth.isBuilder(),
+      gaTrackingId: GA_TRACKING_ID,
+    },
+  };
+};
+
+export default function AppExtractEventsReadData({
+  user,
+  owner,
+  schema,
+  events,
+  readOnly,
+  gaTrackingId,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  return (
+    <AppLayout
+      user={user}
+      owner={owner}
+      gaTrackingId={gaTrackingId}
+      app={undefined}
+      dataSource={undefined}
+    >
+      <div className="flex h-full flex-col">
+        <div className="mt-2 flex flex-initial">
+          <MainTab currentTab="Extract" owner={owner} />
+        </div>
+
+        <div className="container mx-auto my-10 sm:max-w-3xl lg:max-w-4xl xl:max-w-5xl">
+          <div className="mb-10 divide-y divide-gray-200">
+            <div className="pb-6">
+              <h3 className="text-base font-medium leading-6 text-gray-900">
+                Extracted data for [[{schema.marker}]]
+              </h3>
+              <p className="mt-1 text-sm text-gray-500">
+                Manage the list of extracted data for this marker.
+              </p>
+            </div>
+            <div></div>
+          </div>
+          <div>
+            <div className="my-5">
+              <div className="overflow-x-auto sm:-mx-6 lg:-mx-8">
+                <div className="inline-block min-w-full py-2 sm:px-6 lg:px-8">
+                  <div className="overflow-hidden">
+                    <table className="min-w-full text-left text-sm font-light">
+                      <thead className="border font-medium">
+                        <tr>
+                          <th scope="col" className="border px-3 py-4">
+                            Marker
+                          </th>
+                          <th scope="col" className="border px-12 py-4">
+                            Properties
+                          </th>
+                          <th scope="col" className="border px-3 py-4">
+                            Source Document
+                          </th>
+                          <th scope="col" className="border px-3 py-4">
+                            Manage
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {events.map((event) => (
+                          <tr key={event.id} className="border">
+                            <td className="whitespace-nowrap border px-3 py-4 text-sm font-medium text-gray-900">
+                              {event.marker}
+                            </td>
+                            <td className="border px-3 py-4 text-sm text-gray-500">
+                              <EventProperties event={event} />
+                            </td>
+                            <td className="whitespace-nowrap border px-3 py-4 text-sm text-gray-500">
+                              [todo]
+                            </td>
+                            <td className="whitespace-nowrap border px-3 py-4 text-sm text-gray-500">
+                              [todo]
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </AppLayout>
+  );
+}
+
+const EventProperties = ({ event }: { event: ExtractedEventType }) => {
+  const properties = event.properties;
+
+  const renderValue = (value: string | string[]) => {
+    if (typeof value === "string") {
+      return <p>{value}</p>;
+    }
+
+    const isStringArray = (value: string | string[]) =>
+      Array.isArray(value) && value.every((item) => typeof item === "string");
+    if (isStringArray(value)) {
+      return (
+        <ul className="list-inside list-disc">
+          {value.map((item, index) => (
+            <li key={index}>{item}</li>
+          ))}
+        </ul>
+      );
+    }
+
+    return null;
+  };
+
+  return (
+    <div className="space-y-4">
+      {Object.entries(properties).map(([key, value]) => (
+        <div key={key} className="flex flex-col">
+          <span className="font-bold">{key}</span>
+          {renderValue(value)}
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/front/pages/w/[wId]/u/extract/index.tsx
+++ b/front/pages/w/[wId]/u/extract/index.tsx
@@ -1,4 +1,12 @@
-import { PlusIcon } from "@heroicons/react/24/outline";
+import {
+  ArrowDownOnSquareIcon,
+  ArrowDownOnSquareStackIcon,
+  ArrowUpTrayIcon,
+  ClipboardDocumentCheckIcon,
+  LightBulbIcon,
+  PlusIcon,
+  WrenchIcon,
+} from "@heroicons/react/24/outline";
 import { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import Link from "next/link";
 import { useRouter } from "next/router";
@@ -59,7 +67,7 @@ export default function AppExtractEvents({
     >
       <div className="flex h-full flex-col">
         <div className="mt-2 flex flex-initial">
-          <MainTab currentTab="Extract data" owner={owner} />
+          <MainTab currentTab="Extract" owner={owner} />
         </div>
 
         <div className="container mx-auto my-10 sm:max-w-3xl lg:max-w-4xl xl:max-w-5xl">
@@ -76,76 +84,149 @@ export default function AppExtractEvents({
             </div>
           )}
 
-          <h3 className="text-base font-medium leading-6 text-gray-900">
-            Extract events Templates
-          </h3>
-          <p className="mt-1 text-sm text-gray-500">
-            This section allows you to define templates associated to a given
-            marker. See for an example{" "}
-            <a onClick={() => alert("Not implemented yet, sorry 😬")}>here</a>!
-          </p>
-          <div className="my-10 flex flex-col">
-            <div className="overflow-x-auto sm:-mx-6 lg:-mx-8">
-              <div className="inline-block min-w-full py-2 sm:px-6 lg:px-8">
-                <div className="overflow-hidden">
-                  <table className="min-w-full text-left text-sm font-light">
-                    <thead className="border-b bg-white font-medium">
-                      <tr>
-                        <th scope="col" className="px-3 py-4">
-                          Marker
-                        </th>
-                        <th scope="col" className="px-12 py-4">
-                          Description
-                        </th>
-                        <th scope="col" className="px-3 py-4">
-                          Status
-                        </th>
-                        <th scope="col" className="px-3 py-4">
-                          {readOnly ? "Manage" : "View"}
-                        </th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {!isSchemasLoading &&
-                        schemas?.map((schema) => (
-                          <tr key={schema.marker} className="border-b bg-white">
-                            <td className="whitespace-nowrap px-3 py-4 font-medium">
-                              {schema.marker}
-                            </td>
-                            <td className="whitespace-nowrap px-12 py-4">
-                              {schema.description}
-                            </td>
-                            <td className="whitespace-nowrap px-3 py-4">
-                              {schema.status === "active" ? "✅" : "❌"}
-                            </td>
-                            <td className="whitespace-nowrap px-3 py-4">
-                              <Button
-                                type="submit"
-                                onClick={() =>
-                                  router.push(
-                                    `/w/${owner.sId}/u/extract/${schema.marker}`
-                                  )
-                                }
-                              >
-                                <div>
-                                  {readOnly
-                                    ? "View template"
-                                    : "Manage template"}
-                                </div>
-                              </Button>
-                            </td>
-                          </tr>
-                        ))}
-                    </tbody>
-                  </table>
+          <div className="mb-12 divide-y divide-gray-200">
+            <div className="pb-6">
+              <h3 className="text-base font-medium leading-6 text-gray-900">
+                Extract
+              </h3>
+              <p className="mt-1 text-sm text-gray-500">
+                Extract associates a template with a [[marker]] to automate the
+                extraction of structured data from your datasources.
+              </p>
+            </div>
+            <div>
+              <div className="mt-6">
+                <p className="mb-4 text-sm ">
+                  Step1: Set some markers/templates
+                </p>
+                <ul className="list-inside text-sm font-light">
+                  <li>
+                    <LightBulbIcon className="mr-1 inline-block h-5 w-5" />
+                    Define a new marker, such as <i>idea</i> or <i>tasks</i>.
+                  </li>
+                  <li>
+                    <WrenchIcon className="mr-1 inline-block h-5 w-5" />
+                    Define the properties to extract for this template:&nbsp;
+                    for <i>idea</i> it could be a name and a description;&nbsp;
+                    for <i>tasks</i> it could be an owner, a day, and a list of
+                    tasks.
+                  </li>
+                </ul>
+              </div>
+              <div className="mt-6">
+                <p className="mb-4 text-sm ">Step 2: Extract data</p>
+                <ul className="list-inside text-sm font-light">
+                  <li>
+                    <ArrowDownOnSquareIcon className="mr-1 inline-block h-5 w-5" />
+                    On any of your datasources, write [[idea]] or [[tasks]]
+                    whenever you want to extract this data.
+                  </li>
+                  <li>
+                    <ArrowDownOnSquareStackIcon className="mr-1 inline-block h-5 w-5" />
+                    If there are multiple ideas on the same document, you can
+                    just append a unique identifier on the marker, such as
+                    [[idea:2]].
+                  </li>
+                </ul>
+              </div>
+              <div className="mt-6">
+                <p className="mb-4 text-sm ">
+                  Step 3: Manage your extracted data
+                </p>
+                <ul className="list-inside text-sm font-light">
+                  <li>
+                    <ClipboardDocumentCheckIcon className="mr-1 inline-block h-5 w-5" />
+                    Read and validate or fix the extracted data.
+                  </li>
+                  <li>
+                    <ArrowUpTrayIcon className="mr-1 inline-block h-5 w-5" />
+                    Export the validated data as you wish.
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>
+          <div className="mb-10 divide-y divide-gray-200">
+            <div className="pb-6">
+              <h3 className="text-base font-medium leading-6 text-gray-900">
+                Markers & templates
+              </h3>
+              <p className="mt-1 text-sm text-gray-500">
+                Manage your markers & templates and access extracted data.
+              </p>
+            </div>
+            <div>
+              <div className="overflow-x-auto sm:-mx-6 lg:-mx-8">
+                <div className="inline-block min-w-full py-2 sm:px-6 lg:px-8">
+                  <div className="mt-4">
+                    <table className="min-w-full text-left text-sm font-light">
+                      <thead className="font-medium">
+                        <tr>
+                          <th scope="col" className="px-3 py-4">
+                            Marker
+                          </th>
+                          <th scope="col" className="px-12 py-4">
+                            Description
+                          </th>
+                          <th scope="col" className="px-3 py-4">
+                            Template
+                          </th>
+                          <th scope="col" className="px-3 py-4">
+                            Extracted data
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {!isSchemasLoading &&
+                          schemas?.map((schema) => (
+                            <tr key={schema.marker} className="border-y">
+                              <td className="whitespace-nowrap px-3 py-4 font-medium">
+                                [[{schema.marker}]]
+                              </td>
+                              <td className="whitespace-nowrap px-12 py-4">
+                                {schema.description}
+                              </td>
+                              <td className="whitespace-nowrap px-3 py-4">
+                                <Button
+                                  type="submit"
+                                  onClick={() =>
+                                    router.push(
+                                      `/w/${owner.sId}/u/extract/${schema.marker}`
+                                    )
+                                  }
+                                >
+                                  <div>
+                                    {readOnly
+                                      ? "View template"
+                                      : "Manage template"}
+                                  </div>
+                                </Button>
+                              </td>
+                              <td className="whitespace-nowrap px-3 py-4">
+                                <Button
+                                  type="submit"
+                                  onClick={() =>
+                                    router.push(
+                                      `/w/${owner.sId}/u/extract/${schema.marker}/data`
+                                    )
+                                  }
+                                >
+                                  <div>See extracted data</div>
+                                </Button>
+                              </td>
+                            </tr>
+                          ))}
+                      </tbody>
+                    </table>
 
-                  <div className="my-10">
-                    <Link href={`/w/${owner.sId}/u/extract/new`}>
-                      <Button disabled={readOnly}>
-                        <PlusIcon className="-ml-1 mr-1 h-5 w-5" />
-                        Create Template
-                      </Button>
-                    </Link>
+                    <div className="my-10">
+                      <Link href={`/w/${owner.sId}/u/extract/new`}>
+                        <Button disabled={readOnly}>
+                          <PlusIcon className="-ml-1 mr-1 h-5 w-5" />
+                          Create New
+                        </Button>
+                      </Link>
+                    </div>
                   </div>
                 </div>
               </div>

--- a/front/types/extract.ts
+++ b/front/types/extract.ts
@@ -1,6 +1,9 @@
+import { ModelId } from "@app/lib/models";
+
 export type EventSchemaStatus = "active" | "disabled";
 
 export type EventSchemaType = {
+  id: ModelId;
   marker: string;
   description?: string;
   status: EventSchemaStatus;
@@ -28,4 +31,14 @@ export type EventSchemaPropertiesTypeForModel = {
     description: string;
     items?: { type: (typeof eventSchemaPropertyAllTypes)[number] };
   };
+};
+
+export type ExtractedEventType = {
+  id: ModelId;
+  marker: string;
+  properties: {
+    [key: string]: string | string[];
+  };
+  dataSourceId: ModelId;
+  documentId: string;
 };


### PR DESCRIPTION
- Rename the tab "Extract"
- Rework the index page to explain how it works. 
- Add a button to access extracted event
- Add a page to read extracted events -> To be continued on the next PR to add the link to the datasource + the ability to delete or marked as checked an extracted event. 


### Screenshots

Don't hesitate to tell me if that's ugly with the icons, if that's too much text, any feedback 🙇🏻‍♀️ 

**Index view of Extracts:** 
<img width="1512" alt="Capture d’écran 2023-07-24 à 11 21 16" src="https://github.com/dust-tt/dust/assets/3803406/684d17b3-f9ef-49e1-80e5-84e6a7571e85">



**Detail view of a marker > Reading extracting events**
<img width="1508" alt="Capture d’écran 2023-07-24 à 10 11 06" src="https://github.com/dust-tt/dust/assets/3803406/ac5c0626-6bfc-4f11-83b6-7832814e25a7">

