### PR TITLE
slack: use display name or real name or username in conversations

### DIFF
--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -745,8 +745,13 @@ export async function getUserName(
 
   const info = await slackClient.users.info({ user: slackUserId });
 
-  if (info && info.user?.name) {
-    await cacheSet(getUserCacheKey(slackUserId, connectorId), info.user.name);
+  if(info && info.user) {
+    const displayName = info.user.profile?.display_name;
+    const realName = info.user.profile?.real_name;
+    const userName = displayName || realName || info.user.name;
+
+  if (userName) {
+    await cacheSet(getUserCacheKey(slackUserId, connectorId), userName);
     return info.user.name;
   }
   return;

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -745,14 +745,15 @@ export async function getUserName(
 
   const info = await slackClient.users.info({ user: slackUserId });
 
-  if(info && info.user) {
+  if (info && info.user) {
     const displayName = info.user.profile?.display_name;
     const realName = info.user.profile?.real_name;
     const userName = displayName || realName || info.user.name;
 
-  if (userName) {
-    await cacheSet(getUserCacheKey(slackUserId, connectorId), userName);
-    return info.user.name;
+    if (userName) {
+      await cacheSet(getUserCacheKey(slackUserId, connectorId), userName);
+      return info.user.name;
+    }
   }
   return;
 }


### PR DESCRIPTION
When generating content fragment we rely on `getUserName` which pulls `user.info.name`. It seems that Slack truncates that value as per: https://github.com/orgs/dust-tt/projects/2/views/1?pane=issue&itemId=45759617

This PR instead attempts to pull the `user.profile.display_name`, if failed (happens for bots), the `user.profile.real_name`, and if not available falls back to the `user.name`.

For content fragment that's definitely what we want. For ingestion of slack threads it's a more interesting question. I think that's also what we want since this is what a human would want.

Fixes: https://github.com/dust-tt/tasks/issues/256