### PR TITLE
API: posting new conversation: await message created

### DIFF
--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -138,8 +138,10 @@ async function handler(
       }
 
       if (message) {
-        // If a message was provided we do await for the message to be posted before returning the
-        // conversation along with the message.
+        // If a message was provided we do await for the message to be created
+        // before returning the conversation along with the message.
+        // PostUserMessageWithPubSub returns swiftly since it only waits for the
+        // initial message creation event (or error)
         const messageRes = await postUserMessageWithPubSub(auth, {
           conversation,
           content: message.content,

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -109,8 +109,8 @@ async function handler(
 
       const { content, context, mentions } = bodyValidation.right;
 
-      // Not awaiting this promise on prupose. We want to answer "OK" to the client ASAP and process
-      // the events in the background.
+      /* postUserMessageWithPubSub returns swiftly since it only waits for the
+        initial message creation event (or error) */
       const messageRes = await postUserMessageWithPubSub(auth, {
         conversation,
         content,


### PR DESCRIPTION
This PR ensures a conversation is not created if we cannot create its first message, and allows error handling before creating the conversation

Namely, when creating a new conversation with a message, the message creation event (or error) is awaited. This is fast because we do not wait for the full message posting (with all redis events, etc.), only the creation event.

In doing so, it aligns the behaviour of
`front/pages/api/w/[wId]/assistant/conversations/index.ts` with the ones of
`front/pages/api/v1/w/[wId]/assistant/conversations/index.ts`, `front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts` and
`front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts`, who were already awaiting

Required for [this task](https://github.com/dust-tt/tasks/issues/128) (plan limits -- do not create the conversation if the message cannot be created because the message limit has been reached) but also sound in general.