### PR TITLE
Better handling of drive returning 404

### DIFF
--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -405,6 +405,9 @@ export async function retrieveGoogleDriveConnectorPermissions({
       const resources: ConnectorResource[] = await Promise.all(
         drives.map(async (d): Promise<ConnectorResource> => {
           const driveObject = await getGoogleDriveObject(authCredentials, d.id);
+          if (!driveObject) {
+            throw new Error(`Drive ${d.id} unexpectedly not found (got 404).`);
+          }
           return {
             provider: c.type,
             internalId: driveObject.id,


### PR DESCRIPTION
It's possible to get 404.

This PR changes the signature of `getGoogleDriveObject` to possibly return `null` and handle that case by throwing error (same behavior) except for  `getFilesParent` where we stop iteration (which would likely lead to a deletion)