### PR TITLE
Progress toward making retrieval work

### DIFF
--- a/front/lib/actions/registry.ts
+++ b/front/lib/actions/registry.ts
@@ -17,7 +17,7 @@ export const DustProdActionRegistry = createActionRegistry({
       workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
       appId: "f4816b1e13",
       appHash:
-        "67c42a248bd203a7ae3a1cf895e8b83e2f8d771e42d8ec46e4d5dadae2623f9f",
+        "a2f2883ec526e30d6f1d9c3e539968b383bda23ebdf737de15312172898915c0",
     },
     config: {
       MODEL: {

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -229,7 +229,7 @@ export async function generateRetrievalParams(
       if (configuration.query === "auto") {
         if (!rawInputs.query || typeof rawInputs.query !== "string") {
           return new Err(
-            new Error("Failed to genreate a valid retrieval query.")
+            new Error("Failed to generate a valid retrieval query.")
           );
         }
         query = rawInputs.query as string;
@@ -443,7 +443,7 @@ export async function* runRetrieval(
     relativeTimeFrameDuration: params.relativeTimeFrame?.duration ?? null,
     relativeTimeFrameUnit: params.relativeTimeFrame?.unit ?? null,
     topK: params.topK,
-    retrievalConfigurationId: c.id,
+    retrievalConfigurationId: c.sId,
   });
 
   yield {

--- a/front/lib/models/assistant/actions/retrieval.ts
+++ b/front/lib/models/assistant/actions/retrieval.ts
@@ -23,6 +23,8 @@ export class AgentRetrievalConfiguration extends Model<
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
+  declare sId: string;
+
   declare query: "auto" | "none" | "templated";
   declare queryTemplate: string | null;
   declare relativeTimeFrame: "auto" | "none" | "custom";
@@ -46,6 +48,10 @@ AgentRetrievalConfiguration.init(
       type: DataTypes.DATE,
       allowNull: false,
       defaultValue: DataTypes.NOW,
+    },
+    sId: {
+      type: DataTypes.STRING,
+      allowNull: false,
     },
     query: {
       type: DataTypes.STRING,
@@ -214,14 +220,12 @@ export class AgentRetrievalAction extends Model<
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
+  declare retrievalConfigurationId: string;
+
   declare query: string | null;
   declare relativeTimeFrameDuration: number | null;
   declare relativeTimeFrameUnit: TimeframeUnit | null;
   declare topK: number;
-
-  declare retrievalConfigurationId: ForeignKey<
-    AgentRetrievalConfiguration["id"]
-  >;
 }
 AgentRetrievalAction.init(
   {
@@ -239,6 +243,10 @@ AgentRetrievalAction.init(
       type: DataTypes.DATE,
       allowNull: false,
       defaultValue: DataTypes.NOW,
+    },
+    retrievalConfigurationId: {
+      type: DataTypes.STRING,
+      allowNull: false,
     },
     query: {
       type: DataTypes.TEXT,
@@ -275,15 +283,6 @@ AgentRetrievalAction.init(
     },
   }
 );
-
-AgentRetrievalConfiguration.hasMany(AgentRetrievalAction, {
-  foreignKey: { name: "retrievalConfigurationId", allowNull: false },
-  // We don't want to delete the action when the configuration is deleted
-  // But really we don't want to delete configurations ever.
-});
-AgentRetrievalAction.belongsTo(AgentRetrievalConfiguration, {
-  foreignKey: { name: "retrievalConfigurationId", allowNull: false },
-});
 
 export class RetrievalDocument extends Model<
   InferAttributes<RetrievalDocument>,

--- a/front/migrations/20230916_drop_v2_tables.sql
+++ b/front/migrations/20230916_drop_v2_tables.sql
@@ -1,0 +1,13 @@
+DROP TABLE retrieval_document_chunks;
+DROP TABLE retrieval_documents;
+DROP TABLE mentions;
+DROP TABLE messages;
+DROP TABLE user_messages;
+DROP TABLE agent_messages;
+DROP TABLE agent_retrieval_actions;
+DROP TABLE agent_configurations;
+DROP TABLE agent_data_source_configurations;
+DROP TABLE agent_retrieval_configurations;
+DROP TABLE agent_generation_configurations;
+
+

--- a/front/types/assistant/actions/retrieval.ts
+++ b/front/types/assistant/actions/retrieval.ts
@@ -52,6 +52,7 @@ export type RetrievalQuery = "auto" | "none" | TemplatedQuery;
 export type RetrievalTimeframe = "auto" | "none" | TimeFrame;
 export type RetrievalConfigurationType = {
   id: ModelId;
+  sId: string;
 
   type: "retrieval_configuration";
   dataSources: DataSourceConfiguration[];


### PR DESCRIPTION
- Fixes app hash
- Some error message standardization
- Add an sId to retrieval configuration because we have virtual ones with global agents use that instead of a foreign key in the retrieval action
- Uses prodAPI to retrieve the data sources in the slack global agent so that we retrieve the Dust slack data source when running in development. That incurs a bit of network in prod but that's front to front so should be just fine
- File rename globalAgent.ts -> global_agent.ts

Deploy will require running the commands in the migration (aka delete everything)