### PR TITLE
Flav/new conversation landing page

### DIFF
--- a/front/components/assistant/AssistantPreview.tsx
+++ b/front/components/assistant/AssistantPreview.tsx
@@ -5,17 +5,17 @@ import { useContext, useState } from "react";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { PostAgentListStatusRequestBody } from "@app/pages/api/w/[wId]/members/me/agent_list_status";
 
-type GalleryItemVariant = "home" | "gallery";
+type AssistantPreviewVariant = "home" | "gallery";
 
-interface GalleryItemProps {
+interface AssistantPreviewProps {
   owner: WorkspaceType;
   agentConfiguration: AgentConfigurationType;
   onShowDetails: () => void;
   onUpdate: () => void;
-  variant: GalleryItemVariant;
+  variant: AssistantPreviewVariant;
 }
 
-function getDescriptionClassName(variant: GalleryItemVariant): string {
+function getDescriptionClassName(variant: AssistantPreviewVariant): string {
   switch (variant) {
     case "home":
       return "text-xs text-element-700";
@@ -24,7 +24,7 @@ function getDescriptionClassName(variant: GalleryItemVariant): string {
   }
 }
 
-function getNameClassName(variant: GalleryItemVariant): string {
+function getNameClassName(variant: AssistantPreviewVariant): string {
   switch (variant) {
     case "home":
       return "text-sm font-medium text-element-900";
@@ -33,13 +33,13 @@ function getNameClassName(variant: GalleryItemVariant): string {
   }
 }
 
-export default function GalleryItem({
+export default function AssistantPreview({
   owner,
   agentConfiguration,
   onShowDetails,
   onUpdate,
   variant,
-}: GalleryItemProps) {
+}: AssistantPreviewProps) {
   const [isAdding, setIsAdding] = useState<boolean>(false);
   const sendNotification = useContext(SendNotificationsContext);
 
@@ -124,7 +124,7 @@ export default function GalleryItem({
   ];
 
   // Define button groups with JSX elements, including default buttons
-  const buttonGroups: Record<GalleryItemVariant, JSX.Element[]> = {
+  const buttonGroups: Record<AssistantPreviewVariant, JSX.Element[]> = {
     gallery: [addButton, showAssistantButton].filter(Boolean) as JSX.Element[],
     home: defaultButtons,
   };

--- a/front/components/assistant/AssistantPreview.tsx
+++ b/front/components/assistant/AssistantPreview.tsx
@@ -5,7 +5,7 @@ import { useContext, useState } from "react";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { PostAgentListStatusRequestBody } from "@app/pages/api/w/[wId]/members/me/agent_list_status";
 
-type AssistantPreviewVariant = "home" | "gallery";
+type AssistantPreviewVariant = "gallery" | "home";
 
 interface AssistantPreviewProps {
   owner: WorkspaceType;
@@ -33,7 +33,7 @@ function getNameClassName(variant: AssistantPreviewVariant): string {
   }
 }
 
-export default function AssistantPreview({
+export function AssistantPreview({
   owner,
   agentConfiguration,
   onShowDetails,
@@ -41,7 +41,7 @@ export default function AssistantPreview({
   variant,
 }: AssistantPreviewProps) {
   const [isAdding, setIsAdding] = useState<boolean>(false);
-  // TODO(flav) Shift notification logic to the caller. This maintains the purity of the component by decoupling it from side-effect operations.
+  // TODO(flav) Move notification logic to the caller. This maintains the purity of the component by decoupling it from side-effect operations.
   const sendNotification = useContext(SendNotificationsContext);
 
   const addToAgentList = async () => {

--- a/front/components/assistant/AssistantPreview.tsx
+++ b/front/components/assistant/AssistantPreview.tsx
@@ -41,6 +41,7 @@ export default function AssistantPreview({
   variant,
 }: AssistantPreviewProps) {
   const [isAdding, setIsAdding] = useState<boolean>(false);
+  // TODO(flav) Shift notification logic to the caller. This maintains the purity of the component by decoupling it from side-effect operations.
   const sendNotification = useContext(SendNotificationsContext);
 
   const addToAgentList = async () => {

--- a/front/pages/w/[wId]/assistant/gallery.tsx
+++ b/front/pages/w/[wId]/assistant/gallery.tsx
@@ -12,7 +12,7 @@ import { useRouter } from "next/router";
 import { useState } from "react";
 
 import { AssistantDetails } from "@app/components/assistant/AssistantDetails";
-import AssistantPreview from "@app/components/assistant/AssistantPreview";
+import { AssistantPreview } from "@app/components/assistant/AssistantPreview";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { subNavigationConversations } from "@app/components/sparkle/navigation";

--- a/front/pages/w/[wId]/assistant/gallery.tsx
+++ b/front/pages/w/[wId]/assistant/gallery.tsx
@@ -1,10 +1,5 @@
 import {
-  Avatar,
-  Button,
-  Chip,
-  MoreIcon,
   Page,
-  PlusIcon,
   Searchbar,
   Tab,
 } from "@dust-tt/sparkle";
@@ -18,17 +13,17 @@ import {
 } from "@dust-tt/types";
 import { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
-import { useContext, useState } from "react";
+import { useState } from "react";
 
 import { AssistantDetails } from "@app/components/assistant/AssistantDetails";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { subNavigationConversations } from "@app/components/sparkle/navigation";
-import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
 import { useAgentConfigurations } from "@app/lib/swr";
 import { subFilter } from "@app/lib/utils";
-import { PostAgentListStatusRequestBody } from "@app/pages/api/w/[wId]/members/me/agent_list_status";
+
+import GalleryItem from "./item";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
@@ -84,112 +79,6 @@ export const getServerSideProps: GetServerSideProps<{
       gaTrackingId: GA_TRACKING_ID,
     },
   };
-};
-
-const GalleryItem = function ({
-  owner,
-  agentConfiguration,
-  onShowDetails,
-  onUpdate,
-}: {
-  owner: WorkspaceType;
-  agentConfiguration: AgentConfigurationType;
-  onShowDetails: () => void;
-  onUpdate: () => void;
-}) {
-  const [isAdding, setIsAdding] = useState<boolean>(false);
-  const sendNotification = useContext(SendNotificationsContext);
-
-  return (
-    <div className="flex flex-row gap-2">
-      <Avatar
-        visual={<img src={agentConfiguration.pictureUrl} alt="Agent Avatar" />}
-        size="md"
-      />
-      <div className="flex flex-col gap-2">
-        <div className="text-md font-medium text-element-900">
-          @{agentConfiguration.name}
-        </div>
-        <div className="flex flex-row gap-2">
-          {agentConfiguration.userListStatus === "in-list" && (
-            <Chip color="emerald" size="xs" label="Added" />
-          )}
-          <Button.List isWrapping={true}>
-            {agentConfiguration.userListStatus !== "in-list" && (
-              <>
-                <Button
-                  variant="tertiary"
-                  icon={PlusIcon}
-                  disabled={isAdding}
-                  size="xs"
-                  label={"Add"}
-                  onClick={async () => {
-                    setIsAdding(true);
-
-                    const body: PostAgentListStatusRequestBody = {
-                      agentId: agentConfiguration.sId,
-                      listStatus: "in-list",
-                    };
-
-                    const res = await fetch(
-                      `/api/w/${owner.sId}/members/me/agent_list_status`,
-                      {
-                        method: "POST",
-                        headers: {
-                          "Content-Type": "application/json",
-                        },
-                        body: JSON.stringify(body),
-                      }
-                    );
-                    if (!res.ok) {
-                      const data = await res.json();
-                      sendNotification({
-                        title: `Error adding Assistant`,
-                        description: data.error.message,
-                        type: "error",
-                      });
-                    } else {
-                      sendNotification({
-                        title: `Assistant added`,
-                        type: "success",
-                      });
-                      onUpdate();
-                    }
-
-                    setIsAdding(false);
-                  }}
-                />
-                {/*
-                <Button
-                  variant="tertiary"
-                  icon={PlayIcon}
-                  size="xs"
-                  label={"Test"}
-                  onClick={() => {
-                    // TODO: test
-                  }}
-                />
-                */}
-              </>
-            )}
-            <Button
-              variant="tertiary"
-              icon={MoreIcon}
-              size="xs"
-              label={"Show Assistant"}
-              labelVisible={false}
-              onClick={() => {
-                onShowDetails();
-              }}
-            />
-          </Button.List>
-        </div>
-        <div className="text-sm text-element-800">
-          {agentConfiguration.description}
-        </div>
-      </div>
-    </div>
-  );
 };
 
 export default function AssistantsGallery({

--- a/front/pages/w/[wId]/assistant/gallery.tsx
+++ b/front/pages/w/[wId]/assistant/gallery.tsx
@@ -12,14 +12,13 @@ import { useRouter } from "next/router";
 import { useState } from "react";
 
 import { AssistantDetails } from "@app/components/assistant/AssistantDetails";
+import AssistantPreview from "@app/components/assistant/AssistantPreview";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { subNavigationConversations } from "@app/components/sparkle/navigation";
 import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
 import { useAgentConfigurations } from "@app/lib/swr";
 import { subFilter } from "@app/lib/utils";
-
-import GalleryItem from "./item";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
@@ -187,7 +186,7 @@ export default function AssistantsGallery({
         <div className="flex flex-col gap-2">
           <div className="grid grid-cols-2 gap-8 sm:grid-cols-2">
             {filtered.map((a) => (
-              <GalleryItem
+              <AssistantPreview
                 key={a.sId}
                 owner={owner}
                 agentConfiguration={a}

--- a/front/pages/w/[wId]/assistant/gallery.tsx
+++ b/front/pages/w/[wId]/assistant/gallery.tsx
@@ -1,8 +1,4 @@
-import {
-  Page,
-  Searchbar,
-  Tab,
-} from "@dust-tt/sparkle";
+import { Page, Searchbar, Tab } from "@dust-tt/sparkle";
 import {
   AgentConfigurationType,
   AgentsGetViewType,
@@ -201,6 +197,7 @@ export default function AssistantsGallery({
                 onUpdate={() => {
                   void mutateAgentConfigurations();
                 }}
+                variant="gallery"
               />
             ))}
           </div>

--- a/front/pages/w/[wId]/assistant/item.tsx
+++ b/front/pages/w/[wId]/assistant/item.tsx
@@ -15,6 +15,24 @@ interface GalleryItemProps {
   variant: GalleryItemVariant;
 }
 
+function getDescriptionClassName(variant: GalleryItemVariant): string {
+  switch (variant) {
+    case "home":
+      return "text-xs text-element-700";
+    default:
+      return "text-sm text-element-800";
+  }
+}
+
+function getNameClassName(variant: GalleryItemVariant): string {
+  switch (variant) {
+    case "home":
+      return "text-sm font-medium text-element-900";
+    default:
+      return "text-md font-medium text-element-900";
+  }
+}
+
 export default function GalleryItem({
   owner,
   agentConfiguration,
@@ -120,7 +138,7 @@ export default function GalleryItem({
         size="md"
       />
       <div className="flex flex-col gap-2">
-        <div className="text-md font-medium text-element-900">
+        <div className={getNameClassName(variant)}>
           @{agentConfiguration.name}
         </div>
         <div className="flex flex-row gap-2">
@@ -130,7 +148,7 @@ export default function GalleryItem({
             )}
           <Button.List isWrapping={true}>{buttonsToRender}</Button.List>
         </div>
-        <div className="text-sm text-element-800">
+        <div className={getDescriptionClassName(variant)}>
           {agentConfiguration.description}
         </div>
       </div>

--- a/front/pages/w/[wId]/assistant/item.tsx
+++ b/front/pages/w/[wId]/assistant/item.tsx
@@ -1,0 +1,118 @@
+import {
+  Avatar,
+  Button,
+  Chip,
+  MoreIcon,
+  PlusIcon
+} from "@dust-tt/sparkle";
+import { AgentConfigurationType, WorkspaceType } from "@dust-tt/types";
+import { useContext, useState } from "react";
+
+import { SendNotificationsContext } from "@app/components/sparkle/Notification";
+import { PostAgentListStatusRequestBody } from "@app/pages/api/w/[wId]/members/me/agent_list_status";
+
+export default function GalleryItem({
+  owner,
+  agentConfiguration,
+  onShowDetails,
+  onUpdate,
+}: {
+  owner: WorkspaceType;
+  agentConfiguration: AgentConfigurationType;
+  onShowDetails: () => void;
+  onUpdate: () => void;
+}) {
+  const [isAdding, setIsAdding] = useState<boolean>(false);
+  const sendNotification = useContext(SendNotificationsContext);
+
+  return (
+    <div className="flex flex-row gap-2">
+      <Avatar
+        visual={<img src={agentConfiguration.pictureUrl} alt="Agent Avatar" />}
+        size="md"
+      />
+      <div className="flex flex-col gap-2">
+        <div className="text-md font-medium text-element-900">
+          @{agentConfiguration.name}
+        </div>
+        <div className="flex flex-row gap-2">
+          {agentConfiguration.userListStatus === "in-list" && (
+            <Chip color="emerald" size="xs" label="Added" />
+          )}
+          <Button.List isWrapping={true}>
+            {agentConfiguration.userListStatus !== "in-list" && (
+              <>
+                <Button
+                  variant="tertiary"
+                  icon={PlusIcon}
+                  disabled={isAdding}
+                  size="xs"
+                  label={"Add"}
+                  onClick={async () => {
+                    setIsAdding(true);
+
+                    const body: PostAgentListStatusRequestBody = {
+                      agentId: agentConfiguration.sId,
+                      listStatus: "in-list",
+                    };
+
+                    const res = await fetch(
+                      `/api/w/${owner.sId}/members/me/agent_list_status`,
+                      {
+                        method: "POST",
+                        headers: {
+                          "Content-Type": "application/json",
+                        },
+                        body: JSON.stringify(body),
+                      }
+                    );
+                    if (!res.ok) {
+                      const data = await res.json();
+                      sendNotification({
+                        title: `Error adding Assistant`,
+                        description: data.error.message,
+                        type: "error",
+                      });
+                    } else {
+                      sendNotification({
+                        title: `Assistant added`,
+                        type: "success",
+                      });
+                      onUpdate();
+                    }
+
+                    setIsAdding(false);
+                  }}
+                />
+                {/*
+                <Button
+                  variant="tertiary"
+                  icon={PlayIcon}
+                  size="xs"
+                  label={"Test"}
+                  onClick={() => {
+                    // TODO: test
+                  }}
+                />
+                */}
+              </>
+            )}
+            <Button
+              variant="tertiary"
+              icon={MoreIcon}
+              size="xs"
+              label={"Show Assistant"}
+              labelVisible={false}
+              onClick={() => {
+                onShowDetails();
+              }}
+            />
+          </Button.List>
+        </div>
+        <div className="text-sm text-element-800">
+          {agentConfiguration.description}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/front/pages/w/[wId]/assistant/item.tsx
+++ b/front/pages/w/[wId]/assistant/item.tsx
@@ -1,29 +1,117 @@
-import {
-  Avatar,
-  Button,
-  Chip,
-  MoreIcon,
-  PlusIcon
-} from "@dust-tt/sparkle";
+import { Avatar, Button, Chip, MoreIcon, PlusIcon } from "@dust-tt/sparkle";
 import { AgentConfigurationType, WorkspaceType } from "@dust-tt/types";
 import { useContext, useState } from "react";
 
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { PostAgentListStatusRequestBody } from "@app/pages/api/w/[wId]/members/me/agent_list_status";
 
+type GalleryItemVariant = "home" | "gallery";
+
+interface GalleryItemProps {
+  owner: WorkspaceType;
+  agentConfiguration: AgentConfigurationType;
+  onShowDetails: () => void;
+  onUpdate: () => void;
+  variant: GalleryItemVariant;
+}
+
 export default function GalleryItem({
   owner,
   agentConfiguration,
   onShowDetails,
   onUpdate,
-}: {
-  owner: WorkspaceType;
-  agentConfiguration: AgentConfigurationType;
-  onShowDetails: () => void;
-  onUpdate: () => void;
-}) {
+  variant,
+}: GalleryItemProps) {
   const [isAdding, setIsAdding] = useState<boolean>(false);
   const sendNotification = useContext(SendNotificationsContext);
+
+  const addToAgentList = async () => {
+    setIsAdding(true);
+
+    try {
+      const body: PostAgentListStatusRequestBody = {
+        agentId: agentConfiguration.sId,
+        listStatus: "in-list",
+      };
+
+      const response = await fetch(
+        `/api/w/${owner.sId}/members/me/agent_list_status`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(body),
+        }
+      );
+
+      if (!response.ok) {
+        const data = await response.json();
+        sendNotification({
+          title: `Error adding Assistant`,
+          description: data.error.message,
+          type: "error",
+        });
+      } else {
+        sendNotification({
+          title: `Assistant added`,
+          type: "success",
+        });
+        onUpdate();
+      }
+    } catch (error) {
+      sendNotification({
+        title: `Error adding Assistant`,
+        description: error instanceof Error ? error.message : String(error),
+        type: "error",
+      });
+    } finally {
+      setIsAdding(false);
+    }
+  };
+
+  const addButton = agentConfiguration.userListStatus !== "in-list" && (
+    <Button
+      variant="tertiary"
+      icon={PlusIcon}
+      disabled={isAdding}
+      size="xs"
+      label={"Add"}
+      onClick={addToAgentList}
+    />
+  );
+
+  const showAssistantButton = (
+    <Button
+      icon={MoreIcon}
+      label={"Show Assistant"}
+      labelVisible={false}
+      size="xs"
+      variant="tertiary"
+      onClick={onShowDetails}
+    />
+  );
+
+  const defaultButtons = [
+    showAssistantButton,
+    // <Button
+    //     variant="tertiary"
+    //     icon={PlayIcon}
+    //     size="xs"
+    //     label={"Test"}
+    //     onClick={() => {
+    //       // TODO: test
+    //     }}
+    //   />,
+  ];
+
+  // Define button groups with JSX elements, including default buttons
+  const buttonGroups: Record<GalleryItemVariant, JSX.Element[]> = {
+    gallery: [addButton, showAssistantButton].filter(Boolean) as JSX.Element[],
+    home: defaultButtons,
+  };
+
+  const buttonsToRender = buttonGroups[variant] || [];
 
   return (
     <div className="flex flex-row gap-2">
@@ -36,78 +124,11 @@ export default function GalleryItem({
           @{agentConfiguration.name}
         </div>
         <div className="flex flex-row gap-2">
-          {agentConfiguration.userListStatus === "in-list" && (
-            <Chip color="emerald" size="xs" label="Added" />
-          )}
-          <Button.List isWrapping={true}>
-            {agentConfiguration.userListStatus !== "in-list" && (
-              <>
-                <Button
-                  variant="tertiary"
-                  icon={PlusIcon}
-                  disabled={isAdding}
-                  size="xs"
-                  label={"Add"}
-                  onClick={async () => {
-                    setIsAdding(true);
-
-                    const body: PostAgentListStatusRequestBody = {
-                      agentId: agentConfiguration.sId,
-                      listStatus: "in-list",
-                    };
-
-                    const res = await fetch(
-                      `/api/w/${owner.sId}/members/me/agent_list_status`,
-                      {
-                        method: "POST",
-                        headers: {
-                          "Content-Type": "application/json",
-                        },
-                        body: JSON.stringify(body),
-                      }
-                    );
-                    if (!res.ok) {
-                      const data = await res.json();
-                      sendNotification({
-                        title: `Error adding Assistant`,
-                        description: data.error.message,
-                        type: "error",
-                      });
-                    } else {
-                      sendNotification({
-                        title: `Assistant added`,
-                        type: "success",
-                      });
-                      onUpdate();
-                    }
-
-                    setIsAdding(false);
-                  }}
-                />
-                {/*
-                <Button
-                  variant="tertiary"
-                  icon={PlayIcon}
-                  size="xs"
-                  label={"Test"}
-                  onClick={() => {
-                    // TODO: test
-                  }}
-                />
-                */}
-              </>
+          {agentConfiguration.userListStatus === "in-list" &&
+            variant === "gallery" && (
+              <Chip color="emerald" size="xs" label="Added" />
             )}
-            <Button
-              variant="tertiary"
-              icon={MoreIcon}
-              size="xs"
-              label={"Show Assistant"}
-              labelVisible={false}
-              onClick={() => {
-                onShowDetails();
-              }}
-            />
-          </Button.List>
+          <Button.List isWrapping={true}>{buttonsToRender}</Button.List>
         </div>
         <div className="text-sm text-element-800">
           {agentConfiguration.description}

--- a/front/pages/w/[wId]/assistant/new.tsx
+++ b/front/pages/w/[wId]/assistant/new.tsx
@@ -1,12 +1,8 @@
 import {
-  Avatar,
   BookOpenIcon,
   Button,
   ChatBubbleBottomCenterTextIcon,
-  ChatBubbleLeftRightIcon,
-  ChevronDownIcon,
-  ChevronUpIcon,
-  MoreIcon,
+  CloudArrowLeftRightIcon,
   Page,
   PlusIcon,
   Popup,
@@ -98,8 +94,6 @@ export default function AssistantNew({
   const [conversation, setConversation] = useState<ConversationType | null>(
     null
   );
-  const [showAllAgents, setShowAllAgents] = useState<boolean>(false);
-
   const { agentConfigurations, mutateAgentConfigurations } =
     useAgentConfigurations({
       workspaceId: owner.sId,
@@ -109,9 +103,7 @@ export default function AssistantNew({
   const activeAgents = agentConfigurations.filter((a) => a.status === "active");
   activeAgents.sort(compareAgentsForSort);
 
-  const displayedAgents = showAllAgents
-    ? activeAgents
-    : activeAgents.slice(0, 4);
+  const displayedAgents = activeAgents.slice(0, isBuilder ? 2 : 4);
 
   const { submit: handleSubmit } = useSubmitFunction(
     async (
@@ -244,99 +236,101 @@ export default function AssistantNew({
                 <Page.Vertical gap="md" align="left">
                   {/* FEATURED AGENTS */}
                   <Page.Vertical gap="lg" align="left">
-                    <Page.Vertical gap="xs" align="left">
-                      <Page.SectionHeader title="How can I help you today?" />
-                      {isBuilder && (
-                        <>
-                          <Page.P variant="secondary">
-                            Dust comes with multiple assistants, each with a
-                            specific set of skills.
-                            <br />
-                            Create assistants tailored for your needs.
-                          </Page.P>
-                        </>
-                      )}
-                    </Page.Vertical>
-                    <div className="flex flex-col gap-2">
-                      <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
-                        {displayedAgents.map((agent) => (
-                          <a
-                            key={agent.sId}
-                            className="cursor-pointer"
-                            onClick={() => {
-                              setSelectedAssistant({
-                                configurationId: agent.sId,
-                              });
-                              setShouldAnimateInput(true);
-                            }}
-                          >
-                            <GalleryItem
-                              agentConfiguration={agent}
+                    <Page.SectionHeader title="How can I help you today?" />
+                    <div className="flex flex-row gap-2">
+                      <div className="flex w-full flex-col gap-2">
+                        {isBuilder && (
+                          <div className="text-base font-bold text-element-800">
+                            Your assistant team
+                          </div>
+                        )}
+                        <div
+                          className={`grid grid-cols-2 gap-4 py-2 ${
+                            isBuilder ? "" : "sm:grid-cols-4"
+                          }`}
+                        >
+                          {displayedAgents.map((agent) => (
+                            <a
                               key={agent.sId}
-                              owner={owner}
-                              onShowDetails={() => {
-                                setShowDetails(agent);
+                              className="cursor-pointer"
+                              onClick={() => {
+                                setSelectedAssistant({
+                                  configurationId: agent.sId,
+                                });
+                                setShouldAnimateInput(true);
                               }}
-                              onUpdate={async () => {
-                                await mutateAgentConfigurations();
+                            >
+                              <GalleryItem
+                                agentConfiguration={agent}
+                                key={agent.sId}
+                                owner={owner}
+                                onShowDetails={() => {
+                                  setShowDetails(agent);
+                                }}
+                                onUpdate={async () => {
+                                  await mutateAgentConfigurations();
+                                }}
+                                variant="home"
+                              />
+                            </a>
+                          ))}
+                        </div>
+                        <Button.List isWrapping={true}>
+                          <div className="flex flex-wrap gap-2">
+                            <Button
+                              variant="primary"
+                              icon={BookOpenIcon}
+                              size="xs"
+                              label={"Discover more in the Assistant Gallery"}
+                              onClick={async () => {
+                                await router.push(
+                                  `/w/${owner.sId}/assistant/gallery?flow=personal_add`
+                                );
                               }}
-                              variant="home"
                             />
-                          </a>
-                        ))}
-                      </div>
-                    </div>
-                    <Button.List isWrapping={true}>
-                      <div className="flex flex-wrap gap-2">
-                        <Button
-                          variant="primary"
-                          icon={BookOpenIcon}
-                          size="xs"
-                          label={"Discover more in the Assistant Gallery"}
-                          onClick={async () => {
-                            await router.push(
-                              `/w/${owner.sId}/assistant/gallery?flow=personal_add`
-                            );
-                          }}
-                        />
-                        <StartHelperConversationButton
-                          content="@help, what can I use the assistants for?"
-                          handleSubmit={handleSubmit}
-                        />
-                        <StartHelperConversationButton
-                          content="@help, what are the limitations of assistants?"
-                          handleSubmit={handleSubmit}
-                        />
+                            <StartHelperConversationButton
+                              content="@help, what can I use the assistants for?"
+                              handleSubmit={handleSubmit}
+                            />
+                            <StartHelperConversationButton
+                              content="@help, what are the limitations of assistants?"
+                              handleSubmit={handleSubmit}
+                            />
+                          </div>
+                        </Button.List>
                       </div>
                       {isBuilder && (
-                        <>
-                          <Button
-                            variant="primary"
-                            icon={PlusIcon}
-                            label="Create an assistant"
-                            hasMagnifying={false}
-                            size="xs"
-                            onClick={() => {
-                              void router.push(
-                                `/w/${owner.sId}/builder/assistants/new`
-                              );
-                            }}
-                          />
-                          <Button
-                            variant="secondary"
-                            icon={WrenchIcon}
-                            label="Manage assistants"
-                            hasMagnifying={false}
-                            size="xs"
-                            onClick={() => {
-                              void router.push(
-                                `/w/${owner.sId}/builder/assistants`
-                              );
-                            }}
-                          />
-                        </>
+                        <div className="flex w-full flex-col gap-2">
+                          <div className="text-base font-bold text-element-800">
+                            Data Sources
+                          </div>
+                          <div className="text-xs font-normal text-element-700">
+                            Make assistants smarter by giving them access to
+                            your company’s knowledge and data.
+                          </div>
+                          <Button.List isWrapping={true}>
+                            <div className="flex flex-wrap gap-2">
+                              <Button
+                                variant="secondary"
+                                icon={CloudArrowLeftRightIcon}
+                                size="xs"
+                                label={"Manage Data Sources"}
+                                onClick={async () => {
+                                  await router.push(
+                                    `/w/${owner.sId}/builder/data-sources/managed`
+                                  );
+                                }}
+                              />
+                              <StartHelperConversationButton
+                                content="@help, tell me about Data Sources"
+                                variant="tertiary"
+                                handleSubmit={handleSubmit}
+                              />
+                            </div>
+                          </Button.List>
+                        </div>
                       )}
-                    </Button.List>
+                    </div>
                   </Page.Vertical>
                 </Page.Vertical>
               </div>
@@ -380,7 +374,7 @@ function StartHelperConversationButton({
       contentType: ContentFragmentContentType;
     }
   ) => Promise<void>;
-  variant?: "primary" | "secondary";
+  variant?: "primary" | "secondary" | "tertiary";
   size?: "sm" | "xs";
 }) {
   const contentWithMarkdownMention = content.replace(

--- a/front/pages/w/[wId]/assistant/new.tsx
+++ b/front/pages/w/[wId]/assistant/new.tsx
@@ -3,10 +3,9 @@ import {
   Button,
   ChatBubbleBottomCenterTextIcon,
   CloudArrowLeftRightIcon,
+  FolderOpenIcon,
   Page,
-  PlusIcon,
   Popup,
-  WrenchIcon,
 } from "@dust-tt/sparkle";
 import {
   AgentConfigurationType,
@@ -314,10 +313,21 @@ export default function AssistantNew({
                                 variant="secondary"
                                 icon={CloudArrowLeftRightIcon}
                                 size="xs"
-                                label={"Manage Data Sources"}
+                                label={"Manage Connections"}
                                 onClick={async () => {
                                   await router.push(
                                     `/w/${owner.sId}/builder/data-sources/managed`
+                                  );
+                                }}
+                              />
+                              <Button
+                                variant="secondary"
+                                icon={FolderOpenIcon}
+                                size="xs"
+                                label={"Manage Folders"}
+                                onClick={async () => {
+                                  await router.push(
+                                    `/w/${owner.sId}/builder/data-sources/static`
                                   );
                                 }}
                               />

--- a/front/pages/w/[wId]/assistant/new.tsx
+++ b/front/pages/w/[wId]/assistant/new.tsx
@@ -24,7 +24,7 @@ import { useRouter } from "next/router";
 import { useContext, useEffect, useState } from "react";
 
 import { AssistantDetails } from "@app/components/assistant/AssistantDetails";
-import AssistantPreview from "@app/components/assistant/AssistantPreview";
+import { AssistantPreview } from "@app/components/assistant/AssistantPreview";
 import Conversation from "@app/components/assistant/conversation/Conversation";
 import { GenerationContextProvider } from "@app/components/assistant/conversation/GenerationContextProvider";
 import {

--- a/front/pages/w/[wId]/assistant/new.tsx
+++ b/front/pages/w/[wId]/assistant/new.tsx
@@ -20,6 +20,7 @@ import {
 } from "@dust-tt/types";
 import * as t from "io-ts";
 import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import Link from "next/link";
 import { useRouter } from "next/router";
 import { useContext, useEffect, useState } from "react";
 
@@ -275,17 +276,16 @@ export default function AssistantNew({
                         </div>
                         <Button.List isWrapping={true}>
                           <div className="flex flex-wrap gap-2">
-                            <Button
-                              variant="primary"
-                              icon={BookOpenIcon}
-                              size="xs"
-                              label={"Discover more in the Assistant Gallery"}
-                              onClick={async () => {
-                                await router.push(
-                                  `/w/${owner.sId}/assistant/gallery?flow=personal_add`
-                                );
-                              }}
-                            />
+                            <Link
+                              href={`/w/${owner.sId}/assistant/gallery?flow=conversation_add`}
+                            >
+                              <Button
+                                variant="primary"
+                                icon={BookOpenIcon}
+                                size="xs"
+                                label="Discover more in the Assistant Gallery"
+                              />
+                            </Link>
                             <StartHelperConversationButton
                               content="@help, what can I use the assistants for?"
                               handleSubmit={handleSubmit}
@@ -308,28 +308,27 @@ export default function AssistantNew({
                           </div>
                           <Button.List isWrapping={true}>
                             <div className="flex flex-wrap gap-2">
-                              <Button
-                                variant="secondary"
-                                icon={CloudArrowLeftRightIcon}
-                                size="xs"
-                                label={"Manage Connections"}
-                                onClick={async () => {
-                                  await router.push(
-                                    `/w/${owner.sId}/builder/data-sources/managed`
-                                  );
-                                }}
-                              />
-                              <Button
-                                variant="secondary"
-                                icon={FolderOpenIcon}
-                                size="xs"
-                                label={"Manage Folders"}
-                                onClick={async () => {
-                                  await router.push(
-                                    `/w/${owner.sId}/builder/data-sources/static`
-                                  );
-                                }}
-                              />
+                              <Link
+                                href={`/w/${owner.sId}/builder/data-sources/managed`}
+                              >
+                                <Button
+                                  variant="secondary"
+                                  icon={CloudArrowLeftRightIcon}
+                                  size="xs"
+                                  label="Manage Connections"
+                                />
+                              </Link>
+                              <Link
+                                href={`/w/${owner.sId}/builder/data-sources/static`}
+                              >
+                                <Button
+                                  variant="secondary"
+                                  icon={FolderOpenIcon}
+                                  size="xs"
+                                  label={"Manage Folders"}
+                                />
+                              </Link>
+
                               <StartHelperConversationButton
                                 content="@help, tell me about Data Sources"
                                 variant="tertiary"

--- a/front/pages/w/[wId]/assistant/new.tsx
+++ b/front/pages/w/[wId]/assistant/new.tsx
@@ -239,7 +239,7 @@ export default function AssistantNew({
             />
           )}
           {!conversation ? (
-            <div className="align-center flex h-full">
+            <div className="flex h-full items-center">
               <div className="flex text-sm font-normal text-element-800">
                 <Page.Vertical gap="md" align="left">
                   {/* FEATURED AGENTS */}

--- a/front/pages/w/[wId]/assistant/new.tsx
+++ b/front/pages/w/[wId]/assistant/new.tsx
@@ -24,6 +24,7 @@ import { useRouter } from "next/router";
 import { useContext, useEffect, useState } from "react";
 
 import { AssistantDetails } from "@app/components/assistant/AssistantDetails";
+import AssistantPreview from "@app/components/assistant/AssistantPreview";
 import Conversation from "@app/components/assistant/conversation/Conversation";
 import { GenerationContextProvider } from "@app/components/assistant/conversation/GenerationContextProvider";
 import {
@@ -39,8 +40,6 @@ import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { useAgentConfigurations } from "@app/lib/swr";
 import type { PostConversationsResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations";
-
-import GalleryItem from "./item";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
@@ -259,7 +258,7 @@ export default function AssistantNew({
                                 setShouldAnimateInput(true);
                               }}
                             >
-                              <GalleryItem
+                              <AssistantPreview
                                 agentConfiguration={agent}
                                 key={agent.sId}
                                 owner={owner}


### PR DESCRIPTION
See https://github.com/dust-tt/dust/issues/2654

This PR implements the new conversation landing page designs from Figma.

Highlights:
- Reuses and customizes the assistant display component from the `Gallery` page, reducing duplication.
- Added a `variant` prop to allow tailored rendering of assistants across contexts.

**New conversation landing page as a member:**

![NewConversationLandingPageMember](https://github.com/dust-tt/dust/assets/7428970/17a74777-f7ad-4c77-8d1f-0c0f1100f9c0)

**New conversation landing page as an admin:**

![NewConversationLandingPageBuilderAdmin](https://github.com/dust-tt/dust/assets/7428970/93dccb5f-cc40-4e83-a271-475cf8b97e3d)

