### PR TITLE
Onboarding: new welcome page

### DIFF
--- a/front/components/sparkle/OnboardingLayout.tsx
+++ b/front/components/sparkle/OnboardingLayout.tsx
@@ -1,0 +1,108 @@
+import Head from "next/head";
+import Script from "next/script";
+import { useRef } from "react";
+import React from "react";
+
+import Particles from "@app/components/home/particles";
+import { WorkspaceType } from "@app/types/user";
+
+export default function OnboardingLayout({
+  owner,
+  gaTrackingId,
+  children,
+}: {
+  owner?: WorkspaceType;
+  gaTrackingId: string;
+  children: React.ReactNode;
+}) {
+  const scrollRef1 = useRef<HTMLDivElement | null>(null);
+  const scrollRef2 = useRef<HTMLDivElement | null>(null);
+  const scrollRef3 = useRef<HTMLDivElement | null>(null);
+
+  return (
+    <>
+      <Head>
+        <title>{`Dust - ${owner?.name || "Onboarding"}`}</title>
+        <link rel="shortcut icon" href="/static/favicon.png" />
+
+        <meta name="apple-mobile-web-app-title" content="Dust" />
+        <link rel="apple-touch-icon" href="/static/AppIcon.png" />
+        <link
+          rel="apple-touch-icon"
+          sizes="60x60"
+          href="/static/AppIcon_60.png"
+        />
+        <link
+          rel="apple-touch-icon"
+          sizes="76x76"
+          href="/static/AppIcon_76.png"
+        />
+        <link
+          rel="apple-touch-icon"
+          sizes="120x120"
+          href="/static/AppIcon_120.png"
+        />
+        <link
+          rel="apple-touch-icon"
+          sizes="152x152"
+          href="/static/AppIcon_152.png"
+        />
+        <link
+          rel="apple-touch-icon"
+          sizes="167x167"
+          href="/static/AppIcon_167.png"
+        />
+        <link
+          rel="apple-touch-icon"
+          sizes="180x180"
+          href="/static/AppIcon_180.png"
+        />
+        <link
+          rel="apple-touch-icon"
+          sizes="192x192"
+          href="/static/AppIcon_192.png"
+        />
+        <link
+          rel="apple-touch-icon"
+          sizes="228x228"
+          href="/static/AppIcon_228.png"
+        />
+
+        <meta
+          name="viewport"
+          content="width=device-width, initial-scale=1, maximum-scale=1"
+        />
+      </Head>
+
+      {/* Keeping the background dark */}
+      <div className="fixed bottom-0 left-0 right-0 top-0 -z-50 bg-slate-800" />
+      {/* Particle system */}
+      <div className="fixed bottom-0 left-0 right-0 top-0 -z-40 overflow-hidden">
+        <Particles
+          scrollRef1={scrollRef1}
+          scrollRef2={scrollRef2}
+          scrollRef3={scrollRef3}
+        />
+      </div>
+
+      <div className="s-dark text-slate-200">
+        <main className="z-10 mx-auto max-w-4xl px-6 pt-24">{children}</main>
+      </div>
+      <>
+        <Script
+          src={`https://www.googletagmanager.com/gtag/js?id=${gaTrackingId}`}
+          strategy="afterInteractive"
+        />
+        <Script id="google-analytics" strategy="afterInteractive">
+          {`
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){window.dataLayer.push(arguments);}
+            gtag('js', new Date());
+  
+            gtag('config', '${gaTrackingId}');
+            `}
+        </Script>
+      </>
+    </>
+  );
+}

--- a/front/lib/api/user.ts
+++ b/front/lib/api/user.ts
@@ -1,4 +1,3 @@
-import { ModelId } from "@app/lib/databases";
 import { User, UserMetadata } from "@app/lib/models";
 import { UserMetadataType, UserType } from "@app/types/user";
 
