### PR TITLE
Add support for assistant generation temperature configuration

### DIFF
--- a/docs/src/pages/core-blocks.mdx
+++ b/docs/src/pages/core-blocks.mdx
@@ -167,6 +167,10 @@ It is used to issue completion requests to large language models as part of an a
   <Property name="model_id" type="string">
     The model to use from the provider specified by `provider_id`.
   </Property>
+  <Property name="temperature" type="float">
+    An override for the temperature to use when sampling from the model. See the
+    specification section for more details.
+  </Property>
   <Property name="use_cache" type="bool">
     Whether to rely on the automated caching mechanism of the `llm` block. If
     set to _true_ and a previous request was made with the same specification
@@ -292,6 +296,10 @@ generates a new message in response.
   </Property>
   <Property name="model_id" type="string">
     The model to use from the provider specified by `provider_id`.
+  </Property>
+  <Property name="temperature" type="float">
+    An override for the temperature to use when sampling from the model. See the
+    specification section for more details.
   </Property>
   <Property name="use_cache" type="bool">
     Whether to rely on the automated caching mechanism of the `llm` block. If

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -318,6 +318,7 @@ export default function AssistantBuilder({
             providerId: "openai",
             modelId: "gpt-4",
           },
+          temperature: 0.7,
         },
       },
     };

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -139,6 +139,7 @@ export async function getAgentConfiguration(
             providerId: generationConfig.providerId,
             modelId: generationConfig.modelId,
           },
+          temperature: generationConfig.temperature,
         }
       : null,
   };
@@ -295,12 +296,14 @@ export async function createAgentGenerationConfiguration(
   {
     prompt,
     model,
+    temperature,
   }: {
     prompt: string;
     model: {
       providerId: string;
       modelId: string;
     };
+    temperature: number;
   }
 ): Promise<AgentGenerationConfigurationType> {
   const owner = auth.workspace();
@@ -308,10 +311,15 @@ export async function createAgentGenerationConfiguration(
     throw new Error("Unexpected `auth` without `workspace`.");
   }
 
+  if (temperature < 0) {
+    throw new Error("Temperature must be positive.");
+  }
+
   const genConfig = await AgentGenerationConfiguration.create({
     prompt: prompt,
     providerId: model.providerId,
     modelId: model.modelId,
+    temperature: temperature,
   });
 
   return {
@@ -321,6 +329,7 @@ export async function createAgentGenerationConfiguration(
       providerId: genConfig.providerId,
       modelId: genConfig.modelId,
     },
+    temperature: genConfig.temperature,
   };
 }
 
@@ -333,17 +342,23 @@ export async function updateAgentGenerationConfiguration(
   {
     prompt,
     model,
+    temperature,
   }: {
     prompt: string;
     model: {
       providerId: string;
       modelId: string;
     };
+    temperature: number;
   }
 ): Promise<AgentGenerationConfigurationType> {
   const owner = auth.workspace();
   if (!owner) {
     throw new Error("Unexpected `auth` without `workspace`.");
+  }
+
+  if (temperature < 0) {
+    throw new Error("Temperature must be positive.");
   }
 
   const agentConfig = await AgentConfiguration.findOne({
@@ -377,6 +392,7 @@ export async function updateAgentGenerationConfiguration(
     prompt: prompt,
     providerId: model.providerId,
     modelId: model.modelId,
+    temperature: temperature,
   });
 
   return {
@@ -386,6 +402,7 @@ export async function updateAgentGenerationConfiguration(
       providerId: updatedGenConfig.providerId,
       modelId: updatedGenConfig.modelId,
     },
+    temperature: updatedGenConfig.temperature,
   };
 }
 

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -280,6 +280,7 @@ export async function* runGeneration(
   );
   config.MODEL.provider_id = model.providerId;
   config.MODEL.model_id = model.modelId;
+  config.MODEL.temperature = c.temperature;
 
   // This is the console.log you want to uncomment to generate inputs for the generator app.
   // console.log(

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -36,6 +36,7 @@ async function _getGPT35TurboGlobalAgent(): Promise<AgentConfigurationType> {
         providerId: "openai",
         modelId: "gpt-3.5-turbo",
       },
+      temperature: 0.7,
     },
     action: null,
   };
@@ -57,6 +58,7 @@ async function _getGPT4GlobalAgent(): Promise<AgentConfigurationType> {
         providerId: "openai",
         modelId: "gpt-4",
       },
+      temperature: 0.7,
     },
     action: null,
   };
@@ -78,6 +80,7 @@ async function _getClaudeInstantGlobalAgent(): Promise<AgentConfigurationType> {
         providerId: "anthropic",
         modelId: "claude-instant-1.2",
       },
+      temperature: 0.7,
     },
     action: null,
   };
@@ -99,6 +102,7 @@ async function _getClaudeGlobalAgent(): Promise<AgentConfigurationType> {
         providerId: "anthropic",
         modelId: "claude-2",
       },
+      temperature: 0.7,
     },
     action: null,
   };
@@ -144,6 +148,7 @@ async function _getSlackGlobalAgent(
         providerId: "openai",
         modelId: "gpt-4",
       },
+      temperature: 0.4,
     },
     action: {
       id: -1,
@@ -202,6 +207,7 @@ async function _getDustGlobalAgent(
         providerId: "openai",
         modelId: "gpt-4",
       },
+      temperature: 0.4,
     },
     action: {
       id: -1,

--- a/front/lib/models/assistant/agent.ts
+++ b/front/lib/models/assistant/agent.ts
@@ -27,6 +27,7 @@ export class AgentGenerationConfiguration extends Model<
   declare prompt: string;
   declare providerId: string;
   declare modelId: string;
+  declare temperature: number;
 }
 AgentGenerationConfiguration.init(
   {
@@ -56,6 +57,11 @@ AgentGenerationConfiguration.init(
     modelId: {
       type: DataTypes.STRING,
       allowNull: false,
+    },
+    temperature: {
+      type: DataTypes.FLOAT,
+      allowNull: false,
+      defaultValue: 0.7,
     },
   },
   {

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/index.ts
@@ -106,6 +106,7 @@ async function handler(
               providerId: generation.model.providerId,
               modelId: generation.model.modelId,
             },
+            temperature: generation.temperature,
           }
         );
       }

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -81,6 +81,7 @@ export const PostOrPatchAgentConfigurationRequestBodySchema = t.type({
         providerId: t.string,
         modelId: t.string,
       }),
+      temperature: t.number,
     }),
   }),
 });
@@ -150,6 +151,7 @@ async function handler(
           providerId: generation.model.providerId,
           modelId: generation.model.modelId,
         },
+        temperature: generation.temperature,
       });
 
       let actionConfig: AgentActionConfigurationType | null = null;

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -51,6 +51,7 @@ export type AgentGenerationConfigurationType = {
     providerId: string;
     modelId: string;
   };
+  temperature: number;
 };
 
 /**


### PR DESCRIPTION
- Adds a config override to LLM and Chat blocks in core
- Document them
- Add temperature to AgentConfiguration model and types
- Use generation configuration temperature at sampling

For #1446 

Deploy:
- front init_db (default value of 0.7 will be set)
- core deploy 
- front deploy
- docs deploy