### PR TITLE
Wrap tooltip label if too long

### DIFF
--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.1.93",
+  "version": "0.1.94",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/components/Tooltip.tsx
+++ b/sparkle/src/components/Tooltip.tsx
@@ -47,7 +47,9 @@ export function Tooltip({
   const tooltipPositionClasses =
     position === "above" ? "s-bottom-full s-mb-2" : "s-top-full s-mt-2";
 
-  const labelClasses = "s-whitespace-nowrap";
+  // if tooltip text is too long we need to wrap it
+  const labelLength = label?.length || 0;
+  const labelClasses = labelLength > 80 ? "w-[38em]" : "s-whitespace-nowrap";
 
   return (
     <div


### PR DESCRIPTION
Assistant descriptions, for instance, can be lengthy