### PR TITLE
Admin and builder guidances (Assistant Builder and Connections)

### DIFF
--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -898,6 +898,12 @@ export default function AssistantBuilder({
                             </strong>
                           </div>
                         );
+                      case "none":
+                        return <></>;
+                      default:
+                        ((x: never) => {
+                          throw new Error("Unkonwn role " + x);
+                        })(owner.role);
                     }
                   })()}
                 </div>

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -17,7 +17,7 @@ import {
 } from "@dust-tt/sparkle";
 import * as t from "io-ts";
 import { useRouter } from "next/router";
-import { Fragment, ReactNode, useCallback, useEffect, useState } from "react";
+import { ReactNode, useCallback, useEffect, useState } from "react";
 import React from "react";
 import ReactTextareaAutosize from "react-textarea-autosize";
 import { mutate } from "swr";
@@ -856,10 +856,53 @@ export default function AssistantBuilder({
             <div className="text-2xl font-bold text-element-900">
               Data Sources & Actions
             </div>
-            <ContentMessage
-              title="You don't have any active data source or connection"
-              message="Assistants can answer using existing knowledge.\n\nThere are two types of"
-            />
+            {configurableDataSources.length === 0 && (
+              <ContentMessage title="You don't have any active data source or connection">
+                <div className="flex flex-col gap-y-3">
+                  <div>Assistants can answer using existing knowledge.</div>
+                  <div>
+                    There are two types of knowledge sources:{" "}
+                    <strong>Data Sources</strong> (Files you can upload) and{" "}
+                    <strong>Connections</strong> (Automatically synchronized
+                    with platforms like Notion, Slack, ...).
+                  </div>
+                  {(() => {
+                    switch (owner.role) {
+                      case "admin":
+                        return (
+                          <div>
+                            <strong>
+                              Visit the "Data Sources" and "Connections"
+                              sections in your workspace admin panel to add new
+                              sources of knowledge.
+                            </strong>
+                          </div>
+                        );
+                      case "builder":
+                        return (
+                          <div>
+                            <strong>
+                              Only Admins can activate Connections.
+                              <br />
+                              You can Data Sources by visiting "Data Source" in
+                              your workspace admin panel.
+                            </strong>
+                          </div>
+                        );
+                      case "user":
+                        return (
+                          <div>
+                            <strong>
+                              Only Admins and Builders can activate Connections
+                              and Data Sources.
+                            </strong>
+                          </div>
+                        );
+                    }
+                  })()}
+                </div>
+              </ContentMessage>
+            )}
             <div>
               You can ask the assistant to perform actions before answering,
               like{" "}

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -4,6 +4,7 @@ import {
   Avatar,
   Button,
   Collapsible,
+  ContentMessage,
   ContextItem,
   DropdownMenu,
   Input,
@@ -855,6 +856,10 @@ export default function AssistantBuilder({
             <div className="text-2xl font-bold text-element-900">
               Data Sources & Actions
             </div>
+            <ContentMessage
+              title="You don't have any active data source or connection"
+              message="Assistants can answer using existing knowledge.\n\nThere are two types of"
+            />
             <div>
               You can ask the assistant to perform actions before answering,
               like{" "}

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -859,7 +859,10 @@ export default function AssistantBuilder({
             {configurableDataSources.length === 0 && (
               <ContentMessage title="You don't have any active data source or connection">
                 <div className="flex flex-col gap-y-3">
-                  <div>Assistants can answer using existing knowledge.</div>
+                  <div>
+                    Assistants can incorporate existing company data and
+                    knowledge to formulate answers.
+                  </div>
                   <div>
                     There are two types of knowledge sources:{" "}
                     <strong>Data Sources</strong> (Files you can upload) and{" "}

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -852,7 +852,9 @@ export default function AssistantBuilder({
           </div>
 
           <div className="flex flex-col gap-6 text-sm text-element-700">
-            <div className="text-2xl font-bold text-element-900">Actions</div>
+            <div className="text-2xl font-bold text-element-900">
+              Data Sources & Actions
+            </div>
             <div>
               You can ask the assistant to perform actions before answering,
               like{" "}

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@dust-tt/sparkle": "^0.2.32",
+        "@dust-tt/sparkle": "^0.2.33",
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",
         "@headlessui/react": "^1.7.7",
@@ -860,9 +860,9 @@
       "integrity": "sha512-smLocSfrt3s53H/XSVP3/1kP42oqvrkjUPtyaFd1F79ux24oE31BKt+q0c6lsa6hOYrFzsIwyc5GXAI5JmfOew=="
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.32",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.32.tgz",
-      "integrity": "sha512-43Lcc+qbKYmLyYjbIrE/HDgVMwknKlbIpuVmJNrJs8c8je4tXmKBYFYYJfFCrNgo+1TZhrqyEhVIRzD9PWPcvA==",
+      "version": "0.2.33",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.33.tgz",
+      "integrity": "sha512-l+FWmM8dh+46rgtS5tH97nbLt4f0RSlH6yLaziY7bW29abQzDdisFBtwlTKKvKDm/gp8StpNeEkiaF7tPzJCdQ==",
       "dependencies": {
         "@headlessui/react": "^1.7.17"
       },

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@dust-tt/sparkle": "^0.2.33",
+        "@dust-tt/sparkle": "^0.2.34",
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",
         "@headlessui/react": "^1.7.7",
@@ -860,9 +860,9 @@
       "integrity": "sha512-smLocSfrt3s53H/XSVP3/1kP42oqvrkjUPtyaFd1F79ux24oE31BKt+q0c6lsa6hOYrFzsIwyc5GXAI5JmfOew=="
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.33",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.33.tgz",
-      "integrity": "sha512-l+FWmM8dh+46rgtS5tH97nbLt4f0RSlH6yLaziY7bW29abQzDdisFBtwlTKKvKDm/gp8StpNeEkiaF7tPzJCdQ==",
+      "version": "0.2.34",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.34.tgz",
+      "integrity": "sha512-/v0yr8syW8OmJOvH1QjYFWFTyFeTIwCNkfcvLkeupXIHR1hzg7gOCx2nuJswuPuNCwmLh68BjqspR7Y4tFJJzQ==",
       "dependencies": {
         "@headlessui/react": "^1.7.17"
       },

--- a/front/package.json
+++ b/front/package.json
@@ -13,7 +13,7 @@
     "initdb": "env $(cat .env.local) npx tsx admin/db.ts"
   },
   "dependencies": {
-    "@dust-tt/sparkle": "^0.2.33",
+    "@dust-tt/sparkle": "^0.2.34",
     "@emoji-mart/data": "^1.1.2",
     "@emoji-mart/react": "^1.1.1",
     "@headlessui/react": "^1.7.7",

--- a/front/package.json
+++ b/front/package.json
@@ -13,7 +13,7 @@
     "initdb": "env $(cat .env.local) npx tsx admin/db.ts"
   },
   "dependencies": {
-    "@dust-tt/sparkle": "^0.2.32",
+    "@dust-tt/sparkle": "^0.2.33",
     "@emoji-mart/data": "^1.1.2",
     "@emoji-mart/react": "^1.1.1",
     "@headlessui/react": "^1.7.7",

--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -3,6 +3,7 @@ import {
   Chip,
   CloudArrowLeftRightIcon,
   Cog6ToothIcon,
+  ContentMessage,
   ContextItem,
   DropdownMenu,
   Page,
@@ -351,6 +352,11 @@ export default function DataSourcesView({
           icon={CloudArrowLeftRightIcon}
           description="Manage connections to your products and the real-time data feeds Dust has access to."
         />
+        {owner.role !== "admin" && (
+          <ContentMessage title="Roles">
+            Only Admins can activate and manage Connections.
+          </ContentMessage>
+        )}
         <ContextItem.List>
           {localIntegrations.map((ds) => {
             return (


### PR DESCRIPTION
Fixes: https://github.com/dust-tt/dust/issues/2372

Compared to the Figma designed I didn't hide the drop down since we also have Dust apps that can be useful. I think that's fine.

There's also a small bug on the new ContentMessage component where the icon get squeezed if the content is multi-line. Will look to fix it in sparkle after merging.

![Screenshot from 2023-11-06 10-48-41](https://github.com/dust-tt/dust/assets/15067/a1927b64-1918-44b0-9ccc-522e37985838)
![Screenshot from 2023-11-06 10-50-26](https://github.com/dust-tt/dust/assets/15067/b26f64fc-2073-46ec-bd82-d6d3d84a1aa3)
