### PR TITLE
fix: use upsert instead of create

### DIFF
--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -1020,7 +1020,7 @@ export async function cachePage({
 
   const parent = getPageOrBlockParent(notionPage);
 
-  await NotionConnectorPageCacheEntry.create({
+  await NotionConnectorPageCacheEntry.upsert({
     notionPageId: pageId,
     connectorId: connector.id,
     pageProperties: {},
@@ -1267,7 +1267,7 @@ export async function cacheDatabaseChildren({
 
   await Promise.all(
     pages.map((page) =>
-      NotionConnectorPageCacheEntry.create({
+      NotionConnectorPageCacheEntry.upsert({
         notionPageId: page.id,
         connectorId: connector.id,
         pageProperties: {},


### PR DESCRIPTION
It can happen that a `child_database` returns a page as children and that same page is also returned by the search endpoint. In those cases, we hit the unique constraint.