### PR TITLE
Remove option to display lab, keep only for Dust

### DIFF
--- a/front/components/sparkle/navigation.tsx
+++ b/front/components/sparkle/navigation.tsx
@@ -68,7 +68,8 @@ export const topNavigation = ({
     },
   ];
 
-  if (!owner.disableLabs) {
+  const displayLabs = isDevelopmentOrDustWorkspace(owner);
+  if (displayLabs) {
     nav.push({
       id: "lab",
       label: "Lab",
@@ -211,6 +212,13 @@ export const subNavigationLab = ({
 }) => {
   const nav: SparkleAppLayoutNavigation[] = [
     {
+      id: "extract",
+      label: "Extract",
+      icon: ArrowUpOnSquareIcon,
+      href: `/w/${owner.sId}/u/extract`,
+      current: current === "extract",
+    },
+    {
       id: "gens",
       label: "Gens",
       icon: Square3Stack3DIcon,
@@ -218,16 +226,6 @@ export const subNavigationLab = ({
       current: current === "gens",
     },
   ];
-
-  if (isDevelopmentOrDustWorkspace(owner)) {
-    nav.push({
-      id: "extract",
-      label: "Extract",
-      icon: ArrowUpOnSquareIcon,
-      href: `/w/${owner.sId}/u/extract`,
-      current: current === "extract",
-    });
-  }
 
   return nav;
 };

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -218,7 +218,6 @@ export class Authenticator {
           allowedDomain: this._workspace.allowedDomain || null,
           role: this._role,
           plan: planForWorkspace(this._workspace),
-          disableLabs: this._workspace.disableLabs,
         }
       : null;
   }

--- a/front/lib/models.ts
+++ b/front/lib/models.ts
@@ -147,7 +147,6 @@ export class Workspace extends Model<
   declare description?: string;
   declare allowedDomain?: string;
   declare plan?: string | null;
-  declare disableLabs?: boolean;
 }
 Workspace.init(
   {
@@ -182,10 +181,6 @@ Workspace.init(
     },
     plan: {
       type: DataTypes.STRING,
-    },
-    disableLabs: {
-      type: DataTypes.BOOLEAN,
-      defaultValue: false,
     },
   },
   {

--- a/front/pages/api/poke/workspaces/[wId]/downgrade.ts
+++ b/front/pages/api/poke/workspaces/[wId]/downgrade.ts
@@ -92,7 +92,6 @@ async function handler(
           allowedDomain: workspace.allowedDomain || null,
           role: "admin",
           plan,
-          disableLabs: workspace.disableLabs,
         },
       });
 

--- a/front/pages/api/poke/workspaces/[wId]/upgrade.ts
+++ b/front/pages/api/poke/workspaces/[wId]/upgrade.ts
@@ -83,7 +83,6 @@ async function handler(
           allowedDomain: workspace.allowedDomain || null,
           role: "admin",
           plan,
-          disableLabs: workspace.disableLabs,
         },
       });
 

--- a/front/pages/api/poke/workspaces/index.ts
+++ b/front/pages/api/poke/workspaces/index.ts
@@ -145,7 +145,6 @@ async function handler(
           name: ws.name,
           allowedDomain: ws.allowedDomain || null,
           plan: planForWorkspace(ws),
-          disableLabs: ws.disableLabs,
           role: "admin",
         })),
       });

--- a/front/pages/api/w/[wId]/index.ts
+++ b/front/pages/api/w/[wId]/index.ts
@@ -79,7 +79,6 @@ async function handler(
       await w.update({
         name: req.body.name,
         allowedDomain: req.body.allowedDomain,
-        disableLabs: req.body.disableLabs,
       });
 
       owner.name = req.body.name as string;

--- a/front/pages/w/[wId]/workspace/index.tsx
+++ b/front/pages/w/[wId]/workspace/index.tsx
@@ -75,14 +75,8 @@ export default function WorkspaceAdmin({
   const { members, isMembersLoading } = useMembers(owner);
   const { invitations, isInvitationsLoading } = useWorkspaceInvitations(owner);
 
-  const [disableLabs, setDisableLabs] = useState(owner.disableLabs || false);
-
   const formValidation = () => {
-    if (
-      workspaceName === owner.name &&
-      allowedDomain === owner.allowedDomain &&
-      owner.disableLabs === disableLabs
-    ) {
+    if (workspaceName === owner.name && allowedDomain === owner.allowedDomain) {
       return false;
     }
     let valid = true;
@@ -115,7 +109,7 @@ export default function WorkspaceAdmin({
 
   useEffect(() => {
     setDisabled(!formValidation());
-  }, [workspaceName, allowedDomain, disableLabs]);
+  }, [workspaceName, allowedDomain]);
 
   const handleUpdateWorkspace = async () => {
     setUpdating(true);
@@ -127,7 +121,6 @@ export default function WorkspaceAdmin({
       body: JSON.stringify({
         name: workspaceName,
         allowedDomain: allowedDomain,
-        disableLabs: disableLabs,
       }),
     });
     if (!res.ok) {
@@ -295,30 +288,6 @@ export default function WorkspaceAdmin({
                   </div>
                 </div>
               ) : null}
-            </div>
-          </div>
-
-          <div className="grid grid-cols-1 gap-x-4 sm:grid-cols-5">
-            <div className="sm:col-span-3">
-              <div className="flex justify-between">
-                <label
-                  htmlFor="appName"
-                  className="block text-sm font-medium text-gray-700"
-                >
-                  Manage experimental features
-                </label>
-              </div>
-            </div>
-            <div className="sm:col-span-3">
-              <div className="mt-2 flex">
-                <Checkbox
-                  checked={disableLabs}
-                  onChange={(checked) => setDisableLabs(checked)}
-                />
-                <p className="ml-3 block text-sm text-sm font-normal text-gray-500">
-                  Hide experimental features for the workspace.
-                </p>
-              </div>
             </div>
           </div>
 

--- a/front/types/user.ts
+++ b/front/types/user.ts
@@ -24,7 +24,6 @@ export type WorkspaceType = {
   allowedDomain: string | null;
   role: RoleType;
   plan: PlanType;
-  disableLabs?: boolean;
 };
 
 export type UserType = {


### PR DESCRIPTION
There was an option for admins to chose to display experimental features or not. 
This PR removes this option. Labs is not displayed anymore except in dev mode or with Dust workspace.

Note: Needs to sync db to remove the field from workspaces.