### PR TITLE
`core` sections support in `front`

### DIFF
--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -1381,8 +1381,7 @@ struct DataSourcesDocumentsUpsertPayload {
     tags: Vec<String>,
     parents: Vec<String>,
     source_url: Option<String>,
-    text: String,
-    section: Option<Section>,
+    section: Section,
     credentials: run::Credentials,
     light_document_output: Option<bool>,
 }
@@ -1426,14 +1425,7 @@ async fn data_sources_documents_upsert(
                         &payload.tags,
                         &payload.parents,
                         &payload.source_url,
-                        match payload.section {
-                            Some(s) => s,
-                            None => Section {
-                                prefix: None,
-                                content: Some(payload.text),
-                                sections: vec![],
-                            },
-                        },
+                        payload.section,
                         true, // preserve system tags
                     )
                     .await

--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -1381,7 +1381,8 @@ struct DataSourcesDocumentsUpsertPayload {
     tags: Vec<String>,
     parents: Vec<String>,
     source_url: Option<String>,
-    section: Section,
+    text: Option<String>,
+    section: Option<Section>,
     credentials: run::Credentials,
     light_document_output: Option<bool>,
 }
@@ -1396,6 +1397,32 @@ async fn data_sources_documents_upsert(
         Some(v) => v,
         None => false,
     };
+
+    utils::info(&format!(
+        "Upserting document: section_is_set={} text_is_set={}",
+        payload.section.is_some(),
+        payload.text.is_some()
+    ));
+
+    let section = match payload.section {
+        Some(s) => s,
+        None => match payload.text {
+            Some(text) => Section {
+                prefix: None,
+                content: Some(text),
+                sections: vec![],
+            },
+            None => {
+                return error_response(
+                    StatusCode::BAD_REQUEST,
+                    "bad_request",
+                    "Either `section` or `text` must be provided",
+                    None,
+                )
+            }
+        },
+    };
+
     match state
         .store
         .load_data_source(&project, &data_source_id)
@@ -1425,7 +1452,7 @@ async fn data_sources_documents_upsert(
                         &payload.tags,
                         &payload.parents,
                         &payload.source_url,
-                        payload.section,
+                        section,
                         true, // preserve system tags
                     )
                     .await

--- a/front/lib/core_api.ts
+++ b/front/lib/core_api.ts
@@ -57,6 +57,21 @@ export type CoreAPIDataSource = {
   config: CoreAPIDataSourceConfig;
 };
 
