### PR TITLE
core: move to RwLock for BPE

### DIFF
--- a/core/src/providers/azure_openai.rs
+++ b/core/src/providers/azure_openai.rs
@@ -17,7 +17,7 @@ use hyper::header;
 use hyper::{body::Buf, http::StatusCode, Body, Client, Method, Request, Uri};
 use hyper_tls::HttpsConnector;
 use itertools::izip;
-use parking_lot::Mutex;
+use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::io::prelude::*;
@@ -179,7 +179,7 @@ impl AzureOpenAILLM {
         .parse::<Uri>()?)
     }
 
-    fn tokenizer(&self) -> Arc<Mutex<CoreBPE>> {
+    fn tokenizer(&self) -> Arc<RwLock<CoreBPE>> {
         match self.model_id.as_ref() {
             Some(model_id) => match model_id.as_str() {
                 "code_davinci-002" | "code-cushman-001" => p50k_base_singleton(),
@@ -606,7 +606,7 @@ impl AzureOpenAIEmbedder {
         .parse::<Uri>()?)
     }
 
-    fn tokenizer(&self) -> Arc<Mutex<CoreBPE>> {
+    fn tokenizer(&self) -> Arc<RwLock<CoreBPE>> {
         match self.model_id.as_ref() {
             Some(model_id) => match model_id.as_str() {
                 "text-embedding-ada-002" => cl100k_base_singleton(),

--- a/core/src/providers/google_vertex_ai.rs
+++ b/core/src/providers/google_vertex_ai.rs
@@ -4,7 +4,7 @@ use eventsource_client as es;
 use eventsource_client::Client as ESClient;
 use futures::TryStreamExt;
 use hyper_tls::HttpsConnector;
-use parking_lot::Mutex;
+use parking_lot::{Mutex, RwLock};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::sync::Arc;
@@ -255,7 +255,7 @@ impl GoogleVertexAiLLM {
         }
     }
 
-    fn tokenizer(&self) -> Arc<Mutex<CoreBPE>> {
+    fn tokenizer(&self) -> Arc<RwLock<CoreBPE>> {
         cl100k_base_singleton()
     }
 }

--- a/core/src/providers/mistral.rs
+++ b/core/src/providers/mistral.rs
@@ -11,7 +11,7 @@ use eventsource_client::Client as ESClient;
 use futures::TryStreamExt;
 use hyper::{body::Buf, Body, Client, Method, Request, Uri};
 use hyper_tls::HttpsConnector;
-use parking_lot::Mutex;
+use parking_lot::{Mutex, RwLock};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use serde_json::Value;
@@ -198,7 +198,7 @@ impl MistralAILLM {
         mistral_messages
     }
 
-    fn tokenizer(&self) -> Arc<Mutex<CoreBPE>> {
+    fn tokenizer(&self) -> Arc<RwLock<CoreBPE>> {
         return p50k_base_singleton();
     }
 

--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -15,7 +15,7 @@ use futures::TryStreamExt;
 use hyper::{body::Buf, Body, Client, Method, Request, Uri};
 use hyper_tls::HttpsConnector;
 use itertools::izip;
-use parking_lot::Mutex;
+use parking_lot::{Mutex, RwLock};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use serde_json::Value;
@@ -1116,7 +1116,7 @@ impl OpenAILLM {
         Ok(format!("https://api.openai.com/v1/chat/completions",).parse::<Uri>()?)
     }
 
-    fn tokenizer(&self) -> Arc<Mutex<CoreBPE>> {
+    fn tokenizer(&self) -> Arc<RwLock<CoreBPE>> {
         match self.id.as_str() {
             "code_davinci-002" | "code-cushman-001" => p50k_base_singleton(),
             "text-davinci-002" | "text-davinci-003" => p50k_base_singleton(),
@@ -1534,7 +1534,7 @@ impl OpenAIEmbedder {
         Ok(format!("https://api.openai.com/v1/embeddings",).parse::<Uri>()?)
     }
 
-    fn tokenizer(&self) -> Arc<Mutex<CoreBPE>> {
+    fn tokenizer(&self) -> Arc<RwLock<CoreBPE>> {
         match self.id.as_str() {
             "text-embedding-ada-002" => cl100k_base_singleton(),
             _ => r50k_base_singleton(),


### PR DESCRIPTION
Move to RwLock instead of Mutex for BPE access which should parallelize the access to BPE and prevent busy-waiting when the tokenize is busy.

This should allow us to restart connectors without impacting the product (/tokenize)