### PR TITLE
Extracted Events: migrate to use dataSourceName over its id

### DIFF
--- a/front/documents_post_process_hooks/hooks/index.ts
+++ b/front/documents_post_process_hooks/hooks/index.ts
@@ -22,7 +22,7 @@ export type DocumentsPostProcessHookOnUpsertParams = {
   auth: Authenticator;
   dataSourceName: string;
   documentId: string;
-  documentSourceUrl?: string; // @todo Daph remove optional when all jobs without it have been processed
+  documentSourceUrl?: string;
   documentText: string;
   documentHash: string;
   dataSourceConnectorProvider: ConnectorProvider | null;

--- a/front/lib/extract_event_markers.ts
+++ b/front/lib/extract_event_markers.ts
@@ -53,16 +53,16 @@ export function sanitizeRawExtractEventMarkers(
 /**
  * Get the markers from the doc and returns only the ones that are not already in the DB
  * @param documentId
- * @param dataSourceId
+ * @param dataSourceName
  * @param documentText
  */
 export async function getExtractEventMarkersToProcess({
   documentId,
-  dataSourceId,
+  dataSourceName,
   documentText,
 }: {
   documentId: string;
-  dataSourceId: number;
+  dataSourceName: string;
   documentText: string;
 }): Promise<string[]> {
   // Gets all markers from the doc content
@@ -72,7 +72,7 @@ export async function getExtractEventMarkersToProcess({
   const existingExtractedEvents = await ExtractedEvent.findAll({
     where: {
       documentId: documentId,
-      dataSourceId: dataSourceId,
+      dataSourceName: dataSourceName,
       marker: {
         [Op.in]: rawMarkers,
       },

--- a/front/lib/extract_events.ts
+++ b/front/lib/extract_events.ts
@@ -92,7 +92,7 @@ export async function processExtractEvents({
   // Getting the markers from the doc and keeping only those not already in the DB
   const rawMarkers = await getExtractEventMarkersToProcess({
     documentId,
-    dataSourceId: dataSource.id,
+    dataSourceName: dataSourceName,
     documentText,
   });
   const markers = sanitizeRawExtractEventMarkers(rawMarkers);
@@ -101,7 +101,7 @@ export async function processExtractEvents({
     Object.keys(markers).map((marker) => {
       return _processExtractEvent({
         auth: auth,
-        dataSource: dataSource,
+        dataSourceName: dataSourceName,
         sanitizedMarker: marker,
         markers: markers[marker],
         documentText: documentText,
@@ -117,7 +117,7 @@ export async function processExtractEvents({
  */
 async function _processExtractEvent(data: {
   auth: Authenticator;
-  dataSource: DataSource;
+  dataSourceName: string;
   sanitizedMarker: string;
   markers: string[];
   documentText: string;
@@ -126,7 +126,7 @@ async function _processExtractEvent(data: {
 }) {
   const {
     auth,
-    dataSource,
+    dataSourceName,
     sanitizedMarker,
     markers,
     documentId,
@@ -169,7 +169,7 @@ async function _processExtractEvent(data: {
       documentId: documentId,
       properties: properties,
       eventSchemaId: schema.id,
-      dataSourceId: dataSource.id,
+      dataSourceName: dataSourceName,
       marker: properties.marker,
     });
 

--- a/front/lib/extract_events.ts
+++ b/front/lib/extract_events.ts
@@ -18,7 +18,7 @@ import {
   sanitizeRawExtractEventMarkers,
 } from "@app/lib/extract_event_markers";
 import { formatPropertiesForModel } from "@app/lib/extract_events_properties";
-import { DataSource, EventSchema, ExtractedEvent } from "@app/lib/models";
+import { EventSchema, ExtractedEvent } from "@app/lib/models";
 import logger from "@app/logger/logger";
 import { logOnSlack } from "@app/logger/slack_debug_logger";
 
@@ -106,7 +106,7 @@ export async function processExtractEvents({
         markers: markers[marker],
         documentText: documentText,
         documentId: documentId,
-        documentSourceUrl: documentSourceUrl,
+        documentSourceUrl: documentSourceUrl || null,
       });
     })
   );
@@ -122,7 +122,7 @@ async function _processExtractEvent(data: {
   markers: string[];
   documentText: string;
   documentId: string;
-  documentSourceUrl?: string;
+  documentSourceUrl: string | null;
 }) {
   const {
     auth,
@@ -170,6 +170,7 @@ async function _processExtractEvent(data: {
       properties: properties,
       eventSchemaId: schema.id,
       dataSourceName: dataSourceName,
+      documentSourceUrl: documentSourceUrl || null,
       marker: properties.marker,
     });
 
@@ -235,7 +236,7 @@ export async function _logDebugEventOnSlack({
 }: {
   event: ExtractedEvent;
   schema: EventSchema;
-  documentSourceUrl?: string;
+  documentSourceUrl: string | null;
 }): Promise<void> {
   if (event.eventSchemaId !== schema.id) {
     logger.error(
@@ -277,7 +278,7 @@ export async function _logDebugEventOnSlack({
           text: "Open document",
           emoji: true,
         },
-        url: documentSourceUrl || "", // @todo daph remove fallback not needed after all jobs are processed.
+        url: documentSourceUrl || "",
       },
     },
   ];

--- a/front/lib/models.ts
+++ b/front/lib/models.ts
@@ -1112,6 +1112,7 @@ export class ExtractedEvent extends Model<
 
   declare dataSourceName: string;
   declare documentId: string;
+  declare documentSourceUrl: string | null;
 }
 ExtractedEvent.init(
   {
@@ -1147,11 +1148,18 @@ ExtractedEvent.init(
       type: DataTypes.STRING,
       allowNull: false,
     },
+    documentSourceUrl: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
   },
   {
     modelName: "extracted_event",
     sequelize: front_sequelize,
-    indexes: [{ fields: ["eventSchemaId"] }],
+    indexes: [
+      { fields: ["eventSchemaId"] },
+      { fields: ["dataSourceName", "documentId"] },
+    ],
   }
 );
 EventSchema.hasMany(ExtractedEvent, {

--- a/front/lib/models.ts
+++ b/front/lib/models.ts
@@ -1109,7 +1109,8 @@ export class ExtractedEvent extends Model<
   declare properties: any;
 
   declare eventSchemaId: ForeignKey<EventSchema["id"]>;
-  declare dataSourceId: ForeignKey<DataSource["id"]>;
+
+  declare dataSourceName: string;
   declare documentId: string;
 }
 ExtractedEvent.init(
@@ -1138,6 +1139,10 @@ ExtractedEvent.init(
       type: DataTypes.JSONB,
       allowNull: false,
     },
+    dataSourceName: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
     documentId: {
       type: DataTypes.STRING,
       allowNull: false,
@@ -1146,16 +1151,12 @@ ExtractedEvent.init(
   {
     modelName: "extracted_event",
     sequelize: front_sequelize,
-    indexes: [{ fields: ["eventSchemaId"] }, { fields: ["dataSourceId"] }],
+    indexes: [{ fields: ["eventSchemaId"] }],
   }
 );
 EventSchema.hasMany(ExtractedEvent, {
   foreignKey: { allowNull: false },
   onDelete: "CASCADE", // @todo daph define if we really want to delete the extracted event when the schema is deleted
-});
-DataSource.hasMany(ExtractedEvent, {
-  foreignKey: { allowNull: false },
-  onDelete: "CASCADE",
 });
 
 export class DocumentTrackerChangeSuggestion extends Model<

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
@@ -303,6 +303,7 @@ async function handler(
         documentText: req.body.text,
         documentHash: upsertRes.value.document.hash,
         dataSourceConnectorProvider: dataSource.connectorProvider || null,
+        documentSourceUrl: sourceUrl || undefined,
       });
 
       // TODO: parallel.


### PR DESCRIPTION
Migration on the `ExtractedEvents` table to use the `dataSourceName` over `dataSourceId`.

Why this change? 
➡️ More convenient to fetch the datasource from its name (we need it for the UI)

What does it changes? 
➡️ We removed the remove cascade: when we delete a Datasource is removed, we don't delete the extracted events. 


I will truncate the prod table to be able to run this without requiring a migration 🙇🏻‍♀️ 