### PR TITLE
PermissionTree expansion + Notion implementation

### DIFF
--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -366,8 +366,6 @@ export async function retrieveNotionConnectorPermissions(
         });
         const expandable = child ? true : false;
 
-        console.log("PAGE", p.notionPageId, p.title);
-
         return {
           provider: c.type,
           internalId: p.notionPageId,
@@ -384,8 +382,6 @@ export async function retrieveNotionConnectorPermissions(
   );
 
   const dbResources: ConnectorResource[] = dbs.map((db) => {
-    console.log("PAGE", db.notionDatabaseId, db.title);
-
     return {
       provider: c.type,
       internalId: db.notionDatabaseId,

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -26,7 +26,6 @@ import { NangoConnectionId } from "@connectors/types/nango_connection_id";
 import {
   ConnectorPermission,
   ConnectorResource,
-  ConnectorResourceType,
 } from "@connectors/types/resources";
 
 const { NANGO_NOTION_CONNECTOR_ID } = process.env;

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -371,11 +371,11 @@ export async function retrieveNotionConnectorPermissions(
           internalId: p.notionPageId,
           parentInternalId:
             !p.parentId || p.parentId === "workspace" ? null : p.parentId,
-          type: "file" as ConnectorResourceType,
+          type: "file",
           title: p.title || "",
           sourceUrl: p.notionUrl || null,
           expandable,
-          permission: "read" as ConnectorPermission,
+          permission: "read",
         };
       })();
     })
@@ -387,11 +387,11 @@ export async function retrieveNotionConnectorPermissions(
       internalId: db.notionDatabaseId,
       parentInternalId:
         !db.parentId || db.parentId === "workspace" ? null : db.parentId,
-      type: "database" as ConnectorResourceType,
+      type: "database",
       title: db.title || "",
       sourceUrl: db.notionUrl || null,
       expandable: true,
-      permission: "read" as ConnectorPermission,
+      permission: "read",
     };
   });
 

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -366,6 +366,8 @@ export async function retrieveNotionConnectorPermissions(
         });
         const expandable = child ? true : false;
 
+        console.log("PAGE", p.notionPageId, p.title);
+
         return {
           provider: c.type,
           internalId: p.notionPageId,
@@ -381,17 +383,21 @@ export async function retrieveNotionConnectorPermissions(
     })
   );
 
-  const dbResources: ConnectorResource[] = dbs.map((db) => ({
-    provider: c.type,
-    internalId: db.notionDatabaseId,
-    parentInternalId:
-      !db.parentId || db.parentId === "workspace" ? null : db.parentId,
-    type: "database" as ConnectorResourceType,
-    title: db.title || "",
-    sourceUrl: db.notionUrl || null,
-    expandable: true,
-    permission: "read" as ConnectorPermission,
-  }));
+  const dbResources: ConnectorResource[] = dbs.map((db) => {
+    console.log("PAGE", db.notionDatabaseId, db.title);
+
+    return {
+      provider: c.type,
+      internalId: db.notionDatabaseId,
+      parentInternalId:
+        !db.parentId || db.parentId === "workspace" ? null : db.parentId,
+      type: "database" as ConnectorResourceType,
+      title: db.title || "",
+      sourceUrl: db.notionUrl || null,
+      expandable: true,
+      permission: "read" as ConnectorPermission,
+    };
+  });
 
   return new Ok(pageResources.concat(dbResources));
 }

