### PR TITLE
Making update_document_payload() use document_id_hash index.

### DIFF
--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -463,7 +463,7 @@ impl DataSource {
         let field_condition = qdrant::FieldCondition {
             key: "document_id_hash".to_string(),
             r#match: Some(qdrant::Match {
-                match_value: Some(qdrant::r#match::MatchValue::Text(document_id_hash)),
+                match_value: Some(qdrant::r#match::MatchValue::Keyword(document_id_hash)),
             }),
             ..Default::default()
         };


### PR DESCRIPTION
`update_document_payload()` is not using the proper query settings to make use of the `document_id_hash` index.
This took us down in production when doing the same mistake in data_sources/document upsert, so fixing it ahead of time will prevent us from going down again.

See the[ Qdrant doc here](https://qdrant.tech/documentation/concepts/indexing/#payload-index):

```
keyword - for [keyword](https://qdrant.tech/documentation/concepts/payload/#keyword) payload, affects [Match](https://qdrant.tech/documentation/concepts/filtering/#match) filtering conditions.
integer - for [integer](https://qdrant.tech/documentation/concepts/payload/#integer) payload, affects [Match](https://qdrant.tech/documentation/concepts/filtering/#match) and [Range](https://qdrant.tech/documentation/concepts/filtering/#range) filtering conditions.
float - for [float](https://qdrant.tech/documentation/concepts/payload/#float) payload, affects [Range](https://qdrant.tech/documentation/concepts/filtering/#range) filtering conditions.
bool - for [bool](https://qdrant.tech/documentation/concepts/payload/#bool) payload, affects [Match](https://qdrant.tech/documentation/concepts/filtering/#match) filtering conditions (available as of 1.4.0).
geo - for [geo](https://qdrant.tech/documentation/concepts/payload/#geo) payload, affects [Geo Bounding Box](https://qdrant.tech/documentation/concepts/filtering/#geo-bounding-box) and [Geo Radius](https://qdrant.tech/documentation/concepts/filtering/#geo-radius) filtering conditions.
text - a special kind of index, available for [keyword](https://qdrant.tech/documentation/concepts/payload/#keyword) / string payloads, affects [Full Text search](https://qdrant.tech/documentation/concepts/filtering/#full-text-match) filtering conditions. <<<<<<<<<<<<<<<< This one is the problematic one
```