### PR TITLE
Prevent double click on Agent retry generation

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -61,6 +61,9 @@ export function AgentMessage({
   const [streamedAgentMessage, setStreamedAgentMessage] =
     useState<AgentMessageType>(message);
 
+  const [isRetryHandlerProcessing, setIsRetryHandlerProcessing] =
+    useState<boolean>(false);
+
   const shouldStream = (() => {
     if (message.status !== "created") {
       return false;
@@ -233,6 +236,7 @@ export function AgentMessage({
             onClick: () => {
               void retryHandler(agentMessageToRender);
             },
+            disabled: isRetryHandlerProcessing || shouldStream,
           },
         ];
 
@@ -365,6 +369,7 @@ export function AgentMessage({
   }
 
   async function retryHandler(agentMessage: AgentMessageType) {
+    setIsRetryHandlerProcessing(true);
     await fetch(
       `/api/w/${owner.sId}/assistant/conversations/${conversationId}/messages/${agentMessage.sId}/retry`,
       {
@@ -374,6 +379,7 @@ export function AgentMessage({
         },
       }
     );
+    setIsRetryHandlerProcessing(false);
   }
 }
 

--- a/front/components/assistant/conversation/ConversationMessage.tsx
+++ b/front/components/assistant/conversation/ConversationMessage.tsx
@@ -41,6 +41,7 @@ export function ConversationMessage({
     label: string;
     icon: ComponentType;
     onClick: MouseEventHandler<HTMLButtonElement>;
+    disabled?: boolean;
   }[];
   reactions: MessageReactionType[];
   avatarBusy?: boolean;
@@ -272,6 +273,7 @@ export function ConversationMessage({
                     labelVisible={false}
                     icon={button.icon}
                     onClick={button.onClick}
+                    disabled={button.disabled || false}
                   />
                 ))}
               </div>


### PR DESCRIPTION
Eng runner task: https://github.com/dust-tt/tasks/issues/124

Double clicks lead to dd errors: https://dust4ai.slack.com/archives/C05F84CFP0E/p1697703405765839?thread_ts=1697702456.755039&cid=C05F84CFP0E

=> This PRs disable the retry button when we click on it until the generation is done. 