### PR TITLE
Fix mention replacement when multiple mentions are present

### DIFF
--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -98,9 +98,9 @@ export async function renderConversationForModel({
       }
     } else if (isUserMessageType(m)) {
       // Replace all `:mention[{name}]{.*}` with `@name`.
-      const content = m.content.replace(
-        /:mention\[(.+)\]\{.+\}/g,
-        (match, name) => {
+      const content = m.content.replaceAll(
+        /:mention\[([^\]]+)\]\{[^}]+\}/g,
+        (_, name) => {
           return `@${name}`;
         }
       );


### PR DESCRIPTION
With multiple mentions it was doing weird things 

```
@gpt4]{sId=gpt-4} :mention[claude 1 sentence on Arc de Triomphe
```

This fixes that issue.