### PR TITLE
Env var to filter default log level for front & connector

### DIFF
--- a/connectors/src/logger/logger.ts
+++ b/connectors/src/logger/logger.ts
@@ -1,6 +1,7 @@
 import pino, { LoggerOptions } from "pino";
 
 const NODE_ENV = process.env.NODE_ENV;
+const LOG_LEVEL = process.env.LOG_LEVEL || "info";
 const defaultPinoOptions: LoggerOptions = {
   serializers: {
     error: pino.stdSerializers.err,
@@ -10,6 +11,7 @@ const defaultPinoOptions: LoggerOptions = {
       return { level };
     },
   },
+  level: LOG_LEVEL,
 };
 
 const devOptions = {

--- a/front/logger/logger.ts
+++ b/front/logger/logger.ts
@@ -1,6 +1,8 @@
 import pino, { LoggerOptions } from "pino";
 
 const NODE_ENV = process.env.NODE_ENV;
+const LOG_LEVEL = process.env.LOG_LEVEL || "info";
+
 const defaultPinoOptions: LoggerOptions = {
   serializers: {
     error: pino.stdSerializers.err,
@@ -10,6 +12,7 @@ const defaultPinoOptions: LoggerOptions = {
       return { level };
     },
   },
+  level: LOG_LEVEL,
 };
 
 const devOptions = {


### PR DESCRIPTION
Allow setting the default filter of logs' level to > info if we want to. 
There are a lot of info logs in connectors that I sometimes don't care about 🙇🏻‍♀️ 