### PR TITLE
Remove reliance on .env.local

### DIFF
--- a/connectors/admin/cli.sh
+++ b/connectors/admin/cli.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-env $(cat .env.local) npx tsx src/admin/cli.ts "$@"
+npx tsx src/admin/cli.ts "$@"

--- a/connectors/admin/dev.sh
+++ b/connectors/admin/dev.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-NODE_ENV=development env $(cat .env.local) npx tsx ./src/start.ts -p 3002
+NODE_ENV=development npx tsx ./src/start.ts -p 3002

--- a/connectors/admin/init_db.sh
+++ b/connectors/admin/init_db.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-env $(cat .env.local) npx tsx src/admin/db.ts
+npx tsx src/admin/db.ts

--- a/connectors/admin/staging.sh
+++ b/connectors/admin/staging.sh
@@ -2,5 +2,5 @@
 
 export NODE_ENV=staging
 
-env $(cat .env.local) npx tsx ./src/start.ts -p 3002 2>&1
+npx tsx ./src/start.ts -p 3002 2>&1
 

--- a/connectors/package.json
+++ b/connectors/package.json
@@ -6,11 +6,11 @@
     "format:check": "prettier --check .",
     "lint": "eslint .",
     "build": "tsc",
-    "start": "env $(cat .env.local) tsx ./src/start.ts -p 3002",
+    "start": "tsx ./src/start.ts -p 3002",
     "start:web": "tsx ./src/start_server.ts -p 3002",
     "start:worker": "tsx ./src/start_worker.ts",
-    "cli": "env $(cat .env.local) npx tsx src/admin/cli.ts",
-    "initdb": "env $(cat .env.local) npx tsx src/admin/db.ts"
+    "cli": "npx tsx src/admin/cli.ts",
+    "initdb": "npx tsx src/admin/db.ts"
   },
   "dependencies": {
     "@dust-tt/types": "file:../types",

--- a/core/admin/dev.sh
+++ b/core/admin/dev.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-env $(cat .env.local) cargo run --bin dust-api
+cargo run --bin dust-api

--- a/front/admin/cli.sh
+++ b/front/admin/cli.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-env $(cat .env.local) npx tsx admin/cli.ts "$@"
+npx tsx admin/cli.ts "$@"

--- a/front/admin/eval.sh
+++ b/front/admin/eval.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 export NODE_ENV="development"
-env $(cat .env.local) npx tsx ./tests/chat/e2e_eval.ts $*
+npx tsx ./tests/chat/e2e_eval.ts $*

--- a/front/admin/init_db.sh
+++ b/front/admin/init_db.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-env $(cat .env.local) npx tsx admin/db.ts
+npx tsx admin/db.ts
 

--- a/front/admin/init_plans.sh
+++ b/front/admin/init_plans.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-env $(cat .env.local) npx tsx admin/init_plans.ts
+npx tsx admin/init_plans.ts
 

--- a/front/mailing/mailing.sh
+++ b/front/mailing/mailing.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-env $(cat .env.local) npx tsx mailing/$1.ts
+npx tsx mailing/$1.ts

--- a/front/package.json
+++ b/front/package.json
@@ -10,7 +10,7 @@
     "tsc": "tsc",
     "test": "jest",
     "coverage": "jest --coverage",
-    "initdb": "env $(cat .env.local) npx tsx admin/db.ts"
+    "initdb": "npx tsx admin/db.ts"
   },
   "dependencies": {
     "@dust-tt/sparkle": "^0.2.51",

--- a/types/admin/dev.sh
+++ b/types/admin/dev.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-npm ci && npm run start
+npm i && npm run start

--- a/types/admin/dev.sh
+++ b/types/admin/dev.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+npm ci && npm run start


### PR DESCRIPTION
cc @dust-tt/engineering-team 

Removing references to .env.local

It's not used in prod anymore and it's much much more convenient to set all the dev variables in your env with .bashrc

Runbook updated here: https://www.notion.so/dust-tt/Runbook-Local-Dev-setup-720bffc7d67a447184cb957e9471380c