### PR TITLE
enh: copy nit Assistants Builder -> Assistants Manager

### DIFF
--- a/front/components/sparkle/navigation.tsx
+++ b/front/components/sparkle/navigation.tsx
@@ -126,7 +126,7 @@ export const subNavigationAdmin = ({
     if (isDevelopmentOrDustWorkspace(owner)) {
       nav.push({
         id: "assistants",
-        label: "Assistants Builder",
+        label: "Assistants Manager",
         icon: RobotIcon,
         href: `/w/${owner.sId}/builder/assistants`,
         current: current === "assistants",

--- a/front/pages/w/[wId]/builder/assistants/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/index.tsx
@@ -109,9 +109,9 @@ export default function AssistantsBuilder({
       subNavigation={subNavigationAdmin({ owner, current: "assistants" })}
     >
       <PageHeader
-        title="Assistants Builder"
+        title="Assistants Manager"
         icon={RobotIcon}
-        description="Build an assistant."
+        description="Manage your workspace's assistants."
       />
       <div className="flex flex-col gap-4 pb-4">
         <div>


### PR DESCRIPTION
- the "assistant builder" is after you click on edit
- the "assistant manager" is that thing you can reach from the left pane where you see a list of both global and custom assistants