### PR TITLE
Button to subscribe to pro plans (without payment)

### DIFF
--- a/front/components/sparkle/navigation.tsx
+++ b/front/components/sparkle/navigation.tsx
@@ -10,6 +10,7 @@ import {
   PaperAirplaneIcon,
   PlanetIcon,
   RobotIcon,
+  ShapesIcon,
 } from "@dust-tt/sparkle";
 import { UsersIcon } from "@heroicons/react/20/solid";
 
@@ -27,6 +28,7 @@ export type TopNavigationId = "assistant" | "settings";
 export type SubNavigationAdminId =
   | "data_sources_managed"
   | "data_sources_static"
+  | "subscription"
   | "workspace"
   | "members"
   | "developers"
@@ -150,30 +152,44 @@ export const subNavigationAdmin = ({
   });
 
   if (owner.role === "admin") {
+    const menus: SparkleAppLayoutNavigation[] = [];
+    if (isDevelopmentOrDustWorkspace(owner)) {
+      menus.push({
+        id: "subscription",
+        label: "Subscription (Dust only)",
+        icon: ShapesIcon,
+        href: `/w/${owner.sId}/subscription`,
+        current: current === "subscription",
+        subMenuLabel: current === "subscription" ? subMenuLabel : undefined,
+        subMenu: current === "subscription" ? subMenu : undefined,
+      });
+    }
+    menus.push(
+      {
+        id: "workspace",
+        label: "Workspace",
+        icon: PlanetIcon,
+        href: `/w/${owner.sId}/workspace`,
+        current: current === "workspace",
+        subMenuLabel: current === "workspace" ? subMenuLabel : undefined,
+        subMenu: current === "workspace" ? subMenu : undefined,
+      },
+      {
+        id: "members",
+        label: "Members",
+        icon: UsersIcon,
+        href: `/w/${owner.sId}/members`,
+        current: current === "members",
+        subMenuLabel: current === "members" ? subMenuLabel : undefined,
+        subMenu: current === "members" ? subMenu : undefined,
+      }
+    );
+
     nav.push({
       id: "workspace",
       label: "Settings",
       variant: "secondary",
-      menus: [
-        {
-          id: "workspace",
-          label: "Workspace",
-          icon: PlanetIcon,
-          href: `/w/${owner.sId}/workspace`,
-          current: current === "workspace",
-          subMenuLabel: current === "workspace" ? subMenuLabel : undefined,
-          subMenu: current === "workspace" ? subMenu : undefined,
-        },
-        {
-          id: "members",
-          label: "Members",
-          icon: UsersIcon,
-          href: `/w/${owner.sId}/members`,
-          current: current === "members",
-          subMenuLabel: current === "members" ? subMenuLabel : undefined,
-          subMenu: current === "members" ? subMenu : undefined,
-        },
-      ],
+      menus,
     });
   }
 

--- a/front/pages/api/w/[wId]/subscription/index.ts
+++ b/front/pages/api/w/[wId]/subscription/index.ts
@@ -1,0 +1,74 @@
+import { NextApiRequest, NextApiResponse } from "next";
+
+import { Authenticator, getSession } from "@app/lib/auth";
+import { subscribeWorkspaceToPlan } from "@app/lib/plans/subscription";
+import { apiError, withLogging } from "@app/logger/withlogging";
+import { PlanType } from "@app/types/user";
+
+export type GetSubscriptionResponseBody = {
+  plan: PlanType;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<GetSubscriptionResponseBody>
+): Promise<void> {
+  const session = await getSession(req, res);
+  const auth = await Authenticator.fromSession(
+    session,
+    req.query.wId as string
+  );
+
+  const owner = auth.workspace();
+  const plan = auth.plan();
+  if (!owner || !plan) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "The workspace was not found.",
+      },
+    });
+  }
+
+  if (!auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "Only users that are `admins` for the current workspace can see memberships or modify it.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET":
+      // Should return the list of featured plans
+      return apiError(req, res, {
+        status_code: 404,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Not implemented yet.",
+        },
+      });
+
+    case "POST":
+      const newPlan = await subscribeWorkspaceToPlan(auth, {
+        planCode: req.body.planCode,
+      });
+      res.status(200).json({ plan: newPlan });
+      return;
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withLogging(handler);

