### PR TITLE
Working retrieval

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -69,7 +69,6 @@ export function AgentMessage({
       switch (event.type) {
         case "agent_action_success":
         case "retrieval_params":
-        case "retrieval_documents":
           setStreamedAgentMessage((m) => {
             return { ...m, action: event.action };
           });

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -354,15 +354,6 @@ export type RetrievalParamsEvent = {
   action: RetrievalActionType;
 };
 
-// Event sent during retrieval once the retrieved documents have been generated.
-export type RetrievalDocumentsEvent = {
-  type: "retrieval_documents";
-  created: number;
-  configurationId: string;
-  messageId: string;
-  action: RetrievalActionType;
-};
-
 export type RetrievalErrorEvent = {
   type: "retrieval_error";
   created: number;
@@ -395,10 +386,7 @@ export async function* runRetrieval(
   userMessage: UserMessageType,
   agentMessage: AgentMessageType
 ): AsyncGenerator<
-  | RetrievalParamsEvent
-  | RetrievalDocumentsEvent
-  | RetrievalSuccessEvent
-  | RetrievalErrorEvent
+  RetrievalParamsEvent | RetrievalSuccessEvent | RetrievalErrorEvent
 > {
   const owner = auth.workspace();
   if (!owner) {
@@ -460,7 +448,7 @@ export async function* runRetrieval(
         query: params.query,
         topK: params.topK,
       },
-      documents: [],
+      documents: null,
     },
   };
 
@@ -606,23 +594,6 @@ export async function* runRetrieval(
       }
     }
   });
-
-  yield {
-    type: "retrieval_documents",
-    created: Date.now(),
-    configurationId: configuration.sId,
-    messageId: agentMessage.sId,
-    action: {
-      id: action.id,
-      type: "retrieval_action",
-      params: {
-        relativeTimeFrame: params.relativeTimeFrame,
-        query: params.query,
-        topK: params.topK,
-      },
-      documents,
-    },
-  };
 
   yield {
     type: "retrieval_success",

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -4,7 +4,6 @@ import {
 } from "@app/lib/actions/registry";
 import { runAction } from "@app/lib/actions/server";
 import {
-  RetrievalDocumentsEvent,
   RetrievalParamsEvent,
   runRetrieval,
 } from "@app/lib/api/assistant/actions/retrieval";
@@ -115,7 +114,7 @@ export type AgentErrorEvent = {
 };
 
 // Event sent durint the execution of an action. These are action specific.
-export type AgentActionEvent = RetrievalParamsEvent | RetrievalDocumentsEvent;
+export type AgentActionEvent = RetrievalParamsEvent;
 
 // Event sent once the action is completed, we're moving to generating a message if applicable.
 export type AgentActionSuccessEvent = {
@@ -173,9 +172,6 @@ export async function* runAgent(
 
       for await (const event of eventStream) {
         if (event.type === "retrieval_params") {
-          yield event;
-        }
-        if (event.type === "retrieval_documents") {
           yield event;
         }
         if (event.type === "retrieval_error") {

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -997,11 +997,7 @@ async function* streamRunAgentEvents(
 
     // All other events that won't impact the database and are related to actions or tokens
     // generation.
-    if (
-      ["retrieval_params", "retrieval_documents", "generation_tokens"].includes(
-        event.type
-      )
-    ) {
+    if (["retrieval_params", "generation_tokens"].includes(event.type)) {
       yield event;
     }
   }

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -54,9 +54,11 @@ export async function renderConversationForModel({
 
     if (isAgentMessageType(m)) {
       if (m.action) {
-        if (isRetrievalActionType(m.action) && !retrievalFound) {
-          messages.unshift(renderRetrievalActionForModel(m.action));
-          retrievalFound = true;
+        if (isRetrievalActionType(m.action)) {
+          if (!retrievalFound) {
+            messages.unshift(renderRetrievalActionForModel(m.action));
+            retrievalFound = true;
+          }
         } else {
           return new Err(
             new Error(

--- a/front/lib/api/assistant/pubsub.ts
+++ b/front/lib/api/assistant/pubsub.ts
@@ -61,7 +61,6 @@ export async function postUserMessageWithPubSub(
             case "retrieval_params":
             case "agent_error":
             case "agent_action_success":
-            case "retrieval_documents":
             case "generation_tokens":
             case "agent_generation_success":
             case "agent_message_success": {


### PR DESCRIPTION
- Remove the retrieval_documents event which is a repeat of retrieval_success which is turned into agent_action_success event.
- Do not send an empty array at retrieval_params so that the docs are still loading
- Fix logic of extraciton of retrievals