### PR TITLE
Intercom Connector: Models & Skeleton to manage connector object 

### DIFF
--- a/connectors/package-lock.json
+++ b/connectors/package-lock.json
@@ -30,6 +30,7 @@
         "fs-extra": "^11.1.1",
         "googleapis": "^118.0.0",
         "hot-shots": "^10.0.0",
+        "intercom-client": "^4.0.0",
         "io-ts": "^2.2.20",
         "io-ts-reporters": "^2.0.1",
         "lodash.get": "^4.4.2",
@@ -4033,6 +4034,11 @@
         "unix-dgram": "2.x"
       }
     },
+    "node_modules/htmlencode": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/htmlencode/-/htmlencode-0.0.4.tgz",
+      "integrity": "sha512-0uDvNVpzj/E2TfvLLyyXhKBRvF1y84aZsyRxRXFsQobnHaL4pcaXk+Y9cnFlvnxrBLeXDNq/VJBD+ngdBgQG1w=="
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -4163,6 +4169,27 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/intercom-client": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/intercom-client/-/intercom-client-4.0.0.tgz",
+      "integrity": "sha512-xtAsO0wnyd46JNRP98/JK0BXIfWNTO/tUk+1op4rnZ+N/DSdhAaBw8ZaJD8bL8ePNhyAMl/Vd6h7kYI/h9riaw==",
+      "dependencies": {
+        "axios": "^0.24.0",
+        "htmlencode": "^0.0.4",
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">= v8.0.0"
+      }
+    },
+    "node_modules/intercom-client/node_modules/axios": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+      "dependencies": {
+        "follow-redirects": "^1.14.4"
+      }
     },
     "node_modules/io-ts": {
       "version": "2.2.20",

--- a/connectors/package.json
+++ b/connectors/package.json
@@ -35,6 +35,7 @@
     "fs-extra": "^11.1.1",
     "googleapis": "^118.0.0",
     "hot-shots": "^10.0.0",
+    "intercom-client": "^4.0.0",
     "io-ts": "^2.2.20",
     "io-ts-reporters": "^2.0.1",
     "lodash.get": "^4.4.2",

--- a/connectors/src/admin/db.ts
+++ b/connectors/src/admin/db.ts
@@ -25,7 +25,6 @@ import {
 import {
   IntercomArticle,
   IntercomCollection,
-  IntercomConnectorState,
 } from "@connectors/lib/models/intercom";
 import logger from "@connectors/logger/logger";
 
@@ -49,7 +48,6 @@ async function main(): Promise<void> {
   await NotionConnectorPageCacheEntry.sync({ alter: true });
   await NotionConnectorResourcesToCheckCacheEntry.sync({ alter: true });
   await GoogleDriveConfig.sync({ alter: true });
-  await IntercomConnectorState.sync({ alter: true });
   await IntercomCollection.sync({ alter: true });
   await IntercomArticle.sync({ alter: true });
 

--- a/connectors/src/admin/db.ts
+++ b/connectors/src/admin/db.ts
@@ -22,6 +22,11 @@ import {
   SlackConfiguration,
   SlackMessages,
 } from "@connectors/lib/models";
+import {
+  IntercomArticle,
+  IntercomCollection,
+  IntercomConnectorState,
+} from "@connectors/lib/models/intercom";
 import logger from "@connectors/logger/logger";
 
 async function main(): Promise<void> {
@@ -44,6 +49,9 @@ async function main(): Promise<void> {
   await NotionConnectorPageCacheEntry.sync({ alter: true });
   await NotionConnectorResourcesToCheckCacheEntry.sync({ alter: true });
   await GoogleDriveConfig.sync({ alter: true });
+  await IntercomConnectorState.sync({ alter: true });
+  await IntercomCollection.sync({ alter: true });
+  await IntercomArticle.sync({ alter: true });
 
   // enable the `unaccent` extension
   await sequelize_conn.query("CREATE EXTENSION IF NOT EXISTS unaccent;");

--- a/connectors/src/connectors/index.ts
+++ b/connectors/src/connectors/index.ts
@@ -21,6 +21,16 @@ import {
 } from "@connectors/connectors/google_drive";
 import { launchGoogleDriveFullSyncWorkflow } from "@connectors/connectors/google_drive/temporal/client";
 import {
+  cleanupIntercomConnector,
+  createIntercomConnector,
+  fullResyncIntercomConnector,
+  resumeIntercomConnector,
+  retrieveIntercomConnectorPermissions,
+  retrieveIntercomResourcesTitles,
+  stopIntercomConnector,
+  updateIntercomConnector,
+} from "@connectors/connectors/intercom";
+import {
   BotEnabledGetter,
   BotToggler,
   ConnectorBatchResourceTitleRetriever,
@@ -73,6 +83,7 @@ export const CREATE_CONNECTOR_BY_TYPE: Record<
   notion: createNotionConnector,
   github: createGithubConnector,
   google_drive: createGoogleDriveConnector,
+  intercom: createIntercomConnector,
 };
 
 export const UPDATE_CONNECTOR_BY_TYPE: Record<
@@ -83,6 +94,7 @@ export const UPDATE_CONNECTOR_BY_TYPE: Record<
   notion: updateNotionConnector,
   github: updateGithubConnector,
   google_drive: updateGoogleDriveConnector,
+  intercom: updateIntercomConnector,
 };
 
 export const STOP_CONNECTOR_BY_TYPE: Record<
@@ -99,6 +111,7 @@ export const STOP_CONNECTOR_BY_TYPE: Record<
     logger.info({ connectorId }, `Stopping Google Drive connector is a no-op.`);
     return new Ok(connectorId);
   },
+  intercom: stopIntercomConnector,
 };
 
 export const DELETE_CONNECTOR_BY_TYPE: Record<
@@ -109,6 +122,7 @@ export const DELETE_CONNECTOR_BY_TYPE: Record<
   notion: cleanupNotionConnector,
   github: cleanupGithubConnector,
   google_drive: cleanupGoogleDriveConnector,
+  intercom: cleanupIntercomConnector,
 };
 
 export const RESUME_CONNECTOR_BY_TYPE: Record<
@@ -124,6 +138,7 @@ export const RESUME_CONNECTOR_BY_TYPE: Record<
   google_drive: async (connectorId: string) => {
     throw new Error(`Not implemented ${connectorId}`);
   },
+  intercom: resumeIntercomConnector,
 };
 
 const toggleBotNotImplemented = async (
@@ -139,6 +154,7 @@ export const TOGGLE_BOT_BY_TYPE: Record<ConnectorProvider, BotToggler> = {
   notion: toggleBotNotImplemented,
   github: toggleBotNotImplemented,
   google_drive: toggleBotNotImplemented,
+  intercom: toggleBotNotImplemented,
 };
 
 const getBotEnabledNotImplemented = async (
@@ -159,6 +175,7 @@ export const GET_BOT_ENABLED_BY_TYPE: Record<
   notion: getBotEnabledNotImplemented,
   github: getBotEnabledNotImplemented,
   google_drive: getBotEnabledNotImplemented,
+  intercom: getBotEnabledNotImplemented,
 };
 
 export const SYNC_CONNECTOR_BY_TYPE: Record<ConnectorProvider, SyncConnector> =
@@ -167,6 +184,7 @@ export const SYNC_CONNECTOR_BY_TYPE: Record<ConnectorProvider, SyncConnector> =
     notion: fullResyncNotionConnector,
     github: fullResyncGithubConnector,
     google_drive: launchGoogleDriveFullSyncWorkflow,
+    intercom: fullResyncIntercomConnector,
   };
 
 export const RETRIEVE_CONNECTOR_PERMISSIONS_BY_TYPE: Record<
