### PR TITLE
Fix: handle 404 errors on fetching github issue comments page

### DIFF
--- a/connectors/src/connectors/github/temporal/activities.ts
+++ b/connectors/src/connectors/github/temporal/activities.ts
@@ -106,13 +106,23 @@ export async function githubUpsertIssueActivity(
       page: resultPage,
     });
     resultPageLogger.info("Fetching GitHub issue comments result page.");
-    const comments = await getIssueCommentsPage(
-      installationId,
-      repoName,
-      login,
-      issueNumber,
-      resultPage
-    );
+    let comments = undefined;
+    try {
+      comments = await getIssueCommentsPage(
+        installationId,
+        repoName,
+        login,
+        issueNumber,
+        resultPage
+      );
+    } catch (e: any) {
+      if (e.status === 404) {
+        // Github may return a 404 on the first page if the issue has no comments
+        break;
+      } else {
+        throw e;
+      }
+    }
     if (!comments.length) {
       break;
     }

--- a/connectors/src/connectors/github/temporal/activities.ts
+++ b/connectors/src/connectors/github/temporal/activities.ts
@@ -115,8 +115,8 @@ export async function githubUpsertIssueActivity(
         issueNumber,
         resultPage
       );
-    } catch (e: any) {
-      if (e.status === 404) {
+    } catch (e) {
+      if (e instanceof Error && "status" in e && e.status === 404) {
         // Github may return a 404 on the first page if the issue has no comments
         break;
       } else {


### PR DESCRIPTION
Related [error thread](https://dust4ai.slack.com/archives/C05F84CFP0E/p1699882670861289)