### PR TITLE
Route &clib to POST message reaction + retrieve reactions

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -473,6 +473,37 @@ export async function getConversation(
   };
 }
 
+export async function getConversationWithoutContent(
+  auth: Authenticator,
+  conversationId: string,
+  includeDeleted?: boolean
+): Promise<ConversationWithoutContentType | null> {
+  const owner = auth.workspace();
+  if (!owner) {
+    throw new Error("Unexpected `auth` without `workspace`.");
+  }
+
+  const conversation = await Conversation.findOne({
+    where: {
+      sId: conversationId,
+      workspaceId: owner.id,
+      ...(includeDeleted ? {} : { visibility: { [Op.ne]: "deleted" } }),
+    },
+  });
+
+  if (!conversation) {
+    return null;
+  }
+
+  return {
+    id: conversation.id,
+    created: conversation.createdAt.getTime(),
+    sId: conversation.sId,
+    owner,
+    title: conversation.title,
+  };
+}
+
 /**
  * Title generation
  */

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -18,6 +18,7 @@ import {
   GenerationTokensEvent,
   renderConversationForModel,
 } from "@app/lib/api/assistant/generation";
+import { renderMessageReactions } from "@app/lib/api/assistant/reaction";
 import { Authenticator } from "@app/lib/auth";
 import { front_sequelize } from "@app/lib/databases";
 import {
@@ -26,6 +27,7 @@ import {
   ConversationParticipant,
   Mention,
   Message,
+  MessageReaction,
   User,
   UserMessage,
 } from "@app/lib/models";
@@ -242,6 +244,9 @@ async function renderUserMessage(
       email: userMessage.userContextEmail,
       profilePictureUrl: userMessage.userContextProfilePictureUrl,
     },
+    reactions: message.reactions
+      ? renderMessageReactions(message.reactions)
+      : [],
   };
 }
 
@@ -293,7 +298,9 @@ async function renderAgentMessage(
     status: agentMessage.status,
     action: agentRetrievalAction,
     content: agentMessage.content,
-    feedbacks: [],
+    reactions: message.reactions
+      ? renderMessageReactions(message.reactions)
+      : [],
     error,
     configuration: agentConfiguration,
   };
@@ -395,6 +402,11 @@ export async function getConversation(
       {
         model: AgentMessage,
         as: "agentMessage",
+        required: false,
+      },
+      {
+        model: MessageReaction,
+        as: "reactions",
         required: false,
       },
     ],
@@ -707,6 +719,7 @@ export async function* postUserMessage(
         mentions: mentions,
         content,
         context: context,
+        reactions: [],
       };
 
       const results: ({ row: AgentMessage; m: AgentMessageType } | null)[] =
@@ -765,7 +778,7 @@ export async function* postUserMessage(
                   status: "created",
                   action: null,
                   content: null,
-                  feedbacks: [],
+                  reactions: [],
                   error: null,
                   configuration,
                 },
@@ -1087,6 +1100,7 @@ export async function* editUserMessage(
         mentions,
         content,
         context: message.context,
+        reactions: [],
       };
 
       // For now agent messages are appended at the end of conversation
@@ -1155,7 +1169,7 @@ export async function* editUserMessage(
                   status: "created",
                   action: null,
                   content: null,
-                  feedbacks: [],
+                  reactions: [],
                   error: null,
                   configuration,
                 },
@@ -1336,7 +1350,7 @@ export async function* retryAgentMessage(
       status: "created",
       action: null,
       content: null,
-      feedbacks: [],
+      reactions: [],
       error: null,
       configuration: message.configuration,
     };

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -18,7 +18,6 @@ import {
   GenerationTokensEvent,
   renderConversationForModel,
 } from "@app/lib/api/assistant/generation";
