### PR TITLE
Implement assistant preview small variant

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.64",
+  "version": "0.2.65",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.64",
+      "version": "0.2.65",
       "license": "ISC",
       "dependencies": {
         "@headlessui/react": "^1.7.17"

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.64",
+  "version": "0.2.65",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/components/AssistantPreview.tsx
+++ b/sparkle/src/components/AssistantPreview.tsx
@@ -3,27 +3,47 @@ import React from "react";
 import { Avatar } from "@sparkle/components/Avatar";
 import { Button } from "@sparkle/components/Button";
 import { Chip } from "@sparkle/components/Chip";
-import { Dash, More, Play, Plus } from "@sparkle/icons/solid";
+import {
+  ChatBubbleBottomCenterText,
+  Dash,
+  More,
+  Play,
+  Plus,
+} from "@sparkle/icons/solid";
 
 type AssistantPreviewVariant = "sm" | "md" | "lg" | "list";
 
-interface AssistantPreviewProps {
-  allowAddAction?: boolean;
-  allowRemoveAction?: boolean;
+interface BaseAssistantPreviewProps {
   description: string;
-  isAdded: boolean;
-  isUpdatingList: boolean;
-  isWorkspace: boolean;
   name: string;
   pictureUrl: string;
   subtitle: string;
   variant: AssistantPreviewVariant;
+}
 
-  // CTA's.
+type LargeVariantAssistantPreviewProps = BaseAssistantPreviewProps & {
+  variant: "lg";
+
+  allowAddAction?: boolean;
+  allowRemoveAction?: boolean;
+  isAdded: boolean;
+  isUpdatingList: boolean;
+  isWorkspace: boolean;
+
   onShowDetailsClick?: () => void;
   onTestClick?: () => void;
   onUpdate: (action: "added" | "removed") => Promise<void> | void;
-}
+};
+
+type SmallVariantAssistantPreviewProps = BaseAssistantPreviewProps & {
+  variant: "sm";
+
+  onClick: () => void;
+};
+
+type AssistantPreviewProps =
+  | SmallVariantAssistantPreviewProps
+  | LargeVariantAssistantPreviewProps;
 
 // Define defaultProps for the AssistantPreview component.
 AssistantPreview.defaultProps = {
@@ -31,36 +51,51 @@ AssistantPreview.defaultProps = {
   allowRemoveAction: false,
 };
 
-function renderVariantContent(
-  variant: AssistantPreviewVariant,
-  props: AssistantPreviewProps
-) {
-  switch (variant) {
+function renderVariantContent(props: AssistantPreviewProps) {
+  switch (props.variant) {
     case "sm":
-      return <SmallVariantContent />;
-    case "md":
-      return <MediumVariantContent />;
+      return <SmallVariantContent {...props} />;
     case "lg":
-      return <LargeVariantContent props={props} />;
-    case "list":
-      return <ListVariantContent />;
+      return <LargeVariantContent {...props} />;
     default:
       return <></>;
   }
 }
 
 // TODO:
-const SmallVariantContent = () => {
-  throw new Error("Not yet implemented!");
-};
+const SmallVariantContent = (props: SmallVariantAssistantPreviewProps) => {
+  const { description, name, onClick, pictureUrl } = props;
 
-// TODO:
-const MediumVariantContent = () => {
-  throw new Error("Not yet implemented!");
+  return (
+    <div className="s-flex s-flex-col s-py-2">
+      <div className="s-flex s-flex-row s-gap-2">
+        <Avatar
+          visual={<img src={pictureUrl} alt={`Avatar of ${name}`} />}
+          size="md"
+        />
+        <div className="s-flex s-flex-col s-gap-2">
+          <div className="s-text-sm s-font-medium s-text-element-900">
+            @{name}
+          </div>
+          <Button
+            key="start"
+            variant="tertiary"
+            icon={ChatBubbleBottomCenterText}
+            size="xs"
+            label={"Start"}
+            onClick={onClick}
+          />
+        </div>
+      </div>
+      <div className="s-py-1.5 s-text-sm s-font-normal s-text-element-700">
+        {description}
+      </div>
+    </div>
+  );
 };
 
 type GalleryChipProps = Pick<
-  AssistantPreviewProps,
+  LargeVariantAssistantPreviewProps,
   | "allowAddAction"
   | "allowRemoveAction"
   | "isAdded"
@@ -107,7 +142,7 @@ const GalleryChip = ({
 };
 
 type ButtonsGroupProps = Pick<
-  AssistantPreviewProps,
+  LargeVariantAssistantPreviewProps,
   | "allowAddAction"
   | "isAdded"
   | "isUpdatingList"
@@ -164,7 +199,7 @@ const ButtonsGroup = ({
   );
 };
 
-const LargeVariantContent = ({ props }: { props: AssistantPreviewProps }) => {
+const LargeVariantContent = (props: LargeVariantAssistantPreviewProps) => {
   const {
     allowAddAction,
     allowRemoveAction,
@@ -221,13 +256,8 @@ const LargeVariantContent = ({ props }: { props: AssistantPreviewProps }) => {
   );
 };
 
-// TODO:
-const ListVariantContent = () => {
-  throw new Error("Not yet implemented!");
-};
-
 export function AssistantPreview(props: AssistantPreviewProps) {
-  const VariantContent = renderVariantContent(props.variant, props);
+  const VariantContent = renderVariantContent(props);
 
   return <div>{VariantContent}</div>;
 }

--- a/sparkle/src/components/AssistantPreview.tsx
+++ b/sparkle/src/components/AssistantPreview.tsx
@@ -62,7 +62,6 @@ function renderVariantContent(props: AssistantPreviewProps) {
   }
 }
 
-// TODO:
 const SmallVariantContent = (props: SmallVariantAssistantPreviewProps) => {
   const { description, name, onClick, pictureUrl } = props;
 

--- a/sparkle/src/stories/AssistantPreview.stories.tsx
+++ b/sparkle/src/stories/AssistantPreview.stories.tsx
@@ -11,43 +11,73 @@ const meta: Meta<typeof AssistantPreview> = {
 export default meta;
 
 export const AssistantPreviewExample = () => (
-  <div>
-    <h2>Gallery view (variant: `lg`)</h2>
-    <div className="s-flex s-flex-row">
-      <AssistantPreview
-        allowAddAction={true}
-        description={"OpenAI's most powerful and recent model (128k context)."}
-        isAdded={false}
-        isUpdatingList={false}
-        isWorkspace={false}
-        name={"gpt4"}
-        onShowDetailsClick={() => alert("Details button clicked")}
-        onTestClick={() => alert("Test button clicked")}
-        onUpdate={(action) => {
-          alert(`Update button clicked with action: ${action}`);
-          return;
-        }}
-        pictureUrl={"https://dust.tt/static/systemavatar/gpt4_avatar_full.png"}
-        subtitle={"Stanislas Polu, Pauline Pham"}
-        variant={"lg"}
-      />
-      <AssistantPreview
-        allowAddAction={true}
-        allowRemoveAction={true}
-        name={"gpt3.5-turbo"}
-        description={"OpenAI's most powerful and recent model (128k context)."}
-        pictureUrl={"https://dust.tt/static/systemavatar/gpt3_avatar_full.png"}
-        subtitle={"Stanislas Polu, Pauline Pham"}
-        onShowDetailsClick={() => alert("Details button clicked")}
-        onUpdate={(action) => {
-          alert(`Update button clicked with action: ${action}`);
-          return;
-        }}
-        variant={"lg"}
-        isWorkspace={false}
-        isAdded={true}
-        isUpdatingList={false}
-      />
+  <div className="s-flex s-flex-col s-gap-4">
+    <div>
+      <h2>Gallery view (variant: `lg`)</h2>
+      <div className="s-flex s-flex-row">
+        <AssistantPreview
+          allowAddAction={true}
+          description={
+            "OpenAI's most powerful and recent model (128k context)."
+          }
+          isAdded={false}
+          isUpdatingList={false}
+          isWorkspace={false}
+          name={"gpt4"}
+          onShowDetailsClick={() => alert("Details button clicked")}
+          onTestClick={() => alert("Test button clicked")}
+          onUpdate={(action) => {
+            alert(`Update button clicked with action: ${action}`);
+            return;
+          }}
+          pictureUrl={
+            "https://dust.tt/static/systemavatar/gpt4_avatar_full.png"
+          }
+          subtitle={"Stanislas Polu, Pauline Pham"}
+          variant={"lg"}
+        />
+        <AssistantPreview
+          allowAddAction={true}
+          allowRemoveAction={true}
+          name={"gpt3.5-turbo"}
+          description={
+            "OpenAI's most powerful and recent model (128k context)."
+          }
+          pictureUrl={
+            "https://dust.tt/static/systemavatar/gpt3_avatar_full.png"
+          }
+          subtitle={"Stanislas Polu, Pauline Pham"}
+          onShowDetailsClick={() => alert("Details button clicked")}
+          onUpdate={(action) => {
+            alert(`Update button clicked with action: ${action}`);
+            return;
+          }}
+          variant={"lg"}
+          isWorkspace={false}
+          isAdded={true}
+          isUpdatingList={false}
+        />
+      </div>
+    </div>
+    <div>
+      <h2>Gallery view (variant: `sm`)</h2>
+      <div className="s-flex s-flex-row">
+        <AssistantPreview
+          description={
+            "OpenAI's most powerful and recent model (128k context)."
+          }
+          name={"gpt4"}
+          pictureUrl={
+            "https://dust.tt/static/systemavatar/gpt4_avatar_full.png"
+          }
+          subtitle={"Stanislas Polu, Pauline Pham"}
+          variant={"sm"}
+          onClick={() => {
+            alert(`On click button clicked`);
+            return;
+          }}
+        />
+      </div>
     </div>
   </div>
 );


### PR DESCRIPTION
This PR adds the small variant to the `AssistantPreview` sparkle component.

From this [figma file](https://www.figma.com/file/QOxHwppG64GtPocpDhS6Y7/Product?type=design&node-id=2677-10559&mode=design&t=I6pGmlwxIWJ8frYo-0).

<img width="414" alt="image" src="https://github.com/dust-tt/dust/assets/7428970/e1c93534-4f91-476b-8556-f1d94a2f4227">
