### PR TITLE
Exhaustive retrieval builder page: filtering search / timeframe

### DIFF
--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -21,7 +21,7 @@ import DataSourceSelectionSection from "@app/components/assistant_builder/DataSo
 import {
   DROID_AVATAR_FILES,
   DROID_AVATARS_BASE_PATH,
-  TimeFrameMode,
+  FilteringMode,
 } from "@app/components/assistant_builder/shared";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import {
@@ -84,7 +84,7 @@ type AssistantBuilderState = {
     string,
     AssistantBuilderDataSourceConfiguration
   >;
-  timeFrameMode: TimeFrameMode;
+  filteringMode: FilteringMode;
   timeFrame: {
     value: number;
     unit: TimeframeUnit;
@@ -108,7 +108,7 @@ export type AssistantBuilderInitialState = {
   dataSourceConfigurations:
     | AssistantBuilderState["dataSourceConfigurations"]
     | null;
-  timeFrameMode: TimeFrameMode | null;
+  filteringMode: FilteringMode | null;
   timeFrame: AssistantBuilderState["timeFrame"] | null;
   handle: string;
   description: string;
@@ -132,7 +132,7 @@ type AssistantBuilderProps = {
 const DEFAULT_ASSISTANT_STATE: AssistantBuilderState = {
   dataSourceMode: "GENERIC",
   dataSourceConfigurations: {},
-  timeFrameMode: "AUTO",
+  filteringMode: "SEARCH",
   timeFrame: {
     value: 1,
     unit: "month",
@@ -241,9 +241,9 @@ export default function AssistantBuilder({
           initialBuilderState.dataSourceConfigurations ?? {
             ...DEFAULT_ASSISTANT_STATE.dataSourceConfigurations,
           },
-        timeFrameMode:
-          initialBuilderState.timeFrameMode ??
-          DEFAULT_ASSISTANT_STATE.timeFrameMode,
+        filteringMode:
+          initialBuilderState.filteringMode ??
+          DEFAULT_ASSISTANT_STATE.filteringMode,
         timeFrame: initialBuilderState.timeFrame ?? {
           ...DEFAULT_ASSISTANT_STATE.timeFrame,
         },
@@ -316,7 +316,7 @@ export default function AssistantBuilder({
       }
     }
 
-    if (builderState.timeFrameMode === "CUSTOM") {
+    if (builderState.filteringMode === "TIMEFRAME") {
       if (!builderState.timeFrame.value) {
         valid = false;
         setTimeFrameError("Timeframe must be a number");
@@ -332,7 +332,7 @@ export default function AssistantBuilder({
     builderState.instructions,
     builderState.dataSourceMode,
     configuredDataSourceCount,
-    builderState.timeFrameMode,
+    builderState.filteringMode,
     builderState.timeFrame.value,
     assistantHandleIsAvailable,
     assistantHandleIsValid,
@@ -377,12 +377,10 @@ export default function AssistantBuilder({
         break;
       case "SELECTED":
         const tfParam = (() => {
-          switch (builderState.timeFrameMode) {
-            case "AUTO":
+          switch (builderState.filteringMode) {
+            case "SEARCH":
               return "auto";
-            case "ALL_TIME":
-              return "none";
-            case "CUSTOM":
+            case "TIMEFRAME":
               if (!builderState.timeFrame.value) {
                 // unreachable
                 // we keep this for TS
@@ -395,13 +393,13 @@ export default function AssistantBuilder({
             default:
               ((x: never) => {
                 throw new Error(`Unknown time frame mode ${x}`);
-              })(builderState.timeFrameMode);
+              })(builderState.filteringMode);
           }
         })();
 
         actionParam = {
           type: "retrieval_configuration",
-          query: "auto", // TODO ?
+          query: builderState.filteringMode === "SEARCH" ? "auto" : "none",
           timeframe: tfParam,
           topK: "auto",
           dataSources: Object.values(builderState.dataSourceConfigurations).map(
@@ -778,12 +776,12 @@ export default function AssistantBuilder({
                     setShowDataSourcesModal(true);
                   }}
                   onDelete={deleteDataSource}
-                  timeFrameMode={builderState.timeFrameMode}
-                  setTimeFrameMode={(timeFrameMode: TimeFrameMode) => {
+                  filteringMode={builderState.filteringMode}
+                  setFilteringMode={(filteringMode: FilteringMode) => {
                     setEdited(true);
                     setBuilderState((state) => ({
                       ...state,
-                      timeFrameMode,
+                      filteringMode,
                     }));
                   }}
                   timeFrame={builderState.timeFrame}

--- a/front/components/assistant_builder/DataSourceSelectionSection.tsx
+++ b/front/components/assistant_builder/DataSourceSelectionSection.tsx
@@ -12,9 +12,9 @@ import { Transition } from "@headlessui/react";
 import { AssistantBuilderDataSourceConfiguration } from "@app/components/assistant_builder/AssistantBuilder";
 import {
   CONNECTOR_PROVIDER_TO_RESOURCE_NAME,
-  TIME_FRAME_MODE_TO_LABEL,
+  FILTERING_MODE_TO_LABEL,
   TIME_FRAME_UNIT_TO_LABEL,
-  TimeFrameMode,
+  FilteringMode,
 } from "@app/components/assistant_builder/shared";
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 import { classNames } from "@app/lib/utils";
@@ -27,8 +27,8 @@ export default function DataSourceSelectionSection({
   canAddDataSource,
   onManageDataSource,
   onDelete,
-  timeFrameMode,
-  setTimeFrameMode,
+  filteringMode,
+  setFilteringMode,
   timeFrame,
   setTimeFrame,
   timeFrameError,
@@ -42,8 +42,8 @@ export default function DataSourceSelectionSection({
   canAddDataSource: boolean;
   onManageDataSource: (name: string) => void;
   onDelete?: (name: string) => void;
-  timeFrameMode: TimeFrameMode;
-  setTimeFrameMode: (timeFrameMode: TimeFrameMode) => void;
+  filteringMode: FilteringMode;
+  setFilteringMode: (filteringMode: FilteringMode) => void;
   timeFrame: { value: number; unit: TimeframeUnit };
   setTimeFrame: (timeframe: { value: number; unit: TimeframeUnit }) => void;
   timeFrameError: string | null;
@@ -175,25 +175,25 @@ export default function DataSourceSelectionSection({
       <div>
         <div className="flex flex-row items-center space-x-2 pt-4">
           <div className="text-sm font-semibold text-element-900">
-            Timeframe:
+            Filtering:
           </div>
           <DropdownMenu>
             <DropdownMenu.Button>
               <Button
                 type="select"
                 labelVisible={true}
-                label={TIME_FRAME_MODE_TO_LABEL[timeFrameMode]}
+                label={FILTERING_MODE_TO_LABEL[filteringMode]}
                 variant="secondary"
                 size="sm"
               />
             </DropdownMenu.Button>
             <DropdownMenu.Items origin="bottomRight">
-              {Object.entries(TIME_FRAME_MODE_TO_LABEL).map(([key, value]) => (
+              {Object.entries(FILTERING_MODE_TO_LABEL).map(([key, value]) => (
                 <DropdownMenu.Item
                   key={key}
                   label={value}
                   onClick={() => {
-                    setTimeFrameMode(key as TimeFrameMode);
+                    setFilteringMode(key as FilteringMode);
                   }}
                 />
               ))}
@@ -202,7 +202,7 @@ export default function DataSourceSelectionSection({
         </div>
         <div className="mt-4">
           <Transition
-            show={timeFrameMode === "CUSTOM"}
+            show={filteringMode === "TIMEFRAME"}
             enterFrom="opacity-0"
             enterTo="opacity-100"
             leave="transition-all duration-300"
@@ -220,7 +220,7 @@ export default function DataSourceSelectionSection({
           >
             <div className={"flex flex-row items-center gap-4 pb-4"}>
               <div className="text-sm font-semibold text-element-900">
-                Focus on the last
+                Collect data from the last
               </div>
               <input
                 type="text"
@@ -273,12 +273,20 @@ export default function DataSourceSelectionSection({
           </Transition>
         </div>
         <div className="text-sm font-normal text-element-700">
-          You can filter the documents retrieved for a&nbsp;specific
-          time&nbsp;period.
-          <br />
-          When <span className="italic">“Auto”</span> is selected,
-          the&nbsp;assistant will determine the&nbsp;timeframe from
-          the&nbsp;instructions and the&nbsp;question being&nbsp;asked.
+          {filteringMode === "TIMEFRAME" ? (
+            <>
+              The assistant will look exhaustively at all data in the data
+              sources, in reverse chronological order, for the specified
+              timeframe. It will take as much data as it can in its context, and
+              warn you if it could not process all of it.
+            </>
+          ) : (
+            <>
+              The assistant will search the data sources for data that best
+              matches the user query, to retrieve information related to the
+              question.
+            </>
+          )}
         </div>
       </div>
     </Transition>

--- a/front/components/assistant_builder/DataSourceSelectionSection.tsx
+++ b/front/components/assistant_builder/DataSourceSelectionSection.tsx
@@ -13,8 +13,8 @@ import { AssistantBuilderDataSourceConfiguration } from "@app/components/assista
 import {
   CONNECTOR_PROVIDER_TO_RESOURCE_NAME,
   FILTERING_MODE_TO_LABEL,
-  TIME_FRAME_UNIT_TO_LABEL,
   FilteringMode,
+  TIME_FRAME_UNIT_TO_LABEL,
 } from "@app/components/assistant_builder/shared";
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 import { classNames } from "@app/lib/utils";

--- a/front/components/assistant_builder/shared.ts
+++ b/front/components/assistant_builder/shared.ts
@@ -1,12 +1,11 @@
 import { ConnectorProvider } from "@app/lib/connectors_api";
 import { TimeframeUnit } from "@app/types/assistant/actions/retrieval";
 
-export const TIME_FRAME_MODES = ["AUTO", "CUSTOM", "ALL_TIME"] as const;
-export type TimeFrameMode = (typeof TIME_FRAME_MODES)[number];
-export const TIME_FRAME_MODE_TO_LABEL: Record<TimeFrameMode, string> = {
-  AUTO: "Auto (default)",
-  CUSTOM: "Custom",
-  ALL_TIME: "All time",
+export const FILTERING_MODES = ["SEARCH", "TIMEFRAME"] as const;
+export type FilteringMode = (typeof FILTERING_MODES)[number];
+export const FILTERING_MODE_TO_LABEL: Record<FilteringMode, string> = {
+  SEARCH: "Search",
+  TIMEFRAME: "Timeframe",
 };
 export const TIME_FRAME_UNIT_TO_LABEL: Record<TimeframeUnit, string> = {
   hour: "hour(s)",

--- a/front/migrations/20231004_timeframe_none_to_auto.sql
+++ b/front/migrations/20231004_timeframe_none_to_auto.sql
@@ -1,0 +1,3 @@
+UPDATE agent_retrieval_configurations 
+SET "relativeTimeFrame" = 'auto'
+WHERE "relativeTimeFrame" = 'none';

--- a/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
@@ -131,18 +131,18 @@ export default function EditAssistant({
   const selectedDataSource =
     agentConfiguration.action?.type === "retrieval_configuration";
 
-  let timeFrameMode: AssistantBuilderInitialState["filteringMode"] = null;
+  let filteringMode: AssistantBuilderInitialState["filteringMode"] = null;
   let timeFrame: AssistantBuilderInitialState["timeFrame"] = null;
   if (selectedDataSource && agentConfiguration.action?.relativeTimeFrame) {
     switch (agentConfiguration.action.relativeTimeFrame) {
       case "auto":
-        timeFrameMode = "AUTO";
+        filteringMode = "SEARCH";
         break;
       case "none":
-        timeFrameMode = "ALL_TIME";
+        filteringMode = "SEARCH";
         break;
       default:
-        timeFrameMode = "CUSTOM";
+        filteringMode = "TIMEFRAME";
         timeFrame = {
           value: agentConfiguration.action.relativeTimeFrame.duration,
           unit: agentConfiguration.action.relativeTimeFrame.unit,
@@ -158,7 +158,7 @@ export default function EditAssistant({
       dataSources={Object.values(dataSources)}
       initialBuilderState={{
         dataSourceMode: selectedDataSource ? "SELECTED" : "GENERIC",
-        filteringMode: timeFrameMode,
+        filteringMode: filteringMode,
         timeFrame,
         dataSourceConfigurations, // TODO
         handle: agentConfiguration.name,

--- a/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
@@ -131,7 +131,7 @@ export default function EditAssistant({
   const selectedDataSource =
     agentConfiguration.action?.type === "retrieval_configuration";
 
-  let timeFrameMode: AssistantBuilderInitialState["timeFrameMode"] = null;
+  let timeFrameMode: AssistantBuilderInitialState["filteringMode"] = null;
   let timeFrame: AssistantBuilderInitialState["timeFrame"] = null;
   if (selectedDataSource && agentConfiguration.action?.relativeTimeFrame) {
     switch (agentConfiguration.action.relativeTimeFrame) {
@@ -158,7 +158,7 @@ export default function EditAssistant({
       dataSources={Object.values(dataSources)}
       initialBuilderState={{
         dataSourceMode: selectedDataSource ? "SELECTED" : "GENERIC",
-        timeFrameMode,
+        filteringMode: timeFrameMode,
         timeFrame,
         dataSourceConfigurations, // TODO
         handle: agentConfiguration.name,


### PR DESCRIPTION
Context: issue #1864, and [design doc](https://www.notion.so/dust-tt/DesignDoc-Exhaustive-mode-for-datasource-retrieval-202d685b1ccb4e84ac6df5c40fa90dc0?pvs=4#c8b161ee4be340d4bf2d3461dfbc74c2) with visual

Since testing locally is not trivial (requires either talking to local datasources, or adding remote datasources), I can merge and test--and revert quick if issue