### PR TITLE
Show all public Slack channels in link Slack Channel and Assistant sc…

### DIFF
--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -1284,7 +1284,7 @@ function SlackIntegration({
               }}
               expandable={false}
               fullySelected={false}
-              filterPermission="write"
+              filterPermission="none"
             />
           </div>
         </div>


### PR DESCRIPTION
This is the list assistants screen part of the “Link assistant with Slack channel”.

Now I understand better what was confusing:
Before we were only showing channels already joined by the bot (permissions=write). But a joined channel does not mean we know about it (someone can just invite @dust on a channel directly on Slack).

So now we are just listing all channels we can see. Which is what was discussed here:
https://github.com/dust-tt/tasks/issues/218