### PR TITLE
Debounce Google Drive webhook

### DIFF
--- a/connectors/package-lock.json
+++ b/connectors/package-lock.json
@@ -73,6 +73,7 @@
         "dts-cli": "^2.0.3",
         "eslint-plugin-simple-import-sort": "^10.0.0",
         "eventsource-parser": "^1.1.1",
+        "hot-shots": "^10.0.0",
         "io-ts": "^2.2.20",
         "redis": "^4.6.8",
         "uuid": "^9.0.1"

--- a/connectors/src/api/webhooks/webhook_google_drive.ts
+++ b/connectors/src/api/webhooks/webhook_google_drive.ts
@@ -1,8 +1,10 @@
+import { RateLimitError } from "@dust-tt/types";
 import { Request, Response } from "express";
 
 import { launchGoogleDriveIncrementalSyncWorkflow } from "@connectors/connectors/google_drive/temporal/client";
 import { APIErrorWithStatusCode } from "@connectors/lib/error";
 import { GoogleDriveWebhook } from "@connectors/lib/models/google_drive";
+import logger from "@connectors/logger/logger";
 import { apiError, withLogging } from "@connectors/logger/withlogging";
 
 type GoogleDriveWebhookResBody = null | APIErrorWithStatusCode;
@@ -39,7 +41,15 @@ const _webhookGoogleDriveAPIHandler = async (
   const workflowRes = await launchGoogleDriveIncrementalSyncWorkflow(
     webhook.connectorId.toString()
   );
+
   if (workflowRes.isErr()) {
+    if (workflowRes.error instanceof RateLimitError) {
+      logger.info(
+        {},
+        "Did not signal a Gdrive webhook to the incremenal sync workflow because of rate limit"
+      );
+      return res.status(200).end();
+    }
     return apiError(req, res, {
       status_code: 500,
       api_error: {

--- a/connectors/src/api/webhooks/webhook_google_drive.ts
+++ b/connectors/src/api/webhooks/webhook_google_drive.ts
@@ -45,7 +45,10 @@ const _webhookGoogleDriveAPIHandler = async (
   if (workflowRes.isErr()) {
     if (workflowRes.error instanceof RateLimitError) {
       logger.info(
-        {},
+        {
+          connectorId: webhook.connectorId,
+          webhookId: webhook.webhookId,
+        },
         "Did not signal a Gdrive webhook to the incremenal sync workflow because of rate limit"
       );
       return res.status(200).end();

--- a/connectors/src/connectors/google_drive/temporal/config.ts
+++ b/connectors/src/connectors/google_drive/temporal/config.ts
@@ -1,2 +1,3 @@
 export const WORKFLOW_VERSION = 4;
 export const QUEUE_NAME = `google-queue-v${WORKFLOW_VERSION}`;
+export const GDRIVE_INCREMENTAL_SYNC_DEBOUNCE_SEC = 10;

--- a/connectors/src/connectors/google_drive/temporal/workflows.ts
+++ b/connectors/src/connectors/google_drive/temporal/workflows.ts
@@ -12,6 +12,7 @@ import type * as activities from "@connectors/connectors/google_drive/temporal/a
 import type * as sync_status from "@connectors/lib/sync_status";
 import { DataSourceConfig } from "@connectors/types/data_source_config";
 
+import { GDRIVE_INCREMENTAL_SYNC_DEBOUNCE_SEC } from "./config";
 import { newWebhookSignal } from "./signals";
 
 const {
@@ -110,7 +111,7 @@ export async function googleDriveIncrementalSync(
 ) {
   const maxPassCount = 2;
   const debounceMaxCount = 10;
-  const debounceSleepTimeMs = 10 * 1000;
+  const debounceSleepTimeMs = GDRIVE_INCREMENTAL_SYNC_DEBOUNCE_SEC * 1000;
   const secondPassSleepStepMs = 5 * 1000;
   const secondPassSleepTimeMs = 5 * 60 * 1000;
 

--- a/front/lib/api/assistant/pubsub.ts
+++ b/front/lib/api/assistant/pubsub.ts
@@ -66,8 +66,8 @@ export async function postUserMessageWithPubSub(
   if (
     (await rateLimiter({
       key: rateLimitKey,
-      maxPerTimeframe:1,
-      timeframeSeconds:120,
+      maxPerTimeframe,
+      timeframeSeconds,
       logger,
     })) === 0
   ) {

--- a/front/lib/api/assistant/pubsub.ts
+++ b/front/lib/api/assistant/pubsub.ts
@@ -22,10 +22,10 @@ import {
   UserMessageErrorEvent,
   UserMessageNewEvent,
 } from "@dust-tt/types";
+import { rateLimiter } from "@dust-tt/types";
 
 import { Authenticator } from "@app/lib/auth";
 import { AgentMessage, Message } from "@app/lib/models";
-import { rateLimiter } from "@app/lib/rate_limiter";
 import { redisClient } from "@app/lib/redis";
 import { wakeLock } from "@app/lib/wake_lock";
 import logger from "@app/logger/logger";
@@ -64,7 +64,12 @@ export async function postUserMessageWithPubSub(
   }
 
   if (
-    (await rateLimiter(rateLimitKey, maxPerTimeframe, timeframeSeconds)) === 0
+    (await rateLimiter({
+      key: rateLimitKey,
+      maxPerTimeframe:1,
+      timeframeSeconds:120,
+      logger,
+    })) === 0
   ) {
     return new Err({
       status_code: 429,

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -118,6 +118,7 @@
         "dts-cli": "^2.0.3",
         "eslint-plugin-simple-import-sort": "^10.0.0",
         "eventsource-parser": "^1.1.1",
+        "hot-shots": "^10.0.0",
         "io-ts": "^2.2.20",
         "redis": "^4.6.8",
         "uuid": "^9.0.1"

--- a/front/package.json
+++ b/front/package.json
@@ -120,6 +120,8 @@
   },
   "browser": {
     "net": false,
-    "tls": false
+    "tls": false,
+    "fs": false,
+    "dgram": false
   }
 }

--- a/types/package-lock.json
+++ b/types/package-lock.json
@@ -11,6 +11,7 @@
         "dts-cli": "^2.0.3",
         "eslint-plugin-simple-import-sort": "^10.0.0",
         "eventsource-parser": "^1.1.1",
+        "hot-shots": "^10.0.0",
         "io-ts": "^2.2.20",
         "redis": "^4.6.8",
         "uuid": "^9.0.1"
@@ -3330,6 +3331,15 @@
       ],
       "license": "MIT"
     },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "node_modules/bl": {
       "version": "4.1.0",
       "license": "MIT",
@@ -4879,6 +4889,12 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
+    },
     "node_modules/fill-range": {
       "version": "7.0.1",
       "license": "MIT",
@@ -5282,6 +5298,17 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hot-shots": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/hot-shots/-/hot-shots-10.0.0.tgz",
+      "integrity": "sha512-uy/uGpuJk7yuyiKRfZMBNkF1GAOX5O2ifO9rDCaX9jw8fu6eW9QeWC7WRPDI+O98frW1HQgV3+xwjWsZPECIzQ==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "optionalDependencies": {
+        "unix-dgram": "2.x"
       }
     },
     "node_modules/html-encoding-sniffer": {
@@ -6984,6 +7011,12 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "license": "MIT"
+    },
+    "node_modules/nan": {
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.18.0.tgz",
+      "integrity": "sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w==",
+      "optional": true
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -8797,6 +8830,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/unix-dgram": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/unix-dgram/-/unix-dgram-2.0.6.tgz",
+      "integrity": "sha512-AURroAsb73BZ6CdAyMrTk/hYKNj3DuYYEuOaB8bYMOHGKupRNScw90Q5C71tWJc3uE7dIeXRyuwN0xLLq3vDTg==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "nan": "^2.16.0"
+      },
+      "engines": {
+        "node": ">=0.10.48"
       }
     },
     "node_modules/update-browserslist-db": {

--- a/types/package.json
+++ b/types/package.json
@@ -29,12 +29,14 @@
     "dts-cli": "^2.0.3",
     "eslint-plugin-simple-import-sort": "^10.0.0",
     "eventsource-parser": "^1.1.1",
+    "hot-shots": "^10.0.0",
     "io-ts": "^2.2.20",
     "redis": "^4.6.8",
     "uuid": "^9.0.1"
   },
   "browser": {
     "tls": false,
-    "net": false
+    "net": false,
+    "hot-shots": false
   }
 }

--- a/types/src/index.ts
+++ b/types/src/index.ts
@@ -39,4 +39,5 @@ export * from "./front/run";
 export * from "./front/user";
 export * from "./shared/cache";
 export * from "./shared/model_id";
+export * from "./shared/rate_limiter";
 export * from "./shared/utils/assert_never";

--- a/types/src/shared/statsd.ts
+++ b/types/src/shared/statsd.ts
@@ -1,0 +1,10 @@
+import { StatsD } from "hot-shots";
+
+let statsDClient: StatsD | undefined = undefined;
+
+export function getStatsDClient(): StatsD {
+  if (!statsDClient) {
+    statsDClient = new StatsD();
+  }
+  return statsDClient;
+}


### PR DESCRIPTION
# What
With this PR, we use the rate limiter to limit the number of signals we send to the workflow, without ever missing a synchronization.

We also move the rateLimiter() function to `types/`.

# Why

When a user moves a folder with a lot of files on Gdrive, we receive a lot of webhooks, which we forward via a Temporal Signal to the `GoogleDriveIncrementalSyncWorkflow` (one signal per webhook). The workflow itself debounce its execution for 10 seconds, but each signal adds an entry in the workflow history, which leads to slow workflows.
