### PR TITLE
UI: free plan indicates LLM is GPT-3.5

### DIFF
--- a/front/components/PlansTables.tsx
+++ b/front/components/PlansTables.tsx
@@ -30,7 +30,7 @@ function FreePriceTable({ size }: { size: "sm" | "xs" }) {
       <PriceTable.Item size={size} label="One user" variant="dash" />
       <PriceTable.Item size={size} label="One workspace" variant="dash" />
       <PriceTable.Item label="Privacy and Data Security" />
-      <PriceTable.Item label="Advanced LLM models (GPT-4, Claude…)" />
+      <PriceTable.Item label="LLM model: GPT-3.5" />
       <PriceTable.Item label="Unlimited custom assistants" />
       <PriceTable.Item label="50 assistant messages" variant="dash" />
       <PriceTable.Item label="50 documents as data sources" variant="dash" />

--- a/front/components/PlansTables.tsx
+++ b/front/components/PlansTables.tsx
@@ -30,7 +30,7 @@ function FreePriceTable({ size }: { size: "sm" | "xs" }) {
       <PriceTable.Item size={size} label="One user" variant="dash" />
       <PriceTable.Item size={size} label="One workspace" variant="dash" />
       <PriceTable.Item label="Privacy and Data Security" />
-      <PriceTable.Item label="LLM model: GPT-3.5" />
+      <PriceTable.Item label="Regular LLM models (GPT-3.5, Claude instant...)" />
       <PriceTable.Item label="Unlimited custom assistants" />
       <PriceTable.Item label="50 assistant messages" variant="dash" />
       <PriceTable.Item label="50 documents as data sources" variant="dash" />


### PR DESCRIPTION
Line in free plan saying `Advanced LLM models (GPT-4, Claude…)` replaced by `Regular LLM models (GPT-3.5, Claude instant...)`