### PR TITLE
Remove key param from DropdownMenu.Items

### DIFF
--- a/sparkle/src/components/DropdownMenu.tsx
+++ b/sparkle/src/components/DropdownMenu.tsx
@@ -197,7 +197,6 @@ interface DropdownItemProps {
   label: string;
   href?: string;
   disabled?: boolean;
-  key?: string;
   visual?: string | React.ReactNode;
   onClick?: () => void;
 }
@@ -206,12 +205,11 @@ DropdownMenu.Item = function ({
   label,
   href,
   disabled,
-  key = "",
   visual,
   onClick,
 }: DropdownItemProps) {
   return (
-    <Menu.Item disabled={disabled} key={key}>
+    <Menu.Item disabled={disabled}>
       <StandardItem
         className="s-px-4"
         variant="dropdown"

--- a/sparkle/src/stories/DropdownMenu.stories.tsx
+++ b/sparkle/src/stories/DropdownMenu.stories.tsx
@@ -120,8 +120,9 @@ export const DropdownExample = () => {
             <Avatar name="Dust" size="lg" onClick={() => ""} />
           </DropdownMenu.Button>
           <DropdownMenu.Items origin="topRight">
-            <DropdownMenu.Item label="item 1" href="#" />
-            <DropdownMenu.Item label="item 2" href="#" />
+            {["item 1", "item 2", "item 3"].map((item) => (
+              <DropdownMenu.Item label={item} href="#" key={item} />
+            ))}
           </DropdownMenu.Items>
         </DropdownMenu>
       </div>


### PR DESCRIPTION
This creates some errors on `front`. `key` is a special prop and cannot be handled here. 