### PR TITLE
enh(doc tracker): save suggestion reason

### DIFF
--- a/front/documents_post_process_hooks/hooks/document_tracker/suggest_changes/lib.ts
+++ b/front/documents_post_process_hooks/hooks/document_tracker/suggest_changes/lib.ts
@@ -306,6 +306,7 @@ export async function documentTrackerSuggestChangesOnUpsert({
   }
 
   const suggestedChanges = suggestChangesResult.suggested_changes;
+  const reason = suggestChangesResult.reason;
   const matchedDsName = top1.data_source_id;
   const matchedDocId = top1.document_id;
   const matchedDocUrl = top1.source_url;
@@ -379,6 +380,7 @@ export async function documentTrackerSuggestChangesOnUpsert({
         sourceDocumentId: documentId,
         suggestion: suggestedChanges,
         status: "pending",
+        reason,
       })
     )
   );

--- a/front/lib/models.ts
+++ b/front/lib/models.ts
@@ -1176,7 +1176,7 @@ export class DocumentTrackerChangeSuggestion extends Model<
   declare updatedAt: CreationOptional<Date>;
 
   declare suggestion: string;
-  declare suggestionTitle?: string | null;
+  declare reason?: string | null;
   declare status: "pending" | "done" | "rejected";
 
   declare trackedDocumentId: ForeignKey<TrackedDocument["id"]>;
@@ -1194,7 +1194,9 @@ DocumentTrackerChangeSuggestion.init(
     createdAt: { type: DataTypes.DATE, allowNull: false },
     updatedAt: { type: DataTypes.DATE, allowNull: false },
     suggestion: { type: DataTypes.TEXT, allowNull: false },
+    //@ts-expect-error TODO remove once propagated
     suggestionTitle: { type: DataTypes.TEXT, allowNull: true },
+    reason: { type: DataTypes.TEXT, allowNull: true },
     status: {
       type: DataTypes.STRING,
       allowNull: false,


### PR DESCRIPTION
In the `DocumentTrackerChangeSuggestion` model:
- remove the `suggestionTitle` column from the type system (prepare for actual deletion of the column)
- introduce the `reason` column
- populate this column with the `reason` returned by the model

⚠️ Requires DB sync on `front`