### PR TITLE
fix: query-less search should work with an empty query

### DIFF
--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -939,6 +939,14 @@ impl DataSource {
 
         let time_embedding_start = utils::now();
 
+        let query = match query {
+            Some(q) => match q.len() {
+                0 => None,
+                _ => Some(q),
+            },
+            None => None,
+        };
+
         let chunks = match query {
             None => {
                 let store = store.clone();


### PR DESCRIPTION
I manually set `query="none"` on a retrieval config to experiment, and [it breaks](https://app.datadoghq.eu/logs?query=status%3Aerror%20service%3Afront&cols=host%2Cservice&event=AgAAAYq5LCKjQ2_RowAAAAAAAAAYAAAAAEFZcTVMQzN6QUFBZGFHMXNIRmRRNmdBTQAAACQAAAAAMDE4YWI5MmUtMWJkOC00M2NkLWE5MTktNzNmYjA3MTRlYTZk&index=%2A&messageDisplay=inline&refresh_mode=sliding&stream_sort=desc&viz=stream&from_ts=1695322955805&to_ts=1695323855805&live=true). Datasource search is still trying to embed and the API call fails.

With this change, searching a datasource with `""` is equivalent to sending `null`