### PR TITLE
Allow passing a content fragment at conversation creation

### DIFF
--- a/docs/src/pages/conversations.mdx
+++ b/docs/src/pages/conversations.mdx
@@ -290,6 +290,11 @@ The `agent_error` event is sent whenever an error occured durint the AgentMessag
     ### Optional JSON body attributes
 
     <Properties>
+      <Property name="contentFragment" type="object">
+        An initial content fragment object. See "Create a New Content Fragment" endpoint body
+        attributes for more details. The content fragment will be inserted before the user message
+        if both are specified.
+      </Property>
       <Property name="message" type="object">
         An initial user message object. See "Create a New User Message" endpoint body attributes for
         more details.
@@ -369,8 +374,9 @@ The `agent_error` event is sent whenever an error occured durint the AgentMessag
             "configuration":{...}
           }]
         ]
-      }
-      "message": {...}
+      },
+      "message": {...},
+      "contentFragment": {...}
     }
     ```
 
@@ -463,6 +469,70 @@ The `agent_error` event is sent whenever an error occured durint the AgentMessag
           "email":null,
           "profilePictureUrl": "https://dust.tt/static/systemavatar/helper_avatar_full.png"
         }
+      }
+    }
+    ```
+
+  </Col>
+</Row>
+
+---
+
+## Create a new Content Fragment {{ tag: 'POST', label: '/v1/w/:workspace_id/assistant/conversations/:conversation_id/content_fragments' }}
+
+<Row>
+  <Col>
+
+    This endpoint enables you to create a new content fragment in a conversation. Content fragments
+    are pieces of information that can be inserted in conversations and are passed as context to
+    assistants to when they generate an answer.
+
+    ### URL attributes
+
+    <Properties>
+      <Property name="workspace_id" type="string">
+        The ID of the workspace (can be found in the workspace's URL)
+      </Property>
+      <Property name="conversation_id" type="string">
+        The ID of the conversation where you want to create a content fragment.
+      </Property>
+    </Properties>
+
+    ### JSON body attributes
+
+
+    <Properties>
+      <Property name="content" type="string">
+        A string representing the content of the fragment. It must be a non-empty string of less
+        than 64kb.
+      </Property>
+      <Property name="title" type="string">
+        A string representing the title of the fragment. It must be a non-empty string.
+      </Property>
+    </Properties>
+
+  </Col>
+  <Col sticky>
+
+    <CodeGroup title="Request" tag="POST" label="/v1/w/:workspace_id/assistant/conversations/:conversation_id/content_fragments">
+
+    ```bash {{ title: 'cURL' }}
+    curl https://dust.tt/api/v1/w/workspace1/assistant/conversations/conversation1/content_fragments \
+      -H "Authorization: Bearer sk-..." \
+      -H "Content-Type: application/json" \
+      -d '{
+        "content": "This is a content fragment.",
+        "title": "Content Fragment Title"
+      }'
+    ```
+
+    </CodeGroup>
+
+    ```json {{ title: 'Response' }}
+    {
+      "contentFragment": {
+        "title": "Content Fragment Title",
+        "content": "This is a content fragment."
       }
     }
     ```
@@ -720,67 +790,6 @@ The `agent_error` event is sent whenever an error occured durint the AgentMessag
         "configurationId": "helper",
         "messageId": "d349842779",
         "text": "World"
-      }
-    }
-    ```
-
-  </Col>
-</Row>
-
----
-
-## Add a new Content Fragment {{ tag: 'POST', label: '/v1/w/:workspace_id/assistant/conversations/:conversation_id/content_fragments' }}
-
-<Row>
-  <Col>
-
-    This endpoint enables you to create a new content fragment in a conversation. Content fragments are pieces of information that can be inserted in conversations and are passed to assistants as part of the context.
-
-    ### URL attributes
-
-    <Properties>
-      <Property name="workspace_id" type="string">
-        The ID of the workspace (can be found in the workspace's URL)
-      </Property>
-      <Property name="conversation_id" type="string">
-        The ID of the conversation where you want to create a content fragment.
-      </Property>
-    </Properties>
-
-    ### JSON body attributes
-
-
-    <Properties>
-      <Property name="content" type="string">
-        A string representing the content of the fragment. It must be a non-empty string of less than 64kb.
-      </Property>
-      <Property name="title" type="string">
-        A string representing the title of the fragment. It must be a non-empty string.
-      </Property>
-    </Properties>
-
-  </Col>
-  <Col sticky>
-
-    <CodeGroup title="Request" tag="POST" label="/v1/w/:workspace_id/assistant/conversations/:conversation_id/content_fragments">
-
-    ```bash {{ title: 'cURL' }}
-    curl https://dust.tt/api/v1/w/workspace1/assistant/conversations/conversation1/content_fragments \
-      -H "Authorization: Bearer sk-..." \
-      -H "Content-Type: application/json" \
-      -d '{
-        "content": "This is a content fragment.",
-        "title": "Content Fragment Title"
-      }'
-    ```
-
-    </CodeGroup>
-
-    ```json {{ title: 'Response' }}
-    {
-      "contentFragment": {
-        "title": "Content Fragment Title",
-        "content": "This is a content fragment."
       }
     }
     ```

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -6,6 +6,7 @@ import { NextApiRequest, NextApiResponse } from "next";
 import {
   createConversation,
   getConversation,
+  postNewContentFragment,
 } from "@app/lib/api/assistant/conversation";
 import { postUserMessageWithPubSub } from "@app/lib/api/assistant/pubsub";
 import { Authenticator, getAPIKey } from "@app/lib/auth";
@@ -13,9 +14,12 @@ import { ReturnedAPIErrorType } from "@app/lib/error";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import { PostMessagesRequestBodySchema } from "@app/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages";
 import {
+  ContentFragmentType,
   ConversationType,
   UserMessageType,
 } from "@app/types/assistant/conversation";
+
+import { PostContentFragmentRequestBodySchema } from "./[cId]/content_fragments";
 
 const PostConversationsRequestBodySchema = t.type({
   title: t.union([t.string, t.null]),
@@ -25,11 +29,13 @@ const PostConversationsRequestBodySchema = t.type({
     t.literal("deleted"),
   ]),
   message: t.union([PostMessagesRequestBodySchema, t.null]),
+  contentFragment: t.union([PostContentFragmentRequestBodySchema, t.null]),
 });
 
 export type PostConversationsResponseBody = {
   conversation: ConversationType;
   message?: UserMessageType;
+  contentFragment?: ContentFragmentType;
 };
 
 async function handler(
@@ -85,12 +91,42 @@ async function handler(
         });
       }
 
-      const { title, visibility, message } = bodyValidation.right;
+      const { title, visibility, message, contentFragment } =
+        bodyValidation.right;
 
-      const conversation = await createConversation(auth, {
+      if (contentFragment) {
+        if (
+          contentFragment.content.length === 0 ||
+          contentFragment.content.length > 64 * 1024
+        ) {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message:
+                "The content must be a non-empty string of less than 64kb.",
+            },
+          });
+        }
+      }
+
+      let conversation = await createConversation(auth, {
         title,
         visibility,
       });
+
+      let newContentFragment: ContentFragmentType | null = null;
+      let newMessage: UserMessageType | null = null;
+
+      if (contentFragment) {
+        const cf = await postNewContentFragment(auth, {
+          conversation,
+          title: contentFragment.title,
+          content: contentFragment.content,
+        });
+
+        newContentFragment = cf;
+      }
 
       if (message) {
         // If a message was provided we do await for the message to be posted before returning the
@@ -112,22 +148,29 @@ async function handler(
           return apiError(req, res, messageRes.error);
         }
 
-        // If we got the user message we know that the agent messages have been created as well, so
-        // we pull the conversation again to have the created agent message included so that the
-        // user of the API can start streaming events from these agent messages directly.
+        newMessage = messageRes.value;
+      }
+
+      if (newContentFragment || newMessage) {
+        // If we created a user message or a content fragment (or both) we retrieve the
+        // conversation. If a user message was posted, we know that the agent messages have been
+        // created as well, so pulling the conversation again will allow to have an up to date view
+        // of the conversation with agent messages included so that the user of the API can start
+        // streaming events from these agent messages directly.
         const updated = await getConversation(auth, conversation.sId);
 
         if (!updated) {
           throw `Conversation unexpectedly not found after creation: ${conversation.sId}`;
         }
 
-        res
-          .status(200)
-          .json({ conversation: updated, message: messageRes.value });
-      } else {
-        // Otherwise we simply return the conversation created.
-        res.status(200).json({ conversation });
+        conversation = updated;
       }
+
+      res.status(200).json({
+        conversation,
+        message: newMessage ?? undefined,
+        contentFragment: newContentFragment ?? undefined,
+      });
       return;
 
     default:

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -28,8 +28,8 @@ const PostConversationsRequestBodySchema = t.type({
     t.literal("workspace"),
     t.literal("deleted"),
   ]),
-  message: t.union([PostMessagesRequestBodySchema, t.null]),
-  contentFragment: t.union([PostContentFragmentRequestBodySchema, t.null]),
+  message: t.union([PostMessagesRequestBodySchema, t.undefined]),
+  contentFragment: t.union([PostContentFragmentRequestBodySchema, t.undefined]),
 });
 
 export type PostConversationsResponseBody = {


### PR DESCRIPTION
Fixes #1958 

- Allow passing a content fragment as part of the conversation creation (API)
- Update to docs
- Move message (and contentFragment) as undefined instead of null in the schema so that they are really optional