### PR TITLE
Migration fix duplicated subscriptions: add check on planId for subscriptions to delete

### DIFF
--- a/front/migrations/20231107_subscriptions_duplicated.ts
+++ b/front/migrations/20231107_subscriptions_duplicated.ts
@@ -29,6 +29,7 @@ const getValidSubscriptionStartDateForWorkspace = async (
   const subscriptions = await Subscription.findAll({
     where: {
       workspaceId: workspaceId,
+      planId: 5,
     },
     order: [["startDate", "ASC"]],
   });
@@ -56,6 +57,7 @@ const deletedDuplicatedEndedSubscriptionsForWorkspace = async (
     where: {
       workspaceId: workspaceId,
       status: "ended",
+      planId: 5,
     },
   });
   console.log(`    Found ${subscriptions.length} subscriptions`);


### PR DESCRIPTION
Just adding a check on hardcoded planId > otherwise we will remove the ended subscription for stan's perso workspace and my perso's workspace, as we both were on the free upgraded plan before subscribing to pro. 

https://metabase.dust.tt/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7InR5cGUiOiJuYXRpdmUiLCJuYXRpdmUiOnsicXVlcnkiOiJTRUxFQ1QgKiBcbkZST00gd29ya3NwYWNlcyBcbldIRVJFIFwiaWRcIiBJTiAoMTE0OTYsMTE1NDEsMTE2MjYsMTE4NTEsMTIwNjYsMTIxMjYsMTIyMzUsMTIzNjEsMTI1MDIsMTI1NjUsMTI2MjUsMTI2NzUsMTY0Nyw1ODA2LDY2MjcpIiwidGVtcGxhdGUtdGFncyI6e319LCJkYXRhYmFzZSI6NH0sImRpc3BsYXkiOiJ0YWJsZSIsInBhcmFtZXRlcnMiOltdLCJ2aXN1YWxpemF0aW9uX3NldHRpbmdzIjp7fX0=