### PR TITLE
Assistant v2: API route GET assistants

### DIFF
--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -162,9 +162,7 @@ export async function getAgentConfigurations(
   }
   const agents = await AgentConfiguration.findAll({
     where: {
-      workspaceId: {
-        [Op.or]: [owner.id, null],
-      },
+      [Op.or]: [{ workspaceId: owner.id }, { scope: "global" }],
     },
   });
 

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -151,6 +151,31 @@ export async function getAgentConfiguration(
 }
 
 /**
+ * Get the list agent configuration for the workspace.
+ */
+export async function getAgentConfigurations(
+  auth: Authenticator
+): Promise<AgentConfigurationType[] | []> {
+  const owner = auth.workspace();
+  if (!owner) {
+    throw new Error("Cannot find AgentConfiguration: no workspace.");
+  }
+  const agents = await AgentConfiguration.findAll({
+    where: {
+      workspaceId: {
+        [Op.or]: [owner.id, null],
+      },
+    },
+  });
+
+  return Promise.all(
+    agents.map(async (agent) => {
+      return await renderAgentConfigurationByModelId(auth, agent.id);
+    })
+  );
+}
+
+/**
  * Create Agent Configuration
  */
 export async function createAgentConfiguration(

--- a/front/lib/models/assistant/agent.ts
+++ b/front/lib/models/assistant/agent.ts
@@ -84,7 +84,7 @@ export class AgentConfiguration extends Model<
   declare pictureUrl: string | null;
   declare scope: AgentConfigurationScope;
 
-  declare workspaceId: ForeignKey<Workspace["id"]> | null; // null = it's a global agent
+  declare workspaceId: ForeignKey<Workspace["id"]>;
   declare generationConfigurationId: ForeignKey<
     AgentGenerationConfiguration["id"]
   > | null;
@@ -162,11 +162,11 @@ AgentConfiguration.init(
 
 //  Agent config <> Workspace
 Workspace.hasMany(AgentConfiguration, {
-  foreignKey: { name: "workspaceId", allowNull: true }, // null = global Agent
+  foreignKey: { name: "workspaceId", allowNull: false },
   onDelete: "CASCADE",
 });
 AgentConfiguration.belongsTo(Workspace, {
-  foreignKey: { name: "workspaceId", allowNull: true }, // null = global Agent
+  foreignKey: { name: "workspaceId", allowNull: false },
 });
 
 // Agent config <> Generation config

--- a/front/pages/api/w/[wId]/assistants/index.ts
+++ b/front/pages/api/w/[wId]/assistants/index.ts
@@ -1,0 +1,62 @@
+import * as t from "io-ts";
+import { NextApiRequest, NextApiResponse } from "next";
+
+import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
+import { Authenticator, getSession } from "@app/lib/auth";
+import { ReturnedAPIErrorType } from "@app/lib/error";
+import { apiError, withLogging } from "@app/logger/withlogging";
+import { AgentConfigurationType } from "@app/types/assistant/agent";
+
+export type GetAssistantResponseBody = {
+  assistants: AgentConfigurationType[];
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<GetAssistantResponseBody | ReturnedAPIErrorType | void>
+): Promise<void> {
+  const session = await getSession(req, res);
+  const auth = await Authenticator.fromSession(
+    session,
+    req.query.wId as string
+  );
+  const owner = auth.workspace();
+  if (!owner) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "The workspace you're trying to modify was not found.",
+      },
+    });
+  }
+
+  if (!auth.isBuilder()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "app_auth_error",
+        message:
+          "Only the users that are `builders` for the current workspace can access an Assistant.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET":
+      const assistants = await getAgentConfigurations(auth);
+      return res.status(200).json({
+        assistants,
+      });
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withLogging(handler);

--- a/front/pages/api/w/[wId]/assistants/index.ts
+++ b/front/pages/api/w/[wId]/assistants/index.ts
@@ -37,7 +37,7 @@ async function handler(
       api_error: {
         type: "app_auth_error",
         message:
-          "Only the users that are `builders` for the current workspace can access an Assistant.",
+          "Only the users that are `builders` for the current workspace can access Assistants.",
       },
     });
   }


### PR DESCRIPTION
Implements `GET /api/w/[wId]/assistants retrieve assistants`

Was not part of https://github.com/dust-tt/dust/issues/1347 but I'm guessing we will need to list the assistant available for the workspace?