### PR TITLE
Ensure Unique ConnectionId of a connector & prevent user from changing workspace when updating permissions for Notion. 

### DIFF
--- a/connectors/src/api/update_connector.ts
+++ b/connectors/src/api/update_connector.ts
@@ -1,0 +1,83 @@
+import { Request, Response } from "express";
+
+import { UPDATE_CONNECTOR_BY_TYPE } from "@connectors/connectors";
+import { Connector } from "@connectors/lib/models";
+import { apiError, withLogging } from "@connectors/logger/withlogging";
+import { ConnectorsAPIErrorResponse } from "@connectors/types/errors";
+
+type ConnectorUpdateReqBody = {
+  connectionId: string;
+};
+type ConnectorUpdateResBody =
+  | { connectorId: string }
+  | ConnectorsAPIErrorResponse;
+
+const _getConnectorUpdateAPIHandler = async (
+  req: Request<{ connector_id: string }, ConnectorUpdateReqBody>,
+  res: Response<ConnectorUpdateResBody>
+) => {
+  if (!req.params.connector_id) {
+    return apiError(req, res, {
+      api_error: {
+        type: "invalid_request_error",
+        message: "Missing required parameters. Required: connector_id",
+      },
+      status_code: 400,
+    });
+  }
+
+  if (!req.body.connectionId) {
+    return apiError(req, res, {
+      api_error: {
+        type: "invalid_request_error",
+        message: `Missing required parameters. Required : connectionId`,
+      },
+      status_code: 400,
+    });
+  }
+
+  const connector = await Connector.findByPk(req.params.connector_id);
+  if (!connector) {
+    return apiError(req, res, {
+      api_error: {
+        type: "connector_not_found",
+        message: "Connector not found",
+      },
+      status_code: 404,
+    });
+  }
+
+  const connectorUpdater = UPDATE_CONNECTOR_BY_TYPE[connector.type];
+  const updateRes = await connectorUpdater(connector.id, req.body.connectionId);
+
+  if (updateRes.isErr()) {
+    const errorRes = updateRes as { error: ConnectorsAPIErrorResponse };
+    const error = errorRes.error.error;
+
+    if (error.type === "connector_update_unauthorized") {
+      return apiError(req, res, {
+        api_error: {
+          type: error.type,
+          message: error.message,
+        },
+        status_code: 401,
+      });
+    } else {
+      return apiError(req, res, {
+        api_error: {
+          type: "connector_update_error",
+          message: `Could not update the connector: ${error.message}`,
+        },
+        status_code: 500,
+      });
+    }
+  }
+
+  return res.status(200).json({
+    connectorId: updateRes.value,
+  });
+};
+
+export const getConnectorUpdateAPIHandler = withLogging(
+  _getConnectorUpdateAPIHandler
+);

--- a/connectors/src/api_server.ts
+++ b/connectors/src/api_server.ts
@@ -4,6 +4,7 @@ import express from "express";
 import { createConnectorAPIHandler } from "@connectors/api/create_connector";
 import { deleteConnectorAPIHandler } from "@connectors/api/delete_connector";
 import { getConnectorAPIHandler } from "@connectors/api/get_connector";
