### PR TITLE
Fix mention for Assistants pinged via Slackbot

### DIFF
--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -236,7 +236,7 @@ async function botAnswerMessage(
         });
         message = message.replace(
           mc,
-          `:mention[${bestCandidate.assistantName}]{${bestCandidate.assistantId}}`
+          `:mention[${bestCandidate.assistantName}]{sId=${bestCandidate.assistantId}}`
         );
       }
     }

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -236,7 +236,7 @@ async function botAnswerMessage(
         });
         message = message.replace(
           mc,
-          `:metion[${bestCandidate.assistantName}]{${bestCandidate.assistantId}}`
+          `:mention[${bestCandidate.assistantName}]{${bestCandidate.assistantId}}`
         );
       }
     }


### PR DESCRIPTION
I noticed the mention was not there when pinging soupinou from slack: 
https://dust.tt/w/0ec9852c2f/assistant/b260777d36

And on the database: 
<img width="1305" alt="Capture d’écran 2023-10-06 à 16 01 20" src="https://github.com/dust-tt/dust/assets/3803406/6db51c19-94ec-478e-bedf-7aeb15f9758a">

We expect this format: `:mention[helper]{sId=helper}`

