### PR TITLE
Ed's feedback homepage: button size + add new signup button on top of price table

### DIFF
--- a/front/components/Button.tsx
+++ b/front/components/Button.tsx
@@ -105,12 +105,14 @@ export function SignInDropDownButton({
 export function SignUpDropDownButton({
   buttonVariant = "primary",
   buttonLabel = "Start with Dust",
+  buttonSize = "sm",
   buttonIcon = RocketIcon,
   buttonClassname = "",
   onClickGoogle,
 }: {
   buttonVariant?: "primary" | "secondary" | "tertiary";
   buttonLabel?: string;
+  buttonSize?: "sm" | "md" | "lg";
   buttonIcon?: typeof Icon;
   buttonClassname?: string;
   onClickGoogle: () => void;
@@ -121,7 +123,7 @@ export function SignUpDropDownButton({
         <Button
           variant={buttonVariant}
           className={buttonClassname}
-          size="sm"
+          size={buttonSize}
           label={buttonLabel}
           icon={buttonIcon}
         />

--- a/front/pages/index.tsx
+++ b/front/pages/index.tsx
@@ -212,6 +212,7 @@ export default function Home({
                 <div className="sm: flex w-full flex-wrap gap-4 sm:justify-start sm:gap-4 md:gap-6">
                   <SignUpDropDownButton
                     buttonLabel="Start with Dust Now"
+                    buttonSize="md"
                     onClickGoogle={() =>
                       signIn("google", {
                         callbackUrl: getCallbackUrl(router.query),
@@ -656,13 +657,24 @@ export default function Home({
               id="sectionPricing"
               className="col-span-12 text-center md:pb-6 xl:pb-10"
             >
-              <H2 className="text-slate-50">
+              <H2 className="text-slate-50 md:pb-6 xl:pb-10">
                 Start with Dust!
                 <br />
                 <span className="text-slate-200/50">
                   Meet our pricing plans.
                 </span>
               </H2>
+              <div className="lg:px-2 2xl:px-24">
+                <SignUpDropDownButton
+                  buttonLabel="Start with Dust Now"
+                  buttonSize="md"
+                  onClickGoogle={() =>
+                    signIn("google", {
+                      callbackUrl: getCallbackUrl(router.query),
+                    })
+                  }
+                />
+              </div>
             </div>
             <div className="s-dark col-span-12 flex flex-row justify-center lg:px-2 2xl:px-24">
               <PricePlans size="xs" className="lg:hidden" isTabs />


### PR DESCRIPTION
- Set size md to first signup button on page
- Add one signup button on top of the price table


<img width="1538" alt="Capture d’écran 2023-11-06 à 11 28 06" src="https://github.com/dust-tt/dust/assets/3803406/68f47bba-783b-4ea3-a38d-ddc4317cb13b">
