### PR TITLE
Reintroduce Tabs href

### DIFF
--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "scripts": {
     "build": "rollup -c"
   },

--- a/sparkle/src/components/Tab.tsx
+++ b/sparkle/src/components/Tab.tsx
@@ -1,6 +1,7 @@
 import { ReactComponentLike } from "prop-types";
 import React, { MouseEvent } from "react";
 
+import { SparkleContext } from "@sparkle/context";
 import { classNames } from "@sparkle/lib/utils";
 
 type TabProps = {
@@ -10,8 +11,9 @@ type TabProps = {
     current: boolean;
     sizing?: "hug" | "expand";
     icon?: ReactComponentLike;
+    href?: string;
   }>;
-  onTabClick?: (tabName: string, event: MouseEvent<HTMLDivElement>) => void;
+  onTabClick?: (tabName: string, event: MouseEvent<HTMLAnchorElement>) => void;
   className?: string;
 };
 
@@ -59,6 +61,9 @@ const tabSizingClasses = {
 };
 
 export function Tab({ tabs, onTabClick, className = "" }: TabProps) {
+  const { components } = React.useContext(SparkleContext);
+  const Link = components.link;
+
   const renderTabs = () =>
     tabs.map((tab) => {
       const tabStateClasses = tab.current
@@ -88,11 +93,12 @@ export function Tab({ tabs, onTabClick, className = "" }: TabProps) {
       );
 
       return (
-        <div
+        <Link
           key={tab.label}
           className={finalTabClasses}
           aria-current={tab.current ? "page" : undefined}
           onClick={(event) => onTabClick?.(tab.label, event)}
+          href={tab.href}
         >
           <div
             className={
@@ -104,7 +110,7 @@ export function Tab({ tabs, onTabClick, className = "" }: TabProps) {
             {tab.icon && <tab.icon className={finalIconClasses} />}
             {tab.hideLabel ?? tab.label}
           </div>
-        </div>
+        </Link>
       );
     });
 

--- a/sparkle/src/context.tsx
+++ b/sparkle/src/context.tsx
@@ -1,0 +1,22 @@
+import React, { ComponentType, MouseEvent, ReactNode } from "react";
+
+export type SparkleContextType = {
+  components: {
+    link: ComponentType<{
+      href?: string;
+      className?: string;
+      children: ReactNode;
+      onClick?: (event: MouseEvent<HTMLAnchorElement>) => void;
+    }>;
+  };
+};
+
+export const SparkleContext = React.createContext<SparkleContextType>({
+  components: {
+    link: ({ href, className, children }) => (
+      <a href={href} className={className}>
+        {children}
+      </a>
+    ),
+  },
+});


### PR DESCRIPTION
Rely on a react Context to decide which component to use within the tab as anchor (<a> by default, can be overriden at the point of usage by a <Link>).

Published 0.1.4 will try to use in `front`