### PR TITLE
Remove workspace conversations tab

### DIFF
--- a/front/components/use/chat/ChatHistory.tsx
+++ b/front/components/use/chat/ChatHistory.tsx
@@ -57,13 +57,13 @@ export function ChatHistory({
           setOffset(0);
         },
       },
-      {
-        name: "Team Conversations",
-        onClick: () => {
-          setWorkspaceScope(true);
-          setOffset(0);
-        },
-      },
+      // {
+      //   name: "Team Conversations",
+      //   onClick: () => {
+      //     setWorkspaceScope(true);
+      //     setOffset(0);
+      //   },
+      // },
     ];
     const currentTab = workspaceScope
       ? "Team Conversations"


### PR DESCRIPTION
Just remove the tab option
Preserves the paging for "My Conversations" if relevant

![Screenshot from 2023-07-24 18-44-08](https://github.com/dust-tt/dust/assets/15067/ddee500b-de6e-4369-9b42-a5f933c10cbd)
