### PR TITLE
Assitant Input Bar implementation

### DIFF
--- a/front/components/assistant/conversation/InputBar.tsx
+++ b/front/components/assistant/conversation/InputBar.tsx
@@ -132,13 +132,13 @@ function AgentListImpl(
       leaveTo="transform opacity-0 scale-100 translate-y-0"
     >
       <div
-        className="max-h-128 fixed z-10 rounded-xl border border-structure-200 bg-white shadow-xl"
+        className="max-h-128 fixed z-10 w-44 rounded-xl border border-structure-100 bg-white shadow-xl"
         style={{
           bottom: position.bottom,
           left: position.left,
         }}
       >
-        <div className="flex flex-col gap-y-2 overflow-y-auto px-3 py-3">
+        <div className="flex flex-col gap-y-4 overflow-y-auto px-3 py-2">
           {filtered.map((c, i) => (
             <div
               className="flex w-full px-1"
@@ -151,14 +151,14 @@ function AgentListImpl(
                   setFocus(i);
                 }}
               >
-                <div className="flex flex-initial items-center gap-x-2 ">
-                  <div className="flex pt-1">
+                <div className="flex flex-initial items-center gap-x-2 py-1">
+                  <div className="flex">
                     <img src={c.pictureUrl} className="h-5 w-5 rounded-full" />
                   </div>
                   <div
                     className={classNames(
-                      "flex-initial font-medium",
-                      focus === i ? "text-action-500" : "text-element-800"
+                      "flex-initial text-sm font-semibold",
+                      focus === i ? "text-action-500" : "text-element-900"
                     )}
                   >
                     {"@"}
@@ -484,7 +484,11 @@ export function AssistantInputBar({
                   <DropdownMenu.Button icon={RobotIcon} />
                   <DropdownMenu.Items origin="bottomRight">
                     {agentConfigurations.map((c) => (
-                      <DropdownMenu.Item key={c.sId} label={"@" + c.name} />
+                      <DropdownMenu.Item
+                        key={c.sId}
+                        label={"@" + c.name}
+                        imageUrl={c.pictureUrl}
+                      />
                     ))}
                   </DropdownMenu.Items>
                 </DropdownMenu>

--- a/front/components/assistant/conversation/InputBar.tsx
+++ b/front/components/assistant/conversation/InputBar.tsx
@@ -237,6 +237,7 @@ export function AssistantInputBar({
       });
 
       onSubmit(content, mentions);
+      contentEditable.innerHTML = "";
     }
   };
 

--- a/front/components/assistant/conversation/InputBar.tsx
+++ b/front/components/assistant/conversation/InputBar.tsx
@@ -1,74 +1,514 @@
-import { PaperAirplaneIcon } from "@dust-tt/sparkle";
-import { useEffect, useRef, useState } from "react";
-import TextareaAutosize from "react-textarea-autosize";
+import { DropdownMenu, PaperAirplaneIcon, RobotIcon } from "@dust-tt/sparkle";
+import {
+  ForwardedRef,
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from "react";
+import * as ReactDOMServer from "react-dom/server";
 
+import { useAgentConfigurations } from "@app/lib/swr";
 import { classNames } from "@app/lib/utils";
+import { AgentConfigurationType } from "@app/types/assistant/agent";
 import { MentionType } from "@app/types/assistant/conversation";
+import { WorkspaceType } from "@app/types/user";
+
+function AgentMention({
+  agentConfiguration,
+}: {
+  agentConfiguration: AgentConfigurationType;
+}) {
+  return (
+    <div
+      className={classNames(
+        "inline-block rounded-sm px-1 py-0.5 text-xs font-bold",
+        "bg-gray-200"
+      )}
+      contentEditable={false}
+      data-agent-configuration={agentConfiguration?.sId}
+    >
+      {agentConfiguration.name}
+    </div>
+  );
+}
+
+// COMMAND LIST
+
+function AgentListImpl(
+  {
+    owner,
+    visible,
+    filter,
+    position,
+  }: {
+    owner: WorkspaceType;
+    visible: boolean;
+    filter: string;
+    position: {
+      bottom: number;
+      left: number;
+    };
+  },
+  ref: ForwardedRef<{
+    prev: () => void;
+    next: () => void;
+    reset: () => void;
+    selected: () => AgentConfigurationType | null;
+    noMatch: () => boolean;
+  }>
+) {
+  const [focus, setFocus] = useState<number>(0);
+
+  const focusRef = useRef<HTMLDivElement>(null);
+
+  const { agentConfigurations } = useAgentConfigurations({
+    workspaceId: owner.sId,
+  });
+
+  const filtered = agentConfigurations.filter((a) => {
+    return (
+      filter.length === 0 ||
+      a.name.toLowerCase().startsWith(filter.toLowerCase())
+    );
+  });
+
+  useImperativeHandle(ref, () => ({
+    prev: () => {
+      setFocus((f) => (f > 0 ? f - 1 : 0));
+    },
+    next: () => {
+      setFocus((f) => (f < filtered.length - 1 ? f + 1 : filtered.length - 1));
+    },
+    reset: () => {
+      setFocus(0);
+    },
+    selected: () => {
+      if (focus < filtered.length) {
+        return filtered[focus];
+      }
+      return null;
+    },
+    noMatch: () => {
+      return filtered.length === 0;
+    },
+  }));
+
+  useEffect(() => {
+    if (focus > filtered.length - 1) {
+      setFocus(filtered.length - 1);
+    }
+    if (focusRef.current) {
+      focusRef.current.scrollIntoView({
+        // behavior: 'smooth',
+        block: "nearest",
+        inline: "start",
+      });
+    }
+  }, [focus, visible, filter, filtered]);
+
+  return (
+    <>
+      {visible ? (
+        <div
+          className="fixed z-30 w-64 rounded-xl bg-red-100 shadow-xl"
+          style={{
+            bottom: position.bottom,
+            left: position.left,
+          }}
+        >
+          <div className="flex flex-col">
+            <div className="flex-1"></div>
+            <div className="z-10 flex flex-col overflow-auto rounded-xl border bg-white">
+              {filtered.map((c, i) => (
+                <div
+                  className="flex w-full px-1"
+                  key={c.name}
+                  ref={focus === i ? focusRef : null}
+                >
+                  <div
+                    className={classNames(
+                      "flex w-full cursor-pointer flex-col"
+                    )}
+                    onClick={() => {
+                      setFocus(i);
+                    }}
+                    onMouseEnter={() => {
+                      setFocus(i);
+                    }}
+                  >
+                    <div className={classNames("flex flex-initial py-1")}>
+                      <div
+                        className={classNames(
+                          "flex-initial py-1 pl-2 pr-2 font-medium",
+                          focus === i ? "text-action-500" : "text-element-800"
+                        )}
+                      >
+                        {"@"}
+                        {c.name}
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              ))}
+              {filtered.length === 0 ? (
+                <div className="flex items-center justify-center">
+                  <div className="flex-col">
+                    <p className="text-gray-500">No match</p>
+                  </div>
+                </div>
+              ) : null}
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </>
+  );
+}
+
+const AgentList = forwardRef(AgentListImpl);
 
 export function AssistantInputBar({
+  owner,
   onSubmit,
 }: {
+  owner: WorkspaceType;
   onSubmit: (input: string, mentions: MentionType[]) => void;
 }) {
   const [input, setInput] = useState("");
+  const [agentListVisible, setAgentListVisible] = useState(false);
+  const [agentListFilter, setAgentListFilter] = useState("");
+  const [agentListPosition, setAgentListPosition] = useState<{
+    bottom: number;
+    left: number;
+  }>({
+    bottom: 0,
+    left: 0,
+  });
+
   const inputRef = useRef<HTMLTextAreaElement>(null);
+  const agentListRef = useRef<{
+    prev: () => void;
+    next: () => void;
+    reset: () => void;
+    selected: () => AgentConfigurationType | null;
+    noMatch: () => boolean;
+  }>(null);
 
   useEffect(() => {
     inputRef.current?.focus();
   });
 
   return (
-    <div className="flex flex-1">
-      <div className="flex flex-1 flex-row items-center">
-        <div className="flex flex-1 flex-row items-end items-stretch">
-          <TextareaAutosize
-            minRows={1}
-            placeholder={"Ask a question"}
+    <>
+      <AgentList
+        owner={owner}
+        visible={agentListVisible}
+        filter={agentListFilter}
+        ref={agentListRef}
+        position={agentListPosition}
+      />
+      <div className="flex flex-1">
+        <div className="flex flex-1 flex-row items-center">
+          <div
             className={classNames(
-              "flex w-full resize-none bg-white text-base ring-0 focus:ring-0",
-              "rounded-sm rounded-xl border-2",
-              "border-action-200 text-element-800 drop-shadow-2xl focus:border-action-300 focus:ring-0",
-              "placeholder-gray-400",
-              "px-3 py-3 pr-8"
+              "flex flex-1 flex-row items-end items-stretch px-2",
+              "border-2 border-action-200 bg-white focus-within:border-action-300",
+              "rounded-sm rounded-xl drop-shadow-2xl  "
             )}
-            value={input}
-            onChange={(e) => {
-              setInput(e.target.value);
-            }}
-            ref={inputRef}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" && !e.shiftKey) {
-                void onSubmit(input, []);
+          >
+            <div
+              className="inline-block w-full resize-none overflow-auto whitespace-pre-wrap px-3 py-3 font-normal outline-0 focus:outline-0"
+              contentEditable={true}
+              onPaste={(e) => {
                 e.preventDefault();
-                setInput("");
-              }
-            }}
-            autoFocus={true}
-          />
-          <div className={classNames("z-10 -ml-8 flex flex-col")}>
-            <PaperAirplaneIcon
-              className="my-auto h-5 w-5 cursor-pointer text-action-500"
-              onClick={() => {
-                void onSubmit(input, []);
-                setInput("");
+                const text = e.clipboardData.getData("text/plain");
+                document.execCommand("insertText", false, text);
               }}
+              onKeyDown={(e) => {
+                if (e.ctrlKey || e.metaKey) {
+                  if (e.key === "u" || e.key === "b" || e.key === "i") {
+                    e.preventDefault();
+                  }
+                  if (e.key === "Enter") {
+                    e.preventDefault();
+                    //onSubmit();
+                  }
+                }
+              }}
+              onInput={(e) => {
+                const selection = window.getSelection();
+                if (
+                  selection &&
+                  selection.rangeCount !== 0 &&
+                  selection.isCollapsed
+                ) {
+                  const range = selection.getRangeAt(0);
+                  const node = range.endContainer;
+                  const offset = range.endOffset;
+
+                  const lastOne = node.textContent
+                    ? node.textContent.slice(offset - 1, offset)
+                    : null;
+                  const preLastOne = node.textContent
+                    ? node.textContent.slice(offset - 2, offset - 1)
+                    : null;
+
+                  // MENTION WIDGET
+
+                  if (
+                    lastOne === "@" &&
+                    (preLastOne === " " || preLastOne === "") &&
+                    node.textContent &&
+                    node.parentNode
+                  ) {
+                    console.log("create textNode");
+                    const textNode = document.createTextNode(
+                      node.textContent.slice(0, offset - 1)
+                    );
+
+                    console.log("create mentionNode");
+                    const mentionSelectNode = document.createElement("div");
+                    mentionSelectNode.style.display = "inline-block";
+                    mentionSelectNode.setAttribute("key", "mentionSelect");
+                    mentionSelectNode.className = "text-brand font-medium";
+                    mentionSelectNode.textContent = "@";
+                    mentionSelectNode.contentEditable = "false";
+
+                    const inputNode = document.createElement("span");
+                    //inputNode.setAttribute("type", "text");
+                    //inputNode.setAttribute("placeholder", "");
+                    inputNode.className =
+                      "min-w-0 border-none outline-none focus:outline-none focus:border-none ring-0 focus:ring-0 text-brand font-medium px-0 py-0";
+                    inputNode.contentEditable = "true";
+
+                    mentionSelectNode.appendChild(inputNode);
+
+                    const textNode2 = document.createTextNode(
+                      node.textContent.slice(offset)
+                    );
+
+                    node.parentNode.replaceChild(textNode, node);
+                    textNode.parentNode?.insertBefore(
+                      textNode2,
+                      textNode.nextSibling
+                    );
+                    textNode.parentNode?.insertBefore(
+                      mentionSelectNode,
+                      textNode2
+                    );
+
+                    console.log("inserted  + setAgentListVisible(true)");
+
+                    const rect = mentionSelectNode.getBoundingClientRect();
+                    const position = {
+                      left: Math.floor(rect.left) - 24,
+                      bottom: Math.floor(window.innerHeight - rect.bottom) + 32,
+                    };
+                    if (!isNaN(position.left) && !isNaN(position.bottom)) {
+                      setAgentListPosition(position);
+                    }
+
+                    setAgentListVisible(true);
+                    inputNode.focus();
+
+                    inputNode.onblur = () => {
+                      const selected =
+                        agentListRef.current?.selected() as AgentConfigurationType | null;
+                      setAgentListVisible(false);
+                      setAgentListFilter("");
+                      agentListRef.current?.reset();
+
+                      console.log("SELECTED", selected);
+
+                      if (selected) {
+                        const htmlString = ReactDOMServer.renderToStaticMarkup(
+                          <AgentMention agentConfiguration={selected} />
+                        );
+                        // const htmlString = ReactDOMServer.renderToStaticMarkup(
+                        //   <span className="text-red-900 font-bold">
+                        //     /{selected.name}
+                        //   </span>
+                        // );
+                        const wrapper = document.createElement("div");
+                        wrapper.innerHTML = htmlString.trim();
+                        const mentionNode = wrapper.firstChild;
+
+                        if (!mentionNode || !mentionNode.parentNode) {
+                          return;
+                        }
+
+                        // Replace tabSelectNode with mentionSelectNode.
+                        mentionSelectNode.parentNode.replaceChild(
+                          mentionNode,
+                          mentionSelectNode
+                        );
+
+                        // Prepend a space to textNode2 (this will be the space that comes after the
+                        // mention).
+                        textNode2.textContent = ` ${textNode2.textContent}`;
+
+                        // If textNode2 is the last node add a `\n` just because ¯\_(ツ)_/¯
+                        if (textNode2.nextSibling === null) {
+                          textNode2.textContent = `${textNode2.textContent}\n`;
+                        }
+
+                        // Restore the cursor, taking into account the added space.
+                        range.setStart(textNode2, 1);
+                        range.setEnd(textNode2, 1);
+                        selection.removeAllRanges();
+                        selection.addRange(range);
+                      } else if (mentionSelectNode.parentNode) {
+                        // Remove mentionSelectNode restore cursor and re-add @
+                        mentionSelectNode.parentNode.removeChild(
+                          mentionSelectNode
+                        );
+
+                        range.setStart(textNode2, 0);
+                        range.setEnd(textNode2, 0);
+                        selection.removeAllRanges();
+                        selection.addRange(range);
+
+                        // insert the content of mentionSelectNode before textNode2
+                        const textNode3 = document.createTextNode(
+                          mentionSelectNode.textContent || ""
+                        );
+                        textNode.parentNode?.insertBefore(
+                          textNode3,
+                          textNode.nextSibling
+                        );
+                      }
+                      // const s = new CmdState().updatedFromChildNodes(
+                      //   e.target.childNodes
+                      // );
+                      // onStateUpdate(s);
+                    };
+
+                    inputNode.onkeydown = (e) => {
+                      console.log("KEYDOWN", e.key);
+                      if (e.key === "Escape") {
+                        inputNode.blur();
+                        e.preventDefault();
+                      }
+                      if (e.key === "ArrowDown") {
+                        agentListRef.current?.next();
+                        e.preventDefault();
+                      }
+                      if (e.key === "ArrowUp") {
+                        agentListRef.current?.prev();
+                        e.preventDefault();
+                      }
+                      if (e.key === "Backspace") {
+                        if (inputNode.textContent === "") {
+                          agentListRef.current?.reset();
+                          inputNode.blur();
+                          e.preventDefault();
+                        }
+                      }
+                      if (e.key === "Enter" || e.key === " ") {
+                        inputNode.blur();
+                        e.preventDefault();
+                      }
+                    };
+
+                    inputNode.oninput = (e) => {
+                      if (
+                        e.target &&
+                        typeof e.target.textContent === "string"
+                      ) {
+                        console.log("INPUT", e.target.textContent);
+                        setAgentListFilter(e.target.textContent);
+                        e.stopPropagation();
+                        setTimeout(() => {
+                          if (agentListRef.current?.noMatch()) {
+                            agentListRef.current?.reset();
+                            inputNode.blur();
+                          }
+                        });
+                      }
+                    };
+                  }
+                }
+
+                // const s = new CmdState().updatedFromChildNodes(
+                //   e.target.childNodes
+                // );
+                // onStateUpdate(s);
+              }}
+              suppressContentEditableWarning={true}
+            ></div>
+
+            {/**
+            <TextareaAutosize
+              minRows={1}
+              placeholder={"Ask a question"}
+              className={classNames(
+                "flex w-full resize-none border-0 bg-white text-base ring-0 focus:ring-0",
+                "text-element-800",
+                "placeholder-gray-400",
+                "px-3 py-3"
+              )}
+              value={input}
+              onChange={(e) => {
+                setInput(e.target.value);
+              }}
+              ref={inputRef}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && !e.shiftKey && input.length > 0) {
+                  void onSubmit(input, []);
+                  e.preventDefault();
+                  setInput("");
+                }
+              }}
+              autoFocus={true}
             />
+ */}
+            <div className={classNames("z-10 flex flex-row space-x-3 pr-2")}>
+              <div className="flex flex-col justify-center">
+                <DropdownMenu>
+                  <DropdownMenu.Button icon={RobotIcon} />
+                  <DropdownMenu.Items origin="bottomRight">
+                    <DropdownMenu.Item label="item 1" href="#" />
+                    <DropdownMenu.Item label="item 2" href="#" />
+                  </DropdownMenu.Items>
+                </DropdownMenu>
+              </div>
+
+              <PaperAirplaneIcon
+                className={classNames(
+                  "my-auto h-5 w-5",
+                  input.length === 0
+                    ? "text-gray-400"
+                    : "cursor-pointer text-action-500"
+                )}
+                onClick={() => {
+                  if (input.length === 0) {
+                    return;
+                  }
+                  void onSubmit(input, []);
+                  setInput("");
+                }}
+              />
+            </div>
           </div>
         </div>
       </div>
-    </div>
+    </>
   );
 }
 
 export function FixedAssistantInputBar({
+  owner,
   onSubmit,
 }: {
+  owner: WorkspaceType;
   onSubmit: (input: string, mentions: MentionType[]) => void;
 }) {
   return (
     <div className="4xl:px-0 fixed bottom-0 left-0 right-0 z-20 flex-initial px-2 lg:left-80">
       <div className="mx-auto max-w-4xl pb-12">
-        <AssistantInputBar onSubmit={onSubmit} />
+        <AssistantInputBar owner={owner} onSubmit={onSubmit} />
       </div>
     </div>
   );

--- a/front/components/assistant/conversation/InputBar.tsx
+++ b/front/components/assistant/conversation/InputBar.tsx
@@ -516,7 +516,7 @@ export function AssistantInputBar({
                       <DropdownMenu.Item
                         key={c.sId}
                         label={"@" + c.name}
-                        imageUrl={c.pictureUrl}
+                        visual={c.pictureUrl}
                         onClick={() => {
                           const htmlString =
                             ReactDOMServer.renderToStaticMarkup(

--- a/front/components/assistant/conversation/InputBar.tsx
+++ b/front/components/assistant/conversation/InputBar.tsx
@@ -235,6 +235,9 @@ export function AssistantInputBar({
         }
       });
 
+      content = content.trim();
+      content = content.replace(/\u200B/g, "");
+
       onSubmit(content, mentions);
       contentEditable.innerHTML = "";
     }
@@ -518,6 +521,8 @@ export function AssistantInputBar({
                         label={"@" + c.name}
                         visual={c.pictureUrl}
                         onClick={() => {
+                          // We construct the HTML for an AgentMention and inject it in the content
+                          // editable with an extra space after it.
                           const htmlString =
                             ReactDOMServer.renderToStaticMarkup(
                               <AgentMention agentConfiguration={c} />

--- a/front/components/assistant/conversation/InputBar.tsx
+++ b/front/components/assistant/conversation/InputBar.tsx
@@ -528,7 +528,7 @@ export function AssistantInputBar({
                           const contentEditable =
                             document.getElementById("dust-input-bar");
                           if (contentEditable && mentionNode) {
-                            // add mentionNode as last childe of contentEditable
+                            // Add mentionNode as last childe of contentEditable.
                             contentEditable.appendChild(mentionNode);
                             const afterTextNode = document.createTextNode(" ");
                             contentEditable.appendChild(afterTextNode);

--- a/front/components/assistant/conversation/InputBar.tsx
+++ b/front/components/assistant/conversation/InputBar.tsx
@@ -1,6 +1,5 @@
 import {
   Avatar,
-  Button,
   DropdownMenu,
   IconButton,
   PaperAirplaneIcon,

--- a/front/lib/api/assistant/globalAgents.ts
+++ b/front/lib/api/assistant/globalAgents.ts
@@ -24,8 +24,8 @@ async function _getGPT4GlobalAgent(): Promise<AgentConfigurationType> {
   return {
     id: GLOBAL_AGENTS_ID.GPT4,
     sId: GLOBAL_AGENTS_SID.GPT4,
-    name: "GPT4",
-    pictureUrl: null,
+    name: "gpt4",
+    pictureUrl: "https://dust.tt/static/systemavatar/gpt4_avatar_full.png",
     status: "active",
     scope: "global",
     generation: {
@@ -63,8 +63,8 @@ async function _getSlackGlobalAgent(
   return {
     id: GLOBAL_AGENTS_ID.Slack,
     sId: GLOBAL_AGENTS_SID.Slack,
-    name: "Slack",
-    pictureUrl: null,
+    name: "slack",
+    pictureUrl: "https://dust.tt/static/systemavatar/slack_avatar_full.png",
     status: "active",
     scope: "global",
     generation: {

--- a/front/lib/api/assistant/globalAgents.ts
+++ b/front/lib/api/assistant/globalAgents.ts
@@ -133,9 +133,9 @@ export async function getGlobalAgent(
   switch (sId) {
     case GLOBAL_AGENTS_SID.GPT4:
       return _getGPT4GlobalAgent();
-    case GLOBAL_AGENTS_ID.Slack:
+    case GLOBAL_AGENTS_SID.Slack:
       return _getSlackGlobalAgent(auth);
-    case GLOBAL_AGENTS_ID.Claude:
+    case GLOBAL_AGENTS_SID.Claude:
       return _getClaude2GlobalAgent();
     default:
       return null;

--- a/front/lib/api/assistant/globalAgents.ts
+++ b/front/lib/api/assistant/globalAgents.ts
@@ -14,10 +14,12 @@ import { AgentConfigurationType } from "@app/types/assistant/agent";
 enum GLOBAL_AGENTS_SID {
   GPT4 = "gpt-4",
   Slack = "slack",
+  Claude = "claude-2",
 }
 enum GLOBAL_AGENTS_ID {
   GPT4 = -1,
   Slack = -2,
+  Claude = -3,
 }
 
 async function _getGPT4GlobalAgent(): Promise<AgentConfigurationType> {
@@ -34,6 +36,26 @@ async function _getGPT4GlobalAgent(): Promise<AgentConfigurationType> {
       model: {
         providerId: "openai",
         modelId: "gpt-4-0613",
+      },
+    },
+    action: null,
+  };
+}
+
+async function _getClaude2GlobalAgent(): Promise<AgentConfigurationType> {
+  return {
+    id: GLOBAL_AGENTS_ID.Claude,
+    sId: GLOBAL_AGENTS_SID.Claude,
+    name: "claude",
+    pictureUrl: "https://dust.tt/static/systemavatar/claude_avatar_full.png",
+    status: "active",
+    scope: "global",
+    generation: {
+      id: GLOBAL_AGENTS_ID.Claude,
+      prompt: "",
+      model: {
+        providerId: "anthropic",
+        modelId: "claude-2",
       },
     },
     action: null,
@@ -113,6 +135,8 @@ export async function getGlobalAgent(
       return _getGPT4GlobalAgent();
     case GLOBAL_AGENTS_ID.Slack:
       return _getSlackGlobalAgent(auth);
+    case GLOBAL_AGENTS_ID.Claude:
+      return _getClaude2GlobalAgent();
     default:
       return null;
   }
@@ -128,7 +152,10 @@ export async function getGlobalAgents(
 
   // For now we retrieve them all
   // We will store them in the database later to allow admin enable them or not
-  const globalAgents = [await _getGPT4GlobalAgent()];
+  const globalAgents = [
+    await _getGPT4GlobalAgent(),
+    await _getClaude2GlobalAgent(),
+  ];
   const slackAgent = await _getSlackGlobalAgent(auth);
   if (slackAgent) {
     globalAgents.push(slackAgent);

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@dust-tt/sparkle": "0.1.62",
+        "@dust-tt/sparkle": "0.1.66",
         "@headlessui/react": "^1.7.7",
         "@heroicons/react": "^2.0.11",
         "@nangohq/frontend": "^0.16.1",
@@ -714,9 +714,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.1.62",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.1.62.tgz",
-      "integrity": "sha512-f6zqcNKF8cnG0hoPgo715aM5lbq27VkVHj1iB5KqUxVSB64Ytc9OO8T/Q2XeMKoZqQFwe1dX7ZBCN8avdHenrQ==",
+      "version": "0.1.66",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.1.66.tgz",
+      "integrity": "sha512-r38MS+EnPw42F96p06JDHycqp7p3B46Y9+GD1IgW1IRxZhMkUliCHfgAEUeR50wxqbr70FYuWx3aQcionDeRbg==",
       "dependencies": {
         "@headlessui/react": "^1.7.17"
       },

--- a/front/package.json
+++ b/front/package.json
@@ -13,7 +13,7 @@
     "initdb": "env $(cat .env.local) npx tsx admin/db.ts"
   },
   "dependencies": {
-    "@dust-tt/sparkle": "0.1.63",
+    "@dust-tt/sparkle": "0.1.66",
     "@headlessui/react": "^1.7.7",
     "@heroicons/react": "^2.0.11",
     "@nangohq/frontend": "^0.16.1",

--- a/front/pages/w/[wId]/assistant/[cId]/index.tsx
+++ b/front/pages/w/[wId]/assistant/[cId]/index.tsx
@@ -101,7 +101,7 @@ export default function AssistantConversation({
       }
     >
       <Conversation owner={owner} conversationId={conversationId} />
-      <FixedAssistantInputBar onSubmit={handleSubmit} />
+      <FixedAssistantInputBar owner={owner} onSubmit={handleSubmit} />
     </AppLayout>
   );
 }

--- a/front/pages/w/[wId]/assistant/new.tsx
+++ b/front/pages/w/[wId]/assistant/new.tsx
@@ -155,7 +155,7 @@ export default function AssistantNew({
         )}
       </AssistantHelper>
 
-      <FixedAssistantInputBar onSubmit={handleSubmit} />
+      <FixedAssistantInputBar owner={owner} onSubmit={handleSubmit} />
     </AppLayout>
   );
 }

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -67,7 +67,7 @@ export type AgentConfigurationType = {
   status: AgentConfigurationStatus;
 
   name: string;
-  pictureUrl: string | null;
+  pictureUrl: string;
 
   // If undefined, no action performed, otherwise the action is
   // performed (potentially NoOp eg autoSkip above).


### PR DESCRIPTION
cc @dust-tt/engineering-team 

This is 98% there. There is one quite edge-casy bug preventing deleting a mention if it is at the beginning of the input bar by doing backspace (ctrl-a + delete do work). Only happens after you created and deleted a bunch of mentions and recreate one at the beginning.

Basically we manage a content editable from the InputBar component and rely a list of mentions component that we show and hide on demand close to the cursor. That component exposes an API (forwardRef + useImpearativeHandle machinery) to drive the selection (up / down, enter).

It is arguable that we could drive that state from InputBar instead with an onHover(focusIndex) on the AgentList. I'm not 100% convinced it's possible but could be explored, I went this way because I knew I could get to it with that approach.