### PR TITLE
Hide scrollbar in Inputbar

### DIFF
--- a/front/components/assistant/conversation/input_bar/editor/useCustomEditor.tsx
+++ b/front/components/assistant/conversation/input_bar/editor/useCustomEditor.tsx
@@ -176,7 +176,7 @@ const useCustomEditor = ({
   editor?.setOptions({
     editorProps: {
       attributes: {
-        class: "border-0 outline-none overflow-y-auto h-full",
+        class: "border-0 outline-none overflow-y-auto h-full scrollbar-hide",
       },
       handleKeyDown: (view, event) => {
         if (


### PR DESCRIPTION
This PR resolves https://github.com/dust-tt/dust/issues/3048 by removing the scrollbar of the editor within the input bar.

**Before**

![editor-scrollbar-before](https://github.com/dust-tt/dust/assets/7428970/0bad8649-ed02-4b11-a60e-772554ca3cfc)


**After**

![editor-scrollbar-after](https://github.com/dust-tt/dust/assets/7428970/01681022-577e-4b98-b679-ab8199d95730)
