### PR TITLE
fix: don't render mention if node has no children

### DIFF
--- a/front/components/assistant/RenderMessageMarkdown.tsx
+++ b/front/components/assistant/RenderMessageMarkdown.tsx
@@ -34,7 +34,7 @@ const SyntaxHighlighter = dynamic(
 function mentionDirective() {
   return (tree: any) => {
     visit(tree, ["textDirective"], (node) => {
-      if (node.name === "mention") {
+      if (node.name === "mention" && node.children[0]) {
         const data = node.data || (node.data = {});
         data.hName = "mention";
         data.hProperties = {


### PR DESCRIPTION
getting `TypeError: Cannot read properties of undefined (reading 'value')` on a conversation.
Requires deeper investigation but this should do the trick to fix the prod (client-side) error.