### PR TITLE
enh(doc tracker) perform semantic search across all docs

### DIFF
--- a/front/documents_post_process_hooks/hooks/document_tracker/suggest_changes/lib.ts
+++ b/front/documents_post_process_hooks/hooks/document_tracker/suggest_changes/lib.ts
@@ -261,8 +261,27 @@ export async function documentTrackerSuggestChangesOnUpsert({
     localLogger.warn("No documents found.");
     return;
   }
+
+  const retrievedTrackedDocuments = retrievalResult.filter((r) =>
+    r.tags.includes("DUST_TRACKED")
+  );
+
+  if (!retrievedTrackedDocuments.length) {
+    localLogger.info(
+      "No tracked documents retrieved, not calling doc tracker suggest changes action."
+    );
+    return;
+  }
+
+  localLogger.info(
+    {
+      retrievedTrackedDocumentsCount: retrievedTrackedDocuments.length,
+    },
+    "Retrieved tracked documents."
+  );
+
   // TODO: maybe not just look at top1, look at top 3 chunks and do on multiple docs if needed
-  const top1 = retrievalResult[0];
+  const top1 = retrievedTrackedDocuments[0];
   const score = top1.chunks[0].score;
 
   if (score < RETRIEVAL_MIN_SCORE) {

--- a/front/lib/actions/registry.ts
+++ b/front/lib/actions/registry.ts
@@ -181,17 +181,14 @@ export const DustProdActionRegistry = createActionRegistry({
       workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
       appId: "4180309c80",
       appHash:
-        "48f73c1e4edb35f7d2422b07483700dab0140ded9fc5125248c17a5df6d1db18",
+        "8adcc9ae33a63cc735c9a23a97d7bffe658c6ef2400fc997e61e8817f611a1f8",
     },
     config: {
       SEMANTIC_SEARCH: {
         data_sources: [],
-        top_k: 8,
+        top_k: 20,
         filter: {
-          tags: {
-            in: ["__DUST_TRACKED"],
-            not: null,
-          },
+          tags: null,
           timestamp: null,
         },
         use_cache: false,


### PR DESCRIPTION
existing action performs SS against tracked docs only (and takes the top 1).
The new action performs the search against all docs, and only attempts to suggest changes on the best ranked tracked doc among the top 20 results (if any).
This allows to limit doc tracker involvement to docs that are "spiky"