### PR TITLE
Introduce model MessageReaction

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -19,6 +19,7 @@ import {
   MembershipInvitation,
   Mention,
   Message,
+  MessageReaction,
   Provider,
   RetrievalDocument,
   RetrievalDocumentChunk,
@@ -66,6 +67,7 @@ async function main() {
   await UserMessage.sync({ alter: true });
   await AgentMessage.sync({ alter: true });
   await Message.sync({ alter: true });
+  await MessageReaction.sync({ alter: true });
   await Mention.sync({ alter: true });
 
   await XP1User.sync({ alter: true });

--- a/front/lib/models/index.ts
+++ b/front/lib/models/index.ts
@@ -17,6 +17,7 @@ import {
   ConversationParticipant,
   Mention,
   Message,
+  MessageReaction,
   UserMessage,
 } from "@app/lib/models/assistant/conversation";
 import { DataSource } from "@app/lib/models/data_source";
@@ -56,6 +57,7 @@ export {
   MembershipInvitation,
   Mention,
   Message,
+  MessageReaction,
   Provider,
   RetrievalDocument,
   RetrievalDocumentChunk,


### PR DESCRIPTION
### New model to store the reactions on a given Message.

Notes about some choices made here: 
- `MessageReaction` is attached to a `Message` and not necessarily an `AgentMessage`, because we might want to allow reacting on both. 
- `userId` is nullable as at some point we might want to fetch reactjis added to a message from the Slackbot. 
- I followed what was done in `UserMessage` and we store the username and fullName from the session, to be able to see who has reacted with which emoji. 
- The unique contraint is set on `["messageId", "reaction", "userContextUsername"]`. This is not perfect as it means we don't make the difference between daphne.popin account with a userId and daphne.popin from slack, but I think it's better than adding userId in the contraint (as postgre treats all NULL values as distinct from each other).

