### PR TITLE
Fix gpt-3.5-turbo-instruct

### DIFF
--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -444,7 +444,6 @@ pub async fn completion(
         "temperature": temperature,
         "n": n,
         "logprobs": logprobs,
-        "echo": echo,
         "stop": match stop.len() {
             0 => None,
             _ => Some(stop),
@@ -459,6 +458,16 @@ pub async fn completion(
     if model_id.is_some() {
         body["model"] = json!(model_id);
     }
+    match model_id {
+        None => (),
+        Some(model_id) => {
+            body["model"] = json!(model_id);
+            // `gpt-3.5-turbo-instruct` does not support `echo`
+            if !model_id.starts_with("gpt-3.5-turbo-instruct") {
+                body["echo"] = json!(echo);
+            }
+        }
+    };
 
     // println!("BODY: {}", body.to_string());
 


### PR DESCRIPTION
Fixes https://github.com/dust-tt/tasks/issues/117

`gpt-3.5-turbo-instruct` errors if `echo` is set to true. This means we won't get the logprobs of the prompt, but the code properly detect that and only fills the logprobs of the completion.

