### PR TITLE
Add renew webhooks logs

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -863,6 +863,7 @@ export async function renewWebhooks(pageSize: number): Promise<number> {
     },
     limit: pageSize,
   });
+  logger.info({ count: webhooks.length }, `Renewing webhooks`);
 
   for (const wh of webhooks) {
     // Renew each webhook.


### PR DESCRIPTION
Adding a log in the Gdrive renew webhooks workflow in order to monitor this workflow on Datadog.