### PR TITLE
feat(super user panel): add a section for Data Sources to the WS page

### DIFF
--- a/connectors/src/api/delete_connector.ts
+++ b/connectors/src/api/delete_connector.ts
@@ -76,6 +76,8 @@ const _deleteConnectorAPIHandler = async (
 
     await connector.destroy({ transaction: t });
 
+    await t.commit();
+
     return res.json({
       success: true,
     });

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/index.ts
@@ -1,0 +1,129 @@
+import { NextApiRequest, NextApiResponse } from "next";
+
+import { getSession, getUserFromSession } from "@app/lib/auth";
+import { ConnectorsAPI } from "@app/lib/connectors_api";
+import { CoreAPI } from "@app/lib/core_api";
+import { ReturnedAPIErrorType } from "@app/lib/error";
+import { DataSource, Workspace } from "@app/lib/models";
+import { apiError, withLogging } from "@app/logger/withlogging";
+
+export type DeleteDataSourceResponseBody = {
+  success: true;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<DeleteDataSourceResponseBody | ReturnedAPIErrorType>
+): Promise<void> {
+  const session = await getSession(req, res);
+  const user = await getUserFromSession(session);
+
+  if (!user) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "user_not_found",
+        message: "Could not find the user.",
+      },
+    });
+  }
+
+  if (!user.isDustSuperUser) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "user_not_found",
+        message: "Could not find the user.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "DELETE":
+      const { wId } = req.query;
+      if (!wId || typeof wId !== "string") {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              "The request query is invalid, expects { workspaceId: string }.",
+          },
+        });
+      }
+
+      const { name } = req.query;
+      if (!name || typeof name !== "string") {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "The request query is invalid, expects { name: string }.",
+          },
+        });
+      }
+
+      const workspace = await Workspace.findOne({
+        where: {
+          sId: wId,
+        },
+      });
+
+      if (!workspace) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "workspace_not_found",
+            message: "Could not find the workspace.",
+          },
+        });
+      }
+
+      const dataSource = await DataSource.findOne({
+        where: {
+          workspaceId: workspace.id,
+          name,
+        },
+      });
+
+      if (!dataSource) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "data_source_not_found",
+            message: "Could not find the data source.",
+          },
+        });
+      }
+
+      const dustAPIProjectId = dataSource.dustAPIProjectId;
+
+      if (dataSource.connectorId) {
+        await ConnectorsAPI.deleteConnector(
+          dataSource.connectorId.toString(),
+          true
+        );
+      }
+
+      await CoreAPI.deleteDataSource({
+        projectId: dustAPIProjectId,
+        dataSourceName: dataSource.name,
+      });
+
+      await dataSource.destroy();
+
+      // TODO SHOULD WE SCRUB ?!
+      return res.status(200).json({ success: true });
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, DELETE is expected.",
+        },
+      });
+  }
+}
+
+export default withLogging(handler);

