### PR TITLE
Doom: Limitations of workspace on # users and slack bot availability

### DIFF
--- a/front/components/PlansTables.tsx
+++ b/front/components/PlansTables.tsx
@@ -2,6 +2,7 @@ import { Button, PriceTable, RocketIcon, SparklesIcon } from "@dust-tt/sparkle";
 import { Tab } from "@headlessui/react";
 import React from "react";
 
+import { PRO_PLAN_SEAT_29_CODE } from "@app/lib/plans/plan_codes";
 import { classNames } from "@app/lib/utils";
 import { PlanType } from "@app/types/plan";
 
@@ -74,13 +75,13 @@ function ProPriceTable({
       <PriceTable.Item label="Assistants can execute actions" />
       <PriceTable.Item label="Workspace role and permissions" variant="dash" />
       <PriceTable.ActionContainer>
-        {plan.code !== "PRO_PLAN_SEAT_29" && (
+        {plan.code !== PRO_PLAN_SEAT_29_CODE && (
           <Button
             variant="primary"
             size={biggerButtonSize}
             label="Start now"
             icon={RocketIcon}
-            disabled={isProcessing || plan.code === "PRO_PLAN_SEAT_29"}
+            disabled={isProcessing || plan.code === PRO_PLAN_SEAT_29_CODE}
             onClick={onClick}
           />
         )}

--- a/front/lib/plans/enterprise_plans.ts
+++ b/front/lib/plans/enterprise_plans.ts
@@ -1,6 +1,7 @@
 import { Attributes } from "sequelize";
 
 import { Plan } from "@app/lib/models";
+import { ENT_PLAN_FAKE_CODE } from "@app/lib/plans/plan_codes";
 
 export type PlanAttributes = Omit<
   Attributes<Plan>,
@@ -17,10 +18,6 @@ export type PlanAttributes = Omit<
  * As entreprise plans are custom, we won't create them in this file, but directly from Poké.
  */
 
-/**
- * ENT_PLAN_FAKE is not subscribable and is only used to display the Enterprise plan in the UI (hence it's not stored on the db).
- */
-export const ENT_PLAN_FAKE_CODE = "ENT_PLAN_FAKE_CODE";
 export const ENT_PLAN_FAKE_DATA: PlanAttributes = {
   code: ENT_PLAN_FAKE_CODE,
   name: "Entreprise",

--- a/front/lib/plans/free_plans.ts
+++ b/front/lib/plans/free_plans.ts
@@ -1,6 +1,10 @@
 import { Attributes } from "sequelize";
 
 import { Plan } from "@app/lib/models";
+import {
+  FREE_TEST_PLAN_CODE,
+  FREE_UPGRADED_PLAN_CODE,
+} from "@app/lib/plans/plan_codes";
 
 export type PlanAttributes = Omit<
   Attributes<Plan>,
@@ -15,10 +19,6 @@ export type PlanAttributes = Omit<
  *
  * This file about Free plans.
  */
-
-// Current free plans:
-export const FREE_TEST_PLAN_CODE = "FREE_TEST_PLAN";
-export const FREE_UPGRADED_PLAN_CODE = "FREE_UPGRADED_PLAN";
 
 /**
  * FREE_TEST plan is our default plan: this is the plan used by all workspaces until they subscribe to a plan.

--- a/front/lib/plans/plan_codes.ts
+++ b/front/lib/plans/plan_codes.ts
@@ -3,8 +3,7 @@ export const FREE_UPGRADED_PLAN_CODE = "FREE_UPGRADED_PLAN";
 export const FREE_TEST_PLAN_CODE = "FREE_TEST_PLAN";
 
 // Current pro plans:
-export const PRO_PLAN_MAU_29_CODE = "PRO_PLAN_MAU_29";
-export const PRO_PLAN_FIXED_1000_CODE = "PRO_PLAN_FIXED_1000";
+export const PRO_PLAN_SEAT_29_CODE = "PRO_PLAN_SEAT_29";
 
 /**
  * ENT_PLAN_FAKE is not subscribable and is only used to display the Enterprise plan in the UI (hence it's not stored on the db).

--- a/front/lib/plans/plan_codes.ts
+++ b/front/lib/plans/plan_codes.ts
@@ -1,0 +1,12 @@
+// Current free plans:
+export const FREE_UPGRADED_PLAN_CODE = "FREE_UPGRADED_PLAN";
+export const FREE_TEST_PLAN_CODE = "FREE_TEST_PLAN";
+
+// Current pro plans:
+export const PRO_PLAN_MAU_29_CODE = "PRO_PLAN_MAU_29";
+export const PRO_PLAN_FIXED_1000_CODE = "PRO_PLAN_FIXED_1000";
+
+/**
+ * ENT_PLAN_FAKE is not subscribable and is only used to display the Enterprise plan in the UI (hence it's not stored on the db).
+ */
+export const ENT_PLAN_FAKE_CODE = "ENT_PLAN_FAKE_CODE";

--- a/front/lib/plans/pro_plans.ts
+++ b/front/lib/plans/pro_plans.ts
@@ -17,9 +17,6 @@ export type PlanAttributes = Omit<
  * This file about Pro plans.
  */
 
-// Current pro plans:
-export const PRO_PLAN_CODE = "PRO_PLAN_SEAT_29";
-
 /**
  * Paid plans are stored in the database.
  * We can update existing plans or add new one but never remove anything from this list.

--- a/front/lib/plans/pro_plans.ts
+++ b/front/lib/plans/pro_plans.ts
@@ -3,6 +3,8 @@ import { Attributes } from "sequelize";
 import { isDevelopment } from "@app/lib/development";
 import { Plan } from "@app/lib/models";
 
+import { PRO_PLAN_SEAT_29_CODE } from "./plan_codes";
+
 export type PlanAttributes = Omit<
   Attributes<Plan>,
   "id" | "createdAt" | "updatedAt"
@@ -27,7 +29,7 @@ const PRO_PLANS_DATA: PlanAttributes[] = [];
 
 if (isDevelopment()) {
   PRO_PLANS_DATA.push({
-    code: PRO_PLAN_CODE,
+    code: PRO_PLAN_SEAT_29_CODE,
     name: "Pro",
     stripeProductId: "prod_OwKvN4XrUwFw5a",
     billingType: "per_seat",

--- a/front/lib/plans/subscription.ts
+++ b/front/lib/plans/subscription.ts
@@ -1,12 +1,11 @@
 import { Authenticator } from "@app/lib/auth";
 import { front_sequelize } from "@app/lib/databases";
 import { Plan, Subscription, Workspace } from "@app/lib/models";
+import { FREE_TEST_PLAN_DATA, PlanAttributes } from "@app/lib/plans/free_plans";
 import {
   FREE_TEST_PLAN_CODE,
-  FREE_TEST_PLAN_DATA,
   FREE_UPGRADED_PLAN_CODE,
-  PlanAttributes,
-} from "@app/lib/plans/free_plans";
+} from "@app/lib/plans/plan_codes";
 import {
   createCheckoutSession,
   updateStripeSubscriptionQuantity,

--- a/front/migrations/20231023_create_plan_subscriptions.ts
+++ b/front/migrations/20231023_create_plan_subscriptions.ts
@@ -1,7 +1,7 @@
 import { Op } from "sequelize";
 
 import { Plan, Subscription, Workspace } from "@app/lib/models";
-import { FREE_UPGRADED_PLAN_CODE } from "@app/lib/plans/free_plans";
+import { FREE_UPGRADED_PLAN_CODE } from "@app/lib/plans/plan_codes";
 import { generateModelSId } from "@app/lib/utils";
 
 async function main() {

--- a/front/pages/poke/[wId]/index.tsx
+++ b/front/pages/poke/[wId]/index.tsx
@@ -10,6 +10,7 @@ import { getDataSources } from "@app/lib/api/data_sources";
 import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
 import { ConnectorsAPI } from "@app/lib/connectors_api";
 import { CoreAPI } from "@app/lib/core_api";
+import { FREE_TEST_PLAN_CODE } from "@app/lib/plans/plan_codes";
 import { timeAgoFrom } from "@app/lib/utils";
 import { DataSourceType } from "@app/types/data_source";
 import { PlanType } from "@app/types/plan";
@@ -252,8 +253,6 @@ const WorkspacePage = ({
   const workspaceHasManagedDataSources = dataSources.some(
     (ds) => !!ds.connectorProvider
   );
-
-  const FREE_TEST_PLAN_CODE = "FREE_TEST_PLAN";
 
   return (
     <div className="min-h-screen bg-structure-50">

--- a/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
@@ -341,11 +341,13 @@ function SlackBotEnableView({
   readOnly,
   isAdmin,
   dataSource,
+  plan,
 }: {
   owner: WorkspaceType;
   readOnly: boolean;
   isAdmin: boolean;
   dataSource: DataSourceType;
+  plan: PlanType;
 }) {
   const { botEnabled, mutateBotEnabled } = useConnectorBotEnabled({
     owner: owner,
@@ -353,9 +355,9 @@ function SlackBotEnableView({
   });
 
   const sendNotification = useContext(SendNotificationsContext);
-
+  const router = useRouter();
   const [loading, setLoading] = useState(false);
-
+  const [showNoSlackBotPopup, setShowNoSlackBotPopup] = useState(false);
   const handleSetBotEnabled = async (botEnabled: boolean) => {
     setLoading(true);
     const res = await fetch(
@@ -389,14 +391,31 @@ function SlackBotEnableView({
         title="Slack Bot"
         visual={<ContextItem.Visual visual={SlackLogo} />}
         action={
-          <SliderToggle
-            size="sm"
-            onClick={async () => {
-              await handleSetBotEnabled(!botEnabled);
-            }}
-            selected={botEnabled || false}
-            disabled={readOnly || !isAdmin || loading}
-          />
+          <div className="relative">
+            <SliderToggle
+              size="sm"
+              onClick={async () => {
+                if (!plan.limits.assistant.isSlackBotAllowed)
+                  setShowNoSlackBotPopup(true);
+                else await handleSetBotEnabled(!botEnabled);
+              }}
+              selected={botEnabled || false}
+              disabled={readOnly || !isAdmin || loading}
+            />
+            <Popup
+              show={showNoSlackBotPopup}
+              className="absolute bottom-8 right-0"
+              chipLabel={`${plan.name} plan`}
+              description="Your plan does not allow for the Slack bot to be enabled. Upgrade your plan to chat with Dust assistants on Slack."
+              buttonLabel="Check Dust plans"
+              buttonClick={() => {
+                void router.push(`/w/${owner.sId}/subscription`);
+              }}
+              onClose={() => {
+                setShowNoSlackBotPopup(false);
+              }}
+            />
+          </div>
         }
       >
         <ContextItem.Description>
@@ -435,6 +454,7 @@ function ManagedDataSourceView({
   connector,
   nangoConfig,
   githubAppUrl,
+  plan,
 }: {
   owner: WorkspaceType;
   readOnly: boolean;
@@ -448,6 +468,7 @@ function ManagedDataSourceView({
     googleDriveConnectorId: string;
   };
   githubAppUrl: string;
+  plan: PlanType;
 }) {
   const router = useRouter();
 
@@ -670,7 +691,7 @@ function ManagedDataSourceView({
 
             {connectorProvider === "slack" && (
               <SlackBotEnableView
-                {...{ owner, readOnly, isAdmin, dataSource }}
+                {...{ owner, readOnly, isAdmin, dataSource, plan }}
               />
             )}
           </>
@@ -751,6 +772,7 @@ export default function DataSourceView({
             connector,
             nangoConfig,
             githubAppUrl,
+            plan,
           }}
         />
       ) : (

--- a/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
@@ -245,8 +245,8 @@ function StandardDataSourceView({
               <div className="relative mt-0 flex-none">
                 <Popup
                   show={showDocumentsLimitPopup}
-                  chipLabel="Free plan"
-                  description={`You have reached the limit of documents per data source (${plan.limits.dataSources.documents.count} documents). Upgrade to a paid plan for unlimited documents and data sources.`}
+                  chipLabel={`${plan.name} plan`}
+                  description={`You have reached the limit of documents per data source (${plan.limits.dataSources.documents.count} documents). Upgrade your plan for unlimited documents and data sources.`}
                   buttonLabel="Check Dust plans"
                   buttonClick={() => {
                     void router.push(`/w/${owner.sId}/subscription`);

--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -29,9 +29,8 @@ import {
 import { githubAuth } from "@app/lib/github_auth";
 import { timeAgoFrom } from "@app/lib/utils";
 import { DataSourceType } from "@app/types/data_source";
-import { ManageDataSourcesLimitsType, PlanType } from "@app/types/plan";
+import { PlanType } from "@app/types/plan";
 import { UserType, WorkspaceType } from "@app/types/user";
-import { Plan } from "@app/lib/models";
 
 const {
   GA_TRACKING_ID = "",

--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -29,8 +29,9 @@ import {
 import { githubAuth } from "@app/lib/github_auth";
 import { timeAgoFrom } from "@app/lib/utils";
 import { DataSourceType } from "@app/types/data_source";
-import { ManageDataSourcesLimitsType } from "@app/types/plan";
+import { ManageDataSourcesLimitsType, PlanType } from "@app/types/plan";
 import { UserType, WorkspaceType } from "@app/types/user";
+import { Plan } from "@app/lib/models";
 
 const {
   GA_TRACKING_ID = "",
@@ -62,7 +63,7 @@ export const getServerSideProps: GetServerSideProps<{
   readOnly: boolean;
   isAdmin: boolean;
   integrations: DataSourceIntegration[];
-  planConnectionsLimits: ManageDataSourcesLimitsType;
+  plan: PlanType;
   gaTrackingId: string;
   nangoConfig: {
     publicKey: string;
@@ -213,7 +214,7 @@ export const getServerSideProps: GetServerSideProps<{
       readOnly,
       isAdmin,
       integrations,
-      planConnectionsLimits: plan.limits.connections,
+      plan,
       gaTrackingId: GA_TRACKING_ID,
       nangoConfig: {
         publicKey: NANGO_PUBLIC_KEY,
@@ -232,11 +233,12 @@ export default function DataSourcesView({
   readOnly,
   isAdmin,
   integrations,
-  planConnectionsLimits,
+  plan,
   gaTrackingId,
   nangoConfig,
   githubAppUrl,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  const planConnectionsLimits = plan.limits.connections;
   const [localIntegrations, setLocalIntegrations] = useState(integrations);
 
   const [isLoadingByProvider, setIsLoadingByProvider] = useState<
@@ -536,8 +538,8 @@ export default function DataSourcesView({
                         showUpgradePopupForProvider === ds.connectorProvider
                       }
                       className="absolute bottom-8 right-0"
-                      chipLabel="Free plan"
-                      description="Unlock this managed data source by upgrading to a paid plan."
+                      chipLabel={`${plan.name} plan`}
+                      description="Unlock this managed data source by upgrading your plan."
                       buttonLabel="Check Dust plans"
                       buttonClick={() => {
                         void router.push(`/w/${owner.sId}/subscription`);

--- a/front/pages/w/[wId]/builder/data-sources/static.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/static.tsx
@@ -138,8 +138,8 @@ export default function DataSourcesView({
             />
             <Popup
               show={showDatasourceLimitPopup}
-              chipLabel="Free plan"
-              description={`You have reached the limit of data sources (${plan.limits.dataSources.count} data sources). Upgrade to a paid plan for unlimited documents and data sources.`}
+              chipLabel={`${plan.name} plan`}
+              description={`You have reached the limit of data sources (${plan.limits.dataSources.count} data sources). Upgrade your plan for unlimited datasources.`}
               buttonLabel="Check Dust plans"
               buttonClick={() => {
                 void router.push(`/w/${owner.sId}/subscription`);

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -29,12 +29,12 @@ import {
   getUserFromSession,
   RoleType,
 } from "@app/lib/auth";
+import { FREE_TEST_PLAN_CODE } from "@app/lib/plans/plan_codes";
 import { useMembers, useWorkspaceInvitations } from "@app/lib/swr";
 import { classNames, isEmailValid } from "@app/lib/utils";
 import { MembershipInvitationType } from "@app/types/membership_invitation";
 import { PlanType } from "@app/types/plan";
 import { UserType, WorkspaceType } from "@app/types/user";
-import { FREE_TEST_PLAN_CODE } from "@app/lib/plans/plan_codes";
 
 const { GA_TRACKING_ID = "", URL = "" } = process.env;
 

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -11,10 +11,12 @@ import {
   Modal,
   Page,
   PlusIcon,
+  Popup,
   Searchbar,
 } from "@dust-tt/sparkle";
 import { UsersIcon } from "@heroicons/react/20/solid";
 import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import { useRouter } from "next/router";
 import React, { useContext, useState } from "react";
 import { useSWRConfig } from "swr";
 
@@ -30,7 +32,9 @@ import {
 import { useMembers, useWorkspaceInvitations } from "@app/lib/swr";
 import { classNames, isEmailValid } from "@app/lib/utils";
 import { MembershipInvitationType } from "@app/types/membership_invitation";
+import { PlanType } from "@app/types/plan";
 import { UserType, WorkspaceType } from "@app/types/user";
+import { FREE_TEST_PLAN_CODE } from "@app/lib/plans/plan_codes";
 
 const { GA_TRACKING_ID = "", URL = "" } = process.env;
 
@@ -39,6 +43,7 @@ const CLOSING_ANIMATION_DURATION = 200;
 export const getServerSideProps: GetServerSideProps<{
   user: UserType | null;
   owner: WorkspaceType;
+  plan: PlanType;
   gaTrackingId: string;
   url: string;
 }> = async (context) => {
@@ -48,9 +53,9 @@ export const getServerSideProps: GetServerSideProps<{
     session,
     context.params?.wId as string
   );
-
+  const plan = auth.plan();
   const owner = auth.workspace();
-  if (!owner || !auth.isAdmin()) {
+  if (!owner || !auth.isAdmin() || !plan) {
     return {
       notFound: true,
     };
@@ -60,6 +65,7 @@ export const getServerSideProps: GetServerSideProps<{
     props: {
       user,
       owner,
+      plan,
       gaTrackingId: GA_TRACKING_ID,
       url: URL,
     },
@@ -69,13 +75,15 @@ export const getServerSideProps: GetServerSideProps<{
 export default function WorkspaceAdmin({
   user,
   owner,
+  plan,
   gaTrackingId,
   url,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const inviteLink =
     owner.allowedDomain !== null ? `${url}/w/${owner.sId}/join` : null;
+  const router = useRouter();
+  const [showNoInviteLinkPopup, setShowNoInviteLinkPopup] = useState(false);
   const [inviteSettingsModalOpen, setInviteSettingsModalOpen] = useState(false);
-
   return (
     <AppLayout
       user={user}
@@ -134,13 +142,28 @@ export default function WorkspaceAdmin({
                     }}
                   />
                 </div>
-                <div className="flex-none">
+                <div className="relative flex-none">
                   <Button
                     variant="secondary"
                     label="Settings"
                     size="sm"
                     icon={Cog6ToothIcon}
-                    onClick={() => setInviteSettingsModalOpen(true)}
+                    onClick={() => {
+                      if (plan.code === FREE_TEST_PLAN_CODE)
+                        setShowNoInviteLinkPopup(true);
+                      else setInviteSettingsModalOpen(true);
+                    }}
+                  />
+                  <Popup
+                    show={showNoInviteLinkPopup}
+                    chipLabel="Free plan"
+                    description="You cannot create an invitation link with the free plan. Upgrade your plan to invite other members."
+                    buttonLabel="Check Dust plans"
+                    buttonClick={() => {
+                      void router.push(`/w/${owner.sId}/subscription`);
+                    }}
+                    className="absolute bottom-8 right-0"
+                    onClose={() => setShowNoInviteLinkPopup(false)}
                   />
                 </div>
               </div>
@@ -159,6 +182,7 @@ export default function WorkspaceAdmin({
       builder: "amber",
       user: "emerald",
     };
+    const [showNoInviteEmailPopup, setShowNoInviteEmailPopup] = useState(false);
     const [searchText, setSearchText] = useState("");
     const { members, isMembersLoading } = useMembers(owner);
     const { invitations, isInvitationsLoading } =
@@ -239,13 +263,28 @@ export default function WorkspaceAdmin({
                 name={""}
               />
             </div>
-            <div className="flex-none">
+            <div className="relative flex-none">
               <Button
                 variant="primary"
                 label="Invite members"
                 size="sm"
                 icon={PlusIcon}
-                onClick={() => setInviteEmailModalOpen(true)}
+                onClick={() => {
+                  if (plan.code === FREE_TEST_PLAN_CODE)
+                    setShowNoInviteEmailPopup(true);
+                  else setInviteEmailModalOpen(true);
+                }}
+              />
+              <Popup
+                show={showNoInviteEmailPopup}
+                chipLabel="Free plan"
+                description="You cannot invite other members with the free plan. Upgrade your plan for unlimited members."
+                buttonLabel="Check Dust plans"
+                buttonClick={() => {
+                  void router.push(`/w/${owner.sId}/subscription`);
+                }}
+                className="absolute bottom-8 right-0"
+                onClose={() => setShowNoInviteEmailPopup(false)}
               />
             </div>
           </div>

--- a/front/pages/w/[wId]/subscription/index.tsx
+++ b/front/pages/w/[wId]/subscription/index.tsx
@@ -15,6 +15,10 @@ import AppLayout from "@app/components/sparkle/AppLayout";
 import { subNavigationAdmin } from "@app/components/sparkle/navigation";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
+import {
+  FREE_TEST_PLAN_CODE,
+  PRO_PLAN_SEAT_29_CODE,
+} from "@app/lib/plans/plan_codes";
 import { PlanType } from "@app/types/plan";
 import { UserType, WorkspaceType } from "@app/types/user";
 
@@ -114,10 +118,10 @@ export default function Subscription({
     setIsProcessing(false);
   }
 
-  const chipColor = plan.code === "FREE_TEST_PLAN" ? "emerald" : "sky";
+  const chipColor = plan.code === FREE_TEST_PLAN_CODE ? "emerald" : "sky";
 
   const onClickProPlan = async () =>
-    await handleSubscribeToPlan("PRO_PLAN_SEAT_29");
+    await handleSubscribeToPlan(PRO_PLAN_SEAT_29_CODE);
   const onClickEnterprisePlan = () => {
     window.open("mailto:team@dust.tt?subject=Upgrading to Enteprise plan");
   };


### PR DESCRIPTION
Related issues: [users](https://github.com/dust-tt/tasks/issues/132) and [slackbot](https://github.com/dust-tt/tasks/issues/189)

## Notes
- **User limits** are for the FREE PLAN. A follow up PR can address user limits in PRO plans, important but less urgent and has a few questions pending
- **plan codes** were moved to a separate file so they are accessible from client side. Rationale: they are in the client side Plan type, and we can expect that sometimes in front we want to distinguish according to some specific plans
- **future-proofing alerts**: some alerts with 'Free plan' chip actually test for the plan limits, not whether it's free or not => the chip label was changed to `{plan.name} plan` and the text of the popup adapted 

![image](https://github.com/dust-tt/dust/assets/5437393/ef3e8ef6-e344-49d8-a2e3-336afbd55a9b)
![image](https://github.com/dust-tt/dust/assets/5437393/0adea6d5-6234-40fa-ab05-b2f00a0d74c0)
