### PR TITLE
Save Gdrive Synchronized folders in our database

### DIFF
--- a/connectors/src/admin/db.ts
+++ b/connectors/src/admin/db.ts
@@ -5,7 +5,6 @@ import {
   GithubIssue,
   GoogleDriveFiles,
   GoogleDriveFolders,
-  GoogleDriveSyncedFolder,
   GoogleDriveSyncToken,
   GoogleDriveWebhook,
   NotionConnectorState,
@@ -34,7 +33,6 @@ async function main(): Promise<void> {
   await GoogleDriveFiles.sync({ alter: true });
   await GoogleDriveSyncToken.sync({ alter: true });
   await GoogleDriveWebhook.sync({ alter: true });
-  await GoogleDriveSyncedFolder.sync({ alter: true });
 }
 
 main()

--- a/connectors/src/admin/db.ts
+++ b/connectors/src/admin/db.ts
@@ -3,9 +3,9 @@ import {
   GithubConnectorState,
   GithubDiscussion,
   GithubIssue,
-  GoogleDriveBFSDedup,
   GoogleDriveFiles,
   GoogleDriveFolders,
+  GoogleDriveSyncedFolder,
   GoogleDriveSyncToken,
   GoogleDriveWebhook,
   NotionConnectorState,
@@ -34,7 +34,7 @@ async function main(): Promise<void> {
   await GoogleDriveFiles.sync({ alter: true });
   await GoogleDriveSyncToken.sync({ alter: true });
   await GoogleDriveWebhook.sync({ alter: true });
-  await GoogleDriveBFSDedup.sync({ alter: true });
+  await GoogleDriveSyncedFolder.sync({ alter: true });
 }
 
 main()

--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -508,17 +508,7 @@ export async function incrementalSync(
 
     const authCredentials = await getAuthObject(nangoConnectionId);
     const driveClient = await getDriveClient(authCredentials);
-    const lastSeenDB = await GoogleDriveSyncedFolder.findOne({
-      where: {
-        connectorId: connectorId,
-      },
-      order: [["lastSeenTs", "DESC"]],
-      limit: 1,
-    });
-    if (!lastSeenDB) {
-      throw new Error("Could not determine last run id");
-    }
-    const lastSeenTs = lastSeenDB.lastSeenTs.getTime();
+
     const changesRes: GaxiosResponse<drive_v3.Schema$ChangeList> =
       await driveClient.changes.list({
         driveId: driveId,

--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -956,20 +956,3 @@ async function driveObjectToDustType(
     };
   }
 }
-
-export async function getGoogleDriveObjects(
-  connectorId: ModelId,
-  ids: string[]
-): Promise<GoogleDriveObjectType[]> {
-  const connector = await Connector.findByPk(connectorId);
-  if (!connector) {
-    throw new Error(`Connector ${connectorId} not found`);
-  }
-  const authCredentials = await getAuthObject(connector.connectionId);
-  const objects: GoogleDriveObjectType[] = [];
-  for (const id of ids) {
-    const object = await getGoogleDriveObject(authCredentials, id);
-    objects.push(object);
-  }
-  return objects;
-}

--- a/connectors/src/connectors/google_drive/temporal/workflows.ts
+++ b/connectors/src/connectors/google_drive/temporal/workflows.ts
@@ -25,7 +25,6 @@ const {
   populateSyncTokens,
   garbageCollectorFinished,
   getLastGCTime,
-  cleanupSyncedFolders,
   incrementalSync,
 } = proxyActivities<typeof activities>({
   startToCloseTimeout: "20 minutes",
@@ -93,7 +92,6 @@ export async function googleDriveFullSync(
       );
     }
   }
-  await cleanupSyncedFolders(connectorId, lastSeenTs);
   await syncSucceeded(connectorId);
 
   if (garbageCollect) {

--- a/connectors/src/connectors/google_drive/temporal/workflows.ts
+++ b/connectors/src/connectors/google_drive/temporal/workflows.ts
@@ -26,14 +26,11 @@ const {
   populateSyncTokens,
   garbageCollectorFinished,
   getLastGCTime,
-  cleanupDedupList,
+  cleanupSyncedFolders: cleanupDedupList,
   getGoogleDriveObjects,
+  incrementalSync,
 } = proxyActivities<typeof activities>({
   startToCloseTimeout: "20 minutes",
-});
-
-const { incrementalSync } = proxyActivities<typeof activities>({
-  startToCloseTimeout: "120 minutes",
 });
 
 const { reportInitialSyncProgress, syncSucceeded } = proxyActivities<

--- a/connectors/src/connectors/google_drive/temporal/workflows.ts
+++ b/connectors/src/connectors/google_drive/temporal/workflows.ts
@@ -1,11 +1,9 @@
 import {
   continueAsNew,
   executeChild,
-  ParentClosePolicy,
   proxyActivities,
   setHandler,
   sleep,
-  startChild,
   workflowInfo,
 } from "@temporalio/workflow";
 
@@ -24,7 +22,6 @@ const {
   renewWebhooks,
   populateSyncTokens,
   garbageCollectorFinished,
-  getLastGCTime,
   incrementalSync,
 } = proxyActivities<typeof activities>({
   startToCloseTimeout: "20 minutes",
@@ -97,7 +94,7 @@ export async function googleDriveFullSync(
   if (garbageCollect) {
     await executeChild(googleDriveGarbageCollectorWorkflow.name, {
       workflowId: googleDriveGarbageCollectorWorkflowId(connectorId),
-      args: [connectorId, nangoConnectionId, dataSourceConfig],
+      args: [connectorId, startSyncTs],
     });
   }
   console.log("googleDriveFullSync done for connectorId", connectorId);

--- a/connectors/src/lib/models.ts
+++ b/connectors/src/lib/models.ts
@@ -739,6 +739,7 @@ GithubDiscussion.init(
 );
 Connector.hasMany(GithubDiscussion);
 
+// GoogleDriveFolders stores the folders selected by the user to sync.
 export class GoogleDriveFolders extends Model<
   InferAttributes<GoogleDriveFolders>,
   InferCreationAttributes<GoogleDriveFolders>
@@ -785,6 +786,7 @@ GoogleDriveFolders.init(
 
 Connector.hasOne(GoogleDriveFolders);
 
+// GoogleDriveFiles stores files and folders synced from Google Drive.
 export class GoogleDriveFiles extends Model<
   InferAttributes<GoogleDriveFiles>,
   InferCreationAttributes<GoogleDriveFiles>
@@ -796,7 +798,8 @@ export class GoogleDriveFiles extends Model<
   declare connectorId: ForeignKey<Connector["id"]>;
   declare dustFileId: string;
   declare driveFileId: string;
-  declare name: string;
+  declare name: string | null;
+  declare mimeType: string | null;
   declare parentId: string | null;
 }
 
@@ -835,7 +838,13 @@ GoogleDriveFiles.init(
     },
     name: {
       type: DataTypes.STRING,
-      allowNull: false,
+      allowNull: true,
+      defaultValue: "",
+    },
+    mimeType: {
+      type: DataTypes.STRING,
+      allowNull: true,
+      defaultValue: "",
     },
     parentId: {
       type: DataTypes.STRING,

--- a/connectors/src/lib/models.ts
+++ b/connectors/src/lib/models.ts
@@ -957,19 +957,21 @@ GoogleDriveWebhook.init(
 );
 Connector.hasOne(GoogleDriveWebhook);
 
-export class GoogleDriveBFSDedup extends Model<
-  InferAttributes<GoogleDriveBFSDedup>,
-  InferCreationAttributes<GoogleDriveBFSDedup>
+export class GoogleDriveSyncedFolder extends Model<
+  InferAttributes<GoogleDriveSyncedFolder>,
+  InferCreationAttributes<GoogleDriveSyncedFolder>
 > {
   declare id: CreationOptional<number>;
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
   declare connectorId: ForeignKey<Connector["id"]>;
   declare driveFolderId: string;
-  declare runId: string;
+  declare driveParentFolderId: string | null;
+  declare driveFolderName: string;
+  declare runAt: Date;
 }
 
-GoogleDriveBFSDedup.init(
+GoogleDriveSyncedFolder.init(
   {
     id: {
       type: DataTypes.INTEGER,
@@ -994,16 +996,27 @@ GoogleDriveBFSDedup.init(
       type: DataTypes.STRING,
       allowNull: false,
     },
-    runId: {
+    driveParentFolderId: {
       type: DataTypes.STRING,
+      allowNull: true,
+    },
+    driveFolderName: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    runAt: {
+      type: DataTypes.DATE,
       allowNull: false,
     },
   },
   {
     sequelize: sequelize_conn,
-    modelName: "google_drive_bfs_dedup",
+    modelName: "google_drive_synced_folder",
     indexes: [
-      { fields: ["connectorId", "driveFolderId", "runId"], unique: true },
+      {
+        fields: ["connectorId", "driveFolderId", "runId"],
+        unique: true,
+      },
     ],
   }
 );

--- a/connectors/src/lib/models.ts
+++ b/connectors/src/lib/models.ts
@@ -1014,7 +1014,7 @@ GoogleDriveSyncedFolder.init(
     modelName: "google_drive_synced_folder",
     indexes: [
       {
-        fields: ["connectorId", "driveFolderId", "runId"],
+        fields: ["connectorId", "driveFolderId", "runAt"],
         unique: true,
       },
     ],

--- a/connectors/src/lib/models.ts
+++ b/connectors/src/lib/models.ts
@@ -1014,7 +1014,7 @@ GoogleDriveSyncedFolder.init(
     modelName: "google_drive_synced_folder",
     indexes: [
       {
-        fields: ["connectorId", "driveFolderId", "lastSeenTs"],
+        fields: ["connectorId", "driveFolderId"],
         unique: true,
       },
     ],

--- a/connectors/src/lib/models.ts
+++ b/connectors/src/lib/models.ts
@@ -798,8 +798,8 @@ export class GoogleDriveFiles extends Model<
   declare connectorId: ForeignKey<Connector["id"]>;
   declare dustFileId: string;
   declare driveFileId: string;
-  declare name: string | null;
-  declare mimeType: string | null;
+  declare name: string;
+  declare mimeType: string;
   declare parentId: string | null;
 }
 
@@ -838,12 +838,12 @@ GoogleDriveFiles.init(
     },
     name: {
       type: DataTypes.STRING,
-      allowNull: true,
+      allowNull: false,
       defaultValue: "",
     },
     mimeType: {
       type: DataTypes.STRING,
-      allowNull: true,
+      allowNull: false,
       defaultValue: "",
     },
     parentId: {

--- a/connectors/src/lib/models.ts
+++ b/connectors/src/lib/models.ts
@@ -792,10 +792,12 @@ export class GoogleDriveFiles extends Model<
   declare id: CreationOptional<number>;
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
-  declare garbageCollectedAt: Date | null;
+  declare lastSeenTs: Date | null;
   declare connectorId: ForeignKey<Connector["id"]>;
   declare dustFileId: string;
   declare driveFileId: string;
+  declare name: string;
+  declare parentId: string | null;
 }
 
 GoogleDriveFiles.init(
@@ -815,7 +817,7 @@ GoogleDriveFiles.init(
       allowNull: false,
       defaultValue: DataTypes.NOW,
     },
-    garbageCollectedAt: {
+    lastSeenTs: {
       type: DataTypes.DATE,
       allowNull: true,
     },
@@ -830,6 +832,14 @@ GoogleDriveFiles.init(
     driveFileId: {
       type: DataTypes.STRING,
       allowNull: false,
+    },
+    name: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    parentId: {
+      type: DataTypes.STRING,
+      allowNull: true,
     },
   },
   {
@@ -956,67 +966,3 @@ GoogleDriveWebhook.init(
   }
 );
 Connector.hasOne(GoogleDriveWebhook);
-
-export class GoogleDriveSyncedFolder extends Model<
-  InferAttributes<GoogleDriveSyncedFolder>,
-  InferCreationAttributes<GoogleDriveSyncedFolder>
-> {
-  declare id: CreationOptional<number>;
-  declare createdAt: CreationOptional<Date>;
-  declare updatedAt: CreationOptional<Date>;
-  declare connectorId: ForeignKey<Connector["id"]>;
-  declare driveFolderId: string;
-  declare driveParentFolderId: string | null;
-  declare driveFolderName: string;
-  declare lastSeenTs: Date;
-}
-
-GoogleDriveSyncedFolder.init(
-  {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
-    createdAt: {
-      type: DataTypes.DATE,
-      allowNull: false,
-      defaultValue: DataTypes.NOW,
-    },
-    updatedAt: {
-      type: DataTypes.DATE,
-      allowNull: false,
-      defaultValue: DataTypes.NOW,
-    },
-    connectorId: {
-      type: DataTypes.INTEGER,
-      allowNull: false,
-    },
-    driveFolderId: {
-      type: DataTypes.STRING,
-      allowNull: false,
-    },
-    driveParentFolderId: {
-      type: DataTypes.STRING,
-      allowNull: true,
-    },
-    driveFolderName: {
-      type: DataTypes.STRING,
-      allowNull: false,
-    },
-    lastSeenTs: {
-      type: DataTypes.DATE,
-      allowNull: false,
-    },
-  },
-  {
-    sequelize: sequelize_conn,
-    modelName: "google_drive_synced_folder",
-    indexes: [
-      {
-        fields: ["connectorId", "driveFolderId"],
-        unique: true,
-      },
-    ],
-  }
-);

--- a/connectors/src/lib/models.ts
+++ b/connectors/src/lib/models.ts
@@ -968,7 +968,7 @@ export class GoogleDriveSyncedFolder extends Model<
   declare driveFolderId: string;
   declare driveParentFolderId: string | null;
   declare driveFolderName: string;
-  declare runAt: Date;
+  declare lastSeenTs: Date;
 }
 
 GoogleDriveSyncedFolder.init(
@@ -1004,7 +1004,7 @@ GoogleDriveSyncedFolder.init(
       type: DataTypes.STRING,
       allowNull: false,
     },
-    runAt: {
+    lastSeenTs: {
       type: DataTypes.DATE,
       allowNull: false,
     },
@@ -1014,7 +1014,7 @@ GoogleDriveSyncedFolder.init(
     modelName: "google_drive_synced_folder",
     indexes: [
       {
-        fields: ["connectorId", "driveFolderId", "runAt"],
+        fields: ["connectorId", "driveFolderId", "lastSeenTs"],
         unique: true,
       },
     ],

--- a/connectors/src/types/google_drive.ts
+++ b/connectors/src/types/google_drive.ts
@@ -6,6 +6,7 @@ export type GoogleDriveObjectType = {
   updatedAtMs?: number;
   webViewLink?: string;
   mimeType: string;
+  trashed: boolean;
   lastEditor?: {
     displayName: string;
   };

--- a/connectors/src/types/google_drive.ts
+++ b/connectors/src/types/google_drive.ts
@@ -1,6 +1,7 @@
-export type GoogleDriveFileType = {
+export type GoogleDriveObjectType = {
   id: string;
   name: string;
+  parent: string | null;
   createdAtMs: number;
   updatedAtMs?: number;
   webViewLink?: string;


### PR DESCRIPTION
We now save all Gdrive synchronized folders in our database. 

*** We stopped considering multiple parent for a given file as all my research online lead me to think that it does not exists anymore. ***

Google seems to have migrated all these files with multiple parents to shortcuts to these files.

## Full sync workflow:
Save every folder we visit in the our database.

## Incremental Sync workflow
For each file we visit, we get the full parent chain from the Gdrive API, and upsert each folder in our database.