### PR TITLE
Spolu tweaks

### DIFF
--- a/core/src/providers/anthropic.rs
+++ b/core/src/providers/anthropic.rs
@@ -82,22 +82,22 @@ impl AnthropicLLM {
             .iter()
             .map(|cm| -> String {
                 format!(
-                    "\n\n{}:{} {}",
-                    match cm.name.as_ref() {
-                        Some(name) => match cm.role {
-                            ChatMessageRole::User => format!(" [{}]", name),
-                            ChatMessageRole::Function => format!(" [{}]", name),
-                            _ => String::from(""),
-                        },
-                        None => String::from(""),
-                    },
+                    "\n\n{}: {}",
                     match cm.role {
                         ChatMessageRole::System => "System",
                         ChatMessageRole::Assistant => "Assistant",
                         ChatMessageRole::User => "Human",
                         ChatMessageRole::Function => "FunctionResult",
                     },
-                    cm.content.as_ref().unwrap_or(&String::from("")).clone()
+                    cm.content.as_ref().unwrap_or(&String::from("")).clone(),
+                    // match cm.name.as_ref() {
+                    //     Some(name) => match cm.role {
+                    //         ChatMessageRole::User => format!(" [{}]", name),
+                    //         ChatMessageRole::Function => format!(" [{}]", name),
+                    //         _ => String::from(""),
+                    //     },
+                    //     None => String::from(""),
+                    // },
                 )
             })
             .collect::<Vec<_>>()

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -403,8 +403,7 @@ async function _getDustGlobalAgent(
   }
 
   const name = "Dust";
-  const description =
-    "An assistant with context on your managed and static data sources.";
+  const description = "An assistant with context on your company data.";
   const pictureUrl = "https://dust.tt/static/systemavatar/dust_avatar_full.png";
 
   if (settings && settings.status === "disabled_by_admin") {

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -118,24 +118,34 @@ async function handler(
     });
   }
 
-  if (!auth.isBuilder()) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "app_auth_error",
-        message:
-          "Only the users that are `builders` for the current workspace can access Assistants.",
-      },
-    });
-  }
-
   switch (req.method) {
     case "GET":
+      if (!auth.isUser()) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "app_auth_error",
+            message: "Only the workspace users can see Assistants.",
+          },
+        });
+      }
+
       const agentConfigurations = await getAgentConfigurations(auth);
       return res.status(200).json({
         agentConfigurations,
       });
     case "POST":
+      if (!auth.isBuilder()) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "app_auth_error",
+            message:
+              "Only builders of the workspace users can update Assistants.",
+          },
+        });
+      }
+
       const bodyValidation =
         PostOrPatchAgentConfigurationRequestBodySchema.decode(req.body);
       if (isLeft(bodyValidation)) {

--- a/front/pages/w/[wId]/builder/data-sources/index.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/index.tsx
@@ -432,7 +432,7 @@ export default function DataSourcesView({
                           </div>
                         )}
                       </div>
-                      <div className="mt-2 text-sm text-element-700">
+                      <div className="mr-2 mt-2 text-sm text-element-700">
                         {ds.description}
                       </div>
                     </div>


### PR DESCRIPTION
- Stop attempting to show name to claude (it won't know who is who among humans or assistant in the log, but it'll know who he is (prompt))
- Make the assistant builder page accessible to non builder but deactivated
- Fix padding in data source description
- Fix Dust agent description