### PR TITLE
Small edits on Helper

### DIFF
--- a/front/components/assistant/conversation/InputBar.tsx
+++ b/front/components/assistant/conversation/InputBar.tsx
@@ -390,7 +390,7 @@ export function AssistantInputBar({
                 empty ? "" : "hidden"
               )}
             >
-              Ask a question
+              Ask a question or get some @help
             </div>
             <div
               className={classNames(

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -663,9 +663,8 @@ export default function AssistantBuilder({
               <div className="flex-grow self-stretch text-sm font-normal text-element-700">
                 Choose a name reflecting the expertise, knowledge access or
                 function of your&nbsp;assistant. Mentioning the&nbsp;assistant
-                in a conversation, like{" "}
-                <span className="italic">"@helper"</span> will prompt
-                a&nbsp;response from&nbsp;them.
+                in a conversation, like <span className="italic">"@help"</span>{" "}
+                will prompt a&nbsp;response from&nbsp;them.
               </div>
               <div className="text-sm">
                 <Input

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -43,7 +43,7 @@ class HelperAssistantPrompt {
         );
         this.staticPrompt = await readFileAsync(filePath, "utf-8");
       } catch (err) {
-        logger.error("Error reading prompt file for @helper agent:", err);
+        logger.error("Error reading prompt file for @help agent:", err);
         return null;
       }
     }
@@ -93,9 +93,8 @@ async function _getHelperGlobalAgent(
     id: -1,
     sId: GLOBAL_AGENTS_SID.HELPER,
     version: 0,
-    name: "helper",
-    description:
-      "Here to help with everything about assistant, and Dust's product in general",
+    name: "help",
+    description: "Help on how to use Dust",
     pictureUrl: "https://dust.tt/static/systemavatar/helper_avatar_full.png",
     status: "active",
     scope: "global",

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -126,7 +126,6 @@ export enum GLOBAL_AGENTS_SID {
 }
 
 const CUSTOM_ORDER: string[] = [
-  GLOBAL_AGENTS_SID.HELPER,
   GLOBAL_AGENTS_SID.DUST,
   GLOBAL_AGENTS_SID.GPT4,
   GLOBAL_AGENTS_SID.SLACK,
@@ -137,6 +136,7 @@ const CUSTOM_ORDER: string[] = [
   GLOBAL_AGENTS_SID.CLAUDE,
   GLOBAL_AGENTS_SID.CLAUDE_INSTANT,
   GLOBAL_AGENTS_SID.MISTRAL,
+  GLOBAL_AGENTS_SID.HELPER,
 ];
 
 // This function implements our general strategy to sort agents to users (input bar, assistant list,
@@ -145,10 +145,6 @@ export function compareAgentsForSort(
   a: AgentConfigurationType,
   b: AgentConfigurationType
 ) {
-  // Check for 'helper'
-  if (a.sId === GLOBAL_AGENTS_SID.HELPER) return -1;
-  if (b.sId === GLOBAL_AGENTS_SID.HELPER) return 1;
-
   // Check for 'dust'
   if (a.sId === GLOBAL_AGENTS_SID.DUST) return -1;
   if (b.sId === GLOBAL_AGENTS_SID.DUST) return 1;

--- a/front/pages/w/[wId]/assistant/new.tsx
+++ b/front/pages/w/[wId]/assistant/new.tsx
@@ -276,7 +276,7 @@ export default function AssistantNew({
                     </>
                   )}
                   <StartHelperConversationButton
-                    content="Hey @helper, how can I use an assistant?"
+                    content="Hey @help, how can I use an assistant?"
                     handleSubmit={handleSubmit}
                   />
                 </Button.List>
@@ -289,52 +289,52 @@ export default function AssistantNew({
                   {isBuilder ? (
                     <div className="flex flex-wrap gap-2">
                       <StartHelperConversationButton
-                        content="Hey @helper, how can I interact with an assistant?"
+                        content="Hey @help, how can I interact with an assistant?"
                         handleSubmit={handleSubmit}
                         variant="secondary"
                       />
                       <StartHelperConversationButton
-                        content="@helper, what can I use the assistants for?"
+                        content="@help, what can I use the assistants for?"
                         handleSubmit={handleSubmit}
                       />
                       <StartHelperConversationButton
-                        content="@helper, what are custom assistants?"
+                        content="@help, what are custom assistants?"
                         handleSubmit={handleSubmit}
                       />
                       <StartHelperConversationButton
-                        content="@helper, what customized assistants should I create?"
+                        content="@help, what customized assistants should I create?"
                         handleSubmit={handleSubmit}
                       />
                       <StartHelperConversationButton
-                        content="@helper, how can I make assistant smarter with my own data?"
+                        content="@help, how can I make assistant smarter with my own data?"
                         handleSubmit={handleSubmit}
                       />
                       <StartHelperConversationButton
-                        content="@helper, what's the level of security and privacy dust offers?"
+                        content="@help, what's the level of security and privacy dust offers?"
                         handleSubmit={handleSubmit}
                       />
                     </div>
                   ) : (
                     <div className="flex flex-wrap gap-2">
                       <StartHelperConversationButton
-                        content="Hey @helper, how can I interact with an assistant?"
+                        content="Hey @help, how can I interact with an assistant?"
                         handleSubmit={handleSubmit}
                         variant="secondary"
                       />
                       <StartHelperConversationButton
-                        content="Hey @helper, What can I use an assistant for?"
+                        content="Hey @help, What can I use an assistant for?"
                         handleSubmit={handleSubmit}
                       />
                       <StartHelperConversationButton
-                        content="@helper, who creates assistants?"
+                        content="@help, who creates assistants?"
                         handleSubmit={handleSubmit}
                       />
                       <StartHelperConversationButton
-                        content="@helper, how do assistants work exactly?"
+                        content="@help, how do assistants work exactly?"
                         handleSubmit={handleSubmit}
                       />
                       <StartHelperConversationButton
-                        content="@helper, what are the limitations of assistants?"
+                        content="@help, what are the limitations of assistants?"
                         handleSubmit={handleSubmit}
                       />
                     </div>
@@ -369,8 +369,8 @@ function StartHelperConversationButton({
   size?: "sm" | "xs";
 }) {
   const contentWithMarkdownMention = content.replace(
-    "@helper",
-    ":mention[helper]{sId=helper}"
+    "@help",
+    ":mention[help]{sId=helper}"
   );
 
   return (

--- a/front/pages/w/[wId]/builder/assistants/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/index.tsx
@@ -121,7 +121,7 @@ export default function AssistantsBuilder({
         <div>
           <SectionHeader
             title="Dust Assistants"
-            description='Assistants built by Dust for multiple use cases. For instance, use "@helper" for any question Dust related, use the handle "@notion" to target specifically knowledge on Notion…'
+            description='Assistants built by Dust for multiple use cases. For instance, use "@help" for any question Dust related, use the handle "@notion" to target specifically knowledge on Notion…'
           />
           <ContextItem.List className="mt-8  text-element-900">
             {dustAgents.map((agent) => (

--- a/front/prompt/global_agent_helper_prompt.md
+++ b/front/prompt/global_agent_helper_prompt.md
@@ -21,7 +21,7 @@ Dust assistants are AI-powered agents that employ frontier models like GPT-4 and
 - Custom assistants: assistants created by Dust or builders from your company workspace to answer specific use cases. Custom assistants can be augmented with retrieval or see their instructions customized.
   Custom assistants can be used for completing specific tasks defined by Dust or the builders. Dust created custom assistants like @notion or @slack to help you interact directly with your Notion or Slack synchronized documents. Builders at your company can also create custom assistants to help you complete many tasks like improving SQL queries, supporting the customer success team, giving feedback on UX writing content, or writing specific memos or reports.
 
-To illustrate, while @dust handles organizational questions, @helper provides Dust support, @slack searches Slack, and @gpt4/@claude offer direct large language model access. Multiple assistants can be leveraged concurrently to tackle varied tasks.
+To illustrate, while @dust handles organizational questions, @help provides Dust support, @slack searches Slack, and @gpt4/@claude offer direct large language model access. Multiple assistants can be leveraged concurrently to tackle varied tasks.
 
 ### Conversation
 
@@ -146,7 +146,7 @@ A Dust assistant can answer questions and chat with you. Each one is different, 
 
 Use @dust for general company questions. It has access to your company data as well as public data up to September 2021 thanks to GPT4
 
-Use @helper for help with using Dust.
+Use @help for help with using Dust.
 
 Use @slack if you think the information is in Slack.
 
@@ -166,7 +166,7 @@ Dust offers 3 types of assistants:
 
 - Data source assistants to interact directly with your Slack, Google Drive, Github or Notion in a conversational way, or all of them together via @dust.
 - Models assistants to interact with the strongest models available, currently GPT-4 and Claude: @gpt4, @gpt3.5, @claude, @claude-instant.
-- Dust assistants like the @helper to guide you when using Dust.
+- Dust assistants like the @help to guide you when using Dust.
 
 ## Custom assistants
 


### PR DESCRIPTION
Changes requested from issue: https://github.com/dust-tt/tasks/issues/62

- [x] s/@helper/@help(this also requires changing the hard-coded questions
- [x] simplify tagline to just help on how to use Dust
- [x] add a mention of @help in the default inputbar "ask a question or get some @help"
- [x] show last not first in the default assistants visible to a new user after the frontier models


Note: I changed only the name and not the sId of helper to not have to run a migration on all past messages.

Meaning that on old messages, it will look like that: 
<img width="1119" alt="Capture d’écran 2023-10-10 à 13 39 09" src="https://github.com/dust-tt/dust/assets/3803406/3f58b7fc-0cf2-485c-b4f9-749e972f87a5">

