### PR TITLE
enh: give more memory to core pods

### DIFF
--- a/k8s/deployments/core-deployment.yaml
+++ b/k8s/deployments/core-deployment.yaml
@@ -42,11 +42,11 @@ spec:
 
           resources:
             requests:
-              cpu: 1000m
-              memory: 2.5Gi
+              cpu: 1250m
+              memory: 8Gi
             limits:
-              cpu: 1000m
-              memory: 2.5Gi
+              cpu: 1250m
+              memory: 8Gi
 
       volumes:
         - name: service-account-volume


### PR DESCRIPTION
fixes https://github.com/dust-tt/tasks/issues/182

increased CPU so we're within the cpu/memory ratio for k8s autopilot (that's what I understand from [the docs](https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-resource-requests#compute-class-min-max))