### PR TITLE
Improve handling of race conditions during workflow termination

### DIFF
--- a/connectors/src/lib/temporal.ts
+++ b/connectors/src/lib/temporal.ts
@@ -146,7 +146,7 @@ export async function terminateAllWorkflowsForConnectorId(
     } catch (err) {
       // Intentionally ignore errors that indicate the workflow no longer exists.
       if (err instanceof WorkflowNotFoundError) {
-        return;
+        continue;
       }
       throw err;
     }

--- a/connectors/src/lib/temporal.ts
+++ b/connectors/src/lib/temporal.ts
@@ -132,17 +132,25 @@ export async function cancelWorkflow(workflowId: string) {
 
 export async function terminateAllWorkflowsForConnectorId(
   connectorId: ModelId
-): Promise<boolean> {
+) {
   const client = await getTemporalClient();
+
   const workflowInfos = client.workflow.list({
     query: `ExecutionStatus = 'Running' AND connectorId = ${connectorId}`,
   });
-  const promises = [];
+
   for await (const handle of workflowInfos) {
     const workflowHandle = client.workflow.getHandle(handle.workflowId);
-    promises.push(workflowHandle.terminate());
+    try {
+      await workflowHandle.terminate();
+    } catch (err) {
+      // Intentionally ignore errors that indicate the workflow no longer exists.
+      if (err instanceof WorkflowNotFoundError) {
+        return;
+      }
+      throw err;
+    }
   }
-  await Promise.all(promises);
 
-  return true;
+  return;
 }


### PR DESCRIPTION
This PR implements improved handling of race conditions that arise during the termination of workflows. Specifically, when removing a data source and its associated workflows, there is a possibility that a workflow may already be in the process of terminating by Temporal when we attempt to terminate it. To address this, those changes include a try-catch block designed to ignore errors that occur from such timing conflicts.