### PR TITLE
[Ahuna] AssistantBuilder doesn't load agentConfigs, uses names route

### DIFF
--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -83,8 +83,11 @@ const usedModelConfigs = [
 
 // Avatar URLs
 const BASE_URL = "https://dust.tt/";
-const buildAvatarUrl = (basePath: string, fileName: string) =>
-  `${BASE_URL}${basePath}${fileName}`;
+const buildAvatarUrl = (basePath: string, fileName: string) => {
+  const url = new URL(BASE_URL);
+  url.pathname = `${basePath}${fileName}`;
+  return url.toString();
+};
 const DROID_AVATAR_URLS = DROID_AVATAR_FILES.map((f) =>
   buildAvatarUrl(DROID_AVATARS_BASE_PATH, f)
 );

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -69,10 +69,7 @@ import { getSupportedModelConfig } from "@app/lib/assistant";
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 import { isDevelopmentOrDustWorkspace } from "@app/lib/development";
 import { FREE_TEST_PLAN_CODE } from "@app/lib/plans/plan_codes";
-import {
-  useAgentConfigurations,
-  useSlackChannelsLinkedWithAgent,
-} from "@app/lib/swr";
+import { useAgentNames, useSlackChannelsLinkedWithAgent } from "@app/lib/swr";
 import { classNames } from "@app/lib/utils";
 
 const usedModelConfigs = [
@@ -83,6 +80,17 @@ const usedModelConfigs = [
   MISTRAL_SMALL_MODEL_CONFIG,
   GEMINI_PRO_DEFAULT_MODEL_CONFIG,
 ];
+
+// Avatar URLs
+const BASE_URL = "https://dust.tt/";
+const buildAvatarUrl = (basePath: string, fileName: string) =>
+  `${BASE_URL}${basePath}${fileName}`;
+const DROID_AVATAR_URLS = DROID_AVATAR_FILES.map((f) =>
+  buildAvatarUrl(DROID_AVATARS_BASE_PATH, f)
+);
+const SPIRIT_AVATAR_URLS = SPIRIT_AVATAR_FILES.map((f) =>
+  buildAvatarUrl(SPIRIT_AVATARS_BASE_PATH, f)
+);
 
 // Actions
 
@@ -316,77 +324,23 @@ export default function AssistantBuilder({
     string | null
   >(null);
   const [timeFrameError, setTimeFrameError] = useState<string | null>(null);
-  const { agentConfigurations } = useAgentConfigurations({
+  const { agentNames } = useAgentNames({
     workspaceId: owner.sId,
-    agentsGetView: "all",
   });
 
-  const [droidAvatarUrls, setDroidAvatarUrls] = useState<
-    { available: boolean; url: string }[]
-  >([]);
-  const [spiritAvatarUrls, setSpiritAvatarUrls] = useState<
-    { available: boolean; url: string }[]
-  >([]);
   const [isAvatarModalOpen, setIsAvatarModalOpen] = useState(false);
 
   useEffect(() => {
-    if (agentConfigurations?.length) {
-      const BASE_URL = "https://dust.tt/";
-      const buildAvatarUrl = (basePath: string, fileName: string) =>
-        `${BASE_URL}${basePath}${fileName}`;
-
-      const allDroids = DROID_AVATAR_FILES.map((f) =>
-        buildAvatarUrl(DROID_AVATARS_BASE_PATH, f)
-      );
-      const allSpirits = SPIRIT_AVATAR_FILES.map((f) =>
-        buildAvatarUrl(SPIRIT_AVATARS_BASE_PATH, f)
-      );
-
-      const usedAvatarFiles = new Set(
-        agentConfigurations.map((a) => a.pictureUrl.split("/").pop())
-      );
-
-      const availableAvatars = (avatarFiles: string[], basePath: string) =>
-        avatarFiles
-          .filter((f) => !usedAvatarFiles.has(f))
-          .map((f) => buildAvatarUrl(basePath, f));
-
-      let availableUrls = [
-        ...availableAvatars(DROID_AVATAR_FILES, DROID_AVATARS_BASE_PATH),
-        ...availableAvatars(SPIRIT_AVATAR_FILES, SPIRIT_AVATARS_BASE_PATH),
-      ];
-
-      // TODO(@fontanierh): figure out a real solution for avatar exhaustion
-      availableUrls = availableUrls.length
-        ? availableUrls
-        : [...allDroids, ...allSpirits];
-
-      setDroidAvatarUrls(
-        DROID_AVATAR_FILES.map((f) => ({
-          url: `https://dust.tt/${DROID_AVATARS_BASE_PATH}${f}`,
-          available: !usedAvatarFiles.has(f),
-        }))
-      );
-      setSpiritAvatarUrls(
-        SPIRIT_AVATAR_FILES.map((f) => ({
-          url: `https://dust.tt/${SPIRIT_AVATARS_BASE_PATH}${f}`,
-          available: !usedAvatarFiles.has(f),
-        }))
-      );
-      // Only set a random avatar if one isn't already set
-      if (!builderState.avatarUrl) {
-        setBuilderState((state) => ({
-          ...state,
-          avatarUrl:
-            availableUrls[Math.floor(Math.random() * availableUrls.length)],
-        }));
-      }
+    const availableUrls = [...DROID_AVATAR_URLS, ...SPIRIT_AVATAR_URLS];
+    // Only set a random avatar if one isn't already set
+    if (!builderState.avatarUrl) {
+      setBuilderState((state) => ({
+        ...state,
+        avatarUrl:
+          availableUrls[Math.floor(Math.random() * availableUrls.length)],
+      }));
     }
-  }, [
-    agentConfigurations?.length,
-    agentConfigurations,
-    builderState.avatarUrl,
-  ]);
+  }, [builderState.avatarUrl]);
 
   // This state stores the slack channels that should have the current agent as default.
   const [selectedSlackChannels, setSelectedSlackChannels] = useState<
@@ -437,15 +391,14 @@ export default function AssistantBuilder({
 
   const assistantHandleIsAvailable = useCallback(
     (handle: string) => {
-      return !agentConfigurations.some(
-        (agentConfiguration) =>
-          agentConfiguration.name.toLowerCase() ===
-            removeLeadingAt(handle).toLowerCase() &&
+      return !agentNames.some(
+        (name) =>
+          name.toLowerCase() === removeLeadingAt(handle).toLowerCase() &&
           initialBuilderState?.handle.toLowerCase() !==
             removeLeadingAt(handle).toLowerCase()
       );
     },
-    [agentConfigurations, initialBuilderState?.handle]
+    [agentNames, initialBuilderState?.handle]
   );
 
   const configuredDataSourceCount = Object.keys(
@@ -787,8 +740,8 @@ export default function AssistantBuilder({
             avatarUrl,
           }));
         }}
-        droidAvatarUrls={droidAvatarUrls}
-        spiritAvatarUrls={spiritAvatarUrls}
+        droidAvatarUrls={DROID_AVATAR_URLS}
+        spiritAvatarUrls={SPIRIT_AVATAR_URLS}
       />
       <AppLayout
         subscription={subscription}

--- a/front/components/assistant_builder/AssistantBuilderAvatarPicker.tsx
+++ b/front/components/assistant_builder/AssistantBuilderAvatarPicker.tsx
@@ -35,8 +35,8 @@ export function AvatarPicker({
   isOpen: boolean;
   setOpen: (isOpen: boolean) => void;
   onPick: (avatar: string) => void;
-  droidAvatarUrls: { available: boolean; url: string }[];
-  spiritAvatarUrls: { available: boolean; url: string }[];
+  droidAvatarUrls: string[];
+  spiritAvatarUrls: string[];
 }) {
   const [isUploadingAvatar, setIsUploadingAvatar] = useState(false);
   const [currentTab, setCurrentTab] = useState<"droids" | "spirits" | "upload">(
@@ -192,48 +192,32 @@ export function AvatarPicker({
         </div>
         {currentTab === "droids" && (
           <div className="grid grid-cols-4 gap-4 pt-8 lg:grid-cols-8">
-            {droidAvatarUrls.map(({ available, url }) => (
+            {droidAvatarUrls.map((url) => (
               <div
                 key={url}
-                className={classNames(
-                  available ? "cursor-pointer" : "opacity-30"
-                )}
+                className="cursor-pointer"
                 onClick={() => {
-                  if (available) {
-                    onPick(url);
-                    onClose();
-                  }
+                  onPick(url);
+                  onClose();
                 }}
               >
-                <Avatar
-                  size="auto"
-                  visual={<img src={url} />}
-                  clickable={available}
-                />
+                <Avatar size="auto" visual={<img src={url} />} />
               </div>
             ))}
           </div>
         )}
         {currentTab === "spirits" && (
           <div className="grid grid-cols-4 gap-4 pt-8 lg:grid-cols-8">
-            {spiritAvatarUrls.map(({ available, url }) => (
+            {spiritAvatarUrls.map((url) => (
               <div
                 key={url}
-                className={classNames(
-                  available ? "cursor-pointer" : "opacity-30"
-                )}
+                className="cursor-pointer"
                 onClick={() => {
-                  if (available) {
-                    onPick(url);
-                    onClose();
-                  }
+                  onPick(url);
+                  onClose();
                 }}
               >
-                <Avatar
-                  size="auto"
-                  visual={<img src={url} />}
-                  clickable={available}
-                />
+                <Avatar size="auto" visual={<img src={url} />} />
               </div>
             ))}
           </div>

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -556,7 +556,6 @@ export async function getAgentConfigurations(
 
   throw new Error(`Unknown agentsGetView ${agentsGetView}`);
 }
-
 async function getConversationMentions(
   conversationId: string
 ): Promise<AgentMention[]> {
@@ -587,6 +586,29 @@ async function getConversationMentions(
   return mentions.map((m) => ({
     configurationId: m.agentConfigurationId as string,
   }));
+}
+
+/**
+ *  Return names of all agents in the workspace, to avoid name collisions.
+ */
+export async function getAgentNames(auth: Authenticator): Promise<string[]> {
+  const owner = auth.workspace();
+  if (!owner) {
+    throw new Error("Unexpected `auth` without `workspace`.");
+  }
+  if (!auth.isUser()) {
+    throw new Error("Unexpected `auth` from outside workspace.");
+  }
+
+  const agents = await AgentConfiguration.findAll({
+    where: {
+      workspaceId: owner.id,
+      status: "active",
+    },
+    attributes: ["name"],
+  });
+
+  return agents.map((a) => a.name);
 }
 
 /**

--- a/front/lib/swr.ts
+++ b/front/lib/swr.ts
@@ -20,6 +20,7 @@ import { GetRunsResponseBody } from "@app/pages/api/w/[wId]/apps/[aId]/runs";
 import { GetRunBlockResponseBody } from "@app/pages/api/w/[wId]/apps/[aId]/runs/[runId]/blocks/[type]/[name]";
 import { GetRunStatusResponseBody } from "@app/pages/api/w/[wId]/apps/[aId]/runs/[runId]/status";
 import { GetAgentConfigurationsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
+import { GetAgentNamesResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/names";
 import { GetDataSourcesResponseBody } from "@app/pages/api/w/[wId]/data_sources";
 import { GetDocumentsResponseBody } from "@app/pages/api/w/[wId]/data_sources/[name]/documents";
 import { GetOrPostBotEnabledResponseBody } from "@app/pages/api/w/[wId]/data_sources/[name]/managed/bot_enabled";
@@ -586,5 +587,20 @@ export function useApp({
     isAppLoading: !error && !data,
     isAppError: error,
     mutateApp: mutate,
+  };
+}
+
+export function useAgentNames({ workspaceId }: { workspaceId: string }) {
+  const agentNamesFetcher: Fetcher<GetAgentNamesResponseBody> = fetcher;
+  const { data, error, mutate } = useSWR(
+    `/api/w/${workspaceId}/assistant/agent_configurations/names`,
+    agentNamesFetcher
+  );
+
+  return {
+    agentNames: data ? data.agentNames : [],
+    isAgentNamesLoading: !error && !data,
+    isAgentNamesError: error,
+    mutateAgentNames: mutate,
   };
 }

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -157,11 +157,11 @@ async function handler(
 export default withLogging(handler);
 
 /**
- * Create Or Upgrade Agent Configuration
- * If an agentConfigurationId is provided, it will create a new version of the agent configuration
- * with the same agentConfigurationId.
- * If no agentConfigurationId is provided, it will create a new agent configuration.
- * In both cases, it will return the new agent configuration.
+ * Create Or Upgrade Agent Configuration If an agentConfigurationId is provided,
+ * it will create a new version of the agent configuration with the same
+ * agentConfigurationId. If no agentConfigurationId is provided, it will create
+ * a new agent configuration. In both cases, it will return the new agent
+ * configuration.
  **/
 export async function createOrUpgradeAgentConfiguration(
   auth: Authenticator,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/names.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/names.ts
@@ -1,0 +1,57 @@
+import { ReturnedAPIErrorType } from "@dust-tt/types";
+import { NextApiRequest, NextApiResponse } from "next";
+
+import { getAgentNames } from "@app/lib/api/assistant/configuration";
+import { Authenticator, getSession } from "@app/lib/auth";
+import { apiError, withLogging } from "@app/logger/withlogging";
+
+export type GetAgentNamesResponseBody = {
+  agentNames: string[];
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<GetAgentNamesResponseBody | ReturnedAPIErrorType | void>
+): Promise<void> {
+  const session = await getSession(req, res);
+  const auth = await Authenticator.fromSession(
+    session,
+    req.query.wId as string
+  );
+  const owner = auth.workspace();
+  if (!owner) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "The workspace you're trying to modify was not found.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET":
+      if (!auth.isUser()) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "app_auth_error",
+            message: "Only the workspace users can see Assistants.",
+          },
+        });
+      }
+      const agentNames = await getAgentNames(auth);
+      return res.status(200).json({ agentNames });
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withLogging(handler);


### PR DESCRIPTION
Related [task](https://github.com/dust-tt/dust/issues/2970)

Side-effect: allows reuse of already used avatars for agents