### PR TITLE
remove support for text in core

### DIFF
--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -1381,8 +1381,7 @@ struct DataSourcesDocumentsUpsertPayload {
     tags: Vec<String>,
     parents: Vec<String>,
     source_url: Option<String>,
-    text: Option<String>,
-    section: Option<Section>,
+    section: Section,
     credentials: run::Credentials,
     light_document_output: Option<bool>,
 }
@@ -1396,31 +1395,6 @@ async fn data_sources_documents_upsert(
     let light_document_output = match payload.light_document_output {
         Some(v) => v,
         None => false,
-    };
-
-    utils::info(&format!(
-        "Upserting document: section_is_set={} text_is_set={}",
-        payload.section.is_some(),
-        payload.text.is_some()
-    ));
-
-    let section = match payload.section {
-        Some(s) => s,
-        None => match payload.text {
-            Some(text) => Section {
-                prefix: None,
-                content: Some(text),
-                sections: vec![],
-            },
-            None => {
-                return error_response(
-                    StatusCode::BAD_REQUEST,
-                    "bad_request",
-                    "Either `section` or `text` must be provided",
-                    None,
-                )
-            }
-        },
     };
 
     match state
@@ -1452,7 +1426,7 @@ async fn data_sources_documents_upsert(
                         &payload.tags,
                         &payload.parents,
                         &payload.source_url,
-                        section,
+                        payload.section,
                         true, // preserve system tags
                     )
                     .await


### PR DESCRIPTION
This is safe: https://app.datadoghq.eu/logs?query=%22Upserting%20document%3A%22%20&cols=host%2Cservice&index=%2A&messageDisplay=inline&refresh_mode=sliding&stream_sort=desc&viz=stream&from_ts=1701364541792&to_ts=1701365441792&live=true

Even when we receive text in front (backward compatibility) we turn it into section already today