### PR TITLE
Fix conversation scrolling for new messages

### DIFF
--- a/front/components/assistant/conversation/Conversation.tsx
+++ b/front/components/assistant/conversation/Conversation.tsx
@@ -28,6 +28,11 @@ export default function Conversation({
   // State used to re-connect to the events stream; this is a hack to re-trigger
   // the useEffect that set-up the EventSource to the streaming endpoint.
   const [reconnectCounter, setReconnectCounter] = useState(0);
+  useEffect(() => {
+    if (window && window.scrollTo) {
+      window.scrollTo(0, document.body.scrollHeight);
+    }
+  }, [conversation?.content.length]);
 
   useEffect(() => {
     if (!conversation) {
@@ -77,7 +82,7 @@ export default function Conversation({
   }
 
   return (
-    <div className="flex-col gap-6 ">
+    <div className="pb-24">
       {conversation.content.map((message) =>
         message.map((m) => {
           if (m.visibility === "deleted") {


### PR DESCRIPTION
Before: when the conversation reaches the input box and user enters a new message, it went "under the input box" cf screenshot of issue #1468

Now => It scrolls the last message into view, same behaviour as in chat v1
![image](https://github.com/dust-tt/dust/assets/5437393/7474a1f9-c704-4c02-8156-16cf50461cfc)

