### PR TITLE
Minor tweaks text size in code blocks + helper prompt typo

### DIFF
--- a/front/components/RenderMarkdown.tsx
+++ b/front/components/RenderMarkdown.tsx
@@ -150,7 +150,7 @@ function PreBlock({ children }: { children: React.ReactNode }) {
             </div>
           )}
         </div>
-        <div className="overflow-auto pt-8">
+        <div className="overflow-auto pt-8 text-sm">
           {validChildrenContent ? children : fallbackData || children}
         </div>
       </div>
@@ -301,7 +301,7 @@ function CodeBlock({
       {String(children).replace(/\n$/, "")}
     </SyntaxHighlighter>
   ) : (
-    <code className="rounded-md border-structure-100 bg-slate-200 p-1">
+    <code className="rounded-md border-structure-100 bg-slate-200 p-1 text-sm">
       {children}
     </code>
   );

--- a/front/prompt/global_agent_helper_prompt.md
+++ b/front/prompt/global_agent_helper_prompt.md
@@ -2,7 +2,7 @@
 
 I want you to act as a Customer success agent. Your job is to guide the user and help them discover new things about Dust and in general and Assistant in particular.
 Respond to the user questions with accuracy and empathy.
-Make sure you answer with all the details. Double check your answers for errors, don't event things. Focus on guiding me, use bullet points and steps. If you don't know the answer to a question and only if you don't know, just say so.
+Make sure you answer with all the details. Double check your answers for errors, don't invent things. Focus on guiding me, use bullet points and steps. If you don't know the answer to a question and only if you don't know, just say so.
 
 # Context to help you
 


### PR DESCRIPTION
- Reducing size of code text in markdown. 
- Fixing a typo on @/helper prompt. 

Before: 

<img width="1023" alt="Capture d’écran 2023-09-22 à 10 27 14" src="https://github.com/dust-tt/dust/assets/3803406/f0008495-4ca7-4a02-a73c-a9aa2b299081">


After: 
<img width="1012" alt="Capture d’écran 2023-09-22 à 10 27 05" src="https://github.com/dust-tt/dust/assets/3803406/872c32d3-bd29-4996-b82f-a7f1effd1867">
