### PR TITLE
enh(notion connector): avoid long-running activities

### DIFF
--- a/connectors/src/connectors/notion/temporal/config.ts
+++ b/connectors/src/connectors/notion/temporal/config.ts
@@ -1,2 +1,2 @@
-export const WORKFLOW_VERSION = 18;
+export const WORKFLOW_VERSION = 19;
 export const QUEUE_NAME = `notion-queue-v${WORKFLOW_VERSION}`;

--- a/connectors/src/connectors/notion/temporal/worker.ts
+++ b/connectors/src/connectors/notion/temporal/worker.ts
@@ -14,7 +14,6 @@ export async function runNotionWorker() {
     workflowsPath: require.resolve("./workflows"),
     activities,
     taskQueue: QUEUE_NAME,
-    maxConcurrentActivityTaskExecutions: 3,
     connection,
     namespace,
     interceptors: {


### PR DESCRIPTION
Instead of getting all databases' child pages from the "get to sync" activity, we now do this from the `notionSyncResultPageDatabaseWorkflow`, using one activity per result page of the "get children" notion endpoint.

The code will need some refactoring soon as it is becoming convoluted