### PR TITLE
Flav/eslint return await in try catch

### DIFF
--- a/connectors/.eslintrc.js
+++ b/connectors/.eslintrc.js
@@ -31,6 +31,7 @@ module.exports = {
     "simple-import-sort/exports": "error",
     "@typescript-eslint/no-floating-promises": "error",
     "@typescript-eslint/no-unused-vars": "error",
+    "@typescript-eslint/return-await": ["error", "in-try-catch"],
   },
   overrides: [
     {

--- a/connectors/migrations/20230906_2_slack_fill_parents_field.ts
+++ b/connectors/migrations/20230906_2_slack_fill_parents_field.ts
@@ -71,13 +71,12 @@ async function updateParentsFieldForConnector(connector: Connector) {
     process.stdout.write(".");
     // update parents field for each document of the chunk, in parallel
     await Promise.all(
-      chunk.map(
-        async (documentIdAndChannel) =>
-          await updateDocumentParentsField({
-            dataSourceConfig: connector,
-            documentId: documentIdAndChannel.documentId,
-            parents: [documentIdAndChannel.channelId],
-          })
+      chunk.map(async (documentIdAndChannel) =>
+        updateDocumentParentsField({
+          dataSourceConfig: connector,
+          documentId: documentIdAndChannel.documentId,
+          parents: [documentIdAndChannel.channelId],
+        })
       )
     );
   }

--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -310,7 +310,7 @@ export async function retrieveGithubConnectorPermissions({
 
     const [latestDiscussion, latestIssue, repo] = await Promise.all([
       (async () => {
-        return await GithubDiscussion.findOne({
+        return GithubDiscussion.findOne({
           where: {
             connectorId: c.id,
             repoId: repoId.toString(),
@@ -320,7 +320,7 @@ export async function retrieveGithubConnectorPermissions({
         });
       })(),
       (async () => {
-        return await GithubIssue.findOne({
+        return GithubIssue.findOne({
           where: {
             connectorId: c.id,
             repoId: repoId.toString(),

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -720,5 +720,5 @@ export async function googleDriveGarbageCollect(connectorId: ModelId) {
     return new Err(new Error(`Connector not found with id ${connectorId}`));
   }
 
-  return await launchGoogleGarbageCollector(connectorId);
+  return launchGoogleGarbageCollector(connectorId);
 }

--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -92,7 +92,7 @@ export async function getGoogleCredentials(
   if (!NANGO_GOOGLE_DRIVE_CONNECTOR_ID) {
     throw new Error("NANGO_GOOGLE_DRIVE_CONNECTOR_ID is not defined");
   }
-  return await nango_client().getConnection(
+  return nango_client().getConnection(
     NANGO_GOOGLE_DRIVE_CONNECTOR_ID,
     nangoConnectionId,
     false
@@ -274,7 +274,7 @@ export async function syncFiles(
         if (!file.id || !file.createdTime || !file.name || !file.mimeType) {
           throw new Error("Invalid file. File is: " + JSON.stringify(file));
         }
-        return await driveObjectToDustType(file, authCredentials);
+        return driveObjectToDustType(file, authCredentials);
       })
   );
   const subfolders = filesToSync
@@ -286,7 +286,7 @@ export async function syncFiles(
     filesToSync.map((file) => {
       return queue.add(async () => {
         if (!file.trashed) {
-          return await syncOneFile(
+          return syncOneFile(
             connectorId,
             authCredentials,
             dataSourceConfig,

--- a/connectors/src/connectors/slack/lib/channels.ts
+++ b/connectors/src/connectors/slack/lib/channels.ts
@@ -29,7 +29,7 @@ export async function updateSlackChannelInConnectorsDb({
   slackChannelName: string;
   connectorId: number;
 }): Promise<SlackChannelType> {
-  return await sequelize_conn.transaction(async (transaction) => {
+  return sequelize_conn.transaction(async (transaction) => {
     const connector = await Connector.findOne({
       where: {
         id: connectorId,

--- a/connectors/src/connectors/slack/lib/slack_client.ts
+++ b/connectors/src/connectors/slack/lib/slack_client.ts
@@ -52,6 +52,7 @@ export async function getSlackClient(
     apply: async function (target, thisArg, argumentsList) {
       try {
         // @ts-expect-error can't get typescript to be happy with this, but it works.
+        // eslint-disable-next-line @typescript-eslint/return-await
         return await Reflect.apply(target, thisArg, argumentsList);
       } catch (e) {
         // If we get rate limited, we throw a known error.

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -343,7 +343,7 @@ export async function syncMultipleNoNThreaded(
     );
     promises.push(p);
   }
-  return await Promise.all(promises);
+  return Promise.all(promises);
 }
 
 export async function syncNonThreaded(
@@ -525,7 +525,7 @@ export async function syncThreads(
     });
     promises.push(p);
   }
-  return await Promise.all(promises);
+  return Promise.all(promises);
 }
 
 export async function syncThread(

--- a/connectors/src/connectors/slack/temporal/workflows.ts
+++ b/connectors/src/connectors/slack/temporal/workflows.ts
@@ -62,7 +62,7 @@ export async function workspaceFullSync(
             `${percentSync}%`
           );
           i++;
-          return await executeChild(syncOneChannel, {
+          return executeChild(syncOneChannel, {
             workflowId: syncOneChanneWorkflowlId(connectorId, channelId),
             args: [connectorId, channelId, false, fromTs],
             memo: workflowInfo().memo,

--- a/connectors/src/lib/nango_helpers.ts
+++ b/connectors/src/lib/nango_helpers.ts
@@ -38,12 +38,12 @@ export async function getAccessTokenFromNango({
   useCache?: boolean;
 }) {
   if (useCache) {
-    return await _cachedGetAccessTokenFromNango({
+    return _cachedGetAccessTokenFromNango({
       connectionId,
       integrationId,
     });
   } else {
-    return await _getAccessTokenFromNango({ connectionId, integrationId });
+    return _getAccessTokenFromNango({ connectionId, integrationId });
   }
 }
 
@@ -84,13 +84,13 @@ export async function getConnectionFromNango({
   useCache?: boolean;
 }) {
   if (useCache) {
-    return await _getCachedConnectionFromNango({
+    return _getCachedConnectionFromNango({
       connectionId,
       integrationId,
       refreshToken,
     });
   } else {
-    return await _getConnectionFromNango({
+    return _getConnectionFromNango({
       connectionId,
       integrationId,
       refreshToken,

--- a/connectors/src/lib/temporal_monitoring.ts
+++ b/connectors/src/lib/temporal_monitoring.ts
@@ -74,7 +74,7 @@ export class ActivityInboundLogInterceptor
             this.context.info.workflowExecution.runId
           );
 
-          return await next(input);
+          return next(input);
         }
       );
 

--- a/front/.eslintrc.js
+++ b/front/.eslintrc.js
@@ -47,6 +47,7 @@ module.exports = {
       },
     ],
     "simple-import-sort/exports": "error",
+    "@typescript-eslint/return-await": ["error", "in-try-catch"],
   },
   overrides: [
     {

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -331,7 +331,7 @@ export function AgentMessage({
               code: "unexpected_error",
             }
           }
-          retryHandler={async () => await retryHandler(agentMessage)}
+          retryHandler={async () => retryHandler(agentMessage)}
         />
       );
     }

--- a/front/components/assistant/conversation/ConversationMessage.tsx
+++ b/front/components/assistant/conversation/ConversationMessage.tsx
@@ -248,7 +248,7 @@ export function ConversationMessage({
                     emoji={nativeEmoji}
                     count={reaction.users.length.toString()}
                     onClick={async () =>
-                      await handleEmoji({
+                      handleEmoji({
                         emoji: reaction.emoji,
                         isToRemove: hasReacted,
                       })

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -73,7 +73,7 @@ export async function getAgentConfiguration(
   }
 
   if (isGlobalAgentId(agentId)) {
-    return await getGlobalAgent(auth, agentId, null);
+    return getGlobalAgent(auth, agentId, null);
   }
 
   const user = auth.user();
@@ -388,7 +388,7 @@ export async function getAgentConfigurations(
         if (!user) {
           return [];
         }
-        return await AgentUserRelation.findAll({
+        return AgentUserRelation.findAll({
           where: {
             workspaceId: owner.id,
             userId: user?.id,
@@ -895,7 +895,7 @@ export async function createAgentActionConfiguration(
   }
 
   if (action.type === "retrieval_configuration") {
-    return await front_sequelize.transaction(async (t) => {
+    return front_sequelize.transaction(async (t) => {
       const retrievalConfig = await AgentRetrievalConfiguration.create(
         {
           sId: generateModelSId(),

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -209,7 +209,7 @@ async function batchRenderUserMessages(messages: Message[]) {
       if (userIds.length === 0) {
         return [];
       }
-      return await User.findAll({
+      return User.findAll({
         where: {
           id: userIds,
         },
@@ -309,7 +309,7 @@ async function batchRenderAgentMessages(
       return agents;
     })(),
     (async () => {
-      return await Promise.all(
+      return Promise.all(
         agentMessages
           .filter((m) => m.agentMessage?.agentRetrievalActionId)
           .map((m) => {
@@ -881,7 +881,7 @@ export async function* postUserMessage(
         })) ?? -1) + 1;
 
       async function createMessageAndUserMessage() {
-        return await Message.create(
+        return Message.create(
           {
             sId: generateModelSId(),
             rank: nextMessageRank++,
@@ -917,14 +917,14 @@ export async function* postUserMessage(
             transaction: t,
           });
           if (participant) {
-            return await participant.update(
+            return participant.update(
               {
                 action: "posted",
               },
               { transaction: t }
             );
           } else {
-            return await ConversationParticipant.create(
+            return ConversationParticipant.create(
               {
                 conversationId: conversation.id,
                 userId: user.id,
@@ -1335,7 +1335,7 @@ export async function* editUserMessage(
       const userMessageRow = messageRow.userMessage;
       // adding messageRow as param otherwise Ts doesn't get it can't be null
       async function createMessageAndUserMessage(messageRow: Message) {
-        return await Message.create(
+        return Message.create(
           {
             sId: generateModelSId(),
             rank: messageRow.rank,
@@ -1373,7 +1373,7 @@ export async function* editUserMessage(
             transaction: t,
           });
           if (participant) {
-            return await participant.update(
+            return participant.update(
               {
                 action: "posted",
               },

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -469,7 +469,7 @@ async function _getGoogleDriveGlobalAgent(
     dataSources: DataSourceType[];
   }
 ): Promise<AgentConfigurationType | null> {
-  return await _getManagedDataSourceAgent(auth, {
+  return _getManagedDataSourceAgent(auth, {
     settings,
     connectorProvider: "google_drive",
     agentId: GLOBAL_AGENTS_SID.GOOGLE_DRIVE,
@@ -492,7 +492,7 @@ async function _getSlackGlobalAgent(
     dataSources: DataSourceType[];
   }
 ) {
-  return await _getManagedDataSourceAgent(auth, {
+  return _getManagedDataSourceAgent(auth, {
     settings,
     connectorProvider: "slack",
     agentId: GLOBAL_AGENTS_SID.SLACK,
@@ -515,7 +515,7 @@ async function _getGithubGlobalAgent(
     dataSources: DataSourceType[];
   }
 ) {
-  return await _getManagedDataSourceAgent(auth, {
+  return _getManagedDataSourceAgent(auth, {
     settings,
     connectorProvider: "github",
     agentId: GLOBAL_AGENTS_SID.GITHUB,
@@ -539,7 +539,7 @@ async function _getNotionGlobalAgent(
     dataSources: DataSourceType[];
   }
 ): Promise<AgentConfigurationType | null> {
-  return await _getManagedDataSourceAgent(auth, {
+  return _getManagedDataSourceAgent(auth, {
     settings,
     connectorProvider: "notion",
     agentId: GLOBAL_AGENTS_SID.NOTION,

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -73,7 +73,7 @@ export class Authenticator {
   static async fromSession(session: any, wId: string): Promise<Authenticator> {
     const [workspace, user] = await Promise.all([
       (async () => {
-        return await Workspace.findOne({
+        return Workspace.findOne({
           where: {
             sId: wId,
           },
@@ -83,7 +83,7 @@ export class Authenticator {
         if (!session) {
           return null;
         } else {
-          return await User.findOne({
+          return User.findOne({
             where: {
               provider: session.provider.provider,
               providerId: session.provider.id.toString(),
@@ -140,7 +140,7 @@ export class Authenticator {
         if (!wId) {
           return null;
         }
-        return await Workspace.findOne({
+        return Workspace.findOne({
           where: {
             sId: wId,
           },
@@ -150,7 +150,7 @@ export class Authenticator {
         if (!session) {
           return null;
         } else {
-          return await User.findOne({
+          return User.findOne({
             where: {
               provider: session.provider.provider,
               providerId: session.provider.id.toString(),
@@ -186,14 +186,14 @@ export class Authenticator {
   ): Promise<{ auth: Authenticator; keyWorkspaceId: string }> {
     const [workspace, keyWorkspace] = await Promise.all([
       (async () => {
-        return await Workspace.findOne({
+        return Workspace.findOne({
           where: {
             sId: wId,
           },
         });
       })(),
       (async () => {
-        return await Workspace.findOne({
+        return Workspace.findOne({
           where: {
             id: key.workspaceId,
           },
@@ -366,7 +366,7 @@ export async function getSession(
   req: NextApiRequest | GetServerSidePropsContext["req"],
   res: NextApiResponse | GetServerSidePropsContext["res"]
 ): Promise<any> {
-  return await getServerSession(req, res, authOptions);
+  return getServerSession(req, res, authOptions);
 }
 
 /**

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -172,7 +172,7 @@ export const getProduct = async (
 export const getStripeSubscription = async (
   stripeSubscriptionId: string
 ): Promise<Stripe.Subscription> => {
-  return await stripe.subscriptions.retrieve(stripeSubscriptionId);
+  return stripe.subscriptions.retrieve(stripeSubscriptionId);
 };
 
 /**

--- a/front/lib/plans/subscription.ts
+++ b/front/lib/plans/subscription.ts
@@ -132,7 +132,7 @@ export const internalSubscribeWorkspaceToFreeUpgradedPlan = async ({
     );
   }
 
-  return await front_sequelize.transaction(async (t) => {
+  return front_sequelize.transaction(async (t) => {
     // We end the active subscription if any
     if (activeSubscription) {
       await activeSubscription.update({

--- a/front/lib/plans/workspace_usage.ts
+++ b/front/lib/plans/workspace_usage.ts
@@ -15,7 +15,7 @@ export async function countActiveSeatsInWorkspace(
   if (!workspace) {
     throw new Error(`Workspace not found for sId: ${workspaceId}`);
   }
-  return await Membership.count({
+  return Membership.count({
     where: {
       workspaceId: workspace.id,
       role: {

--- a/front/pages/w/[wId]/subscription/index.tsx
+++ b/front/pages/w/[wId]/subscription/index.tsx
@@ -168,7 +168,7 @@ export default function Subscription({
   const plan = subscription.plan;
   const chipColor = plan.code === FREE_TEST_PLAN_CODE ? "emerald" : "sky";
 
-  const onClickProPlan = async () => await handleSubscribePlan();
+  const onClickProPlan = async () => handleSubscribePlan();
   const onClickEnterprisePlan = () => {
     window.open("mailto:team@dust.tt?subject=Upgrading to Enteprise plan");
   };
@@ -233,7 +233,7 @@ export default function Subscription({
                             : "Visit Dust's dashboard on Stripe"
                         }
                         disabled={isProcessing}
-                        onClick={async () => await handleGoToStripePortal()}
+                        onClick={async () => handleGoToStripePortal()}
                       />
                     </div>
                   </>

--- a/sparkle/.eslintrc.js
+++ b/sparkle/.eslintrc.js
@@ -40,6 +40,7 @@ module.exports = {
       },
     ],
     "simple-import-sort/exports": "error",
+    "@typescript-eslint/return-await": ["error", "in-try-catch"],
   },
   overrides: [
     {

--- a/types/.eslintrc.js
+++ b/types/.eslintrc.js
@@ -29,6 +29,7 @@ module.exports = {
     "simple-import-sort/exports": "error",
     "@typescript-eslint/no-floating-promises": "error",
     "@typescript-eslint/no-unused-vars": "error",
+    "@typescript-eslint/return-await": ["error", "in-try-catch"],
   },
   overrides: [
     {


### PR DESCRIPTION
See [thread](https://dust4ai.slack.com/archives/C050SM8NSPK/p1704790756417929)

This PR adds a [new rule](https://typescript-eslint.io/rules/return-await/) in our .eslintrc to always wait for returned promises in try/catch block. Without the await we’re deferring its result, so our catch block never runs.


