### PR TITLE
few typos and broken link fixes in the documentation

### DIFF
--- a/docs/src/pages/introduction.mdx
+++ b/docs/src/pages/introduction.mdx
@@ -109,7 +109,7 @@ viable the approach described above.
 
 Along with a well thought-out UI, improvements in instruction-following was one of the core advances
 of ChatGPT, possibly explaining its rapid success. ChatGPT relied on a novel instruction-following
-fine-tuning paradigm called [reinforcement learning from human feedback](#).
+fine-tuning paradigm called [reinforcement learning from human feedback](https://en.wikipedia.org/wiki/Reinforcement_learning_from_human_feedback).
 
 ### Fine-tuning
 

--- a/docs/src/pages/introduction.mdx
+++ b/docs/src/pages/introduction.mdx
@@ -31,7 +31,7 @@ special `<|EndofText|>` token or runs out of context.
 ### Context Size
 
 To predict the next token, Transformer-based large language models will _attend_ (look at all
-previous tokens, the prompt) with a processus called _Attention_. This computationally expensive
+previous tokens, the prompt) with a process called _Attention_. This computationally expensive
 process imposes constraints on the maximum amount of text a model can operate with. This maximum
 length is referred to as its **context size**. Each large language model has a specific
 context size, but it generally consists of 4000 tokens (~4000 words). Some have 2000, others

--- a/docs/src/pages/overview.mdx
+++ b/docs/src/pages/overview.mdx
@@ -130,7 +130,7 @@ Dust apps can also define datasets which are arrays of JSON objects. Datasets' m
 - Store example inputs on which the app is run during its design. These datasets are pulled from
   `input` blocks.
 - Store few-shot examples used when prompting models. These datasets are made available to `llm`
-  blocks through the use of `data` blocks (see [core blocks](#)).
+  blocks through the use of `data` blocks (see [core blocks](/core-blocks)).
 
 All datasets are automatically versioned and each app version points to their specific dataset
 version.
@@ -142,7 +142,7 @@ Each input's execution trace is completely independent and these cannot be cross
 runs of an app are stored along with the app version and all the associated block outputs. They can
 be retrieved from the `Runs` panel.
 
-Other [core blocks](#) allow the further parallelization of the execution such as the `map` and
+Other [core blocks](/core-blocks) allow the further parallelization of the execution such as the `map` and
 `reduce` blocks. Dust's execution engine will also take care of automatically parallelizing
 execution eagearly when they are used.
 


### PR DESCRIPTION
Hi, reading your documentation I came across a few typos and broken links, so here I propose you the fixes (or at lest pointing to them so you can decide how to fix).