### PR TITLE
GitHub code support: Move issues/discussions to separate parents in github connectors

### DIFF
--- a/connectors/migrations/20240102_github_add_issues_discussions_parents.ts
+++ b/connectors/migrations/20240102_github_add_issues_discussions_parents.ts
@@ -1,0 +1,99 @@
+import {
+  getDiscussionDocumentId,
+  getIssueDocumentId,
+} from "@connectors/connectors/github/temporal/activities";
+import { updateDocumentParentsField } from "@connectors/lib/data_sources";
+import { Connector } from "@connectors/lib/models";
+import { GithubDiscussion, GithubIssue } from "@connectors/lib/models/github";
+
+const { LIVE = null } = process.env;
+
+async function main() {
+  const connectors = await Connector.findAll({
+    where: {
+      type: "github",
+    },
+  });
+
+  for (const connector of connectors) {
+    console.log(`>> Updating connector: ${connector.id}`);
+    await updateParents(connector);
+  }
+}
+
+const CHUNK_SIZE = 32;
+
+async function updateParents(connector: Connector) {
+  const discussions = await GithubDiscussion.findAll({
+    where: {
+      connectorId: connector.id,
+    },
+  });
+
+  const discussionChunks = [];
+  for (let i = 0; i < discussions.length; i += CHUNK_SIZE) {
+    discussionChunks.push(discussions.slice(i, i + CHUNK_SIZE));
+  }
+
+  for (const chunk of discussionChunks) {
+    await Promise.all(
+      chunk.map(async (d) => {
+        const documentId = getDiscussionDocumentId(
+          d.repoId,
+          d.discussionNumber
+        );
+        const parents = [documentId, `${d.repoId}-discussions`, d.repoId];
+        if (LIVE) {
+          await updateDocumentParentsField({
+            dataSourceConfig: connector,
+            documentId,
+            parents,
+          });
+          console.log(`Updated discussion ${documentId} with: ${parents}`);
+        } else {
+          console.log(`Would update ${documentId} with: ${parents}`);
+        }
+      })
+    );
+  }
+
+  const issues = await GithubIssue.findAll({
+    where: {
+      connectorId: connector.id,
+    },
+  });
+
+  const issueChunks = [];
+  for (let i = 0; i < issues.length; i += CHUNK_SIZE) {
+    issueChunks.push(issues.slice(i, i + CHUNK_SIZE));
+  }
+
+  for (const chunk of issueChunks) {
+    await Promise.all(
+      chunk.map(async (i) => {
+        const documentId = getIssueDocumentId(i.repoId, i.issueNumber);
+        const parents = [documentId, `${i.repoId}-issues`, i.repoId];
+        if (LIVE) {
+          await updateDocumentParentsField({
+            dataSourceConfig: connector,
+            documentId,
+            parents,
+          });
+          console.log(`Updated issue ${documentId} with: ${parents}`);
+        } else {
+          console.log(`Would update ${documentId} with: ${parents}`);
+        }
+      })
+    );
+  }
+}
+
+main()
+  .then(() => {
+    console.log("Done");
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/connectors/src/connectors/github/lib/github_api.ts
+++ b/connectors/src/connectors/github/lib/github_api.ts
@@ -124,12 +124,9 @@ export async function getRepo(
 ): Promise<GithubRepo> {
   const octokit = await getOctokit(installationId);
 
-  const { data: r } = await octokit.request(
-    `GET /repositories/:repo_id`,
-    {
-      repo_id: repoId,
-    }
-  );
+  const { data: r } = await octokit.request(`GET /repositories/:repo_id`, {
+    repo_id: repoId,
+  });
 
   return {
     id: r.id,

--- a/connectors/src/connectors/github/lib/github_api.ts
+++ b/connectors/src/connectors/github/lib/github_api.ts
@@ -118,6 +118,34 @@ export async function getReposPage(
   }));
 }
 
+export async function getRepo(
+  installationId: string,
+  repoId: number
+): Promise<GithubRepo> {
+  const octokit = await getOctokit(installationId);
+
+  const { data: r } = await octokit.request(
+    `GET /repositories/:repo_id`,
+    {
+      repo_id: repoId,
+    }
+  );
+
+  return {
+    id: r.id,
+    name: r.name,
+    private: r.private,
+    url: r.html_url,
+    createdAt: r.created_at ? new Date(r.created_at) : null,
+    updatedAt: r.updated_at ? new Date(r.updated_at) : null,
+    description: r.description,
+    owner: {
+      id: r.owner.id,
+      login: r.owner.login,
+    },
+  };
+}
+
 export async function getRepoIssuesPage(
   installationId: string,
   repoName: string,
@@ -326,7 +354,7 @@ export async function getDiscussionCommentsPage(
           }
         }
       }
