### PR TITLE
Chat Session Visibility

### DIFF
--- a/connectors/src/lib/dust_api.ts
+++ b/connectors/src/lib/dust_api.ts
@@ -70,6 +70,7 @@ type ChatSessionType = {
   sId: string;
   title?: string;
   messages?: ChatMessageType[];
+  visibility: string;
 };
 
 // Event sent when the session is initially created.

--- a/front/components/sparkle/AppLayoutTitle.tsx
+++ b/front/components/sparkle/AppLayoutTitle.tsx
@@ -1,12 +1,15 @@
 import { Button } from "@dust-tt/sparkle";
 import { TrashIcon } from "@heroicons/react/24/solid";
-import { ComponentType } from "react";
+import React, { ComponentType } from "react";
+
+import { classNames } from "@app/lib/utils";
 
 export function AppLayoutTitle({
   readOnly,
   title,
   onDelete,
   action,
+  toggle,
 }: {
   readOnly?: boolean;
   title: string;
@@ -16,6 +19,12 @@ export function AppLayoutTitle({
     labelVisible: boolean;
     icon?: ComponentType;
     onAction: () => void;
+  };
+  toggle?: {
+    labelChecked: string;
+    labelUnchecked: string;
+    onToggle: () => void;
+    isChecked: boolean;
   };
 }) {
   return (
@@ -48,6 +57,38 @@ export function AppLayoutTitle({
               onClick={action.onAction}
             />
           </div>
+        )}
+        {!readOnly && toggle && (
+          <>
+            <label className="relative inline-flex cursor-pointer select-none items-center justify-center rounded-full border border-gray-300 bg-gray-200">
+              <input
+                type="checkbox"
+                className="sr-only"
+                checked={toggle.isChecked}
+                onChange={toggle.onToggle}
+              />
+              <span
+                className={classNames(
+                  "flex items-center space-x-[6px] rounded-full px-[10px] py-2 text-sm",
+                  toggle.isChecked
+                    ? "bg-white font-semibold text-action-500"
+                    : "s-opacity-50"
+                )}
+              >
+                {toggle.labelChecked}
+              </span>
+              <span
+                className={classNames(
+                  "flex items-center space-x-[6px] rounded-full px-[10px] py-2 text-sm",
+                  !toggle.isChecked
+                    ? "bg-white font-semibold text-action-500"
+                    : "s-opacity-50"
+                )}
+              >
+                {toggle.labelUnchecked}
+              </span>
+            </label>
+          </>
         )}
       </div>
     </div>

--- a/front/lib/models.ts
+++ b/front/lib/models.ts
@@ -8,7 +8,7 @@ import {
   Sequelize,
 } from "sequelize";
 
-import { MessageFeedbackStatus } from "@app/types/chat";
+import { ChatSessionVisibility, MessageFeedbackStatus } from "@app/types/chat";
 import { EventSchemaPropertyType, EventSchemaStatus } from "@app/types/extract";
 
 import { ConnectorProvider } from "./connectors_api";
@@ -725,6 +725,7 @@ export class ChatSession extends Model<
 
   declare sId: string;
   declare title?: string;
+  declare visibility: ChatSessionVisibility;
 
   declare workspaceId: ForeignKey<Workspace["id"]>;
   declare userId: ForeignKey<User["id"]>;
@@ -754,6 +755,11 @@ ChatSession.init(
     title: {
       type: DataTypes.TEXT,
       allowNull: true,
+    },
+    visibility: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+      defaultValue: "private",
     },
   },
   {

--- a/front/lib/swr.ts
+++ b/front/lib/swr.ts
@@ -13,7 +13,10 @@ import { GetWorkspaceInvitationsResponseBody } from "@app/pages/api/w/[wId]/invi
 import { GetKeysResponseBody } from "@app/pages/api/w/[wId]/keys";
 import { GetMembersResponseBody } from "@app/pages/api/w/[wId]/members";
 import { GetProvidersResponseBody } from "@app/pages/api/w/[wId]/providers";
-import { GetChatSessionsResponseBody } from "@app/pages/api/w/[wId]/use/chats";
+import {
+  GetChatSessionResponseBody,
+  GetChatSessionsResponseBody,
+} from "@app/pages/api/w/[wId]/use/chats";
 import { GetEventSchemasResponseBody } from "@app/pages/api/w/[wId]/use/extract";
 import { GetExtractedEventsResponseBody } from "@app/pages/api/w/[wId]/use/extract/[marker]/events/[eId]";
 import { AppType } from "@app/types/app";
@@ -220,6 +223,21 @@ export function useChatSessions(
     isChatSessionsLoading: !error && !data,
     isChatSessionsError: error,
     mutateChatSessions: mutate,
+  };
+}
+
+export function useChatSession(owner: WorkspaceType, cId: string) {
+  const runsFetcher: Fetcher<GetChatSessionResponseBody> = fetcher;
+  const { data, error, mutate } = useSWR(
+    `/api/w/${owner.sId}/use/chats/${cId}`,
+    runsFetcher
+  );
+
+  return {
+    chatSession: data ? data.session : undefined,
+    isChatSessionsLoading: !error && !data,
+    isChatSessionsError: error,
+    mutateChatSession: mutate,
   };
 }
 

--- a/front/pages/w/[wId]/u/chat/[cId]/index.tsx
+++ b/front/pages/w/[wId]/u/chat/[cId]/index.tsx
@@ -80,7 +80,6 @@ export const getServerSideProps: GetServerSideProps<{
   owner: WorkspaceType;
   workspaceDataSources: DataSource[];
   prodCredentials: DustAPICredentials;
-  readOnly: boolean;
   gaTrackingId: string;
 }> = async (context) => {
   const session = await getSession(context.req, context.res);
@@ -144,7 +143,6 @@ export const getServerSideProps: GetServerSideProps<{
       owner,
       workspaceDataSources: dataSources,
       prodCredentials,
-      readOnly: false,
       gaTrackingId: GA_TRACKING_ID,
     },
   };
@@ -620,7 +618,6 @@ export default function AppChat({
   owner,
   workspaceDataSources,
   prodCredentials,
-  readOnly,
   gaTrackingId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const router = useRouter();
@@ -632,6 +629,10 @@ export default function AppChat({
     owner,
     chatSessionId
   );
+
+  const readOnly = chatSession?.userId
+    ? chatSession?.userId !== user?.id
+    : false;
 
   const [title, setTitle] = useState<string>(
     chatSession?.title || "New Conversation"
@@ -1101,7 +1102,9 @@ export default function AppChat({
 
   const handleDelete = async () => {
     const confirmed = window.confirm(
-      `After deletion, the conversation "${chatSession?.title}" cannot be recovered. Delete the conversation?`
+      `After deletion, the conversation "${
+        chatSession?.title || "[Untitled]"
+      }" cannot be recovered. Delete the conversation?`
     );
     if (confirmed) {
       // call the delete API

--- a/front/types/chat.ts
+++ b/front/types/chat.ts
@@ -37,4 +37,7 @@ export type ChatSessionType = {
   sId: string;
   title?: string;
   messages?: ChatMessageType[];
+  visibility: string;
 };
+
+export type ChatSessionVisibility = "private" | "workspace";


### PR DESCRIPTION
**Context**

Initial PR from @philipperolet was here: https://github.com/dust-tt/dust/compare/chat-session-visibility?expand=1
I decided to restart from scratch because: 
- We wanted a toggle over a button to choose the visibility (private / workspace).
- The API in the initial PR was introducing a new route `/w/[wId]/use/chats/[cId]/shared` while I assumed we could simply patch `/w/[wId]/use/chats/[cId]`.
- The initial PR was also introducing a refactoring of the header which was more complex & that can still be owner by @philipperolet.
- PR had a lot of commits including multiple "Merge branch 'main' into chat-shareable-conversations", which is something I never succeed to work with as rebases are a nightmare. 


**On this PR**

- [x] Add a new field `visibility` to ChatSession, default to "private".
- [x] Route `/w/[wId]/use/chats/[cId]` can be patched to change the `visibility`
- [x] Route `/w/[wId]/use/chats/[cId]` can be get to get the detail of a ChatSession.
- [x] In the Chat App, we get the ChatSession not from `getServerSideProps` but from a `useChatSession` that allow mutation. 

If PR is approved, I'll make a sparkle component of the toggle field.
<img width="1452" alt="Capture d’écran 2023-08-01 à 13 54 02" src="https://github.com/dust-tt/dust/assets/3803406/44c21436-9345-4aac-a69f-ba53658eb182">

**Next immediate PRs**
- [ ] Make a sparkle component of the toggle field.
- [ ] Add an icon to copy the link to the session (not a button, discussed with Gab)
- [ ] Give access to "workspace chat sessions "following the designs in Figma.
  