### PR TITLE
Improve Permissions UI

### DIFF
--- a/front/components/ConnectorPermissionsModal.tsx
+++ b/front/components/ConnectorPermissionsModal.tsx
@@ -24,6 +24,13 @@ const CONNECTOR_TYPE_TO_NAME: Record<ConnectorProvider, string> = {
   github: "GitHub",
 };
 
+const CONNECTOR_TYPE_TO_RESOURCE_NAME: Record<ConnectorProvider, string> = {
+  notion: "top-level Notion pages",
+  google_drive: "Google Drive folders",
+  slack: "Slack channels",
+  github: "GitHub repositories",
+};
+
 function PermissionTreeChildren({
   owner,
   dataSource,
@@ -163,7 +170,7 @@ export default function ConnectorPermissionsModal({
                       </Dialog.Title>
                       {synchronizedTimeAgo && (
                         <span className="text-gray-500">
-                          Last sync ~{synchronizedTimeAgo} ago
+                          Last synchronized ~{synchronizedTimeAgo} ago
                         </span>
                       )}
                     </div>
@@ -186,8 +193,8 @@ export default function ConnectorPermissionsModal({
                 <div>
                   <div className="mt-16">
                     <div className="px-2 text-sm text-gray-500">
-                      Top-level resources accessible by this managed data
-                      source:
+                      Dust has access to the following{" "}
+                      {CONNECTOR_TYPE_TO_RESOURCE_NAME[connector.type]}:
                     </div>
                   </div>
                 </div>

--- a/front/components/ConnectorPermissionsModal.tsx
+++ b/front/components/ConnectorPermissionsModal.tsx
@@ -25,7 +25,7 @@ const CONNECTOR_TYPE_TO_NAME: Record<ConnectorProvider, string> = {
 };
 
 const CONNECTOR_TYPE_TO_RESOURCE_NAME: Record<ConnectorProvider, string> = {
-  notion: "top-level Notion pages",
+  notion: "top-level Notion pages or databases",
   google_drive: "Google Drive folders",
   slack: "Slack channels",
   github: "GitHub repositories",


### PR DESCRIPTION
- align wording to synchronized
- say "top-level Notion pages or databases"
- say "Google Drive folders"
- say "Slack channels"
- say "GitHub repositories"