### PR TITLE
Poké: allow upgrading to a free plan

### DIFF
--- a/front/pages/api/poke/workspaces/[wId]/upgrade.ts
+++ b/front/pages/api/poke/workspaces/[wId]/upgrade.ts
@@ -5,7 +5,7 @@ import { NextApiRequest, NextApiResponse } from "next";
 import { Authenticator, getSession } from "@app/lib/auth";
 import {
   internalSubscribeWorkspaceToFreeUpgradedPlan,
-  pokeInviteWorkspaceToEnterprisePlan,
+  pokeUpgradeOrInviteWorkspaceToPlan,
 } from "@app/lib/plans/subscription";
 import { apiError, withLogging } from "@app/logger/withlogging";
 
@@ -45,7 +45,7 @@ async function handler(
           workspaceId: owner.sId,
         });
       } else {
-        await pokeInviteWorkspaceToEnterprisePlan(auth, planCode);
+        await pokeUpgradeOrInviteWorkspaceToPlan(auth, planCode);
       }
 
       return res.status(200).json({

--- a/front/pages/poke/[wId]/index.tsx
+++ b/front/pages/poke/[wId]/index.tsx
@@ -419,7 +419,7 @@ const WorkspacePage = ({
     }
   });
 
-  const { submit: onInviteToEnterprisePlan } = useSubmitFunction(
+  const { submit: onUpgradeOrInviteToPlan } = useSubmitFunction(
     async (plan: PlanType) => {
       if (
         !window.confirm(
@@ -535,7 +535,7 @@ const WorkspacePage = ({
               {plans && (
                 <div className="pt-8">
                   <Collapsible>
-                    <Collapsible.Button label="Invite to enterprise plan" />
+                    <Collapsible.Button label="Invite or Upgrade to plan" />
                     <Collapsible.Panel>
                       <div className="flex flex-col gap-2 pt-4">
                         {plans.map((p) => {
@@ -552,8 +552,12 @@ const WorkspacePage = ({
                             <div key={p.code}>
                               <Button
                                 variant="secondary"
-                                label={`${p.name} (${p.code})`}
-                                onClick={() => onInviteToEnterprisePlan(p)}
+                                label={
+                                  p.billingType === "free"
+                                    ? `Upgrade to free plan: ${p.code}`
+                                    : `Invite to paid plan: ${p.code}`
+                                }
+                                onClick={() => onUpgradeOrInviteToPlan(p)}
                                 disabled={[
                                   subscription.plan.code,
                                   planInvitation?.planCode ?? "",


### PR DESCRIPTION
### Context 

Eng runner card: https://github.com/dust-tt/tasks/issues/318

On Poké there was a section "Invite to Enterprise plan" that is listing all the Plans that are in DB.
This PR just edit the code related to this so that it handles free plans: for free plans, we immediately upgrade the workspace, and for paid plans we keep the invitation logic.


Screenshots to see the wording changes: 

**Before:** 
<kbd>
<img width="437" alt="Screenshot 2024-01-08 at 11 38 32" src="https://github.com/dust-tt/dust/assets/3803406/a4d481d0-ccbe-4cc3-bd84-025a0bdde8ab">
</kbd>

**After:** 
<kbd>
<img width="460" alt="Screenshot 2024-01-08 at 11 37 56" src="https://github.com/dust-tt/dust/assets/3803406/49fdfd21-3db8-4403-a2a1-68c4e4caa7e3">
</kbd>