### PR TITLE
enh: catch all 500,502,522

### DIFF
--- a/connectors/src/lib/temporal_monitoring.ts
+++ b/connectors/src/lib/temporal_monitoring.ts
@@ -90,20 +90,17 @@ export class ActivityInboundLogInterceptor
         maybeNangoError.status &&
         [522, 502, 500].includes(maybeNangoError.status)
       ) {
-        if (maybeNangoError.config?.url?.includes("nango")) {
-          throw {
-            __is_dust_error: true,
-            message: `Got ${maybeNangoError.status} Bad Response from Nango`,
-            type: "nango_5xx_bad_response",
-          };
-        } else {
-          this.logger.info(
-            {
-              raw_json_error: JSON.stringify(maybeNangoError, null, 2),
-            },
-            "Got 5xx Bad Response from external API"
-          );
-        }
+        this.logger.info(
+          {
+            raw_json_error: JSON.stringify(maybeNangoError, null, 2),
+          },
+          "Got 5xx Bad Response from external API"
+        );
+        throw {
+          __is_dust_error: true,
+          message: `Got ${maybeNangoError.status} Bad Response from Nango`,
+          type: "nango_5xx_bad_response",
+        };
       }
 
       if (err instanceof ExternalOauthTokenError) {


### PR DESCRIPTION
Catching Nango 500ish errors is currently broken, because `maybeNangoError.config?.url?.includes("nango")` is always false.
This commit:
- re-enables catching nango errors by removing this condition
- as a result, **all**  top level 500, 502, 522 errors are being caught
- that's not a big issue, as we have the "stuck workflows" monitor that will still fire after repeated failures of the same activity (even for known errors)

I have added a log of the full stringified error to better understand what we have access to and how I can better narrow it down to Nango errors only.


@spolu FYI