### PR TITLE
Connectors stop workflow when a OAuth token is revoked

### DIFF
--- a/connectors/package-lock.json
+++ b/connectors/package-lock.json
@@ -20,6 +20,7 @@
         "@types/lodash.memoize": "^4.1.7",
         "@types/minimist": "^1.2.2",
         "@types/uuid": "^9.0.2",
+        "axios": "^1.5.1",
         "body-parser": "^1.20.2",
         "dd-trace": "^3.16.0",
         "eventsource-parser": "^1.0.0",
@@ -715,29 +716,6 @@
         "node": ">=16.7"
       }
     },
-    "node_modules/@nangohq/node/node_modules/axios": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.6.tgz",
-      "integrity": "sha512-PEcdkk7JcdPiMDkvM4K6ZBRYq9keuVJsToxm2zQIM70Qqo2WHTdJZMXcG9X+RmRp2VPNUQC8W1RAGbgt6b1yMg==",
-      "dependencies": {
-        "follow-redirects": "^1.15.0",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
-    "node_modules/@nangohq/node/node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1280,6 +1258,28 @@
       "engines": {
         "node": ">= 12.13.0",
         "npm": ">= 6.12.0"
+      }
+    },
+    "node_modules/@slack/web-api/node_modules/axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "dependencies": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@slack/web-api/node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/@slack/web-api/node_modules/p-queue": {
@@ -2352,12 +2352,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.1.tgz",
+      "integrity": "sha512-Q28iYCWzNHjAm+yEAot5QaAMxhMghWLFVf7rRdwhUI+c2jix2DUXjAHXVi+s1ibs3mjPO/cCgbA++3BjD0vP/A==",
       "dependencies": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axios/node_modules/form-data": {

--- a/connectors/package.json
+++ b/connectors/package.json
@@ -25,6 +25,7 @@
     "@types/lodash.memoize": "^4.1.7",
     "@types/minimist": "^1.2.2",
     "@types/uuid": "^9.0.2",
+    "axios": "^1.5.1",
     "body-parser": "^1.20.2",
     "dd-trace": "^3.16.0",
     "eventsource-parser": "^1.0.0",

--- a/connectors/src/api/get_connector.ts
+++ b/connectors/src/api/get_connector.ts
@@ -78,8 +78,7 @@ const _getConnector = async (
     firstSuccessfulSyncTime: connector.firstSuccessfulSyncTime?.getTime(),
     firstSyncProgress,
     defaultNewResourcePermission: connector.defaultNewResourcePermission,
-    errorMessage: connector.errorMessage,
-    errorType: connector.errorType,
+    errorType: connector.errorType || undefined,
   });
 };
 

--- a/connectors/src/api/get_connector.ts
+++ b/connectors/src/api/get_connector.ts
@@ -78,6 +78,8 @@ const _getConnector = async (
     firstSuccessfulSyncTime: connector.firstSuccessfulSyncTime?.getTime(),
     firstSyncProgress,
     defaultNewResourcePermission: connector.defaultNewResourcePermission,
+    errorMessage: connector.errorMessage,
+    errorType: connector.errorType,
   });
 };
 

