### PR TITLE
connectors: normalize tags

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -533,7 +533,7 @@ async function syncOneFile(
   }
   const tags = [`title:${file.name}`];
   if (file.updatedAtMs) {
-    tags.push(`lastEditedAt:${file.updatedAtMs}`);
+    tags.push(`updatedAt:${file.updatedAtMs}`);
   }
   if (file.createdAtMs) {
     tags.push(`createdAt:${file.createdAtMs}`);

--- a/connectors/src/connectors/notion/lib/tags.ts
+++ b/connectors/src/connectors/notion/lib/tags.ts
@@ -19,7 +19,7 @@ export function getTagsForPage({
   return tags.concat([
     `author:${author}`,
     `lastEditor:${lastEditor}`,
-    `lastEditedAt:${updatedTime}`,
     `createdAt:${createdTime}`,
+    `updatedAt:${updatedTime}`,
   ]);
 }

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -448,8 +448,8 @@ export async function syncNonThreaded(
       sourceUrl = linkRes.permalink;
     }
   }
-  const lastMessage = messages[messages.length - 1];
-  const createdAt = lastMessage?.ts
+  const lastMessage = messages.at(-1);
+  const updatedAt = lastMessage?.ts
     ? parseInt(lastMessage.ts, 10) * 1000
     : undefined;
 
@@ -467,7 +467,7 @@ export async function syncNonThreaded(
     documentId,
     documentContent: content,
     documentUrl: sourceUrl,
-    timestampMs: createdAt,
+    timestampMs: updatedAt,
     tags,
     parents: [channelId],
     upsertContext: {
@@ -619,8 +619,8 @@ export async function syncThread(
       sourceUrl = linkRes.permalink;
     }
   }
-  const lastMessage = allMessages[allMessages.length - 1];
-  const createdAt = lastMessage?.ts
+  const lastMessage = allMessages.at(-1);
+  const updatedAt = lastMessage?.ts
     ? parseInt(lastMessage.ts, 10) * 1000
     : undefined;
 
@@ -638,7 +638,7 @@ export async function syncThread(
     documentId,
     documentContent: content,
     documentUrl: sourceUrl,
-    timestampMs: createdAt,
+    timestampMs: updatedAt,
     tags,
     parents: [channelId],
     upsertContext: {


### PR DESCRIPTION
Normalize tags creation across connectors:

Standard tags are:
```
title
author
lastEditor
createdAt
updatedAt
```

Note: data source document timetstampTs should be aligned with updatedAt

cc @dust-tt/engineering-team let's try to enforce that for future connectors