### PR TITLE
fix(search chunks w/o text query): add GIN index on tags_array

### DIFF
--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -299,7 +299,7 @@ pub const POSTGRES_TABLES: [&'static str; 11] = [
     );",
 ];
 
-pub const SQL_INDEXES: [&'static str; 16] = [
+pub const SQL_INDEXES: [&'static str; 17] = [
     "CREATE INDEX IF NOT EXISTS
        idx_specifications_project_created ON specifications (project, created);",
     "CREATE INDEX IF NOT EXISTS
@@ -338,4 +338,6 @@ pub const SQL_INDEXES: [&'static str; 16] = [
     "CREATE INDEX IF NOT EXISTS
        idx_data_sources_documents_data_source_document_id_created
        ON data_sources_documents (data_source, document_id, created DESC);",
+    "CREATE INDEX IF NOT EXISTS
+       idx_data_sources_documents_tags_array ON data_sources_documents USING GIN (tags_array);",
 ];


### PR DESCRIPTION
We are going to add support for searching in Data Sources without providing a text query. The desired behaviour is to return content by reverse-chron timestamp. This is not do-able with Qdrant directly and will be done in SQL. We'll need to be able to filter documents by tag on the `core` database.
Now that we have a `tags_array` `TEXT[]` column, we can add a GIN index to optimally filter by tag (GIN indexes are the best to index arrays)