### PR TITLE
Stripe: Handle payment invoices and notify user

### DIFF
--- a/front/components/sparkle/AppLayout.tsx
+++ b/front/components/sparkle/AppLayout.tsx
@@ -461,15 +461,15 @@ function SubscriptionEndBanner({ endDate }: { endDate: number }) {
 function SubscriptionPastDueBanner() {
   return (
     <div className="border-y border-warning-200 bg-warning-100 px-3 py-3 text-xs text-warning-900">
-      <div className="font-bold">Oh no, your payment failed!</div>
+      <div className="font-bold">Your payment has failed!</div>
       <div className="font-normal">
         <br />
         Please make sure to update your payment method in the Admin section to
-        keep your account. We will retry in a few days.
+        maintain access to your workspace. We will retry in a few days.
         <br />
         <br />
-        Careful! After 3 retry, your workspace will be downgraded to the free
-        plan. Connections will be deleted and members will be revoked. Details{" "}
+        After 3 attempts, your workspace will be downgraded to the free plan.
+        Connections will be deleted and members will be revoked. Details{" "}
         <Link
           href="https://dust-tt.notion.site/What-happens-when-we-cancel-our-Dust-subscription-59aad3866dcc4bbdb26a54e1ce0d848a?pvs=4"
           target="_blank"

--- a/front/components/sparkle/AppLayout.tsx
+++ b/front/components/sparkle/AppLayout.tsx
@@ -112,6 +112,7 @@ function NavigationBar({
         {subscription.endDate && (
           <SubscriptionEndBanner endDate={subscription.endDate} />
         )}
+        {subscription.paymentFailingSince && <SubscriptionPastDueBanner />}
         {nav.length > 1 && (
           <div className="pt-2">
             <Tab tabs={nav} />
@@ -444,6 +445,31 @@ function SubscriptionEndBanner({ endDate }: { endDate: number }) {
       <div className="font-bold">Subscription ending on {formattedEndDate}</div>
       <div className="font-normal">
         Connections will be deleted and members will be revoked. Details{" "}
+        <Link
+          href="https://dust-tt.notion.site/What-happens-when-we-cancel-our-Dust-subscription-59aad3866dcc4bbdb26a54e1ce0d848a?pvs=4"
+          target="_blank"
+          className="underline"
+        >
+          here
+        </Link>
+        .
+      </div>
+    </div>
+  );
+}
+
+function SubscriptionPastDueBanner() {
+  return (
+    <div className="border-y border-warning-200 bg-warning-100 px-3 py-3 text-xs text-warning-900">
+      <div className="font-bold">Oh no, your payment failed!</div>
+      <div className="font-normal">
+        <br />
+        Please make sure to update your payment method in the Admin section to
+        keep your account. We will retry in a few days.
+        <br />
+        <br />
+        Careful! After 3 retry, your workspace will be downgraded to the free
+        plan. Connections will be deleted and members will be revoked. Details{" "}
         <Link
           href="https://dust-tt.notion.site/What-happens-when-we-cancel-our-Dust-subscription-59aad3866dcc4bbdb26a54e1ce0d848a?pvs=4"
           target="_blank"

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -519,6 +519,7 @@ export async function subscriptionForWorkspace(
       "stripeCustomerId",
       "startDate",
       "endDate",
+      "paymentFailingSince",
     ],
     where: { workspaceId: w.id, status: "active" },
     include: [
@@ -558,6 +559,8 @@ export async function subscriptionForWorkspace(
     stripeCustomerId: activeSubscription?.stripeCustomerId || null,
     startDate: startDate?.getTime() || null,
     endDate: endDate?.getTime() || null,
+    paymentFailingSince:
+      activeSubscription?.paymentFailingSince?.getTime() || null,
     plan: {
       code: plan.code,
       name: plan.name,

--- a/front/lib/email.ts
+++ b/front/lib/email.ts
@@ -161,3 +161,27 @@ export async function sendAdminDowngradeTooMuchDataEmail(
   };
   return sendEmail(email, message);
 }
+
+export async function sendAdminSubscriptionPaymentFailedEmail(
+  email: string,
+  customerPortailUrl: string | null
+): Promise<void> {
+  const message = {
+    from: {
+      name: "Dust team",
+      email: "team@dust.tt",
+    },
+    subject: `[Dust] Your payment has failed`,
+    html: `<p>Hello from Dust,</p>
+    <p>Your payment has failed. Please visit ${customerPortailUrl} to edit your payment information.</p>
+    <p>
+      Please note failed payments are retried 3 times before downgrading your workspace, 
+      removing any feature attached to the paid plan you were on, and permanently deleting connections and the data associated with them.
+      Any assistant that are linked to connections will also be removed.
+    </p>
+    <p>Please reply to this email if you have any questions.</p>
+    <br />
+    <p>The Dust team</p>`,
+  };
+  return sendEmail(email, message);
+}

--- a/front/lib/email.ts
+++ b/front/lib/email.ts
@@ -175,9 +175,7 @@ export async function sendAdminSubscriptionPaymentFailedEmail(
     html: `<p>Hello from Dust,</p>
     <p>Your payment has failed. Please visit ${customerPortailUrl} to edit your payment information.</p>
     <p>
-      Please note failed payments are retried 3 times before downgrading your workspace, 
-      removing any feature attached to the paid plan you were on, and permanently deleting connections and the data associated with them.
-      Any assistant that are linked to connections will also be removed.
+      Please note: your workspace will be downgraded after 3 failed payment retries. This will trigger the removal of any feature attached to the paid plan you were on, and the permanent deletion of connections and the data associated with them. Any assistant that are linked to connections will also be removed.
     </p>
     <p>Please reply to this email if you have any questions.</p>
     <br />

--- a/front/lib/models/plan.ts
+++ b/front/lib/models/plan.ts
@@ -3,9 +3,7 @@ import {
   FreeBillingType,
   PAID_BILLING_TYPES,
   PaidBillingType,
-  SUBSCRIPTION_PAYMENT_STATUSES,
   SUBSCRIPTION_STATUSES,
-  SubscriptionPaymentStatusType,
   SubscriptionStatusType,
 } from "@dust-tt/types";
 import {
@@ -150,7 +148,9 @@ export class Subscription extends Model<
 
   declare sId: string; // unique
   declare status: SubscriptionStatusType;
-  declare paymentStatus: SubscriptionPaymentStatusType | null;
+  declare paymentStatus: string | null; // to be removed
+  declare paymentFailingSince: Date | null;
+
   declare startDate: Date;
   declare endDate: Date | null;
 
@@ -194,9 +194,10 @@ Subscription.init(
     paymentStatus: {
       type: DataTypes.STRING,
       allowNull: true,
-      validate: {
-        isIn: [SUBSCRIPTION_PAYMENT_STATUSES],
-      },
+    },
+    paymentFailingSince: {
+      type: DataTypes.DATE,
+      allowNull: true,
     },
     startDate: {
       type: DataTypes.DATE,

--- a/front/lib/plans/subscription.ts
+++ b/front/lib/plans/subscription.ts
@@ -63,6 +63,7 @@ export const internalSubscribeWorkspaceToFreeTestPlan = async ({
     stripeCustomerId: null,
     startDate: null,
     endDate: null,
+    paymentFailingSince: null,
     plan: {
       code: freeTestPlan.code,
       name: freeTestPlan.name,
@@ -160,6 +161,7 @@ export const internalSubscribeWorkspaceToFreeUpgradedPlan = async ({
       stripeCustomerId: newSubscription.stripeCustomerId,
       startDate: newSubscription.startDate.getTime(),
       endDate: newSubscription.endDate?.getTime() || null,
+      paymentFailingSince: null,
       plan: {
         code: plan.code,
         name: plan.name,

--- a/front/pages/w/[wId]/subscription/index.tsx
+++ b/front/pages/w/[wId]/subscription/index.tsx
@@ -1,4 +1,5 @@
 import {
+  ArrowPathIcon,
   Button,
   Chip,
   ExternalLinkIcon,
@@ -215,10 +216,22 @@ export default function Subscription({
                     <Page.H variant="h5">Payment, invoicing & billing</Page.H>
                     <div className="pt-2">
                       <Button
-                        icon={ExternalLinkIcon}
+                        icon={
+                          subscription.paymentFailingSince
+                            ? ArrowPathIcon
+                            : ExternalLinkIcon
+                        }
                         size="sm"
-                        variant="secondary"
-                        label="Visit Dust's dashboard on Stripe"
+                        variant={
+                          subscription.paymentFailingSince
+                            ? "secondaryWarning"
+                            : "secondary"
+                        }
+                        label={
+                          subscription.paymentFailingSince
+                            ? "Update your payment method"
+                            : "Visit Dust's dashboard on Stripe"
+                        }
                         disabled={isProcessing}
                         onClick={async () => await handleGoToStripePortal()}
                       />

--- a/types/src/front/plan.ts
+++ b/types/src/front/plan.ts
@@ -41,10 +41,6 @@ export type PaidBillingType = (typeof PAID_BILLING_TYPES)[number];
 export const SUBSCRIPTION_STATUSES = ["active", "ended"] as const;
 export type SubscriptionStatusType = (typeof SUBSCRIPTION_STATUSES)[number];
 
-export const SUBSCRIPTION_PAYMENT_STATUSES = ["succeeded", "past_due"] as const;
-export type SubscriptionPaymentStatusType =
-  (typeof SUBSCRIPTION_PAYMENT_STATUSES)[number];
-
 export type PlanType = {
   code: string;
   name: string;
@@ -60,6 +56,7 @@ export type SubscriptionType = {
   stripeCustomerId: string | null;
   startDate: number | null;
   endDate: number | null;
+  paymentFailingSince: number | null;
   plan: PlanType;
 };
 


### PR DESCRIPTION
### Context

We want to properly handle workspaces in Past due payment: https://github.com/dust-tt/tasks/issues/315

- Add a new field `paymentFailingSince` to the subscription model, to allow us to track workspaces in past due payment.
- Update Stripe webhook to handle events payment success and failed to set the valid payment status and notifiy admins per email if there's a failed payment.
- Display a banner on the workspace when subscription is in past_due & prevent adding new members to the workspace.
This is PR 1.


I'll share wording on Slack to make them validate by Gab (here: https://dust4ai.slack.com/archives/C050A0S2Z7F/p1704705594362979)


### Deployment

I this PR I introduced a `paymentStatus` field.
Here instead I'm setting a date field so we store since when it's failing.  -> https://github.com/dust-tt/dust/pull/3084
Meaning I should merge the revert of this PR first: https://github.com/dust-tt/dust/pull/3092/files

1/ Merge https://github.com/dust-tt/dust/pull/3092/files
2/ Deploy front
4/ Merge this PR
5/ Run migration on Front edge
6/ Deploy front
7/ Write migration to manually remove `paymentStatus` column 