### PR TITLE
Typed errors in our libs + mapping to HTTP errors

### DIFF
--- a/front/lib/error.ts
+++ b/front/lib/error.ts
@@ -70,3 +70,17 @@ export type APIErrorWithStatusCode = {
   api_error: APIError;
   status_code: number;
 };
+
+/**
+ * Error repported by the Dust Libraries.
+ */
+export type DustErrorType = "invalid_user_input" | "internal_error";
+
+export class DustError extends Error {
+  errorCode: DustErrorType;
+
+  constructor(message: string, errorCode: DustErrorType) {
+    super(message);
+    this.errorCode = errorCode;
+  }
+}


### PR DESCRIPTION
This PR aims at fixing two issues:
- We have a lot of repetitive and **verbose** error handling in our API handlers.
- We often don't have a way to map a library level error to a HTTP level error.

Usage:
```typescript
// lib.ts
async function myLib() {
// ....
return new Err(new DustError(message, "invalid_user_input")); // the errorCode is type checked obviously
}
```

```typescript
// api/w/index.ts

const myLibRes = await myLib();
if (myLibRes.isErr()) {
 // the APIErrorWithStatusCode is derived from the DustError in `apiError()`
// code is shorter, less reptitive, and you can specify the error type from the lib function.
  return apiError(req, res, undefined, myLibres.error);
}
```

