### PR TITLE
Markdown: do not nowrap in table body

### DIFF
--- a/front/components/RenderMarkdown.tsx
+++ b/front/components/RenderMarkdown.tsx
@@ -256,7 +256,7 @@ function TableBodyBlock({ children }: { children: React.ReactNode }) {
 
 function TableHeaderBlock({ children }: { children: React.ReactNode }) {
   return (
-    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wider text-element-700 dark:text-element-700-dark">
+    <th className="whitespace-nowrap px-6 py-3 text-left text-xs font-semibold uppercase tracking-wider text-element-700 dark:text-element-700-dark">
       {children}
     </th>
   );
@@ -264,7 +264,7 @@ function TableHeaderBlock({ children }: { children: React.ReactNode }) {
 
 function TableDataBlock({ children }: { children: React.ReactNode }) {
   return (
-    <td className="whitespace-nowrap px-6 py-4 text-sm text-element-800 dark:text-element-800-dark">
+    <td className="px-6 py-4 text-sm text-element-800 dark:text-element-800-dark">
       {children}
     </td>
   );


### PR DESCRIPTION
Fixes #1729 
Fixes #1743

nowrap on header but not body

![Screenshot from 2023-09-23 14-28-27](https://github.com/dust-tt/dust/assets/15067/936c7833-d315-4a70-9196-755df8573566)
![Screenshot from 2023-09-23 14-28-43](https://github.com/dust-tt/dust/assets/15067/c0922cc1-7894-44ed-8352-84ed2d5433f5)

