### PR TITLE
Enable PDF syncing for Gdrive + config unified interface for connectors

### DIFF
--- a/connectors/migrations/20231109_2_create_gdrive_config.ts
+++ b/connectors/migrations/20231109_2_create_gdrive_config.ts
@@ -1,0 +1,29 @@
+import { Connector, GoogleDriveConfig } from "@connectors/lib/models";
+
+async function main() {
+  const gDriveConnectors = await Connector.findAll({
+    where: {
+      type: "google_drive",
+    },
+  });
+
+  for (const connector of gDriveConnectors) {
+    const config = await GoogleDriveConfig.create({
+      connectorId: connector.id,
+      pdfEnabled: false,
+    });
+    console.log(
+      `Created config for connector ${config.connectorId} with id ${config.id} and pdfEnabled ${config.pdfEnabled}`
+    );
+  }
+}
+
+main()
+  .then(() => {
+    console.log("Done");
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/connectors/src/admin/db.ts
+++ b/connectors/src/admin/db.ts
@@ -5,6 +5,7 @@ import {
   GithubConnectorState,
   GithubDiscussion,
   GithubIssue,
+  GoogleDriveConfig,
   GoogleDriveFiles,
   GoogleDriveFolders,
   GoogleDriveSyncToken,
@@ -42,6 +43,7 @@ async function main(): Promise<void> {
   await NotionConnectorBlockCacheEntry.sync({ alter: true });
   await NotionConnectorPageCacheEntry.sync({ alter: true });
   await NotionConnectorResourcesToCheckCacheEntry.sync({ alter: true });
+  await GoogleDriveConfig.sync({ alter: true });
 
   // enable the `unaccent` extension
   await sequelize_conn.query("CREATE EXTENSION IF NOT EXISTS unaccent;");

--- a/connectors/src/api/connector_config.ts
+++ b/connectors/src/api/connector_config.ts
@@ -1,0 +1,144 @@
+import { Request, Response } from "express";
+import { isLeft } from "fp-ts/lib/Either";
+import * as t from "io-ts";
+import * as reporter from "io-ts-reporters";
+
+import {
+  GET_CONNECTOR_CONFIG_BY_TYPE,
+  SET_CONNECTOR_CONFIG_BY_TYPE,
+} from "@connectors/connectors";
+import { Connector } from "@connectors/lib/models";
+import { apiError, withLogging } from "@connectors/logger/withlogging";
+import { ConnectorsAPIErrorResponse } from "@connectors/types/errors";
+
+const ConfigSetReqBodySchema = t.type({
+  configValue: t.string,
+});
+type ConfigSetReqBody = t.TypeOf<typeof ConfigSetReqBodySchema>;
+
+type ConfigGetResBody =
+  | { connectorId: number; configKey: string; configValue: string }
+  | ConnectorsAPIErrorResponse;
+
+const _getConnectorConfig = async (
+  req: Request<{ connector_id: string; config_key: string }>,
+  res: Response<ConfigGetResBody>
+) => {
+  if (!req.params.connector_id) {
+    return apiError(req, res, {
+      api_error: {
+        type: "invalid_request_error",
+        message: "Missing required parameters. Required: connector_id",
+      },
+      status_code: 400,
+    });
+  }
+  if (!req.params.config_key) {
+    return apiError(req, res, {
+      api_error: {
+        type: "invalid_request_error",
+        message: "Missing required parameters. Required: config_key",
+      },
+      status_code: 400,
+    });
+  }
+
+  const connector = await Connector.findOne({
+    where: { id: req.params.connector_id },
+  });
+  if (!connector) {
+    return apiError(req, res, {
+      api_error: {
+        type: "connector_not_found",
+        message: `Connector with id ${req.params.connector_id} not found`,
+      },
+      status_code: 404,
+    });
+  }
+  const getter = GET_CONNECTOR_CONFIG_BY_TYPE[connector.type];
+  const configValueRes = await getter(connector.id, req.params.config_key);
+  if (configValueRes.isErr()) {
+    return apiError(
+      req,
+      res,
+      {
+        api_error: {
+          type: "internal_server_error",
+          message: `Unable to get config value for connector ${connector.id} and key ${req.params.config_key}`,
+        },
+        status_code: 500,
+      },
+      configValueRes.error
+    );
+  }
+
+  return res.status(200).json({
+    connectorId: connector.id,
+    configKey: req.params.config_key,
+    configValue: configValueRes.value,
+  });
+};
+
+export const getConnectorConfigAPIHandler = withLogging(_getConnectorConfig);
+
+const _setConnectorConfig = async (
+  req: Request<
+    { connector_id: string; config_key: string },
+    ConfigGetResBody,
+    ConfigSetReqBody
+  >,
+  res: Response<ConfigGetResBody>
+) => {
+  if (!req.params.connector_id) {
+    return apiError(req, res, {
+      api_error: {
+        type: "invalid_request_error",
+        message: "Missing required parameters. Required: connector_id",
+      },
+      status_code: 400,
+    });
+  }
+  if (!req.params.config_key) {
+    return apiError(req, res, {
+      api_error: {
+        type: "invalid_request_error",
+        message: "Missing required parameters. Required: config_key",
+      },
+      status_code: 400,
+    });
+  }
+
+  const bodyValidation = ConfigSetReqBodySchema.decode(req.body);
+  if (isLeft(bodyValidation)) {
+    const pathError = reporter.formatValidationErrors(bodyValidation.left);
+    return apiError(req, res, {
+      api_error: {
+        type: "invalid_request_error",
+        message: `Invalid request body: ${pathError}`,
+      },
+      status_code: 400,
+    });
+  }
+  const connector = await Connector.findOne({
+    where: { id: req.params.connector_id },
+  });
+  if (!connector) {
+    return apiError(req, res, {
+      api_error: {
+        type: "connector_not_found",
+        message: `Connector with id ${req.params.connector_id} not found`,
+      },
+      status_code: 404,
+    });
+  }
+  const setter = SET_CONNECTOR_CONFIG_BY_TYPE[connector.type];
+  await setter(connector.id, req.params.config_key, req.body.configValue);
+
+  return res.status(200).json({
+    connectorId: connector.id,
+    configKey: req.params.config_key,
+    configValue: req.body.configValue,
+  });
+};
+
+export const setConnectorConfigAPIHandler = withLogging(_setConnectorConfig);

--- a/connectors/src/api_server.ts
+++ b/connectors/src/api_server.ts
@@ -26,6 +26,11 @@ import { webhookSlackAPIHandler } from "@connectors/api/webhooks/webhook_slack";
 import logger from "@connectors/logger/logger";
 import { authMiddleware } from "@connectors/middleware/auth";
 
+import {
+  getConnectorConfigAPIHandler,
+  setConnectorConfigAPIHandler,
+} from "./api/connector_config";
+
 export function startServer(port: number) {
   process.on("unhandledRejection", (reason, promise) => {
     logger.error({ promise, reason }, "Unhandled Rejection");
@@ -100,6 +105,16 @@ export function startServer(port: number) {
     "/webhooks/:webhooks_secret/github",
     bodyParser.raw({ type: "application/json" }),
     webhookGithubAPIHandler
+  );
+
+  app.post(
+    "/connectors/:connector_id/config/:config_key",
+    setConnectorConfigAPIHandler
+  );
+
+  app.get(
+    "/connectors/:connector_id/config/:config_key",
+    getConnectorConfigAPIHandler
   );
 
   const server = app.listen(port, () => {

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -80,6 +80,16 @@ export async function createGoogleDriveConnector(
           { transaction: t }
         );
 
+        await GoogleDriveConfig.create(
+          {
+            connectorId: connector.id,
+            pdfEnabled: false,
+          },
+          {
+            transaction: t,
+          }
+        );
+
         const webhookInfo = await registerWebhook(connector);
         if (webhookInfo.isErr()) {
           throw webhookInfo.error;

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -9,6 +9,7 @@ import {
 import { ConnectorPermissionRetriever } from "@connectors/connectors/interface";
 import {
   Connector,
+  GoogleDriveConfig,
   GoogleDriveFiles,
   GoogleDriveFolders,
   GoogleDriveSyncToken,
@@ -590,5 +591,72 @@ export async function retrieveGoogleDriveObjectsParents(
     return new Ok(parents);
   } catch (err) {
     return new Err(err as Error);
+  }
+}
+
+export async function getGoogleDriveConfig(
+  connectorId: ModelId,
+  configKey: string
+) {
+  const connector = await Connector.findOne({
+    where: { id: connectorId },
+  });
+  if (!connector) {
+    return new Err(new Error(`Connector not found with id ${connectorId}`));
+  }
+  const config = await GoogleDriveConfig.findOne({
+    where: { connectorId: connectorId },
+  });
+  if (!config) {
+    return new Err(
+      new Error(`Google Drive config not found with connectorId ${connectorId}`)
+    );
+  }
+  switch (configKey) {
+    case "pdfEnabled": {
+      return new Ok(config.pdfEnabled ? "true" : "false");
+    }
+    default:
+      return new Err(new Error(`Invalid config key ${configKey}`));
+  }
+}
+
+export async function setGoogleDriveConfig(
+  connectorId: ModelId,
+  configKey: string,
+  configValue: string
+) {
+  const connector = await Connector.findOne({
+    where: { id: connectorId },
+  });
+  if (!connector) {
+    return new Err(new Error(`Connector not found with id ${connectorId}`));
+  }
+  const config = await GoogleDriveConfig.findOne({
+    where: { connectorId: connectorId },
+  });
+  if (!config) {
+    return new Err(
+      new Error(`Google Drive config not found with connectorId ${connectorId}`)
+    );
+  }
+  switch (configKey) {
+    case "pdfEnabled": {
+      if (!["true", "false"].includes(configValue)) {
+        return new Err(
+          new Error(
+            `Invalid config value ${configValue}, must be true or false`
+          )
+        );
+      }
+      await config.update({
+        pdfEnabled: configValue === "true",
+      });
+      return new Ok(void 0);
+    }
+
+    default: {
+      return new Err(new Error(`Invalid config key ${configKey}`));
+    }
   }
 }

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -662,6 +662,13 @@ export async function setGoogleDriveConfig(
       await config.update({
         pdfEnabled: configValue === "true",
       });
+      const workflowRes = await launchGoogleDriveFullSyncWorkflow(
+        connectorId.toString(),
+        null
+      );
+      if (workflowRes.isErr()) {
+        return workflowRes;
+      }
       return new Ok(void 0);
     }
 

--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -26,6 +26,7 @@ import { dpdf2text } from "@connectors/lib/dpdf2text";
 import { ExternalOauthTokenError } from "@connectors/lib/error";
 import {
   Connector,
+  GoogleDriveConfig,
   GoogleDriveFiles,
   GoogleDriveFolders,
   GoogleDriveSyncToken,
@@ -44,15 +45,27 @@ const MIME_TYPES_TO_EXPORT: { [key: string]: string } = {
   "application/vnd.google-apps.document": "text/plain",
   "application/vnd.google-apps.presentation": "text/plain",
 };
-// Deactivated CSV for now 20230721 (spolu)
-// Deactivated PDF for now 20230803 (fontanierh)
-// const MIME_TYPES_TO_DOWNLOAD = ["text/plain", "text/csv", "application/pdf"];
-const MIME_TYPES_TO_DOWNLOAD = ["text/plain"];
-const MIME_TYPES_TO_SYNC = [
-  ...MIME_TYPES_TO_DOWNLOAD,
-  ...Object.keys(MIME_TYPES_TO_EXPORT),
-  "application/vnd.google-apps.folder",
-];
+
+async function getMimeTypesToDownload(connectorId: ModelId) {
+  const mimeTypes = ["text/plain"];
+  const config = await GoogleDriveConfig.findOne({
+    where: {
+      connectorId: connectorId,
+    },
+  });
+  if (config?.pdfEnabled) {
+    mimeTypes.push("application/pdf");
+  }
+
+  return mimeTypes;
+}
+
+async function getMimesTypeToSync(connectorId: ModelId) {
+  const mimeTypes = await getMimeTypesToDownload(connectorId);
+  mimeTypes.push("application/vnd.google-apps.folder");
+
+  return mimeTypes;
+}
 
 export const statsDClient = new StatsD();
 
@@ -195,6 +208,7 @@ export async function syncFiles(
   if (!connector) {
     throw new Error(`Connector ${connectorId} not found`);
   }
+  const mimeTypeToSync = await getMimesTypeToSync(connectorId);
   const authCredentials = await getAuthObject(connector.connectionId);
   const driveFolder = await getGoogleDriveObject(
     authCredentials,
@@ -229,9 +243,9 @@ export async function syncFiles(
   }
 
   const drive = await getDriveClient(authCredentials);
-  const mimeTypesSearchString = MIME_TYPES_TO_SYNC.map(
-    (mimeType) => `mimeType='${mimeType}'`
-  ).join(" or ");
+  const mimeTypesSearchString = mimeTypeToSync
+    .map((mimeType) => `mimeType='${mimeType}'`)
+    .join(" or ");
 
   const res = await drive.files.list({
     corpora: "allDrives",
@@ -299,6 +313,7 @@ async function syncOneFile(
   startSyncTs: number,
   isBatchSync = false
 ): Promise<boolean> {
+  const mimeTypesToDownload = await getMimeTypesToDownload(connectorId);
   const documentId = getDocumentId(file.id);
   let documentContent: string | undefined = undefined;
 
@@ -358,7 +373,7 @@ async function syncOneFile(
       );
       throw e;
     }
-  } else if (MIME_TYPES_TO_DOWNLOAD.includes(file.mimeType)) {
+  } else if (mimeTypesToDownload.includes(file.mimeType)) {
     const drive = await getDriveClient(oauth2client);
 
     let res;
@@ -604,6 +619,7 @@ export async function incrementalSync(
     if (!nextPageToken) {
       nextPageToken = await getSyncPageToken(connectorId, driveId, sharedDrive);
     }
+    const mimeTypesToSync = await getMimesTypeToSync(connectorId);
 
     const selectedFoldersIds = await getFoldersToSync(connectorId);
 
@@ -648,7 +664,7 @@ export async function incrementalSync(
       }
       if (
         !change.file.mimeType ||
-        !MIME_TYPES_TO_SYNC.includes(change.file.mimeType)
+        !mimeTypesToSync.includes(change.file.mimeType)
       ) {
         continue;
       }

--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -62,6 +62,7 @@ async function getMimeTypesToDownload(connectorId: ModelId) {
 
 async function getMimesTypeToSync(connectorId: ModelId) {
   const mimeTypes = await getMimeTypesToDownload(connectorId);
+  mimeTypes.push(...Object.keys(MIME_TYPES_TO_EXPORT));
   mimeTypes.push("application/vnd.google-apps.folder");
 
   return mimeTypes;

--- a/connectors/src/connectors/index.ts
+++ b/connectors/src/connectors/index.ts
@@ -11,9 +11,11 @@ import {
 import {
   cleanupGoogleDriveConnector,
   createGoogleDriveConnector,
+  getGoogleDriveConfig,
   retrieveGoogleDriveConnectorPermissions,
   retrieveGoogleDriveObjectsParents,
   retrieveGoogleDriveObjectsTitles,
+  setGoogleDriveConfig,
   setGoogleDriveConnectorPermissions,
   updateGoogleDriveConnector,
 } from "@connectors/connectors/google_drive";
@@ -23,6 +25,8 @@ import {
   BotToggler,
   ConnectorBatchResourceTitleRetriever,
   ConnectorCleaner,
+  ConnectorConfigGetter,
+  ConnectorConfigSetter,
   ConnectorCreator,
   ConnectorPermissionRetriever,
   ConnectorPermissionSetter,
@@ -211,4 +215,36 @@ export const RETRIEVE_RESOURCE_PARENTS_BY_TYPE: Record<
   google_drive: retrieveGoogleDriveObjectsParents,
   slack: async () => new Ok([]), // Slack is flat
   github: async () => new Ok([]), // Github is flat,
+};
+
+export const SET_CONNECTOR_CONFIG_BY_TYPE: Record<
+  ConnectorProvider,
+  ConnectorConfigSetter
+> = {
+  slack: () => {
+    throw new Error("Not implemented");
+  },
+  notion: async () => {
+    throw new Error("Not implemented");
+  },
+  github: async () => {
+    throw new Error("Not implemented");
+  },
+  google_drive: setGoogleDriveConfig,
+};
+
+export const GET_CONNECTOR_CONFIG_BY_TYPE: Record<
+  ConnectorProvider,
+  ConnectorConfigGetter
+> = {
+  slack: () => {
+    throw new Error("Not implemented");
+  },
+  notion: async () => {
+    throw new Error("Not implemented");
+  },
+  github: async () => {
+    throw new Error("Not implemented");
+  },
+  google_drive: getGoogleDriveConfig,
 };

--- a/connectors/src/connectors/interface.ts
+++ b/connectors/src/connectors/interface.ts
@@ -70,3 +70,14 @@ export type ConnectorResourceParentsRetriever = (
   internalId: string,
   memoizationKey?: string
 ) => Promise<Result<string[], Error>>;
+
+export type ConnectorConfigSetter = (
+  connectorId: ModelId,
+  configKey: string,
+  configValue: string
+) => Promise<Result<void, Error>>;
+
+export type ConnectorConfigGetter = (
+  connectorId: ModelId,
+  configKey: string
+) => Promise<Result<string, Error>>;

--- a/connectors/src/lib/models.ts
+++ b/connectors/src/lib/models.ts
@@ -1045,6 +1045,51 @@ GithubDiscussion.init(
 );
 Connector.hasMany(GithubDiscussion);
 
+export class GoogleDriveConfig extends Model<
+  InferAttributes<GoogleDriveConfig>,
+  InferCreationAttributes<GoogleDriveConfig>
+> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+  declare connectorId: ForeignKey<Connector["id"]>;
+  declare pdfEnabled: boolean;
+}
+
+GoogleDriveConfig.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    connectorId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+    pdfEnabled: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    },
+  },
+  {
+    sequelize: sequelize_conn,
+    modelName: "google_drive_configs",
+    indexes: [{ fields: ["connectorId"], unique: true }],
+  }
+);
+
 // GoogleDriveFolders stores the folders selected by the user to sync.
 export class GoogleDriveFolders extends Model<
   InferAttributes<GoogleDriveFolders>,

--- a/front/lib/connectors_api.ts
+++ b/front/lib/connectors_api.ts
@@ -286,6 +286,46 @@ export const ConnectorsAPI = {
     return _resultFromResponse(res);
   },
 
+  async setConnectorConfig(
+    connectorId: string,
+    configKey: string,
+    configValue: string
+  ): Promise<ConnectorsAPIResponse<void>> {
+    const res = await fetch(
+      `${CONNECTORS_API}/connectors/${connectorId}/config/${configKey}`,
+      {
+        method: "POST",
+        headers: getDefaultHeaders(),
+        body: JSON.stringify({
+          configValue,
+        }),
+      }
+    );
+
+    return _resultFromResponse(res);
+  },
+
+  async getConnectorConfig(
+    connectorId: string,
+    configKey: string
+  ): Promise<
+    ConnectorsAPIResponse<{
+      connectorId: number;
+      configKey: string;
+      configValue: string;
+    }>
+  > {
+    const res = await fetch(
+      `${CONNECTORS_API}/connectors/${connectorId}/config/${configKey}`,
+      {
+        method: "GET",
+        headers: getDefaultHeaders(),
+      }
+    );
+
+    return _resultFromResponse(res);
+  },
+
   async getResourcesParents({
     connectorId,
     resourceInternalIds,

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/config.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/config.ts
@@ -1,0 +1,153 @@
+import { NextApiRequest, NextApiResponse } from "next";
+
+import { Authenticator, getSession } from "@app/lib/auth";
+import { ConnectorsAPI } from "@app/lib/connectors_api";
+import { ReturnedAPIErrorType } from "@app/lib/error";
+import { DataSource, Workspace } from "@app/lib/models";
+import { apiError, withLogging } from "@app/logger/withlogging";
+
+export type SetConfigResponseBody = {
+  configKey: string;
+  configValue: string;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<SetConfigResponseBody | ReturnedAPIErrorType>
+): Promise<void> {
+  const session = await getSession(req, res);
+  const auth = await Authenticator.fromSuperUserSession(session, null);
+  const user = auth.user();
+
+  if (!user) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "user_not_found",
+        message: "Could not find the user.",
+      },
+    });
+  }
+
+  if (!auth.isDustSuperUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "user_not_found",
+        message: "Could not find the user.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "POST":
+      const { wId } = req.query;
+      if (!wId || typeof wId !== "string") {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              "The request query is invalid, expects { workspaceId: string }.",
+          },
+        });
+      }
+
+      const { name } = req.query;
+
+      if (!req.body || typeof req.body.configKey !== "string") {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              "Missing required parameters. Required: configKey (string)",
+          },
+        });
+      }
+      if (!req.body || typeof req.body.configValue !== "string") {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              "Missing required parameters. Required: configValue (string)",
+          },
+        });
+      }
+      const { configKey, configValue } = req.body;
+
+      const workspace = await Workspace.findOne({
+        where: {
+          sId: wId,
+        },
+      });
+
+      if (!workspace) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "workspace_not_found",
+            message: "Could not find the workspace.",
+          },
+        });
+      }
+
+      const dataSource = await DataSource.findOne({
+        where: {
+          workspaceId: workspace.id,
+          name,
+        },
+      });
+
+      if (!dataSource) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "data_source_not_found",
+            message: "Could not find the data source.",
+          },
+        });
+      }
+
+      if (!dataSource.connectorId) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "ConnectorId not set.",
+          },
+        });
+      }
+
+      const connectorRes = await ConnectorsAPI.setConnectorConfig(
+        dataSource.connectorId,
+        configKey,
+        configValue
+      );
+
+      if (connectorRes.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: `An error occurred while setting the connector configuration`,
+            connectors_error: connectorRes.error,
+          },
+        });
+      }
+
+      return res.status(200).json({ configKey, configValue });
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, DELETE is expected.",
+        },
+      });
+  }
+}
+
+export default withLogging(handler);

