### PR TITLE
Truncate Content Fragment when they are too big

### DIFF
--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -188,9 +188,8 @@ export async function renderConversationForModel({
     } else if (messages[i].role === "content_fragment") {
       const c = allowedTokenCount - tokensUsed;
       tokensUsed += c;
-      const truncatedMessage = messages[i];
-      truncatedMessage.content = truncatedMessage.content.substring(0, c);
-      selected.unshift(truncatedMessage);
+      messages[i].content = messages[i].content.substring(0, c);
+      selected.unshift(messages[i]);
     }
   }
 

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -182,6 +182,9 @@ export async function renderConversationForModel({
   // Go backward and accumulate as much as we can within allowedTokenCount.
   const selected: ModelMessageType[] = [];
   for (let i = messages.length - 1; i >= 0; i--) {
+    if (tokensUsed >= allowedTokenCount) {
+      break;
+    }
     const r = messagesCountRes[i];
     if (r.isErr()) {
       return new Err(r.error);

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -185,6 +185,12 @@ export async function renderConversationForModel({
     if (tokensUsed + c <= allowedTokenCount) {
       tokensUsed += c;
       selected.unshift(messages[i]);
+    } else if (messages[i].role === "content_fragment") {
+      const c = allowedTokenCount - tokensUsed;
+      tokensUsed += c;
+      const truncatedMessage = messages[i];
+      truncatedMessage.content = truncatedMessage.content.substring(0, c);
+      selected.unshift(truncatedMessage);
     }
   }
 

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -199,7 +199,6 @@ export async function renderConversationForModel({
       });
     } else if (messages[i].role === "content_fragment") {
       const c = allowedTokenCount - tokensUsed;
-      tokensUsed += c;
       const contentFragmentMessage = messages[i].message;
       if (contentFragmentMessage) {
         if (isContentFragmentType(contentFragmentMessage)) {
@@ -220,6 +219,7 @@ export async function renderConversationForModel({
         }
       }
 
+      tokensUsed += c;
       selected.unshift({
         role: messages[i].role,
         content: messages[i].content,

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -223,8 +223,6 @@ export async function renderConversationForModel({
         name: messages[i].name,
       });
     }
-
-    console.log("selected are ", selected);
   }
 
   logger.info(


### PR DESCRIPTION
Truncate content fragment in prompt generation to fill the context window (vs skipping it).

Next is to notify the user about the truncation.