### PR TITLE
Centralize account_inactive error in Slack Client

### DIFF
--- a/connectors/src/connectors/slack/lib/slack_client.ts
+++ b/connectors/src/connectors/slack/lib/slack_client.ts
@@ -3,10 +3,11 @@ import {
   CodedError,
   ErrorCode,
   WebAPIHTTPError,
+  WebAPIPlatformError,
   WebClient,
 } from "@slack/web-api";
 
-import { WorkflowError } from "@connectors/lib/error";
+import { ExternalOauthTokenError, WorkflowError } from "@connectors/lib/error";
 import { Connector } from "@connectors/lib/models";
 import { getAccessTokenFromNango } from "@connectors/lib/nango_helpers";
 const { NANGO_SLACK_CONNECTOR_ID } = process.env;
@@ -78,6 +79,16 @@ export async function getSlackClient(
               __is_dust_error: true,
             };
             throw workflowError;
+          }
+        }
+        if (slackError.code === ErrorCode.PlatformError) {
+          const platformError = e as WebAPIPlatformError;
+          if (
+            ["account_inactive", "invalid_auth"].includes(
+              platformError.data.error
+            )
+          ) {
+            throw new ExternalOauthTokenError();
           }
         }
         throw e;


### PR DESCRIPTION
### Context

We had two workflows `slackGarbageCollectorWorkflow` that errors with `Error: An API error occurred: account_inactive`.
See here the [error logs](https://app.datadoghq.eu/logs?query=%22Unhandled%20activity%20error%22%20%40activityName%3AgetChannelsToGarbageCollect&cols=service%2C%40workflowName%2C%40activityName%2C%40error.__is_dust_error&index=%2A&messageDisplay=inline&refresh_mode=sliding&saved-view-id=99803&stream_sort=%40duration%2Cdesc&viz=stream&from_ts=1704298311168&to_ts=1704384711168&live=true). 

This specific error occurs when the Slackbot has been deactivated. 

The two workflows have been cancelled and I contacted the users to ask them if we can reinstall their Slack connection.

### Proposal

To avoid having again a stuck workflow for this reason I discussed this issue with @lasryaric.
Recommendation was to raise an `ExternalOauthTokenError` whenever we try to access to a SlackClient and the Slack api answers with `account_inactive`.

This is what's implemented in this PR. 

The `ExternalOauthTokenError` will be caught [here](https://github.com/dust-tt/dust/blob/main/connectors/src/lib/temporal_monitoring.ts#L106C1-L117) to cancel the workflow and error the connector. 



### Note

Here again I'm not sure how to easily reproduce to test in local, so this is untested. 
Being the runner is slowly turning me into a 🤠 