### PR TITLE
Update init-plans with real pro plan

### DIFF
--- a/front/lib/plans/pro_plans.ts
+++ b/front/lib/plans/pro_plans.ts
@@ -1,5 +1,6 @@
 import { Attributes } from "sequelize";
 
+import { isDevelopment } from "@app/lib/development";
 import { Plan } from "@app/lib/models";
 
 export type PlanAttributes = Omit<
@@ -25,30 +26,17 @@ export const PRO_PLAN_FIXED_1000_CODE = "PRO_PLAN_FIXED_1000";
  * We can update existing plans or add new one but never remove anything from this list.
  * Entreprise custom plans will be created from Poké.
  */
+
 const PRO_PLANS_DATA: PlanAttributes[] = [
   {
-    code: "PRO_PLAN_MAU_29",
+    code: "PRO_PLAN_SEAT_29",
     name: "Pro",
-    stripeProductId: "prod_OtB9SOIwFyiQnl",
-    billingType: "monthly_active_users",
+    stripeProductId: isDevelopment()
+      ? "prod_OvrzyxfSDz5Jqd" // Pro plan in Stripe Test env
+      : "prod_OvDLYMqgnjKK1I", // Pro plan in Stripe Prod env
+    billingType: "per_seat",
     maxMessages: -1,
     maxUsersInWorkspace: 500,
-    isSlackbotAllowed: true,
-    isManagedSlackAllowed: true,
-    isManagedNotionAllowed: true,
-    isManagedGoogleDriveAllowed: true,
-    isManagedGithubAllowed: true,
-    maxDataSourcesCount: -1,
-    maxDataSourcesDocumentsCount: -1,
-    maxDataSourcesDocumentsSizeMb: 2,
-  },
-  {
-    code: "PRO_PLAN_FIXED_1000",
-    name: "Pro Fixed",
-    stripeProductId: "prod_OtBhelMswszehT",
-    billingType: "fixed",
-    maxMessages: -1,
-    maxUsersInWorkspace: 50,
     isSlackbotAllowed: true,
     isManagedSlackAllowed: true,
     isManagedNotionAllowed: true,

--- a/front/pages/w/[wId]/subscription/index.tsx
+++ b/front/pages/w/[wId]/subscription/index.tsx
@@ -139,17 +139,9 @@ export default function Subscription({
             <Button
               variant="primary"
               label="Subscribe to Pro"
-              disabled={isProcessing || plan.code === "PRO_PLAN_MAU_29"}
+              disabled={isProcessing || plan.code === "PRO_PLAN_SEAT_29"}
               onClick={async () =>
-                await handleSubscribeToPlan("PRO_PLAN_MAU_29")
-              }
-            />
-            <Button
-              variant="primary"
-              label="Subscribe to Pro Fixed"
-              disabled={isProcessing || plan.code === "PRO_PLAN_FIXED_1000"}
-              onClick={async () =>
-                await handleSubscribeToPlan("PRO_PLAN_FIXED_1000")
+                await handleSubscribeToPlan("PRO_PLAN_SEAT_29")
               }
             />
             {plan.stripeCustomerId && (


### PR DESCRIPTION
Update the pro plans:

I created 2 product in Stripe, one in test mode and one in prod. 
The command `./admin/init_plan.sh` will create the Pro plan in prod or test mode based on 'isDevelopment()`.

Todo deployment: 
- Merge and deploy this PR
- Log on prod: run `./admin/init_plans`
- PSQL on prod db: remove `PRO_PLAN_MAU_29` and `PRO_PLAN_FIXED_1000` that were test plans.


Next step: prettify the subscription page to match the figma (display the price tables from Sparkle)
