### PR TITLE
Propagate prompt to inputs generator

### DIFF
--- a/front/lib/actions/registry.ts
+++ b/front/lib/actions/registry.ts
@@ -17,7 +17,7 @@ export const DustProdActionRegistry = createActionRegistry({
       workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
       appId: "f4816b1e13",
       appHash:
-        "813ee600c134cb03693b1fea467204f1cf27247180ce1e6f0d090c46b1b29d53",
+        "f24ac7033d61b371be1473ddf9a6946513dda65c8b58b66aff182a73c171916f",
     },
     config: {
       MODEL: {
@@ -65,7 +65,7 @@ export const DustProdActionRegistry = createActionRegistry({
       workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
       appId: "6a27050429",
       appHash:
-        "77452e1a74f766a4b40c13c241c3cf36458b527b9bda36a35781906d4b54dcdd",
+        "efa092ecb7b337d2ed78ab9d3c9ff6204ef95af044b0258c0d220866666bdf6b",
     },
     config: {
       MODEL: {

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -34,9 +34,16 @@ import {
 // This method is used by actions to generate its inputs if needed.
 export async function generateActionInputs(
   auth: Authenticator,
+  configuration: AgentConfigurationType,
   specification: AgentActionSpecification,
   conversation: ConversationType
 ): Promise<Result<Record<string, string | boolean | number>, Error>> {
+  // We inject the prompt of the model so that its input generation behavior can be modified by its
+  // instructions. If there is no genration phase we default to a generic prompt.
+  const prompt = configuration.generation
+    ? configuration.generation.prompt
+    : "You are a conversational assistant with access to function calling.";
+
   const model = {
     providerId: "openai",
     modelId: "gpt-3.5-turbo-16k",
@@ -65,6 +72,7 @@ export async function generateActionInputs(
     {
       conversation: modelConversationRes.value.modelConversation,
       specification,
+      prompt,
     },
   ]);
 


### PR DESCRIPTION
Pass the prompt to inputs generator so that we can influence the inputs generation with the assistant instructions (if defined).

eg: in instruction say: focus on documents from less than 1 month ago