### PR TITLE
Fix: Remove join from Mention to AgentConfiguration on renderUserMessage

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -91,11 +91,6 @@ async function renderUserMessage(
           as: "user",
           required: false,
         },
-        {
-          model: AgentConfiguration,
-          as: "agentConfiguration",
-          required: false,
-        },
       ],
     }),
     (async () => {


### PR DESCRIPTION
There's no more relation between Mention to AgentConfiguration.
It was not used in here anymore since we store directly the sId. 