### PR TITLE
isDevelopmentOrDustWorkspace true for Dust-app

### DIFF
--- a/front/lib/development.ts
+++ b/front/lib/development.ts
@@ -1,10 +1,16 @@
 import { WorkspaceType } from "@dust-tt/types";
 
 const PRODUCTION_DUST_WORKSPACE_ID = "0ec9852c2f";
+const PRODUCTION_DUST_APPS_WORKSPACE_ID = "78bda07b39";
+
 export function isDevelopment() {
   return process.env.NODE_ENV === "development";
 }
 
 export function isDevelopmentOrDustWorkspace(owner: WorkspaceType) {
-  return isDevelopment() || owner.sId === PRODUCTION_DUST_WORKSPACE_ID;
+  return (
+    isDevelopment() ||
+    owner.sId === PRODUCTION_DUST_WORKSPACE_ID ||
+    owner.sId === PRODUCTION_DUST_APPS_WORKSPACE_ID
+  );
 }


### PR DESCRIPTION
Opening `isDevelopmentOrDustWorkspace` to our Dust-app workspace -> I need to have access to the database on Dust-apps.