### PR TITLE
Fix Front Edge override config

### DIFF
--- a/k8s/deployments/front-edge-deployment.yaml
+++ b/k8s/deployments/front-edge-deployment.yaml
@@ -34,6 +34,10 @@ spec:
             # don't have the same memory limits as the regular front pods
             - name: NODE_OPTIONS
               value: "-r dd-trace/init --max-old-space-size=400"
+            - name: NEXTAUTH_URL
+              value: https://front-edge.dust.tt
+            - name: URL
+              value: https://front-edge.dust.tt
 
             - name: DD_AGENT_HOST
               valueFrom:


### PR DESCRIPTION
Front Edge login redirects to dust.tt due to a missing configuration removed here: https://github.com/dust-tt/dust/pull/2552
This PR just adds it back.


**Deployment**
- Merge PR.
- run `k8s/apply_infra.sh` locally.
- check Front Edge login is fixed.