### PR TITLE
chore: remove `Assistant` prefix from models, types, foreign keys, variables

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -1,13 +1,13 @@
 import {
   App,
   AssistantAgentMessage,
-  AssistantConversation,
   AssistantMessage,
   AssistantUserMessage,
   ChatMessage,
   ChatRetrievedDocument,
   ChatSession,
   Clone,
+  Conversation,
   Dataset,
   DataSource,
   DocumentTrackerChangeSuggestion,
@@ -49,7 +49,7 @@ async function main() {
   await ExtractedEvent.sync({ alter: true });
   await DocumentTrackerChangeSuggestion.sync({ alter: true });
 
-  await AssistantConversation.sync({ alter: true });
+  await Conversation.sync({ alter: true });
   await AssistantUserMessage.sync({ alter: true });
   await AssistantAgentMessage.sync({ alter: true });
   await AssistantMessage.sync({ alter: true });

--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -1,7 +1,6 @@
 import {
   AgentMessage,
   App,
-  AssistantMessage,
   ChatMessage,
   ChatRetrievedDocument,
   ChatSession,
@@ -16,6 +15,7 @@ import {
   Key,
   Membership,
   MembershipInvitation,
+  Message,
   Provider,
   Run,
   TrackedDocument,
@@ -52,7 +52,7 @@ async function main() {
   await Conversation.sync({ alter: true });
   await UserMessage.sync({ alter: true });
   await AgentMessage.sync({ alter: true });
-  await AssistantMessage.sync({ alter: true });
+  await Message.sync({ alter: true });
 
   await XP1User.sync({ alter: true });
   await XP1Run.sync({ alter: true });

--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -2,7 +2,6 @@ import {
   App,
   AssistantAgentMessage,
   AssistantMessage,
-  AssistantUserMessage,
   ChatMessage,
   ChatRetrievedDocument,
   ChatSession,
@@ -21,6 +20,7 @@ import {
   Run,
   TrackedDocument,
   User,
+  UserMessage,
   UserMetadata,
   Workspace,
   XP1Run,
@@ -50,7 +50,7 @@ async function main() {
   await DocumentTrackerChangeSuggestion.sync({ alter: true });
 
   await Conversation.sync({ alter: true });
-  await AssistantUserMessage.sync({ alter: true });
+  await UserMessage.sync({ alter: true });
   await AssistantAgentMessage.sync({ alter: true });
   await AssistantMessage.sync({ alter: true });
 

--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -1,6 +1,6 @@
 import {
+  AgentMessage,
   App,
-  AssistantAgentMessage,
   AssistantMessage,
   ChatMessage,
   ChatRetrievedDocument,
@@ -51,7 +51,7 @@ async function main() {
 
   await Conversation.sync({ alter: true });
   await UserMessage.sync({ alter: true });
-  await AssistantAgentMessage.sync({ alter: true });
+  await AgentMessage.sync({ alter: true });
   await AssistantMessage.sync({ alter: true });
 
   await XP1User.sync({ alter: true });

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -299,7 +299,7 @@ export type RetrievalSuccessEvent = {
   action: RetrievalActionType;
 };
 
-// This method is in charge of running the retrieval and creating an AssistantAgentRetrieval DB
+// This method is in charge of running the retrieval and creating an AgentRetrieval DB
 // object in the database (along with the RetrievedDocument objects). It does not create any generic
 // model related to the conversation.
 export async function* runRetrieval(

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -24,8 +24,8 @@ import {
 } from "@app/types/assistant/agent";
 import {
   AssistantAgentMessageType,
-  AssistantConversationType,
   AssistantUserMessageType,
+  ConversationType,
 } from "@app/types/assistant/conversation";
 
 /**
@@ -174,7 +174,7 @@ export async function retrievalActionSpecification(
 export async function generateRetrievalParams(
   auth: Authenticator,
   configuration: RetrievalConfigurationType,
-  conversation: AssistantConversationType,
+  conversation: ConversationType,
   userMessage: AssistantUserMessageType
 ): Promise<
   Result<
@@ -305,7 +305,7 @@ export type RetrievalSuccessEvent = {
 export async function* runRetrieval(
   auth: Authenticator,
   configuration: AgentConfigurationType,
-  conversation: AssistantConversationType,
+  conversation: ConversationType,
   userMessage: AssistantUserMessageType,
   agentMessage: AssistantAgentMessageType
 ): AsyncGenerator<

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -24,8 +24,8 @@ import {
 } from "@app/types/assistant/agent";
 import {
   AssistantAgentMessageType,
-  AssistantUserMessageType,
   ConversationType,
+  UserMessageType,
 } from "@app/types/assistant/conversation";
 
 /**
@@ -175,7 +175,7 @@ export async function generateRetrievalParams(
   auth: Authenticator,
   configuration: RetrievalConfigurationType,
   conversation: ConversationType,
-  userMessage: AssistantUserMessageType
+  userMessage: UserMessageType
 ): Promise<
   Result<
     { query: string | null; relativeTimeFrame: TimeFrame | null; topK: number },
@@ -306,7 +306,7 @@ export async function* runRetrieval(
   auth: Authenticator,
   configuration: AgentConfigurationType,
   conversation: ConversationType,
-  userMessage: AssistantUserMessageType,
+  userMessage: UserMessageType,
   agentMessage: AssistantAgentMessageType
 ): AsyncGenerator<
   | RetrievalParamsEvent

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -23,7 +23,7 @@ import {
   AgentConfigurationType,
 } from "@app/types/assistant/agent";
 import {
-  AssistantAgentMessageType,
+  AgentMessageType,
   ConversationType,
   UserMessageType,
 } from "@app/types/assistant/conversation";
@@ -307,7 +307,7 @@ export async function* runRetrieval(
   configuration: AgentConfigurationType,
   conversation: ConversationType,
   userMessage: UserMessageType,
-  agentMessage: AssistantAgentMessageType
+  agentMessage: AgentMessageType
 ): AsyncGenerator<
   | RetrievalParamsEvent
   | RetrievalDocumentsEvent

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -14,8 +14,8 @@ import {
   AgentMessageConfigurationType,
 } from "@app/types/assistant/agent";
 import {
+  AgentActionType,
   AgentMessageType,
-  AssistantAgentActionType,
   ConversationType,
 } from "@app/types/assistant/conversation";
 
@@ -184,7 +184,7 @@ export type AgentActionSuccessEvent = {
   created: number;
   configurationId: string;
   messageId: string;
-  action: AssistantAgentActionType;
+  action: AgentActionType;
 };
 
 // Event sent when tokens are streamed as the the agent is generating a message.

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -16,7 +16,7 @@ import {
 import {
   AssistantAgentActionType,
   AssistantAgentMessageType,
-  AssistantConversationType,
+  ConversationType,
 } from "@app/types/assistant/conversation";
 
 import {
@@ -88,7 +88,7 @@ export async function updateAgentConfiguration(
 export async function generateActionInputs(
   auth: Authenticator,
   specification: AgentActionSpecification,
-  conversation: AssistantConversationType
+  conversation: ConversationType
 ): Promise<Result<Record<string, string | boolean | number>, Error>> {
   const model = {
     providerId: "openai",
@@ -211,7 +211,7 @@ export type AgentMessageSuccessEvent = {
 export async function* runAgent(
   auth: Authenticator,
   configuration: AgentConfigurationType,
-  conversation: AssistantConversationType
+  conversation: ConversationType
 ): AsyncGenerator<
   | AgentMessageNewEvent
   | AgentErrorEvent

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -14,8 +14,8 @@ import {
   AgentMessageConfigurationType,
 } from "@app/types/assistant/agent";
 import {
+  AgentMessageType,
   AssistantAgentActionType,
-  AssistantAgentMessageType,
   ConversationType,
 } from "@app/types/assistant/conversation";
 
@@ -160,7 +160,7 @@ export type AgentMessageNewEvent = {
   type: "agent_message_new";
   created: number;
   configurationId: string;
-  message: AssistantAgentMessageType;
+  message: AgentMessageType;
 };
 
 // Generic event sent when an error occured (whether it's during the action or the message generation).
@@ -202,10 +202,10 @@ export type AgentMessageSuccessEvent = {
   created: number;
   configurationId: string;
   messageId: string;
-  message: AssistantAgentMessageType;
+  message: AgentMessageType;
 };
 
-// This interface is used to execute an agent. It is in charge of creating the AssistantAgentMessage
+// This interface is used to execute an agent. It is in charge of creating the AgentMessage
 // object in database (fully completed or with error set if an error occured). It is called to run
 // an agent or when retrying a previous agent interaction.
 export async function* runAgent(

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -12,7 +12,7 @@ import { front_sequelize } from "@app/lib/databases";
 import {
   AssistantAgentMessage,
   AssistantMessage,
-  AssistantUserMessage,
+  UserMessage,
 } from "@app/lib/models";
 import { Err, Ok, Result } from "@app/lib/result";
 import { generateModelSId } from "@app/lib/utils";
@@ -21,12 +21,12 @@ import { isRetrievalActionType } from "@app/types/assistant/actions/retrieval";
 import {
   AssistantAgentMessageType,
   AssistantMention,
-  AssistantUserMessageContext,
-  AssistantUserMessageType,
   ConversationType,
   isAgentMessageType,
   isAssistantAgentMention,
   isUserMessageType,
+  UserMessageContext,
+  UserMessageType,
 } from "@app/types/assistant/conversation";
 
 import { renderRetrievalActionForModel } from "./actions/retrieval";
@@ -156,7 +156,7 @@ export async function renderConversationForModel({
 // Event sent when the user message is created.
 export type UserMessageNewEvent = {
   type: "user_message_new";
-  message: AssistantUserMessageType;
+  message: UserMessageType;
 };
 
 // This method is in charge of creating a new user message in database, running the necessary agents
@@ -172,7 +172,7 @@ export async function* postUserMessage(
     conversation: ConversationType;
     message: string;
     mentions: AssistantMention[];
-    context: AssistantUserMessageContext;
+    context: UserMessageContext;
   }
 ): AsyncGenerator<
   | UserMessageNewEvent
@@ -185,7 +185,7 @@ export async function* postUserMessage(
 > {
   const user = auth.user();
 
-  let userMessage: AssistantUserMessageType | null = null;
+  let userMessage: UserMessageType | null = null;
   const agentMessages: AssistantAgentMessageType[] = [];
 
   await front_sequelize.transaction(async (t) => {
@@ -204,7 +204,7 @@ export async function* postUserMessage(
         assistantConversationId: conversation.id,
         parentId: null,
         assistantUserMessageId: (
-          await AssistantUserMessage.create(
+          await UserMessage.create(
             {
               message: message,
               userContextUsername: context.username,
@@ -349,7 +349,7 @@ export async function* editUserMessage(
     content,
   }: {
     conversation: ConversationType;
-    message: AssistantUserMessageType;
+    message: UserMessageType;
     content: string;
   }
 ): AsyncGenerator<

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -203,7 +203,7 @@ export async function* postUserMessage(
         rank: nextMessageRank++,
         conversationId: conversation.id,
         parentId: null,
-        assistantUserMessageId: (
+        userMessageId: (
           await UserMessage.create(
             {
               message: message,

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -9,17 +9,13 @@ import {
 import { Authenticator } from "@app/lib/auth";
 import { CoreAPI } from "@app/lib/core_api";
 import { front_sequelize } from "@app/lib/databases";
-import {
-  AssistantAgentMessage,
-  AssistantMessage,
-  UserMessage,
-} from "@app/lib/models";
+import { AgentMessage, AssistantMessage, UserMessage } from "@app/lib/models";
 import { Err, Ok, Result } from "@app/lib/result";
 import { generateModelSId } from "@app/lib/utils";
 import logger from "@app/logger/logger";
 import { isRetrievalActionType } from "@app/types/assistant/actions/retrieval";
 import {
-  AssistantAgentMessageType,
+  AgentMessageType,
   AssistantMention,
   ConversationType,
   isAgentMessageType,
@@ -186,7 +182,7 @@ export async function* postUserMessage(
   const user = auth.user();
 
   let userMessage: UserMessageType | null = null;
-  const agentMessages: AssistantAgentMessageType[] = [];
+  const agentMessages: AgentMessageType[] = [];
 
   await front_sequelize.transaction(async (t) => {
     let nextMessageRank =
@@ -244,8 +240,8 @@ export async function* postUserMessage(
             rank: nextMessageRank++,
             conversationId: conversation.id,
             parentId: userMessage.id,
-            assistantAgentMessageId: (
-              await AssistantAgentMessage.create({}, { transaction: t })
+            agentMessageId: (
+              await AgentMessage.create({}, { transaction: t })
             ).id,
           },
           {
@@ -309,7 +305,7 @@ export async function* postUserMessage(
 }
 
 // This method is in charge of re-running an agent interaction (generating a new
-// AssistantAgentMessage as a result)
+// AgentMessage as a result)
 export async function* retryAgentMessage(
   auth: Authenticator,
   {
@@ -317,7 +313,7 @@ export async function* retryAgentMessage(
     message,
   }: {
     conversation: ConversationType;
-    message: AssistantAgentMessageType;
+    message: AgentMessageType;
   }
 ): AsyncGenerator<
   | AgentMessageNewEvent

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -20,10 +20,10 @@ import logger from "@app/logger/logger";
 import { isRetrievalActionType } from "@app/types/assistant/actions/retrieval";
 import {
   AssistantAgentMessageType,
-  AssistantConversationType,
   AssistantMention,
   AssistantUserMessageContext,
   AssistantUserMessageType,
+  ConversationType,
   isAgentMessageType,
   isAssistantAgentMention,
   isUserMessageType,
@@ -52,7 +52,7 @@ export async function renderConversationForModel({
   model,
   allowedTokenCount,
 }: {
-  conversation: AssistantConversationType;
+  conversation: ConversationType;
   model: { providerId: string; modelId: string };
   allowedTokenCount: number;
 }): Promise<Result<ModelConversationType, Error>> {
@@ -169,7 +169,7 @@ export async function* postUserMessage(
     mentions,
     context,
   }: {
-    conversation: AssistantConversationType;
+    conversation: ConversationType;
     message: string;
     mentions: AssistantMention[];
     context: AssistantUserMessageContext;
@@ -316,7 +316,7 @@ export async function* retryAgentMessage(
     conversation,
     message,
   }: {
-    conversation: AssistantConversationType;
+    conversation: ConversationType;
     message: AssistantAgentMessageType;
   }
 ): AsyncGenerator<
@@ -348,7 +348,7 @@ export async function* editUserMessage(
     message,
     content,
   }: {
-    conversation: AssistantConversationType;
+    conversation: ConversationType;
     message: AssistantUserMessageType;
     content: string;
   }

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -192,7 +192,7 @@ export async function* postUserMessage(
     let nextMessageRank =
       ((await AssistantMessage.max<number | null, AssistantMessage>("rank", {
         where: {
-          assistantConversationId: conversation.id,
+          conversationId: conversation.id,
         },
         transaction: t,
       })) ?? -1) + 1;
@@ -201,7 +201,7 @@ export async function* postUserMessage(
       {
         sId: generateModelSId(),
         rank: nextMessageRank++,
-        assistantConversationId: conversation.id,
+        conversationId: conversation.id,
         parentId: null,
         assistantUserMessageId: (
           await UserMessage.create(
@@ -242,7 +242,7 @@ export async function* postUserMessage(
           {
             sId: generateModelSId(),
             rank: nextMessageRank++,
-            assistantConversationId: conversation.id,
+            conversationId: conversation.id,
             parentId: userMessage.id,
             assistantAgentMessageId: (
               await AssistantAgentMessage.create({}, { transaction: t })

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -10,7 +10,7 @@ import {
 import { front_sequelize } from "@app/lib/databases";
 import { User } from "@app/lib/models/user";
 import {
-  AssistantAgentMessageStatus,
+  AgentMessageStatus,
   AssistantMessageVisibility,
   ConversationVisibility,
 } from "@app/types/assistant/conversation";
@@ -117,20 +117,20 @@ User.hasMany(UserMessage, {
   foreignKey: { name: "userId" },
 });
 
-export class AssistantAgentMessage extends Model<
-  InferAttributes<AssistantAgentMessage>,
-  InferCreationAttributes<AssistantAgentMessage>
+export class AgentMessage extends Model<
+  InferAttributes<AgentMessage>,
+  InferCreationAttributes<AgentMessage>
 > {
   declare id: CreationOptional<number>;
 
-  declare status: CreationOptional<AssistantAgentMessageStatus>;
+  declare status: CreationOptional<AgentMessageStatus>;
 
   declare message: string | null;
   declare errorCode: string | null;
   declare errorMessage: string | null;
 }
 
-AssistantAgentMessage.init(
+AgentMessage.init(
   {
     id: {
       type: DataTypes.INTEGER,
@@ -176,9 +176,7 @@ export class AssistantMessage extends Model<
 
   declare parentId: ForeignKey<AssistantMessage["id"]> | null;
   declare userMessageId: ForeignKey<UserMessage["id"]> | null;
-  declare assistantAgentMessageId: ForeignKey<
-    AssistantAgentMessage["id"]
-  > | null;
+  declare agentMessageId: ForeignKey<AgentMessage["id"]> | null;
 }
 
 AssistantMessage.init(
@@ -219,9 +217,9 @@ AssistantMessage.init(
     ],
     hooks: {
       beforeValidate: (message) => {
-        if (!message.userMessageId === !message.assistantAgentMessageId) {
+        if (!message.userMessageId === !message.agentMessageId) {
           throw new Error(
-            "Exactly one of userMessageId, assistantAgentMessageId must be non-null"
+            "Exactly one of userMessageId, agentMessageId must be non-null"
           );
         }
       },
@@ -235,8 +233,8 @@ Conversation.hasMany(AssistantMessage, {
 UserMessage.hasOne(AssistantMessage, {
   foreignKey: "userMessageId",
 });
-AssistantAgentMessage.hasOne(AssistantMessage, {
-  foreignKey: "assistantAgentMessageId",
+AgentMessage.hasOne(AssistantMessage, {
+  foreignKey: "agentMessageId",
 });
 AssistantMessage.belongsTo(AssistantMessage, {
   foreignKey: "parentId",

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -11,22 +11,22 @@ import { front_sequelize } from "@app/lib/databases";
 import { User } from "@app/lib/models/user";
 import {
   AssistantAgentMessageStatus,
-  AssistantConversationVisibility,
   AssistantMessageVisibility,
+  ConversationVisibility,
 } from "@app/types/assistant/conversation";
 
-export class AssistantConversation extends Model<
-  InferAttributes<AssistantConversation>,
-  InferCreationAttributes<AssistantConversation>
+export class Conversation extends Model<
+  InferAttributes<Conversation>,
+  InferCreationAttributes<Conversation>
 > {
   declare id: CreationOptional<number>;
   declare sId: string;
   declare title: string | null;
   declare created: Date;
-  declare visibility: CreationOptional<AssistantConversationVisibility>;
+  declare visibility: CreationOptional<ConversationVisibility>;
 }
 
-AssistantConversation.init(
+Conversation.init(
   {
     id: {
       type: DataTypes.INTEGER,
@@ -172,7 +172,7 @@ export class AssistantMessage extends Model<
   declare rank: number;
   declare visibility: CreationOptional<AssistantMessageVisibility>;
 
-  declare assistantConversationId: ForeignKey<AssistantConversation["id"]>;
+  declare assistantConversationId: ForeignKey<Conversation["id"]>;
 
   declare parentId: ForeignKey<AssistantMessage["id"]> | null;
   declare assistantUserMessageId: ForeignKey<AssistantUserMessage["id"]> | null;
@@ -230,7 +230,7 @@ AssistantMessage.init(
     },
   }
 );
-AssistantConversation.hasMany(AssistantMessage, {
+Conversation.hasMany(AssistantMessage, {
   foreignKey: { name: "assistantConversationId", allowNull: false },
   onDelete: "CASCADE",
 });

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -175,7 +175,7 @@ export class AssistantMessage extends Model<
   declare conversationId: ForeignKey<Conversation["id"]>;
 
   declare parentId: ForeignKey<AssistantMessage["id"]> | null;
-  declare assistantUserMessageId: ForeignKey<UserMessage["id"]> | null;
+  declare userMessageId: ForeignKey<UserMessage["id"]> | null;
   declare assistantAgentMessageId: ForeignKey<
     AssistantAgentMessage["id"]
   > | null;
@@ -219,11 +219,9 @@ AssistantMessage.init(
     ],
     hooks: {
       beforeValidate: (message) => {
-        if (
-          !message.assistantUserMessageId === !message.assistantAgentMessageId
-        ) {
+        if (!message.userMessageId === !message.assistantAgentMessageId) {
           throw new Error(
-            "Exactly one of assistantUserMessageId, assistantAgentMessageId must be non-null"
+            "Exactly one of userMessageId, assistantAgentMessageId must be non-null"
           );
         }
       },
@@ -235,7 +233,7 @@ Conversation.hasMany(AssistantMessage, {
   onDelete: "CASCADE",
 });
 UserMessage.hasOne(AssistantMessage, {
-  foreignKey: "assistantUserMessageId",
+  foreignKey: "userMessageId",
 });
 AssistantAgentMessage.hasOne(AssistantMessage, {
   foreignKey: "assistantAgentMessageId",

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -172,7 +172,7 @@ export class AssistantMessage extends Model<
   declare rank: number;
   declare visibility: CreationOptional<AssistantMessageVisibility>;
 
-  declare assistantConversationId: ForeignKey<Conversation["id"]>;
+  declare conversationId: ForeignKey<Conversation["id"]>;
 
   declare parentId: ForeignKey<AssistantMessage["id"]> | null;
   declare assistantUserMessageId: ForeignKey<UserMessage["id"]> | null;
@@ -214,7 +214,7 @@ AssistantMessage.init(
     indexes: [
       {
         unique: true,
-        fields: ["version", "assistantConversationId", "rank"],
+        fields: ["version", "conversationId", "rank"],
       },
     ],
     hooks: {
@@ -231,7 +231,7 @@ AssistantMessage.init(
   }
 );
 Conversation.hasMany(AssistantMessage, {
-  foreignKey: { name: "assistantConversationId", allowNull: false },
+  foreignKey: { name: "conversationId", allowNull: false },
   onDelete: "CASCADE",
 });
 UserMessage.hasOne(AssistantMessage, {

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -58,9 +58,9 @@ Conversation.init(
   }
 );
 
-export class AssistantUserMessage extends Model<
-  InferAttributes<AssistantUserMessage>,
-  InferCreationAttributes<AssistantUserMessage>
+export class UserMessage extends Model<
+  InferAttributes<UserMessage>,
+  InferCreationAttributes<UserMessage>
 > {
   declare id: CreationOptional<number>;
 
@@ -75,7 +75,7 @@ export class AssistantUserMessage extends Model<
   declare userId: ForeignKey<User["id"]> | null;
 }
 
-AssistantUserMessage.init(
+UserMessage.init(
   {
     id: {
       type: DataTypes.INTEGER,
@@ -113,7 +113,7 @@ AssistantUserMessage.init(
   }
 );
 
-User.hasMany(AssistantUserMessage, {
+User.hasMany(UserMessage, {
   foreignKey: { name: "userId" },
 });
 
@@ -175,7 +175,7 @@ export class AssistantMessage extends Model<
   declare assistantConversationId: ForeignKey<Conversation["id"]>;
 
   declare parentId: ForeignKey<AssistantMessage["id"]> | null;
-  declare assistantUserMessageId: ForeignKey<AssistantUserMessage["id"]> | null;
+  declare assistantUserMessageId: ForeignKey<UserMessage["id"]> | null;
   declare assistantAgentMessageId: ForeignKey<
     AssistantAgentMessage["id"]
   > | null;
@@ -234,7 +234,7 @@ Conversation.hasMany(AssistantMessage, {
   foreignKey: { name: "assistantConversationId", allowNull: false },
   onDelete: "CASCADE",
 });
-AssistantUserMessage.hasOne(AssistantMessage, {
+UserMessage.hasOne(AssistantMessage, {
   foreignKey: "assistantUserMessageId",
 });
 AssistantAgentMessage.hasOne(AssistantMessage, {

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -53,7 +53,7 @@ Conversation.init(
     },
   },
   {
-    modelName: "assistant_conversation",
+    modelName: "conversation",
     sequelize: front_sequelize,
   }
 );
@@ -108,7 +108,7 @@ UserMessage.init(
     },
   },
   {
-    modelName: "assistant_user_message",
+    modelName: "user_message",
     sequelize: front_sequelize,
   }
 );
@@ -156,7 +156,7 @@ AgentMessage.init(
     },
   },
   {
-    modelName: "assistant_agent_message",
+    modelName: "agent_message",
     sequelize: front_sequelize,
   }
 );
@@ -207,7 +207,7 @@ Message.init(
     },
   },
   {
-    modelName: "assistant_message",
+    modelName: "message",
     sequelize: front_sequelize,
     indexes: [
       {
@@ -232,9 +232,11 @@ Conversation.hasMany(Message, {
 });
 UserMessage.hasOne(Message, {
   foreignKey: "userMessageId",
+  as: "_message",
 });
 AgentMessage.hasOne(Message, {
   foreignKey: "agentMessageId",
+  as: "_message",
 });
 Message.belongsTo(Message, {
   foreignKey: "parentId",

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -11,8 +11,8 @@ import { front_sequelize } from "@app/lib/databases";
 import { User } from "@app/lib/models/user";
 import {
   AgentMessageStatus,
-  AssistantMessageVisibility,
   ConversationVisibility,
+  MessageVisibility,
 } from "@app/types/assistant/conversation";
 
 export class Conversation extends Model<
@@ -161,25 +161,25 @@ AgentMessage.init(
   }
 );
 
-export class AssistantMessage extends Model<
-  InferAttributes<AssistantMessage>,
-  InferCreationAttributes<AssistantMessage>
+export class Message extends Model<
+  InferAttributes<Message>,
+  InferCreationAttributes<Message>
 > {
   declare id: CreationOptional<number>;
   declare sId: string;
 
   declare version: CreationOptional<number>;
   declare rank: number;
-  declare visibility: CreationOptional<AssistantMessageVisibility>;
+  declare visibility: CreationOptional<MessageVisibility>;
 
   declare conversationId: ForeignKey<Conversation["id"]>;
 
-  declare parentId: ForeignKey<AssistantMessage["id"]> | null;
+  declare parentId: ForeignKey<Message["id"]> | null;
   declare userMessageId: ForeignKey<UserMessage["id"]> | null;
   declare agentMessageId: ForeignKey<AgentMessage["id"]> | null;
 }
 
-AssistantMessage.init(
+Message.init(
   {
     id: {
       type: DataTypes.INTEGER,
@@ -226,16 +226,16 @@ AssistantMessage.init(
     },
   }
 );
-Conversation.hasMany(AssistantMessage, {
+Conversation.hasMany(Message, {
   foreignKey: { name: "conversationId", allowNull: false },
   onDelete: "CASCADE",
 });
-UserMessage.hasOne(AssistantMessage, {
+UserMessage.hasOne(Message, {
   foreignKey: "userMessageId",
 });
-AgentMessage.hasOne(AssistantMessage, {
+AgentMessage.hasOne(Message, {
   foreignKey: "agentMessageId",
 });
-AssistantMessage.belongsTo(AssistantMessage, {
+Message.belongsTo(Message, {
   foreignKey: "parentId",
 });

--- a/front/lib/models/index.ts
+++ b/front/lib/models/index.ts
@@ -1,6 +1,6 @@
 import { App, Clone, Dataset, Provider, Run } from "@app/lib/models/apps";
 import {
-  AssistantAgentMessage,
+  AgentMessage,
   AssistantMessage,
   Conversation,
   UserMessage,
@@ -27,8 +27,8 @@ import {
 import { XP1Run, XP1User } from "@app/lib/models/xp1";
 
 export {
+  AgentMessage,
   App,
-  AssistantAgentMessage,
   AssistantMessage,
   ChatMessage,
   ChatRetrievedDocument,

--- a/front/lib/models/index.ts
+++ b/front/lib/models/index.ts
@@ -1,8 +1,8 @@
 import { App, Clone, Dataset, Provider, Run } from "@app/lib/models/apps";
 import {
   AgentMessage,
-  AssistantMessage,
   Conversation,
+  Message,
   UserMessage,
 } from "@app/lib/models/assistant/conversation";
 import {
@@ -29,7 +29,6 @@ import { XP1Run, XP1User } from "@app/lib/models/xp1";
 export {
   AgentMessage,
   App,
-  AssistantMessage,
   ChatMessage,
   ChatRetrievedDocument,
   ChatSession,
@@ -44,6 +43,7 @@ export {
   Key,
   Membership,
   MembershipInvitation,
+  Message,
   Provider,
   Run,
   TrackedDocument,

--- a/front/lib/models/index.ts
+++ b/front/lib/models/index.ts
@@ -1,9 +1,9 @@
 import { App, Clone, Dataset, Provider, Run } from "@app/lib/models/apps";
 import {
   AssistantAgentMessage,
-  AssistantConversation,
   AssistantMessage,
   AssistantUserMessage,
+  Conversation,
 } from "@app/lib/models/assistant/conversation";
 import {
   ChatMessage,
@@ -29,13 +29,13 @@ import { XP1Run, XP1User } from "@app/lib/models/xp1";
 export {
   App,
   AssistantAgentMessage,
-  AssistantConversation,
   AssistantMessage,
   AssistantUserMessage,
   ChatMessage,
   ChatRetrievedDocument,
   ChatSession,
   Clone,
+  Conversation,
   Dataset,
   DataSource,
   DocumentTrackerChangeSuggestion,

--- a/front/lib/models/index.ts
+++ b/front/lib/models/index.ts
@@ -2,8 +2,8 @@ import { App, Clone, Dataset, Provider, Run } from "@app/lib/models/apps";
 import {
   AssistantAgentMessage,
   AssistantMessage,
-  AssistantUserMessage,
   Conversation,
+  UserMessage,
 } from "@app/lib/models/assistant/conversation";
 import {
   ChatMessage,
@@ -30,7 +30,6 @@ export {
   App,
   AssistantAgentMessage,
   AssistantMessage,
-  AssistantUserMessage,
   ChatMessage,
   ChatRetrievedDocument,
   ChatSession,
@@ -49,6 +48,7 @@ export {
   Run,
   TrackedDocument,
   User,
+  UserMessage,
   UserMetadata,
   Workspace,
   XP1Run,

--- a/front/types/assistant/actions/retrieval.ts
+++ b/front/types/assistant/actions/retrieval.ts
@@ -4,7 +4,7 @@
 
 import { ModelId } from "@app/lib/databases";
 import { AgentActionConfigurationType } from "@app/types/assistant/agent";
-import { AssistantAgentActionType } from "@app/types/assistant/conversation";
+import { AgentActionType } from "@app/types/assistant/conversation";
 
 export type TimeFrame = {
   count: number;
@@ -76,13 +76,13 @@ export type RetrievalDocumentType = {
 };
 
 export function isRetrievalActionType(
-  arg: AssistantAgentActionType
+  arg: AgentActionType
 ): arg is RetrievalActionType {
   return arg.type === "retrieval_action";
 }
 
 export type RetrievalActionType = {
-  id: ModelId; // AssistantAgentRetrieval.
+  id: ModelId; // AgentRetrieval.
   type: "retrieval_action";
   params: {
     dataSources: "all" | DataSourceConfiguration[];

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -122,17 +122,17 @@ export function isAgentMessageType(
  * Conversations
  */
 
-export type AssistantConversationVisibility = "private" | "workspace";
+export type ConversationVisibility = "private" | "workspace";
 
 /**
  * content [][] structure is intended to allow retries (of agent messages) or edits (of user
  * messages).
  */
-export type AssistantConversationType = {
+export type ConversationType = {
   id: ModelId;
   created: number;
   sId: string;
   title: string | null;
   content: (AssistantUserMessageType[] | AssistantAgentMessageType[])[];
-  visibility: AssistantConversationVisibility;
+  visibility: ConversationVisibility;
 };

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -62,7 +62,7 @@ export type UserMessageType = {
 };
 
 export function isUserMessageType(
-  arg: UserMessageType | AssistantAgentMessageType
+  arg: UserMessageType | AgentMessageType
 ): arg is UserMessageType {
   return arg.type === "user_message";
 }
@@ -79,7 +79,7 @@ export type AssistantUserFeedbackType = {
 
 export type AssistantAgentActionType = RetrievalActionType;
 
-export type AssistantAgentMessageStatus =
+export type AgentMessageStatus =
   | "created"
   | "action_running"
   | "writing"
@@ -93,7 +93,7 @@ export type AssistantAgentMessageStatus =
  * them together in case of error of either. We store an error only here whether it's an error
  * coming from the action or from the message generation.
  */
-export type AssistantAgentMessageType = {
+export type AgentMessageType = {
   id: ModelId;
   type: "agent_message";
   sId: string;
@@ -102,7 +102,7 @@ export type AssistantAgentMessageType = {
   parentMessageId: string | null;
 
   configuration: AgentConfigurationType;
-  status: AssistantAgentMessageStatus;
+  status: AgentMessageStatus;
   action: AssistantAgentActionType | null;
   message: string | null;
   feedbacks: AssistantUserFeedbackType[];
@@ -113,8 +113,8 @@ export type AssistantAgentMessageType = {
 };
 
 export function isAgentMessageType(
-  arg: UserMessageType | AssistantAgentMessageType
-): arg is AssistantAgentMessageType {
+  arg: UserMessageType | AgentMessageType
+): arg is AgentMessageType {
   return arg.type === "agent_message";
 }
 
@@ -133,6 +133,6 @@ export type ConversationType = {
   created: number;
   sId: string;
   title: string | null;
-  content: (UserMessageType[] | AssistantAgentMessageType[])[];
+  content: (UserMessageType[] | AgentMessageType[])[];
   visibility: ConversationVisibility;
 };

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -8,29 +8,25 @@ import { AgentConfigurationType } from "./agent";
  * Mentions
  */
 
-export type AssistantAgentMention = {
+export type AgentMention = {
   configurationId: string;
 };
 
-export type AssistantUserMention = {
+export type UserMention = {
   provider: string;
   providerId: string;
 };
 
-export type AssistantMention = AssistantAgentMention | AssistantUserMention;
+export type Mention = AgentMention | UserMention;
 
-export type AssistantMessageVisibility = "visible" | "deleted";
+export type MessageVisibility = "visible" | "deleted";
 
-export function isAssistantAgentMention(
-  arg: AssistantMention
-): arg is AssistantAgentMention {
-  return (arg as AssistantAgentMention).configurationId !== undefined;
+export function isAgentMention(arg: Mention): arg is AgentMention {
+  return (arg as AgentMention).configurationId !== undefined;
 }
 
-export function isAssistantUserMention(
-  arg: AssistantMention
-): arg is AssistantUserMention {
-  const maybeUserMention = arg as AssistantUserMention;
+export function isUserMention(arg: Mention): arg is UserMention {
+  const maybeUserMention = arg as UserMention;
   return (
     maybeUserMention.provider !== undefined &&
     maybeUserMention.providerId !== undefined
@@ -53,10 +49,10 @@ export type UserMessageType = {
   id: ModelId;
   type: "user_message";
   sId: string;
-  visibility: AssistantMessageVisibility;
+  visibility: MessageVisibility;
   version: number;
   user: UserType | null;
-  mentions: AssistantMention[];
+  mentions: Mention[];
   message: string;
   context: UserMessageContext;
 };
@@ -71,13 +67,13 @@ export function isUserMessageType(
  * Agent messages
  */
 
-export type AssistantUserFeedbackType = {
+export type UserFeedbackType = {
   user: UserType;
   value: "positive" | "negative" | null;
   comment: string | null;
 };
 
-export type AssistantAgentActionType = RetrievalActionType;
+export type AgentActionType = RetrievalActionType;
 
 export type AgentMessageStatus =
   | "created"
@@ -97,15 +93,15 @@ export type AgentMessageType = {
   id: ModelId;
   type: "agent_message";
   sId: string;
-  visibility: AssistantMessageVisibility;
+  visibility: MessageVisibility;
   version: number;
   parentMessageId: string | null;
 
   configuration: AgentConfigurationType;
   status: AgentMessageStatus;
-  action: AssistantAgentActionType | null;
+  action: AgentActionType | null;
   message: string | null;
-  feedbacks: AssistantUserFeedbackType[];
+  feedbacks: UserFeedbackType[];
   error: {
     code: string;
     message: string;

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -41,7 +41,7 @@ export function isAssistantUserMention(
  * User messages
  */
 
-export type AssistantUserMessageContext = {
+export type UserMessageContext = {
   username: string;
   timezone: string;
   fullName: string | null;
@@ -49,7 +49,7 @@ export type AssistantUserMessageContext = {
   profilePictureUrl: string | null;
 };
 
-export type AssistantUserMessageType = {
+export type UserMessageType = {
   id: ModelId;
   type: "user_message";
   sId: string;
@@ -58,12 +58,12 @@ export type AssistantUserMessageType = {
   user: UserType | null;
   mentions: AssistantMention[];
   message: string;
-  context: AssistantUserMessageContext;
+  context: UserMessageContext;
 };
 
 export function isUserMessageType(
-  arg: AssistantUserMessageType | AssistantAgentMessageType
-): arg is AssistantUserMessageType {
+  arg: UserMessageType | AssistantAgentMessageType
+): arg is UserMessageType {
   return arg.type === "user_message";
 }
 
@@ -113,7 +113,7 @@ export type AssistantAgentMessageType = {
 };
 
 export function isAgentMessageType(
-  arg: AssistantUserMessageType | AssistantAgentMessageType
+  arg: UserMessageType | AssistantAgentMessageType
 ): arg is AssistantAgentMessageType {
   return arg.type === "agent_message";
 }
@@ -133,6 +133,6 @@ export type ConversationType = {
   created: number;
   sId: string;
   title: string | null;
-  content: (AssistantUserMessageType[] | AssistantAgentMessageType[])[];
+  content: (UserMessageType[] | AssistantAgentMessageType[])[];
   visibility: ConversationVisibility;
 };


### PR DESCRIPTION
Was confusing and annoying