### PR TITLE
Prevent Gdrive update permissions to change domain

### DIFF
--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -117,7 +117,7 @@ export async function updateGoogleDriveConnector(
         message: "Connector not found",
         type: "connector_not_found",
       },
-    } as ConnectorsAPIErrorResponse);
+    });
   }
 
   // Ideally we want to check that the Google Project ID is the same as the one from the connector

--- a/connectors/src/connectors/index.ts
+++ b/connectors/src/connectors/index.ts
@@ -13,6 +13,7 @@ import {
   cleanupGoogleDriveConnector,
   createGoogleDriveConnector,
   retrieveGoogleDriveConnectorPermissions,
+  updateGoogleDriveConnector,
 } from "@connectors/connectors/google_drive";
 import { launchGoogleDriveFullSyncWorkflow } from "@connectors/connectors/google_drive/temporal/client";
 import {
@@ -73,9 +74,7 @@ export const UPDATE_CONNECTOR_BY_TYPE: Record<
   slack: updateSlackConnector,
   notion: updateNotionConnector,
   github: updateGithubConnector,
-  google_drive: async (connectorId: ModelId) => {
-    throw new Error(`Not implemented ${connectorId}`);
-  },
+  google_drive: updateGoogleDriveConnector,
 };
 
 type ConnectorStopper = (connectorId: string) => Promise<Result<string, Error>>;

--- a/front/pages/w/[wId]/ds/[name]/settings.tsx
+++ b/front/pages/w/[wId]/ds/[name]/settings.tsx
@@ -655,6 +655,13 @@ function ManagedDataSourceSettings({
             "You cannot select another Github Organization.\nPlease contact us at team@dust.tt if you initially selected a wrong Organization.",
         };
       }
+      if (provider === "google_drive") {
+        return {
+          success: false,
+          error:
+            "You cannot select another Google Drive Domain.\nPlease contact us at team@dust.tt if you initially selected a wrong shared Drive.",
+        };
+      }
     }
     return {
       success: false,


### PR DESCRIPTION
Following https://github.com/dust-tt/dust/pull/989, this one is for Gdrive. 
We want to prevent users from changing the Gdrive when they are trying to update its permissions (adding or removing folders).


I couldn't find an easy way to retrieve the Google Project id from the Google Drive client API. I might have missed it, but I did not wanted to spend too much time on this, so I decided to opt for a workaround that I think should work. Of course, dear reviewers, if I missed it, I'd be happy to change that logic 🙇🏻‍♀️ 

I'm retrieving the user who initiated the permission to the grive and comparing its domain from her email address with the domain from the email address who initiated the new permission. It should cover all cases as we only handle shared gdrive

WDYT? 😬 