### PR TITLE
feat: add support for content fragments

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -33,6 +33,7 @@ import {
   XP1User,
 } from "@app/lib/models";
 import { GlobalAgentSettings } from "@app/lib/models/assistant/agent";
+import { ContentFragment } from "@app/lib/models/assistant/conversation";
 
 async function main() {
   await User.sync({ alter: true });
@@ -66,6 +67,7 @@ async function main() {
   await ConversationParticipant.sync({ alter: true });
   await UserMessage.sync({ alter: true });
   await AgentMessage.sync({ alter: true });
+  await ContentFragment.sync({ alter: true });
   await Message.sync({ alter: true });
   await MessageReaction.sync({ alter: true });
   await Mention.sync({ alter: true });

--- a/front/components/assistant/conversation/Conversation.tsx
+++ b/front/components/assistant/conversation/Conversation.tsx
@@ -15,11 +15,8 @@ import {
 } from "@app/lib/swr";
 import {
   AgentMention,
-  AgentMessageType,
-  ContentFragmentType,
   isAgentMention,
   isUserMessageType,
-  UserMessageType,
 } from "@app/types/assistant/conversation";
 import { UserType, WorkspaceType } from "@app/types/user";
 
@@ -157,24 +154,10 @@ export default function Conversation({
     return <div>No conversation here</div>;
   }
 
-  const messages = conversation.content.map((versionedMessages) => {
-    let m: UserMessageType | AgentMessageType | ContentFragmentType | null =
-      null;
-    for (const x of versionedMessages) {
-      if (!m || x.version > m.version) {
-        m = x;
-      }
-    }
-    if (!m) {
-      throw new Error("Found empty array in conversation content");
-    }
-
-    return m;
-  });
-
   return (
     <div className="pb-24">
-      {messages.map((m) => {
+      {conversation.content.map((versionedMessages) => {
+        const m = versionedMessages[versionedMessages.length - 1];
         const convoReactions = reactions.find((r) => r.messageId === m.sId);
         const messageReactions = convoReactions?.reactions || [];
 

--- a/front/components/assistant/conversation/Conversation.tsx
+++ b/front/components/assistant/conversation/Conversation.tsx
@@ -217,7 +217,7 @@ export default function Conversation({
               </div>
             );
           case "content_fragment":
-            return null; // TODO: should we display content fragments?
+            return null;
           default:
             ((message: never) => {
               console.error("Unknown message type", message);

--- a/front/components/assistant/conversation/Conversation.tsx
+++ b/front/components/assistant/conversation/Conversation.tsx
@@ -158,8 +158,6 @@ export default function Conversation({
   }
 
   const messages = conversation.content.map((versionedMessages) => {
-    // Lots of typing because of the reduce which Typescript
-    // doesn't handle well on union types
     let m: UserMessageType | AgentMessageType | ContentFragmentType | null =
       null;
     for (const x of versionedMessages) {

--- a/front/lib/actions/registry.ts
+++ b/front/lib/actions/registry.ts
@@ -17,7 +17,7 @@ export const DustProdActionRegistry = createActionRegistry({
       workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
       appId: "f4816b1e13",
       appHash:
-        "ee76c3a205ae832dfedc178b263f375a6cd91e7387ccb32827d811948415fd2b",
+        "0d84ff37404c33b94005b4eff24bd34f9a9bda85a6a9e74076faedc8a92854df",
     },
     config: {
       MODEL: {
@@ -33,7 +33,7 @@ export const DustProdActionRegistry = createActionRegistry({
       workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
       appId: "84dfc1d4f7",
       appHash:
-        "2c9e4cb1a2772d77c88590bd81d2ae578c9c5a6016fde8c37ffd0b0e2b124638",
+        "cddc215f2cc07e4a1bdd9c253524ac09667de629420af2570ab1e715fa4ee2b2",
     },
     config: {
       MODEL: {
@@ -65,7 +65,7 @@ export const DustProdActionRegistry = createActionRegistry({
       workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
       appId: "6a27050429",
       appHash:
-        "00fed4ea8d869d185c88d6518447bc54ba5466d8c75c2cae006194fc2fc3e287",
+        "e0b00417afae51adc7e23c1365850fab154d9b945364c47074ef907915cf8c2c",
     },
     config: {
       MODEL: {

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -315,6 +315,7 @@ function renderContentFragment({
     type: "content_fragment",
     visibility: message.visibility,
     version: message.version,
+    title: contentFragment.title,
     content: contentFragment.content,
   };
 }
@@ -1464,8 +1465,11 @@ export async function* retryAgentMessage(
 // Injects a new content fragment in the conversation.
 export async function postNewContentFragment(
   auth: Authenticator,
-  conversation: ConversationType,
-  content: string
+  {
+    conversation,
+    title,
+    content,
+  }: { conversation: ConversationType; title: string; content: string }
 ): Promise<ContentFragmentType> {
   const owner = auth.workspace();
 
@@ -1476,7 +1480,7 @@ export async function postNewContentFragment(
   const { contentFragmentRow, messageRow } = await front_sequelize.transaction(
     async (t) => {
       const contentFragmentRow = await ContentFragment.create(
-        { content },
+        { content, title },
         { transaction: t }
       );
       const nextMessageRank =

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1466,59 +1466,47 @@ export async function postNewContentFragment(
   auth: Authenticator,
   conversation: ConversationType,
   content: string
-): Promise<Result<ContentFragmentType, Error>> {
+): Promise<ContentFragmentType> {
   const owner = auth.workspace();
 
   if (!owner || owner.id !== conversation.owner.id) {
-    return new Err(new Error("The conversation does not exist."));
+    throw new Error("Invalid auth for conversation.");
   }
 
-  try {
-    const { contentFragmentRow, messageRow } =
-      await front_sequelize.transaction(async (t) => {
-        const contentFragmentRow = await ContentFragment.create(
-          { content },
-          { transaction: t }
-        );
-        const nextMessageRank =
-          ((await Message.max<number | null, Message>("rank", {
-            where: {
-              conversationId: conversation.id,
-            },
-            transaction: t,
-          })) ?? -1) + 1;
-        const messageRow = await Message.create(
-          {
-            sId: generateModelSId(),
-            rank: nextMessageRank,
+  const { contentFragmentRow, messageRow } = await front_sequelize.transaction(
+    async (t) => {
+      const contentFragmentRow = await ContentFragment.create(
+        { content },
+        { transaction: t }
+      );
+      const nextMessageRank =
+        ((await Message.max<number | null, Message>("rank", {
+          where: {
             conversationId: conversation.id,
-            contentFragmentId: contentFragmentRow.id,
           },
-          {
-            transaction: t,
-          }
-        );
-        return { contentFragmentRow, messageRow };
-      });
+          transaction: t,
+        })) ?? -1) + 1;
+      const messageRow = await Message.create(
+        {
+          sId: generateModelSId(),
+          rank: nextMessageRank,
+          conversationId: conversation.id,
+          contentFragmentId: contentFragmentRow.id,
+        },
+        {
+          transaction: t,
+        }
+      );
+      return { contentFragmentRow, messageRow };
+    }
+  );
 
-    const contentFragment = renderContentFragment({
-      message: messageRow,
-      contentFragment: contentFragmentRow,
-    });
+  const contentFragment = renderContentFragment({
+    message: messageRow,
+    contentFragment: contentFragmentRow,
+  });
 
-    return new Ok(contentFragment);
-  } catch (e) {
-    logger.error(
-      {
-        error: e,
-        workspaceId: auth.workspace()?.sId,
-        conversationId: conversation.sId,
-      },
-      "Error posting new content fragment"
-    );
-
-    return new Err(new Error("Error posting new content fragment"));
-  }
+  return contentFragment;
 }
 
 async function* streamRunAgentEvents(

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -27,6 +27,7 @@ import {
   AgentMessageType,
   ConversationType,
   isAgentMessageType,
+  isContentFragmentType,
   isUserMessageType,
   UserMessageType,
 } from "@app/types/assistant/conversation";
@@ -92,8 +93,7 @@ export async function renderConversationForModel({
           content: m.content,
         });
       }
-    }
-    if (isUserMessageType(m)) {
+    } else if (isUserMessageType(m)) {
       // Replace all `:mention[{name}]{.*}` with `@name`.
       const content = m.content.replace(
         /:mention\[(.+)\]\{.+\}/g,
@@ -106,6 +106,16 @@ export async function renderConversationForModel({
         name: m.context.username,
         content,
       });
+    } else if (isContentFragmentType(m)) {
+      messages.unshift({
+        role: "action" as const,
+        name: "content_fragment",
+        content: m.content,
+      });
+    } else {
+      ((x: never) => {
+        throw new Error(`Unexpected message type: ${x}`);
+      })(m);
     }
   }
 

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -110,7 +110,7 @@ export async function renderConversationForModel({
       messages.unshift({
         role: "content_fragment" as const,
         name: "inject_content_fragment",
-        content: m.content,
+        content: `${m.title}\nCONTENT:\n${m.content}`,
       });
     } else {
       ((x: never) => {

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -37,7 +37,7 @@ import {
  */
 
 export type ModelMessageType = {
-  role: "action" | "agent" | "user";
+  role: "action" | "agent" | "user" | "content_fragment";
   name: string;
   content: string;
 };
@@ -62,7 +62,7 @@ export async function renderConversationForModel({
     Error
   >
 > {
-  const messages = [];
+  const messages: ModelMessageType[] = [];
 
   let retrievalFound = false;
 
@@ -108,7 +108,7 @@ export async function renderConversationForModel({
       });
     } else if (isContentFragmentType(m)) {
       messages.unshift({
-        role: "action" as const,
+        role: "content_fragment" as const,
         name: "content_fragment",
         content: m.content,
       });

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -109,7 +109,7 @@ export async function renderConversationForModel({
     } else if (isContentFragmentType(m)) {
       messages.unshift({
         role: "content_fragment" as const,
-        name: "content_fragment",
+        name: "inject_content_fragment",
         content: m.content,
       });
     } else {

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -433,12 +433,10 @@ Message.init(
     hooks: {
       beforeValidate: (message) => {
         if (
-          (!message.userMessageId &&
-            !message.agentMessageId &&
-            !message.contentFragmentId) ||
-          (message.userMessageId &&
-            message.agentMessageId &&
-            message.contentFragmentId)
+          Number(!!message.userMessageId) +
+            Number(!!message.agentMessageId) +
+            Number(!!message.contentFragmentId) !==
+          1
         ) {
           throw new Error(
             "Exactly one of userMessageId, agentMessageId, contentFragmentId must be non-null"

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -322,6 +322,7 @@ export class ContentFragment extends Model<
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
+  declare title: string;
   declare content: string;
 }
 
@@ -341,6 +342,10 @@ ContentFragment.init(
       type: DataTypes.DATE,
       allowNull: false,
       defaultValue: DataTypes.NOW,
+    },
+    title: {
+      type: DataTypes.TEXT,
+      allowNull: false,
     },
     content: {
       type: DataTypes.TEXT,

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
@@ -50,7 +50,7 @@ async function handler(
 
   switch (req.method) {
     case "POST":
-      const { content } = req.body;
+      const { content, title } = req.body;
 
       if (
         typeof content !== "string" ||
@@ -67,11 +67,21 @@ async function handler(
         });
       }
 
-      const contentFragment = await postNewContentFragment(
-        auth,
+      if (typeof title !== "string" || title.length === 0) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "The title must be a non-empty string.",
+          },
+        });
+      }
+
+      const contentFragment = await postNewContentFragment(auth, {
         conversation,
-        content
-      );
+        title,
+        content,
+      });
 
       res.status(200).json({ contentFragment });
       return;

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
@@ -1,0 +1,100 @@
+import { NextApiRequest, NextApiResponse } from "next";
+
+import {
+  getConversation,
+  postNewContentFragment,
+} from "@app/lib/api/assistant/conversation";
+import { Authenticator, getAPIKey } from "@app/lib/auth";
+import { ReturnedAPIErrorType } from "@app/lib/error";
+import { apiError, withLogging } from "@app/logger/withlogging";
+import { ContentFragmentType } from "@app/types/assistant/conversation";
+
+export type PostContentFragmentsResponseBody = {
+  contentFragment: ContentFragmentType;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<PostContentFragmentsResponseBody | ReturnedAPIErrorType>
+): Promise<void> {
+  const keyRes = await getAPIKey(req);
+  if (keyRes.isErr()) {
+    return apiError(req, res, keyRes.error);
+  }
+
+  const { auth, keyWorkspaceId } = await Authenticator.fromKey(
+    keyRes.value,
+    req.query.wId as string
+  );
+
+  if (!auth.isBuilder() || keyWorkspaceId !== req.query.wId) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "The Assistant API is only available on your own workspace.",
+      },
+    });
+  }
+
+  const conversation = await getConversation(auth, req.query.cId as string);
+  if (!conversation) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "conversation_not_found",
+        message: "Conversation not found.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "POST":
+      const { content } = req.body;
+      // check that content is a non-null, non-empty string of less than 64kb
+      if (
+        typeof content !== "string" ||
+        content.length === 0 ||
+        content.length > 64 * 1024
+      ) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              "The content must be a non-empty string of less than 64kb.",
+          },
+        });
+      }
+
+      const contentFragmentRes = await postNewContentFragment(
+        auth,
+        conversation,
+        content
+      );
+
+      if (contentFragmentRes.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "An internal server error occurred.",
+          },
+        });
+      }
+
+      res.status(200).json({ contentFragment: contentFragmentRes.value });
+      return;
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, POST is expected.",
+        },
+      });
+  }
+}
+
+export default withLogging(handler);

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
@@ -67,23 +67,13 @@ async function handler(
         });
       }
 
-      const contentFragmentRes = await postNewContentFragment(
+      const contentFragment = await postNewContentFragment(
         auth,
         conversation,
         content
       );
 
-      if (contentFragmentRes.isErr()) {
-        return apiError(req, res, {
-          status_code: 500,
-          api_error: {
-            type: "internal_server_error",
-            message: "An internal server error occurred.",
-          },
-        });
-      }
-
-      res.status(200).json({ contentFragment: contentFragmentRes.value });
+      res.status(200).json({ contentFragment });
       return;
 
     default:

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
@@ -51,7 +51,7 @@ async function handler(
   switch (req.method) {
     case "POST":
       const { content } = req.body;
-      // check that content is a non-null, non-empty string of less than 64kb
+
       if (
         typeof content !== "string" ||
         content.length === 0 ||

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -129,6 +129,7 @@ export type ContentFragmentType = {
   visibility: MessageVisibility;
   version: number;
 
+  title: string;
   content: string;
 };
 

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -73,7 +73,7 @@ export type UserMessageType = {
 };
 
 export function isUserMessageType(
-  arg: UserMessageType | AgentMessageType
+  arg: UserMessageType | AgentMessageType | ContentFragmentType
 ): arg is UserMessageType {
   return arg.type === "user_message";
 }
@@ -112,9 +112,30 @@ export type AgentMessageType = {
 };
 
 export function isAgentMessageType(
-  arg: UserMessageType | AgentMessageType
+  arg: UserMessageType | AgentMessageType | ContentFragmentType
 ): arg is AgentMessageType {
   return arg.type === "agent_message";
+}
+
+/**
+ * Content Fragments
+ */
+
+export type ContentFragmentType = {
+  id: ModelId;
+  sId: string;
+  created: number;
+  type: "content_fragment";
+  visibility: MessageVisibility;
+  version: number;
+
+  content: string;
+};
+
+export function isContentFragmentType(
+  arg: UserMessageType | AgentMessageType | ContentFragmentType
+): arg is ContentFragmentType {
+  return arg.type === "content_fragment";
 }
 
 /**
@@ -134,7 +155,7 @@ export type ConversationType = {
   owner: WorkspaceType;
   title: string | null;
   visibility: ConversationVisibility;
-  content: (UserMessageType[] | AgentMessageType[])[];
+  content: (UserMessageType[] | AgentMessageType[] | ContentFragmentType[])[];
 };
 
 export type UserParticipant = {


### PR DESCRIPTION
- Content fragments are stored like messages
- They are not rendered in the UI
- They are rendered for the model as function calls
- there is a `postNewContentFragment` lib fucntion
- there is an external API endpoint that allows posting new fragments of up to 64kb