-import { renderMessageReactions } from "@app/lib/api/assistant/reaction";
 import { Authenticator } from "@app/lib/auth";
 import { front_sequelize } from "@app/lib/databases";
 import {
@@ -27,7 +26,6 @@ import {
   ConversationParticipant,
   Mention,
   Message,
-  MessageReaction,
   User,
   UserMessage,
 } from "@app/lib/models";
@@ -244,9 +242,6 @@ async function renderUserMessage(
       email: userMessage.userContextEmail,
       profilePictureUrl: userMessage.userContextProfilePictureUrl,
     },
-    reactions: message.reactions
-      ? renderMessageReactions(message.reactions)
-      : [],
   };
 }
 
@@ -298,9 +293,6 @@ async function renderAgentMessage(
     status: agentMessage.status,
     action: agentRetrievalAction,
     content: agentMessage.content,
-    reactions: message.reactions
-      ? renderMessageReactions(message.reactions)
-      : [],
     error,
     configuration: agentConfiguration,
   };
@@ -402,11 +394,6 @@ export async function getConversation(
       {
         model: AgentMessage,
         as: "agentMessage",
-        required: false,
-      },
-      {
-        model: MessageReaction,
-        as: "reactions",
         required: false,
       },
     ],
@@ -719,7 +706,6 @@ export async function* postUserMessage(
         mentions: mentions,
         content,
         context: context,
-        reactions: [],
       };
 
       const results: ({ row: AgentMessage; m: AgentMessageType } | null)[] =
@@ -778,7 +764,6 @@ export async function* postUserMessage(
                   status: "created",
                   action: null,
                   content: null,
-                  reactions: [],
                   error: null,
                   configuration,
                 },
@@ -1100,7 +1085,6 @@ export async function* editUserMessage(
         mentions,
         content,
         context: message.context,
-        reactions: [],
       };
 
       // For now agent messages are appended at the end of conversation
@@ -1169,7 +1153,6 @@ export async function* editUserMessage(
                   status: "created",
                   action: null,
                   content: null,
-                  reactions: [],
                   error: null,
                   configuration,
                 },
@@ -1350,7 +1333,6 @@ export async function* retryAgentMessage(
       status: "created",
       action: null,
       content: null,
-      reactions: [],
       error: null,
       configuration: message.configuration,
     };

--- a/front/lib/api/assistant/reaction.ts
+++ b/front/lib/api/assistant/reaction.ts
@@ -1,0 +1,82 @@
+import { Authenticator } from "@app/lib/auth";
+import { ModelId } from "@app/lib/databases";
+import { Message, MessageReaction } from "@app/lib/models";
+import { MessageReactionType } from "@app/types/assistant/conversation";
+
+export async function addOrRemoveMessageReaction(
+  auth: Authenticator,
+  {
+    messageId,
+    userId,
+    userContextUsername,
+    userContextFullName,
+    reaction,
+  }: {
+    messageId: string;
+    userId: ModelId;
+    userContextUsername: string;
+    userContextFullName: string | null;
+    reaction: string;
+  }
+): Promise<boolean | null> {
+  const owner = auth.workspace();
+  if (!owner) {
+    throw new Error("Unexpected `auth` without `workspace`.");
+  }
+
+  const message = await Message.findOne({
+    where: {
+      sId: messageId,
+    },
+  });
+
+  if (!message) {
+    return null;
+  }
+
+  const existingReaction = await MessageReaction.findOne({
+    where: {
+      messageId: message.id,
+      userId,
+      reaction,
+    },
+  });
+  if (existingReaction) {
+    await existingReaction.destroy();
+    return true;
+  }
+
+  const r = await MessageReaction.create({
+    messageId: message.id,
+    userId,
+    userContextUsername,
+    userContextFullName,
+    reaction,
+  });
+  return r !== null;
+}
+
+export function renderMessageReactions(
+  reactions: MessageReaction[]
+): MessageReactionType[] {
+  return reactions.reduce<MessageReactionType[]>((acc, r) => {
+    const reaction = acc.find((r2) => r2.emoji === r.reaction);
+    if (reaction) {
+      reaction.users.push({
+        username: r.userContextUsername,
+        fullName: r.userContextFullName,
+      });
+    } else {
+      acc.push({
+        emoji: r.reaction,
+        users: [
+          {
+            username: r.userContextUsername,
+            fullName: r.userContextFullName,
+          },
+        ],
+      });
+    }
+    return acc;
+  }, []);
+}

