### PR TITLE
Stripe webhook: Answer 200 when we don't want to process the webhook and not retry it

### DIFF
--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -183,7 +183,7 @@ async function handler(
                   "[Stripe Webhook] Received checkout.session.completed when we already have a subscription for this plan on the workspace. Check on Stripe dashboard."
                 );
 
-                return res.status(409).json({
+                return res.status(200).json({
                   success: false,
                   message:
                     "Conflict: Active subscription already exists for this workspace/plan.",
@@ -205,7 +205,7 @@ async function handler(
                   "[Stripe Webhook] Received checkout.session.completed when we already have a subscription with payment on the workspace. Check on Stripe dashboard."
                 );
 
-                return res.status(409).json({
+                return res.status(200).json({
                   success: false,
                   message:
                     "Conflict: Active subscription with payment already exists for this workspace.",


### PR DESCRIPTION
### Context 

We currently error the webhook when there's already an active paid subscription for a workspace.
That causes it to be retried by Stripe, which is not what we want. We want to be alerted only.

https://dust4ai.slack.com/archives/C05F84CFP0E/p1704489085572599?thread_ts=1704488974.893049&cid=C05F84CFP0E

### Change

Still do not process the webhook, but answer a 200 so it is not retried.
We will still get the Monitor from Datadog if that happens so we can check manually if there's an issue, and if we need to retry the webhook we can do it manually from Stripe dashboard.