### PR TITLE
feat(connectors): add endpoints for resources titles and parents

### DIFF
--- a/connectors/src/api/get_resources_parents.ts
+++ b/connectors/src/api/get_resources_parents.ts
@@ -1,0 +1,92 @@
+import { Request, Response } from "express";
+import { zip } from "fp-ts/lib/Array";
+import { isLeft } from "fp-ts/lib/Either";
+import * as t from "io-ts";
+import * as reporter from "io-ts-reporters";
+
+import { RETRIEVE_RESOURCE_PARENTS_BY_TYPE } from "@connectors/connectors";
+import { Connector } from "@connectors/lib/models";
+import logger from "@connectors/logger/logger";
+import { apiError, withLogging } from "@connectors/logger/withlogging";
+
+const GetResourcesParentsRequestBodySchema = t.type({
+  resourceInternalIds: t.array(t.string),
+});
+
+export type GetResourcesParentsRequestBody = t.TypeOf<
+  typeof GetResourcesParentsRequestBodySchema
+>;
+
+type GetResourcesParentsResponseBody = {
+  resources: {
+    internalId: string;
+    parents: string[] | null;
+  }[];
+};
+
+const _getResourcesDetail = async (
+  req: Request<
+    { connector_id: string },
+    GetResourcesParentsResponseBody,
+    GetResourcesParentsRequestBody
+  >,
+  res: Response<GetResourcesParentsResponseBody>
+) => {
+  const connector = await Connector.findByPk(req.params.connector_id);
+  if (!connector) {
+    return apiError(req, res, {
+      api_error: {
+        type: "connector_not_found",
+        message: "Connector not found",
+      },
+      status_code: 404,
+    });
+  }
+
+  const bodyValidation = GetResourcesParentsRequestBodySchema.decode(req.body);
+  if (isLeft(bodyValidation)) {
+    const pathError = reporter.formatValidationErrors(bodyValidation.left);
+    return apiError(req, res, {
+      api_error: {
+        type: "invalid_request_error",
+        message: `Invalid request body: ${pathError}`,
+      },
+      status_code: 400,
+    });
+  }
+
+  const { resourceInternalIds } = bodyValidation.right;
+
+  const parentsGetter = RETRIEVE_RESOURCE_PARENTS_BY_TYPE[connector.type];
+  const parentsResults = await Promise.all(
+    resourceInternalIds.map((resourceInternalId) =>
+      parentsGetter(connector.id, resourceInternalId)
+    )
+  );
+  const resources: { internalId: string; parents: string[] }[] = [];
+
+  for (const [internalId, parentsResult] of zip(
+    resourceInternalIds,
+    parentsResults
+  )) {
+    if (parentsResult.isErr()) {
+      logger.error(parentsResult.error, "Failed to get resource parents");
+      return apiError(req, res, {
+        api_error: {
+          type: "internal_server_error",
+          message: parentsResult.error.message,
+        },
+        status_code: 500,
+      });
+    }
+
+    resources.push({
+      internalId,
+      parents: parentsResult.value,
+    });
+  }
+
+  return res.status(200).json({ resources });
+};
+
+export const getResourcesDetailAPIHandler = withLogging(_getResourcesDetail);

--- a/connectors/src/api/get_resources_parents.ts
+++ b/connectors/src/api/get_resources_parents.ts
@@ -24,7 +24,7 @@ type GetResourcesParentsResponseBody = {
   }[];
 };
 
