### PR TITLE
File attachment

### DIFF
--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -213,6 +213,7 @@ async function botAnswerMessage(
     slackChannel,
     lastSlackChatBotMessage?.threadTs || slackThreadTs || slackMessageTs,
     lastSlackChatBotMessage?.messageTs || slackThreadTs || slackMessageTs,
+    slackChatBotMessage,
     connector
   );
 
@@ -618,8 +619,9 @@ async function makeContentFragment(
   channelId: string,
   threadTs: string,
   startingAtTs: string | null,
+  slackChatBotMessage: SlackChatBotMessage,
   connector: Connector
-) {
+): Promise<Result<PostContentFragmentRequestBody | null, Error>> {
   let allMessages: MessageElement[] = [];
 
   let next_cursor = undefined;
@@ -710,5 +712,6 @@ async function makeContentFragment(
     content: text,
     url: url,
     contentType: "slack_thread_content",
-  } as PostContentFragmentRequestBody);
+    context: null,
+  });
 }

--- a/connectors/src/lib/dust_api.ts
+++ b/connectors/src/lib/dust_api.ts
@@ -89,6 +89,15 @@ export const PostContentFragmentRequestBodySchemaIoTs = t.type({
   content: t.string,
   url: t.union([t.string, t.null]),
   contentType: t.literal("slack_thread_content"),
+  context: t.union([
+    t.type({
+      username: t.string,
+      fullName: t.union([t.string, t.null]),
+      email: t.union([t.string, t.null]),
+      profilePictureUrl: t.union([t.string, t.null]),
+    }),
+    t.null,
+  ]),
 });
 
 const PostConversationsRequestBodySchemaIoTs = t.type({

--- a/front/components/assistant/conversation/ContentFragment.tsx
+++ b/front/components/assistant/conversation/ContentFragment.tsx
@@ -9,6 +9,9 @@ export function ContentFragment({ message }: { message: ContentFragmentType }) {
     case "slack_thread_content":
       logoType = "slack";
       break;
+    case "file_attachment":
+      logoType = "document";
+      break;
 
     default:
       assertNever(message.contentType);
@@ -18,6 +21,7 @@ export function ContentFragment({ message }: { message: ContentFragmentType }) {
       title={message.title}
       type={logoType}
       href={message.url || undefined}
+      avatarUrl={message.context.profilePictureUrl ?? undefined}
     />
   );
 }

--- a/front/components/assistant/conversation/InputBar.tsx
+++ b/front/components/assistant/conversation/InputBar.tsx
@@ -1,9 +1,12 @@
 import {
+  AttachmentStrokeIcon,
   Avatar,
   Button,
+  Citation,
   IconButton,
   PaperAirplaneIcon,
   StopIcon,
+  Tooltip,
 } from "@dust-tt/sparkle";
 import { Transition } from "@headlessui/react";
 import {
@@ -22,7 +25,9 @@ import { mutate } from "swr";
 
 import { AssistantPicker } from "@app/components/assistant/AssistantPicker";
 import { GenerationContext } from "@app/components/assistant/conversation/GenerationContextProvider";
+import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { compareAgentsForSort } from "@app/lib/assistant";
+import { handleFileUploadToText } from "@app/lib/client/handle_file_upload";
 import { useAgentConfigurations } from "@app/lib/swr";
 import { classNames, subFilter } from "@app/lib/utils";
 import { AgentConfigurationType } from "@app/types/assistant/agent";
@@ -202,7 +207,11 @@ export function AssistantInputBar({
   stickyMentions,
 }: {
   owner: WorkspaceType;
-  onSubmit: (input: string, mentions: MentionType[]) => void;
+  onSubmit: (
+    input: string,
+    mentions: MentionType[],
+    contentFragment?: { title: string; content: string }
+  ) => void;
   stickyMentions?: AgentMention[];
 }) {
   const [agentListVisible, setAgentListVisible] = useState(false);
@@ -214,6 +223,13 @@ export function AssistantInputBar({
     bottom: 0,
     left: 0,
   });
+  const [contentFragmentBody, setContentFragmentBody] = useState<
+    string | undefined
+  >(undefined);
+  const [contentFragmentFilename, setContentFragmentFilename] = useState<
+    string | undefined
+  >(undefined);
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const inputRef = useRef<HTMLDivElement>(null);
   const agentListRef = useRef<{
     prev: () => void;
@@ -255,6 +271,7 @@ export function AssistantInputBar({
   const { agentConfigurations } = useAgentConfigurations({
     workspaceId: owner.sId,
   });
+  const sendNotification = useContext(SendNotificationsContext);
 
   const activeAgents = agentConfigurations.filter((a) => a.status === "active");
   activeAgents.sort(compareAgentsForSort);
@@ -291,9 +308,27 @@ export function AssistantInputBar({
 
       content = content.trim();
       content = content.replace(/\u200B/g, "");
+      let contentFragment:
+        | {
+            title: string;
+            content: string;
+            url: string | null;
+            contentType: string;
+          }
+        | undefined = undefined;
+      if (contentFragmentBody && contentFragmentFilename) {
+        contentFragment = {
+          title: contentFragmentFilename,
+          content: contentFragmentBody,
+          url: null,
+          contentType: "file_attachment",
+        };
+      }
 
-      onSubmit(content, mentions);
+      onSubmit(content, mentions, contentFragment);
       contentEditable.innerHTML = "";
+      setContentFragmentFilename(undefined);
+      setContentFragmentBody(undefined);
     }
   };
 
@@ -376,7 +411,7 @@ export function AssistantInputBar({
         position={agentListPosition}
       />
       <div className="flex flex-1">
-        <div className="flex flex-1 flex-row items-center">
+        <div className="flex flex-1 flex-row items-end">
           <div
             className={classNames(
               "relative flex flex-1 flex-row items-stretch px-4",
@@ -387,325 +422,382 @@ export function AssistantInputBar({
                 : ""
             )}
           >
-            <div
-              className={classNames(
-                // This div is placeholder text for the contenteditable
-                contentEditableClasses,
-                "absolute -z-10 text-element-600 dark:text-element-600-dark",
-                empty ? "" : "hidden"
-              )}
-            >
-              Ask a question or get some @help
-            </div>
-            <div
-              className={classNames(
-                contentEditableClasses,
-                "scrollbar-hide",
-                "overflow-y-auto",
-                "max-h-64"
-              )}
-              contentEditable={true}
-              ref={inputRef}
-              id={"dust-input-bar"}
-              suppressContentEditableWarning={true}
-              onPaste={(e) => {
-                e.preventDefault();
-
-                // Get the plain text.
-                const text = e.clipboardData.getData("text/plain");
-
-                // If the text is single line.
-                if (text.indexOf("\n") === -1 && text.indexOf("\r") === -1) {
-                  document.execCommand("insertText", false, text);
-                  return;
-                }
-
-                const selection = window.getSelection();
-                if (!selection) {
-                  return;
-                }
-                const range = selection.getRangeAt(0);
-                let node = range.endContainer;
-                let offset = range.endOffset;
-
-                if (
-                  // @ts-expect-error - parentNode is the contenteditable, it has a getAttribute.
-                  node.getAttribute &&
-                  // @ts-expect-error - parentNode is the contenteditable, it has a getAttribute.
-                  node.getAttribute("id") === "dust-input-bar"
-                ) {
-                  const textNode = document.createTextNode("");
-                  node.appendChild(textNode);
-                  node = textNode;
-                  offset = 0;
-                }
-
-                if (
-                  node.parentNode &&
-                  // @ts-expect-error - parentNode is the contenteditable, it has a getAttribute.
-                  node.parentNode.getAttribute &&
-                  // @ts-expect-error - parentNode is the contenteditable, it has a getAttribute.
-                  node.parentNode.getAttribute("id") === "dust-input-bar"
-                ) {
-                  // Inject the text at the cursor position.
-                  node.textContent =
-                    node.textContent?.slice(0, offset) +
-                    text +
-                    node.textContent?.slice(offset);
-                }
-
-                // Scroll to the end of the input
-                if (inputRef.current) {
-                  setTimeout(() => {
-                    const element = inputRef.current;
-                    if (element) {
-                      element.scrollTop = element.scrollHeight;
-                    }
-                  }, 0);
-                }
-
-                // Move the cursor to the end of the paste.
-                const newRange = document.createRange();
-                newRange.setStart(node, offset + text.length);
-                newRange.setEnd(node, offset + text.length);
-                selection.removeAllRanges();
-                selection.addRange(newRange);
-              }}
-              onKeyDown={(e) => {
-                // We prevent the content editable from creating italics, bold and underline.
-                if (e.ctrlKey || e.metaKey) {
-                  if (e.key === "u" || e.key === "b" || e.key === "i") {
-                    e.preventDefault();
+            <div className="flex flex-row items-end pb-4">
+              <input
+                type="file"
+                ref={fileInputRef}
+                style={{ display: "none" }}
+                onChange={async (e) => {
+                  // focus on the input text after the file selection interaction is over
+                  inputRef.current?.focus();
+                  const file = e?.target?.files?.[0];
+                  if (!file) return;
+                  const res = await handleFileUploadToText(file);
+                  if (res.isErr()) {
+                    sendNotification({
+                      type: "error",
+                      title: "Error uploading file.",
+                      description: res.error.message,
+                    });
+                    return;
                   }
-                }
-                if (!e.shiftKey && e.key === "Enter") {
+                  setContentFragmentFilename(res.value.title);
+                  setContentFragmentBody(res.value.content);
+                }}
+              />
+
+              <Tooltip
+                label="Add a document to the conversation (.txt, .pdf, .md)."
+                position="above"
+              >
+                <IconButton
+                  className="s-element-700 block"
+                  variant={"tertiary"}
+                  icon={AttachmentStrokeIcon}
+                  size="md"
+                  disabled={!!contentFragmentFilename}
+                  onClick={() => {
+                    fileInputRef.current?.click();
+                  }}
+                />
+              </Tooltip>
+            </div>
+            <div className="flex flex-1 flex-col gap-y-2">
+              <div
+                className={classNames(
+                  // This div is placeholder text for the contenteditable
+                  contentEditableClasses,
+                  "absolute bottom-0 -z-10 text-element-600 dark:text-element-600-dark",
+                  empty ? "" : "hidden"
+                )}
+              >
+                Ask a question or get some @help
+              </div>
+
+              {contentFragmentFilename && contentFragmentBody && (
+                <div className="py-3">
+                  <Citation
+                    title={contentFragmentFilename}
+                    description={contentFragmentBody?.substring(0, 100)}
+                    onClose={() => {
+                      setContentFragmentBody(undefined);
+                      setContentFragmentFilename(undefined);
+                    }}
+                  />
+                </div>
+              )}
+
+              <div
+                className={classNames(
+                  contentEditableClasses,
+                  "scrollbar-hide",
+                  "overflow-y-auto",
+                  "max-h-64"
+                )}
+                contentEditable={true}
+                ref={inputRef}
+                id={"dust-input-bar"}
+                suppressContentEditableWarning={true}
+                onPaste={(e) => {
                   e.preventDefault();
-                  e.stopPropagation();
-                  void handleSubmit();
-                }
-              }}
-              onInput={() => {
-                const selection = window.getSelection();
-                if (
-                  selection &&
-                  selection.rangeCount !== 0 &&
-                  selection.isCollapsed
-                ) {
+
+                  // Get the plain text.
+                  const text = e.clipboardData.getData("text/plain");
+
+                  // If the text is single line.
+                  if (text.indexOf("\n") === -1 && text.indexOf("\r") === -1) {
+                    document.execCommand("insertText", false, text);
+                    return;
+                  }
+
+                  const selection = window.getSelection();
+                  if (!selection) {
+                    return;
+                  }
                   const range = selection.getRangeAt(0);
-                  const node = range.endContainer;
-                  const offset = range.endOffset;
-
-                  const lastOne = node.textContent
-                    ? node.textContent.slice(offset - 1, offset)
-                    : null;
-                  const preLastOne = node.textContent
-                    ? node.textContent.slice(offset - 2, offset - 1)
-                    : null;
-
-                  // Mention selection logic.
+                  let node = range.endContainer;
+                  let offset = range.endOffset;
 
                   if (
-                    lastOne === "@" &&
-                    (preLastOne === " " || preLastOne === "") &&
-                    node.textContent &&
+                    // @ts-expect-error - parentNode is the contenteditable, it has a getAttribute.
+                    node.getAttribute &&
+                    // @ts-expect-error - parentNode is the contenteditable, it has a getAttribute.
+                    node.getAttribute("id") === "dust-input-bar"
+                  ) {
+                    const textNode = document.createTextNode("");
+                    node.appendChild(textNode);
+                    node = textNode;
+                    offset = 0;
+                  }
+
+                  if (
                     node.parentNode &&
                     // @ts-expect-error - parentNode is the contenteditable, it has a getAttribute.
                     node.parentNode.getAttribute &&
                     // @ts-expect-error - parentNode is the contenteditable, it has a getAttribute.
                     node.parentNode.getAttribute("id") === "dust-input-bar"
                   ) {
-                    const mentionSelectNode = document.createElement("div");
-
-                    mentionSelectNode.style.display = "inline-block";
-                    mentionSelectNode.setAttribute("key", "mentionSelect");
-                    mentionSelectNode.className = "text-brand font-medium";
-                    mentionSelectNode.textContent = "@";
-                    mentionSelectNode.contentEditable = "false";
-
-                    const inputNode = document.createElement("span");
-                    inputNode.setAttribute("ignore", "none");
-                    inputNode.className = classNames(
-                      "min-w-0 px-0 py-0",
-                      "border-none outline-none focus:outline-none focus:border-none ring-0 focus:ring-0",
-                      "text-brand font-medium"
-                    );
-                    inputNode.contentEditable = "true";
-
-                    mentionSelectNode.appendChild(inputNode);
-
-                    const beforeTextNode = document.createTextNode(
-                      node.textContent.slice(0, offset - 1)
-                    );
-                    const afterTextNode = document.createTextNode(
-                      node.textContent.slice(offset)
-                    );
-
-                    node.parentNode.replaceChild(beforeTextNode, node);
-
-                    beforeTextNode.parentNode?.insertBefore(
-                      afterTextNode,
-                      beforeTextNode.nextSibling
-                    );
-                    beforeTextNode.parentNode?.insertBefore(
-                      mentionSelectNode,
-                      afterTextNode
-                    );
-
-                    const rect = mentionSelectNode.getBoundingClientRect();
-                    const position = {
-                      left: Math.floor(rect.left) - 24,
-                      bottom: Math.floor(window.innerHeight - rect.bottom) + 32,
-                    };
-                    if (!isNaN(position.left) && !isNaN(position.bottom)) {
-                      setAgentListPosition(position);
-                    }
-
-                    setAgentListVisible(true);
-                    inputNode.focus();
-
-                    inputNode.onblur = () => {
-                      let selected = agentListRef.current?.selected();
-                      setAgentListVisible(false);
-                      setTimeout(() => {
-                        setAgentListFilter("");
-                        agentListRef.current?.reset();
-                      });
-
-                      if (inputNode.getAttribute("ignore") !== "none") {
-                        selected = null;
-                      }
-
-                      // console.log("SELECTED", selected);
-
-                      // We received a selected agent configration, recover the state of the
-                      // contenteditable and inject an AgentMention component.
-                      if (selected) {
-                        // Construct an AgentMention component and inject it as HTML.
-                        const mentionNode = getAgentMentionNode(selected);
-
-                        // This is mainly to please TypeScript.
-                        if (!mentionNode || !mentionSelectNode.parentNode) {
-                          return;
-                        }
-
-                        // Replace mentionSelectNode with mentionNode.
-                        mentionSelectNode.parentNode.replaceChild(
-                          mentionNode,
-                          mentionSelectNode
-                        );
-
-                        // Prepend a space to afterTextNode (this will be the space that comes after
-                        // the mention).
-                        afterTextNode.textContent = ` ${afterTextNode.textContent}`;
-
-                        // If afterTextNode is the last node add an invisible character to prevent a
-                        // Chrome bugish behaviour  ¯\_(ツ)_/¯
-                        if (afterTextNode.nextSibling === null) {
-                          afterTextNode.textContent = `${afterTextNode.textContent}\u200B`;
-                        }
-
-                        // Restore the cursor, taking into account the added space.
-                        range.setStart(afterTextNode, 1);
-                        range.setEnd(afterTextNode, 1);
-                        selection.removeAllRanges();
-                        selection.addRange(range);
-                      }
-
-                      // We didn't receive a selected agent configuration, restore the state of the
-                      // contenteditable and re-inject the content that was created during the
-                      // selection process into the contenteditable.
-                      if (!selected && mentionSelectNode.parentNode) {
-                        mentionSelectNode.parentNode.removeChild(
-                          mentionSelectNode
-                        );
-
-                        range.setStart(afterTextNode, 0);
-                        range.setEnd(afterTextNode, 0);
-                        selection.removeAllRanges();
-                        selection.addRange(range);
-
-                        // Insert the content of mentionSelectNode after beforeTextNode only if
-                        // we're not in ignore mode unless we are in ingnore mode (the user
-                        // backspaced into the @)
-                        if (
-                          inputNode.getAttribute("ignore") === "none" ||
-                          inputNode.getAttribute("ignore") === "space"
-                        ) {
-                          const newTextNode = document.createTextNode(
-                            (mentionSelectNode.textContent || "") +
-                              (inputNode.getAttribute("ignore") === "space"
-                                ? " "
-                                : "")
-                          );
-                          beforeTextNode.parentNode?.insertBefore(
-                            newTextNode,
-                            beforeTextNode.nextSibling
-                          );
-                        }
-                      }
-                    };
-
-                    // These are events on the small contentEditable that receives the user input
-                    // and drives the agent list selection.
-                    inputNode.onkeydown = (e) => {
-                      // console.log("KEYDOWN", e.key);
-                      if (e.key === "Escape") {
-                        agentListRef.current?.reset();
-                        inputNode.setAttribute("ignore", "escape");
-                        inputNode.blur();
-                        e.preventDefault();
-                      }
-                      if (e.key === "ArrowDown") {
-                        agentListRef.current?.next();
-                        e.preventDefault();
-                      }
-                      if (e.key === "ArrowUp") {
-                        agentListRef.current?.prev();
-                        e.preventDefault();
-                      }
-                      if (e.key === "Backspace") {
-                        if (inputNode.textContent === "") {
-                          agentListRef.current?.reset();
-                          inputNode.setAttribute("ignore", "backspace");
-                          inputNode.blur();
-                          e.preventDefault();
-                        }
-                      }
-                      if (e.key === " ") {
-                        if (agentListRef.current?.perfectMatch()) {
-                          inputNode.blur();
-                          e.preventDefault();
-                        } else {
-                          agentListRef.current?.reset();
-                          inputNode.setAttribute("ignore", "space");
-                          inputNode.blur();
-                          e.preventDefault();
-                        }
-                      }
-                      if (e.key === "Enter") {
-                        inputNode.blur();
-                        e.preventDefault();
-                      }
-                    };
-
-                    // These are the event that drive the selection of the the agent list, if we
-                    // have no more match we just blur to exit the selection process.
-                    inputNode.oninput = (e) => {
-                      const target = e.target as HTMLInputElement;
-                      // console.log("INPUT", target.textContent);
-                      setAgentListFilter(target.textContent || "");
-                      e.stopPropagation();
-                      setTimeout(() => {
-                        if (agentListRef.current?.noMatch()) {
-                          agentListRef.current?.reset();
-                          inputNode.blur();
-                        }
-                      });
-                    };
+                    // Inject the text at the cursor position.
+                    node.textContent =
+                      node.textContent?.slice(0, offset) +
+                      text +
+                      node.textContent?.slice(offset);
                   }
-                }
-              }}
-            ></div>
+
+                  // Scroll to the end of the input
+                  if (inputRef.current) {
+                    setTimeout(() => {
+                      const element = inputRef.current;
+                      if (element) {
+                        element.scrollTop = element.scrollHeight;
+                      }
+                    }, 0);
+                  }
+
+                  // Move the cursor to the end of the paste.
+                  const newRange = document.createRange();
+                  newRange.setStart(node, offset + text.length);
+                  newRange.setEnd(node, offset + text.length);
+                  selection.removeAllRanges();
+                  selection.addRange(newRange);
+                }}
+                onKeyDown={(e) => {
+                  // We prevent the content editable from creating italics, bold and underline.
+                  if (e.ctrlKey || e.metaKey) {
+                    if (e.key === "u" || e.key === "b" || e.key === "i") {
+                      e.preventDefault();
+                    }
+                  }
+                  if (!e.shiftKey && e.key === "Enter") {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    void handleSubmit();
+                  }
+                }}
+                onInput={() => {
+                  const selection = window.getSelection();
+                  if (
+                    selection &&
+                    selection.rangeCount !== 0 &&
+                    selection.isCollapsed
+                  ) {
+                    const range = selection.getRangeAt(0);
+                    const node = range.endContainer;
+                    const offset = range.endOffset;
+
+                    const lastOne = node.textContent
+                      ? node.textContent.slice(offset - 1, offset)
+                      : null;
+                    const preLastOne = node.textContent
+                      ? node.textContent.slice(offset - 2, offset - 1)
+                      : null;
+
+                    // Mention selection logic.
+
+                    if (
+                      lastOne === "@" &&
+                      (preLastOne === " " || preLastOne === "") &&
+                      node.textContent &&
+                      node.parentNode &&
+                      // @ts-expect-error - parentNode is the contenteditable, it has a getAttribute.
+                      node.parentNode.getAttribute &&
+                      // @ts-expect-error - parentNode is the contenteditable, it has a getAttribute.
+                      node.parentNode.getAttribute("id") === "dust-input-bar"
+                    ) {
+                      const mentionSelectNode = document.createElement("div");
+
+                      mentionSelectNode.style.display = "inline-block";
+                      mentionSelectNode.setAttribute("key", "mentionSelect");
+                      mentionSelectNode.className = "text-brand font-medium";
+                      mentionSelectNode.textContent = "@";
+                      mentionSelectNode.contentEditable = "false";
+
+                      const inputNode = document.createElement("span");
+                      inputNode.setAttribute("ignore", "none");
+                      inputNode.className = classNames(
+                        "min-w-0 px-0 py-0",
+                        "border-none outline-none focus:outline-none focus:border-none ring-0 focus:ring-0",
+                        "text-brand font-medium"
+                      );
+                      inputNode.contentEditable = "true";
+
+                      mentionSelectNode.appendChild(inputNode);
+
+                      const beforeTextNode = document.createTextNode(
+                        node.textContent.slice(0, offset - 1)
+                      );
+                      const afterTextNode = document.createTextNode(
+                        node.textContent.slice(offset)
+                      );
+
+                      node.parentNode.replaceChild(beforeTextNode, node);
+
+                      beforeTextNode.parentNode?.insertBefore(
+                        afterTextNode,
+                        beforeTextNode.nextSibling
+                      );
+                      beforeTextNode.parentNode?.insertBefore(
+                        mentionSelectNode,
+                        afterTextNode
+                      );
+
+                      const rect = mentionSelectNode.getBoundingClientRect();
+                      const position = {
+                        left: Math.floor(rect.left) - 24,
+                        bottom:
+                          Math.floor(window.innerHeight - rect.bottom) + 32,
+                      };
+                      if (!isNaN(position.left) && !isNaN(position.bottom)) {
+                        setAgentListPosition(position);
+                      }
+
+                      setAgentListVisible(true);
+                      inputNode.focus();
+
+                      inputNode.onblur = () => {
+                        let selected = agentListRef.current?.selected();
+                        setAgentListVisible(false);
+                        setTimeout(() => {
+                          setAgentListFilter("");
+                          agentListRef.current?.reset();
+                        });
+
+                        if (inputNode.getAttribute("ignore") !== "none") {
+                          selected = null;
+                        }
+
+                        // console.log("SELECTED", selected);
+
+                        // We received a selected agent configration, recover the state of the
+                        // contenteditable and inject an AgentMention component.
+                        if (selected) {
+                          // Construct an AgentMention component and inject it as HTML.
+                          const mentionNode = getAgentMentionNode(selected);
+
+                          // This is mainly to please TypeScript.
+                          if (!mentionNode || !mentionSelectNode.parentNode) {
+                            return;
+                          }
+
+                          // Replace mentionSelectNode with mentionNode.
+                          mentionSelectNode.parentNode.replaceChild(
+                            mentionNode,
+                            mentionSelectNode
+                          );
+
+                          // Prepend a space to afterTextNode (this will be the space that comes after
+                          // the mention).
+                          afterTextNode.textContent = ` ${afterTextNode.textContent}`;
+
+                          // If afterTextNode is the last node add an invisible character to prevent a
+                          // Chrome bugish behaviour  ¯\_(ツ)_/¯
+                          if (afterTextNode.nextSibling === null) {
+                            afterTextNode.textContent = `${afterTextNode.textContent}\u200B`;
+                          }
+
+                          // Restore the cursor, taking into account the added space.
+                          range.setStart(afterTextNode, 1);
+                          range.setEnd(afterTextNode, 1);
+                          selection.removeAllRanges();
+                          selection.addRange(range);
+                        }
+
+                        // We didn't receive a selected agent configuration, restore the state of the
+                        // contenteditable and re-inject the content that was created during the
+                        // selection process into the contenteditable.
+                        if (!selected && mentionSelectNode.parentNode) {
+                          mentionSelectNode.parentNode.removeChild(
+                            mentionSelectNode
+                          );
+
+                          range.setStart(afterTextNode, 0);
+                          range.setEnd(afterTextNode, 0);
+                          selection.removeAllRanges();
+                          selection.addRange(range);
+
+                          // Insert the content of mentionSelectNode after beforeTextNode only if
+                          // we're not in ignore mode unless we are in ingnore mode (the user
+                          // backspaced into the @)
+                          if (
+                            inputNode.getAttribute("ignore") === "none" ||
+                            inputNode.getAttribute("ignore") === "space"
+                          ) {
+                            const newTextNode = document.createTextNode(
+                              (mentionSelectNode.textContent || "") +
+                                (inputNode.getAttribute("ignore") === "space"
+                                  ? " "
+                                  : "")
+                            );
+                            beforeTextNode.parentNode?.insertBefore(
+                              newTextNode,
+                              beforeTextNode.nextSibling
+                            );
+                          }
+                        }
+                      };
+
+                      // These are events on the small contentEditable that receives the user input
+                      // and drives the agent list selection.
+                      inputNode.onkeydown = (e) => {
+                        // console.log("KEYDOWN", e.key);
+                        if (e.key === "Escape") {
+                          agentListRef.current?.reset();
+                          inputNode.setAttribute("ignore", "escape");
+                          inputNode.blur();
+                          e.preventDefault();
+                        }
+                        if (e.key === "ArrowDown") {
+                          agentListRef.current?.next();
+                          e.preventDefault();
+                        }
+                        if (e.key === "ArrowUp") {
+                          agentListRef.current?.prev();
+                          e.preventDefault();
+                        }
+                        if (e.key === "Backspace") {
+                          if (inputNode.textContent === "") {
+                            agentListRef.current?.reset();
+                            inputNode.setAttribute("ignore", "backspace");
+                            inputNode.blur();
+                            e.preventDefault();
+                          }
+                        }
+                        if (e.key === " ") {
+                          if (agentListRef.current?.perfectMatch()) {
+                            inputNode.blur();
+                            e.preventDefault();
+                          } else {
+                            agentListRef.current?.reset();
+                            inputNode.setAttribute("ignore", "space");
+                            inputNode.blur();
+                            e.preventDefault();
+                          }
+                        }
+                        if (e.key === "Enter") {
+                          inputNode.blur();
+                          e.preventDefault();
+                        }
+                      };
+
+                      // These are the event that drive the selection of the the agent list, if we
+                      // have no more match we just blur to exit the selection process.
+                      inputNode.oninput = (e) => {
+                        const target = e.target as HTMLInputElement;
+                        // console.log("INPUT", target.textContent);
+                        setAgentListFilter(target.textContent || "");
+                        e.stopPropagation();
+                        setTimeout(() => {
+                          if (agentListRef.current?.noMatch()) {
+                            agentListRef.current?.reset();
+                            inputNode.blur();
+                          }
+                        });
+                      };
+                    }
+                  }
+                }}
+              ></div>
+            </div>
 
             <div
               className={classNames(
@@ -761,7 +853,11 @@ export function FixedAssistantInputBar({
   conversationId,
 }: {
   owner: WorkspaceType;
-  onSubmit: (input: string, mentions: MentionType[]) => void;
+  onSubmit: (
+    input: string,
+    mentions: MentionType[],
+    contentFragment?: { title: string; content: string }
+  ) => void;
   stickyMentions?: AgentMention[];
   conversationId: string | null;
 }) {

--- a/front/components/assistant/conversation/InputBar.tsx
+++ b/front/components/assistant/conversation/InputBar.tsx
@@ -451,7 +451,7 @@ export function AssistantInputBar({
                 position="above"
               >
                 <IconButton
-                  className="s-element-700 block"
+                  className="element-700 block"
                   variant={"tertiary"}
                   icon={AttachmentStrokeIcon}
                   size="md"

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -41,6 +41,7 @@ import logger from "@app/logger/logger";
 import {
   AgentMessageType,
   ContentFragmentContentType,
+  ContentFragmentContextType,
   ContentFragmentType,
   ConversationType,
   ConversationVisibility,
@@ -339,6 +340,12 @@ function renderContentFragment({
     content: contentFragment.content,
     url: contentFragment.url,
     contentType: contentFragment.contentType,
+    context: {
+      profilePictureUrl: contentFragment.userContextProfilePictureUrl,
+      fullName: contentFragment.userContextFullName,
+      email: contentFragment.userContextEmail,
+      username: contentFragment.userContextUsername,
+    },
   };
 }
 
@@ -1675,12 +1682,14 @@ export async function postNewContentFragment(
     content,
     url,
     contentType,
+    context,
   }: {
     conversation: ConversationType;
     title: string;
     content: string;
     url: string | null;
     contentType: ContentFragmentContentType;
+    context: ContentFragmentContextType;
   }
 ): Promise<ContentFragmentType> {
   const owner = auth.workspace();
@@ -1694,7 +1703,17 @@ export async function postNewContentFragment(
       await getConversationRankVersionLock(conversation, t);
 
       const contentFragmentRow = await ContentFragment.create(
-        { content, title, url, contentType },
+        {
+          content,
+          title,
+          url,
+          contentType,
+          userId: auth.user()?.id,
+          userContextProfilePictureUrl: context.profilePictureUrl,
+          userContextEmail: context.email,
+          userContextFullName: context.fullName,
+          userContextUsername: context.username,
+        },
         { transaction: t }
       );
       const nextMessageRank =

--- a/front/lib/client/handle_file_upload.ts
+++ b/front/lib/client/handle_file_upload.ts
@@ -1,0 +1,93 @@
+// @ts-expect-error: type package doesn't load properly because of how we are loading pdfjs
+import * as PDFJS from "pdfjs-dist/build/pdf";
+
+import { Err, Ok, Result } from "../result";
+PDFJS.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${PDFJS.version}/pdf.worker.min.js`;
+
+export async function handleFileUploadToText(
+  file: File
+): Promise<Result<{ title: string; content: string }, Error>> {
+  return new Promise((resolve) => {
+    const handleFileLoadedText = (e: ProgressEvent<FileReader>) => {
+      const content = e.target?.result;
+      if (content && typeof content === "string") {
+        return resolve(new Ok({ title: file.name, content }));
+      } else {
+        return resolve(
+          new Err(
+            new Error(
+              "Failed extracting text from file. Please check that your file is not empty."
+            )
+          )
+        );
+        return;
+      }
+    };
+    const handleFileLoadedPDF = async (e: ProgressEvent<FileReader>) => {
+      try {
+        const arrayBuffer = e.target?.result;
+        if (!(arrayBuffer instanceof ArrayBuffer)) {
+          return resolve(
+            new Err(
+              new Error("Failed extracting text from PDF. Unexpected error")
+            )
+          );
+        }
+        const loadingTask = PDFJS.getDocument({ data: arrayBuffer });
+        const pdf = await loadingTask.promise;
+        let text = "";
+        for (let pageNum = 1; pageNum <= pdf.numPages; pageNum++) {
+          const page = await pdf.getPage(pageNum);
+          const content = await page.getTextContent();
+          const strings = content.items.map((item: unknown) => {
+            if (
+              item &&
+              typeof item === "object" &&
+              "str" in item &&
+              typeof item.str === "string"
+            ) {
+              return item.str;
+            }
+          });
+          text += strings.join(" ") + "\n";
+        }
+        return resolve(new Ok({ title: file.name, content: text }));
+      } catch (e) {
+        console.error("Failed extracting text from PDF", e);
+        const errorMessage =
+          e instanceof Error ? e.message : "Unexpected error";
+        return resolve(
+          new Err(new Error(`Failed extracting text from PDF. ${errorMessage}`))
+        );
+      }
+    };
+
+    try {
+      if (file.type === "application/pdf") {
+        const fileReader = new FileReader();
+        fileReader.onloadend = handleFileLoadedPDF;
+        fileReader.readAsArrayBuffer(file);
+      } else if (
+        ["text/plain", "text/csv", "text/markdown"].includes(file.type)
+      ) {
+        const fileData = new FileReader();
+        fileData.onloadend = handleFileLoadedText;
+        fileData.readAsText(file);
+      } else {
+        return resolve(
+          new Err(
+            new Error(
+              "File type not supported. Supported file types: .txt, .pdf, .md"
+            )
+          )
+        );
+      }
+    } catch (e) {
+      console.error("Error handling file", e);
+      const errorMessage = e instanceof Error ? e.message : "Unexpected error";
+      return resolve(
+        new Err(new Error(`Error handling file. ${errorMessage}`))
+      );
+    }
+  });
+}

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -351,6 +351,13 @@ export class ContentFragment extends Model<
   declare content: string;
   declare url: string | null;
   declare contentType: ContentFragmentContentType;
+
+  declare userContextUsername: string | null;
+  declare userContextFullName: string | null;
+  declare userContextEmail: string | null;
+  declare userContextProfilePictureUrl: string | null;
+
+  declare userId: ForeignKey<User["id"]> | null;
 }
 
 ContentFragment.init(
@@ -386,12 +393,35 @@ ContentFragment.init(
       type: DataTypes.STRING,
       allowNull: false,
     },
+    userContextProfilePictureUrl: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
+    userContextUsername: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
+    userContextFullName: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
+    userContextEmail: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
   },
   {
     modelName: "content_fragment",
     sequelize: front_sequelize,
   }
 );
+
+User.hasMany(ContentFragment, {
+  foreignKey: { name: "userId", allowNull: true }, // null = ContentFragment is not associated with a user
+});
+ContentFragment.belongsTo(User, {
+  foreignKey: { name: "userId", allowNull: true },
+});
 
 export class Message extends Model<
   InferAttributes<Message>,

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -125,6 +125,13 @@ async function handler(
           content: contentFragment.content,
           url: contentFragment.url,
           contentType: contentFragment.contentType,
+          context: {
+            username: contentFragment.context?.username || null,
+            fullName: contentFragment.context?.fullName || null,
+            email: contentFragment.context?.email || null,
+            profilePictureUrl:
+              contentFragment.context?.profilePictureUrl || null,
+          },
         });
 
         newContentFragment = cf;

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/content_fragment/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/content_fragment/index.ts
@@ -21,7 +21,6 @@ export const PostContentFragmentRequestBodySchema = t.type({
     t.literal("file_attachment"),
   ]),
   context: t.type({
-    timezone: t.string,
     profilePictureUrl: t.union([t.string, t.null]),
   }),
 });

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/content_fragment/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/content_fragment/index.ts
@@ -7,14 +7,10 @@ import {
   getConversation,
   postNewContentFragment,
 } from "@app/lib/api/assistant/conversation";
-import { Authenticator, getAPIKey } from "@app/lib/auth";
+import { Authenticator, getSession } from "@app/lib/auth";
 import { ReturnedAPIErrorType } from "@app/lib/error";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import { ContentFragmentType } from "@app/types/assistant/conversation";
-
-export type PostContentFragmentsResponseBody = {
-  contentFragment: ContentFragmentType;
-};
 
 export const PostContentFragmentRequestBodySchema = t.type({
   title: t.string,
@@ -24,15 +20,10 @@ export const PostContentFragmentRequestBodySchema = t.type({
     t.literal("slack_thread_content"),
     t.literal("file_attachment"),
   ]),
-  context: t.union([
-    t.type({
-      profilePictureUrl: t.union([t.string, t.null]),
-      fullName: t.union([t.string, t.null]),
-      email: t.union([t.string, t.null]),
-      username: t.union([t.string, t.null]),
-    }),
-    t.null,
-  ]),
+  context: t.type({
+    timezone: t.string,
+    profilePictureUrl: t.union([t.string, t.null]),
+  }),
 });
 
 export type PostContentFragmentRequestBody = t.TypeOf<
@@ -41,29 +32,50 @@ export type PostContentFragmentRequestBody = t.TypeOf<
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<PostContentFragmentsResponseBody | ReturnedAPIErrorType>
+  res: NextApiResponse<
+    { contentFragment: ContentFragmentType } | ReturnedAPIErrorType
+  >
 ): Promise<void> {
-  const keyRes = await getAPIKey(req);
-  if (keyRes.isErr()) {
-    return apiError(req, res, keyRes.error);
-  }
-
-  const { auth, keyWorkspaceId } = await Authenticator.fromKey(
-    keyRes.value,
+  const session = await getSession(req, res);
+  const auth = await Authenticator.fromSession(
+    session,
     req.query.wId as string
   );
 
-  if (!auth.isBuilder() || keyWorkspaceId !== req.query.wId) {
+  const owner = auth.workspace();
+  if (!owner) {
     return apiError(req, res, {
-      status_code: 400,
+      status_code: 404,
       api_error: {
-        type: "invalid_request_error",
-        message: "The Assistant API is only available on your own workspace.",
+        type: "workspace_not_found",
+        message: "The workspace you're trying to modify was not found.",
       },
     });
   }
 
-  const conversation = await getConversation(auth, req.query.cId as string);
+  const user = auth.user();
+  if (!user || !auth.isUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_user_not_found",
+        message: "Could not find the user of the current session.",
+      },
+    });
+  }
+
+  if (!(typeof req.query.cId === "string")) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid query parameters, `cId` (string) is required.",
+      },
+    });
+  }
+
+  const conversationId = req.query.cId;
+  const conversation = await getConversation(auth, conversationId);
   if (!conversation) {
     return apiError(req, res, {
       status_code: 404,
@@ -92,31 +104,19 @@ async function handler(
         });
       }
 
-      const { content, title, url, contentType, context } =
-        bodyValidation.right;
-
-      if (content.length === 0 || content.length > 64 * 1024) {
-        return apiError(req, res, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message:
-              "The content must be a non-empty string of less than 64kb.",
-          },
-        });
-      }
+      const contentFragmentPayload = bodyValidation.right;
 
       const contentFragment = await postNewContentFragment(auth, {
         conversation,
-        title,
-        content,
-        url,
-        contentType,
+        title: contentFragmentPayload.title,
+        content: contentFragmentPayload.content,
+        url: contentFragmentPayload.url,
+        contentType: contentFragmentPayload.contentType,
         context: {
-          username: context?.username || null,
-          fullName: context?.fullName || null,
-          email: context?.email || null,
-          profilePictureUrl: context?.profilePictureUrl || null,
+          username: user.username,
+          fullName: user.fullName,
+          email: user.email,
+          profilePictureUrl: contentFragmentPayload.context.profilePictureUrl,
         },
       });
 

--- a/front/pages/api/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/index.ts
@@ -13,6 +13,7 @@ import { postUserMessageWithPubSub } from "@app/lib/api/assistant/pubsub";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { ReturnedAPIErrorType } from "@app/lib/error";
 import { apiError, withLogging } from "@app/logger/withlogging";
+import { PostContentFragmentRequestBodySchema } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/content_fragment";
 import { PostMessagesRequestBodySchema } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/messages";
 import {
   ContentFragmentType,
@@ -20,8 +21,6 @@ import {
   ConversationWithoutContentType,
   UserMessageType,
 } from "@app/types/assistant/conversation";
-
-import { PostContentFragmentRequestBodySchema } from "./[cId]/content_fragment";
 
 export const PostConversationsRequestBodySchema = t.type({
   title: t.union([t.string, t.null]),

--- a/front/pages/api/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/index.ts
@@ -5,7 +5,9 @@ import { NextApiRequest, NextApiResponse } from "next";
 
 import {
   createConversation,
+  getConversation,
   getUserConversations,
+  postNewContentFragment,
 } from "@app/lib/api/assistant/conversation";
 import { postUserMessageWithPubSub } from "@app/lib/api/assistant/pubsub";
 import { Authenticator, getSession } from "@app/lib/auth";
@@ -13,10 +15,13 @@ import { ReturnedAPIErrorType } from "@app/lib/error";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import { PostMessagesRequestBodySchema } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/messages";
 import {
+  ContentFragmentType,
   ConversationType,
   ConversationWithoutContentType,
   UserMessageType,
 } from "@app/types/assistant/conversation";
+
+import { PostContentFragmentRequestBodySchema } from "./[cId]/content_fragment";
 
 export const PostConversationsRequestBodySchema = t.type({
   title: t.union([t.string, t.null]),
@@ -26,6 +31,7 @@ export const PostConversationsRequestBodySchema = t.type({
     t.literal("deleted"),
   ]),
   message: t.union([PostMessagesRequestBodySchema, t.null]),
+  contentFragment: t.union([PostContentFragmentRequestBodySchema, t.undefined]),
 });
 
 export type GetConversationsResponseBody = {
@@ -34,6 +40,7 @@ export type GetConversationsResponseBody = {
 export type PostConversationsResponseBody = {
   conversation: ConversationType;
   message?: UserMessageType;
+  contentFragment?: ContentFragmentType;
 };
 
 async function handler(
@@ -117,14 +124,41 @@ async function handler(
         });
       }
 
-      const { title, visibility, message } = bodyValidation.right;
+      const { title, visibility, message, contentFragment } =
+        bodyValidation.right;
 
-      const conversation = await createConversation(auth, {
+      let conversation = await createConversation(auth, {
         title,
         visibility,
       });
 
+      let newContentFragment: ContentFragmentType | null = null;
       let newMessage: UserMessageType | null = null;
+
+      if (contentFragment) {
+        const cf = await postNewContentFragment(auth, {
+          conversation,
+          title: contentFragment.title,
+          content: contentFragment.content,
+          url: contentFragment.url,
+          contentType: contentFragment.contentType,
+          context: {
+            username: user.username,
+            fullName: user.fullName,
+            email: user.email,
+            profilePictureUrl: contentFragment.context.profilePictureUrl,
+          },
+        });
+
+        newContentFragment = cf;
+        const updatedConversation = await getConversation(
+          auth,
+          conversation.sId
+        );
+        if (updatedConversation) {
+          conversation = updatedConversation;
+        }
+      }
 
       if (message) {
         /* If a message was provided we do await for the message to be created
@@ -150,7 +184,26 @@ async function handler(
         newMessage = messageRes.value;
       }
 
-      res.status(200).json({ conversation, message: newMessage ?? undefined });
+      if (newContentFragment || newMessage) {
+        // If we created a user message or a content fragment (or both) we retrieve the
+        // conversation. If a user message was posted, we know that the agent messages have been
+        // created as well, so pulling the conversation again will allow to have an up to date view
+        // of the conversation with agent messages included so that the user of the API can start
+        // streaming events from these agent messages directly.
+        const updated = await getConversation(auth, conversation.sId);
+
+        if (!updated) {
+          throw `Conversation unexpectedly not found after creation: ${conversation.sId}`;
+        }
+
+        conversation = updated;
+      }
+
+      res.status(200).json({
+        conversation,
+        message: newMessage ?? undefined,
+        contentFragment: newContentFragment ?? undefined,
+      });
       return;
 
     default:

--- a/front/pages/w/[wId]/assistant/[cId]/index.tsx
+++ b/front/pages/w/[wId]/assistant/[cId]/index.tsx
@@ -83,7 +83,49 @@ export default function AssistantConversation({
     conversationId,
     workspaceId: owner.sId,
   });
-  const handleSubmit = async (input: string, mentions: MentionType[]) => {
+  const handleSubmit = async (
+    input: string,
+    mentions: MentionType[],
+    contentFragment?: {
+      title: string;
+      content: string;
+    }
+  ) => {
+    // Create a new content fragment.
+    if (contentFragment) {
+      const mcfRes = await fetch(
+        `/api/w/${owner.sId}/assistant/conversations/${conversationId}/content_fragment`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            title: contentFragment.title,
+            content: contentFragment.content,
+            url: null,
+            contentType: "file_attachment",
+            context: {
+              timezone:
+                Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC",
+              profilePictureUrl: user.image,
+            },
+          }),
+        }
+      );
+
+      if (!mcfRes.ok) {
+        const data = await mcfRes.json();
+        console.error("Error creating content fragment", data);
+        sendNotification({
+          title: "Error uploading file.",
+          description: data.error.message || "Please try again or contact us.",
+          type: "error",
+        });
+        return;
+      }
+    }
+
     // Create a new user message.
     const mRes = await fetch(
       `/api/w/${owner.sId}/assistant/conversations/${conversationId}/messages`,

--- a/front/pages/w/[wId]/assistant/new.tsx
+++ b/front/pages/w/[wId]/assistant/new.tsx
@@ -125,8 +125,6 @@ export default function AssistantNew({
               contentType: "file_attachment",
               url: null,
               context: {
-                timezone:
-                  Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC",
                 profilePictureUrl: user.image,
               },
             }

--- a/front/pages/w/[wId]/assistant/new.tsx
+++ b/front/pages/w/[wId]/assistant/new.tsx
@@ -33,6 +33,7 @@ import type {
   PostConversationsResponseBody,
 } from "@app/pages/api/w/[wId]/assistant/conversations";
 import {
+  ContentFragmentContentType,
   ConversationType,
   MentionType,
 } from "@app/types/assistant/conversation";
@@ -99,7 +100,14 @@ export default function AssistantNew({
     : activeAgents.slice(0, 4);
 
   const { submit: handleSubmit } = useSubmitFunction(
-    async (input: string, mentions: MentionType[]) => {
+    async (
+      input: string,
+      mentions: MentionType[],
+      contentFragment?: {
+        title: string;
+        content: string;
+      }
+    ) => {
       const body: t.TypeOf<typeof PostConversationsRequestBodySchema> = {
         title: null,
         visibility: "unlisted",
@@ -111,6 +119,18 @@ export default function AssistantNew({
           },
           mentions,
         },
+        contentFragment: contentFragment
+          ? {
+              ...contentFragment,
+              contentType: "file_attachment",
+              url: null,
+              context: {
+                timezone:
+                  Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC",
+                profilePictureUrl: user.image,
+              },
+            }
+          : undefined,
       };
 
       // Create new conversation and post the initial message at the same time.
@@ -379,7 +399,15 @@ function StartHelperConversationButton({
   size = "xs",
 }: {
   content: string;
-  handleSubmit: (input: string, mentions: MentionType[]) => Promise<void>;
+  handleSubmit: (
+    input: string,
+    mentions: MentionType[],
+    contentFragment?: {
+      title: string;
+      content: string;
+      contentType: ContentFragmentContentType;
+    }
+  ) => Promise<void>;
   variant?: "primary" | "secondary";
   size?: "sm" | "xs";
 }) {

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -124,7 +124,16 @@ export function isAgentMessageType(
 /**
  * Content Fragments
  */
-export type ContentFragmentContentType = "slack_thread_content";
+export type ContentFragmentContextType = {
+  username: string | null;
+  fullName: string | null;
+  email: string | null;
+  profilePictureUrl: string | null;
+};
+
+export type ContentFragmentContentType =
+  | "slack_thread_content"
+  | "file_attachment";
 
 export type ContentFragmentType = {
   id: ModelId;
@@ -138,6 +147,7 @@ export type ContentFragmentType = {
   content: string;
   url: string | null;
   contentType: ContentFragmentContentType;
+  context: ContentFragmentContextType;
 };
 
 export function isContentFragmentType(


### PR DESCRIPTION
# Add support for file attachment as content fragment in conversations.

_(Does not build in CI because I modified Sparkle directly in this branch, I will fix that ASAP, but you can still review the code. It builds otherwise)._

- Support for PDF and plain/text files only as per [framing](https://github.com/dust-tt/dust/issues/2548).
- Add a file picker in the UI.
- Adding full context (username, timezone, profilerURL etc) to content fragment.
- [Video demo.](https://www.loom.com/share/ae25da820de54b92ae37c6a9af9aef3d)
- Screenshot:


<img width="1282" alt="Screen Shot 2023-11-15 at 23 09 48" src="https://github.com/dust-tt/dust/assets/358965/b7491949-2dc6-47d7-a1d5-396cf565c2c2">

# Deployment
- Deploy Sparkle.
- Update front/package.json @dust-tt/sparkle dependency.
- `front> npm run initdb`
- Deploy front.
- Deploy connectors.

