### PR TITLE
TextSynth support

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -30,6 +30,7 @@ pub mod providers {
         pub mod tiktoken;
     }
     pub mod anthropic;
+    pub mod textsynth;
 }
 pub mod http {
     pub mod request;

--- a/core/src/providers/provider.rs
+++ b/core/src/providers/provider.rs
@@ -13,6 +13,8 @@ use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use std::time::Duration;
 
+use super::textsynth::TextSynthProvider;
+
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum ProviderID {
@@ -22,6 +24,7 @@ pub enum ProviderID {
     #[serde(rename = "azure_openai")]
     AzureOpenAI,
     Anthropic,
+    TextSynth,
 }
 
 impl ToString for ProviderID {
@@ -32,6 +35,7 @@ impl ToString for ProviderID {
             ProviderID::AI21 => String::from("ai21"),
             ProviderID::AzureOpenAI => String::from("azure_openai"),
             ProviderID::Anthropic => String::from("anthropic"),
+            ProviderID::TextSynth => String::from("textsynth"),
         }
     }
 }
@@ -45,6 +49,7 @@ impl FromStr for ProviderID {
             "ai21" => Ok(ProviderID::AI21),
             "azure_openai" => Ok(ProviderID::AzureOpenAI),
             "anthropic" => Ok(ProviderID::Anthropic),
+            "textsynth" => Ok(ProviderID::TextSynth),
             _ => Err(ParseError::with_message(
                 "Unknown provider ID (possible values: openai, cohere, ai21, azure_openai)",
             ))?,
@@ -139,5 +144,6 @@ pub fn provider(t: ProviderID) -> Box<dyn Provider + Sync + Send> {
         ProviderID::AI21 => Box::new(AI21Provider::new()),
         ProviderID::AzureOpenAI => Box::new(AzureOpenAIProvider::new()),
         ProviderID::Anthropic => Box::new(AnthropicProvider::new()),
+        ProviderID::TextSynth => Box::new(TextSynthProvider::new()),
     }
 }

--- a/core/src/providers/textsynth.rs
+++ b/core/src/providers/textsynth.rs
@@ -1,0 +1,485 @@
+use crate::providers::embedder::Embedder;
+use crate::providers::llm::Tokens;
+use crate::providers::llm::{ChatMessage, LLMChatGeneration, LLMGeneration, LLM};
+use crate::providers::provider::{ModelError, ModelErrorRetryOptions, Provider, ProviderID};
+use crate::run::Credentials;
+use crate::utils;
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use hyper::{body::Buf, Body, Client, Method, Request, Uri};
+use hyper_tls::HttpsConnector;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::io::prelude::*;
+use std::time::Duration;
+use tokio::sync::mpsc::UnboundedSender;
+
+use super::embedder::EmbedderVector;
+use super::llm::ChatFunction;
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Error {
+    pub error: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct TokenizeResponse {
+    pub tokens: Vec<usize>,
+}
+
+async fn api_tokenize(api_key: &str, engine: &str, text: &str) -> Result<Vec<usize>> {
+    let https = HttpsConnector::new();
+    let cli = Client::builder().build::<_, hyper::Body>(https);
+
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri(format!("https://api.textsynth.com/v1/engines/{}/tokenize", engine).parse::<Uri>()?)
+        .header("Content-Type", "application/json")
+        .header("Authorization", format!("Bearer {}", api_key))
+        .body(Body::from(
+            json!({
+                "text": text,
+            })
+            .to_string(),
+        ))?;
+
+    let res = cli.request(req).await?;
+    let status = res.status();
+    let body = hyper::body::aggregate(res).await?;
+    let mut b: Vec<u8> = vec![];
+    body.reader().read_to_end(&mut b)?;
+    let c: &[u8] = &b;
+
+    let r = match status {
+        hyper::StatusCode::OK => {
+            let r: TokenizeResponse = serde_json::from_slice(c)?;
+            Ok(r)
+        }
+        hyper::StatusCode::TOO_MANY_REQUESTS => {
+            let error: Error = serde_json::from_slice(c).unwrap_or(Error {
+                error: "Too many requests".to_string(),
+            });
+            Err(ModelError {
+                message: format!("TextSynthAPIError: {}", error.error),
+                retryable: Some(ModelErrorRetryOptions {
+                    sleep: Duration::from_millis(2000),
+                    factor: 2,
+                    retries: 8,
+                }),
+            })
+        }
+        hyper::StatusCode::BAD_REQUEST => {
+            let error: Error = serde_json::from_slice(c).unwrap_or(Error {
+                error: "Unknown error".to_string(),
+            });
+            Err(ModelError {
+                message: format!("TextSynthAPIError: {}", error.error),
+                retryable: None,
+            })
+        }
+        _ => {
+            let error: Error = serde_json::from_slice(c)?;
+            Err(ModelError {
+                message: format!("TextSynthAPIError: {}", error.error),
+                retryable: None,
+            })
+        }
+    }?;
+    Ok(r.tokens)
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Completion {
+    pub text: String,
+    pub reached_end: bool,
+    pub input_tokens: usize,
+    pub output_tokens: usize,
+}
+
+pub struct TextSynthLLM {
+    id: String,
+    api_key: Option<String>,
+}
+
+impl TextSynthLLM {
+    pub fn new(id: String) -> Self {
+        TextSynthLLM { id, api_key: None }
+    }
+
+    fn uri(&self) -> Result<Uri> {
+        Ok(format!(
+            "https://api.textsynth.com/v1/engines/{}/completions",
+            self.id
+        )
+        .parse::<Uri>()?)
+    }
+
+    fn chat_uri(&self) -> Result<Uri> {
+        Ok(format!("https://api.textsynth.com/v1/engines/{}/chat", self.id).parse::<Uri>()?)
+    }
+
+    async fn completion(
+        &self,
+        prompt: &str,
+        max_tokens: Option<i32>,
+        temperature: f32,
+        stop: &Vec<String>,
+        top_k: Option<usize>,
+        top_p: Option<f32>,
+        frequency_penalty: Option<f32>,
+        presence_penalty: Option<f32>,
+        repetition_penalty: Option<f32>,
+        typical_p: Option<f32>,
+    ) -> Result<Completion> {
+        assert!(self.api_key.is_some());
+
+        let https = HttpsConnector::new();
+        let cli = Client::builder().build::<_, hyper::Body>(https);
+
+        let mut body = json!({
+            "prompt": prompt,
+                    "temperature": temperature,
+        });
+        if max_tokens.is_some() {
+            body["max_tokens"] = json!(max_tokens.unwrap());
+        }
+        if stop.len() > 0 {
+            body["stop"] = json!(stop);
+        }
+        if top_k.is_some() {
+            body["top_k"] = json!(top_k.unwrap());
+        }
+        if top_p.is_some() {
+            body["top_p"] = json!(top_k.unwrap());
+        }
+        if frequency_penalty.is_some() {
+            body["frequency_penalty"] = json!(frequency_penalty.unwrap());
+        }
+        if presence_penalty.is_some() {
+            body["presence_penalty"] = json!(presence_penalty.unwrap());
+        }
+        if repetition_penalty.is_some() {
+            body["repetition_penalty"] = json!(repetition_penalty.unwrap());
+        }
+        if typical_p.is_some() {
+            body["typical_p"] = json!(typical_p.unwrap());
+        }
+
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri(self.uri()?)
+            .header("Content-Type", "application/json")
+            .header(
+                "Authorization",
+                format!("Bearer {}", self.api_key.clone().unwrap()),
+            )
+            .body(Body::from(body.to_string()))?;
+
+        let res = cli.request(req).await?;
+        let status = res.status();
+        let body = hyper::body::aggregate(res).await?;
+        let mut b: Vec<u8> = vec![];
+        body.reader().read_to_end(&mut b)?;
+        let c: &[u8] = &b;
+
+        let response = match status {
+            hyper::StatusCode::OK => {
+                // print content of c
+                println!("RESPONSE: {}", String::from_utf8_lossy(c));
+                let completion: Completion = serde_json::from_slice(c)?;
+                Ok(completion)
+            }
+            hyper::StatusCode::TOO_MANY_REQUESTS => {
+                let error: Error = serde_json::from_slice(c).unwrap_or(Error {
+                    error: "Too many requests".to_string(),
+                });
+                Err(ModelError {
+                    message: format!("TextSynthAPIError: {}", error.error),
+                    retryable: Some(ModelErrorRetryOptions {
+                        sleep: Duration::from_millis(2000),
+                        factor: 2,
+                        retries: 8,
+                    }),
+                })
+            }
+            hyper::StatusCode::BAD_REQUEST => {
+                let error: Error = serde_json::from_slice(c).unwrap_or(Error {
+                    error: "Unknown error".to_string(),
+                });
+                Err(ModelError {
+                    message: format!("TextSynthAPIError: {}", error.error),
+                    retryable: None,
+                })
+            }
+            _ => {
+                let error: Error = serde_json::from_slice(c)?;
+                Err(ModelError {
+                    message: format!("TextSynthAPIError: {}", error.error),
+                    retryable: None,
+                })
+            }
+        }?;
+        Ok(response)
+    }
+}
+
+#[async_trait]
+impl LLM for TextSynthLLM {
+    fn id(&self) -> String {
+        self.id.clone()
+    }
+
+    async fn initialize(&mut self, credentials: Credentials) -> Result<()> {
+        match credentials.get("TEXTSYNTH_API_KEY") {
+            Some(api_key) => {
+                self.api_key = Some(api_key.clone());
+            }
+            None => match tokio::task::spawn_blocking(|| std::env::var("TEXTSYNTH_API_KEY")).await?
+            {
+                Ok(key) => {
+                    self.api_key = Some(key);
+                }
+                Err(_) => Err(anyhow!(
+                    "Credentials or environment variable `TEXTSYNTH_API_KEY` is not set."
+                ))?,
+            },
+        }
+        Ok(())
+    }
+
+    fn context_size(&self) -> usize {
+        match self.id.as_str() {
+            "mistral_7B" => 4096,
+            "mistral_7B_instruct" => 4096,
+            "falcon_7B" => 2048,
+            "falcon_40B" => 2048,
+            "falcon_40B-chat" => 2048,
+            "llama2_7B" => 4096,
+            _ => 2048,
+        }
+    }
+
+    async fn encode(&self, text: &str) -> Result<Vec<usize>> {
+        assert!(self.api_key.is_some());
+
+        api_tokenize(
+            self.api_key.clone().unwrap().as_str(),
+            self.id.as_str(),
+            text,
+        )
+        .await
+    }
+
+    async fn decode(&self, _tokens: Vec<usize>) -> Result<String> {
+        Err(anyhow!(
+            "Encode/Decode not implemented for provider `textsynth`"
+        ))
+    }
+
+    async fn generate(
+        &self,
+        prompt: &str,
+        mut max_tokens: Option<i32>,
+        temperature: f32,
+        _n: usize,
+        stop: &Vec<String>,
+        frequency_penalty: Option<f32>,
+        presence_penalty: Option<f32>,
+        top_p: Option<f32>,
+        _top_logprobs: Option<i32>,
+        _extras: Option<Value>,
+        _event_sender: Option<UnboundedSender<Value>>,
+    ) -> Result<LLMGeneration> {
+        assert!(self.api_key.is_some());
+
+        if let Some(m) = max_tokens {
+            if m == -1 {
+                let tokens = self.encode(prompt).await?;
+                max_tokens = Some((self.context_size() - tokens.len()) as i32);
+                // println!("Using max_tokens = {}", max_tokens.unwrap());
+            }
+        }
+
+        // println!("STOP: {:?}", stop);
+
+        let c = self
+            .completion(
+                prompt,
+                max_tokens,
+                temperature,
+                stop,
+                None,
+                top_p,
+                frequency_penalty,
+                presence_penalty,
+                None,
+                None,
+            )
+            .await?;
+
+        // println!("COMPLETION: {:?}", c);
+
+        Ok(LLMGeneration {
+            created: utils::now(),
+            provider: ProviderID::TextSynth.to_string(),
+            model: self.id.clone(),
+            completions: vec![Tokens {
+                text: c.text.clone(),
+                tokens: Some(vec![]),
+                logprobs: Some(vec![]),
+                top_logprobs: Some(vec![]),
+            }],
+            prompt: Tokens {
+                text: prompt.to_string(),
+                tokens: None,
+                logprobs: None,
+                top_logprobs: None,
+            },
+        })
+    }
+
+    async fn chat(
+        &self,
+        _messages: &Vec<ChatMessage>,
+        _functions: &Vec<ChatFunction>,
+        _function_call: Option<String>,
+        _temperature: f32,
+        _top_p: Option<f32>,
+        _n: usize,
+        _stop: &Vec<String>,
+        _max_tokens: Option<i32>,
+        _presence_penalty: Option<f32>,
+        _frequency_penalty: Option<f32>,
+        _extras: Option<Value>,
+        _event_sender: Option<UnboundedSender<Value>>,
+    ) -> Result<LLMChatGeneration> {
+        Err(anyhow!(
+            "Chat capabilties are not implemented for provider `textsynth`"
+        ))
+    }
+}
+
+pub struct TextSynthEmbedder {
+    id: String,
+}
+
+impl TextSynthEmbedder {
+    pub fn new(id: String) -> Self {
+        TextSynthEmbedder { id }
+    }
+}
+
+#[async_trait]
+impl Embedder for TextSynthEmbedder {
+    fn id(&self) -> String {
+        self.id.clone()
+    }
+
+    async fn initialize(&mut self, _credentials: Credentials) -> Result<()> {
+        Err(anyhow!("Embedders not available for provider `textsynth`"))
+    }
+
+    fn context_size(&self) -> usize {
+        2048
+    }
+    fn embedding_size(&self) -> usize {
+        2048
+    }
+
+    async fn encode(&self, _text: &str) -> Result<Vec<usize>> {
+        Err(anyhow!(
+            "Encode/Decode not implemented for provider `textsynth`"
+        ))
+    }
+
+    async fn decode(&self, _tokens: Vec<usize>) -> Result<String> {
+        Err(anyhow!(
+            "Encode/Decode not implemented for provider `textsynth`"
+        ))
+    }
+
+    async fn tokenize(&self, _text: String) -> Result<Vec<(usize, String)>> {
+        Err(anyhow!("Tokenize not implemented for provider `textsynth`"))
+    }
+
+    async fn embed(&self, _text: Vec<&str>, _extras: Option<Value>) -> Result<Vec<EmbedderVector>> {
+        Err(anyhow!("Embeddings not available for provider `textsynth`"))
+    }
+}
+
+pub struct TextSynthProvider {}
+
+impl TextSynthProvider {
+    pub fn new() -> Self {
+        TextSynthProvider {}
+    }
+}
+
+#[async_trait]
+impl Provider for TextSynthProvider {
+    fn id(&self) -> ProviderID {
+        ProviderID::TextSynth
+    }
+
+    fn setup(&self) -> Result<()> {
+        utils::info("Setting up TextSynth:");
+        utils::info("");
+        utils::info(
+            "To use TextSynth's models, you must set the environment variable `TEXTSYNTH_API_KEY`.",
+        );
+        utils::info("Your API key can be found at `https://textsynth.com/settings.html`.");
+        utils::info("");
+        utils::info("Once ready you can check your setup with `dust provider test textsynth`");
+
+        Ok(())
+    }
+
+    async fn test(&self) -> Result<()> {
+        if !utils::confirm(
+            "You are about to make a request for 1 token to `mistral_7B` on the TextSynth API.",
+        )? {
+            Err(anyhow!("User aborted TextSynth test."))?;
+        }
+
+        let mut llm = self.llm(String::from("mistral_7B"));
+        llm.initialize(Credentials::new()).await?;
+
+        let _ = llm
+            .generate(
+                "Hello 😊",
+                Some(1),
+                0.7,
+                1,
+                &vec![],
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await?;
+
+        // let t = llm.encode("Hello 😊").await?;
+        // let d = llm.decode(t).await?;
+        // assert!(d == "Hello 😊");
+
+        // let mut embedder = self.embedder(String::from("large"));
+        // embedder.initialize(Credentials::new()).await?;
+
+        // let _v = embedder.embed("Hello 😊", None).await?;
+        // println!("EMBEDDING SIZE: {}", v.vector.len());
+
+        utils::done("Test successfully completed! TextSynth is ready to use.");
+
+        Ok(())
+    }
+
+    fn llm(&self, id: String) -> Box<dyn LLM + Sync + Send> {
+        Box::new(TextSynthLLM::new(id))
+    }
+
+    fn embedder(&self, id: String) -> Box<dyn Embedder + Sync + Send> {
+        Box::new(TextSynthEmbedder::new(id))
+    }
+}

--- a/core/src/providers/textsynth.rs
+++ b/core/src/providers/textsynth.rs
@@ -114,9 +114,9 @@ impl TextSynthLLM {
         .parse::<Uri>()?)
     }
 
-    fn chat_uri(&self) -> Result<Uri> {
-        Ok(format!("https://api.textsynth.com/v1/engines/{}/chat", self.id).parse::<Uri>()?)
-    }
+    // fn chat_uri(&self) -> Result<Uri> {
+    //     Ok(format!("https://api.textsynth.com/v1/engines/{}/chat", self.id).parse::<Uri>()?)
+    // }
 
     async fn completion(
         &self,

--- a/core/src/providers/textsynth.rs
+++ b/core/src/providers/textsynth.rs
@@ -184,8 +184,6 @@ impl TextSynthLLM {
 
         let response = match status {
             hyper::StatusCode::OK => {
-                // print content of c
-                println!("RESPONSE: {}", String::from_utf8_lossy(c));
                 let completion: Completion = serde_json::from_slice(c)?;
                 Ok(completion)
             }
@@ -296,7 +294,6 @@ impl LLM for TextSynthLLM {
             if m == -1 {
                 let tokens = self.encode(prompt).await?;
                 max_tokens = Some((self.context_size() - tokens.len()) as i32);
-                // println!("Using max_tokens = {}", max_tokens.unwrap());
             }
         }
 

--- a/front/components/providers/TextSynthSetup.tsx
+++ b/front/components/providers/TextSynthSetup.tsx
@@ -1,0 +1,208 @@
+import { Button } from "@dust-tt/sparkle";
+import { Dialog, Transition } from "@headlessui/react";
+import { Fragment, useEffect, useState } from "react";
+import { useSWRConfig } from "swr";
+
+import { checkProvider } from "@app/lib/providers";
+import { WorkspaceType } from "@app/types/user";
+
+export default function TextSynthSetup({
+  owner,
+  open,
+  setOpen,
+  config,
+  enabled,
+}: {
+  owner: WorkspaceType;
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  config: { [key: string]: string };
+  enabled: boolean;
+}) {
+  const { mutate } = useSWRConfig();
+
+  const [apiKey, setApiKey] = useState(config ? config.api_key : "");
+  const [testSuccessful, setTestSuccessful] = useState(false);
+  const [testRunning, setTestRunning] = useState(false);
+  const [testError, setTestError] = useState("");
+  const [enableRunning, setEnableRunning] = useState(false);
+
+  useEffect(() => {
+    if (config && config.api_key.length > 0 && apiKey.length == 0) {
+      setApiKey(config.api_key);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [config]);
+
+  const runTest = async () => {
+    setTestRunning(true);
+    setTestError("");
+    const check = await checkProvider(owner, "textsynth", {
+      api_key: apiKey,
+    });
+
+    if (!check.ok) {
+      setTestError(check.error || "Unknown error");
+      setTestSuccessful(false);
+      setTestRunning(false);
+    } else {
+      setTestError("");
+      setTestSuccessful(true);
+      setTestRunning(false);
+    }
+  };
+
+  const handleEnable = async () => {
+    setEnableRunning(true);
+    const res = await fetch(`/api/w/${owner.sId}/providers/textsynth`, {
+      headers: {
+        "Content-Type": "application/json",
+      },
+      method: "POST",
+      body: JSON.stringify({
+        config: JSON.stringify({
+          api_key: apiKey,
+        }),
+      }),
+    });
+    await res.json();
+    setEnableRunning(false);
+    setOpen(false);
+    await mutate(`/api/w/${owner.sId}/providers`);
+  };
+
+  const handleDisable = async () => {
+    const res = await fetch(`/api/w/${owner.sId}/providers/textsynth`, {
+      method: "DELETE",
+    });
+    await res.json();
+    setOpen(false);
+    await mutate(`/api/w/${owner.sId}/providers`);
+  };
+
+  return (
+    <Transition.Root show={open} as={Fragment}>
+      <Dialog as="div" className="relative z-30" onClose={() => setOpen(false)}>
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-300"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-200"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="fixed inset-0 bg-gray-800 bg-opacity-75 transition-opacity" />
+        </Transition.Child>
+
+        <div className="fixed inset-0 z-30 overflow-y-auto">
+          <div className="flex min-h-full items-end items-center justify-center p-4">
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-300"
+              leave="ease-in duration-200"
+              leaveTo="opacity-0"
+            >
+              <Dialog.Panel className="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-sm sm:p-6 lg:max-w-lg">
+                <div>
+                  <div className="mt-3">
+                    <Dialog.Title
+                      as="h3"
+                      className="text-lg font-medium leading-6 text-gray-900"
+                    >
+                      Setup TextSynth
+                    </Dialog.Title>
+                    <div className="mt-4">
+                      <p className="text-sm text-gray-500">
+                        To use TextSynth models you must provide your API key.
+                        It can be found{" "}
+                        <a
+                          className="font-bold text-action-600 hover:text-action-500"
+                          href="https://textsynth.com/settings.html"
+                          target="_blank"
+                        >
+                          here
+                        </a>
+                      </p>
+                      <p className="mt-2 text-sm text-gray-500">
+                        We'll never use your API key for anything other than to
+                        run your apps.
+                      </p>
+                    </div>
+                    <div className="mt-6">
+                      <input
+                        type="text"
+                        className="block w-full rounded-md border-gray-300 shadow-sm focus:border-action-500 focus:ring-action-500 sm:text-sm"
+                        placeholder="TextSynth API Key"
+                        value={apiKey}
+                        onChange={(e) => {
+                          setApiKey(e.target.value);
+                          setTestSuccessful(false);
+                        }}
+                      />
+                    </div>
+                  </div>
+                </div>
+                <div className="mt-1 px-2 text-sm">
+                  {testError.length > 0 ? (
+                    <span className="text-red-500">Error: {testError}</span>
+                  ) : testSuccessful ? (
+                    <span className="text-green-600">
+                      Test succeeded! You can enable TextSynth.
+                    </span>
+                  ) : (
+                    <span>&nbsp;</span>
+                  )}
+                </div>
+                <div className="mt-5 flex flex-row items-center space-x-2 sm:mt-6">
+                  {enabled ? (
+                    <div
+                      className="flex-initial cursor-pointer text-sm font-bold text-red-500"
+                      onClick={() => handleDisable()}
+                    >
+                      Disable
+                    </div>
+                  ) : (
+                    <></>
+                  )}
+                  <div className="flex-1"></div>
+                  <div className="flex flex-initial">
+                    {/* TODO: typescript */}
+                    <Button
+                      onClick={() => setOpen(false)}
+                      label="Cancel"
+                      variant="secondary"
+                    />
+                  </div>
+                  <div className="flex flex-initial">
+                    {testSuccessful ? (
+                      <Button
+                        onClick={() => handleEnable()}
+                        disabled={enableRunning}
+                        label={
+                          enabled
+                            ? enableRunning
+                              ? "Updating..."
+                              : "Update"
+                            : enableRunning
+                            ? "Enabling..."
+                            : "Enable"
+                        }
+                      />
+                    ) : (
+                      <Button
+                        disabled={apiKey.length == 0 || testRunning}
+                        onClick={() => runTest()}
+                        label={testRunning ? "Testing..." : "Test"}
+                      />
+                    )}
+                  </div>
+                </div>
+              </Dialog.Panel>
+            </Transition.Child>
+          </div>
+        </div>
+      </Dialog>
+    </Transition.Root>
+  );
+}

--- a/front/lib/api/credentials.ts
+++ b/front/lib/api/credentials.ts
@@ -1,7 +1,10 @@
 import { CredentialsType, ProviderType } from "@app/types/provider";
 
-const { DUST_MANAGED_OPENAI_API_KEY = "", DUST_MANAGED_ANTHROPIC_API_KEY } =
-  process.env;
+const {
+  DUST_MANAGED_OPENAI_API_KEY = "",
+  DUST_MANAGED_ANTHROPIC_API_KEY = "",
+  DUST_MANAGED_TEXTSYNTH_API_KEY = "",
+} = process.env;
 
 export const credentialsFromProviders = (
   providers: ProviderType[]
@@ -31,6 +34,9 @@ export const credentialsFromProviders = (
       case "anthropic":
         credentials["ANTHROPIC_API_KEY"] = config.api_key;
         break;
+      case "textsynth":
+        credentials["TEXTSYNTH_API_KEY"] = config.api_key;
+        break;
       case "serpapi":
         credentials["SERP_API_KEY"] = config.api_key;
         break;
@@ -49,5 +55,6 @@ export const dustManagedCredentials = (): CredentialsType => {
   return {
     OPENAI_API_KEY: DUST_MANAGED_OPENAI_API_KEY,
     ANTHROPIC_API_KEY: DUST_MANAGED_ANTHROPIC_API_KEY,
+    TEXTSYNTH_API_KEY: DUST_MANAGED_TEXTSYNTH_API_KEY,
   };
 };

--- a/front/lib/providers.ts
+++ b/front/lib/providers.ts
@@ -58,7 +58,7 @@ export const modelProviders: ModelProvider[] = [
     name: "TextSynth",
     built: true,
     enabled: false,
-    chat: true,
+    chat: false,
     embed: false,
   },
   {

--- a/front/lib/providers.ts
+++ b/front/lib/providers.ts
@@ -54,6 +54,14 @@ export const modelProviders: ModelProvider[] = [
     embed: false,
   },
   {
+    providerId: "textsynth",
+    name: "TextSynth",
+    built: true,
+    enabled: false,
+    chat: true,
+    embed: false,
+  },
+  {
     providerId: "hugging_face",
     name: "Hugging Face",
     built: false,

--- a/front/pages/api/w/[wId]/providers/[pId]/check.ts
+++ b/front/pages/api/w/[wId]/providers/[pId]/check.ts
@@ -144,6 +144,31 @@ async function handler(
           }
           return;
 
+        case "textsynth":
+          const testCompletion = await fetch(
+            "https://api.textsynth.com/v1/engines/mistral_7B/completions",
+            {
+              method: "POST",
+              headers: {
+                Authorization: `Bearer ${config.api_key}`,
+                "Content-Type": "application/json",
+              },
+              body: JSON.stringify({
+                prompt: "<html>",
+                max_tokens: 1,
+              }),
+            }
+          );
+
+          if (!testCompletion.ok) {
+            const err = await testCompletion.json();
+            res.status(400).json({ ok: false, error: err.error });
+          } else {
+            await testCompletion.json();
+            res.status(200).json({ ok: true });
+          }
+          return;
+
         case "serpapi":
           const testSearch = await fetch(
             `https://serpapi.com/search?engine=google&q=Coffee&api_key=${config.api_key}`,

--- a/front/pages/api/w/[wId]/providers/[pId]/models.ts
+++ b/front/pages/api/w/[wId]/providers/[pId]/models.ts
@@ -200,6 +200,27 @@ async function handler(
           res.status(200).json({ models: anthropic_models });
           return;
 
+        case "textsynth":
+          if (chat) {
+            res.status(200).json({
+              models: [
+                { id: "mistral_7B_instruct" },
+                { id: "falcon_40B-chat" },
+              ],
+            });
+            return;
+          }
+          res.status(200).json({
+            models: [
+              { id: "mistral_7B" },
+              { id: "mistral_7B_instruct" },
+              { id: "falcon_7B" },
+              { id: "falcon_40B" },
+              { id: "llama2_7B" },
+            ],
+          });
+          return;
+
         default:
           res.status(404).json({ error: "Provider not found" });
           return;

--- a/front/pages/api/w/[wId]/providers/[pId]/models.ts
+++ b/front/pages/api/w/[wId]/providers/[pId]/models.ts
@@ -204,8 +204,8 @@ async function handler(
           if (chat) {
             res.status(200).json({
               models: [
-                { id: "mistral_7B_instruct" },
-                { id: "falcon_40B-chat" },
+                //  { id: "mistral_7B_instruct" },
+                //  { id: "falcon_40B-chat" },
               ],
             });
             return;

--- a/front/pages/w/[wId]/a/index.tsx
+++ b/front/pages/w/[wId]/a/index.tsx
@@ -20,6 +20,7 @@ import CohereSetup from "@app/components/providers/CohereSetup";
 import OpenAISetup from "@app/components/providers/OpenAISetup";
 import SerpAPISetup from "@app/components/providers/SerpAPISetup";
 import SerperSetup from "@app/components/providers/SerperSetup";
+import TextSynthSetup from "@app/components/providers/TextSynthSetup";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { subNavigationAdmin } from "@app/components/sparkle/navigation";
 import { getApps } from "@app/lib/api/app";
@@ -203,6 +204,7 @@ export function Providers({ owner }: { owner: WorkspaceType }) {
   const [ai21Open, setAI21Open] = useState(false);
   const [azureOpenAIOpen, setAzureOpenAIOpen] = useState(false);
   const [anthropicOpen, setAnthropicOpen] = useState(false);
+  const [textSynthOpen, setTextSynthOpen] = useState(false);
   const [serpapiOpen, setSerpapiOpen] = useState(false);
   const [serperOpen, setSerperOpen] = useState(false);
   const [browserlessapiOpen, setBrowserlessapiOpen] = useState(false);
@@ -254,6 +256,13 @@ export function Providers({ owner }: { owner: WorkspaceType }) {
         setOpen={setAnthropicOpen}
         enabled={configs["anthropic"] ? true : false}
         config={configs["anthropic"] ? configs["anthropic"] : null}
+      />
+      <TextSynthSetup
+        owner={owner}
+        open={textSynthOpen}
+        setOpen={setTextSynthOpen}
+        enabled={configs["textsynth"] ? true : false}
+        config={configs["textsynth"] ? configs["textsynth"] : null}
       />
       <SerpAPISetup
         owner={owner}
@@ -332,6 +341,9 @@ export function Providers({ owner }: { owner: WorkspaceType }) {
                           break;
                         case "anthropic":
                           setAnthropicOpen(true);
+                          break;
+                        case "textsynth":
+                          setTextSynthOpen(true);
                           break;
                       }
                     }}

--- a/front/types/provider.ts
+++ b/front/types/provider.ts
@@ -10,6 +10,7 @@ export type CredentialsType = {
   AZURE_OPENAI_API_KEY?: string;
   AZURE_OPENAI_ENDPOINT?: string;
   ANTHROPIC_API_KEY?: string;
+  TEXTSYNTH_API_KEY?: string;
   SERP_API_KEY?: string;
   SERPER_API_KEY?: string;
   BROWSERLESS_API_KEY?: string;


### PR DESCRIPTION
Adds support for provider `textsynth` with models to be used in `llm` blocks.

First pass:
- No chat
- No streaming
- No tokenization

Will tackle these in subsequent PRs.

![Screenshot from 2023-10-02 15-38-17](https://github.com/dust-tt/dust/assets/15067/b3b5cc7c-6ac1-4432-9560-c162121092de)
