### PR TITLE
URL revamp DUST_PROD_API

### DIFF
--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -20,7 +20,7 @@ const {
   DUST_DEVELOPMENT_WORKSPACE_ID,
   DUST_DEVELOPMENT_SYSTEM_API_KEY,
   NODE_ENV,
-  DUST_API = "https://dust.tt",
+  DUST_PROD_API = "https://dust.tt",
 } = process.env;
 
 export type RoleType = "admin" | "builder" | "user" | "none";
@@ -558,7 +558,7 @@ export async function prodAPICredentialsForOwner(
 
   if (
     NODE_ENV === "development" &&
-    !DUST_API.startsWith("http://localhost") &&
+    !DUST_PROD_API.startsWith("http://localhost") &&
     !useLocalInDev
   ) {
     if (!DUST_DEVELOPMENT_SYSTEM_API_KEY) {

--- a/front/lib/dust_api.ts
+++ b/front/lib/dust_api.ts
@@ -5,7 +5,7 @@ import logger from "@app/logger/logger";
 import { DataSourceType } from "@app/types/data_source";
 import { RunType } from "@app/types/run";
 
-const { DUST_API = "https://dust.tt", NODE_ENV } = process.env;
+const { DUST_PROD_API = "https://dust.tt", NODE_ENV } = process.env;
 
 export type DustAPIErrorResponse = {
   type: string;
@@ -300,7 +300,7 @@ export class DustAPI {
   apiUrl() {
     return this._useLocalInDev && NODE_ENV === "development"
       ? "http://localhost:3000"
-      : DUST_API;
+      : DUST_PROD_API;
   }
 
   /**


### PR DESCRIPTION
DUST_PROD_API  part of the URLs revamp from this [design doc](https://www.notion.so/dust-tt/Engineering-e0f834b5be5a43569baaf76e9c41adf2?p=8e1aab69fdb84809b8be4fc9f75e719e&pm=s).

Deployment:
```
kubectl patch secret front-secrets -p '{"stringData":{"DUST_PROD_API":"http://front-service"}}'
```

Deploy front via github action