### PR TITLE
Fix chat readOnly condition

### DIFF
--- a/front/pages/w/[wId]/u/chat/[cId]/index.tsx
+++ b/front/pages/w/[wId]/u/chat/[cId]/index.tsx
@@ -576,9 +576,10 @@ export default function AppChat({
     chatSessionId
   );
 
-  const readOnly = chatSession?.userId
-    ? chatSession?.userId !== user?.id
-    : false;
+  let readOnly = true;
+  if (chatSession?.userId && user?.id && chatSession.userId === user.id) {
+    readOnly = false;
+  }
 
   const [title, setTitle] = useState<string>(
     chatSession?.title || "New Conversation"


### PR DESCRIPTION
ReadOnly was false when there's no user attached (using Slackbot).
I fixed the condition and made it easier to read. 