### PR TITLE
databases_list Core api route: add total for pagination

### DIFF
--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -1848,12 +1848,15 @@ async fn databases_list(
             "Failed to list databases",
             Some(e),
         ),
-        Ok(dbs) => (
+        Ok((dbs, total)) => (
             StatusCode::OK,
             Json(APIResponse {
                 error: None,
                 response: Some(json!({
-                    "databases": dbs
+                    "databases": dbs,
+                    "offset": query.offset,
+                    "limit": query.limit,
+                    "total": total,
                 })),
             }),
         ),

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -1828,15 +1828,14 @@ impl DataSource {
         ));
 
         // Delete databases (concurrently).
-        let databases = store
+        let (databases, total) = store
             .list_databases(&self.project, &self.data_source_id, None)
             .await?;
         try_join_all(databases.iter().map(|db| db.delete(store.clone()))).await?;
 
         utils::done(&format!(
             "Deleted databases: data_source_id={} database_count={}",
-            self.data_source_id,
-            databases.len(),
+            self.data_source_id, total,
         ));
 
         // Delete data source and documents (SQL).

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -177,7 +177,7 @@ pub trait Store {
         project: &Project,
         data_source_id: &str,
         limit_offset: Option<(usize, usize)>,
-    ) -> Result<Vec<Database>>;
+    ) -> Result<(Vec<Database>, usize)>;
     async fn assign_live_sqlite_worker_to_database(
         &self,
         project: &Project,


### PR DESCRIPTION
Tiny PR to retrieve more info from the `databases_list` route in core. 
This is to be able to properly handle pagination in Front. 

<img width="421" alt="Screenshot 2023-12-19 at 10 03 50" src="https://github.com/dust-tt/dust/assets/3803406/ea0cef5e-60d7-4ac4-b1cd-90d74cb8b028">
