### PR TITLE
connectors: add standardized presentation of author and lastEditor

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -513,6 +513,7 @@ async function syncOneFile(
     title: file.name,
     updatedAt: file.updatedAtMs ? new Date(file.updatedAtMs) : undefined,
     createdAt: file.createdAtMs ? new Date(file.createdAtMs) : undefined,
+    lastEditor: file.lastEditor ? file.lastEditor.displayName : undefined,
     content: documentContent
       ? { prefix: null, content: documentContent, sections: [] }
       : null,

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -1757,6 +1757,8 @@ export async function renderAndUpsertPageFromCache({
       title: title ?? null,
       createdAt: createdAt,
       updatedAt: updatedAt,
+      author,
+      lastEditor,
       content: { prefix: null, content: renderedPage, sections: [] },
     });
 

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -346,11 +346,15 @@ export function renderDocumentTitleAndContent({
   if (updatedAt) {
     c.prefix += `$updatedAt: ${updatedAt.toISOString()}\n`;
   }
-  if (author) {
+  if (author && lastEditor && author === lastEditor) {
     c.prefix += `$author: ${author}\n`;
-  }
-  if (lastEditor) {
-    c.prefix += `$lastEditor: ${lastEditor}\n`;
+  } else {
+    if (author) {
+      c.prefix += `$author: ${author}\n`;
+    }
+    if (lastEditor) {
+      c.prefix += `$lastEditor: ${lastEditor}\n`;
+    }
   }
   if (content) {
     c.sections.push(content);

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -323,11 +323,15 @@ export function renderDocumentTitleAndContent({
   title,
   createdAt,
   updatedAt,
+  author,
+  lastEditor,
   content,
 }: {
   title: string | null;
   createdAt?: Date;
   updatedAt?: Date;
+  author?: string;
+  lastEditor?: string;
   content: CoreAPIDataSourceDocumentSection | null;
 }): CoreAPIDataSourceDocumentSection {
   if (title && title.trim()) {
@@ -341,6 +345,12 @@ export function renderDocumentTitleAndContent({
   }
   if (updatedAt) {
     c.prefix += `$updatedAt: ${updatedAt.toISOString()}\n`;
+  }
+  if (author) {
+    c.prefix += `$author: ${author}\n`;
+  }
+  if (lastEditor) {
+    c.prefix += `$lastEditor: ${lastEditor}\n`;
   }
   if (content) {
     c.sections.push(content);


### PR DESCRIPTION
Adds standardized author/lastEditor presentation in `renderDocumentTitleAndContent`

Align gdrive (pre-full-resync) and notion (pre-full-resync) on it.

Slack and github have authors spread over the document content itself (messages based)