### PR TITLE
Fix product id for plan pro in prod

### DIFF
--- a/front/lib/plans/pro_plans.ts
+++ b/front/lib/plans/pro_plans.ts
@@ -33,7 +33,7 @@ const PRO_PLANS_DATA: PlanAttributes[] = [
     name: "Pro",
     stripeProductId: isDevelopment()
       ? "prod_OvrzyxfSDz5Jqd" // Pro plan in Stripe Test env
-      : "prod_OvDLYMqgnjKK1I", // Pro plan in Stripe Prod env
+      : "prod_OvrkkwZwLUOlpx", // Pro plan in Stripe Prod env
     billingType: "per_seat",
     maxMessages: -1,
     maxUsersInWorkspace: 500,


### PR DESCRIPTION
The id is already valid on the prod db. 