### PR TITLE
Remove tooltips on mobile screens

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -13,7 +13,7 @@
     "initdb": "env $(cat .env.local) npx tsx admin/db.ts"
   },
   "dependencies": {
-    "@dust-tt/sparkle": "0.1.73",
+    "@dust-tt/sparkle": "0.1.74",
     "@headlessui/react": "^1.7.7",
     "@heroicons/react": "^2.0.11",
     "@nangohq/frontend": "^0.16.1",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.1.73",
+  "version": "0.1.74",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/components/Tooltip.tsx
+++ b/sparkle/src/components/Tooltip.tsx
@@ -36,7 +36,7 @@ export function Tooltip({ children, label, position = "above" }: TooltipProps) {
     "s-absolute s-whitespace-nowrap s-z-10 s-px-3 s-py-2 s-text-sm s-rounded-xl s-border s-shadow-md s-transition-all s-duration-500 s-ease-out s-transform s-bg-structure-0 dark:s-bg-structure-0-dark s-text-element-700 dark:s-text-element-700-dark";
   const hiddenClasses = "s-translate-y-2 s-opacity-0 s-pointer-events-none"; // Added s-pointer-events-none
   const visibleClasses = "-s-translate-y-0 s-opacity-100";
-
+  const hiddenOnMobileClasses = "s-hidden sm:s-block";
   const tooltipCenterClasses = "s-left-1/2 -s-translate-x-1/2";
   const tooltipPositionClasses =
     position === "above" ? "s-bottom-full s-mb-2" : "s-top-full s-mt-2";
@@ -52,6 +52,7 @@ export function Tooltip({ children, label, position = "above" }: TooltipProps) {
         className={classNames(
           `${isHovered ? visibleClasses : hiddenClasses}`,
           baseClasses,
+          hiddenOnMobileClasses,
           tooltipPositionClasses,
           tooltipCenterClasses
         )}


### PR DESCRIPTION
Current tooltips break mobile display

After 15mn exploration, no trivial fix in sight

As per discussion with Ed, tooltips are virtually useless on mobile, so we might as well remove them, so that they only appear on desktop

Before:
![Screenshot from 2023-09-21 17-44-24](https://github.com/dust-tt/dust/assets/5437393/a3763b74-e9fe-4bed-81d5-a62e8142e8d0)

After:
![image](https://github.com/dust-tt/dust/assets/5437393/ffb97142-57a6-468a-b5a2-9054145e0b61)
