### PR TITLE
Citations UI at the bottom (no summary)

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -43,7 +43,8 @@ import {
   PROVIDER_LOGO_PATH,
   providerFromDocument,
   titleFromDocument,
-} from "./RetrievalAction";
+} from "@app/components/assistant/conversation/RetrievalAction";
+import { classNames } from "@app/lib/utils";
 
 export function AgentMessage({
   message,
@@ -375,19 +376,30 @@ export function AgentMessage({
     const citationContainer = useRef<HTMLDivElement>(null);
 
     useEffect(() => {
-      if (citationContainer.current && lastHoveredReference !== null) {
-        // get the offset of the first child in its container
-        const offset = (
-          citationContainer.current.firstElementChild
-            ?.firstElementChild as HTMLElement
-        ).offsetLeft;
-        const scrolling =
-          (citationContainer.current.firstElementChild?.firstElementChild
-            ?.scrollWidth || 0) *
-          (lastHoveredReference - 2);
-        citationContainer.current.scrollLeft = scrolling - offset;
+      if (citationContainer.current) {
+        if (lastHoveredReference !== null) {
+          citationContainer.current.scrollTo({
+            left: citationsScrollOffset(lastHoveredReference),
+            behavior: "smooth",
+          });
+        }
       }
-    });
+    }, [lastHoveredReference]);
+
+    function citationsScrollOffset(reference: number | null) {
+      if (!citationContainer.current || reference === null) {
+        return 0;
+      }
+      const offset = (
+        citationContainer.current.firstElementChild
+          ?.firstElementChild as HTMLElement
+      ).offsetLeft;
+      const scrolling =
+        (citationContainer.current.firstElementChild?.firstElementChild
+          ?.scrollWidth || 0) *
+        (reference - 2);
+      return scrolling - offset;
+    }
 
     activeReferences.sort((a, b) => a.index - b.index);
     return (
@@ -401,7 +413,12 @@ export function AgentMessage({
             const provider = providerFromDocument(document);
             return (
               <div
-                className="flex w-48 flex-none flex-col gap-2 rounded-xl border border-structure-100 p-3 sm:w-64"
+                className={classNames(
+                  "flex w-48 flex-none flex-col gap-2 rounded-xl border border-structure-100 p-3 sm:w-64",
+                  lastHoveredReference === index
+                    ? "animate-[bgblink_500ms_3]"
+                    : ""
+                )}
                 key={index}
               >
                 <div className="flex items-center gap-1.5">

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -6,17 +6,23 @@ import {
   DocumentDuplicateIcon,
   DocumentTextIcon,
   DropdownMenu,
+  ExternalLinkIcon,
   EyeIcon,
   IconButton,
-  LinkStrokeIcon,
   Spinner,
 } from "@dust-tt/sparkle";
 import Link from "next/link";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useContext, useEffect, useRef, useState } from "react";
 
 import { AgentAction } from "@app/components/assistant/conversation/AgentAction";
 import { ConversationMessage } from "@app/components/assistant/conversation/ConversationMessage";
 import { GenerationContext } from "@app/components/assistant/conversation/GenerationContextProvider";
+import {
+  linkFromDocument,
+  PROVIDER_LOGO_PATH,
+  providerFromDocument,
+  titleFromDocument,
+} from "@app/components/assistant/conversation/RetrievalAction";
 import { RenderMessageMarkdown } from "@app/components/assistant/RenderMessageMarkdown";
 import { useEventSource } from "@app/hooks/useEventSource";
 import {
@@ -28,6 +34,7 @@ import {
   AgentMessageSuccessEvent,
 } from "@app/lib/api/assistant/agent";
 import { GenerationTokensEvent } from "@app/lib/api/assistant/generation";
+import { classNames } from "@app/lib/utils";
 import {
   isRetrievalActionType,
   RetrievalDocumentType,
@@ -37,14 +44,6 @@ import {
   MessageReactionType,
 } from "@app/types/assistant/conversation";
 import { UserType, WorkspaceType } from "@app/types/user";
-
-import {
-  linkFromDocument,
-  PROVIDER_LOGO_PATH,
-  providerFromDocument,
-  titleFromDocument,
-} from "@app/components/assistant/conversation/RetrievalAction";
-import { classNames } from "@app/lib/utils";
 
 export function AgentMessage({
   message,
@@ -338,12 +337,15 @@ export function AgentMessage({
               content={agentMessage.content}
               blinkingCursor={streaming}
               citationsContext={{
-              references,
-              updateActiveReferences,
-              setHoveredReference: setLastHoveredReference,
-            }}
-          />
-            <Citations activeReferences={activeReferences} />
+                references,
+                updateActiveReferences,
+                setHoveredReference: setLastHoveredReference,
+              }}
+            />
+            <Citations
+              activeReferences={activeReferences}
+              lastHoveredReference={lastHoveredReference}
+            />
           </div>
         )}
         {agentMessage.status === "cancelled" && (
@@ -368,93 +370,95 @@ export function AgentMessage({
       }
     );
   }
-  function Citations({
-    activeReferences,
-  }: {
-    activeReferences: { index: number; document: RetrievalDocumentType }[];
-  }) {
-    const citationContainer = useRef<HTMLDivElement>(null);
+}
 
-    useEffect(() => {
-      if (citationContainer.current) {
-        if (lastHoveredReference !== null) {
-          citationContainer.current.scrollTo({
-            left: citationsScrollOffset(lastHoveredReference),
-            behavior: "smooth",
-          });
-        }
-      }
-    }, [lastHoveredReference]);
+function Citations({
+  activeReferences,
+  lastHoveredReference,
+}: {
+  activeReferences: { index: number; document: RetrievalDocumentType }[];
+  lastHoveredReference: number | null;
+}) {
+  const citationContainer = useRef<HTMLDivElement>(null);
 
-    function citationsScrollOffset(reference: number | null) {
-      if (!citationContainer.current || reference === null) {
-        return 0;
+  useEffect(() => {
+    if (citationContainer.current) {
+      if (lastHoveredReference !== null) {
+        citationContainer.current.scrollTo({
+          left: citationsScrollOffset(lastHoveredReference),
+          behavior: "smooth",
+        });
       }
-      const offset = (
-        citationContainer.current.firstElementChild
-          ?.firstElementChild as HTMLElement
-      ).offsetLeft;
-      const scrolling =
-        (citationContainer.current.firstElementChild?.firstElementChild
-          ?.scrollWidth || 0) *
-        (reference - 2);
-      return scrolling - offset;
     }
+  }, [lastHoveredReference]);
 
-    activeReferences.sort((a, b) => a.index - b.index);
-    return (
-      <div
-        className="-mx-[100%] mt-9 overflow-x-auto px-[100%] scrollbar-hide"
-        id={`message-${message.sId}-citations`}
-        ref={citationContainer}
-      >
-        <div className="left-100 relative flex gap-2">
-          {activeReferences.map(({ document, index }) => {
-            const provider = providerFromDocument(document);
-            return (
-              <div
-                className={classNames(
-                  "flex w-48 flex-none flex-col gap-2 rounded-xl border border-structure-100 p-3 sm:w-64",
-                  lastHoveredReference === index
-                    ? "animate-[bgblink_500ms_3]"
-                    : ""
-                )}
-                key={index}
-              >
-                <div className="flex items-center gap-1.5">
-                  <div className="flex h-5 w-5 items-center justify-center rounded-full border border-violet-200 bg-violet-100 text-xs font-semibold text-element-800">
-                    {index}
-                  </div>
-                  <div className="h-5 w-5">
-                    {provider === "none" ? (
-                      <DocumentTextIcon className="h-5 w-5 text-slate-500" />
-                    ) : (
-                      <img
-                        src={PROVIDER_LOGO_PATH[providerFromDocument(document)]}
-                        className="h-5 w-5"
-                      />
-                    )}
-                  </div>
-                  <div className="flex-grow text-xs" />
-                  <Link href={linkFromDocument(document)} target="_blank">
-                    <IconButton
-                      icon={LinkStrokeIcon}
-                      size="xs"
-                      variant="primary"
-                    />
-                  </Link>
-                </div>
-                <div className="text-xs font-bold text-element-900">
-                  {titleFromDocument(document)}
-                </div>
-              </div>
-            );
-          })}
-          <div className="h-1 w-[100%] flex-none" />
-        </div>
-      </div>
-    );
+  function citationsScrollOffset(reference: number | null) {
+    if (!citationContainer.current || reference === null) {
+      return 0;
+    }
+    const offset = (
+      citationContainer.current.firstElementChild
+        ?.firstElementChild as HTMLElement
+    ).offsetLeft;
+    const scrolling =
+      (citationContainer.current.firstElementChild?.firstElementChild
+        ?.scrollWidth || 0) *
+      (reference - 2);
+    return scrolling - offset;
   }
+
+  activeReferences.sort((a, b) => a.index - b.index);
+  return (
+    <div
+      className="-mx-[100%] mt-9 overflow-x-auto px-[100%] scrollbar-hide"
+      ref={citationContainer}
+    >
+      <div className="left-100 relative flex gap-2">
+        {activeReferences.map(({ document, index }) => {
+          const provider = providerFromDocument(document);
+          return (
+            <div
+              className={classNames(
+                "flex w-48 flex-none flex-col gap-2 rounded-xl border border-structure-100 p-3 sm:w-64",
+                lastHoveredReference === index
+                  ? "animate-[bgblink_500ms_3]"
+                  : ""
+              )}
+              key={index}
+            >
+              <div className="flex items-center gap-1.5">
+                <div className="flex h-5 w-5 items-center justify-center rounded-full border border-violet-200 bg-violet-100 text-xs font-semibold text-element-800">
+                  {index}
+                </div>
+                <div className="h-5 w-5">
+                  {provider === "none" ? (
+                    <DocumentTextIcon className="h-5 w-5 text-slate-500" />
+                  ) : (
+                    <img
+                      src={PROVIDER_LOGO_PATH[providerFromDocument(document)]}
+                      className="h-5 w-5"
+                    />
+                  )}
+                </div>
+                <div className="flex-grow text-xs" />
+                <Link href={linkFromDocument(document)} target="_blank">
+                  <IconButton
+                    icon={ExternalLinkIcon}
+                    size="xs"
+                    variant="primary"
+                  />
+                </Link>
+              </div>
+              <div className="text-xs font-bold text-element-900">
+                {titleFromDocument(document)}
+              </div>
+            </div>
+          );
+        })}
+        <div className="h-1 w-[100%] flex-none" />
+      </div>
+    </div>
+  );
 }
 
 function ErrorMessage({

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -372,8 +372,8 @@ function Citations({
 }) {
   activeReferences.sort((a, b) => a.index - b.index);
   return (
-    <div className="w-[110%] overflow-x-auto scrollbar-hide sm:w-[120%]">
-      <div className="mt-9 flex gap-2">
+    <div className="-mx-[100%] mt-9 overflow-x-auto px-[100%] scrollbar-hide">
+      <div className="flex gap-2">
         {activeReferences.map(({ document, index }) => {
           const provider = providerFromDocument(document);
           return (
@@ -410,6 +410,7 @@ function Citations({
             </div>
           );
         })}
+        <div className="h-1 w-[100%] flex-none" />
       </div>
     </div>
   );

--- a/front/components/assistant/conversation/ConversationMessage.tsx
+++ b/front/components/assistant/conversation/ConversationMessage.tsx
@@ -112,54 +112,19 @@ export function ConversationMessage({
   }
 
   return (
-    <div className="flex w-full gap-4">
-      {/* COLUMN 1: AVATAR - in small size if small layout */}
-      <div>
-        <div className="sm:hidden">
-          <Avatar
-            visual={pictureUrl}
-            name={name || undefined}
-            size="xs"
-            busy={avatarBusy}
-          />
-        </div>
-        <div className="hidden sm:block">
-          <Avatar
-            visual={pictureUrl}
-            name={name || undefined}
-            size="md"
-            busy={avatarBusy}
-          />
-        </div>
-      </div>
-
-      {/* COLUMN 2: CONTENT
-       * min-w-0 prevents the content from overflowing the container
-       */}
-      <div className="flex min-w-0 flex-grow flex-col gap-4">
-        <div className="text-sm font-medium">{name}</div>
-        <div className="min-w-0 break-words text-base font-normal">
-          {children}
-        </div>
-      </div>
-
-      {/* COLUMN 3: BUTTONS */}
-      <div className="w-16  overflow-visible">
-        <div className="w-[8vw]">
-          {/* COPY / RETRY */}
-          {buttons && (
-            <div className="mb-6 flex flex-wrap gap-1">
-              {buttons.map((button, i) => (
-                <Button
-                  key={`message-${messageId}-button-${i}`}
-                  variant="tertiary"
-                  size="xs"
-                  label={button.label}
-                  labelVisible={false}
-                  icon={button.icon}
-                  onClick={button.onClick}
-                />
-              ))}
+    <>
+      {/* SMALL SIZE SCREEN*/}
+      <div className="flex w-full gap-4 xl:hidden">
+        <div className="flex flex-grow flex-col gap-4">
+          <div className="flex items-start gap-2">
+            <div className="flex h-8 flex-grow items-center gap-2">
+              <Avatar
+                visual={pictureUrl}
+                name={name || undefined}
+                size="xs"
+                busy={avatarBusy}
+              />
+              <div className="flex-grow text-sm font-medium">{name}</div>
             </div>
             <div className="flex flex-col items-end gap-2">
               {/* COPY / RETRY */}
@@ -274,7 +239,9 @@ export function ConversationMessage({
           busy={avatarBusy}
         />
 
-        {/* COLUMN 2: CONTENT */}
+        {/* COLUMN 2: CONTENT
+         * min-w-0 prevents the content from overflowing the container
+         */}
         <div className="flex min-w-0 flex-grow flex-col gap-4">
           <div className="text-sm font-medium">{name}</div>
           <div className="min-w-0 break-words text-base font-normal">

--- a/front/components/assistant/conversation/ConversationMessage.tsx
+++ b/front/components/assistant/conversation/ConversationMessage.tsx
@@ -112,19 +112,54 @@ export function ConversationMessage({
   }
 
   return (
-    <>
-      {/* SMALL SIZE SCREEN*/}
-      <div className="flex w-full gap-4 xl:hidden">
-        <div className="flex flex-grow flex-col gap-4">
-          <div className="flex items-start gap-2">
-            <div className="flex h-8 flex-grow items-center gap-2">
-              <Avatar
-                visual={pictureUrl}
-                name={name || undefined}
-                size="xs"
-                busy={avatarBusy}
-              />
-              <div className="flex-grow text-sm font-medium">{name}</div>
+    <div className="flex w-full gap-4">
+      {/* COLUMN 1: AVATAR - in small size if small layout */}
+      <div>
+        <div className="sm:hidden">
+          <Avatar
+            visual={pictureUrl}
+            name={name || undefined}
+            size="xs"
+            busy={avatarBusy}
+          />
+        </div>
+        <div className="hidden sm:block">
+          <Avatar
+            visual={pictureUrl}
+            name={name || undefined}
+            size="md"
+            busy={avatarBusy}
+          />
+        </div>
+      </div>
+
+      {/* COLUMN 2: CONTENT
+       * min-w-0 prevents the content from overflowing the container
+       */}
+      <div className="flex min-w-0 flex-grow flex-col gap-4">
+        <div className="text-sm font-medium">{name}</div>
+        <div className="min-w-0 break-words text-base font-normal">
+          {children}
+        </div>
+      </div>
+
+      {/* COLUMN 3: BUTTONS */}
+      <div className="w-16  overflow-visible">
+        <div className="w-[8vw]">
+          {/* COPY / RETRY */}
+          {buttons && (
+            <div className="mb-6 flex flex-wrap gap-1">
+              {buttons.map((button, i) => (
+                <Button
+                  key={`message-${messageId}-button-${i}`}
+                  variant="tertiary"
+                  size="xs"
+                  label={button.label}
+                  labelVisible={false}
+                  icon={button.icon}
+                  onClick={button.onClick}
+                />
+              ))}
             </div>
             <div className="flex flex-col items-end gap-2">
               {/* COPY / RETRY */}

--- a/front/components/assistant/conversation/ConversationMessage.tsx
+++ b/front/components/assistant/conversation/ConversationMessage.tsx
@@ -115,7 +115,7 @@ export function ConversationMessage({
     <>
       {/* SMALL SIZE SCREEN*/}
       <div className="flex w-full gap-4 xl:hidden">
-        <div className="flex flex-grow flex-col gap-4">
+        <div className="flex w-full flex-grow flex-col gap-4">
           <div className="flex items-start gap-2">
             <div className="flex h-8 flex-grow items-center gap-2">
               <Avatar

--- a/front/components/sparkle/AppLayout.tsx
+++ b/front/components/sparkle/AppLayout.tsx
@@ -361,7 +361,7 @@ export default function AppLayout({
           >
             <div
               className={classNames(
-                "mx-auto h-full",
+                "mx-auto h-full overflow-x-hidden",
                 isWideMode ? "w-full" : "max-w-4xl px-6"
               )}
             >

--- a/front/styles/global.css
+++ b/front/styles/global.css
@@ -67,3 +67,13 @@ main {
     transform: translate3d(8px, 3px, 0);
   }
 }
+
+@keyframes bgblink {
+  0%,
+  100% {
+    @apply bg-structure-0;
+  }
+  50% {
+    @apply bg-structure-200;
+  }
+}


### PR DESCRIPTION
Related issue #1990

Notes

- No ArrowOutofBox icon => used LinkIcon as a placeholder
- Citations' appearances are streamed (a citation appear when the citation link appears)
- Did as per figma with overflowing citations and hidden scroll
  - question mark on intuitivity of hidden scroll for users (shift+scroll is not natural for everybody)
  - => should we get it to switch to natural horizontal scroll on hover on citations (without shift)? spent 5mn to look how to do it but apparently this is [non-standard](https://github.com/tailwindlabs/tailwindcss/discussions/7869). it could still be done using a pure JS solution, WDYT?
  - experimented with grids of 3 citations per row (2 on mobile) but with many citations it takes too much space 
![Screenshot from 2023-10-08 20-39-57](https://github.com/dust-tt/dust/assets/5437393/69ac86f8-c721-4708-9220-89c7f55145b8)
![Screenshot from 2023-10-08 20-36-37](https://github.com/dust-tt/dust/assets/5437393/011cf9a3-bd70-4ee9-859c-a88d5f3295e3)

On mobile
![Screenshot from 2023-10-08 20-40-28](https://github.com/dust-tt/dust/assets/5437393/498a28ce-5302-4638-b0a2-41e718fb7df4)
