### PR TITLE
Refactor: Remove uId from Workspaces and Apps

### DIFF
--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -109,11 +109,8 @@ const workspace = async (command: string, args: parseArgs.ParsedArgs) => {
         throw new Error("Missing --name argument");
       }
 
-      const uId = new_id();
-
       const w = await Workspace.create({
-        uId,
-        sId: generateModelSId(uId),
+        sId: generateModelSId(),
         name: args.name,
       });
 

--- a/front/lib/api/app.ts
+++ b/front/lib/api/app.ts
@@ -35,7 +35,6 @@ export async function getApp(
 
   return {
     id: app.id,
-    uId: app.uId,
     sId: app.sId,
     name: app.name,
     description: app.description,
@@ -72,7 +71,6 @@ export async function getApps(auth: Authenticator): Promise<AppType[]> {
   return apps.map((app) => {
     return {
       id: app.id,
-      uId: app.uId,
       sId: app.sId,
       name: app.name,
       description: app.description,

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -213,7 +213,6 @@ export class Authenticator {
     return this._workspace
       ? {
           id: this._workspace.id,
-          uId: this._workspace.uId,
           sId: this._workspace.sId,
           name: this._workspace.name,
           allowedDomain: this._workspace.allowedDomain || null,
@@ -319,7 +318,6 @@ export async function getUserFromSession(
       }
       return {
         id: w.id,
-        uId: w.uId,
         sId: w.sId,
         name: w.name,
         allowedDomain: w.allowedDomain || null,

--- a/front/lib/models.ts
+++ b/front/lib/models.ts
@@ -306,7 +306,6 @@ export class App extends Model<
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
-  declare uId: string;
   declare sId: string;
   declare name: string;
   declare description?: string;
@@ -334,10 +333,6 @@ App.init(
       type: DataTypes.DATE,
       allowNull: false,
       defaultValue: DataTypes.NOW,
-    },
-    uId: {
-      type: DataTypes.STRING,
-      allowNull: false,
     },
     sId: {
       type: DataTypes.STRING,

--- a/front/lib/models.ts
+++ b/front/lib/models.ts
@@ -142,7 +142,6 @@ export class Workspace extends Model<
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
-  declare uId: string;
   declare sId: string;
   declare name: string;
   declare description?: string;
@@ -166,10 +165,6 @@ Workspace.init(
       type: DataTypes.DATE,
       allowNull: false,
       defaultValue: DataTypes.NOW,
-    },
-    uId: {
-      type: DataTypes.STRING,
-      allowNull: false,
     },
     sId: {
       type: DataTypes.STRING,

--- a/front/lib/utils.ts
+++ b/front/lib/utils.ts
@@ -13,13 +13,7 @@ export function new_id() {
   return Buffer.from(b).toString("hex");
 }
 
-export function generateModelSId(
-  fromExistingUId: string | null = null
-): string {
-  if (fromExistingUId) {
-    return fromExistingUId.slice(0, 10);
-  }
-
+export function generateModelSId(): string {
   const sId = new_id();
   return sId.slice(0, 10);
 }

--- a/front/migrations/20230413_workspaces_memberships.ts
+++ b/front/migrations/20230413_workspaces_memberships.ts
@@ -25,7 +25,6 @@ async function main() {
             const uId = new_id();
 
             const w = await Workspace.create({
-              uId,
               sId: uId.slice(0, 10),
               name: u.username,
               //@ts-expect-error old migration code kept for reference

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -138,8 +138,6 @@ async function handler(
       // The user does not exist. We create it and create a personal workspace if there is no invite
       // associated with the login request.
       if (!user) {
-        const uId = new_id();
-
         user = await User.create({
           provider: session.provider.provider,
           providerId: session.provider.id.toString(),
@@ -152,8 +150,7 @@ async function handler(
         // will be added to the workspace they were invited to (either by email or by domain) below.
         if (!workspaceInvite && !membershipInvite) {
           const w = await Workspace.create({
-            uId,
-            sId: generateModelSId(uId),
+            sId: generateModelSId(),
             name: session.user.username,
           });
 

--- a/front/pages/api/poke/workspaces/[wId]/downgrade.ts
+++ b/front/pages/api/poke/workspaces/[wId]/downgrade.ts
@@ -87,7 +87,6 @@ async function handler(
       return res.status(200).json({
         workspace: {
           id: workspace.id,
-          uId: workspace.uId,
           sId: workspace.sId,
           name: workspace.name,
           allowedDomain: workspace.allowedDomain || null,

--- a/front/pages/api/poke/workspaces/[wId]/upgrade.ts
+++ b/front/pages/api/poke/workspaces/[wId]/upgrade.ts
@@ -78,7 +78,6 @@ async function handler(
       return res.status(200).json({
         workspace: {
           id: workspace.id,
-          uId: workspace.uId,
           sId: workspace.sId,
           name: workspace.name,
           allowedDomain: workspace.allowedDomain || null,

--- a/front/pages/api/poke/workspaces/index.ts
+++ b/front/pages/api/poke/workspaces/index.ts
@@ -141,7 +141,6 @@ async function handler(
       return res.status(200).json({
         workspaces: workspaces.map((ws) => ({
           id: ws.id,
-          uId: ws.uId,
           sId: ws.sId,
           name: ws.name,
           allowedDomain: ws.allowedDomain || null,

--- a/front/pages/api/w/[wId]/apps/[aId]/clone.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/clone.ts
@@ -104,12 +104,10 @@ async function handler(
       }
 
       const description = req.body.description ? req.body.description : null;
-      const uId = new_id();
 
       const [cloned] = await Promise.all([
         App.create({
-          uId,
-          sId: generateModelSId(uId),
+          sId: generateModelSId(),
           name: req.body.name,
           description,
           visibility: req.body.visibility,
@@ -138,7 +136,6 @@ async function handler(
       res.status(201).json({
         app: {
           id: cloned.id,
-          uId: cloned.uId,
           sId: cloned.sId,
           name: cloned.name,
           description: cloned.description,

--- a/front/pages/api/w/[wId]/apps/[aId]/index.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/index.ts
@@ -101,7 +101,6 @@ async function handler(
       res.status(200).json({
         app: {
           id: app.id,
-          uId: app.uId,
           sId: app.sId,
           name: app.name,
           description: app.description,

--- a/front/pages/api/w/[wId]/apps/[aId]/state.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/state.ts
@@ -115,7 +115,6 @@ async function handler(
       res.status(200).json({
         app: {
           id: app.id,
-          uId: app.uId,
           sId: app.sId,
           name: app.name,
           description: app.description,

--- a/front/pages/api/w/[wId]/apps/index.ts
+++ b/front/pages/api/w/[wId]/apps/index.ts
@@ -75,11 +75,9 @@ async function handler(
       }
 
       const description = req.body.description ? req.body.description : null;
-      const uId = new_id();
 
       const app = await App.create({
-        uId,
-        sId: generateModelSId(uId),
+        sId: generateModelSId(),
         name: req.body.name,
         description,
         visibility: req.body.visibility,
@@ -90,7 +88,6 @@ async function handler(
       res.status(201).json({
         app: {
           id: app.id,
-          uId: app.uId,
           sId: app.sId,
           name: app.name,
           description: app.description,

--- a/front/types/app.ts
+++ b/front/types/app.ts
@@ -9,7 +9,6 @@ export type BlockRunConfig = {
 
 export type AppType = {
   id: ModelId;
-  uId: string;
   sId: string;
   name: string;
   description?: string;

--- a/front/types/user.ts
+++ b/front/types/user.ts
@@ -19,7 +19,6 @@ export type PlanType = {
 
 export type WorkspaceType = {
   id: ModelId;
-  uId: string;
   sId: string;
   name: string;
   allowedDomain: string | null;


### PR DESCRIPTION
The `uId` column was unused in both models. 
- [x] Commit 1: Remove `uId` from `Workspaces`.
- [x] Commit 2: Remove `uId` from `Apps`.
- [x] Commit 3: Remove the param in `generateModelSId`, not needed anymore.

