### PR TITLE
allow inviting to the pro plan for free_upgraded users

### DIFF
--- a/front/pages/poke/[wId]/index.tsx
+++ b/front/pages/poke/[wId]/index.tsx
@@ -14,7 +14,6 @@ import { CoreAPI } from "@app/lib/core_api";
 import {
   FREE_TEST_PLAN_CODE,
   FREE_UPGRADED_PLAN_CODE,
-  PRO_PLAN_SEAT_29_CODE,
 } from "@app/lib/plans/plan_codes";
 import { getPlanInvitation } from "@app/lib/plans/subscription";
 import { usePokePlans } from "@app/lib/swr";

--- a/front/pages/poke/[wId]/index.tsx
+++ b/front/pages/poke/[wId]/index.tsx
@@ -363,7 +363,6 @@ const WorkspacePage = ({
                           if (
                             [
                               FREE_TEST_PLAN_CODE,
-                              PRO_PLAN_SEAT_29_CODE,
                               FREE_UPGRADED_PLAN_CODE,
                             ].includes(p.code)
                           ) {


### PR DESCRIPTION
Users that are on the FREE_UPGRADED_PLAN_CODE have no way to upgrade to the the paying plan.

This will let us invite them to the pro plan.