### PR TITLE
[Caloris 2] Move Notion to chunking V2 with structure

### DIFF
--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -1756,21 +1756,13 @@ export async function renderAndUpsertPageFromCache({
       minute: "2-digit",
     });
 
-    const propsUpdatedTime = updatedTime.toLocaleString("en-US", {
-      month: "short",
-      day: "numeric",
-      year: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-    });
-
     // Properties and tags are added as prefix to the document top level section
     // section Title is in a separate prefix (both title and properties can be
     // lenghty, this avoids cutting one entirely)
     const content = renderPrefixSection(titlePrefix);
     let propsPrefix = `${
       title ? "\n" : ""
-    }$author: ${author}\n$last_editor: ${lastEditor}\n$created: ${propsCreatedTime}\n$last_edited: ${propsUpdatedTime}\n`;
+    }$author: ${author}\n$created: ${propsCreatedTime}\n`;
     for (const p of parsedProperties) {
       if (!p.text) continue;
       // We skip the title as it is added separately as prefix to the top-level document section.


### PR DESCRIPTION
Related [task](https://github.com/dust-tt/dust/issues/2458)

## Notes
1. differs a bit from framing => rather than 1 section per block, uses the already-rendered markdown with pre-existing lib function `renderMarkdownSection`

2. as a consequence, no extra line return between blocks (one line return only)

3. Wondering about removing last editor / last edited to lighten the prefix size?

Rendered content ======
![image](https://github.com/dust-tt/dust/assets/5437393/e07e5568-e258-49d4-bc0a-f1b7123fb605)

Notion page =======
![image](https://github.com/dust-tt/dust/assets/5437393/cfcdf53a-9799-4d88-a5a0-5427d89ad58d)
