### PR TITLE
Author column in agent_configuration migration speedup

### DIFF
--- a/front/migrations/20231204_author_backfill.ts
+++ b/front/migrations/20231204_author_backfill.ts
@@ -1,10 +1,4 @@
-import {
-  AgentConfiguration,
-  Membership,
-  User,
-  Workspace,
-} from "@app/lib/models";
-import { cons } from "fp-ts/lib/NonEmptyArray";
+import { AgentConfiguration, Membership, User } from "@app/lib/models";
 
 async function main() {
   console.log("Starting author backfill");


### PR DESCRIPTION
The migration as is was too slow and would have locked deploys for very long
- Only workspaces with multiple agent configs
- Batches of 16 of batches of 16