### PR TITLE
URLs revamp: DUST_FRONT_API

### DIFF
--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -4,8 +4,8 @@ import logger from "@connectors/logger/logger";
 import { statsDClient } from "@connectors/logger/withlogging";
 import { DataSourceConfig } from "@connectors/types/data_source_config";
 
-const { FRONT_API } = process.env;
-if (!FRONT_API) {
+const { DUST_FRONT_API } = process.env;
+if (!DUST_FRONT_API) {
   throw new Error("FRONT_API not set");
 }
 
@@ -95,7 +95,7 @@ async function _upsertToDatasource({
   const now = new Date();
 
   const urlSafeName = encodeURIComponent(dataSourceConfig.dataSourceName);
-  const endpoint = `${FRONT_API}/api/v1/w/${dataSourceConfig.workspaceId}/data_sources/${urlSafeName}/documents/${documentId}`;
+  const endpoint = `${DUST_FRONT_API}/api/v1/w/${dataSourceConfig.workspaceId}/data_sources/${urlSafeName}/documents/${documentId}`;
   const dustRequestPayload = {
     text: documentText,
     source_url: documentUrl,
@@ -168,7 +168,7 @@ export async function deleteFromDataSource(
   const localLogger = logger.child({ ...loggerArgs, documentId });
 
   const urlSafeName = encodeURIComponent(dataSourceConfig.dataSourceName);
-  const endpoint = `${FRONT_API}/api/v1/w/${dataSourceConfig.workspaceId}/data_sources/${urlSafeName}/documents/${documentId}`;
+  const endpoint = `${DUST_FRONT_API}/api/v1/w/${dataSourceConfig.workspaceId}/data_sources/${urlSafeName}/documents/${documentId}`;
   const dustRequestConfig: AxiosRequestConfig = {
     headers: {
       Authorization: `Bearer ${dataSourceConfig.workspaceAPIKey}`,
@@ -204,7 +204,7 @@ export async function updateDocumentParentsField(
 ) {
   const localLogger = logger.child({ ...loggerArgs, documentId });
   const urlSafeName = encodeURIComponent(dataSourceConfig.dataSourceName);
-  const endpoint = `${FRONT_API}/api/v1/w/${dataSourceConfig.workspaceId}/data_sources/${urlSafeName}/documents/${documentId}/parents`;
+  const endpoint = `${DUST_FRONT_API}/api/v1/w/${dataSourceConfig.workspaceId}/data_sources/${urlSafeName}/documents/${documentId}/parents`;
   const dustRequestConfig: AxiosRequestConfig = {
     headers: {
       Authorization: `Bearer ${dataSourceConfig.workspaceAPIKey}`,

--- a/connectors/src/lib/dust_api.ts
+++ b/connectors/src/lib/dust_api.ts
@@ -18,7 +18,7 @@ type DataSourceType = {
   connectorProvider?: ConnectorProvider;
 };
 
-const { DUST_API = "https://dust.tt" } = process.env;
+const { DUST_FRONT_API } = process.env;
 
 type DustAPIErrorResponse = {
   type: string;
@@ -348,6 +348,9 @@ export class DustAPI {
    */
   constructor(credentials: DustAPICredentials) {
     this._credentials = credentials;
+    if (!DUST_FRONT_API) {
+      throw new Error("Missing DUST_FRONT_API env variable.");
+    }
   }
 
   workspaceId(): string {
@@ -362,7 +365,7 @@ export class DustAPI {
    */
   async getDataSources(workspaceId: string) {
     const res = await fetch(
-      `${DUST_API}/api/v1/w/${workspaceId}/data_sources`,
+      `${DUST_FRONT_API}/api/v1/w/${workspaceId}/data_sources`,
       {
         method: "GET",
         headers: {
@@ -392,7 +395,7 @@ export class DustAPI {
     >
   > {
     const res = await fetch(
-      `${DUST_API}/api/v1/w/${this.workspaceId()}/assistant/conversations`,
+      `${DUST_FRONT_API}/api/v1/w/${this.workspaceId()}/assistant/conversations`,
       {
         method: "POST",
         headers: {
@@ -426,7 +429,7 @@ export class DustAPI {
     message: PostMessagesRequestBodySchema;
   }) {
     const res = await fetch(
-      `${DUST_API}/api/v1/w/${this.workspaceId()}/assistant/conversations/${conversationId}/messages`,
+      `${DUST_FRONT_API}/api/v1/w/${this.workspaceId()}/assistant/conversations/${conversationId}/messages`,
       {
         method: "POST",
         headers: {
@@ -460,7 +463,7 @@ export class DustAPI {
     };
 
     const res = await fetch(
-      `${DUST_API}/api/v1/w/${this.workspaceId()}/assistant/conversations/${
+      `${DUST_FRONT_API}/api/v1/w/${this.workspaceId()}/assistant/conversations/${
         conversation.sId
       }/messages/${message.sId}/events`,
       {
@@ -559,7 +562,7 @@ export class DustAPI {
 
   async getConversation({ conversationId }: { conversationId: string }) {
     const res = await fetch(
-      `${DUST_API}/api/v1/w/${this.workspaceId()}/assistant/conversations/${conversationId}`,
+      `${DUST_FRONT_API}/api/v1/w/${this.workspaceId()}/assistant/conversations/${conversationId}`,
       {
         method: "GET",
         headers: {
@@ -579,7 +582,7 @@ export class DustAPI {
 
   async getAgentConfigurations() {
     const res = await fetch(
-      `${DUST_API}/api/v1/w/${this.workspaceId()}/assistant/agent_configurations`,
+      `${DUST_FRONT_API}/api/v1/w/${this.workspaceId()}/assistant/agent_configurations`,
       {
         method: "GET",
         headers: {
@@ -605,7 +608,7 @@ export class DustAPI {
     contentFragment: PostContentFragmentRequestBody;
   }) {
     const res = await fetch(
-      `${DUST_API}/api/v1/w/${this.workspaceId()}/assistant/conversations/${conversationId}/content_fragments`,
+      `${DUST_FRONT_API}/api/v1/w/${this.workspaceId()}/assistant/conversations/${conversationId}/content_fragments`,
       {
         method: "POST",
         headers: {

--- a/k8s/deployments/connectors-edge-deployment.yaml
+++ b/k8s/deployments/connectors-edge-deployment.yaml
@@ -36,7 +36,7 @@ spec:
             - name: NODE_OPTIONS
               value: "-r dd-trace/init --max-old-space-size=600"
 
-            - name: FRONT_API
+            - name: DUST_FRONT_API
               value: http://front-edge-service
 
             - name: DD_AGENT_HOST


### PR DESCRIPTION
Revamp of the FRONT_API / DUST_FRONT_API url.
See design doc [here](https://www.notion.so/dust-tt/Engineering-e0f834b5be5a43569baaf76e9c41adf2?p=8e1aab69fdb84809b8be4fc9f75e719e&pm=s)

Deploy steps:
```
kubectl patch secret connectors-secrets -p '{"stringData":{"DUST_FRONT_API":" http://front-service"}}' 

# Deploy connectors via the Github action
# Wait for deploy to finish

# We apparently have no way to delete a secret key
kubectl patch secret connectors-secrets -p '{"stringData":{"FRONT_API":""}}' 
```