### PR TITLE
Enabling eslint rule for front: react-hooks/exhaustive-deps

### DIFF
--- a/front/.eslintrc.js
+++ b/front/.eslintrc.js
@@ -20,7 +20,6 @@ module.exports = {
     "@typescript-eslint/no-explicit-any": 0,
     "no-case-declarations": 0,
     "react-hooks/rules-of-hooks": 0,
-    "react-hooks/exhaustive-deps": 0,
     "@next/next/no-img-element": 0,
     "@typescript-eslint/no-floating-promises": "error",
     "jsx-a11y/alt-text": 0,

--- a/front/components/app/DatasetView.tsx
+++ b/front/components/app/DatasetView.tsx
@@ -9,7 +9,7 @@ import {
   XCircleIcon,
 } from "@dust-tt/sparkle";
 import dynamic from "next/dynamic";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import TextareaAutosize from "react-textarea-autosize";
 
 import { checkDatasetData } from "@app/lib/datasets";
@@ -118,7 +118,7 @@ export default function DatasetView({
   const [datasetTypes, setDatasetTypes] = useState([] as string[]);
   const [datasetInitializing, setDatasetInitializing] = useState(true);
 
-  const datasetNameValidation = useCallback(() => {
+  const datasetNameValidation = () => {
     let valid = true;
 
     let exists = false;
@@ -144,20 +144,9 @@ export default function DatasetView({
     }
 
     return valid;
-  }, [dataset?.name, datasetName, datasets]);
+  };
 
-  const inferDatasetTypes = useCallback(() => {
-    if (datasetData.length > 0) {
-      setDatasetTypes(getDatasetTypes(datasetKeys, datasetData[0]));
-      if (datasetInitializing) {
-        setTimeout(() => {
-          setDatasetInitializing(false);
-        }, 10);
-      }
-    }
-  }, [datasetData, datasetInitializing, datasetKeys]);
-
-  const datasetTypesValidation = useCallback(() => {
+  const datasetTypesValidation = () => {
     // Initial inference of types
     if (datasetTypes.length == 0) {
       inferDatasetTypes();
@@ -174,10 +163,10 @@ export default function DatasetView({
     });
 
     return valid;
-  }, [datasetData, datasetKeys, datasetTypes, inferDatasetTypes]);
+  };
 
   // Export the dataset with correct types (post-editing and validation)
-  const exportDataset = useCallback(() => {
+  const exportDataset = () => {
     const finalDataset = [] as any[];
 
     datasetData.map((d, i) => {
@@ -198,7 +187,18 @@ export default function DatasetView({
     });
 
     return finalDataset;
-  }, [datasetData, datasetKeys, datasetTypes]);
+  };
+
+  const inferDatasetTypes = () => {
+    if (datasetData.length > 0) {
+      setDatasetTypes(getDatasetTypes(datasetKeys, datasetData[0]));
+      if (datasetInitializing) {
+        setTimeout(() => {
+          setDatasetInitializing(false);
+        }, 10);
+      }
+    }
+  };
 
   const handleKeyUpdate = (i: number, newKey: string) => {
     const oldKey = datasetKeys[i];
@@ -361,18 +361,8 @@ export default function DatasetView({
         data: exportDataset(),
       });
     }
-  }, [
-    datasetName,
-    datasetDescription,
-    datasetData,
-    datasetKeys,
-    datasetTypes,
-    datasetTypesValidation,
-    datasetNameValidation,
-    onUpdate,
-    datasetInitializing,
-    exportDataset,
-  ]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [datasetName, datasetDescription, datasetData, datasetKeys, datasetTypes]);
 
   return (
     <div>

--- a/front/components/app/DatasetView.tsx
+++ b/front/components/app/DatasetView.tsx
@@ -9,7 +9,7 @@ import {
   XCircleIcon,
 } from "@dust-tt/sparkle";
 import dynamic from "next/dynamic";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import TextareaAutosize from "react-textarea-autosize";
 
 import { checkDatasetData } from "@app/lib/datasets";
@@ -118,7 +118,7 @@ export default function DatasetView({
   const [datasetTypes, setDatasetTypes] = useState([] as string[]);
   const [datasetInitializing, setDatasetInitializing] = useState(true);
 
-  const datasetNameValidation = () => {
+  const datasetNameValidation = useCallback(() => {
     let valid = true;
 
     let exists = false;
@@ -144,9 +144,20 @@ export default function DatasetView({
     }
 
     return valid;
-  };
+  }, [dataset?.name, datasetName, datasets]);
 
-  const datasetTypesValidation = () => {
+  const inferDatasetTypes = useCallback(() => {
+    if (datasetData.length > 0) {
+      setDatasetTypes(getDatasetTypes(datasetKeys, datasetData[0]));
+      if (datasetInitializing) {
+        setTimeout(() => {
+          setDatasetInitializing(false);
+        }, 10);
+      }
+    }
+  }, [datasetData, datasetInitializing, datasetKeys]);
+
+  const datasetTypesValidation = useCallback(() => {
     // Initial inference of types
     if (datasetTypes.length == 0) {
       inferDatasetTypes();
@@ -163,10 +174,10 @@ export default function DatasetView({
     });
 
     return valid;
-  };
+  }, [datasetData, datasetKeys, datasetTypes, inferDatasetTypes]);
 
   // Export the dataset with correct types (post-editing and validation)
-  const exportDataset = () => {
+  const exportDataset = useCallback(() => {
     const finalDataset = [] as any[];
 
     datasetData.map((d, i) => {
@@ -187,18 +198,7 @@ export default function DatasetView({
     });
 
     return finalDataset;
-  };
-
-  const inferDatasetTypes = () => {
-    if (datasetData.length > 0) {
-      setDatasetTypes(getDatasetTypes(datasetKeys, datasetData[0]));
-      if (datasetInitializing) {
-        setTimeout(() => {
-          setDatasetInitializing(false);
-        }, 10);
-      }
-    }
-  };
+  }, [datasetData, datasetKeys, datasetTypes]);
 
   const handleKeyUpdate = (i: number, newKey: string) => {
     const oldKey = datasetKeys[i];
@@ -361,7 +361,18 @@ export default function DatasetView({
         data: exportDataset(),
       });
     }
-  }, [datasetName, datasetDescription, datasetData, datasetKeys, datasetTypes]);
+  }, [
+    datasetName,
+    datasetDescription,
+    datasetData,
+    datasetKeys,
+    datasetTypes,
+    datasetTypesValidation,
+    datasetNameValidation,
+    onUpdate,
+    datasetInitializing,
+    exportDataset,
+  ]);
 
   return (
     <div>

--- a/front/components/data_source/DataSourcePicker.tsx
+++ b/front/components/data_source/DataSourcePicker.tsx
@@ -49,14 +49,8 @@ export default function DataSourcePicker({
         onDataSourcesUpdate([]);
       }
     }
-  }, [
-    readOnly,
-    isDataSourcesLoading,
-    isDataSourcesError,
-    dataSources,
-    name,
-    onDataSourcesUpdate,
-  ]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [readOnly, isDataSourcesLoading, isDataSourcesError, dataSources, name]);
 
   useEffect(() => {
     if (

--- a/front/components/data_source/DataSourcePicker.tsx
+++ b/front/components/data_source/DataSourcePicker.tsx
@@ -49,7 +49,14 @@ export default function DataSourcePicker({
         onDataSourcesUpdate([]);
       }
     }
-  }, [readOnly, isDataSourcesLoading, isDataSourcesError, dataSources, name]);
+  }, [
+    readOnly,
+    isDataSourcesLoading,
+    isDataSourcesError,
+    dataSources,
+    name,
+    onDataSourcesUpdate,
+  ]);
 
   useEffect(() => {
     if (

--- a/front/components/home/particles.tsx
+++ b/front/components/home/particles.tsx
@@ -337,7 +337,7 @@ export default function Particules({
       //window.removeEventListener("scroll", onScroll, false);
       renderer.dispose();
     };
-  }, []);
+  }, [scrollRef1, scrollRef2, scrollRef3]);
 
   return (
     <div id="canvas-container">

--- a/front/components/home/scrollingHeader.tsx
+++ b/front/components/home/scrollingHeader.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import React, { ReactNode, useEffect, useState } from "react";
+import React, { ReactNode, useCallback, useEffect, useState } from "react";
 
 // Define your scroll limit here
 const SCROLL_LIMIT_1 = 12;
@@ -16,15 +16,15 @@ const ScrollingHeader = ({
   const [isScrolled1, setIsScrolled1] = useState(false);
   const [isScrolled2, setIsScrolled2] = useState(false);
 
-  const checkScroll = () => {
+  const checkScroll = useCallback(() => {
     setIsScrolled1(window.scrollY > SCROLL_LIMIT_1);
     setIsScrolled2(window.scrollY > showItemY); // use here
-  };
+  }, [showItemY]);
 
   useEffect(() => {
     window.addEventListener("scroll", checkScroll);
     return () => window.removeEventListener("scroll", checkScroll);
-  }, [showItemY]); // add here
+  }, [checkScroll, showItemY]); // add here
 
   useEffect(() => {
     const invisibleFirstElements = document.querySelectorAll(".invisibleFirst");

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -5,9 +5,8 @@ import {
 import { runAction } from "@app/lib/actions/server";
 import { generateActionInputs } from "@app/lib/api/assistant/agent";
 import { ModelMessageType } from "@app/lib/api/assistant/generation";
-import { Authenticator, prodAPICredentialsForOwner } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
 import { front_sequelize } from "@app/lib/databases";
-import { DustAPI } from "@app/lib/dust_api";
 import {
   AgentRetrievalAction,
   RetrievalDocument,

--- a/front/lib/front.js
+++ b/front/lib/front.js
@@ -32,5 +32,5 @@ export function useRegisterUnloadHandlers(
     return () => {
       router.events.off("routeChangeStart", confirmBrowseAway);
     };
-  }, [editorDirty, router]);
+  }, [editorDirty, router, unloadWarning]);
 }

--- a/front/pages/api/v1/w/[wId]/assistant/conversation/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversation/index.ts
@@ -16,7 +16,7 @@ async function handler(
     return apiError(req, res, keyRes.error);
   }
 
-  const { auth, keyWorkspaceId } = await Authenticator.fromKey(
+  const { keyWorkspaceId } = await Authenticator.fromKey(
     keyRes.value,
     req.query.wId as string
   );

--- a/front/pages/w/[wId]/a/[aId]/clone.tsx
+++ b/front/pages/w/[wId]/a/[aId]/clone.tsx
@@ -3,7 +3,7 @@ import { ChevronRightIcon } from "@heroicons/react/20/solid";
 import { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
@@ -81,7 +81,7 @@ export default function CloneView({
   const [targetWorkspace, setTargetWorkspace] = useState(user.workspaces[0]);
   const [cloning, setCloning] = useState(false);
 
-  const formValidation = () => {
+  const formValidation = useCallback(() => {
     if (appName.length == 0) {
       setAppNameError("");
       return false;
@@ -95,11 +95,11 @@ export default function CloneView({
       setAppNameError("");
       return true;
     }
-  };
+  }, [appName]);
 
   useEffect(() => {
     setDisabled(!formValidation());
-  }, [appName]);
+  }, [appName, formValidation]);
 
   const router = useRouter();
 

--- a/front/pages/w/[wId]/a/[aId]/clone.tsx
+++ b/front/pages/w/[wId]/a/[aId]/clone.tsx
@@ -3,7 +3,7 @@ import { ChevronRightIcon } from "@heroicons/react/20/solid";
 import { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
@@ -81,7 +81,7 @@ export default function CloneView({
   const [targetWorkspace, setTargetWorkspace] = useState(user.workspaces[0]);
   const [cloning, setCloning] = useState(false);
 
-  const formValidation = useCallback(() => {
+  const formValidation = () => {
     if (appName.length == 0) {
       setAppNameError("");
       return false;
@@ -95,11 +95,12 @@ export default function CloneView({
       setAppNameError("");
       return true;
     }
-  }, [appName]);
+  };
 
   useEffect(() => {
     setDisabled(!formValidation());
-  }, [appName, formValidation]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [appName]);
 
   const router = useRouter();
 

--- a/front/pages/w/[wId]/a/[aId]/datasets/[name]/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/datasets/[name]/index.tsx
@@ -104,7 +104,8 @@ export default function ViewDatasetView({
     if (isFinishedEditing) {
       void Router.push(`/w/${owner.sId}/a/${app.sId}/datasets`);
     }
-  }, [app.sId, isFinishedEditing, owner.sId]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isFinishedEditing]);
 
   const onUpdate = (
     initializing: boolean,

--- a/front/pages/w/[wId]/a/[aId]/datasets/[name]/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/datasets/[name]/index.tsx
@@ -104,7 +104,7 @@ export default function ViewDatasetView({
     if (isFinishedEditing) {
       void Router.push(`/w/${owner.sId}/a/${app.sId}/datasets`);
     }
-  }, [isFinishedEditing]);
+  }, [app.sId, isFinishedEditing, owner.sId]);
 
   const onUpdate = (
     initializing: boolean,

--- a/front/pages/w/[wId]/a/[aId]/datasets/new.tsx
+++ b/front/pages/w/[wId]/a/[aId]/datasets/new.tsx
@@ -88,7 +88,7 @@ export default function NewDatasetView({
     if (isFinishedEditing) {
       void Router.push(`/w/${owner.sId}/a/${app.sId}/datasets`);
     }
-  }, [isFinishedEditing]);
+  }, [app.sId, isFinishedEditing, owner.sId]);
 
   const onUpdate = (
     initializing: boolean,

--- a/front/pages/w/[wId]/a/[aId]/datasets/new.tsx
+++ b/front/pages/w/[wId]/a/[aId]/datasets/new.tsx
@@ -88,7 +88,8 @@ export default function NewDatasetView({
     if (isFinishedEditing) {
       void Router.push(`/w/${owner.sId}/a/${app.sId}/datasets`);
     }
-  }, [app.sId, isFinishedEditing, owner.sId]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isFinishedEditing]);
 
   const onUpdate = (
     initializing: boolean,

--- a/front/pages/w/[wId]/a/[aId]/execute/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/execute/index.tsx
@@ -8,7 +8,7 @@ import {
 import { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import dynamic from "next/dynamic";
 import { useRouter } from "next/router";
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import TextareaAutosize from "react-textarea-autosize";
 // TODO: type sse.js or use something else
 // @ts-expect-error there are no types for sse.js.
@@ -380,15 +380,12 @@ export default function ExecuteView({
   );
 
   const [inputData, setInputData] = useState({} as { [key: string]: any });
-  const isInputDataValid = useCallback(
-    () =>
-      inputDatasetKeys.every(
-        (k) =>
-          (inputData[k] || "").length > 0 &&
-          getValueType(inputData[k]) === datasetTypes[k]
-      ),
-    [datasetTypes, inputData, inputDatasetKeys]
-  );
+  const isInputDataValid = () =>
+    inputDatasetKeys.every(
+      (k) =>
+        (inputData[k] || "").length > 0 &&
+        getValueType(inputData[k]) === datasetTypes[k]
+    );
 
   const [isRunning, setIsRunning] = useState(false);
   const [isDoneRunning, setIsDoneRunning] = useState(false);
@@ -421,10 +418,7 @@ export default function ExecuteView({
     return 0;
   });
 
-  const canRun = useCallback(
-    () => !isRunning && isInputDataValid() && savedRun?.app_hash,
-    [isInputDataValid, isRunning, savedRun?.app_hash]
-  );
+  const canRun = () => !isRunning && isInputDataValid() && savedRun?.app_hash;
 
   useEffect(() => {
     if (isDoneRunning) {
@@ -437,14 +431,15 @@ export default function ExecuteView({
 
       setFinalOutputBlockTypeName(`${lastBlock.type}-${lastBlock.name}`);
     }
-  }, [executionLogs.blockOrder, isDoneRunning]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isDoneRunning]);
 
   const handleValueChange = (k: string, value: string) => {
     const newInputData = { [k]: value };
     setInputData({ ...inputData, ...newInputData });
   };
 
-  const handleRun = useCallback(() => {
+  const handleRun = () => {
     setExecutionLogs({
       blockOrder: [],
       lastStatusEventByBlockTypeName: {},
@@ -549,17 +544,15 @@ export default function ExecuteView({
 
       source.stream();
     }, 0);
-  }, [app.sId, config, datasetTypes, inputData, owner.sId, savedRun?.app_hash]);
+  };
 
-  const handleKeyPress = useCallback(
-    (event: KeyboardEvent | React.KeyboardEvent) => {
-      if (event.metaKey === true && event.key === "Enter" && canRun()) {
-        handleRun();
-        return false;
-      }
-    },
-    [canRun, handleRun]
-  );
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const handleKeyPress = (event: KeyboardEvent | React.KeyboardEvent) => {
+    if (event.metaKey === true && event.key === "Enter" && canRun()) {
+      handleRun();
+      return false;
+    }
+  };
 
   useEffect(() => {
     document.addEventListener("keydown", handleKeyPress);

--- a/front/pages/w/[wId]/a/[aId]/settings.tsx
+++ b/front/pages/w/[wId]/a/[aId]/settings.tsx
@@ -2,7 +2,7 @@ import { Button, Tab } from "@dust-tt/sparkle";
 import { ChevronRightIcon } from "@heroicons/react/24/outline";
 import { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
-import { useCallback, useState } from "react";
+import { useState } from "react";
 import { useEffect } from "react";
 
 import AppLayout from "@app/components/sparkle/AppLayout";
@@ -84,7 +84,7 @@ export default function SettingsView({
   const [isDeleting, setIsDeleting] = useState(false);
   const [isUpdating, setIsUpdating] = useState(false);
 
-  const formValidation = useCallback(() => {
+  const formValidation = () => {
     if (appName.length == 0) {
       setAppNameError("");
       return false;
@@ -98,7 +98,7 @@ export default function SettingsView({
       setAppNameError("");
       return true;
     }
-  }, [appName]);
+  };
 
   const router = useRouter();
 
@@ -149,7 +149,9 @@ export default function SettingsView({
 
   useEffect(() => {
     setDisabled(!formValidation());
-  }, [appName, formValidation]);
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [appName]);
 
   return (
     <AppLayout

--- a/front/pages/w/[wId]/a/[aId]/settings.tsx
+++ b/front/pages/w/[wId]/a/[aId]/settings.tsx
@@ -2,7 +2,7 @@ import { Button, Tab } from "@dust-tt/sparkle";
 import { ChevronRightIcon } from "@heroicons/react/24/outline";
 import { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { useEffect } from "react";
 
 import AppLayout from "@app/components/sparkle/AppLayout";
@@ -84,7 +84,7 @@ export default function SettingsView({
   const [isDeleting, setIsDeleting] = useState(false);
   const [isUpdating, setIsUpdating] = useState(false);
 
-  const formValidation = () => {
+  const formValidation = useCallback(() => {
     if (appName.length == 0) {
       setAppNameError("");
       return false;
@@ -98,7 +98,7 @@ export default function SettingsView({
       setAppNameError("");
       return true;
     }
-  };
+  }, [appName]);
 
   const router = useRouter();
 
@@ -149,7 +149,7 @@ export default function SettingsView({
 
   useEffect(() => {
     setDisabled(!formValidation());
-  }, [appName]);
+  }, [appName, formValidation]);
 
   return (
     <AppLayout

--- a/front/pages/w/[wId]/a/new.tsx
+++ b/front/pages/w/[wId]/a/new.tsx
@@ -2,7 +2,7 @@ import { Button, SectionHeader } from "@dust-tt/sparkle";
 import { ChevronRightIcon } from "@heroicons/react/20/solid";
 import { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { subNavigationAdmin } from "@app/components/sparkle/navigation";
@@ -56,7 +56,7 @@ export default function NewApp({
 
   const [creating, setCreating] = useState(false);
 
-  const formValidation = () => {
+  const formValidation = useCallback(() => {
     if (appName.length == 0) {
       setAppNameError("");
       return false;
@@ -70,11 +70,11 @@ export default function NewApp({
       setAppNameError("");
       return true;
     }
-  };
+  }, [appName]);
 
   useEffect(() => {
     setDisabled(!formValidation());
-  }, [appName]);
+  }, [appName, formValidation]);
 
   const router = useRouter();
 

--- a/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
@@ -416,12 +416,12 @@ function ManagedDataSourceView({
         })
         .catch(console.error);
     }
-  }, []);
+  }, [dataSource.name, owner.sId, router]);
 
   useEffect(() => {
     if (connector.lastSyncSuccessfulTime)
       setSynchronizedTimeAgo(timeAgoFrom(connector.lastSyncSuccessfulTime));
-  }, []);
+  }, [connector.lastSyncSuccessfulTime]);
 
   const handleUpdatePermissions = async () => {
     if (!connector) {

--- a/front/pages/w/[wId]/builder/data-sources/[name]/search.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/search.tsx
@@ -139,7 +139,7 @@ export default function DataSourceView({
     return () => {
       isCancelled = true;
     };
-  }, [dataSource.name, searchQuery]);
+  }, [dataSource.name, owner.sId, searchQuery]);
 
   return (
     <AppLayout

--- a/front/pages/w/[wId]/builder/data-sources/[name]/upsert.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/upsert.tsx
@@ -112,7 +112,7 @@ export default function DataSourceUpsert({
         })
         .catch((e) => console.error(e));
     }
-  }, [loadDocumentId]);
+  }, [dataSource.name, loadDocumentId, owner.sId]);
 
   const handleFileLoadedText = (e: any) => {
     const content = e.target.result;

--- a/front/pages/w/[wId]/builder/data-sources/new.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/new.tsx
@@ -2,7 +2,7 @@ import { Button, Checkbox, SectionHeader } from "@dust-tt/sparkle";
 import { ChevronRightIcon } from "@heroicons/react/20/solid";
 import { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { subNavigationAdmin } from "@app/components/sparkle/navigation";
@@ -69,7 +69,7 @@ export default function DataSourceNew({
 
   const [dataSourceDescription, setDataSourceDescription] = useState("");
 
-  const formValidation = () => {
+  const formValidation = useCallback(() => {
     let exists = false;
     dataSources.forEach((d) => {
       if (d.name == dataSourceName) {
@@ -97,11 +97,11 @@ export default function DataSourceNew({
       setDataSourceNameError("");
       return true;
     }
-  };
+  }, [dataSourceName, dataSources]);
 
   useEffect(() => {
     setDisabled(!formValidation());
-  }, [dataSourceName]);
+  }, [dataSourceName, formValidation]);
 
   const router = useRouter();
 

--- a/front/pages/w/[wId]/u/extract/events/[sId]/edit.tsx
+++ b/front/pages/w/[wId]/u/extract/events/[sId]/edit.tsx
@@ -76,7 +76,6 @@ export default function AppExtractEventsCreate({
   user,
   owner,
   event,
-  schema,
   readOnly,
   gaTrackingId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {

--- a/front/pages/w/[wId]/u/gens/index.tsx
+++ b/front/pages/w/[wId]/u/gens/index.tsx
@@ -321,7 +321,8 @@ export function DocumentView({
       console.log("Trying to unmount");
       interruptRef.current = true;
     };
-  }, [document, document.documentId, onExtractUpdate, owner, query]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [document.documentId]);
 
   useEffect(() => {
     const extractInput = [
@@ -406,15 +407,8 @@ export function DocumentView({
     return () => {
       interruptRef.current = true;
     };
-  }, [
-    document,
-    document.documentId,
-    onScoreReady,
-    owner,
-    pinned,
-    query,
-    template?.instructions,
-  ]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [document.documentId]);
 
   return (
     <div className="flex flex-col">
@@ -638,7 +632,8 @@ export function TemplatesView({
       templates[editingTemplate].visibility != "default" &&
       (isBuilder || templates[editingTemplate].visibility == "user")
     );
-  }, [editingTemplate, isBuilder, templates]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [editingTemplate]);
 
   const colorOptions = [
     "bg-red-500",
@@ -652,11 +647,13 @@ export function TemplatesView({
     if (selectedTemplate != -1) {
       onTemplateSelect(templates[selectedTemplate]);
     }
-  }, [onTemplateSelect, selectedTemplate, templates]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedTemplate]);
 
   useEffect(() => {
     onTemplateSelect(templates[0]);
-  }, [onTemplateSelect, templates]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const handleTemplateDelete = (index: number) => {
     setTemplates((prevTemplates) => {

--- a/front/pages/w/[wId]/u/gens/index.tsx
+++ b/front/pages/w/[wId]/u/gens/index.tsx
@@ -321,7 +321,7 @@ export function DocumentView({
       console.log("Trying to unmount");
       interruptRef.current = true;
     };
-  }, [document.documentId]);
+  }, [document, document.documentId, onExtractUpdate, owner, query]);
 
   useEffect(() => {
     const extractInput = [
@@ -406,7 +406,15 @@ export function DocumentView({
     return () => {
       interruptRef.current = true;
     };
-  }, [document.documentId]);
+  }, [
+    document,
+    document.documentId,
+    onScoreReady,
+    owner,
+    pinned,
+    query,
+    template?.instructions,
+  ]);
 
   return (
     <div className="flex flex-col">
@@ -630,7 +638,7 @@ export function TemplatesView({
       templates[editingTemplate].visibility != "default" &&
       (isBuilder || templates[editingTemplate].visibility == "user")
     );
-  }, [editingTemplate]);
+  }, [editingTemplate, isBuilder, templates]);
 
   const colorOptions = [
     "bg-red-500",
@@ -644,11 +652,11 @@ export function TemplatesView({
     if (selectedTemplate != -1) {
       onTemplateSelect(templates[selectedTemplate]);
     }
-  }, [selectedTemplate]);
+  }, [onTemplateSelect, selectedTemplate, templates]);
 
   useEffect(() => {
     onTemplateSelect(templates[0]);
-  }, []);
+  }, [onTemplateSelect, templates]);
 
   const handleTemplateDelete = (index: number) => {
     setTemplates((prevTemplates) => {

--- a/front/pages/w/[wId]/workspace/index.tsx
+++ b/front/pages/w/[wId]/workspace/index.tsx
@@ -8,7 +8,7 @@ import {
 import { Listbox } from "@headlessui/react";
 import { CheckIcon } from "@heroicons/react/20/solid";
 import { GetServerSideProps, InferGetServerSidePropsType } from "next";
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { mutate } from "swr";
 
 import AppLayout from "@app/components/sparkle/AppLayout";
@@ -75,7 +75,7 @@ export default function WorkspaceAdmin({
   const { members, isMembersLoading } = useMembers(owner);
   const { invitations, isInvitationsLoading } = useWorkspaceInvitations(owner);
 
-  const formValidation = () => {
+  const formValidation = useCallback(() => {
     if (workspaceName === owner.name && allowedDomain === owner.allowedDomain) {
       return false;
     }
@@ -105,11 +105,11 @@ export default function WorkspaceAdmin({
       setWorkspaceNameError("");
     }
     return valid;
-  };
+  }, [allowedDomain, owner.allowedDomain, owner.name, workspaceName]);
 
   useEffect(() => {
     setDisabled(!formValidation());
-  }, [workspaceName, allowedDomain]);
+  }, [workspaceName, allowedDomain, formValidation]);
 
   const handleUpdateWorkspace = async () => {
     setUpdating(true);

--- a/front/pages/xp1/activate/index.jsx
+++ b/front/pages/xp1/activate/index.jsx
@@ -1,6 +1,6 @@
 import Head from "next/head";
 import Script from "next/script";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { HighlightButton } from "@app/components/Button";
 import { Logo } from "@app/components/Logo";
@@ -12,7 +12,7 @@ export default function Activate({ ga_tracking_id }) {
   const [name, setName] = useState("");
   const [disable, setDisabled] = useState(true);
 
-  const formValidation = () => {
+  const formValidation = useCallback(() => {
     if (!email || email.length === 0) return false;
     if (!name || name.length === 0) return false;
 
@@ -23,11 +23,11 @@ export default function Activate({ ga_tracking_id }) {
     }
 
     return true;
-  };
+  }, [email, name]);
 
   useEffect(() => {
     setDisabled(!formValidation());
-  }, [email, name]);
+  }, [email, name, formValidation]);
 
   return (
     <>

--- a/front/pages/xp1/activate/index.jsx
+++ b/front/pages/xp1/activate/index.jsx
@@ -1,6 +1,6 @@
 import Head from "next/head";
 import Script from "next/script";
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 import { HighlightButton } from "@app/components/Button";
 import { Logo } from "@app/components/Logo";
@@ -12,7 +12,7 @@ export default function Activate({ ga_tracking_id }) {
   const [name, setName] = useState("");
   const [disable, setDisabled] = useState(true);
 
-  const formValidation = useCallback(() => {
+  const formValidation = () => {
     if (!email || email.length === 0) return false;
     if (!name || name.length === 0) return false;
 
@@ -23,11 +23,12 @@ export default function Activate({ ga_tracking_id }) {
     }
 
     return true;
-  }, [email, name]);
+  };
 
   useEffect(() => {
     setDisabled(!formValidation());
-  }, [email, name, formValidation]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [email, name]);
 
   return (
     <>


### PR DESCRIPTION
Enabling `react-hooks/exhaustive-deps` for front.

Here is why:
- enabling this rules gives us an eslint warning when we are missing dependencies in useEffect(), reducing the number of bugs in the UI. Especially bugs where the UI does not properly update to the new state because the useEffect() was not re-triggered on state change sit depends on.
- Forces us to wrap our inner functions in useCallback , which avoids re-rendering the UI (at least in the shadow DOM) too many times when nothing changed (but the reference to the inner function).
