### PR TITLE
Increase PGSQL connection pool for front

### DIFF
--- a/front/lib/databases.ts
+++ b/front/lib/databases.ts
@@ -4,6 +4,7 @@ const { FRONT_DATABASE_URI, XP1_DATABASE_URI } = process.env;
 
 export const front_sequelize = new Sequelize(FRONT_DATABASE_URI as string, {
   pool: {
+    // default is 5
     max: 10,
   },
   logging: false,

--- a/front/lib/databases.ts
+++ b/front/lib/databases.ts
@@ -3,6 +3,9 @@ import { Sequelize } from "sequelize";
 const { FRONT_DATABASE_URI, XP1_DATABASE_URI } = process.env;
 
 export const front_sequelize = new Sequelize(FRONT_DATABASE_URI as string, {
+  pool: {
+    max: 10,
+  },
   logging: false,
 });
 export const xp1_sequelize = new Sequelize(XP1_DATABASE_URI as string, {


### PR DESCRIPTION
Rational : 
We have been observing a spike in latency in the past few days.
We have simple HTTP queries like `GET /api/v1/w/[wId]/data_sources` taking 700ms, doing nothing except talking to PGSQL for a few seconds.

Our PG monitoring on Google Cloud shows that we have a total of 100 PG connections which includes front, connectors, connectors workers, core and XP1.

Doubling our connections pool on front should get us from 25 to 50 connections issued by front. For a grand total of 150 connections, with a limit of 500 set on our PG server.

