### PR TITLE
Poke: Fix checkbox display plan page

### DIFF
--- a/front/components/poke/plans/form.tsx
+++ b/front/components/poke/plans/form.tsx
@@ -341,7 +341,6 @@ export const Field: React.FC<FieldProps> = ({
               }
               setEditingPlan({ ...editingPlan, [fieldName]: x });
             }}
-            disabled={!isEditing || disabled}
           />
         );
       case "select":


### PR DESCRIPTION
The disable state of our checkbox does not allow us to see if it's checked or not. 
We don't need the disable state here as `onChange` function is returning immediately if we're not in edit mode. 

Before: 
<img width="525" alt="Screenshot 2023-12-18 at 12 28 32" src="https://github.com/dust-tt/dust/assets/3803406/e5d18e4c-c61c-4132-818d-6b61e1a65577">

After: 
<img width="515" alt="Screenshot 2023-12-18 at 12 28 13" src="https://github.com/dust-tt/dust/assets/3803406/6d70f796-ec72-40d9-aa35-77707f2bbc45">
