### PR TITLE
Fix claude streaming

### DIFF
--- a/core/src/providers/anthropic.rs
+++ b/core/src/providers/anthropic.rs
@@ -227,6 +227,7 @@ impl AnthropicLLM {
         stop: &Vec<String>,
         event_sender: UnboundedSender<Value>,
     ) -> Result<Response> {
+        let https = HttpsConnector::new();
         let url = self.uri()?.to_string();
 
         let mut builder = match es::ClientBuilder::for_url(url.as_str()) {
@@ -277,7 +278,7 @@ impl AnthropicLLM {
                     .delay_max(Duration::from_secs(8))
                     .build(),
             )
-            .build();
+            .build_with_conn(https);
 
         let mut stream = client.stream();
 


### PR DESCRIPTION
We had the error from claude when streaming:
```
ERROR: Error generating agent message: Error querying `anthropic:claude-instant-1.2`: error=Error streaming from Anthropic: HttpStream(hyper::Error(Connect, Custom { kind: Other, error: Custom { kind: InvalidData, error: InvalidSCT(UnknownLog) } })) (code: agent_generation_error)
```

This PR fixes it by explicitely building the https connection with likely more lenient options