### PR TITLE
poke: Improve data sources

### DIFF
--- a/front/pages/poke/[wId]/data_sources/[name]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[name]/index.tsx
@@ -1,0 +1,241 @@
+import {
+  Button,
+  ContextItem,
+  DocumentTextIcon,
+  EyeIcon,
+  Page,
+} from "@dust-tt/sparkle";
+import { JsonViewer } from "@textea/json-viewer";
+import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import { useRouter } from "next/router";
+import React, { useEffect, useState } from "react";
+
+import PokeNavbar from "@app/components/poke/PokeNavbar";
+import { getDataSource } from "@app/lib/api/data_sources";
+import { Authenticator, getSession } from "@app/lib/auth";
+import { ConnectorsAPI, ConnectorType } from "@app/lib/connectors_api";
+import { getDisplayNameForDocument } from "@app/lib/data_sources";
+import { useDocuments } from "@app/lib/swr";
+import { timeAgoFrom } from "@app/lib/utils";
+import { DataSourceType } from "@app/types/data_source";
+import { WorkspaceType } from "@app/types/user";
+
+export const getServerSideProps: GetServerSideProps<{
+  owner: WorkspaceType;
+  dataSource: DataSourceType;
+  connector: ConnectorType | null;
+}> = async (context) => {
+  const wId = context.params?.wId;
+  if (!wId || typeof wId !== "string") {
+    return {
+      notFound: true,
+    };
+  }
+
+  const dataSourceName = context.params?.name;
+  if (!dataSourceName || typeof dataSourceName !== "string") {
+    return {
+      notFound: true,
+    };
+  }
+
+  const session = await getSession(context.req, context.res);
+  const auth = await Authenticator.fromSuperUserSession(session, wId);
+  const user = auth.user();
+  const owner = auth.workspace();
+
+  if (!user || !owner) {
+    return {
+      redirect: {
+        destination: "/login",
+        permanent: false,
+      },
+    };
+  }
+
+  if (!auth.isDustSuperUser()) {
+    return {
+      notFound: true,
+    };
+  }
+
+  const dataSource = await getDataSource(auth, dataSourceName);
+  if (!dataSource) {
+    return {
+      notFound: true,
+    };
+  }
+
+  let connector: ConnectorType | null = null;
+  if (dataSource.connectorId) {
+    const connectorRes = await ConnectorsAPI.getConnector(
+      dataSource.connectorId
+    );
+    if (connectorRes.isOk()) {
+      connector = connectorRes.value;
+    }
+  }
+
+  return {
+    props: {
+      owner,
+      dataSource,
+      connector,
+    },
+  };
+};
+
+const DataSourcePage = ({
+  owner,
+  dataSource,
+  connector,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) => {
+  const [limit] = useState(10);
+  const [offset, setOffset] = useState(0);
+
+  const { documents, total, isDocumentsLoading, isDocumentsError } =
+    useDocuments(owner, dataSource, limit, offset);
+
+  const [displayNameByDocId, setDisplayNameByDocId] = useState<
+    Record<string, string>
+  >({});
+
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!isDocumentsLoading && !isDocumentsError) {
+      setDisplayNameByDocId(
+        documents.reduce(
+          (acc, doc) =>
+            Object.assign(acc, {
+              [doc.document_id]: getDisplayNameForDocument(doc),
+            }),
+          {}
+        )
+      );
+    }
+    if (isDocumentsError) {
+      setDisplayNameByDocId({});
+    }
+  }, [documents, isDocumentsLoading, isDocumentsError]);
+
+  let last = offset + limit;
+  if (offset + limit > total) {
+    last = total;
+  }
+
+  return (
+    <div className="min-h-screen bg-structure-50">
+      <PokeNavbar />
+      <div className="mx-auto max-w-4xl">
+        <div className="px-8 py-8"></div>
+        <Page.Vertical align="stretch">
+          <Page.SectionHeader title={`${dataSource.name}`} />
+
+          <div className="my-8 flex flex-col gap-y-4">
+            <JsonViewer value={dataSource} rootName={false} />
+            <JsonViewer value={connector} rootName={false} />
+          </div>
+
+          <div className="mt-4 flex flex-row">
+            <div className="flex flex-1">
+              <div className="flex flex-col">
+                <div className="flex flex-row">
+                  <div className="flex flex-initial gap-x-2">
+                    <Button
+                      variant="tertiary"
+                      disabled={offset < limit}
+                      onClick={() => {
+                        if (offset >= limit) {
+                          setOffset(offset - limit);
+                        } else {
+                          setOffset(0);
+                        }
+                      }}
+                      label="Previous"
+                    />
+                    <Button
+                      variant="tertiary"
+                      label="Next"
+                      disabled={offset + limit >= total}
+                      onClick={() => {
+                        if (offset + limit < total) {
+                          setOffset(offset + limit);
+                        }
+                      }}
+                    />
+                  </div>
+                </div>
+
+                <div className="mt-3 flex flex-auto pl-2 text-sm text-gray-700">
+                  {total > 0 && (
+                    <span>
+                      Showing documents {offset + 1} - {last} of {total}{" "}
+                      documents
+                    </span>
+                  )}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="py-8">
+            <ContextItem.List>
+              {documents.map((d) => (
+                <ContextItem
+                  key={d.document_id}
+                  title={displayNameByDocId[d.document_id]}
+                  visual={
+                    <ContextItem.Visual
+                      visual={({ className }) =>
+                        DocumentTextIcon({
+                          className: className + " text-element-600",
+                        })
+                      }
+                    />
+                  }
+                  action={
+                    <Button.List>
+                      <Button
+                        variant="secondary"
+                        icon={EyeIcon}
+                        onClick={() => {
+                          window.confirm(
+                            "Are you sure you want to access this sensible user data?"
+                          );
+                          void router.push(
+                            `/poke/${owner.sId}/data_sources/${
+                              dataSource.name
+                            }/view?documentId=${encodeURIComponent(
+                              d.document_id
+                            )}`
+                          );
+                        }}
+                        label="View"
+                        labelVisible={false}
+                      />
+                    </Button.List>
+                  }
+                >
+                  <ContextItem.Description>
+                    <div className="pt-2 text-sm text-element-700">
+                      {Math.floor(d.text_size / 1024)} kb,{" "}
+                      {timeAgoFrom(d.timestamp)} ago
+                    </div>
+                  </ContextItem.Description>
+                </ContextItem>
+              ))}
+            </ContextItem.List>
+            {documents.length == 0 ? (
+              <div className="mt-10 flex flex-col items-center justify-center text-sm text-gray-500">
+                <p>Empty</p>
+              </div>
+            ) : null}
+          </div>
+        </Page.Vertical>
+      </div>
+    </div>
+  );
+};
+
+export default DataSourcePage;

