### PR TITLE
fix: key in sparkle link/linkcontext

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.1.33",
+      "version": "0.1.34",
       "license": "ISC",
       "devDependencies": {
         "@babel/core": "^7.22.9",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/context.tsx
+++ b/sparkle/src/context.tsx
@@ -1,7 +1,6 @@
 import React, { ComponentType, MouseEvent, ReactNode } from "react";
 
 export type SparkleContextLinkType = ComponentType<{
-  key?: React.Key | null;
   href: string;
   className?: string;
   children: ReactNode;
@@ -25,7 +24,6 @@ export type SparkleContextType = {
 };
 
 export const aLink: SparkleContextLinkType = ({
-  key,
   href,
   className,
   ariaCurrent,
@@ -34,7 +32,6 @@ export const aLink: SparkleContextLinkType = ({
   children,
 }) => (
   <a
-    key={key}
     href={href}
     className={className}
     aria-current={ariaCurrent}
@@ -46,7 +43,6 @@ export const aLink: SparkleContextLinkType = ({
 );
 
 export const noHrefLink: SparkleContextLinkType = ({
-  key,
   className,
   ariaCurrent,
   ariaLabel,
@@ -54,7 +50,6 @@ export const noHrefLink: SparkleContextLinkType = ({
   children,
 }) => (
   <a
-    key={key}
     className={className}
     aria-current={ariaCurrent}
     arria-label={ariaLabel}


### PR DESCRIPTION
The signature of our Link-like objects had a `key` which I think should not be there. Removing it here and publishing to check that this is indeed a fix.