### PR TITLE
Assistant Builder: refactor data sources mode

### DIFF
--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -81,7 +81,7 @@ type ActionMode = (typeof ACTION_MODES)[number];
 const ACTION_MODE_TO_LABEL: Record<ActionMode, string> = {
   GENERIC: "No action (Generic model)",
   RETRIEVAL_SEARCH: "Search Data Sources",
-  RETRIEVAL_EXHAUSTIVE: "Exhaustive Data  Sources Processing",
+  RETRIEVAL_EXHAUSTIVE: "Exhaustive Data Sources Processing",
   DUST_APP_RUN: "Run Dust App",
 };
 
@@ -919,7 +919,8 @@ export default function AssistantBuilder({
                   relevant time frame using the "Collect data from" field below.
                 </div>
                 <div>
-                  The available data sources are managed by administrators.
+                  <strong>Note:</strong> The available data sources are managed
+                  by administrators.
                 </div>
               </div>
               <DataSourceSelectionSection
@@ -1016,7 +1017,7 @@ export default function AssistantBuilder({
                     of the answers to specific questions will depend on the
                     quality of the data.
                   </p>
-                  <p>
+                  <p className="mt-1">
                     <strong>
                       You can narrow your search on most recent documents
                     </strong>{" "}
@@ -1468,7 +1469,7 @@ function ActionModeSection({
         });
       }}
     >
-      <div className="flex flex-col gap-6">{children}</div>
+      <div className="flex flex-col gap-6 text-justify">{children}</div>
     </Transition>
   );
 }

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -36,6 +36,7 @@ import {
   AppLayoutSimpleSaveCancelTitle,
 } from "@app/components/sparkle/AppLayoutTitle";
 import { subNavigationAdmin } from "@app/components/sparkle/navigation";
