### PR TITLE
Optimize GET /agent_configurations

### DIFF
--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -1,4 +1,4 @@
-import { ModelId, SupportedModel } from "@dust-tt/types";
+import { SupportedModel } from "@dust-tt/types";
 import { DustAppRunConfigurationType } from "@dust-tt/types";
 import {
   DataSourceConfiguration,

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -247,21 +247,11 @@ export async function getAgentConfigurations(
       },
     ],
   });
-  const agentsById = rawAgents.reduce((acc, curr) => {
-    const previousValue = acc.get(curr.id);
-    if (previousValue === undefined) {
-      acc.set(curr.id, curr);
-    } else if (previousValue.version < curr.version) {
-      acc.set(curr.id, curr);
-    }
-
-    return acc;
-  }, new Map<ModelId, AgentConfiguration>());
 
   const agents = (
     await Promise.all(
       rawAgents.map(async (a) => {
-        return await getAgentConfiguration(auth, a.sId, agentsById.get(a.id));
+        return await getAgentConfiguration(auth, a.sId, a);
       })
     )
   ).filter((a) => a !== null) as AgentConfigurationType[];


### PR DESCRIPTION
`GET /api/w/[wId]/assistant/agent_configurations` is among the slowest calls (if not the slowest) that shows up on Datadog outside of the streaming calls.
This is an attempt at optimizing it. Pretty confident this should help a lot this call and leave more slots for other API calls to obtain a DB connection.

[Here](https://app.datadoghq.eu/apm/traces?query=%40_top_level%3A1%20env%3Aprod%20service%3Afront%20-resource_name%3A%22GET%20%2Fapi%2Fw%2F%5BwId%5D%2Fassistant%2Fconversations%2F%5BcId%5D%2Fevents%22%20%40http.method%3AGET%20-%40http.path_group%3A%22%2Fapi%2Fw%2F%3F%2Fassistant%2Fconversations%2F%3F%2Fmessages%2F%3F%2Fevents%22%20-%40http.route%3A%22%2Fapi%2Fv1%2Fw%2F%5BwId%5D%2Fapps%2F%5BaId%5D%2Fruns%2F%5BrunId%5D%22&cols=core_service%2Ccore_resource_name%2Clog_duration%2Clog_http.method%2Clog_http.status_code&graphType=flamegraph&historicalData=false&messageDisplay=inline&query_translation_version=v0&shouldShowLegend=true&sort=span_count&sort_by=%40duration&sort_order=desc&spanID=3703687566146363653&spanType=service-entry&timeHint=1702043718483&trace=37036875661463636533703687566146363653&traceID=3703687566146363653&traceQuery=&view=spans&start=1702044244671&end=1702045144671&paused=false) is a trace of a 2.58 seconds long call to this API endpoint.