### PR TITLE
[Ahuna] Views for getAgentConfigurations 

### DIFF
--- a/front/components/assistant/conversation/AgentSuggestion.tsx
+++ b/front/components/assistant/conversation/AgentSuggestion.tsx
@@ -26,6 +26,7 @@ export function AgentSuggestion({
 }) {
   const { agentConfigurations } = useAgentConfigurations({
     workspaceId: owner.sId,
+    agentsGetViewType: { conversationId: conversation.sId },
   });
   const sendNotification = useContext(SendNotificationsContext);
 

--- a/front/components/assistant/conversation/InputBar.tsx
+++ b/front/components/assistant/conversation/InputBar.tsx
@@ -62,6 +62,7 @@ function AgentListImpl(
     visible,
     filter,
     position,
+    conversationId,
   }: {
     owner: WorkspaceType;
     visible: boolean;
@@ -70,6 +71,7 @@ function AgentListImpl(
       bottom: number;
       left: number;
     };
+    conversationId: string | null;
   },
   ref: ForwardedRef<{
     prev: () => void;
@@ -86,6 +88,7 @@ function AgentListImpl(
 
   const { agentConfigurations } = useAgentConfigurations({
     workspaceId: owner.sId,
+    agentsGetViewType: conversationId ? { conversationId } : "list",
   });
 
   const activeAgents = agentConfigurations.filter((a) => a.status === "active");
@@ -283,6 +286,7 @@ export function AssistantInputBar({
 
   const { agentConfigurations } = useAgentConfigurations({
     workspaceId: owner.sId,
+    agentsGetViewType: conversationId ? { conversationId } : "list",
   });
   const sendNotification = useContext(SendNotificationsContext);
 
@@ -473,6 +477,7 @@ export function AssistantInputBar({
         filter={agentListFilter}
         ref={agentListRef}
         position={agentListPosition}
+        conversationId={conversationId}
       />
 
       {generationContext.generatingMessageIds.length > 0 && (

--- a/front/components/assistant/conversation/UserMessage.tsx
+++ b/front/components/assistant/conversation/UserMessage.tsx
@@ -5,11 +5,10 @@ import {
   UserMessageType,
 } from "@dust-tt/types";
 
+import { AgentSuggestion } from "@app/components/assistant/conversation/AgentSuggestion";
 import { ConversationMessage } from "@app/components/assistant/conversation/ConversationMessage";
 import { RenderMessageMarkdown } from "@app/components/assistant/RenderMessageMarkdown";
 import { useAgentConfigurations } from "@app/lib/swr";
-
-import { AgentSuggestion } from "./AgentSuggestion";
 
 export function UserMessage({
   message,
@@ -26,6 +25,7 @@ export function UserMessage({
 }) {
   const { agentConfigurations } = useAgentConfigurations({
     workspaceId: owner.sId,
+    agentsGetViewType: { conversationId: conversation.sId },
   });
 
   return (

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -28,6 +28,7 @@ import {
 import { TimeframeUnit } from "@dust-tt/types";
 import { AppType } from "@dust-tt/types";
 import { PlanType, SubscriptionType } from "@dust-tt/types";
+import { PostOrPatchAgentConfigurationRequestBodySchema } from "@dust-tt/types";
 import * as t from "io-ts";
 import { useRouter } from "next/router";
 import { ReactNode, useCallback, useEffect, useState } from "react";
@@ -37,12 +38,15 @@ import { mutate } from "swr";
 
 import { AvatarPicker } from "@app/components/assistant_builder/AssistantBuilderAvatarPicker";
 import AssistantBuilderDataSourceModal from "@app/components/assistant_builder/AssistantBuilderDataSourceModal";
+import AssistantBuilderDustAppModal from "@app/components/assistant_builder/AssistantBuilderDustAppModal";
 import DataSourceSelectionSection from "@app/components/assistant_builder/DataSourceSelectionSection";
+import DustAppSelectionSection from "@app/components/assistant_builder/DustAppSelectionSection";
 import {
   DROID_AVATAR_FILES,
   DROID_AVATARS_BASE_PATH,
   TIME_FRAME_UNIT_TO_LABEL,
 } from "@app/components/assistant_builder/shared";
+import DataSourceResourceSelectorTree from "@app/components/DataSourceResourceSelectorTree";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import {
   AppLayoutSimpleCloseTitle,
@@ -58,11 +62,6 @@ import {
   useSlackChannelsLinkedWithAgent,
 } from "@app/lib/swr";
 import { classNames } from "@app/lib/utils";
-import { PostOrPatchAgentConfigurationRequestBodySchema } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
-
-import DataSourceResourceSelectorTree from "../DataSourceResourceSelectorTree";
-import AssistantBuilderDustAppModal from "./AssistantBuilderDustAppModal";
-import DustAppSelectionSection from "./DustAppSelectionSection";
 
 const usedModelConfigs = [
   GPT_4_TURBO_MODEL_CONFIG,
@@ -250,6 +249,7 @@ export default function AssistantBuilder({
   const [timeFrameError, setTimeFrameError] = useState<string | null>(null);
   const { agentConfigurations } = useAgentConfigurations({
     workspaceId: owner.sId,
+    agentsGetViewType: "all",
   });
 
   const [avatarUrls, setAvatarUrls] = useState<

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -1,6 +1,11 @@
-import { SupportedModel } from "@dust-tt/types";
+import {
+  AgentMention,
+  AgentRelationOverrideType,
+  SupportedModel,
+} from "@dust-tt/types";
 import { DustAppRunConfigurationType } from "@dust-tt/types";
 import {
+  AgentsGetViewType,
   DataSourceConfiguration,
   isTemplatedQuery,
   isTimeFrame,
@@ -15,6 +20,7 @@ import {
   AgentGenerationConfigurationType,
   AgentStatus,
 } from "@dust-tt/types";
+import { isSupportedModel } from "@dust-tt/types";
 import { Op, Transaction } from "sequelize";
 
 import {
@@ -22,7 +28,6 @@ import {
   getGlobalAgents,
   isGlobalAgentId,
 } from "@app/lib/api/assistant/global_agents";
-import { isSupportedModel } from "@app/lib/assistant";
 import { Authenticator } from "@app/lib/auth";
 import { front_sequelize } from "@app/lib/databases";
 import {
@@ -31,13 +36,18 @@ import {
   AgentDustAppRunConfiguration,
   AgentGenerationConfiguration,
   AgentRetrievalConfiguration,
+  Conversation,
   DataSource,
+  Mention,
+  Message,
   Workspace,
 } from "@app/lib/models";
+import { AgentUserRelation } from "@app/lib/models/assistant/agent";
 import { generateModelSId } from "@app/lib/utils";
 
 /**
  * Get an agent configuration
+ *
  */
 export async function getAgentConfiguration(
   auth: Authenticator,
@@ -77,6 +87,14 @@ export async function getAgentConfiguration(
         {
           model: AgentDustAppRunConfiguration,
           as: "dustAppRunConfiguration",
+        },
+        {
+          model: AgentUserRelation,
+          where: {
+            userId: auth.user()?.id,
+          },
+          attributes: ["relation"],
+          required: false,
         },
       ],
       limit: 1,
@@ -192,11 +210,16 @@ export async function getAgentConfiguration(
     };
   }
 
+  const relationOverride =
+    agent.relationOverrides?.length > 0
+      ? agent.relationOverrides[0].relation
+      : null;
   return {
     id: agent.id,
     sId: agent.sId,
     version: agent.version,
     scope: agent.scope,
+    relationOverride,
     name: agent.name,
     pictureUrl: agent.pictureUrl,
     description: agent.description,
@@ -207,67 +230,182 @@ export async function getAgentConfiguration(
 }
 
 /**
- * Get the list agent configuration for the workspace, optionally whose names
+ * Get agent configurations for the workspace, optionally whose names
  * match a prefix
+ * @param agentsGetView the kind of list of agents we want to get, see AgentsGetViewType
  */
 export async function getAgentConfigurations(
   auth: Authenticator,
+  agentsGetView: AgentsGetViewType,
   agentPrefix?: string
 ): Promise<AgentConfigurationType[] | []> {
   const owner = auth.workspace();
   if (!owner) {
     throw new Error("Unexpected `auth` without `workspace`.");
   }
+  if (!auth.isUser()) {
+    throw new Error("Unexpected `auth` from outside workspace.");
+  }
 
-  const [agents, globalAgents] = await Promise.all([
-    (async () => {
-      const rawAgents = await AgentConfiguration.findAll({
+  const agentsSequelizeQuery = {
+    where: {
+      workspaceId: owner.id,
+      status: "active",
+      ...(agentPrefix ? { name: { [Op.iLike]: `${agentPrefix}%` } } : {}),
+    },
+    include: [
+      {
+        model: AgentGenerationConfiguration,
+        as: "generationConfiguration",
+      },
+      {
+        model: AgentRetrievalConfiguration,
+        as: "retrievalConfiguration",
+      },
+      {
+        model: AgentDustAppRunConfiguration,
+        as: "dustAppRunConfiguration",
+      },
+      {
+        model: AgentUserRelation,
         where: {
-          workspaceId: owner.id,
-          status: "active",
-          ...(agentPrefix
-            ? {
-                name: {
-                  [Op.iLike]: `${agentPrefix}%`,
-                },
-              }
-            : {}),
+          userId: auth.user()?.id,
         },
-        order: [["name", "ASC"]],
+        attributes: ["relation"],
+        required: false,
+      },
+    ],
+  };
+
+  const globalAgents = (await getGlobalAgents(auth)).filter(
+    (a) =>
+      !agentPrefix || a.name.toLowerCase().startsWith(agentPrefix.toLowerCase())
+  );
+
+  const getLocalAgentConfigurations = async (agents: AgentConfiguration[]) => {
+    return (
+      await Promise.all(
+        agents.map((a) => getAgentConfiguration(auth, a.sId, a))
+      )
+    ).filter((a) => a !== null) as AgentConfigurationType[];
+  };
+
+  if (agentsGetView === "super_user") {
+    if (!auth.isDustSuperUser()) {
+      throw new Error("superuser view is for dust superusers only.");
+    }
+    const agents = await AgentConfiguration.findAll(agentsSequelizeQuery);
+    return [...(await getLocalAgentConfigurations(agents)), ...globalAgents];
+  }
+
+  if (agentsGetView === "all") {
+    const agents = await AgentConfiguration.findAll({
+      ...agentsSequelizeQuery,
+      where: {
+        ...agentsSequelizeQuery.where,
+        scope: { [Op.in]: ["published", "workspace"] },
+      },
+    });
+    return [...(await getLocalAgentConfigurations(agents)), ...globalAgents];
+  }
+
+  if (agentsGetView === "list") {
+    const user = auth.user();
+    if (!user) {
+      throw new Error("List view is specific to a user.");
+    }
+    const agents = await AgentConfiguration.findAll({
+      ...agentsSequelizeQuery,
+      where: {
+        ...agentsSequelizeQuery.where,
+        [Op.or]: [
+          { scope: { [Op.in]: ["published", "workspace"] } },
+          { authorId: user.id },
+        ],
+      },
+    });
+    const localAgents = (await getLocalAgentConfigurations(agents)).filter(
+      (a) => {
+        if (a.scope === "workspace") {
+          return a.relationOverride !== "not-in-list";
+        }
+        if (a.scope === "published") {
+          return a.relationOverride === "in-list";
+        }
+        return true; // user's private agents should be returned
+      }
+    ) as AgentConfigurationType[];
+    return [...localAgents, ...globalAgents];
+  }
+
+  // conversation view
+  if (typeof agentsGetView === "object" && agentsGetView.conversationId) {
+    const user = auth.user();
+    if (!user) {
+      throw new Error("Conversation view is specific to a user.");
+    }
+    const [agents, mentions] = await Promise.all([
+      AgentConfiguration.findAll({
+        ...agentsSequelizeQuery,
+        where: {
+          ...agentsSequelizeQuery.where,
+          [Op.or]: [
+            { scope: { [Op.in]: ["published", "workspace"] } },
+            { authorId: user && user.id },
+          ],
+        },
+      }),
+      getConversationMentions(agentsGetView.conversationId),
+    ]);
+    const mentionedAgentIds = mentions.map((m) => m.configurationId);
+    const localAgents = (await getLocalAgentConfigurations(agents)).filter(
+      (a) => {
+        if (mentionedAgentIds.includes(a.sId)) {
+          return true;
+        }
+        if (a.scope === "workspace") {
+          return a.relationOverride !== "not-in-list";
+        }
+        if (a.scope === "published") {
+          return a.relationOverride === "in-list";
+        }
+        return true; // user's private agents should be returned
+      }
+    ) as AgentConfigurationType[];
+    return [...localAgents, ...globalAgents];
+  }
+
+  throw new Error(`Unknown agentsGetView ${agentsGetView}`);
+}
+
+async function getConversationMentions(
+  conversationId: string
+): Promise<AgentMention[]> {
+  const mentions = await Mention.findAll({
+    attributes: ["agentConfigurationId"],
+    where: {
+      agentConfigurationId: {
+        [Op.ne]: null,
+      },
+    },
+    include: [
+      {
+        model: Message,
+        attributes: [],
         include: [
           {
-            model: AgentGenerationConfiguration,
-            as: "generationConfiguration",
-          },
-          {
-            model: AgentRetrievalConfiguration,
-            as: "retrievalConfiguration",
-          },
-          {
-            model: AgentDustAppRunConfiguration,
-            as: "dustAppRunConfiguration",
+            model: Conversation,
+            as: "conversation",
+            attributes: [],
+            where: { sId: conversationId },
           },
         ],
-      });
-
-      return (
-        await Promise.all(
-          rawAgents.map(async (a) => {
-            return await getAgentConfiguration(auth, a.sId, a);
-          })
-        )
-      ).filter((a) => a !== null) as AgentConfigurationType[];
-    })(),
-    (async () => {
-      return (await getGlobalAgents(auth)).filter(
-        (a) =>
-          !agentPrefix ||
-          a.name.toLowerCase().startsWith(agentPrefix.toLowerCase())
-      );
-    })(),
-  ]);
-
-  return [...globalAgents, ...agents];
+      },
+    ],
+  });
+  return mentions.map((m) => ({
+    configurationId: m.agentConfigurationId as string,
+  }));
 }
 
 /**
@@ -306,6 +444,7 @@ export async function createAgentConfiguration(
   }
 
   let version = 0;
+  let formerAgentRelationOverride: AgentRelationOverrideType | null = null;
 
   const agentConfig = await front_sequelize.transaction(
     async (t): Promise<AgentConfiguration> => {
@@ -323,8 +462,43 @@ export async function createAgentConfiguration(
 
         if (latestVersion !== null) {
           version = latestVersion + 1;
-        }
+          const formerAgent = await AgentConfiguration.findOne({
+            where: {
+              sId: agentConfigurationId,
+              workspaceId: owner.id,
+              version: latestVersion,
+            },
+            attributes: ["scope"],
+            include: [
+              {
+                model: AgentUserRelation,
+                where: {
+                  userId: user.id,
+                },
+                attributes: ["relation"],
+              },
+            ],
+            transaction: t,
+          });
+          if (
+            formerAgent?.relationOverrides &&
+            formerAgent.relationOverrides.length > 0
+          ) {
+            formerAgentRelationOverride =
+              formerAgent.relationOverrides[0].relation;
+          }
+          // At time of writing, private agents can only be created from
+          // scratch. An existing agent that is not already private cannot be
+          // updated back to private.
 
+          if (
+            formerAgent &&
+            scope === "private" &&
+            formerAgent.scope !== "private"
+          ) {
+            throw new Error("Published agents cannot go back to private.");
+          }
+        }
         await AgentConfiguration.update(
           { status: "archived" },
           {
@@ -369,6 +543,7 @@ export async function createAgentConfiguration(
     sId: agentConfig.sId,
     version: agentConfig.version,
     scope: agentConfig.scope,
+    relationOverride: formerAgentRelationOverride,
     name: agentConfig.name,
     description: agentConfig.description,
     pictureUrl: agentConfig.pictureUrl,

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -417,8 +417,10 @@ async function getConversationMentions(
             as: "conversation",
             attributes: [],
             where: { sId: conversationId },
+            required: true,
           },
         ],
+        required: true,
       },
     ],
   });

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -28,18 +28,17 @@ import { Err, Ok, Result } from "@dust-tt/types";
 import moment from "moment-timezone";
 
 import { runActionStreamed } from "@app/lib/actions/server";
+import { renderDustAppRunActionForModel } from "@app/lib/api/assistant/actions/dust_app_run";
 import {
   renderRetrievalActionForModel,
   retrievalMetaPrompt,
 } from "@app/lib/api/assistant/actions/retrieval";
+import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
 import { getSupportedModelConfig, isLargeModel } from "@app/lib/assistant";
 import { Authenticator } from "@app/lib/auth";
 import { FREE_TEST_PLAN_CODE } from "@app/lib/plans/plan_codes";
 import { redisClient } from "@app/lib/redis";
 import logger from "@app/logger/logger";
-
-import { renderDustAppRunActionForModel } from "./actions/dust_app_run";
-import { getAgentConfigurations } from "./configuration";
 const CANCELLATION_CHECK_INTERVAL = 500;
 
 /**
@@ -238,7 +237,12 @@ export async function constructPrompt(
 
   // if meta includes the string "{ASSISTANTS_LIST}"
   if (meta.includes("{ASSISTANTS_LIST}")) {
-    const agents = await getAgentConfigurations(auth);
+    if (!auth.isUser())
+      throw new Error("Unexpected unauthenticated call to `constructPrompt`");
+    const agents = await getAgentConfigurations(
+      auth,
+      auth.user() ? "list" : "all"
+    );
     meta = meta.replaceAll(
       "{ASSISTANTS_LIST}",
       agents

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -100,6 +100,7 @@ async function _getHelperGlobalAgent(
     description: "Help on how to use Dust",
     pictureUrl: "https://dust.tt/static/systemavatar/helper_avatar_full.png",
     status: "active",
+    relationOverride: null,
     scope: "global",
     generation: {
       id: -1,
@@ -126,6 +127,7 @@ async function _getGPT35TurboGlobalAgent({
     pictureUrl: "https://dust.tt/static/systemavatar/gpt3_avatar_full.png",
     status: settings ? settings.status : "active",
     scope: "global",
+    relationOverride: null,
     generation: {
       id: -1,
       prompt: "",
@@ -155,6 +157,7 @@ async function _getGPT4GlobalAgent({
     pictureUrl: "https://dust.tt/static/systemavatar/gpt4_avatar_full.png",
     status,
     scope: "global",
+    relationOverride: null,
     generation: {
       id: -1,
       prompt: "",
@@ -184,6 +187,7 @@ async function _getClaudeInstantGlobalAgent({
     pictureUrl: "https://dust.tt/static/systemavatar/claude_avatar_full.png",
     status: settings ? settings.status : "active",
     scope: "global",
+    relationOverride: null,
     generation: {
       id: -1,
       prompt: "",
@@ -215,6 +219,7 @@ async function _getClaudeGlobalAgent({
     pictureUrl: "https://dust.tt/static/systemavatar/claude_avatar_full.png",
     status: settings ? settings.status : status,
     scope: "global",
+    relationOverride: null,
     generation: {
       id: -1,
       prompt: "",
@@ -242,6 +247,7 @@ async function _getMistralGlobalAgent({
     pictureUrl: "https://dust.tt/static/systemavatar/mistral_avatar_full.png",
     status: settings ? settings.status : "disabled_by_admin",
     scope: "global",
+    relationOverride: null,
     generation: {
       id: -1,
       prompt: "",
@@ -300,6 +306,7 @@ async function _getManagedDataSourceAgent(
       pictureUrl,
       status: "disabled_by_admin",
       scope: "global",
+      relationOverride: null,
       generation: null,
       action: null,
     };
@@ -319,6 +326,7 @@ async function _getManagedDataSourceAgent(
       pictureUrl,
       status: "disabled_missing_datasource",
       scope: "global",
+      relationOverride: null,
       generation: null,
       action: null,
     };
@@ -333,6 +341,7 @@ async function _getManagedDataSourceAgent(
     pictureUrl,
     status: "active",
     scope: "global",
+    relationOverride: null,
     generation: {
       id: -1,
       prompt,
@@ -488,6 +497,7 @@ async function _getDustGlobalAgent(
       pictureUrl,
       status: "disabled_by_admin",
       scope: "global",
+      relationOverride: null,
       generation: null,
       action: null,
     };
@@ -515,6 +525,7 @@ async function _getDustGlobalAgent(
       pictureUrl,
       status: "disabled_missing_datasource",
       scope: "global",
+      relationOverride: null,
       generation: null,
       action: null,
     };
@@ -529,6 +540,7 @@ async function _getDustGlobalAgent(
     pictureUrl,
     status: "active",
     scope: "global",
+    relationOverride: null,
     generation: {
       id: -1,
       prompt:

--- a/front/lib/api/assistant/relation_override.ts
+++ b/front/lib/api/assistant/relation_override.ts
@@ -8,14 +8,17 @@ import {
   AgentUserRelation,
 } from "@app/lib/models/assistant/agent";
 
+/**
+ *
+ * @returns Map of agentId to relation override
+ */
 export async function getAgentRelationOverridesForUser(
   auth: Authenticator
 ): Promise<
   Result<
     {
-      assistantId: string;
-      agentRelationOverride: AgentRelationOverrideType;
-    }[],
+      [assistantId: string]: AgentRelationOverrideType;
+    },
     Error
   >
 > {
@@ -31,10 +34,15 @@ export async function getAgentRelationOverridesForUser(
       },
     ],
   });
-  const agentRelationOverrides = agentRelations.map((mav) => ({
-    assistantId: mav.agentConfiguration.sId,
-    agentRelationOverride: mav.relation,
-  }));
+  const agentRelationOverrides = agentRelations.reduce(
+    (acc, agentRelation) => {
+      acc[agentRelation.agentConfiguration.sId] = agentRelation.relation;
+      return acc;
+    },
+    {} as {
+      [assistantId: string]: AgentRelationOverrideType;
+    }
+  );
   return new Ok(agentRelationOverrides);
 }
 

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -1,15 +1,6 @@
 import { AgentConfigurationType } from "@dust-tt/types";
 import { SUPPORTED_MODEL_CONFIGS, SupportedModel } from "@dust-tt/types";
 
-export function isSupportedModel(model: unknown): model is SupportedModel {
-  const maybeSupportedModel = model as SupportedModel;
-  return SUPPORTED_MODEL_CONFIGS.some(
-    (m) =>
-      m.modelId === maybeSupportedModel.modelId &&
-      m.providerId === maybeSupportedModel.providerId
-  );
-}
-
 export function isLargeModel(model: unknown): model is SupportedModel {
   const maybeSupportedModel = model as SupportedModel;
   const m = SUPPORTED_MODEL_CONFIGS.find(

--- a/front/lib/databases.ts
+++ b/front/lib/databases.ts
@@ -7,7 +7,7 @@ export const front_sequelize = new Sequelize(FRONT_DATABASE_URI as string, {
     // default is 5
     max: 10,
   },
-  logging: console.log,
+  logging: false,
 });
 export const xp1_sequelize = new Sequelize(XP1_DATABASE_URI as string, {
   logging: false,

--- a/front/lib/databases.ts
+++ b/front/lib/databases.ts
@@ -7,7 +7,7 @@ export const front_sequelize = new Sequelize(FRONT_DATABASE_URI as string, {
     // default is 5
     max: 10,
   },
-  logging: false,
+  logging: console.log,
 });
 export const xp1_sequelize = new Sequelize(XP1_DATABASE_URI as string, {
   logging: false,

--- a/front/lib/models/assistant/agent.ts
+++ b/front/lib/models/assistant/agent.ts
@@ -19,11 +19,10 @@ import {
 } from "sequelize";
 
 import { front_sequelize } from "@app/lib/databases";
+import { AgentDustAppRunConfiguration } from "@app/lib/models/assistant/actions/dust_app_run";
 import { AgentRetrievalConfiguration } from "@app/lib/models/assistant/actions/retrieval";
 import { User } from "@app/lib/models/user";
 import { Workspace } from "@app/lib/models/workspace";
-
-import { AgentDustAppRunConfiguration } from "./actions/dust_app_run";
 
 /**
  * Configuration of Agent generation.
@@ -118,6 +117,7 @@ export class AgentConfiguration extends Model<
   declare generationConfiguration: NonAttribute<AgentGenerationConfiguration>;
   declare retrievalConfiguration: NonAttribute<AgentRetrievalConfiguration>;
   declare dustAppRunConfiguration: NonAttribute<DustAppRunConfigurationType>;
+  declare relationOverrides: NonAttribute<AgentUserRelation[]>;
 }
 AgentConfiguration.init(
   {
@@ -368,6 +368,15 @@ Workspace.hasMany(AgentUserRelation, {
 AgentConfiguration.hasMany(AgentUserRelation, {
   foreignKey: { allowNull: false },
   onDelete: "CASCADE",
+});
+AgentUserRelation.belongsTo(User, {
+  foreignKey: { allowNull: false },
+});
+AgentUserRelation.belongsTo(Workspace, {
+  foreignKey: { allowNull: false },
+});
+AgentUserRelation.belongsTo(AgentConfiguration, {
+  foreignKey: { allowNull: false },
 });
 
 AgentUserRelation.addHook(

--- a/front/lib/swr.ts
+++ b/front/lib/swr.ts
@@ -1,4 +1,4 @@
-import { DataSourceType } from "@dust-tt/types";
+import { AgentsGetViewType, DataSourceType } from "@dust-tt/types";
 import { WorkspaceType } from "@dust-tt/types";
 import { ConversationMessageReactions, ConversationType } from "@dust-tt/types";
 import { AppType } from "@dust-tt/types";
@@ -459,14 +459,19 @@ export function useConversationReactions({
 
 export function useAgentConfigurations({
   workspaceId,
+  agentsGetViewType,
 }: {
   workspaceId: string;
+  agentsGetViewType: AgentsGetViewType;
 }) {
   const agentConfigurationsFetcher: Fetcher<GetAgentConfigurationsResponseBody> =
     fetcher;
-
+  const viewQueryString =
+    typeof agentsGetViewType === "string"
+      ? `view=${agentsGetViewType}`
+      : `conversationId=${agentsGetViewType.conversationId}`;
   const { data, error, mutate } = useSWR(
-    `/api/w/${workspaceId}/assistant/agent_configurations`,
+    `/api/w/${workspaceId}/assistant/agent_configurations?${viewQueryString}`,
     agentConfigurationsFetcher
   );
 

--- a/front/migrations/20231204_author_backfill.ts
+++ b/front/migrations/20231204_author_backfill.ts
@@ -27,10 +27,6 @@ async function main() {
       })
     );
   }
-
-  for (const w of workspaceIds) {
-    await backfillAuthor(w);
-  }
 }
 
 async function backfillAuthor(workspaceId: number) {
@@ -58,7 +54,7 @@ async function backfillAuthor(workspaceId: number) {
       authorId: author.id,
     },
     {
-      // @ts-ignore
+      // @ts-expect-error null is not tolerated by sequelize after migration
       where: {
         workspaceId,
         authorId: null,

--- a/front/migrations/20231204_drop_chat_v0.sql
+++ b/front/migrations/20231204_drop_chat_v0.sql
@@ -1,4 +1,4 @@
-DROP TABLE IF EXISTS "chat_messages";
 DROP TABLE IF EXISTS "chat_retrieved_documents";
+DROP TABLE IF EXISTS "chat_messages";
 DROP TABLE IF EXISTS "chat_sessions";
 DROP TABLE IF EXISTS "member_agent_visibilities";

--- a/front/pages/api/v1/w/[wId]/assistant/agent_configurations.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/agent_configurations.ts
@@ -34,7 +34,7 @@ async function handler(
 
   switch (req.method) {
     case "GET": {
-      const agentConfigurations = await getAgentConfigurations(auth);
+      const agentConfigurations = await getAgentConfigurations(auth, "all");
       return res.status(200).json({
         agentConfigurations,
       });

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/index.ts
@@ -1,4 +1,7 @@
-import { AgentConfigurationType } from "@dust-tt/types";
+import {
+  AgentConfigurationType,
+  PostOrPatchAgentConfigurationRequestBodySchema,
+} from "@dust-tt/types";
 import { ReturnedAPIErrorType } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as reporter from "io-ts-reporters";
@@ -10,11 +13,7 @@ import {
 } from "@app/lib/api/assistant/configuration";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { apiError, withLogging } from "@app/logger/withlogging";
-
-import {
-  createOrUpgradeAgentConfiguration,
-  PostOrPatchAgentConfigurationRequestBodySchema,
-} from "..";
+import { createOrUpgradeAgentConfiguration } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
 
 export type GetAgentConfigurationResponseBody = {
   agentConfiguration: AgentConfigurationType;

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -1,8 +1,9 @@
-import { SupportedModel, TimeframeUnitCodec } from "@dust-tt/types";
 import {
   AgentActionConfigurationType,
   AgentConfigurationType,
   AgentGenerationConfigurationType,
+  GetAgentConfigurationsQuerySchema,
+  PostOrPatchAgentConfigurationRequestBodySchema,
 } from "@dust-tt/types";
 import { ReturnedAPIErrorType } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
@@ -16,7 +17,6 @@ import {
   createAgentGenerationConfiguration,
   getAgentConfigurations,
 } from "@app/lib/api/assistant/configuration";
-import { isSupportedModel } from "@app/lib/assistant";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { apiError, withLogging } from "@app/logger/withlogging";
 
@@ -26,82 +26,6 @@ export type GetAgentConfigurationsResponseBody = {
 export type PostAgentConfigurationResponseBody = {
   agentConfiguration: AgentConfigurationType;
 };
-
-export const PostOrPatchAgentConfigurationRequestBodySchema = t.type({
-  assistant: t.type({
-    name: t.string,
-    description: t.string,
-    pictureUrl: t.string,
-    status: t.union([t.literal("active"), t.literal("archived")]),
-    scope: t.union([
-      t.literal("workspace"),
-      t.literal("published"),
-      t.literal("private"),
-    ]),
-    action: t.union([
-      t.null,
-      t.type({
-        type: t.literal("retrieval_configuration"),
-        query: t.union([
-          t.type({
-            template: t.string,
-          }),
-          t.literal("auto"),
-          t.literal("none"),
-        ]),
-        timeframe: t.union([
-          t.literal("auto"),
-          t.literal("none"),
-          t.type({
-            duration: t.number,
-            unit: TimeframeUnitCodec,
-          }),
-        ]),
-        topK: t.union([t.number, t.literal("auto")]),
-        dataSources: t.array(
-          t.type({
-            dataSourceId: t.string,
-            workspaceId: t.string,
-            filter: t.type({
-              tags: t.union([
-                t.type({
-                  in: t.array(t.string),
-                  not: t.array(t.string),
-                }),
-                t.null,
-              ]),
-              parents: t.union([
-                t.type({
-                  in: t.array(t.string),
-                  not: t.array(t.string),
-                }),
-                t.null,
-              ]),
-            }),
-          })
-        ),
-      }),
-      t.type({
-        type: t.literal("dust_app_run_configuration"),
-        appWorkspaceId: t.string,
-        appId: t.string,
-      }),
-    ]),
-    generation: t.type({
-      prompt: t.string,
-      // enforce that the model is a supported model
-      // the modelId and providerId are checked together, so
-      // (gpt-4, anthropic) won't pass
-      model: new t.Type<SupportedModel>(
-        "SupportedModel",
-        isSupportedModel,
-        (i, c) => (isSupportedModel(i) ? t.success(i) : t.failure(i, c)),
-        t.identity
-      ),
-      temperature: t.number,
-    }),
-  }),
-});
 
 async function handler(
   req: NextApiRequest,
@@ -139,8 +63,38 @@ async function handler(
           },
         });
       }
+      // extract the view from the query parameters
+      const queryValidation = GetAgentConfigurationsQuerySchema.decode(
+        req.query
+      );
+      if (isLeft(queryValidation)) {
+        const pathError = reporter.formatValidationErrors(queryValidation.left);
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid query parameters: ${pathError}`,
+          },
+        });
+      }
 
-      const agentConfigurations = await getAgentConfigurations(auth);
+      const { view, conversationId } = queryValidation.right;
+      const viewParam = view
+        ? view
+        : conversationId
+        ? { conversationId }
+        : undefined;
+      if (!viewParam) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              "The view query parameter is required if no conversationId is provided.",
+          },
+        });
+      }
+      const agentConfigurations = await getAgentConfigurations(auth, viewParam);
       return res.status(200).json({
         agentConfigurations,
       });

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -83,17 +83,7 @@ async function handler(
         ? view
         : conversationId
         ? { conversationId }
-        : undefined;
-      if (!viewParam) {
-        return apiError(req, res, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message:
-              "The view query parameter is required if no conversationId is provided.",
-          },
-        });
-      }
+        : "all";
       const agentConfigurations = await getAgentConfigurations(auth, viewParam);
       return res.status(200).json({
         agentConfigurations,

--- a/front/pages/api/w/[wId]/members/me/assistant_relation_override.ts
+++ b/front/pages/api/w/[wId]/members/me/assistant_relation_override.ts
@@ -23,9 +23,8 @@ export type PostAgentRelationOverrideResponseBody = {
 
 export type GetAgentRelationOverrideResponseBody = {
   agentRelationOverrides: {
-    assistantId: string;
-    agentRelationOverride: AgentRelationOverrideType;
-  }[];
+    [assistantId: string]: AgentRelationOverrideType;
+  };
 };
 
 export const PostAgentRelationOverrideRequestBodySchema = t.type({

--- a/front/pages/poke/[wId]/index.tsx
+++ b/front/pages/poke/[wId]/index.tsx
@@ -82,7 +82,9 @@ export const getServerSideProps: GetServerSideProps<{
   }
 
   const dataSources = await getDataSources(auth);
-  const agentConfigurations = (await getAgentConfigurations(auth)).filter(
+  const agentConfigurations = (
+    await getAgentConfigurations(auth, "super_user")
+  ).filter(
     (a) =>
       !Object.values(GLOBAL_AGENTS_SID).includes(a.sId as GLOBAL_AGENTS_SID)
   );

--- a/front/pages/w/[wId]/assistant/new.tsx
+++ b/front/pages/w/[wId]/assistant/new.tsx
@@ -97,6 +97,7 @@ export default function AssistantNew({
 
   const { agentConfigurations } = useAgentConfigurations({
     workspaceId: owner.sId,
+    agentsGetViewType: "list",
   });
 
   const activeAgents = agentConfigurations.filter((a) => a.status === "active");

--- a/front/pages/w/[wId]/builder/assistants/dust.tsx
+++ b/front/pages/w/[wId]/builder/assistants/dust.tsx
@@ -69,6 +69,7 @@ export default function EditDustAssistant({
   const { agentConfigurations, mutateAgentConfigurations } =
     useAgentConfigurations({
       workspaceId: owner.sId,
+      agentsGetViewType: "all",
     });
   const { dataSources, mutateDataSources } = useDataSources(owner);
 

--- a/front/pages/w/[wId]/builder/assistants/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/index.tsx
@@ -70,6 +70,7 @@ export default function AssistantsBuilder({
   const { agentConfigurations, mutateAgentConfigurations } =
     useAgentConfigurations({
       workspaceId: owner.sId,
+      agentsGetViewType: "all",
     });
   const [assistantSearch, setAssistantSearch] = useState<string>("");
   const [showDisabledFreeWorkspacePopup, setShowDisabledFreeWorkspacePopup] =

--- a/types/src/front/api_handlers/internal/agent_configuration.ts
+++ b/types/src/front/api_handlers/internal/agent_configuration.ts
@@ -1,0 +1,92 @@
+import * as t from "io-ts";
+
+import { TimeframeUnitCodec } from "../../assistant/actions/retrieval";
+import { isSupportedModel, SupportedModel } from "../../lib/assistant";
+
+// Get schema for the url query parameters: a view parameter with all the types
+// of AgentGetViewType
+export const GetAgentConfigurationsQuerySchema = t.type({
+  view: t.union([
+    t.literal("list"),
+    t.literal("super_user"),
+    t.literal("all"),
+    t.undefined,
+  ]),
+  conversationId: t.union([t.string, t.undefined]),
+});
+
+export const PostOrPatchAgentConfigurationRequestBodySchema = t.type({
+  assistant: t.type({
+    name: t.string,
+    description: t.string,
+    pictureUrl: t.string,
+    status: t.union([t.literal("active"), t.literal("archived")]),
+    scope: t.union([
+      t.literal("workspace"),
+      t.literal("published"),
+      t.literal("private"),
+    ]),
+    action: t.union([
+      t.null,
+      t.type({
+        type: t.literal("retrieval_configuration"),
+        query: t.union([
+          t.type({
+            template: t.string,
+          }),
+          t.literal("auto"),
+          t.literal("none"),
+        ]),
+        timeframe: t.union([
+          t.literal("auto"),
+          t.literal("none"),
+          t.type({
+            duration: t.number,
+            unit: TimeframeUnitCodec,
+          }),
+        ]),
+        topK: t.union([t.number, t.literal("auto")]),
+        dataSources: t.array(
+          t.type({
+            dataSourceId: t.string,
+            workspaceId: t.string,
+            filter: t.type({
+              tags: t.union([
+                t.type({
+                  in: t.array(t.string),
+                  not: t.array(t.string),
+                }),
+                t.null,
+              ]),
+              parents: t.union([
+                t.type({
+                  in: t.array(t.string),
+                  not: t.array(t.string),
+                }),
+                t.null,
+              ]),
+            }),
+          })
+        ),
+      }),
+      t.type({
+        type: t.literal("dust_app_run_configuration"),
+        appWorkspaceId: t.string,
+        appId: t.string,
+      }),
+    ]),
+    generation: t.type({
+      prompt: t.string,
+      // enforce that the model is a supported model
+      // the modelId and providerId are checked together, so
+      // (gpt-4, anthropic) won't pass
+      model: new t.Type<SupportedModel>(
+        "SupportedModel",
+        isSupportedModel,
+        (i, c) => (isSupportedModel(i) ? t.success(i) : t.failure(i, c)),
+        t.identity
+      ),
+      temperature: t.number,
+    }),
+  }),
+});

--- a/types/src/front/assistant/agent.ts
+++ b/types/src/front/assistant/agent.ts
@@ -67,6 +67,13 @@ export type GlobalAgentStatus =
 export type AgentStatus = "active" | "archived";
 export type AgentConfigurationStatus = AgentStatus | GlobalAgentStatus;
 
+/**
+ * Agent configuration scope
+ * - 'global' scope are Dust assistants, not editable, inside-list for all, cannot be overriden
+ * - 'workspace' scope are editable by builders only,  inside-list by default but user can change it
+ * - 'published' scope are editable by everybody, outside-list by default
+ * - 'private' scope are editable by author only, inside-list for author, cannot be overriden (so no entry in the table
+ */
 export type AgentConfigurationScope =
   | "global"
   | "workspace"
@@ -77,6 +84,23 @@ export type AgentConfigurationScope =
  * scope 'published' aren't. But a user can override the default behaviour, as per the type below */
 export type AgentRelationOverrideType = "in-list" | "not-in-list";
 
+/**
+ * Agents can be retrieved according to different 'views':
+ * - list: all agents in the user's list
+ * - conversation: all agents in the user's list + agents in the current
+ *   conversation (requries a conversation sId)
+ * - all: workspace + published agents (not private ones), eg. for agent gallery
+ * - superuser: all agents, including private ones => CAREFUL. Currently used by
+ *   poke only
+ * Global agents enabled for the workspace are always returned with all the views.
+ */
+
+export type AgentsGetViewType =
+  | "list"
+  | { conversationId: string }
+  | "all"
+  | "super_user";
+
 export type AgentConfigurationType = {
   id: ModelId;
 
@@ -84,6 +108,7 @@ export type AgentConfigurationType = {
   version: number;
 
   scope: AgentConfigurationScope;
+  relationOverride: AgentRelationOverrideType | null;
   status: AgentConfigurationStatus;
 
   name: string;

--- a/types/src/front/lib/assistant.ts
+++ b/types/src/front/lib/assistant.ts
@@ -94,3 +94,12 @@ export type SupportedModel = ExtractSpecificKeys<
   (typeof SUPPORTED_MODEL_CONFIGS)[number],
   "providerId" | "modelId"
 >;
+
+export function isSupportedModel(model: unknown): model is SupportedModel {
+  const maybeSupportedModel = model as SupportedModel;
+  return SUPPORTED_MODEL_CONFIGS.some(
+    (m) =>
+      m.modelId === maybeSupportedModel.modelId &&
+      m.providerId === maybeSupportedModel.providerId
+  );
+}

--- a/types/src/index.ts
+++ b/types/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./core/data_source";
+export * from "./front/api_handlers/internal/agent_configuration";
 export * from "./front/api_handlers/internal/assistant";
 export * from "./front/api_handlers/public/assistant";
 export * from "./front/api_handlers/public/data_sources";


### PR DESCRIPTION
Fixes #2808 and previously #2778 

- Fixes failing calls to getAgentConfigurations when user was not set 
- Default to view "all" for api get calls without a "view" parameter

Related [discussion](https://dust4ai.slack.com/archives/C050SM8NSPK/p1702039668546789)