### PR TITLE
Don't raise error when there's a missing folder on google drive markFolderAsVisited

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -1034,9 +1034,12 @@ export async function markFolderAsVisited(
   }
   const authCredentials = await getAuthObject(connector.connectionId);
   const file = await getGoogleDriveObject(authCredentials, driveFileId);
+
   if (!file) {
-    throw new Error(`File ${driveFileId} unexpectedly not found (got 404)`);
+    // We got a 404 on this folder, we skip it.
+    return;
   }
+
   await GoogleDriveFiles.upsert({
     connectorId: connectorId,
     dustFileId: getDocumentId(driveFileId),


### PR DESCRIPTION
I have not checked if the proper fix is not to enter this function; I just did same as in https://github.com/dust-tt/dust/pull/2158/files 🙈 