### PR TITLE
fix: citations breaking autoscroll

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -342,10 +342,12 @@ export function AgentMessage({
                 setHoveredReference: setLastHoveredReference,
               }}
             />
-            <Citations
-              activeReferences={activeReferences}
-              lastHoveredReference={lastHoveredReference}
-            />
+            <div className="overflow-x-hidden">
+              <Citations
+                activeReferences={activeReferences}
+                lastHoveredReference={lastHoveredReference}
+              />
+            </div>
           </div>
         )}
         {agentMessage.status === "cancelled" && (

--- a/front/components/sparkle/AppLayout.tsx
+++ b/front/components/sparkle/AppLayout.tsx
@@ -355,7 +355,7 @@ export default function AppLayout({
 
           <main
             className={classNames(
-              "h-full overflow-x-hidden pt-16",
+              "h-full pt-16",
               titleChildren ? "" : "lg:pt-8"
             )}
           >


### PR DESCRIPTION
`overflow-x-hidden` in the `AppLayout` is breaking the auto-scroll behaviour in the assistant (upon sending a user message and also while streaming the assistant response)