### PR TITLE
Re-throw unhandled Slack errors

### DIFF
--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -774,6 +774,8 @@ export function getSlackClient(slackAccessToken: string): WebClient {
             throw workflowError;
           }
         }
+
+        throw e;
       }
     },
   };


### PR DESCRIPTION
Re-throw unhandled Slack errors. This will fix the unexpected undefined response we get from the Slack API.