### PR TITLE
Improvement to ConnectorPermissionsTree

### DIFF
--- a/connectors/src/api/get_connector_permissions.ts
+++ b/connectors/src/api/get_connector_permissions.ts
@@ -72,15 +72,7 @@ const _getConnectorPermissions = async (
   }
 
   return res.status(200).json({
-    resources: pRes.value.sort((a, b) => {
-      if (a.title > b.title) {
-        return 1;
-      }
-      if (a.title < b.title) {
-        return -1;
-      }
-      return 0;
-    }),
+    resources: pRes.value,
   });
 };
 

--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -312,6 +312,10 @@ export async function retrieveGithubConnectorPermissions({
     );
   }
 
+  resources.sort((a, b) => {
+    return a.title.localeCompare(b.title);
+  });
+
   return new Ok(resources);
 }
 

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -416,7 +416,13 @@ export async function retrieveNotionConnectorPermissions({
 
   const dbResources = await Promise.all(dbs.map((db) => getDbResources(db)));
 
-  return new Ok(pageResources.concat(dbResources));
+  const resources = pageResources.concat(dbResources);
+
+  resources.sort((a, b) => {
+    return a.title.localeCompare(b.title);
+  });
+
+  return new Ok(resources);
 }
 
 export async function retrieveNotionResourcesTitles(

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -370,6 +370,10 @@ export async function retrieveSlackConnectorPermissions({
     permission: ch.permission,
   }));
 
+  resources.sort((a, b) => {
+    return a.title.localeCompare(b.title);
+  });
+
   return new Ok(resources);
 }
 

--- a/front/components/ConnectorPermissionsModal.tsx
+++ b/front/components/ConnectorPermissionsModal.tsx
@@ -189,11 +189,8 @@ export default function ConnectorPermissionsModal({
         defaultNewResourcePermission ? (
           <>
             {canUpdatePermissions && defaultPermissionTitleText ? (
-              <div className="ml-2 mt-8 flex flex-row">
-                <span className="text-sm text-gray-500">
-                  {defaultPermissionTitleText}
-                </span>
-                <div className="flex-grow">
+              <div className="ml-10 mt-8 flex flex-row">
+                <div className="flex flex-initial mr-4">
                   <Checkbox
                     className="ml-auto"
                     onChange={(checked) => {
@@ -207,16 +204,19 @@ export default function ConnectorPermissionsModal({
                     }
                   />
                 </div>
+                <span className="text-sm text-gray-500">
+                  {defaultPermissionTitleText}
+                </span>
               </div>
             ) : null}
             <div>
-              <div className="ml-2 mt-16">
+              <div className="ml-2 mt-8">
                 <div className="text-sm text-gray-500">
                   {resourceListTitleText}
                 </div>
               </div>
             </div>
-            <div className="mb-16 ml-2 mt-8">
+            <div className="mb-16 mt-8 mx-2">
               <PermissionTree
                 owner={owner}
                 dataSource={dataSource}

--- a/front/components/ConnectorPermissionsModal.tsx
+++ b/front/components/ConnectorPermissionsModal.tsx
@@ -190,7 +190,7 @@ export default function ConnectorPermissionsModal({
           <>
             {canUpdatePermissions && defaultPermissionTitleText ? (
               <div className="ml-10 mt-8 flex flex-row">
-                <div className="flex flex-initial mr-4">
+                <div className="mr-4 flex flex-initial">
                   <Checkbox
                     className="ml-auto"
                     onChange={(checked) => {
@@ -216,7 +216,7 @@ export default function ConnectorPermissionsModal({
                 </div>
               </div>
             </div>
-            <div className="mb-16 mt-8 mx-2">
+            <div className="mx-2 mb-16 mt-8">
               <PermissionTree
                 owner={owner}
                 dataSource={dataSource}


### PR DESCRIPTION
Fixes https://github.com/dust-tt/tasks/issues/114

- Move ConnectorPermissionsTree to sparkle Tree
- Disable and auto-select childrens of selected nodes (google drive selection UI)
- Move sorting of resources to connectors implementations (drive we want folders first)
- Adapt Slack popup alignment and checkbox to the use of Tree

It does not fix the fact that selected children do not trigger a partial check of parents (because they are not loaded). We'll want this directionally but not quite possible at low-ish complexity right now.

![Screenshot from 2023-10-17 17-09-51](https://github.com/dust-tt/dust/assets/15067/8f7ed641-604b-4288-b896-7e3824c9c647)
![Screenshot from 2023-10-17 17-10-08](https://github.com/dust-tt/dust/assets/15067/9be29831-3b90-48f8-83cb-885953f8f053)
![Screenshot from 2023-10-17 17-10-19](https://github.com/dust-tt/dust/assets/15067/97133c10-d9b2-46e1-a628-b8fd592612b2)
![Screenshot from 2023-10-17 17-10-35](https://github.com/dust-tt/dust/assets/15067/fa3f4d66-2d4f-4423-b065-e202e9bc514d)
