### PR TITLE
Follow-up to #1100

### DIFF
--- a/connectors/src/connectors/notion/lib/notion_api.ts
+++ b/connectors/src/connectors/notion/lib/notion_api.ts
@@ -603,7 +603,7 @@ function parsePropertyText(
     case "last_edited_time":
       return property.last_edited_time;
     case "title":
-      return property.title
+      return property.title && property.title.map
         ? property.title.map((t) => t.plain_text).join(" ")
         : null;
     case "rich_text":


### PR DESCRIPTION
https://github.com/dust-tt/dust/pull/1100 didn't fix it. See: https://app.datadoghq.eu/logs?query=%22Unhandled%20Activity%20Error%22%20&cols=host%2Cservice&event=AgAAAYn9W5JwTg0DiQAAAAAAAAAYAAAAAEFZbjlXNWMyQUFBdDJuVDBNTjdMeVFGTgAAACQAAAAAMDE4OWZkNWItOWFkMS00ZDBlLWE2M2UtYmZlMWI2YWJmMTc2&index=%2A&messageDisplay=inline&stream_sort=desc&viz=stream&from_ts=1692171980643&to_ts=1692172880643&live=true

Looks like the object is not null AND wrongly typed (typescript guarantees `RichTextResponse[]` but that's clearly not an array based on the error).