### PR TITLE
core: data_source block, replace variables in filter.tags

### DIFF
--- a/core/src/blocks/data_source.rs
+++ b/core/src/blocks/data_source.rs
@@ -55,12 +55,8 @@ impl DataSource {
         })
     }
 
-    fn replace_query_variables(text: &str, env: &Env) -> Result<String> {
-        replace_variables_in_string(text, "query", env)
-    }
-
     fn query(&self, env: &Env) -> Result<String> {
-        let mut query = Self::replace_query_variables(&self.query, env)?;
+        let mut query = replace_variables_in_string(&self.query, "query", env)?;
 
         // replace <DUST_TRIPLE_BACKTICKS> with ```
         query = query.replace("<DUST_TRIPLE_BACKTICKS>", "```");
@@ -236,7 +232,37 @@ impl Block for DataSource {
 
         let filter = match config {
             Some(v) => match v.get("filter") {
-                Some(v) => Some(SearchFilter::from_json_str(v.to_string().as_str())?),
+                Some(v) => {
+                    let mut filter = SearchFilter::from_json_str(v.to_string().as_str())?;
+
+                    match filter.tags.as_mut() {
+                        Some(tags) => {
+                            // define a function
+                            let replace_tags = |tags: &mut Vec<String>, field: &str| {
+                                for t in tags.iter_mut() {
+                                    *t = replace_variables_in_string(t, field, env)?;
+                                }
+                                Ok::<_, anyhow::Error>(())
+                            };
+
+                            match tags.is_in.as_mut() {
+                                Some(is_in) => {
+                                    replace_tags(is_in, "filter.tags.is_in")?;
+                                }
+                                None => (),
+                            };
+                            match tags.is_not.as_mut() {
+                                Some(is_not) => {
+                                    replace_tags(is_not, "filter.tags.is_not")?;
+                                }
+                                None => (),
+                            };
+                        }
+                        None => (),
+                    };
+
+                    Some(filter)
+                }
                 _ => None,
             },
             _ => None,

--- a/core/src/blocks/data_source.rs
+++ b/core/src/blocks/data_source.rs
@@ -237,7 +237,6 @@ impl Block for DataSource {
 
                     match filter.tags.as_mut() {
                         Some(tags) => {
-                            // define a function
                             let replace_tags = |tags: &mut Vec<String>, field: &str| {
                                 for t in tags.iter_mut() {
                                     *t = replace_variables_in_string(t, field, env)?;

--- a/docs/src/pages/core-blocks.mdx
+++ b/docs/src/pages/core-blocks.mdx
@@ -454,5 +454,8 @@ for more details about how documents are chunked to enable semantic search.
       "timestamp": {"gt": 1675215950729, "lt": 1680012404017}
     }
     ```
+    The `tags.in` and `tags.not` values can be templated using the
+    [Tera](https://keats.github.io/tera/docs/#templates) templating language (see the [LLM
+    block](/core-blocks#llm-block) documentation for more details on templating).
   </Property>
 </Properties>


### PR DESCRIPTION
- This PR aims to allow the replacement of variables in the tags provided as config to a `data_source` block.

The use-case goes as follow:

The app receive as input a tag to filter on. The app, applies filtering received as input (or other block output) on a data source block for parameterized filtering of the retrieval step.

![Screenshot from 2023-11-21 17-15-43](https://github.com/dust-tt/dust/assets/15067/4a41709d-63eb-4540-b6b8-0bee55cb472b)
