### PR TITLE
DUST_CLIENT_FACING_URL part of URL revamp

### DIFF
--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -32,7 +32,7 @@ import {
   getUserName,
 } from "./temporal/activities";
 
-const { DUST_API = "https://dust.tt" } = process.env;
+const { DUST_CLIENT_FACING_URL } = process.env;
 
 class SlackExternalUserError extends Error {}
 
@@ -446,7 +446,7 @@ async function botAnswerMessage(
         let finalAnswer = normalizeContentForSlack(
           _processCiteMention(fullAnswer, action)
         );
-        finalAnswer += `...\n\n <${DUST_API}/w/${connector.workspaceId}/assistant/${conversation.sId}|Continue this conversation on Dust>`;
+        finalAnswer += `...\n\n <${DUST_CLIENT_FACING_URL}/w/${connector.workspaceId}/assistant/${conversation.sId}|Continue this conversation on Dust>`;
 
         await slackClient.chat.update({
           channel: slackChannel,
@@ -466,7 +466,7 @@ async function botAnswerMessage(
         let finalAnswer = normalizeContentForSlack(
           _processCiteMention(fullAnswer, action)
         );
-        finalAnswer += `\n\n <${DUST_API}/w/${connector.workspaceId}/assistant/${conversation.sId}|Continue this conversation on Dust>`;
+        finalAnswer += `\n\n <${DUST_CLIENT_FACING_URL}/w/${connector.workspaceId}/assistant/${conversation.sId}|Continue this conversation on Dust>`;
 
         await slackClient.chat.update({
           channel: slackChannel,
@@ -516,7 +516,7 @@ function _processCiteMention(
             }
             const link = ref.sourceUrl
               ? ref.sourceUrl
-              : `${DUST_API}/w/${
+              : `${DUST_CLIENT_FACING_URL}/w/${
                   ref.dataSourceWorkspaceId
                 }/builder/data-sources/${
                   ref.dataSourceId


### PR DESCRIPTION
DUST_CLIENT_FACING_URL part of [URL revamp](https://www.notion.so/dust-tt/DesignDoc-Dust-services-URLs-revamp-8e1aab69fdb84809b8be4fc9f75e719e#aea05a4a7a7948039f23991348795b1b)

Deploy steps:

```
kubectl patch secret connectors-secrets -p '{"stringData":{"DUST_CLIENT_FACING_URL":"https://dust.tt"}}'
kubectl patch secret front-secrets -p '{"stringData":{"DUST_CLIENT_FACING_URL":"https://dust.tt"}}'
```

Then deploy front and connectors via github.



