### PR TITLE
Agent config: remove scope column

### DIFF
--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -80,7 +80,7 @@ export async function renderAgentConfigurationByModelId(
   return {
     id: agent.id,
     sId: agent.sId,
-    scope: agent.scope,
+    scope: "workspace",
     name: agent.name,
     pictureUrl: agent.pictureUrl,
     status: agent.status,
@@ -140,10 +140,7 @@ export async function getAgentConfiguration(
   });
 
   // If not found or found but non-global and not on the current workspace, return null.
-  if (
-    !agent ||
-    (agent.workspaceId !== owner.id && agent.scope === "workspace")
-  ) {
+  if (!agent || agent.workspaceId !== owner.id) {
     return null;
   }
 
@@ -162,7 +159,7 @@ export async function getAgentConfigurations(
   }
   const agents = await AgentConfiguration.findAll({
     where: {
-      [Op.or]: [{ workspaceId: owner.id }, { scope: "global" }],
+      workspaceId: owner.id,
     },
   });
 
@@ -203,7 +200,6 @@ export async function createAgentConfiguration(
     status: status,
     name: name,
     pictureUrl: pictureUrl,
-    scope: "workspace",
     workspaceId: owner.id,
     generationConfigurationId: generation?.id || null,
     retrievalConfigurationId: action?.id || null,
@@ -212,7 +208,7 @@ export async function createAgentConfiguration(
   return {
     id: agentConfig.id,
     sId: agentConfig.sId,
-    scope: agentConfig.scope,
+    scope: "workspace",
     name: agentConfig.name,
     pictureUrl: agentConfig.pictureUrl,
     status: agentConfig.status,

--- a/front/lib/models/assistant/agent.ts
+++ b/front/lib/models/assistant/agent.ts
@@ -11,10 +11,7 @@ import {
 import { front_sequelize } from "@app/lib/databases";
 import { AgentRetrievalConfiguration } from "@app/lib/models/assistant/actions/retrieval";
 import { Workspace } from "@app/lib/models/workspace";
-import {
-  AgentConfigurationScope,
-  AgentConfigurationStatus,
-} from "@app/types/assistant/agent";
+import { AgentConfigurationStatus } from "@app/types/assistant/agent";
 
 /**
  * Configuration of Agent generation.
@@ -82,7 +79,6 @@ export class AgentConfiguration extends Model<
   declare status: AgentConfigurationStatus;
   declare name: string;
   declare pictureUrl: string | null;
-  declare scope: AgentConfigurationScope;
 
   declare workspaceId: ForeignKey<Workspace["id"]>;
   declare generationConfigurationId: ForeignKey<
@@ -130,11 +126,6 @@ AgentConfiguration.init(
       type: DataTypes.TEXT,
       allowNull: true,
     },
-    scope: {
-      type: DataTypes.STRING,
-      allowNull: false,
-      defaultValue: "workspace",
-    },
   },
   {
     modelName: "agent_configuration",
@@ -148,15 +139,6 @@ AgentConfiguration.init(
       { fields: ["workspaceId", "name", "scope"], unique: true },
       { fields: ["sId"], unique: true },
     ],
-    hooks: {
-      beforeValidate: (agent: AgentConfiguration) => {
-        if (agent.scope !== "workspace" && agent.workspaceId) {
-          throw new Error("Workspace id must be null for global agent");
-        } else if (agent.scope === "workspace" && !agent.workspaceId) {
-          throw new Error("Workspace id must be set for non-global agent");
-        }
-      },
-    },
   }
 );
 


### PR DESCRIPTION
Global agents won't be stored in db. 
We keep the `scope` field  (set to "workspace") for the type only, and remove the column. 

