### PR TITLE
feat: keep track of slack channels in connectors DB

### DIFF
--- a/connectors/migrations/20230725_slack_channel_permissions.ts
+++ b/connectors/migrations/20230725_slack_channel_permissions.ts
@@ -34,6 +34,7 @@ async function main() {
     const channelIdsToDelete = Object.keys(channelsInDb).filter(
       (id) => !channelIdsInSlackSet.has(id)
     );
+    console.log("Deleting channels", { channelIdsToDelete, connectorId: c.id });
     await SlackChannel.destroy({
       where: {
         connectorId: c.id,
@@ -50,6 +51,10 @@ async function main() {
         console.log("Channel has no name", channel);
         continue;
       }
+      console.log("Upserting channel", {
+        channelId: channel.id,
+        connectorId: c.id,
+      });
       const existingChannel = channelsInDb[channel.id];
       if (existingChannel) {
         await existingChannel.update({

--- a/connectors/migrations/20230725_slack_channel_permissions.ts
+++ b/connectors/migrations/20230725_slack_channel_permissions.ts
@@ -1,0 +1,65 @@
+import {
+  getAccessToken,
+  getChannels,
+} from "@connectors/connectors/slack/temporal/activities";
+import { Connector, SlackChannel } from "@connectors/lib/models";
+
+async function main() {
+  const slackConnectors = await Connector.findAll({
+    where: {
+      type: "slack",
+    },
+  });
+
+  for (const c of slackConnectors) {
+    const channelsInDb = (
+      await SlackChannel.findAll({
+        where: {
+          connectorId: c.id,
+        },
+      })
+    ).reduce(
+      (acc, c) => Object.assign(acc, { [c.slackChannelId]: c }),
+      {} as {
+        [key: string]: SlackChannel;
+      }
+    );
+
+    const accessToken = await getAccessToken(c.connectionId);
+    const channelsInSlack = await getChannels(accessToken);
+
+    for (const channel of channelsInSlack) {
+      if (!channel.id) {
+        console.log("Channel has no id", channel);
+        continue;
+      }
+      if (!channel.name) {
+        console.log("Channel has no name", channel);
+        continue;
+      }
+      const existingChannel = channelsInDb[channel.id];
+      if (existingChannel) {
+        await existingChannel.update({
+          slackChannelName: channel.name,
+        });
+      } else {
+        await SlackChannel.create({
+          connectorId: c.id,
+          slackChannelId: channel.id,
+          slackChannelName: channel.name,
+          permission: "read_write",
+        });
+      }
+    }
+  }
+}
+
+main()
+  .then(() => {
+    console.log("Done");
+    process.exit(0);
+  })
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });

--- a/connectors/migrations/20230725_slack_channel_permissions.ts
+++ b/connectors/migrations/20230725_slack_channel_permissions.ts
@@ -27,6 +27,19 @@ async function main() {
 
     const accessToken = await getAccessToken(c.connectionId);
     const channelsInSlack = await getChannels(accessToken);
+    const channelIdsInSlackSet = new Set(
+      channelsInSlack.map((c) => c.id).filter((id) => id)
+    );
+
+    const channelIdsToDelete = Object.keys(channelsInDb).filter(
+      (id) => !channelIdsInSlackSet.has(id)
+    );
+    await SlackChannel.destroy({
+      where: {
+        connectorId: c.id,
+        slackChannelId: channelIdsToDelete,
+      },
+    });
 
     for (const channel of channelsInSlack) {
       if (!channel.id) {

--- a/connectors/src/admin/db.ts
+++ b/connectors/src/admin/db.ts
@@ -10,6 +10,7 @@ import {
   NotionConnectorState,
   NotionDatabase,
   NotionPage,
+  SlackChannel,
   SlackChatBotMessage,
   SlackConfiguration,
   SlackMessages,
@@ -20,6 +21,7 @@ async function main(): Promise<void> {
   await Connector.sync({ alter: true });
   await SlackConfiguration.sync({ alter: true });
   await SlackMessages.sync({ alter: true });
+  await SlackChannel.sync({ alter: true });
   await SlackChatBotMessage.sync({ alter: true });
   await NotionPage.sync({ alter: true });
   await NotionDatabase.sync({ alter: true });

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -85,6 +85,7 @@ export async function createSlackConnector(
           slackTeamId: teamInfo.team.id,
           connectorId: connector.id,
           botEnabled: false,
+          defaultChannelPermission: "read_write",
         },
         { transaction: t }
       );

--- a/connectors/src/connectors/slack/lib/channels.ts
+++ b/connectors/src/connectors/slack/lib/channels.ts
@@ -1,0 +1,73 @@
+import { sequelize_conn, SlackChannel } from "@connectors/lib/models";
+
+export type SlackChannelType = {
+  id: number;
+  connectorId: number;
+
+  name: string;
+  slackId: string;
+  isIndexed: boolean;
+};
+
+export async function upsertSlackChannelInConnectorsDb({
+  slackChannelId,
+  slackChannelName,
+  connectorId,
+}: {
+  slackChannelId: string;
+  slackChannelName: string;
+  connectorId: number;
+}): Promise<SlackChannelType> {
+  const transaction = await sequelize_conn.transaction();
+  let channel = await SlackChannel.findOne({
+    where: {
+      connectorId,
+      slackChannelId,
+    },
+    transaction,
+  });
+
+  if (!channel) {
+    channel = await SlackChannel.create(
+      {
+        connectorId,
+        slackChannelId,
+        slackChannelName,
+        isIndexed: true,
+      },
+      { transaction }
+    );
+  } else {
+    if (channel.slackChannelName !== slackChannelName) {
+      channel = await channel.update(
+        {
+          slackChannelName,
+        },
+        { transaction }
+      );
+    }
+  }
+
+  return {
+    id: channel.id,
+    connectorId: channel.connectorId,
+    name: channel.slackChannelName,
+    slackId: channel.slackChannelId,
+    isIndexed: channel.isIndexed,
+  };
+}
+
+export async function deleteChannelFromConnectorsDb({
+  slackChannelId,
+  connectorId,
+}: {
+  slackChannelId: string;
+  connectorId: number;
+}): Promise<void> {
+  await SlackChannel.destroy({
+    where: {
+      connectorId,
+      slackChannelId,
+    },
+  });
+}

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -136,7 +136,7 @@ export async function syncChannel(
     slackChannelName: channelName,
     connectorId: parseInt(connectorId),
   });
-  if (!channel.isIndexed) {
+  if (!["read", "read_write"].includes(channel.permission)) {
     logger.info(
       {
         connectorId,

--- a/connectors/src/lib/models.ts
+++ b/connectors/src/lib/models.ts
@@ -130,6 +130,7 @@ export class SlackConfiguration extends Model<
   declare slackTeamId: string;
   declare botEnabled: boolean;
   declare connectorId: ForeignKey<Connector["id"]>;
+  declare defaultChannelPermission: "none" | "read" | "write" | "read_write";
 }
 
 SlackConfiguration.init(
@@ -157,6 +158,11 @@ SlackConfiguration.init(
       type: DataTypes.BOOLEAN,
       allowNull: false,
       defaultValue: false,
+    },
+    defaultChannelPermission: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      defaultValue: "read_write",
     },
   },
   {
@@ -245,7 +251,7 @@ export class SlackChannel extends Model<
   declare slackChannelId: string;
   declare slackChannelName: string;
 
-  declare isIndexed: boolean;
+  declare permission: "none" | "read" | "write" | "read_write";
 }
 
 SlackChannel.init(
@@ -277,10 +283,10 @@ SlackChannel.init(
       type: DataTypes.STRING,
       allowNull: false,
     },
-    isIndexed: {
-      type: DataTypes.BOOLEAN,
+    permission: {
+      type: DataTypes.STRING,
       allowNull: false,
-      defaultValue: true,
+      defaultValue: "read_write",
     },
   },
   {
@@ -292,6 +298,8 @@ SlackChannel.init(
     ],
   }
 );
+
+Connector.hasMany(SlackChannel);
 
 export class SlackChatBotMessage extends Model<
   InferAttributes<SlackChatBotMessage>,

--- a/connectors/src/lib/models.ts
+++ b/connectors/src/lib/models.ts
@@ -233,6 +233,66 @@ SlackMessages.init(
 
 Connector.hasOne(SlackMessages);
 
+export class SlackChannel extends Model<
+  InferAttributes<SlackChannel>,
+  InferCreationAttributes<SlackChannel>
+> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare connectorId: ForeignKey<Connector["id"]>;
+  declare slackChannelId: string;
+  declare slackChannelName: string;
+
+  declare isIndexed: boolean;
+}
+
+SlackChannel.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    connectorId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+    slackChannelId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    slackChannelName: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    isIndexed: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: true,
+    },
+  },
+  {
+    sequelize: sequelize_conn,
+    modelName: "slack_channels",
+    indexes: [
+      { fields: ["connectorId", "slackChannelId"], unique: true },
+      { fields: ["connectorId"] },
+    ],
+  }
+);
+
 export class SlackChatBotMessage extends Model<
   InferAttributes<SlackChatBotMessage>,
   InferCreationAttributes<SlackChatBotMessage>


### PR DESCRIPTION
- add a new model to keep track of Slack channels
- add a "permission" field on it, which can be `read` (bot can read data in the channel), `write` (bot can speak in the channel), `read_write` (both) or `none`. Will be backfilled to "read_write" for all existing connectors (behaviour ISO with pre-PR)
- add `defaultChannelPermission` field to slack configuration -> all new `SlackChannel` object for that slack connector will get this default permission (defaults to "read_write" for all existing and new conenctors, ISO with pre-PR)
- add a backfill script for the `SlackChannel` model
- update `syncChannel` and `deleteChannel` logic so it respectively upserts and deletes in the `SlackChannel` table