### PR TITLE
Fix: on empty array, tags_in / parents_in match no document

### DIFF
--- a/core/src/stores/postgres.rs
+++ b/core/src/stores/postgres.rs
@@ -1409,38 +1409,30 @@ impl Store for PostgresStore {
             if let Some(tags_filter) = &filter.tags {
                 if let Some(tags) = &tags_filter.is_in {
                     tags_is_in = tags.to_vec();
-                    if !tags_is_in.is_empty() {
-                        where_clauses.push(format!("tags_array && ${}", p_idx));
-                        params.push(&tags_is_in);
-                        p_idx += 1;
-                    }
+                    where_clauses.push(format!("tags_array && ${}", p_idx));
+                    params.push(&tags_is_in);
+                    p_idx += 1;
                 }
                 if let Some(tags) = &tags_filter.is_not {
                     tags_is_not = tags.to_vec();
-                    if !tags_is_not.is_empty() {
-                        where_clauses.push(format!("NOT tags_array && ${}", p_idx));
-                        params.push(&tags_is_not);
-                        p_idx += 1;
-                    }
+                    where_clauses.push(format!("NOT tags_array && ${}", p_idx));
+                    params.push(&tags_is_not);
+                    p_idx += 1;
                 }
             }
 
             if let Some(parents_filter) = &filter.parents {
                 if let Some(parents) = &parents_filter.is_in {
                     parents_is_in = parents.to_vec();
-                    if !parents_is_in.is_empty() {
-                        where_clauses.push(format!("parents && ${}", p_idx));
-                        params.push(&parents_is_in);
-                        p_idx += 1;
-                    }
+                    where_clauses.push(format!("parents && ${}", p_idx));
+                    params.push(&parents_is_in);
+                    p_idx += 1;
                 }
                 if let Some(parents) = &parents_filter.is_not {
                     parents_is_not = parents.to_vec();
-                    if !parents_is_not.is_empty() {
-                        where_clauses.push(format!("NOT parents && ${}", p_idx));
-                        params.push(&parents_is_not);
-                        p_idx += 1;
-                    }
+                    where_clauses.push(format!("NOT parents && ${}", p_idx));
+                    params.push(&parents_is_not);
+                    p_idx += 1;
                 }
             }
 

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -567,21 +567,36 @@ export async function* runRetrieval(
   }));
 
   for (const ds of c.dataSources) {
-    if (ds.filter.tags) {
-      if (!config.DATASOURCE.filter.tags) {
-        config.DATASOURCE.filter.tags = { in: [], not: [] };
+    /** Caveat: empty array in tags.in means "no document match" since no
+     * documents has any tags that is in the tags.in array (same for parents)*/
+    if (!config.DATASOURCE.filter.tags) {
+      config.DATASOURCE.filter.tags = {};
+    }
+    if (ds.filter.tags?.in) {
+      if (!config.DATASOURCE.filter.tags.in) {
+        config.DATASOURCE.filter.tags.in = [];
       }
-
       config.DATASOURCE.filter.tags.in.push(...ds.filter.tags.in);
+    }
+    if (ds.filter.tags?.not) {
+      if (!config.DATASOURCE.filter.tags.not) {
+        config.DATASOURCE.filter.tags.not = [];
+      }
       config.DATASOURCE.filter.tags.not.push(...ds.filter.tags.not);
     }
-
-    if (ds.filter.parents) {
-      if (!config.DATASOURCE.filter.parents) {
-        config.DATASOURCE.filter.parents = { in: [], not: [] };
+    if (!config.DATASOURCE.filter.parents) {
+      config.DATASOURCE.filter.parents = {};
+    }
+    if (ds.filter.parents?.in) {
+      if (!config.DATASOURCE.filter.parents.in) {
+        config.DATASOURCE.filter.parents.in = [];
       }
-
       config.DATASOURCE.filter.parents.in.push(...ds.filter.parents.in);
+    }
+    if (ds.filter.parents?.not) {
+      if (!config.DATASOURCE.filter.parents.not) {
+        config.DATASOURCE.filter.parents.not = [];
+      }
       config.DATASOURCE.filter.parents.not.push(...ds.filter.parents.not);
     }
   }


### PR DESCRIPTION
Following PR #2129

It had been decided IRL (stan, aric, henry, pr) that the correct API for tags / parents on an empty array:
- *in* => no document should match
- *not_in* => all documents should match

This PR enacts this change by removing the emptyness checks (the overlap operator leads to the correct logic by itself)