### PR TITLE
[Doom - Downgrade] Limit downgraded retrieval on static datasources

### DIFF
--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -32,7 +32,6 @@ import {
   ConversationType,
   UserMessageType,
 } from "@app/types/assistant/conversation";
-import { PlanType } from "@app/types/plan";
 
 import { getDataSources } from "../../data_sources";
 


### PR DESCRIPTION
Related [task](https://github.com/dust-tt/dust/issues/2484)

### Technical notes
The check on datasource count is not too costly and is only performed when limits are set and the assistant actually uses static DS => fine IMHO

However for the following document limit count we will probably need to proceed differently (too costly to count all docs every time IMHO)