### PR TITLE
DX Import non-relative paths

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,6 @@
     "source.organizeImports": false,
     "source.fixAll.eslint": true
   },
-  "eslint.run": "onSave"
+  "eslint.run": "onSave",
+  "typescript.preferences.importModuleSpecifier": "non-relative"
 }


### PR DESCRIPTION
This PR updates the shared VScode config to use the `non-relative` imports.

This goes with the current standards to use:
`import { isLargeModel } from "@app/lib/assistant";` over `import { isLargeModel } from "../../lib/assistant";`