### PR TITLE
fix(migrate notion block parents): resource connectorId may be null

### DIFF
--- a/connectors/src/lib/models.ts
+++ b/connectors/src/lib/models.ts
@@ -444,7 +444,7 @@ export class NotionPage extends Model<
   declare title?: string | null;
   declare notionUrl?: string | null;
 
-  declare connectorId: ForeignKey<Connector["id"]>;
+  declare connectorId: ForeignKey<Connector["id"]> | null;
 }
 
 NotionPage.init(
@@ -528,7 +528,7 @@ export class NotionDatabase extends Model<
   declare title?: string | null;
   declare notionUrl?: string | null;
 
-  declare connectorId: ForeignKey<Connector["id"]>;
+  declare connectorId: ForeignKey<Connector["id"]> | null;
 }
 
 NotionDatabase.init(


### PR DESCRIPTION
model definitions are lying, our foreign key is nullable and is in fact sometimes null