### PR TITLE
core: SearchFilter parents.is_in_map

### DIFF
--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -1122,7 +1122,10 @@ async fn data_sources_search(
                     state.qdrant_clients.clone(),
                     &payload.query,
                     payload.top_k,
-                    payload.filter,
+                    match payload.filter {
+                        Some(filter) => Some(filter.postprocess_for_data_source(&data_source_id)),
+                        None => None,
+                    },
                     payload.full_text,
                     payload.target_document_tokens,
                 )

--- a/core/src/blocks/data_source.rs
+++ b/core/src/blocks/data_source.rs
@@ -101,7 +101,10 @@ impl DataSource {
                 env.qdrant_clients.clone(),
                 &Some(q.to_string()),
                 top_k,
-                filter,
+                match filter {
+                    Some(filter) => Some(filter.postprocess_for_data_source(&data_source_id)),
+                    None => None,
+                },
                 self.full_text,
                 target_document_tokens,
             )

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -96,8 +96,8 @@ impl SearchFilter {
                     match &parents.is_in_map {
                         Some(h) => match h.get(data_source_id) {
                             Some(v) => match &mut is_in {
-                                Some(v) => {
-                                    v.extend(v.clone());
+                                Some(is_in) => {
+                                    is_in.extend(v.clone());
                                 }
                                 None => {
                                     is_in = Some(v.clone());

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -80,7 +80,7 @@ impl SearchFilter {
     // the current `data_source_id`` and set `parents.is_in_map` to `None` since this is a virtual
     // filter that we never want to send to qdrant.
     pub fn postprocess_for_data_source(&self, data_source_id: &str) -> SearchFilter {
-        SearchFilter {
+        let filter = SearchFilter {
             tags: self.tags.clone(),
             parents: match &self.parents {
                 Some(parents) => {
@@ -108,6 +108,12 @@ impl SearchFilter {
                         None => (),
                     }
 
+                    utils::info(&format!(
+                        "Postprocessed `parents.in`: data_source_id={} \
+                         is_in={:?} is_in_map={:?} postprocessed_is_in={:?}",
+                        data_source_id, &parents.is_in, &parents.is_in_map, is_in,
+                    ));
+
                     Some(ParentsFilter {
                         is_in,
                         is_in_map: None,
@@ -117,7 +123,8 @@ impl SearchFilter {
                 None => None,
             },
             timestamp: self.timestamp.clone(),
-        }
+        };
+        filter
     }
 
     pub fn ensure_postprocessed(&self) -> Result<()> {

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -40,11 +40,14 @@ pub struct TagsFilter {
 }
 
 /// A filter to apply to the search query based on document parents. All documents returned must have at least
-/// one parent in `is_in` and none of their parents in `is_not`.
+/// one parent in `is_in` and none of their parents in `is_not`. The `is_in_map` field allows to
+/// sepecify parents per data_source_id.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ParentsFilter {
     #[serde(rename = "in")]
     pub is_in: Option<Vec<String>>,
+    #[serde(rename = "in_map")]
+    pub is_in_map: Option<HashMap<String, Vec<String>>>,
     #[serde(rename = "not")]
     pub is_not: Option<Vec<String>>,
 }
@@ -71,6 +74,62 @@ impl SearchFilter {
     pub fn from_json_str(json: &str) -> Result<Self> {
         let filter: SearchFilter = serde_json::from_str(json)?;
         Ok(filter)
+    }
+
+    // We postprocess `parents.is_in_map` if it is set to augment or set `parents.is_in` based on
+    // the current `data_source_id`` and set `parents.is_in_map` to `None` since this is a virtual
+    // filter that we never want to send to qdrant.
+    pub fn postprocess_for_data_source(&self, data_source_id: &str) -> SearchFilter {
+        SearchFilter {
+            tags: self.tags.clone(),
+            parents: match &self.parents {
+                Some(parents) => {
+                    let mut is_in: Option<Vec<String>> = None;
+
+                    match &parents.is_in {
+                        Some(v) => {
+                            is_in = Some(v.clone());
+                        }
+                        None => (),
+                    }
+
+                    match &parents.is_in_map {
+                        Some(h) => match h.get(data_source_id) {
+                            Some(v) => match &mut is_in {
+                                Some(v) => {
+                                    v.extend(v.clone());
+                                }
+                                None => {
+                                    is_in = Some(v.clone());
+                                }
+                            },
+                            None => (),
+                        },
+                        None => (),
+                    }
+
+                    Some(ParentsFilter {
+                        is_in,
+                        is_in_map: None,
+                        is_not: parents.is_not.clone(),
+                    })
+                }
+                None => None,
+            },
+            timestamp: self.timestamp.clone(),
+        }
+    }
+
+    pub fn ensure_postprocessed(&self) -> Result<()> {
+        match &self.parents {
+            Some(parents) => match &parents.is_in_map {
+                Some(_) => Err(anyhow!(
+                    "SearchFilter must be postprocessed before being used"
+                )),
+                None => Ok(()),
+            },
+            None => Ok(()),
+        }
     }
 }
 
@@ -1058,6 +1117,14 @@ impl DataSource {
         target_document_tokens: Option<usize>,
     ) -> Result<Vec<Document>> {
         let qdrant_client = qdrant_clients.main_client(&self.config.qdrant_config);
+
+        // We ensure that we have not left a `parents.is_in_map`` in the filter.
+        match filter.as_ref() {
+            Some(filter) => {
+                filter.ensure_postprocessed()?;
+            }
+            None => (),
+        }
 
         if top_k > DataSource::MAX_TOP_K_SEARCH {
             return Err(anyhow!("top_k must be <= {}", DataSource::MAX_TOP_K_SEARCH));


### PR DESCRIPTION
- Adds a `parents.is_in_map` to SearchFilter in `core` that receives an array of parents per `data_source_id`.
- When sending the `search` request to the `DataSource` postprocess the SearchFilter to copy the parents associated with that data source in `parents.is_in`
- Also ensure we never go into DataSource::search with a `parents.is_in_map` set.