### PR TITLE
Remove conversation title on new.tsx

### DIFF
--- a/front/pages/w/[wId]/assistant/new.tsx
+++ b/front/pages/w/[wId]/assistant/new.tsx
@@ -15,7 +15,6 @@ import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 
 import Conversation from "@app/components/assistant/conversation/Conversation";
-import { ConversationTitle } from "@app/components/assistant/conversation/ConversationTitle";
 import { GenerationContextProvider } from "@app/components/assistant/conversation/GenerationContextProvider";
 import {
   FixedAssistantInputBar,

--- a/front/pages/w/[wId]/assistant/new.tsx
+++ b/front/pages/w/[wId]/assistant/new.tsx
@@ -35,13 +35,12 @@ import {
 } from "@app/types/assistant/conversation";
 import { UserType, WorkspaceType } from "@app/types/user";
 
-const { URL = "", GA_TRACKING_ID = "" } = process.env;
+const { GA_TRACKING_ID = "" } = process.env;
 
 export const getServerSideProps: GetServerSideProps<{
   user: UserType;
   isBuilder: boolean;
   owner: WorkspaceType;
-  baseUrl: string;
   gaTrackingId: string;
 }> = async (context) => {
   const session = await getSession(context.req, context.res);
@@ -66,7 +65,6 @@ export const getServerSideProps: GetServerSideProps<{
       user,
       isBuilder: auth.isBuilder(),
       owner,
-      baseUrl: URL,
       gaTrackingId: GA_TRACKING_ID,
     },
   };
@@ -76,7 +74,6 @@ export default function AssistantNew({
   user,
   isBuilder,
   owner,
-  baseUrl,
   gaTrackingId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const router = useRouter();

--- a/front/pages/w/[wId]/assistant/new.tsx
+++ b/front/pages/w/[wId]/assistant/new.tsx
@@ -160,15 +160,6 @@ export default function AssistantNew({
           pageTitle={"Dust - New Conversation"}
           gaTrackingId={gaTrackingId}
           topNavigationCurrent="assistant"
-          titleChildren={
-            conversation && (
-              <ConversationTitle
-                owner={owner}
-                conversation={conversation}
-                shareLink={`${baseUrl}/w/${owner.sId}/assistant/${conversation.sId}`}
-              />
-            )
-          }
           navChildren={
             <AssistantSidebarMenu
               owner={owner}


### PR DESCRIPTION
Often there is a flicker of the conversation title as we move from new.tsx to the [cId] index.tsx

Just remove the title on new so that it never appears and only appears on the main conversation page