### PR TITLE
Cache chunk embedding in core/upsert API

### DIFF
--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -739,7 +739,7 @@ impl DataSource {
         let vectors = splits_with_hash
             .iter()
             .enumerate()
-            .map(|(i, ci)| match embeddings.remove(&ci.hash) {
+            .map(|(i, ci)| match embeddings.get(&ci.hash) {
                 Some(v) => Ok((i, ci.text.clone(), v)),
                 None => Err(anyhow!(
                     "DataSource embedding error: Chunk not found in cache"
@@ -759,7 +759,7 @@ impl DataSource {
                     text: s,
                     hash,
                     offset: i,
-                    vector: Some(v.vector),
+                    vector: Some(v.vector.clone()),
                     score: None,
                 }
             })

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -675,12 +675,10 @@ impl DataSource {
                     }
                 });
                 page_offset = scroll_results.next_page_offset;
-
                 if page_offset.is_none() {
                     break;
                 }
             }
-
             let cache_hits = splits
                 .iter()
                 .filter(|s| {

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -599,7 +599,7 @@ impl DataSource {
             utils::now() - now
         ));
 
-        // Ordered results with offset, stirng and vector
+        let now = utils::now();
         let mut texthash2embedding: HashMap<String, EmbedderVector> = HashMap::new();
         let mut page_offset: Option<PointId> = None;
         loop {
@@ -709,6 +709,7 @@ impl DataSource {
             }
         }
 
+        // Ordered results with offset, stirng and vector
         let embedded_vectors = splits
             .iter()
             .enumerate()
@@ -716,7 +717,6 @@ impl DataSource {
                 let mut hasher = blake3::Hasher::new();
                 hasher.update(s.as_bytes());
                 let text_only_hash = format!("{}", hasher.finalize().to_hex());
-                // let v = cached_embeddings.get(&chunk_hash).unwrap();
                 let r = match texthash2embedding.contains_key(&text_only_hash) {
                     true => Ok((
                         i,
@@ -735,8 +735,6 @@ impl DataSource {
                 Err(e) => return Err(anyhow!("DataSource chunk embedding error: {}", e))?,
             }
         }
-
-        let now = utils::now();
 
         // Embed chunks with max concurrency of 2.
         //let e = stream::iter(splits.into_iter().enumerate())

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -587,7 +587,7 @@ impl DataSource {
         struct ChunkInfo {
             text: String,
             hash: String,
-        };
+        }
 
         // Split text in chunks.
         let splits = splitter(self.config.splitter_id)


### PR DESCRIPTION
On upsert, we fetch all the existing chunk for a given document from Qdrant and re-use the embedding for a given chunk hash if it exists, avoiding a roundtrip to OpenAI servers.