### PR TITLE
Polish Markdown component UI

### DIFF
--- a/front/components/RenderMarkdown.tsx
+++ b/front/components/RenderMarkdown.tsx
@@ -166,7 +166,7 @@ function CodeBlock({
   const slate900 = slate["900"];
   const slate50 = slate["50"];
   const emerald500 = emerald["500"];
-  const amber500 = amber["400"];
+  const amber400 = amber["400"];
   const amber200 = amber["200"];
   const pink400 = pink["400"];
   const yellow300 = yellow["300"];
@@ -208,28 +208,28 @@ function CodeBlock({
           color: pink400,
         },
         "hljs-number": {
-          color: amber500,
+          color: amber400,
         },
         "hljs-built_in": {
-          color: amber500,
+          color: amber400,
         },
         "hljs-builtin-name": {
-          color: amber500,
+          color: amber400,
         },
         "hljs-literal": {
-          color: amber500,
+          color: amber400,
         },
         "hljs-type": {
-          color: amber500,
+          color: amber400,
         },
         "hljs-params": {
-          color: amber500,
+          color: amber400,
         },
         "hljs-meta": {
-          color: amber500,
+          color: amber400,
         },
         "hljs-link": {
-          color: amber500,
+          color: amber400,
         },
         "hljs-attribute": {
           color: yellow300,

--- a/front/components/RenderMarkdown.tsx
+++ b/front/components/RenderMarkdown.tsx
@@ -55,6 +55,9 @@ export function RenderMarkdown({ content }: { content: string }) {
         pre: PreBlock,
         code: CodeBlock,
         a: LinkBlock,
+        ul: UlBlock,
+        ol: OlBlock,
+        li: LiBlock,
         p: React.Fragment,
       }}
       remarkPlugins={[remarkGfm]}
@@ -139,6 +142,16 @@ function PreBlock({ children }: { children: React.ReactNode }) {
   );
 }
 
+function UlBlock({ children }: { children: React.ReactNode }) {
+  return <ul className="list-disc py-2">{children}</ul>;
+}
+function OlBlock({ children }: { children: React.ReactNode }) {
+  return <ol className="list-decimal py-3">{children}</ol>;
+}
+function LiBlock({ children }: { children: React.ReactNode }) {
+  return <li className="py-2">{children}</li>;
+}
+
 function CodeBlock({
   inline,
   className,
@@ -149,17 +162,11 @@ function CodeBlock({
   children?: React.ReactNode;
 }): JSX.Element {
   const match = /language-(\w+)/.exec(className || "");
-  let language = match ? match[1] : "text";
-
-  const supportedLanguages = ["js", "ts", "tsx", "json", "text", "python"];
-  if (!supportedLanguages.includes(language)) {
-    language = "text";
-  }
-
+  const language = match ? match[1] : "text";
   const slate900 = slate["900"];
   const slate50 = slate["50"];
   const emerald500 = emerald["500"];
-  const amber500 = amber["500"];
+  const amber500 = amber["400"];
   const amber200 = amber["200"];
   const pink400 = pink["400"];
   const yellow300 = yellow["300"];
@@ -256,7 +263,7 @@ function CodeBlock({
           overflowX: "auto",
           background: slate900,
           color: slate50,
-          padding: "0.5em",
+          padding: "1em",
         },
         "hljs-emphasis": {
           fontStyle: "italic",
@@ -271,6 +278,8 @@ function CodeBlock({
       {String(children).replace(/\n$/, "")}
     </SyntaxHighlighter>
   ) : (
-    <code className="rounded-md p-1">{children}</code>
+    <code className="rounded-md border-structure-100 bg-slate-200 p-1">
+      {children}
+    </code>
   );
 }

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -167,7 +167,7 @@ function renderMessage(agentMessage: AgentMessageType) {
     return (
       <>
         <div className="mb-2 text-xs font-bold text-element-600">Answer:</div>
-        <div className="mb-2 break-all text-base font-normal">
+        <div className="mb-2">
           <RenderMarkdown content={agentMessage.content} />
         </div>
       </>
@@ -183,7 +183,7 @@ function renderMessage(agentMessage: AgentMessageType) {
             <div className="mb-2 text-xs font-bold text-element-600">
               Answer:
             </div>
-            <div className="mb-2 break-all text-base font-normal">
+            <div className="mb-2">
               <RenderMarkdown content={agentMessage.content} />
             </div>
           </>

--- a/front/components/assistant/conversation/ConversationMessage.tsx
+++ b/front/components/assistant/conversation/ConversationMessage.tsx
@@ -18,10 +18,12 @@ export function ConversationMessage({
       <div className="flex-shrink-0">
         <Avatar visual={pictureUrl} name={name || undefined} size="sm" />
       </div>
-      <div className="flex-grow">
-        <div className="flex flex-col gap-4">
+      <div className="min-w-0 flex-grow">
+        <div className="flex-col gap-4">
           <div className="text-sm font-medium">{name}</div>
-          <div>{children}</div>
+          <div className="min-w-0 break-words text-base font-normal">
+            {children}
+          </div>
         </div>
       </div>
     </div>

--- a/front/components/assistant/conversation/UserMessage.tsx
+++ b/front/components/assistant/conversation/UserMessage.tsx
@@ -10,9 +10,7 @@ export function UserMessage({ message }: { message: UserMessageType }) {
       pictureUrl={message.user?.image}
       name={message.context.fullName}
     >
-      <div className="break-all text-base font-normal">
-        <RenderMarkdown content={message.content} />
-      </div>
+      <RenderMarkdown content={message.content} />
     </ConversationMessage>
   );
 }


### PR DESCRIPTION
A few small fixes: 
- Block code supports all languages supported by the lib.
- Markdown display proper ul/li & ol/li lists.
- Inline code block is more readable
- break-all class removed as it should, and replace by break-words (it required a few fixes in the layout).

<img width="931" alt="Capture d’écran 2023-09-15 à 14 44 20" src="https://github.com/dust-tt/dust/assets/3803406/c01e076a-0aa0-41aa-a47b-1c6a8801d04c">
