### PR TITLE
Move padding in dropdown menu from item*s* to item

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -307,7 +307,7 @@ function ErrorMessage({
           </DropdownMenu.Button>
           <div className="relative bottom-6 z-30">
             <DropdownMenu.Items origin="topLeft" width={320}>
-              <div className="flex flex-col gap-3 pb-3 pt-5">
+              <div className="flex flex-col gap-3 px-4 pb-3 pt-5">
                 <div className="text-sm font-normal text-warning-800">
                   {fullMessage}
                 </div>

--- a/front/components/assistant/conversation/ConversationTitle.tsx
+++ b/front/components/assistant/conversation/ConversationTitle.tsx
@@ -48,7 +48,7 @@ export function ConversationTitle({
                 />
               </DropdownMenu.Button>
               <DropdownMenu.Items width={280}>
-                <div className="flex flex-col gap-y-4 py-4">
+                <div className="flex flex-col gap-y-4 px-4 py-4">
                   <div className="flex flex-col gap-y-2">
                     <div className="grow text-sm font-medium text-element-800">
                       Are you sure you want to delete?
@@ -83,7 +83,7 @@ export function ConversationTitle({
             />
           </DropdownMenu.Button>
           <DropdownMenu.Items width={280}>
-            <div className="flex flex-col gap-y-4 py-4">
+            <div className="flex flex-col gap-y-4 p-4">
               <div className="flex flex-col gap-y-2">
                 <div className="grow text-sm font-medium text-element-800">
                   Share this conversation with others

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -815,7 +815,7 @@ export default function AssistantBuilder({
                   />
                 </DropdownMenu.Button>
                 <DropdownMenu.Items origin="bottomLeft" width={280}>
-                  <div className="flex flex-col gap-y-4 py-4">
+                  <div className="flex flex-col gap-y-4 px-4 py-4">
                     <div className="flex flex-col gap-y-2">
                       <div className="grow text-sm font-medium text-element-800">
                         Are you sure you want to delete?

--- a/front/components/sparkle/AppLayoutChatTitle.tsx
+++ b/front/components/sparkle/AppLayoutChatTitle.tsx
@@ -68,7 +68,7 @@ export function AppLayoutChatTitle({
                 />
               </DropdownMenu.Button>
               <DropdownMenu.Items width={280}>
-                <div className="flex flex-col gap-y-4 py-4">
+                <div className="flex flex-col gap-y-4 px-4 py-4">
                   <div className="flex flex-col gap-y-2">
                     <div className="flex flex-row">
                       <div className="grow text-sm font-medium text-element-800">

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@dust-tt/sparkle": "0.1.79",
+        "@dust-tt/sparkle": "0.1.80-pr-dropdown",
         "@headlessui/react": "^1.7.7",
         "@heroicons/react": "^2.0.11",
         "@nangohq/frontend": "^0.16.1",
@@ -718,9 +718,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.1.79",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.1.79.tgz",
-      "integrity": "sha512-zlAPXR3hkaNIKSY0dmWXoQK0G3sXHE1DLlZ7pA2zJtKdcCqtmth0ifUmR9ia0tBt0R/zrU97WzrpKwOQm3yrrw==",
+      "version": "0.1.80-pr-dropdown",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.1.80-pr-dropdown.tgz",
+      "integrity": "sha512-Qb0vW9qKTu7ORvUYfuRpQ3MhVXYONv3QbuR4QcmQpucvrr4ovrapcOmh4t5en01CvX2cW+uzivrsJMaw1I+MXg==",
       "dependencies": {
         "@headlessui/react": "^1.7.17"
       },

--- a/front/package.json
+++ b/front/package.json
@@ -13,7 +13,7 @@
     "initdb": "env $(cat .env.local) npx tsx admin/db.ts"
   },
   "dependencies": {
-    "@dust-tt/sparkle": "0.1.79",
+    "@dust-tt/sparkle": "0.1.80-pr-dropdown",
     "@headlessui/react": "^1.7.7",
     "@heroicons/react": "^2.0.11",
     "@nangohq/frontend": "^0.16.1",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.1.79",
+  "version": "0.1.80",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/components/DropdownMenu.tsx
+++ b/sparkle/src/components/DropdownMenu.tsx
@@ -213,6 +213,7 @@ DropdownMenu.Item = function ({
   return (
     <Menu.Item disabled={disabled} key={key}>
       <StandardItem
+        className="s-px-4"
         variant="dropdown"
         size="md"
         href={href}
@@ -300,7 +301,7 @@ DropdownMenu.Items = function ({
       <Menu.Items
         className={`s-absolute s-z-10 ${getOriginClass(
           origin
-        )} s-rounded-xl s-border s-border-structure-100 s-bg-structure-0 s-px-4 s-shadow-lg focus:s-outline-none dark:s-border-structure-100-dark dark:s-bg-structure-0-dark`}
+        )} s-rounded-xl s-border s-border-structure-100 s-bg-structure-0 s-shadow-lg focus:s-outline-none dark:s-border-structure-100-dark dark:s-bg-structure-0-dark`}
         style={styleInsert(origin)}
       >
         <StandardItem.List>{children}</StandardItem.List>


### PR DESCRIPTION
Required for implementation of create/manage assistant buttons design in selection menu, and search bar (issues #1622 and #1721), to have full-width border separators as per picture
![image](https://github.com/dust-tt/dust/assets/5437393/80ac3de3-cffa-4c36-b648-d21c6ee5c5c7)

Moreover seems rational that while Drowpdown.Item elements should have a standardized padding, custom stuff in the menu (non-itemized) may manage its padding

Each dropdown in code using DropdownMenu.Item(s) has been checked for the change to be non-breaking