### PR TITLE
Decrease MAX_ITERATION_PER_WORKFLOW for Notion

### DIFF
--- a/connectors/src/connectors/notion/temporal/workflows.ts
+++ b/connectors/src/connectors/notion/temporal/workflows.ts
@@ -38,7 +38,7 @@ const {
 
 // soft limit on the number of iterations of the loop that should be ran in a single workflow
 // before "continuing as new" to avoid hitting the workflow log size limit
-const MAX_ITERATIONS_PER_WORKFLOW = 50;
+const MAX_ITERATIONS_PER_WORKFLOW = 32;
 
 // Notion's "last edited" timestamp is precise to the minute
 const SYNC_PERIOD_DURATION_MS = 60_000;


### PR DESCRIPTION
cc @fontanierh 

We run in this with Alan's Notion here: https://cloud.temporal.io/namespaces/dust-prod.gmnlm/workflows/workflow-notion-4d76593070-managed-notion/272397a7-9d9d-498b-9a3b-d616c4b706b8/history?per-page=100

I presume this is due to the addition of the DB activities. Decreasing from 50 to 32 but may require another look at it and probably some form of alerting?