### PR TITLE
Log long SQL connection acquisition time

### DIFF
--- a/front/lib/databases.ts
+++ b/front/lib/databases.ts
@@ -1,6 +1,10 @@
 import { Sequelize } from "sequelize";
 
+import logger from "@app/logger/logger";
+
 const { FRONT_DATABASE_URI, XP1_DATABASE_URI } = process.env;
+
+const acquireAttempts = new WeakMap();
 
 export const front_sequelize = new Sequelize(FRONT_DATABASE_URI as string, {
   pool: {
@@ -8,6 +12,22 @@ export const front_sequelize = new Sequelize(FRONT_DATABASE_URI as string, {
     max: 10,
   },
   logging: false,
+  hooks: {
+    beforePoolAcquire: (options) => {
+      acquireAttempts.set(options, Date.now());
+    },
+    afterPoolAcquire: (connection, options) => {
+      const elapsedTime = Date.now() - acquireAttempts.get(options);
+      if (elapsedTime > 100) {
+        logger.info(
+          {
+            elapsedTime,
+          },
+          "Long sequelize connection acquisition detected"
+        );
+      }
+    },
+  },
 });
 export const xp1_sequelize = new Sequelize(XP1_DATABASE_URI as string, {
   logging: false,


### PR DESCRIPTION
Datadog traces indicate prolonged "waiting" periods without explanation, likely due to unprofiled SQL queries in Sequelize awaiting connection pool availability. We're implementing logs for delayed acquisition actions.