--- a/front/pages/poke/[wId]/index.tsx
+++ b/front/pages/poke/[wId]/index.tsx
@@ -237,17 +237,13 @@ const WorkspacePage = ({
                   onClick={onDowngrade}
                   disabled={!isFullyUpgraded || workspaceHasManagedDataSources}
                 />
-                <Tooltip
-                  label={"delete managed data sources first"}
-                  position="below"
-                >
-                  <Button
-                    label="Upgrade"
-                    type="secondary"
-                    onClick={onUpgrade}
-                    disabled={isFullyUpgraded}
-                  />
-                </Tooltip>
+
+                <Button
+                  label="Upgrade"
+                  type="secondary"
+                  onClick={onUpgrade}
+                  disabled={isFullyUpgraded}
+                />
               </div>
             </div>
             {isFullyUpgraded && workspaceHasManagedDataSources && (

--- a/front/pages/poke/[wId]/index.tsx
+++ b/front/pages/poke/[wId]/index.tsx
@@ -5,12 +5,20 @@ import { useRouter } from "next/router";
 import React from "react";
 
 import PokeNavbar from "@app/components/poke/PokeNavbar";
+import { getDataSources } from "@app/lib/api/data_sources";
 import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
+import { ConnectorsAPI } from "@app/lib/connectors_api";
+import { CoreAPI } from "@app/lib/core_api";
+import { timeAgoFrom } from "@app/lib/utils";
+import { DataSourceType } from "@app/types/data_source";
 import { UserType, WorkspaceType } from "@app/types/user";
 
 export const getServerSideProps: GetServerSideProps<{
   user: UserType;
   workspace: WorkspaceType;
+  dataSources: DataSourceType[];
+  documentCounts: Record<string, number>;
+  dataSourcesSynchronizedAgo: Record<string, string>;
 }> = async (context) => {
   const session = await getSession(context.req, context.res);
   const user = await getUserFromSession(session);
@@ -46,16 +54,75 @@ export const getServerSideProps: GetServerSideProps<{
     };
   }
 
+  const dataSources = await getDataSources(auth);
+
+  // sort data source so that managed ones (i.e ones with a connector provider) are first
+  dataSources.sort((a, b) => {
+    if (a.connectorProvider && !b.connectorProvider) {
+      return -1;
+    }
+    if (!a.connectorProvider && b.connectorProvider) {
+      return 1;
+    }
+    return 0;
+  });
+
+  const docCountByDsName: Record<string, number> = {};
+
+  await Promise.all(
+    dataSources.map(async (ds) => {
+      const res = await CoreAPI.getDataSourceDocuments({
+        projectId: ds.dustAPIProjectId,
+        dataSourceName: ds.name,
+        limit: 0,
+        offset: 0,
+      });
+      if (res.isErr()) {
+        throw res.error;
+      }
+      docCountByDsName[ds.name] = res.value.total;
+    })
+  );
+
+  const synchronizedAgoByDsName: Record<string, string> = {};
+
+  await Promise.all(
+    dataSources.map(async (ds) => {
+      if (!ds.connectorId) {
+        return;
+      }
+      const statusRes = await ConnectorsAPI.getConnector(
+        ds.connectorId?.toString()
+      );
+      if (statusRes.isErr()) {
+        throw statusRes.error;
+      }
+      const { lastSyncSuccessfulTime } = statusRes.value;
+
+      if (!lastSyncSuccessfulTime) {
+        return;
+      }
+
+      synchronizedAgoByDsName[ds.name] = timeAgoFrom(lastSyncSuccessfulTime);
+    })
+  );
+
   return {
     props: {
       user,
       workspace,
+      dataSources,
+      documentCounts: docCountByDsName,
+      dataSourcesSynchronizedAgo: synchronizedAgoByDsName,
     },
   };
 };
 
 const WorkspacePage = ({
   workspace,
+  dataSources,
+  documentCounts,
+  dataSourcesSynchronizedAgo,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
   const router = useRouter();
 
@@ -101,6 +168,39 @@ const WorkspacePage = ({
     }
   };
 
+  const onDataSourcesDelete = async (dataSourceName: string) => {
+    if (
+      !window.confirm(
+        `Are you sure you want to delete the ${dataSourceName} data source? There is no going back.`
+      )
+    ) {
+      return;
+    }
+
+    if (!window.confirm(`really, Really, REALLY sure ?`)) {
+      return;
+    }
+
+    try {
+      const r = await fetch(
+        `/api/poke/workspaces/${workspace.sId}/data_sources/${dataSourceName}`,
+        {
+          method: "DELETE",
+          headers: {
+            "Content-Type": "application/json",
+          },
+        }
+      );
+      if (!r.ok) {
+        throw new Error("Failed to delete data source.");
+      }
+      await router.reload();
+    } catch (e) {
+      console.error(e);
+      window.alert("An error occurred while deleting the data source.");
+    }
+  };
+
   const isFullyUpgraded =
     workspace.plan?.limits.dataSources.count === -1 &&
     workspace.plan?.limits.dataSources.documents.count === -1 &&
@@ -111,34 +211,66 @@ const WorkspacePage = ({
     <div className="min-h-screen bg-structure-50">
       <PokeNavbar />
       <div className="flex-grow p-6">
-        <>
-          <h1 className="mb-4 text-2xl font-bold">{workspace.name}</h1>
-          <h2 className="text-md mb-4 font-bold">Plan:</h2>
-          {isFullyUpgraded ? (
-            <p className="mb-4 text-green-600">
-              This workspace is fully upgraded.
-            </p>
-          ) : (
-            <p className="mb-4 text-green-600">
-              This workspace is not upgraded.
-            </p>
-          )}
-          <JsonViewer value={workspace.plan} rootName={false} />
-          <div className="mt-4 flex-row">
-            <Button
-              label="Downgrade"
-              type="secondaryWarning"
-              onClick={onDowngrade}
-              disabled={!isFullyUpgraded}
-            />
-            <Button
-              label="Upgrade"
-              type="secondary"
-              onClick={onUpgrade}
-              disabled={isFullyUpgraded}
-            />
+        <h1 className="mb-8 text-2xl font-bold">{workspace.name}</h1>
+        <div className="flex justify-center">
+          <div className="mx-2 w-1/3">
+            <h2 className="text-md mb-4 font-bold">Plan:</h2>
+            {isFullyUpgraded ? (
+              <p className="mb-4 text-green-600">
+                This workspace is fully upgraded.
+              </p>
+            ) : (
+              <p className="mb-4 text-green-600">
+                This workspace is not upgraded.
+              </p>
+            )}
+            <JsonViewer value={workspace.plan} rootName={false} />
+            <div className="mt-4 flex-row">
+              <Button
+                label="Downgrade"
+                type="secondaryWarning"
+                onClick={onDowngrade}
+                disabled={!isFullyUpgraded}
+              />
+              <Button
+                label="Upgrade"
+                type="secondary"
+                onClick={onUpgrade}
+                disabled={isFullyUpgraded}
+              />
+            </div>
           </div>
-        </>
+          <div className="mx-2 w-1/3">
+            <h2 className="text-md mb-4 font-bold">Data Sources:</h2>
+            {dataSources.map((ds) => (
+              <div
+                key={ds.id}
+                className="my-4 rounded-lg border-2 border-gray-200 p-4 shadow-lg"
+              >
+                <div className="flex items-center justify-between">
+                  <h3 className="mb-2 text-lg font-semibold">{ds.name}</h3>
+                  <Button
+                    label="Delete"
+                    type="secondaryWarning"
+                    onClick={() => onDataSourcesDelete(ds.name)}
+                  />
+                </div>
+                <p className="mb-2 text-sm text-gray-600">
+                  {ds.connectorProvider ? "Managed - " : "Non-managed - "}{" "}
+                  <span className="font-medium">
+                    {documentCounts[ds.name] ?? 0}
+                  </span>{" "}
+                  documents
+                </p>
+                {dataSourcesSynchronizedAgo[ds.name] && (
+                  <p className="mb-2 text-sm text-gray-600">
+                    Synchronized {dataSourcesSynchronizedAgo[ds.name]} ago
+                  </p>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/front/pages/poke/[wId]/index.tsx
+++ b/front/pages/poke/[wId]/index.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@dust-tt/sparkle";
+import { Button, Tooltip } from "@dust-tt/sparkle";
 import { JsonViewer } from "@textea/json-viewer";
 import { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
@@ -201,6 +201,10 @@ const WorkspacePage = ({
     }
   };
 
+  const workspaceHasManagedDataSources = dataSources.some(
+    (ds) => !!ds.connectorProvider
+  );
+
   const isFullyUpgraded =
     workspace.plan?.limits.dataSources.count === -1 &&
     workspace.plan?.limits.dataSources.documents.count === -1 &&
@@ -225,20 +229,34 @@ const WorkspacePage = ({
               </p>
             )}
             <JsonViewer value={workspace.plan} rootName={false} />
-            <div className="mt-4 flex-row">
-              <Button
-                label="Downgrade"
-                type="secondaryWarning"
-                onClick={onDowngrade}
-                disabled={!isFullyUpgraded}
-              />
-              <Button
-                label="Upgrade"
-                type="secondary"
-                onClick={onUpgrade}
-                disabled={isFullyUpgraded}
-              />
+            <div>
+              <div className="mt-4 flex-row">
+                <Button
+                  label="Downgrade"
+                  type="secondaryWarning"
+                  onClick={onDowngrade}
+                  disabled={!isFullyUpgraded || workspaceHasManagedDataSources}
+                />
+                <Tooltip
+                  label={"delete managed data sources first"}
+                  position="below"
+                >
+                  <Button
+                    label="Upgrade"
+                    type="secondary"
+                    onClick={onUpgrade}
+                    disabled={isFullyUpgraded}
+                  />
+                </Tooltip>
+              </div>
             </div>
+            {isFullyUpgraded && workspaceHasManagedDataSources && (
+              <span className="mx-2 w-1/3">
+                <p className="mb-4 text-sm text-warning ">
+                  Delete managed data sources before downgrading.
+                </p>
+              </span>
+            )}
           </div>
           <div className="mx-2 w-1/3">
             <h2 className="text-md mb-4 font-bold">Data Sources:</h2>


### PR DESCRIPTION
- you can see the list of data sources (managed first, then non-managed)
- you can see how many docs they have
- you can see the last successful sync time
- you can delete them
    - I fixed a pretty sad bug on `connectors` where the `Connector` object's deletion wasn't actually committed
    - Currently, we do not scrub the GCP data -- wondering if we should cc @spolu 