### PR TITLE
[Eng runner] Send email after github connection deletion

### DIFF
--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -430,7 +430,8 @@ const dataSource = async (command: string, args: parseArgs.ParsedArgs) => {
       console.log(
         "\n\n...to fully scrub the customer data from our infra (GCS clean-up)."
       );
-
+      console.log(`WARNING: For Github datasource, the user may want to uninstall the app from Github
+      to revoke the authorization. If needed, send an email (cf template in lib/email.ts) `);
       return;
     }
 

--- a/front/lib/email.ts
+++ b/front/lib/email.ts
@@ -55,6 +55,22 @@ The Dust Team
   console.log("ACTIVATION KEY SENT", user.email);
 };
 
+export async function sendGithubDeletionEmail(email: string): Promise<void> {
+  const cancelMessage = {
+    from: {
+      name: "Dust team",
+      email: "team@dust.tt",
+    },
+    subject: `[Dust] Github connection deleted - important information`,
+    html: `<p>Hello from Dust,</p>
+    <p>Your Dust connection to Github was deleted, along with all the related data on Dust servers.</p>
+    <p>You can uninstall the Dust app from your Github account to revoke authorizations initially granted to Dust when you connected the Github account.</p>
+    <p>Please reply to this email if you have any questions.</p>
+    <p>The Dust team</p>`,
+  };
+  return sendEmail(email, cancelMessage);
+}
+
 /** Emails for cancelling / reactivating subscription */
 
 export async function sendCancelSubscriptionEmail(

--- a/front/lib/email.ts
+++ b/front/lib/email.ts
@@ -64,7 +64,7 @@ export async function sendGithubDeletionEmail(email: string): Promise<void> {
     subject: `[Dust] Github connection deleted - important information`,
     html: `<p>Hello from Dust,</p>
     <p>Your Dust connection to Github was deleted, along with all the related data on Dust servers.</p>
-    <p>You can uninstall the Dust app from your Github account to revoke authorizations initially granted to Dust when you connected the Github account.</p>
+    <p>You can now uninstall the Dust app from your Github account to revoke authorizations initially granted to Dust when you connected the Github account.</p>
     <p>Please reply to this email if you have any questions.</p>
     <p>The Dust team</p>`,
   };


### PR DESCRIPTION
Related [task](https://github.com/dust-tt/tasks/issues/283)

Did not add the link because it depends on whether the account is individual or org, which `front` does not know
(connectors might be able to get the info but making a route for that seems overkill)