### PR TITLE
Remove limits for largeModels

### DIFF
--- a/connectors/src/lib/dust_api.ts
+++ b/connectors/src/lib/dust_api.ts
@@ -153,18 +153,6 @@ export type ConversationVisibility = "unlisted" | "workspace" | "deleted";
  *  Expresses limits for usage of the product Any positive number enforces the limit, -1 means no
  *  limit. If the limit is undefined we revert to the default limit.
  * */
-export type LimitsType = {
-  dataSources: {
-    count: number;
-    documents: { count: number; sizeMb: number };
-    managed: boolean;
-  };
-  largeModels?: boolean;
-};
-
-export type PlanType = {
-  limits: LimitsType;
-};
 
 export type RoleType = "admin" | "builder" | "user" | "none";
 
@@ -174,8 +162,6 @@ export type WorkspaceType = {
   name: string;
   allowedDomain: string | null;
   role: RoleType;
-  plan: PlanType;
-  upgradedAt: number | null;
 };
 
 /**

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -55,7 +55,7 @@ import { PostOrPatchAgentConfigurationRequestBodySchema } from "@app/pages/api/w
 import { AppType } from "@app/types/app";
 import { TimeframeUnit } from "@app/types/assistant/actions/retrieval";
 import { DataSourceType } from "@app/types/data_source";
-import { PlanType, UserType, WorkspaceType } from "@app/types/user";
+import { UserType, WorkspaceType } from "@app/types/user";
 
 import DataSourceResourceSelectorTree from "../DataSourceResourceSelectorTree";
 import AssistantBuilderDustAppModal from "./AssistantBuilderDustAppModal";
@@ -158,7 +158,6 @@ export type AssistantBuilderInitialState = {
 type AssistantBuilderProps = {
   user: UserType;
   owner: WorkspaceType;
-  plan: PlanType;
   gaTrackingId: string;
   dataSources: DataSourceType[];
   dustApps: AppType[];
@@ -203,7 +202,6 @@ const getCreativityLevelFromTemperature = (temperature: number) => {
 export default function AssistantBuilder({
   user,
   owner,
-  plan,
   gaTrackingId,
   dataSources,
   dustApps,
@@ -220,9 +218,7 @@ export default function AssistantBuilder({
     ...DEFAULT_ASSISTANT_STATE,
     generationSettings: {
       ...DEFAULT_ASSISTANT_STATE.generationSettings,
-      modelSettings: plan.limits.largeModels
-        ? GPT_4_32K_MODEL_CONFIG
-        : GPT_3_5_TURBO_16K_MODEL_CONFIG,
+      modelSettings: GPT_4_32K_MODEL_CONFIG,
     },
   });
 
@@ -843,7 +839,6 @@ export default function AssistantBuilder({
                 />
               </div>
               <AdvancedSettings
-                plan={plan}
                 generationSettings={builderState.generationSettings}
                 setGenerationSettings={(generationSettings) => {
                   setEdited(true);
@@ -1336,11 +1331,9 @@ function AssistantBuilderTextArea({
 }
 
 function AdvancedSettings({
-  plan,
   generationSettings,
   setGenerationSettings,
 }: {
-  plan: PlanType;
   generationSettings: AssistantBuilderState["generationSettings"];
   setGenerationSettings: (
     generationSettingsSettings: AssistantBuilderState["generationSettings"]
@@ -1377,27 +1370,22 @@ function AdvancedSettings({
                 />
               </DropdownMenu.Button>
               <DropdownMenu.Items origin="topLeft">
-                {usedModelConfigs
-                  .filter(
-                    (modelConfig) =>
-                      !modelConfig.largeModel || plan.limits.largeModels
-                  )
-                  .map((modelConfig) => (
-                    <DropdownMenu.Item
-                      key={modelConfig.modelId}
-                      label={modelConfig.displayName}
-                      onClick={() => {
-                        setGenerationSettings({
-                          ...generationSettings,
-                          modelSettings: {
-                            modelId: modelConfig.modelId,
-                            providerId: modelConfig.providerId,
-                            // safe because the SupportedModel is derived from the SUPPORTED_MODEL_CONFIGS array
-                          } as SupportedModel,
-                        });
-                      }}
-                    />
-                  ))}
+                {usedModelConfigs.map((modelConfig) => (
+                  <DropdownMenu.Item
+                    key={modelConfig.modelId}
+                    label={modelConfig.displayName}
+                    onClick={() => {
+                      setGenerationSettings({
+                        ...generationSettings,
+                        modelSettings: {
+                          modelId: modelConfig.modelId,
+                          providerId: modelConfig.providerId,
+                          // safe because the SupportedModel is derived from the SUPPORTED_MODEL_CONFIGS array
+                        } as SupportedModel,
+                      });
+                    }}
+                  />
+                ))}
               </DropdownMenu.Items>
             </DropdownMenu>
           </div>

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -13,11 +13,7 @@ import {
   renderConversationForModel,
   runGeneration,
 } from "@app/lib/api/assistant/generation";
-import {
-  GPT_3_5_TURBO_16K_MODEL_CONFIG,
-  GPT_4_32K_MODEL_CONFIG,
-  GPT_4_MODEL_CONFIG,
-} from "@app/lib/assistant";
+import { GPT_4_32K_MODEL_CONFIG, GPT_4_MODEL_CONFIG } from "@app/lib/assistant";
 import { Authenticator } from "@app/lib/auth";
 import { Err, Ok, Result } from "@app/lib/result";
 import logger from "@app/logger/logger";
@@ -64,18 +60,10 @@ export async function generateActionInputs(
 
   const MIN_GENERATION_TOKENS = 2048;
 
-  const plan = auth.plan();
-  const useLargeModels = plan && plan.limits.largeModels ? true : false;
-
-  let model: { providerId: string; modelId: string } = useLargeModels
-    ? {
-        providerId: GPT_4_32K_MODEL_CONFIG.providerId,
-        modelId: GPT_4_32K_MODEL_CONFIG.modelId,
-      }
-    : {
-        providerId: GPT_3_5_TURBO_16K_MODEL_CONFIG.providerId,
-        modelId: GPT_3_5_TURBO_16K_MODEL_CONFIG.modelId,
-      };
+  let model: { providerId: string; modelId: string } = {
+    providerId: GPT_4_32K_MODEL_CONFIG.providerId,
+    modelId: GPT_4_32K_MODEL_CONFIG.modelId,
+  };
 
   // Turn the conversation into a digest that can be presented to the model.
   const modelConversationRes = await renderConversationForModel({

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -5,11 +5,7 @@ import {
   getGlobalAgents,
   isGlobalAgentId,
 } from "@app/lib/api/assistant/global_agents";
-import {
-  getSupportedModelConfig,
-  isSupportedModel,
-  SupportedModel,
-} from "@app/lib/assistant";
+import { isSupportedModel, SupportedModel } from "@app/lib/assistant";
 import { Authenticator } from "@app/lib/auth";
 import { front_sequelize } from "@app/lib/databases";
 import {
@@ -189,11 +185,6 @@ export async function getAgentConfiguration(
       temperature: generationConfig.temperature,
       model,
     };
-
-    // Enforce plan limits: check if large models are allowed and act accordingly
-    if (!plan.limits.largeModels && getSupportedModelConfig(model).largeModel) {
-      return null;
-    }
   }
 
   return {
@@ -404,9 +395,6 @@ export async function createAgentGenerationConfiguration(
 
   if (temperature < 0) {
     throw new Error("Temperature must be positive.");
-  }
-  if (getSupportedModelConfig(model).largeModel && !plan.limits.largeModels) {
-    throw new Error("You need to upgrade your plan to use large models.");
   }
 
   const genConfig = await AgentGenerationConfiguration.create({

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -7,7 +7,6 @@ const readFileAsync = promisify(fs.readFile);
 import {
   CLAUDE_DEFAULT_MODEL_CONFIG,
   CLAUDE_INSTANT_DEFAULT_MODEL_CONFIG,
-  getSupportedModelConfig,
   GPT_3_5_TURBO_16K_MODEL_CONFIG,
   GPT_4_32K_MODEL_CONFIG,
   MISTRAL_7B_DEFAULT_MODEL_CONFIG,
@@ -83,16 +82,10 @@ async function _getHelperGlobalAgent(
   if (!plan) {
     throw new Error("Unexpected `auth` without `plan`.");
   }
-  const model = plan.limits.largeModels
-    ? {
-        providerId: GPT_4_32K_MODEL_CONFIG.providerId,
-        modelId: GPT_4_32K_MODEL_CONFIG.modelId,
-      }
-    : {
-        providerId: GPT_3_5_TURBO_16K_MODEL_CONFIG.providerId,
-        modelId: GPT_3_5_TURBO_16K_MODEL_CONFIG.modelId,
-      };
-
+  const model = {
+    providerId: GPT_4_32K_MODEL_CONFIG.providerId,
+    modelId: GPT_4_32K_MODEL_CONFIG.modelId,
+  };
   return {
     id: -1,
     sId: GLOBAL_AGENTS_SID.HELPER,
@@ -584,16 +577,7 @@ export async function getGlobalAgent(
     default:
       return null;
   }
-  if (!agentConfiguration) return null;
 
-  // Enforce plan limits: check if large models are allowed and act accordingly
-  if (
-    !plan.limits.largeModels &&
-    agentConfiguration.generation &&
-    getSupportedModelConfig(agentConfiguration.generation?.model).largeModel
-  ) {
-    agentConfiguration.status = "disabled_free_workspace";
-  }
   return agentConfiguration;
 }
 

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -13,7 +13,6 @@ export const GPT_4_32K_MODEL_CONFIG = {
   modelId: GPT_4_32K_MODEL_ID,
   displayName: "GPT 4",
   contextSize: 32768,
-  largeModel: true,
   recommendedTopK: 32,
 } as const;
 
@@ -22,7 +21,6 @@ export const GPT_4_MODEL_CONFIG = {
   modelId: GPT_4_MODEL_ID,
   displayName: "GPT 4",
   contextSize: 8192,
-  largeModel: true,
   recommendedTopK: 16,
 };
 
@@ -31,7 +29,6 @@ export const GPT_3_5_TURBO_16K_MODEL_CONFIG = {
   modelId: "gpt-3.5-turbo-16k",
   displayName: "GPT 3.5 Turbo",
   contextSize: 16384,
-  largeModel: false,
   recommendedTopK: 16,
 } as const;
 
@@ -40,7 +37,6 @@ export const GPT_3_5_TURBO_MODEL_CONFIG = {
   modelId: "gpt-3.5-turbo",
   displayName: "GPT 3.5 Turbo",
   contextSize: 4096,
-  largeModel: false,
   recommendedTopK: 16,
 } as const;
 
@@ -49,7 +45,6 @@ export const CLAUDE_DEFAULT_MODEL_CONFIG = {
   modelId: "claude-2",
   displayName: "Claude 2",
   contextSize: 100000,
-  largeModel: true,
   recommendedTopK: 32,
 } as const;
 
@@ -58,7 +53,6 @@ export const CLAUDE_INSTANT_DEFAULT_MODEL_CONFIG = {
   modelId: "claude-instant-1.2",
   displayName: "Claude Instant 1.2",
   contextSize: 100000,
-  largeModel: false,
   recommendedTopK: 32,
 } as const;
 
@@ -67,7 +61,6 @@ export const MISTRAL_7B_DEFAULT_MODEL_CONFIG = {
   modelId: "mistral_7B_instruct",
   displayName: "Mistral 7B",
   contextSize: 8192,
-  largeModel: false,
   recommendedTopK: 16,
 } as const;
 

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -15,11 +15,7 @@ import {
   User,
   Workspace,
 } from "@app/lib/models";
-import {
-  FREE_TEST_PLAN_DATA,
-  FREE_UPGRADED_PLAN_CODE,
-  PlanAttributes,
-} from "@app/lib/plans/free_plans";
+import { FREE_TEST_PLAN_DATA, PlanAttributes } from "@app/lib/plans/free_plans";
 import { Err, Ok, Result } from "@app/lib/result";
 import { new_id } from "@app/lib/utils";
 import logger from "@app/logger/logger";
@@ -517,7 +513,6 @@ export async function planForWorkspace(
       users: {
         maxUsers: plan.maxUsersInWorkspace,
       },
-      largeModels: plan.code === FREE_UPGRADED_PLAN_CODE, // TODO: remove this, it is always true now (kept to limit the scope of the PR)
     },
   };
 }

--- a/front/lib/plans/subscription.ts
+++ b/front/lib/plans/subscription.ts
@@ -64,7 +64,6 @@ export const internalSubscribeWorkspaceToFreeTestPlan = async ({
       users: {
         maxUsers: freeTestPlan.maxUsersInWorkspace,
       },
-      largeModels: false, // TODO: remove this, it is always true now (kept to limit the scope of the PR)
     },
   };
 };
@@ -153,7 +152,6 @@ export const internalSubscribeWorkspaceToFreeUpgradedPlan = async ({
         users: {
           maxUsers: plan.maxUsersInWorkspace,
         },
-        largeModels: true, // TODO: remove this, it is always true now (kept to limit the scope of the PR)
       },
     };
   });

--- a/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
@@ -13,7 +13,7 @@ import { isDustAppRunConfiguration } from "@app/types/assistant/actions/dust_app
 import { isRetrievalConfiguration } from "@app/types/assistant/actions/retrieval";
 import { AgentConfigurationType } from "@app/types/assistant/agent";
 import { DataSourceType } from "@app/types/data_source";
-import { PlanType, UserType, WorkspaceType } from "@app/types/user";
+import { UserType, WorkspaceType } from "@app/types/user";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
@@ -24,7 +24,6 @@ type DataSourceConfig = NonNullable<
 export const getServerSideProps: GetServerSideProps<{
   user: UserType;
   owner: WorkspaceType;
-  plan: PlanType;
   gaTrackingId: string;
   dataSources: DataSourceType[];
   dataSourceConfigurations: Record<string, DataSourceConfig>;
@@ -40,8 +39,7 @@ export const getServerSideProps: GetServerSideProps<{
   );
 
   const owner = auth.workspace();
-  const plan = auth.plan();
-  if (!owner || !user || !auth.isBuilder() || !plan || !context.params?.aId) {
+  if (!owner || !user || !auth.isBuilder() || !context.params?.aId) {
     return {
       notFound: true,
     };
@@ -140,7 +138,6 @@ export const getServerSideProps: GetServerSideProps<{
     props: {
       user,
       owner,
-      plan,
       gaTrackingId: GA_TRACKING_ID,
       dataSources: allDataSources,
       dataSourceConfigurations,
@@ -154,7 +151,6 @@ export const getServerSideProps: GetServerSideProps<{
 export default function EditAssistant({
   user,
   owner,
-  plan,
   gaTrackingId,
   dataSources,
   dataSourceConfigurations,
@@ -196,7 +192,6 @@ export default function EditAssistant({
     <AssistantBuilder
       user={user}
       owner={owner}
-      plan={plan}
       gaTrackingId={gaTrackingId}
       dataSources={dataSources}
       dustApps={dustApps}

--- a/front/pages/w/[wId]/builder/assistants/new.tsx
+++ b/front/pages/w/[wId]/builder/assistants/new.tsx
@@ -6,14 +6,13 @@ import { getDataSources } from "@app/lib/api/data_sources";
 import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
 import { AppType } from "@app/types/app";
 import { DataSourceType } from "@app/types/data_source";
-import { PlanType, UserType, WorkspaceType } from "@app/types/user";
+import { UserType, WorkspaceType } from "@app/types/user";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
 export const getServerSideProps: GetServerSideProps<{
   user: UserType;
   owner: WorkspaceType;
-  plan: PlanType;
   gaTrackingId: string;
   dataSources: DataSourceType[];
   dustApps: AppType[];
@@ -26,9 +25,8 @@ export const getServerSideProps: GetServerSideProps<{
   );
 
   const owner = auth.workspace();
-  const plan = auth.plan();
 
-  if (!owner || !user || !auth.isBuilder() || !plan) {
+  if (!owner || !user || !auth.isBuilder()) {
     return {
       notFound: true,
     };
@@ -41,7 +39,6 @@ export const getServerSideProps: GetServerSideProps<{
     props: {
       user,
       owner,
-      plan,
       gaTrackingId: GA_TRACKING_ID,
       dataSources: allDataSources,
       dustApps: allDustApps,
@@ -52,7 +49,6 @@ export const getServerSideProps: GetServerSideProps<{
 export default function CreateAssistant({
   user,
   owner,
-  plan,
   gaTrackingId,
   dataSources,
   dustApps,
@@ -61,7 +57,6 @@ export default function CreateAssistant({
     <AssistantBuilder
       user={user}
       owner={owner}
-      plan={plan}
       gaTrackingId={gaTrackingId}
       dataSources={dataSources}
       dustApps={dustApps}

--- a/front/types/user.ts
+++ b/front/types/user.ts
@@ -28,7 +28,6 @@ export type LimitsType = {
   users: {
     maxUsers: number;
   };
-  largeModels: boolean; // TODO: remove this, it is always true now (kept to limit the scope of the PR)
 };
 
 export type PlanType = {


### PR DESCRIPTION
Removes all the logic related to limiting largeModels depending on the Workspace plan. 
+ Update WorkspaceType from connector to match the latest changes (missed it on previous PRs)