### PR TITLE
sparkle: enforce truncation of items in dropdown

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.24",
+  "version": "0.2.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.24",
+      "version": "0.2.25",
       "license": "ISC",
       "dependencies": {
         "@headlessui/react": "^1.7.17"

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.24",
+  "version": "0.2.25",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/components/DropdownMenu.tsx
+++ b/sparkle/src/components/DropdownMenu.tsx
@@ -212,7 +212,7 @@ DropdownMenu.Item = function ({
     // need to use as="div" -- otherwise we get a "forwardRef" error in the console
     <Menu.Item disabled={disabled} as="div">
       <StandardItem
-        className="s-px-4"
+        className="s-w-full s-px-4"
         variant="dropdown"
         size="md"
         href={href}

--- a/sparkle/src/stories/DropdownMenu.stories.tsx
+++ b/sparkle/src/stories/DropdownMenu.stories.tsx
@@ -40,6 +40,25 @@ export const DropdownExample = () => {
       </div>
       <div className="s-h-12" />
       <div className="s-flex s-gap-6">
+        <div className="s-text-sm">Long items small width</div>
+        <DropdownMenu>
+          <DropdownMenu.Button
+            icon={ChatBubbleBottomCenterTextIcon}
+            tooltip="Moonlab"
+            tooltipPosition="below"
+          />
+          <DropdownMenu.Items origin="topLeft" width={120}>
+            <DropdownMenu.Item label="item 1 is longish" href="#" />
+            <DropdownMenu.Item label="item 2 is also longer" href="#" />
+            <DropdownMenu.Item
+              label="item with a long title because it is long"
+              href="#"
+            />
+          </DropdownMenu.Items>
+        </DropdownMenu>
+      </div>
+      <div className="s-h-12" />
+      <div className="s-flex s-gap-6">
         <div className="s-text-sm">Top right menu</div>
         <DropdownMenu>
           <DropdownMenu.Button label="Moonlab" icon={PlanetIcon} />
@@ -61,6 +80,10 @@ export const DropdownExample = () => {
           <DropdownMenu.Items origin="topLeft">
             <DropdownMenu.Item label="item 1" href="#" />
             <DropdownMenu.Item label="item 2" href="#" />
+            <DropdownMenu.Item
+              label="item 2 with a long title because it is long"
+              href="#"
+            />
           </DropdownMenu.Items>
         </DropdownMenu>
       </div>


### PR DESCRIPTION
`s-w-full` was missing on the StandardItem in Menu.Item

Truncation now works as expected. Note that `width` is configurable as number on the dropdown

![Screenshot from 2023-10-25 15-32-53](https://github.com/dust-tt/dust/assets/15067/bec0f6a4-ce74-4e2c-a5f3-6bf0fe886b47)
