### PR TITLE
Add support to search notion pages in CLI

### DIFF
--- a/connectors/src/admin/cli.ts
+++ b/connectors/src/admin/cli.ts
@@ -470,10 +470,11 @@ const notion = async (command: string, args: parseArgs.ParsedArgs) => {
         workspaceId: wId,
       });
 
-      const pages = await searchNotionPagesForQuery(
-        connector.connectionId,
-        query
-      );
+      const pages = await searchNotionPagesForQuery({
+        connectorId: connector.id,
+        connectionId: connector.connectionId,
+        query,
+      });
 
       console.table(pages);
 

--- a/connectors/src/admin/cli.ts
+++ b/connectors/src/admin/cli.ts
@@ -24,6 +24,7 @@ import {
   launchGoogleDriveIncrementalSyncWorkflow,
   launchGoogleDriveRenewWebhooksWorkflow,
 } from "@connectors/connectors/google_drive/temporal/client";
+import { searchNotionPagesForQuery } from "@connectors/connectors/notion/lib/cli";
 import { QUEUE_NAME } from "@connectors/connectors/notion/temporal/config";
 import { upsertPageWorkflow } from "@connectors/connectors/notion/temporal/workflows";
 import { uninstallSlack } from "@connectors/connectors/slack";
@@ -44,6 +45,31 @@ import {
 import logger from "@connectors/logger/logger";
 
 const { NANGO_SLACK_CONNECTOR_ID } = process.env;
+
+async function getConnectorOrThrow({
+  connectorType,
+  workspaceId,
+}: {
+  connectorType: string;
+  workspaceId: string;
+}): Promise<Connector> {
+  if (!workspaceId) {
+    throw new Error("Missing workspace ID (wId)");
+  }
+  const connector = await Connector.findOne({
+    where: {
+      type: connectorType,
+      workspaceId: workspaceId,
+      dataSourceName: "managed-" + connectorType,
+    },
+  });
+  if (!connector) {
+    throw new Error(
+      `No connector found for ${connectorType} workspace with ID ${workspaceId}`
+    );
+  }
+  return connector;
+}
 
 const connectors = async (command: string, args: parseArgs.ParsedArgs) => {
   if (!args.wId) {
@@ -433,6 +459,24 @@ const notion = async (command: string, args: parseArgs.ParsedArgs) => {
           connectorId: connectorId,
         },
       });
+      break;
+    }
+
+    case "search-pages": {
+      const { query, wId } = args;
+
+      const connector = await getConnectorOrThrow({
+        connectorType: "notion",
+        workspaceId: wId,
+      });
+
+      const pages = await searchNotionPagesForQuery(
+        connector.connectionId,
+        query
+      );
+
+      console.log(">> pages:", JSON.stringify(pages.results));
+
       break;
     }
 

--- a/connectors/src/admin/cli.ts
+++ b/connectors/src/admin/cli.ts
@@ -475,7 +475,7 @@ const notion = async (command: string, args: parseArgs.ParsedArgs) => {
         query
       );
 
-      console.log(">> pages:", JSON.stringify(pages.results));
+      console.table(pages);
 
       break;
     }

--- a/connectors/src/connectors/notion/lib/cli.ts
+++ b/connectors/src/connectors/notion/lib/cli.ts
@@ -1,11 +1,32 @@
+import { ModelId } from "@dust-tt/types";
 import { Client } from "@notionhq/client";
+import { Op } from "sequelize";
 
 import { getNotionAccessToken } from "@connectors/connectors/notion/temporal/activities";
+import { NotionDatabase } from "@connectors/lib/models/notion";
 
