### PR TITLE
Move slack to chunker v2 structure

### DIFF
--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -1,4 +1,4 @@
-import { ModelId } from "@dust-tt/types";
+import { CoreAPIDataSourceDocumentSection, ModelId } from "@dust-tt/types";
 import {
   CodedError,
   ErrorCode,
@@ -405,8 +405,9 @@ export async function syncNonThreaded(
   }
   messages.reverse();
 
-  const text = await formatMessagesForUpsert(
+  const content = await formatMessagesForUpsert(
     channelId,
+    channelName,
     messages,
     connectorId,
     client
@@ -435,20 +436,18 @@ export async function syncNonThreaded(
     : undefined;
 
   const tags = getTagsForPage(documentId, channelId, channelName);
+
   await SlackMessages.upsert({
     connectorId: connectorId,
     channelId: channelId,
     messageTs: undefined,
     documentId: documentId,
   });
+
   await upsertToDatasource({
     dataSourceConfig,
     documentId,
-    documentContent: {
-      prefix: null,
-      content: text,
-      sections: [],
-    },
+    documentContent: content,
     documentUrl: sourceUrl,
     timestampMs: createdAt,
     tags,
@@ -582,8 +581,9 @@ export async function syncThread(
     return;
   }
 
-  const text = await formatMessagesForUpsert(
+  const content = await formatMessagesForUpsert(
     channelId,
+    channelName,
     allMessages,
     connectorId,
     slackClient
@@ -618,11 +618,7 @@ export async function syncThread(
   await upsertToDatasource({
     dataSourceConfig,
     documentId,
-    documentContent: {
-      prefix: null,
-      content: text,
-      sections: [],
-    },
+    documentContent: content,
     documentUrl: sourceUrl,
     timestampMs: createdAt,
     tags,
@@ -659,31 +655,62 @@ async function processMessageForMentions(
 
 export async function formatMessagesForUpsert(
   channelId: string,
+  channelName: string,
   messages: MessageElement[],
   connectorId: ModelId,
   slackClient: WebClient
-) {
-  return (
-    await Promise.all(
-      messages.map(async (message) => {
-        const text = await processMessageForMentions(
-          message.text as string,
-          connectorId,
-          slackClient
-        );
+): Promise<CoreAPIDataSourceDocumentSection> {
+  const data = await Promise.all(
+    messages.map(async (message) => {
+      const text = await processMessageForMentions(
+        message.text as string,
+        connectorId,
+        slackClient
+      );
 
-        const userName = await getUserName(
-          message.user as string,
-          connectorId,
-          slackClient
-        );
-        const messageDate = new Date(parseInt(message.ts as string, 10) * 1000);
-        const messageDateStr = formatDateForUpsert(messageDate);
+      const userName = await getUserName(
+        message.user as string,
+        connectorId,
+        slackClient
+      );
+      const messageDate = new Date(parseInt(message.ts as string, 10) * 1000);
+      const messageDateStr = formatDateForUpsert(messageDate);
 
-        return `>> @${userName} [${messageDateStr}]:\n${text}\n`;
-      })
-    )
-  ).join("\n");
+      return {
+        dateStr: messageDateStr,
+        userName,
+        text: text,
+        content: text + "\n",
+        sections: [],
+      };
+    })
+  );
+
+  const first = data[0];
+  if (!first) {
+    throw new Error("Cannot format empty list of messages");
+  }
+
+  const truncate = (text: string) => {
+    const t = text.replace(/\s+/g, " ");
+    if (t.length > 128) {
+      t.substring(0, 128) + "...";
+    } else {
+      t;
+    }
+  };
+
+  return {
+    prefix: `Thread in #${channelName} [${first.dateStr}]: ${truncate(
+      first.text
+    )}\n`,
+    content: null,
+    sections: data.map((d) => ({
+      prefix: `>> @${d.userName} [${d.dateStr}]:\n`,
+      content: d.text + "\n",
+      sections: [],
+    })),
+  };
 }
 
 export async function fetchUsers(connectorId: ModelId) {

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -691,19 +691,10 @@ export async function formatMessagesForUpsert(
     throw new Error("Cannot format empty list of messages");
   }
 
-  const truncate = (text: string) => {
-    const t = text.replace(/\s+/g, " ");
-    if (t.length > 128) {
-      t.substring(0, 128) + "...";
-    } else {
-      t;
-    }
-  };
-
   return {
-    prefix: `Thread in #${channelName} [${first.dateStr}]: ${truncate(
-      first.text
-    )}\n`,
+    prefix: `Thread in #${channelName} [${first.dateStr}]: ${
+      first.text.replace(/\s+/g, " ").trim().substring(0, 128) + "..."
+    }\n`,
     content: null,
     sections: data.map((d) => ({
       prefix: `>> @${d.userName} [${d.dateStr}]:\n`,


### PR DESCRIPTION
New rendering will look like:
```
Thread in #product [20231130 22:54]: It would be fairly simple to add AI-generated charts...
>> @henry [20231130 22:54]:
It would be fairly simple to add AI-generated charts
>> @henry [20231130 22:59]:
maybe for these kind of purely visualisation code use-case, a smaller model fine-tuned on code would allow to save a ton of time ?
>> @henry [20231201 10:28]:
is that something that would be worth building at some point @spolu @gabriel ? I think we could inline the charts easily inside of the message with a sandboxed iframe. It would be better than what chatgpt has because they are interactive (and matplotlib is ugly)
```

The initial `Thread in ...` part will be repeated in all chunks. The author of the message is repeated as well in chunks if the message is rendered to multiple chunks