### PR TITLE
Fix missing key js error on Avatar Stack

### DIFF
--- a/sparkle/src/components/Avatar.tsx
+++ b/sparkle/src/components/Avatar.tsx
@@ -199,8 +199,9 @@ Avatar.Stack = function ({
         marginLeft: "20px",
       }}
     >
-      {childrenArray.map((child) => (
+      {childrenArray.map((child, i) => (
         <div
+          key={i}
           className="s-cursor-pointer s-drop-shadow-md"
           style={{
             width: isHovered ? sizeSetting.widthHovered : sizeSetting.width,


### PR DESCRIPTION
Add missing key on component AvatarStack.

Lazy me don't plan on bumping the version just for this change meaning it will be live when we introduce a bigger change in Sparkle. 


I know using index as key is not good practice for dynamic data, but for now on our use case the order won't change so I guess that's okay. 