### PR TITLE
[WIP] Connectors connectionId for Nango always unique

### DIFF
--- a/connectors/src/api/get_connector_auth_info.ts
+++ b/connectors/src/api/get_connector_auth_info.ts
@@ -1,0 +1,57 @@
+import { Request, Response } from "express";
+
+import { RETRIEVE_CONNECTOR_AUTH_INFO_BY_TYPE } from "@connectors/connectors";
+import { Connector } from "@connectors/lib/models";
+import { apiError, withLogging } from "@connectors/logger/withlogging";
+import { ConnectorsAPIErrorResponse } from "@connectors/types/errors";
+
+type GetConnectorAuthInfoRes =
+  | { scope: string; id: string; name: string }
+  | ConnectorsAPIErrorResponse;
+
+const _getConnectorAuthInfo = async (
+  req: Request<{ connector_id: string }, GetConnectorAuthInfoRes, undefined>,
+  res: Response<GetConnectorAuthInfoRes>
+) => {
+  if (!req.params.connector_id) {
+    return apiError(req, res, {
+      api_error: {
+        type: "invalid_request_error",
+        message: "Missing required parameters. Required: connector_id",
+      },
+      status_code: 400,
+    });
+  }
+
+  const connector = await Connector.findByPk(req.params.connector_id);
+  if (!connector) {
+    return apiError(req, res, {
+      api_error: {
+        type: "connector_not_found",
+        message: "Connector not found",
+      },
+      status_code: 404,
+    });
+  }
+
+  const connectorAuthInfoRetriever =
+    RETRIEVE_CONNECTOR_AUTH_INFO_BY_TYPE[connector.type];
+
+  const pRes = await connectorAuthInfoRetriever(connector.id);
+
+  if (pRes.isErr()) {
+    return apiError(req, res, {
+      api_error: {
+        type: "internal_server_error",
+        message: pRes.error.message,
+      },
+      status_code: 500,
+    });
+  }
+
+  return res.status(200).json(pRes.value);
+};
+
+export const getConnectorAuthInfoAPIHandler = withLogging(
+  _getConnectorAuthInfo
+);

--- a/connectors/src/api/update_connector.ts
+++ b/connectors/src/api/update_connector.ts
@@ -1,0 +1,84 @@
+import { Request, Response } from "express";
+
+import { UPDATE_CONNECTOR_BY_TYPE } from "@connectors/connectors";
+import { Connector } from "@connectors/lib/models";
+import logger from "@connectors/logger/logger";
+import { apiError, withLogging } from "@connectors/logger/withlogging";
+import { ConnectorsAPIErrorResponse } from "@connectors/types/errors";
+
+type ConnectorUpdateReqBody = {
+  connectionId: string;
+};
+type ConnectorUpdateResBody =
+  | { connectorId: string }
+  | ConnectorsAPIErrorResponse;
+
+const _getConnectorUpdateAPIHandler = async (
+  req: Request<{ connector_id: string }, ConnectorUpdateReqBody>,
+  res: Response<ConnectorUpdateResBody>
+) => {
+  if (!req.params.connector_id) {
+    return apiError(req, res, {
+      api_error: {
+        type: "invalid_request_error",
+        message: "Missing required parameters. Required: connector_id",
+      },
+      status_code: 400,
+    });
+  }
+
+  if (!req.body.connectionId) {
+    return apiError(req, res, {
+      api_error: {
+        type: "invalid_request_error",
+        message: `Missing required parameters. Required : connectionId`,
+      },
+      status_code: 400,
+    });
+  }
+
+  const connector = await Connector.findByPk(req.params.connector_id);
+  if (!connector) {
+    return apiError(req, res, {
+      api_error: {
+        type: "connector_not_found",
+        message: "Connector not found",
+      },
+      status_code: 404,
+    });
+  }
+
+  const connectorUpdater = UPDATE_CONNECTOR_BY_TYPE[connector.type];
+  const updateRes = await connectorUpdater(connector.id, req.body.connectionId);
+
+  if (updateRes.isErr()) {
+    const errorRes = updateRes as { error: ConnectorsAPIErrorResponse };
+    const error = errorRes.error.error;
+
+    if (error.type === "connector_update_scope_unauthorized") {
+      return apiError(req, res, {
+        api_error: {
+          type: error.type,
+          message: error.message,
+        },
+        status_code: 401,
+      });
+    } else {
+      return apiError(req, res, {
+        api_error: {
+          type: "connector_update_error",
+          message: `Could not update the connector: ${error.message}`,
+        },
+        status_code: 500,
+      });
+    }
+  }
+
+  return res.status(200).json({
+    connectorId: updateRes.value,
+  });
+};
+
+export const getConnectorUpdateAPIHandler = withLogging(
+  _getConnectorUpdateAPIHandler
+);

