### PR TITLE
Enable builder to update keys, better errors

### DIFF
--- a/front/lib/error.ts
+++ b/front/lib/error.ts
@@ -21,6 +21,8 @@ export type APIErrorType =
   | "run_error"
   | "app_not_found"
   | "app_auth_error"
+  | "provider_auth_error"
+  | "provider_not_found"
   | "dataset_not_found"
   | "workspace_not_found"
   | "workspace_auth_error"

--- a/front/pages/api/w/[wId]/data_sources/[name]/search.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/search.ts
@@ -166,6 +166,5 @@ export default async function handler(
           message: "The method passed is not supported, GET is expected.",
         },
       });
-      break;
   }
 }

--- a/front/pages/api/w/[wId]/providers/[pId]/index.ts
+++ b/front/pages/api/w/[wId]/providers/[pId]/index.ts
@@ -2,7 +2,7 @@ import { NextApiRequest, NextApiResponse } from "next";
 
 import { Authenticator, getSession } from "@app/lib/auth";
 import { Provider } from "@app/lib/models";
-import { withLogging } from "@app/logger/withlogging";
+import { apiError, withLogging } from "@app/logger/withlogging";
 import { ProviderType } from "@app/types/provider";
 
 export type PostProviderResponseBody = {
@@ -27,13 +27,24 @@ async function handler(
 
   const owner = auth.workspace();
   if (!owner) {
-    res.status(404).end();
-    return;
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "provider_not_found",
+        message: "The provider you're trying to check was not found.",
+      },
+    });
   }
 
-  if (!auth.isAdmin()) {
-    res.status(403).end();
-    return;
+  if (!auth.isBuilder()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "provider_auth_error",
+        message:
+          "Only the users that are `builders` for the current workspace can configure providers.",
+      },
+    });
   }
 
   let [provider] = await Promise.all([
@@ -46,15 +57,25 @@ async function handler(
   ]);
 
   if (!req.query.pId || typeof req.query.pId !== "string") {
-    res.status(400).end();
-    return;
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid provider ID in request parameters.",
+      },
+    });
   }
 
   switch (req.method) {
     case "POST":
-      if (!req.body || !(typeof req.body.config == "string")) {
-        res.status(400).end();
-        return;
+      if (!req.body || !(typeof req.body.config === "string")) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Invalid configuration in provider update request body.",
+          },
+        });
       }
 
       if (!provider) {
@@ -63,6 +84,7 @@ async function handler(
           config: req.body.config,
           workspaceId: owner.id,
         });
+
         res.status(201).json({
           provider: {
             providerId: provider.providerId,
@@ -73,6 +95,7 @@ async function handler(
         await provider.update({
           config: req.body.config,
         });
+
         res.status(200).json({
           provider: {
             providerId: provider.providerId,
@@ -80,13 +103,17 @@ async function handler(
           },
         });
       }
-
       return;
 
     case "DELETE":
       if (!provider) {
-        res.status(404).end();
-        return;
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "provider_not_found",
+            message: "The provider you're trying to delete was not found.",
+          },
+        });
       }
 
       await Provider.destroy({
@@ -104,8 +131,14 @@ async function handler(
       return;
 
     default:
-      res.status(405).end();
-      return;
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message:
+            "The method passed is not supported, GET or DELETE is expected.",
+        },
+      });
   }
 }
 

--- a/front/pages/api/w/[wId]/providers/index.ts
+++ b/front/pages/api/w/[wId]/providers/index.ts
@@ -2,7 +2,7 @@ import { NextApiRequest, NextApiResponse } from "next";
 
 import { Authenticator, getSession } from "@app/lib/auth";
 import { Provider } from "@app/lib/models";
-import { withLogging } from "@app/logger/withlogging";
+import { apiError, withLogging } from "@app/logger/withlogging";
 import { ProviderType } from "@app/types/provider";
 
 export type GetProvidersResponseBody = {
@@ -21,13 +21,24 @@ async function handler(
 
   const owner = auth.workspace();
   if (!owner) {
-    res.status(404).end();
-    return;
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "The workspace you're trying to access was not found.",
+      },
+    });
   }
 
   if (!auth.isBuilder()) {
-    res.status(403).end();
-    return;
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "provider_auth_error",
+        message:
+          "Only the users that are `builders` for the current workspace can list providers.",
+      },
+    });
   }
 
   switch (req.method) {
@@ -49,7 +60,13 @@ async function handler(
       return;
 
     default:
-      res.status(405).end();
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
       return;
   }
 }


### PR DESCRIPTION
Since builders have access to the UI we should let them update keys for developer tools.
Directionally this is what the builder role will be about.