### PR TITLE
Fix autoscroll OR citations broken

### DIFF
--- a/front/styles/global.css
+++ b/front/styles/global.css
@@ -3,7 +3,6 @@
 @tailwind utilities;
 
 html,
-body,
 main {
   @apply h-full;
 }


### PR DESCRIPTION
Apparently body height full can mess with horizontal [scroll](https://stackoverflow.com/questions/35526252/scrolltop-animate-does-not-work-if-html-body-is-overflow-x-hidden)
Does not explain why it's only when there is an overflow-x-hidden on some part of the layout -- but fixes autoscroll while keeping citations working
Did quick checks locally that it doesn't break anything else
