### PR TITLE
QdrantDataSourceConfig, main read, shadow write

### DIFF
--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -8,6 +8,7 @@ use crate::stores::store::Store;
 use crate::utils;
 use anyhow::{anyhow, Result};
 use cloud_storage::Object;
+use futures::future::try_join_all;
 use futures::StreamExt;
 use futures::TryStreamExt;
 use qdrant_client::qdrant::vectors::VectorsOptions;
@@ -27,7 +28,7 @@ use tokio::try_join;
 use tokio_stream::{self as stream};
 use uuid::Uuid;
 
-use super::qdrant::{QdrantClients, QdrantCluster};
+use super::qdrant::{QdrantClients, QdrantDataSourceConfig};
 
 /// A filter to apply to the search query based on `tags`. All documents returned must have at least
 /// one tag in `is_in` and none of the tags in `is_not`.
@@ -188,7 +189,7 @@ pub struct DataSourceConfig {
     pub extras: Option<Value>,
     pub splitter_id: SplitterID,
     pub max_chunk_size: usize,
-    pub use_cache: bool,
+    pub qdrant_config: Option<QdrantDataSourceConfig>,
 }
 
 /// The `data_source_id` is the unique identifier that allows routing to the right data in SQL store
@@ -305,7 +306,7 @@ impl DataSource {
         credentials: Credentials,
         qdrant_clients: QdrantClients,
     ) -> Result<()> {
-        let qdrant_client = qdrant_clients.get(QdrantCluster::Main0);
+        let qdrant_client = qdrant_clients.main_client(&self.config.qdrant_config);
 
         let mut embedder = provider(self.config.provider_id).embedder(self.config.model_id.clone());
         embedder.initialize(credentials).await?;
@@ -425,8 +426,6 @@ impl DataSource {
         document_id: String,
         parents: Vec<String>,
     ) -> Result<()> {
-        let qdrant_client = qdrant_clients.get(QdrantCluster::Main0);
-
         store
             .update_data_source_document_parents(
                 &self.project,
@@ -440,7 +439,7 @@ impl DataSource {
         hasher.update(document_id.as_bytes());
         let document_id_hash = format!("{}", hasher.finalize().to_hex());
 
-        self.update_document_payload(qdrant_client, document_id_hash, "parents", parents)
+        self.update_document_payload(qdrant_clients, document_id_hash, "parents", parents)
             .await?;
         Ok(())
     }
@@ -453,8 +452,6 @@ impl DataSource {
         add_tags: Vec<String>,
         remove_tags: Vec<String>,
     ) -> Result<Vec<String>> {
-        let qdrant_client = qdrant_clients.get(QdrantCluster::Main0);
-
         let new_tags = store
             .update_data_source_document_tags(
                 &self.project,
@@ -469,14 +466,14 @@ impl DataSource {
         hasher.update(document_id.as_bytes());
         let document_id_hash = format!("{}", hasher.finalize().to_hex());
 
-        self.update_document_payload(qdrant_client, document_id_hash, "tags", new_tags.clone())
+        self.update_document_payload(qdrant_clients, document_id_hash, "tags", new_tags.clone())
             .await?;
         Ok(new_tags)
     }
 
     async fn update_document_payload(
         &self,
-        qdrant_client: Arc<QdrantClient>,
+        qdrant_clients: QdrantClients,
         document_id_hash: String,
         field_name: &str,
         field_value: impl Into<Value>,
@@ -499,14 +496,21 @@ impl DataSource {
             })),
         };
 
-        qdrant_client
-            .set_payload(
-                self.qdrant_collection().to_string(),
-                &points_selector,
-                payload,
-                None,
-            )
-            .await?;
+        try_join_all(
+            qdrant_clients
+                .write_clients(&self.config.qdrant_config)
+                .iter()
+                .map(|qdrant_client| {
+                    qdrant_client.set_payload(
+                        self.qdrant_collection().to_string(),
+                        &points_selector,
+                        payload.clone(),
+                        None,
+                    )
+                }),
+        )
+        .await?;
+
         Ok(())
     }
 
@@ -523,7 +527,8 @@ impl DataSource {
         text: &str,
         preserve_system_tags: bool,
     ) -> Result<Document> {
-        let qdrant_client = qdrant_clients.get(QdrantCluster::Main0);
+        let qdrant_client = qdrant_clients.main_client(&self.config.qdrant_config);
+        let qdrant_write_clients = qdrant_clients.write_clients(&self.config.qdrant_config);
 
         // disallow preserve_system_tags=true if tags contains a string starting with the system tag prefix
         // prevents having duplicate system tags or have users accidentally add system tags (from UI/API)
@@ -830,28 +835,27 @@ impl DataSource {
         document.token_count = Some(document.chunks.len() * self.config.max_chunk_size);
 
         let now = utils::now();
+
         // Clean-up previous document chunks (vector search db).
-        let _ = qdrant_client
-            .delete_points(
-                self.qdrant_collection(),
-                &qdrant::Filter {
-                    must_not: vec![],
-                    should: vec![],
-                    must: vec![qdrant::FieldCondition {
-                        key: "document_id_hash".to_string(),
-                        r#match: Some(qdrant::Match {
-                            match_value: Some(qdrant::r#match::MatchValue::Keyword(
-                                document_id_hash.clone(),
-                            )),
-                        }),
-                        ..Default::default()
-                    }
-                    .into()],
-                }
-                .into(),
-                None,
-            )
-            .await?;
+        let filter: PointsSelector = qdrant::Filter {
+            must_not: vec![],
+            should: vec![],
+            must: vec![qdrant::FieldCondition {
+                key: "document_id_hash".to_string(),
+                r#match: Some(qdrant::Match {
+                    match_value: Some(qdrant::r#match::MatchValue::Keyword(
+                        document_id_hash.clone(),
+                    )),
+                }),
+                ..Default::default()
+            }
+            .into()],
+        }
+        .into();
+        try_join_all(qdrant_write_clients.iter().map(|qdrant_client| {
+            qdrant_client.delete_points(self.qdrant_collection(), &filter, None)
+        }))
+        .await?;
 
         utils::done(&format!(
             "Deleted previous document in Qdrant: data_source_id={} document_id={} duration={}ms",
@@ -915,9 +919,10 @@ impl DataSource {
                 let now = utils::now();
                 let chunk_len = chunk.len();
 
-                let _ = qdrant_client
-                    .upsert_points(self.qdrant_collection(), chunk, None)
-                    .await?;
+                try_join_all(qdrant_write_clients.iter().map(|qdrant_client| {
+                    qdrant_client.upsert_points(self.qdrant_collection(), chunk.clone(), None)
+                }))
+                .await?;
 
                 utils::done(&format!(
                     "Success upserting chunk in qdrant: points_count={} duration={}ms",
@@ -953,7 +958,7 @@ impl DataSource {
         full_text: bool,
         target_document_tokens: Option<usize>,
     ) -> Result<Vec<Document>> {
-        let qdrant_client = qdrant_clients.get(QdrantCluster::Main0);
+        let qdrant_client = qdrant_clients.main_client(&self.config.qdrant_config);
 
         if top_k > DataSource::MAX_TOP_K_SEARCH {
             return Err(anyhow!("top_k must be <= {}", DataSource::MAX_TOP_K_SEARCH));
@@ -1530,7 +1535,7 @@ impl DataSource {
         qdrant_clients: QdrantClients,
         document_id: &str,
     ) -> Result<()> {
-        let qdrant_client = qdrant_clients.get(QdrantCluster::Main0);
+        let qdrant_write_clients = qdrant_clients.write_clients(&self.config.qdrant_config);
         let store = store.clone();
 
         let mut hasher = blake3::Hasher::new();
@@ -1538,27 +1543,25 @@ impl DataSource {
         let document_id_hash = format!("{}", hasher.finalize().to_hex());
 
         // Clean-up document chunks (vector search db).
-        let _ = qdrant_client
-            .delete_points(
-                self.qdrant_collection(),
-                &qdrant::Filter {
-                    must_not: vec![],
-                    should: vec![],
-                    must: vec![qdrant::FieldCondition {
-                        key: "document_id_hash".to_string(),
-                        r#match: Some(qdrant::Match {
-                            match_value: Some(qdrant::r#match::MatchValue::Keyword(
-                                document_id_hash.clone(),
-                            )),
-                        }),
-                        ..Default::default()
-                    }
-                    .into()],
-                }
-                .into(),
-                None,
-            )
-            .await?;
+        let filter: PointsSelector = qdrant::Filter {
+            must_not: vec![],
+            should: vec![],
+            must: vec![qdrant::FieldCondition {
+                key: "document_id_hash".to_string(),
+                r#match: Some(qdrant::Match {
+                    match_value: Some(qdrant::r#match::MatchValue::Keyword(
+                        document_id_hash.clone(),
+                    )),
+                }),
+                ..Default::default()
+            }
+            .into()],
+        }
+        .into();
+        try_join_all(qdrant_write_clients.iter().map(|qdrant_client| {
+            qdrant_client.delete_points(self.qdrant_collection(), &filter, None)
+        }))
+        .await?;
 
         // Delete document (SQL)
         store
@@ -1573,7 +1576,13 @@ impl DataSource {
         store: Box<dyn Store + Sync + Send>,
         qdrant_clients: QdrantClients,
     ) -> Result<()> {
-        let qdrant_client = qdrant_clients.get(QdrantCluster::Main0);
+        if qdrant_clients.has_shadow_write(&self.config.qdrant_config) {
+            Err(anyhow!(
+                "Cannot delete data source with a shadow_write_cluster set"
+            ))?;
+        }
+
+        let qdrant_client = qdrant_clients.main_client(&self.config.qdrant_config);
         let store = store.clone();
 
         // Delete collection (vector search db).

--- a/core/src/data_sources/qdrant.rs
+++ b/core/src/data_sources/qdrant.rs
@@ -78,13 +78,6 @@ impl QdrantClients {
         }
     }
 
-    pub fn has_shadow_write(&self, config: &Option<QdrantDataSourceConfig>) -> bool {
-        match config {
-            Some(c) => c.shadow_write_cluster.is_some(),
-            None => false,
-        }
-    }
-
     // Returns the client for the cluster specified in the config or the main-0 cluster if no config
     // is provided.
     pub fn main_client(&self, config: &Option<QdrantDataSourceConfig>) -> Arc<QdrantClient> {
@@ -94,15 +87,27 @@ impl QdrantClients {
         }
     }
 
-    // Returns the main client along with the shadow_write_client if specified.
-    pub fn write_clients(&self, config: &Option<QdrantDataSourceConfig>) -> Vec<Arc<QdrantClient>> {
-        let main_client = self.main_client(config);
+    pub fn shadow_write_cluster(
+        &self,
+        config: &Option<QdrantDataSourceConfig>,
+    ) -> Option<QdrantCluster> {
+        match config {
+            Some(c) => c.shadow_write_cluster,
+            None => None,
+        }
+    }
+
+    // Returns the shadow write client if the config specifies a shadow write cluster.
+    pub fn shadow_write_client(
+        &self,
+        config: &Option<QdrantDataSourceConfig>,
+    ) -> Option<Arc<QdrantClient>> {
         match config {
             Some(c) => match c.shadow_write_cluster {
-                Some(cluster) => vec![main_client, self.client(cluster)],
-                None => vec![main_client],
+                Some(cluster) => Some(self.client(cluster)),
+                None => None,
             },
-            None => vec![main_client],
+            None => None,
         }
     }
 }

--- a/core/src/data_sources/qdrant.rs
+++ b/core/src/data_sources/qdrant.rs
@@ -28,6 +28,12 @@ pub struct QdrantClients {
     clients: Arc<Mutex<HashMap<QdrantCluster, Arc<QdrantClient>>>>,
 }
 
+#[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]
+pub struct QdrantDataSourceConfig {
+    cluster: QdrantCluster,
+    shadow_write_cluster: Option<QdrantCluster>,
+}
+
 impl QdrantClients {
     async fn qdrant_client(cluster: QdrantCluster) -> Result<QdrantClient> {
         let url_var = format!("{}_URL", env_var_prefix_for_cluster(cluster));
@@ -64,11 +70,39 @@ impl QdrantClients {
         })
     }
 
-    pub fn get(&self, cluster: QdrantCluster) -> Arc<QdrantClient> {
+    pub fn client(&self, cluster: QdrantCluster) -> Arc<QdrantClient> {
         let clients = self.clients.lock();
         match clients.get(&cluster) {
             Some(client) => client.clone(),
             None => panic!("No qdrant_client for cluster {:?}", cluster),
+        }
+    }
+
+    pub fn has_shadow_write(&self, config: &Option<QdrantDataSourceConfig>) -> bool {
+        match config {
+            Some(c) => c.shadow_write_cluster.is_some(),
+            None => false,
+        }
+    }
+
+    // Returns the client for the cluster specified in the config or the main-0 cluster if no config
+    // is provided.
+    pub fn main_client(&self, config: &Option<QdrantDataSourceConfig>) -> Arc<QdrantClient> {
+        match config {
+            Some(config) => self.client(config.cluster),
+            None => self.client(QdrantCluster::Main0),
+        }
+    }
+
+    // Returns the main client along with the shadow_write_client if specified.
+    pub fn write_clients(&self, config: &Option<QdrantDataSourceConfig>) -> Vec<Arc<QdrantClient>> {
+        let main_client = self.main_client(config);
+        match config {
+            Some(c) => match c.shadow_write_cluster {
+                Some(cluster) => vec![main_client, self.client(cluster)],
+                None => vec![main_client],
+            },
+            None => vec![main_client],
         }
     }
 }

--- a/front/migrations/20231115_update_core_data_source_config.ts
+++ b/front/migrations/20231115_update_core_data_source_config.ts
@@ -1,0 +1,72 @@
+import { Sequelize } from "sequelize";
+
+// To be run from connectors with `CORE_DATABASE_URI`
+const { CORE_DATABASE_URI, LIVE = false } = process.env;
+
+async function main() {
+  const core_sequelize = new Sequelize(CORE_DATABASE_URI as string, {
+    logging: false,
+  });
+
+  const dataSourcesData = await core_sequelize.query(
+    `SELECT id, config_json FROM data_sources`
+  );
+
+  const dataSources = dataSourcesData[0] as {
+    id: number;
+    config_json: string;
+  }[];
+
+  console.log(`Found ${dataSources.length} data sources to process`);
+
+  const chunks = [];
+  for (let i = 0; i < dataSources.length; i += 32) {
+    chunks.push(dataSources.slice(i, i + 32));
+  }
+
+  for (let i = 0; i < chunks.length; i++) {
+    console.log(`Processing chunk ${i}/${chunks.length}...`);
+    const chunk = chunks[i];
+    await Promise.all(
+      chunk.map(async (d) => {
+        return processDataSource(core_sequelize, d);
+      })
+    );
+  }
+}
+
+async function processDataSource(
+  core_sequelize: Sequelize,
+  d: { id: number; config_json: string }
+) {
+  console.log(">", d.config_json);
+
+  const config = JSON.parse(d.config_json);
+
+  delete config.use_cache;
+  config.qdrant_config = null;
+
+  console.log("<", JSON.stringify(config));
+
+  if (LIVE) {
+    await core_sequelize.query(
+      `UPDATE data_sources SET config_json = :config WHERE id = :id`,
+      {
+        replacements: {
+          id: d.id,
+          config: JSON.stringify(config),
+        },
+      }
+    );
+  }
+}
+
+main()
+  .then(() => {
+    console.log("Done");
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/index.ts
@@ -96,13 +96,17 @@ async function handler(
           true
         );
         if (connDeleteRes.isErr()) {
-          return apiError(req, res, {
-            status_code: 500,
-            api_error: {
-              type: "internal_server_error",
-              message: `Error deleting connector: ${connDeleteRes.error.error.message}`,
-            },
-          });
+          // If we get a not found we proceed with the deletion of the data source. This will enable
+          // us to retry deletion of the data source if it fails at the Core level.
+          if (connDeleteRes.error.error.type !== "connector_not_found") {
+            return apiError(req, res, {
+              status_code: 500,
+              api_error: {
+                type: "internal_server_error",
+                message: `Error deleting connector: ${connDeleteRes.error.error.message}`,
+              },
+            });
+          }
         }
       }
 


### PR DESCRIPTION
This PR introduces an optional QdrantDataSourceConfig object on the DataSource config (which is stored in DB, if not present works fine).

This object specifies the main cluster to use (read/write) as well as an optional shadow_write cluster.

If nothing is specified we default to the current `main-0` cluster. Otherwise we read from the main cluster.
If the shadow_write cluster is specified we write sequentially to both cluster only erroring on the main clusrter.

This will enable shadow writing to a cluster while we move the data from another one to it.

Also removes use_cache which was unused.

This is ~ a no-op to deploy. Will just start adding a null qdrant_config in the data source config in base for new data sources:
```
dust_api=# SELECT config_json FROM data_sources;
                                                                 config_json                                                                  
----------------------------------------------------------------------------------------------------------------------------------------------
 {"provider_id":"openai","model_id":"text-embedding-ada-002","extras":null,"splitter_id":"base_v0","max_chunk_size":256,"use_cache":false}
 {"provider_id":"openai","model_id":"text-embedding-ada-002","extras":null,"splitter_id":"base_v0","max_chunk_size":256,"use_cache":false}
 {"provider_id":"openai","model_id":"text-embedding-ada-002","extras":null,"splitter_id":"base_v0","max_chunk_size":256,"qdrant_config":null}
(3 rows)
```