### PR TITLE
Stop Generation works with messages stuck in created

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -61,21 +61,8 @@ export function AgentMessage({
   const [streamedAgentMessage, setStreamedAgentMessage] =
     useState<AgentMessageType>(message);
 
-  const shouldStream = (() => {
-    switch (streamedAgentMessage.status) {
-      case "succeeded":
-      case "failed":
-      case "cancelled":
-        return false;
-      case "created":
-        return true;
-
-      default:
-        ((status: never) => {
-          throw new Error(`Unknown status: ${status}`);
-        })(streamedAgentMessage.status);
-    }
-  })();
+  const shouldStream =
+    message.status === "created" && streamedAgentMessage.status === "created";
 
   const buildEventSourceURL = useCallback(
     (lastEvent: string | null) => {
@@ -163,8 +150,11 @@ export function AgentMessage({
     switch (message.status) {
       case "succeeded":
       case "failed":
-      case "cancelled":
         return message;
+      case "cancelled":
+        return message.content
+          ? message
+          : { ...message, content: streamedAgentMessage.content };
       case "created":
         return streamedAgentMessage;
 

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -61,8 +61,25 @@ export function AgentMessage({
   const [streamedAgentMessage, setStreamedAgentMessage] =
     useState<AgentMessageType>(message);
 
-  const shouldStream =
-    message.status === "created" && streamedAgentMessage.status === "created";
+  const shouldStream = (() => {
+    if (message.status !== "created") {
+      return false;
+    }
+
+    switch (streamedAgentMessage.status) {
+      case "succeeded":
+      case "failed":
+      case "cancelled":
+        return false;
+      case "created":
+        return true;
+
+      default:
+        ((status: never) => {
+          throw new Error(`Unknown status: ${status}`);
+        })(streamedAgentMessage.status);
+    }
+  })();
 
   const buildEventSourceURL = useCallback(
     (lastEvent: string | null) => {

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -169,9 +169,9 @@ export function AgentMessage({
       case "failed":
         return message;
       case "cancelled":
-        return message.content
-          ? message
-          : { ...message, content: streamedAgentMessage.content };
+        return streamedAgentMessage.status === "created"
+          ? streamedAgentMessage
+          : message;
       case "created":
         return streamedAgentMessage;
 

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -163,7 +163,7 @@ export function AgentMessage({
 
   useEventSource(buildEventSourceURL, onEventCallback);
 
-  const agentMessageToRender = (() => {
+  const agentMessageToRender = ((): AgentMessageType => {
     switch (message.status) {
       case "succeeded":
       case "failed":

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -170,7 +170,7 @@ export function AgentMessage({
         return message;
       case "cancelled":
         return streamedAgentMessage.status === "created"
-          ? streamedAgentMessage
+          ? { ...streamedAgentMessage, status: "cancelled" }
           : message;
       case "created":
         return streamedAgentMessage;

--- a/front/components/assistant/conversation/InputBar.tsx
+++ b/front/components/assistant/conversation/InputBar.tsx
@@ -18,6 +18,7 @@ import {
   useState,
 } from "react";
 import * as ReactDOMServer from "react-dom/server";
+import { mutate } from "swr";
 
 import { AssistantPicker } from "@app/components/assistant/AssistantPicker";
 import { GenerationContext } from "@app/components/assistant/conversation/GenerationContextProvider";
@@ -791,6 +792,9 @@ export function FixedAssistantInputBar({
           messageIds: generationContext.generatingMessageIds,
         }),
       }
+    );
+    await mutate(
+      `/api/w/${owner.sId}/assistant/conversations/${conversationId}`
     );
   };
 

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -419,7 +419,10 @@ export async function* runGeneration(
         shouldYieldCancel = true;
         await redis.set(
           `assistant:generation:cancelled:${agentMessage.sId}`,
-          0
+          0,
+          {
+            EX: 3600, // 1 hour
+          }
         );
       }
     } catch (error) {

--- a/front/lib/api/assistant/pubsub.ts
+++ b/front/lib/api/assistant/pubsub.ts
@@ -313,7 +313,7 @@ export async function cancelMessageGenerationEvent(
       // Submit event to redis stream so we stop the generation
       const redisTask = redis.set(
         `assistant:generation:cancelled:${messageId}`,
-        "1",
+        1,
         {
           EX: 3600, // 1 hour
         }

--- a/front/lib/api/assistant/pubsub.ts
+++ b/front/lib/api/assistant/pubsub.ts
@@ -308,34 +308,39 @@ export async function cancelMessageGenerationEvent(
 ): Promise<void> {
   const redis = await redisClient();
 
-  const tasks = messageIds.map((messageId) => {
-    // Submit event to redis stream so we stop the generation
-    const redisTask = redis.set(
-      `assistant:generation:cancelled:${messageId}`,
-      "1",
-      {
-        EX: 3600, // 1 hour
-      }
-    );
+  try {
+    const tasks = messageIds.map((messageId) => {
+      // Submit event to redis stream so we stop the generation
+      const redisTask = redis.set(
+        `assistant:generation:cancelled:${messageId}`,
+        "1",
+        {
+          EX: 3600, // 1 hour
+        }
+      );
 
-    // Already set the status to cancel
-    const dbTask = Message.findOne({
-      where: { sId: messageId },
-    }).then(async (message) => {
-      if (message && message.agentMessageId) {
-        await AgentMessage.update(
-          { status: "cancelled" },
-          { where: { id: message.agentMessageId } }
-        );
-      }
+      // Already set the status to cancel
+      const dbTask = Message.findOne({
+        where: { sId: messageId },
+      }).then(async (message) => {
+        if (message && message.agentMessageId) {
+          await AgentMessage.update(
+            { status: "cancelled" },
+            { where: { id: message.agentMessageId } }
+          );
+        }
+      });
+
+      // Return both tasks as a single promise
+      return Promise.all([redisTask, dbTask]);
     });
 
-    // Return both tasks as a single promise
-    return Promise.all([redisTask, dbTask]);
-  });
-
-  await Promise.all(tasks);
-  await redis.quit();
+    await Promise.all(tasks);
+  } catch (e) {
+    logger.error({ error: e }, "Error cancelling message generation");
+  } finally {
+    await redis.quit();
+  }
 }
 
 export async function* getMessagesEvents(


### PR DESCRIPTION
Eng runner card: https://github.com/dust-tt/tasks/issues/102

- When clicking on the "Stop Generation" button, on top of emitting a Redis key (for which I added an expiration date) that will be managed by `runGeneration` to stop the generation, we immediately set the status of the message to `cancelled`. After this action, we mutate the conversation.

On `AgentMessage`:
- On the UI we consider that a message is streaming if both `streamedAgentMessage` and `message` have a status to created.
- `agentMessageToRender`: if the message is in cancelled but has no content yet we return it with the content already streamed (to handle the case when the backend has not already stopped the generation and saved the content). 

WDYT?