### PR TITLE
Inputbar tuning

### DIFF
--- a/front/components/assistant/conversation/InputBar.tsx
+++ b/front/components/assistant/conversation/InputBar.tsx
@@ -364,7 +364,7 @@ export function AssistantInputBar({
               className={classNames(
                 // This div is placeholder text for the contenteditable
                 contentEditableClasses,
-                "absolute text-element-600 dark:text-element-600-dark",
+                "absolute -z-10 text-element-600 dark:text-element-600-dark",
                 empty ? "" : "hidden"
               )}
             >

--- a/front/components/assistant/conversation/InputBar.tsx
+++ b/front/components/assistant/conversation/InputBar.tsx
@@ -219,8 +219,9 @@ export function AssistantInputBar({
     noMatch: () => boolean;
     perfectMatch: () => boolean;
   }>(null);
-
-  const [empty, setEmpty] = useState<boolean>(true);
+  const [empty, setEmpty] = useState<boolean>(
+    !stickyMentions || stickyMentions?.length === 0
+  );
   useEffect(() => {
     inputRef.current?.focus();
   }, []);
@@ -267,6 +268,7 @@ export function AssistantInputBar({
 
       onSubmit(content, mentions);
       contentEditable.innerHTML = "";
+      setEmpty(true);
     }
   };
 
@@ -327,6 +329,8 @@ export function AssistantInputBar({
 
         stickyMentionsTextContent.current =
           contentEditable.textContent?.trim() || null;
+        // since a mention was added, the inputbar isn't empty
+        setEmpty(false);
       }
       // move the cursor to the end of the input bar
       if (lastTextNode) {

--- a/front/components/assistant/conversation/InputBar.tsx
+++ b/front/components/assistant/conversation/InputBar.tsx
@@ -631,6 +631,13 @@ export function AssistantInputBar({
                           agentListRef.current?.reset();
                           inputNode.setAttribute("ignore", "backspace");
                           inputNode.blur();
+                          setEmpty(
+                            !inputRef.current?.textContent ||
+                              inputRef.current?.textContent?.replace(
+                                /\u200B/g,
+                                ""
+                              ).length === 0
+                          );
                           e.preventDefault();
                         }
                       }

--- a/front/components/assistant/conversation/InputBar.tsx
+++ b/front/components/assistant/conversation/InputBar.tsx
@@ -180,6 +180,17 @@ function AgentListImpl(
 
 const AgentList = forwardRef(AgentListImpl);
 
+function moveCursorToEnd(el: HTMLElement) {
+  const range = document.createRange();
+  const sel = window.getSelection();
+  if (sel) {
+    range.selectNodeContents(el);
+    range.collapse(false);
+    sel.removeAllRanges();
+    sel.addRange(range);
+  }
+}
+
 export function AssistantInputBar({
   owner,
   onSubmit,
@@ -319,14 +330,7 @@ export function AssistantInputBar({
       }
       // move the cursor to the end of the input bar
       if (lastTextNode) {
-        const selection = window.getSelection();
-        if (selection) {
-          const range = document.createRange();
-          range.setStart(lastTextNode, lastTextNode.length);
-          range.setEnd(lastTextNode, lastTextNode.length);
-          selection.removeAllRanges();
-          selection.addRange(range);
-        }
+        moveCursorToEnd(contentEditable);
       }
     }
   }, [stickyMentions, agentConfigurations, stickyMentionsTextContent]);
@@ -335,7 +339,6 @@ export function AssistantInputBar({
     "border-0 px-3 py-4 outline-none ring-0 focus:border-0 focus:outline-none focus:ring-0",
     "whitespace-pre-wrap font-normal"
   );
-
   return (
     <>
       <AgentList
@@ -359,7 +362,7 @@ export function AssistantInputBar({
           >
             <div
               className={classNames(
-                // Placeholder text for the contenteditable
+                // This div is placeholder text for the contenteditable
                 contentEditableClasses,
                 "absolute text-element-600 dark:text-element-600-dark",
                 empty ? "" : "hidden"
@@ -682,6 +685,8 @@ export function AssistantInputBar({
                       contentEditable.appendChild(mentionNode);
                       const afterTextNode = document.createTextNode(" ");
                       contentEditable.appendChild(afterTextNode);
+                      contentEditable.focus();
+                      moveCursorToEnd(contentEditable);
                     }
                   }}
                   assistants={activeAgents}

--- a/front/components/assistant/conversation/InputBar.tsx
+++ b/front/components/assistant/conversation/InputBar.tsx
@@ -209,6 +209,7 @@ export function AssistantInputBar({
     perfectMatch: () => boolean;
   }>(null);
 
+  const [empty, setEmpty] = useState<boolean>(true);
   useEffect(() => {
     inputRef.current?.focus();
   }, []);
@@ -221,6 +222,9 @@ export function AssistantInputBar({
   activeAgents.sort(compareAgentsForSort);
 
   const handleSubmit = async () => {
+    if (empty) {
+      return;
+    }
     const contentEditable = document.getElementById("dust-input-bar");
     if (contentEditable) {
       const mentions: MentionType[] = [];
@@ -326,6 +330,11 @@ export function AssistantInputBar({
       }
     }
   }, [stickyMentions, agentConfigurations, stickyMentionsTextContent]);
+  const contentEditableClasses = classNames(
+    "inline-block w-full",
+    "border-0 px-3 py-4 outline-none ring-0 focus:border-0 focus:outline-none focus:ring-0",
+    "whitespace-pre-wrap font-normal"
+  );
 
   return (
     <>
@@ -340,7 +349,7 @@ export function AssistantInputBar({
         <div className="flex flex-1 flex-row items-center">
           <div
             className={classNames(
-              "flex flex-1 flex-row items-end items-stretch px-4",
+              "relative flex flex-1 flex-row items-end items-stretch px-4",
               "border-2 border-action-300 bg-white focus-within:border-action-400",
               "rounded-xl drop-shadow-2xl transition-all duration-300",
               isAnimating
@@ -350,10 +359,16 @@ export function AssistantInputBar({
           >
             <div
               className={classNames(
-                "inline-block w-full",
-                "border-0 px-3 py-4 outline-none ring-0 focus:border-0 focus:outline-none focus:ring-0",
-                "whitespace-pre-wrap font-normal "
+                // Placeholder text for the contenteditable
+                contentEditableClasses,
+                "absolute text-element-600 dark:text-element-600-dark",
+                empty ? "" : "hidden"
               )}
+            >
+              Ask a question
+            </div>
+            <div
+              className={contentEditableClasses}
               contentEditable={true}
               ref={inputRef}
               id={"dust-input-bar"}
@@ -425,6 +440,11 @@ export function AssistantInputBar({
                 }
               }}
               onInput={() => {
+                setEmpty(
+                  !inputRef.current?.textContent ||
+                    inputRef.current?.textContent.replace(/\u200B/g, "")
+                      .length === 0
+                );
                 const selection = window.getSelection();
                 if (
                   selection &&
@@ -672,6 +692,7 @@ export function AssistantInputBar({
                 variant="primary"
                 icon={PaperAirplaneIcon}
                 size="md"
+                disabled={empty}
                 onClick={() => {
                   void handleSubmit();
                 }}


### PR DESCRIPTION
Three added behaviours:
  - submit disabled when input is empty (incl. button greyed)
  - placeholder text added
  - on assistant selection by picker, focuses back on input at end of text

Note: only mentions are considered a valid, non-empty input--since some assistants may be meaningfully called without any more text (e.g. @summarize_conversation, or just @gpt4 after you called claude to get a second opinion). There is no big downside since most assistants will properly answer when not given input (eg. gpt4: "Hello! It seems like you didn't ask a question or provide any instructions in your last message. How can I assist you further?")
