### PR TITLE
Introduce new PlanType as part of SubscriptionType and remove PokéPlanType

### DIFF
--- a/front/components/poke/plans/form.tsx
+++ b/front/components/poke/plans/form.tsx
@@ -10,8 +10,7 @@ import {
 import { useCallback, useState } from "react";
 
 import { assertNever, classNames } from "@app/lib/utils";
-import { PokePlanType } from "@app/pages/api/poke/plans";
-import { FreeBillingType, PaidBillingType } from "@app/types/plan";
+import { FreeBillingType, PaidBillingType, PlanType } from "@app/types/plan";
 
 export type EditingPlanType = {
   name: string;
@@ -31,7 +30,7 @@ export type EditingPlanType = {
   isNewPlan?: boolean;
 };
 
-export const fromPokePlanType = (plan: PokePlanType): EditingPlanType => {
+export const fromPlanType = (plan: PlanType): EditingPlanType => {
   return {
     name: plan.name,
     stripeProductId: plan.stripeProductId || "",
@@ -50,7 +49,7 @@ export const fromPokePlanType = (plan: PokePlanType): EditingPlanType => {
   };
 };
 
-export const toPokePlanType = (editingPlan: EditingPlanType): PokePlanType => {
+export const toPlanType = (editingPlan: EditingPlanType): PlanType => {
   return {
     code: editingPlan.code.trim(),
     name: editingPlan.name.trim(),

--- a/front/pages/api/poke/plans.ts
+++ b/front/pages/api/poke/plans.ts
@@ -9,8 +9,9 @@ import { ReturnedAPIErrorType } from "@app/lib/error";
 import { Plan } from "@app/lib/models";
 import { getProduct } from "@app/lib/plans/stripe";
 import { apiError, withLogging } from "@app/logger/withlogging";
+import { PlanType } from "@app/types/plan";
 
-export const PokePlanTypeSchema = t.type({
+export const PlanTypeSchema = t.type({
   code: t.string,
   name: t.string,
   limits: t.type({
@@ -44,14 +45,12 @@ export const PokePlanTypeSchema = t.type({
   ]),
 });
 
-export type PokePlanType = t.TypeOf<typeof PokePlanTypeSchema>;
-
 export type UpsertPokePlanResponseBody = {
-  plan: PokePlanType;
+  plan: PlanType;
 };
 
 export type GetPokePlansResponseBody = {
-  plans: PokePlanType[];
+  plans: PlanType[];
 };
 
 async function handler(
@@ -76,7 +75,7 @@ async function handler(
   switch (req.method) {
     case "GET":
       const planModels = await Plan.findAll({ order: [["createdAt", "ASC"]] });
-      const plans: PokePlanType[] = planModels.map((plan) => ({
+      const plans: PlanType[] = planModels.map((plan) => ({
         code: plan.code,
         name: plan.name,
         stripeProductId: plan.stripeProductId,
@@ -108,7 +107,7 @@ async function handler(
 
       const stripeProductIds = plans
         .filter(
-          (plan): plan is PokePlanType & { stripeProductId: string } =>
+          (plan): plan is PlanType & { stripeProductId: string } =>
             !!plan.stripeProductId
         )
         .map((plan) => plan.stripeProductId);
@@ -133,7 +132,7 @@ async function handler(
       return;
 
     case "POST":
-      const bodyValidation = PokePlanTypeSchema.decode(req.body);
+      const bodyValidation = PlanTypeSchema.decode(req.body);
       if (isLeft(bodyValidation)) {
         const pathError = reporter.formatValidationErrors(bodyValidation.left);
         return apiError(req, res, {

--- a/front/pages/poke/plans.tsx
+++ b/front/pages/poke/plans.tsx
@@ -14,16 +14,15 @@ import { useSWRConfig } from "swr";
 import {
   EditingPlanType,
   Field,
-  fromPokePlanType,
+  fromPlanType,
   PLAN_FIELDS,
-  toPokePlanType,
+  toPlanType,
   useEditingPlan,
 } from "@app/components/poke/plans/form";
 import PokeNavbar from "@app/components/poke/PokeNavbar";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { usePokePlans } from "@app/lib/swr";
-
-import { PokePlanType } from "../api/poke/plans";
+import { PlanType } from "@app/types/plan";
 
 export const getServerSideProps: GetServerSideProps<object> = async (
   _context
@@ -110,7 +109,7 @@ const PlansPage = (
       }
     }
 
-    const requestBody: PokePlanType = toPokePlanType(editingPlan);
+    const requestBody: PlanType = toPlanType(editingPlan);
 
     const r = await fetch("/api/poke/plans", {
       method: "POST",
@@ -133,7 +132,7 @@ const PlansPage = (
     resetEditingPlan();
   };
 
-  const plansToRender: EditingPlanType[] = (plans || []).map(fromPokePlanType);
+  const plansToRender: EditingPlanType[] = (plans || []).map(fromPlanType);
   if (editingPlan?.isNewPlan) {
     plansToRender.push(editingPlan);
   }

--- a/front/types/plan.ts
+++ b/front/types/plan.ts
@@ -37,16 +37,19 @@ export const PAID_BILLING_TYPES = [
 export type FreeBillingType = (typeof FREE_BILLING_TYPES)[number];
 export type PaidBillingType = (typeof PAID_BILLING_TYPES)[number];
 
-export type SubscriptionType = {
+export type PlanType = {
   code: string;
   name: string;
-  status: "active" | "ended";
-  subscriptionId: string | null; // null for the free test plan that is not in db
-  stripeSubscriptionId: string | null;
-  stripeCustomerId: string | null;
+  limits: LimitsType;
   stripeProductId: string | null;
   billingType: FreeBillingType | PaidBillingType;
+};
+
+export type SubscriptionType = PlanType & {
+  subscriptionId: string | null; // null for the free test plan that is not in the database
+  status: "active" | "ended";
+  stripeSubscriptionId: string | null;
+  stripeCustomerId: string | null;
   startDate: number | null;
   endDate: number | null;
-  limits: LimitsType;
 };


### PR DESCRIPTION
Introduce a new `PlanType` and set it as part of `SubscriptionType`.
Small Poké refactor to use `PlanType ` over `PokéPlanType` that I was able to remove. 