### PR TITLE
Rate limiter for postUserMessageWithPubsub()

### DIFF
--- a/front/lib/api/assistant/pubsub.ts
+++ b/front/lib/api/assistant/pubsub.ts
@@ -19,6 +19,7 @@ import { GenerationTokensEvent } from "@app/lib/api/assistant/generation";
 import { Authenticator } from "@app/lib/auth";
 import { APIErrorWithStatusCode } from "@app/lib/error";
 import { AgentMessage, Message } from "@app/lib/models";
+import { rateLimiter } from "@app/lib/rate_limiter";
 import { redisClient } from "@app/lib/redis";
 import { Err, Ok, Result } from "@app/lib/result";
 import { wakeLock } from "@app/lib/wake_lock";
@@ -47,6 +48,30 @@ export async function postUserMessageWithPubSub(
     context: UserMessageContext;
   }
 ): Promise<Result<UserMessageType, PubSubError>> {
+  let maxPerTimeframe: number | undefined = undefined;
+  let timeframeSeconds: number | undefined = undefined;
+  let rateLimitKey: string | undefined = "";
+  if (auth.user()?.id) {
+    maxPerTimeframe = 15;
+    timeframeSeconds = 120;
+    rateLimitKey = `postUserMessageUser:${auth.user()?.id}`;
+  } else {
+    maxPerTimeframe = 20;
+    timeframeSeconds = 120;
+    rateLimitKey = `postUserMessageWorkspace:${auth.workspace()?.id}`;
+  }
+
+  if (
+    (await rateLimiter(rateLimitKey, maxPerTimeframe, timeframeSeconds)) === 0
+  ) {
+    return new Err({
+      status_code: 429,
+      api_error: {
+        type: "rate_limit_error",
+        message: "Rate limit exceeded. Please try again in a few minutes.",
+      },
+    });
+  }
   const postMessageEvents = postUserMessage(auth, {
     conversation,
     content,

--- a/front/lib/api/assistant/pubsub.ts
+++ b/front/lib/api/assistant/pubsub.ts
@@ -52,7 +52,7 @@ export async function postUserMessageWithPubSub(
   let timeframeSeconds: number | undefined = undefined;
   let rateLimitKey: string | undefined = "";
   if (auth.user()?.id) {
-    maxPerTimeframe = 15;
+    maxPerTimeframe = 3;
     timeframeSeconds = 120;
     rateLimitKey = `postUserMessageUser:${auth.user()?.id}`;
   } else {
@@ -68,7 +68,9 @@ export async function postUserMessageWithPubSub(
       status_code: 429,
       api_error: {
         type: "rate_limit_error",
-        message: "Rate limit exceeded. Please try again in a few minutes.",
+        message: `You have reached the maximum number of ${maxPerTimeframe} messages per ${Math.ceil(
+          timeframeSeconds / 60
+        )} minutes of your account. Please try again later.`,
       },
     });
   }

--- a/front/lib/error.ts
+++ b/front/lib/error.ts
@@ -50,7 +50,8 @@ export type APIErrorType =
   | "subscription_error"
   | "stripe_webhook_error"
   | "stripe_api_error"
-  | "stripe_invalid_product_id_error";
+  | "stripe_invalid_product_id_error"
+  | "rate_limit_error";
 
 export type APIError = {
   type: APIErrorType;

--- a/front/lib/rate_limiter.ts
+++ b/front/lib/rate_limiter.ts
@@ -1,0 +1,30 @@
+import { v4 as uuidv4 } from "uuid";
+
+import { redisClient } from "./redis";
+
+export async function rateLimiter(
+  key: string,
+  maxPerTimeframe: number,
+  timeframeSeconds: number
+) {
+  const redis = await redisClient();
+  const redisKey = `rate_limiter:${key}`;
+  try {
+    const zcountRes = await redis.zCount(
+      redisKey,
+      new Date().getTime() - timeframeSeconds * 1000,
+      "+inf"
+    );
+    const remaining = maxPerTimeframe - zcountRes;
+    if (remaining > 0) {
+      await redis.zAdd(redisKey, {
+        score: new Date().getTime(),
+        value: uuidv4(),
+      });
+      await redis.expire(redisKey, timeframeSeconds * 2);
+    }
+    return remaining;
+  } finally {
+    await redis.quit();
+  }
+}

--- a/front/lib/rate_limiter.ts
+++ b/front/lib/rate_limiter.ts
@@ -29,6 +29,8 @@ export async function rateLimiter(
         value: uuidv4(),
       });
       await redis.expire(redisKey, timeframeSeconds * 2);
+    } else {
+      statsDClient.increment("ratelimiter.exceeded.count", 1, tags);
     }
     const totalTimeMs = new Date().getTime() - now.getTime();
 
@@ -37,11 +39,7 @@ export async function rateLimiter(
       totalTimeMs,
       tags
     );
-    statsDClient.distribution(
-      "ratelimiter.remaining.distribution",
-      remaining,
-      tags
-    );
+
     return remaining;
   } catch (e) {
     statsDClient.increment("ratelimiter.error.count", 1, tags);

--- a/front/lib/rate_limiter.ts
+++ b/front/lib/rate_limiter.ts
@@ -1,6 +1,6 @@
 import { v4 as uuidv4 } from "uuid";
 
-import { redisClient } from "./redis";
+import { redisClient } from "@app/lib/redis";
 
 export async function rateLimiter(
   key: string,


### PR DESCRIPTION
Rate limiter with a sliding window.
Usage:
```
const remaining = await rateLimiter(key, maxPerTimeFrame, timeframeSeoncds);
```

Redis sorted sets are used for the sliding window with a log(n) cost (with N being the number of successful HTTP calls made by the user).
