### PR TITLE
Support long format for time ago

### DIFF
--- a/front/lib/utils.ts
+++ b/front/lib/utils.ts
@@ -39,7 +39,14 @@ export const utcDateFrom = (millisSinceEpoch: number | string | Date) => {
   return d.toUTCString();
 };
 
-export const timeAgoFrom = (millisSinceEpoch: number) => {
+function maybePlural(unit: number, label: string) {
+  return `${label}${unit > 1 ? "s" : ""}`;
+}
+
+export const timeAgoFrom = (
+  millisSinceEpoch: number,
+  { useLongFormat = false }: { useLongFormat?: boolean } = {}
+) => {
   // return the duration elapsed from the given time to now in human readable format (using seconds, minutes, days)
   const now = new Date().getTime();
   const diff = now - millisSinceEpoch;
@@ -50,19 +57,19 @@ export const timeAgoFrom = (millisSinceEpoch: number) => {
   const months = Math.floor(days / 30);
   const years = Math.floor(days / 365);
   if (years > 0) {
-    return years + "y";
+    return `${years}${useLongFormat ? maybePlural(years, " year") : "y"}`;
   }
   if (months > 0) {
-    return months + "m";
+    return `${months}${useLongFormat ? maybePlural(months, " month") : "m"}`;
   }
   if (days > 0) {
-    return days + "d";
+    return `${days}${useLongFormat ? maybePlural(days, " day") : "d"}`;
   }
   if (hours > 0) {
-    return hours + "h";
+    return `${hours}${useLongFormat ? maybePlural(hours, " hour") : "h"}`;
   }
   if (minutes > 0) {
-    return minutes + "m";
+    return `${minutes}${useLongFormat ? maybePlural(minutes, " minute") : "m"}`;
   }
   return seconds + "s";
 };

--- a/front/pages/w/[wId]/a/index.tsx
+++ b/front/pages/w/[wId]/a/index.tsx
@@ -195,7 +195,7 @@ export function APIKeys({ owner }: { owner: WorkspaceType }) {
                     </div>
                     <p className="front-normal text-xs text-element-700">
                       Created {key.creator ? `by ${key.creator} ` : ""}
-                      {timeAgoFrom(key.createdAt)} ago.
+                      {timeAgoFrom(key.createdAt, { useLongFormat: true })} ago.
                     </p>
                   </div>
                 </div>


### PR DESCRIPTION
Add support for `useLongFormat` to `timeAgo` to avoid confusion between minutes and months both symbolized by `m`.

<img width="907" alt="image" src="https://github.com/dust-tt/dust/assets/7428970/8f900dec-5f8e-4d70-87a4-7593875bf3b2">
