### PR TITLE
Chat: No API call for new chat

### DIFF
--- a/front/lib/swr.ts
+++ b/front/lib/swr.ts
@@ -227,10 +227,18 @@ export function useChatSessions(
   };
 }
 
-export function useChatSession(owner: WorkspaceType, cId: string) {
+export function useChatSession({
+  owner,
+  cId,
+  disabled,
+}: {
+  owner: WorkspaceType;
+  cId: string;
+  disabled?: boolean;
+}) {
   const runsFetcher: Fetcher<GetChatSessionResponseBody> = fetcher;
   const { data, error, mutate } = useSWR(
-    `/api/w/${owner.sId}/use/chats/${cId}`,
+    disabled ? null : `/api/w/${owner.sId}/use/chats/${cId}`,
     runsFetcher
   );
 


### PR DESCRIPTION
**Context**

When we click on "New Chat" a sId is generated and it redirects to `chat/[sId]`.
Meaning that on `chat/[sId]`, we have to deal with both cases: the chat session exist or the chat session is new.


It used to be done on getServerSideProps: We were querying the db and it would return null if there was no session, in which case we were generating a fake `ChatSessionType` object. 

Se here: https://github.com/dust-tt/dust/pull/1052/files#diff-b4851b50e49603ac62c665b6752cbe5bbbcb981bffac7c59ba2aa39716a71075L152

I removed this code yesterday because I needed to benefit from the mutate SWR mechanism.
We are now are fetching the ChatSession from the API using `useChatSession`.

That means we now have a 404 when the Chat is new and there's no existing Session. 
It's not a problem for user but, and in a sense a 404 makes sense, but we want to be able to distinguish real 404 (when we queried a session that should exist and is not, and this use case).

So this PR introduces a hacky solution: 
On the `getServerSideProps`, we check if the session exist or not by querying the DB, and we set a boolean `isNewChat`.
We then pass this boolean to disable or not the SWR request. This pattern already exist in the codebase.

I think the proper fix would be to not generate a `sId`, and redirect in the url to pretend being in an existing session. 
If I'm on `/w/[wId]/u/chat/` then it's a new chat, and if I'm on `/w/[wId]/u/chat/[sId]` I'm on an existing chat session. 

Currently, as the generated sId is used from the url, we can easily generate chat sessions called badly, such as `/w/[wId]/u/chat/soupinou` or `/w/[wId]/u/chat/[sId]/somethingverylongnotsurethisisabigproblembutweshouldprobablyfixit`.