### PR TITLE
chore: cleanup models in data_source.ts

### DIFF
--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -37,12 +37,12 @@ export async function getDataSource(
   return {
     id: dataSource.id,
     name: dataSource.name,
-    description: dataSource.description,
+    description: dataSource.description ?? undefined,
     visibility: dataSource.visibility,
-    config: dataSource.config,
+    config: dataSource.config ?? undefined,
     dustAPIProjectId: dataSource.dustAPIProjectId,
-    connectorId: dataSource.connectorId,
-    connectorProvider: dataSource.connectorProvider,
+    connectorId: dataSource.connectorId ?? undefined,
+    connectorProvider: dataSource.connectorProvider ?? undefined,
     assistantDefaultSelected: dataSource.assistantDefaultSelected,
   };
 }
@@ -75,12 +75,12 @@ export async function getDataSources(
     return {
       id: dataSource.id,
       name: dataSource.name,
-      description: dataSource.description,
+      description: dataSource.description ?? undefined,
       visibility: dataSource.visibility,
-      config: dataSource.config,
+      config: dataSource.config ?? undefined,
       dustAPIProjectId: dataSource.dustAPIProjectId,
-      connectorId: dataSource.connectorId,
-      connectorProvider: dataSource.connectorProvider,
+      connectorId: dataSource.connectorId ?? undefined,
+      connectorProvider: dataSource.connectorProvider ?? undefined,
       assistantDefaultSelected: dataSource.assistantDefaultSelected,
     };
   });

--- a/front/lib/document_tracker.ts
+++ b/front/lib/document_tracker.ts
@@ -13,6 +13,11 @@ export async function updateTrackedDocuments(
   if (!dataSource) {
     throw new Error(`Could not find data source with id ${dataSourceId}`);
   }
+  if (!dataSource.workspaceId) {
+    throw new Error(
+      `Data source with id ${dataSourceId} has no workspace id set`
+    );
+  }
 
   const hasExistingTrackedDocs = !!(await TrackedDocument.count({
     where: {

--- a/front/lib/models/data_source.ts
+++ b/front/lib/models/data_source.ts
@@ -20,14 +20,14 @@ export class DataSource extends Model<
   declare updatedAt: CreationOptional<Date>;
 
   declare name: string;
-  declare description?: string;
+  declare description: string | null;
   declare visibility: "public" | "private";
   declare assistantDefaultSelected: boolean;
-  declare config?: string;
+  declare config: string | null;
   declare dustAPIProjectId: string;
-  declare connectorId?: string;
-  declare connectorProvider?: ConnectorProvider;
-  declare workspaceId: ForeignKey<Workspace["id"]>;
+  declare connectorId: string | null;
+  declare connectorProvider: ConnectorProvider | null;
+  declare workspaceId: ForeignKey<Workspace["id"]> | null;
 }
 
 DataSource.init(

--- a/front/pages/api/w/[wId]/data_sources/[name]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/index.ts
@@ -95,7 +95,7 @@ async function handler(
         });
       }
 
-      let ds: DataSourceType;
+      let ds: DataSource;
       if (dataSource.connectorId) {
         // managed data source
         if (
@@ -143,13 +143,13 @@ async function handler(
         dataSource: {
           id: ds.id,
           name: ds.name,
-          description: ds.description,
+          description: ds.description ?? undefined,
           visibility: ds.visibility,
           assistantDefaultSelected: ds.assistantDefaultSelected,
-          config: ds.config,
+          config: ds.config ?? undefined,
           dustAPIProjectId: ds.dustAPIProjectId,
-          connectorId: ds.connectorId,
-          connectorProvider: ds.connectorProvider,
+          connectorId: ds.connectorId ?? undefined,
+          connectorProvider: ds.connectorProvider ?? undefined,
         },
       });
 

--- a/front/pages/api/w/[wId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/index.ts
@@ -162,9 +162,9 @@ async function handler(
         dataSource: {
           id: ds.id,
           name: ds.name,
-          description: ds.description,
+          description: ds.description ?? undefined,
           visibility: ds.visibility,
-          config: ds.config,
+          config: ds.config ?? undefined,
           dustAPIProjectId: ds.dustAPIProjectId,
           assistantDefaultSelected: ds.assistantDefaultSelected,
         },

--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -242,9 +242,9 @@ async function handler(
         dataSource: {
           id: dataSource.id,
           name: dataSource.name,
-          description: dataSource.description,
+          description: dataSource.description ?? undefined,
           visibility: dataSource.visibility,
-          config: dataSource.config,
+          config: dataSource.config ?? undefined,
           dustAPIProjectId: dataSource.dustAPIProjectId,
           connectorId: connectorsRes.value.id,
           connectorProvider: provider,


### PR DESCRIPTION
The idea is to:
- replace `x?: T` by `x: T | null` in all models
- replace `x: ForeignKey<...>` by `x: ForeignKey<...> | null` in most places (very few of our FKs are actually non-nullable)

This PR focuses on data_source.ts