### PR TITLE
Fix google drive read permission view

### DIFF
--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -347,17 +347,16 @@ export async function retrieveGoogleDriveConnectorPermissions({
               parentInternalId: null,
               type: "folder",
               title: fd.name || "",
-              sourceUrl: fd.webViewLink || null,
+              sourceUrl: null, // Out of consistency we don't send `fd.webViewLink`.
               dustDocumentId: null,
               lastUpdatedAt: fd.updatedAtMs || null,
               expandable:
-                (await GoogleDriveFiles.count({
+                (await GoogleDriveFiles.findOne({
                   where: {
                     connectorId: connectorId,
                     parentId: f.folderId,
-                    mimeType: "application/vnd.google-apps.folder",
                   },
-                })) > 0,
+                })) !== null,
               permission: "read",
             };
           })
@@ -397,13 +396,12 @@ export async function retrieveGoogleDriveConnectorPermissions({
               lastUpdatedAt: f.lastUpsertedTs?.getTime() || null,
               sourceUrl: null,
               expandable:
-                (await GoogleDriveFiles.count({
+                (await GoogleDriveFiles.findOne({
                   where: {
                     connectorId: connectorId,
                     parentId: f.driveFileId,
-                    mimeType: "application/vnd.google-apps.folder",
                   },
-                })) > 0,
+                })) !== null,
               permission: "read",
             };
           })();


### PR DESCRIPTION
Fixes: https://github.com/dust-tt/tasks/issues/196

- We had a bad query looking for folders instead of anything to decide if expandable
- We have a link for the top level folders (they are retrieved from GDrive) but not subfolders so let's not put any link anywhere to avoid the weirdness in the UI

At some point we night want to capture the sourceUrl on `GoogleDriveFiles` to be able to show the links from the google drive permission tree

![Screenshot from 2023-11-03 16-23-10](https://github.com/dust-tt/dust/assets/15067/37e068cf-d230-4293-9318-d66bbab58c81)
