### PR TITLE
feat(builder): add support for 'select all' in data source

### DIFF
--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -72,14 +72,17 @@ export const CONNECTOR_PROVIDER_TO_RESOURCE_NAME: Record<
   github: { singular: "repository", plural: "repositories" },
 };
 
+export type AssistantBuilderDataSourceConfiguration = {
+  dataSource: DataSourceType;
+  selectedResources: Record<string, string>;
+  isSelectAll: boolean;
+};
+
 type AssistantBuilderState = {
   dataSourceMode: DataSourceMode;
   dataSourceConfigurations: Record<
     string,
-    {
-      dataSource: DataSourceType;
-      selectedResources: Record<string, string>;
-    }
+    AssistantBuilderDataSourceConfiguration
   >;
   timeFrameMode: TimeFrameMode;
   timeFrame: {
@@ -172,10 +175,8 @@ export default function AssistantBuilder({
     ...DEFAULT_ASSISTANT_STATE,
   });
   const [showDataSourcesModal, setShowDataSourcesModal] = useState(false);
-  const [dataSourceToManage, setDataSourceToManage] = useState<{
-    dataSource: DataSourceType;
-    selectedResources: Record<string, string>;
-  } | null>(null);
+  const [dataSourceToManage, setDataSourceToManage] =
+    useState<AssistantBuilderDataSourceConfiguration | null>(null);
   const [edited, setEdited] = useState(false);
   const [submitEnabled, setSubmitEnabled] = useState(false);
 
@@ -405,11 +406,11 @@ export default function AssistantBuilder({
           timeframe: tfParam,
           topK: 16, // TODO ?
           dataSources: Object.values(builderState.dataSourceConfigurations).map(
-            ({ dataSource, selectedResources }) => ({
+            ({ dataSource, selectedResources, isSelectAll }) => ({
               dataSourceId: dataSource.name,
               workspaceId: owner.sId,
               filter: {
-                parents: Object.keys(selectedResources).length
+                parents: !isSelectAll
                   ? { in: Object.keys(selectedResources), not: [] }
                   : null,
                 tags: null,
@@ -491,7 +492,7 @@ export default function AssistantBuilder({
         }}
         owner={owner}
         dataSources={configurableDataSources}
-        onSave={({ dataSource, selectedResources }) => {
+        onSave={({ dataSource, selectedResources, isSelectAll }) => {
           setBuilderState((state) => ({
             ...state,
             dataSourceConfigurations: {
@@ -499,6 +500,7 @@ export default function AssistantBuilder({
               [dataSource.name]: {
                 dataSource,
                 selectedResources,
+                isSelectAll,
               },
             },
           }));

--- a/front/components/assistant_builder/DataSourceSelectionSection.tsx
+++ b/front/components/assistant_builder/DataSourceSelectionSection.tsx
@@ -9,6 +9,7 @@ import {
 } from "@dust-tt/sparkle";
 import { Transition } from "@headlessui/react";
 
+import { AssistantBuilderDataSourceConfiguration } from "@app/components/assistant_builder/AssistantBuilder";
 import {
   CONNECTOR_PROVIDER_TO_RESOURCE_NAME,
   TIME_FRAME_MODE_TO_LABEL,
@@ -18,7 +19,6 @@ import {
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 import { classNames } from "@app/lib/utils";
 import { TimeframeUnit } from "@app/types/assistant/actions/retrieval";
-import { DataSourceType } from "@app/types/data_source";
 
 export default function DataSourceSelectionSection({
   show,
@@ -36,7 +36,7 @@ export default function DataSourceSelectionSection({
   show: boolean;
   dataSourceConfigurations: Record<
     string,
-    { dataSource: DataSourceType; selectedResources: Record<string, string> }
+    AssistantBuilderDataSourceConfiguration
   >;
   openDataSourceModal: () => void;
   canAddDataSource: boolean;
@@ -101,7 +101,7 @@ export default function DataSourceSelectionSection({
         ) : (
           <ContextItem.List className="mt-6">
             {Object.entries(dataSourceConfigurations).map(
-              ([key, { dataSource, selectedResources }]) => {
+              ([key, { dataSource, selectedResources, isSelectAll }]) => {
                 const selectedParentIds = Object.keys(selectedResources);
                 return (
                   <ContextItem
@@ -149,7 +149,7 @@ export default function DataSourceSelectionSection({
                   >
                     <ContextItem.Description
                       description={
-                        dataSource.connectorProvider
+                        dataSource.connectorProvider && !isSelectAll
                           ? `Assistant has access to ${
                               selectedParentIds.length
                             } ${

--- a/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
@@ -66,11 +66,13 @@ export const getServerSideProps: GetServerSideProps<{
   const selectedResources: {
     dataSourceName: string;
     resources: string[] | null;
+    isSelectAll: boolean;
   }[] = [];
   for (const ds of config.action?.dataSources ?? []) {
     selectedResources.push({
       dataSourceName: ds.dataSourceId,
       resources: ds.filter.parents?.in ?? null,
+      isSelectAll: !ds.filter.parents,
     });
   }
 
@@ -78,7 +80,11 @@ export const getServerSideProps: GetServerSideProps<{
     selectedResources.map(async (ds): Promise<DataSourceConfig> => {
       const dataSource = dataSourceByName[ds.dataSourceName];
       if (!dataSource.connectorId || !ds.resources) {
-        return { dataSource: dataSource, selectedResources: {} };
+        return {
+          dataSource: dataSource,
+          selectedResources: {},
+          isSelectAll: ds.isSelectAll,
+        };
       }
       const response = await ConnectorsAPI.getResourcesTitles({
         connectorId: dataSource.connectorId,
@@ -98,6 +104,7 @@ export const getServerSideProps: GetServerSideProps<{
       return {
         dataSource: dataSource,
         selectedResources,
+        isSelectAll: ds.isSelectAll,
       };
     })
   );


### PR DESCRIPTION
Adds a slider toggle to "select all" the data source, which saves & close the modal.
When you come back to it, you see the toggle checked and you don't see the resource tree. You can uncheck the toggle to select again.
Within a session, what you had previously selected remains checked when you un-toggle. This state is of course lost when you leave the builder (we can't preserve it).

<img width="1249" alt="Screenshot 2023-09-22 at 11 53 06" src="https://github.com/dust-tt/dust/assets/14199823/9d7aae56-7ae0-4844-b8f5-143a288e3156">

The design on Figma is a button, but not really doable like this currently (we need a state where the user comes back and sees that his datasource is in "select all" mode)