### PR TITLE
Allow null score for retrieved documents

### DIFF
--- a/connectors/src/lib/dust_api.ts
+++ b/connectors/src/lib/dust_api.ts
@@ -241,11 +241,11 @@ export type RetrievalDocumentType = {
   reference: string; // Short random string so that the model can refer to the document.
   timestamp: number;
   tags: string[];
-  score: number;
+  score: number | null;
   chunks: {
     text: string;
     offset: number;
-    score: number;
+    score: number | null;
   }[];
 };
 

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -325,8 +325,17 @@ export async function renderRetrievalActionByModelId(
         offset: c.offset,
         score: c.score,
       }));
-
-    chunks.sort((a, b) => b.score - a.score);
+    chunks.sort((a, b) => {
+      if (a.score === null && b.score === null) {
+        return a.offset - b.offset;
+      }
+      if (a.score !== null && b.score !== null) {
+        b.score - a.score;
+      }
+      throw new Error(
+        "Unexpected comparison of null and non-null scored chunks."
+      );
+    });
 
     return {
       id: d.id,
@@ -341,7 +350,17 @@ export async function renderRetrievalActionByModelId(
     };
   });
 
-  documents.sort((a, b) => b.score - a.score);
+  documents.sort((a, b) => {
+    if (a.score === null && b.score === null) {
+      return b.timestamp - a.timestamp;
+    }
+    if (a.score !== null && b.score !== null) {
+      b.score - a.score;
+    }
+    throw new Error(
+      "Unexpected comparison of null and non-null scored documents."
+    );
+  });
 
   return {
     id: action.id,

--- a/front/lib/models/assistant/actions/retrieval.ts
+++ b/front/lib/models/assistant/actions/retrieval.ts
@@ -314,7 +314,7 @@ export class RetrievalDocument extends Model<
   declare reference: string;
   declare documentTimestamp: Date;
   declare tags: string[];
-  declare score: number;
+  declare score: number | null;
 
   declare retrievalActionId: ForeignKey<AgentRetrievalAction["id"]>;
 }
@@ -390,7 +390,7 @@ export class RetrievalDocumentChunk extends Model<
 
   declare text: string;
   declare offset: number;
-  declare score: number;
+  declare score: number | null;
 
   declare retrievalDocumentId: ForeignKey<RetrievalDocument["id"]>;
 }

--- a/front/lib/models/assistant/actions/retrieval.ts
+++ b/front/lib/models/assistant/actions/retrieval.ts
@@ -362,7 +362,7 @@ RetrievalDocument.init(
     },
     score: {
       type: DataTypes.REAL,
-      allowNull: false,
+      allowNull: true,
     },
   },
   {
@@ -422,7 +422,7 @@ RetrievalDocumentChunk.init(
     },
     score: {
       type: DataTypes.REAL,
-      allowNull: false,
+      allowNull: true,
     },
   },
   {

--- a/front/types/assistant/actions/retrieval.ts
+++ b/front/types/assistant/actions/retrieval.ts
@@ -92,11 +92,11 @@ export type RetrievalDocumentType = {
   reference: string; // Short random string so that the model can refer to the document.
   timestamp: number;
   tags: string[];
-  score: number;
+  score: number | null;
   chunks: {
     text: string;
     offset: number;
-    score: number;
+    score: number | null;
   }[];
 };
 


### PR DESCRIPTION
Required for exhaustive retrieval; now it is legitimate for retrieved documents not to have a score

IMHO no need for additional code checks: when semantic seaching, qdrant is not supposed to return null scores