### PR TITLE
enh(infra): lower CPU/RAM requests/limits for most k8s deployments

### DIFF
--- a/k8s/configmaps/connectors-worker-configmap.yaml
+++ b/k8s/configmaps/connectors-worker-configmap.yaml
@@ -5,7 +5,7 @@ metadata:
 data:
   DD_ENV: "prod"
   DD_SERVICE: "connectors-worker"
-  NODE_OPTIONS: "-r dd-trace/init --max-old-space-size=6000"
+  NODE_OPTIONS: "-r dd-trace/init --max-old-space-size=4200"
   DD_LOGS_INJECTION: "true"
   DD_RUNTIME_METRICS_ENABLED: "true"
   NODE_ENV: "production"

--- a/k8s/configmaps/front-worker-configmap.yaml
+++ b/k8s/configmaps/front-worker-configmap.yaml
@@ -5,7 +5,7 @@ metadata:
 data:
   DD_ENV: "prod"
   DD_SERVICE: "front-worker"
-  NODE_OPTIONS: "-r dd-trace/init --max-old-space-size=6000"
+  NODE_OPTIONS: "-r dd-trace/init --max-old-space-size=1750"
   DD_LOGS_INJECTION: "true"
   DD_RUNTIME_METRICS_ENABLED: "true"
   NODE_ENV: "production"

--- a/k8s/deployments/blog-deployment.yaml
+++ b/k8s/deployments/blog-deployment.yaml
@@ -34,8 +34,8 @@ spec:
 
           resources:
             requests:
-              cpu: 2000m
-              memory: 8Gi
+              cpu: 500m
+              memory: 1Gi
             limits:
-              cpu: 2000m
-              memory: 8Gi
+              cpu: 500m
+              memory: 1Gi

--- a/k8s/deployments/connectors-deployment.yaml
+++ b/k8s/deployments/connectors-deployment.yaml
@@ -43,11 +43,11 @@ spec:
 
           resources:
             requests:
-              cpu: 2000m
-              memory: 8Gi
+              cpu: 1000m
+              memory: 2.5Gi
             limits:
-              cpu: 2000m
-              memory: 8Gi
+              cpu: 1000m
+              memory: 2.5Gi
 
       volumes:
         - name: cert-volume

--- a/k8s/deployments/connectors-worker-deployment.yaml
+++ b/k8s/deployments/connectors-worker-deployment.yaml
@@ -42,11 +42,11 @@ spec:
           resources:
             requests:
               cpu: 2000m
-              memory: 8Gi
+              memory: 6Gi
 
             limits:
               cpu: 2000m
-              memory: 8Gi
+              memory: 6Gi
 
       volumes:
         - name: cert-volume

--- a/k8s/deployments/docs-deployment.yaml
+++ b/k8s/deployments/docs-deployment.yaml
@@ -35,8 +35,8 @@ spec:
 
           resources:
             requests:
-              cpu: 2000m
-              memory: 8Gi
+              cpu: 500m
+              memory: 1Gi
             limits:
-              cpu: 2000m
-              memory: 8Gi
+              cpu: 500m
+              memory: 1Gi

--- a/k8s/deployments/front-deployment.yaml
+++ b/k8s/deployments/front-deployment.yaml
@@ -42,12 +42,12 @@ spec:
 
           resources:
             requests:
-              cpu: 2000m
-              memory: 8Gi
+              cpu: 1000m
+              memory: 2.5Gi
 
             limits:
-              cpu: 2000m
-              memory: 8Gi
+              cpu: 1000m
+              memory: 2.5Gi
 
       volumes:
         - name: cert-volume

--- a/k8s/deployments/front-worker-deployment.yaml
+++ b/k8s/deployments/front-worker-deployment.yaml
@@ -41,12 +41,12 @@ spec:
 
           resources:
             requests:
-              cpu: 2000m
-              memory: 8Gi
+              cpu: 1000m
+              memory: 2.5Gi
 
             limits:
-              cpu: 2000m
-              memory: 8Gi
+              cpu: 1000m
+              memory: 2.5Gi
 
       volumes:
         - name: cert-volume


### PR DESCRIPTION
- for most deployments, we're using a very small amount of the RAM/CPU allocation per pod
- this causes us to overpay for infra, but also causes deployments to be slower as GKE often needs to provision (an) additional node(s) when we rollout restart a deployment (and later also has to scale it down)
- because we bundle temporal workflows at launch time, we need to have high CPU on the temporal worker pods, otherwise the startup time is very slow. This is quite sub-optimal, as this CPU is only ever needed on startup, the fix would be to pre-bundle the termporal workflows (in CI ?) but this PR doesn't aim to fix it.

⚠️ The requests/limits in this PR are already applied on the prod k8s cluster