### PR TITLE
Add padding to compensate for the removal of Citations

### DIFF
--- a/front/components/assistant/conversation/Conversation.tsx
+++ b/front/components/assistant/conversation/Conversation.tsx
@@ -161,7 +161,7 @@ export default function Conversation({
   }
 
   return (
-    <div className="pb-24">
+    <div className="pb-32">
       {conversation.content.map((versionedMessages) => {
         const m = versionedMessages[versionedMessages.length - 1];
         const convoReactions = reactions.find((r) => r.messageId === m.sId);


### PR DESCRIPTION
We don't show the empty Citations div if there are no citations. As a result while we stream the stop generation button is visible on top of the text. Adjust padding of the Conversations to fix that