### PR TITLE
fix: prevent long lines in codeblocks from breaking the UI

### DIFF
--- a/front/components/assistant/conversation/ConversationMessage.tsx
+++ b/front/components/assistant/conversation/ConversationMessage.tsx
@@ -240,7 +240,7 @@ export function ConversationMessage({
         />
 
         {/* COLUMN 2: CONTENT */}
-        <div className="flex flex-grow flex-col gap-4">
+        <div className="flex min-w-0 flex-grow flex-col gap-4">
           <div className="text-sm font-medium">{name}</div>
           <div className="min-w-0 break-words text-base font-normal">
             {children}


### PR DESCRIPTION
avoids breaking UI when there are long lines of code in code blocks. 
Code blocks are scrollable when lines are long.