### PR TITLE
Display authors in personal assistant view

### DIFF
--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -32,6 +32,7 @@ import {
   getGlobalAgents,
   isGlobalAgentId,
 } from "@app/lib/api/assistant/global_agents";
+import { agentConfigurationWasUpdatedBy } from "@app/lib/api/assistant/recent_authors";
 import { agentUserListStatus } from "@app/lib/api/assistant/user_relation";
 import { Authenticator } from "@app/lib/auth";
 import { front_sequelize } from "@app/lib/databases";
@@ -50,8 +51,6 @@ import {
 } from "@app/lib/models";
 import { AgentUserRelation } from "@app/lib/models/assistant/agent";
 import { generateModelSId } from "@app/lib/utils";
-
-import { agentConfigurationWasUpdatedBy } from "./recent_authors";
 
 /**
  * Get an agent configuration

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -786,7 +786,7 @@ export async function createAgentConfiguration(
     await agentConfigurationWasUpdatedBy({
       agentId: agent.sId,
       workspaceId: owner.sId,
-      authorId: agent.authorId.toFixed(),
+      authorId: agent.authorId,
       version: agent.version,
     });
 

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -783,10 +783,8 @@ export async function createAgentConfiguration(
     });
 
     await agentConfigurationWasUpdatedBy({
-      agentId: agent.sId,
-      workspaceId: owner.sId,
-      authorId: agent.authorId,
-      version: agent.version,
+      agent: agentConfiguration,
+      auth,
     });
 
     return new Ok(agentConfiguration);

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -51,6 +51,8 @@ import {
 import { AgentUserRelation } from "@app/lib/models/assistant/agent";
 import { generateModelSId } from "@app/lib/utils";
 
+import { agentConfigurationWasUpdatedBy } from "./recent_authors";
+
 /**
  * Get an agent configuration
  *
@@ -779,6 +781,13 @@ export async function createAgentConfiguration(
     agentConfiguration.userListStatus = agentUserListStatus({
       agentConfiguration,
       listStatusOverride,
+    });
+
+    await agentConfigurationWasUpdatedBy({
+      agentId: agent.sId,
+      workspaceId: owner.sId,
+      authorId: agent.authorId.toFixed(),
+      version: agent.version,
     });
 
     return new Ok(agentConfiguration);

--- a/front/lib/api/assistant/recent_authors.ts
+++ b/front/lib/api/assistant/recent_authors.ts
@@ -1,4 +1,8 @@
-import { AgentRecentAuthors, UserType } from "@dust-tt/types";
+import {
+  AgentConfigurationType,
+  AgentRecentAuthors,
+  UserType,
+} from "@dust-tt/types";
 import { Sequelize } from "sequelize";
 
 import { AgentConfiguration } from "@app/lib/models";
@@ -99,25 +103,26 @@ function renderAuthors(
         }
         return members.find((m) => m.id === authorId)?.fullName ?? null;
       })
-      // Filter out `undefined` authors.
+      // Filter out `null` authors.
       .filter((name): name is string => name !== null)
   );
 }
 
 export async function getAgentRecentAuthors(
   {
-    agentId,
+    agentConfiguration,
     workspaceId,
-    isGlobalAgent,
     currentUserId,
   }: {
-    agentId: string;
+    agentConfiguration: AgentConfigurationType;
     workspaceId: string;
-    isGlobalAgent: boolean;
     currentUserId?: number;
   },
   members: UserType[]
 ): Promise<AgentRecentAuthors> {
+  const { sId: agentId, versionAuthorId } = agentConfiguration;
+
+  const isGlobalAgent = versionAuthorId === null;
   // For global agents, which have no authors, return early.
   if (isGlobalAgent) {
     return [];

--- a/front/lib/api/assistant/recent_authors.ts
+++ b/front/lib/api/assistant/recent_authors.ts
@@ -112,21 +112,21 @@ function renderAuthors(
 export async function getAgentRecentAuthors(
   {
     agentConfiguration,
-    authenticator,
+    auth,
   }: {
     agentConfiguration: AgentConfigurationType;
-    authenticator: Authenticator;
+    auth: Authenticator;
   },
   members: UserType[]
 ): Promise<AgentRecentAuthors> {
   const { sId: agentId, versionAuthorId } = agentConfiguration;
 
-  const owner = authenticator.workspace();
+  const owner = auth.workspace();
   if (!owner) {
     throw new Error("Owner is required");
   }
   const { sId: workspaceId } = owner;
-  const currentUserId = authenticator.user()?.id;
+  const currentUserId = auth.user()?.id;
 
   const isGlobalAgent = versionAuthorId === null;
   // For global agents, which have no authors, return early.

--- a/front/lib/api/assistant/recent_authors.ts
+++ b/front/lib/api/assistant/recent_authors.ts
@@ -1,0 +1,115 @@
+import { AgentRecentAuthorIds } from "@dust-tt/types";
+import { Sequelize } from "sequelize";
+
+import { AgentConfiguration } from "@app/lib/models";
+import { safeRedisClient } from "@app/lib/redis";
+
+// We keep the most recent authorIds for 7 days.
+const rankingTimeframeSec = 60 * 60 * 24 * 7; // 7 days.
+
+function _getRecentAuthorIdsKey({
+  workspaceId,
+  agentId,
+}: {
+  workspaceId: string;
+  agentId: string;
+}) {
+  // One sorted set per agent for keeping record of the most recent author ids, with:
+  // score: version of each configuration of the agent
+  // value: author id.
+  return `agent_recent_author_ids_${workspaceId}_${agentId}`;
+}
+
+async function fetchRecentAuthorIdsWithVersion(agentId: string) {
+  return AgentConfiguration.findAll({
+    attributes: [
+      "authorId",
+      [Sequelize.fn("MAX", Sequelize.col("version")), "version"],
+    ],
+    group: "authorId",
+    where: {
+      sId: agentId,
+    },
+    order: [
+      ["version", "DESC"], // Order by version descending.
+      ["authorId", "DESC"],
+    ],
+    limit: 3, // Limit to the last 3 authors.
+  });
+}
+
+async function setAuthorIdsWithVersionInRedis(
+  agentId: string,
+  workspaceId: string,
+  authorIdsWithScore: { value: string; score: number }[]
+) {
+  const agentRecentAuthorIdsKey = _getRecentAuthorIdsKey({
+    agentId,
+    workspaceId,
+  });
+  await safeRedisClient(async (redis) => {
+    // Insert <authorId:version> into Redis sorted set.
+    // Update only if the author is new or the version is higher.
+    await redis.zAdd(agentRecentAuthorIdsKey, authorIdsWithScore, { GT: true });
+    await redis.expire(agentRecentAuthorIdsKey, rankingTimeframeSec);
+  });
+}
+
+async function populateAuthorIdsFromDb(agentId: string, workspaceId: string) {
+  const recentAuthorIdsWithVersion = await fetchRecentAuthorIdsWithVersion(
+    agentId
+  );
+
+  const authorIdsWithScore = recentAuthorIdsWithVersion.map((a) => ({
+    value: a.get("authorId").toFixed(),
+    score: a.version,
+  }));
+
+  await setAuthorIdsWithVersionInRedis(
+    agentId,
+    workspaceId,
+    authorIdsWithScore
+  );
+
+  return recentAuthorIdsWithVersion.map((a) => a.authorId);
+}
+
+export async function getAgentRecentAuthorIds({
+  agentId,
+  workspaceId,
+}: {
+  agentId: string;
+  workspaceId: string;
+}): Promise<AgentRecentAuthorIds> {
+  const agentRecentAuthorIdsKey = _getRecentAuthorIdsKey({
+    agentId,
+    workspaceId,
+  });
+
+  const recentAuthorIds = await safeRedisClient(async (redis) =>
+    redis.zRange(agentRecentAuthorIdsKey, 0, 2, { REV: true })
+  );
+
+  if (recentAuthorIds.length > 0) {
+    return recentAuthorIds.map((n) => Number.parseInt(n, 10));
+  }
+
+  // Populate from the database and store in Redis if the entry is not already present.
+  return await populateAuthorIdsFromDb(agentId, workspaceId);
+}
+
+export async function agentConfigurationWasUpdatedBy({
+  agentId,
+  workspaceId,
+  authorId,
+  version,
+}: {
+  agentId: string;
+  workspaceId: string;
+  authorId: string;
+  version: number;
+}) {
+  await setAuthorIdsWithVersionInRedis(agentId, workspaceId, [
+    { value: authorId, score: version },
+  ]);
+}

--- a/front/lib/api/assistant/recent_authors.ts
+++ b/front/lib/api/assistant/recent_authors.ts
@@ -154,10 +154,10 @@ export async function agentConfigurationWasUpdatedBy({
 }: {
   agentId: string;
   workspaceId: string;
-  authorId: string;
+  authorId: number;
   version: number;
 }) {
   await setAuthorIdsWithVersionInRedis(agentId, workspaceId, [
-    { value: authorId, score: version },
+    { value: authorId.toString(), score: version },
   ]);
 }

--- a/front/lib/api/assistant/recent_authors.ts
+++ b/front/lib/api/assistant/recent_authors.ts
@@ -60,6 +60,10 @@ async function populateAuthorIdsFromDb(agentId: string, workspaceId: string) {
     agentId
   );
 
+  if (recentAuthorIdsWithVersion.length === 0) {
+    return [];
+  }
+
   const authorIdsWithScore = recentAuthorIdsWithVersion.map((a) => ({
     value: a.get("authorId").toFixed(),
     score: a.version,
@@ -77,10 +81,17 @@ async function populateAuthorIdsFromDb(agentId: string, workspaceId: string) {
 export async function getAgentRecentAuthorIds({
   agentId,
   workspaceId,
+  isGlobalAgent,
 }: {
   agentId: string;
   workspaceId: string;
+  isGlobalAgent: boolean;
 }): Promise<AgentRecentAuthorIds> {
+  // For global agents, which have no authors, return early.
+  if (isGlobalAgent) {
+    return [];
+  }
+
   const agentRecentAuthorIdsKey = _getRecentAuthorIdsKey({
     agentId,
     workspaceId,

--- a/front/lib/swr.ts
+++ b/front/lib/swr.ts
@@ -444,22 +444,35 @@ export function useConversationReactions({
 export function useAgentConfigurations({
   workspaceId,
   agentsGetView,
-  withUsage,
+  includes = [],
 }: {
   workspaceId: string;
   agentsGetView: AgentsGetViewType;
-  withUsage?: boolean;
+  includes?: ("authors" | "usage")[];
 }) {
   const agentConfigurationsFetcher: Fetcher<GetAgentConfigurationsResponseBody> =
     fetcher;
-  const viewQueryString =
-    typeof agentsGetView === "string"
-      ? `view=${agentsGetView}`
-      : `conversationId=${agentsGetView.conversationId}`;
+
+  // Function to generate query parameters.
+  function getQueryString() {
+    const params = new URLSearchParams();
+    if (typeof agentsGetView === "string") {
+      params.append("view", agentsGetView);
+    } else {
+      params.append("conversationId", agentsGetView.conversationId);
+    }
+    if (includes.includes("usage")) {
+      params.append("withUsage", "true");
+    }
+    if (includes.includes("authors")) {
+      params.append("withAuthors", "true");
+    }
+    return params.toString();
+  }
+
+  const queryString = getQueryString();
   const { data, error, mutate } = useSWR(
-    `/api/w/${workspaceId}/assistant/agent_configurations?${viewQueryString}&withUsage=${
-      withUsage ? true : false
-    }`,
+    `/api/w/${workspaceId}/assistant/agent_configurations?${queryString}`,
     agentConfigurationsFetcher
   );
 

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@dust-tt/sparkle": "^0.2.58",
+        "@dust-tt/sparkle": "^0.2.59",
         "@dust-tt/types": "file:../types",
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",
@@ -895,9 +895,9 @@
       "integrity": "sha512-smLocSfrt3s53H/XSVP3/1kP42oqvrkjUPtyaFd1F79ux24oE31BKt+q0c6lsa6hOYrFzsIwyc5GXAI5JmfOew=="
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.58",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.58.tgz",
-      "integrity": "sha512-DGBUvM+5qCvFlZosZ0UPVx8pkb0pAl22i+AA9sQzpE5LohNvXwoWuhyJkNTkT2Px1vTEtqoBtL6x3gNG0kejLA==",
+      "version": "0.2.59",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.59.tgz",
+      "integrity": "sha512-J3W4e0UA+Hdc0wIby0WaeRfFVrHCJPjEL279TdoDiJU1behIEK4QohKxBcsMFNrapKx+9n3Fa9ysoe5PUtHFsg==",
       "dependencies": {
         "@headlessui/react": "^1.7.17"
       },

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@dust-tt/sparkle": "^0.2.55",
+        "@dust-tt/sparkle": "^0.2.58",
         "@dust-tt/types": "file:../types",
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",
@@ -895,9 +895,9 @@
       "integrity": "sha512-smLocSfrt3s53H/XSVP3/1kP42oqvrkjUPtyaFd1F79ux24oE31BKt+q0c6lsa6hOYrFzsIwyc5GXAI5JmfOew=="
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.55",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.55.tgz",
-      "integrity": "sha512-DC49NJ7T9e9O3HSN6k3FmBYSufYt18xI1JMv0Nfdq4xYsz7FI7lf7Hx5KObgN8OAJikii3pZnSl3OGyGJr+okA==",
+      "version": "0.2.58",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.58.tgz",
+      "integrity": "sha512-DGBUvM+5qCvFlZosZ0UPVx8pkb0pAl22i+AA9sQzpE5LohNvXwoWuhyJkNTkT2Px1vTEtqoBtL6x3gNG0kejLA==",
       "dependencies": {
         "@headlessui/react": "^1.7.17"
       },

--- a/front/package.json
+++ b/front/package.json
@@ -13,7 +13,7 @@
     "initdb": "npx tsx admin/db.ts"
   },
   "dependencies": {
-    "@dust-tt/sparkle": "^0.2.55",
+    "@dust-tt/sparkle": "^0.2.58",
     "@dust-tt/types": "file:../types",
     "@emoji-mart/data": "^1.1.2",
     "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -13,7 +13,7 @@
     "initdb": "npx tsx admin/db.ts"
   },
   "dependencies": {
-    "@dust-tt/sparkle": "^0.2.58",
+    "@dust-tt/sparkle": "^0.2.59",
     "@dust-tt/types": "file:../types",
     "@emoji-mart/data": "^1.1.2",
     "@emoji-mart/react": "^1.1.1",

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -130,8 +130,7 @@ async function handler(
                 lastAuthors: await getAgentRecentAuthors(
                   {
                     agentConfiguration,
-                    workspaceId: owner.sId,
-                    currentUserId: auth.user()?.id,
+                    authenticator: auth,
                   },
                   members
                 ),

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -130,7 +130,7 @@ async function handler(
                 lastAuthors: await getAgentRecentAuthors(
                   {
                     agentConfiguration,
-                    authenticator: auth,
+                    auth,
                   },
                   members
                 ),

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -126,6 +126,7 @@ async function handler(
                 ...agentConfiguration,
                 lastAuthorIds: await getAgentRecentAuthorIds({
                   agentId: agentConfiguration.sId,
+                  isGlobalAgent: agentConfiguration.versionAuthorId === null,
                   workspaceId: owner.sId,
                 }),
               };

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -129,8 +129,7 @@ async function handler(
                 ...agentConfiguration,
                 lastAuthors: await getAgentRecentAuthors(
                   {
-                    agentId: agentConfiguration.sId,
-                    isGlobalAgent: agentConfiguration.versionAuthorId === null,
+                    agentConfiguration,
                     workspaceId: owner.sId,
                     currentUserId: auth.user()?.id,
                   },

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -129,7 +129,7 @@ async function handler(
                 ...agentConfiguration,
                 lastAuthors: await getAgentRecentAuthors(
                   {
-                    agentConfiguration,
+                    agent: agentConfiguration,
                     auth,
                   },
                   members

--- a/front/pages/w/[wId]/assistant/assistants.tsx
+++ b/front/pages/w/[wId]/assistant/assistants.tsx
@@ -311,7 +311,7 @@ export default function PersonalAssistants({
                             }
                             size="xs"
                           />
-                          {agent.lastAuthors.join(",")}
+                          {agent.lastAuthors.join(", ")}
                         </>
                       ) : (
                         <></>

--- a/front/pages/w/[wId]/assistant/assistants.tsx
+++ b/front/pages/w/[wId]/assistant/assistants.tsx
@@ -3,6 +3,7 @@ import {
   BookOpenIcon,
   Button,
   ContextItem,
+  Icon,
   MoreIcon,
   Page,
   PencilSquareIcon,
@@ -13,6 +14,8 @@ import {
   Tab,
   Tooltip,
   TrashIcon,
+  UserGroupIcon,
+  UserIcon,
   XMarkIcon,
 } from "@dust-tt/sparkle";
 import {
@@ -100,6 +103,7 @@ export default function PersonalAssistants({
     useAgentConfigurations({
       workspaceId: owner.sId,
       agentsGetView: view === "personal" ? "list" : "workspace",
+      includes: view === "personal" ? ["authors"] : [],
     });
 
   const [assistantSearch, setAssistantSearch] = useState<string>("");
@@ -296,6 +300,23 @@ export default function PersonalAssistants({
                   <ContextItem
                     key={agent.sId}
                     title={`@${agent.name}`}
+                    subElement={
+                      agent.lastAuthors && agent.lastAuthors.length > 0 ? (
+                        <>
+                          <Icon
+                            visual={
+                              agent.lastAuthors.length > 1
+                                ? UserGroupIcon
+                                : UserIcon
+                            }
+                            size="xs"
+                          />
+                          {agent.lastAuthors.join(",")}
+                        </>
+                      ) : (
+                        <></>
+                      )
+                    }
                     visual={
                       <Avatar
                         visual={<img src={agent.pictureUrl} />}

--- a/front/pages/w/[wId]/assistant/gallery.tsx
+++ b/front/pages/w/[wId]/assistant/gallery.tsx
@@ -92,7 +92,7 @@ export default function AssistantsGallery({
     useAgentConfigurations({
       workspaceId: owner.sId,
       agentsGetView,
-      withUsage: orderBy === "usage",
+      includes: orderBy === "usage" ? ["usage"] : [],
     });
 
   const [assistantSearch, setAssistantSearch] = useState<string>("");

--- a/types/src/front/api_handlers/internal/agent_configuration.ts
+++ b/types/src/front/api_handlers/internal/agent_configuration.ts
@@ -17,6 +17,7 @@ export const GetAgentConfigurationsQuerySchema = t.type({
   ]),
   conversationId: t.union([t.string, t.undefined]),
   withUsage: t.union([t.literal("true"), t.literal("false"), t.undefined]),
+  withAuthors: t.union([t.literal("true"), t.literal("false"), t.undefined]),
 });
 
 export const GetAgentConfigurationsLeaderboardQuerySchema = t.type({

--- a/types/src/front/assistant/agent.ts
+++ b/types/src/front/assistant/agent.ts
@@ -106,6 +106,16 @@ export type AgentsGetViewType =
   | "global"
   | "admin_internal";
 
+export type AgentUsageType = {
+  userCount: number;
+  messageCount: number;
+
+  // userCount and messageCount are over the last `timePeriodSec` seconds
+  timePeriodSec: number;
+};
+
+export type AgentRecentAuthorIds = readonly number[];
+
 export type AgentConfigurationType = {
   id: ModelId;
 
@@ -134,12 +144,7 @@ export type AgentConfigurationType = {
 
   // Usage is expensive to compute, so we only compute it when needed.
   usage?: AgentUsageType;
-};
 
-export type AgentUsageType = {
-  userCount: number;
-  messageCount: number;
-
-  // userCount and messageCount are over the last `timePeriodSec` seconds
-  timePeriodSec: number;
+  // `lastAuthors` is expensive to compute, so we only compute it when needed.
+  lastAuthorIds?: AgentRecentAuthorIds;
 };

--- a/types/src/front/assistant/agent.ts
+++ b/types/src/front/assistant/agent.ts
@@ -114,7 +114,7 @@ export type AgentUsageType = {
   timePeriodSec: number;
 };
 
-export type AgentRecentAuthorIds = readonly number[];
+export type AgentRecentAuthors = readonly string[];
 
 export type AgentConfigurationType = {
   id: ModelId;
@@ -146,5 +146,5 @@ export type AgentConfigurationType = {
   usage?: AgentUsageType;
 
   // `lastAuthors` is expensive to compute, so we only compute it when needed.
-  lastAuthorIds?: AgentRecentAuthorIds;
+  lastAuthors?: AgentRecentAuthors;
 };


### PR DESCRIPTION
Slack context: [thread](https://dust4ai.slack.com/archives/C050A0S2Z7F/p1702910140159249).
Figma: [here](https://www.figma.com/file/QOxHwppG64GtPocpDhS6Y7/Product?node-id=2914%3A9312&mode=dev).

This PR resolves https://github.com/dust-tt/dust/issues/2912 by implementing a feature to display the last 3 authors in the personal gallery. Due to Sequelize's limitations in not fully exposing PostgreSQL's capabilities, an efficient MySQL query at runtime wasn't feasible without potentially impacting endpoint performance. A raw query was considered. However, this would bypass Sequelize's relational abstractions.

The chosen approach involves using a Redis sorted set as a "cached view" to store the most recent author ids for each assistant, with a TTL of 3 days. This leverages Redis's automatic data lifecycle management, allowing us to append new data without manual cleanup of older entries. The sorted set is refreshed with every assistant update.

**Key points:**
- Implements Redis caching for recent author data.
- API side now fetches member names, a temporary pattern until the need for broader member awareness arises on the client side.
- Introduces `withAuthors` query parameter to `/agent_configurations` endpoint, similar to `withUsage`. This will be restructured in a future PR for a more refined selection mechanism.

<img width="859" alt="image" src="https://github.com/dust-tt/dust/assets/7428970/22b6d610-ac53-495e-b2d1-cd6f2ef8d801">
