### PR TITLE
fix: sparkle error log (forwardRef)

### DIFF
--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.1.84",
+  "version": "0.1.85",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/components/DropdownMenu.tsx
+++ b/sparkle/src/components/DropdownMenu.tsx
@@ -209,7 +209,8 @@ DropdownMenu.Item = function ({
   onClick,
 }: DropdownItemProps) {
   return (
-    <Menu.Item disabled={disabled}>
+    // need to use as="div" -- otherwise we get a "forwardRef" error in the console
+    <Menu.Item disabled={disabled} as="div">
       <StandardItem
         className="s-px-4"
         variant="dropdown"


### PR DESCRIPTION
This is kind of a headless UI bug IMO (or at the very least, a footgun), because the stock `Menu.Button` doesn't forward the ref. Using `as="div"` allows to actually forward it.

Quite a long fight to fix: https://github.com/orgs/dust-tt/projects/3?pane=issue&itemId=39805682