### PR TITLE
Support fuzzy search on assistant suggestions in the input bar.

### DIFF
--- a/front/components/assistant/conversation/input_bar/editor/suggestion.ts
+++ b/front/components/assistant/conversation/input_bar/editor/suggestion.ts
@@ -2,7 +2,7 @@ import { ReactRenderer } from "@tiptap/react";
 import tippy from "tippy.js";
 
 import { MentionList } from "@app/components/assistant/conversation/input_bar/editor/MentionList";
-import { subFilter } from "@app/lib/utils";
+import { compareForFuzzySort, subFilter } from "@app/lib/utils";
 
 export interface EditorSuggestion {
   id: string;
@@ -18,22 +18,9 @@ export function makeGetAssistantSuggestions(suggestions: EditorSuggestion[]) {
     items: ({ query }: { query: string }) => {
       const lowerCaseQuery = query.toLowerCase();
 
-      // Higly inspired by `filterAndSortAgents`.
       return suggestions
         .filter((item) => subFilter(lowerCaseQuery, item.label.toLowerCase()))
-        .sort((a, b) => {
-          // Find the index of the token in both strings.
-          const indexA = a.label.toLowerCase().indexOf(lowerCaseQuery);
-          const indexB = b.label.toLowerCase().indexOf(lowerCaseQuery);
-
-          // If the token index is the same, compare the strings lexicographically.
-          if (indexA === indexB) {
-            return a.label.localeCompare(b.label);
-          }
-
-          // Otherwise, sort based on the index of the token's first occurrence.
-          return indexA - indexB;
-        })
+        .sort((a, b) => compareForFuzzySort(lowerCaseQuery, a.label, b.label))
         .slice(0, SUGGESTION_DISPLAY_LIMIT);
     },
 

--- a/front/components/assistant/conversation/input_bar/editor/suggestion.ts
+++ b/front/components/assistant/conversation/input_bar/editor/suggestion.ts
@@ -2,6 +2,7 @@ import { ReactRenderer } from "@tiptap/react";
 import tippy from "tippy.js";
 
 import { MentionList } from "@app/components/assistant/conversation/input_bar/editor/MentionList";
+import { subFilter } from "@app/lib/utils";
 
 export interface EditorSuggestion {
   id: string;
@@ -15,10 +16,24 @@ export function makeGetAssistantSuggestions(suggestions: EditorSuggestion[]) {
   return {
     // TODO: Consider refactoring to eliminate the dependency on tippy.
     items: ({ query }: { query: string }) => {
+      const lowerCaseQuery = query.toLowerCase();
+
+      // Higly inspired by `filterAndSortAgents`.
       return suggestions
-        .filter((item) =>
-          item.label.toLowerCase().startsWith(query.toLowerCase())
-        )
+        .filter((item) => subFilter(lowerCaseQuery, item.label.toLowerCase()))
+        .sort((a, b) => {
+          // Find the index of the token in both strings.
+          const indexA = a.label.toLowerCase().indexOf(lowerCaseQuery);
+          const indexB = b.label.toLowerCase().indexOf(lowerCaseQuery);
+
+          // If the token index is the same, compare the strings lexicographically.
+          if (indexA === indexB) {
+            return a.label.localeCompare(b.label);
+          }
+
+          // Otherwise, sort based on the index of the token's first occurrence.
+          return indexA - indexB;
+        })
         .slice(0, SUGGESTION_DISPLAY_LIMIT);
     },
 

--- a/front/lib/utils.ts
+++ b/front/lib/utils.ts
@@ -128,25 +128,35 @@ export function subFilter(a: string, b: string) {
   return i === a.length;
 }
 
+export function compareForFuzzySort(query: string, a: string, b: string) {
+  // Find the index of the token in both strings.
+  const indexA = a.toLowerCase().indexOf(query);
+  const indexB = b.toLowerCase().indexOf(query);
+
+  // If the token index is the same, compare the strings lexicographically.
+  if (indexA === indexB) {
+    return a.localeCompare(b);
+  }
+
+  // Otherwise, sort based on the index of the token's first occurrence.
+  return indexA - indexB;
+}
+
 export function filterAndSortAgents(
   agents: AgentConfigurationType[],
   searchText: string
 ) {
+  const lowerCaseSearchText = searchText.toLowerCase();
+
   const filtered = agents.filter((a) =>
-    subFilter(searchText.toLowerCase(), a.name.toLowerCase())
+    subFilter(lowerCaseSearchText, a.name.toLowerCase())
   );
 
   // Sort by position of the subFilter in the name (position of the first character matching).
   if (searchText.length > 0) {
-    filtered.sort((a, b) => {
-      const aPos = a.name.toLowerCase().indexOf(searchText[0].toLowerCase());
-      const bPos = b.name.toLowerCase().indexOf(searchText[0].toLowerCase());
-      return aPos - bPos;
-    });
-
-    // Finally sort by length of the name. Only do so if we filtered by a subsequence as otherwise
-    // we want to preserve the initial ordering of agents.
-    filtered.sort((a, b) => a.name.length - b.name.length);
+    filtered.sort((a, b) =>
+      compareForFuzzySort(lowerCaseSearchText, a.name, b.name)
+    );
   }
 
   return filtered;


### PR DESCRIPTION
This PR resolves https://github.com/dust-tt/dust/issues/3055.

While refactoring the `InputBar` we oversaw the assistant suggestions and introduced a regression that only support prefix matching. This PR introduces support for fuzzy search like it used to be before. It adds the need to sort as well to have a predictable order.

![input-bar-fuzzy-search](https://github.com/dust-tt/dust/assets/7428970/860549ec-5c99-447f-b59a-3a6a7940b352)
