### PR TITLE
Fix condition about displaying the Gather Feedback on Coming soon Connection

### DIFF
--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -421,12 +421,12 @@ export default function DataSourcesView({
                               })(ds.connectorProvider);
                           }
 
-                          if (isDataSourceAllowedInPlan) {
+                          if (isDataSourceAllowedInPlan && ds.isBuilt) {
                             await handleEnableManagedDataSource(
                               ds.connectorProvider as ConnectorProvider,
                               ds.setupWithSuffix
                             );
-                          } else if (!ds.isBuilt) {
+                          } else if (isDataSourceAllowedInPlan && !ds.isBuilt) {
                             setShowPreviewPopupForProvider(
                               ds.connectorProvider
                             );


### PR DESCRIPTION
No impact has dataSource Intercom was not allowed in the Prod Pro and Free Trial plans so we were showing this modal, but this is the condition we want to have. 