### PR TITLE
poke: workspace segementation

### DIFF
--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -28,6 +28,7 @@ export async function getWorkspaceInfos(
     name: workspace.name,
     allowedDomain: workspace.allowedDomain,
     role: "none",
+    segmentation: workspace.segmentation,
   };
 }
 

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -1,4 +1,9 @@
-import { RoleType, UserType, WorkspaceType } from "@dust-tt/types";
+import {
+  RoleType,
+  UserType,
+  WorkspaceSegmentationType,
+  WorkspaceType,
+} from "@dust-tt/types";
 import { MembershipInvitationType } from "@dust-tt/types";
 
 import { Authenticator } from "@app/lib/auth";
@@ -21,6 +26,41 @@ export async function getWorkspaceInfos(
   if (!workspace) {
     return null;
   }
+
+  return {
+    id: workspace.id,
+    sId: workspace.sId,
+    name: workspace.name,
+    allowedDomain: workspace.allowedDomain,
+    role: "none",
+    segmentation: workspace.segmentation,
+  };
+}
+
+export async function setInternalWorkspaceSegmentation(
+  auth: Authenticator,
+  segmentation: WorkspaceSegmentationType
+): Promise<WorkspaceType> {
+  const owner = auth.workspace();
+  const user = auth.user();
+
+  if (!owner || !user || !auth.isDustSuperUser()) {
+    throw new Error("Forbidden update to workspace segmentation.");
+  }
+
+  const workspace = await Workspace.findOne({
+    where: {
+      id: owner.id,
+    },
+  });
+
+  if (!workspace) {
+    throw new Error("Could not find workspace.");
+  }
+
+  await workspace.update({
+    segmentation,
+  });
 
   return {
     id: workspace.id,

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -292,6 +292,7 @@ export class Authenticator {
           name: this._workspace.name,
           allowedDomain: this._workspace.allowedDomain || null,
           role: this._role,
+          segmentation: this._workspace.segmentation || null,
         }
       : null;
   }
@@ -412,6 +413,7 @@ export async function getUserFromSession(
         name: w.name,
         allowedDomain: w.allowedDomain || null,
         role,
+        segmentation: w.segmentation || null,
       };
     }),
   };

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -292,9 +292,7 @@ export class Authenticator {
           name: this._workspace.name,
           allowedDomain: this._workspace.allowedDomain || null,
           role: this._role,
-          segmentation: this.isDustSuperUser()
-            ? this._workspace.segmentation
-            : null,
+          segmentation: this._workspace.segmentation || null,
         }
       : null;
   }
@@ -415,7 +413,7 @@ export async function getUserFromSession(
         name: w.name,
         allowedDomain: w.allowedDomain || null,
         role,
-        segmentation: null,
+        segmentation: w.segmentation || null,
       };
     }),
   };

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -292,7 +292,9 @@ export class Authenticator {
           name: this._workspace.name,
           allowedDomain: this._workspace.allowedDomain || null,
           role: this._role,
-          segmentation: this._workspace.segmentation || null,
+          segmentation: this.isDustSuperUser()
+            ? this._workspace.segmentation
+            : null,
         }
       : null;
   }
@@ -413,7 +415,7 @@ export async function getUserFromSession(
         name: w.name,
         allowedDomain: w.allowedDomain || null,
         role,
-        segmentation: w.segmentation || null,
+        segmentation: null,
       };
     }),
   };

