### PR TITLE
Select Slack channels to sync directly on Dust and have the bot auto …

### DIFF
--- a/connectors/migrations/20230725_slack_channel_permissions.ts
+++ b/connectors/migrations/20230725_slack_channel_permissions.ts
@@ -1,7 +1,4 @@
-import {
-  getAccessToken,
-  getChannels,
-} from "@connectors/connectors/slack/temporal/activities";
+import { getChannels } from "@connectors/connectors/slack/temporal/activities";
 import { Connector, SlackChannel } from "@connectors/lib/models";
 
 async function main() {
@@ -25,8 +22,7 @@ async function main() {
       }
     );
 
-    const accessToken = await getAccessToken(c.connectionId);
-    const channelsInSlack = await getChannels(accessToken, true);
+    const channelsInSlack = await getChannels(c.id, true);
     const channelIdsInSlackSet = new Set(
       channelsInSlack.map((c) => c.id).filter((id) => id)
     );

--- a/connectors/migrations/20230725_slack_channel_permissions.ts
+++ b/connectors/migrations/20230725_slack_channel_permissions.ts
@@ -26,7 +26,7 @@ async function main() {
     );
 
     const accessToken = await getAccessToken(c.connectionId);
-    const channelsInSlack = await getChannels(accessToken);
+    const channelsInSlack = await getChannels(accessToken, true);
     const channelIdsInSlackSet = new Set(
       channelsInSlack.map((c) => c.id).filter((id) => id)
     );

--- a/connectors/src/api/webhooks/webhook_slack.ts
+++ b/connectors/src/api/webhooks/webhook_slack.ts
@@ -1,10 +1,7 @@
 import { Request, Response } from "express";
 
 import { botAnswerMessageWithErrorHandling } from "@connectors/connectors/slack/bot";
-import {
-  getAccessToken,
-  getBotUserIdMemoized,
-} from "@connectors/connectors/slack/temporal/activities";
+import { getBotUserIdMemoized } from "@connectors/connectors/slack/temporal/activities";
 import {
   launchSlackSyncOneMessageWorkflow,
   launchSlackSyncOneThreadWorkflow,
@@ -182,8 +179,8 @@ const _webhookSlackAPIHandler = async (
               status_code: 404,
             });
           }
