### PR TITLE
Allow no title in title prop in Notion

### DIFF
--- a/connectors/src/connectors/notion/lib/notion_api.ts
+++ b/connectors/src/connectors/notion/lib/notion_api.ts
@@ -603,7 +603,9 @@ function parsePropertyText(
     case "last_edited_time":
       return property.last_edited_time;
     case "title":
-      return property.title.map((t) => t.plain_text).join(" ");
+      return property.title
+        ? property.title.map((t) => t.plain_text).join(" ")
+        : null;
     case "rich_text":
       return property.rich_text.map((t) => t.plain_text).join(" ");
     case "people":


### PR DESCRIPTION
Seen in the wild: https://app.datadoghq.eu/logs?query=%40workflowId%3Aworkflow-notion-b69afe5b30-managed-notion-result-page-251-pages-0-gc%20&cols=host%2Cservice&event=AgAAAYn9UKwT4fYCdQAAAAAAAAAYAAAAAEFZbjlVTFBNQUFBaUtLZkV1SkxtalFBNQAAACQAAAAAMDE4OWZkNTEtNjE0Ny00MzRmLTg2NGItZWJmMjg1NDllOTY5&index=%2A&messageDisplay=inline&stream_sort=desc&viz=stream&from_ts=1692157545635&to_ts=1692171945635&live=true