### PR TITLE
enh: expire all cached DBs when worker reconnects

### DIFF
--- a/core/src/sqlite_workers/client.rs
+++ b/core/src/sqlite_workers/client.rs
@@ -100,4 +100,23 @@ impl SqliteWorker {
             ))?,
         }
     }
+
+    pub async fn expire_all(&self) -> Result<()> {
+        let worker_url = self.url();
+
+        let req = Request::builder()
+            .method("DELETE")
+            .uri(format!("{}/databases", worker_url))
+            .body(Body::from(""))?;
+
+        let res = Client::new().request(req).await?;
+
+        match res.status().as_u16() {
+            200 => Ok(()),
+            s => Err(anyhow!(
+                "Failed to expire all databases on sqlite worker. Status: {}",
+                s
+            ))?,
+        }
+    }
 }

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -261,7 +261,7 @@ pub trait Store {
 
     // SQLite Workers
     async fn sqlite_workers_list(&self) -> Result<Vec<SqliteWorker>>;
-    async fn sqlite_workers_upsert(&self, url: &str) -> Result<SqliteWorker>;
+    async fn sqlite_workers_upsert(&self, url: &str, ttl: u64) -> Result<(SqliteWorker, bool)>;
     async fn sqlite_workers_delete(&self, url: &str) -> Result<()>;
     async fn sqlite_workers_cleanup(&self, ttl: u64) -> Result<()>;
 


### PR DESCRIPTION
If a worker is temporarily disconnected from `core`, we have no guarantee that its cached databases are still up-to-date after it reconnects (the worker might have missed a delete call). 

So after a worker is created or brought back to life on core, we call an "expire all" endpoint on the worker to signal it to clear its registry if any.