@@ -177,6 +195,7 @@ export const RETRIEVE_CONNECTOR_PERMISSIONS_BY_TYPE: Record<
   github: retrieveGithubConnectorPermissions,
   notion: retrieveNotionConnectorPermissions,
   google_drive: retrieveGoogleDriveConnectorPermissions,
+  intercom: retrieveIntercomConnectorPermissions,
 };
 
 export const SET_CONNECTOR_PERMISSIONS_BY_TYPE: Record<
@@ -195,6 +214,13 @@ export const SET_CONNECTOR_PERMISSIONS_BY_TYPE: Record<
     );
   },
   google_drive: setGoogleDriveConnectorPermissions,
+  intercom: async () => {
+    return new Err(
+      new Error(
+        `Setting Intercom connector permissions is not implemented yet.`
+      )
+    );
+  },
 };
 
 export const BATCH_RETRIEVE_RESOURCE_TITLE_BY_TYPE: Record<
@@ -205,6 +231,7 @@ export const BATCH_RETRIEVE_RESOURCE_TITLE_BY_TYPE: Record<
   notion: retrieveNotionResourcesTitles,
   github: retrieveGithubReposTitles,
   google_drive: retrieveGoogleDriveObjectsTitles,
+  intercom: retrieveIntercomResourcesTitles,
 };
 
 export const RETRIEVE_RESOURCE_PARENTS_BY_TYPE: Record<
