### PR TITLE
override gpt4-32k when low token used

### DIFF
--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -43,7 +43,6 @@ export type ModelMessageType = {
 
 export type ModelConversationType = {
   messages: ModelMessageType[];
-  tokensUsed: number;
 };
 
 // This function transforms a conversation in a simplified format that we feed the model as context.
@@ -56,7 +55,12 @@ export async function renderConversationForModel({
   conversation: ConversationType;
   model: { providerId: string; modelId: string };
   allowedTokenCount: number;
-}): Promise<Result<ModelConversationType, Error>> {
+}): Promise<
+  Result<
+    { modelConversation: ModelConversationType; tokensUsed: number },
+    Error
+  >
+> {
   const messages = [];
 
   let retrievalFound = false;
@@ -159,7 +163,9 @@ export async function renderConversationForModel({
   );
 
   return new Ok({
-    messages: selected,
+    modelConversation: {
+      messages: selected,
+    },
     tokensUsed,
   });
 }
@@ -324,7 +330,7 @@ export async function* runGeneration(
 
   const res = await runActionStreamed(auth, "assistant-v2-generator", config, [
     {
-      conversation: modelConversationRes.value,
+      conversation: modelConversationRes.value.modelConversation,
       prompt: constructPrompt(userMessage, configuration),
     },
   ]);

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -6,9 +6,12 @@ import { WorkspaceType } from "@app/types/user";
  * Supported models
  */
 
+export const GPT_4_32K_MODEL_ID = "gpt-4-32k" as const;
+export const GPT_4_MODEL_ID = "gpt-4" as const;
+
 export const GPT_4_DEFAULT_MODEL_CONFIG = {
   providerId: "openai",
-  modelId: "gpt-4-32k",
+  modelId: GPT_4_32K_MODEL_ID,
   displayName: "GPT 4",
   contextSize: 32768,
   largeModel: true,
@@ -42,17 +45,19 @@ export const CLAUDE_INSTANT_DEFAULT_MODEL_CONFIG = {
   recommendedTopK: 32,
 } as const;
 
+export const GPT_4_MODEL_CONFIG = {
+  providerId: "openai",
+  modelId: GPT_4_MODEL_ID,
+  displayName: "GPT 4",
+  contextSize: 8192,
+  largeModel: true,
+  recommendedTopK: 16,
+};
+
 export const SUPPORTED_MODEL_CONFIGS = [
   GPT_3_5_TURBO_DEFAULT_MODEL_CONFIG,
   GPT_4_DEFAULT_MODEL_CONFIG,
-  {
-    providerId: "openai",
-    modelId: "gpt-4",
-    displayName: "GPT 4",
-    contextSize: 8192,
-    largeModel: true,
-    recommendedTopK: 16,
-  },
+  GPT_4_MODEL_CONFIG,
   CLAUDE_DEFAULT_MODEL_CONFIG,
   CLAUDE_INSTANT_DEFAULT_MODEL_CONFIG,
 ] as const;


### PR DESCRIPTION
If model is gpt4-32 and the conversation uses less than 4k tokens, then we should switch to gp4 standard 

https://github.com/orgs/dust-tt/projects/3?pane=issue&itemId=39571850