### PR TITLE
Set name for Intercom tables index

### DIFF
--- a/connectors/src/lib/models/intercom.ts
+++ b/connectors/src/lib/models/intercom.ts
@@ -77,6 +77,7 @@ IntercomCollection.init(
       {
         fields: ["intercomWorkspaceId", "collectionId", "connectorId"],
         unique: true,
+        name: "intercom_workspace_collection_connector_idx",
       },
       { fields: ["connectorId"] },
       { fields: ["collectionId"] },
@@ -154,6 +155,7 @@ IntercomArticle.init(
       {
         fields: ["intercomWorkspaceId", "articleId", "connectorId"],
         unique: true,
+        name: "intercom_workspace_article_connector_idx",
       },
       { fields: ["connectorId"] },
       { fields: ["articleId"] },


### PR DESCRIPTION
When the default name of an index is too long, Sequelize is not happy and we have this error when running init-db on connectors: 

```
{"level":"error","time":1700657348725,"pid":40781,"hostname":"Daphnes-MacBook-Pro.local","error":{"type":"DatabaseError","message":"relation \"intercom_collections_intercom_workspace_id_collection_id_connec\" already exists"
```

Next step is cleaning the old index. 
Needs to run `./admin/init_db.sh` on Connectors -> can be run directly after deployment as the code does not need to be deployed first.