### PR TITLE
fix: input generators context size for gpt-4-32k

### DIFF
--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -79,7 +79,7 @@ export async function generateActionInputs(
 
   const contextSize = isFree
     ? GPT_3_5_TURBO_MODEL_CONFIG.contextSize
-    : GPT_4_TURBO_MODEL_CONFIG.contextSize;
+    : GPT_4_32K_MODEL_CONFIG.contextSize;
 
   // Turn the conversation into a digest that can be presented to the model.
   const modelConversationRes = await renderConversationForModel({

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -10,7 +10,6 @@ import {
   GPT_3_5_TURBO_MODEL_CONFIG,
   GPT_4_32K_MODEL_CONFIG,
   GPT_4_MODEL_CONFIG,
-  GPT_4_TURBO_MODEL_CONFIG,
   isDatabaseQueryConfiguration,
 } from "@dust-tt/types";
 import {


### PR DESCRIPTION
We currently use gpt-4 32k for inputs generation because gpt-4-1106-preview does not well support accented data in JSON.

We were still checking context size in the process using gpt-4-1106-preview context size instead of gpt-4-32k, leading to possible context exceeded errors:

https://app.datadoghq.eu/logs?query=%22Agent%20error%22%20&cols=host%2Cservice&event=AgAAAYzO2rZAqI8Q0wAAAAAAAAAYAAAAAEFZek8ycmpZQUFCc1JPRWw1QlZwS1FCUgAAACQAAAAAMDE4Y2NlZTAtZmI0ZC00YmVjLWIzZGItNjNhY2Q2MjdmYWNl&index=%2A&messageDisplay=inline&refresh_mode=sliding&stream_sort=desc&viz=stream&from_ts=1704190976534&to_ts=1704277376534&live=true