--- a/front/components/ConnectorPermissionsTree.tsx
+++ b/front/components/ConnectorPermissionsTree.tsx
@@ -52,7 +52,6 @@ function PermissionTreeChildren({
   permissionFilter,
   canUpdatePermissions,
   onPermissionUpdate,
-  depth,
   showExpand,
 }: {
   owner: WorkspaceType;
@@ -67,7 +66,6 @@ function PermissionTreeChildren({
     internalId: string;
     permission: ConnectorPermission;
   }) => void;
-  depth: number;
   showExpand?: boolean;
 }) {
   const { resources, isResourcesLoading, isResourcesError } =
@@ -170,7 +168,6 @@ function PermissionTreeChildren({
                       permissionFilter={permissionFilter}
                       canUpdatePermissions={canUpdatePermissions}
                       onPermissionUpdate={onPermissionUpdate}
-                      depth={depth + 1}
                       showExpand={showExpand}
                     />
                   </div>
@@ -214,7 +211,6 @@ export function PermissionTree({
         permissionFilter={permissionFilter}
         canUpdatePermissions={canUpdatePermissions}
         onPermissionUpdate={onPermissionUpdate}
-        depth={0}
         showExpand={showExpand}
       />
     </div>

--- a/front/components/ConnectorPermissionsTree.tsx
+++ b/front/components/ConnectorPermissionsTree.tsx
@@ -1,4 +1,9 @@
-import { Checkbox, DocumentTextIcon } from "@dust-tt/sparkle";
+import {
+  Checkbox,
+  ChevronDownIcon,
+  ChevronRightIcon,
+  DocumentTextIcon,
+} from "@dust-tt/sparkle";
 import {
   ChatBubbleLeftRightIcon,
   CircleStackIcon,
@@ -11,6 +16,7 @@ import {
   ConnectorResourceType,
 } from "@app/lib/connectors_api";
 import { useConnectorPermissions } from "@app/lib/swr";
+import { classNames } from "@app/lib/utils";
 import { DataSourceType } from "@app/types/data_source";
 import { WorkspaceType } from "@app/types/user";
 
@@ -46,6 +52,8 @@ function PermissionTreeChildren({
   permissionFilter,
   canUpdatePermissions,
   onPermissionUpdate,
+  depth,
+  showExpand,
 }: {
   owner: WorkspaceType;
   dataSource: DataSourceType;
@@ -59,6 +67,8 @@ function PermissionTreeChildren({
     internalId: string;
     permission: ConnectorPermission;
   }) => void;
+  depth: number;
+  showExpand?: boolean;
 }) {
   const { resources, isResourcesLoading, isResourcesError } =
     useConnectorPermissions(
@@ -72,9 +82,11 @@ function PermissionTreeChildren({
     Record<string, boolean>
   >({});
 
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+
   if (isResourcesError) {
     return (
-      <div className="text-red-300">
+      <div className="text-sm text-warning">
         Failed to retrieve permissions likely due to a revoked authorization.
       </div>
     );
@@ -92,7 +104,39 @@ function PermissionTreeChildren({
             return (
               <div key={r.internalId}>
                 <div className="flex flex-row items-center py-1 text-sm">
-                  <IconComponent className="h-6 w-6 text-slate-300" />
+                  {showExpand && (
+                    <div className="mr-4">
+                      {expanded[r.internalId] ? (
+                        <ChevronDownIcon
+                          className="h-5 w-5 cursor-pointer text-action-600"
+                          onClick={() => {
+                            setExpanded((prev) => ({
+                              ...prev,
+                              [r.internalId]: false,
+                            }));
+                          }}
+                        />
+                      ) : (
+                        <ChevronRightIcon
+                          className={classNames(
+                            "h-5 w-5",
+                            r.expandable
+                              ? "cursor-pointer text-action-600"
+                              : "cursor-not-allowed text-slate-300"
+                          )}
+                          onClick={() => {
+                            if (r.expandable) {
+                              setExpanded((prev) => ({
+                                ...prev,
+                                [r.internalId]: true,
+                              }));
+                            }
+                          }}
+                        />
+                      )}
+                    </div>
+                  )}
+                  <IconComponent className="h-5 w-5 text-slate-300" />
                   <span className="ml-2 text-sm font-medium text-element-900">{`${titlePrefix}${r.title}`}</span>
                   {canUpdatePermissions && onPermissionUpdate ? (
                     <div className="flex-grow">
@@ -116,6 +160,21 @@ function PermissionTreeChildren({
                     </div>
                   ) : null}
                 </div>
+                {expanded[r.internalId] && (
+                  <div className="flex flex-row">
+                    <div className="ml-4" />
+                    <PermissionTreeChildren
+                      owner={owner}
+                      dataSource={dataSource}
+                      parentId={r.internalId}
+                      permissionFilter={permissionFilter}
+                      canUpdatePermissions={canUpdatePermissions}
+                      onPermissionUpdate={onPermissionUpdate}
+                      depth={depth + 1}
+                      showExpand={showExpand}
+                    />
+                  </div>
+                )}
               </div>
             );
           })}
@@ -131,6 +190,7 @@ export function PermissionTree({
   permissionFilter,
   canUpdatePermissions,
   onPermissionUpdate,
+  showExpand,
 }: {
   owner: WorkspaceType;
   dataSource: DataSourceType;
@@ -143,9 +203,10 @@ export function PermissionTree({
     internalId: string;
     permission: ConnectorPermission;
   }) => void;
+  showExpand?: boolean;
 }) {
   return (
-    <div className="">
+    <div className="overflow-x-auto">
       <PermissionTreeChildren
         owner={owner}
         dataSource={dataSource}
@@ -153,6 +214,8 @@ export function PermissionTree({
         permissionFilter={permissionFilter}
         canUpdatePermissions={canUpdatePermissions}
         onPermissionUpdate={onPermissionUpdate}
+        depth={0}
+        showExpand={showExpand}
       />
     </div>
   );

--- a/front/pages/w/[wId]/ds/[name]/index.tsx
+++ b/front/pages/w/[wId]/ds/[name]/index.tsx
@@ -346,7 +346,7 @@ function StandardDataSourceView({
 }
 
 const CONNECTOR_TYPE_TO_HELPER_TEXT: Record<ConnectorProvider, string> = {
-  notion: "Top-level Notion pages and databases Dust has access to:",
+  notion: "Explore the Notion pages and databases Dust has access to:",
   google_drive: "Google Drive folders and files Dust has access to:",
   slack: "Slack channels Dust has access to:",
   github: "GitHub repositories Dust has access to:",
@@ -360,6 +360,13 @@ const CONNECTOR_TYPE_TO_MISMATCH_ERROR: Record<ConnectorProvider, string> = {
     "You cannot select another Github Organization.\nPlease contact us at team@dust.tt if you initially selected a wrong Organization.",
   google_drive:
     "You cannot select another Google Drive Domain.\nPlease contact us at team@dust.tt if you initially selected a wrong shared Drive.",
+};
+
+const CONNECTOR_TYPE_TO_SHOW_EXPAND: Record<ConnectorProvider, boolean> = {
+  notion: true,
+  slack: false,
+  github: false,
+  google_drive: false,
 };
 
 function ManagedDataSourceView({
@@ -560,11 +567,12 @@ function ManagedDataSourceView({
           {CONNECTOR_TYPE_TO_HELPER_TEXT[connectorProvider]}
         </div>
 
-        <div>
+        <div className="pb-8">
           <PermissionTree
             owner={owner}
             dataSource={dataSource}
             permissionFilter="read"
+            showExpand={CONNECTOR_TYPE_TO_SHOW_EXPAND[connectorProvider]}
           />
         </div>
       </div>


### PR DESCRIPTION
Implements the ability for the PermissionTree to show children (lazily on-demand).

Enable this capability for the Notion connector.

![Screenshot from 2023-08-25 09-18-39](https://github.com/dust-tt/dust/assets/15067/565fab66-8229-4260-b9da-264b83fc6f4a)
