### PR TITLE
User: introduce first and last name

### DIFF
--- a/front/lib/models/user.ts
+++ b/front/lib/models/user.ts
@@ -21,6 +21,8 @@ export class User extends Model<
   declare username: string;
   declare email: string;
   declare name: string;
+  declare firstName: string | null;
+  declare lastName: string | null;
 
   declare isDustSuperUser: CreationOptional<boolean>;
 }
@@ -60,6 +62,14 @@ User.init(
     name: {
       type: DataTypes.STRING,
       allowNull: false,
+    },
+    firstName: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
+    lastName: {
+      type: DataTypes.STRING,
+      allowNull: true,
     },
     isDustSuperUser: {
       type: DataTypes.BOOLEAN,

--- a/front/lib/user.ts
+++ b/front/lib/user.ts
@@ -68,8 +68,8 @@ export const guessFirstandLastNameFromFullName = (
 
   if (nameParts.length === 1) return { firstName: fullName, lastName: null };
 
-  const lastName = nameParts.pop() || null;
-  const firstName = nameParts.join(" ");
+  const firstName = nameParts.shift() || null;
+  const lastName = nameParts.join(" ");
 
   return { firstName, lastName };
 };

--- a/front/lib/user.ts
+++ b/front/lib/user.ts
@@ -58,3 +58,18 @@ export function setUserMetadataFromClient(metadata: UserMetadataType) {
     }
   })();
 }
+
+export const guessFirstandLastNameFromFullName = (
+  fullName: string
+): { firstName: string | null; lastName: string | null } => {
+  if (!fullName) return { firstName: null, lastName: null };
+
+  const nameParts = fullName.split(" ");
+
+  if (nameParts.length === 1) return { firstName: fullName, lastName: null };
+
+  const lastName = nameParts.pop() || null;
+  const firstName = nameParts.join(" ");
+
+  return { firstName, lastName };
+};


### PR DESCRIPTION
Introduce new fiels on the user model for first and last name. 

We set them when we create the user. For past users, we will have to run a migration. 
Can be done separately as fields are not used yet. 

`session.user` contains a name field with the full name, so we have to guess. 
Not sure it's the best but the default I picked is "last word is the last name, rest is first name".
In any case, this is just the default value we will set: on the new onboarding, when coming from the Google Sign in we will ask the user to validate their name. 

Note: I haven't checked if there is a way to have more data in session.user, I probably should 😅 