### PR TITLE
Set custom search attribute 'connectorId' for temporal workflows

### DIFF
--- a/connectors/src/connectors/github/temporal/client.ts
+++ b/connectors/src/connectors/github/temporal/client.ts
@@ -55,7 +55,7 @@ export async function launchGithubFullSyncWorkflow(connectorId: string) {
   }
 
   await client.workflow.start(githubFullSyncWorkflow, {
-    args: [dataSourceConfig, githubInstallationId],
+    args: [dataSourceConfig, githubInstallationId, connectorId],
     taskQueue: QUEUE_NAME,
     workflowId: getFullSyncWorkflowId(dataSourceConfig),
     searchAttributes: {
@@ -110,7 +110,13 @@ export async function launchGithubReposSyncWorkflow(
   const githubInstallationId = connector.connectionId;
 
   await client.workflow.start(githubReposSyncWorkflow, {
-    args: [dataSourceConfig, githubInstallationId, orgLogin, repos],
+    args: [
+      dataSourceConfig,
+      githubInstallationId,
+      orgLogin,
+      repos,
+      connectorId,
+    ],
     taskQueue: QUEUE_NAME,
     workflowId: getReposSyncWorkflowId(dataSourceConfig),
     searchAttributes: {

--- a/connectors/src/connectors/github/temporal/client.ts
+++ b/connectors/src/connectors/github/temporal/client.ts
@@ -58,6 +58,9 @@ export async function launchGithubFullSyncWorkflow(connectorId: string) {
     args: [dataSourceConfig, githubInstallationId],
     taskQueue: QUEUE_NAME,
     workflowId: getFullSyncWorkflowId(dataSourceConfig),
+    searchAttributes: {
+      connectorId: [parseInt(connectorId)],
+    },
     memo: {
       connectorId: connectorId,
     },
@@ -110,6 +113,9 @@ export async function launchGithubReposSyncWorkflow(
     args: [dataSourceConfig, githubInstallationId, orgLogin, repos],
     taskQueue: QUEUE_NAME,
     workflowId: getReposSyncWorkflowId(dataSourceConfig),
+    searchAttributes: {
+      connectorId: [parseInt(connectorId)],
+    },
     memo: {
       connectorId: connectorId,
     },
@@ -149,6 +155,9 @@ export async function launchGithubIssueSyncWorkflow(
     ],
     taskQueue: QUEUE_NAME,
     workflowId,
+    searchAttributes: {
+      connectorId: [parseInt(connectorId)],
+    },
     signal: newWebhookSignal,
     signalArgs: undefined,
     memo: {
@@ -189,6 +198,9 @@ export async function launchGithubDiscussionSyncWorkflow(
       repoLogin,
       discussionNumber,
     ],
+    searchAttributes: {
+      connectorId: [parseInt(connectorId)],
+    },
     taskQueue: QUEUE_NAME,
     workflowId,
     signal: newWebhookSignal,
@@ -224,6 +236,9 @@ export async function launchGithubIssueGarbageCollectWorkflow(
       issueNumber,
     ],
     taskQueue: QUEUE_NAME,
+    searchAttributes: {
+      connectorId: [parseInt(connectorId)],
+    },
     workflowId: getIssueGarbageCollectWorkflowId(
       dataSourceConfig,
       repoId,
@@ -269,6 +284,9 @@ export async function launchGithubDiscussionGarbageCollectWorkflow(
       repoId,
       discussionNumber
     ),
+    searchAttributes: {
+      connectorId: [parseInt(connectorId)],
+    },
   });
 }
 
@@ -292,6 +310,9 @@ export async function launchGithubRepoGarbageCollectWorkflow(
     args: [dataSourceConfig, githubInstallationId, repoId.toString()],
     taskQueue: QUEUE_NAME,
     workflowId: getRepoGarbageCollectWorkflowId(dataSourceConfig, repoId),
+    searchAttributes: {
+      connectorId: [parseInt(connectorId)],
+    },
     memo: {
       connectorId: connectorId,
     },

--- a/connectors/src/connectors/github/temporal/config.ts
+++ b/connectors/src/connectors/github/temporal/config.ts
@@ -1,2 +1,2 @@
-export const WORKFLOW_VERSION = 1;
+export const WORKFLOW_VERSION = 2;
 export const QUEUE_NAME = `github-queue-v${WORKFLOW_VERSION}`;

--- a/connectors/src/connectors/github/temporal/workflows.ts
+++ b/connectors/src/connectors/github/temporal/workflows.ts
@@ -45,10 +45,10 @@ const MAX_CONCURRENT_ISSUE_SYNC_ACTIVITIES_PER_WORKFLOW = 3;
 
 export async function githubFullSyncWorkflow(
   dataSourceConfig: DataSourceConfig,
-  githubInstallationId: string
+  githubInstallationId: string,
+  connectorId: string
 ) {
   await githubSaveStartSyncActivity(dataSourceConfig);
-
   const loggerArgs = {
     dataSourceName: dataSourceConfig.dataSourceName,
     workspaceId: dataSourceConfig.workspaceId,
@@ -78,6 +78,9 @@ export async function githubFullSyncWorkflow(
         queue.add(() =>
           executeChild(githubRepoSyncWorkflow, {
             workflowId: childWorkflowId,
+            searchAttributes: {
+              connectorId: [parseInt(connectorId)],
+            },
             args: [
               dataSourceConfig,
               githubInstallationId,
@@ -102,7 +105,8 @@ export async function githubReposSyncWorkflow(
   dataSourceConfig: DataSourceConfig,
   githubInstallationId: string,
   orgLogin: string,
-  repos: { name: string; id: number }[]
+  repos: { name: string; id: number }[],
+  connectorId: string
 ) {
   const queue = new PQueue({ concurrency: MAX_CONCURRENT_REPO_SYNC_WORKFLOWS });
   const promises: Promise<void>[] = [];
@@ -114,6 +118,9 @@ export async function githubReposSyncWorkflow(
       queue.add(() =>
         executeChild(githubRepoSyncWorkflow, {
           workflowId: childWorkflowId,
+          searchAttributes: {
+            connectorId: [parseInt(connectorId)],
+          },
           args: [
             dataSourceConfig,
             githubInstallationId,

--- a/connectors/src/connectors/google_drive/temporal/client.ts
+++ b/connectors/src/connectors/google_drive/temporal/client.ts
@@ -57,7 +57,9 @@ export async function launchGoogleDriveFullSyncWorkflow(
       args: [connectorIdModelId, dataSourceConfig],
       taskQueue: QUEUE_NAME,
       workflowId: workflowId,
-
+      searchAttributes: {
+        connectorId: [parseInt(connectorId)],
+      },
       memo: {
         connectorId: connectorId,
       },
@@ -111,6 +113,9 @@ export async function launchGoogleDriveIncrementalSyncWorkflow(
       args: [connectorIdModelId, dataSourceConfig],
       taskQueue: QUEUE_NAME,
       workflowId: workflowId,
+      searchAttributes: {
+        connectorId: [parseInt(connectorId)],
+      },
       signal: newWebhookSignal,
       signalArgs: undefined,
       memo: {
@@ -202,7 +207,9 @@ export async function launchGoogleGarbageCollector(
       args: [connector.id, new Date().getTime()],
       taskQueue: QUEUE_NAME,
       workflowId: workflowId,
-
+      searchAttributes: {
+        connectorId: [connectorId],
+      },
       memo: {
         connectorId: connectorId,
       },

--- a/connectors/src/connectors/google_drive/temporal/config.ts
+++ b/connectors/src/connectors/google_drive/temporal/config.ts
@@ -1,3 +1,3 @@
-export const WORKFLOW_VERSION = 4;
+export const WORKFLOW_VERSION = 5;
 export const QUEUE_NAME = `google-queue-v${WORKFLOW_VERSION}`;
 export const GDRIVE_INCREMENTAL_SYNC_DEBOUNCE_SEC = 10;

--- a/connectors/src/connectors/google_drive/temporal/workflows.ts
+++ b/connectors/src/connectors/google_drive/temporal/workflows.ts
@@ -94,6 +94,9 @@ export async function googleDriveFullSync(
   if (garbageCollect) {
     await executeChild(googleDriveGarbageCollectorWorkflow, {
       workflowId: googleDriveGarbageCollectorWorkflowId(connectorId),
+      searchAttributes: {
+        connectorId: [connectorId],
+      },
       args: [connectorId, startSyncTs],
       memo: workflowInfo().memo,
     });

--- a/connectors/src/connectors/notion/temporal/client.ts
+++ b/connectors/src/connectors/notion/temporal/client.ts
@@ -44,6 +44,9 @@ export async function launchNotionSyncWorkflow(
     args: [{ connectorId, startFromTs, forceResync }],
     taskQueue: QUEUE_NAME,
     workflowId: getWorkflowId(dataSourceConfig),
+    searchAttributes: {
+      connectorId: [connectorId],
+    },
     memo: {
       connectorId: connectorId,
     },

--- a/connectors/src/connectors/notion/temporal/config.ts
+++ b/connectors/src/connectors/notion/temporal/config.ts
@@ -1,2 +1,2 @@
-export const WORKFLOW_VERSION = 26;
+export const WORKFLOW_VERSION = 27;
 export const QUEUE_NAME = `notion-queue-v${WORKFLOW_VERSION}`;

--- a/connectors/src/connectors/notion/temporal/workflows.ts
+++ b/connectors/src/connectors/notion/temporal/workflows.ts
@@ -258,6 +258,9 @@ export async function upsertPageWorkflow({
         workflowId: `${getWorkflowIdV2(
           connectorId
         )}-page-${pageId}-block-${block}-children`,
+        searchAttributes: {
+          connectorId: [connectorId],
+        },
         args: [{ connectorId, pageId, blockId: block }],
         parentClosePolicy: ParentClosePolicy.PARENT_CLOSE_POLICY_TERMINATE,
         memo: workflowInfo().memo,
@@ -268,6 +271,9 @@ export async function upsertPageWorkflow({
         workflowId: `${getWorkflowIdV2(
           connectorId
         )}-page-${pageId}-child-database-${databaseId}`,
+        searchAttributes: {
+          connectorId: [connectorId],
+        },
         args: [{ connectorId, databaseId }],
         parentClosePolicy: ParentClosePolicy.PARENT_CLOSE_POLICY_TERMINATE,
         memo: workflowInfo().memo,
@@ -322,6 +328,9 @@ export async function notionProcessBlockChildrenWorkflow({
         workflowId: `${getWorkflowIdV2(
           connectorId
         )}-page-${pageId}-block-${block}-children`,
+        searchAttributes: {
+          connectorId: [connectorId],
+        },
         args: [{ connectorId, pageId, blockId: block }],
         parentClosePolicy: ParentClosePolicy.PARENT_CLOSE_POLICY_TERMINATE,
         memo: workflowInfo().memo,
@@ -332,6 +341,9 @@ export async function notionProcessBlockChildrenWorkflow({
         workflowId: `${getWorkflowIdV2(
           connectorId
         )}-page-${pageId}-child-database-${databaseId}`,
+        searchAttributes: {
+          connectorId: [connectorId],
+        },
         args: [{ connectorId, databaseId }],
         parentClosePolicy: ParentClosePolicy.PARENT_CLOSE_POLICY_TERMINATE,
         memo: workflowInfo().memo,
@@ -385,6 +397,9 @@ export async function syncResultPageWorkflow({
       upsertQueue.add(() =>
         executeChild(upsertPageWorkflow, {
           workflowId: `${getWorkflowIdV2(connectorId)}-upsert-page-${pageId}`,
+          searchAttributes: {
+            connectorId: [connectorId],
+          },
           args: [{ connectorId, pageId, runTimestamp, isBatchSync, pageIndex }],
           parentClosePolicy: ParentClosePolicy.PARENT_CLOSE_POLICY_TERMINATE,
           memo: workflowInfo().memo,
@@ -553,6 +568,9 @@ async function performUpserts({
                 pageIds: batch,
               },
             ],
+            searchAttributes: {
+              connectorId: [connectorId],
+            },
             parentClosePolicy: ParentClosePolicy.PARENT_CLOSE_POLICY_TERMINATE,
             memo: workflowInfo().memo,
           })
@@ -595,6 +613,9 @@ async function performUpserts({
                 databaseIds: batch,
               },
             ],
+            searchAttributes: {
+              connectorId: [connectorId],
+            },
             parentClosePolicy: ParentClosePolicy.PARENT_CLOSE_POLICY_TERMINATE,
             memo: workflowInfo().memo,
           })

--- a/connectors/src/connectors/slack/temporal/client.ts
+++ b/connectors/src/connectors/slack/temporal/client.ts
@@ -51,6 +51,9 @@ export async function launchSlackSyncWorkflow(
       args: [parseInt(connectorId), fromTs],
       taskQueue: QUEUE_NAME,
       workflowId: workflowId,
+      searchAttributes: {
+        connectorId: [parseInt(connectorId)],
+      },
       signal: syncChannelSignal,
       signalArgs: [{ channelIds: channelsToSync ? channelsToSync : [] }],
       memo: {
@@ -101,6 +104,9 @@ export async function launchSlackSyncOneThreadWorkflow(
         args: [connectorId, channelId, threadTs],
         taskQueue: QUEUE_NAME,
         workflowId: workflowId,
+        searchAttributes: {
+          connectorId: [connectorId],
+        },
         signal: newWebhookSignal,
         signalArgs: undefined,
         memo: {
@@ -140,6 +146,9 @@ export async function launchSlackSyncOneMessageWorkflow(
         args: [connectorId, channelId, threadTs],
         taskQueue: QUEUE_NAME,
         workflowId: workflowId,
+        searchAttributes: {
+          connectorId: [connectorId],
+        },
         signal: newWebhookSignal,
         signalArgs: undefined,
         memo: {
@@ -167,6 +176,9 @@ export async function launchSlackGarbageCollectWorkflow(connectorId: ModelId) {
       args: [connectorId],
       taskQueue: QUEUE_NAME,
       workflowId: workflowId,
+      searchAttributes: {
+        connectorId: [connectorId],
+      },
       memo: {
         connectorId: connectorId,
       },

--- a/connectors/src/connectors/slack/temporal/config.ts
+++ b/connectors/src/connectors/slack/temporal/config.ts
@@ -1,2 +1,2 @@
-export const WORKFLOW_VERSION = 3;
+export const WORKFLOW_VERSION = 4;
 export const QUEUE_NAME = `slack-queue-v${WORKFLOW_VERSION}`;

--- a/connectors/src/connectors/slack/temporal/workflows.ts
+++ b/connectors/src/connectors/slack/temporal/workflows.ts
@@ -64,6 +64,9 @@ export async function workspaceFullSync(
           i++;
           return await executeChild(syncOneChannel, {
             workflowId: syncOneChanneWorkflowlId(connectorId, channelId),
+            searchAttributes: {
+              connectorId: [connectorId],
+            },
             args: [connectorId, channelId, false, fromTs],
             memo: workflowInfo().memo,
           });
@@ -76,6 +79,9 @@ export async function workspaceFullSync(
 
   await executeChild(slackGarbageCollectorWorkflow, {
     workflowId: slackGarbageCollectorWorkflowId(connectorId),
+    searchAttributes: {
+      connectorId: [connectorId],
+    },
     args: [connectorId],
     memo: workflowInfo().memo,
   });


### PR DESCRIPTION
The PR below will add a connector id search attribute for our workflows. As explained by [temporal](https://docs.temporal.io/dev-guide/typescript/observability#visibility) this allows to programatically retrieve all workflows by their connector id (+ other filters as an SQL-like where clause)
The first use case is killing running gdrive workflows when we delete the connector.
