### PR TITLE
Reduce metrics cardinality

### DIFF
--- a/connectors/src/logger/withlogging.ts
+++ b/connectors/src/logger/withlogging.ts
@@ -51,7 +51,8 @@ export const withLogging = (handler: any) => {
 
     const tags = [
       `method:${req.method}`,
-      `url:${req.url}`,
+      // Removed due to high cardinality
+      // `url:${req.url}`,
       `status_code:${res.statusCode}`,
     ];
 

--- a/front/logger/withlogging.ts
+++ b/front/logger/withlogging.ts
@@ -49,7 +49,8 @@ export const withLogging = (handler: any) => {
 
     const tags = [
       `method:${req.method}`,
-      `url:${req.url}`,
+      // Removed due to high cardinality
+      // `url:${req.url}`,
       `status_code:${res.statusCode}`,
     ];
 


### PR DESCRIPTION
as per email from datadog most of the metrics cardinatlity comes from the URL tag in our request count and duration distribution. Removing it since we're not using it: https://app.datadoghq.eu/metric/summary?facet.metric_type=-is_non_distribution&metric=requests.duration.distribution