### PR TITLE
Add a description when hover on mention in a message

### DIFF
--- a/front/components/RenderMarkdown.tsx
+++ b/front/components/RenderMarkdown.tsx
@@ -24,6 +24,7 @@ import { visit } from "unist-util-visit";
 
 import { classNames } from "@app/lib/utils";
 import { RetrievalDocumentType } from "@app/types/assistant/actions/retrieval";
+import { AgentConfigurationType } from "@app/types/assistant/agent";
 
 import {
   PROVIDER_LOGO_PATH,
@@ -41,11 +42,11 @@ function mentionDirective() {
     visit(tree, ["textDirective"], (node) => {
       if (node.name === "mention") {
         const data = node.data || (node.data = {});
-        data.hName = "span";
+        data.hName = "mention";
         data.hProperties = {
-          className: "inline-block font-medium text-brand",
+          agentSId: node.attributes.sId,
+          agentName: node.children[0].value,
         };
-        node.children.unshift({ type: "text", value: "@" });
       }
     });
   };
@@ -124,10 +125,12 @@ export function RenderMarkdown({
   content,
   blinkingCursor,
   references,
+  agentConfigurations,
 }: {
   content: string;
   blinkingCursor: boolean;
   references?: { [key: string]: RetrievalDocumentType };
+  agentConfigurations?: AgentConfigurationType[];
 }) {
   return (
     <div className={blinkingCursor ? "blinking-cursor" : ""}>
@@ -147,6 +150,19 @@ export function RenderMarkdown({
           tbody: TableBodyBlock,
           th: TableHeaderBlock,
           td: TableDataBlock,
+          // @ts-expect-error - `mention` is a custom tag, currently refused by
+          // react-markdown types although the functionality is supported
+          mention: ({ agentName, agentSId }) => {
+            const agentConfiguration = agentConfigurations?.find(
+              (agentConfiguration) => agentConfiguration.sId === agentSId
+            );
+            return (
+              <MentionBlock
+                agentConfiguration={agentConfiguration}
+                agentName={agentName}
+              />
+            );
+          },
         }}
         remarkPlugins={[
           remarkDirective,
@@ -158,6 +174,35 @@ export function RenderMarkdown({
         {addClosingBackticks(content)}
       </ReactMarkdown>
     </div>
+  );
+}
+
+function MentionBlock({
+  agentName,
+  agentConfiguration,
+}: {
+  agentName: string;
+  agentConfiguration?: AgentConfigurationType;
+}) {
+  const statusText =
+    agentConfiguration?.status === "archived"
+      ? "[ARCHIVED] "
+      : agentConfiguration?.status === "active"
+      ? ""
+      : "[DISABLED] ";
+  const tooltipContent = (
+    <div className="w-48">
+      {agentConfiguration
+        ? statusText + agentConfiguration.description
+        : "Description unavailable"}
+    </div>
+  );
+  return (
+    <span className="inline-block cursor-default font-medium text-brand">
+      <Tooltip contentChildren={tooltipContent} position="below">
+        @{agentName}
+      </Tooltip>
+    </span>
   );
 }
 

--- a/front/components/assistant/RenderMessageMarkdown.tsx
+++ b/front/components/assistant/RenderMessageMarkdown.tsx
@@ -30,7 +30,7 @@ import {
   PROVIDER_LOGO_PATH,
   providerFromDocument,
   titleFromDocument,
-} from "./assistant/conversation/RetrievalAction";
+} from "./conversation/RetrievalAction";
 
 const SyntaxHighlighter = dynamic(
   () => import("react-syntax-highlighter").then((mod) => mod.Light),
@@ -121,7 +121,7 @@ function addClosingBackticks(str: string): string {
   return str;
 }
 
-export function RenderMarkdown({
+export function RenderMessageMarkdown({
   content,
   blinkingCursor,
   references,
@@ -185,16 +185,14 @@ function MentionBlock({
   agentConfiguration?: AgentConfigurationType;
 }) {
   const statusText =
-    agentConfiguration?.status === "archived"
-      ? "[ARCHIVED] "
+    !agentConfiguration || agentConfiguration?.status === "archived"
+      ? "(This assistant was deleted)"
       : agentConfiguration?.status === "active"
       ? ""
-      : "[DISABLED] ";
+      : " (This assistant is deactivated for this workspace)";
   const tooltipContent = (
     <div className="w-48">
-      {agentConfiguration
-        ? statusText + agentConfiguration.description
-        : "Description unavailable"}
+      {agentConfiguration?.description + "" + statusText}
     </div>
   );
   return (

--- a/front/components/assistant/RenderMessageMarkdown.tsx
+++ b/front/components/assistant/RenderMessageMarkdown.tsx
@@ -189,10 +189,11 @@ function MentionBlock({
       ? "(This assistant was deleted)"
       : agentConfiguration?.status === "active"
       ? ""
-      : " (This assistant is deactivated for this workspace)";
+      : "(This assistant is deactivated for this workspace)";
   const tooltipContent = (
-    <div className="w-48">
-      {agentConfiguration?.description + "" + statusText}
+    <div className="flex w-64 flex-col gap-2">
+      <span>{agentConfiguration?.description}</span>
+      <span>{statusText}</span>
     </div>
   );
   return (

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -12,7 +12,7 @@ import { useCallback, useEffect, useState } from "react";
 
 import { AgentAction } from "@app/components/assistant/conversation/AgentAction";
 import { ConversationMessage } from "@app/components/assistant/conversation/ConversationMessage";
-import { RenderMarkdown } from "@app/components/RenderMarkdown";
+import { RenderMessageMarkdown } from "@app/components/assistant/RenderMessageMarkdown";
 import { useEventSource } from "@app/hooks/useEventSource";
 import {
   AgentActionEvent,
@@ -220,7 +220,7 @@ export function AgentMessage({
     // Messages with no action and text
     if (agentMessage.action === null && agentMessage.content) {
       return (
-        <RenderMarkdown
+        <RenderMessageMarkdown
           content={agentMessage.content}
           blinkingCursor={streaming}
         />
@@ -253,7 +253,7 @@ export function AgentMessage({
           {agentMessage.content && agentMessage.content !== "" && (
             <>
               <div className="pt-4">
-                <RenderMarkdown
+                <RenderMessageMarkdown
                   content={agentMessage.content}
                   blinkingCursor={streaming}
                   references={references}

--- a/front/components/assistant/conversation/UserMessage.tsx
+++ b/front/components/assistant/conversation/UserMessage.tsx
@@ -1,5 +1,6 @@
 import { ConversationMessage } from "@app/components/assistant/conversation/ConversationMessage";
 import { RenderMarkdown } from "@app/components/RenderMarkdown";
+import { useAgentConfigurations } from "@app/lib/swr";
 import {
   ConversationType,
   UserMessageType,
@@ -17,6 +18,10 @@ export function UserMessage({
   conversation: ConversationType;
   owner: WorkspaceType;
 }) {
+  const { agentConfigurations } = useAgentConfigurations({
+    workspaceId: owner.sId,
+  });
+
   return (
     <ConversationMessage
       pictureUrl={message.context.profilePictureUrl}
@@ -25,7 +30,11 @@ export function UserMessage({
     >
       <div className="flex flex-col gap-4">
         <div>
-          <RenderMarkdown content={message.content} blinkingCursor={false} />
+          <RenderMarkdown
+            content={message.content}
+            blinkingCursor={false}
+            agentConfigurations={agentConfigurations}
+          />
         </div>
         {message.mentions.length === 0 &&
           conversation.content[conversation.content.length - 1].some(

--- a/front/components/assistant/conversation/UserMessage.tsx
+++ b/front/components/assistant/conversation/UserMessage.tsx
@@ -1,5 +1,5 @@
 import { ConversationMessage } from "@app/components/assistant/conversation/ConversationMessage";
-import { RenderMarkdown } from "@app/components/RenderMarkdown";
+import { RenderMessageMarkdown } from "@app/components/assistant/RenderMessageMarkdown";
 import { useAgentConfigurations } from "@app/lib/swr";
 import {
   ConversationType,
@@ -30,7 +30,7 @@ export function UserMessage({
     >
       <div className="flex flex-col gap-4">
         <div>
-          <RenderMarkdown
+          <RenderMessageMarkdown
             content={message.content}
             blinkingCursor={false}
             agentConfigurations={agentConfigurations}


### PR DESCRIPTION
Related issue: #1619 

In a following PR I propose to: 1. add a min-width to the Sparkle tooltip component and 2. Remove the div w-48 and move the text as a label
The min-width is necessary IMHO: i've noticed a few times where the tooltip is displayed on a very narrow space because its object is small


![image](https://github.com/dust-tt/dust/assets/5437393/c2a8ec6a-abb4-4a3b-a722-19c31b2d8d74)

Archived or Disabled get a status text added
![image](https://github.com/dust-tt/dust/assets/5437393/326da9b8-9e84-4042-b991-5a5db4a407f5)

