### PR TITLE
Flav/whitelist slack domains

### DIFF
--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -20,9 +20,7 @@ import * as t from "io-ts";
 import jaroWinkler from "talisman/metrics/jaro-winkler";
 
 import {
-  checkUserPermissions,
   getSlackClient,
-  getSlackConversationInfo,
   getSlackUserInfo,
   isUserAllowedToUseChatbot,
 } from "@connectors/connectors/slack/lib/slack_client";

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -19,7 +19,13 @@ import { ConversationsRepliesResponse } from "@slack/web-api/dist/response/Conve
 import * as t from "io-ts";
 import jaroWinkler from "talisman/metrics/jaro-winkler";
 
-import { getSlackClient } from "@connectors/connectors/slack/lib/slack_client";
+import {
+  checkUserPermissions,
+  getSlackClient,
+  getSlackConversationInfo,
+  getSlackUserInfo,
+  isUserAllowedToUseChatbot,
+} from "@connectors/connectors/slack/lib/slack_client";
 import { Connector } from "@connectors/lib/models";
 import {
   SlackChannel,
@@ -82,7 +88,8 @@ export async function botAnswerMessageWithErrorHandling(
       slackUserId,
       slackMessageTs,
       slackThreadTs,
-      connector
+      connector,
+      slackConfig
     );
     if (res.isErr()) {
       logger.error(
@@ -147,7 +154,8 @@ async function botAnswerMessage(
   slackUserId: string,
   slackMessageTs: string,
   slackThreadTs: string | null,
-  connector: Connector
+  connector: Connector,
+  slackConfig: SlackConfiguration
 ): Promise<Result<AgentGenerationSuccessEvent, Error>> {
   let lastSlackChatBotMessage: SlackChatBotMessage | null = null;
   if (slackThreadTs) {
@@ -164,22 +172,20 @@ async function botAnswerMessage(
 
   // We start by retrieving the slack user info.
   const slackClient = await getSlackClient(connector.id);
-  const slackUserInfo = await slackClient.users.info({
-    user: slackUserId,
-  });
+  const slackUserInfo = await getSlackUserInfo(slackClient, slackUserId);
 
   if (!slackUserInfo.ok || !slackUserInfo.user) {
     throw new Error(`Failed to get user info: ${slackUserInfo.error}`);
   }
 
-  // We check that the user is not restricted or a stranger.
-  // See incident: https://dust4ai.slack.com/archives/C05B529FHV1/p1704799263814619
-  if (
-    slackUserInfo.user.profile?.team !== slackTeamId ||
-    slackUserInfo.user.is_restricted ||
-    slackUserInfo.user.is_ultra_restricted ||
-    slackUserInfo.user.is_stranger
-  ) {
+  const hasChatbotAccess = await isUserAllowedToUseChatbot(
+    slackClient,
+    slackUserInfo,
+    slackChannel,
+    slackTeamId,
+    slackConfig.whitelistedDomains
+  );
+  if (!hasChatbotAccess) {
     return new Err(
       new SlackExternalUserError(
         "Hi there. Sorry, but I can only answer to members of the workspace where I am installed."

--- a/connectors/src/connectors/slack/lib/slack_client.ts
+++ b/connectors/src/connectors/slack/lib/slack_client.ts
@@ -147,6 +147,7 @@ export async function isUserAllowedToUseChatbot(
 
   if (isExternal) {
     const userDomain = profile?.email?.split("@")[1];
+    // Ensure the domain matches exactly.
     const isWhitelistedDomain = userDomain
       ? whitelistedDomains?.includes(userDomain) ?? false
       : false;

--- a/connectors/src/connectors/slack/lib/slack_client.ts
+++ b/connectors/src/connectors/slack/lib/slack_client.ts
@@ -115,8 +115,9 @@ async function getSlackConversationInfo(
   return slackClient.conversations.info({ channel: channelId });
 }
 
-// We check that the user is not restricted or a stranger.
-// For public channels, we check if the email's domain has been whitelisted.
+// Verify the Slack user is not an external guest to the workspace.
+// An exception is made for users from domains on the whitelist,
+// allowing them to interact with the bot in public channels.
 // See incident: https://dust4ai.slack.com/archives/C05B529FHV1/p1704799263814619
 export async function isUserAllowedToUseChatbot(
   slackClient: WebClient,

--- a/connectors/src/connectors/slack/lib/slack_client.ts
+++ b/connectors/src/connectors/slack/lib/slack_client.ts
@@ -1,7 +1,6 @@
 import { ModelId } from "@dust-tt/types";
 import {
   CodedError,
-  ConversationsInfoResponse,
   ErrorCode,
   UsersInfoResponse,
   WebAPIHTTPError,

--- a/connectors/src/lib/models/slack.ts
+++ b/connectors/src/lib/models/slack.ts
@@ -20,6 +20,7 @@ export class SlackConfiguration extends Model<
   declare slackTeamId: string;
   declare botEnabled: boolean;
   declare connectorId: ForeignKey<Connector["id"]>;
+  declare whitelistedDomains?: readonly string[];
 }
 SlackConfiguration.init(
   {
@@ -46,6 +47,10 @@ SlackConfiguration.init(
       type: DataTypes.BOOLEAN,
       allowNull: false,
       defaultValue: false,
+    },
+    whitelistedDomains: {
+      type: DataTypes.ARRAY(DataTypes.STRING),
+      allowNull: true,
     },
   },
   {


### PR DESCRIPTION
This PR resolves https://github.com/dust-tt/tasks/issues/323.

It introduces a `whitelistedDomains` column to the `slack_configurations` table. This addition allow specific Slack users (based on their email's domain) to query the slackbot within public channels.
This new column, implemented as an array of strings, is designed for straightforward querying within both raw SQL and TypeScript.

Additionally, permission checks have been streamlined into a separate function for clarity and separation from the core Slack logic.