@@ -60,28 +59,28 @@ export async function setUserMetadata(
 }
 
 export async function updateUserFullName({
-  userId,
+  user,
   firstName,
   lastName,
 }: {
-  userId: ModelId;
+  user: UserType;
   firstName: string;
   lastName: string;
 }): Promise<boolean | null> {
-  const user = await User.findOne({
+  const u = await User.findOne({
     where: {
-      id: userId,
+      id: user.id,
     },
   });
 
-  if (!user) {
+  if (!u) {
     return null;
   }
 
-  user.firstName = firstName;
-  user.lastName = lastName;
-  user.name = `${firstName} ${lastName}`;
-  await user.save();
+  u.firstName = firstName;
+  u.lastName = lastName;
+  u.name = `${firstName} ${lastName}`;
+  await u.save();
 
   return true;
 }

--- a/front/lib/api/user.ts
+++ b/front/lib/api/user.ts
@@ -1,4 +1,5 @@
-import { UserMetadata } from "@app/lib/models";
+import { ModelId } from "@app/lib/databases";
+import { User, UserMetadata } from "@app/lib/models";
 import { UserMetadataType, UserType } from "@app/types/user";
 
 /**
@@ -56,4 +57,31 @@ export async function setUserMetadata(
 
   metadata.value = update.value;
   await metadata.save();
+}
+
+export async function updateUserFullName({
+  userId,
+  firstName,
+  lastName,
+}: {
+  userId: ModelId;
+  firstName: string;
+  lastName: string;
+}): Promise<boolean | null> {
+  const user = await User.findOne({
+    where: {
+      id: userId,
+    },
+  });
+
+  if (!user) {
+    return null;
+  }
+
+  user.firstName = firstName;
+  user.lastName = lastName;
+  user.name = `${firstName} ${lastName}`;
+  await user.save();
+
+  return true;
 }

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@dust-tt/sparkle": "^0.2.13",
+        "@dust-tt/sparkle": "^0.2.14",
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",
         "@headlessui/react": "^1.7.7",
@@ -727,9 +727,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.13.tgz",
-      "integrity": "sha512-mmd59YveWO8zzS5M3b5z53pEIpLyMr67x5//LcLzf1R4+XrbxaI4Hzzkb7DVZCY033ppJpA0c5KgkeFbk6FcGA==",
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.14.tgz",
+      "integrity": "sha512-UNXNk6GigHpRpwKIjJ4Q2gKNh3H/q0Ad3ULQ7OHx9rqD1Tyopg4YGCLuS0+9BswF0e/4wiYZWQ7sAKd48JjenA==",
       "dependencies": {
         "@headlessui/react": "^1.7.17"
       },

--- a/front/package.json
+++ b/front/package.json
@@ -13,7 +13,7 @@
     "initdb": "env $(cat .env.local) npx tsx admin/db.ts"
   },
   "dependencies": {
-    "@dust-tt/sparkle": "^0.2.13",
+    "@dust-tt/sparkle": "^0.2.14",
     "@emoji-mart/data": "^1.1.2",
     "@emoji-mart/react": "^1.1.1",
     "@headlessui/react": "^1.7.7",

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -286,10 +286,12 @@ async function handler(
       if (targetWorkspace) {
         // For users joining a workspace from trying to access a conversation, we redirect to this conversation after signing in.
         if (req.query.join === "true" && req.query.cId) {
-          res.redirect(`/w/${targetWorkspace.sId}/assistant/${req.query.cId}`);
+          res.redirect(
+            `/w/${targetWorkspace.sId}/welcome?cId=${req.query.cId}`
+          );
           return;
         }
-        res.redirect(`/w/${targetWorkspace.sId}`);
+        res.redirect(`/w/${targetWorkspace.sId}/welcome`);
         return;
       }
 

--- a/front/pages/api/user/index.ts
+++ b/front/pages/api/user/index.ts
@@ -49,7 +49,7 @@ async function handler(
       }
 
       const result = await updateUserFullName({
-        userId: user.id,
+        user: user,
         firstName: req.body.firstName,
         lastName: req.body.lastName,
       });

--- a/front/pages/api/user/index.ts
+++ b/front/pages/api/user/index.ts
@@ -1,0 +1,83 @@
+import { isLeft } from "fp-ts/lib/Either";
+import * as t from "io-ts";
+import * as reporter from "io-ts-reporters";
+import { NextApiRequest, NextApiResponse } from "next";
+
+import { updateUserFullName } from "@app/lib/api/user";
+import { getSession, getUserFromSession } from "@app/lib/auth";
+import { ReturnedAPIErrorType } from "@app/lib/error";
+import { apiError, withLogging } from "@app/logger/withlogging";
+
+export type PostUserMetadataResponseBody = {
+  success: boolean;
+};
+
+const PatchUserBodySchema = t.type({
+  firstName: t.string,
+  lastName: t.string,
+});
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<PostUserMetadataResponseBody | ReturnedAPIErrorType>
+): Promise<void> {
+  const session = await getSession(req, res);
+  const user = await getUserFromSession(session);
+
+  if (!user) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "user_not_found",
+        message: "The user was not found.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "PATCH":
+      const bodyValidation = PatchUserBodySchema.decode(req.body);
+      if (isLeft(bodyValidation)) {
+        const pathError = reporter.formatValidationErrors(bodyValidation.left);
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid request body: ${pathError}`,
+          },
+        });
+      }
+
+      const result = await updateUserFullName({
+        userId: user.id,
+        firstName: req.body.firstName,
+        lastName: req.body.lastName,
+      });
+
+      if (!result) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "internal_server_error",
+            message: "Couldn't update the user.",
+          },
+        });
+      }
+
+      res.status(200).json({
+        success: true,
+      });
+      return;
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, PATCH is expected.",
+        },
+      });
+  }
+}
+
+export default withLogging(handler);

--- a/front/pages/w/[wId]/join.tsx
+++ b/front/pages/w/[wId]/join.tsx
@@ -105,9 +105,10 @@ export default function Join({
   onboardingType,
   workspace,
   signUpCallbackUrl,
+  gaTrackingId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   return (
-    <OnboardingLayout owner={workspace} gaTrackingId={GA_TRACKING_ID}>
+    <OnboardingLayout owner={workspace} gaTrackingId={gaTrackingId}>
       <div className="grid grid-cols-1">
         <div>
           <Logo className="h-[48px] w-[192px] px-1" />

--- a/front/pages/w/[wId]/join.tsx
+++ b/front/pages/w/[wId]/join.tsx
@@ -3,7 +3,9 @@ import { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import { signIn } from "next-auth/react";
 
 import { SignInButton } from "@app/components/Button";
+import OnboardingLayout from "@app/components/sparkle/OnboardingLayout";
 import { getWorkspaceInfos } from "@app/lib/api/workspace";
+import { WorkspaceType } from "@app/types/user";
 
 const { URL = "", GA_TRACKING_ID = "" } = process.env;
 
@@ -33,7 +35,7 @@ type OnboardingType =
 
 export const getServerSideProps: GetServerSideProps<{
   onboardingType: OnboardingType;
-  workspaceName: string;
+  workspace: WorkspaceType;
   signUpCallbackUrl: string;
   gaTrackingId: string;
   baseUrl: string;
@@ -91,7 +93,7 @@ export const getServerSideProps: GetServerSideProps<{
   return {
     props: {
       onboardingType: onboardingType,
-      workspaceName: workspace.name,
+      workspace: workspace,
       signUpCallbackUrl: signUpCallbackUrl,
       baseUrl: URL,
       gaTrackingId: GA_TRACKING_ID,
@@ -101,64 +103,57 @@ export const getServerSideProps: GetServerSideProps<{
 
 export default function Join({
   onboardingType,
-  workspaceName,
+  workspace,
   signUpCallbackUrl,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   return (
-    <>
-      <div className="fixed bottom-0 left-0 right-0 top-0 -z-50 bg-slate-800" />
-      <main className="z-10 mx-6">
-        <div className="container mx-auto sm:max-w-3xl lg:max-w-4xl xl:max-w-5xl">
-          <div style={{ height: "10vh" }}></div>
-          <div className="grid grid-cols-1">
-            <div>
-              <Logo className="h-[48px] w-[192px] px-1" />
-            </div>
-            <p className="mt-16 font-objektiv text-4xl font-bold tracking-tighter text-slate-50 md:text-6xl">
-              <span className="text-red-400 sm:font-objektiv md:font-objektiv">
-                Secure AI assistant
-              </span>{" "}
-              <br />
-              with your company’s knowledge
-              <br />
-            </p>
-          </div>
-          <div className="h-10"></div>
-          <div className="font-regular text-lg text-slate-200">
-            <p>Glad to see you!</p>
-
-            {onboardingType === "domain_conversation_link" ? (
-              <p>
-                Please log in or sign up with your company email to access this
-                conversation.
-              </p>
-            ) : (
-              <p>
-                You've been invited to join the {workspaceName} workspace on
-                Dust.
-              </p>
-            )}
-
-            {onboardingType === "email_invite" && (
-              <p>How would you like to connect?</p>
-            )}
-          </div>
-
-          <div className="h-16" />
-
-          <div className="flex flex-col items-center justify-center gap-4">
-            <SignInButton
-              label="Sign up with Google"
-              icon={GoogleLogo}
-              onClick={() => {
-                void signIn("google", {
-                  callbackUrl: signUpCallbackUrl,
-                });
-              }}
-            />
-          </div>
+    <OnboardingLayout owner={workspace} gaTrackingId={GA_TRACKING_ID}>
+      <div className="grid grid-cols-1">
+        <div>
+          <Logo className="h-[48px] w-[192px] px-1" />
         </div>
-      </main>
-    </>
+        <p className="mt-16 font-objektiv text-4xl font-bold tracking-tighter text-slate-50 md:text-6xl">
+          <span className="text-red-400 sm:font-objektiv md:font-objektiv">
+            Secure AI assistant
+          </span>{" "}
+          <br />
+          with your company’s knowledge
+          <br />
+        </p>
+      </div>
+      <div className="h-10"></div>
+      <div className="font-regular text-lg text-slate-200">
+        <p>Glad to see you!</p>
+
+        {onboardingType === "domain_conversation_link" ? (
+          <p>
+            Please log in or sign up with your company email to access this
+            conversation.
+          </p>
+        ) : (
+          <p>
+            You've been invited to join the {workspace.name} workspace on Dust.
+          </p>
+        )}
+
+        {onboardingType === "email_invite" && (
+          <p>How would you like to connect?</p>
+        )}
+      </div>
+
+      <div className="h-16" />
+
+      <div className="flex flex-col items-center justify-center gap-4">
+        <SignInButton
+          label="Sign up with Google"
+          icon={GoogleLogo}
+          onClick={() => {
+            void signIn("google", {
+              callbackUrl: signUpCallbackUrl,
+            });
+          }}
+        />
+      </div>
+    </OnboardingLayout>
   );
 }

--- a/front/pages/w/[wId]/welcome.tsx
+++ b/front/pages/w/[wId]/welcome.tsx
@@ -103,7 +103,7 @@ export default function Welcome({
           <div>
             <p className="mt-16 font-objektiv text-2xl font-bold tracking-tighter">
               <span className="text-red-400 sm:font-objektiv md:font-objektiv">
-                Hello {user.username}
+                Hello {firstName}
               </span>
               <br />
               Let's check a few things.

--- a/front/pages/w/[wId]/welcome.tsx
+++ b/front/pages/w/[wId]/welcome.tsx
@@ -3,6 +3,7 @@ import { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 
+import OnboardingLayout from "@app/components/sparkle/OnboardingLayout";
 import { getUserMetadata } from "@app/lib/api/user";
 import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
 import { UserType, WorkspaceType } from "@app/types/user";
@@ -97,77 +98,75 @@ export default function Welcome({
   };
 
   return (
-    <div className="s-dark h-full bg-slate-800 text-slate-200">
-      <main className="z-10 mx-auto max-w-4xl px-6 pt-24">
-        <div className="flex flex-col gap-6">
-          <div>
-            <p className="mt-16 font-objektiv text-2xl font-bold tracking-tighter">
-              <span className="text-red-400 sm:font-objektiv md:font-objektiv">
-                Hello {firstName}
-              </span>
-              <br />
-              Let's check a few things.
-            </p>
-          </div>
-          <div>
-            <p>
-              Your email is <span className="font-bold">{user.email}</span>.
-            </p>
-          </div>
-          <div>
-            <p className="pb-2">Your name is:</p>
-            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-              <Input
-                name="firstName"
-                placeholder=""
-                value={firstName}
-                onChange={setFirstName}
-              />
-              <Input
-                name="lastName"
-                placeholder=""
-                value={lastName}
-                onChange={setLastName}
-              />
-            </div>
-          </div>
-          <div>
-            <p className="pb-2">
-              How often do you use ChatGPT or other AI Assistant?
-            </p>
-            <RadioButton
-              name="expertise"
-              className="flex-col sm:flex-row"
-              choices={[
-                {
-                  label: "Never!",
-                  value: "beginner",
-                  disabled: false,
-                },
-                {
-                  label: "Occasionally",
-                  value: "intermediate",
-                  disabled: false,
-                },
-                {
-                  label: "Regularly",
-                  value: "advanced",
-                  disabled: false,
-                },
-              ]}
-              value={expertise}
-              onChange={setExpertise}
+    <OnboardingLayout owner={owner} gaTrackingId={GA_TRACKING_ID}>
+      <div className="flex flex-col gap-6">
+        <div>
+          <p className="mt-16 font-objektiv text-2xl font-bold tracking-tighter">
+            <span className="text-red-400 sm:font-objektiv md:font-objektiv">
+              Hello {firstName}
+            </span>
+            <br />
+            Let's check a few things.
+          </p>
+        </div>
+        <div>
+          <p>
+            Your email is <span className="font-bold">{user.email}</span>.
+          </p>
+        </div>
+        <div>
+          <p className="pb-2">Your name is:</p>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <Input
+              name="firstName"
+              placeholder=""
+              value={firstName}
+              onChange={setFirstName}
             />
-          </div>
-          <div className="flex justify-center pt-6">
-            <Button
-              label="Start with Dust!"
-              disabled={!isFormValid}
-              onClick={handleSubmit}
+            <Input
+              name="lastName"
+              placeholder=""
+              value={lastName}
+              onChange={setLastName}
             />
           </div>
         </div>
-      </main>
-    </div>
+        <div>
+          <p className="pb-2">
+            How often do you use ChatGPT or other AI Assistant?
+          </p>
+          <RadioButton
+            name="expertise"
+            className="flex-col sm:flex-row"
+            choices={[
+              {
+                label: "Never!",
+                value: "beginner",
+                disabled: false,
+              },
+              {
+                label: "Occasionally",
+                value: "intermediate",
+                disabled: false,
+              },
+              {
+                label: "Regularly",
+                value: "advanced",
+                disabled: false,
+              },
+            ]}
+            value={expertise}
+            onChange={setExpertise}
+          />
+        </div>
+        <div className="flex justify-center pt-6">
+          <Button
+            label="Start with Dust!"
+            disabled={!isFormValid}
+            onClick={handleSubmit}
+          />
+        </div>
+      </div>
+    </OnboardingLayout>
   );
 }

--- a/front/pages/w/[wId]/welcome.tsx
+++ b/front/pages/w/[wId]/welcome.tsx
@@ -1,0 +1,171 @@
+import { Button, Input, RadioButton } from "@dust-tt/sparkle";
+import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+
+import { getUserMetadata } from "@app/lib/api/user";
+import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
+import { UserType, WorkspaceType } from "@app/types/user";
+
+const { URL = "", GA_TRACKING_ID = "" } = process.env;
+
+export const getServerSideProps: GetServerSideProps<{
+  user: UserType;
+  owner: WorkspaceType;
+  defaultExpertise: string;
+  conversationId: string | null;
+  gaTrackingId: string;
+  baseUrl: string;
+}> = async (context) => {
+  const session = await getSession(context.req, context.res);
+  const user = await getUserFromSession(session);
+  const auth = await Authenticator.fromSession(
+    session,
+    context.params?.wId as string
+  );
+
+  const owner = auth.workspace();
+  if (!owner || !auth.isUser() || !user) {
+    return {
+      redirect: {
+        destination: "/",
+        permanent: false,
+      },
+    };
+  }
+
+  const expertise = await getUserMetadata(user, "expertise");
+
+  // If user was in onboarding flow "domain_conversation_link"
+  // We will redirect to the conversation page after onboarding.
+  const conversationId =
+    typeof context.query.cId === "string" ? context.query.cId : null;
+
+  return {
+    props: {
+      user,
+      owner,
+      defaultExpertise: expertise?.value || "",
+      conversationId,
+      baseUrl: URL,
+      gaTrackingId: GA_TRACKING_ID,
+    },
+  };
+};
+
+export default function Welcome({
+  user,
+  owner,
+  defaultExpertise,
+  conversationId,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  const router = useRouter();
+  const [firstName, setFirstName] = useState<string>(user.name.split(" ")[0]);
+  const [lastName, setLastName] = useState<string>(user.name.split(" ")[1]);
+  const [expertise, setExpertise] = useState<string>(defaultExpertise);
+  const [isFormValid, setIsFormValid] = useState<boolean>(false);
+
+  useEffect(() => {
+    setIsFormValid(
+      firstName.length > 0 && lastName.length > 0 && expertise !== ""
+    );
+  }, [firstName, lastName, expertise]);
+
+  const handleSubmit = async () => {
+    const updateUserFullNameRes = await fetch("/api/user", {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ firstName, lastName }),
+    });
+    if (updateUserFullNameRes.ok) {
+      await fetch("/api/user/metadata/expertise", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ value: expertise }),
+      });
+    }
+    // We don't block the user if it fails here.
+    if (conversationId) {
+      await router.push(`/w/${owner.sId}/assistant/${conversationId}`);
+    } else {
+      await router.push(`/w/${owner.sId}/assistant/new`);
+    }
+  };
+
+  return (
+    <div className="s-dark h-full bg-slate-800 text-slate-200">
+      <main className="z-10 mx-auto max-w-4xl px-6 pt-24">
+        <div className="flex flex-col gap-6">
+          <div>
+            <p className="mt-16 font-objektiv text-2xl font-bold tracking-tighter">
+              <span className="text-red-400 sm:font-objektiv md:font-objektiv">
+                Hello {user.username}
+              </span>
+              <br />
+              Let's check a few things.
+            </p>
+          </div>
+          <div>
+            <p>
+              Your email is <span className="font-bold">{user.email}</span>.
+            </p>
+          </div>
+          <div>
+            <p className="pb-2">Your name is:</p>
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              <Input
+                name="firstName"
+                placeholder=""
+                value={firstName}
+                onChange={setFirstName}
+              />
+              <Input
+                name="lastName"
+                placeholder=""
+                value={lastName}
+                onChange={setLastName}
+              />
+            </div>
+          </div>
+          <div>
+            <p className="pb-2">How much do you know about AI assistants?</p>
+            <RadioButton
+              name="expertise"
+              className="flex-col sm:flex-row"
+              choices={[
+                {
+                  label: "Nothing!",
+                  value: "beginner",
+                  disabled: false,
+                },
+                {
+                  label: "I know the basics",
+                  value: "intermediate",
+                  disabled: false,
+                },
+                {
+                  label: "I'm a pro",
+                  value: "advanced",
+                  disabled: false,
+                },
+              ]}
+              value={expertise}
+              onChange={setExpertise}
+            />
+          </div>
+          <div className="flex justify-center pt-6">
+            <Button
+              label="Start with Dust!"
+              disabled={!isFormValid}
+              onClick={handleSubmit}
+            />
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/front/pages/w/[wId]/welcome.tsx
+++ b/front/pages/w/[wId]/welcome.tsx
@@ -132,23 +132,25 @@ export default function Welcome({
             </div>
           </div>
           <div>
-            <p className="pb-2">How much do you know about AI assistants?</p>
+            <p className="pb-2">
+              How often do you use ChatGPT or other AI Assistant?
+            </p>
             <RadioButton
               name="expertise"
               className="flex-col sm:flex-row"
               choices={[
                 {
-                  label: "Nothing!",
+                  label: "Never!",
                   value: "beginner",
                   disabled: false,
                 },
                 {
-                  label: "I know the basics",
+                  label: "Occasionally",
                   value: "intermediate",
                   disabled: false,
                 },
                 {
-                  label: "I'm a pro",
+                  label: "Regularly",
                   value: "advanced",
                   disabled: false,
                 },

--- a/front/pages/w/[wId]/welcome.tsx
+++ b/front/pages/w/[wId]/welcome.tsx
@@ -59,6 +59,7 @@ export default function Welcome({
   owner,
   defaultExpertise,
   conversationId,
+  gaTrackingId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const router = useRouter();
   const [firstName, setFirstName] = useState<string>(user.name.split(" ")[0]);
@@ -98,7 +99,7 @@ export default function Welcome({
   };
 
   return (
-    <OnboardingLayout owner={owner} gaTrackingId={GA_TRACKING_ID}>
+    <OnboardingLayout owner={owner} gaTrackingId={gaTrackingId}>
       <div className="flex flex-col gap-6">
         <div>
           <p className="mt-16 font-objektiv text-2xl font-bold tracking-tighter">
@@ -133,7 +134,7 @@ export default function Welcome({
         </div>
         <div>
           <p className="pb-2">
-            How often do you use ChatGPT or other AI Assistant?
+            How often do you use ChatGPT or other AI assistants?
           </p>
           <RadioButton
             name="expertise"
@@ -150,7 +151,7 @@ export default function Welcome({
                 disabled: false,
               },
               {
-                label: "Regularly",
+                label: "Daily",
                 value: "advanced",
                 disabled: false,
               },


### PR DESCRIPTION
## Context

This task is part of the new onboarding for members joining a workspace. 
After landing on the `/join` page and going through Google Sign in, instead of landing on the Assistant, they will land on this new welcome page, where we ask the user to confirm their name and let us know about their AI expertise. 

## Tech choices

**Data Model**
I decided to store the expertise as a `UserMetadata` instead of introducing a new field on the `User` model. 

**Form Submission**
The form submission is allowed only when all fields are filled. 
When we submit:
- we first PATCH on `/api/user` -> this is a bit weird to patch without an id in the url but we get the user from the api route. 
- then if successful we post the metadata on the existing route for this model.
- if something is wrong among those 2 calls, we won't block the user and she will go to next step.

**Redirection**
Once the form is submitted, user will be redirected on the Assistant or directly to a conversation if they are onboarding in the flow "[domain_conversation_link](https://github.com/dust-tt/dust/blob/main/front/pages/w/%5BwId%5D/join.tsx#L10-L27)". 

## Screenshot - web 
<img width="1218" alt="Capture d’écran 2023-10-13 à 13 42 28" src="https://github.com/dust-tt/dust/assets/3803406/95021fe7-6bac-4e68-aa15-bcf45756db40">

## Screenshot - mobile 

<img width="390" alt="Capture d’écran 2023-10-13 à 13 42 06" src="https://github.com/dust-tt/dust/assets/3803406/14aceda0-2ff6-4d1c-acb3-f8725d0a495b">


## Next step

- Introduce the video page before redirecting to the Assistant.
- Cleaning: Introduce a proper OnboardingLayout that will be used for join / welcome and the video page. 
