### PR TITLE
Members page: notifications on errors or successes

### DIFF
--- a/front/components/sparkle/Notification.tsx
+++ b/front/components/sparkle/Notification.tsx
@@ -64,7 +64,7 @@ export function NotificationsList({
   notifications: (NotificationType & { id: string })[];
 }) {
   return (
-    <div className="z-60 fixed bottom-0 right-0 w-80">
+    <div className="fixed bottom-0 right-0 z-60 w-80">
       <div className="flex flex-col items-center justify-center gap-4 p-4">
         {notifications.map((n) => {
           return (
@@ -93,11 +93,11 @@ export function Notification({ title, description, type }: NotificationType) {
       show={showNotification}
       appear={true}
       enter="transition ease-in-out duration-300 transform"
-      enterFrom="-translate-y-16 opacity-0"
+      enterFrom="translate-y-16 opacity-0"
       enterTo="translate-y-0 opacity-100"
       leave="transition ease-in-out duration-300 transform"
       leaveFrom="translate-y-0 opacity-100"
-      leaveTo="-translate-y-16 opacity-0"
+      leaveTo="translate-y-16 opacity-0"
     >
       <div className="flex rounded-md border border-structure-100 bg-structure-0 p-2 shadow-md">
         <div>

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -444,7 +444,7 @@ function InviteSettingsModal({
   const [domainUpdating, setDomainUpdating] = useState(false);
   const [domainInput, setDomainInput] = useState(owner.allowedDomain || "");
   const [allowedDomainError, setAllowedDomainError] = useState("");
-
+  const sendNotification = useContext(SendNotificationsContext);
   async function handleUpdateWorkspace(): Promise<void> {
     setDomainUpdating(true);
     const res = await fetch(`/api/w/${owner.sId}`, {
@@ -457,7 +457,11 @@ function InviteSettingsModal({
       }),
     });
     if (!res.ok) {
-      window.alert("Failed to update workspace.");
+      sendNotification({
+        type: "error",
+        title: "Update failed",
+        description: `Failed to update workspace with new domain ${domainInput}.`,
+      });
       setDomainUpdating(false);
     } else {
       // We perform a full refresh so that the Workspace name updates and we get a fresh owner
@@ -618,7 +622,7 @@ function ChangeMemberModal({
   const [revokeMemberModalOpen, setRevokeMemberModalOpen] = useState(false);
   const [selectedRole, setSelectedRole] = useState<RoleType | null>(null);
   const [isSaving, setIsSaving] = useState(false);
-
+  const sendNotification = useContext(SendNotificationsContext);
   if (!member) return null; // Unreachable
 
   async function handleMemberRoleChange(
@@ -635,8 +639,17 @@ function ChangeMemberModal({
       }),
     });
     if (!res.ok) {
-      window.alert("Failed to update membership.");
+      sendNotification({
+        type: "error",
+        title: "Update failed",
+        description: "Failed to update member's role.",
+      });
     } else {
+      sendNotification({
+        type: "success",
+        title: "Role updated",
+        description: `Role updated for ${member.name}.`,
+      });
       await mutate(`/api/w/${owner.sId}/members`);
     }
   }

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -282,6 +282,7 @@ export default function WorkspaceAdmin({
                     {!isInvitation(item) && (
                       <div className="font-medium text-element-900">
                         {item.name}
+                        {user?.id === item.id && " (you)"}
                       </div>
                     )}
 

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -534,21 +534,36 @@ function RevokeInvitationModal({
 }) {
   const { mutate } = useSWRConfig();
   const [isSaving, setIsSaving] = useState(false);
+  const sendNotification = useContext(SendNotificationsContext);
   if (!invitation) return null;
 
-  async function handleRevokeInvitation(invitationId: number): Promise<void> {
-    const res = await fetch(`/api/w/${owner.sId}/invitations/${invitationId}`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        status: "revoked",
-      }),
-    });
+  async function handleRevokeInvitation(
+    invitation: MembershipInvitationType
+  ): Promise<void> {
+    const res = await fetch(
+      `/api/w/${owner.sId}/invitations/${invitation.id}`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          status: "revoked",
+        }),
+      }
+    );
     if (!res.ok) {
-      window.alert("Failed to revoke member's invitation.");
+      sendNotification({
+        type: "error",
+        title: "Revoke failed",
+        description: "Failed to revoke member's invitation.",
+      });
     } else {
+      sendNotification({
+        type: "success",
+        title: "Invitation revoked",
+        description: `Invitation revoked for ${invitation.inviteEmail}.`,
+      });
       await mutate(`/api/w/${owner.sId}/invitations`);
     }
   }
@@ -573,7 +588,7 @@ function RevokeInvitationModal({
             label={isSaving ? "Revoking..." : "Yes, revoke"}
             onClick={async () => {
               setIsSaving(true);
-              await handleRevokeInvitation(invitation.id);
+              await handleRevokeInvitation(invitation);
               onClose();
               /* Delay to let react close the modal before cleaning isSaving, to
                * avoid the user seeing the button change label again during the closing animation */

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -20,6 +20,7 @@ import { useSWRConfig } from "swr";
 
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { subNavigationAdmin } from "@app/components/sparkle/navigation";
+import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import {
   Authenticator,
   getSession,
@@ -30,7 +31,6 @@ import { useMembers, useWorkspaceInvitations } from "@app/lib/swr";
 import { classNames, isEmailValid } from "@app/lib/utils";
 import { MembershipInvitationType } from "@app/types/membership_invitation";
 import { UserType, WorkspaceType } from "@app/types/user";
-import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 
 const { GA_TRACKING_ID = "", URL = "" } = process.env;
 

--- a/front/tailwind.config.js
+++ b/front/tailwind.config.js
@@ -8,6 +8,9 @@ module.exports = {
       objektiv: ["'objektiv-mk1'", "sans-serif"],
     },
     extend: {
+      zIndex: {
+        60: "60",
+      },
       minHeight: (theme) => ({
         ...theme("spacing"),
       }),


### PR DESCRIPTION
Instead of alerts or silent successes

(except for the window.reload for updating the invite link but it's shown by the updated text after reload)