### PR TITLE
Update format of Mentions

### DIFF
--- a/front/components/assistant/conversation/InputBar.tsx
+++ b/front/components/assistant/conversation/InputBar.tsx
@@ -233,8 +233,8 @@ export function AssistantInputBar({
             mentions.push({
               configurationId: agentConfigurationId,
             });
-            // Internal format for mentions is `:mention[agentName]{id=agentConfigurationId}`.
-            content += `:mention[${agentName}]{id=${agentConfigurationId}}`;
+            // Internal format for mentions is `:mention[agentName]{sId=agentConfigurationId}`.
+            content += `:mention[${agentName}]{sId=${agentConfigurationId}}`;
           }
         }
         if (node.nodeType === Node.TEXT_NODE) {

--- a/front/components/assistant/conversation/InputBar.tsx
+++ b/front/components/assistant/conversation/InputBar.tsx
@@ -233,8 +233,8 @@ export function AssistantInputBar({
             mentions.push({
               configurationId: agentConfigurationId,
             });
-            // Internal format for mentions is `:mention[agentName]{agentConfigurationId}`.
-            content += `:mention[${agentName}]{${agentConfigurationId}}`;
+            // Internal format for mentions is `:mention[agentName]{id=agentConfigurationId}`.
+            content += `:mention[${agentName}]{id=${agentConfigurationId}}`;
           }
         }
         if (node.nodeType === Node.TEXT_NODE) {

--- a/front/pages/w/[wId]/assistant/new.tsx
+++ b/front/pages/w/[wId]/assistant/new.tsx
@@ -313,7 +313,7 @@ function StartHelperConversationButton({
 }) {
   const contentWithMarkdownMention = content.replace(
     "@helper",
-    ":mention[helper]{id=helper}"
+    ":mention[helper]{sId=helper}"
   );
 
   return (

--- a/front/pages/w/[wId]/assistant/new.tsx
+++ b/front/pages/w/[wId]/assistant/new.tsx
@@ -313,7 +313,7 @@ function StartHelperConversationButton({
 }) {
   const contentWithMarkdownMention = content.replace(
     "@helper",
-    ":mention[helper]{helper}"
+    ":mention[helper]{id=helper}"
   );
 
   return (


### PR DESCRIPTION
@spolu this changes the format of Mentions. 

Our `remark-directive` lib does not retrieve the attributes (i.e the sid part) id on the `textDirective` node if it starts by a number. 

On `micromark-extension-directive` doc, there's an [example](https://github.com/micromark/micromark-extension-directive#syntax) for youtube mention, they use this: 
```
::youtube[Video of a cat in a box]{vid=01ab2cd3efg}
```

So I'm suggesting we use this: 
```
:mention[agentName]{sId=agentConfigurationId}
```

I think that's a better option than trying to tweak the library + I like that we specify it's the id on the attribute (could have been a link for example). 

WDYT?