### PR TITLE
fix: attempt to resolve notion resource parents

### DIFF
--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -347,17 +347,19 @@ export async function retrieveNotionConnectorPermissions({
     return new Err(new Error("Connector not found"));
   }
 
+  const parentId = parentInternalId || "workspace";
+
   const [pages, dbs] = await Promise.all([
     NotionPage.findAll({
       where: {
         connectorId,
-        parentId: parentInternalId || "workspace",
+        parentId,
       },
     }),
     NotionDatabase.findAll({
       where: {
         connectorId,
-        parentId: parentInternalId || "workspace",
+        parentId,
       },
     }),
   ]);
@@ -379,6 +381,7 @@ export async function retrieveNotionConnectorPermissions({
         },
       }),
     ]);
+
     const expandable = childPage || childDB ? true : false;
 
     return {
@@ -416,13 +419,30 @@ export async function retrieveNotionConnectorPermissions({
 
   const dbResources = await Promise.all(dbs.map((db) => getDbResources(db)));
 
+  const folderResources: ConnectorResource[] = [];
+  if (!parentInternalId) {
+    // We also need to return a "fake" top-level folder call "Orphaned" to include resources
+    // we haven't been able to find a parent for.
+    folderResources.push({
+      provider: c.type,
+      // Orphaned resources in the database will have "unknown" as their parentId.
+      internalId: "unknown",
+      parentInternalId: null,
+      type: "folder",
+      title: "Orphaned Resources",
+      sourceUrl: null,
+      expandable: true,
+      permission: "read",
+    });
+  }
+
   const resources = pageResources.concat(dbResources);
 
   resources.sort((a, b) => {
     return a.title.localeCompare(b.title);
   });
 
-  return new Ok(resources);
+  return new Ok(resources.concat(folderResources));
 }
 
 export async function retrieveNotionResourcesTitles(


### PR DESCRIPTION
- when the parent of a page is not reachable, we try to get the page again (in hopes of getting a better parent)
- when we really can't find a proper parent, then we use "unkown"
- in the connector resources display, we add a new top-level folder for "orphaned" resources
- when we come across a parent that we haven't heard of before, we add it to the cache of resources to check (at the end of the run, we attempt to index those)