### PR TITLE
Better handled undefined from slack

### DIFF
--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -664,6 +664,9 @@ export async function getBotUserId(
   }
 
   const authRes = await client.auth.test({});
+  if (!authRes) {
+    throw new Error(`Failed to fetch auth info: received undefined response`);
+  }
   if (authRes.error) {
     throw new Error(`Failed to fetch auth info: ${authRes.error}`);
   }


### PR DESCRIPTION
Fix to better handle authRes returned as undefined as seen here in the wild: https://app.datadoghq.eu/logs?query=%22Unhandled%20API%20Error%22%20service%3Aconnectors&cols=host%2Cservice&event=AgAAAYtrbMWuhGMLLQAAAAAAAAAYAAAAAEFZdHJiTTZMQUFEZGQzVi1FaVYxT3dBQwAAACQAAAAAMDE4YjZiNmQtYTUxYy00MDQ4LTkwMDUtNjQzYzBjOWNlNWIw&index=%2A&messageDisplay=inline&refresh_mode=sliding&stream_sort=desc&viz=stream&from_ts=1698313604638&to_ts=1698314504638&live=true