### PR TITLE
Extract: finish rename datasourceName

### DIFF
--- a/front/lib/api/extract.ts
+++ b/front/lib/api/extract.ts
@@ -148,8 +148,9 @@ export async function getExtractedEvents(
       id: event.id,
       marker: event.marker,
       properties: event.properties,
-      dataSourceId: event.dataSourceId,
+      dataSourceName: event.dataSourceName,
       documentId: event.documentId,
+      documentSourceUrl: event.documentSourceUrl,
     };
   });
 }

--- a/front/types/extract.ts
+++ b/front/types/extract.ts
@@ -39,6 +39,7 @@ export type ExtractedEventType = {
   properties: {
     [key: string]: string | string[];
   };
-  dataSourceId: ModelId;
+  dataSourceName: string;
   documentId: string;
+  documentSourceUrl: string | null;
 };


### PR DESCRIPTION
Because I just merged the PR to use dataSourceName over dataSourceId in Extracted events (https://github.com/dust-tt/dust/pull/930), and then https://github.com/dust-tt/dust/pull/929 -> in which I introduced types that needed to be updated following the migration. 

No issue on prod, the code was not deployed yet. 