### PR TITLE
enh(notion): display block children in orphaned resources

### DIFF
--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -1614,6 +1614,13 @@ export async function renderAndUpsertPageFromCache({
     );
   }
 
+  // If the parent is still a block, it means we couldn't find a valid parent. In that case, we
+  // mark the parent as "unknown" so that the resource shows up in the orphaned resources list.
+  if (parentType === "block") {
+    parentId = "unknown";
+    parentType = "unknown";
+  }
+
   // checks if the parent is accessible. If not, attempts to refetch the page to hopefully get a
   // valid parent. If that fails, returns "unknown" parent (i.e, orphaned node).
   const resolvedParent = await resolveResourceParent({


### PR DESCRIPTION
When a database or page parent is a block that is within a page that our integration is not allowed to see, the "parentId" will be the ID of that block.
That means we cannot surface this database in the resource tree. If we use `unknown` as the parent, it will show up in the orphaned resources which is better.