### PR TITLE
Core API endpoint to update document `parents` field

### DIFF
--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -13,9 +13,9 @@ use axum::{
 use dust::{
     app,
     blocks::block::BlockType,
-    data_sources::data_source::{self, DataSource, SearchFilter},
+    data_sources::data_source::{self, SearchFilter},
     dataset,
-    project::{self, Project},
+    project::{self},
     providers::provider::{provider, ProviderID},
     run,
     stores::postgres,
@@ -142,15 +142,11 @@ async fn projects_create(
     extract::Extension(state): extract::Extension<Arc<APIState>>,
 ) -> (StatusCode, Json<APIResponse>) {
     match state.store.create_project().await {
-        Err(e) => (
+        Err(e) => error_response(
             StatusCode::INTERNAL_SERVER_ERROR,
-            Json(APIResponse {
-                error: Some(APIError {
-                    code: String::from("internal_server_error"),
-                    message: format!("Failed to create a new project: {}", e),
-                }),
-                response: None,
-            }),
+            "internal_server_error",
+            "Failed to create a new project",
+            Some(e),
         ),
         Ok(project) => (
             StatusCode::OK,
@@ -176,15 +172,11 @@ async fn projects_clone(
     // Create cloned project
     let project = match state.store.create_project().await {
         Err(e) => {
-            return (
+            return error_response(
                 StatusCode::INTERNAL_SERVER_ERROR,
-                Json(APIResponse {
-                    error: Some(APIError {
-                        code: String::from("internal_server_error"),
-                        message: format!("Failed to create cloned project: {}", e),
-                    }),
-                    response: None,
-                }),
+                "internal_server_error",
+                "Failed to create cloned project",
+                Some(e),
             )
         }
         Ok(project) => project,
@@ -193,15 +185,11 @@ async fn projects_clone(
     // Retrieve datasets
     let datasets = match state.store.list_datasets(&cloned).await {
         Err(e) => {
-            return (
+            return error_response(
                 StatusCode::INTERNAL_SERVER_ERROR,
-                Json(APIResponse {
-                    error: Some(APIError {
-                        code: String::from("internal_server_error"),
-                        message: format!("Failed to list cloned project datasets: {}", e),
-                    }),
-                    response: None,
-                }),
+                "internal_server_error",
+                "Failed to list cloned project datasets",
+                Some(e),
             )
         }
         Ok(datasets) => datasets,
@@ -228,15 +216,11 @@ async fn projects_clone(
     .collect::<Result<Vec<_>>>()
     {
         Err(e) => {
-            return (
+            return error_response(
                 StatusCode::INTERNAL_SERVER_ERROR,
-                Json(APIResponse {
-                    error: Some(APIError {
-                        code: String::from("internal_server_error"),
-                        message: format!("Failed to clone project datasets: {}", e),
-                    }),
-                    response: None,
-                }),
+                "internal_server_error",
+                "Failed to clone project datasets",
+                Some(e),
             )
         }
         Ok(_) => (),
@@ -266,15 +250,11 @@ async fn specifications_check(
 ) -> (StatusCode, Json<APIResponse>) {
     let _project = project::Project::new_from_id(project_id);
     match app::App::new(&payload.specification).await {
-        Err(e) => (
+        Err(e) => error_response(
             StatusCode::BAD_REQUEST,
-            Json(APIResponse {
-                error: Some(APIError {
-                    code: String::from("invalid_specification_error"),
-                    message: e.to_string(),
-                }),
-                response: None,
-            }),
+            "invalid_specification_error",
+            "Invalid specification",
+            Some(e),
         ),
         Ok(app) => (
             StatusCode::OK,
@@ -299,26 +279,18 @@ async fn specifications_retrieve(
 ) -> (StatusCode, Json<APIResponse>) {
     let project = project::Project::new_from_id(project_id);
     match state.store.load_specification(&project, &hash).await {
-        Err(e) => (
+        Err(e) => error_response(
             StatusCode::INTERNAL_SERVER_ERROR,
-            Json(APIResponse {
-                error: Some(APIError {
-                    code: String::from("internal_server_error"),
-                    message: format!("Failed to retrieve specification: {}", e),
-                }),
-                response: None,
-            }),
+            "internal_server_error",
+            "Failed to retrieve specification",
+            Some(e),
         ),
         Ok(s) => match s {
-            None => (
+            None => error_response(
                 StatusCode::NOT_FOUND,
-                Json(APIResponse {
-                    error: Some(APIError {
-                        code: String::from("specification_not_found"),
-                        message: format!("No specification found with hash `{}`", hash),
-                    }),
-                    response: None,
-                }),
+                "specification_not_found",
+                &format!("No specification found with hash `{}`", hash),
+                None,
             ),
             Some((created, spec)) => (
                 StatusCode::OK,
@@ -351,15 +323,11 @@ async fn datasets_register(
 ) -> (StatusCode, Json<APIResponse>) {
     let project = project::Project::new_from_id(project_id);
     match dataset::Dataset::new_from_jsonl(&payload.dataset_id, payload.data).await {
-        Err(e) => (
+        Err(e) => error_response(
             StatusCode::BAD_REQUEST,
-            Json(APIResponse {
-                error: Some(APIError {
-                    code: String::from("invalid_dataset_error"),
-                    message: e.to_string(),
-                }),
-                response: None,
-            }),
+            "invalid_dataset_error",
+            "Invalid dataset",
+            Some(e),
         ),
         Ok(d) => {
             // First retrieve the latest hash of the dataset to avoid registering if it matches the
@@ -374,15 +342,11 @@ async fn datasets_register(
             };
             if !(current_hash.is_some() && current_hash.unwrap() == d.hash()) {
                 match state.store.register_dataset(&project, &d).await {
-                    Err(e) => (
+                    Err(e) => error_response(
                         StatusCode::INTERNAL_SERVER_ERROR,
-                        Json(APIResponse {
-                            error: Some(APIError {
-                                code: String::from("internal_server_error"),
-                                message: format!("Failed to store dataset: {}", e),
-                            }),
-                            response: None,
-                        }),
+                        "internal_server_error",
+                        "Failed to store dataset",
+                        Some(e),
                     ),
                     Ok(()) => (
                         StatusCode::OK,
@@ -425,15 +389,11 @@ async fn datasets_list(
 ) -> (StatusCode, Json<APIResponse>) {
     let project = project::Project::new_from_id(project_id);
     match state.store.list_datasets(&project).await {
-        Err(e) => (
+        Err(e) => error_response(
             StatusCode::INTERNAL_SERVER_ERROR,
-            Json(APIResponse {
-                error: Some(APIError {
-                    code: String::from("internal_server_error"),
-                    message: format!("Failed to list datasets: {}", e),
-                }),
-                response: None,
-            }),
+            "internal_server_error",
+            "Failed to list datasets",
+            Some(e),
         ),
         Ok(datasets) => {
             let datasets = datasets
@@ -471,29 +431,21 @@ async fn datasets_retrieve(
 ) -> (StatusCode, Json<APIResponse>) {
     let project = project::Project::new_from_id(project_id);
     match state.store.load_dataset(&project, &dataset_id, &hash).await {
-        Err(e) => (
+        Err(e) => error_response(
             StatusCode::INTERNAL_SERVER_ERROR,
-            Json(APIResponse {
-                error: Some(APIError {
-                    code: String::from("internal_server_error"),
-                    message: format!("Failed to retrieve dataset: {}", e),
-                }),
-                response: None,
-            }),
+            "internal_server_error",
+            "Failed to retrieve dataset",
+            Some(e),
         ),
         Ok(dataset) => match dataset {
-            None => (
+            None => error_response(
                 StatusCode::NOT_FOUND,
-                Json(APIResponse {
-                    error: Some(APIError {
-                        code: String::from("dataset_not_found"),
-                        message: format!(
-                            "No dataset found for id `{}` and hash `{}`",
-                            dataset_id, hash
-                        ),
-                    }),
-                    response: None,
-                }),
+                "dataset_not_found",
+                &format!(
+                    "No dataset found for id `{}` and hash `{}`",
+                    dataset_id, hash,
+                ),
+                None,
             ),
             Some(d) => (
                 StatusCode::OK,
@@ -523,7 +475,7 @@ async fn run_helper(
     project_id: i64,
     payload: RunsCreatePayload,
     state: Arc<APIState>,
-) -> Result<app::App, (StatusCode, APIError)> {
+) -> Result<app::App, (StatusCode, Json<APIResponse>)> {
     let project = project::Project::new_from_id(project_id);
 
     let mut register_spec = true;
@@ -531,20 +483,18 @@ async fn run_helper(
         Some(spec) => spec,
         None => match payload.specification_hash {
             Some(hash) => match state.store.load_specification(&project, &hash).await {
-                Err(e) => Err((
+                Err(e) => Err(error_response(
                     StatusCode::INTERNAL_SERVER_ERROR,
-                    APIError {
-                        code: String::from("internal_server_error"),
-                        message: format!("Failed to retrieve specification: {}", e),
-                    },
+                    "internal_server_error",
+                    "Failed to retrieve specification",
+                    Some(e),
                 ))?,
                 Ok(spec) => match spec {
-                    None => Err((
+                    None => Err(error_response(
                         StatusCode::NOT_FOUND,
-                        APIError {
-                            code: String::from("specification_not_found"),
-                            message: format!("No specification found for hash `{}`", hash),
-                        },
+                        "specification_not_found",
+                        &format!("No specification found for hash `{}`", hash),
+                        None,
                     ))?,
                     Some((_, s)) => {
                         register_spec = false;
@@ -552,26 +502,22 @@ async fn run_helper(
                     }
                 },
             },
-            None => Err((
+            None => Err(error_response(
                 StatusCode::BAD_REQUEST,
-                APIError {
-                    code: String::from("missing_specification_error"),
-                    message: String::from(
-                        "No specification provided, \
-                                 either `specification` or `specification_hash` must be provided",
-                    ),
-                },
+                "missing_specification_error",
+                "No specification provided, either `specification` or 
+                `specification_hash` must be provided",
+                None,
             ))?,
         },
     };
 
     let mut app = match app::App::new(&specification).await {
-        Err(e) => Err((
+        Err(e) => Err(error_response(
             StatusCode::BAD_REQUEST,
-            APIError {
-                code: String::from("invalid_specification_error"),
-                message: e.to_string(),
-            },
+            "invalid_specification_error",
+            "Invalid specification",
+            Some(e),
         ))?,
         Ok(app) => app,
     };
@@ -579,31 +525,28 @@ async fn run_helper(
     let mut d = match payload.dataset_id.as_ref() {
         None => None,
         Some(dataset_id) => match state.store.latest_dataset_hash(&project, dataset_id).await {
-            Err(e) => Err((
+            Err(e) => Err(error_response(
                 StatusCode::INTERNAL_SERVER_ERROR,
-                APIError {
-                    code: String::from("internal_server_error"),
-                    message: format!("Failed to retrieve dataset: {}", e),
-                },
+                "internal_server_error",
+                "Failed to retrieve dataset",
+                Some(e),
             ))?,
-            Ok(None) => Err((
+            Ok(None) => Err(error_response(
                 StatusCode::NOT_FOUND,
-                APIError {
-                    code: String::from("dataset_not_found"),
-                    message: format!("No dataset found for id `{}`", dataset_id),
-                },
+                "dataset_not_found",
+                &format!("No dataset found for id `{}`", dataset_id),
+                None,
             ))?,
             Ok(Some(latest)) => match state
                 .store
                 .load_dataset(&project, dataset_id, &latest)
                 .await
             {
-                Err(e) => Err((
+                Err(e) => Err(error_response(
                     StatusCode::INTERNAL_SERVER_ERROR,
-                    APIError {
-                        code: String::from("internal_server_error"),
-                        message: format!("Failed to retrieve dataset: {}", e),
-                    },
+                    "internal_server_error",
+                    "Failed to retrieve dataset",
+                    Some(e),
                 ))?,
                 Ok(d) => match d {
                     None => unreachable!(),
@@ -615,27 +558,23 @@ async fn run_helper(
 
     if d.is_some() {
         if payload.run_type != run::RunType::Local {
-            Err((
+            Err(error_response(
                 StatusCode::BAD_REQUEST,
-                APIError {
-                    code: String::from("invalid_run_type_error"),
-                    message: String::from(
-                        "RunType `local` is expected when a `dataset_id` is provided",
-                    ),
-                },
+                "invalid_run_type_error",
+                "RunType `local` is expected when a `dataset_id` is provided",
+                None,
             ))?
         }
 
         if d.as_ref().unwrap().len() == 0 {
-            Err((
+            Err(error_response(
                 StatusCode::BAD_REQUEST,
-                APIError {
-                    code: String::from("dataset_empty_error"),
-                    message: format!(
-                        "Dataset `{}` has 0 record",
-                        payload.dataset_id.as_ref().unwrap()
-                    ),
-                },
+                "dataset_empty_error",
+                &format!(
+                    "Dataset `{}` has 0 record",
+                    payload.dataset_id.as_ref().unwrap()
+                ),
+                None,
             ))?
         }
 
@@ -651,12 +590,11 @@ async fn run_helper(
 
     if payload.inputs.is_some() {
         d = match dataset::Dataset::new_from_jsonl("inputs", payload.inputs.unwrap()).await {
-            Err(e) => Err((
+            Err(e) => Err(error_response(
                 StatusCode::BAD_REQUEST,
-                APIError {
-                    code: String::from("invalid_inputs_error"),
-                    message: e.to_string(),
-                },
+                "invalid_inputs_error",
+                "Invalid inputs",
+                Some(e),
             ))?,
             Ok(d) => Some(d),
         };
@@ -671,12 +609,11 @@ async fn run_helper(
             .register_specification(&project, &app.hash(), &specification)
             .await
         {
-            Err(e) => Err((
+            Err(e) => Err(error_response(
                 StatusCode::INTERNAL_SERVER_ERROR,
-                APIError {
-                    code: String::from("internal_server_error"),
-                    message: format!("Failed to register specification: {}", e),
-                },
+                "internal_server_error",
+                "Failed to register specification",
+                Some(e),
             ))?,
             Ok(_) => (),
         }
@@ -692,12 +629,11 @@ async fn run_helper(
         )
         .await
     {
-        Err(e) => Err((
+        Err(e) => Err(error_response(
             StatusCode::INTERNAL_SERVER_ERROR,
-            APIError {
-                code: String::from("internal_server_error"),
-                message: format!("Failed prepare run: {}", e),
-            },
+            "internal_server_error",
+            "Failed prepare run",
+            Some(e),
         ))?,
         Ok(()) => (),
     }
@@ -738,13 +674,7 @@ async fn runs_create(
                 }),
             )
         }
-        Err((status_code, api_error)) => (
-            status_code,
-            Json(APIResponse {
-                error: Some(api_error),
-                response: None,
-            }),
-        ),
+        Err(err) => err,
     }
 }
 
@@ -798,13 +728,15 @@ async fn runs_create_stream(
             });
         }
         Err((_, api_error)) => {
-            let _ = tx.send(json!({
-                "type": "error",
-                "content": {
-                    "code": api_error.code,
-                    "message": api_error.message,
-                },
-            }));
+            if let Some(error) = &api_error.0.error {
+                let _ = tx.send(json!({
+                    "type": "error",
+                    "content": {
+                        "code": error.code,
+                        "message": error.message,
+                    },
+                }));
+            }
         }
     }
 
@@ -849,15 +781,11 @@ async fn runs_list(
         .list_runs(&project, query.run_type, Some((query.limit, query.offset)))
         .await
     {
-        Err(e) => (
+        Err(e) => error_response(
             StatusCode::INTERNAL_SERVER_ERROR,
-            Json(APIResponse {
-                error: Some(APIError {
-                    code: String::from("internal_server_error"),
-                    message: format!("Failed to list runs: {}", e),
-                }),
-                response: None,
-            }),
+            "internal_server_error",
+            "Failed to list runs",
+            Some(e),
         ),
         Ok((runs, total)) => (
             StatusCode::OK,
@@ -886,15 +814,11 @@ async fn runs_retrieve_batch(
 ) -> (StatusCode, Json<APIResponse>) {
     let project = project::Project::new_from_id(project_id);
     match state.store.load_runs(&project, payload.run_ids).await {
-        Err(e) => (
+        Err(e) => error_response(
             StatusCode::INTERNAL_SERVER_ERROR,
-            Json(APIResponse {
-                error: Some(APIError {
-                    code: String::from("internal_server_error"),
-                    message: format!("Failed to retrieve runs: {}", e),
-                }),
-                response: None,
-            }),
+            "internal_server_error",
+            "Failed to retrieve runs",
+            Some(e),
         ),
         Ok(runs) => (
             StatusCode::OK,
@@ -914,26 +838,18 @@ async fn runs_retrieve(
 ) -> (StatusCode, Json<APIResponse>) {
     let project = project::Project::new_from_id(project_id);
     match state.store.load_run(&project, &run_id, None).await {
-        Err(e) => (
+        Err(e) => error_response(
             StatusCode::INTERNAL_SERVER_ERROR,
-            Json(APIResponse {
-                error: Some(APIError {
-                    code: String::from("internal_server_error"),
-                    message: format!("Failed to retrieve run: {}", e),
-                }),
-                response: None,
-            }),
+            "internal_server_error",
+            "Failed to retrieve run",
+            Some(e),
         ),
         Ok(run) => match run {
-            None => (
+            None => error_response(
                 StatusCode::NOT_FOUND,
-                Json(APIResponse {
-                    error: Some(APIError {
-                        code: String::from("run_not_found"),
-                        message: format!("No run found for id `{}`", run_id),
-                    }),
-                    response: None,
-                }),
+                "run_not_found",
+                &format!("No run found for id `{}`", run_id),
+                None,
             ),
             Some(run) => (
                 StatusCode::OK,
@@ -963,26 +879,18 @@ async fn runs_retrieve_block(
         .load_run(&project, &run_id, Some(Some((block_type, block_name))))
         .await
     {
-        Err(e) => (
+        Err(e) => error_response(
             StatusCode::INTERNAL_SERVER_ERROR,
-            Json(APIResponse {
-                error: Some(APIError {
-                    code: String::from("internal_server_error"),
-                    message: format!("Failed to retrieve run: {}", e),
-                }),
-                response: None,
-            }),
+            "internal_server_error",
+            "Failed to retrieve run",
+            Some(e),
         ),
         Ok(run) => match run {
-            None => (
+            None => error_response(
                 StatusCode::NOT_FOUND,
-                Json(APIResponse {
-                    error: Some(APIError {
-                        code: String::from("run_not_found"),
-                        message: format!("No run found for id `{}`", run_id),
-                    }),
-                    response: None,
-                }),
+                "run_not_found",
+                &format!("No run found for id `{}`", run_id),
+                None,
             ),
             Some(run) => (
                 StatusCode::OK,
@@ -1003,26 +911,18 @@ async fn runs_retrieve_status(
 ) -> (StatusCode, Json<APIResponse>) {
     let project = project::Project::new_from_id(project_id);
     match state.store.load_run(&project, &run_id, Some(None)).await {
-        Err(e) => (
+        Err(e) => error_response(
             StatusCode::INTERNAL_SERVER_ERROR,
-            Json(APIResponse {
-                error: Some(APIError {
-                    code: String::from("internal_server_error"),
-                    message: format!("Failed to retrieve run: {}", e),
-                }),
-                response: None,
-            }),
+            "internal_server_error",
+            "Failed to retrieve run",
+            Some(e),
         ),
         Ok(run) => match run {
-            None => (
+            None => error_response(
                 StatusCode::NOT_FOUND,
-                Json(APIResponse {
-                    error: Some(APIError {
-                        code: String::from("run_not_found"),
-                        message: format!("No run found for id `{}`", run_id),
-                    }),
-                    response: None,
-                }),
+                "run_not_found",
+                &format!("No run found for id `{}`", run_id),
+                None,
             ),
             Some(run) => (
                 StatusCode::OK,
@@ -1057,26 +957,18 @@ async fn data_sources_register(
         .setup(payload.credentials, state.qdrant_client.clone())
         .await
     {
-        Err(e) => (
+        Err(e) => error_response(
             StatusCode::INTERNAL_SERVER_ERROR,
-            Json(APIResponse {
-                error: Some(APIError {
-                    code: String::from("internal_server_error"),
-                    message: format!("Failed to register data source: {}", e),
-                }),
-                response: None,
-            }),
+            "internal_server_error",
+            "Failed to register data source",
+            Some(e),
         ),
         Ok(()) => match state.store.register_data_source(&project, &ds).await {
-            Err(e) => (
+            Err(e) => error_response(
                 StatusCode::INTERNAL_SERVER_ERROR,
-                Json(APIResponse {
-                    error: Some(APIError {
-                        code: String::from("internal_server_error"),
-                        message: format!("Failed to register data source: {}", e),
-                    }),
-                    response: None,
-                }),
+                "internal_server_error",
+                "Failed to register data source",
+                Some(e),
             ),
             Ok(()) => (
                 StatusCode::OK,
@@ -1118,26 +1010,18 @@ async fn data_sources_search(
         .load_data_source(&project, &data_source_id)
         .await
     {
-        Err(e) => (
+        Err(e) => error_response(
             StatusCode::INTERNAL_SERVER_ERROR,
-            Json(APIResponse {
-                error: Some(APIError {
-                    code: String::from("internal_server_error"),
-                    message: format!("Failed to retrieve data source: {}", e),
-                }),
-                response: None,
-            }),
+            "internal_server_error",
+            "Failed to retrieve data source",
+            Some(e),
         ),
         Ok(ds) => match ds {
-            None => (
+            None => error_response(
                 StatusCode::NOT_FOUND,
-                Json(APIResponse {
-                    error: Some(APIError {
-                        code: String::from("data_source_not_found"),
-                        message: format!("No data source found for id `{}`", data_source_id),
-                    }),
-                    response: None,
-                }),
+                "data_source_not_found",
+                &format!("No data source found for id `{}`", data_source_id),
+                None,
             ),
             Some(ds) => match ds
                 .search(
@@ -1161,15 +1045,11 @@ async fn data_sources_search(
                         })),
                     }),
                 ),
-                Err(e) => (
+                Err(e) => error_response(
                     StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(APIResponse {
-                        error: Some(APIError {
-                            code: String::from("internal_server_error"),
-                            message: format!("Failed to perform the search: {}", e),
-                        }),
-                        response: None,
-                    }),
+                    "internal_server_error",
+                    "Failed to perform the search",
+                    Some(e),
                 ),
             },
         },
@@ -1202,35 +1082,62 @@ async fn data_sources_documents_update_tags(
     let remove_tags_set: HashSet<String> = remove_tags.iter().cloned().collect();
 
     if add_tags_set.intersection(&remove_tags_set).count() > 0 {
-        return (
+        return error_response(
             StatusCode::BAD_REQUEST,
-            Json(APIResponse {
-                error: Some(APIError {
-                    code: String::from("bad_request"),
-                    message: String::from(
-                        "The `add_tags` and `remove_tags` lists have a non-empty intersection.",
-                    ),
-                }),
-                response: None,
-            }),
+            "bad_request",
+            "The `add_tags` and `remove_tags` lists have a non-empty intersection.",
+            None,
         );
     }
-
-    match load_data_source(&state, &project, &data_source_id).await {
-        Ok(ds) => match ds
-            .update_tags(
-                state.store.clone(),
-                state.qdrant_client.clone(),
-                document_id,
-                add_tags_set.into_iter().collect(),
-                remove_tags_set.into_iter().collect(),
-            )
-            .await
-        {
-            Err(e) => server_error_response("Failed to update document tags", e),
-            Ok(_) => datasource_ok_response(ds),
+    match state
+        .store
+        .load_data_source(&project, &data_source_id)
+        .await
+    {
+        Err(e) => error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "internal_server_error",
+            "Failed to retrieve data source",
+            Some(e),
+        ),
+        Ok(ds) => match ds {
+            None => error_response(
+                StatusCode::NOT_FOUND,
+                "data_source_not_found",
+                &format!("No data source found for id `{}`", data_source_id),
+                None,
+            ),
+            Some(ds) => match ds
+                .update_tags(
+                    state.store.clone(),
+                    state.qdrant_client.clone(),
+                    document_id,
+                    add_tags_set.into_iter().collect(),
+                    remove_tags_set.into_iter().collect(),
+                )
+                .await
+            {
+                Err(e) => error_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "internal_server_error",
+                    "Failed to update document tags",
+                    Some(e),
+                ),
+                Ok(_) => (
+                    StatusCode::OK,
+                    Json(APIResponse {
+                        error: None,
+                        response: Some(json!({
+                            "data_source": {
+                                "created": ds.created(),
+                                "data_source_id": ds.data_source_id(),
+                                "config": ds.config(),
+                            },
+                        })),
+                    }),
+                ),
+            },
         },
-        Err(api_error) => api_error,
     }
 }
 
@@ -1248,87 +1155,78 @@ async fn data_sources_documents_update_parents(
 ) -> (StatusCode, Json<APIResponse>) {
     let project = project::Project::new_from_id(project_id);
 
-    match load_data_source(&state, &project, &data_source_id).await {
-        Ok(ds) => match ds
-            .update_parents(
-                state.store.clone(),
-                state.qdrant_client.clone(),
-                document_id,
-                payload.parents,
-            )
-            .await
-        {
-            Err(e) => server_error_response("Failed to update document parents", e),
-            Ok(_) => datasource_ok_response(ds),
+    match state
+        .store
+        .load_data_source(&project, &data_source_id)
+        .await
+    {
+        Err(e) => error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "internal_server_error",
+            "Failed to retrieve data source",
+            Some(e),
+        ),
+        Ok(ds) => match ds {
+            None => error_response(
+                StatusCode::NOT_FOUND,
+                "data_source_not_found",
+                &format!("No data source found for id `{}`", data_source_id),
+                None,
+            ),
+            Some(ds) => match ds
+                .update_parents(
+                    state.store.clone(),
+                    state.qdrant_client.clone(),
+                    document_id,
+                    payload.parents,
+                )
+                .await
+            {
+                Err(e) => error_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "internal_server_error",
+                    "Failed to update document parents",
+                    Some(e),
+                ),
+                Ok(_) => (
+                    StatusCode::OK,
+                    Json(APIResponse {
+                        error: None,
+                        response: Some(json!({
+                            "data_source": {
+                                "created": ds.created(),
+                                "data_source_id": ds.data_source_id(),
+                                "config": ds.config(),
+                            },
+                        })),
+                    }),
+                ),
+            },
         },
-        Err(api_error) => api_error,
     }
 }
 
-fn server_error_response(message: &str, e: anyhow::Error) -> (StatusCode, Json<APIResponse>) {
+fn error_response(
+    status: StatusCode,
+    code: &str,
+    message: &str,
+    error: Option<anyhow::Error>,
+) -> (StatusCode, Json<APIResponse>) {
     (
-        StatusCode::INTERNAL_SERVER_ERROR,
+        status,
         Json(APIResponse {
             error: Some(APIError {
-                code: String::from("internal_server_error"),
-                message: format!("{}: {}", message, e),
+                code: code.to_string(),
+                message: match error {
+                    Some(err) => format!("{}\nError: {}", message, err),
+                    None => message.to_string(),
+                },
             }),
             response: None,
         }),
     )
 }
 
-fn datasource_ok_response(ds: DataSource) -> (StatusCode, Json<APIResponse>) {
-    (
-        StatusCode::OK,
-        Json(APIResponse {
-            error: None,
-            response: Some(json!({
-                "data_source": {
-                    "created": ds.created(),
-                    "data_source_id": ds.data_source_id(),
-                    "config": ds.config(),
-                },
-            })),
-        }),
-    )
-}
-
-async fn load_data_source(
-    state: &Arc<APIState>,
-    project: &Project,
-    data_source_id: &str,
-) -> Result<DataSource, (StatusCode, Json<APIResponse>)> {
-    match state
-        .store
-        .load_data_source(&project, &data_source_id)
-        .await
-    {
-        Err(e) => Err((
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(APIResponse {
-                error: Some(APIError {
-                    code: String::from("internal_server_error"),
-                    message: format!("Failed to retrieve data source: {}", e),
-                }),
-                response: None,
-            }),
-        )),
-        Ok(ds) => match ds {
-            None => Err((
-                StatusCode::NOT_FOUND,
-                Json(APIResponse {
-                    error: Some(APIError {
-                        code: String::from("data_source_not_found"),
-                        message: format!("No data source found for id `{}`", data_source_id),
-                    }),
-                    response: None,
-                }),
-            )),
-            Some(ds) => Ok(ds),
-        },
-    }
-}
 // List versions of a document in a data source.
 
 #[derive(serde::Deserialize)]
@@ -1356,15 +1254,11 @@ async fn data_sources_documents_versions_list(
         )
         .await
     {
-        Err(e) => (
+        Err(e) => error_response(
             StatusCode::INTERNAL_SERVER_ERROR,
-            Json(APIResponse {
-                error: Some(APIError {
-                    code: String::from("internal_server_error"),
-                    message: format!("Failed to list document versions: {}", e),
-                }),
-                response: None,
-            }),
+            "internal_server_error",
+            "Failed to list document versions",
+            Some(e),
         ),
         Ok((versions, total)) => (
             StatusCode::OK,
@@ -1410,26 +1304,18 @@ async fn data_sources_documents_upsert(
         .load_data_source(&project, &data_source_id)
         .await
     {
-        Err(e) => (
+        Err(e) => error_response(
             StatusCode::INTERNAL_SERVER_ERROR,
-            Json(APIResponse {
-                error: Some(APIError {
-                    code: String::from("internal_server_error"),
-                    message: format!("Failed to retrieve data source: {}", e),
-                }),
-                response: None,
-            }),
+            "internal_server_error",
+            "Failed to retrieve data source",
+            Some(e),
         ),
         Ok(ds) => match ds {
-            None => (
+            None => error_response(
                 StatusCode::NOT_FOUND,
-                Json(APIResponse {
-                    error: Some(APIError {
-                        code: String::from("data_source_not_found"),
-                        message: format!("No data source found for id `{}`", data_source_id),
-                    }),
-                    response: None,
-                }),
+                "data_source_not_found",
+                &format!("No data source found for id `{}`", data_source_id),
+                None,
             ),
             Some(ds) => {
                 match ds
@@ -1447,15 +1333,11 @@ async fn data_sources_documents_upsert(
                     )
                     .await
                 {
-                    Err(e) => (
+                    Err(e) => error_response(
                         StatusCode::INTERNAL_SERVER_ERROR,
-                        Json(APIResponse {
-                            error: Some(APIError {
-                                code: String::from("internal_server_error"),
-                                message: format!("Failed to upsert document: {}", e),
-                            }),
-                            response: None,
-                        }),
+                        "internal_server_error",
+                        "Failed to upsert document",
+                        Some(e),
                     ),
                     Ok(d) => {
                         let mut response_data = json!({
@@ -1514,15 +1396,11 @@ async fn data_sources_documents_list(
         )
         .await
     {
-        Err(e) => (
+        Err(e) => error_response(
             StatusCode::INTERNAL_SERVER_ERROR,
-            Json(APIResponse {
-                error: Some(APIError {
-                    code: String::from("internal_server_error"),
-                    message: format!("Failed to list data source: {}", e),
-                }),
-                response: None,
-            }),
+            "internal_server_error",
+            "Failed to list data source",
+            Some(e),
         ),
         Ok((documents, total)) => (
             StatusCode::OK,
@@ -1556,50 +1434,34 @@ async fn data_sources_documents_retrieve(
         .load_data_source(&project, &data_source_id)
         .await
     {
-        Err(e) => (
+        Err(e) => error_response(
             StatusCode::INTERNAL_SERVER_ERROR,
-            Json(APIResponse {
-                error: Some(APIError {
-                    code: String::from("internal_server_error"),
-                    message: format!("Failed to retrieve data source: {}", e),
-                }),
-                response: None,
-            }),
+            "internal_server_error",
+            "Failed to retrieve data source",
+            Some(e),
         ),
         Ok(ds) => match ds {
-            None => (
+            None => error_response(
                 StatusCode::NOT_FOUND,
-                Json(APIResponse {
-                    error: Some(APIError {
-                        code: String::from("data_source_not_found"),
-                        message: format!("No data source found for id `{}`", data_source_id),
-                    }),
-                    response: None,
-                }),
+                "data_source_not_found",
+                &format!("No data source found for id `{}`", data_source_id),
+                None,
             ),
             Some(ds) => match ds
                 .retrieve(state.store.clone(), &document_id, true, &query.version_hash)
                 .await
             {
-                Err(e) => (
+                Err(e) => error_response(
                     StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(APIResponse {
-                        error: Some(APIError {
-                            code: String::from("internal_server_error"),
-                            message: format!("Failed to retrieve document: {}", e),
-                        }),
-                        response: None,
-                    }),
+                    "internal_server_error",
+                    "Failed to retrieve document",
+                    Some(e),
                 ),
-                Ok(None) => (
+                Ok(None) => error_response(
                     StatusCode::NOT_FOUND,
-                    Json(APIResponse {
-                        error: Some(APIError {
-                            code: String::from("data_source_document_not_found"),
-                            message: format!("No document found for id `{}`", document_id),
-                        }),
-                        response: None,
-                    }),
+                    "data_source_document_not_found",
+                    &format!("No document found for id `{}`", document_id),
+                    None,
                 ),
                 Ok(Some(d)) => (
                     StatusCode::OK,
@@ -1632,26 +1494,18 @@ async fn data_sources_documents_delete(
         .load_data_source(&project, &data_source_id)
         .await
     {
-        Err(e) => (
+        Err(e) => error_response(
             StatusCode::INTERNAL_SERVER_ERROR,
-            Json(APIResponse {
-                error: Some(APIError {
-                    code: String::from("internal_server_error"),
-                    message: format!("Failed to retrieve data source: {}", e),
-                }),
-                response: None,
-            }),
+            "internal_server_error",
+            "Failed to retrieve data source",
+            Some(e),
         ),
         Ok(ds) => match ds {
-            None => (
+            None => error_response(
                 StatusCode::NOT_FOUND,
-                Json(APIResponse {
-                    error: Some(APIError {
-                        code: String::from("data_source_not_found"),
-                        message: format!("No data source found for id `{}`", data_source_id),
-                    }),
-                    response: None,
-                }),
+                "data_source_not_found",
+                &format!("No data source found for id `{}`", data_source_id),
+                None,
             ),
             Some(ds) => match ds
                 .delete_document(
@@ -1661,15 +1515,11 @@ async fn data_sources_documents_delete(
                 )
                 .await
             {
-                Err(e) => (
+                Err(e) => error_response(
                     StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(APIResponse {
-                        error: Some(APIError {
-                            code: String::from("internal_server_error"),
-                            message: format!("Failed to delete document: {}", e),
-                        }),
-                        response: None,
-                    }),
+                    "internal_server_error",
+                    "Failed to delete document",
+                    Some(e),
                 ),
                 Ok(_) => (
                     StatusCode::OK,
@@ -1701,40 +1551,28 @@ async fn data_sources_delete(
         .load_data_source(&project, &data_source_id)
         .await
     {
-        Err(e) => (
+        Err(e) => error_response(
             StatusCode::INTERNAL_SERVER_ERROR,
-            Json(APIResponse {
-                error: Some(APIError {
-                    code: String::from("internal_server_error"),
-                    message: format!("Failed to retrieve data source: {}", e),
-                }),
-                response: None,
-            }),
+            "internal_server_error",
+            "Failed to retrieve data source",
+            Some(e),
         ),
         Ok(ds) => match ds {
-            None => (
+            None => error_response(
                 StatusCode::NOT_FOUND,
-                Json(APIResponse {
-                    error: Some(APIError {
-                        code: String::from("data_source_not_found"),
-                        message: format!("No data source found for id `{}`", data_source_id),
-                    }),
-                    response: None,
-                }),
+                "data_source_not_found",
+                &format!("No data source found for id `{}`", data_source_id),
+                None,
             ),
             Some(ds) => match ds
                 .delete(state.store.clone(), state.qdrant_client.clone())
                 .await
             {
-                Err(e) => (
+                Err(e) => error_response(
                     StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(APIResponse {
-                        error: Some(APIError {
-                            code: String::from("internal_server_error"),
-                            message: format!("Failed to delete data source: {}", e),
-                        }),
-                        response: None,
-                    }),
+                    "internal_server_error",
+                    "Failed to delete data source",
+                    Some(e),
                 ),
                 Ok(_) => (
                     StatusCode::OK,
@@ -1768,15 +1606,11 @@ async fn tokenize(
 ) -> (StatusCode, Json<APIResponse>) {
     let embedder = provider(payload.provider_id).embedder(payload.model_id);
     match embedder.encode(&payload.text).await {
-        Err(e) => (
+        Err(e) => error_response(
             StatusCode::INTERNAL_SERVER_ERROR,
-            Json(APIResponse {
-                error: Some(APIError {
-                    code: String::from("internal_server_error"),
-                    message: format!("Failed to tokenize text: {}", e),
-                }),
-                response: None,
-            }),
+            "internal_server_error",
+            "Failed to tokenize text",
+            Some(e),
         ),
         Ok(tokens) => (
             StatusCode::OK,

--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -1212,13 +1212,14 @@ fn error_response(
     message: &str,
     error: Option<anyhow::Error>,
 ) -> (StatusCode, Json<APIResponse>) {
+    utils::error(&format!("{}: {}\nError: {:?}", code, message, error));
     (
         status,
         Json(APIResponse {
             error: Some(APIError {
                 code: code.to_string(),
                 message: match error {
-                    Some(err) => format!("{}\nError: {}", message, err),
+                    Some(err) => format!("{}\nError: {:?}", message, err),
                     None => message.to_string(),
                 },
             }),

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -411,13 +411,8 @@ impl DataSource {
             )
             .await?;
 
-        self.upsert_field_to_document_payload(
-            qdrant_client,
-            document_id,
-            "parents",
-            new_parents.clone(),
-        )
-        .await?;
+        self.update_document_payload(qdrant_client, document_id, "parents", new_parents.clone())
+            .await?;
         Ok(())
     }
 
@@ -438,12 +433,12 @@ impl DataSource {
                 &remove_tags,
             )
             .await?;
-        self.upsert_field_to_document_payload(qdrant_client, document_id, "tags", new_tags.clone())
+        self.update_document_payload(qdrant_client, document_id, "tags", new_tags.clone())
             .await?;
         Ok(new_tags)
     }
 
-    async fn upsert_field_to_document_payload(
+    async fn update_document_payload(
         &self,
         qdrant_client: Arc<QdrantClient>,
         document_id: String,

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -92,13 +92,19 @@ pub struct Chunk {
 /// The "parents" field is an array of ids of parents to the document,
 /// corresponding to its hierarchy, ordered by closest parent first.
 ///
-/// At index 0 is the document's direct parent, then at index 1 is the direct
-/// parent of the element represented at index 0, etc. It is assumed that a
-/// document (or folder, or hierarchical level) only has at most one direct
-/// parent. Therefore, there is an unambiguous mapping between the parents array
-/// and the document's hierarchical position. For example, for a regular file
-/// system (or filesystem-like such as Google Drive), each parent would
-/// correspond to a subfolder in the path to the document.
+/// At index 0 is the document id itself, then at index 1 its direct parent,
+/// then at index 2 is the direct parent of the element represented at index 1,
+/// etc. It is assumed that a document (or folder, or hierarchical level) only
+/// has at most one direct parent. Therefore, there is an unambiguous mapping
+/// between the parents array and the document's hierarchical position. For
+/// example, for a regular file system (or filesystem-like such as Google
+/// Drive), each parent would correspond to a subfolder in the path to the
+/// document.
+///
+/// The document’s id is stored in the field, since the field is used in
+/// filtering search to search only parts of the hierarchy: it is natural that
+/// if the document’s id is selected as a parent filter, the document itself
+/// shows up in the search.
 ///
 /// Note however that the hierarchical system depends on the managed datasource.
 /// For example, in the Slack managed datasource, documents only have a single

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -449,7 +449,7 @@ impl DataSource {
         payload.insert(field_name, field_value.into());
 
         let field_condition = qdrant::FieldCondition {
-            key: "document_id".to_string(),
+            key: "document_id_hash".to_string(),
             r#match: Some(qdrant::Match {
                 match_value: Some(qdrant::r#match::MatchValue::Text(document_id)),
             }),

--- a/core/src/stores/postgres.rs
+++ b/core/src/stores/postgres.rs
@@ -13,7 +13,7 @@ use crate::stores::store::{Store, POSTGRES_TABLES, SQL_INDEXES};
 use crate::utils;
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
-use bb8::{Pool, PooledConnection};
+use bb8::Pool;
 use bb8_postgres::PostgresConnectionManager;
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -114,6 +114,13 @@ pub trait Store {
         add_tags: &Vec<String>,
         remove_tags: &Vec<String>,
     ) -> Result<Vec<String>>;
+    async fn update_data_source_document_parents(
+        &self,
+        project: &Project,
+        data_source_id: &str,
+        document_id: &str,
+        parents: &Vec<String>,
+    ) -> Result<()>;
     async fn list_data_source_document_versions(
         &self,
         project: &Project,


### PR DESCRIPTION
New Core API path allowing to upsert the parents field only in a given document