+import { getConnectorPermissionsAPIHandler } from "@connectors/api/get_connector_permissions";
 import {
   googleDriveGetFoldersAPIHandler,
   googleDriveSetFoldersAPIHandler,
@@ -11,13 +12,12 @@ import {
 import { resumeConnectorAPIHandler } from "@connectors/api/resume_connector";
 import { stopConnectorAPIHandler } from "@connectors/api/stop_connector";
 import { syncConnectorAPIHandler } from "@connectors/api/sync_connector";
+import { getConnectorUpdateAPIHandler } from "@connectors/api/update_connector";
 import { webhookGithubAPIHandler } from "@connectors/api/webhooks/webhook_github";
 import { webhookGoogleDriveAPIHandler } from "@connectors/api/webhooks/webhook_google_drive";
 import { webhookSlackAPIHandler } from "@connectors/api/webhooks/webhook_slack";
 import logger from "@connectors/logger/logger";
 import { authMiddleware } from "@connectors/middleware/auth";
-
-import { getConnectorPermissionsAPIHandler } from "./api/get_connector_permissions";
 
 export function startServer(port: number) {
   const app = express();
@@ -40,6 +40,7 @@ export function startServer(port: number) {
   app.use(authMiddleware);
 
   app.post("/connectors/create/:connector_provider", createConnectorAPIHandler);
+  app.post("/connectors/update/:connector_id/", getConnectorUpdateAPIHandler);
   app.post("/connectors/stop/:connector_id", stopConnectorAPIHandler);
   app.post("/connectors/resume/:connector_id", resumeConnectorAPIHandler);
   app.delete("/connectors/delete/:connector_id", deleteConnectorAPIHandler);

--- a/connectors/src/connectors/index.ts
+++ b/connectors/src/connectors/index.ts
@@ -21,6 +21,7 @@ import {
   resumeNotionConnector,
   retrieveNotionConnectorPermissions,
   stopNotionConnector,
+  updateNotionConnector,
 } from "@connectors/connectors/notion";
 import {
   cleanupSlackConnector,
@@ -34,6 +35,7 @@ import { Err, Ok, Result } from "@connectors/lib/result";
 import logger from "@connectors/logger/logger";
 import { ConnectorProvider } from "@connectors/types/connector";
 import { DataSourceConfig } from "@connectors/types/data_source_config";
+import { ConnectorsAPIErrorResponse } from "@connectors/types/errors";
 import {
   ConnectorPermission,
   ConnectorResource,
@@ -52,6 +54,27 @@ export const CREATE_CONNECTOR_BY_TYPE: Record<
   notion: createNotionConnector,
   github: createGithubConnector,
   google_drive: createGoogleDriveConnector,
+};
+
+type ConnectorUpdater = (
+  connectorId: ModelId,
+  connectionId: string
+) => Promise<Result<string, ConnectorsAPIErrorResponse>>;
+
+export const UPDATE_CONNECTOR_BY_TYPE: Record<
+  ConnectorProvider,
+  ConnectorUpdater
+> = {
+  slack: async (connectorId: ModelId) => {
+    throw new Error(`Not implemented ${connectorId}`);
+  },
+  notion: updateNotionConnector,
+  github: async (connectorId: ModelId) => {
+    throw new Error(`Not implemented ${connectorId}`);
+  },
+  google_drive: async (connectorId: ModelId) => {
+    throw new Error(`Not implemented ${connectorId}`);
+  },
 };
 
 type ConnectorStopper = (connectorId: string) => Promise<Result<string, Error>>;

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -18,6 +18,7 @@ import { nango_client } from "@connectors/lib/nango_client";
 import { Err, Ok, Result } from "@connectors/lib/result";
 import mainLogger from "@connectors/logger/logger";
 import { DataSourceConfig } from "@connectors/types/data_source_config";
+import { ConnectorsAPIErrorResponse } from "@connectors/types/errors";
 import { NangoConnectionId } from "@connectors/types/nango_connection_id";
 import {
   ConnectorPermission,
@@ -73,6 +74,67 @@ export async function createNotionConnector(
     await transaction.rollback();
     return new Err(e as Error);
   }
+}
+
+export async function updateNotionConnector(
+  connectorId: ModelId,
+  connectionId: string
+): Promise<Result<string, ConnectorsAPIErrorResponse>> {
+  if (!NANGO_NOTION_CONNECTOR_ID) {
+    throw new Error("NANGO_NOTION_CONNECTOR_ID not set");
+  }
+
+  const c = await Connector.findOne({
+    where: {
+      id: connectorId,
+    },
+  });
+  if (!c) {
+    logger.error({ connectorId }, "Connector not found");
+    return new Err({
+      error: {
+        message: "Connector not found",
+        type: "connector_not_found",
+      },
+    } as ConnectorsAPIErrorResponse);
+  }
+
+  const connectionRes = await nango_client().getConnection(
+    NANGO_NOTION_CONNECTOR_ID,
+    c.connectionId,
+    false,
+    false
+  );
+  const newConnectionRes = await nango_client().getConnection(
+    NANGO_NOTION_CONNECTOR_ID,
+    connectionId,
+    false,
+    false
+  );
+
+  const workspaceId = connectionRes?.credentials?.raw?.workspace_id || null;
+  const newWorkspaceId =
+    newConnectionRes?.credentials?.raw?.workspace_id || null;
+
+  if (!workspaceId || !newWorkspaceId) {
+    return new Err({
+      error: {
+        type: "connector_update_error",
+        message: "Error retrieving nango connection info to update connector",
+      },
+    } as ConnectorsAPIErrorResponse);
+  }
+  if (workspaceId !== newWorkspaceId) {
+    return new Err({
+      error: {
+        type: "connector_update_unauthorized",
+        message: "Cannot change workspace of a Notion connector",
+      },
+    } as ConnectorsAPIErrorResponse);
+  }
+
+  await c.update({ connectionId });
+  return new Ok(c.id.toString());
 }
 
 export async function stopNotionConnector(

--- a/connectors/src/lib/error.ts
+++ b/connectors/src/lib/error.ts
@@ -4,6 +4,8 @@ export type APIErrorType =
   | "invalid_request_error"
   | "connector_not_found"
   | "connector_configuration_not_found"
+  | "connector_update_error"
+  | "connector_update_unauthorized"
   | "not_found";
 
 export type APIError = {

--- a/connectors/src/types/errors.ts
+++ b/connectors/src/types/errors.ts
@@ -1,5 +1,6 @@
 export type ConnectorsAPIErrorResponse = {
   error: {
     message: string;
+    type?: string;
   };
 };

--- a/front/lib/connector_connection_id.ts
+++ b/front/lib/connector_connection_id.ts
@@ -1,0 +1,16 @@
+import { ConnectorProvider } from "@app/lib/connectors_api";
+import { client_side_new_id } from "@app/lib/utils";
+
+export function buildConnectionId(
+  wId: string,
+  provider: ConnectorProvider,
+  suffix: string | null
+): string {
+  let connectionName = `${provider}-${wId}`;
+  if (suffix) {
+    connectionName += `-${suffix}`;
+  }
+  const uId = client_side_new_id();
+  connectionName += `-${uId.slice(0, 10)}`;
+  return connectionName;
+}

--- a/front/lib/connectors_api.ts
+++ b/front/lib/connectors_api.ts
@@ -260,10 +260,9 @@ async function _resultFromResponse<T>(
       logger.error({ jsonError }, "Unexpected response from ConnectorAPI");
       return new Err(jsonError);
     } else {
+      const textError = await response.text();
       try {
-        const textError = await response.text();
         const errorResponse = JSON.parse(textError);
-
         const errorMessage = errorResponse?.error?.message;
         const errorType = errorResponse?.error?.type;
 
@@ -279,7 +278,11 @@ async function _resultFromResponse<T>(
         });
       } catch (error) {
         logger.error(
-          { statusCode: response.status, statusText: response.statusText },
+          {
+            statusCode: response.status,
+            error,
+            textError,
+          },
           "Unexpected response from ConnectorAPI"
         );
         return new Err({

--- a/front/lib/connectors_api.ts
+++ b/front/lib/connectors_api.ts
@@ -263,11 +263,24 @@ async function _resultFromResponse<T>(
       try {
         const textError = await response.text();
         const errorResponse = JSON.parse(textError);
+
+        const errorMessage = errorResponse?.error?.message;
+        const errorType = errorResponse?.error?.type;
+
+        if (typeof errorMessage !== "string" || typeof errorType !== "string") {
+          throw new Error("Unexpected response from ConnectorAPI");
+        }
+
         logger.error(
           { errorResponse },
           "Unexpected response from ConnectorAPI"
         );
-        return new Err(errorResponse);
+        return new Err({
+          error: {
+            message: errorMessage,
+            type: errorType,
+          },
+        });
       } catch (error) {
         logger.error(
           { statusCode: response.status, statusText: response.statusText },

--- a/front/lib/connectors_api.ts
+++ b/front/lib/connectors_api.ts
@@ -271,10 +271,6 @@ async function _resultFromResponse<T>(
           throw new Error("Unexpected response from ConnectorAPI");
         }
 
-        logger.error(
-          { errorResponse },
-          "Unexpected response from ConnectorAPI"
-        );
         return new Err({
           error: {
             message: errorMessage,

--- a/front/lib/error.ts
+++ b/front/lib/error.ts
@@ -38,7 +38,9 @@ export type APIErrorType =
   | "template_not_found"
   | "chat_message_not_found"
   | "event_schema_not_found"
-  | "extracted_event_not_found";
+  | "extracted_event_not_found"
+  | "connector_update_error"
+  | "connector_update_unauthorized";
 
 export type APIError = {
   type: APIErrorType;

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/update.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/update.ts
@@ -1,0 +1,114 @@
+import { NextApiRequest, NextApiResponse } from "next";
+
+import { getDataSource } from "@app/lib/api/data_sources";
+import { Authenticator, getSession } from "@app/lib/auth";
+import {
+  ConnectorsAPI,
+  ConnectorsAPIErrorResponse,
+} from "@app/lib/connectors_api";
+import { ReturnedAPIErrorType } from "@app/lib/error";
+import { apiError, withLogging } from "@app/logger/withlogging";
+
+export type GetDataSourceUpdateResponseBody = {
+  connectorId: string;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    GetDataSourceUpdateResponseBody | ReturnedAPIErrorType | void
+  >
+): Promise<void> {
+  const session = await getSession(req, res);
+  const auth = await Authenticator.fromSession(
+    session,
+    req.query.wId as string
+  );
+
+  const owner = auth.workspace();
+  if (!owner) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "data_source_not_found",
+        message: "The data source you requested was not found.",
+      },
+    });
+  }
+
+  const dataSource = await getDataSource(auth, req.query.name as string);
+  if (!dataSource) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "data_source_not_found",
+        message: "The data source you requested was not found.",
+      },
+    });
+  }
+
+  if (!dataSource.connectorId) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "data_source_not_managed",
+        message: "The data source you requested is not managed.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "POST":
+      if (!req.body || !(typeof req.body.connectionId == "string")) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              "The request body is invalid, expects { connectionId: string }.",
+          },
+        });
+      }
+
+      const updateRes = await ConnectorsAPI.updateConnector({
+        connectorId: dataSource.connectorId.toString(),
+        connectionId: req.body.connectionId,
+      });
+
+      if (updateRes.isErr()) {
+        const errorRes = updateRes as { error: ConnectorsAPIErrorResponse };
+        const error = errorRes.error.error;
+
+        if (error.type === "connector_update_unauthorized") {
+          return apiError(req, res, {
+            api_error: {
+              type: error.type,
+              message: error.message,
+            },
+            status_code: 401,
+          });
+        } else {
+          return apiError(req, res, {
+            api_error: {
+              type: "connector_update_error",
+              message: `Could not update the connector: ${error.message}`,
+            },
+            status_code: 500,
+          });
+        }
+      }
+      res.status(200).json(updateRes.value);
+      return;
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withLogging(handler);

--- a/front/pages/w/[wId]/ds/index.tsx
+++ b/front/pages/w/[wId]/ds/index.tsx
@@ -11,6 +11,7 @@ import { subNavigationAdmin } from "@app/components/sparkle/navigation";
 import { getDataSources } from "@app/lib/api/data_sources";
 import { setUserMetadata } from "@app/lib/api/user";
 import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
+import { buildConnectionId } from "@app/lib/connector_connection_id";
 import {
   connectorIsUsingNango,
   ConnectorProvider,
@@ -282,14 +283,11 @@ export default function DataSourcesView({
           google_drive: nangoConfig.googleDriveConnectorId,
         }[provider];
         const nango = new Nango({ publicKey: nangoConfig.publicKey });
+        const newConnectionId = buildConnectionId(owner.sId, provider, suffix);
         const {
           connectionId: nangoConnectionId,
-        }: { providerConfigKey: string; connectionId: string } = suffix
-          ? await nango.auth(
-              nangoConnectorId,
-              `${provider}-${owner.sId}-${suffix}`
-            )
-          : await nango.auth(nangoConnectorId, `${provider}-${owner.sId}`);
+        }: { providerConfigKey: string; connectionId: string } =
+          await nango.auth(nangoConnectorId, newConnectionId);
         connectionId = nangoConnectionId;
       } else if (provider === "github") {
         const installationId = await githubAuth(githubAppUrl);


### PR DESCRIPTION
- Ensure Unique ConnectionId of a connector.
- Prevent user from changing workspace when updating permissions for Notion. 


Note: This PR is a subset of https://github.com/dust-tt/dust/pull/968 that I decided to close. 
-> I decided to extract only the udpateConnector logic because I un-convinced myself of the usefulness of the getAuthInfo logic. 

Next steps: 
- Prevent for other connectors than Notion
- Block it in the Nango UI for connectors that support it. 