--- a/front/pages/poke/[wId]/index.tsx
+++ b/front/pages/poke/[wId]/index.tsx
@@ -33,6 +33,7 @@ export const getServerSideProps: GetServerSideProps<{
   planInvitation: PlanInvitationType | null;
   dataSources: DataSourceType[];
   slackbotEnabled?: boolean;
+  gdrivePDFEnabled?: boolean;
   documentCounts: Record<string, number>;
   dataSourcesSynchronizedAgo: Record<string, string>;
 }> = async (context) => {
@@ -137,6 +138,23 @@ export const getServerSideProps: GetServerSideProps<{
     }
     slackbotEnabled = botEnabledRes.value.botEnabled;
   }
+  // Get Gdrive PDF enabled status
+  const gdriveConnectorId = dataSources.find(
+    (ds) => ds.connectorProvider === "google_drive"
+  )?.connectorId;
+
+  let gdrivePDFEnabled = false;
+  if (gdriveConnectorId) {
+    const gdrivePDFEnabledRes = await ConnectorsAPI.getConnectorConfig(
+      gdriveConnectorId,
+      "pdfEnabled"
+    );
+    if (gdrivePDFEnabledRes.isErr()) {
+      throw gdrivePDFEnabledRes.error;
+    }
+    gdrivePDFEnabled =
+      gdrivePDFEnabledRes.value.configValue === "true" ? true : false;
+  }
 
   const planInvitation = await getPlanInvitation(auth);
 
