### PR TITLE
[Chunking] Fix: null title doesn't write "null"

### DIFF
--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -339,6 +339,7 @@ export function renderDocumentTitleAndContent({
     title = null;
   }
   const c = renderPrefixSection(title);
+  c.prefix = c.prefix || "";
   if (createdAt) {
     c.prefix += `$createdAt: ${createdAt.toISOString()}\n`;
   }
@@ -358,6 +359,7 @@ export function renderDocumentTitleAndContent({
   if (content) {
     c.sections.push(content);
   }
+  if (c.prefix === "") c.prefix = null;
   return c;
 }
 


### PR DESCRIPTION
Documents with no title used to have `null` appended to other data

![image](https://github.com/dust-tt/dust/assets/5437393/e65fe9bd-b6cd-44fb-b8ee-77680e0f6eeb)

Now they don't

![image](https://github.com/dust-tt/dust/assets/5437393/77e93943-6c87-4785-ab73-5440b5f15eb1)
