### PR TITLE
Allow scrolling tabs for dust apps on mobile

### DIFF
--- a/front/pages/w/[wId]/a/[aId]/clone.tsx
+++ b/front/pages/w/[wId]/a/[aId]/clone.tsx
@@ -149,7 +149,7 @@ export default function CloneView({
       hideSidebar
     >
       <div className="flex w-full flex-col">
-        <div className="mt-2">
+        <div className="mt-2 overflow-x-auto scrollbar-hide">
           <Tab tabs={subNavigationApp({ owner, app, current: "settings" })} />
         </div>
         <div className="mt-8 flex flex-1">

--- a/front/pages/w/[wId]/a/[aId]/datasets/[name]/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/datasets/[name]/index.tsx
@@ -169,7 +169,7 @@ export default function ViewDatasetView({
       hideSidebar
     >
       <div className="flex w-full flex-col">
-        <div className="mt-2">
+        <div className="mt-2 overflow-x-scroll">
           <Tab tabs={subNavigationApp({ owner, app, current: "datasets" })} />
         </div>
         <div className="mt-8 flex flex-col">

--- a/front/pages/w/[wId]/a/[aId]/datasets/[name]/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/datasets/[name]/index.tsx
@@ -169,7 +169,7 @@ export default function ViewDatasetView({
       hideSidebar
     >
       <div className="flex w-full flex-col">
-        <div className="mt-2 overflow-x-scroll">
+        <div className="mt-2 overflow-x-auto scrollbar-hide">
           <Tab tabs={subNavigationApp({ owner, app, current: "datasets" })} />
         </div>
         <div className="mt-8 flex flex-col">

--- a/front/pages/w/[wId]/a/[aId]/datasets/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/datasets/index.tsx
@@ -111,7 +111,7 @@ export default function DatasetsView({
       hideSidebar
     >
       <div className="flex w-full flex-col">
-        <div className="mt-2 overflow-x-scroll">
+        <div className="mt-2 overflow-x-auto scrollbar-hide">
           <Tab tabs={subNavigationApp({ owner, app, current: "datasets" })} />
         </div>
         <div className="mt-8 flex flex-col">

--- a/front/pages/w/[wId]/a/[aId]/datasets/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/datasets/index.tsx
@@ -111,7 +111,7 @@ export default function DatasetsView({
       hideSidebar
     >
       <div className="flex w-full flex-col">
-        <div className="mt-2">
+        <div className="mt-2 overflow-x-scroll">
           <Tab tabs={subNavigationApp({ owner, app, current: "datasets" })} />
         </div>
         <div className="mt-8 flex flex-col">

--- a/front/pages/w/[wId]/a/[aId]/datasets/new.tsx
+++ b/front/pages/w/[wId]/a/[aId]/datasets/new.tsx
@@ -142,7 +142,7 @@ export default function NewDatasetView({
       hideSidebar
     >
       <div className="flex w-full flex-col">
-        <div className="mt-2 overflow-x-scroll">
+        <div className="mt-2 overflow-x-auto scrollbar-hide">
           <Tab tabs={subNavigationApp({ owner, app, current: "datasets" })} />
         </div>
         <div className="mt-8 flex flex-col">

--- a/front/pages/w/[wId]/a/[aId]/datasets/new.tsx
+++ b/front/pages/w/[wId]/a/[aId]/datasets/new.tsx
@@ -142,7 +142,7 @@ export default function NewDatasetView({
       hideSidebar
     >
       <div className="flex w-full flex-col">
-        <div className="mt-2">
+        <div className="mt-2 overflow-x-scroll">
           <Tab tabs={subNavigationApp({ owner, app, current: "datasets" })} />
         </div>
         <div className="mt-8 flex flex-col">

--- a/front/pages/w/[wId]/a/[aId]/execute/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/execute/index.tsx
@@ -585,7 +585,7 @@ export default function ExecuteView({
       hideSidebar
     >
       <div className="flex w-full flex-col">
-        <div className="mt-2 overflow-x-scroll">
+        <div className="mt-2 overflow-x-auto scrollbar-hide">
           <Tab tabs={subNavigationApp({ owner, app, current: "execute" })} />
         </div>
         <div className="mt-8 flex flex-col">

--- a/front/pages/w/[wId]/a/[aId]/execute/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/execute/index.tsx
@@ -585,7 +585,7 @@ export default function ExecuteView({
       hideSidebar
     >
       <div className="flex w-full flex-col">
-        <div className="mt-2">
+        <div className="mt-2 overflow-x-scroll">
           <Tab tabs={subNavigationApp({ owner, app, current: "execute" })} />
         </div>
         <div className="mt-8 flex flex-col">

--- a/front/pages/w/[wId]/a/[aId]/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/index.tsx
@@ -325,7 +325,7 @@ export default function AppView({
       }
     >
       <div className="flex w-full flex-col">
-        <div className="mt-2 overflow-x-auto">
+        <div className="mt-2 overflow-x-auto scrollbar-hide">
           <Tab
             tabs={subNavigationApp({ owner, app, current: "specification" })}
           />

--- a/front/pages/w/[wId]/a/[aId]/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/index.tsx
@@ -325,7 +325,7 @@ export default function AppView({
       }
     >
       <div className="flex w-full flex-col">
-        <div className="mt-2">
+        <div className="mt-2 overflow-x-auto">
           <Tab
             tabs={subNavigationApp({ owner, app, current: "specification" })}
           />

--- a/front/pages/w/[wId]/a/[aId]/runs/[runId]/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/runs/[runId]/index.tsx
@@ -158,7 +158,7 @@ export default function AppRun({
       hideSidebar
     >
       <div className="flex w-full flex-col">
-        <div className="mt-2 overflow-x-auto">
+        <div className="mt-2 overflow-x-auto scrollbar-hide">
           <Tab tabs={subNavigationApp({ owner, app, current: "runs" })} />
         </div>
         <div className="mt-8 flex flex-col">

--- a/front/pages/w/[wId]/a/[aId]/runs/[runId]/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/runs/[runId]/index.tsx
@@ -158,7 +158,7 @@ export default function AppRun({
       hideSidebar
     >
       <div className="flex w-full flex-col">
-        <div className="mt-2">
+        <div className="mt-2 overflow-x-auto">
           <Tab tabs={subNavigationApp({ owner, app, current: "runs" })} />
         </div>
         <div className="mt-8 flex flex-col">

--- a/front/pages/w/[wId]/a/[aId]/runs/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/runs/index.tsx
@@ -145,7 +145,7 @@ export default function RunsView({
       hideSidebar
     >
       <div className="flex w-full flex-col">
-        <div className="mt-2">
+        <div className="mt-2 overflow-x-scroll">
           <Tab tabs={subNavigationApp({ owner, app, current: "runs" })} />
         </div>
         <div className="mt-8 flex">

--- a/front/pages/w/[wId]/a/[aId]/runs/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/runs/index.tsx
@@ -145,7 +145,7 @@ export default function RunsView({
       hideSidebar
     >
       <div className="flex w-full flex-col">
-        <div className="mt-2 overflow-x-scroll">
+        <div className="mt-2 overflow-x-auto scrollbar-hide">
           <Tab tabs={subNavigationApp({ owner, app, current: "runs" })} />
         </div>
         <div className="mt-8 flex">

--- a/front/pages/w/[wId]/a/[aId]/settings.tsx
+++ b/front/pages/w/[wId]/a/[aId]/settings.tsx
@@ -174,7 +174,7 @@ export default function SettingsView({
       hideSidebar
     >
       <div className="flex w-full flex-col">
-        <div className="mt-2">
+        <div className="mt-2 overflow-x-scroll">
           <Tab tabs={subNavigationApp({ owner, app, current: "settings" })} />
         </div>
         <div className="mt-8 flex flex-1">

--- a/front/pages/w/[wId]/a/[aId]/settings.tsx
+++ b/front/pages/w/[wId]/a/[aId]/settings.tsx
@@ -174,7 +174,7 @@ export default function SettingsView({
       hideSidebar
     >
       <div className="flex w-full flex-col">
-        <div className="mt-2 overflow-x-scroll">
+        <div className="mt-2 overflow-x-auto scrollbar-hide">
           <Tab tabs={subNavigationApp({ owner, app, current: "settings" })} />
         </div>
         <div className="mt-8 flex flex-1">

--- a/front/pages/w/[wId]/a/[aId]/settings.tsx
+++ b/front/pages/w/[wId]/a/[aId]/settings.tsx
@@ -340,7 +340,7 @@ export default function SettingsView({
                 </div>
               </div>
             </div>
-            <div className="flex pt-6">
+            <div className="flex py-6">
               <Button
                 disabled={disable || isUpdating || isDeleting}
                 onClick={handleUpdate}

--- a/front/pages/w/[wId]/a/[aId]/specification.tsx
+++ b/front/pages/w/[wId]/a/[aId]/specification.tsx
@@ -110,7 +110,7 @@ export default function Specification({
       hideSidebar
     >
       <div className="flex w-full flex-col">
-        <div className="mt-2 overflow-x-scroll">
+        <div className="mt-2 overflow-x-auto scrollbar-hide">
           <Tab
             tabs={subNavigationApp({ owner, app, current: "specification" })}
           />

--- a/front/pages/w/[wId]/a/[aId]/specification.tsx
+++ b/front/pages/w/[wId]/a/[aId]/specification.tsx
@@ -110,7 +110,7 @@ export default function Specification({
       hideSidebar
     >
       <div className="flex w-full flex-col">
-        <div className="mt-2">
+        <div className="mt-2 overflow-x-scroll">
           <Tab
             tabs={subNavigationApp({ owner, app, current: "specification" })}
           />


### PR DESCRIPTION
Eng runner task #2

scroll is visible at first (shows it's scrollable), then disappears on scroll (which is the default behaviour on mobile)

There are maybe cleaner solutions, but IMHO it's the right 80/20 for this relatively rare situation (dust app devs on mobile)
![Screenshot from 2023-10-06 17-25-25](https://github.com/dust-tt/dust/assets/5437393/f6046ec1-2535-4be7-90aa-b1d4b1d549e6)

![Screenshot from 2023-10-06 17-25-33](https://github.com/dust-tt/dust/assets/5437393/bf0c9473-072a-48c7-8efb-d17a953c908a)
