### PR TITLE
enh: protect retry button from double clicks

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -30,6 +30,7 @@ import {
   AgentMessageSuccessEvent,
 } from "@app/lib/api/assistant/agent";
 import { GenerationTokensEvent } from "@app/lib/api/assistant/generation";
+import { useSubmitFunction } from "@app/lib/client/utils";
 import {
   isRetrievalActionType,
   RetrievalDocumentType,
@@ -482,6 +483,11 @@ function ErrorMessage({
 }) {
   const fullMessage =
     "ERROR: " + error.message + (error.code ? ` (code: ${error.code})` : "");
+
+  const { submit: retry, isSubmitting: isRetrying } = useSubmitFunction(
+    async () => retryHandler()
+  );
+
   return (
     <div className="flex flex-col gap-9">
       <div className="flex flex-col gap-1 sm:flex-row">
@@ -527,7 +533,8 @@ function ErrorMessage({
           size="sm"
           icon={ArrowPathIcon}
           label="Retry"
-          onClick={retryHandler}
+          onClick={retry}
+          disabled={isRetrying}
         />
       </div>
     </div>


### PR DESCRIPTION
We're getting dropped streams because of double clicking on "retry" ([datadog](https://app.datadoghq.eu/logs?query=%22Error%20Posting%20message%22%20&cols=host%2Cservice&event=AgAAAYuUcAIZi77KcwAAAAAAAAAYAAAAAEFZdVVjQTdpQUFBUGNwV2ZnRFRhRndBYQAAACQAAAAAMDE4Yjk0NzEtNTQ4Mi00YzMyLTg0MTQtM2YyYTllOThhYzZm&index=%2A&messageDisplay=inline&refresh_mode=sliding&stream_sort=desc&view=spans&viz=stream&from_ts=1697617448427&to_ts=1697631848427&live=true))