### PR TITLE
Init paid plans model config

### DIFF
--- a/front/admin/init_plans.ts
+++ b/front/admin/init_plans.ts
@@ -1,7 +1,9 @@
 import { upsertFreePlans } from "@app/lib/plans/free_plans";
+import { upsertProPlans } from "@app/lib/plans/pro_plans";
 
 async function main() {
   await upsertFreePlans();
+  await upsertProPlans();
   process.exit(0);
 }
 

--- a/front/lib/models/plan.ts
+++ b/front/lib/models/plan.ts
@@ -22,6 +22,7 @@ export class Plan extends Model<
 
   declare code: string; // unique
   declare name: string;
+  declare stripeProductId: string | null;
 
   // workspace limitations
   declare maxMessages: number;
@@ -59,6 +60,10 @@ Plan.init(
     name: {
       type: DataTypes.STRING,
       allowNull: false,
+    },
+    stripeProductId: {
+      type: DataTypes.STRING,
+      allowNull: true,
     },
     maxMessages: {
       type: DataTypes.INTEGER,

--- a/front/lib/plans/enterprise_plans.ts
+++ b/front/lib/plans/enterprise_plans.ts
@@ -1,0 +1,38 @@
+import { Attributes } from "sequelize";
+
+import { Plan } from "@app/lib/models";
+
+export type PlanAttributes = Omit<
+  Attributes<Plan>,
+  "id" | "createdAt" | "updatedAt"
+>;
+
+/**
+ * We have 3 categories of plans:
+ * - Free: plans with no paid subscription.
+ * - Pro: plans with a paid subscription, not tailored. -> i.e. the same plan is used by all Pro workspaces.
+ * - Entreprise: plans with a paid subscription, tailored to the needs of the entreprise. -> i.e. we will have one plan per "Entreprise".
+ *
+ * This file about Entreprise plans.
+ * As entreprise plans are custom, we won't create them in this file, but directly from Poké.
+ */
+
+/**
+ * ENT_PLAN_FAKE is not subscribable and is only used to display the Enterprise plan in the UI (hence it's not stored on the db).
+ */
+export const ENT_PLAN_FAKE_CODE = "ENT_PLAN_FAKE_CODE";
+export const ENT_PLAN_FAKE_DATA: PlanAttributes = {
+  code: ENT_PLAN_FAKE_CODE,
+  name: "Entreprise",
+  stripeProductId: null,
+  maxMessages: -1,
+  maxUsersInWorkspace: -1,
+  isSlackbotAllowed: true,
+  isManagedSlackAllowed: true,
+  isManagedNotionAllowed: true,
+  isManagedGoogleDriveAllowed: true,
+  isManagedGithubAllowed: true,
+  maxNbStaticDataSources: -1,
+  maxNbStaticDocuments: -1,
+  maxSizeStaticDataSources: 2, // 2MB
+};

--- a/front/lib/plans/pro_plans.ts
+++ b/front/lib/plans/pro_plans.ts
@@ -13,44 +13,40 @@ export type PlanAttributes = Omit<
  * - Pro: plans with a paid subscription, not tailored. -> i.e. the same plan is used by all Pro workspaces.
  * - Entreprise: plans with a paid subscription, tailored to the needs of the entreprise. -> i.e. we will have one plan per "Entreprise".
  *
- * This file about Free plans.
+ * This file about Pro plans.
  */
 
-// Current free plans:
-export const FREE_TEST_PLAN_CODE = "FREE_TEST_PLAN";
-export const FREE_UPGRADED_PLAN_CODE = "FREE_UPGRADED_PLAN";
+// Current pro plans:
+export const PRO_PLAN_MAU_29_CODE = "PRO_PLAN_MAU_29";
+export const PRO_PLAN_FIXED_1000_CODE = "PRO_PLAN_FIXED_1000";
 
 /**
- * FREE_TEST plan is our default plan: this is the plan used by all workspaces until they subscribe to a plan.
- * It is not stored in the database (as we don't create a subsription).
- */
-export const FREE_TEST_PLAN_DATA: PlanAttributes = {
-  code: FREE_TEST_PLAN_CODE,
-  name: "Test",
-  stripeProductId: null,
-  maxMessages: 100,
-  maxUsersInWorkspace: 1,
-  isSlackbotAllowed: false,
-  isManagedSlackAllowed: false,
-  isManagedNotionAllowed: false,
-  isManagedGoogleDriveAllowed: false,
-  isManagedGithubAllowed: false,
-  maxNbStaticDataSources: 10,
-  maxNbStaticDocuments: 10,
-  maxSizeStaticDataSources: 2, // 2MB
-};
-
-/**
- * Other FREE plans are stored in the database.
+ * Paid plans are stored in the database.
  * We can update existing plans or add new one but never remove anything from this list.
+ * Entreprise custom plans will be created from Poké.
  */
-const FREE_PLANS_DATA: PlanAttributes[] = [
+const PRO_PLANS_DATA: PlanAttributes[] = [
   {
-    code: FREE_UPGRADED_PLAN_CODE,
-    name: "Free Trial",
-    stripeProductId: null,
+    code: "PRO_PLAN_MAU_29",
+    name: "Pro",
+    stripeProductId: "prod_OtB9SOIwFyiQnl",
     maxMessages: -1,
-    maxUsersInWorkspace: -1,
+    maxUsersInWorkspace: 500,
+    isSlackbotAllowed: true,
+    isManagedSlackAllowed: true,
+    isManagedNotionAllowed: true,
+    isManagedGoogleDriveAllowed: true,
+    isManagedGithubAllowed: true,
+    maxNbStaticDataSources: -1,
+    maxNbStaticDocuments: -1,
+    maxSizeStaticDataSources: 2, // 2MB
+  },
+  {
+    code: "PRO_PLAN_FIXED_1000",
+    name: "Pro Fixed",
+    stripeProductId: "prod_OtBhelMswszehT",
+    maxMessages: -1,
+    maxUsersInWorkspace: 50,
     isSlackbotAllowed: true,
     isManagedSlackAllowed: true,
     isManagedNotionAllowed: true,
@@ -65,8 +61,8 @@ const FREE_PLANS_DATA: PlanAttributes[] = [
 /**
  * Function to call when we edit something in FREE_PLANS_DATA to update the database. It will create or update the plans.
  */
-export const upsertFreePlans = async () => {
-  for (const planData of FREE_PLANS_DATA) {
+export const upsertProPlans = async () => {
+  for (const planData of PRO_PLANS_DATA) {
     const plan = await Plan.findOne({
       where: {
         code: planData.code,
@@ -74,10 +70,10 @@ export const upsertFreePlans = async () => {
     });
     if (plan === null) {
       await Plan.create(planData);
-      console.log(`Free plan ${planData.code} created.`);
+      console.log(`Pro plan ${planData.code} created.`);
     } else {
       await plan.update(planData);
-      console.log(`Free plan ${planData.code} updated.`);
+      console.log(`Pro plan ${planData.code} updated.`);
     }
   }
 };


### PR DESCRIPTION
- Add a `stripeProductId` on the plan models. 
- Create two fake products on Stripe (test env): one with price based on monthly active users, one with fixed price. 
- Add lib to create paid plans: add two plans related to the 2 Stripe products, and update the command `./admin/init_plan.sh` to load pro plans. 
- Add tiny lib for entreprise plans. 


**Notes**: 

For clarity, I decided to split the definitions of plans into our three categories: 
- front/lib/plans/free_plans.ts
- front/lib/plans/pro_plans.ts
- front/lib/plans/enterprise_plans.ts

=> We could get rid of entreprise_plans.ts as those plans won't be configured from the code, the only we need is the default values to show in the UI. I think it's clearer to have them all in here but not a strong opinion. 

=> Next step is edit the subscription file to allow switching to one of the pro plans > then we need to plug all this with Stripe. 