### PR TITLE
Cloud build accept optional param with path

### DIFF
--- a/.github/workflows/deploy-alerting-temporal.yml
+++ b/.github/workflows/deploy-alerting-temporal.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Build the image on Cloud Build
         run: |
           chmod +x ./k8s/cloud-build.sh
-          ./k8s/cloud-build.sh alerting/temporal
+          ./k8s/cloud-build.sh alerting-temporal alerting/temporal
 
       - name: Deploy the image on Kubernetes
         run: |

--- a/k8s/cloud-build.sh
+++ b/k8s/cloud-build.sh
@@ -1,12 +1,14 @@
 #!/bin/sh
 # first arg : name of image to build
+# second arg (optional) : working directory. If not provided, it defaults to "../$1"
 set -e
 
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" >/dev/null 2>&1 && pwd)"
+WORKING_DIR="${2:-${SCRIPT_DIR}/../$1}"
 
 # Change the current working directory to the directory in which to build the image
-cd "${SCRIPT_DIR}/../$1"
+cd "$WORKING_DIR"
 
 # Check the current working directory
 echo "Current working directory is $(pwd)"


### PR DESCRIPTION
cloud-build expect that the name of the image correspond to the path of the project. 
We need to tweak it to be able to have image called "alerting-temporal" in "/alerting/temporal" 


```sh
./k8s/cloud-build.sh "alerting-temporal" "alerting/temporal"
Current working directory is /Users/daph/space/dust/alerting/temporal
```
```sh
./k8s/cloud-build.sh "blog"
Current working directory is /Users/daph/space/dust/blog
```