### PR TITLE
Subscription page display price tables

### DIFF
--- a/front/components/PlansTables.tsx
+++ b/front/components/PlansTables.tsx
@@ -1,10 +1,4 @@
-import {
-  Button,
-  LightbulbIcon,
-  PriceTable,
-  RocketIcon,
-  SparklesIcon,
-} from "@dust-tt/sparkle";
+import { Button, PriceTable, RocketIcon, SparklesIcon } from "@dust-tt/sparkle";
 import { Tab } from "@headlessui/react";
 import React from "react";
 
@@ -17,27 +11,15 @@ interface PricePlanProps {
   isTabs?: boolean;
   plan: PlanType;
   onClickProPlan: () => void;
-  onClickTestPlan: () => void;
   onClickEnterprisePlan: () => void;
   isProcessing: boolean;
 }
 
-function FreePriceTable({
-  size,
-  plan,
-  onClick,
-  isProcessing,
-}: {
-  size: "sm" | "xs";
-  plan: PlanType;
-  onClick: () => void;
-  isProcessing: boolean;
-}) {
-  const biggerButtonSize = size === "xs" ? "sm" : "md";
+function FreePriceTable({ size }: { size: "sm" | "xs" }) {
   return (
     <PriceTable
       title="Free"
-      price="$0"
+      price="0€"
       priceLabel=""
       color="emerald"
       size={size}
@@ -51,18 +33,6 @@ function FreePriceTable({
       <PriceTable.Item label="100 assistant messages" variant="dash" />
       <PriceTable.Item label="50 documents as data sources" variant="dash" />
       <PriceTable.Item label="No connections" variant="xmark" />
-      <PriceTable.ActionContainer>
-        {plan.code !== "FREE_TEST_PLAN" && (
-          <Button
-            variant="primary"
-            size={biggerButtonSize}
-            label="Downgrade to Free"
-            disabled={isProcessing}
-            icon={LightbulbIcon}
-            onClick={onClick}
-          />
-        )}
-      </PriceTable.ActionContainer>
     </PriceTable>
   );
 }
@@ -166,7 +136,6 @@ export function PricePlans({
   className = "",
   plan,
   onClickProPlan,
-  onClickTestPlan,
   onClickEnterprisePlan,
   isProcessing,
 }: PricePlanProps) {
@@ -229,12 +198,7 @@ export function PricePlans({
           </Tab.List>
           <Tab.Panels className="mt-8">
             <Tab.Panel>
-              <FreePriceTable
-                size={size}
-                plan={plan}
-                isProcessing={isProcessing}
-                onClick={onClickTestPlan}
-              />
+              <FreePriceTable size={size} />
             </Tab.Panel>
             <Tab.Panel>
               <ProPriceTable
@@ -263,12 +227,7 @@ export function PricePlans({
           className
         )}
       >
-        <FreePriceTable
-          size={size}
-          plan={plan}
-          isProcessing={isProcessing}
-          onClick={onClickTestPlan}
-        />
+        <FreePriceTable size={size} />
         <ProPriceTable
           size={size}
           plan={plan}

--- a/front/components/PlansTables.tsx
+++ b/front/components/PlansTables.tsx
@@ -1,0 +1,286 @@
+import {
+  Button,
+  LightbulbIcon,
+  PriceTable,
+  RocketIcon,
+  SparklesIcon,
+} from "@dust-tt/sparkle";
+import { Tab } from "@headlessui/react";
+import React from "react";
+
+import { classNames } from "@app/lib/utils";
+import { PlanType } from "@app/types/user";
+
+interface PricePlanProps {
+  size: "sm" | "xs";
+  className?: string;
+  isTabs?: boolean;
+  plan: PlanType;
+  onClickProPlan: () => void;
+  onClickTestPlan: () => void;
+  onClickEnterprisePlan: () => void;
+  isProcessing: boolean;
+}
+
+function FreePriceTable({
+  size,
+  plan,
+  onClick,
+  isProcessing,
+}: {
+  size: "sm" | "xs";
+  plan: PlanType;
+  onClick: () => void;
+  isProcessing: boolean;
+}) {
+  const biggerButtonSize = size === "xs" ? "sm" : "md";
+  return (
+    <PriceTable
+      title="Free"
+      price="$0"
+      priceLabel=""
+      color="emerald"
+      size={size}
+      magnified={false}
+    >
+      <PriceTable.Item size={size} label="One user" variant="dash" />
+      <PriceTable.Item size={size} label="One workspace" variant="dash" />
+      <PriceTable.Item label="Privacy and Data Security" />
+      <PriceTable.Item label="Advanced LLM models (GPT-4, Claude…)" />
+      <PriceTable.Item label="Unlimited custom assistants" />
+      <PriceTable.Item label="100 assistant messages" variant="dash" />
+      <PriceTable.Item label="50 documents as data sources" variant="dash" />
+      <PriceTable.Item label="No connections" variant="xmark" />
+      <PriceTable.ActionContainer>
+        {plan.code !== "FREE_TEST_PLAN" && (
+          <Button
+            variant="primary"
+            size={biggerButtonSize}
+            label="Downgrade to Free"
+            disabled={isProcessing}
+            icon={LightbulbIcon}
+            onClick={onClick}
+          />
+        )}
+      </PriceTable.ActionContainer>
+    </PriceTable>
+  );
+}
+
+function ProPriceTable({
+  size,
+  plan,
+  onClick,
+  isProcessing,
+}: {
+  size: "sm" | "xs";
+  plan: PlanType;
+  onClick: () => void;
+  isProcessing: boolean;
+}) {
+  const biggerButtonSize = size === "xs" ? "sm" : "md";
+  return (
+    <PriceTable
+      title="Pro"
+      price="29€"
+      color="sky"
+      priceLabel="/ month / user"
+      size={size}
+      magnified={false}
+    >
+      <PriceTable.Item label="From 1 user" />
+      <PriceTable.Item label="One workspace" variant="dash" />
+      <PriceTable.Item label="Privacy and Data Security" />
+      <PriceTable.Item label="Advanced LLM models (GPT-4, Claude…)" />
+      <PriceTable.Item label="Unlimited custom assistants" />
+      <PriceTable.Item label="Unlimited messages" />
+      <PriceTable.Item label="Up to 1Go/user of data sources" />
+      <PriceTable.Item
+        label="Connections
+  (GitHub, Google Drive, Notion, Slack)"
+      />
+      <PriceTable.Item label="Single Sign-on (Google, GitHub)" />
+      <PriceTable.Item label="Dust Slackbot" />
+      <PriceTable.Item label="Assistants can execute actions" />
+      <PriceTable.Item label="Workspace role and permissions" variant="dash" />
+      <PriceTable.ActionContainer>
+        {plan.code !== "PRO_PLAN_SEAT_29" && (
+          <Button
+            variant="primary"
+            size={biggerButtonSize}
+            label="Start now"
+            icon={RocketIcon}
+            disabled={isProcessing || plan.code === "PRO_PLAN_SEAT_29"}
+            onClick={onClick}
+          />
+        )}
+      </PriceTable.ActionContainer>
+    </PriceTable>
+  );
+}
+function EnterprisePriceTable({
+  size,
+  onClick,
+  isProcessing,
+}: {
+  size: "sm" | "xs";
+  onClick: () => void;
+  isProcessing: boolean;
+}) {
+  const biggerButtonSize = size === "xs" ? "sm" : "md";
+  return (
+    <PriceTable title="Enterprise" price="Custom" size={size} magnified={false}>
+      <PriceTable.Item label="From 100 users" />
+      <PriceTable.Item label="Multiple workspaces" />
+      <PriceTable.Item label="Privacy and Data Security" />
+      <PriceTable.Item label="Advanced LLM models (GPT-4, Claude…)" />
+      <PriceTable.Item label="Unlimited custom assistants" />
+      <PriceTable.Item label="Unlimited messages" />
+      <PriceTable.Item label="Unlimited data sources" />
+      <PriceTable.Item
+        label="Connections
+  (GitHub, Google Drive, Notion, Slack…)"
+      />
+      <PriceTable.Item label="Single Sign-on" />
+      <PriceTable.Item label="Dust Slackbot" />
+      <PriceTable.Item label="Assistants can execute actions" />
+      <PriceTable.Item label="Advanced workspace role and permissions" />
+      <PriceTable.Item label="Dedicated account support" />
+      <PriceTable.ActionContainer>
+        <Button
+          variant="primary"
+          size={biggerButtonSize}
+          label="Contact us"
+          icon={SparklesIcon}
+          disabled={isProcessing}
+          onClick={onClick}
+        />
+      </PriceTable.ActionContainer>
+    </PriceTable>
+  );
+}
+
+export function PricePlans({
+  size = "sm",
+  isTabs = false,
+  className = "",
+  plan,
+  onClickProPlan,
+  onClickTestPlan,
+  onClickEnterprisePlan,
+  isProcessing,
+}: PricePlanProps) {
+  if (isTabs) {
+    return (
+      <div
+        className={classNames(
+          "mx-0 sm:mx-24",
+          "w-full max-w-md px-2 py-16 sm:px-0",
+          className
+        )}
+      >
+        <Tab.Group>
+          <Tab.List className="flex space-x-1 rounded-full border border-slate-600/40 bg-slate-900/40 p-1 backdrop-blur">
+            <Tab
+              className={({ selected }) =>
+                classNames(
+                  "w-full rounded-full font-semibold transition-all duration-300 ease-out",
+                  "py-2 text-sm",
+                  "md:py-3 md:text-lg",
+                  "ring-0 focus:outline-none",
+                  selected
+                    ? "bg-emerald-500 text-white shadow"
+                    : "text-slate-300 hover:bg-white/[0.12] hover:text-white"
+                )
+              }
+            >
+              Free
+            </Tab>
+            <Tab
+              className={({ selected }) =>
+                classNames(
+                  "w-full rounded-full font-semibold transition-all duration-300 ease-out",
+                  "py-2 text-sm",
+                  "md:py-3 md:text-lg",
+                  "ring-0 focus:outline-none",
+                  selected
+                    ? "bg-sky-500 text-white shadow"
+                    : "text-slate-300 hover:bg-white/[0.12] hover:text-white"
+                )
+              }
+            >
+              Pro
+            </Tab>
+            <Tab
+              className={({ selected }) =>
+                classNames(
+                  "w-full rounded-full font-semibold transition-all duration-300 ease-out",
+                  "py-2 text-sm",
+                  "md:py-3 md:text-lg",
+                  "ring-0 focus:outline-none",
+                  selected
+                    ? "bg-pink-500 text-white shadow"
+                    : "text-slate-300 hover:bg-white/[0.12] hover:text-white"
+                )
+              }
+            >
+              Enterprise
+            </Tab>
+          </Tab.List>
+          <Tab.Panels className="mt-8">
+            <Tab.Panel>
+              <FreePriceTable
+                size={size}
+                plan={plan}
+                isProcessing={isProcessing}
+                onClick={onClickTestPlan}
+              />
+            </Tab.Panel>
+            <Tab.Panel>
+              <ProPriceTable
+                size={size}
+                plan={plan}
+                isProcessing={isProcessing}
+                onClick={onClickProPlan}
+              />
+            </Tab.Panel>
+            <Tab.Panel>
+              <EnterprisePriceTable
+                size={size}
+                isProcessing={isProcessing}
+                onClick={onClickEnterprisePlan}
+              />
+            </Tab.Panel>
+          </Tab.Panels>
+        </Tab.Group>
+      </div>
+    );
+  } else {
+    return (
+      <div
+        className={classNames(
+          "mx-4 flex flex-row md:-mx-12 md:gap-4 lg:gap-6 xl:mx-0 xl:gap-8 2xl:gap-10",
+          className
+        )}
+      >
+        <FreePriceTable
+          size={size}
+          plan={plan}
+          isProcessing={isProcessing}
+          onClick={onClickTestPlan}
+        />
+        <ProPriceTable
+          size={size}
+          plan={plan}
+          isProcessing={isProcessing}
+          onClick={onClickProPlan}
+        />
+        <EnterprisePriceTable
+          size={size}
+          isProcessing={isProcessing}
+          onClick={onClickEnterprisePlan}
+        />
+      </div>
+    );
+  }
+}

--- a/front/lib/plans/free_plans.ts
+++ b/front/lib/plans/free_plans.ts
@@ -26,7 +26,7 @@ export const FREE_UPGRADED_PLAN_CODE = "FREE_UPGRADED_PLAN";
  */
 export const FREE_TEST_PLAN_DATA: PlanAttributes = {
   code: FREE_TEST_PLAN_CODE,
-  name: "Test",
+  name: "Free",
   stripeProductId: null,
   billingType: "free",
   maxMessages: 100,

--- a/front/lib/plans/pro_plans.ts
+++ b/front/lib/plans/pro_plans.ts
@@ -36,7 +36,7 @@ const PRO_PLANS_DATA: PlanAttributes[] = [
       : "prod_OvDLYMqgnjKK1I", // Pro plan in Stripe Prod env
     billingType: "per_seat",
     maxMessages: -1,
-    maxUsersInWorkspace: 500,
+    maxUsersInWorkspace: 1000,
     isSlackbotAllowed: true,
     isManagedSlackAllowed: true,
     isManagedNotionAllowed: true,

--- a/front/lib/plans/subscription.ts
+++ b/front/lib/plans/subscription.ts
@@ -35,6 +35,7 @@ export const internalSubscribeWorkspaceToFreeTestPlan = async ({
   const activeSubscription = await Subscription.findOne({
     where: { workspaceId: workspace.id, status: "active" },
   });
+
   if (activeSubscription) {
     await activeSubscription.update({
       status: "ended",

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@dust-tt/sparkle": "^0.2.28",
+        "@dust-tt/sparkle": "^0.2.29",
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",
         "@headlessui/react": "^1.7.7",
@@ -860,9 +860,9 @@
       "integrity": "sha512-smLocSfrt3s53H/XSVP3/1kP42oqvrkjUPtyaFd1F79ux24oE31BKt+q0c6lsa6hOYrFzsIwyc5GXAI5JmfOew=="
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.28",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.28.tgz",
-      "integrity": "sha512-Bn2l0L+FrKkSOZU86IAayHWB5U6RphOQsYgV2kHydnMhqj+mSGXprq2+sOOEzU3ZT8RTpGVaOk729n8JLG5U3g==",
+      "version": "0.2.29",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.29.tgz",
+      "integrity": "sha512-zc5Apcwip4x6GjEeQbDP5IBqsdE3OyltRA+6XGIve3UzJQtiNwAda62a4G3ifAmhY9mcgt4IbU8z0VSeCEqlMQ==",
       "dependencies": {
         "@headlessui/react": "^1.7.17"
       },

--- a/front/package.json
+++ b/front/package.json
@@ -13,7 +13,7 @@
     "initdb": "env $(cat .env.local) npx tsx admin/db.ts"
   },
   "dependencies": {
-    "@dust-tt/sparkle": "^0.2.28",
+    "@dust-tt/sparkle": "^0.2.29",
     "@emoji-mart/data": "^1.1.2",
     "@emoji-mart/react": "^1.1.1",
     "@headlessui/react": "^1.7.7",

--- a/front/pages/w/[wId]/subscription/index.tsx
+++ b/front/pages/w/[wId]/subscription/index.tsx
@@ -1,8 +1,16 @@
-import { Button, Chip, Page, PageHeader, ShapesIcon } from "@dust-tt/sparkle";
+import {
+  Button,
+  Chip,
+  ExternalLinkIcon,
+  Page,
+  PageHeader,
+  ShapesIcon,
+} from "@dust-tt/sparkle";
 import { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import router from "next/router";
 import React, { useContext } from "react";
 
+import { PricePlans } from "@app/components/PlansTables";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { subNavigationAdmin } from "@app/components/sparkle/navigation";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
@@ -112,6 +120,16 @@ export default function Subscription({
     setIsProcessing(false);
   }
 
+  const chipColor = plan.code === "FREE_TEST_PLAN" ? "emerald" : "sky";
+
+  const onClickTestPlan = async () =>
+    await handleSubscribeToPlan("FREE_TEST_PLAN");
+  const onClickProPlan = async () =>
+    await handleSubscribeToPlan("PRO_PLAN_SEAT_29");
+  const onClickEnterprisePlan = () => {
+    window.open("mailto:team@dust.tt?subject=Upgrading to Enteprise plan");
+  };
+
   return (
     <AppLayout
       user={user}
@@ -127,31 +145,55 @@ export default function Subscription({
           description="Choose the plan that works for you."
         />
         <Page.Vertical align="stretch" gap="md">
-          <Page.H variant="h5">Your plan </Page.H>
-          <div>
-            You're currently on the <Chip color="pink" label={plan.name} />{" "}
-            plan.
+          <div className="flex">
+            <div className="flex-1">
+              <Page.H variant="h5">Your plan </Page.H>
+              <div className="pt-2">
+                You're on&nbsp;&nbsp;
+                <Chip size="sm" color={chipColor} label={plan.name} />
+              </div>
+            </div>
+            <div className="flex-1">
+              {plan.stripeCustomerId && (
+                <>
+                  <Page.H variant="h5">Payment, invoicing & billing</Page.H>
+                  <div className="pt-2">
+                    <Button
+                      icon={ExternalLinkIcon}
+                      size="sm"
+                      variant="secondary"
+                      label="Visit Dust's dashboard on Stripe"
+                      disabled={isProcessing}
+                      onClick={async () => await handleGoToStripePortal()}
+                    />
+                  </div>
+                </>
+              )}
+            </div>
           </div>
-
-          <Page.H variant="h5">Manage my plan </Page.H>
-
-          <div className="flex flex-row gap-2">
-            <Button
-              variant="primary"
-              label="Subscribe to Pro"
-              disabled={isProcessing || plan.code === "PRO_PLAN_SEAT_29"}
-              onClick={async () =>
-                await handleSubscribeToPlan("PRO_PLAN_SEAT_29")
-              }
-            />
-            {plan.stripeCustomerId && (
-              <Button
-                variant="primary"
-                label="Visit Dust's billing dashboard on Stripe"
-                disabled={isProcessing}
-                onClick={async () => await handleGoToStripePortal()}
+          <div className="pt-2">
+            <Page.H variant="h5">Manage my plan</Page.H>
+            <div className="s-h-full s-w-full pt-2">
+              <PricePlans
+                size="xs"
+                className="xl:hidden"
+                isTabs
+                plan={plan}
+                onClickTestPlan={onClickTestPlan}
+                onClickProPlan={onClickProPlan}
+                onClickEnterprisePlan={onClickEnterprisePlan}
+                isProcessing={isProcessing}
               />
-            )}
+              <PricePlans
+                size="xs"
+                className="hidden xl:flex"
+                plan={plan}
+                onClickTestPlan={onClickTestPlan}
+                onClickProPlan={onClickProPlan}
+                onClickEnterprisePlan={onClickEnterprisePlan}
+                isProcessing={isProcessing}
+              />
+            </div>
           </div>
         </Page.Vertical>
       </Page.Vertical>

--- a/front/pages/w/[wId]/subscription/index.tsx
+++ b/front/pages/w/[wId]/subscription/index.tsx
@@ -122,8 +122,6 @@ export default function Subscription({
 
   const chipColor = plan.code === "FREE_TEST_PLAN" ? "emerald" : "sky";
 
-  const onClickTestPlan = async () =>
-    await handleSubscribeToPlan("FREE_TEST_PLAN");
   const onClickProPlan = async () =>
     await handleSubscribeToPlan("PRO_PLAN_SEAT_29");
   const onClickEnterprisePlan = () => {
@@ -179,7 +177,6 @@ export default function Subscription({
                 className="xl:hidden"
                 isTabs
                 plan={plan}
-                onClickTestPlan={onClickTestPlan}
                 onClickProPlan={onClickProPlan}
                 onClickEnterprisePlan={onClickEnterprisePlan}
                 isProcessing={isProcessing}
@@ -188,7 +185,6 @@ export default function Subscription({
                 size="xs"
                 className="hidden xl:flex"
                 plan={plan}
-                onClickTestPlan={onClickTestPlan}
                 onClickProPlan={onClickProPlan}
                 onClickEnterprisePlan={onClickEnterprisePlan}
                 isProcessing={isProcessing}


### PR DESCRIPTION
The code from PlansTables has mostly been copied from @Duncid's PR here: https://github.com/dust-tt/dust/pull/2305
🙇🏻‍♀️ 

IN my screenshot the price is in dollar but I updated in the code.


### Big layout
<img width="1558" alt="Capture d’écran 2023-11-02 à 16 58 26" src="https://github.com/dust-tt/dust/assets/3803406/f35f52bd-0652-4349-97f4-894b644fcb96">

### Small layout
<img width="1090" alt="Capture d’écran 2023-11-02 à 17 01 50" src="https://github.com/dust-tt/dust/assets/3803406/ec0db4be-1e8d-439e-a008-0f2e7ea2229f">
