### PR TITLE
enh: notion upsert page workflow

### DIFF
--- a/connectors/migrations/20230906_notion_fill_parents_field.ts
+++ b/connectors/migrations/20230906_notion_fill_parents_field.ts
@@ -67,7 +67,7 @@ async function updateParentsFieldForConnector(connector: Connector) {
 
   // update all parents fields for all pages and databases
   await updateAllParentsFields(
-    connector,
+    connector.id,
     pages.map((p) => p.notionPageId),
     databases.map((d) => d.notionDatabaseId)
   );

--- a/connectors/src/admin/db.ts
+++ b/connectors/src/admin/db.ts
@@ -9,6 +9,8 @@ import {
   GoogleDriveFolders,
   GoogleDriveSyncToken,
   GoogleDriveWebhook,
+  NotionConnectorBlockCacheEntry,
+  NotionConnectorPageCacheEntry,
   NotionConnectorState,
   NotionDatabase,
   NotionPage,
@@ -36,6 +38,8 @@ async function main(): Promise<void> {
   await GoogleDriveFiles.sync({ alter: true });
   await GoogleDriveSyncToken.sync({ alter: true });
   await GoogleDriveWebhook.sync({ alter: true });
+  await NotionConnectorBlockCacheEntry.sync({ alter: true });
+  await NotionConnectorPageCacheEntry.sync({ alter: true });
 
   // enable the `unaccent` extension
   await sequelize_conn.query("CREATE EXTENSION IF NOT EXISTS unaccent;");

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -75,7 +75,7 @@ export async function createNotionConnector(
 
       return connector;
     });
-    await launchNotionSyncWorkflow(connector.id.toString());
+    await launchNotionSyncWorkflow(connector.id);
     return new Ok(connector.id.toString());
   } catch (e) {
     logger.error({ error: e }, "Error creating notion connector.");
@@ -228,7 +228,7 @@ export async function resumeNotionConnector(
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
   try {
     await launchNotionSyncWorkflow(
-      connector.id.toString(),
+      connector.id,
       connector.lastSyncSuccessfulTime
         ? connector.lastSyncStartTime?.getTime()
         : null
@@ -278,7 +278,7 @@ export async function fullResyncNotionConnector(
 
   try {
     await launchNotionSyncWorkflow(
-      connector.id.toString(),
+      connector.id,
       fromTs,
       true //forceResync
     );
@@ -464,14 +464,7 @@ export async function retrieveNotionResourceParents(
   const memo = memoizationKey || uuidv4();
 
   try {
-    const parents = await getParents(
-      {
-        dataSourceName: connector.dataSourceName,
-        workspaceId: connector.workspaceId,
-      },
-      internalId,
-      memo
-    );
+    const parents = await getParents(connectorId, internalId, memo);
 
     return new Ok(parents);
   } catch (e) {

--- a/connectors/src/connectors/notion/lib/connectors_db_helpers.ts
+++ b/connectors/src/connectors/notion/lib/connectors_db_helpers.ts
@@ -1,4 +1,9 @@
-import { Connector, NotionDatabase, NotionPage } from "@connectors/lib/models";
+import {
+  Connector,
+  ModelId,
+  NotionDatabase,
+  NotionPage,
+} from "@connectors/lib/models";
 import { DataSourceInfo } from "@connectors/types/data_source_config";
 
 // Note: this function does not let you "remove" a skipReason.
@@ -88,28 +93,17 @@ export async function upsertNotionPageInConnectorsDb({
 }
 
 export async function getNotionPageFromConnectorsDb(
-  dataSourceInfo: DataSourceInfo,
+  connectorId: ModelId,
   notionPageId: string,
   lastSeenTs?: number
 ): Promise<NotionPage | null> {
-  const connector = await Connector.findOne({
-    where: {
-      type: "notion",
-      workspaceId: dataSourceInfo.workspaceId,
-      dataSourceName: dataSourceInfo.dataSourceName,
-    },
-  });
-  if (!connector) {
-    throw new Error("Could not find connector");
-  }
-
   const where: {
     notionPageId: string;
-    connectorId: string;
+    connectorId: ModelId;
     lastSeenTs?: Date;
   } = {
     notionPageId,
-    connectorId: connector.id.toString(),
+    connectorId,
   };
 
   if (lastSeenTs) {
@@ -121,7 +115,7 @@ export async function getNotionPageFromConnectorsDb(
 
 // Note: this function does not let you "remove" a skipReason.
 export async function upsertNotionDatabaseInConnectorsDb({
-  dataSourceInfo,
+  connectorId,
   notionDatabaseId,
   lastSeenTs,
   parentType,
@@ -131,7 +125,7 @@ export async function upsertNotionDatabaseInConnectorsDb({
   skipReason,
   lastCreatedOrMovedRunTs,
 }: {
-  dataSourceInfo: DataSourceInfo;
+  connectorId: ModelId;
   notionDatabaseId: string;
   lastSeenTs: number;
   parentType?: string | null;
@@ -144,8 +138,7 @@ export async function upsertNotionDatabaseInConnectorsDb({
   const connector = await Connector.findOne({
     where: {
       type: "notion",
-      workspaceId: dataSourceInfo.workspaceId,
-      dataSourceName: dataSourceInfo.dataSourceName,
+      id: connectorId,
     },
   });
   if (!connector) {
@@ -200,28 +193,17 @@ export async function upsertNotionDatabaseInConnectorsDb({
 }
 
 export async function getNotionDatabaseFromConnectorsDb(
-  dataSourceInfo: DataSourceInfo,
+  connectorId: ModelId,
   notionDatabaseId: string,
   lastSeenTs?: number
 ): Promise<NotionDatabase | null> {
-  const connector = await Connector.findOne({
-    where: {
-      type: "notion",
-      workspaceId: dataSourceInfo.workspaceId,
-      dataSourceName: dataSourceInfo.dataSourceName,
-    },
-  });
-  if (!connector) {
-    throw new Error("Could not find connector");
-  }
-
   const where: {
     notionDatabaseId: string;
-    connectorId: string;
+    connectorId: ModelId;
     lastSeenTs?: Date;
   } = {
     notionDatabaseId,
-    connectorId: connector.id.toString(),
+    connectorId,
   };
 
   if (lastSeenTs) {
@@ -237,24 +219,13 @@ export async function getNotionDatabaseFromConnectorsDb(
  * !! Not children *of a page*
  */
 export async function getPageChildrenOf(
-  dataSourceInfo: DataSourceInfo,
+  connectorId: ModelId,
   notionId: string
 ): Promise<NotionPage[]> {
-  const connector = await Connector.findOne({
-    where: {
-      type: "notion",
-      workspaceId: dataSourceInfo.workspaceId,
-      dataSourceName: dataSourceInfo.dataSourceName,
-    },
-  });
-  if (!connector) {
-    throw new Error("Could not find connector");
-  }
-
   return NotionPage.findAll({
     where: {
       parentId: notionId,
-      connectorId: connector.id,
+      connectorId: connectorId,
     },
   });
 }
@@ -265,24 +236,13 @@ export async function getPageChildrenOf(
  * !! Not children *of a database*
  */
 export async function getDatabaseChildrenOf(
-  dataSourceInfo: DataSourceInfo,
+  connectorId: ModelId,
   notionId: string
 ): Promise<NotionDatabase[]> {
-  const connector = await Connector.findOne({
-    where: {
-      type: "notion",
-      workspaceId: dataSourceInfo.workspaceId,
-      dataSourceName: dataSourceInfo.dataSourceName,
-    },
-  });
-  if (!connector) {
-    throw new Error("Could not find connector");
-  }
-
   return NotionDatabase.findAll({
     where: {
       parentId: notionId,
-      connectorId: connector.id,
+      connectorId: connectorId,
     },
   });
 }

--- a/connectors/src/connectors/notion/lib/notion_api.ts
+++ b/connectors/src/connectors/notion/lib/notion_api.ts
@@ -574,30 +574,32 @@ export function parsePageProperties(page: PageObjectResponse) {
   return properties;
 }
 
-export async function retrievePageBlocksResultPage({
+export async function retrieveBlockChildrenResultPage({
   accessToken,
-  pageId,
+  blockOrPageId,
   cursor,
   loggerArgs,
 }: {
   accessToken: string;
-  pageId: string;
+  blockOrPageId: string;
   cursor: string | null;
   loggerArgs: Record<string, string | number>;
 }): Promise<ListBlockChildrenResponse | null> {
-  const localLogger = logger.child({ ...loggerArgs, pageId });
+  const localLogger = logger.child(loggerArgs);
 
   const notionClient = new Client({ auth: accessToken });
 
   try {
-    localLogger.info("Fetching page blocks result page from Notion API.");
+    localLogger.info(
+      "Fetching block or page children result page from Notion API."
+    );
     const resultPage = await notionClient.blocks.children.list({
-      block_id: pageId,
+      block_id: blockOrPageId,
       start_cursor: cursor ?? undefined,
     });
     localLogger.info(
       { count: resultPage.results.length },
-      "Received page blocks result page from Notion API."
+      "Received block or page children result page from Notion API."
     );
     return resultPage;
   } catch (e) {
@@ -612,7 +614,7 @@ export async function retrievePageBlocksResultPage({
             message: e.message,
           },
         },
-        "Couldn't get page blocks."
+        "Couldn't get block or page children."
       );
       return null;
     } else {

--- a/connectors/src/connectors/notion/lib/tags.ts
+++ b/connectors/src/connectors/notion/lib/tags.ts
@@ -1,6 +1,6 @@
-import type { ParsedPage } from "@connectors/connectors/notion/lib/notion_api";
+import { ParsedNotionPage } from "@connectors/connectors/notion/lib/types";
 
-export function getTagsForPage(page: ParsedPage): string[] {
+export function getTagsForPage(page: ParsedNotionPage): string[] {
   const tags: string[] = [];
   if (page.title) {
     tags.push(`title:${page.title}`);

--- a/connectors/src/connectors/notion/lib/tags.ts
+++ b/connectors/src/connectors/notion/lib/tags.ts
@@ -1,15 +1,25 @@
-import { ParsedNotionPage } from "@connectors/connectors/notion/lib/types";
-
-export function getTagsForPage(page: ParsedNotionPage): string[] {
+export function getTagsForPage({
+  title,
+  author,
+  lastEditor,
+  updatedTime,
+  createdTime,
+}: {
+  title?: string | null;
+  author: string;
+  lastEditor: string;
+  updatedTime: number;
+  createdTime: number;
+}): string[] {
   const tags: string[] = [];
-  if (page.title) {
-    tags.push(`title:${page.title}`);
+  if (title) {
+    tags.push(`title:${title}`);
   }
 
   return tags.concat([
-    `author:${page.author}`,
-    `lastEditor:${page.lastEditor}`,
-    `lastEditedAt:${page.updatedTime}`,
-    `createdAt:${page.createdTime}`,
+    `author:${author}`,
+    `lastEditor:${lastEditor}`,
+    `lastEditedAt:${updatedTime}`,
+    `createdAt:${createdTime}`,
   ]);
 }

--- a/connectors/src/connectors/notion/lib/types.ts
+++ b/connectors/src/connectors/notion/lib/types.ts
@@ -1,0 +1,47 @@
+import {
+  BlockObjectResponse,
+  PageObjectResponse,
+} from "@notionhq/client/build/src/api-endpoints";
+
+// notion SDK types
+export type PageObjectProperties = PageObjectResponse["properties"];
+export type PropertyKeys = keyof PageObjectProperties;
+export type PropertyTypes = PageObjectProperties[PropertyKeys]["type"];
+
+// Extractor types
+export type ParsedNotionPage = {
+  id: string;
+  url: string;
+  title?: string;
+  properties: ParsedNotionPageProperty[];
+  blocks: ParsedNotionBlock[];
+  rendered: string;
+  createdTime: number;
+  updatedTime: number;
+  author: string;
+  lastEditor: string;
+  hasBody: boolean;
+  parentType: "database" | "page" | "block" | "workspace";
+  parentId: string;
+};
+
+export type ParsedNotionPageProperty = {
+  key: string;
+  id: string;
+  type: PropertyTypes;
+  text: string | null;
+};
+
+export type ParsedNotionBlock = {
+  id: string;
+  type: BlockObjectResponse["type"];
+  text: string | null;
+};
+
+export type ParsedNotionDatabase = {
+  id: string;
+  url: string;
+  title?: string;
+  parentType: "database" | "page" | "block" | "workspace";
+  parentId: string;
+};

--- a/connectors/src/connectors/notion/lib/types.ts
+++ b/connectors/src/connectors/notion/lib/types.ts
@@ -32,9 +32,11 @@ export type ParsedNotionPageProperty = {
   text: string | null;
 };
 
+export type NotionBlockType = BlockObjectResponse["type"];
+
 export type ParsedNotionBlock = {
   id: string;
-  type: BlockObjectResponse["type"];
+  type: NotionBlockType;
   text: string | null;
 };
 

--- a/connectors/src/connectors/notion/lib/types.ts
+++ b/connectors/src/connectors/notion/lib/types.ts
@@ -38,6 +38,8 @@ export type ParsedNotionBlock = {
   id: string;
   type: NotionBlockType;
   text: string | null;
+  hasChildren: boolean;
+  childDatabaseTitle: string | null;
 };
 
 export type ParsedNotionDatabase = {

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -1356,7 +1356,6 @@ export async function notionRenderAndUpsertPageFromCache({
     .map((b) => ({
       id: b.notionBlockId,
       title:
-        // allow non null assertion here:
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         b.childDatabaseTitle!,
     }))

--- a/connectors/src/connectors/notion/temporal/client.ts
+++ b/connectors/src/connectors/notion/temporal/client.ts
@@ -8,7 +8,7 @@ import { QUEUE_NAME } from "@connectors/connectors/notion/temporal/config";
 import { getWorkflowId } from "@connectors/connectors/notion/temporal/utils";
 import { notionSyncWorkflow } from "@connectors/connectors/notion/temporal/workflows";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
-import { Connector } from "@connectors/lib/models";
+import { Connector, ModelId } from "@connectors/lib/models";
 import { getTemporalClient } from "@connectors/lib/temporal";
 import mainLogger from "@connectors/logger/logger";
 import { DataSourceInfo } from "@connectors/types/data_source_config";
@@ -16,7 +16,7 @@ import { DataSourceInfo } from "@connectors/types/data_source_config";
 const logger = mainLogger.child({ provider: "notion" });
 
 export async function launchNotionSyncWorkflow(
-  connectorId: string,
+  connectorId: ModelId,
   startFromTs: number | null = null,
   forceResync = false
 ) {
@@ -40,7 +40,7 @@ export async function launchNotionSyncWorkflow(
   }
 
   await client.workflow.start(notionSyncWorkflow, {
-    args: [dataSourceConfig, startFromTs || undefined, forceResync],
+    args: [{ connectorId, startFromTs, forceResync }],
     taskQueue: QUEUE_NAME,
     workflowId: getWorkflowId(dataSourceConfig),
   });

--- a/connectors/src/connectors/notion/temporal/config.ts
+++ b/connectors/src/connectors/notion/temporal/config.ts
@@ -1,2 +1,2 @@
-export const WORKFLOW_VERSION = 24;
+export const WORKFLOW_VERSION = 25;
 export const QUEUE_NAME = `notion-queue-v${WORKFLOW_VERSION}`;

--- a/connectors/src/connectors/notion/temporal/utils.ts
+++ b/connectors/src/connectors/notion/temporal/utils.ts
@@ -1,5 +1,10 @@
+import { ModelId } from "@connectors/lib/models";
 import { DataSourceInfo } from "@connectors/types/data_source_config";
 
 export function getWorkflowId(dataSourceInfo: DataSourceInfo) {
   return `workflow-notion-${dataSourceInfo.workspaceId}-${dataSourceInfo.dataSourceName}`;
+}
+
+export function getWorkflowIdV2(connectorId: ModelId) {
+  return `notion-${connectorId}`;
 }

--- a/connectors/src/lib/models.ts
+++ b/connectors/src/lib/models.ts
@@ -9,6 +9,10 @@ import {
 } from "sequelize";
 
 import {
+  NotionBlockType,
+  ParsedNotionPageProperty,
+} from "@connectors/connectors/notion/lib/types";
+import {
   type ConnectorProvider,
   ConnectorSyncStatus,
 } from "@connectors/types/connector";
@@ -652,6 +656,129 @@ NotionDatabase.init(
 );
 
 Connector.hasMany(NotionDatabase);
+
+export class NotionConnectorPageCacheEntry extends Model<
+  InferAttributes<NotionConnectorPageCacheEntry>,
+  InferCreationAttributes<NotionConnectorPageCacheEntry>
+> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare notionPageId: string;
+  declare pageProperties: ParsedNotionPageProperty[]; // JSON -- typed but not guaranteed
+
+  declare connectorId: ForeignKey<Connector["id"]>;
+}
+
+NotionConnectorPageCacheEntry.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    notionPageId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    pageProperties: {
+      type: DataTypes.JSONB,
+      allowNull: false,
+    },
+  },
+  {
+    sequelize: sequelize_conn,
+    modelName: "notion_connector_page_cache_entries",
+    indexes: [{ fields: ["notionPageId", "connectorId"], unique: true }],
+  }
+);
+
+Connector.hasMany(NotionConnectorPageCacheEntry);
+
+export class NotionConnectorBlockCacheEntry extends Model<
+  InferAttributes<NotionConnectorBlockCacheEntry>,
+  InferCreationAttributes<NotionConnectorBlockCacheEntry>
+> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare notionPageId: string;
+  declare notionBlockId: string;
+  declare blockText: string | null;
+  declare blockType: NotionBlockType;
+  declare parentBlockId: string | null;
+  declare indexInParent: number;
+
+  declare connectorId: ForeignKey<Connector["id"]>;
+}
+
+NotionConnectorBlockCacheEntry.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    notionPageId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    notionBlockId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    blockText: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+    },
+    blockType: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    parentBlockId: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
+    indexInParent: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+  },
+  {
+    sequelize: sequelize_conn,
+    modelName: "notion_connector_block_cache_entries",
+    indexes: [
+      {
+        fields: ["notionBlockId", "connectorId", "notionPageId"],
+        unique: true,
+      },
+    ],
+  }
+);
+
+Connector.hasMany(NotionConnectorBlockCacheEntry);
 
 export class GithubConnectorState extends Model<
   InferAttributes<GithubConnectorState>,

--- a/connectors/src/lib/models.ts
+++ b/connectors/src/lib/models.ts
@@ -10,7 +10,7 @@ import {
 
 import {
   NotionBlockType,
-  ParsedNotionPageProperty,
+  PageObjectProperties,
 } from "@connectors/connectors/notion/lib/types";
 import {
   type ConnectorProvider,
@@ -666,7 +666,7 @@ export class NotionConnectorPageCacheEntry extends Model<
   declare updatedAt: CreationOptional<Date>;
 
   declare notionPageId: string;
-  declare pageProperties: ParsedNotionPageProperty[]; // JSON -- typed but not guaranteed
+  declare pageProperties: PageObjectProperties; // JSON -- typed but not guaranteed
   declare parentId: string;
   declare parentType: "database" | "page" | "workspace" | "block" | "unknown";
   declare lastEditedById: string;

--- a/connectors/src/lib/models.ts
+++ b/connectors/src/lib/models.ts
@@ -673,6 +673,7 @@ export class NotionConnectorPageCacheEntry extends Model<
   declare createdById: string;
   declare createdTime: string;
   declare lastEditedTime: string;
+  declare url: string;
 
   declare connectorId: ForeignKey<Connector["id"]>;
 }
@@ -714,6 +715,10 @@ NotionConnectorPageCacheEntry.init(
       type: DataTypes.STRING,
       allowNull: false,
     },
+    createdById: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
     createdTime: {
       type: DataTypes.STRING,
       allowNull: false,
@@ -722,7 +727,7 @@ NotionConnectorPageCacheEntry.init(
       type: DataTypes.STRING,
       allowNull: false,
     },
-    createdById: {
+    url: {
       type: DataTypes.STRING,
       allowNull: false,
     },
@@ -733,7 +738,7 @@ NotionConnectorPageCacheEntry.init(
     indexes: [
       { fields: ["notionPageId", "connectorId"], unique: true },
       { fields: ["connectorId"] },
-      { fields: ["parentDatabaseId"] },
+      { fields: ["parentId"] },
     ],
   }
 );

--- a/connectors/src/lib/models.ts
+++ b/connectors/src/lib/models.ts
@@ -721,6 +721,9 @@ export class NotionConnectorBlockCacheEntry extends Model<
   declare parentBlockId: string | null;
   declare indexInParent: number;
 
+  // special case for child DBs
+  declare childDatabaseTitle?: string | null;
+
   declare connectorId: ForeignKey<Connector["id"]>;
 }
 
@@ -764,6 +767,10 @@ NotionConnectorBlockCacheEntry.init(
     indexInParent: {
       type: DataTypes.INTEGER,
       allowNull: false,
+    },
+    childDatabaseTitle: {
+      type: DataTypes.STRING,
+      allowNull: true,
     },
   },
   {

--- a/connectors/src/lib/models.ts
+++ b/connectors/src/lib/models.ts
@@ -667,6 +667,12 @@ export class NotionConnectorPageCacheEntry extends Model<
 
   declare notionPageId: string;
   declare pageProperties: ParsedNotionPageProperty[]; // JSON -- typed but not guaranteed
+  declare parentId: string;
+  declare parentType: "database" | "page" | "workspace" | "block" | "unknown";
+  declare lastEditedById: string;
+  declare createdById: string;
+  declare createdTime: string;
+  declare lastEditedTime: string;
 
   declare connectorId: ForeignKey<Connector["id"]>;
 }
@@ -696,11 +702,39 @@ NotionConnectorPageCacheEntry.init(
       type: DataTypes.JSONB,
       allowNull: false,
     },
+    parentId: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
+    parentType: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    lastEditedById: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    createdTime: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    lastEditedTime: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    createdById: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
   },
   {
     sequelize: sequelize_conn,
     modelName: "notion_connector_page_cache_entries",
-    indexes: [{ fields: ["notionPageId", "connectorId"], unique: true }],
+    indexes: [
+      { fields: ["notionPageId", "connectorId"], unique: true },
+      { fields: ["connectorId"] },
+      { fields: ["parentDatabaseId"] },
+    ],
   }
 );
 
@@ -781,6 +815,8 @@ NotionConnectorBlockCacheEntry.init(
         fields: ["notionBlockId", "connectorId", "notionPageId"],
         unique: true,
       },
+      { fields: ["connectorId"] },
+      { fields: ["parentBlockId"] },
     ],
   }
 );


### PR DESCRIPTION
Mostly, the implementation for [this design doc](https://www.notion.so/dust-tt/d151a5226dba4f8fbe094365da5f00d4?v=73f1ca4b919b4cef89fabbf66e671af6&p=6d0722d3dc3b40d5a97c4eaed0e09b5b&pm=s).

This transforms the "notion upsert page" activity into a workflow, which turns out to be a massive change.

I used the opportunity to cleanup some stuff too:
- the workflow now takes a connector ID instead of workspaceId / workspaceAPIKey / datasourceName (better !)
- the notion access token is re-fetched from nango everytime
- I removed useless prefix/suffix from workflows and activity names

I have tested it locally against our own notion workspace