### PR TITLE
Fixes display issues with the tooltip on agent mentions

### DIFF
--- a/front/components/assistant/RenderMessageMarkdown.tsx
+++ b/front/components/assistant/RenderMessageMarkdown.tsx
@@ -190,15 +190,10 @@ function MentionBlock({
       : agentConfiguration?.status === "active"
       ? ""
       : "(This assistant is deactivated for this workspace)";
-  const tooltipContent = (
-    <div className="flex w-64 flex-col gap-2">
-      <span>{agentConfiguration?.description}</span>
-      <span>{statusText}</span>
-    </div>
-  );
+  const tooltipLabel = agentConfiguration?.description || "" + " " + statusText;
   return (
     <span className="inline-block cursor-default font-medium text-brand">
-      <Tooltip contentChildren={tooltipContent} position="below">
+      <Tooltip label={tooltipLabel} position="below">
         @{agentName}
       </Tooltip>
     </span>


### PR DESCRIPTION
Also ensures that for long descriptions, the tooltip displays multiline

![image](https://github.com/dust-tt/dust/assets/5437393/4d76e3e9-7e48-4df4-9810-54e2287691d6)

