### PR TITLE
Styling inline code in Markdown component

### DIFF
--- a/front/components/RenderMarkdown.tsx
+++ b/front/components/RenderMarkdown.tsx
@@ -301,7 +301,7 @@ function CodeBlock({
       {String(children).replace(/\n$/, "")}
     </SyntaxHighlighter>
   ) : (
-    <code className="rounded-md border-structure-100 bg-slate-200 p-1 text-sm">
+    <code className="rounded-md border-structure-200 bg-structure-100 px-1.5 py-1 text-sm text-amber-600 dark:border-structure-200-dark dark:bg-structure-100-dark dark:text-amber-400">
       {children}
     </code>
   );


### PR DESCRIPTION
Courtesy of @Duncid cc https://dust4ai.slack.com/archives/C050A0S2Z7F/p1695377100262739?thread_ts=1695281729.488859&cid=C050A0S2Z7F

Before: 


<img width="1012" alt="Capture d’écran 2023-09-22 à 10 27 05" src="https://github.com/dust-tt/dust/assets/3803406/620a9ed9-bdbf-47e6-81db-fed5619e383f">



After: 

<img width="993" alt="Capture d’écran 2023-09-22 à 13 09 44" src="https://github.com/dust-tt/dust/assets/3803406/c959b562-c1b5-42f5-bfcf-6b29e667aa4a">

