### PR TITLE
enh(docs): use sparkle Dust logo

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@algolia/autocomplete-core": "^1.7.3",
         "@algolia/autocomplete-preset-algolia": "^1.7.3",
+        "@dust-tt/sparkle": "0.1.26",
         "@headlessui/react": "^1.7.7",
         "@mdx-js/loader": "^2.1.5",
         "@mdx-js/react": "^2.1.5",
@@ -20,6 +21,7 @@
         "algoliasearch": "^4.14.2",
         "autoprefixer": "^10.4.7",
         "clsx": "^1.2.0",
+        "dd-trace": "^3.16.0",
         "focus-visible": "^5.2.0",
         "framer-motion": "7.8.1",
         "mdast-util-to-string": "^3.1.0",
@@ -176,6 +178,89 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@datadog/native-appsec": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@datadog/native-appsec/-/native-appsec-3.2.0.tgz",
+      "integrity": "sha512-biAa7EFfuavjSWgSQaCit9CqGzr6Af5nhzfNNGJ38Y/Y387hDvLivAR374kK1z6XoxGZEOa+XPbVogmV/2Bcjw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "node-gyp-build": "^3.9.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@datadog/native-iast-rewriter": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@datadog/native-iast-rewriter/-/native-iast-rewriter-2.0.1.tgz",
+      "integrity": "sha512-Mm+FG3XxEbPrAfJQPOMHts7iZZXRvg9gnGeeFRGkyirmRcQcOpZO4wFe/8K61DUVa5pXpgAJQ2ZkBGYF1O9STg==",
+      "dependencies": {
+        "node-gyp-build": "^4.5.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@datadog/native-iast-rewriter/node_modules/node-gyp-build": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
+      "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/@datadog/native-iast-taint-tracking": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-1.5.0.tgz",
+      "integrity": "sha512-SOWIk1M6PZH0osNB191Voz2rKBPoF5hISWVSK9GiJPrD40+xjib1Z/bFDV7EkDn3kjOyordSBdNPG5zOqZJdyg==",
+      "dependencies": {
+        "node-gyp-build": "^3.9.0"
+      }
+    },
+    "node_modules/@datadog/native-metrics": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@datadog/native-metrics/-/native-metrics-2.0.0.tgz",
+      "integrity": "sha512-YklGVwUtmKGYqFf1MNZuOHvTYdKuR4+Af1XkWcMD8BwOAjxmd9Z+97328rCOY8TFUJzlGUPaXzB8j2qgG/BMwA==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "node-addon-api": "^6.1.0",
+        "node-gyp-build": "^3.9.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@datadog/pprof": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@datadog/pprof/-/pprof-3.1.0.tgz",
+      "integrity": "sha512-Bg8O8yrHeL2KKHXhLoAAT33ZfzLnZ6rWfOjy8PkcNhUJy3UwNVLbUoApf+99EyLjqpzpk/kZXrIAMBzMMB8ilg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "delay": "^5.0.0",
+        "node-gyp-build": "<4.0",
+        "p-limit": "^3.1.0",
+        "pprof-format": "^2.0.7",
+        "source-map": "^0.7.4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@datadog/sketches-js": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@datadog/sketches-js/-/sketches-js-2.1.0.tgz",
+      "integrity": "sha512-smLocSfrt3s53H/XSVP3/1kP42oqvrkjUPtyaFd1F79ux24oE31BKt+q0c6lsa6hOYrFzsIwyc5GXAI5JmfOew=="
+    },
+    "node_modules/@dust-tt/sparkle": {
+      "version": "0.1.26",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.1.26.tgz",
+      "integrity": "sha512-oZaDdShEZKkRVD00ClbA+6Cx86/x+q92Mz11nNYSBCbcF+2PhGDfhu82iw+gqN7vWYCMwug/xS8UkQ03i3OKJA==",
+      "peerDependencies": {
+        "react": "^18.2.0"
       }
     },
     "node_modules/@emotion/is-prop-valid": {
@@ -697,6 +782,90 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.4.1.tgz",
+      "integrity": "sha512-O2yRJce1GOc6PAy3QxFM4NzFiWzvScDC1/5ihYBL6BUEVdq0XMWN01sppE+H6bBXbaFYipjwFLEWLg5PaSOThA==",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.15.1.tgz",
+      "integrity": "sha512-V6GoRTY6aANMDDOQ9CiHOiLWEK2b2b3OGZK+zk05Li5merb9jadFeV5ooTSGtjxfxVNMpQUaQERO1cdbdbeEGg==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.15.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.15.1.tgz",
+      "integrity": "sha512-n8Kur1/CZlYG32YCEj30CoUqA8R7UyDVZzoEU6SDP+13+kXDT2kFVu6MpcnEUTyGP3i058ID6Qjp5h6IJxdPPQ==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+    },
     "node_modules/@rushstack/eslint-patch": {
       "version": "1.2.0",
       "dev": true,
@@ -850,8 +1019,7 @@
     "node_modules/@types/node": {
       "version": "18.15.7",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.7.tgz",
-      "integrity": "sha512-LFmUbFunqmBn26wJZgZPYZPrDR1RwGOu2v79Mgcka1ndO6V0/cwjivPTc4yoK6n9kmw4/ls1r8cLrvh2iMibFA==",
-      "peer": true
+      "integrity": "sha512-LFmUbFunqmBn26wJZgZPYZPrDR1RwGOu2v79Mgcka1ndO6V0/cwjivPTc4yoK6n9kmw4/ls1r8cLrvh2iMibFA=="
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
@@ -1139,10 +1307,9 @@
       }
     },
     "node_modules/acorn-import-assertions": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
-      "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
-      "peer": true,
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
+      "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
       "peerDependencies": {
         "acorn": "^8"
       }
@@ -1638,6 +1805,11 @@
         "node": ">=6.0"
       }
     },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
