### PR TITLE
chore: cleanup models in gens.ts xp1.ts and workspace.ts

### DIFF
--- a/front/lib/models/workspace.ts
+++ b/front/lib/models/workspace.ts
@@ -20,9 +20,9 @@ export class Workspace extends Model<
 
   declare sId: string;
   declare name: string;
-  declare description?: string;
-  declare allowedDomain?: string;
-  declare plan?: string | null;
+  declare description: string | null;
+  declare allowedDomain: string | null;
+  declare plan: string | null;
 }
 Workspace.init(
   {

--- a/front/pages/api/w/[wId]/use/gens/templates/[tId]/index.ts
+++ b/front/pages/api/w/[wId]/use/gens/templates/[tId]/index.ts
@@ -103,7 +103,7 @@ async function handler(
           });
         }
 
-        result = await updateTemplate(auth, pRes.value);
+        result = await updateTemplate(auth, { ...pRes.value, userId: null });
         if (!result) {
           return apiError(req, res, {
             status_code: 404,
@@ -125,7 +125,7 @@ async function handler(
         });
       }
       res.status(201).json({
-        template: pRes.value,
+        template: { ...pRes.value, userId: null },
       });
       return;
 

--- a/front/pages/w/[wId]/u/gens/index.tsx
+++ b/front/pages/w/[wId]/u/gens/index.tsx
@@ -585,30 +585,31 @@ export function TemplatesView({
   savedTemplates: GensTemplateType[];
   isBuilder: boolean;
 }) {
-  const [templates, setTemplates] = useState<GensTemplateType[]>(
-    [
-      {
-        name: "Neutral",
-        color: "bg-green-500",
-        instructions: "",
-        sId: "0000",
-        visibility: "default" as GensTemplateVisibilityType,
-      },
-      {
-        name: "Fact Gatherer",
-        color: "bg-red-500",
-        instructions: [
-          "Extract facts and important information in a list",
-          "Present your answers in list format",
-          "The user text is part of a document they're writing on the topic, and we want to help them get access to more information. The user might be mid-sentence, we just want to get context and helpful information",
-          "Don't say things like 'based on the document', 'The main points are', ... If you can't find useful information, just say so",
-          "We just want to gather facts and answers related to the document text",
-        ].join("\n"),
-        sId: "0000",
-        visibility: "default" as GensTemplateVisibilityType,
-      },
-    ].concat(savedTemplates)
-  );
+  const [templates, setTemplates] = useState<GensTemplateType[]>([
+    {
+      name: "Neutral",
+      color: "bg-green-500",
+      instructions: "",
+      sId: "0000",
+      visibility: "default" as GensTemplateVisibilityType,
+      userId: null,
+    },
+    {
+      name: "Fact Gatherer",
+      color: "bg-red-500",
+      instructions: [
+        "Extract facts and important information in a list",
+        "Present your answers in list format",
+        "The user text is part of a document they're writing on the topic, and we want to help them get access to more information. The user might be mid-sentence, we just want to get context and helpful information",
+        "Don't say things like 'based on the document', 'The main points are', ... If you can't find useful information, just say so",
+        "We just want to gather facts and answers related to the document text",
+      ].join("\n"),
+      sId: "0000",
+      visibility: "default" as GensTemplateVisibilityType,
+      userId: null,
+    },
+    ...savedTemplates,
+  ]);
   const [selectedTemplate, setSelectedTemplate] = useState<number>(0);
   const [editingTemplate, setEditingTemplate] = useState<number>(-1);
   const [editingTemplateTitle, setEditingTemplateTitle] = useState<string>("");
@@ -847,6 +848,7 @@ export function TemplatesView({
                                 instructions: editingTemplateInstructions,
                                 sId: client_side_new_id(),
                                 visibility: editingTemplateVisibility,
+                                userId: null,
                               };
                               const curr_templates = templates.map((d) => d);
                               if (editingTemplate == -1) {

--- a/front/types/gens.ts
+++ b/front/types/gens.ts
@@ -23,5 +23,5 @@ export type GensTemplateType = {
   color: string;
   sId: string;
   visibility: GensTemplateVisibilityType;
-  userId?: number;
+  userId: number | null;
 };


### PR DESCRIPTION
The idea is to:

replace x?: T by x: T | null in all models
replace x: ForeignKey<...> by x: ForeignKey<...> | null in most places (very few of our FKs are actually non-nullable)
This PR focuses on gens.ts and xp1.ts and workspace.ts

⚠️ There's a bunch of "TODO: fix this lie", because there is no "easy" way to fix the fact that a bunch of "workspaceId" foreign key can actually be null while the code assumes it cannot.
The right fix (which has to be impl'd in a separate PR), is to actually make `workspaceId` non-nullable.