### PR TITLE
Fix: core: no-query retrieval gets only status "latest" documents

### DIFF
--- a/core/src/stores/postgres.rs
+++ b/core/src/stores/postgres.rs
@@ -1452,6 +1452,8 @@ impl Store for PostgresStore {
             }
         }
 
+        where_clauses.push("status = 'latest'".to_string());
+
         let serialized_where_clauses = where_clauses.join(" AND ");
 
         // compute the total count


### PR DESCRIPTION
Previously, when retrieving document ids, the same document_id can be retrieved multiple times, reaching the topK limit earlier than expected and resulting in an incomplete retrieval