### PR TITLE
Fix nav admin workspace condition

### DIFF
--- a/front/components/sparkle/navigation.tsx
+++ b/front/components/sparkle/navigation.tsx
@@ -133,21 +133,23 @@ export const subNavigationAdmin = ({
     ],
   });
 
-  nav.push({
-    id: "workspace",
-    label: "Workspace",
-    menus: [
-      {
-        id: "workspace",
-        label: "Settings",
-        icon: KeyIcon,
-        href: `/w/${owner.sId}/workspace`,
-        current: current === "workspace",
-        subMenuLabel: current === "workspace" ? subMenuLabel : undefined,
-        subMenu: current === "workspace" ? subMenu : undefined,
-      },
-    ],
-  });
+  if (owner.role === "admin") {
+    nav.push({
+      id: "workspace",
+      label: "Workspace",
+      menus: [
+        {
+          id: "workspace",
+          label: "Settings",
+          icon: KeyIcon,
+          href: `/w/${owner.sId}/workspace`,
+          current: current === "workspace",
+          subMenuLabel: current === "workspace" ? subMenuLabel : undefined,
+          subMenu: current === "workspace" ? subMenu : undefined,
+        },
+      ],
+    });
+  }
 
   nav.push({
     id: "developers",


### PR DESCRIPTION
Actually here I missed something: https://github.com/dust-tt/dust/pull/2005/files
Workspace navigation to edit the settings is only for admin not builder! 
(no issue has the other code was not deployed yet).