### PR TITLE
add some space below the conversation (like chatGPT)

### DIFF
--- a/front/components/assistant/conversation/InputBar.tsx
+++ b/front/components/assistant/conversation/InputBar.tsx
@@ -145,7 +145,7 @@ function AgentListImpl(
       leaveTo="transform opacity-0 scale-100 translate-y-0"
     >
       <div
-        className="fixed z-10 max-h-96 overflow-y-auto rounded-xl border border-structure-100 bg-white shadow-xl"
+        className="fixed z-10 max-h-64 overflow-y-auto rounded-xl border border-structure-100 bg-white shadow-xl"
         style={{
           bottom: position.bottom,
           left: position.left,
@@ -404,7 +404,7 @@ export function AssistantInputBar({
                 contentEditableClasses,
                 "scrollbar-hide",
                 "overflow-y-auto",
-                "max-h-96"
+                "max-h-64"
               )}
               contentEditable={true}
               ref={inputRef}

--- a/front/pages/w/[wId]/assistant/[cId]/index.tsx
+++ b/front/pages/w/[wId]/assistant/[cId]/index.tsx
@@ -146,6 +146,7 @@ export default function AssistantConversation({
           conversationId={conversationId}
           onStickyMentionsChange={setStickyMentions}
         />
+        <div className="h-48" />
         <FixedAssistantInputBar
           owner={owner}
           onSubmit={handleSubmit}


### PR DESCRIPTION
https://github.com/dust-tt/dust/issues/2029

When the inputbar is at max height, we don't want it to hide parts of the conversation. The solution is the same as what chatGPT does: add some empty space below the conversation

I also changed the max height of the input to something closer to chatgpt