### PR TITLE
Support billing based on monthly active users

### DIFF
--- a/front/lib/plans/subscription.ts
+++ b/front/lib/plans/subscription.ts
@@ -12,9 +12,15 @@ import {
 } from "@app/lib/plans/plan_codes";
 import {
   createCheckoutSession,
+  getStripeSubscription,
   updateStripeSubscriptionQuantity,
+  updateStripeSubscriptionUsage,
 } from "@app/lib/plans/stripe";
-import { countActiveSeatsInWorkspace } from "@app/lib/plans/workspace_usage";
+import {
+  countActiveSeatsInWorkspace,
+  countActiveUsersInWorkspaceSince,
+} from "@app/lib/plans/workspace_usage";
+import { redisClient } from "@app/lib/redis";
 import { generateModelSId } from "@app/lib/utils";
 import logger from "@app/logger/logger";
 import {
@@ -22,6 +28,7 @@ import {
   PlanType,
   SubscriptionType,
 } from "@app/types/plan";
+import { WorkspaceType } from "@app/types/user";
 
 /**
  * Internal function to subscribe to the default FREE_TEST_PLAN.
@@ -445,6 +452,65 @@ export const updateWorkspacePerSeatSubscriptionUsage = async ({
   } catch (err) {
     logger.error(
       `Error while updating Stripe subscription quantity for workspace ${workspaceId}: ${err}`
+    );
+  }
+};
+
+export const updateWorkspacePerMonthlyActiveUsersSubscriptionUsage = async ({
+  owner,
+  subscription,
+}: {
+  owner: WorkspaceType;
+  subscription: SubscriptionType;
+}): Promise<void> => {
+  try {
+    if (subscription.plan.billingType !== "monthly_active_users") {
+      // We only update the usage for plans with billingType === "monthly_active_users"
+      return;
+    }
+    if (
+      !subscription.stripeSubscriptionId ||
+      !subscription.stripeCustomerId ||
+      !subscription.plan.stripeProductId
+    ) {
+      throw new Error(
+        "Cannot update usage in monthly_active_users subscription: missing Stripe subscription ID or Stripe customer ID."
+      );
+    }
+
+    const redis = await redisClient();
+    const redisKey = `workspace:usage:${owner.sId}`;
+    const usageForWorkspace = await redis.get(redisKey);
+    if (usageForWorkspace) {
+      // If already reported usage for this workspace in the last hour we do nothing
+      return;
+    }
+
+    const stripeSubscription = await getStripeSubscription(
+      subscription.stripeSubscriptionId
+    );
+
+    if (!stripeSubscription) {
+      throw new Error(
+        `Cannot update usage in monthly_active_users subscription: Stripe subscription ${subscription.stripeSubscriptionId} not found.`
+      );
+    }
+    const quantity = await countActiveUsersInWorkspaceSince({
+      workspace: owner,
+      since: new Date(stripeSubscription.current_period_start * 1000),
+    });
+    await updateStripeSubscriptionUsage({
+      stripeSubscription,
+      quantity,
+    });
+
+    // We store the usage in Redis to update Stripe only once per hour if mutliple messages are sent
+    await redis.set(redisKey, quantity, {
+      EX: 3600, // 1 hour
+    });
+  } catch (err) {
+    logger.error(
+      `Error while updating Stripe subscription usage for workspace ${owner.sId}: ${err}`
     );
   }
 };

--- a/front/lib/plans/subscription.ts
+++ b/front/lib/plans/subscription.ts
@@ -463,7 +463,9 @@ export const updateWorkspacePerMonthlyActiveUsersSubscriptionUsage = async ({
   owner: WorkspaceType;
   subscription: SubscriptionType;
 }): Promise<void> => {
+  let redis = null;
   try {
+    redis = await redisClient();
     if (subscription.plan.billingType !== "monthly_active_users") {
       // We only update the usage for plans with billingType === "monthly_active_users"
       return;
@@ -478,7 +480,6 @@ export const updateWorkspacePerMonthlyActiveUsersSubscriptionUsage = async ({
       );
     }
 
-    const redis = await redisClient();
     const redisKey = `workspace:usage:${owner.sId}`;
     const usageForWorkspace = await redis.get(redisKey);
     if (usageForWorkspace) {
@@ -512,6 +513,10 @@ export const updateWorkspacePerMonthlyActiveUsersSubscriptionUsage = async ({
     logger.error(
       `Error while updating Stripe subscription usage for workspace ${owner.sId}: ${err}`
     );
+  } finally {
+    if (redis) {
+      await redis.quit();
+    }
   }
 };
 

--- a/front/lib/plans/workspace_usage.ts
+++ b/front/lib/plans/workspace_usage.ts
@@ -1,6 +1,8 @@
-import { Op } from "sequelize";
+import { Op, QueryTypes } from "sequelize";
 
+import { front_sequelize } from "@app/lib/databases";
 import { Membership, Workspace } from "@app/lib/models/workspace";
+import { WorkspaceType } from "@app/types/user";
 
 export async function countActiveSeatsInWorkspace(
   workspaceId: string
@@ -21,4 +23,43 @@ export async function countActiveSeatsInWorkspace(
       },
     },
   });
+}
+
+/**
+ * An active user is a user who has posted at least one message during the billing period.
+ * To handle Slack users, we are using the userContextEmail field of the message to distinguish users.
+ */
+export async function countActiveUsersInWorkspaceSince({
+  workspace,
+  since,
+}: {
+  workspace: WorkspaceType;
+  since: Date;
+}): Promise<number> {
+  const result = await front_sequelize.query<{
+    count: string;
+  }>(
+    `
+      SELECT COUNT(DISTINCT "userMessage"."userContextEmail") as "count"
+      FROM "messages" AS "message"
+      INNER JOIN "conversations" AS "conversation"
+        ON "message"."conversationId" = "conversation"."id"
+        AND "conversation"."workspaceId" = :workspaceId
+      LEFT OUTER JOIN "user_messages" AS "userMessage"
+        ON "message"."userMessageId" = "userMessage"."id"
+      WHERE "message"."createdAt" >= :since
+      AND "message"."userMessageId" IS NOT NULL
+    `,
+    {
+      replacements: { workspaceId: workspace.id, since: since },
+      type: QueryTypes.SELECT,
+    }
+  );
+
+  if (!result.length) {
+    throw new Error(
+      `Query to compute active users in workspace retrieved no result.`
+    );
+  }
+  return parseInt(result[0].count, 10);
 }


### PR DESCRIPTION
This PRs adds support for metered billing based on monthly active users. 

Stripe test product: https://dashboard.stripe.com/test/products/prod_OyV94JVvnzhI6t
Needs to be configured with:
- Usage type = Metered usage, 
- Aggregation mode = Last value during period

The query that counts the number of active users is based on the different emails that created a message during the billing period.  That means we should count Slack users, and the deduplication is based on the fact they share the same company email. Was discussed here: https://docs.google.com/document/d/1X9sjAc7UDAzP1J1paLfUHVCbQoVHutM9DyID0YQSK3E/edit