@@ -148,6 +166,7 @@ export const getServerSideProps: GetServerSideProps<{
       planInvitation: planInvitation ?? null,
       dataSources,
       slackbotEnabled,
+      gdrivePDFEnabled,
       documentCounts: docCountByDsName,
       dataSourcesSynchronizedAgo: synchronizedAgoByDsName,
     },
@@ -160,6 +179,7 @@ const WorkspacePage = ({
   planInvitation,
   dataSources,
   slackbotEnabled,
+  gdrivePDFEnabled,
   documentCounts,
   dataSourcesSynchronizedAgo,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
@@ -265,6 +285,31 @@ const WorkspacePage = ({
     } catch (e) {
       console.error(e);
       window.alert("An error occurred while toggling slackbot.");
+    }
+  });
+
+  const { submit: onGdrivePDFToggle } = useSubmitFunction(async () => {
+    try {
+      const r = await fetch(
+        `/api/poke/workspaces/${owner.sId}/data_sources/managed-google_drive/config`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            configKey: "pdfEnabled",
+            configValue: `${!gdrivePDFEnabled}`,
+          }),
+        }
+      );
+      if (!r.ok) {
+        throw new Error("Failed to toggle Gdrive PDF sync.");
+      }
+      router.reload();
+    } catch (e) {
+      console.error(e);
+      window.alert("Failed to toggle Gdrive PDF sync.");
     }
   });
 
