### PR TITLE
fix autoscrolling down the list of messages when feedback on a message changes

### DIFF
--- a/front/pages/w/[wId]/u/chat/[cId]/index.tsx
+++ b/front/pages/w/[wId]/u/chat/[cId]/index.tsx
@@ -683,7 +683,7 @@ export default function AppChat({
     if (window && window.scrollTo) {
       window.scrollTo(0, document.body.scrollHeight);
     }
-  }, [messages, response]);
+  }, [messages.length, response]);
 
   const handleInputUpdate = (input: string) => {
     setInput(input);


### PR DESCRIPTION
NRE
This fix will only trigger autoscroll when messages.length changes, not for any change of the messages array
This avoids among others an autoscroll down when the feedback thumbs are used

Also, while debugging => realized that all the app is rerendered every time messages is changed, no matter how little
=> requires good componentization, this will be fixed in another yak-shave PR on the chat index.tsx,