### PR TITLE
Edit assistant order

### DIFF
--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -416,7 +416,7 @@ async function _getDustGlobalAgent(
     throw new Error("Unexpected `auth` without `workspace`.");
   }
 
-  const name = "Dust";
+  const name = "dust";
   const description = "An assistant with context on your company data.";
   const pictureUrl = "https://dust.tt/static/systemavatar/dust_avatar_full.png";
 

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -96,6 +96,7 @@ export enum GLOBAL_AGENTS_SID {
 }
 
 const CUSTOM_ORDER: string[] = [
+  GLOBAL_AGENTS_SID.HELPER,
   GLOBAL_AGENTS_SID.DUST,
   GLOBAL_AGENTS_SID.GPT4,
   GLOBAL_AGENTS_SID.SLACK,
@@ -105,7 +106,6 @@ const CUSTOM_ORDER: string[] = [
   GLOBAL_AGENTS_SID.GPT35_TURBO,
   GLOBAL_AGENTS_SID.CLAUDE,
   GLOBAL_AGENTS_SID.CLAUDE_INSTANT,
-  GLOBAL_AGENTS_SID.HELPER,
 ];
 
 // This function implements our general strategy to sort agents to users (input bar, assistant list,
@@ -114,13 +114,17 @@ export function compareAgentsForSort(
   a: AgentConfigurationType,
   b: AgentConfigurationType
 ) {
-  // Check for 'Dust'
-  if (a.name === GLOBAL_AGENTS_SID.DUST) return -1;
-  if (b.name === GLOBAL_AGENTS_SID.DUST) return 1;
+  // Check for 'helper'
+  if (a.sId === GLOBAL_AGENTS_SID.HELPER) return -1;
+  if (b.sId === GLOBAL_AGENTS_SID.HELPER) return 1;
+
+  // Check for 'dust'
+  if (a.sId === GLOBAL_AGENTS_SID.DUST) return -1;
+  if (b.sId === GLOBAL_AGENTS_SID.DUST) return 1;
 
   // Check for 'gpt4'
-  if (a.name === GLOBAL_AGENTS_SID.GPT4) return -1;
-  if (b.name === GLOBAL_AGENTS_SID.GPT4) return 1;
+  if (a.sId === GLOBAL_AGENTS_SID.GPT4) return -1;
+  if (b.sId === GLOBAL_AGENTS_SID.GPT4) return 1;
 
   // Check for agents with 'scope' set to 'workspace'
   if (a.scope === "workspace" && b.scope !== "workspace") return -1;


### PR DESCRIPTION
Source: https://github.com/dust-tt/dust/issues/1746

- Change order of assistants, put @helper first
- Rename Dust to dust
- Edit compareAgentsForSort comparison based on sId instead of name