### PR TITLE
Refactor subscribeWorkspaceToPlan to return the PlanType

### DIFF
--- a/front/pages/api/w/[wId]/subscriptions/index.ts
+++ b/front/pages/api/w/[wId]/subscriptions/index.ts
@@ -5,9 +5,11 @@ import { ReturnedAPIErrorType } from "@app/lib/error";
 import { subscribeWorkspaceToPlan } from "@app/lib/plans/subscription";
 import logger from "@app/logger/logger";
 import { apiError, withLogging } from "@app/logger/withlogging";
+import { PlanType } from "@app/types/plan";
 
 export type PostSubscriptionResponseBody = {
-  checkoutUrl: string | null;
+  plan: PlanType;
+  checkoutUrl?: string;
 };
 
 async function handler(
@@ -46,10 +48,10 @@ async function handler(
   switch (req.method) {
     case "POST":
       try {
-        const stripeCheckoutUrl = await subscribeWorkspaceToPlan(auth, {
+        const response = await subscribeWorkspaceToPlan(auth, {
           planCode: req.body.planCode,
         });
-        return res.status(200).json({ checkoutUrl: stripeCheckoutUrl || null });
+        return res.status(200).json(response);
       } catch (error) {
         logger.error({ error }, "Error while subscribing workspace to plan");
         return apiError(req, res, {

--- a/front/pages/w/[wId]/subscription/index.tsx
+++ b/front/pages/w/[wId]/subscription/index.tsx
@@ -168,7 +168,7 @@ export default function Subscription({
               )}
             </div>
           </div>
-          <div className="pt-2">
+          <div className="mb-10 pt-2">
             <Page.H variant="h5">Manage my plan</Page.H>
             <div className="s-h-full s-w-full pt-2">
               <PricePlans


### PR DESCRIPTION
We were unhappy with the signature of `subscribeWorkspaceToPlan`.
It could not return a `SubscriptionType` because for paid plan the subscription is created only after the checkout session is completed. So we were just returning the checkoutUrl of the checkout session or null if the subscription was to a free plan. 

Now that we have a specific type for plan, we can return both the Plan we want to subscribe to and the `checkoutUrl` if we're in the process of subscribing to a paid plan. 