### PR TITLE
[Front - Admin] Rewording user reinstating

### DIFF
--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -519,11 +519,9 @@ function ReinviteUserModal({
       <div className="mt-6 flex flex-col gap-6 px-2">
         <div>
           {" "}
-          {`${user.fullName} (${user.email}) `} was previously revoked from the
-          workspace. You can reinstate them, in which case they will be switched
-          back to a 'user' role and regain access to their historical data on
-          Dust (e.g. conversation history...). This will take effect
-          immediately.
+          <span className="font-semibold">{user.email + " "}</span> was revoked
+          from the workspace. Reinstating them as member will also immediately
+          reinstate their conversation history on Dust.
         </div>
         <div className="flex gap-2">
           <Button


### PR DESCRIPTION
Following #2496 

@gabhubert given your initial wording
```
$email is a revoked $member of the workspace. Reinstating as $member of the workspace them will also immediately reinstate their conversation history on Dust.
```
I made the following changes
- is a revoked $member => I guess you want the last role of the member here, we don't have it => wrote "was revoked from the workspace
- 'Reinstating as $member of the workspace them' => Reinstating them as member (we cannot do variable role as is so putting member directly; since the page is already saying "member list" I think it's clear
![image](https://github.com/dust-tt/dust/assets/5437393/0a3bb4e6-4994-47c3-9ac6-f6f1d7829ddd)
