### PR TITLE
enh(infra) add readiness probe for connectors and front

### DIFF
--- a/k8s/deployments/connectors-deployment.yaml
+++ b/k8s/deployments/connectors-deployment.yaml
@@ -24,6 +24,12 @@ spec:
           imagePullPolicy: Always
           ports:
             - containerPort: 3002
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 3002
+            initialDelaySeconds: 5
+            periodSeconds: 5
 
           envFrom:
             - configMapRef:

--- a/k8s/deployments/front-deployment.yaml
+++ b/k8s/deployments/front-deployment.yaml
@@ -23,6 +23,12 @@ spec:
           imagePullPolicy: Always
           ports:
             - containerPort: 3000
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 5
+            periodSeconds: 5
 
           envFrom:
             - configMapRef:


### PR DESCRIPTION
Connnector deploys sometimes cause a (very small number) of API errors. This is quite possibly related to kube routing traffic to pods that aren't ready yet.
We had the same issue previously with `core`, and we solved it using a `readinessProbe` on the deployment (i.e define a healthcheck endpoint and have kube ping it until it replies 200 before it starts receiving traffic)