### PR TITLE
Add missing version to Assistant helper

### DIFF
--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -80,6 +80,7 @@ async function _getHelperGlobalAgent(
   return {
     id: -1,
     sId: GLOBAL_AGENTS_SID.HELPER,
+    version: 0,
     name: "helper",
     description:
       "Here to help with everything about assistant, and Dust's product in general",


### PR DESCRIPTION
Fixing https://github.com/dust-tt/dust/actions/runs/6250962699
agent version was introduced and I did not rebase before merging!