### PR TITLE
Extract: rework events statuses UI

### DIFF
--- a/front/lib/api/extract.ts
+++ b/front/lib/api/extract.ts
@@ -1,3 +1,5 @@
+import { Op } from "sequelize";
+
 import { Authenticator } from "@app/lib/auth";
 import { isDevelopmentOrDustWorkspace } from "@app/lib/development";
 import { EventSchema, ExtractedEvent, ModelId } from "@app/lib/models";
@@ -21,6 +23,7 @@ function _getExtractedEventType(event: ExtractedEvent): ExtractedEventType {
     sId: event.sId,
     marker: event.marker,
     properties: event.properties,
+    status: event.status,
     dataSourceName: event.dataSourceName,
     documentId: event.documentId,
     documentSourceUrl: event.documentSourceUrl,
@@ -220,6 +223,7 @@ export async function getExtractedEvents({
       sId: schemaSId,
       workspaceId: owner.id,
     },
+    order: [["createdAt", "DESC"]],
   });
 
   if (!schema) {
@@ -229,6 +233,9 @@ export async function getExtractedEvents({
   const events = await ExtractedEvent.findAll({
     where: {
       eventSchemaId: schema.id,
+      status: {
+        [Op.ne]: "rejected", // Op.ne == 'not equal'
+      },
     },
     order: [["createdAt", "DESC"]],
   });

--- a/front/lib/extract_event_markers.ts
+++ b/front/lib/extract_event_markers.ts
@@ -69,6 +69,7 @@ export async function getExtractEventMarkersToProcess({
   const rawMarkers = getRawExtractEventMarkersFromText(documentText);
 
   // Gets all markers already in the DB for this document
+  // Event if an event was rejected, we don't want to re-extract the marker.
   const existingExtractedEvents = await ExtractedEvent.findAll({
     where: {
       documentId: documentId,

--- a/front/types/extract.ts
+++ b/front/types/extract.ts
@@ -1,6 +1,7 @@
 import { ModelId } from "@app/lib/models";
 
 export type EventSchemaStatus = "active" | "disabled";
+export type ExtractedEventStatus = "pending" | "accepted" | "rejected";
 
 export type EventSchemaType = {
   id: ModelId;
@@ -41,6 +42,7 @@ export type ExtractedEventType = {
   properties: {
     [key: string]: string | string[];
   };
+  status: ExtractedEventStatus;
   dataSourceName: string;
   documentId: string;
   documentSourceUrl: string | null;


### PR DESCRIPTION
- [x] Do not display `rejected` events on the App -> treated as a soft delete
- [x] Sort extracted events per creation date.
- [x] Display the logo of the managed datasource to access the source document
- [x] Icon buttons to accept/reject an event
- [x] Rework a bit the list table, hopefully a bit prettier. 