### PR TITLE
sparkle: fix Citation types

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.10",
+      "version": "0.2.11",
       "license": "ISC",
       "dependencies": {
         "@headlessui/react": "^1.7.17"

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/components/Citation.tsx
+++ b/sparkle/src/components/Citation.tsx
@@ -7,7 +7,7 @@ import { Drive, Github, Notion, Slack } from "@sparkle/logo/platforms";
 import { ExternalLinkIcon, Icon, IconButton } from "..";
 
 interface CitationProps {
-  type?: "slack" | "drive" | "github" | "notion" | "document";
+  type?: "slack" | "google_drive" | "github" | "notion" | "document";
   title: string;
   description?: string;
   index?: ReactNode;
@@ -17,7 +17,7 @@ interface CitationProps {
 
 const typeIcons = {
   slack: Slack,
-  drive: Drive,
+  google_drive: Drive,
   github: Github,
   notion: Notion,
   document: DocumentText,

--- a/sparkle/src/stories/Citation.stories.tsx
+++ b/sparkle/src/stories/Citation.stories.tsx
@@ -10,7 +10,7 @@ const meta = {
 
 export default meta;
 
-export const ListChipsExample = () => (
+export const CitationsExample = () => (
   <div className="s-flex s-flex-col s-gap-8">
     <Citation
       title="Source: Thread on #general"
@@ -34,7 +34,7 @@ export const ListChipsExample = () => (
       />
       <Citation
         title="Title"
-        type="drive"
+        type="google_drive"
         index="3"
         href="https://www.google.com"
         description="Write a 120 character description of the citation here to be displayed in the citation list."


### PR DESCRIPTION
`front` uses `google_drive` not `drive` so fixing sparkle will save us a bit of tedious useless code