### PR TITLE
Do not render the citation divs if there is no citations

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -420,27 +420,29 @@ function Citations({
 
   activeReferences.sort((a, b) => a.index - b.index);
   return (
-    <div
-      className="-mx-[100%] mt-9 overflow-x-auto px-[100%] pb-4 scrollbar-hide"
-      ref={citationContainer}
-    >
-      <div className="left-100 relative flex gap-2">
-        {activeReferences.map(({ document, index }) => {
-          const provider = providerFromDocument(document);
-          return (
-            <Citation
-              key={index}
-              isBlinking={lastHoveredReference === index}
-              type={provider === "none" ? "document" : provider}
-              title={titleFromDocument(document)}
-              href={linkFromDocument(document)}
-              index={index}
-            />
-          );
-        })}
-        <div className="h-1 w-[100%] flex-none" />
+    activeReferences.length > 0 && (
+      <div
+        className="-mx-[100%] mt-9 overflow-x-auto px-[100%] pb-4 scrollbar-hide"
+        ref={citationContainer}
+      >
+        <div className="left-100 relative flex gap-2">
+          {activeReferences.map(({ document, index }) => {
+            const provider = providerFromDocument(document);
+            return (
+              <Citation
+                key={index}
+                isBlinking={lastHoveredReference === index}
+                type={provider === "none" ? "document" : provider}
+                title={titleFromDocument(document)}
+                href={linkFromDocument(document)}
+                index={index}
+              />
+            );
+          })}
+          <div className="h-1 w-[100%] flex-none" />
+        </div>
       </div>
-    </div>
+    )
   );
 }
 

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -351,10 +351,12 @@ export function AgentMessage({
                 setHoveredReference: setLastHoveredReference,
               }}
             />
-            <Citations
-              activeReferences={activeReferences}
-              lastHoveredReference={lastHoveredReference}
-            />
+            {activeReferences.length > 0 && (
+              <Citations
+                activeReferences={activeReferences}
+                lastHoveredReference={lastHoveredReference}
+              />
+            )}
           </div>
         )}
         {agentMessage.status === "cancelled" && (
@@ -420,29 +422,27 @@ function Citations({
 
   activeReferences.sort((a, b) => a.index - b.index);
   return (
-    activeReferences.length > 0 && (
-      <div
-        className="-mx-[100%] mt-9 overflow-x-auto px-[100%] pb-4 scrollbar-hide"
-        ref={citationContainer}
-      >
-        <div className="left-100 relative flex gap-2">
-          {activeReferences.map(({ document, index }) => {
-            const provider = providerFromDocument(document);
-            return (
-              <Citation
-                key={index}
-                isBlinking={lastHoveredReference === index}
-                type={provider === "none" ? "document" : provider}
-                title={titleFromDocument(document)}
-                href={linkFromDocument(document)}
-                index={index}
-              />
-            );
-          })}
-          <div className="h-1 w-[100%] flex-none" />
-        </div>
+    <div
+      className="-mx-[100%] mt-9 overflow-x-auto px-[100%] pb-4 scrollbar-hide"
+      ref={citationContainer}
+    >
+      <div className="left-100 relative flex gap-2">
+        {activeReferences.map(({ document, index }) => {
+          const provider = providerFromDocument(document);
+          return (
+            <Citation
+              key={index}
+              isBlinking={lastHoveredReference === index}
+              type={provider === "none" ? "document" : provider}
+              title={titleFromDocument(document)}
+              href={linkFromDocument(document)}
+              index={index}
+            />
+          );
+        })}
+        <div className="h-1 w-[100%] flex-none" />
       </div>
-    )
+    </div>
   );
 }
 


### PR DESCRIPTION
This would inject extraneous space below agent messages, particularly visible when there was a cancellation chip

![Screenshot from 2023-10-25 19-33-56](https://github.com/dust-tt/dust/assets/15067/0f7b5149-d8a4-4d9d-adb0-e47f22b88244)
