### PR TITLE
Bump sparkle version

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.57",
+  "version": "0.2.58",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.57",
+      "version": "0.2.58",
       "license": "ISC",
       "dependencies": {
         "@headlessui/react": "^1.7.17"

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.57",
+  "version": "0.2.58",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",


### PR DESCRIPTION
In https://github.com/dust-tt/dust/pull/3040, we forgot to bump the package version.