### PR TITLE
Fix error handling and model

### DIFF
--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -157,7 +157,8 @@ export async function* runAgent(
   | AgentActionSuccessEvent
   | GenerationTokensEvent
   | AgentGenerationSuccessEvent
-  | AgentMessageSuccessEvent
+  | AgentMessageSuccessEvent,
+  void
 > {
   // First run the action if a configuration is present.
   if (configuration.action !== null) {
@@ -175,7 +176,7 @@ export async function* runAgent(
           yield event;
         }
         if (event.type === "retrieval_error") {
-          return {
+          yield {
             type: "agent_error",
             created: event.created,
             configurationId: configuration.sId,
@@ -185,6 +186,7 @@ export async function* runAgent(
               message: event.error.message,
             },
           };
+          return;
         }
         if (event.type === "retrieval_success") {
           yield {
@@ -222,7 +224,7 @@ export async function* runAgent(
         yield event;
       }
       if (event.type === "generation_error") {
-        return {
+        yield {
           type: "agent_error",
           created: event.created,
           configurationId: configuration.sId,
@@ -232,6 +234,7 @@ export async function* runAgent(
             message: event.error.message,
           },
         };
+        return;
       }
       if (event.type === "generation_success") {
         yield {

--- a/front/lib/api/assistant/pubsub.ts
+++ b/front/lib/api/assistant/pubsub.ts
@@ -109,10 +109,13 @@ export async function postUserMessageWithPubSub(
 export async function* getConversationEvents(
   conversationId: string,
   lastEventId: string | null
-): AsyncGenerator<{
-  eventId: string;
-  data: UserMessageNewEvent | AgentMessageNewEvent;
-}> {
+): AsyncGenerator<
+  {
+    eventId: string;
+    data: UserMessageNewEvent | AgentMessageNewEvent;
+  },
+  void
+> {
   const redis = await redisClient();
   const pubsubChannel = getConversationChannelId(conversationId);
 
@@ -146,15 +149,18 @@ export async function* getConversationEvents(
 export async function* getMessagesEvents(
   messageId: string,
   lastEventId: string | null
-): AsyncGenerator<{
-  eventId: string;
-  data:
-    | AgentErrorEvent
-    | AgentActionEvent
-    | AgentActionSuccessEvent
-    | GenerationTokensEvent
-    | AgentGenerationSuccessEvent;
-}> {
+): AsyncGenerator<
+  {
+    eventId: string;
+    data:
+      | AgentErrorEvent
+      | AgentActionEvent
+      | AgentActionSuccessEvent
+      | GenerationTokensEvent
+      | AgentGenerationSuccessEvent;
+  },
+  void
+> {
   const pubsubChannel = getMessageChannelId(messageId);
   const redis = await redisClient();
 

--- a/front/lib/api/chat.ts
+++ b/front/lib/api/chat.ts
@@ -549,7 +549,8 @@ export async function* newChat(
   | ChatMessageTriggerEvent
   | ChatMessageCreateEvent
   | ChatMessageTokensEvent
-  | ChatSessionUpdateEvent
+  | ChatSessionUpdateEvent,
+  void
 > {
   const owner = auth.workspace();
   if (!owner) {
@@ -608,7 +609,8 @@ export async function* newChat(
   async function* runChatAssistant(
     retrievalMode: "auto" | "none"
   ): AsyncGenerator<
-    ChatMessageTokensEvent | ChatMessageCreateEvent | ChatMessageTriggerEvent
+    ChatMessageTokensEvent | ChatMessageCreateEvent | ChatMessageTriggerEvent,
+    void
   > {
     assistantConfig.MODEL.function_call = retrievalMode;
     const res = await runActionStreamed(

--- a/front/pages/w/[wId]/builder/assistants/new.tsx
+++ b/front/pages/w/[wId]/builder/assistants/new.tsx
@@ -306,7 +306,7 @@ export default function CreateAssistant({
           model: {
             // TODO: make this configurable
             providerId: "openai",
-            modelId: "gpt4",
+            modelId: "gpt-4",
           },
         },
       },


### PR DESCRIPTION
Fix #1510 

@dust-tt/engineering-team returning in an async generator does not yield the object as event (it instead returns what will be returned by the async generator return() function). We had a mix of yield {} return and return {} so I standardized erroneously last week on return {}. This PR instead standardizes on `yield{}; return` and enforces this by specifying the type of the return to `void`

Also fixes `gpt-4` instead of `gpt4` in the custom assistant settings