### PR TITLE
Cap message limit

### DIFF
--- a/front/components/PlansTables.tsx
+++ b/front/components/PlansTables.tsx
@@ -68,7 +68,7 @@ function ProPriceTable({
       <PriceTable.Item label="Privacy and Data Security" />
       <PriceTable.Item label="Advanced models (GPT-4, Claude…)" />
       <PriceTable.Item label="Unlimited custom assistants" />
-      <PriceTable.Item label="Unlimited messages" />
+      <PriceTable.Item label="Unlimited messages with a fair usage cap: 50 messages/3 hours" />
       <PriceTable.Item label="Up to 1Gb/user of data sources" />
       <PriceTable.Item
         label="Connections
@@ -110,7 +110,7 @@ function EnterprisePriceTable({
       <PriceTable.Item label="Privacy and Data Security" />
       <PriceTable.Item label="Advanced models (GPT-4, Claude…)" />
       <PriceTable.Item label="Unlimited custom assistants" />
-      <PriceTable.Item label="Unlimited messages" />
+      <PriceTable.Item label="Unlimited messages with a fair usage cap: 50 messages/3 hours" />
       <PriceTable.Item label="Unlimited data sources" />
       <PriceTable.Item
         label="Connections

--- a/front/components/PlansTables.tsx
+++ b/front/components/PlansTables.tsx
@@ -68,7 +68,7 @@ function ProPriceTable({
       <PriceTable.Item label="Privacy and Data Security" />
       <PriceTable.Item label="Advanced models (GPT-4, Claude…)" />
       <PriceTable.Item label="Unlimited custom assistants" />
-      <PriceTable.Item label="Unlimited messages with a fair usage cap: 50 messages/3 hours" />
+      <PriceTable.Item label="Unlimited messages" />
       <PriceTable.Item label="Up to 1Gb/user of data sources" />
       <PriceTable.Item
         label="Connections
@@ -110,7 +110,7 @@ function EnterprisePriceTable({
       <PriceTable.Item label="Privacy and Data Security" />
       <PriceTable.Item label="Advanced models (GPT-4, Claude…)" />
       <PriceTable.Item label="Unlimited custom assistants" />
-      <PriceTable.Item label="Unlimited messages with a fair usage cap: 50 messages/3 hours" />
+      <PriceTable.Item label="Unlimited messages" />
       <PriceTable.Item label="Unlimited data sources" />
       <PriceTable.Item
         label="Connections

--- a/front/lib/api/assistant/pubsub.ts
+++ b/front/lib/api/assistant/pubsub.ts
@@ -52,8 +52,8 @@ export async function postUserMessageWithPubSub(
   let timeframeSeconds: number | undefined = undefined;
   let rateLimitKey: string | undefined = "";
   if (auth.user()?.id) {
-    maxPerTimeframe = 256;
-    timeframeSeconds = 60 * 60;
+    maxPerTimeframe = 50;
+    timeframeSeconds = 60 * 60 * 3;
     rateLimitKey = `postUserMessageUser:${auth.user()?.id}`;
   } else {
     maxPerTimeframe = 512;

--- a/front/pages/w/[wId]/subscription/index.tsx
+++ b/front/pages/w/[wId]/subscription/index.tsx
@@ -7,6 +7,7 @@ import {
   Spinner,
 } from "@dust-tt/sparkle";
 import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import Link from "next/link";
 import { useRouter } from "next/router";
 import React, { useContext, useEffect } from "react";
 
@@ -256,6 +257,9 @@ export default function Subscription({
                   </div>
                 </div>
               ))}
+            <Link href="/terms" target="_blank" className="text-sm">
+              Terms of use apply to all plans.
+            </Link>
           </Page.Vertical>
         ) : (
           <Page.Vertical>


### PR DESCRIPTION

I changed the rate limit only for messages with user id, others stays at 512. 

Wording updated on the Price table but still in discussion here: https://dust4ai.slack.com/archives/C05UDJU9JKW/p1700959630986929
