### PR TITLE
Fix error loading convo with archived agent

### DIFF
--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -71,7 +71,7 @@ export async function getAgentConfiguration(
     limit: 1,
   });
 
-  if (!agent || agent.status === "archived") {
+  if (!agent) {
     return null;
   }
 


### PR DESCRIPTION
We should be able to retrieve an archived agent. 
Fixes 500 on convo page when one archived agent was mentioned in the convo

https://dust4ai.slack.com/archives/C05F84CFP0E/p1695399608073359