### PR TITLE
Store upgradedAt date in workspace

### DIFF
--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -2,7 +2,7 @@ import { Storage } from "@google-cloud/storage";
 import parseArgs from "minimist";
 import readline from "readline";
 
-import { upgradeWorkspace } from "@app/lib/api/workspace";
+import { downgradeWorkspace, upgradeWorkspace } from "@app/lib/api/workspace";
 import { planForWorkspace } from "@app/lib/auth";
 import { ConnectorsAPI } from "@app/lib/connectors_api";
 import { CoreAPI } from "@app/lib/core_api";
@@ -232,33 +232,7 @@ const workspace = async (command: string, args: parseArgs.ParsedArgs) => {
         throw new Error(`Workspace not found: wId='${args.wId}'`);
       }
 
-      let plan = {} as any;
-      if (w.plan) {
-        try {
-          plan = JSON.parse(w.plan);
-        } catch (err) {
-          console.log("Ignoring existing plan since not parseable JSON.");
-        }
-      }
-
-      if (!plan.limits) {
-        plan.limits = {};
-      }
-      if (!plan.limits.dataSources) {
-        plan.limits.dataSources = {};
-      }
-      if (!plan.limits.dataSources.documents) {
-        plan.limits.dataSources.documents = {};
-      }
-
-      plan.limits.dataSources.count = 1;
-      plan.limits.dataSources.documents.count = 32;
-      plan.limits.dataSources.documents.sizeMb = 1;
-      plan.limits.dataSources.managed = false;
-
-      w.plan = JSON.stringify(plan);
-      await w.save();
-
+      await downgradeWorkspace(w.id);
       await workspace("show", args);
       return;
     }

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -122,7 +122,22 @@ export async function upgradeWorkspace(workspaceId: number) {
   plan.limits.dataSources.managed = true;
 
   workspace.plan = JSON.stringify(plan);
+  workspace.upgradedAt = new Date();
   await workspace.save();
+
+  return workspace;
+}
+
+export async function downgradeWorkspace(workspaceId: number) {
+  const workspace = await Workspace.findByPk(workspaceId);
+
+  if (!workspace) {
+    throw new Error(`Workspace not found. id=${workspaceId}`);
+  }
+  await workspace.update({
+    plan: null,
+    upgradedAt: null,
+  });
 
   return workspace;
 }

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -250,6 +250,7 @@ export class Authenticator {
           allowedDomain: this._workspace.allowedDomain || null,
           role: this._role,
           plan: planForWorkspace(this._workspace),
+          upgradedAt: this._workspace.upgradedAt?.getTime() || null,
         }
       : null;
   }
@@ -354,6 +355,7 @@ export async function getUserFromSession(
         allowedDomain: w.allowedDomain || null,
         role,
         plan: planForWorkspace(w),
+        upgradedAt: w.upgradedAt?.getTime() || null,
       };
     }),
     isDustSuperUser: user.isDustSuperUser,

--- a/front/lib/models/workspace.ts
+++ b/front/lib/models/workspace.ts
@@ -17,6 +17,7 @@ export class Workspace extends Model<
   declare id: CreationOptional<number>;
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
+  declare upgradedAt: Date | null;
 
   declare sId: string;
   declare name: string;
@@ -40,6 +41,10 @@ Workspace.init(
       type: DataTypes.DATE,
       allowNull: false,
       defaultValue: DataTypes.NOW,
+    },
+    upgradedAt: {
+      type: DataTypes.DATE,
+      allowNull: true,
     },
     sId: {
       type: DataTypes.STRING,

--- a/front/migrations/20231909_workspace_upgraded_at.ts
+++ b/front/migrations/20231909_workspace_upgraded_at.ts
@@ -1,0 +1,50 @@
+import { Op } from "sequelize";
+
+import { Workspace } from "@app/lib/models";
+
+async function main() {
+  console.log("Fetching Upgraded Worspaces...");
+  const workspaces = await Workspace.findAll({
+    where: {
+      plan: {
+        [Op.not]: null,
+      },
+    },
+  });
+  console.log(`Found ${workspaces.length} workspaces to mark as upgraded`);
+
+  const chunkSize = 16;
+  const chunks = [];
+  for (let i = 0; i < workspaces.length; i += chunkSize) {
+    chunks.push(workspaces.slice(i, i + chunkSize));
+  }
+
+  for (let i = 0; i < chunks.length; i++) {
+    console.log(`Processing chunk ${i}/${chunks.length}...`);
+    const chunk = chunks[i];
+    await Promise.all(
+      chunk.map((workspace: Workspace) => {
+        return markWorkspaceAsUpgraded(workspace);
+      })
+    );
+  }
+}
+
+async function markWorkspaceAsUpgraded(workspace: Workspace) {
+  if (!workspace.upgradedAt && workspace.plan) {
+    const updatedAt = workspace.updatedAt;
+    await workspace.update({
+      upgradedAt: updatedAt,
+    });
+  }
+}
+
+main()
+  .then(() => {
+    console.log("done");
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/front/pages/api/poke/workspaces/[wId]/downgrade.ts
+++ b/front/pages/api/poke/workspaces/[wId]/downgrade.ts
@@ -1,5 +1,6 @@
 import { NextApiRequest, NextApiResponse } from "next";
 
+import { downgradeWorkspace } from "@app/lib/api/workspace";
 import {
   getSession,
   getUserFromSession,
@@ -71,16 +72,7 @@ async function handler(
         });
       }
 
-      await Workspace.update(
-        {
-          plan: null,
-        },
-        {
-          where: {
-            id: workspace.id,
-          },
-        }
-      );
+      await downgradeWorkspace(workspace.id);
 
       const plan = await planForWorkspace(workspace);
 
@@ -92,6 +84,7 @@ async function handler(
           allowedDomain: workspace.allowedDomain || null,
           role: "admin",
           plan,
+          upgradedAt: workspace.upgradedAt?.getTime() || null,
         },
       });
 

