### PR TITLE
[Sparkle] Modal transitions show on mount

### DIFF
--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.48",
+  "version": "0.2.49",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.49",
+  "version": "0.2.48",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/components/Modal.tsx
+++ b/sparkle/src/components/Modal.tsx
@@ -125,7 +125,6 @@ export function Modal({
           leave="s-ease-in s-duration-150"
           leaveFrom="s-opacity-100"
           leaveTo="s-opacity-0"
-          appear={true}
         >
           <div className="s-fixed s-inset-0 s-bg-white/80 s-backdrop-blur-sm s-transition-opacity" />
         </Transition.Child>
@@ -140,7 +139,6 @@ export function Modal({
               leave="s-ease-in s-duration-200"
               leaveFrom={transitionLeaveFrom}
               leaveTo={transitionLeaveTo}
-              appear={true}
             >
               <Dialog.Panel
                 className={classNames(

--- a/sparkle/src/components/Modal.tsx
+++ b/sparkle/src/components/Modal.tsx
@@ -115,7 +115,7 @@ export function Modal({
   } = getModalClasses(type);
 
   return (
-    <Transition.Root show={isOpen} as={Fragment}>
+    <Transition.Root show={isOpen} as={Fragment} appear={true}>
       <Dialog as="div" className="s-relative s-z-50" onClose={onClose}>
         <Transition.Child
           as={Fragment}
@@ -125,6 +125,7 @@ export function Modal({
           leave="s-ease-in s-duration-150"
           leaveFrom="s-opacity-100"
           leaveTo="s-opacity-0"
+          appear={true}
         >
           <div className="s-fixed s-inset-0 s-bg-white/80 s-backdrop-blur-sm s-transition-opacity" />
         </Transition.Child>
@@ -139,6 +140,7 @@ export function Modal({
               leave="s-ease-in s-duration-200"
               leaveFrom={transitionLeaveFrom}
               leaveTo={transitionLeaveTo}
+              appear={true}
             >
               <Dialog.Panel
                 className={classNames(

--- a/sparkle/src/components/Modal.tsx
+++ b/sparkle/src/components/Modal.tsx
@@ -115,7 +115,7 @@ export function Modal({
   } = getModalClasses(type);
 
   return (
-    <Transition.Root show={isOpen} as={Fragment} appear={true}>
+    <Transition show={isOpen} as={Fragment} appear={true}>
       <Dialog as="div" className="s-relative s-z-50" onClose={onClose}>
         <Transition.Child
           as={Fragment}
@@ -167,6 +167,6 @@ export function Modal({
           </div>
         </div>
       </Dialog>
-    </Transition.Root>
+    </Transition>
   );
 }


### PR DESCRIPTION
Make it so that modal transitions are effective on initial modal mount

Useful notably because some modals are shown right when mounted

Also fixes: Transition.Root is for vue.js, Transition is for react cf [doc](https://headlessui.com/react/transition#transition-child)
