### PR TITLE
Manage subscription per monthly active seats

### DIFF
--- a/front/components/poke/plans/form.tsx
+++ b/front/components/poke/plans/form.tsx
@@ -11,6 +11,7 @@ import { useCallback, useState } from "react";
 
 import { assertNever, classNames } from "@app/lib/utils";
 import { PokePlanType } from "@app/pages/api/poke/plans";
+import { PaidBillingType } from "@app/types/user";
 
 export type EditingPlanType = {
   name: string;
@@ -26,7 +27,7 @@ export type EditingPlanType = {
   dataSourcesDocumentsCount: string | number;
   dataSourcesDocumentsSizeMb: string | number;
   maxUsers: string | number;
-  billingType: "fixed" | "free" | "monthly_active_users";
+  billingType: "free" | PaidBillingType;
   isNewPlan?: boolean;
 };
 

--- a/front/components/poke/plans/form.tsx
+++ b/front/components/poke/plans/form.tsx
@@ -11,7 +11,7 @@ import { useCallback, useState } from "react";
 
 import { assertNever, classNames } from "@app/lib/utils";
 import { PokePlanType } from "@app/pages/api/poke/plans";
-import { PaidBillingType } from "@app/types/user";
+import { FreeBillingType, PaidBillingType } from "@app/types/user";
 
 export type EditingPlanType = {
   name: string;
@@ -27,7 +27,7 @@ export type EditingPlanType = {
   dataSourcesDocumentsCount: string | number;
   dataSourcesDocumentsSizeMb: string | number;
   maxUsers: string | number;
-  billingType: "free" | PaidBillingType;
+  billingType: FreeBillingType | PaidBillingType;
   isNewPlan?: boolean;
 };
 
@@ -114,6 +114,16 @@ export const useEditingPlan = () => {
   }, []);
 
   return { editingPlan, resetEditingPlan, createNewPlan, setEditingPlan };
+};
+
+const BILLING_TYPE_SELECT_CHOICES: Record<
+  FreeBillingType | PaidBillingType,
+  string
+> = {
+  fixed: "Fixed",
+  free: "Free",
+  monthly_active_users: "MAU",
+  monthly_active_seats: "Seats",
 };
 
 export const PLAN_FIELDS = {
@@ -224,11 +234,12 @@ export const PLAN_FIELDS = {
   },
   billingType: {
     type: "select",
-    choices: [
-      { value: "fixed", label: "Fixed" },
-      { value: "free", label: "Free" },
-      { value: "monthly_active_users", label: "MAU" },
-    ],
+    choices: Object.entries(BILLING_TYPE_SELECT_CHOICES).map(
+      ([value, label]) => ({
+        value,
+        label,
+      })
+    ),
     width: "small",
     title: "Billing",
     error: (plan: EditingPlanType) => (plan.billingType ? null : "Required"),

--- a/front/components/poke/plans/form.tsx
+++ b/front/components/poke/plans/form.tsx
@@ -123,7 +123,7 @@ const BILLING_TYPE_SELECT_CHOICES: Record<
   fixed: "Fixed",
   free: "Free",
   monthly_active_users: "MAU",
-  monthly_active_seats: "Seats",
+  per_seat: "Per Seat",
 };
 
 export const PLAN_FIELDS = {

--- a/front/lib/models/plan.ts
+++ b/front/lib/models/plan.ts
@@ -23,7 +23,11 @@ export class Plan extends Model<
   declare code: string; // unique
   declare name: string;
   declare stripeProductId: string | null;
-  declare billingType: "fixed" | "monthly_active_users" | "free";
+  declare billingType:
+    | "free"
+    | "fixed"
+    | "monthly_active_users"
+    | "monthly_active_seats";
 
   // workspace limitations
   declare maxMessages: number;
@@ -71,7 +75,9 @@ Plan.init(
       allowNull: false,
       defaultValue: "fixed",
       validate: {
-        isIn: [["fixed", "monthly_active_users", "free"]],
+        isIn: [
+          ["free", "free", "monthly_active_users", "monthly_active_seats"],
+        ],
       },
     },
     maxMessages: {

--- a/front/lib/models/plan.ts
+++ b/front/lib/models/plan.ts
@@ -11,6 +11,12 @@ import {
 
 import { front_sequelize } from "@app/lib/databases";
 import { Workspace } from "@app/lib/models/workspace";
+import {
+  FREE_BILLING_TYPES,
+  FreeBillingType,
+  PAID_BILLING_TYPES,
+  PaidBillingType,
+} from "@app/types/user";
 
 export class Plan extends Model<
   InferAttributes<Plan>,
@@ -23,11 +29,7 @@ export class Plan extends Model<
   declare code: string; // unique
   declare name: string;
   declare stripeProductId: string | null;
-  declare billingType:
-    | "free"
-    | "fixed"
-    | "monthly_active_users"
-    | "monthly_active_seats";
+  declare billingType: FreeBillingType | PaidBillingType;
 
   // workspace limitations
   declare maxMessages: number;
@@ -75,9 +77,7 @@ Plan.init(
       allowNull: false,
       defaultValue: "fixed",
       validate: {
-        isIn: [
-          ["free", "free", "monthly_active_users", "monthly_active_seats"],
-        ],
+        isIn: [[...FREE_BILLING_TYPES, ...PAID_BILLING_TYPES]],
       },
     },
     maxMessages: {

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -1,6 +1,8 @@
 import Stripe from "stripe";
 
-import { PlanType, WorkspaceType } from "@app/types/user";
+import { countActiveSeatsInWorkspace } from "@app/lib/plans/workspace_usage";
+import logger from "@app/logger/logger";
+import { PaidBillingType, PlanType, WorkspaceType } from "@app/types/user";
 
 const { STRIPE_SECRET_KEY = "", URL = "" } = process.env;
 
@@ -30,13 +32,13 @@ export const createCheckoutSession = async ({
   owner,
   planCode,
   productId,
-  isFixedPriceBilling,
+  billingType,
   stripeCustomerId,
 }: {
   owner: WorkspaceType;
   planCode: string;
   productId: string;
-  isFixedPriceBilling: boolean;
+  billingType: PaidBillingType;
   stripeCustomerId: string | null;
 }): Promise<string | null> => {
   const priceId = await getPriceId(productId);
@@ -46,14 +48,36 @@ export const createCheckoutSession = async ({
     );
   }
 
-  const item = isFixedPriceBilling
-    ? {
+  let item: { price: string; quantity?: number } | null = null;
+
+  switch (billingType) {
+    case "fixed":
+      // For a fixed price, quantity is 1 and will not change.
+      item = {
         price: priceId,
-        quantity: 1, // Fix the quantity to 1 for fixed price billing
-      }
-    : {
+        quantity: 1,
+      };
+      break;
+    case "monthly_active_seats":
+      // For a metered billing based on the number of seats, we create a line item with quantity = number of users in the workspace.
+      // We will update the quantity of the line item when the number of users changes.
+      item = {
+        price: priceId,
+        quantity: await countActiveSeatsInWorkspace(owner.sId),
+      };
+      break;
+    case "monthly_active_users":
+      // For a metered billing based on the usage, we create a line item with no quantity.
+      // We will notify Stripe of the usage when users are active in the workspace: when they post a message.
+      item = {
         price: priceId,
       };
+      break;
+    default:
+      throw new Error(
+        `Cannot subscribe to plan ${planCode}:  unknown billing type ${billingType}.`
+      );
+  }
 
   const session = await stripe.checkout.sessions.create({
     mode: "subscription",
@@ -102,4 +126,69 @@ export const getProduct = async (
 ): Promise<Stripe.Product> => {
   const product = await stripe.products.retrieve(productId);
   return product;
+};
+
+/**
+ * Calls the Stripe API to update the quantity of a subscription.
+ * https://stripe.com/docs/billing/subscriptions/upgrade-downgrade
+ */
+export const updateStripeSubscriptionQuantity = async ({
+  stripeSubscriptionId,
+  stripeProductId,
+  stripeCustomerId,
+  quantity,
+}: {
+  stripeSubscriptionId: string;
+  stripeProductId: string;
+  stripeCustomerId: string;
+  quantity: number;
+}): Promise<void> => {
+  // First, we get the current subscription
+  const stripeSubscriptions = await stripe.subscriptions.list({
+    customer: stripeCustomerId,
+  });
+
+  if (stripeSubscriptions.data.length !== 1) {
+    logger.error(
+      {
+        stripeSubscriptionId,
+        stripeCustomerId,
+        nbSubscriptions: stripeSubscriptions.data.length,
+      },
+      `Cannot update subscription quantity: expected 1 subscription.`
+    );
+    return;
+  }
+
+  const stripeSubscription = stripeSubscriptions.data[0];
+  if (stripeSubscription.id !== stripeSubscriptionId) {
+    logger.error(
+      {
+        customerId: stripeCustomerId,
+        idOnDust: stripeSubscriptionId,
+        idOnStripe: stripeSubscription.id,
+      },
+      `Cannot update subscription quantity: stripe subscription ID mismatch.`
+    );
+    return;
+  }
+
+  const currentQuantity = stripeSubscriptions.data[0].items.data[0].quantity;
+  if (currentQuantity === quantity) {
+    // No need to update the subscription
+    return;
+  }
+
+  const priceId = await getPriceId(stripeProductId);
+  if (!priceId) {
+    logger.error(
+      { stripeProductId, stripeSubscriptionId, stripeCustomerId },
+      `Cannot update subscription quantity: stripe Price ID not found for this Product id.`
+    );
+  }
+
+  const subscriptionItemId = stripeSubscription.items.data[0].id;
+  await stripe.subscriptions.update(stripeSubscriptionId, {
+    items: [{ id: subscriptionItemId, quantity, price: priceId || undefined }],
+  });
 };

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -58,7 +58,7 @@ export const createCheckoutSession = async ({
         quantity: 1,
       };
       break;
-    case "monthly_active_seats":
+    case "per_seat":
       // For a metered billing based on the number of seats, we create a line item with quantity = number of users in the workspace.
       // We will update the quantity of the line item when the number of users changes.
       item = {

--- a/front/lib/plans/subscription.ts
+++ b/front/lib/plans/subscription.ts
@@ -13,6 +13,7 @@ import {
 } from "@app/lib/plans/stripe";
 import { countActiveSeatsInWorkspace } from "@app/lib/plans/workspace_usage";
 import { generateModelSId } from "@app/lib/utils";
+import logger from "@app/logger/logger";
 import { PlanType } from "@app/types/user";
 
 /**
@@ -308,10 +309,16 @@ export const updateWorkspacePerSeatSubscriptionUsage = async ({
 
   // We update the subscription usage
   const activeSeats = await countActiveSeatsInWorkspace(workspace.sId);
-  await updateStripeSubscriptionQuantity({
-    stripeSubscriptionId: activeSubscription.stripeSubscriptionId,
-    stripeCustomerId: activeSubscription.stripeCustomerId,
-    stripeProductId: activeSubscription.plan.stripeProductId,
-    quantity: activeSeats,
-  });
+  try {
+    await updateStripeSubscriptionQuantity({
+      stripeSubscriptionId: activeSubscription.stripeSubscriptionId,
+      stripeCustomerId: activeSubscription.stripeCustomerId,
+      stripeProductId: activeSubscription.plan.stripeProductId,
+      quantity: activeSeats,
+    });
+  } catch (err) {
+    logger.error(
+      `Error while updating Stripe subscription quantity for workspace ${workspace.sId}: ${err}`
+    );
+  }
 };

--- a/front/lib/plans/workspace_usage.ts
+++ b/front/lib/plans/workspace_usage.ts
@@ -1,0 +1,24 @@
+import { Op } from "sequelize";
+
+import { Membership, Workspace } from "@app/lib/models/workspace";
+
+export async function countActiveSeatsInWorkspace(
+  workspaceId: string
+): Promise<number> {
+  const workspace = await Workspace.findOne({
+    where: {
+      sId: workspaceId,
+    },
+  });
+  if (!workspace) {
+    throw new Error(`Workspace not found for sId: ${workspaceId}`);
+  }
+  return await Membership.count({
+    where: {
+      workspaceId: workspace.id,
+      role: {
+        [Op.in]: ["user", "builder", "admin"],
+      },
+    },
+  });
+}

--- a/front/lib/plans/workspace_usage.ts
+++ b/front/lib/plans/workspace_usage.ts
@@ -17,7 +17,7 @@ export async function countActiveSeatsInWorkspace(
     where: {
       workspaceId: workspace.id,
       role: {
-        [Op.in]: ["user", "builder", "admin"],
+        [Op.notIn]: ["none", "revoked"],
       },
     },
   });

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -322,9 +322,9 @@ async function _createAndLogMembership({
     workspaceId: workspace.id,
   });
 
-  // If the user is joining a workspace with a subscription based on monthly_active_seats,
+  // If the user is joining a workspace with a subscription based on per_seat,
   // we need to update the Stripe subscription quantity.
-  await updateWorkspacePerSeatSubscriptionUsage({ workspaceId: workspace.sId });
+  void updateWorkspacePerSeatSubscriptionUsage({ workspaceId: workspace.sId });
 
   return m;
 }

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -10,7 +10,10 @@ import {
   User,
   Workspace,
 } from "@app/lib/models";
-import { internalSubscribeWorkspaceToFreeTestPlan } from "@app/lib/plans/subscription";
+import {
+  internalSubscribeWorkspaceToFreeTestPlan,
+  updateWorkspacePerSeatSubscriptionUsage,
+} from "@app/lib/plans/subscription";
 import { guessFirstandLastNameFromFullName } from "@app/lib/user";
 import { generateModelSId } from "@app/lib/utils";
 import { apiError, withLogging } from "@app/logger/withlogging";
@@ -162,11 +165,9 @@ async function handler(
           });
 
           await _createAndLogMembership({
-            workspaceId: w.id,
-            workspaceName: w.name,
+            workspace: w,
             userId: user.id,
             role: "admin",
-            invitationFlow: "personal",
           });
 
           await internalSubscribeWorkspaceToFreeTestPlan({
@@ -190,11 +191,9 @@ async function handler(
 
         if (!m) {
           m = await _createAndLogMembership({
-            workspaceId: workspaceInvite.id,
-            workspaceName: workspaceInvite.name,
+            workspace: workspaceInvite,
             userId: user.id,
             role: "user",
-            invitationFlow: "domain",
           });
         }
 
@@ -242,11 +241,9 @@ async function handler(
 
         if (!m) {
           m = await _createAndLogMembership({
-            workspaceId: targetWorkspace.id,
-            workspaceName: targetWorkspace.name,
+            workspace: targetWorkspace,
             userId: user.id,
             role: "user",
-            invitationFlow: "email",
           });
         }
         membershipInvite.status = "consumed";
@@ -310,27 +307,24 @@ async function handler(
   }
 }
 
-async function _createAndLogMembership(data: {
+async function _createAndLogMembership({
+  userId,
+  workspace,
+  role,
+}: {
   userId: number;
-  workspaceId: number;
-  workspaceName: string;
+  workspace: Workspace;
   role: "admin" | "user";
-  invitationFlow: "domain" | "email" | "personal";
 }) {
   const m = await Membership.create({
-    role: data.role,
-    userId: data.userId,
-    workspaceId: data.workspaceId,
+    role: role,
+    userId: userId,
+    workspaceId: workspace.id,
   });
 
-  // const tags = [
-  //   `workspace_id:${data.workspaceId}`,
-  //   `workspace_name:${data.workspaceName}`,
-  //   `user_id:${data.userId}`,
-  //   `role:${data.role}`,
-  //   `invitation_flow:${data.invitationFlow}`,
-  // ];
-  // statsDClient.increment("workspace.membership_created", 1, tags);
+  // If the user is joining a workspace with a subscription based on monthly_active_seats,
+  // we need to update the Stripe subscription quantity.
+  await updateWorkspacePerSeatSubscriptionUsage({ workspaceId: workspace.sId });
 
   return m;
 }

--- a/front/pages/api/poke/plans.ts
+++ b/front/pages/api/poke/plans.ts
@@ -39,6 +39,7 @@ export const PokePlanTypeSchema = t.type({
   billingType: t.union([
     t.literal("fixed"),
     t.literal("monthly_active_users"),
+    t.literal("monthly_active_seats"),
     t.literal("free"),
   ]),
 });

--- a/front/pages/api/poke/plans.ts
+++ b/front/pages/api/poke/plans.ts
@@ -39,7 +39,7 @@ export const PokePlanTypeSchema = t.type({
   billingType: t.union([
     t.literal("fixed"),
     t.literal("monthly_active_users"),
-    t.literal("monthly_active_seats"),
+    t.literal("per_seat"),
     t.literal("free"),
   ]),
 });

--- a/front/pages/api/poke/workspaces/[wId]/revoke.ts
+++ b/front/pages/api/poke/workspaces/[wId]/revoke.ts
@@ -3,6 +3,7 @@ import { NextApiRequest, NextApiResponse } from "next";
 import { getSession, getUserFromSession } from "@app/lib/auth";
 import { ReturnedAPIErrorType } from "@app/lib/error";
 import { Membership, Workspace } from "@app/lib/models";
+import { updateWorkspacePerSeatSubscriptionUsage } from "@app/lib/plans/subscription";
 import { apiError, withLogging } from "@app/logger/withlogging";
 
 export type RevokeUserResponseBody = {
@@ -96,6 +97,9 @@ async function handler(
 
       await m.update({
         role: "revoked",
+      });
+      await updateWorkspacePerSeatSubscriptionUsage({
+        workspaceId: workspace.sId,
       });
 
       return res.status(200).json({ success: true });

--- a/front/pages/api/w/[wId]/members/[userId]/index.ts
+++ b/front/pages/api/w/[wId]/members/[userId]/index.ts
@@ -2,6 +2,7 @@ import { NextApiRequest, NextApiResponse } from "next";
 
 import { Authenticator, getSession } from "@app/lib/auth";
 import { Membership, User } from "@app/lib/models";
+import { updateWorkspacePerSeatSubscriptionUsage } from "@app/lib/plans/subscription";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import { UserType } from "@app/types/user";
 
@@ -95,6 +96,11 @@ async function handler(
       await membership.update({
         role: req.body.role,
       });
+      if (req.body.role === "revoked") {
+        await updateWorkspacePerSeatSubscriptionUsage({
+          workspaceId: owner.sId,
+        });
+      }
 
       const w = { ...owner };
       w.role = "none";

--- a/front/types/user.ts
+++ b/front/types/user.ts
@@ -34,7 +34,7 @@ export const FREE_BILLING_TYPES = ["free"] as const;
 export const PAID_BILLING_TYPES = [
   "fixed",
   "monthly_active_users",
-  "monthly_active_seats",
+  "per_seat",
 ] as const;
 
 export type FreeBillingType = (typeof FREE_BILLING_TYPES)[number];

--- a/front/types/user.ts
+++ b/front/types/user.ts
@@ -30,10 +30,15 @@ export type LimitsType = {
   };
 };
 
-export type PaidBillingType =
-  | "fixed"
-  | "monthly_active_users"
-  | "monthly_active_seats";
+export const FREE_BILLING_TYPES = ["free"] as const;
+export const PAID_BILLING_TYPES = [
+  "fixed",
+  "monthly_active_users",
+  "monthly_active_seats",
+] as const;
+
+export type FreeBillingType = (typeof FREE_BILLING_TYPES)[number];
+export type PaidBillingType = (typeof PAID_BILLING_TYPES)[number];
 
 export type PlanType = {
   code: string;
@@ -43,7 +48,7 @@ export type PlanType = {
   stripeSubscriptionId: string | null;
   stripeCustomerId: string | null;
   stripeProductId: string | null;
-  billingType: "free" | PaidBillingType;
+  billingType: FreeBillingType | PaidBillingType;
   startDate: number | null;
   endDate: number | null;
   limits: LimitsType;

--- a/front/types/user.ts
+++ b/front/types/user.ts
@@ -30,6 +30,11 @@ export type LimitsType = {
   };
 };
 
+export type PaidBillingType =
+  | "fixed"
+  | "monthly_active_users"
+  | "monthly_active_seats";
+
 export type PlanType = {
   code: string;
   name: string;
@@ -38,7 +43,7 @@ export type PlanType = {
   stripeSubscriptionId: string | null;
   stripeCustomerId: string | null;
   stripeProductId: string | null;
-  billingType: "fixed" | "monthly_active_users" | "free";
+  billingType: "free" | PaidBillingType;
   startDate: number | null;
   endDate: number | null;
   limits: LimitsType;


### PR DESCRIPTION
We decided that the Pro plan (self-serve- will have a billing based on monthly active seats. 

- [x] Introduce a new value `monthly_active_seats` in billingType
- [x] Send the valid quantity for the Stripe subscription when  when creating a checkout session. 
- [x] Create a `updateStripeSubscriptionQuantity` in stripe lib to update the quantity of a subscription. 
- [x] Create a `updateWorkspacePerSeatSubscriptionUsage` that will ask to update the Stripe subscription if the number of active seats has changed and the subscription is based on active seats. 
- [x] Edit login.js to call this new business logic when we add a membership on a workspace, and the revoke logic (in poké and in app)


I need to make some tests to check how the billing works when a seat is added in the middle of the month or removed. 
Maybe what we will want is to increase the price when a new membership is created during a month, do nothing when there's a revoke, but after the end of the billing period reset the quantity to the number of active users. 

But I guess this can be reviewed already 🙏🏻 