### PR TITLE
Fix autoscroll in various situations (retrieval actions, citations...)

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -193,6 +193,20 @@ export function AgentMessage({
     }
   })();
 
+  // Autoscroll is performed when a message is generating and the page is
+  // already scrolled down; but if the user has scrolled the page up after the
+  // start of the message, we do not want to scroll it back down.
+  //
+  // Checking the conversation is already at the bottom of the screen is done
+  // modulo a small margin (50px). This value is small because if large, it
+  // prevents user from scrolling up when the message continues generating
+  // (forces it back down), but it cannot be zero otherwise the scroll does not
+  // happen.
+  //
+  // Keeping a ref on the message's height, and accounting to the height
+  // difference when new parts of the message are generated, allows for the
+  // scroll to happen even if the newly generated parts are larger than 50px
+  // (e.g. citations)
   const messageRef = useRef<HTMLDivElement>(null);
   const messageHeight = useRef<number | null>(null);
   useEffect(() => {

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -64,6 +64,14 @@ export function AgentMessage({
   const [isRetryHandlerProcessing, setIsRetryHandlerProcessing] =
     useState<boolean>(false);
 
+  const [references, setReferences] = useState<{
+    [key: string]: RetrievalDocumentType;
+  }>({});
+
+  const [activeReferences, setActiveReferences] = useState<
+    { index: number; document: RetrievalDocumentType }[]
+  >([]);
+
   const shouldStream = (() => {
     if (message.status !== "created") {
       return false;
@@ -185,12 +193,16 @@ export function AgentMessage({
     }
   })();
 
+  const messageRef = useRef<HTMLDivElement>(null);
+  const messageHeight = useRef<number | null>(null);
   useEffect(() => {
+    const previousHeight = messageHeight.current || 0;
+    messageHeight.current = messageRef.current?.scrollHeight || previousHeight;
     const mainTag = document.getElementById("main-content");
     if (mainTag && agentMessageToRender.status === "created") {
       if (
         mainTag.offsetHeight + mainTag.scrollTop >=
-        mainTag.scrollHeight - 50
+        mainTag.scrollHeight - (50 + messageHeight.current - previousHeight)
       ) {
         mainTag.scrollTo(0, mainTag.scrollHeight);
       }
@@ -199,6 +211,7 @@ export function AgentMessage({
     agentMessageToRender.content,
     agentMessageToRender.status,
     agentMessageToRender.action,
+    activeReferences.length,
   ]);
 
   // GenerationContext: to know if we are generating or not
@@ -244,12 +257,6 @@ export function AgentMessage({
           },
         ];
 
-  const [references, setReferences] = useState<{
-    [key: string]: RetrievalDocumentType;
-  }>({});
-  const [activeReferences, setActiveReferences] = useState<
-    { index: number; document: RetrievalDocumentType }[]
-  >([]);
   function updateActiveReferences(
     document: RetrievalDocumentType,
     index: number
@@ -290,7 +297,9 @@ export function AgentMessage({
       reactions={reactions}
       enableEmojis={true}
     >
-      {renderMessage(agentMessageToRender, references, shouldStream)}
+      <div ref={messageRef}>
+        {renderMessage(agentMessageToRender, references, shouldStream)}
+      </div>
     </ConversationMessage>
   );
 

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -195,7 +195,11 @@ export function AgentMessage({
         mainTag.scrollTo(0, mainTag.scrollHeight);
       }
     }
-  }, [agentMessageToRender.content, agentMessageToRender.status]);
+  }, [
+    agentMessageToRender.content,
+    agentMessageToRender.status,
+    agentMessageToRender.action,
+  ]);
 
   // GenerationContext: to know if we are generating or not
   const generationContext = useContext(GenerationContext);


### PR DESCRIPTION
Autoscroll is performed when a message is generating and the page is already scrolled down; but if the user has scrolled the page up after the start of the message, we do not want to scroll it back down. 

Checking the conversation is already at the bottom of the screen is done modulo a small margin (50px). This value is small because if large, it prevents user from scrolling up when the message continues generating (forces it back down), but it cannot be zero otherwise the scroll does not happen.

This PR fixes a few issues with the previous version, namely:
- it did not listen to some new content events (e.g. actions, citations) and thus did not scroll in this case;
- it did not scroll if the newly generated content was larger than 50px (e.g. citations);

The former is fixed via useeffect dependencies.

The latter is ensured by keeping a ref on the message's height, and accounting to the height difference when new parts of the message are generated.
