### PR TITLE
Remove Mistral_7B leftovers

### DIFF
--- a/front/pages/index.tsx
+++ b/front/pages/index.tsx
@@ -484,7 +484,7 @@ export default function Home({
               <ReactiveIcon colorHEX="#D4A480" tooltipLabel="Anthropic Claude">
                 <AnthropicWhiteLogo />
               </ReactiveIcon>
-              <ReactiveIcon colorHEX="#1A1C20" tooltipLabel="Mistral 7B">
+              <ReactiveIcon colorHEX="#1A1C20" tooltipLabel="Mistral 8x7B">
                 <MistralLogo />
               </ReactiveIcon>
               <ReactiveIcon colorHEX="#1E3A8A" tooltipLabel="Microsoft Azure">

--- a/front/pages/index.tsx
+++ b/front/pages/index.tsx
@@ -484,7 +484,7 @@ export default function Home({
               <ReactiveIcon colorHEX="#D4A480" tooltipLabel="Anthropic Claude">
                 <AnthropicWhiteLogo />
               </ReactiveIcon>
-              <ReactiveIcon colorHEX="#1A1C20" tooltipLabel="Mistral 8x7B">
+              <ReactiveIcon colorHEX="#1A1C20" tooltipLabel="Mistral">
                 <MistralLogo />
               </ReactiveIcon>
               <ReactiveIcon colorHEX="#1E3A8A" tooltipLabel="Microsoft Azure">

--- a/types/src/front/lib/assistant.ts
+++ b/types/src/front/lib/assistant.ts
@@ -67,19 +67,8 @@ export const CLAUDE_INSTANT_DEFAULT_MODEL_CONFIG = {
   largeModel: false,
 } as const;
 
-export const MISTRAL_7B_INSTRUCT_MODEL_ID = "mistral_7B_instruct" as const;
 export const MISTRAL_MEDIUM_MODEL_ID = "mistral-medium" as const;
 export const MISTRAL_SMALL_MODEL_ID = "mistral-small" as const;
-
-// TODO(flav) Delete.
-export const MISTRAL_7B_DEFAULT_MODEL_CONFIG = {
-  providerId: "textsynth",
-  modelId: MISTRAL_7B_INSTRUCT_MODEL_ID,
-  displayName: "Mistral 7B",
-  contextSize: 8192,
-  recommendedTopK: 16,
-  largeModel: false,
-} as const;
 
 export const MISTRAL_MEDIUM_MODEL_CONFIG = {
   providerId: "mistral",
@@ -115,7 +104,6 @@ export const SUPPORTED_MODEL_CONFIGS = [
   GPT_4_TURBO_MODEL_CONFIG,
   CLAUDE_DEFAULT_MODEL_CONFIG,
   CLAUDE_INSTANT_DEFAULT_MODEL_CONFIG,
-  MISTRAL_7B_DEFAULT_MODEL_CONFIG,
   MISTRAL_MEDIUM_MODEL_CONFIG,
   MISTRAL_SMALL_MODEL_CONFIG,
   GEMINI_PRO_DEFAULT_MODEL_CONFIG,


### PR DESCRIPTION
This PR cleans up any remaining code associated with the outdated `Mistral_7B` model in the assistant context. TextSynth will continue to be supported as a service provider, as we currently offer a range of models via this platform.

