### PR TITLE
New admin pages improvements

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@dust-tt/sparkle": "^0.2.17",
+        "@dust-tt/sparkle": "^0.2.19",
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",
         "@headlessui/react": "^1.7.7",
@@ -859,9 +859,9 @@
       "integrity": "sha512-smLocSfrt3s53H/XSVP3/1kP42oqvrkjUPtyaFd1F79ux24oE31BKt+q0c6lsa6hOYrFzsIwyc5GXAI5JmfOew=="
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.17",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.17.tgz",
-      "integrity": "sha512-VBw7a1YMO5fiseCGM30/c+iIme3YOFc3O65iWhgTRBy/wsjI9YDiODwaJf3xxkfRttfrxlOQK1LJyAihp4VgUg==",
+      "version": "0.2.19",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.19.tgz",
+      "integrity": "sha512-98mcHUobn6wTjLCzXLJx5tKyLJggJdA8rzTWT5YRH0o+FUf+ci3TZ/zL8XBXN/tHjWWgUbJp9gtgRmzbpY4k9w==",
       "dependencies": {
         "@headlessui/react": "^1.7.17"
       },
@@ -14668,6 +14668,111 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "13.5.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.5.4.tgz",
+      "integrity": "sha512-Df8SHuXgF1p+aonBMcDPEsaahNo2TCwuie7VXED4FVyECvdXfRT9unapm54NssV9tF3OQFKBFOdlje4T43VO0w==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "13.5.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.5.4.tgz",
+      "integrity": "sha512-siPuUwO45PnNRMeZnSa8n/Lye5ZX93IJom9wQRB5DEOdFrw0JjOMu1GINB8jAEdwa7Vdyn1oJ2xGNaQpdQQ9Pw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "13.5.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.5.4.tgz",
+      "integrity": "sha512-l/k/fvRP/zmB2jkFMfefmFkyZbDkYW0mRM/LB+tH5u9pB98WsHXC0WvDHlGCYp3CH/jlkJPL7gN8nkTQVrQ/2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "13.5.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.5.4.tgz",
+      "integrity": "sha512-YYGb7SlLkI+XqfQa8VPErljb7k9nUnhhRrVaOdfJNCaQnHBcvbT7cx/UjDQLdleJcfyg1Hkn5YSSIeVfjgmkTg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "13.5.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.5.4.tgz",
+      "integrity": "sha512-mDSQfqxAlfpeZOLPxLymZkX0hYF3juN57W6vFHTvwKlnHfmh12Pt7hPIRLYIShk8uYRsKPtMTth/EzpwRI+u8w==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "13.5.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.5.4.tgz",
+      "integrity": "sha512-aoqAT2XIekIWoriwzOmGFAvTtVY5O7JjV21giozBTP5c6uZhpvTWRbmHXbmsjZqY4HnEZQRXWkSAppsIBweKqw==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "13.5.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.5.4.tgz",
+      "integrity": "sha512-cyRvlAxwlddlqeB9xtPSfNSCRy8BOa4wtMo0IuI9P7Y0XT2qpDrpFKRyZ7kUngZis59mPVla5k8X1oOJ8RxDYg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     }
   }

