### PR TITLE
Fix core build fail due to newly released rust version

### DIFF
--- a/.github/workflows/build-and-test-core.yml
+++ b/.github/workflows/build-and-test-core.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.71.1
 
       - name: checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Following discussions in [this pr](https://github.com/dust-tt/dust/pull/1135) and [this slack thread](https://dust4ai.slack.com/archives/C050SM8NSPK/p1692966598767489)