### PR TITLE
Create getResourceId/getDocumentId for connector resources /documents, and systematize the use of those functions

### DIFF
--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -5,6 +5,7 @@ import {
   validateInstallationId,
 } from "@connectors/connectors/github/lib/github_api";
 import { launchGithubFullSyncWorkflow } from "@connectors/connectors/github/temporal/client";
+import { getGithubRepoResourceId } from "@connectors/lib/ids";
 import {
   Connector,
   GithubConnectorState,
@@ -20,7 +21,6 @@ import {
   ConnectorPermission,
   ConnectorResource,
 } from "@connectors/types/resources";
-import { getGithubRepoResourceId } from "@connectors/lib/ids";
 
 type GithubInstallationId = string;
 

--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -20,6 +20,7 @@ import {
   ConnectorPermission,
   ConnectorResource,
 } from "@connectors/types/resources";
+import { getGithubRepoResourceId } from "@connectors/lib/ids";
 
 type GithubInstallationId = string;
 
@@ -294,7 +295,7 @@ export async function retrieveGithubConnectorPermissions(
     resources = resources.concat(
       page.map((repo) => ({
         provider: c.type,
-        internalId: repo.id.toString(),
+        internalId: getGithubRepoResourceId(repo.id.toString()),
         parentInternalId: null,
         type: "folder",
         title: repo.name,

--- a/connectors/src/connectors/github/temporal/activities.ts
+++ b/connectors/src/connectors/github/temporal/activities.ts
@@ -16,6 +16,10 @@ import {
   upsertToDatasource,
 } from "@connectors/lib/data_sources";
 import {
+  getGithubDiscussionDocumentId,
+  getGithubIssueDocumentId,
+} from "@connectors/lib/ids";
+import {
   Connector,
   GithubDiscussion,
   GithubIssue,
@@ -23,10 +27,6 @@ import {
 import { syncStarted, syncSucceeded } from "@connectors/lib/sync_status";
 import mainLogger from "@connectors/logger/logger";
 import { DataSourceConfig } from "@connectors/types/data_source_config";
-import {
-  getGithubDiscussionDocumentId,
-  getGithubIssueDocumentId,
-} from "@connectors/lib/ids";
 
 const logger = mainLogger.child({
   provider: "github",

--- a/connectors/src/connectors/github/temporal/activities.ts
+++ b/connectors/src/connectors/github/temporal/activities.ts
@@ -23,6 +23,10 @@ import {
 import { syncStarted, syncSucceeded } from "@connectors/lib/sync_status";
 import mainLogger from "@connectors/logger/logger";
 import { DataSourceConfig } from "@connectors/types/data_source_config";
+import {
+  getGithubDiscussionDocumentId,
+  getGithubIssueDocumentId,
+} from "@connectors/lib/ids";
 
 const logger = mainLogger.child({
   provider: "github",
@@ -130,7 +134,7 @@ export async function githubUpsertIssueActivity(
     resultPage += 1;
   }
 
-  const documentId = getIssueDocumentId(repoId.toString(), issueNumber);
+  const documentId = getGithubIssueDocumentId(repoId.toString(), issueNumber);
   const issueAuthor = renderGithubUser(issue.creator);
   const tags = [
     `title:${issue.title}`,
@@ -264,7 +268,7 @@ export async function githubUpsertDiscussionActivity(
     nextCursor = cursor;
   }
 
-  const documentId = getDiscussionDocumentId(
+  const documentId = getGithubDiscussionDocumentId(
     repoId.toString(),
     discussionNumber
   );
@@ -506,7 +510,7 @@ async function deleteIssue(
     );
   }
 
-  const documentId = getIssueDocumentId(repoId.toString(), issueNumber);
+  const documentId = getGithubIssueDocumentId(repoId.toString(), issueNumber);
   localLogger.info(
     { documentId },
     "Deleting GitHub issue from Dust data source."
@@ -555,7 +559,7 @@ async function deleteDiscussion(
     localLogger.warn("Discussion not found in DB");
   }
 
-  const documentId = getDiscussionDocumentId(
+  const documentId = getGithubDiscussionDocumentId(
     repoId.toString(),
     discussionNumber
   );
@@ -583,15 +587,4 @@ function renderGithubUser(user: GithubUser | null): string {
     return `@${user.login}`;
   }
   return `@${user.id}`;
-}
-
-function getIssueDocumentId(repoId: string, issueNumber: number): string {
-  return `github-issue-${repoId}-${issueNumber}`;
-}
-
-function getDiscussionDocumentId(
-  repoId: string,
-  discussionNumber: number
-): string {
-  return `github-discussion-${repoId}-${discussionNumber}`;
 }

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -34,6 +34,11 @@ import {
   getGoogleDriveObject,
 } from "./temporal/activities";
 import { launchGoogleDriveFullSyncWorkflow } from "./temporal/client";
+import {
+  getGDriveFileDocumentId,
+  getGDriveFolderResourceId,
+} from "@connectors/lib/ids";
+import { get } from "http";
 export type NangoConnectionId = string;
 
 const {
@@ -336,7 +341,7 @@ export async function retrieveGoogleDriveConnectorPermissions(
           }
           return {
             provider: c.type,
-            internalId: f.folderId,
+            internalId: getGDriveFolderResourceId(f.folderId),
             parentInternalId: null,
             type: "folder",
             title: fd.name || "",
@@ -368,7 +373,10 @@ export async function retrieveGoogleDriveConnectorPermissions(
           return (async () => {
             return {
               provider: c.type,
-              internalId: f.driveFileId,
+              internalId:
+                f.mimeType === "application/vnd.google-apps.folder"
+                  ? getGDriveFolderResourceId(f.driveFileId)
+                  : getGDriveFileDocumentId(f.driveFileId),
               parentInternalId: null,
               type:
                 f.mimeType === "application/vnd.google-apps.folder"
@@ -401,8 +409,11 @@ export async function retrieveGoogleDriveConnectorPermissions(
 
           return {
             provider: c.type,
-            internalId: driveObject.id,
-            parentInternalId: driveObject.parent,
+            internalId: getGDriveFolderResourceId(driveObject.id),
+            parentInternalId:
+              driveObject.parent === null
+                ? null
+                : getGDriveFolderResourceId(driveObject.parent),
             type: "folder" as ConnectorResourceType,
             title: driveObject.name,
             sourceUrl: driveObject.webViewLink || null,
@@ -455,8 +466,11 @@ export async function retrieveGoogleDriveConnectorPermissions(
 
           return {
             provider: c.type,
-            internalId: driveObject.id,
-            parentInternalId: driveObject.parent,
+            internalId: getGDriveFolderResourceId(driveObject.id),
+            parentInternalId:
+              driveObject.parent === null
+                ? null
+                : getGDriveFolderResourceId(driveObject.parent),
             type: "folder" as ConnectorResourceType,
             title: driveObject.name,
             sourceUrl: driveObject.webViewLink || null,

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -4,6 +4,10 @@ import { GaxiosResponse } from "googleapis-common";
 import { Transaction } from "sequelize";
 
 import {
+  getGDriveFileDocumentId,
+  getGDriveFolderResourceId,
+} from "@connectors/lib/ids";
+import {
   Connector,
   GoogleDriveFiles,
   GoogleDriveFolders,
@@ -34,11 +38,6 @@ import {
   getGoogleDriveObject,
 } from "./temporal/activities";
 import { launchGoogleDriveFullSyncWorkflow } from "./temporal/client";
-import {
-  getGDriveFileDocumentId,
-  getGDriveFolderResourceId,
-} from "@connectors/lib/ids";
-import { get } from "http";
 export type NangoConnectionId = string;
 
 const {

--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -23,6 +23,7 @@ import { literal, Op } from "sequelize";
 
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { dpdf2text } from "@connectors/lib/dpdf2text";
+import { getGDriveFileDocumentId } from "@connectors/lib/ids";
 import {
   Connector,
   GoogleDriveFiles,
@@ -35,7 +36,6 @@ import {
 import logger from "@connectors/logger/logger";
 
 import { registerWebhook } from "../lib";
-import { getGDriveFileDocumentId } from "@connectors/lib/ids";
 
 const FILES_SYNC_CONCURRENCY = 10;
 const FILES_GC_CONCURRENCY = 5;

--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -35,6 +35,7 @@ import {
 import logger from "@connectors/logger/logger";
 
 import { registerWebhook } from "../lib";
+import { getGDriveFileDocumentId } from "@connectors/lib/ids";
 
 const FILES_SYNC_CONCURRENCY = 10;
 const FILES_GC_CONCURRENCY = 5;
@@ -276,7 +277,7 @@ async function syncOneFile(
   startSyncTs: number,
   isBatchSync = false
 ): Promise<boolean> {
-  const documentId = getDocumentId(file.id);
+  const documentId = getGDriveFileDocumentId(file.id);
   let documentContent: string | undefined = undefined;
   if (MIME_TYPES_TO_EXPORT[file.mimeType]) {
     const drive = await getDriveClient(oauth2client);
@@ -612,7 +613,7 @@ export async function incrementalSync(
       if (driveFile.mimeType === "application/vnd.google-apps.folder") {
         await GoogleDriveFiles.upsert({
           connectorId: connectorId,
-          dustFileId: getDocumentId(driveFile.id),
+          dustFileId: getGDriveFileDocumentId(driveFile.id),
           driveFileId: file.id,
           name: file.name,
           mimeType: file.mimeType,
@@ -995,10 +996,6 @@ export async function driveObjectToDustType(
   }
 }
 
-function getDocumentId(driveFileId: string): string {
-  return `gdrive-${driveFileId}`;
-}
-
 export async function markFolderAsVisited(
   connectorId: ModelId,
   driveFileId: string
@@ -1011,7 +1008,7 @@ export async function markFolderAsVisited(
   const file = await getGoogleDriveObject(authCredentials, driveFileId);
   await GoogleDriveFiles.upsert({
     connectorId: connectorId,
-    dustFileId: getDocumentId(driveFileId),
+    dustFileId: getGDriveFileDocumentId(driveFileId),
     driveFileId: file.id,
     name: file.name,
     mimeType: file.mimeType,

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -7,6 +7,10 @@ import {
 } from "@connectors/connectors/notion/temporal/client";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import {
+  getNotionDatabaseResourceId,
+  getNotionPageDocumentId,
+} from "@connectors/lib/ids";
+import {
   Connector,
   ModelId,
   NotionConnectorState,
@@ -27,10 +31,6 @@ import {
   ConnectorPermission,
   ConnectorResource,
 } from "@connectors/types/resources";
-import {
-  getNotionDatabaseResourceId,
-  getNotionPageDocumentId,
-} from "@connectors/lib/ids";
 
 const { NANGO_NOTION_CONNECTOR_ID } = process.env;
 const logger = mainLogger.child({ provider: "notion" });

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -23,6 +23,7 @@ import {
   MAX_DOCUMENT_TXT_LEN,
   upsertToDatasource,
 } from "@connectors/lib/data_sources";
+import { getNotionPageDocumentId } from "@connectors/lib/ids";
 import {
   Connector,
   NotionConnectorState,
@@ -36,7 +37,6 @@ import {
   DataSourceConfig,
   DataSourceInfo,
 } from "@connectors/types/data_source_config";
-import { getNotionPageDocumentId } from "@connectors/lib/ids";
 
 const logger = mainLogger.child({ provider: "notion" });
 

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -36,6 +36,7 @@ import {
   DataSourceConfig,
   DataSourceInfo,
 } from "@connectors/types/data_source_config";
+import { getNotionPageDocumentId } from "@connectors/lib/ids";
 
 const logger = mainLogger.child({ provider: "notion" });
 
@@ -258,10 +259,9 @@ export async function notionUpsertPageActivity(
 
   if (parsedPage && parsedPage.hasBody) {
     upsertTs = new Date().getTime();
-    const documentId = `notion-${parsedPage.id}`;
     await upsertToDatasource({
       dataSourceConfig,
-      documentId,
+      documentId: getNotionPageDocumentId(parsedPage.id),
       documentText: parsedPage.rendered,
       documentUrl: parsedPage.url,
       timestampMs: parsedPage.updatedTime,
@@ -717,7 +717,10 @@ export async function garbageCollectActivity(
     }
 
     iterationLogger.info("Deleting page.");
-    await deleteFromDataSource(dataSourceConfig, `notion-${page.notionPageId}`);
+    await deleteFromDataSource(
+      dataSourceConfig,
+      getNotionPageDocumentId(page.notionPageId)
+    );
     await page.destroy();
 
     deletedPagesCount++;

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -7,6 +7,7 @@ import {
   launchSlackGarbageCollectWorkflow,
   launchSlackSyncWorkflow,
 } from "@connectors/connectors/slack/temporal/client.js";
+import { getSlackChannelResourceId } from "@connectors/lib/ids";
 import {
   Connector,
   ModelId,
@@ -30,7 +31,6 @@ import {
 } from "@connectors/types/resources";
 
 import { getAccessToken, getSlackClient } from "./temporal/activities";
-import { getSlackChannelResourceId } from "@connectors/lib/ids";
 
 const { NANGO_SLACK_CONNECTOR_ID, SLACK_CLIENT_ID, SLACK_CLIENT_SECRET } =
   process.env;

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -30,6 +30,7 @@ import {
 } from "@connectors/types/resources";
 
 import { getAccessToken, getSlackClient } from "./temporal/activities";
+import { getSlackChannelResourceId } from "@connectors/lib/ids";
 
 const { NANGO_SLACK_CONNECTOR_ID, SLACK_CLIENT_ID, SLACK_CLIENT_SECRET } =
   process.env;
@@ -345,7 +346,7 @@ export async function retrieveSlackConnectorPermissions(
 
   const resources: ConnectorResource[] = slackChannels.map((ch) => ({
     provider: "slack",
-    internalId: ch.slackChannelId,
+    internalId: getSlackChannelResourceId(ch.slackChannelId),
     parentInternalId: null,
     type: "channel",
     title: ch.slackChannelName,

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -34,6 +34,7 @@ import mainLogger from "@connectors/logger/logger";
 import { DataSourceConfig } from "@connectors/types/data_source_config";
 
 import { getWeekEnd, getWeekStart } from "../lib/utils";
+import { getSlackMessagesDocumentId, getSlackThreadDocumentId } from "@connectors/lib/ids";
 
 const { NANGO_SLACK_CONNECTOR_ID } = process.env;
 const logger = mainLogger.child({ provider: "slack" });
@@ -378,11 +379,11 @@ export async function syncNonThreaded(
     client
   );
 
-  const startDate = new Date(startTsMs);
-  const endDate = new Date(endTsMs);
-  const startDateStr = `${startDate.getFullYear()}-${startDate.getMonth()}-${startDate.getDate()}`;
-  const endDateStr = `${endDate.getFullYear()}-${endDate.getMonth()}-${endDate.getDate()}`;
-  const documentId = `slack-${channelId}-messages-${startDateStr}-${endDateStr}`;
+  const documentId = getSlackMessagesDocumentId(
+    channelId,
+    startTsMs,
+    endTsMs
+  );
   const firstMessage = messages[0];
   let sourceUrl: string | undefined = undefined;
 
@@ -529,7 +530,7 @@ export async function syncThread(
     connectorId,
     client
   );
-  const documentId = `slack-${channelId}-thread-${threadTs}`;
+  const documentId = getSlackThreadDocumentId(channelId, threadTs);
 
   const firstMessage = allMessages[0];
   let sourceUrl: string | undefined = undefined;

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -24,7 +24,10 @@ import {
   upsertToDatasource,
 } from "@connectors/lib/data_sources";
 import { WorkflowError } from "@connectors/lib/error";
-import { getSlackMessagesDocumentId, getSlackThreadDocumentId } from "@connectors/lib/ids";
+import {
+  getSlackMessagesDocumentId,
+  getSlackThreadDocumentId,
+} from "@connectors/lib/ids";
 import { SlackChannel, SlackMessages } from "@connectors/lib/models";
 import { nango_client } from "@connectors/lib/nango_client";
 import {
@@ -379,11 +382,7 @@ export async function syncNonThreaded(
     client
   );
 
-  const documentId = getSlackMessagesDocumentId(
-    channelId,
-    startTsMs,
-    endTsMs
-  );
+  const documentId = getSlackMessagesDocumentId(channelId, startTsMs, endTsMs);
   const firstMessage = messages[0];
   let sourceUrl: string | undefined = undefined;
 

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -24,6 +24,7 @@ import {
   upsertToDatasource,
 } from "@connectors/lib/data_sources";
 import { WorkflowError } from "@connectors/lib/error";
+import { getSlackMessagesDocumentId, getSlackThreadDocumentId } from "@connectors/lib/ids";
 import { SlackChannel, SlackMessages } from "@connectors/lib/models";
 import { nango_client } from "@connectors/lib/nango_client";
 import {
@@ -34,7 +35,6 @@ import mainLogger from "@connectors/logger/logger";
 import { DataSourceConfig } from "@connectors/types/data_source_config";
 
 import { getWeekEnd, getWeekStart } from "../lib/utils";
-import { getSlackMessagesDocumentId, getSlackThreadDocumentId } from "@connectors/lib/ids";
 
 const { NANGO_SLACK_CONNECTOR_ID } = process.env;
 const logger = mainLogger.child({ provider: "slack" });

--- a/connectors/src/lib/ids.ts
+++ b/connectors/src/lib/ids.ts
@@ -1,0 +1,57 @@
+// Github
+export function getGithubDiscussionDocumentId(
+  repoId: string,
+  discussionNumber: number
+): string {
+  return `github-discussion-${repoId}-${discussionNumber}`;
+}
+
+export function getGithubIssueDocumentId(
+  repoId: string,
+  issueNumber: number
+): string {
+  return `github-issue-${repoId}-${issueNumber}`;
+}
+
+export function getGithubRepoResourceId(repoId: string): string {
+  return `github-repo-${repoId}`;
+}
+
+/// Notion
+export function getNotionDatabaseResourceId(databaseId: string): string {
+  return `notion-database-${databaseId}`;
+}
+
+export function getNotionPageDocumentId(pageId: string): string {
+  return `notion-${pageId}`;
+}
+
+/// Slack
+export function getSlackChannelResourceId(channelId: string): string {
+  return `slack-channel-${channelId}`;
+}
+
+export function getSlackMessagesDocumentId(
+  channelId: string,
+  startTsMs: number,
+  endTsMs: number
+): string {
+  const startDate = new Date(startTsMs);
+  const endDate = new Date(endTsMs);
+  const startDateStr = `${startDate.getFullYear()}-${startDate.getMonth()}-${startDate.getDate()}`;
+  const endDateStr = `${endDate.getFullYear()}-${endDate.getMonth()}-${endDate.getDate()}`;
+  return `slack-${channelId}-messages-${startDateStr}-${endDateStr}`;
+}
+
+export function getSlackThreadDocumentId(channelId: string, threadTs: string) {
+  return `slack-${channelId}-thread-${threadTs}`;
+}
+
+/// Google Drive
+export function getGDriveFileDocumentId(driveFileId: string): string {
+  return `gdrive-${driveFileId}`;
+}
+
+export function getGDriveFolderResourceId(driveFolderId: string): string {
+  return `gdrive-folder-${driveFolderId}`;
+}


### PR DESCRIPTION
we use getDocumentId if the resource is mapped to an upserted document (and thus has a documentId in qdrant and core sql)
we use getResourceId otherwise, in which managed data sources confine their id computation logic for non-upserted docs

The goal is to then cleanly align the parents field with this convention and to enforce id alignment with code: make sure through those functions that we always use the same id schemes across the codebase. 

After this PR is merged, the plan:
- upmerge it to the 3 pending PRs for parents field: notion, slack, github
- use getResourceId in those PRs for the parents field
- merge those PRs and migrate
- do the same for Google Drive