### PR TITLE
Fix saving Assistant with slack channel selected

### DIFF
--- a/connectors/src/api/slack_channels_linked_with_agent.ts
+++ b/connectors/src/api/slack_channels_linked_with_agent.ts
@@ -90,8 +90,11 @@ const _patchSlackChannelsLinkedWithAgentHandler = async (
       }
     );
     await Promise.all(
-      slackChannels.map((slackChannel) =>
-        slackChannel.update({ agentConfigurationId }, { transaction: t })
+      slackChannelIds.map((slackChannelId) =>
+        SlackChannel.update(
+          { agentConfigurationId },
+          { where: { connectorId, slackChannelId }, transaction: t }
+        )
       )
     );
   });

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -301,10 +301,10 @@ export default function AssistantBuilder({
 
   // This state stores the slack channels that should have the current agent as default.
   const [selectedSlackChannels, setSelectedSlackChannels] = useState<
-    {
-      channelId: string;
-      channelName: string;
-    }[]
+    | {
+        channelId: string;
+        channelName: string;
+      }[]
   >([]);
   // Retrieve all the slack channels that are linked with an agent.
   const { slackChannels: slackChannelsLinkedWithAgent } =


### PR DESCRIPTION
The promise all was disfunctioning in the case where the assistant was already set on some channels.

The bug it created was:
- create an assitsant
- set some channels
- save
- edit the assistant, eg title
- save again
=> The assistant would have lost all its linked slack channels

Fixes: https://github.com/dust-tt/tasks/issues/162 