### PR TITLE
enh: catch nango 522 error

### DIFF
--- a/connectors/src/lib/temporal_monitoring.ts
+++ b/connectors/src/lib/temporal_monitoring.ts
@@ -80,11 +80,16 @@ export class ActivityInboundLogInterceptor
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (err: unknown) {
-      const maybeNangoError = err as { code?: string; status?: number };
+      const maybeNangoError = err as {
+        code?: string;
+        status?: number;
+        config?: { url?: string };
+      };
       if (
         maybeNangoError.code === "ERR_BAD_RESPONSE" &&
         maybeNangoError.status &&
-        [522, 502, 500].includes(maybeNangoError.status)
+        [522, 502, 500].includes(maybeNangoError.status) &&
+        maybeNangoError.config?.url?.includes("api.nango.dev")
       ) {
         throw {
           __is_dust_error: true,

--- a/connectors/src/lib/temporal_monitoring.ts
+++ b/connectors/src/lib/temporal_monitoring.ts
@@ -84,7 +84,7 @@ export class ActivityInboundLogInterceptor
       if (
         maybeNangoError.code === "ERR_BAD_RESPONSE" &&
         maybeNangoError.status &&
-        [522, 502].includes(maybeNangoError.status)
+        [522, 502, 500].includes(maybeNangoError.status)
       ) {
         throw {
           __is_dust_error: true,

--- a/connectors/src/lib/temporal_monitoring.ts
+++ b/connectors/src/lib/temporal_monitoring.ts
@@ -83,12 +83,13 @@ export class ActivityInboundLogInterceptor
       const maybeNangoError = err as { code?: string; status?: number };
       if (
         maybeNangoError.code === "ERR_BAD_RESPONSE" &&
-        maybeNangoError.status === 522
+        maybeNangoError.status &&
+        [522, 502].includes(maybeNangoError.status)
       ) {
         throw {
           __is_dust_error: true,
-          message: "Got 522 Bad Response from Nango",
-          type: "nango_522_bad_response",
+          message: `Got ${maybeNangoError.status} Bad Response from Nango`,
+          type: "nango_5xx_bad_response",
         };
       }
 


### PR DESCRIPTION
- we don't want unhandled activity errors due to nango transient errors
- if the error is not transient, the "stuck workflow" monitor will fire