### PR TITLE
[Doom - Downgrade] Revoke users when subscription canceled

### DIFF
--- a/front/lib/email.ts
+++ b/front/lib/email.ts
@@ -24,8 +24,8 @@ export async function sendEmail(email: string, message: any) {
     );
   } catch (error) {
     logger.error(
-      { error, email },
-      "Error sending email to admin about subscription cancellation."
+      { error, email, subject: message.subject },
+      "Error sending email."
     );
   }
 }

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -12,7 +12,7 @@ import {
   sendReactivateSubscriptionEmail,
 } from "@app/lib/email";
 import { ReturnedAPIErrorType } from "@app/lib/error";
-import { Plan, Subscription, Workspace } from "@app/lib/models";
+import { Membership, Plan, Subscription, Workspace } from "@app/lib/models";
 import { PlanInvitation } from "@app/lib/models/plan";
 import { generateModelSId } from "@app/lib/utils";
 import logger from "@app/logger/logger";
@@ -368,6 +368,7 @@ async function handler(
               status: "ended",
               endDate: new Date(),
             });
+            await revokeUsersForDowngrade(activeSubscription.workspace.sId);
             await sendOpsEmail(activeSubscription.workspace.sId);
           } else {
             logger.warn(
@@ -394,4 +395,21 @@ async function handler(
   }
 }
 
+/**
+ * Remove everybody except the most tenured admin
+ * @param workspaceId
+ */
+async function revokeUsersForDowngrade(workspaceId: string) {
+  const memberships = await Membership.findAll({
+    where: { workspaceId },
+    order: [["createdAt", "ASC"]],
+  });
+  const adminMemberships = memberships.filter((m) => m.role === "admin");
+  // the first membership with role admin will not be revoked
+  adminMemberships.shift();
+  const nonAdminMemberships = memberships.filter((m) => m.role !== "admin");
+  for (const membership of [...adminMemberships, ...nonAdminMemberships]) {
+    await membership.update({ role: "revoked" });
+  }
+}
 export default withLogging(handler);

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -368,7 +368,7 @@ async function handler(
               status: "ended",
               endDate: new Date(),
             });
-            await revokeUsersForDowngrade(activeSubscription.workspace.sId);
+            await revokeUsersForDowngrade(activeSubscription.workspace.id);
             await sendOpsEmail(activeSubscription.workspace.sId);
           } else {
             logger.warn(
@@ -399,7 +399,7 @@ async function handler(
  * Remove everybody except the most tenured admin
  * @param workspaceId
  */
-async function revokeUsersForDowngrade(workspaceId: string) {
+async function revokeUsersForDowngrade(workspaceId: number) {
   const memberships = await Membership.findAll({
     where: { workspaceId },
     order: [["createdAt", "ASC"]],


### PR DESCRIPTION
Related [task](https://github.com/dust-tt/dust/issues/2483)

### Notes
- Safety checked with @daph that stripe prevents spoofing the webhook calls :+1: (retrospectively obvious they'd do that but better safe than sorry)
- Did not use api calls to revoke users since 1. this is already a handler 2. the api calls upgrade subscription count which in this case isn't warranted