### PR TITLE
Chat: Remove hack and fetch session from API even if new

### DIFF
--- a/front/lib/swr.ts
+++ b/front/lib/swr.ts
@@ -230,15 +230,13 @@ export function useChatSessions(
 export function useChatSession({
   owner,
   cId,
-  disabled,
 }: {
   owner: WorkspaceType;
   cId: string;
-  disabled?: boolean;
 }) {
   const runsFetcher: Fetcher<GetChatSessionResponseBody> = fetcher;
   const { data, error, mutate } = useSWR(
-    disabled ? null : `/api/w/${owner.sId}/use/chats/${cId}`,
+    `/api/w/${owner.sId}/use/chats/${cId}`,
     runsFetcher
   );
 

--- a/front/pages/api/w/[wId]/use/chats/[cId]/index.ts
+++ b/front/pages/api/w/[wId]/use/chats/[cId]/index.ts
@@ -43,7 +43,7 @@ const chatSessionUpdateSchema: JSONSchemaType<{
 };
 
 export type ChatSessionResponseBody = {
-  session: ChatSessionType;
+  session: ChatSessionType | null;
 };
 
 async function handler(
@@ -186,13 +186,7 @@ async function handler(
       const session = await getChatSessionWithMessages(auth, cId);
 
       if (!session) {
-        return apiError(req, res, {
-          status_code: 404,
-          api_error: {
-            type: "chat_session_not_found",
-            message: "The chat session was not found.",
-          },
-        });
+        return res.status(200).json({ session: null });
       }
 
       res.status(200).json({

--- a/front/pages/w/[wId]/u/chat/[cId]/index.tsx
+++ b/front/pages/w/[wId]/u/chat/[cId]/index.tsx
@@ -78,9 +78,9 @@ type DataSource = {
 };
 
 export const getServerSideProps: GetServerSideProps<{
+  chatSessionId: string;
   user: UserType | null;
   owner: WorkspaceType;
-  isNewChat: boolean;
   workspaceDataSources: DataSource[];
   prodCredentials: DustAPICredentials;
   url: string;
@@ -142,13 +142,12 @@ export const getServerSideProps: GetServerSideProps<{
   });
 
   const cId = context.params?.cId as string;
-  const chatSession = await getChatSessionWithMessages(auth, cId);
 
   return {
     props: {
+      chatSessionId: cId,
       user,
       owner,
-      isNewChat: chatSession === null,
       workspaceDataSources: dataSources,
       prodCredentials,
       url: URL,
@@ -565,23 +564,21 @@ export function MessageView({
 }
 
 export default function AppChat({
+  chatSessionId,
   user,
   owner,
   workspaceDataSources,
   prodCredentials,
   url,
   gaTrackingId,
-  isNewChat,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const router = useRouter();
 
   const prodAPI = new DustAPI(prodCredentials);
-  const chatSessionId = router.query.cId as string;
 
   const { chatSession, mutateChatSession } = useChatSession({
     owner,
     cId: chatSessionId,
-    disabled: isNewChat,
   });
 
   let readOnly = true;
@@ -1021,6 +1018,8 @@ export default function AppChat({
     void (async () => {
       const t = await updateTitle(title, m);
       await upsertChatSession(t);
+      void mutateChatSession();
+      void mutateChatSessions();
     })();
 
     setLoading(false);


### PR DESCRIPTION
Context must read: https://github.com/dust-tt/dust/pull/1079

This was a wrong fix. Hacking that it's a new chat or not from serverSideProps that are not reloaded was not a good solution. 
It's legit to query the API to know if a session exists or not. 

I think having the 404 was fine but for two reasons I added a commit to answer empty instead of raising a 404:
- Even before all this rework, querying `/chat/anything` would create a new session with `sId=anything` and not raise an error. 
- We don't want errors on Datadog that are not errors. 

While working on that I discovered that the `sId` is unique (among all workspaces), we might want to fix that because I'm not sure we correctly handle this error (even if not likely to happen soon?).
