### PR TITLE
feat: add connectors endpoint to link slack channel and agent

### DIFF
--- a/connectors/src/api/slack_channel_link_with_agent.ts
+++ b/connectors/src/api/slack_channel_link_with_agent.ts
@@ -1,0 +1,86 @@
+import { Request, Response } from "express";
+import { isLeft } from "fp-ts/lib/Either";
+import * as t from "io-ts";
+import * as reporter from "io-ts-reporters";
+
+import { APIErrorWithStatusCode } from "@connectors/lib/error";
+import { SlackChannel } from "@connectors/lib/models";
+import { apiError, withLogging } from "@connectors/logger/withlogging";
+
+const LinkSlackChannelWithAgentReqBodySchema = t.type({
+  connectorId: t.string,
+  agentConfigurationId: t.string,
+});
+
+type LinkSlackChannelWithAgentReqBody = t.TypeOf<
+  typeof LinkSlackChannelWithAgentReqBodySchema
+>;
+
+type LinkSlackChannelWithAgentResBody =
+  | { success: true }
+  | APIErrorWithStatusCode;
+
+const _linkSlackChannelWithAgentHandler = async (
+  req: Request<
+    {
+      slackChannelId: string;
+    },
+    LinkSlackChannelWithAgentResBody,
+    LinkSlackChannelWithAgentReqBody
+  >,
+  res: Response<LinkSlackChannelWithAgentResBody>
+) => {
+  if (!req.params.slackChannelId) {
+    return apiError(req, res, {
+      api_error: {
+        type: "invalid_request_error",
+        message: "Missing required parameters. Required: slackChannelId",
+      },
+      status_code: 400,
+    });
+  }
+
+  const { slackChannelId } = req.params;
+
+  const bodyValidation = LinkSlackChannelWithAgentReqBodySchema.decode(
+    req.body
+  );
+
+  if (isLeft(bodyValidation)) {
+    const pathError = reporter.formatValidationErrors(bodyValidation.left);
+    return apiError(req, res, {
+      api_error: {
+        type: "invalid_request_error",
+        message: `Invalid request body: ${pathError}`,
+      },
+      status_code: 400,
+    });
+  }
+
+  const { connectorId, agentConfigurationId } = bodyValidation.right;
+
+  const slackChannel = await SlackChannel.findOne({
+    where: { connectorId, slackChannelId },
+  });
+
+  if (!slackChannel) {
+    return apiError(req, res, {
+      api_error: {
+        type: "slack_channel_not_found",
+        message: `Slack channel not found for connectorId ${connectorId} and slackChannelId ${slackChannelId}`,
+      },
+      status_code: 404,
+    });
+  }
+
+  slackChannel.agentConfigurationId = agentConfigurationId;
+  await slackChannel.save();
+
+  res.status(200).send({
+    success: true,
+  });
+};
+
+export const linkSlackChannelWithAgentHandler = withLogging(
+  _linkSlackChannelWithAgentHandler
+);

--- a/connectors/src/api_server.ts
+++ b/connectors/src/api_server.ts
@@ -22,6 +22,7 @@ import { authMiddleware } from "@connectors/middleware/auth";
 
 import { getResourcesParentsAPIHandler } from "./api/get_resources_parents";
 import { getResourcesTitlesAPIHandler } from "./api/get_resources_titles";
+import { linkSlackChannelWithAgentHandler } from "./api/slack_channel_link_with_agent";
 
 export function startServer(port: number) {
   const app = express();
@@ -69,6 +70,11 @@ export function startServer(port: number) {
   app.post(
     "/connectors/:connector_id/permissions",
     setConnectorPermissionsAPIHandler
+  );
+
+  app.post(
+    "/slack/channels/:slackChannelId/link_with_agent",
+    linkSlackChannelWithAgentHandler
   );
 
   app.post("/webhooks/:webhook_secret/slack", webhookSlackAPIHandler);

--- a/connectors/src/connectors/slack/lib/channels.ts
+++ b/connectors/src/connectors/slack/lib/channels.ts
@@ -12,6 +12,7 @@ export type SlackChannelType = {
   name: string;
   slackId: string;
   permission: ConnectorPermission;
+  agentConfigurationId: string | null;
 };
 
 export async function upsertSlackChannelInConnectorsDb({
@@ -70,6 +71,7 @@ export async function upsertSlackChannelInConnectorsDb({
       name: channel.slackChannelName,
       slackId: channel.slackChannelId,
       permission: channel.permission,
+      agentConfigurationId: channel.agentConfigurationId,
     };
   });
 }

--- a/connectors/src/lib/error.ts
+++ b/connectors/src/lib/error.ts
@@ -7,7 +7,8 @@ export type APIErrorType =
   | "connector_update_error"
   | "connector_update_unauthorized"
   | "connector_oauth_target_mismatch"
-  | "not_found";
+  | "not_found"
+  | "slack_channel_not_found";
 
 export type APIError = {
   type: APIErrorType;

--- a/connectors/src/lib/models.ts
+++ b/connectors/src/lib/models.ts
@@ -255,6 +255,7 @@ export class SlackChannel extends Model<
   declare slackChannelName: string;
 
   declare permission: ConnectorPermission;
+  declare agentConfigurationId: CreationOptional<string | null>;
 }
 
 SlackChannel.init(
@@ -290,6 +291,10 @@ SlackChannel.init(
       type: DataTypes.STRING,
       allowNull: false,
       defaultValue: "read_write",
+    },
+    agentConfigurationId: {
+      type: DataTypes.STRING,
+      allowNull: true,
     },
   },
   {

--- a/front/lib/connectors_api.ts
+++ b/front/lib/connectors_api.ts
@@ -336,6 +336,30 @@ export const ConnectorsAPI = {
 
     return _resultFromResponse(res);
   },
+
+  async linkSlackChannelWithAgent({
+    connectorId,
+    slackChannelId,
+    agentConfigurationId,
+  }: {
+    connectorId: string;
+    slackChannelId: string;
+    agentConfigurationId: string;
+  }): Promise<ConnectorsAPIResponse<{ success: true }>> {
+    const res = await fetch(
+      `${CONNECTORS_API}/slack/channels/${slackChannelId}/link_with_agent`,
+      {
+        method: "POST",
+        headers: getDefaultHeaders(),
+        body: JSON.stringify({
+          connectorId,
+          agentConfigurationId,
+        }),
+      }
+    );
+
+    return _resultFromResponse(res);
+  },
 };
 
 function getDefaultHeaders() {


### PR DESCRIPTION
https://github.com/dust-tt/dust/issues/1963

This doesn't implement the logic on slackbot side