### PR TITLE
Default to UTC if no timezone is available

### DIFF
--- a/front/pages/w/[wId]/assistant/[cId]/index.tsx
+++ b/front/pages/w/[wId]/assistant/[cId]/index.tsx
@@ -70,7 +70,7 @@ export default function AssistantConversation({
         body: JSON.stringify({
           content: input,
           context: {
-            timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+            timezone: Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC",
             profilePictureUrl: user.image,
           },
           mentions,

--- a/front/pages/w/[wId]/assistant/new.tsx
+++ b/front/pages/w/[wId]/assistant/new.tsx
@@ -104,7 +104,7 @@ export default function AssistantNew({
       message: {
         content: input,
         context: {
-          timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+          timezone: Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC",
           profilePictureUrl: user.image,
         },
         mentions,


### PR DESCRIPTION
Despite the type system it's possible for some users to get `undefined`. Default to `UTC`.