### PR TITLE
Extract: Ability to Accept or Reject an extracted event

### DIFF
--- a/front/lib/api/extract.ts
+++ b/front/lib/api/extract.ts
@@ -228,16 +228,18 @@ export async function getExtractedEvents({
   });
 }
 
-export async function deleteExtractedEvent({
+export async function updateExtractedEvent({
   auth,
   sId,
+  status,
 }: {
   auth: Authenticator;
   sId: string;
-}): Promise<boolean> {
+  status: "accepted" | "rejected";
+}): Promise<ExtractedEventType | null> {
   const owner = auth.workspace();
   if (!owner) {
-    return false;
+    return null;
   }
 
   const event = await ExtractedEvent.findOne({
@@ -247,7 +249,7 @@ export async function deleteExtractedEvent({
   });
 
   if (!event) {
-    return false;
+    return null;
   }
 
   // Make sure the event belongs to the workspace before editing
@@ -257,9 +259,12 @@ export async function deleteExtractedEvent({
     },
   });
   if (!schema || schema.workspaceId !== owner.id) {
-    return false;
+    return null;
   }
 
-  await event.destroy();
-  return true;
+  await event.update({
+    status,
+  });
+
+  return _getExtractedEventType(event);
 }

--- a/front/lib/api/extract.ts
+++ b/front/lib/api/extract.ts
@@ -190,6 +190,16 @@ export async function getExtractedEvent({
     return null;
   }
 
+  // Make sure the event belongs to the workspace before editing
+  const schema = await EventSchema.findOne({
+    where: {
+      id: event.eventSchemaId,
+    },
+  });
+  if (!schema || schema.workspaceId !== owner.id) {
+    return null;
+  }
+
   return _getExtractedEventType(event);
 }
 

--- a/front/lib/extract_events.ts
+++ b/front/lib/extract_events.ts
@@ -170,6 +170,7 @@ async function _processExtractEvent(data: {
       sId: generateModelSId(),
       documentId: documentId,
       properties: properties,
+      status: "pending",
       eventSchemaId: schema.id,
       dataSourceName: dataSourceName,
       documentSourceUrl: documentSourceUrl || null,

--- a/front/lib/models.ts
+++ b/front/lib/models.ts
@@ -1119,6 +1119,7 @@ export class ExtractedEvent extends Model<
 
   declare marker: string;
   declare properties: any;
+  declare status: "pending" | "accepted" | "rejected";
 
   declare eventSchemaId: ForeignKey<EventSchema["id"]>;
 
@@ -1155,6 +1156,11 @@ ExtractedEvent.init(
     properties: {
       type: DataTypes.JSONB,
       allowNull: false,
+    },
+    status: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      defaultValue: "pending",
     },
     dataSourceName: {
       type: DataTypes.STRING,

--- a/front/pages/api/w/[wId]/use/extract/events/[sId]/index.ts
+++ b/front/pages/api/w/[wId]/use/extract/events/[sId]/index.ts
@@ -73,6 +73,18 @@ async function handler(
     });
   }
 
+  // Checking this event is attached to a schema that belongs to the workspace
+  const schema = await getEventSchemaByModelId({ auth, id: event.schemaId });
+  if (!schema) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "event_schema_not_found",
+        message: "The event was not found.",
+      },
+    });
+  }
+
   switch (req.method) {
     case "DELETE":
       await deleteExtractedEvent({

--- a/front/pages/api/w/[wId]/use/extract/events/[sId]/index.ts
+++ b/front/pages/api/w/[wId]/use/extract/events/[sId]/index.ts
@@ -75,18 +75,6 @@ async function handler(
     });
   }
 
-  // Checking this event is attached to a schema that belongs to the workspace
-  const schema = await getEventSchemaByModelId({ auth, id: event.schemaId });
-  if (!schema) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "event_schema_not_found",
-        message: "The event was not found.",
-      },
-    });
-  }
-
   switch (req.method) {
     case "PATCH":
       if (


### PR DESCRIPTION
This PRs remove the ability to delete an extract event and replaces it with the ability to "Accept" or "Reject" one. 
We introduce a new `status` field for `ExtractedEvents`.

Done: 
- Introduce new `status` field.
- Update the API to remove the DELETE and replace it with a patch.
- Replace the "Delete" button by two new buttons "Accept" and "Reject".

Next PR will focus on the UI: 
- Properly display the status
- Rework the help content.

Second Next PR I'll try to handle a basic update mechanism to edit an event -> to keep it simple for a first step I'll check if relevant to reuse what we have on the Dust apps to play with JSON fields.