-    } 
+    }
     `,
     {
       owner: login,

--- a/connectors/src/connectors/github/temporal/activities.ts
+++ b/connectors/src/connectors/github/temporal/activities.ts
@@ -221,6 +221,7 @@ export async function githubUpsertIssueActivity(
     // convention to use the external id string.
     parents: [
       getIssueDocumentId(repoId.toString(), issue.number),
+      `${repoId}-issues`,
       repoId.toString(),
     ],
     retries: 3,
@@ -399,6 +400,7 @@ export async function githubUpsertDiscussionActivity(
     // convention to use the external id string.
     parents: [
       getDiscussionDocumentId(repoId.toString(), discussionNumber),
+      `${repoId}-discussions`,
       repoId.toString(),
     ],
     retries: 3,

--- a/connectors/src/connectors/github/temporal/activities.ts
+++ b/connectors/src/connectors/github/temporal/activities.ts
@@ -219,11 +219,7 @@ export async function githubUpsertIssueActivity(
     // Therefore as a special case we use getIssueDocumentId() to get a parent string
     // The repo id from github is globally unique so used as-is, as per
     // convention to use the external id string.
-    parents: [
-      getIssueDocumentId(repoId.toString(), issue.number),
-      `${repoId}-issues`,
-      repoId.toString(),
-    ],
+    parents: [documentId, `${repoId}-issues`, repoId.toString()],
     retries: 3,
     delayBetweenRetriesMs: 500,
     loggerArgs: { ...loggerArgs, provider: "github" },
@@ -398,11 +394,7 @@ export async function githubUpsertDiscussionActivity(
     // as a special case we use getDiscussionDocumentId() to get a parent string
     // The repo id from github is globally unique so used as-is, as per
     // convention to use the external id string.
-    parents: [
-      getDiscussionDocumentId(repoId.toString(), discussionNumber),
-      `${repoId}-discussions`,
-      repoId.toString(),
-    ],
+    parents: [documentId, `${repoId}-discussions`, repoId.toString()],
     retries: 3,
     delayBetweenRetriesMs: 500,
     loggerArgs: { ...loggerArgs, provider: "github" },

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -483,7 +483,7 @@ export async function retrieveSlackConnectorPermissions({
     internalId: ch.slackChannelId,
     parentInternalId: null,
     type: "channel",
-    title: ch.slackChannelName,
+    title: `#${ch.slackChannelName}`,
     sourceUrl: `https://app.slack.com/client/${slackConfig.slackTeamId}/${ch.slackChannelId}`,
     expandable: false,
     permission: ch.permission,

--- a/connectors/src/lib/models/github.ts
+++ b/connectors/src/lib/models/github.ts
@@ -146,7 +146,7 @@ GithubDiscussion.init(
     indexes: [
       { fields: ["repoId", "discussionNumber", "connectorId"], unique: true },
       { fields: ["connectorId"] },
-      { fields: ["repoId"] },
+      { fields: ["repoId", "updatedAt"] },
     ],
     modelName: "github_discussions",
   }

--- a/front/components/ConnectorPermissionsTree.tsx
+++ b/front/components/ConnectorPermissionsTree.tsx
@@ -95,7 +95,6 @@ function PermissionTreeChildren({
   return (
     <Tree isLoading={isResourcesLoading}>
       {resources.map((r, i) => {
-        const titlePrefix = r.type === "channel" ? "#" : "";
         return (
           <Tree.Item
             key={r.internalId}
@@ -107,7 +106,7 @@ function PermissionTreeChildren({
               }));
             }}
             type={r.expandable ? "node" : "leaf"}
-            label={`${titlePrefix}${r.title}`}
+            label={r.title}
             variant={r.type}
             className="whitespace-nowrap"
             checkbox={

--- a/front/components/DataSourceResourceSelectorTree.tsx
+++ b/front/components/DataSourceResourceSelectorTree.tsx
@@ -149,7 +149,6 @@ function DataSourceResourceSelectorChildren({
         <div className="flex-1 space-y-1">
           {resources.map((r) => {
             const IconComponent = getIconForType(r.type);
-            const titlePrefix = r.type === "channel" ? "#" : "";
             const checkStatus = getCheckStatus(r.internalId);
             return (
               <div key={r.internalId}>
@@ -189,7 +188,9 @@ function DataSourceResourceSelectorChildren({
                   <div>
                     <IconComponent className="h-5 w-5 text-slate-300" />
                   </div>
-                  <span className="ml-2 line-clamp-1 text-sm font-medium text-element-900">{`${titlePrefix}${r.title}`}</span>
+                  <span className="ml-2 line-clamp-1 text-sm font-medium text-element-900">
+                    {r.title}
+                  </span>
                   <div className="ml-32 flex-grow">
                     <Checkbox
                       variant="checkable"

--- a/front/lib/connector_providers.ts
+++ b/front/lib/connector_providers.ts
@@ -64,7 +64,7 @@ export const CONNECTOR_CONFIGURATIONS: Record<
     limitations:
       "Dust only gathers data from issues, discussions and top-level pull requests (but not in-code comments in pull requests, nor the actual source code or other Github data).",
     logoComponent: GithubLogo,
-    isNested: false,
+    isNested: true,
   },
   intercom: {
     name: "Intercom",


### PR DESCRIPTION
Fixes #3026 

- Add a new parent to Issues and Discussions in Github connector: Issues and Discussions respectively
- Migration to add this extra parent to all existing Issues and Discussions
- Adapt getConnectorPermission for Github to expose Issues and Discussions

The motivation is to be able to add a "Code" sub-"folder" to each repository.

Deploy:
- Deploy connectors
- Run init_db on connectors (index addition)
- Run migration
- Deploy front

Because we run the migration before deploying front, the isNested will be set to false for Github in the assistant data source selection, preventing someone from selecting Issues or Discussions, which mean the interim during which the migration is run is guaranteed to have no impact on users.

![Screenshot from 2024-01-02 17-12-26](https://github.com/dust-tt/dust/assets/15067/8214c928-3870-4689-81bf-f032a6ca89f1)
