### PR TITLE
Disable tailwind input text outline css rule

### DIFF
--- a/front/styles/global.css
+++ b/front/styles/global.css
@@ -35,3 +35,8 @@ main {
     content: "";
   }
 }
+
+/* Override the default focus styles for input[type="text"] */
+input[type="text"]:focus {
+  outline: none;
+}


### PR DESCRIPTION
Source: https://dust4ai.slack.com/archives/C050SM8NSPK/p1691048998252609

Some new CSS rules have been applied to our inputs (I guess with Sparkle introduction).
An `outline` was was adding a blue border on focus that was overriding our borders (that can be grey, blue or red).

The good fix will be to introduce a `TextInput` component on Sparkle and use it everywhere. 
This is a dirty fix. I could have added an `outline-none` to each text fields over adding a CSS rule, but I picked this option. 

**Classes `outline-none`:**
- Pro: We keep our global.css clean.
- Con: We have to manually add it to each fields. Takes more time. 

**Global CSS rule:** 
- Pro: Quick, instantly for all inputs. 
- Con: The engineer who will implement the inputText in Sparkle needs to see this CSS rule and remove it. 