### PR TITLE
Handle pubsub user message errors

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -932,7 +932,7 @@ export async function* editUserMessage(
       type: "user_message_error",
       created: Date.now(),
       error: {
-        code: "not_allowed",
+        code: "edition_unsupported",
         message:
           "Adding agent mentions when editing is only supported for the last message of the conversation",
       },

--- a/front/lib/api/assistant/pubsub.ts
+++ b/front/lib/api/assistant/pubsub.ts
@@ -28,6 +28,8 @@ import {
   UserMessageType,
 } from "@app/types/assistant/conversation";
 
+export type PubSubError = APIErrorWithStatusCode;
+
 export async function postUserMessageWithPubSub(
   auth: Authenticator,
   {
@@ -41,7 +43,7 @@ export async function postUserMessageWithPubSub(
     mentions: MentionType[];
     context: UserMessageContext;
   }
-): Promise<Result<UserMessageType, APIErrorWithStatusCode>> {
+): Promise<Result<UserMessageType, PubSubError>> {
   const postMessageEvents = postUserMessage(auth, {
     conversation,
     content,
@@ -64,7 +66,7 @@ export async function editUserMessageWithPubSub(
     content: string;
     mentions: MentionType[];
   }
-): Promise<Result<UserMessageType, APIErrorWithStatusCode>> {
+): Promise<Result<UserMessageType, PubSubError>> {
   const editMessageEvents = editUserMessage(auth, {
     conversation,
     message,
@@ -89,9 +91,9 @@ async function handleUserMessageEvents(
     | ConversationTitleEvent,
     void
   >
-): Promise<Result<UserMessageType, APIErrorWithStatusCode>> {
-  const promise: Promise<Result<UserMessageType, APIErrorWithStatusCode>> =
-    new Promise((resolve) => {
+): Promise<Result<UserMessageType, PubSubError>> {
+  const promise: Promise<Result<UserMessageType, PubSubError>> = new Promise(
+    (resolve) => {
       void (async () => {
         const redis = await redisClient();
         let didResolve = false;
@@ -168,7 +170,8 @@ async function handleUserMessageEvents(
           }
         }
       })();
-    });
+    }
+  );
 
   return promise;
 }
@@ -182,9 +185,9 @@ export async function retryAgentMessageWithPubSub(
     conversation: ConversationType;
     message: AgentMessageType;
   }
-): Promise<Result<AgentMessageType, APIErrorWithStatusCode>> {
-  const promise: Promise<Result<AgentMessageType, APIErrorWithStatusCode>> =
-    new Promise((resolve) => {
+): Promise<Result<AgentMessageType, PubSubError>> {
+  const promise: Promise<Result<AgentMessageType, PubSubError>> = new Promise(
+    (resolve) => {
       void (async () => {
         const redis = await redisClient();
         let didResolve = false;
@@ -243,7 +246,8 @@ export async function retryAgentMessageWithPubSub(
           }
         }
       })();
-    });
+    }
+  );
 
   return promise;
 }

--- a/front/lib/api/assistant/pubsub.ts
+++ b/front/lib/api/assistant/pubsub.ts
@@ -16,7 +16,9 @@ import {
 } from "@app/lib/api/assistant/conversation";
 import { GenerationTokensEvent } from "@app/lib/api/assistant/generation";
 import { Authenticator } from "@app/lib/auth";
+import { APIErrorWithStatusCode } from "@app/lib/error";
 import { redisClient } from "@app/lib/redis";
+import { Err, Ok, Result } from "@app/lib/result";
 import logger from "@app/logger/logger";
 import {
   AgentMessageType,
@@ -39,7 +41,7 @@ export async function postUserMessageWithPubSub(
     mentions: MentionType[];
     context: UserMessageContext;
   }
-): Promise<UserMessageType> {
+): Promise<Result<UserMessageType, APIErrorWithStatusCode>> {
   const postMessageEvents = postUserMessage(auth, {
     conversation,
     content,
@@ -62,7 +64,7 @@ export async function editUserMessageWithPubSub(
     content: string;
     mentions: MentionType[];
   }
-): Promise<UserMessageType> {
+): Promise<Result<UserMessageType, APIErrorWithStatusCode>> {
   const editMessageEvents = editUserMessage(auth, {
     conversation,
     message,
@@ -87,71 +89,86 @@ async function handleUserMessageEvents(
     | ConversationTitleEvent,
     void
   >
-): Promise<UserMessageType> {
-  const promise: Promise<UserMessageType> = new Promise((resolve, reject) => {
-    void (async () => {
-      const redis = await redisClient();
-      let didResolve = false;
-      try {
-        for await (const event of messageEventGenerator) {
-          switch (event.type) {
-            case "user_message_new":
-            case "agent_message_new":
-            case "conversation_title": {
-              const pubsubChannel = getConversationChannelId(conversation.sId);
-              await redis.xAdd(pubsubChannel, "*", {
-                payload: JSON.stringify(event),
-              });
-              await redis.expire(pubsubChannel, 60 * 10);
-              if (event.type === "user_message_new") {
-                didResolve = true;
-                resolve(event.message);
+): Promise<Result<UserMessageType, APIErrorWithStatusCode>> {
+  const promise: Promise<Result<UserMessageType, APIErrorWithStatusCode>> =
+    new Promise((resolve) => {
+      void (async () => {
+        const redis = await redisClient();
+        let didResolve = false;
+        try {
+          for await (const event of messageEventGenerator) {
+            switch (event.type) {
+              case "user_message_new":
+              case "agent_message_new":
+              case "conversation_title": {
+                const pubsubChannel = getConversationChannelId(
+                  conversation.sId
+                );
+                await redis.xAdd(pubsubChannel, "*", {
+                  payload: JSON.stringify(event),
+                });
+                await redis.expire(pubsubChannel, 60 * 10);
+                if (event.type === "user_message_new") {
+                  didResolve = true;
+                  resolve(new Ok(event.message));
+                }
+                break;
               }
-              break;
-            }
-            case "retrieval_params":
-            case "agent_error":
-            case "agent_action_success":
-            case "generation_tokens":
-            case "agent_generation_success":
-            case "agent_message_success": {
-              const pubsubChannel = getMessageChannelId(event.messageId);
-              await redis.xAdd(pubsubChannel, "*", {
-                payload: JSON.stringify(event),
-              });
-              await redis.expire(pubsubChannel, 60 * 10);
-              break;
-            }
-            case "user_message_error": {
-              // We reject the promise here which means we'll get a 500 in the route calling
-              // postUserMessageWithPubSub. This is fine since `user_message_error` can only happen
-              // if we're trying to send a message to a conversation that we don't have access to,
-              // or this has already been checked if getConversation has been called.
-              reject(new Error(event.error.message));
-              break;
-            }
+              case "retrieval_params":
+              case "agent_error":
+              case "agent_action_success":
+              case "generation_tokens":
+              case "agent_generation_success":
+              case "agent_message_success": {
+                const pubsubChannel = getMessageChannelId(event.messageId);
+                await redis.xAdd(pubsubChannel, "*", {
+                  payload: JSON.stringify(event),
+                });
+                await redis.expire(pubsubChannel, 60 * 10);
+                break;
+              }
+              case "user_message_error": {
+                // We resolve the promise with an error as we were not able to create the user
+                // message. This is possible for a variety of reason and will get turned into a 400
+                // in the API route calling `{post/edit}UserMessageWithPubSub`.
+                didResolve = true;
+                resolve(
+                  new Err({
+                    status_code: 400,
+                    api_error: {
+                      type: "invalid_request_error",
+                      message: event.error.message,
+                    },
+                  })
+                );
+                break;
+              }
 
-            default:
-              ((event: never) => {
-                logger.error("Unknown event type", event);
-              })(event);
-              return null;
+              default:
+                ((event: never) => {
+                  logger.error("Unknown event type", event);
+                })(event);
+                return null;
+            }
+          }
+        } catch (e) {
+          logger.error({ error: e }, "Error Posting message");
+        } finally {
+          await redis.quit();
+          if (!didResolve) {
+            resolve(
+              new Err({
+                status_code: 500,
+                api_error: {
+                  type: "internal_server_error",
+                  message: `Never got the user_message_new event for ${conversation.sId}`,
+                },
+              })
+            );
           }
         }
-      } catch (e) {
-        logger.error({ error: e }, "Error Posting message");
-      } finally {
-        await redis.quit();
-        if (!didResolve) {
-          reject(
-            new Error(
-              `Never got the user_message_new event for ${conversation.sId}`
-            )
-          );
-        }
-      }
-    })();
-  });
+      })();
+    });
 
   return promise;
 }
@@ -165,61 +182,68 @@ export async function retryAgentMessageWithPubSub(
     conversation: ConversationType;
     message: AgentMessageType;
   }
-): Promise<AgentMessageType> {
-  const promise: Promise<AgentMessageType> = new Promise((resolve, reject) => {
-    void (async () => {
-      const redis = await redisClient();
-      let didResolve = false;
-      try {
-        for await (const event of retryAgentMessage(auth, {
-          conversation,
-          message,
-        })) {
-          switch (event.type) {
-            case "agent_message_new": {
-              const pubsubChannel = getConversationChannelId(conversation.sId);
-              await redis.xAdd(pubsubChannel, "*", {
-                payload: JSON.stringify(event),
-              });
-              await redis.expire(pubsubChannel, 60 * 10);
-              didResolve = true;
-              resolve(event.message);
-              break;
+): Promise<Result<AgentMessageType, APIErrorWithStatusCode>> {
+  const promise: Promise<Result<AgentMessageType, APIErrorWithStatusCode>> =
+    new Promise((resolve) => {
+      void (async () => {
+        const redis = await redisClient();
+        let didResolve = false;
+        try {
+          for await (const event of retryAgentMessage(auth, {
+            conversation,
+            message,
+          })) {
+            switch (event.type) {
+              case "agent_message_new": {
+                const pubsubChannel = getConversationChannelId(
+                  conversation.sId
+                );
+                await redis.xAdd(pubsubChannel, "*", {
+                  payload: JSON.stringify(event),
+                });
+                await redis.expire(pubsubChannel, 60 * 10);
+                didResolve = true;
+                resolve(new Ok(event.message));
+                break;
+              }
+              case "retrieval_params":
+              case "agent_error":
+              case "agent_action_success":
+              case "generation_tokens":
+              case "agent_generation_success":
+              case "agent_message_success": {
+                const pubsubChannel = getMessageChannelId(event.messageId);
+                await redis.xAdd(pubsubChannel, "*", {
+                  payload: JSON.stringify(event),
+                });
+                await redis.expire(pubsubChannel, 60 * 10);
+                break;
+              }
+              default:
+                ((event: never) => {
+                  logger.error("Unknown event type", event);
+                })(event);
+                return null;
             }
-            case "retrieval_params":
-            case "agent_error":
-            case "agent_action_success":
-            case "generation_tokens":
-            case "agent_generation_success":
-            case "agent_message_success": {
-              const pubsubChannel = getMessageChannelId(event.messageId);
-              await redis.xAdd(pubsubChannel, "*", {
-                payload: JSON.stringify(event),
-              });
-              await redis.expire(pubsubChannel, 60 * 10);
-              break;
-            }
-            default:
-              ((event: never) => {
-                logger.error("Unknown event type", event);
-              })(event);
-              return null;
+          }
+        } catch (e) {
+          logger.error({ error: e }, "Error Posting message");
+        } finally {
+          await redis.quit();
+          if (!didResolve) {
+            resolve(
+              new Err({
+                status_code: 500,
+                api_error: {
+                  type: "internal_server_error",
+                  message: `Never got the user_message_new event for ${conversation.sId}`,
+                },
+              })
+            );
           }
         }
-      } catch (e) {
-        logger.error({ error: e }, "Error Posting message");
-      } finally {
-        await redis.quit();
-        if (!didResolve) {
-          reject(
-            new Error(
-              `Never got the agent_message_new event for ${conversation.sId}`
-            )
-          );
-        }
-      }
-    })();
-  });
+      })();
+    });
 
   return promise;
 }

--- a/front/pages/api/v1/w/[wId]/assistant/[cId]/messages/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/[cId]/messages/index.ts
@@ -93,14 +93,20 @@ async function handler(
           },
         });
       }
+
       const { content, context, mentions } = bodyValidation.right;
-      const message = await postUserMessageWithPubSub(auth, {
+
+      const messageRes = await postUserMessageWithPubSub(auth, {
         conversation,
         content,
         mentions,
         context,
       });
-      res.status(200).json({ message: message });
+      if (messageRes.isErr()) {
+        return apiError(req, res, messageRes.error);
+      }
+
+      res.status(200).json({ message: messageRes.value });
       return;
 
     default:

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -94,8 +94,9 @@ async function handler(
       });
 
       if (message) {
-        // Not awaiting this promise on prupose. We want to answer "OK" to the client ASAP and process
-        // the events in the background.
+        // Not awaiting this promise on purpose. We want to answer "OK" to the client ASAP and
+        // process the events in the background. So that the client gets updated as soon as
+        // possible.
         void postUserMessageWithPubSub(auth, {
           conversation,
           content: message.content,
@@ -109,6 +110,7 @@ async function handler(
           },
         });
       }
+
       res.status(200).json({ conversation });
       return;
 

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit.ts
@@ -132,14 +132,17 @@ async function handler(
       }
       const { content, mentions } = bodyValidation.right;
 
-      const editedMessage = await editUserMessageWithPubSub(auth, {
+      const editedMessageRes = await editUserMessageWithPubSub(auth, {
         conversation,
         message,
         content,
         mentions,
       });
+      if (editedMessageRes.isErr()) {
+        return apiError(req, res, editedMessageRes.error);
+      }
 
-      res.status(200).json({ message: editedMessage });
+      res.status(200).json({ message: editedMessageRes.value });
       return;
 
     default:

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/retry.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/retry.ts
@@ -125,12 +125,15 @@ async function handler(
         });
       }
 
-      const retriedMessage = await retryAgentMessageWithPubSub(auth, {
+      const retriedMessageRes = await retryAgentMessageWithPubSub(auth, {
         conversation,
         message,
       });
+      if (retriedMessageRes.isErr()) {
+        return apiError(req, res, retriedMessageRes.error);
+      }
 
-      res.status(200).json({ message: retriedMessage });
+      res.status(200).json({ message: retriedMessageRes.value });
       return;
 
     default:

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -111,7 +111,7 @@ async function handler(
 
       // Not awaiting this promise on prupose. We want to answer "OK" to the client ASAP and process
       // the events in the background.
-      const message = await postUserMessageWithPubSub(auth, {
+      const messageRes = await postUserMessageWithPubSub(auth, {
         conversation,
         content,
         mentions,
@@ -123,8 +123,11 @@ async function handler(
           profilePictureUrl: context.profilePictureUrl,
         },
       });
+      if (messageRes.isErr()) {
+        return apiError(req, res, messageRes.error);
+      }
 
-      res.status(200).json({ message: message });
+      res.status(200).json({ message: messageRes.value });
       return;
 
     default:

--- a/front/pages/api/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/index.ts
@@ -119,8 +119,9 @@ async function handler(
       });
 
       if (message) {
-        // Not awaiting this promise on prupose. We want to answer "OK" to the client ASAP and process
-        // the events in the background.
+        // Not awaiting this promise on purpose. We want to answer "OK" to the client ASAP and
+        // process the events in the background. So that the client gets updated as soon as
+        // possible.
         void postUserMessageWithPubSub(auth, {
           conversation,
           content: message.content,


### PR DESCRIPTION
We've seen unhandled API errors in the wild: https://app.datadoghq.eu/logs?query=service%3Afront%20%22Unhandled%20API%20Error%22%20&cols=host%2Cservice&event=AgAAAYrLY6YiMzTMigAAAAAAAAAYAAAAAEFZckxZN2V4QUFCVDhVZ25RYXZOQ2dBUwAAACQAAAAAMDE4YWNiNjktY2MzMy00Y2I3LWE0NjItNWQ4YzFkMTIzNDBk&index=%2A&messageDisplay=inline&refresh_mode=sliding&stream_sort=desc&viz=stream&from_ts=1695626780471&to_ts=1695630380471&live=true