### PR TITLE
enh(notion) dont reprocess child pages for existing db

### DIFF
--- a/connectors/src/connectors/notion/temporal/workflows.ts
+++ b/connectors/src/connectors/notion/temporal/workflows.ts
@@ -451,12 +451,10 @@ export async function syncResultPageDatabaseWorkflow({
           ...loggerArgs,
           pageIndex,
         },
-        // Note: we don't want to optimize this step due to Notion not always returning all the
-        // dbs (so if we miss it at initial sync and it gets touched we will miss all its old
-        // pages here again. It's a lot of additional work but it helps catching as much as we
-        // can from Notion). The caller of this function filters the edited page based on our
-        // knowledge of it in DB so this won't create extraneous upserts.
-        excludeUpToDatePages: false,
+        // This will prevent syncing pages that are already up to date, unless
+        // this is the first run for this database or a garbage collection run.
+        excludeUpToDatePages: !isGarbageCollectionRun,
+        runTimestamp,
       });
       cursor = nextCursor;
       pageIndex += 1;

--- a/connectors/src/lib/models/notion.ts
+++ b/connectors/src/lib/models/notion.ts
@@ -165,6 +165,7 @@ export class NotionDatabase extends Model<
 
   declare notionDatabaseId: string;
   declare lastSeenTs: Date;
+  declare firstSeenTs?: Date;
   declare lastCreatedOrMovedRunTs: CreationOptional<Date | null>;
 
   declare skipReason?: string | null;
@@ -201,6 +202,10 @@ NotionDatabase.init(
     lastSeenTs: {
       type: DataTypes.DATE,
       allowNull: false,
+    },
+    firstSeenTs: {
+      type: DataTypes.DATE,
+      allowNull: true,
     },
     lastCreatedOrMovedRunTs: {
       type: DataTypes.DATE,


### PR DESCRIPTION
Add a new `fistSeenTs` column to `NotionDatabase` and decide to exclude up-to-date pages if it is the first run for the database.
This should save quite a few activities.