### PR TITLE
enh: qdrant ops

### DIFF
--- a/core/bin/qdrant_migrator.rs
+++ b/core/bin/qdrant_migrator.rs
@@ -117,14 +117,14 @@ fn main() -> Result<()> {
                 {
                     Some(info) => {
                         utils::info(&format!(
-                            "[MAIN] Qdrant collection: cluster={} collection={} status={} \
-                             points_count={}",
-                            qdrant_clients
-                                .main_cluster(&ds.config().qdrant_config)
-                                .to_string(),
+                            "[MAIN] Qdrant collection: collection={} status={} \
+                             points_count={} cluster={} ",
                             ds.qdrant_collection(),
                             info.status.to_string(),
                             info.points_count,
+                            qdrant_clients
+                                .main_cluster(&ds.config().qdrant_config)
+                                .to_string(),
                         ));
                     }
                     None => Err(anyhow!("Qdrant collection not found"))?,
@@ -142,13 +142,13 @@ fn main() -> Result<()> {
                         {
                             Some(info) => {
                                 utils::info(&format!(
-                            "[SHADOW] Qdrant collection: cluster={} collection={} status={}\
-                             points_count={}",
-                            shadow_write_cluster.to_string(),
-                            ds.qdrant_collection(),
-                            info.status.to_string(),
-                            info.points_count,
-                        ));
+                                    "[SHADOW] Qdrant collection: collection={} status={} \
+                             points_count={} cluster={}",
+                                    ds.qdrant_collection(),
+                                    info.status.to_string(),
+                                    info.points_count,
+                                    shadow_write_cluster.to_string(),
+                                ));
                             }
                             None => Err(anyhow!("Qdrant collection not found"))?,
                         }
@@ -253,13 +253,13 @@ fn main() -> Result<()> {
                         match utils::confirm(&format!(
                             "[DANGER] Are you sure you want to delete this qdrant \
                              shadow_write_cluster collection? \
-                             (this is definitive) shadow_write_cluster={} points_count={}",
+                             (this is definitive) points_count={} shadow_write_cluster={}",
+                            info.points_count,
                             match qdrant_clients.shadow_write_cluster(&ds.config().qdrant_config) {
                                 Some(cluster) => cluster.to_string(),
                                 None => "none".to_string(),
                             }
                             .to_string(),
-                            info.points_count,
                         ))? {
                             true => (),
                             false => Err(anyhow!("Aborted"))?,

--- a/front/lib/core_api.ts
+++ b/front/lib/core_api.ts
@@ -36,13 +36,18 @@ export type CoreAPIDataset = CoreAPIDatasetWithoutData & {
   data: { [key: string]: any }[];
 };
 
+export type QdrantCluster = "main-0" | "dedicated-0";
+
 export type CoreAPIDataSourceConfig = {
   provider_id: string;
   model_id: string;
   extras?: any | null;
   splitter_id: string;
   max_chunk_size: number;
-  use_cache: boolean;
+  qdrant_config: {
+    cluster: QdrantCluster;
+    shadow_write_cluster: QdrantCluster | null;
+  } | null;
 };
 
 export type CoreAPIDataSource = {

--- a/front/migrations/20230522_slack_doc_rename_incident.ts
+++ b/front/migrations/20230522_slack_doc_rename_incident.ts
@@ -58,7 +58,7 @@ async function main() {
             model_id: dataSourceModelId,
             splitter_id: "base_v0",
             max_chunk_size: dataSourceMaxChunkSize,
-            use_cache: false,
+            qdrant_config: null,
           },
           credentials,
         });

--- a/front/migrations/20230803_wipe_gdrive_connectors.ts
+++ b/front/migrations/20230803_wipe_gdrive_connectors.ts
@@ -47,7 +47,7 @@ async function main() {
         model_id: "text-embedding-ada-002",
         splitter_id: "base_v0",
         max_chunk_size: 256,
-        use_cache: false,
+        qdrant_config: null,
       },
       credentials: dustManagedCredentials(),
     });

--- a/front/pages/api/w/[wId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/index.ts
@@ -6,8 +6,11 @@ import { Authenticator, getSession } from "@app/lib/auth";
 import { CoreAPI } from "@app/lib/core_api";
 import { ReturnedAPIErrorType } from "@app/lib/error";
 import { DataSource } from "@app/lib/models";
+import { FREE_TEST_PLAN_CODE } from "@app/lib/plans/plan_codes";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import { DataSourceType } from "@app/types/data_source";
+
+const { NODE_ENV } = process.env;
 
 export type GetDataSourcesResponseBody = {
   dataSources: Array<DataSourceType>;
@@ -133,7 +136,16 @@ async function handler(
           model_id: dataSourceModelId,
           splitter_id: "base_v0",
           max_chunk_size: dataSourceMaxChunkSize,
-          use_cache: false,
+          qdrant_config:
+            plan.code !== FREE_TEST_PLAN_CODE && NODE_ENV === "production"
+              ? {
+                  cluster: "dedicated-0",
+                  shadow_write_cluster: null,
+                }
+              : {
+                  cluster: "main-0",
+                  shadow_write_cluster: null,
+                },
         },
         credentials,
       });

--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -15,6 +15,8 @@ import logger from "@app/logger/logger";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import { DataSourceType } from "@app/types/data_source";
 
+const { NODE_ENV } = process.env;
+
 export type PostManagedDataSourceResponseBody = {
   dataSource: DataSourceType;
   connector: ConnectorType;
@@ -193,7 +195,16 @@ async function handler(
           model_id: dataSourceModelId,
           splitter_id: "base_v0",
           max_chunk_size: dataSourceMaxChunkSize,
-          use_cache: false,
+          qdrant_config:
+            NODE_ENV === "production"
+              ? {
+                  cluster: "dedicated-0",
+                  shadow_write_cluster: null,
+                }
+              : {
+                  cluster: "main-0",
+                  shadow_write_cluster: null,
+                },
         },
         credentials,
       });


### PR DESCRIPTION
- Nits to output of `qdrant_migrator`
- Automatically create new data sources that are connected or from paying users on `dedicated-0` in production