### PR TITLE
Red Poké on prod + remove justified text on agent config

### DIFF
--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -1471,7 +1471,7 @@ function ActionModeSection({
         });
       }}
     >
-      <div className="flex flex-col gap-6 text-justify">{children}</div>
+      <div className="flex flex-col gap-6">{children}</div>
     </Transition>
   );
 }

--- a/front/components/poke/PokeNavbar.tsx
+++ b/front/components/poke/PokeNavbar.tsx
@@ -1,8 +1,16 @@
 import { Logo } from "@dust-tt/sparkle";
 import Link from "next/link";
 
+import { isDevelopment } from "@app/lib/development";
+import { classNames } from "@app/lib/utils";
+
 export const PokeNavbar: React.FC = () => (
-  <nav className="flex items-center justify-between bg-brand px-4 py-6 pr-8">
+  <nav
+    className={classNames(
+      "flex items-center justify-between px-4 py-6 pr-8",
+      isDevelopment() ? "bg-brand" : "bg-red-500"
+    )}
+  >
     <div className="flex items-center">
       <Logo type="colored-grey" className="-mr-5 h-4 w-32 p-0" />
       <Link href="/poke">


### PR DESCRIPTION
2 unrelated changes: 
- Remove justified text on the agent config page when selecting action = Exhaustive data source processing. 
- Make Poké header red when not in local to prevent stupid mistakes when you think you're in local and you were in prod. 

<img width="1193" alt="Capture d’écran 2023-10-25 à 11 33 44" src="https://github.com/dust-tt/dust/assets/3803406/5b8a13b3-855d-47ab-a154-4a62b6f7f022">

