### PR TITLE
Prevent workspaces in past due payment to add new members

### DIFF
--- a/front/pages/api/w/[wId]/invitations/index.ts
+++ b/front/pages/api/w/[wId]/invitations/index.ts
@@ -49,6 +49,17 @@ async function handler(
     });
   }
 
+  const subscription = auth.subscription();
+  if (!subscription) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "The subscription was not found.",
+      },
+    });
+  }
+
   switch (req.method) {
     case "GET":
       const invitations = await getPendingInvitations(auth);
@@ -75,6 +86,17 @@ async function handler(
       }
       if (!DUST_INVITE_TOKEN_SECRET) {
         throw new Error("DUST_INVITE_TOKEN_SECRET is not set");
+      }
+
+      if (subscription.paymentFailingSince) {
+        return apiError(req, res, {
+          status_code: 402,
+          api_error: {
+            type: "subscription_payment_failed",
+            message:
+              "The subscription payment has failed, impossible to add new members.",
+          },
+        });
       }
 
       // Create MembershipInvitation

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -182,7 +182,11 @@ export default function WorkspaceAdmin({
       builder: "amber",
       user: "emerald",
     };
-    const [showNoInviteEmailPopup, setShowNoInviteEmailPopup] = useState(false);
+    const [showNoInviteFreePlanPopup, setShowNoInviteFreePlanPopup] =
+      useState(false);
+    const [showNoInviteFailedPaymentPopup, setShowNoInviteFailedPaymentPopup] =
+      useState(false);
+
     const [searchText, setSearchText] = useState("");
     const { members, isMembersLoading } = useMembers(owner);
     const { invitations, isInvitationsLoading } =
@@ -271,12 +275,14 @@ export default function WorkspaceAdmin({
                 icon={PlusIcon}
                 onClick={() => {
                   if (plan.code === FREE_TEST_PLAN_CODE)
-                    setShowNoInviteEmailPopup(true);
+                    setShowNoInviteFreePlanPopup(true);
+                  else if (subscription.paymentFailingSince)
+                    setShowNoInviteFailedPaymentPopup(true);
                   else setInviteEmailModalOpen(true);
                 }}
               />
               <Popup
-                show={showNoInviteEmailPopup}
+                show={showNoInviteFreePlanPopup}
                 chipLabel="Free plan"
                 description="You cannot invite other members with the free plan. Upgrade your plan for unlimited members."
                 buttonLabel="Check Dust plans"
@@ -284,7 +290,18 @@ export default function WorkspaceAdmin({
                   void router.push(`/w/${owner.sId}/subscription`);
                 }}
                 className="absolute bottom-8 right-0"
-                onClose={() => setShowNoInviteEmailPopup(false)}
+                onClose={() => setShowNoInviteFreePlanPopup(false)}
+              />
+              <Popup
+                show={showNoInviteFailedPaymentPopup}
+                chipLabel="Failed Payment"
+                description="You cannot invite other members while your workspace has a failed payment."
+                buttonLabel="Check Subscription"
+                buttonClick={() => {
+                  void router.push(`/w/${owner.sId}/subscription`);
+                }}
+                className="absolute bottom-8 right-0"
+                onClose={() => setShowNoInviteFailedPaymentPopup(false)}
               />
             </div>
           </div>

--- a/types/src/front/lib/error.ts
+++ b/types/src/front/lib/error.ts
@@ -48,7 +48,8 @@ export type APIErrorType =
   | "test_plan_message_limit_reached"
   | "global_agent_error"
   | "stripe_invalid_product_id_error"
-  | "rate_limit_error";
+  | "rate_limit_error"
+  | "subscription_payment_failed";
 
 export type APIError = {
   type: APIErrorType;


### PR DESCRIPTION
### Context

Workspaces with a past due payment status should not be able to add new members to the workspaces.

Wording picked to be similar with the one we have to limit the free plan: "You cannot invite other members with the free plan. Upgrade your plan for unlimited members."


Clicking on the "Add Members" button will trigger this popup: 

<kbd>
<img width="616" alt="Screenshot 2024-01-08 at 17 13 52" src="https://github.com/dust-tt/dust/assets/3803406/a9a3a7bf-9819-4af0-a24b-46e1a00521b0">
</kbd>

<br /><br />
The button redirects to the Subscription page where there's a red button to go fix the payment method on Stripe: 

<kbd>
<img width="974" alt="Screenshot 2024-01-08 at 17 17 16" src="https://github.com/dust-tt/dust/assets/3803406/928ac169-b319-45ca-bb9f-c3ad0738875e">
</kbd>