--- a/connectors/src/api_server.ts
+++ b/connectors/src/api_server.ts
@@ -4,6 +4,8 @@ import express from "express";
 import { createConnectorAPIHandler } from "@connectors/api/create_connector";
 import { deleteConnectorAPIHandler } from "@connectors/api/delete_connector";
 import { getConnectorAPIHandler } from "@connectors/api/get_connector";
+import { getConnectorAuthInfoAPIHandler } from "@connectors/api/get_connector_auth_info";
+import { getConnectorPermissionsAPIHandler } from "@connectors/api/get_connector_permissions";
 import {
   googleDriveGetFoldersAPIHandler,
   googleDriveSetFoldersAPIHandler,
@@ -11,13 +13,12 @@ import {
 import { resumeConnectorAPIHandler } from "@connectors/api/resume_connector";
 import { stopConnectorAPIHandler } from "@connectors/api/stop_connector";
 import { syncConnectorAPIHandler } from "@connectors/api/sync_connector";
+import { getConnectorUpdateAPIHandler } from "@connectors/api/update_connector";
 import { webhookGithubAPIHandler } from "@connectors/api/webhooks/webhook_github";
 import { webhookGoogleDriveAPIHandler } from "@connectors/api/webhooks/webhook_google_drive";
 import { webhookSlackAPIHandler } from "@connectors/api/webhooks/webhook_slack";
 import logger from "@connectors/logger/logger";
 import { authMiddleware } from "@connectors/middleware/auth";
-
-import { getConnectorPermissionsAPIHandler } from "./api/get_connector_permissions";
 
 export function startServer(port: number) {
   const app = express();
@@ -43,11 +44,16 @@ export function startServer(port: number) {
   app.post("/connectors/stop/:connector_id", stopConnectorAPIHandler);
   app.post("/connectors/resume/:connector_id", resumeConnectorAPIHandler);
   app.delete("/connectors/delete/:connector_id", deleteConnectorAPIHandler);
+  app.post("/connectors/update/:connector_id/", getConnectorUpdateAPIHandler);
   app.get("/connectors/:connector_id", getConnectorAPIHandler);
   app.post("/connectors/sync/:connector_id", syncConnectorAPIHandler);
   app.get(
     "/connectors/:connector_id/permissions",
     getConnectorPermissionsAPIHandler
+  );
+  app.get(
+    "/connectors/:connector_id/auth_info",
+    getConnectorAuthInfoAPIHandler
   );
 
   app.post("/webhooks/:webhook_secret/slack", webhookSlackAPIHandler);

--- a/connectors/src/connectors/index.ts
+++ b/connectors/src/connectors/index.ts
@@ -19,8 +19,10 @@ import {
   createNotionConnector,
   fullResyncNotionConnector,
   resumeNotionConnector,
+  retrieveNotionConnectorAuthInfo,
   retrieveNotionConnectorPermissions,
   stopNotionConnector,
+  updateNotionConnector,
 } from "@connectors/connectors/notion";
 import {
   cleanupSlackConnector,
@@ -29,7 +31,7 @@ import {
 } from "@connectors/connectors/slack";
 import { launchSlackSyncWorkflow } from "@connectors/connectors/slack/temporal/client";
 import { ModelId } from "@connectors/lib/models";
-import { Ok, Result } from "@connectors/lib/result";
+import { Err, Ok, Result } from "@connectors/lib/result";
 import logger from "@connectors/logger/logger";
 import { ConnectorProvider } from "@connectors/types/connector";
 import { DataSourceConfig } from "@connectors/types/data_source_config";
@@ -128,4 +130,50 @@ export const RETRIEVE_CONNECTOR_PERMISSIONS_BY_TYPE: Record<
   github: retrieveGithubConnectorPermissions,
   notion: retrieveNotionConnectorPermissions,
   google_drive: retrieveGoogleDriveConnectorPermissions,
+};
+
+type ConnectorUpdater = (
+  connectorId: ModelId,
+  connectionId: string
+) => Promise<Result<string, Error>>;
+
+export const UPDATE_CONNECTOR_BY_TYPE: Record<
+  ConnectorProvider,
+  ConnectorUpdater
+> = {
+  slack: async (connectorId: ModelId) => {
+    throw new Error(`Not implemented ${connectorId}`);
+  },
+  notion: updateNotionConnector,
+  github: async (connectorId: ModelId) => {
+    throw new Error(`Not implemented ${connectorId}`);
+  },
+  google_drive: async (connectorId: ModelId) => {
+    throw new Error(`Not implemented ${connectorId}`);
+  },
+};
+
+export type ConnectorAuthInfo = {
+  scope: string;
+  id: string;
+  name: string;
+};
+type ConnectorAuthInfoRetriever = (
+  connectorId: ModelId
+) => Promise<Result<ConnectorAuthInfo, Error>>;
+
+export const RETRIEVE_CONNECTOR_AUTH_INFO_BY_TYPE: Record<
+  ConnectorProvider,
+  ConnectorAuthInfoRetriever
+> = {
+  slack: async () => {
+    return new Err(new Error("Not implemented"));
+  },
+  github: async () => {
+    return new Err(new Error("Not implemented"));
+  },
+  notion: retrieveNotionConnectorAuthInfo,
+  google_drive: async () => {
+    return new Err(new Error("Not implemented"));
+  },
 };

--- a/connectors/src/lib/error.ts
+++ b/connectors/src/lib/error.ts
@@ -4,6 +4,7 @@ export type APIErrorType =
   | "invalid_request_error"
   | "connector_not_found"
   | "connector_configuration_not_found"
+  | "connector_cannot_update_scope"
   | "not_found";
 
 export type APIError = {

--- a/connectors/src/types/errors.ts
+++ b/connectors/src/types/errors.ts
@@ -1,5 +1,6 @@
 export type ConnectorsAPIErrorResponse = {
   error: {
     message: string;
+    type?: string;
   };
 };

--- a/front/components/ConnectorPermissionsModal.tsx
+++ b/front/components/ConnectorPermissionsModal.tsx
@@ -9,7 +9,7 @@ import { Dialog, Transition } from "@headlessui/react";
 import { Fragment, useEffect, useState } from "react";
 
 import { ConnectorProvider, ConnectorType } from "@app/lib/connectors_api";
-import { useConnectorPermissions } from "@app/lib/swr";
+import { useConnectorAuthInfo, useConnectorPermissions } from "@app/lib/swr";
 import { timeAgoFrom } from "@app/lib/utils";
 import { DataSourceType } from "@app/types/data_source";
 import { WorkspaceType } from "@app/types/user";
@@ -126,6 +126,7 @@ export default function ConnectorPermissionsModal({
   const [synchronizedTimeAgo, setSynchronizedTimeAgo] = useState<string | null>(
     null
   );
+  const { authInfo } = useConnectorAuthInfo(owner, dataSource);
 
   useEffect(() => {
     if (connector.lastSyncSuccessfulTime)
@@ -169,9 +170,14 @@ export default function ConnectorPermissionsModal({
                         {CONNECTOR_TYPE_TO_NAME[connector.type]} permissions
                       </Dialog.Title>
                       {synchronizedTimeAgo && (
-                        <span className="text-gray-500">
+                        <p className="text-gray-500">
                           Last synchronized ~{synchronizedTimeAgo} ago
-                        </span>
+                        </p>
+                      )}
+                      {authInfo && (
+                        <p className="text-gray-500">
+                          {authInfo.scope} name: {authInfo.name}
+                        </p>
                       )}
                     </div>
                   </div>

--- a/front/lib/connector_nango.ts
+++ b/front/lib/connector_nango.ts
@@ -1,0 +1,16 @@
+import { ConnectorProvider } from "@app/lib/connectors_api";
+import { client_side_new_id } from "@app/lib/utils";
+
+export function buildConnectionId(
+  wId: string,
+  provider: ConnectorProvider,
+  suffix: string | null
+): string {
+  let connectionName = `${provider}-${wId}`;
+  if (suffix) {
+    connectionName += `-${suffix}`;
+  }
+  const uId = client_side_new_id();
+  connectionName += `-${uId.slice(0, 10)}`;
+  return connectionName;
+}

--- a/front/lib/error.ts
+++ b/front/lib/error.ts
@@ -38,7 +38,9 @@ export type APIErrorType =
   | "template_not_found"
   | "chat_message_not_found"
   | "event_schema_not_found"
-  | "extracted_event_not_found";
+  | "extracted_event_not_found"
+  | "connector_update_scope_unauthorized"
+  | "connector_update_error";
 
 export type APIError = {
   type: APIErrorType;

--- a/front/lib/swr.ts
+++ b/front/lib/swr.ts
@@ -7,6 +7,7 @@ import { GetRunBlockResponseBody } from "@app/pages/api/w/[wId]/apps/[aId]/runs/
 import { GetRunStatusResponseBody } from "@app/pages/api/w/[wId]/apps/[aId]/runs/[runId]/status";
 import { GetDataSourcesResponseBody } from "@app/pages/api/w/[wId]/data_sources";
 import { GetDocumentsResponseBody } from "@app/pages/api/w/[wId]/data_sources/[name]/documents";
+import { GetDataSourceAuthInfoResponseBody } from "@app/pages/api/w/[wId]/data_sources/[name]/managed/auth_info";
 import { GetDataSourcePermissionsResponseBody } from "@app/pages/api/w/[wId]/data_sources/[name]/managed/permissions";
 import { GetWorkspaceInvitationsResponseBody } from "@app/pages/api/w/[wId]/invitations";
 import { GetKeysResponseBody } from "@app/pages/api/w/[wId]/keys";
@@ -271,6 +272,22 @@ export function useConnectorPermissions(
     resources: data ? data.resources : [],
     isResourcesLoading: !error && !data,
     isResourcesError: error,
+  };
+}
+
+export function useConnectorAuthInfo(
+  owner: WorkspaceType,
+  dataSource: DataSourceType
+) {
+  const autInfoFetcher: Fetcher<GetDataSourceAuthInfoResponseBody> = fetcher;
+
+  const url = `/api/w/${owner.sId}/data_sources/${dataSource.name}/managed/auth_info`;
+  const { data, error } = useSWR(url, autInfoFetcher);
+
+  return {
+    authInfo: data,
+    isAuthInfoLoading: !error && !data,
+    isAuthInfoError: error,
   };
 }
 

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/auth_info.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/auth_info.ts
@@ -1,0 +1,88 @@
+import { NextApiRequest, NextApiResponse } from "next";
+
+import { getDataSource } from "@app/lib/api/data_sources";
+import { Authenticator, getSession } from "@app/lib/auth";
+import { ConnectorsAPI } from "@app/lib/connectors_api";
+import { ReturnedAPIErrorType } from "@app/lib/error";
+import { apiError, withLogging } from "@app/logger/withlogging";
+
+export type GetDataSourceAuthInfoResponseBody = {
+  scope: string;
+  id: string;
+  name: string;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    GetDataSourceAuthInfoResponseBody | ReturnedAPIErrorType | void
+  >
+): Promise<void> {
+  const session = await getSession(req, res);
+  const auth = await Authenticator.fromSession(
+    session,
+    req.query.wId as string
+  );
+
+  const owner = auth.workspace();
+  if (!owner) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "data_source_not_found",
+        message: "The data source you requested was not found.",
+      },
+    });
+  }
+
+  const dataSource = await getDataSource(auth, req.query.name as string);
+  if (!dataSource) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "data_source_not_found",
+        message: "The data source you requested was not found.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET":
+      if (!dataSource.connectorId) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "data_source_not_managed",
+            message: "The data source you requested is not managed.",
+          },
+        });
+      }
+
+      const authInfoRes = await ConnectorsAPI.getConnectorAuthInfo({
+        connectorId: dataSource.connectorId,
+      });
+      if (authInfoRes.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message:
+              "An error occurred while retrieving the data source auth info.",
+          },
+        });
+      }
+      res.status(200).json(authInfoRes.value);
+      return;
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withLogging(handler);

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/update.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/update.ts
@@ -1,0 +1,114 @@
+import { NextApiRequest, NextApiResponse } from "next";
+
+import { getDataSource } from "@app/lib/api/data_sources";
+import { Authenticator, getSession } from "@app/lib/auth";
+import {
+  ConnectorsAPI,
+  ConnectorsAPIErrorResponse,
+} from "@app/lib/connectors_api";
+import { ReturnedAPIErrorType } from "@app/lib/error";
+import { apiError, withLogging } from "@app/logger/withlogging";
+
+export type GetDataSourceUpdateResponseBody = {
+  connectorId: string;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    GetDataSourceUpdateResponseBody | ReturnedAPIErrorType | void
+  >
+): Promise<void> {
+  const session = await getSession(req, res);
+  const auth = await Authenticator.fromSession(
+    session,
+    req.query.wId as string
+  );
+
+  const owner = auth.workspace();
+  if (!owner) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "data_source_not_found",
+        message: "The data source you requested was not found.",
+      },
+    });
+  }
+
+  const dataSource = await getDataSource(auth, req.query.name as string);
+  if (!dataSource) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "data_source_not_found",
+        message: "The data source you requested was not found.",
+      },
+    });
+  }
+
+  if (!dataSource.connectorId) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "data_source_not_managed",
+        message: "The data source you requested is not managed.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "POST":
+      if (!req.body || !(typeof req.body.connectionId == "string")) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              "The request body is invalid, expects { connectionId: string }.",
+          },
+        });
+      }
+
+      const updateRes = await ConnectorsAPI.updateConnector({
+        connectorId: dataSource.connectorId.toString(),
+        connectionId: req.body.connectionId,
+      });
+
+      if (updateRes.isErr()) {
+        const errorRes = updateRes as { error: ConnectorsAPIErrorResponse };
+        const error = errorRes.error.error;
+
+        if (error.type === "connector_update_scope_unauthorized") {
+          return apiError(req, res, {
+            api_error: {
+              type: error.type,
+              message: error.message,
+            },
+            status_code: 401,
+          });
+        } else {
+          return apiError(req, res, {
+            api_error: {
+              type: "connector_update_error",
+              message: `Could not update the connector: ${error.message}`,
+            },
+            status_code: 500,
+          });
+        }
+      }
+      res.status(200).json(updateRes.value);
+      return;
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withLogging(handler);

