### PR TITLE
Try to handle missing data in webhook checkout.session.completed

### DIFF
--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -25,6 +25,22 @@ async function getPriceId(productId: string): Promise<string | null> {
 }
 
 /**
+ * Calls the Stripe API to get the productId from a subscription ID.
+ */
+export const getProductIdFromStripeSubscriptionId = async (
+  subscriptionId: string
+): Promise<string | null> => {
+  const subscription = await stripe.subscriptions.retrieve(subscriptionId);
+  if (
+    subscription.items.data.length &&
+    typeof subscription.items.data[0].price.product === "string"
+  ) {
+    return subscription.items.data[0].price.product;
+  }
+  return null;
+};
+
+/**
  * Calls the Stripe API to create a checkout session for a given workspace/plan.
  * We return the URL of the checkout session.
  * Once the users has completed the checkout, we will receive an event on our Stripe webhook


### PR DESCRIPTION
We received this error from the Stripe webhook handler this morning: https://app.datadoghq.eu/dashboard/i8e-twv-3vr/stripe-monitoring?refresh_mode=sliding&view=spans&from_ts=1699091140996&to_ts=1699105540996&live=true


Looks like we're missing the planCode and the workspace id: 
<img width="744" alt="Capture d’écran 2023-11-04 à 16 07 55" src="https://github.com/dust-tt/dust/assets/3803406/172a8c14-816f-4dbf-80b3-9b97b19cfc38">

This PR adds fallback to retrieve the workspace id and plan code if we don't have them: 
- For the workspace, if not provided, we try to get it from an existing activeSubscription for this customerId
- For the plan, if not provided, we try to fetch it from the stripe product id that we can retrieve from fetching the subscription object. 

If we don't have them, we still ignore the event but with a dedicated logger error so we know which is missing. 

WDYT?