### PR TITLE
notion: handle undefined rich_text

### DIFF
--- a/connectors/src/connectors/notion/lib/notion_api.ts
+++ b/connectors/src/connectors/notion/lib/notion_api.ts
@@ -729,15 +729,9 @@ function parsePropertyText(
         ? property.title.map((t) => t.plain_text).join(" ")
         : null;
     case "rich_text":
-      if (!Array.isArray(property.rich_text)) {
-        logger.warn(
-          {
-            property,
-          },
-          "Unexpected rich_text structure"
-        );
-      }
-      return property.rich_text.map((t) => t.plain_text).join(" ");
+      return property.rich_text && property.rich_text.map
+        ? property.rich_text.map((t) => t.plain_text).join(" ")
+        : null;
     case "people":
       return property.people.length > 0
         ? property.people.map((p) => ("name" in p ? p.name : p.id)).join(", ")


### PR DESCRIPTION
Looks like at times, rich_text is just undefined (like title as per the code right above)

https://app.datadoghq.eu/logs?query=%22Unexpected%20rich_text%20structure%22%20&cols=host%2Cservice&event=AgAAAYtm5phL7j-j7wAAAAAAAAAYAAAAAEFZdG01cXI2QUFDeWNZbG1FTlpUZlFBTAAAACQAAAAAMDE4YjY2ZTYtZTQ3NC00OWRkLWFiZGYtMmQ5MmU5YjVjZjQ2&index=%2A&messageDisplay=inline&refresh_mode=sliding&stream_sort=desc&viz=stream&from_ts=1698237749454&to_ts=1698238649454&live=true

Return `null` when that's the case.