### PR TITLE
Add more info on log Gdrive Failed to renew webhook

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -1017,7 +1017,15 @@ export async function renewOneWebhook(webhookId: ModelId) {
         await wh.destroy();
         return;
       }
-      logger.error({ error: e }, `Failed to renew webhook`);
+      logger.error(
+        {
+          error: e,
+          connectorId: wh.connectorId,
+          workspaceId: connector.workspaceId,
+          id: wh.id,
+        },
+        `Failed to renew webhook`
+      );
       const tags = [
         `connector_id:${wh.connectorId}`,
         `workspaceId:${connector.workspaceId}`,


### PR DESCRIPTION
It will be more convenient to attach the id of connector/workspace to the error log when investigating a "Failed to renew webhook" error.