### PR TITLE
feat(doc tracker): support markdown in emails

### DIFF
--- a/front/documents_post_process_hooks/hooks/document_tracker/suggest_changes/lib.ts
+++ b/front/documents_post_process_hooks/hooks/document_tracker/suggest_changes/lib.ts
@@ -1,5 +1,6 @@
 import sgMail from "@sendgrid/mail";
 import { Op } from "sequelize";
+import showdown from "showdown";
 
 import {
   DocumentsPostProcessHookFilterParams,
@@ -425,6 +426,8 @@ async function sendSuggestionEmail({
   const matchedDocumentLink = `<a href="${matchedDocumentUrl}">${matchedDocumentName}</a>`;
   const incomingDocumentLink = `<a href="${incomingDocumentUrl}">${incomingDocumentName}</a>`;
 
+  const htmlSuggestion = new showdown.Converter().makeHtml(suggestedChanges);
+
   const msg = {
     to: recipientEmail,
     from: "team@dust.tt",
@@ -433,7 +436,7 @@ async function sendSuggestionEmail({
       "Hello!<br>" +
       `We have a suggestion for you to update the document ${matchedDocumentLink},` +
       `based on the new document ${incomingDocumentLink}:<br>` +
-      `${suggestedChanges}<br>` +
+      `${htmlSuggestion}<br>` +
       `The Dust team`,
   };
   await sgMail.send(msg);

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -49,6 +49,7 @@
         "react-textarea-autosize": "^8.4.0",
         "remark-gfm": "^3.0.1",
         "sequelize": "^6.31.0",
+        "showdown": "^2.1.0",
         "sqlite3": "^5.1.4",
         "sse.js": "^0.6.1",
         "swr": "^2.0.2",
@@ -65,6 +66,7 @@
         "@types/pegjs": "^0.10.3",
         "@types/react": "^18.0.28",
         "@types/react-dom": "^18.0.11",
+        "@types/showdown": "^2.0.1",
         "@types/uuid": "^9.0.1",
         "@typescript-eslint/eslint-plugin": "^5.57.1",
         "@typescript-eslint/parser": "^5.57.1",
@@ -2956,6 +2958,12 @@
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
       "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
+      "dev": true
+    },
+    "node_modules/@types/showdown": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/showdown/-/showdown-2.0.1.tgz",
+      "integrity": "sha512-xdnAw2nFqomkaL0QdtEk0t7yz26UkaVPl4v1pYJvtE1T0fmfQEH3JaxErEhGByEAl3zUZrkNBlneuJp0WJGqEA==",
       "dev": true
     },
     "node_modules/@types/stack-utils": {
@@ -12031,6 +12039,29 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/showdown": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/showdown/-/showdown-2.1.0.tgz",
+      "integrity": "sha512-/6NVYu4U819R2pUIk79n67SYgJHWCce0a5xTP979WbNp0FL9MN1I1QK662IDU1b6JzKTvmhgI7T7JYIxBi3kMQ==",
+      "dependencies": {
+        "commander": "^9.0.0"
+      },
+      "bin": {
+        "showdown": "bin/showdown.js"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://www.paypal.me/tiviesantos"
+      }
+    },
+    "node_modules/showdown/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "engines": {
+        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/side-channel": {

--- a/front/package.json
+++ b/front/package.json
@@ -13,6 +13,7 @@
     "initdb": "env $(cat .env.local) npx tsx admin/db.ts"
   },
   "dependencies": {
+    "@dust-tt/sparkle": "^0.1.2",
     "@headlessui/react": "^1.7.7",
     "@heroicons/react": "^2.0.11",
     "@nangohq/frontend": "^0.16.1",
@@ -56,12 +57,12 @@
     "react-textarea-autosize": "^8.4.0",
     "remark-gfm": "^3.0.1",
     "sequelize": "^6.31.0",
+    "showdown": "^2.1.0",
     "sqlite3": "^5.1.4",
     "sse.js": "^0.6.1",
     "swr": "^2.0.2",
     "tailwindcss": "^3.2.4",
-    "uuid": "^9.0.0",
-    "@dust-tt/sparkle": "^0.1.2"
+    "uuid": "^9.0.0"
   },
   "devDependencies": {
     "@google-cloud/storage": "^6.11.0",
@@ -73,6 +74,7 @@
     "@types/pegjs": "^0.10.3",
     "@types/react": "^18.0.28",
     "@types/react-dom": "^18.0.11",
+    "@types/showdown": "^2.0.1",
     "@types/uuid": "^9.0.1",
     "@typescript-eslint/eslint-plugin": "^5.57.1",
     "@typescript-eslint/parser": "^5.57.1",


### PR DESCRIPTION
- Doc tracker tends to give suggestions in markdown format
- It looks kind of ugly as raw text in the email
- this will convert the suggestion string from markdown into HTML