### PR TITLE
fix: only pull write permission slack channels from assistant builder

### DIFF
--- a/connectors/src/api/get_connector_permissions.ts
+++ b/connectors/src/api/get_connector_permissions.ts
@@ -36,9 +36,16 @@ const _getConnectorPermissions = async (
   if (
     req.query.filterPermission &&
     typeof req.query.filterPermission === "string" &&
-    ["read"].includes(req.query.filterPermission)
+    ["read", "write"].includes(req.query.filterPermission)
   ) {
-    filterPermission = "read";
+    switch (req.query.filterPermission) {
+      case "read":
+        filterPermission = "read";
+        break;
+      case "write":
+        filterPermission = "write";
+        break;
+    }
   }
 
   const connector = await Connector.findByPk(req.params.connector_id);

--- a/connectors/src/api/get_connector_permissions.ts
+++ b/connectors/src/api/get_connector_permissions.ts
@@ -35,8 +35,7 @@ const _getConnectorPermissions = async (
   let filterPermission: ConnectorPermission | null = null;
   if (
     req.query.filterPermission &&
-    typeof req.query.filterPermission === "string" &&
-    ["read", "write"].includes(req.query.filterPermission)
+    typeof req.query.filterPermission === "string"
   ) {
     switch (req.query.filterPermission) {
       case "read":

--- a/front/lib/swr.ts
+++ b/front/lib/swr.ts
@@ -268,6 +268,7 @@ export function useConnectorPermissions({
   if (filterPermission) {
     url += `&filterPermission=${filterPermission}`;
   }
+  console.log("URL", url);
 
   const { data, error } = useSWR(disabled ? null : url, permissionsFetcher);
 

--- a/front/lib/swr.ts
+++ b/front/lib/swr.ts
@@ -268,7 +268,6 @@ export function useConnectorPermissions({
   if (filterPermission) {
     url += `&filterPermission=${filterPermission}`;
   }
-  console.log("URL", url);
 
   const { data, error } = useSWR(disabled ? null : url, permissionsFetcher);
 

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/permissions/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/permissions/index.ts
@@ -103,10 +103,19 @@ async function handler(
       if (
         req.query.filterPermission &&
         typeof req.query.filterPermission === "string" &&
-        ["read"].includes(req.query.filterPermission)
+        ["read", "write"].includes(req.query.filterPermission)
       ) {
-        filterPermission = "read";
+        switch (req.query.filterPermission) {
+          case "read":
+            filterPermission = "read";
+            break;
+          case "write":
+            filterPermission = "write";
+            break;
+        }
       }
+
+      console.log("filterPermission", filterPermission);
 
       const permissionsRes = await ConnectorsAPI.getConnectorPermissions({
         connectorId: dataSource.connectorId,

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/permissions/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/permissions/index.ts
@@ -115,8 +115,6 @@ async function handler(
         }
       }
 
-      console.log("filterPermission", filterPermission);
-
       const permissionsRes = await ConnectorsAPI.getConnectorPermissions({
         connectorId: dataSource.connectorId,
         parentId,

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/permissions/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/permissions/index.ts
@@ -102,8 +102,7 @@ async function handler(
       let filterPermission: ConnectorPermission | undefined = undefined;
       if (
         req.query.filterPermission &&
-        typeof req.query.filterPermission === "string" &&
-        ["read", "write"].includes(req.query.filterPermission)
+        typeof req.query.filterPermission === "string"
       ) {
         switch (req.query.filterPermission) {
           case "read":


### PR DESCRIPTION
Otherwise we show the full list of channels and when selecting one we haven't joined it will error since the SlackChannel object does not exist.

Also add a saving on connectors edit permissions since it can be a bit slowish at time and we don't want people to furiously click on save