### PR TITLE
enh: gpt-4-turbo rollout

### DIFF
--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -42,7 +42,7 @@ import {
   CLAUDE_INSTANT_DEFAULT_MODEL_CONFIG,
   getSupportedModelConfig,
   GPT_3_5_TURBO_16K_MODEL_CONFIG,
-  GPT_4_32K_MODEL_CONFIG,
+  GPT_4_TURBO_MODEL_CONFIG,
   SupportedModel,
 } from "@app/lib/assistant";
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
@@ -63,7 +63,7 @@ import AssistantBuilderDustAppModal from "./AssistantBuilderDustAppModal";
 import DustAppSelectionSection from "./DustAppSelectionSection";
 
 const usedModelConfigs = [
-  GPT_4_32K_MODEL_CONFIG,
+  GPT_4_TURBO_MODEL_CONFIG,
   GPT_3_5_TURBO_16K_MODEL_CONFIG,
   CLAUDE_DEFAULT_MODEL_CONFIG,
   CLAUDE_INSTANT_DEFAULT_MODEL_CONFIG,
@@ -219,7 +219,7 @@ export default function AssistantBuilder({
     ...DEFAULT_ASSISTANT_STATE,
     generationSettings: {
       ...DEFAULT_ASSISTANT_STATE.generationSettings,
-      modelSettings: GPT_4_32K_MODEL_CONFIG,
+      modelSettings: GPT_4_TURBO_MODEL_CONFIG,
     },
   });
 

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -13,7 +13,7 @@ import {
   renderConversationForModel,
   runGeneration,
 } from "@app/lib/api/assistant/generation";
-import { GPT_4_32K_MODEL_CONFIG, GPT_4_MODEL_CONFIG } from "@app/lib/assistant";
+import { GPT_4_TURBO_MODEL_CONFIG } from "@app/lib/assistant";
 import { Authenticator } from "@app/lib/auth";
 import { Err, Ok, Result } from "@app/lib/result";
 import logger from "@app/logger/logger";
@@ -60,9 +60,9 @@ export async function generateActionInputs(
 
   const MIN_GENERATION_TOKENS = 2048;
 
-  let model: { providerId: string; modelId: string } = {
-    providerId: GPT_4_32K_MODEL_CONFIG.providerId,
-    modelId: GPT_4_32K_MODEL_CONFIG.modelId,
+  const model: { providerId: string; modelId: string } = {
+    providerId: GPT_4_TURBO_MODEL_CONFIG.providerId,
+    modelId: GPT_4_TURBO_MODEL_CONFIG.modelId,
   };
 
   // Turn the conversation into a digest that can be presented to the model.
@@ -71,24 +71,11 @@ export async function generateActionInputs(
     model,
     prompt,
     allowedTokenCount:
-      GPT_4_32K_MODEL_CONFIG.contextSize - MIN_GENERATION_TOKENS,
+      GPT_4_TURBO_MODEL_CONFIG.contextSize - MIN_GENERATION_TOKENS,
   });
 
   if (modelConversationRes.isErr()) {
     return modelConversationRes;
-  }
-
-  // If we use gpt-4-32k but tokens used is less than GPT_4_CONTEXT_SIZE-MIN_GENERATION_TOKENS then
-  // switch the model back to GPT_4 standard (8k context, cheaper).
-  if (
-    model.modelId === GPT_4_32K_MODEL_CONFIG.modelId &&
-    modelConversationRes.value.tokensUsed <
-      GPT_4_MODEL_CONFIG.contextSize - MIN_GENERATION_TOKENS
-  ) {
-    model = {
-      providerId: GPT_4_MODEL_CONFIG.providerId,
-      modelId: GPT_4_MODEL_CONFIG.modelId,
-    };
   }
 
   const config = cloneBaseConfig(

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -334,7 +334,7 @@ export async function* runGeneration(
 
   let model = c.model;
 
-  const contextSize = getSupportedModelConfig(model).contextSize;
+  const contextSize = getSupportedModelConfig(c.model).contextSize;
 
   const MIN_GENERATION_TOKENS = 2048;
 

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -9,11 +9,7 @@ import {
   renderRetrievalActionForModel,
   retrievalMetaPrompt,
 } from "@app/lib/api/assistant/actions/retrieval";
-import {
-  getSupportedModelConfig,
-  GPT_4_32K_MODEL_ID,
-  GPT_4_MODEL_CONFIG,
-} from "@app/lib/assistant";
+import { getSupportedModelConfig } from "@app/lib/assistant";
 import { Authenticator } from "@app/lib/auth";
 import { CoreAPI } from "@app/lib/core_api";
 import { redisClient } from "@app/lib/redis";
@@ -332,7 +328,7 @@ export async function* runGeneration(
     return;
   }
 
-  let model = c.model;
+  const model = c.model;
 
   const contextSize = getSupportedModelConfig(c.model).contextSize;
 
@@ -366,19 +362,6 @@ export async function* runGeneration(
       },
     };
     return;
-  }
-
-  // If model is gpt4-32k but tokens used is less than GPT_4_CONTEXT_SIZE-MIN_GENERATION_TOKENS,
-  // then we override the model to gpt4 standard (8k context, cheaper).
-  if (
-    model.modelId === GPT_4_32K_MODEL_ID &&
-    modelConversationRes.value.tokensUsed <
-      GPT_4_MODEL_CONFIG.contextSize - MIN_GENERATION_TOKENS
-  ) {
-    model = {
-      modelId: GPT_4_MODEL_CONFIG.modelId,
-      providerId: GPT_4_MODEL_CONFIG.providerId,
-    };
   }
 
   const config = cloneBaseConfig(

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -328,15 +328,13 @@ export async function* runGeneration(
     return;
   }
 
-  const model = c.model;
-
   const contextSize = getSupportedModelConfig(c.model).contextSize;
 
   const MIN_GENERATION_TOKENS = 2048;
 
   if (contextSize < MIN_GENERATION_TOKENS) {
     throw new Error(
-      `Model contextSize unexpectedly small for model: ${model.providerId} ${model.modelId}`
+      `Model contextSize unexpectedly small for model: ${c.model.providerId} ${c.model.modelId}`
     );
   }
 
@@ -345,7 +343,7 @@ export async function* runGeneration(
   // Turn the conversation into a digest that can be presented to the model.
   const modelConversationRes = await renderConversationForModel({
     conversation,
-    model,
+    model: c.model,
     prompt,
     allowedTokenCount: contextSize - MIN_GENERATION_TOKENS,
   });
@@ -358,7 +356,7 @@ export async function* runGeneration(
       messageId: agentMessage.sId,
       error: {
         code: "internal_server_error",
-        message: `Failed tokenization for ${model.providerId} ${model.modelId}: ${modelConversationRes.error.message}`,
+        message: `Failed tokenization for ${c.model.providerId} ${c.model.modelId}: ${modelConversationRes.error.message}`,
       },
     };
     return;
@@ -367,8 +365,8 @@ export async function* runGeneration(
   const config = cloneBaseConfig(
     DustProdActionRegistry["assistant-v2-generator"].config
   );
-  config.MODEL.provider_id = model.providerId;
-  config.MODEL.model_id = model.modelId;
+  config.MODEL.provider_id = c.model.providerId;
+  config.MODEL.model_id = c.model.modelId;
   config.MODEL.temperature = c.temperature;
 
   // This is the console.log you want to uncomment to generate inputs for the generator app.
@@ -383,7 +381,7 @@ export async function* runGeneration(
     {
       workspaceId: conversation.owner.sId,
       conversationId: conversation.sId,
-      model: model,
+      model: c.model,
       temperature: c.temperature,
     },
     "[ASSISTANT_TRACE] Generation exection"

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -8,24 +8,19 @@ import {
   CLAUDE_DEFAULT_MODEL_CONFIG,
   CLAUDE_INSTANT_DEFAULT_MODEL_CONFIG,
   GPT_3_5_TURBO_16K_MODEL_CONFIG,
-  GPT_4_32K_MODEL_CONFIG,
   GPT_4_TURBO_MODEL_CONFIG,
   MISTRAL_7B_DEFAULT_MODEL_CONFIG,
 } from "@app/lib/assistant";
 import { GLOBAL_AGENTS_SID } from "@app/lib/assistant";
 import { Authenticator, prodAPICredentialsForOwner } from "@app/lib/auth";
 import { ConnectorProvider } from "@app/lib/connectors_api";
-import { isDevelopmentOrDustWorkspace } from "@app/lib/development";
 import { DustAPI } from "@app/lib/dust_api";
 import { GlobalAgentSettings } from "@app/lib/models/assistant/agent";
-import { FREE_TEST_PLAN_CODE } from "@app/lib/plans/plan_codes";
 import logger from "@app/logger/logger";
 import {
   AgentConfigurationType,
   GlobalAgentStatus,
 } from "@app/types/assistant/agent";
-import { PlanType } from "@app/types/plan";
-import { WorkspaceType } from "@app/types/user";
 
 class HelperAssistantPrompt {
   private static instance: HelperAssistantPrompt;
@@ -88,8 +83,8 @@ async function _getHelperGlobalAgent(
     throw new Error("Unexpected `auth` without `plan`.");
   }
   const model = {
-    providerId: GPT_4_32K_MODEL_CONFIG.providerId,
-    modelId: GPT_4_32K_MODEL_CONFIG.modelId,
+    providerId: GPT_4_TURBO_MODEL_CONFIG.providerId,
+    modelId: GPT_4_TURBO_MODEL_CONFIG.modelId,
   };
   return {
     id: -1,
@@ -138,24 +133,13 @@ async function _getGPT35TurboGlobalAgent({
   };
 }
 
-async function _getGPT4GlobalAgent({
-  owner,
-  plan,
-}: {
-  owner: WorkspaceType;
-  plan: PlanType;
-}): Promise<AgentConfigurationType> {
-  const isFreePlan = plan.code === FREE_TEST_PLAN_CODE;
-  const isDustOrDevWorkspace = isDevelopmentOrDustWorkspace(owner);
-  const shouldUseTurboModel = isFreePlan || isDustOrDevWorkspace;
+async function _getGPT4GlobalAgent(): Promise<AgentConfigurationType> {
   return {
     id: -1,
     sId: GLOBAL_AGENTS_SID.GPT4,
     version: 0,
     name: "gpt4",
-    description: shouldUseTurboModel
-      ? "OpenAI's cost-effective and high throughput model (128K context)."
-      : "OpenAI's most powerful model (32k context).",
+    description: "OpenAI's most powerful and recent model (128k context).",
     pictureUrl: "https://dust.tt/static/systemavatar/gpt4_avatar_full.png",
     status: "active",
     scope: "global",
@@ -163,12 +147,8 @@ async function _getGPT4GlobalAgent({
       id: -1,
       prompt: "",
       model: {
-        providerId: shouldUseTurboModel
-          ? GPT_4_TURBO_MODEL_CONFIG.providerId
-          : GPT_4_32K_MODEL_CONFIG.providerId,
-        modelId: shouldUseTurboModel
-          ? GPT_4_TURBO_MODEL_CONFIG.modelId
-          : GPT_4_32K_MODEL_CONFIG.modelId,
+        providerId: GPT_4_TURBO_MODEL_CONFIG.providerId,
+        modelId: GPT_4_TURBO_MODEL_CONFIG.modelId,
       },
       temperature: 0.7,
     },
@@ -339,8 +319,8 @@ async function _getManagedDataSourceAgent(
       id: -1,
       prompt,
       model: {
-        providerId: GPT_4_32K_MODEL_CONFIG.providerId,
-        modelId: GPT_4_32K_MODEL_CONFIG.modelId,
+        providerId: GPT_4_TURBO_MODEL_CONFIG.providerId,
+        modelId: GPT_4_TURBO_MODEL_CONFIG.modelId,
       },
       temperature: 0.4,
     },
@@ -514,8 +494,8 @@ async function _getDustGlobalAgent(
       prompt:
         "Assist the user based on the retrieved data from their workspace.",
       model: {
-        providerId: GPT_4_32K_MODEL_CONFIG.providerId,
-        modelId: GPT_4_32K_MODEL_CONFIG.modelId,
+        providerId: GPT_4_TURBO_MODEL_CONFIG.providerId,
+        modelId: GPT_4_TURBO_MODEL_CONFIG.modelId,
       },
       temperature: 0.4,
     },
@@ -568,7 +548,7 @@ export async function getGlobalAgent(
       agentConfiguration = await _getGPT35TurboGlobalAgent({ settings });
       break;
     case GLOBAL_AGENTS_SID.GPT4:
-      agentConfiguration = await _getGPT4GlobalAgent({ owner, plan });
+      agentConfiguration = await _getGPT4GlobalAgent();
       break;
     case GLOBAL_AGENTS_SID.CLAUDE_INSTANT:
       agentConfiguration = await _getClaudeInstantGlobalAgent({ settings });

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -28,7 +28,7 @@ export const GPT_4_MODEL_CONFIG = {
 export const GPT_4_TURBO_MODEL_CONFIG = {
   providerId: "openai",
   modelId: GPT_4_TURBO_MODEL_ID,
-  displayName: "GPT 4 Turbo",
+  displayName: "GPT 4",
   contextSize: 128000,
   recommendedTopK: 32,
 } as const;

--- a/front/migrations/20231113_migrate_assistants_to_gpt4_turbo.ts
+++ b/front/migrations/20231113_migrate_assistants_to_gpt4_turbo.ts
@@ -1,0 +1,65 @@
+import {
+  AgentConfiguration,
+  AgentGenerationConfiguration,
+  Workspace,
+} from "@app/lib/models";
+import { Err } from "@app/lib/result";
+
+const { LIVE, WORKSPACE } = process.env;
+
+async function main() {
+  if (!WORKSPACE) {
+    throw new Err("WORKSPACE is required");
+  }
+  const wId = WORKSPACE;
+
+  console.log(`Updateing agents for workspace ${wId}...`);
+  const w = await Workspace.findOne({ where: { sId: wId } });
+  if (!w) {
+    throw new Error(`Workspace ${wId} not found`);
+  }
+
+  const agentConfigurations = await AgentConfiguration.findAll({
+    where: { workspaceId: w.id },
+  });
+
+  for (const c of agentConfigurations) {
+    if (!c.generationConfigurationId) {
+      console.log(
+        "Skipping agent (no generation configuration)",
+        c.sId,
+        c.name
+      );
+      continue;
+    }
+
+    const g = await AgentGenerationConfiguration.findOne({
+      where: { id: c.generationConfigurationId },
+    });
+
+    if (!g) {
+      throw new Error(
+        `Generation configuration ${c.generationConfigurationId} not found`
+      );
+    }
+
+    if (g.modelId === "gpt-4" || g.modelId === "gpt-4-32k") {
+      if (LIVE) {
+        await g.update({ modelId: "gpt-4-1106-preview" });
+        console.log("Updated", c.sId, c.name);
+      } else {
+        console.log("Would update", c.sId, c.name);
+      }
+    }
+  }
+}
+
+main()
+  .then(() => {
+    console.log("Done");
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });


### PR DESCRIPTION
This PR:
- Moves to gpt-4-turbo for action generation
- Moves to gpt-4-turbo for the global gpt-4 agent for everyone
- New custom assistants will be on gpt-4-turbo
- Introduce a migration to update agents to gpt-4-turbo for a specific workspace

Will run the migration on our own workspace for now