### PR TITLE
core: QdrantCluster / QdrantClients

### DIFF
--- a/core/src/app.rs
+++ b/core/src/app.rs
@@ -1,11 +1,11 @@
 use crate::blocks::block::{parse_block, Block, BlockResult, BlockType, Env, InputState, MapState};
+use crate::data_sources::qdrant::QdrantClients;
 use crate::dataset::Dataset;
 use crate::project::Project;
 use crate::run::{BlockExecution, BlockStatus, Credentials, Run, RunConfig, RunType, Status};
 use crate::stores::store::Store;
 use crate::utils;
 use crate::{DustParser, Rule};
-use ::qdrant_client::prelude::QdrantClient;
 use anyhow::{anyhow, Result};
 use futures::StreamExt;
 use futures::TryStreamExt;
@@ -302,7 +302,7 @@ impl App {
         &mut self,
         credentials: Credentials,
         store: Box<dyn Store + Sync + Send>,
-        qdrant_client: Arc<QdrantClient>,
+        qdrant_clients: QdrantClients,
         event_sender: Option<UnboundedSender<Value>>,
     ) -> Result<()> {
         assert!(self.run.is_some());
@@ -344,7 +344,7 @@ impl App {
             map: None,
             project: project.clone(),
             store: store.clone(),
-            qdrant_client: qdrant_client,
+            qdrant_clients: qdrant_clients,
             credentials: credentials.clone(),
         }]];
 

--- a/core/src/blocks/block.rs
+++ b/core/src/blocks/block.rs
@@ -2,6 +2,7 @@ use crate::blocks::{
     browser::Browser, chat::Chat, code::Code, curl::Curl, data::Data, data_source::DataSource,
     end::End, input::Input, llm::LLM, map::Map, r#while::While, reduce::Reduce, search::Search,
 };
+use crate::data_sources::qdrant::QdrantClients;
 use crate::project::Project;
 use crate::run::{Credentials, RunConfig};
 use crate::stores::store::Store;
@@ -11,7 +12,6 @@ use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use lazy_static::lazy_static;
 use pest::iterators::Pair;
-use qdrant_client::prelude::QdrantClient;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -19,7 +19,6 @@ use std::any::Any;
 use std::collections::HashMap;
 use std::error::Error;
 use std::str::FromStr;
-use std::sync::Arc;
 use tera::{Context, Tera};
 use tokio::sync::mpsc::UnboundedSender;
 
@@ -45,7 +44,7 @@ pub struct Env {
     #[serde(skip_serializing)]
     pub store: Box<dyn Store + Sync + Send>,
     #[serde(skip_serializing)]
-    pub qdrant_client: Arc<QdrantClient>,
+    pub qdrant_clients: QdrantClients,
     #[serde(skip_serializing)]
     pub project: Project,
     #[serde(skip_serializing)]

--- a/core/src/blocks/data_source.rs
+++ b/core/src/blocks/data_source.rs
@@ -195,7 +195,7 @@ impl DataSource {
             .search(
                 env.credentials.clone(),
                 env.store.clone(),
-                env.qdrant_client.clone(),
+                env.qdrant_clients.clone(),
                 &Some(q.to_string()),
                 top_k,
                 filter,

--- a/core/src/data_sources/qdrant.rs
+++ b/core/src/data_sources/qdrant.rs
@@ -1,0 +1,74 @@
+use anyhow::{anyhow, Result};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use qdrant_client::prelude::{QdrantClient, QdrantClientConfig};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Deserialize, Eq, Hash)]
+pub enum QdrantCluster {
+    #[serde(rename = "main-0")]
+    Main0,
+    //#[serde(rename = "dedicated-0")]
+    //Dedicated0,
+}
+
+static QDRANT_CLUSTER_VARIANTS: &[QdrantCluster] = &[QdrantCluster::Main0];
+
+pub fn env_var_prefix_for_cluster(cluster: QdrantCluster) -> &'static str {
+    match cluster {
+        QdrantCluster::Main0 => "QDRANT_MAIN_0",
+        // QDrantCluster::Dedicated0 => "QDRANT_DEDICATED_0",
+    }
+}
+
+#[derive(Clone)]
+pub struct QdrantClients {
+    clients: Arc<Mutex<HashMap<QdrantCluster, Arc<QdrantClient>>>>,
+}
+
+impl QdrantClients {
+    async fn qdrant_client(cluster: QdrantCluster) -> Result<QdrantClient> {
+        let url_var = format!("{}_URL", env_var_prefix_for_cluster(cluster));
+        let api_key_var = format!("{}_API_KEY", env_var_prefix_for_cluster(cluster));
+
+        match std::env::var(url_var.clone()) {
+            Ok(url) => {
+                let mut config = QdrantClientConfig::from_url(&url);
+                match std::env::var(api_key_var.clone()) {
+                    Ok(api_key) => {
+                        config.set_api_key(&api_key);
+                        QdrantClient::new(Some(config))
+                    }
+                    Err(_) => Err(anyhow!("{} is not set", api_key_var))?,
+                }
+            }
+            Err(_) => Err(anyhow!("{} is not set", url_var))?,
+        }
+    }
+
+    pub async fn build() -> Result<Self> {
+        let clients = futures::future::try_join_all(QDRANT_CLUSTER_VARIANTS.into_iter().map(
+            |cluster| async move {
+                let client = Self::qdrant_client(*cluster).await?;
+                Ok::<_, anyhow::Error>((*cluster, Arc::new(client)))
+            },
+        ))
+        .await?
+        .into_iter()
+        .collect::<HashMap<_, _>>();
+
+        Ok(Self {
+            clients: Arc::new(Mutex::new(clients)),
+        })
+    }
+
+    pub fn get(&self, cluster: QdrantCluster) -> Arc<QdrantClient> {
+        let clients = self.clients.lock();
+        match clients.get(&cluster) {
+            Some(client) => client.clone(),
+            None => panic!("No qdrant_client for cluster {:?}", cluster),
+        }
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -13,6 +13,7 @@ pub mod app;
 pub mod dataset;
 pub mod data_sources {
     pub mod data_source;
+    pub mod qdrant;
     pub mod splitter;
 }
 pub mod databases {

--- a/core/src/providers/provider.rs
+++ b/core/src/providers/provider.rs
@@ -5,6 +5,7 @@ use crate::providers::cohere::CohereProvider;
 use crate::providers::embedder::Embedder;
 use crate::providers::llm::LLM;
 use crate::providers::openai::OpenAIProvider;
+use crate::providers::textsynth::TextSynthProvider;
 use crate::utils::ParseError;
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
@@ -12,8 +13,6 @@ use futures::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use std::time::Duration;
-
-use super::textsynth::TextSynthProvider;
 
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Deserialize)]
 #[serde(rename_all = "lowercase")]


### PR DESCRIPTION
The goal of this PR is to introduce a structure that is safe to clone around (Arc<Mutex<>> protected) that lets us initialize multiple connections to multiple qdrant clusters and easily get the connection we need at the point of use.

From there we will be able to refer to QdrantCluster from data source configuration to route/migrate/shadow write

Deploy plan:
- add `QDRANT_MAIN_0_API_KEY` and `QDRANT_MAIN_0_URL` secrets to core-secrets
- deploy core