### PR TITLE
feat: upsert context + skip doc tracker if sync_type is `batch`

### DIFF
--- a/connectors/src/connectors/github/temporal/activities.ts
+++ b/connectors/src/connectors/github/temporal/activities.ts
@@ -133,17 +133,17 @@ export async function githubUpsertIssueActivity(
     tags.push(`author:${issueAuthor}`);
   }
   // TODO: last commentor, last comment date, issue labels (as tags)
-  await upsertToDatasource(
+  await upsertToDatasource({
     dataSourceConfig,
     documentId,
-    renderedIssue,
-    issue.url,
-    issue.createdAt.getTime(),
-    tags,
-    3,
-    500,
-    { ...loggerArgs, provider: "github" }
-  );
+    documentText: renderedIssue,
+    documentUrl: issue.url,
+    timestampMs: issue.createdAt.getTime(),
+    tags: tags,
+    retries: 3,
+    delayBetweenRetriesMs: 500,
+    loggerArgs: { ...loggerArgs, provider: "github" },
+  });
 
   const connector = await Connector.findOne({
     where: {
@@ -255,17 +255,17 @@ export async function githubUpsertDiscussionActivity(
     `lasUpdatedAt:${new Date(discussion.updatedAt).getTime()}`,
   ];
 
-  await upsertToDatasource(
+  await upsertToDatasource({
     dataSourceConfig,
     documentId,
-    renderedDiscussion,
-    discussion.url,
-    new Date(discussion.createdAt).getTime(),
+    documentText: renderedDiscussion,
+    documentUrl: discussion.url,
+    timestampMs: new Date(discussion.createdAt).getTime(),
     tags,
-    3,
-    500,
-    { ...loggerArgs, provider: "github" }
-  );
+    retries: 3,
+    delayBetweenRetriesMs: 500,
+    loggerArgs: { ...loggerArgs, provider: "github" },
+  });
 
   const connector = await Connector.findOne({
     where: {

--- a/connectors/src/connectors/github/temporal/activities.ts
+++ b/connectors/src/connectors/github/temporal/activities.ts
@@ -85,7 +85,8 @@ export async function githubUpsertIssueActivity(
   login: string,
   issueNumber: number,
   dataSourceConfig: DataSourceConfig,
-  loggerArgs: Record<string, string | number>
+  loggerArgs: Record<string, string | number>,
+  isBatchSync = false
 ) {
   const localLogger = logger.child({
     ...loggerArgs,
@@ -143,6 +144,9 @@ export async function githubUpsertIssueActivity(
     retries: 3,
     delayBetweenRetriesMs: 500,
     loggerArgs: { ...loggerArgs, provider: "github" },
+    upsertContext: {
+      sync_type: isBatchSync ? "batch" : "incremental",
+    },
   });
 
   const connector = await Connector.findOne({
@@ -181,7 +185,8 @@ export async function githubUpsertDiscussionActivity(
   login: string,
   discussionNumber: number,
   dataSourceConfig: DataSourceConfig,
-  loggerArgs: Record<string, string | number>
+  loggerArgs: Record<string, string | number>,
+  isBatchSync: boolean
 ) {
   const localLogger = logger.child({
     ...loggerArgs,
@@ -265,6 +270,9 @@ export async function githubUpsertDiscussionActivity(
     retries: 3,
     delayBetweenRetriesMs: 500,
     loggerArgs: { ...loggerArgs, provider: "github" },
+    upsertContext: {
+      sync_type: isBatchSync ? "batch" : "incremental",
+    },
   });
 
   const connector = await Connector.findOne({

--- a/connectors/src/connectors/github/temporal/workflows.ts
+++ b/connectors/src/connectors/github/temporal/workflows.ts
@@ -172,7 +172,8 @@ export async function githubRepoSyncWorkflow(
             repoLogin,
             issueNumber,
             dataSourceConfig,
-            loggerArgs
+            loggerArgs,
+            true // isBatchSync
           )
         )
       );
@@ -199,7 +200,8 @@ export async function githubRepoSyncWorkflow(
             repoLogin,
             discussionNumber,
             dataSourceConfig,
-            loggerArgs
+            loggerArgs,
+            true // isBatchSync
           )
         )
       );
@@ -295,7 +297,8 @@ export async function githubDiscussionSyncWorkflow(
       repoLogin,
       discussionNumber,
       dataSourceConfig,
-      { ...loggerArgs, debounceCount }
+      { ...loggerArgs, debounceCount },
+      false // isBatchSync
     );
 
     await githubSaveSuccessSyncActivity(dataSourceConfig);

--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -315,14 +315,14 @@ async function syncOneFile(
   });
 
   if (documentContent.length <= MAX_DOCUMENT_TXT_LEN) {
-    await upsertToDatasource(
+    await upsertToDatasource({
       dataSourceConfig,
       documentId,
-      documentContent,
-      file.webViewLink,
-      file.updatedAtMs,
-      tags
-    );
+      documentText: documentContent,
+      documentUrl: file.webViewLink,
+      timestampMs: file.updatedAtMs,
+      tags,
+    });
   } else {
     logger.info(
       {

--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -217,7 +217,8 @@ export async function syncFiles(
             connectorId,
             authCredentials,
             dataSourceConfig,
-            file
+            file,
+            true // isBatchSync
           );
         }
       });
@@ -234,7 +235,8 @@ async function syncOneFile(
   connectorId: ModelId,
   oauth2client: OAuth2Client,
   dataSourceConfig: DataSourceConfig,
-  file: GoogleDriveFileType
+  file: GoogleDriveFileType,
+  isBatchSync = false
 ) {
   let documentContent: string | undefined = undefined;
   if (MIME_TYPES_TO_EXPORT[file.mimeType]) {
@@ -322,6 +324,9 @@ async function syncOneFile(
       documentUrl: file.webViewLink,
       timestampMs: file.updatedAtMs,
       tags,
+      upsertContext: {
+        sync_type: isBatchSync ? "batch" : "incremental",
+      },
     });
   } else {
     logger.info(

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -209,7 +209,8 @@ export async function notionUpsertPageActivity(
   pageId: string,
   dataSourceConfig: DataSourceConfig,
   runTimestamp: number,
-  loggerArgs: Record<string, string | number>
+  loggerArgs: Record<string, string | number>,
+  isFullSync: boolean
 ) {
   const localLogger = logger.child({ ...loggerArgs, pageId });
 
@@ -268,6 +269,9 @@ export async function notionUpsertPageActivity(
       retries: 3,
       delayBetweenRetriesMs: 500,
       loggerArgs,
+      upsertContext: {
+        sync_type: isFullSync ? "batch" : "incremental",
+      },
     });
   } else {
     localLogger.info("Skipping page without body");

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -258,17 +258,17 @@ export async function notionUpsertPageActivity(
   if (parsedPage && parsedPage.hasBody) {
     upsertTs = new Date().getTime();
     const documentId = `notion-${parsedPage.id}`;
-    await upsertToDatasource(
+    await upsertToDatasource({
       dataSourceConfig,
       documentId,
-      parsedPage.rendered,
-      parsedPage.url,
-      parsedPage.updatedTime,
-      getTagsForPage(parsedPage),
-      3,
-      500,
-      loggerArgs
-    );
+      documentText: parsedPage.rendered,
+      documentUrl: parsedPage.url,
+      timestampMs: parsedPage.updatedTime,
+      tags: getTagsForPage(parsedPage),
+      retries: 3,
+      delayBetweenRetriesMs: 500,
+      loggerArgs,
+    });
   } else {
     localLogger.info("Skipping page without body");
   }

--- a/connectors/src/connectors/notion/temporal/workflows.ts
+++ b/connectors/src/connectors/notion/temporal/workflows.ts
@@ -166,6 +166,7 @@ export async function notionSyncWorkflow(
                   notionAccessToken,
                   batch,
                   runTimestamp,
+                  isInitialSync || forceResync || isGargageCollectionRun,
                 ],
                 parentClosePolicy:
                   ParentClosePolicy.PARENT_CLOSE_POLICY_TERMINATE,
@@ -251,7 +252,8 @@ export async function notionSyncResultPageWorkflow(
   dataSourceConfig: DataSourceConfig,
   notionAccessToken: string,
   pageIds: string[],
-  runTimestamp: number
+  runTimestamp: number,
+  isBatchSync = false
 ) {
   const upsertQueue = new PQueue({
     concurrency: MAX_PENDING_UPSERT_ACTIVITIES,
@@ -272,7 +274,8 @@ export async function notionSyncResultPageWorkflow(
           pageId,
           dataSourceConfig,
           runTimestamp,
-          loggerArgs
+          loggerArgs,
+          isBatchSync
         )
       )
     );

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -305,7 +305,8 @@ export async function syncMultipleNoNThreaded(
         channelName,
         startTsMs,
         getWeekEnd(new Date(startTsMs)).getTime(),
-        connectorId
+        connectorId,
+        true // isBatchSync
       )
     );
     promises.push(p);
@@ -320,7 +321,8 @@ export async function syncNonThreaded(
   channelName: string,
   startTsMs: number,
   endTsMs: number,
-  connectorId: string
+  connectorId: string,
+  isBatchSync = false
 ) {
   const client = getSlackClient(slackAccessToken);
   const nextCursor: string | undefined = undefined;
@@ -410,6 +412,9 @@ export async function syncNonThreaded(
     documentUrl: sourceUrl,
     timestampMs: createdAt,
     tags,
+    upsertContext: {
+      sync_type: isBatchSync ? "batch" : "incremental",
+    },
   });
 }
 
@@ -460,7 +465,8 @@ export async function syncThreads(
         channelId,
         channelName,
         threadTs,
-        connectorId
+        connectorId,
+        true // isBatchSync
       );
     });
     promises.push(p);
@@ -474,7 +480,8 @@ export async function syncThread(
   channelId: string,
   channelName: string,
   threadTs: string,
-  connectorId: string
+  connectorId: string,
+  isBatchSync = false
 ) {
   const client = getSlackClient(slackAccessToken);
 
@@ -551,6 +558,9 @@ export async function syncThread(
     documentUrl: sourceUrl,
     timestampMs: createdAt,
     tags,
+    upsertContext: {
+      sync_type: isBatchSync ? "batch" : "incremental",
+    },
   });
 }
 

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -403,14 +403,14 @@ export async function syncNonThreaded(
     messageTs: undefined,
     documentId: documentId,
   });
-  await upsertToDatasource(
+  await upsertToDatasource({
     dataSourceConfig,
     documentId,
-    text,
-    sourceUrl,
-    createdAt,
-    tags
-  );
+    documentText: text,
+    documentUrl: sourceUrl,
+    timestampMs: createdAt,
+    tags,
+  });
 }
 
 export async function syncThreads(
@@ -544,14 +544,14 @@ export async function syncThread(
     messageTs: threadTs,
     documentId: documentId,
   });
-  await upsertToDatasource(
+  await upsertToDatasource({
     dataSourceConfig,
     documentId,
-    text,
-    sourceUrl,
-    createdAt,
-    tags
-  );
+    documentText: text,
+    documentUrl: sourceUrl,
+    timestampMs: createdAt,
+    tags,
+  });
 }
 
 async function processMessageForMentions(

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -14,7 +14,7 @@ if (!FRONT_API) {
 export const MAX_DOCUMENT_TXT_LEN = 750000;
 
 type UpsertContext = {
-  sync_type?: "full" | "incremental";
+  sync_type: "batch" | "incremental";
 };
 
 type UpsertToDataSourceParams = {
@@ -25,7 +25,7 @@ type UpsertToDataSourceParams = {
   timestampMs?: number;
   tags?: string[];
   loggerArgs?: Record<string, string | number>;
-  upsertContext?: UpsertContext;
+  upsertContext: UpsertContext;
 };
 
 type UpsertToDataSourceRetryOptions = {
@@ -72,7 +72,7 @@ async function _upsertToDatasource({
   timestampMs,
   tags,
   loggerArgs = {},
-  upsertContext = {},
+  upsertContext,
 }: UpsertToDataSourceParams) {
   const localLogger = logger.child({
     ...loggerArgs,

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -13,32 +13,38 @@ if (!FRONT_API) {
 // and large files are generally less useful anyway.
 export const MAX_DOCUMENT_TXT_LEN = 750000;
 
-export async function upsertToDatasource(
-  dataSourceConfig: DataSourceConfig,
-  documentId: string,
-  documentText: string,
-  documentUrl?: string,
-  timestampMs?: number,
-  tags?: string[],
+type UpsertContext = {
+  sync_type?: "full" | "incremental";
+};
+
+type UpsertToDataSourceParams = {
+  dataSourceConfig: DataSourceConfig;
+  documentId: string;
+  documentText: string;
+  documentUrl?: string;
+  timestampMs?: number;
+  tags?: string[];
+  loggerArgs?: Record<string, string | number>;
+  upsertContext?: UpsertContext;
+};
+
+type UpsertToDataSourceRetryOptions = {
+  retries?: number;
+  delayBetweenRetriesMs?: number;
+};
+
+export async function upsertToDatasource({
   retries = 10,
-  delayBetweenRetriesMs = 500,
-  loggerArgs: Record<string, string | number> = {}
-) {
+  delayBetweenRetriesMs = 1000,
+  ...params
+}: UpsertToDataSourceParams & UpsertToDataSourceRetryOptions) {
   if (retries < 1) {
     throw new Error("retries must be >= 1");
   }
   const errors = [];
   for (let i = 0; i < retries; i++) {
     try {
-      return await _upsertToDatasource(
-        dataSourceConfig,
-        documentId,
-        documentText,
-        documentUrl,
-        timestampMs,
-        tags,
-        loggerArgs
-      );
+      return await _upsertToDatasource(params);
     } catch (e) {
       const sleepTime = delayBetweenRetriesMs * (i + 1) ** 2;
       logger.warn(
@@ -58,15 +64,16 @@ export async function upsertToDatasource(
   throw new Error(errors.join("\n"));
 }
 
-async function _upsertToDatasource(
-  dataSourceConfig: DataSourceConfig,
-  documentId: string,
-  documentText: string,
-  documentUrl?: string,
-  timestamp?: number,
-  tags?: string[],
-  loggerArgs: Record<string, string | number> = {}
-) {
+async function _upsertToDatasource({
+  dataSourceConfig,
+  documentId,
+  documentText,
+  documentUrl,
+  timestampMs,
+  tags,
+  loggerArgs = {},
+  upsertContext = {},
+}: UpsertToDataSourceParams) {
   const localLogger = logger.child({
     ...loggerArgs,
     documentId,
@@ -90,9 +97,10 @@ async function _upsertToDatasource(
   const dustRequestPayload = {
     text: documentText,
     source_url: documentUrl,
-    timestamp,
+    timestamp: timestampMs,
     tags,
     light_document_output: true,
+    upsert_context: upsertContext,
   };
   const dustRequestConfig: AxiosRequestConfig = {
     headers: {

--- a/front/documents_post_process_hooks/hooks/document_tracker/suggest_changes/lib.ts
+++ b/front/documents_post_process_hooks/hooks/document_tracker/suggest_changes/lib.ts
@@ -35,16 +35,28 @@ const logger = mainLogger.child({
   postProcessHook: "document_tracker_suggest_changes",
 });
 
-export async function shouldDocumentTrackerSuggestChangesRun({
-  auth,
-  dataSourceName,
-  documentId,
-  dataSourceConnectorProvider,
-  verb,
-}: DocumentsPostProcessHookFilterParams): Promise<boolean> {
-  if (verb !== "upsert") {
+export async function shouldDocumentTrackerSuggestChangesRun(
+  params: DocumentsPostProcessHookFilterParams
+): Promise<boolean> {
+  if (params.verb !== "upsert") {
     logger.info(
       "document_tracker_suggest_changes post process hook should only run for upsert."
+    );
+    return false;
+  }
+
+  const {
+    upsertContext,
+    auth,
+    dataSourceName,
+    documentId,
+    dataSourceConnectorProvider,
+  } = params;
+  const isBatchSync = upsertContext?.sync_type === "batch";
+
+  if (isBatchSync) {
+    logger.info(
+      "document_tracker_suggest_changes post process hook should not run for batch sync."
     );
     return false;
   }

--- a/front/documents_post_process_hooks/hooks/index.ts
+++ b/front/documents_post_process_hooks/hooks/index.ts
@@ -6,6 +6,7 @@ import {
 import { extractEventPostProcessHook } from "@app/documents_post_process_hooks/hooks/extract_event";
 import { Authenticator } from "@app/lib/auth";
 import { ConnectorProvider } from "@app/lib/connectors_api";
+import { UpsertContext } from "@app/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]";
 
 export const DOCUMENTS_POST_PROCESS_HOOK_TYPES = [
   "document_tracker_update_tracked_documents",
@@ -26,6 +27,7 @@ export type DocumentsPostProcessHookOnUpsertParams = {
   documentText: string;
   documentHash: string;
   dataSourceConnectorProvider: ConnectorProvider | null;
+  upsertContext?: UpsertContext;
 };
 
 export type DocumentsPostProcessHookOnDeleteParams = {


### PR DESCRIPTION
1. move data_sources.upsertToDatasource to object arg
2. allow passing an `upsert_context`

I need an upsert context to know the "sync_type" (batch sync or incremental sync) at upsert time in front, so the doc tracker can decide to not run on diffs that originate from a batch sync
the reasoning:
- Data from full sync is often stale, causing irrelevant, outdated, low signal and noisy change suggestions 
- It's also quite expensive

