### PR TITLE
feat: add versioning to agent config

### DIFF
--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -57,7 +57,7 @@ export async function getAgentConfiguration(
     },
   });
 
-  if (!latestVersion) {
+  if (latestVersion === null) {
     return null;
   }
 

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -204,7 +204,7 @@ export async function createAgentConfiguration(
     status,
     generation,
     action,
-    sId,
+    agentConfigurationId,
   }: {
     name: string;
     description: string;
@@ -212,8 +212,7 @@ export async function createAgentConfiguration(
     status: AgentConfigurationStatus;
     generation: AgentGenerationConfigurationType | null;
     action: AgentActionConfigurationType | null;
-    version?: number;
-    sId?: string;
+    agentConfigurationId?: string;
   }
 ): Promise<AgentConfigurationType> {
   const owner = auth.workspace();
@@ -225,14 +224,14 @@ export async function createAgentConfiguration(
 
   const agentConfig = await front_sequelize.transaction(
     async (t): Promise<AgentConfiguration> => {
-      if (sId) {
+      if (agentConfigurationId) {
         const latestVersion = await AgentConfiguration.max<
           number | null,
           AgentConfiguration
         >("version", {
           where: {
             workspaceId: owner.id,
-            sId: sId,
+            sId: agentConfigurationId,
           },
           transaction: t,
         });
@@ -245,7 +244,7 @@ export async function createAgentConfiguration(
           { status: "archived" },
           {
             where: {
-              sId: sId,
+              sId: agentConfigurationId,
               workspaceId: owner.id,
             },
             transaction: t,
@@ -256,7 +255,7 @@ export async function createAgentConfiguration(
       // Create Agent config
       return AgentConfiguration.create(
         {
-          sId: sId || generateModelSId(),
+          sId: agentConfigurationId || generateModelSId(),
           version,
           status: status,
           name: name,

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -222,6 +222,7 @@ export async function getAgentConfigurations(
   const rawAgents = await AgentConfiguration.findAll({
     where: {
       workspaceId: owner.id,
+      status: "active",
       ...(agentPrefix
         ? {
             name: {
@@ -231,6 +232,7 @@ export async function getAgentConfigurations(
         : {}),
     },
   });
+
   const agents = await Promise.all(
     rawAgents.map(async (a) => {
       const agentConfig = await getAgentConfiguration(auth, a.sId);

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -125,6 +125,7 @@ export async function getAgentConfiguration(
   return {
     id: agent.id,
     sId: agent.sId,
+    version: agent.version,
     scope: "workspace",
     name: agent.name,
     pictureUrl: agent.pictureUrl,
@@ -200,6 +201,8 @@ export async function createAgentConfiguration(
     status,
     generation,
     action,
+    sId,
+    version = 0,
   }: {
     name: string;
     description: string;
@@ -207,6 +210,8 @@ export async function createAgentConfiguration(
     status: AgentConfigurationStatus;
     generation: AgentGenerationConfigurationType | null;
     action: AgentActionConfigurationType | null;
+    version?: number;
+    sId?: string;
   }
 ): Promise<AgentConfigurationType> {
   const owner = auth.workspace();
@@ -216,7 +221,8 @@ export async function createAgentConfiguration(
 
   // Create Agent config
   const agentConfig = await AgentConfiguration.create({
-    sId: generateModelSId(),
+    sId: sId || generateModelSId(),
+    version,
     status: status,
     name: name,
     description: description,
@@ -231,6 +237,7 @@ export async function createAgentConfiguration(
   return {
     id: agentConfig.id,
     sId: agentConfig.sId,
+    version: agentConfig.version,
     scope: "workspace",
     name: agentConfig.name,
     description: agentConfig.description,

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -47,28 +47,12 @@ export async function getAgentConfiguration(
     return await getGlobalAgent(auth, agentId);
   }
 
-  const latestVersion = await AgentConfiguration.max<
-    number | null,
-    AgentConfiguration
-  >("version", {
-    where: {
-      sId: agentId,
-      workspaceId: owner.id,
-    },
-  });
-
-  if (latestVersion === null) {
-    return null;
-  }
-
   const agent = await AgentConfiguration.findOne({
     where: {
       sId: agentId,
       workspaceId: owner.id,
-      version: {
-        [Op.eq]: latestVersion,
-      },
     },
+    order: [["version", "DESC"]],
     include: [
       {
         model: AgentGenerationConfiguration,
@@ -79,7 +63,9 @@ export async function getAgentConfiguration(
         as: "retrievalConfiguration",
       },
     ],
+    limit: 1,
   });
+
   if (!agent) {
     return null;
   }

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -47,10 +47,27 @@ export async function getAgentConfiguration(
     return await getGlobalAgent(auth, agentId);
   }
 
+  const latestVersion = await AgentConfiguration.max<
+    number | null,
+    AgentConfiguration
+  >("version", {
+    where: {
+      sId: agentId,
+      workspaceId: owner.id,
+    },
+  });
+
+  if (!latestVersion) {
+    return null;
+  }
+
   const agent = await AgentConfiguration.findOne({
     where: {
       sId: agentId,
       workspaceId: owner.id,
+      version: {
+        [Op.eq]: latestVersion,
+      },
     },
     include: [
       {

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -768,7 +768,8 @@ export async function* retryAgentMessage(
       {
         status: "created",
         agentConfigurationId: messageRow.agentMessage.agentConfigurationId,
-        agentConfigurationVersion: 0,
+        agentConfigurationVersion:
+          messageRow.agentMessage.agentConfigurationVersion,
       },
       { transaction: t }
     );

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -596,6 +596,7 @@ export async function* postUserMessage(
                 {
                   status: "created",
                   agentConfigurationId: configuration.sId,
+                  agentConfigurationVersion: configuration.version,
                 },
                 { transaction: t }
               );
@@ -767,6 +768,7 @@ export async function* retryAgentMessage(
       {
         status: "created",
         agentConfigurationId: messageRow.agentMessage.agentConfigurationId,
+        agentConfigurationVersion: 0,
       },
       { transaction: t }
     );

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -28,6 +28,7 @@ async function _getGPT35TurboGlobalAgent(): Promise<AgentConfigurationType> {
   return {
     id: -1,
     sId: GLOBAL_AGENTS_SID.GPT35_TURBO,
+    version: 0,
     name: "gpt3.5-turbo",
     description: "OpenAI's cost-effective and high throughput model.",
     pictureUrl: "https://dust.tt/static/systemavatar/gpt3_avatar_full.png",
@@ -50,6 +51,7 @@ async function _getGPT4GlobalAgent(): Promise<AgentConfigurationType> {
   return {
     id: -1,
     sId: GLOBAL_AGENTS_SID.GPT4,
+    version: 0,
     name: "gpt4",
     description: "OpenAI's most powerful model.",
     pictureUrl: "https://dust.tt/static/systemavatar/gpt4_avatar_full.png",
@@ -72,6 +74,7 @@ async function _getClaudeInstantGlobalAgent(): Promise<AgentConfigurationType> {
   return {
     id: -1,
     sId: GLOBAL_AGENTS_SID.CLAUDE_INSTANT,
+    version: 0,
     name: "claude-instant",
     description: "Anthropic's low-latency and high throughput model.",
     pictureUrl: "https://dust.tt/static/systemavatar/claude_avatar_full.png",
@@ -94,6 +97,7 @@ async function _getClaudeGlobalAgent(): Promise<AgentConfigurationType> {
   return {
     id: -1,
     sId: GLOBAL_AGENTS_SID.CLAUDE,
+    version: 0,
     name: "claude",
     description: "Anthropic's superior performance model.",
     pictureUrl: "https://dust.tt/static/systemavatar/claude_avatar_full.png",
@@ -145,6 +149,7 @@ async function _getManagedDataSourceAgent(
   return {
     id: -1,
     sId: agentId,
+    version: 0,
     name: name,
     description,
     pictureUrl,
@@ -254,6 +259,7 @@ async function _getDustGlobalAgent(
   return {
     id: -1,
     sId: GLOBAL_AGENTS_SID.DUST,
+    version: 0,
     name: "Dust",
     description:
       "An assistant with context on your managed and static data sources.",

--- a/front/lib/models/assistant/agent.ts
+++ b/front/lib/models/assistant/agent.ts
@@ -82,6 +82,8 @@ export class AgentConfiguration extends Model<
   declare updatedAt: CreationOptional<Date>;
 
   declare sId: string;
+  declare version: number;
+
   declare status: AgentConfigurationStatus;
   declare name: string;
   declare description: string;
@@ -118,7 +120,11 @@ AgentConfiguration.init(
     sId: {
       type: DataTypes.STRING,
       allowNull: false,
-      unique: true,
+    },
+    version: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      defaultValue: 0,
     },
     status: {
       type: DataTypes.STRING,
@@ -144,7 +150,8 @@ AgentConfiguration.init(
     indexes: [
       { fields: ["workspaceId"] },
       { fields: ["workspaceId", "name"], unique: true },
-      { fields: ["sId"], unique: true },
+      { fields: ["sId"] },
+      { fields: ["sId", "version"], unique: true },
     ],
   }
 );

--- a/front/lib/models/assistant/agent.ts
+++ b/front/lib/models/assistant/agent.ts
@@ -149,7 +149,7 @@ AgentConfiguration.init(
     sequelize: front_sequelize,
     indexes: [
       { fields: ["workspaceId"] },
-      { fields: ["workspaceId", "name"], unique: true },
+      { fields: ["workspaceId", "name"] },
       { fields: ["sId"] },
       { fields: ["sId", "version"], unique: true },
     ],

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -243,7 +243,11 @@ export class AgentMessage extends Model<
   declare errorMessage: string | null;
 
   declare agentRetrievalActionId: ForeignKey<AgentRetrievalAction["id"]> | null;
-  declare agentConfigurationId: string; // Not a relation as global agents are not in the DB
+
+  // Not a relation as global agents are not in the DB
+  // needs both sId and version to uniquely identify the agent configuration
+  declare agentConfigurationId: string;
+  declare agentConfigurationVersion: number;
 }
 
 AgentMessage.init(
@@ -282,7 +286,12 @@ AgentMessage.init(
     },
     agentConfigurationId: {
       type: DataTypes.STRING,
-      allowNull: true,
+      allowNull: false,
+    },
+    agentConfigurationVersion: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      defaultValue: 0,
     },
   },
   {

--- a/front/migrations/20230920_agent_config_drop_sid_unique_constraints.sql
+++ b/front/migrations/20230920_agent_config_drop_sid_unique_constraints.sql
@@ -15,3 +15,10 @@ alter table
 
 alter table
     "agent_configurations" drop constraint "agent_configurations_sId_key5";
+
+alter table
+    "agent_configurations" drop constraint "agent_configurations_workspace_id_name";
+
+DROP index "agent_configurations_s_id";
+
+drop index "agent_configurations_workspace_id_name";

--- a/front/migrations/20230920_agent_config_drop_sid_unique_constraints.sql
+++ b/front/migrations/20230920_agent_config_drop_sid_unique_constraints.sql
@@ -1,0 +1,17 @@
+alter table
+    "agent_configurations" drop constraint "agent_configurations_sId_key";
+
+alter table
+    "agent_configurations" drop constraint "agent_configurations_sId_key1";
+
+alter table
+    "agent_configurations" drop constraint "agent_configurations_sId_key2";
+
+alter table
+    "agent_configurations" drop constraint "agent_configurations_sId_key3";
+
+alter table
+    "agent_configurations" drop constraint "agent_configurations_sId_key4";
+
+alter table
+    "agent_configurations" drop constraint "agent_configurations_sId_key5";

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/index.ts
@@ -2,16 +2,16 @@ import { isLeft } from "fp-ts/lib/Either";
 import * as reporter from "io-ts-reporters";
 import { NextApiRequest, NextApiResponse } from "next";
 
-import {
-  createOrUpgradeAgentConfiguration,
-  getAgentConfiguration,
-} from "@app/lib/api/assistant/configuration";
+import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { ReturnedAPIErrorType } from "@app/lib/error";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import { AgentConfigurationType } from "@app/types/assistant/agent";
 
-import { PostOrPatchAgentConfigurationRequestBodySchema } from "..";
+import {
+  createOrUpgradeAgentConfiguration,
+  PostOrPatchAgentConfigurationRequestBodySchema,
+} from "..";
 
 export type GetAgentConfigurationResponseBody = {
   agentConfiguration: AgentConfigurationType;
@@ -82,18 +82,11 @@ async function handler(
         });
       }
 
-      const { name, pictureUrl, status, action, generation, description } =
-        bodyValidation.right.assistant;
-
-      const agentConfiguration = await createOrUpgradeAgentConfiguration(auth, {
-        name,
-        description,
-        pictureUrl,
-        status,
-        generation: generation,
-        action: action,
-        agentConfigurationId: req.query.aId as string,
-      });
+      const agentConfiguration = await createOrUpgradeAgentConfiguration(
+        auth,
+        bodyValidation.right,
+        req.query.aId as string
+      );
 
       return res.status(200).json({
         agentConfiguration: agentConfiguration,

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -63,7 +63,10 @@ export type AgentConfigurationScope = "global" | "workspace";
 
 export type AgentConfigurationType = {
   id: ModelId;
+
   sId: string;
+  version: number;
+
   scope: AgentConfigurationScope;
   status: AgentConfigurationStatus;
 


### PR DESCRIPTION
- adds a version field to `AgentConfiguration`
- makes `AgentConfiguration` unique on `(sId, version)`
- adds a migration to remove unicity on `(sId)`
- adds a `agentConfigurationVersion` field to `AgentMessage`
- update the `getAgent` logic to fetch the agent that has the highest version
- add the ability to pass the `sId` (default to unique new sId) to the agent creation code. If the sId is passed, the the new agent will have an increamented version for that sId and existing assistants with that sId will be archived

The unique indexes on `sId` from `AgentConfiguration` were duplicated multiple times (for some reason), which is why the SQL migration is dropping multiple constraints. see [here](https://metabase.dust.tt/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7InR5cGUiOiJuYXRpdmUiLCJuYXRpdmUiOnsicXVlcnkiOiJTRUxFQ1QgY29uLipcbiAgICAgICBGUk9NIHBnX2NhdGFsb2cucGdfY29uc3RyYWludCBjb25cbiAgICAgICAgICAgIElOTkVSIEpPSU4gcGdfY2F0YWxvZy5wZ19jbGFzcyByZWxcbiAgICAgICAgICAgICAgICAgICAgICAgT04gcmVsLm9pZCA9IGNvbi5jb25yZWxpZFxuICAgICAgICAgICAgSU5ORVIgSk9JTiBwZ19jYXRhbG9nLnBnX25hbWVzcGFjZSBuc3BcbiAgICAgICAgICAgICAgICAgICAgICAgT04gbnNwLm9pZCA9IGNvbm5hbWVzcGFjZVxuICAgICAgIFdIRVJFIHJlbC5yZWxuYW1lID0gJ2FnZW50X2NvbmZpZ3VyYXRpb25zJzsiLCJ0ZW1wbGF0ZS10YWdzIjp7fX0sImRhdGFiYXNlIjo0fSwiZGlzcGxheSI6InRhYmxlIiwicGFyYW1ldGVycyI6W10sInZpc3VhbGl6YXRpb25fc2V0dGluZ3MiOnt9fQ==)

PATCH code has  been updated to use versioning as well, and the "update" methods were deleted. "create" methods for action / generation / agent configurations have been taken out of the interface, in favour of a `createOrUpgradeAgentConfiguration` method that does all the creates and handles the versioning

`getAgentConfigurations` has also been fixed  to not look at assistants that are archived.

⚠️ In order:
- run SQL migration
- run initdb
- deploy