### PR TITLE
Managed Data Source view

### DIFF
--- a/connectors/src/api/delete_connector.ts
+++ b/connectors/src/api/delete_connector.ts
@@ -76,8 +76,6 @@ const _deleteConnectorAPIHandler = async (
 
     await connector.destroy({ transaction: t });
 
-    await t.commit();
-
     return res.json({
       success: true,
     });

--- a/connectors/src/api/get_connector_permissions.ts
+++ b/connectors/src/api/get_connector_permissions.ts
@@ -4,7 +4,10 @@ import { RETRIEVE_CONNECTOR_PERMISSIONS_BY_TYPE } from "@connectors/connectors";
 import { Connector } from "@connectors/lib/models";
 import { apiError, withLogging } from "@connectors/logger/withlogging";
 import { ConnectorsAPIErrorResponse } from "@connectors/types/errors";
-import { ConnectorResource } from "@connectors/types/resources";
+import {
+  ConnectorPermission,
+  ConnectorResource,
+} from "@connectors/types/resources";
 
 type GetConnectorPermissionsRes =
   | { resources: ConnectorResource[] }
@@ -29,6 +32,15 @@ const _getConnectorPermissions = async (
       ? null
       : req.query.parentId;
 
+  let filterPermission: ConnectorPermission | null = null;
+  if (
+    req.query.filterPermission &&
+    typeof req.query.filterPermission === "string" &&
+    ["read"].includes(req.query.filterPermission)
+  ) {
+    filterPermission = "read";
+  }
+
   const connector = await Connector.findByPk(req.params.connector_id);
   if (!connector) {
     return apiError(req, res, {
@@ -45,7 +57,8 @@ const _getConnectorPermissions = async (
 
   const pRes = await connectorPermissionRetriever(
     connector.id,
-    parentInternalId
+    parentInternalId,
+    filterPermission
   );
 
   if (pRes.isErr()) {

--- a/connectors/src/connectors/index.ts
+++ b/connectors/src/connectors/index.ts
@@ -144,7 +144,8 @@ export const SYNC_CONNECTOR_BY_TYPE: Record<ConnectorProvider, SyncConnector> =
 
 type ConnectorPermissionRetriever = (
   connectorId: ModelId,
-  parentInternalId: string | null
+  parentInternalId: string | null,
+  filterPermission: ConnectorPermission | null
 ) => Promise<Result<ConnectorResource[], Error>>;
 
 export const RETRIEVE_CONNECTOR_PERMISSIONS_BY_TYPE: Record<

--- a/front/components/ConnectorPermissionsModal.tsx
+++ b/front/components/ConnectorPermissionsModal.tsx
@@ -5,7 +5,7 @@ import {
 } from "@dust-tt/sparkle";
 import { Dialog, Transition } from "@headlessui/react";
 import { Cog6ToothIcon } from "@heroicons/react/20/solid";
-import { Fragment, useEffect, useState } from "react";
+import { Fragment, useState } from "react";
 import { mutate } from "swr";
 
 import {
@@ -14,18 +14,10 @@ import {
   ConnectorType,
 } from "@app/lib/connectors_api";
 import { useConnectorDefaultNewResourcePermission } from "@app/lib/swr";
-import { timeAgoFrom } from "@app/lib/utils";
 import { DataSourceType } from "@app/types/data_source";
 import { WorkspaceType } from "@app/types/user";
 
 import { PermissionTree } from "./ConnectorPermissionsTree";
-
-const CONNECTOR_TYPE_TO_NAME: Record<ConnectorProvider, string> = {
-  notion: "Notion",
-  google_drive: "Google Drive",
-  slack: "Slack",
-  github: "GitHub",
-};
 
 const CONNECTOR_TYPE_TO_RESOURCE_NAME: Record<ConnectorProvider, string> = {
   notion: "top-level Notion pages or databases",
@@ -74,15 +66,6 @@ export default function ConnectorPermissionsModal({
   setOpen: (open: boolean) => void;
   onEditPermission: () => void;
 }) {
-  const [synchronizedTimeAgo, setSynchronizedTimeAgo] = useState<string | null>(
-    null
-  );
-
-  useEffect(() => {
-    if (connector.lastSyncSuccessfulTime)
-      setSynchronizedTimeAgo(timeAgoFrom(connector.lastSyncSuccessfulTime));
-  }, []);
-
   const [updatedPermissionByInternalId, setUpdatedPermissionByInternalId] =
     useState<Record<string, ConnectorPermission>>({});
 
@@ -214,64 +197,47 @@ export default function ConnectorPermissionsModal({
               leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
             >
               <Dialog.Panel className="relative max-w-2xl transform overflow-hidden rounded-lg bg-white px-4 pb-4 text-left shadow-xl transition-all sm:p-6 lg:w-1/2">
-                <div className="flex items-start justify-between sm:mt-5">
-                  <div>
-                    <Dialog.Title
-                      as="h3"
-                      className="text-xl font-semibold leading-6 text-gray-900"
-                    >
-                      {CONNECTOR_TYPE_TO_NAME[connector.type]} permissions
-                    </Dialog.Title>
-                    {synchronizedTimeAgo && (
-                      <span className="text-gray-500">
-                        Last synchronized ~{synchronizedTimeAgo} ago
-                      </span>
-                    )}
-                    <div className="mt-4">
+                <div className="mt-5 flex items-start justify-between sm:mt-0">
+                  <Button
+                    onClick={() => {
+                      onEditPermission();
+                    }}
+                    labelVisible={true}
+                    label="Re-authorize"
+                    type="tertiary"
+                    size="xs"
+                    icon={Cog6ToothIcon}
+                  />
+                  {Object.keys(updatedPermissionByInternalId).length ||
+                  automaticallyIncludeNewResources !== null ? (
+                    <div className="flex gap-1">
                       <Button
-                        onClick={() => {
-                          onEditPermission();
-                        }}
                         labelVisible={true}
-                        label="Re-authorize"
-                        type="tertiary"
+                        onClick={closeModal}
+                        label="Cancel"
+                        type="secondary"
                         size="xs"
-                        icon={Cog6ToothIcon}
+                      />
+                      <Button
+                        labelVisible={true}
+                        onClick={save}
+                        label="Save"
+                        type="primary"
+                        size="xs"
                       />
                     </div>
-                  </div>
-                  <div>
-                    {Object.keys(updatedPermissionByInternalId).length ||
-                    automaticallyIncludeNewResources !== null ? (
-                      <div className="flex gap-1">
-                        <Button
-                          labelVisible={true}
-                          onClick={closeModal}
-                          label="Cancel"
-                          type="secondary"
-                          size="xs"
-                        />
-                        <Button
-                          labelVisible={true}
-                          onClick={save}
-                          label="Save"
-                          type="primary"
-                          size="xs"
-                        />
-                      </div>
-                    ) : (
-                      <div onClick={closeModal} className="cursor-pointer">
-                        <XCircleIcon className="h-6 w-6 text-gray-500" />
-                      </div>
-                    )}
-                  </div>
+                  ) : (
+                    <div onClick={closeModal} className="cursor-pointer">
+                      <XCircleIcon className="h-6 w-6 text-gray-500" />
+                    </div>
+                  )}
                 </div>
                 {!isDefaultNewResourcePermissionLoading &&
                 defaultNewResourcePermission ? (
                   <>
                     {canUpdatePermissions ? (
-                      <div className=" mt-8 flex flex-row">
-                        <span className="ml-2 text-sm text-gray-500">
+                      <div className="ml-2 mt-8 flex flex-row">
+                        <span className="text-sm text-gray-500">
                           {defaultPermissionTitleText}
                         </span>
                         <div className="flex-grow">
@@ -291,13 +257,13 @@ export default function ConnectorPermissionsModal({
                       </div>
                     ) : null}
                     <div>
-                      <div className="mt-16">
-                        <div className="px-2 text-sm text-gray-500">
+                      <div className="ml-2 mt-16">
+                        <div className="text-sm text-gray-500">
                           {resourceListTitleText}
                         </div>
                       </div>
                     </div>
-                    <div className="mb-16 mt-8">
+                    <div className="mb-16 ml-2 mt-8">
                       <PermissionTree
                         owner={owner}
                         dataSource={dataSource}

--- a/front/components/ConnectorPermissionsTree.tsx
+++ b/front/components/ConnectorPermissionsTree.tsx
@@ -1,0 +1,159 @@
+import { Checkbox, DocumentTextIcon } from "@dust-tt/sparkle";
+import {
+  ChatBubbleLeftRightIcon,
+  CircleStackIcon,
+  FolderIcon,
+} from "@heroicons/react/20/solid";
+import { useState } from "react";
+
+import {
+  ConnectorPermission,
+  ConnectorResourceType,
+} from "@app/lib/connectors_api";
+import { useConnectorPermissions } from "@app/lib/swr";
+import { DataSourceType } from "@app/types/data_source";
+import { WorkspaceType } from "@app/types/user";
+
+import { Spinner } from "./Spinner";
+
+export type IconComponentType =
+  | typeof DocumentTextIcon
+  | typeof FolderIcon
+  | typeof CircleStackIcon
+  | typeof ChatBubbleLeftRightIcon;
+
+function getIconForType(type: ConnectorResourceType): IconComponentType {
+  switch (type) {
+    case "file":
+      return DocumentTextIcon;
+    case "folder":
+      return FolderIcon;
+    case "database":
+      return CircleStackIcon;
+    case "channel":
+      return ChatBubbleLeftRightIcon;
+    default:
+      ((n: never) => {
+        throw new Error("Unreachable " + n);
+      })(type);
+  }
+}
+
+function PermissionTreeChildren({
+  owner,
+  dataSource,
+  parentId,
+  permissionFilter,
+  canUpdatePermissions,
+  onPermissionUpdate,
+}: {
+  owner: WorkspaceType;
+  dataSource: DataSourceType;
+  parentId: string | null;
+  permissionFilter?: ConnectorPermission;
+  canUpdatePermissions?: boolean;
+  onPermissionUpdate?: ({
+    internalId,
+    permission,
+  }: {
+    internalId: string;
+    permission: ConnectorPermission;
+  }) => void;
+}) {
+  const { resources, isResourcesLoading, isResourcesError } =
+    useConnectorPermissions(
+      owner,
+      dataSource,
+      parentId,
+      permissionFilter || null
+    );
+
+  const [localStateByInternalId, setLocalStateByInternalId] = useState<
+    Record<string, boolean>
+  >({});
+
+  if (isResourcesError) {
+    return (
+      <div className="text-red-300">
+        Failed to retrieve permissions likely due to a revoked authorization.
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {isResourcesLoading ? (
+        <Spinner />
+      ) : (
+        <div className="space-y-1">
+          {resources.map((r) => {
+            const IconComponent = getIconForType(r.type);
+            const titlePrefix = r.type === "channel" ? "#" : "";
+            return (
+              <div key={r.internalId}>
+                <div className="flex flex-row items-center py-1 text-sm">
+                  <IconComponent className="h-6 w-6 text-slate-300" />
+                  <span className="ml-2 text-sm font-medium text-element-900">{`${titlePrefix}${r.title}`}</span>
+                  {canUpdatePermissions && onPermissionUpdate ? (
+                    <div className="flex-grow">
+                      <Checkbox
+                        className="ml-auto"
+                        checked={
+                          localStateByInternalId[r.internalId] ??
+                          ["read", "read_write"].includes(r.permission)
+                        }
+                        onChange={(checked) => {
+                          setLocalStateByInternalId((prev) => ({
+                            ...prev,
+                            [r.internalId]: checked,
+                          }));
+                          onPermissionUpdate({
+                            internalId: r.internalId,
+                            permission: checked ? "read_write" : "write",
+                          });
+                        }}
+                      />
+                    </div>
+                  ) : null}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </>
+  );
+}
+
+export function PermissionTree({
+  owner,
+  dataSource,
+  permissionFilter,
+  canUpdatePermissions,
+  onPermissionUpdate,
+}: {
+  owner: WorkspaceType;
+  dataSource: DataSourceType;
+  permissionFilter?: ConnectorPermission;
+  canUpdatePermissions?: boolean;
+  onPermissionUpdate?: ({
+    internalId,
+    permission,
+  }: {
+    internalId: string;
+    permission: ConnectorPermission;
+  }) => void;
+}) {
+  return (
+    <div className="">
+      <PermissionTreeChildren
+        owner={owner}
+        dataSource={dataSource}
+        parentId={null}
+        permissionFilter={permissionFilter}
+        canUpdatePermissions={canUpdatePermissions}
+        onPermissionUpdate={onPermissionUpdate}
+      />
+    </div>
+  );
+}

--- a/front/lib/connectors_api.ts
+++ b/front/lib/connectors_api.ts
@@ -184,14 +184,20 @@ export const ConnectorsAPI = {
   async getConnectorPermissions({
     connectorId,
     parentId,
+    filterPermission,
   }: {
     connectorId: string;
     parentId?: string;
+    filterPermission?: ConnectorPermission;
   }): Promise<ConnectorsAPIResponse<{ resources: ConnectorResource[] }>> {
-    let url = `${CONNECTORS_API}/connectors/${connectorId}/permissions`;
+    let url = `${CONNECTORS_API}/connectors/${connectorId}/permissions?source=front`;
     if (parentId) {
-      url += `?parentId=${parentId}`;
+      url += `&parentId=${parentId}`;
     }
+    if (filterPermission) {
+      url += `&filterPermission=${filterPermission}`;
+    }
+
     const res = await fetch(url, {
       method: "GET",
       headers: getDefaultHeaders(),

--- a/front/lib/swr.ts
+++ b/front/lib/swr.ts
@@ -25,6 +25,8 @@ import { DataSourceType } from "@app/types/data_source";
 import { RunRunType } from "@app/types/run";
 import { WorkspaceType } from "@app/types/user";
 
+import { ConnectorPermission } from "./connectors_api";
+
 export const fetcher = async (...args: Parameters<typeof fetch>) =>
   fetch(...args).then(async (res) => {
     if (res.status >= 300) {
@@ -293,14 +295,18 @@ export function useEventSchemas(owner: WorkspaceType) {
 export function useConnectorPermissions(
   owner: WorkspaceType,
   dataSource: DataSourceType,
-  parentId: string | null
+  parentId: string | null,
+  filterPermission: ConnectorPermission | null
 ) {
   const permissionsFetcher: Fetcher<GetDataSourcePermissionsResponseBody> =
     fetcher;
 
-  let url = `/api/w/${owner.sId}/data_sources/${dataSource.name}/managed/permissions`;
+  let url = `/api/w/${owner.sId}/data_sources/${dataSource.name}/managed/permissions?source=client`;
   if (parentId) {
-    url += `?parentId=${parentId}`;
+    url += `&parentId=${parentId}`;
+  }
+  if (filterPermission) {
+    url += `&filterPermission=${filterPermission}`;
   }
 
   const { data, error } = useSWR(url, permissionsFetcher);

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/permissions/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/permissions/index.ts
@@ -5,7 +5,11 @@ import { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSource } from "@app/lib/api/data_sources";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { ConnectorResource, ConnectorsAPI } from "@app/lib/connectors_api";
+import {
+  ConnectorPermission,
+  ConnectorResource,
+  ConnectorsAPI,
+} from "@app/lib/connectors_api";
 import { ReturnedAPIErrorType } from "@app/lib/error";
 import { apiError, withLogging } from "@app/logger/withlogging";
 
@@ -74,6 +78,15 @@ async function handler(
         parentId = req.query.parentId;
       }
 
+      let filterPermission: ConnectorPermission | undefined = undefined;
+      if (
+        req.query.filterPermission &&
+        typeof req.query.filterPermission === "string" &&
+        ["read"].includes(req.query.filterPermission)
+      ) {
+        filterPermission = "read";
+      }
+
       if (!dataSource.connectorId) {
         return apiError(req, res, {
           status_code: 400,
@@ -87,6 +100,7 @@ async function handler(
       const permissionsRes = await ConnectorsAPI.getConnectorPermissions({
         connectorId: dataSource.connectorId,
         parentId,
+        filterPermission,
       });
       if (permissionsRes.isErr()) {
         return apiError(req, res, {

--- a/front/pages/w/[wId]/ds/[name]/index.tsx
+++ b/front/pages/w/[wId]/ds/[name]/index.tsx
@@ -5,32 +5,61 @@ import {
   SectionHeader,
 } from "@dust-tt/sparkle";
 import { TrashIcon } from "@heroicons/react/20/solid";
+import Nango from "@nangohq/frontend";
 import { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import { useSWRConfig } from "swr";
 
+import ConnectorPermissionsModal from "@app/components/ConnectorPermissionsModal";
+import { PermissionTree } from "@app/components/ConnectorPermissionsTree";
+import GoogleDriveFoldersPickerModal from "@app/components/GoogleDriveFoldersPickerModal";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { subNavigationAdmin } from "@app/components/sparkle/navigation";
 import { getDataSource } from "@app/lib/api/data_sources";
 import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
+import { buildConnectionId } from "@app/lib/connector_connection_id";
+import {
+  connectorIsUsingNango,
+  ConnectorProvider,
+  ConnectorsAPI,
+  ConnectorType,
+} from "@app/lib/connectors_api";
 import {
   getDisplayNameForDocument,
   getProviderLogoPathForDataSource,
 } from "@app/lib/data_sources";
+import { githubAuth } from "@app/lib/github_auth";
 import { useDocuments } from "@app/lib/swr";
 import { timeAgoFrom } from "@app/lib/utils";
 import { DataSourceType } from "@app/types/data_source";
 import { UserType, WorkspaceType } from "@app/types/user";
 
-const { GA_TRACKING_ID = "" } = process.env;
+import { DATA_SOURCE_INTEGRATIONS } from "..";
+
+const {
+  GA_TRACKING_ID = "",
+  NANGO_SLACK_CONNECTOR_ID = "",
+  NANGO_NOTION_CONNECTOR_ID = "",
+  NANGO_GOOGLE_DRIVE_CONNECTOR_ID = "",
+  NANGO_PUBLIC_KEY = "",
+  GITHUB_APP_URL = "",
+} = process.env;
 
 export const getServerSideProps: GetServerSideProps<{
   user: UserType | null;
   owner: WorkspaceType;
   readOnly: boolean;
   dataSource: DataSourceType;
+  connector: ConnectorType | null;
+  nangoConfig: {
+    publicKey: string;
+    slackConnectorId: string;
+    notionConnectorId: string;
+    googleDriveConnectorId: string;
+  };
+  githubAppUrl: string;
   gaTrackingId: string;
 }> = async (context) => {
   const session = await getSession(context.req, context.res);
@@ -54,8 +83,17 @@ export const getServerSideProps: GetServerSideProps<{
     };
   }
 
-  // Managed data sources are read-only (you can't add a document).
-  const readOnly = !auth.isBuilder() || !!dataSource.connectorId;
+  let connector: ConnectorType | null = null;
+  if (dataSource.connectorId) {
+    const connectorRes = await ConnectorsAPI.getConnector(
+      dataSource.connectorId
+    );
+    if (connectorRes.isOk()) {
+      connector = connectorRes.value;
+    }
+  }
+
+  const readOnly = !auth.isBuilder();
 
   return {
     props: {
@@ -63,18 +101,30 @@ export const getServerSideProps: GetServerSideProps<{
       owner,
       readOnly,
       dataSource,
+      connector,
+      nangoConfig: {
+        publicKey: NANGO_PUBLIC_KEY,
+        slackConnectorId: NANGO_SLACK_CONNECTOR_ID,
+        notionConnectorId: NANGO_NOTION_CONNECTOR_ID,
+        googleDriveConnectorId: NANGO_GOOGLE_DRIVE_CONNECTOR_ID,
+      },
+      githubAppUrl: GITHUB_APP_URL,
       gaTrackingId: GA_TRACKING_ID,
     },
   };
 };
 
-export default function DataSourceView({
+function StandardDataSourceView({
   user,
   owner,
   readOnly,
   dataSource,
-  gaTrackingId,
-}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+}: {
+  user: UserType | null;
+  owner: WorkspaceType;
+  readOnly: boolean;
+  dataSource: DataSourceType;
+}) {
   const { mutate } = useSWRConfig();
 
   const [limit] = useState(10);
@@ -130,6 +180,414 @@ export default function DataSourceView({
   };
 
   return (
+    <div className="flex flex-col">
+      <SectionHeader
+        title={`Manage ${dataSource.name}`}
+        description="Use this page to view and upload documents to your data source."
+        action={
+          readOnly
+            ? undefined
+            : {
+                label: "Settings",
+                type: "tertiary",
+                icon: Cog6ToothIcon,
+                onClick: () => {
+                  void router.push(
+                    `/w/${owner.sId}/ds/${dataSource.name}/settings`
+                  );
+                },
+              }
+        }
+      />
+
+      <div className="mt-16 flex flex-row">
+        <div className="flex flex-1">
+          <div className="flex flex-col">
+            <div className="flex flex-row">
+              <div className="flex flex-initial">
+                <div className="flex">
+                  <Button
+                    type="tertiary"
+                    disabled={offset < limit}
+                    onClick={() => {
+                      if (offset >= limit) {
+                        setOffset(offset - limit);
+                      } else {
+                        setOffset(0);
+                      }
+                    }}
+                    label="Previous"
+                  />
+                </div>
+                <div className="ml-2 flex">
+                  <Button
+                    type="tertiary"
+                    label="Next"
+                    disabled={offset + limit >= total}
+                    onClick={() => {
+                      if (offset + limit < total) {
+                        setOffset(offset + limit);
+                      }
+                    }}
+                  />
+                </div>
+              </div>
+            </div>
+
+            <div className="mt-3 flex flex-auto pl-2 text-sm text-gray-700">
+              {total > 0 && (
+                <span>
+                  Showing documents {offset + 1} - {last} of {total} documents
+                </span>
+              )}
+            </div>
+          </div>
+        </div>
+        {readOnly ? null : (
+          <div className="">
+            <div className="mt-0 flex-none">
+              <Button
+                type="secondary"
+                icon={PlusIcon}
+                label="Document"
+                onClick={() => {
+                  // Enforce plan limits: DataSource documents count.
+                  if (
+                    owner.plan.limits.dataSources.documents.count != -1 &&
+                    total >= owner.plan.limits.dataSources.documents.count
+                  ) {
+                    window.alert(
+                      "Data Sources are limited to 32 documents on our free plan. Contact team@dust.tt if you want to increase this limit."
+                    );
+                    return;
+                  } else {
+                    void router.push(
+                      `/w/${owner.sId}/ds/${dataSource.name}/upsert`
+                    );
+                  }
+                }}
+              />
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div className="mt-8 overflow-hidden pb-8">
+        <ul role="list" className="space-y-4">
+          {documents.map((d) => (
+            <li
+              key={d.document_id}
+              className="group rounded border border-gray-300 px-2 px-4"
+            >
+              <Link
+                href={`/w/${owner.sId}/ds/${
+                  dataSource.name
+                }/upsert?documentId=${encodeURIComponent(d.document_id)}`}
+                className="block"
+              >
+                <div className="mx-2 py-4">
+                  <div className="grid grid-cols-5 items-center justify-between">
+                    <div className="col-span-4">
+                      <div className="flex">
+                        {documentPoviderIconPath ? (
+                          <div className="mr-1.5 mt-1 flex h-4 w-4 flex-initial">
+                            <img src={documentPoviderIconPath}></img>
+                          </div>
+                        ) : null}
+                        <p className="truncate text-base font-bold text-action-600">
+                          {displayNameByDocId[d.document_id]}
+                        </p>
+                      </div>
+                    </div>
+                    <div className="col-span-1">
+                      {readOnly ? null : (
+                        <div className="ml-2 flex flex-row">
+                          <div className="flex flex-1"></div>
+                          <div className="flex flex-initial">
+                            <TrashIcon
+                              className="hidden h-4 w-4 text-gray-400 hover:text-red-600 group-hover:block"
+                              onClick={async (e) => {
+                                e.preventDefault();
+                                await handleDelete(d.document_id);
+                              }}
+                            />
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                  <div className="mt-2 flex justify-between">
+                    <div className="flex flex-initial">
+                      <p className="text-sm text-gray-300">
+                        {Math.floor(d.text_size / 1024)} kb / {d.chunk_count}{" "}
+                        chunks{" "}
+                      </p>
+                    </div>
+                    <div className="mt-0 flex items-center">
+                      <p className="text-sm text-gray-500">
+                        {timeAgoFrom(d.timestamp)} ago
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </Link>
+            </li>
+          ))}
+          {documents.length == 0 ? (
+            <div className="mt-10 flex flex-col items-center justify-center text-sm text-gray-500">
+              <p>No documents found for this Data Source.</p>
+              <p className="mt-2">
+                You can upload documents manually or by API.
+              </p>
+            </div>
+          ) : null}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+const CONNECTOR_TYPE_TO_HELPER_TEXT: Record<ConnectorProvider, string> = {
+  notion:
+    "Explore the top-level Notion pages and databases Dust has access to:",
+  google_drive:
+    "Explore the Google Drive folders and files Dust has access to:",
+  slack: "Explore the Slack channels Dust has access to:",
+  github: "Explore the GitHub repositories Dust has access to:",
+};
+
+function ManagedDataSourceView({
+  user,
+  owner,
+  readOnly,
+  dataSource,
+  connector,
+  nangoConfig,
+  githubAppUrl,
+}: {
+  user: UserType | null;
+  owner: WorkspaceType;
+  readOnly: boolean;
+  dataSource: DataSourceType;
+  connector: ConnectorType;
+  nangoConfig: {
+    publicKey: string;
+    slackConnectorId: string;
+    notionConnectorId: string;
+    googleDriveConnectorId: string;
+  };
+  githubAppUrl: string;
+}) {
+  const router = useRouter();
+
+  const [showPermissionModal, setShowPermissionModal] = useState(false);
+  const [googleDrivePickerOpen, setGoogleDrivePickerOpen] = useState(false);
+
+  const [synchronizedTimeAgo, setSynchronizedTimeAgo] = useState<string | null>(
+    null
+  );
+
+  const connectorProvider = dataSource.connectorProvider;
+  if (!connectorProvider) {
+    throw new Error("Connector provider is not defined");
+  }
+
+  useEffect(() => {
+    if (connector.lastSyncSuccessfulTime)
+      setSynchronizedTimeAgo(timeAgoFrom(connector.lastSyncSuccessfulTime));
+  }, []);
+
+  const handleUpdatePermissions = async () => {
+    if (!connector) {
+      console.error("No connector");
+      return;
+    }
+    const provider = connector.type;
+
+    if (connectorIsUsingNango(provider)) {
+      const nangoConnectorId = {
+        slack: nangoConfig.slackConnectorId,
+        notion: nangoConfig.notionConnectorId,
+        google_drive: nangoConfig.googleDriveConnectorId,
+      }[provider];
+
+      const nango = new Nango({ publicKey: nangoConfig.publicKey });
+
+      const newConnectionId = buildConnectionId(owner.sId, provider);
+      await nango.auth(nangoConnectorId, newConnectionId);
+
+      const updateRes = await updateConnectorConnectionId(
+        newConnectionId,
+        provider
+      );
+      if (updateRes.error) {
+        window.alert(updateRes.error);
+      }
+
+      if (connector && connector.type === "google_drive") {
+        setGoogleDrivePickerOpen(true);
+      }
+    } else if (provider === "github") {
+      const installationId = await githubAuth(githubAppUrl).catch((e) => {
+        console.error(e);
+      });
+
+      if (!installationId) {
+        window.alert(
+          "Failed to update the Github permissions. Please contact-us at team@dust.tt"
+        );
+      } else {
+        const updateRes = await updateConnectorConnectionId(
+          installationId,
+          provider
+        );
+        if (updateRes.error) {
+          window.alert(updateRes.error);
+        }
+      }
+    }
+  };
+
+  const updateConnectorConnectionId = async (
+    newConnectionId: string,
+    provider: string
+  ) => {
+    const res = await fetch(
+      `/api/w/${owner.sId}/data_sources/${dataSource.name}/managed/update`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ connectionId: newConnectionId }),
+      }
+    );
+
+    if (res.ok) {
+      return { success: true, error: null };
+    }
+
+    const jsonErr = await res.json();
+    const error = jsonErr.error;
+
+    if (error.type === "connector_oauth_target_mismatch") {
+      if (provider === "slack") {
+        return {
+          success: false,
+          error: `You cannot select another Slack Team.\nPlease contact us at team@dust.tt if you initially selected the wrong Team.`,
+        };
+      }
+      if (provider === "notion") {
+        return {
+          success: false,
+          error:
+            "You cannot select another Notion Workspace.\nPlease contact us at team@dust.tt if you initially selected a wrong Workspace.",
+        };
+      }
+      if (provider === "github") {
+        return {
+          success: false,
+          error:
+            "You cannot select another Github Organization.\nPlease contact us at team@dust.tt if you initially selected a wrong Organization.",
+        };
+      }
+      if (provider === "google_drive") {
+        return {
+          success: false,
+          error:
+            "You cannot select another Google Drive Domain.\nPlease contact us at team@dust.tt if you initially selected a wrong shared Drive.",
+        };
+      }
+    }
+    return {
+      success: false,
+      error: `Failed to update the permissions of the Data Source: (contact team@dust.tt for assistance)`,
+    };
+  };
+
+  return (
+    <>
+      <ConnectorPermissionsModal
+        owner={owner}
+        connector={connector}
+        dataSource={dataSource}
+        isOpen={showPermissionModal}
+        setOpen={setShowPermissionModal}
+        onEditPermission={() => {
+          void handleUpdatePermissions();
+        }}
+      />
+      {connector && connector?.type == "google_drive" && (
+        <GoogleDriveFoldersPickerModal
+          owner={owner}
+          connectorId={connector.id}
+          isOpen={googleDrivePickerOpen}
+          setOpen={setGoogleDrivePickerOpen}
+        />
+      )}
+      <div className="flex flex-col gap-8">
+        <SectionHeader
+          title={`${DATA_SOURCE_INTEGRATIONS[connectorProvider].name} Permissions`}
+          description={
+            synchronizedTimeAgo
+              ? `Last Sync ~ ${synchronizedTimeAgo}`
+              : `Synchronizing`
+          }
+          action={
+            readOnly
+              ? undefined
+              : {
+                  label: "Settings",
+                  type: "tertiary",
+                  icon: Cog6ToothIcon,
+                  onClick: () => {
+                    void router.push(
+                      `/w/${owner.sId}/ds/${dataSource.name}/settings`
+                    );
+                  },
+                }
+          }
+        />
+        <div className="flex flex-row items-center justify-between">
+          <div className="text-sm text-element-900">
+            {CONNECTOR_TYPE_TO_HELPER_TEXT[connectorProvider]}
+          </div>
+          <Button
+            label="Edit permissions"
+            type="secondary"
+            onClick={() => {
+              if (connectorProvider === "slack") {
+                setShowPermissionModal(true);
+              } else {
+                void handleUpdatePermissions();
+              }
+            }}
+          />
+        </div>
+
+        <div>
+          <PermissionTree
+            owner={owner}
+            dataSource={dataSource}
+            permissionFilter="read"
+          />
+        </div>
+      </div>
+    </>
+  );
+}
+
+export default function DataSourceView({
+  user,
+  owner,
+  readOnly,
+  dataSource,
+  connector,
+  nangoConfig,
+  githubAppUrl,
+  gaTrackingId,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  return (
     <AppLayout
       user={user}
       owner={owner}
@@ -140,166 +598,21 @@ export default function DataSourceView({
         current: "data_sources",
       })}
     >
-      <div className="flex flex-col">
-        <SectionHeader
-          title={`Manage ${dataSource.name}`}
-          description="Use this page to view and upload documents to your data source."
-          action={{
-            label: "Settings",
-            type: "tertiary",
-            icon: Cog6ToothIcon,
-            onClick: () => {
-              void router.push(
-                `/w/${owner.sId}/ds/${dataSource.name}/settings`
-              );
-            },
+      {dataSource.connectorId && connector ? (
+        <ManagedDataSourceView
+          {...{
+            user,
+            owner,
+            readOnly,
+            dataSource,
+            connector,
+            nangoConfig,
+            githubAppUrl,
           }}
         />
-
-        <div className="mt-16 flex flex-row">
-          <div className="flex flex-1">
-            <div className="flex flex-col">
-              <div className="flex flex-row">
-                <div className="flex flex-initial">
-                  <div className="flex">
-                    <Button
-                      type="tertiary"
-                      disabled={offset < limit}
-                      onClick={() => {
-                        if (offset >= limit) {
-                          setOffset(offset - limit);
-                        } else {
-                          setOffset(0);
-                        }
-                      }}
-                      label="Previous"
-                    />
-                  </div>
-                  <div className="ml-2 flex">
-                    <Button
-                      type="tertiary"
-                      label="Next"
-                      disabled={offset + limit >= total}
-                      onClick={() => {
-                        if (offset + limit < total) {
-                          setOffset(offset + limit);
-                        }
-                      }}
-                    />
-                  </div>
-                </div>
-              </div>
-
-              <div className="mt-3 flex flex-auto pl-2 text-sm text-gray-700">
-                {total > 0 && (
-                  <span>
-                    Showing documents {offset + 1} - {last} of {total} documents
-                  </span>
-                )}
-              </div>
-            </div>
-          </div>
-          {readOnly ? null : (
-            <div className="">
-              <div className="mt-0 flex-none">
-                <Button
-                  type="secondary"
-                  icon={PlusIcon}
-                  label="Document"
-                  onClick={() => {
-                    // Enforce plan limits: DataSource documents count.
-                    if (
-                      owner.plan.limits.dataSources.documents.count != -1 &&
-                      total >= owner.plan.limits.dataSources.documents.count
-                    ) {
-                      window.alert(
-                        "Data Sources are limited to 32 documents on our free plan. Contact team@dust.tt if you want to increase this limit."
-                      );
-                      return;
-                    } else {
-                      void router.push(
-                        `/w/${owner.sId}/ds/${dataSource.name}/upsert`
-                      );
-                    }
-                  }}
-                />
-              </div>
-            </div>
-          )}
-        </div>
-
-        <div className="mt-8 overflow-hidden pb-8">
-          <ul role="list" className="space-y-4">
-            {documents.map((d) => (
-              <li
-                key={d.document_id}
-                className="group rounded border border-gray-300 px-2 px-4"
-              >
-                <Link
-                  href={`/w/${owner.sId}/ds/${
-                    dataSource.name
-                  }/upsert?documentId=${encodeURIComponent(d.document_id)}`}
-                  className="block"
-                >
-                  <div className="mx-2 py-4">
-                    <div className="grid grid-cols-5 items-center justify-between">
-                      <div className="col-span-4">
-                        <div className="flex">
-                          {documentPoviderIconPath ? (
-                            <div className="mr-1.5 mt-1 flex h-4 w-4 flex-initial">
-                              <img src={documentPoviderIconPath}></img>
-                            </div>
-                          ) : null}
-                          <p className="truncate text-base font-bold text-action-600">
-                            {displayNameByDocId[d.document_id]}
-                          </p>
-                        </div>
-                      </div>
-                      <div className="col-span-1">
-                        {readOnly ? null : (
-                          <div className="ml-2 flex flex-row">
-                            <div className="flex flex-1"></div>
-                            <div className="flex flex-initial">
-                              <TrashIcon
-                                className="hidden h-4 w-4 text-gray-400 hover:text-red-600 group-hover:block"
-                                onClick={async (e) => {
-                                  e.preventDefault();
-                                  await handleDelete(d.document_id);
-                                }}
-                              />
-                            </div>
-                          </div>
-                        )}
-                      </div>
-                    </div>
-                    <div className="mt-2 flex justify-between">
-                      <div className="flex flex-initial">
-                        <p className="text-sm text-gray-300">
-                          {Math.floor(d.text_size / 1024)} kb / {d.chunk_count}{" "}
-                          chunks{" "}
-                        </p>
-                      </div>
-                      <div className="mt-0 flex items-center">
-                        <p className="text-sm text-gray-500">
-                          {timeAgoFrom(d.timestamp)} ago
-                        </p>
-                      </div>
-                    </div>
-                  </div>
-                </Link>
-              </li>
-            ))}
-            {documents.length == 0 ? (
-              <div className="mt-10 flex flex-col items-center justify-center text-sm text-gray-500">
-                <p>No documents found for this Data Source.</p>
-                <p className="mt-2">
-                  You can upload documents manually or by API.
-                </p>
-              </div>
-            ) : null}
-          </ul>
-        </div>
-      </div>
+      ) : (
+        <StandardDataSourceView {...{ user, owner, readOnly, dataSource }} />
+      )}
     </AppLayout>
   );
 }

--- a/front/pages/w/[wId]/ds/[name]/search.tsx
+++ b/front/pages/w/[wId]/ds/[name]/search.tsx
@@ -1,8 +1,10 @@
 import { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import Link from "next/link";
+import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 
 import AppLayout from "@app/components/sparkle/AppLayout";
+import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { subNavigationAdmin } from "@app/components/sparkle/navigation";
 import { getDataSource } from "@app/lib/api/data_sources";
 import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
@@ -78,6 +80,8 @@ export default function DataSourceView({
 
   const documentPoviderIconPath = getProviderLogoPathForDataSource(dataSource);
 
+  const router = useRouter();
+
   useEffect(
     () =>
       setDisplayNameByDocId(
@@ -147,17 +151,17 @@ export default function DataSourceView({
         owner,
         current: "data_sources",
       })}
+      titleChildren={
+        <AppLayoutSimpleCloseTitle
+          title="Search documents"
+          onClose={() => {
+            void router.push(`/w/${owner.sId}/ds/${dataSource.name}`);
+          }}
+        />
+      }
     >
       <div className="flex flex-col">
         <div className="sm:col-span-6">
-          <div className="flex justify-between">
-            <label
-              htmlFor="appDescription"
-              className="block text-sm font-medium text-gray-700"
-            >
-              Search Documents
-            </label>
-          </div>
           <div className="mt-1 flex rounded-md shadow-sm">
             <input
               type="text"

--- a/front/pages/w/[wId]/ds/index.tsx
+++ b/front/pages/w/[wId]/ds/index.tsx
@@ -53,7 +53,7 @@ type DataSourceIntegration = {
   setupWithSuffix: string | null;
 };
 
-const DATA_SOURCE_INTEGRATIONS: {
+export const DATA_SOURCE_INTEGRATIONS: {
   [key in ConnectorProvider]: {
     name: string;
     connectorProvider: ConnectorProvider;


### PR DESCRIPTION
The overall goal is simplification and step towards presenting an explorable hierarchy of files for Notion and Google Drive.

Refactor the managed data source view to show to the user what we see.

Currently we show only top-level resources for Notion and Google Drive but will add hierarchy exploration as a follow-up PR.
Centralize the Edit Permission in that view (directly send to Notion/Google/Github or open the popup for Slack since we have a layer of internal permission edition).

Simplify greatly to Managed data source settings screen.

Add a search button to managed data sources since some users may still be relying on it.

add filterPermission to the connectors API in preparation for Google Drive cc @lasryaric 