### PR TITLE
[WIP] DustAPI() uses DUST_FRONT_API || url

### DIFF
--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -223,16 +223,13 @@ async function botAnswerMessage(
     connector
   );
 
-  const dustAPI = new DustAPI(
-    {
+  const dustAPI = new DustAPI({
+    credentials: {
       workspaceId: connector.workspaceId,
       apiKey: connector.workspaceAPIKey,
     },
     logger,
-    {
-      useLocalInDev: true,
-    }
-  );
+  });
   const mainMessage = await slackClient.chat.postMessage({
     channel: slackChannel,
     text: "_Thinking..._",

--- a/front/documents_post_process_hooks/hooks/document_tracker/lib.ts
+++ b/front/documents_post_process_hooks/hooks/document_tracker/lib.ts
@@ -3,7 +3,7 @@ import { DustAPI } from "@dust-tt/types";
 import { TRACKABLE_CONNECTOR_TYPES } from "@app/documents_post_process_hooks/hooks/document_tracker/consts";
 import { Authenticator, prodAPICredentialsForOwner } from "@app/lib/auth";
 import logger from "@app/logger/logger";
-const {DUST_PROD_API} = process.env;
+const { DUST_PROD_API } = process.env;
 
 export async function getTrackableDataSources(workspaceId: string): Promise<
   {
@@ -24,7 +24,11 @@ export async function getTrackableDataSources(workspaceId: string): Promise<
     throw new Error("DUST_PROD_API env variable is not set");
   }
 
-  const prodAPI = new DustAPI({credentials:prodCredentials, logger, url: DUST_PROD_API});
+  const prodAPI = new DustAPI({
+    credentials: prodCredentials,
+    logger,
+    url: DUST_PROD_API,
+  });
 
   // Fetch data sources
   const dsRes = await prodAPI.getDataSources(prodAPI.workspaceId());

--- a/front/documents_post_process_hooks/hooks/document_tracker/lib.ts
+++ b/front/documents_post_process_hooks/hooks/document_tracker/lib.ts
@@ -3,6 +3,7 @@ import { DustAPI } from "@dust-tt/types";
 import { TRACKABLE_CONNECTOR_TYPES } from "@app/documents_post_process_hooks/hooks/document_tracker/consts";
 import { Authenticator, prodAPICredentialsForOwner } from "@app/lib/auth";
 import logger from "@app/logger/logger";
+const {DUST_PROD_API} = process.env;
 
 export async function getTrackableDataSources(workspaceId: string): Promise<
   {
@@ -19,8 +20,11 @@ export async function getTrackableDataSources(workspaceId: string): Promise<
     );
   }
   const prodCredentials = await prodAPICredentialsForOwner(owner);
+  if (!DUST_PROD_API) {
+    throw new Error("DUST_PROD_API env variable is not set");
+  }
 
-  const prodAPI = new DustAPI(prodCredentials, logger);
+  const prodAPI = new DustAPI({credentials:prodCredentials, logger, url: DUST_PROD_API});
 
   // Fetch data sources
   const dsRes = await prodAPI.getDataSources(prodAPI.workspaceId());

--- a/front/lib/actions/helpers.ts
+++ b/front/lib/actions/helpers.ts
@@ -15,6 +15,8 @@ import {
 import { Authenticator, prodAPICredentialsForOwner } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 
+const { DUST_PROD_API } = process.env;
+
 interface CallActionParams<V extends t.Mixed> {
   workspaceId: string;
   input: { [key: string]: unknown };
@@ -59,8 +61,10 @@ export async function callAction<V extends t.Mixed>({
     );
   }
   const prodCredentials = await prodAPICredentialsForOwner(owner);
-
-  const prodAPI = new DustAPI(prodCredentials, logger);
+  if (!DUST_PROD_API) {
+    throw new Error("DUST_PROD_API env variable is not set");
+  }
+  const prodAPI = new DustAPI({credentials:prodCredentials, logger, url:DUST_PROD_API});
 
   const response = (await prodAPI.runApp(app, config, [input])) as Result<
     unknown,

--- a/front/lib/actions/helpers.ts
+++ b/front/lib/actions/helpers.ts
@@ -64,7 +64,11 @@ export async function callAction<V extends t.Mixed>({
   if (!DUST_PROD_API) {
     throw new Error("DUST_PROD_API env variable is not set");
   }
-  const prodAPI = new DustAPI({credentials:prodCredentials, logger, url:DUST_PROD_API});
+  const prodAPI = new DustAPI({
+    credentials: prodCredentials,
+    logger,
+    url: DUST_PROD_API,
+  });
 
   const response = (await prodAPI.runApp(app, config, [input])) as Result<
     unknown,

--- a/front/lib/actions/server.ts
+++ b/front/lib/actions/server.ts
@@ -6,7 +6,7 @@ import { Authenticator, prodAPICredentialsForOwner } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import { statsDClient } from "@app/logger/withlogging";
 
-const {DUST_PROD_API} = process.env;
+const { DUST_PROD_API } = process.env;
 
 // Record an event and a log for the action error.
 const logActionError = (
@@ -86,7 +86,11 @@ export async function runActionStreamed(
     throw new Error("DUST_PROD_API env variable is not set");
   }
   const prodCredentials = await prodAPICredentialsForOwner(owner);
-  const api = new DustAPI({credentials:prodCredentials, logger, url: DUST_PROD_API});
+  const api = new DustAPI({
+    credentials: prodCredentials,
+    logger,
+    url: DUST_PROD_API,
+  });
 
   const res = await api.runAppStreamed(action.app, config, inputs);
   if (res.isErr()) {
@@ -171,7 +175,11 @@ export async function runAction(
   const now = new Date();
 
   const prodCredentials = await prodAPICredentialsForOwner(owner);
-  const api = new DustAPI({credentials:prodCredentials, logger, url: DUST_PROD_API});
+  const api = new DustAPI({
+    credentials: prodCredentials,
+    logger,
+    url: DUST_PROD_API,
+  });
 
   const res = await api.runApp(action.app, config, inputs);
   if (res.isErr()) {

--- a/front/lib/api/assistant/actions/dust_app_run.ts
+++ b/front/lib/api/assistant/actions/dust_app_run.ts
@@ -34,8 +34,6 @@ import { getApp } from "../../app";
 import { getDatasetSchema } from "../../datasets";
 import { generateActionInputs } from "../agent";
 
-const { DUST_PROD_API } = process.env;
-
 /**
  * Model rendering of DustAppRuns.
  */
@@ -369,14 +367,7 @@ export async function* runDustApp(
   const prodCredentials = await prodAPICredentialsForOwner(owner, {
     useLocalInDev: true,
   });
-  if (!DUST_PROD_API) {
-    throw new Error("DUST_PROD_API env variable is not set.");
-  }
-  const api = new DustAPI({
-    credentials: prodCredentials,
-    logger,
-    url: DUST_PROD_API,
-  });
+  const api = new DustAPI({ credentials: prodCredentials, logger });
 
   // As we run the app (using a system API key here), we do force using the workspace credentials so
   // that the app executes in the exact same conditions in which they were developed.

--- a/front/lib/api/assistant/actions/dust_app_run.ts
+++ b/front/lib/api/assistant/actions/dust_app_run.ts
@@ -34,6 +34,8 @@ import { getApp } from "../../app";
 import { getDatasetSchema } from "../../datasets";
 import { generateActionInputs } from "../agent";
 
+const { DUST_PROD_API } = process.env;
+
 /**
  * Model rendering of DustAppRuns.
  */
@@ -367,7 +369,14 @@ export async function* runDustApp(
   const prodCredentials = await prodAPICredentialsForOwner(owner, {
     useLocalInDev: true,
   });
-  const api = new DustAPI({ credentials: prodCredentials, logger });
+  if (!DUST_PROD_API) {
+    throw new Error("DUST_PROD_API env variable is not set.");
+  }
+  const api = new DustAPI({
+    credentials: prodCredentials,
+    logger,
+    url: DUST_PROD_API,
+  });
 
   // As we run the app (using a system API key here), we do force using the workspace credentials so
   // that the app executes in the exact same conditions in which they were developed.

--- a/front/lib/api/assistant/actions/dust_app_run.ts
+++ b/front/lib/api/assistant/actions/dust_app_run.ts
@@ -367,7 +367,7 @@ export async function* runDustApp(
   const prodCredentials = await prodAPICredentialsForOwner(owner, {
     useLocalInDev: true,
   });
-  const api = new DustAPI({credentials:prodCredentials, logger});
+  const api = new DustAPI({ credentials: prodCredentials, logger });
 
   // As we run the app (using a system API key here), we do force using the workspace credentials so
   // that the app executes in the exact same conditions in which they were developed.

--- a/front/lib/api/assistant/actions/dust_app_run.ts
+++ b/front/lib/api/assistant/actions/dust_app_run.ts
@@ -367,9 +367,7 @@ export async function* runDustApp(
   const prodCredentials = await prodAPICredentialsForOwner(owner, {
     useLocalInDev: true,
   });
-  const api = new DustAPI(prodCredentials, logger, {
-    useLocalInDev: true,
-  });
+  const api = new DustAPI({credentials:prodCredentials, logger});
 
   // As we run the app (using a system API key here), we do force using the workspace credentials so
   // that the app executes in the exact same conditions in which they were developed.

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -21,6 +21,7 @@ import { Authenticator, prodAPICredentialsForOwner } from "@app/lib/auth";
 import { GlobalAgentSettings } from "@app/lib/models/assistant/agent";
 import { FREE_TEST_PLAN_CODE } from "@app/lib/plans/plan_codes";
 import logger from "@app/logger/logger";
+const { DUST_PROD_API } = process.env;
 
 class HelperAssistantPrompt {
   private static instance: HelperAssistantPrompt;
@@ -484,7 +485,14 @@ async function _getDustGlobalAgent(
   }
 
   const prodCredentials = await prodAPICredentialsForOwner(owner);
-  const api = new DustAPI(prodCredentials, logger);
+  if (!DUST_PROD_API) {
+    throw new Error("DUST_PROD_API env variable is not set");
+  }
+  const api = new DustAPI({
+    credentials: prodCredentials,
+    logger,
+    url: DUST_PROD_API,
+  });
 
   const dsRes = await api.getDataSources(prodCredentials.workspaceId);
   if (dsRes.isErr()) {

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -287,7 +287,14 @@ async function _getManagedDataSourceAgent(
   }
 
   const prodCredentials = await prodAPICredentialsForOwner(owner);
-  const api = new DustAPI(prodCredentials, logger);
+  if (!DUST_PROD_API) {
+    throw new Error("DUST_PROD_API env variable is not set");
+  }
+  const api = new DustAPI({
+    credentials: prodCredentials,
+    logger,
+    url: DUST_PROD_API,
+  });
 
   const dsRes = await api.getDataSources(prodCredentials.workspaceId);
   if (dsRes.isErr()) {

--- a/types/src/front/lib/dust_api.ts
+++ b/types/src/front/lib/dust_api.ts
@@ -317,14 +317,10 @@ export class DustAPI {
     logger: LoggerInterface;
     url?: string;
   }) {
-    if (!url && !DUST_FRONT_API) {
-      throw new Error("Missing Dust API URL");
-    }
-
     if (url) {
       this._url = url;
     } else {
-      this._url = DUST_FRONT_API as string;
+      this._url = DUST_FRONT_API;
     }
 
     this._credentials = credentials;

--- a/types/src/front/lib/dust_api.ts
+++ b/types/src/front/lib/dust_api.ts
@@ -24,7 +24,7 @@ import {
 } from "./api/assistant/agent";
 import { GenerationTokensEvent } from "./api/assistant/generation";
 
-const { DUST_FRONT_API } = process.env;
+const { DUST_FRONT_API = "https://dust.tt" } = process.env;
 
 export type DustAPIErrorResponse = {
   type: string;


### PR DESCRIPTION
# Description

DustAPI() now uses `process.env.DUST_FRONT_API` by defaults, and accepts a `url` parameter to override it.
`DUST_FRONT_API` is set to `https://dust.tt` if null (in `types/[...]/dust_api.ts` only)