--- a/front/pages/poke/[wId]/data_sources/[name]/view.tsx
+++ b/front/pages/poke/[wId]/data_sources/[name]/view.tsx
@@ -1,0 +1,150 @@
+import { Input, Page } from "@dust-tt/sparkle";
+import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+
+import PokeNavbar from "@app/components/poke/PokeNavbar";
+import { getDataSource } from "@app/lib/api/data_sources";
+import { Authenticator, getSession } from "@app/lib/auth";
+import { CoreAPI, CoreAPIDocument } from "@app/lib/core_api";
+import { classNames } from "@app/lib/utils";
+
+export const getServerSideProps: GetServerSideProps<{
+  document: CoreAPIDocument;
+}> = async (context) => {
+  const wId = context.params?.wId;
+  if (!wId || typeof wId !== "string") {
+    return {
+      notFound: true,
+    };
+  }
+
+  const dataSourceName = context.params?.name;
+  if (!dataSourceName || typeof dataSourceName !== "string") {
+    return {
+      notFound: true,
+    };
+  }
+
+  const session = await getSession(context.req, context.res);
+  const auth = await Authenticator.fromSuperUserSession(session, wId);
+  const user = auth.user();
+  const owner = auth.workspace();
+
+  if (!user || !owner) {
+    return {
+      redirect: {
+        destination: "/login",
+        permanent: false,
+      },
+    };
+  }
+
+  if (!auth.isDustSuperUser()) {
+    return {
+      notFound: true,
+    };
+  }
+
+  const dataSource = await getDataSource(auth, context.params?.name as string);
+  if (!dataSource) {
+    return {
+      notFound: true,
+    };
+  }
+
+  const document = await CoreAPI.getDataSourceDocument({
+    projectId: dataSource.dustAPIProjectId,
+    dataSourceName: dataSource.name,
+    documentId: context.query.documentId as string,
+  });
+
+  if (document.isErr()) {
+    return {
+      notFound: true,
+    };
+  }
+
+  return {
+    props: {
+      document: document.value.document,
+    },
+  };
+};
+
+export default function DataSourceUpsert({
+  document,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  return (
+    <div className="min-h-screen bg-structure-50">
+      <PokeNavbar />
+      <div className="mx-auto max-w-4xl">
+        <div className="pt-6">
+          <Page.Vertical align="stretch">
+            <div className="pt-4">
+              <Page.SectionHeader title="Document title" />
+              <div className="pt-4">
+                <Input
+                  placeholder="Document title"
+                  name="document"
+                  disabled={true}
+                  value={document.document_id}
+                />
+              </div>
+            </div>
+
+            <div className="pt-4">
+              <Page.SectionHeader title="Source URL" />
+              <div className="pt-4">
+                <Input
+                  placeholder=""
+                  name="document"
+                  disabled={true}
+                  value={document.source_url || ""}
+                />
+              </div>
+            </div>
+
+            <div className="pt-4">
+              <Page.SectionHeader title="Text content" />
+              <div className="pt-4">
+                <textarea
+                  name="text"
+                  id="text"
+                  rows={20}
+                  readOnly={true}
+                  className={classNames(
+                    "font-mono text-normal block w-full min-w-0 flex-1 rounded-md",
+                    "border-structure-200 bg-structure-50",
+                    "focus:border-gray-300 focus:ring-0"
+                  )}
+                  disabled={true}
+                  value={document.text || ""}
+                />
+              </div>
+            </div>
+
+            <div className="pt-4">
+              <Page.SectionHeader title="Tags" />
+              <div className="pt-4">
+                {document.tags.map((tag, index) => (
+                  <div key={index} className="flex flex-grow flex-row">
+                    <div className="flex flex-1 flex-row gap-8">
+                      <div className="flex flex-1 flex-col">
+                        <Input
+                          className="w-full"
+                          placeholder="Tag"
+                          name="tag"
+                          disabled={true}
+                          value={tag}
+                        />
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </Page.Vertical>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/front/pages/poke/index.tsx
+++ b/front/pages/poke/index.tsx
@@ -87,7 +87,7 @@ const Dashboard = (
             <ul className="mt-4 space-y-4">
               {searchResults.map((ws) => (
                 <Link href={`/poke/${ws.sId}`} key={ws.id}>
-                  <li className="rounded-lg bg-white p-4 shadow transition-colors duration-200 hover:bg-gray-100">
+                  <li className="border-material-100 rounded-lg border bg-white p-4 transition-colors duration-200 hover:bg-gray-100">
                     <h2 className="text-xl font-semibold">{ws.name}</h2>
                     <p className="text-sm text-gray-500">sId: {ws.sId}</p>
                   </li>
@@ -101,7 +101,7 @@ const Dashboard = (
               !isUpgradedWorkspacesError &&
               upgradedWorkspaces.map((ws) => (
                 <Link href={`/poke/${ws.sId}`} key={ws.id}>
-                  <li className="rounded-lg bg-white p-4 shadow transition-colors duration-200 hover:bg-gray-100">
+                  <li className="border-material-100 rounded-lg border bg-white p-4 transition-colors duration-200 hover:bg-gray-100">
                     <h2 className="text-xl font-semibold">{ws.name}</h2>
                     <p className="text-sm text-gray-500">sId: {ws.sId}</p>
                   </li>

--- a/front/pages/poke/plans.tsx
+++ b/front/pages/poke/plans.tsx
@@ -167,7 +167,7 @@ const PlansPage = (
                   <th className="px-4 py-2">Edit</th>
                 </tr>
               </thead>
-              <tbody className="h-full bg-white pb-48 text-gray-700 shadow-md">
+              <tbody className="h-full bg-white pb-48 text-gray-700">
                 {plansToRender?.map((plan) => {
                   const planId = plan.isNewPlan ? "newPlan" : plan.code;
 


### PR DESCRIPTION
- removes count from the workspace page (no more waiting)
- add a data source page that shows dataSource and connector object  + list of documents
- add a document page to see content of a document

![Screenshot from 2023-11-17 12-36-47](https://github.com/dust-tt/dust/assets/15067/aa4398bd-7303-45cc-8d08-6bcdb6d5bab7)
![Screenshot from 2023-11-17 12-36-56](https://github.com/dust-tt/dust/assets/15067/e957d8ef-438d-468f-b69f-6591e9631673)
![Screenshot from 2023-11-17 12-37-02](https://github.com/dust-tt/dust/assets/15067/f53a223a-fa34-4c18-b76c-a2aa4bc485c1)
