### PR TITLE
Fix user profile pic on shared conversation in chat v1

### DIFF
--- a/front/pages/w/[wId]/u/chat/[cId]/index.tsx
+++ b/front/pages/w/[wId]/u/chat/[cId]/index.tsx
@@ -509,6 +509,7 @@ export function MessageView({
   message,
   loading,
   isLatestRetrieval,
+  readOnly,
   feedback,
 }: {
   user: UserType | null;
@@ -544,7 +545,7 @@ export function MessageView({
                 busy={loading}
               />
             ) : (
-              <Avatar visual={user?.image} size="sm" />
+              <Avatar visual={readOnly ? null : user?.image} size="sm" />
             )}
           </div>
           <div


### PR DESCRIPTION
Fixes https://github.com/dust-tt/tasks/issues/4

If the user is in readOnly (= does not own the convo), we display the default profile pic. 
<img width="836" alt="Capture d’écran 2023-09-14 à 09 57 46" src="https://github.com/dust-tt/dust/assets/3803406/4d0b47f0-dea3-4fa6-ba8c-c92a731e79ee">