--- a/front/lib/api/assistant/reaction.ts
+++ b/front/lib/api/assistant/reaction.ts
@@ -1,62 +1,43 @@
 import { Authenticator } from "@app/lib/auth";
 import { ModelId } from "@app/lib/databases";
 import { Message, MessageReaction } from "@app/lib/models";
-import { MessageReactionType } from "@app/types/assistant/conversation";
+import {
+  ConversationMessageReactions,
+  MessageReactionType,
+} from "@app/types/assistant/conversation";
 
-export async function addOrRemoveMessageReaction(
+/**
+ * We retrieve the reactions for a whole conversation, not just a single message.
+ */
+export async function getMessageReactions(
   auth: Authenticator,
-  {
-    messageId,
-    userId,
-    userContextUsername,
-    userContextFullName,
-    reaction,
-  }: {
-    messageId: string;
-    userId: ModelId;
-    userContextUsername: string;
-    userContextFullName: string | null;
-    reaction: string;
-  }
-): Promise<boolean | null> {
+  conversationId: ModelId
+): Promise<ConversationMessageReactions | null> {
   const owner = auth.workspace();
   if (!owner) {
     throw new Error("Unexpected `auth` without `workspace`.");
   }
 
-  const message = await Message.findOne({
+  const messages = await Message.findAll({
     where: {
-      sId: messageId,
+      conversationId: conversationId,
     },
+    include: [
+      {
+        model: MessageReaction,
+        as: "reactions",
+        required: false,
+      },
+    ],
   });
 
-  if (!message) {
-    return null;
-  }
-
-  const existingReaction = await MessageReaction.findOne({
-    where: {
-      messageId: message.id,
-      userId,
-      reaction,
-    },
-  });
-  if (existingReaction) {
-    await existingReaction.destroy();
-    return true;
-  }
-
-  const r = await MessageReaction.create({
-    messageId: message.id,
-    userId,
-    userContextUsername,
-    userContextFullName,
-    reaction,
-  });
-  return r !== null;
+  return messages.map((m) => ({
+    messageId: m.sId,
+    reactions: _renderMessageReactions(m.reactions || []),
+  }));
 }
 
-export function renderMessageReactions(
+function _renderMessageReactions(
   reactions: MessageReaction[]
 ): MessageReactionType[] {
   return reactions.reduce<MessageReactionType[]>((acc, r) => {
@@ -79,4 +60,98 @@ export function renderMessageReactions(
     }
     return acc;
   }, []);
+}
+
+/**
+ * We create a reaction for a single message.
+ * As user can be null (user from Slack), we also store the user context, as we do for messages.
+ */
+export async function createMessageReaction(
+  auth: Authenticator,
+  {
+    messageId,
+    userId,
+    context,
+    reaction,
+  }: {
+    messageId: string;
+    userId: ModelId | null;
+    context: {
+      username: string;
+      fullName: string | null;
+    };
+    reaction: string;
+  }
+): Promise<boolean | null> {
+  const owner = auth.workspace();
+  if (!owner) {
+    throw new Error("Unexpected `auth` without `workspace`.");
+  }
+
+  const message = await Message.findOne({
+    where: {
+      sId: messageId,
+    },
+  });
+
+  if (!message) {
+    return null;
+  }
+
+  const newReaction = await MessageReaction.create({
+    messageId: message.id,
+    userId,
+    userContextUsername: context.username,
+    userContextFullName: context.fullName,
+    reaction,
+  });
+  return newReaction !== null;
+}
+
+/**
+ * The id of a reaction is not exposed on the API so we need to find it from the message id and the user context.
+ * We destroy reactions, no point in soft-deleting them.
+ */
+export async function deleteMessageReaction(
+  auth: Authenticator,
+  {
+    messageId,
+    userId,
+    context,
+    reaction,
+  }: {
+    messageId: string;
+    userId: ModelId | null;
+    context: {
+      username: string;
+      fullName: string | null;
+    };
+    reaction: string;
+  }
+): Promise<boolean | null> {
+  const owner = auth.workspace();
+  if (!owner) {
+    throw new Error("Unexpected `auth` without `workspace`.");
+  }
+
+  const message = await Message.findOne({
+    where: {
+      sId: messageId,
+    },
+  });
+
+  if (!message) {
+    return null;
+  }
+
+  const deletedReaction = await MessageReaction.destroy({
+    where: {
+      messageId: message.id,
+      userId,
+      userContextUsername: context.username,
+      userContextFullName: context.fullName,
+      reaction,
+    },
+  });
+  return deletedReaction === 1;
 }

--- a/front/lib/error.ts
+++ b/front/lib/error.ts
@@ -44,6 +44,7 @@ export type APIErrorType =
   | "conversation_not_found"
   | "agent_configuration_not_found"
   | "message_not_found"
+  | "message_reaction_error"
   | "global_agent_error";
 
 export type APIError = {

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -336,6 +336,7 @@ export class Message extends Model<
 
   declare userMessage?: NonAttribute<UserMessage>;
   declare agentMessage?: NonAttribute<AgentMessage>;
+  declare reactions?: NonAttribute<MessageReaction[]>;
 }
 
 Message.init(
@@ -492,6 +493,7 @@ MessageReaction.init(
 );
 
 Message.hasMany(MessageReaction, {
+  as: "reactions",
   foreignKey: { name: "messageId", allowNull: false },
   onDelete: "CASCADE",
 });

--- a/front/lib/swr.ts
+++ b/front/lib/swr.ts
@@ -18,7 +18,10 @@ import { GetProvidersResponseBody } from "@app/pages/api/w/[wId]/providers";
 import { GetExtractedEventsResponseBody } from "@app/pages/api/w/[wId]/use/extract/events/[sId]";
 import { GetEventSchemasResponseBody } from "@app/pages/api/w/[wId]/use/extract/templates";
 import { AppType } from "@app/types/app";
-import { ConversationType } from "@app/types/assistant/conversation";
+import {
+  ConversationMessageReactions,
+  ConversationType,
+} from "@app/types/assistant/conversation";
 import { DataSourceType } from "@app/types/data_source";
 import { RunRunType } from "@app/types/run";
 import { WorkspaceType } from "@app/types/user";
@@ -387,6 +390,30 @@ export function useConversations({ workspaceId }: { workspaceId: string }) {
     isConversationsLoading: !error && !data,
     isConversationsError: error,
     mutateConversations: mutate,
+  };
+}
+
+export function useConversationReactions({
+  conversationId,
+  workspaceId,
+}: {
+  conversationId: string;
+  workspaceId: string;
+}) {
+  const conversationReactionsFetcher: Fetcher<{
+    reactions: ConversationMessageReactions;
+  }> = fetcher;
+
+  const { data, error, mutate } = useSWR(
+    `/api/w/${workspaceId}/assistant/conversations/${conversationId}/reactions`,
+    conversationReactionsFetcher
+  );
+
+  return {
+    reactions: data ? data.reactions : null,
+    isReactionsLoading: !error && !data,
+    isReactionsError: error,
+    mutateReactions: mutate,
   };
 }
 

--- a/front/lib/swr.ts
+++ b/front/lib/swr.ts
@@ -410,7 +410,7 @@ export function useConversationReactions({
   );
 
   return {
-    reactions: data ? data.reactions : null,
+    reactions: data ? data.reactions : [],
     isReactionsLoading: !error && !data,
     isReactionsError: error,
     mutateReactions: mutate,

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/reactions/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/reactions/index.ts
@@ -1,0 +1,138 @@
+import { isLeft } from "fp-ts/lib/Either";
+import * as t from "io-ts";
+import * as reporter from "io-ts-reporters";
+import { NextApiRequest, NextApiResponse } from "next";
+
+import { getConversation } from "@app/lib/api/assistant/conversation";
+import { addOrRemoveMessageReaction } from "@app/lib/api/assistant/reaction";
+import { Authenticator, getSession } from "@app/lib/auth";
+import { ReturnedAPIErrorType } from "@app/lib/error";
+import { apiError, withLogging } from "@app/logger/withlogging";
+
+export const PostReactionRequestBodySchema = t.type({
+  reaction: t.string,
+});
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<{ success: boolean } | ReturnedAPIErrorType>
+): Promise<void> {
+  const session = await getSession(req, res);
+  const auth = await Authenticator.fromSession(
+    session,
+    req.query.wId as string
+  );
+
+  const owner = auth.workspace();
+  if (!owner) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "The workspace you're trying to modify was not found.",
+      },
+    });
+  }
+
+  const user = auth.user();
+  if (!user) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_user_not_found",
+        message: "Could not find the user of the current session.",
+      },
+    });
+  }
+
+  if (!auth.isUser()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "Only users of the current workspace can add reactions.",
+      },
+    });
+  }
+  if (!(typeof req.query.cId === "string")) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid query parameters, `cId` (string) is required.",
+      },
+    });
+  }
+
+  const conversationId = req.query.cId;
+  const conversation = await getConversation(auth, conversationId);
+  if (!conversation) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "conversation_not_found",
+        message: "Conversation not found.",
+      },
+    });
+  }
+
+  if (!(typeof req.query.mId === "string")) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid query parameters, `mId` (string) is required.",
+      },
+    });
+  }
+  const messageId = req.query.mId;
+
+  switch (req.method) {
+    case "POST":
+      const bodyValidation = PostReactionRequestBodySchema.decode(req.body);
+
+      if (isLeft(bodyValidation)) {
+        const pathError = reporter.formatValidationErrors(bodyValidation.left);
+
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid request body: ${pathError}`,
+          },
+        });
+      }
+      const { reaction } = bodyValidation.right;
+      const created = await addOrRemoveMessageReaction(auth, {
+        messageId,
+        userId: user.id,
+        userContextUsername: user.username,
+        userContextFullName: user.name,
+        reaction,
+      });
+
+      if (created) {
+        res.status(200).json({ success: true });
+        return;
+      } else {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "message_reaction_error",
+            message: "Message reaction not created.",
+          },
+        });
+      }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, POST is expected.",
+        },
+      });
+  }
+}
+
+export default withLogging(handler);

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/reactions/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/reactions/index.ts
@@ -3,7 +3,7 @@ import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 import { NextApiRequest, NextApiResponse } from "next";
 
-import { getConversation } from "@app/lib/api/assistant/conversation";
+import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation";
 import {
   createMessageReaction,
   deleteMessageReaction,
@@ -73,7 +73,10 @@ async function handler(
   }
 
   const conversationId = req.query.cId;
-  const conversation = await getConversation(auth, conversationId);
+  const conversation = await getConversationWithoutContent(
+    auth,
+    conversationId
+  );
   if (!conversation) {
     return apiError(req, res, {
       status_code: 404,
@@ -111,7 +114,8 @@ async function handler(
     case "POST":
       const created = await createMessageReaction(auth, {
         messageId,
-        userId: user.id,
+        conversation,
+        user: user,
         context: {
           username: user.username,
           fullName: user.name,
@@ -134,7 +138,8 @@ async function handler(
     case "DELETE":
       const deleted = await deleteMessageReaction(auth, {
         messageId,
-        userId: user.id,
+        conversation,
+        user: user,
         context: {
           username: user.username,
           fullName: user.name,

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/reactions.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/reactions.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from "next";
 
-import { getConversation } from "@app/lib/api/assistant/conversation";
+import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation";
 import { getMessageReactions } from "@app/lib/api/assistant/reaction";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { ReturnedAPIErrorType } from "@app/lib/error";
@@ -61,7 +61,10 @@ async function handler(
   }
 
   const conversationId = req.query.cId;
-  const conversation = await getConversation(auth, conversationId);
+  const conversation = await getConversationWithoutContent(
+    auth,
+    conversationId
+  );
   if (!conversation) {
     return apiError(req, res, {
       status_code: 404,
@@ -74,7 +77,7 @@ async function handler(
 
   switch (req.method) {
     case "GET":
-      const reactions = await getMessageReactions(auth, conversation.id);
+      const reactions = await getMessageReactions(auth, conversation);
       if (reactions) {
         res.status(200).json({ reactions });
         return;

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -1,5 +1,4 @@
 import { ModelId } from "@app/lib/databases";
-import { MessageReaction } from "@app/lib/models";
 import { UserType, WorkspaceType } from "@app/types/user";
 
 import { RetrievalActionType } from "./actions/retrieval";
@@ -42,6 +41,7 @@ export type ConversationMessageReactions = {
 export type MessageReactionType = {
   emoji: string;
   users: {
+    userId: ModelId | null;
     username: string;
     fullName: string | null;
   }[];

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -34,6 +34,11 @@ export function isUserMention(arg: MentionType): arg is UserMention {
   );
 }
 
+export type ConversationMessageReactions = {
+  messageId: string;
+  reactions: MessageReactionType[];
+}[];
+
 export type MessageReactionType = {
   emoji: string;
   users: {
@@ -64,7 +69,6 @@ export type UserMessageType = {
   mentions: MentionType[];
   content: string;
   context: UserMessageContext;
-  reactions: MessageReactionType[];
 };
 
 export function isUserMessageType(
@@ -103,7 +107,6 @@ export type AgentMessageType = {
     code: string;
     message: string;
   } | null;
-  reactions: MessageReactionType[];
 };
 
 export function isAgentMessageType(

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -1,4 +1,5 @@
 import { ModelId } from "@app/lib/databases";
+import { MessageReaction } from "@app/lib/models";
 import { UserType, WorkspaceType } from "@app/types/user";
 
 import { RetrievalActionType } from "./actions/retrieval";
@@ -33,6 +34,14 @@ export function isUserMention(arg: MentionType): arg is UserMention {
   );
 }
 
+export type MessageReactionType = {
+  emoji: string;
+  users: {
+    username: string;
+    fullName: string | null;
+  }[];
+};
+
 /**
  * User messages
  */
@@ -55,6 +64,7 @@ export type UserMessageType = {
   mentions: MentionType[];
   content: string;
   context: UserMessageContext;
+  reactions: MessageReactionType[];
 };
 
 export function isUserMessageType(
@@ -66,12 +76,6 @@ export function isUserMessageType(
 /**
  * Agent messages
  */
-
-export type UserFeedbackType = {
-  user: UserType;
-  value: "positive" | "negative" | null;
-  comment: string | null;
-};
 
 export type AgentActionType = RetrievalActionType;
 export type AgentMessageStatus = "created" | "succeeded" | "failed";
@@ -95,11 +99,11 @@ export type AgentMessageType = {
   status: AgentMessageStatus;
   action: AgentActionType | null;
   content: string | null;
-  feedbacks: UserFeedbackType[];
   error: {
     code: string;
     message: string;
   } | null;
+  reactions: MessageReactionType[];
 };
 
 export function isAgentMessageType(


### PR DESCRIPTION
This PR introducing the route & lib updates to handle reactions on message. 
Note: this expects a user at the moment, and will need to be updated to allow non user (= slack users) to post a reaction. 

1/ Adding or removing a reaction: 
- New route POST `w/[wId]/assistant/conversations/[cId]/messages/[mId]/reactions` -> will add or delete a reaction.
- New lib function `addOrRemoveMessageReaction`

2/ Retrieving messages reactions
- Add missing alias and typing on the model to retrieve reactions from a message.
- Introduce type `MessageReactionType` and edit `AgentMessageType` & `UserMessageType` to add an array of reactions.
- Join on `MessageReaction` when we query a message. 
- Introduce `renderMessageReactions` called everywhere we retrieve a message on `lib/api/assistant/conversations`
