### PR TITLE
Fix required props on AssistantPreview

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.65",
+  "version": "0.2.66",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.65",
+      "version": "0.2.66",
       "license": "ISC",
       "dependencies": {
         "@headlessui/react": "^1.7.17"

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.65",
+  "version": "0.2.66",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/components/AssistantPreview.tsx
+++ b/sparkle/src/components/AssistantPreview.tsx
@@ -17,7 +17,6 @@ interface BaseAssistantPreviewProps {
   description: string;
   name: string;
   pictureUrl: string;
-  subtitle: string;
   variant: AssistantPreviewVariant;
 }
 
@@ -29,6 +28,7 @@ type LargeVariantAssistantPreviewProps = BaseAssistantPreviewProps & {
   isAdded: boolean;
   isUpdatingList: boolean;
   isWorkspace: boolean;
+  subtitle: string;
 
   onShowDetailsClick?: () => void;
   onTestClick?: () => void;

--- a/sparkle/src/stories/AssistantPreview.stories.tsx
+++ b/sparkle/src/stories/AssistantPreview.stories.tsx
@@ -70,7 +70,6 @@ export const AssistantPreviewExample = () => (
           pictureUrl={
             "https://dust.tt/static/systemavatar/gpt4_avatar_full.png"
           }
-          subtitle={"Stanislas Polu, Pauline Pham"}
           variant={"sm"}
           onClick={() => {
             alert(`On click button clicked`);


### PR DESCRIPTION
This PR removes the unused prop `subtitle` from the small variant of the `AssistantPreview` component.