### PR TITLE
connectors: safer slack clean-up in case of org mismatch

### DIFF
--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -182,8 +182,8 @@ export async function updateSlackConnector(
         },
       });
 
-      // Reovoke the token if no other slack connector is active on the same slackTeamId.
-      if (configurations.length == 1) {
+      // Revoke the token if no other slack connector is active on the same slackTeamId.
+      if (configurations.length == 0) {
         await uninstallSlack(connectionId);
       } else {
         logger.info(

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -184,14 +184,30 @@ export async function updateSlackConnector(
 
       // Revoke the token if no other slack connector is active on the same slackTeamId.
       if (configurations.length == 0) {
+        logger.info(
+          {
+            connectorId: c.id,
+            slackTeamId: newTeamId,
+            nangoConnectionId: connectionId,
+          },
+          `Attempting Slack app deactivation [updateSlackConnector/team_id_mismatch]`
+        );
         await uninstallSlack(connectionId);
+        logger.info(
+          {
+            connectorId: c.id,
+            slackTeamId: newTeamId,
+            nangoConnectionId: connectionId,
+          },
+          `Deactivated Slack app [updateSlackConnector/team_id_mismatch]`
+        );
       } else {
         logger.info(
           {
             slackTeamId: newTeamId,
             activeConfigurations: configurations.length,
           },
-          `Skipping deactivation of the Slack app`
+          `Skipping deactivation of the Slack app [updateSlackConnector/team_id_mismatch]`
         );
       }
 
@@ -311,14 +327,30 @@ export async function cleanupSlackConnector(
 
     // We deactivate our connections only if we are the only live slack connection for this team.
     if (configurations.length == 1) {
+      logger.info(
+        {
+          connectorId: connector.id,
+          slackTeamId: configuration.slackTeamId,
+          nangoConnectionId: connector.connectionId,
+        },
+        `Attempting Slack app deactivation [cleanupSlackConnector]`
+      );
       await uninstallSlack(connector.connectionId);
+      logger.info(
+        {
+          connectorId: connector.id,
+          slackTeamId: configuration.slackTeamId,
+        },
+        `Deactivated Slack app [cleanupSlackConnector]`
+      );
     } else {
       logger.info(
         {
+          connectorId: connector.id,
           slackTeamId: configuration.slackTeamId,
           activeConfigurations: configurations.length - 1,
         },
-        `Skipping deactivation of the Slack app`
+        `Skipping deactivation of the Slack app [cleanupSlackConnector]`
       );
     }
 


### PR DESCRIPTION
`uninstallSlack` can throw or return an Err
we catch these Err and handle accordingly on the two call sites