### PR TITLE
enh: always sort connector resources by title

### DIFF
--- a/connectors/src/api/get_connector_permissions.ts
+++ b/connectors/src/api/get_connector_permissions.ts
@@ -72,7 +72,15 @@ const _getConnectorPermissions = async (
   }
 
   return res.status(200).json({
-    resources: pRes.value,
+    resources: pRes.value.sort((a, b) => {
+      if (a.title > b.title) {
+        return 1;
+      }
+      if (a.title < b.title) {
+        return -1;
+      }
+      return 0;
+    }),
   });
 };
 


### PR DESCRIPTION
Simple, in-memory sort on the `connectors` backend.
This applies both to the "Connector Permissions" modal and to the "Data Source Resource Selection" modal of the assistant builder.