### PR TITLE
Onboarding - AllowedDomain migration

### DIFF
--- a/front/migrations/helpers.ts
+++ b/front/migrations/helpers.ts
@@ -1,0 +1,53 @@
+import yargs, { Options } from "yargs";
+import { hideBin } from "yargs/helpers";
+
+// Define a type for the argument specification object.
+export type ArgumentSpecs = {
+  [key: string]: Options & { type?: "string" | "boolean" | "number" };
+};
+
+// Define a type for the worker function.
+export type WorkerFunction<T> = (args: T) => Promise<void>;
+
+// Define a utility type to infer the argument types from the argument specs.
+export type InferArgs<T> = {
+  [P in keyof T]: T[P] extends { type: "number" }
+    ? number
+    : T[P] extends { type: "boolean" }
+    ? boolean
+    : T[P] extends { type: "string" }
+    ? string
+    : never;
+} & { execute?: boolean };
+
+const defaultArgumentSpecs: ArgumentSpecs = {
+  execute: {
+    alias: "e",
+    describe: "Execute the script",
+    type: "boolean" as const,
+    default: false,
+  },
+};
+
+export function makeScript<T extends ArgumentSpecs>(
+  argumentSpecs: T,
+  worker: WorkerFunction<InferArgs<T> & { execute: boolean }>
+): void {
+  const argv = yargs(hideBin(process.argv));
+
+  const combinedArgumentSpecs = { ...defaultArgumentSpecs, ...argumentSpecs };
+
+  // Configure yargs using the provided argument specifications.
+  Object.entries(combinedArgumentSpecs).forEach(([key, options]) => {
+    argv.option(key, options);
+  });
+  argv
+    .help("h")
+    .alias("h", "help")
+    .parseAsync()
+    .then((args) => worker(args as InferArgs<T & { execute: boolean }>))
+    .catch((error) => {
+      console.error("An error occurred:", error);
+      process.exit(1);
+    });
+}

--- a/front/migrations/helpers.ts
+++ b/front/migrations/helpers.ts
@@ -7,10 +7,10 @@ export type ArgumentSpecs = {
 };
 
 // Define a type for the worker function.
-export type WorkerFunction<T> = (args: T) => Promise<void>;
+type WorkerFunction<T> = (args: T) => Promise<void>;
 
 // Define a utility type to infer the argument types from the argument specs.
