### PR TITLE
enh: increase resources for front-worker

### DIFF
--- a/k8s/configmaps/front-worker-configmap.yaml
+++ b/k8s/configmaps/front-worker-configmap.yaml
@@ -5,7 +5,7 @@ metadata:
 data:
   DD_ENV: "prod"
   DD_SERVICE: "front-worker"
-  NODE_OPTIONS: "-r dd-trace/init --max-old-space-size=1750"
+  NODE_OPTIONS: "-r dd-trace/init --max-old-space-size=4200"
   DD_LOGS_INJECTION: "true"
   DD_RUNTIME_METRICS_ENABLED: "true"
   NODE_ENV: "production"

--- a/k8s/deployments/front-worker-deployment.yaml
+++ b/k8s/deployments/front-worker-deployment.yaml
@@ -41,12 +41,12 @@ spec:
 
           resources:
             requests:
-              cpu: 1000m
-              memory: 2.5Gi
+              cpu: 2000m
+              memory: 6Gi
 
             limits:
-              cpu: 1000m
-              memory: 2.5Gi
+              cpu: 2000m
+              memory: 6Gi
 
       volumes:
         - name: cert-volume


### PR DESCRIPTION
already applied -- the way we run temporal is very resource-hungry, so the `front-worker` pods need more memory