### PR TITLE
Update Intercom models

### DIFF
--- a/connectors/src/admin/db.ts
+++ b/connectors/src/admin/db.ts
@@ -22,6 +22,7 @@ import {
 import {
   IntercomArticle,
   IntercomCollection,
+  IntercomHelpCenter,
 } from "@connectors/lib/models/intercom";
 import {
   NotionConnectorBlockCacheEntry,
@@ -68,6 +69,7 @@ async function main(): Promise<void> {
   await NotionConnectorPageCacheEntry.sync({ alter: true });
   await NotionConnectorResourcesToCheckCacheEntry.sync({ alter: true });
   await GoogleDriveConfig.sync({ alter: true });
+  await IntercomHelpCenter.sync({ alter: true });
   await IntercomCollection.sync({ alter: true });
   await IntercomArticle.sync({ alter: true });
   await WebCrawlerConfiguration.sync({ alter: true });

--- a/connectors/src/lib/models/intercom.ts
+++ b/connectors/src/lib/models/intercom.ts
@@ -9,6 +9,83 @@ import {
 
 import { Connector, sequelize_conn } from "@connectors/lib/models";
 
+export class IntercomHelpCenter extends Model<
+  InferAttributes<IntercomHelpCenter>,
+  InferCreationAttributes<IntercomHelpCenter>
+> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare intercomWorkspaceId: string;
+  declare helpCenterId: string;
+
+  declare name: string;
+  declare identifier: string;
+
+  declare lastUpsertedTs?: Date;
+  declare permission: "read" | "none";
+
+  declare connectorId: ForeignKey<Connector["id"]>;
+}
+IntercomHelpCenter.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    intercomWorkspaceId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    helpCenterId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    name: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    identifier: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    lastUpsertedTs: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    },
+    permission: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+  },
+  {
+    sequelize: sequelize_conn,
+    indexes: [
+      {
+        fields: ["connectorId", "helpCenterId"],
+        unique: true,
+        name: "intercom_connector_help_center_idx",
+      },
+      { fields: ["connectorId"] },
+      { fields: ["helpCenterId"] },
+    ],
+    modelName: "intercom_help_centers",
+  }
+);
+Connector.hasMany(IntercomHelpCenter);
+
 export class IntercomCollection extends Model<
   InferAttributes<IntercomCollection>,
   InferCreationAttributes<IntercomCollection>
@@ -20,11 +97,15 @@ export class IntercomCollection extends Model<
   declare intercomWorkspaceId: string;
   declare collectionId: string;
 
-  declare helpCenterId: string | null;
+  declare helpCenterId: string;
   declare parentId: string | null;
 
   declare name: string;
   declare description: string | null;
+  declare url: string;
+
+  declare lastUpsertedTs?: Date;
+  declare permission: "read" | "none";
 
   declare connectorId: ForeignKey<Connector["id"]>;
 }
@@ -70,14 +151,26 @@ IntercomCollection.init(
       type: DataTypes.STRING,
       allowNull: true,
     },
+    url: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    lastUpsertedTs: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    },
+    permission: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
   },
   {
     sequelize: sequelize_conn,
     indexes: [
       {
-        fields: ["intercomWorkspaceId", "collectionId", "connectorId"],
+        fields: ["connectorId", "collectionId"],
         unique: true,
-        name: "intercom_workspace_collection_connector_idx",
+        name: "intercom_connector_collection_idx",
       },
       { fields: ["connectorId"] },
       { fields: ["collectionId"] },
@@ -98,11 +191,17 @@ export class IntercomArticle extends Model<
   declare intercomWorkspaceId: string;
   declare articleId: string;
   declare authorId: string;
+  declare title: string;
+  declare url: string;
 
   declare parentId: string | null;
   declare parentType: "collection" | null;
+  declare parents: string[];
 
   declare state: "draft" | "published";
+
+  declare lastUpsertedTs?: Date;
+  declare permission: "read" | "none";
 
   declare connectorId: ForeignKey<Connector["id"]>;
 }
@@ -132,6 +231,14 @@ IntercomArticle.init(
       type: DataTypes.STRING,
       allowNull: false,
     },
+    title: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    url: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
     authorId: {
       type: DataTypes.STRING,
       allowNull: false,
@@ -144,7 +251,19 @@ IntercomArticle.init(
       type: DataTypes.STRING,
       allowNull: true,
     },
+    parents: {
+      type: DataTypes.ARRAY(DataTypes.STRING),
+      allowNull: false,
+    },
     state: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    lastUpsertedTs: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    },
+    permission: {
       type: DataTypes.STRING,
       allowNull: false,
     },
@@ -153,9 +272,9 @@ IntercomArticle.init(
     sequelize: sequelize_conn,
     indexes: [
       {
-        fields: ["intercomWorkspaceId", "articleId", "connectorId"],
+        fields: ["connectorId", "articleId"],
         unique: true,
-        name: "intercom_workspace_article_connector_idx",
+        name: "intercom_connector_article_idx",
       },
       { fields: ["connectorId"] },
       { fields: ["articleId"] },

--- a/front/lib/connector_providers.ts
+++ b/front/lib/connector_providers.ts
@@ -94,10 +94,10 @@ export const CONNECTOR_CONFIGURATIONS: Record<
     hide: false,
     logoPath: "/static/intercom_32x32.png",
     description:
-      "Authorize granular access to your company's Intercom Help Centers. Dust does not access your conversations.",
+      "Authorize access to your Intercom Help Center Collections & Articles. Conversations coming soon.",
     limitations: null,
     logoComponent: IntercomLogo,
-    isNested: false,
+    isNested: true,
   },
   webcrawler: {
     name: "Web Crawler",


### PR DESCRIPTION
Adds a model `IntercomHelpCenter` (an IntercomWorkspace with advanced plan can have multiple help centers) + add some missing columns to models `IntercomCollection` & `IntercomArticle`.


Deployment: run init_db on connectors