### PR TITLE
Update Datadog config to access temporal data

### DIFF
--- a/k8s/datadog-values.yml
+++ b/k8s/datadog-values.yml
@@ -27,6 +27,16 @@ datadog:
 
   kubeStateMetricsEnabled: false
 
+confd:
+  prometheus.yaml: |
+    init_config:
+    instances:
+      - temporal_prometheus_url: https://gmnlm.tmprl.cloud/prometheus
+        namespace: "temporal"
+        metrics:
+          - temporal_cloud_v0_workflow_failed_count
+          - temporal_cloud_v0_workflow_timeout_count
+
 clusterAgent:
   enabled: true
   resources:
@@ -47,6 +57,16 @@ agents:
         limits:
           cpu: 200m
           memory: 512Mi
+      env:
+        - name: DD_ADDITIONAL_CONFIG_PROVIDERS
+          value: "confd"
+      volumeMounts:
+        - name: confd
+          mountPath: /confd
+  volumes:
+    - name: confd
+      configMap:
+        name: datadog-confd
 
 providers:
   gke:

--- a/k8s/datadog-values.yml
+++ b/k8s/datadog-values.yml
@@ -36,6 +36,8 @@ confd:
         metrics:
           - temporal_cloud_v0_workflow_failed_count
           - temporal_cloud_v0_workflow_timeout_count
+          - temporal_cloud_v0_workflow_cancel_count
+        ssl_ca_cert: /etc/certs/temporal-datadog-cert
 
 clusterAgent:
   enabled: true
@@ -63,10 +65,15 @@ agents:
       volumeMounts:
         - name: confd
           mountPath: /confd
+        - name: cert-volume
+          mountPath: /etc/certs
   volumes:
     - name: confd
       configMap:
         name: datadog-confd
+    - name: cert-volume
+      secret:
+        secretName: temporal-datadog-cert
 
 providers:
   gke:

--- a/k8s/datadog-values.yml
+++ b/k8s/datadog-values.yml
@@ -27,6 +27,10 @@ datadog:
 
   kubeStateMetricsEnabled: false
 
+prometheusScrape:
+    enabled: true
+    serviceEndpoints: true
+
 confd:
   prometheus.yaml: |
     init_config:

--- a/k8s/datadog-values.yml
+++ b/k8s/datadog-values.yml
@@ -37,7 +37,8 @@ confd:
           - temporal_cloud_v0_workflow_failed_count
           - temporal_cloud_v0_workflow_timeout_count
           - temporal_cloud_v0_workflow_cancel_count
-        ssl_ca_cert: /etc/certs/temporal-datadog-cert
+        ssl_cert: /etc/certs/temporal-datadog.crt
+        ssl_private_key: /etc/certs/temporal-datadog-cert.key
 
 clusterAgent:
   enabled: true

--- a/k8s/datadog-values.yml
+++ b/k8s/datadog-values.yml
@@ -31,7 +31,7 @@ confd:
   prometheus.yaml: |
     init_config:
     instances:
-      - temporal_prometheus_url: https://gmnlm.tmprl.cloud/prometheus
+      - prometheus_url: https://gmnlm.tmprl.cloud/prometheus
         namespace: "temporal"
         metrics:
           - temporal_cloud_v0_workflow_failed_count

--- a/k8s/datadog-values.yml
+++ b/k8s/datadog-values.yml
@@ -36,7 +36,7 @@ confd:
     init_config:
     instances:
       - prometheus_url: https://gmnlm.tmprl.cloud/prometheus
-        namespace: "dust-front-prod.gmnlm"
+        namespace: "default"
         metrics:
           - temporal_cloud_v0_workflow_failed_count
           - temporal_cloud_v0_workflow_timeout_count

--- a/k8s/datadog-values.yml
+++ b/k8s/datadog-values.yml
@@ -32,7 +32,7 @@ confd:
     init_config:
     instances:
       - prometheus_url: https://gmnlm.tmprl.cloud/prometheus
-        namespace: "temporal"
+        namespace: "dust-front-prod.gmnlm"
         metrics:
           - temporal_cloud_v0_workflow_failed_count
           - temporal_cloud_v0_workflow_timeout_count


### PR DESCRIPTION
Datadog documentation: [Introducing Prometheus support for Datadog Agent 6](https://www.datadoghq.com/blog/monitor-prometheus-metrics/)
Doc from Keith. T. from Temporal: https://keithtenzer.com/temporal/temporal_cloud_observability/


What has been done: 
1/ Generate a new certificate for temporal on GCP. I followed the doc on [Notion](https://www.notion.so/dust-tt/Runbook-Temporal-infra-e065e5ccd53443c1a57118d08c7a19f9) 
2/ Enable observability on Temporal Cloud in: https://cloud.temporal.io/settings/integrations/observability, creating a new prometheus endpoint
3/ Open this PR to edit the datadog config to listen to this new endpoint. 

Non tested, no idea if this will work!