-export type InferArgs<T> = {
+type InferArgs<T> = {
   [P in keyof T]: T[P] extends { type: "number" }
     ? number
     : T[P] extends { type: "boolean" }

--- a/front/migrations/remove_disposable_allowed_domains.ts
+++ b/front/migrations/remove_disposable_allowed_domains.ts
@@ -31,15 +31,17 @@ makeScript({}, async ({ execute }) => {
       const firstAdminUser = await User.findOne({
         include: {
           model: Membership,
-          attributes: [], // Exclude Membership attributes from the final result
+          attributes: [], // Exclude Membership attributes from the final result.
           where: {
-            role: "admin", // Adjust as needed, if you're looking for a specific role
+            role: "admin",
+            workspaceId: workspace.id,
           },
+          required: true, //  /!\ Needed to ensure we retrieve users from the provided workspaceId!
         },
         where: {
           provider: "google",
         },
-        order: [["createdAt", "ASC"]], // Use ASC for the earliest signup
+        order: [["createdAt", "ASC"]], // Use ASC for the earliest signup.
         limit: 1,
       });
 
@@ -58,7 +60,8 @@ makeScript({}, async ({ execute }) => {
       }
 
       console.log(
-        `>> About to update workspace allowedDomain from ${workspace.allowedDomain} to ${newAllowedDomain} for workspace Id ${workspace.id}`
+        `>> About to update workspace allowedDomain from ${workspace.allowedDomain} to ${newAllowedDomain} for workspace Id ${workspace.id}:`,
+        workspace.allowedDomain === newAllowedDomain ? "[SAME]" : "[DIFFERENT]"
       );
 
       if (execute) {

--- a/front/migrations/remove_disposable_allowed_domains.ts
+++ b/front/migrations/remove_disposable_allowed_domains.ts
@@ -1,0 +1,70 @@
+import { Op } from "sequelize";
+
+import { Membership, User, Workspace } from "@app/lib/models";
+import { isDisposableEmailDomain } from "@app/lib/utils/disposable_email_domains";
+import { makeScript } from "@app/migrations/helpers";
+
+makeScript({}, async ({ execute }) => {
+  const workspaces = await Workspace.findAll({
+    attributes: ["id", "allowedDomain"],
+    where: {
+      allowedDomain: {
+        [Op.not]: null,
+        [Op.ne]: "",
+      },
+    },
+  });
+
+  for (const workspace of workspaces) {
+    if (!workspace.allowedDomain) {
+      continue;
+    }
+
+    let newAllowedDomain = null;
+
+    // We first check if the domain is disposable,
+    // If yes, then we remove it.
+    if (isDisposableEmailDomain(workspace.allowedDomain)) {
+      newAllowedDomain = null;
+    } else {
+      // If no, then we ensure that this domain belongs to their google workspace.
+      const firstAdminUser = await User.findOne({
+        include: {
+          model: Membership,
+          attributes: [], // Exclude Membership attributes from the final result
+          where: {
+            role: "admin", // Adjust as needed, if you're looking for a specific role
+          },
+        },
+        where: {
+          provider: "google",
+        },
+        order: [["createdAt", "ASC"]], // Use ASC for the earliest signup
+        limit: 1,
+      });
+
+      if (!firstAdminUser) {
+        console.error(
+          `Not first admin found for workspace ${workspace.id} -- Skipping.`
+        );
+        continue;
+      }
+
+      const [, adminEmailDomain] = firstAdminUser.email.split("@");
+      if (isDisposableEmailDomain(adminEmailDomain)) {
+        newAllowedDomain = null;
+      } else {
+        newAllowedDomain = adminEmailDomain;
+      }
+
+      console.log(
+        `>> About to update workspace allowedDomain from ${workspace.allowedDomain} to ${newAllowedDomain} for workspace Id ${workspace.id}`
+      );
+
+      if (execute) {
+        workspace.allowedDomain = newAllowedDomain;
+        await workspace.save();
+      }
+    }
+  }
+});

--- a/front/migrations/remove_disposable_allowed_domains.ts
+++ b/front/migrations/remove_disposable_allowed_domains.ts
@@ -15,6 +15,7 @@ makeScript({}, async ({ execute }) => {
     },
   });
 
+  let updatedWorkspacesCount = 0;
   for (const workspace of workspaces) {
     if (!workspace.allowedDomain) {
       continue;
@@ -64,10 +65,18 @@ makeScript({}, async ({ execute }) => {
         workspace.allowedDomain === newAllowedDomain ? "[SAME]" : "[DIFFERENT]"
       );
 
+      const isSameEmailDomain = workspace.allowedDomain === newAllowedDomain;
+      if (isSameEmailDomain) {
+        continue;
+      }
+
       if (execute) {
         workspace.allowedDomain = newAllowedDomain;
         await workspace.save();
       }
+      updatedWorkspacesCount++;
     }
   }
+
+  console.log(`Updated allowedDomain on ${updatedWorkspacesCount} workspaces.`);
 });


### PR DESCRIPTION
As part of our efforts to enhance the onboarding process for new users, this PR introduces a migration to validate the `allowedDomain` across all workspaces.

Two scenarios:
- If the `allowedDomain` is identified as a disposable domain, it will be cleared and reset to null. For instance, domains like gmail.com will be removed.
- If the `allowedDomain` is already set, we will confirm that it corresponds to the domain of the first admin who registered via Google Workspace. Should there be a discrepancy, the `allowedDomain` **will be updated** to match the domain of the admin's email.

_Bonus:_ This PR adds an util `makeScript` that bundles a default dry run with command line parsing.