### PR TITLE
fix(sparkle modal): use padding instead of margin

### DIFF
--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.1.60",
+  "version": "0.1.61",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/components/Modal.tsx
+++ b/sparkle/src/components/Modal.tsx
@@ -72,18 +72,12 @@ export function Modal({
                     : "s-max-w-2xl lg:s-w-1/2"
                 }`}
               >
+                <BarHeader
+                  title={title || ""}
+                  rightActions={<BarHeader.ButtonBar {...buttonBarProps} />}
+                />
                 <div
-                  className={`s-mt-16 ${
-                    isFullScreen ? "s-sticky s-top-0" : ""
-                  }`}
-                >
-                  <BarHeader
-                    title={title || ""}
-                    rightActions={<BarHeader.ButtonBar {...buttonBarProps} />}
-                  />
-                </div>
-                <div
-                  className={`${
+                  className={`s-pt-8 ${
                     isFullScreen ? "s-h-full s-overflow-y-auto" : ""
                   }`}
                 >

--- a/sparkle/src/stories/Modal.stories.tsx
+++ b/sparkle/src/stories/Modal.stories.tsx
@@ -51,10 +51,18 @@ export const ModalExample = () => {
         isFullScreen={true}
         title="Modal title"
       >
-        <div className="s-mt-4 s-h-96 s-text-left">I'm the modal content</div>
-        <div className="s-mt-4 s-h-96 s-text-left">I'm the modal content</div>
-        <div className="s-mt-4 s-h-96 s-text-left">I'm the modal content</div>
-        <div className="s-mt-4 s-h-96 s-text-left">I'm the modal content</div>
+        <div className="s-mt-4 s-h-96 s-bg-red-300 s-text-left">
+          I'm the modal content
+        </div>
+        <div className="bg-red s-mt-4 s-h-96 s-bg-red-300 s-text-left">
+          I'm the modal content
+        </div>
+        <div className="bg-red s-mt-4 s-h-96 s-bg-red-300 s-text-left">
+          I'm the modal content
+        </div>
+        <div className="bg-red s-mt-4 s-h-96 s-bg-red-300 s-text-left">
+          I'm the modal content
+        </div>
       </Modal>
       <Button
         label="Modal without action and without changes"


### PR DESCRIPTION
We want the content to scroll "into" the header bar instead of into some margin a few pixels below