### PR TITLE
Introducing paymentstatus in Subscription model

### DIFF
--- a/front/lib/models/plan.ts
+++ b/front/lib/models/plan.ts
@@ -3,7 +3,9 @@ import {
   FreeBillingType,
   PAID_BILLING_TYPES,
   PaidBillingType,
+  SUBSCRIPTION_PAYMENT_STATUSES,
   SUBSCRIPTION_STATUSES,
+  SubscriptionPaymentStatusType,
   SubscriptionStatusType,
 } from "@dust-tt/types";
 import {
@@ -148,6 +150,7 @@ export class Subscription extends Model<
 
   declare sId: string; // unique
   declare status: SubscriptionStatusType;
+  declare paymentStatus: SubscriptionPaymentStatusType | null;
   declare startDate: Date;
   declare endDate: Date | null;
 
@@ -186,6 +189,13 @@ Subscription.init(
       allowNull: false,
       validate: {
         isIn: [SUBSCRIPTION_STATUSES],
+      },
+    },
+    paymentStatus: {
+      type: DataTypes.STRING,
+      allowNull: true,
+      validate: {
+        isIn: [SUBSCRIPTION_PAYMENT_STATUSES],
       },
     },
     startDate: {

--- a/types/src/front/plan.ts
+++ b/types/src/front/plan.ts
@@ -41,6 +41,10 @@ export type PaidBillingType = (typeof PAID_BILLING_TYPES)[number];
 export const SUBSCRIPTION_STATUSES = ["active", "ended"] as const;
 export type SubscriptionStatusType = (typeof SUBSCRIPTION_STATUSES)[number];
 
+export const SUBSCRIPTION_PAYMENT_STATUSES = ["succeeded", "past_due"] as const;
+export type SubscriptionPaymentStatusType =
+  (typeof SUBSCRIPTION_PAYMENT_STATUSES)[number];
+
 export type PlanType = {
   code: string;
   name: string;


### PR DESCRIPTION
### Context

We want to properly handle workspaces in Past due payment: https://github.com/dust-tt/tasks/issues/315

I will split this work into 3 PRs: 
1. Add a new field `paymentStatus` to the subscription model, to allow us to track workspaces in past due payment. 
2. Update Stripe webhook to handle events payment success and failed to set the valid payment status and notifiy admins per email if there's a failed payment. 
3. Display a banner on the workspace when subscription is in past_due & prevent adding new members to the workspace.

This is PR 1.

### Deployment

Requires an init_db but column is not used yet, so safe to run even on Front.