### PR TITLE
Ahuna: new navigation

### DIFF
--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -1,4 +1,4 @@
-import { Button, ChatBubbleBottomCenterPlusIcon, ChatBubbleBottomCenterTextIcon, Item } from "@dust-tt/sparkle";
+import { Button, ChatBubbleBottomCenterPlusIcon, Item } from "@dust-tt/sparkle";
 import { WorkspaceType } from "@dust-tt/types";
 import { ConversationWithoutContentType } from "@dust-tt/types";
 import moment from "moment";

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -1,4 +1,4 @@
-import { Button, ChatBubbleBottomCenterTextIcon, Item } from "@dust-tt/sparkle";
+import { Button, ChatBubbleBottomCenterPlusIcon, ChatBubbleBottomCenterTextIcon, Item } from "@dust-tt/sparkle";
 import { WorkspaceType } from "@dust-tt/types";
 import { ConversationWithoutContentType } from "@dust-tt/types";
 import moment from "moment";
@@ -69,7 +69,7 @@ export function AssistantSidebarMenu({
     <div className="flex grow flex-col">
       <div className="flex h-0 min-h-full w-full overflow-y-auto">
         <div className="flex w-full flex-col pl-4 pr-2">
-          <div className="py-4 pr-2 text-right">
+          <div className="pb-4 pr-2 text-right">
             <Link
               href={`/w/${owner.sId}/assistant/new`}
               onClick={() => {
@@ -85,8 +85,8 @@ export function AssistantSidebarMenu({
             >
               <Button
                 labelVisible={true}
-                label="New Conversation"
-                icon={ChatBubbleBottomCenterTextIcon}
+                label="New"
+                icon={ChatBubbleBottomCenterPlusIcon}
                 className="flex-none shrink"
               />
             </Link>

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -1143,8 +1143,8 @@ export default function AssistantBuilder({
               show={builderState.actionMode === "RETRIEVAL_SEARCH"}
             >
               <div>
-                The assistant will perform a search on the selected data source,
-                run the instructions on the results.{" "}
+                The assistant will perform a search on the selected data
+                sources, and run the instructions on the results.{" "}
                 <span className="font-semibold">
                   It’s the best approach with large quantities of data.
                 </span>

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -54,7 +54,7 @@ import {
   AppLayoutSimpleCloseTitle,
   AppLayoutSimpleSaveCancelTitle,
 } from "@app/components/sparkle/AppLayoutTitle";
-import { subNavigationAdmin } from "@app/components/sparkle/navigation";
+import { subNavigationAssistants } from "@app/components/sparkle/navigation";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { getSupportedModelConfig } from "@app/lib/assistant";
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
@@ -770,10 +770,10 @@ export default function AssistantBuilder({
         user={user}
         owner={owner}
         gaTrackingId={gaTrackingId}
-        topNavigationCurrent="admin"
-        subNavigation={subNavigationAdmin({
+        topNavigationCurrent="assistants"
+        subNavigation={subNavigationAssistants({
           owner,
-          current: "assistants",
+          current: "workspace_assistants",
         })}
         titleChildren={
           !edited ? (

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -770,7 +770,7 @@ export default function AssistantBuilder({
         user={user}
         owner={owner}
         gaTrackingId={gaTrackingId}
-        topNavigationCurrent="settings"
+        topNavigationCurrent="admin"
         subNavigation={subNavigationAdmin({
           owner,
           current: "assistants",

--- a/front/components/sparkle/navigation.tsx
+++ b/front/components/sparkle/navigation.tsx
@@ -8,7 +8,6 @@ import {
   FolderOpenIcon,
   PaperAirplaneIcon,
   PlanetIcon,
-  RobotIcon,
   RobotSharedIcon,
   ServerIcon,
   ShapesIcon,

--- a/front/components/sparkle/navigation.tsx
+++ b/front/components/sparkle/navigation.tsx
@@ -116,9 +116,13 @@ export const topNavigation = ({
 };
 
 export const subNavigationConversations = ({
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   owner,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   current,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   subMenuLabel,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   subMenu,
 }: {
   owner: WorkspaceType;
@@ -128,23 +132,25 @@ export const subNavigationConversations = ({
 }) => {
   const nav: SidebarNavigation[] = [];
 
-  nav.push({
-    id: "assistants",
-    label: null,
-    variant: "secondary",
-    menus: [
-      {
-        id: "personal_assistants",
-        label: "My Assistants",
-        icon: RobotIcon,
-        href: `/w/${owner.sId}/builder/assistants`,
-        current: current === "personal_assistants",
-        subMenuLabel:
-          current === "personal_assistants" ? subMenuLabel : undefined,
-        subMenu: current === "personal_assistants" ? subMenu : undefined,
-      },
-    ],
-  });
+  // To be added for personal assistants view.
+
+  // nav.push({
+  //   id: "assistants",
+  //   label: null,
+  //   variant: "secondary",
+  //   menus: [
+  //     {
+  //       id: "personal_assistants",
+  //       label: "My Assistants",
+  //       icon: RobotIcon,
+  //       href: `/w/${owner.sId}/builder/assistants`,
+  //       current: current === "personal_assistants",
+  //       subMenuLabel:
+  //         current === "personal_assistants" ? subMenuLabel : undefined,
+  //       subMenu: current === "personal_assistants" ? subMenu : undefined,
+  //     },
+  //   ],
+  // });
 
   return nav;
 };

--- a/front/components/sparkle/navigation.tsx
+++ b/front/components/sparkle/navigation.tsx
@@ -4,12 +4,12 @@ import {
   CloudArrowLeftRightIcon,
   Cog6ToothIcon,
   CommandLineIcon,
-  DocumentPileIcon,
   DocumentTextIcon,
   FolderOpenIcon,
   PaperAirplaneIcon,
   PlanetIcon,
   RobotIcon,
+  RobotSharedIcon,
   ServerIcon,
   ShapesIcon,
 } from "@dust-tt/sparkle";
@@ -24,7 +24,7 @@ import { isDevelopmentOrDustWorkspace } from "@app/lib/development";
  * ones for the topNavigation (same across the whole app) and for the subNavigation which appears in
  * some section of the app in the AppLayout navigation panel.
  */
-export type TopNavigationId = "assistant" | "settings";
+export type TopNavigationId = "conversations" | "assistants" | "admin";
 
 export type SubNavigationAdminId =
   | "data_sources_managed"
@@ -33,7 +33,8 @@ export type SubNavigationAdminId =
   | "workspace"
   | "members"
   | "developers"
-  | "assistants"
+  | "workspace_assistants"
+  | "personal_assistants"
   | "extract"
   | "databases";
 export type SubNavigationDataSourceId = "documents" | "search" | "settings";
@@ -44,6 +45,7 @@ export type SubNavigationAppId =
   | "runs"
   | "settings";
 export type SubNavigationLabId = "extract" | "databases";
+
 export type SparkleAppLayoutNavigation = {
   id:
     | TopNavigationId
@@ -62,7 +64,7 @@ export type SparkleAppLayoutNavigation = {
 };
 
 export type SidebarNavigation = {
-  id: "conversation" | "workspace" | "developers" | "lab";
+  id: "assistants" | "data_sources" | "workspace" | "developers" | "lab";
   label: string | null;
   variant: "primary" | "secondary";
   menus: SparkleAppLayoutNavigation[];
@@ -78,23 +80,133 @@ export const topNavigation = ({
   const nav: SparkleAppLayoutNavigation[] = [];
 
   nav.push({
-    id: "assistant",
+    id: "conversations",
     label: "Conversations",
     href: `/w/${owner.sId}/assistant/new`,
     icon: ChatBubbleLeftRightIcon,
-    sizing: "hug",
-    current: current === "assistant",
+    sizing: "expand",
+    current: current === "conversations",
   });
 
   if (owner.role === "admin" || owner.role === "builder") {
     nav.push({
+      id: "assistants",
+      label: "Assistants",
+      hideLabel: true,
+      icon: RobotSharedIcon,
+      href: `/w/${owner.sId}/builder/assistants`,
+      current: current === "assistants",
+      sizing: "hug",
+    });
+    nav.push({
       id: "settings",
       label: "Admin",
+      hideLabel: true,
       icon: Cog6ToothIcon,
-      href: `/w/${owner.sId}/builder/assistants`,
-      current: current === "settings",
+      href:
+        owner.role === "admin"
+          ? `/w/${owner.sId}/workspace`
+          : `/w/${owner.sId}/a`,
+      current: current === "admin",
+      sizing: "hug",
     });
   }
+
+  return nav;
+};
+
+export const subNavigationConversations = ({
+  owner,
+  current,
+  subMenuLabel,
+  subMenu,
+}: {
+  owner: WorkspaceType;
+  current: SubNavigationAdminId;
+  subMenuLabel?: string;
+  subMenu?: SparkleAppLayoutNavigation[];
+}) => {
+  const nav: SidebarNavigation[] = [];
+
+  nav.push({
+    id: "assistants",
+    label: null,
+    variant: "secondary",
+    menus: [
+      {
+        id: "personal_assistants",
+        label: "My Assistants",
+        icon: RobotIcon,
+        href: `/w/${owner.sId}/builder/assistants`,
+        current: current === "personal_assistants",
+        subMenuLabel:
+          current === "personal_assistants" ? subMenuLabel : undefined,
+        subMenu: current === "personal_assistants" ? subMenu : undefined,
+      },
+    ],
+  });
+
+  return nav;
+};
+
+export const subNavigationAssistants = ({
+  owner,
+  current,
+  subMenuLabel,
+  subMenu,
+}: {
+  owner: WorkspaceType;
+  current: SubNavigationAdminId;
+  subMenuLabel?: string;
+  subMenu?: SparkleAppLayoutNavigation[];
+}) => {
+  const nav: SidebarNavigation[] = [];
+
+  nav.push({
+    id: "assistants",
+    label: null,
+    variant: "secondary",
+    menus: [
+      {
+        id: "workspace_assistants",
+        label: "Workspace Assistants",
+        icon: RobotSharedIcon,
+        href: `/w/${owner.sId}/builder/assistants`,
+        current: current === "workspace_assistants",
+        subMenuLabel:
+          current === "workspace_assistants" ? subMenuLabel : undefined,
+        subMenu: current === "workspace_assistants" ? subMenu : undefined,
+      },
+    ],
+  });
+
+  nav.push({
+    id: "data_sources",
+    label: "Data Sources",
+    variant: "secondary",
+    menus: [
+      {
+        id: "data_sources_managed",
+        label: "Connections",
+        icon: CloudArrowLeftRightIcon,
+        href: `/w/${owner.sId}/builder/data-sources/managed`,
+        current: current === "data_sources_managed",
+        subMenuLabel:
+          current === "data_sources_managed" ? subMenuLabel : undefined,
+        subMenu: current === "data_sources_managed" ? subMenu : undefined,
+      },
+      {
+        id: "data_sources_static",
+        label: "Folders",
+        icon: FolderOpenIcon,
+        href: `/w/${owner.sId}/builder/data-sources/static`,
+        current: current === "data_sources_static",
+        subMenuLabel:
+          current === "data_sources_static" ? subMenuLabel : undefined,
+        subMenu: current === "data_sources_static" ? subMenu : undefined,
+      },
+    ],
+  });
 
   return nav;
 };
@@ -116,58 +228,12 @@ export const subNavigationAdmin = ({
     return nav;
   }
 
-  nav.push({
-    id: "conversation",
-    label: null,
-    variant: "secondary",
-    menus: [
-      {
-        id: "assistants",
-        label: "Assistants",
-        icon: RobotIcon,
-        href: `/w/${owner.sId}/builder/assistants`,
-        current: current === "assistants",
-        subMenuLabel: current === "assistants" ? subMenuLabel : undefined,
-        subMenu: current === "assistants" ? subMenu : undefined,
-      },
-      {
-        id: "data_sources_managed",
-        label: "Connections",
-        icon: CloudArrowLeftRightIcon,
-        href: `/w/${owner.sId}/builder/data-sources/managed`,
-        current: current === "data_sources_managed",
-        subMenuLabel:
-          current === "data_sources_managed" ? subMenuLabel : undefined,
-        subMenu: current === "data_sources_managed" ? subMenu : undefined,
-      },
-      {
-        id: "data_sources_static",
-        label: "Data Sources",
-        icon: DocumentPileIcon,
-        href: `/w/${owner.sId}/builder/data-sources/static`,
-        current: current === "data_sources_static",
-        subMenuLabel:
-          current === "data_sources_static" ? subMenuLabel : undefined,
-        subMenu: current === "data_sources_static" ? subMenu : undefined,
-      },
-    ],
-  });
-
   if (owner.role === "admin") {
     nav.push({
       id: "workspace",
-      label: "Settings",
+      label: null,
       variant: "secondary",
       menus: [
-        {
-          id: "subscription",
-          label: "Subscription",
-          icon: ShapesIcon,
-          href: `/w/${owner.sId}/subscription`,
-          current: current === "subscription",
-          subMenuLabel: current === "subscription" ? subMenuLabel : undefined,
-          subMenu: current === "subscription" ? subMenu : undefined,
-        },
         {
           id: "workspace",
           label: "Workspace",
@@ -176,6 +242,15 @@ export const subNavigationAdmin = ({
           current: current === "workspace",
           subMenuLabel: current === "workspace" ? subMenuLabel : undefined,
           subMenu: current === "workspace" ? subMenu : undefined,
+        },
+        {
+          id: "subscription",
+          label: "Subscription",
+          icon: ShapesIcon,
+          href: `/w/${owner.sId}/subscription`,
+          current: current === "subscription",
+          subMenuLabel: current === "subscription" ? subMenuLabel : undefined,
+          subMenu: current === "subscription" ? subMenu : undefined,
         },
         {
           id: "members",
@@ -192,12 +267,12 @@ export const subNavigationAdmin = ({
 
   nav.push({
     id: "developers",
-    label: "Developers",
+    label: owner.role === "admin" ? "Developers" : null,
     variant: "secondary",
     menus: [
       {
         id: "developers",
-        label: "Tools",
+        label: "Developer Tools",
         icon: CommandLineIcon,
         href: `/w/${owner.sId}/a`,
         current: current === "developers",

--- a/front/pages/w/[wId]/a/[aId]/clone.tsx
+++ b/front/pages/w/[wId]/a/[aId]/clone.tsx
@@ -140,7 +140,7 @@ export default function CloneView({
       user={user}
       owner={owner}
       gaTrackingId={gaTrackingId}
-      topNavigationCurrent="settings"
+      topNavigationCurrent="admin"
       subNavigation={subNavigationAdmin({
         owner,
         current: "developers",

--- a/front/pages/w/[wId]/a/[aId]/datasets/[name]/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/datasets/[name]/index.tsx
@@ -176,7 +176,7 @@ export default function ViewDatasetView({
       user={user}
       owner={owner}
       gaTrackingId={gaTrackingId}
-      topNavigationCurrent="settings"
+      topNavigationCurrent="admin"
       subNavigation={subNavigationAdmin({
         owner,
         current: "developers",

--- a/front/pages/w/[wId]/a/[aId]/datasets/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/datasets/index.tsx
@@ -101,7 +101,7 @@ export default function DatasetsView({
       user={user}
       owner={owner}
       gaTrackingId={gaTrackingId}
-      topNavigationCurrent="settings"
+      topNavigationCurrent="admin"
       subNavigation={subNavigationAdmin({
         owner,
         current: "developers",

--- a/front/pages/w/[wId]/a/[aId]/datasets/new.tsx
+++ b/front/pages/w/[wId]/a/[aId]/datasets/new.tsx
@@ -138,7 +138,7 @@ export default function NewDatasetView({
       user={user}
       owner={owner}
       gaTrackingId={gaTrackingId}
-      topNavigationCurrent="settings"
+      topNavigationCurrent="admin"
       subNavigation={subNavigationAdmin({
         owner,
         current: "developers",

--- a/front/pages/w/[wId]/a/[aId]/execute/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/execute/index.tsx
@@ -575,7 +575,7 @@ export default function ExecuteView({
       user={user}
       owner={owner}
       gaTrackingId={gaTrackingId}
-      topNavigationCurrent="settings"
+      topNavigationCurrent="admin"
       subNavigation={subNavigationAdmin({
         owner,
         current: "developers",

--- a/front/pages/w/[wId]/a/[aId]/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/index.tsx
@@ -316,7 +316,7 @@ export default function AppView({
       user={user}
       owner={owner}
       gaTrackingId={gaTrackingId}
-      topNavigationCurrent="settings"
+      topNavigationCurrent="admin"
       subNavigation={subNavigationAdmin({
         owner,
         current: "developers",

--- a/front/pages/w/[wId]/a/[aId]/runs/[runId]/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/runs/[runId]/index.tsx
@@ -148,7 +148,7 @@ export default function AppRun({
       user={user}
       owner={owner}
       gaTrackingId={gaTrackingId}
-      topNavigationCurrent="settings"
+      topNavigationCurrent="admin"
       subNavigation={subNavigationAdmin({
         owner,
         current: "developers",

--- a/front/pages/w/[wId]/a/[aId]/runs/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/runs/index.tsx
@@ -135,7 +135,7 @@ export default function RunsView({
       user={user}
       owner={owner}
       gaTrackingId={gaTrackingId}
-      topNavigationCurrent="settings"
+      topNavigationCurrent="admin"
       subNavigation={subNavigationAdmin({
         owner,
         current: "developers",

--- a/front/pages/w/[wId]/a/[aId]/settings.tsx
+++ b/front/pages/w/[wId]/a/[aId]/settings.tsx
@@ -164,7 +164,7 @@ export default function SettingsView({
       user={user}
       owner={owner}
       gaTrackingId={gaTrackingId}
-      topNavigationCurrent="settings"
+      topNavigationCurrent="admin"
       subNavigation={subNavigationAdmin({
         owner,
         current: "developers",

--- a/front/pages/w/[wId]/a/[aId]/specification.tsx
+++ b/front/pages/w/[wId]/a/[aId]/specification.tsx
@@ -102,7 +102,7 @@ export default function Specification({
       user={user}
       owner={owner}
       gaTrackingId={gaTrackingId}
-      topNavigationCurrent="settings"
+      topNavigationCurrent="admin"
       subNavigation={subNavigationAdmin({
         owner,
         current: "developers",

--- a/front/pages/w/[wId]/a/index.tsx
+++ b/front/pages/w/[wId]/a/index.tsx
@@ -461,7 +461,7 @@ export default function Developers({
       user={user}
       owner={owner}
       gaTrackingId={gaTrackingId}
-      topNavigationCurrent="settings"
+      topNavigationCurrent="admin"
       subNavigation={subNavigationAdmin({ owner, current: "developers" })}
     >
       <Page.Vertical gap="xl" align="stretch">

--- a/front/pages/w/[wId]/a/new.tsx
+++ b/front/pages/w/[wId]/a/new.tsx
@@ -112,7 +112,7 @@ export default function NewApp({
       user={user}
       owner={owner}
       gaTrackingId={gaTrackingId}
-      topNavigationCurrent="settings"
+      topNavigationCurrent="admin"
       subNavigation={subNavigationAdmin({ owner, current: "developers" })}
     >
       <div className="flex flex-col">

--- a/front/pages/w/[wId]/assistant/[cId]/index.tsx
+++ b/front/pages/w/[wId]/assistant/[cId]/index.tsx
@@ -195,7 +195,7 @@ export default function AssistantConversation({
             : `Dust - New Conversation`
         }
         gaTrackingId={gaTrackingId}
-        topNavigationCurrent="assistant"
+        topNavigationCurrent="conversations"
         titleChildren={
           conversation && (
             <ConversationTitle

--- a/front/pages/w/[wId]/assistant/new.tsx
+++ b/front/pages/w/[wId]/assistant/new.tsx
@@ -39,6 +39,7 @@ import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { useAgentConfigurations } from "@app/lib/swr";
 import type { PostConversationsResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations";
+import {subNavigationConversations} from "@app/components/sparkle/navigation";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
@@ -202,7 +203,11 @@ export default function AssistantNew({
           isWideMode={conversation ? true : false}
           pageTitle={"Dust - New Conversation"}
           gaTrackingId={gaTrackingId}
-          topNavigationCurrent="assistant"
+          topNavigationCurrent="conversations"
+          subNavigation={subNavigationConversations({
+            owner,
+            current: "data_sources_managed",
+          })}
           navChildren={
             <AssistantSidebarMenu
               owner={owner}

--- a/front/pages/w/[wId]/assistant/new.tsx
+++ b/front/pages/w/[wId]/assistant/new.tsx
@@ -33,13 +33,13 @@ import {
 } from "@app/components/assistant/conversation/InputBar";
 import { AssistantSidebarMenu } from "@app/components/assistant/conversation/SidebarMenu";
 import AppLayout from "@app/components/sparkle/AppLayout";
+import { subNavigationConversations } from "@app/components/sparkle/navigation";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { compareAgentsForSort } from "@app/lib/assistant";
 import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { useAgentConfigurations } from "@app/lib/swr";
 import type { PostConversationsResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations";
-import {subNavigationConversations} from "@app/components/sparkle/navigation";
 
 const { GA_TRACKING_ID = "" } = process.env;
 

--- a/front/pages/w/[wId]/builder/assistants/dust.tsx
+++ b/front/pages/w/[wId]/builder/assistants/dust.tsx
@@ -18,7 +18,7 @@ import { useContext } from "react";
 
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
-import { subNavigationAdmin } from "@app/components/sparkle/navigation";
+import { subNavigationAssistants } from "@app/components/sparkle/navigation";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
@@ -158,8 +158,8 @@ export default function EditDustAssistant({
       user={user}
       owner={owner}
       gaTrackingId={gaTrackingId}
-      topNavigationCurrent="admin"
-      subNavigation={subNavigationAdmin({ owner, current: "assistants" })}
+      topNavigationCurrent="assistants"
+      subNavigation={subNavigationAssistants({ owner, current: "workspace_assistants" })}
       titleChildren={
         <AppLayoutSimpleCloseTitle
           title="Manage Dust Assistant"

--- a/front/pages/w/[wId]/builder/assistants/dust.tsx
+++ b/front/pages/w/[wId]/builder/assistants/dust.tsx
@@ -159,7 +159,10 @@ export default function EditDustAssistant({
       owner={owner}
       gaTrackingId={gaTrackingId}
       topNavigationCurrent="assistants"
-      subNavigation={subNavigationAssistants({ owner, current: "workspace_assistants" })}
+      subNavigation={subNavigationAssistants({
+        owner,
+        current: "workspace_assistants",
+      })}
       titleChildren={
         <AppLayoutSimpleCloseTitle
           title="Manage Dust Assistant"

--- a/front/pages/w/[wId]/builder/assistants/dust.tsx
+++ b/front/pages/w/[wId]/builder/assistants/dust.tsx
@@ -158,7 +158,7 @@ export default function EditDustAssistant({
       user={user}
       owner={owner}
       gaTrackingId={gaTrackingId}
-      topNavigationCurrent="settings"
+      topNavigationCurrent="admin"
       subNavigation={subNavigationAdmin({ owner, current: "assistants" })}
       titleChildren={
         <AppLayoutSimpleCloseTitle

--- a/front/pages/w/[wId]/builder/assistants/gallery.tsx
+++ b/front/pages/w/[wId]/builder/assistants/gallery.tsx
@@ -22,7 +22,7 @@ import { useContext, useState } from "react";
 import { AssistantDetails } from "@app/components/assistant/AssistantDetails";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
-import { subNavigationAdmin } from "@app/components/sparkle/navigation";
+import { subNavigationAdmin, subNavigationAssistants, subNavigationConversations } from "@app/components/sparkle/navigation";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
 import { useAgentConfigurations } from "@app/lib/swr";
@@ -246,7 +246,7 @@ export default function AssistantsGallery({
       hideSidebar
       gaTrackingId={gaTrackingId}
       topNavigationCurrent="admin"
-      subNavigation={subNavigationAdmin({ owner, current: "assistants" })}
+      subNavigation={subNavigationConversations({ owner, current: "personal_assistants" })}
       titleChildren={
         <AppLayoutSimpleCloseTitle
           title="Assistant Gallery"

--- a/front/pages/w/[wId]/builder/assistants/gallery.tsx
+++ b/front/pages/w/[wId]/builder/assistants/gallery.tsx
@@ -245,7 +245,7 @@ export default function AssistantsGallery({
       owner={owner}
       hideSidebar
       gaTrackingId={gaTrackingId}
-      topNavigationCurrent="settings"
+      topNavigationCurrent="admin"
       subNavigation={subNavigationAdmin({ owner, current: "assistants" })}
       titleChildren={
         <AppLayoutSimpleCloseTitle

--- a/front/pages/w/[wId]/builder/assistants/gallery.tsx
+++ b/front/pages/w/[wId]/builder/assistants/gallery.tsx
@@ -22,7 +22,7 @@ import { useContext, useState } from "react";
 import { AssistantDetails } from "@app/components/assistant/AssistantDetails";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
-import { subNavigationAdmin, subNavigationAssistants, subNavigationConversations } from "@app/components/sparkle/navigation";
+import { subNavigationConversations } from "@app/components/sparkle/navigation";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
 import { useAgentConfigurations } from "@app/lib/swr";
@@ -246,7 +246,10 @@ export default function AssistantsGallery({
       hideSidebar
       gaTrackingId={gaTrackingId}
       topNavigationCurrent="admin"
-      subNavigation={subNavigationConversations({ owner, current: "personal_assistants" })}
+      subNavigation={subNavigationConversations({
+        owner,
+        current: "personal_assistants",
+      })}
       titleChildren={
         <AppLayoutSimpleCloseTitle
           title="Assistant Gallery"

--- a/front/pages/w/[wId]/builder/assistants/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/index.tsx
@@ -19,7 +19,7 @@ import { useRouter } from "next/router";
 import { useState } from "react";
 
 import AppLayout from "@app/components/sparkle/AppLayout";
-import { subNavigationAdmin } from "@app/components/sparkle/navigation";
+import { subNavigationAssistants } from "@app/components/sparkle/navigation";
 import { compareAgentsForSort } from "@app/lib/assistant";
 import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
 import { useAgentConfigurations } from "@app/lib/swr";
@@ -122,8 +122,11 @@ export default function AssistantsBuilder({
       user={user}
       owner={owner}
       gaTrackingId={gaTrackingId}
-      topNavigationCurrent="settings"
-      subNavigation={subNavigationAdmin({ owner, current: "assistants" })}
+      topNavigationCurrent="assistants"
+      subNavigation={subNavigationAssistants({
+        owner,
+        current: "workspace_assistants",
+      })}
     >
       <Page.Vertical gap="xl" align="stretch">
         <Page.Header

--- a/front/pages/w/[wId]/builder/assistants/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/index.tsx
@@ -130,7 +130,7 @@ export default function AssistantsBuilder({
     >
       <Page.Vertical gap="xl" align="stretch">
         <Page.Header
-          title="Assistants"
+          title="Workspace Assistants"
           icon={RobotIcon}
           description="Create, manage and deploy Assistants to your collaborators."
         />

--- a/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
@@ -193,7 +193,7 @@ function StandardDataSourceView({
     <div className="pt-6">
       <Page.Vertical align="stretch">
         <Page.SectionHeader
-          title={`Data Source ${dataSource.name}`}
+          title={`Folder ${dataSource.name}`}
           description="Use this page to view and upload documents to your data source."
           action={
             readOnly
@@ -760,7 +760,7 @@ export default function DataSourceView({
       user={user}
       owner={owner}
       gaTrackingId={gaTrackingId}
-      topNavigationCurrent="settings"
+      topNavigationCurrent="assistants"
       subNavigation={subNavigationAdmin({
         owner,
         current: dataSource.connectorId
@@ -769,7 +769,7 @@ export default function DataSourceView({
       })}
       titleChildren={
         <AppLayoutSimpleCloseTitle
-          title={`Manage Data Source`}
+          title={`Manage ${dataSource.connectorId ? "Connection" : "Folder"}`}
           onClose={() => {
             if (dataSource.connectorId) {
               void router.push(`/w/${owner.sId}/builder/data-sources/managed`);

--- a/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
@@ -36,7 +36,7 @@ import ConnectorPermissionsModal from "@app/components/ConnectorPermissionsModal
 import { PermissionTree } from "@app/components/ConnectorPermissionsTree";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
-import { subNavigationAdmin } from "@app/components/sparkle/navigation";
+import { subNavigationAssistants } from "@app/components/sparkle/navigation";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { getDataSource } from "@app/lib/api/data_sources";
 import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
@@ -761,7 +761,7 @@ export default function DataSourceView({
       owner={owner}
       gaTrackingId={gaTrackingId}
       topNavigationCurrent="assistants"
-      subNavigation={subNavigationAdmin({
+      subNavigation={subNavigationAssistants({
         owner,
         current: dataSource.connectorId
           ? "data_sources_managed"

--- a/front/pages/w/[wId]/builder/data-sources/[name]/search.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/search.tsx
@@ -150,7 +150,7 @@ export default function DataSourceView({
       user={user}
       owner={owner}
       gaTrackingId={gaTrackingId}
-      topNavigationCurrent="settings"
+      topNavigationCurrent="admin"
       subNavigation={subNavigationAdmin({
         owner,
         current: dataSource.connectorId

--- a/front/pages/w/[wId]/builder/data-sources/[name]/search.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/search.tsx
@@ -8,7 +8,7 @@ import { useEffect, useState } from "react";
 
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
-import { subNavigationAdmin } from "@app/components/sparkle/navigation";
+import { subNavigationAssistants } from "@app/components/sparkle/navigation";
 import { getDataSource } from "@app/lib/api/data_sources";
 import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
 import {
@@ -150,8 +150,8 @@ export default function DataSourceView({
       user={user}
       owner={owner}
       gaTrackingId={gaTrackingId}
-      topNavigationCurrent="admin"
-      subNavigation={subNavigationAdmin({
+      topNavigationCurrent="assistants"
+      subNavigation={subNavigationAssistants({
         owner,
         current: dataSource.connectorId
           ? "data_sources_managed"

--- a/front/pages/w/[wId]/builder/data-sources/[name]/settings.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/settings.tsx
@@ -192,7 +192,7 @@ function StandardDataSourceSettings({
       user={user}
       owner={owner}
       gaTrackingId={gaTrackingId}
-      topNavigationCurrent="settings"
+      topNavigationCurrent="admin"
       subNavigation={subNavigationAdmin({
         owner,
         current: "data_sources_static",

--- a/front/pages/w/[wId]/builder/data-sources/[name]/settings.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/settings.tsx
@@ -15,7 +15,7 @@ import { useSWRConfig } from "swr";
 
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleSaveCancelTitle } from "@app/components/sparkle/AppLayoutTitle";
-import { subNavigationAdmin } from "@app/components/sparkle/navigation";
+import { subNavigationAssistants } from "@app/components/sparkle/navigation";
 import { getDataSource } from "@app/lib/api/data_sources";
 import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
 import { classNames } from "@app/lib/utils";
@@ -192,8 +192,8 @@ function StandardDataSourceSettings({
       user={user}
       owner={owner}
       gaTrackingId={gaTrackingId}
-      topNavigationCurrent="admin"
-      subNavigation={subNavigationAdmin({
+      topNavigationCurrent="assistants"
+      subNavigation={subNavigationAssistants({
         owner,
         current: "data_sources_static",
       })}

--- a/front/pages/w/[wId]/builder/data-sources/[name]/upsert.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/upsert.tsx
@@ -25,7 +25,7 @@ import { PlanType, SubscriptionType } from "@dust-tt/types";
 
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleSaveCancelTitle } from "@app/components/sparkle/AppLayoutTitle";
-import { subNavigationAdmin } from "@app/components/sparkle/navigation";
+import { subNavigationAssistants } from "@app/components/sparkle/navigation";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { getDataSource } from "@app/lib/api/data_sources";
 import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
@@ -235,8 +235,8 @@ export default function DataSourceUpsert({
       user={user}
       owner={owner}
       gaTrackingId={gaTrackingId}
-      topNavigationCurrent="admin"
-      subNavigation={subNavigationAdmin({
+      topNavigationCurrent="assistants"
+      subNavigation={subNavigationAssistants({
         owner,
         current: "data_sources_static",
       })}

--- a/front/pages/w/[wId]/builder/data-sources/[name]/upsert.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/upsert.tsx
@@ -235,7 +235,7 @@ export default function DataSourceUpsert({
       user={user}
       owner={owner}
       gaTrackingId={gaTrackingId}
-      topNavigationCurrent="settings"
+      topNavigationCurrent="admin"
       subNavigation={subNavigationAdmin({
         owner,
         current: "data_sources_static",

--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -29,7 +29,7 @@ import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 
 import AppLayout from "@app/components/sparkle/AppLayout";
-import { subNavigationAdmin } from "@app/components/sparkle/navigation";
+import { subNavigationAssistants } from "@app/components/sparkle/navigation";
 import { getDataSources } from "@app/lib/api/data_sources";
 import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
 import { buildConnectionId } from "@app/lib/connector_connection_id";
@@ -357,8 +357,8 @@ export default function DataSourcesView({
       user={user}
       owner={owner}
       gaTrackingId={gaTrackingId}
-      topNavigationCurrent="settings"
-      subNavigation={subNavigationAdmin({
+      topNavigationCurrent="assistants"
+      subNavigation={subNavigationAssistants({
         owner,
         current: "data_sources_managed",
       })}

--- a/front/pages/w/[wId]/builder/data-sources/new.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/new.tsx
@@ -9,7 +9,7 @@ import { useCallback, useEffect, useState } from "react";
 
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleSaveCancelTitle } from "@app/components/sparkle/AppLayoutTitle";
-import { subNavigationAdmin } from "@app/components/sparkle/navigation";
+import { subNavigationAssistants } from "@app/components/sparkle/navigation";
 import { getDataSources } from "@app/lib/api/data_sources";
 import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
 import { classNames } from "@app/lib/utils";
@@ -159,8 +159,8 @@ export default function DataSourceNew({
       user={user}
       owner={owner}
       gaTrackingId={gaTrackingId}
-      topNavigationCurrent="admin"
-      subNavigation={subNavigationAdmin({
+      topNavigationCurrent="assistants"
+      subNavigation={subNavigationAssistants({
         owner,
         current: "data_sources_static",
       })}

--- a/front/pages/w/[wId]/builder/data-sources/new.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/new.tsx
@@ -159,7 +159,7 @@ export default function DataSourceNew({
       user={user}
       owner={owner}
       gaTrackingId={gaTrackingId}
-      topNavigationCurrent="settings"
+      topNavigationCurrent="admin"
       subNavigation={subNavigationAdmin({
         owner,
         current: "data_sources_static",

--- a/front/pages/w/[wId]/builder/data-sources/static.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/static.tsx
@@ -118,7 +118,7 @@ export default function DataSourcesView({
         <Page.Header
           title="Folders"
           icon={DocumentPileIcon}
-          description="Make more documents accessible to this workspace. Manage folder data sources manually or via API."
+          description="Make more documents accessible to this workspace. Manage folders manually or via API."
         />
 
         {dataSources.length > 0 ? (

--- a/front/pages/w/[wId]/builder/data-sources/static.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/static.tsx
@@ -16,7 +16,7 @@ import { useRouter } from "next/router";
 import { useState } from "react";
 
 import AppLayout from "@app/components/sparkle/AppLayout";
-import { subNavigationAdmin, subNavigationAssistants } from "@app/components/sparkle/navigation";
+import { subNavigationAssistants } from "@app/components/sparkle/navigation";
 import { getDataSources } from "@app/lib/api/data_sources";
 import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
 import { useSubmitFunction } from "@app/lib/client/utils";

--- a/front/pages/w/[wId]/builder/data-sources/static.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/static.tsx
@@ -16,7 +16,7 @@ import { useRouter } from "next/router";
 import { useState } from "react";
 
 import AppLayout from "@app/components/sparkle/AppLayout";
-import { subNavigationAdmin } from "@app/components/sparkle/navigation";
+import { subNavigationAdmin, subNavigationAssistants } from "@app/components/sparkle/navigation";
 import { getDataSources } from "@app/lib/api/data_sources";
 import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
 import { useSubmitFunction } from "@app/lib/client/utils";
@@ -108,17 +108,17 @@ export default function DataSourcesView({
       user={user}
       owner={owner}
       gaTrackingId={gaTrackingId}
-      topNavigationCurrent="settings"
-      subNavigation={subNavigationAdmin({
+      topNavigationCurrent="assistants"
+      subNavigation={subNavigationAssistants({
         owner,
         current: "data_sources_static",
       })}
     >
       <Page.Vertical gap="xl" align="stretch">
         <Page.Header
-          title="Data Sources"
+          title="Folders"
           icon={DocumentPileIcon}
-          description="Make more documents accessible to this workspace. Manage data sources manually or via API."
+          description="Make more documents accessible to this workspace. Manage folder data sources manually or via API."
         />
 
         {dataSources.length > 0 ? (
@@ -129,7 +129,7 @@ export default function DataSourcesView({
               action={
                 !readOnly
                   ? {
-                      label: "Add a new data source",
+                      label: "Add a new Folder",
                       variant: "primary",
                       icon: PlusIcon,
                       onClick: async () => {

--- a/front/pages/w/[wId]/databases/index.tsx
+++ b/front/pages/w/[wId]/databases/index.tsx
@@ -120,7 +120,7 @@ export default function AppDatabases({
       user={user}
       owner={owner}
       gaTrackingId={gaTrackingId}
-      topNavigationCurrent="settings"
+      topNavigationCurrent="admin"
       subNavigation={subNavigationAdmin({ owner, current: "databases" })}
     >
       <DatabaseModal

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -89,7 +89,7 @@ export default function WorkspaceAdmin({
       user={user}
       owner={owner}
       gaTrackingId={gaTrackingId}
-      topNavigationCurrent="settings"
+      topNavigationCurrent="admin"
       subNavigation={subNavigationAdmin({ owner, current: "members" })}
     >
       <Page.Vertical gap="xl" align="stretch">

--- a/front/pages/w/[wId]/subscription/index.tsx
+++ b/front/pages/w/[wId]/subscription/index.tsx
@@ -184,7 +184,7 @@ export default function Subscription({
       user={user}
       owner={owner}
       gaTrackingId={gaTrackingId}
-      topNavigationCurrent="settings"
+      topNavigationCurrent="admin"
       subNavigation={subNavigationAdmin({ owner, current: "subscription" })}
     >
       <Page.Vertical gap="xl" align="stretch">

--- a/front/pages/w/[wId]/u/extract/events/[sId]/edit.tsx
+++ b/front/pages/w/[wId]/u/extract/events/[sId]/edit.tsx
@@ -90,7 +90,7 @@ export default function AppExtractEventsCreate({
       user={user}
       owner={owner}
       gaTrackingId={gaTrackingId}
-      topNavigationCurrent="settings"
+      topNavigationCurrent="admin"
       subNavigation={subNavigationAdmin({ owner, current: "extract" })}
     >
       <Page.Header

--- a/front/pages/w/[wId]/u/extract/index.tsx
+++ b/front/pages/w/[wId]/u/extract/index.tsx
@@ -64,7 +64,7 @@ export default function AppExtractEvents({
       user={user}
       owner={owner}
       gaTrackingId={gaTrackingId}
-      topNavigationCurrent="settings"
+      topNavigationCurrent="admin"
       subNavigation={subNavigationAdmin({ owner, current: "extract" })}
     >
       <Page.Header

--- a/front/pages/w/[wId]/u/extract/templates/[sId]/edit.tsx
+++ b/front/pages/w/[wId]/u/extract/templates/[sId]/edit.tsx
@@ -68,7 +68,7 @@ export default function AppExtractEventsUpdate({
       user={user}
       owner={owner}
       gaTrackingId={gaTrackingId}
-      topNavigationCurrent="settings"
+      topNavigationCurrent="admin"
       subNavigation={subNavigationAdmin({ owner, current: "extract" })}
     >
       <ExtractEventSchemaForm

--- a/front/pages/w/[wId]/u/extract/templates/[sId]/index.tsx
+++ b/front/pages/w/[wId]/u/extract/templates/[sId]/index.tsx
@@ -138,7 +138,7 @@ export default function AppExtractEventsReadData({
       user={user}
       owner={owner}
       gaTrackingId={gaTrackingId}
-      topNavigationCurrent="settings"
+      topNavigationCurrent="admin"
       subNavigation={subNavigationAdmin({ owner, current: "extract" })}
     >
       <Page.Header

--- a/front/pages/w/[wId]/u/extract/templates/new.tsx
+++ b/front/pages/w/[wId]/u/extract/templates/new.tsx
@@ -53,7 +53,7 @@ export default function AppExtractEventsCreate({
       user={user}
       owner={owner}
       gaTrackingId={gaTrackingId}
-      topNavigationCurrent="settings"
+      topNavigationCurrent="admin"
       subNavigation={subNavigationAdmin({ owner, current: "extract" })}
     >
       <ExtractEventSchemaForm owner={owner} readOnly={readOnly} />

--- a/front/pages/w/[wId]/workspace/index.tsx
+++ b/front/pages/w/[wId]/workspace/index.tsx
@@ -208,7 +208,7 @@ export default function WorkspaceAdmin({
       user={user}
       owner={owner}
       gaTrackingId={gaTrackingId}
-      topNavigationCurrent="settings"
+      topNavigationCurrent="admin"
       subNavigation={subNavigationAdmin({ owner, current: "workspace" })}
     >
       <Page.Vertical align="stretch" gap="xl">


### PR DESCRIPTION
Will add screenshots tomorrow.

- Reshape navigation to prepare for personal assistants.
- Move Static Data Sources to "Folders" :)
- Some nits here and there.

cc @Duncid note: Conversations + assistants + cog overflow our menu :) so for now it's Conversations + two icons.