### PR TITLE
Introduce model GlobalAgentSettings

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -35,6 +35,7 @@ import {
   XP1Run,
   XP1User,
 } from "@app/lib/models";
+import { GlobalAgentSettings } from "@app/lib/models/assistant/agent";
 
 async function main() {
   await User.sync({ alter: true });
@@ -62,6 +63,7 @@ async function main() {
   await AgentRetrievalConfiguration.sync({ alter: true });
   await AgentDataSourceConfiguration.sync({ alter: true });
   await AgentConfiguration.sync({ alter: true });
+  await GlobalAgentSettings.sync({ alter: true });
 
   await AgentRetrievalAction.sync({ alter: true });
   await RetrievalDocument.sync({ alter: true });

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -26,9 +26,9 @@ import {
 } from "@app/types/assistant/actions/retrieval";
 import {
   AgentActionConfigurationType,
-  AgentConfigurationStatus,
   AgentConfigurationType,
   AgentGenerationConfigurationType,
+  AgentStatus,
 } from "@app/types/assistant/agent";
 
 /**
@@ -211,7 +211,7 @@ export async function createAgentConfiguration(
     name: string;
     description: string;
     pictureUrl: string;
-    status: AgentConfigurationStatus;
+    status: AgentStatus;
     generation: AgentGenerationConfigurationType | null;
     action: AgentActionConfigurationType | null;
     agentConfigurationId?: string;

--- a/front/lib/models/assistant/agent.ts
+++ b/front/lib/models/assistant/agent.ts
@@ -11,10 +11,7 @@ import {
 import { front_sequelize } from "@app/lib/databases";
 import { AgentRetrievalConfiguration } from "@app/lib/models/assistant/actions/retrieval";
 import { Workspace } from "@app/lib/models/workspace";
-import {
-  AgentConfigurationStatus,
-  GlobalAgentConfigurationStatus,
-} from "@app/types/assistant/agent";
+import { AgentStatus, GlobalAgentStatus } from "@app/types/assistant/agent";
 
 /**
  * Configuration of Agent generation.
@@ -87,7 +84,7 @@ export class AgentConfiguration extends Model<
   declare sId: string;
   declare version: number;
 
-  declare status: AgentConfigurationStatus;
+  declare status: AgentStatus;
   declare name: string;
   declare description: string;
   declare pictureUrl: string;
@@ -202,7 +199,7 @@ export class GlobalAgentSettings extends Model<
   declare agentId: string;
   declare workspaceId: ForeignKey<Workspace["id"]>;
 
-  declare status: GlobalAgentConfigurationStatus;
+  declare status: GlobalAgentStatus;
 }
 GlobalAgentSettings.init(
   {

--- a/front/lib/models/assistant/agent.ts
+++ b/front/lib/models/assistant/agent.ts
@@ -11,7 +11,10 @@ import {
 import { front_sequelize } from "@app/lib/databases";
 import { AgentRetrievalConfiguration } from "@app/lib/models/assistant/actions/retrieval";
 import { Workspace } from "@app/lib/models/workspace";
-import { AgentConfigurationStatus } from "@app/types/assistant/agent";
+import {
+  AgentConfigurationStatus,
+  GlobalAgentConfigurationStatus,
+} from "@app/types/assistant/agent";
 
 /**
  * Configuration of Agent generation.
@@ -183,4 +186,65 @@ AgentRetrievalConfiguration.hasOne(AgentConfiguration, {
 AgentConfiguration.belongsTo(AgentRetrievalConfiguration, {
   as: "retrievalConfiguration",
   foreignKey: { name: "retrievalConfigurationId", allowNull: true }, // null = no retrieval action set for this Agent
+});
+
+/**
+ * Global Agent settings
+ */
+export class GlobalAgentSettings extends Model<
+  InferAttributes<GlobalAgentSettings>,
+  InferCreationAttributes<GlobalAgentSettings>
+> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare agentId: string;
+  declare workspaceId: ForeignKey<Workspace["id"]>;
+
+  declare status: GlobalAgentConfigurationStatus;
+}
+GlobalAgentSettings.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    agentId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    status: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      defaultValue: "disabled",
+    },
+  },
+  {
+    modelName: "global_agent_settings",
+    sequelize: front_sequelize,
+    indexes: [
+      { fields: ["workspaceId"] },
+      { fields: ["workspaceId", "agentId"], unique: true },
+    ],
+  }
+);
+//  Global Agent config <> Workspace
+Workspace.hasMany(GlobalAgentSettings, {
+  foreignKey: { name: "workspaceId", allowNull: false },
+  onDelete: "CASCADE",
+});
+GlobalAgentSettings.belongsTo(Workspace, {
+  foreignKey: { name: "workspaceId", allowNull: false },
 });

--- a/front/lib/models/index.ts
+++ b/front/lib/models/index.ts
@@ -9,6 +9,7 @@ import {
 import {
   AgentConfiguration,
   AgentGenerationConfiguration,
+  GlobalAgentSettings,
 } from "@app/lib/models/assistant/agent";
 import {
   AgentMessage,
@@ -59,6 +60,7 @@ export {
   EventSchema,
   ExtractedEvent,
   GensTemplate,
+  GlobalAgentSettings,
   Key,
   Membership,
   MembershipInvitation,

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -60,6 +60,7 @@ export type AgentGenerationConfigurationType = {
 
 export type AgentConfigurationStatus = "active" | "archived";
 export type AgentConfigurationScope = "global" | "workspace";
+export type GlobalAgentConfigurationStatus = "active" | "disabled";
 
 export type AgentConfigurationType = {
   id: ModelId;

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -58,9 +58,13 @@ export type AgentGenerationConfigurationType = {
  * Agent configuration
  */
 
-export type AgentConfigurationStatus = "active" | "archived";
+export type GlobalAgentStatus =
+  | "active"
+  | "disabled_by_admin"
+  | "disabled_missing_datasource";
+export type AgentStatus = "active" | "archived";
+export type AgentConfigurationStatus = AgentStatus | GlobalAgentStatus;
 export type AgentConfigurationScope = "global" | "workspace";
-export type GlobalAgentConfigurationStatus = "active" | "disabled";
 
 export type AgentConfigurationType = {
   id: ModelId;


### PR DESCRIPTION
Ability to deactivate a global agent.

Todo: 

- [x] Introduce model GlobalAgentSettings.
- [ ] Create lib function and api routes to create/update settings.
- [ ] Handle click on toggle to deactivate / reactivate a global agents on the builder page.
- [ ] Handle status when there's no ds
- [ ] Update getGlobalAgents to take into account `GlobalAgentSettings`