### PR TITLE
Workpace setting layout consistent with Members management

### DIFF
--- a/front/pages/w/[wId]/workspace/index.tsx
+++ b/front/pages/w/[wId]/workspace/index.tsx
@@ -204,19 +204,19 @@ export default function WorkspaceAdmin({
       topNavigationCurrent="settings"
       subNavigation={subNavigationAdmin({ owner, current: "workspace" })}
     >
-      <Page.Vertical>
-        <div className="mx-auto flex w-full max-w-2xl flex-col gap-6">
-          <PageHeader
-            title="Workspace Settings"
-            icon={Cog6ToothIcon}
-            description="Use this page to manage your workspace."
-          />
-          <div />
-          <Page.SectionHeader
-            title="Workspace name"
-            description="Think GitHub repository names, short and memorable."
-          />
-          <div className="flex w-full flex-col gap-4">
+      <Page.Vertical gap="xl" align="stretch">
+        <PageHeader
+          title="Workspace Settings"
+          icon={Cog6ToothIcon}
+          description="Use this page to manage your workspace."
+        />
+        <Page.Vertical align="stretch" gap="md">
+          <Page.H variant="h5">Workspace name</Page.H>
+          <Page.P variant="secondary">
+            Think GitHub repository names, short and memorable.
+          </Page.P>
+
+          <div className="flex flex-col items-stretch gap-2 sm:flex-row">
             <div className="flex-grow">
               <Input
                 name="name"
@@ -227,7 +227,7 @@ export default function WorkspaceAdmin({
                 showErrorLabel={true}
               />
             </div>
-            <div>
+            <div className="flex-none">
               <Button
                 variant="secondary"
                 disabled={disable || updating}
@@ -236,47 +236,46 @@ export default function WorkspaceAdmin({
               />
             </div>
           </div>
+        </Page.Vertical>
 
-          <div />
-          {!!monthOptions.length && (
-            <>
-              <Page.SectionHeader
-                title="Workspace Activity"
-                description="Download monthly workspace activity details."
-              />
-              <div className="align-center flex flex-row gap-2">
-                <DropdownMenu>
-                  <DropdownMenu.Button>
-                    <Button
-                      type="select"
-                      labelVisible={true}
-                      label={selectedMonth || ""}
-                      variant="secondary"
-                      size="sm"
+        {!!monthOptions.length && (
+          <Page.Vertical align="stretch" gap="md">
+            <Page.H variant="h5">Workspace Activity</Page.H>
+            <Page.P variant="secondary">
+              Download monthly workspace activity details.
+            </Page.P>
+            <div className="align-center flex flex-row gap-2">
+              <DropdownMenu>
+                <DropdownMenu.Button>
+                  <Button
+                    type="select"
+                    labelVisible={true}
+                    label={selectedMonth || ""}
+                    variant="secondary"
+                    size="sm"
+                  />
+                </DropdownMenu.Button>
+                <DropdownMenu.Items origin="topLeft">
+                  {monthOptions.map((month) => (
+                    <DropdownMenu.Item
+                      key={month}
+                      label={month}
+                      onClick={() => handleSelectMonth(month)}
                     />
-                  </DropdownMenu.Button>
-                  <DropdownMenu.Items origin="topLeft">
-                    {monthOptions.map((month) => (
-                      <DropdownMenu.Item
-                        key={month}
-                        label={month}
-                        onClick={() => handleSelectMonth(month)}
-                      />
-                    ))}
-                  </DropdownMenu.Items>
-                </DropdownMenu>
-                <Button
-                  label="Download activity data"
-                  icon={CloudArrowDownIcon}
-                  variant="secondary"
-                  onClick={() => {
-                    void handleDownload(selectedMonth);
-                  }}
-                />
-              </div>
-            </>
-          )}
-        </div>
+                  ))}
+                </DropdownMenu.Items>
+              </DropdownMenu>
+              <Button
+                label="Download activity data"
+                icon={CloudArrowDownIcon}
+                variant="secondary"
+                onClick={() => {
+                  void handleDownload(selectedMonth);
+                }}
+              />
+            </div>
+          </Page.Vertical>
+        )}
       </Page.Vertical>
     </AppLayout>
   );


### PR DESCRIPTION
The members & workspaces settings pages had a different layout (not the same max-xl width, and not the same titles). The difference in width is especially annoying so I took 5 min to change it. 

As the Member page was done with Ed's designs, I aligned the workspace one on it: 

Review with hidden whitespaces: https://github.com/dust-tt/dust/pull/2217/files?diff=split&w=1


### Before
<img width="1800" alt="Capture d’écran 2023-10-20 à 11 40 44" src="https://github.com/dust-tt/dust/assets/3803406/66569f03-dbd4-4e26-ab0a-f7295efe814b">


### After 
<img width="1798" alt="Capture d’écran 2023-10-20 à 11 38 30" src="https://github.com/dust-tt/dust/assets/3803406/b886a581-1ef7-4b43-a8ab-a71374a739be">
