### PR TITLE
Update Anthropic chat prompt

### DIFF
--- a/core/src/providers/anthropic.rs
+++ b/core/src/providers/anthropic.rs
@@ -90,26 +90,18 @@ impl AnthropicLLM {
                         ChatMessageRole::Function => "Human",
                     },
                     match cm.role {
-                        ChatMessageRole::System => "[System Instructions] ".to_string(),
+                        ChatMessageRole::System => "[system_instructions] ".to_string(),
                         ChatMessageRole::Assistant => "".to_string(),
                         ChatMessageRole::User => match cm.name.as_ref() {
-                            Some(name) => format!("[User {}]", name),
+                            Some(name) => format!("[user: {}] ", name),
                             None => "".to_string(),
                         },
                         ChatMessageRole::Function => match cm.name.as_ref() {
-                            Some(name) => format!("[Function Result `{}`]", name),
+                            Some(name) => format!("[function_result: {}] ", name),
                             None => "[Function Result]".to_string(),
                         },
                     },
                     cm.content.as_ref().unwrap_or(&String::from("")).clone(),
-                    // match cm.name.as_ref() {
-                    //     Some(name) => match cm.role {
-                    //         ChatMessageRole::User => format!(" [{}]", name),
-                    //         ChatMessageRole::Function => format!(" [{}]", name),
-                    //         _ => String::from(""),
-                    //     },
-                    //     None => String::from(""),
-                    // },
                 )
             })
             .collect::<Vec<_>>()

--- a/core/src/providers/anthropic.rs
+++ b/core/src/providers/anthropic.rs
@@ -82,12 +82,24 @@ impl AnthropicLLM {
             .iter()
             .map(|cm| -> String {
                 format!(
-                    "\n\n{}: {}",
+                    "\n\n{}: {}{}",
                     match cm.role {
-                        ChatMessageRole::System => "System",
+                        ChatMessageRole::System => "Human",
                         ChatMessageRole::Assistant => "Assistant",
                         ChatMessageRole::User => "Human",
-                        ChatMessageRole::Function => "FunctionResult",
+                        ChatMessageRole::Function => "Human",
+                    },
+                    match cm.role {
+                        ChatMessageRole::System => "[System Instructions] ".to_string(),
+                        ChatMessageRole::Assistant => "".to_string(),
+                        ChatMessageRole::User => match cm.name.as_ref() {
+                            Some(name) => format!("[User {}]", name),
+                            None => "".to_string(),
+                        },
+                        ChatMessageRole::Function => match cm.name.as_ref() {
+                            Some(name) => format!("[Function Result `{}`]", name),
+                            None => "[Function Result]".to_string(),
+                        },
                     },
                     cm.content.as_ref().unwrap_or(&String::from("")).clone(),
                     // match cm.name.as_ref() {
@@ -123,8 +135,6 @@ impl AnthropicLLM {
         let mut stop_tokens = stop.clone();
         stop_tokens.push(String::from("\n\nHuman:"));
         stop_tokens.push(String::from("\n\nAssistant:"));
-        stop_tokens.push(String::from("\n\nSystem:"));
-        stop_tokens.push(String::from("\n\nFunctionResult:"));
 
         if max_tokens.is_none() || max_tokens.unwrap() == -1 {
             let tokens = self.encode(&prompt).await?;
@@ -176,8 +186,6 @@ impl AnthropicLLM {
         let mut stop_tokens = stop.clone();
         stop_tokens.push(String::from("\n\nHuman:"));
         stop_tokens.push(String::from("\n\nAssistant:"));
-        stop_tokens.push(String::from("\n\nSystem:"));
-        stop_tokens.push(String::from("\n\nFunctionResult:"));
 
         if max_tokens.is_none() || max_tokens.unwrap() == -1 {
             let tokens = self.encode(&prompt).await?;


### PR DESCRIPTION
Fixes: https://github.com/dust-tt/tasks/issues/144

Anthropic wants to enforce `\n\nHuman:... \n\nAssistant:` format moving forward. This PR updates our Chat prompt logic to compy to this requirement while preserving as much functionality as possible.

Tested with:
```

Human: [system_instructions] You are an helpful assistant in charge of helping with code questions. You reply straight to the point.

Human: [user: ryan] Hello world in Rust

Assistant: Here is hello world in Rust:

``rust
fn main() {
  println!("Hello, world!");
}
``

To print "Hello, world!" in Rust, you need a main function that calls the println! macro.

Human: [user: spolu] Awesome what is println! in one line?

Human: [function_result: user_context] Context on user spolu, they only understand french

Assistant:
```

Seems to work pretty well