### PR TITLE
Cookie Banner homepage

### DIFF
--- a/front/pages/index.tsx
+++ b/front/pages/index.tsx
@@ -1010,17 +1010,21 @@ const CookieBanner = ({
       leaveFrom="opacity-100"
       leaveTo="opacity-0"
       className={classNames(
-        "z-30 flex w-72 flex-col gap-3 rounded-xl border border-pink-100 bg-pink-50 p-4 shadow-xl",
+        "z-30 flex w-64 flex-col gap-3 rounded-xl border border-structure-100 bg-white p-4 shadow-xl",
         className || ""
       )}
     >
       <div className="text-sm font-normal text-element-900">
-        We use cookies to improve your experience on our site. By using our
-        service, you agree to our{" "}
-        <A variant="tertiary">
-          <Link href="/terms">Terms of Use</Link>
-        </A>
-        .
+        We use{" "}
+        <A variant="primary">
+          <Link
+            href="https://dust-tt.notion.site/Cookie-Policy-ec63a7fb72104a7babff1bf413e2c1ec"
+            target="_blank"
+          >
+            cookies
+          </Link>
+        </A>{" "}
+        to improve your experience on our site.
       </div>
       <div className="flex gap-2">
         <Button

--- a/front/pages/index.tsx
+++ b/front/pages/index.tsx
@@ -36,6 +36,8 @@ import {
 
 const defaultFlexClasses = "flex flex-col gap-4";
 
+import { Transition } from "@headlessui/react";
+
 import {
   SignInDropDownButton,
   SignUpDropDownButton,
@@ -89,6 +91,9 @@ export default function Home({
   const scrollRef2 = useRef<HTMLDivElement | null>(null);
   const scrollRef3 = useRef<HTMLDivElement | null>(null);
   const scrollRef4 = useRef<HTMLDivElement | null>(null);
+
+  const [showCookieBanner, setShowCookieBanner] = useState<boolean>(true);
+  const [hasAcceptedCookies, setHasAcceptedCookies] = useState<boolean>(false);
 
   useEffect(() => {
     if (logoRef.current) {
@@ -752,21 +757,34 @@ export default function Home({
         </div>
 
         <Footer />
-        <>
-          <Script
-            src={`https://www.googletagmanager.com/gtag/js?id=${gaTrackingId}`}
-            strategy="afterInteractive"
-          />
-          <Script id="google-analytics" strategy="afterInteractive">
-            {`
+        <CookieBanner
+          className="fixed bottom-4 right-4"
+          show={showCookieBanner}
+          onClickAccept={() => {
+            setHasAcceptedCookies(true);
+            setShowCookieBanner(false);
+          }}
+          onClickRefuse={() => {
+            setShowCookieBanner(false);
+          }}
+        />
+        {hasAcceptedCookies && (
+          <>
+            <Script
+              src={`https://www.googletagmanager.com/gtag/js?id=${gaTrackingId}`}
+              strategy="afterInteractive"
+            />
+            <Script id="google-analytics" strategy="afterInteractive">
+              {`
              window.dataLayer = window.dataLayer || [];
              function gtag(){window.dataLayer.push(arguments);}
              gtag('js', new Date());
 
              gtag('config', '${gaTrackingId}');
             `}
-          </Script>
-        </>
+            </Script>
+          </>
+        )}
       </main>
     </>
   );
@@ -967,5 +985,57 @@ const Footer = () => {
         </Grid>
       </div>
     </div>
+  );
+};
+
+const CookieBanner = ({
+  show,
+  onClickAccept,
+  onClickRefuse,
+  className,
+}: {
+  show: boolean;
+  onClickAccept: () => void;
+  onClickRefuse: () => void;
+  className?: string;
+}) => {
+  return (
+    <Transition
+      show={show}
+      enter="transition-opacity s-duration-300"
+      appear={true}
+      enterFrom="opacity-0"
+      enterTo="opacity-100"
+      leave="transition-opacity duration-300"
+      leaveFrom="opacity-100"
+      leaveTo="opacity-0"
+      className={classNames(
+        "z-30 flex w-72 flex-col gap-3 rounded-xl border border-pink-100 bg-pink-50 p-4 shadow-xl",
+        className || ""
+      )}
+    >
+      <div className="text-sm font-normal text-element-900">
+        We use cookies to improve your experience on our site. By using our
+        service, you agree to our{" "}
+        <A variant="tertiary">
+          <Link href="/terms">Terms of Use</Link>
+        </A>
+        .
+      </div>
+      <div className="flex gap-2">
+        <Button
+          variant="primary"
+          size="sm"
+          label="Accept All"
+          onClick={onClickAccept}
+        />
+        <Button
+          variant="tertiary"
+          size="sm"
+          label="Reject All"
+          onClick={onClickRefuse}
+        />
+      </div>
+    </Transition>
   );
 };

--- a/front/pages/index.tsx
+++ b/front/pages/index.tsx
@@ -1028,16 +1028,16 @@ const CookieBanner = ({
       </div>
       <div className="flex gap-2">
         <Button
+          variant="tertiary"
+          size="sm"
+          label="Reject"
+          onClick={onClickRefuse}
+        />
+        <Button
           variant="primary"
           size="sm"
           label="Accept All"
           onClick={onClickAccept}
-        />
-        <Button
-          variant="tertiary"
-          size="sm"
-          label="Reject All"
-          onClick={onClickRefuse}
         />
       </div>
     </Transition>


### PR DESCRIPTION
This is probably the most basic we can do. 
It does not move. 🏃🏻‍♀️ 
It load GA only if accepted. It is displayed again if we refresh.

Review with hidden whitespaces: https://github.com/dust-tt/dust/pull/2400/files?diff=split&w=1

<img width="1992" alt="Capture d’écran 2023-11-06 à 16 25 56" src="https://github.com/dust-tt/dust/assets/3803406/f7ef71b7-2b53-4223-a8cc-50cc46361124">
