### PR TITLE
Extract: make sId non nullable and unique

### DIFF
--- a/front/lib/models.ts
+++ b/front/lib/models.ts
@@ -1075,7 +1075,7 @@ EventSchema.init(
     },
     sId: {
       type: DataTypes.STRING,
-      allowNull: true, // @todo daph remove this after migration 20230829_extract_sids
+      allowNull: false,
     },
     marker: {
       type: DataTypes.STRING,
@@ -1155,7 +1155,7 @@ ExtractedEvent.init(
     },
     sId: {
       type: DataTypes.STRING,
-      allowNull: true, // @todo daph remove this after migration 20230829_extract_sids
+      allowNull: false,
     },
     marker: {
       type: DataTypes.STRING,


### PR DESCRIPTION
Following https://github.com/dust-tt/dust/pull/1160
After initial migration are run and the `sId` are filled, we can make them non nullable and unique. 