### PR TITLE
fix(slack connector): skip webhook if slack channel not yet in DB

### DIFF
--- a/connectors/src/api/webhooks/webhook_slack.ts
+++ b/connectors/src/api/webhooks/webhook_slack.ts
@@ -215,18 +215,14 @@ const _webhookSlackAPIHandler = async (
                   },
                 });
                 if (!slackChannel) {
-                  logger.error(
+                  logger.info(
                     {
                       connectorId: c.connectorId,
                       slackChannelId: channel,
                     },
-                    "Could not find Slack channel in DB"
+                    "Skipping wehbook: Slack channel not yet in DB"
                   );
-                  return new Err(
-                    new Error(
-                      `Could not find Slack channel ${channel} in DB for connector ${c.connectorId}`
-                    )
-                  );
+                  return new Ok(undefined);
                 }
                 if (!["read", "read_write"].includes(slackChannel.permission)) {
                   logger.info(
@@ -262,18 +258,14 @@ const _webhookSlackAPIHandler = async (
                   },
                 });
                 if (!slackChannel) {
-                  logger.error(
+                  logger.info(
                     {
                       connectorId: c.connectorId,
                       slackChannelId: channel,
                     },
-                    "Could not find Slack channel in DB"
+                    "Skipping wehbook: Slack channel not yet in DB"
                   );
-                  return new Err(
-                    new Error(
-                      `Could not find Slack channel ${channel} in DB for connector ${c.connectorId}`
-                    )
-                  );
+                  return new Ok(undefined);
                 }
                 if (!["read", "read_write"].includes(slackChannel.permission)) {
                   logger.info(


### PR DESCRIPTION
https://dust4ai.slack.com/archives/C050SM8NSPK/p1691044310540319

when the bot is invited to a new channel, we create a workflow to process this channel. 
If there is already a "bot joined channel" workflow for this connector, then we signal this workflow to also process the channel in question: the channels are then processed sequentially. However, the webhooks are immediately activated for the channel, which creates errors because we cannot find the channel object (and we can't check if the bot has read permission on them).

With this change, we'll skip the webhooks if we don't have the channel object. This is fine, because if we have read permission we'll sync the full channel anyway. As soon as we start syncing the channel, we'll save the channel object so we'll start accepting the webhooks.