### PR TITLE
Admin member improvements

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@dust-tt/sparkle": "^0.2.20",
+        "@dust-tt/sparkle": "^0.2.21",
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",
         "@headlessui/react": "^1.7.7",
@@ -859,9 +859,9 @@
       "integrity": "sha512-smLocSfrt3s53H/XSVP3/1kP42oqvrkjUPtyaFd1F79ux24oE31BKt+q0c6lsa6hOYrFzsIwyc5GXAI5JmfOew=="
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.20",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.20.tgz",
-      "integrity": "sha512-MiH5EYa9T/Nl8tLZd2zgGRJjk3BBaXWpcNCGa3HQ8Arv/s4OrB0SYPv1z+GVdnS/+R44pD8WG860JlT6uCQ10Q==",
+      "version": "0.2.21",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.21.tgz",
+      "integrity": "sha512-8LWXIYvDkHS4LlXKqVbNxwwZBDoSIIN+d7+w0Ep2JTvo6RBdQQGQryLHLZzqznPK0Py+MvoKG/vlukOESby9NA==",
       "dependencies": {
         "@headlessui/react": "^1.7.17"
       },

--- a/front/package.json
+++ b/front/package.json
@@ -13,7 +13,7 @@
     "initdb": "env $(cat .env.local) npx tsx admin/db.ts"
   },
   "dependencies": {
-    "@dust-tt/sparkle": "^0.2.20",
+    "@dust-tt/sparkle": "^0.2.21",
     "@emoji-mart/data": "^1.1.2",
     "@emoji-mart/react": "^1.1.1",
     "@headlessui/react": "^1.7.7",

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -156,8 +156,9 @@ export default function WorkspaceAdmin({
       user: "emerald",
     };
     const [searchText, setSearchText] = useState("");
-    const { members } = useMembers(owner);
-    const { invitations } = useWorkspaceInvitations(owner);
+    const { members, isMembersLoading } = useMembers(owner);
+    const { invitations, isInvitationsLoading } =
+      useWorkspaceInvitations(owner);
     const [inviteEmailModalOpen, setInviteEmailModalOpen] = useState(false);
 
     /** Modal for changing member role: we need to use 2 states: set the member
@@ -317,6 +318,27 @@ export default function WorkspaceAdmin({
                 </div>
               </div>
             )
+          )}
+          {(isMembersLoading || isInvitationsLoading) && (
+            <div className="flex animate-pulse cursor-pointer items-center justify-center gap-3 border-t border-structure-200 bg-structure-50 py-2 text-xs sm:text-sm">
+              <div className="hidden sm:block">
+                <Avatar size="xs" />
+              </div>
+              <div className="flex grow flex-col gap-1 sm:flex-row sm:gap-3">
+                <div className="font-medium text-element-900">Loading...</div>
+                <div className="grow font-normal text-element-700">
+                  user.email@here.com
+                </div>
+              </div>
+              <div>
+                <Chip size="xs" color="slate">
+                  Loading...
+                </Chip>
+              </div>
+              <div className="hidden sm:block">
+                <ChevronRightIcon />
+              </div>
+            </div>
           )}
         </div>
       </>
@@ -529,8 +551,8 @@ function RevokeInvitationModal({
           <Button
             variant="primaryWarning"
             label="Yes, revoke"
-            onClick={() => {
-              handleRevokeInvitation(invitation.id);
+            onClick={async () => {
+              await handleRevokeInvitation(invitation.id);
               onClose();
             }}
           />

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -26,7 +26,6 @@ import {
   getUserFromSession,
   RoleType,
 } from "@app/lib/auth";
-import { ModelId } from "@app/lib/databases";
 import { useMembers, useWorkspaceInvitations } from "@app/lib/swr";
 import { classNames, isEmailValid } from "@app/lib/utils";
 import { MembershipInvitationType } from "@app/types/membership_invitation";
@@ -186,15 +185,17 @@ export default function WorkspaceAdmin({
         .filter(
           (m) =>
             !searchText ||
-            m.name.toLowerCase().includes(searchText) ||
-            m.email?.toLowerCase().includes(searchText) ||
-            m.username?.toLowerCase().includes(searchText)
+            m.name.toLowerCase().includes(searchText.toLowerCase()) ||
+            m.email?.toLowerCase().includes(searchText.toLowerCase()) ||
+            m.username?.toLowerCase().includes(searchText.toLowerCase())
         ),
       ...invitations
         .sort((a, b) => a.inviteEmail.localeCompare(b.inviteEmail))
         .filter((i) => i.status === "pending")
         .filter(
-          (i) => !searchText || i.inviteEmail.toLowerCase().includes(searchText)
+          (i) =>
+            !searchText ||
+            i.inviteEmail.toLowerCase().includes(searchText.toLowerCase())
         ),
     ];
 
@@ -611,8 +612,8 @@ function ChangeMemberModal({
       type="right-side"
       onSave={async () => {
         setIsSaving(true);
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion --
-        // we know it's not null because of the hasChanged check
+        // we know selectRole is not null because of the hasChanged check
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         await handleMemberRoleChange(member, selectedRole!);
         onClose();
         setIsSaving(false);

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -529,7 +529,10 @@ function RevokeInvitationModal({
           <Button
             variant="primaryWarning"
             label="Yes, revoke"
-            onClick={() => invitation && handleRevokeInvitation(invitation.id)}
+            onClick={() => {
+              handleRevokeInvitation(invitation.id);
+              onClose();
+            }}
           />
         </div>
       </div>


### PR DESCRIPTION
Loading visual when members are loaded, cf screenshot (pulsating animation)--at dust we won't see it but Alan & Qonto might

and a few code improvements following daph suggestions and fix a modal not closing issue

Note: loading only shows when no members or no invitations (on screenshot I forced it to show)
![image](https://github.com/dust-tt/dust/assets/5437393/c29c0723-c121-4cde-a550-78ad386c06e7)

