### PR TITLE
adapt retrieveSlackConnectorPermissions

### DIFF
--- a/connectors/src/connectors/slack/lib/channels.ts
+++ b/connectors/src/connectors/slack/lib/channels.ts
@@ -3,6 +3,7 @@ import {
   SlackChannel,
   SlackConfiguration,
 } from "@connectors/lib/models";
+import { ConnectorPermission } from "@connectors/types/resources";
 
 export type SlackChannelType = {
   id: number;
@@ -10,7 +11,7 @@ export type SlackChannelType = {
 
   name: string;
   slackId: string;
-  permission: "none" | "read" | "write" | "read_write";
+  permission: ConnectorPermission;
 };
 
 export async function upsertSlackChannelInConnectorsDb({

--- a/connectors/src/lib/models.ts
+++ b/connectors/src/lib/models.ts
@@ -12,6 +12,7 @@ import {
   type ConnectorProvider,
   ConnectorSyncStatus,
 } from "@connectors/types/connector";
+import { ConnectorPermission } from "@connectors/types/resources";
 
 const { CONNECTORS_DATABASE_URI } = process.env;
 if (!CONNECTORS_DATABASE_URI) {
@@ -130,7 +131,7 @@ export class SlackConfiguration extends Model<
   declare slackTeamId: string;
   declare botEnabled: boolean;
   declare connectorId: ForeignKey<Connector["id"]>;
-  declare defaultChannelPermission: "none" | "read" | "write" | "read_write";
+  declare defaultChannelPermission: ConnectorPermission;
 }
 
 SlackConfiguration.init(
@@ -251,7 +252,7 @@ export class SlackChannel extends Model<
   declare slackChannelId: string;
   declare slackChannelName: string;
 
-  declare permission: "none" | "read" | "write" | "read_write";
+  declare permission: ConnectorPermission;
 }
 
 SlackChannel.init(

--- a/connectors/src/types/resources.ts
+++ b/connectors/src/types/resources.ts
@@ -4,7 +4,7 @@ import { ConnectorProvider } from "./connector";
  * This type represents the permission associated with a ConnectorResource. For now the only
  * permission we handle is read. but we could have more complex permissions in the future.
  */
-export type ConnectorPermission = "read" | null;
+export type ConnectorPermission = "read" | "write" | "read_write" | "none";
 
 export type ConnectorResourceType = "file" | "folder" | "database" | "channel";
 

--- a/front/lib/connectors_api.ts
+++ b/front/lib/connectors_api.ts
@@ -47,7 +47,7 @@ export type ConnectorType = {
   firstSyncProgress?: string;
 };
 
-export type ConnectorPermission = "read" | null;
+export type ConnectorPermission = "read" | "write" | "read_write" | "none";
 export type ConnectorResourceType = "file" | "folder" | "database" | "channel";
 
 export type ConnectorResource = {


### PR DESCRIPTION
~~need to complete backfill from https://github.com/dust-tt/dust/pull/954 first~~ => done

- unify the `ConnectorPermission` enum
- update `retrieveSlackConnectorPermissions` to use the new `SlackChannel` table