+      "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ=="
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "license": "MIT"
@@ -1696,6 +1868,11 @@
         "node": ">= 8"
       }
     },
+    "node_modules/crypto-randomuuid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-randomuuid/-/crypto-randomuuid-1.0.0.tgz",
+      "integrity": "sha512-/RC5F4l1SCqD/jazwUF6+t34Cd8zTSAGZ7rvvZu1whZUhD2a5MOGKjSGowoGcpj/cbVZk1ZODIooJEQQq3nNAA=="
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "license": "MIT",
@@ -1714,6 +1891,56 @@
       "version": "1.0.8",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/dd-trace": {
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-3.31.0.tgz",
+      "integrity": "sha512-c12qdJ/ydPnjc3BbiOBG/t6U+B4roVqSrUKdLNijr1R/Hwc2ftbNdToqo+6gAw8MY1uIm1xgHYPJ7agCLACglQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@datadog/native-appsec": "^3.2.0",
+        "@datadog/native-iast-rewriter": "2.0.1",
+        "@datadog/native-iast-taint-tracking": "1.5.0",
+        "@datadog/native-metrics": "^2.0.0",
+        "@datadog/pprof": "3.1.0",
+        "@datadog/sketches-js": "^2.1.0",
+        "@opentelemetry/api": "^1.0.0",
+        "@opentelemetry/core": "^1.14.0",
+        "crypto-randomuuid": "^1.0.0",
+        "diagnostics_channel": "^1.1.0",
+        "ignore": "^5.2.4",
+        "import-in-the-middle": "^1.4.1",
+        "int64-buffer": "^0.1.9",
+        "ipaddr.js": "^2.1.0",
+        "istanbul-lib-coverage": "3.2.0",
+        "koalas": "^1.0.2",
+        "limiter": "^1.1.4",
+        "lodash.kebabcase": "^4.1.1",
+        "lodash.pick": "^4.4.0",
+        "lodash.sortby": "^4.7.0",
+        "lodash.uniq": "^4.5.0",
+        "lru-cache": "^7.14.0",
+        "methods": "^1.1.2",
+        "module-details-from-path": "^1.0.3",
+        "msgpack-lite": "^0.1.26",
+        "node-abort-controller": "^3.1.1",
+        "opentracing": ">=0.12.1",
+        "path-to-regexp": "^0.1.2",
+        "protobufjs": "^7.2.4",
+        "retry": "^0.13.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/dd-trace/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -1795,6 +2022,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delay": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/delay/-/delay-5.0.0.tgz",
+      "integrity": "sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "license": "MIT",
@@ -1815,6 +2053,14 @@
       },
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/diagnostics_channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/diagnostics_channel/-/diagnostics_channel-1.1.0.tgz",
+      "integrity": "sha512-OE1ngLDjSBPG6Tx0YATELzYzy3RKHC+7veQ8gLa8yS7AAgw65mFbVdcsu3501abqOZCEZqZyAIemB0zXlqDSuw==",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/didyoumean": {
@@ -2493,6 +2739,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/event-lite": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/event-lite/-/event-lite-0.1.3.tgz",
+      "integrity": "sha512-8qz9nOz5VeD2z96elrEKD2U433+L3DWdUdDkOINLGOJvx1GsMBbMn0aCeu28y8/e85A6mCigBiFlYMnTBEGlSw=="
+    },
     "node_modules/events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -2939,9 +3190,27 @@
       "version": "1.0.8",
       "license": "MIT"
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/ignore": {
       "version": "5.2.4",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -2960,6 +3229,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-in-the-middle": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.4.1.tgz",
