### PR TITLE
Conditionally load gfm plugin based on markdown flavor

### DIFF
--- a/connectors/src/connectors/github/temporal/activities.ts
+++ b/connectors/src/connectors/github/temporal/activities.ts
@@ -20,7 +20,7 @@ import {
 } from "@connectors/connectors/github/lib/github_api";
 import {
   deleteFromDataSource,
-  renderGfmMarkdownSection,
+  renderMarkdownSection,
   upsertToDatasource,
 } from "@connectors/lib/data_sources";
 import { Connector } from "@connectors/lib/models";
@@ -108,9 +108,10 @@ async function renderIssue(
 
   const issue = await getIssue(installationId, repoName, login, issueNumber);
 
-  const content = renderGfmMarkdownSection(
+  const content = renderMarkdownSection(
     `Issue #${issue.number} [${repoName}]: ${issue.title}\n`,
-    issue.body || ""
+    issue.body || "",
+    { flavor: "gfm" }
   );
 
   let resultPage = 1;
@@ -146,9 +147,10 @@ async function renderIssue(
 
     for (const comment of comments) {
       if (comment.body) {
-        const c = renderGfmMarkdownSection(
+        const c = renderMarkdownSection(
           `>> ${renderGithubUser(comment.creator)}:\n`,
-          comment.body
+          comment.body,
+          { flavor: "gfm" }
         );
         content.sections.push(c);
       }
@@ -278,9 +280,10 @@ async function renderDiscussion(
     discussionNumber
   );
 
-  const content = renderGfmMarkdownSection(
+  const content = renderMarkdownSection(
     `Discussion #${discussion.number} [${repoName}]: ${discussion.title}\n`,
-    discussion.bodyText
+    discussion.bodyText,
+    { flavor: "gfm" }
   );
 
   let nextCursor: string | null = null;
@@ -308,7 +311,9 @@ async function renderDiscussion(
         prefix += "[ACCEPTED ANSWER] ";
       }
       prefix += `${comment.author?.login || "Unknown author"}:\n`;
-      const c = renderGfmMarkdownSection(prefix, comment.bodyText);
+      const c = renderMarkdownSection(prefix, comment.bodyText, {
+        flavor: "gfm",
+      });
       content.sections.push(c);
 
       let nextChildCursor: string | null = null;
@@ -328,9 +333,10 @@ async function renderDiscussion(
           );
 
         for (const childComment of childComments) {
-          const cc = renderGfmMarkdownSection(
+          const cc = renderMarkdownSection(
             `>> ${childComment.author?.login || "Unknown author"}:\n`,
-            childComment.bodyText
+            childComment.bodyText,
+            { flavor: "gfm" }
           );
           c.sections.push(cc);
         }

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -295,13 +295,17 @@ export function renderPrefixSection(
 /// This function is used to render markdown from the GFM markdown format to our Section format.
 /// The top-level node is always with prefix and content null and can be edited to add a prefix or
 /// content.
-export function renderGfmMarkdownSection(
+export function renderMarkdownSection(
   prefix: string | null,
-  markdown: string
+  markdown: string,
+  { flavor }: { flavor?: "gfm" } = {}
 ): CoreAPIDataSourceDocumentSection {
+  const extensions = flavor === "gfm" ? [gfm()] : [];
+  const mdastExtensions = flavor === "gfm" ? [gfmFromMarkdown()] : [];
+
   const tree = fromMarkdown(markdown, {
-    extensions: [gfm()],
-    mdastExtensions: [gfmFromMarkdown()],
+    extensions: extensions,
+    mdastExtensions: mdastExtensions,
   });
 
   const top = renderPrefixSection(prefix);
@@ -342,4 +346,11 @@ export function renderGfmMarkdownSection(
   }
 
   return top;
+}
+
+export function renderGfmMarkdownSection(
+  prefix: string | null,
+  markdown: string
+): CoreAPIDataSourceDocumentSection {
+  return renderMarkdownSection(prefix, markdown, { flavor: "gfm" });
 }

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -292,7 +292,7 @@ export function renderPrefixSection(
   };
 }
 
-/// This function is used to render markdown from the GFM markdown format to our Section format.
+/// This function is used to render markdown from (alternatively GFM format) to our Section format.
 /// The top-level node is always with prefix and content null and can be edited to add a prefix or
 /// content.
 export function renderMarkdownSection(

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -347,10 +347,3 @@ export function renderMarkdownSection(
 
   return top;
 }
-
-export function renderGfmMarkdownSection(
-  prefix: string | null,
-  markdown: string
-): CoreAPIDataSourceDocumentSection {
-  return renderMarkdownSection(prefix, markdown, { flavor: "gfm" });
-}


### PR DESCRIPTION
Developing the Confluence connector, which involves obtaining HTML content and transforming it into Markdown using a dedicated library. The Markdown format is advantageous as it enables us to leverage the enhancements made with chunking V2, applying the markdown hierarchy as a prefix for subsequent chunks.

This PR,  segregate the `gfm` (GitHub Flavored Markdown) variant to allow for its reuse with standard markdown. This is feasible because `gfm` is a superset of all the features of basic markdown.