### PR TITLE
Fix edit message race condition using distributed lock

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1,5 +1,6 @@
 import crypto from "crypto";
 import { Op, Transaction } from "sequelize";
+import { v4 as uuidv4 } from "uuid";
 
 import {
   cloneBaseConfig,
@@ -22,6 +23,7 @@ import {
 } from "@app/lib/api/assistant/generation";
 import { Authenticator } from "@app/lib/auth";
 import { front_sequelize } from "@app/lib/databases";
+import { distributedLock } from "@app/lib/lock";
 import {
   AgentMessage,
   Conversation,
@@ -629,6 +631,7 @@ async function getConversationRankVersionLock(
   conversation: ConversationType,
   t: Transaction
 ) {
+  const uid = uuidv4();
   const now = new Date();
   // Get a lock using the unique lock key (number withing postgresql BigInt range).
   const hash = crypto
@@ -636,6 +639,7 @@ async function getConversationRankVersionLock(
     .update(`conversation_message_rank_version_${conversation.id}`)
     .digest("hex");
   const lockKey = parseInt(hash, 16) % 9999999999;
+  logger.info("[ASSISTANT_TRACE] Acquiring advisory lock", { lockKey, uid });
   await front_sequelize.query("SELECT pg_advisory_xact_lock(:key)", {
     transaction: t,
     replacements: { key: lockKey },
@@ -647,6 +651,7 @@ async function getConversationRankVersionLock(
       conversationId: conversation.sId,
       duration: new Date().getTime() - now.getTime(),
       lockKey,
+      uid,
     },
     "[ASSISTANT_TRACE] Advisory lock acquired"
   );
@@ -1064,327 +1069,340 @@ export async function* editUserMessage(
   | AgentMessageSuccessEvent,
   void
 > {
-  const user = auth.user();
-  const owner = auth.workspace();
+  const unlock = await distributedLock(`editUserMessage_${conversation.id}`);
+  try {
+    const refreshedConversation = await getConversation(auth, conversation.sId);
+    if (refreshedConversation) {
+      conversation = refreshedConversation;
+    }
 
-  if (!owner || owner.id !== conversation.owner.id) {
-    yield {
-      type: "user_message_error",
-      created: Date.now(),
-      error: {
-        code: "conversation_not_found",
-        message: "The conversation does not exist.",
-      },
-    };
-    return;
-  }
-  if (auth.user()?.id !== message.user?.id) {
-    yield {
-      type: "user_message_error",
-      created: Date.now(),
-      error: {
-        code: "not_allowed",
-        message: "Only the author of the message can edit it",
-      },
-    };
-    return;
-  }
-  if (message.mentions.filter((m) => isAgentMention(m)).length > 0) {
-    yield {
-      type: "user_message_error",
-      created: Date.now(),
-      error: {
-        code: "not_allowed",
-        message:
-          "Editing a message that already has agent mentions is not yet supported",
-      },
-    };
-    return;
-  }
+    const user = auth.user();
+    const owner = auth.workspace();
 
-  if (
-    !conversation.content[conversation.content.length - 1].some(
-      (m) => m.sId === message.sId
-    ) &&
-    mentions.filter((m) => isAgentMention(m)).length > 0
-  ) {
-    yield {
-      type: "user_message_error",
-      created: Date.now(),
-      error: {
-        code: "edition_unsupported",
-        message:
-          "Adding agent mentions when editing is only supported for the last message of the conversation",
-      },
-    };
-    return;
-  }
-
-  // In one big transaction creante all Message, UserMessage, AgentMessage and Mention rows.
-  const { userMessage, agentMessages, agentMessageRows } =
-    await front_sequelize.transaction(async (t) => {
-      await getConversationRankVersionLock(conversation, t);
-
-      const messageRow = await Message.findOne({
-        where: {
-          sId: message.sId,
-          conversationId: conversation.id,
+    if (!owner || owner.id !== conversation.owner.id) {
+      yield {
+        type: "user_message_error",
+        created: Date.now(),
+        error: {
+          code: "conversation_not_found",
+          message: "The conversation does not exist.",
         },
-        include: [
-          {
-            model: UserMessage,
-            as: "userMessage",
-            required: true,
-          },
-        ],
-      });
-      if (!messageRow || !messageRow.userMessage) {
-        throw new Error(
-          "Unexpected: Message or UserMessage to edit not found in DB"
-        );
-      }
-      const userMessageRow = messageRow.userMessage;
-      // adding messageRow as param otherwise Ts doesn't get it can't be null
-      async function createMessageAndUserMessage(messageRow: Message) {
-        return await Message.create(
-          {
-            sId: generateModelSId(),
-            rank: messageRow.rank,
+      };
+      return;
+    }
+    if (auth.user()?.id !== message.user?.id) {
+      yield {
+        type: "user_message_error",
+        created: Date.now(),
+        error: {
+          code: "not_allowed",
+          message: "Only the author of the message can edit it",
+        },
+      };
+      return;
+    }
+    if (message.mentions.filter((m) => isAgentMention(m)).length > 0) {
+      yield {
+        type: "user_message_error",
+        created: Date.now(),
+        error: {
+          code: "not_allowed",
+          message:
+            "Editing a message that already has agent mentions is not yet supported",
+        },
+      };
+      return;
+    }
+
+    if (
+      !conversation.content[conversation.content.length - 1].some(
+        (m) => m.sId === message.sId
+      ) &&
+      mentions.filter((m) => isAgentMention(m)).length > 0
+    ) {
+      yield {
+        type: "user_message_error",
+        created: Date.now(),
+        error: {
+          code: "edition_unsupported",
+          message:
+            "Adding agent mentions when editing is only supported for the last message of the conversation",
+        },
+      };
+      return;
+    }
+
+    // In one big transaction creante all Message, UserMessage, AgentMessage and Mention rows.
+    const { userMessage, agentMessages, agentMessageRows } =
+      await front_sequelize.transaction(async (t) => {
+        await getConversationRankVersionLock(conversation, t);
+
+        const messageRow = await Message.findOne({
+          where: {
+            sId: message.sId,
             conversationId: conversation.id,
-            parentId: messageRow.parentId,
-            version: messageRow.version + 1,
-            userMessageId: (
-              await UserMessage.create(
+          },
+          include: [
+            {
+              model: UserMessage,
+              as: "userMessage",
+              required: true,
+            },
+          ],
+          transaction: t,
+        });
+        if (!messageRow || !messageRow.userMessage) {
+          throw new Error(
+            "Unexpected: Message or UserMessage to edit not found in DB"
+          );
+        }
+        const userMessageRow = messageRow.userMessage;
+        // adding messageRow as param otherwise Ts doesn't get it can't be null
+        async function createMessageAndUserMessage(messageRow: Message) {
+          return await Message.create(
+            {
+              sId: generateModelSId(),
+              rank: messageRow.rank,
+              conversationId: conversation.id,
+              parentId: messageRow.parentId,
+              version: messageRow.version + 1,
+              userMessageId: (
+                await UserMessage.create(
+                  {
+                    content,
+                    userContextUsername: userMessageRow.userContextUsername,
+                    userContextTimezone: userMessageRow.userContextTimezone,
+                    userContextFullName: userMessageRow.userContextFullName,
+                    userContextEmail: userMessageRow.userContextEmail,
+                    userContextProfilePictureUrl:
+                      userMessageRow.userContextProfilePictureUrl,
+                    userId: userMessageRow.userId,
+                  },
+                  { transaction: t }
+                )
+              ).id,
+            },
+            {
+              transaction: t,
+            }
+          );
+        }
+        async function createOrUpdateParticipation() {
+          if (user) {
+            const participant = await ConversationParticipant.findOne({
+              where: {
+                conversationId: conversation.id,
+                userId: user.id,
+              },
+              transaction: t,
+            });
+            if (participant) {
+              return await participant.update(
                 {
-                  content,
-                  userContextUsername: userMessageRow.userContextUsername,
-                  userContextTimezone: userMessageRow.userContextTimezone,
-                  userContextFullName: userMessageRow.userContextFullName,
-                  userContextEmail: userMessageRow.userContextEmail,
-                  userContextProfilePictureUrl:
-                    userMessageRow.userContextProfilePictureUrl,
-                  userId: userMessageRow.userId,
+                  action: "posted",
                 },
                 { transaction: t }
-              )
-            ).id,
-          },
-          {
-            transaction: t,
-          }
-        );
-      }
-      async function createOrUpdateParticipation() {
-        if (user) {
-          const participant = await ConversationParticipant.findOne({
-            where: {
-              conversationId: conversation.id,
-              userId: user.id,
-            },
-            transaction: t,
-          });
-          if (participant) {
-            return await participant.update(
-              {
-                action: "posted",
-              },
-              { transaction: t }
-            );
-          } else {
-            throw new Error(
-              "Unreachable: edited message implies participation"
-            );
+              );
+            } else {
+              throw new Error(
+                "Unreachable: edited message implies participation"
+              );
+            }
           }
         }
-      }
-      const result = await Promise.all([
-        createMessageAndUserMessage(messageRow),
-        createOrUpdateParticipation(),
-      ]);
+        const result = await Promise.all([
+          createMessageAndUserMessage(messageRow),
+          createOrUpdateParticipation(),
+        ]);
 
-      const m = result[0];
-      const userMessage: UserMessageType = {
-        id: m.id,
-        created: m.createdAt.getTime(),
-        sId: m.sId,
-        type: "user_message",
-        visibility: m.visibility,
-        version: m.version,
-        user: user,
-        mentions,
-        content,
-        context: message.context,
-      };
+        const m = result[0];
+        const userMessage: UserMessageType = {
+          id: m.id,
+          created: m.createdAt.getTime(),
+          sId: m.sId,
+          type: "user_message",
+          visibility: m.visibility,
+          version: m.version,
+          user: user,
+          mentions,
+          content,
+          context: message.context,
+        };
 
-      // For now agent messages are appended at the end of conversation
-      // it is fine since for now editing with new mentions is only supported
-      // for the last user message
-      let nextMessageRank =
-        ((await Message.max<number | null, Message>("rank", {
-          where: {
-            conversationId: conversation.id,
-          },
-          transaction: t,
-        })) ?? -1) + 1;
-      const results: ({ row: AgentMessage; m: AgentMessageType } | null)[] =
-        await Promise.all(
-          mentions.filter(isAgentMention).map((mention) => {
-            // For each assistant/agent mention, create an "empty" agent message.
-            return (async () => {
-              // `getAgentConfiguration` checks that we're only pulling a configuration from the
-              // same workspace or a global one.
-              const configuration = await getAgentConfiguration(
-                auth,
-                mention.configurationId
-              );
-              if (!configuration) {
-                return null;
-              }
-
-              await Mention.create(
-                {
-                  messageId: m.id,
-                  agentConfigurationId: configuration.sId,
-                },
-                { transaction: t }
-              );
-
-              const agentMessageRow = await AgentMessage.create(
-                {
-                  status: "created",
-                  agentConfigurationId: configuration.sId,
-                  agentConfigurationVersion: configuration.version,
-                },
-                { transaction: t }
-              );
-              const messageRow = await Message.create(
-                {
-                  sId: generateModelSId(),
-                  rank: nextMessageRank++,
-                  conversationId: conversation.id,
-                  parentId: userMessage.id,
-                  agentMessageId: agentMessageRow.id,
-                },
-                {
-                  transaction: t,
+        // For now agent messages are appended at the end of conversation
+        // it is fine since for now editing with new mentions is only supported
+        // for the last user message
+        let nextMessageRank =
+          ((await Message.max<number | null, Message>("rank", {
+            where: {
+              conversationId: conversation.id,
+            },
+            transaction: t,
+          })) ?? -1) + 1;
+        const results: ({ row: AgentMessage; m: AgentMessageType } | null)[] =
+          await Promise.all(
+            mentions.filter(isAgentMention).map((mention) => {
+              // For each assistant/agent mention, create an "empty" agent message.
+              return (async () => {
+                // `getAgentConfiguration` checks that we're only pulling a configuration from the
+                // same workspace or a global one.
+                const configuration = await getAgentConfiguration(
+                  auth,
+                  mention.configurationId
+                );
+                if (!configuration) {
+                  return null;
                 }
-              );
 
-              return {
-                row: agentMessageRow,
-                m: {
-                  id: messageRow.id,
-                  created: agentMessageRow.createdAt.getTime(),
-                  sId: messageRow.sId,
-                  type: "agent_message",
-                  visibility: "visible",
-                  version: 0,
-                  parentMessageId: userMessage.sId,
-                  status: "created",
-                  action: null,
-                  content: null,
-                  error: null,
-                  configuration,
+                await Mention.create(
+                  {
+                    messageId: m.id,
+                    agentConfigurationId: configuration.sId,
+                  },
+                  { transaction: t }
+                );
+
+                const agentMessageRow = await AgentMessage.create(
+                  {
+                    status: "created",
+                    agentConfigurationId: configuration.sId,
+                    agentConfigurationVersion: configuration.version,
+                  },
+                  { transaction: t }
+                );
+                const messageRow = await Message.create(
+                  {
+                    sId: generateModelSId(),
+                    rank: nextMessageRank++,
+                    conversationId: conversation.id,
+                    parentId: userMessage.id,
+                    agentMessageId: agentMessageRow.id,
+                  },
+                  {
+                    transaction: t,
+                  }
+                );
+
+                return {
+                  row: agentMessageRow,
+                  m: {
+                    id: messageRow.id,
+                    created: agentMessageRow.createdAt.getTime(),
+                    sId: messageRow.sId,
+                    type: "agent_message",
+                    visibility: "visible",
+                    version: 0,
+                    parentMessageId: userMessage.sId,
+                    status: "created",
+                    action: null,
+                    content: null,
+                    error: null,
+                    configuration,
+                  },
+                };
+              })();
+            })
+          );
+
+        await Promise.all(
+          mentions.filter(isUserMention).map((mention) => {
+            return (async () => {
+              const user = await User.findOne({
+                where: {
+                  provider: mention.provider,
+                  providerId: mention.providerId,
                 },
-              };
+              });
+
+              if (user) {
+                await Mention.create(
+                  {
+                    messageId: m.id,
+                    userId: user.id,
+                  },
+                  { transaction: t }
+                );
+              }
             })();
           })
         );
 
-      await Promise.all(
-        mentions.filter(isUserMention).map((mention) => {
-          return (async () => {
-            const user = await User.findOne({
-              where: {
-                provider: mention.provider,
-                providerId: mention.providerId,
-              },
-            });
+        const nonNullResults = results.filter((r) => r !== null) as {
+          row: AgentMessage;
+          m: AgentMessageType;
+        }[];
+        return {
+          userMessage,
+          agentMessages: nonNullResults.map(({ m }) => m),
+          agentMessageRows: nonNullResults.map(({ row }) => row),
+        };
+      });
 
-            if (user) {
-              await Mention.create(
-                {
-                  messageId: m.id,
-                  userId: user.id,
-                },
-                { transaction: t }
-              );
-            }
-          })();
-        })
+    if (agentMessageRows.length !== agentMessages.length) {
+      throw new Error(
+        "Unreachable: agentMessageRows and agentMessages mismatch"
       );
-
-      const nonNullResults = results.filter((r) => r !== null) as {
-        row: AgentMessage;
-        m: AgentMessageType;
-      }[];
-      return {
-        userMessage,
-        agentMessages: nonNullResults.map(({ m }) => m),
-        agentMessageRows: nonNullResults.map(({ row }) => row),
-      };
-    });
-
-  if (agentMessageRows.length !== agentMessages.length) {
-    throw new Error("Unreachable: agentMessageRows and agentMessages mismatch");
-  }
-
-  yield {
-    type: "user_message_new",
-    created: Date.now(),
-    messageId: userMessage.sId,
-    message: userMessage,
-  };
-
-  for (let i = 0; i < agentMessages.length; i++) {
-    const agentMessage = agentMessages[i];
+    }
 
     yield {
-      type: "agent_message_new",
+      type: "user_message_new",
       created: Date.now(),
-      configurationId: agentMessage.configuration.sId,
-      messageId: agentMessage.sId,
-      message: agentMessage,
+      messageId: userMessage.sId,
+      message: userMessage,
     };
-  }
 
-  const eventStreamGenerators = agentMessages.map((agentMessage, i) => {
-    // We stitch the conversation to add the user message and only that agent message
-    // so that it can be used to prompt the agent.
-    const eventStream = runAgent(
-      auth,
-      agentMessage.configuration,
-      {
-        ...conversation,
-        content: [...conversation.content, [userMessage], [agentMessage]],
-      },
-      userMessage,
-      agentMessage
-    );
+    for (let i = 0; i < agentMessages.length; i++) {
+      const agentMessage = agentMessages[i];
 
-    return streamRunAgentEvents(
-      auth,
-      eventStream,
-      agentMessages[i],
-      agentMessageRows[i]
-    );
-  });
-
-  const eventStreamsPromises = eventStreamGenerators.map((gen) => gen.next());
-  while (eventStreamsPromises.length > 0) {
-    const winner = await Promise.race(
-      eventStreamsPromises.map(async (p, i) => {
-        return { v: await p, offset: i };
-      })
-    );
-    if (winner.v.done) {
-      eventStreamGenerators.splice(winner.offset, 1);
-      eventStreamsPromises.splice(winner.offset, 1);
-    } else {
-      eventStreamsPromises[winner.offset] =
-        eventStreamGenerators[winner.offset].next();
-      yield winner.v.value;
+      yield {
+        type: "agent_message_new",
+        created: Date.now(),
+        configurationId: agentMessage.configuration.sId,
+        messageId: agentMessage.sId,
+        message: agentMessage,
+      };
     }
+
+    const eventStreamGenerators = agentMessages.map((agentMessage, i) => {
+      // We stitch the conversation to add the user message and only that agent message
+      // so that it can be used to prompt the agent.
+      const eventStream = runAgent(
+        auth,
+        agentMessage.configuration,
+        {
+          ...conversation,
+          content: [...conversation.content, [userMessage], [agentMessage]],
+        },
+        userMessage,
+        agentMessage
+      );
+
+      return streamRunAgentEvents(
+        auth,
+        eventStream,
+        agentMessages[i],
+        agentMessageRows[i]
+      );
+    });
+
+    const eventStreamsPromises = eventStreamGenerators.map((gen) => gen.next());
+    while (eventStreamsPromises.length > 0) {
+      const winner = await Promise.race(
+        eventStreamsPromises.map(async (p, i) => {
+          return { v: await p, offset: i };
+        })
+      );
+      if (winner.v.done) {
+        eventStreamGenerators.splice(winner.offset, 1);
+        eventStreamsPromises.splice(winner.offset, 1);
+      } else {
+        eventStreamsPromises[winner.offset] =
+          eventStreamGenerators[winner.offset].next();
+        yield winner.v.value;
+      }
+    }
+  } finally {
+    await unlock();
   }
 }
 

--- a/front/lib/lock.ts
+++ b/front/lib/lock.ts
@@ -1,0 +1,63 @@
+import { uuid4 } from "@temporalio/workflow";
+import crypto from "crypto";
+
+import logger from "@app/logger/logger";
+
+import { front_sequelize } from "./databases";
+
+function lockKeyToHash(lockKey: string): number {
+  const hash = crypto.createHash("md5").update(lockKey).digest("hex");
+  const lockKeyHashed = parseInt(hash, 16) % 9999999999;
+
+  return lockKeyHashed;
+}
+
+export async function distributedLock(lockKey: string) {
+  const uid = uuid4();
+  const now = new Date();
+
+  const lockKeyHashed = lockKeyToHash(lockKey);
+  logger.info(
+    {
+      lockKey,
+      uid,
+      lockKeyHashed,
+    },
+    "[DISTRIBUTED_LOCK] Acquiring advisory lock"
+  );
+  await front_sequelize.query("SELECT pg_advisory_lock(:key)", {
+    replacements: { key: lockKeyHashed },
+  });
+
+  logger.info(
+    {
+      duration: new Date().getTime() - now.getTime(),
+      lockKeyHashed,
+      lockKey,
+      uid,
+    },
+    "[DISTRIBUTED_LOCK] Advisory lock acquired"
+  );
+
+  return async () => {
+    await distributedLockRelease(lockKey, uid);
+  };
+}
+
+export async function distributedLockRelease(
+  lockKey: string,
+  uid: string | undefined
+) {
+  const lockKeyHashed = lockKeyToHash(lockKey);
+  logger.info(
+    {
+      lockKey,
+      uid,
+      lockKeyHashed,
+    },
+    "[DISTRIBUTED_LOCK] Releasing advisory lock"
+  );
+  await front_sequelize.query("SELECT pg_advisory_unlock(:key)", {
+    replacements: { key: lockKeyHashed },
+  });
+}


### PR DESCRIPTION
When we edit a user message, we give the sId of the message to edit and then create a new one based on this one. So if we have two concurrent requests, the second one will fail 100% of the time.

The lock should be at a higher level and prevent the editing of the message entirely.

On top of that, the editUserMessage() function takes a snapshot of a conversation (vs a conversationId), which does help looking at fresh data once the lock is acquired.

