### PR TITLE
Fix title-overflow on mobile + button overflow on new conversation

### DIFF
--- a/front/components/sparkle/AppLayoutTitle.tsx
+++ b/front/components/sparkle/AppLayoutTitle.tsx
@@ -12,6 +12,7 @@ export function AppLayoutSimpleCloseTitle({
     <BarHeader
       title={title}
       rightActions={<BarHeader.ButtonBar variant="close" onClose={onClose} />}
+      className="ml-10 lg:ml-0"
     />
   );
 }
@@ -35,6 +36,7 @@ export function AppLayoutSimpleSaveCancelTitle({
           onSave={onSave}
         />
       }
+      className="ml-10 lg:ml-0"
     />
   );
 }

--- a/front/pages/w/[wId]/assistant/new.tsx
+++ b/front/pages/w/[wId]/assistant/new.tsx
@@ -194,7 +194,7 @@ export default function AssistantNew({
                   ))}
                 </div>
               </div>
-              <Button.List>
+              <Button.List isWrapping={true}>
                 {activeAgents.length > 4 && (
                   <Button
                     variant="primary"


### PR DESCRIPTION
Fixes #1656 

- set isWrapping true on the new conversations button list
- add a margin to the header bar on mobile to leave space for the hamburger