### PR TITLE
chore: cleanup models in doc_tracker.ts and extract.ts

### DIFF
--- a/front/lib/api/extract.ts
+++ b/front/lib/api/extract.ts
@@ -12,7 +12,7 @@ function _getEventSchemaType(schema: EventSchema): EventSchemaType {
     id: schema.id,
     sId: schema.sId,
     marker: schema.marker,
-    description: schema.description,
+    description: schema.description ?? undefined,
     status: schema.status,
     properties: schema.properties,
   };

--- a/front/lib/extract_events.ts
+++ b/front/lib/extract_events.ts
@@ -154,7 +154,7 @@ async function _processExtractEventsForMarker({
     auth,
     content: contentToProcess,
     marker: marker,
-    schema: schema,
+    schema: { ...schema, description: schema.description ?? undefined },
   });
 
   if (result.length === 0) {

--- a/front/lib/models/doc_tracker.ts
+++ b/front/lib/models/doc_tracker.ts
@@ -81,7 +81,7 @@ export class DocumentTrackerChangeSuggestion extends Model<
   declare updatedAt: CreationOptional<Date>;
 
   declare suggestion: string;
-  declare reason?: string | null;
+  declare reason: string | null;
   declare status: "pending" | "done" | "rejected";
 
   declare trackedDocumentId: ForeignKey<TrackedDocument["id"]>;

--- a/front/lib/models/extract.ts
+++ b/front/lib/models/extract.ts
@@ -22,9 +22,9 @@ export class EventSchema extends Model<
   declare sId: string;
 
   declare marker: string;
-  declare description?: string;
+  declare description: string | null;
   declare status: EventSchemaStatus;
-  declare debug?: boolean;
+  declare debug: boolean | null;
   declare properties: EventSchemaPropertyType[];
   declare userId: ForeignKey<User["id"]>;
   declare workspaceId: ForeignKey<Workspace["id"]>;


### PR DESCRIPTION
The idea is to:
- replace `x?: T` by `x: T | null` in all models
- replace `x: ForeignKey<...>` by `x: ForeignKey<...> | null` in most places (very few of our FKs are actually non-nullable)

This PR focuses on doc_tracker.ts and extract.ts