### PR TITLE
Remove access to workspace.upgradedAt

### DIFF
--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -28,7 +28,6 @@ export async function getWorkspaceInfos(
     name: workspace.name,
     allowedDomain: workspace.allowedDomain,
     role: "none",
-    upgradedAt: workspace.upgradedAt?.getTime() || null,
   };
 }
 

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -272,7 +272,6 @@ export class Authenticator {
           name: this._workspace.name,
           allowedDomain: this._workspace.allowedDomain || null,
           role: this._role,
-          upgradedAt: this._workspace.upgradedAt?.getTime() || null,
         }
       : null;
   }
@@ -380,7 +379,6 @@ export async function getUserFromSession(
         name: w.name,
         allowedDomain: w.allowedDomain || null,
         role,
-        upgradedAt: w.upgradedAt?.getTime() || null,
       };
     }),
     isDustSuperUser: user.isDustSuperUser,

--- a/front/pages/api/poke/workspaces/[wId]/downgrade.ts
+++ b/front/pages/api/poke/workspaces/[wId]/downgrade.ts
@@ -79,7 +79,6 @@ async function handler(
           name: workspace.name,
           allowedDomain: workspace.allowedDomain || null,
           role: "admin",
-          upgradedAt: workspace.upgradedAt?.getTime() || null,
         },
       });
 

--- a/front/pages/api/poke/workspaces/[wId]/upgrade.ts
+++ b/front/pages/api/poke/workspaces/[wId]/upgrade.ts
@@ -79,7 +79,6 @@ async function handler(
           name: workspace.name,
           allowedDomain: workspace.allowedDomain || null,
           role: "admin",
-          upgradedAt: workspace.upgradedAt?.getTime() || null,
         },
       });
 

--- a/front/pages/poke/[wId]/index.tsx
+++ b/front/pages/poke/[wId]/index.tsx
@@ -252,6 +252,8 @@ const WorkspacePage = ({
     (ds) => !!ds.connectorProvider
   );
 
+  const FREE_TEST_PLAN_CODE = "FREE_TEST_PLAN";
+
   return (
     <div className="min-h-screen bg-structure-50">
       <PokeNavbar />
@@ -271,18 +273,6 @@ const WorkspacePage = ({
         <div className="flex justify-center">
           <div className="mx-2 w-1/3">
             <h2 className="text-md mb-4 font-bold">Plan:</h2>
-            {workspace.upgradedAt ? (
-              <p className="mb-4 text-green-600">
-                This workspace was fully upgraded
-                {workspace.upgradedAt &&
-                  ` on ${new Date(workspace.upgradedAt).toLocaleDateString()}`}
-                .
-              </p>
-            ) : (
-              <p className="mb-4 text-green-600">
-                This workspace is not upgraded.
-              </p>
-            )}
             <JsonViewer value={plan} rootName={false} />
             <div>
               <div className="mt-4 flex-row">
@@ -291,7 +281,8 @@ const WorkspacePage = ({
                   variant="secondaryWarning"
                   onClick={onDowngrade}
                   disabled={
-                    !workspace.upgradedAt || workspaceHasManagedDataSources
+                    plan.code === FREE_TEST_PLAN_CODE ||
+                    workspaceHasManagedDataSources
                   }
                 />
 
@@ -299,17 +290,18 @@ const WorkspacePage = ({
                   label="Upgrade"
                   variant="secondary"
                   onClick={onUpgrade}
-                  disabled={!!workspace.upgradedAt}
+                  disabled={plan.code !== FREE_TEST_PLAN_CODE}
                 />
               </div>
             </div>
-            {workspace.upgradedAt && workspaceHasManagedDataSources && (
-              <span className="mx-2 w-1/3">
-                <p className="text-warning mb-4 text-sm ">
-                  Delete managed data sources before downgrading.
-                </p>
-              </span>
-            )}
+            {plan.code !== FREE_TEST_PLAN_CODE &&
+              workspaceHasManagedDataSources && (
+                <span className="mx-2 w-1/3">
+                  <p className="text-warning mb-4 text-sm ">
+                    Delete managed data sources before downgrading.
+                  </p>
+                </span>
+              )}
           </div>
           <div className="mx-2 w-1/3">
             <h2 className="text-md mb-4 font-bold">Data Sources:</h2>

--- a/front/pages/poke/index.tsx
+++ b/front/pages/poke/index.tsx
@@ -55,7 +55,6 @@ const Dashboard = (
     isWorkspacesError: isSearchResultsError,
   } = usePokeWorkspaces({
     search: searchTerm,
-    upgraded: false,
     disabled: searchDisabled,
     limit: 10,
   });
@@ -69,7 +68,7 @@ const Dashboard = (
       <PokeNavbar />
       <div className="flex-grow p-6">
         <>
-          <h1 className="mb-4 text-2xl font-bold">Free Workspaces</h1>
+          <h1 className="mb-4 text-2xl font-bold">Search in Workspaces</h1>
           <input
             className="w-full rounded-lg border border-gray-300 p-2 focus:outline-none focus:ring-2 focus:ring-blue-600"
             type="text"

--- a/front/types/user.ts
+++ b/front/types/user.ts
@@ -46,7 +46,6 @@ export type WorkspaceType = {
   name: string;
   allowedDomain: string | null;
   role: RoleType;
-  upgradedAt: number | null;
 };
 
 export type UserProviderType = "github" | "google";


### PR DESCRIPTION
`workspace.upgradedAt` should not be called anymore and will be removed. 

So on this PR: 
- Remove `upgradedAt` from `WorkspaceType`.
- Use the current plan code to know if the workspace is upgraded on the Workspace Settings page to display the list of csv with monthly usage data

On Poké a few changes: 
- We fetch the list of subscriptions to know which workspaces are ugpraded or not to display them on the homepage. This is not great but we can live with this first version. 
- The title of the search field has been updated and now search on all workspaces, not only the non upgraded ones. 
