### PR TITLE
Sparkle: Style dropdown submenu

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.59",
+  "version": "0.2.60",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.59",
+      "version": "0.2.60",
       "license": "ISC",
       "dependencies": {
         "@headlessui/react": "^1.7.17"

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.59",
+  "version": "0.2.60",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/components/DropdownMenu.tsx
+++ b/sparkle/src/components/DropdownMenu.tsx
@@ -9,7 +9,7 @@ import React, {
   useState,
 } from "react";
 
-import { ChevronDown, ChevronUpDown } from "@sparkle/icons/solid";
+import { ChevronDown, ChevronRight, ChevronUpDown } from "@sparkle/icons/solid";
 import { classNames } from "@sparkle/lib/utils";
 
 import { Icon } from "./Icon";
@@ -158,6 +158,13 @@ DropdownMenu.Button = function ({
     );
   }
 
+  const chevronIcon =
+    type === "select"
+      ? ChevronUpDown
+      : type === "submenu"
+      ? ChevronRight
+      : ChevronDown;
+
   return (
     <>
       {tooltip ? (
@@ -174,7 +181,7 @@ DropdownMenu.Button = function ({
           >
             <Icon visual={icon} size={size} className={finalIconClasses} />
             <Icon
-              visual={type === "select" ? ChevronUpDown : ChevronDown}
+              visual={chevronIcon}
               size={size === "sm" ? "xs" : "sm"}
               className={finalChevronClasses}
             />
@@ -202,7 +209,7 @@ DropdownMenu.Button = function ({
             {label}
           </span>
           <Icon
-            visual={type === "select" ? ChevronUpDown : ChevronDown}
+            visual={chevronIcon}
             size={size === "sm" ? "xs" : "sm"}
             className={finalChevronClasses}
           />
@@ -265,12 +272,14 @@ DropdownMenu.Item = function ({
 interface DropdownItemsProps {
   origin?: "topLeft" | "topRight" | "bottomLeft" | "bottomRight" | "auto";
   width?: number;
+  marginLeft?: number;
   children: React.ReactNode;
 }
 
 DropdownMenu.Items = function ({
   origin = "auto",
   width = 160,
+  marginLeft = 0,
   children,
 }: DropdownItemsProps) {
   const buttonRef = useContext(ButtonRefContext);
@@ -314,14 +323,22 @@ DropdownMenu.Items = function ({
     }
   };
 
-  const styleInsert = (origin: string) => {
+  const styleInsert = (origin: string, marginLeft: number) => {
     switch (origin) {
       case "topLeft":
-        return { width: `${width}px`, top: `${buttonHeight + 8}px` };
+        return {
+          width: `${width}px`,
+          top: `${buttonHeight + 8}px`,
+          left: `${marginLeft}px`,
+        };
       case "topRight":
-        return { width: `${width}px`, top: `${buttonHeight + 8}px` };
+        return {
+          width: `${width}px`,
+          top: `${buttonHeight + 8}px`,
+          left: `${marginLeft}px`,
+        };
       default:
-        return { width: `${width}px` };
+        return { width: `${width}px`, left: `${marginLeft}px` };
     }
   };
 
@@ -339,7 +356,7 @@ DropdownMenu.Items = function ({
         className={`s-absolute s-z-10 ${getOriginClass(
           origin
         )} s-rounded-xl s-border s-border-structure-100 s-bg-structure-0 s-py-1 s-shadow-lg focus:s-outline-none dark:s-border-structure-100-dark dark:s-bg-structure-0-dark`}
-        style={styleInsert(origin)}
+        style={styleInsert(origin, marginLeft)}
       >
         <StandardItem.List>{children}</StandardItem.List>
       </Menu.Items>

--- a/sparkle/src/stories/DropdownMenu.stories.tsx
+++ b/sparkle/src/stories/DropdownMenu.stories.tsx
@@ -152,11 +152,11 @@ export const DropdownExample = () => {
         <div className="s-text-sm">SubMenu</div>
         <DropdownMenu>
           <DropdownMenu.Button type="select" label="No action" />
-          <DropdownMenu.Items origin="topLeft" width={300}>
+          <DropdownMenu.Items origin="topLeft" width={200}>
             <DropdownMenu.Item label="No action" href="#" />
             <DropdownMenu.Item label="Search data sources" href="#" />
             <DropdownMenu.Item label="Advanced actions" hasChildren={true}>
-              <DropdownMenu.Items origin="topLeft" width={360}>
+              <DropdownMenu.Items origin="topLeft" width={360} marginLeft={40}>
                 <DropdownMenu.Item
                   label="Retrieve most recent content from data sources"
                   href="#"


### PR DESCRIPTION
### Context

This PRs does small edits on the Sparkle Dropdown component. 

Changes:
- Display ChevronRight for a submenu item.
- Allow setting a leftMargin for a submenu.

Why? Applying feedback from here: https://github.com/dust-tt/tasks/issues/309#issuecomment-1875024810

### Screenshots

**Level 1:**
<kbd>
<img width="408" alt="Screenshot 2024-01-03 at 14 10 38" src="https://github.com/dust-tt/dust/assets/3803406/c2afaa62-6ae0-4a79-8c80-84a63b637e52">
</kbd>

**Level 2 (set with a margin Left of 40px):** 
<kbd>
<img width="638" alt="Screenshot 2024-01-03 at 14 10 28" src="https://github.com/dust-tt/dust/assets/3803406/1b4d653b-802c-494e-a634-0e03d500b2b7">
</kbd>
