### PR TITLE
Add Slack bot picker

### DIFF
--- a/connectors/src/api/webhooks/webhook_slack.ts
+++ b/connectors/src/api/webhooks/webhook_slack.ts
@@ -78,7 +78,8 @@ async function handleChatBot(req: Request, res: Response) {
     slackChannel,
     slackUserId,
     slackMessageTs,
-    slackThreadTs
+    slackThreadTs,
+    []
   );
   if (botRes.isErr()) {
     logger.error(

--- a/connectors/src/api/webhooks/webhook_slack.ts
+++ b/connectors/src/api/webhooks/webhook_slack.ts
@@ -72,15 +72,15 @@ async function handleChatBot(req: Request, res: Response) {
   // We need to answer 200 quickly to Slack, otherwise they will retry the HTTP request.
   res.status(200).send();
 
-  const botRes = await botAnswerMessageWithErrorHandling(
-    slackMessage,
+  const botRes = await botAnswerMessageWithErrorHandling({
+    message: slackMessage,
     slackTeamId,
     slackChannel,
     slackUserId,
     slackMessageTs,
     slackThreadTs,
-    []
-  );
+    mentionOverride: [],
+  });
   if (botRes.isErr()) {
     logger.error(
       {

--- a/connectors/src/api/webhooks/webhook_slack_interaction.ts
+++ b/connectors/src/api/webhooks/webhook_slack_interaction.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from "express";
 
-import { botAnswerMessageWithErrorHandling } from "@connectors/connectors/slack/bot";
+import { botPickAssistant } from "@connectors/connectors/slack/bot";
 import { APIErrorWithStatusCode } from "@connectors/lib/error";
 import logger from "@connectors/logger/logger";
 import { withLogging } from "@connectors/logger/withlogging";
@@ -80,23 +80,22 @@ const _webhookSlackInteractionsAPIHandler = async (
     return res.status(200).end();
   }
 
-  const botRes = await botAnswerMessageWithErrorHandling({
-    message: "",
+  const pickRes = await botPickAssistant({
     slackTeamId: payload.team.id,
     slackChannel: payload.channel.id,
-    slackUserId: payload.user.id,
     slackMessageTs: payload.message.ts,
     slackThreadTs: payload.message?.thread_ts || null,
     mentionOverride: [agentConfigId],
   });
-  if (botRes.isErr()) {
+  if (pickRes.isErr()) {
     logger.error(
       {
-        error: botRes.error,
-        payload: payload,
+        payload,
+        error: pickRes.error,
       },
-      "Failed to handle Slack reaction"
+      `Failed to edit message in slack`
     );
+    return;
   }
 };
 

--- a/connectors/src/api/webhooks/webhook_slack_interaction.ts
+++ b/connectors/src/api/webhooks/webhook_slack_interaction.ts
@@ -39,7 +39,7 @@ type SlackWebhookResBody =
   | null
   | APIErrorWithStatusCode;
 
-const _webhookSlackReactionsAPIHandler = async (
+const _webhookSlackInteractionsAPIHandler = async (
   req: Request<
     Record<string, string>,
     SlackWebhookResBody,
@@ -54,7 +54,6 @@ const _webhookSlackReactionsAPIHandler = async (
   const agentConfigId =
     payload.state?.values?.agentConfigId?.static_selectAgentConfig
       ?.selected_option?.value;
-  console.log("agentConfigId", agentConfigId);
   if (!agentConfigId) {
     logger.error(
       {
@@ -81,15 +80,15 @@ const _webhookSlackReactionsAPIHandler = async (
     return res.status(200).end();
   }
 
-  const botRes = await botAnswerMessageWithErrorHandling(
-    ".",
-    payload.team.id,
-    payload.channel.id,
-    payload.user.id,
-    payload.message.ts,
-    payload.message?.thread_ts || null,
-    [agentConfigId]
-  );
+  const botRes = await botAnswerMessageWithErrorHandling({
+    message: "",
+    slackTeamId: payload.team.id,
+    slackChannel: payload.channel.id,
+    slackUserId: payload.user.id,
+    slackMessageTs: payload.message.ts,
+    slackThreadTs: payload.message?.thread_ts || null,
+    mentionOverride: [agentConfigId],
+  });
   if (botRes.isErr()) {
     logger.error(
       {
@@ -101,6 +100,6 @@ const _webhookSlackReactionsAPIHandler = async (
   }
 };
 
-export const webhookSlackReactionsAPIHandler = withLogging(
-  _webhookSlackReactionsAPIHandler
+export const webhookSlackInteractionsAPIHandler = withLogging(
+  _webhookSlackInteractionsAPIHandler
 );

--- a/connectors/src/api/webhooks/webhook_slack_reaction.ts
+++ b/connectors/src/api/webhooks/webhook_slack_reaction.ts
@@ -1,0 +1,106 @@
+import { Request, Response } from "express";
+
+import { botAnswerMessageWithErrorHandling } from "@connectors/connectors/slack/bot";
+import { APIErrorWithStatusCode } from "@connectors/lib/error";
+import logger from "@connectors/logger/logger";
+import { withLogging } from "@connectors/logger/withlogging";
+
+type SlackInteractionPayload = {
+  team?: {
+    id: string;
+    domain: string;
+  };
+  channel?: {
+    id: string;
+    name: string;
+  };
+  message?: {
+    ts: string;
+    thread_ts?: string;
+  };
+  user?: {
+    id: string;
+  };
+  state?: {
+    values: {
+      [key: string]: {
+        [key: string]: {
+          selected_option?: {
+            value: string;
+          };
+        };
+      };
+    };
+  };
+};
+
+type SlackWebhookResBody =
+  | { challenge: string }
+  | null
+  | APIErrorWithStatusCode;
+
+const _webhookSlackReactionsAPIHandler = async (
+  req: Request<
+    Record<string, string>,
+    SlackWebhookResBody,
+    {
+      payload: string;
+    }
+  >,
+  res: Response<SlackWebhookResBody>
+) => {
+  res.status(200).end();
+  const payload: SlackInteractionPayload = JSON.parse(req.body.payload);
+  const agentConfigId =
+    payload.state?.values?.agentConfigId?.static_selectAgentConfig
+      ?.selected_option?.value;
+  console.log("agentConfigId", agentConfigId);
+  if (!agentConfigId) {
+    logger.error(
+      {
+        payload,
+      },
+      `Missing agentConfigId in slack reactions payload`
+    );
+    return;
+  }
+  // returns 200 on all non supported messages types because slack will retry
+  // indefinitely otherwise.
+  if (
+    !payload.team?.id ||
+    !payload.channel?.id ||
+    !payload.message?.ts ||
+    !payload.user?.id
+  ) {
+    logger.error(
+      {
+        payload,
+      },
+      `Missing required fields in slack reactions payload`
+    );
+    return res.status(200).end();
+  }
+
+  const botRes = await botAnswerMessageWithErrorHandling(
+    ".",
+    payload.team.id,
+    payload.channel.id,
+    payload.user.id,
+    payload.message.ts,
+    payload.message?.thread_ts || null,
+    [agentConfigId]
+  );
+  if (botRes.isErr()) {
+    logger.error(
+      {
+        error: botRes.error,
+        payload: payload,
+      },
+      "Failed to handle Slack reaction"
+    );
+  }
+};
+
+export const webhookSlackReactionsAPIHandler = withLogging(
+  _webhookSlackReactionsAPIHandler
+);

--- a/connectors/src/api_server.ts
+++ b/connectors/src/api_server.ts
@@ -26,6 +26,8 @@ import { webhookSlackAPIHandler } from "@connectors/api/webhooks/webhook_slack";
 import logger from "@connectors/logger/logger";
 import { authMiddleware } from "@connectors/middleware/auth";
 
+import { webhookSlackReactionsAPIHandler } from "./api/webhooks/webhook_slack_reaction";
+
 export function startServer(port: number) {
   const app = express();
 
@@ -43,6 +45,8 @@ export function startServer(port: number) {
       },
     })
   );
+
+  app.use(express.urlencoded({ extended: true })); // support encoded bodies
 
   app.use(authMiddleware);
 
@@ -84,6 +88,10 @@ export function startServer(port: number) {
   );
 
   app.post("/webhooks/:webhook_secret/slack", webhookSlackAPIHandler);
+  app.post(
+    "/webhooks/:webhook_secret/slack_reactions",
+    webhookSlackReactionsAPIHandler
+  );
   app.post(
     "/webhooks/:webhook_secret/google_drive",
     webhookGoogleDriveAPIHandler

--- a/connectors/src/api_server.ts
+++ b/connectors/src/api_server.ts
@@ -23,10 +23,9 @@ import { getConnectorUpdateAPIHandler } from "@connectors/api/update_connector";
 import { webhookGithubAPIHandler } from "@connectors/api/webhooks/webhook_github";
 import { webhookGoogleDriveAPIHandler } from "@connectors/api/webhooks/webhook_google_drive";
 import { webhookSlackAPIHandler } from "@connectors/api/webhooks/webhook_slack";
+import { webhookSlackInteractionsAPIHandler } from "@connectors/api/webhooks/webhook_slack_interaction";
 import logger from "@connectors/logger/logger";
 import { authMiddleware } from "@connectors/middleware/auth";
-
-import { webhookSlackReactionsAPIHandler } from "./api/webhooks/webhook_slack_reaction";
 
 export function startServer(port: number) {
   const app = express();
@@ -89,8 +88,8 @@ export function startServer(port: number) {
 
   app.post("/webhooks/:webhook_secret/slack", webhookSlackAPIHandler);
   app.post(
-    "/webhooks/:webhook_secret/slack_reactions",
-    webhookSlackReactionsAPIHandler
+    "/webhooks/:webhook_secret/slack_interaction",
+    webhookSlackInteractionsAPIHandler
   );
   app.post(
     "/webhooks/:webhook_secret/google_drive",

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -309,11 +309,11 @@ async function botAnswerMessage(
         assistantId: agentConfigurationToMention.sId,
         assistantName: agentConfigurationToMention.name,
       });
-    } else {
-      // If no mention is found and no channel-based routing rule is found, we use the default assistant.
-      // mentions.push({ assistantId: "dust", assistantName: "dust" });
     }
   }
+
+  // If no mention is found from direct mention (~gpt-4) or channel-based routing rules
+  // We look at mention override (eg: a mention coming from the Slack assistant picker UI).
   if (mentions.length === 0 && mentionOverride.length > 0) {
     const agentConfigs = agentConfigurations.filter(
       (ac) => ac.sId === mentionOverride[0]

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -36,15 +36,23 @@ const { DUST_API = "https://dust.tt" } = process.env;
 
 class SlackExternalUserError extends Error {}
 
-export async function botAnswerMessageWithErrorHandling(
-  message: string,
-  slackTeamId: string,
-  slackChannel: string,
-  slackUserId: string,
-  slackMessageTs: string,
-  slackThreadTs: string | null,
-  mentionOverride: string[]
-): Promise<Result<AgentGenerationSuccessEvent | null, Error>> {
+export async function botAnswerMessageWithErrorHandling({
+  message,
+  slackTeamId,
+  slackChannel,
+  slackUserId,
+  slackMessageTs,
+  slackThreadTs,
+  mentionOverride,
+}: {
+  message: string;
+  slackTeamId: string;
+  slackChannel: string;
+  slackUserId: string;
+  slackMessageTs: string;
+  slackThreadTs: string | null;
+  mentionOverride: string[];
+}): Promise<Result<AgentGenerationSuccessEvent | null, Error>> {
   const slackConfig = await SlackConfiguration.findOne({
     where: {
       slackTeamId: slackTeamId,
@@ -62,7 +70,7 @@ export async function botAnswerMessageWithErrorHandling(
   if (!connector) {
     return new Err(new Error("Failed to find connector"));
   }
-  const res = await botAnswerMessage(
+  const res = await botAnswerMessage({
     message,
     slackTeamId,
     slackChannel,
@@ -70,8 +78,8 @@ export async function botAnswerMessageWithErrorHandling(
     slackMessageTs,
     slackThreadTs,
     connector,
-    mentionOverride
-  );
+    mentionOverride,
+  });
   if (res.isErr()) {
     logger.error(
       {
@@ -112,16 +120,25 @@ export async function botAnswerMessageWithErrorHandling(
   return res;
 }
 
-async function botAnswerMessage(
-  message: string,
-  slackTeamId: string,
-  slackChannel: string,
-  slackUserId: string,
-  slackMessageTs: string,
-  slackThreadTs: string | null,
-  connector: Connector,
-  mentionOverride: string[]
-): Promise<Result<AgentGenerationSuccessEvent | null, Error>> {
+async function botAnswerMessage({
+  message,
+  slackTeamId,
+  slackChannel,
+  slackUserId,
+  slackMessageTs,
+  slackThreadTs,
+  connector,
+  mentionOverride,
+}: {
+  message: string;
+  slackTeamId: string;
+  slackChannel: string;
+  slackUserId: string;
+  slackMessageTs: string;
+  slackThreadTs: string | null;
+  connector: Connector;
+  mentionOverride: string[];
+}): Promise<Result<AgentGenerationSuccessEvent | null, Error>> {
   let lastSlackChatBotMessage: SlackChatBotMessage | null = null;
   if (slackThreadTs) {
     lastSlackChatBotMessage = await SlackChatBotMessage.findOne({

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -170,7 +170,9 @@ async function botAnswerMessage(
   if (agentConfigurationsRes.isErr()) {
     return new Err(new Error(agentConfigurationsRes.error.message));
   }
-  const agentConfigurations = agentConfigurationsRes.value;
+  const agentConfigurations = agentConfigurationsRes.value.filter(
+    (ac) => ac.status === "active"
+  );
   const slackUserInfo = await slackClient.users.info({
     user: slackUserId,
   });

--- a/connectors/src/lib/dust_api.ts
+++ b/connectors/src/lib/dust_api.ts
@@ -325,6 +325,7 @@ export type ConversationType = {
 export type AgentConfigurationType = {
   sId: string;
   name: string;
+  status: string;
 };
 
 export type ContentFragmentType = {

--- a/connectors/src/lib/models.ts
+++ b/connectors/src/lib/models.ts
@@ -319,7 +319,7 @@ export class SlackChatBotMessage extends Model<
   declare connectorId: ForeignKey<Connector["id"]>;
   declare channelId: string;
   declare message: string;
-  declare messageFormatted: string|null;
+  declare messageFormatted: string | null;
   declare slackUserId: string;
   declare slackEmail: string;
   declare slackUserName: string;

--- a/connectors/src/lib/models.ts
+++ b/connectors/src/lib/models.ts
@@ -319,6 +319,7 @@ export class SlackChatBotMessage extends Model<
   declare connectorId: ForeignKey<Connector["id"]>;
   declare channelId: string;
   declare message: string;
+  declare messageFormatted: string|null;
   declare slackUserId: string;
   declare slackEmail: string;
   declare slackUserName: string;
@@ -330,6 +331,8 @@ export class SlackChatBotMessage extends Model<
   declare chatSessionSid: string | null;
   declare completedAt: Date | null;
   declare conversationId: string | null; // conversationId is set only for V2 conversations
+  declare userMessageId: string | null;
+  declare slackAnswerTs: string | null;
 }
 
 SlackChatBotMessage.init(
@@ -370,6 +373,10 @@ SlackChatBotMessage.init(
       type: DataTypes.TEXT,
       allowNull: false,
     },
+    messageFormatted: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+    },
     slackUserId: {
       type: DataTypes.STRING,
       allowNull: false,
@@ -394,11 +401,19 @@ SlackChatBotMessage.init(
       type: DataTypes.STRING,
       allowNull: true,
     },
+    userMessageId: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
     slackFullName: {
       type: DataTypes.STRING,
       allowNull: true,
     },
     slackAvatar: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
+    slackAnswerTs: {
       type: DataTypes.STRING,
       allowNull: true,
     },

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit.ts
@@ -1,0 +1,153 @@
+import { isLeft } from "fp-ts/lib/Either";
+import * as t from "io-ts";
+import * as reporter from "io-ts-reporters";
+import { NextApiRequest, NextApiResponse } from "next";
+
+import { getConversation } from "@app/lib/api/assistant/conversation";
+import { editUserMessageWithPubSub } from "@app/lib/api/assistant/pubsub";
+import { Authenticator, getAPIKey } from "@app/lib/auth";
+import { ReturnedAPIErrorType } from "@app/lib/error";
+import { apiError, withLogging } from "@app/logger/withlogging";
+import {
+  isUserMessageType,
+  UserMessageType,
+} from "@app/types/assistant/conversation";
+
+export const PostEditRequestBodySchema = t.type({
+  content: t.string,
+  mentions: t.array(
+    t.union([
+      t.type({ configurationId: t.string }),
+      t.type({
+        provider: t.string,
+        providerId: t.string,
+      }),
+    ])
+  ),
+});
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<{ message: UserMessageType } | ReturnedAPIErrorType>
+): Promise<void> {
+    const keyRes = await getAPIKey(req);
+    if (keyRes.isErr()) {
+      return apiError(req, res, keyRes.error);
+    }
+  
+    const { auth, keyWorkspaceId } = await Authenticator.fromKey(
+      keyRes.value,
+      req.query.wId as string
+    );
+  
+    if (!auth.isBuilder() || keyWorkspaceId !== req.query.wId) {
+      return apiError(req, res, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "The Assistant API is only available on your own workspace.",
+        },
+      });
+    }
+
+  const owner = auth.workspace();
+  if (!owner) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "The workspace you're trying to modify was not found.",
+      },
+    });
+  }
+
+  
+  if (!(typeof req.query.cId === "string")) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid query parameters, `cId` (string) is required.",
+      },
+    });
+  }
+
+  const conversationId = req.query.cId;
+  const conversation = await getConversation(auth, conversationId);
+  if (!conversation) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "conversation_not_found",
+        message: "Conversation not found.",
+      },
+    });
+  }
+
+  if (!(typeof req.query.mId === "string")) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid query parameters, `mId` (string) is required.",
+      },
+    });
+  }
+  const messageId = req.query.mId;
+
+  switch (req.method) {
+    case "POST":
+      const bodyValidation = PostEditRequestBodySchema.decode(req.body);
+
+      if (isLeft(bodyValidation)) {
+        const pathError = reporter.formatValidationErrors(bodyValidation.left);
+
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid request body: ${pathError}`,
+          },
+        });
+      }
+
+      const message = conversation.content
+        .flat()
+        .find((m) => m.sId === messageId);
+      if (!message || !isUserMessageType(message)) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              "The message you're trying to edit does not exist or is not an user message.",
+          },
+        });
+      }
+      const { content, mentions } = bodyValidation.right;
+
+      const editedMessageRes = await editUserMessageWithPubSub(auth, {
+        conversation,
+        message,
+        content,
+        mentions,
+      });
+      if (editedMessageRes.isErr()) {
+        return apiError(req, res, editedMessageRes.error);
+      }
+
+      res.status(200).json({ message: editedMessageRes.value });
+      return;
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, POST is expected.",
+        },
+      });
+  }
+}
+
+export default withLogging(handler);

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit.ts
@@ -30,25 +30,25 @@ async function handler(
   req: NextApiRequest,
   res: NextApiResponse<{ message: UserMessageType } | ReturnedAPIErrorType>
 ): Promise<void> {
-    const keyRes = await getAPIKey(req);
-    if (keyRes.isErr()) {
-      return apiError(req, res, keyRes.error);
-    }
-  
-    const { auth, keyWorkspaceId } = await Authenticator.fromKey(
-      keyRes.value,
-      req.query.wId as string
-    );
-  
-    if (!auth.isBuilder() || keyWorkspaceId !== req.query.wId) {
-      return apiError(req, res, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "The Assistant API is only available on your own workspace.",
-        },
-      });
-    }
+  const keyRes = await getAPIKey(req);
+  if (keyRes.isErr()) {
+    return apiError(req, res, keyRes.error);
+  }
+
+  const { auth, keyWorkspaceId } = await Authenticator.fromKey(
+    keyRes.value,
+    req.query.wId as string
+  );
+
+  if (!auth.isBuilder() || keyWorkspaceId !== req.query.wId) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "The Assistant API is only available on your own workspace.",
+      },
+    });
+  }
 
   const owner = auth.workspace();
   if (!owner) {
@@ -61,7 +61,6 @@ async function handler(
     });
   }
 
-  
   if (!(typeof req.query.cId === "string")) {
     return apiError(req, res, {
       status_code: 400,


### PR DESCRIPTION
Using the Slack interactive UI API to allow users to pick up an assistant when talking to our bot if no assistant could be derived from channel based routing rules and the message has no direct mention (eg: ~gpt4).

<img width="844" alt="Screen Shot 2023-10-16 at 11 17 29" src="https://github.com/dust-tt/dust/assets/358965/efbef103-8bd4-46c3-97e1-c4d77b6e11ad">
<img width="946" alt="Screen Shot 2023-10-16 at 11 17 32" src="https://github.com/dust-tt/dust/assets/358965/447757ec-f4c2-46ac-8b4c-bad424458387">
<img width="1005" alt="Screen Shot 2023-10-16 at 11 18 17" src="https://github.com/dust-tt/dust/assets/358965/bd6a45f9-c7aa-4754-b52c-d5d676973a47">
