### PR TITLE
Extract: Respect order of props from Schema

### DIFF
--- a/front/lib/actions/registry.ts
+++ b/front/lib/actions/registry.ts
@@ -220,7 +220,7 @@ export const DustProdActionRegistry = createActionRegistry({
       workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
       appId: "d4f31b6a63",
       appHash:
-        "73215c9d3fb6819c979d83bae86681313a41ea21760ffd9372d7f2a711387d18",
+        "65304e44043046ff37dd85e98b31557f21937a6b0b468fbfa2eb4bf424f1cc0d",
     },
     config: {
       MODEL: {

--- a/front/lib/api/extract.ts
+++ b/front/lib/api/extract.ts
@@ -18,7 +18,10 @@ function _getEventSchemaType(schema: EventSchema): EventSchemaType {
   };
 }
 
-function _getExtractedEventType(event: ExtractedEvent): ExtractedEventType {
+function _getExtractedEventType(
+  event: ExtractedEvent,
+  schema: EventSchema
+): ExtractedEventType {
   return {
     id: event.id,
     sId: event.sId,
@@ -28,6 +31,10 @@ function _getExtractedEventType(event: ExtractedEvent): ExtractedEventType {
     dataSourceName: event.dataSourceName,
     documentId: event.documentId,
     documentSourceUrl: event.documentSourceUrl,
+    schema: {
+      marker: schema.marker,
+      sId: schema.sId,
+    },
   };
 }
 
@@ -204,7 +211,7 @@ export async function getExtractedEvent({
     return null;
   }
 
-  return _getExtractedEventType(event);
+  return _getExtractedEventType(event, schema);
 }
 
 export async function getExtractedEvents({
@@ -242,7 +249,7 @@ export async function getExtractedEvents({
   });
 
   return events.map((event): ExtractedEventType => {
-    return _getExtractedEventType(event);
+    return _getExtractedEventType(event, schema);
   });
 }
 
@@ -292,5 +299,5 @@ export async function updateExtractedEvent({
     });
   }
 
-  return _getExtractedEventType(event);
+  return _getExtractedEventType(event, schema);
 }

--- a/front/pages/w/[wId]/u/extract/templates/[sId]/index.tsx
+++ b/front/pages/w/[wId]/u/extract/templates/[sId]/index.tsx
@@ -279,6 +279,11 @@ const EventProperties = ({
 
   return (
     <div className="space-y-4">
+      <div className="flex flex-col">
+        <span className="font-bold">marker</span>
+        {renderPropertyValue(eventProperties["marker"])}
+      </div>
+
       {schema.properties.map((eventProperty) => {
         const propertyName = eventProperty.name;
         const propertyValue = eventProperties[propertyName];

--- a/front/pages/w/[wId]/u/extract/templates/[sId]/index.tsx
+++ b/front/pages/w/[wId]/u/extract/templates/[sId]/index.tsx
@@ -166,7 +166,7 @@ export default function AppExtractEventsReadData({
                         href={`/w/${owner.sId}/u/extract/events/${event.sId}/edit`}
                         className="block"
                       >
-                        <EventProperties event={event} />
+                        <EventProperties event={event} schema={schema} />
                       </Link>
                     </td>
                     <td className="w-auto border-y px-4 py-4 text-right align-top">
@@ -241,10 +241,23 @@ export default function AppExtractEventsReadData({
   );
 }
 
-const EventProperties = ({ event }: { event: ExtractedEventType }) => {
-  const properties = event.properties;
+// In schema properties are stored as an array of objects
+// Example: [
+//   {"name": "name", "type": "string", "description": "Name of the idea"}]
+//   {"name": "author", "type": "string", "description": "Author of the idea "}
+// ]
+// In event properties are stored as an object with undefined order as it is a JSONB column
+// Example: {"name": "My idea", "author": "Michael Scott"}
+const EventProperties = ({
+  event,
+  schema,
+}: {
+  event: ExtractedEventType;
+  schema: EventSchemaType;
+}) => {
+  const eventProperties = event.properties;
 
-  const renderValue = (value: string | string[]) => {
+  const renderPropertyValue = (value: string | string[]) => {
     if (typeof value === "string") {
       return <p>{value}</p>;
     }
@@ -266,12 +279,16 @@ const EventProperties = ({ event }: { event: ExtractedEventType }) => {
 
   return (
     <div className="space-y-4">
-      {Object.entries(properties).map(([key, value]) => (
-        <div key={key} className="flex flex-col">
-          <span className="font-bold">{key}</span>
-          {renderValue(value)}
-        </div>
-      ))}
+      {schema.properties.map((eventProperty) => {
+        const propertyName = eventProperty.name;
+        const propertyValue = eventProperties[propertyName];
+        return (
+          <div key={propertyName} className="flex flex-col">
+            <span className="font-bold">{propertyName}</span>
+            {renderPropertyValue(propertyValue)}
+          </div>
+        );
+      })}
     </div>
   );
 };

--- a/front/types/extract.ts
+++ b/front/types/extract.ts
@@ -46,4 +46,8 @@ export type ExtractedEventType = {
   dataSourceName: string;
   documentId: string;
   documentSourceUrl: string | null;
+  schema: {
+    marker: string;
+    sId: string;
+  };
 };


### PR DESCRIPTION
- Display order of props following what was defined in the schema.
- If you submit the edit form of an event, it automatically sets its status to `accepted`.
- When we display the marker, we display it first (changed in the Dust app so new `appHash`).
- Fix some navigation back links (enabled via adding the schema sId in `ExtractedEventType`.