### PR TITLE
feat: support for parsing date/time in CSV

### DIFF
--- a/front/lib/core_api.ts
+++ b/front/lib/core_api.ts
@@ -85,7 +85,7 @@ export type CoreAPIDatabase = {
 
 export type CoreAPIDatabaseTableSchema = Record<
   string,
-  "int" | "float" | "text" | "bool"
+  "int" | "float" | "text" | "bool" | "datetime"
 >;
 
 export type CoreAPIDatabaseTable = {


### PR DESCRIPTION
the `new Date()` in JS is actually pretty neat. It supports a wide range of formats without the need to specify anything.
For `xx/xx/yyyy` style dates, it will use the (very dumb) US date format however.

Also add int->float widening to `TableSchema::from_rows`.

<img width="915" alt="Screenshot 2023-12-01 at 12 42 24" src="https://github.com/dust-tt/dust/assets/14199823/d8b16109-5939-4320-a89d-7f34f3a18759">

data used here looks like this (from [kaggle](https://www.kaggle.com/datasets/sumanthvrao/daily-climate-time-series-data?select=DailyDelhiClimateTrain.csv)):
```
date,meantemp,humidity,wind_speed,meanpressure
2017-03-27,29.5,38.625,13.65,1009.5
2017-03-28,29.88888888888889,40.666666666666664,8.844444444444445,1009.0
2017-03-29,31.0,34.5,13.2,1007.125
2017-03-30,29.285714285714285,36.857142857142854,10.585714285714285,1007.1428571428571
2017-03-31,30.625,37.625,6.949999999999999,1007.5
2017-04-01,31.375,35.125,9.0375,1005.0
```
