### PR TITLE
Move tokenize on models not embedders

### DIFF
--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -505,7 +505,7 @@ async fn run_helper(
             None => Err(error_response(
                 StatusCode::BAD_REQUEST,
                 "missing_specification_error",
-                "No specification provided, either `specification` or 
+                "No specification provided, either `specification` or
                 `specification_hash` must be provided",
                 None,
             ))?,
@@ -1610,8 +1610,8 @@ struct TokenizePayload {
 async fn tokenize(
     extract::Json(payload): extract::Json<TokenizePayload>,
 ) -> (StatusCode, Json<APIResponse>) {
-    let embedder = provider(payload.provider_id).embedder(payload.model_id);
-    match embedder.tokenize(payload.text).await {
+    let embedder = provider(payload.provider_id).llm(payload.model_id);
+    match embedder.tokenize(&payload.text).await {
         Err(e) => error_response(
             StatusCode::INTERNAL_SERVER_ERROR,
             "internal_server_error",

--- a/core/src/providers/ai21.rs
+++ b/core/src/providers/ai21.rs
@@ -190,6 +190,10 @@ impl LLM for AI21LLM {
         Err(anyhow!("Encode/Decode not implemented for provider `ai21`"))
     }
 
+    async fn tokenize(&self, _text: &str) -> Result<Vec<(usize, String)>> {
+        Err(anyhow!("Tokenize not implemented for provider `ai21`"))
+    }
+
     async fn generate(
         &self,
         prompt: &str,
@@ -383,10 +387,6 @@ impl Embedder for AI21Embedder {
 
     async fn decode(&self, _tokens: Vec<usize>) -> Result<String> {
         Err(anyhow!("Encode/Decode not implemented for provider `ai21`"))
-    }
-
-    async fn tokenize(&self, _text: String) -> Result<Vec<(usize, String)>> {
-        Err(anyhow!("Tokenize not implemented for provider `ai21`"))
     }
 
     async fn embed(&self, _text: Vec<&str>, _extras: Option<Value>) -> Result<Vec<EmbedderVector>> {

--- a/core/src/providers/anthropic.rs
+++ b/core/src/providers/anthropic.rs
@@ -572,6 +572,10 @@ impl LLM for AnthropicLLM {
         decode_async(anthropic_base_singleton(), tokens).await
     }
 
+    async fn tokenize(&self, text: &str) -> Result<Vec<(usize, String)>> {
+        tokenize_async(anthropic_base_singleton(), text).await
+    }
+
     async fn chat(
         &self,
         messages: &Vec<ChatMessage>,
@@ -663,10 +667,6 @@ impl Embedder for AnthropicEmbedder {
 
     async fn decode(&self, tokens: Vec<usize>) -> Result<String> {
         decode_async(anthropic_base_singleton(), tokens).await
-    }
-
-    async fn tokenize(&self, text: String) -> Result<Vec<(usize, String)>> {
-        tokenize_async(anthropic_base_singleton(), text).await
     }
 
     async fn embed(&self, _text: Vec<&str>, _extras: Option<Value>) -> Result<Vec<EmbedderVector>> {

--- a/core/src/providers/azure_openai.rs
+++ b/core/src/providers/azure_openai.rs
@@ -1,3 +1,4 @@
+use super::tiktoken::tiktoken::{decode_async, encode_async, tokenize_async};
 use crate::providers::embedder::{Embedder, EmbedderVector};
 use crate::providers::llm::Tokens;
 use crate::providers::llm::{ChatMessage, LLMChatGeneration, LLMGeneration, LLM};
@@ -265,13 +266,15 @@ impl LLM for AzureOpenAILLM {
     }
 
     async fn encode(&self, text: &str) -> Result<Vec<usize>> {
-        let tokens = { self.tokenizer().lock().encode_with_special_tokens(text) };
-        Ok(tokens)
+        encode_async(self.tokenizer(), text).await
     }
 
     async fn decode(&self, tokens: Vec<usize>) -> Result<String> {
-        let str = { self.tokenizer().lock().decode(tokens)? };
-        Ok(str)
+        decode_async(self.tokenizer(), tokens).await
+    }
+
+    async fn tokenize(&self, text: &str) -> Result<Vec<(usize, String)>> {
+        tokenize_async(self.tokenizer(), text).await
     }
 
     async fn generate(
@@ -598,10 +601,6 @@ impl Embedder for AzureOpenAIEmbedder {
     async fn decode(&self, tokens: Vec<usize>) -> Result<String> {
         let str = { self.tokenizer().lock().decode(tokens)? };
         Ok(str)
-    }
-
-    async fn tokenize(&self, _text: String) -> Result<Vec<(usize, String)>> {
-        Err(anyhow!("Tokenize not implemented for provider `anthropic`"))
     }
 
     async fn embed(&self, text: Vec<&str>, extras: Option<Value>) -> Result<Vec<EmbedderVector>> {

--- a/core/src/providers/cohere.rs
+++ b/core/src/providers/cohere.rs
@@ -297,6 +297,16 @@ impl LLM for CohereLLM {
         api_decode(self.api_key.as_ref().unwrap(), tokens).await
     }
 
+    // We return empty string in tokenize to partially support the endpoint.
+    async fn tokenize(&self, text: &str) -> Result<Vec<(usize, String)>> {
+        assert!(self.api_key.is_some());
+        let tokens = api_encode(self.api_key.as_ref().unwrap(), text).await?;
+        Ok(tokens
+            .iter()
+            .map(|t| (*t, "".to_string()))
+            .collect::<Vec<_>>())
+    }
+
     async fn generate(
         &self,
         prompt: &str,
@@ -532,10 +542,6 @@ impl Embedder for CohereEmbedder {
     async fn decode(&self, tokens: Vec<usize>) -> Result<String> {
         assert!(self.api_key.is_some());
         api_decode(self.api_key.as_ref().unwrap(), tokens).await
-    }
-
-    async fn tokenize(&self, _text: String) -> Result<Vec<(usize, String)>> {
-        Err(anyhow!("Tokenize not implemented for provider `Cohere`"))
     }
 
     async fn embed(&self, text: Vec<&str>, _extras: Option<Value>) -> Result<Vec<EmbedderVector>> {

--- a/core/src/providers/embedder.rs
+++ b/core/src/providers/embedder.rs
@@ -26,8 +26,6 @@ pub trait Embedder {
     async fn encode(&self, text: &str) -> Result<Vec<usize>>;
     async fn decode(&self, tokens: Vec<usize>) -> Result<String>;
 
-    async fn tokenize(&self, text: String) -> Result<Vec<(usize, String)>>;
-
     async fn embed(&self, text: Vec<&str>, extras: Option<Value>) -> Result<Vec<EmbedderVector>>;
 }
 

--- a/core/src/providers/llm.rs
+++ b/core/src/providers/llm.rs
@@ -103,6 +103,7 @@ pub trait LLM {
 
     async fn encode(&self, text: &str) -> Result<Vec<usize>>;
     async fn decode(&self, tokens: Vec<usize>) -> Result<String>;
+    async fn tokenize(&self, text: &str) -> Result<Vec<(usize, String)>>;
 
     async fn generate(
         &self,

--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -1160,6 +1160,10 @@ impl LLM for OpenAILLM {
         decode_async(self.tokenizer(), tokens).await
     }
 
+    async fn tokenize(&self, text: &str) -> Result<Vec<(usize, String)>> {
+        tokenize_async(self.tokenizer(), text).await
+    }
+
     async fn generate(
         &self,
         prompt: &str,
@@ -1573,10 +1577,6 @@ impl Embedder for OpenAIEmbedder {
 
     async fn decode(&self, tokens: Vec<usize>) -> Result<String> {
         decode_async(self.tokenizer(), tokens).await
-    }
-
-    async fn tokenize(&self, text: String) -> Result<Vec<(usize, String)>> {
-        tokenize_async(self.tokenizer(), text).await
     }
 
     async fn embed(&self, text: Vec<&str>, extras: Option<Value>) -> Result<Vec<EmbedderVector>> {

--- a/core/src/providers/tiktoken/tiktoken.rs
+++ b/core/src/providers/tiktoken/tiktoken.rs
@@ -145,10 +145,8 @@ pub async fn encode_async(bpe: Arc<Mutex<CoreBPE>>, text: &str) -> Result<Vec<us
     Ok(r)
 }
 
-pub async fn tokenize_async(
-    bpe: Arc<Mutex<CoreBPE>>,
-    text: String,
-) -> Result<Vec<(usize, String)>> {
+pub async fn tokenize_async(bpe: Arc<Mutex<CoreBPE>>, text: &str) -> Result<Vec<(usize, String)>> {
+    let text = text.to_string();
     let r = task::spawn_blocking(move || bpe.lock().tokenize(&text)).await?;
     Ok(r)
 }
@@ -643,7 +641,7 @@ impl CoreBPE {
         self._encode_native(text, &allowed_special).0
     }
 
-    pub fn tokenize(&self, text: &String) -> Vec<(usize, String)> {
+    pub fn tokenize(&self, text: &str) -> Vec<(usize, String)> {
         let allowed_special = self
             .special_tokens_encoder
             .keys()
@@ -842,7 +840,7 @@ mod tests {
 
     #[tokio::test]
     async fn tokenize_test() {
-        async fn run_tokenize_test(soupinou: String, expected_soupinou: Vec<(usize, String)>) {
+        async fn run_tokenize_test(soupinou: &str, expected_soupinou: Vec<(usize, String)>) {
             let bpe = p50k_base_singleton();
             let res = tokenize_async(bpe, soupinou).await;
             assert_eq!(res.unwrap(), expected_soupinou);
@@ -857,7 +855,7 @@ mod tests {
             (259, "in".to_string()),
             (280, "ou".to_string()),
         ];
-        run_tokenize_test(regular, expected_regular).await;
+        run_tokenize_test(&regular, expected_regular).await;
 
         let unicode = "Soupinou 🤗".to_string();
         let expected_unicode: Vec<(usize, String)> = vec![
@@ -870,7 +868,7 @@ mod tests {
             (245, "�".to_string()),
         ];
 
-        run_tokenize_test(unicode, expected_unicode).await;
+        run_tokenize_test(&unicode, expected_unicode).await;
 
         let japanese = "ほこり".to_string();
         let expected_japanese: Vec<(usize, String)> = vec![
@@ -880,6 +878,6 @@ mod tests {
             (28255, "り".to_string()),
         ];
 
-        run_tokenize_test(japanese, expected_japanese).await;
+        run_tokenize_test(&japanese, expected_japanese).await;
     }
 }

--- a/front/documents_post_process_hooks/hooks/document_tracker/suggest_changes/lib.ts
+++ b/front/documents_post_process_hooks/hooks/document_tracker/suggest_changes/lib.ts
@@ -226,8 +226,8 @@ export async function documentTrackerSuggestChangesOnUpsert({
 
   const tokensInDiff = await CoreAPI.tokenize({
     text: diffText,
-    modelId: "text-embedding-ada-002",
     providerId: "openai",
+    modelId: "gpt-3.5-turbo",
   });
   if (tokensInDiff.isErr()) {
     throw tokensInDiff.error;

--- a/front/lib/actions/registry.ts
+++ b/front/lib/actions/registry.ts
@@ -78,87 +78,6 @@ export const DustProdActionRegistry = createActionRegistry({
     },
   },
 
-  "chat-retrieval": {
-    app: {
-      workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
-      appId: "0d7ab66fd2",
-      appHash:
-        "63d4bea647370f23fa396dc59347cfbd92354bced26783c9a99812a8b1b14371",
-    },
-    config: {
-      DATASOURCE: {
-        data_sources: [],
-        top_k: 16,
-        filter: { tags: null, timestamp: null },
-        use_cache: false,
-      },
-    },
-  },
-  "chat-assistant": {
-    app: {
-      workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
-      appId: "ab43ff2450",
-      appHash:
-        "5ba93a4b1750336ff15614b16d2f735de444e63ff22ec03f8c6e8b48392e0ea5",
-    },
-    config: {
-      MODEL: {
-        provider_id: "openai",
-        model_id: "gpt-3.5-turbo",
-        use_cache: true,
-        use_stream: true,
-      },
-    },
-  },
-  "chat-assistant-wfn": {
-    app: {
-      workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
-      appId: "0052be4be7",
-      appHash:
-        "e2291ceaa774bf3a05d1c3a20db6b6de613070ae683704d6e3076d2711755d81",
-    },
-    config: {
-      MODEL: {
-        provider_id: "openai",
-        model_id: "gpt-4-0613",
-        function_call: "auto",
-        use_cache: true,
-        use_stream: true,
-      },
-    },
-  },
-  "chat-message-e2e-eval": {
-    app: {
-      workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
-      appId: "201e6de608",
-      appHash:
-        "f676a2de5b83bdbd02b55beaefddafb0bb16f53715d9d7ba3c219ec09b6b0588",
-    },
-    config: {
-      RULE_VALIDITY: {
-        provider_id: "openai",
-        model_id: "gpt-3.5-turbo-0613",
-        function_call: "send_rule_validity",
-        use_cache: true,
-      },
-    },
-  },
-  "chat-title": {
-    app: {
-      workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
-      appId: "8fe968eef3",
-      appHash:
-        "528251ebc7b5bc59027877842ca6ff05c64c08765c3ab1f5e1b799395cdb3b57",
-    },
-    config: {
-      TITLE_CHAT: {
-        provider_id: "openai",
-        model_id: "gpt-3.5-turbo-0613",
-        function_call: "post_title",
-        use_cache: true,
-      },
-    },
-  },
   "doc-tracker-retrieval": {
     app: {
       workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
@@ -192,7 +111,7 @@ export const DustProdActionRegistry = createActionRegistry({
     config: {
       SUGGEST_CHANGES: {
         provider_id: "openai",
-        model_id: "gpt-4-0613",
+        model_id: "gpt-4",
         use_cache: false,
         function_call: "suggest_changes",
       },
@@ -208,7 +127,7 @@ export const DustProdActionRegistry = createActionRegistry({
     config: {
       MODEL: {
         provider_id: "openai",
-        model_id: "gpt-4-0613",
+        model_id: "gpt-4",
         use_cache: false,
         function_call: "extract_events",
       },

--- a/front/lib/extract_event_app.ts
+++ b/front/lib/extract_event_app.ts
@@ -167,11 +167,10 @@ function extractMaxTokens({
 export async function getTokenizedText(
   text: string
 ): Promise<{ tokens: CoreAPITokenType[] }> {
-  console.log("computeNbTokens4");
   const tokenizeResponse = await CoreAPI.tokenize({
     text: text,
-    modelId: "text-embedding-ada-002",
     providerId: "openai",
+    modelId: "gpt-4",
   });
   if (tokenizeResponse.isErr()) {
     {

--- a/front/pages/w/[wId]/a/[aId]/settings.tsx
+++ b/front/pages/w/[wId]/a/[aId]/settings.tsx
@@ -109,7 +109,7 @@ export default function SettingsView({
         method: "DELETE",
       });
       if (res.ok) {
-        await router.push(`/w/${owner.sId}/`);
+        await router.push(`/w/${owner.sId}/a`);
       } else {
         setIsDeleting(false);
         const err = (await res.json()) as { error: APIError };


### PR DESCRIPTION
- Move tokenize endpoint to `llm` not `embedder`
- Partial support (emtpy strings) for textsynth and cohere
- Some clean-up