### PR TITLE
Import plans: update code for test env and make sure we don't override in prod

### DIFF
--- a/front/components/PlansTables.tsx
+++ b/front/components/PlansTables.tsx
@@ -2,6 +2,7 @@ import { Button, PriceTable, RocketIcon, SparklesIcon } from "@dust-tt/sparkle";
 import { Tab } from "@headlessui/react";
 import React from "react";
 
+import { PRO_PLAN_CODE } from "@app/lib/plans/pro_plans";
 import { classNames } from "@app/lib/utils";
 import { PlanType } from "@app/types/plan";
 
@@ -74,13 +75,13 @@ function ProPriceTable({
       <PriceTable.Item label="Assistants can execute actions" />
       <PriceTable.Item label="Workspace role and permissions" variant="dash" />
       <PriceTable.ActionContainer>
-        {plan.code !== "PRO_PLAN_SEAT_29" && (
+        {plan.code !== PRO_PLAN_CODE && (
           <Button
             variant="primary"
             size={biggerButtonSize}
             label="Start now"
             icon={RocketIcon}
-            disabled={isProcessing || plan.code === "PRO_PLAN_SEAT_29"}
+            disabled={isProcessing || plan.code === PRO_PLAN_CODE}
             onClick={onClick}
           />
         )}

--- a/front/lib/plans/pro_plans.ts
+++ b/front/lib/plans/pro_plans.ts
@@ -18,8 +18,7 @@ export type PlanAttributes = Omit<
  */
 
 // Current pro plans:
-export const PRO_PLAN_MAU_29_CODE = "PRO_PLAN_MAU_29";
-export const PRO_PLAN_FIXED_1000_CODE = "PRO_PLAN_FIXED_1000";
+export const PRO_PLAN_CODE = "PRO_PLAN_SEAT_29";
 
 /**
  * Paid plans are stored in the database.
@@ -27,13 +26,13 @@ export const PRO_PLAN_FIXED_1000_CODE = "PRO_PLAN_FIXED_1000";
  * Entreprise custom plans will be created from Poké.
  */
 
-const PRO_PLANS_DATA: PlanAttributes[] = [
-  {
-    code: "PRO_PLAN_SEAT_29",
+const PRO_PLANS_DATA: PlanAttributes[] = [];
+
+if (isDevelopment()) {
+  PRO_PLANS_DATA.push({
+    code: PRO_PLAN_CODE,
     name: "Pro",
-    stripeProductId: isDevelopment()
-      ? "prod_OvrzyxfSDz5Jqd" // Pro plan in Stripe Test env
-      : "prod_OvrkkwZwLUOlpx", // Pro plan in Stripe Prod env
+    stripeProductId: "prod_OwKvN4XrUwFw5a",
     billingType: "per_seat",
     maxMessages: -1,
     maxUsersInWorkspace: 1000,
@@ -45,8 +44,8 @@ const PRO_PLANS_DATA: PlanAttributes[] = [
     maxDataSourcesCount: -1,
     maxDataSourcesDocumentsCount: -1,
     maxDataSourcesDocumentsSizeMb: 2,
-  },
-];
+  });
+}
 
 /**
  * Function to call when we edit something in FREE_PLANS_DATA to update the database. It will create or update the plans.

--- a/front/pages/w/[wId]/subscription/index.tsx
+++ b/front/pages/w/[wId]/subscription/index.tsx
@@ -15,6 +15,7 @@ import AppLayout from "@app/components/sparkle/AppLayout";
 import { subNavigationAdmin } from "@app/components/sparkle/navigation";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
+import { PRO_PLAN_CODE } from "@app/lib/plans/pro_plans";
 import { PlanType } from "@app/types/plan";
 import { UserType, WorkspaceType } from "@app/types/user";
 
@@ -116,8 +117,7 @@ export default function Subscription({
 
   const chipColor = plan.code === "FREE_TEST_PLAN" ? "emerald" : "sky";
 
-  const onClickProPlan = async () =>
-    await handleSubscribeToPlan("PRO_PLAN_SEAT_29");
+  const onClickProPlan = async () => await handleSubscribeToPlan(PRO_PLAN_CODE);
   const onClickEnterprisePlan = () => {
     window.open("mailto:team@dust.tt?subject=Upgrading to Enteprise plan");
   };


### PR DESCRIPTION
- store `PRO_PLAN_SEAT_29` in a const
- in ./admin/import_plans.sd -> we update the code of FREE_PLAN because I needed to update our test product to collect VAT, and we don't update anymore the pro plan in prod mode. If the pro plan limits needs to be updated on prod we do it from poké.