### PR TITLE
[Ahuna] Users can create private assistants & change scope in builder

### DIFF
--- a/front/components/assistant/AssistantActions.tsx
+++ b/front/components/assistant/AssistantActions.tsx
@@ -15,12 +15,14 @@ export function DeleteAssistantDialog({
   show,
   onClose,
   onDelete,
+  isPrivateAssistant,
 }: {
   owner: WorkspaceType;
   agentConfigurationId: string;
   show: boolean;
   onClose: () => void;
   onDelete: () => void;
+  isPrivateAssistant?: boolean;
 }) {
   const sendNotification = useContext(SendNotificationsContext);
 
@@ -29,7 +31,7 @@ export function DeleteAssistantDialog({
       isOpen={show}
       title={`Deleting assistant`}
       onCancel={onClose}
-      validateLabel="Delete for Everyone"
+      validateLabel={isPrivateAssistant ? "Delete" : "Delete for Everyone"}
       validateVariant="primaryWarning"
       onValidate={async () => {
         try {
@@ -68,8 +70,9 @@ export function DeleteAssistantDialog({
         <div className="font-bold">Are you sure you want to delete?</div>
 
         <div>
-          This will be permanent and delete the&nbsp;assistant
-          for&nbsp;everyone.
+          {isPrivateAssistant
+            ? "This will delete your personal assistant permanently."
+            : "This will be permanent and delete the assistant for everyone."}
         </div>
       </div>
     </Dialog>
@@ -94,7 +97,7 @@ export function RemoveAssistantFromListDialog({
   return (
     <Dialog
       isOpen={show}
-      title={`Remove @${agentConfiguration.name} from my list`}
+      title={`Remove from my list`}
       onCancel={onClose}
       validateLabel="Remove"
       validateVariant="primaryWarning"

--- a/front/components/assistant/AssistantPreview.tsx
+++ b/front/components/assistant/AssistantPreview.tsx
@@ -208,29 +208,31 @@ export function AssistantPreview({
   ];
 
   let galleryChip = null;
-  switch (flow) {
-    case "personal":
-      galleryChip = agentConfiguration.userListStatus === "in-list" && (
-        <Chip
-          color="emerald"
-          size="xs"
-          label={agentConfiguration.scope === "global" ? "Active" : "Added"}
-        />
-      );
-      break;
-    case "workspace":
-      galleryChip = ["workspace", "global"].includes(
-        agentConfiguration.scope
-      ) && (
-        <Chip
-          color="emerald"
-          size="xs"
-          label={agentConfiguration.scope === "global" ? "Active" : "Added"}
-        />
-      );
-      break;
-    default:
-      assertNever(flow);
+  if (variant === "gallery") {
+    switch (flow) {
+      case "personal":
+        galleryChip = agentConfiguration.userListStatus === "in-list" && (
+          <Chip
+            color="emerald"
+            size="xs"
+            label={agentConfiguration.scope === "global" ? "Active" : "Added"}
+          />
+        );
+        break;
+      case "workspace":
+        galleryChip = ["workspace", "global"].includes(
+          agentConfiguration.scope
+        ) && (
+          <Chip
+            color="emerald"
+            size="xs"
+            label={agentConfiguration.scope === "global" ? "Active" : "Added"}
+          />
+        );
+        break;
+      default:
+        assertNever(flow);
+    }
   }
 
   // Define button groups with JSX elements, including default buttons

--- a/front/components/assistant_builder/TeamSharingSection.tsx
+++ b/front/components/assistant_builder/TeamSharingSection.tsx
@@ -1,0 +1,275 @@
+import {
+  Button,
+  CheckCircleIcon,
+  Dialog,
+  Icon,
+  ImageIcon,
+  Tooltip,
+} from "@dust-tt/sparkle";
+import { AgentConfigurationScope, WorkspaceType } from "@dust-tt/types";
+import { useState } from "react";
+
+export function TeamSharingSection({
+  owner,
+  initialScope,
+  newScope,
+  setNewScope,
+}: {
+  owner: WorkspaceType;
+  initialScope: AgentConfigurationScope;
+  newScope: Exclude<AgentConfigurationScope, "global">;
+  setNewScope: (scope: Exclude<AgentConfigurationScope, "global">) => void;
+}) {
+  const [showPublishDialog, setShowPublishDialog] = useState(false);
+  const [showWorkspaceRemoveDialog, setShowWorkspaceRemoveDialog] =
+    useState(false);
+  const [showCreateDuplicateDialog, setShowCreateDuplicateDialog] =
+    useState(false);
+
+  if (initialScope !== "private" && newScope === "private") {
+    throw new Error("Cannot change scope back to private");
+  }
+  if (initialScope === "global") {
+    return null;
+  }
+
+  if (initialScope === "private" && newScope === "private")
+    return (
+      <div className="flex flex-col gap-3">
+        <div className="text-lg font-bold text-element-900">Team sharing</div>
+        <div className="flex items-center gap-3">
+          <PublishDialog
+            show={showPublishDialog}
+            onClose={() => setShowPublishDialog(false)}
+            setPublished={() => setNewScope("published")}
+          />
+          <div>
+            <Button
+              variant="secondary"
+              size="sm"
+              label="Publish to Assistant Gallery"
+              icon={ImageIcon}
+              onClick={() => setShowPublishDialog(true)}
+            />
+          </div>
+          <div className="flex-grow text-sm text-element-700">
+            Make the assistant available to your team in the{" "}
+            <span className="font-bold">Assistant Gallery</span>. <br /> Your
+            team will be allowed to{" "}
+            <span className="font-bold">use and modify</span> the assistant.
+          </div>
+        </div>
+      </div>
+    );
+
+  if (initialScope === "private" && newScope === "published") {
+    return (
+      <div className="flex flex-col gap-3">
+        <div className="text-lg font-bold text-element-900">Team sharing</div>
+        <div className="flex items-center gap-3">
+          <div>
+            <Icon
+              visual={CheckCircleIcon}
+              size="lg"
+              className="text-success-500"
+            />
+          </div>
+          <div className="flex-grow text-sm text-element-700">
+            Make the assistant available to your team in the{" "}
+            <span className="font-bold">Assistant Gallery</span>. <br /> Your
+            team will be allowed to{" "}
+            <span className="font-bold">use and modify</span> the assistant.
+          </div>
+          <div>
+            <Button
+              variant="tertiary"
+              size="sm"
+              label="Cancel publication"
+              onClick={() => setNewScope("private")}
+            />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (initialScope === "published" && newScope === "published") {
+    return (
+      <div className="flex flex-col gap-3">
+        <CreateDuplicateDialog
+          show={showCreateDuplicateDialog}
+          onClose={() => setShowCreateDuplicateDialog(false)}
+          createDuplicate={function (): void {
+            throw new Error("Function not implemented.");
+          }}
+        />
+        <div className="text-lg font-bold text-element-900">Team sharing</div>
+        <div className="flex items-center gap-3">
+          <div className="flex-grow text-sm text-element-700">
+            This assistant can be discovered by everyone in the{" "}
+            <span className="font-bold">Assistant Gallery</span>. Any edits will
+            apply to everyone. You can create a duplicate to tweak your own,
+            private version.
+          </div>
+          <div>
+            <Tooltip label="Coming soon: you can create a duplicate to tweak your own, private version">
+              <Button
+                variant="secondary"
+                size="sm"
+                label="Create a duplicate"
+                onClick={() => setShowCreateDuplicateDialog(true)}
+                disabled={true}
+              />
+            </Tooltip>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (initialScope === "workspace" && newScope === "workspace") {
+    return (
+      <div className="flex flex-col gap-3">
+        <WorkspaceRemoveDialog
+          show={showWorkspaceRemoveDialog}
+          onClose={() => setShowWorkspaceRemoveDialog(false)}
+          setPublished={() => setNewScope("published")}
+        />
+        <div className="text-lg font-bold text-element-900">Team sharing</div>
+        <div className="flex items-center gap-3">
+          <div className="flex-grow text-sm text-element-700">
+            The assistant is in the workspace list. Only admins and builders can{" "}
+            <span className="font-bold">modify and delete</span> the assistant.
+            It is included by default in every member's list.
+          </div>
+          {(owner.role === "admin" || owner.role === "builder") && (
+            <Button
+              variant="tertiary"
+              size="sm"
+              label="Remove from workspace list"
+              onClick={() => setShowWorkspaceRemoveDialog(true)}
+            />
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  if (initialScope === "workspace" && newScope === "published") {
+    return (
+      <div className="flex flex-col gap-3">
+        <div className="text-lg font-bold text-element-900">Team sharing</div>
+        <div className="flex items-center gap-3">
+          <div>
+            <Icon
+              visual={CheckCircleIcon}
+              size="lg"
+              className="text-success-500"
+            />
+          </div>
+          <div className="flex-grow text-sm text-element-700">
+            The assistant will be removed from the workspace list. It will be
+            discoverable by members, but it won't be in their list by default.
+            Any workspace member can modify the assistant.
+          </div>
+          <div>
+            <Button
+              variant="tertiary"
+              size="sm"
+              label="Keep in workspace list"
+              onClick={() => setNewScope("workspace")}
+            />
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+function PublishDialog({
+  show,
+  onClose,
+  setPublished,
+}: {
+  show: boolean;
+  onClose: () => void;
+  setPublished: () => void;
+}) {
+  return (
+    <Dialog
+      isOpen={show}
+      title="Publishing to Assistant Gallery"
+      onCancel={onClose}
+      validateLabel="Ok"
+      validateVariant="primary"
+      onValidate={async () => {
+        setPublished();
+        onClose();
+      }}
+    >
+      <div>
+        Once published, the assistant will be visible and editable by members of
+        your workspace.
+      </div>
+    </Dialog>
+  );
+}
+
+function WorkspaceRemoveDialog({
+  show,
+  onClose,
+  setPublished,
+}: {
+  show: boolean;
+  onClose: () => void;
+  setPublished: () => void;
+}) {
+  return (
+    <Dialog
+      isOpen={show}
+      title="Removing from workspace list"
+      onCancel={onClose}
+      validateLabel="Remove"
+      validateVariant="primaryWarning"
+      onValidate={async () => {
+        setPublished();
+        onClose();
+      }}
+    >
+      <div>
+        Removing from the workspace leaves the assistant discoverable by
+        members, but it won't be in their list by default. Any workspace member
+        can modify the assistant.
+      </div>
+    </Dialog>
+  );
+}
+
+function CreateDuplicateDialog({
+  show,
+  onClose,
+  createDuplicate,
+}: {
+  show: boolean;
+  onClose: () => void;
+  createDuplicate: () => void;
+}) {
+  return (
+    <Dialog
+      isOpen={show}
+      title="Creating a duplicate"
+      onCancel={onClose}
+      validateLabel="Ok"
+      validateVariant="primary"
+      onValidate={async () => {
+        createDuplicate();
+        onClose();
+      }}
+    >
+      <div>
+        An exact copy of the assistant will be created for you only. You will
+        pick a new name and Avatar.
+      </div>
+    </Dialog>
+  );
+}

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -677,11 +677,27 @@ export async function createAgentConfiguration(
           }
         );
       }
+      const sId = agentConfigurationId || generateModelSId();
+
+      // If creating a new private or published agent, it should be in the
+      // user's list, so it appears in their 'assistants' page
+      if (scope === "private" && !agentConfigurationId) {
+        listStatusOverride = "in-list";
+        await AgentUserRelation.create(
+          {
+            workspaceId: owner.id,
+            agentConfiguration: sId,
+            userId: user.id,
+            listStatusOverride: "in-list",
+          },
+          { transaction: t }
+        );
+      }
 
       // Create Agent config.
       return AgentConfiguration.create(
         {
-          sId: agentConfigurationId || generateModelSId(),
+          sId,
           version,
           status,
           scope,

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -679,9 +679,10 @@ export async function createAgentConfiguration(
       }
       const sId = agentConfigurationId || generateModelSId();
 
-      // If creating a new private or published agent, it should be in the
-      // user's list, so it appears in their 'assistants' page
-      if (scope === "private" && !agentConfigurationId) {
+      // If creating a new private or published agent, it should be in the user's list, so it
+      // appears in their 'assistants' page (at creation for assistants created published, or at
+      // publication once a private assistant gets published).
+      if (["private", "published"].includes(scope) && !agentConfigurationId) {
         listStatusOverride = "in-list";
         await AgentUserRelation.create(
           {

--- a/front/pages/w/[wId]/assistant/assistants.tsx
+++ b/front/pages/w/[wId]/assistant/assistants.tsx
@@ -8,6 +8,7 @@ import {
   PlusIcon,
   RobotIcon,
   Searchbar,
+  Tab,
   Tooltip,
   XMarkIcon,
 } from "@dust-tt/sparkle";
@@ -21,7 +22,10 @@ import { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import Link from "next/link";
 import { useState } from "react";
 
-import { RemoveAssistantFromListDialog } from "@app/components/assistant/AssistantActions";
+import {
+  DeleteAssistantDialog,
+  RemoveAssistantFromListDialog,
+} from "@app/components/assistant/AssistantActions";
 import { AssistantSidebarMenu } from "@app/components/assistant/conversation/SidebarMenu";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import {
@@ -30,14 +34,18 @@ import {
 } from "@app/components/sparkle/navigation";
 import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
 import { useAgentConfigurations } from "@app/lib/swr";
-import { subFilter } from "@app/lib/utils";
+import { classNames, subFilter } from "@app/lib/utils";
 
 const { GA_TRACKING_ID = "" } = process.env;
+
+const PERSONAL_ASSISTANTS_VIEWS = ["personal", "workspace"] as const;
+export type PersonalAssitsantsView = (typeof PERSONAL_ASSISTANTS_VIEWS)[number];
 
 export const getServerSideProps: GetServerSideProps<{
   user: UserType;
   owner: WorkspaceType;
   subscription: SubscriptionType;
+  view: PersonalAssitsantsView;
   gaTrackingId: string;
 }> = async (context) => {
   const session = await getSession(context.req, context.res);
@@ -56,11 +64,18 @@ export const getServerSideProps: GetServerSideProps<{
     };
   }
 
+  const view = PERSONAL_ASSISTANTS_VIEWS.includes(
+    context.query.view as PersonalAssitsantsView
+  )
+    ? (context.query.view as PersonalAssitsantsView)
+    : "personal";
+
   return {
     props: {
       user,
       owner,
       subscription,
+      view,
       gaTrackingId: GA_TRACKING_ID,
     },
   };
@@ -70,6 +85,7 @@ export default function PersonalAssistants({
   user,
   owner,
   subscription,
+  view,
   gaTrackingId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const { agentConfigurations, mutateAgentConfigurations } =
@@ -80,14 +96,36 @@ export default function PersonalAssistants({
 
   const [assistantSearch, setAssistantSearch] = useState<string>("");
 
-  const filtered = agentConfigurations.filter((a) => {
+  const viewAssistants = agentConfigurations.filter((a) => {
+    if (view === "personal") {
+      return a.scope === "private" || a.scope === "published";
+    }
+    if (view === "workspace") {
+      return a.scope === "workspace" || a.scope === "global";
+    }
+  });
+
+  const filtered = viewAssistants.filter((a) => {
     return subFilter(assistantSearch.toLowerCase(), a.name.toLowerCase());
   });
 
   const [showRemovalModal, setShowRemovalModal] =
     useState<AgentConfigurationType | null>(null);
+  const [showDeletionModal, setShowDeletionModal] =
+    useState<AgentConfigurationType | null>(null);
 
-  // const isBuilder = owner.role === "builder" || owner.role === "admin";
+  const tabs = [
+    {
+      label: "Personal",
+      href: `/w/${owner.sId}/assistant/assistants?view=personal`,
+      current: view === "personal",
+    },
+    {
+      label: "From Workspace",
+      href: `/w/${owner.sId}/assistant/assistants?view=workspace`,
+      current: view === "workspace",
+    },
+  ];
 
   return (
     <AppLayout
@@ -126,91 +164,134 @@ export default function PersonalAssistants({
           }}
         />
       )}
+      {showDeletionModal && (
+        <DeleteAssistantDialog
+          owner={owner}
+          agentConfigurationId={showDeletionModal.sId}
+          show={!!showDeletionModal}
+          onClose={() => setShowDeletionModal(null)}
+          onDelete={() => {
+            void mutateAgentConfigurations();
+          }}
+          isPrivateAssistant={true}
+        />
+      )}
+
       <Page.Vertical gap="xl" align="stretch">
         <Page.Header
           title="Manage my assistants"
           icon={RobotIcon}
           description="Manage your list of assistants, create and discover new ones."
         />
-        <div className="flex flex-col gap-y-2">
-          <div className="flex flex-row gap-2">
-            <div className="flex w-full flex-1">
-              <div className="w-full">
-                <Searchbar
-                  name="search"
-                  placeholder="Assistant Name"
-                  value={assistantSearch}
-                  onChange={(s) => {
-                    setAssistantSearch(s);
-                  }}
-                />
+        <Page.Vertical gap="lg" align="stretch">
+          <Tab tabs={tabs} />
+          <Page.Vertical gap="md" align="stretch">
+            <div className="flex flex-row gap-2">
+              <div className="flex w-full flex-1">
+                <div className="w-full">
+                  <Searchbar
+                    name="search"
+                    placeholder="Assistant Name"
+                    value={assistantSearch}
+                    onChange={(s) => {
+                      setAssistantSearch(s);
+                    }}
+                  />
+                </div>
               </div>
+              <Button.List>
+                <Link
+                  href={`/w/${owner.sId}/assistant/gallery?flow=personal_add`}
+                >
+                  <Button
+                    variant="primary"
+                    icon={BookOpenIcon}
+                    label="Add from gallery"
+                  />
+                </Link>
+                {view !== "workspace" && viewAssistants.length > 0 && (
+                  <Tooltip label="Create your own assistant">
+                    <Link
+                      href={`/w/${owner.sId}/builder/assistants/new?flow=my_assistants`}
+                    >
+                      <Button variant="primary" icon={PlusIcon} label="New" />
+                    </Link>
+                  </Tooltip>
+                )}
+              </Button.List>
             </div>
-            <Button.List>
-              <Link
-                href={`/w/${owner.sId}/assistant/gallery?flow=personal_add`}
+
+            {view === "workspace" || viewAssistants.length > 0 ? (
+              <ContextItem.List className="text-element-900">
+                {filtered.map((agent) => (
+                  <ContextItem
+                    key={agent.sId}
+                    title={`@${agent.name}`}
+                    visual={
+                      <Avatar
+                        visual={<img src={agent.pictureUrl} />}
+                        size={"sm"}
+                      />
+                    }
+                    action={
+                      agent.scope !== "global" && (
+                        <div className="flex gap-2">
+                          <Link
+                            href={`/w/${owner.sId}/builder/assistants/${agent.sId}?flow=my_assistants`}
+                          >
+                            <Button
+                              variant="tertiary"
+                              icon={PencilSquareIcon}
+                              label="Edit"
+                              size="xs"
+                              disabled={agent.scope === "workspace"}
+                            />
+                          </Link>
+
+                          <Button
+                            variant="tertiary"
+                            icon={XMarkIcon}
+                            label="Remove from my list"
+                            labelVisible={false}
+                            onClick={() => {
+                              agent.scope === "private"
+                                ? setShowDeletionModal(agent)
+                                : setShowRemovalModal(agent);
+                            }}
+                            size="xs"
+                          />
+                        </div>
+                      )
+                    }
+                  >
+                    <ContextItem.Description>
+                      <div className="text-element-700">
+                        {agent.description}
+                      </div>
+                    </ContextItem.Description>
+                  </ContextItem>
+                ))}
+              </ContextItem.List>
+            ) : (
+              <div
+                className={classNames(
+                  "relative mt-4 flex h-full min-h-48 items-center justify-center rounded-lg bg-structure-50"
+                )}
               >
-                <Button
-                  variant="primary"
-                  icon={BookOpenIcon}
-                  label="Add from gallery"
-                />
-              </Link>
-              <Tooltip label="Create your own assistant">
                 <Link
                   href={`/w/${owner.sId}/builder/assistants/new?flow=my_assistants`}
                 >
-                  <Button variant="primary" icon={PlusIcon} label="New" />
+                  <Button
+                    size="sm"
+                    label="Create an Assistant"
+                    variant="primary"
+                    icon={PlusIcon}
+                  />
                 </Link>
-              </Tooltip>
-            </Button.List>
-          </div>
-
-          <ContextItem.List className="text-element-900">
-            {filtered.map((agent) => (
-              <ContextItem
-                key={agent.sId}
-                title={`@${agent.name}`}
-                visual={
-                  <Avatar visual={<img src={agent.pictureUrl} />} size={"sm"} />
-                }
-                action={
-                  agent.scope !== "global" && (
-                    <div className="flex gap-2">
-                      <Link
-                        href={`/w/${owner.sId}/builder/assistants/${agent.sId}?flow=my_assistants`}
-                      >
-                        <Button
-                          variant="secondary"
-                          icon={PencilSquareIcon}
-                          label="Edit"
-                          labelVisible={false}
-                          size="xs"
-                          disabled={agent.scope === "workspace"}
-                        />
-                      </Link>
-
-                      <Button
-                        variant="tertiary"
-                        icon={XMarkIcon}
-                        label="Remove from my list"
-                        labelVisible={false}
-                        onClick={() => {
-                          setShowRemovalModal(agent);
-                        }}
-                        size="xs"
-                      />
-                    </div>
-                  )
-                }
-              >
-                <ContextItem.Description>
-                  <div className="text-element-700">{agent.description}</div>
-                </ContextItem.Description>
-              </ContextItem>
-            ))}
-          </ContextItem.List>
-        </div>
+              </div>
+            )}
+          </Page.Vertical>
+        </Page.Vertical>
       </Page.Vertical>
     </AppLayout>
   );

--- a/front/pages/w/[wId]/assistant/assistants.tsx
+++ b/front/pages/w/[wId]/assistant/assistants.tsx
@@ -4,6 +4,7 @@ import {
   Button,
   ContextItem,
   Page,
+  PencilSquareIcon,
   PlusIcon,
   RobotIcon,
   Searchbar,
@@ -155,16 +156,16 @@ export default function PersonalAssistants({
                   label="Add from gallery"
                 />
               </Link>
-              <Tooltip label="Coming soon">
-                <Button
-                  variant="primary"
-                  icon={PlusIcon}
-                  disabled={true}
-                  label="New"
-                />
+              <Tooltip label="Create your own assistant">
+                <Link
+                  href={`/w/${owner.sId}/builder/assistants/new?flow=my_assistants`}
+                >
+                  <Button variant="primary" icon={PlusIcon} label="New" />
+                </Link>
               </Tooltip>
             </Button.List>
           </div>
+
           <ContextItem.List className="text-element-900">
             {filtered.map((agent) => (
               <ContextItem
@@ -175,16 +176,31 @@ export default function PersonalAssistants({
                 }
                 action={
                   agent.scope !== "global" && (
-                    <Button
-                      variant="tertiary"
-                      icon={XMarkIcon}
-                      label="Remove from my list"
-                      labelVisible={false}
-                      onClick={() => {
-                        setShowRemovalModal(agent);
-                      }}
-                      size="xs"
-                    />
+                    <div className="flex gap-2">
+                      <Link
+                        href={`/w/${owner.sId}/builder/assistants/${agent.sId}?flow=my_assistants`}
+                      >
+                        <Button
+                          variant="secondary"
+                          icon={PencilSquareIcon}
+                          label="Edit"
+                          labelVisible={false}
+                          size="xs"
+                          disabled={agent.scope === "workspace"}
+                        />
+                      </Link>
+
+                      <Button
+                        variant="tertiary"
+                        icon={XMarkIcon}
+                        label="Remove from my list"
+                        labelVisible={false}
+                        onClick={() => {
+                          setShowRemovalModal(agent);
+                        }}
+                        size="xs"
+                      />
+                    </div>
                   )
                 }
               >

--- a/front/pages/w/[wId]/assistant/gallery.tsx
+++ b/front/pages/w/[wId]/assistant/gallery.tsx
@@ -111,14 +111,14 @@ export default function AssistantsGallery({
       current: agentsGetView === "all",
     },
     {
+      label: "Published",
+      href: `/w/${owner.sId}/assistant/gallery?view=published&flow=` + flow,
+      current: agentsGetView === "published",
+    },
+    {
       label: "From Workspace",
       href: `/w/${owner.sId}/assistant/gallery?view=workspace&flow=` + flow,
       current: agentsGetView === "workspace",
-    },
-    {
-      label: "From Teammates",
-      href: `/w/${owner.sId}/assistant/gallery?view=published&flow=` + flow,
-      current: agentsGetView === "published",
     },
     {
       label: "From Dust",

--- a/front/pages/w/[wId]/builder/assistants/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/index.tsx
@@ -208,7 +208,9 @@ export default function WorkspaceAssistants({
                 />
               </Link>
               {workspaceAgents.length > 0 && (
-                <Link href={`/w/${owner.sId}/builder/assistants/new`}>
+                <Link
+                  href={`/w/${owner.sId}/builder/assistants/new?flow=workspace_assistants`}
+                >
                   <Button variant="primary" icon={PlusIcon} label="New" />
                 </Link>
               )}
@@ -285,7 +287,9 @@ export default function WorkspaceAssistants({
                 "relative mt-4 flex h-full min-h-48 items-center justify-center rounded-lg bg-structure-50"
               )}
             >
-              <Link href={`/w/${owner.sId}/builder/assistants/new`}>
+              <Link
+                href={`/w/${owner.sId}/builder/assistants/new?flow=workspace_assistants`}
+              >
                 <Button
                   disabled={!isBuilder}
                   size="sm"

--- a/front/pages/w/[wId]/builder/assistants/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/index.tsx
@@ -183,7 +183,7 @@ export default function WorkspaceAssistants({
           icon={RobotIcon}
           description="Workspace assistants will be activated by default for every member of the workspace. Only Admins and Builders can activate, create, or edit workspace assistants."
         />
-        <div className="flex flex-col gap-y-2">
+        <Page.Vertical gap="md" align="stretch">
           <div className="flex flex-row gap-2">
             <div className="flex w-full flex-1">
               <div className="w-full">
@@ -231,6 +231,17 @@ export default function WorkspaceAssistants({
                   }
                   action={
                     <Button.List>
+                      <Link
+                        href={`/w/${owner.sId}/builder/assistants/${agent.sId}`}
+                      >
+                        <Button
+                          variant="tertiary"
+                          icon={PencilSquareIcon}
+                          label="Edit"
+                          size="xs"
+                          disabled={!isBuilder}
+                        />
+                      </Link>
                       <DropdownMenu>
                         <DropdownMenu.Button>
                           <Button
@@ -260,18 +271,6 @@ export default function WorkspaceAssistants({
                           />
                         </DropdownMenu.Items>
                       </DropdownMenu>
-
-                      <Link
-                        href={`/w/${owner.sId}/builder/assistants/${agent.sId}`}
-                      >
-                        <Button
-                          variant="tertiary"
-                          icon={PencilSquareIcon}
-                          label="Edit"
-                          size="xs"
-                          disabled={!isBuilder}
-                        />
-                      </Link>
                     </Button.List>
                   }
                 >
@@ -300,7 +299,7 @@ export default function WorkspaceAssistants({
               </Link>
             </div>
           )}
-        </div>
+        </Page.Vertical>
 
         <div className="flex flex-col gap-y-2">
           <Page.SectionHeader


### PR DESCRIPTION
Related [task](https://github.com/dust-tt/dust/issues/2647) 

@Duncid added you for review with screenshots below, and a proposal for "workspace" assistants builder: it felt natural that team sharing section remained across all builder screens, tell me if you're fine with it

![image](https://github.com/dust-tt/dust/assets/5437393/0c64820f-f079-4e01-9cc0-1ab4d00ffe48)
---
From private to published

![image](https://github.com/dust-tt/dust/assets/5437393/396165e1-e2ea-4acb-a768-7991c1944604)
![image](https://github.com/dust-tt/dust/assets/5437393/188027ac-6768-4cfe-86cd-068e0df35dd4)
![image](https://github.com/dust-tt/dust/assets/5437393/afdf447e-191f-47aa-aeff-26ad97792c6b)
---

After publication
![image](https://github.com/dust-tt/dust/assets/5437393/d35134b3-4bae-475c-b9d4-47da1f4b9fba)
---

Suggestion for worskpace assistants, as accessed by "Workspace assistants" nav
![image](https://github.com/dust-tt/dust/assets/5437393/547b3cd6-58f5-4e14-a8ab-078be05f31b1)
![image](https://github.com/dust-tt/dust/assets/5437393/c672aec6-a897-4233-a07c-364d00838dd1)
![image](https://github.com/dust-tt/dust/assets/5437393/a723d9c8-113c-4864-86fc-c66915f2c00f)
