### PR TITLE
Add vim, redis-cli and psql to front docker image

### DIFF
--- a/front/Dockerfile
+++ b/front/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:18.15.0 as front
 
+RUN apt-get update && apt-get install vim redis-tools postgresql-client
+
 WORKDIR /types
 COPY /types/package*.json ./
 COPY /types/ .

--- a/front/Dockerfile
+++ b/front/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:18.15.0 as front
 
-RUN apt-get update && apt-get install vim redis-tools postgresql-client
+RUN apt-get update && apt-get install -y vim redis-tools postgresql-client
 
 WORKDIR /types
 COPY /types/package*.json ./


### PR DESCRIPTION
This PR adds some utils to our `front` docker image.

It adds:
- `vim`
- `psql`
- `redis-cli`