### PR TITLE
Migration user First and last name

### DIFF
--- a/front/migrations/20231017_user_first_and_last_name.ts
+++ b/front/migrations/20231017_user_first_and_last_name.ts
@@ -1,0 +1,51 @@
+import { Op } from "sequelize";
+
+import { User } from "@app/lib/models";
+import { guessFirstandLastNameFromFullName } from "@app/lib/user";
+
+async function main() {
+  const users = await User.findAll({
+    where: {
+      firstName: {
+        [Op.or]: [null, ""],
+      },
+    },
+  });
+
+  console.log(`Found ${users.length} users to update`);
+
+  const chunks = [];
+  for (let i = 0; i < users.length; i += 16) {
+    chunks.push(users.slice(i, i + 16));
+  }
+
+  for (let i = 0; i < chunks.length; i++) {
+    console.log(`Processing chunk ${i}/${chunks.length}...`);
+    const chunk = chunks[i];
+    await Promise.all(
+      chunk.map((u) => {
+        return (async () => {
+          if (!u.firstName) {
+            const { firstName, lastName } = guessFirstandLastNameFromFullName(
+              u.name
+            );
+            await u.update({
+              firstName,
+              lastName,
+            });
+          }
+        })();
+      })
+    );
+  }
+}
+
+main()
+  .then(() => {
+    console.log("Done");
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });


### PR DESCRIPTION
Following https://github.com/dust-tt/dust/pull/2065 where new users are asked to confirm their name on the onboarding flow, this is a migration to update **all existing users** with a `firstName` empty or null.

This is not perfect, we are setting the first word in firstName and the rest in last name. We're okay with it.

Once run, we will be able to change this line: https://github.com/dust-tt/dust/blob/main/front/pages/w/%5BwId%5D/assistant/new.tsx#L183


Command, to run in the evening: 
```shell
env $(cat .env.local) npx tsx migrations/20231017_user_first_and_last_name.ts
``` 



