### PR TITLE
[Gdrive Oauth] Adding CSP header to fix alert revealed by ZAP scanner

### DIFF
--- a/front/next.config.js
+++ b/front/next.config.js
@@ -36,11 +36,12 @@ module.exports = removeImports({
         source: "/:path*", // Match all paths
         headers: [
           {
-            key:'Content-Security-Policy',
-            value:"script-src 'self' 'unsafe-inline' 'unsafe-eval' www.googletagmanager.com",
-          }
-        ]
-      }
-    ]
-  }
+            key: "Content-Security-Policy",
+            value:
+              "script-src 'self' 'unsafe-inline' 'unsafe-eval' www.googletagmanager.com",
+          },
+        ],
+      },
+    ];
+  },
 });

--- a/front/next.config.js
+++ b/front/next.config.js
@@ -30,4 +30,17 @@ module.exports = removeImports({
       },
     ];
   },
+  async headers() {
+    return [
+      {
+        source: "/:path*", // Match all paths
+        headers: [
+          {
+            key:'Content-Security-Policy',
+            value:"script-src 'self' 'unsafe-inline' 'unsafe-eval' www.googletagmanager.com",
+          }
+        ]
+      }
+    ]
+  }
 });

--- a/front/pages/index.tsx
+++ b/front/pages/index.tsx
@@ -426,7 +426,6 @@ export default function Home({
              gtag('config', '${gaTrackingId}');
             `}
           </Script>
-          <Script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.4.0/p5.js" />
         </>
       </main>
     </>


### PR DESCRIPTION
This is to fix the following alert reported by ZAP:
```


Medium | Content Security Policy (CSP) Header Not Set

Description | Content Security Policy (CSP) is an added layer of security that helps to detect and mitigate certain types of attacks, including Cross Site Scripting (XSS) and data injection attacks. These attacks are used for everything from data theft to site defacement or distribution of malware. CSP provides a set of standard HTTP headers that allow website owners to declare approved sources of content that browsers should be allowed to load on that page — covered types are JavaScript, CSS, HTML frames, fonts, images and embeddable objects such as Java applets, ActiveX, audio and video files.


```

<img width="1509" alt="Screen Shot 2023-10-18 at 10 50 44" src="https://github.com/dust-tt/dust/assets/358965/850afe8b-3a08-4155-8700-4cdd86ef90a8">

This header means that we can only load javascript code from the domain serving the code (dust.tt) and www.googletagmanager.com.

I tested the website and the webapp locally, and checked for all `<script` mention in our codebase.

Let me know if you think I missed something.