### PR TITLE
Do not pass nango connection id through temporal workflow

### DIFF
--- a/connectors/src/connectors/notion/temporal/client.ts
+++ b/connectors/src/connectors/notion/temporal/client.ts
@@ -27,8 +27,6 @@ export async function launchNotionSyncWorkflow(
   }
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
 
-  const nangoConnectionId = connector.connectionId;
-
   const workflow = await getNotionWorkflow(dataSourceConfig);
 
   if (workflow && workflow.executionDescription.status.name === "RUNNING") {
@@ -42,12 +40,7 @@ export async function launchNotionSyncWorkflow(
   }
 
   await client.workflow.start(notionSyncWorkflow, {
-    args: [
-      dataSourceConfig,
-      nangoConnectionId,
-      startFromTs || undefined,
-      forceResync,
-    ],
+    args: [dataSourceConfig, startFromTs || undefined, forceResync],
     taskQueue: QUEUE_NAME,
     workflowId: getWorkflowId(dataSourceConfig),
   });

--- a/connectors/src/connectors/notion/temporal/config.ts
+++ b/connectors/src/connectors/notion/temporal/config.ts
@@ -1,2 +1,2 @@
-export const WORKFLOW_VERSION = 16;
+export const WORKFLOW_VERSION = 17;
 export const QUEUE_NAME = `notion-queue-v${WORKFLOW_VERSION}`;

--- a/connectors/src/connectors/notion/temporal/workflows.ts
+++ b/connectors/src/connectors/notion/temporal/workflows.ts
@@ -61,7 +61,6 @@ function preProcessTimestampForNotion(ts: number) {
 
 export async function notionSyncWorkflow(
   dataSourceConfig: DataSourceConfig,
-  nangoConnectionId: string,
   startFromTs?: number,
   forceResync = false
 ) {
@@ -74,7 +73,7 @@ export async function notionSyncWorkflow(
   setHandler(getLastSyncPeriodTsQuery, () => lastSyncedPeriodTs);
 
   const { notionAccessToken, shouldGargageCollect: isGargageCollectionRun } =
-    await getInitialWorkflowParamsActivity(dataSourceConfig, nangoConnectionId);
+    await getInitialWorkflowParamsActivity(dataSourceConfig);
 
   const isInitialSync = !lastSyncedPeriodTs;
 
@@ -242,7 +241,6 @@ export async function notionSyncWorkflow(
 
   await continueAsNew<typeof notionSyncWorkflow>(
     dataSourceConfig,
-    nangoConnectionId,
     // Cannot actually be undefined, but TS doesn't know that.
     lastSyncedPeriodTs ?? undefined
   );


### PR DESCRIPTION
This is motivated by: https://dust4ai.slack.com/archives/C050SM8NSPK/p1692621512325619

When re-authing notion we now change the nango connection Id (safe re-auth to avoid cross workspace auth). Or so far we were storing the nango connection Id in the Notion temporal workflow which is long lived.

This PR relies on the dataSourceConfig to find that information at each start of the workflow. This is not entirely perfect as we will be running on the old notion access token for as long as the workflow runs (until continued as new), but this should "work" as the access tokens are probably the same anyway.

In the future we might want to restart the workflow when we update the token so that we're sure it runs on the right nango connection id.