### PR TITLE
front: Add plan code to actions metrics

### DIFF
--- a/front/lib/actions/server.ts
+++ b/front/lib/actions/server.ts
@@ -11,7 +11,7 @@ import { statsDClient } from "@app/logger/withlogging";
 // Record an event and a log for the action error.
 const logActionError = (
   loggerArgs: {
-    workspace: { sId: string; name: string };
+    workspace: { sId: string; name: string; plan_code: string | null };
     action: string;
     app: DustAppType;
   },
@@ -63,6 +63,7 @@ export async function runActionStreamed(
     workspace: {
       sId: owner.sId,
       name: owner.name,
+      plan_code: auth.plan()?.code || null,
     },
     action: actionName,
     app: action.app,
@@ -74,6 +75,7 @@ export async function runActionStreamed(
     `action:${actionName}`,
     `workspace:${owner.sId}`,
     `workspace_name:${owner.name}`,
+    `workspace_plan_code:${auth.plan()?.code || null}`,
   ];
 
   statsDClient.increment("use_actions.count", 1, tags);
@@ -146,6 +148,7 @@ export async function runAction(
     workspace: {
       sId: owner.sId,
       name: owner.name,
+      plan_code: auth.plan()?.code || null,
     },
     action: actionName,
     app: action.app,
@@ -157,6 +160,7 @@ export async function runAction(
     `action:${actionName}`,
     `workspace:${owner.sId}`,
     `workspace_name:${owner.name}`,
+    `workspace_plan_code:${auth.plan()?.code || null}`,
   ];
 
   statsDClient.increment("use_actions.count", 1, tags);


### PR DESCRIPTION
The goal is to be able to plot action counts by plan_code and in particular see the volume of free users