### PR TITLE
Assistant: global agents

### DIFF
--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -3,7 +3,7 @@ import { Op, Transaction } from "sequelize";
 import {
   getGlobalAgent,
   getGlobalAgents,
-  isGlobalAgent,
+  isGlobalAgentId,
 } from "@app/lib/api/assistant/globalAgents";
 import { Authenticator } from "@app/lib/auth";
 import { front_sequelize, ModelId } from "@app/lib/databases";
@@ -139,7 +139,7 @@ export async function getAgentConfiguration(
     throw new Error("Cannot find AgentConfiguration: no workspace.");
   }
 
-  if (isGlobalAgent(agentId)) {
+  if (isGlobalAgentId(agentId)) {
     return await getGlobalAgent(auth, agentId);
   }
 

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -1,5 +1,10 @@
 import { Op, Transaction } from "sequelize";
 
+import {
+  getGlobalAgent,
+  getGlobalAgents,
+  isGlobalAgent,
+} from "@app/lib/api/assistant/globalAgents";
 import { Authenticator } from "@app/lib/auth";
 import { front_sequelize, ModelId } from "@app/lib/databases";
 import {
@@ -133,6 +138,11 @@ export async function getAgentConfiguration(
   if (!owner) {
     throw new Error("Cannot find AgentConfiguration: no workspace.");
   }
+
+  if (isGlobalAgent(agentId)) {
+    return await getGlobalAgent(auth, agentId);
+  }
+
   const agent = await AgentConfiguration.findOne({
     where: {
       sId: agentId,
@@ -157,17 +167,20 @@ export async function getAgentConfigurations(
   if (!owner) {
     throw new Error("Cannot find AgentConfiguration: no workspace.");
   }
-  const agents = await AgentConfiguration.findAll({
+
+  const rawAgents = await AgentConfiguration.findAll({
     where: {
       workspaceId: owner.id,
     },
   });
-
-  return Promise.all(
-    agents.map(async (agent) => {
-      return await renderAgentConfigurationByModelId(auth, agent.id);
+  const agents = await Promise.all(
+    rawAgents.map(async (a) => {
+      return await renderAgentConfigurationByModelId(auth, a.id);
     })
   );
+  const globalAgents = await getGlobalAgents(auth);
+
+  return [...globalAgents, ...agents];
 }
 
 /**

--- a/front/lib/api/assistant/globalAgents.ts
+++ b/front/lib/api/assistant/globalAgents.ts
@@ -29,7 +29,7 @@ async function _getGPT4GlobalAgent(): Promise<AgentConfigurationType> {
     status: "active",
     scope: "global",
     generation: {
-      id: 0,
+      id: GLOBAL_AGENTS_ID.GPT4,
       prompt: "",
       model: {
         providerId: "openai",
@@ -68,7 +68,7 @@ async function _getSlackGlobalAgent(
     status: "active",
     scope: "global",
     generation: {
-      id: 0,
+      id: GLOBAL_AGENTS_ID.Slack,
       prompt:
         "Answer the following question using all the data available in your Slack workspace.",
       model: {
@@ -77,7 +77,7 @@ async function _getSlackGlobalAgent(
       },
     },
     action: {
-      id: 0,
+      id: GLOBAL_AGENTS_ID.Slack,
       type: "retrieval_configuration",
       query: "auto",
       relativeTimeFrame: "auto",

--- a/front/lib/api/assistant/globalAgents.ts
+++ b/front/lib/api/assistant/globalAgents.ts
@@ -1,0 +1,128 @@
+import { Authenticator } from "@app/lib/auth";
+import { DataSource } from "@app/lib/models";
+import { AgentConfigurationType } from "@app/types/assistant/agent";
+
+/**
+ * GLOBAL AGENTS CONFIGURATION
+ *
+ * To add an agent:
+ * - Add a unique SID in GLOBAL_AGENTS_SID.
+ * - Add a unique ID in GLOBAL_AGENTS_ID.
+ * - Add a case in getGlobalAgent with associated function.
+ */
+
+enum GLOBAL_AGENTS_SID {
+  GPT4 = "6b5203c158",
+  Slack = "4c974a7ac9",
+}
+enum GLOBAL_AGENTS_ID {
+  GPT4 = -1,
+  Slack = -2,
+}
+
+async function _getGPT4GlobalAgent(): Promise<AgentConfigurationType> {
+  return {
+    id: GLOBAL_AGENTS_ID.GPT4,
+    sId: GLOBAL_AGENTS_SID.GPT4,
+    name: "GPT4",
+    pictureUrl: null,
+    status: "active",
+    scope: "global",
+    generation: {
+      id: 0,
+      prompt: "Answer the following question:",
+      model: {
+        providerId: "openai",
+        modelId: "gpt-4-0613",
+      },
+    },
+    action: null,
+  };
+}
+
+async function _getSlackGlobalAgent(
+  auth: Authenticator
+): Promise<AgentConfigurationType> {
+  const workspace = auth.workspace();
+  const workspaceId = auth.workspace()?.id;
+  if (!workspace || !workspaceId) {
+    throw new Error("Cannot find Global Agent Configuration: no workspace.");
+  }
+
+  const slackDataSources = await DataSource.findAll({
+    where: {
+      connectorProvider: "slack",
+      workspaceId: workspaceId,
+    },
+  });
+
+  return {
+    id: GLOBAL_AGENTS_ID.Slack,
+    sId: GLOBAL_AGENTS_SID.Slack,
+    name: "Slack",
+    pictureUrl: null,
+    status: "active",
+    scope: "global",
+    generation: {
+      id: 0,
+      prompt:
+        "Answer the following question using all the data available in your Slack workspace.",
+      model: {
+        providerId: "openai",
+        modelId: "gpt-3.5-turbo",
+      },
+    },
+    action: {
+      id: 0,
+      type: "retrieval_configuration",
+      query: "auto",
+      relativeTimeFrame: "auto",
+      topK: 32,
+      dataSources: slackDataSources.map((ds) => ({
+        dataSourceId: ds.name,
+        workspaceId: workspace.sId,
+        filter: { tags: null, parents: null },
+      })),
+    },
+  };
+}
+
+/**
+ * EXPORTED FUNCTIONS
+ */
+
+export function isGlobalAgent(sId: string): boolean {
+  return (Object.values(GLOBAL_AGENTS_SID) as string[]).includes(sId);
+}
+
+export async function getGlobalAgent(
+  auth: Authenticator,
+  sId: string | number
+): Promise<AgentConfigurationType | null> {
+  const owner = auth.workspace();
+  if (!owner) {
+    throw new Error("Cannot find Global Agent Configuration: no workspace.");
+  }
+
+  switch (sId) {
+    case GLOBAL_AGENTS_SID.GPT4:
+      return _getGPT4GlobalAgent();
+    case GLOBAL_AGENTS_ID.Slack:
+      return _getSlackGlobalAgent(auth);
+    default:
+      return null;
+  }
+}
+
+export async function getGlobalAgents(
+  auth: Authenticator
+): Promise<AgentConfigurationType[]> {
+  const owner = auth.workspace();
+  if (!owner) {
+    throw new Error("Cannot find Global Agent Configuration: no workspace.");
+  }
+
+  // For now we retrieve them all
+  // We will store them in the database later to allow admin enable them or not
+  return [await _getGPT4GlobalAgent(), await _getSlackGlobalAgent(auth)];
+}


### PR DESCRIPTION
This PR introduces the global agents, showing how we will be able to define and retrieve global agents.

Note: for now we retrieve all global agents in `getAgentConfigurations()` -> I want to validate what we have now before introducing the `GlobalAgentEnablement` logic to allow admins to pick which global agent is available or not for their workspace. 