### PR TITLE
Force flush of the setState() in the useEventSource() hook

### DIFF
--- a/front/hooks/useEventSource.ts
+++ b/front/hooks/useEventSource.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { flushSync } from "react-dom";
 
 export function useEventSource(
   buildURL: (lastMessage: string | null) => string | null
@@ -24,7 +25,9 @@ export function useEventSource(
     };
 
     es.onmessage = (event: MessageEvent<string>) => {
-      setLastMessage(event.data);
+      flushSync(() => {
+        setLastMessage(event.data);
+      });
     };
 
     es.onerror = () => {


### PR DESCRIPTION
Looks like this is our solution to the streaming bug.
Docs is here:
https://react.dev/reference/react-dom/flushSync