### PR TITLE
chore: cleanup models in chat.ts

### DIFF
--- a/front/lib/api/chat.ts
+++ b/front/lib/api/chat.ts
@@ -265,7 +265,7 @@ export async function getChatSessionWithMessages(
     messages: messages.map((m) => {
       return {
         role: m.role,
-        message: m.message,
+        message: m.message ?? undefined,
         feedback: m.feedback,
         sId: m.sId,
         retrievals: chatMessagesRetrieval[m.id].map((r) => {
@@ -328,7 +328,7 @@ export async function getChatMessage(
 
   return {
     role: chatMessage.role,
-    message: chatMessage.message,
+    message: chatMessage.message ?? undefined,
     feedback: chatMessage.feedback,
     sId: chatMessage.sId,
     retrievals: retrievedDocuments.map((r) => {

--- a/front/lib/models/chat.ts
+++ b/front/lib/models/chat.ts
@@ -25,7 +25,7 @@ export class ChatSession extends Model<
   declare visibility: ChatSessionVisibility;
 
   declare workspaceId: ForeignKey<Workspace["id"]> | null;
-  declare userId: ForeignKey<User["id"]>;
+  declare userId: ForeignKey<User["id"]> | null;
 }
 
 ChatSession.init(
@@ -83,9 +83,9 @@ export class ChatMessage extends Model<
   declare updatedAt: CreationOptional<Date>;
   declare feedback: MessageFeedbackStatus;
   declare role: "user" | "retrieval" | "assistant" | "error";
-  declare message?: string;
+  declare message: string | null;
   // `retrievals` are stored in a separate table
-  declare chatSessionId: ForeignKey<ChatSession["id"]>;
+  declare chatSessionId: ForeignKey<ChatSession["id"]> | null;
 }
 
 ChatMessage.init(
@@ -149,7 +149,7 @@ export class ChatRetrievedDocument extends Model<
   declare score: number;
   // `chunks` are not stored for Chat history
 
-  declare chatMessageId: ForeignKey<ChatMessage["id"]>;
+  declare chatMessageId: ForeignKey<ChatMessage["id"]> | null;
 }
 
 ChatRetrievedDocument.init(

--- a/front/pages/api/w/[wId]/use/chats/[cId]/messages/[mId]/index.ts
+++ b/front/pages/api/w/[wId]/use/chats/[cId]/messages/[mId]/index.ts
@@ -224,7 +224,7 @@ async function handler(
       });
       // return the deleted message
       res.status(200).json({
-        message,
+        message: { ...message, message: message.message ?? undefined },
       });
       return;
     }


### PR DESCRIPTION
The idea is to:
- replace `x?: T` by `x: T | null` in all models
- replace `x: ForeignKey<...>` by `x: ForeignKey<...> | null` in most places (very few of our FKs are actually non-nullable)

This PR focuses on chat.ts