### PR TITLE
Slack: better full sync

### DIFF
--- a/connectors/src/connectors/slack/temporal/signals.ts
+++ b/connectors/src/connectors/slack/temporal/signals.ts
@@ -1,9 +1,10 @@
 import { defineSignal } from "@temporalio/workflow";
 
 export const newWebhookSignal = defineSignal<[void]>("new_webhook_signal");
-export interface botJoinedChanelSignalInput {
-  channelId: string;
+
+export interface syncChannelSignalInput {
+  channelIds: string[];
 }
-export const botJoinedChanelSignal = defineSignal<[botJoinedChanelSignalInput]>(
-  "bot_joined_channel_signal"
+export const syncChannelSignal = defineSignal<[syncChannelSignalInput]>(
+  "sync_channel_signal"
 );

--- a/connectors/src/lib/models.ts
+++ b/connectors/src/lib/models.ts
@@ -48,7 +48,7 @@ export class Connector extends Model<
   declare errorType: ConnectorErrorType | null;
   declare lastSyncStartTime?: Date;
   declare lastSyncFinishTime?: Date;
-  declare lastSyncSuccessfulTime?: Date;
+  declare lastSyncSuccessfulTime?: Date | null;
   declare firstSuccessfulSyncTime?: Date;
   declare firstSyncProgress?: string;
   declare lastGCTime: Date | null;

--- a/connectors/src/lib/sync_status.ts
+++ b/connectors/src/lib/sync_status.ts
@@ -44,6 +44,7 @@ export async function reportInitialSyncProgress(
     return new Err(new Error("Connector not found"));
   }
   connector.firstSyncProgress = progress;
+  connector.lastSyncSuccessfulTime = null;
   await connector.save();
 
   return new Ok(undefined);


### PR DESCRIPTION
Slack full sync improvements:
- There is only one full sync workflow now.
- The full sync workflow is not started on connector creation anymore.
- It's started only when one or more channels have been selected.
- Channels to sync are sent via Temporal signals, allowing for selecting a set of channels and selecting some others while the full sync workflow is running.
- Sending everything through the full sync workflow allows for a proper display of the "syncing" status.

Fixing:
https://github.com/dust-tt/tasks/issues/199
https://github.com/dust-tt/tasks/issues/198
