### PR TITLE
Conversation creation and rendering

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -20,6 +20,7 @@ import {
   Key,
   Membership,
   MembershipInvitation,
+  Mention,
   Message,
   Provider,
   RetrievalDocument,
@@ -69,6 +70,7 @@ async function main() {
   await UserMessage.sync({ alter: true });
   await AgentMessage.sync({ alter: true });
   await Message.sync({ alter: true });
+  await Mention.sync({ alter: true });
 
   await XP1User.sync({ alter: true });
   await XP1Run.sync({ alter: true });

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -200,7 +200,7 @@ export async function generateRetrievalParams(
   if (configuration.query !== "none" && configuration.query !== "auto") {
     query = configuration.query.template.replace(
       "_USER_MESSAGE_",
-      userMessage.message
+      userMessage.content
     );
   }
 

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -266,7 +266,7 @@ export async function generateRetrievalParams(
  * Action rendering.
  */
 
-// Internal interface for the retrieval and rendering of a retrieval action. This should no be
+// Internal interface for the retrieval and rendering of a retrieval action. This should not be used
 // outside of api/assistant. We allow a ModelId interface here because we don't have `sId` on
 // actions (the `sId` is on the `Message` object linked to the `UserMessage` parent of this action).
 export async function renderRetrievalActionByModelId(

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -267,7 +267,8 @@ export async function generateRetrievalParams(
  */
 
 // Internal interface for the retrieval and rendering of a retrieval action. This should no be
-// outside of api/assistant. We allow a ModelId interface here to save a round trip to the database.
+// outside of api/assistant. We allow a ModelId interface here because we don't have `sId` on
+// actions (the `sId` is on the `Message` object linked to the `UserMessage` parent of this action).
 export async function renderRetrievalActionByModelId(
   id: ModelId
 ): Promise<RetrievalActionType> {

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -70,6 +70,7 @@ export async function getAgentConfiguration(
     : [];
 
   return {
+    id: agent.id,
     sId: agent.sId,
     name: agent.name,
     pictureUrl: agent.pictureUrl,
@@ -130,6 +131,7 @@ export async function createAgentConfiguration(
   });
 
   return {
+    id: agentConfig.id,
     sId: agentConfig.sId,
     name: agentConfig.name,
     pictureUrl: agentConfig.pictureUrl,
@@ -204,6 +206,7 @@ export async function updateAgentConfiguration(
     : [];
 
   return {
+    id: updatedAgentConfig.id,
     sId: updatedAgentConfig.sId,
     name: updatedAgentConfig.name,
     pictureUrl: updatedAgentConfig.pictureUrl,

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -137,7 +137,7 @@ async function renderUserMessage(
       }
       throw new Error("Unreachable: mention must be either agent or user");
     }),
-    message: userMessage.message,
+    content: userMessage.content,
     context: {
       username: userMessage.userContextUsername,
       timezone: userMessage.userContextTimezone,
@@ -189,7 +189,7 @@ async function renderAgentMessage(
     parentMessageId: null,
     status: agentMessage.status,
     action: agentRetrievalAction,
-    message: agentMessage.message,
+    content: agentMessage.content,
     feedbacks: [],
     error: null,
     configuration,
@@ -344,12 +344,12 @@ export async function* postUserMessage(
   auth: Authenticator,
   {
     conversation,
-    message,
+    content,
     mentions,
     context,
   }: {
     conversation: ConversationType;
-    message: string;
+    content: string;
     mentions: MentionType[];
     context: UserMessageContext;
   }
@@ -385,7 +385,7 @@ export async function* postUserMessage(
           userMessageId: (
             await UserMessage.create(
               {
-                message: message,
+                content,
                 userContextUsername: context.username,
                 userContextTimezone: context.timezone,
                 userContextFullName: context.fullName,
@@ -410,7 +410,7 @@ export async function* postUserMessage(
         version: 0,
         user: user,
         mentions: mentions,
-        message: message,
+        content,
         context: context,
       };
 
@@ -460,7 +460,7 @@ export async function* postUserMessage(
                   parentMessageId: userMessage.sId,
                   status: "created",
                   action: null,
-                  message: null,
+                  content: null,
                   feedbacks: [],
                   error: null,
                   configuration,
@@ -561,7 +561,7 @@ export async function* postUserMessage(
         if (event.type === "agent_generation_success") {
           // Store message in database.
           await agentMessageRow.update({
-            message: event.text,
+            content: event.text,
           });
           yield event;
         }

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -362,6 +362,7 @@ export async function* postUserMessage(
 > {
   const user = auth.user();
 
+  // In one big transaction creante all Message, UserMessage, AgentMessage and Mention rows.
   const { userMessage, agentMessages, agentMessageRows } =
     await front_sequelize.transaction(async (t) => {
       let nextMessageRank =

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -13,7 +13,6 @@ import { front_sequelize } from "@app/lib/databases";
 import {
   AgentConfiguration,
   AgentMessage,
-  AgentRetrievalAction,
   Conversation,
   Mention,
   Message,
@@ -229,18 +228,6 @@ export async function getConversation(
         model: AgentMessage,
         as: "agentMessage",
         required: false,
-        include: [
-          {
-            model: AgentRetrievalAction,
-            as: "agentRetrievalAction",
-            required: false,
-          },
-          {
-            model: AgentConfiguration,
-            as: "agentConfiguration",
-            required: true,
-          },
-        ],
       },
     ],
   });

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -259,7 +259,10 @@ export async function getConversation(
     return a.version - b.version;
   });
 
-  // We need to escape the type system here to create content.
+  // We need to escape the type system here to create content. We pre-create an array that will hold
+  // the versions of each User/Assistant message. The lenght of that array is by definition the
+  // maximal rank of the conversation messages we just retrieved. In the case there is no message
+  // the rank is -1 and the array length is 0 as expected.
   const content: any[] = Array.from(
     { length: messages.reduce((acc, m) => Math.max(acc, m.rank), -1) + 1 },
     () => []

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -65,11 +65,11 @@ export async function renderConversationForModel({
           );
         }
       }
-      if (m.message) {
+      if (m.content) {
         messages.unshift({
           role: "agent" as const,
           name: m.configuration.name,
-          content: m.message,
+          content: m.content,
         });
       }
     }
@@ -77,7 +77,7 @@ export async function renderConversationForModel({
       messages.unshift({
         role: "user" as const,
         name: m.context.username,
-        content: m.message,
+        content: m.content,
       });
     }
   }

--- a/front/lib/api/assistant/pubsub.ts
+++ b/front/lib/api/assistant/pubsub.ts
@@ -23,12 +23,12 @@ export async function postUserMessageWithPubSub(
   auth: Authenticator,
   {
     conversation,
-    message,
+    content,
     mentions,
     context,
   }: {
     conversation: ConversationType;
-    message: string;
+    content: string;
     mentions: MentionType[];
     context: UserMessageContext;
   }
@@ -37,7 +37,7 @@ export async function postUserMessageWithPubSub(
   try {
     for await (const event of postUserMessage(auth, {
       conversation,
-      message,
+      content,
       mentions,
       context,
     })) {
@@ -74,7 +74,7 @@ export async function postUserMessageWithPubSub(
   } finally {
     await redis.quit();
   }
-  console.log("exiting postUserMessageWithPubSub", message, conversation.sId);
+  // console.log("exiting postUserMessageWithPubSub", conversation.sId);
 }
 
 export async function* getConversationEvents(

--- a/front/lib/api/assistant/pubsub.ts
+++ b/front/lib/api/assistant/pubsub.ts
@@ -15,7 +15,7 @@ import { redisClient } from "@app/lib/redis";
 import logger from "@app/logger/logger";
 import {
   ConversationType,
-  Mention,
+  MentionType,
   UserMessageContext,
 } from "@app/types/assistant/conversation";
 
@@ -29,7 +29,7 @@ export async function postUserMessageWithPubSub(
   }: {
     conversation: ConversationType;
     message: string;
-    mentions: Mention[];
+    mentions: MentionType[];
     context: UserMessageContext;
   }
 ) {

--- a/front/lib/models/assistant/actions/retrieval.ts
+++ b/front/lib/models/assistant/actions/retrieval.ts
@@ -185,17 +185,26 @@ AgentDataSourceConfiguration.init(
 AgentRetrievalConfiguration.hasOne(AgentConfiguration, {
   foreignKey: { name: "retrievalConfigurationId", allowNull: true }, // null = no retrieval action set for this Agent
 });
+AgentConfiguration.belongsTo(AgentRetrievalConfiguration, {
+  foreignKey: { name: "retrievalConfigurationId", allowNull: true }, // null = no retrieval action set for this Agent
+});
 
 // Retrieval config <> Data source config
 AgentRetrievalConfiguration.hasMany(AgentDataSourceConfiguration, {
   foreignKey: { name: "retrievalConfigurationId", allowNull: false },
   onDelete: "CASCADE",
 });
+AgentDataSourceConfiguration.belongsTo(AgentRetrievalConfiguration, {
+  foreignKey: { name: "retrievalConfigurationId", allowNull: false },
+});
 
 // Data source config <> Data source
 DataSource.hasMany(AgentDataSourceConfiguration, {
   foreignKey: { name: "dataSourceId", allowNull: false },
   onDelete: "CASCADE",
+});
+AgentDataSourceConfiguration.belongsTo(DataSource, {
+  foreignKey: { name: "dataSourceId", allowNull: false },
 });
 
 /**
@@ -276,6 +285,9 @@ AgentRetrievalConfiguration.hasMany(AgentRetrievalAction, {
   // We don't want to delete the action when the configuration is deleted
   // But really we don't want to delete configurations ever.
 });
+AgentRetrievalAction.belongsTo(AgentRetrievalConfiguration, {
+  foreignKey: { name: "retrievalConfigurationId", allowNull: false },
+});
 
 export class RetrievalDocument extends Model<
   InferAttributes<RetrievalDocument>,
@@ -353,6 +365,9 @@ AgentRetrievalAction.hasMany(RetrievalDocument, {
   foreignKey: { name: "retrievalActionId", allowNull: false },
   onDelete: "CASCADE",
 });
+RetrievalDocument.belongsTo(AgentRetrievalAction, {
+  foreignKey: { name: "retrievalActionId", allowNull: false },
+});
 
 export class RetrievalDocumentChunk extends Model<
   InferAttributes<RetrievalDocumentChunk>,
@@ -409,4 +424,7 @@ RetrievalDocumentChunk.init(
 RetrievalDocument.hasMany(RetrievalDocumentChunk, {
   foreignKey: { name: "retrievalDocumentId", allowNull: false },
   onDelete: "CASCADE",
+});
+RetrievalDocumentChunk.belongsTo(RetrievalDocument, {
+  foreignKey: { name: "retrievalDocumentId", allowNull: false },
 });

--- a/front/lib/models/assistant/agent.ts
+++ b/front/lib/models/assistant/agent.ts
@@ -105,6 +105,12 @@ AgentConfiguration.init(
   }
 );
 
+//  Agent config <> Workspace
+Workspace.hasMany(AgentConfiguration, {
+  foreignKey: { name: "workspaceId", allowNull: true }, // null = global Agent
+  onDelete: "CASCADE",
+});
+
 /**
  * Configuration of Agent generation.
  */
@@ -155,12 +161,6 @@ AgentGenerationConfiguration.init(
     sequelize: front_sequelize,
   }
 );
-
-//  Agent config <> Workspace
-Workspace.hasMany(AgentConfiguration, {
-  foreignKey: { name: "workspaceId", allowNull: true }, // null = global Agent
-  onDelete: "CASCADE",
-});
 
 // Agent config <> Generation config
 AgentGenerationConfiguration.hasOne(AgentConfiguration, {

--- a/front/lib/models/assistant/agent.ts
+++ b/front/lib/models/assistant/agent.ts
@@ -16,6 +16,57 @@ import {
 } from "@app/types/assistant/agent";
 
 /**
+ * Configuration of Agent generation.
+ */
+export class AgentGenerationConfiguration extends Model<
+  InferAttributes<AgentGenerationConfiguration>,
+  InferCreationAttributes<AgentGenerationConfiguration>
+> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare prompt: string;
+  declare providerId: string;
+  declare modelId: string;
+}
+AgentGenerationConfiguration.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    prompt: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+    },
+    providerId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    modelId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+  },
+  {
+    modelName: "agent_generation_configuration",
+    sequelize: front_sequelize,
+  }
+);
+
+/**
  * Agent configuration
  */
 export class AgentConfiguration extends Model<
@@ -110,59 +161,14 @@ Workspace.hasMany(AgentConfiguration, {
   foreignKey: { name: "workspaceId", allowNull: true }, // null = global Agent
   onDelete: "CASCADE",
 });
-
-/**
- * Configuration of Agent generation.
- */
-export class AgentGenerationConfiguration extends Model<
-  InferAttributes<AgentGenerationConfiguration>,
-  InferCreationAttributes<AgentGenerationConfiguration>
-> {
-  declare id: CreationOptional<number>;
-  declare createdAt: CreationOptional<Date>;
-  declare updatedAt: CreationOptional<Date>;
-
-  declare prompt: string;
-  declare providerId: string;
-  declare modelId: string;
-}
-AgentGenerationConfiguration.init(
-  {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
-    createdAt: {
-      type: DataTypes.DATE,
-      allowNull: false,
-      defaultValue: DataTypes.NOW,
-    },
-    updatedAt: {
-      type: DataTypes.DATE,
-      allowNull: false,
-      defaultValue: DataTypes.NOW,
-    },
-    prompt: {
-      type: DataTypes.TEXT,
-      allowNull: false,
-    },
-    providerId: {
-      type: DataTypes.STRING,
-      allowNull: false,
-    },
-    modelId: {
-      type: DataTypes.STRING,
-      allowNull: false,
-    },
-  },
-  {
-    modelName: "agent_generation_configuration",
-    sequelize: front_sequelize,
-  }
-);
+AgentConfiguration.belongsTo(Workspace, {
+  foreignKey: { name: "workspaceId", allowNull: true }, // null = global Agent
+});
 
 // Agent config <> Generation config
 AgentGenerationConfiguration.hasOne(AgentConfiguration, {
+  foreignKey: { name: "generationConfigurationId", allowNull: true }, // null = no generation set for this Agent
+});
+AgentConfiguration.belongsTo(AgentGenerationConfiguration, {
   foreignKey: { name: "generationConfigurationId", allowNull: true }, // null = no generation set for this Agent
 });

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -30,6 +30,8 @@ export class Conversation extends Model<
   declare sId: string;
   declare title: string | null;
   declare visibility: CreationOptional<ConversationVisibility>;
+
+  declare workspaceId: ForeignKey<Workspace["id"]>;
 }
 
 Conversation.init(
@@ -77,8 +79,12 @@ Conversation.init(
 );
 
 Workspace.hasMany(Conversation, {
-  foreignKey: { allowNull: false },
+  foreignKey: { name: "workspaceId", allowNull: false },
   onDelete: "CASCADE",
+});
+
+Conversation.belongsTo(Workspace, {
+  foreignKey: { name: "workspaceId", allowNull: false },
 });
 
 export class UserMessage extends Model<
@@ -151,6 +157,9 @@ UserMessage.init(
 User.hasMany(UserMessage, {
   foreignKey: { name: "userId", allowNull: true }, // null = message is not associated with a user
 });
+UserMessage.belongsTo(User, {
+  foreignKey: { name: "userId", allowNull: true },
+});
 
 export class AgentMessage extends Model<
   InferAttributes<AgentMessage>,
@@ -220,12 +229,16 @@ AgentMessage.init(
 AgentRetrievalAction.hasOne(AgentMessage, {
   foreignKey: { name: "agentRetrievalActionId", allowNull: true }, // null = no retrieval action set for this Agent
   onDelete: "CASCADE",
-  as: "agentRetrievalAction",
+});
+AgentMessage.belongsTo(AgentRetrievalAction, {
+  foreignKey: { name: "agentRetrievalActionId", allowNull: true }, // null = no retrieval action set for this Agent
 });
 
 AgentConfiguration.hasMany(AgentMessage, {
   foreignKey: { name: "agentConfigurationId", allowNull: false },
-  as: "agentConfiguration",
+});
+AgentMessage.belongsTo(AgentConfiguration, {
+  foreignKey: { name: "agentConfigurationId", allowNull: false },
 });
 
 export class Message extends Model<
@@ -313,18 +326,29 @@ Message.init(
     },
   }
 );
+
 Conversation.hasMany(Message, {
   foreignKey: { name: "conversationId", allowNull: false },
   onDelete: "CASCADE",
 });
+Message.belongsTo(Conversation, {
+  foreignKey: { name: "conversationId", allowNull: false },
+});
+
 UserMessage.hasOne(Message, {
   foreignKey: "userMessageId",
-  as: "userMessage",
 });
+Message.belongsTo(UserMessage, {
+  foreignKey: "userMessageId",
+});
+
 AgentMessage.hasOne(Message, {
   foreignKey: "agentMessageId",
-  as: "agentMessage",
 });
+Message.belongsTo(AgentMessage, {
+  foreignKey: "agentMessageId",
+});
+
 Message.belongsTo(Message, {
   foreignKey: "parentId",
 });
@@ -373,11 +397,20 @@ Message.hasMany(Mention, {
   foreignKey: { name: "messageId", allowNull: false },
   onDelete: "CASCADE",
 });
+Mention.belongsTo(Message, {
+  foreignKey: { name: "messageId", allowNull: false },
+});
+
 User.hasMany(Mention, {
   foreignKey: { name: "userId", allowNull: true }, // null = mention is not a user mention
-  as: "user",
 });
+Mention.belongsTo(User, {
+  foreignKey: { name: "userId", allowNull: true }, // null = mention is not a user mention
+});
+
 AgentConfiguration.hasMany(Mention, {
   foreignKey: { name: "agentConfigurationId", allowNull: true }, // null = mention is not an agent mention
-  as: "agentConfiguration",
+});
+Mention.belongsTo(AgentConfiguration, {
+  foreignKey: { name: "agentConfigurationId", allowNull: true }, // null = mention is not an agent mention
 });

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -95,7 +95,7 @@ export class UserMessage extends Model<
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
-  declare message: string;
+  declare content: string;
 
   declare userContextUsername: string;
   declare userContextTimezone: string;
@@ -123,7 +123,7 @@ UserMessage.init(
       allowNull: false,
       defaultValue: DataTypes.NOW,
     },
-    message: {
+    content: {
       type: DataTypes.TEXT,
       allowNull: false,
     },
@@ -171,7 +171,7 @@ export class AgentMessage extends Model<
 
   declare status: CreationOptional<AgentMessageStatus>;
 
-  declare message: string | null;
+  declare content: string | null;
   declare errorCode: string | null;
   declare errorMessage: string | null;
 
@@ -201,7 +201,7 @@ AgentMessage.init(
       allowNull: false,
       defaultValue: "created",
     },
-    message: {
+    content: {
       type: DataTypes.TEXT,
       allowNull: true,
     },
@@ -336,21 +336,21 @@ Message.belongsTo(Conversation, {
 });
 
 UserMessage.hasOne(Message, {
-  foreignKey: "userMessageId",
+  foreignKey: { name: "userMessageId", allowNull: true },
 });
 Message.belongsTo(UserMessage, {
-  foreignKey: "userMessageId",
+  foreignKey: { name: "userMessageId", allowNull: true },
 });
 
 AgentMessage.hasOne(Message, {
-  foreignKey: "agentMessageId",
+  foreignKey: { name: "agentMessageId", allowNull: true },
 });
 Message.belongsTo(AgentMessage, {
-  foreignKey: "agentMessageId",
+  foreignKey: { name: "agentMessageId", allowNull: true },
 });
 
 Message.belongsTo(Message, {
-  foreignKey: "parentId",
+  foreignKey: { name: "parentId", allowNull: true },
 });
 
 export class Mention extends Model<

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -10,6 +10,7 @@ import {
 
 import { front_sequelize } from "@app/lib/databases";
 import { AgentRetrievalAction } from "@app/lib/models/assistant/actions/retrieval";
+import { AgentConfiguration } from "@app/lib/models/assistant/agent";
 import { User } from "@app/lib/models/user";
 import { Workspace } from "@app/lib/models/workspace";
 import {
@@ -17,8 +18,6 @@ import {
   ConversationVisibility,
   MessageVisibility,
 } from "@app/types/assistant/conversation";
-
-import { AgentConfiguration } from "./agent";
 
 export class Conversation extends Model<
   InferAttributes<Conversation>,

--- a/front/lib/models/index.ts
+++ b/front/lib/models/index.ts
@@ -13,6 +13,7 @@ import {
 import {
   AgentMessage,
   Conversation,
+  Mention,
   Message,
   UserMessage,
 } from "@app/lib/models/assistant/conversation";
@@ -59,6 +60,7 @@ export {
   Key,
   Membership,
   MembershipInvitation,
+  Mention,
   Message,
   Provider,
   RetrievalDocument,

--- a/front/pages/api/v1/w/[wId]/assistant/[cId]/messages/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/[cId]/messages/index.ts
@@ -76,7 +76,7 @@ async function handler(
       void postUserMessageWithPubSub(auth, {
         conversation: {
           id: conv.id,
-          created: conv.created.getTime(),
+          created: conv.createdAt.getTime(),
           sId: conv.sId,
           title: conv.title,
           // not sure how to provide the content here for now.

--- a/front/pages/api/v1/w/[wId]/assistant/[cId]/messages/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/[cId]/messages/index.ts
@@ -59,7 +59,7 @@ async function handler(
   // no time for actual io-ts parsing right now, so here is the expected structure.
   // Will handle proper parsing later.
   const payload = req.body as {
-    message: string;
+    content: string;
     context: {
       timezone: string;
       username: string;
@@ -83,7 +83,7 @@ async function handler(
           content: [],
           visibility: conv.visibility,
         },
-        message: payload.message,
+        content: payload.content,
         mentions: [],
         context: {
           timezone: payload.context.timezone,

--- a/front/pages/api/v1/w/[wId]/assistant/conversation/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversation/index.ts
@@ -47,12 +47,11 @@ async function handler(
       const conv = await Conversation.create({
         sId: generateModelSId(),
         title: req.body.title,
-        created: new Date(),
         visibility: req.body.visibility,
       });
       return res.status(200).json({
         id: conv.id,
-        created: conv.created.getTime(),
+        created: conv.createdAt.getTime(),
         sId: conv.sId,
         title: conv.title,
         visibility: conv.visibility,

--- a/front/types/assistant/actions/retrieval.ts
+++ b/front/types/assistant/actions/retrieval.ts
@@ -99,7 +99,6 @@ export type RetrievalActionType = {
   id: ModelId; // AgentRetrieval.
   type: "retrieval_action";
   params: {
-    dataSources: "all" | DataSourceConfiguration[];
     relativeTimeFrame: TimeFrame | null;
     query: string | null;
     topK: number;

--- a/front/types/assistant/actions/retrieval.ts
+++ b/front/types/assistant/actions/retrieval.ts
@@ -99,6 +99,7 @@ export type RetrievalActionType = {
   id: ModelId; // AgentRetrieval.
   type: "retrieval_action";
   params: {
+    dataSources: "all" | DataSourceConfiguration[];
     relativeTimeFrame: TimeFrame | null;
     query: string | null;
     topK: number;

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -61,6 +61,7 @@ export type AgentConfigurationStatus = "active" | "archived";
 export type AgentConfigurationScope = "global" | "workspace";
 
 export type AgentConfigurationType = {
+  id: ModelId;
   sId: string;
   status: AgentConfigurationStatus;
 

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -55,7 +55,7 @@ export type UserMessageType = {
   version: number;
   user: UserType | null;
   mentions: MentionType[];
-  message: string;
+  content: string;
   context: UserMessageContext;
 };
 
@@ -96,7 +96,7 @@ export type AgentMessageType = {
   configuration: AgentConfigurationType;
   status: AgentMessageStatus;
   action: AgentActionType | null;
-  message: string | null;
+  content: string | null;
   feedbacks: UserFeedbackType[];
   error: {
     code: string;

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -9,23 +9,25 @@ import { AgentConfigurationType } from "./agent";
  */
 
 export type AgentMention = {
+  id: ModelId;
   configurationId: string;
 };
 
 export type UserMention = {
+  id: ModelId;
   provider: string;
   providerId: string;
 };
 
-export type Mention = AgentMention | UserMention;
+export type MentionType = AgentMention | UserMention;
 
 export type MessageVisibility = "visible" | "deleted";
 
-export function isAgentMention(arg: Mention): arg is AgentMention {
+export function isAgentMention(arg: MentionType): arg is AgentMention {
   return (arg as AgentMention).configurationId !== undefined;
 }
 
-export function isUserMention(arg: Mention): arg is UserMention {
+export function isUserMention(arg: MentionType): arg is UserMention {
   const maybeUserMention = arg as UserMention;
   return (
     maybeUserMention.provider !== undefined &&
@@ -52,7 +54,7 @@ export type UserMessageType = {
   visibility: MessageVisibility;
   version: number;
   user: UserType | null;
-  mentions: Mention[];
+  mentions: MentionType[];
   message: string;
   context: UserMessageContext;
 };
@@ -112,7 +114,7 @@ export function isAgentMessageType(
  * Conversations
  */
 
-export type ConversationVisibility = "private" | "workspace";
+export type ConversationVisibility = "unlisted" | "workspace";
 
 /**
  * content [][] structure is intended to allow retries (of agent messages) or edits (of user
@@ -123,6 +125,6 @@ export type ConversationType = {
   created: number;
   sId: string;
   title: string | null;
-  content: (UserMessageType[] | AgentMessageType[])[];
   visibility: ConversationVisibility;
+  content: (UserMessageType[] | AgentMessageType[])[];
 };


### PR DESCRIPTION
Fixes #1320 #1319

This implements conversation creation and update and more importantly conversation retrieval whose role is to render the entire conversation from all the models that are backing it

This is the direction I'm taking:

Try to lean on sequelize to retrieve joined models when possible:
  - userMessage / agentMessage for Message retrieval
  - do the same for AgentRetrievalConfiguration retrieval

So we have 1 query to get the list of UserMessage and AgentMessage

Then in parallel we render all messages at once. 
- for UserMessage that means mostly retrieving the Mentions
- for AgentMessage that means retrieving the Action and the Configuration of the Agent that took the action in parallel

So we have 1 big query then in parallel 1 small query for each user message and for agent message in parallel retrieving the action (1 query, maybe I can do it as an `include` directly in the initial query) and rely on our future logic to get an action configuration. This won't be doable in one query because there's an array of DataSourceConfiguration to be retrieved so likely 2 queries.

So modulo parallelism the we should be able to have only 2-3 queries sequenced to reconstruct everything.