### PR TITLE
DBML + remove HashMaps + separate DatabaseRow/DatabaseResult

### DIFF
--- a/connectors/src/lib/databases.ts
+++ b/connectors/src/lib/databases.ts
@@ -78,8 +78,9 @@ type UpsertRowsParams = {
   databaseId: string;
   tableId: string;
   contents: {
-    rowId: string;
-    row: Record<string, string | number | boolean | null>;
+    created: number;
+    row_id: string;
+    value: Record<string, string | number | boolean | null>;
   }[];
   truncate: boolean | undefined;
 };

--- a/connectors/src/lib/databases.ts
+++ b/connectors/src/lib/databases.ts
@@ -77,7 +77,10 @@ type UpsertRowsParams = {
   dataSourceConfig: DataSourceConfig;
   databaseId: string;
   tableId: string;
-  contents: Record<string, Record<string, string | number | boolean | null>>;
+  contents: {
+    rowId: string;
+    row: Record<string, string | number | boolean | null>;
+  }[];
   truncate: boolean | undefined;
 };
 

--- a/connectors/src/lib/databases.ts
+++ b/connectors/src/lib/databases.ts
@@ -77,8 +77,7 @@ type UpsertRowsParams = {
   dataSourceConfig: DataSourceConfig;
   databaseId: string;
   tableId: string;
-  contents: {
-    created: number;
+  rows: {
     row_id: string;
     value: Record<string, string | number | boolean | null>;
   }[];
@@ -89,7 +88,7 @@ async function _upsertRows({
   dataSourceConfig: { workspaceAPIKey, workspaceId, dataSourceName },
   databaseId,
   tableId,
-  contents,
+  rows,
   truncate,
 }: UpsertRowsParams): Promise<void> {
   const res = await fetch(
@@ -100,7 +99,7 @@ async function _upsertRows({
         "Content-Type": "application/json",
         Authorization: `Bearer ${workspaceAPIKey}`,
       },
-      body: JSON.stringify({ contents, truncate }),
+      body: JSON.stringify({ rows, truncate }),
     }
   );
   if (!res.ok) {

--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -1921,7 +1921,7 @@ async fn databases_tables_list(
 
 #[derive(serde::Deserialize)]
 struct DatabasesRowsUpsertPayload {
-    contents: Vec<DatabaseRow>,
+    rows: Vec<DatabaseRow>,
     truncate: Option<bool>,
 }
 
@@ -1961,7 +1961,7 @@ async fn databases_rows_upsert(
             ),
             Some(db) => {
                 match db
-                    .batch_upsert_rows(state.store.clone(), &table_id, payload.contents, truncate)
+                    .batch_upsert_rows(state.store.clone(), &table_id, payload.rows, truncate)
                     .await
                 {
                     Err(e) => error_response(

--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -17,6 +17,7 @@ use dust::{
         data_source::{self, SearchFilter},
         qdrant::QdrantClients,
     },
+    databases::database::DatabaseRow,
     dataset,
     project::{self},
     providers::provider::{provider, ProviderID},
@@ -1920,7 +1921,7 @@ async fn databases_tables_list(
 
 #[derive(serde::Deserialize)]
 struct DatabasesRowsUpsertPayload {
-    contents: HashMap<String, serde_json::Value>,
+    contents: Vec<DatabaseRow>,
     truncate: Option<bool>,
 }
 

--- a/core/src/blocks/database_schema.rs
+++ b/core/src/blocks/database_schema.rs
@@ -1,4 +1,5 @@
 use crate::blocks::block::{Block, BlockResult, BlockType, Env};
+use crate::databases::database::DatabaseSchemaTable;
 use crate::Rule;
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
@@ -89,7 +90,7 @@ async fn get_database_schema(
     data_source_id: &String,
     database_id: &String,
     env: &Env,
-) -> Result<crate::databases::database::DatabaseSchema> {
+) -> Result<Vec<DatabaseSchemaTable>> {
     let project = get_data_source_project(workspace_id, data_source_id, env).await?;
     let database = match env
         .store

--- a/core/src/databases/database.rs
+++ b/core/src/databases/database.rs
@@ -1,6 +1,7 @@
 use super::table_schema::TableSchema;
 use crate::{project::Project, stores::store::Store, utils};
 use anyhow::{anyhow, Result};
+use itertools::Itertools;
 use rayon::prelude::*;
 use rusqlite::{params_from_iter, Connection};
 use serde::{Deserialize, Serialize};

--- a/core/src/databases/database.rs
+++ b/core/src/databases/database.rs
@@ -76,12 +76,12 @@ impl Database {
         &self,
         store: Box<dyn Store + Sync + Send>,
         table_id: &str,
-        contents: Vec<DatabaseRow>,
+        rows: Vec<DatabaseRow>,
         truncate: bool,
     ) -> Result<()> {
         // This will be used to update the schema incrementally once we store schemas. For now this
         // is a way to validate the content of the rows (only primitive types).
-        let _ = TableSchema::from_rows(&contents)?;
+        let _ = TableSchema::from_rows(&rows)?;
 
         store
             .batch_upsert_database_rows(
@@ -89,7 +89,7 @@ impl Database {
                 &self.data_source_id,
                 &self.database_id,
                 table_id,
-                &contents,
+                &rows,
                 truncate,
             )
             .await
@@ -379,23 +379,15 @@ pub trait HasValue {
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct DatabaseRow {
-    created: u64,
     row_id: String,
     value: Value,
 }
 
 impl DatabaseRow {
-    pub fn new(created: u64, row_id: String, value: Value) -> Self {
-        DatabaseRow {
-            created,
-            row_id,
-            value,
-        }
+    pub fn new(row_id: String, value: Value) -> Self {
+        DatabaseRow { row_id, value }
     }
 
-    pub fn created(&self) -> u64 {
-        self.created
-    }
     pub fn row_id(&self) -> &str {
         &self.row_id
     }
@@ -472,8 +464,8 @@ mod tests {
             "description": "not null anymore and prety long so that it's not shown in note",
         });
         let rows = &vec![
-            DatabaseRow::new(utils::now(), "1".to_string(), row_1),
-            DatabaseRow::new(utils::now(), "2".to_string(), row_2),
+            DatabaseRow::new("1".to_string(), row_1),
+            DatabaseRow::new("2".to_string(), row_2),
         ];
 
         let schema = TableSchema::from_rows(rows)?;

--- a/core/src/databases/database.rs
+++ b/core/src/databases/database.rs
@@ -381,15 +381,15 @@ pub trait HasValue {
 pub struct DatabaseRow {
     created: u64,
     row_id: String,
-    content: Value,
+    value: Value,
 }
 
 impl DatabaseRow {
-    pub fn new(created: u64, row_id: String, content: Value) -> Self {
+    pub fn new(created: u64, row_id: String, value: Value) -> Self {
         DatabaseRow {
             created,
             row_id,
-            content,
+            value,
         }
     }
 
@@ -400,13 +400,13 @@ impl DatabaseRow {
         &self.row_id
     }
     pub fn content(&self) -> &Value {
-        &self.content
+        &self.value
     }
 }
 
 impl HasValue for DatabaseRow {
     fn value(&self) -> &Value {
-        &self.content
+        &self.value
     }
 }
 
@@ -438,14 +438,14 @@ impl DatabaseSchemaTable {
 
     pub fn render_dbml(&self) -> String {
         format!(
-            "Table {} {{\n{}\n  Note: '''\n{}\n  '''\n}}",
+            "Table {} {{\n{}\n\n  Note: '{}'\n}}",
             self.table.name(),
-            self.schema.render_dbml_columns(),
-            self.table
-                .description()
-                .split("\n")
-                .map(|l| format!("    {}", l))
-                .join("\n")
+            self.schema
+                .columns()
+                .iter()
+                .map(|c| format!("  {}", c.render_dbml()))
+                .join("\n"),
+            self.table.description()
         )
     }
 }
@@ -487,17 +487,15 @@ mod tests {
         let table_schema = DatabaseSchemaTable::new(table, schema);
 
         let expected = r#"Table test_dbml {
-  label text [note: 'possible values: "foo", "bar"']
   user_id integer [note: 'possible values: 1, 2']
   temperature real [note: 'possible values: 1.2, 2.4']
-  ready integer [note: 'possible values: TRUE, FALSE']
+  label text [note: 'possible values: "foo", "bar"']
+  ready boolean [note: 'possible values: TRUE, FALSE']
   description text
 
-  Note: '''
-    Test records for DBML rendering
-  '''
-}
-"#;
+  Note: 'Test records for DBML rendering'
+}"#
+        .to_string();
         assert_eq!(table_schema.render_dbml(), expected);
 
         Ok(())

--- a/core/src/databases/database.rs
+++ b/core/src/databases/database.rs
@@ -1,13 +1,11 @@
+use super::table_schema::TableSchema;
 use crate::{project::Project, stores::store::Store, utils};
 use anyhow::{anyhow, Result};
-
+use itertools::Itertools;
 use rayon::prelude::*;
 use rusqlite::{params_from_iter, Connection};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::collections::HashMap;
-
-use super::table_schema::TableSchema;
 
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -53,23 +51,23 @@ impl Database {
         }
     }
 
-    pub async fn get_schema(&self, store: Box<dyn Store + Sync + Send>) -> Result<DatabaseSchema> {
+    pub async fn get_schema(
+        &self,
+        store: Box<dyn Store + Sync + Send>,
+    ) -> Result<Vec<DatabaseSchemaTable>> {
         match self.db_type {
             DatabaseType::REMOTE => Err(anyhow!("Remote DB not implemented.")),
             DatabaseType::LOCAL => {
                 let rows = self.get_rows(store).await?;
 
-                let schema = rows
-                    .par_iter()
+                rows.par_iter()
                     .map(|(table, r)| {
-                        Ok((
-                            table.name().to_string(),
-                            DatabaseSchemaTable::new(table.clone(), TableSchema::from_rows(&r)?),
+                        Ok(DatabaseSchemaTable::new(
+                            table.clone(),
+                            TableSchema::from_rows(&r)?,
                         ))
                     })
-                    .collect::<Result<HashMap<_, _>>>()?;
-
-                Ok(DatabaseSchema(schema))
+                    .collect::<Result<Vec<_>>>()
             }
         }
     }
@@ -78,17 +76,12 @@ impl Database {
         &self,
         store: Box<dyn Store + Sync + Send>,
         table_id: &str,
-        contents: HashMap<String, Value>,
+        contents: Vec<DatabaseRow>,
         truncate: bool,
     ) -> Result<()> {
-        let rows = contents
-            .into_iter()
-            .map(|(row_id, content)| DatabaseRow::new(utils::now(), Some(row_id), content))
-            .collect::<Vec<_>>();
-
         // This will be used to update the schema incrementally once we store schemas. For now this
         // is a way to validate the content of the rows (only primitive types).
-        let _ = TableSchema::from_rows(&rows)?;
+        let _ = TableSchema::from_rows(&contents)?;
 
         store
             .batch_upsert_database_rows(
@@ -96,7 +89,7 @@ impl Database {
                 &self.data_source_id,
                 &self.database_id,
                 table_id,
-                &rows,
+                &contents,
                 truncate,
             )
             .await
@@ -120,13 +113,7 @@ impl Database {
                 ));
 
                 let time_get_rows_start = utils::now();
-                let rows_by_table = match self.get_rows(store.clone()).await {
-                    Ok(rows) => Ok(rows
-                        .into_iter()
-                        .map(|(table, rows)| (table.name().to_string(), rows))
-                        .collect::<HashMap<_, _>>()),
-                    _ => Err(anyhow!("Error retrieving rows from database.")),
-                }?;
+                let rows = self.get_rows(store.clone()).await?;
                 utils::done(&format!(
                     "DSSTRUCTSTAT Finished retrieving rows: duration={}ms",
                     utils::now() - time_get_rows_start
@@ -135,12 +122,8 @@ impl Database {
                 let generate_create_table_sql_start = utils::now();
                 let create_tables_sql: String = schema
                     .iter()
-                    .filter(|(_, table)| !table.schema.is_empty())
-                    .map(|(table_name, table)| {
-                        table
-                            .schema
-                            .get_create_table_sql_string(table_name.as_str())
-                    })
+                    .filter(|s| !s.is_empty())
+                    .map(|s| s.schema.get_create_table_sql_string(s.table.name()))
                     .collect::<Vec<_>>()
                     .join("\n");
                 utils::done(&format!(
@@ -158,16 +141,16 @@ impl Database {
                 ));
 
                 let insert_execute_start = utils::now();
-                rows_by_table
-                    .iter()
+                rows.iter()
                     .filter(|(_, rows)| !rows.is_empty())
-                    .map(|(table_name, rows)| {
-                        let table_schema = match schema.get(table_name) {
-                            Some(s) => Ok(s),
-                            None => Err(anyhow!("No schema found for table {}", table_name)),
-                        }?;
+                    .map(|(table, rows)| {
+                        let table_schema =
+                            match schema.iter().find(|s| s.table.name() == table.name()) {
+                                Some(s) => Ok(s),
+                                None => Err(anyhow!("No schema found for table {}", table.name())),
+                            }?;
 
-                        let (sql, field_names) = table_schema.schema.get_insert_sql(table_name);
+                        let (sql, field_names) = table_schema.schema.get_insert_sql(table.name());
                         let mut stmt = conn.prepare(&sql)?;
 
                         rows.par_iter()
@@ -176,7 +159,7 @@ impl Database {
                                     Ok(params) => Ok(params_from_iter(params)),
                                     Err(e) => Err(anyhow!(
                                         "Error getting insert params for row {}: {}",
-                                        r.row_id().unwrap_or_else(|| String::from("")),
+                                        r.row_id(),
                                         e
                                     )),
                                 },
@@ -204,7 +187,7 @@ impl Database {
         &self,
         store: Box<dyn Store + Sync + Send>,
         query: &str,
-    ) -> Result<(Vec<DatabaseRow>, TableSchema)> {
+    ) -> Result<(Vec<DatabaseResult>, TableSchema)> {
         match self.db_type {
             DatabaseType::REMOTE => Err(anyhow!("Remote DB not implemented.")),
             DatabaseType::LOCAL => {
@@ -272,7 +255,7 @@ impl Database {
                     })?
                     .collect::<Result<Vec<_>>>()?
                     .into_par_iter()
-                    .map(|v| DatabaseRow::new(utils::now(), None, v))
+                    .map(|value| DatabaseResult { value })
                     .collect::<Vec<_>>();
                 utils::done(&format!(
                     "DSSTRUCTSTAT Finished executing user query: duration={}ms",
@@ -389,18 +372,23 @@ impl DatabaseTable {
         &self.description
     }
 }
-#[derive(Debug, Serialize, Clone)]
+
+pub trait HasValue {
+    fn value(&self) -> &Value;
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct DatabaseRow {
     created: u64,
-    row_id: Option<String>,
+    row_id: String,
     content: Value,
 }
 
 impl DatabaseRow {
-    pub fn new(created: u64, row_id: Option<String>, content: Value) -> Self {
+    pub fn new(created: u64, row_id: String, content: Value) -> Self {
         DatabaseRow {
-            created: created,
-            row_id: row_id,
+            created,
+            row_id,
             content,
         }
     }
@@ -408,11 +396,28 @@ impl DatabaseRow {
     pub fn created(&self) -> u64 {
         self.created
     }
-    pub fn row_id(&self) -> Option<String> {
-        self.row_id.clone()
+    pub fn row_id(&self) -> &str {
+        &self.row_id
     }
     pub fn content(&self) -> &Value {
         &self.content
+    }
+}
+
+impl HasValue for DatabaseRow {
+    fn value(&self) -> &Value {
+        &self.content
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct DatabaseResult {
+    value: Value,
+}
+
+impl HasValue for DatabaseResult {
+    fn value(&self) -> &Value {
+        &self.value
     }
 }
 
@@ -430,16 +435,71 @@ impl DatabaseSchemaTable {
     pub fn is_empty(&self) -> bool {
         self.schema.is_empty()
     }
+
+    pub fn render_dbml(&self) -> String {
+        format!(
+            "Table {} {{\n{}\n  Note: '''\n{}\n  '''\n}}",
+            self.table.name(),
+            self.schema.render_dbml_columns(),
+            self.table
+                .description()
+                .split("\n")
+                .map(|l| format!("    {}", l))
+                .join("\n")
+        )
+    }
 }
 
-#[derive(Debug, Serialize)]
-pub struct DatabaseSchema(HashMap<String, DatabaseSchemaTable>);
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::utils;
+    use serde_json::json;
 
-impl DatabaseSchema {
-    pub fn iter(&self) -> std::collections::hash_map::Iter<String, DatabaseSchemaTable> {
-        self.0.iter()
-    }
-    pub fn get(&self, table_name: &str) -> Option<&DatabaseSchemaTable> {
-        self.0.get(table_name)
+    #[test]
+    fn test_database_schema_table_to_dbml() -> Result<()> {
+        let row_1 = json!({
+            "user_id": 1,
+            "temperature": 1.2,
+            "label": "foo",
+            "ready": true,
+        });
+        let row_2 = json!({
+            "user_id": 2,
+            "temperature": 2.4,
+            "label": "bar",
+            "ready": false,
+            "description": "not null anymore and prety long so that it's not shown in note",
+        });
+        let rows = &vec![
+            DatabaseRow::new(utils::now(), "1".to_string(), row_1),
+            DatabaseRow::new(utils::now(), "2".to_string(), row_2),
+        ];
+
+        let schema = TableSchema::from_rows(rows)?;
+        let table = DatabaseTable::new(
+            utils::now(),
+            "database_id",
+            "table_id",
+            "test_dbml",
+            "Test records for DBML rendering",
+        );
+        let table_schema = DatabaseSchemaTable::new(table, schema);
+
+        let expected = r#"Table test_dbml {
+  label text [note: 'possible values: "foo", "bar"']
+  user_id integer [note: 'possible values: 1, 2']
+  temperature real [note: 'possible values: 1.2, 2.4']
+  ready integer [note: 'possible values: TRUE, FALSE']
+  description text
+
+  Note: '''
+    Test records for DBML rendering
+  '''
+}
+"#;
+        assert_eq!(table_schema.render_dbml(), expected);
+
+        Ok(())
     }
 }

--- a/core/src/databases/database.rs
+++ b/core/src/databases/database.rs
@@ -1,7 +1,6 @@
 use super::table_schema::TableSchema;
 use crate::{project::Project, stores::store::Store, utils};
 use anyhow::{anyhow, Result};
-use itertools::Itertools;
 use rayon::prelude::*;
 use rusqlite::{params_from_iter, Connection};
 use serde::{Deserialize, Serialize};

--- a/core/src/databases/table_schema.rs
+++ b/core/src/databases/table_schema.rs
@@ -1,9 +1,8 @@
-use super::database::DatabaseRow;
+use super::database::{DatabaseRow, HasValue};
 use anyhow::{anyhow, Result};
 use rusqlite::{types::ToSqlOutput, ToSql};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::collections::HashMap;
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "lowercase")]
@@ -38,31 +37,58 @@ impl ToSql for SqlParam {
     }
 }
 
+// This is used for display and DBML rendering.
+impl std::fmt::Display for TableSchemaFieldType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TableSchemaFieldType::Int => write!(f, "integer"),
+            TableSchemaFieldType::Float => write!(f, "real"),
+            TableSchemaFieldType::Text => write!(f, "text"),
+            TableSchemaFieldType::Bool => write!(f, "boolean"),
+        }
+    }
+}
+
 static POSSIBLE_VALUES_MAX_LEN: usize = 32;
-static POSSIBLE_VALUES_MAX_COUNT: usize = 8;
+static POSSIBLE_VALUES_MAX_COUNT: usize = 16;
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct TableSchemaColumn {
+    pub name: String,
     pub value_type: TableSchemaFieldType,
     pub possible_values: Option<Vec<String>>,
 }
 
 impl TableSchemaColumn {
-    pub fn new(field_type: TableSchemaFieldType) -> Self {
+    pub fn new(name: &str, field_type: TableSchemaFieldType) -> Self {
         Self {
+            name: name.to_string(),
             value_type: field_type,
             possible_values: None,
+        }
+    }
+
+    pub fn render_dbml(&self) -> String {
+        match &self.possible_values {
+            Some(possible_values) => {
+                let mut note = format!("{} [note: 'possible values: ", self.name);
+                note.push_str(&possible_values.join(", "));
+                note.push_str("']");
+                note
+            }
+            None => String::from(""),
         }
     }
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-pub struct TableSchema(HashMap<String, TableSchemaColumn>);
+pub struct TableSchema(Vec<TableSchemaColumn>);
 
 impl TableSchema {
     pub fn empty() -> Self {
-        Self(HashMap::new())
+        Self(vec![])
     }
+
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
@@ -101,17 +127,13 @@ impl TableSchema {
         }
     }
 
-    pub fn from_rows(rows: &Vec<DatabaseRow>) -> Result<Self> {
-        let mut schema: HashMap<String, TableSchemaColumn> = HashMap::new();
+    pub fn from_rows<T: HasValue>(rows: &Vec<T>) -> Result<Self> {
+        let mut schema: Vec<TableSchemaColumn> = vec![];
 
         for (row_index, row) in rows.iter().enumerate() {
-            let object = match row.content().as_object() {
+            let object = match row.value().as_object() {
                 Some(object) => object,
-                None => Err(anyhow!(
-                    "Row [{}] {:?} is not an object",
-                    row_index,
-                    row.row_id()
-                ))?,
+                None => Err(anyhow!("Row {} is not an object", row_index,))?,
             };
 
             for (k, v) in object {
@@ -130,22 +152,20 @@ impl TableSchema {
                     }
                     Value::String(_) => TableSchemaFieldType::Text,
                     Value::Object(_) | Value::Array(_) => Err(anyhow!(
-                        "Field {} is not a primitive type on row [{}] {:?} \
+                        "Field {} is not a primitive type on row {} \
                          (object and arrays are not supported)",
                         k,
                         row_index,
-                        row.row_id()
                     ))?,
                     Value::Null => unreachable!(),
                 };
 
-                if let Some(column) = schema.get_mut(k) {
-                    if &column.value_type != &value_type {
+                if let Some(column) = schema.iter_mut().find(|c| &c.name == k) {
+                    if column.value_type != value_type {
                         return Err(anyhow!(
-                            "Field {} has conflicting types on row [{}] {:?}: {:?} and {:?}",
+                            "Field {} has conflicting types on row {}: {:?} and {:?}",
                             k,
                             row_index,
-                            row.row_id(),
                             column.value_type,
                             value_type
                         ));
@@ -153,11 +173,12 @@ impl TableSchema {
                     Self::accumulate_value(column, v);
                 } else {
                     let mut column = TableSchemaColumn {
+                        name: k.clone(),
                         value_type,
                         possible_values: Some(vec![]),
                     };
                     Self::accumulate_value(&mut column, v);
-                    schema.insert(k.clone(), column);
+                    schema.push(column);
                 }
             }
         }
@@ -171,14 +192,14 @@ impl TableSchema {
             table_name,
             self.0
                 .iter()
-                .map(|(name, column)| {
+                .map(|column| {
                     let sql_type = match column.value_type {
                         TableSchemaFieldType::Int => "INT",
                         TableSchemaFieldType::Float => "REAL",
                         TableSchemaFieldType::Text => "TEXT",
                         TableSchemaFieldType::Bool => "BOOLEAN",
                     };
-                    format!("\"{}\" {}", name, sql_type)
+                    format!("\"{}\" {}", column.name, sql_type)
                 })
                 .collect::<Vec<_>>()
                 .join(", ")
@@ -186,7 +207,7 @@ impl TableSchema {
     }
 
     pub fn get_insert_sql(&self, table_name: &str) -> (String, Vec<&String>) {
-        let field_names: Vec<&String> = self.0.keys().collect();
+        let field_names: Vec<&String> = self.0.iter().map(|c| &c.name).collect();
         (
             format!(
                 "INSERT INTO \"{}\" ({}) VALUES ({});",
@@ -234,6 +255,14 @@ impl TableSchema {
                 .collect::<Result<Vec<_>>>(),
         }
     }
+
+    pub fn render_dbml_columns(&self) -> String {
+        self.0
+            .iter()
+            .map(|c| c.render_dbml())
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
 }
 
 #[cfg(test)]
@@ -242,6 +271,7 @@ mod tests {
     use crate::utils;
     use rusqlite::{params_from_iter, Connection};
     use serde_json::json;
+    use std::collections::HashMap;
 
     #[test]
     fn test_table_schema_from_rows() -> Result<()> {
@@ -259,49 +289,39 @@ mod tests {
             "field5": "not null anymore",
         });
         let rows = &vec![
-            DatabaseRow::new(utils::now(), Some("1".to_string()), row_1),
-            DatabaseRow::new(utils::now(), Some("2".to_string()), row_2),
+            DatabaseRow::new(utils::now(), "1".to_string(), row_1),
+            DatabaseRow::new(utils::now(), "2".to_string(), row_2),
         ];
 
         let schema = TableSchema::from_rows(rows)?;
 
-        let expected_map: HashMap<String, TableSchemaColumn> = [
-            (
-                "field1",
-                TableSchemaColumn {
-                    value_type: TableSchemaFieldType::Int,
-                    possible_values: Some(vec!["1".to_string(), "2".to_string()]),
-                },
-            ),
-            (
-                "field2",
-                TableSchemaColumn {
-                    value_type: TableSchemaFieldType::Float,
-                    possible_values: Some(vec!["1.2".to_string(), "2.4".to_string()]),
-                },
-            ),
-            ("field3", TableSchemaColumn::new(TableSchemaFieldType::Text)),
-            (
-                "field4",
-                TableSchemaColumn {
-                    value_type: TableSchemaFieldType::Bool,
-                    possible_values: Some(vec!["TRUE".to_string(), "FALSE".to_string()]),
-                },
-            ),
-            (
-                "field5",
-                TableSchemaColumn {
-                    value_type: TableSchemaFieldType::Text,
-                    possible_values: Some(vec!["\"not null anymore\"".to_string()]),
-                },
-            ),
-        ]
-        .iter()
-        .cloned()
-        .map(|(field_id, column)| (field_id.to_string(), column))
-        .collect();
-
-        let expected_schema = TableSchema(expected_map);
+        let expected_schema = TableSchema(vec![
+            TableSchemaColumn {
+                name: "field1".to_string(),
+                value_type: TableSchemaFieldType::Int,
+                possible_values: Some(vec!["1".to_string(), "2".to_string()]),
+            },
+            TableSchemaColumn {
+                name: "field2".to_string(),
+                value_type: TableSchemaFieldType::Float,
+                possible_values: Some(vec!["1.2".to_string(), "2.4".to_string()]),
+            },
+            TableSchemaColumn {
+                name: "field3".to_string(),
+                value_type: TableSchemaFieldType::Text,
+                possible_values: None,
+            },
+            TableSchemaColumn {
+                name: "field4".to_string(),
+                value_type: TableSchemaFieldType::Bool,
+                possible_values: Some(vec!["TRUE".to_string(), "FALSE".to_string()]),
+            },
+            TableSchemaColumn {
+                name: "field5".to_string(),
+                value_type: TableSchemaFieldType::Text,
+                possible_values: Some(vec!["\"not null anymore\"".to_string()]),
+            },
+        ]);
 
         assert_eq!(schema, expected_schema);
 
@@ -328,8 +348,8 @@ mod tests {
             "field7": {"anotherKey": "anotherValue"}
         });
         let rows = &vec![
-            DatabaseRow::new(utils::now(), Some("1".to_string()), row_1),
-            DatabaseRow::new(utils::now(), Some("2".to_string()), row_2),
+            DatabaseRow::new(utils::now(), "1".to_string(), row_1),
+            DatabaseRow::new(utils::now(), "2".to_string(), row_2),
         ];
 
         match TableSchema::from_rows(rows) {
@@ -357,9 +377,9 @@ mod tests {
             "field1": "now it's a text field",
         });
         let rows = &vec![
-            DatabaseRow::new(utils::now(), Some("1".to_string()), row_1),
-            DatabaseRow::new(utils::now(), Some("2".to_string()), row_2),
-            DatabaseRow::new(utils::now(), Some("3".to_string()), row_3),
+            DatabaseRow::new(utils::now(), "1".to_string(), row_1),
+            DatabaseRow::new(utils::now(), "2".to_string(), row_2),
+            DatabaseRow::new(utils::now(), "3".to_string(), row_3),
         ];
 
         let schema = TableSchema::from_rows(rows);
@@ -372,16 +392,14 @@ mod tests {
 
     #[test]
     fn test_table_schema_from_empty_rows() {
-        let rows = &vec![];
-
+        let rows: &Vec<DatabaseRow> = &vec![];
         let schema = TableSchema::from_rows(rows);
-
         assert!(schema.is_ok(), "Schema from empty rows should be valid.");
     }
 
     #[test]
     fn test_table_schema_get_create_table_sql_string() -> Result<()> {
-        let schema = create_test_schema()?;
+        let schema = create_test_schema();
 
         let sql = schema.get_create_table_sql_string("test_table");
 
@@ -407,12 +425,12 @@ mod tests {
 
     #[test]
     fn test_get_insert_row_sql_string_success() -> Result<()> {
-        let schema = create_test_schema()?;
+        let schema = create_test_schema();
         let conn = setup_in_memory_db(&schema)?;
 
         let row = DatabaseRow::new(
             utils::now(),
-            None,
+            "row_1".to_string(),
             json!({
                 "field1": 1,
                 "field2": 2.4,
@@ -452,7 +470,7 @@ mod tests {
 
     #[test]
     fn test_get_insert_row_sql_string_missing_fields() -> Result<()> {
-        let schema = create_test_schema()?;
+        let schema = create_test_schema();
         let conn = setup_in_memory_db(&schema)?;
 
         let row_content = json!({
@@ -464,7 +482,7 @@ mod tests {
         let (sql, field_names) = schema.get_insert_sql("test_table");
         let params = params_from_iter(schema.get_insert_params(
             &field_names,
-            &DatabaseRow::new(utils::now(), Some("1".to_string()), row_content),
+            &DatabaseRow::new(utils::now(), "1".to_string(), row_content),
         )?);
         let mut stmt = conn.prepare(&sql)?;
         stmt.execute(params)?;
@@ -490,22 +508,29 @@ mod tests {
     }
 
     // Helper function to create a test schema
-    fn create_test_schema() -> Result<TableSchema> {
-        let schema_map: HashMap<String, TableSchemaColumn> = [
-            ("field1", TableSchemaColumn::new(TableSchemaFieldType::Int)),
-            (
-                "field2",
-                TableSchemaColumn::new(TableSchemaFieldType::Float),
-            ),
-            ("field3", TableSchemaColumn::new(TableSchemaFieldType::Text)),
-            ("field4", TableSchemaColumn::new(TableSchemaFieldType::Bool)),
-        ]
-        .iter()
-        .cloned()
-        .map(|(field_id, column)| (field_id.to_string(), column))
-        .collect();
-
-        Ok(TableSchema(schema_map))
+    fn create_test_schema() -> TableSchema {
+        TableSchema(vec![
+            TableSchemaColumn {
+                name: "field1".to_string(),
+                value_type: TableSchemaFieldType::Int,
+                possible_values: None,
+            },
+            TableSchemaColumn {
+                name: "field2".to_string(),
+                value_type: TableSchemaFieldType::Float,
+                possible_values: None,
+            },
+            TableSchemaColumn {
+                name: "field3".to_string(),
+                value_type: TableSchemaFieldType::Text,
+                possible_values: None,
+            },
+            TableSchemaColumn {
+                name: "field4".to_string(),
+                value_type: TableSchemaFieldType::Bool,
+                possible_values: None,
+            },
+        ])
     }
 
     // Helper function to set up an in-memory database with a test table

--- a/core/src/databases/table_schema.rs
+++ b/core/src/databases/table_schema.rs
@@ -71,12 +71,15 @@ impl TableSchemaColumn {
     pub fn render_dbml(&self) -> String {
         match &self.possible_values {
             Some(possible_values) => {
-                let mut note = format!("{} [note: 'possible values: ", self.name);
+                let mut note = format!(
+                    "{} {} [note: 'possible values: ",
+                    self.name, self.value_type
+                );
                 note.push_str(&possible_values.join(", "));
                 note.push_str("']");
                 note
             }
-            None => String::from(""),
+            None => format!("{} {}", self.name, self.value_type),
         }
     }
 }
@@ -91,6 +94,10 @@ impl TableSchema {
 
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
+    }
+
+    pub fn columns(&self) -> &Vec<TableSchemaColumn> {
+        &self.0
     }
 
     fn accumulate_value(column: &mut TableSchemaColumn, v: &Value) -> () {
@@ -254,14 +261,6 @@ impl TableSchema {
                 })
                 .collect::<Result<Vec<_>>>(),
         }
-    }
-
-    pub fn render_dbml_columns(&self) -> String {
-        self.0
-            .iter()
-            .map(|c| c.render_dbml())
-            .collect::<Vec<_>>()
-            .join("\n")
     }
 }
 

--- a/core/src/databases/table_schema.rs
+++ b/core/src/databases/table_schema.rs
@@ -267,7 +267,6 @@ impl TableSchema {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::utils;
     use rusqlite::{params_from_iter, Connection};
     use serde_json::json;
     use std::collections::HashMap;
@@ -288,8 +287,8 @@ mod tests {
             "field5": "not null anymore",
         });
         let rows = &vec![
-            DatabaseRow::new(utils::now(), "1".to_string(), row_1),
-            DatabaseRow::new(utils::now(), "2".to_string(), row_2),
+            DatabaseRow::new("1".to_string(), row_1),
+            DatabaseRow::new("2".to_string(), row_2),
         ];
 
         let schema = TableSchema::from_rows(rows)?;
@@ -347,8 +346,8 @@ mod tests {
             "field7": {"anotherKey": "anotherValue"}
         });
         let rows = &vec![
-            DatabaseRow::new(utils::now(), "1".to_string(), row_1),
-            DatabaseRow::new(utils::now(), "2".to_string(), row_2),
+            DatabaseRow::new("1".to_string(), row_1),
+            DatabaseRow::new("2".to_string(), row_2),
         ];
 
         match TableSchema::from_rows(rows) {
@@ -376,9 +375,9 @@ mod tests {
             "field1": "now it's a text field",
         });
         let rows = &vec![
-            DatabaseRow::new(utils::now(), "1".to_string(), row_1),
-            DatabaseRow::new(utils::now(), "2".to_string(), row_2),
-            DatabaseRow::new(utils::now(), "3".to_string(), row_3),
+            DatabaseRow::new("1".to_string(), row_1),
+            DatabaseRow::new("2".to_string(), row_2),
+            DatabaseRow::new("3".to_string(), row_3),
         ];
 
         let schema = TableSchema::from_rows(rows);
@@ -428,7 +427,6 @@ mod tests {
         let conn = setup_in_memory_db(&schema)?;
 
         let row = DatabaseRow::new(
-            utils::now(),
             "row_1".to_string(),
             json!({
                 "field1": 1,
@@ -481,7 +479,7 @@ mod tests {
         let (sql, field_names) = schema.get_insert_sql("test_table");
         let params = params_from_iter(schema.get_insert_params(
             &field_names,
-            &DatabaseRow::new(utils::now(), "1".to_string(), row_content),
+            &DatabaseRow::new("1".to_string(), row_content),
         )?);
         let mut stmt = conn.prepare(&sql)?;
         stmt.execute(params)?;

--- a/core/src/stores/postgres.rs
+++ b/core/src/stores/postgres.rs
@@ -2209,7 +2209,7 @@ impl Store for PostgresStore {
             None => Ok(None),
             Some((created, row_id, data)) => Ok(Some(DatabaseRow::new(
                 created as u64,
-                Some(row_id),
+                row_id,
                 Value::from_str(&data)?,
             ))),
         }
@@ -2293,7 +2293,7 @@ impl Store for PostgresStore {
                 let row_id: String = row.get(1);
                 let data: String = row.get(2);
                 let content: Value = serde_json::from_str(&data)?;
-                Ok(DatabaseRow::new(created as u64, Some(row_id), content))
+                Ok(DatabaseRow::new(created as u64, row_id, content))
             })
             .collect::<Result<Vec<_>>>()?;
 
@@ -2391,16 +2391,12 @@ impl Store for PostgresStore {
             .await?;
 
         for row in rows {
-            let row_id = match row.row_id() {
-                Some(row_id) => row_id.to_string(),
-                None => unreachable!(),
-            };
             c.execute(
                 &stmt,
                 &[
                     &table_row_id,
                     &(row.created() as i64),
-                    &row_id,
+                    &row.row_id().to_string(),
                     &row.content().to_string(),
                 ],
             )

--- a/core/src/stores/postgres.rs
+++ b/core/src/stores/postgres.rs
@@ -2207,11 +2207,7 @@ impl Store for PostgresStore {
 
         match d {
             None => Ok(None),
-            Some((created, row_id, data)) => Ok(Some(DatabaseRow::new(
-                created as u64,
-                row_id,
-                Value::from_str(&data)?,
-            ))),
+            Some((_, row_id, data)) => Ok(Some(DatabaseRow::new(row_id, Value::from_str(&data)?))),
         }
     }
 
@@ -2289,11 +2285,10 @@ impl Store for PostgresStore {
         let rows: Vec<DatabaseRow> = rows
             .iter()
             .map(|row| {
-                let created: i64 = row.get(0);
                 let row_id: String = row.get(1);
                 let data: String = row.get(2);
                 let content: Value = serde_json::from_str(&data)?;
-                Ok(DatabaseRow::new(created as u64, row_id, content))
+                Ok(DatabaseRow::new(row_id, content))
             })
             .collect::<Result<Vec<_>>>()?;
 
@@ -2395,7 +2390,7 @@ impl Store for PostgresStore {
                 &stmt,
                 &[
                     &table_row_id,
-                    &(row.created() as i64),
+                    &(utils::now() as i64),
                     &row.row_id().to_string(),
                     &row.content().to_string(),
                 ],


### PR DESCRIPTION
- Implemented DBML rendering + test 
- Didn't connect it to the block, wondering what you think is good here, we'll likely have to unpack the vector and add the dbml along the schema?
- Removed all hashmap so that we're stable by insertion / column orders
- Made row_id compulsory on DatabaseRow and introduced DatabaseResult
- This means I now expose the created in the API. The real question here, is do we want to keep it internal (we can use a different type) or do we want to remove it or do we want to expose it?

Also killed DatabaseSchema to simplify code in places