### PR TITLE
Adjust gaps within ContextItem subElement

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.58",
+  "version": "0.2.59",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.58",
+      "version": "0.2.59",
       "license": "ISC",
       "dependencies": {
         "@headlessui/react": "^1.7.17"

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.58",
+  "version": "0.2.59",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/components/ContextItem.tsx
+++ b/sparkle/src/components/ContextItem.tsx
@@ -35,7 +35,7 @@ export function ContextItem({
             <div className="s-text-normal s-flex s-flex-col s-justify-center s-font-semibold">
               {title}
             </div>
-            <div className="s-flex s-items-center s-text-element-600">
+            <div className="s-flex s-items-center s-gap-1 s-text-element-600">
               {subElement}
             </div>
           </div>


### PR DESCRIPTION
This PR fixes the last gap required in the sub element of `ContextItem`.

**Before**

<img width="1007" alt="image" src="https://github.com/dust-tt/dust/assets/7428970/505b0064-b63e-4837-b948-c9db4f3f5747">

**After**

<img width="1007" alt="image" src="https://github.com/dust-tt/dust/assets/7428970/4e176fb3-8174-4bf2-b6ee-a9a6ba49e9fc">
