### PR TITLE
[Ahuna] Assistant Details modal

### DIFF
--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -14,6 +14,8 @@ import {
   CommandLineIcon,
   Button,
   TrashIcon,
+  PlusIcon,
+  DashIcon,
 } from "@dust-tt/sparkle";
 import ReactMarkdown from "react-markdown";
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
@@ -21,7 +23,6 @@ import { ConnectorProvider } from "@app/lib/connectors_api";
 import { useApp } from "@app/lib/swr";
 import { WorkspaceType } from "@app/types/user";
 import { useContext, useState } from "react";
-import { useRouter } from "next/router";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 
 export function AssistantDetails({
@@ -189,8 +190,33 @@ function ButtonsSection({
       ["builder", "admin"].includes(owner.role)) ||
     (["published", "private"].includes(agentConfiguration.scope) &&
       inMyList(agentConfiguration));
+  const canAddRemoveList = ["published", "workspace"].includes(
+    agentConfiguration.scope
+  );
   return (
     <Button.List className="flex items-center justify-end gap-1">
+      {canAddRemoveList &&
+        (inMyList(agentConfiguration) ? (
+          <Button
+            label="Remove from my list"
+            variant="tertiary"
+            icon={DashIcon}
+            size="xs"
+            onClick={() => {
+              // TODO IMPLEMENT
+            }}
+          />
+        ) : (
+          <Button
+            label="Add to my list"
+            variant="tertiary"
+            icon={PlusIcon}
+            size="xs"
+            onClick={() => {
+              // TODO IMPLEMENT
+            }}
+          />
+        ))}
       {canDelete && (
         <>
           <DeletionModal
@@ -227,7 +253,6 @@ function DeletionModal({
   onClose: () => void;
   detailsModalClose: () => void;
 }) {
-  const router = useRouter();
   const sendNotification = useContext(SendNotificationsContext);
 
   const [isDeleting, setIsDeleting] = useState<boolean>(false);

--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -1,4 +1,21 @@
 import {
+  Avatar,
+  Button,
+  CloudArrowDownIcon,
+  CommandLineIcon,
+  DashIcon,
+  Modal,
+  PlusIcon,
+  TrashIcon,
+} from "@dust-tt/sparkle";
+import { useContext, useState } from "react";
+import ReactMarkdown from "react-markdown";
+
+import { SendNotificationsContext } from "@app/components/sparkle/Notification";
+import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
+import { ConnectorProvider } from "@app/lib/connectors_api";
+import { useApp } from "@app/lib/swr";
+import {
   DustAppRunConfigurationType,
   isDustAppRunConfiguration,
 } from "@app/types/assistant/actions/dust_app_run";
@@ -7,23 +24,7 @@ import {
   isRetrievalConfiguration,
 } from "@app/types/assistant/actions/retrieval";
 import { AgentConfigurationType } from "@app/types/assistant/agent";
-import {
-  Modal,
-  Avatar,
-  CloudArrowDownIcon,
-  CommandLineIcon,
-  Button,
-  TrashIcon,
-  PlusIcon,
-  DashIcon,
-} from "@dust-tt/sparkle";
-import ReactMarkdown from "react-markdown";
-import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
-import { ConnectorProvider } from "@app/lib/connectors_api";
-import { useApp } from "@app/lib/swr";
 import { WorkspaceType } from "@app/types/user";
-import { useContext, useState } from "react";
-import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 
 export function AssistantDetails({
   owner,
@@ -312,7 +313,7 @@ function DeletionModal({
   );
 }
 
-function inMyList(agentConfiguration: AgentConfigurationType): boolean {
+function inMyList(_agentConfiguration: AgentConfigurationType): boolean {
   // TODO IMPLEMENT
-  return true;
+  return !!_agentConfiguration || true;
 }

--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -137,7 +137,7 @@ function DataSourcesSection({
           : CloudArrowDownIcon;
         const dsDocumentNumberText = `(${
           ds.filter.parents?.in.length ?? "all"
-        } elements)`;
+        } element(s))`;
         return (
           <div className="flex flex-col gap-2" key={ds.dataSourceId}>
             <div className="flex items-center gap-2 capitalize">

--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -7,12 +7,22 @@ import {
   isRetrievalConfiguration,
 } from "@app/types/assistant/actions/retrieval";
 import { AgentConfigurationType } from "@app/types/assistant/agent";
-import { Modal, Avatar, CloudArrowDownIcon } from "@dust-tt/sparkle";
+import {
+  Modal,
+  Avatar,
+  CloudArrowDownIcon,
+  CommandLineIcon,
+  Button,
+  TrashIcon,
+} from "@dust-tt/sparkle";
 import ReactMarkdown from "react-markdown";
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 import { ConnectorProvider } from "@app/lib/connectors_api";
 import { useApp } from "@app/lib/swr";
 import { WorkspaceType } from "@app/types/user";
+import { useContext, useState } from "react";
+import { useRouter } from "next/router";
+import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 
 export function AssistantDetails({
   owner,
@@ -21,51 +31,68 @@ export function AssistantDetails({
   onClose,
 }: {
   owner: WorkspaceType;
-  assistant: AgentConfigurationType | null;
+  assistant: AgentConfigurationType;
   show: boolean;
   onClose: () => void;
 }) {
+  const DescriptionSection = () => (
+    <div className="flex flex-col gap-4 sm:flex-row">
+      <Avatar
+        visual={<img src={assistant.pictureUrl} alt="Assistant avatar" />}
+        size="md"
+      />
+      <div>{assistant.description}</div>
+    </div>
+  );
+
+  const InstructionsSection = () =>
+    assistant.generation?.prompt ? (
+      <div className="flex flex-col gap-2">
+        <div className="text-lg font-bold text-element-800">Instructions</div>
+        <ReactMarkdown className="max-h-64 overflow-y-auto">
+          {assistant.generation.prompt}
+        </ReactMarkdown>
+      </div>
+    ) : (
+      "This assistant has no instructions."
+    );
+
+  const ActionSection = () =>
+    assistant.action ? (
+      isDustAppRunConfiguration(assistant.action) ? (
+        <div className="flex flex-col gap-2">
+          <div className="text-lg font-bold text-element-800">Action</div>
+          <DustAppSection dustApp={assistant.action} owner={owner} />
+        </div>
+      ) : isRetrievalConfiguration(assistant.action) ? (
+        <div className="flex flex-col gap-2">
+          <div className="text-lg font-bold text-element-800">
+            Data source(s)
+          </div>
+          <DataSourcesSection
+            dataSourceConfigurations={assistant.action.dataSources}
+          />
+        </div>
+      ) : null
+    ) : null;
+
   return (
     <Modal
       isOpen={show}
-      title={`@${assistant?.name}`}
+      title={`@${assistant.name}`}
       onClose={onClose}
       hasChanged={false}
       variant="side-sm"
     >
       <div className="flex flex-col gap-5 p-6 text-sm text-element-700">
-        <div className="flex">buttons</div>
-        <div className="flex flex-col gap-4 sm:flex-row">
-          <Avatar
-            visual={<img src={assistant?.pictureUrl} alt="Assistant avatar" />}
-            size="md"
-          />
-          <div>{assistant?.description}</div>
-        </div>
-
-        <div className="flex flex-col gap-2">
-          <div className="text-lg font-bold text-element-800">Instructions</div>
-          <ReactMarkdown className="max-h-64 overflow-y-auto">
-            {assistant?.generation?.prompt || ""}
-          </ReactMarkdown>
-        </div>
-        {assistant?.action ? (
-          isDustAppRunConfiguration(assistant.action) ? (
-            <div className="flex flex-col gap-2">
-              <div className="text-lg font-bold text-element-800">Action</div>
-              <DustAppSection dustApp={assistant.action} owner={owner} />
-            </div>
-          ) : isRetrievalConfiguration(assistant.action) ? (
-            <div className="flex flex-col gap-2">
-              <div className="text-lg font-bold text-element-800">
-                Data source(s)
-              </div>
-              <DataSourcesSection
-                dataSourceConfigurations={assistant.action.dataSources}
-              />
-            </div>
-          ) : null
-        ) : null}
+        <ButtonsSection
+          owner={owner}
+          agentConfiguration={assistant}
+          detailsModalClose={onClose}
+        />
+        <DescriptionSection />
+        <InstructionsSection />
+        <ActionSection />
       </div>
     </Modal>
   );
@@ -80,6 +107,7 @@ function DataSourcesSection({
     ds.dataSourceId.startsWith("managed-")
       ? (ds.dataSourceId.slice(8) as ConnectorProvider)
       : undefined;
+
   const compareDatasourceNames = (
     a: DataSourceConfiguration,
     b: DataSourceConfiguration
@@ -97,6 +125,7 @@ function DataSourcesSection({
     }
     return a.dataSourceId > b.dataSourceId ? -1 : 1;
   };
+
   return (
     <div className="flex flex-col gap-1">
       {dataSourceConfigurations.sort(compareDatasourceNames).map((ds) => {
@@ -123,6 +152,7 @@ function DataSourcesSection({
     </div>
   );
 }
+
 function DustAppSection({
   owner,
   dustApp,
@@ -131,5 +161,133 @@ function DustAppSection({
   dustApp: DustAppRunConfigurationType;
 }) {
   const { app } = useApp({ workspaceId: owner.sId, appId: dustApp.appId });
-  return <div>{app ? app.name : ""}</div>;
+  return (
+    <div className="flex flex-col gap-2">
+      <div>The following action is run before answering:</div>
+      <div className="flex items-center gap-2 capitalize">
+        <div>
+          <CommandLineIcon />
+        </div>
+        <div>{app ? app.name : ""}</div>
+      </div>
+    </div>
+  );
+}
+
+function ButtonsSection({
+  owner,
+  agentConfiguration,
+  detailsModalClose,
+}: {
+  owner: WorkspaceType;
+  agentConfiguration: AgentConfigurationType;
+  detailsModalClose: () => void;
+}) {
+  const [showDeletionModal, setShowDeletionModal] = useState<boolean>(false);
+  const canDelete =
+    (agentConfiguration.scope === "workspace" &&
+      ["builder", "admin"].includes(owner.role)) ||
+    (["published", "private"].includes(agentConfiguration.scope) &&
+      inMyList(agentConfiguration));
+  return (
+    <Button.List className="flex items-center justify-end gap-1">
+      {canDelete && (
+        <>
+          <DeletionModal
+            owner={owner}
+            agentConfiguration={agentConfiguration}
+            show={showDeletionModal}
+            onClose={() => setShowDeletionModal(false)}
+            detailsModalClose={detailsModalClose}
+          />
+          <Button
+            label={"Delete"}
+            icon={TrashIcon}
+            variant="secondaryWarning"
+            size="xs"
+            disabled={!["builder", "admin"].includes(owner.role)}
+            onClick={() => setShowDeletionModal(true)}
+          />
+        </>
+      )}
+    </Button.List>
+  );
+}
+
+function DeletionModal({
+  owner,
+  agentConfiguration,
+  show,
+  onClose,
+  detailsModalClose,
+}: {
+  owner: WorkspaceType;
+  agentConfiguration: AgentConfigurationType;
+  show: boolean;
+  onClose: () => void;
+  detailsModalClose: () => void;
+}) {
+  const router = useRouter();
+  const sendNotification = useContext(SendNotificationsContext);
+
+  const [isDeleting, setIsDeleting] = useState<boolean>(false);
+  return (
+    <Modal
+      isOpen={show}
+      title={`Delete @${agentConfiguration.name}`}
+      onClose={onClose}
+      hasChanged={false}
+      variant="dialogue"
+    >
+      <div className="flex flex-col gap-2 p-6 text-sm text-element-700">
+        <div>
+          Are you sure you want to delete this assistant? It will be removed for
+          all users and the action cannot be undone.
+          <br />
+          Consider just removing it from your list if you are not sure others
+          won't be affected.
+        </div>
+      </div>
+      <div className="flex flex-row justify-end gap-1">
+        <Button label="Cancel" variant="tertiary" onClick={onClose} />
+        <Button
+          label={isDeleting ? "Deleting..." : "Yes, Delete"}
+          variant="primaryWarning"
+          onClick={async () => {
+            setIsDeleting(true);
+            const res = await fetch(
+              `/api/w/${owner.sId}/assistant/agent_configurations/${agentConfiguration.sId}`,
+              {
+                method: "DELETE",
+              }
+            );
+            onClose();
+            detailsModalClose();
+            if (!res.ok) {
+              const data = await res.json();
+              sendNotification({
+                title: "Error deleting Assistant",
+                description: data.error.message,
+                type: "error",
+              });
+              return;
+            } else {
+              sendNotification({
+                title: "Assistant deleted",
+                type: "success",
+              });
+            }
+
+            setIsDeleting(false);
+          }}
+          disabled={isDeleting}
+        />
+      </div>
+    </Modal>
+  );
+}
+
+function inMyList(agentConfiguration: AgentConfigurationType): boolean {
+  // TODO IMPLEMENT
+  return true;
 }

--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -8,23 +8,23 @@ import {
   PlusIcon,
   TrashIcon,
 } from "@dust-tt/sparkle";
+import { ConnectorProvider } from "@dust-tt/types";
+import {
+  DustAppRunConfigurationType,
+  isDustAppRunConfiguration,
+} from "@dust-tt/types";
+import {
+  DataSourceConfiguration,
+  isRetrievalConfiguration,
+} from "@dust-tt/types";
+import { AgentConfigurationType } from "@dust-tt/types";
+import { WorkspaceType } from "@dust-tt/types";
 import { useContext, useState } from "react";
 import ReactMarkdown from "react-markdown";
 
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
-import { ConnectorProvider } from "@app/lib/connectors_api";
 import { useApp } from "@app/lib/swr";
-import {
-  DustAppRunConfigurationType,
-  isDustAppRunConfiguration,
-} from "@app/types/assistant/actions/dust_app_run";
-import {
-  DataSourceConfiguration,
-  isRetrievalConfiguration,
-} from "@app/types/assistant/actions/retrieval";
-import { AgentConfigurationType } from "@app/types/assistant/agent";
-import { WorkspaceType } from "@app/types/user";
 
 export function AssistantDetails({
   owner,

--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -1,0 +1,135 @@
+import {
+  DustAppRunConfigurationType,
+  isDustAppRunConfiguration,
+} from "@app/types/assistant/actions/dust_app_run";
+import {
+  DataSourceConfiguration,
+  isRetrievalConfiguration,
+} from "@app/types/assistant/actions/retrieval";
+import { AgentConfigurationType } from "@app/types/assistant/agent";
+import { Modal, Avatar, CloudArrowDownIcon } from "@dust-tt/sparkle";
+import ReactMarkdown from "react-markdown";
+import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
+import { ConnectorProvider } from "@app/lib/connectors_api";
+import { useApp } from "@app/lib/swr";
+import { WorkspaceType } from "@app/types/user";
+
+export function AssistantDetails({
+  owner,
+  assistant,
+  show,
+  onClose,
+}: {
+  owner: WorkspaceType;
+  assistant: AgentConfigurationType | null;
+  show: boolean;
+  onClose: () => void;
+}) {
+  return (
+    <Modal
+      isOpen={show}
+      title={`@${assistant?.name}`}
+      onClose={onClose}
+      hasChanged={false}
+      variant="side-sm"
+    >
+      <div className="flex flex-col gap-5 p-6 text-sm text-element-700">
+        <div className="flex">buttons</div>
+        <div className="flex flex-col gap-4 sm:flex-row">
+          <Avatar
+            visual={<img src={assistant?.pictureUrl} alt="Assistant avatar" />}
+            size="md"
+          />
+          <div>{assistant?.description}</div>
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <div className="text-lg font-bold text-element-800">Instructions</div>
+          <ReactMarkdown className="max-h-64 overflow-y-auto">
+            {assistant?.generation?.prompt || ""}
+          </ReactMarkdown>
+        </div>
+        {assistant?.action ? (
+          isDustAppRunConfiguration(assistant.action) ? (
+            <div className="flex flex-col gap-2">
+              <div className="text-lg font-bold text-element-800">Action</div>
+              <DustAppSection dustApp={assistant.action} owner={owner} />
+            </div>
+          ) : isRetrievalConfiguration(assistant.action) ? (
+            <div className="flex flex-col gap-2">
+              <div className="text-lg font-bold text-element-800">
+                Data source(s)
+              </div>
+              <DataSourcesSection
+                dataSourceConfigurations={assistant.action.dataSources}
+              />
+            </div>
+          ) : null
+        ) : null}
+      </div>
+    </Modal>
+  );
+}
+
+function DataSourcesSection({
+  dataSourceConfigurations,
+}: {
+  dataSourceConfigurations: DataSourceConfiguration[];
+}) {
+  const getProviderName = (ds: DataSourceConfiguration) =>
+    ds.dataSourceId.startsWith("managed-")
+      ? (ds.dataSourceId.slice(8) as ConnectorProvider)
+      : undefined;
+  const compareDatasourceNames = (
+    a: DataSourceConfiguration,
+    b: DataSourceConfiguration
+  ) => {
+    const aProviderName = getProviderName(a);
+    const bProviderName = getProviderName(b);
+    if (aProviderName && bProviderName) {
+      return aProviderName > bProviderName ? -1 : 1;
+    }
+    if (aProviderName) {
+      return -1;
+    }
+    if (bProviderName) {
+      return 1;
+    }
+    return a.dataSourceId > b.dataSourceId ? -1 : 1;
+  };
+  return (
+    <div className="flex flex-col gap-1">
+      {dataSourceConfigurations.sort(compareDatasourceNames).map((ds) => {
+        const providerName = getProviderName(ds);
+        const DsLogo = providerName
+          ? CONNECTOR_CONFIGURATIONS[providerName].logoComponent
+          : CloudArrowDownIcon;
+        const dsDocumentNumberText = `(${
+          ds.filter.parents?.in.length ?? "all"
+        } elements)`;
+        return (
+          <div className="flex flex-col gap-2" key={ds.dataSourceId}>
+            <div className="flex items-center gap-2 capitalize">
+              <div>
+                <DsLogo />
+              </div>
+              <div>{`${
+                providerName ?? ds.dataSourceId
+              } ${dsDocumentNumberText}`}</div>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+function DustAppSection({
+  owner,
+  dustApp,
+}: {
+  owner: WorkspaceType;
+  dustApp: DustAppRunConfigurationType;
+}) {
+  const { app } = useApp({ workspaceId: owner.sId, appId: dustApp.appId });
+  return <div>{app ? app.name : ""}</div>;
+}

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -1128,7 +1128,7 @@ export default function AssistantBuilder({
             >
               <div className="text-sm text-element-700">
                 Your assistant can execute a Dust Application of your design
-                before answering. The output of the app (last block) is injeced
+                before answering. The output of the app (last block) is injected
                 in context for the model to generate an answer. The inputs of
                 the app will be automatically generated from the context of the
                 conversation based on the descriptions you provided in the

--- a/front/lib/swr.ts
+++ b/front/lib/swr.ts
@@ -555,3 +555,25 @@ export function useDatabaseTables({
     mutateTables: mutate,
   };
 }
+
+export function useApp({
+  workspaceId,
+  appId,
+}: {
+  workspaceId: string;
+  appId: string;
+}) {
+  const appFetcher: Fetcher<{ app: AppType }> = fetcher;
+
+  const { data, error, mutate } = useSWR(
+    `/api/w/${workspaceId}/apps/${appId}`,
+    appFetcher
+  );
+
+  return {
+    app: data ? data.app : null,
+    isAppLoading: !error && !data,
+    isAppError: error,
+    mutateApp: mutate,
+  };
+}

--- a/front/package.json
+++ b/front/package.json
@@ -13,7 +13,7 @@
     "initdb": "env $(cat .env.local) npx tsx admin/db.ts"
   },
   "dependencies": {
-    "@dust-tt/sparkle": "^0.2.48",
+    "@dust-tt/sparkle": "^0.2.49",
     "@dust-tt/types": "file:../types",
     "@emoji-mart/data": "^1.1.2",
     "@emoji-mart/react": "^1.1.1",

--- a/front/pages/api/w/[wId]/apps/[aId]/index.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/index.ts
@@ -7,13 +7,13 @@ import { App } from "@app/lib/models";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import { AppType } from "@app/types/app";
 
-export type PostAppResponseBody = {
+export type GetOrPostAppResponseBody = {
   app: AppType;
 };
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<PostAppResponseBody | ReturnedAPIErrorType>
+  res: NextApiResponse<GetOrPostAppResponseBody | ReturnedAPIErrorType>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(
@@ -60,6 +60,21 @@ async function handler(
   }
 
   switch (req.method) {
+    case "GET":
+      res.status(200).json({
+        app: {
+          id: app.id,
+          sId: app.sId,
+          name: app.name,
+          description: app.description,
+          visibility: app.visibility,
+          savedSpecification: app.savedSpecification,
+          savedConfig: app.savedConfig,
+          savedRun: app.savedRun,
+          dustAPIProjectId: app.dustAPIProjectId,
+        },
+      });
+      break;
     case "POST":
       if (!auth.isBuilder()) {
         return apiError(req, res, {

--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.48",
+  "version": "0.2.49",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.48",
+      "version": "0.2.49",
       "license": "ISC",
       "dependencies": {
         "@headlessui/react": "^1.7.17"


### PR DESCRIPTION
Related [task](https://github.com/dust-tt/dust/issues/2645) and [figma](https://www.figma.com/file/QOxHwppG64GtPocpDhS6Y7/Product?type=design&node-id=2700-17176&mode=design&t=UaNFF8R1A4ti0dQ0-4)

NOTE: shipping the PR would have **no user facing impact** since the Assistant Details modal is not yet accessible anywhere in the app. This is a prep for AssistantGallery Modal & My assistants pages that I'll do next.

## Priorization & product questions
- Assistant instructions
  - Since prompt can be very long (e.g. help see screenshot below) and summarizing is non trivial (store? or latency to display window?) and non essential, settled for scroll `auto` with a `max-h-64` as v1
  - Do we show prompts of system agents here? (@help in particular) => would say no, and just answer "Instructions of this assistant are not available." WDYT?
- assistant deletion -> ux wise it is shown for any assistant in the user's list -- but not if it's not in their list, to minimize mishaps
  - Would we prefer to always show it but disabled when deletion is not possible?
  - There can be user frustrations when an assistant they created and published is deleted by somebody else => just to confirm we are clear on that

- global assistants => at the time they are considered on the user's list, can only be triggered on / off for the whole workspace
  - allowing users to opt out of them (e.g. opt out of @gpt4) is slightly more work + I'm not sure we want that?

- Add / remove from my list
  - Only show for 'workspace' / 'published'
  - Not operational as per this PR

#### Not yet done - to priorize
- modal display: removing the blur
- modal closing: replacing the cross on right by a chevron on left
- display usage stats in the modal
- duplicate button (planned soon though)

To discuss whether:  should be done before user-facingness / ok v2 but guaranteed in climb / ok v3, should be done but we can wait  / actually not that important

#### Shots
With dust app action, already in list, deletable
![image](https://github.com/dust-tt/dust/assets/5437393/97d256ae-88a3-488d-b3f7-a3d794e4394e)

Not yet in list, deletable, no action
![image](https://github.com/dust-tt/dust/assets/5437393/f4cf0460-cb7c-4993-8b61-7c914a5dda7f)

Data sources
![image](https://github.com/dust-tt/dust/assets/5437393/97d897ed-3ea3-4326-8df4-e4e7226feb4a)

Delete popup
![image](https://github.com/dust-tt/dust/assets/5437393/bb2b328a-3aa9-42a8-a196-bd7babbe789b)

Long instructions
![image](https://github.com/dust-tt/dust/assets/5437393/9b942777-11f5-45c0-a72d-5fc230b802c9)

Raw model
![image](https://github.com/dust-tt/dust/assets/5437393/6d76c9e5-8f89-4519-b937-a3d2c6b2eda1)



