### PR TITLE
Query database agent: manage when no SQL is generated

### DIFF
--- a/front/components/assistant/conversation/DatabaseQueryAction.tsx
+++ b/front/components/assistant/conversation/DatabaseQueryAction.tsx
@@ -29,17 +29,17 @@ export default function DatabaseQueryAction({
     <>
       <div className="grid grid-cols-[auto,1fr] gap-2">
         <div className="grid-cols-auto grid items-center">
-          {!output || !query ? (
+          {!output ? (
             <div>
               <Spinner size="sm" />
             </div>
           ) : (
             <div className="text-xs font-bold text-element-600">
-              <span>Query Executed:</span>
+              <span>{query ? "Query Executed:" : "Result: "}</span>
             </div>
           )}
         </div>
-        {!!query && (
+        {!!output && (
           <div className="row-span-1 select-none">
             <div
               className="cursor-pointer"
@@ -48,7 +48,7 @@ export default function DatabaseQueryAction({
               }}
             >
               <Chip color="purple">
-                {query}
+                {query ? query : "No query generated, expand to see why"}
                 <Icon
                   visual={outputVisible ? ChevronDownIcon : ChevronRightIcon}
                   size="xs"

--- a/types/src/front/lib/actions/registry.ts
+++ b/types/src/front/lib/actions/registry.ts
@@ -138,7 +138,7 @@ export const DustProdActionRegistry = createActionRegistry({
       workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
       appId: "e0c5993d65",
       appHash:
-        "fe195a214e8c3c5a6dbb715bd772c7fc7b42d5f0874af2485215443ea278a987",
+        "f4895d867ca82023fb5933e6279e2e315164a386145fd971dc9e7293c9fc4cce",
     },
     config: {
       MODEL: {


### PR DESCRIPTION
This PR is about handling the case when we cannot generate a SQL when the question has nothing to do with the database. 

Dust app updated: https://dust.tt/w/78bda07b39/a/e0c5993d65

Prompt of the agent: 
```
You answer your team's question about the completed KYBs dataset by querying a SQL database.

You always reply in the language that the user asked their question in.
If it makes sense, output your analysis as a Markdown table (but never wrap it in a code block).
```


<img width="833" alt="Screenshot 2023-12-18 at 14 39 31" src="https://github.com/dust-tt/dust/assets/3803406/aec98b17-d696-4044-9b52-26fa2b423976">
