### PR TITLE
Extract: Util to sort event properties

### DIFF
--- a/front/lib/api/extract.ts
+++ b/front/lib/api/extract.ts
@@ -3,6 +3,7 @@ import { Op } from "sequelize";
 import { Authenticator } from "@app/lib/auth";
 import { ModelId } from "@app/lib/databases";
 import { isDevelopmentOrDustWorkspace } from "@app/lib/development";
+import { sortedEventProperties } from "@app/lib/extract_events_properties";
 import { EventSchema, ExtractedEvent } from "@app/lib/models";
 import { generateModelSId } from "@app/lib/utils";
 import { EventSchemaType, ExtractedEventType } from "@app/types/extract";
@@ -26,7 +27,7 @@ function _getExtractedEventType(
     id: event.id,
     sId: event.sId,
     marker: event.marker,
-    properties: event.properties,
+    properties: sortedEventProperties(schema.properties, event.properties),
     status: event.status,
     dataSourceName: event.dataSourceName,
     documentId: event.documentId,

--- a/front/lib/extract_events_properties.ts
+++ b/front/lib/extract_events_properties.ts
@@ -2,6 +2,7 @@ import {
   EventSchemaPropertiesTypeForModel,
   eventSchemaPropertyAllTypes,
   EventSchemaPropertyType,
+  ExtractedEventPropertyType,
 } from "@app/types/extract";
 
 /**
@@ -64,4 +65,21 @@ export function formatPropertiesForModel(
         };
   });
   return result;
+}
+
+export function sortedEventProperties(
+  shemaProperties: EventSchemaPropertyType[],
+  eventProperties: ExtractedEventPropertyType
+): ExtractedEventPropertyType {
+  const orderedEventProps: ExtractedEventPropertyType = {
+    marker: eventProperties.marker,
+  };
+
+  shemaProperties.forEach(({ name }) => {
+    if (Object.prototype.hasOwnProperty.call(eventProperties, name)) {
+      orderedEventProps[name] = eventProperties[name];
+    }
+  });
+
+  return orderedEventProps;
 }

--- a/front/lib/extract_events_properties.ts
+++ b/front/lib/extract_events_properties.ts
@@ -67,6 +67,10 @@ export function formatPropertiesForModel(
   return result;
 }
 
+/**
+ * Util to event properties according to schema
+ * (Envent properties are stored in a jsonb column in db, which is unordered)
+ */
 export function sortedEventProperties(
   shemaProperties: EventSchemaPropertyType[],
   eventProperties: ExtractedEventPropertyType

--- a/front/pages/w/[wId]/u/extract/events/[sId]/edit.tsx
+++ b/front/pages/w/[wId]/u/extract/events/[sId]/edit.tsx
@@ -121,7 +121,6 @@ const BasicEventPropsEditor = ({
   owner: WorkspaceType;
   readOnly: boolean;
 }) => {
-  // Order object keys according to schema (jsonb column in db is unordered)
   const [jsonText, setJsonText] = useState(
     JSON.stringify(event.properties, null, 4)
   );

--- a/front/pages/w/[wId]/u/extract/events/[sId]/edit.tsx
+++ b/front/pages/w/[wId]/u/extract/events/[sId]/edit.tsx
@@ -13,7 +13,6 @@ import { subNavigationLab } from "@app/components/sparkle/navigation";
 import { getEventSchema, getExtractedEvent } from "@app/lib/api/extract";
 import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
 import { APIError } from "@app/lib/error";
-import { sortedEventProperties } from "@app/lib/extract_events_properties";
 import { classNames } from "@app/lib/utils";
 import { EventSchemaType, ExtractedEventType } from "@app/types/extract";
 import { UserType, WorkspaceType } from "@app/types/user";
@@ -104,7 +103,6 @@ export default function AppExtractEventsCreate({
         <div className="mt-6">
           <BasicEventPropsEditor
             event={event}
-            schema={schema}
             owner={owner}
             readOnly={readOnly}
           />
@@ -116,22 +114,16 @@ export default function AppExtractEventsCreate({
 
 const BasicEventPropsEditor = ({
   event,
-  schema,
   owner,
   readOnly,
 }: {
   event: ExtractedEventType;
-  schema: EventSchemaType;
   owner: WorkspaceType;
   readOnly: boolean;
 }) => {
   // Order object keys according to schema (jsonb column in db is unordered)
   const [jsonText, setJsonText] = useState(
-    JSON.stringify(
-      sortedEventProperties(schema.properties, event.properties),
-      null,
-      4
-    )
+    JSON.stringify(event.properties, null, 4)
   );
   const router = useRouter();
   const [isValid, setIsValid] = useState(true);

--- a/front/pages/w/[wId]/u/extract/events/[sId]/edit.tsx
+++ b/front/pages/w/[wId]/u/extract/events/[sId]/edit.tsx
@@ -13,6 +13,7 @@ import { subNavigationLab } from "@app/components/sparkle/navigation";
 import { getEventSchema, getExtractedEvent } from "@app/lib/api/extract";
 import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
 import { APIError } from "@app/lib/error";
+import { sortedEventProperties } from "@app/lib/extract_events_properties";
 import { classNames } from "@app/lib/utils";
 import { EventSchemaType, ExtractedEventType } from "@app/types/extract";
 import { UserType, WorkspaceType } from "@app/types/user";
@@ -125,18 +126,12 @@ const BasicEventPropsEditor = ({
   readOnly: boolean;
 }) => {
   // Order object keys according to schema (jsonb column in db is unordered)
-  const eventProps = event.properties;
-  const orderedEventProps: {
-    [key: string]: string | string[];
-  } = { marker: eventProps.marker };
-  schema.properties.forEach(({ name }) => {
-    if (Object.prototype.hasOwnProperty.call(eventProps, name)) {
-      orderedEventProps[name] = eventProps[name];
-    }
-  });
-
   const [jsonText, setJsonText] = useState(
-    JSON.stringify(orderedEventProps, null, 4)
+    JSON.stringify(
+      sortedEventProperties(schema.properties, event.properties),
+      null,
+      4
+    )
   );
   const router = useRouter();
   const [isValid, setIsValid] = useState(true);

--- a/front/pages/w/[wId]/u/extract/templates/[sId]/index.tsx
+++ b/front/pages/w/[wId]/u/extract/templates/[sId]/index.tsx
@@ -23,7 +23,6 @@ import { subNavigationLab } from "@app/components/sparkle/navigation";
 import { getEventSchema } from "@app/lib/api/extract";
 import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
 import { APIError } from "@app/lib/error";
-import { sortedEventProperties } from "@app/lib/extract_events_properties";
 import { useExtractedEvents } from "@app/lib/swr";
 import { classNames, objectToMarkdown } from "@app/lib/utils";
 import { DATA_SOURCE_INTEGRATIONS } from "@app/pages/w/[wId]/ds";
@@ -167,7 +166,7 @@ export default function AppExtractEventsReadData({
                         href={`/w/${owner.sId}/u/extract/events/${event.sId}/edit`}
                         className="block"
                       >
-                        <EventProperties event={event} schema={schema} />
+                        <EventProperties event={event} />
                       </Link>
                     </td>
                     <td className="w-auto border-y px-4 py-4 text-right align-top">
@@ -180,7 +179,7 @@ export default function AppExtractEventsReadData({
                     </td>
                     <td className="w-auto border-y px-4 py-4 align-top">
                       <div className="flex flex-row space-x-2">
-                        <ExtractButtonAndModal event={event} schema={schema} />
+                        <ExtractButtonAndModal event={event} />
 
                         <IconButton
                           icon={CheckCircleIcon}
@@ -249,18 +248,7 @@ export default function AppExtractEventsReadData({
 // ]
 // In event properties are stored as an object with undefined order as it is a JSONB column
 // Example: {"name": "My idea", "author": "Michael Scott"}
-const EventProperties = ({
-  event,
-  schema,
-}: {
-  event: ExtractedEventType;
-  schema: EventSchemaType;
-}) => {
-  const sortedProps = sortedEventProperties(
-    schema.properties,
-    event.properties
-  );
-
+const EventProperties = ({ event }: { event: ExtractedEventType }) => {
   const renderPropertyValue = (value: string | string[]) => {
     if (typeof value === "string") {
       return <p>{value}</p>;
@@ -283,10 +271,10 @@ const EventProperties = ({
 
   return (
     <div className="space-y-4">
-      {Object.keys(sortedProps).map((key) => (
+      {Object.keys(event.properties).map((key) => (
         <div key={key} className="flex flex-col">
           <span className="font-bold">{key}</span>
-          {renderPropertyValue(sortedProps[key])}
+          {renderPropertyValue(event.properties[key])}
         </div>
       ))}
     </div>
@@ -328,29 +316,18 @@ const EventDataSourceLogo = ({ event }: { event: ExtractedEventType }) => {
   );
 };
 
-const ExtractButtonAndModal = ({
-  event,
-  schema,
-}: {
-  event: ExtractedEventType;
-  schema: EventSchemaType;
-}) => {
+const ExtractButtonAndModal = ({ event }: { event: ExtractedEventType }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [copySuccess, setCopySuccess] = useState<string | null>(null);
 
   const handleClick = async (format: "JSON" | "Markdown"): Promise<void> => {
     let content: string | null = null;
 
-    const sortedProps = sortedEventProperties(
-      schema.properties,
-      event.properties
-    );
-
     if (format === "JSON") {
-      content = JSON.stringify(sortedProps);
+      content = JSON.stringify(event.properties);
     }
     if (format === "Markdown") {
-      content = objectToMarkdown(sortedProps);
+      content = objectToMarkdown(event.properties);
     }
 
     if (!content) {

--- a/front/types/extract.ts
+++ b/front/types/extract.ts
@@ -39,9 +39,7 @@ export type ExtractedEventType = {
   id: ModelId;
   sId: string;
   marker: string;
-  properties: {
-    [key: string]: string | string[];
-  };
+  properties: ExtractedEventPropertyType;
   status: ExtractedEventStatus;
   dataSourceName: string;
   documentId: string;
@@ -50,4 +48,8 @@ export type ExtractedEventType = {
     marker: string;
     sId: string;
   };
+};
+
+export type ExtractedEventPropertyType = {
+  [key: string]: string | string[];
 };


### PR DESCRIPTION
On my last PR: https://github.com/dust-tt/dust/pull/1251 I sorted the event properties following what was defined in the event schema. I missed the sort when we were copy pasting data as json.

I wonder if this sorting logic shouldn't be moved directly when we create the type 🤔 
=> Edit: I added a commit to move the sorting logic when we build the type, this should ensure we have the valid order everywhere, and it makes the code easier to read.