### PR TITLE
feat: process child pages/dbs that we haven't heard of before

### DIFF
--- a/connectors/src/admin/db.ts
+++ b/connectors/src/admin/db.ts
@@ -11,6 +11,7 @@ import {
   GoogleDriveWebhook,
   NotionConnectorBlockCacheEntry,
   NotionConnectorPageCacheEntry,
+  NotionConnectorResourcesToCheckCacheEntry,
   NotionConnectorState,
   NotionDatabase,
   NotionPage,
@@ -40,6 +41,7 @@ async function main(): Promise<void> {
   await GoogleDriveWebhook.sync({ alter: true });
   await NotionConnectorBlockCacheEntry.sync({ alter: true });
   await NotionConnectorPageCacheEntry.sync({ alter: true });
+  await NotionConnectorResourcesToCheckCacheEntry.sync({ alter: true });
 
   // enable the `unaccent` extension
   await sequelize_conn.query("CREATE EXTENSION IF NOT EXISTS unaccent;");

--- a/connectors/src/connectors/notion/lib/notion_api.ts
+++ b/connectors/src/connectors/notion/lib/notion_api.ts
@@ -253,7 +253,10 @@ export async function getDatabaseChildPages({
       if (
         NOTION_UNAUTHORIZED_ACCESS_ERROR_CODES.includes(
           (e as { code: string }).code
-        )
+        ) ||
+        // This happens if the database is a "linked" database - we can't query those so
+        // it's not useful to retry.
+        (e as { code: string }).code === "validation_error"
       ) {
         tryLogger.info("Database not accessible.");
         return {
@@ -445,7 +448,10 @@ export async function getParsedDatabase(
   } catch (e) {
     if (
       APIResponseError.isAPIResponseError(e) &&
-      e.code === "object_not_found"
+      (NOTION_UNAUTHORIZED_ACCESS_ERROR_CODES.includes(e.code) ||
+        // This happens if the database is a "linked" database - we can't query those so
+        // it's not useful to retry.
+        e.code === "validation_error")
     ) {
       localLogger.info("Database not found.");
       return null;

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -1024,7 +1024,9 @@ export async function cachePage({
     notionPageId: pageId,
     connectorId: connector.id,
     pageProperties: {},
-    pagePropertiesText: JSON.stringify(notionPage.properties),
+    pagePropertiesText: ((p: PageObjectProperties) => JSON.stringify(p))(
+      notionPage.properties
+    ),
     parentType: parent.type,
     parentId: parent.id,
     createdById: notionPage.created_by.id,
@@ -1269,7 +1271,9 @@ export async function cacheDatabaseChildren({
         notionPageId: page.id,
         connectorId: connector.id,
         pageProperties: {},
-        pagePropertiesText: JSON.stringify(page.properties),
+        pagePropertiesText: ((p: PageObjectProperties) => JSON.stringify(p))(
+          page.properties
+        ),
         parentId: databaseId,
         parentType: "database",
         createdById: page.created_by.id,

--- a/connectors/src/lib/models.ts
+++ b/connectors/src/lib/models.ts
@@ -702,7 +702,7 @@ NotionConnectorPageCacheEntry.init(
     },
     pageProperties: {
       type: DataTypes.JSONB,
-      allowNull: false,
+      allowNull: true,
     },
     pagePropertiesText: {
       type: DataTypes.TEXT,

--- a/connectors/src/lib/models.ts
+++ b/connectors/src/lib/models.ts
@@ -837,6 +837,57 @@ NotionConnectorBlockCacheEntry.init(
 
 Connector.hasMany(NotionConnectorBlockCacheEntry);
 
+export class NotionConnectorResourcesToCheckCacheEntry extends Model<
+  InferAttributes<NotionConnectorResourcesToCheckCacheEntry>,
+  InferCreationAttributes<NotionConnectorResourcesToCheckCacheEntry>
+> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare notionId: string;
+  declare resourceType: "page" | "database";
+  declare connectorId: ForeignKey<Connector["id"]>;
+}
+
+NotionConnectorResourcesToCheckCacheEntry.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    notionId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    resourceType: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+  },
+  {
+    sequelize: sequelize_conn,
+    modelName: "notion_connector_resources_to_check_cache_entries",
+    indexes: [
+      { fields: ["notionId", "connectorId"], unique: true },
+      { fields: ["connectorId"] },
+    ],
+  }
+);
+
+Connector.hasMany(NotionConnectorResourcesToCheckCacheEntry);
+
 export class GithubConnectorState extends Model<
   InferAttributes<GithubConnectorState>,
   InferCreationAttributes<GithubConnectorState>


### PR DESCRIPTION
keeps track of child pages/DBs we see on pages, and at the end of the run, upsert those that we haven't heard of before.