### PR TITLE
Stripe Checkout: Allow setting a coupon code

### DIFF
--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -109,6 +109,7 @@ export const createCheckoutSession = async ({
       planCode: planCode,
     },
     line_items: [item],
+    allow_promotion_codes: true,
     billing_address_collection: "auto",
     automatic_tax: {
       enabled: true,


### PR DESCRIPTION
https://stripe.com/docs/payments/checkout/discounts


Looks like that: 
<img width="533" alt="Screenshot 2024-01-05 at 15 26 10" src="https://github.com/dust-tt/dust/assets/3803406/f2c5ff80-558c-4acc-8bd8-a71ab47ac06e">
