### PR TITLE
Tiktoken fix tokenize

### DIFF
--- a/core/src/providers/tiktoken/tiktoken.rs
+++ b/core/src/providers/tiktoken/tiktoken.rs
@@ -266,6 +266,8 @@ impl CoreBPE {
         results
     }
 
+    // Copy of _encode_native but returns both the tokens and the associated string in a tuple
+    // As needed in tokenize function
     fn _tokenize_with_spe_regex(
         &self,
         text: &str,


### PR DESCRIPTION

There was an error when trying to tokenize this content: https://dust.tt/w/0ec9852c2f/ds/managed-github/upsert?documentId=github-issue-526514610-1249

Error: 
```
thread 'tokio-runtime-worker' panicked at 'called `Result::unwrap()` on an `Err` value: Utf8Error { valid_up_to: 0, error_len: None }', src/providers/tiktoken/tiktoken.rs:341:26
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
[!] internal_server_error: Failed to tokenize text
Error: Some(task 42 panicked)
```

The error was coming from the `std::str::from_utf8` that I replaced by `String::from_utf8_lossy`
-> meaning that non utf8 characters will be replaced by �, which I think is okay?

I also introduced `_tokenize_with_spe_regex` which matches the logic from `_encode_native` instead of `_encode_ordinary_native`, as discussed yesterday. 
