### PR TITLE
Add login error page & handle domain error

### DIFF
--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -73,15 +73,10 @@ async function handler(
           }
 
           if (allowedDomain !== session.user.email.split("@")[1]) {
-            return apiError(req, res, {
-              status_code: 401,
-              api_error: {
-                type: "workspace_auth_error",
-                message: `You are not authorized to join this workspace (your domain: ${
-                  session.user.email.split("@")[1]
-                }), contact us at team@dust.tt for assistance.`,
-              },
-            });
+            res.redirect(
+              `/login-error?domain=${session.user.email.split("@")[1]}`
+            );
+            return;
           }
         }
       }

--- a/front/pages/login-error.tsx
+++ b/front/pages/login-error.tsx
@@ -1,0 +1,69 @@
+import { Button, Logo } from "@dust-tt/sparkle";
+import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import Link from "next/link";
+
+const { URL = "", GA_TRACKING_ID = "" } = process.env;
+
+export const getServerSideProps: GetServerSideProps<{
+  domain?: string;
+  gaTrackingId: string;
+  baseUrl: string;
+}> = async (context) => {
+  return {
+    props: {
+      domain: context.query.domain as string,
+      baseUrl: URL,
+      gaTrackingId: GA_TRACKING_ID,
+    },
+  };
+};
+
+export default function LoginError({
+  domain,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  return (
+    <>
+      <div className="fixed bottom-0 left-0 right-0 top-0 -z-50 bg-slate-800" />
+      <main className="z-10 mx-6">
+        <div className="container mx-auto sm:max-w-3xl lg:max-w-4xl xl:max-w-5xl">
+          <div style={{ height: "10vh" }}></div>
+          <div className="grid grid-cols-1">
+            <div>
+              <Logo className="h-[48px] w-[192px] px-1" />
+            </div>
+            <p className="mt-16 font-objektiv text-4xl font-bold tracking-tighter text-slate-50 md:text-6xl">
+              <span className="text-red-400 sm:font-objektiv md:font-objektiv">
+                Secure AI assistant
+              </span>{" "}
+              <br />
+              with your company’s knowledge
+              <br />
+            </p>
+          </div>
+          <div className="h-10"></div>
+          <div>
+            <p className="font-regular mb-8 text-slate-400">
+              We could not process your sign up request!
+            </p>
+            <p className="font-regular mb-8 text-slate-400">
+              {domain ? (
+                <>
+                  The domain @{domain} attached to your email address is not
+                  authorized to join this workspace.
+                  <br />
+                  Please contact your workspace admin to get access or contact
+                  us at team@dust.tt for assistance.
+                </>
+              ) : (
+                <>Please contact us at team@dust.tt for assistance.</>
+              )}
+            </p>
+            <Link href="/">
+              <Button variant="primary" label="Back to homepage" size="md" />
+            </Link>
+          </div>
+        </div>
+      </main>
+    </>
+  );
+}


### PR DESCRIPTION
We now display an error over a blank page with a json message if a user tries to log in on a workspace with whitelisted domain on the wrong domain! 

Before: 
```
{"error":{"type":"workspace_auth_error","message":"You are not authorized to join this workspace (your domain: casquedelumiere.com), contact us at team@dust.tt for assistance."}}
```

Now: 
<img width="974" alt="Capture d’écran 2023-09-28 à 09 30 43" src="https://github.com/dust-tt/dust/assets/3803406/77f12a20-2a5b-442a-8429-57f9b0a1282f">


Note: 
- We should handle a bunch of other errors from the login api route re-using this route! Can do it another PR if we want to!
