### PR TITLE
Remove agent config id relations

### DIFF
--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -6,7 +6,7 @@ import {
   isGlobalAgentId,
 } from "@app/lib/api/assistant/globalAgents";
 import { Authenticator } from "@app/lib/auth";
-import { front_sequelize, ModelId } from "@app/lib/databases";
+import { front_sequelize } from "@app/lib/databases";
 import {
   AgentConfiguration,
   AgentDataSourceConfiguration,
@@ -30,20 +30,25 @@ import {
   AgentGenerationConfigurationType,
 } from "@app/types/assistant/agent";
 
-// Internal interface for the retrieval and rendering of a retrieval action.
-// This should not be used outside of api/assistant.
-// It helps us be smarter in the code to render AgentMessages
-export async function renderAgentConfigurationByModelId(
+/**
+ * Get an agent configuration
+ */
+export async function getAgentConfiguration(
   auth: Authenticator,
-  id: ModelId
-): Promise<AgentConfigurationType> {
+  agentId: string
+): Promise<AgentConfigurationType | null> {
   const owner = auth.workspace();
   if (!owner) {
     throw new Error("Cannot find AgentConfiguration: no workspace.");
   }
+
+  if (isGlobalAgentId(agentId)) {
+    return await getGlobalAgent(auth, agentId);
+  }
+
   const agent = await AgentConfiguration.findOne({
     where: {
-      id: id,
+      sId: agentId,
       workspaceId: owner.id,
     },
     include: [
@@ -58,7 +63,7 @@ export async function renderAgentConfigurationByModelId(
     ],
   });
   if (!agent) {
-    throw new Error("Cannot find AgentConfiguration.");
+    return null;
   }
 
   const dataSourcesConfig = await AgentDataSourceConfiguration.findAll({
@@ -128,36 +133,6 @@ export async function renderAgentConfigurationByModelId(
 }
 
 /**
- * Get an agent configuration
- */
-export async function getAgentConfiguration(
-  auth: Authenticator,
-  agentId: string
-): Promise<AgentConfigurationType | null> {
-  const owner = auth.workspace();
-  if (!owner) {
-    throw new Error("Cannot find AgentConfiguration: no workspace.");
-  }
-
-  if (isGlobalAgentId(agentId)) {
-    return await getGlobalAgent(auth, agentId);
-  }
-
-  const agent = await AgentConfiguration.findOne({
-    where: {
-      sId: agentId,
-    },
-  });
-
-  // If not found or found but non-global and not on the current workspace, return null.
-  if (!agent || agent.workspaceId !== owner.id) {
-    return null;
-  }
-
-  return await renderAgentConfigurationByModelId(auth, agent.id);
-}
-
-/**
  * Get the list agent configuration for the workspace.
  */
 export async function getAgentConfigurations(
@@ -175,7 +150,11 @@ export async function getAgentConfigurations(
   });
   const agents = await Promise.all(
     rawAgents.map(async (a) => {
-      return await renderAgentConfigurationByModelId(auth, a.id);
+      const agentConfig = await getAgentConfiguration(auth, a.sId);
+      if (!agentConfig) {
+        throw new Error("AgentConfiguration not found");
+      }
+      return agentConfig;
     })
   );
   const globalAgents = await getGlobalAgents(auth);

--- a/front/lib/api/assistant/pubsub.ts
+++ b/front/lib/api/assistant/pubsub.ts
@@ -87,6 +87,8 @@ export async function postUserMessageWithPubSub(
               return null;
           }
         }
+      } catch (e) {
+        logger.error({ error: e }, "Error Posting message");
       } finally {
         await redis.quit();
         if (!didResolve) {

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -10,7 +10,6 @@ import {
 
 import { front_sequelize } from "@app/lib/databases";
 import { AgentRetrievalAction } from "@app/lib/models/assistant/actions/retrieval";
-import { AgentConfiguration } from "@app/lib/models/assistant/agent";
 import { User } from "@app/lib/models/user";
 import { Workspace } from "@app/lib/models/workspace";
 import {

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -176,7 +176,7 @@ export class AgentMessage extends Model<
   declare errorMessage: string | null;
 
   declare agentRetrievalActionId: ForeignKey<AgentRetrievalAction["id"]> | null;
-  declare agentConfigurationId: ForeignKey<AgentConfiguration["id"]>;
+  declare agentId: string; // Not a relation as global agents are not in the DB
 }
 
 AgentMessage.init(
@@ -213,6 +213,10 @@ AgentMessage.init(
       type: DataTypes.TEXT,
       allowNull: true,
     },
+    agentId: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
   },
   {
     modelName: "agent_message",
@@ -232,13 +236,6 @@ AgentRetrievalAction.hasOne(AgentMessage, {
 });
 AgentMessage.belongsTo(AgentRetrievalAction, {
   foreignKey: { name: "agentRetrievalActionId", allowNull: true }, // null = no retrieval action set for this Agent
-});
-
-AgentConfiguration.hasMany(AgentMessage, {
-  foreignKey: { name: "agentConfigurationId", allowNull: false },
-});
-AgentMessage.belongsTo(AgentConfiguration, {
-  foreignKey: { name: "agentConfigurationId", allowNull: false },
 });
 
 export class Message extends Model<
@@ -367,10 +364,9 @@ export class Mention extends Model<
 
   declare messageId: ForeignKey<Message["id"]>;
   declare userId: ForeignKey<User["id"]> | null;
-  declare agentConfigurationId: ForeignKey<AgentConfiguration["id"]> | null;
+  declare agentId: string | null; // Not a relation as global agents are not in the DB
 
   declare user?: NonAttribute<User>;
-  declare agentConfiguration?: NonAttribute<AgentConfiguration>;
 }
 
 Mention.init(
@@ -389,6 +385,10 @@ Mention.init(
       type: DataTypes.DATE,
       allowNull: false,
       defaultValue: DataTypes.NOW,
+    },
+    agentId: {
+      type: DataTypes.STRING,
+      allowNull: true,
     },
   },
   {
@@ -410,13 +410,4 @@ User.hasMany(Mention, {
 });
 Mention.belongsTo(User, {
   foreignKey: { name: "userId", allowNull: true }, // null = mention is not a user mention
-});
-
-AgentConfiguration.hasMany(Mention, {
-  as: "agentConfiguration",
-  foreignKey: { name: "agentConfigurationId", allowNull: true }, // null = mention is not an agent mention
-});
-Mention.belongsTo(AgentConfiguration, {
-  as: "agentConfiguration",
-  foreignKey: { name: "agentConfigurationId", allowNull: true }, // null = mention is not an agent mention
 });


### PR DESCRIPTION
As global agents are not stored on the database (see [globalAgents.ts](https://github.com/dust-tt/dust/blob/main/front/lib/api/assistant/globalAgents.ts)), we need to remove some relationships: 
- AgentConfiguration <> Mention
- AgentConfiguration <> AgentMessage

As it's not a foreign key anymore, we decided to store directly the short id. 
Second commit is removing internal `renderAgentConfigurationByModelId` that is not needed anymore.
