### PR TITLE
Bump Mistral 7B context size to 8192 tokens

### DIFF
--- a/core/src/providers/textsynth.rs
+++ b/core/src/providers/textsynth.rs
@@ -796,8 +796,8 @@ impl LLM for TextSynthLLM {
 
     fn context_size(&self) -> usize {
         match self.id.as_str() {
-            "mistral_7B" => 4096,
-            "mistral_7B_instruct" => 4096,
+            "mistral_7B" => 8192,
+            "mistral_7B_instruct" => 8192,
             "falcon_7B" => 2048,
             "falcon_40B" => 2048,
             "falcon_40B-chat" => 2048,

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -66,9 +66,9 @@ export const MISTRAL_7B_DEFAULT_MODEL_CONFIG = {
   providerId: "textsynth",
   modelId: "mistral_7B_instruct",
   displayName: "Mistral 7B",
-  contextSize: 4096,
+  contextSize: 8192,
   largeModel: false,
-  recommendedTopK: 8,
+  recommendedTopK: 16,
 } as const;
 
 export const SUPPORTED_MODEL_CONFIGS = [


### PR DESCRIPTION
As per discussion with TextSynth Mistral 7B can be bumped to 8k.