+      "integrity": "sha512-hGG0PcCsykVo8MBVH8l0uEWLWW6DXMgJA9jvC0yps6M3uIJ8L/tagTCbyF8Ud5TtqJ8/jmZL1YkyySyeVkVQrA==",
+      "dependencies": {
+        "acorn": "^8.8.2",
+        "acorn-import-assertions": "^1.9.0",
+        "cjs-module-lexer": "^1.2.2",
+        "module-details-from-path": "^1.0.3"
       }
     },
     "node_modules/imurmurhash": {
@@ -2988,6 +3268,11 @@
       "version": "0.1.1",
       "license": "MIT"
     },
+    "node_modules/int64-buffer": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/int64-buffer/-/int64-buffer-0.1.10.tgz",
+      "integrity": "sha512-v7cSY1J8ydZ0GyjUHqF+1bshJ6cnEVLo9EnjB8p+4HDRPZc9N5jjmvUV7NvEsqQOKyH0pmIBFWXVQbiS0+OBbA=="
+    },
     "node_modules/internal-slot": {
       "version": "1.0.5",
       "dev": true,
@@ -2999,6 +3284,14 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.1.0.tgz",
+      "integrity": "sha512-LlbxQ7xKzfBusov6UMi4MFpEg0m+mAm9xyNGEduwXMEDuf4WfzB/RZwMVYEd7IKGvh4IUkEXYxtAVu9T3OelJQ==",
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/is-alphabetical": {
@@ -3360,6 +3653,14 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
+      "integrity": "sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/jest-worker": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
@@ -3462,6 +3763,14 @@
         "node": ">=6"
       }
     },
+    "node_modules/koalas": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/koalas/-/koalas-1.0.2.tgz",
+      "integrity": "sha512-RYhBbYaTTTHId3l6fnMZc3eGQNW6FVCqMG6AMwA5I1Mafr6AflaXeoi6x3xQuATRotGYRLk6+1ELZH4dstFNOA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/language-subtag-registry": {
       "version": "0.3.22",
       "dev": true,
@@ -3494,6 +3803,11 @@
         "node": ">=10"
       }
     },
+    "node_modules/limiter": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
+      "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA=="
+    },
     "node_modules/loader-runner": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
@@ -3525,9 +3839,34 @@
       "version": "4.0.6",
       "license": "MIT"
     },
+    "node_modules/lodash.kebabcase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
+      "integrity": "sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g=="
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "license": "MIT"
+    },
+    "node_modules/lodash.pick": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+      "integrity": "sha512-hXt6Ul/5yWjfklSGvLQl8vM//l3FtyHZeuelpzK6mm99pNvN9yTDruNZPEJZD1oWrqo+izBmB7oUfWgcCX7s4Q=="
+    },
+    "node_modules/lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA=="
+    },
+    "node_modules/lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ=="
+    },
+    "node_modules/long": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
     },
     "node_modules/longest-streak": {
       "version": "3.1.0",
@@ -3549,7 +3888,6 @@
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
@@ -3860,6 +4198,14 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/micromark": {
@@ -4557,6 +4903,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.3.tgz",
+      "integrity": "sha512-ySViT69/76t8VhE1xXHK6Ch4NcDd26gx0MzKXLO+F7NOtnqH68d9zF94nT8ZWSxXh8ELOERsnJO/sWt1xZYw5A=="
+    },
     "node_modules/mri": {
       "version": "1.2.0",
       "license": "MIT",
@@ -4567,6 +4918,25 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "license": "MIT"
+    },
+    "node_modules/msgpack-lite": {
+      "version": "0.1.26",
+      "resolved": "https://registry.npmjs.org/msgpack-lite/-/msgpack-lite-0.1.26.tgz",
+      "integrity": "sha512-SZ2IxeqZ1oRFGo0xFGbvBJWMp3yLIY9rlIJyxy8CGrwZn1f0ZK4r6jV/AM1r0FZMDUkWkglOk/eeKIL9g77Nxw==",
+      "dependencies": {
+        "event-lite": "^0.1.1",
+        "ieee754": "^1.1.8",
+        "int64-buffer": "^0.1.9",
+        "isarray": "^1.0.0"
+      },
+      "bin": {
+        "msgpack": "bin/msgpack"
+      }
+    },
+    "node_modules/msgpack-lite/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
     },
     "node_modules/nanoid": {
       "version": "3.3.4",
@@ -4661,6 +5031,26 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/node-abort-controller": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
+      "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ=="
+    },
+    "node_modules/node-addon-api": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
+      "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA=="
+    },
+    "node_modules/node-gyp-build": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.9.0.tgz",
+      "integrity": "sha512-zLcTg6P4AbcHPq465ZMFNXx7XpKKJh+7kkN699NiQWisR2uWYOWNWqRHAmbnmKiL4e9aLSlmy5U7rEMUXV59+A==",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/node-releases": {
@@ -4809,6 +5199,14 @@
         "wrappy": "1"
       }
     },
