### PR TITLE
front-edge-backendconfig should be in the repo

### DIFF
--- a/k8s/apply_infra.sh
+++ b/k8s/apply_infra.sh
@@ -63,6 +63,7 @@ echo "Applying backend configs"
 echo "-----------------------------------"
 
 kubectl apply -f "$(dirname "$0")/backend-configs/front-backend-config.yaml"
+kubectl apply -f "$(dirname "$0")/backend-configs/front-edge-backend-config.yaml"
 kubectl apply -f "$(dirname "$0")/backend-configs/connectors-backend-config.yaml"
 kubectl apply -f "$(dirname "$0")/backend-configs/metabase-backend-config.yaml"
 

--- a/k8s/backend-configs/front-edge-backend-config.yaml
+++ b/k8s/backend-configs/front-edge-backend-config.yaml
@@ -1,0 +1,11 @@
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: front-edge-backendconfig
+spec:
+  customResponseHeaders:
+    headers:
+      - "Strict-Transport-Security: max-age=86400"
+  sessionAffinity:
+    affinityType: "CLIENT_IP"
+  timeoutSec: 300

--- a/k8s/services/front-edge-service.yaml
+++ b/k8s/services/front-edge-service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: front-edge-service
   annotations:
-    cloud.google.com/backend-config: '{"default": "front-backendconfig"}'
+    cloud.google.com/backend-config: '{"default": "front-edge-backendconfig"}'
 spec:
   selector:
     app: front-edge


### PR DESCRIPTION
We temporarily need a specific header and to disable cookie-based session affinity on front-edge.
This has been applied on the kube repo for days, so we might as well commit it.