### PR TITLE
feat: sparkle modal barheader & fullscreen support

### DIFF
--- a/sparkle/src/components/BarHeader.tsx
+++ b/sparkle/src/components/BarHeader.tsx
@@ -33,12 +33,36 @@ export function BarHeader({
   );
 }
 
-interface ListItemProps {
-  variant: "close" | "back" | "validate" | "conversation";
-}
+type BarHeaderButtonBarCloseProps = {
+  variant: "close";
+  onClose?: () => void;
+};
 
-BarHeader.ButtonBar = function ({ variant }: ListItemProps) {
-  switch (variant) {
+type BarHeaderButtonBarBackProps = {
+  variant: "back";
+  onBack?: () => void;
+};
+
+type BarHeaderButtonBarValidateProps = {
+  variant: "validate";
+  onCancel?: () => void;
+  onSave?: () => void;
+};
+
+type BarHeaderButtonBarConversationProps = {
+  variant: "conversation";
+  onDelete?: () => void;
+  onShare?: () => void;
+};
+
+export type BarHeaderButtonBarProps =
+  | BarHeaderButtonBarCloseProps
+  | BarHeaderButtonBarBackProps
+  | BarHeaderButtonBarValidateProps
+  | BarHeaderButtonBarConversationProps;
+
+BarHeader.ButtonBar = function (props: BarHeaderButtonBarProps) {
+  switch (props.variant) {
     case "back":
       return (
         <Button
@@ -48,6 +72,7 @@ BarHeader.ButtonBar = function ({ variant }: ListItemProps) {
           label="Back"
           tooltipPosition="below"
           labelVisible={false}
+          onClick={props.onBack}
         />
       );
     case "close":
@@ -59,13 +84,24 @@ BarHeader.ButtonBar = function ({ variant }: ListItemProps) {
           label="Close"
           tooltipPosition="below"
           labelVisible={false}
+          onClick={props.onClose}
         />
       );
     case "validate":
       return (
         <>
-          <Button size="sm" label="Cancel" variant="secondaryWarning" />
-          <Button size="sm" label="Save" variant="primary" />
+          <Button
+            size="sm"
+            label="Cancel"
+            variant="secondaryWarning"
+            onClick={props.onCancel}
+          />
+          <Button
+            size="sm"
+            label="Save"
+            variant="primary"
+            onClick={props.onSave}
+          />
         </>
       );
     case "conversation":
@@ -78,12 +114,14 @@ BarHeader.ButtonBar = function ({ variant }: ListItemProps) {
             variant="secondaryWarning"
             labelVisible={false}
             tooltipPosition="below"
+            onClick={props.onDelete}
           />
           <Button
             size="sm"
             label="Share"
             icon={ArrowUpOnSquare}
             variant="secondary"
+            onClick={props.onShare}
           />
         </>
       );

--- a/sparkle/src/components/Modal.tsx
+++ b/sparkle/src/components/Modal.tsx
@@ -12,6 +12,7 @@ interface ModalProps {
   hasChanged: boolean;
   onSave?: () => void;
   title?: string;
+  isFullScreen?: boolean;
 }
 
 export function Modal({
@@ -21,6 +22,7 @@ export function Modal({
   hasChanged,
   onSave,
   title,
+  isFullScreen = false,
 }: ModalProps) {
   const buttonBarProps: BarHeaderButtonBarProps = hasChanged
     ? {
@@ -48,8 +50,12 @@ export function Modal({
           <div className="s-fixed s-inset-0 s-bg-gray-500 s-bg-opacity-75 s-transition-opacity" />
         </Transition.Child>
 
-        <div className="s-h-5/5 s-fixed s-inset-0 s-z-50 s-overflow-y-auto">
-          <div className="s-flex s-min-h-full s-items-end s-justify-center s-p-4 s-text-center sm:s-items-center sm:s-p-0">
+        <div className="s-fixed s-inset-0 s-z-50 s-overflow-y-auto">
+          <div
+            className={`s-flex s-items-center s-justify-center s-p-4 s-text-center sm:s-items-center sm:s-p-0 ${
+              isFullScreen ? "s-h-full" : "s-min-h-full"
+            }`}
+          >
             <Transition.Child
               as={Fragment}
               enter="s-ease-out s-duration-300"
@@ -59,12 +65,28 @@ export function Modal({
               leaveFrom="s-opacity-100 s-translate-y-0 sm:s-scale-100"
               leaveTo="s-opacity-0 s-translate-y-4 sm:s-translate-y-0 sm:s-scale-95"
             >
-              <Dialog.Panel className="s-relative s-max-w-2xl s-transform s-overflow-hidden s-rounded-lg s-bg-white s-px-4 s-pb-4 s-shadow-xl s-transition-all sm:s-p-6 lg:s-w-1/2">
-                <div className="s-mt-16">
+              <Dialog.Panel
+                className={`s-relative s-transform s-overflow-hidden s-rounded-lg s-bg-white s-px-4 s-pb-4 s-shadow-xl s-transition-all sm:s-p-6 ${
+                  isFullScreen
+                    ? "s-m-0 s-h-full s-max-h-full s-w-full s-max-w-full"
+                    : "s-max-w-2xl lg:s-w-1/2"
+                }`}
+              >
+                <div
+                  className={`s-mt-16 ${
+                    isFullScreen ? "s-sticky s-top-0" : ""
+                  }`}
+                >
                   <BarHeader
                     title={title || ""}
                     rightActions={<BarHeader.ButtonBar {...buttonBarProps} />}
                   />
+                </div>
+                <div
+                  className={`${
+                    isFullScreen ? "s-h-full s-overflow-y-auto" : ""
+                  }`}
+                >
                   {children}
                 </div>
               </Dialog.Panel>

--- a/sparkle/src/components/Modal.tsx
+++ b/sparkle/src/components/Modal.tsx
@@ -52,7 +52,7 @@ export function Modal({
 
         <div className="s-fixed s-inset-0 s-z-50 s-overflow-y-auto">
           <div
-            className={`s-flex s-items-center s-justify-center s-p-4 s-text-center sm:s-items-center sm:s-p-0 ${
+            className={`s-flex s-items-center s-justify-center s-p-4 sm:s-p-0 ${
               isFullScreen ? "s-h-full" : "s-min-h-full"
             }`}
           >

--- a/sparkle/src/components/Modal.tsx
+++ b/sparkle/src/components/Modal.tsx
@@ -1,8 +1,8 @@
 import { Dialog, Transition } from "@headlessui/react";
 import React, { Fragment } from "react";
 
-import XCircleIcon from "../icons/solid/XCircle";
-import { Button, ButtonProps } from "./Button";
+import { BarHeader, BarHeaderButtonBarProps } from "./BarHeader";
+import { ButtonProps } from "./Button";
 
 interface ModalProps {
   isOpen: boolean;
@@ -11,16 +11,28 @@ interface ModalProps {
   children: React.ReactNode;
   hasChanged: boolean;
   onSave?: () => void;
+  title?: string;
 }
 
 export function Modal({
   isOpen,
   onClose,
-  action,
   children,
   hasChanged,
   onSave,
+  title,
 }: ModalProps) {
+  const buttonBarProps: BarHeaderButtonBarProps = hasChanged
+    ? {
+        variant: "validate",
+        onCancel: onClose,
+        onSave: onSave,
+      }
+    : {
+        variant: "close",
+        onClose: onClose,
+      };
+
   return (
     <Transition.Root show={isOpen} as={Fragment}>
       <Dialog as="div" className="s-relative s-z-50" onClose={onClose}>
@@ -48,35 +60,13 @@ export function Modal({
               leaveTo="s-opacity-0 s-translate-y-4 sm:s-translate-y-0 sm:s-scale-95"
             >
               <Dialog.Panel className="s-relative s-max-w-2xl s-transform s-overflow-hidden s-rounded-lg s-bg-white s-px-4 s-pb-4 s-shadow-xl s-transition-all sm:s-p-6 lg:s-w-1/2">
-                <div className="s-flex s-items-start s-justify-between sm:s-mt-0">
-                  <div>{action && <Button {...action} />}</div>
-                  {hasChanged ? (
-                    <div className="s-flex s-justify-end s-gap-1">
-                      <Button
-                        labelVisible={true}
-                        onClick={onClose}
-                        label="Cancel"
-                        variant="secondary"
-                        size="xs"
-                      />
-                      <Button
-                        labelVisible={true}
-                        onClick={onSave}
-                        label="Save"
-                        variant="primary"
-                        size="xs"
-                      />
-                    </div>
-                  ) : (
-                    <div
-                      onClick={onClose}
-                      className="s-cursor-pointer s-self-center"
-                    >
-                      <XCircleIcon className="s-h-6 s-w-6 s-text-gray-500" />
-                    </div>
-                  )}
+                <div className="s-mt-16">
+                  <BarHeader
+                    title={title || ""}
+                    rightActions={<BarHeader.ButtonBar {...buttonBarProps} />}
+                  />
+                  {children}
                 </div>
-                {children}
               </Dialog.Panel>
             </Transition.Child>
           </div>

--- a/sparkle/src/stories/Modal.stories.tsx
+++ b/sparkle/src/stories/Modal.stories.tsx
@@ -1,11 +1,7 @@
 import type { Meta } from "@storybook/react";
 import React, { useState } from "react";
 
-import {
-  Button,
-  ChatBubbleBottomCenterTextIcon,
-  Modal,
-} from "../index_with_tw_base";
+import { Button, Modal } from "../index_with_tw_base";
 
 const meta = {
   title: "Molecule/Modal",
@@ -17,6 +13,9 @@ export default meta;
 export const ModalExample = () => {
   const [isOpenNoActionNoChange, setIsOpenNoActionNoChange] = useState(false);
   const [isOpenWithActionAndChange, setIsOpenWithActionAndChange] =
+    useState(false);
+  const [isFullScreenModalOpen, setIsFullScreenModalOpen] = useState(false);
+  const [isFullScreenModalOverflowOpen, setIsFullScreenModalOverflowOpen] =
     useState(false);
 
   return (
@@ -35,15 +34,29 @@ export const ModalExample = () => {
         isOpen={isOpenWithActionAndChange}
         onClose={() => setIsOpenWithActionAndChange(false)}
         hasChanged={true}
-        action={{
-          icon: ChatBubbleBottomCenterTextIcon,
-          label: "Contact an agent",
-          labelVisible: true,
-          variant: "tertiary",
-          size: "xs",
-        }}
       >
         <div className="s-mt-4 s-h-72 s-text-left">I'm the modal content</div>
+      </Modal>
+      <Modal
+        isOpen={isFullScreenModalOpen}
+        onClose={() => setIsFullScreenModalOpen(false)}
+        hasChanged={true}
+        isFullScreen={true}
+        title="Modal title"
+      >
+        <div className="s-mt-4 s-h-72 s-text-left">I'm the modal content</div>
+      </Modal>
+      <Modal
+        isOpen={isFullScreenModalOverflowOpen}
+        onClose={() => setIsFullScreenModalOverflowOpen(false)}
+        hasChanged={true}
+        isFullScreen={true}
+        title="Modal title"
+      >
+        <div className="s-mt-4 s-h-96 s-text-left">I'm the modal content</div>
+        <div className="s-mt-4 s-h-96 s-text-left">I'm the modal content</div>
+        <div className="s-mt-4 s-h-96 s-text-left">I'm the modal content</div>
+        <div className="s-mt-4 s-h-96 s-text-left">I'm the modal content</div>
       </Modal>
       <Button
         label="Modal without action and without changes"
@@ -52,6 +65,14 @@ export const ModalExample = () => {
       <Button
         label="Modal with action and changes"
         onClick={() => setIsOpenWithActionAndChange(true)}
+      />
+      <Button
+        label="Modal full screen"
+        onClick={() => setIsFullScreenModalOpen(true)}
+      />
+      <Button
+        label="Modal full screen with overflowing content"
+        onClick={() => setIsFullScreenModalOverflowOpen(true)}
       />
     </>
   );

--- a/sparkle/src/stories/Modal.stories.tsx
+++ b/sparkle/src/stories/Modal.stories.tsx
@@ -25,6 +25,7 @@ export const ModalExample = () => {
         isOpen={isOpenNoActionNoChange}
         onClose={() => setIsOpenNoActionNoChange(false)}
         hasChanged={false}
+        title="Modal title"
       >
         <div className="s-mt-4 s-h-72">
           I'm the modal content and I am centered by default

--- a/sparkle/src/stories/Modal.stories.tsx
+++ b/sparkle/src/stories/Modal.stories.tsx
@@ -26,9 +26,7 @@ export const ModalExample = () => {
         hasChanged={false}
         title="Modal title"
       >
-        <div className="s-mt-4 s-h-72">
-          I'm the modal content and I am centered by default
-        </div>
+        <div className="s-mt-4 s-h-72">I'm the modal content</div>
       </Modal>
       <Modal
         isOpen={isOpenWithActionAndChange}


### PR DESCRIPTION
- improve bar header button bar to accept the appropriate callback(s) depending on variant
- update the sparkle modal to use the barheader / button bar
- add support for fullscreen to sparkle modal

(all that is needed for assistant V2)