### PR TITLE
Sparkle: new component radio button

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "license": "ISC",
       "dependencies": {
         "@headlessui/react": "^1.7.17"

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/components/RadioButton.tsx
+++ b/sparkle/src/components/RadioButton.tsx
@@ -1,0 +1,76 @@
+import React from "react";
+
+import { classNames } from "@sparkle/lib/utils";
+
+export type RadioButtonProps = {
+  name: string;
+  choices: RadioButtonChoice[];
+  value: string;
+  layout: "inline" | "stacked";
+  onChange: (value: string) => void;
+};
+
+export type RadioButtonChoice = {
+  label: string;
+  value: string;
+  disabled: boolean;
+};
+
+const labelClasses = {
+  base: "dark:s-text-element-800-dark",
+  selected: "s-opacity-100 s-bg-action-500",
+  disabled: "s-opacity-50",
+};
+
+const inputClasses = {
+  base: "focus:s-outline-none s-ring-0 s-bg-action-50 dark:s-bg-structure-200-dark dark:s-ring-structure-200-dark s-p-2",
+  selected: "s-opacity-100 s-bg-action-500",
+  disabled:
+    "s-cursor-not-allowed dark:s-bg-structure-0-dark dark:s-border-structure-300-dark",
+};
+
+export function RadioButton({
+  name,
+  choices,
+  value,
+  layout,
+  onChange,
+}: RadioButtonProps) {
+  return (
+    <div
+      className={classNames(
+        "s-flex",
+        layout === "inline" ? "s-flex-row s-gap-x-4" : "s-flex-col s-gap-y-2"
+      )}
+    >
+      {choices.map((choice) => (
+        <div key={choice.value}>
+          <label
+            className={classNames(
+              "s-flex s-items-center s-space-x-2",
+              labelClasses.base,
+              choice.disabled ? labelClasses.disabled : ""
+            )}
+          >
+            <input
+              type="radio"
+              name={name}
+              value={choice.value}
+              checked={value === choice.value}
+              disabled={choice.disabled}
+              onChange={(e) => {
+                onChange(e.target.value);
+              }}
+              className={classNames(
+                inputClasses.base,
+                choice.disabled ? inputClasses.disabled : "",
+                choice.value === value ? inputClasses.selected : ""
+              )}
+            />
+            <span>{choice.label}</span>
+          </label>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/sparkle/src/stories/RadioButton.stories.tsx
+++ b/sparkle/src/stories/RadioButton.stories.tsx
@@ -1,0 +1,70 @@
+import { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+
+import { RadioButton } from "@sparkle/components/RadioButton";
+
+const meta = {
+  title: "Atoms/RadioButton",
+  component: RadioButton,
+} satisfies Meta<typeof RadioButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const RadioButtonExamples = () => {
+  const [value1, setValue1] = React.useState<string>("yes");
+  const [value2, setValue2] = React.useState<string>("");
+
+  return (
+    <div>
+      <RadioButton
+        name="test1"
+        layout="inline"
+        choices={[
+          {
+            label: "yes",
+            value: "yes",
+            disabled: false,
+          },
+          {
+            label: "no",
+            value: "no",
+            disabled: false,
+          },
+          {
+            label: "maybe",
+            value: "maybe",
+            disabled: true,
+          },
+        ]}
+        value={value1}
+        onChange={(v) => {
+          setValue1(v);
+        }}
+      />
+      <br />
+      <br />
+      <br />
+      <RadioButton
+        name="test2"
+        layout="stacked"
+        choices={[
+          {
+            label: "more",
+            value: "more",
+            disabled: false,
+          },
+          {
+            label: "less",
+            value: "no",
+            disabled: false,
+          },
+        ]}
+        value={value2}
+        onChange={(v) => {
+          setValue2(v);
+        }}
+      />
+    </div>
+  );
+};

--- a/sparkle/src/stories/RadioButton.stories.tsx
+++ b/sparkle/src/stories/RadioButton.stories.tsx
@@ -9,7 +9,6 @@ const meta = {
 } satisfies Meta<typeof RadioButton>;
 
 export default meta;
-type Story = StoryObj<typeof meta>;
 
 export const RadioButtonExamples = () => {
   const [value1, setValue1] = React.useState<string>("yes");


### PR DESCRIPTION
We need radio buttons for this screen: 

<img width="922" alt="Capture d’écran 2023-10-12 à 17 19 09" src="https://github.com/dust-tt/dust/assets/3803406/0788015e-d19b-4490-8b4d-7ce4058a1962">

 
### Screenshots from storybook

<img width="910" alt="Capture d’écran 2023-10-12 à 17 18 22" src="https://github.com/dust-tt/dust/assets/3803406/9c521715-b25c-435a-9f5b-38f5a43522aa">
<img width="892" alt="Capture d’écran 2023-10-12 à 17 18 30" src="https://github.com/dust-tt/dust/assets/3803406/41e51530-cb87-4a46-a31d-dd90bcf3cb5f">
