### PR TITLE
Agent error UI

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -176,12 +176,14 @@ function renderMessage(agentMessage: AgentMessageType) {
   // understandable directly to them)
   if (agentMessage.status === "failed") {
     return (
-      <div>
-        <div className="mb-2 text-xs font-bold text-element-600">
-          <p>Error Code: {agentMessage.error?.code}</p>
-          <p>Error Message: {agentMessage.error?.message}</p>
-        </div>
-      </div>
+      <ErrorMessage
+        error={
+          agentMessage.error || {
+            message: "Unexpected Error",
+            code: "unexpected_error",
+          }
+        }
+      />
     );
   }
 
@@ -279,6 +281,10 @@ function ErrorMessage({ error }: { error: { code: string; message: string } }) {
           size="sm"
           icon={ArrowPathIcon}
           label="Retry"
+          onClick={() => {
+            // TODO
+            alert("To be done in a few hours");
+          }}
         />
       </div>
     </div>

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -253,8 +253,8 @@ function ErrorMessage({ error }: { error: { code: string; message: string } }) {
               label="See the error"
             />
           </DropdownMenu.Button>
-          <div className="relative bottom-4">
-            <DropdownMenu.Items origin="bottomLeft" width={320}>
+          <div className="relative bottom-6 z-30">
+            <DropdownMenu.Items origin="topLeft" width={320}>
               <div className="flex flex-col gap-3 pb-3 pt-5">
                 <div className="text-sm font-normal text-warning-800">
                   {fullMessage}

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -1,4 +1,13 @@
-import { ClipboardIcon, Spinner } from "@dust-tt/sparkle";
+import {
+  ArrowPathIcon,
+  Button,
+  Chip,
+  ClipboardIcon,
+  DocumentDuplicateIcon,
+  DropdownMenu,
+  EyeIcon,
+  Spinner,
+} from "@dust-tt/sparkle";
 import { useCallback, useState } from "react";
 
 import { AgentAction } from "@app/components/assistant/conversation/AgentAction";
@@ -128,7 +137,19 @@ export function AgentMessage({
         })(message.status);
     }
   })();
-
+  const buttons =
+    message.status === "failed"
+      ? []
+      : [
+          {
+            icon: ClipboardIcon,
+            onClick: () => {
+              void navigator.clipboard.writeText(
+                agentMessageToRender.content || ""
+              );
+            },
+          },
+        ];
   return (
     <ConversationMessage
       pictureUrl={agentMessageToRender.configuration.pictureUrl}
@@ -209,4 +230,62 @@ function renderMessage(agentMessage: AgentMessageType) {
       </>
     );
   }
+}
+function ErrorMessage({ error }: { error: { code: string; message: string } }) {
+  const fullMessage =
+    "ERROR: " + error.message + (error.code ? ` (code: ${error.code})` : "");
+  return (
+    <div className="flex flex-col gap-9">
+      <div className="flex flex-col gap-1 sm:flex-row">
+        <Chip
+          color="warning"
+          label={"ERROR: " + shortText(error.message)}
+          size="xs"
+        />
+        <DropdownMenu>
+          <DropdownMenu.Button>
+            <Button
+              variant="tertiary"
+              size="xs"
+              className="ml-2"
+              icon={EyeIcon}
+              label="See the error"
+            />
+          </DropdownMenu.Button>
+          <div className="relative bottom-4">
+            <DropdownMenu.Items origin="bottomLeft" width={320}>
+              <div className="flex flex-col gap-3 pb-3 pt-5">
+                <div className="text-sm font-normal text-warning-800">
+                  {fullMessage}
+                </div>
+                <div className="self-end">
+                  <Button
+                    variant="tertiary"
+                    size="xs"
+                    icon={DocumentDuplicateIcon}
+                    label={"Copy"}
+                    onClick={() =>
+                      void navigator.clipboard.writeText(fullMessage)
+                    }
+                  />
+                </div>
+              </div>
+            </DropdownMenu.Items>
+          </div>
+        </DropdownMenu>
+      </div>
+      <div className="self-center">
+        <Button
+          variant="primary"
+          size="sm"
+          icon={ArrowPathIcon}
+          label="Retry"
+        />
+      </div>
+    </div>
+  );
+}
+
+function shortText(text: string, maxLength = 30) {
+  return text.length > maxLength ? text.substring(0, maxLength) + "..." : text;
 }

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -44,7 +44,6 @@ export function AgentMessage({
         return false;
       case "created":
         return true;
-        break;
 
       default:
         ((status: never) => {
@@ -155,16 +154,7 @@ export function AgentMessage({
       pictureUrl={agentMessageToRender.configuration.pictureUrl}
       name={agentMessageToRender.configuration.name}
       messageId={agentMessageToRender.sId}
-      buttons={[
-        {
-          icon: ClipboardIcon,
-          onClick: () => {
-            void navigator.clipboard.writeText(
-              agentMessageToRender.content || ""
-            );
-          },
-        },
-      ]}
+      buttons={buttons}
     >
       {renderMessage(agentMessageToRender)}
     </ConversationMessage>

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -247,7 +247,6 @@ function ErrorMessage({ error }: { error: { code: string; message: string } }) {
             <Button
               variant="tertiary"
               size="xs"
-              className="ml-2"
               icon={EyeIcon}
               label="See the error"
             />

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@dust-tt/sparkle": "0.1.69",
+        "@dust-tt/sparkle": "0.1.70",
         "@headlessui/react": "^1.7.7",
         "@heroicons/react": "^2.0.11",
         "@nangohq/frontend": "^0.16.1",
@@ -716,9 +716,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.1.69",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.1.69.tgz",
-      "integrity": "sha512-RGK7P3NhZGMy+ZvjmruvEhGYdMiaH49IAZcpbcucW0aINvYEW23LMPfunI8FxGS9J5KGGcmVEv68IT15/Gl8gw==",
+      "version": "0.1.70",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.1.70.tgz",
+      "integrity": "sha512-t4Cl2UzTwmHBVhJFrzMiaz7/akkW3ZgXgCLHIzdRUCubVIpnFHBYaf3iTuFAeacNSYZwgUukSq+Q5IMGQ66TyQ==",
       "dependencies": {
         "@headlessui/react": "^1.7.17"
       },

--- a/front/package.json
+++ b/front/package.json
@@ -13,7 +13,7 @@
     "initdb": "env $(cat .env.local) npx tsx admin/db.ts"
   },
   "dependencies": {
-    "@dust-tt/sparkle": "0.1.69",
+    "@dust-tt/sparkle": "0.1.70",
     "@headlessui/react": "^1.7.7",
     "@heroicons/react": "^2.0.11",
     "@nangohq/frontend": "^0.16.1",


### PR DESCRIPTION
This PR is about the visual aspect of an agent's error message.
The "Retry" button is visible but not functional. Making it work has been added as a separate backlog item and will be done in a subsequent PR this afternoon. Visuals:
![image](https://github.com/dust-tt/dust/assets/5437393/c1b693ec-cb36-4f40-b1f9-af5ea8bf0258)
With error unfolded:
![image](https://github.com/dust-tt/dust/assets/5437393/d510dc25-f5ac-4326-8f71-cf975cf61c6f)