+    "node_modules/opentracing": {
+      "version": "0.14.7",
+      "resolved": "https://registry.npmjs.org/opentracing/-/opentracing-0.14.7.tgz",
+      "integrity": "sha512-vz9iS7MJ5+Bp1URw8Khvdyw1H/hGvzHWlKQ7eRrQojSCDL1/SrWfrY9QebLw97n2deyRtzHRC3MkQfVNUCo91Q==",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.1",
       "dev": true,
@@ -4827,7 +5225,6 @@
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
@@ -4909,6 +5306,11 @@
     "node_modules/path-parse": {
       "version": "1.0.7",
       "license": "MIT"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -5075,6 +5477,11 @@
       "version": "4.2.0",
       "license": "MIT"
     },
+    "node_modules/pprof-format": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/pprof-format/-/pprof-format-2.0.7.tgz",
+      "integrity": "sha512-1qWaGAzwMpaXJP9opRa23nPnt2Egi7RMNoNBptEE/XwHbcn4fC2b/4U4bKc5arkGkIh2ZabpF2bEb+c5GNHEKA=="
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "dev": true,
@@ -5187,6 +5594,29 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.4.tgz",
+      "integrity": "sha512-AT+RJgD2sH8phPmCf7OUZR8xGdcJRga4+1cOaXJ64hvcSkVhNcRHOwIxUatPH15+nj59WAGTDv3LSGZPEQbJaQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/punycode": {
@@ -5413,6 +5843,14 @@
         "node": ">=4"
       }
     },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.0.4",
       "license": "MIT",
@@ -5525,9 +5963,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.3.8",
-      "dev": true,
-      "license": "ISC",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -6429,7 +6867,6 @@
     },
     "node_modules/yallist": {
       "version": "4.0.0",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/yaml": {
@@ -6441,7 +6878,6 @@
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"

--- a/docs/package.json
+++ b/docs/package.json
@@ -25,6 +25,7 @@
     "autoprefixer": "^10.4.7",
     "clsx": "^1.2.0",
     "dd-trace": "^3.16.0",
+    "@dust-tt/sparkle": "0.1.26",
     "focus-visible": "^5.2.0",
     "framer-motion": "7.8.1",
     "mdast-util-to-string": "^3.1.0",

--- a/docs/src/components/Header.jsx
+++ b/docs/src/components/Header.jsx
@@ -4,7 +4,7 @@ import clsx from "clsx";
 import { motion, useScroll, useTransform } from "framer-motion";
 
 import { Button } from "@/components/Button";
-import { Logo } from "@/components/Logo";
+import { Logo } from "@dust-tt/sparkle";
 import {
   MobileNavigation,
   useIsInsideMobileNavigation,
@@ -60,7 +60,7 @@ export const Header = forwardRef(function Header({ className }, ref) {
       <div className="flex items-center gap-5 lg:hidden">
         <MobileNavigation />
         <Link href="https://dust.tt" aria-label="Home">
-          <Logo className="h-6" />
+          <Logo className="-ml-8 h-4 w-32" />
         </Link>
       </div>
       <div className="flex flex-1" />

--- a/docs/src/components/Layout.jsx
+++ b/docs/src/components/Layout.jsx
@@ -3,7 +3,7 @@ import { motion } from "framer-motion";
 
 import { Footer } from "@/components/Footer";
 import { Header } from "@/components/Header";
-import { Logo } from "@/components/Logo";
+import { Logo } from "@dust-tt/sparkle";
 import { Navigation } from "@/components/Navigation";
 import { Prose } from "@/components/Prose";
 import { SectionProvider } from "@/components/SectionProvider";
@@ -19,7 +19,7 @@ export function Layout({ children, sections = [] }) {
           <div className="contents lg:pointer-events-auto lg:block lg:w-72 lg:overflow-y-auto lg:border-r lg:border-zinc-900/10 lg:px-6 lg:pt-4 lg:pb-8 lg:dark:border-white/10 xl:w-80">
             <div className="hidden lg:flex">
               <Link href="https://dust.tt" aria-label="Home">
-                <Logo className="h-6" />
+                <Logo className="-ml-8 h-4 w-32" />
               </Link>
             </div>
             <Header />


### PR DESCRIPTION
- add sparkle as a dependency for `docs`
- replace the old logo by the new one
<img width="1785" alt="Screenshot 2023-07-31 at 12 23 38" src="https://github.com/dust-tt/dust/assets/14199823/5c1d1d86-0b7f-4d91-951b-88bb1516dd15">

