### PR TITLE
Prevent Github update permissions to change Organization

### DIFF
--- a/connectors/src/connectors/index.ts
+++ b/connectors/src/connectors/index.ts
@@ -7,6 +7,7 @@ import {
   resumeGithubConnector,
   retrieveGithubConnectorPermissions,
   stopGithubConnector,
+  updateGithubConnector,
 } from "@connectors/connectors/github";
 import {
   cleanupGoogleDriveConnector,
@@ -68,9 +69,7 @@ export const UPDATE_CONNECTOR_BY_TYPE: Record<
 > = {
   slack: updateSlackConnector,
   notion: updateNotionConnector,
-  github: async (connectorId: ModelId) => {
-    throw new Error(`Not implemented ${connectorId}`);
-  },
+  github: updateGithubConnector,
   google_drive: async (connectorId: ModelId) => {
     throw new Error(`Not implemented ${connectorId}`);
   },

--- a/front/lib/github_auth.ts
+++ b/front/lib/github_auth.ts
@@ -6,7 +6,7 @@ export async function githubAuth(githubAppUrl: string): Promise<string> {
     const popupMessageEventListener = (event: MessageEvent) => {
       if (event.origin !== window.location.origin) return;
 
-      if (event.data.type === "installed") {
+      if (event.data.type === "installed_or_updated") {
         authComplete = true;
         resolve(event.data.installationId);
         window.removeEventListener("message", popupMessageEventListener);

--- a/front/pages/github-callback.ts
+++ b/front/pages/github-callback.ts
@@ -14,7 +14,7 @@ export default function Complete() {
     window.opener &&
       window.opener.postMessage(
         {
-          type: "installed",
+          type: "installed_or_updated",
           installationId: queryString["installation_id"],
         },
         window.location.origin

--- a/front/pages/w/[wId]/ds/[name]/settings.tsx
+++ b/front/pages/w/[wId]/ds/[name]/settings.tsx
@@ -592,9 +592,23 @@ function ManagedDataSourceSettings({
         setGoogleDrivePickerOpen(true);
       }
     } else if (provider === "github") {
-      await githubAuth(githubAppUrl).catch((e) => {
+      const installationId = await githubAuth(githubAppUrl).catch((e) => {
         console.error(e);
       });
+
+      if (!installationId) {
+        window.alert(
+          "Failed to update the Github permissions. Please contact-us at team@dust.tt"
+        );
+      } else {
+        const updateRes = await updateConnectorConnectionId(
+          installationId,
+          provider
+        );
+        if (updateRes.error) {
+          window.alert(updateRes.error);
+        }
+      }
     }
   };
 
@@ -632,6 +646,13 @@ function ManagedDataSourceSettings({
           success: false,
           error:
             "You cannot select another Notion Workspace.\nPlease contact us at team@dust.tt if you initially selected a wrong Workspace.",
+        };
+      }
+      if (provider === "github") {
+        return {
+          success: false,
+          error:
+            "You cannot select another Github Organization.\nPlease contact us at team@dust.tt if you initially selected a wrong Organization.",
         };
       }
     }


### PR DESCRIPTION
Preventing users to select another Github or when they try to update the permissions of a Github managed datasource. 
Following https://github.com/dust-tt/dust/pull/989