### PR TITLE
Extract big docs v2

### DIFF
--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -1611,20 +1611,19 @@ async fn tokenize(
     extract::Json(payload): extract::Json<TokenizePayload>,
 ) -> (StatusCode, Json<APIResponse>) {
     let embedder = provider(payload.provider_id).embedder(payload.model_id);
-    match embedder.custom_tokenize(payload.text).await {
+    match embedder.tokenize(payload.text).await {
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,
             "internal_server_error",
             "Failed to tokenize text",
             Some(e),
         ),
-        Ok((tokens, strings)) => (
+        Ok(tokens) => (
             StatusCode::OK,
             Json(APIResponse {
                 error: None,
                 response: Some(json!({
                     "tokens": tokens,
-                    "strings": strings,
                 })),
             }),
         ),

--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -1618,23 +1618,16 @@ async fn tokenize(
             "Failed to tokenize text",
             Some(e),
         ),
-        Ok(tokens) => {
-            // let tokens_with_numbers: Vec<(usize, String)> = tokens
-            //     .iter()
-            //     .enumerate()
-            //     .map(|(i, &token)| (i, token))
-            //     .collect();
-
-            (
-                StatusCode::OK,
-                Json(APIResponse {
-                    error: None,
-                    response: Some(json!({
-                        "tokens": tokens,
-                    })),
-                }),
-            )
-        }
+        Ok((tokens, strings)) => (
+            StatusCode::OK,
+            Json(APIResponse {
+                error: None,
+                response: Some(json!({
+                    "tokens": tokens,
+                    "strings": strings,
+                })),
+            }),
+        ),
     }
 }
 

--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -1611,22 +1611,30 @@ async fn tokenize(
     extract::Json(payload): extract::Json<TokenizePayload>,
 ) -> (StatusCode, Json<APIResponse>) {
     let embedder = provider(payload.provider_id).embedder(payload.model_id);
-    match embedder.encode(&payload.text).await {
-        Err(e) => error_response(
+    match embedder.custom_tokenize(payload.text).await {
+        Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,
             "internal_server_error",
             "Failed to tokenize text",
             Some(e),
         ),
-        Ok(tokens) => (
-            StatusCode::OK,
-            Json(APIResponse {
-                error: None,
-                response: Some(json!({
-                    "tokens": tokens,
-                })),
-            }),
-        ),
+        Ok(tokens) => {
+            // let tokens_with_numbers: Vec<(usize, String)> = tokens
+            //     .iter()
+            //     .enumerate()
+            //     .map(|(i, &token)| (i, token))
+            //     .collect();
+
+            (
+                StatusCode::OK,
+                Json(APIResponse {
+                    error: None,
+                    response: Some(json!({
+                        "tokens": tokens,
+                    })),
+                }),
+            )
+        }
     }
 }
 

--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -1612,7 +1612,7 @@ async fn tokenize(
 ) -> (StatusCode, Json<APIResponse>) {
     let embedder = provider(payload.provider_id).embedder(payload.model_id);
     match embedder.tokenize(payload.text).await {
-        Err(e) => (
+        Err(e) => error_response(
             StatusCode::INTERNAL_SERVER_ERROR,
             "internal_server_error",
             "Failed to tokenize text",

--- a/core/src/providers/ai21.rs
+++ b/core/src/providers/ai21.rs
@@ -385,6 +385,10 @@ impl Embedder for AI21Embedder {
         Err(anyhow!("Encode/Decode not implemented for provider `ai21`"))
     }
 
+    async fn custom_tokenize(&self, _text: String) -> Result<(Vec<usize>, Vec<String>)> {
+        Err(anyhow!("Tokenize not implemented for provider `ai21`"))
+    }
+
     async fn embed(&self, _text: Vec<&str>, _extras: Option<Value>) -> Result<Vec<EmbedderVector>> {
         Err(anyhow!("Embeddings not available for provider `ai21`"))
     }

--- a/core/src/providers/ai21.rs
+++ b/core/src/providers/ai21.rs
@@ -385,7 +385,7 @@ impl Embedder for AI21Embedder {
         Err(anyhow!("Encode/Decode not implemented for provider `ai21`"))
     }
 
-    async fn custom_tokenize(&self, _text: String) -> Result<(Vec<usize>, Vec<String>)> {
+    async fn tokenize(&self, _text: String) -> Result<Vec<(usize, String)>> {
         Err(anyhow!("Tokenize not implemented for provider `ai21`"))
     }
 

--- a/core/src/providers/anthropic.rs
+++ b/core/src/providers/anthropic.rs
@@ -631,7 +631,7 @@ impl Embedder for AnthropicEmbedder {
         ))
     }
 
-    async fn custom_tokenize(&self, _text: String) -> Result<(Vec<usize>, Vec<String>)> {
+    async fn tokenize(&self, _text: String) -> Result<Vec<(usize, String)>> {
         Err(anyhow!("Tokenize not implemented for provider `anthropic`"))
     }
 

--- a/core/src/providers/anthropic.rs
+++ b/core/src/providers/anthropic.rs
@@ -631,6 +631,10 @@ impl Embedder for AnthropicEmbedder {
         ))
     }
 
+    async fn custom_tokenize(&self, _text: String) -> Result<(Vec<usize>, Vec<String>)> {
+        Err(anyhow!("Tokenize not implemented for provider `anthropic`"))
+    }
+
     async fn embed(&self, _text: Vec<&str>, _extras: Option<Value>) -> Result<Vec<EmbedderVector>> {
         Err(anyhow!("Embeddings not available for provider `anthropic`"))
     }

--- a/core/src/providers/azure_openai.rs
+++ b/core/src/providers/azure_openai.rs
@@ -600,6 +600,10 @@ impl Embedder for AzureOpenAIEmbedder {
         Ok(str)
     }
 
+    async fn custom_tokenize(&self, _text: String) -> Result<(Vec<usize>, Vec<String>)> {
+        Err(anyhow!("Tokenize not implemented for provider `anthropic`"))
+    }
+
     async fn embed(&self, text: Vec<&str>, extras: Option<Value>) -> Result<Vec<EmbedderVector>> {
         let e = embed(
             self.uri()?,

--- a/core/src/providers/azure_openai.rs
+++ b/core/src/providers/azure_openai.rs
@@ -600,7 +600,7 @@ impl Embedder for AzureOpenAIEmbedder {
         Ok(str)
     }
 
-    async fn custom_tokenize(&self, _text: String) -> Result<(Vec<usize>, Vec<String>)> {
+    async fn tokenize(&self, _text: String) -> Result<Vec<(usize, String)>> {
         Err(anyhow!("Tokenize not implemented for provider `anthropic`"))
     }
 

--- a/core/src/providers/cohere.rs
+++ b/core/src/providers/cohere.rs
@@ -534,6 +534,10 @@ impl Embedder for CohereEmbedder {
         api_decode(self.api_key.as_ref().unwrap(), tokens).await
     }
 
+    async fn custom_tokenize(&self, _text: String) -> Result<(Vec<usize>, Vec<String>)> {
+        Err(anyhow!("Tokenize not implemented for provider `Cohere`"))
+    }
+
     async fn embed(&self, text: Vec<&str>, _extras: Option<Value>) -> Result<Vec<EmbedderVector>> {
         assert!(self.api_key.is_some());
 

--- a/core/src/providers/cohere.rs
+++ b/core/src/providers/cohere.rs
@@ -534,7 +534,7 @@ impl Embedder for CohereEmbedder {
         api_decode(self.api_key.as_ref().unwrap(), tokens).await
     }
 
-    async fn custom_tokenize(&self, _text: String) -> Result<(Vec<usize>, Vec<String>)> {
+    async fn tokenize(&self, _text: String) -> Result<Vec<(usize, String)>> {
         Err(anyhow!("Tokenize not implemented for provider `Cohere`"))
     }
 

--- a/core/src/providers/embedder.rs
+++ b/core/src/providers/embedder.rs
@@ -26,6 +26,8 @@ pub trait Embedder {
     async fn encode(&self, text: &str) -> Result<Vec<usize>>;
     async fn decode(&self, tokens: Vec<usize>) -> Result<String>;
 
+    async fn custom_tokenize(&self, text: String) -> Result<(Vec<usize>, Vec<String>)>;
+
     async fn embed(&self, text: Vec<&str>, extras: Option<Value>) -> Result<Vec<EmbedderVector>>;
 }
 

--- a/core/src/providers/embedder.rs
+++ b/core/src/providers/embedder.rs
@@ -26,7 +26,7 @@ pub trait Embedder {
     async fn encode(&self, text: &str) -> Result<Vec<usize>>;
     async fn decode(&self, tokens: Vec<usize>) -> Result<String>;
 
-    async fn custom_tokenize(&self, text: String) -> Result<(Vec<usize>, Vec<String>)>;
+    async fn tokenize(&self, text: String) -> Result<Vec<(usize, String)>>;
 
     async fn embed(&self, text: Vec<&str>, extras: Option<Value>) -> Result<Vec<EmbedderVector>>;
 }

--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -1575,7 +1575,7 @@ impl Embedder for OpenAIEmbedder {
         decode_async(self.tokenizer(), tokens).await
     }
 
-    async fn custom_tokenize(&self, text: String) -> Result<(Vec<usize>, Vec<String>)> {
+    async fn tokenize(&self, text: String) -> Result<Vec<(usize, String)>> {
         tokenize_async(self.tokenizer(), text).await
     }
 

--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -28,7 +28,7 @@ use tokio::sync::mpsc::UnboundedSender;
 use tokio::time::timeout;
 
 use super::llm::{ChatFunction, ChatFunctionCall};
-use super::tiktoken::tiktoken::{decode_async, encode_async};
+use super::tiktoken::tiktoken::{decode_async, encode_async, tokenize_async};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Usage {
@@ -1573,6 +1573,10 @@ impl Embedder for OpenAIEmbedder {
 
     async fn decode(&self, tokens: Vec<usize>) -> Result<String> {
         decode_async(self.tokenizer(), tokens).await
+    }
+
+    async fn custom_tokenize(&self, text: String) -> Result<(Vec<usize>, Vec<String>)> {
+        tokenize_async(self.tokenizer(), text).await
     }
 
     async fn embed(&self, text: Vec<&str>, extras: Option<Value>) -> Result<Vec<EmbedderVector>> {

--- a/core/src/providers/tiktoken/tiktoken.rs
+++ b/core/src/providers/tiktoken/tiktoken.rs
@@ -116,7 +116,7 @@ pub async fn tokenize_async(
     bpe: Arc<Mutex<CoreBPE>>,
     text: String,
 ) -> Result<Vec<(usize, String)>> {
-    let r = task::spawn_blocking(move || bpe.lock().tokenize_with_matching_string(&text)).await?;
+    let r = task::spawn_blocking(move || bpe.lock().tokenize(&text)).await?;
     Ok(r)
 }
 
@@ -249,7 +249,7 @@ impl CoreBPE {
         ret
     }
 
-    fn _tokenize_with_matching_string(&self, text: &String) -> Vec<(usize, String)> {
+    fn _tokenize(&self, text: &String) -> Vec<(usize, String)> {
         let regex = self._get_regex();
         let mut results = vec![];
 
@@ -553,8 +553,8 @@ impl CoreBPE {
         self._encode_native(text, &allowed_special).0
     }
 
-    pub fn tokenize_with_matching_string(&self, text: &String) -> Vec<(usize, String)> {
-        self._tokenize_with_matching_string(text)
+    pub fn tokenize(&self, text: &String) -> Vec<(usize, String)> {
+        self._tokenize(text)
     }
 
     pub fn encode_with_special_tokens(&self, text: &str) -> Vec<usize> {

--- a/core/src/providers/tiktoken/tiktoken.rs
+++ b/core/src/providers/tiktoken/tiktoken.rs
@@ -266,6 +266,10 @@ impl CoreBPE {
         results
     }
 
+    /**
+     * Implemented to match the logic in _encode_ordinary_native
+     * Used in tokenize function
+     */
     pub fn _tokenize_byte_pair_encode(
         piece: &[u8],
         ranks: &HashMap<Vec<u8>, usize>,

--- a/core/src/providers/tiktoken/tiktoken.rs
+++ b/core/src/providers/tiktoken/tiktoken.rs
@@ -256,22 +256,18 @@ impl CoreBPE {
 
         for mat in regex.find_iter(text) {
             let string = mat.unwrap().as_str();
-            let bstring = string.as_bytes();
-
-            if let Some(token) = self.encoder.get(bstring) {
+            let piece = string.as_bytes();
+            if let Some(token) = self.encoder.get(piece) {
                 tokens.push(*token);
                 strings.push((*string).to_string());
                 continue;
-            } else {
-                let mut _rank_pieces = Vec::new();
-                let mut _string_pieces = Vec::new();
-
-                (_rank_pieces, _string_pieces) =
-                    Self::_tokenize_byte_pair_encode(bstring, &self.encoder);
-
-                tokens.extend(_rank_pieces);
-                strings.extend(_string_pieces);
             }
+
+            let (_rank_pieces, _string_pieces) =
+                Self::_tokenize_byte_pair_encode(piece, &self.encoder);
+
+            tokens.extend(_rank_pieces);
+            strings.extend(_string_pieces);
         }
         (tokens, strings)
     }

--- a/front/lib/core_api.ts
+++ b/front/lib/core_api.ts
@@ -726,7 +726,7 @@ export const CoreAPI = {
     text: string;
     modelId: string;
     providerId: string;
-  }): Promise<CoreAPIResponse<{ tokens: number[] }>> {
+  }): Promise<CoreAPIResponse<{ tokens: number[]; strings: string[] }>> {
     const response = await fetch(`${CORE_API}/tokenize`, {
       method: "POST",
       headers: {

--- a/front/lib/core_api.ts
+++ b/front/lib/core_api.ts
@@ -88,6 +88,8 @@ export type CoreAPIRun = {
   traces: Array<[[BlockType, string], Array<Array<TraceType>>]>;
 };
 
+export type CoreAPITokenType = [number, string];
+
 type CoreAPICreateRunParams = {
   projectId: string;
   runAsWorkspaceId: string;
@@ -726,7 +728,7 @@ export const CoreAPI = {
     text: string;
     modelId: string;
     providerId: string;
-  }): Promise<CoreAPIResponse<{ tokens: number[]; strings: string[] }>> {
+  }): Promise<CoreAPIResponse<{ tokens: CoreAPITokenType[] }>> {
     const response = await fetch(`${CORE_API}/tokenize`, {
       method: "POST",
       headers: {

--- a/front/lib/extract_event_app.ts
+++ b/front/lib/extract_event_app.ts
@@ -64,7 +64,8 @@ export async function _runExtractEventApp({
 
 /**
  * Gets the maximum text content to process for the Dust app.
- * We don't go up to the maximum number of tokens because the Dust app
+ * We define a maximum number of tokens that the Dust app can process.
+ * It will return the text around the marker: first we expand the text before the marker, than after the marker.
  */
 export async function _getMaxTextContentToProcess({
   fullText,
@@ -73,11 +74,11 @@ export async function _getMaxTextContentToProcess({
   fullText: string;
   marker: string;
 }): Promise<string> {
-  const MAX_TOKENS = 6000;
   const tokenized = await getTokenizedText(fullText);
   const tokens = tokenized.tokens;
   const strings = tokenized.strings;
   const nbTokens = tokens.length;
+  const MAX_TOKENS = 6000;
 
   // If the text is small enough, just return it
   if (nbTokens < MAX_TOKENS) {
@@ -86,7 +87,7 @@ export async function _getMaxTextContentToProcess({
 
   // Otherwise we extract the tokens around the marker
   // and return the text corresponding to those tokens
-  const extractTokensResult = extractTokens({
+  const extractTokensResult = extractMaxTokens({
     fullText,
     tokens,
     strings,
@@ -98,7 +99,12 @@ export async function _getMaxTextContentToProcess({
 }
 
 /**
- * Gets the indexes of the tokens around the marker
+ * Gets the indexes of the tokens corresponding to the marker.
+ * Example, for params:
+ * - full_text: Un petit Soupinou des bois [[idea:2]]
+ * - strings: ["Un", " petit", " Sou", "pin", "ou", " des", " bois", " [[", "idea", ":", "2", "]]"];
+ * - marker: "[[idea:2]]"
+ * Will return { start: 7, end: 11 }
  */
 function findMarkersIndexes({
   fullText,
@@ -134,9 +140,9 @@ function findMarkersIndexes({
 }
 
 /**
- * Extracts the tokens around the marker
+ * Extracts the maximum number of tokens around the marker.
  */
-function extractTokens({
+function extractMaxTokens({
   fullText,
   tokens,
   strings,
@@ -185,7 +191,12 @@ function extractTokens({
 }
 
 /**
- * Calling Core API to get the number of tokens in a text.
+ * Calls Core API to get the tokens and associated strings for a given text.
+ * Ex: "Un petit Soupinou des bois [[idea:2]]" will return:
+ * {
+ *   tokens: [1844, 46110,  9424, 13576, 283, 951, 66304,  4416, 42877, 25, 17, 5163],
+ *   strings: ["Un", " petit", " Sou", "pin", "ou", " des", " bois", " [[", "idea", ":", "2", "]]"],
+ * }
  */
 export async function getTokenizedText(
   text: string

--- a/front/lib/extract_event_app.ts
+++ b/front/lib/extract_event_app.ts
@@ -73,7 +73,7 @@ export async function _getMaxTextContentToProcess({
   fullText: string;
   marker: string;
 }): Promise<string> {
-  const MAX_TOKENS = 10;
+  const MAX_TOKENS = 6000;
   const tokenized = await getTokenizedText(fullText);
   const tokens = tokenized.tokens;
   const strings = tokenized.strings;

--- a/front/lib/extract_event_app.ts
+++ b/front/lib/extract_event_app.ts
@@ -5,6 +5,7 @@ import {
 import { runAction } from "@app/lib/actions/server";
 import { Authenticator } from "@app/lib/auth";
 import { CoreAPI } from "@app/lib/core_api";
+import { findMarkersIndexes } from "@app/lib/extract_event_markers";
 import { formatPropertiesForModel } from "@app/lib/extract_events_properties";
 import logger from "@app/logger/logger";
 import { EventSchemaType } from "@app/types/extract";
@@ -96,47 +97,6 @@ export async function _getMaxTextContentToProcess({
   });
 
   return extractTokensResult.strings.join("");
-}
-
-/**
- * Gets the indexes of the tokens corresponding to the marker.
- * Example, for params:
- * - full_text: Un petit Soupinou des bois [[idea:2]]
- * - strings: ["Un", " petit", " Sou", "pin", "ou", " des", " bois", " [[", "idea", ":", "2", "]]"];
- * - marker: "[[idea:2]]"
- * Will return { start: 7, end: 11 }
- */
-function findMarkersIndexes({
-  fullText,
-  marker,
-  strings,
-}: {
-  fullText: string;
-  marker: string;
-  strings: string[];
-}): { start: number; end: number } {
-  const markerIndex = fullText.indexOf(marker);
-  if (markerIndex === -1) return { start: -1, end: -1 };
-
-  let charCount = 0;
-  let startIndex = -1;
-  let endIndex = -1;
-
-  for (let i = 0; i < strings.length; i++) {
-    const str = strings[i];
-    charCount += str.length;
-
-    if (startIndex === -1 && charCount > markerIndex) {
-      startIndex = i;
-    }
-
-    if (charCount >= markerIndex + marker.length) {
-      endIndex = i;
-      break;
-    }
-  }
-
-  return { start: startIndex, end: endIndex };
 }
 
 /**

--- a/front/lib/extract_event_markers.ts
+++ b/front/lib/extract_event_markers.ts
@@ -84,3 +84,44 @@ export async function getExtractEventMarkersToProcess({
     (rawMarker) => !existingExtractedEventMarkers.includes(rawMarker)
   );
 }
+
+/**
+ * Gets the indexes of the tokens corresponding to the marker.
+ * Example, for params:
+ * - full_text: Un petit Soupinou des bois [[idea:2]]
+ * - strings: ["Un", " petit", " Sou", "pin", "ou", " des", " bois", " [[", "idea", ":", "2", "]]"];
+ * - marker: "[[idea:2]]"
+ * Will return { start: 7, end: 11 }
+ */
+export function findMarkersIndexes({
+  fullText,
+  marker,
+  strings,
+}: {
+  fullText: string;
+  marker: string;
+  strings: string[];
+}): { start: number; end: number } {
+  const markerIndex = fullText.indexOf(marker);
+  if (markerIndex === -1) return { start: -1, end: -1 };
+
+  let charCount = 0;
+  let startIndex = -1;
+  let endIndex = -1;
+
+  for (let i = 0; i < strings.length; i++) {
+    const str = strings[i];
+    charCount += str.length;
+
+    if (startIndex === -1 && charCount > markerIndex) {
+      startIndex = i;
+    }
+
+    if (charCount >= markerIndex + marker.length) {
+      endIndex = i;
+      break;
+    }
+  }
+
+  return { start: startIndex, end: endIndex };
+}

--- a/front/lib/extract_event_markers.ts
+++ b/front/lib/extract_event_markers.ts
@@ -2,6 +2,8 @@ import { Op } from "sequelize";
 
 import { ExtractedEvent } from "@app/lib/models";
 
+import { CoreAPITokenType } from "./core_api";
+
 const EXTRACT_EVENT_PATTERN = /\[\[(.*?)\]\]/; // Ex: [[event]]
 
 /**
@@ -89,18 +91,31 @@ export async function getExtractEventMarkersToProcess({
  * Gets the indexes of the tokens corresponding to the marker.
  * Example, for params:
  * - full_text: Un petit Soupinou des bois [[idea:2]]
- * - strings: ["Un", " petit", " Sou", "pin", "ou", " des", " bois", " [[", "idea", ":", "2", "]]"];
+ * - tokens: [
+    [ 1844, 'Un' ],
+    [ 46110, ' petit' ],
+    [ 9424, ' Sou' ],
+    [ 13576, 'pin' ],
+    [ 283, 'ou' ],
+    [ 951, ' des' ],
+    [ 66304, ' bois' ],
+    [ 4416, ' [[' ],
+    [ 42877, 'idea' ],
+    [ 25, ':' ],
+    [ 17, '2' ],
+    [ 5163, ']]' ]
+  ]
  * - marker: "[[idea:2]]"
  * Will return { start: 7, end: 11 }
  */
 export function findMarkersIndexes({
   fullText,
   marker,
-  strings,
+  tokens,
 }: {
   fullText: string;
   marker: string;
-  strings: string[];
+  tokens: CoreAPITokenType[];
 }): { start: number; end: number } {
   const markerIndex = fullText.indexOf(marker);
   if (markerIndex === -1) return { start: -1, end: -1 };
@@ -109,8 +124,8 @@ export function findMarkersIndexes({
   let startIndex = -1;
   let endIndex = -1;
 
-  for (let i = 0; i < strings.length; i++) {
-    const str = strings[i];
+  for (let i = 0; i < tokens.length; i++) {
+    const str = tokens[i][1];
     charCount += str.length;
 
     if (startIndex === -1 && charCount > markerIndex) {

--- a/front/lib/extract_events.ts
+++ b/front/lib/extract_events.ts
@@ -145,7 +145,7 @@ async function _processExtractEventsForMarker({
 
   // 2/ Check that the document is not to big for the Dust App.
   const contentToProcess = await _getMaxTextContentToProcess({
-    fullDocumentText: documentText,
+    fullText: documentText,
     marker: marker,
   });
 

--- a/front/tests/lib/markers.test.ts
+++ b/front/tests/lib/markers.test.ts
@@ -1,4 +1,5 @@
 import {
+  findMarkersIndexes,
   getRawExtractEventMarkersFromText,
   hasExtractEventMarker,
 } from "@app/lib/extract_event_markers";
@@ -71,6 +72,83 @@ describe("Test getExtractEventMarker", function () {
     ];
     cases.forEach((c) => {
       expect(getRawExtractEventMarkersFromText(c.text)).toEqual(c.markers);
+    });
+  });
+});
+
+describe("Test findMarkerIndexes", function () {
+  test("findMarkerIndexes", function () {
+    const fullTextSoupinou = "Un petit Soupinou des bois [[idea:2]]";
+    const stringsSoupinou = [
+      "Un",
+      " petit",
+      " Sou",
+      "pin",
+      "ou",
+      " des",
+      " bois",
+      " [[",
+      "idea",
+      ":",
+      "2",
+      "]]",
+    ];
+
+    const fullTextSticious =
+      "I’m not superstitious [[office_quote]], but I am a little stitious. [[office_quote]]";
+    const stringsSticious = [
+      "I",
+      "’m",
+      " not",
+      " super",
+      "stit",
+      "ious",
+      " [[",
+      "office",
+      "_quote",
+      "]],",
+      " but",
+      " I",
+      " am",
+      " a",
+      " little",
+      " st",
+      "itious",
+      ".",
+      " [[",
+      "office",
+      "_quote",
+      "]]",
+    ];
+
+    const cases = [
+      {
+        fullText: fullTextSoupinou,
+        marker: "[[idea:2]]",
+        strings: stringsSoupinou,
+        expected: { start: 7, end: 11 }, // main case
+      },
+      {
+        fullText: fullTextSoupinou,
+        marker: "[[idea]]",
+        strings: stringsSoupinou,
+        expected: { start: -1, end: -1 }, // not found
+      },
+      {
+        fullText: fullTextSticious,
+        marker: "[[office_quote]]",
+        strings: stringsSticious,
+        expected: { start: 6, end: 9 }, // takes the first one
+      },
+    ];
+    cases.forEach((c) => {
+      expect(
+        findMarkersIndexes({
+          fullText: c.fullText,
+          marker: c.marker,
+          strings: c.strings,
+        })
+      ).toEqual(c.expected);
     });
   });
 });

--- a/front/tests/lib/markers.test.ts
+++ b/front/tests/lib/markers.test.ts
@@ -1,3 +1,4 @@
+import { CoreAPITokenType } from "@app/lib/core_api";
 import {
   findMarkersIndexes,
   getRawExtractEventMarkersFromText,
@@ -79,65 +80,65 @@ describe("Test getExtractEventMarker", function () {
 describe("Test findMarkerIndexes", function () {
   test("findMarkerIndexes", function () {
     const fullTextSoupinou = "Un petit Soupinou des bois [[idea:2]]";
-    const stringsSoupinou = [
-      "Un",
-      " petit",
-      " Sou",
-      "pin",
-      "ou",
-      " des",
-      " bois",
-      " [[",
-      "idea",
-      ":",
-      "2",
-      "]]",
+    const tokensSoupinou: CoreAPITokenType[] = [
+      [1844, "Un"],
+      [46110, " petit"],
+      [9424, " Sou"],
+      [13576, "pin"],
+      [283, "ou"],
+      [951, " des"],
+      [66304, " bois"],
+      [4416, " [["],
+      [42877, "idea"],
+      [25, ":"],
+      [17, "2"],
+      [5163, "]]"],
     ];
 
     const fullTextSticious =
-      "I’m not superstitious [[office_quote]], but I am a little stitious. [[office_quote]]";
-    const stringsSticious = [
-      "I",
-      "’m",
-      " not",
-      " super",
-      "stit",
-      "ious",
-      " [[",
-      "office",
-      "_quote",
-      "]],",
-      " but",
-      " I",
-      " am",
-      " a",
-      " little",
-      " st",
-      "itious",
-      ".",
-      " [[",
-      "office",
-      "_quote",
-      "]]",
+      "I’m not superstitious [[office_quote]] but I am a little stitious. [[office_quote]]";
+    const tokensStitious: CoreAPITokenType[] = [
+      [40, "I"],
+      [4344, "’m"],
+      [539, " not"],
+      [2307, " super"],
+      [3781, "stit"],
+      [1245, "ious"],
+      [4416, " [["],
+      [27614, "office"],
+      [46336, "_quote"],
+      [21128, "]],"],
+      [719, " but"],
+      [358, " I"],
+      [1097, " am"],
+      [264, " a"],
+      [2697, " little"],
+      [357, " st"],
+      [65795, "itious"],
+      [13, "."],
+      [4416, " [["],
+      [27614, "office"],
+      [46336, "_quote"],
+      [5163, "]]"],
     ];
 
     const cases = [
       {
         fullText: fullTextSoupinou,
         marker: "[[idea:2]]",
-        strings: stringsSoupinou,
+        tokens: tokensSoupinou,
         expected: { start: 7, end: 11 }, // main case
       },
       {
         fullText: fullTextSoupinou,
         marker: "[[idea]]",
-        strings: stringsSoupinou,
+        tokens: tokensSoupinou,
         expected: { start: -1, end: -1 }, // not found
       },
       {
         fullText: fullTextSticious,
         marker: "[[office_quote]]",
-        strings: stringsSticious,
+        tokens: tokensStitious,
         expected: { start: 6, end: 9 }, // takes the first one
       },
     ];
@@ -146,7 +147,7 @@ describe("Test findMarkerIndexes", function () {
         findMarkersIndexes({
           fullText: c.fullText,
           marker: c.marker,
-          strings: c.strings,
+          tokens: c.tokens,
         })
       ).toEqual(c.expected);
     });


### PR DESCRIPTION
### Change on Core

Edit the `tokenize` route on Core to add the list of strings associated to the list of tokens. 
```
// response before
{ 
    tokens: [1844, 46110, 9424, 13576, 283, 951, 66304, 4416, 42877, 25, 17, 5163],
}

// reponse after
{ 
    tokens: [
      [1844, "Un"],
      [46110, " petit"],
      [9424, " Sou"],
      [13576, "pin"],
      [283, "ou"],
      [951, " des"],
      [66304, " bois"],
      [4416, " [["],
      [42877, "idea"],
      [25, ":"],
      [17, "2"],
      [5163, "]]"],
     ];
}
```

### Change on Front

Edit the logic to fetch the max amount of tokens for Extract using this new route. 



### Notes
- Don't review per commit 😬 
- First Rust PR 😬 
