### PR TITLE
refactor: bring back database dust app blocks

### DIFF
--- a/core/src/sqlite_workers/sqlite_database.rs
+++ b/core/src/sqlite_workers/sqlite_database.rs
@@ -132,7 +132,7 @@ async fn create_in_memory_sqlite_db(
         let databases_store = databases_store.clone();
         async move {
             let (rows, _) = databases_store
-                .list_table_rows(table.table_id(), None)
+                .list_table_rows(&table.unique_id(), None)
                 .await?;
             Ok::<_, anyhow::Error>((table.clone(), rows))
         }

--- a/front/components/app/NewBlock.tsx
+++ b/front/components/app/NewBlock.tsx
@@ -4,9 +4,11 @@ import { BlockType } from "@dust-tt/types";
 import { Menu } from "@headlessui/react";
 import { PlusIcon } from "@heroicons/react/20/solid";
 
+import { isActivatedStructuredDB } from "@app/lib/development";
 import { classNames } from "@app/lib/utils";
 
 export default function NewBlock({
+  owner,
   spec,
   disabled,
   onClick,
@@ -97,6 +99,23 @@ export default function NewBlock({
       description: "Loop over a set of blocks until a condition is met.",
     },
   ];
+
+  if (isActivatedStructuredDB(owner)) {
+    blocks.push(
+      {
+        type: "database_schema",
+        typeNames: ["database_schema"],
+        name: "Database Schema",
+        description: "Retrieve the schema of a database.",
+      },
+      {
+        type: "database",
+        typeNames: ["database"],
+        name: "Database",
+        description: "Query a database.",
+      }
+    );
+  }
 
   if (!containsInput) {
     blocks.splice(0, 0, {

--- a/front/components/app/SpecRunView.tsx
+++ b/front/components/app/SpecRunView.tsx
@@ -7,6 +7,9 @@ import {
 import { BlockType, RunType } from "@dust-tt/types";
 import TextareaAutosize from "react-textarea-autosize";
 
+import Database from "@app/components/app/blocks/Database";
+import DatabaseSchema from "@app/components/app/blocks/DatabaseSchema";
+
 import Browser from "./blocks/Browser";
 import Chat from "./blocks/Chat";
 import Code from "./blocks/Code";
@@ -319,6 +322,46 @@ export default function SpecRunView({
             case "browser":
               return (
                 <Browser
+                  key={idx}
+                  block={block}
+                  owner={owner}
+                  app={app}
+                  spec={spec}
+                  run={run}
+                  status={status}
+                  running={runRequested || run?.status.run == "running"}
+                  readOnly={readOnly}
+                  onBlockUpdate={(block) => handleSetBlock(idx, block)}
+                  onBlockDelete={() => handleDeleteBlock(idx)}
+                  onBlockUp={() => handleMoveBlockUp(idx)}
+                  onBlockDown={() => handleMoveBlockDown(idx)}
+                  onBlockNew={(blockType) => handleNewBlock(idx, blockType)}
+                />
+              );
+
+            case "database_schema":
+              return (
+                <DatabaseSchema
+                  key={idx}
+                  block={block}
+                  owner={owner}
+                  app={app}
+                  spec={spec}
+                  run={run}
+                  status={status}
+                  running={runRequested || run?.status.run == "running"}
+                  readOnly={readOnly}
+                  onBlockUpdate={(block) => handleSetBlock(idx, block)}
+                  onBlockDelete={() => handleDeleteBlock(idx)}
+                  onBlockUp={() => handleMoveBlockUp(idx)}
+                  onBlockDown={() => handleMoveBlockDown(idx)}
+                  onBlockNew={(blockType) => handleNewBlock(idx, blockType)}
+                />
+              );
+
+            case "database":
+              return (
+                <Database
                   key={idx}
                   block={block}
                   owner={owner}

--- a/front/components/app/blocks/Database.tsx
+++ b/front/components/app/blocks/Database.tsx
@@ -1,0 +1,170 @@
+import "@uiw/react-textarea-code-editor/dist.css";
+
+import { WorkspaceType } from "@dust-tt/types";
+import {
+  AppType,
+  SpecificationBlockType,
+  SpecificationType,
+} from "@dust-tt/types";
+import { BlockType, RunType } from "@dust-tt/types";
+import dynamic from "next/dynamic";
+
+import DataSourcePicker from "@app/components/data_source/DataSourcePicker";
+import TablePicker from "@app/components/tables/TablePicker";
+import { classNames, shallowBlockClone } from "@app/lib/utils";
+
+import Block from "./Block";
+
+const CodeEditor = dynamic(
+  () => import("@uiw/react-textarea-code-editor").then((mod) => mod.default),
+  { ssr: false }
+);
+
+export default function Database({
+  owner,
+  app,
+  spec,
+  run,
+  block,
+  status,
+  running,
+  readOnly,
+  onBlockUpdate,
+  onBlockDelete,
+  onBlockUp,
+  onBlockDown,
+  onBlockNew,
+}: React.PropsWithChildren<{
+  owner: WorkspaceType;
+  app: AppType;
+  spec: SpecificationType;
+  run: RunType | null;
+  block: SpecificationBlockType;
+  status: any;
+  running: boolean;
+  readOnly: boolean;
+  onBlockUpdate: (block: SpecificationBlockType) => void;
+  onBlockDelete: () => void;
+  onBlockUp: () => void;
+  onBlockDown: () => void;
+  onBlockNew: (blockType: BlockType | "map_reduce" | "while_end") => void;
+}>) {
+  return (
+    <Block
+      owner={owner}
+      app={app}
+      spec={spec}
+      run={run}
+      block={block}
+      status={status}
+      running={running}
+      readOnly={readOnly}
+      canUseCache={false}
+      onBlockUpdate={onBlockUpdate}
+      onBlockDelete={onBlockDelete}
+      onBlockUp={onBlockUp}
+      onBlockDown={onBlockDown}
+      onBlockNew={onBlockNew}
+    >
+      <div className="mx-4 flex w-full flex-col gap-2">
+        <div className="flex flex-col flex-col gap-2 pt-4 xl:flex-row">
+          <div className="flex flex-col xl:flex-row xl:space-x-2">
+            <div className="mr-1 flex flex-initial text-sm font-medium leading-8 text-gray-700">
+              Table:
+            </div>
+            <div className="mr-2 flex flex-initial flex-row items-center space-x-1 text-sm font-medium leading-8 text-gray-700">
+              <DataSourcePicker
+                owner={owner}
+                readOnly={readOnly}
+                currentDataSources={
+                  block.config.tables?.[0]
+                    ? [
+                        {
+                          data_source_id:
+                            block.config.tables?.[0].data_source_id,
+                          workspace_id: block.config.tables?.[0].workspace_id,
+                        },
+                      ]
+                    : []
+                }
+                onDataSourcesUpdate={(dataSources) => {
+                  if (dataSources.length === 0) {
+                    return;
+                  }
+                  const ds = dataSources[0];
+                  const b = shallowBlockClone(block);
+                  if (!b.config.tables) {
+                    b.config.tables = [];
+                  }
+                  b.config.tables[0] = {
+                    workspace_id: ds.workspace_id,
+                    data_source_id: ds.data_source_id,
+                  };
+                  onBlockUpdate(b);
+                }}
+              />
+            </div>
+          </div>
+          {block.config.tables?.[0] && (
+            <div className="flex flex-col xl:flex-row xl:space-x-2">
+              <div className="mr-2 flex flex-initial flex-row items-center space-x-1 text-sm font-medium leading-8 text-gray-700">
+                <TablePicker
+                  owner={owner}
+                  dataSource={{
+                    workspace_id: block.config.tables?.[0].workspace_id,
+                    data_source_id: block.config.tables?.[0].data_source_id,
+                  }}
+                  readOnly={readOnly}
+                  currentTableId={block.config.tables?.[0].table_id}
+                  onTableUpdate={(table) => {
+                    const b = shallowBlockClone(block);
+                    block.config.tables[0].table_id = table.table_id;
+                    onBlockUpdate(b);
+                  }}
+                />
+              </div>
+            </div>
+          )}
+        </div>
+        {block.config.tables?.[0].table_id && (
+          <div>
+            <div className="mr-1 flex flex-initial text-sm font-medium leading-8 text-gray-700">
+              query:
+            </div>
+            <div className="flex w-full font-normal">
+              <div className="w-full leading-5">
+                <div
+                  className={classNames("border border-slate-100 bg-slate-100")}
+                  style={{
+                    minHeight: "48px",
+                  }}
+                >
+                  <CodeEditor
+                    data-color-mode="light"
+                    readOnly={readOnly}
+                    value={block.spec.query}
+                    language="jinja2"
+                    placeholder=""
+                    onChange={(e) => {
+                      const b = shallowBlockClone(block);
+                      b.spec.query = e.target.value;
+                      onBlockUpdate(b);
+                    }}
+                    padding={3}
+                    style={{
+                      color: "rgb(55 65 81)",
+                      fontSize: 13,
+                      fontFamily:
+                        "ui-monospace, SFMono-Regular, SF Mono, Consolas, Liberation Mono, Menlo, monospace",
+                      backgroundColor: "rgb(241 245 249)",
+                    }}
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </Block>
+  );
+}

--- a/front/components/app/blocks/DatabaseSchema.tsx
+++ b/front/components/app/blocks/DatabaseSchema.tsx
@@ -1,0 +1,126 @@
+import "@uiw/react-textarea-code-editor/dist.css";
+
+import { WorkspaceType } from "@dust-tt/types";
+import {
+  AppType,
+  SpecificationBlockType,
+  SpecificationType,
+} from "@dust-tt/types";
+import { BlockType, RunType } from "@dust-tt/types";
+
+import DataSourcePicker from "@app/components/data_source/DataSourcePicker";
+import TablePicker from "@app/components/tables/TablePicker";
+import { shallowBlockClone } from "@app/lib/utils";
+
+import Block from "./Block";
+
+export default function DatabaseSchema({
+  owner,
+  app,
+  spec,
+  run,
+  block,
+  status,
+  running,
+  readOnly,
+  onBlockUpdate,
+  onBlockDelete,
+  onBlockUp,
+  onBlockDown,
+  onBlockNew,
+}: React.PropsWithChildren<{
+  owner: WorkspaceType;
+  app: AppType;
+  spec: SpecificationType;
+  run: RunType | null;
+  block: SpecificationBlockType;
+  status: any;
+  running: boolean;
+  readOnly: boolean;
+  onBlockUpdate: (block: SpecificationBlockType) => void;
+  onBlockDelete: () => void;
+  onBlockUp: () => void;
+  onBlockDown: () => void;
+  onBlockNew: (blockType: BlockType | "map_reduce" | "while_end") => void;
+}>) {
+  return (
+    <Block
+      owner={owner}
+      app={app}
+      spec={spec}
+      run={run}
+      block={block}
+      status={status}
+      running={running}
+      readOnly={readOnly}
+      canUseCache={false}
+      onBlockUpdate={onBlockUpdate}
+      onBlockDelete={onBlockDelete}
+      onBlockUp={onBlockUp}
+      onBlockDown={onBlockDown}
+      onBlockNew={onBlockNew}
+    >
+      <div className="mx-4 flex w-full flex-col gap-2">
+        <div className="flex flex-col flex-col gap-2 pt-4 xl:flex-row">
+          <div className="flex flex-col xl:flex-row xl:space-x-2">
+            <div className="mr-1 flex flex-initial text-sm font-medium leading-8 text-gray-700">
+              Table:
+            </div>
+            <div className="mr-2 flex flex-initial flex-row items-center space-x-1 text-sm font-medium leading-8 text-gray-700">
+              <DataSourcePicker
+                owner={owner}
+                readOnly={readOnly}
+                currentDataSources={
+                  block.config.tables?.[0]
+                    ? [
+                        {
+                          data_source_id:
+                            block.config.tables?.[0].data_source_id,
+                          workspace_id: block.config.tables?.[0].workspace_id,
+                        },
+                      ]
+                    : []
+                }
+                onDataSourcesUpdate={(dataSources) => {
+                  if (dataSources.length === 0) {
+                    return;
+                  }
+                  const ds = dataSources[0];
+                  const b = shallowBlockClone(block);
+                  if (!b.config.tables) {
+                    b.config.tables = [];
+                  }
+                  b.config.tables[0] = {
+                    workspace_id: ds.workspace_id,
+                    data_source_id: ds.data_source_id,
+                  };
+                  onBlockUpdate(b);
+                }}
+              />
+            </div>
+          </div>
+          {block.config.tables?.[0] && (
+            <div className="flex flex-col xl:flex-row xl:space-x-2">
+              <div className="mr-2 flex flex-initial flex-row items-center space-x-1 text-sm font-medium leading-8 text-gray-700">
+                <TablePicker
+                  owner={owner}
+                  dataSource={{
+                    workspace_id: block.config.tables?.[0].workspace_id,
+                    data_source_id: block.config.tables?.[0].data_source_id,
+                  }}
+                  readOnly={readOnly}
+                  currentTableId={block.config.tables?.[0].table_id}
+                  onTableUpdate={(table) => {
+                    const b = shallowBlockClone(block);
+                    block.config.tables[0].table_id = table.table_id;
+                    onBlockUpdate(b);
+                  }}
+                />
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </Block>
+  );
+}

--- a/front/components/tables/TablePicker.tsx
+++ b/front/components/tables/TablePicker.tsx
@@ -1,0 +1,111 @@
+import { WorkspaceType } from "@dust-tt/types";
+import { CoreAPITable } from "@dust-tt/types";
+import { Menu } from "@headlessui/react";
+import { ChevronDownIcon } from "@heroicons/react/20/solid";
+
+import { useTables } from "@app/lib/swr";
+import { classNames } from "@app/lib/utils";
+
+export default function TablePicker({
+  owner,
+  dataSource,
+  currentTableId,
+  readOnly,
+  onTableUpdate,
+}: {
+  owner: WorkspaceType;
+  dataSource: {
+    workspace_id: string;
+    data_source_id: string;
+  };
+  currentTableId?: string;
+  readOnly: boolean;
+  onTableUpdate: (table: CoreAPITable) => void;
+}) {
+  void owner;
+  void dataSource;
+
+  const { tables } = useTables({
+    workspaceId: dataSource.workspace_id,
+    dataSourceName: dataSource.data_source_id,
+  });
+
+  const currentTable = currentTableId
+    ? tables.find((t) => t.table_id === currentTableId)
+    : null;
+
+  return (
+    <div className="flex items-center">
+      <div className="flex items-center">
+        {readOnly ? (
+          currentTable ? (
+            <div className="text-sm font-bold text-action-500">
+              {currentTable.name}
+            </div>
+          ) : (
+            "No Table"
+          )
+        ) : (
+          <Menu as="div" className="relative inline-block text-left">
+            <div>
+              <Menu.Button
+                className={classNames(
+                  "inline-flex items-center rounded-md py-1 text-sm font-normal text-gray-700",
+                  currentTable ? "px-0" : "border px-3",
+                  readOnly
+                    ? "border-white text-gray-300"
+                    : "border-orange-400 text-gray-700",
+                  "focus:outline-none focus:ring-0"
+                )}
+              >
+                {currentTable ? (
+                  <>
+                    <div className="mr-1 text-sm font-bold text-action-500">
+                      {currentTable.name}
+                    </div>
+                    <ChevronDownIcon className="mt-0.5 h-4 w-4 hover:text-gray-700" />
+                  </>
+                ) : tables && tables.length > 0 ? (
+                  "Select Table"
+                ) : (
+                  "No Tables"
+                )}
+              </Menu.Button>
+            </div>
+
+            {(tables || []).length > 0 ? (
+              <Menu.Items
+                className={classNames(
+                  "absolute z-10 mt-1 w-max origin-top-left rounded-md bg-white shadow-sm ring-1 ring-black ring-opacity-5 focus:outline-none",
+                  currentTable ? "-left-4" : "left-1"
+                )}
+              >
+                <div className="py-1">
+                  {(tables || []).map((t) => {
+                    return (
+                      <Menu.Item key={t.table_id}>
+                        {({ active }) => (
+                          <span
+                            className={classNames(
+                              active
+                                ? "bg-gray-50 text-gray-900"
+                                : "text-gray-700",
+                              "block cursor-pointer px-4 py-2 text-sm"
+                            )}
+                            onClick={() => onTableUpdate(t)}
+                          >
+                            {t.name}
+                          </span>
+                        )}
+                      </Menu.Item>
+                    );
+                  })}
+                </div>
+              </Menu.Items>
+            ) : null}
+          </Menu>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/front/lib/config.ts
+++ b/front/lib/config.ts
@@ -91,6 +91,18 @@ export function extractConfig(spec: SpecificationType): BlockRunConfig {
             : false,
         };
         break;
+      case "database_schema":
+        c[spec[i].name] = {
+          type: "database_schema",
+          tables: spec[i].config?.tables,
+        };
+        break;
+      case "database":
+        c[spec[i].name] = {
+          type: "database",
+          tables: spec[i].config?.tables,
+        };
+        break;
       case "data":
       case "code":
       case "map":

--- a/front/lib/specification.ts
+++ b/front/lib/specification.ts
@@ -242,6 +242,26 @@ export function addBlock(
         },
       });
       break;
+    case "database_schema":
+      s.splice(idx + 1, 0, {
+        type: "database_schema",
+        name: getNextName(spec, "DATABASE_SCHEMA"),
+        indent: 0,
+        spec: {},
+        config: {},
+      });
+      break;
+    case "database":
+      s.splice(idx + 1, 0, {
+        type: "database",
+        name: getNextName(spec, "DATABASE"),
+        indent: 0,
+        spec: {
+          query: "",
+        },
+        config: {},
+      });
+      break;
     default:
       s.splice(idx + 1, 0, {
         type: blockType,
@@ -550,6 +570,20 @@ export function dumpSpecification(
         if (block.spec.wait_for) {
           out += `  wait_for: \n\`\`\`\n${block.spec.wait_for}\n\`\`\`\n`;
         }
+        out += `}\n`;
+        out += "\n";
+        break;
+      }
+      case "database_schema": {
+        out += `database_schema ${block.name} { }\n`;
+        out += "\n";
+        break;
+      }
+      case "database": {
+        out += `database ${block.name} {\n`;
+        out += `  query: \n\`\`\`\n${escapeTripleBackticks(
+          block.spec.query
+        )}\n\`\`\`\n`;
         out += `}\n`;
         out += "\n";
         break;

--- a/types/src/front/run.ts
+++ b/types/src/front/run.ts
@@ -13,7 +13,9 @@ export type BlockType =
   | "end"
   | "search"
   | "curl"
-  | "browser";
+  | "browser"
+  | "database_schema"
+  | "database";
 
 export type RunRunType = "deploy" | "local" | "execute";
 type Status = "running" | "succeeded" | "errored";


### PR DESCRIPTION
They are now compatible with the new API. 
The UI of the blocks only allow you to select a single table, but the API let's you pass an array. Not unlike the datasource block.