### PR TITLE
Employee onboarding join page

### DIFF
--- a/front/components/Button.tsx
+++ b/front/components/Button.tsx
@@ -1,3 +1,5 @@
+import { Button } from "@dust-tt/sparkle";
+
 import { classNames } from "@app/lib/utils";
 
 export function GoogleSignInButton({
@@ -17,5 +19,24 @@ export function GoogleSignInButton({
     >
       {children}
     </button>
+  );
+}
+
+export function SignInButton({
+  label,
+  icon = null,
+  onClick = null,
+}: React.PropsWithChildren<{
+  label: string;
+  icon?: any;
+  onClick?: any;
+}>) {
+  return (
+    <Button
+      label={label}
+      variant="tertiary"
+      icon={icon}
+      onClick={onClick}
+    ></Button>
   );
 }

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -1,4 +1,4 @@
-import { Authenticator } from "@app/lib/auth";
+import { Authenticator, planForWorkspace } from "@app/lib/auth";
 import { RoleType } from "@app/lib/auth";
 import {
   Membership,
@@ -7,15 +7,30 @@ import {
   Workspace,
 } from "@app/lib/models";
 import { MembershipInvitationType } from "@app/types/membership_invitation";
-import { UserType } from "@app/types/user";
+import { UserType, WorkspaceType } from "@app/types/user";
 
-export async function isWorkspaceAllowedOnDomain(wId: string) {
+export async function getWorkspaceInfos(
+  wId: string
+): Promise<WorkspaceType | null> {
   const workspace = await Workspace.findOne({
     where: {
       sId: wId,
     },
   });
-  return workspace && workspace.allowedDomain !== null;
+
+  if (!workspace) {
+    return null;
+  }
+
+  return {
+    id: workspace.id,
+    sId: workspace.sId,
+    name: workspace.name,
+    allowedDomain: workspace.allowedDomain,
+    role: "none",
+    plan: planForWorkspace(workspace),
+    upgradedAt: workspace.upgradedAt?.getTime() || null,
+  };
 }
 
 /**

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@dust-tt/sparkle": "0.1.98",
+        "@dust-tt/sparkle": "0.2.01",
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",
         "@headlessui/react": "^1.7.7",
@@ -727,9 +727,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.1.98",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.1.98.tgz",
-      "integrity": "sha512-pb4smqmPJw7T28JWl82dwzDtaX79rpBeu2w5UnaJFOr7ByRrCchEpnHFEQh7fTJDm31hdD/qO7cQvGGwxTDcMA==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.1.tgz",
+      "integrity": "sha512-sXj8SpompVjRswhctZFWOovzKCcrryoU5RGptyqMHz6lvt98riaPOhqbF4nftgMEiF3lmHd4EQ0WnRsNvX2GQw==",
       "dependencies": {
         "@headlessui/react": "^1.7.17"
       },

--- a/front/package.json
+++ b/front/package.json
@@ -13,7 +13,7 @@
     "initdb": "env $(cat .env.local) npx tsx admin/db.ts"
   },
   "dependencies": {
-    "@dust-tt/sparkle": "0.1.98",
+    "@dust-tt/sparkle": "0.2.01",
     "@emoji-mart/data": "^1.1.2",
     "@emoji-mart/react": "^1.1.1",
     "@headlessui/react": "^1.7.7",

--- a/front/pages/api/w/[wId]/invitations/index.ts
+++ b/front/pages/api/w/[wId]/invitations/index.ts
@@ -90,13 +90,16 @@ async function handler(
         DUST_INVITE_TOKEN_SECRET
       );
 
-      const invitationUrl = `${URL}/w/${owner.id}/join/?t=${invitationToken}`;
+      const invitationUrl = `${URL}/w/${owner.sId}/join/?t=${invitationToken}`;
 
       // Send invite email
       const message = {
         to: invitation.inviteEmail,
-        from: "team@dust.tt",
-        subject: `[DUST] You have been invited to join the '${owner.name}' workspace`,
+        from: {
+          name: "Dust team",
+          email: "team@dust.tt",
+        },
+        subject: `[Dust] You have been invited to join the '${owner.name}' workspace`,
         text: `Welcome to Dust!\n\nYou have been invited to join the '${owner.name}' workspace.\n\nClick the link below to accept the invitation:\n\n${invitationUrl}`,
       };
       await sgMail.send(message);

--- a/front/pages/api/w/[wId]/invitations/index.ts
+++ b/front/pages/api/w/[wId]/invitations/index.ts
@@ -90,12 +90,14 @@ async function handler(
         DUST_INVITE_TOKEN_SECRET
       );
 
+      const invitationUrl = `${URL}/w/${owner.id}/join/?t=${invitationToken}`;
+
       // Send invite email
       const message = {
         to: invitation.inviteEmail,
         from: "team@dust.tt",
         subject: `[DUST] You have been invited to join the '${owner.name}' workspace`,
-        text: `Welcome to Dust!\n\nYou have been invited to join the '${owner.name}' workspace.\n\nClick the link below to accept the invitation:\n\n${URL}?inviteToken=${invitationToken}`,
+        text: `Welcome to Dust!\n\nYou have been invited to join the '${owner.name}' workspace.\n\nClick the link below to accept the invitation:\n\n${invitationUrl}`,
       };
       await sgMail.send(message);
       res.status(200).json({

--- a/front/pages/w/[wId]/join.tsx
+++ b/front/pages/w/[wId]/join.tsx
@@ -1,4 +1,4 @@
-import { GithubLogo, Logo } from "@dust-tt/sparkle";
+import { GoogleLogo, Logo } from "@dust-tt/sparkle";
 import { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import { signIn } from "next-auth/react";
 
@@ -14,20 +14,16 @@ const { URL = "", GA_TRACKING_ID = "" } = process.env;
  *   url = /w/[wId]/join?t=[token]
  *      -> you've been invited to a workspace by email from the member management page.
  *      -> we don't care if workspace has allowed domain.
- *      -> signup is both for Google and Github.
  *
  * Case 2: "domain_invite_link"
  *   url = /w/[wId]/join
  *      -> Workspace has activated onboarding with link for an allowed domain.
  *      -> the workspace needs to have allowed domain.
- *      -> signup is only for Google.
  *
  * Case 3: "domain_conversation_link"
  *   url = /w/[wId]/join?cId=[conversationId]
  *      -> you're redirected to this page from trying to access a conversation if you're not logged in and the workspace has allowed domain.
- *      -> the workspace needs to have allowed domain.
- *      -> signup is only for Google. *
- *
+ *      -> the workspace needs to have allowed domain. *
  */
 
 type OnboardingType =
@@ -153,24 +149,13 @@ export default function Join({
           <div className="flex flex-col items-center justify-center gap-4">
             <SignInButton
               label="Sign up with Google"
-              //icon={GoogleLogo} waiting for Google logo to be added to sparkle
+              icon={GoogleLogo}
               onClick={() => {
                 void signIn("google", {
                   callbackUrl: signUpCallbackUrl,
                 });
               }}
             />
-            {onboardingType === "email_invite" && (
-              <SignInButton
-                label="Sign up with GitHub"
-                icon={GithubLogo}
-                onClick={() => {
-                  void signIn("github", {
-                    callbackUrl: signUpCallbackUrl,
-                  });
-                }}
-              />
-            )}
           </div>
         </div>
       </main>

--- a/front/pages/w/[wId]/join.tsx
+++ b/front/pages/w/[wId]/join.tsx
@@ -1,41 +1,102 @@
-import { Logo } from "@dust-tt/sparkle";
+import { GithubLogo, Logo } from "@dust-tt/sparkle";
 import { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import { signIn } from "next-auth/react";
 
-import { GoogleSignInButton } from "@app/components/Button";
-import { isWorkspaceAllowedOnDomain } from "@app/lib/api/workspace";
+import { SignInButton } from "@app/components/Button";
+import { getWorkspaceInfos } from "@app/lib/api/workspace";
 
 const { URL = "", GA_TRACKING_ID = "" } = process.env;
 
+/**
+ * 3 ways to end up here:
+ *
+ * Case 1: "email_invite"
+ *   url = /w/[wId]/join?t=[token]
+ *      -> you've been invited to a workspace by email from the member management page.
+ *      -> we don't care if workspace has allowed domain.
+ *      -> signup is both for Google and Github.
+ *
+ * Case 2: "domain_invite_link"
+ *   url = /w/[wId]/join
+ *      -> Workspace has activated onboarding with link for an allowed domain.
+ *      -> the workspace needs to have allowed domain.
+ *      -> signup is only for Google.
+ *
+ * Case 3: "domain_conversation_link"
+ *   url = /w/[wId]/join?cId=[conversationId]
+ *      -> you're redirected to this page from trying to access a conversation if you're not logged in and the workspace has allowed domain.
+ *      -> the workspace needs to have allowed domain.
+ *      -> signup is only for Google. *
+ *
+ */
+
+type OnboardingType =
+  | "email_invite"
+  | "domain_invite_link"
+  | "domain_conversation_link";
+
 export const getServerSideProps: GetServerSideProps<{
-  wId: string;
-  cId: string;
+  onboardingType: OnboardingType;
+  workspaceName: string;
+  signUpCallbackUrl: string;
   gaTrackingId: string;
   baseUrl: string;
 }> = async (context) => {
   const wId = context.query.wId as string;
-  const cId = context.query.cId as string;
-
-  if (!wId || !cId) {
+  if (!wId) {
+    return {
+      notFound: true,
+    };
+  }
+  const workspace = await getWorkspaceInfos(wId);
+  if (!workspace) {
     return {
       notFound: true,
     };
   }
 
-  const isAllowedOnDomain = await isWorkspaceAllowedOnDomain(wId);
-  if (!isAllowedOnDomain) {
+  const cId = typeof context.query.cId === "string" ? context.query.cId : null;
+  const token = typeof context.query.t === "string" ? context.query.t : null;
+
+  const onboardingType: OnboardingType = cId
+    ? "domain_conversation_link"
+    : token
+    ? "email_invite"
+    : "domain_invite_link";
+
+  // Redirect to 404 if in a flow where we need allowed domain and domain is not allowed.
+  if (
+    !workspace.allowedDomain &&
+    (onboardingType === "domain_conversation_link" ||
+      onboardingType === "domain_invite_link")
+  ) {
     return {
-      redirect: {
-        destination: "/",
-        permanent: false,
-      },
+      notFound: true,
     };
+  }
+
+  let signUpCallbackUrl: string | undefined = undefined;
+  switch (onboardingType) {
+    case "domain_conversation_link":
+      signUpCallbackUrl = `/api/login?wId=${wId}&cId=${cId}&join=true`;
+      break;
+    case "email_invite":
+      signUpCallbackUrl = `/api/login?wId=${wId}&inviteToken=${token}`;
+      break;
+    case "domain_invite_link":
+      signUpCallbackUrl = `/api/login?wId=${wId}`;
+      break;
+    default:
+      return {
+        notFound: true,
+      };
   }
 
   return {
     props: {
-      wId: wId,
-      cId: cId,
+      onboardingType: onboardingType,
+      workspaceName: workspace.name,
+      signUpCallbackUrl: signUpCallbackUrl,
       baseUrl: URL,
       gaTrackingId: GA_TRACKING_ID,
     },
@@ -43,8 +104,9 @@ export const getServerSideProps: GetServerSideProps<{
 };
 
 export default function Join({
-  wId,
-  cId,
+  onboardingType,
+  workspaceName,
+  signUpCallbackUrl,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   return (
     <>
@@ -66,23 +128,49 @@ export default function Join({
             </p>
           </div>
           <div className="h-10"></div>
-          <div>
-            <p className="font-regular mb-16 text-slate-400">
-              Glad to see you!
-              <br />
-              Please log in or sign up with your company email to access this
-              page.
-            </p>
-            <GoogleSignInButton
-              onClick={() =>
-                signIn("google", {
-                  callbackUrl: `/api/login?wId=${wId}&cId=${cId}&join=true`,
-                })
-              }
-            >
-              <img src="/static/google_white_32x32.png" className="h-4 w-4" />
-              <span className="ml-2 mr-1">Sign in with Google</span>
-            </GoogleSignInButton>
+          <div className="font-regular text-lg text-slate-200">
+            <p>Glad to see you!</p>
+
+            {onboardingType === "domain_conversation_link" ? (
+              <p>
+                Please log in or sign up with your company email to access this
+                conversation.
+              </p>
+            ) : (
+              <p>
+                You've been invited to join the Dust workspace of{" "}
+                {workspaceName}.
+              </p>
+            )}
+
+            {onboardingType === "email_invite" && (
+              <p>How would you like to connect?</p>
+            )}
+          </div>
+
+          <div className="h-16" />
+
+          <div className="flex flex-col items-center justify-center gap-4">
+            <SignInButton
+              label="Sign up with Google"
+              //icon={GoogleLogo} waiting for Google logo to be added to sparkle
+              onClick={() => {
+                void signIn("google", {
+                  callbackUrl: signUpCallbackUrl,
+                });
+              }}
+            />
+            {onboardingType === "email_invite" && (
+              <SignInButton
+                label="Sign up with GitHub"
+                icon={GithubLogo}
+                onClick={() => {
+                  void signIn("github", {
+                    callbackUrl: signUpCallbackUrl,
+                  });
+                }}
+              />
+            )}
           </div>
         </div>
       </main>

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -65,7 +65,7 @@ export default function WorkspaceAdmin({
   const [allowedDomainError, setAllowedDomainError] = useState("");
 
   const inviteLink =
-    owner.allowedDomain !== null ? `${url}/w/${owner.id}/join` : null;
+    owner.allowedDomain !== null ? `${url}/w/${owner.sId}/join` : null;
 
   const [inviteEmail, setInviteEmail] = useState("");
   const [isSending, setIsSending] = useState(false);

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -65,9 +65,7 @@ export default function WorkspaceAdmin({
   const [allowedDomainError, setAllowedDomainError] = useState("");
 
   const inviteLink =
-    owner.allowedDomain !== null
-      ? `${url}/?signIn=google&wId=${owner.sId}`
-      : null;
+    owner.allowedDomain !== null ? `${url}/w/${owner.id}/join` : null;
 
   const [inviteEmail, setInviteEmail] = useState("");
   const [isSending, setIsSending] = useState(false);


### PR DESCRIPTION
Changes the url for invite_email and domain_invite_link to the join page that was created earlier (seamless onboarding feature allowing a user to create an account from accessing a convo page if the workspace has allowed invitation by allowed domain). 

No big changes on the UI of the page: 
<img width="1579" alt="Capture d’écran 2023-10-11 à 12 29 47" src="https://github.com/dust-tt/dust/assets/3803406/2b9b1b82-783d-4dc5-9a56-c1ac62ba2ab3">

Notes: we're just missing a logo for Github, Ed is on it!