### PR TITLE
front: new paid data sources to dedicated-1

### DIFF
--- a/front/pages/api/w/[wId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/index.ts
@@ -142,7 +142,7 @@ async function handler(
           qdrant_config:
             plan.code !== FREE_TEST_PLAN_CODE && NODE_ENV === "production"
               ? {
-                  cluster: "dedicated-0",
+                  cluster: "dedicated-1",
                   shadow_write_cluster: null,
                 }
               : {

--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -198,7 +198,7 @@ async function handler(
           qdrant_config:
             NODE_ENV === "production"
               ? {
-                  cluster: "dedicated-0",
+                  cluster: "dedicated-1",
                   shadow_write_cluster: null,
                 }
               : {

--- a/types/src/core/data_source.ts
+++ b/types/src/core/data_source.ts
@@ -1,4 +1,4 @@
-export type QdrantCluster = "main-0" | "dedicated-0";
+export type QdrantCluster = "main-0" | "dedicated-0" | "dedicated-1";
 
 export type CoreAPIDataSourceConfig = {
   provider_id: string;


### PR DESCRIPTION
Fixes: https://github.com/dust-tt/dust/issues/3021

All new data sources from paid customers will be created on `dedicated-1`

Deploy:
- Migrate our collections there 
- Check that everything works
- Deploy front

Blocked on: https://github.com/dust-tt/dust/pull/3019