### PR TITLE
enh: ability to continue unclaimed conversations 

### DIFF
--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -195,7 +195,7 @@ async function botAnswerMessage(
         thread_ts: slackMessageTs,
       });
     } else if (event.type === "chat_session_update") {
-      const finalAnswer = `${fullAnswer}\n\n <${DUST_API}/w/${connector.workspaceId}/u/chat/${event.session.sId}|View this conversation on Dust>`;
+      const finalAnswer = `${fullAnswer}\n\n <${DUST_API}/w/${connector.workspaceId}/u/chat/${event.session.sId}|Continue this conversation on Dust>`;
       await slackClient.chat.update({
         channel: slackChannel,
         text: finalAnswer,

--- a/front/lib/api/chat.ts
+++ b/front/lib/api/chat.ts
@@ -109,6 +109,49 @@ export async function getChatSession(
   };
 }
 
+export async function takeOwnerShipOfChatSession(
+  auth: Authenticator,
+  sId: string
+): Promise<ChatSessionType> {
+  const owner = auth.workspace();
+  if (!owner) {
+    throw new Error("Unexpected `auth` without `workspace`.");
+  }
+
+  const user = auth.user();
+  if (!user) {
+    throw new Error("Unexpected `auth` without `user`.");
+  }
+
+  const chatSession = await ChatSession.findOne({
+    where: {
+      workspaceId: owner.id,
+      sId,
+    },
+  });
+
+  if (!chatSession) {
+    throw new Error("Chat session not found.");
+  }
+
+  if (chatSession.userId !== null && chatSession.userId !== user.id) {
+    throw new Error("Chat session .");
+  }
+
+  await chatSession.update({
+    userId: user.id,
+  });
+
+  return {
+    id: chatSession.id,
+    userId: chatSession.userId,
+    created: chatSession.createdAt.getTime(),
+    sId: chatSession.sId,
+    title: chatSession.title,
+    visibility: chatSession.visibility,
+  };
+}
+
 export async function upsertChatSession(
   auth: Authenticator,
   sId: string,

--- a/front/lib/api/chat.ts
+++ b/front/lib/api/chat.ts
@@ -135,12 +135,14 @@ export async function takeOwnerShipOfChatSession(
   }
 
   if (chatSession.userId !== null && chatSession.userId !== user.id) {
-    throw new Error("Chat session .");
+    throw new Error("Chat session already belongs to another user.");
   }
 
-  await chatSession.update({
-    userId: user.id,
-  });
+  if (chatSession.userId === null) {
+    await chatSession.update({
+      userId: user.id,
+    });
+  }
 
   return {
     id: chatSession.id,

--- a/front/lib/models.ts
+++ b/front/lib/models.ts
@@ -721,10 +721,10 @@ export class ChatSession extends Model<
   declare updatedAt: CreationOptional<Date>;
 
   declare sId: string;
-  declare title?: string;
+  declare title: string | null;
   declare visibility: ChatSessionVisibility;
 
-  declare workspaceId: ForeignKey<Workspace["id"]>;
+  declare workspaceId: ForeignKey<Workspace["id"]> | null;
   declare userId: ForeignKey<User["id"]>;
 }
 

--- a/front/pages/api/w/[wId]/use/chats/[cId]/index.ts
+++ b/front/pages/api/w/[wId]/use/chats/[cId]/index.ts
@@ -83,7 +83,8 @@ async function handler(
       status_code: 403,
       api_error: {
         type: "workspace_auth_error",
-        message: "Only users of the current workspace can retrieve chats.",
+        message:
+          "Only users of the current workspace can update chat sessions.",
       },
     });
   }

--- a/front/pages/api/w/[wId]/use/chats/[cId]/take.ts
+++ b/front/pages/api/w/[wId]/use/chats/[cId]/take.ts
@@ -1,0 +1,112 @@
+import { NextApiRequest, NextApiResponse } from "next";
+
+import { getChatSession, takeOwnerShipOfChatSession } from "@app/lib/api/chat";
+import { Authenticator, getSession } from "@app/lib/auth";
+import { ReturnedAPIErrorType } from "@app/lib/error";
+import { apiError, withLogging } from "@app/logger/withlogging";
+import { ChatSessionType } from "@app/types/chat";
+
+export type ChatSessionResponseBody = {
+  session: ChatSessionType | null;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<ChatSessionResponseBody | ReturnedAPIErrorType>
+): Promise<void> {
+  const session = await getSession(req, res);
+  const auth = await Authenticator.fromSession(
+    session,
+    req.query.wId as string
+  );
+
+  const owner = auth.workspace();
+  if (!owner) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "The workspace you're trying to modify was not found.",
+      },
+    });
+  }
+
+  if (!auth.user()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_user_not_found",
+        message: "Could not find the user of the current session.",
+      },
+    });
+  }
+
+  if (!auth.isUser()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "Only users of the current workspace can update chat sessions.",
+      },
+    });
+  }
+
+  if (!(typeof req.query.cId === "string")) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid query parameters, `cId` (string) is required.",
+      },
+    });
+  }
+  const cId = req.query.cId;
+
+  switch (req.method) {
+    case "POST": {
+      const chatSession = await getChatSession(auth, cId);
+      if (!chatSession) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "chat_session_not_found",
+            message: "The chat session was not found.",
+          },
+        });
+      }
+
+      if (
+        chatSession.userId !== null &&
+        chatSession.userId !== auth.user()?.id
+      ) {
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "chat_session_auth_error",
+            message:
+              "You can't take ownership of a chat session already owned by another user.",
+          },
+        });
+      }
+
+      const session = await takeOwnerShipOfChatSession(auth, cId);
+
+      res.status(200).json({
+        session,
+      });
+      return;
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, POST is expected.",
+        },
+      });
+  }
+}
+
+export default withLogging(handler);

