### PR TITLE
Citation superscripts & citations index in UI look the same

### DIFF
--- a/front/components/assistant/RenderMessageMarkdown.tsx
+++ b/front/components/assistant/RenderMessageMarkdown.tsx
@@ -261,12 +261,6 @@ function CiteBlock(props: ReactMarkdownProps) {
           const title = titleFromDocument(document);
           const link = linkFromDocument(document);
 
-          const citeClassNames = classNames(
-            "rounded-md bg-structure-100 px-1",
-            "text-xs font-semibold text-action-500",
-            "hover:bg-structure-200 hover:text-action-600"
-          );
-
           return (
             <sup key={`${r.ref}-${i}`}>
               <Tooltip
@@ -291,10 +285,11 @@ function CiteBlock(props: ReactMarkdownProps) {
                   href={link}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className={citeClassNames}
                   onMouseEnter={() => setHoveredReference(r.counter)}
                 >
-                  {r.counter}
+                  <div className="flex h-4 w-4 items-center justify-center rounded-full border border-violet-200 bg-violet-100 text-xs font-semibold text-element-800 hover:border-violet-400">
+                    {r.counter}
+                  </div>
                 </a>
               </Tooltip>
             </sup>


### PR DESCRIPTION
As per this [conversation](https://dust4ai.slack.com/archives/C050A0S2Z7F/p1696951512280429)

![Screenshot from 2023-10-10 17-35-26](https://github.com/dust-tt/dust/assets/5437393/a4ab947d-fd83-4215-bdec-f81575304694)
