### PR TITLE
Support whitelisting slack domain in cli

### DIFF
--- a/connectors/src/admin/cli.ts
+++ b/connectors/src/admin/cli.ts
@@ -569,6 +569,47 @@ const slack = async (command: string, args: parseArgs.ParsedArgs) => {
       }
       break;
     }
+
+    case "whitelist-domains": {
+      const { wId, whitelistedDomains } = args;
+      if (!wId) {
+        throw new Error("Missing --wId argument");
+      }
+      if (!whitelistedDomains) {
+        throw new Error("Missing --whitelistedDomains argument");
+      }
+
+      const connector = await Connector.findOne({
+        where: {
+          workspaceId: args.wId,
+          type: "slack",
+        },
+      });
+      if (!connector) {
+        throw new Error(`Could not find connector for workspace ${args.wId}`);
+      }
+
+      const whitelistedDomainsArray = whitelistedDomains.split(",");
+      // TODO(2024-01-10 flav) Add domain validation.
+      console.log(
+        `Whitelisting following domains for slack:\n- ${whitelistedDomainsArray.join(
+          "\n-"
+        )}`
+      );
+
+      await SlackConfiguration.update(
+        {
+          whitelistedDomains: whitelistedDomainsArray,
+        },
+        {
+          where: {
+            connectorId: connector.id,
+          },
+        }
+      );
+
+      break;
+    }
   }
 };
 


### PR DESCRIPTION
Follow up of https://github.com/dust-tt/dust/pull/3115 to support slack `whitelist-domains` in the connector's cli.