--- a/front/pages/w/[wId]/u/chat/[cId]/index.tsx
+++ b/front/pages/w/[wId]/u/chat/[cId]/index.tsx
@@ -1271,7 +1271,7 @@ export default function AppChat({
                 )}
 
                 {canTakeOwnership && (
-                  <div className="mt-8">
+                  <div className="mt-16 flex justify-center">
                     <Button
                       type="primary"
                       label="Continue Conversation"

--- a/front/pages/w/[wId]/u/chat/[cId]/index.tsx
+++ b/front/pages/w/[wId]/u/chat/[cId]/index.tsx
@@ -1,6 +1,8 @@
 import {
   Button,
   ChatBubbleBottomCenterTextIcon,
+  ChevronDownIcon,
+  ChevronRightIcon,
   ClipboardCheckIcon,
   ClipboardIcon,
   CloudArrowDownIcon,
@@ -9,8 +11,8 @@ import {
   Logo,
   PageHeader,
   PaperAirplaneIcon,
+  RobotIcon,
 } from "@dust-tt/sparkle";
-import { ChevronDownIcon, ChevronRightIcon } from "@heroicons/react/20/solid";
 import { UserCircleIcon } from "@heroicons/react/24/solid";
 import { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import Link from "next/link";
@@ -578,6 +580,8 @@ export default function AppChat({
     readOnly = false;
   }
 
+  const canTakeOwnership = chatSession && !chatSession.userId;
+
   const [title, setTitle] = useState<string>(
     chatSession?.title || "New Conversation"
   );
@@ -1090,6 +1094,21 @@ export default function AppChat({
     }
   };
 
+  const handleTakeOwnership = async () => {
+    const res = await fetch(
+      `/api/w/${owner.sId}/use/chats/${chatSessionId}/take`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }
+    );
+    if (res.ok) {
+      void mutateChatSession();
+    }
+  };
+
   return (
     <AppLayout
       user={user}
@@ -1249,6 +1268,17 @@ export default function AppChat({
                       </p>
                     </div>
                   </>
+                )}
+
+                {canTakeOwnership && (
+                  <div className="mt-8">
+                    <Button
+                      type="primary"
+                      label="Continue conversation"
+                      icon={RobotIcon}
+                      onClick={handleTakeOwnership}
+                    />
+                  </div>
                 )}
               </div>
             </div>

--- a/front/pages/w/[wId]/u/chat/[cId]/index.tsx
+++ b/front/pages/w/[wId]/u/chat/[cId]/index.tsx
@@ -1274,7 +1274,7 @@ export default function AppChat({
                   <div className="mt-8">
                     <Button
                       type="primary"
-                      label="Continue conversation"
+                      label="Continue Conversation"
                       icon={RobotIcon}
                       onClick={handleTakeOwnership}
                     />

--- a/front/types/chat.ts
+++ b/front/types/chat.ts
@@ -32,10 +32,10 @@ export type ChatMessageType = {
 
 export type ChatSessionType = {
   id: ModelId;
-  userId: number;
+  userId: ModelId | null;
   created: number;
   sId: string;
-  title?: string;
+  title: string | null;
   messages?: ChatMessageType[];
   visibility: ChatSessionVisibility;
 };


### PR DESCRIPTION
Fix dust-tt/tasks#21 

When a conversation is created by API it is not assigned to a user. When that's the case we allow visiting users to continue the conversation (effectively giving them ownership of the unclaimed conversation).

- The PR also fixes a few types inaccuracies.
- It also updates the Slack bot message from "View conversation" to "Continue conversation"

![Screenshot from 2023-08-31 12-10-32](https://github.com/dust-tt/dust/assets/15067/9341f774-a33f-4431-82dc-74c4af69f8dd)
