### PR TITLE
Extract: Add sId on models

### DIFF
--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -567,7 +567,9 @@ const eventSchema = async (command: string, args: parseArgs.ParsedArgs) => {
       if (!args.properties) {
         throw new Error("Missing --properties argument");
       }
+      const sId = new_id();
       const schema = await EventSchema.create({
+        sId: sId.slice(0, 10),
         marker: args.marker,
         workspaceId: args.wId,
         userId: args.uId,

--- a/front/lib/api/extract.ts
+++ b/front/lib/api/extract.ts
@@ -1,6 +1,7 @@
 import { Authenticator } from "@app/lib/auth";
 import { isDevelopmentOrDustWorkspace } from "@app/lib/development";
 import { EventSchema, ExtractedEvent } from "@app/lib/models";
+import { new_id } from "@app/lib/utils";
 import { EventSchemaType, ExtractedEventType } from "@app/types/extract";
 
 export async function getEventSchemas(
@@ -70,7 +71,9 @@ export async function createEventSchema(
     return;
   }
 
+  const sId = new_id();
   const schema = await EventSchema.create({
+    sId: sId.slice(0, 10),
     marker: marker,
     description: description,
     properties: properties,

--- a/front/lib/extract_events.ts
+++ b/front/lib/extract_events.ts
@@ -19,6 +19,7 @@ import {
 } from "@app/lib/extract_event_markers";
 import { formatPropertiesForModel } from "@app/lib/extract_events_properties";
 import { EventSchema, ExtractedEvent } from "@app/lib/models";
+import { new_id } from "@app/lib/utils";
 import logger from "@app/logger/logger";
 import { logOnSlack } from "@app/logger/slack_debug_logger";
 
@@ -165,7 +166,9 @@ async function _processExtractEvent(data: {
       return;
     }
 
+    const sId = new_id();
     const event = await ExtractedEvent.create({
+      sId: sId.slice(0, 10),
       documentId: documentId,
       properties: properties,
       eventSchemaId: schema.id,

--- a/front/lib/models.ts
+++ b/front/lib/models.ts
@@ -1046,6 +1046,7 @@ export class EventSchema extends Model<
   declare id: CreationOptional<number>;
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
+  declare sId: string;
 
   declare marker: string;
   declare description?: string;
@@ -1071,6 +1072,10 @@ EventSchema.init(
       type: DataTypes.DATE,
       allowNull: false,
       defaultValue: DataTypes.NOW,
+    },
+    sId: {
+      type: DataTypes.STRING,
+      allowNull: true, // @todo daph remove this after migration 20230829_extract_sids
     },
     marker: {
       type: DataTypes.STRING,
@@ -1098,7 +1103,10 @@ EventSchema.init(
   {
     modelName: "event_schema",
     sequelize: front_sequelize,
-    indexes: [{ fields: ["workspaceId", "marker"], unique: true }],
+    indexes: [
+      { fields: ["workspaceId", "marker"], unique: true },
+      //{ fields: ["sId"], unique: true }, @todo daph add this after migration 20230829_extract_sids
+    ],
   }
 );
 Workspace.hasMany(EventSchema, {
@@ -1117,6 +1125,7 @@ export class ExtractedEvent extends Model<
   declare id: CreationOptional<number>;
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
+  declare sId: string;
 
   declare marker: string;
   declare properties: any;
@@ -1143,6 +1152,10 @@ ExtractedEvent.init(
       type: DataTypes.DATE,
       allowNull: false,
       defaultValue: DataTypes.NOW,
+    },
+    sId: {
+      type: DataTypes.STRING,
+      allowNull: true, // @todo daph remove this after migration 20230829_extract_sids
     },
     marker: {
       type: DataTypes.STRING,
@@ -1172,6 +1185,7 @@ ExtractedEvent.init(
     indexes: [
       { fields: ["eventSchemaId"] },
       { fields: ["dataSourceName", "documentId"] },
+      //{ fields: ["sId"], unique: true }, @todo daph add this after migration 20230829_extract_sids
     ],
   }
 );

--- a/front/lib/models.ts
+++ b/front/lib/models.ts
@@ -1105,7 +1105,7 @@ EventSchema.init(
     sequelize: front_sequelize,
     indexes: [
       { fields: ["workspaceId", "marker"], unique: true },
-      //{ fields: ["sId"], unique: true }, @todo daph add this after migration 20230829_extract_sids
+      { fields: ["sId"], unique: true },
     ],
   }
 );
@@ -1185,7 +1185,7 @@ ExtractedEvent.init(
     indexes: [
       { fields: ["eventSchemaId"] },
       { fields: ["dataSourceName", "documentId"] },
-      //{ fields: ["sId"], unique: true }, @todo daph add this after migration 20230829_extract_sids
+      { fields: ["sId"], unique: true },
     ],
   }
 );

--- a/front/migrations/20230829_event_schema_sids.ts
+++ b/front/migrations/20230829_event_schema_sids.ts
@@ -1,0 +1,36 @@
+import { EventSchema } from "@app/lib/models";
+import { new_id } from "@app/lib/utils";
+
+async function main() {
+  const chunks = [];
+  const schemas = await EventSchema.findAll();
+  for (let i = 0; i < schemas.length; i += 16) {
+    chunks.push(schemas.slice(i, i + 16));
+  }
+  for (let i = 0; i < chunks.length; i++) {
+    console.log(`Processing chunk ${i}/${chunks.length}...`);
+    const chunk = chunks[i];
+    await Promise.all(
+      chunk.map((m) => {
+        return (async () => {
+          if (!m.sId) {
+            const sId = new_id();
+            await m.update({
+              sId: sId.slice(0, 10),
+            });
+          }
+        })();
+      })
+    );
+  }
+}
+
+main()
+  .then(() => {
+    console.log("Done");
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/front/migrations/20230829_extracted_event_sids.ts
+++ b/front/migrations/20230829_extracted_event_sids.ts
@@ -1,0 +1,36 @@
+import { ExtractedEvent } from "@app/lib/models";
+import { new_id } from "@app/lib/utils";
+
+async function main() {
+  const chunks = [];
+  const events = await ExtractedEvent.findAll();
+  for (let i = 0; i < events.length; i += 16) {
+    chunks.push(events.slice(i, i + 16));
+  }
+  for (let i = 0; i < chunks.length; i++) {
+    console.log(`Processing chunk ${i}/${chunks.length}...`);
+    const chunk = chunks[i];
+    await Promise.all(
+      chunk.map((m) => {
+        return (async () => {
+          if (!m.sId) {
+            const sId = new_id();
+            await m.update({
+              sId: sId.slice(0, 10),
+            });
+          }
+        })();
+      })
+    );
+  }
+}
+
+main()
+  .then(() => {
+    console.log("Done");
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });


### PR DESCRIPTION
Adding `sId` fields for both models `EventSchema` and `ExtractedEvent` to enforce RESTfulness on API and consistency: 
- [x] Add new nullable field `sId`
- [x] Handle existing rows: create migration files to fill the sId.
- [x] New rows: set sId when creating a new object (both in app and in cli command).


Deployment: 
```
# On front
./admin/init-db.sh
env $(cat .env.local) npx tsx migrations/20230829_event_schema_sids.ts
env $(cat .env.local) npx tsx migrations/20230829_extracted_event_sids.ts
```

Next PRs: 
- Set sId field non nullable.
- Update API to use sIds. 