### PR TITLE
Prompting improvements

### DIFF
--- a/core/src/providers/anthropic.rs
+++ b/core/src/providers/anthropic.rs
@@ -82,12 +82,20 @@ impl AnthropicLLM {
             .iter()
             .map(|cm| -> String {
                 format!(
-                    "\n\n{}: {}",
+                    "\n\n{}:{} {}",
+                    match cm.name.as_ref() {
+                        Some(name) => match cm.role {
+                            ChatMessageRole::User => format!(" [{}]", name),
+                            ChatMessageRole::Function => format!(" [{}]", name),
+                            _ => String::from(""),
+                        },
+                        None => String::from(""),
+                    },
                     match cm.role {
-                        ChatMessageRole::System => "Human",
+                        ChatMessageRole::System => "System",
                         ChatMessageRole::Assistant => "Assistant",
                         ChatMessageRole::User => "Human",
-                        ChatMessageRole::Function => "Human",
+                        ChatMessageRole::Function => "FunctionResult",
                     },
                     cm.content.as_ref().unwrap_or(&String::from("")).clone()
                 )
@@ -115,6 +123,8 @@ impl AnthropicLLM {
         let mut stop_tokens = stop.clone();
         stop_tokens.push(String::from("\n\nHuman:"));
         stop_tokens.push(String::from("\n\nAssistant:"));
+        stop_tokens.push(String::from("\n\nSystem:"));
+        stop_tokens.push(String::from("\n\nFunctionResult:"));
 
         if max_tokens.is_none() || max_tokens.unwrap() == -1 {
             let tokens = self.encode(&prompt).await?;
@@ -163,6 +173,8 @@ impl AnthropicLLM {
         let mut stop_tokens = stop.clone();
         stop_tokens.push(String::from("\n\nHuman:"));
         stop_tokens.push(String::from("\n\nAssistant:"));
+        stop_tokens.push(String::from("\n\nSystem:"));
+        stop_tokens.push(String::from("\n\nFunctionResult:"));
 
         if max_tokens.is_none() || max_tokens.unwrap() == -1 {
             let tokens = self.encode(&prompt).await?;

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -133,12 +133,10 @@ export function renderRetrievalActionForModel(
 
     content += `TITLE: ${title} (data source: ${dataSourceName})\n`;
     content += `REFERENCE: ${d.reference}\n`;
-
     content += `EXTRACTS:\n`;
     for (const c of d.chunks) {
       content += `${c.text}\n`;
     }
-
     content += "\n";
   }
 

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -80,7 +80,7 @@ export async function renderConversationForModel({
     if (isUserMessageType(m)) {
       // Replace all `:mention[{name}]{.*}` with `@name`.
       const content = m.content.replace(
-        /:mention\[(.*?)\]{.*?}/g,
+        /:mention\[(.+)\]\{.+\}/g,
         (match, name) => {
           return `@${name}`;
         }

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -1,3 +1,5 @@
+import moment from "moment-timezone";
+
 import {
   cloneBaseConfig,
   DustProdActionRegistry,
@@ -76,10 +78,17 @@ export async function renderConversationForModel({
       }
     }
     if (isUserMessageType(m)) {
+      // Replace all `:mention[{name}]{.*}` with `@name`.
+      const content = m.content.replace(
+        /:mention\[(.*?)\]{.*?}/g,
+        (match, name) => {
+          return `@${name}`;
+        }
+      );
       messages.unshift({
         role: "user" as const,
         name: m.context.username,
-        content: m.content,
+        content,
       });
     }
   }
@@ -195,6 +204,26 @@ export type GenerationSuccessEvent = {
   text: string;
 };
 
+// Construct the full prompt from the agent configuration.
+// - Meta data about the agent and current time.
+function constructPrompt(
+  userMessage: UserMessageType,
+  configuration: AgentConfigurationType
+) {
+  if (!configuration.generation) {
+    return "";
+  }
+
+  const d = moment(new Date()).tz(userMessage.context.timezone);
+
+  let meta = "";
+  meta += `ASSISTANT: @${configuration.name}\n`;
+  meta += `LOCAL_TIME: ${d.format("YYYY-MM-DD HH:mm")}\n`;
+  meta += `INSTRUCTIONS:\n${configuration.generation.prompt}`;
+
+  return meta;
+}
+
 // This function is in charge of running the generation of a message from the agent. It does not
 // create any state, only stream tokens and/or error and final success events.
 export async function* runGeneration(
@@ -286,14 +315,14 @@ export async function* runGeneration(
   // console.log(
   //   JSON.stringify({
   //     conversation: modelConversationRes.value,
-  //     prompt: c.prompt,
+  //     prompt: constructPrompt(userMessage, configuration),
   //   })
   // );
 
   const res = await runActionStreamed(auth, "assistant-v2-generator", config, [
     {
       conversation: modelConversationRes.value,
-      prompt: c.prompt,
+      prompt: constructPrompt(userMessage, configuration),
     },
   ]);
 

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -31,6 +31,7 @@
         "io-ts-reporters": "^2.0.1",
         "jsonwebtoken": "^9.0.0",
         "minimist": "^1.2.8",
+        "moment-timezone": "^0.5.43",
         "next": "^13.1.5",
         "next-auth": "^4.18.10",
         "next-remove-imports": "^1.0.8",
@@ -9158,7 +9159,8 @@
     },
     "node_modules/moment-timezone": {
       "version": "0.5.43",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.43.tgz",
+      "integrity": "sha512-72j3aNyuIsDxdF1i7CEgV2FfxM1r6aaqJyLB2vwb33mXYyoyLly+F1zbWqhA3/bVIoJ4szlUoMbUnVdid32NUQ==",
       "dependencies": {
         "moment": "^2.29.4"
       },

--- a/front/package.json
+++ b/front/package.json
@@ -39,6 +39,7 @@
     "io-ts-reporters": "^2.0.1",
     "jsonwebtoken": "^9.0.0",
     "minimist": "^1.2.8",
+    "moment-timezone": "^0.5.43",
     "next": "^13.1.5",
     "next-auth": "^4.18.10",
     "next-remove-imports": "^1.0.8",


### PR DESCRIPTION
- Make claude aware of humans and action result names
- Replace encoded `:mention[]{}` by `@name` when rendering conversation for models
- Add minimal meta prompt with the agent name and local time

Deploy: `core` then `front`

![Screenshot from 2023-09-21 10-49-11](https://github.com/dust-tt/dust/assets/15067/1014eb3f-5171-48ca-85e5-597b1751ee64)
