### PR TITLE
feat(#1221): Sticky user preferences for DS selection in Chat v0

### DIFF
--- a/front/lib/user.ts
+++ b/front/lib/user.ts
@@ -37,7 +37,10 @@ export function setUserMetadataFromClient(metadata: UserMetadataType) {
         `/api/user/metadata/${encodeURIComponent(metadata.key)}`,
         {
           method: "POST",
-          body: JSON.stringify(metadata),
+          body: JSON.stringify({ value: metadata.value }),
+          headers: {
+            "Content-Type": "application/json",
+          },
         }
       );
 
@@ -51,5 +54,5 @@ export function setUserMetadataFromClient(metadata: UserMetadataType) {
     } catch (err) {
       console.error("setUserMetadata error", err);
     }
-  });
+  })();
 }


### PR DESCRIPTION
Implements https://github.com/dust-tt/tasks/issues/11

- takes precedence over workspace-wide settings
- only impacts data sources that are manually switched on / off
- not ideal that we need 2 API calls, but better than having to maintain a local copy of the user metadata IMO