### PR TITLE
[Connectors - Gdrive] Fix: documentContent undefined

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -361,6 +361,17 @@ async function syncOneFile(
       }
       if (typeof res.data === "string") {
         documentContent = res.data;
+      } else if (
+        typeof res.data === "object" ||
+        typeof res.data === "number" ||
+        typeof res.data === "boolean" ||
+        typeof res.data === "bigint"
+      ) {
+        // In case the contents returned by the file export matches a JS type,
+        // we need to convert it
+        //  e.g. a google presentation with just the number
+        // 1 in it, the export will return the number 1 instead of a string
+        documentContent = res.data?.toString();
       } else {
         logger.error(
           {


### PR DESCRIPTION
Related [discussion](https://dust4ai.slack.com/archives/C05F84CFP0E/p1702650848745159)

In case the contents returned by file export from gdrive api matches a JS type, we need to convert it to string

e.g. a google presentation with just the number 1 in it, the export will return the number 1 instead of a string