### PR TITLE
Make VScode intellisense navigate to source files instead of build ar…

### DIFF
--- a/types/package.json
+++ b/types/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "author": "Dust",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "module": "dist/types.esm.js",
   "typings": "dist/index.d.ts",
   "files": [

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -6,6 +6,8 @@
     "moduleResolution": "node",
     "emitDeclarationOnly": false,
     "declaration": true,
-    "baseUrl": "./src"
+    "baseUrl": "./src",
+    "sourceMap": true,
+    "declarationMap": true
   }
 }


### PR DESCRIPTION
Make VScode intellisense navigate to source files instead of build artifact.

The key settings is `declarationMap` but `sourceMap` is also nice to have for debugging.