### PR TITLE
Prevent Slack update permission to change Team Id

### DIFF
--- a/connectors/src/connectors/index.ts
+++ b/connectors/src/connectors/index.ts
@@ -28,6 +28,7 @@ import {
   createSlackConnector,
   retrieveSlackConnectorPermissions,
   setSlackConnectorPermissions,
+  updateSlackConnector,
 } from "@connectors/connectors/slack";
 import { launchSlackSyncWorkflow } from "@connectors/connectors/slack/temporal/client";
 import { ModelId } from "@connectors/lib/models";
@@ -65,9 +66,7 @@ export const UPDATE_CONNECTOR_BY_TYPE: Record<
   ConnectorProvider,
   ConnectorUpdater
 > = {
-  slack: async (connectorId: ModelId) => {
-    throw new Error(`Not implemented ${connectorId}`);
-  },
+  slack: updateSlackConnector,
   notion: updateNotionConnector,
   github: async (connectorId: ModelId) => {
     throw new Error(`Not implemented ${connectorId}`);

--- a/front/pages/w/[wId]/ds/[name]/settings.tsx
+++ b/front/pages/w/[wId]/ds/[name]/settings.tsx
@@ -618,21 +618,28 @@ function ManagedDataSourceSettings({
       return { success: true, error: null };
     }
 
-    let errorMessage =
-      "Failed to update the permissions of the Data Source (contact team@dust.tt for assistance)";
-
     const jsonErr = await res.json();
     const error = jsonErr.error;
 
-    if (
-      error.type === "connector_update_unauthorized" &&
-      provider === "notion"
-    ) {
-      errorMessage =
-        "Failed to update the permissions of the Data Source: You cannot select another Notion workspace.\nPlease contact us at team@dust.tt if you initially selected a wrong workspace.";
+    if (error.type === "connector_update_unauthorized") {
+      if (provider === "slack") {
+        return {
+          success: false,
+          error: `You cannot select another Slack Team.\nPlease contact us at team@dust.tt if you initially selected the wrong Team.`,
+        };
+      }
+      if (provider === "notion") {
+        return {
+          success: false,
+          error:
+            "You cannot select another Notion Workspace.\nPlease contact us at team@dust.tt if you initially selected a wrong Workspace.",
+        };
+      }
     }
-
-    return { success: false, error: errorMessage };
+    return {
+      success: false,
+      error: `Failed to update the permissions of the Data Source: (contact team@dust.tt for assistance)`,
+    };
   };
 
   return (


### PR DESCRIPTION
Following: https://github.com/dust-tt/dust/pull/989
Prevents users from selecting another Team when updating permissions of a Slack datasource. 

Not: non tested, I don't have the SlackBot on my local yet 🙈 