### PR TITLE
Fix routers and mutation

### DIFF
--- a/front/components/ConnectorPermissionsModal.tsx
+++ b/front/components/ConnectorPermissionsModal.tsx
@@ -1,7 +1,7 @@
 import { Checkbox, Modal } from "@dust-tt/sparkle";
 import { Cog6ToothIcon } from "@heroicons/react/20/solid";
 import { useState } from "react";
-import { mutate } from "swr";
+import { useSWRConfig } from "swr";
 
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 import {
@@ -63,6 +63,8 @@ export default function ConnectorPermissionsModal({
   setOpen: (open: boolean) => void;
   onEditPermission: () => void;
 }) {
+  const { mutate } = useSWRConfig();
+
   const [updatedPermissionByInternalId, setUpdatedPermissionByInternalId] =
     useState<Record<string, ConnectorPermission>>({});
 

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -10,11 +10,11 @@ import {
   TrashIcon,
 } from "@dust-tt/sparkle";
 import * as t from "io-ts";
-import router from "next/router";
+import { useRouter } from "next/router";
 import { useCallback, useEffect, useState } from "react";
 import React from "react";
 import ReactTextareaAutosize from "react-textarea-autosize";
-import { mutate } from "swr";
+import { useSWRConfig } from "swr";
 
 import { AvatarPicker } from "@app/components/assistant_builder/AssistantBuilderAvatarPicker";
 import AssistantBuilderDataSourceModal from "@app/components/assistant_builder/AssistantBuilderDataSourceModal";
@@ -172,6 +172,9 @@ export default function AssistantBuilder({
   initialBuilderState,
   agentConfigurationId,
 }: AssistantBuilderProps) {
+  const router = useRouter();
+  const { mutate } = useSWRConfig();
+
   const [builderState, setBuilderState] = useState<AssistantBuilderState>({
     ...DEFAULT_ASSISTANT_STATE,
     generationSettings: {
@@ -477,6 +480,7 @@ export default function AssistantBuilder({
       return;
     }
 
+    await mutate(`/api/w/${owner.sId}/assistant/agent_configurations`);
     await router.push(`/w/${owner.sId}/builder/assistants`);
     setIsSavingOrDeleting(false);
   };
@@ -555,7 +559,7 @@ export default function AssistantBuilder({
                           await mutate(
                             `/api/w/${owner.sId}/assistant/agent_configurations`
                           );
-                          void router.push(
+                          await router.push(
                             `/w/${owner.sId}/builder/assistants`
                           );
                           setIsSavingOrDeleting(false);

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -14,7 +14,6 @@ import { useRouter } from "next/router";
 import { useCallback, useEffect, useState } from "react";
 import React from "react";
 import ReactTextareaAutosize from "react-textarea-autosize";
-import { useSWRConfig } from "swr";
 
 import { AvatarPicker } from "@app/components/assistant_builder/AssistantBuilderAvatarPicker";
 import AssistantBuilderDataSourceModal from "@app/components/assistant_builder/AssistantBuilderDataSourceModal";
@@ -173,7 +172,6 @@ export default function AssistantBuilder({
   agentConfigurationId,
 }: AssistantBuilderProps) {
   const router = useRouter();
-  const { mutate } = useSWRConfig();
 
   const [builderState, setBuilderState] = useState<AssistantBuilderState>({
     ...DEFAULT_ASSISTANT_STATE,
@@ -479,8 +477,6 @@ export default function AssistantBuilder({
       setIsSavingOrDeleting(false);
       return;
     }
-
-    await mutate(`/api/w/${owner.sId}/assistant/agent_configurations`);
     await router.push(`/w/${owner.sId}/builder/assistants`);
     setIsSavingOrDeleting(false);
   };
@@ -556,9 +552,6 @@ export default function AssistantBuilder({
                       setIsSavingOrDeleting(true);
                       submitForm()
                         .then(async () => {
-                          await mutate(
-                            `/api/w/${owner.sId}/assistant/agent_configurations`
-                          );
                           await router.push(
                             `/w/${owner.sId}/builder/assistants`
                           );

--- a/front/lib/user.ts
+++ b/front/lib/user.ts
@@ -1,4 +1,4 @@
-import { mutate } from "swr";
+import { useSWRConfig } from "swr";
 
 import { GetUserMetadataResponseBody } from "@app/pages/api/user/metadata/[key]";
 import { UserMetadataType } from "@app/types/user";
@@ -31,6 +31,8 @@ export async function getUserMetadataFromClient(key: string) {
  * @param metadata MetadataType the metadata to set for the current user.
  */
 export function setUserMetadataFromClient(metadata: UserMetadataType) {
+  const { mutate } = useSWRConfig();
+
   void (async () => {
     try {
       const res = await fetch(

--- a/front/pages/w/[wId]/a/[aId]/datasets/[name]/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/datasets/[name]/index.tsx
@@ -2,7 +2,7 @@ import "@uiw/react-textarea-code-editor/dist.css";
 
 import { Button, Tab } from "@dust-tt/sparkle";
 import { GetServerSideProps, InferGetServerSidePropsType } from "next";
-import Router, { useRouter } from "next/router";
+import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 
 import DatasetView from "@app/components/app/DatasetView";
@@ -87,6 +87,8 @@ export default function ViewDatasetView({
   dataset,
   gaTrackingId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  const router = useRouter();
+
   const [disable, setDisabled] = useState(true);
   const [loading, setLoading] = useState(false);
 
@@ -102,7 +104,7 @@ export default function ViewDatasetView({
   // this should happen.
   useEffect(() => {
     if (isFinishedEditing) {
-      void Router.push(`/w/${owner.sId}/a/${app.sId}/datasets`);
+      void router.push(`/w/${owner.sId}/a/${app.sId}/datasets`);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isFinishedEditing]);
@@ -145,8 +147,6 @@ export default function ViewDatasetView({
     setEditorDirty(false);
     setIsFinishedEditing(true);
   };
-
-  const router = useRouter();
 
   return (
     <AppLayout

--- a/front/pages/w/[wId]/a/[aId]/datasets/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/datasets/index.tsx
@@ -1,7 +1,7 @@
 import { Button, PlusIcon, Tab, TrashIcon } from "@dust-tt/sparkle";
 import { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import Link from "next/link";
-import Router, { useRouter } from "next/router";
+import { useRouter } from "next/router";
 
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
@@ -73,6 +73,8 @@ export default function DatasetsView({
   datasets,
   gaTrackingId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  const router = useRouter();
+
   const handleDelete = async (datasetName: string) => {
     if (confirm("Are you sure you want to delete this dataset entirely?")) {
       await fetch(
@@ -84,11 +86,9 @@ export default function DatasetsView({
           },
         }
       );
-      await Router.push(`/w/${owner.sId}/a/${app.sId}/datasets`);
+      await router.push(`/w/${owner.sId}/a/${app.sId}/datasets`);
     }
   };
-
-  const router = useRouter();
 
   return (
     <AppLayout

--- a/front/pages/w/[wId]/a/[aId]/datasets/new.tsx
+++ b/front/pages/w/[wId]/a/[aId]/datasets/new.tsx
@@ -2,7 +2,7 @@ import "@uiw/react-textarea-code-editor/dist.css";
 
 import { Button, Tab } from "@dust-tt/sparkle";
 import { GetServerSideProps, InferGetServerSidePropsType } from "next";
-import Router, { useRouter } from "next/router";
+import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 
 import DatasetView from "@app/components/app/DatasetView";
@@ -71,6 +71,8 @@ export default function NewDatasetView({
   datasets,
   gaTrackingId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  const router = useRouter();
+
   const [disable, setDisabled] = useState(true);
   const [loading, setLoading] = useState(false);
   const [dataset, setDataset] = useState(null as DatasetType | null);
@@ -86,7 +88,7 @@ export default function NewDatasetView({
   // this should happen.
   useEffect(() => {
     if (isFinishedEditing) {
-      void Router.push(`/w/${owner.sId}/a/${app.sId}/datasets`);
+      void router.push(`/w/${owner.sId}/a/${app.sId}/datasets`);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isFinishedEditing]);
@@ -118,8 +120,6 @@ export default function NewDatasetView({
     setEditorDirty(false);
     setIsFinishedEditing(true);
   };
-
-  const router = useRouter();
 
   return (
     <AppLayout

--- a/front/pages/w/[wId]/a/[aId]/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/index.tsx
@@ -9,7 +9,7 @@ import {
 import { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 import { useRef, useState } from "react";
-import { mutate } from "swr";
+import { useSWRConfig } from "swr";
 
 import Deploy from "@app/components/app/Deploy";
 import NewBlock from "@app/components/app/NewBlock";
@@ -147,6 +147,8 @@ export default function AppView({
   url,
   gaTrackingId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  const { mutate } = useSWRConfig();
+
   const [spec, setSpec] = useState(
     JSON.parse(app.savedSpecification || `[]`) as SpecificationType
   );

--- a/front/pages/w/[wId]/a/index.tsx
+++ b/front/pages/w/[wId]/a/index.tsx
@@ -10,7 +10,7 @@ import { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { useState } from "react";
-import { mutate } from "swr";
+import { useSWRConfig } from "swr";
 
 import AI21Setup from "@app/components/providers/AI21Setup";
 import AnthropicSetup from "@app/components/providers/AnthropicSetup";
@@ -77,6 +77,8 @@ export const getServerSideProps: GetServerSideProps<{
 };
 
 export function APIKeys({ owner }: { owner: WorkspaceType }) {
+  const { mutate } = useSWRConfig();
+
   const { keys } = useKeys(owner);
   const [isRevealed, setIsRevealed] = useState(
     {} as { [key: string]: boolean }

--- a/front/pages/w/[wId]/builder/data-sources/[name]/settings.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/settings.tsx
@@ -3,7 +3,7 @@ import { ChevronRightIcon } from "@heroicons/react/20/solid";
 import { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 import { useCallback, useEffect, useState } from "react";
-import { mutate } from "swr";
+import { useSWRConfig } from "swr";
 
 import ModelPicker from "@app/components/app/ModelPicker";
 import AppLayout from "@app/components/sparkle/AppLayout";
@@ -159,6 +159,8 @@ function StandardDataSourceSettings({
   }) => Promise<void>;
   gaTrackingId: string;
 }) {
+  const { mutate } = useSWRConfig();
+
   const dataSourceConfig = JSON.parse(dataSource.config || "{}");
 
   const [dataSourceDescription, setDataSourceDescription] = useState(

--- a/front/pages/w/[wId]/u/extract/templates/[sId]/index.tsx
+++ b/front/pages/w/[wId]/u/extract/templates/[sId]/index.tsx
@@ -16,7 +16,7 @@ import Link from "next/link";
 import { useRouter } from "next/router";
 import React, { Fragment } from "react";
 import { useState } from "react";
-import { mutate } from "swr";
+import { useSWRConfig } from "swr";
 
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { subNavigationAdmin } from "@app/components/sparkle/navigation";
@@ -78,6 +78,8 @@ export default function AppExtractEventsReadData({
   gaTrackingId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const router = useRouter();
+  const { mutate } = useSWRConfig();
+
   const [isProcessing, setIsProcessing] = useState(false);
   const { events, isEventsLoading } = useExtractedEvents({
     owner,

--- a/front/pages/w/[wId]/workspace/index.tsx
+++ b/front/pages/w/[wId]/workspace/index.tsx
@@ -9,7 +9,7 @@ import { Listbox } from "@headlessui/react";
 import { CheckIcon } from "@heroicons/react/20/solid";
 import { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import React, { useCallback, useEffect, useState } from "react";
-import { mutate } from "swr";
+import { useSWRConfig } from "swr";
 
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { subNavigationAdmin } from "@app/components/sparkle/navigation";
@@ -56,6 +56,8 @@ export default function WorkspaceAdmin({
   gaTrackingId,
   url,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  const { mutate } = useSWRConfig();
+
   const [disable, setDisabled] = useState(true);
   const [updating, setUpdating] = useState(false);
 


### PR DESCRIPTION
NextJS recommends using useRouter and useSWRConfig (for mutate)

After testing, after all the lack of mutation was due to the use of `import router from ...` instead of using `userRouter`. Fixed that and cleaned-up all use of router and mutate.