### PR TITLE
Take prompt into account in accounting for tokens

### DIFF
--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -74,6 +74,7 @@ export async function generateActionInputs(
   const modelConversationRes = await renderConversationForModel({
     conversation,
     model,
+    prompt,
     allowedTokenCount:
       GPT_4_32K_MODEL_CONFIG.contextSize - MIN_GENERATION_TOKENS,
   });

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -534,6 +534,7 @@ export async function generateConversationTitle(
   const modelConversationRes = await renderConversationForModel({
     conversation,
     model,
+    prompt: "", // There is no prompt for title generation.
     allowedTokenCount,
   });
 


### PR DESCRIPTION
Fix #2001 

Verified creating an assistant with a very long prompt. I get failures on main which are now handled with this fix.
We should probably enforce a limit on the length of a prompt...