-export async function searchNotionPagesForQuery(
-  connectionId: string,
-  query: string
-) {
+async function listSkippedDatabaseIdsForConnectorId(connectorId: ModelId) {
+  const skippedDatabases = await NotionDatabase.findAll({
+    where: {
+      connectorId: connectorId,
+      skipReason: {
+        [Op.not]: null,
+      },
+    },
+  });
+
+  return new Set(skippedDatabases.map((db) => db.notionDatabaseId));
+}
+
+export async function searchNotionPagesForQuery({
+  connectorId,
+  connectionId,
+  query,
+}: {
+  connectorId: ModelId;
+  connectionId: string;
+  query: string;
+}) {
   const notionAccessToken = await getNotionAccessToken(connectionId);
 
   const notionClient = new Client({
@@ -17,9 +38,14 @@ export async function searchNotionPagesForQuery(
     page_size: 20,
   });
 
+  const skippedDatabaseIds = await listSkippedDatabaseIdsForConnectorId(
+    connectorId
+  );
+
   return pages.results.map((p) => ({
     id: p.id,
     type: p.object,
     title: "title" in p ? p.title[0]?.plain_text : "<unknown>",
+    isSkipped: p.object === "database" && skippedDatabaseIds.has(p.id),
   }));
 }

--- a/connectors/src/connectors/notion/lib/cli.ts
+++ b/connectors/src/connectors/notion/lib/cli.ts
@@ -1,0 +1,21 @@
+import { Client } from "@notionhq/client";
+
+import { getNotionAccessToken } from "@connectors/connectors/notion/temporal/activities";
+
+export async function searchNotionPagesForQuery(
+  connectionId: string,
+  query: string
+) {
+  const notionAccessToken = await getNotionAccessToken(connectionId);
+
+  const notionClient = new Client({
+    auth: notionAccessToken,
+  });
+
+  const pages = await notionClient.search({
+    query,
+    page_size: 20,
+  });
+
+  return pages;
+}

--- a/connectors/src/connectors/notion/lib/cli.ts
+++ b/connectors/src/connectors/notion/lib/cli.ts
@@ -17,5 +17,9 @@ export async function searchNotionPagesForQuery(
     page_size: 20,
   });
 
-  return pages;
+  return pages.results.map((p) => ({
+    id: p.id,
+    type: p.object,
+    title: "title" in p ? p.title[0]?.plain_text : "<unknown>",
+  }));
 }

--- a/connectors/src/connectors/notion/lib/cli.ts
+++ b/connectors/src/connectors/notion/lib/cli.ts
@@ -1,5 +1,5 @@
 import { ModelId } from "@dust-tt/types";
-import { Client } from "@notionhq/client";
+import { Client, isFullDatabase, isFullPage } from "@notionhq/client";
 import { Op } from "sequelize";
 
 import { getNotionAccessToken } from "@connectors/connectors/notion/temporal/activities";
@@ -47,5 +47,6 @@ export async function searchNotionPagesForQuery({
     type: p.object,
     title: "title" in p ? p.title[0]?.plain_text : "<unknown>",
     isSkipped: p.object === "database" && skippedDatabaseIds.has(p.id),
+    isFull: p.object === "database" ? isFullDatabase(p) : isFullPage(p),
   }));
 }

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -1,5 +1,5 @@
 import { ModelId } from "@dust-tt/types";
-import { APIResponseError, isFullBlock, isFullPage } from "@notionhq/client";
+import { isFullBlock, isFullPage, isNotionClientError } from "@notionhq/client";
 import { Context } from "@temporalio/activity";
 import { Op } from "sequelize";
 
@@ -263,7 +263,7 @@ export async function getPagesAndDatabasesToSync({
       skippedDatabaseIds
     );
   } catch (e) {
-    if (APIResponseError.isAPIResponseError(e)) {
+    if (isNotionClientError(e)) {
       // Sometimes a cursor will consistently fail with 500.
       // In this case, there is not much we can do, so we just give up and move on.
       // Notion workspaces are resynced daily so nothing is lost forever.


### PR DESCRIPTION
This PR introduces a feature to the CLI that enables searching for Notion pages. This enhancement comes in response to numerous reports regarding pages that were not appearing in Dust, and it is anticipated that this tool will simplify the debugging process.

<img width="737" alt="image" src="https://github.com/dust-tt/dust/assets/7428970/b914dafd-1e90-4141-aeef-b5c6a12ed3a5">