--- a/front/pages/api/poke/workspaces/[wId]/upgrade.ts
+++ b/front/pages/api/poke/workspaces/[wId]/upgrade.ts
@@ -83,6 +83,7 @@ async function handler(
           allowedDomain: workspace.allowedDomain || null,
           role: "admin",
           plan,
+          upgradedAt: workspace.upgradedAt?.getTime() || null,
         },
       });
 

--- a/front/pages/api/poke/workspaces/index.ts
+++ b/front/pages/api/poke/workspaces/index.ts
@@ -146,6 +146,7 @@ async function handler(
           allowedDomain: ws.allowedDomain || null,
           plan: planForWorkspace(ws),
           role: "admin",
+          upgradedAt: ws.upgradedAt?.getTime() || null,
         })),
       });
     default:

--- a/front/pages/poke/[wId]/index.tsx
+++ b/front/pages/poke/[wId]/index.tsx
@@ -115,7 +115,7 @@ export const getServerSideProps: GetServerSideProps<{
     (ds) => ds.connectorProvider === "slack"
   )?.connectorId;
 
-  let slackbotEnabled;
+  let slackbotEnabled = false;
   if (slackConnectorId) {
     const botEnabledRes = await ConnectorsAPI.getBotEnabled(slackConnectorId);
     if (botEnabledRes.isErr()) {
@@ -248,11 +248,13 @@ const WorkspacePage = ({
     (ds) => !!ds.connectorProvider
   );
 
+  // @todo remove fallback on workspace plan
   const isFullyUpgraded =
-    workspace.plan?.limits.dataSources.count === -1 &&
-    workspace.plan?.limits.dataSources.documents.count === -1 &&
-    workspace.plan?.limits.dataSources.documents.sizeMb === -1 &&
-    workspace.plan?.limits.dataSources.managed === true;
+    workspace.upgradedAt !== null ||
+    (workspace.plan?.limits.dataSources.count === -1 &&
+      workspace.plan?.limits.dataSources.documents.count === -1 &&
+      workspace.plan?.limits.dataSources.documents.sizeMb === -1 &&
+      workspace.plan?.limits.dataSources.managed === true);
 
   return (
     <div className="min-h-screen bg-structure-50">
@@ -275,7 +277,10 @@ const WorkspacePage = ({
             <h2 className="text-md mb-4 font-bold">Plan:</h2>
             {isFullyUpgraded ? (
               <p className="mb-4 text-green-600">
-                This workspace is fully upgraded.
+                This workspace was fully upgraded
+                {workspace.upgradedAt &&
+                  `on ${new Date(workspace.upgradedAt).toLocaleDateString()}`}
+                .
               </p>
             ) : (
               <p className="mb-4 text-green-600">

--- a/front/types/user.ts
+++ b/front/types/user.ts
@@ -24,6 +24,7 @@ export type WorkspaceType = {
   allowedDomain: string | null;
   role: RoleType;
   plan: PlanType;
+  upgradedAt: number | null;
 };
 
 export type UserProviderType = "github" | "google";


### PR DESCRIPTION
Eng runner task: add upgrade timestamp on poké dust-tt/tasks#3 


- [x] Update `workspace` model, add nullable `upgradedAt` field, update `WorkspaceType` accordingly. 
- [x] Update `upgradeWorkspace`
- [x] Micro refactor introduce `downgradeWorkspace` and use it both on poké and on our admin cli commands;
- [x] On poké, display the upgraded date if we have it. 
- [x] Migration file to handle already upgraded workspace: we will fill the value with the last udpated date of the workspace. 

Run migration with: 
```sh
env $(cat .env.local) npx tsx migrations/20231909_workspace_upgraded_at.ts
```  