+import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import {
   CLAUDE_DEFAULT_MODEL_CONFIG,
   CLAUDE_INSTANT_DEFAULT_MODEL_CONFIG,
@@ -60,7 +61,6 @@ import { UserType, WorkspaceType } from "@app/types/user";
 import DataSourceResourceSelectorTree from "../DataSourceResourceSelectorTree";
 import AssistantBuilderDustAppModal from "./AssistantBuilderDustAppModal";
 import DustAppSelectionSection from "./DustAppSelectionSection";
-import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 
 const usedModelConfigs = [
   GPT_4_32K_MODEL_CONFIG,

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -720,7 +720,7 @@ export default function AssistantBuilder({
                           console.error(e);
                           sendNotification({
                             title: "Error saving Assistant",
-                            description: `Please try again. If the error persists, pease reach out to team@dust.tt (error ${e.message})`,
+                            description: `Please try again. If the error persists, reach out to team@dust.tt (error ${e.message})`,
                             type: "error",
                           });
                           setIsSavingOrDeleting(false);
@@ -905,7 +905,7 @@ export default function AssistantBuilder({
             >
               <div>
                 The assistant will look exhaustively at all the Data Sources, in
-                chronological order.
+                reverse chronological order (most recent first).
               </div>
               <div className="grid grid-cols-2 gap-4">
                 <div>

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -60,6 +60,7 @@ import { UserType, WorkspaceType } from "@app/types/user";
 import DataSourceResourceSelectorTree from "../DataSourceResourceSelectorTree";
 import AssistantBuilderDustAppModal from "./AssistantBuilderDustAppModal";
 import DustAppSelectionSection from "./DustAppSelectionSection";
+import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 
 const usedModelConfigs = [
   GPT_4_32K_MODEL_CONFIG,
@@ -209,7 +210,7 @@ export default function AssistantBuilder({
   agentConfigurationId,
 }: AssistantBuilderProps) {
   const router = useRouter();
-
+  const sendNotification = React.useContext(SendNotificationsContext);
   const slackDataSource = dataSources.find(
     (ds) => ds.connectorProvider === "slack"
   );
@@ -223,6 +224,7 @@ export default function AssistantBuilder({
         : GPT_3_5_TURBO_16K_MODEL_CONFIG,
     },
   });
+
   const [showDataSourcesModal, setShowDataSourcesModal] = useState(false);
   const [dataSourceToManage, setDataSourceToManage] =
     useState<AssistantBuilderDataSourceConfiguration | null>(null);
@@ -607,7 +609,11 @@ export default function AssistantBuilder({
 
     if (!res.ok) {
       const data = await res.json();
-      window.alert(`Error deleting Assistant: ${data.error.message}`);
+      sendNotification({
+        title: "Error deleting Assistant",
+        description: data.error.message,
+        type: "error",
+      });
       setIsSavingOrDeleting(false);
       return;
     }
@@ -712,10 +718,11 @@ export default function AssistantBuilder({
                         })
                         .catch((e) => {
                           console.error(e);
-                          alert(
-                            "An error occured while saving your agent." +
-                              " Please try again. If the error persists, pease reach out to team@dust.tt"
-                          );
+                          sendNotification({
+                            title: "Error saving Assistant",
+                            description: `Please try again. If the error persists, pease reach out to team@dust.tt (error ${e.message})`,
+                            type: "error",
+                          });
                           setIsSavingOrDeleting(false);
                         });
                     }

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -975,19 +975,32 @@ export default function AssistantBuilder({
               <>
                 <div>
                   The assistant will perform a search on the selected data
-                  source, run the instructions on the results.
+                  source, run the instructions on the results.{" "}
                   <span className="font-semibold">
-                    It’s the best approach with large quantity of data.
+                    It’s the best approach with large quantities of data.
                   </span>
                 </div>
                 <div className="grid grid-cols-2 gap-4">
                   <div>
-                    <strong>Select your sources with care</strong>
-                    The quality of the answers to specific questions will depend
-                    on the quality of the data.
+                    <p>
+                      <strong>Select your sources with care</strong> The quality
+                      of the answers to specific questions will depend on the
+                      quality of the data.
+                    </p>
+                    <p>
+                      <strong>
+                        You can narrow your search on most recent documents
+                      </strong>{" "}
+                      by adding instructions in your prompt such as 'Only search
+                      in documents from the last 3 months', 'Only look at data
+                      from the last 2 days', etc.
+                    </p>
                   </div>
                   <div>
-                    The available data sources are managed by administrators.
+                    <p>
+                      <strong>Note:</strong> The available data sources are
+                      managed by administrators.
+                    </p>
                   </div>
                 </div>
 

--- a/front/components/assistant_builder/DataSourceSelectionSection.tsx
+++ b/front/components/assistant_builder/DataSourceSelectionSection.tsx
@@ -3,37 +3,22 @@ import {
   CloudArrowDownIcon,
   Cog6ToothIcon,
   ContextItem,
-  DropdownMenu,
   PlusIcon,
   TrashIcon,
 } from "@dust-tt/sparkle";
-import { Transition } from "@headlessui/react";
 
 import { AssistantBuilderDataSourceConfiguration } from "@app/components/assistant_builder/AssistantBuilder";
-import {
-  CONNECTOR_PROVIDER_TO_RESOURCE_NAME,
-  FILTERING_MODE_TO_LABEL,
-  FilteringMode,
-  TIME_FRAME_UNIT_TO_LABEL,
-} from "@app/components/assistant_builder/shared";
+import { CONNECTOR_PROVIDER_TO_RESOURCE_NAME } from "@app/components/assistant_builder/shared";
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 import { classNames } from "@app/lib/utils";
-import { TimeframeUnit } from "@app/types/assistant/actions/retrieval";
 
 export default function DataSourceSelectionSection({
-  show,
   dataSourceConfigurations,
   openDataSourceModal,
   canAddDataSource,
   onManageDataSource,
   onDelete,
-  filteringMode,
-  setFilteringMode,
-  timeFrame,
-  setTimeFrame,
-  timeFrameError,
 }: {
-  show: boolean;
   dataSourceConfigurations: Record<
     string,
     AssistantBuilderDataSourceConfiguration
@@ -42,253 +27,113 @@ export default function DataSourceSelectionSection({
   canAddDataSource: boolean;
   onManageDataSource: (name: string) => void;
   onDelete?: (name: string) => void;
-  filteringMode: FilteringMode;
-  setFilteringMode: (filteringMode: FilteringMode) => void;
-  timeFrame: { value: number; unit: TimeframeUnit };
-  setTimeFrame: (timeframe: { value: number; unit: TimeframeUnit }) => void;
-  timeFrameError: string | null;
 }) {
   return (
-    <Transition
-      show={show}
-      enterFrom="opacity-0"
-      enterTo="opacity-100"
-      leave="transition-all duration-300"
-      enter="transition-all duration-300"
-      leaveFrom="opacity-100"
-      leaveTo="opacity-0"
-      className="overflow-hidden pt-6"
-      afterEnter={() => {
-        window.scrollBy({
-          left: 0,
-          top: 140,
-          behavior: "smooth",
-        });
-      }}
-    >
-      <div>
-        <div className="flex flex-row items-start">
-          <div className="pb-3 text-sm font-bold">Select the Data Sources:</div>
-          <div className="flex-grow" />
-          {Object.keys(dataSourceConfigurations).length > 0 && (
-            <Button
-              labelVisible={true}
-              label="Add Data Sources"
-              variant="primary"
-              size="sm"
-              icon={PlusIcon}
-              onClick={openDataSourceModal}
-              disabled={!canAddDataSource}
-              hasMagnifying={false}
-            />
-          )}
-        </div>
-        {!Object.keys(dataSourceConfigurations).length ? (
-          <div
-            className={classNames(
-              "flex h-full min-h-48 items-center justify-center rounded-lg bg-structure-50"
-            )}
-          >
-            <Button
-              labelVisible={true}
-              label="Add Data Sources"
-              variant="primary"
-              size="md"
-              icon={PlusIcon}
-              onClick={openDataSourceModal}
-              disabled={!canAddDataSource}
-            />
-          </div>
-        ) : (
-          <ContextItem.List className="mt-6 border-b border-t border-structure-200">
-            {Object.entries(dataSourceConfigurations).map(
-              ([key, { dataSource, selectedResources, isSelectAll }]) => {
-                const selectedParentIds = Object.keys(selectedResources);
-                return (
-                  <ContextItem
-                    key={key}
-                    title={
-                      dataSource.connectorProvider
-                        ? CONNECTOR_CONFIGURATIONS[dataSource.connectorProvider]
-                            .name
-                        : dataSource.name
-                    }
-                    visual={
-                      <ContextItem.Visual
-                        visual={
-                          dataSource.connectorProvider
-                            ? CONNECTOR_CONFIGURATIONS[
-                                dataSource.connectorProvider
-                              ].logoComponent
-                            : CloudArrowDownIcon
-                        }
-                      />
-                    }
-                    action={
-                      <Button.List>
-                        <Button
-                          icon={TrashIcon}
-                          variant="secondaryWarning"
-                          label="Remove"
-                          labelVisible={false}
-                          onClick={() => {
-                            onDelete?.(key);
-                          }}
-                        />
-                        <Button
-                          variant="secondary"
-                          icon={Cog6ToothIcon}
-                          label="Manage"
-                          size="sm"
-                          onClick={() => {
-                            onManageDataSource(key);
-                          }}
-                          disabled={dataSource.connectorProvider === null}
-                        />
-                      </Button.List>
-                    }
-                  >
-                    <ContextItem.Description
-                      description={
-                        dataSource.connectorProvider && !isSelectAll
-                          ? `Assistant has access to ${
-                              selectedParentIds.length
-                            } ${
-                              selectedParentIds.length === 1
-                                ? CONNECTOR_PROVIDER_TO_RESOURCE_NAME[
-                                    dataSource.connectorProvider
-                                  ].singular
-                                : CONNECTOR_PROVIDER_TO_RESOURCE_NAME[
-                                    dataSource.connectorProvider
-                                  ].plural
-                            }`
-                          : "Assistant has access to all documents"
-                      }
-                    />
-                  </ContextItem>
-                );
-              }
-            )}
-          </ContextItem.List>
+    <div className="overflow-hidden">
+      <div className="flex flex-row items-start">
+        <div className="pb-3 text-sm font-bold">Select the Data Sources:</div>
+        <div className="flex-grow" />
+        {Object.keys(dataSourceConfigurations).length > 0 && (
+          <Button
+            labelVisible={true}
+            label="Add Data Sources"
+            variant="primary"
+            size="sm"
+            icon={PlusIcon}
+            onClick={openDataSourceModal}
+            disabled={!canAddDataSource}
+            hasMagnifying={false}
+          />
         )}
       </div>
-      <div>
-        <div className="flex flex-row items-center space-x-2 pt-4">
-          <div className="text-sm font-semibold text-element-900">
-            Filtering:
-          </div>
-          <DropdownMenu>
-            <DropdownMenu.Button>
-              <Button
-                type="select"
-                labelVisible={true}
-                label={FILTERING_MODE_TO_LABEL[filteringMode]}
-                variant="secondary"
-                size="sm"
-              />
-            </DropdownMenu.Button>
-            <DropdownMenu.Items origin="bottomRight">
-              {Object.entries(FILTERING_MODE_TO_LABEL).map(([key, value]) => (
-                <DropdownMenu.Item
-                  key={key}
-                  label={value}
-                  onClick={() => {
-                    setFilteringMode(key as FilteringMode);
-                  }}
-                />
-              ))}
-            </DropdownMenu.Items>
-          </DropdownMenu>
+      {!Object.keys(dataSourceConfigurations).length ? (
+        <div
+          className={classNames(
+            "flex h-full min-h-48 items-center justify-center rounded-lg bg-structure-50"
+          )}
+        >
+          <Button
+            labelVisible={true}
+            label="Add Data Sources"
+            variant="primary"
+            size="md"
+            icon={PlusIcon}
+            onClick={openDataSourceModal}
+            disabled={!canAddDataSource}
+          />
         </div>
-        <div className="mt-4">
-          <Transition
-            show={filteringMode === "TIMEFRAME"}
-            enterFrom="opacity-0"
-            enterTo="opacity-100"
-            leave="transition-all duration-300"
-            enter="transition-all duration-300"
-            leaveFrom="opacity-100"
-            leaveTo="opacity-0"
-            className=""
-            afterEnter={() => {
-              window.scrollBy({
-                left: 0,
-                top: 70,
-                behavior: "smooth",
-              });
-            }}
-          >
-            <div className={"flex flex-row items-center gap-4 pb-4"}>
-              <div className="text-sm font-semibold text-element-900">
-                Collect data from the last
-              </div>
-              <input
-                type="text"
-                className={classNames(
-                  "h-8 w-16 rounded-md border-gray-300 text-center text-sm",
-                  !timeFrameError
-                    ? "focus:border-action-500 focus:ring-action-500"
-                    : "border-red-500 focus:border-red-500 focus:ring-red-500",
-                  "bg-structure-50 stroke-structure-50"
-                )}
-                value={timeFrame.value || ""}
-                onChange={(e) => {
-                  const value = parseInt(e.target.value, 10);
-                  if (!isNaN(value) || !e.target.value) {
-                    setTimeFrame({
-                      value,
-                      unit: timeFrame.unit,
-                    });
+      ) : (
+        <ContextItem.List className="mt-6 border-b border-t border-structure-200">
+          {Object.entries(dataSourceConfigurations).map(
+            ([key, { dataSource, selectedResources, isSelectAll }]) => {
+              const selectedParentIds = Object.keys(selectedResources);
+              return (
+                <ContextItem
+                  key={key}
+                  title={
+                    dataSource.connectorProvider
+                      ? CONNECTOR_CONFIGURATIONS[dataSource.connectorProvider]
+                          .name
+                      : dataSource.name
                   }
-                }}
-              />
-              <DropdownMenu>
-                <DropdownMenu.Button tooltipPosition="above">
-                  <Button
-                    type="select"
-                    labelVisible={true}
-                    label={TIME_FRAME_UNIT_TO_LABEL[timeFrame.unit]}
-                    variant="secondary"
-                    size="sm"
-                  />
-                </DropdownMenu.Button>
-                <DropdownMenu.Items origin="bottomLeft">
-                  {Object.entries(TIME_FRAME_UNIT_TO_LABEL).map(
-                    ([key, value]) => (
-                      <DropdownMenu.Item
-                        key={key}
-                        label={value}
+                  visual={
+                    <ContextItem.Visual
+                      visual={
+                        dataSource.connectorProvider
+                          ? CONNECTOR_CONFIGURATIONS[
+                              dataSource.connectorProvider
+                            ].logoComponent
+                          : CloudArrowDownIcon
+                      }
+                    />
+                  }
+                  action={
+                    <Button.List>
+                      <Button
+                        icon={TrashIcon}
+                        variant="secondaryWarning"
+                        label="Remove"
+                        labelVisible={false}
                         onClick={() => {
-                          setTimeFrame({
-                            value: timeFrame.value,
-                            unit: key as TimeframeUnit,
-                          });
+                          onDelete?.(key);
                         }}
                       />
-                    )
-                  )}
-                </DropdownMenu.Items>
-              </DropdownMenu>
-            </div>
-          </Transition>
-        </div>
-        <div className="text-sm font-normal text-element-700">
-          {filteringMode === "TIMEFRAME" ? (
-            <>
-              The assistant will look exhaustively at all data in the data
-              sources, in reverse chronological order, for the specified
-              timeframe. It will take as much data as it can in its context, and
-              warn you if it could not process all of it.
-            </>
-          ) : (
-            <>
-              The assistant will search the data sources for data that best
-              matches the user query, to retrieve information related to the
-              question.
-            </>
+                      <Button
+                        variant="secondary"
+                        icon={Cog6ToothIcon}
+                        label="Manage"
+                        size="sm"
+                        onClick={() => {
+                          onManageDataSource(key);
+                        }}
+                        disabled={dataSource.connectorProvider === null}
+                      />
+                    </Button.List>
+                  }
+                >
+                  <ContextItem.Description
+                    description={
+                      dataSource.connectorProvider && !isSelectAll
+                        ? `Assistant has access to ${
+                            selectedParentIds.length
+                          } ${
+                            selectedParentIds.length === 1
+                              ? CONNECTOR_PROVIDER_TO_RESOURCE_NAME[
+                                  dataSource.connectorProvider
+                                ].singular
+                              : CONNECTOR_PROVIDER_TO_RESOURCE_NAME[
+                                  dataSource.connectorProvider
+                                ].plural
+                          }`
+                        : "Assistant has access to all documents"
+                    }
+                  />
+                </ContextItem>
+              );
+            }
           )}
-        </div>
-      </div>
-    </Transition>
+        </ContextItem.List>
+      )}
+    </div>
   );
 }

--- a/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
@@ -160,26 +160,26 @@ export default function EditAssistant({
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   let actionMode: AssistantBuilderInitialState["actionMode"] = "GENERIC";
 
-  let filteringMode: AssistantBuilderInitialState["filteringMode"] = null;
   let timeFrame: AssistantBuilderInitialState["timeFrame"] = null;
 
   if (isRetrievalConfiguration(agentConfiguration.action)) {
-    actionMode = "RETRIEVAL";
-    if (agentConfiguration.action?.relativeTimeFrame) {
-      switch (agentConfiguration.action.relativeTimeFrame) {
-        case "auto":
-          filteringMode = "SEARCH";
-          break;
-        case "none":
-          filteringMode = "SEARCH";
-          break;
-        default:
-          filteringMode = "TIMEFRAME";
-          timeFrame = {
-            value: agentConfiguration.action.relativeTimeFrame.duration,
-            unit: agentConfiguration.action.relativeTimeFrame.unit,
-          };
+    if (agentConfiguration.action.query === "none") {
+      if (
+        agentConfiguration.action.relativeTimeFrame === "auto" ||
+        agentConfiguration.action.relativeTimeFrame === "none"
+      ) {
+        throw new Error(
+          "Invalid configuration: exhaustive retrieval must have a definite time frame"
+        );
       }
+      actionMode = "RETRIEVAL_EXHAUSTIVE";
+      timeFrame = {
+        value: agentConfiguration.action.relativeTimeFrame.duration,
+        unit: agentConfiguration.action.relativeTimeFrame.unit,
+      };
+    }
+    if (agentConfiguration.action.query === "auto") {
+      actionMode = "RETRIEVAL_SEARCH";
     }
   }
 
@@ -196,7 +196,6 @@ export default function EditAssistant({
       dustApps={dustApps}
       initialBuilderState={{
         actionMode,
-        filteringMode,
         timeFrame,
         dataSourceConfigurations,
         dustAppConfiguration,

--- a/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
@@ -168,6 +168,7 @@ export default function EditAssistant({
         agentConfiguration.action.relativeTimeFrame === "auto" ||
         agentConfiguration.action.relativeTimeFrame === "none"
       ) {
+        /** Should never happen. Throw loudly if it does */
         throw new Error(
           "Invalid configuration: exhaustive retrieval must have a definite time frame"
         );


### PR DESCRIPTION
Related [task](https://github.com/dust-tt/dust/issues/2083) with figma inside

Side technical notes:
- refactored custom timeframe logic out of the datasourceselectionsection component
- a few classNames were changed to map to figma
- added explanations for how to limit search to recent documents.
- turned alerts in notifications
- transitions slide rather than block bluntly disappearing


![image](https://github.com/dust-tt/dust/assets/5437393/f89c0bae-6596-489e-83d1-79db6f8e60e6)
![Screenshot from 2023-10-23 09-09-01](https://github.com/dust-tt/dust/assets/5437393/447d4ebb-990f-4158-9f3e-72876aa3bbbe)
