### PR TITLE
Allow blacklisting GDrive file ids.

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -46,7 +46,7 @@ const GDRIVE_FILE_IDS_BLACKLIST = [
   "1IR3Ql2-QfGf9VUIqTqAunzYJi0pQNg3u",
   "1Seekzy_3m_P0blWP37mU2roMc5HYtULH",
   "1aUUY4nDPrM8YCxFybW_ClVud4TnqQC1w",
-  "10Yaj4T-_UOzSaE7Ea0qEZLULU1noZWSX"
+  "10Yaj4T-_UOzSaE7Ea0qEZLULU1noZWSX",
 ];
 
 export const MIME_TYPES_TO_EXPORT: { [key: string]: string } = {
@@ -526,8 +526,6 @@ async function syncOneFile(
     // We do not support this file type
     return false;
   }
-
-  if (document.)
 
   if (!documentContent || documentContent.trim().length === 0) {
     logger.info(

--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -409,17 +409,6 @@ async function syncOneFile(
   } else if (mimeTypesToDownload.includes(file.mimeType)) {
     const drive = await getDriveClient(oauth2client);
 
-    if (GDRIVE_FILE_IDS_BLACKLIST.includes(file.id)) {
-      logger.info(
-        {
-          file_id: file.id,
-          title: file.name,
-        },
-        `File ID is blacklisted. Skipping`
-      );
-      return false;
-    }
-
     let res;
     try {
       res = await drive.files.get(
@@ -524,6 +513,17 @@ async function syncOneFile(
     }
   } else {
     // We do not support this file type
+    return false;
+  }
+
+  if (GDRIVE_FILE_IDS_BLACKLIST.includes(file.id)) {
+    logger.info(
+      {
+        file_id: file.id,
+        title: file.name,
+      },
+      `File ID is blacklisted. Skipping`
+    );
     return false;
   }
 

--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -42,6 +42,13 @@ import logger from "@connectors/logger/logger";
 const FILES_SYNC_CONCURRENCY = 10;
 const FILES_GC_CONCURRENCY = 5;
 
+const GDRIVE_FILE_IDS_BLACKLIST = [
+  "1IR3Ql2-QfGf9VUIqTqAunzYJi0pQNg3u",
+  "1Seekzy_3m_P0blWP37mU2roMc5HYtULH",
+  "1aUUY4nDPrM8YCxFybW_ClVud4TnqQC1w",
+  "10Yaj4T-_UOzSaE7Ea0qEZLULU1noZWSX"
+];
+
 export const MIME_TYPES_TO_EXPORT: { [key: string]: string } = {
   "application/vnd.google-apps.document": "text/plain",
   "application/vnd.google-apps.presentation": "text/plain",
@@ -402,6 +409,17 @@ async function syncOneFile(
   } else if (mimeTypesToDownload.includes(file.mimeType)) {
     const drive = await getDriveClient(oauth2client);
 
+    if (GDRIVE_FILE_IDS_BLACKLIST.includes(file.id)) {
+      logger.info(
+        {
+          file_id: file.id,
+          title: file.name,
+        },
+        `File ID is blacklisted. Skipping`
+      );
+      return false;
+    }
+
     let res;
     try {
       res = await drive.files.get(
@@ -509,6 +527,8 @@ async function syncOneFile(
     return false;
   }
 
+  if (document.)
+
   if (!documentContent || documentContent.trim().length === 0) {
     logger.info(
       {
@@ -520,6 +540,8 @@ async function syncOneFile(
       },
       "Skipping empty document"
     );
+
+    return false;
   }
 
   const content = renderDocumentTitleAndContent({


### PR DESCRIPTION
This PR implements the ability to blacklist certain Google Drive file IDs that are problematic during our ingestion process. It's a temporary measure that we plan to roll back by next week.
