### PR TITLE
[Front] Fix agent sort order

### DIFF
--- a/front/lib/utils.ts
+++ b/front/lib/utils.ts
@@ -136,17 +136,12 @@ export function subFilter(a: string, b: string) {
 }
 
 export function compareForFuzzySort(query: string, a: string, b: string) {
-  // Find the index of the token in both strings.
-  const indexA = a.toLowerCase().indexOf(query);
-  const indexB = b.toLowerCase().indexOf(query);
-
-  // If the token index is the same, compare the strings lexicographically.
-  if (indexA === indexB) {
+  const distanceToQuery = (s: string) =>
+    s.length - query.length + s.indexOf(query.charAt(0));
+  if (distanceToQuery(a) === distanceToQuery(b)) {
     return a.localeCompare(b);
   }
-
-  // Otherwise, sort based on the index of the token's first occurrence.
-  return indexA - indexB;
+  return distanceToQuery(a) - distanceToQuery(b);
 }
 
 export function filterAndSortAgents(


### PR DESCRIPTION
`compareForFuzzySort` was broken
![image](https://github.com/dust-tt/dust/assets/5437393/d4804cc4-2156-4368-acfa-61114e4a0595)

This PR fixes the issue by sorting first the matches with smallest size, then those with first matching letter, then by lexical order

Before:

![image](https://github.com/dust-tt/dust/assets/5437393/8fe9a2b3-b454-437c-add8-709368e898f7)

After:
![image](https://github.com/dust-tt/dust/assets/5437393/31a9a765-a0b8-439f-b19c-69a355656324)
