### PR TITLE
Add subElement in Sparkle `ContextItem`

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.55",
+  "version": "0.2.56",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.55",
+      "version": "0.2.56",
       "license": "ISC",
       "dependencies": {
         "@headlessui/react": "^1.7.17"

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.55",
+  "version": "0.2.56",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/components/ContextItem.tsx
+++ b/sparkle/src/components/ContextItem.tsx
@@ -5,19 +5,21 @@ import { classNames } from "@sparkle/lib/utils";
 import { Icon } from "./Icon";
 
 type ContextItemProps = {
-  title: string;
-  visual: ReactNode;
   action?: ReactNode;
   children?: ReactNode;
   hasSeparator?: boolean;
+  subElement?: ReactNode;
+  title: ReactNode;
+  visual: ReactNode;
 };
 
 export function ContextItem({
-  title,
-  visual,
   action,
   children,
   hasSeparator = true,
+  subElement,
+  title,
+  visual,
 }: ContextItemProps) {
   return (
     <div
@@ -25,13 +27,17 @@ export function ContextItem({
         hasSeparator ? "s-border-b s-border-structure-200" : "",
         "s-flex s-w-full s-flex-col"
       )}
-      aria-label={title}
     >
       <div className="s-flex s-flex-row s-gap-3 s-px-2 s-py-4">
         <div className="s-flex">{visual}</div>
         <div className="s-flex s-grow s-flex-col s-gap-1">
-          <div className="s-text-normal s-flex  s-flex-col s-justify-center s-font-semibold">
-            {title}
+          <div className="s-flex s-grow s-flex-row s-gap-1">
+            <div className="s-text-normal s-flex s-flex-col s-justify-center s-font-semibold">
+              {title}
+            </div>
+            <div className="s-flex s-items-center s-text-element-600">
+              {subElement}
+            </div>
           </div>
           <div className="-s-mt-1">{children}</div>
         </div>

--- a/sparkle/src/components/ContextItem.tsx
+++ b/sparkle/src/components/ContextItem.tsx
@@ -31,7 +31,7 @@ export function ContextItem({
       <div className="s-flex s-flex-row s-gap-3 s-px-2 s-py-4">
         <div className="s-flex">{visual}</div>
         <div className="s-flex s-grow s-flex-col s-gap-1">
-          <div className="s-flex s-grow s-flex-row s-gap-1">
+          <div className="s-flex s-grow s-flex-row">
             <div className="s-text-normal s-flex s-flex-col s-justify-center s-font-semibold">
               {title}
             </div>

--- a/sparkle/src/stories/ContextItem.stories.tsx
+++ b/sparkle/src/stories/ContextItem.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta } from "@storybook/react";
 import React from "react";
 
+import { User } from "@sparkle/icons/solid";
 import { Drive, Github, Notion, Slack } from "@sparkle/logo/platforms";
 
 import {
@@ -10,6 +11,7 @@ import {
   CloudArrowDownIcon,
   Cog6ToothIcon,
   ContextItem,
+  Icon,
   PencilSquareIcon,
   SliderToggle,
   TrashIcon,
@@ -77,6 +79,12 @@ export const ListItemExample = () => (
       </ContextItem>
       <ContextItem
         title="Github"
+        subElement={
+          <>
+            <Icon visual={User} size="xs" />
+            Connected by Stan
+          </>
+        }
         visual={<ContextItem.Visual visual={Github} />}
       >
         <>


### PR DESCRIPTION
Working on https://www.figma.com/file/QOxHwppG64GtPocpDhS6Y7/Product?type=design&node-id=2914-9312&mode=design&t=UrNCI8Kpzxu1PT9o-0

This PR updates the Sparkle component for `ContextItem` so we can add a sub element next to the title.

This is a temporary solution and will probably get reverted once we migrate all those views to use the `AssistantPreview` component.

<img width="1037" alt="image" src="https://github.com/dust-tt/dust/assets/7428970/811c14af-2e0f-4781-b9ac-f8ad6d00e147">
