### PR TITLE
sparkle: Remove from front for now

### DIFF
--- a/front/components/ConnectorPermissionsModal.tsx
+++ b/front/components/ConnectorPermissionsModal.tsx
@@ -1,11 +1,11 @@
+import { Dialog, Transition } from "@headlessui/react";
 import {
-  ChatBubbleBottomCenterTextIcon,
+  ChatBubbleLeftRightIcon,
+  CircleStackIcon,
   Cog6ToothIcon,
   DocumentTextIcon,
-  FolderOpenIcon,
-  Square3Stack3DIcon,
-} from "@dust-tt/sparkle";
-import { Dialog, Transition } from "@headlessui/react";
+  FolderIcon,
+} from "@heroicons/react/20/solid";
 import { Fragment, useEffect, useState } from "react";
 
 import { ConnectorProvider, ConnectorType } from "@app/lib/connectors_api";
@@ -62,19 +62,19 @@ function PermissionTreeChildren({
                     )}
                     {r.type === "database" && (
                       <>
-                        <Square3Stack3DIcon className="h-6 w-6 text-slate-300" />
+                        <CircleStackIcon className="h-6 w-6 text-slate-300" />
                         <span className="ml-2">{r.title}</span>
                       </>
                     )}
                     {r.type === "folder" && (
                       <>
-                        <FolderOpenIcon className="h-6 w-6 text-slate-300" />
+                        <FolderIcon className="h-6 w-6 text-slate-300" />
                         <span className="ml-2">{r.title}</span>
                       </>
                     )}
                     {r.type === "channel" && (
                       <>
-                        <ChatBubbleBottomCenterTextIcon className="h-6 w-6 text-slate-300" />
+                        <ChatBubbleLeftRightIcon className="h-6 w-6 text-slate-300" />
                         <span className="ml-2">#{r.title}</span>
                       </>
                     )}

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -5,7 +5,6 @@
   "packages": {
     "": {
       "dependencies": {
-        "@dust-tt/sparkle": "^0.1.2",
         "@headlessui/react": "^1.7.7",
         "@heroicons/react": "^2.0.11",
         "@nangohq/frontend": "^0.16.1",
@@ -803,14 +802,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@datadog/sketches-js/-/sketches-js-2.1.0.tgz",
       "integrity": "sha512-smLocSfrt3s53H/XSVP3/1kP42oqvrkjUPtyaFd1F79ux24oE31BKt+q0c6lsa6hOYrFzsIwyc5GXAI5JmfOew=="
-    },
-    "node_modules/@dust-tt/sparkle": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.1.2.tgz",
-      "integrity": "sha512-TeoIbx3Ql7/N+pq1DNpEeg4Uds9Cy6H1SMH0v4/L0EtnHoPlUVLXYiMPd7vmrcYYEAGQ7Tw9LWqZ/SUvL53CjQ==",
-      "peerDependencies": {
-        "react": "^18.2.0"
-      }
     },
     "node_modules/@esbuild-kit/cjs-loader": {
       "version": "2.4.2",

--- a/front/package.json
+++ b/front/package.json
@@ -13,7 +13,6 @@
     "initdb": "env $(cat .env.local) npx tsx admin/db.ts"
   },
   "dependencies": {
-    "@dust-tt/sparkle": "^0.1.2",
     "@headlessui/react": "^1.7.7",
     "@heroicons/react": "^2.0.11",
     "@nangohq/frontend": "^0.16.1",


### PR DESCRIPTION
A few weird bugs have been reported and all trace back to the import of sparkle (double menu, button mis-rendering)

We need to figure out what's going on here