@@ -215,6 +242,7 @@ export const RETRIEVE_RESOURCE_PARENTS_BY_TYPE: Record<
   google_drive: retrieveGoogleDriveObjectsParents,
   slack: async () => new Ok([]), // Slack is flat
   github: async () => new Ok([]), // Github is flat,
+  intercom: async () => new Ok([]), // Intercom is not truly flat as we can put articles & collections inside collections but will handle this later
 };
 
 export const SET_CONNECTOR_CONFIG_BY_TYPE: Record<
@@ -231,6 +259,9 @@ export const SET_CONNECTOR_CONFIG_BY_TYPE: Record<
     throw new Error("Not implemented");
   },
   google_drive: setGoogleDriveConfig,
+  intercom: async () => {
+    throw new Error("Not implemented");
+  },
 };
 
 export const GET_CONNECTOR_CONFIG_BY_TYPE: Record<
@@ -247,4 +278,7 @@ export const GET_CONNECTOR_CONFIG_BY_TYPE: Record<
     throw new Error("Not implemented");
   },
   google_drive: getGoogleDriveConfig,
+  intercom: async () => {
+    throw new Error("Not implemented");
+  },
 };

--- a/connectors/src/connectors/intercom/index.ts
+++ b/connectors/src/connectors/intercom/index.ts
@@ -1,0 +1,127 @@
+import { validateAccessToken } from "@connectors/connectors/intercom/lib/intercom_api";
+import { ConnectorPermissionRetriever } from "@connectors/connectors/interface";
+import { Connector, ModelId, sequelize_conn } from "@connectors/lib/models";
+import { IntercomConnectorState } from "@connectors/lib/models/intercom";
+import { getAccessTokenFromNango } from "@connectors/lib/nango_helpers";
+import { Err, Ok, Result } from "@connectors/lib/result";
+import logger from "@connectors/logger/logger";
+import { DataSourceConfig } from "@connectors/types/data_source_config";
+import { ConnectorsAPIErrorResponse } from "@connectors/types/errors";
+import { NangoConnectionId } from "@connectors/types/nango_connection_id";
+import {
+  ConnectorPermission,
+  ConnectorResource,
+} from "@connectors/types/resources";
+
+const { NANGO_INTERCOM_CONNECTOR_ID } = process.env;
+
+export async function createIntercomConnector(
+  dataSourceConfig: DataSourceConfig,
+  connectionId: NangoConnectionId
+): Promise<Result<string, Error>> {
+  const nangoConnectionId = connectionId;
+
+  if (!NANGO_INTERCOM_CONNECTOR_ID) {
+    throw new Error("NANGO_INTERCOM_CONNECTOR_ID not set");
+  }
+
+  const accessToken = await getAccessTokenFromNango({
+    connectionId: nangoConnectionId,
+    integrationId: NANGO_INTERCOM_CONNECTOR_ID,
+    useCache: false,
+  });
+
+  if (!validateAccessToken(accessToken)) {
+    return new Err(new Error("Intercom access token is invalid"));
+  }
+
+  try {
+    const connector = await sequelize_conn.transaction(async (t) => {
+      const connector = await Connector.create(
+        {
+          type: "intercom",
+          connectionId: nangoConnectionId,
+          workspaceAPIKey: dataSourceConfig.workspaceAPIKey,
+          workspaceId: dataSourceConfig.workspaceId,
+          dataSourceName: dataSourceConfig.dataSourceName,
+          defaultNewResourcePermission: "read_write",
+        },
+        { transaction: t }
+      );
+      await IntercomConnectorState.create(
+        {
+          connectorId: connector.id,
+        },
+        { transaction: t }
+      );
+
+      return connector;
+    });
+    // @todo Daph lauch workflow await launchIntercomSyncWorkflow(connector.id);
+    return new Ok(connector.id.toString());
+  } catch (e) {
+    logger.error({ error: e }, "Error creating Intercom connector.");
+    return new Err(e as Error);
+  }
+}
+
+export async function updateIntercomConnector(
+  connectorId: ModelId,
+  {
+    connectionId,
+    newDefaultNewResourcePermission,
+  }: {
+    connectionId?: NangoConnectionId | null;
+    newDefaultNewResourcePermission?: ConnectorPermission | null;
+  }
+): Promise<Result<string, ConnectorsAPIErrorResponse>> {
+  console.log({ connectorId, connectionId, newDefaultNewResourcePermission });
+  throw new Error("Not implemented");
+}
+
+export async function cleanupIntercomConnector(
+  connectorId: string
+): Promise<Result<void, Error>> {
+  console.log({ connectorId });
+  throw new Error("Not implemented");
+}
+
+export async function stopIntercomConnector(
+  connectorId: string
+): Promise<Result<string, Error>> {
+  console.log({ connectorId });
+  throw new Error("Not implemented");
+}
+
+export async function resumeIntercomConnector(
+  connectorId: string
+): Promise<Result<string, Error>> {
+  console.log({ connectorId });
+  throw new Error("Not implemented");
+}
+
+export async function fullResyncIntercomConnector(
+  connectorId: string,
+  fromTs: number | null
+): Promise<Result<string, Error>> {
+  console.log({ connectorId, fromTs });
+  throw new Error("Not implemented");
+}
+
+export async function retrieveIntercomConnectorPermissions({
+  connectorId,
+  parentInternalId,
+}: Parameters<ConnectorPermissionRetriever>[0]): Promise<
+  Result<ConnectorResource[], Error>
+> {
+  console.log({ connectorId, parentInternalId });
+  throw new Error("Not implemented");
+}
+
+export async function retrieveIntercomResourcesTitles(
+  connectorId: ModelId,
+  internalIds: string[]
+): Promise<Result<Record<string, string | null>, Error>> {
+  console.log({ connectorId, internalIds });
+  throw new Error("Not implemented");
+}

