### PR TITLE
Quick fix: banner to indicate service disruption due to openAI

### DIFF
--- a/front/components/sparkle/AppLayout.tsx
+++ b/front/components/sparkle/AppLayout.tsx
@@ -364,6 +364,25 @@ export default function AppLayout({
             </div>
           </div>
 
+          {/** BEGIN Incident Banner */}
+          <div className="flex w-full items-center justify-center bg-warning-300 py-2 text-element-900">
+            <div className="">
+              <span className="font-bold">OpenAI Outage:</span> OpenAI is
+              encountering a{" "}
+              <a
+                href="https://status.openai.com/"
+                target="_blank"
+                className="underline"
+              >
+                full outage of their APIs
+              </a>
+              {". "}
+              All our services are impacted except assistants with no retrieval,
+              and based on Anthropic AI.
+            </div>
+          </div>
+          {/** END Incident Banner */}
+
           <main
             id="main-content"
             className={classNames(

--- a/front/pages/_document.tsx
+++ b/front/pages/_document.tsx
@@ -14,6 +14,21 @@ class MyDocument extends Document {
           <link href="https://use.typekit.net/jnb2umy.css" rel="stylesheet" />
         </Head>
         <body>
+          <div className="relative z-50 flex w-full items-center justify-center border-b bg-warning-200 text-element-800">
+            <div className="">
+              <span className="font-bold">OpenAI outage:</span> OpenAI is
+              encountering a{" "}
+              <a
+                href="https://status.openai.com/"
+                target="_blank"
+                className="underline"
+              >
+                full outage of their APIs
+              </a>{" "}
+              All our services are impacted except assistants with no retrieval
+              based on Anthropic AI.
+            </div>
+          </div>
           <Main />
           <NextScript />
         </body>

--- a/front/pages/_document.tsx
+++ b/front/pages/_document.tsx
@@ -14,21 +14,6 @@ class MyDocument extends Document {
           <link href="https://use.typekit.net/jnb2umy.css" rel="stylesheet" />
         </Head>
         <body>
-          <div className="relative z-50 flex w-full items-center justify-center border-b bg-warning-200 text-element-800">
-            <div className="">
-              <span className="font-bold">OpenAI outage:</span> OpenAI is
-              encountering a{" "}
-              <a
-                href="https://status.openai.com/"
-                target="_blank"
-                className="underline"
-              >
-                full outage of their APIs
-              </a>{" "}
-              All our services are impacted except assistants with no retrieval
-              based on Anthropic AI.
-            </div>
-          </div>
           <Main />
           <NextScript />
         </body>


### PR DESCRIPTION
This is to merge fast. Meanwhile, will improve for it not to overwrite the logo etc.
![image](https://github.com/dust-tt/dust/assets/5437393/7319e917-655b-4245-b878-cfa524285cfc)