### PR TITLE
Conversations are marked as deleted rather than destroyed

### DIFF
--- a/connectors/src/lib/dust_api.ts
+++ b/connectors/src/lib/dust_api.ts
@@ -148,7 +148,11 @@ const PostMessagesRequestBodySchemaIoTs = t.type({
 
 const PostConversationsRequestBodySchemaIoTs = t.type({
   title: t.union([t.string, t.null]),
-  visibility: t.union([t.literal("unlisted"), t.literal("workspace")]),
+  visibility: t.union([
+    t.literal("unlisted"),
+    t.literal("workspace"),
+    t.literal("deleted"),
+  ]),
   message: PostMessagesRequestBodySchemaIoTs,
 });
 
@@ -190,7 +194,7 @@ export type GenerationSuccessEvent = {
   text: string;
 };
 
-export type ConversationVisibility = "unlisted" | "workspace";
+export type ConversationVisibility = "unlisted" | "workspace" | "deleted";
 
 /**
  *  Expresses limits for usage of the product Any positive number enforces the limit, -1 means no
@@ -557,7 +561,7 @@ export class DustAPI {
 
   async createConversation(
     title: string | null,
-    visibility: "unlisted" | "workspace",
+    visibility: ConversationVisibility,
     message: PostMessagesRequestBodySchema
   ) {
     const requestPayload: PostConversationsRequestBodySchema = {

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -124,9 +124,14 @@ export async function updateConversation(
   return c;
 }
 
+/**
+ *  Mark the conversation as deleted, but does not remove it from database
+ *  unless destroy is explicitly set to true
+ */
 export async function deleteConversation(
   auth: Authenticator,
-  conversationId: string
+  conversationId: string,
+  destroy?: boolean
 ): Promise<void> {
   const owner = auth.workspace();
   if (!owner) {
@@ -144,7 +149,13 @@ export async function deleteConversation(
     throw new Error(`Conversation ${conversationId} not found`);
   }
 
-  await conversation.destroy();
+  if (destroy) {
+    await conversation.destroy();
+  } else {
+    await conversation.update({
+      visibility: "deleted",
+    });
+  }
 }
 
 /**

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1,3 +1,5 @@
+import { Op } from "sequelize";
+
 import {
   cloneBaseConfig,
   DustProdActionRegistry,
@@ -45,7 +47,6 @@ import {
 } from "@app/types/assistant/conversation";
 
 import { renderRetrievalActionByModelId } from "./actions/retrieval";
-import { Op } from "sequelize";
 
 /**
  * Conversation Creation, update and deletion

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -133,8 +133,13 @@ export async function updateConversation(
  */
 export async function deleteConversation(
   auth: Authenticator,
-  conversationId: string,
-  destroy?: boolean
+  {
+    conversationId,
+    destroy,
+  }: {
+    conversationId: string;
+    destroy?: boolean;
+  }
 ): Promise<void> {
   const owner = auth.workspace();
   if (!owner) {
@@ -316,9 +321,6 @@ export async function getUserConversations(
         model: Conversation,
         as: "conversation",
         required: true,
-        where: {
-          ...(includeDeleted ? {} : { visibility: { [Op.ne]: "deleted" } }),
-        },
       },
     ],
     order: [["createdAt", "DESC"]],
@@ -330,7 +332,10 @@ export async function getUserConversations(
         logger.error("Participation without conversation");
         return acc;
       }
-      if (p.conversation.workspaceId !== owner.id) {
+      if (
+        p.conversation.workspaceId !== owner.id ||
+        (p.conversation.visibility === "deleted" && !includeDeleted)
+      ) {
         return acc;
       }
 

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -13,7 +13,11 @@ import { ConversationType } from "@app/types/assistant/conversation";
 
 const PostConversationsRequestBodySchema = t.type({
   title: t.union([t.string, t.null]),
-  visibility: t.union([t.literal("unlisted"), t.literal("workspace")]),
+  visibility: t.union([
+    t.literal("unlisted"),
+    t.literal("workspace"),
+    t.literal("deleted"),
+  ]),
   message: t.union([PostMessagesRequestBodySchema, t.null]),
 });
 

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -15,7 +15,11 @@ import { ConversationType } from "@app/types/assistant/conversation";
 
 export const PatchConversationsRequestBodySchema = t.type({
   title: t.union([t.string, t.null]),
-  visibility: t.union([t.literal("unlisted"), t.literal("workspace")]),
+  visibility: t.union([
+    t.literal("unlisted"),
+    t.literal("workspace"),
+    t.literal("deleted"),
+  ]),
 });
 
 export type GetConversationsResponseBody = {

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -96,7 +96,7 @@ async function handler(
       return;
 
     case "DELETE":
-      await deleteConversation(auth, conversation.sId);
+      await deleteConversation(auth, { conversationId: conversation.sId });
 
       res.status(200).end();
       return;

--- a/front/pages/api/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/index.ts
@@ -19,7 +19,11 @@ import {
 
 export const PostConversationsRequestBodySchema = t.type({
   title: t.union([t.string, t.null]),
-  visibility: t.union([t.literal("unlisted"), t.literal("workspace")]),
+  visibility: t.union([
+    t.literal("unlisted"),
+    t.literal("workspace"),
+    t.literal("deleted"),
+  ]),
   message: t.union([PostMessagesRequestBodySchema, t.null]),
 });
 

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -112,7 +112,7 @@ export function isAgentMessageType(
  * Conversations
  */
 
-export type ConversationVisibility = "unlisted" | "workspace";
+export type ConversationVisibility = "unlisted" | "workspace" | "deleted";
 
 /**
  * content [][] structure is intended to allow retries (of agent messages) or edits (of user


### PR DESCRIPTION
- Destroy is still possible via an explicit boolean
- conversations lib: by default, deleted conversations are not returned unless explicitely requested