### PR TITLE
Fix catch nango 522 error

### DIFF
--- a/connectors/src/lib/temporal_monitoring.ts
+++ b/connectors/src/lib/temporal_monitoring.ts
@@ -80,6 +80,8 @@ export class ActivityInboundLogInterceptor
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (err: unknown) {
+      error = err;
+
       const maybeNangoError = err as {
         code?: string;
         status?: number;
@@ -96,7 +98,7 @@ export class ActivityInboundLogInterceptor
           },
           "Got 5xx Bad Response from external API"
         );
-        throw {
+        error = {
           __is_dust_error: true,
           message: `Got ${maybeNangoError.status} Bad Response from Nango`,
           type: "nango_5xx_bad_response",
@@ -115,7 +117,6 @@ export class ActivityInboundLogInterceptor
           await cancelWorkflow(workflowId);
         }
       }
-      error = err;
       throw err;
     } finally {
       const durationMs = new Date().getTime() - startTime.getTime();


### PR DESCRIPTION
### Context

Last week we got 650+ errors `"Unhandled activity error" @error_stack:"AxiosError: Request failed with status code 522`: [here](https://app.datadoghq.eu/logs?query=%22Unhandled%20activity%20error%22%20%40error_stack%3A%22AxiosError%3A%20Request%20failed%20with%20status%20code%20522%0A%20%20%20%20at%20settle%20%28%2Fapp%2Fnode_modules%2Faxios%2Flib%2Fcore%2Fsettle.js%3A19%3A12%29%0A%20%20%20%20at%20IncomingMessage.handleStreamEnd%20%28%2Fapp%2Fnode_modules%2Faxios%2Flib%2Fadapters%2Fhttp.js%3A585%3A11%29%0A%20%20%20%20at%20IncomingMessage.emit%20%28node%3Aevents%3A525%3A35%29%0A%20%20%20%20at%20IncomingMessage.emit%20%28node%3Adomain%3A489%3A12%29%0A%20%20%20%20at%20endReadableNT%20%28node%3Ainternal%2Fstreams%2Freadable%3A1359%3A12%29%0A%20%20%20%20at%20process.processTicksAndRejections%20%28node%3Ainternal%2Fprocess%2Ftask_queues%3A82%3A21%29%22%20&cols=service%2C%40workflowName%2C%40activityName%2C%40error.__is_dust_error&event=AgAAAYzWRHIP7OTnqQAAAAAAAAAYAAAAAEFZeldSSGJSQUFEcy1aZXM3aGlqd3dBcAAAACQAAAAAMDE4Y2Q2YjctODUwYy00MzZjLWExZWQtY2U5ZGFjZjVkODMw&index=%2A&messageDisplay=inline&refresh_mode=sliding&saved-view-id=99803&stream_sort=%40duration%2Cdesc&viz=stream&from_ts=1702129129772&to_ts=1704721129772&live=true).

It shouldn't be a unhandled activity error, as we know it's transient and don't want to be alerted immediately. 
cf https://github.com/dust-tt/dust/pull/2535, https://github.com/dust-tt/dust/pull/2937, & https://github.com/dust-tt/dust/pull/2963 