### PR TITLE
Move to claude2.1

### DIFF
--- a/core/src/providers/anthropic.rs
+++ b/core/src/providers/anthropic.rs
@@ -82,15 +82,15 @@ impl AnthropicLLM {
             .iter()
             .map(|cm| -> String {
                 format!(
-                    "\n\n{}: {}{}",
+                    "{}: {}{}",
                     match cm.role {
-                        ChatMessageRole::System => "Human",
-                        ChatMessageRole::Assistant => "Assistant",
-                        ChatMessageRole::User => "Human",
-                        ChatMessageRole::Function => "Human",
+                        ChatMessageRole::System => "",
+                        ChatMessageRole::Assistant => "\n\nAssistant",
+                        ChatMessageRole::User => "\n\nHuman",
+                        ChatMessageRole::Function => "\n\nHuman",
                     },
                     match cm.role {
-                        ChatMessageRole::System => "[system_instructions] ".to_string(),
+                        ChatMessageRole::System => "".to_string(),
                         ChatMessageRole::Assistant => "".to_string(),
                         ChatMessageRole::User => match cm.name.as_ref() {
                             Some(name) => format!("[user: {}] ", name),
@@ -444,7 +444,11 @@ impl LLM for AnthropicLLM {
     }
 
     fn context_size(&self) -> usize {
-        100000
+        if self.id.starts_with("claude-2.1") {
+            200000
+        } else {
+            100000
+        }
     }
 
     async fn generate(

--- a/docs/src/pages/conversations.mdx
+++ b/docs/src/pages/conversations.mdx
@@ -455,8 +455,8 @@ The `agent_error` event is sent whenever an error occured durint the AgentMessag
       <Property name="mentions" type="[]{configurationId}">
         Mentions are a way to trigger the response of an assistant in a message. They are an array
         of objects with a single `configurationId` field which points the assistant being mentioned.
-        Available global assistant `configurationId` are: `helper`, `dust`, `gpt-3.5-turbo`,
-        `gpt-4`, `claude-2`, `claude-instant-1`, `slack`, `google_drive`, `notion`, `github`. To
+        Available global assistant `configurationId` are: `helper`, `dust`, `gpt3.5-turbo`,
+        `gpt4`, `claude`, `claude-instant`, `slack`, `google_drive`, `notion`, `github`. To
         mention custom assistants, you can find the assistant `configurationId` in the URL of the
         assistant page.
       </Property>

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -48,9 +48,9 @@ export const GPT_3_5_TURBO_MODEL_CONFIG = {
 
 export const CLAUDE_DEFAULT_MODEL_CONFIG = {
   providerId: "anthropic",
-  modelId: "claude-2",
+  modelId: "claude-2.1",
   displayName: "Claude 2",
-  contextSize: 100000,
+  contextSize: 200000,
   recommendedTopK: 32,
   largeModel: true,
 } as const;

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -46,9 +46,22 @@ export const GPT_3_5_TURBO_MODEL_CONFIG = {
   largeModel: false,
 } as const;
 
+export const CLAUDE_2_1_MODEL_ID = "claude-2.1" as const;
+export const CLAUDE_2_MODEL_ID = "claude-2" as const;
+export const CLAUDE_INSTANT_1_2_MODEL_ID = "claude-instant-1.2" as const;
+
+export const CLAUDE_LEGACY_2_MODEL_CONFIG = {
+  providerId: "anthropic",
+  modelId: CLAUDE_2_MODEL_ID,
+  displayName: "Claude 2",
+  contextSize: 100000,
+  recommendedTopK: 32,
+  largeModel: true,
+} as const;
+
 export const CLAUDE_DEFAULT_MODEL_CONFIG = {
   providerId: "anthropic",
-  modelId: "claude-2.1",
+  modelId: CLAUDE_2_1_MODEL_ID,
   displayName: "Claude 2",
   contextSize: 200000,
   recommendedTopK: 32,
@@ -57,16 +70,18 @@ export const CLAUDE_DEFAULT_MODEL_CONFIG = {
 
 export const CLAUDE_INSTANT_DEFAULT_MODEL_CONFIG = {
   providerId: "anthropic",
-  modelId: "claude-instant-1.2",
+  modelId: CLAUDE_INSTANT_1_2_MODEL_ID,
   displayName: "Claude Instant 1.2",
   contextSize: 100000,
   recommendedTopK: 32,
   largeModel: false,
 } as const;
 
+export const MISTRAL_7B_INSTRUCT_MODEL_ID = "mistral_7B_instruct" as const;
+
 export const MISTRAL_7B_DEFAULT_MODEL_CONFIG = {
   providerId: "textsynth",
-  modelId: "mistral_7B_instruct",
+  modelId: MISTRAL_7B_INSTRUCT_MODEL_ID,
   displayName: "Mistral 7B",
   contextSize: 8192,
   recommendedTopK: 16,
@@ -79,6 +94,7 @@ export const SUPPORTED_MODEL_CONFIGS = [
   GPT_4_MODEL_CONFIG,
   GPT_4_TURBO_MODEL_CONFIG,
   CLAUDE_DEFAULT_MODEL_CONFIG,
+  CLAUDE_LEGACY_2_MODEL_CONFIG,
   CLAUDE_INSTANT_DEFAULT_MODEL_CONFIG,
   MISTRAL_7B_DEFAULT_MODEL_CONFIG,
 ] as const;

--- a/front/migrations/20231113_migrate_assistants_models.ts
+++ b/front/migrations/20231113_migrate_assistants_models.ts
@@ -1,5 +1,6 @@
 import {
-  GPT_3_5_TURBO_MODEL_ID,
+  CLAUDE_2_1_MODEL_ID,
+  // GPT_3_5_TURBO_MODEL_ID,
   // GPT_4_TURBO_MODEL_ID,
 } from "@app/lib/assistant";
 import {
@@ -21,7 +22,7 @@ const { LIVE, WORKSPACE } = process.env;
 
 // claude-2 are being replaced by claude-2.1
 const FROM_MODELS = ["claude-2"];
-const TO_MODEL = "claude-2.1";
+const TO_MODEL = CLAUDE_2_1_MODEL_ID;
 
 async function updateWorkspaceAssistants(wId: string) {
   // console.log(`Updating agents for workspace ${wId}...`);
@@ -59,9 +60,19 @@ async function updateWorkspaceAssistants(wId: string) {
       if (LIVE) {
         const oldModel = g.modelId;
         await g.update({ modelId: TO_MODEL });
-        console.log("Updated", c.sId, c.name, "from " + oldModel);
+        console.log(
+          "Updated",
+          c.sId,
+          c.name,
+          "from " + oldModel + " to " + TO_MODEL
+        );
       } else {
-        console.log("Would update", c.sId, c.name, "from " + g.modelId);
+        console.log(
+          "Would update",
+          c.sId,
+          c.name,
+          "from " + g.modelId + " to " + TO_MODEL
+        );
       }
     }
   }

--- a/front/migrations/20231113_migrate_assistants_models.ts
+++ b/front/migrations/20231113_migrate_assistants_models.ts
@@ -16,8 +16,12 @@ const { LIVE, WORKSPACE } = process.env;
 // const TO_MODEL = GPT_4_TURBO_MODEL_ID;
 
 // GPT-3.5 Turbo and GPT-3.5 Turbo 16k are being replaced by GPT-3.5 Turbo 1106
-const FROM_MODELS = ["gpt-3.5-turbo", "gpt-3.5-turbo-16k"];
-const TO_MODEL = GPT_3_5_TURBO_MODEL_ID;
+// const FROM_MODELS = ["gpt-3.5-turbo", "gpt-3.5-turbo-16k"];
+// const TO_MODEL = GPT_3_5_TURBO_MODEL_ID;
+
+// claude-2 are being replaced by claude-2.1
+const FROM_MODELS = ["claude-2"];
+const TO_MODEL = "claude-2.1";
 
 async function updateWorkspaceAssistants(wId: string) {
   // console.log(`Updating agents for workspace ${wId}...`);

--- a/front/pages/api/w/[wId]/providers/[pId]/models.ts
+++ b/front/pages/api/w/[wId]/providers/[pId]/models.ts
@@ -213,6 +213,7 @@ async function handler(
         case "anthropic":
           const anthropic_models = [
             { id: "claude-2" },
+            { id: "claude-2.1" },
             { id: "claude-instant-1.2" },
           ];
           res.status(200).json({ models: anthropic_models });


### PR DESCRIPTION
- Follows new prompting instructions around system prompting for anthropic models
- Use claude-2.1 for @claude
- Backward support for claude-2 while we migrate assistants

Deploy:
- Deploy `core` (tested this format works with current models)
- Deploy `front`
- Run migration

Follow-up PR to remove `CLAUDE_LEGACY_2_MODEL_CONFIG`