### PR TITLE
Conversation display participants

### DIFF
--- a/front/components/assistant/conversation/ConversationTitle.tsx
+++ b/front/components/assistant/conversation/ConversationTitle.tsx
@@ -50,10 +50,10 @@ export function ConversationTitle({
       </div>
 
       <div className="flex gap-2">
-        <div className="flex">
+        <div className="hidden lg:flex">
           {conversation.participants.agents.map((agent) => (
             <div
-              className="-mr-4 inline-block last:mr-0"
+              className="-mr-5 inline-block last:mr-0"
               key={agent.configurationId}
             >
               <Avatar
@@ -65,9 +65,9 @@ export function ConversationTitle({
             </div>
           ))}
         </div>
-        <div className="flex">
+        <div className="hidden lg:flex">
           {conversation.participants.users.map((user, i) => (
-            <div className="-mr-4 inline-block last:mr-0" key={i}>
+            <div className="-mr-5 inline-block last:mr-0" key={i}>
               <Avatar
                 name={user.name}
                 visual={user.pictureUrl}

--- a/front/components/assistant/conversation/ConversationTitle.tsx
+++ b/front/components/assistant/conversation/ConversationTitle.tsx
@@ -49,16 +49,35 @@ export function ConversationTitle({
         <span className="font-bold">{conversation?.title || ""}</span>
       </div>
 
-      <div className="flex gap-1">
-        {conversation.participants.map((participant) => (
-          <Avatar
-            key={participant.id}
-            name={participant.name}
-            visual={participant.pictureUrl}
-            size="md"
-            isRounded={true}
-          />
-        ))}
+      <div className="flex gap-2">
+        <div className="flex">
+          {conversation.participants.agents.map((agent) => (
+            <div
+              className="-mr-4 inline-block last:mr-0"
+              key={agent.configurationId}
+            >
+              <Avatar
+                name={agent.name}
+                visual={agent.pictureUrl}
+                size="md"
+                isRounded={true}
+              />
+            </div>
+          ))}
+        </div>
+        <div className="flex">
+          {conversation.participants.users.map((user, i) => (
+            <div className="-mr-4 inline-block last:mr-0" key={i}>
+              <Avatar
+                name={user.name}
+                visual={user.pictureUrl}
+                size="md"
+                isRounded={true}
+              />
+            </div>
+          ))}
+        </div>
+
         <div className="hidden lg:flex">
           {onDelete && (
             <DropdownMenu>

--- a/front/components/assistant/conversation/ConversationTitle.tsx
+++ b/front/components/assistant/conversation/ConversationTitle.tsx
@@ -1,5 +1,6 @@
 import {
   ArrowUpOnSquareIcon,
+  Avatar,
   Button,
   ClipboardCheckIcon,
   DropdownMenu,
@@ -8,12 +9,17 @@ import {
 } from "@dust-tt/sparkle";
 import React, { useState } from "react";
 
+import { useConversation } from "@app/lib/swr";
+import { WorkspaceType } from "@app/types/user";
+
 export function ConversationTitle({
-  title,
+  owner,
+  conversationId,
   shareLink,
   onDelete,
 }: {
-  title: string;
+  owner: WorkspaceType;
+  conversationId: string;
   shareLink: string;
   onDelete?: () => void;
 }) {
@@ -27,13 +33,32 @@ export function ConversationTitle({
     }, 1000);
   };
 
+  const { conversation, isConversationError, isConversationLoading } =
+    useConversation({
+      conversationId,
+      workspaceId: owner.sId,
+    });
+
+  if (isConversationLoading || isConversationError || !conversation) {
+    return null;
+  }
+
   return (
     <div className="grid h-full max-w-full grid-cols-[1fr,auto] items-center gap-4">
       <div className="overflow-hidden truncate">
-        <span className="font-bold">{title}</span>
+        <span className="font-bold">{conversation?.title || ""}</span>
       </div>
 
-      <div className="flex space-x-1">
+      <div className="flex gap-1">
+        {conversation.participants.map((participant) => (
+          <Avatar
+            key={participant.id}
+            name={participant.name}
+            visual={participant.pictureUrl}
+            size="md"
+            isRounded={true}
+          />
+        ))}
         <div className="hidden lg:flex">
           {onDelete && (
             <DropdownMenu>

--- a/front/components/assistant/conversation/ConversationTitle.tsx
+++ b/front/components/assistant/conversation/ConversationTitle.tsx
@@ -69,7 +69,7 @@ export function ConversationTitle({
           {conversation.participants.users.map((user, i) => (
             <div className="-mr-5 inline-block last:mr-0" key={i}>
               <Avatar
-                name={user.name}
+                name={user.fullName || user.username}
                 visual={user.pictureUrl}
                 size="md"
                 isRounded={true}

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -11,7 +11,7 @@ import { WorkspaceType } from "@app/types/user";
 export function AssistantSidebarMenu({ owner }: { owner: WorkspaceType }) {
   const router = useRouter();
 
-  const { conversations, isConversationLoading, isConversationError } =
+  const { conversations, isConversationsLoading, isConversationsError } =
     useConversations({
       workspaceId: owner.sId,
     });
@@ -55,7 +55,7 @@ export function AssistantSidebarMenu({ owner }: { owner: WorkspaceType }) {
   };
 
   const conversationsByDate =
-    !isConversationLoading && conversations.length
+    !isConversationsLoading && conversations.length
       ? groupConversationsByDate(conversations)
       : {};
 
@@ -73,7 +73,7 @@ export function AssistantSidebarMenu({ owner }: { owner: WorkspaceType }) {
               />
             </Link>
           </div>
-          {isConversationError && (
+          {isConversationsError && (
             <div className="py-1">
               <Item.SectionHeader label="Error loading conversations" />
             </div>

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -412,8 +412,8 @@ export async function getConversation(
           const key = `${m.context.username}-${m.context.profilePictureUrl}`;
           if (!userParticipants.has(key)) {
             userParticipants.set(key, {
-              id: key,
-              name: m.context.fullName || m.context.username,
+              username: m.context.username,
+              fullName: m.context.fullName,
               pictureUrl: m.context.profilePictureUrl,
             });
           }

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -82,7 +82,7 @@ export async function createConversation(
     title: conversation.title,
     visibility: conversation.visibility,
     content: [],
-    participants: [],
+    participants: { users: [], agents: [] },
   };
 }
 
@@ -400,7 +400,8 @@ export async function getConversation(
     ],
   });
 
-  const participants = new Map();
+  const userParticipants = new Map();
+  const agentParticipants = new Map();
 
   const render = await Promise.all(
     messages.map((message) => {
@@ -409,10 +410,10 @@ export async function getConversation(
           const m = await renderUserMessage(message, message.userMessage);
 
           const key = `${m.context.username}-${m.context.profilePictureUrl}`;
-          if (!participants.has(key)) {
-            participants.set(key, {
+          if (!userParticipants.has(key)) {
+            userParticipants.set(key, {
               id: key,
-              name: m.context.fullName,
+              name: m.context.fullName || m.context.username,
               pictureUrl: m.context.profilePictureUrl,
             });
           }
@@ -425,8 +426,8 @@ export async function getConversation(
             messages,
           });
           const key = m.sId;
-          if (!participants.has(key)) {
-            participants.set(key, {
+          if (!agentParticipants.has(key)) {
+            agentParticipants.set(key, {
               id: key,
               name: m.configuration.name,
               pictureUrl: m.configuration.pictureUrl,
@@ -466,7 +467,10 @@ export async function getConversation(
     title: conversation.title,
     visibility: conversation.visibility,
     content,
-    participants: Array.from(participants.values()),
+    participants: {
+      users: Array.from(userParticipants.values()),
+      agents: Array.from(agentParticipants.values()),
+    },
   };
 }
 

--- a/front/lib/swr.ts
+++ b/front/lib/swr.ts
@@ -439,9 +439,9 @@ export function useConversations({ workspaceId }: { workspaceId: string }) {
 
   return {
     conversations: data ? data.conversations : [],
-    isConversationLoading: !error && !data,
-    isConversationError: error,
-    mutateConversation: mutate,
+    isConversationsLoading: !error && !data,
+    isConversationsError: error,
+    mutateConversations: mutate,
   };
 }
 

--- a/front/pages/w/[wId]/assistant/[cId]/index.tsx
+++ b/front/pages/w/[wId]/assistant/[cId]/index.tsx
@@ -1,7 +1,5 @@
 import { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
-import { useState } from "react";
-import { mutate } from "swr";
 
 import Conversation from "@app/components/assistant/conversation/Conversation";
 import { ConversationTitle } from "@app/components/assistant/conversation/ConversationTitle";
@@ -58,8 +56,6 @@ export default function AssistantConversation({
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const router = useRouter();
 
-  const [title, setTitle] = useState<string | null>(null);
-
   const handleSubmit = async (input: string, mentions: MentionType[]) => {
     // Create a new user message.
     const mRes = await fetch(
@@ -113,7 +109,8 @@ export default function AssistantConversation({
       topNavigationCurrent="assistant"
       titleChildren={
         <ConversationTitle
-          title={title || ""}
+          owner={owner}
+          conversationId={conversationId}
           shareLink={`${baseUrl}/w/${owner.sId}/assistant/${conversationId}`}
           onDelete={() => {
             void handdleDeleteConversation();
@@ -122,15 +119,7 @@ export default function AssistantConversation({
       }
       navChildren={<AssistantSidebarMenu owner={owner} />}
     >
-      <Conversation
-        owner={owner}
-        conversationId={conversationId}
-        onTitleUpdate={(title) => {
-          setTitle(title);
-          // We mutate the list of conversations so that the title gets updated.
-          void mutate(`/api/w/${owner.sId}/assistant/conversations`);
-        }}
-      />
+      <Conversation owner={owner} conversationId={conversationId} />
       <FixedAssistantInputBar owner={owner} onSubmit={handleSubmit} />
     </AppLayout>
   );

--- a/front/pages/w/[wId]/assistant/new.tsx
+++ b/front/pages/w/[wId]/assistant/new.tsx
@@ -144,7 +144,8 @@ export default function AssistantNew({
       titleChildren={
         conversation && (
           <ConversationTitle
-            title={conversation.title || ""}
+            owner={owner}
+            conversationId={conversation.sId}
             shareLink={`${baseUrl}/w/${owner.sId}/assistant/${conversation.sId}`}
           />
         )
@@ -321,13 +322,7 @@ export default function AssistantNew({
           </Page.Vertical>
         </div>
       ) : (
-        <Conversation
-          owner={owner}
-          conversationId={conversation.sId}
-          onTitleUpdate={() => {
-            // Nothing to do as this new page will be long gone by the time the title is updated.
-          }}
-        />
+        <Conversation owner={owner} conversationId={conversation.sId} />
       )}
 
       <FixedAssistantInputBar owner={owner} onSubmit={handleSubmit} />

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -126,7 +126,21 @@ export type ConversationType = {
   title: string | null;
   visibility: ConversationVisibility;
   content: (UserMessageType[] | AgentMessageType[])[];
-  participants: { id: string; name: string; pictureUrl: string | null }[];
+  participants: {
+    users: UserParticipant[];
+    agents: AgentParticipant[];
+  };
+};
+
+export type UserParticipant = {
+  userName: string;
+  name: string;
+  pictureUrl: string | null;
+};
+export type AgentParticipant = {
+  configurationId: string;
+  name: string;
+  pictureUrl: string | null;
 };
 
 /**

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -133,8 +133,8 @@ export type ConversationType = {
 };
 
 export type UserParticipant = {
-  userName: string;
-  name: string;
+  username: string;
+  fullName: string | null;
   pictureUrl: string | null;
 };
 export type AgentParticipant = {

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -126,6 +126,7 @@ export type ConversationType = {
   title: string | null;
   visibility: ConversationVisibility;
   content: (UserMessageType[] | AgentMessageType[])[];
+  participants: { id: string; name: string; pictureUrl: string | null }[];
 };
 
 /**


### PR DESCRIPTION
This PR adds a `participants` array to `ConversationType`, which is filled  on `getConversation`.

Then a few changes on the components `Conversation` and `ConversationTitle`: 
- `Conversation` is in charge of listening to the streamed events, and it calls mutate if there's a change. (No more logic with onTitleUpdate)
- `ConversationTitle` now loads the conversation with `useConversation`, meaning it will get automatically refreshed if any other component has used mutate. 

I want to rename `ConversationTitle` to `ConversationHeader` but I plan on doing it in a separate PR to not mess with the diff. 


Participants are displayed in the header: 
<img width="476" alt="Capture d’écran 2023-09-26 à 14 24 49" src="https://github.com/dust-tt/dust/assets/3803406/664a95b6-5436-49bb-8978-8336ef66e314">



