### PR TITLE
enh: support more CSV delimiters

### DIFF
--- a/core/src/blocks/llm.rs
+++ b/core/src/blocks/llm.rs
@@ -9,7 +9,6 @@ use async_trait::async_trait;
 use pest::iterators::Pair;
 use serde::Serialize;
 use serde_json::{json, Value};
-use std::collections::HashMap;
 use std::str::FromStr;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedSender};
 

--- a/front/lib/client/handle_file_upload.ts
+++ b/front/lib/client/handle_file_upload.ts
@@ -67,7 +67,14 @@ export async function handleFileUploadToText(
         fileReader.onloadend = handleFileLoadedPDF;
         fileReader.readAsArrayBuffer(file);
       } else if (
-        ["text/plain", "text/csv", "text/markdown"].includes(file.type)
+        [
+          "text/plain",
+          "text/csv",
+          "text/markdown",
+          "text/tsv",
+          "text/comma-separated-values",
+          "text/tab-separated-values",
+        ].includes(file.type)
       ) {
         const fileData = new FileReader();
         fileData.onloadend = handleFileLoadedText;
@@ -76,7 +83,7 @@ export async function handleFileUploadToText(
         return resolve(
           new Err(
             new Error(
-              "File type not supported. Supported file types: .txt, .pdf, .md"
+              "File type not supported. Supported file types: .txt, .pdf, .md, .csv, .tsv"
             )
           )
         );

--- a/front/pages/api/w/[wId]/data_sources/[name]/databases/csv.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/databases/csv.ts
@@ -211,7 +211,24 @@ export default withLogging(handler);
 async function rowsFromCsv(
   csv: string
 ): Promise<Result<CoreAPIDatabaseRow[], APIError>> {
-  const parser = parse(csv);
+  // Detect the delimiter.
+  const delimiters = [",", ";", "\t"];
+  let delimiter: string | undefined = undefined;
+  for (const c of csv) {
+    if (delimiters.includes(c)) {
+      delimiter = c;
+      break;
+    }
+  }
+
+  if (!delimiter) {
+    return new Err({
+      type: "invalid_request_error",
+      message: `Could not detect delimiter.`,
+    });
+  }
+
+  const parser = parse(csv, { delimiter });
   let header: string[] | undefined = undefined;
   const valuesByCol: Record<string, string[]> = {};
 

--- a/front/pages/w/[wId]/databases/index.tsx
+++ b/front/pages/w/[wId]/databases/index.tsx
@@ -273,11 +273,19 @@ function DatabaseModal({
             });
             return;
           }
-          if (file.type !== "text/csv") {
+
+          if (
+            ![
+              "text/csv",
+              "text/tsv",
+              "text/comma-separated-values",
+              "text/tab-separated-values",
+            ].includes(file.type)
+          ) {
             sendNotification({
               type: "error",
               title: "Invalid file type",
-              description: "Please upload a CSV file.",
+              description: "Please upload a CSV or TSV file.",
             });
             return;
           }


### PR DESCRIPTION
`;` CSV delimiter (used by MacOS numbers) and `tsv` files (using tab separator)