### PR TITLE
feat: support "auto" topKmode on retrieval config

### DIFF
--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -411,7 +411,7 @@ export default function AssistantBuilder({
           type: "retrieval_configuration",
           query: "auto", // TODO ?
           timeframe: tfParam,
-          topK: 16, // TODO ?
+          topK: "auto",
           dataSources: Object.values(builderState.dataSourceConfigurations).map(
             ({ dataSource, selectedResources, isSelectAll }) => ({
               dataSourceId: dataSource.name,

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -5,6 +5,7 @@ import {
 import { runAction } from "@app/lib/actions/server";
 import { generateActionInputs } from "@app/lib/api/assistant/agent";
 import { ModelMessageType } from "@app/lib/api/assistant/generation";
+import { getSupportedModelConfig } from "@app/lib/assistant";
 import { Authenticator } from "@app/lib/auth";
 import { front_sequelize, ModelId } from "@app/lib/databases";
 import {
@@ -192,7 +193,11 @@ export async function generateRetrievalParams(
   userMessage: UserMessageType
 ): Promise<
   Result<
-    { query: string | null; relativeTimeFrame: TimeFrame | null; topK: number },
+    {
+      query: string | null;
+      relativeTimeFrame: TimeFrame | null;
+      topK: number | "auto";
+    },
     Error
   >
 > {
@@ -439,6 +444,25 @@ export async function* runRetrieval(
 
   const params = paramsRes.value;
 
+  const model = configuration.generation?.model;
+
+  let topK = 16;
+
+  if (params.topK === "auto") {
+    if (!model) {
+      logger.warn(
+        "Retrieval topK mode is set to auto, but there is no model to infer it from. Defaulting to 16."
+      );
+    } else {
+      const supportedModel = getSupportedModelConfig(model);
+      topK = supportedModel.recommendedTopK;
+    }
+  } else {
+    topK = params.topK;
+  }
+
+  // let topK: number  = params.topK === "auto" ?
+
   // Create the AgentRetrievalAction object in the database and yield an event for the generation of
   // the params. We store the action here as the params have been generated, if an error occurs
   // later on, the action won't have retrieved documents but the error will be stored on the parent
@@ -447,7 +471,7 @@ export async function* runRetrieval(
     query: params.query,
     relativeTimeFrameDuration: params.relativeTimeFrame?.duration ?? null,
     relativeTimeFrameUnit: params.relativeTimeFrame?.unit ?? null,
-    topK: params.topK,
+    topK,
     retrievalConfigurationId: c.sId,
   });
 
@@ -463,7 +487,7 @@ export async function* runRetrieval(
       params: {
         relativeTimeFrame: params.relativeTimeFrame,
         query: params.query,
-        topK: params.topK,
+        topK,
       },
       documents: null,
     },
@@ -507,7 +531,7 @@ export async function* runRetrieval(
   }
 
   // Handle top k.
-  config.DATASOURCE.top_k = params.topK;
+  config.DATASOURCE.top_k = topK;
 
   const res = await runAction(auth, "assistant-v2-retrieval", config, [
     {
@@ -631,7 +655,7 @@ export async function* runRetrieval(
       params: {
         relativeTimeFrame: params.relativeTimeFrame,
         query: params.query,
-        topK: params.topK,
+        topK,
       },
       documents,
     },

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -461,8 +461,6 @@ export async function* runRetrieval(
     topK = params.topK;
   }
 
-  // let topK: number  = params.topK === "auto" ?
-
   // Create the AgentRetrievalAction object in the database and yield an event for the generation of
   // the params. We store the action here as the params have been generated, if an error occurs
   // later on, the action won't have retrieved documents but the error will be stored on the parent

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -51,7 +51,7 @@ export const SUPPORTED_MODEL_CONFIGS = [
     displayName: "GPT 4",
     contextSize: 8192,
     largeModel: true,
-    recommendedTopK: 32,
+    recommendedTopK: 16,
   },
   CLAUDE_DEFAULT_MODEL_CONFIG,
   CLAUDE_INSTANT_DEFAULT_MODEL_CONFIG,

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -12,6 +12,7 @@ export const GPT_4_DEFAULT_MODEL_CONFIG = {
   displayName: "GPT 4",
   contextSize: 32768,
   largeModel: true,
+  recommendedTopK: 32,
 } as const;
 
 export const GPT_3_5_TURBO_DEFAULT_MODEL_CONFIG = {
@@ -20,6 +21,7 @@ export const GPT_3_5_TURBO_DEFAULT_MODEL_CONFIG = {
   displayName: "GPT 3.5 Turbo",
   contextSize: 4096,
   largeModel: false,
+  recommendedTopK: 16,
 } as const;
 
 export const CLAUDE_DEFAULT_MODEL_CONFIG = {
@@ -28,6 +30,7 @@ export const CLAUDE_DEFAULT_MODEL_CONFIG = {
   displayName: "Claude 2",
   contextSize: 100000,
   largeModel: true,
+  recommendedTopK: 32,
 } as const;
 
 export const CLAUDE_INSTANT_DEFAULT_MODEL_CONFIG = {
@@ -36,6 +39,7 @@ export const CLAUDE_INSTANT_DEFAULT_MODEL_CONFIG = {
   displayName: "Claude Instant 1.2",
   contextSize: 100000,
   largeModel: false,
+  recommendedTopK: 32,
 } as const;
 
 export const SUPPORTED_MODEL_CONFIGS = [
@@ -47,6 +51,7 @@ export const SUPPORTED_MODEL_CONFIGS = [
     displayName: "GPT 4",
     contextSize: 8192,
     largeModel: true,
+    recommendedTopK: 32,
   },
   CLAUDE_DEFAULT_MODEL_CONFIG,
   CLAUDE_INSTANT_DEFAULT_MODEL_CONFIG,

--- a/front/lib/models/assistant/actions/retrieval.ts
+++ b/front/lib/models/assistant/actions/retrieval.ts
@@ -30,8 +30,10 @@ export class AgentRetrievalConfiguration extends Model<
   declare relativeTimeFrame: "auto" | "none" | "custom";
   declare relativeTimeFrameDuration: number | null;
   declare relativeTimeFrameUnit: TimeframeUnit | null;
-  declare topK: number;
+  declare topK: number | null;
+  declare topKMode: "auto" | "custom";
 }
+
 AgentRetrievalConfiguration.init(
   {
     id: {
@@ -79,6 +81,11 @@ AgentRetrievalConfiguration.init(
       type: DataTypes.INTEGER,
       allowNull: false,
     },
+    topKMode: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      defaultValue: "auto",
+    },
   },
   {
     modelName: "agent_retrieval_configuration",
@@ -104,6 +111,15 @@ AgentRetrievalConfiguration.init(
               "Custom relative time frame must have a duration and unit set"
             );
           }
+        }
+
+        // Validation for TopK
+        if (retrieval.topKMode == "custom") {
+          if (retrieval.topK === null) {
+            throw new Error("topK must be set when topKMode is 'custom'");
+          }
+        } else if (retrieval.topK !== null) {
+          throw new Error("topK must be null when topKMode is not 'custom'");
         }
       },
     },

--- a/front/lib/models/assistant/actions/retrieval.ts
+++ b/front/lib/models/assistant/actions/retrieval.ts
@@ -79,7 +79,7 @@ AgentRetrievalConfiguration.init(
     },
     topK: {
       type: DataTypes.INTEGER,
-      allowNull: false,
+      allowNull: true,
     },
     topKMode: {
       type: DataTypes.STRING,

--- a/front/migrations/20230922_workspace_plan_large_model.ts
+++ b/front/migrations/20230922_workspace_plan_large_model.ts
@@ -1,7 +1,7 @@
 import { Op } from "sequelize";
 
-import { Workspace } from "@app/lib/models";
 import { planForWorkspace } from "@app/lib/auth";
+import { Workspace } from "@app/lib/models";
 
 async function main() {
   console.log("Fetching Upgraded Worspaces...");
@@ -34,7 +34,7 @@ async function main() {
 }
 
 async function addLargeModelTrue(workspace: Workspace) {
-  let plan = planForWorkspace(workspace);
+  const plan = planForWorkspace(workspace);
   plan.limits.largeModels = true;
   await workspace.update({
     plan: JSON.stringify(plan),

--- a/front/migrations/20230925_topk_mode.ts
+++ b/front/migrations/20230925_topk_mode.ts
@@ -1,0 +1,25 @@
+import { AgentRetrievalConfiguration } from "@app/lib/models";
+
+async function main() {
+  console.log("Setting topK to null for all auto topKMode configurations...");
+  await AgentRetrievalConfiguration.update(
+    {
+      topK: null,
+    },
+    {
+      where: {
+        topKMode: "auto",
+      },
+    }
+  );
+}
+
+main()
+  .then(() => {
+    console.log("done");
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -52,7 +52,7 @@ export const PostOrPatchAgentConfigurationRequestBodySchema = t.type({
             unit: TimeframeUnitCodec,
           }),
         ]),
-        topK: t.number,
+        topK: t.union([t.number, t.literal("auto")]),
         dataSources: t.array(
           t.type({
             dataSourceId: t.string,

--- a/front/types/assistant/actions/retrieval.ts
+++ b/front/types/assistant/actions/retrieval.ts
@@ -68,7 +68,7 @@ export type RetrievalConfigurationType = {
   dataSources: DataSourceConfiguration[];
   query: RetrievalQuery;
   relativeTimeFrame: RetrievalTimeframe;
-  topK: number;
+  topK: number | "auto";
 
   // Dynamically decide to skip, if needed in the future
   // autoSkip: boolean;


### PR DESCRIPTION
When topKMode is "auto", `topK` should be null. We'll use the `recommendedTopk` from `SUPPORTED_MODELS` instead.

https://github.com/orgs/dust-tt/projects/3?pane=issue&itemId=39572055
