### PR TITLE
Use new Plan models

### DIFF
--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -17,7 +17,8 @@ import {
 } from "@app/lib/plans/free_plans";
 import {
   getActiveWorkspacePlan,
-  internalSubscribeWorkspaceToFreePlan,
+  internalSubscribeWorkspaceToFreeTestPlan,
+  internalSubscribeWorkspaceToFreeUpgradedPlan,
 } from "@app/lib/plans/subscription";
 import { generateModelSId } from "@app/lib/utils";
 
@@ -108,9 +109,8 @@ const workspace = async (command: string, args: parseArgs.ParsedArgs) => {
         sId: generateModelSId(),
         name: args.name,
       });
-      await internalSubscribeWorkspaceToFreePlan({
+      await internalSubscribeWorkspaceToFreeTestPlan({
         workspaceModelId: w.id,
-        planCode: FREE_TEST_PLAN_CODE,
       });
 
       args.wId = w.sId;
@@ -118,7 +118,7 @@ const workspace = async (command: string, args: parseArgs.ParsedArgs) => {
       return;
     }
 
-    case "subscribe-plan-free-trial": {
+    case "subscribe-plan-free-upgraded": {
       if (!args.wId) {
         throw new Error("Missing --wId argument");
       }
@@ -132,15 +132,14 @@ const workspace = async (command: string, args: parseArgs.ParsedArgs) => {
         throw new Error(`Workspace not found: wId='${args.wId}'`);
       }
 
-      await internalSubscribeWorkspaceToFreePlan({
+      await internalSubscribeWorkspaceToFreeUpgradedPlan({
         workspaceModelId: w.id,
-        planCode: FREE_UPGRADED_PLAN_CODE,
       });
       await workspace("show", args);
       return;
     }
 
-    case "subscribe-plan-test": {
+    case "subscribe-plan-free-test": {
       if (!args.wId) {
         throw new Error("Missing --wId argument");
       }
@@ -154,9 +153,8 @@ const workspace = async (command: string, args: parseArgs.ParsedArgs) => {
         throw new Error(`Workspace not found: wId='${args.wId}'`);
       }
 
-      await internalSubscribeWorkspaceToFreePlan({
+      await internalSubscribeWorkspaceToFreeTestPlan({
         workspaceModelId: w.id,
-        planCode: FREE_TEST_PLAN_CODE,
       });
       await workspace("show", args);
       return;

--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -12,8 +12,8 @@ import {
   Workspace,
 } from "@app/lib/models";
 import {
-  FREE_TRIAL_PLAN_CODE,
-  TEST_PLAN_CODE,
+  FREE_TEST_PLAN_CODE,
+  FREE_UPGRADED_PLAN_CODE,
 } from "@app/lib/plans/free_plans";
 import {
   getActiveWorkspacePlan,
@@ -110,7 +110,7 @@ const workspace = async (command: string, args: parseArgs.ParsedArgs) => {
       });
       await internalSubscribeWorkspaceToFreePlan({
         workspaceModelId: w.id,
-        planCode: TEST_PLAN_CODE,
+        planCode: FREE_TEST_PLAN_CODE,
       });
 
       args.wId = w.sId;
@@ -134,7 +134,7 @@ const workspace = async (command: string, args: parseArgs.ParsedArgs) => {
 
       await internalSubscribeWorkspaceToFreePlan({
         workspaceModelId: w.id,
-        planCode: FREE_TRIAL_PLAN_CODE,
+        planCode: FREE_UPGRADED_PLAN_CODE,
       });
       await workspace("show", args);
       return;
@@ -156,7 +156,7 @@ const workspace = async (command: string, args: parseArgs.ParsedArgs) => {
 
       await internalSubscribeWorkspaceToFreePlan({
         workspaceModelId: w.id,
-        planCode: TEST_PLAN_CODE,
+        planCode: FREE_TEST_PLAN_CODE,
       });
       await workspace("show", args);
       return;

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -214,9 +214,7 @@ export default function AssistantBuilder({
     ...DEFAULT_ASSISTANT_STATE,
     generationSettings: {
       ...DEFAULT_ASSISTANT_STATE.generationSettings,
-      modelSettings: owner.plan.limits.largeModels
-        ? GPT_4_32K_MODEL_CONFIG
-        : GPT_3_5_TURBO_16K_MODEL_CONFIG,
+      modelSettings: GPT_4_32K_MODEL_CONFIG,
     },
   });
   const [showDataSourcesModal, setShowDataSourcesModal] = useState(false);
@@ -848,7 +846,6 @@ export default function AssistantBuilder({
                 />
               </div>
               <AdvancedSettings
-                owner={owner}
                 generationSettings={builderState.generationSettings}
                 setGenerationSettings={(generationSettings) => {
                   setEdited(true);
@@ -1277,11 +1274,9 @@ function AssistantBuilderTextArea({
 }
 
 function AdvancedSettings({
-  owner,
   generationSettings,
   setGenerationSettings,
 }: {
-  owner: WorkspaceType;
   generationSettings: AssistantBuilderState["generationSettings"];
   setGenerationSettings: (
     generationSettingsSettings: AssistantBuilderState["generationSettings"]
@@ -1318,27 +1313,22 @@ function AdvancedSettings({
                 />
               </DropdownMenu.Button>
               <DropdownMenu.Items origin="topLeft">
-                {usedModelConfigs
-                  .filter(
-                    (modelConfig) =>
-                      !modelConfig.largeModel || owner.plan.limits.largeModels
-                  )
-                  .map((modelConfig) => (
-                    <DropdownMenu.Item
-                      key={modelConfig.modelId}
-                      label={modelConfig.displayName}
-                      onClick={() => {
-                        setGenerationSettings({
-                          ...generationSettings,
-                          modelSettings: {
-                            modelId: modelConfig.modelId,
-                            providerId: modelConfig.providerId,
-                            // safe because the SupportedModel is derived from the SUPPORTED_MODEL_CONFIGS array
-                          } as SupportedModel,
-                        });
-                      }}
-                    />
-                  ))}
+                {usedModelConfigs.map((modelConfig) => (
+                  <DropdownMenu.Item
+                    key={modelConfig.modelId}
+                    label={modelConfig.displayName}
+                    onClick={() => {
+                      setGenerationSettings({
+                        ...generationSettings,
+                        modelSettings: {
+                          modelId: modelConfig.modelId,
+                          providerId: modelConfig.providerId,
+                          // safe because the SupportedModel is derived from the SUPPORTED_MODEL_CONFIGS array
+                        } as SupportedModel,
+                      });
+                    }}
+                  />
+                ))}
               </DropdownMenu.Items>
             </DropdownMenu>
           </div>

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -13,11 +13,7 @@ import {
   renderConversationForModel,
   runGeneration,
 } from "@app/lib/api/assistant/generation";
-import {
-  GPT_3_5_TURBO_16K_MODEL_CONFIG,
-  GPT_4_32K_MODEL_CONFIG,
-  GPT_4_MODEL_CONFIG,
-} from "@app/lib/assistant";
+import { GPT_4_32K_MODEL_CONFIG, GPT_4_MODEL_CONFIG } from "@app/lib/assistant";
 import { Authenticator } from "@app/lib/auth";
 import { Err, Ok, Result } from "@app/lib/result";
 import logger from "@app/logger/logger";
@@ -63,20 +59,10 @@ export async function generateActionInputs(
 
   const MIN_GENERATION_TOKENS = 2048;
 
-  const useLargeModels = auth.workspace()?.plan.limits.largeModels
-    ? true
-    : false;
-
-  let model: { providerId: string; modelId: string } = useLargeModels
-    ? {
-        providerId: GPT_4_32K_MODEL_CONFIG.providerId,
-        modelId: GPT_4_32K_MODEL_CONFIG.modelId,
-      }
-    : {
-        providerId: GPT_3_5_TURBO_16K_MODEL_CONFIG.providerId,
-        modelId: GPT_3_5_TURBO_16K_MODEL_CONFIG.modelId,
-      };
-
+  let model: { providerId: string; modelId: string } = {
+    providerId: GPT_4_32K_MODEL_CONFIG.providerId,
+    modelId: GPT_4_32K_MODEL_CONFIG.modelId,
+  };
   // Turn the conversation into a digest that can be presented to the model.
   const modelConversationRes = await renderConversationForModel({
     conversation,

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -5,11 +5,7 @@ import {
   getGlobalAgents,
   isGlobalAgentId,
 } from "@app/lib/api/assistant/global_agents";
-import {
-  getSupportedModelConfig,
-  isSupportedModel,
-  SupportedModel,
-} from "@app/lib/assistant";
+import { isSupportedModel, SupportedModel } from "@app/lib/assistant";
 import { Authenticator } from "@app/lib/auth";
 import { front_sequelize } from "@app/lib/databases";
 import {
@@ -185,14 +181,6 @@ export async function getAgentConfiguration(
       temperature: generationConfig.temperature,
       model,
     };
-
-    // Enforce plan limits: check if large models are allowed and act accordingly
-    if (
-      !owner.plan.limits.largeModels &&
-      getSupportedModelConfig(model).largeModel
-    ) {
-      return null;
-    }
   }
 
   return {
@@ -399,12 +387,6 @@ export async function createAgentGenerationConfiguration(
 
   if (temperature < 0) {
     throw new Error("Temperature must be positive.");
-  }
-  if (
-    getSupportedModelConfig(model).largeModel &&
-    !owner.plan.limits.largeModels
-  ) {
-    throw new Error("You need to upgrade your plan to use large models.");
   }
 
   const genConfig = await AgentGenerationConfiguration.create({

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -7,7 +7,6 @@ const readFileAsync = promisify(fs.readFile);
 import {
   CLAUDE_DEFAULT_MODEL_CONFIG,
   CLAUDE_INSTANT_DEFAULT_MODEL_CONFIG,
-  getSupportedModelConfig,
   GPT_3_5_TURBO_16K_MODEL_CONFIG,
   GPT_4_32K_MODEL_CONFIG,
   MISTRAL_7B_DEFAULT_MODEL_CONFIG,
@@ -75,19 +74,6 @@ async function _getHelperGlobalAgent(
   if (staticPrompt) {
     prompt = prompt + staticPrompt;
   }
-  const owner = auth.workspace();
-  if (!owner) {
-    throw new Error("Unexpected `auth` without `workspace`.");
-  }
-  const model = owner.plan.limits.largeModels
-    ? {
-        providerId: GPT_4_32K_MODEL_CONFIG.providerId,
-        modelId: GPT_4_32K_MODEL_CONFIG.modelId,
-      }
-    : {
-        providerId: GPT_3_5_TURBO_16K_MODEL_CONFIG.providerId,
-        modelId: GPT_3_5_TURBO_16K_MODEL_CONFIG.modelId,
-      };
 
   return {
     id: -1,
@@ -101,7 +87,10 @@ async function _getHelperGlobalAgent(
     generation: {
       id: -1,
       prompt: prompt,
-      model,
+      model: {
+        providerId: GPT_4_32K_MODEL_CONFIG.providerId,
+        modelId: GPT_4_32K_MODEL_CONFIG.modelId,
+      },
       temperature: 0.2,
     },
     action: null,
@@ -579,16 +568,6 @@ export async function getGlobalAgent(
       break;
     default:
       return null;
-  }
-  if (!agentConfiguration) return null;
-
-  // Enforce plan limits: check if large models are allowed and act accordingly
-  if (
-    !owner.plan.limits.largeModels &&
-    agentConfiguration.generation &&
-    getSupportedModelConfig(agentConfiguration.generation?.model).largeModel
-  ) {
-    agentConfiguration.status = "disabled_free_workspace";
   }
   return agentConfiguration;
 }

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -6,7 +6,6 @@ import {
   User,
   Workspace,
 } from "@app/lib/models";
-import { getActiveWorkspacePlan } from "@app/lib/plans/subscription";
 import { MembershipInvitationType } from "@app/types/membership_invitation";
 import { UserType, WorkspaceType } from "@app/types/user";
 
@@ -29,7 +28,6 @@ export async function getWorkspaceInfo(
     name: workspace.name,
     allowedDomain: workspace.allowedDomain,
     role: "none",
-    plan: await getActiveWorkspacePlan({ workspaceModelId: workspace.id }),
     upgradedAt: workspace.upgradedAt?.getTime() || null,
   };
 }

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -10,7 +10,7 @@ import { getActiveWorkspacePlan } from "@app/lib/plans/subscription";
 import { MembershipInvitationType } from "@app/types/membership_invitation";
 import { UserType, WorkspaceType } from "@app/types/user";
 
-export async function getWorkspaceInfos(
+export async function getWorkspaceInfo(
   wId: string
 ): Promise<WorkspaceType | null> {
   const workspace = await Workspace.findOne({

--- a/front/lib/models/plan.ts
+++ b/front/lib/models/plan.ts
@@ -117,7 +117,7 @@ export class Subscription extends Model<
   declare updatedAt: CreationOptional<Date>;
 
   declare sId: string; // unique
-  declare status: string; // "active" | "ended" | "cancelled"
+  declare status: "active" | "ended" | "cancelled";
   declare startDate: Date;
   declare endDate: Date | null;
 

--- a/front/lib/models/plan.ts
+++ b/front/lib/models/plan.ts
@@ -117,7 +117,7 @@ export class Subscription extends Model<
   declare updatedAt: CreationOptional<Date>;
 
   declare sId: string; // unique
-  declare status: string; // "active" | "ended"
+  declare status: string; // "active" | "ended" | "cancelled"
   declare startDate: Date;
   declare endDate: Date | null;
 
@@ -152,7 +152,7 @@ Subscription.init(
       type: DataTypes.STRING,
       allowNull: false,
       validate: {
-        isIn: [["active", "ended"]],
+        isIn: [["active", "ended", "cancelled"]],
       },
     },
     startDate: {
@@ -196,7 +196,7 @@ Subscription.addHook(
 
 // Plan <> Subscription relationship: attribute "planId" in Subscription
 Plan.hasMany(Subscription, {
-  foreignKey: { name: "workspaceId", allowNull: false },
+  foreignKey: { name: "planId", allowNull: false },
   onDelete: "CASCADE",
 });
 Subscription.belongsTo(Plan, {

--- a/front/lib/plans/free_plans.ts
+++ b/front/lib/plans/free_plans.ts
@@ -2,32 +2,45 @@ import { Attributes } from "sequelize";
 
 import { Plan } from "@app/lib/models";
 
-type PlanAttributes = Omit<Attributes<Plan>, "id" | "createdAt" | "updatedAt">;
-
-export const TEST_PLAN_CODE = "TEST_PLAN_V0";
-export const FREE_TRIAL_PLAN_CODE = "TRIAL_PLAN_V0";
+export type PlanAttributes = Omit<
+  Attributes<Plan>,
+  "id" | "createdAt" | "updatedAt"
+>;
 
 /**
- * This file is used to store the plans data.
- * We never delete plans, we only add new ones.
+ * We have 2 FREE plans:
+ * - The TEST plan, a free plan with strong limitations, used until the user subscribes to a paid plan.
+ * - The FREE_UPGRADED plan, a free plan with no limitations that won't be users for users that are not Dust once we have paid plans.
  */
+
+/**
+ * Our TEST plan is our default plan, when no subscription is ON.
+ * It is the only plan not stored in the database.
+ */
+export const FREE_TEST_PLAN_CODE = "FREE_TEST_PLAN";
+export const FREE_TEST_PLAN_DATA: PlanAttributes = {
+  code: FREE_TEST_PLAN_CODE,
+  name: "Test",
+  maxWeeklyMessages: 50,
+  maxUsersInWorkspace: 1,
+  isSlackbotAllowed: false,
+  isManagedSlackAllowed: false,
+  isManagedNotionAllowed: false,
+  isManagedGoogleDriveAllowed: false,
+  isManagedGithubAllowed: false,
+  maxNbStaticDataSources: 10,
+  maxNbStaticDocuments: 10,
+  maxSizeStaticDataSources: 2, // 2MB
+};
+
+/**
+ * Other FREE plans are stored in the database.
+ * We never remove anything from this list, we only add new plans and run a migration to create new subscriptions for them.
+ */
+export const FREE_UPGRADED_PLAN_CODE = "FREE_UPGRADED_PLAN";
 const FREE_PLANS_DATA: PlanAttributes[] = [
   {
-    code: "TEST_PLAN_V0",
-    name: "Test",
-    maxWeeklyMessages: 50,
-    maxUsersInWorkspace: 1,
-    isSlackbotAllowed: false,
-    isManagedSlackAllowed: false,
-    isManagedNotionAllowed: false,
-    isManagedGoogleDriveAllowed: false,
-    isManagedGithubAllowed: false,
-    maxNbStaticDataSources: 10,
-    maxNbStaticDocuments: 10,
-    maxSizeStaticDataSources: 2, // 2MB
-  },
-  {
-    code: "TRIAL_PLAN_V0",
+    code: FREE_UPGRADED_PLAN_CODE,
     name: "Free Trial",
     maxWeeklyMessages: -1,
     maxUsersInWorkspace: -1,
@@ -42,23 +55,30 @@ const FREE_PLANS_DATA: PlanAttributes[] = [
   },
 ];
 
+/**
+ * Function to call when we edit something in FREE_PLANS_DATA to update the database. It will create or update the plans.
+ */
 export const upsertFreePlans = async () => {
   for (const planData of FREE_PLANS_DATA) {
-    await _upsertFreePlan(planData);
+    const plan = await Plan.findOne({
+      where: {
+        code: planData.code,
+      },
+    });
+    if (plan === null) {
+      await Plan.create(planData);
+      console.log(`Free plan ${planData.code} created.`);
+    } else {
+      await plan.update(planData);
+      console.log(`Free plan ${planData.code} updated.`);
+    }
   }
 };
 
-const _upsertFreePlan = async (planData: PlanAttributes) => {
-  const plan = await Plan.findOne({
-    where: {
-      code: planData.code,
-    },
-  });
-  if (plan === null) {
-    await Plan.create(planData);
-    console.log(`Free plan ${planData.code} created.`);
-  } else {
-    await plan.update(planData);
-    console.log(`Free plan ${planData.code} updated.`);
-  }
-};
+/**
+ * We will have 2 Paid plans:
+ * - The PRO plan
+ * - The TEAM plan
+ *
+ * TBD below
+ */

--- a/front/lib/plans/free_plans.ts
+++ b/front/lib/plans/free_plans.ts
@@ -4,6 +4,9 @@ import { Plan } from "@app/lib/models";
 
 type PlanAttributes = Omit<Attributes<Plan>, "id" | "createdAt" | "updatedAt">;
 
+export const TEST_PLAN_CODE = "TEST_PLAN_V0";
+export const FREE_TRIAL_PLAN_CODE = "TRIAL_PLAN_V0";
+
 /**
  * This file is used to store the plans data.
  * We never delete plans, we only add new ones.
@@ -21,7 +24,7 @@ const FREE_PLANS_DATA: PlanAttributes[] = [
     isManagedGithubAllowed: false,
     maxNbStaticDataSources: 10,
     maxNbStaticDocuments: 10,
-    maxSizeStaticDataSources: 1000,
+    maxSizeStaticDataSources: 2, // 2MB
   },
   {
     code: "TRIAL_PLAN_V0",
@@ -35,7 +38,7 @@ const FREE_PLANS_DATA: PlanAttributes[] = [
     isManagedGithubAllowed: true,
     maxNbStaticDataSources: -1,
     maxNbStaticDocuments: -1,
-    maxSizeStaticDataSources: -1,
+    maxSizeStaticDataSources: 2, // 2MB
   },
 ];
 

--- a/front/lib/plans/subscription.ts
+++ b/front/lib/plans/subscription.ts
@@ -1,0 +1,171 @@
+import { front_sequelize, ModelId } from "@app/lib/databases";
+import { Plan, Subscription } from "@app/lib/models";
+import {
+  FREE_TRIAL_PLAN_CODE,
+  TEST_PLAN_CODE,
+} from "@app/lib/plans/free_plans";
+import { generateModelSId } from "@app/lib/utils";
+import logger from "@app/logger/logger";
+import { SubscribedPlanType } from "@app/types/user";
+
+export const getActiveWorkspacePlan = async ({
+  workspaceModelId,
+}: {
+  workspaceModelId: ModelId;
+}): Promise<SubscribedPlanType> => {
+  let plan = null;
+  let startDate = new Date();
+  let endDate = null;
+
+  const activeSubscription = await Subscription.findOne({
+    where: { workspaceId: workspaceModelId, status: "active" },
+  });
+
+  if (activeSubscription) {
+    plan = await Plan.findOne({
+      where: { id: activeSubscription.planId },
+    });
+    startDate = activeSubscription.startDate;
+    endDate = activeSubscription.endDate;
+  }
+
+  // This should never happen, all workspace should have an active subscription
+  // If it happens we log and error that requires immediate fix.
+  // We return the free test plan to avoid breaking the app
+  if (!activeSubscription || !plan) {
+    logger.error(
+      { workspaceModelId },
+      "Cannot find active subscription or plan for workspace. Please fix ASAP. Returning a free plan."
+    );
+    plan = await Plan.findOne({
+      where: { code: TEST_PLAN_CODE },
+    });
+    if (!plan) {
+      throw new Error(`Cannot find free plan ${TEST_PLAN_CODE}.`);
+    }
+  }
+
+  return {
+    code: plan.code,
+    name: plan.name,
+    startDate: startDate?.getTime(),
+    endDate: endDate?.getTime() || null,
+    limits: {
+      assistant: {
+        isSlackBotAllowed: plan.isSlackbotAllowed,
+        maxWeeklyMessages: plan.maxWeeklyMessages,
+      },
+      managedDataSources: {
+        isSlackAllowed: plan.isManagedSlackAllowed,
+        isNotionAllowed: plan.isManagedNotionAllowed,
+        isGoogleDriveAllowed: plan.isManagedGoogleDriveAllowed,
+        isGithubAllowed: plan.isManagedGithubAllowed,
+      },
+      staticDataSources: {
+        count: plan.maxNbStaticDataSources,
+        documents: {
+          count: plan.maxNbStaticDocuments,
+          sizeMb: plan.maxSizeStaticDataSources,
+        },
+      },
+      users: {
+        maxUsers: plan.maxUsersInWorkspace,
+      },
+    },
+  };
+};
+
+/**
+ * Internal function to subscribe a workspace to a free plan.
+ * Used to subscribe to free Test plan or free Trial plan only.
+ */
+export const internalSubscribeWorkspaceToFreePlan = async ({
+  workspaceModelId,
+  planCode,
+}: {
+  workspaceModelId: ModelId;
+  planCode: string;
+}): Promise<SubscribedPlanType> => {
+  if (planCode !== TEST_PLAN_CODE && planCode !== FREE_TRIAL_PLAN_CODE) {
+    throw new Error(`Cannot subscribe to plan ${planCode}:  not found.`);
+  }
+  const newPlan = await Plan.findOne({
+    where: { code: planCode },
+  });
+  if (!newPlan) {
+    throw new Error(`Cannot subscribe to plan ${planCode}:  not found.`);
+  }
+  const activeSubscription = await Subscription.findOne({
+    where: { workspaceId: workspaceModelId, status: "active" },
+  });
+  if (activeSubscription && activeSubscription.planId === newPlan.id) {
+    throw new Error(
+      `Cannot subscribe to plan ${planCode}:  already subscribed.`
+    );
+  }
+
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  return await front_sequelize.transaction(async (t) => {
+    // We end the active subscription if any: status is set to ended yesterday, or cancelled if we both subscribed and cancelled on the same day.
+    if (activeSubscription) {
+      const yesterday = new Date(today);
+      yesterday.setDate(yesterday.getDate() - 1);
+
+      if (activeSubscription.startDate >= today) {
+        await activeSubscription.update(
+          { status: "cancelled", endDate: today },
+          { transaction: t }
+        );
+      } else {
+        await activeSubscription.update(
+          { status: "ended", endDate: yesterday },
+          { transaction: t }
+        );
+      }
+    }
+
+    // We create a new subscription
+    const newSubscription = await Subscription.create(
+      {
+        sId: generateModelSId(),
+        workspaceId: workspaceModelId,
+        planId: newPlan.id,
+        status: "active",
+        startDate: today,
+      },
+      { transaction: t }
+    );
+
+    return {
+      code: newPlan.code,
+      name: newPlan.name,
+      status: newSubscription.status,
+      startDate: newSubscription.startDate?.getTime(),
+      endDate: newSubscription.endDate?.getTime() || null,
+      limits: {
+        assistant: {
+          isSlackBotAllowed: newPlan.isSlackbotAllowed,
+          maxWeeklyMessages: newPlan.maxWeeklyMessages,
+        },
+        managedDataSources: {
+          isSlackAllowed: newPlan.isManagedSlackAllowed,
+          isNotionAllowed: newPlan.isManagedNotionAllowed,
+          isGoogleDriveAllowed: newPlan.isManagedGoogleDriveAllowed,
+          isGithubAllowed: newPlan.isManagedGithubAllowed,
+        },
+        staticDataSources: {
+          count: newPlan.maxNbStaticDataSources,
+          documents: {
+            count: newPlan.maxNbStaticDocuments,
+            sizeMb: newPlan.maxSizeStaticDataSources,
+          },
+        },
+        users: {
+          maxUsers: newPlan.maxUsersInWorkspace,
+        },
+      },
+    };
+  });
+};

--- a/front/migrations/20230919_workspace_upgraded_at.ts
+++ b/front/migrations/20230919_workspace_upgraded_at.ts
@@ -31,7 +31,7 @@ async function main() {
 }
 
 async function markWorkspaceAsUpgraded(workspace: Workspace) {
-  if (!workspace.upgradedAt && workspace.plan) {
+  if (!workspace.upgradedAt) {
     const updatedAt = workspace.updatedAt;
     await workspace.update({
       upgradedAt: updatedAt,

--- a/front/migrations/20230922_workspace_plan_large_model.ts
+++ b/front/migrations/20230922_workspace_plan_large_model.ts
@@ -1,6 +1,5 @@
 import { Op } from "sequelize";
 
-import { planForWorkspace } from "@app/lib/auth";
 import { Workspace } from "@app/lib/models";
 
 async function main() {
@@ -24,22 +23,22 @@ async function main() {
 
   for (let i = 0; i < chunks.length; i++) {
     console.log(`Processing chunk ${i}/${chunks.length}...`);
-    const chunk = chunks[i];
-    await Promise.all(
-      chunk.map((workspace: Workspace) => {
-        return addLargeModelTrue(workspace);
-      })
-    );
+    // const chunk = chunks[i];
+    // await Promise.all(
+    //   chunk.map((workspace: Workspace) => {
+    //     return addLargeModelTrue(workspace);
+    //   })
+    // );
   }
 }
 
-async function addLargeModelTrue(workspace: Workspace) {
-  const plan = planForWorkspace(workspace);
-  plan.limits.largeModels = true;
-  await workspace.update({
-    plan: JSON.stringify(plan),
-  });
-}
+// async function addLargeModelTrue(workspace: Workspace) {
+//   const plan = planForWorkspace(workspace);
+//   plan.limits.largeModels = true;
+//   await workspace.update({
+//     plan: JSON.stringify(plan),
+//   });
+// }
 
 main()
   .then(() => {

--- a/front/migrations/20230929_enforce_1mb_even_for_upgraded_workspaces.ts
+++ b/front/migrations/20230929_enforce_1mb_even_for_upgraded_workspaces.ts
@@ -1,6 +1,6 @@
 import { Op } from "sequelize";
 
-import { planForWorkspace } from "@app/lib/auth";
+//import { planForWorkspace } from "@app/lib/auth";
 import { Workspace } from "@app/lib/models";
 
 const { LIVE = false } = process.env;
@@ -26,26 +26,26 @@ async function main() {
 
   for (let i = 0; i < chunks.length; i++) {
     console.log(`Processing chunk ${i}/${chunks.length}...`);
-    const chunk = chunks[i];
-    await Promise.all(
-      chunk.map((workspace: Workspace) => {
-        return set1MBLimit(!!LIVE, workspace);
-      })
-    );
+    // const chunk = chunks[i];
+    // await Promise.all(
+    //   chunk.map((workspace: Workspace) => {
+    //     return set1MBLimit(!!LIVE, workspace);
+    //   })
+    // );
   }
 }
 
-async function set1MBLimit(live: boolean, workspace: Workspace) {
-  const plan = planForWorkspace(workspace);
-  plan.limits.dataSources.documents.sizeMb = 2;
-  if (live) {
-    await workspace.update({
-      plan: JSON.stringify(plan),
-    });
-  } else {
-    console.log(`Would have mutated ${workspace.sId}`);
-  }
-}
+// async function set1MBLimit(live: boolean, workspace: Workspace) {
+//   const plan = planForWorkspace(workspace);
+//   plan.limits.dataSources.documents.sizeMb = 2;
+//   if (live) {
+//     await workspace.update({
+//       plan: JSON.stringify(plan),
+//     });
+//   } else {
+//     console.log(`Would have mutated ${workspace.sId}`);
+//   }
+// }
 
 main()
   .then(() => {

--- a/front/migrations/20231023_create_plan_subscriptions.ts
+++ b/front/migrations/20231023_create_plan_subscriptions.ts
@@ -1,0 +1,82 @@
+import { Plan, Subscription, Workspace } from "@app/lib/models";
+import {
+  FREE_TRIAL_PLAN_CODE,
+  TEST_PLAN_CODE,
+} from "@app/lib/plans/free_plans";
+import { generateModelSId } from "@app/lib/utils";
+
+async function main() {
+  const workspaces = await Workspace.findAll();
+
+  console.log(`Found ${workspaces.length} workspaces to update`);
+
+  const chunks = [];
+  for (let i = 0; i < workspaces.length; i += 16) {
+    chunks.push(workspaces.slice(i, i + 16));
+  }
+
+  const testPlan = await Plan.findOne({
+    where: {
+      code: TEST_PLAN_CODE,
+    },
+  });
+  const freeTrialPlan = await Plan.findOne({
+    where: {
+      code: FREE_TRIAL_PLAN_CODE,
+    },
+  });
+
+  if (!testPlan || !freeTrialPlan) {
+    console.error(`Cannot find test or free plan. Aborting.`);
+    return;
+  }
+
+  for (let i = 0; i < chunks.length; i++) {
+    console.log(`Processing chunk ${i}/${chunks.length}...`);
+    const chunk = chunks[i];
+    await Promise.all(
+      chunk.map(async (workspace: Workspace) => {
+        const activeSubscription = await Subscription.findOne({
+          where: { workspaceId: workspace.id, status: "active" },
+        });
+        if (activeSubscription) {
+          return;
+        }
+
+        if (workspace.upgradedAt) {
+          // We subscribe to Free Trial plan
+          const startDate = workspace.upgradedAt;
+          startDate.setHours(0, 0, 0, 0);
+          await Subscription.create({
+            sId: generateModelSId(),
+            workspaceId: workspace.id,
+            planId: freeTrialPlan.id,
+            status: "active",
+            startDate: startDate,
+          });
+        } else {
+          // We subscribe to Test plan
+          const startDate = workspace.createdAt;
+          startDate.setHours(0, 0, 0, 0);
+          await Subscription.create({
+            sId: generateModelSId(),
+            workspaceId: workspace.id,
+            planId: testPlan.id,
+            status: "active",
+            startDate: startDate,
+          });
+        }
+      })
+    );
+  }
+}
+
+main()
+  .then(() => {
+    console.log("Done");
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/front/migrations/20231023_create_plan_subscriptions.ts
+++ b/front/migrations/20231023_create_plan_subscriptions.ts
@@ -1,7 +1,7 @@
 import { Plan, Subscription, Workspace } from "@app/lib/models";
 import {
-  FREE_TRIAL_PLAN_CODE,
-  TEST_PLAN_CODE,
+  FREE_TEST_PLAN_CODE,
+  FREE_UPGRADED_PLAN_CODE,
 } from "@app/lib/plans/free_plans";
 import { generateModelSId } from "@app/lib/utils";
 
@@ -17,12 +17,12 @@ async function main() {
 
   const testPlan = await Plan.findOne({
     where: {
-      code: TEST_PLAN_CODE,
+      code: FREE_TEST_PLAN_CODE,
     },
   });
   const freeTrialPlan = await Plan.findOne({
     where: {
-      code: FREE_TRIAL_PLAN_CODE,
+      code: FREE_UPGRADED_PLAN_CODE,
     },
   });
 

--- a/front/migrations/20231023_create_plan_subscriptions.ts
+++ b/front/migrations/20231023_create_plan_subscriptions.ts
@@ -37,7 +37,7 @@ async function main() {
     await Promise.all(
       chunk.map(async (workspace: Workspace) => {
         const activeSubscription = await Subscription.findOne({
-          where: { workspaceId: workspace.id },
+          where: { workspaceId: workspace.id, status: "active" },
         });
         if (activeSubscription) {
           return;
@@ -51,6 +51,7 @@ async function main() {
             sId: generateModelSId(),
             workspaceId: workspace.id,
             planId: freeUpgradedPlan.id,
+            status: "active",
             startDate: startDate,
           });
         }

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -11,8 +11,8 @@ import {
   Workspace,
 } from "@app/lib/models";
 import {
-  FREE_TRIAL_PLAN_CODE,
-  TEST_PLAN_CODE,
+  FREE_TEST_PLAN_CODE,
+  FREE_UPGRADED_PLAN_CODE,
 } from "@app/lib/plans/free_plans";
 import { internalSubscribeWorkspaceToFreePlan } from "@app/lib/plans/subscription";
 import { guessFirstandLastNameFromFullName } from "@app/lib/user";
@@ -183,12 +183,12 @@ async function handler(
           if (EMAILS_TO_AUTO_UPGRADE.includes(user.email)) {
             await internalSubscribeWorkspaceToFreePlan({
               workspaceModelId: w.id,
-              planCode: FREE_TRIAL_PLAN_CODE,
+              planCode: FREE_UPGRADED_PLAN_CODE,
             });
           } else {
             await internalSubscribeWorkspaceToFreePlan({
               workspaceModelId: w.id,
-              planCode: TEST_PLAN_CODE,
+              planCode: FREE_TEST_PLAN_CODE,
             });
           }
           isAdminOnboarding = true;

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -11,10 +11,9 @@ import {
   Workspace,
 } from "@app/lib/models";
 import {
-  FREE_TEST_PLAN_CODE,
-  FREE_UPGRADED_PLAN_CODE,
-} from "@app/lib/plans/free_plans";
-import { internalSubscribeWorkspaceToFreePlan } from "@app/lib/plans/subscription";
+  internalSubscribeWorkspaceToFreeTestPlan,
+  internalSubscribeWorkspaceToFreeUpgradedPlan,
+} from "@app/lib/plans/subscription";
 import { guessFirstandLastNameFromFullName } from "@app/lib/user";
 import { generateModelSId } from "@app/lib/utils";
 import { apiError, withLogging } from "@app/logger/withlogging";
@@ -181,14 +180,12 @@ async function handler(
           });
 
           if (EMAILS_TO_AUTO_UPGRADE.includes(user.email)) {
-            await internalSubscribeWorkspaceToFreePlan({
+            await internalSubscribeWorkspaceToFreeUpgradedPlan({
               workspaceModelId: w.id,
-              planCode: FREE_UPGRADED_PLAN_CODE,
             });
           } else {
-            await internalSubscribeWorkspaceToFreePlan({
+            await internalSubscribeWorkspaceToFreeTestPlan({
               workspaceModelId: w.id,
-              planCode: FREE_TEST_PLAN_CODE,
             });
           }
           isAdminOnboarding = true;

--- a/front/pages/api/poke/workspaces/[wId]/downgrade.ts
+++ b/front/pages/api/poke/workspaces/[wId]/downgrade.ts
@@ -68,7 +68,7 @@ async function handler(
         });
       }
 
-      const plan = await internalSubscribeWorkspaceToFreeTestPlan({
+      await internalSubscribeWorkspaceToFreeTestPlan({
         workspaceModelId: workspace.id,
       });
 
@@ -79,7 +79,6 @@ async function handler(
           name: workspace.name,
           allowedDomain: workspace.allowedDomain || null,
           role: "admin",
-          plan,
           upgradedAt: workspace.upgradedAt?.getTime() || null,
         },
       });

--- a/front/pages/api/poke/workspaces/[wId]/downgrade.ts
+++ b/front/pages/api/poke/workspaces/[wId]/downgrade.ts
@@ -1,13 +1,10 @@
 import { NextApiRequest, NextApiResponse } from "next";
 
-import { downgradeWorkspace } from "@app/lib/api/workspace";
-import {
-  getSession,
-  getUserFromSession,
-  planForWorkspace,
-} from "@app/lib/auth";
+import { getSession, getUserFromSession } from "@app/lib/auth";
 import { ReturnedAPIErrorType } from "@app/lib/error";
 import { Workspace } from "@app/lib/models";
+import { TEST_PLAN_CODE } from "@app/lib/plans/free_plans";
+import { internalSubscribeWorkspaceToFreePlan } from "@app/lib/plans/subscription";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import { WorkspaceType } from "@app/types/user";
 
@@ -72,9 +69,10 @@ async function handler(
         });
       }
 
-      await downgradeWorkspace(workspace.id);
-
-      const plan = await planForWorkspace(workspace);
+      const plan = await internalSubscribeWorkspaceToFreePlan({
+        workspaceModelId: workspace.id,
+        planCode: TEST_PLAN_CODE,
+      });
 
       return res.status(200).json({
         workspace: {

--- a/front/pages/api/poke/workspaces/[wId]/downgrade.ts
+++ b/front/pages/api/poke/workspaces/[wId]/downgrade.ts
@@ -3,8 +3,7 @@ import { NextApiRequest, NextApiResponse } from "next";
 import { getSession, getUserFromSession } from "@app/lib/auth";
 import { ReturnedAPIErrorType } from "@app/lib/error";
 import { Workspace } from "@app/lib/models";
-import { FREE_TEST_PLAN_CODE } from "@app/lib/plans/free_plans";
-import { internalSubscribeWorkspaceToFreePlan } from "@app/lib/plans/subscription";
+import { internalSubscribeWorkspaceToFreeTestPlan } from "@app/lib/plans/subscription";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import { WorkspaceType } from "@app/types/user";
 
@@ -69,9 +68,8 @@ async function handler(
         });
       }
 
-      const plan = await internalSubscribeWorkspaceToFreePlan({
+      const plan = await internalSubscribeWorkspaceToFreeTestPlan({
         workspaceModelId: workspace.id,
-        planCode: FREE_TEST_PLAN_CODE,
       });
 
       return res.status(200).json({

--- a/front/pages/api/poke/workspaces/[wId]/downgrade.ts
+++ b/front/pages/api/poke/workspaces/[wId]/downgrade.ts
@@ -3,7 +3,7 @@ import { NextApiRequest, NextApiResponse } from "next";
 import { getSession, getUserFromSession } from "@app/lib/auth";
 import { ReturnedAPIErrorType } from "@app/lib/error";
 import { Workspace } from "@app/lib/models";
-import { TEST_PLAN_CODE } from "@app/lib/plans/free_plans";
+import { FREE_TEST_PLAN_CODE } from "@app/lib/plans/free_plans";
 import { internalSubscribeWorkspaceToFreePlan } from "@app/lib/plans/subscription";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import { WorkspaceType } from "@app/types/user";
@@ -71,7 +71,7 @@ async function handler(
 
       const plan = await internalSubscribeWorkspaceToFreePlan({
         workspaceModelId: workspace.id,
-        planCode: TEST_PLAN_CODE,
+        planCode: FREE_TEST_PLAN_CODE,
       });
 
       return res.status(200).json({

--- a/front/pages/api/poke/workspaces/[wId]/upgrade.ts
+++ b/front/pages/api/poke/workspaces/[wId]/upgrade.ts
@@ -1,13 +1,10 @@
 import { NextApiRequest, NextApiResponse } from "next";
 
-import { upgradeWorkspace } from "@app/lib/api/workspace";
-import {
-  getSession,
-  getUserFromSession,
-  planForWorkspace,
-} from "@app/lib/auth";
+import { getSession, getUserFromSession } from "@app/lib/auth";
 import { ReturnedAPIErrorType } from "@app/lib/error";
 import { Workspace } from "@app/lib/models";
+import { FREE_TRIAL_PLAN_CODE } from "@app/lib/plans/free_plans";
+import { internalSubscribeWorkspaceToFreePlan } from "@app/lib/plans/subscription";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import { WorkspaceType } from "@app/types/user";
 
@@ -72,8 +69,10 @@ async function handler(
         });
       }
 
-      await upgradeWorkspace(workspace.id);
-      const plan = await planForWorkspace(workspace);
+      const plan = await internalSubscribeWorkspaceToFreePlan({
+        workspaceModelId: workspace.id,
+        planCode: FREE_TRIAL_PLAN_CODE,
+      });
 
       return res.status(200).json({
         workspace: {

--- a/front/pages/api/poke/workspaces/[wId]/upgrade.ts
+++ b/front/pages/api/poke/workspaces/[wId]/upgrade.ts
@@ -68,7 +68,7 @@ async function handler(
         });
       }
 
-      const plan = await internalSubscribeWorkspaceToFreeUpgradedPlan({
+      await internalSubscribeWorkspaceToFreeUpgradedPlan({
         workspaceModelId: workspace.id,
       });
 
@@ -79,7 +79,6 @@ async function handler(
           name: workspace.name,
           allowedDomain: workspace.allowedDomain || null,
           role: "admin",
-          plan,
           upgradedAt: workspace.upgradedAt?.getTime() || null,
         },
       });

--- a/front/pages/api/poke/workspaces/[wId]/upgrade.ts
+++ b/front/pages/api/poke/workspaces/[wId]/upgrade.ts
@@ -3,8 +3,7 @@ import { NextApiRequest, NextApiResponse } from "next";
 import { getSession, getUserFromSession } from "@app/lib/auth";
 import { ReturnedAPIErrorType } from "@app/lib/error";
 import { Workspace } from "@app/lib/models";
-import { FREE_UPGRADED_PLAN_CODE } from "@app/lib/plans/free_plans";
-import { internalSubscribeWorkspaceToFreePlan } from "@app/lib/plans/subscription";
+import { internalSubscribeWorkspaceToFreeUpgradedPlan } from "@app/lib/plans/subscription";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import { WorkspaceType } from "@app/types/user";
 
@@ -69,9 +68,8 @@ async function handler(
         });
       }
 
-      const plan = await internalSubscribeWorkspaceToFreePlan({
+      const plan = await internalSubscribeWorkspaceToFreeUpgradedPlan({
         workspaceModelId: workspace.id,
-        planCode: FREE_UPGRADED_PLAN_CODE,
       });
 
       return res.status(200).json({

--- a/front/pages/api/poke/workspaces/[wId]/upgrade.ts
+++ b/front/pages/api/poke/workspaces/[wId]/upgrade.ts
@@ -3,7 +3,7 @@ import { NextApiRequest, NextApiResponse } from "next";
 import { getSession, getUserFromSession } from "@app/lib/auth";
 import { ReturnedAPIErrorType } from "@app/lib/error";
 import { Workspace } from "@app/lib/models";
-import { FREE_TRIAL_PLAN_CODE } from "@app/lib/plans/free_plans";
+import { FREE_UPGRADED_PLAN_CODE } from "@app/lib/plans/free_plans";
 import { internalSubscribeWorkspaceToFreePlan } from "@app/lib/plans/subscription";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import { WorkspaceType } from "@app/types/user";
@@ -71,7 +71,7 @@ async function handler(
 
       const plan = await internalSubscribeWorkspaceToFreePlan({
         workspaceModelId: workspace.id,
-        planCode: FREE_TRIAL_PLAN_CODE,
+        planCode: FREE_UPGRADED_PLAN_CODE,
       });
 
       return res.status(200).json({

--- a/front/pages/api/poke/workspaces/index.ts
+++ b/front/pages/api/poke/workspaces/index.ts
@@ -1,18 +1,15 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import { FindOptions, Op, WhereOptions } from "sequelize";
 
-import {
-  getSession,
-  getUserFromSession,
-  planForWorkspace,
-} from "@app/lib/auth";
+import { getSession, getUserFromSession } from "@app/lib/auth";
 import { ReturnedAPIErrorType } from "@app/lib/error";
 import { Workspace } from "@app/lib/models";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import { WorkspaceType } from "@app/types/user";
 
+type WorkspaceWithoutPlan = Omit<WorkspaceType, "plan">;
 export type GetWorkspacesResponseBody = {
-  workspaces: WorkspaceType[];
+  workspaces: WorkspaceWithoutPlan[];
 };
 
 async function handler(
@@ -144,7 +141,6 @@ async function handler(
           sId: ws.sId,
           name: ws.name,
           allowedDomain: ws.allowedDomain || null,
-          plan: planForWorkspace(ws),
           role: "admin",
           upgradedAt: ws.upgradedAt?.getTime() || null,
         })),

--- a/front/pages/api/poke/workspaces/index.ts
+++ b/front/pages/api/poke/workspaces/index.ts
@@ -7,9 +7,8 @@ import { Workspace } from "@app/lib/models";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import { WorkspaceType } from "@app/types/user";
 
-type WorkspaceWithoutPlan = Omit<WorkspaceType, "plan">;
 export type GetWorkspacesResponseBody = {
-  workspaces: WorkspaceWithoutPlan[];
+  workspaces: WorkspaceType[];
 };
 
 async function handler(

--- a/front/pages/api/poke/workspaces/index.ts
+++ b/front/pages/api/poke/workspaces/index.ts
@@ -99,13 +99,13 @@ async function handler(
       if (upgraded !== undefined) {
         if (upgraded) {
           conditions.push({
-            plan: {
+            upgradedAt: {
               [Op.not]: null,
             },
           });
         } else {
           conditions.push({
-            plan: null,
+            upgradedAt: null,
           });
         }
       }

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
@@ -80,6 +80,8 @@ async function handler(
     });
   }
 
+  const plan = auth.plan();
+
   const dataSource = await getDataSource(auth, req.query.name as string);
 
   if (!dataSource) {
@@ -225,7 +227,7 @@ async function handler(
       // We only load the number of documents if the limit is not -1 (unlimited).
       // the `getDataSourceDocuments` query involves a SELECT COUNT(*) in the DB that is not
       // optimized, so we avoid it for large workspaces if we know we're unlimited anyway
-      if (owner.plan.limits.staticDataSources.documents.count != -1) {
+      if (plan.limits.staticDataSources.documents.count != -1) {
         const documents = await CoreAPI.getDataSourceDocuments({
           projectId: dataSource.dustAPIProjectId,
           dataSourceName: dataSource.name,
@@ -245,9 +247,8 @@ async function handler(
         }
 
         if (
-          owner.plan.limits.staticDataSources.documents.count != -1 &&
-          documents.value.total >=
-            owner.plan.limits.staticDataSources.documents.count
+          plan.limits.staticDataSources.documents.count != -1 &&
+          documents.value.total >= plan.limits.staticDataSources.documents.count
         ) {
           return apiError(req, res, {
             status_code: 401,
@@ -262,9 +263,9 @@ async function handler(
 
       // Enforce plan limits: DataSource document size.
       if (
-        owner.plan.limits.staticDataSources.documents.sizeMb != -1 &&
+        plan.limits.staticDataSources.documents.sizeMb != -1 &&
         req.body.text.length >
-          1024 * 1024 * owner.plan.limits.staticDataSources.documents.sizeMb
+          1024 * 1024 * plan.limits.staticDataSources.documents.sizeMb
       ) {
         return apiError(req, res, {
           status_code: 401,

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
@@ -225,7 +225,7 @@ async function handler(
       // We only load the number of documents if the limit is not -1 (unlimited).
       // the `getDataSourceDocuments` query involves a SELECT COUNT(*) in the DB that is not
       // optimized, so we avoid it for large workspaces if we know we're unlimited anyway
-      if (owner.plan.limits.dataSources.documents.count != -1) {
+      if (owner.plan.limits.staticDataSources.documents.count != -1) {
         const documents = await CoreAPI.getDataSourceDocuments({
           projectId: dataSource.dustAPIProjectId,
           dataSourceName: dataSource.name,
@@ -245,8 +245,9 @@ async function handler(
         }
 
         if (
-          owner.plan.limits.dataSources.documents.count != -1 &&
-          documents.value.total >= owner.plan.limits.dataSources.documents.count
+          owner.plan.limits.staticDataSources.documents.count != -1 &&
+          documents.value.total >=
+            owner.plan.limits.staticDataSources.documents.count
         ) {
           return apiError(req, res, {
             status_code: 401,
@@ -261,9 +262,9 @@ async function handler(
 
       // Enforce plan limits: DataSource document size.
       if (
-        owner.plan.limits.dataSources.documents.sizeMb != -1 &&
+        owner.plan.limits.staticDataSources.documents.sizeMb != -1 &&
         req.body.text.length >
-          1024 * 1024 * owner.plan.limits.dataSources.documents.sizeMb
+          1024 * 1024 * owner.plan.limits.staticDataSources.documents.sizeMb
       ) {
         return apiError(req, res, {
           status_code: 401,

--- a/front/pages/api/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
@@ -143,7 +143,7 @@ async function handler(
       // We only load the number of documents if the limit is not -1 (unlimited).
       // the `getDataSourceDocuments` query involves a SELECT COUNT(*) in the DB that is not
       // optimized, so we avoid it for large workspaces if we know we're unlimited anyway
-      if (owner.plan.limits.dataSources.documents.count != -1) {
+      if (owner.plan.limits.staticDataSources.documents.count != -1) {
         const documents = await CoreAPI.getDataSourceDocuments({
           projectId: dataSource.dustAPIProjectId,
           dataSourceName: dataSource.name,
@@ -162,8 +162,9 @@ async function handler(
         }
 
         if (
-          owner.plan.limits.dataSources.documents.count != -1 &&
-          documents.value.total >= owner.plan.limits.dataSources.documents.count
+          owner.plan.limits.staticDataSources.documents.count != -1 &&
+          documents.value.total >=
+            owner.plan.limits.staticDataSources.documents.count
         ) {
           return apiError(req, res, {
             status_code: 401,
@@ -178,9 +179,9 @@ async function handler(
 
       // Enforce plan limits: DataSource document size.
       if (
-        owner.plan.limits.dataSources.documents.sizeMb != -1 &&
+        owner.plan.limits.staticDataSources.documents.sizeMb != -1 &&
         req.body.text.length >
-          1024 * 1024 * owner.plan.limits.dataSources.documents.sizeMb
+          1024 * 1024 * owner.plan.limits.staticDataSources.documents.sizeMb
       ) {
         return apiError(req, res, {
           status_code: 401,

--- a/front/pages/api/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
@@ -33,6 +33,7 @@ async function handler(
       },
     });
   }
+  const plan = auth.plan();
 
   const dataSource = await getDataSource(auth, req.query.name as string);
 
@@ -143,7 +144,7 @@ async function handler(
       // We only load the number of documents if the limit is not -1 (unlimited).
       // the `getDataSourceDocuments` query involves a SELECT COUNT(*) in the DB that is not
       // optimized, so we avoid it for large workspaces if we know we're unlimited anyway
-      if (owner.plan.limits.staticDataSources.documents.count != -1) {
+      if (plan.limits.staticDataSources.documents.count != -1) {
         const documents = await CoreAPI.getDataSourceDocuments({
           projectId: dataSource.dustAPIProjectId,
           dataSourceName: dataSource.name,
@@ -162,9 +163,8 @@ async function handler(
         }
 
         if (
-          owner.plan.limits.staticDataSources.documents.count != -1 &&
-          documents.value.total >=
-            owner.plan.limits.staticDataSources.documents.count
+          plan.limits.staticDataSources.documents.count != -1 &&
+          documents.value.total >= plan.limits.staticDataSources.documents.count
         ) {
           return apiError(req, res, {
             status_code: 401,
@@ -179,9 +179,9 @@ async function handler(
 
       // Enforce plan limits: DataSource document size.
       if (
-        owner.plan.limits.staticDataSources.documents.sizeMb != -1 &&
+        plan.limits.staticDataSources.documents.sizeMb != -1 &&
         req.body.text.length >
-          1024 * 1024 * owner.plan.limits.staticDataSources.documents.sizeMb
+          1024 * 1024 * plan.limits.staticDataSources.documents.sizeMb
       ) {
         return apiError(req, res, {
           status_code: 401,

--- a/front/pages/api/w/[wId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/index.ts
@@ -90,8 +90,8 @@ async function handler(
 
       // Enforce plan limits: DataSources count.
       if (
-        owner.plan.limits.dataSources.count != -1 &&
-        dataSources.length >= owner.plan.limits.dataSources.count
+        owner.plan.limits.staticDataSources.count != -1 &&
+        dataSources.length >= owner.plan.limits.staticDataSources.count
       ) {
         return apiError(req, res, {
           status_code: 401,

--- a/front/pages/api/w/[wId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/index.ts
@@ -41,6 +41,7 @@ async function handler(
       },
     });
   }
+  const plan = auth.plan();
 
   const dataSources = await getDataSources(auth);
 
@@ -90,8 +91,8 @@ async function handler(
 
       // Enforce plan limits: DataSources count.
       if (
-        owner.plan.limits.staticDataSources.count != -1 &&
-        dataSources.length >= owner.plan.limits.staticDataSources.count
+        plan.limits.staticDataSources.count != -1 &&
+        dataSources.length >= plan.limits.staticDataSources.count
       ) {
         return apiError(req, res, {
           status_code: 401,

--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -117,8 +117,30 @@ async function handler(
       const dataSourceModelId = "text-embedding-ada-002";
       const dataSourceMaxChunkSize = 256;
 
+      let isDataSourceAllowedInPlan: boolean;
+      switch (provider) {
+        case "slack":
+          isDataSourceAllowedInPlan =
+            owner.plan.limits.managedDataSources.isSlackAllowed;
+          break;
+        case "notion":
+          isDataSourceAllowedInPlan =
+            owner.plan.limits.managedDataSources.isNotionAllowed;
+          break;
+        case "github":
+          isDataSourceAllowedInPlan =
+            owner.plan.limits.managedDataSources.isGithubAllowed;
+          break;
+        case "google_drive":
+          isDataSourceAllowedInPlan =
+            owner.plan.limits.managedDataSources.isGoogleDriveAllowed;
+          break;
+        default:
+          isDataSourceAllowedInPlan = false; // default to false if provider is not recognized
+      }
+
       // Enforce plan limits: managed DataSources.
-      if (!owner.plan.limits.dataSources.managed) {
+      if (!isDataSourceAllowedInPlan) {
         return apiError(req, res, {
           status_code: 401,
           api_error: {

--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -41,6 +41,8 @@ async function handler(
     });
   }
 
+  const plan = auth.plan();
+
   switch (req.method) {
     case "POST":
       if (!auth.isAdmin()) {
@@ -121,19 +123,19 @@ async function handler(
       switch (provider) {
         case "slack":
           isDataSourceAllowedInPlan =
-            owner.plan.limits.managedDataSources.isSlackAllowed;
+            plan.limits.managedDataSources.isSlackAllowed;
           break;
         case "notion":
           isDataSourceAllowedInPlan =
-            owner.plan.limits.managedDataSources.isNotionAllowed;
+            plan.limits.managedDataSources.isNotionAllowed;
           break;
         case "github":
           isDataSourceAllowedInPlan =
-            owner.plan.limits.managedDataSources.isGithubAllowed;
+            plan.limits.managedDataSources.isGithubAllowed;
           break;
         case "google_drive":
           isDataSourceAllowedInPlan =
-            owner.plan.limits.managedDataSources.isGoogleDriveAllowed;
+            plan.limits.managedDataSources.isGoogleDriveAllowed;
           break;
         default:
           isDataSourceAllowedInPlan = false; // default to false if provider is not recognized

--- a/front/pages/poke/[wId]/index.tsx
+++ b/front/pages/poke/[wId]/index.tsx
@@ -12,11 +12,12 @@ import { ConnectorsAPI } from "@app/lib/connectors_api";
 import { CoreAPI } from "@app/lib/core_api";
 import { timeAgoFrom } from "@app/lib/utils";
 import { DataSourceType } from "@app/types/data_source";
-import { UserType, WorkspaceType } from "@app/types/user";
+import { SubscribedPlanType, UserType, WorkspaceType } from "@app/types/user";
 
 export const getServerSideProps: GetServerSideProps<{
   user: UserType;
   workspace: WorkspaceType;
+  plan: SubscribedPlanType;
   dataSources: DataSourceType[];
   slackbotEnabled?: boolean;
   documentCounts: Record<string, number>;
@@ -50,6 +51,7 @@ export const getServerSideProps: GetServerSideProps<{
   const auth = await Authenticator.fromSuperUserSession(session, wId);
 
   const workspace = auth.workspace();
+  const plan = auth.plan();
 
   if (!workspace) {
     return {
@@ -128,6 +130,7 @@ export const getServerSideProps: GetServerSideProps<{
     props: {
       user,
       workspace,
+      plan,
       dataSources,
       slackbotEnabled,
       documentCounts: docCountByDsName,
@@ -138,6 +141,7 @@ export const getServerSideProps: GetServerSideProps<{
 
 const WorkspacePage = ({
   workspace,
+  plan,
   dataSources,
   slackbotEnabled,
   documentCounts,
@@ -268,10 +272,10 @@ const WorkspacePage = ({
           <div className="mx-2 w-1/3">
             <h2 className="text-md mb-4 font-bold">Plan:</h2>
             <p className="mb-4 text-green-600">
-              This workspace is on {workspace.plan.code} plan since{" "}
-              {new Date(workspace.plan.startDate).toLocaleDateString()}.
+              This workspace is on {plan.code} plan since{" "}
+              {new Date(plan.startDate).toLocaleDateString()}.
             </p>
-            <JsonViewer value={workspace.plan} rootName={false} />
+            <JsonViewer value={plan} rootName={false} />
             <div>
               <div className="mt-4 flex-row">
                 <Button

--- a/front/pages/poke/[wId]/index.tsx
+++ b/front/pages/poke/[wId]/index.tsx
@@ -267,18 +267,10 @@ const WorkspacePage = ({
         <div className="flex justify-center">
           <div className="mx-2 w-1/3">
             <h2 className="text-md mb-4 font-bold">Plan:</h2>
-            {workspace.upgradedAt ? (
-              <p className="mb-4 text-green-600">
-                This workspace was fully upgraded
-                {workspace.upgradedAt &&
-                  ` on ${new Date(workspace.upgradedAt).toLocaleDateString()}`}
-                .
-              </p>
-            ) : (
-              <p className="mb-4 text-green-600">
-                This workspace is not upgraded.
-              </p>
-            )}
+            <p className="mb-4 text-green-600">
+              This workspace is on {workspace.plan.code} plan since{" "}
+              {new Date(workspace.plan.startDate).toLocaleDateString()}.
+            </p>
             <JsonViewer value={workspace.plan} rootName={false} />
             <div>
               <div className="mt-4 flex-row">

--- a/front/pages/poke/index.tsx
+++ b/front/pages/poke/index.tsx
@@ -95,7 +95,9 @@ const Dashboard = (
               ))}
             </ul>
           )}
-          <h1 className="mb-4 mt-8 text-2xl font-bold">Upgraded Workspaces</h1>
+          <h1 className="mb-4 mt-8 text-2xl font-bold">
+            Free Trial Workspaces
+          </h1>
           <ul className="space-y-4">
             {!isUpgradedWorkspacesLoading &&
               !isUpgradedWorkspacesError &&

--- a/front/pages/w/[wId]/builder/assistants/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/index.tsx
@@ -73,12 +73,6 @@ export default function AssistantsBuilder({
   const isBuilder = owner.role === "builder" || owner.role === "admin";
 
   const handleToggleAgentStatus = async (agent: AgentConfigurationType) => {
-    if (agent.status === "disabled_free_workspace") {
-      window.alert(
-        `@${agent.name} is only available on our paid plans. Contact us at team@dust.tt to get access.`
-      );
-      return;
-    }
     const res = await fetch(
       `/api/w/${owner.sId}/assistant/global_agents/${agent.sId}`,
       {

--- a/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
@@ -33,7 +33,7 @@ import { githubAuth } from "@app/lib/github_auth";
 import { useDocuments } from "@app/lib/swr";
 import { timeAgoFrom } from "@app/lib/utils";
 import { DataSourceType } from "@app/types/data_source";
-import { UserType, WorkspaceType } from "@app/types/user";
+import { SubscribedPlanType, UserType, WorkspaceType } from "@app/types/user";
 
 const {
   GA_TRACKING_ID = "",
@@ -49,6 +49,7 @@ const GOOGLE_OAUTH_WORKSPACE_IDS = ["17fd918e1d", "2f151df544"];
 export const getServerSideProps: GetServerSideProps<{
   user: UserType | null;
   owner: WorkspaceType;
+  plan: SubscribedPlanType;
   readOnly: boolean;
   isAdmin: boolean;
   dataSource: DataSourceType;
@@ -76,6 +77,7 @@ export const getServerSideProps: GetServerSideProps<{
       notFound: true,
     };
   }
+  const plan = auth.plan();
 
   const dataSource = await getDataSource(auth, context.params?.name as string);
   if (!dataSource) {
@@ -105,6 +107,7 @@ export const getServerSideProps: GetServerSideProps<{
     props: {
       user,
       owner,
+      plan,
       readOnly,
       isAdmin,
       dataSource,
@@ -124,10 +127,12 @@ export const getServerSideProps: GetServerSideProps<{
 
 function StandardDataSourceView({
   owner,
+  plan,
   readOnly,
   dataSource,
 }: {
   owner: WorkspaceType;
+  plan: SubscribedPlanType;
   readOnly: boolean;
   dataSource: DataSourceType;
 }) {
@@ -237,8 +242,8 @@ function StandardDataSourceView({
                 onClick={() => {
                   // Enforce plan limits: DataSource documents count.
                   if (
-                    owner.plan.limits.staticDataSources.documents.count != -1 &&
-                    total >= owner.plan.limits.staticDataSources.documents.count
+                    plan.limits.staticDataSources.documents.count != -1 &&
+                    total >= plan.limits.staticDataSources.documents.count
                   ) {
                     window.alert(
                       "Data Sources are limited to 32 documents on our free plan. Contact team@dust.tt if you want to increase this limit."
@@ -573,6 +578,7 @@ function ManagedDataSourceView({
 export default function DataSourceView({
   user,
   owner,
+  plan,
   readOnly,
   isAdmin,
   dataSource,
@@ -624,7 +630,7 @@ export default function DataSourceView({
         />
       ) : (
         <StandardDataSourceView
-          {...{ owner, readOnly: readOnly || standardView, dataSource }}
+          {...{ owner, plan, readOnly: readOnly || standardView, dataSource }}
         />
       )}
     </AppLayout>

--- a/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
@@ -237,8 +237,8 @@ function StandardDataSourceView({
                 onClick={() => {
                   // Enforce plan limits: DataSource documents count.
                   if (
-                    owner.plan.limits.dataSources.documents.count != -1 &&
-                    total >= owner.plan.limits.dataSources.documents.count
+                    owner.plan.limits.staticDataSources.documents.count != -1 &&
+                    total >= owner.plan.limits.staticDataSources.documents.count
                   ) {
                     window.alert(
                       "Data Sources are limited to 32 documents on our free plan. Contact team@dust.tt if you want to increase this limit."

--- a/front/pages/w/[wId]/builder/data-sources/[name]/upsert.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/upsert.tsx
@@ -118,10 +118,12 @@ export default function DataSourceUpsert({
     }
   }, [dataSource.name, loadDocumentId, owner.sId]);
 
+  const planDocumentLimits = owner.plan.limits.staticDataSources.documents;
+
   const alertDataSourcesLimit = () => {
     window.alert(
       "DataSource document upload size is limited to " +
-        `${owner.plan.limits.dataSources.documents.sizeMb}MB (of raw text)` +
+        `${planDocumentLimits.sizeMb}MB (of raw text)` +
         ". Contact team@dust.tt if you want to increase this limit."
     );
   };
@@ -132,8 +134,8 @@ export default function DataSourceUpsert({
 
     // Enforce plan limits: DataSource documents size.
     if (
-      owner.plan.limits.dataSources.documents.sizeMb != -1 &&
-      text.length > 1024 * 1024 * owner.plan.limits.dataSources.documents.sizeMb
+      planDocumentLimits.sizeMb != -1 &&
+      text.length > 1024 * 1024 * planDocumentLimits.sizeMb
     ) {
       alertDataSourcesLimit();
       return;
@@ -157,8 +159,8 @@ export default function DataSourceUpsert({
 
     // Enforce plan limits: DataSource documents size.
     if (
-      owner.plan.limits.dataSources.documents.sizeMb != -1 &&
-      text.length > 1024 * 1024 * owner.plan.limits.dataSources.documents.sizeMb
+      planDocumentLimits.sizeMb != -1 &&
+      text.length > 1024 * 1024 * planDocumentLimits.sizeMb
     ) {
       alertDataSourcesLimit();
       return;

--- a/front/pages/w/[wId]/builder/data-sources/[name]/upsert.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/upsert.tsx
@@ -22,13 +22,14 @@ import { getDataSource } from "@app/lib/api/data_sources";
 import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
 import { classNames } from "@app/lib/utils";
 import { DataSourceType } from "@app/types/data_source";
-import { UserType, WorkspaceType } from "@app/types/user";
+import { SubscribedPlanType, UserType, WorkspaceType } from "@app/types/user";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
 export const getServerSideProps: GetServerSideProps<{
   user: UserType | null;
   owner: WorkspaceType;
+  plan: SubscribedPlanType;
   readOnly: boolean;
   dataSource: DataSourceType;
   loadDocumentId: string | null;
@@ -47,6 +48,7 @@ export const getServerSideProps: GetServerSideProps<{
       notFound: true,
     };
   }
+  const plan = auth.plan();
 
   const dataSource = await getDataSource(auth, context.params?.name as string);
   if (!dataSource) {
@@ -62,6 +64,7 @@ export const getServerSideProps: GetServerSideProps<{
     props: {
       user,
       owner,
+      plan,
       readOnly,
       dataSource,
       loadDocumentId: (context.query.documentId || null) as string | null,
@@ -73,6 +76,7 @@ export const getServerSideProps: GetServerSideProps<{
 export default function DataSourceUpsert({
   user,
   owner,
+  plan,
   readOnly,
   dataSource,
   loadDocumentId,
@@ -118,7 +122,7 @@ export default function DataSourceUpsert({
     }
   }, [dataSource.name, loadDocumentId, owner.sId]);
 
-  const planDocumentLimits = owner.plan.limits.staticDataSources.documents;
+  const planDocumentLimits = plan.limits.staticDataSources.documents;
 
   const alertDataSourcesLimit = () => {
     window.alert(

--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -98,6 +98,8 @@ export const getServerSideProps: GetServerSideProps<{
     };
   }
 
+  const plan = auth.plan();
+
   const readOnly = !auth.isBuilder();
   const isAdmin = auth.isAdmin();
 
@@ -217,7 +219,7 @@ export const getServerSideProps: GetServerSideProps<{
       readOnly,
       isAdmin,
       integrations,
-      managedDataSourcesLimits: owner.plan.limits.managedDataSources,
+      managedDataSourcesLimits: plan.limits.managedDataSources,
       gaTrackingId: GA_TRACKING_ID,
       nangoConfig: {
         publicKey: NANGO_PUBLIC_KEY,

--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -33,7 +33,11 @@ import {
 import { githubAuth } from "@app/lib/github_auth";
 import { timeAgoFrom } from "@app/lib/utils";
 import { DataSourceType } from "@app/types/data_source";
-import { UserType, WorkspaceType } from "@app/types/user";
+import {
+  ManageDataSourcesLimitsType,
+  UserType,
+  WorkspaceType,
+} from "@app/types/user";
 
 const {
   GA_TRACKING_ID = "",
@@ -63,7 +67,7 @@ export const getServerSideProps: GetServerSideProps<{
   readOnly: boolean;
   isAdmin: boolean;
   integrations: DataSourceIntegration[];
-  canUseManagedDataSources: boolean;
+  managedDataSourcesLimits: ManageDataSourcesLimitsType;
   gaTrackingId: string;
   nangoConfig: {
     publicKey: string;
@@ -213,7 +217,7 @@ export const getServerSideProps: GetServerSideProps<{
       readOnly,
       isAdmin,
       integrations,
-      canUseManagedDataSources: owner.plan.limits.dataSources.managed,
+      managedDataSourcesLimits: owner.plan.limits.managedDataSources,
       gaTrackingId: GA_TRACKING_ID,
       nangoConfig: {
         publicKey: NANGO_PUBLIC_KEY,
@@ -232,7 +236,7 @@ export default function DataSourcesView({
   readOnly,
   isAdmin,
   integrations,
-  canUseManagedDataSources,
+  managedDataSourcesLimits,
   gaTrackingId,
   nangoConfig,
   githubAppUrl,
@@ -387,18 +391,42 @@ export default function DataSourcesView({
                             ds.connectorProvider as ConnectorProvider
                           ] ||
                           !isAdmin;
-                        const onclick = canUseManagedDataSources
-                          ? async () => {
-                              await handleEnableManagedDataSource(
-                                ds.connectorProvider as ConnectorProvider,
-                                ds.setupWithSuffix
-                              );
-                            }
-                          : () => {
-                              window.alert(
-                                "Managed Data Sources are only available on our paid plans. Contact us at team@dust.tt to get access."
-                              );
-                            };
+                        const onclick = async () => {
+                          let isDataSourceAllowedInPlan: boolean;
+
+                          switch (ds.connectorProvider) {
+                            case "slack":
+                              isDataSourceAllowedInPlan =
+                                managedDataSourcesLimits.isSlackAllowed;
+                              break;
+                            case "notion":
+                              isDataSourceAllowedInPlan =
+                                managedDataSourcesLimits.isNotionAllowed;
+                              break;
+                            case "github":
+                              isDataSourceAllowedInPlan =
+                                managedDataSourcesLimits.isGithubAllowed;
+                              break;
+                            case "google_drive":
+                              isDataSourceAllowedInPlan =
+                                managedDataSourcesLimits.isGoogleDriveAllowed;
+                              break;
+                            default:
+                              isDataSourceAllowedInPlan = false; // default to false if provider is not recognized
+                          }
+
+                          if (isDataSourceAllowedInPlan) {
+                            await handleEnableManagedDataSource(
+                              ds.connectorProvider as ConnectorProvider,
+                              ds.setupWithSuffix
+                            );
+                          } else {
+                            window.alert(
+                              "Managed Data Sources are only available on our paid plans. Contact us at team@dust.tt to get access."
+                            );
+                          }
+                          return;
+                        };
                         const label = !ds.isBuilt
                           ? "Coming soon"
                           : !isLoadingByProvider[

--- a/front/pages/w/[wId]/builder/data-sources/static.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/static.tsx
@@ -78,8 +78,8 @@ export default function DataSourcesView({
   const handleCreateDataSource = async () => {
     // Enforce plan limits: DataSources count.
     if (
-      owner.plan.limits.dataSources.count != -1 &&
-      dataSources.length >= owner.plan.limits.dataSources.count
+      owner.plan.limits.staticDataSources.count != -1 &&
+      dataSources.length >= owner.plan.limits.staticDataSources.count
     ) {
       window.alert(
         "You are limited to 1 DataSource on our free plan. Contact team@dust.tt if you want to increase this limit."

--- a/front/pages/w/[wId]/builder/data-sources/static.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/static.tsx
@@ -18,13 +18,14 @@ import { getDataSources } from "@app/lib/api/data_sources";
 import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
 import { classNames } from "@app/lib/utils";
 import { DataSourceType } from "@app/types/data_source";
-import { UserType, WorkspaceType } from "@app/types/user";
+import { SubscribedPlanType, UserType, WorkspaceType } from "@app/types/user";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
 export const getServerSideProps: GetServerSideProps<{
   user: UserType | null;
   owner: WorkspaceType;
+  plan: SubscribedPlanType;
   readOnly: boolean;
   dataSources: DataSourceType[];
   gaTrackingId: string;
@@ -49,6 +50,7 @@ export const getServerSideProps: GetServerSideProps<{
       notFound: true,
     };
   }
+  const plan = auth.plan();
 
   const readOnly = !auth.isBuilder();
 
@@ -59,6 +61,7 @@ export const getServerSideProps: GetServerSideProps<{
     props: {
       user,
       owner,
+      plan,
       readOnly,
       dataSources,
       gaTrackingId: GA_TRACKING_ID,
@@ -69,6 +72,7 @@ export const getServerSideProps: GetServerSideProps<{
 export default function DataSourcesView({
   user,
   owner,
+  plan,
   readOnly,
   dataSources,
   gaTrackingId,
@@ -78,8 +82,8 @@ export default function DataSourcesView({
   const handleCreateDataSource = async () => {
     // Enforce plan limits: DataSources count.
     if (
-      owner.plan.limits.staticDataSources.count != -1 &&
-      dataSources.length >= owner.plan.limits.staticDataSources.count
+      plan.limits.staticDataSources.count != -1 &&
+      dataSources.length >= plan.limits.staticDataSources.count
     ) {
       window.alert(
         "You are limited to 1 DataSource on our free plan. Contact team@dust.tt if you want to increase this limit."

--- a/front/pages/w/[wId]/join.tsx
+++ b/front/pages/w/[wId]/join.tsx
@@ -4,7 +4,7 @@ import { signIn } from "next-auth/react";
 
 import { SignInButton } from "@app/components/Button";
 import OnboardingLayout from "@app/components/sparkle/OnboardingLayout";
-import { getWorkspaceInfos } from "@app/lib/api/workspace";
+import { getWorkspaceInfo } from "@app/lib/api/workspace";
 import { WorkspaceType } from "@app/types/user";
 
 const { URL = "", GA_TRACKING_ID = "" } = process.env;
@@ -46,7 +46,7 @@ export const getServerSideProps: GetServerSideProps<{
       notFound: true,
     };
   }
-  const workspace = await getWorkspaceInfos(wId);
+  const workspace = await getWorkspaceInfo(wId);
   if (!workspace) {
     return {
       notFound: true,

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -62,8 +62,7 @@ export type AgentGenerationConfigurationType = {
 export type GlobalAgentStatus =
   | "active"
   | "disabled_by_admin"
-  | "disabled_missing_datasource"
-  | "disabled_free_workspace";
+  | "disabled_missing_datasource";
 export type AgentStatus = "active" | "archived";
 export type AgentConfigurationStatus = AgentStatus | GlobalAgentStatus;
 export type AgentConfigurationScope = "global" | "workspace";

--- a/front/types/user.ts
+++ b/front/types/user.ts
@@ -21,6 +21,7 @@ export type ManageDataSourcesLimitsType = {
 export type SubscribedPlanType = {
   code: string;
   name: string;
+  status: string;
   startDate: number;
   endDate: number | null;
   limits: {

--- a/front/types/user.ts
+++ b/front/types/user.ts
@@ -7,7 +7,6 @@ export type WorkspaceType = {
   name: string;
   allowedDomain: string | null;
   role: RoleType;
-  plan: SubscribedPlanType;
   upgradedAt: number | null;
 };
 

--- a/front/types/user.ts
+++ b/front/types/user.ts
@@ -1,31 +1,45 @@
 import { RoleType } from "@app/lib/auth";
 import { ModelId } from "@app/lib/databases";
 
-/**
- *  Expresses limits for usage of the product Any positive number enforces the limit, -1 means no
- *  limit. If the limit is undefined we revert to the default limit.
- * */
-export type LimitsType = {
-  dataSources: {
-    count: number;
-    documents: { count: number; sizeMb: number };
-    managed: boolean;
-  };
-  largeModels?: boolean;
-};
-
-export type PlanType = {
-  limits: LimitsType;
-};
-
 export type WorkspaceType = {
   id: ModelId;
   sId: string;
   name: string;
   allowedDomain: string | null;
   role: RoleType;
-  plan: PlanType;
+  plan: SubscribedPlanType;
   upgradedAt: number | null;
+};
+
+export type ManageDataSourcesLimitsType = {
+  isSlackAllowed: boolean;
+  isNotionAllowed: boolean;
+  isGoogleDriveAllowed: boolean;
+  isGithubAllowed: boolean;
+};
+
+export type SubscribedPlanType = {
+  code: string;
+  name: string;
+  startDate: number;
+  endDate: number | null;
+  limits: {
+    assistant: {
+      isSlackBotAllowed: boolean;
+      maxWeeklyMessages: number;
+    };
+    managedDataSources: ManageDataSourcesLimitsType;
+    staticDataSources: {
+      count: number;
+      documents: {
+        count: number;
+        sizeMb: number;
+      };
+    };
+    users: {
+      maxUsers: number;
+    };
+  };
 };
 
 export type UserProviderType = "github" | "google";


### PR DESCRIPTION
Quite a big PR, sorry 🙈 

This PRs handle the migration to the new Plan/Subscription model.
If too big for review I will split it. 

**1/ Have Subscription/Plan for all workspaces**
- Migration to create the Subscription objects for all workspaces: upgraded workspaces will be on `FREE_TRIAL_PLAN_CODE` and others on `TEST_PLAN_CODE`.

**2/ Have `workspace.plan` access the data from the Plan/Subscription objects**
- Introduce new type `SubscribedPlanType` to hold the new format of workspace limitations.
- Update `Authenticator` to access the Subscription/Plan data and have `workspace.plan` fetching this data.
- Update all calls from `workspace.plan.limits` to match the new format from `SubscribedPlanType`. A big part of the diff on that is we always allow BIG models so we removed all logic related to that. 

**2/ Udpate current upgrade/downgrade logic:** 
- On Poké
- With the cli commands for Henry 



**About the Subscription Business logic:** 
- introduce `getActiveWorkspacePlan` to replace `planForWorkspace` -> This fetched the active subscription. If not found we raise an error that we will want to fix immediately, and we fallback on a very limited plan.
- to subscribe to a free plan we introduced `internalSubscribeWorkspaceToFreePlan` -> it takes the plan code in parameter to know if we want the test plan or the free trial plan. If there's already an active plan it ends it yesterday and create the new subscription today. 



What still needs to be addressed very soon is: 
- Remove all calls from `workspace.upgradedAt`. This will be my next PR. We have 2 remaining calls: 
    - on Poké to display the list of upgraded workspaces and decide which button between upgrade/downgrade should be active
    - on the workspace setting pages to display the months for which we can access the list of monthly active users
- Properly handle the new workspace limitation of number of messages per week (Philippe will start working on it today)


### Note: 
I added a comment on top of each file to ease the review but let me know if that's too big to review 🙏🏻 


### Deploy:

First drop table Plan & Subscription
```
./admin/init_db.sh
./admin/init_plans.sh
env $(cat .env.local) npx tsx migrations/20231023_create_plan_subscriptions.ts
``` 
