### PR TITLE
sparkle: Fix popup

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.37",
+  "version": "0.2.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.37",
+      "version": "0.2.38",
       "license": "ISC",
       "dependencies": {
         "@headlessui/react": "^1.7.17"

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.37",
+  "version": "0.2.38",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/components/Popup.tsx
+++ b/sparkle/src/components/Popup.tsx
@@ -38,7 +38,7 @@ export function Popup({
       leaveFrom="s-opacity-100"
       leaveTo="s-opacity-0"
       className={classNames(
-        "relative s-z-30 s-flex s-w-64 s-flex-col s-gap-3 s-rounded-xl s-border s-border-pink-100 s-bg-pink-50 s-p-4 s-shadow-xl",
+        "s-z-30 s-flex s-w-64 s-flex-col s-gap-3 s-rounded-xl s-border s-border-pink-100 s-bg-pink-50 s-p-4 s-shadow-xl",
         className || ""
       )}
     >


### PR DESCRIPTION
`relative` was not visible in storybook but did have an effect in production