### PR TITLE
fix(gdrive): reduce upsert concurrency to 1 per workflow

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -36,7 +36,7 @@ import logger from "@connectors/logger/logger";
 
 import { registerWebhook } from "../lib";
 
-const FILES_SYNC_CONCURRENCY = 3;
+const FILES_SYNC_CONCURRENCY = 1;
 const FILES_GC_CONCURRENCY = 3;
 
 const MIME_TYPES_TO_EXPORT: { [key: string]: string } = {


### PR DESCRIPTION
We can bump it a little if we seem to be able to handle it