### PR TITLE
Hide database blocks on Dust apps until ready to be used

### DIFF
--- a/front/components/app/NewBlock.tsx
+++ b/front/components/app/NewBlock.tsx
@@ -1,18 +1,21 @@
 import { Button } from "@dust-tt/sparkle";
-import { SpecificationType } from "@dust-tt/types";
+import { SpecificationType, WorkspaceType } from "@dust-tt/types";
 import { BlockType } from "@dust-tt/types";
 import { Menu } from "@headlessui/react";
 import { PlusIcon } from "@heroicons/react/20/solid";
 
+import { isActivatedStructuredDB } from "@app/lib/development";
 import { classNames } from "@app/lib/utils";
 
 export default function NewBlock({
+  owner,
   spec,
   disabled,
   onClick,
   direction,
   small,
 }: {
+  owner: WorkspaceType;
   spec: SpecificationType;
   disabled: boolean;
   onClick: (type: BlockType | "map_reduce" | "while_end") => void;
@@ -95,19 +98,24 @@ export default function NewBlock({
       name: "While End",
       description: "Loop over a set of blocks until a condition is met.",
     },
-    {
-      type: "database",
-      typeNames: ["database"],
-      name: "Database",
-      description: "Query a database.",
-    },
-    {
-      type: "database_schema",
-      typeNames: ["database_schema"],
-      name: "Database Schema",
-      description: "Retrieve the schema of a database.",
-    },
   ];
+
+  if (isActivatedStructuredDB(owner)) {
+    blocks.push(
+      {
+        type: "database",
+        typeNames: ["database"],
+        name: "Database",
+        description: "Query a database.",
+      },
+      {
+        type: "database_schema",
+        typeNames: ["database_schema"],
+        name: "Database Schema",
+        description: "Retrieve the schema of a database.",
+      }
+    );
+  }
 
   if (!containsInput) {
     blocks.splice(0, 0, {

--- a/front/components/app/blocks/Block.tsx
+++ b/front/components/app/blocks/Block.tsx
@@ -158,6 +158,7 @@ export default function Block({
           >
             <div className="mr-1 mt-1 flex-initial text-gray-400">
               <NewBlock
+                owner={owner}
                 disabled={readOnly}
                 onClick={onBlockNew}
                 spec={spec}

--- a/front/pages/w/[wId]/a/[aId]/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/index.tsx
@@ -340,6 +340,7 @@ export default function AppView({
         <div className="mt-8 flex flex-auto flex-col">
           <div className="mb-4 flex flex-row items-center space-x-2">
             <NewBlock
+              owner={owner}
               disabled={readOnly}
               onClick={async (blockType) => {
                 await handleNewBlock(null, blockType);
@@ -445,6 +446,7 @@ export default function AppView({
             <div className="my-4 flex flex-row items-center space-x-2">
               <div className="flex">
                 <NewBlock
+                  owner={owner}
                   disabled={readOnly}
                   onClick={async (blockType) => {
                     await handleNewBlock(null, blockType);


### PR DESCRIPTION
Do not let users add new blocks of type database/database_schema on Dust apps as they are not ready to be used yet. 