### PR TITLE
Limit Free plans to 50 messages

### DIFF
--- a/front/components/PlansTables.tsx
+++ b/front/components/PlansTables.tsx
@@ -30,7 +30,7 @@ function FreePriceTable({ size }: { size: "sm" | "xs" }) {
       <PriceTable.Item label="Privacy and Data Security" />
       <PriceTable.Item label="Advanced LLM models (GPT-4, Claude…)" />
       <PriceTable.Item label="Unlimited custom assistants" />
-      <PriceTable.Item label="100 assistant messages" variant="dash" />
+      <PriceTable.Item label="50 assistant messages" variant="dash" />
       <PriceTable.Item label="50 documents as data sources" variant="dash" />
       <PriceTable.Item label="No connections" variant="xmark" />
     </PriceTable>

--- a/front/lib/plans/free_plans.ts
+++ b/front/lib/plans/free_plans.ts
@@ -29,7 +29,7 @@ export const FREE_TEST_PLAN_DATA: PlanAttributes = {
   name: "Free",
   stripeProductId: null,
   billingType: "free",
-  maxMessages: 100,
+  maxMessages: 50,
   maxUsersInWorkspace: 1,
   isSlackbotAllowed: false,
   isManagedSlackAllowed: false,

--- a/front/prompt/global_agent_helper_prompt.md
+++ b/front/prompt/global_agent_helper_prompt.md
@@ -142,7 +142,7 @@ To configure the @dust assistant, got to `Admin` > `Assistants` and click on the
 - creation of custom workflows
 - create and use the assistants on a data source with up to 32 documents of 750KB each.
 - access to GPT4
-- 100 messages limit
+- 50 messages limit
 
 ### **Dust Paid plans**
 


### PR DESCRIPTION
Changes: set to 50 in the free plan data, in the pricing table, and in @help prompt. 


