### PR TITLE
enh: add retrievedAt column on retrievalDocument

### DIFF
--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -625,6 +625,7 @@ export async function* runRetrieval(
           documentId: d.documentId,
           reference: d.reference,
           timestamp: d.timestamp,
+          retrievedAt: new Date(d.timestamp),
           tags: d.tags,
           score: d.score,
           retrievalActionId: action.id,

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -625,7 +625,7 @@ export async function* runRetrieval(
           documentId: d.documentId,
           reference: d.reference,
           timestamp: d.timestamp,
-          retrievedAt: new Date(d.timestamp),
+          documentTimestamp: new Date(d.timestamp),
           tags: d.tags,
           score: d.score,
           retrievalActionId: action.id,

--- a/front/lib/models/assistant/actions/retrieval.ts
+++ b/front/lib/models/assistant/actions/retrieval.ts
@@ -313,7 +313,7 @@ export class RetrievalDocument extends Model<
   declare documentId: string;
   declare reference: string;
   declare timestamp: number;
-  declare retrievedAt: Date | null;
+  declare documentTimestamp: Date | null;
   declare tags: string[];
   declare score: number;
 
@@ -357,7 +357,7 @@ RetrievalDocument.init(
       type: DataTypes.BIGINT,
       allowNull: false,
     },
-    retrievedAt: {
+    documentTimestamp: {
       type: DataTypes.DATE,
       allowNull: true,
     },

--- a/front/lib/models/assistant/actions/retrieval.ts
+++ b/front/lib/models/assistant/actions/retrieval.ts
@@ -313,7 +313,7 @@ export class RetrievalDocument extends Model<
   declare documentId: string;
   declare reference: string;
   declare timestamp: number;
-  declare retrievedAt: Date;
+  declare retrievedAt: Date | null;
   declare tags: string[];
   declare score: number;
 
@@ -359,7 +359,7 @@ RetrievalDocument.init(
     },
     retrievedAt: {
       type: DataTypes.DATE,
-      allowNull: false,
+      allowNull: true,
     },
     tags: {
       type: DataTypes.ARRAY(DataTypes.STRING),

--- a/front/lib/models/assistant/actions/retrieval.ts
+++ b/front/lib/models/assistant/actions/retrieval.ts
@@ -313,6 +313,7 @@ export class RetrievalDocument extends Model<
   declare documentId: string;
   declare reference: string;
   declare timestamp: number;
+  declare retrievedAt: Date;
   declare tags: string[];
   declare score: number;
 
@@ -354,6 +355,10 @@ RetrievalDocument.init(
     },
     timestamp: {
       type: DataTypes.BIGINT,
+      allowNull: false,
+    },
+    retrievedAt: {
+      type: DataTypes.DATE,
       allowNull: false,
     },
     tags: {

--- a/front/migrations/20230929_retrieveal_docs_document_timestamp.sql
+++ b/front/migrations/20230929_retrieveal_docs_document_timestamp.sql
@@ -1,0 +1,4 @@
+UPDATE
+    "retrieval_documents"
+SET
+    "documentTimestamp" = to_timestamp("timestamp" / 1000);


### PR DESCRIPTION
fixing https://github.com/orgs/dust-tt/projects/3?pane=issue&itemId=40057879

step 1: this PR, adding the new `retrievedAt` field (nullable)
step 2: backfill the new column
step 3: update the code to only use retrievedAt
step 4: get rid of the timestamp column