### PR TITLE
Fix Assistant  mobile nav width

### DIFF
--- a/front/components/sparkle/AppLayout.tsx
+++ b/front/components/sparkle/AppLayout.tsx
@@ -40,7 +40,7 @@ function NavigationBar({
   const router = useRouter();
 
   return (
-    <div className="flex grow flex-col border-r border-structure-200 bg-structure-50">
+    <div className="flex min-w-0 grow flex-col border-r border-structure-200 bg-structure-50">
       <div className="mt-4 flex flex-col gap-4">
         <div className="flex flex-row">
           <div className="flex flex-initial items-center">


### PR DESCRIPTION
Fixing https://github.com/dust-tt/tasks/issues/5

> Flexbox Behavior: In a flex container, a flex item will try to respect the size of its container, but not always. For example, the child may grow if it contains content that cannot be broken or shrunk down. You could add min-w-0 to the child div to make sure it respects its parent's fixed width.

Once you found that, it's a 7 char PR. 😅 