### PR TITLE
fix checks: allow empty string in front, don't send upsert if there is no message in slack connector

### DIFF
--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -398,11 +398,13 @@ export async function syncNonThreaded(
     }
     hasMore = c.has_more;
   } while (hasMore);
+
   if (messages.length === 0) {
     // no non threaded messages, so we're done
     return;
   }
   messages.reverse();
+
   const text = await formatMessagesForUpsert(
     channelId,
     messages,
@@ -571,6 +573,11 @@ export async function syncThread(
   const botUserId = await getBotUserIdMemoized(slackClient);
   allMessages = allMessages.filter((m) => m.user !== botUserId);
 
+  if (allMessages.length === 0) {
+    // No threaded messages, so we're done.
+    return;
+  }
+
   const text = await formatMessagesForUpsert(
     channelId,
     allMessages,
@@ -603,6 +610,7 @@ export async function syncThread(
     messageTs: threadTs,
     documentId: documentId,
   });
+
   await upsertToDatasource({
     dataSourceConfig,
     documentId,

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
@@ -199,13 +199,14 @@ async function handler(
         sourceUrl = standardizedSourceUrl;
       }
 
-      const section = bodyValidation.right.text
-        ? {
-            prefix: null,
-            content: bodyValidation.right.text,
-            sections: [],
-          }
-        : bodyValidation.right.section || null;
+      const section =
+        typeof bodyValidation.right.text === "string"
+          ? {
+              prefix: null,
+              content: bodyValidation.right.text,
+              sections: [],
+            }
+          : bodyValidation.right.section || null;
 
       if (!section) {
         return apiError(req, res, {

--- a/front/pages/api/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
@@ -106,13 +106,14 @@ async function handler(
         sourceUrl = standardizedSourceUrl;
       }
 
-      const section = bodyValidation.right.text
-        ? {
-            prefix: null,
-            content: bodyValidation.right.text,
-            sections: [],
-          }
-        : bodyValidation.right.section || null;
+      const section =
+        typeof bodyValidation.right.text === "string"
+          ? {
+              prefix: null,
+              content: bodyValidation.right.text,
+              sections: [],
+            }
+          : bodyValidation.right.section || null;
 
       if (!section) {
         return apiError(req, res, {


### PR DESCRIPTION
Example error: https://app.datadoghq.eu/logs?query=%22API%20Error%22%20&cols=host%2Cservice&event=AgAAAYwg2Et5iQpmZAAAAAAAAAAYAAAAAEFZd2cyRTZVQUFDWGNsQ0pSek9sNVFBSQAAACQAAAAAMDE4YzIwZGEtNmNjMi00NTRlLWEyNzAtYjIyMWI5NTI2ZWM0&index=%2A&messageDisplay=inline&refresh_mode=paused&stream_sort=desc&view=spans&viz=stream&from_ts=1701358772342&to_ts=1701358915658&live=false

slack thread is empty
text = ""

front interpret it as a falsy value and error with a validation error.