### PR TITLE
Fix: Github Discussion comment author can be null

### DIFF
--- a/connectors/src/connectors/github/lib/github_graphql.ts
+++ b/connectors/src/connectors/github/lib/github_graphql.ts
@@ -34,9 +34,12 @@ const DiscussionCommentNodeSchema = t.type({
   bodyText: t.string,
   createdAt: t.string,
   updatedAt: t.string,
-  author: t.type({
-    login: t.string,
-  }),
+  author: t.union([
+    t.type({
+      login: t.string,
+    }),
+    t.null,
+  ]),
 });
 
 export type DiscussionCommentNode = t.TypeOf<

--- a/connectors/src/connectors/github/temporal/activities.ts
+++ b/connectors/src/connectors/github/temporal/activities.ts
@@ -235,7 +235,9 @@ export async function githubUpsertDiscussionActivity(
       if (comment.isAnswer) {
         renderedDiscussion += "[ACCEPTED ANSWER] ";
       }
-      renderedDiscussion += `${comment.author.login}: ${comment.bodyText}||`;
+      renderedDiscussion += `${comment.author?.login || "Unknown author"}: ${
+        comment.bodyText
+      }||`;
       let nextChildCursor: string | null = null;
       for (;;) {
         const { cursor: childCursor, comments: childComments } =
@@ -245,7 +247,9 @@ export async function githubUpsertDiscussionActivity(
             nextChildCursor
           );
         for (const childComment of childComments) {
-          renderedDiscussion += `----${childComment.author.login}: ${childComment.bodyText}||`;
+          renderedDiscussion += `----${
+            childComment.author?.login || "Unknown author"
+          }: ${childComment.bodyText}||`;
         }
 
         if (!childCursor) {


### PR DESCRIPTION
Related [discussion](https://dust4ai.slack.com/archives/C05F84CFP0E/p1699564850972439)

**Deploy**
This does not warrant a new queue number IMHO, so regular deploy of connectors should solve the alerts