### PR TITLE
Turn p in div in render markdown to avoid error with tooltips

### DIFF
--- a/front/components/RenderMarkdown.tsx
+++ b/front/components/RenderMarkdown.tsx
@@ -358,7 +358,7 @@ function LiBlock({ children }: { children: React.ReactNode }) {
   return <li className="py-2 first:pt-0 last:pb-0">{children}</li>;
 }
 function ParagraphBlock({ children }: { children: React.ReactNode }) {
-  return <p className="py-2 first:pt-0 last:pb-0">{children}</p>;
+  return <div className="py-2 first:pt-0 last:pb-0">{children}</div>;
 }
 
 function CodeBlock({


### PR DESCRIPTION
For #1674 

@PopDaph I was not able to notice any difference. Am I missing something?