--- a/connectors/src/connectors/google_drive/temporal/client.ts
+++ b/connectors/src/connectors/google_drive/temporal/client.ts
@@ -53,6 +53,10 @@ export async function launchGoogleDriveFullSyncWorkflow(
       args: [connectorIdModelId, nangoConnectionId, dataSourceConfig],
       taskQueue: "google-queue",
       workflowId: workflowId,
+
+      memo: {
+        connectorId: connectorId,
+      },
     });
     logger.info(
       {

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -120,7 +120,7 @@ async function _upsertToDatasource({
     );
   } catch (e) {
     const elapsed = new Date().getTime() - now.getTime();
-    if (axios.isAxiosError(e) && e.config.data) {
+    if (axios.isAxiosError(e) && e.config?.data) {
       e.config.data = "[REDACTED]";
     }
     statsDClient.increment("data_source_upserts_error.count", 1, statsDTags);

--- a/connectors/src/lib/error.ts
+++ b/connectors/src/lib/error.ts
@@ -48,3 +48,6 @@ export class HTTPError extends Error {
     this.statusCode = statusCode;
   }
 }
+
+// This error is thrown when we are dealing with a revoked OAuth token.
+export class ExternalOauthTokenError extends Error {}

--- a/connectors/src/lib/models.ts
+++ b/connectors/src/lib/models.ts
@@ -45,8 +45,7 @@ export class Connector extends Model<
   declare dataSourceName: string;
 
   declare lastSyncStatus?: ConnectorSyncStatus;
-  declare errorMessage?: string;
-  declare errorType?: ConnectorErrorType;
+  declare errorType: ConnectorErrorType | null;
   declare lastSyncStartTime?: Date;
   declare lastSyncFinishTime?: Date;
   declare lastSyncSuccessfulTime?: Date;
@@ -95,10 +94,6 @@ Connector.init(
       allowNull: false,
     },
     lastSyncStatus: {
-      type: DataTypes.STRING,
-      allowNull: true,
-    },
-    errorMessage: {
       type: DataTypes.STRING,
       allowNull: true,
     },

--- a/connectors/src/lib/models.ts
+++ b/connectors/src/lib/models.ts
@@ -13,6 +13,7 @@ import {
   PageObjectProperties,
 } from "@connectors/connectors/notion/lib/types";
 import {
+  ConnectorErrorType,
   type ConnectorProvider,
   ConnectorSyncStatus,
 } from "@connectors/types/connector";
@@ -44,6 +45,8 @@ export class Connector extends Model<
   declare dataSourceName: string;
 
   declare lastSyncStatus?: ConnectorSyncStatus;
+  declare errorMessage?: string;
+  declare errorType?: ConnectorErrorType;
   declare lastSyncStartTime?: Date;
   declare lastSyncFinishTime?: Date;
   declare lastSyncSuccessfulTime?: Date;
@@ -92,6 +95,14 @@ Connector.init(
       allowNull: false,
     },
     lastSyncStatus: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
+    errorMessage: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
+    errorType: {
       type: DataTypes.STRING,
       allowNull: true,
     },

--- a/connectors/src/lib/nango_client.ts
+++ b/connectors/src/lib/nango_client.ts
@@ -24,12 +24,7 @@ class CustomNango extends Nango {
     } catch (e) {
       if (axios.isAxiosError(e)) {
         if (e.response?.status === 400) {
-          if (
-            typeof e.response.data === "object" &&
-            e.response?.data !== null &&
-            "error" in e.response.data &&
-            typeof e.response.data.error === "string"
-          ) {
+          if (typeof e?.response?.data?.error === "string") {
             const errorText = e.response.data.error;
             if (
               errorText.includes(

--- a/connectors/src/lib/nango_client.ts
+++ b/connectors/src/lib/nango_client.ts
@@ -1,14 +1,58 @@
 import { Nango } from "@nangohq/node";
+import axios from "axios";
+
+import { ExternalOauthTokenError } from "@connectors/lib/error";
 
 import { Err, Ok, Result } from "./result";
 
 const { NANGO_SECRET_KEY } = process.env;
 
-export function nango_client(): Nango {
+class CustomNango extends Nango {
+  async getConnection(
+    providerConfigKey: string,
+    connectionId: string,
+    forceRefresh?: boolean,
+    refreshToken?: boolean
+  ) {
+    try {
+      return await super.getConnection(
+        providerConfigKey,
+        connectionId,
+        true,
+        refreshToken
+      );
+    } catch (e) {
+      if (axios.isAxiosError(e)) {
+        if (e.response?.status === 400) {
+          if (
+            typeof e.response.data === "object" &&
+            e.response?.data !== null &&
+            "error" in e.response.data &&
+            typeof e.response.data.error === "string"
+          ) {
+            const errorText = e.response.data.error;
+            if (
+              errorText.includes(
+                "The external API returned an error when trying to refresh the access token"
+              ) &&
+              errorText.includes("invalid_grant")
+            ) {
+              throw new ExternalOauthTokenError();
+            }
+          }
+        }
+      }
+
+      throw e;
+    }
+  }
+}
+
+export function nango_client() {
   if (!NANGO_SECRET_KEY) {
     throw new Error("Env var NANGO_SECRET_KEY is not defined");
   }
-  const nango = new Nango({ secretKey: NANGO_SECRET_KEY });
+  const nango = new CustomNango({ secretKey: NANGO_SECRET_KEY });
 
   return nango;
 }

--- a/connectors/src/lib/sync_status.ts
+++ b/connectors/src/lib/sync_status.ts
@@ -9,14 +9,12 @@ async function syncFinished({
   connectorId,
   status,
   finishedAt,
-  errorMessage,
   errorType,
 }: {
   connectorId: ModelId;
   status: ConnectorSyncStatus;
   finishedAt: Date;
-  errorMessage?: string;
-  errorType?: ConnectorErrorType;
+  errorType: ConnectorErrorType | null;
 }): Promise<Result<void, Error>> {
   const connector = await Connector.findByPk(connectorId);
   if (!connector) {
@@ -24,7 +22,6 @@ async function syncFinished({
   }
   connector.lastSyncStatus = status;
   connector.lastSyncFinishTime = finishedAt;
-  connector.errorMessage = errorMessage;
   connector.errorType = errorType;
   if (status === "succeeded") {
     if (!connector.firstSuccessfulSyncTime) {
@@ -65,8 +62,7 @@ export async function syncSucceeded(connectorId: ModelId, at?: Date) {
     connectorId: connectorId,
     status: "succeeded",
     finishedAt: at,
-    errorMessage: undefined,
-    errorType: undefined,
+    errorType: null,
   });
 }
 
@@ -87,7 +83,6 @@ export async function syncFailed(
     connectorId,
     status: "failed",
     finishedAt: new Date(),
-    errorMessage,
     errorType,
   });
 }

--- a/connectors/src/lib/temporal.ts
+++ b/connectors/src/lib/temporal.ts
@@ -1,4 +1,9 @@
-import { Client, Connection, ConnectionOptions } from "@temporalio/client";
+import {
+  Client,
+  Connection,
+  ConnectionOptions,
+  WorkflowNotFoundError,
+} from "@temporalio/client";
 import { NativeConnection } from "@temporalio/worker";
 import fs from "fs-extra";
 
@@ -92,4 +97,20 @@ export async function getConnectorId(
     }
   }
   return WORKFLOW_ID2CONNECTOR_ID_CACHE[workflowRunId] || null;
+}
+
+export async function cancelWorkflow(workflowId: string) {
+  const client = await getTemporalClient();
+  try {
+    const workflowHandle = await client.workflow.getHandle(workflowId);
+    await workflowHandle.cancel();
+
+    return true;
+  } catch (e) {
+    if (!(e instanceof WorkflowNotFoundError)) {
+      throw e;
+    }
+  }
+
+  return false;
 }

--- a/connectors/src/lib/temporal.ts
+++ b/connectors/src/lib/temporal.ts
@@ -2,8 +2,11 @@ import { Client, Connection, ConnectionOptions } from "@temporalio/client";
 import { NativeConnection } from "@temporalio/worker";
 import fs from "fs-extra";
 
+import { ModelId } from "./models";
+
 // This is a singleton connection to the Temporal server.
 let TEMPORAL_CLIENT: Client | undefined;
+const WORKFLOW_ID2CONNECTOR_ID_CACHE: Record<string, ModelId> = {};
 
 export async function getTemporalClient(): Promise<Client> {
   if (TEMPORAL_CLIENT) {
@@ -64,4 +67,29 @@ export async function getTemporalWorkerConnection(): Promise<{
   const connectionOptions = await getConnectionOptions();
   const connection = await NativeConnection.connect(connectionOptions);
   return { connection, namespace: process.env.TEMPORAL_NAMESPACE };
+}
+
+export async function getConnectorId(
+  workflowRunId: string
+): Promise<ModelId | null> {
+  if (!WORKFLOW_ID2CONNECTOR_ID_CACHE[workflowRunId]) {
+    const client = await getTemporalClient();
+    const workflowHandle = await client.workflow.getHandle(workflowRunId);
+    const described = await workflowHandle.describe();
+    if (described.memo && described.memo.connectorId) {
+      if (typeof described.memo.connectorId === "number") {
+        WORKFLOW_ID2CONNECTOR_ID_CACHE[workflowRunId] =
+          described.memo.connectorId;
+      } else if (typeof described.memo.connectorId === "string") {
+        WORKFLOW_ID2CONNECTOR_ID_CACHE[workflowRunId] = parseInt(
+          described.memo.connectorId,
+          10
+        );
+      }
+    }
+    if (!WORKFLOW_ID2CONNECTOR_ID_CACHE[workflowRunId]) {
+      return null;
+    }
+  }
+  return WORKFLOW_ID2CONNECTOR_ID_CACHE[workflowRunId] || null;
 }

--- a/connectors/src/lib/temporal_monitoring.ts
+++ b/connectors/src/lib/temporal_monitoring.ts
@@ -90,7 +90,7 @@ export class ActivityInboundLogInterceptor
           if (connectorId) {
             await syncFailed(
               connectorId,
-              "Oops! It seems that our access to your account has been revoked. Please reconnect to continue using our services.",
+              "Oops! It seems that our access to your account has been revoked. Please re-authorize this Data Source to keep your data up to date.",
               "oauth_token_revoked"
             );
             const client = await getTemporalClient();

--- a/connectors/src/types/connector.ts
+++ b/connectors/src/types/connector.ts
@@ -13,6 +13,7 @@ export function isConnectorProvider(val: string): val is ConnectorProvider {
 }
 
 export type ConnectorSyncStatus = "succeeded" | "failed";
+export type ConnectorErrorType = "oauth_token_revoked";
 
 export type ConnectorType = {
   id: number;
@@ -24,6 +25,8 @@ export type ConnectorType = {
   lastSyncSuccessfulTime?: number;
   firstSuccessfulSyncTime?: number;
   firstSyncProgress?: string;
+  errorType?: string;
+  errorMessage?: string;
 
   defaultNewResourcePermission: ConnectorPermission;
 };

--- a/front/lib/connectors_api.ts
+++ b/front/lib/connectors_api.ts
@@ -48,7 +48,6 @@ export type ConnectorType = {
   lastSyncSuccessfulTime?: number;
   firstSuccessfulSyncTime?: number;
   firstSyncProgress?: string;
-  errorMessage?: string;
   errorType?: ConnectorErrorType;
 
   defaultNewResourcePermission: ConnectorPermission;

--- a/front/lib/connectors_api.ts
+++ b/front/lib/connectors_api.ts
@@ -15,6 +15,8 @@ const {
 
 export type ConnectorsAPIResponse<T> = Result<T, ConnectorsAPIErrorResponse>;
 export type ConnectorSyncStatus = "succeeded" | "failed";
+export type ConnectorErrorType = "oauth_token_revoked";
+
 const CONNECTOR_PROVIDERS = [
   "slack",
   "notion",
@@ -46,6 +48,8 @@ export type ConnectorType = {
   lastSyncSuccessfulTime?: number;
   firstSuccessfulSyncTime?: number;
   firstSyncProgress?: string;
+  errorMessage?:string;
+  errorType?:ConnectorErrorType;
 
   defaultNewResourcePermission: ConnectorPermission;
 };

--- a/front/lib/connectors_api.ts
+++ b/front/lib/connectors_api.ts
@@ -48,8 +48,8 @@ export type ConnectorType = {
   lastSyncSuccessfulTime?: number;
   firstSuccessfulSyncTime?: number;
   firstSyncProgress?: string;
-  errorMessage?:string;
-  errorType?:ConnectorErrorType;
+  errorMessage?: string;
+  errorType?: ConnectorErrorType;
 
   defaultNewResourcePermission: ConnectorPermission;
 };

--- a/front/lib/temporal_monitoring.ts
+++ b/front/lib/temporal_monitoring.ts
@@ -55,7 +55,7 @@ export class ActivityInboundLogInterceptor
       this.logger.info("Activity started.");
       return await next(input);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (err: any) {
+    } catch (err) {
       error = err;
       throw err;
     } finally {

--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -518,14 +518,19 @@ export default function DataSourcesView({
                   {ds && ds.connector && (
                     <div className="mb-1 mt-2">
                       {(() => {
-                        if (ds.connector.errorType) {
+                        if (ds.fetchConnectorError) {
+                          return (
+                            <Chip color="warning">
+                              Error loading the connector. Try again in a few
+                              minutes.
+                            </Chip>
+                          );
+                        } else if (ds.connector.errorType) {
                           return (
                             <Chip color="warning">
                               {ds.connector.errorMessage}
                             </Chip>
                           );
-                        } else if (ds.fetchConnectorError) {
-                          return <Chip color="warning">errored</Chip>;
                         } else if (!ds.connector.lastSyncSuccessfulTime) {
                           return (
                             <Chip color="amber" isBusy>

--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -528,7 +528,9 @@ export default function DataSourcesView({
                         } else if (ds.connector.errorType) {
                           return (
                             <Chip color="warning">
-                              {ds.connector.errorMessage}
+                              Oops! It seems that our access to your account has
+                              been revoked. Please re-authorize this Data Source
+                              to keep your data up to date on Dust.
                             </Chip>
                           );
                         } else if (!ds.connector.lastSyncSuccessfulTime) {

--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -517,26 +517,32 @@ export default function DataSourcesView({
                 >
                   {ds && ds.connector && (
                     <div className="mb-1 mt-2">
-                      {ds.fetchConnectorError ? (
-                        <Chip color="warning">errored</Chip>
-                      ) : (
-                        <>
-                          {!ds.connector.lastSyncSuccessfulTime ? (
+                      {(() => {
+                        if (ds.connector.errorType) {
+                          return (
+                            <Chip color="warning">
+                              {ds.connector.errorMessage}
+                            </Chip>
+                          );
+                        } else if (ds.fetchConnectorError) {
+                          return <Chip color="warning">errored</Chip>;
+                        } else if (!ds.connector.lastSyncSuccessfulTime) {
+                          return (
                             <Chip color="amber" isBusy>
                               Synchronizing
                               {ds.connector?.firstSyncProgress
                                 ? ` (${ds.connector?.firstSyncProgress})`
                                 : null}
                             </Chip>
-                          ) : (
-                            <>
-                              <Chip color="slate">
-                                Last Sync ~ {ds.synchronizedAgo} ago
-                              </Chip>
-                            </>
-                          )}
-                        </>
-                      )}
+                          );
+                        } else {
+                          return (
+                            <Chip color="slate">
+                              Last Sync ~ {ds.synchronizedAgo} ago
+                            </Chip>
+                          );
+                        }
+                      })()}
                     </div>
                   )}
                   <ContextItem.Description>


### PR DESCRIPTION
The goal of this PR is to stop connectors workflows when the token associated with the workflow is revoked.
For that, have:
- A custom Nango client that extends the Nango() class and override the `getConnection()` method to throw a custom error
- At the worker activity level, we cancel the current workflow when we detect such error.
- (New - Monday October 23 2023): the error is now saved in the connectors table and displayed in the UI.

There is a special case for the Gdrive `renewWebhook` workflow which we can't cancel because it processing webhooks for all connectors.

<img width="1162" alt="Screen Shot 2023-10-23 at 21 42 58" src="https://github.com/dust-tt/dust/assets/358965/c076c061-abd0-4569-937d-e5a07cb74993">
