### PR TITLE
+indexes for AgentDataSourceConfiguration and AgentConfiguration

### DIFF
--- a/front/lib/models/assistant/actions/retrieval.ts
+++ b/front/lib/models/assistant/actions/retrieval.ts
@@ -187,8 +187,7 @@ AgentDataSourceConfiguration.init(
     modelName: "agent_data_source_configuration",
     indexes: [
       {
-        name: "agent_ds_config_ds_retrieval_idx",
-        fields: ["dataSourceId", "retrievalConfigurationId"],
+        fields: ["retrievalConfigurationId"],
       },
     ],
     sequelize: front_sequelize,

--- a/front/lib/models/assistant/actions/retrieval.ts
+++ b/front/lib/models/assistant/actions/retrieval.ts
@@ -185,6 +185,11 @@ AgentDataSourceConfiguration.init(
   },
   {
     modelName: "agent_data_source_configuration",
+    indexes: [
+      {
+        fields: ["dataSourceId", "retrievalConfigurationId"],
+      },
+    ],
     sequelize: front_sequelize,
     hooks: {
       beforeValidate: (dataSourceConfig: AgentDataSourceConfiguration) => {

--- a/front/lib/models/assistant/actions/retrieval.ts
+++ b/front/lib/models/assistant/actions/retrieval.ts
@@ -187,6 +187,7 @@ AgentDataSourceConfiguration.init(
     modelName: "agent_data_source_configuration",
     indexes: [
       {
+        name: "agent_ds_config_ds_retrieval_idx",
         fields: ["dataSourceId", "retrievalConfigurationId"],
       },
     ],

--- a/front/lib/models/assistant/agent.ts
+++ b/front/lib/models/assistant/agent.ts
@@ -174,6 +174,7 @@ AgentConfiguration.init(
     indexes: [
       { fields: ["workspaceId"] },
       { fields: ["workspaceId", "name"] },
+      { fields: ["workspaceId", "status", "name"] },
       { fields: ["sId"] },
       { fields: ["sId", "version"], unique: true },
       { fields: ["authorId"] },


### PR DESCRIPTION
Adding indexes for two queries:
- [Query 1](https://github.com/dust-tt/dust/blob/2a28c677e3159bf6132d5f43c7a41cfa9244cf79/front/lib/api/assistant/configuration.ts#L92)
- [Query 2](https://github.com/dust-tt/dust/blob/2a28c677e3159bf6132d5f43c7a41cfa9244cf79/front/lib/api/assistant/configuration.ts#L219)

Query 1 has been the number 1 ressource consuming query in the front database for a little while now (as reported on [GCP query insight](https://console.cloud.google.com/sql/instances/dust-api-db/insights;database=dust-front;duration=PT1H;query_hash=2201675645681319626;sort_by=TOTAL_EXEC_TIME?project=or1g1n-186209)), and number 2 showed up as a pretty slow query (200 ms) on datadog.

# Deployment:

- Deploy to front
- Run initdb from front.