### PR TITLE
feat(assistant v2): creates message objects

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -229,7 +229,6 @@ export async function* postUserMessage(
       type: "user_message",
       visibility: "visible",
       version: 0,
-      parentMessageId: null,
       user: user,
       mentions: mentions,
       message: message,

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -122,7 +122,7 @@ export class AssistantAgentMessage extends Model<
   InferAttributes<AssistantAgentMessage>,
   InferCreationAttributes<AssistantAgentMessage>
 > {
-  declare id: number;
+  declare id: CreationOptional<number>;
 
   declare status: CreationOptional<AssistantAgentMessageStatus>;
 

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -62,7 +62,8 @@ export class AssistantUserMessage extends Model<
   InferAttributes<AssistantUserMessage>,
   InferCreationAttributes<AssistantUserMessage>
 > {
-  declare id: number;
+  declare id: CreationOptional<number>;
+
   declare message: string;
 
   declare userContextUsername: string;
@@ -165,10 +166,10 @@ export class AssistantMessage extends Model<
   InferAttributes<AssistantMessage>,
   InferCreationAttributes<AssistantMessage>
 > {
-  declare id: number;
+  declare id: CreationOptional<number>;
   declare sId: string;
 
-  declare version: number;
+  declare version: CreationOptional<number>;
   declare rank: number;
   declare visibility: CreationOptional<AssistantMessageVisibility>;
 

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -19,11 +19,11 @@ export class AssistantConversation extends Model<
   InferAttributes<AssistantConversation>,
   InferCreationAttributes<AssistantConversation>
 > {
-  declare id: number;
+  declare id: CreationOptional<number>;
   declare sId: string;
   declare title: string | null;
   declare created: Date;
-  declare visibility: AssistantConversationVisibility;
+  declare visibility: CreationOptional<AssistantConversationVisibility>;
 }
 
 AssistantConversation.init(
@@ -218,11 +218,9 @@ AssistantMessage.init(
       },
     ],
     hooks: {
-      // TODO @fontanierh: check if we want to add a Check Constraint (from db.ts ?)
       beforeValidate: (message) => {
         if (
-          (message.assistantUserMessageId === null) ===
-          (message.assistantAgentMessageId === null)
+          !message.assistantUserMessageId === !message.assistantAgentMessageId
         ) {
           throw new Error(
             "Exactly one of assistantUserMessageId, assistantAgentMessageId must be non-null"

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -72,7 +72,7 @@ export class AssistantUserMessage extends Model<
   declare userContextEmail: string | null;
   declare userContextProfilePictureUrl: string | null;
 
-  declare userId: ForeignKey<User["id"]>;
+  declare userId: ForeignKey<User["id"]> | null;
 }
 
 AssistantUserMessage.init(
@@ -114,8 +114,7 @@ AssistantUserMessage.init(
 );
 
 User.hasMany(AssistantUserMessage, {
-  foreignKey: { name: "userId", allowNull: false },
-  onDelete: "CASCADE",
+  foreignKey: { name: "userId" },
 });
 
 export class AssistantAgentMessage extends Model<

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -21,6 +21,22 @@ export type AssistantMention = AssistantAgentMention | AssistantUserMention;
 
 export type AssistantMessageVisibility = "visible" | "deleted";
 
+export function isAssistantAgentMention(
+  arg: AssistantMention
+): arg is AssistantAgentMention {
+  return (arg as AssistantAgentMention).configurationId !== undefined;
+}
+
+export function isAssistantUserMention(
+  arg: AssistantMention
+): arg is AssistantUserMention {
+  const maybeUserMention = arg as AssistantUserMention;
+  return (
+    maybeUserMention.provider !== undefined &&
+    maybeUserMention.providerId !== undefined
+  );
+}
+
 /**
  * User messages
  */

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -55,7 +55,6 @@ export type AssistantUserMessageType = {
   sId: string;
   visibility: AssistantMessageVisibility;
   version: number;
-  parentMessageId: string | null;
   user: UserType | null;
   mentions: AssistantMention[];
   message: string;

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -39,8 +39,7 @@ export type AssistantUserMessageType = {
   sId: string;
   visibility: AssistantMessageVisibility;
   version: number;
-  parentMessageId: string;
-
+  parentMessageId: string | null;
   user: UserType | null;
   mentions: AssistantMention[];
   message: string;

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -133,7 +133,6 @@ export type AssistantConversationType = {
   created: number;
   sId: string;
   title: string | null;
-  participants: UserType[];
   content: (AssistantUserMessageType[] | AssistantAgentMessageType[])[];
   visibility: AssistantConversationVisibility;
 };


### PR DESCRIPTION
adds a bit of implementation to `postUserMessage`:
- creates the user message rows
- creates "empty" agent messages with status "created"
- yields the "new message" events

It doesn't run the agents yet