### PR TITLE
sparkle: add very basic checkbox component + storybook

### DIFF
--- a/dust-storybook/package-lock.json
+++ b/dust-storybook/package-lock.json
@@ -44,7 +44,7 @@
     },
     "../sparkle": {
       "name": "@dust-tt/sparkle",
-      "version": "0.1.13",
+      "version": "0.1.14",
       "license": "ISC",
       "devDependencies": {
         "@rollup/plugin-commonjs": "^25.0.2",

--- a/dust-storybook/src/stories/Checkbox.stories.ts
+++ b/dust-storybook/src/stories/Checkbox.stories.ts
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Checkbox } from "sparkle";
+
+import "sparkle/dist/cjs/index.css";
+
+const meta = {
+  title: "Atoms/Checkbox",
+  component: Checkbox,
+} satisfies Meta<typeof Checkbox>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Checked: Story = {
+  args: {
+    checked: true,
+  },
+};
+
+export const Unchecked: Story = {
+  args: {
+    checked: false,
+  },
+};

--- a/sparkle/src/components/Checkbox.tsx
+++ b/sparkle/src/components/Checkbox.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+
+interface CheckboxProps {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  className?: string;
+  disabled?: boolean;
+}
+
+export function Checkbox({
+  checked,
+  onChange,
+  className,
+  disabled,
+}: CheckboxProps) {
+  return (
+    <input
+      type="checkbox"
+      checked={checked}
+      onChange={(e) => onChange && onChange(e.target.checked)}
+      className={className}
+      disabled={disabled}
+    />
+  );
+}

--- a/sparkle/src/index.ts
+++ b/sparkle/src/index.ts
@@ -21,6 +21,9 @@ export { Icon };
 import { Logo } from "./logo";
 export { Logo };
 
+import { Checkbox } from "./components/Checkbox";
+export { Checkbox };
+
 import {
   ArrowUpOnSquare as ArrowUpOnSquareIcon,
   Beaker as BeakerIcon,


### PR DESCRIPTION
The checkbox we currently use in `front`