### PR TITLE
Add AssistantPreview component in Sparkle (variant: lg)

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.60",
+  "version": "0.2.61",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.60",
+      "version": "0.2.61",
       "license": "ISC",
       "dependencies": {
         "@headlessui/react": "^1.7.17"

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.60",
+  "version": "0.2.61",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/_index.ts
+++ b/sparkle/src/_index.ts
@@ -22,6 +22,9 @@ export { Item };
 import { ContextItem } from "./components/ContextItem";
 export { ContextItem };
 
+import { AssistantPreview } from "./components/AssistantPreview";
+export { AssistantPreview };
+
 import { Chip } from "./components/Chip";
 export { Chip };
 

--- a/sparkle/src/components/AssistantPreview.tsx
+++ b/sparkle/src/components/AssistantPreview.tsx
@@ -67,7 +67,7 @@ const LargeVariantContent = ({ props }: { props: AssistantPreviewProps }) => {
     subtitle,
   } = props;
 
-  const galleryChip = allowAddAction && isAdded && (
+  const galleryChip = isAdded && (
     <div className="s-group">
       <Chip
         color="emerald"
@@ -75,19 +75,21 @@ const LargeVariantContent = ({ props }: { props: AssistantPreviewProps }) => {
         label="Added"
         className="group-hover:s-hidden"
       />
-      <div className="s-hidden group-hover:s-block">
-        <Button.List isWrapping={true}>
-          <Button
-            key="remove"
-            variant="tertiary"
-            icon={Dash}
-            disabled={isUpdatingList}
-            size="xs"
-            label={"Remove"}
-            onClick={() => onUpdate("removed")}
-          />
-        </Button.List>
-      </div>
+      {allowAddAction && (
+        <div className="s-hidden group-hover:s-block">
+          <Button.List isWrapping={true}>
+            <Button
+              key="remove"
+              variant="tertiary"
+              icon={Dash}
+              disabled={isUpdatingList}
+              size="xs"
+              label={"Remove"}
+              onClick={() => onUpdate("removed")}
+            />
+          </Button.List>
+        </div>
+      )}
     </div>
   );
 

--- a/sparkle/src/components/AssistantPreview.tsx
+++ b/sparkle/src/components/AssistantPreview.tsx
@@ -73,7 +73,7 @@ const LargeVariantContent = ({ props }: { props: AssistantPreviewProps }) => {
         color="emerald"
         size="xs"
         label="Added"
-        className="group-hover:s-hidden"
+        className={allowAddAction ? "group-hover:s-hidden" : ""}
       />
       {allowAddAction && (
         <div className="s-hidden group-hover:s-block">

--- a/sparkle/src/components/AssistantPreview.tsx
+++ b/sparkle/src/components/AssistantPreview.tsx
@@ -8,6 +8,7 @@ import { Dash, More, Play, Plus } from "@sparkle/icons/solid";
 type AssistantPreviewVariant = "sm" | "md" | "lg" | "list";
 
 interface AssistantPreviewProps {
+  allowAddAction: boolean;
   description: string;
   isAdded: boolean;
   isUpdatingList: boolean;
@@ -53,19 +54,20 @@ const MediumVariantContent = () => {
 
 const LargeVariantContent = ({ props }: { props: AssistantPreviewProps }) => {
   const {
-    isWorkspace,
-    isAdded,
-    name,
     description,
-    subtitle,
-    pictureUrl,
+    isAdded,
+    allowAddAction,
+    isUpdatingList,
+    isWorkspace,
+    name,
+    onShowDetailsClick,
     onTestClick,
     onUpdate,
-    onShowDetailsClick,
-    isUpdatingList,
+    pictureUrl,
+    subtitle,
   } = props;
 
-  const galleryChip = isAdded && (
+  const galleryChip = allowAddAction && isAdded && (
     <div className="s-group">
       <Chip
         color="emerald"
@@ -89,7 +91,7 @@ const LargeVariantContent = ({ props }: { props: AssistantPreviewProps }) => {
     </div>
   );
 
-  const addButton = !isAdded && (
+  const addButton = !isAdded && allowAddAction && (
     <Button
       key="add"
       variant="tertiary"

--- a/sparkle/src/components/AssistantPreview.tsx
+++ b/sparkle/src/components/AssistantPreview.tsx
@@ -1,0 +1,169 @@
+import React from "react";
+
+import { Avatar } from "@sparkle/components/Avatar";
+import { Button } from "@sparkle/components/Button";
+import { Chip } from "@sparkle/components/Chip";
+import { Dash, More, Play, Plus } from "@sparkle/icons/solid";
+
+type AssistantPreviewVariant = "sm" | "md" | "lg" | "list";
+
+interface AssistantPreviewProps {
+  description: string;
+  isAdded: boolean;
+  isUpdatingList: boolean;
+  isWorkspace: boolean;
+  name: string;
+  pictureUrl: string;
+  subtitle: string;
+  variant: AssistantPreviewVariant;
+
+  // CTA's.
+  onShowDetailsClick?: () => void;
+  onTestClick?: () => void;
+  onUpdate: (action: "added" | "removed") => Promise<void> | void;
+}
+
+function getVariantContent(
+  variant: AssistantPreviewVariant,
+  props: AssistantPreviewProps
+) {
+  switch (variant) {
+    case "sm":
+      return <SmallVariantContent />;
+    case "md":
+      return <MediumVariantContent />;
+    case "lg":
+      return <LargeVariantContent props={props} />;
+    case "list":
+      return <ListVariantContent />;
+    default:
+      return <></>;
+  }
+}
+
+// TODO:
+const SmallVariantContent = () => {
+  throw new Error("Not yet implemented!");
+};
+
+// TODO:
+const MediumVariantContent = () => {
+  throw new Error("Not yet implemented!");
+};
+
+const LargeVariantContent = ({ props }: { props: AssistantPreviewProps }) => {
+  const {
+    isWorkspace,
+    isAdded,
+    name,
+    description,
+    subtitle,
+    pictureUrl,
+    onTestClick,
+    onUpdate,
+    onShowDetailsClick,
+    isUpdatingList,
+  } = props;
+
+  const galleryChip = isAdded && (
+    <div className="s-group">
+      <Chip
+        color="emerald"
+        size="xs"
+        label="Added"
+        className="group-hover:s-hidden"
+      />
+      <div className="s-hidden group-hover:s-block">
+        <Button.List isWrapping={true}>
+          <Button
+            key="remove"
+            variant="tertiary"
+            icon={Dash}
+            disabled={isUpdatingList}
+            size="xs"
+            label={"Remove"}
+            onClick={() => onUpdate("removed")}
+          />
+        </Button.List>
+      </div>
+    </div>
+  );
+
+  const addButton = !isAdded && (
+    <Button
+      key="add"
+      variant="tertiary"
+      icon={Plus}
+      disabled={isUpdatingList}
+      size="xs"
+      label={isWorkspace ? "Add to Workspace" : "Add"}
+      onClick={() => onUpdate("added")}
+    />
+  );
+
+  let testButton = null;
+  if (onTestClick) {
+    testButton = (
+      <Button
+        key="test"
+        variant="tertiary"
+        icon={Play}
+        size="xs"
+        label={"Test"}
+        onClick={onTestClick}
+      />
+    );
+  }
+
+  const showAssistantButton = (
+    <Button
+      key="show_details"
+      icon={More}
+      label={"View Assistant"}
+      labelVisible={false}
+      size="xs"
+      variant="tertiary"
+      onClick={onShowDetailsClick}
+    />
+  );
+
+  const buttonsToRender =
+    ([addButton, testButton, showAssistantButton].filter(
+      Boolean
+    ) as JSX.Element[]) ?? [];
+
+  return (
+    <div className="s-flex s-flex-row s-gap-2 s-py-2">
+      <Avatar visual={<img src={pictureUrl} alt="Agent Avatar" />} size="md" />
+      <div className="s-flex s-flex-col s-gap-2">
+        <div>
+          <div className="s-text-sm s-font-medium s-text-element-900">
+            @{name}
+          </div>
+          <div className="s-text-sm s-font-normal s-text-element-700">
+            {subtitle}
+          </div>
+        </div>
+        <div className="s-flex s-flex-row s-gap-2">
+          {galleryChip}
+          <Button.List isWrapping={true}>{buttonsToRender}</Button.List>
+        </div>
+        <div className="s-text-sm s-font-normal s-text-element-800">
+          {description}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// TODO:
+const ListVariantContent = () => {
+  throw new Error("Not yet implemented!");
+};
+
+export function AssistantPreview(props: AssistantPreviewProps) {
+  // You can also use a function to get variant-specific styles or components
+  const VariantContent = getVariantContent(props.variant, props);
+
+  return <div>{VariantContent}</div>;
+}

--- a/sparkle/src/stories/AssistantPreview.stories.tsx
+++ b/sparkle/src/stories/AssistantPreview.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta } from "@storybook/react";
+import React from "react";
+
+import { AssistantPreview } from "../index_with_tw_base";
+
+const meta: Meta<typeof AssistantPreview> = {
+  title: "Molecule/AssistantPreview",
+  component: AssistantPreview,
+};
+
+export default meta;
+
+export const AssistantPreviewExample = () => (
+  <div>
+    <h2>Gallery view (variant: `lg`)</h2>
+    <div className="s-flex s-flex-row">
+      <AssistantPreview
+        description={"OpenAI's most powerful and recent model (128k context)."}
+        isAdded={false}
+        isUpdatingList={false}
+        isWorkspace={false}
+        name={"gpt4"}
+        onShowDetailsClick={() => alert("Details button clicked")}
+        onTestClick={() => alert("Test button clicked")}
+        onUpdate={(action) => {
+          alert(`Update button clicked with action: ${action}`);
+          return;
+        }}
+        pictureUrl={"https://dust.tt/static/systemavatar/gpt4_avatar_full.png"}
+        subtitle={"Stanislas Polu, Pauline Pham"}
+        variant={"lg"}
+      />
+      <AssistantPreview
+        name={"gpt3.5-turbo"}
+        description={"OpenAI's most powerful and recent model (128k context)."}
+        pictureUrl={"https://dust.tt/static/systemavatar/gpt3_avatar_full.png"}
+        subtitle={"Stanislas Polu, Pauline Pham"}
+        onShowDetailsClick={() => alert("Details button clicked")}
+        onUpdate={(action) => {
+          alert(`Update button clicked with action: ${action}`);
+          return;
+        }}
+        variant={"lg"}
+        isWorkspace={false}
+        isAdded={true}
+        isUpdatingList={false}
+      />
+    </div>
+  </div>
+);

--- a/sparkle/src/stories/AssistantPreview.stories.tsx
+++ b/sparkle/src/stories/AssistantPreview.stories.tsx
@@ -15,6 +15,7 @@ export const AssistantPreviewExample = () => (
     <h2>Gallery view (variant: `lg`)</h2>
     <div className="s-flex s-flex-row">
       <AssistantPreview
+        allowAddAction={true}
         description={"OpenAI's most powerful and recent model (128k context)."}
         isAdded={false}
         isUpdatingList={false}
@@ -31,6 +32,7 @@ export const AssistantPreviewExample = () => (
         variant={"lg"}
       />
       <AssistantPreview
+        allowAddAction={true}
         name={"gpt3.5-turbo"}
         description={"OpenAI's most powerful and recent model (128k context)."}
         pictureUrl={"https://dust.tt/static/systemavatar/gpt3_avatar_full.png"}

--- a/sparkle/src/stories/AssistantPreview.stories.tsx
+++ b/sparkle/src/stories/AssistantPreview.stories.tsx
@@ -33,6 +33,7 @@ export const AssistantPreviewExample = () => (
       />
       <AssistantPreview
         allowAddAction={true}
+        allowRemoveAction={true}
         name={"gpt3.5-turbo"}
         description={"OpenAI's most powerful and recent model (128k context)."}
         pictureUrl={"https://dust.tt/static/systemavatar/gpt3_avatar_full.png"}


### PR DESCRIPTION
This PR refactor the `AssistantPreview` component into Sparkle.

Key points to note:
- Sparkle components are designed to be "pure", free from notifications or API logic. Such logic should be managed by parent components like `AssistantPreviewContainer`.
- Currently, our types are not published, which restricts their use in Sparkle. As a temporary solution, we're exposing a range of props to work around this constraint.
- This first PR only support the variant `lg` used in the gallery. So we can test if if serves our needs.


![Storybook-AssistantPreview-LG](https://github.com/dust-tt/dust/assets/7428970/427a933b-8bb7-40a8-b8b1-a1978e5b692f)