### PR TITLE
Handle Agent Query database action display in AssistantDetails modal

### DIFF
--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -6,9 +6,15 @@ import {
   DashIcon,
   Modal,
   PlusIcon,
+  ServerIcon,
   TrashIcon,
 } from "@dust-tt/sparkle";
-import { AgentUserListStatus, ConnectorProvider } from "@dust-tt/types";
+import {
+  AgentUserListStatus,
+  ConnectorProvider,
+  DatabaseQueryConfigurationType,
+  isDatabaseQueryConfiguration,
+} from "@dust-tt/types";
 import {
   DustAppRunConfigurationType,
   isDustAppRunConfiguration,
@@ -24,7 +30,7 @@ import ReactMarkdown from "react-markdown";
 
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
-import { useApp } from "@app/lib/swr";
+import { useApp, useDatabase } from "@app/lib/swr";
 import { PostAgentListStatusRequestBody } from "@app/pages/api/w/[wId]/members/me/agent_list_status";
 
 import { DeleteAssistantDialog } from "./AssistantActions";
@@ -80,6 +86,14 @@ export function AssistantDetails({
           </div>
           <DataSourcesSection
             dataSourceConfigurations={assistant.action.dataSources}
+          />
+        </div>
+      ) : isDatabaseQueryConfiguration(assistant.action) ? (
+        <div className="flex flex-col gap-2">
+          <div className="text-lg font-bold text-element-800">Database</div>
+          <DatabaseQuerySection
+            databaseQueryConfig={assistant.action}
+            owner={owner}
           />
         </div>
       ) : null
@@ -181,6 +195,41 @@ function DustAppSection({
           <CommandLineIcon />
         </div>
         <div>{app ? app.name : ""}</div>
+      </div>
+    </div>
+  );
+}
+
+function DatabaseQuerySection({
+  owner,
+  databaseQueryConfig,
+}: {
+  owner: WorkspaceType;
+  databaseQueryConfig: DatabaseQueryConfigurationType;
+}) {
+  const { database } = useDatabase({
+    workspaceId: owner.sId,
+    dataSourceName: databaseQueryConfig.dataSourceId,
+    databaseId: databaseQueryConfig.databaseId,
+  });
+
+  if (database) {
+    return (
+      <div className="flex flex-col gap-2">
+        <div>The following database is queried before answering:</div>
+        <div className="flex items-center gap-2 capitalize">
+          <div>
+            <ServerIcon />
+          </div>
+          <div>{database.name}</div>
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div className="flex flex-col gap-2">
+      <div>
+        No database selected, please check the configuration of this Assistant!
       </div>
     </div>
   );

--- a/front/lib/swr.ts
+++ b/front/lib/swr.ts
@@ -1,4 +1,8 @@
-import { AgentsGetViewType, DataSourceType } from "@dust-tt/types";
+import {
+  AgentsGetViewType,
+  CoreAPIDatabase,
+  DataSourceType,
+} from "@dust-tt/types";
 import { WorkspaceType } from "@dust-tt/types";
 import { ConversationMessageReactions, ConversationType } from "@dust-tt/types";
 import { AppType } from "@dust-tt/types";
@@ -531,6 +535,30 @@ export function useDatabases({
     isDatabasesLoading: !error && !data,
     isDatabasesError: error,
     mutateDatabases: mutate,
+  };
+}
+
+export function useDatabase({
+  workspaceId,
+  dataSourceName,
+  databaseId,
+}: {
+  workspaceId: string;
+  dataSourceName: string;
+  databaseId?: string;
+}) {
+  const databaseFetcher: Fetcher<{ database: CoreAPIDatabase }> = fetcher;
+
+  const { data, error, mutate } = useSWR(
+    `/api/w/${workspaceId}/data_sources/${dataSourceName}/databases/${databaseId}`,
+    databaseFetcher
+  );
+
+  return {
+    database: data ? data.database : null,
+    isDatabaseLoading: !error && !data,
+    isDatabaseError: error,
+    mutateDatabase: mutate,
   };
 }
 

--- a/front/pages/api/w/[wId]/data_sources/[name]/databases/[dId]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/databases/[dId]/index.ts
@@ -61,6 +61,30 @@ async function handler(
   }
   const coreAPI = new CoreAPI(logger);
   switch (req.method) {
+    case "GET":
+      const databaseRes = await coreAPI.getDatabase({
+        projectId: dataSource.dustAPIProjectId,
+        dataSourceName: dataSource.name,
+        databaseId,
+      });
+      if (databaseRes.isErr()) {
+        logger.error({
+          dataSourcename: dataSource.name,
+          workspaceId: owner.id,
+          error: databaseRes.error,
+        });
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "Failed to get database.",
+          },
+        });
+      }
+
+      const { database } = databaseRes.value;
+
+      return res.status(200).json({ database });
     case "DELETE":
       const deleteRes = await coreAPI.deleteDatabase({
         projectId: dataSource.dustAPIProjectId,
@@ -92,7 +116,8 @@ async function handler(
         status_code: 405,
         api_error: {
           type: "method_not_supported_error",
-          message: "The method passed is not supported, DELETE is expected.",
+          message:
+            "The method passed is not supported, GET or DELETE is expected.",
         },
       });
   }


### PR DESCRIPTION
We've recently introduced a new modal to display the config of an agent. 
This small PR handles a proper display of its action when it's set to "Database Query". 


<img width="518" alt="Screenshot 2023-12-18 at 15 48 32" src="https://github.com/dust-tt/dust/assets/3803406/5af0d141-0201-4fb7-8042-2839784bc755">
