### PR TITLE
Use runActionStreamed for all actions

### DIFF
--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -2,7 +2,7 @@ import {
   cloneBaseConfig,
   DustProdActionRegistry,
 } from "@app/lib/actions/registry";
-import { runAction } from "@app/lib/actions/server";
+import { runActionStreamed } from "@app/lib/actions/server";
 import {
   RetrievalParamsEvent,
   runRetrieval,
@@ -110,13 +110,18 @@ export async function generateActionInputs(
   config.MODEL.provider_id = model.providerId;
   config.MODEL.model_id = model.modelId;
 
-  const res = await runAction(auth, "assistant-v2-inputs-generator", config, [
-    {
-      conversation: modelConversationRes.value.modelConversation,
-      specification,
-      prompt,
-    },
-  ]);
+  const res = await runActionStreamed(
+    auth,
+    "assistant-v2-inputs-generator",
+    config,
+    [
+      {
+        conversation: modelConversationRes.value.modelConversation,
+        specification,
+        prompt,
+      },
+    ]
+  );
 
   if (res.isErr()) {
     return new Err(
@@ -126,24 +131,33 @@ export async function generateActionInputs(
     );
   }
 
-  const run = res.value;
+  const { eventStream } = res.value;
 
   const output: Record<string, string | boolean | number> = {};
-  for (const t of run.traces) {
-    if (t[1][0][0].error) {
+
+  for await (const event of eventStream) {
+    if (event.type === "error") {
       return new Err(
-        new Error(`Error generating action inputs: ${t[1][0][0].error}`)
+        new Error(`Error generating action inputs: ${event.content.message}`)
       );
     }
-    if (t[0][1] === "OUTPUT") {
-      const v = t[1][0][0].value as any;
-      for (const k in v) {
-        if (
-          typeof v[k] === "string" ||
-          typeof v[k] === "boolean" ||
-          typeof v[k] === "number"
-        ) {
-          output[k] = v[k];
+
+    if (event.type === "block_execution") {
+      const e = event.content.execution[0][0];
+      if (e.error) {
+        return new Err(new Error(`Error generating action inputs: ${e.error}`));
+      }
+
+      if (event.content.block_name === "OUTPUT" && e.value) {
+        const v = e.value as any;
+        for (const k in v) {
+          if (
+            typeof v[k] === "string" ||
+            typeof v[k] === "boolean" ||
+            typeof v[k] === "number"
+          ) {
+            output[k] = v[k];
+          }
         }
       }
     }


### PR DESCRIPTION
Fixes https://github.com/dust-tt/tasks/issues/119

Run all actions streamed to avoid time-outs waiting for the results (while polling our API. Also avoid polling which is not great and possibly a bit slower).

This was all tested locally.

