### PR TITLE
More resilient data source deleted documents scrubbing

### DIFF
--- a/front/production_checks/checks/scrub_deleted_core_document_versions.ts
+++ b/front/production_checks/checks/scrub_deleted_core_document_versions.ts
@@ -163,41 +163,26 @@ async function scrubDocument({
     .bucket(DUST_DATA_SOURCES_BUCKET)
     .getFiles({ prefix: path });
 
-  try {
-    await Promise.all(
-      files.map((f) => {
-        if (!seen.has(f.name)) {
-          seen.add(f.name);
-          logger.info(
-            {
-              path: f.name,
-              documentId: document_id,
-              documentHash: hash,
-              dataSourceProject: dataSource.project,
-              dataSourceInternalId: dataSource.internal_id,
-              dataSourceId: dataSource.id,
-            },
-            "Scrubbing"
-          );
+  await Promise.all(
+    files.map((f) => {
+      if (!seen.has(f.name)) {
+        seen.add(f.name);
+        logger.info(
+          {
+            path: f.name,
+            documentId: document_id,
+            documentHash: hash,
+            dataSourceProject: dataSource.project,
+            dataSourceInternalId: dataSource.internal_id,
+            dataSourceId: dataSource.id,
+          },
+          "Scrubbing"
+        );
 
-          return f.delete();
-        }
-      })
-    );
-  } catch (e) {
-    logger.error(
-      {
-        error: e,
-        documentId: document_id,
-        documentHash: hash,
-        dataSourceProject: dataSource.project,
-        dataSourceInternalId: dataSource.internal_id,
-        dataSourceId: dataSource.id,
-      },
-      "Failed to scrub GDrive file. Giving up for this iteration."
-    );
-    return false;
-  }
+        return f.delete();
+      }
+    })
+  );
 
   await core_sequelize.query(
     `DELETE FROM data_sources_documents WHERE data_source = :data_source AND document_id = :document_id AND hash = :hash AND status = 'deleted'`,

--- a/front/production_checks/checks/scrub_deleted_core_document_versions.ts
+++ b/front/production_checks/checks/scrub_deleted_core_document_versions.ts
@@ -152,26 +152,41 @@ async function scrubDocument(
     .bucket(DUST_DATA_SOURCES_BUCKET)
     .getFiles({ prefix: path });
 
-  await Promise.all(
-    files.map((f) => {
-      if (!seen.has(f.name)) {
-        seen.add(f.name);
-        logger.info(
-          {
-            path: f.name,
-            documentId: document_id,
-            documentHash: hash,
-            dataSourceProject: dataSource.project,
-            dataSourceInternalId: dataSource.internal_id,
-            dataSourceId: dataSource.id,
-          },
-          "Scrubbing"
-        );
+  try {
+    await Promise.all(
+      files.map((f) => {
+        if (!seen.has(f.name)) {
+          seen.add(f.name);
+          logger.info(
+            {
+              path: f.name,
+              documentId: document_id,
+              documentHash: hash,
+              dataSourceProject: dataSource.project,
+              dataSourceInternalId: dataSource.internal_id,
+              dataSourceId: dataSource.id,
+            },
+            "Scrubbing"
+          );
 
-        return f.delete();
-      }
-    })
-  );
+          return f.delete();
+        }
+      })
+    );
+  } catch (e) {
+    logger.error(
+      {
+        error: e,
+        documentId: document_id,
+        documentHash: hash,
+        dataSourceProject: dataSource.project,
+        dataSourceInternalId: dataSource.internal_id,
+        dataSourceId: dataSource.id,
+      },
+      "Failed to scrub GDrive file. Giving up for this iteration."
+    );
+    return false;
+  }
 
   await core_sequelize.query(
     `DELETE FROM data_sources_documents WHERE data_source = :data_source AND document_id = :document_id AND hash = :hash AND status = 'deleted'`,

--- a/front/production_checks/temporal/activities.ts
+++ b/front/production_checks/temporal/activities.ts
@@ -30,7 +30,7 @@ export async function runAllChecksActivity() {
 
 async function runAllChecks(checks: Check[]) {
   const allCheckUuid = uuidv4();
-  mainLogger.info({ uuid: allCheckUuid }, "Running all checks");
+  mainLogger.info({ all_check_uuid: allCheckUuid }, "Running all checks");
   for (const check of checks) {
     const uuid = uuidv4();
     const logger = mainLogger.child({


### PR DESCRIPTION
When there are many documents we can have races against the same URL:

https://app.datadoghq.eu/logs?query=%22Scrubbing%22%20%40path%3A%225759%2Fe7175c4172d5ba484a88a69f8dbf70e57047f91f934a71f3c56a2e1521a6a006%2F5578587a4ff2d190473873f2785c14dcc2b2869d01a51c01efc0606912b9c8f8%2Fc6087ca46b00f9ddc6d9660fce80f8fb1d2f401bf97990b99f92175406328a46%2Fcontent.txt%22%20&agg_m=count&agg_t=count&cols=host%2Cservice&index=%2A&messageDisplay=inline&refresh_mode=sliding&stream_sort=desc&view=spans&viz=stream&from_ts=1701674235013&to_ts=1701677835013&live=true

-> Absorb errors and skip the end of the loop (will be retried at next iteration)

We also see some OAuth errors which may be coming from the fact that we re-auth a ton:

https://app.datadoghq.eu/logs?query=%22Production%20check%20failed%22%20&agg_m=count&agg_t=count&cols=host%2Cservice&event=AgAAAYwz5jdYhCxjLAAAAAAAAAAYAAAAAEFZd3o1a0hMQUFCTU5QMHpQVm9EV0FBQQAAACQAAAAAMDE4YzMzZWMtODQxZC00OTdlLTgxM2EtNGRjNTU4MzFmYWEz&index=%2A&messageDisplay=inline&refresh_mode=sliding&stream_sort=desc&view=spans&viz=stream&from_ts=1701674235013&to_ts=1701677835013&live=true

-> Share storage