### PR TITLE
sparkle: Static Data Source screens

### DIFF
--- a/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
@@ -2,6 +2,9 @@ import {
   Button,
   Cog6ToothIcon,
   ContextItem,
+  DocumentTextIcon,
+  Page,
+  PencilSquareIcon,
   PlusIcon,
   SectionHeader,
   SlackLogo,
@@ -9,7 +12,6 @@ import {
 } from "@dust-tt/sparkle";
 import Nango from "@nangohq/frontend";
 import { GetServerSideProps, InferGetServerSidePropsType } from "next";
-import Link from "next/link";
 import { useRouter } from "next/router";
 import { useContext, useEffect, useState } from "react";
 
@@ -29,10 +31,7 @@ import {
   ConnectorsAPI,
   ConnectorType,
 } from "@app/lib/connectors_api";
-import {
-  getDisplayNameForDocument,
-  getProviderLogoPathForDataSource,
-} from "@app/lib/data_sources";
+import { getDisplayNameForDocument } from "@app/lib/data_sources";
 import { APIError } from "@app/lib/error";
 import { githubAuth } from "@app/lib/github_auth";
 import { useConnectorBotEnabled, useDocuments } from "@app/lib/swr";
@@ -149,8 +148,6 @@ function StandardDataSourceView({
     Record<string, string>
   >({});
 
-  const documentPoviderIconPath = getProviderLogoPathForDataSource(dataSource);
-
   const router = useRouter();
 
   useEffect(() => {
@@ -176,154 +173,148 @@ function StandardDataSourceView({
   }
 
   return (
-    <div className="flex flex-col">
-      <SectionHeader
-        title={`Data Source ${dataSource.name}`}
-        description="Use this page to view and upload documents to your data source."
-        action={
-          readOnly
-            ? undefined
-            : {
-                label: "Settings",
-                variant: "tertiary",
-                icon: Cog6ToothIcon,
-                onClick: () => {
-                  void router.push(
-                    `/w/${owner.sId}/builder/data-sources/${dataSource.name}/settings`
-                  );
-                },
-              }
-        }
-      />
+    <div className="pt-6">
+      <Page.Vertical align="stretch">
+        <Page.SectionHeader
+          title={`Data Source ${dataSource.name}`}
+          description="Use this page to view and upload documents to your data source."
+          action={
+            readOnly
+              ? undefined
+              : {
+                  label: "Settings",
+                  variant: "tertiary",
+                  icon: Cog6ToothIcon,
+                  onClick: () => {
+                    void router.push(
+                      `/w/${owner.sId}/builder/data-sources/${dataSource.name}/settings`
+                    );
+                  },
+                }
+          }
+        />
 
-      <div className="mt-16 flex flex-row">
-        <div className="flex flex-1">
-          <div className="flex flex-col">
-            <div className="flex flex-row">
-              <div className="flex flex-initial gap-x-2">
+        <div className="mt-16 flex flex-row">
+          <div className="flex flex-1">
+            <div className="flex flex-col">
+              <div className="flex flex-row">
+                <div className="flex flex-initial gap-x-2">
+                  <Button
+                    variant="tertiary"
+                    disabled={offset < limit}
+                    onClick={() => {
+                      if (offset >= limit) {
+                        setOffset(offset - limit);
+                      } else {
+                        setOffset(0);
+                      }
+                    }}
+                    label="Previous"
+                  />
+                  <Button
+                    variant="tertiary"
+                    label="Next"
+                    disabled={offset + limit >= total}
+                    onClick={() => {
+                      if (offset + limit < total) {
+                        setOffset(offset + limit);
+                      }
+                    }}
+                  />
+                </div>
+              </div>
+
+              <div className="mt-3 flex flex-auto pl-2 text-sm text-gray-700">
+                {total > 0 && (
+                  <span>
+                    Showing documents {offset + 1} - {last} of {total} documents
+                  </span>
+                )}
+              </div>
+            </div>
+          </div>
+
+          {readOnly ? null : (
+            <div className="">
+              <div className="mt-0 flex-none">
                 <Button
-                  variant="tertiary"
-                  disabled={offset < limit}
+                  variant="primary"
+                  icon={PlusIcon}
+                  label="Add document"
                   onClick={() => {
-                    if (offset >= limit) {
-                      setOffset(offset - limit);
+                    // Enforce plan limits: DataSource documents count.
+                    if (
+                      plan.limits.dataSources.documents.count != -1 &&
+                      total >= plan.limits.dataSources.documents.count
+                    ) {
+                      window.alert(
+                        "Data Sources are limited to 32 documents on our free plan. Contact team@dust.tt if you want to increase this limit."
+                      );
+                      return;
                     } else {
-                      setOffset(0);
-                    }
-                  }}
-                  label="Previous"
-                />
-                <Button
-                  variant="tertiary"
-                  label="Next"
-                  disabled={offset + limit >= total}
-                  onClick={() => {
-                    if (offset + limit < total) {
-                      setOffset(offset + limit);
+                      void router.push(
+                        `/w/${owner.sId}/builder/data-sources/${dataSource.name}/upsert`
+                      );
                     }
                   }}
                 />
               </div>
             </div>
-
-            <div className="mt-3 flex flex-auto pl-2 text-sm text-gray-700">
-              {total > 0 && (
-                <span>
-                  Showing documents {offset + 1} - {last} of {total} documents
-                </span>
-              )}
-            </div>
-          </div>
+          )}
         </div>
-        {readOnly ? null : (
-          <div className="">
-            <div className="mt-0 flex-none">
-              <Button
-                variant="primary"
-                icon={PlusIcon}
-                label="Add document"
-                onClick={() => {
-                  // Enforce plan limits: DataSource documents count.
-                  if (
-                    plan.limits.dataSources.documents.count != -1 &&
-                    total >= plan.limits.dataSources.documents.count
-                  ) {
-                    window.alert(
-                      "Data Sources are limited to 32 documents on our free plan. Contact team@dust.tt if you want to increase this limit."
-                    );
-                    return;
-                  } else {
-                    void router.push(
-                      `/w/${owner.sId}/builder/data-sources/${dataSource.name}/upsert`
-                    );
-                  }
-                }}
-              />
-            </div>
-          </div>
-        )}
-      </div>
 
-      <div className="mt-8 overflow-hidden pb-8">
-        <ul role="list" className="space-y-4">
-          {documents.map((d) => (
-            <li
-              key={d.document_id}
-              className="group rounded border border-gray-300 px-2 px-4"
-            >
-              <Link
-                href={`/w/${owner.sId}/builder/data-sources/${
-                  dataSource.name
-                }/upsert?documentId=${encodeURIComponent(d.document_id)}`}
-                className="block"
+        <div className="py-8">
+          <ContextItem.List>
+            {documents.map((d) => (
+              <ContextItem
+                key={d.document_id}
+                title={displayNameByDocId[d.document_id]}
+                visual={
+                  <ContextItem.Visual
+                    visual={({ className }) =>
+                      DocumentTextIcon({
+                        className: className + " text-element-600",
+                      })
+                    }
+                  />
+                }
+                action={
+                  <Button.List>
+                    <Button
+                      variant="secondary"
+                      icon={PencilSquareIcon}
+                      onClick={() => {
+                        void router.push(
+                          `/w/${owner.sId}/builder/data-sources/${
+                            dataSource.name
+                          }/upsert?documentId=${encodeURIComponent(
+                            d.document_id
+                          )}`
+                        );
+                      }}
+                      label="Edit"
+                      labelVisible={false}
+                    />
+                  </Button.List>
+                }
               >
-                <div className="mx-2 py-4">
-                  <div className="grid grid-cols-5 items-center justify-between">
-                    <div className="col-span-4">
-                      <div className="flex">
-                        {documentPoviderIconPath ? (
-                          <div className="mr-1.5 mt-1 flex h-4 w-4 flex-initial">
-                            <img src={documentPoviderIconPath}></img>
-                          </div>
-                        ) : null}
-                        <p className="truncate text-base font-bold text-action-600">
-                          {displayNameByDocId[d.document_id]}
-                        </p>
-                      </div>
-                    </div>
-                    <div className="col-span-1">
-                      <div className="ml-2 flex flex-row">
-                        <div className="flex flex-1"></div>
-                        <div className="mt-0 flex items-center">
-                          <p className="text-sm text-gray-500">
-                            {timeAgoFrom(d.timestamp)} ago
-                          </p>
-                        </div>
-                      </div>
-                    </div>
+                <ContextItem.Description>
+                  <div className="pt-2 text-sm text-element-700">
+                    {Math.floor(d.text_size / 1024)} kb,{" "}
+                    {timeAgoFrom(d.timestamp)} ago
                   </div>
-                  <div className="mt-2 flex justify-between">
-                    <div className="flex flex-initial">
-                      <p className="text-sm text-gray-300">
-                        {Math.floor(d.text_size / 1024)} kb / {d.chunk_count}{" "}
-                        chunks{" "}
-                      </p>
-                    </div>
-                  </div>
-                </div>
-              </Link>
-            </li>
-          ))}
+                </ContextItem.Description>
+              </ContextItem>
+            ))}
+          </ContextItem.List>
           {documents.length == 0 ? (
             <div className="mt-10 flex flex-col items-center justify-center text-sm text-gray-500">
               <p>No documents found for this Data Source.</p>
-              <p className="mt-2">
-                You can upload documents manually or by API.
-              </p>
+              <p className="mt-2">You can add documents manually or by API.</p>
             </div>
           ) : null}
-        </ul>
-      </div>
+        </div>
+      </Page.Vertical>
     </div>
   );
 }

--- a/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
@@ -241,7 +241,7 @@ function StandardDataSourceView({
               <Button
                 variant="primary"
                 icon={PlusIcon}
-                label="Document"
+                label="Add document"
                 onClick={() => {
                   // Enforce plan limits: DataSource documents count.
                   if (

--- a/front/pages/w/[wId]/builder/data-sources/[name]/settings.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/settings.tsx
@@ -1,4 +1,4 @@
-import { Button, Checkbox, DropdownMenu, TrashIcon } from "@dust-tt/sparkle";
+import { Button, DropdownMenu, TrashIcon } from "@dust-tt/sparkle";
 import { ChevronRightIcon } from "@heroicons/react/20/solid";
 import { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
@@ -139,10 +139,6 @@ function StandardDataSourceSettings({
   const [dataSourceDescription, setDataSourceDescription] = useState(
     dataSource.description || ""
   );
-  const [assistantDefaultSelected, setAssistantDefaultSelected] = useState(
-    dataSource.assistantDefaultSelected
-  );
-
   const [isSavingOrDeleting, setIsSavingOrDeleting] = useState(false);
   const [isEdited, setIsEdited] = useState(false);
 
@@ -153,11 +149,8 @@ function StandardDataSourceSettings({
     if (dataSourceDescription !== dataSource.description) {
       edited = true;
     }
-    if (assistantDefaultSelected === !dataSource.assistantDefaultSelected) {
-      edited = true;
-    }
     setIsEdited(edited);
-  }, [dataSource, dataSourceDescription, assistantDefaultSelected]);
+  }, [dataSource, dataSourceDescription]);
 
   useEffect(() => {
     formValidation();
@@ -209,7 +202,8 @@ function StandardDataSourceSettings({
                   await handleUpdate({
                     description: dataSourceDescription,
                     visibility: "private",
-                    assistantDefaultSelected,
+                    assistantDefaultSelected:
+                      dataSource.assistantDefaultSelected,
                   });
                   setIsSavingOrDeleting(false);
                 }
@@ -286,29 +280,6 @@ function StandardDataSourceSettings({
                     A good description will help users discover and understand
                     the purpose of your Data Source.
                   </p>
-                </div>
-
-                <div className="mt-2 sm:col-span-6">
-                  <div className="flex justify-between">
-                    <label
-                      htmlFor="assistantDefaultSelected"
-                      className="block text-sm font-medium text-gray-700"
-                    >
-                      Availability to @dust
-                    </label>
-                  </div>
-                  <div className="mt-2 flex items-center">
-                    <Checkbox
-                      checked={assistantDefaultSelected}
-                      onChange={(checked) =>
-                        setAssistantDefaultSelected(checked)
-                      }
-                    />
-                    <p className="ml-3 block text-sm text-sm font-normal text-gray-500">
-                      Make this Data Source available to the{" "}
-                      <span className="font-semibold">@dust</span> assistant.
-                    </p>
-                  </div>
                 </div>
               </div>
             </div>

--- a/front/pages/w/[wId]/builder/data-sources/[name]/settings.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/settings.tsx
@@ -345,7 +345,8 @@ function StandardDataSourceSettings({
                       </div>
 
                       <div className="text-sm font-normal text-element-700">
-                        This will delete the Data Source for everyone.
+                        This will delete the Data Source and all associated
+                        Documents for everyone.
                       </div>
                     </div>
                     <div className="flex justify-center">

--- a/front/pages/w/[wId]/builder/data-sources/[name]/upsert.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/upsert.tsx
@@ -13,7 +13,6 @@ import {
   EyeSlashIcon,
   Input,
   Page,
-  PencilSquareIcon,
   PlusIcon,
   TrashIcon,
 } from "@dust-tt/sparkle";

--- a/front/pages/w/[wId]/builder/data-sources/[name]/upsert.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/upsert.tsx
@@ -2,22 +2,22 @@ import { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 // @ts-expect-error: type package doesn't load properly because of how we are loading pdfjs
 import * as PDFJS from "pdfjs-dist/build/pdf";
-import { useEffect, useRef, useState } from "react";
+import { useContext, useEffect, useRef, useState } from "react";
 PDFJS.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${PDFJS.version}/pdf.worker.min.js`;
 
 import {
   Button,
   DocumentPlusIcon,
   DropdownMenu,
-  IconButton,
-  PlusIcon,
+  Input,
+  Page,
   TrashIcon,
-  XCircleIcon,
 } from "@dust-tt/sparkle";
 
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleSaveCancelTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { subNavigationAdmin } from "@app/components/sparkle/navigation";
+import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { getDataSource } from "@app/lib/api/data_sources";
 import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
 import { classNames } from "@app/lib/utils";
@@ -94,6 +94,8 @@ export default function DataSourceUpsert({
   const [downloading, setDownloading] = useState(false);
   const [uploading, setUploading] = useState(false);
 
+  const sendNotification = useContext(SendNotificationsContext);
+
   useEffect(() => {
     setDisabled(!documentId || !text);
   }, [documentId, text]);
@@ -123,11 +125,11 @@ export default function DataSourceUpsert({
   }, [dataSource.name, loadDocumentId, owner.sId]);
 
   const alertDataSourcesLimit = () => {
-    window.alert(
-      "DataSource document upload size is limited to " +
-        `${plan.limits.dataSources.documents.sizeMb}MB (of raw text)` +
-        ". Contact team@dust.tt if you want to increase this limit."
-    );
+    sendNotification({
+      type: "error",
+      title: "Upload size limit",
+      description: `Data Source document upload size is limited to ${plan.limits.dataSources.documents.count}MB (of raw text) Contact team@dust.tt if you want to increase this limit.`,
+    });
   };
 
   const handleFileLoadedText = (e: any) => {
@@ -181,7 +183,12 @@ export default function DataSourceUpsert({
       fileData.onloadend = handleFileLoadedText;
       fileData.readAsText(file);
     } else {
-      window.alert("File type not supported.");
+      sendNotification({
+        type: "error",
+        title: "File type not supported",
+        description: `Supported file types are: .txt, .pdf, .md, .csv.`,
+      });
+      setUploading(false);
     }
   };
 
@@ -213,7 +220,11 @@ export default function DataSourceUpsert({
     } else {
       const data = await res.json();
       console.log("UPSERT Error", data.error);
-      window.alert(`Error upserting document: ${data.error.message}`);
+      sendNotification({
+        type: "error",
+        title: "Error upserting document",
+        description: data.error.message,
+      });
       setLoading(false);
     }
   };
@@ -221,16 +232,6 @@ export default function DataSourceUpsert({
   const handleTagUpdate = (index: number, value: string) => {
     const newTags = [...tags];
     newTags[index] = value;
-    setTags(newTags);
-  };
-
-  const handleAddTag = () => {
-    setTags([...tags, ""]);
-  };
-
-  const handleTagDelete = (index: number) => {
-    const newTags = [...tags];
-    newTags.splice(index, 1);
     setTags(newTags);
   };
 
@@ -265,7 +266,7 @@ export default function DataSourceUpsert({
       })}
       titleChildren={
         <AppLayoutSimpleSaveCancelTitle
-          title="Upsert a document"
+          title={loadDocumentId ? "Edit document" : "Add a new document"}
           onCancel={() => {
             void router.push(
               `/w/${owner.sId}/builder/data-sources/${dataSource.name}`
@@ -283,213 +284,123 @@ export default function DataSourceUpsert({
       }
       hideSidebar={true}
     >
-      <div className="flex flex-col pt-8">
-        <div className="space-y-2">
-          <div className="flex flex-1">
-            <div className="w-full">
-              <div className="grid gap-x-4 gap-y-4 sm:grid-cols-5">
-                <div className="sm:col-span-5">
-                  <label
-                    htmlFor="documentId"
-                    className="block text-sm font-medium text-gray-700"
-                  >
-                    Document ID
-                  </label>
-                  <div className="mt-1 flex rounded-md shadow-sm">
-                    <input
-                      type="text"
-                      name="document"
-                      id="document"
-                      readOnly={readOnly}
-                      className={classNames(
-                        "block w-full min-w-0 flex-1 rounded-md border-gray-300 text-sm",
-                        "border-gray-300",
-                        readOnly
-                          ? "focus:border-gray-300 focus:ring-0"
-                          : "focus:border-action-500 focus:ring-action-500"
-                      )}
-                      value={documentId}
-                      onChange={(e) => setDocumentId(e.target.value)}
+      <div className="pt-6">
+        <Page.Vertical align="stretch">
+          <div className="pt-4">
+            <Page.SectionHeader title="Document title" />
+            <div className="pt-4">
+              <Input
+                placeholder="Document title"
+                name="document"
+                disabled={readOnly || !!loadDocumentId}
+                value={documentId}
+                onChange={(v) => setDocumentId(v)}
+              />
+            </div>
+          </div>
+
+          <div className="pt-4">
+            <Page.SectionHeader
+              title="Associated URL"
+              description="The URL of the associated document (if any). Will be used to link users to the original document in assistants citations."
+            />
+            <div className="pt-4">
+              <Input
+                placeholder="https://..."
+                name="document"
+                disabled={readOnly}
+                value={sourceUrl}
+                onChange={(v) => setSourceUrl(v)}
+              />
+            </div>
+          </div>
+
+          <div className="pt-4">
+            {!readOnly && (
+              <input
+                className="hidden"
+                type="file"
+                accept=".txt, .pdf, .md, .csv"
+                ref={fileInputRef}
+                onChange={async (e) => {
+                  if (e.target.files && e.target.files.length > 0) {
+                    await handleFileUpload(e.target.files[0]);
+                  }
+                }}
+              ></input>
+            )}
+            <Page.SectionHeader
+              title="Text content"
+              description="Copy paste content or upload a file (text or PDF)."
+              action={{
+                label: uploading ? "Uploading..." : "Upload file",
+                variant: "secondary",
+                icon: DocumentPlusIcon,
+                onClick: () => {
+                  if (fileInputRef.current) {
+                    fileInputRef.current.click();
+                  }
+                },
+              }}
+            />
+            <div className="pt-4">
+              <textarea
+                name="text"
+                id="text"
+                rows={20}
+                readOnly={readOnly}
+                className={classNames(
+                  "font-mono text-normal block w-full min-w-0 flex-1 rounded-md",
+                  "border-structure-200 bg-structure-50",
+                  readOnly
+                    ? "focus:border-gray-300 focus:ring-0"
+                    : "focus:border-action-300 focus:ring-action-300",
+                  downloading ? "text-element-600" : " text-element-900"
+                )}
+                disabled={downloading}
+                value={
+                  downloading
+                    ? "Downloading..."
+                    : uploading
+                    ? "Uploading..."
+                    : text
+                }
+                onChange={(e) => setText(e.target.value)}
+              />
+            </div>
+          </div>
+
+          {tags.length > 0 && (
+            <div className="pt-4">
+              <Page.SectionHeader
+                title="Developer Tags"
+                description="Tags can be set by API to filter Data Source retrieval or provide a user-friendly title for programmatically uploaded documents."
+              />
+              <div className="pt-4">
+                {tags.map((tag, index) => (
+                  <div key={index}>
+                    <Input
+                      placeholder="Tag"
+                      name="tag"
+                      disabled={true}
+                      value={tag}
+                      onChange={(v) => handleTagUpdate(index, v)}
                     />
                   </div>
-                  <p className="my-2 text-sm text-gray-500">
-                    The ID of the document (it can be anything such as a file
-                    name or title). Upserting with the ID of a document that
-                    already exists will replace it.
-                  </p>
-                </div>
+                ))}
               </div>
             </div>
-          </div>
-
-          <div className="flex flex-1">
-            <div className="mb-4 w-full">
-              <div className="mt-2 grid grid-cols-5 gap-x-4 gap-y-4">
-                <div className="col-span-3">
-                  <label
-                    htmlFor="tags"
-                    className="block text-sm font-medium text-gray-700"
-                  >
-                    Tags
-                  </label>
-                  {tags.map((tag, index) => (
-                    <div
-                      key={index}
-                      className="group mt-1 flex rounded-md shadow-sm"
-                    >
-                      <input
-                        type="text"
-                        name="document"
-                        id="document"
-                        readOnly={readOnly}
-                        className={classNames(
-                          "block w-full min-w-0 flex-1 rounded-md text-sm",
-                          "border-gray-300",
-                          readOnly
-                            ? "focus:border-gray-300 focus:ring-0"
-                            : "focus:border-action-500 focus:ring-action-500"
-                        )}
-                        value={tag}
-                        onChange={(e) => handleTagUpdate(index, e.target.value)}
-                      />
-                      {!readOnly ? (
-                        <IconButton
-                          icon={XCircleIcon}
-                          variant="tertiary"
-                          onClick={() => {
-                            handleTagDelete(index);
-                          }}
-                          className="ml-1"
-                        />
-                      ) : null}
-                    </div>
-                  ))}
-                  {!readOnly ? (
-                    <div className="mt-2 flex flex-row">
-                      <Button
-                        size="xs"
-                        label="Add tag"
-                        icon={PlusIcon}
-                        variant="tertiary"
-                        onClick={() => handleAddTag()}
-                      />
-                    </div>
-                  ) : null}
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div className="w-full pb-4">
-            <div className="grid gap-x-4 gap-y-4 sm:grid-cols-5">
-              <div className="sm:col-span-5">
-                <label
-                  htmlFor="documentId"
-                  className="block text-sm font-medium text-gray-700"
-                >
-                  Source URL
-                </label>
-                <div className="mt-1 flex rounded-md shadow-sm">
-                  <input
-                    type="text"
-                    name="document"
-                    id="document"
-                    readOnly={readOnly}
-                    className={classNames(
-                      "block w-full min-w-0 flex-1 rounded-md border-gray-300 text-sm",
-                      "border-gray-300",
-                      readOnly
-                        ? "focus:border-gray-300 focus:ring-0"
-                        : "focus:border-action-500 focus:ring-action-500"
-                    )}
-                    value={sourceUrl}
-                    onChange={(e) => setSourceUrl(e.target.value)}
-                  />
-                </div>
-                <p className="my-2 text-sm text-gray-500">
-                  The URL of the source document (if any). This will be used to
-                  link users to the original document in assistants citations.
-                </p>
-              </div>
-            </div>
-          </div>
-
-          <div className="flex w-full flex-1">
-            <div className="w-full sm:col-span-5">
-              <div className="flex flex-row items-center">
-                <div className="flex-1">
-                  <h3 className="text-sm font-medium text-gray-700">
-                    Text Content
-                  </h3>
-                  <p className="my-2 text-sm text-gray-500">
-                    Upload (text or PDF) or copy the text data for the document
-                    you want to create or replace (upsert).
-                  </p>
-                </div>
-                {!readOnly ? (
-                  <div className="ml-2 mt-0 flex-initial">
-                    <input
-                      className="hidden"
-                      type="file"
-                      accept=".txt, .pdf, .md, .csv"
-                      ref={fileInputRef}
-                      onChange={async (e) => {
-                        if (e.target.files && e.target.files.length > 0) {
-                          await handleFileUpload(e.target.files[0]);
-                        }
-                      }}
-                    ></input>
-                    <Button
-                      variant="tertiary"
-                      onClick={() => {
-                        if (fileInputRef.current) {
-                          fileInputRef.current.click();
-                        }
-                      }}
-                      icon={DocumentPlusIcon}
-                      disabled={readOnly || uploading}
-                      label={uploading ? "Uploading..." : "Upload"}
-                    ></Button>
-                  </div>
-                ) : null}
-              </div>
-              <div className="mt-1 flex rounded-md shadow-sm">
-                <textarea
-                  name="text"
-                  id="text"
-                  rows={20}
-                  readOnly={readOnly}
-                  className={classNames(
-                    "font-mono block w-full min-w-0 flex-1 rounded-md text-xs",
-                    "border-gray-300",
-                    readOnly
-                      ? "focus:border-gray-300 focus:ring-0"
-                      : "focus:border-action-500 focus:ring-action-500",
-                    downloading ? "text-gray-300" : ""
-                  )}
-                  disabled={downloading}
-                  value={
-                    downloading
-                      ? "Downloading..."
-                      : uploading
-                      ? "Uploading..."
-                      : text
-                  }
-                  onChange={(e) => setText(e.target.value)}
-                />
-              </div>
-            </div>
-          </div>
+          )}
 
           {!readOnly && loadDocumentId && (
-            <div className="flex pt-16">
+            <div className="flex py-16">
               <div className="flex">
                 <DropdownMenu>
                   <DropdownMenu.Button>
                     <Button
-                      variant="secondaryWarning"
+                      variant="primaryWarning"
                       icon={TrashIcon}
-                      label={"Delete this Document"}
+                      label={"Remove document"}
                     />
                   </DropdownMenu.Button>
                   <DropdownMenu.Items width={280}>
@@ -523,7 +434,7 @@ export default function DataSourceUpsert({
               </div>
             </div>
           )}
-        </div>
+        </Page.Vertical>
       </div>
     </AppLayout>
   );

--- a/front/pages/w/[wId]/builder/data-sources/[name]/upsert.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/upsert.tsx
@@ -9,8 +9,12 @@ import {
   Button,
   DocumentPlusIcon,
   DropdownMenu,
+  EyeIcon,
+  EyeSlashIcon,
   Input,
   Page,
+  PencilSquareIcon,
+  PlusIcon,
   TrashIcon,
 } from "@dust-tt/sparkle";
 
@@ -93,6 +97,8 @@ export default function DataSourceUpsert({
   const [loading, setLoading] = useState(false);
   const [downloading, setDownloading] = useState(false);
   const [uploading, setUploading] = useState(false);
+
+  const [developerOptionsVisible, setDeveloperOptionsVisible] = useState(false);
 
   const sendNotification = useContext(SendNotificationsContext);
 
@@ -235,6 +241,16 @@ export default function DataSourceUpsert({
     setTags(newTags);
   };
 
+  const handleAddTag = () => {
+    setTags([...tags, ""]);
+  };
+
+  const handleTagDelete = (index: number) => {
+    const newTags = [...tags];
+    newTags.splice(index, 1);
+    setTags(newTags);
+  };
+
   const handleDelete = async () => {
     const res = await fetch(
       `/api/w/${owner.sId}/data_sources/${
@@ -369,23 +385,56 @@ export default function DataSourceUpsert({
               />
             </div>
           </div>
+          <div className="pt-4">
+            <Page.SectionHeader
+              title="Developer Options"
+              action={{
+                label: developerOptionsVisible ? "Hide" : "Show",
+                variant: "tertiary",
+                icon: developerOptionsVisible ? EyeSlashIcon : EyeIcon,
+                onClick: () => {
+                  setDeveloperOptionsVisible(!developerOptionsVisible);
+                },
+              }}
+            />
+          </div>
 
-          {tags.length > 0 && (
+          {developerOptionsVisible && (
             <div className="pt-4">
               <Page.SectionHeader
-                title="Developer Tags"
-                description="Tags can be set by API to filter Data Source retrieval or provide a user-friendly title for programmatically uploaded documents."
+                title=""
+                description="Tags can be set to filter Data Source retrieval or provide a user-friendly title for programmatically uploaded documents (`title:User-friendly Title`)."
+                action={{
+                  label: "Add tag",
+                  variant: "tertiary",
+                  icon: PlusIcon,
+                  onClick: () => handleAddTag(),
+                }}
               />
               <div className="pt-4">
                 {tags.map((tag, index) => (
-                  <div key={index}>
-                    <Input
-                      placeholder="Tag"
-                      name="tag"
-                      disabled={true}
-                      value={tag}
-                      onChange={(v) => handleTagUpdate(index, v)}
-                    />
+                  <div key={index} className="flex flex-grow flex-row">
+                    <div className="flex flex-1 flex-row gap-8">
+                      <div className="flex flex-1 flex-col">
+                        <Input
+                          className="w-full"
+                          placeholder="Tag"
+                          name="tag"
+                          disabled={readOnly}
+                          value={tag}
+                          onChange={(v) => handleTagUpdate(index, v)}
+                        />
+                      </div>
+                      <div className="flex">
+                        <Button
+                          label="Remove"
+                          icon={TrashIcon}
+                          variant="secondaryWarning"
+                          onClick={() => handleTagDelete(index)}
+                          labelVisible={false}
+                        />
+                      </div>
+                    </div>
                   </div>
                 ))}
               </div>

--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -589,9 +589,9 @@ export default function DataSourcesView({
           })}
         </ContextItem.List>{" "}
         <Page.Vertical>
-          <Page.H>Limitations</Page.H>
+          <Page.SectionHeader title="Limitations" />
           <Page.P variant="secondary">
-            <ul>
+            <ul className="list-disc pl-4 text-sm">
               <li>
                 <span className="font-bold">Slack</span>: Dust doesn't take into
                 account external files or content behind a url.

--- a/front/pages/w/[wId]/builder/data-sources/new.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/new.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, SectionHeader } from "@dust-tt/sparkle";
+import { SectionHeader } from "@dust-tt/sparkle";
 import { ChevronRightIcon } from "@heroicons/react/20/solid";
 import { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
@@ -66,8 +66,6 @@ export default function DataSourceNew({
 
   const [dataSourceName, setDataSourceName] = useState("");
   const [dataSourceNameError, setDataSourceNameError] = useState("");
-  const [assistantDefaultSelected, setAssistantDefaultSelected] =
-    useState(true);
 
   const [dataSourceDescription, setDataSourceDescription] = useState("");
 
@@ -107,18 +105,9 @@ export default function DataSourceNew({
       edited = true;
     }
 
-    if (assistantDefaultSelected === false) {
-      edited = true;
-    }
-
     setIsEdited(edited);
     setIsValid(valid);
-  }, [
-    dataSourceName,
-    dataSourceDescription,
-    assistantDefaultSelected,
-    dataSources,
-  ]);
+  }, [dataSourceName, dataSourceDescription, dataSources]);
 
   useEffect(() => {
     formValidation();
@@ -137,7 +126,7 @@ export default function DataSourceNew({
         name: dataSourceName,
         description: dataSourceDescription,
         visibility: "private",
-        assistantDefaultSelected,
+        assistantDefaultSelected: false,
       }),
     });
     if (res.ok) {
@@ -243,27 +232,6 @@ export default function DataSourceNew({
                 A good description will help users discover and understand the
                 purpose of your Data Source.
               </p>
-            </div>
-
-            <div className="mt-2 sm:col-span-6">
-              <div className="flex justify-between">
-                <label
-                  htmlFor="assistantDefaultSelected"
-                  className="block text-sm font-medium text-gray-700"
-                >
-                  Availability to @dust
-                </label>
-              </div>
-              <div className="mt-2 flex items-center">
-                <Checkbox
-                  checked={assistantDefaultSelected}
-                  onChange={(checked) => setAssistantDefaultSelected(checked)}
-                />
-                <p className="ml-3 block text-sm text-sm font-normal text-gray-500">
-                  Make this Data Source available to the{" "}
-                  <span className="font-semibold">@dust</span> assistant.
-                </p>
-              </div>
             </div>
           </div>
         </div>

--- a/front/pages/w/[wId]/builder/data-sources/new.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/new.tsx
@@ -1,4 +1,4 @@
-import { SectionHeader } from "@dust-tt/sparkle";
+import { Checkbox, SectionHeader } from "@dust-tt/sparkle";
 import { ChevronRightIcon } from "@heroicons/react/20/solid";
 import { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
@@ -66,6 +66,8 @@ export default function DataSourceNew({
 
   const [dataSourceName, setDataSourceName] = useState("");
   const [dataSourceNameError, setDataSourceNameError] = useState("");
+  const [assistantDefaultSelected, setAssistantDefaultSelected] =
+    useState(true);
 
   const [dataSourceDescription, setDataSourceDescription] = useState("");
 
@@ -105,9 +107,18 @@ export default function DataSourceNew({
       edited = true;
     }
 
+    if (assistantDefaultSelected === false) {
+      edited = true;
+    }
+
     setIsEdited(edited);
     setIsValid(valid);
-  }, [dataSourceName, dataSourceDescription, dataSources]);
+  }, [
+    dataSourceName,
+    dataSourceDescription,
+    dataSources,
+    assistantDefaultSelected,
+  ]);
 
   useEffect(() => {
     formValidation();
@@ -126,7 +137,7 @@ export default function DataSourceNew({
         name: dataSourceName,
         description: dataSourceDescription,
         visibility: "private",
-        assistantDefaultSelected: false,
+        assistantDefaultSelected,
       }),
     });
     if (res.ok) {
@@ -232,6 +243,27 @@ export default function DataSourceNew({
                 A good description will help users discover and understand the
                 purpose of your Data Source.
               </p>
+            </div>
+
+            <div className="mt-2 sm:col-span-6">
+              <div className="flex justify-between">
+                <label
+                  htmlFor="assistantDefaultSelected"
+                  className="block text-sm font-medium text-gray-700"
+                >
+                  Availability to @dust
+                </label>
+              </div>
+              <div className="mt-2 flex items-center">
+                <Checkbox
+                  checked={assistantDefaultSelected}
+                  onChange={(checked) => setAssistantDefaultSelected(checked)}
+                />
+                <p className="ml-3 block text-sm text-sm font-normal text-gray-500">
+                  Make this Data Source available to the{" "}
+                  <span className="font-semibold">@dust</span> assistant.
+                </p>
+              </div>
             </div>
           </div>
         </div>

--- a/front/prompt/global_agent_helper_prompt.md
+++ b/front/prompt/global_agent_helper_prompt.md
@@ -51,7 +51,7 @@ Large Language Models (LLMs) embedding refers to the process of transforming tex
 
 ### How to invite members to the workspace
 
-As an Admin, go to 🗝️ Admin > `Workspace` > Members. You can invite members by email via `Member list` or define a whitelisted email domain in `Invitation Link` > `Settings` and then share the invitation Link. Once the members accept the invitation, select their users role: admin, builder or user.
+As an Admin, go to ️Admin > `Workspace` > Members. You can invite members by email via `Member list` or define a whitelisted email domain in `Invitation Link` > `Settings` and then share the invitation Link. Once the members accept the invitation, select their users role: admin, builder or user.
 
 ### What are the users’ different roles?
 
@@ -68,7 +68,7 @@ As an Admin, go to 🗝️ Admin > `Workspace` > Members. You can invite memb
 - Edit member roles.
 - Link and update Connections to the Workspace.
 
-### [](https://github.com/dust-tt/dust/blob/main/front/prompt/global_agent_helper_prompt.md#how-do-i-install-the-dust-assistant-in-slack)**How do I install the @Dust assistant in Slack?**
+### **How do I install the @Dust assistant in Slack?**
 
 Dust assistant in Slack is only available to paid plans and you need to connect Slack as a Connection to activate the bot. To get Dust in Slack, an admin needs to install it. Ensure the Dust app is installed and authorized in your workspace before you invite it to a channel.
 
@@ -99,9 +99,7 @@ To export your @dust conversation history in Slack, keep in mind that it's like 
 
 Connections are available only for paid plans.
 
-As an Admin, go to 🗝️ Admin > Connections > Select the desired Connection and click `Connect` > Authenticate your account and select the data you wish to synchronize with Dust.
-
-If you want the @dust assistant to default to using specific data for answers, as an admin, go to `Settings` inside the chosen Connection then select "Make this Data Source available to the @dust assistant" below `Availability to @dust`.
+As an Admin, go to ️Admin > Connections > Select the desired Connection and click `Connect` > Authenticate your account and select the data you wish to synchronize with Dust.
 
 ##Slack
 
@@ -113,17 +111,17 @@ To synchronize Notion pages, the admin can only select top level pages. To add l
 
 **How to update Connections**
 
-As an admin, 🗝️ Admin > `Connections` > Select the desired Connection and click `Manage` > `Edit permissions` > Explore and either select or deselect the data you want to synchronize with Dust.
+As an admin, ️Admin > `Connections` > Select the desired Connection and click `Manage` > `Edit permissions` > Explore and either select or deselect the data you want to synchronize with Dust.
 
 ### How long does synchronizing new messages or documents created in one of my Connections takes?
 
-Dust synchronization is run in seconds or a few minutes depending on the Connection. You can check the last sync of a Connection in 🗝️ Admin > `Connections`> “last sync ~ x s ago,” and check if a document has been synced and what's in there by searching and clicking on the needed document from the search bar.
+Dust synchronization is run in seconds or a few minutes depending on the Connection. You can check the last sync of a Connection in ️Admin > `Connections`> “last sync ~ x s ago,” and check if a document has been synced and what's in there by searching and clicking on the needed document from the search bar.
 
 ### How to add data that are not supported as a Connection by Dust
 
 As a user, you can add your data to a connected platform like Notion or Google Drive. Dust will then automatically sync it through @dust, @notion, or @googledrive.
 
-As an admin or builder go to 🗝️ Admin > `Data Sources` > select the button `Add a new Data Source` > give your data source a name and optionally a description. If you want to add this data source to @dust by default select `Make this Data Source available to the @dust assistant` > then validate `create` .
+As an admin or builder go to ️Admin > `Data Sources` > select the button `Add a new Data Source` > give your data source a name and optionally a description. Then click on `create` .
 
 ### **Does Dust use user and company data to train its models?**
 
@@ -132,6 +130,10 @@ No, Dust does not use user or company data to retrain its models. Any data sent 
 ### How many words are there in a 750KB document?
 
 A 750KB plain text document could contain around 125,000 words, assuming an average of 5 characters per word. But remember, this is a rough estimate. The actual word count can vary based on the document's format and content.
+
+### How to configure which data sources @dust has access to
+
+To configure the @dust assistant, got to `Admin` > `Assistants` and click on the `Manage` button next to the @dust assistant. You'll be enable / disable @dust and select which data sources it has access to.
 
 ## Dust’s plans
 
@@ -198,7 +200,7 @@ The key parts to set up when creating a custom assistant are `Instructions`, `
 
 **Actions:** This gives the assistant context thanks to Data Sources. The more specific the data source, the better the assistant's answers. If the assistant's task doesn't need specific knowledge, you can skip adding a data source. You can use a Dust Application to create custom assistants that perform tasks, allowing you to leverage apps for advanced use cases.
 
-Dust apps are Large Language Model (LLM) apps. As an admin or a builder, to create Dust apps go to 🗝️ Admin > Developers > Tools > select Create App. From there, you can give the app a name and decide who can access the app. A Large Language Model app uses one or more calls to models or services like APIs or Data Sources to do a specific task. They're like a layer on top of a model that makes it work a certain way.
+Dust apps are Large Language Model (LLM) apps. As an admin or a builder, to create Dust apps go to ️`Admin` > `Developers` > `Tools` and click `Create App`. From there, you can give the app a name and decide who can access the app. A Large Language Model app uses one or more calls to models or services like APIs or Data Sources to do a specific task. They're like a layer on top of a model that makes it work a certain way.
 
 ### How to edit a custom assistant?
 
@@ -338,7 +340,7 @@ Assistants are different. They combine a large language model, context, planning
 
 ### How to create custom apps?
 
-As an Admin or a builder, to create Dust custom apps go to 🗝️ Admin > `Developers`> `Tools` > select `Create App` . From there, you can give the app a name and decide who can access the app.
+As an Admin or a builder, to create Dust custom apps go to ️Admin > `Developers`> `Tools` > select `Create App` . From there, you can give the app a name and decide who can access the app.
 
 To learn how to develop an app you can explore Dust technical documentation here - https://docs.dust.tt/
 


### PR DESCRIPTION
Fixes: https://github.com/dust-tt/dust/issues/2201

Refactors upsert page and document list page. Follows framing in the issue above with an exception for tags: we only display them if they have been set by API otherwise we hide that section entirely. The design was not perfectly clear and this strikes a decent 80/20.

![Screenshot from 2023-10-31 18-24-07](https://github.com/dust-tt/dust/assets/15067/002f3eff-eb78-4666-91e6-1d2c8e61f654)
![Screenshot from 2023-10-31 18-24-16](https://github.com/dust-tt/dust/assets/15067/6d232143-108d-4bd9-978e-58db106fe26a)
![Screenshot from 2023-10-31 18-24-27](https://github.com/dust-tt/dust/assets/15067/ce561abf-d216-4e50-9f37-90cad469d5f7)
