### PR TITLE
Remove type a ConnectorsAPIErrorResponse in connector update

### DIFF
--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -121,7 +121,7 @@ export async function updateNotionConnector(
         message: "Connector not found",
         type: "connector_not_found",
       },
-    } as ConnectorsAPIErrorResponse);
+    });
   }
 
   if (connectionId) {
@@ -149,7 +149,7 @@ export async function updateNotionConnector(
           type: "connector_update_error",
           message: "Error retrieving nango connection info to update connector",
         },
-      } as ConnectorsAPIErrorResponse);
+      });
     }
     if (workspaceId !== newWorkspaceId) {
       return new Err({
@@ -157,7 +157,7 @@ export async function updateNotionConnector(
           type: "connector_oauth_target_mismatch",
           message: "Cannot change workspace of a Notion connector",
         },
-      } as ConnectorsAPIErrorResponse);
+      });
     }
 
     await c.update({ connectionId });

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -138,7 +138,7 @@ export async function updateSlackConnector(
         message: "Connector not found",
         type: "connector_not_found",
       },
-    } as ConnectorsAPIErrorResponse);
+    });
   }
 
   const currentSlackConfig = await SlackConfiguration.findOne({
@@ -153,7 +153,7 @@ export async function updateSlackConnector(
         message: "Slack configuration not found",
         type: "connector_not_found",
       },
-    } as ConnectorsAPIErrorResponse);
+    });
   }
 
   const updateParams: Parameters<typeof c.update>[0] = {};
@@ -173,7 +173,7 @@ export async function updateSlackConnector(
           type: "connector_oauth_target_mismatch",
           message: "Cannot change the Slack Team of a Data Source",
         },
-      } as ConnectorsAPIErrorResponse);
+      });
     }
 
     updateParams.connectionId = connectionId;


### PR DESCRIPTION
Removing the `as ConnectorsAPIErrorResponse` that allow not respecting the typing of the function 😅 