### PR TITLE
Dark mode support in storybook

### DIFF
--- a/dust-storybook/.storybook/main.ts
+++ b/dust-storybook/.storybook/main.ts
@@ -5,7 +5,6 @@ const config: StorybookConfig = {
     "@storybook/addon-links",
     "@storybook/addon-essentials",
     "@storybook/addon-interactions",
-    "@storybook/addon-mdx-gfm",
     "storybook-dark-mode",
   ],
   framework: {

--- a/dust-storybook/.storybook/preview.tsx
+++ b/dust-storybook/.storybook/preview.tsx
@@ -1,6 +1,5 @@
-import React from "react";
-
 import type { Preview } from "@storybook/react";
+import { themes } from "@storybook/theming";
 
 const preview: Preview = {
   parameters: {
@@ -10,6 +9,16 @@ const preview: Preview = {
         color: /(background|color)$/i,
         date: /Date$/,
       },
+    },
+    darkMode: {
+      darkClass: ["dark"],
+      lightClass: ["light"],
+      stylePreview: true,
+      dark: { ...themes.dark, appBg: "#292C2E" },
+      light: { ...themes.normal, appBg: "white" },
+    },
+    backgrounds: {
+      values: [{ name: "dark", value: "#1B1C1D" }],
     },
   },
 };


### PR DESCRIPTION
This is not yet perfect but here it goes:
- there's a new dark mode button that will change the storybook UI as well as style the preview so the component will go in dark mode, but I couldn't find a way to change the preview background automatically
- so I added a global background parmeter (picture icon on the left of the top-menu) that will let you set the preview background to black and clear it

Some screenshots attached, Tab dark mode is currently broken but we don't plan to use it anyway for now
![Screenshot from 2023-07-25 14-11-26](https://github.com/dust-tt/dust/assets/15067/665b9787-631c-43c5-a3c0-8308dbddaee3)
![Screenshot from 2023-07-25 14-12-08](https://github.com/dust-tt/dust/assets/15067/c1708823-3234-46ad-a24c-b8174c51cf70)
![Screenshot from 2023-07-25 14-12-19](https://github.com/dust-tt/dust/assets/15067/9e2cf018-8ad3-4d24-b890-9d3664f21e20)
