### PR TITLE
Add CLI to garbage collect all Gdrives.

### DIFF
--- a/connectors/src/admin/cli.ts
+++ b/connectors/src/admin/cli.ts
@@ -4,6 +4,7 @@ import readline from "readline";
 
 import {
   DELETE_CONNECTOR_BY_TYPE,
+  GARBAGE_COLLECT_BY_TYPE,
   RESUME_CONNECTOR_BY_TYPE,
   STOP_CONNECTOR_BY_TYPE,
   SYNC_CONNECTOR_BY_TYPE,
@@ -263,6 +264,19 @@ const notion = async (command: string, args: parseArgs.ParsedArgs) => {
 
 const google = async (command: string, args: parseArgs.ParsedArgs) => {
   switch (command) {
+    case "garbage-collect-all": {
+      const connectors = await Connector.findAll({
+        where: {
+          type: "google_drive",
+        },
+      });
+      for (const connector of connectors) {
+        await throwOnError(
+          GARBAGE_COLLECT_BY_TYPE[connector.type](connector.id)
+        );
+      }
+      return;
+    }
     case "restart-google-webhooks": {
       await throwOnError(launchGoogleDriveRenewWebhooksWorkflow());
       return;

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -36,7 +36,10 @@ import {
   getGoogleCredentials,
   getGoogleDriveObject,
 } from "./temporal/activities";
-import { launchGoogleDriveFullSyncWorkflow } from "./temporal/client";
+import {
+  launchGoogleDriveFullSyncWorkflow,
+  launchGoogleGarbageCollector,
+} from "./temporal/client";
 export type NangoConnectionId = string;
 import { ModelId } from "@dust-tt/types";
 import { v4 as uuidv4 } from "uuid";
@@ -707,4 +710,15 @@ export async function setGoogleDriveConfig(
       return new Err(new Error(`Invalid config key ${configKey}`));
     }
   }
+}
+
+export async function googleDriveGarbageCollect(connectorId: ModelId) {
+  const connector = await Connector.findOne({
+    where: { id: connectorId },
+  });
+  if (!connector) {
+    return new Err(new Error(`Connector not found with id ${connectorId}`));
+  }
+
+  return await launchGoogleGarbageCollector(connectorId);
 }

--- a/connectors/src/connectors/index.ts
+++ b/connectors/src/connectors/index.ts
@@ -14,6 +14,7 @@ import {
   cleanupGoogleDriveConnector,
   createGoogleDriveConnector,
   getGoogleDriveConfig,
+  googleDriveGarbageCollect,
   retrieveGoogleDriveConnectorPermissions,
   retrieveGoogleDriveObjectsParents,
   retrieveGoogleDriveObjectsTitles,
@@ -40,6 +41,7 @@ import {
   ConnectorConfigGetter,
   ConnectorConfigSetter,
   ConnectorCreator,
+  ConnectorGarbageCollector,
   ConnectorPermissionRetriever,
   ConnectorPermissionSetter,
   ConnectorResourceParentsRetriever,
@@ -278,6 +280,25 @@ export const GET_CONNECTOR_CONFIG_BY_TYPE: Record<
     throw new Error("Not implemented");
   },
   google_drive: getGoogleDriveConfig,
+  intercom: async () => {
+    throw new Error("Not implemented");
+  },
+};
+
+export const GARBAGE_COLLECT_BY_TYPE: Record<
+  ConnectorProvider,
+  ConnectorGarbageCollector
+> = {
+  slack: () => {
+    throw new Error("Not implemented");
+  },
+  notion: async () => {
+    throw new Error("Not implemented");
+  },
+  github: async () => {
+    throw new Error("Not implemented");
+  },
+  google_drive: googleDriveGarbageCollect,
   intercom: async () => {
     throw new Error("Not implemented");
   },

--- a/connectors/src/connectors/interface.ts
+++ b/connectors/src/connectors/interface.ts
@@ -82,3 +82,7 @@ export type ConnectorConfigGetter = (
   connectorId: ModelId,
   configKey: string
 ) => Promise<Result<string, Error>>;
+
+export type ConnectorGarbageCollector = (
+  connectorId: ModelId
+) => Promise<Result<string, Error>>;


### PR DESCRIPTION
Following [this](https://dust4ai.slack.com/archives/C05ASU7SCVA/p1701969426903499) issue, we need to run the garbage collector on all Google Drives managed Data Sources.

We were not properly cleaned up deleted folders (but files inside were properly deleted).
