### PR TITLE
enh(slack connector permissions): order channels by createdAt DESC

### DIFF
--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -317,7 +317,10 @@ export async function retrieveSlackConnectorPermissions(
     where: {
       connectorId: connectorId,
     },
-    order: [["createdAt", "DESC"]],
+    order: [
+      ["createdAt", "DESC"],
+      ["slackChannelName", "ASC"],
+    ],
   });
 
   const resources: ConnectorResource[] = slackChannels.map((ch) => ({

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -312,11 +312,14 @@ export async function retrieveSlackConnectorPermissions(
     logger.error({ connectorId }, "Slack configuration not found");
     return new Err(new Error("Slack configuration not found"));
   }
+
   const slackChannels = await SlackChannel.findAll({
     where: {
       connectorId: connectorId,
     },
+    order: [["createdAt", "DESC"]],
   });
+
   const resources: ConnectorResource[] = slackChannels.map((ch) => ({
     provider: "slack",
     internalId: ch.slackChannelId,


### PR DESCRIPTION
https://dust4ai.slack.com/archives/C0525Q93AEL/p1690966855068439?thread_ts=1690966735.468889&cid=C0525Q93AEL

Will be kind of random in case of full sync, but gets us most of the way there and should solve the pain in majority of cases