### PR TITLE
Revert const plancode

### DIFF
--- a/front/components/PlansTables.tsx
+++ b/front/components/PlansTables.tsx
@@ -2,7 +2,6 @@ import { Button, PriceTable, RocketIcon, SparklesIcon } from "@dust-tt/sparkle";
 import { Tab } from "@headlessui/react";
 import React from "react";
 
-import { PRO_PLAN_CODE } from "@app/lib/plans/pro_plans";
 import { classNames } from "@app/lib/utils";
 import { PlanType } from "@app/types/plan";
 
@@ -75,13 +74,13 @@ function ProPriceTable({
       <PriceTable.Item label="Assistants can execute actions" />
       <PriceTable.Item label="Workspace role and permissions" variant="dash" />
       <PriceTable.ActionContainer>
-        {plan.code !== PRO_PLAN_CODE && (
+        {plan.code !== "PRO_PLAN_SEAT_29" && (
           <Button
             variant="primary"
             size={biggerButtonSize}
             label="Start now"
             icon={RocketIcon}
-            disabled={isProcessing || plan.code === PRO_PLAN_CODE}
+            disabled={isProcessing || plan.code === "PRO_PLAN_SEAT_29"}
             onClick={onClick}
           />
         )}

--- a/front/pages/w/[wId]/subscription/index.tsx
+++ b/front/pages/w/[wId]/subscription/index.tsx
@@ -15,7 +15,6 @@ import AppLayout from "@app/components/sparkle/AppLayout";
 import { subNavigationAdmin } from "@app/components/sparkle/navigation";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
-import { PRO_PLAN_CODE } from "@app/lib/plans/pro_plans";
 import { PlanType } from "@app/types/plan";
 import { UserType, WorkspaceType } from "@app/types/user";
 
@@ -117,7 +116,8 @@ export default function Subscription({
 
   const chipColor = plan.code === "FREE_TEST_PLAN" ? "emerald" : "sky";
 
-  const onClickProPlan = async () => await handleSubscribeToPlan(PRO_PLAN_CODE);
+  const onClickProPlan = async () =>
+    await handleSubscribeToPlan("PRO_PLAN_SEAT_29");
   const onClickEnterprisePlan = () => {
     window.open("mailto:team@dust.tt?subject=Upgrading to Enteprise plan");
   };


### PR DESCRIPTION
Can't import `import { PRO_PLAN_CODE } from "@app/lib/plans/pro_plans";` from front. 
Just reverting this as @philipperolet is in the middle of refactoring it 🙇🏻‍♀️  