### PR TITLE
core database: batch_upsert validation + save a bunch of clones

### DIFF
--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -1960,7 +1960,7 @@ async fn databases_rows_upsert(
             ),
             Some(db) => {
                 match db
-                    .batch_upsert_rows(state.store.clone(), &table_id, &payload.contents, truncate)
+                    .batch_upsert_rows(state.store.clone(), &table_id, payload.contents, truncate)
                     .await
                 {
                     Err(e) => error_response(

--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -1942,31 +1942,45 @@ async fn databases_rows_upsert(
 
     match state
         .store
-        .batch_upsert_database_rows(
-            &project,
-            &data_source_id,
-            &database_id,
-            &table_id,
-            &payload.contents,
-            truncate,
-        )
+        .load_database(&project, &data_source_id, &database_id)
         .await
     {
         Err(e) => error_response(
             StatusCode::INTERNAL_SERVER_ERROR,
             "internal_server_error",
-            "Failed to upsert database rows",
+            "Failed to retrieve database",
             Some(e),
         ),
-        Ok(()) => (
-            StatusCode::OK,
-            Json(APIResponse {
-                error: None,
-                response: Some(json!({
-                    "success": true
-                })),
-            }),
-        ),
+        Ok(db) => match db {
+            None => error_response(
+                StatusCode::NOT_FOUND,
+                "database_not_found",
+                &format!("No database found for id `{}`", database_id),
+                None,
+            ),
+            Some(db) => {
+                match db
+                    .batch_upsert_rows(state.store.clone(), &table_id, &payload.contents, truncate)
+                    .await
+                {
+                    Err(e) => error_response(
+                        StatusCode::BAD_REQUEST,
+                        "invalid_database_rows_content",
+                        "The rows content is invalid",
+                        Some(e),
+                    ),
+                    Ok(()) => (
+                        StatusCode::OK,
+                        Json(APIResponse {
+                            error: None,
+                            response: Some(json!({
+                                "success": true
+                            })),
+                        }),
+                    ),
+                }
+            }
+        },
     }
 }
 

--- a/core/src/databases/table_schema.rs
+++ b/core/src/databases/table_schema.rs
@@ -234,14 +234,42 @@ mod tests {
     }
 
     #[test]
+    fn test_table_schema_from_invalid_rows() -> Result<()> {
+        let row_1 = json!({
+            "field1": 1,
+            "field2": 1.2,
+            "field3": "text",
+            "field4": true,
+            "field6": ["array", "elements"],
+            "field7": {"key": "value"}
+        });
+        let row_2 = json!({
+            "field1": 2,
+            "field2": 2.4,
+            "field3": "more text",
+            "field4": false,
+            "field5": "not null anymore",
+            "field6": ["more", "elements"],
+            "field7": {"anotherKey": "anotherValue"}
+        });
+        let rows = &vec![
+            DatabaseRow::new(utils::now(), Some("1".to_string()), row_1),
+            DatabaseRow::new(utils::now(), Some("2".to_string()), row_2),
+        ];
+
+        match TableSchema::from_rows(rows) {
+            Ok(_) => Err(anyhow!("Schema should have failed due to invalid rows.")),
+            Err(_) => Ok(()),
+        }
+    }
+
+    #[test]
     fn test_table_schema_from_rows_conflicting_types() {
         let row_1 = json!({
             "field1": 1,
             "field2": 1.2,
             "field3": "text",
             "field4": true,
-            // "field6": ["array", "elements"],
-            // "field7": {"key": "value"}
         });
         let row_2 = json!({
             "field1": 2,
@@ -249,8 +277,6 @@ mod tests {
             "field3": "more text",
             "field4": "this was a bool before",
             "field5": "not null anymore",
-            // "field6": ["more", "elements"],
-            // "field7": {"anotherKey": "anotherValue"}
         });
         let row_3 = json!({
             "field1": "now it's a text field",

--- a/core/src/databases/table_schema.rs
+++ b/core/src/databases/table_schema.rs
@@ -195,8 +195,8 @@ mod tests {
             "field2": 1.2,
             "field3": "text",
             "field4": true,
-            "field6": ["array", "elements"],
-            "field7": {"key": "value"}
+            // "field6": ["array", "elements"],
+            // "field7": {"key": "value"}
         });
         let row_2 = json!({
             "field1": 2,
@@ -204,8 +204,8 @@ mod tests {
             "field3": "more text",
             "field4": false,
             "field5": "not null anymore",
-            "field6": ["more", "elements"],
-            "field7": {"anotherKey": "anotherValue"}
+            // "field6": ["more", "elements"],
+            // "field7": {"anotherKey": "anotherValue"}
         });
         let rows = &vec![
             DatabaseRow::new(utils::now(), Some("1".to_string()), row_1),
@@ -219,8 +219,8 @@ mod tests {
             ("field3", TableSchemaFieldType::Text),
             ("field4", TableSchemaFieldType::Bool),
             ("field5", TableSchemaFieldType::Text),
-            ("field6", TableSchemaFieldType::Text),
-            ("field7", TableSchemaFieldType::Text),
+            // ("field6", TableSchemaFieldType::Text),
+            // ("field7", TableSchemaFieldType::Text),
         ]
         .iter()
         .map(|(field_id, field_type)| (field_id.to_string(), field_type.clone()))
@@ -240,8 +240,8 @@ mod tests {
             "field2": 1.2,
             "field3": "text",
             "field4": true,
-            "field6": ["array", "elements"],
-            "field7": {"key": "value"}
+            // "field6": ["array", "elements"],
+            // "field7": {"key": "value"}
         });
         let row_2 = json!({
             "field1": 2,
@@ -249,8 +249,8 @@ mod tests {
             "field3": "more text",
             "field4": "this was a bool before",
             "field5": "not null anymore",
-            "field6": ["more", "elements"],
-            "field7": {"anotherKey": "anotherValue"}
+            // "field6": ["more", "elements"],
+            // "field7": {"anotherKey": "anotherValue"}
         });
         let row_3 = json!({
             "field1": "now it's a text field",

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -11,7 +11,6 @@ use crate::providers::llm::{LLMChatGeneration, LLMChatRequest, LLMGeneration, LL
 use crate::run::{Run, RunStatus, RunType};
 use anyhow::Result;
 use async_trait::async_trait;
-use serde_json::Value;
 use std::collections::HashMap;
 
 #[async_trait]
@@ -202,7 +201,7 @@ pub trait Store {
         data_source_id: &str,
         database_id: &str,
         table_id: &str,
-        contents: &HashMap<String, Value>,
+        rows: &Vec<DatabaseRow>,
         truncate: bool,
     ) -> Result<()>;
     async fn load_database_row(


### PR DESCRIPTION
- Change of `DatabaseRow::new` signature saves a lot of clones
- Validate rows before inserting them in database (by generating their schema, which will be used later to update the schema in base)