### PR TITLE
Remove suffix on ConnectionId

### DIFF
--- a/front/lib/connector_connection_id.ts
+++ b/front/lib/connector_connection_id.ts
@@ -3,13 +3,9 @@ import { client_side_new_id } from "@app/lib/utils";
 
 export function buildConnectionId(
   wId: string,
-  provider: ConnectorProvider,
-  suffix: string | null
+  provider: ConnectorProvider
 ): string {
   let connectionName = `${provider}-${wId}`;
-  if (suffix) {
-    connectionName += `-${suffix}`;
-  }
   const uId = client_side_new_id();
   connectionName += `-${uId.slice(0, 10)}`;
   return connectionName;

--- a/front/pages/w/[wId]/ds/[name]/settings.tsx
+++ b/front/pages/w/[wId]/ds/[name]/settings.tsx
@@ -554,7 +554,6 @@ function ManagedDataSourceSettings({
 
   const { total } = useDocuments(owner, dataSource, 0, 0);
 
-  // @todo: When updating a permission we lost a potential suffix on the connectionId name. Fix it?
   const handleUpdatePermissions = async () => {
     if (!canUpdatePermissions) {
       window.alert(
@@ -578,7 +577,7 @@ function ManagedDataSourceSettings({
 
       const nango = new Nango({ publicKey: nangoConfig.publicKey });
 
-      const newConnectionId = buildConnectionId(owner.sId, provider, null);
+      const newConnectionId = buildConnectionId(owner.sId, provider);
       await nango.auth(nangoConnectorId, newConnectionId);
 
       const updateRes = await updateConnectorConnectionId(

--- a/front/pages/w/[wId]/ds/index.tsx
+++ b/front/pages/w/[wId]/ds/index.tsx
@@ -283,7 +283,7 @@ export default function DataSourcesView({
           google_drive: nangoConfig.googleDriveConnectorId,
         }[provider];
         const nango = new Nango({ publicKey: nangoConfig.publicKey });
-        const newConnectionId = buildConnectionId(owner.sId, provider, suffix);
+        const newConnectionId = buildConnectionId(owner.sId, provider);
         const {
           connectionId: nangoConnectionId,
         }: { providerConfigKey: string; connectionId: string } =


### PR DESCRIPTION
Following https://github.com/dust-tt/dust/pull/989
We don't need anymore a suffix in the connectionId as it's now unique anyway. 