### PR TITLE
Add notifications post subscription

### DIFF
--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -109,7 +109,7 @@ export const createCheckoutSession = async ({
     automatic_tax: {
       enabled: true,
     },
-    success_url: `${URL}/w/${owner.sId}/subscription?type=succeeded&session_id={CHECKOUT_SESSION_ID}`,
+    success_url: `${URL}/w/${owner.sId}/subscription?type=succeeded&session_id={CHECKOUT_SESSION_ID}&plan_code=${planCode}`,
     cancel_url: `${URL}/w/${owner.sId}/subscription?type=cancelled`,
   });
 

--- a/front/pages/w/[wId]/subscription/index.tsx
+++ b/front/pages/w/[wId]/subscription/index.tsx
@@ -7,7 +7,7 @@ import {
   ShapesIcon,
 } from "@dust-tt/sparkle";
 import { GetServerSideProps, InferGetServerSidePropsType } from "next";
-import router from "next/router";
+import { useRouter } from "next/router";
 import React, { useContext } from "react";
 
 import { PricePlans } from "@app/components/PlansTables";
@@ -68,6 +68,7 @@ export default function Subscription({
   planInvitation,
   gaTrackingId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  const router = useRouter();
   const sendNotification = useContext(SendNotificationsContext);
 
   const { submit: handleSubscribePlan, isSubmitting: isSubscribingPlan } =

--- a/front/pages/w/[wId]/subscription/index.tsx
+++ b/front/pages/w/[wId]/subscription/index.tsx
@@ -5,10 +5,11 @@ import {
   Page,
   PageHeader,
   ShapesIcon,
+  Spinner,
 } from "@dust-tt/sparkle";
 import { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
-import React, { useContext } from "react";
+import React, { useContext, useEffect } from "react";
 
 import { PricePlans } from "@app/components/PlansTables";
 import AppLayout from "@app/components/sparkle/AppLayout";
@@ -70,6 +71,35 @@ export default function Subscription({
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const router = useRouter();
   const sendNotification = useContext(SendNotificationsContext);
+  const [isWebhookProcessing, setIsWebhookProcessing] =
+    React.useState<boolean>(false);
+
+  useEffect(() => {
+    if (router.query.type === "succeeded") {
+      if (subscription.plan.code === router.query.plan_code) {
+        sendNotification({
+          type: "success",
+          title: `Subscription to ${subscription.plan.name}`,
+          description: `Your subscription to ${subscription.plan.name} is now active. Thank you for your trust.`,
+        });
+        // Then we remove the query params to avoid going through this logic again.
+        void router.push(
+          { pathname: `/w/${owner.sId}/subscription` },
+          undefined,
+          {
+            shallow: true,
+          }
+        );
+      } else {
+        // If the Stripe webhook is not yet received, we try waiting for it and reload the page every 5 seconds until it's done.
+        setIsWebhookProcessing(true);
+        setTimeout(() => {
+          void router.reload();
+        }, 5000);
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []); // Intentionally passing an empty dependency array to execute only once
 
   const { submit: handleSubscribePlan, isSubmitting: isSubscribingPlan } =
     useSubmitFunction(async () => {
@@ -86,6 +116,14 @@ export default function Subscription({
           title: "Subscribtion failed",
           description: "Failed to subscribe to a new plan.",
         });
+        // Then we remove the query params to avoid going through this logic again.
+        void router.push(
+          { pathname: `/w/${owner.sId}/subscription` },
+          undefined,
+          {
+            shallow: true,
+          }
+        );
       } else {
         const content = await res.json();
         if (content.checkoutUrl) {
@@ -159,8 +197,14 @@ export default function Subscription({
               <div className="flex-1">
                 <Page.H variant="h5">Your plan </Page.H>
                 <div className="pt-2">
-                  You're on&nbsp;&nbsp;
-                  <Chip size="sm" color={chipColor} label={plan.name} />
+                  {isWebhookProcessing ? (
+                    <Spinner />
+                  ) : (
+                    <>
+                      You're on&nbsp;&nbsp;
+                      <Chip size="sm" color={chipColor} label={plan.name} />
+                    </>
+                  )}
                 </div>
               </div>
               <div className="flex-1">


### PR DESCRIPTION
We display a notification on the subscription page post subscription: 
- If user cancelled the checkout session, we display an error notif
- If user successfully subscribed and we already processed the webhook (should be the case all the time), we display a success notif. 
- If user successfully subscribed and we have not processed the webhook yet (should not happen), we reload the page after 1 second. Not perfect but okay enough?

Wordings in notifications are temporary, I'll make them review by Gab on Slack.