### PR TITLE
[Ops] change title of ops email for canceled subscription

### DIFF
--- a/front/lib/email.ts
+++ b/front/lib/email.ts
@@ -114,7 +114,7 @@ export async function sendOpsEmail(workspaceSId: string): Promise<void> {
       name: "System",
       email: "ops@dust.tt",
     },
-    subject: `[OPS] A subscription has been canceled`,
+    subject: `[OPS - Eng runner] A subscription has been canceled`,
     html: `<p>Hi Dust ops,</p> 
     <p>The subscription of workspace '${workspaceSId}' was just canceled. Go to the <a href="https://dust.tt/poke/${workspaceSId}">Poke Page</a> and follow the <a href="https://www.notion.so/dust-tt/Runbook-Canceled-subscription-0011ab1afebe467b871b25f572b56a9e?pvs=4">Runbook</a> for when a subscription is cancelled</p>
     <p>We'll automate this soon. Just doing that to be extra sure for the ~10 first downgrades.</p>


### PR DESCRIPTION
Clearer text that it's eng runner's purview
Uncontroversial text only PR => merging