--- a/front/lib/models/workspace.ts
+++ b/front/lib/models/workspace.ts
@@ -1,3 +1,4 @@
+import { WorkspaceSegmentationType } from "@dust-tt/types";
 import {
   CreationOptional,
   DataTypes,
@@ -25,6 +26,7 @@ export class Workspace extends Model<
   declare name: string;
   declare description: string | null;
   declare allowedDomain: string | null;
+  declare segmentation: WorkspaceSegmentationType;
   declare subscriptions: NonAttribute<Subscription[]>;
 }
 Workspace.init(
@@ -61,6 +63,10 @@ Workspace.init(
     },
     allowedDomain: {
       type: DataTypes.STRING,
+    },
+    segmentation: {
+      type: DataTypes.STRING,
+      allowNull: true,
     },
   },
   {

--- a/front/pages/api/poke/workspaces/[wId]/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/index.ts
@@ -40,7 +40,7 @@ async function handler(
   }
 
   switch (req.method) {
-    case "POST":
+    case "PATCH":
       const bodyValidation = WorkspaceTypeSchema.decode(req.body);
       if (isLeft(bodyValidation)) {
         const pathError = reporter.formatValidationErrors(bodyValidation.left);

--- a/front/pages/api/poke/workspaces/[wId]/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/index.ts
@@ -1,18 +1,25 @@
 import { WorkspaceType } from "@dust-tt/types";
 import { ReturnedAPIErrorType } from "@dust-tt/types";
+import { isLeft } from "fp-ts/lib/Either";
+import * as t from "io-ts";
+import * as reporter from "io-ts-reporters";
 import { NextApiRequest, NextApiResponse } from "next";
 
 import { Authenticator, getSession } from "@app/lib/auth";
-import { internalSubscribeWorkspaceToFreeTestPlan } from "@app/lib/plans/subscription";
+import { Workspace } from "@app/lib/models";
 import { apiError, withLogging } from "@app/logger/withlogging";
 
-export type DowngradeWorkspaceResponseBody = {
+export const WorkspaceTypeSchema = t.type({
+  segmentation: t.union([t.literal("interesting"), t.null]),
+});
+
+export type SegmentWorkspaceResponseBody = {
   workspace: WorkspaceType;
 };
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<DowngradeWorkspaceResponseBody | ReturnedAPIErrorType>
+  res: NextApiResponse<SegmentWorkspaceResponseBody | ReturnedAPIErrorType>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSuperUserSession(
@@ -34,8 +41,36 @@ async function handler(
 
   switch (req.method) {
     case "POST":
-      await internalSubscribeWorkspaceToFreeTestPlan({
-        workspaceId: owner.sId,
+      const bodyValidation = WorkspaceTypeSchema.decode(req.body);
+      if (isLeft(bodyValidation)) {
+        const pathError = reporter.formatValidationErrors(bodyValidation.left);
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `The request body is invalid: ${pathError}`,
+          },
+        });
+      }
+      const body = bodyValidation.right;
+      const workspace = await Workspace.findOne({
+        where: {
+          id: owner.id,
+        },
+      });
+
+      if (!workspace) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "workspace_not_found",
+            message: "Could not find the workspace.",
+          },
+        });
+      }
+
+      await workspace.update({
+        segmentation: body.segmentation,
       });
 
       return res.status(200).json({
@@ -45,7 +80,7 @@ async function handler(
           name: owner.name,
           allowedDomain: owner.allowedDomain || null,
           role: "admin",
-          segmentation: owner.segmentation || null,
+          segmentation: body.segmentation,
         },
       });
 

--- a/front/pages/api/poke/workspaces/[wId]/upgrade.ts
+++ b/front/pages/api/poke/workspaces/[wId]/upgrade.ts
@@ -55,6 +55,7 @@ async function handler(
           name: owner.name,
           allowedDomain: owner.allowedDomain || null,
           role: "admin",
+          segmentation: owner.segmentation || null,
         },
       });
 

--- a/front/pages/api/poke/workspaces/index.ts
+++ b/front/pages/api/poke/workspaces/index.ts
@@ -141,6 +141,7 @@ async function handler(
           name: ws.name,
           allowedDomain: ws.allowedDomain || null,
           role: "admin",
+          segmentation: ws.segmentation,
         })),
       });
     default:

--- a/front/pages/poke/[wId]/index.tsx
+++ b/front/pages/poke/[wId]/index.tsx
@@ -1,9 +1,15 @@
-import { Button, Collapsible, SliderToggle } from "@dust-tt/sparkle";
+import {
+  Button,
+  Collapsible,
+  DropdownMenu,
+  SliderToggle,
+} from "@dust-tt/sparkle";
 import {
   AgentConfigurationType,
   DataSourceType,
   isDustAppRunConfiguration,
   isRetrievalConfiguration,
+  WorkspaceSegmentationType,
 } from "@dust-tt/types";
 import { UserType, WorkspaceType } from "@dust-tt/types";
 import { PlanInvitationType, PlanType, SubscriptionType } from "@dust-tt/types";
@@ -270,6 +276,29 @@ const WorkspacePage = ({
     }
   );
 
