### PR TITLE
enh(drive connector): keep track of last upsert ts

### DIFF
--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -394,7 +394,7 @@ export async function retrieveGoogleDriveConnectorPermissions({
                 f.mimeType === "application/vnd.google-apps.folder"
                   ? null
                   : getDocumentId(f.driveFileId),
-              lastUpdatedAt: f.lastSeenTs?.getTime() || null,
+              lastUpdatedAt: f.lastUpsertedTs?.getTime() || null,
               sourceUrl: null,
               expandable:
                 (await GoogleDriveFiles.count({

--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -469,8 +469,6 @@ async function syncOneFile(
       },
     });
     upsertTimestampMs = file.updatedAtMs;
-
-    return true;
   } else {
     logger.info(
       {
@@ -499,7 +497,7 @@ async function syncOneFile(
 
   await GoogleDriveFiles.upsert(params);
 
-  return false;
+  return !!upsertTimestampMs;
 }
 
 // Please consider using the memoized version getFileParentsMemoized instead of this one.

--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -19,7 +19,7 @@ import { uuid4 } from "@temporalio/workflow";
 import { google } from "googleapis";
 import { drive_v3 } from "googleapis";
 import { OAuth2Client } from "googleapis-common";
-import { literal, Op } from "sequelize";
+import { CreationAttributes, literal, Op } from "sequelize";
 
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { dpdf2text } from "@connectors/lib/dpdf2text";
@@ -447,15 +447,7 @@ async function syncOneFile(
   }
   tags.push(`mimeType:${file.mimeType}`);
 
-  await GoogleDriveFiles.upsert({
-    connectorId: connectorId,
-    dustFileId: documentId,
-    driveFileId: file.id,
-    name: file.name,
-    mimeType: file.mimeType,
-    parentId: file.parent,
-    lastSeenTs: new Date(),
-  });
+  let upsertTimestampMs: number | undefined = undefined;
 
   if (documentContent.length <= MAX_DOCUMENT_TXT_LEN) {
     const parents = (
@@ -476,6 +468,7 @@ async function syncOneFile(
         sync_type: isBatchSync ? "batch" : "incremental",
       },
     });
+    upsertTimestampMs = file.updatedAtMs;
 
     return true;
   } else {
@@ -489,6 +482,22 @@ async function syncOneFile(
       `Document too big to be upserted. Skipping`
     );
   }
+
+  const params: CreationAttributes<GoogleDriveFiles> = {
+    connectorId: connectorId,
+    dustFileId: documentId,
+    driveFileId: file.id,
+    name: file.name,
+    mimeType: file.mimeType,
+    parentId: file.parent,
+    lastSeenTs: new Date(),
+  };
+
+  if (upsertTimestampMs) {
+    params.lastUpsertedTs = new Date(upsertTimestampMs);
+  }
+
+  await GoogleDriveFiles.upsert(params);
 
   return false;
 }

--- a/connectors/src/lib/models.ts
+++ b/connectors/src/lib/models.ts
@@ -1101,6 +1101,7 @@ export class GoogleDriveFiles extends Model<
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
   declare lastSeenTs: Date | null;
+  declare lastUpsertedTs: Date | null;
   declare connectorId: ForeignKey<Connector["id"]>;
   declare dustFileId: string;
   declare driveFileId: string;
@@ -1127,6 +1128,10 @@ GoogleDriveFiles.init(
       defaultValue: DataTypes.NOW,
     },
     lastSeenTs: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    },
+    lastUpsertedTs: {
       type: DataTypes.DATE,
       allowNull: true,
     },


### PR DESCRIPTION
- We're currently not keeping track in our database of the last time we upserted a GDrive file
- When returning the connectors permissions from DB, we are using the `lastSeenTs` as the "last update timestamp".
- This turns out to be wrong, because we "see" stuff a lot more often than we update them
- This changes fixes the issue by saving a timestamp when we upsert the doc
- This timestamp can be null

Requires:
- init db
- optionally a full resync. Otherwise we'll return null a lot of the time