### PR TITLE
Fix: exhaustive retrieval with multiple tags / parents

### DIFF
--- a/core/src/stores/postgres.rs
+++ b/core/src/stores/postgres.rs
@@ -1410,7 +1410,7 @@ impl Store for PostgresStore {
                 if let Some(tags) = &tags_filter.is_in {
                     tags_is_in = tags.to_vec();
                     if !tags_is_in.is_empty() {
-                        where_clauses.push(format!("tags_array @> ${}", p_idx));
+                        where_clauses.push(format!("tags_array && ${}", p_idx));
                         params.push(&tags_is_in);
                         p_idx += 1;
                     }
@@ -1418,7 +1418,7 @@ impl Store for PostgresStore {
                 if let Some(tags) = &tags_filter.is_not {
                     tags_is_not = tags.to_vec();
                     if !tags_is_not.is_empty() {
-                        where_clauses.push(format!("NOT tags_array @> ${}", p_idx));
+                        where_clauses.push(format!("NOT tags_array && ${}", p_idx));
                         params.push(&tags_is_not);
                         p_idx += 1;
                     }
@@ -1429,7 +1429,7 @@ impl Store for PostgresStore {
                 if let Some(parents) = &parents_filter.is_in {
                     parents_is_in = parents.to_vec();
                     if !parents_is_in.is_empty() {
-                        where_clauses.push(format!("parents @> ${}", p_idx));
+                        where_clauses.push(format!("parents && ${}", p_idx));
                         params.push(&parents_is_in);
                         p_idx += 1;
                     }
@@ -1437,7 +1437,7 @@ impl Store for PostgresStore {
                 if let Some(parents) = &parents_filter.is_not {
                     parents_is_not = parents.to_vec();
                     if !parents_is_not.is_empty() {
-                        where_clauses.push(format!("NOT parents @> ${}", p_idx));
+                        where_clauses.push(format!("NOT parents && ${}", p_idx));
                         params.push(&parents_is_not);
                         p_idx += 1;
                     }


### PR DESCRIPTION
**Issue**
Exhaustive data source retrieval uses a "@>" operator to check whether tags / parents of a documents match those specified in `tags_in | parents_in | tags_not | parents_not` from the retrieval configuration

The `parents_in` retrieval configuration is an "OR": any document who has one parent inside the list of parents_in should be matched

But the "@>" is an "AND", checking the `parents` array of the document contains all the values of `parents_in`. This causes exhaustive retrieval not to perform as expected when parents_in contains more than 1 element.

Regarding other fields (`tags_in`, `parents_not`, `tags_not`), they also should behave like an OR. While there might be some cases where people want an AND, those cases are most likely a minority

**Fix**
Use the postgres overlap operator "&&" instead

**Impact**
1 non-dust custom assistant with more than 1 parent, created thursday (19 oct 2023) and updated yesterday (20 oct 2023). See [Metabase query](https://metabase.dust.tt/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7InR5cGUiOiJuYXRpdmUiLCJuYXRpdmUiOnsicXVlcnkiOiJTRUxFQ1QgXCJhZ2VudF9jb25maWd1cmF0aW9uc1wiLiosIFwiYWdlbnRfcmV0cmlldmFsX2NvbmZpZ3VyYXRpb25zXCIuKiwgXCJhZ2VudF9kYXRhX3NvdXJjZV9jb25maWd1cmF0aW9uc1wiLipcbkZST00gXCJhZ2VudF9jb25maWd1cmF0aW9uc1wiIFxuSk9JTiBcImFnZW50X3JldHJpZXZhbF9jb25maWd1cmF0aW9uc1wiIFxuT04gXCJhZ2VudF9jb25maWd1cmF0aW9uc1wiLlwicmV0cmlldmFsQ29uZmlndXJhdGlvbklkXCIgPSBcImFnZW50X3JldHJpZXZhbF9jb25maWd1cmF0aW9uc1wiLlwiaWRcIlxuSk9JTiBcImFnZW50X2RhdGFfc291cmNlX2NvbmZpZ3VyYXRpb25zXCJcbk9OIFwiYWdlbnRfcmV0cmlldmFsX2NvbmZpZ3VyYXRpb25zXCIuaWQgPSBcImFnZW50X2RhdGFfc291cmNlX2NvbmZpZ3VyYXRpb25zXCIuXCJyZXRyaWV2YWxDb25maWd1cmF0aW9uSWRcIlxuV0hFUkUgXCJhZ2VudF9jb25maWd1cmF0aW9uc1wiLlwid29ya3NwYWNlSWRcIiBOT1QgSU4gKFxuICAgIFNFTEVDVCBcImlkXCIgRlJPTSBcIndvcmtzcGFjZXNcIiBXSEVSRSBcInNJZFwiID0gJzBlYzk4NTJjMmYnXG4pIFxuQU5EIFwiYWdlbnRfcmV0cmlldmFsX2NvbmZpZ3VyYXRpb25zXCIuXCJxdWVyeVwiID0gJ25vbmUnXG5BTkQgYXJyYXlfbGVuZ3RoKGFnZW50X2RhdGFfc291cmNlX2NvbmZpZ3VyYXRpb25zLlwicGFyZW50c0luXCIsIDEpID4gMTsiLCJ0ZW1wbGF0ZS10YWdzIjp7fX0sImRhdGFiYXNlIjo0fSwiZGlzcGxheSI6InRhYmxlIiwicGFyYW1ldGVycyI6W10sInZpc3VhbGl6YXRpb25fc2V0dGluZ3MiOnt9fQ==)

The associated customer is `Alan`, the bot name is `renewal_feedback`

**Deploy plan**
On monday morning (I'll take)

- Deploy core with this PR's fix
- Send coms to Alan
- Report in incident