### PR TITLE
bump sparkle to v0.1.34

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@dust-tt/sparkle": "0.1.33",
+        "@dust-tt/sparkle": "0.1.34",
         "@headlessui/react": "^1.7.7",
         "@heroicons/react": "^2.0.11",
         "@nangohq/frontend": "^0.16.1",
@@ -713,9 +713,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.1.33",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.1.33.tgz",
-      "integrity": "sha512-j7ZjM3BwZUyh4T10CRg1zEjzOIwQduvfs981bnTt+jwReLilrZZUE5GG0JLU4KtEiSvf6lQlTIP4qCtVJ7aM5g==",
+      "version": "0.1.34",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.1.34.tgz",
+      "integrity": "sha512-KsUtKsbQISQJw9ofg8M2hExnV9B8kd/l1xRi+SeYLukssZzoJ3C9OZRBKTngj9ZW5Qf9l+ELVGPPRC4u1wD9bQ==",
       "peerDependencies": {
         "react": "^18.2.0"
       }

--- a/front/package.json
+++ b/front/package.json
@@ -13,7 +13,7 @@
     "initdb": "env $(cat .env.local) npx tsx admin/db.ts"
   },
   "dependencies": {
-    "@dust-tt/sparkle": "0.1.33",
+    "@dust-tt/sparkle": "0.1.34",
     "@headlessui/react": "^1.7.7",
     "@heroicons/react": "^2.0.11",
     "@nangohq/frontend": "^0.16.1",


### PR DESCRIPTION
sparkle bump is minimal (remove an extraneous `key` attribute on Link like components (used by sparkle to be Next-JS independent but be able to use Link in Tab and Item))