### PR TITLE
Fixing Google Analytics

### DIFF
--- a/front/next.config.js
+++ b/front/next.config.js
@@ -37,11 +37,6 @@ module.exports = removeImports({
         source: "/:path*", // Match all paths
         headers: [
           {
-            key: "Content-Security-Policy",
-            value:
-              "script-src 'self' 'unsafe-inline' 'unsafe-eval' www.googletagmanager.com",
-          },
-          {
             key: "X-Frame-Options",
             value: "DENY",
           },


### PR DESCRIPTION
Reverting this change for two reasons:
- it conflicts with Google Analytics
- I found the exact list of requirements and the associated CWE (common weakness) is actually not required by CASA tier 2 (even though it's reported by ZAP).