### PR TITLE
Memoize extra agent configurations.

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -7,6 +7,7 @@ import {
   Fragment,
   useContext,
   useEffect,
+  useMemo,
   useState,
 } from "react";
 import { mutate } from "swr";
@@ -68,15 +69,15 @@ export function AssistantInputBar({
       workspaceId: owner.sId,
       agentsGetView: conversationId ? { conversationId } : "list",
     });
-  const agentConfigurationsToAdd = additionalAgentConfigurations
-    ? additionalAgentConfigurations.filter(
-        (a) => !baseAgentConfigurations.find((b) => a.sId === b.sId)
-      )
-    : [];
-  const agentConfigurations = [
-    ...baseAgentConfigurations,
-    ...agentConfigurationsToAdd,
-  ];
+
+  const agentConfigurations = useMemo(() => {
+    const agentConfigurationsToAdd = additionalAgentConfigurations
+      ? additionalAgentConfigurations.filter(
+          (a) => !baseAgentConfigurations.find((b) => a.sId === b.sId)
+        )
+      : [];
+    return [...baseAgentConfigurations, ...agentConfigurationsToAdd];
+  }, [baseAgentConfigurations, additionalAgentConfigurations]);
 
   const sendNotification = useContext(SendNotificationsContext);
 


### PR DESCRIPTION
This PR addresses the recently introduced regression (https://github.com/dust-tt/dust/pull/3016) that resulted in multiple re-renders, which cleared the content from the input bar. The issue stemmed from alterations to the values returned by a hook that retains changes.

The issue comes from those lines: 
https://github.com/dust-tt/dust/blob/091e62d49492ba24a4b9736ed8e2fae23a2c48c6/front/components/assistant/conversation/input_bar/InputBar.tsx#L71-L79

**Before:**

![editor-cleared](https://github.com/dust-tt/dust/assets/7428970/d5a6c37f-f2b8-4d44-8c30-38048f692d7b)

**After:**

![editor-does-not-clear](https://github.com/dust-tt/dust/assets/7428970/35949ded-1281-4dcb-afad-f01537893323)

