### PR TITLE
Gdrive Connector: log tags when failing to upsert document

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -482,18 +482,23 @@ async function syncOneFile(
     parents.push(file.id);
     parents.reverse();
 
-    await upsertToDatasource({
-      dataSourceConfig,
-      documentId,
-      documentText: documentContent,
-      documentUrl: file.webViewLink,
-      timestampMs: file.updatedAtMs,
-      tags,
-      parents: parents,
-      upsertContext: {
-        sync_type: isBatchSync ? "batch" : "incremental",
-      },
-    });
+    try {
+      await upsertToDatasource({
+        dataSourceConfig,
+        documentId,
+        documentText: documentContent,
+        documentUrl: file.webViewLink,
+        timestampMs: file.updatedAtMs,
+        tags,
+        parents: parents,
+        upsertContext: {
+          sync_type: isBatchSync ? "batch" : "incremental",
+        },
+      });
+    } catch (e) {
+      logger.error({ error: e, tags }, "Failed to upsert document");
+      throw e;
+    }
     upsertTimestampMs = file.updatedAtMs;
   } else {
     logger.info(


### PR DESCRIPTION
Just adding a log to understand what tags are in the document that is blocked.
Context: https://dust4ai.slack.com/archives/C05F84CFP0E/p1700609031417019