### PR TITLE
enh: add global handler for uncaught exceptions/rejections

### DIFF
--- a/connectors/src/api_server.ts
+++ b/connectors/src/api_server.ts
@@ -27,6 +27,14 @@ import logger from "@connectors/logger/logger";
 import { authMiddleware } from "@connectors/middleware/auth";
 
 export function startServer(port: number) {
+  process.on("unhandledRejection", (reason, promise) => {
+    logger.error("Unhandled Rejection at:", promise, "reason:", reason);
+  });
+
+  process.on("uncaughtException", (error) => {
+    logger.error("Uncaught Exception thrown", error);
+  });
+
   const app = express();
 
   // for health check -- doesn't go through auth middleware


### PR DESCRIPTION
Currently those aren't JSON-logged and they crash the process