### PR TITLE
enh(sparkle modal): don't align text to the left

### DIFF
--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.1.48",
+  "version": "0.1.49",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/components/Modal.tsx
+++ b/sparkle/src/components/Modal.tsx
@@ -47,7 +47,7 @@ export function Modal({
               leaveFrom="s-opacity-100 s-translate-y-0 sm:s-scale-100"
               leaveTo="s-opacity-0 s-translate-y-4 sm:s-translate-y-0 sm:s-scale-95"
             >
-              <Dialog.Panel className="s-relative s-max-w-2xl s-transform s-overflow-hidden s-rounded-lg s-bg-white s-px-4 s-pb-4 s-text-left s-shadow-xl s-transition-all sm:s-p-6 lg:s-w-1/2">
+              <Dialog.Panel className="s-relative s-max-w-2xl s-transform s-overflow-hidden s-rounded-lg s-bg-white s-px-4 s-pb-4 s-shadow-xl s-transition-all sm:s-p-6 lg:s-w-1/2">
                 <div className="s-flex s-items-start s-justify-between sm:s-mt-0">
                   <div>{action && <Button {...action} />}</div>
                   {hasChanged ? (

--- a/sparkle/src/stories/Modal.stories.tsx
+++ b/sparkle/src/stories/Modal.stories.tsx
@@ -26,7 +26,9 @@ export const ModalExample = () => {
         onClose={() => setIsOpenNoActionNoChange(false)}
         hasChanged={false}
       >
-        <div className="s-mt-4 s-h-72 " />
+        <div className="s-mt-4 s-h-72">
+          I'm the modal content and I am centered by default
+        </div>
       </Modal>
       <Modal
         isOpen={isOpenWithActionAndChange}
@@ -40,7 +42,7 @@ export const ModalExample = () => {
           size: "xs",
         }}
       >
-        <div className="s-mt-4 s-h-72 " />
+        <div className="s-mt-4 s-h-72 s-text-left">I'm the modal content</div>
       </Modal>
       <Button
         label="Modal without action and without changes"


### PR DESCRIPTION
For the assistant V2 datasource resource picker, we need a modal with the text centered, which isn't possible with the current sparkle modal as it has `text-left` on the div that contains the children