### PR TITLE
Seamless workspace onboarding if domain activated with google signin

### DIFF
--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -9,6 +9,15 @@ import {
 import { MembershipInvitationType } from "@app/types/membership_invitation";
 import { UserType } from "@app/types/user";
 
+export async function isWorkspaceAllowedOnDomain(wId: string) {
+  const workspace = await Workspace.findOne({
+    where: {
+      sId: wId,
+    },
+  });
+  return workspace && workspace.allowedDomain !== null;
+}
+
 /**
  * Returns the users members of the workspace associated with the authenticator (without listing
  * their own workspaces).

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -270,6 +270,11 @@ async function handler(
       }
 
       if (targetWorkspace) {
+        // For users joining a workspace from trying to access a conversation, we redirect to this conversation after signing in.
+        if (req.query.join === "true" && req.query.cId) {
+          res.redirect(`/w/${targetWorkspace.sId}/assistant/${req.query.cId}`);
+          return;
+        }
         res.redirect(`/w/${targetWorkspace.sId}`);
         return;
       }

--- a/front/pages/w/[wId]/assistant/[cId]/index.tsx
+++ b/front/pages/w/[wId]/assistant/[cId]/index.tsx
@@ -30,7 +30,7 @@ export const getServerSideProps: GetServerSideProps<{
   if (!owner || !auth.isUser() || !user) {
     return {
       redirect: {
-        destination: "/",
+        destination: `/w/${context.query.wId}/join?cId=${context.query.cId}`,
         permanent: false,
       },
     };

--- a/front/pages/w/[wId]/join.tsx
+++ b/front/pages/w/[wId]/join.tsx
@@ -7,7 +7,12 @@ import { isWorkspaceAllowedOnDomain } from "@app/lib/api/workspace";
 
 const { URL = "", GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps: GetServerSideProps = async (context) => {
+export const getServerSideProps: GetServerSideProps<{
+  wId: string;
+  cId: string;
+  gaTrackingId: string;
+  baseUrl: string;
+}> = async (context) => {
   const wId = context.query.wId as string;
   const cId = context.query.cId as string;
 

--- a/front/pages/w/[wId]/join.tsx
+++ b/front/pages/w/[wId]/join.tsx
@@ -1,0 +1,86 @@
+import { Logo } from "@dust-tt/sparkle";
+import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import { signIn } from "next-auth/react";
+
+import { GoogleSignInButton } from "@app/components/Button";
+import { isWorkspaceAllowedOnDomain } from "@app/lib/api/workspace";
+
+const { URL = "", GA_TRACKING_ID = "" } = process.env;
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const wId = context.query.wId as string;
+  const cId = context.query.cId as string;
+
+  if (!wId || !cId) {
+    return {
+      notFound: true,
+    };
+  }
+
+  const isAllowedOnDomain = await isWorkspaceAllowedOnDomain(wId);
+  if (!isAllowedOnDomain) {
+    return {
+      redirect: {
+        destination: "/",
+        permanent: false,
+      },
+    };
+  }
+
+  return {
+    props: {
+      wId: wId,
+      cId: cId,
+      baseUrl: URL,
+      gaTrackingId: GA_TRACKING_ID,
+    },
+  };
+};
+
+export default function Join({
+  wId,
+  cId,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  return (
+    <>
+      <div className="fixed bottom-0 left-0 right-0 top-0 -z-50 bg-slate-800" />
+      <main className="z-10 mx-6">
+        <div className="container mx-auto sm:max-w-3xl lg:max-w-4xl xl:max-w-5xl">
+          <div style={{ height: "10vh" }}></div>
+          <div className="grid grid-cols-1">
+            <div>
+              <Logo className="h-[48px] w-[192px] px-1" />
+            </div>
+            <p className="mt-16 font-objektiv text-4xl font-bold tracking-tighter text-slate-50 md:text-6xl">
+              <span className="text-red-400 sm:font-objektiv md:font-objektiv">
+                Secure AI assistant
+              </span>{" "}
+              <br />
+              with your company’s knowledge
+              <br />
+            </p>
+          </div>
+          <div className="h-10"></div>
+          <div>
+            <p className="font-regular mb-16 text-slate-400">
+              Glad to see you!
+              <br />
+              Please log-in or sign-up with your company email to access this
+              page.
+            </p>
+            <GoogleSignInButton
+              onClick={() =>
+                signIn("google", {
+                  callbackUrl: `/api/login?wId=${wId}&cId=${cId}&join=true`,
+                })
+              }
+            >
+              <img src="/static/google_white_32x32.png" className="h-4 w-4" />
+              <span className="ml-2 mr-1">Sign in with Google</span>
+            </GoogleSignInButton>
+          </div>
+        </div>
+      </main>
+    </>
+  );
+}

--- a/front/pages/w/[wId]/join.tsx
+++ b/front/pages/w/[wId]/join.tsx
@@ -70,7 +70,7 @@ export default function Join({
             <p className="font-regular mb-16 text-slate-400">
               Glad to see you!
               <br />
-              Please log-in or sign-up with your company email to access this
+              Please log in or sign up with your company email to access this
               page.
             </p>
             <GoogleSignInButton


### PR DESCRIPTION
When a non logged-in user is trying to access a conversation: 
- if the workspace has allowed a domain, we redirect to a new join page.
- otherwise, we send back to the homepage, as before.

The join page on the workspace folder, with this url: `w/[wId]/join?cId=[cId]` .
It looks like this: 
<img width="1800" alt="Capture d’écran 2023-09-26 à 21 45 36" src="https://github.com/dust-tt/dust/assets/3803406/63c0f1a4-becc-4d03-96ae-8043117876f3">

If they click on the signin button and login with an email address valid for the allowed domain, they are automatically added as user of the workspace and redirected to the conversation they were trying to access. 

If the domain is invalid we treat the error as before (i.e we display this:)
```
{"error":{"type":"workspace_auth_error","message":"You are not authorized to join this workspace (your domain: casquedelumiere.com), contact us at team@dust.tt for assistance."}}
```

Note: if you already have an account, and try to access a conversation for a workspace which you don't have membership for, you are redirected to the assistant/new for your workspace. This is the same behavior as before, no change.