### PR TITLE
[Notion chunking] Fix issue with too much prefix

### DIFF
--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -2059,7 +2059,7 @@ function renderPageSection({
 
     // Prefix for depths 0 and 1, and only if children
     const blockSection =
-      depth < 2 && adaptedBlocksByParentId[b.notionBlockId]?.length
+      depth < 1 && adaptedBlocksByParentId[b.notionBlockId]?.length
         ? renderPrefixSection(renderedBlock)
         : {
             prefix: null,

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -1562,9 +1562,7 @@ export async function renderAndUpsertPageFromCache({
   const parsedProperties = parsePageProperties(
     JSON.parse(pageCacheEntry.pagePropertiesText) as PageObjectProperties
   );
-  for (const [i, p] of parsedProperties
-    .filter((p) => p.key !== "title" && p.text)
-    .entries()) {
+  for (const p of parsedProperties.filter((p) => p.key !== "title" && p.text)) {
     const propertyContent = `$${p.key}: ${p.text}\n`;
     renderedPageSection.sections.unshift({
       prefix: null,

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -1566,10 +1566,6 @@ export async function renderAndUpsertPageFromCache({
     .filter((p) => p.key !== "title" && p.text)
     .entries()) {
     const propertyContent = `$${p.key}: ${p.text}\n`;
-    if (i < 3) {
-      renderedPageSection.prefix = renderedPageSection.prefix ?? "";
-      renderedPageSection.prefix += propertyContent;
-    }
     renderedPageSection.sections.unshift({
       prefix: null,
       content: propertyContent,
@@ -2059,7 +2055,7 @@ function renderPageSection({
 
     // Prefix for depths 0 and 1, and only if children
     const blockSection =
-      depth < 1 && adaptedBlocksByParentId[b.notionBlockId]?.length
+      depth < 2 && adaptedBlocksByParentId[b.notionBlockId]?.length
         ? renderPrefixSection(renderedBlock)
         : {
             prefix: null,


### PR DESCRIPTION
Fixes an issue in which some documents get too much prefix by removing page properties as prefix and leaving them as initial page content