### PR TITLE
Suppress paragraph warning with Tooltip

### DIFF
--- a/front/components/assistant/RenderMessageMarkdown.tsx
+++ b/front/components/assistant/RenderMessageMarkdown.tsx
@@ -538,9 +538,9 @@ function LiBlock({ children }: { children: React.ReactNode }) {
 }
 function ParagraphBlock({ children }: { children: React.ReactNode }) {
   return (
-    <p className="whitespace-pre-wrap py-2 text-base font-normal leading-7 text-element-800 first:pt-0 last:pb-0">
+    <div className="whitespace-pre-wrap py-2 text-base font-normal leading-7 text-element-800 first:pt-0 last:pb-0">
       {children}
-    </p>
+    </div>
   );
 }
 


### PR DESCRIPTION
This pull request resolves the issue https://github.com/dust-tt/dust/issues/3007. It changes the mapping of Markdown paragraphs from `<p>` tags to `<div>` tags, which eliminates the warning previously observed in the console.