### PR TITLE
Rename PlanType to SubscriptionType

### DIFF
--- a/front/components/PlansTables.tsx
+++ b/front/components/PlansTables.tsx
@@ -4,13 +4,13 @@ import React from "react";
 
 import { PRO_PLAN_SEAT_29_CODE } from "@app/lib/plans/plan_codes";
 import { classNames } from "@app/lib/utils";
-import { PlanType } from "@app/types/plan";
+import { SubscriptionType } from "@app/types/plan";
 
 interface PricePlanProps {
   size: "sm" | "xs";
   className?: string;
   isTabs?: boolean;
-  plan?: PlanType;
+  plan?: SubscriptionType;
   onClickProPlan?: () => void;
   onClickEnterprisePlan?: () => void;
   isProcessing?: boolean;
@@ -45,7 +45,7 @@ function ProPriceTable({
   isProcessing,
 }: {
   size: "sm" | "xs";
-  plan?: PlanType;
+  plan?: SubscriptionType;
   onClick?: () => void;
   isProcessing?: boolean;
 }) {

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -51,7 +51,7 @@ import {
   UserMessageContext,
   UserMessageType,
 } from "@app/types/assistant/conversation";
-import { PlanType } from "@app/types/plan";
+import { SubscriptionType } from "@app/types/plan";
 import { WorkspaceType } from "@app/types/user";
 
 import { renderDustAppRunActionByModelId } from "./actions/dust_app_run";
@@ -1806,7 +1806,7 @@ async function isMessagesLimitReached({
   plan,
 }: {
   owner: WorkspaceType;
-  plan: PlanType;
+  plan: SubscriptionType;
 }): Promise<boolean> {
   if (plan.limits.assistant.maxMessages === -1) {
     return false;

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -20,7 +20,7 @@ import { Err, Ok, Result } from "@app/lib/result";
 import { new_id } from "@app/lib/utils";
 import logger from "@app/logger/logger";
 import { authOptions } from "@app/pages/api/auth/[...nextauth]";
-import { PlanType } from "@app/types/plan";
+import { SubscriptionType } from "@app/types/plan";
 import { UserType, WorkspaceType } from "@app/types/user";
 
 import { DustAPICredentials } from "./dust_api";
@@ -45,14 +45,14 @@ export class Authenticator {
   _workspace: Workspace | null;
   _user: User | null;
   _role: RoleType;
-  _plan: PlanType | null;
+  _plan: SubscriptionType | null;
 
   // Should only be called from the static methods below.
   constructor(
     workspace: Workspace | null,
     user: User | null,
     role: RoleType,
-    plan: PlanType | null
+    plan: SubscriptionType | null
   ) {
     this._workspace = workspace;
     this._user = user;
@@ -92,7 +92,7 @@ export class Authenticator {
     ]);
 
     let role = "none" as RoleType;
-    let plan: PlanType | null = null;
+    let plan: SubscriptionType | null = null;
 
     if (user && workspace) {
       [role, plan] = await Promise.all([
@@ -273,7 +273,7 @@ export class Authenticator {
       : null;
   }
 
-  plan(): PlanType | null {
+  plan(): SubscriptionType | null {
     return this._plan;
   }
 
@@ -439,13 +439,13 @@ export async function getAPIKey(
 }
 
 /**
- * Construct the PlanType for the provided workspace.
+ * Construct the SubscriptionType for the provided workspace.
  * @param w WorkspaceType the workspace to get the plan for
- * @returns PlanType
+ * @returns SubscriptionType
  */
 export async function planForWorkspace(
   w: Workspace
-): Promise<Promise<PlanType>> {
+): Promise<Promise<SubscriptionType>> {
   const activeSubscription = await Subscription.findOne({
     attributes: [
       "id",

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -2,7 +2,7 @@ import Stripe from "stripe";
 
 import { countActiveSeatsInWorkspace } from "@app/lib/plans/workspace_usage";
 import { assertNever } from "@app/lib/utils";
-import { PaidBillingType, PlanType } from "@app/types/plan";
+import { PaidBillingType, SubscriptionType } from "@app/types/plan";
 import { WorkspaceType } from "@app/types/user";
 
 const { STRIPE_SECRET_KEY = "", URL = "" } = process.env;
@@ -106,7 +106,7 @@ export const createCustomerPortalSession = async ({
   plan,
 }: {
   owner: WorkspaceType;
-  plan: PlanType;
+  plan: SubscriptionType;
 }): Promise<string | null> => {
   if (!plan.stripeCustomerId) {
     throw new Error("No customer ID found for the workspace");

--- a/front/lib/plans/subscription.ts
+++ b/front/lib/plans/subscription.ts
@@ -13,7 +13,7 @@ import {
 import { countActiveSeatsInWorkspace } from "@app/lib/plans/workspace_usage";
 import { generateModelSId } from "@app/lib/utils";
 import logger from "@app/logger/logger";
-import { PlanType } from "@app/types/plan";
+import { SubscriptionType } from "@app/types/plan";
 
 /**
  * Internal function to subscribe to the default FREE_TEST_PLAN.
@@ -23,7 +23,7 @@ export const internalSubscribeWorkspaceToFreeTestPlan = async ({
   workspaceId,
 }: {
   workspaceId: string;
-}): Promise<PlanType> => {
+}): Promise<SubscriptionType> => {
   const workspace = await Workspace.findOne({
     where: { sId: workspaceId },
   });
@@ -89,7 +89,7 @@ export const internalSubscribeWorkspaceToFreeUpgradedPlan = async ({
   workspaceId,
 }: {
   workspaceId: string;
-}): Promise<PlanType> => {
+}): Promise<SubscriptionType> => {
   const workspace = await Workspace.findOne({
     where: { sId: workspaceId },
   });

--- a/front/pages/poke/[wId]/index.tsx
+++ b/front/pages/poke/[wId]/index.tsx
@@ -13,13 +13,13 @@ import { CoreAPI } from "@app/lib/core_api";
 import { FREE_TEST_PLAN_CODE } from "@app/lib/plans/plan_codes";
 import { timeAgoFrom } from "@app/lib/utils";
 import { DataSourceType } from "@app/types/data_source";
-import { PlanType } from "@app/types/plan";
+import { SubscriptionType } from "@app/types/plan";
 import { UserType, WorkspaceType } from "@app/types/user";
 
 export const getServerSideProps: GetServerSideProps<{
   user: UserType;
   workspace: WorkspaceType;
-  plan: PlanType;
+  plan: SubscriptionType;
   dataSources: DataSourceType[];
   slackbotEnabled?: boolean;
   documentCounts: Record<string, number>;

--- a/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
@@ -41,7 +41,7 @@ import { githubAuth } from "@app/lib/github_auth";
 import { useConnectorBotEnabled, useDocuments } from "@app/lib/swr";
 import { timeAgoFrom } from "@app/lib/utils";
 import { DataSourceType } from "@app/types/data_source";
-import { PlanType } from "@app/types/plan";
+import { SubscriptionType } from "@app/types/plan";
 import { UserType, WorkspaceType } from "@app/types/user";
 
 const {
@@ -56,7 +56,7 @@ const {
 export const getServerSideProps: GetServerSideProps<{
   user: UserType | null;
   owner: WorkspaceType;
-  plan: PlanType;
+  plan: SubscriptionType;
   readOnly: boolean;
   isAdmin: boolean;
   dataSource: DataSourceType;
@@ -139,7 +139,7 @@ function StandardDataSourceView({
   dataSource,
 }: {
   owner: WorkspaceType;
-  plan: PlanType;
+  plan: SubscriptionType;
   readOnly: boolean;
   dataSource: DataSourceType;
 }) {
@@ -347,7 +347,7 @@ function SlackBotEnableView({
   readOnly: boolean;
   isAdmin: boolean;
   dataSource: DataSourceType;
-  plan: PlanType;
+  plan: SubscriptionType;
 }) {
   const { botEnabled, mutateBotEnabled } = useConnectorBotEnabled({
     owner: owner,
@@ -468,7 +468,7 @@ function ManagedDataSourceView({
     googleDriveConnectorId: string;
   };
   githubAppUrl: string;
-  plan: PlanType;
+  plan: SubscriptionType;
 }) {
   const router = useRouter();
 

--- a/front/pages/w/[wId]/builder/data-sources/[name]/upsert.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/upsert.tsx
@@ -25,7 +25,7 @@ import { getDataSource } from "@app/lib/api/data_sources";
 import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
 import { classNames } from "@app/lib/utils";
 import { DataSourceType } from "@app/types/data_source";
-import { PlanType } from "@app/types/plan";
+import { SubscriptionType } from "@app/types/plan";
 import { UserType, WorkspaceType } from "@app/types/user";
 
 const { GA_TRACKING_ID = "" } = process.env;
@@ -33,7 +33,7 @@ const { GA_TRACKING_ID = "" } = process.env;
 export const getServerSideProps: GetServerSideProps<{
   user: UserType | null;
   owner: WorkspaceType;
-  plan: PlanType;
+  plan: SubscriptionType;
   readOnly: boolean;
   dataSource: DataSourceType;
   loadDocumentId: string | null;

--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -30,7 +30,7 @@ import {
 import { githubAuth } from "@app/lib/github_auth";
 import { timeAgoFrom } from "@app/lib/utils";
 import { DataSourceType } from "@app/types/data_source";
-import { PlanType } from "@app/types/plan";
+import { SubscriptionType } from "@app/types/plan";
 import { UserType, WorkspaceType } from "@app/types/user";
 
 const {
@@ -63,7 +63,7 @@ export const getServerSideProps: GetServerSideProps<{
   readOnly: boolean;
   isAdmin: boolean;
   integrations: DataSourceIntegration[];
-  plan: PlanType;
+  plan: SubscriptionType;
   gaTrackingId: string;
   nangoConfig: {
     publicKey: string;

--- a/front/pages/w/[wId]/builder/data-sources/static.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/static.tsx
@@ -20,7 +20,7 @@ import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { classNames } from "@app/lib/utils";
 import { DataSourceType } from "@app/types/data_source";
-import { PlanType } from "@app/types/plan";
+import { SubscriptionType } from "@app/types/plan";
 import { UserType, WorkspaceType } from "@app/types/user";
 
 const { GA_TRACKING_ID = "" } = process.env;
@@ -28,7 +28,7 @@ const { GA_TRACKING_ID = "" } = process.env;
 export const getServerSideProps: GetServerSideProps<{
   user: UserType | null;
   owner: WorkspaceType;
-  plan: PlanType;
+  plan: SubscriptionType;
   readOnly: boolean;
   dataSources: DataSourceType[];
   gaTrackingId: string;

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -33,7 +33,7 @@ import { FREE_TEST_PLAN_CODE } from "@app/lib/plans/plan_codes";
 import { useMembers, useWorkspaceInvitations } from "@app/lib/swr";
 import { classNames, isEmailValid } from "@app/lib/utils";
 import { MembershipInvitationType } from "@app/types/membership_invitation";
-import { PlanType } from "@app/types/plan";
+import { SubscriptionType } from "@app/types/plan";
 import { UserType, WorkspaceType } from "@app/types/user";
 
 const { GA_TRACKING_ID = "", URL = "" } = process.env;
@@ -43,7 +43,7 @@ const CLOSING_ANIMATION_DURATION = 200;
 export const getServerSideProps: GetServerSideProps<{
   user: UserType | null;
   owner: WorkspaceType;
-  plan: PlanType;
+  plan: SubscriptionType;
   gaTrackingId: string;
   url: string;
 }> = async (context) => {

--- a/front/pages/w/[wId]/subscription/index.tsx
+++ b/front/pages/w/[wId]/subscription/index.tsx
@@ -19,7 +19,7 @@ import {
   FREE_TEST_PLAN_CODE,
   PRO_PLAN_SEAT_29_CODE,
 } from "@app/lib/plans/plan_codes";
-import { PlanType } from "@app/types/plan";
+import { SubscriptionType } from "@app/types/plan";
 import { UserType, WorkspaceType } from "@app/types/user";
 
 const { GA_TRACKING_ID = "" } = process.env;
@@ -27,7 +27,7 @@ const { GA_TRACKING_ID = "" } = process.env;
 export const getServerSideProps: GetServerSideProps<{
   user: UserType | null;
   owner: WorkspaceType;
-  plan: PlanType;
+  plan: SubscriptionType;
   gaTrackingId: string;
 }> = async (context) => {
   const session = await getSession(context.req, context.res);

--- a/front/pages/w/[wId]/workspace/index.tsx
+++ b/front/pages/w/[wId]/workspace/index.tsx
@@ -12,7 +12,7 @@ import React, { useCallback, useEffect, useState } from "react";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { subNavigationAdmin } from "@app/components/sparkle/navigation";
 import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
-import { PlanType } from "@app/types/plan";
+import { SubscriptionType } from "@app/types/plan";
 import { UserType, WorkspaceType } from "@app/types/user";
 
 const { GA_TRACKING_ID = "" } = process.env;
@@ -20,7 +20,7 @@ const { GA_TRACKING_ID = "" } = process.env;
 export const getServerSideProps: GetServerSideProps<{
   user: UserType | null;
   owner: WorkspaceType;
-  plan: PlanType;
+  plan: SubscriptionType;
   gaTrackingId: string;
 }> = async (context) => {
   const session = await getSession(context.req, context.res);

--- a/front/types/plan.ts
+++ b/front/types/plan.ts
@@ -37,7 +37,7 @@ export const PAID_BILLING_TYPES = [
 export type FreeBillingType = (typeof FREE_BILLING_TYPES)[number];
 export type PaidBillingType = (typeof PAID_BILLING_TYPES)[number];
 
-export type PlanType = {
+export type SubscriptionType = {
   code: string;
   name: string;
   status: "active" | "ended";


### PR DESCRIPTION

Part of https://github.com/dust-tt/tasks/issues/169 
This PR **only renames `PlanType` to `SubscriptionType`.**

Next PR: Introduce a new PlanType 
-> SubscriptionType contains a PlanType
-> PlanType will be used both in front app and in Poké (replacing `PokéPlanType`).


Next @spolu do we want to rename ` const plan = auth.plan()` with `const subscription = auth.subscription()` everywhere? That would be a big one 😄 