### PR TITLE
Gdrive: Ensure we have the valid rights before creating the connector

### DIFF
--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -61,35 +61,44 @@ export async function createGoogleDriveConnector(
         const driveClient = await getDriveClient(nangoConnectionId);
 
         // Sanity checks to confirm we have sufficient permissions
-        const sanityCheckAbout = await driveClient.about.get({ fields: "*" });
-        if (sanityCheckAbout.status !== 200) {
-          throw new Error(
-            `Could not get google drive info. Error message: ${
-              sanityCheckAbout.statusText || "unknown"
-            }`
-          );
-        }
-        const sanityCheckFilesGet = await driveClient.files.get({
-          fileId: "root",
-        });
-        if (sanityCheckFilesGet.status !== 200) {
-          throw new Error(
-            `Could not call google drive files get. Error message: ${
-              sanityCheckFilesGet.statusText || "unknown"
-            }`
-          );
-        }
-        const sanityCheckFilesList = await driveClient.drives.list({
-          pageSize: 10,
-          fields: "nextPageToken, drives(id, name)",
-        });
-        if (sanityCheckFilesList.status !== 200) {
-          throw new Error(
-            `Could not call google drive files list. Error message: ${
-              sanityCheckFilesList.statusText || "unknown"
-            }`
-          );
-        }
+        Promise.all([
+          driveClient.about.get({ fields: "*" }),
+          driveClient.files.get({ fileId: "root" }),
+          driveClient.drives.list({
+            pageSize: 10,
+            fields: "nextPageToken, drives(id, name)",
+          }),
+        ])
+          .then(
+            ([sanityCheckAbout, sanityCheckFilesGet, sanityCheckFilesList]) => {
+              if (sanityCheckAbout.status !== 200) {
+                throw new Error(
+                  `Could not get google drive info. Error message: ${
+                    sanityCheckAbout.statusText || "unknown"
+                  }`
+                );
+              }
+              if (sanityCheckFilesGet.status !== 200) {
+                throw new Error(
+                  `Could not call google drive files get. Error message: ${
+                    sanityCheckFilesGet.statusText || "unknown"
+                  }`
+                );
+              }
+              if (sanityCheckFilesList.status !== 200) {
+                throw new Error(
+                  `Could not call google drive files list. Error message: ${
+                    sanityCheckFilesList.statusText || "unknown"
+                  }`
+                );
+              }
+            }
+          )
+          .catch(() => {
+            throw new Error(
+              "Error trying to check sufficient permissions from Google."
+            );
+          });
 
         const connector = await Connector.create(
           {

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -59,11 +59,34 @@ export async function createGoogleDriveConnector(
           throw new Error("NANGO_GOOGLE_DRIVE_CONNECTOR_ID is not defined");
         }
         const driveClient = await getDriveClient(nangoConnectionId);
-        const sanityCheckRes = await driveClient.about.get({ fields: "*" });
-        if (sanityCheckRes.status !== 200) {
+
+        // Sanity checks to confirm we have sufficient permissions
+        const sanityCheckAbout = await driveClient.about.get({ fields: "*" });
+        if (sanityCheckAbout.status !== 200) {
           throw new Error(
             `Could not get google drive info. Error message: ${
-              sanityCheckRes.statusText || "unknown"
+              sanityCheckAbout.statusText || "unknown"
+            }`
+          );
+        }
+        const sanityCheckFilesGet = await driveClient.files.get({
+          fileId: "root",
+        });
+        if (sanityCheckFilesGet.status !== 200) {
+          throw new Error(
+            `Could not call google drive files get. Error message: ${
+              sanityCheckFilesGet.statusText || "unknown"
+            }`
+          );
+        }
+        const sanityCheckFilesList = await driveClient.drives.list({
+          pageSize: 10,
+          fields: "nextPageToken, drives(id, name)",
+        });
+        if (sanityCheckFilesList.status !== 200) {
+          throw new Error(
+            `Could not call google drive files list. Error message: ${
+              sanityCheckFilesList.statusText || "unknown"
             }`
           );
         }


### PR DESCRIPTION
https://github.com/dust-tt/tasks/issues/247

We now display an error if we don't have both required permission (instead of allowing it and then breaking in the connector). 

Error is ugly but that was already the case before, so won't fix in this PR 🙏🏻 
<img width="916" alt="Screenshot 2023-11-22 at 17 53 39" src="https://github.com/dust-tt/dust/assets/3803406/33b8b8e0-fa39-4541-8a5b-84935bbf52bf">


