### PR TITLE
fix(assistant builder): handle is taken

### DIFF
--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -165,10 +165,11 @@ export default function AssistantBuilder({
     (handle: string) => {
       return !agentConfigurations.some(
         (agentConfiguration) =>
-          agentConfiguration.name.toLowerCase() === handle.toLowerCase()
+          agentConfiguration.name.toLowerCase() === handle.toLowerCase() &&
+          initialBuilderState?.handle !== handle
       );
     },
-    [agentConfigurations]
+    [agentConfigurations, initialBuilderState?.handle]
   );
 
   const configuredDataSourceCount = Object.keys(


### PR DESCRIPTION
assistant in edit mode should be allowed to keep its name