### PR TITLE
Plan/Subscription: fix model [1]

### DIFF
--- a/front/lib/models/plan.ts
+++ b/front/lib/models/plan.ts
@@ -24,7 +24,7 @@ export class Plan extends Model<
   declare name: string;
 
   // workspace limitations
-  declare maxWeeklyMessages: number;
+  declare maxMessages: number;
   declare maxUsersInWorkspace: number;
   declare isSlackbotAllowed: boolean;
   declare isManagedSlackAllowed: boolean;
@@ -60,7 +60,7 @@ Plan.init(
       type: DataTypes.STRING,
       allowNull: false,
     },
-    maxWeeklyMessages: {
+    maxMessages: {
       type: DataTypes.INTEGER,
       allowNull: false,
     },
@@ -117,7 +117,7 @@ export class Subscription extends Model<
   declare updatedAt: CreationOptional<Date>;
 
   declare sId: string; // unique
-  declare status: string; // "active" | "ended"
+  declare status: "active" | "ended" | "cancelled";
   declare startDate: Date;
   declare endDate: Date | null;
 
@@ -152,7 +152,7 @@ Subscription.init(
       type: DataTypes.STRING,
       allowNull: false,
       validate: {
-        isIn: [["active", "ended"]],
+        isIn: [["active", "ended", "cancelled"]],
       },
     },
     startDate: {
@@ -196,7 +196,7 @@ Subscription.addHook(
 
 // Plan <> Subscription relationship: attribute "planId" in Subscription
 Plan.hasMany(Subscription, {
-  foreignKey: { name: "workspaceId", allowNull: false },
+  foreignKey: { name: "planId", allowNull: false },
   onDelete: "CASCADE",
 });
 Subscription.belongsTo(Plan, {

--- a/front/lib/plans/free_plans.ts
+++ b/front/lib/plans/free_plans.ts
@@ -12,7 +12,7 @@ const FREE_PLANS_DATA: PlanAttributes[] = [
   {
     code: "TEST_PLAN_V0",
     name: "Test",
-    maxWeeklyMessages: 50,
+    maxMessages: 50,
     maxUsersInWorkspace: 1,
     isSlackbotAllowed: false,
     isManagedSlackAllowed: false,
@@ -26,7 +26,7 @@ const FREE_PLANS_DATA: PlanAttributes[] = [
   {
     code: "TRIAL_PLAN_V0",
     name: "Free Trial",
-    maxWeeklyMessages: -1,
+    maxMessages: -1,
     maxUsersInWorkspace: -1,
     isSlackbotAllowed: true,
     isManagedSlackAllowed: true,


### PR DESCRIPTION
This PR:
- Fixes the name of a relation between Plan & Subscription
- Rename `maxWeeklyMessages` to `maxMessages`
- Add a new `cancelled` status to Subscription