### PR TITLE
V0 sidebar get past conversations

### DIFF
--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -2,10 +2,7 @@ import { Button, ChatBubbleBottomCenterPlusIcon, Item } from "@dust-tt/sparkle";
 import { useRouter } from "next/router";
 
 import { useConversations } from "@app/lib/swr";
-import {
-  ConversationType,
-  ConversationWithoutContentType,
-} from "@app/types/assistant/conversation";
+import { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import { WorkspaceType } from "@app/types/user";
 
 export function AssistantSidebarMenu({ owner }: { owner: WorkspaceType }) {

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -1,0 +1,69 @@
+import { Button, ChatBubbleBottomCenterPlusIcon, Item } from "@dust-tt/sparkle";
+import { useRouter } from "next/router";
+
+import { useConversations } from "@app/lib/swr";
+import {
+  ConversationType,
+  ConversationWithoutContentType,
+} from "@app/types/assistant/conversation";
+import { WorkspaceType } from "@app/types/user";
+
+export function AssistantSidebarMenu({ owner }: { owner: WorkspaceType }) {
+  const router = useRouter();
+
+  const onNewConversation = async () => {
+    void router.push(`/w/${owner.sId}/assistant/new`);
+  };
+
+  // @todo move to a lib function?
+  const isWorkspaceUpgraded =
+    owner.plan !== null &&
+    typeof owner.plan?.limits?.dataSources?.count === "number" &&
+    owner.plan?.limits?.dataSources?.count !== 0;
+
+  const { conversations } = useConversations({ workspaceId: owner.sId });
+
+  return (
+    <div className="flex grow flex-col">
+      <div className="flex h-0 min-h-full w-full overflow-y-auto">
+        <div className="flex w-full flex-col pl-4 pr-2">
+          <div className="pr py-4 text-right">
+            <Button
+              disabled={!isWorkspaceUpgraded}
+              labelVisible={true}
+              label="New Conversation"
+              icon={ChatBubbleBottomCenterPlusIcon}
+              onClick={onNewConversation}
+              className="flex-none shrink"
+            />
+          </div>
+          {conversations.length > 0 && (
+            <div className="py-1 text-xs uppercase text-slate-400">
+              <Item.SectionHeader label="Past Conversations" />
+            </div>
+          )}
+          <Item.List>
+            {conversations.length === 0
+              ? null
+              : conversations.map((c: ConversationWithoutContentType) => {
+                  return (
+                    <Item
+                      key={c.sId}
+                      size="sm"
+                      selected={router.query.cId === c.sId}
+                      label={
+                        c.title ||
+                        `Conversation from ${new Date(
+                          c.created
+                        ).toLocaleDateString()}`
+                      }
+                      href={`/w/${owner.sId}/assistant/${c.sId}`}
+                    />
+                  );
+                })}
+          </Item.List>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -12,12 +12,6 @@ export function AssistantSidebarMenu({ owner }: { owner: WorkspaceType }) {
     void router.push(`/w/${owner.sId}/assistant/new`);
   };
 
-  // @todo move to a lib function?
-  const isWorkspaceUpgraded =
-    owner.plan !== null &&
-    typeof owner.plan?.limits?.dataSources?.count === "number" &&
-    owner.plan?.limits?.dataSources?.count !== 0;
-
   const { conversations } = useConversations({ workspaceId: owner.sId });
 
   return (
@@ -26,7 +20,6 @@ export function AssistantSidebarMenu({ owner }: { owner: WorkspaceType }) {
         <div className="flex w-full flex-col pl-4 pr-2">
           <div className="pr py-4 text-right">
             <Button
-              disabled={!isWorkspaceUpgraded}
               labelVisible={true}
               label="New Conversation"
               icon={ChatBubbleBottomCenterPlusIcon}

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -24,6 +24,7 @@ import {
   AgentMessageType,
   ConversationType,
   ConversationVisibility,
+  ConversationWithoutContentType,
   isAgentMention,
   isAgentMessageType,
   isUserMention,
@@ -197,6 +198,51 @@ async function renderAgentMessage(
     error,
     configuration: agentConfiguration,
   };
+}
+
+/**
+ * TEMPORARY, we need to replace that by a proper list of participants attacthed to the conversation
+ */
+export async function getUserConversations(
+  auth: Authenticator
+): Promise<ConversationWithoutContentType[]> {
+  const owner = auth.workspace();
+  const user = auth.user();
+  if (!owner) {
+    throw new Error("Unexpected `auth` without `workspace`.");
+  }
+  if (!user) {
+    throw new Error("Unexpected `auth` without `workspace`.");
+  }
+
+  const conversations = await Conversation.findAll({
+    attributes: ["id", "sId", "title", "createdAt"],
+    include: [
+      {
+        model: Message,
+        attributes: [], // not needed
+        include: [
+          {
+            model: UserMessage,
+            as: "userMessage",
+            attributes: [], // not needed
+            where: { userId: user.id },
+          },
+        ],
+      },
+    ],
+    order: [["createdAt", "DESC"]],
+  });
+
+  return conversations.map((conversation) => {
+    return {
+      id: conversation.id,
+      created: conversation.createdAt.getTime(),
+      sId: conversation.sId,
+      owner,
+      title: conversation.title,
+    };
+  });
 }
 
 export async function getConversation(

--- a/front/lib/swr.ts
+++ b/front/lib/swr.ts
@@ -426,6 +426,23 @@ export function useConversation({
   };
 }
 
+export function useConversations({ workspaceId }: { workspaceId: string }) {
+  const conversationFetcher: Fetcher<{ conversations: ConversationType[] }> =
+    fetcher;
+
+  const { data, error, mutate } = useSWR(
+    `/api/w/${workspaceId}/assistant/conversations`,
+    conversationFetcher
+  );
+
+  return {
+    conversations: data ? data.conversations : [],
+    isConversationLoading: !error && !data,
+    isConversationError: error,
+    mutateConversation: mutate,
+  };
+}
+
 export function useAgentConfigurations({
   workspaceId,
 }: {

--- a/front/pages/poke/[wId]/index.tsx
+++ b/front/pages/poke/[wId]/index.tsx
@@ -279,7 +279,7 @@ const WorkspacePage = ({
               <p className="mb-4 text-green-600">
                 This workspace was fully upgraded
                 {workspace.upgradedAt &&
-                  `on ${new Date(workspace.upgradedAt).toLocaleDateString()}`}
+                  ` on ${new Date(workspace.upgradedAt).toLocaleDateString()}`}
                 .
               </p>
             ) : (

--- a/front/pages/w/[wId]/assistant/[cId]/index.tsx
+++ b/front/pages/w/[wId]/assistant/[cId]/index.tsx
@@ -3,6 +3,7 @@ import { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import Conversation from "@app/components/assistant/conversation/Conversation";
 import { ConversationTitle } from "@app/components/assistant/conversation/ConversationTitle";
 import { FixedAssistantInputBar } from "@app/components/assistant/conversation/InputBar";
+import { AssistantSidebarMenu } from "@app/components/assistant/conversation/SidebarMenu";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
 import { MentionType } from "@app/types/assistant/conversation";
@@ -97,6 +98,7 @@ export default function AssistantConversation({
           visibility={"unlisted"}
         />
       }
+      navChildren={<AssistantSidebarMenu owner={owner} />}
     >
       <Conversation owner={owner} conversationId={conversationId} />
       <FixedAssistantInputBar owner={owner} onSubmit={handleSubmit} />

--- a/front/pages/w/[wId]/assistant/new.tsx
+++ b/front/pages/w/[wId]/assistant/new.tsx
@@ -13,6 +13,7 @@ import { useState } from "react";
 import Conversation from "@app/components/assistant/conversation/Conversation";
 import { ConversationTitle } from "@app/components/assistant/conversation/ConversationTitle";
 import { FixedAssistantInputBar } from "@app/components/assistant/conversation/InputBar";
+import { AssistantSidebarMenu } from "@app/components/assistant/conversation/SidebarMenu";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
 import type {
@@ -140,6 +141,7 @@ export default function AssistantNew({
           />
         )
       }
+      navChildren={<AssistantSidebarMenu owner={owner} />}
     >
       {!conversation ? (
         <>

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -127,3 +127,10 @@ export type ConversationType = {
   visibility: ConversationVisibility;
   content: (UserMessageType[] | AgentMessageType[])[];
 };
+export type ConversationWithoutContentType = {
+  id: ModelId;
+  created: number;
+  sId: string;
+  owner: WorkspaceType;
+  title: string | null;
+};


### PR DESCRIPTION
This adds a basic sidebar navigation for past conversations, just the raw list, no group per date. 

It fetches all the conversations in which you have posted at least one user message. Ad discussed IRL, it won't be efficient, we need to properly manage the list of participants somewhere.

I'm submitting as is because it was mostly coded and it can be useful for the team to have access to past convo while testing or developing. 