### PR TITLE
enh(doc tracker): upgrade to a CoT prompt

### DIFF
--- a/front/documents_post_process_hooks/hooks/document_tracker/suggest_changes/actions/doc_tracker_suggest_changes.ts
+++ b/front/documents_post_process_hooks/hooks/document_tracker/suggest_changes/actions/doc_tracker_suggest_changes.ts
@@ -36,9 +36,11 @@ export async function callDocTrackerSuggestChangesAction(
 const DocTrackerSuggestChangesActionValueSchema = t.union([
   t.type({
     match: t.literal(false),
+    reason: t.string,
   }),
   t.type({
     match: t.literal(true),
     suggested_changes: t.string,
+    reason: t.string,
   }),
 ]);

--- a/front/lib/actions/registry.ts
+++ b/front/lib/actions/registry.ts
@@ -240,7 +240,7 @@ export const DustProdActionRegistry = createActionRegistry({
       workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
       appId: "76b40f14fb",
       appHash:
-        "3e59e6d02fe60e120c285851a850649378c803d36e7e6e9f4cab72d291e1a258",
+        "93877e16b59a07eff3b4f154b8f568f172d6a463f27bd3bcbf5f6aa264216163",
     },
     config: {
       SUGGEST_CHANGES: {


### PR DESCRIPTION
Upgrades doc tracker to a slightly better prompt, that uses a second function argument, `reason`, meant to be a high level explanation for why a doc should or shouldn't be updated.
Because the `reason` arg is generated first, it works as a kind of "chain of thought"

Here is the relevant dust app log: https://dust.tt/w/78bda07b39/a/76b40f14fb/runs/0bd6483adb22a29494df2d24bb7f9dce10d0f5905ead77f503363a7b145577ae