### PR TITLE
Start sync workflow after transaction.commit()

### DIFF
--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -55,7 +55,7 @@ export async function createNotionConnector(
   }
 
   try {
-    return await sequelize_conn.transaction(async (transaction) => {
+    const connector = await sequelize_conn.transaction(async (transaction) => {
       const connector = await Connector.create(
         {
           type: "notion",
@@ -73,9 +73,11 @@ export async function createNotionConnector(
         },
         { transaction }
       );
-      await launchNotionSyncWorkflow(connector.id.toString());
-      return new Ok(connector.id.toString());
+
+      return connector;
     });
+    await launchNotionSyncWorkflow(connector.id.toString());
+    return new Ok(connector.id.toString());
   } catch (e) {
     logger.error({ error: e }, "Error creating notion connector.");
     return new Err(e as Error);


### PR DESCRIPTION
This PR https://github.com/dust-tt/dust/pull/1907 removed all unmanaged transactions to fix an incident resulting from an unmanaged transaction never being committed nor rolled back when an exception was being thrown in the middle of the transaction.
The problem of this fix is that it did not wait for the transaction to be committed before starting a workflow, which reads the DB from a different transaction.