### PR TITLE
Store dataSourceWorkspaceId on RetrievalDocument to create proper links

### DIFF
--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -324,12 +324,19 @@ function _processCiteMention(
         .map((key) => {
           const k = key.trim();
           const ref = references[k];
-          if (ref && ref.sourceUrl) {
+          if (ref) {
             if (!refCounter[k]) {
               counter++;
               refCounter[k] = counter;
             }
-            return `[<${ref.sourceUrl}|${refCounter[k]}>]`;
+            const link = ref.sourceUrl
+              ? ref.sourceUrl
+              : `${DUST_API}/w/${
+                  ref.dataSourceWorkspaceId
+                }/builder/data-sources/${
+                  ref.dataSourceId
+                }/upsert?documentId=${encodeURIComponent(ref.documentId)}`;
+            return `[<${link}|${refCounter[k]}>]`;
           }
           return "";
         })

--- a/connectors/src/lib/dust_api.ts
+++ b/connectors/src/lib/dust_api.ts
@@ -235,6 +235,7 @@ export type RetrievalActionType = {
 };
 
 export type RetrievalDocumentType = {
+  dataSourceWorkspaceId: string;
   dataSourceId: string;
   sourceUrl: string | null;
   documentId: string;

--- a/front/components/assistant/RenderMessageMarkdown.tsx
+++ b/front/components/assistant/RenderMessageMarkdown.tsx
@@ -1,7 +1,7 @@
 import {
   ClipboardCheckIcon,
   ClipboardIcon,
-  DocumentDuplicateStrokeIcon,
+  DocumentTextIcon,
   IconButton,
   Tooltip,
 } from "@dust-tt/sparkle";
@@ -27,6 +27,7 @@ import { RetrievalDocumentType } from "@app/types/assistant/actions/retrieval";
 import { AgentConfigurationType } from "@app/types/assistant/agent";
 
 import {
+  linkFromDocument,
   PROVIDER_LOGO_PATH,
   providerFromDocument,
   titleFromDocument,
@@ -77,7 +78,6 @@ function citeDirective() {
             .map((ref: string) => ({
               counter: counter(ref),
               ref,
-              link: "https://dust.tt",
             }));
 
           // `sup` will then be mapped to a custom component `CiteBlock`.
@@ -215,7 +215,6 @@ function CiteBlockWrapper(references: {
         JSON.parse(props.references) as {
           counter: number;
           ref: string;
-          link: string;
         }[]
       ).filter((r) => r.ref in references);
 
@@ -226,6 +225,8 @@ function CiteBlockWrapper(references: {
 
             const provider = providerFromDocument(document);
             const title = titleFromDocument(document);
+            const link = linkFromDocument(document);
+
             const citeClassNames = classNames(
               "rounded-md bg-structure-100 px-1",
               "text-xs font-semibold text-action-500",
@@ -241,7 +242,7 @@ function CiteBlockWrapper(references: {
                         {provider !== "none" ? (
                           <img src={PROVIDER_LOGO_PATH[provider]}></img>
                         ) : (
-                          <DocumentDuplicateStrokeIcon className="h-4 w-4 text-slate-500" />
+                          <DocumentTextIcon className="h-4 w-4 text-slate-500" />
                         )}
                       </div>
                       <div className="text-md flex whitespace-nowrap">
@@ -251,19 +252,15 @@ function CiteBlockWrapper(references: {
                   }
                   position="below"
                 >
-                  {document.sourceUrl ? (
-                    <a
-                      // TODO(spolu): for custom data source add data source name to title
-                      href={document.sourceUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className={citeClassNames}
-                    >
-                      {r.counter}
-                    </a>
-                  ) : (
-                    <span className={citeClassNames}>{r.counter}</span>
-                  )}
+                  <a
+                    // TODO(spolu): for custom data source add data source name to title
+                    href={link}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={citeClassNames}
+                  >
+                    {r.counter}
+                  </a>
                 </Tooltip>
               </sup>
             );

--- a/front/components/assistant/conversation/RetrievalAction.tsx
+++ b/front/components/assistant/conversation/RetrievalAction.tsx
@@ -225,7 +225,9 @@ export function linkFromDocument(document: RetrievalDocumentType): string {
   if (document.sourceUrl) {
     return document.sourceUrl;
   } else {
-    return `https://dust.tt/w/${document.dataSourceWorkspaceId}/builder/data-sources/${
+    return `https://dust.tt/w/${
+      document.dataSourceWorkspaceId
+    }/builder/data-sources/${
       document.dataSourceId
     }/upsert?documentId=${encodeURIComponent(document.documentId)}`;
   }

--- a/front/components/assistant/conversation/RetrievalAction.tsx
+++ b/front/components/assistant/conversation/RetrievalAction.tsx
@@ -2,7 +2,7 @@ import {
   ChevronDownIcon,
   ChevronRightIcon,
   Chip,
-  DocumentDuplicateStrokeIcon,
+  DocumentTextIcon,
   Icon,
   Spinner,
   Tooltip,
@@ -75,7 +75,7 @@ export default function RetrievalAction({
             </div>
           )}
         </div>
-        <div className="row-span-1">
+        <div className="row-span-1 select-none">
           {retrievalAction.documents && (
             <div
               onClick={() => setDocListVisible(!docListVisible)}
@@ -103,18 +103,18 @@ export default function RetrievalAction({
               leaveFrom="opacity-100 scale-100"
               leaveTo="opacity-0 scale-95"
             >
-              <ul className="ml-2 gap-2">
+              <ul className="ml-2 flex flex-col gap-y-2">
                 {retrievalAction.documents.map((document, i) => {
                   const provider = providerFromDocument(document);
                   return (
                     <li key={i}>
                       <a
-                        href={document.sourceUrl || ""}
-                        className="front-bold text-xs text-element-800"
+                        href={linkFromDocument(document)}
+                        className="front-bold flex flex-row items-center text-xs text-element-800"
                         target="_blank"
                       >
                         {provider === "none" ? (
-                          <DocumentDuplicateStrokeIcon className="mr-1 inline-block h-4 w-4 text-element-500" />
+                          <DocumentTextIcon className="mr-1 inline-block h-4 w-4 text-slate-500" />
                         ) : (
                           <img
                             src={
@@ -149,7 +149,7 @@ function RetrievedDocumentsInfo(documents: RetrievalDocumentType[]) {
               {summary[k].provider !== "none" ? (
                 <img src={PROVIDER_LOGO_PATH[summary[k].provider]}></img>
               ) : (
-                <DocumentDuplicateStrokeIcon className="h-4 w-4 text-slate-500" />
+                <DocumentTextIcon className="h-4 w-4 text-slate-500" />
               )}
             </div>
             <div className="flex-initial text-gray-700">{summary[k].count}</div>
@@ -219,4 +219,14 @@ export function titleFromDocument(document: RetrievalDocumentType): string {
   }
 
   return document.documentId;
+}
+
+export function linkFromDocument(document: RetrievalDocumentType): string {
+  if (document.sourceUrl) {
+    return document.sourceUrl;
+  } else {
+    return `https://dust.tt/w/${document.dataSourceWorkspaceId}/builder/data-sources/${
+      document.dataSourceId
+    }/upsert?documentId=${encodeURIComponent(document.documentId)}`;
+  }
 }

--- a/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
+++ b/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
@@ -1,6 +1,5 @@
 import {
   CloudArrowDownIcon,
-  DocumentDuplicateIcon,
   Item,
   Modal,
   PageHeader,
@@ -165,7 +164,7 @@ function PickDataSource({
               icon={
                 ds.connectorProvider
                   ? CONNECTOR_CONFIGURATIONS[ds.connectorProvider].logoComponent
-                  : DocumentDuplicateIcon
+                  : CloudArrowDownIcon
               }
               key={ds.name}
               size="md"

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -599,6 +599,10 @@ export async function* runRetrieval(
   const run = res.value;
   let documents: RetrievalDocumentType[] = [];
 
+  // This is not perfect and will be erroneous in case of two data sources with the same id from two
+  // different workspaces. We don't support cross workspace data sources right now. But we'll likely
+  // want `core` to return the `workspace_id` that was used eventualy.
+  // TODO(spolu): make `core` return data source workspace id.
   const dataSourcesIdToWorkspaceId: { [key: string]: string } = {};
   for (const ds of c.dataSources) {
     dataSourcesIdToWorkspaceId[ds.dataSourceId] = ds.workspaceId;

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -340,6 +340,7 @@ export async function renderRetrievalActionByModelId(
 
     return {
       id: d.id,
+      dataSourceWorkspaceId: d.dataSourceWorkspaceId,
       dataSourceId: d.dataSourceId,
       sourceUrl: d.sourceUrl,
       documentId: d.documentId,
@@ -598,6 +599,11 @@ export async function* runRetrieval(
   const run = res.value;
   let documents: RetrievalDocumentType[] = [];
 
+  const dataSourcesIdToWorkspaceId: { [key: string]: string } = {};
+  for (const ds of c.dataSources) {
+    dataSourcesIdToWorkspaceId[ds.dataSourceId] = ds.workspaceId;
+  }
+
   for (const t of run.traces) {
     if (t[1][0][0].error) {
       yield {
@@ -633,6 +639,7 @@ export async function* runRetrieval(
         const reference = refs[i % refs.length];
         return {
           id: 0, // dummy pending database insertion
+          dataSourceWorkspaceId: dataSourcesIdToWorkspaceId[d.data_source_id],
           dataSourceId: d.data_source_id,
           documentId: d.document_id,
           reference,
@@ -656,6 +663,7 @@ export async function* runRetrieval(
     for (const d of documents) {
       const document = await RetrievalDocument.create(
         {
+          dataSourceWorkspaceId: d.dataSourceWorkspaceId,
           dataSourceId: d.dataSourceId,
           sourceUrl: d.sourceUrl,
           documentId: d.documentId,

--- a/front/lib/models/assistant/actions/retrieval.ts
+++ b/front/lib/models/assistant/actions/retrieval.ts
@@ -308,6 +308,7 @@ export class RetrievalDocument extends Model<
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
+  declare dataSourceWorkspaceId: string;
   declare dataSourceId: string;
   declare sourceUrl: string | null;
   declare documentId: string;
@@ -335,6 +336,10 @@ RetrievalDocument.init(
       type: DataTypes.DATE,
       allowNull: false,
       defaultValue: DataTypes.NOW,
+    },
+    dataSourceWorkspaceId: {
+      type: DataTypes.STRING,
+      allowNull: true,
     },
     dataSourceId: {
       type: DataTypes.STRING,

--- a/front/migrations/20231005_populate_retrieved_documents_workspace_id.ts
+++ b/front/migrations/20231005_populate_retrieved_documents_workspace_id.ts
@@ -1,0 +1,134 @@
+import { Op } from "sequelize";
+
+import { ModelId } from "@app/lib/databases";
+import {
+  AgentMessage,
+  Conversation,
+  Message,
+  RetrievalDocument,
+  Workspace,
+} from "@app/lib/models";
+
+const { LIVE = false } = process.env;
+
+async function main() {
+  console.log("Fetching Upgraded Worspaces...");
+  const workspaces = await Workspace.findAll({});
+  console.log(
+    `Found ${workspaces.length} workspaces for which to add largeModels = true`
+  );
+
+  const chunkSize = 16;
+  const chunks = [];
+  for (let i = 0; i < workspaces.length; i += chunkSize) {
+    chunks.push(workspaces.slice(i, i + chunkSize));
+  }
+
+  for (let i = 0; i < chunks.length; i++) {
+    console.log(`Processing chunk ${i}/${chunks.length}...`);
+    const chunk = chunks[i];
+    await Promise.all(
+      chunk.map((workspace: Workspace) => {
+        return updateAllConversations(!!LIVE, workspace);
+      })
+    );
+  }
+}
+
+async function updateAllConversations(live: boolean, workspace: Workspace) {
+  const conversations = await Conversation.findAll({
+    where: {
+      workspaceId: workspace.id,
+    },
+  });
+
+  const chunkSize = 16;
+  const chunks = [];
+  for (let i = 0; i < conversations.length; i += chunkSize) {
+    chunks.push(conversations.slice(i, i + chunkSize));
+  }
+
+  for (let i = 0; i < chunks.length; i++) {
+    console.log(`Processing chunk ${i}/${chunks.length}...`);
+    const chunk = chunks[i];
+    await Promise.all(
+      chunk.map((c: Conversation) => {
+        return updateConversation(live, c, workspace);
+      })
+    );
+  }
+}
+
+async function updateConversation(
+  live: boolean,
+  conversation: Conversation,
+  workspace: Workspace
+) {
+  const messages = await Message.findAll({
+    where: {
+      // where conversationId = conversation.id
+      // and agentMessageId is not null
+      [Op.and]: [
+        {
+          conversationId: conversation.id,
+          agentMessageId: {
+            [Op.ne]: null,
+          },
+        },
+      ],
+    },
+  });
+
+  await Promise.all(
+    messages.map((message) => {
+      return updateMessage(
+        live,
+        conversation,
+        message.agentMessageId as number,
+        workspace
+      );
+    })
+  );
+}
+
+async function updateMessage(
+  live: boolean,
+  conversation: Conversation,
+  agentMessageId: ModelId,
+  workspace: Workspace
+) {
+  const m = await AgentMessage.findByPk(agentMessageId);
+  if (m?.agentRetrievalActionId) {
+    const documents = await RetrievalDocument.findAll({
+      where: {
+        retrievalActionId: m.agentRetrievalActionId,
+      },
+    });
+    console.log(
+      `LIVE=${live} workspace=${workspace.sId} conversation=${conversation.sId} documents=${documents.length}`
+    );
+
+    if (live) {
+      await RetrievalDocument.update(
+        {
+          dataSourceWorkspaceId: workspace.sId,
+        },
+        {
+          where: {
+            retrievalActionId: m.agentRetrievalActionId,
+          },
+        }
+      );
+    }
+  }
+}
+
+main()
+  .then(() => {
+    console.log("done");
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/front/types/assistant/actions/retrieval.ts
+++ b/front/types/assistant/actions/retrieval.ts
@@ -86,6 +86,7 @@ export function isRetrievalConfiguration(
 
 export type RetrievalDocumentType = {
   id: ModelId;
+  dataSourceWorkspaceId: string;
   dataSourceId: string;
   sourceUrl: string | null;
   documentId: string;


### PR DESCRIPTION
Fixes #1913

- Add dataSourceWorkspaceId to RetrievalDocument (allowNull=true for now)
- Migration to populate the workspaceId knowning that all retrievael are happening within workspace today
- Leverage dataSourceWorkspaceId to be able to create links for data sources without a sourceUrl
- Use DocumentTextIcon instead of DucplicateDocumentIcon 
- Fix alignment of text and icons in RetrieavalAciton list
- Fix display of citation for slack bot when no dataSource is present
- Fix linking in RenderMarkdown and the RetrievalAction list

Deployment:
- init_db on front
- run migration
- deploy front
- deploy connectors
- run migration again

The follow-up PR to set allowNull: true