@@ -465,6 +510,20 @@ const WorkspacePage = ({
                     <SliderToggle
                       selected={slackbotEnabled}
                       onClick={onSlackbotToggle}
+                    />
+                  </div>
+                )}
+                {ds.connectorProvider === "google_drive" && (
+                  <div className="mb-2 flex items-center justify-between text-sm text-gray-600">
+                    <div>
+                      PDF syncing enabled?{" "}
+                      <span className="font-medium">
+                        {JSON.stringify(gdrivePDFEnabled)}
+                      </span>
+                    </div>
+                    <SliderToggle
+                      selected={gdrivePDFEnabled}
+                      onClick={onGdrivePDFToggle}
                     />
                   </div>
                 )}

--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -614,7 +614,9 @@ export default function DataSourcesView({
           </Page.P>
           <Page.P>
             <span className="font-bold">Google Drive</span>: Dust doesn't take
-            into account files with more than 750Kb of extracted text.
+            into account files with more than 750Kb of extracted text. By
+            default, Dust doesn't take into account .pdf files. Email us at
+            team@dust.tt to include .pdf files.
           </Page.P>
           <Page.P>
             <span className="font-bold">Github</span>: Dust only gathers data

--- a/front/prompt/global_agent_helper_prompt.md
+++ b/front/prompt/global_agent_helper_prompt.md
@@ -129,7 +129,7 @@ When synchronizing your Slack, Notion, Google Drive, and Github platforms. Here 
 
 Slack: Dust doesn't take into account external files or content behind a URL.
 Notion: Dust doesn't take into account external files or content behind a URL.
-Google Drive: Dust doesn't take into account files with more than 750Kb of extracted text.
+Google Drive: Google Drive: Dust doesn't take into account files with more than 750Kb of extracted text. By default, Dust doesn't take into account .pdf files. Email us at team@dust.tt to include .pdf files.
 Github: Dust only gathers data from issues, discussions, and top-level pull request comments (but not in-code comments in pull requests, nor the actual source code or other GitHub data)
 
 ### How long does synchronizing new messages or documents created in one of my Connections takes?


### PR DESCRIPTION
# What?

Adding PDF syncing for Gdrive, behind a config flag.

The config flag is set via the new unified configuration system for connectors.

# Deployment
- Deploy code on connectors-edge
- Run the migration:
```
npx tsx migrations/20231109_2_create_gdrive_config.ts
```
- Deploy connectors
- Deploy front