### PR TITLE
Put V2 in top nav for Dust, remove Gens link

### DIFF
--- a/front/components/sparkle/navigation.tsx
+++ b/front/components/sparkle/navigation.tsx
@@ -9,7 +9,6 @@ import {
   KeyIcon,
   PaperAirplaneIcon,
   RobotIcon,
-  Square3Stack3DIcon,
   TestTubeIcon,
 } from "@dust-tt/sparkle";
 
@@ -22,7 +21,7 @@ import { WorkspaceType } from "@app/types/user";
  * ones for the topNavigation (same across the whole app) and for the subNavigation which appears in
  * some section of the app in the AppLayout navigation panel.
  */
-export type TopNavigationId = "assistant" | "lab" | "settings";
+export type TopNavigationId = "assistant" | "assistant_v2" | "lab" | "settings";
 
 export type SubNavigationAdminId =
   | "data_sources"
@@ -36,8 +35,7 @@ export type SubNavigationAppId =
   | "execute"
   | "runs"
   | "settings";
-export type SubNavigationLabId = "gens" | "extract" | "assistant";
-
+export type SubNavigationLabId = "extract";
 export type SparkleAppLayoutNavigation = {
   id:
     | TopNavigationId
@@ -63,7 +61,7 @@ export const topNavigation = ({
   owner: WorkspaceType;
   current: TopNavigationId;
 }) => {
-  const displayLabs = isDevelopmentOrDustWorkspace(owner);
+  const isDust = isDevelopmentOrDustWorkspace(owner);
   const nav: SparkleAppLayoutNavigation[] = [
     {
       id: "assistant",
@@ -72,15 +70,25 @@ export const topNavigation = ({
       icon: ChatBubbleBottomCenterTextIcon,
       sizing: "hug",
       current: current === "assistant",
-      hasSeparator: displayLabs ? false : true,
+      hasSeparator: isDust ? false : true,
     },
   ];
-  if (displayLabs) {
+  if (isDust) {
+    nav.push({
+      id: "assistants",
+      label: "V2",
+      href: `/w/${owner.sId}/assistant/new`,
+      icon: RobotIcon,
+      sizing: "hug",
+      current: current === "assistant_v2",
+      hasSeparator: isDust ? false : true,
+    });
+
     nav.push({
       id: "lab",
-      label: "Lab",
+      label: "",
       icon: TestTubeIcon,
-      href: `/w/${owner.sId}/u/gens`,
+      href: `/w/${owner.sId}/u/extract`,
       sizing: "hug",
       current: current === "lab",
       hasSeparator: true,
@@ -240,20 +248,6 @@ export const subNavigationLab = ({
       icon: ArrowUpOnSquareIcon,
       href: `/w/${owner.sId}/u/extract`,
       current: current === "extract",
-    },
-    {
-      id: "gens",
-      label: "Gens",
-      icon: Square3Stack3DIcon,
-      href: `/w/${owner.sId}/u/gens`,
-      current: current === "gens",
-    },
-    {
-      id: "assistant",
-      label: "Assistant v2",
-      icon: RobotIcon,
-      href: `/w/${owner.sId}/assistant/new`,
-      current: current === "assistant",
     },
   ];
 

--- a/front/pages/w/[wId]/assistant/[cId]/index.tsx
+++ b/front/pages/w/[wId]/assistant/[cId]/index.tsx
@@ -4,7 +4,6 @@ import Conversation from "@app/components/assistant/conversation/Conversation";
 import { ConversationTitle } from "@app/components/assistant/conversation/ConversationTitle";
 import { FixedAssistantInputBar } from "@app/components/assistant/conversation/InputBar";
 import AppLayout from "@app/components/sparkle/AppLayout";
-import { subNavigationLab } from "@app/components/sparkle/navigation";
 import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
 import { MentionType } from "@app/types/assistant/conversation";
 import { UserType, WorkspaceType } from "@app/types/user";
@@ -86,8 +85,7 @@ export default function AssistantConversation({
       owner={owner}
       isWideMode={true}
       gaTrackingId={gaTrackingId}
-      topNavigationCurrent="lab"
-      subNavigation={subNavigationLab({ owner, current: "assistant" })}
+      topNavigationCurrent="assistant_v2"
       titleChildren={
         <ConversationTitle
           title={""} // TODO: Get title from conversation.

--- a/front/pages/w/[wId]/assistant/new.tsx
+++ b/front/pages/w/[wId]/assistant/new.tsx
@@ -14,7 +14,6 @@ import Conversation from "@app/components/assistant/conversation/Conversation";
 import { ConversationTitle } from "@app/components/assistant/conversation/ConversationTitle";
 import { FixedAssistantInputBar } from "@app/components/assistant/conversation/InputBar";
 import AppLayout from "@app/components/sparkle/AppLayout";
-import { subNavigationLab } from "@app/components/sparkle/navigation";
 import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
 import type {
   PostConversationsRequestBodySchema,
@@ -127,8 +126,7 @@ export default function AssistantNew({
       owner={owner}
       isWideMode={conversation ? true : false}
       gaTrackingId={gaTrackingId}
-      topNavigationCurrent="lab"
-      subNavigation={subNavigationLab({ owner, current: "assistant" })}
+      topNavigationCurrent="assistant_v2"
       titleChildren={
         conversation && (
           <ConversationTitle

--- a/front/pages/w/[wId]/u/gens/index.tsx
+++ b/front/pages/w/[wId]/u/gens/index.tsx
@@ -17,7 +17,6 @@ import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 import TextareaAutosize from "react-textarea-autosize";
 
 import AppLayout from "@app/components/sparkle/AppLayout";
-import { subNavigationLab } from "@app/components/sparkle/navigation";
 import { Spinner } from "@app/components/Spinner";
 import GensTimeRangePicker, {
   gensDefaultTimeRange,
@@ -1338,7 +1337,6 @@ export default function AppGens({
       owner={owner}
       gaTrackingId={gaTrackingId}
       topNavigationCurrent="lab"
-      subNavigation={subNavigationLab({ owner, current: "gens" })}
     >
       <div className="flex flex-col">
         <Transition.Root show={explainExpanded} as={Fragment}>


### PR DESCRIPTION
Small changes on the sidebar navigation prior to handling conversation history on the V2.

I wanted to  puts the V2 in a top nav (for Dust workspace or dev mode) in order to:
- have the full sidebar for the Assistant navigation 
- ease the release, we will have already the proper navigation we will just have to remove "assistant" and use it where we have "assistant_V2"
- save us all one click to access the V2.

  
<img width="1299" alt="Capture d’écran 2023-09-19 à 09 53 51" src="https://github.com/dust-tt/dust/assets/3803406/864f49b1-25b3-4ac1-aa93-21baa1ff22a5">




And as discussed yesterday, a few changes on the Lab menu: 
- Set Extract per default
- Remove link to Gens
- Remove link to V2 (as it's now in top nav)



