### PR TITLE
Assistant: Add missing CreationOptional id/createdAt/updatedAt in config models

### DIFF
--- a/front/lib/models/assistant/actions/retrieval.ts
+++ b/front/lib/models/assistant/actions/retrieval.ts
@@ -1,4 +1,5 @@
 import {
+  CreationOptional,
   DataTypes,
   ForeignKey,
   InferAttributes,
@@ -18,7 +19,9 @@ export class AgentRetrievalConfiguration extends Model<
   InferAttributes<AgentRetrievalConfiguration>,
   InferCreationAttributes<AgentRetrievalConfiguration>
 > {
-  declare id: number;
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
 
   declare query: "auto" | "none" | "templated";
   declare queryTemplate: string | null;
@@ -35,6 +38,16 @@ AgentRetrievalConfiguration.init(
       type: DataTypes.INTEGER,
       autoIncrement: true,
       primaryKey: true,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
     },
     query: {
       type: DataTypes.STRING,
@@ -100,7 +113,9 @@ export class AgentDataSourceConfiguration extends Model<
   InferAttributes<AgentDataSourceConfiguration>,
   InferCreationAttributes<AgentDataSourceConfiguration>
 > {
-  declare id: number;
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
 
   declare minTimestamp: number | null;
   declare maxTimestamp: number | null;
@@ -123,6 +138,16 @@ AgentDataSourceConfiguration.init(
       type: DataTypes.INTEGER,
       autoIncrement: true,
       primaryKey: true,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
     },
     minTimestamp: {
       type: DataTypes.INTEGER,

--- a/front/lib/models/assistant/agent.ts
+++ b/front/lib/models/assistant/agent.ts
@@ -1,4 +1,5 @@
 import {
+  CreationOptional,
   DataTypes,
   ForeignKey,
   InferAttributes,
@@ -21,7 +22,9 @@ export class AgentConfiguration extends Model<
   InferAttributes<AgentConfiguration>,
   InferCreationAttributes<AgentConfiguration>
 > {
-  declare id: number;
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
 
   declare sId: string;
   declare status: AgentConfigurationStatus;
@@ -39,6 +42,16 @@ AgentConfiguration.init(
       type: DataTypes.INTEGER,
       autoIncrement: true,
       primaryKey: true,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
     },
     sId: {
       type: DataTypes.STRING,
@@ -95,7 +108,9 @@ export class AgentGenerationConfiguration extends Model<
   InferAttributes<AgentGenerationConfiguration>,
   InferCreationAttributes<AgentGenerationConfiguration>
 > {
-  declare id: number;
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
 
   declare prompt: string;
   declare modelProvider: string;
@@ -109,6 +124,16 @@ AgentGenerationConfiguration.init(
       type: DataTypes.INTEGER,
       autoIncrement: true,
       primaryKey: true,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
     },
     prompt: {
       type: DataTypes.TEXT,


### PR DESCRIPTION
Tiny! Just adding createdAt/UpdatedAt on the new models added earlier for AgentConfig + setting them and `id` as `CreationOptional`