### PR TITLE
Fetch all AgentDSConfigs at once for GET /agent_configurations

### DIFF
--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -52,7 +52,8 @@ import { generateModelSId } from "@app/lib/utils";
 export async function getAgentConfiguration(
   auth: Authenticator,
   agentId: string,
-  agentConfiguration?: AgentConfiguration
+  preFetchedAgentConfiguration?: AgentConfiguration,
+  preFetchedDataSourcesConfig?: AgentDataSourceConfiguration[]
 ): Promise<AgentConfigurationType | null> {
   const owner = auth.workspace();
   if (!owner || !auth.isUser()) {
@@ -68,7 +69,7 @@ export async function getAgentConfiguration(
   }
   const user = auth.user();
   const agent =
-    agentConfiguration ??
+    preFetchedAgentConfiguration ??
     (await AgentConfiguration.findOne({
       where: {
         sId: agentId,
@@ -112,23 +113,26 @@ export async function getAgentConfiguration(
     | null = null;
 
   if (agent.retrievalConfigurationId) {
-    const dataSourcesConfig = await AgentDataSourceConfiguration.findAll({
-      where: {
-        retrievalConfigurationId: agent.retrievalConfiguration?.id,
-      },
-      include: [
-        {
-          model: DataSource,
-          as: "dataSource",
-          include: [
-            {
-              model: Workspace,
-              as: "workspace",
+    const dataSourcesConfig =
+      preFetchedDataSourcesConfig !== undefined
+        ? preFetchedDataSourcesConfig
+        : await AgentDataSourceConfiguration.findAll({
+            where: {
+              retrievalConfigurationId: agent.retrievalConfiguration?.id,
             },
-          ],
-        },
-      ],
-    });
+            include: [
+              {
+                model: DataSource,
+                as: "dataSource",
+                include: [
+                  {
+                    model: Workspace,
+                    as: "workspace",
+                  },
+                ],
+              },
+            ],
+          });
     const retrievalConfig = agent.retrievalConfiguration;
 
     if (!retrievalConfig) {
@@ -293,9 +297,40 @@ export async function getAgentConfigurations(
     agentsSequelizeQuery: FindOptions
   ) => {
     const agents = await AgentConfiguration.findAll(agentsSequelizeQuery);
+    const retrievalConfigurationIds = agents
+      .map((a) => a.retrievalConfigurationId)
+      .flatMap((id) => (id ? [id] : []));
+    const dataSourcesConfig = await AgentDataSourceConfiguration.findAll({
+      where: {
+        retrievalConfigurationId: { [Op.in]: retrievalConfigurationIds },
+      },
+      include: [
+        {
+          model: DataSource,
+          as: "dataSource",
+          include: [
+            {
+              model: Workspace,
+              as: "workspace",
+            },
+          ],
+        },
+      ],
+    });
+
     return (
       await Promise.all(
-        agents.map((a) => getAgentConfiguration(auth, a.sId, a))
+        agents.map((a) =>
+          getAgentConfiguration(
+            auth,
+            a.sId,
+            a,
+            dataSourcesConfig.filter(
+              (dsc) =>
+                dsc.retrievalConfigurationId === a.retrievalConfigurationId
+            )
+          )
+        )
       )
     ).filter((a) => a !== null) as AgentConfigurationType[];
   };

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -53,7 +53,7 @@ export async function getAgentConfiguration(
   auth: Authenticator,
   agentId: string,
   preFetchedAgentConfiguration?: AgentConfiguration,
-  preFetchedDataSourcesConfig?: AgentDataSourceConfiguration[]
+  preFetchedDataSourceConfigurations?: AgentDataSourceConfiguration[]
 ): Promise<AgentConfigurationType | null> {
   const owner = auth.workspace();
   if (!owner || !auth.isUser()) {
@@ -114,8 +114,8 @@ export async function getAgentConfiguration(
 
   if (agent.retrievalConfigurationId) {
     const dataSourcesConfig =
-      preFetchedDataSourcesConfig !== undefined
-        ? preFetchedDataSourcesConfig
+      preFetchedDataSourceConfigurations !== undefined
+        ? preFetchedDataSourceConfigurations
         : await AgentDataSourceConfiguration.findAll({
             where: {
               retrievalConfigurationId: agent.retrievalConfiguration?.id,


### PR DESCRIPTION
Last round of optimization for the `GET /api/w/[wId]/assistant/agent_configurations` endpoint.

I did the following tests:
- Created 4 custom assistants, with the following Data Sources: Slack, Gdrive, Slack+Gdrive, None.
- Sent a `curl` request to the HTTP endpoint and made a diff of the output between main and this branch
- Output matches perfectly, 0 diff.
