### PR TITLE
fix permissioning for connectorPermissions

### DIFF
--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -1425,7 +1425,7 @@ function SlackIntegration({
             }}
             expandable={false}
             fullySelected={false}
-            filterPermission="none"
+            filterPermission="write"
           />
         </Page>
       </Modal>

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -1425,6 +1425,8 @@ function SlackIntegration({
             }}
             expandable={false}
             fullySelected={false}
+            // Write are the channels we're in. Builders can get write but cannot get "none"
+            // (reserved to admins).
             filterPermission="write"
           />
         </Page>

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/permissions/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/permissions/index.ts
@@ -82,16 +82,17 @@ async function handler(
     });
   }
 
-  if (!auth.isBuilder()) {
+  if (!auth.isUser()) {
     return apiError(req, res, {
       status_code: 403,
       api_error: {
         type: "data_source_auth_error",
         message:
-          "Only the users that are `builders` for the current workspace can view the permissions of a data source.",
+          "Only users of the current workspace can view the permissions of a data source.",
       },
     });
   }
+
   const connectorsAPI = new ConnectorsAPI(logger);
 
   switch (req.method) {
@@ -113,6 +114,19 @@ async function handler(
           case "write":
             filterPermission = "write";
             break;
+        }
+      }
+
+      if (filterPermission !== "read") {
+        if (!auth.isAdmin()) {
+          return apiError(req, res, {
+            status_code: 403,
+            api_error: {
+              type: "data_source_auth_error",
+              message:
+                "Only admins of the current workspace can view non 'read' permissions of a data source.",
+            },
+          });
         }
       }
 

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/permissions/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/permissions/index.ts
@@ -2,6 +2,7 @@ import {
   ConnectorPermission,
   ConnectorResource,
   ConnectorsAPI,
+  assertNever,
 } from "@dust-tt/types";
 import { ReturnedAPIErrorType } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
@@ -117,17 +118,41 @@ async function handler(
         }
       }
 
-      if (filterPermission !== "read") {
-        if (!auth.isAdmin()) {
-          return apiError(req, res, {
-            status_code: 403,
-            api_error: {
-              type: "data_source_auth_error",
-              message:
-                "Only admins of the current workspace can view non 'read' permissions of a data source.",
-            },
-          });
-        }
+      switch (filterPermission) {
+        case "read":
+          // We let users get the read  permissions of a connector
+          // `read` is used for data source selection when creating personal assitsants
+          break;
+        case "write":
+          // We let builders get the write permissions of a connector.
+          // `write` is used for selection of default slack channel in the workspace assistant
+          // builder.
+          if (!auth.isBuilder()) {
+            return apiError(req, res, {
+              status_code: 403,
+              api_error: {
+                type: "data_source_auth_error",
+                message:
+                  "Only builders of the current workspace can view non 'write' permissions of a data source.",
+              },
+            });
+          }
+          break;
+        case undefined:
+          // Only admins can browse "all" the resources of a connector.
+          if (!auth.isAdmin()) {
+            return apiError(req, res, {
+              status_code: 403,
+              api_error: {
+                type: "data_source_auth_error",
+                message:
+                  "Only admins of the current workspace can view all permissions of a data source.",
+              },
+            });
+          }
+          break;
+        default:
+          assertNever(filterPermission);
       }
 
       const permissionsRes = await connectorsAPI.getConnectorPermissions({

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/permissions/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/permissions/index.ts
@@ -1,8 +1,8 @@
 import {
+  assertNever,
   ConnectorPermission,
   ConnectorResource,
   ConnectorsAPI,
-  assertNever,
 } from "@dust-tt/types";
 import { ReturnedAPIErrorType } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";


### PR DESCRIPTION
- allow null/undefined/non connectors permissions only to admins (allow browsing everything as an example in gdrive)
- allow write to builder (for slack integration in AssistantBuilder) cc @lasryaric
- allow read to users for data source (connection) resource selection in personal assistant

cc @dust-tt/engineering-team as this is a bit tricky please review