### PR TITLE
Sparkle: tweak Dropdown with submenu

### DIFF
--- a/sparkle/src/components/DropdownMenu.tsx
+++ b/sparkle/src/components/DropdownMenu.tsx
@@ -81,7 +81,7 @@ export function DropdownMenu({ children, className = "" }: DropdownMenuProps) {
 
 export interface DropdownButtonProps {
   label?: string;
-  type?: "menu" | "select";
+  type?: "menu" | "submenu" | "select";
   size?: "sm" | "md";
   tooltip?: string;
   tooltipPosition?: TooltipProps["position"];
@@ -188,11 +188,19 @@ DropdownMenu.Button = function ({
             disabled ? "s-cursor-default" : "s-cursor-pointer",
             className,
             "s-group s-flex s-justify-items-center s-text-sm s-font-medium focus:s-outline-none focus:s-ring-0",
-            label ? (size === "md" ? "s-gap-2" : "s-gap-1.5") : "s-gap-0.5"
+            label ? (size === "md" ? "s-gap-2" : "s-gap-1.5") : "s-gap-0.5",
+            type === "submenu" ? "s-opacity-50" : ""
           )}
         >
           <Icon visual={icon} size={size} className={finalIconClasses} />
-          <span className={finalLabelClasses}>{label}</span>
+          <span
+            className={classNames(
+              finalLabelClasses,
+              type === "submenu" ? "s-w-full" : ""
+            )}
+          >
+            {label}
+          </span>
           <Icon
             visual={type === "select" ? ChevronUpDown : ChevronDown}
             size={size === "sm" ? "xs" : "sm"}
@@ -212,6 +220,8 @@ interface DropdownItemProps {
   visual?: string | React.ReactNode;
   icon?: ComponentType;
   onClick?: () => void;
+  hasChildren?: boolean;
+  children?: React.ReactNode;
 }
 
 DropdownMenu.Item = function ({
@@ -222,19 +232,32 @@ DropdownMenu.Item = function ({
   visual,
   icon,
   onClick,
+  hasChildren,
+  children,
 }: DropdownItemProps) {
   return (
     // need to use as="div" -- otherwise we get a "forwardRef" error in the console
     <Menu.Item disabled={disabled} as="div">
-      <StandardItem.Dropdown
-        className="s-w-full s-px-4"
-        href={href}
-        onClick={onClick}
-        label={label}
-        visual={visual}
-        icon={icon}
-        description={description}
-      />
+      {hasChildren ? (
+        <DropdownMenu className="s-w-full s-gap-x-2 s-px-4 s-py-2">
+          <DropdownMenu.Button
+            label={label}
+            type="submenu"
+            className="s-w-full"
+          />
+          {children}
+        </DropdownMenu>
+      ) : (
+        <StandardItem.Dropdown
+          className="s-w-full s-px-4"
+          href={href}
+          onClick={onClick}
+          label={label}
+          visual={visual}
+          icon={icon}
+          description={description}
+        />
+      )}
     </Menu.Item>
   );
 };

--- a/sparkle/src/stories/DropdownMenu.stories.tsx
+++ b/sparkle/src/stories/DropdownMenu.stories.tsx
@@ -146,6 +146,31 @@ export const DropdownExample = () => {
           </DropdownMenu.Items>
         </DropdownMenu>
       </div>
+
+      <div className="s-h-12" />
+      <div className="s-flex s-gap-6">
+        <div className="s-text-sm">SubMenu</div>
+        <DropdownMenu>
+          <DropdownMenu.Button type="select" label="No action" />
+          <DropdownMenu.Items origin="topLeft" width={300}>
+            <DropdownMenu.Item label="No action" href="#" />
+            <DropdownMenu.Item label="Search data sources" href="#" />
+            <DropdownMenu.Item label="Advanced actions" hasChildren={true}>
+              <DropdownMenu.Items origin="topLeft" width={360}>
+                <DropdownMenu.Item
+                  label="Retrieve most recent content from data sources"
+                  href="#"
+                />
+                <DropdownMenu.Item
+                  label="Run a Dust application and retrieve the output"
+                  href="#"
+                />
+              </DropdownMenu.Items>
+            </DropdownMenu.Item>
+          </DropdownMenu.Items>
+        </DropdownMenu>
+      </div>
+
       <div className="s-h-12" />
       <div className="s-flex s-gap-6">
         <div className="s-text-sm">With custom button</div>


### PR DESCRIPTION
Goal of this PR is to have a mininum viable dropdown with submenu component. 
We want to use it on the Assistant builder form to simplify the Action configuration. 

Here's what it looks like: 
<kbd>
<img width="553" alt="Screenshot 2024-01-02 at 21 22 14" src="https://github.com/dust-tt/dust/assets/3803406/85174422-4066-4843-8be3-490bb1b635aa">
</kbd>

Here's when we click on "Advanced actions": 
<kbd>
<img width="542" alt="Screenshot 2024-01-02 at 21 22 20" src="https://github.com/dust-tt/dust/assets/3803406/15198458-1ed5-4b66-a6fa-25bcb079b26d">
</kbd>
