### PR TITLE
Fix copy email subject preview Intercom Connection

### DIFF
--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -584,7 +584,7 @@ export default function DataSourcesView({
                       buttonLabel="Contact us"
                       buttonClick={() => {
                         window.open(
-                          "mailto:team@dust.tt?subject=Intersted in the Intercom connection"
+                          "mailto:team@dust.tt?subject=Early access to the Intercom connection"
                         );
                       }}
                       onClose={() => {


### PR DESCRIPTION
I was not careful with the copy of the default email subject accessible on the Button in the Popup for the new Intercom Connection. 