+export type CoreAPIDataSourceDocumentSection = {
+  prefix: string | null;
+  content: string | null;
+  sections: CoreAPIDataSourceDocumentSection[];
+};
+
+export function sectionFullText(
+  section: CoreAPIDataSourceDocumentSection
+): string {
+  return (
+    `${section.prefix || ""}${section.content || ""}` +
+    section.sections.map(sectionFullText).join("")
+  );
+}
+
 export type CoreAPIDocument = {
   data_source_id: string;
   created: number;
@@ -686,7 +701,7 @@ export const CoreAPI = {
     tags,
     parents,
     sourceUrl,
-    text,
+    section,
     credentials,
     lightDocumentOutput = false,
   }: {
@@ -697,7 +712,7 @@ export const CoreAPI = {
     tags: string[];
     parents: string[];
     sourceUrl?: string | null;
-    text: string;
+    section: CoreAPIDataSourceDocumentSection;
     credentials: CredentialsType;
     lightDocumentOutput?: boolean;
   }): Promise<
@@ -730,7 +745,7 @@ export const CoreAPI = {
             body: JSON.stringify({
               document_id: documentId,
               timestamp,
-              text,
+              section,
               tags,
               parents,
               source_url: sourceUrl,

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
@@ -74,7 +74,7 @@ export const PostDataSourceDocumentRequestBodySchema = t.type({
   tags: t.union([t.array(t.string), t.undefined, t.null]),
   parents: t.union([t.array(t.string), t.undefined, t.null]),
   source_url: t.union([t.string, t.undefined, t.null]),
-  upsert_context: t.union([UpsertContextSchema, t.null]),
+  upsert_context: t.union([UpsertContextSchema, t.undefined, t.null]),
   section: t.union([Section, t.undefined, t.null]),
   light_document_output: t.union([t.boolean, t.undefined]),
 });

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
@@ -69,12 +69,12 @@ const Section: t.RecursiveType<
 );
 
 export const PostDataSourceDocumentRequestBodySchema = t.type({
-  text: t.union([t.string, t.undefined, t.null]),
   timestamp: t.union([t.number, t.undefined, t.null]),
   tags: t.union([t.array(t.string), t.undefined, t.null]),
   parents: t.union([t.array(t.string), t.undefined, t.null]),
   source_url: t.union([t.string, t.undefined, t.null]),
   upsert_context: t.union([UpsertContextSchema, t.undefined, t.null]),
+  text: t.union([t.string, t.undefined, t.null]),
   section: t.union([Section, t.undefined, t.null]),
   light_document_output: t.union([t.boolean, t.undefined]),
 });

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
@@ -1,6 +1,7 @@
 import { DataSourceType } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
+import * as reporter from "io-ts-reporters";
 import { NextApiRequest, NextApiResponse } from "next";
 
 import {
@@ -14,7 +15,12 @@ import {
 import { dustManagedCredentials } from "@app/lib/api/credentials";
 import { getDataSource } from "@app/lib/api/data_sources";
 import { Authenticator, getAPIKey } from "@app/lib/auth";
-import { CoreAPI, CoreAPILightDocument } from "@app/lib/core_api";
+import {
+  CoreAPI,
+  CoreAPIDataSourceDocumentSection,
+  CoreAPILightDocument,
+  sectionFullText,
+} from "@app/lib/core_api";
 import { ReturnedAPIErrorType } from "@app/lib/error";
 import { validateUrl } from "@app/lib/utils";
 import { apiError, withLogging } from "@app/logger/withlogging";
@@ -50,6 +56,28 @@ const UpsertContextSchema = t.type({
   ]),
 });
 export type UpsertContext = t.TypeOf<typeof UpsertContextSchema>;
+
+const Section: t.RecursiveType<
+  t.Type<CoreAPIDataSourceDocumentSection>,
+  CoreAPIDataSourceDocumentSection
+> = t.recursion("Section", () =>
+  t.type({
+    prefix: t.union([t.string, t.null]),
+    content: t.union([t.string, t.null]),
+    sections: t.array(Section),
+  })
+);
+
+export const PostDataSourceDocumentRequestBodySchema = t.type({
+  text: t.union([t.string, t.undefined, t.null]),
+  timestamp: t.union([t.number, t.undefined, t.null]),
+  tags: t.union([t.array(t.string), t.undefined, t.null]),
+  parents: t.union([t.array(t.string), t.undefined, t.null]),
+  source_url: t.union([t.string, t.undefined, t.null]),
+  upsert_context: t.union([UpsertContextSchema, t.null]),
+  section: t.union([Section, t.undefined, t.null]),
+  light_document_output: t.union([t.boolean, t.undefined]),
+});
 
 async function handler(
   req: NextApiRequest,
@@ -139,75 +167,24 @@ async function handler(
         });
       }
 
-      if (!req.body || !(typeof req.body.text == "string")) {
+      const bodyValidation = PostDataSourceDocumentRequestBodySchema.decode(
+        req.body
+      );
+      if (isLeft(bodyValidation)) {
+        const pathError = reporter.formatValidationErrors(bodyValidation.left);
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "Invalid request body, `text` (string) is required.",
+            message: `Invalid request body: ${pathError}`,
           },
         });
       }
 
-      let timestamp = null;
-      if (req.body.timestamp) {
-        if (typeof req.body.timestamp !== "number") {
-          return apiError(req, res, {
-            status_code: 400,
-            api_error: {
-              type: "invalid_request_error",
-              message:
-                "Invalid request body, `timestamp` if provided must be a number.",
-            },
-          });
-        }
-        timestamp = req.body.timestamp;
-      }
-
-      let tags = [];
-      if (req.body.tags) {
-        if (!Array.isArray(req.body.tags)) {
-          return apiError(req, res, {
-            status_code: 400,
-            api_error: {
-              type: "invalid_request_error",
-              message:
-                "Invalid request body, `tags` if provided must be an array of strings.",
-            },
-          });
-        }
-        tags = req.body.tags;
-      }
-
-      let parents = [];
-      if (req.body.parents) {
-        if (!Array.isArray(req.body.parents)) {
-          return apiError(req, res, {
-            status_code: 400,
-            api_error: {
-              type: "invalid_request_error",
-              message:
-                "Invalid request body, `parents` if provided must be an array of strings.",
-            },
-          });
-        }
-        parents = req.body.parents;
-      }
-
       let sourceUrl: string | null = null;
