### PR TITLE
Implement meta prompt handling for function result in Mistral API

### DIFF
--- a/core/src/providers/mistral.rs
+++ b/core/src/providers/mistral.rs
@@ -86,7 +86,7 @@ impl TryFrom<&BaseChatMessage> for ChatMessage {
             },
             ChatMessageRole::Function => match cm.name.as_ref() {
                 Some(name) => format!("[function_result: {}] ", name), // Include space here.
-                None => "[Function Result]".to_string(),
+                None => "[function_result]".to_string(),
             },
             _ => String::from(""),
         };

--- a/core/src/providers/mistral.rs
+++ b/core/src/providers/mistral.rs
@@ -51,8 +51,7 @@ impl TryFrom<&ChatMessageRole> for MistralAIChatMessageRole {
             ChatMessageRole::Assistant => Ok(MistralAIChatMessageRole::Assistant),
             ChatMessageRole::System => Ok(MistralAIChatMessageRole::System),
             ChatMessageRole::User => Ok(MistralAIChatMessageRole::User),
-            // Handle other cases that are not supported
-            _ => Err(anyhow!("Role not supported by Mistral AI")),
+            ChatMessageRole::Function => Ok(MistralAIChatMessageRole::User),
         }
     }
 }

--- a/core/src/providers/mistral.rs
+++ b/core/src/providers/mistral.rs
@@ -80,10 +80,15 @@ impl TryFrom<&BaseChatMessage> for ChatMessage {
         let mistral_role = MistralAIChatMessageRole::try_from(&cm.role)
             .map_err(|e| anyhow!("Error converting role: {:?}", e))?;
 
-        let meta_prompt = match cm.name.as_ref() {
-            Some(name) if mistral_role == MistralAIChatMessageRole::User => {
-                format!("[user: {}] ", name) // Include space here.
-            }
+        let meta_prompt = match cm.role {
+            ChatMessageRole::User => match cm.name.as_ref() {
+                Some(name) => format!("[user: {}] ", name), // Include space here.
+                None => String::from(""),
+            },
+            ChatMessageRole::Function => match cm.name.as_ref() {
+                Some(name) => format!("[function_result: {}] ", name), // Include space here.
+                None => "[Function Result]".to_string(),
+            },
             _ => String::from(""),
         };
 


### PR DESCRIPTION
As per this comment: https://github.com/dust-tt/dust/pull/2929#pullrequestreview-1788505209

This PR updates the `try_from` logic to map `ChatMessageRole::Function` to `MistralChatMessageRole::User` as well as also handling the meta prompt for `function_result`.

