### PR TITLE
Add descriptions to dataset properties, store dataset schemas

### DIFF
--- a/front/components/app/DatasetView.tsx
+++ b/front/components/app/DatasetView.tsx
@@ -373,7 +373,6 @@ export default function DatasetView({
       datasetTypesValidation(),
       {
         name: datasetName.slice(0, MODELS_STRING_MAX_LENGTH),
-        // keys: datasetKeys,
         description: (datasetDescription || "").slice(
           0,
           MODELS_STRING_MAX_LENGTH
@@ -405,7 +404,6 @@ export default function DatasetView({
         valid,
         {
           name: datasetName.slice(0, MODELS_STRING_MAX_LENGTH),
-          // keys: datasetKeys,
           description: (datasetDescription || "").slice(
             0,
             MODELS_STRING_MAX_LENGTH

--- a/front/components/app/DatasetView.tsx
+++ b/front/components/app/DatasetView.tsx
@@ -16,7 +16,7 @@ import { checkDatasetData } from "@app/lib/datasets";
 import { getDatasetTypes, getValueType } from "@app/lib/datasets";
 import { MODELS_STRING_MAX_LENGTH } from "@app/lib/utils";
 import { classNames } from "@app/lib/utils";
-import { DatasetEntry, DatasetType } from "@app/types/dataset";
+import { DatasetEntry, DatasetSchema, DatasetType } from "@app/types/dataset";
 
 const CodeEditor = dynamic(
   () => import("@uiw/react-textarea-code-editor").then((mod) => mod.default),
@@ -84,16 +84,19 @@ export default function DatasetView({
   readOnly,
   datasets,
   dataset,
+  schema,
   onUpdate,
   nameDisabled,
 }: {
   readOnly: boolean;
   datasets: DatasetType[];
   dataset: DatasetType | null;
+  schema: DatasetSchema | null;
   onUpdate: (
     initializing: boolean,
     valid: boolean,
-    dataset: DatasetType
+    dataset: DatasetType,
+    schema: DatasetSchema
   ) => void;
   nameDisabled: boolean;
 }) {
@@ -113,9 +116,13 @@ export default function DatasetView({
     dataset.description
   );
   const [datasetData, setDatasetData] = useState(dataset.data || []);
-
-  const [datasetKeys, setDatasetKeys] = useState(checkDatasetData(datasetData));
-  const [datasetTypes, setDatasetTypes] = useState([] as string[]);
+  const [datasetKeys, setDatasetKeys] = useState(
+    checkDatasetData({ data: datasetData })
+  );
+  const [datasetKeyDescriptions, setDatasetKeyDescriptions] = useState<
+    string[]
+  >((schema || []).map((s) => s.description || ""));
+  const [datasetTypes, setDatasetTypes] = useState<string[]>([]);
   const [datasetInitializing, setDatasetInitializing] = useState(true);
 
   const datasetNameValidation = () => {
@@ -200,6 +207,21 @@ export default function DatasetView({
     }
   };
 
+  const inferSchema = (): DatasetSchema => {
+    if (datasetData.length > 0) {
+      const types = getDatasetTypes(datasetKeys, datasetData[0]);
+      return types.map((t, i) => {
+        return {
+          key: datasetKeys[i],
+          type: t,
+          description: datasetKeyDescriptions[i] || null,
+        };
+      });
+    } else {
+      return [];
+    }
+  };
+
   const handleKeyUpdate = (i: number, newKey: string) => {
     const oldKey = datasetKeys[i];
     const data = datasetData.map((d) => {
@@ -242,8 +264,12 @@ export default function DatasetView({
     setDatasetKeys(keys);
 
     const types = datasetTypes;
-    types[i + 1] = "string";
+    types.splice(i + 1, 0, "string");
     setDatasetTypes(types);
+
+    const descriptions = datasetKeyDescriptions;
+    descriptions.splice(i + 1, 0, "");
+    setDatasetKeyDescriptions(descriptions);
   };
 
   const handleDeleteKey = (i: number) => {
@@ -252,11 +278,25 @@ export default function DatasetView({
       return d;
     });
 
+    setDatasetData(data);
+
     const keys = datasetKeys.map((k) => k);
     keys.splice(i, 1);
-
-    setDatasetData(data);
     setDatasetKeys(keys);
+
+    const types = datasetTypes;
+    types.splice(i, 1);
+    setDatasetTypes(types);
+
+    const descriptions = datasetKeyDescriptions.map((d) => d);
+    descriptions.splice(i, 1);
+    setDatasetKeyDescriptions(descriptions);
+  };
+
+  const handleKeyDescriptionChange = (i: number, value: any) => {
+    const descriptions = [...datasetKeyDescriptions];
+    descriptions[i] = value;
+    setDatasetKeyDescriptions(descriptions);
   };
 
   const handleValueChange = (i: number, k: string, value: any) => {
@@ -316,23 +356,32 @@ export default function DatasetView({
     }
     let keys = [] as string[];
     try {
-      keys = checkDatasetData(data);
+      keys = checkDatasetData({
+        data,
+      });
     } catch (e) {
       window.alert(`${e}`);
     }
 
     setDatasetKeys(keys);
+    setDatasetKeyDescriptions(keys.map(() => ""));
     setDatasetData(data);
     setDatasetTypes([]);
-    onUpdate(datasetInitializing, datasetTypesValidation(), {
-      name: datasetName.slice(0, MODELS_STRING_MAX_LENGTH),
-      // keys: datasetKeys,
-      description: (datasetDescription || "").slice(
-        0,
-        MODELS_STRING_MAX_LENGTH
-      ),
-      data: datasetData,
-    });
+
+    onUpdate(
+      datasetInitializing,
+      datasetTypesValidation(),
+      {
+        name: datasetName.slice(0, MODELS_STRING_MAX_LENGTH),
+        // keys: datasetKeys,
+        description: (datasetDescription || "").slice(
+          0,
+          MODELS_STRING_MAX_LENGTH
+        ),
+        data: datasetData,
+      },
+      inferSchema()
+    );
   };
 
   const handleFileUpload = (file: File) => {
@@ -351,18 +400,30 @@ export default function DatasetView({
 
     if (onUpdate) {
       // TODO(spolu): Optimize, as it might not be great to send the entire data on each update.
-      onUpdate(datasetInitializing, valid, {
-        name: datasetName.slice(0, MODELS_STRING_MAX_LENGTH),
-        // keys: datasetKeys,
-        description: (datasetDescription || "").slice(
-          0,
-          MODELS_STRING_MAX_LENGTH
-        ),
-        data: exportDataset(),
-      });
+      onUpdate(
+        datasetInitializing,
+        valid,
+        {
+          name: datasetName.slice(0, MODELS_STRING_MAX_LENGTH),
+          // keys: datasetKeys,
+          description: (datasetDescription || "").slice(
+            0,
+            MODELS_STRING_MAX_LENGTH
+          ),
+          data: exportDataset(),
+        },
+        inferSchema()
+      );
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [datasetName, datasetDescription, datasetData, datasetKeys, datasetTypes]);
+  }, [
+    datasetName,
+    datasetDescription,
+    datasetData,
+    datasetKeys,
+    datasetKeyDescriptions,
+    datasetTypes,
+  ]);
 
   return (
     <div>
@@ -420,13 +481,14 @@ export default function DatasetView({
           {!readOnly ? (
             <p className="mt-2 text-sm text-gray-500">
               Set the properties and types to ensure your dataset is valid when
-              you update it.
+              you update it. The properties descriptions are used to generate
+              the inputs to your app when run from an Assistant.
             </p>
           ) : null}
         </div>
 
         <div className="sm:col-span-5">
-          <div className="space-y-[1px]">
+          <div className="space-y-2">
             {datasetKeys.map((k, j) => (
               <div key={j} className="grid sm:grid-cols-10">
                 <div className="sm:col-span-3">
@@ -434,7 +496,7 @@ export default function DatasetView({
                     <div className="flex flex-1">
                       <input
                         className={classNames(
-                          "font-mono w-full border-0 bg-slate-300 px-1 py-1 text-[13px] font-normal outline-none focus:outline-none",
+                          "font-mono w-full border-0 bg-slate-300 px-1 py-1 text-[13px] font-bold outline-none focus:outline-none",
                           readOnly
                             ? "border-white ring-0 focus:border-white focus:ring-0"
                             : "border-white ring-0 focus:border-gray-300 focus:ring-0"
@@ -477,7 +539,7 @@ export default function DatasetView({
                     </span>
                   ) : (
                     <div className="inline-flex" role="group">
-                      {["string", "number", "boolean", "object"].map((type) => (
+                      {["string", "number", "boolean", "json"].map((type) => (
                         <button
                           key={type}
                           type="button"
@@ -494,11 +556,26 @@ export default function DatasetView({
                             setDatasetTypes(types);
                           }}
                         >
-                          {type == "object" ? "JSON" : type}
+                          {type == "json" ? "JSON" : type}
                         </button>
                       ))}
                     </div>
                   )}
+                </div>
+                <div className="bg-slate-100 sm:col-span-10">
+                  <TextareaAutosize
+                    minRows={1}
+                    className={classNames(
+                      "font-mono w-full resize-none border-0 bg-transparent px-1 py-0 text-[13px] font-normal italic placeholder-gray-400 ring-0 focus:ring-0",
+                      readOnly ? "text-gray-500" : "text-gray-700"
+                    )}
+                    readOnly={readOnly}
+                    placeholder="Property description"
+                    value={datasetKeyDescriptions[j] || ""}
+                    onChange={(e) => {
+                      handleKeyDescriptionChange(j, e.target.value);
+                    }}
+                  />
                 </div>
               </div>
             ))}
@@ -545,7 +622,7 @@ export default function DatasetView({
                               : "border-red-500"
                           )}
                         >
-                          {datasetTypes[datasetKeys.indexOf(k)] === "object" ? (
+                          {datasetTypes[datasetKeys.indexOf(k)] === "json" ? (
                             <CodeEditor
                               data-color-mode="light"
                               readOnly={readOnly}

--- a/front/lib/api/datasets.ts
+++ b/front/lib/api/datasets.ts
@@ -2,7 +2,7 @@ import { Authenticator } from "@app/lib/auth";
 import { CoreAPI } from "@app/lib/core_api";
 import { Dataset } from "@app/lib/models";
 import { AppType } from "@app/types/app";
-import { DatasetType } from "@app/types/dataset";
+import { DatasetSchema, DatasetType } from "@app/types/dataset";
 
 export async function getDatasets(
   auth: Authenticator,
@@ -56,6 +56,31 @@ export async function getDataset(
     description: dataset.description,
     data: null,
   };
+}
+
+export async function getDatasetSchema(
+  auth: Authenticator,
+  app: AppType,
+  name: string
+): Promise<DatasetSchema | null> {
+  const owner = auth.workspace();
+  if (!owner) {
+    return null;
+  }
+
+  const dataset = await Dataset.findOne({
+    where: {
+      workspaceId: owner.id,
+      appId: app.id,
+      name,
+    },
+  });
+
+  if (!dataset) {
+    return null;
+  }
+
+  return dataset.schema;
 }
 
 export async function getDatasetHash(

--- a/front/lib/models/apps.ts
+++ b/front/lib/models/apps.ts
@@ -9,6 +9,7 @@ import {
 
 import { front_sequelize } from "@app/lib/databases";
 import { Workspace } from "@app/lib/models/workspace";
+import { DatasetSchema } from "@app/types/dataset";
 
 export class App extends Model<
   InferAttributes<App>,
@@ -150,6 +151,7 @@ export class Dataset extends Model<
 
   declare name: string;
   declare description: string | null;
+  declare schema: DatasetSchema | null;
 
   declare workspaceId: ForeignKey<Workspace["id"]>;
   declare appId: ForeignKey<App["id"]>;
@@ -177,6 +179,10 @@ Dataset.init(
     },
     description: {
       type: DataTypes.STRING,
+    },
+    schema: {
+      type: DataTypes.JSONB,
+      allowNull: true,
     },
   },
   {

--- a/front/pages/w/[wId]/a/[aId]/datasets/[name]/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/datasets/[name]/index.tsx
@@ -164,8 +164,6 @@ export default function ViewDatasetView({
     setIsFinishedEditing(true);
   };
 
-  console.log(schema);
-
   return (
     <AppLayout
       user={user}

--- a/front/pages/w/[wId]/a/[aId]/datasets/[name]/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/datasets/[name]/index.tsx
@@ -13,11 +13,11 @@ import {
   subNavigationApp,
 } from "@app/components/sparkle/navigation";
 import { getApp } from "@app/lib/api/app";
-import { getDatasetHash } from "@app/lib/api/datasets";
+import { getDatasetHash, getDatasetSchema } from "@app/lib/api/datasets";
 import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
 import { useRegisterUnloadHandlers } from "@app/lib/front";
 import { AppType } from "@app/types/app";
-import { DatasetType } from "@app/types/dataset";
+import { DatasetSchema, DatasetType } from "@app/types/dataset";
 import { UserType, WorkspaceType } from "@app/types/user";
 
 const { GA_TRACKING_ID = "" } = process.env;
@@ -28,6 +28,7 @@ export const getServerSideProps: GetServerSideProps<{
   readOnly: boolean;
   app: AppType;
   dataset: DatasetType;
+  schema: DatasetSchema | null;
   gaTrackingId: string;
 }> = async (context) => {
   const session = await getSession(context.req, context.res);
@@ -67,6 +68,8 @@ export const getServerSideProps: GetServerSideProps<{
     };
   }
 
+  const schema = await getDatasetSchema(auth, app, dataset.name);
+
   return {
     props: {
       user,
@@ -74,6 +77,7 @@ export const getServerSideProps: GetServerSideProps<{
       readOnly,
       app,
       dataset,
+      schema,
       gaTrackingId: GA_TRACKING_ID,
     },
   };
@@ -85,6 +89,7 @@ export default function ViewDatasetView({
   readOnly,
   app,
   dataset,
+  schema,
   gaTrackingId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const router = useRouter();
@@ -95,6 +100,9 @@ export default function ViewDatasetView({
   const [editorDirty, setEditorDirty] = useState(false);
   const [isFinishedEditing, setIsFinishedEditing] = useState(false);
   const [updatedDataset, setUpdatedDataset] = useState(dataset);
+  const [updatedSchema, setUpdatedSchema] = useState<DatasetSchema | null>(
+    schema
+  );
 
   useRegisterUnloadHandlers(editorDirty);
 
@@ -112,8 +120,12 @@ export default function ViewDatasetView({
   const onUpdate = (
     initializing: boolean,
     valid: boolean,
-    currentDatasetInEditor: DatasetType
+    currentDatasetInEditor: DatasetType,
+    schema: DatasetSchema
   ) => {
+    if (readOnly) {
+      return;
+    }
     setDisabled(!valid);
     if (
       !initializing &&
@@ -128,6 +140,7 @@ export default function ViewDatasetView({
     }
     if (valid) {
       setUpdatedDataset(currentDatasetInEditor);
+      setUpdatedSchema(schema);
     }
   };
 
@@ -140,13 +153,18 @@ export default function ViewDatasetView({
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify(updatedDataset),
+        body: JSON.stringify({
+          dataset: updatedDataset,
+          schema: updatedSchema,
+        }),
       }
     );
     await res.json();
     setEditorDirty(false);
     setIsFinishedEditing(true);
   };
+
+  console.log(schema);
 
   return (
     <AppLayout
@@ -180,15 +198,8 @@ export default function ViewDatasetView({
                   readOnly={readOnly}
                   datasets={[] as DatasetType[]}
                   dataset={updatedDataset}
-                  onUpdate={(
-                    initializing: boolean,
-                    valid: boolean,
-                    currentDatasetInEditor: DatasetType
-                  ) => {
-                    if (!readOnly) {
-                      onUpdate(initializing, valid, currentDatasetInEditor);
-                    }
-                  }}
+                  schema={schema}
+                  onUpdate={onUpdate}
                   nameDisabled={true}
                 />
 

--- a/front/pages/w/[wId]/a/[aId]/datasets/new.tsx
+++ b/front/pages/w/[wId]/a/[aId]/datasets/new.tsx
@@ -17,7 +17,7 @@ import { getDatasets } from "@app/lib/api/datasets";
 import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
 import { useRegisterUnloadHandlers } from "@app/lib/front";
 import { AppType } from "@app/types/app";
-import { DatasetType } from "@app/types/dataset";
+import { DatasetSchema, DatasetType } from "@app/types/dataset";
 import { UserType, WorkspaceType } from "@app/types/user";
 
 const { GA_TRACKING_ID = "" } = process.env;
@@ -75,7 +75,8 @@ export default function NewDatasetView({
 
   const [disable, setDisabled] = useState(true);
   const [loading, setLoading] = useState(false);
-  const [dataset, setDataset] = useState(null as DatasetType | null);
+  const [dataset, setDataset] = useState<DatasetType | null>(null);
+  const [schema, setSchema] = useState<DatasetSchema | null>(null);
 
   const [editorDirty, setEditorDirty] = useState(false);
   const [isFinishedEditing, setIsFinishedEditing] = useState(false);
@@ -96,7 +97,8 @@ export default function NewDatasetView({
   const onUpdate = (
     initializing: boolean,
     valid: boolean,
-    currentDatasetInEditor: DatasetType
+    currentDatasetInEditor: DatasetType,
+    schema: DatasetSchema
   ) => {
     setDisabled(!valid);
     if (!initializing) {
@@ -104,6 +106,7 @@ export default function NewDatasetView({
     }
     if (valid) {
       setDataset(currentDatasetInEditor);
+      setSchema(schema);
     }
   };
 
@@ -114,7 +117,10 @@ export default function NewDatasetView({
       headers: {
         "Content-Type": "application/json",
       },
-      body: JSON.stringify(dataset),
+      body: JSON.stringify({
+        dataset,
+        schema,
+      }),
     });
     await res.json();
     setEditorDirty(false);
@@ -152,6 +158,7 @@ export default function NewDatasetView({
                 readOnly={false}
                 datasets={datasets}
                 dataset={dataset}
+                schema={schema}
                 onUpdate={onUpdate}
                 nameDisabled={false}
               />

--- a/front/pages/w/[wId]/a/[aId]/execute/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/execute/index.tsx
@@ -365,7 +365,7 @@ export default function ExecuteView({
   gaTrackingId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const [inputDatasetKeys] = useState(
-    inputDataset ? checkDatasetData(inputDataset.data) : []
+    inputDataset ? checkDatasetData({ data: inputDataset.data }) : []
   );
   const [datasetTypes] = useState(
     inputDatasetKeys.length

--- a/front/tests/lib/datasets.test.ts
+++ b/front/tests/lib/datasets.test.ts
@@ -3,27 +3,27 @@ import { checkDatasetData, getDatasetTypes } from "@app/lib/datasets";
 describe("checkDatasetData", function () {
   test("returns dataset keys if there are no key mismatch", function () {
     const dataset = [{ hello: "world" }, { hello: "dust" }];
-    const keys = checkDatasetData(dataset);
+    const keys = checkDatasetData({ data: dataset });
     expect(keys).toEqual(["hello"]);
   });
 
   test("throws an error if data is not an array", function () {
     const dataset = { hello: "world" };
-    expect(() => checkDatasetData(dataset as any)).toThrow(
+    expect(() => checkDatasetData({ data: dataset as any })).toThrow(
       "data must be an array"
     );
   });
 
   test("throws an error if data is an empty array", function () {
     const dataset: object[] = [];
-    expect(() => checkDatasetData(dataset)).toThrow(
+    expect(() => checkDatasetData({ data: dataset })).toThrow(
       "Data must be a non-empty array"
     );
   });
 
   test("throws an error if there is a key mismatch", function () {
     const dataset = [{ hello: "world" }, { hello: "dust", foo: "bar" }];
-    expect(() => checkDatasetData(dataset)).toThrow(
+    expect(() => checkDatasetData({ data: dataset })).toThrow(
       "Keys mismatch between data entries: hello != hello,foo"
     );
   });

--- a/front/types/dataset.ts
+++ b/front/types/dataset.ts
@@ -7,3 +7,9 @@ export type DatasetType = {
   description: string | null;
   data: Array<DatasetEntry> | null;
 };
+
+export type DatasetSchema = {
+  key: string;
+  type: "string" | "number" | "boolean" | "json";
+  description: string | null;
+}[];


### PR DESCRIPTION
This PR adds the capability to add descriptions to Dust apps dataset properties. This is used to produce a DatasetSchema that is stored in DB and that we will be able to leverage to generate inputs to call the app from an custom Assistant.


The code of DatasetView is fucked beyond repair. After 3 attempts at refactoring it I gave up and added the feature in a minimally invasive way, keeping all the bad patterns that exist there for now :/

Deploy procedure:
- init_db on front
- deploy front