### PR TITLE
GPT4 turbo for free plan

### DIFF
--- a/core/src/providers/azure_openai.rs
+++ b/core/src/providers/azure_openai.rs
@@ -251,6 +251,9 @@ impl LLM for AzureOpenAILLM {
                 if model_id.starts_with("gpt-4-32k") {
                     return 32768;
                 }
+                if model_id.starts_with("gpt-4-1106-preview") {
+                    return 128000;
+                }
                 if model_id.starts_with("gpt-4") {
                     return 8192;
                 }

--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -1150,6 +1150,9 @@ impl LLM for OpenAILLM {
         if self.id.starts_with("gpt-4-32k") {
             return 32768;
         }
+        if self.id.starts_with("gpt-4-1106-preview") {
+            return 128000;
+        }
         if self.id.starts_with("gpt-4") {
             return 8192;
         }

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -7,6 +7,7 @@ import { AgentConfigurationType } from "@app/types/assistant/agent";
 
 export const GPT_4_32K_MODEL_ID = "gpt-4-32k" as const;
 export const GPT_4_MODEL_ID = "gpt-4" as const;
+export const GPT_4_TURBO_MODEL_ID = "gpt-4-1106-preview" as const;
 
 export const GPT_4_32K_MODEL_CONFIG = {
   providerId: "openai",
@@ -23,6 +24,14 @@ export const GPT_4_MODEL_CONFIG = {
   contextSize: 8192,
   recommendedTopK: 16,
 };
+
+export const GPT_4_TURBO_MODEL_CONFIG = {
+  providerId: "openai",
+  modelId: GPT_4_TURBO_MODEL_ID,
+  displayName: "GPT 4 Turbo",
+  contextSize: 128000,
+  recommendedTopK: 32,
+} as const;
 
 export const GPT_3_5_TURBO_16K_MODEL_CONFIG = {
   providerId: "openai",
@@ -69,6 +78,7 @@ export const SUPPORTED_MODEL_CONFIGS = [
   GPT_3_5_TURBO_MODEL_CONFIG,
   GPT_4_32K_MODEL_CONFIG,
   GPT_4_MODEL_CONFIG,
+  GPT_4_TURBO_MODEL_CONFIG,
   CLAUDE_DEFAULT_MODEL_CONFIG,
   CLAUDE_INSTANT_DEFAULT_MODEL_CONFIG,
   MISTRAL_7B_DEFAULT_MODEL_CONFIG,


### PR DESCRIPTION
For workspaces with free plan, GPT4 is GPT4-turbo instead of GPT4-32K.
https://platform.openai.com/docs/models/gpt-4-and-gpt-4-turbo