### PR TITLE
Avoid messages-count sequential queries to SQL when generating contentFragment

### DIFF
--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -626,6 +626,15 @@ async function makeContentFragment(
   let next_cursor = undefined;
 
   let shouldTake = false;
+
+  const slackBotMessages = await SlackChatBotMessage.findAll({
+    where: {
+      connectorId: connector.id,
+      channelId: channelId,
+      threadTs: threadTs,
+    },
+  });
+
   do {
     const replies: ConversationsRepliesResponse =
       await slackClient.conversations.replies({
@@ -657,15 +666,8 @@ async function makeContentFragment(
         continue;
       }
       if (shouldTake) {
-        const slackChatBotMessage = await SlackChatBotMessage.findOne({
-          where: {
-            connectorId: connector.id,
-            messageTs: m.ts,
-            channelId: channelId,
-          },
-        });
-        if (slackChatBotMessage) {
-          // If this message is a mention to the bot, we don't send it as a content fragment
+        if (slackBotMessages.find((sbm) => sbm.messageTs === m.ts)) {
+          // If this message is a mention to the bot, we don't send it as a content fragment.
           continue;
         }
         allMessages.push(m);

--- a/connectors/src/lib/models/slack.ts
+++ b/connectors/src/lib/models/slack.ts
@@ -281,6 +281,7 @@ SlackChatBotMessage.init(
   {
     sequelize: sequelize_conn,
     modelName: "slack_chat_bot_messages",
+    indexes: [{ fields: ["connectorId", "channelId", "threadTs"] }],
   }
 );
 Connector.hasOne(SlackChatBotMessage);


### PR DESCRIPTION
Run into it while fixing the getUserName issue this morning.

We currently do slack thread messages count SQL queries sequentially when generating a contentFragment. Instead make one query to retrieve all slack bot messages we know of for the current thread in one query and use that to filter them.