-      if (req.body.source_url) {
-        if (typeof req.body.source_url !== "string") {
-          return apiError(req, res, {
-            status_code: 400,
-            api_error: {
-              type: "invalid_request_error",
-              message:
-                "Invalid request body, `source_url` if provided must be a string.",
-            },
-          });
-        }
+      if (bodyValidation.right.source_url) {
         const { valid: isSourceUrlValid, standardized: standardizedSourceUrl } =
-          validateUrl(req.body.source_url);
+          validateUrl(bodyValidation.right.source_url);
 
         if (!isSourceUrlValid) {
           return apiError(req, res, {
@@ -221,6 +198,27 @@ async function handler(
         }
         sourceUrl = standardizedSourceUrl;
       }
+
+      const section = bodyValidation.right.text
+        ? {
+            prefix: null,
+            content: bodyValidation.right.text,
+            sections: [],
+          }
+        : bodyValidation.right.section || null;
+
+      if (!section) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              "Invalid request body, `text` or `section` must be provided.",
+          },
+        });
+      }
+
+      const fullText = sectionFullText(section);
 
       // Enforce plan limits: DataSource documents count.
       // We only load the number of documents if the limit is not -1 (unlimited).
@@ -263,8 +261,7 @@ async function handler(
       // Enforce plan limits: DataSource document size.
       if (
         plan.limits.dataSources.documents.sizeMb != -1 &&
-        req.body.text.length >
-          1024 * 1024 * plan.limits.dataSources.documents.sizeMb
+        fullText.length > 1024 * 1024 * plan.limits.dataSources.documents.sizeMb
       ) {
         return apiError(req, res, {
           status_code: 401,
@@ -284,13 +281,14 @@ async function handler(
         projectId: dataSource.dustAPIProjectId,
         dataSourceName: dataSource.name,
         documentId: req.query.documentId as string,
-        timestamp,
-        tags,
-        parents,
+        tags: bodyValidation.right.tags || [],
+        parents: bodyValidation.right.parents || [],
         sourceUrl,
-        text: req.body.text,
+        timestamp: bodyValidation.right.timestamp || null,
+        section,
         credentials,
-        lightDocumentOutput: req.body.light_document_output === true,
+        lightDocumentOutput:
+          bodyValidation.right.light_document_output === true,
       });
 
       if (upsertRes.isErr()) {
@@ -309,24 +307,15 @@ async function handler(
         data_source: dataSource,
       });
 
-      const upsertContextValidation = UpsertContextSchema.decode(
-        req.body.upsert_context
-      );
-
-      let upsertContext: UpsertContext | undefined = undefined;
-      if (!isLeft(upsertContextValidation)) {
-        upsertContext = upsertContextValidation.right;
-      }
-
       const postUpsertHooksToRun = await getDocumentsPostUpsertHooksToRun({
         auth: await Authenticator.internalBuilderForWorkspace(owner.sId),
         dataSourceName: dataSource.name,
         documentId: req.query.documentId as string,
-        documentText: req.body.text,
+        documentText: fullText,
         documentHash: upsertRes.value.document.hash,
         dataSourceConnectorProvider: dataSource.connectorProvider || null,
         documentSourceUrl: sourceUrl || undefined,
-        upsertContext,
+        upsertContext: bodyValidation.right.upsert_context || undefined,
       });
 
       // TODO: parallel.

--- a/front/pages/w/[wId]/builder/data-sources/[name]/upsert.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/upsert.tsx
@@ -4,7 +4,6 @@ import { useRouter } from "next/router";
 import * as PDFJS from "pdfjs-dist/build/pdf";
 import { useContext, useEffect, useRef, useState } from "react";
 PDFJS.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${PDFJS.version}/pdf.worker.min.js`;
-
 import {
   Button,
   DocumentPlusIcon,
@@ -157,7 +156,11 @@ export default function DataSourceUpsert({
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          text,
+          section: {
+            prefix: null,
+            content: text,
+            sections: [],
+          },
           source_url: sourceUrl || undefined,
           tags: tags.filter((tag) => tag),
         }),
@@ -170,7 +173,6 @@ export default function DataSourceUpsert({
       );
     } else {
       const data = await res.json();
-      console.log("UPSERT Error", data.error);
       sendNotification({
         type: "error",
         title: "Error upserting document",


### PR DESCRIPTION
- Introduce `CoreAPIDataSourceDocumentSection`
- Expose it in our internal and external upsert APIs
- Move these APIs to io-ts

These APIs still accept `text` which they turn into a Section with no prefix.

(will rebase on new types/ hierarchy as soon as ready)

Deploy:
`core` supports both text and section, both optionally, so we want to deploy `core` first (will keep getting text) and then deploy `front` (will get section but no text)