### PR TITLE
connectors: renderDocumentTitleAndContent

### DIFF
--- a/connectors/src/connectors/github/temporal/activities.ts
+++ b/connectors/src/connectors/github/temporal/activities.ts
@@ -111,6 +111,8 @@ async function renderIssue(
 
   const content = renderDocumentForTitleAndContent({
     title: `Issue #${issue.number} [${repoName}]: ${issue.title}`,
+    createdAt: issue.createdAt,
+    updatedAt: issue.updatedAt,
     content: renderMarkdownSection(issue.body || "", { flavor: "gfm" }),
   });
 

--- a/connectors/src/connectors/github/temporal/activities.ts
+++ b/connectors/src/connectors/github/temporal/activities.ts
@@ -20,7 +20,7 @@ import {
 } from "@connectors/connectors/github/lib/github_api";
 import {
   deleteFromDataSource,
-  renderDocumentForTitleAndContent,
+  renderDocumentTitleAndContent,
   renderMarkdownSection,
   upsertToDatasource,
 } from "@connectors/lib/data_sources";
@@ -109,7 +109,7 @@ async function renderIssue(
 
   const issue = await getIssue(installationId, repoName, login, issueNumber);
 
-  const content = renderDocumentForTitleAndContent({
+  const content = renderDocumentTitleAndContent({
     title: `Issue #${issue.number} [${repoName}]: ${issue.title}`,
     createdAt: issue.createdAt,
     updatedAt: issue.updatedAt,
@@ -282,7 +282,7 @@ async function renderDiscussion(
     discussionNumber
   );
 
-  const content = renderDocumentForTitleAndContent({
+  const content = renderDocumentTitleAndContent({
     title: `Discussion #${discussion.number} [${repoName}]: ${discussion.title}`,
     content: renderMarkdownSection(discussion.bodyText, { flavor: "gfm" }),
   });

--- a/connectors/src/connectors/github/temporal/activities.ts
+++ b/connectors/src/connectors/github/temporal/activities.ts
@@ -113,7 +113,7 @@ async function renderIssue(
     title: `Issue #${issue.number} [${repoName}]: ${issue.title}`,
     createdAt: issue.createdAt,
     updatedAt: issue.updatedAt,
-    content: renderMarkdownSection(issue.body || "", { flavor: "gfm" }),
+    content: renderMarkdownSection(issue.body ?? "", { flavor: "gfm" }),
   });
 
   let resultPage = 1;

--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -7,7 +7,7 @@ import PQueue from "p-queue";
 import {
   deleteFromDataSource,
   MAX_DOCUMENT_TXT_LEN,
-  renderDocumentForTitleAndContent,
+  renderDocumentTitleAndContent,
   upsertToDatasource,
 } from "@connectors/lib/data_sources";
 import { HTTPError } from "@connectors/lib/error";
@@ -509,7 +509,7 @@ async function syncOneFile(
     return false;
   }
 
-  const content = renderDocumentForTitleAndContent({
+  const content = renderDocumentTitleAndContent({
     title: file.name,
     updatedAt: file.updatedAtMs ? new Date(file.updatedAtMs) : undefined,
     createdAt: file.createdAtMs ? new Date(file.createdAtMs) : undefined,

--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -511,6 +511,8 @@ async function syncOneFile(
 
   const content = renderDocumentForTitleAndContent({
     title: file.name,
+    updatedAt: file.updatedAtMs ? new Date(file.updatedAtMs) : undefined,
+    createdAt: file.createdAtMs ? new Date(file.createdAtMs) : undefined,
     content: documentContent
       ? { prefix: null, content: documentContent, sections: [] }
       : null,

--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -509,11 +509,12 @@ async function syncOneFile(
     return false;
   }
 
-  // Add the title of the file to the beginning of the document.
-  const content = renderSectionForTitleAndContent(
-    file.name,
-    documentContent || null
-  );
+  const content = renderSectionForTitleAndContent({
+    title: file.name,
+    content: documentContent
+      ? { prefix: null, content: documentContent, sections: [] }
+      : null,
+  });
 
   if (documentContent === undefined) {
     logger.error(

--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -7,7 +7,7 @@ import PQueue from "p-queue";
 import {
   deleteFromDataSource,
   MAX_DOCUMENT_TXT_LEN,
-  renderSectionForTitleAndContent,
+  renderDocumentForTitleAndContent,
   upsertToDatasource,
 } from "@connectors/lib/data_sources";
 import { HTTPError } from "@connectors/lib/error";
@@ -509,7 +509,7 @@ async function syncOneFile(
     return false;
   }
 
-  const content = renderSectionForTitleAndContent({
+  const content = renderDocumentForTitleAndContent({
     title: file.name,
     content: documentContent
       ? { prefix: null, content: documentContent, sections: [] }

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -41,7 +41,7 @@ import {
 import {
   deleteFromDataSource,
   MAX_DOCUMENT_TXT_LEN,
-  renderDocumentForTitleAndContent,
+  renderDocumentTitleAndContent,
   upsertToDatasource,
 } from "@connectors/lib/data_sources";
 import { ExternalOauthTokenError } from "@connectors/lib/error";
@@ -1753,7 +1753,7 @@ export async function renderAndUpsertPageFromCache({
       runTimestamp.toString()
     );
 
-    const content = renderDocumentForTitleAndContent({
+    const content = renderDocumentTitleAndContent({
       title: title ?? null,
       createdAt: createdAt,
       updatedAt: updatedAt,

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -1753,10 +1753,10 @@ export async function renderAndUpsertPageFromCache({
       runTimestamp.toString()
     );
 
-    const content = renderSectionForTitleAndContent(
-      title || null,
-      renderedPage
-    );
+    const content = renderSectionForTitleAndContent({
+      title,
+      content: { prefix: null, content: renderedPage, sections: [] },
+    });
 
     localLogger.info(
       "notionRenderAndUpsertPageFromCache: Upserting to Data Source."

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -41,7 +41,7 @@ import {
 import {
   deleteFromDataSource,
   MAX_DOCUMENT_TXT_LEN,
-  renderSectionForTitleAndContent,
+  renderDocumentForTitleAndContent,
   upsertToDatasource,
 } from "@connectors/lib/data_sources";
 import { ExternalOauthTokenError } from "@connectors/lib/error";
@@ -1753,8 +1753,8 @@ export async function renderAndUpsertPageFromCache({
       runTimestamp.toString()
     );
 
-    const content = renderSectionForTitleAndContent({
-      title,
+    const content = renderDocumentForTitleAndContent({
+      title: title ?? null,
       content: { prefix: null, content: renderedPage, sections: [] },
     });
 

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -1734,8 +1734,8 @@ export async function renderAndUpsertPageFromCache({
     skipReason = "body_too_large";
   }
 
-  const createdTime = new Date(pageCacheEntry.createdTime).getTime();
-  const updatedTime = new Date(pageCacheEntry.lastEditedTime).getTime();
+  const createdAt = new Date(pageCacheEntry.createdTime);
+  const updatedAt = new Date(pageCacheEntry.lastEditedTime);
 
   if (!pageHasBody) {
     localLogger.info(
@@ -1755,6 +1755,8 @@ export async function renderAndUpsertPageFromCache({
 
     const content = renderDocumentForTitleAndContent({
       title: title ?? null,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
       content: { prefix: null, content: renderedPage, sections: [] },
     });
 
@@ -1770,13 +1772,13 @@ export async function renderAndUpsertPageFromCache({
       documentId,
       documentContent: content,
       documentUrl: pageCacheEntry.url,
-      timestampMs: updatedTime,
+      timestampMs: updatedAt.getTime(),
       tags: getTagsForPage({
         title,
         author,
         lastEditor,
-        createdTime,
-        updatedTime,
+        createdTime: createdAt.getTime(),
+        updatedTime: updatedAt.getTime(),
       }),
       parents,
       retries: 3,

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -756,13 +756,13 @@ async function makeContentFragment(
     return new Err(new Error("Could not retrieve channel name"));
   }
 
-  const content = await formatMessagesForUpsert(
-    channelId,
-    channel.channel.name,
-    allMessages,
-    connector.id,
-    slackClient
-  );
+  const content = await formatMessagesForUpsert({
+    channelName: channel.channel.name,
+    messages: allMessages,
+    isThread: true,
+    connectorId: connector.id,
+    slackClient,
+  });
 
   let url: string | null = null;
   if (allMessages[0]?.ts) {

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -711,8 +711,8 @@ export async function formatMessagesForUpsert({
     })
   );
 
-  const first = data[0];
-  const last = data[data.length - 1];
+  const first = data.at(0);
+  const last = data.at(-1);
   if (!last || !first) {
     throw new Error("Cannot format empty list of messages");
   }

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -717,10 +717,14 @@ export async function formatMessagesForUpsert({
     throw new Error("Cannot format empty list of messages");
   }
 
+  const title = isThread
+    ? `Thread in #${channelName}: ${
+        first.text.replace(/\s+/g, " ").trim().substring(0, 128) + "..."
+      }`
+    : `Messages in #${channelName}`;
+
   return renderDocumentTitleAndContent({
-    title: `${isThread ? "Thread" : "Messages"} in #${channelName}: ${
-      first.text.replace(/\s+/g, " ").trim().substring(0, 128) + "..."
-    }`,
+    title,
     createdAt: first.messageDate,
     updatedAt: last.messageDate,
     content: {

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -30,7 +30,7 @@ import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_c
 import { cacheGet, cacheSet } from "@connectors/lib/cache";
 import {
   deleteFromDataSource,
-  renderDocumentForTitleAndContent,
+  renderDocumentTitleAndContent,
   upsertToDatasource,
 } from "@connectors/lib/data_sources";
 import { WorkflowError } from "@connectors/lib/error";
@@ -717,7 +717,7 @@ export async function formatMessagesForUpsert({
     throw new Error("Cannot format empty list of messages");
   }
 
-  return renderDocumentForTitleAndContent({
+  return renderDocumentTitleAndContent({
     title: `${isThread ? "Thread" : "Messages"} in #${channelName}: ${
       first.text.replace(/\s+/g, " ").trim().substring(0, 128) + "..."
     }`,

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -30,6 +30,7 @@ import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_c
 import { cacheGet, cacheSet } from "@connectors/lib/cache";
 import {
   deleteFromDataSource,
+  renderDocumentForTitleAndContent,
   upsertToDatasource,
 } from "@connectors/lib/data_sources";
 import { WorkflowError } from "@connectors/lib/error";
@@ -422,13 +423,13 @@ export async function syncNonThreaded(
   }
   messages.reverse();
 
-  const content = await formatMessagesForUpsert(
-    channelId,
+  const content = await formatMessagesForUpsert({
     channelName,
     messages,
+    isThread: false,
     connectorId,
-    client
-  );
+    slackClient: client,
+  });
 
   const startDate = new Date(startTsMs);
   const endDate = new Date(endTsMs);
@@ -598,13 +599,13 @@ export async function syncThread(
     return;
   }
 
-  const content = await formatMessagesForUpsert(
-    channelId,
+  const content = await formatMessagesForUpsert({
     channelName,
-    allMessages,
+    messages: allMessages,
+    isThread: true,
     connectorId,
-    slackClient
-  );
+    slackClient,
+  });
 
   const firstMessage = allMessages[0];
   let sourceUrl: string | undefined = undefined;
@@ -670,13 +671,19 @@ async function processMessageForMentions(
   return message;
 }
 
-export async function formatMessagesForUpsert(
-  channelId: string,
-  channelName: string,
-  messages: MessageElement[],
-  connectorId: ModelId,
-  slackClient: WebClient
-): Promise<CoreAPIDataSourceDocumentSection> {
+export async function formatMessagesForUpsert({
+  channelName,
+  messages,
+  isThread,
+  connectorId,
+  slackClient,
+}: {
+  channelName: string;
+  messages: MessageElement[];
+  isThread: boolean;
+  connectorId: ModelId;
+  slackClient: WebClient;
+}): Promise<CoreAPIDataSourceDocumentSection> {
   const data = await Promise.all(
     messages.map(async (message) => {
       const text = await processMessageForMentions(
@@ -694,6 +701,7 @@ export async function formatMessagesForUpsert(
       const messageDateStr = formatDateForUpsert(messageDate);
 
       return {
+        messageDate,
         dateStr: messageDateStr,
         userName,
         text: text,
@@ -704,21 +712,27 @@ export async function formatMessagesForUpsert(
   );
 
   const first = data[0];
-  if (!first) {
+  const last = data[data.length - 1];
+  if (!last || !first) {
     throw new Error("Cannot format empty list of messages");
   }
 
-  return {
-    prefix: `Thread in #${channelName} [${first.dateStr}]: ${
+  return renderDocumentForTitleAndContent({
+    title: `${isThread ? "Thread" : "Messages"} in #${channelName}: ${
       first.text.replace(/\s+/g, " ").trim().substring(0, 128) + "..."
-    }\n`,
-    content: null,
-    sections: data.map((d) => ({
-      prefix: `>> @${d.userName} [${d.dateStr}]:\n`,
-      content: d.text + "\n",
-      sections: [],
-    })),
-  };
+    }`,
+    createdAt: first.messageDate,
+    updatedAt: last.messageDate,
+    content: {
+      prefix: null,
+      content: null,
+      sections: data.map((d) => ({
+        prefix: `>> @${d.userName} [${d.dateStr}]:\n`,
+        content: d.text + "\n",
+        sections: [],
+      })),
+    },
+  });
 }
 
 export async function fetchUsers(connectorId: ModelId) {

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -229,7 +229,7 @@ async function _updateDocumentParentsField({
   }
 }
 
-const MAX_TITLE_SECTION_PREFIX_LENGTH = 128;
+const MAX_TITLE_SECTION_PREFIX_LENGTH = 256;
 
 export function renderPrefixSection(
   prefix: string | null
@@ -310,19 +310,31 @@ export function renderMarkdownSection(
   return top;
 }
 
+// Will render the document creating a prefix that contains a $title possibly truncated (whose
+// remainder is set as first content of the docuemnt) along with $createdAt and $lastUpdatedAt
 export function renderDocumentForTitleAndContent({
   title,
+  createdAt,
+  updatedAt,
   content,
 }: {
   title: string | null;
+  createdAt?: Date;
+  updatedAt?: Date;
   content: CoreAPIDataSourceDocumentSection | null;
 }): CoreAPIDataSourceDocumentSection {
   if (title && title.trim()) {
-    title = `$title: ${title}\n\n`;
+    title = `$title: ${title}\n`;
   } else {
     title = null;
   }
   const c = renderPrefixSection(title);
+  if (createdAt) {
+    c.prefix += `$createdAt: ${createdAt.toISOString()}\n`;
+  }
+  if (updatedAt) {
+    c.prefix += `$lastUpdatedAt: ${updatedAt.toISOString()}\n`;
+  }
   if (content) {
     c.sections.push(content);
   }

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -229,7 +229,7 @@ async function _updateDocumentParentsField({
   }
 }
 
-const MAX_TITLE_SECTION_PREFIX_LENGTH = 256;
+const MAX_SECTION_PREFIX_LENGTH = 256;
 
 // The role of this function is to create a prefix from an arbitrary long string. The prefix
 // provided should will not be augmented with `\n`, so it should include appropriate carriage
@@ -245,10 +245,10 @@ export function renderPrefixSection(
       sections: [],
     };
   }
-  if (prefix.length > MAX_TITLE_SECTION_PREFIX_LENGTH) {
+  if (prefix.length > MAX_SECTION_PREFIX_LENGTH) {
     return {
-      prefix: prefix.substring(0, MAX_TITLE_SECTION_PREFIX_LENGTH) + "...\n",
-      content: `... ${prefix.substring(MAX_TITLE_SECTION_PREFIX_LENGTH)}`,
+      prefix: prefix.substring(0, MAX_SECTION_PREFIX_LENGTH) + "...\n",
+      content: `... ${prefix.substring(MAX_SECTION_PREFIX_LENGTH)}`,
       sections: [],
     };
   }

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -229,12 +229,12 @@ async function _updateDocumentParentsField({
   }
 }
 
-const MAX_SECTION_PREFIX_LENGTH = 256;
+const MAX_SECTION_PREFIX_LENGTH = 192;
 
 // The role of this function is to create a prefix from an arbitrary long string. The prefix
-// provided should will not be augmented with `\n`, so it should include appropriate carriage
-// returns. If the prefix is too long (>256 chars), it will be truncated. The remained will be
-// returned as content of the resulting section.
+// provided will not be augmented with `\n`, so it should include appropriate carriage return. If
+// the prefix is too long (>256 chars), it will be truncated. The remained will be returned as
+// content of the resulting section.
 export function renderPrefixSection(
   prefix: string | null
 ): CoreAPIDataSourceDocumentSection {

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -310,10 +310,13 @@ export function renderMarkdownSection(
   return top;
 }
 
-export function renderSectionForTitleAndContent(
-  title: string | null,
-  content: CoreAPIDataSourceDocumentSection | null
-): CoreAPIDataSourceDocumentSection {
+export function renderSectionForTitleAndContent({
+  title,
+  content,
+}: {
+  title: string | null;
+  content: CoreAPIDataSourceDocumentSection | null;
+}): CoreAPIDataSourceDocumentSection {
   if (title && title.trim()) {
     title = `$title: ${title}\n\n`;
   } else {

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -340,7 +340,7 @@ export function renderDocumentForTitleAndContent({
     c.prefix += `$createdAt: ${createdAt.toISOString()}\n`;
   }
   if (updatedAt) {
-    c.prefix += `$lastUpdatedAt: ${updatedAt.toISOString()}\n`;
+    c.prefix += `$updatedAt: ${updatedAt.toISOString()}\n`;
   }
   if (content) {
     c.sections.push(content);

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -319,7 +319,7 @@ export function renderMarkdownSection(
 // connectors. The title should not include any `\n`.
 // If the title is too long it will be truncated and the remainder of the title will be set as
 // content of the top-level section.
-export function renderDocumentForTitleAndContent({
+export function renderDocumentTitleAndContent({
   title,
   createdAt,
   updatedAt,

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -229,39 +229,7 @@ async function _updateDocumentParentsField({
   }
 }
 
-const MAX_SECTION_PREFIX_LENGTH = 128;
-
-export function renderSectionForTitleAndContent(
-  title: string | null,
-  content: string | null
-): CoreAPIDataSourceDocumentSection {
-  if (!title || !title.trim()) {
-    return {
-      prefix: null,
-      content,
-      sections: [],
-    };
-  }
-
-  if (title.length > MAX_SECTION_PREFIX_LENGTH) {
-    return {
-      prefix: `$title: ${title.substring(0, MAX_SECTION_PREFIX_LENGTH)}...\n\n`,
-      content: `... ${title.substring(MAX_SECTION_PREFIX_LENGTH)}\n\n`,
-      sections: [
-        {
-          prefix: null,
-          content,
-          sections: [],
-        },
-      ],
-    };
-  }
-  return {
-    prefix: `$title: ${title}\n\n`,
-    content,
-    sections: [],
-  };
-}
+const MAX_TITLE_SECTION_PREFIX_LENGTH = 128;
 
 export function renderPrefixSection(
   prefix: string | null
@@ -273,10 +241,10 @@ export function renderPrefixSection(
       sections: [],
     };
   }
-  if (prefix.length > MAX_SECTION_PREFIX_LENGTH) {
+  if (prefix.length > MAX_TITLE_SECTION_PREFIX_LENGTH) {
     return {
-      prefix: prefix.substring(0, MAX_SECTION_PREFIX_LENGTH) + "...\n",
-      content: `... ${prefix.substring(MAX_SECTION_PREFIX_LENGTH)}\n`,
+      prefix: prefix.substring(0, MAX_TITLE_SECTION_PREFIX_LENGTH) + "...\n",
+      content: `... ${prefix.substring(MAX_TITLE_SECTION_PREFIX_LENGTH)}`,
       sections: [],
     };
   }
@@ -291,7 +259,6 @@ export function renderPrefixSection(
 /// The top-level node is always with prefix and content null and can be edited to add a prefix or
 /// content.
 export function renderMarkdownSection(
-  prefix: string | null,
   markdown: string,
   { flavor }: { flavor?: "gfm" } = {}
 ): CoreAPIDataSourceDocumentSection {
@@ -303,7 +270,7 @@ export function renderMarkdownSection(
     mdastExtensions: mdastExtensions,
   });
 
-  const top = renderPrefixSection(prefix);
+  const top = { prefix: null, content: null, sections: [] };
 
   let path: { depth: number; content: CoreAPIDataSourceDocumentSection }[] = [
     { depth: 0, content: top },
@@ -341,4 +308,20 @@ export function renderMarkdownSection(
   }
 
   return top;
+}
+
+export function renderSectionForTitleAndContent(
+  title: string | null,
+  content: CoreAPIDataSourceDocumentSection | null
+): CoreAPIDataSourceDocumentSection {
+  if (title && title.trim()) {
+    title = `$title: ${title}\n\n`;
+  } else {
+    title = null;
+  }
+  const c = renderPrefixSection(title);
+  if (content) {
+    c.sections.push(content);
+  }
+  return c;
 }

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -310,7 +310,7 @@ export function renderMarkdownSection(
   return top;
 }
 
-export function renderSectionForTitleAndContent({
+export function renderDocumentForTitleAndContent({
   title,
   content,
 }: {

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -231,6 +231,10 @@ async function _updateDocumentParentsField({
 
 const MAX_TITLE_SECTION_PREFIX_LENGTH = 256;
 
+// The role of this function is to create a prefix from an arbitrary long string. The prefix
+// provided should will not be augmented with `\n`, so it should include appropriate carriage
+// returns. If the prefix is too long (>256 chars), it will be truncated. The remained will be
+// returned as content of the resulting section.
 export function renderPrefixSection(
   prefix: string | null
 ): CoreAPIDataSourceDocumentSection {
@@ -310,8 +314,11 @@ export function renderMarkdownSection(
   return top;
 }
 
-// Will render the document creating a prefix that contains a $title possibly truncated (whose
-// remainder is set as first content of the docuemnt) along with $createdAt and $lastUpdatedAt
+// Will render the document based on title, optional createdAt and updatedAt and a structured
+// content. The title, createdAt and updatedAt will be presented in a standardized way across
+// connectors. The title should not include any `\n`.
+// If the title is too long it will be truncated and the remainder of the title will be set as
+// content of the top-level section.
 export function renderDocumentForTitleAndContent({
   title,
   createdAt,


### PR DESCRIPTION
Cleans up and introduce `renderDocumentTitleAndContent` 

Will test locally on all connectors.

The motivation is to have one function to render the full document based on a structured content, a title and optional createdAt and updatedAt. It will create a prefix to the document in a standardized way: 
- `$title: {title}` with `\n` added.
- if provided present `$createdAt` and `$updatedAt` in a standardized way.
- It will cut the title if too long and add the remainder as first content.

To simplify `renderMarkdownSection` removed the prefix logic, which is replaced by a use of `renderDocumentTitleAndContent` for the document and manual content creation for each comment sections (github connector)

We bump the prefix split at 256 (128 is a bit tight + allows us to cover slack with this as well)

The rationale is to have a standardized presentation of our document prefixes. Other in-document prefixes are left to the connector implementation discretion.


Tests to run:
- [x] Slack thread with short first message
- [x] Slack thread with long first message
- [x] Slack channel document
- [x] Github issue with short title
- [x] Github issue with long h1/h2 
- [x] Github issue with long title
- [ ] Google drive document with short title
- [ ] Google drive document with long title
- [x] Notion document with short title
- [x] Notion document with long title