### PR TITLE
Fix the API key smooth scroll

### DIFF
--- a/front/pages/w/[wId]/a/index.tsx
+++ b/front/pages/w/[wId]/a/index.tsx
@@ -101,7 +101,7 @@ export function APIKeys({ owner }: { owner: WorkspaceType }) {
       const mainTag = document.querySelector("main");
       if (mainTag) {
         mainTag.scrollTo({
-          top: document.body.scrollHeight,
+          top: mainTag.scrollHeight,
           behavior: "smooth",
         });
       }


### PR DESCRIPTION
This PR resolves https://github.com/dust-tt/tasks/issues/317. After an API Key is created, we scroll to the top of the main div instead of the bottom. This is fixed by using the proper element's height. However, the solution is not yet ideal because the revoked key is shown at the end of the list. Something for later on.