### PR TITLE
Generate conversation titles

### DIFF
--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -99,9 +99,11 @@ export function AssistantSidebarMenu({ owner }: { owner: WorkspaceType }) {
                               selected={router.query.cId === c.sId}
                               label={
                                 c.title ||
-                                `Conversation from ${new Date(
-                                  c.created
-                                ).toLocaleDateString()}`
+                                (moment(c.created).isSame(moment(), "day")
+                                  ? "New Conversation"
+                                  : `Conversation from ${new Date(
+                                      c.created
+                                    ).toLocaleDateString()}`)
                               }
                               onClick={async () =>
                                 await router.push(

--- a/front/lib/actions/registry.ts
+++ b/front/lib/actions/registry.ts
@@ -28,6 +28,22 @@ export const DustProdActionRegistry = createActionRegistry({
       },
     },
   },
+  "assistant-v2-title-generator": {
+    app: {
+      workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
+      appId: "84dfc1d4f7",
+      appHash:
+        "b7b8a87fde20d0302dfc13e80f147a5dc1967bb9795f55a47428b92936e5cdec",
+    },
+    config: {
+      MODEL: {
+        provider_id: "openai",
+        model_id: "gpt-3.5-turbo-16k",
+        function_call: "update_title",
+        use_cache: false,
+      },
+    },
+  },
   "assistant-v2-retrieval": {
     app: {
       workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1,4 +1,9 @@
 import {
+  cloneBaseConfig,
+  DustProdActionRegistry,
+} from "@app/lib/actions/registry";
+import { runAction } from "@app/lib/actions/server";
+import {
   AgentActionEvent,
   AgentActionSuccessEvent,
   AgentErrorEvent,
@@ -7,7 +12,10 @@ import {
   runAgent,
 } from "@app/lib/api/assistant/agent";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
-import { GenerationTokensEvent } from "@app/lib/api/assistant/generation";
+import {
+  GenerationTokensEvent,
+  renderConversationForModel,
+} from "@app/lib/api/assistant/generation";
 import { Authenticator } from "@app/lib/auth";
 import { front_sequelize } from "@app/lib/databases";
 import {
@@ -19,6 +27,7 @@ import {
   User,
   UserMessage,
 } from "@app/lib/models";
+import { Err, Ok, Result } from "@app/lib/result";
 import { generateModelSId } from "@app/lib/utils";
 import logger from "@app/logger/logger";
 import {
@@ -412,6 +421,75 @@ export async function getConversation(
 }
 
 /**
+ * Title generation
+ */
+
+export async function generateConversationTitle(
+  auth: Authenticator,
+  conversation: ConversationType
+): Promise<Result<string, Error>> {
+  const model = {
+    providerId: "openai",
+    modelId: "gpt-3.5-turbo-16k",
+  };
+  const allowedTokenCount = 12288; // for 16k model.
+
+  // Turn the conversation into a digest that can be presented to the model.
+  const modelConversationRes = await renderConversationForModel({
+    conversation,
+    model,
+    allowedTokenCount,
+  });
+
+  if (modelConversationRes.isErr()) {
+    return modelConversationRes;
+  }
+
+  const config = cloneBaseConfig(
+    DustProdActionRegistry["assistant-v2-title-generator"].config
+  );
+  config.MODEL.provider_id = model.providerId;
+  config.MODEL.model_id = model.modelId;
+
+  const res = await runAction(auth, "assistant-v2-title-generator", config, [
+    {
+      conversation: modelConversationRes.value,
+    },
+  ]);
+
+  if (res.isErr()) {
+    return new Err(
+      new Error(`Error generating conversation title: ${res.error}`)
+    );
+  }
+
+  const run = res.value;
+
+  let title: string | null = null;
+  for (const t of run.traces) {
+    if (t[1][0][0].error) {
+      return new Err(
+        new Error(`Error generating conversation title: ${t[1][0][0].error}`)
+      );
+    }
+    if (t[0][1] === "OUTPUT") {
+      const v = t[1][0][0].value as any;
+      if (v.conversation_title) {
+        title = v.conversation_title;
+      }
+    }
+  }
+
+  if (title === null) {
+    return new Err(
+      new Error(`Error generating conversation title: malformed output`)
+    );
+  }
+
+  return new Ok(title);
+}
+
+/**
  * Conversation API
  */
 
@@ -442,6 +520,13 @@ export type AgentMessageNewEvent = {
   message: AgentMessageType;
 };
 
+// Event sent when the conversation title is updated.
+export type ConversationTitleEvent = {
+  type: "conversation_title";
+  created: number;
+  title: string;
+};
+
 // This method is in charge of creating a new user message in database, running the necessary agents
 // in response and updating accordingly the conversation. AgentMentions must point to valid agent
 // configurations from the same workspace or whose scope is global.
@@ -467,7 +552,8 @@ export async function* postUserMessage(
   | AgentActionSuccessEvent
   | GenerationTokensEvent
   | AgentGenerationSuccessEvent
-  | AgentMessageSuccessEvent,
+  | AgentMessageSuccessEvent
+  | ConversationTitleEvent,
   void
 > {
   const user = auth.user();
@@ -717,6 +803,44 @@ export async function* postUserMessage(
       eventStreamsPromises[winner.offset] =
         eventStreamGenerators[winner.offset].next();
       yield winner.v.value;
+    }
+  }
+
+  // Generate a new title if the conversation does not have one already.
+  if (conversation.title === null) {
+    const titleRes = await generateConversationTitle(auth, {
+      ...conversation,
+      content: [
+        ...conversation.content,
+        [userMessage],
+        ...agentMessages.map((m) => [m]),
+      ],
+    });
+    if (titleRes.isErr()) {
+      logger.error(
+        {
+          error: titleRes.error,
+        },
+        "Conversation title generation error"
+      );
+    } else {
+      const title = titleRes.value;
+      await Conversation.update(
+        {
+          title,
+        },
+        {
+          where: {
+            id: conversation.id,
+          },
+        }
+      );
+
+      yield {
+        type: "conversation_title",
+        created: Date.now(),
+        title,
+      };
     }
   }
 }

--- a/front/lib/api/assistant/pubsub.ts
+++ b/front/lib/api/assistant/pubsub.ts
@@ -6,6 +6,7 @@ import {
 } from "@app/lib/api/assistant/agent";
 import {
   AgentMessageNewEvent,
+  ConversationTitleEvent,
   postUserMessage,
   retryAgentMessage,
   UserMessageNewEvent,
@@ -49,7 +50,8 @@ export async function postUserMessageWithPubSub(
         })) {
           switch (event.type) {
             case "user_message_new":
-            case "agent_message_new": {
+            case "agent_message_new":
+            case "conversation_title": {
               const pubsubChannel = getConversationChannelId(conversation.sId);
               await redis.xAdd(pubsubChannel, "*", {
                 payload: JSON.stringify(event),
@@ -182,7 +184,7 @@ export async function* getConversationEvents(
 ): AsyncGenerator<
   {
     eventId: string;
-    data: UserMessageNewEvent | AgentMessageNewEvent;
+    data: UserMessageNewEvent | AgentMessageNewEvent | ConversationTitleEvent;
   },
   void
 > {

--- a/front/pages/w/[wId]/assistant/[cId]/index.tsx
+++ b/front/pages/w/[wId]/assistant/[cId]/index.tsx
@@ -1,5 +1,7 @@
 import { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
+import { useState } from "react";
+import { mutate } from "swr";
 
 import Conversation from "@app/components/assistant/conversation/Conversation";
 import { ConversationTitle } from "@app/components/assistant/conversation/ConversationTitle";
@@ -56,6 +58,8 @@ export default function AssistantConversation({
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const router = useRouter();
 
+  const [title, setTitle] = useState<string | null>(null);
+
   const handleSubmit = async (input: string, mentions: MentionType[]) => {
     // Create a new user message.
     const mRes = await fetch(
@@ -109,7 +113,7 @@ export default function AssistantConversation({
       topNavigationCurrent="assistant_v2"
       titleChildren={
         <ConversationTitle
-          title={""} // TODO: Get title from conversation.
+          title={title || ""}
           shareLink={`${baseUrl}/w/${owner.sId}/assistant/${conversationId}`}
           onDelete={() => {
             void handdleDeleteConversation();
@@ -118,7 +122,15 @@ export default function AssistantConversation({
       }
       navChildren={<AssistantSidebarMenu owner={owner} />}
     >
-      <Conversation owner={owner} conversationId={conversationId} />
+      <Conversation
+        owner={owner}
+        conversationId={conversationId}
+        onTitleUpdate={(title) => {
+          setTitle(title);
+          // We mutate the list of conversations so that the title gets updated.
+          void mutate(`/api/w/${owner.sId}/assistant/conversations`);
+        }}
+      />
       <FixedAssistantInputBar owner={owner} onSubmit={handleSubmit} />
     </AppLayout>
   );

--- a/front/pages/w/[wId]/assistant/new.tsx
+++ b/front/pages/w/[wId]/assistant/new.tsx
@@ -241,7 +241,13 @@ export default function AssistantNew({
           </div>
         </>
       ) : (
-        <Conversation owner={owner} conversationId={conversation.sId} />
+        <Conversation
+          owner={owner}
+          conversationId={conversation.sId}
+          onTitleUpdate={() => {
+            // Nothing to do as this new page will be long gone by the time the title is updated.
+          }}
+        />
       )}
 
       <FixedAssistantInputBar owner={owner} onSubmit={handleSubmit} />


### PR DESCRIPTION
Fixes #1520 

Generate a title if it does not exist in `postNewUserMessage` at the end and emit a new `conversation_title` event which gets streamed to the conversation events through pubsub.

Client side expose a `onTitleUpdate` on the `Conversation` component, update the title bar and mutate (at distance, not great but OK) the conversations list for the left side-bar.

New app is here: https://dust.tt/w/78bda07b39/a/84dfc1d4f7