### PR TITLE
Popup component in sparkle

### DIFF
--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.29",
+  "version": "0.2.30",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/_index.ts
+++ b/sparkle/src/_index.ts
@@ -76,6 +76,9 @@ export { Searchbar };
 import { RadioButton } from "./components/RadioButton";
 export { RadioButton };
 
+import { Popup } from "./components/Popup";
+export { Popup };
+
 //TO BE REMOVED SOON
 import { SectionHeader } from "./components/SectionHeader";
 export { SectionHeader };

--- a/sparkle/src/components/Popup.tsx
+++ b/sparkle/src/components/Popup.tsx
@@ -1,6 +1,8 @@
 import { Transition } from "@headlessui/react";
-import { classNames } from "@sparkle/lib/utils";
 import React from "react";
+
+import { classNames } from "@sparkle/lib/utils";
+
 import { Button } from "./Button";
 import { Chip } from "./Chip";
 

--- a/sparkle/src/components/Popup.tsx
+++ b/sparkle/src/components/Popup.tsx
@@ -1,0 +1,54 @@
+import { Transition } from "@headlessui/react";
+import { classNames } from "@sparkle/lib/utils";
+import React from "react";
+import { Button } from "./Button";
+import { Chip } from "./Chip";
+
+type PopupProps = {
+  show: boolean;
+  chipLabel: string;
+  description: string;
+  buttonLabel: string;
+  buttonClick: () => void;
+  className?: string;
+};
+
+export function Popup({
+  show,
+  chipLabel,
+  description,
+  buttonLabel,
+  buttonClick,
+  className,
+}: PopupProps) {
+  return (
+    <Transition
+      show={show}
+      enter="s-transition-opacity s-duration-300"
+      enterFrom="s-opacity-0"
+      enterTo="s-opacity-100"
+      leave="s-transition-opacity s-duration-300"
+      leaveFrom="s-opacity-100"
+      leaveTo="s-opacity-0"
+      className={classNames(
+        "s-z-30 s-flex s-w-64 s-flex-col s-gap-3 s-rounded-lg s-border s-border-amber-100 s-bg-amber-50 s-p-4 s-shadow-lg",
+        className || ""
+      )}
+    >
+      <div>
+        <Chip color="red">{chipLabel}</Chip>
+      </div>
+      <div className="s-text-sm s-font-normal s-text-element-900">
+        {description}
+      </div>
+      <div className="s-self-center">
+        <Button
+          variant="primary"
+          size="sm"
+          label={buttonLabel}
+          onClick={buttonClick}
+        />
+      </div>
+    </Transition>
+  );
+}

--- a/sparkle/src/stories/Popup.stories.tsx
+++ b/sparkle/src/stories/Popup.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta } from "@storybook/react";
+import React from "react";
+
+import { Popup } from "../index_with_tw_base";
+
+const meta = {
+  title: "Atoms/Popup",
+  component: Popup,
+} satisfies Meta<typeof Popup>;
+
+export default meta;
+
+export const PopupExample = () => (
+  <div className="s-flex s-flex-col s-gap-4">
+    <Popup
+      show={true}
+      chipLabel={"Basic"}
+      description={"Yes"}
+      buttonLabel={"Ok"}
+      buttonClick={function (): void {
+        alert("Onclick fn");
+      }}
+    />
+
+    <Popup
+      show={true}
+      chipLabel={"Positioned"}
+      description={"Positioned bottom via className"}
+      buttonLabel={"Ok"}
+      buttonClick={function (): void {
+        alert("Onclick fn");
+      }}
+      className="s-fixed s-bottom-16"
+    />
+  </div>
+);


### PR DESCRIPTION
Related [issue](https://github.com/dust-tt/tasks/issues/133) and [specs](https://github.com/dust-tt/decisions/issues/101)

### Points of attention
1. **Closeability** Currently, did as per specs (popup not closeable) but we might want a close button. If yes, I can add it to this PR, the same as in notifications (IconButton with cross on the right) -- makes the interface a bit heavier though since it will get an onClose => WDYT?

2. **Popup positioning** The solutions were either to
 a. Have the popup handle the positioning by wrapping the component on which we want to position it (like tooltip)
 b. Have the popup handle the positioning, being put inside the component and using absolute positioning
 c. Let the user handle the positioning via a className => **I went for this**

Rejected a. because

- does not work on fixed positioned components, such as fixedinputbar which is the reason why the Popup was created in the first place
- requires wrapping in a div relative, which can raise issues if the component assumed otherwise
- wrapping a component by something secondary (the popup to show for the free trial when) is bad style IMHO

Rejected b. because

- not possible for all components (e.g. if they don't have children)
- would force the user to set position relative for the component in which the popup is added
- can require state to be passed to a component that needn't be aware of it -- the show state

