### PR TITLE
fix(poke): mount service account volume on front-worker

### DIFF
--- a/k8s/deployments/front-worker-deployment.yaml
+++ b/k8s/deployments/front-worker-deployment.yaml
@@ -36,6 +36,8 @@ spec:
           volumeMounts:
             - name: cert-volume
               mountPath: /etc/certs
+            - name: service-account-volume
+              mountPath: /etc/service-accounts
 
           resources:
             requests:
@@ -50,3 +52,6 @@ spec:
         - name: cert-volume
           secret:
             secretName: temporal-front-cert
+        - name: service-account-volume
+          secret:
+            secretName: gcp-service-account-secret


### PR DESCRIPTION
we now need the service account in `front-worker` as that's where we're scrubbing from