-          const slackAccessToken = await getAccessToken(connector.connectionId);
-          const myUserId = await getBotUserIdMemoized(slackAccessToken);
+
+          const myUserId = await getBotUserIdMemoized(slackConfig.connectorId);
           if (req.body.event?.user === myUserId) {
             // Message sent from the bot itself.
             return res.status(200).send();
@@ -237,7 +234,7 @@ const _webhookSlackAPIHandler = async (
                   return new Ok(undefined);
                 }
                 return launchSlackSyncOneThreadWorkflow(
-                  c.connectorId.toString(),
+                  c.connectorId,
                   channel,
                   thread_ts
                 );
@@ -280,7 +277,7 @@ const _webhookSlackAPIHandler = async (
                   return new Ok(undefined);
                 }
                 return launchSlackSyncOneMessageWorkflow(
-                  c.connectorId.toString(),
+                  c.connectorId,
                   channel,
                   ts
                 );
@@ -346,7 +343,7 @@ const _webhookSlackAPIHandler = async (
 
         const results = await Promise.all(
           slackConfigurations.map((c) => {
-            return launchSlackGarbageCollectWorkflow(c.connectorId.toString());
+            return launchSlackGarbageCollectWorkflow(c.connectorId);
           })
         );
         for (const r of results) {

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -351,7 +351,6 @@ async function botAnswerMessage(
   }
   let conversation: ConversationType | undefined = undefined;
   let userMessage: UserMessageType | undefined = undefined;
-
   if (lastSlackChatBotMessage?.conversationId) {
     if (buildContentFragmentRes.value) {
       const contentFragmentRes = await dustAPI.postContentFragment({

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -8,6 +8,7 @@ import { Message } from "@slack/web-api/dist/response/ConversationsHistoryRespon
 import { ConversationsRepliesResponse } from "@slack/web-api/dist/response/ConversationsRepliesResponse";
 import levenshtein from "fast-levenshtein";
 
+import { getSlackClient } from "@connectors/connectors/slack/lib/slack_client";
 import {
   AgentActionType,
   AgentConfigurationType,
@@ -31,9 +32,7 @@ import logger from "@connectors/logger/logger";
 
 import {
   formatMessagesForUpsert,
-  getAccessToken,
   getBotUserIdMemoized,
-  getSlackClient,
   getUserName,
 } from "./temporal/activities";
 
@@ -92,8 +91,8 @@ export async function botAnswerMessageWithErrorHandling(
     } else {
       errorMessage = `An error occured. Our team has been notified and will work on it as soon as possible.`;
     }
-    const accessToken = await getAccessToken(connector.connectionId);
-    const slackClient = getSlackClient(accessToken);
+
+    const slackClient = await getSlackClient(connector.id);
     await slackClient.chat.postMessage({
       channel: slackChannel,
       text: errorMessage,
@@ -152,8 +151,7 @@ async function botAnswerMessage(
     conversationId: lastSlackChatBotMessage?.conversationId,
   });
 
-  const accessToken = await getAccessToken(connector.connectionId);
-  const slackClient = getSlackClient(accessToken);
+  const slackClient = await getSlackClient(connector.id);
   // Start computing the content fragment as early as possible since it's independent from all the other I/O operations
   // and a lot of the subsequent I/O operations can only be done sequentially.
   const contentFragmentPromise = makeContentFragment(
@@ -217,17 +215,13 @@ async function botAnswerMessage(
   // becomes: What is the command to upgrade a workspace in production (cc @julien) ?
   const matches = message.match(/<@[A-Z-0-9]+>/g);
   if (matches) {
-    const mySlackUser = await getBotUserIdMemoized(accessToken);
+    const mySlackUser = await getBotUserIdMemoized(connector.id);
     for (const m of matches) {
       const userId = m.replace(/<|@|>/g, "");
       if (userId === mySlackUser) {
         message = message.replace(m, "");
       } else {
-        const userName = await getUserName(
-          userId,
-          connector.id.toString(),
-          slackClient
-        );
+        const userName = await getUserName(userId, connector.id, slackClient);
         message = message.replace(m, `@${userName}`);
       }
     }
@@ -671,7 +665,7 @@ async function makeContentFragment(
   const text = await formatMessagesForUpsert(
     channelId,
     allMessages,
-    connector.id.toString(),
+    connector.id,
     slackClient
   );
   let url: string | null = null;

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -2,6 +2,9 @@ import { WebClient } from "@slack/web-api";
 import PQueue from "p-queue";
 
 import { ConnectorPermissionRetriever } from "@connectors/connectors/interface";
+import { getChannels } from "@connectors/connectors/slack//temporal/activities";
+import { joinChannel } from "@connectors/connectors/slack/lib/channels";
+import { getSlackClient } from "@connectors/connectors/slack/lib/slack_client";
 import {
   launchSlackBotJoinedWorkflow,
   launchSlackGarbageCollectWorkflow,
@@ -28,13 +31,6 @@ import {
   ConnectorPermission,
   ConnectorResource,
 } from "@connectors/types/resources";
-
-import {
-  getAccessToken,
-  getChannels,
-  getSlackClient,
-  joinChannel,
-} from "./temporal/activities";
 
 const { NANGO_SLACK_CONNECTOR_ID, SLACK_CLIENT_ID, SLACK_CLIENT_SECRET } =
   process.env;
@@ -173,8 +169,7 @@ export async function updateSlackConnector(
   const updateParams: Parameters<typeof c.update>[0] = {};
 
   if (connectionId) {
-    const accessToken = await getAccessToken(connectionId);
-    const slackClient = await getSlackClient(accessToken);
+    const slackClient = await getSlackClient(c.id);
     const teamInfoRes = await slackClient.team.info();
     if (!teamInfoRes.ok || !teamInfoRes.team?.id) {
       return new Err({
@@ -251,8 +246,8 @@ export async function cleanupSlackConnector(
       if (!SLACK_CLIENT_SECRET) {
         return new Err(new Error("SLACK_CLIENT_SECRET is not defined"));
       }
-      const accessToken = await getAccessToken(connector.connectionId);
-      const slackClient = getSlackClient(accessToken);
+
+      const slackClient = await getSlackClient(connector.id);
       const deleteRes = await slackClient.apps.uninstall({
         client_id: SLACK_CLIENT_ID,
         client_secret: SLACK_CLIENT_SECRET,
@@ -367,22 +362,27 @@ export async function retrieveSlackConnectorPermissions({
     permission: ConnectorPermission;
   }[] = [];
 
-  const accessToken = await getAccessToken(c.connectionId);
-  const remoteChannels = await getChannels(accessToken, false);
+  const [remoteChannels, localChannels] = await Promise.all([
+    getChannels(c.id, false),
+    SlackChannel.findAll({
+      where: {
+        connectorId: connectorId,
+      },
+    }),
+  ]);
+  const localChannelsById = localChannels.reduce((acc, ch) => {
+    acc[ch.slackChannelId] = ch;
+    return acc;
+  }, {} as Record<string, SlackChannel>);
+
   for (const remoteChannel of remoteChannels) {
     if (!remoteChannel.id || !remoteChannel.name) {
       continue;
     }
 
     const permissions =
-      (
-        await SlackChannel.findOne({
-          where: {
-            connectorId: connectorId,
-            slackChannelId: remoteChannel.id,
-          },
-        })
-      )?.permission || (remoteChannel.is_member ? "write" : "none");
+      localChannelsById[remoteChannel.id]?.permission ||
+      (remoteChannel.is_member ? "write" : "none");
 
     if (
       permissionToFilter.length === 0 ||
@@ -456,8 +456,7 @@ export async function setSlackConnectorPermissions(
   let shouldGarbageCollect = false;
   for (const [id, permission] of Object.entries(permissions)) {
     let channel = channels[id];
-    const slackAccessToken = await getAccessToken(connector.connectionId);
-    const slackClient = await getSlackClient(slackAccessToken);
+    const slackClient = await getSlackClient(connector.id);
     if (!channel) {
       const remoteChannel = await slackClient.conversations.info({
         channel: id,
@@ -476,7 +475,7 @@ export async function setSlackConnectorPermissions(
         );
       }
       const joinRes = await joinChannel(connectorId, id);
-      if (joinRes === "cant_join") {
+      if (joinRes.isErr()) {
         return new Err(
           new Error(
             `Our Slack bot (@Dust) was not able to join the Slack channel #${remoteChannel.channel.name}. Please re-authorize Slack or invite @Dust to #${remoteChannel.channel.name} manually.`
@@ -515,14 +514,14 @@ export async function setSlackConnectorPermissions(
             connectorId,
             channel.slackChannelId
           );
-          if (joinChannelRes === "cant_join") {
+          if (joinChannelRes.isErr()) {
             throw new Error(
               `Our Slack bot (@Dust) was not able to join the Slack channel #${channel.slackChannelName}. Please re-authorize Slack or invite @Dust to #${channel.slackChannelName} manually.`
             );
           }
 
           const res = await launchSlackBotJoinedWorkflow(
-            connectorId.toString(),
+            connectorId,
             channel.slackChannelId
           );
           if (res.isErr()) {
@@ -547,7 +546,7 @@ export async function setSlackConnectorPermissions(
   }
 
   if (shouldGarbageCollect) {
-    const res = await launchSlackGarbageCollectWorkflow(connectorId.toString());
+    const res = await launchSlackGarbageCollectWorkflow(connectorId);
     if (res.isErr()) {
       return res;
     }

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -6,8 +6,8 @@ import { getChannels } from "@connectors/connectors/slack//temporal/activities";
 import { joinChannel } from "@connectors/connectors/slack/lib/channels";
 import { getSlackClient } from "@connectors/connectors/slack/lib/slack_client";
 import {
-  launchSlackBotJoinedWorkflow,
   launchSlackGarbageCollectWorkflow,
+  launchSlackSyncOneChannelDebouncedWorkflow,
   launchSlackSyncWorkflow,
 } from "@connectors/connectors/slack/temporal/client.js";
 import {
@@ -520,7 +520,7 @@ export async function setSlackConnectorPermissions(
             );
           }
 
-          const res = await launchSlackBotJoinedWorkflow(
+          const res = await launchSlackSyncOneChannelDebouncedWorkflow(
             connectorId,
             channel.slackChannelId
           );

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -478,7 +478,7 @@ export async function setSlackConnectorPermissions(
       if (joinRes.isErr()) {
         return new Err(
           new Error(
-            `Our Slack bot (@Dust) was not able to join the Slack channel #${remoteChannel.channel.name}. Please re-authorize Slack or invite @Dust to #${remoteChannel.channel.name} manually.`
+            `Our Slack bot (@Dust) was not able to join the Slack channel #${remoteChannel.channel.name}. Please re-authorize Slack or invite @Dust from #${remoteChannel.channel.name} on Slack.`
           )
         );
       }
@@ -516,7 +516,7 @@ export async function setSlackConnectorPermissions(
           );
           if (joinChannelRes.isErr()) {
             throw new Error(
-              `Our Slack bot (@Dust) was not able to join the Slack channel #${channel.slackChannelName}. Please re-authorize Slack or invite @Dust to #${channel.slackChannelName} manually.`
+              `Our Slack bot (@Dust) was not able to join the Slack channel #${remoteChannel.channel.name}. Please re-authorize Slack or invite @Dust from #${remoteChannel.channel.name} on Slack.`
             );
           }
 

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -516,7 +516,7 @@ export async function setSlackConnectorPermissions(
           );
           if (joinChannelRes.isErr()) {
             throw new Error(
-              `Our Slack bot (@Dust) was not able to join the Slack channel #${remoteChannel.channel.name}. Please re-authorize Slack or invite @Dust from #${remoteChannel.channel.name} on Slack.`
+              `Our Slack bot (@Dust) was not able to join the Slack channel #${channel.slackChannelName}. Please re-authorize Slack or invite @Dust from #${channel.slackChannelName} on Slack.`
             );
           }
 

--- a/connectors/src/connectors/slack/lib/channels.ts
+++ b/connectors/src/connectors/slack/lib/channels.ts
@@ -1,9 +1,17 @@
+import { CodedError, ErrorCode, WebAPIPlatformError } from "@slack/web-api";
+import { Channel } from "@slack/web-api/dist/response/ConversationsListResponse";
+
 import {
   Connector,
+  ModelId,
   sequelize_conn,
   SlackChannel,
 } from "@connectors/lib/models";
+import { Err, Ok, Result } from "@connectors/lib/result";
+import logger from "@connectors/logger/logger";
 import { ConnectorPermission } from "@connectors/types/resources";
+
+import { getSlackClient } from "./slack_client";
 
 export type SlackChannelType = {
   id: number;
@@ -74,4 +82,55 @@ export async function upsertSlackChannelInConnectorsDb({
       agentConfigurationId: channel.agentConfigurationId,
     };
   });
+}
+
+export async function joinChannel(
+  connectorId: ModelId,
+  channelId: string
+): Promise<
+  Result<{ result: "ok" | "already_joined"; channel: Channel }, Error>
+> {
+  const connector = await Connector.findByPk(connectorId);
+  if (!connector) {
+    throw new Error(`Connector ${connectorId} not found`);
+  }
+
+  const client = await getSlackClient(connector.id);
+  try {
+    const channelInfo = await client.conversations.info({ channel: channelId });
+    if (!channelInfo.channel) {
+      return new Err(new Error("Channel not found."));
+    }
+    if (channelInfo.channel?.is_member) {
+      return new Ok({ result: "already_joined", channel: channelInfo.channel });
+    }
+    const joinRes = await client.conversations.join({ channel: channelId });
+    if (joinRes.ok) {
+      return new Ok({ result: "ok", channel: channelInfo.channel });
+    } else {
+      return new Ok({ result: "already_joined", channel: channelInfo.channel });
+    }
+  } catch (e) {
+    const slackError = e as CodedError;
+    if (slackError.code === ErrorCode.PlatformError) {
+      const platformError = slackError as WebAPIPlatformError;
+      if (platformError.data.error === "missing_scope") {
+        logger.info(
+          {
+            channelId,
+            connectorId,
+          },
+          "Could not join the channel because of a missing scope. Please re-authorize your Slack connection and try again."
+        );
+        return new Err(
+          new Error(
+            "Could not join the channel because of a missing scope. Please re-authorize your Slack connection and try again."
+          )
+        );
+      }
+      throw e;
+    }
+  }
+
+  return new Err(new Error(`Can't join the channel`));
 }

--- a/connectors/src/connectors/slack/lib/slack_client.ts
+++ b/connectors/src/connectors/slack/lib/slack_client.ts
@@ -1,0 +1,87 @@
+import {
+  CodedError,
+  ErrorCode,
+  WebAPIHTTPError,
+  WebClient,
+} from "@slack/web-api";
+
+import { WorkflowError } from "@connectors/lib/error";
+import { Connector, ModelId } from "@connectors/lib/models";
+import { getAccessTokenFromNango } from "@connectors/lib/nango_helpers";
+const { NANGO_SLACK_CONNECTOR_ID } = process.env;
+
+// Timeout in ms for all network requests;
+const SLACK_NETWORK_TIMEOUT_MS = 30000;
+
+export async function getSlackClient(connectorId: ModelId): Promise<WebClient>;
+export async function getSlackClient(
+  slackAccessToken: string
+): Promise<WebClient>;
+export async function getSlackClient(
+  connectorIdOrAccessToken: string | ModelId
+): Promise<WebClient> {
+  let slackAccessToken: string | undefined = undefined;
+  if (typeof connectorIdOrAccessToken === "number") {
+    const connector = await Connector.findByPk(connectorIdOrAccessToken);
+    if (!connector) {
+      throw new Error(`Could not find connector ${connectorIdOrAccessToken}`);
+    }
+    slackAccessToken = await getAccessToken(connector.connectionId);
+  } else {
+    slackAccessToken = connectorIdOrAccessToken;
+  }
+  const slackClient = new WebClient(slackAccessToken, {
+    timeout: SLACK_NETWORK_TIMEOUT_MS,
+    retryConfig: {
+      retries: 1,
+      factor: 1,
+    },
+  });
+
+  const handler: ProxyHandler<WebClient> = {
+    get: function (target, prop, receiver) {
+      const value = Reflect.get(target, prop, receiver);
+      if (["function", "object"].indexOf(typeof value) > -1) {
+        return new Proxy(value, handler);
+      }
+
+      return Reflect.get(target, prop, receiver);
+    },
+    apply: async function (target, thisArg, argumentsList) {
+      try {
+        // @ts-expect-error can't get typescript to be happy with this, but it works.
+        return await Reflect.apply(target, thisArg, argumentsList);
+      } catch (e) {
+        const slackError = e as CodedError;
+        if (slackError.code === ErrorCode.HTTPError) {
+          const httpError = slackError as WebAPIHTTPError;
+          if (httpError.statusCode === 503) {
+            const workflowError: WorkflowError = {
+              type: "upstream_is_down_activity_error",
+              message: `Slack is down: ${httpError.message}`,
+              __is_dust_error: true,
+            };
+            throw workflowError;
+          }
+        }
+
+        throw e;
+      }
+    },
+  };
+
+  const proxied = new Proxy(slackClient, handler);
+
+  return proxied;
+}
+
+async function getAccessToken(nangoConnectionId: string): Promise<string> {
+  if (!NANGO_SLACK_CONNECTOR_ID) {
+    throw new Error("NANGO_SLACK_CONNECTOR_ID is not defined");
+  }
+  return getAccessTokenFromNango({
+    connectionId: nangoConnectionId,
+    integrationId: NANGO_SLACK_CONNECTOR_ID,
+    useCache: true,
+  });
+}

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -17,7 +17,10 @@ import memoize from "lodash.memoize";
 import PQueue from "p-queue";
 import { Op, Sequelize } from "sequelize";
 
-import { upsertSlackChannelInConnectorsDb } from "@connectors/connectors/slack/lib/channels";
+import {
+  joinChannel,
+  upsertSlackChannelInConnectorsDb,
+} from "@connectors/connectors/slack/lib/channels";
 import { getSlackClient } from "@connectors/connectors/slack/lib/slack_client";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { cacheGet, cacheSet } from "@connectors/lib/cache";
@@ -882,4 +885,13 @@ export async function deleteChannelsFromConnectorDb(
     },
     "Deleted channels from connectors db while garbage collecting."
   );
+}
+
+export async function joinChannelAct(connectorId: ModelId, channelId: string) {
+  const res = await joinChannel(connectorId, channelId);
+  if (res.isErr()) {
+    throw res.error;
+  }
+
+  return res.value;
 }

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -1,7 +1,6 @@
 import {
   CodedError,
   ErrorCode,
-  WebAPIHTTPError,
   WebAPIPlatformError,
   WebClient,
 } from "@slack/web-api";
@@ -19,6 +18,8 @@ import PQueue from "p-queue";
 import { Op, Sequelize } from "sequelize";
 
 import { upsertSlackChannelInConnectorsDb } from "@connectors/connectors/slack/lib/channels";
+import { getSlackClient } from "@connectors/connectors/slack/lib/slack_client";
+import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { cacheGet, cacheSet } from "@connectors/lib/cache";
 import {
   deleteFromDataSource,
@@ -31,7 +32,6 @@ import {
   SlackChannel,
   SlackMessages,
 } from "@connectors/lib/models";
-import { getAccessTokenFromNango } from "@connectors/lib/nango_helpers";
 import {
   reportInitialSyncProgress,
   syncSucceeded,
@@ -41,14 +41,10 @@ import { DataSourceConfig } from "@connectors/types/data_source_config";
 
 import { getWeekEnd, getWeekStart } from "../lib/utils";
 
-const { NANGO_SLACK_CONNECTOR_ID } = process.env;
 const logger = mainLogger.child({ provider: "slack" });
 
 // This controls the maximum number of concurrent calls to syncThread and syncNonThreaded.
 const MAX_CONCURRENCY_LEVEL = 2;
-
-// Timeout in ms for all network requests;
-const NETWORK_REQUEST_TIMEOUT_MS = 30000;
 
 /**
  * Slack API rate limit TLDR:
@@ -61,10 +57,10 @@ const NETWORK_REQUEST_TIMEOUT_MS = 30000;
  */
 
 export async function getChannels(
-  slackAccessToken: string,
+  connectorId: ModelId,
   joinedOnly: boolean
 ): Promise<Channel[]> {
-  const client = getSlackClient(slackAccessToken);
+  const client = await getSlackClient(connectorId);
   const allChannels = [];
   let nextCursor: string | undefined = undefined;
   do {
@@ -97,10 +93,10 @@ export async function getChannels(
 }
 
 export async function getChannel(
-  slackAccessToken: string,
+  connectorId: ModelId,
   channelId: string
 ): Promise<Channel> {
-  const client = getSlackClient(slackAccessToken);
+  const client = await getSlackClient(connectorId);
   const res = await client.conversations.info({ channel: channelId });
   // Despite the typing, in practice `conversations.info` can be undefined at times.
   if (!res) {
@@ -127,62 +123,24 @@ interface SyncChannelRes {
   weeksSynced: Record<number, boolean>;
 }
 
-export async function joinChannel(
-  connectorId: ModelId,
-  channelId: string
-): Promise<"ok" | "already_joined" | "cant_join"> {
-  const connector = await Connector.findByPk(connectorId);
-  if (!connector) {
-    throw new Error(`Connector ${connectorId} not found`);
-  }
-  const accessToken = await getAccessToken(connector.connectionId);
-  const client = getSlackClient(accessToken);
-  try {
-    const channelInfo = await client.conversations.info({ channel: channelId });
-    if (channelInfo.channel?.is_member) {
-      return "already_joined";
-    }
-    const joinRes = await client.conversations.join({ channel: channelId });
-    if (joinRes.ok) {
-      return "ok";
-    } else {
-      return "already_joined";
-    }
-  } catch (e) {
-    const slackError = e as CodedError;
-    if (slackError.code === ErrorCode.PlatformError) {
-      const platformError = slackError as WebAPIPlatformError;
-      if (platformError.data.error === "missing_scope") {
-        logger.info(
-          {
-            channelId,
-            connectorId,
-          },
-          "Could not join channel because of a missing scope. User need to re-authorize it's Slack connection to get the channels:join scope."
-        );
-        return "cant_join";
-      }
-      throw e;
-    }
-  }
-
-  return "cant_join";
-}
-
 export async function syncChannel(
-  slackAccessToken: string,
   channelId: string,
   channelName: string,
-  dataSourceConfig: DataSourceConfig,
-  connectorId: string,
+  connectorId: ModelId,
   fromTs: number | null,
   weeksSynced: Record<number, boolean>,
   messagesCursor?: string
 ): Promise<SyncChannelRes | undefined> {
+  const connector = await Connector.findByPk(connectorId);
+  if (!connector) {
+    throw new Error(`Connector ${connectorId} not found`);
+  }
+  const dataSourceConfig = dataSourceConfigFromConnector(connector);
+
   const channel = await upsertSlackChannelInConnectorsDb({
     slackChannelId: channelId,
     slackChannelName: channelName,
-    connectorId: parseInt(connectorId),
+    connectorId: connectorId,
   });
   if (!["read", "read_write"].includes(channel.permission)) {
     logger.info(
@@ -198,7 +156,7 @@ export async function syncChannel(
   const threadsToSync: string[] = [];
   let unthreadedTimeframesToSync: number[] = [];
   const messages = await getMessagesForChannel(
-    slackAccessToken,
+    connectorId,
     channelId,
     100,
     messagesCursor
@@ -270,7 +228,6 @@ export async function syncChannel(
 
   await syncThreads(
     dataSourceConfig,
-    slackAccessToken,
     channelId,
     channelName,
     threadsToSync,
@@ -282,7 +239,6 @@ export async function syncChannel(
   );
 
   await syncMultipleNoNThreaded(
-    slackAccessToken,
     dataSourceConfig,
     channelId,
     channelName,
@@ -298,12 +254,12 @@ export async function syncChannel(
 }
 
 export async function getMessagesForChannel(
-  slackAccessToken: string,
+  connectorId: ModelId,
   channelId: string,
   limit = 100,
   nextCursor?: string
 ): Promise<ConversationsHistoryResponse> {
-  const client = getSlackClient(slackAccessToken);
+  const client = await getSlackClient(connectorId);
 
   const c: ConversationsHistoryResponse = await client.conversations.history({
     channel: channelId,
@@ -337,12 +293,11 @@ export async function getMessagesForChannel(
 }
 
 export async function syncMultipleNoNThreaded(
-  slackAccessToken: string,
   dataSourceConfig: DataSourceConfig,
   channelId: string,
   channelName: string,
   timestampsMs: number[],
-  connectorId: string
+  connectorId: ModelId
 ) {
   const queue = new PQueue({ concurrency: MAX_CONCURRENCY_LEVEL });
 
@@ -350,8 +305,6 @@ export async function syncMultipleNoNThreaded(
   for (const startTsMs of timestampsMs) {
     const p = queue.add(() =>
       syncNonThreaded(
-        slackAccessToken,
-        dataSourceConfig,
         channelId,
         channelName,
         startTsMs,
@@ -366,16 +319,19 @@ export async function syncMultipleNoNThreaded(
 }
 
 export async function syncNonThreaded(
-  slackAccessToken: string,
-  dataSourceConfig: DataSourceConfig,
   channelId: string,
   channelName: string,
   startTsMs: number,
   endTsMs: number,
-  connectorId: string,
+  connectorId: ModelId,
   isBatchSync = false
 ) {
-  const client = getSlackClient(slackAccessToken);
+  const connector = await Connector.findByPk(connectorId);
+  if (!connector) {
+    throw new Error(`Connector ${connectorId} not found`);
+  }
+  const dataSourceConfig = dataSourceConfigFromConnector(connector);
+  const client = await getSlackClient(connectorId);
   const nextCursor: string | undefined = undefined;
   const messages: Message[] = [];
 
@@ -453,7 +409,7 @@ export async function syncNonThreaded(
 
   const tags = getTagsForPage(documentId, channelId, channelName);
   await SlackMessages.upsert({
-    connectorId: parseInt(connectorId),
+    connectorId: connectorId,
     channelId: channelId,
     messageTs: undefined,
     documentId: documentId,
@@ -474,11 +430,10 @@ export async function syncNonThreaded(
 
 export async function syncThreads(
   dataSourceConfig: DataSourceConfig,
-  slackAccessToken: string,
   channelId: string,
   channelName: string,
   threadsTs: string[],
-  connectorId: string
+  connectorId: ModelId
 ) {
   const queue = new PQueue({ concurrency: MAX_CONCURRENCY_LEVEL });
 
@@ -514,8 +469,6 @@ export async function syncThreads(
       }
 
       return syncThread(
-        dataSourceConfig,
-        slackAccessToken,
         channelId,
         channelName,
         threadTs,
@@ -529,15 +482,18 @@ export async function syncThreads(
 }
 
 export async function syncThread(
-  dataSourceConfig: DataSourceConfig,
-  slackAccessToken: string,
   channelId: string,
   channelName: string,
   threadTs: string,
-  connectorId: string,
+  connectorId: ModelId,
   isBatchSync = false
 ) {
-  const client = getSlackClient(slackAccessToken);
+  const connector = await Connector.findByPk(connectorId);
+  if (!connector) {
+    throw new Error(`Connector ${connectorId} not found`);
+  }
+  const dataSourceConfig = dataSourceConfigFromConnector(connector);
+  const slackClient = await getSlackClient(connectorId);
 
   let allMessages: Message[] = [];
 
@@ -546,7 +502,7 @@ export async function syncThread(
   do {
     try {
       const replies: ConversationsRepliesResponse =
-        await client.conversations.replies({
+        await slackClient.conversations.replies({
           channel: channelId,
           ts: threadTs,
           cursor: next_cursor,
@@ -585,14 +541,14 @@ export async function syncThread(
     }
   } while (next_cursor);
 
-  const botUserId = await getBotUserIdMemoized(slackAccessToken);
+  const botUserId = await getBotUserIdMemoized(slackClient);
   allMessages = allMessages.filter((m) => m.user !== botUserId);
 
   const text = await formatMessagesForUpsert(
     channelId,
     allMessages,
     connectorId,
-    client
+    slackClient
   );
   const documentId = `slack-${channelId}-thread-${threadTs}`;
 
@@ -600,7 +556,7 @@ export async function syncThread(
   let sourceUrl: string | undefined = undefined;
 
   if (firstMessage && firstMessage.ts) {
-    const linkRes = await client.chat.getPermalink({
+    const linkRes = await slackClient.chat.getPermalink({
       channel: channelId,
       message_ts: firstMessage.ts,
     });
@@ -616,7 +572,7 @@ export async function syncThread(
   const tags = getTagsForPage(documentId, channelId, channelName, threadTs);
 
   await SlackMessages.upsert({
-    connectorId: parseInt(connectorId),
+    connectorId: connectorId,
     channelId: channelId,
     messageTs: threadTs,
     documentId: documentId,
@@ -637,7 +593,7 @@ export async function syncThread(
 
 async function processMessageForMentions(
   message: string,
-  connectorId: string,
+  connectorId: ModelId,
   slackClient: WebClient
 ): Promise<string> {
   const matches = message.match(/<@[A-Z-0-9]+>/g);
@@ -662,7 +618,7 @@ async function processMessageForMentions(
 export async function formatMessagesForUpsert(
   channelId: string,
   messages: Message[],
-  connectorId: string,
+  connectorId: ModelId,
   slackClient: WebClient
 ) {
   return (
@@ -688,12 +644,9 @@ export async function formatMessagesForUpsert(
   ).join("\n");
 }
 
-export async function fetchUsers(
-  slackAccessToken: string,
-  connectorId: string
-) {
+export async function fetchUsers(connectorId: ModelId) {
   let cursor: string | undefined;
-  const client = getSlackClient(slackAccessToken);
+  const client = await getSlackClient(connectorId);
   do {
     const res = await client.users.list({
       cursor: cursor,
@@ -714,18 +667,16 @@ export async function fetchUsers(
   } while (cursor);
 }
 
+export async function getBotUserId(slackClient: WebClient): Promise<string>;
+export async function getBotUserId(connectorId: ModelId): Promise<string>;
 export async function getBotUserId(
-  slackAccessToken: WebClient
-): Promise<string>;
-export async function getBotUserId(slackAccessToken: string): Promise<string>;
-export async function getBotUserId(
-  slackAccessToken: string | WebClient
+  connectorIdOrSlackClient: ModelId | WebClient
 ): Promise<string> {
   let client: WebClient | undefined = undefined;
-  if (slackAccessToken instanceof WebClient) {
-    client = slackAccessToken;
+  if (connectorIdOrSlackClient instanceof WebClient) {
+    client = connectorIdOrSlackClient;
   } else {
-    client = getSlackClient(slackAccessToken);
+    client = await getSlackClient(connectorIdOrSlackClient);
   }
 
   const authRes = await client.auth.test({});
@@ -741,39 +692,26 @@ export async function getBotUserId(
 
 export const getBotUserIdMemoized = memoize(getBotUserId);
 
-export async function getAccessToken(
-  nangoConnectionId: string
-): Promise<string> {
-  if (!NANGO_SLACK_CONNECTOR_ID) {
-    throw new Error("NANGO_SLACK_CONNECTOR_ID is not defined");
-  }
-  return getAccessTokenFromNango({
-    connectionId: nangoConnectionId,
-    integrationId: NANGO_SLACK_CONNECTOR_ID,
-    useCache: true,
-  });
-}
-
-export async function saveSuccessSyncActivity(connectorId: string) {
+export async function saveSuccessSyncActivity(connectorId: ModelId) {
   logger.info(
     {
       connectorId,
     },
     "Saving success sync activity for connector"
   );
-  await syncSucceeded(parseInt(connectorId));
+  await syncSucceeded(connectorId);
 }
 
 export async function reportInitialSyncProgressActivity(
-  connectorId: string,
+  connectorId: ModelId,
   progress: string
 ) {
-  await reportInitialSyncProgress(parseInt(connectorId), progress);
+  await reportInitialSyncProgress(connectorId, progress);
 }
 
 export async function getUserName(
   slackUserId: string,
-  connectorId: string,
+  connectorId: ModelId,
   slackClient: WebClient
 ): Promise<string | undefined> {
   const fromCache = await cacheGet(getUserCacheKey(slackUserId, connectorId));
@@ -790,7 +728,7 @@ export async function getUserName(
   return;
 }
 
-function getUserCacheKey(userId: string, connectorId: string) {
+function getUserCacheKey(userId: string, connectorId: ModelId) {
   return `slack-userid2name-${connectorId}-${userId}`;
 }
 
@@ -802,52 +740,6 @@ export function formatDateForUpsert(date: Date) {
   const minutes = date.getMinutes().toString().padStart(2, "0");
 
   return `${year}${month}${day} ${hours}:${minutes}`;
-}
-
-export function getSlackClient(slackAccessToken: string): WebClient {
-  const slackClient = new WebClient(slackAccessToken, {
-    timeout: NETWORK_REQUEST_TIMEOUT_MS,
-    retryConfig: {
-      retries: 1,
-      factor: 1,
-    },
-  });
-
-  const handler: ProxyHandler<WebClient> = {
-    get: function (target, prop, receiver) {
-      const value = Reflect.get(target, prop, receiver);
-      if (["function", "object"].indexOf(typeof value) > -1) {
-        return new Proxy(value, handler);
-      }
-
-      return Reflect.get(target, prop, receiver);
-    },
-    apply: async function (target, thisArg, argumentsList) {
-      try {
-        // @ts-expect-error can't get typescript to be happy with this, but it works.
-        return await Reflect.apply(target, thisArg, argumentsList);
-      } catch (e) {
-        const slackError = e as CodedError;
-        if (slackError.code === ErrorCode.HTTPError) {
-          const httpError = slackError as WebAPIHTTPError;
-          if (httpError.statusCode === 503) {
-            const workflowError: WorkflowError = {
-              type: "upstream_is_down_activity_error",
-              message: `Slack is down: ${httpError.message}`,
-              __is_dust_error: true,
-            };
-            throw workflowError;
-          }
-        }
-
-        throw e;
-      }
-    },
-  };
-
-  const proxied = new Proxy(slackClient, handler);
-
-  return proxied;
 }
 
 function getTagsForPage(
@@ -888,8 +780,7 @@ export function formatDateForThreadTitle(date: Date) {
 }
 
 export async function getChannelsToGarbageCollect(
-  slackAccessToken: string,
-  connectorId: string
+  connectorId: ModelId
 ): Promise<{
   // either no longer visible to the integration, or bot no longer has read permission on
   channelsToDeleteFromDataSource: string[];
@@ -908,7 +799,7 @@ export async function getChannelsToGarbageCollect(
   );
 
   const remoteChannels = new Set(
-    (await getChannels(slackAccessToken, true))
+    (await getChannels(connectorId, true))
       .filter((c) => c.id)
       .map((c) => c.id as string)
   );
@@ -940,14 +831,15 @@ export async function getChannelsToGarbageCollect(
   };
 }
 
-export async function deleteChannel(
-  channelId: string,
-  dataSourceConfig: DataSourceConfig,
-  connectorId: string
-) {
+export async function deleteChannel(channelId: string, connectorId: ModelId) {
   const maxMessages = 1000;
   let nbDeleted = 0;
 
+  const connector = await Connector.findByPk(connectorId);
+  if (!connector) {
+    throw new Error(`Could not find connector ${connectorId}`);
+  }
+  const dataSourceConfig = dataSourceConfigFromConnector(connector);
   let slackMessages: SlackMessages[] = [];
   do {
     slackMessages = await SlackMessages.findAll({
@@ -973,7 +865,7 @@ export async function deleteChannel(
 
 export async function deleteChannelsFromConnectorDb(
   channelsToDeleteFromConnectorsDb: string[],
-  connectorId: string
+  connectorId: ModelId
 ) {
   await SlackChannel.destroy({
     where: {

--- a/connectors/src/connectors/slack/temporal/client.ts
+++ b/connectors/src/connectors/slack/temporal/client.ts
@@ -142,7 +142,7 @@ export async function launchSlackSyncOneMessageWorkflow(
   }
 }
 
-export async function launchSlackBotJoinedWorkflow(
+export async function launchSlackSyncOneChannelDebouncedWorkflow(
   connectorId: ModelId,
   channelId: string
 ) {

--- a/connectors/src/connectors/slack/temporal/client.ts
+++ b/connectors/src/connectors/slack/temporal/client.ts
@@ -1,5 +1,4 @@
-import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
-import { Connector } from "@connectors/lib/models";
+import { Connector, ModelId } from "@connectors/lib/models";
 import { Err, Ok } from "@connectors/lib/result";
 import { getTemporalClient } from "@connectors/lib/temporal";
 import mainLogger from "@connectors/logger/logger";
@@ -40,10 +39,15 @@ export async function launchSlackSyncWorkflow(
   };
   const nangoConnectionId = connector.connectionId;
 
-  const workflowId = workspaceFullSyncWorkflowId(connectorId, fromTs);
+  const workflowId = workspaceFullSyncWorkflowId(parseInt(connectorId), fromTs);
   try {
     await client.workflow.start(workspaceFullSync, {
-      args: [connectorId, dataSourceConfig, nangoConnectionId, fromTs],
+      args: [
+        parseInt(connectorId),
+        dataSourceConfig,
+        nangoConnectionId,
+        fromTs,
+      ],
       taskQueue: QUEUE_NAME,
       workflowId: workflowId,
     });
@@ -69,7 +73,7 @@ export async function launchSlackSyncWorkflow(
 }
 
 export async function launchSlackSyncOneThreadWorkflow(
-  connectorId: string,
+  connectorId: ModelId,
   channelId: string,
   threadTs: string
 ) {
@@ -78,12 +82,6 @@ export async function launchSlackSyncOneThreadWorkflow(
     return new Err(new Error(`Connector ${connectorId} not found`));
   }
   const client = await getTemporalClient();
-  const dataSourceConfig: DataSourceConfig = {
-    workspaceAPIKey: connector.workspaceAPIKey,
-    workspaceId: connector.workspaceId,
-    dataSourceName: connector.dataSourceName,
-  };
-  const nangoConnectionId = connector.connectionId;
 
   const workflowId = syncOneThreadDebouncedWorkflowId(
     connectorId,
@@ -94,13 +92,7 @@ export async function launchSlackSyncOneThreadWorkflow(
     const handle = await client.workflow.signalWithStart(
       syncOneThreadDebounced,
       {
-        args: [
-          connectorId,
-          dataSourceConfig,
-          nangoConnectionId,
-          channelId,
-          threadTs,
-        ],
+        args: [connectorId, channelId, threadTs],
         taskQueue: QUEUE_NAME,
         workflowId: workflowId,
         signal: newWebhookSignal,
@@ -115,7 +107,7 @@ export async function launchSlackSyncOneThreadWorkflow(
 }
 
 export async function launchSlackSyncOneMessageWorkflow(
-  connectorId: string,
+  connectorId: ModelId,
   channelId: string,
   threadTs: string
 ) {
@@ -124,13 +116,6 @@ export async function launchSlackSyncOneMessageWorkflow(
     return new Err(new Error(`Connector ${connectorId} not found`));
   }
   const client = await getTemporalClient();
-
-  const dataSourceConfig: DataSourceConfig = {
-    workspaceAPIKey: connector.workspaceAPIKey,
-    workspaceId: connector.workspaceId,
-    dataSourceName: connector.dataSourceName,
-  };
-  const nangoConnectionId = connector.connectionId;
 
   const messageTs = parseInt(threadTs as string) * 1000;
   const weekStartTsMs = getWeekStart(new Date(messageTs)).getTime();
@@ -143,13 +128,7 @@ export async function launchSlackSyncOneMessageWorkflow(
     const handle = await client.workflow.signalWithStart(
       syncOneMessageDebounced,
       {
-        args: [
-          connectorId,
-          dataSourceConfig,
-          nangoConnectionId,
-          channelId,
-          threadTs,
-        ],
+        args: [connectorId, channelId, threadTs],
         taskQueue: QUEUE_NAME,
         workflowId: workflowId,
         signal: newWebhookSignal,
@@ -164,7 +143,7 @@ export async function launchSlackSyncOneMessageWorkflow(
 }
 
 export async function launchSlackBotJoinedWorkflow(
-  connectorId: string,
+  connectorId: ModelId,
   channelId: string
 ) {
   const connector = await Connector.findByPk(connectorId);
@@ -173,17 +152,10 @@ export async function launchSlackBotJoinedWorkflow(
   }
   const client = await getTemporalClient();
 
-  const dataSourceConfig: DataSourceConfig = {
-    workspaceAPIKey: connector.workspaceAPIKey,
-    workspaceId: connector.workspaceId,
-    dataSourceName: connector.dataSourceName,
-  };
-  const nangoConnectionId = connector.connectionId;
-
   const workflowId = botJoinedChannelWorkflowId(connectorId);
   try {
     await client.workflow.signalWithStart(memberJoinedChannel, {
-      args: [connectorId, nangoConnectionId, dataSourceConfig],
+      args: [connectorId],
       taskQueue: QUEUE_NAME,
       workflowId: workflowId,
       signal: botJoinedChanelSignal,
@@ -191,7 +163,7 @@ export async function launchSlackBotJoinedWorkflow(
     });
     logger.info(
       {
-        workspaceId: dataSourceConfig.workspaceId,
+        workspaceId: connector.workspaceId,
         workflowId,
       },
       `Started workflow.`
@@ -200,7 +172,7 @@ export async function launchSlackBotJoinedWorkflow(
   } catch (e) {
     logger.error(
       {
-        workspaceId: dataSourceConfig.workspaceId,
+        workspaceId: connector.workspaceId,
         workflowId,
         error: e,
       },
@@ -210,27 +182,22 @@ export async function launchSlackBotJoinedWorkflow(
   }
 }
 
-export async function launchSlackGarbageCollectWorkflow(connectorId: string) {
+export async function launchSlackGarbageCollectWorkflow(connectorId: ModelId) {
   const connector = await Connector.findByPk(connectorId);
   if (!connector) {
     return new Err(new Error(`Connector ${connectorId} not found`));
   }
   const client = await getTemporalClient();
 
-  const dataSourceConfig: DataSourceConfig =
-    dataSourceConfigFromConnector(connector);
-  const nangoConnectionId = connector.connectionId;
-
   const workflowId = slackGarbageCollectorWorkflowId(connectorId);
   try {
     await client.workflow.start(slackGarbageCollectorWorkflow, {
-      args: [connectorId, dataSourceConfig, nangoConnectionId],
+      args: [connectorId],
       taskQueue: QUEUE_NAME,
       workflowId: workflowId,
     });
     logger.info(
       {
-        workspaceId: dataSourceConfig.workspaceId,
         workflowId,
       },
       `Started slackGarbageCollector workflow.`
@@ -239,7 +206,6 @@ export async function launchSlackGarbageCollectWorkflow(connectorId: string) {
   } catch (e) {
     logger.error(
       {
-        workspaceId: dataSourceConfig.workspaceId,
         workflowId,
         error: e,
       },

--- a/connectors/src/connectors/slack/temporal/workflows.ts
+++ b/connectors/src/connectors/slack/temporal/workflows.ts
@@ -9,7 +9,6 @@ import type * as activities from "@connectors/connectors/slack/temporal/activiti
 import { ModelId } from "@connectors/lib/models";
 import { DataSourceConfig } from "@connectors/types/data_source_config";
 
-import { joinChannel } from "../lib/channels";
 import { getWeekEnd, getWeekStart } from "../lib/utils";
 import {
   botJoinedChanelSignal,
@@ -27,6 +26,7 @@ const {
   saveSuccessSyncActivity,
   reportInitialSyncProgressActivity,
   getChannelsToGarbageCollect,
+  joinChannelAct,
   deleteChannel,
   deleteChannelsFromConnectorDb,
 } = proxyActivities<typeof activities>({
@@ -78,13 +78,7 @@ export async function syncOneChannel(
   fromTs: number | null
 ) {
   console.log(`Syncing channel ${channelName} (${channelId})`);
-  const joinRes = await joinChannel(connectorId, channelId);
-  if (joinRes.isErr()) {
-    // Here we have a channel that we are supposed to sync but we can't join it.
-    // This should pretty much never happen since we always ask for the channels:join scope when connecting
-    // Slack via OAuth, so if it happens we should surface the error.
-    throw new Error(joinRes.error.message);
-  }
+  await joinChannelAct(connectorId, channelId);
 
   let messagesCursor: string | undefined = undefined;
   let weeksSynced: Record<number, boolean> = {};

--- a/connectors/src/connectors/slack/temporal/workflows.ts
+++ b/connectors/src/connectors/slack/temporal/workflows.ts
@@ -27,6 +27,7 @@ const {
   reportInitialSyncProgressActivity,
   getChannelsToGarbageCollect,
   deleteChannel,
+  joinChannel,
   deleteChannelsFromConnectorDb,
 } = proxyActivities<typeof activities>({
   startToCloseTimeout: "10 minutes",
@@ -52,7 +53,7 @@ export async function workspaceFullSync(
 ): Promise<void> {
   const slackAccessToken = await getAccessToken(nangoConnectionId);
   await fetchUsers(slackAccessToken, connectorId);
-  const channels = await getChannels(slackAccessToken);
+  const channels = await getChannels(slackAccessToken, true);
   let i = 0;
   for (const channel of channels) {
     if (!channel.id || !channel.name) {
@@ -88,6 +89,7 @@ export async function syncOneChannel(
   fromTs: number | null
 ) {
   console.log(`Syncing channel ${channelName} (${channelId})`);
+  await joinChannel(parseInt(connectorId, 10), channelId);
 
   const slackAccessToken = await getAccessToken(nangoConnectionId);
   let messagesCursor: string | undefined = undefined;

--- a/front/components/ConnectorPermissionsModal.tsx
+++ b/front/components/ConnectorPermissionsModal.tsx
@@ -26,8 +26,7 @@ const CONNECTOR_TYPE_TO_RESOURCE_LIST_TITLE_TEXT: Record<
   ConnectorProvider,
   string | null
 > = {
-  slack:
-    "Dust's Slack application (@Dust) was invited to the channels below from your Slack workspace. Select below which channels you wish to also synchronize the data from as part of the Slack managed data source.",
+  slack: "Select which channels to synchronize with Dust from the list below:",
   notion: null,
   google_drive: null,
   github: null,
@@ -37,7 +36,7 @@ const CONNECTOR_TYPE_TO_DEFAULT_PERMISSION_TITLE_TEXT: Record<
   ConnectorProvider,
   string | null
 > = {
-  slack: "Automatically synchronize data from channels Dust is invited to.",
+  slack: null,
   notion: null,
   google_drive: null,
   github: null,

--- a/front/components/ConnectorPermissionsModal.tsx
+++ b/front/components/ConnectorPermissionsModal.tsx
@@ -122,7 +122,8 @@ export default function ConnectorPermissionsModal({
         );
 
         if (!r.ok) {
-          window.alert("An unexpected error occurred");
+          const error: { error: { message: string } } = await r.json();
+          window.alert(error.error.message);
         }
 
         await mutate(

--- a/front/lib/connector_providers.ts
+++ b/front/lib/connector_providers.ts
@@ -40,7 +40,7 @@ export const CONNECTOR_CONFIGURATIONS: Record<
     isBuilt: true,
     logoPath: "/static/slack_32x32.png",
     description:
-      "Authorize granular access to your Slack on a channel-by-channel basis.",
+      "Authorize granular access to your Slack workspace on a channel-by-channel basis.",
     logoComponent: SlackLogo,
     isNested: false,
   },

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/permissions/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/permissions/index.ts
@@ -182,7 +182,7 @@ async function handler(
           status_code: 500,
           api_error: {
             type: "internal_server_error",
-            message: `An error occurred while setting the data source permissions.`,
+            message: connectorsRes.error.error.message,
           },
         });
       }

--- a/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
@@ -407,8 +407,7 @@ function SlackBotEnableView({
 const CONNECTOR_TYPE_TO_HELPER_TEXT: Record<ConnectorProvider, string> = {
   notion: "Explore the Notion pages and databases Dust has access to.",
   google_drive: "Google Drive folders and files Dust has access to.",
-  slack:
-    "To synchronize data from Slack, first visit Slack to invite the @Dust Slack application in the desired channels. You can also select a subset of the channels the @Dust slack application was invited to for synchronization with 'Edit Permissions'. Slack channels Dust has access to.",
+  slack: "Slack channels synchronized with Dust:",
   github: "GitHub repositories Dust has access to.",
 };
 

--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -60,6 +60,8 @@ type DataSourceIntegration = {
   setupWithSuffix: string | null;
 };
 
+const REDIRECT_TO_EDIT_PERMISSIONS = ["google_drive", "slack"];
+
 export const getServerSideProps: GetServerSideProps<{
   user: UserType | null;
   owner: WorkspaceType;
@@ -311,7 +313,7 @@ export default function DataSourcesView({
               : ds;
           })
         );
-        if (provider === "google_drive") {
+        if (REDIRECT_TO_EDIT_PERMISSIONS.includes(provider)) {
           void router.push(
             `/w/${owner.sId}/builder/data-sources/${createdManagedDataSource.dataSource.name}?edit_permissions=true`
           );


### PR DESCRIPTION
This covers: https://github.com/dust-tt/dust/issues/2198

- Remove double opt-in to sync a Slack channel: (only select it in the web UI and have the Slack bot automatically join the channel)
- Graceful handling for workspaces without the scope, but looks like everybody already has it in production on Nango 🥇 
- Front is now showing the error reported by connectors when saving permissions.
