### PR TITLE
Handle transient nango and notion errors

### DIFF
--- a/connectors/src/connectors/notion/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/notion/temporal/cast_known_errors.ts
@@ -42,9 +42,9 @@ export class NotionCastKnownErrorsInterceptor
           };
         }
       } else if (UnknownHTTPResponseError.isUnknownHTTPResponseError(err)) {
-        if ([502, 504].includes(err.status)) {
-          // sometimes notion returns 502/504s, they are transient and look
-          // like rate limiting errors
+        if ([502, 504, 530].includes(err.status)) {
+          // Sometimes notion returns 502/504s, they are transient and look like rate limiting
+          // errors. 530 is transient and looks like DNS errors.
           throw {
             __is_dust_error: true,
             message: err.message,

--- a/connectors/src/lib/error.ts
+++ b/connectors/src/lib/error.ts
@@ -33,6 +33,7 @@ export function errorFromAny(e: any): Error {
 export type WorkflowErrorType =
   | "unhandled_internal_activity_error"
   | "transient_upstream_activity_error"
+  | "transient_nango_activity_error"
   | "upstream_is_down_activity_error";
 
 export type WorkflowError = {

--- a/connectors/src/lib/nango_client.ts
+++ b/connectors/src/lib/nango_client.ts
@@ -1,7 +1,7 @@
 import { Nango } from "@nangohq/node";
 import axios from "axios";
 
-import { ExternalOauthTokenError } from "@connectors/lib/error";
+import { ExternalOauthTokenError, WorkflowError } from "@connectors/lib/error";
 
 import { Err, Ok, Result } from "./result";
 
@@ -36,8 +36,15 @@ class CustomNango extends Nango {
             }
           }
         }
+        if (e.status === 520 && e.code === "ERR_BAD_RESPONSE") {
+          const workflowError: WorkflowError = {
+            type: "transient_nango_activity_error",
+            message: `Nango transient 520 errors`,
+            __is_dust_error: true,
+          };
+          throw workflowError;
+        }
       }
-
       throw e;
     }
   }


### PR DESCRIPTION
Fixes: https://github.com/dust-tt/tasks/issues/153

- Handles Nango transient 520 errors (cloudflare errors)
- Handles a new HTTP status we got from Notion (530)

Logs: https://app.datadoghq.eu/logs?query=%22Unhandled%20Activity%20Error%22%20&cols=host%2Cservice&index=%2A&messageDisplay=inline&refresh_mode=paused&stream_sort=desc&view=spans&viz=stream&from_ts=1698341719163&to_ts=1698345149676&live=false