### PR TITLE
core: k8s

### DIFF
--- a/.github/workflows/deploy-core.yml
+++ b/.github/workflows/deploy-core.yml
@@ -1,0 +1,54 @@
+name: Deploy Core
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: deploy_core
+  cancel-in-progress: false
+
+env:
+  GCLOUD_PROJECT_ID: ${{ secrets.GCLOUD_PROJECT_ID }}
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Get short sha
+        id: short_sha
+        run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      - name: "Authenticate with Google Cloud"
+        uses: "google-github-actions/auth@v1"
+        with:
+          credentials_json: "${{ secrets.GCLOUD_SA_KEY }}"
+
+      - name: "Set up Cloud SDK"
+        uses: "google-github-actions/setup-gcloud@v1"
+
+      - name: Install gke-gcloud-auth-plugin
+        run: |
+          gcloud components install gke-gcloud-auth-plugin
+
+      - name: Setup kubectl
+        run: |
+          gcloud container clusters get-credentials dust-kube --region us-central1
+
+      - name: Build the image on Cloud Build
+        run: |
+          chmod +x ./k8s/cloud-build.sh
+          ./k8s/cloud-build.sh core
+
+      - name: Deploy the image on Kubernetes
+        run: |
+          chmod +x ./k8s/deploy-image.sh
+          ./k8s/deploy-image.sh gcr.io/$GCLOUD_PROJECT_ID/core-image:${{ steps.short_sha.outputs.short_sha }} core-deployment
+
+      - name: Wait for rollout to complete
+        run: |
+          echo "Waiting for rollout to complete (web)"
+          kubectl rollout status deployment/core-deployment --timeout=10m

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -1,0 +1,12 @@
+FROM rust:1.70.0 as core
+
+WORKDIR /app
+
+COPY . .
+
+RUN cargo build --release
+
+EXPOSE 3001
+
+# Set a default command, it will start the API service if no command is provided
+CMD ["cargo", "run", "--release", "--bin", "dust-api"]

--- a/core/dockerignore
+++ b/core/dockerignore
@@ -1,0 +1,11 @@
+target
+
+# misc
+.DS_Store
+*.pem
+
+.env
+.env*.local
+
+Dockerfile*
+.dockerignore

--- a/k8s/apply_infra.sh
+++ b/k8s/apply_infra.sh
@@ -2,7 +2,6 @@
 
 set -e
 
-
 function apply_deployment {
     # This function applies a deployment, but if the deployment already exists,
     # it will replace the image with the current image to avoid a rolling update
@@ -57,6 +56,7 @@ kubectl apply -f "$(dirname "$0")/configmaps/connectors-edge-configmap.yaml"
 kubectl apply -f "$(dirname "$0")/configmaps/blog-configmap.yaml"
 kubectl apply -f "$(dirname "$0")/configmaps/docs-configmap.yaml"
 kubectl apply -f "$(dirname "$0")/configmaps/alerting-temporal-configmap.yaml"
+kubectl apply -f "$(dirname "$0")/configmaps/core-configmap.yaml"
 
 echo "-----------------------------------"
 echo "Applying backend configs"
@@ -100,6 +100,7 @@ apply_deployment blog-deployment
 apply_deployment docs-deployment
 apply_deployment metabase-deployment
 apply_deployment alerting-temporal-deployment
+apply_deployment core-deployment
 
 
 echo "-----------------------------------"
@@ -114,6 +115,7 @@ kubectl apply -f "$(dirname "$0")/services/connectors-edge-service.yaml"
 kubectl apply -f "$(dirname "$0")/services/blog-service.yaml"
 kubectl apply -f "$(dirname "$0")/services/docs-service.yaml"
 kubectl apply -f "$(dirname "$0")/services/metabase-service.yaml"
+kubectl apply -f "$(dirname "$0")/services/core-service.yaml"
 
 
 echo "-----------------------------------"

--- a/k8s/configmaps/core-configmap.yaml
+++ b/k8s/configmaps/core-configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: core-config
+data:
+  DD_ENV: "prod"
+  DD_SERVICE: "core"
+  DD_LOGS_INJECTION: "true"
+  DD_RUNTIME_METRICS_ENABLED: "true"

--- a/k8s/deployments/core-deployment.yaml
+++ b/k8s/deployments/core-deployment.yaml
@@ -16,6 +16,7 @@ spec:
       annotations:
         ad.datadoghq.com/web.logs: '[{"source": "core","service": "core","tags": ["env:prod"]}]'
     spec:
+      terminationGracePeriodSeconds: 180
       containers:
         - name: web
           image: gcr.io/or1g1n-186209/core-image:latest

--- a/k8s/deployments/core-deployment.yaml
+++ b/k8s/deployments/core-deployment.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: core-deployment
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: core
+  template:
+    metadata:
+      labels:
+        app: core
+        name: core-pod
+        admission.datadoghq.com/enabled: "true"
+      annotations:
+        ad.datadoghq.com/web.logs: '[{"source": "core","service": "core","tags": ["env:prod"]}]'
+    spec:
+      containers:
+        - name: web
+          image: gcr.io/or1g1n-186209/core-image:latest
+          command: ["cargo", "run", "--release", "--bin", "dust-api"]
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 3001
+
+          envFrom:
+            - configMapRef:
+                name: core-config
+            - secretRef:
+                name: core-secrets
+          env:
+            - name: DD_AGENT_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+
+          volumeMounts:
+            - name: service-account-volume
+              mountPath: /etc/service-accounts
+
+          resources:
+            requests:
+              cpu: 1000m
+              memory: 2.5Gi
+            limits:
+              cpu: 1000m
+              memory: 2.5Gi
+
+      volumes:
+        - name: service-account-volume
+          secret:
+            secretName: gcp-service-account-secret

--- a/k8s/services/core-service.yaml
+++ b/k8s/services/core-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: core-service
+spec:
+  selector:
+    app: core
+    name: core-pod
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 3001
+  type: ClusterIP


### PR DESCRIPTION
Fixes: https://github.com/dust-tt/tasks/issues/148

This creates the Dockerfile, and k8s configuration for a `core` service

- `core-secrets` has been created with the following:
```
SERVICE_ACCOUNT=/etc/service-accounts/gcp-service-account.json 
DUST_FRONT_API=http://front-service
```
(Other values are unchanged)

It also implements graceful sthudown on SIGTERM for `core` 

Deploy plan:
- Apply the new parts of infra
- Set up deployment through github actions
- Test deploying
- Make sure we can talk to it from `front`
- Make `front-edge` talk to the new `core` and test it
- Move `front`
- Kill old instances with fire