### PR TITLE
Fix ContextItem gap

### DIFF
--- a/sparkle/src/components/ContextItem.tsx
+++ b/sparkle/src/components/ContextItem.tsx
@@ -31,7 +31,7 @@ export function ContextItem({
       <div className="s-flex s-flex-row s-gap-3 s-px-2 s-py-4">
         <div className="s-flex">{visual}</div>
         <div className="s-flex s-grow s-flex-col s-gap-1">
-          <div className="s-flex s-grow s-flex-row">
+          <div className="s-flex s-grow s-flex-row s-gap-3">
             <div className="s-text-normal s-flex s-flex-col s-justify-center s-font-semibold">
               {title}
             </div>


### PR DESCRIPTION
Fix `ContextItem` gap in the flexbox.

**Before**

<img width="874" alt="image" src="https://github.com/dust-tt/dust/assets/7428970/79032bc3-5eec-4ae0-9a89-a1fde42099d3">

**After**

<img width="853" alt="image" src="https://github.com/dust-tt/dust/assets/7428970/579177a7-a490-4cf7-86fa-e582ab6e8fad">