--- a/front/package.json
+++ b/front/package.json
@@ -13,7 +13,7 @@
     "initdb": "env $(cat .env.local) npx tsx admin/db.ts"
   },
   "dependencies": {
-    "@dust-tt/sparkle": "^0.2.17",
+    "@dust-tt/sparkle": "^0.2.19",
     "@emoji-mart/data": "^1.1.2",
     "@emoji-mart/react": "^1.1.1",
     "@headlessui/react": "^1.7.7",

--- a/front/package.json
+++ b/front/package.json
@@ -13,7 +13,7 @@
     "initdb": "env $(cat .env.local) npx tsx admin/db.ts"
   },
   "dependencies": {
-    "@dust-tt/sparkle": "^0.2.19",
+    "@dust-tt/sparkle": "^0.2.20",
     "@emoji-mart/data": "^1.1.2",
     "@emoji-mart/react": "^1.1.1",
     "@headlessui/react": "^1.7.7",

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -10,7 +10,6 @@ import {
   Modal,
   Page,
   PlusIcon,
-  QuestionMarkCircleStrokeIcon,
   Searchbar,
 } from "@dust-tt/sparkle";
 import { UsersIcon } from "@heroicons/react/20/solid";
@@ -158,8 +157,8 @@ export default function WorkspaceAdmin({
     members: UserType[];
     invitations: MembershipInvitationType[];
   }) {
-    const COLOR_FOR_ROLE: { [key: string]: "pink" | "amber" | "emerald" } = {
-      admin: "pink",
+    const COLOR_FOR_ROLE: { [key: string]: "red" | "amber" | "emerald" } = {
+      admin: "red",
       builder: "amber",
       user: "emerald",
     };
@@ -656,8 +655,8 @@ function ChangeMemberModal({
             <Button
               variant="primaryWarning"
               label="Yes, revoke"
-              onClick={() => {
-                handleMemberRoleChange(member, "none");
+              onClick={async () => {
+                await handleMemberRoleChange(member, "none");
                 setRevokeMemberModalOpen(false);
               }}
             />

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -342,9 +342,11 @@ function InviteEmailModal({
     <Modal
       isOpen={showModal}
       onClose={onClose}
-      hasChanged={false}
+      hasChanged={emailError === "" && inviteEmail !== "" && !isSending}
       title="Invite new users"
       type="right-side"
+      saveLabel="Invite"
+      onSave={handleSendInvitation}
     >
       <div className="mt-6 flex flex-col gap-6 px-2 text-sm">
         <Page.P>
@@ -365,15 +367,6 @@ function InviteEmailModal({
                   setInviteEmail(e.trim());
                   setEmailError("");
                 }}
-              />
-            </div>
-            <div className="flex-none">
-              <Button
-                variant="primary"
-                label="Invite"
-                size="sm"
-                disabled={emailError !== "" || inviteEmail === "" || isSending}
-                onClick={handleSendInvitation}
               />
             </div>
           </div>

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -513,7 +513,6 @@ function RevokeInvitationModal({
       onClose={onClose}
       hasChanged={false}
       title="Revoke invitation"
-      type="right-side"
     >
       <div className="mt-6 flex flex-col gap-6 px-2">
         <div>

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -561,6 +561,7 @@ function ChangeMemberModal({
   owner: WorkspaceType;
 }) {
   const { mutate } = useSWRConfig();
+  const [currentRole, setCurrentRole] = useState<RoleType | null>(null);
   if (!member) return null; // Unreachable
   const roleTexts: { [k: string]: string } = {
     admin: "Admins can manage members, in addition to builders' rights.",
@@ -568,10 +569,14 @@ function ChangeMemberModal({
       "Builders can create custom assistants and use advanced dev tools.",
     user: "Users can use assistants provided by Dust as well as custom assistants created by their company.",
   };
+  const onCloseMutate = async () => {
+    await mutate(`/api/w/${owner.sId}/members`);
+    onClose();
+  };
   return (
     <Modal
       isOpen={showModal}
-      onClose={onClose}
+      onClose={onCloseMutate}
       hasChanged={false}
       title={member.name || "Unreachable"}
       type="right-side"
@@ -591,7 +596,7 @@ function ChangeMemberModal({
               <DropdownMenu.Button type="select">
                 <Button
                   variant="secondary"
-                  label={member.workspaces[0].role}
+                  label={currentRole || member.workspaces[0].role}
                   size="sm"
                   type="select"
                   className="capitalize"
@@ -634,7 +639,7 @@ function ChangeMemberModal({
   );
   async function handleMemberRoleChange(
     member: UserType,
-    role: string
+    role: RoleType
   ): Promise<void> {
     const res = await fetch(`/api/w/${owner.sId}/members/${member.id}`, {
       method: "POST",
@@ -648,7 +653,7 @@ function ChangeMemberModal({
     if (!res.ok) {
       window.alert("Failed to update membership.");
     } else {
-      await mutate(`/api/w/${owner.sId}/members`);
+      setCurrentRole(role);
     }
   }
 }

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -647,6 +647,7 @@ function ChangeMemberModal({
               onClick={async () => {
                 await handleMemberRoleChange(member, "none");
                 setRevokeMemberModalOpen(false);
+                onClose();
               }}
             />
           </div>
@@ -664,7 +665,7 @@ function ChangeMemberModal({
         "Content-Type": "application/json",
       },
       body: JSON.stringify({
-        role,
+        role: role === "none" ? "revoked" : role,
       }),
     });
     if (!res.ok) {

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -562,6 +562,7 @@ function ChangeMemberModal({
 }) {
   const { mutate } = useSWRConfig();
   const [currentRole, setCurrentRole] = useState<RoleType | null>(null);
+  const [revokeMemberModalOpen, setRevokeMemberModalOpen] = useState(false);
   if (!member) return null; // Unreachable
   const roleTexts: { [k: string]: string } = {
     admin: "Admins can manage members, in addition to builders' rights.",
@@ -626,7 +627,7 @@ function ChangeMemberModal({
               variant="primaryWarning"
               label="Revoke member access"
               size="sm"
-              onClick={() => handleMemberRoleChange(member, "none")}
+              onClick={() => setRevokeMemberModalOpen(true)}
             />
           </div>
           <Page.P>
@@ -635,6 +636,34 @@ function ChangeMemberModal({
           </Page.P>
         </div>
       </div>
+      <Modal
+        onClose={() => setRevokeMemberModalOpen(false)}
+        isOpen={revokeMemberModalOpen}
+        title="Revoke member access"
+        hasChanged={false}
+      >
+        <div className="mt-6 flex flex-col gap-6 px-2">
+          <div>
+            Revoke access for user{" "}
+            <span className="font-bold">{member.name}</span>?
+          </div>
+          <div className="flex gap-2">
+            <Button
+              variant="tertiary"
+              label="Cancel"
+              onClick={() => setRevokeMemberModalOpen(false)}
+            />
+            <Button
+              variant="primaryWarning"
+              label="Yes, revoke"
+              onClick={() => {
+                handleMemberRoleChange(member, "none");
+                setRevokeMemberModalOpen(false);
+              }}
+            />
+          </div>
+        </div>
+      </Modal>
     </Modal>
   );
   async function handleMemberRoleChange(

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -264,7 +264,7 @@ export default function WorkspaceAdmin({
               >
                 <div className="hidden sm:block">
                   {isInvitation(item) ? (
-                    <QuestionMarkCircleStrokeIcon className="h-7 w-7" />
+                    <Avatar size="xs" />
                   ) : (
                     <Avatar visual={item.image} name={item.name} size="xs" />
                   )}


### PR DESCRIPTION
As discussed IRL with @Duncid
- changing user role: avoid reloading page on success 
- confirmation modal (regular not side or full) for revoking access / revoking  invitation (screenshot below)
- Email invite with bar header with custom save button "Invite" (see screenshot)
- use empty avatars for pending invitations
![image](https://github.com/dust-tt/dust/assets/5437393/be2fe1ac-50ec-4a73-b721-35798be7c132)
![Screenshot from 2023-10-16 15-33-41](https://github.com/dust-tt/dust/assets/5437393/01dea3a8-6faa-4705-abe1-b1a99f9e9e04)
