### PR TITLE
Dust global agent

### DIFF
--- a/front/lib/actions/registry.ts
+++ b/front/lib/actions/registry.ts
@@ -49,7 +49,7 @@ export const DustProdActionRegistry = createActionRegistry({
       workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
       appId: "6a27050429",
       appHash:
-        "356e16f5254284cc1c08512bebf9638bbc3e94eb5b29ac27599ccce7bee7843c",
+        "77452e1a74f766a4b40c13c241c3cf36458b527b9bda36a35781906d4b54dcdd",
     },
     config: {
       MODEL: {

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -281,6 +281,14 @@ export async function* runGeneration(
   config.MODEL.provider_id = model.providerId;
   config.MODEL.model_id = model.modelId;
 
+  // This is the console.log you want to uncomment to generate inputs for the generator app.
+  // console.log(
+  //   JSON.stringify({
+  //     conversation: modelConversationRes.value,
+  //     prompt: c.prompt,
+  //   })
+  // );
+
   const res = await runActionStreamed(auth, "assistant-v2-generator", config, [
     {
       conversation: modelConversationRes.value,

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -12,27 +12,46 @@ import { AgentConfigurationType } from "@app/types/assistant/agent";
  */
 
 enum GLOBAL_AGENTS_SID {
+  GPT35_TURBO = "gpt-3.5-turbo",
   GPT4 = "gpt-4",
-  Slack = "slack",
-  Claude = "claude-2",
+  CLAUDE_INSTANT = "claude-instant-1",
+  CLAUDE = "claude-2",
+  SLACK = "slack",
+  DUST = "dust",
 }
-enum GLOBAL_AGENTS_ID {
-  GPT4 = -1,
-  Slack = -2,
-  Claude = -3,
+
+async function _getGPT35TurboGlobalAgent(): Promise<AgentConfigurationType> {
+  return {
+    id: -1,
+    sId: GLOBAL_AGENTS_SID.GPT35_TURBO,
+    name: "gpt3.5-turbo",
+    description: "OpenAI's cost-effective and high throughput model.",
+    pictureUrl: "https://dust.tt/static/systemavatar/gpt3_avatar_full.png",
+    status: "active",
+    scope: "global",
+    generation: {
+      id: -1,
+      prompt: "",
+      model: {
+        providerId: "openai",
+        modelId: "gpt-3.5-turbo",
+      },
+    },
+    action: null,
+  };
 }
 
 async function _getGPT4GlobalAgent(): Promise<AgentConfigurationType> {
   return {
-    id: GLOBAL_AGENTS_ID.GPT4,
+    id: -1,
     sId: GLOBAL_AGENTS_SID.GPT4,
     name: "gpt4",
-    description: "OpenAI's most powerful model to date.",
+    description: "OpenAI's most powerful model.",
     pictureUrl: "https://dust.tt/static/systemavatar/gpt4_avatar_full.png",
     status: "active",
     scope: "global",
     generation: {
-      id: GLOBAL_AGENTS_ID.GPT4,
+      id: -1,
       prompt: "",
       model: {
         providerId: "openai",
@@ -43,17 +62,38 @@ async function _getGPT4GlobalAgent(): Promise<AgentConfigurationType> {
   };
 }
 
-async function _getClaude2GlobalAgent(): Promise<AgentConfigurationType> {
+async function _getClaudeInstantGlobalAgent(): Promise<AgentConfigurationType> {
   return {
-    id: GLOBAL_AGENTS_ID.Claude,
-    sId: GLOBAL_AGENTS_SID.Claude,
-    name: "claude",
-    description: "Anthropic's flagship model.",
+    id: -1,
+    sId: GLOBAL_AGENTS_SID.CLAUDE_INSTANT,
+    name: "claude-instant",
+    description: "Anthropic's low-latency and high throughput model.",
     pictureUrl: "https://dust.tt/static/systemavatar/claude_avatar_full.png",
     status: "active",
     scope: "global",
     generation: {
-      id: GLOBAL_AGENTS_ID.Claude,
+      id: -1,
+      prompt: "",
+      model: {
+        providerId: "anthropic",
+        modelId: "claude-instant-1.2",
+      },
+    },
+    action: null,
+  };
+}
+
+async function _getClaudeGlobalAgent(): Promise<AgentConfigurationType> {
+  return {
+    id: -1,
+    sId: GLOBAL_AGENTS_SID.CLAUDE,
+    name: "claude",
+    description: "Anthropic's superior performance model.",
+    pictureUrl: "https://dust.tt/static/systemavatar/claude_avatar_full.png",
+    status: "active",
+    scope: "global",
+    generation: {
+      id: -1,
       prompt: "",
       model: {
         providerId: "anthropic",
@@ -89,15 +129,15 @@ async function _getSlackGlobalAgent(
   }
 
   return {
-    id: GLOBAL_AGENTS_ID.Slack,
-    sId: GLOBAL_AGENTS_SID.Slack,
+    id: -1,
+    sId: GLOBAL_AGENTS_SID.SLACK,
     name: "slack",
     description: "An assistant with context on your Slack workspace.",
     pictureUrl: "https://dust.tt/static/systemavatar/slack_avatar_full.png",
     status: "active",
     scope: "global",
     generation: {
-      id: GLOBAL_AGENTS_ID.Slack,
+      id: -1,
       prompt:
         "Assist the user based on the retrieved data from their Slack workspace.",
       model: {
@@ -106,13 +146,71 @@ async function _getSlackGlobalAgent(
       },
     },
     action: {
-      id: GLOBAL_AGENTS_ID.Slack,
-      sId: GLOBAL_AGENTS_SID.Slack + "-action",
+      id: -1,
+      sId: GLOBAL_AGENTS_SID.SLACK + "-action",
       type: "retrieval_configuration",
       query: "auto",
       relativeTimeFrame: "auto",
       topK: 16,
       dataSources: slackDataSources.map((ds) => ({
+        dataSourceId: ds.name,
+        workspaceId: prodCredentials.workspaceId,
+        filter: { tags: null, parents: null },
+      })),
+    },
+  };
+}
+
+async function _getDustGlobalAgent(
+  auth: Authenticator
+): Promise<AgentConfigurationType | null> {
+  const owner = auth.workspace();
+  if (!owner) {
+    throw new Error("Unexpected `auth` without `workspace`.");
+  }
+
+  const prodCredentials = await prodAPICredentialsForOwner(owner);
+  const api = new DustAPI(prodCredentials);
+
+  const dsRes = await api.getDataSources(prodCredentials.workspaceId);
+  if (dsRes.isErr()) {
+    return null;
+  }
+
+  const dataSources = dsRes.value.filter(
+    (d) => d.assistantDefaultSelected === true
+  );
+
+  if (dataSources.length === 0) {
+    return null;
+  }
+
+  return {
+    id: -1,
+    sId: GLOBAL_AGENTS_SID.DUST,
+    name: "Dust",
+    description:
+      "An assistant with context on your managed and static data sources.",
+    pictureUrl: "https://dust.tt/static/systemavatar/dust_avatar_full.png",
+    status: "active",
+    scope: "global",
+    generation: {
+      id: -1,
+      prompt:
+        "Assist the user based on the retrieved data from their workspace.",
+      model: {
+        providerId: "openai",
+        modelId: "gpt-4",
+      },
+    },
+    action: {
+      id: -1,
+      sId: GLOBAL_AGENTS_SID.DUST + "-action",
+      type: "retrieval_configuration",
+      query: "auto",
+      relativeTimeFrame: "auto",
+      topK: 16,
+      dataSources: dataSources.map((ds) => ({
         dataSourceId: ds.name,
         workspaceId: prodCredentials.workspaceId,
         filter: { tags: null, parents: null },
@@ -139,12 +237,18 @@ export async function getGlobalAgent(
   }
 
   switch (sId) {
+    case GLOBAL_AGENTS_SID.GPT35_TURBO:
+      return _getGPT35TurboGlobalAgent();
     case GLOBAL_AGENTS_SID.GPT4:
       return _getGPT4GlobalAgent();
-    case GLOBAL_AGENTS_SID.Slack:
+    case GLOBAL_AGENTS_SID.CLAUDE_INSTANT:
+      return _getClaudeInstantGlobalAgent();
+    case GLOBAL_AGENTS_SID.CLAUDE:
+      return _getClaudeGlobalAgent();
+    case GLOBAL_AGENTS_SID.SLACK:
       return _getSlackGlobalAgent(auth);
-    case GLOBAL_AGENTS_SID.Claude:
-      return _getClaude2GlobalAgent();
+    case GLOBAL_AGENTS_SID.DUST:
+      return _getDustGlobalAgent(auth);
     default:
       return null;
   }
@@ -161,12 +265,20 @@ export async function getGlobalAgents(
   // For now we retrieve them all
   // We will store them in the database later to allow admin enable them or not
   const globalAgents = [
+    await _getGPT35TurboGlobalAgent(),
     await _getGPT4GlobalAgent(),
-    await _getClaude2GlobalAgent(),
+    await _getClaudeInstantGlobalAgent(),
+    await _getClaudeGlobalAgent(),
   ];
+
   const slackAgent = await _getSlackGlobalAgent(auth);
   if (slackAgent) {
     globalAgents.push(slackAgent);
   }
+  const dustAgent = await _getDustGlobalAgent(auth);
+  if (dustAgent) {
+    globalAgents.push(dustAgent);
+  }
+
   return globalAgents;
 }


### PR DESCRIPTION
Adds a global dust agent which pulls the data sources similarly to current Dust.

Also updates the geneartor dust app to scrub `.` from the name in the chat message format which is not allowed by OpenAI