### PR TITLE
Use constructPrompt for inputs generation

### DIFF
--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -228,7 +228,8 @@ export async function generateRetrievalParams(
       auth,
       configuration,
       spec,
-      conversation
+      conversation,
+      userMessage
     );
 
     if (rawInputsRes.isOk()) {

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -8,6 +8,7 @@ import {
   runRetrieval,
 } from "@app/lib/api/assistant/actions/retrieval";
 import {
+  constructPrompt,
   GenerationTokensEvent,
   renderConversationForModel,
   runGeneration,
@@ -36,13 +37,17 @@ export async function generateActionInputs(
   auth: Authenticator,
   configuration: AgentConfigurationType,
   specification: AgentActionSpecification,
-  conversation: ConversationType
+  conversation: ConversationType,
+  userMessage: UserMessageType
 ): Promise<Result<Record<string, string | boolean | number>, Error>> {
   // We inject the prompt of the model so that its input generation behavior can be modified by its
-  // instructions. If there is no genration phase we default to a generic prompt.
-  const prompt = configuration.generation
-    ? configuration.generation.prompt
-    : "You are a conversational assistant with access to function calling.";
+  // instructions. It also injects context about the local time. If there is no generation phase we
+  // default to a generic prompt.
+  const prompt = constructPrompt(
+    userMessage,
+    configuration,
+    "You are a conversational assistant with access to function calling."
+  );
 
   const model = {
     providerId: "openai",

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -217,20 +217,23 @@ export type GenerationSuccessEvent = {
 
 // Construct the full prompt from the agent configuration.
 // - Meta data about the agent and current time.
-function constructPrompt(
+// - Insructions from the agent configuration (in case of generation)
+// - Meta data about the retrieval action (in case of retrieval)
+export function constructPrompt(
   userMessage: UserMessageType,
-  configuration: AgentConfigurationType
+  configuration: AgentConfigurationType,
+  fallbackPrompt?: string
 ) {
-  if (!configuration.generation) {
-    return "";
-  }
-
   const d = moment(new Date()).tz(userMessage.context.timezone);
 
   let meta = "";
   meta += `ASSISTANT: @${configuration.name}\n`;
-  meta += `LOCAL_TIME: ${d.format("YYYY-MM-DD HH:mm")}\n`;
-  meta += `INSTRUCTIONS:\n${configuration.generation.prompt}`;
+  meta += `LOCAL_TIME: ${d.format("YYYY-MM-DD HH:mm (ddd)")}\n`;
+  if (configuration.generation) {
+    meta += `INSTRUCTIONS:\n${configuration.generation.prompt}`;
+  } else if (fallbackPrompt) {
+    meta += `INSTRUCTIONS:\n${fallbackPrompt}`;
+  }
 
   if (isRetrievalConfiguration(configuration.action)) {
     meta += "\n" + retrievalMetaPrompt();


### PR DESCRIPTION
Relies on `constructPrompt` for inputs generation (access to LOCAL_TIME).
Extend `constructPrompt` to inject the current day of the week in LOCAL_TIME

Fixes #1942 