### PR TITLE
Rename agent id column

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -128,9 +128,9 @@ async function renderUserMessage(
         }
       : null,
     mentions: mentions.map((m) => {
-      if (m.agentId) {
+      if (m.agentConfigurationId) {
         return {
-          configurationId: m.agentId,
+          configurationId: m.agentConfigurationId,
         };
       }
       if (m.user) {
@@ -456,7 +456,7 @@ export async function* postUserMessage(
               await Mention.create(
                 {
                   messageId: m.id,
-                  agentId: configuration.sId,
+                  agentConfigurationId: configuration.sId,
                 },
                 { transaction: t }
               );
@@ -766,7 +766,7 @@ export async function* editUserMessage(
               await Mention.create(
                 {
                   messageId: m.id,
-                  agentId: configuration.sId,
+                  agentConfigurationId: configuration.sId,
                 },
                 { transaction: t }
               );

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -158,7 +158,7 @@ async function renderAgentMessage(
   agentMessage: AgentMessage
 ): Promise<AgentMessageType> {
   const [agentConfiguration, agentRetrievalAction] = await Promise.all([
-    getAgentConfiguration(auth, agentMessage.agentId),
+    getAgentConfiguration(auth, agentMessage.agentConfigurationId),
     (async () => {
       if (agentMessage.agentRetrievalActionId) {
         return await renderRetrievalActionByModelId(
@@ -170,7 +170,9 @@ async function renderAgentMessage(
   ]);
 
   if (!agentConfiguration) {
-    throw new Error(`Configuration ${agentMessage.agentId} not found`);
+    throw new Error(
+      `Configuration ${agentMessage.agentConfigurationId} not found`
+    );
   }
 
   return {
@@ -464,7 +466,7 @@ export async function* postUserMessage(
               const agentMessageRow = await AgentMessage.create(
                 {
                   status: "created",
-                  agentId: configuration.sId,
+                  agentConfigurationId: configuration.sId,
                 },
                 { transaction: t }
               );

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -175,7 +175,7 @@ export class AgentMessage extends Model<
   declare errorMessage: string | null;
 
   declare agentRetrievalActionId: ForeignKey<AgentRetrievalAction["id"]> | null;
-  declare agentId: string; // Not a relation as global agents are not in the DB
+  declare agentConfigurationId: string; // Not a relation as global agents are not in the DB
 }
 
 AgentMessage.init(
@@ -212,7 +212,7 @@ AgentMessage.init(
       type: DataTypes.TEXT,
       allowNull: true,
     },
-    agentId: {
+    agentConfigurationId: {
       type: DataTypes.STRING,
       allowNull: true,
     },

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -363,7 +363,7 @@ export class Mention extends Model<
 
   declare messageId: ForeignKey<Message["id"]>;
   declare userId: ForeignKey<User["id"]> | null;
-  declare agentId: string | null; // Not a relation as global agents are not in the DB
+  declare agentConfigurationId: string | null; // Not a relation as global agents are not in the DB
 
   declare user?: NonAttribute<User>;
 }
@@ -385,7 +385,7 @@ Mention.init(
       allowNull: false,
       defaultValue: DataTypes.NOW,
     },
-    agentId: {
+    agentConfigurationId: {
       type: DataTypes.STRING,
       allowNull: true,
     },


### PR DESCRIPTION
Following: https://github.com/dust-tt/dust/pull/1405
As sequelize.sync does not handle a column type change, I first renamed the column, ran the migration on prod, and now I'm setting back the old name and will run this other migration on prod!