### PR TITLE
Add index to mention.messageId

### DIFF
--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -470,6 +470,11 @@ Mention.init(
   {
     modelName: "mention",
     sequelize: front_sequelize,
+    indexes: [
+      {
+        fields: ["messageId"],
+      },
+    ],
   }
 );
 


### PR DESCRIPTION
Search on Mention.messageId have been performed 1000 times just today, and there is no index on this field.
This query is taking more time every time a new message is added.

Latency spike in production *could be* related to that. Let's see. 