### PR TITLE
Stop extending memoize TTL

### DIFF
--- a/types/src/shared/memoize.ts
+++ b/types/src/shared/memoize.ts
@@ -8,18 +8,11 @@ export function memoize<T extends (...args: any[]) => any>(
   ttlMs: number
 ): T {
   const cache = new Map<string, ReturnType<T>>();
-  let ttlTimeout: NodeJS.Timeout | undefined = undefined;
 
-  const extendTTL = () => {
-    clearTimeout(ttlTimeout);
-    ttlTimeout = setTimeout(() => {
-      cache.clear();
-    }, ttlMs);
-  };
-  extendTTL();
+  setTimeout(() => {
+    cache.clear();
+  }, ttlMs);
   return function (...args: Parameters<T>): ReturnType<T> {
-    extendTTL();
-
     const key = resolver(...args);
     if (cache.has(key)) {
       const cacheHit = cache.get(key);


### PR DESCRIPTION
Moving from from marking the cache as "fresh" every time the memoized function is called to only at the first time.