### PR TITLE
Agent config: can't select all datasources

### DIFF
--- a/front/types/assistant/actions/retrieval.ts
+++ b/front/types/assistant/actions/retrieval.ts
@@ -43,7 +43,7 @@ export type RetrievalConfigurationType = {
   id: ModelId;
 
   type: "retrieval_configuration";
-  dataSources: "all" | DataSourceConfiguration[];
+  dataSources: DataSourceConfiguration[];
   query: "auto" | "none" | TemplatedQuery;
   relativeTimeFrame: "auto" | "none" | TimeFrame;
   topK: number;


### PR DESCRIPTION
Removing option to select all dataSources in agent configuration. 
Review with hidden whitespaces: https://github.com/dust-tt/dust/pull/1333/files?diff=split&w=1

