### PR TITLE
Extract: Fix broken UI list of templates

### DIFF
--- a/front/pages/w/[wId]/u/extract/index.tsx
+++ b/front/pages/w/[wId]/u/extract/index.tsx
@@ -179,7 +179,7 @@ export default function AppExtractEvents({
                               <td className="whitespace-nowrap px-3 py-4 font-medium">
                                 [[{schema.marker}]]
                               </td>
-                              <td className="whitespace-nowrap px-12 py-4">
+                              <td className="px-12 py-4">
                                 {schema.description}
                               </td>
                               <td className="whitespace-nowrap px-3 py-4">


### PR DESCRIPTION
When the description of a template was too long, because of the "no-wrap class" it was introducing a vertical scrolling. 