### PR TITLE
Refactor: put PlanType inside SubscriptionType

### DIFF
--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -2,7 +2,7 @@ import { Storage } from "@google-cloud/storage";
 import parseArgs from "minimist";
 import readline from "readline";
 
-import { planForWorkspace } from "@app/lib/auth";
+import { subscriptionForWorkspace } from "@app/lib/auth";
 import { ConnectorsAPI } from "@app/lib/connectors_api";
 import { CoreAPI } from "@app/lib/core_api";
 import {
@@ -59,7 +59,8 @@ const workspace = async (command: string, args: parseArgs.ParsedArgs) => {
       console.log(`  wId: ${w.sId}`);
       console.log(`  name: ${w.name}`);
 
-      const plan = await planForWorkspace(w);
+      const subscription = await subscriptionForWorkspace(w);
+      const plan = subscription.plan;
       console.log(`  plan:`);
       console.log(`    limits:`);
       console.log(`      dataSources:`);

--- a/front/components/PlansTables.tsx
+++ b/front/components/PlansTables.tsx
@@ -4,13 +4,13 @@ import React from "react";
 
 import { PRO_PLAN_SEAT_29_CODE } from "@app/lib/plans/plan_codes";
 import { classNames } from "@app/lib/utils";
-import { SubscriptionType } from "@app/types/plan";
+import { PlanType } from "@app/types/plan";
 
 interface PricePlanProps {
   size: "sm" | "xs";
   className?: string;
   isTabs?: boolean;
-  plan?: SubscriptionType;
+  plan?: PlanType;
   onClickProPlan?: () => void;
   onClickEnterprisePlan?: () => void;
   isProcessing?: boolean;
@@ -45,7 +45,7 @@ function ProPriceTable({
   isProcessing,
 }: {
   size: "sm" | "xs";
-  plan?: SubscriptionType;
+  plan?: PlanType;
   onClick?: () => void;
   isProcessing?: boolean;
 }) {

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -51,7 +51,7 @@ import {
   UserMessageContext,
   UserMessageType,
 } from "@app/types/assistant/conversation";
-import { SubscriptionType } from "@app/types/plan";
+import { PlanType } from "@app/types/plan";
 import { WorkspaceType } from "@app/types/user";
 
 import { renderDustAppRunActionByModelId } from "./actions/dust_app_run";
@@ -1806,7 +1806,7 @@ async function isMessagesLimitReached({
   plan,
 }: {
   owner: WorkspaceType;
-  plan: SubscriptionType;
+  plan: PlanType;
 }): Promise<boolean> {
   if (plan.limits.assistant.maxMessages === -1) {
     return false;

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -103,17 +103,17 @@ export const createCheckoutSession = async ({
  */
 export const createCustomerPortalSession = async ({
   owner,
-  plan,
+  subscription,
 }: {
   owner: WorkspaceType;
-  plan: SubscriptionType;
+  subscription: SubscriptionType;
 }): Promise<string | null> => {
-  if (!plan.stripeCustomerId) {
+  if (!subscription.stripeCustomerId) {
     throw new Error("No customer ID found for the workspace");
   }
 
   const portalSession = await stripe.billingPortal.sessions.create({
-    customer: plan.stripeCustomerId,
+    customer: subscription.stripeCustomerId,
     return_url: `${URL}/w/${owner.sId}/subscription`,
   });
 

--- a/front/lib/plans/subscription.ts
+++ b/front/lib/plans/subscription.ts
@@ -46,36 +46,38 @@ export const internalSubscribeWorkspaceToFreeTestPlan = async ({
   const freeTestPlan: PlanAttributes = FREE_TEST_PLAN_DATA;
 
   return {
-    code: freeTestPlan.code,
-    name: freeTestPlan.name,
     status: "active",
     subscriptionId: null,
     stripeSubscriptionId: null,
     stripeCustomerId: null,
-    stripeProductId: null,
-    billingType: freeTestPlan.billingType,
     startDate: null,
     endDate: null,
-    limits: {
-      assistant: {
-        isSlackBotAllowed: freeTestPlan.isSlackbotAllowed,
-        maxMessages: freeTestPlan.maxMessages,
-      },
-      connections: {
-        isSlackAllowed: freeTestPlan.isManagedSlackAllowed,
-        isNotionAllowed: freeTestPlan.isManagedNotionAllowed,
-        isGoogleDriveAllowed: freeTestPlan.isManagedGoogleDriveAllowed,
-        isGithubAllowed: freeTestPlan.isManagedGithubAllowed,
-      },
-      dataSources: {
-        count: freeTestPlan.maxDataSourcesCount,
-        documents: {
-          count: freeTestPlan.maxDataSourcesDocumentsCount,
-          sizeMb: freeTestPlan.maxDataSourcesDocumentsSizeMb,
+    plan: {
+      code: freeTestPlan.code,
+      name: freeTestPlan.name,
+      stripeProductId: null,
+      billingType: freeTestPlan.billingType,
+      limits: {
+        assistant: {
+          isSlackBotAllowed: freeTestPlan.isSlackbotAllowed,
+          maxMessages: freeTestPlan.maxMessages,
         },
-      },
-      users: {
-        maxUsers: freeTestPlan.maxUsersInWorkspace,
+        connections: {
+          isSlackAllowed: freeTestPlan.isManagedSlackAllowed,
+          isNotionAllowed: freeTestPlan.isManagedNotionAllowed,
+          isGoogleDriveAllowed: freeTestPlan.isManagedGoogleDriveAllowed,
+          isGithubAllowed: freeTestPlan.isManagedGithubAllowed,
+        },
+        dataSources: {
+          count: freeTestPlan.maxDataSourcesCount,
+          documents: {
+            count: freeTestPlan.maxDataSourcesDocumentsCount,
+            sizeMb: freeTestPlan.maxDataSourcesDocumentsSizeMb,
+          },
+        },
+        users: {
+          maxUsers: freeTestPlan.maxUsersInWorkspace,
+        },
       },
     },
   };
@@ -140,36 +142,38 @@ export const internalSubscribeWorkspaceToFreeUpgradedPlan = async ({
     );
 
     return {
-      code: plan.code,
-      name: plan.name,
       status: "active",
       subscriptionId: newSubscription.sId,
       stripeSubscriptionId: newSubscription.stripeSubscriptionId,
       stripeCustomerId: newSubscription.stripeCustomerId,
-      stripeProductId: null,
-      billingType: "free",
       startDate: newSubscription.startDate.getTime(),
       endDate: newSubscription.endDate?.getTime() || null,
-      limits: {
-        assistant: {
-          isSlackBotAllowed: plan.isSlackbotAllowed,
-          maxMessages: plan.maxMessages,
-        },
-        connections: {
-          isSlackAllowed: plan.isManagedSlackAllowed,
-          isNotionAllowed: plan.isManagedNotionAllowed,
-          isGoogleDriveAllowed: plan.isManagedGoogleDriveAllowed,
-          isGithubAllowed: plan.isManagedGithubAllowed,
-        },
-        dataSources: {
-          count: plan.maxDataSourcesCount,
-          documents: {
-            count: plan.maxDataSourcesDocumentsCount,
-            sizeMb: plan.maxDataSourcesDocumentsSizeMb,
+      plan: {
+        code: plan.code,
+        name: plan.name,
+        stripeProductId: null,
+        billingType: "free",
+        limits: {
+          assistant: {
+            isSlackBotAllowed: plan.isSlackbotAllowed,
+            maxMessages: plan.maxMessages,
           },
-        },
-        users: {
-          maxUsers: plan.maxUsersInWorkspace,
+          connections: {
+            isSlackAllowed: plan.isManagedSlackAllowed,
+            isNotionAllowed: plan.isManagedNotionAllowed,
+            isGoogleDriveAllowed: plan.isManagedGoogleDriveAllowed,
+            isGithubAllowed: plan.isManagedGithubAllowed,
+          },
+          dataSources: {
+            count: plan.maxDataSourcesCount,
+            documents: {
+              count: plan.maxDataSourcesDocumentsCount,
+              sizeMb: plan.maxDataSourcesDocumentsSizeMb,
+            },
+          },
+          users: {
+            maxUsers: plan.maxUsersInWorkspace,
+          },
         },
       },
     };

--- a/front/pages/api/stripe/portal.ts
+++ b/front/pages/api/stripe/portal.ts
@@ -35,8 +35,8 @@ async function handler(
   const auth = await Authenticator.fromSession(session, workspaceId);
 
   const owner = auth.workspace();
-  const plan = auth.plan();
-  if (!owner || !plan) {
+  const subscription = auth.subscription();
+  if (!owner || !subscription) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
@@ -59,7 +59,10 @@ async function handler(
 
   switch (req.method) {
     case "POST":
-      const portalUrl = await createCustomerPortalSession({ owner, plan });
+      const portalUrl = await createCustomerPortalSession({
+        owner,
+        subscription,
+      });
       if (portalUrl) {
         res.status(200).json({ portalUrl });
         return;

--- a/front/pages/poke/[wId]/index.tsx
+++ b/front/pages/poke/[wId]/index.tsx
@@ -19,7 +19,7 @@ import { UserType, WorkspaceType } from "@app/types/user";
 export const getServerSideProps: GetServerSideProps<{
   user: UserType;
   workspace: WorkspaceType;
-  plan: SubscriptionType;
+  subscription: SubscriptionType;
   dataSources: DataSourceType[];
   slackbotEnabled?: boolean;
   documentCounts: Record<string, number>;
@@ -53,9 +53,9 @@ export const getServerSideProps: GetServerSideProps<{
   const auth = await Authenticator.fromSuperUserSession(session, wId);
 
   const workspace = auth.workspace();
-  const plan = auth.plan();
+  const subscription = auth.subscription();
 
-  if (!workspace || !plan) {
+  if (!workspace || !subscription) {
     return {
       notFound: true,
     };
@@ -132,7 +132,7 @@ export const getServerSideProps: GetServerSideProps<{
     props: {
       user,
       workspace,
-      plan,
+      subscription,
       dataSources,
       slackbotEnabled,
       documentCounts: docCountByDsName,
@@ -143,7 +143,7 @@ export const getServerSideProps: GetServerSideProps<{
 
 const WorkspacePage = ({
   workspace,
-  plan,
+  subscription,
   dataSources,
   slackbotEnabled,
   documentCounts,
@@ -273,7 +273,7 @@ const WorkspacePage = ({
         <div className="flex justify-center">
           <div className="mx-2 w-1/3">
             <h2 className="text-md mb-4 font-bold">Plan:</h2>
-            <JsonViewer value={plan} rootName={false} />
+            <JsonViewer value={subscription} rootName={false} />
             <div>
               <div className="mt-4 flex-row">
                 <Button
@@ -281,7 +281,7 @@ const WorkspacePage = ({
                   variant="secondaryWarning"
                   onClick={onDowngrade}
                   disabled={
-                    plan.code === FREE_TEST_PLAN_CODE ||
+                    subscription.plan.code === FREE_TEST_PLAN_CODE ||
                     workspaceHasManagedDataSources
                   }
                 />
@@ -290,11 +290,11 @@ const WorkspacePage = ({
                   label="Upgrade"
                   variant="secondary"
                   onClick={onUpgrade}
-                  disabled={plan.code !== FREE_TEST_PLAN_CODE}
+                  disabled={subscription.plan.code !== FREE_TEST_PLAN_CODE}
                 />
               </div>
             </div>
-            {plan.code !== FREE_TEST_PLAN_CODE &&
+            {subscription.plan.code !== FREE_TEST_PLAN_CODE &&
               workspaceHasManagedDataSources && (
                 <span className="mx-2 w-1/3">
                   <p className="text-warning mb-4 text-sm ">

--- a/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
@@ -41,7 +41,7 @@ import { githubAuth } from "@app/lib/github_auth";
 import { useConnectorBotEnabled, useDocuments } from "@app/lib/swr";
 import { timeAgoFrom } from "@app/lib/utils";
 import { DataSourceType } from "@app/types/data_source";
-import { SubscriptionType } from "@app/types/plan";
+import { PlanType } from "@app/types/plan";
 import { UserType, WorkspaceType } from "@app/types/user";
 
 const {
@@ -56,7 +56,7 @@ const {
 export const getServerSideProps: GetServerSideProps<{
   user: UserType | null;
   owner: WorkspaceType;
-  plan: SubscriptionType;
+  plan: PlanType;
   readOnly: boolean;
   isAdmin: boolean;
   dataSource: DataSourceType;
@@ -139,7 +139,7 @@ function StandardDataSourceView({
   dataSource,
 }: {
   owner: WorkspaceType;
-  plan: SubscriptionType;
+  plan: PlanType;
   readOnly: boolean;
   dataSource: DataSourceType;
 }) {
@@ -347,7 +347,7 @@ function SlackBotEnableView({
   readOnly: boolean;
   isAdmin: boolean;
   dataSource: DataSourceType;
-  plan: SubscriptionType;
+  plan: PlanType;
 }) {
   const { botEnabled, mutateBotEnabled } = useConnectorBotEnabled({
     owner: owner,
@@ -468,7 +468,7 @@ function ManagedDataSourceView({
     googleDriveConnectorId: string;
   };
   githubAppUrl: string;
-  plan: SubscriptionType;
+  plan: PlanType;
 }) {
   const router = useRouter();
 

--- a/front/pages/w/[wId]/builder/data-sources/[name]/upsert.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/upsert.tsx
@@ -25,7 +25,7 @@ import { getDataSource } from "@app/lib/api/data_sources";
 import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
 import { classNames } from "@app/lib/utils";
 import { DataSourceType } from "@app/types/data_source";
-import { SubscriptionType } from "@app/types/plan";
+import { PlanType } from "@app/types/plan";
 import { UserType, WorkspaceType } from "@app/types/user";
 
 const { GA_TRACKING_ID = "" } = process.env;
@@ -33,7 +33,7 @@ const { GA_TRACKING_ID = "" } = process.env;
 export const getServerSideProps: GetServerSideProps<{
   user: UserType | null;
   owner: WorkspaceType;
-  plan: SubscriptionType;
+  plan: PlanType;
   readOnly: boolean;
   dataSource: DataSourceType;
   loadDocumentId: string | null;

--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -30,7 +30,7 @@ import {
 import { githubAuth } from "@app/lib/github_auth";
 import { timeAgoFrom } from "@app/lib/utils";
 import { DataSourceType } from "@app/types/data_source";
-import { SubscriptionType } from "@app/types/plan";
+import { PlanType } from "@app/types/plan";
 import { UserType, WorkspaceType } from "@app/types/user";
 
 const {
@@ -63,7 +63,7 @@ export const getServerSideProps: GetServerSideProps<{
   readOnly: boolean;
   isAdmin: boolean;
   integrations: DataSourceIntegration[];
-  plan: SubscriptionType;
+  plan: PlanType;
   gaTrackingId: string;
   nangoConfig: {
     publicKey: string;

--- a/front/pages/w/[wId]/builder/data-sources/static.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/static.tsx
@@ -20,7 +20,7 @@ import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { classNames } from "@app/lib/utils";
 import { DataSourceType } from "@app/types/data_source";
-import { SubscriptionType } from "@app/types/plan";
+import { PlanType } from "@app/types/plan";
 import { UserType, WorkspaceType } from "@app/types/user";
 
 const { GA_TRACKING_ID = "" } = process.env;
@@ -28,7 +28,7 @@ const { GA_TRACKING_ID = "" } = process.env;
 export const getServerSideProps: GetServerSideProps<{
   user: UserType | null;
   owner: WorkspaceType;
-  plan: SubscriptionType;
+  plan: PlanType;
   readOnly: boolean;
   dataSources: DataSourceType[];
   gaTrackingId: string;

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -33,7 +33,7 @@ import { FREE_TEST_PLAN_CODE } from "@app/lib/plans/plan_codes";
 import { useMembers, useWorkspaceInvitations } from "@app/lib/swr";
 import { classNames, isEmailValid } from "@app/lib/utils";
 import { MembershipInvitationType } from "@app/types/membership_invitation";
-import { SubscriptionType } from "@app/types/plan";
+import { PlanType } from "@app/types/plan";
 import { UserType, WorkspaceType } from "@app/types/user";
 
 const { GA_TRACKING_ID = "", URL = "" } = process.env;
@@ -43,7 +43,7 @@ const CLOSING_ANIMATION_DURATION = 200;
 export const getServerSideProps: GetServerSideProps<{
   user: UserType | null;
   owner: WorkspaceType;
-  plan: SubscriptionType;
+  plan: PlanType;
   gaTrackingId: string;
   url: string;
 }> = async (context) => {

--- a/front/pages/w/[wId]/subscription/index.tsx
+++ b/front/pages/w/[wId]/subscription/index.tsx
@@ -27,7 +27,7 @@ const { GA_TRACKING_ID = "" } = process.env;
 export const getServerSideProps: GetServerSideProps<{
   user: UserType | null;
   owner: WorkspaceType;
-  plan: SubscriptionType;
+  subscription: SubscriptionType;
   gaTrackingId: string;
 }> = async (context) => {
   const session = await getSession(context.req, context.res);
@@ -38,8 +38,8 @@ export const getServerSideProps: GetServerSideProps<{
   );
 
   const owner = auth.workspace();
-  const plan = auth.plan();
-  if (!owner || !auth.isAdmin() || !plan) {
+  const subscription = auth.subscription();
+  if (!owner || !auth.isAdmin() || !subscription) {
     return {
       notFound: true,
     };
@@ -49,7 +49,7 @@ export const getServerSideProps: GetServerSideProps<{
     props: {
       user,
       owner,
-      plan,
+      subscription,
       gaTrackingId: GA_TRACKING_ID,
     },
   };
@@ -58,7 +58,7 @@ export const getServerSideProps: GetServerSideProps<{
 export default function Subscription({
   user,
   owner,
-  plan,
+  subscription,
   gaTrackingId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const sendNotification = useContext(SendNotificationsContext);
@@ -118,6 +118,7 @@ export default function Subscription({
     setIsProcessing(false);
   }
 
+  const plan = subscription.plan;
   const chipColor = plan.code === FREE_TEST_PLAN_CODE ? "emerald" : "sky";
 
   const onClickProPlan = async () =>
@@ -150,7 +151,7 @@ export default function Subscription({
               </div>
             </div>
             <div className="flex-1">
-              {plan.stripeCustomerId && (
+              {subscription.stripeCustomerId && (
                 <>
                   <Page.H variant="h5">Payment, invoicing & billing</Page.H>
                   <div className="pt-2">

--- a/front/pages/w/[wId]/workspace/index.tsx
+++ b/front/pages/w/[wId]/workspace/index.tsx
@@ -20,7 +20,7 @@ const { GA_TRACKING_ID = "" } = process.env;
 export const getServerSideProps: GetServerSideProps<{
   user: UserType | null;
   owner: WorkspaceType;
-  plan: SubscriptionType;
+  subscription: SubscriptionType;
   gaTrackingId: string;
 }> = async (context) => {
   const session = await getSession(context.req, context.res);
@@ -31,8 +31,8 @@ export const getServerSideProps: GetServerSideProps<{
   );
 
   const owner = auth.workspace();
-  const plan = auth.plan();
-  if (!owner || !auth.isAdmin() || !plan) {
+  const subscription = auth.subscription();
+  if (!owner || !auth.isAdmin() || !subscription) {
     return {
       notFound: true,
     };
@@ -42,7 +42,7 @@ export const getServerSideProps: GetServerSideProps<{
     props: {
       user,
       owner,
-      plan,
+      subscription,
       gaTrackingId: GA_TRACKING_ID,
     },
   };
@@ -51,7 +51,7 @@ export const getServerSideProps: GetServerSideProps<{
 export default function WorkspaceAdmin({
   user,
   owner,
-  plan,
+  subscription,
   gaTrackingId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const [disable, setDisabled] = useState(true);
@@ -181,8 +181,8 @@ export default function WorkspaceAdmin({
 
   // This is not perfect as workspaces who were on multiple paid plans will have the list of months only for the current plan.
   // We're living with it until it's a problem.
-  if (plan.startDate) {
-    const startDate = new Date(plan.startDate);
+  if (subscription.startDate) {
+    const startDate = new Date(subscription.startDate);
     const startDateYear = startDate.getFullYear();
     const startDateMonth = startDate.getMonth();
 

--- a/front/types/plan.ts
+++ b/front/types/plan.ts
@@ -45,11 +45,12 @@ export type PlanType = {
   billingType: FreeBillingType | PaidBillingType;
 };
 
-export type SubscriptionType = PlanType & {
+export type SubscriptionType = {
   subscriptionId: string | null; // null for the free test plan that is not in the database
   status: "active" | "ended";
   stripeSubscriptionId: string | null;
   stripeCustomerId: string | null;
   startDate: number | null;
   endDate: number | null;
+  plan: PlanType;
 };


### PR DESCRIPTION
Changes: 

- `auth.plan()` return `PlanType`
- `auth.subscription()` return `SubscriptionType`
- `SubscriptionType` contains a key plan that contains the `PlanType` as opposed to merging `PlanType` keys in `SubscriptionType`.