### PR TITLE
Poke: Scrub GCP when deleting a Managed datasource

### DIFF
--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/index.ts
@@ -145,7 +145,6 @@ async function handler(
         await Promise.all(
           chunk.map((f) => {
             return (async () => {
-              console.log(`Deleting file: ${f.name}`);
               await f.delete();
             })();
           })

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/index.ts
@@ -8,7 +8,7 @@ import { ReturnedAPIErrorType } from "@app/lib/error";
 import { DataSource, Workspace } from "@app/lib/models";
 import { apiError, withLogging } from "@app/logger/withlogging";
 
-const { DUST_DATA_SOURCES_BUCKET = "", SERVICE_ACCOUNT } = process.env;
+const { DUST_DATA_SOURCES_BUCKET, SERVICE_ACCOUNT } = process.env;
 
 export type DeleteDataSourceResponseBody = {
   success: true;
@@ -48,7 +48,16 @@ async function handler(
           status_code: 500,
           api_error: {
             type: "internal_server_error",
-            message: "Could not find the service account for GCP.",
+            message: "Could not find the service account for GCP config.",
+          },
+        });
+      }
+      if (!DUST_DATA_SOURCES_BUCKET) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "Could not find the datasource bucket config.",
           },
         });
       }

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/index.ts
@@ -1,3 +1,4 @@
+import { Storage } from "@google-cloud/storage";
 import { NextApiRequest, NextApiResponse } from "next";
 
 import { getSession, getUserFromSession } from "@app/lib/auth";
@@ -6,6 +7,8 @@ import { CoreAPI } from "@app/lib/core_api";
 import { ReturnedAPIErrorType } from "@app/lib/error";
 import { DataSource, Workspace } from "@app/lib/models";
 import { apiError, withLogging } from "@app/logger/withlogging";
+
+const { DUST_DATA_SOURCES_BUCKET = "", SERVICE_ACCOUNT } = process.env;
 
 export type DeleteDataSourceResponseBody = {
   success: true;
@@ -40,6 +43,16 @@ async function handler(
 
   switch (req.method) {
     case "DELETE":
+      if (!SERVICE_ACCOUNT) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "Could not find the service account for GCP.",
+          },
+        });
+      }
+
       const { wId } = req.query;
       if (!wId || typeof wId !== "string") {
         return apiError(req, res, {
@@ -112,7 +125,33 @@ async function handler(
 
       await dataSource.destroy();
 
-      // TODO SHOULD WE SCRUB ?!
+      const storage = new Storage({ keyFilename: SERVICE_ACCOUNT });
+
+      const [files] = await storage
+        .bucket(DUST_DATA_SOURCES_BUCKET)
+        .getFiles({ prefix: dustAPIProjectId });
+
+      const chunkSize = 32;
+      const chunks = [];
+      for (let i = 0; i < files.length; i += chunkSize) {
+        chunks.push(files.slice(i, i + chunkSize));
+      }
+
+      for (let i = 0; i < chunks.length; i++) {
+        const chunk = chunks[i];
+        if (!chunk) {
+          continue;
+        }
+        await Promise.all(
+          chunk.map((f) => {
+            return (async () => {
+              console.log(`Deleting file: ${f.name}`);
+              await f.delete();
+            })();
+          })
+        );
+      }
+
       return res.status(200).json({ success: true });
 
     default:

--- a/k8s/deployments/front-deployment.yaml
+++ b/k8s/deployments/front-deployment.yaml
@@ -37,6 +37,8 @@ spec:
           volumeMounts:
             - name: cert-volume
               mountPath: /etc/certs
+            - name: service-account-volume
+              mountPath: /etc/service-account
 
           resources:
             requests:
@@ -51,3 +53,6 @@ spec:
         - name: cert-volume
           secret:
             secretName: temporal-front-cert
+        - name: service-account-volume
+          secret:
+            secretName: service-account-secret


### PR DESCRIPTION
I copied from admin/cli. 
I could have moved into a file in `/front/lib` to avoid duplication but as it's dangerous I like the fact it's not exported.

Not tested yet, I'll test on my local!

