### PR TITLE
Display chip for cancelled messages

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -293,19 +293,9 @@ export function AgentMessage({
       );
     }
 
-    // Messages with no action and text
-    if (agentMessage.action === null && agentMessage.content) {
-      return (
-        <RenderMessageMarkdown
-          content={agentMessage.content}
-          blinkingCursor={streaming}
-        />
-      );
-    }
-    // Messages with action
-    if (agentMessage.action) {
-      return (
-        <>
+    return (
+      <>
+        {agentMessage.action && (
           <div
             className={
               agentMessage.content && agentMessage.content !== ""
@@ -315,20 +305,25 @@ export function AgentMessage({
           >
             <AgentAction action={agentMessage.action} />
           </div>
-          {agentMessage.content && agentMessage.content !== "" && (
-            <>
-              <div className="pt-4">
-                <RenderMessageMarkdown
-                  content={agentMessage.content}
-                  blinkingCursor={streaming}
-                  references={references}
-                />
-              </div>
-            </>
-          )}
-        </>
-      );
-    }
+        )}
+        {agentMessage.content && agentMessage.content !== "" && (
+          <div className={agentMessage.action ? "pt-4" : ""}>
+            <RenderMessageMarkdown
+              content={agentMessage.content}
+              blinkingCursor={streaming}
+              references={references}
+            />
+          </div>
+        )}
+        {agentMessage.status === "cancelled" && (
+          <Chip
+            label="Message generation was cancelled"
+            size="xs"
+            className="mt-4"
+          />
+        )}
+      </>
+    );
   }
 
   async function retryHandler(agentMessage: AgentMessageType) {


### PR DESCRIPTION
Displaying a chip when a message is cancelled, from this discussion: https://dust4ai.slack.com/archives/C050A0S2Z7F/p1696924941531459

<img width="670" alt="Capture d’écran 2023-10-10 à 14 00 17" src="https://github.com/dust-tt/dust/assets/3803406/c2182245-5f30-4c54-bf56-73a71c5b03eb">
