### PR TITLE
Free users cannot access larger models

### DIFF
--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -44,7 +44,6 @@ import { PostOrPatchAgentConfigurationRequestBodySchema } from "@app/pages/api/w
 import { TimeframeUnit } from "@app/types/assistant/actions/retrieval";
 import { DataSourceType } from "@app/types/data_source";
 import { UserType, WorkspaceType } from "@app/types/user";
-import { planForWorkspace } from "@app/lib/auth";
 
 const usedModelConfigs = [
   GPT_4_DEFAULT_MODEL_CONFIG,

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -172,7 +172,7 @@ export async function getAgentConfiguration(
  * Get the list agent configuration for the workspace, optionally whose names
  * match a prefix
  */
-export async function getAgentConfigurations(
+export async function getAgentCnfigurations(
   auth: Authenticator,
   agentPrefix?: string
 ): Promise<AgentConfigurationType[] | []> {

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -357,6 +357,12 @@ export async function createAgentGenerationConfiguration(
   if (temperature < 0) {
     throw new Error("Temperature must be positive.");
   }
+  if (
+    getSupportedModelConfig(model).largeModel &&
+    !owner.plan.limits.largeModels
+  ) {
+    throw new Error("You need to upgrade your plan to use large models.");
+  }
 
   const genConfig = await AgentGenerationConfiguration.create({
     prompt: prompt,

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -172,7 +172,7 @@ export async function getAgentConfiguration(
  * Get the list agent configuration for the workspace, optionally whose names
  * match a prefix
  */
-export async function getAgentCnfigurations(
+export async function getAgentConfigurations(
   auth: Authenticator,
   agentPrefix?: string
 ): Promise<AgentConfigurationType[] | []> {

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -9,7 +9,7 @@ import {
   getSupportedModelConfig,
   isSupportedModel,
   SupportedModel,
-} from "@app/lib/api/assistant/supported_models";
+} from "@app/lib/assistant";
 import { Authenticator } from "@app/lib/auth";
 import { front_sequelize } from "@app/lib/databases";
 import {

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -5,7 +5,11 @@ import {
   getGlobalAgents,
   isGlobalAgentId,
 } from "@app/lib/api/assistant/global_agents";
-import { isSupportedModel, SupportedModel } from "@app/lib/assistant";
+import {
+  getSupportedModelConfig,
+  isSupportedModel,
+  SupportedModel,
+} from "@app/lib/api/assistant/supported_models";
 import { Authenticator } from "@app/lib/auth";
 import { front_sequelize } from "@app/lib/databases";
 import {
@@ -141,6 +145,13 @@ export async function getAgentConfiguration(
       temperature: generationConfig.temperature,
       model,
     };
+    // Enforce plan limits: check if large models are allowed and act accordingly
+    if (
+      !owner.plan.limits.largeModels &&
+      !getSupportedModelConfig(model).largeModel
+    ) {
+      return null;
+    }
   }
 
   return {

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -655,7 +655,7 @@ export async function* postUserMessage(
         context: context,
       };
 
-      const results: { row: AgentMessage; m: AgentMessageType }[] =
+      const results: ({ row: AgentMessage; m: AgentMessageType } | null)[] =
         await Promise.all(
           mentions.filter(isAgentMention).map((mention) => {
             // For each assistant/agent mention, create an "empty" agent message.
@@ -667,7 +667,7 @@ export async function* postUserMessage(
                 mention.configurationId
               );
               if (!configuration) {
-                throw new Error(`Configuration not found`);
+                return null;
               }
 
               await Mention.create(
@@ -743,10 +743,15 @@ export async function* postUserMessage(
         })
       );
 
+      const nonNullResults = results.filter((r) => r !== null) as {
+        row: AgentMessage;
+        m: AgentMessageType;
+      }[];
+
       return {
         userMessage,
-        agentMessages: results.map(({ m }) => m),
-        agentMessageRows: results.map(({ row }) => row),
+        agentMessages: nonNullResults.map(({ m }) => m),
+        agentMessageRows: nonNullResults.map(({ row }) => row),
       };
     });
 
@@ -1035,7 +1040,7 @@ export async function* editUserMessage(
           },
           transaction: t,
         })) ?? -1) + 1;
-      const results: { row: AgentMessage; m: AgentMessageType }[] =
+      const results: ({ row: AgentMessage; m: AgentMessageType } | null)[] =
         await Promise.all(
           mentions.filter(isAgentMention).map((mention) => {
             // For each assistant/agent mention, create an "empty" agent message.
@@ -1047,7 +1052,7 @@ export async function* editUserMessage(
                 mention.configurationId
               );
               if (!configuration) {
-                throw new Error(`Configuration not found`);
+                return null;
               }
 
               await Mention.create(
@@ -1123,10 +1128,14 @@ export async function* editUserMessage(
         })
       );
 
+      const nonNullResults = results.filter((r) => r !== null) as {
+        row: AgentMessage;
+        m: AgentMessageType;
+      }[];
       return {
         userMessage,
-        agentMessages: results.map(({ m }) => m),
-        agentMessageRows: results.map(({ row }) => row),
+        agentMessages: nonNullResults.map(({ m }) => m),
+        agentMessageRows: nonNullResults.map(({ row }) => row),
       };
     });
 

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -508,28 +508,48 @@ export async function getGlobalAgent(
 
   switch (sId) {
     case GLOBAL_AGENTS_SID.HELPER:
-      return _getHelperGlobalAgent({ user });
+	  agentConfiguration = await _getHelperGlobalAgent({user});
+      break;
     case GLOBAL_AGENTS_SID.GPT35_TURBO:
-      return _getGPT35TurboGlobalAgent({ settings });
+	  agentConfiguration = await _getGPT35TurboGlobalAgent({settings});
+      break;
     case GLOBAL_AGENTS_SID.GPT4:
-      return _getGPT4GlobalAgent({ settings });
+	  agentConfiguration = await _getGPT4GlobalAgent({settings});
+      break;
     case GLOBAL_AGENTS_SID.CLAUDE_INSTANT:
-      return _getClaudeInstantGlobalAgent({ settings });
+	  agentConfiguration = await _getClaudeInstantGlobalAgent({settings});
+      break;
     case GLOBAL_AGENTS_SID.CLAUDE:
-      return _getClaudeGlobalAgent({ settings });
+	  agentConfiguration = await _getClaudeGlobalAgent({settings});
+      break;
     case GLOBAL_AGENTS_SID.SLACK:
-      return _getSlackGlobalAgent(auth, { settings });
+	  agentConfiguration = await _getSlackGlobalAgent(auth, {settings});
+      break;
     case GLOBAL_AGENTS_SID.GOOGLE_DRIVE:
-      return _getGoogleDriveGlobalAgent(auth, { settings });
+	  agentConfiguration = await _getGoogleDriveGlobalAgent(auth, {settings});
+      break;
     case GLOBAL_AGENTS_SID.NOTION:
-      return _getNotionGlobalAgent(auth, { settings });
+	  agentConfiguration = await _getNotionGlobalAgent(auth, {settings});
+      break;
     case GLOBAL_AGENTS_SID.GITHUB:
-      return _getGithubGlobalAgent(auth, { settings });
+	  agentConfiguration = await _getGithubGlobalAgent(auth, {settings});
+      break;
     case GLOBAL_AGENTS_SID.DUST:
-      return _getDustGlobalAgent(auth, { settings });
+	  agentConfiguration = await _getDustGlobalAgent(auth, {settings});
+      break;
     default:
       return null;
   }
+  // Enforce plan limits: check if large models are allowed and act accordingly
+  if (
+    !agentConfiguration ||
+    (!owner.plan.limits.largeModels &&
+      agentConfiguration.generation &&
+      !getSupportedModelConfig(agentConfiguration.generation?.model).largeModel)
+  ) {
+    return null;
+  }
+  return agentConfiguration;
 }
 
 export async function getGlobalAgents(

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -546,7 +546,7 @@ export async function getGlobalAgent(
   if (
     !owner.plan.limits.largeModels &&
     agentConfiguration.generation &&
-    !getSupportedModelConfig(agentConfiguration.generation?.model).largeModel
+    getSupportedModelConfig(agentConfiguration.generation?.model).largeModel
   ) {
     agentConfiguration.status = "require_upgrade";
   }

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -549,7 +549,7 @@ export async function getGlobalAgent(
     agentConfiguration.generation &&
     getSupportedModelConfig(agentConfiguration.generation?.model).largeModel
   ) {
-    agentConfiguration.status = "require_upgrade";
+    agentConfiguration.status = "disabled_free_workspace";
   }
   return agentConfiguration;
 }

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -7,6 +7,7 @@ const readFileAsync = promisify(fs.readFile);
 import {
   CLAUDE_DEFAULT_MODEL_CONFIG,
   CLAUDE_INSTANT_DEFAULT_MODEL_CONFIG,
+  getSupportedModelConfig,
   GPT_3_5_TURBO_DEFAULT_MODEL_CONFIG,
   GPT_4_DEFAULT_MODEL_CONFIG,
 } from "@app/lib/assistant";

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -505,49 +505,50 @@ export async function getGlobalAgent(
   const settings = await GlobalAgentSettings.findOne({
     where: { workspaceId: owner.id, agentId: sId },
   });
-
+  let agentConfiguration: AgentConfigurationType | null = null;
   switch (sId) {
     case GLOBAL_AGENTS_SID.HELPER:
-	  agentConfiguration = await _getHelperGlobalAgent({user});
+      agentConfiguration = await _getHelperGlobalAgent({ user });
       break;
     case GLOBAL_AGENTS_SID.GPT35_TURBO:
-	  agentConfiguration = await _getGPT35TurboGlobalAgent({settings});
+      agentConfiguration = await _getGPT35TurboGlobalAgent({ settings });
       break;
     case GLOBAL_AGENTS_SID.GPT4:
-	  agentConfiguration = await _getGPT4GlobalAgent({settings});
+      agentConfiguration = await _getGPT4GlobalAgent({ settings });
       break;
     case GLOBAL_AGENTS_SID.CLAUDE_INSTANT:
-	  agentConfiguration = await _getClaudeInstantGlobalAgent({settings});
+      agentConfiguration = await _getClaudeInstantGlobalAgent({ settings });
       break;
     case GLOBAL_AGENTS_SID.CLAUDE:
-	  agentConfiguration = await _getClaudeGlobalAgent({settings});
+      agentConfiguration = await _getClaudeGlobalAgent({ settings });
       break;
     case GLOBAL_AGENTS_SID.SLACK:
-	  agentConfiguration = await _getSlackGlobalAgent(auth, {settings});
+      agentConfiguration = await _getSlackGlobalAgent(auth, { settings });
       break;
     case GLOBAL_AGENTS_SID.GOOGLE_DRIVE:
-	  agentConfiguration = await _getGoogleDriveGlobalAgent(auth, {settings});
+      agentConfiguration = await _getGoogleDriveGlobalAgent(auth, { settings });
       break;
     case GLOBAL_AGENTS_SID.NOTION:
-	  agentConfiguration = await _getNotionGlobalAgent(auth, {settings});
+      agentConfiguration = await _getNotionGlobalAgent(auth, { settings });
       break;
     case GLOBAL_AGENTS_SID.GITHUB:
-	  agentConfiguration = await _getGithubGlobalAgent(auth, {settings});
+      agentConfiguration = await _getGithubGlobalAgent(auth, { settings });
       break;
     case GLOBAL_AGENTS_SID.DUST:
-	  agentConfiguration = await _getDustGlobalAgent(auth, {settings});
+      agentConfiguration = await _getDustGlobalAgent(auth, { settings });
       break;
     default:
       return null;
   }
+  if (!agentConfiguration) return null;
+
   // Enforce plan limits: check if large models are allowed and act accordingly
   if (
-    !agentConfiguration ||
-    (!owner.plan.limits.largeModels &&
-      agentConfiguration.generation &&
-      !getSupportedModelConfig(agentConfiguration.generation?.model).largeModel)
+    !owner.plan.limits.largeModels &&
+    agentConfiguration.generation &&
+    !getSupportedModelConfig(agentConfiguration.generation?.model).largeModel
   ) {
-    return null;
+    agentConfiguration.status = "require_upgrade";
   }
   return agentConfiguration;
 }

--- a/front/pages/w/[wId]/builder/assistants/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/index.tsx
@@ -77,6 +77,12 @@ export default function AssistantsBuilder({
   dustAgents.sort(compareAgentsForSort);
 
   const handleToggleAgentStatus = async (agent: AgentConfigurationType) => {
+    if (agent.status === "disabled_free_workspace") {
+      window.alert(
+        "Assistants with larger models are only available on our paid plans. Contact us at team@dust.tt to get access."
+      );
+      return;
+    }
     const res = await fetch(
       `/api/w/${owner.sId}/assistant/global_agents/${agent.sId}`,
       {
@@ -137,10 +143,7 @@ export default function AssistantsBuilder({
                         await handleToggleAgentStatus(agent);
                       }}
                       selected={agent.status === "active"}
-                      disabled={
-                        agent.status === "disabled_missing_datasource" ||
-                        agent.status === "require_upgrade"
-                      }
+                      disabled={agent.status === "disabled_missing_datasource"}
                     />
                   ) : null
                 }

--- a/front/pages/w/[wId]/builder/assistants/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/index.tsx
@@ -79,7 +79,7 @@ export default function AssistantsBuilder({
   const handleToggleAgentStatus = async (agent: AgentConfigurationType) => {
     if (agent.status === "disabled_free_workspace") {
       window.alert(
-        "Assistants with larger models are only available on our paid plans. Contact us at team@dust.tt to get access."
+        `${agent.name} is only available on our paid plans. Contact us at team@dust.tt to get access.`
       );
       return;
     }

--- a/front/pages/w/[wId]/builder/assistants/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/index.tsx
@@ -79,7 +79,7 @@ export default function AssistantsBuilder({
   const handleToggleAgentStatus = async (agent: AgentConfigurationType) => {
     if (agent.status === "disabled_free_workspace") {
       window.alert(
-        `Assistant @${agent.name} is only available on our paid plans. Contact us at team@dust.tt to get access.`
+        `@${agent.name} is only available on our paid plans. Contact us at team@dust.tt to get access.`
       );
       return;
     }

--- a/front/pages/w/[wId]/builder/assistants/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/index.tsx
@@ -137,7 +137,10 @@ export default function AssistantsBuilder({
                         await handleToggleAgentStatus(agent);
                       }}
                       selected={agent.status === "active"}
-                      disabled={agent.status === "disabled_missing_datasource"}
+                      disabled={
+                        agent.status === "disabled_missing_datasource" ||
+                        agent.status === "require_upgrade"
+                      }
                     />
                   ) : null
                 }

--- a/front/pages/w/[wId]/builder/assistants/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/index.tsx
@@ -79,7 +79,7 @@ export default function AssistantsBuilder({
   const handleToggleAgentStatus = async (agent: AgentConfigurationType) => {
     if (agent.status === "disabled_free_workspace") {
       window.alert(
-        `${agent.name} is only available on our paid plans. Contact us at team@dust.tt to get access.`
+        `Assistant @${agent.name} is only available on our paid plans. Contact us at team@dust.tt to get access.`
       );
       return;
     }

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -59,7 +59,8 @@ export type AgentGenerationConfigurationType = {
 export type GlobalAgentStatus =
   | "active"
   | "disabled_by_admin"
-  | "disabled_missing_datasource";
+  | "disabled_missing_datasource"
+  | "require_upgrade";
 export type AgentStatus = "active" | "archived";
 export type AgentConfigurationStatus = AgentStatus | GlobalAgentStatus;
 export type AgentConfigurationScope = "global" | "workspace";

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -60,7 +60,7 @@ export type GlobalAgentStatus =
   | "active"
   | "disabled_by_admin"
   | "disabled_missing_datasource"
-  | "require_upgrade";
+  | "disabled_free_workspace";
 export type AgentStatus = "active" | "archived";
 export type AgentConfigurationStatus = AgentStatus | GlobalAgentStatus;
 export type AgentConfigurationScope = "global" | "workspace";


### PR DESCRIPTION
Following issue #1577 and PR #1662 

Free users now don't have access to large models (tested with free & upgraded versions, on model selection and agent list)

Remaining work: 
- Assistant list toggle => fix the behaviour
- Solution for the "contact us" (cf @Duncid comment about design in the issue)

If ok, pending the cool designed solution, I can do like we do for managed datasources =>
```
                  if (agent.status === "require_upgrade")
                    alert(
                      "Advanced assistants are only available on our paid plans. Contact us at team@dust.tt to get access."
                    );
```