### PR TITLE
fix unexpected undefined in slack uk user retrieval

### DIFF
--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -702,7 +702,7 @@ export async function getUserName(
 
   const info = await slackClient.users.info({ user: slackUserId });
 
-  if (info.user?.name) {
+  if (info && info.user?.name) {
     await cacheSet(getUserCacheKey(slackUserId, connectorId), info.user.name);
     return info.user.name;
   }


### PR DESCRIPTION
It seems we unexpectedly get an undefined info as per https://app.datadoghq.eu/logs?query=%22Unhandled%20Activity%20Error%22%20&cols=host%2Cservice&event=AgAAAYp2Zef29dNWfAAAAAAAAAAYAAAAAEFZcDJaZWk1QUFBdzFXbjI4a3lxNUFBSQAAACQAAAAAMDE4YTc2NjUtZWU0OS00MjAxLTk2MDktOTkwYmZkOTEzMDlm&index=%2A&messageDisplay=inline&refresh_mode=sliding&stream_sort=desc&viz=stream&from_ts=1694199913529&to_ts=1694203513529&live=true