-const _getResourcesDetail = async (
+const _getResourcesParents = async (
   req: Request<
     { connector_id: string },
     GetResourcesParentsResponseBody,
@@ -89,4 +89,4 @@ const _getResourcesDetail = async (
   return res.status(200).json({ resources });
 };
 
-export const getResourcesDetailAPIHandler = withLogging(_getResourcesDetail);
+export const getResourcesParentsAPIHandler = withLogging(_getResourcesParents);

--- a/connectors/src/api/get_resources_titles.ts
+++ b/connectors/src/api/get_resources_titles.ts
@@ -1,0 +1,86 @@
+import { Request, Response } from "express";
+import { isLeft } from "fp-ts/lib/Either";
+import * as t from "io-ts";
+import * as reporter from "io-ts-reporters";
+
+import { BATCH_RETRIEVE_RESOURCE_TITLE_BY_TYPE } from "@connectors/connectors";
+import { Connector } from "@connectors/lib/models";
+import { Result } from "@connectors/lib/result";
+import { apiError, withLogging } from "@connectors/logger/withlogging";
+
+const GetResourcesTitlesRequestBodySchema = t.type({
+  resourceInternalIds: t.array(t.string),
+});
+type GetResourcesTitlesRequestBody = t.TypeOf<
+  typeof GetResourcesTitlesRequestBodySchema
+>;
+
+type GetResourcesTitlesResponseBody = {
+  resources: {
+    internalId: string;
+    title: string | null;
+  }[];
+};
+
+const _getResourcesDetail = async (
+  req: Request<
+    { connector_id: string },
+    GetResourcesTitlesResponseBody,
+    GetResourcesTitlesRequestBody
+  >,
+  res: Response<GetResourcesTitlesResponseBody>
+) => {
+  const connector = await Connector.findByPk(req.params.connector_id);
+  if (!connector) {
+    return apiError(req, res, {
+      api_error: {
+        type: "connector_not_found",
+        message: "Connector not found",
+      },
+      status_code: 404,
+    });
+  }
+
+  const bodyValidation = GetResourcesTitlesRequestBodySchema.decode(req.body);
+  if (isLeft(bodyValidation)) {
+    const pathError = reporter.formatValidationErrors(bodyValidation.left);
+    return apiError(req, res, {
+      api_error: {
+        type: "invalid_request_error",
+        message: `Invalid request body: ${pathError}`,
+      },
+      status_code: 400,
+    });
+  }
+
+  const { resourceInternalIds } = bodyValidation.right;
+
+  const titlesRes: Result<
+    Record<string, string | null>,
+    Error
+  > = await BATCH_RETRIEVE_RESOURCE_TITLE_BY_TYPE[connector.type](
+    connector.id,
+    resourceInternalIds
+  );
+
+  if (titlesRes.isErr()) {
+    return apiError(req, res, {
+      api_error: {
+        type: "internal_server_error",
+        message: titlesRes.error.message,
+      },
+      status_code: 500,
+    });
+  }
+
+  const titles = titlesRes.value;
+
+  return res.status(200).json({
+    resources: resourceInternalIds.map((internalId) => ({
+      internalId,
+      title: titles[internalId] || null,
+    })),
+  });
+};
+
+export const getResourcesDetailAPIHandler = withLogging(_getResourcesDetail);

--- a/connectors/src/api/get_resources_titles.ts
+++ b/connectors/src/api/get_resources_titles.ts
@@ -22,7 +22,7 @@ type GetResourcesTitlesResponseBody = {
   }[];
 };
 
-const _getResourcesDetail = async (
+const _getResourcesTitles = async (
   req: Request<
     { connector_id: string },
     GetResourcesTitlesResponseBody,
@@ -83,4 +83,4 @@ const _getResourcesDetail = async (
   });
 };
 
-export const getResourcesDetailAPIHandler = withLogging(_getResourcesDetail);
+export const getResourcesTitlesAPIHandler = withLogging(_getResourcesTitles);

--- a/connectors/src/api_server.ts
+++ b/connectors/src/api_server.ts
@@ -56,11 +56,13 @@ export function startServer(port: number) {
     "/connectors/:connector_id/permissions",
     getConnectorPermissionsAPIHandler
   );
-  app.get(
+  app.post(
+    // must be POST because of body
     "/connectors/:connector_id/resources/parents",
     getResourcesParentsAPIHandler
   );
-  app.get(
+  app.post(
+    // must be POST because of body
     "/connectors/:connector_id/resources/titles",
     getResourcesTitlesAPIHandler
   );

--- a/connectors/src/api_server.ts
+++ b/connectors/src/api_server.ts
@@ -20,6 +20,9 @@ import { webhookSlackAPIHandler } from "@connectors/api/webhooks/webhook_slack";
 import logger from "@connectors/logger/logger";
 import { authMiddleware } from "@connectors/middleware/auth";
 
+import { getResourcesParentsAPIHandler } from "./api/get_resources_parents";
+import { getResourcesTitlesAPIHandler } from "./api/get_resources_titles";
+
 export function startServer(port: number) {
   const app = express();
 
@@ -52,6 +55,14 @@ export function startServer(port: number) {
   app.get(
     "/connectors/:connector_id/permissions",
     getConnectorPermissionsAPIHandler
+  );
+  app.get(
+    "/connectors/:connector_id/resources/parents",
+    getResourcesParentsAPIHandler
+  );
+  app.get(
+    "/connectors/:connector_id/resources/titles",
+    getResourcesTitlesAPIHandler
   );
   app.post(
     "/connectors/:connector_id/permissions",

--- a/connectors/src/connectors/google_drive/lib.ts
+++ b/connectors/src/connectors/google_drive/lib.ts
@@ -2,7 +2,7 @@ import memoize from "lodash.memoize";
 import { v4 as uuidv4 } from "uuid";
 
 import { HTTPError } from "@connectors/lib/error";
-import { GoogleDriveFiles } from "@connectors/lib/models";
+import { GoogleDriveFiles, ModelId } from "@connectors/lib/models";
 import { Err, Ok, type Result } from "@connectors/lib/result.js";
 
 import { getAuthObject } from "./temporal/activities";
@@ -55,7 +55,7 @@ export async function registerWebhook(
 }
 
 async function _getLocalParents(
-  connectorId: string,
+  connectorId: ModelId,
   driveObjectId: string,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars -- used for memoization
   memoizationKey: string

--- a/connectors/src/connectors/index.ts
+++ b/connectors/src/connectors/index.ts
@@ -4,6 +4,7 @@ import {
   fullResyncGithubConnector,
   resumeGithubConnector,
   retrieveGithubConnectorPermissions,
+  retrieveGithubReposTitles,
   stopGithubConnector,
   updateGithubConnector,
 } from "@connectors/connectors/github";
@@ -11,6 +12,8 @@ import {
   cleanupGoogleDriveConnector,
   createGoogleDriveConnector,
   retrieveGoogleDriveConnectorPermissions,
+  retrieveGoogleDriveObjectsParents,
+  retrieveGoogleDriveObjectsTitles,
   setGoogleDriveConnectorPermissions,
   updateGoogleDriveConnector,
 } from "@connectors/connectors/google_drive";
@@ -18,10 +21,12 @@ import { launchGoogleDriveFullSyncWorkflow } from "@connectors/connectors/google
 import {
   BotEnabledGetter,
   BotToggler,
+  ConnectorBatchResourceTitleRetriever,
   ConnectorCleaner,
   ConnectorCreator,
   ConnectorPermissionRetriever,
   ConnectorPermissionSetter,
+  ConnectorResourceParentsRetriever,
   ConnectorResumer,
   ConnectorStopper,
   ConnectorUpdater,
@@ -33,12 +38,15 @@ import {
   fullResyncNotionConnector,
   resumeNotionConnector,
   retrieveNotionConnectorPermissions,
+  retrieveNotionResourceParents,
+  retrieveNotionResourcesTitles,
   stopNotionConnector,
   updateNotionConnector,
 } from "@connectors/connectors/notion";
 import {
   cleanupSlackConnector,
   createSlackConnector,
+  retrieveSlackChannelsTitles,
   retrieveSlackConnectorPermissions,
   setSlackConnectorPermissions,
   updateSlackConnector,
@@ -183,4 +191,24 @@ export const SET_CONNECTOR_PERMISSIONS_BY_TYPE: Record<
     );
   },
   google_drive: setGoogleDriveConnectorPermissions,
+};
+
+export const BATCH_RETRIEVE_RESOURCE_TITLE_BY_TYPE: Record<
+  ConnectorProvider,
+  ConnectorBatchResourceTitleRetriever
+> = {
+  slack: retrieveSlackChannelsTitles,
+  notion: retrieveNotionResourcesTitles,
+  github: retrieveGithubReposTitles,
+  google_drive: retrieveGoogleDriveObjectsTitles,
+};
+
+export const RETRIEVE_RESOURCE_PARENTS_BY_TYPE: Record<
+  ConnectorProvider,
+  ConnectorResourceParentsRetriever
+> = {
+  notion: retrieveNotionResourceParents,
+  google_drive: retrieveGoogleDriveObjectsParents,
+  slack: async () => new Ok([]), // Slack is flat
+  github: async () => new Ok([]), // Github is flat,
 };

--- a/connectors/src/connectors/interface.ts
+++ b/connectors/src/connectors/interface.ts
@@ -62,3 +62,14 @@ export type ConnectorPermissionSetter = (
   // internalId -> "read" | "write" | "read_write" | "none"
   permissions: Record<string, ConnectorPermission>
 ) => Promise<Result<void, Error>>;
+
+export type ConnectorBatchResourceTitleRetriever = (
+  connectorId: ModelId,
+  internalIds: string[]
+) => Promise<Result<Record<string, string | null>, Error>>;
+
+export type ConnectorResourceParentsRetriever = (
+  connectorId: ModelId,
+  internalId: string,
+  memoizationKey?: string
+) => Promise<Result<string[], Error>>;

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -457,3 +457,22 @@ export async function setSlackConnectorPermissions(
 
   return new Ok(undefined);
 }
+
+export async function retrieveSlackChannelsTitles(
+  connectorId: ModelId,
+  internalIds: string[]
+): Promise<Result<Record<string, string>, Error>> {
+  const channels = await SlackChannel.findAll({
+    where: {
+      connectorId: connectorId,
+      slackChannelId: internalIds,
+    },
+  });
+
+  const titles: Record<string, string> = {};
+  for (const ch of channels) {
+    titles[ch.slackChannelId] = ch.slackChannelName;
+  }
+
+  return new Ok(titles);
+}

--- a/front/lib/connectors_api.ts
+++ b/front/lib/connectors_api.ts
@@ -280,6 +280,62 @@ export const ConnectorsAPI = {
 
     return _resultFromResponse(res);
   },
+
+  async getResourcesParents({
+    connectorId,
+    resourceInternalIds,
+  }: {
+    connectorId: string;
+    resourceInternalIds: string[];
+  }): Promise<
+    ConnectorsAPIResponse<
+      {
+        internalId: string;
+        parents: string[];
+      }[]
+    >
+  > {
+    const res = await fetch(
+      `${CONNECTORS_API}/connectors/${connectorId}/resources/parents`,
+      {
+        method: "POST",
+        headers: getDefaultHeaders(),
+        body: JSON.stringify({
+          resourceInternalIds,
+        }),
+      }
+    );
+
+    return _resultFromResponse(res);
+  },
+
+  async getResourcesTitles({
+    connectorId,
+    resourceInternalIds,
+  }: {
+    connectorId: string;
+    resourceInternalIds: string[];
+  }): Promise<
+    ConnectorsAPIResponse<
+      {
+        internalId: string;
+        title: string;
+      }[]
+    >
+  > {
+    const res = await fetch(
+      `${CONNECTORS_API}/connectors/${connectorId}/resources/titles`,
+      {
+        method: "POST",
+        headers: getDefaultHeaders(),
+        body: JSON.stringify({
+          resourceInternalIds,
+        }),
+      }
+    );
+
+    return _resultFromResponse(res);
+  },
 };
 
 function getDefaultHeaders() {

--- a/front/lib/utils.ts
+++ b/front/lib/utils.ts
@@ -115,12 +115,15 @@ export const objectToMarkdown = (obj: any, indent = 0) => {
   return markdown;
 };
 
-export function ioTsEnum<EnumType>(enumValues: readonly string[]) {
+export function ioTsEnum<EnumType>(
+  enumValues: readonly string[],
+  enumName?: string
+) {
   const isEnumValue = (input: unknown): input is EnumType =>
     enumValues.includes(input as string);
 
   return new t.Type<EnumType>(
-    uuidv4(),
+    enumName || uuidv4(),
     isEnumValue,
     (input, context) =>
       isEnumValue(input) ? t.success(input) : t.failure(input, context),


### PR DESCRIPTION
2 endpoints because:
- we never need both at the same time
- parents are a lot more expensive to compute than titles
- makes the code simpler to have separate endpoints vs a single "generic" endpoint