### PR TITLE
feat: update channel permissions slack

### DIFF
--- a/connectors/src/api/set_connector_permissions.ts
+++ b/connectors/src/api/set_connector_permissions.ts
@@ -1,0 +1,104 @@
+import { Request, Response } from "express";
+import { isLeft } from "fp-ts/lib/Either";
+import * as t from "io-ts";
+import * as reporter from "io-ts-reporters";
+
+import { SET_CONNECTOR_PERMISSIONS_BY_TYPE } from "@connectors/connectors";
+import { Connector } from "@connectors/lib/models";
+import { apiError, withLogging } from "@connectors/logger/withlogging";
+import { ConnectorsAPIErrorResponse } from "@connectors/types/errors";
+
+type SetConnectorPermissionsRes =
+  | { success: true }
+  | ConnectorsAPIErrorResponse;
+
+const SetConnectorPermissionsRequestBodySchema = t.type({
+  resources: t.array(
+    t.type({
+      internal_id: t.string,
+      permission: t.union([
+        t.literal("none"),
+        t.literal("read"),
+        t.literal("write"),
+        t.literal("read_write"),
+      ]),
+    })
+  ),
+});
+type SetConnectorPermissionsRequestBody = t.TypeOf<
+  typeof SetConnectorPermissionsRequestBodySchema
+>;
+
+const _setConnectorPermissions = async (
+  req: Request<
+    { connector_id: string },
+    SetConnectorPermissionsRes,
+    SetConnectorPermissionsRequestBody
+  >,
+  res: Response<SetConnectorPermissionsRes>
+) => {
+  if (!req.params.connector_id) {
+    return apiError(req, res, {
+      api_error: {
+        type: "invalid_request_error",
+        message: "Missing required parameters. Required: connector_id",
+      },
+      status_code: 400,
+    });
+  }
+
+  const bodyValidation = SetConnectorPermissionsRequestBodySchema.decode(
+    req.body
+  );
+
+  if (isLeft(bodyValidation)) {
+    const pathError = reporter.formatValidationErrors(bodyValidation.left);
+    return apiError(req, res, {
+      api_error: {
+        type: "invalid_request_error",
+        message: `Invalid request body: ${pathError}`,
+      },
+      status_code: 400,
+    });
+  }
+
+  const { resources } = bodyValidation.right;
+
+  const connector = await Connector.findByPk(req.params.connector_id);
+  if (!connector) {
+    return apiError(req, res, {
+      api_error: {
+        type: "connector_not_found",
+        message: "Connector not found",
+      },
+      status_code: 404,
+    });
+  }
+
+  const connectorPermissionSetter =
+    SET_CONNECTOR_PERMISSIONS_BY_TYPE[connector.type];
+
+  const pRes = await connectorPermissionSetter(
+    connector.id,
+    resources.reduce(
+      (acc, r) => Object.assign(acc, { [r.internal_id]: r.permission }),
+      {}
+    )
+  );
+
+  if (pRes.isErr()) {
+    return apiError(req, res, {
+      api_error: {
+        type: "internal_server_error",
+        message: pRes.error.message,
+      },
+      status_code: 500,
+    });
+  }
+
+  return res.status(200).json({ success: true });
+};
+
+export const setConnectorPermissionsAPIHandler = withLogging(
+  _setConnectorPermissions
+);

--- a/connectors/src/api_server.ts
+++ b/connectors/src/api_server.ts
@@ -10,6 +10,7 @@ import {
   googleDriveSetFoldersAPIHandler,
 } from "@connectors/api/google_drive";
 import { resumeConnectorAPIHandler } from "@connectors/api/resume_connector";
+import { setConnectorPermissionsAPIHandler } from "@connectors/api/set_connector_permissions";
 import { stopConnectorAPIHandler } from "@connectors/api/stop_connector";
 import { syncConnectorAPIHandler } from "@connectors/api/sync_connector";
 import { getConnectorUpdateAPIHandler } from "@connectors/api/update_connector";
