### PR TITLE
fix: dont return anything from notion workflows

### DIFF
--- a/connectors/migrations/20230906_notion_fill_parents_field.ts
+++ b/connectors/migrations/20230906_notion_fill_parents_field.ts
@@ -66,7 +66,11 @@ async function updateParentsFieldForConnector(connector: Connector) {
   });
 
   // update all parents fields for all pages and databases
-  await updateAllParentsFields(connector, [...pages, ...databases]);
+  await updateAllParentsFields(
+    connector,
+    pages.map((p) => p.notionPageId),
+    databases.map((d) => d.notionDatabaseId)
+  );
 }
 
 main()

--- a/connectors/src/connectors/notion/lib/connectors_db_helpers.ts
+++ b/connectors/src/connectors/notion/lib/connectors_db_helpers.ts
@@ -50,7 +50,7 @@ export async function upsertNotionPageInConnectorsDb({
     notionUrl?: string;
     lastUpsertedTs?: Date;
     skipReason?: string;
-    lastCreatedOrMovedRunTs?: number;
+    lastCreatedOrMovedRunTs?: Date;
   } = {
     lastSeenTs: new Date(lastSeenTs),
   };
@@ -73,7 +73,7 @@ export async function upsertNotionPageInConnectorsDb({
     updateParams.notionUrl = notionUrl;
   }
   if (lastCreatedOrMovedRunTs) {
-    updateParams.lastCreatedOrMovedRunTs = lastCreatedOrMovedRunTs;
+    updateParams.lastCreatedOrMovedRunTs = new Date(lastCreatedOrMovedRunTs);
   }
 
   if (page) {
@@ -165,7 +165,7 @@ export async function upsertNotionDatabaseInConnectorsDb({
     title?: string;
     notionUrl?: string;
     skipReason?: string;
-    lastCreatedOrMovedRunTs?: number;
+    lastCreatedOrMovedRunTs?: Date;
   } = {
     lastSeenTs: new Date(lastSeenTs),
   };
@@ -185,7 +185,7 @@ export async function upsertNotionDatabaseInConnectorsDb({
     updateParams.notionUrl = notionUrl;
   }
   if (lastCreatedOrMovedRunTs) {
-    updateParams.lastCreatedOrMovedRunTs = lastCreatedOrMovedRunTs;
+    updateParams.lastCreatedOrMovedRunTs = new Date(lastCreatedOrMovedRunTs);
   }
 
   if (database) {

--- a/connectors/src/connectors/notion/lib/connectors_db_helpers.ts
+++ b/connectors/src/connectors/notion/lib/connectors_db_helpers.ts
@@ -12,6 +12,7 @@ export async function upsertNotionPageInConnectorsDb({
   notionUrl,
   lastUpsertedTs,
   skipReason,
+  lastCreatedOrMovedRunTs,
 }: {
   dataSourceInfo: DataSourceInfo;
   notionPageId: string;
@@ -22,6 +23,7 @@ export async function upsertNotionPageInConnectorsDb({
   notionUrl?: string | null;
   lastUpsertedTs?: number;
   skipReason?: string;
+  lastCreatedOrMovedRunTs?: number;
 }): Promise<NotionPage> {
   const connector = await Connector.findOne({
     where: {
@@ -48,6 +50,7 @@ export async function upsertNotionPageInConnectorsDb({
     notionUrl?: string;
     lastUpsertedTs?: Date;
     skipReason?: string;
+    lastCreatedOrMovedRunTs?: number;
   } = {
     lastSeenTs: new Date(lastSeenTs),
   };
@@ -68,6 +71,9 @@ export async function upsertNotionPageInConnectorsDb({
   }
   if (notionUrl) {
     updateParams.notionUrl = notionUrl;
+  }
+  if (lastCreatedOrMovedRunTs) {
+    updateParams.lastCreatedOrMovedRunTs = lastCreatedOrMovedRunTs;
   }
 
   if (page) {
@@ -123,6 +129,7 @@ export async function upsertNotionDatabaseInConnectorsDb({
   title,
   notionUrl,
   skipReason,
+  lastCreatedOrMovedRunTs,
 }: {
   dataSourceInfo: DataSourceInfo;
   notionDatabaseId: string;
@@ -132,6 +139,7 @@ export async function upsertNotionDatabaseInConnectorsDb({
   title?: string | null;
   notionUrl?: string | null;
   skipReason?: string;
+  lastCreatedOrMovedRunTs?: number;
 }): Promise<NotionDatabase> {
   const connector = await Connector.findOne({
     where: {
@@ -157,6 +165,7 @@ export async function upsertNotionDatabaseInConnectorsDb({
     title?: string;
     notionUrl?: string;
     skipReason?: string;
+    lastCreatedOrMovedRunTs?: number;
   } = {
     lastSeenTs: new Date(lastSeenTs),
   };
@@ -174,6 +183,9 @@ export async function upsertNotionDatabaseInConnectorsDb({
   }
   if (notionUrl) {
     updateParams.notionUrl = notionUrl;
+  }
+  if (lastCreatedOrMovedRunTs) {
+    updateParams.lastCreatedOrMovedRunTs = lastCreatedOrMovedRunTs;
   }
 
   if (database) {

--- a/connectors/src/connectors/notion/lib/parents.ts
+++ b/connectors/src/connectors/notion/lib/parents.ts
@@ -146,9 +146,11 @@ async function getPagesToUpdate(
       return pageOrDbId;
     }
   };
+  const visited = new Set<string>();
 
   while (toProcess.size > 0) {
     const pageOrDbIdToProcess = shift() as string; // guaranteed to be defined as toUpdate.size > 0
+    visited.add(pageOrDbIdToProcess);
 
     const pageChildren = await getPageChildrenOf(
       dataSourceConfig,
@@ -168,6 +170,9 @@ async function getPagesToUpdate(
 
     // add all page and DB children to toProcess
     for (const child of [...pageChildren, ...databaseChildren]) {
+      if (visited.has(notionPageOrDbId(child))) {
+        continue;
+      }
       const childId = notionPageOrDbId(child);
       toProcess.add(childId);
     }

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -348,7 +348,7 @@ export async function notionUpsertPageActivity(
   runTimestamp: number,
   loggerArgs: Record<string, string | number>,
   isFullSync: boolean
-): Promise<UpsertActivityResult> {
+): Promise<void> {
   const localLogger = logger.child({ ...loggerArgs, pageId });
 
   const notionPage = await getNotionPageFromConnectorsDb(
@@ -360,7 +360,7 @@ export async function notionUpsertPageActivity(
 
   if (alreadySeenInRun) {
     localLogger.info("Skipping page already seen in this run");
-    return { pageOrDb: notionPage, createdOrMoved: false };
+    return;
   }
 
   const isSkipped = !!notionPage?.skipReason;
@@ -370,7 +370,7 @@ export async function notionUpsertPageActivity(
       { skipReason: notionPage.skipReason },
       "Skipping page with skip reason"
     );
-    return { pageOrDb: notionPage, createdOrMoved: false };
+    return;
   }
 
   let upsertTs: number | undefined = undefined;
@@ -383,7 +383,7 @@ export async function notionUpsertPageActivity(
 
   if (parsedPage && parsedPage.rendered.length > MAX_DOCUMENT_TXT_LEN) {
     localLogger.info("Skipping page with too large body");
-    const newNotionPage = await upsertNotionPageInConnectorsDb({
+    await upsertNotionPageInConnectorsDb({
       dataSourceInfo: dataSourceConfig,
       notionPageId: pageId,
       lastSeenTs: runTimestamp,
@@ -393,8 +393,9 @@ export async function notionUpsertPageActivity(
       notionUrl: parsedPage ? parsedPage.url : null,
       lastUpsertedTs: upsertTs,
       skipReason: "body_too_large",
+      lastCreatedOrMovedRunTs: createdOrMoved ? runTimestamp : undefined,
     });
-    return { pageOrDb: newNotionPage, createdOrMoved };
+    return;
   }
 
   if (parsedPage && parsedPage.hasBody) {
@@ -425,7 +426,7 @@ export async function notionUpsertPageActivity(
   }
 
   localLogger.info("notionUpsertPageActivity: Upserting notion page in DB.");
-  const newNotionPage = await upsertNotionPageInConnectorsDb({
+  await upsertNotionPageInConnectorsDb({
     dataSourceInfo: dataSourceConfig,
     notionPageId: pageId,
     lastSeenTs: runTimestamp,
@@ -434,8 +435,9 @@ export async function notionUpsertPageActivity(
     title: parsedPage ? parsedPage.title : null,
     notionUrl: parsedPage ? parsedPage.url : null,
     lastUpsertedTs: upsertTs,
+    lastCreatedOrMovedRunTs: createdOrMoved ? runTimestamp : undefined,
   });
-  return { pageOrDb: newNotionPage, createdOrMoved };
+  return;
 }
 
 export async function notionUpsertDatabaseActivity(
@@ -444,7 +446,7 @@ export async function notionUpsertDatabaseActivity(
   dataSourceConfig: DataSourceConfig,
   runTimestamp: number,
   loggerArgs: Record<string, string | number>
-): Promise<UpsertActivityResult> {
+): Promise<void> {
   const localLogger = logger.child({ ...loggerArgs, databaseId });
 
   const notionDatabase = await getNotionDatabaseFromConnectorsDb(
@@ -457,7 +459,7 @@ export async function notionUpsertDatabaseActivity(
 
   if (alreadySeenInRun) {
     localLogger.info("Skipping database already seen in this run");
-    return { pageOrDb: notionDatabase, createdOrMoved: false };
+    return;
   }
 
   const isSkipped = !!notionDatabase?.skipReason;
@@ -467,7 +469,7 @@ export async function notionUpsertDatabaseActivity(
       { skipReason: notionDatabase.skipReason },
       "Skipping database with skip reason"
     );
-    return { pageOrDb: notionDatabase, createdOrMoved: false };
+    return;
   }
 
   localLogger.info(
@@ -480,7 +482,7 @@ export async function notionUpsertDatabaseActivity(
     parsedDb?.parentType !== notionDatabase?.parentType ||
     parsedDb?.parentId !== notionDatabase?.parentId;
 
-  const newNotionDb = await upsertNotionDatabaseInConnectorsDb({
+  await upsertNotionDatabaseInConnectorsDb({
     dataSourceInfo: dataSourceConfig,
     notionDatabaseId: databaseId,
     lastSeenTs: runTimestamp,
@@ -488,8 +490,8 @@ export async function notionUpsertDatabaseActivity(
     parentId: parsedDb ? parsedDb.parentId : null,
     title: parsedDb ? parsedDb.title : null,
     notionUrl: parsedDb ? parsedDb.url : null,
+    lastCreatedOrMovedRunTs: createdOrMoved ? runTimestamp : undefined,
   });
-  return { pageOrDb: newNotionDb, createdOrMoved: createdOrMoved };
 }
 
 export async function saveSuccessSyncActivity(
@@ -964,7 +966,7 @@ export async function garbageCollectActivity(
 
 export async function updateParentsFieldsActivity(
   dataSourceConfig: DataSourceConfig,
-  activitiesResults: UpsertActivityResult[],
+  runTimestamp: number,
   activityExecutionTimestamp: number
 ) {
   const localLogger = logger.child({
@@ -973,13 +975,44 @@ export async function updateParentsFieldsActivity(
   });
   // Get documents whose path changed (created or moved) If there is
   // createdOrMoved, then the document cannot be null thus the cast is safe
-  const documents = activitiesResults
-    .filter((aRes) => aRes.createdOrMoved)
-    .map((aRes) => aRes.pageOrDb) as (NotionPage | NotionDatabase)[];
+
+  const connector = await Connector.findOne({
+    where: {
+      type: "notion",
+      workspaceId: dataSourceConfig.workspaceId,
+      dataSourceName: dataSourceConfig.dataSourceName,
+    },
+  });
+  if (!connector) {
+    throw new Error("Could not find connector");
+  }
+
+  const notionPageIds = (
+    await NotionPage.findAll({
+      where: {
+        connectorId: connector.id,
+        lastCreatedOrMovedRunTs: runTimestamp,
+      },
+      attributes: ["notionPageId"],
+    })
+  ).map((page) => page.notionPageId);
+
+  const notionDatabaseIds = (
+    await NotionDatabase.findAll({
+      where: {
+        connectorId: connector.id,
+        lastCreatedOrMovedRunTs: runTimestamp,
+      },
+      attributes: ["notionDatabaseId"],
+    })
+  ).map((db) => db.notionDatabaseId);
+
   const nbUpdated = await updateAllParentsFields(
     dataSourceConfig,
-    documents,
+    notionPageIds,
+    notionDatabaseIds,
     activityExecutionTimestamp.toString()
   );
+
   localLogger.info({ nbUpdated }, "Updated parents fields.");
 }

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -973,8 +973,6 @@ export async function updateParentsFieldsActivity(
     workspaceId: dataSourceConfig.workspaceId,
     dataSourceName: dataSourceConfig.dataSourceName,
   });
-  // Get documents whose path changed (created or moved) If there is
-  // createdOrMoved, then the document cannot be null thus the cast is safe
 
   const connector = await Connector.findOne({
     where: {

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -336,11 +336,6 @@ export async function notionGetToSyncActivity(
   };
 }
 
-export type UpsertActivityResult = {
-  pageOrDb: NotionPage | NotionDatabase | null;
-  createdOrMoved: boolean;
-};
-
 export async function notionUpsertPageActivity(
   accessToken: string,
   pageId: string,

--- a/connectors/src/connectors/notion/temporal/workflows.ts
+++ b/connectors/src/connectors/notion/temporal/workflows.ts
@@ -10,7 +10,6 @@ import {
 import PQueue from "p-queue";
 
 import type * as activities from "@connectors/connectors/notion/temporal/activities";
-import { UpsertActivityResult } from "@connectors/connectors/notion/temporal/activities";
 import { DataSourceConfig } from "@connectors/types/data_source_config";
 
 import { getWorkflowId } from "./utils";

--- a/connectors/src/connectors/notion/temporal/workflows.ts
+++ b/connectors/src/connectors/notion/temporal/workflows.ts
@@ -95,12 +95,7 @@ export async function notionSyncWorkflow(
       concurrency: MAX_CONCURRENT_CHILD_WORKFLOWS,
     });
 
-    const promises: Promise<
-      {
-        upsertPageResults: UpsertActivityResult[];
-        upsertDatabaseResults: UpsertActivityResult[];
-      }[]
-    >[] = [];
+    const promises: Promise<void>[] = [];
 
     // we go through each result page of the notion  search API
     do {
@@ -134,7 +129,7 @@ export async function notionSyncWorkflow(
       // the worflow that processes databases will itself trigger child workflows to process
       // batches of child pages.
       promises.push(
-        getUpsertResults({
+        performUpserts({
           dataSourceConfig,
           notionAccessToken,
           pageIds,
@@ -150,18 +145,11 @@ export async function notionSyncWorkflow(
     } while (cursor);
 
     // wait for all child workflows to finish
-    const results = (await Promise.all(promises)).flat();
-
-    const pageUpsertResults = results.flatMap((r) => r.upsertPageResults);
-    const databaseUpsertResults = results.flatMap(
-      (r) => r.upsertDatabaseResults
-    );
-
-    const allResults = [...pageUpsertResults, ...databaseUpsertResults];
+    await Promise.all(promises);
 
     await updateParentsFieldsActivity(
       dataSourceConfig,
-      allResults,
+      runTimestamp,
       new Date().getTime()
     );
 
@@ -204,12 +192,12 @@ export async function notionSyncResultPageWorkflow(
   pageIds: string[],
   runTimestamp: number,
   isBatchSync = false
-): Promise<(UpsertActivityResult | void)[]> {
+): Promise<void> {
   const upsertQueue = new PQueue({
     concurrency: MAX_PENDING_UPSERT_ACTIVITIES,
   });
 
-  const promises: Promise<UpsertActivityResult | void>[] = [];
+  const promises: Promise<void>[] = [];
 
   for (const [pageIndex, pageId] of pageIds.entries()) {
     const loggerArgs = {
@@ -231,7 +219,7 @@ export async function notionSyncResultPageWorkflow(
     );
   }
 
-  return await Promise.all(promises);
+  await Promise.all(promises);
 }
 
 export async function notionSyncResultPageDatabaseWorkflow(
@@ -241,10 +229,7 @@ export async function notionSyncResultPageDatabaseWorkflow(
   runTimestamp: number,
   isGarbageCollectionRun = false,
   isBatchSync = false
-): Promise<{
-  upsertPageResults: UpsertActivityResult[];
-  upsertDatabaseResults: UpsertActivityResult[];
-}> {
+): Promise<void> {
   const upsertQueue = new PQueue({
     concurrency: MAX_PENDING_UPSERT_ACTIVITIES,
   });
@@ -252,13 +237,7 @@ export async function notionSyncResultPageDatabaseWorkflow(
     concurrency: MAX_CONCURRENT_CHILD_WORKFLOWS,
   });
 
-  const databaseUpsertPromises: Promise<UpsertActivityResult | void>[] = [];
-  const resultsPromises: Promise<
-    {
-      upsertPageResults: UpsertActivityResult[];
-      upsertDatabaseResults: UpsertActivityResult[];
-    }[]
-  >[] = [];
+  let promises: Promise<void>[] = [];
 
   for (const [databaseIndex, databaseId] of databaseIds.entries()) {
     const loggerArgs = {
@@ -267,7 +246,7 @@ export async function notionSyncResultPageDatabaseWorkflow(
       databaseIndex,
     };
 
-    databaseUpsertPromises.push(
+    promises.push(
       upsertQueue.add(() =>
         notionUpsertDatabaseActivity(
           notionAccessToken,
@@ -282,12 +261,8 @@ export async function notionSyncResultPageDatabaseWorkflow(
 
   // wait for all db upserts before moving on to the children pages
   // otherwise we don't have control over concurrency
-  const dbUpsertResults: UpsertActivityResult[] = [];
-  for (const result of await Promise.all(databaseUpsertPromises)) {
-    if (result) {
-      dbUpsertResults.push(result);
-    }
-  }
+  await Promise.all(promises);
+  promises = [];
 
   for (const databaseId of databaseIds) {
     let cursor: string | null = null;
@@ -315,7 +290,7 @@ export async function notionSyncResultPageDatabaseWorkflow(
       });
       cursor = nextCursor;
       pageIndex += 1;
-      const upsertResultsPromise = getUpsertResults({
+      const upsertsPromise = performUpserts({
         dataSourceConfig,
         notionAccessToken,
         pageIds,
@@ -329,19 +304,14 @@ export async function notionSyncResultPageDatabaseWorkflow(
         childWorkflowsNameSuffix: `database-children-${databaseId}`,
       });
 
-      resultsPromises.push(upsertResultsPromise);
+      promises.push(upsertsPromise);
     } while (cursor);
   }
 
-  const upsertResults = (await Promise.all(resultsPromises)).flat();
-
-  return {
-    upsertPageResults: upsertResults.flatMap((r) => r.upsertPageResults),
-    upsertDatabaseResults: dbUpsertResults,
-  };
+  await Promise.all(promises);
 }
 
-async function getUpsertResults({
+async function performUpserts({
   dataSourceConfig,
   notionAccessToken,
   pageIds,
@@ -365,19 +335,11 @@ async function getUpsertResults({
   skipUpToDatePages: boolean;
   queue: PQueue;
   childWorkflowsNameSuffix?: string;
-}): Promise<
-  {
-    upsertPageResults: UpsertActivityResult[];
-    upsertDatabaseResults: UpsertActivityResult[];
-  }[]
-> {
+}): Promise<void> {
   let pagesToSync: string[] = [];
   let databasesToSync: string[] = [];
 
-  const promises: Promise<{
-    upsertPageResults: UpsertActivityResult[];
-    upsertDatabaseResults: UpsertActivityResult[];
-  }>[] = [];
+  const promises: Promise<void>[] = [];
 
   if (isGarbageCollectionRun) {
     // Mark pages and databases as visited to avoid deleting them and return pages and databases
@@ -396,7 +358,7 @@ async function getUpsertResults({
   }
 
   if (!pagesToSync.length && !databasesToSync.length) {
-    return [];
+    return;
   }
 
   if (pagesToSync.length) {
@@ -418,40 +380,19 @@ async function getUpsertResults({
       }
 
       promises.push(
-        queue
-          .add(() =>
-            executeChild(notionSyncResultPageWorkflow, {
-              workflowId,
-              args: [
-                dataSourceConfig,
-                notionAccessToken,
-                batch,
-                runTimestamp,
-                isBatchSync,
-              ],
-              parentClosePolicy:
-                ParentClosePolicy.PARENT_CLOSE_POLICY_TERMINATE,
-            })
-          )
-          .then((r) => {
-            if (!r) {
-              return {
-                upsertPageResults: [],
-                upsertDatabaseResults: [],
-              };
-            }
-            const pageResults: UpsertActivityResult[] = [];
-            for (const result of r) {
-              if (result) {
-                pageResults.push(result);
-              }
-            }
-
-            return {
-              upsertPageResults: pageResults,
-              upsertDatabaseResults: [],
-            };
+        queue.add(() =>
+          executeChild(notionSyncResultPageWorkflow, {
+            workflowId,
+            args: [
+              dataSourceConfig,
+              notionAccessToken,
+              batch,
+              runTimestamp,
+              isBatchSync,
+            ],
+            parentClosePolicy: ParentClosePolicy.PARENT_CLOSE_POLICY_TERMINATE,
           })
+        )
       );
     }
   }
@@ -478,36 +419,23 @@ async function getUpsertResults({
       }
 
       promises.push(
-        queue
-          .add(() =>
-            executeChild(notionSyncResultPageDatabaseWorkflow, {
-              workflowId,
-              args: [
-                dataSourceConfig,
-                notionAccessToken,
-                batch,
-                runTimestamp,
-                isGarbageCollectionRun,
-                isBatchSync,
-              ],
-              parentClosePolicy:
-                ParentClosePolicy.PARENT_CLOSE_POLICY_TERMINATE,
-            })
-          )
-          .then((r) => {
-            if (!r) {
-              return {
-                upsertPageResults: [],
-                upsertDatabaseResults: [],
-              };
-            }
-            return r;
+        queue.add(() =>
+          executeChild(notionSyncResultPageDatabaseWorkflow, {
+            workflowId,
+            args: [
+              dataSourceConfig,
+              notionAccessToken,
+              batch,
+              runTimestamp,
+              isGarbageCollectionRun,
+              isBatchSync,
+            ],
+            parentClosePolicy: ParentClosePolicy.PARENT_CLOSE_POLICY_TERMINATE,
           })
+        )
       );
     }
   }
 
-  const results = await Promise.all(promises);
-
-  return results;
+  await Promise.all(promises);
 }

--- a/connectors/src/lib/models.ts
+++ b/connectors/src/lib/models.ts
@@ -436,7 +436,7 @@ export class NotionPage extends Model<
   declare notionPageId: string;
   declare lastSeenTs: Date;
   declare lastUpsertedTs?: Date;
-  declare lastCreatedOrMovedRunTs: CreationOptional<number | null>;
+  declare lastCreatedOrMovedRunTs: CreationOptional<Date | null>;
 
   declare skipReason?: string | null;
 
@@ -479,7 +479,7 @@ NotionPage.init(
       allowNull: true,
     },
     lastCreatedOrMovedRunTs: {
-      type: DataTypes.INTEGER,
+      type: DataTypes.DATE,
       allowNull: true,
     },
     skipReason: {
@@ -536,7 +536,7 @@ export class NotionDatabase extends Model<
 
   declare notionDatabaseId: string;
   declare lastSeenTs: Date;
-  declare lastCreatedOrMovedRunTs: CreationOptional<number | null>;
+  declare lastCreatedOrMovedRunTs: CreationOptional<Date | null>;
 
   declare skipReason?: string | null;
 
@@ -575,7 +575,7 @@ NotionDatabase.init(
       allowNull: false,
     },
     lastCreatedOrMovedRunTs: {
-      type: DataTypes.INTEGER,
+      type: DataTypes.DATE,
       allowNull: true,
     },
     skipReason: {

--- a/connectors/src/lib/models.ts
+++ b/connectors/src/lib/models.ts
@@ -436,6 +436,7 @@ export class NotionPage extends Model<
   declare notionPageId: string;
   declare lastSeenTs: Date;
   declare lastUpsertedTs?: Date;
+  declare lastCreatedOrMovedRunTs: CreationOptional<number | null>;
 
   declare skipReason?: string | null;
 
@@ -477,6 +478,10 @@ NotionPage.init(
       type: DataTypes.DATE,
       allowNull: true,
     },
+    lastCreatedOrMovedRunTs: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+    },
     skipReason: {
       type: DataTypes.STRING,
       allowNull: true,
@@ -509,6 +514,7 @@ NotionPage.init(
       { fields: ["connectorId"] },
       { fields: ["lastSeenTs"] },
       { fields: ["parentId"] },
+      { fields: ["lastCreatedOrMovedRunTs"] },
       {
         fields: ["titleSearchVector"],
         using: "gist",
@@ -530,6 +536,7 @@ export class NotionDatabase extends Model<
 
   declare notionDatabaseId: string;
   declare lastSeenTs: Date;
+  declare lastCreatedOrMovedRunTs: CreationOptional<number | null>;
 
   declare skipReason?: string | null;
 
@@ -567,6 +574,10 @@ NotionDatabase.init(
       type: DataTypes.DATE,
       allowNull: false,
     },
+    lastCreatedOrMovedRunTs: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+    },
     skipReason: {
       type: DataTypes.STRING,
       allowNull: true,
@@ -598,6 +609,7 @@ NotionDatabase.init(
       { fields: ["notionDatabaseId", "connectorId"], unique: true },
       { fields: ["connectorId", "skipReason"] },
       { fields: ["lastSeenTs"] },
+      { fields: ["lastCreatedOrMovedRunTs"] },
       { fields: ["parentId"] },
       {
         fields: ["titleSearchVector"],


### PR DESCRIPTION
We've occasionally gone over the workflow return size limit on temporal.
This is due to 2 things:
- 1) we are returning every "upsert result" down to the root to update the parents field
- 2) we have child workflows that might themselves spawn a lot of child workflows, so they become "bottlenecks" through which a lot of data flows (so we can pass it back to the main workflow)

The solution:
- use the database, and stop returning data from  the workflows