### PR TITLE
GitHub code syncing logic

### DIFF
--- a/connectors/src/admin/cli.ts
+++ b/connectors/src/admin/cli.ts
@@ -135,12 +135,12 @@ const github = async (command: string, args: parseArgs.ParsedArgs) => {
 
       const installationId = connector.connectionId;
 
-      const { tempDir, files, directories } = await processRepository(
+      const { tempDir, files, directories } = await processRepository({
         installationId,
-        args.owner,
-        args.repo,
-        "999"
-      );
+        repoLogin: args.owner,
+        repoName: args.repo,
+        repoId: "999",
+      });
 
       files.forEach((f) => {
         console.log(f);

--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -52,6 +52,7 @@ export async function createGithubConnector(
         {
           connectorId: connector.id,
           webhooksEnabledAt: new Date(),
+          codeSyncEnabled: false,
         },
         { transaction }
       );

--- a/connectors/src/connectors/github/lib/github_api.ts
+++ b/connectors/src/connectors/github/lib/github_api.ts
@@ -609,16 +609,21 @@ async function* getFiles(dir: string): AsyncGenerator<string> {
 // This function returns file and directories object with parent, internalIds, and sourceUrl
 // information. The root of the directory is considered the null parent (and will have to be
 // stitched by the activity).
-export async function processRepository(
-  installationId: string,
-  login: string,
-  repoName: string,
-  repoId: string
-) {
+export async function processRepository({
+  installationId,
+  repoLogin,
+  repoName,
+  repoId,
+}: {
+  installationId: string;
+  repoLogin: string;
+  repoName: string;
+  repoId: string;
+}) {
   const octokit = await getOctokit(installationId);
 
   const { data } = await octokit.rest.repos.get({
-    owner: login,
+    owner: repoLogin,
     repo: repoName,
   });
   const defaultBranch = data.default_branch;
@@ -643,7 +648,7 @@ export async function processRepository(
   const { data: tarballStream } = (await octokit.request(
     "GET /repos/{owner}/{repo}/tarball/{ref}",
     {
-      owner: login,
+      owner: repoLogin,
       repo: repoName,
       ref: defaultBranch,
       request: {
@@ -737,7 +742,7 @@ export async function processRepository(
         files.push({
           fileName,
           filePath: path,
-          sourceUrl: `https://github.com/${login}/${repoName}/blob/${defaultBranch}/${join(
+          sourceUrl: `https://github.com/${repoLogin}/${repoName}/blob/${defaultBranch}/${join(
             path.join("/"),
             fileName
           )}`,
@@ -763,7 +768,7 @@ export async function processRepository(
           directories.push({
             dirName,
             dirPath,
-            sourceUrl: `https://github.com/${login}/${repoName}/blob/${defaultBranch}/${join(
+            sourceUrl: `https://github.com/${repoLogin}/${repoName}/blob/${defaultBranch}/${join(
               dirPath.join("/"),
               dirName
             )}`,

--- a/connectors/src/connectors/github/temporal/activities.ts
+++ b/connectors/src/connectors/github/temporal/activities.ts
@@ -795,8 +795,12 @@ export async function githubCodeSyncActivity(
       "Downloaded Github repository for sync"
     );
 
-    // From here everything happens locally this is a big activity but if retried we're really just
-    // retrying downloading the repository externally.
+    // From here everything happens locally or consists in upserting data. This is a big activity
+    // but if retried we're really just retrying downloading the repository externally and the
+    // upserts that succeeded before won't be retried as their associated GithubCodeFile object will
+    // have been updated. This means that while the syncing is not succeeedd we might have slightly
+    // incoherent state (files that moved will appear twice before final cleanup). This seems fine
+    // given that syncing stallness is already considered an incident.
 
     const codeSyncStartedAt = new Date();
     const rootInternalId = `github-code-${repoId}`;

--- a/connectors/src/connectors/github/temporal/workflows.ts
+++ b/connectors/src/connectors/github/temporal/workflows.ts
@@ -215,6 +215,8 @@ export async function githubRepoSyncWorkflow(
     nextCursor = cursor;
   }
 
+  // TOOD(spolu) add code syncing
+
   await Promise.all(promises);
 }
 

--- a/connectors/src/lib/models/github.ts
+++ b/connectors/src/lib/models/github.ts
@@ -158,3 +158,81 @@ GithubDiscussion.init(
   }
 );
 Connector.hasMany(GithubDiscussion);
+
+export class GithubCodeFile extends Model<
+  InferAttributes<GithubCodeFile>,
+  InferCreationAttributes<GithubCodeFile>
+> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+  declare lastSeenAt: CreationOptional<Date>;
+
+  declare repoId: string;
+  declare documentId: string;
+  declare parentInternalId: string;
+
+  declare fileName: string;
+  declare sourceUrl: string;
+  declare contentHash: string;
+
+  declare connectorId: ForeignKey<Connector["id"]>;
+}
+GithubCodeFile.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    lastSeenAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    repoId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    documentId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    parentInternalId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    fileName: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    sourceUrl: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    contentHash: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+  },
+  {
+    sequelize: sequelize_conn,
+    indexes: [
+      { fields: ["connectorId", "repoId", "internalId"], unique: true },
+      { fields: ["connectorId"] },
+      { fields: ["connectorId", "repoId", "updatedAt"] },
+    ],
+    modelName: "github_code_files",
+  }
+);
+Connector.hasMany(GithubIssue);

--- a/connectors/src/lib/models/github.ts
+++ b/connectors/src/lib/models/github.ts
@@ -228,11 +228,82 @@ GithubCodeFile.init(
   {
     sequelize: sequelize_conn,
     indexes: [
-      { fields: ["connectorId", "repoId", "internalId"], unique: true },
-      { fields: ["connectorId"] },
-      { fields: ["connectorId", "repoId", "updatedAt"] },
+      { fields: ["connectorId", "repoId", "documentId"], unique: true },
+      { fields: ["connectorId", "repoId", "lastSeenAt"] },
     ],
     modelName: "github_code_files",
   }
 );
-Connector.hasMany(GithubIssue);
+Connector.hasMany(GithubCodeFile);
+
+export class GithubCodeDirectory extends Model<
+  InferAttributes<GithubCodeDirectory>,
+  InferCreationAttributes<GithubCodeDirectory>
+> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+  declare lastSeenAt: CreationOptional<Date>;
+
+  declare repoId: string;
+  declare internalId: string;
+  declare parentInternalId: string;
+
+  declare dirName: string;
+  declare sourceUrl: string;
+
+  declare connectorId: ForeignKey<Connector["id"]>;
+}
+GithubCodeDirectory.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    lastSeenAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    repoId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    internalId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    parentInternalId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    dirName: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    sourceUrl: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+  },
+  {
+    sequelize: sequelize_conn,
+    indexes: [
+      { fields: ["connectorId", "repoId", "internalId"], unique: true },
+      { fields: ["connectorId", "repoId", "lastSeenAt"] },
+    ],
+    modelName: "github_code_directories",
+  }
+);
+Connector.hasMany(GithubCodeDirectory);

--- a/connectors/src/lib/models/github.ts
+++ b/connectors/src/lib/models/github.ts
@@ -18,6 +18,7 @@ export class GithubConnectorState extends Model<
   declare updatedAt: CreationOptional<Date>;
 
   declare webhooksEnabledAt?: Date | null;
+  declare codeSyncEnabled: boolean;
 
   declare connectorId: ForeignKey<Connector["id"]>;
 }
@@ -41,6 +42,11 @@ GithubConnectorState.init(
     webhooksEnabledAt: {
       type: DataTypes.DATE,
       allowNull: true,
+    },
+    codeSyncEnabled: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
     },
   },
   {


### PR DESCRIPTION
Introduces the `GithubCodeSyncActivity` which:
- checks the connector state `codeSyncEnabled`, exits early if false
- call `processRepository` got get a list of `files` and `directories` to sync
- sync files, update the `lastSeenAt` field for all files retrieved, updating the ones that changed
- sync directories, bump `updatedAt` if a file was changed under a directory (see `updatedDirectories`) and bump the `lastSeenAt`
- finally removes all files and directories that were not seen since the beginning of the activity

The activity is a bit big, but, it has only one github dependency (the initial tar download) and make progress even in case of failures of upsertion (we save the files object as we upsert them and won't re-upsert them if an upsertion fails and the activity restarts)

In case of upsertion failure, the previously upserted files have been udpated and won't require a new update. In the next run only their `lastSeenAt` will be mutated (which is 0 failure rate).

This activity is not yet plugged in workflows, next steps:
- plug it in sync repo workflow
- create a workflow for daily update

(full end-to-end test will be done as I plug it in at the workflow logic)

Fixes: https://github.com/dust-tt/dust/issues/3029