### PR TITLE
[Fix] Gdrive: Text documents over 500MB made the sync crash

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -413,6 +413,10 @@ async function syncOneFile(
 
     if (file.mimeType === "text/plain") {
       if (res.data instanceof ArrayBuffer) {
+        // If data is > 4 times the limit, we skip the file since even if
+        // converted to utf-8 it will overcome the limit enforced below. This
+        // avoids operations on very long text files, that can cause
+        // Buffer.toString to crash if the file is > 500MB
         if (res.data.byteLength > 4 * MAX_DOCUMENT_TXT_LEN) {
           logger.info(
             {

--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -413,6 +413,17 @@ async function syncOneFile(
 
     if (file.mimeType === "text/plain") {
       if (res.data instanceof ArrayBuffer) {
+        if (res.data.byteLength > 4 * MAX_DOCUMENT_TXT_LEN) {
+          logger.info(
+            {
+              file_id: file.id,
+              mimeType: file.mimeType,
+              title: file.name,
+            },
+            `File too big to be chunked. Skipping`
+          );
+          return false;
+        }
         documentContent = Buffer.from(res.data).toString("utf-8");
       }
     } else if (file.mimeType === "application/pdf") {


### PR DESCRIPTION
See [here](https://dust4ai.slack.com/archives/C05F84CFP0E/p1702379687087599)

Converting to string could not be done and an error was thrown

Fix: checking for max doc length before converting to string, with a *4 on the max length to account for long characters that are more than 1 byte

There is another check below to see if the text rendered to utf-8 chars is bigger than `MAX_DOC_TXT_LEN`