--- a/connectors/src/connectors/intercom/index.ts
+++ b/connectors/src/connectors/intercom/index.ts
@@ -1,7 +1,6 @@
 import { validateAccessToken } from "@connectors/connectors/intercom/lib/intercom_api";
 import { ConnectorPermissionRetriever } from "@connectors/connectors/interface";
-import { Connector, ModelId, sequelize_conn } from "@connectors/lib/models";
-import { IntercomConnectorState } from "@connectors/lib/models/intercom";
+import { Connector, ModelId } from "@connectors/lib/models";
 import { getAccessTokenFromNango } from "@connectors/lib/nango_helpers";
 import { Err, Ok, Result } from "@connectors/lib/result";
 import logger from "@connectors/logger/logger";
@@ -36,26 +35,13 @@ export async function createIntercomConnector(
   }
 
   try {
-    const connector = await sequelize_conn.transaction(async (t) => {
-      const connector = await Connector.create(
-        {
-          type: "intercom",
-          connectionId: nangoConnectionId,
-          workspaceAPIKey: dataSourceConfig.workspaceAPIKey,
-          workspaceId: dataSourceConfig.workspaceId,
-          dataSourceName: dataSourceConfig.dataSourceName,
-          defaultNewResourcePermission: "read_write",
-        },
-        { transaction: t }
-      );
-      await IntercomConnectorState.create(
-        {
-          connectorId: connector.id,
-        },
-        { transaction: t }
-      );
-
-      return connector;
+    const connector = await Connector.create({
+      type: "intercom",
+      connectionId: nangoConnectionId,
+      workspaceAPIKey: dataSourceConfig.workspaceAPIKey,
+      workspaceId: dataSourceConfig.workspaceId,
+      dataSourceName: dataSourceConfig.dataSourceName,
+      defaultNewResourcePermission: "read_write",
     });
     // @todo Daph lauch workflow await launchIntercomSyncWorkflow(connector.id);
     return new Ok(connector.id.toString());

--- a/connectors/src/connectors/intercom/lib/intercom_api.ts
+++ b/connectors/src/connectors/intercom/lib/intercom_api.ts
@@ -1,0 +1,13 @@
+import { Client } from "intercom-client";
+
+export async function validateAccessToken(notionAccessToken: string) {
+  const intercomClient = new Client({
+    tokenAuth: { token: notionAccessToken },
+  });
+  try {
+    await intercomClient.admins.list(); // trying a simple request
+  } catch (e) {
+    return false;
+  }
+  return true;
+}

--- a/connectors/src/connectors/intercom/lib/intercom_api.ts
+++ b/connectors/src/connectors/intercom/lib/intercom_api.ts
@@ -1,8 +1,8 @@
 import { Client } from "intercom-client";
 
-export async function validateAccessToken(notionAccessToken: string) {
+export async function validateAccessToken(intercomAccessToken: string) {
   const intercomClient = new Client({
-    tokenAuth: { token: notionAccessToken },
+    tokenAuth: { token: intercomAccessToken },
   });
   try {
     await intercomClient.admins.list(); // trying a simple request

--- a/connectors/src/lib/models/intercom.ts
+++ b/connectors/src/lib/models/intercom.ts
@@ -9,50 +9,6 @@ import {
 
 import { Connector, sequelize_conn } from "@connectors/lib/models";
 
-export class IntercomConnectorState extends Model<
-  InferAttributes<IntercomConnectorState>,
-  InferCreationAttributes<IntercomConnectorState>
-> {
-  declare id: CreationOptional<number>;
-  declare createdAt: CreationOptional<Date>;
-  declare updatedAt: CreationOptional<Date>;
-
-  declare lastGarbageCollectionFinishTime?: Date;
-
-  declare connectorId: ForeignKey<Connector["id"]>;
-}
-
-IntercomConnectorState.init(
-  {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
-    createdAt: {
-      type: DataTypes.DATE,
-      allowNull: false,
-      defaultValue: DataTypes.NOW,
-    },
-    updatedAt: {
-      type: DataTypes.DATE,
-      allowNull: false,
-      defaultValue: DataTypes.NOW,
-    },
-    lastGarbageCollectionFinishTime: {
-      type: DataTypes.DATE,
-      allowNull: true,
-    },
-  },
-  {
-    sequelize: sequelize_conn,
-    modelName: "intercom_connector_states",
-    indexes: [{ fields: ["connectorId"], unique: true }],
-  }
-);
-
-Connector.hasOne(IntercomConnectorState);
-
 export class IntercomCollection extends Model<
   InferAttributes<IntercomCollection>,
   InferCreationAttributes<IntercomCollection>
@@ -61,7 +17,7 @@ export class IntercomCollection extends Model<
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
-  declare workspaceId: string;
+  declare intercomWorkspaceId: string;
   declare collectionId: string;
 
   declare helpCenterId: string | null;
@@ -90,7 +46,7 @@ IntercomCollection.init(
       allowNull: false,
       defaultValue: DataTypes.NOW,
     },
-    workspaceId: {
+    intercomWorkspaceId: {
       type: DataTypes.STRING,
       allowNull: false,
     },
@@ -118,7 +74,10 @@ IntercomCollection.init(
   {
     sequelize: sequelize_conn,
     indexes: [
-      { fields: ["workspaceId", "collectionId", "connectorId"], unique: true },
+      {
+        fields: ["intercomWorkspaceId", "collectionId", "connectorId"],
+        unique: true,
+      },
       { fields: ["connectorId"] },
       { fields: ["collectionId"] },
     ],
@@ -135,7 +94,7 @@ export class IntercomArticle extends Model<
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
-  declare workspaceId: string;
+  declare intercomWorkspaceId: string;
   declare articleId: string;
   declare authorId: string;
 
@@ -164,7 +123,7 @@ IntercomArticle.init(
       allowNull: false,
       defaultValue: DataTypes.NOW,
     },
-    workspaceId: {
+    intercomWorkspaceId: {
       type: DataTypes.STRING,
       allowNull: false,
     },
@@ -192,7 +151,10 @@ IntercomArticle.init(
   {
     sequelize: sequelize_conn,
     indexes: [
-      { fields: ["workspaceId", "articleId", "connectorId"], unique: true },
+      {
+        fields: ["intercomWorkspaceId", "articleId", "connectorId"],
+        unique: true,
+      },
       { fields: ["connectorId"] },
       { fields: ["articleId"] },
     ],

--- a/connectors/src/lib/models/intercom.ts
+++ b/connectors/src/lib/models/intercom.ts
@@ -1,0 +1,202 @@
+import {
+  CreationOptional,
+  DataTypes,
+  ForeignKey,
+  InferAttributes,
+  InferCreationAttributes,
+  Model,
+} from "sequelize";
+
+import { Connector, sequelize_conn } from "@connectors/lib/models";
+
+export class IntercomConnectorState extends Model<
+  InferAttributes<IntercomConnectorState>,
+  InferCreationAttributes<IntercomConnectorState>
+> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare lastGarbageCollectionFinishTime?: Date;
+
+  declare connectorId: ForeignKey<Connector["id"]>;
+}
+
+IntercomConnectorState.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    lastGarbageCollectionFinishTime: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    },
+  },
+  {
+    sequelize: sequelize_conn,
+    modelName: "intercom_connector_states",
+    indexes: [{ fields: ["connectorId"], unique: true }],
+  }
+);
+
+Connector.hasOne(IntercomConnectorState);
+
+export class IntercomCollection extends Model<
+  InferAttributes<IntercomCollection>,
+  InferCreationAttributes<IntercomCollection>
+> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare workspaceId: string;
+  declare collectionId: string;
+
+  declare helpCenterId: string | null;
+  declare parentId: string | null;
+
+  declare name: string;
+  declare description: string | null;
+
+  declare connectorId: ForeignKey<Connector["id"]>;
+}
+
+IntercomCollection.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    workspaceId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    collectionId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    helpCenterId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    parentId: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
+    name: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    description: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
+  },
+  {
+    sequelize: sequelize_conn,
+    indexes: [
+      { fields: ["workspaceId", "collectionId", "connectorId"], unique: true },
+      { fields: ["connectorId"] },
+      { fields: ["collectionId"] },
+    ],
+    modelName: "intercom_collections",
+  }
+);
+Connector.hasMany(IntercomCollection);
+
+export class IntercomArticle extends Model<
+  InferAttributes<IntercomArticle>,
+  InferCreationAttributes<IntercomArticle>
+> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare workspaceId: string;
+  declare articleId: string;
+  declare authorId: string;
+
+  declare parentId: string | null;
+  declare parentType: "collection" | null;
+
+  declare state: "draft" | "published";
+
+  declare connectorId: ForeignKey<Connector["id"]>;
+}
+
+IntercomArticle.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    workspaceId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    articleId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    authorId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    parentId: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
+    parentType: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
+    state: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+  },
+  {
+    sequelize: sequelize_conn,
+    indexes: [
+      { fields: ["workspaceId", "articleId", "connectorId"], unique: true },
+      { fields: ["connectorId"] },
+      { fields: ["articleId"] },
+    ],
+    modelName: "intercom_articles",
+  }
+);
+Connector.hasMany(IntercomArticle);

--- a/connectors/src/types/connector.ts
+++ b/connectors/src/types/connector.ts
@@ -5,6 +5,7 @@ const CONNECTOR_PROVIDERS = [
   "notion",
   "github",
   "google_drive",
+  "intercom",
 ] as const;
 export type ConnectorProvider = (typeof CONNECTOR_PROVIDERS)[number];
 


### PR DESCRIPTION
We want to implement a new Intercom connector. In the end we want to sync both Conversations and Help Center, but we will start by the Help Center data. 

A Help Center in Intercom contains a list of Articles that can be put inside Collections. A Collection can contain multiple Articles and sub Collections. (I don't have access to it on our test Intercom but) Intercom allows creating multiple Help Centers. Meaning probably the good level of authorization we will offer will be at the Help Center level. 

There's no webhook for Help Centers so we will have to manage the sync from the regular API. 
I've installed the Intercom Node API: https://github.com/intercom/intercom-node.

Note: Since last version "Sections" have been merged within Collections so we don't have to bother about Sections: https://developers.intercom.com/docs/references/changelog/#help-centers-no-longer-have-sections.

I've created a CasqueDeLumiere Intercom app to create an Intercom App allowing us to use OAuth. I need to create a proper Dust Intercom as this will be the one holding the Dust Intercom App, and then I'll make the tests with CasqueDeLumiere. 

In order to not come up with a huge PR I will try to split them even tho the Connector is not usable yet. 

This PR adds:
- The models to store Intercom connector state, collections and articles. I decided to put the intercom models in a models/intercom.ts file because the file models containing all the models start being quite big. I intend to refactor the others models to move them all in their a dedicated file per connector, in a next PR. 
- The backbone of the lib to create/stop/update/... the Intercom connector. Only the `createConnector` function has been partially filled at this point. 

Requires adding an env var `NANGO_INTERCOM_CONNECTOR_ID` in front and connector. Runbook updated. 