@@ -49,6 +50,10 @@ export function startServer(port: number) {
   app.get(
     "/connectors/:connector_id/permissions",
     getConnectorPermissionsAPIHandler
+  );
+  app.post(
+    "/connectors/:connector_id/permissions",
+    setConnectorPermissionsAPIHandler
   );
 
   app.post("/webhooks/:webhook_secret/slack", webhookSlackAPIHandler);

--- a/connectors/src/connectors/slack/lib/channels.ts
+++ b/connectors/src/connectors/slack/lib/channels.ts
@@ -75,18 +75,3 @@ export async function upsertSlackChannelInConnectorsDb({
     permission: channel.permission,
   };
 }
-
-export async function deleteChannelFromConnectorsDb({
-  slackChannelId,
-  connectorId,
-}: {
-  slackChannelId: string;
-  connectorId: number;
-}): Promise<void> {
-  await SlackChannel.destroy({
-    where: {
-      connectorId,
-      slackChannelId,
-    },
-  });
-}

--- a/connectors/src/connectors/slack/temporal/workflows.ts
+++ b/connectors/src/connectors/slack/temporal/workflows.ts
@@ -27,6 +27,7 @@ const {
   reportInitialSyncProgressActivity,
   getChannelsToGarbageCollect,
   deleteChannel,
+  deleteChannelsFromConnectorDb,
 } = proxyActivities<typeof activities>({
   startToCloseTimeout: "10 minutes",
 });
@@ -251,13 +252,15 @@ export async function slackGarbageCollectorWorkflow(
 ): Promise<void> {
   const slackAccessToken = await getAccessToken(nangoConnectionId);
 
-  const channelIds = await getChannelsToGarbageCollect(
-    slackAccessToken,
-    connectorId
-  );
-  for (const channelId of channelIds) {
+  const { channelsToDeleteFromConnectorsDb, channelsToDeleteFromDataSource } =
+    await getChannelsToGarbageCollect(slackAccessToken, connectorId);
+  for (const channelId of channelsToDeleteFromDataSource) {
     await deleteChannel(channelId, dataSourceConfig, connectorId);
   }
+  await deleteChannelsFromConnectorDb(
+    channelsToDeleteFromConnectorsDb,
+    connectorId
+  );
 }
 
 export function workspaceFullSyncWorkflowId(

--- a/front/components/ConnectorPermissionsModal.tsx
+++ b/front/components/ConnectorPermissionsModal.tsx
@@ -1,6 +1,9 @@
-import { DocumentTextIcon } from "@dust-tt/sparkle";
-import { Button, Checkbox } from "@dust-tt/sparkle";
-// import { Button, HighlightButton } from "./Button";
+import {
+  Button,
+  Checkbox,
+  DocumentTextIcon,
+  XCircleStrokeIcon as XCircleIcon,
+} from "@dust-tt/sparkle";
 import { Dialog, Transition } from "@headlessui/react";
 import {
   ChatBubbleLeftRightIcon,
@@ -69,10 +72,12 @@ function PermissionTreeChildren({
   dataSource,
   parentId,
   onPermissionUpdate,
+  canUpdatePermissions,
 }: {
   owner: WorkspaceType;
   dataSource: DataSourceType;
   parentId: string | null;
+  canUpdatePermissions: boolean;
   onPermissionUpdate: ({
     internalId,
     permission,
@@ -103,46 +108,27 @@ function PermissionTreeChildren({
                   <div className="ml-1 flex flex-row items-center py-1 text-base">
                     <IconComponent className="h-6 w-6 text-slate-300" />
                     <span className="ml-2">{`${titlePrefix}${r.title}`}</span>
-                    {/* align the checkbox to the right */}
-                    <div className="flex-grow">
-                      <Checkbox
-                        className="ml-auto"
-                        checked={
-                          localStateByInternalId[r.internalId] ??
-                          ["read", "read_write"].includes(r.permission)
-                        }
-                        onChange={(checked) => {
-                          setLocalStateByInternalId((prev) => ({
-                            ...prev,
-                            [r.internalId]: checked,
-                          }));
-                          onPermissionUpdate({
-                            internalId: r.internalId,
-                            permission: checked ? "read_write" : "write",
-                          });
-                        }}
-                      />
-                    </div>
-                    {/* <Checkbox */}
-                    {/* <input
-                      type="checkbox"
-                      className="ml-auto"
-                      checked={
-                        localStateByInternalId[r.internalId] ??
-                        ["read", "read_write"].includes(r.permission)
-                      }
-                      onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                        const checked = e.target.checked;
-                        setLocalStateByInternalId((prev) => ({
-                          ...prev,
-                          [r.internalId]: checked,
-                        }));
-                        onPermissionUpdate({
-                          internalId: r.internalId,
-                          permission: checked ? "read_write" : "write",
-                        });
-                      }}
-                    /> */}
+                    {canUpdatePermissions ? (
+                      <div className="flex-grow">
+                        <Checkbox
+                          className="ml-auto"
+                          checked={
+                            localStateByInternalId[r.internalId] ??
+                            ["read", "read_write"].includes(r.permission)
+                          }
+                          onChange={(checked) => {
+                            setLocalStateByInternalId((prev) => ({
+                              ...prev,
+                              [r.internalId]: checked,
+                            }));
+                            onPermissionUpdate({
+                              internalId: r.internalId,
+                              permission: checked ? "read_write" : "write",
+                            });
+                          }}
+                        />
+                      </div>
+                    ) : null}
                   </div>
                 </div>
               );
@@ -159,9 +145,11 @@ function PermissionTree({
   owner,
   dataSource,
   onPermissionUpdate,
+  canUpdatePermissions,
 }: {
   owner: WorkspaceType;
   dataSource: DataSourceType;
+  canUpdatePermissions: boolean;
   onPermissionUpdate: ({
     internalId,
     permission,
@@ -176,6 +164,7 @@ function PermissionTree({
         owner={owner}
         dataSource={dataSource}
         parentId={null}
+        canUpdatePermissions={canUpdatePermissions}
         onPermissionUpdate={onPermissionUpdate}
       />
     </div>
@@ -249,7 +238,7 @@ export default function ConnectorPermissionsModal({
 
   return (
     <Transition.Root show={isOpen} as={Fragment}>
-      <Dialog as="div" className="relative z-10" onClose={setOpen}>
+      <Dialog as="div" className="relative z-10" onClose={closeModal}>
         <Transition.Child
           as={Fragment}
           enter="ease-out duration-300"
@@ -298,9 +287,6 @@ export default function ConnectorPermissionsModal({
                           size="xs"
                           icon={Cog6ToothIcon}
                         />
-                        {/* <Cog6ToothIcon className="mr-2 h-3 w-3" />
-                          Re-authorize
-                        </Button> */}
                       </div>
                     </div>
                     <div className="mt-3">
@@ -310,23 +296,19 @@ export default function ConnectorPermissionsModal({
                             onClick={closeModal}
                             label="Cancel"
                             type="secondary"
-                            size="sm"
+                            size="xs"
                           />
                           <Button
                             onClick={save}
                             label="Save"
                             type="primary"
-                            size="sm"
+                            size="xs"
                           />
                         </div>
                       ) : (
-                        <Button
-                          type="primary"
-                          size="xs"
-                          label="Settings"
-                          icon={Cog6ToothIcon}
-                          disabled={false}
-                        />
+                        <div onClick={closeModal} className="cursor-pointer">
+                          <XCircleIcon className="h-6 w-6 text-gray-500" />
+                        </div>
                       )}
                     </div>
                   </div>
@@ -357,6 +339,9 @@ export default function ConnectorPermissionsModal({
                   <PermissionTree
                     owner={owner}
                     dataSource={dataSource}
+                    canUpdatePermissions={PERMISSIONS_EDITABLE_CONNECTOR_TYPES.has(
+                      connector.type
+                    )}
                     onPermissionUpdate={({ internalId, permission }) => {
                       setUpdatedPermissionByInternalId((prev) => ({
                         ...prev,

--- a/front/components/ConnectorPermissionsModal.tsx
+++ b/front/components/ConnectorPermissionsModal.tsx
@@ -263,68 +263,52 @@ export default function ConnectorPermissionsModal({
               leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
             >
               <Dialog.Panel className="relative max-w-2xl transform overflow-hidden rounded-lg bg-white px-4 pb-4 text-left shadow-xl transition-all sm:p-6 lg:w-1/2">
-                <div>
-                  <div className="flex flex-row justify-between">
-                    <div className="mt-3 flex-initial sm:mt-5">
-                      <Dialog.Title
-                        as="h3"
-                        className="text-xl font-semibold leading-6 text-gray-900"
-                      >
-                        {CONNECTOR_TYPE_TO_NAME[connector.type]} permissions
-                      </Dialog.Title>
-                      {synchronizedTimeAgo && (
-                        <span className="text-gray-500">
-                          Last synchronized ~{synchronizedTimeAgo} ago
-                        </span>
-                      )}
-                      <div className="mt-1 flex flex-initial">
-                        <Button
-                          onClick={() => {
-                            onEditPermission();
-                          }}
-                          label="Re-authorize"
-                          type="tertiary"
-                          size="xs"
-                          icon={Cog6ToothIcon}
-                        />
-                      </div>
-                    </div>
-                    <div className="mt-3">
-                      {Object.keys(updatedPermissionByInternalId).length ? (
-                        <div className="flex flex-row gap-1">
-                          <Button
-                            onClick={closeModal}
-                            label="Cancel"
-                            type="secondary"
-                            size="xs"
-                          />
-                          <Button
-                            onClick={save}
-                            label="Save"
-                            type="primary"
-                            size="xs"
-                          />
-                        </div>
-                      ) : (
-                        <div onClick={closeModal} className="cursor-pointer">
-                          <XCircleIcon className="h-6 w-6 text-gray-500" />
-                        </div>
-                      )}
+                <div className="flex items-start justify-between sm:mt-5">
+                  <div>
+                    <Dialog.Title
+                      as="h3"
+                      className="text-xl font-semibold leading-6 text-gray-900"
+                    >
+                      {CONNECTOR_TYPE_TO_NAME[connector.type]} permissions
+                    </Dialog.Title>
+                    {synchronizedTimeAgo && (
+                      <span className="text-gray-500">
+                        Last synchronized ~{synchronizedTimeAgo} ago
+                      </span>
+                    )}
+                    <div className="mt-4">
+                      <Button
+                        onClick={() => {
+                          onEditPermission();
+                        }}
+                        label="Re-authorize"
+                        type="tertiary"
+                        size="xs"
+                        icon={Cog6ToothIcon}
+                      />
                     </div>
                   </div>
-                </div>
-                <div className=" mt-8 flex flex-row">
-                  <span className="ml-2 text-sm text-gray-500">
-                    Automatically include new{" "}
-                    {CONNECTOR_TYPE_TO_RESOURCE_NAME[connector.type]}:
-                  </span>
-                  <div className="flex-grow">
-                    <Checkbox
-                      className="ml-auto cursor-not-allowed"
-                      disabled={true}
-                      checked={true}
-                      onChange={() => null}
-                    />
+                  <div>
+                    {Object.keys(updatedPermissionByInternalId).length ? (
+                      <div className="flex gap-1">
+                        <Button
+                          onClick={closeModal}
+                          label="Cancel"
+                          type="secondary"
+                          size="xs"
+                        />
+                        <Button
+                          onClick={save}
+                          label="Save"
+                          type="primary"
+                          size="xs"
+                        />
+                      </div>
+                    ) : (
+                      <div onClick={closeModal} className="cursor-pointer">
+                        <XCircleIcon className="h-6 w-6 text-gray-500" />
+                      </div>
+                    )}
                   </div>
                 </div>
                 <div>

--- a/front/lib/connectors_api.ts
+++ b/front/lib/connectors_api.ts
@@ -194,6 +194,30 @@ export const ConnectorsAPI = {
     return _resultFromResponse(res);
   },
 
+  async setConnectorPermissions({
+    connectorId,
+    resources,
+  }: {
+    connectorId: string;
+    resources: { internalId: string; permission: ConnectorPermission }[];
+  }): Promise<ConnectorsAPIResponse<void>> {
+    const res = await fetch(
+      `${CONNECTORS_API}/connectors/${connectorId}/permissions`,
+      {
+        method: "POST",
+        headers: getDefaultHeaders(),
+        body: JSON.stringify({
+          resources: resources.map(({ internalId, permission }) => ({
+            internal_id: internalId,
+            permission,
+          })),
+        }),
+      }
+    );
+
+    return _resultFromResponse(res);
+  },
+
   async getConnector(
     connectorId: string
   ): Promise<ConnectorsAPIResponse<ConnectorType>> {


### PR DESCRIPTION
<img width="693" alt="Screenshot 2023-07-27 at 12 30 21" src="https://github.com/dust-tt/dust/assets/14199823/f6293f83-7541-4d22-9978-245fdb489035">
<img width="677" alt="Screenshot 2023-07-27 at 12 30 16" src="https://github.com/dust-tt/dust/assets/14199823/edfffb86-d096-4231-b0f1-756cde145c26">

## What's included

- UI to update per-channel permissions (only for datasources that allow it, i.e Slack only for now)
- GC logic to delete `SlackChannel` objects when a channel is no longer visible
- GC logic to delete content from channels w/o read permissions
- Webhooks logic to skip if channel is not read-permitted
- Endpoints to update permissions for a list of connector resources
- Trigger channel sync / garbage collect based on updated permission
- Exit quickly from channel sync when read permissions are removed


## What's not included

- ability to customize "automatically include new channels". Right now it's true for everyone and read-only.