### PR TITLE
[Connectors - Error handling] Fix catching of slack rate limit errors

### DIFF
--- a/connectors/src/connectors/slack/lib/slack_client.ts
+++ b/connectors/src/connectors/slack/lib/slack_client.ts
@@ -52,6 +52,22 @@ export async function getSlackClient(
         // @ts-expect-error can't get typescript to be happy with this, but it works.
         return await Reflect.apply(target, thisArg, argumentsList);
       } catch (e) {
+        // If we get rate limited, we throw a known error. The activity will be
+        // automatically retried, no need to generate an alert
+        // Note: a previous version using slackError.code === ErrorCode.RateLimitedError failed
+        // see PR #2689 for details
+        if (
+          e instanceof Error &&
+          e.message.startsWith("A rate limit was exceeded")
+        ) {
+          throw {
+            __is_dust_error: true,
+            message: e.message,
+            triggeringError: e,
+            type: "connector_rate_limit_activity_error",
+          };
+        }
+
         const slackError = e as CodedError;
         if (slackError.code === ErrorCode.HTTPError) {
           const httpError = slackError as WebAPIHTTPError;
@@ -63,15 +79,6 @@ export async function getSlackClient(
             };
             throw workflowError;
           }
-        }
-        if (slackError.code === ErrorCode.RateLimitedError) {
-          // If we get rate limited, we throw a known error. The activity will be
-          // automatically retried, no need to generate an alert
-          throw {
-            __is_dust_error: true,
-            message: slackError.message,
-            type: "connector_rate_limit_activity_error",
-          };
         }
         throw e;
       }

--- a/connectors/src/connectors/slack/lib/slack_client.ts
+++ b/connectors/src/connectors/slack/lib/slack_client.ts
@@ -52,8 +52,7 @@ export async function getSlackClient(
         // @ts-expect-error can't get typescript to be happy with this, but it works.
         return await Reflect.apply(target, thisArg, argumentsList);
       } catch (e) {
-        // If we get rate limited, we throw a known error. The activity will be
-        // automatically retried, no need to generate an alert
+        // If we get rate limited, we throw a known error.
         // Note: a previous version using slackError.code === ErrorCode.RateLimitedError failed
         // see PR #2689 for details
         if (
@@ -64,7 +63,7 @@ export async function getSlackClient(
             __is_dust_error: true,
             message: e.message,
             triggeringError: e,
-            type: "connector_rate_limit_activity_error",
+            type: "connector_rate_limit_error",
           };
         }
 

--- a/connectors/src/lib/error.ts
+++ b/connectors/src/lib/error.ts
@@ -8,7 +8,8 @@ export type APIErrorType =
   | "connector_update_unauthorized"
   | "connector_oauth_target_mismatch"
   | "not_found"
-  | "slack_channel_not_found";
+  | "slack_channel_not_found"
+  | "connector_rate_limit_error";
 
 export type APIError = {
   type: APIErrorType;
@@ -34,8 +35,7 @@ export type WorkflowErrorType =
   | "unhandled_internal_activity_error"
   | "transient_upstream_activity_error"
   | "transient_nango_activity_error"
-  | "upstream_is_down_activity_error"
-  | "connector_rate_limit_activity_error";
+  | "upstream_is_down_activity_error";
 
 export type WorkflowError = {
   type: WorkflowErrorType;


### PR DESCRIPTION
Related [task](https://github.com/dust-tt/tasks/issues/217)

Initial version to catch limits was using the error code provided by the slack API `slackError.code ===
ErrorCode.RateLimitedError`, see PR #2425

Butapparently the error sent by the slack client when rate-limited is actually not complying
the slack [error handling guidelines](https://slack.dev/node-slack-sdk/web-api#handle-errors)

Thus the error message prefix matching code of this PR to be sure the error is caught properly