### PR TITLE
Rename maxSizeStaticDataSources to maxSizeMbStaticDataSources in Plan

### DIFF
--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -462,7 +462,7 @@ export async function planForWorkspace(
           "isManagedGithubAllowed",
           "maxNbStaticDataSources",
           "maxNbStaticDocuments",
-          "maxSizeStaticDataSources",
+          "maxSizeMbStaticDataSources",
           "maxUsersInWorkspace",
         ],
       },
@@ -511,7 +511,7 @@ export async function planForWorkspace(
         count: plan.maxNbStaticDataSources,
         documents: {
           count: plan.maxNbStaticDocuments,
-          sizeMb: plan.maxSizeStaticDataSources,
+          sizeMb: plan.maxSizeMbStaticDataSources,
         },
       },
       users: {

--- a/front/lib/models/plan.ts
+++ b/front/lib/models/plan.ts
@@ -33,7 +33,7 @@ export class Plan extends Model<
   declare isManagedGithubAllowed: boolean;
   declare maxNbStaticDataSources: number;
   declare maxNbStaticDocuments: number;
-  declare maxSizeStaticDataSources: number;
+  declare maxSizeMbStaticDataSources: number;
 }
 Plan.init(
   {
@@ -96,9 +96,10 @@ Plan.init(
       type: DataTypes.INTEGER,
       allowNull: false,
     },
-    maxSizeStaticDataSources: {
+    maxSizeMbStaticDataSources: {
       type: DataTypes.INTEGER,
-      allowNull: false,
+      allowNull: true,
+      defaultValue: 2,
     },
   },
   {

--- a/front/lib/plans/free_plans.ts
+++ b/front/lib/plans/free_plans.ts
@@ -30,7 +30,7 @@ export const FREE_TEST_PLAN_DATA: PlanAttributes = {
   isManagedGithubAllowed: false,
   maxNbStaticDataSources: 10,
   maxNbStaticDocuments: 10,
-  maxSizeStaticDataSources: 2, // 2MB
+  maxSizeMbStaticDataSources: 2,
 };
 
 /**
@@ -51,7 +51,7 @@ const FREE_PLANS_DATA: PlanAttributes[] = [
     isManagedGithubAllowed: true,
     maxNbStaticDataSources: -1,
     maxNbStaticDocuments: -1,
-    maxSizeStaticDataSources: 2, // 2MB
+    maxSizeMbStaticDataSources: 2,
   },
 ];
 

--- a/front/lib/plans/subscription.ts
+++ b/front/lib/plans/subscription.ts
@@ -58,7 +58,7 @@ export const internalSubscribeWorkspaceToFreeTestPlan = async ({
         count: freeTestPlan.maxNbStaticDataSources,
         documents: {
           count: freeTestPlan.maxNbStaticDocuments,
-          sizeMb: freeTestPlan.maxSizeStaticDataSources,
+          sizeMb: freeTestPlan.maxSizeMbStaticDataSources,
         },
       },
       users: {
@@ -147,7 +147,7 @@ export const internalSubscribeWorkspaceToFreeUpgradedPlan = async ({
           count: plan.maxNbStaticDataSources,
           documents: {
             count: plan.maxNbStaticDocuments,
-            sizeMb: plan.maxSizeStaticDataSources,
+            sizeMb: plan.maxSizeMbStaticDataSources,
           },
         },
         users: {


### PR DESCRIPTION
I had to allow Null otherwise Sequelize would not let me run the migration.
I will set it back to non nullable afterwards.