### PR TITLE
Subscription: drop column PaymentStatus

### DIFF
--- a/front/lib/models/plan.ts
+++ b/front/lib/models/plan.ts
@@ -148,7 +148,6 @@ export class Subscription extends Model<
 
   declare sId: string; // unique
   declare status: SubscriptionStatusType;
-  declare paymentStatus: string | null; // to be removed
   declare paymentFailingSince: Date | null;
 
   declare startDate: Date;
@@ -190,10 +189,6 @@ Subscription.init(
       validate: {
         isIn: [SUBSCRIPTION_STATUSES],
       },
-    },
-    paymentStatus: {
-      type: DataTypes.STRING,
-      allowNull: true,
     },
     paymentFailingSince: {
       type: DataTypes.DATE,

--- a/front/migrations/20240108_subscription_remove_paymentstatus.ts
+++ b/front/migrations/20240108_subscription_remove_paymentstatus.ts
@@ -1,0 +1,18 @@
+import { front_sequelize } from "@app/lib/databases";
+
+async function main() {
+  console.log("dropping payment_status column from subscriptions table");
+  await front_sequelize.query(
+    `ALTER TABLE "subscriptions" DROP COLUMN "paymentStatus"`
+  );
+}
+
+main()
+  .then(() => {
+    console.log("done");
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });


### PR DESCRIPTION
This column was created then deprecated in favor of another one storing a data instead.

Deploy to front then run `npx tsx ./migrations/20240108_subscription_remove_paymentstatus.ts`