### PR TITLE
Conversation - Layout Emojis on right column

### DIFF
--- a/front/components/assistant/conversation/ConversationMessage.tsx
+++ b/front/components/assistant/conversation/ConversationMessage.tsx
@@ -2,10 +2,17 @@ import { Avatar, Button, DropdownMenu } from "@dust-tt/sparkle";
 import { Emoji, EmojiMartData } from "@emoji-mart/data";
 import Picker from "@emoji-mart/react";
 import { FaceSmileIcon } from "@heroicons/react/24/outline";
-import { ComponentType, MouseEventHandler, useEffect, useState } from "react";
+import {
+  ComponentType,
+  MouseEvent,
+  MouseEventHandler,
+  useEffect,
+  useState,
+} from "react";
 import React from "react";
 import { mutate } from "swr";
 
+import { classNames } from "@app/lib/utils";
 import { MessageReactionType } from "@app/types/assistant/conversation";
 import { UserType, WorkspaceType } from "@app/types/user";
 
@@ -101,12 +108,8 @@ export function ConversationMessage({
   const hasReactedDown =
     reactionDown?.users.some((u) => u.userId === user.id) ?? false;
 
-  const reactionLove = reactions.find((r) => r.emoji === "heart");
-  const hasReactedLove =
-    reactionLove?.users.some((u) => u.userId === user.id) ?? false;
-
   let otherReactions = reactions.filter(
-    (r) => r.emoji !== "+1" && r.emoji !== "-1" && r.emoji !== "heart"
+    (r) => r.emoji !== "+1" && r.emoji !== "-1"
   );
   let hasMoreReactions = null;
   if (otherReactions.length > MAX_MORE_REACTIONS_TO_SHOW) {
@@ -115,43 +118,31 @@ export function ConversationMessage({
   }
 
   return (
-    <div className="grid grid-cols-12 gap-4">
+    <div className="flex w-full gap-4">
       {/* COLUMN 1: AVATAR - in small size if small layout */}
-      <div className="col-span-1">
-        <div className="sm:hidden">
-          <Avatar
-            visual={pictureUrl}
-            name={name || undefined}
-            size="xs"
-            busy={avatarBusy}
-          />
-        </div>
-        <div className="hidden sm:block">
-          <Avatar
-            visual={pictureUrl}
-            name={name || undefined}
-            size="md"
-            busy={avatarBusy}
-          />
-        </div>
+      <div>
+        <Avatar
+          visual={pictureUrl}
+          name={name || undefined}
+          size="md"
+          busy={avatarBusy}
+        />
       </div>
 
       {/* COLUMN 2: CONTENT */}
-      <div className="col-span-8">
-        <div className="flex flex-col gap-4">
-          <div className="text-sm font-medium">{name}</div>
-          <div className="min-w-0 break-words text-base font-normal">
-            {children}
-          </div>
+      <div className="flex flex-grow flex-col gap-4">
+        <div className="text-sm font-medium">{name}</div>
+        <div className="min-w-0 break-words text-base font-normal">
+          {children}
         </div>
       </div>
 
       {/* COLUMN 3: BUTTONS */}
-      <div className="col-span-3">
-        {/* COPY / RETRY */}
-        {buttons && (
-          <div className="mb-6">
-            <Button.List>
+      <div className="w-16  overflow-visible">
+        <div className="w-[8vw]">
+          {/* COPY / RETRY */}
+          {buttons && (
+            <div className="mb-6 flex flex-wrap gap-1">
               {buttons.map((button, i) => (
                 <Button
                   key={`message-${messageId}-button-${i}`}
@@ -163,92 +154,115 @@ export function ConversationMessage({
                   onClick={button.onClick}
                 />
               ))}
-            </Button.List>
-          </div>
-        )}
-
-        {/* EMOJIS */}
-        <Button.List isWrapping={true}>
-          <Button
-            variant={hasReactedUp ? "secondary" : "tertiary"}
-            size="xs"
-            label={reactionUp ? `👍 ${reactionUp.users.length}` : "👍 "}
-            onClick={async () => await handleEmojiClick("+1")}
-          />
-          <Button
-            variant={hasReactedDown ? "secondary" : "tertiary"}
-            size="xs"
-            label={reactionDown ? `👎 ${reactionDown.users.length}` : `👎`}
-            onClick={async () => await handleEmojiClick("-1")}
-          />
-          <Button
-            variant={hasReactedLove ? "secondary" : "tertiary"}
-            size="xs"
-            label={reactionLove ? `❤️ ${reactionLove.users.length}` : "❤️ "}
-            onClick={async () => await handleEmojiClick("heart")}
-          />
-          {otherReactions.map((reaction) => {
-            const hasReacted = reaction.users.some((u) => u.userId === user.id);
-            const emoji = emojiData?.emojis[reaction.emoji];
-            const nativeEmoji = emoji?.skins[0].native;
-            if (!nativeEmoji) {
-              return null;
-            }
-            return (
-              <Button
-                key={reaction.emoji}
-                variant={hasReacted ? "secondary" : "tertiary"}
-                size="xs"
-                label={`${nativeEmoji} ${reaction.users.length}`}
-                onClick={async () =>
-                  await handleEmoji({
-                    emoji: reaction.emoji,
-                    isToRemove: hasReacted,
-                  })
-                }
-              />
-            );
-          })}
-          {hasMoreReactions && (
-            <span className="text-xs">+{hasMoreReactions}</span>
+            </div>
           )}
-        </Button.List>
-        <div className="mt-2">
-          <DropdownMenu>
-            <DropdownMenu.Button>
-              <Button
-                variant="tertiary"
-                size="xs"
-                icon={FaceSmileIcon}
-                labelVisible={false}
-                label="Add another emoji"
-                type="menu"
-              />
-            </DropdownMenu.Button>
-            <DropdownMenu.Items width={280}>
-              <Picker
-                theme="light"
-                previewPosition="none"
-                data={emojiData}
-                onEmojiSelect={async (emojiData: Emoji) => {
-                  const reaction = reactions.find(
-                    (r) => r.emoji === emojiData.id
-                  );
-                  const hasReacted =
-                    (reaction &&
-                      reaction.users.find((u) => u.userId === user.id) !==
-                        undefined) ||
-                    false;
-                  await handleEmoji({
-                    emoji: emojiData.id,
-                    isToRemove: hasReacted,
-                  });
-                }}
-              />
-            </DropdownMenu.Items>
-          </DropdownMenu>
+
+          {/* EMOJIS */}
+          <div className="flex flex-wrap gap-3 pl-2">
+            <ButtonEmoji
+              variant={hasReactedUp ? "selected" : "unselected"}
+              emoji="👍"
+              count={reactionUp ? reactionUp.users.length.toString() : ""}
+              onClick={async () => await handleEmojiClick("+1")}
+            />
+            <ButtonEmoji
+              variant={hasReactedDown ? "selected" : "unselected"}
+              emoji="👎"
+              count={reactionDown ? reactionDown.users.length.toString() : ""}
+              onClick={async () => await handleEmojiClick("-1")}
+            />
+            {otherReactions.map((reaction) => {
+              const hasReacted = reaction.users.some(
+                (u) => u.userId === user.id
+              );
+              const emoji = emojiData?.emojis[reaction.emoji];
+              const nativeEmoji = emoji?.skins[0].native;
+              if (!nativeEmoji) {
+                return null;
+              }
+              return (
+                <ButtonEmoji
+                  key={reaction.emoji}
+                  variant={hasReactedDown ? "selected" : "unselected"}
+                  emoji={nativeEmoji}
+                  count={reaction.users.length.toString()}
+                  onClick={async () =>
+                    await handleEmoji({
+                      emoji: reaction.emoji,
+                      isToRemove: hasReacted,
+                    })
+                  }
+                />
+              );
+            })}
+            {hasMoreReactions && (
+              <span className="text-xs">+{hasMoreReactions}</span>
+            )}
+          </div>
+          <div className="mt-2">
+            <DropdownMenu>
+              <DropdownMenu.Button>
+                <Button
+                  variant="tertiary"
+                  size="xs"
+                  icon={FaceSmileIcon}
+                  labelVisible={false}
+                  label="Add another emoji"
+                  type="menu"
+                />
+              </DropdownMenu.Button>
+              <DropdownMenu.Items width={280}>
+                <Picker
+                  theme="light"
+                  previewPosition="none"
+                  data={emojiData}
+                  onEmojiSelect={async (emojiData: Emoji) => {
+                    const reaction = reactions.find(
+                      (r) => r.emoji === emojiData.id
+                    );
+                    const hasReacted =
+                      (reaction &&
+                        reaction.users.find((u) => u.userId === user.id) !==
+                          undefined) ||
+                      false;
+                    await handleEmoji({
+                      emoji: emojiData.id,
+                      isToRemove: hasReacted,
+                    });
+                  }}
+                />
+              </DropdownMenu.Items>
+            </DropdownMenu>
+          </div>
         </div>
       </div>
+    </div>
+  );
+}
+
+interface ButtonEmojiProps {
+  variant?: "selected" | "unselected";
+  count?: string;
+  emoji?: string;
+  onClick?: (event: MouseEvent<HTMLButtonElement>) => void;
+}
+
+export function ButtonEmoji({
+  variant,
+  emoji,
+  count,
+  onClick,
+}: ButtonEmojiProps) {
+  return (
+    <div
+      className={classNames(
+        variant ? "text-action-500" : "text-element-800",
+        "flex cursor-pointer items-center gap-1.5 text-base font-medium transition-all duration-300 hover:text-action-400 active:text-action-600"
+      )}
+      onClick={onClick}
+    >
+      {emoji}
+      {count && <span className="text-xs">{count}</span>}
     </div>
   );
 }

--- a/front/components/assistant/conversation/ConversationMessage.tsx
+++ b/front/components/assistant/conversation/ConversationMessage.tsx
@@ -2,13 +2,7 @@ import { Avatar, Button, DropdownMenu } from "@dust-tt/sparkle";
 import { Emoji, EmojiMartData } from "@emoji-mart/data";
 import Picker from "@emoji-mart/react";
 import { FaceSmileIcon } from "@heroicons/react/24/outline";
-import {
-  ComponentType,
-  MouseEvent,
-  MouseEventHandler,
-  useEffect,
-  useState,
-} from "react";
+import { ComponentType, MouseEventHandler, useEffect, useState } from "react";
 import React from "react";
 import { mutate } from "swr";
 
@@ -121,12 +115,22 @@ export function ConversationMessage({
     <div className="flex w-full gap-4">
       {/* COLUMN 1: AVATAR - in small size if small layout */}
       <div>
-        <Avatar
-          visual={pictureUrl}
-          name={name || undefined}
-          size="md"
-          busy={avatarBusy}
-        />
+        <div className="sm:hidden">
+          <Avatar
+            visual={pictureUrl}
+            name={name || undefined}
+            size="xs"
+            busy={avatarBusy}
+          />
+        </div>
+        <div className="hidden sm:block">
+          <Avatar
+            visual={pictureUrl}
+            name={name || undefined}
+            size="md"
+            busy={avatarBusy}
+          />
+        </div>
       </div>
 
       {/* COLUMN 2: CONTENT */}
@@ -244,7 +248,7 @@ interface ButtonEmojiProps {
   variant?: "selected" | "unselected";
   count?: string;
   emoji?: string;
-  onClick?: (event: MouseEvent<HTMLButtonElement>) => void;
+  onClick?: () => void;
 }
 
 export function ButtonEmoji({

--- a/front/components/assistant/conversation/ConversationMessage.tsx
+++ b/front/components/assistant/conversation/ConversationMessage.tsx
@@ -1,21 +1,15 @@
-import {
-  Avatar,
-  Button,
-  DropdownMenu,
-  IconButton,
-  PlusIcon,
-} from "@dust-tt/sparkle";
+import { Avatar, Button, DropdownMenu } from "@dust-tt/sparkle";
 import { Emoji, EmojiMartData } from "@emoji-mart/data";
 import Picker from "@emoji-mart/react";
+import { FaceSmileIcon } from "@heroicons/react/24/outline";
 import { ComponentType, MouseEventHandler, useEffect, useState } from "react";
 import React from "react";
 import { mutate } from "swr";
 
-import { classNames } from "@app/lib/utils";
 import { MessageReactionType } from "@app/types/assistant/conversation";
 import { UserType, WorkspaceType } from "@app/types/user";
 
-const MAX_REACTIONS_TO_SHOW = 15;
+const MAX_MORE_REACTIONS_TO_SHOW = 9;
 
 /**
  * Parent component for both UserMessage and AgentMessage, to ensure avatar,
@@ -98,69 +92,69 @@ export function ConversationMessage({
     });
   };
 
+  // Extracting some of the emoji logic from the render function to make it more readable
+  const reactionUp = reactions.find((r) => r.emoji === "+1");
+  const hasReactedUp =
+    reactionUp?.users.some((u) => u.userId === user.id) ?? false;
+
+  const reactionDown = reactions.find((r) => r.emoji === "-1");
+  const hasReactedDown =
+    reactionDown?.users.some((u) => u.userId === user.id) ?? false;
+
+  const reactionLove = reactions.find((r) => r.emoji === "heart");
+  const hasReactedLove =
+    reactionLove?.users.some((u) => u.userId === user.id) ?? false;
+
+  let otherReactions = reactions.filter(
+    (r) => r.emoji !== "+1" && r.emoji !== "-1" && r.emoji !== "heart"
+  );
   let hasMoreReactions = null;
-  if (reactions.length > MAX_REACTIONS_TO_SHOW) {
-    hasMoreReactions = reactions.length - MAX_REACTIONS_TO_SHOW;
-    reactions = reactions.slice(0, MAX_REACTIONS_TO_SHOW);
+  if (otherReactions.length > MAX_MORE_REACTIONS_TO_SHOW) {
+    hasMoreReactions = otherReactions.length - MAX_MORE_REACTIONS_TO_SHOW;
+    otherReactions = otherReactions.slice(0, MAX_MORE_REACTIONS_TO_SHOW);
   }
 
   return (
-    <div className="flex w-full flex-row gap-4">
-      <div className="flex-shrink-0">
-        <Avatar
-          visual={pictureUrl}
-          name={name || undefined}
-          size="md"
-          busy={avatarBusy}
-        />
+    <div className="grid grid-cols-12 gap-4">
+      {/* COLUMN 1: AVATAR - in small size if small layout */}
+      <div className="col-span-1">
+        <div className="sm:hidden">
+          <Avatar
+            visual={pictureUrl}
+            name={name || undefined}
+            size="xs"
+            busy={avatarBusy}
+          />
+        </div>
+        <div className="hidden sm:block">
+          <Avatar
+            visual={pictureUrl}
+            name={name || undefined}
+            size="md"
+            busy={avatarBusy}
+          />
+        </div>
       </div>
-      <div className="min-w-0 flex-grow">
+
+      {/* COLUMN 2: CONTENT */}
+      <div className="col-span-8">
         <div className="flex flex-col gap-4">
           <div className="text-sm font-medium">{name}</div>
           <div className="min-w-0 break-words text-base font-normal">
             {children}
           </div>
-          <div>
-            {reactions.map((reaction) => {
-              const hasReacted =
-                reaction.users.find((u) => u.userId === user.id) !== undefined;
-              const emoji = emojiData?.emojis[reaction.emoji];
-              if (!emoji) {
-                return null;
-              }
-              return (
-                <React.Fragment key={reaction.emoji}>
-                  <a
-                    className="cursor-pointer"
-                    onClick={async () => {
-                      await handleEmoji({
-                        emoji: reaction.emoji,
-                        isToRemove: hasReacted,
-                      });
-                    }}
-                  >
-                    <Reacji
-                      key={reaction.emoji}
-                      count={reaction.users.length}
-                      isHighlighted={hasReacted}
-                      emoji={emoji}
-                    ></Reacji>
-                  </a>
-                </React.Fragment>
-              );
-            })}
-            {hasMoreReactions && (
-              <span className="text-base text-xs">+{hasMoreReactions}</span>
-            )}
-          </div>
         </div>
       </div>
-      <div className="flex flex-col gap-2">
-        <div className="flex flex-col items-start gap-2 sm:flex-row">
-          {buttons &&
-            buttons.map((button, i) => (
-              <div key={`message-${messageId}-button-${i}`}>
+
+      {/* COLUMN 3: BUTTONS */}
+      <div className="col-span-3">
+        {/* COPY / RETRY */}
+        {buttons && (
+          <div className="mb-6">
+            <Button.List>
+              {buttons.map((button, i) => (
                 <Button
+                  key={`message-${messageId}-button-${i}`}
                   variant="tertiary"
                   size="xs"
                   label={button.label}
@@ -168,32 +162,68 @@ export function ConversationMessage({
                   icon={button.icon}
                   onClick={button.onClick}
                 />
-              </div>
-            ))}
-        </div>
+              ))}
+            </Button.List>
+          </div>
+        )}
 
-        <div className="duration-400 active:s-border-action-500 box-border inline-flex scale-100 cursor-pointer items-center gap-x-1 whitespace-nowrap rounded-full border border-structure-200 bg-structure-0 px-2 text-xs text-element-800 ">
-          <a
-            className="cursor-pointer px-1 py-1.5 hover:border-action-200 hover:bg-action-50 hover:drop-shadow-md active:scale-95 active:bg-action-100 active:drop-shadow-none"
+        {/* EMOJIS */}
+        <Button.List isWrapping={true}>
+          <Button
+            variant={hasReactedUp ? "secondary" : "tertiary"}
+            size="xs"
+            label={reactionUp ? `👍 ${reactionUp.users.length}` : "👍 "}
             onClick={async () => await handleEmojiClick("+1")}
-          >
-            👍
-          </a>
-          <a
-            className="cursor-pointer px-1 py-1.5 hover:border-action-200 hover:bg-action-50 hover:drop-shadow-md active:scale-95 active:bg-action-100 active:drop-shadow-none"
+          />
+          <Button
+            variant={hasReactedDown ? "secondary" : "tertiary"}
+            size="xs"
+            label={reactionDown ? `👎 ${reactionDown.users.length}` : `👎`}
             onClick={async () => await handleEmojiClick("-1")}
-          >
-            👎
-          </a>
-          <a
-            className="cursor-pointer px-1 py-1.5 hover:border-action-200 hover:bg-action-50 hover:drop-shadow-md active:scale-95 active:bg-action-100 active:drop-shadow-none"
+          />
+          <Button
+            variant={hasReactedLove ? "secondary" : "tertiary"}
+            size="xs"
+            label={reactionLove ? `❤️ ${reactionLove.users.length}` : "❤️ "}
             onClick={async () => await handleEmojiClick("heart")}
-          >
-            ❤️
-          </a>
+          />
+          {otherReactions.map((reaction) => {
+            const hasReacted = reaction.users.some((u) => u.userId === user.id);
+            const emoji = emojiData?.emojis[reaction.emoji];
+            const nativeEmoji = emoji?.skins[0].native;
+            if (!nativeEmoji) {
+              return null;
+            }
+            return (
+              <Button
+                key={reaction.emoji}
+                variant={hasReacted ? "secondary" : "tertiary"}
+                size="xs"
+                label={`${nativeEmoji} ${reaction.users.length}`}
+                onClick={async () =>
+                  await handleEmoji({
+                    emoji: reaction.emoji,
+                    isToRemove: hasReacted,
+                  })
+                }
+              />
+            );
+          })}
+          {hasMoreReactions && (
+            <span className="text-xs">+{hasMoreReactions}</span>
+          )}
+        </Button.List>
+        <div className="mt-2">
           <DropdownMenu>
             <DropdownMenu.Button>
-              <IconButton variant="tertiary" size="xs" icon={PlusIcon} />
+              <Button
+                variant="tertiary"
+                size="xs"
+                icon={FaceSmileIcon}
+                labelVisible={false}
+                label="Add another emoji"
+                type="menu"
+              />
             </DropdownMenu.Button>
             <DropdownMenu.Items width={280}>
               <Picker
@@ -220,33 +250,5 @@ export function ConversationMessage({
         </div>
       </div>
     </div>
-  );
-}
-
-function Reacji({
-  count,
-  isHighlighted,
-  emoji,
-}: {
-  count: number;
-  isHighlighted: boolean;
-  emoji: Emoji;
-}) {
-  const nativeEmoji = emoji.skins[0].native;
-  if (!nativeEmoji) {
-    return null;
-  }
-  return (
-    <span className="whitespace-nowrap pr-2">
-      {nativeEmoji}&nbsp;
-      <span
-        className={classNames(
-          "text-xs",
-          isHighlighted ? "font-bold text-action-500" : ""
-        )}
-      >
-        {count}
-      </span>
-    </span>
   );
 }


### PR DESCRIPTION
This PR puts back the emojis on the right column, requested by Ed here: https://dust4ai.slack.com/archives/C050A0S2Z7F/p1696433064220129


Because the emojis sections won't have the same size depending on wether someone has reacted, I had to move to a grid layout for the message: 
- First column for avatar: I decided to display the avatar in xs in mobile, which work really well.
- Second column for the message content. 
- Third column for all the buttons. 

Please note that the Icon used for the new emoji button is not final, just waiting for Ed to merge one of his PR. 

### On Web
![Capture d’écran 2023-10-04 à 20 54 33](https://github.com/dust-tt/dust/assets/3803406/ded4fdf1-8df4-4db6-9653-6657900bad2c)

### On Mobile
![Capture d’écran 2023-10-04 à 20 54 40](https://github.com/dust-tt/dust/assets/3803406/30667243-4a43-4977-bbed-713391343274)

