### PR TITLE
Util shared function to generate model sId

### DIFF
--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -13,7 +13,7 @@ import {
   User,
   Workspace,
 } from "@app/lib/models";
-import { new_id } from "@app/lib/utils";
+import { generateModelSId, new_id } from "@app/lib/utils";
 
 const { DUST_DATA_SOURCES_BUCKET = "", SERVICE_ACCOUNT } = process.env;
 
@@ -113,7 +113,7 @@ const workspace = async (command: string, args: parseArgs.ParsedArgs) => {
 
       const w = await Workspace.create({
         uId,
-        sId: uId.slice(0, 10),
+        sId: generateModelSId(uId),
         name: args.name,
       });
 
@@ -567,9 +567,8 @@ const eventSchema = async (command: string, args: parseArgs.ParsedArgs) => {
       if (!args.properties) {
         throw new Error("Missing --properties argument");
       }
-      const sId = new_id();
       const schema = await EventSchema.create({
-        sId: sId.slice(0, 10),
+        sId: generateModelSId(),
         marker: args.marker,
         workspaceId: args.wId,
         userId: args.uId,

--- a/front/lib/api/chat.ts
+++ b/front/lib/api/chat.ts
@@ -1,4 +1,4 @@
-import { new_id } from "@app/lib/utils";
+import { generateModelSId, new_id } from "@app/lib/utils";
 import logger from "@app/logger/logger";
 import { statsDClient } from "@app/logger/withlogging";
 import {
@@ -302,11 +302,6 @@ export async function getChatMessage(
       };
     }),
   };
-}
-
-export function newChatSessionId() {
-  const uId = new_id();
-  return uId.slice(0, 10);
 }
 
 export async function upsertChatMessage(
@@ -742,7 +737,7 @@ export async function* newChat(
     return;
   }
 
-  const sId = newChatSessionId();
+  const sId = generateModelSId();
   const session = await upsertChatSession(auth, sId, null, null);
   yield { type: "chat_session_create", session } as ChatSessionCreateEvent;
 

--- a/front/lib/api/extract.ts
+++ b/front/lib/api/extract.ts
@@ -1,7 +1,7 @@
 import { Authenticator } from "@app/lib/auth";
 import { isDevelopmentOrDustWorkspace } from "@app/lib/development";
 import { EventSchema, ExtractedEvent } from "@app/lib/models";
-import { new_id } from "@app/lib/utils";
+import { generateModelSId } from "@app/lib/utils";
 import { EventSchemaType, ExtractedEventType } from "@app/types/extract";
 
 export async function getEventSchemas(
@@ -71,9 +71,8 @@ export async function createEventSchema(
     return;
   }
 
-  const sId = new_id();
   const schema = await EventSchema.create({
-    sId: sId.slice(0, 10),
+    sId: generateModelSId(),
     marker: marker,
     description: description,
     properties: properties,

--- a/front/lib/extract_events.ts
+++ b/front/lib/extract_events.ts
@@ -19,7 +19,7 @@ import {
 } from "@app/lib/extract_event_markers";
 import { formatPropertiesForModel } from "@app/lib/extract_events_properties";
 import { EventSchema, ExtractedEvent } from "@app/lib/models";
-import { new_id } from "@app/lib/utils";
+import { generateModelSId } from "@app/lib/utils";
 import logger from "@app/logger/logger";
 import { logOnSlack } from "@app/logger/slack_debug_logger";
 
@@ -166,9 +166,8 @@ async function _processExtractEvent(data: {
       return;
     }
 
-    const sId = new_id();
     const event = await ExtractedEvent.create({
-      sId: sId.slice(0, 10),
+      sId: generateModelSId(),
       documentId: documentId,
       properties: properties,
       eventSchemaId: schema.id,

--- a/front/lib/utils.ts
+++ b/front/lib/utils.ts
@@ -13,6 +13,17 @@ export function new_id() {
   return Buffer.from(b).toString("hex");
 }
 
+export function generateModelSId(
+  fromExistingUId: string | null = null
+): string {
+  if (fromExistingUId) {
+    return fromExistingUId.slice(0, 10);
+  }
+
+  const sId = new_id();
+  return sId.slice(0, 10);
+}
+
 export function client_side_new_id() {
   // blake3 is not available in the browser
   // remove the dashes from the uuid

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -12,7 +12,7 @@ import {
   User,
   Workspace,
 } from "@app/lib/models";
-import { new_id } from "@app/lib/utils";
+import { generateModelSId, new_id } from "@app/lib/utils";
 import { apiError, withLogging } from "@app/logger/withlogging";
 
 import { authOptions } from "./auth/[...nextauth]";
@@ -153,7 +153,7 @@ async function handler(
         if (!workspaceInvite && !membershipInvite) {
           const w = await Workspace.create({
             uId,
-            sId: uId.slice(0, 10),
+            sId: generateModelSId(uId),
             name: session.user.username,
           });
 

--- a/front/pages/api/w/[wId]/apps/[aId]/clone.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/clone.ts
@@ -6,7 +6,7 @@ import { Authenticator, getSession } from "@app/lib/auth";
 import { CoreAPI } from "@app/lib/core_api";
 import { ReturnedAPIErrorType } from "@app/lib/error";
 import { App, Clone, Dataset } from "@app/lib/models";
-import { new_id } from "@app/lib/utils";
+import { generateModelSId, new_id } from "@app/lib/utils";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import { AppType } from "@app/types/app";
 
@@ -109,7 +109,7 @@ async function handler(
       const [cloned] = await Promise.all([
         App.create({
           uId,
-          sId: uId.slice(0, 10),
+          sId: generateModelSId(uId),
           name: req.body.name,
           description,
           visibility: req.body.visibility,

--- a/front/pages/api/w/[wId]/apps/index.ts
+++ b/front/pages/api/w/[wId]/apps/index.ts
@@ -4,7 +4,7 @@ import { Authenticator, getSession } from "@app/lib/auth";
 import { CoreAPI } from "@app/lib/core_api";
 import { ReturnedAPIErrorType } from "@app/lib/error";
 import { App } from "@app/lib/models";
-import { new_id } from "@app/lib/utils";
+import { generateModelSId, new_id } from "@app/lib/utils";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import { AppType } from "@app/types/app";
 
@@ -79,7 +79,7 @@ async function handler(
 
       const app = await App.create({
         uId,
-        sId: uId.slice(0, 10),
+        sId: generateModelSId(uId),
         name: req.body.name,
         description,
         visibility: req.body.visibility,

--- a/front/pages/w/[wId]/u/chat/index.tsx
+++ b/front/pages/w/[wId]/u/chat/index.tsx
@@ -1,8 +1,8 @@
 import { GetServerSideProps } from "next";
 
-import { newChatSessionId } from "@app/lib/api/chat";
 import { setUserMetadata } from "@app/lib/api/user";
 import { getSession, getUserFromSession } from "@app/lib/auth";
+import { generateModelSId } from "@app/lib/utils";
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const session = await getSession(context.req, context.res);
@@ -19,7 +19,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     value: `/w/${context.query.wId}/u/chat`,
   });
 
-  const cId = newChatSessionId();
+  const cId = generateModelSId();
   return {
     redirect: {
       destination: `/w/${context.query.wId}/u/chat/${cId}`,


### PR DESCRIPTION
We're using `sId` on our models that are 10 characters long -> this tiny PR introduces an util function to avoid having to redefine it every time. 

The function to generate the `sId` can take or not a param as we have two types of models: 
`Apps` and `Workspaces` store both a `uId` (full uuid) and the truncated 10 char `sId`, and for some other models we store only a `sId` (`ChatSessions`, `EventSchema`, `ExtractedEvent`).

(Note: I did not refactor existing migration files) 
