### PR TITLE
Increase front Sequelize pool from 10 to 20 connections.

### DIFF
--- a/front/lib/databases.ts
+++ b/front/lib/databases.ts
@@ -9,7 +9,7 @@ const acquireAttempts = new WeakMap();
 export const front_sequelize = new Sequelize(FRONT_DATABASE_URI as string, {
   pool: {
     // default is 5
-    max: 10,
+    max: 20,
   },
   logging: false,
   hooks: {


### PR DESCRIPTION
We are seeing a lof of front HTTP queries awaiting for a SQL connection, and we are running at only ~20% to 25% of our max SQL connections on our production server.

Increasing the pool size from 10 to 20 should take us to at most 50% of our available connections and speed up production by lowering waiting time.

[CPU usage](https://console.cloud.google.com/sql/instances/dust-api-db/system-insights?project=or1g1n-186209&pageState=(%22sqlMonitoring%22:(%22groupValue%22:%22PT6H%22,%22customValue%22:null))) is also at ~20% so we are good on that front.