--- a/front/pages/w/[wId]/ds/index.tsx
+++ b/front/pages/w/[wId]/ds/index.tsx
@@ -11,6 +11,7 @@ import GoogleDriveFoldersPickerModal from "@app/components/GoogleDriveFoldersPic
 import { getDataSources } from "@app/lib/api/data_sources";
 import { setUserMetadata } from "@app/lib/api/user";
 import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
+import { buildConnectionId } from "@app/lib/connector_nango";
 import {
   connectorIsUsingNango,
   ConnectorProvider,
@@ -268,19 +269,6 @@ export default function DataSourcesView({
   >({} as Record<ConnectorProvider, boolean | undefined>);
   const [googleDrivePickerOpen, setGoogleDrivePickerOpen] = useState(false);
 
-  function buildNangoConnectionName(
-    provider: ConnectorProvider,
-    suffix: string | null
-  ): string {
-    let connectionName = `${provider}-${owner.sId}`;
-    if (suffix) {
-      connectionName += `-${suffix}`;
-    }
-    const uId = client_side_new_id();
-    connectionName += `-${uId.slice(0, 10)}`;
-    return connectionName;
-  }
-
   const handleEnableManagedDataSource = async (
     provider: ConnectorProvider,
     suffix: string | null
@@ -295,7 +283,11 @@ export default function DataSourcesView({
           google_drive: nangoConfig.googleDriveConnectorId,
         }[provider];
         const nango = new Nango({ publicKey: nangoConfig.publicKey });
-        const newConnectionName = buildNangoConnectionName(provider, suffix);
+        const newConnectionName = buildConnectionId(
+          owner.sId,
+          provider,
+          suffix
+        );
         const {
           connectionId: nangoConnectionId,
         }: { providerConfigKey: string; connectionId: string } =


### PR DESCRIPTION
Generating a unique Nango connection id when adding a datasource to avoid overriding it.


EDIT: NOT READY, need to handle property in `handleUpdatePermissions`: https://github.com/dust-tt/dust/blob/main/front/pages/w/%5BwId%5D/ds/%5Bname%5D/settings.tsx#L555