### PR TITLE
Sparkle: Auto mode for dropdown & disabled toggle does not animate

### DIFF
--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.1.75",
+  "version": "0.1.76",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/components/DropdownMenu.tsx
+++ b/sparkle/src/components/DropdownMenu.tsx
@@ -225,7 +225,7 @@ DropdownMenu.Item = function ({
 };
 
 interface DropdownItemsProps {
-  origin?: "topLeft" | "topRight" | "bottomLeft" | "bottomRight";
+  origin?: "topLeft" | "topRight" | "bottomLeft" | "bottomRight" | "auto";
   width?: number;
   children: React.ReactNode;
 }
@@ -238,6 +238,9 @@ DropdownMenu.Items = function ({
   const buttonRef = useContext(ButtonRefContext);
   const [buttonHeight, setButtonHeight] = useState(0);
 
+  if (origin === "auto") {
+    origin = findOriginFromButton(buttonRef);
+  }
   useEffect(() => {
     if (buttonRef && buttonRef.current) {
       setButtonHeight(buttonRef.current.offsetHeight);
@@ -305,3 +308,22 @@ DropdownMenu.Items = function ({
     </Transition>
   );
 };
+
+function findOriginFromButton(
+  buttonRef: MutableRefObject<HTMLButtonElement | null> | null
+) {
+  if (!buttonRef) {
+    return "topRight";
+  }
+  const buttonRect = buttonRef.current?.getBoundingClientRect();
+  if (!buttonRect) {
+    return "topRight";
+  }
+  const windowHeight = window.innerHeight;
+  // Top half of screen
+  if (buttonRect.top < windowHeight / 2) {
+    return buttonRect.left < window.innerWidth / 2 ? "topLeft" : "topRight";
+  }
+  // Bottom half of screen
+  return buttonRect.left < window.innerWidth / 2 ? "bottomLeft" : "bottomRight";
+}

--- a/sparkle/src/components/DropdownMenu.tsx
+++ b/sparkle/src/components/DropdownMenu.tsx
@@ -231,7 +231,7 @@ interface DropdownItemsProps {
 }
 
 DropdownMenu.Items = function ({
-  origin = "topRight",
+  origin = "auto",
   width = 160,
   children,
 }: DropdownItemsProps) {

--- a/sparkle/src/components/SliderToggle.tsx
+++ b/sparkle/src/components/SliderToggle.tsx
@@ -11,7 +11,7 @@ type SliderToggleProps = {
 };
 
 const baseClasses =
-  "s-box-border s-rounded-full s-border s-border-structure-300 dark:s-border-structure-300-dark s-transition-colors s-duration-300 s-ease-out s-cursor-pointer";
+  "s-box-border s-rounded-full s-border s-border-structure-300 dark:s-border-structure-300-dark s-cursor-pointer s-transition-colors s-duration-300 s-ease-out s-cursor-pointer";
 
 const sizeClasses = {
   sm: "s-h-6 s-w-11",
@@ -26,7 +26,8 @@ const cusrsorSizeClasses = {
 const stateClasses = {
   idle: "s-bg-structure-200 hover:s-bg-action-400",
   selected: "s-bg-success-400 hover:s-bg-success-300",
-  disabled: "s-bg-structure-300 s-cursor-not-allowed",
+  disabled:
+    "s-bg-structure-300 s-cursor-not-allowed hover:s-bg-structure-300 hover:s-cursor-not-allowed",
   dark: {
     idle: "dark:s-bg-structure-200-dark dark:hover:s-bg-action-400",
     selected: "dark:s-bg-success-400-dark",

--- a/sparkle/src/stories/DropdownMenu.stories.tsx
+++ b/sparkle/src/stories/DropdownMenu.stories.tsx
@@ -156,6 +156,16 @@ export const DropdownExample = () => {
           </DropdownMenu.Items>
         </DropdownMenu>
       </div>
+      <div className="w-full s-flex s-justify-end s-gap-6">
+        <div className="s-text-sm">Auto menu</div>
+        <DropdownMenu>
+          <DropdownMenu.Button label="Moonlab" icon={PlanetIcon} />
+          <DropdownMenu.Items origin="auto">
+            <DropdownMenu.Item label="item 1" href="#" />
+            <DropdownMenu.Item label="item 2" href="#" />
+          </DropdownMenu.Items>
+        </DropdownMenu>
+      </div>
     </>
   );
 };


### PR DESCRIPTION
- Dropdown sets its origin according to screen quadrant when set on auto
- SliderToggle does not animate or change color when disabled (and cursor is round-barred)
