### PR TITLE
Add support for Slack follow up

### DIFF
--- a/connectors/src/api/webhooks/webhook_slack.ts
+++ b/connectors/src/api/webhooks/webhook_slack.ts
@@ -52,6 +52,7 @@ async function handleChatBot(req: Request, res: Response) {
   const slackChannel = req.body.event.channel;
   const slackUserId = req.body.event.user;
   const slackMessageTs = req.body.event.ts;
+  const slackThreadTs = req.body.event.thread_ts || null;
   if (
     !slackMessage ||
     !slackTeamId ||
@@ -76,7 +77,8 @@ async function handleChatBot(req: Request, res: Response) {
     slackTeamId,
     slackChannel,
     slackUserId,
-    slackMessageTs
+    slackMessageTs,
+    slackThreadTs
   );
   if (botRes.isErr()) {
     logger.error(

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -324,8 +324,8 @@ async function botAnswerMessage(
   const agentMessage = agentMessages[0] as AgentMessageType;
 
   const streamRes = await dustAPI.streamAgentMessageEvents({
-    conversationId: conversation.sId,
-    messageId: agentMessage.sId,
+    conversation: conversation,
+    message: agentMessage,
   });
 
   if (streamRes.isErr()) {

--- a/connectors/src/lib/dust_api.ts
+++ b/connectors/src/lib/dust_api.ts
@@ -411,11 +411,11 @@ export class DustAPI {
   }
 
   async streamAgentMessageEvents({
-    conversationId,
-    messageId,
+    conversation,
+    message,
   }: {
-    conversationId: string;
-    messageId: string;
+    conversation: ConversationType;
+    message: AgentMessageType;
   }) {
     const headers = {
       "Content-Type": "application/json",
@@ -423,7 +423,9 @@ export class DustAPI {
     };
 
     const res = await fetch(
-      `${DUST_API}/api/v1/w/${this.workspaceId()}/assistant/conversations/${conversationId}/messages/${messageId}/events`,
+      `${DUST_API}/api/v1/w/${this.workspaceId()}/assistant/conversations/${
+        conversation.sId
+      }/messages/${message.sId}/events`,
       {
         method: "GET",
         headers: headers,

--- a/connectors/src/lib/dust_api.ts
+++ b/connectors/src/lib/dust_api.ts
@@ -91,7 +91,7 @@ const PostConversationsRequestBodySchemaIoTs = t.type({
     t.literal("workspace"),
     t.literal("deleted"),
   ]),
-  message: t.union([PostMessagesRequestBodySchemaIoTs, t.null]),
+  message: t.union([PostMessagesRequestBodySchemaIoTs, t.undefined]),
 });
 
 type PostConversationsRequestBodySchema = t.TypeOf<

--- a/connectors/src/lib/models.ts
+++ b/connectors/src/lib/models.ts
@@ -326,6 +326,7 @@ export class SlackChatBotMessage extends Model<
   declare slackAvatar: string | null;
   declare slackTimezone: string | null;
   declare messageTs: string | null;
+  declare threadTs: string | null;
   declare chatSessionSid: string | null;
   declare completedAt: Date | null;
   declare conversationId: string | null; // conversationId is set only for V2 conversations
@@ -354,6 +355,10 @@ SlackChatBotMessage.init(
       allowNull: false,
     },
     messageTs: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
+    threadTs: {
       type: DataTypes.STRING,
       allowNull: true,
     },


### PR DESCRIPTION
Adding support for Slack follow up conversation:
Talking to the bot multiple times in the same thread would end up posting user message in the same conversation.

ContentFragment will be in a follow up PR, which will be highly facilitated by this one.