### PR TITLE
fix(#1203): properly truncate conversation title on large screens

### DIFF
--- a/front/components/sparkle/AppLayoutChatTitle.tsx
+++ b/front/components/sparkle/AppLayoutChatTitle.tsx
@@ -9,7 +9,6 @@ import {
 import { Dialog, Transition } from "@headlessui/react";
 import React, { Fragment, useState } from "react";
 
-import { classNames } from "@app/lib/utils";
 import { ChatSessionVisibility } from "@app/types/chat";
 
 export function AppLayoutChatTitle({
@@ -39,18 +38,12 @@ export function AppLayoutChatTitle({
   const [isOpen, setIsOpen] = useState(false);
 
   return (
-    <div className="flex h-full flex-row items-center">
-      <div className="flex flex-initial font-bold">
-        <div
-          className={classNames(
-            "w-48 overflow-hidden truncate sm:w-96 lg:w-auto lg:px-0"
-          )}
-        >
-          <span>{title}</span>
-        </div>
+    <div className="grid h-full max-w-full grid-cols-[1fr,auto] items-center gap-4">
+      <div className="overflow-hidden truncate">
+        <span className="font-bold">{title}</span>
       </div>
-      <div className="flex flex-1"></div>
-      <div className="-ml-8 hidden flex-initial space-x-1 lg:ml-0 lg:flex">
+
+      <div className="hidden space-x-1 lg:flex">
         {!readOnly && onDelete && (
           <div className="flex flex-initial">
             <Button


### PR DESCRIPTION
Before:

<img width="1645" alt="Screenshot 2023-09-05 at 15 04 01" src="https://github.com/dust-tt/dust/assets/14199823/a896d817-d054-4320-833b-6f9e434a3b55">

After:

<img width="1650" alt="Screenshot 2023-09-05 at 15 04 10" src="https://github.com/dust-tt/dust/assets/14199823/a2cfdeb6-63e5-475f-bece-adeaadec5104">

fixes https://github.com/dust-tt/tasks/issues/16