--- a/front/pages/w/[wId]/subscription/index.tsx
+++ b/front/pages/w/[wId]/subscription/index.tsx
@@ -1,0 +1,138 @@
+import { Button, Chip, Page, PageHeader, ShapesIcon } from "@dust-tt/sparkle";
+import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import router from "next/router";
+import React, { useContext } from "react";
+
+import AppLayout from "@app/components/sparkle/AppLayout";
+import { subNavigationAdmin } from "@app/components/sparkle/navigation";
+import { SendNotificationsContext } from "@app/components/sparkle/Notification";
+import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
+import { isDevelopmentOrDustWorkspace } from "@app/lib/development";
+import { PlanType, UserType, WorkspaceType } from "@app/types/user";
+
+const { GA_TRACKING_ID = "" } = process.env;
+
+export const getServerSideProps: GetServerSideProps<{
+  user: UserType | null;
+  owner: WorkspaceType;
+  plan: PlanType;
+  gaTrackingId: string;
+}> = async (context) => {
+  const session = await getSession(context.req, context.res);
+  const user = await getUserFromSession(session);
+  const auth = await Authenticator.fromSession(
+    session,
+    context.params?.wId as string
+  );
+
+  const owner = auth.workspace();
+  const plan = auth.plan();
+  if (!owner || !auth.isAdmin() || !plan) {
+    return {
+      notFound: true,
+    };
+  }
+
+  if (!isDevelopmentOrDustWorkspace(owner)) {
+    return {
+      notFound: true,
+    };
+  }
+
+  return {
+    props: {
+      user,
+      owner,
+      plan,
+      gaTrackingId: GA_TRACKING_ID,
+    },
+  };
+};
+
+export default function Subscription({
+  user,
+  owner,
+  plan,
+  gaTrackingId,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  const sendNotification = useContext(SendNotificationsContext);
+  const [isProcessing, setIsProcessing] = React.useState<boolean>(false);
+
+  async function handleSubscribeToPlan(planCode: string): Promise<void> {
+    setIsProcessing(true);
+    const res = await fetch(`/api/w/${owner.sId}/subscription`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        planCode,
+      }),
+    });
+    if (!res.ok) {
+      sendNotification({
+        type: "error",
+        title: "Subscribtion failed",
+        description: "Failed to subscribe to a new plan.",
+      });
+    } else {
+      sendNotification({
+        type: "success",
+        title: "Success!",
+        description: `Successfully subscribed to the new plan.`,
+      });
+    }
+    setIsProcessing(false);
+
+    // Reload the page to update the plan (that we load from the server)
+    setTimeout(function () {
+      router.reload();
+    }, 1000);
+  }
+
+  return (
+    <AppLayout
+      user={user}
+      owner={owner}
+      gaTrackingId={gaTrackingId}
+      topNavigationCurrent="settings"
+      subNavigation={subNavigationAdmin({ owner, current: "subscription" })}
+    >
+      <Page.Vertical gap="xl" align="stretch">
+        <PageHeader
+          title="Subscription"
+          icon={ShapesIcon}
+          description="Choose the plan that works for you."
+        />
+        <Page.Vertical align="stretch" gap="md">
+          <Page.H variant="h5">Your plan </Page.H>
+          <div>
+            You're currently on the <Chip color="pink" label={plan.name} />{" "}
+            plan.
+          </div>
+
+          <Page.H variant="h5">Manage my plan </Page.H>
+
+          <div className="flex flex-row gap-2">
+            <Button
+              variant="primary"
+              label="Subscribe to Pro"
+              disabled={isProcessing || plan.code === "PRO_PLAN_MAU_29"}
+              onClick={async () =>
+                await handleSubscribeToPlan("PRO_PLAN_MAU_29")
+              }
+            />
+            <Button
+              variant="primary"
+              label="Subscribe to Pro Fixed"
+              disabled={isProcessing || plan.code === "PRO_PLAN_FIXED_1000"}
+              onClick={async () =>
+                await handleSubscribeToPlan("PRO_PLAN_FIXED_1000")
+              }
+            />
+          </div>
+        </Page.Vertical>
+      </Page.Vertical>
+    </AppLayout>
+  );
+}


### PR DESCRIPTION
This is ongoing work so that it's easier to play with Stripe to enter a subscription flow (there is no payment logic yet with Stripe).

It creates a subscription page that is quite claquée au sol, but it's only for Dust workspace and local, with 2 buttons to subscribe to one of the 2 test Pro plans configured with a StripeProductId. 

Goes along a new API route + a `subscribeWorkspaceToPlan` lib.

<img width="1293" alt="Capture d’écran 2023-10-26 à 16 51 16" src="https://github.com/dust-tt/dust/assets/3803406/75c5fded-4564-4620-8626-360767476800">