+  const { submit: onWorkspaceUpdate } = useSubmitFunction(
+    async (segmentation: WorkspaceSegmentationType) => {
+      try {
+        const r = await fetch(`/api/poke/workspaces/${owner.sId}`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            segmentation,
+          }),
+        });
+        if (!r.ok) {
+          throw new Error("Failed to update workspace.");
+        }
+        await router.reload();
+      } catch (e) {
+        console.error(e);
+        window.alert("An error occurred while updating the workspace.");
+      }
+    }
+  );
+
   const { submit: onAssistantArchive } = useSubmitFunction(
     async (agentConfiguration: AgentConfigurationType) => {
       if (
@@ -407,7 +436,36 @@ const WorkspacePage = ({
 
         <div className="flex justify-center">
           <div className="mx-2 w-1/3">
-            <h2 className="text-md mb-4 font-bold">Plan:</h2>
+            <h2 className="text-md mb-4 font-bold">Segmentation:</h2>
+            <div>
+              <DropdownMenu>
+                <DropdownMenu.Button>
+                  <Button
+                    type="select"
+                    labelVisible={true}
+                    label={owner.segmentation ?? "none"}
+                    variant="secondary"
+                    hasMagnifying={false}
+                    size="sm"
+                  />
+                </DropdownMenu.Button>
+                <DropdownMenu.Items origin="auto" width={240}>
+                  {[null, "interesting"].map((segment) => (
+                    <DropdownMenu.Item
+                      label={segment ?? "none"}
+                      key={segment ?? "all"}
+                      onClick={() => {
+                        void onWorkspaceUpdate(
+                          segment as WorkspaceSegmentationType
+                        );
+                      }}
+                    ></DropdownMenu.Item>
+                  ))}
+                </DropdownMenu.Items>
+              </DropdownMenu>
+            </div>
+
+            <h2 className="text-md mb-4 mt-8 font-bold">Plan:</h2>
             <JsonViewer value={subscription} rootName={false} />
             {planInvitation && (
               <div className="mb-4 flex flex-col gap-2 pt-4 text-sm font-bold">

--- a/front/pages/poke/[wId]/index.tsx
+++ b/front/pages/poke/[wId]/index.tsx
@@ -280,7 +280,7 @@ const WorkspacePage = ({
     async (segmentation: WorkspaceSegmentationType) => {
       try {
         const r = await fetch(`/api/poke/workspaces/${owner.sId}`, {
-          method: "POST",
+          method: "PATCH",
           headers: {
             "Content-Type": "application/json",
           },

--- a/front/pages/poke/index.tsx
+++ b/front/pages/poke/index.tsx
@@ -1,6 +1,5 @@
 import { UserType } from "@dust-tt/types";
 import { GetServerSideProps, InferGetServerSidePropsType } from "next";
-import Link from "next/link";
 import React, { ChangeEvent, useState } from "react";
 
 import PokeNavbar from "@app/components/poke/PokeNavbar";
@@ -86,12 +85,12 @@ const Dashboard = (
           {!isSearchResultsLoading && !isSearchResultsError && (
             <ul className="mt-4 space-y-4">
               {searchResults.map((ws) => (
-                <Link href={`/poke/${ws.sId}`} key={ws.id}>
+                <a href={`/poke/${ws.sId}`} key={ws.id}>
                   <li className="border-material-100 rounded-lg border bg-white p-4 transition-colors duration-200 hover:bg-gray-100">
                     <h2 className="text-xl font-semibold">{ws.name}</h2>
                     <p className="text-sm text-gray-500">sId: {ws.sId}</p>
                   </li>
-                </Link>
+                </a>
               ))}
             </ul>
           )}
@@ -100,12 +99,12 @@ const Dashboard = (
             {!isUpgradedWorkspacesLoading &&
               !isUpgradedWorkspacesError &&
               upgradedWorkspaces.map((ws) => (
-                <Link href={`/poke/${ws.sId}`} key={ws.id}>
+                <a href={`/poke/${ws.sId}`} key={ws.id}>
                   <li className="border-material-100 rounded-lg border bg-white p-4 transition-colors duration-200 hover:bg-gray-100">
                     <h2 className="text-xl font-semibold">{ws.name}</h2>
                     <p className="text-sm text-gray-500">sId: {ws.sId}</p>
                   </li>
-                </Link>
+                </a>
               ))}
           </ul>
         </>

--- a/types/src/front/user.ts
+++ b/types/src/front/user.ts
@@ -1,5 +1,6 @@
 import { ModelId } from "../shared/model_id";
 
+export type WorkspaceSegmentationType = "enterprise";
 export type RoleType = "admin" | "builder" | "user" | "none";
 
 export type WorkspaceType = {
@@ -8,6 +9,7 @@ export type WorkspaceType = {
   name: string;
   allowedDomain: string | null;
   role: RoleType;
+  segmentation: WorkspaceSegmentationType;
 };
 
 export type UserProviderType = "github" | "google";

--- a/types/src/front/user.ts
+++ b/types/src/front/user.ts
@@ -1,6 +1,6 @@
 import { ModelId } from "../shared/model_id";
 
-export type WorkspaceSegmentationType = "enterprise";
+export type WorkspaceSegmentationType = "interesting" | null;
 export type RoleType = "admin" | "builder" | "user" | "none";
 
 export type WorkspaceType = {


### PR DESCRIPTION
Fixes: https://github.com/dust-tt/tasks/issues/264

The segmentation field will be visible client-side to user that would want to look for it. But I think that passes the front test page no problem.