### PR TITLE
oauth_token_revoked: do not cancel long running workflows

### DIFF
--- a/connectors/src/connectors/notion/temporal/client.ts
+++ b/connectors/src/connectors/notion/temporal/client.ts
@@ -49,6 +49,7 @@ export async function launchNotionSyncWorkflow(
     },
     memo: {
       connectorId: connectorId,
+      doNotCancelOnTokenRevoked: true,
     },
   });
 

--- a/connectors/src/lib/temporal.ts
+++ b/connectors/src/lib/temporal.ts
@@ -10,7 +10,9 @@ import fs from "fs-extra";
 
 // This is a singleton connection to the Temporal server.
 let TEMPORAL_CLIENT: Client | undefined;
-const WORKFLOW_ID2CONNECTOR_ID_CACHE: Record<string, ModelId> = {};
+
+const CONNECTOR_ID_CACHE: Record<string, ModelId> = {};
+const DO_NOT_CANCEL_ON_TOKEN_REVOKED_CACHE: Record<string, boolean> = {};
 
 export async function getTemporalClient(): Promise<Client> {
   if (TEMPORAL_CLIENT) {
@@ -76,32 +78,52 @@ export async function getTemporalWorkerConnection(): Promise<{
 export async function getConnectorId(
   workflowRunId: string
 ): Promise<ModelId | null> {
-  if (!WORKFLOW_ID2CONNECTOR_ID_CACHE[workflowRunId]) {
+  if (!CONNECTOR_ID_CACHE[workflowRunId]) {
     const client = await getTemporalClient();
-    const workflowHandle = await client.workflow.getHandle(workflowRunId);
+    const workflowHandle = client.workflow.getHandle(workflowRunId);
     const described = await workflowHandle.describe();
     if (described.memo && described.memo.connectorId) {
       if (typeof described.memo.connectorId === "number") {
-        WORKFLOW_ID2CONNECTOR_ID_CACHE[workflowRunId] =
-          described.memo.connectorId;
+        CONNECTOR_ID_CACHE[workflowRunId] = described.memo.connectorId;
       } else if (typeof described.memo.connectorId === "string") {
-        WORKFLOW_ID2CONNECTOR_ID_CACHE[workflowRunId] = parseInt(
+        CONNECTOR_ID_CACHE[workflowRunId] = parseInt(
           described.memo.connectorId,
           10
         );
       }
     }
-    if (!WORKFLOW_ID2CONNECTOR_ID_CACHE[workflowRunId]) {
-      return null;
+  }
+  return CONNECTOR_ID_CACHE[workflowRunId] || null;
+}
+
+export async function getDoNotCancelOnTokenRevoked(
+  workflowRunId: string
+): Promise<boolean> {
+  const cacheHasWorkflowId = Object.prototype.hasOwnProperty.call(
+    DO_NOT_CANCEL_ON_TOKEN_REVOKED_CACHE.hasOwnProperty,
+    workflowRunId
+  );
+  if (!cacheHasWorkflowId) {
+    const client = await getTemporalClient();
+    const workflowHandle = client.workflow.getHandle(workflowRunId);
+    const described = await workflowHandle.describe();
+    if (described.memo && described.memo.doNotCancelOnTokenRevoked) {
+      if (typeof described.memo.doNotCancelOnTokenRevoked === "boolean") {
+        DO_NOT_CANCEL_ON_TOKEN_REVOKED_CACHE[workflowRunId] =
+          described.memo.doNotCancelOnTokenRevoked;
+      } else if (typeof described.memo.doNotCancelOnTokenRevoked === "string") {
+        DO_NOT_CANCEL_ON_TOKEN_REVOKED_CACHE[workflowRunId] =
+          described.memo.doNotCancelOnTokenRevoked === "true";
+      }
     }
   }
-  return WORKFLOW_ID2CONNECTOR_ID_CACHE[workflowRunId] || null;
+  return DO_NOT_CANCEL_ON_TOKEN_REVOKED_CACHE[workflowRunId] || false;
 }
 
 export async function cancelWorkflow(workflowId: string) {
   const client = await getTemporalClient();
   try {
-    const workflowHandle = await client.workflow.getHandle(workflowId);
+    const workflowHandle = client.workflow.getHandle(workflowId);
     await workflowHandle.cancel();
     return true;
   } catch (e) {

--- a/connectors/src/lib/temporal.ts
+++ b/connectors/src/lib/temporal.ts
@@ -99,11 +99,7 @@ export async function getConnectorId(
 export async function getDoNotCancelOnTokenRevoked(
   workflowRunId: string
 ): Promise<boolean> {
-  const cacheHasWorkflowId = Object.prototype.hasOwnProperty.call(
-    DO_NOT_CANCEL_ON_TOKEN_REVOKED_CACHE.hasOwnProperty,
-    workflowRunId
-  );
-  if (!cacheHasWorkflowId) {
+  if (!(workflowRunId in DO_NOT_CANCEL_ON_TOKEN_REVOKED_CACHE)) {
     const client = await getTemporalClient();
     const workflowHandle = client.workflow.getHandle(workflowRunId);
     const described = await workflowHandle.describe();

--- a/connectors/src/lib/temporal.ts
+++ b/connectors/src/lib/temporal.ts
@@ -113,7 +113,7 @@ export async function getDoNotCancelOnTokenRevoked(
       }
     }
   }
-  return DO_NOT_CANCEL_ON_TOKEN_REVOKED_CACHE[workflowRunId] || false;
+  return DO_NOT_CANCEL_ON_TOKEN_REVOKED_CACHE[workflowRunId] ?? false;
 }
 
 export async function cancelWorkflow(workflowId: string) {


### PR DESCRIPTION
Context: https://dust4ai.slack.com/archives/C05F84CFP0E/p1704966170839509

We will also start throwing `ExternalOauthTokenError` when Notion can't talk to the API due to a revoked token. We want the syncFailed part but we don't want to cancel the workflow wich is expected to be running at all time.

DEPLOY:
- Deploy connectors
- Restart all Notion workflows