### PR TITLE
Agent config: update models

### DIFF
--- a/front/lib/models/assistant/actions/retrieval.ts
+++ b/front/lib/models/assistant/actions/retrieval.ts
@@ -187,7 +187,7 @@ AgentRetrievalConfiguration.hasOne(AgentConfiguration, {
 });
 
 // Retrieval config <> Data source config
-AgentRetrievalConfiguration.hasOne(AgentDataSourceConfiguration, {
+AgentRetrievalConfiguration.hasMany(AgentDataSourceConfiguration, {
   foreignKey: { name: "retrievalConfigurationId", allowNull: false },
   onDelete: "CASCADE",
 });

--- a/front/lib/models/assistant/actions/retrieval.ts
+++ b/front/lib/models/assistant/actions/retrieval.ts
@@ -29,8 +29,6 @@ export class AgentRetrievalConfiguration extends Model<
   declare relativeTimeFrameDuration: number | null;
   declare relativeTimeFrameUnit: TimeframeUnit | null;
   declare topK: number;
-
-  declare agentId: ForeignKey<AgentConfiguration["id"]>;
 }
 AgentRetrievalConfiguration.init(
   {
@@ -117,18 +115,13 @@ export class AgentDataSourceConfiguration extends Model<
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
-  declare timeframeDuration: number | null;
-  declare timeframeUnit: TimeframeUnit | null;
-
   declare tagsIn: string[] | null;
   declare tagsNotIn: string[] | null;
   declare parentsIn: string[] | null;
   declare parentsNotIn: string[] | null;
 
   declare dataSourceId: ForeignKey<DataSource["id"]>;
-  declare retrievalConfigurationId: ForeignKey<
-    AgentRetrievalConfiguration["id"]
-  >;
+  declare retrievalConfigId: ForeignKey<AgentRetrievalConfiguration["id"]>;
 }
 AgentDataSourceConfiguration.init(
   {
@@ -146,14 +139,6 @@ AgentDataSourceConfiguration.init(
       type: DataTypes.DATE,
       allowNull: false,
       defaultValue: DataTypes.NOW,
-    },
-    timeframeDuration: {
-      type: DataTypes.INTEGER,
-      allowNull: true,
-    },
-    timeframeUnit: {
-      type: DataTypes.STRING,
-      allowNull: true,
     },
     tagsIn: {
       type: DataTypes.ARRAY(DataTypes.STRING),
@@ -178,27 +163,36 @@ AgentDataSourceConfiguration.init(
     hooks: {
       beforeValidate: (dataSourceConfig: AgentDataSourceConfiguration) => {
         if (
-          (dataSourceConfig.timeframeDuration === null) !==
-          (dataSourceConfig.timeframeUnit === null)
+          (dataSourceConfig.tagsIn === null) !==
+          (dataSourceConfig.tagsNotIn === null)
         ) {
-          throw new Error(
-            "Timeframe duration/unit must be both set or both null"
-          );
+          throw new Error("Tags must be both set or both null");
+        }
+        if (
+          (dataSourceConfig.parentsIn === null) !==
+          (dataSourceConfig.parentsNotIn === null)
+        ) {
+          throw new Error("Parents must be both set or both null");
         }
       },
     },
   }
 );
 
-// Retrieval config <> data source config
-AgentRetrievalConfiguration.hasMany(AgentDataSourceConfiguration, {
-  foreignKey: { name: "retrievalId", allowNull: false },
+// Agent config <> Retrieval config
+AgentRetrievalConfiguration.hasOne(AgentConfiguration, {
+  foreignKey: { name: "retrievalConfigId", allowNull: true }, // null = no retrieval action set for this Agent
+});
+
+// Retrieval config <> Data source config
+AgentRetrievalConfiguration.hasOne(AgentDataSourceConfiguration, {
+  foreignKey: { name: "retrievalConfigId", allowNull: false },
   onDelete: "CASCADE",
 });
 
-// Agent config <> Retrieval config
-AgentConfiguration.hasOne(AgentRetrievalConfiguration, {
-  foreignKey: { name: "agentId", allowNull: true }, // null = no generation set for this Agent
+// Data source config <> Data source
+DataSource.hasMany(AgentDataSourceConfiguration, {
+  foreignKey: { name: "dataSourceId", allowNull: false },
   onDelete: "CASCADE",
 });
 

--- a/front/lib/models/assistant/actions/retrieval.ts
+++ b/front/lib/models/assistant/actions/retrieval.ts
@@ -121,7 +121,9 @@ export class AgentDataSourceConfiguration extends Model<
   declare parentsNotIn: string[] | null;
 
   declare dataSourceId: ForeignKey<DataSource["id"]>;
-  declare retrievalConfigId: ForeignKey<AgentRetrievalConfiguration["id"]>;
+  declare retrievalConfigurationId: ForeignKey<
+    AgentRetrievalConfiguration["id"]
+  >;
 }
 AgentDataSourceConfiguration.init(
   {
@@ -181,12 +183,12 @@ AgentDataSourceConfiguration.init(
 
 // Agent config <> Retrieval config
 AgentRetrievalConfiguration.hasOne(AgentConfiguration, {
-  foreignKey: { name: "retrievalConfigId", allowNull: true }, // null = no retrieval action set for this Agent
+  foreignKey: { name: "retrievalConfigurationId", allowNull: true }, // null = no retrieval action set for this Agent
 });
 
 // Retrieval config <> Data source config
 AgentRetrievalConfiguration.hasOne(AgentDataSourceConfiguration, {
-  foreignKey: { name: "retrievalConfigId", allowNull: false },
+  foreignKey: { name: "retrievalConfigurationId", allowNull: false },
   onDelete: "CASCADE",
 });
 

--- a/front/lib/models/assistant/agent.ts
+++ b/front/lib/models/assistant/agent.ts
@@ -30,11 +30,15 @@ export class AgentConfiguration extends Model<
   declare status: AgentConfigurationStatus;
   declare name: string;
   declare pictureUrl: string | null;
-
   declare scope: AgentConfigurationScope;
-  declare workspaceId: ForeignKey<Workspace["id"]> | null; // null = it's a global agent
 
-  declare model: ForeignKey<AgentRetrievalConfiguration["id"]> | null;
+  declare workspaceId: ForeignKey<Workspace["id"]> | null; // null = it's a global agent
+  declare generationConfigId: ForeignKey<
+    AgentGenerationConfiguration["id"]
+  > | null;
+  declare retrievalConfigId: ForeignKey<
+    AgentRetrievalConfiguration["id"]
+  > | null;
 }
 AgentConfiguration.init(
   {
@@ -113,10 +117,8 @@ export class AgentGenerationConfiguration extends Model<
   declare updatedAt: CreationOptional<Date>;
 
   declare prompt: string;
-  declare modelProvider: string;
+  declare providerId: string;
   declare modelId: string;
-
-  declare agentId: ForeignKey<AgentConfiguration["id"]>;
 }
 AgentGenerationConfiguration.init(
   {
@@ -139,7 +141,7 @@ AgentGenerationConfiguration.init(
       type: DataTypes.TEXT,
       allowNull: false,
     },
-    modelProvider: {
+    providerId: {
       type: DataTypes.STRING,
       allowNull: false,
     },
@@ -154,14 +156,13 @@ AgentGenerationConfiguration.init(
   }
 );
 
-// Workspace <> Agent config
+//  Agent config <> Workspace
 Workspace.hasMany(AgentConfiguration, {
   foreignKey: { name: "workspaceId", allowNull: true }, // null = global Agent
   onDelete: "CASCADE",
 });
 
 // Agent config <> Generation config
-AgentConfiguration.hasOne(AgentGenerationConfiguration, {
-  foreignKey: { name: "agentId", allowNull: false }, // null = no retrieval action set for this Agent
-  onDelete: "CASCADE",
+AgentGenerationConfiguration.hasOne(AgentConfiguration, {
+  foreignKey: { name: "generationConfigId", allowNull: true }, // null = no generation set for this Agent
 });

--- a/front/lib/models/assistant/agent.ts
+++ b/front/lib/models/assistant/agent.ts
@@ -33,10 +33,10 @@ export class AgentConfiguration extends Model<
   declare scope: AgentConfigurationScope;
 
   declare workspaceId: ForeignKey<Workspace["id"]> | null; // null = it's a global agent
-  declare generationConfigId: ForeignKey<
+  declare generationConfigurationId: ForeignKey<
     AgentGenerationConfiguration["id"]
   > | null;
-  declare retrievalConfigId: ForeignKey<
+  declare retrievalConfigurationId: ForeignKey<
     AgentRetrievalConfiguration["id"]
   > | null;
 }
@@ -164,5 +164,5 @@ Workspace.hasMany(AgentConfiguration, {
 
 // Agent config <> Generation config
 AgentGenerationConfiguration.hasOne(AgentConfiguration, {
-  foreignKey: { name: "generationConfigId", allowNull: true }, // null = no generation set for this Agent
+  foreignKey: { name: "generationConfigurationId", allowNull: true }, // null = no generation set for this Agent
 });


### PR DESCRIPTION
- Changes the relation: agentConfig stores the id to the generation config and retrieval config
- Remove timeframe config from AgentDataSourceConfiguration (stored in the retrieval)
- rename modelProvider to providerId on the generation configuration
- removes `model` from AgentConfiguration that looks like a mistake