### PR TITLE
feat(assistant builder): preserve parentsById

### DIFF
--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/parents.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/parents.ts
@@ -1,0 +1,136 @@
+import { isLeft } from "fp-ts/lib/Either";
+import * as t from "io-ts";
+import * as reporter from "io-ts-reporters";
+import { NextApiRequest, NextApiResponse } from "next";
+
+import { getDataSource } from "@app/lib/api/data_sources";
+import { Authenticator, getSession } from "@app/lib/auth";
+import { ConnectorsAPI } from "@app/lib/connectors_api";
+import { ReturnedAPIErrorType } from "@app/lib/error";
+import { apiError, withLogging } from "@app/logger/withlogging";
+
+const GetConnectorResourceParentsRequestBodySchema = t.type({
+  resourceInternalIds: t.array(t.string),
+});
+
+export type GetConnectorResourceParentsResponseBody = {
+  resources: { parents: string[]; internalId: string }[];
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    GetConnectorResourceParentsResponseBody | ReturnedAPIErrorType
+  >
+): Promise<void> {
+  const session = await getSession(req, res);
+  const auth = await Authenticator.fromSession(
+    session,
+    req.query.wId as string
+  );
+
+  const owner = auth.workspace();
+  if (!owner) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "data_source_not_found",
+        message: "The data source you requested was not found.",
+      },
+    });
+  }
+
+  const dataSource = await getDataSource(auth, req.query.name as string);
+  if (!dataSource) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "data_source_not_found",
+        message: "The data source you requested was not found.",
+      },
+    });
+  }
+
+  if (!dataSource.connectorId) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "data_source_not_managed",
+        message: "The data source you requested is not managed.",
+      },
+    });
+  }
+
+  if (!auth.isBuilder()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "data_source_auth_error",
+        message:
+          "Only the users that are `builders` for the current workspace can retrieve parents of connector resources.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "POST":
+      // We use post because we need a body, but we don't create anything
+
+      const body = req.body;
+      if (!body) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Missing required parameters. Required: resources",
+          },
+        });
+      }
+
+      const bodyValidation =
+        GetConnectorResourceParentsRequestBodySchema.decode(req.body);
+
+      if (isLeft(bodyValidation)) {
+        const pathError = reporter.formatValidationErrors(bodyValidation.left);
+        return apiError(req, res, {
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid request body: ${pathError}`,
+          },
+          status_code: 400,
+        });
+      }
+
+      const { resourceInternalIds } = bodyValidation.right;
+
+      const connectorsRes = await ConnectorsAPI.getResourcesParents({
+        resourceInternalIds,
+        connectorId: dataSource.connectorId,
+      });
+
+      if (connectorsRes.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: `An error occurred while fetching the resources' parents.`,
+          },
+        });
+      }
+
+      res.status(200).json({ resources: connectorsRes.value.resources });
+      return;
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message:
+            "The method passed is not supported, GET or POST is expected.",
+        },
+      });
+  }
+}
+
+export default withLogging(handler);


### PR DESCRIPTION
When coming back to edit an assistant, we are currently losing the "partially checked" checkboxes that indicate that a (arbitrarily deep) subnode is selected.
This fixes the issue by fetching the parents of all selected nodes if they are missing.