### PR TITLE
chore(connectors): actually remove `defaultChannelPermission` column

### DIFF
--- a/connectors/src/lib/models.ts
+++ b/connectors/src/lib/models.ts
@@ -167,12 +167,6 @@ SlackConfiguration.init(
       allowNull: false,
       defaultValue: false,
     },
-    // @ts-expect-error TODO: remove once code deployed
-    defaultChannelPermission: {
-      type: DataTypes.STRING,
-      allowNull: false,
-      defaultValue: "read_write",
-    },
   },
   {
     sequelize: sequelize_conn,


### PR DESCRIPTION
- previously removed from the type system to prepare for actual deletion
- now actually removing the column

⚠️ requires DB sync on `connectors`