### PR TITLE
Stripe checkout: force user email

### DIFF
--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -44,6 +44,10 @@ export const createCheckoutSession = async ({
   if (!owner) {
     throw new Error("No workspace found");
   }
+  const user = auth.user();
+  if (!user) {
+    throw new Error("No user found");
+  }
 
   const plan = await Plan.findOne({ where: { code: planCode } });
   if (!plan) {
@@ -100,6 +104,7 @@ export const createCheckoutSession = async ({
   const session = await stripe.checkout.sessions.create({
     mode: "subscription",
     client_reference_id: owner.sId,
+    customer_email: user.email,
     customer: auth.subscription()?.stripeCustomerId || undefined,
     metadata: {
       planCode: planCode,


### PR DESCRIPTION
Force the user email when creating a new checkout session.
Looks like this: 

<img width="1207" alt="Screenshot 2023-11-27 at 13 34 47" src="https://github.com/dust-tt/dust/assets/3803406/d312e4c8-c9d1-446b-b767-ff6d0145e6cb">

Eng runner card: https://github.com/dust-tt/tasks/issues/254