### PR TITLE
fix: re-apply get agent configs refacto

### DIFF
--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -1,8 +1,8 @@
 import {
   AgentActionType,
-  AgentConfigurationType,
   AgentMessageType,
   ConversationType,
+  LightAgentConfigurationType,
   ModelId,
   RetrievalDocumentType,
   sectionFullText,
@@ -346,7 +346,7 @@ async function botAnswerMessage(
         slackChannelId: slackChannel,
       },
     });
-    let agentConfigurationToMention: AgentConfigurationType | null = null;
+    let agentConfigurationToMention: LightAgentConfigurationType | null = null;
 
     if (channel && channel.agentConfigurationId) {
       agentConfigurationToMention =
@@ -362,7 +362,7 @@ async function botAnswerMessage(
       });
     } else {
       // If no mention is found and no channel-based routing rule is found, we use the default assistant.
-      let defaultAssistant: AgentConfigurationType | null = null;
+      let defaultAssistant: LightAgentConfigurationType | null = null;
       defaultAssistant =
         agentConfigurations.find((ac) => ac.sId === "dust") || null;
       if (!defaultAssistant || defaultAssistant.status !== "active") {

--- a/front/components/assistant/AssistantActions.tsx
+++ b/front/components/assistant/AssistantActions.tsx
@@ -1,12 +1,13 @@
 import { Dialog } from "@dust-tt/sparkle";
 import {
-  AgentConfigurationType,
+  LightAgentConfigurationType,
   PostOrPatchAgentConfigurationRequestBody,
 } from "@dust-tt/types";
 import { WorkspaceType } from "@dust-tt/types";
 import { useContext } from "react";
 
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
+import { useAgentConfiguration } from "@app/lib/swr";
 import { PostAgentListStatusRequestBody } from "@app/pages/api/w/[wId]/members/me/agent_list_status";
 
 export function DeleteAssistantDialog({
@@ -87,7 +88,7 @@ export function RemoveAssistantFromListDialog({
   onRemove,
 }: {
   owner: WorkspaceType;
-  agentConfiguration: AgentConfigurationType;
+  agentConfiguration: LightAgentConfigurationType;
   show: boolean;
   onClose: () => void;
   onRemove: () => void;
@@ -151,12 +152,17 @@ export function RemoveAssistantFromWorkspaceDialog({
   onRemove,
 }: {
   owner: WorkspaceType;
-  agentConfiguration: AgentConfigurationType;
+  agentConfiguration: LightAgentConfigurationType;
   show: boolean;
   onClose: () => void;
   onRemove: () => void;
 }) {
   const sendNotification = useContext(SendNotificationsContext);
+
+  const { agentConfiguration: detailedConfig } = useAgentConfiguration({
+    workspaceId: owner.sId,
+    agentConfigurationId: agentConfiguration.sId,
+  });
 
   return (
     <Dialog
@@ -166,6 +172,9 @@ export function RemoveAssistantFromWorkspaceDialog({
       validateLabel="Remove"
       validateVariant="primaryWarning"
       onValidate={async () => {
+        if (!detailedConfig) {
+          throw new Error("Agent configuration not found");
+        }
         const body: PostOrPatchAgentConfigurationRequestBody = {
           assistant: {
             name: agentConfiguration.name,
@@ -173,7 +182,7 @@ export function RemoveAssistantFromWorkspaceDialog({
             pictureUrl: agentConfiguration.pictureUrl,
             status: "active",
             scope: "published",
-            action: agentConfiguration.action,
+            action: detailedConfig.action,
             generation: agentConfiguration.generation,
           },
         };

--- a/front/components/assistant/AssistantPicker.tsx
+++ b/front/components/assistant/AssistantPicker.tsx
@@ -7,7 +7,7 @@ import {
   Searchbar,
   WrenchIcon,
 } from "@dust-tt/sparkle";
-import { AgentConfigurationType, WorkspaceType } from "@dust-tt/types";
+import { LightAgentConfigurationType, WorkspaceType } from "@dust-tt/types";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 
@@ -22,8 +22,8 @@ export function AssistantPicker({
   size = "md",
 }: {
   owner: WorkspaceType;
-  assistants: AgentConfigurationType[];
-  onItemClick: (assistant: AgentConfigurationType) => void;
+  assistants: LightAgentConfigurationType[];
+  onItemClick: (assistant: LightAgentConfigurationType) => void;
   pickerButton?: React.ReactNode;
   showBuilderButtons?: boolean;
   size?: "sm" | "md";

--- a/front/components/assistant/GalleryAssistantPreviewContainer.tsx
+++ b/front/components/assistant/GalleryAssistantPreviewContainer.tsx
@@ -1,9 +1,8 @@
 import { AssistantPreview } from "@dust-tt/sparkle";
 import {
-  AgentConfigurationType,
   AgentUserListStatus,
+  LightAgentConfigurationType,
   PlanType,
-  PostOrPatchAgentConfigurationRequestBody,
   WorkspaceType,
 } from "@dust-tt/types";
 import { useContext, useEffect, useState } from "react";
@@ -19,17 +18,19 @@ import { PostAgentListStatusRequestBody } from "@app/pages/api/w/[wId]/members/m
 type AssistantPreviewFlow = "personal" | "workspace";
 
 interface GalleryAssistantPreviewContainerProps {
-  agentConfiguration: AgentConfigurationType;
+  agentConfiguration: LightAgentConfigurationType;
   flow: AssistantPreviewFlow;
   onShowDetails: () => void;
   onUpdate: () => void;
   owner: WorkspaceType;
   plan: PlanType | null;
-  setTestModalAssistant?: (agentConfiguration: AgentConfigurationType) => void;
+  setTestModalAssistant?: (
+    agentConfiguration: LightAgentConfigurationType
+  ) => void;
 }
 
 const useAssistantUpdate = (
-  agentConfiguration: AgentConfigurationType,
+  agentConfiguration: LightAgentConfigurationType,
   owner: WorkspaceType,
   sendNotification: (notification: NotificationType) => void,
   onSuccess: (isAdded: boolean) => void,
@@ -44,32 +45,31 @@ const useAssistantUpdate = (
     const isAdding = action === "added";
     const url =
       flow === "workspace"
-        ? `/api/w/${owner.sId}/assistant/agent_configurations/${agentConfiguration.sId}`
+        ? `/api/w/${owner.sId}/assistant/agent_configurations/${agentConfiguration.sId}/scope`
         : `/api/w/${owner.sId}/members/me/agent_list_status`;
-    const method = flow === "workspace" ? "PATCH" : "POST";
 
-    const {
-      action: agentAction,
-      generation,
-      name,
-      description,
-      pictureUrl,
-    } = agentConfiguration;
+    const fullAssistantRes = await fetch(
+      `/api/w/${owner.sId}/assistant/agent_configurations/${agentConfiguration.sId}`,
+      {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }
+    );
+
+    if (!fullAssistantRes.ok) {
+      throw new Error(
+        (await fullAssistantRes.json()).error.message ?? "Error fetching"
+      );
+    }
 
     const body:
-      | PostOrPatchAgentConfigurationRequestBody
+      | { scope: "workspace" | "published" }
       | PostAgentListStatusRequestBody =
       flow === "workspace"
         ? {
-            assistant: {
-              action: agentAction,
-              description,
-              generation,
-              name,
-              pictureUrl,
-              scope,
-              status: "active",
-            },
+            scope,
           }
         : {
             agentId: agentConfiguration.sId,
@@ -78,7 +78,7 @@ const useAssistantUpdate = (
 
     try {
       const response = await fetch(url, {
-        method,
+        method: "POST",
         headers: {
           "Content-Type": "application/json",
         },
@@ -123,7 +123,7 @@ export function GalleryAssistantPreviewContainer({
 
   // Function to determine if the assistant is added based on the flow and configuration.
   const determineIfAdded = (
-    agentConfiguration: AgentConfigurationType,
+    agentConfiguration: LightAgentConfigurationType,
     currentFlow: AssistantPreviewFlow
   ) => {
     return currentFlow === "personal"

--- a/front/components/assistant/RenderMessageMarkdown.tsx
+++ b/front/components/assistant/RenderMessageMarkdown.tsx
@@ -4,7 +4,7 @@ import {
   IconButton,
   Tooltip,
 } from "@dust-tt/sparkle";
-import { AgentConfigurationType } from "@dust-tt/types";
+import { LightAgentConfigurationType } from "@dust-tt/types";
 import { RetrievalDocumentType } from "@dust-tt/types";
 import dynamic from "next/dynamic";
 import React, { ReactNode, useCallback, useEffect, useState } from "react";
@@ -163,7 +163,7 @@ export function RenderMessageMarkdown({
 }: {
   content: string;
   blinkingCursor: boolean;
-  agentConfigurations?: AgentConfigurationType[];
+  agentConfigurations?: LightAgentConfigurationType[];
   citationsContext?: CitationsContextType;
 }) {
   return (
@@ -261,7 +261,7 @@ function MentionBlock({
   agentConfiguration,
 }: {
   agentName: string;
-  agentConfiguration?: AgentConfigurationType;
+  agentConfiguration?: LightAgentConfigurationType;
 }) {
   const statusText =
     !agentConfiguration || agentConfiguration?.status === "archived"

--- a/front/components/assistant/TryAssistantModal.tsx
+++ b/front/components/assistant/TryAssistantModal.tsx
@@ -1,8 +1,8 @@
 import { Modal } from "@dust-tt/sparkle";
 import {
-  AgentConfigurationType,
   AgentMention,
   ConversationType,
+  LightAgentConfigurationType,
   MentionType,
   UserType,
 } from "@dust-tt/types";
@@ -26,7 +26,7 @@ export function TryAssistantModal({
 }: {
   owner: WorkspaceType;
   user: UserType;
-  assistant: AgentConfigurationType;
+  assistant: LightAgentConfigurationType;
   onClose: () => void;
 }) {
   const [stickyMentions, setStickyMentions] = useState<AgentMention[]>([

--- a/front/components/assistant/conversation/AgentSuggestion.tsx
+++ b/front/components/assistant/conversation/AgentSuggestion.tsx
@@ -1,9 +1,9 @@
 import { Button, RobotIcon } from "@dust-tt/sparkle";
 import {
-  AgentConfigurationType,
   ConversationType,
   isAgentMention,
   isUserMessageType,
+  LightAgentConfigurationType,
   UserMessageType,
   WorkspaceType,
 } from "@dust-tt/types";
@@ -38,7 +38,7 @@ export function AgentSuggestion({
   const {
     submit: handleSelectSuggestion,
     isSubmitting: isSelectingSuggestion,
-  } = useSubmitFunction(async (agent: AgentConfigurationType) => {
+  } = useSubmitFunction(async (agent: LightAgentConfigurationType) => {
     const editedContent = `:mention[${agent.name}]{sId=${agent.sId}} ${userMessage.content}`;
     const mRes = await fetch(
       `/api/w/${owner.sId}/assistant/conversations/${conversation.sId}/messages/${userMessage.sId}/edit`,
@@ -118,8 +118,8 @@ export function AgentSuggestion({
    * mentioned, use the shared `compareAgentsForSort` function.
    */
   function compareAgentSuggestions(
-    a: AgentConfigurationType,
-    b: AgentConfigurationType
+    a: LightAgentConfigurationType,
+    b: LightAgentConfigurationType
   ) {
     // index of last user message in conversation mentioning agent a
     const aIndex = conversation.content.findLastIndex((ms) =>

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -1,6 +1,6 @@
 import { Button, Citation, StopIcon } from "@dust-tt/sparkle";
 import { WorkspaceType } from "@dust-tt/types";
-import { AgentConfigurationType } from "@dust-tt/types";
+import { LightAgentConfigurationType } from "@dust-tt/types";
 import { AgentMention, MentionType } from "@dust-tt/types";
 import {
   createContext,
@@ -27,7 +27,7 @@ import { classNames } from "@app/lib/utils";
 function AgentMention({
   agentConfiguration,
 }: {
-  agentConfiguration: AgentConfigurationType;
+  agentConfiguration: LightAgentConfigurationType;
 }) {
   return (
     <div
@@ -56,7 +56,7 @@ export function AssistantInputBar({
   ) => void;
   conversationId: string | null;
   stickyMentions?: AgentMention[];
-  additionalAgentConfigurations?: AgentConfigurationType[];
+  additionalAgentConfigurations?: LightAgentConfigurationType[];
 }) {
   const [contentFragmentBody, setContentFragmentBody] = useState<
     string | undefined
@@ -289,7 +289,7 @@ export function FixedAssistantInputBar({
   ) => void;
   stickyMentions?: AgentMention[];
   conversationId: string | null;
-  additionalAgentConfigurations?: AgentConfigurationType[];
+  additionalAgentConfigurations?: LightAgentConfigurationType[];
 }) {
   return (
     <div className="4xl:px-0 fixed bottom-0 left-0 right-0 z-20 flex-initial lg:left-80">

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -7,8 +7,8 @@ import {
   IconButton,
 } from "@dust-tt/sparkle";
 import {
-  AgentConfigurationType,
   AgentMention,
+  LightAgentConfigurationType,
   WorkspaceType,
 } from "@dust-tt/types";
 import { EditorContent } from "@tiptap/react";
@@ -23,8 +23,8 @@ import useHandleMentions from "@app/components/assistant/conversation/input_bar/
 import { classNames } from "@app/lib/utils";
 
 export interface InputBarContainerProps {
-  allAssistants: AgentConfigurationType[];
-  agentConfigurations: AgentConfigurationType[];
+  allAssistants: LightAgentConfigurationType[];
+  agentConfigurations: LightAgentConfigurationType[];
   disableAttachment: boolean;
   onEnterKeyDown: CustomEditorProps["onEnterKeyDown"];
   onInputFileChange: (e: React.ChangeEvent) => Promise<void>;

--- a/front/components/assistant/conversation/input_bar/editor/useAssistantSuggestions.ts
+++ b/front/components/assistant/conversation/input_bar/editor/useAssistantSuggestions.ts
@@ -1,10 +1,10 @@
-import { AgentConfigurationType } from "@dust-tt/types";
+import { LightAgentConfigurationType } from "@dust-tt/types";
 import { useMemo } from "react";
 
 import { compareAgentsForSort } from "@app/lib/assistant";
 
 const useAssistantSuggestions = (
-  agentConfigurations: AgentConfigurationType[]
+  agentConfigurations: LightAgentConfigurationType[]
 ) => {
   // `useMemo` will ensure that suggestions is only recalculated when `agentConfigurations` changes.
   const suggestions = useMemo(() => {

--- a/front/components/assistant/conversation/input_bar/editor/useHandleMentions.tsx
+++ b/front/components/assistant/conversation/input_bar/editor/useHandleMentions.tsx
@@ -1,4 +1,4 @@
-import { AgentConfigurationType, AgentMention } from "@dust-tt/types";
+import { AgentMention, LightAgentConfigurationType } from "@dust-tt/types";
 import { useEffect, useMemo, useRef } from "react";
 
 import type {
@@ -8,7 +8,7 @@ import type {
 
 const useHandleMentions = (
   editorService: EditorService,
-  agentConfigurations: AgentConfigurationType[],
+  agentConfigurations: LightAgentConfigurationType[],
   stickyMentions: AgentMention[] | undefined,
   selectedAssistant: AgentMention | null
 ) => {

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -1,7 +1,9 @@
 import {
   AgentMention,
   AgentUserListStatus,
+  assertNever,
   Err,
+  LightAgentConfigurationType,
   Ok,
   Result,
   SupportedModel,
@@ -25,10 +27,9 @@ import {
 } from "@dust-tt/types";
 import { isSupportedModel } from "@dust-tt/types";
 import { DatabaseQueryConfigurationType } from "@dust-tt/types";
-import { FindOptions, Op, Transaction, UniqueConstraintError } from "sequelize";
+import { Op, Transaction, UniqueConstraintError } from "sequelize";
 
 import {
-  getGlobalAgent,
   getGlobalAgents,
   isGlobalAgentId,
 } from "@app/lib/api/assistant/global_agents";
@@ -58,11 +59,29 @@ import { generateModelSId } from "@app/lib/utils";
  */
 export async function getAgentConfiguration(
   auth: Authenticator,
-  agentId: string,
-  preFetchedAgentConfiguration?: AgentConfiguration,
-  preFetchedUserRelation?: AgentUserRelation | null,
-  preFetchedDataSourceConfigurations?: AgentDataSourceConfiguration[]
+  agentId: string
 ): Promise<AgentConfigurationType | null> {
+  const res = await getAgentConfigurations({
+    auth,
+    agentsGetView: { agentId },
+    variant: "full",
+  });
+  return res[0] || null;
+}
+
+export async function getAgentConfigurations<V extends "light" | "full">({
+  auth,
+  agentsGetView,
+  agentPrefix,
+  variant,
+}: {
+  auth: Authenticator;
+  agentsGetView: AgentsGetViewType;
+  agentPrefix?: string;
+  variant: V;
+}): Promise<
+  V extends "light" ? LightAgentConfigurationType[] : AgentConfigurationType[]
+> {
   const owner = auth.workspace();
   if (!owner || !auth.isUser()) {
     throw new Error("Unexpected `auth` without `workspace`.");
@@ -72,252 +91,44 @@ export async function getAgentConfiguration(
     throw new Error("Unexpected `auth` without `plan`.");
   }
 
-  if (isGlobalAgentId(agentId)) {
-    return getGlobalAgent(auth, agentId, null);
-  }
-
   const user = auth.user();
 
-  const [agent, userRelation] = await Promise.all([
-    (async () => {
-      const agent =
-        preFetchedAgentConfiguration ??
-        (await AgentConfiguration.findOne({
-          where: {
-            sId: agentId,
-            workspaceId: owner.id,
-          },
-          order: [["version", "DESC"]],
-          include: [
-            {
-              model: AgentGenerationConfiguration,
-              as: "generationConfiguration",
-            },
-            {
-              model: AgentRetrievalConfiguration,
-              as: "retrievalConfiguration",
-            },
-            {
-              model: AgentDustAppRunConfiguration,
-              as: "dustAppRunConfiguration",
-            },
-            {
-              model: AgentDatabaseQueryConfiguration,
-              as: "databaseQueryConfiguration",
-            },
-          ],
-          limit: 1,
-        }));
-
-      return agent;
-    })(),
-    (async () => {
-      if (!user) {
-        return null;
-      }
-      if (preFetchedUserRelation !== undefined) {
-        return preFetchedUserRelation;
-      }
-      return AgentUserRelation.findOne({
-        where: {
-          workspaceId: owner.id,
-          agentConfiguration: agentId,
-          userId: user.id,
-        },
-      });
-    })(),
-  ]);
-
-  if (!agent) {
-    return null;
+  if (
+    agentsGetView === "admin_internal" &&
+    !auth.isDustSuperUser() &&
+    !auth.isAdmin()
+  ) {
+    throw new Error(
+      "superuser view is for dust superusers or internal admin auths only."
+    );
+  }
+  if (agentsGetView === "list" && !user) {
+    throw new Error("List view is specific to a user.");
   }
 
-  let action:
-    | RetrievalConfigurationType
-    | DustAppRunConfigurationType
-    | DatabaseQueryConfigurationType
-    | null = null;
+  const globalAgentsIds =
+    typeof agentsGetView === "object" &&
+    "agentId" in agentsGetView &&
+    isGlobalAgentId(agentsGetView.agentId)
+      ? [agentsGetView.agentId]
+      : undefined;
 
-  /*
-   * Retrieval configuration.
-   */
-  if (agent.retrievalConfigurationId) {
-    const dataSourcesConfig =
-      preFetchedDataSourceConfigurations !== undefined
-        ? preFetchedDataSourceConfigurations
-        : await AgentDataSourceConfiguration.findAll({
-            where: {
-              retrievalConfigurationId: agent.retrievalConfiguration?.id,
-            },
-            include: [
-              {
-                model: DataSource,
-                as: "dataSource",
-                include: [
-                  {
-                    model: Workspace,
-                    as: "workspace",
-                  },
-                ],
-              },
-            ],
-          });
+  let globalAgentsPromise = getGlobalAgents(auth, globalAgentsIds).then(
+    (globals) =>
+      globals.filter(
+        (a) =>
+          !agentPrefix ||
+          a.name.toLowerCase().startsWith(agentPrefix.toLowerCase())
+      )
+  );
 
-    const retrievalConfig = agent.retrievalConfiguration;
-
-    if (!retrievalConfig) {
-      throw new Error(
-        `Couldn't find action configuration for retrieval configuration ${agent.retrievalConfigurationId}}`
-      );
-    }
-
-    let topK: number | "auto" = "auto";
-    if (retrievalConfig.topKMode === "custom") {
-      if (!retrievalConfig.topK) {
-        // unreachable
-        throw new Error(
-          `Couldn't find topK for retrieval configuration ${agent.retrievalConfigurationId}} with 'custom' topK mode`
-        );
-      }
-
-      topK = retrievalConfig.topK;
-    }
-
-    action = {
-      id: retrievalConfig.id,
-      sId: retrievalConfig.sId,
-      type: "retrieval_configuration",
-      query: renderRetrievalQueryType(retrievalConfig),
-      relativeTimeFrame: renderRetrievalTimeframeType(retrievalConfig),
-      topK,
-      dataSources: dataSourcesConfig.map((dsConfig) => {
-        return {
-          dataSourceId: dsConfig.dataSource.name,
-          workspaceId: dsConfig.dataSource.workspace.sId,
-          filter: {
-            tags:
-              dsConfig.tagsIn && dsConfig.tagsNotIn
-                ? { in: dsConfig.tagsIn, not: dsConfig.tagsNotIn }
-                : null,
-            parents:
-              dsConfig.parentsIn && dsConfig.parentsNotIn
-                ? { in: dsConfig.parentsIn, not: dsConfig.parentsNotIn }
-                : null,
-          },
-        };
-      }),
-    };
+  if (agentsGetView === "global") {
+    return globalAgentsPromise;
   }
 
-  /*
-   * DustAppRun configuration.
-   */
-  if (agent.dustAppRunConfigurationId) {
-    const dustAppRunConfig = agent.dustAppRunConfiguration;
-
-    if (!dustAppRunConfig) {
-      throw new Error(
-        `Couldn't find action configuration for DustAppRun configuration ${agent.dustAppRunConfigurationId}}`
-      );
-    }
-
-    action = {
-      id: dustAppRunConfig.id,
-      sId: dustAppRunConfig.sId,
-      type: "dust_app_run_configuration",
-      appWorkspaceId: dustAppRunConfig.appWorkspaceId,
-      appId: dustAppRunConfig.appId,
-    };
-  }
-
-  /*
-   * DatabaseQuery configuration.
-   */
-  if (agent.databaseQueryConfigurationId) {
-    const databaseQueryConfig = agent.databaseQueryConfiguration;
-    if (!databaseQueryConfig) {
-      throw new Error(
-        `Couldn't find action configuration for Database configuration ${agent.databaseQueryConfigurationId}}`
-      );
-    }
-
-    action = {
-      id: databaseQueryConfig.id,
-      sId: databaseQueryConfig.sId,
-      type: "database_query_configuration",
-      dataSourceWorkspaceId: databaseQueryConfig.dataSourceWorkspaceId,
-      dataSourceId: databaseQueryConfig.dataSourceId,
-      databaseId: databaseQueryConfig.databaseId,
-    };
-  }
-
-  /*
-   * Generation configuraiton.
-   */
-  const generationConfig = agent.generationConfiguration;
-  let generation: AgentGenerationConfigurationType | null = null;
-
-  if (generationConfig) {
-    const model = {
-      providerId: generationConfig.providerId,
-      modelId: generationConfig.modelId,
-    };
-    if (!isSupportedModel(model)) {
-      throw new Error(`Unknown model ${model.providerId}/${model.modelId}`);
-    }
-    generation = {
-      id: generationConfig.id,
-      prompt: generationConfig.prompt,
-      temperature: generationConfig.temperature,
-      model,
-    };
-  }
-
-  /*
-   * Final rendering.
-   */
-  const agentConfiguration: AgentConfigurationType = {
-    id: agent.id,
-    sId: agent.sId,
-    version: agent.version,
-    scope: agent.scope,
-    userListStatus: null,
-    name: agent.name,
-    pictureUrl: agent.pictureUrl,
-    description: agent.description,
-    status: agent.status,
-    action: action,
-    generation,
-    versionAuthorId: agent.authorId,
-  };
-
-  agentConfiguration.userListStatus = agentUserListStatus({
-    agentConfiguration,
-    listStatusOverride: userRelation?.listStatusOverride || null,
-  });
-
-  return agentConfiguration;
-}
-
-/**
- * Get agent configurations for the workspace, optionally whose names
- * match a prefix
- * @param agentsGetView the kind of list of agents we want to get, see AgentsGetViewType
- */
-export async function getAgentConfigurations(
-  auth: Authenticator,
-  agentsGetView: AgentsGetViewType,
-  agentPrefix?: string
-): Promise<AgentConfigurationType[] | []> {
-  const owner = auth.workspace();
-  if (!owner) {
-    throw new Error("Unexpected `auth` without `workspace`.");
-  }
-  if (!auth.isUser()) {
-    throw new Error("Unexpected `auth` from outside workspace.");
-  }
-
-  const user = auth.user();
+  globalAgentsPromise = globalAgentsPromise.then((globals) =>
+    globals.filter((a) => a.status === "active")
+  );
 
   const baseAgentsSequelizeQuery = {
     where: {
@@ -325,241 +136,362 @@ export async function getAgentConfigurations(
       status: "active",
       ...(agentPrefix ? { name: { [Op.iLike]: `${agentPrefix}%` } } : {}),
     },
-    include: [
-      {
-        model: AgentGenerationConfiguration,
-        as: "generationConfiguration",
-      },
-      {
-        model: AgentRetrievalConfiguration,
-        as: "retrievalConfiguration",
-      },
-      {
-        model: AgentDustAppRunConfiguration,
-        as: "dustAppRunConfiguration",
-      },
-      {
-        model: AgentDatabaseQueryConfiguration,
-        as: "databaseQueryConfiguration",
-      },
-    ],
   };
 
-  const getGlobalAgentConfigurations = async ({
-    activeOnly,
-  }: {
-    activeOnly: boolean;
-  }) =>
-    (await getGlobalAgents(auth)).filter(
-      (a) =>
-        (!activeOnly || a.status === "active") &&
-        (!agentPrefix ||
-          a.name.toLowerCase().startsWith(agentPrefix.toLowerCase()))
-    );
-
-  const getAgentConfigurationsForQuery = async (
-    agentsSequelizeQuery: FindOptions
-  ) => {
-    const agents = await AgentConfiguration.findAll(agentsSequelizeQuery);
-
-    const retrievalConfigurationIds = agents
-      .map((a) => a.retrievalConfigurationId)
-      .flatMap((id) => (id ? [id] : []));
-
-    const [dataSourcesConfigurations, userRelations] = await Promise.all([
-      AgentDataSourceConfiguration.findAll({
-        where: {
-          retrievalConfigurationId: { [Op.in]: retrievalConfigurationIds },
-        },
-        include: [
-          {
-            model: DataSource,
-            as: "dataSource",
-            include: [
-              {
-                model: Workspace,
-                as: "workspace",
-              },
-            ],
-          },
-        ],
-      }),
-      (async () => {
-        if (!user) {
-          return [];
-        }
-        return AgentUserRelation.findAll({
+  const agentConfigurations: AgentConfiguration[] = await (() => {
+    switch (agentsGetView) {
+      case "admin_internal":
+        return AgentConfiguration.findAll({
+          ...baseAgentsSequelizeQuery,
+        });
+      case "all":
+        return AgentConfiguration.findAll({
+          ...baseAgentsSequelizeQuery,
           where: {
-            workspaceId: owner.id,
-            userId: user?.id,
-            agentConfiguration: { [Op.in]: agents.map((a) => a.sId) },
+            ...baseAgentsSequelizeQuery.where,
+            scope: { [Op.in]: ["workspace", "published"] },
           },
         });
-      })(),
-    ]);
+      case "workspace":
+        return AgentConfiguration.findAll({
+          ...baseAgentsSequelizeQuery,
+          where: {
+            ...baseAgentsSequelizeQuery.where,
+            scope: { [Op.in]: ["workspace"] },
+          },
+        });
+      case "published":
+        return AgentConfiguration.findAll({
+          ...baseAgentsSequelizeQuery,
+          where: {
+            ...baseAgentsSequelizeQuery.where,
+            scope: { [Op.in]: ["published"] },
+          },
+        });
+      case "list":
+        return AgentConfiguration.findAll({
+          ...baseAgentsSequelizeQuery,
+          where: {
+            ...baseAgentsSequelizeQuery.where,
+            [Op.or]: [
+              { scope: { [Op.in]: ["workspace", "published"] } },
+              { authorId: user?.id },
+            ],
+          },
+        });
+      default:
+        if (typeof agentsGetView === "object" && "agentId" in agentsGetView) {
+          if (isGlobalAgentId(agentsGetView.agentId)) {
+            return Promise.resolve([]);
+          }
+          return AgentConfiguration.findAll({
+            ...baseAgentsSequelizeQuery,
+            where: {
+              ...baseAgentsSequelizeQuery.where,
+              sId: agentsGetView.agentId,
+            },
+          });
+        }
+        if (
+          typeof agentsGetView === "object" &&
+          "conversationId" in agentsGetView
+        ) {
+          return AgentConfiguration.findAll({
+            ...baseAgentsSequelizeQuery,
+            where: {
+              ...baseAgentsSequelizeQuery.where,
+              [Op.or]: [
+                { scope: { [Op.in]: ["workspace", "published"] } },
+                { authorId: user?.id },
+              ],
+            },
+          });
+        }
+        assertNever(agentsGetView);
+    }
+  })();
 
-    return (
-      await Promise.all(
-        agents.map((a) =>
-          getAgentConfiguration(
-            auth,
-            a.sId,
-            a,
-            // Make sure to pass null so that it is not fetched again.
-            userRelations.find((r) => r.agentConfiguration === a.sId) || null,
-            dataSourcesConfigurations.filter(
-              (dsc) =>
-                dsc.retrievalConfigurationId === a.retrievalConfigurationId
-            )
-          )
+  function byId<T extends { id: number }>(list: T[]): Record<string, T> {
+    return list.reduce((acc, item) => {
+      acc[item.id] = item;
+      return acc;
+    }, {} as Record<number, T>);
+  }
+
+  const configurationIds = agentConfigurations.map((a) => a.id);
+  const configurationSIds = agentConfigurations.map((a) => a.sId);
+  const generationConfigIds = agentConfigurations
+    .filter((a) => a.generationConfigurationId !== null)
+    .map((a) => a.generationConfigurationId as number);
+  const retrievalConfigIds = agentConfigurations
+    .filter((a) => a.retrievalConfigurationId !== null)
+    .map((a) => a.retrievalConfigurationId as number);
+  const dustAppRunConfigIds = agentConfigurations
+    .filter((a) => a.dustAppRunConfigurationId !== null)
+    .map((a) => a.dustAppRunConfigurationId as number);
+  const databaseQueryConfigIds = agentConfigurations
+    .filter((a) => a.databaseQueryConfigurationId !== null)
+    .map((a) => a.databaseQueryConfigurationId as number);
+
+  const [
+    generationConfigs,
+    retrievalConfigs,
+    dustAppRunConfigs,
+    databaseQueryConfigs,
+    agentUserRelations,
+  ] = await Promise.all([
+    generationConfigIds.length > 0
+      ? AgentGenerationConfiguration.findAll({
+          where: { id: { [Op.in]: generationConfigIds } },
+        }).then(byId)
+      : Promise.resolve({} as Record<number, AgentGenerationConfiguration>),
+    retrievalConfigIds.length > 0 && variant === "full"
+      ? AgentRetrievalConfiguration.findAll({
+          where: { id: { [Op.in]: retrievalConfigIds } },
+        }).then(byId)
+      : Promise.resolve({} as Record<number, AgentRetrievalConfiguration>),
+    dustAppRunConfigIds.length > 0 && variant === "full"
+      ? AgentDustAppRunConfiguration.findAll({
+          where: { id: { [Op.in]: dustAppRunConfigIds } },
+        }).then(byId)
+      : Promise.resolve({} as Record<number, AgentDustAppRunConfiguration>),
+    databaseQueryConfigIds.length > 0 && variant === "full"
+      ? AgentDatabaseQueryConfiguration.findAll({
+          where: { id: { [Op.in]: databaseQueryConfigIds } },
+        }).then(byId)
+      : Promise.resolve({} as Record<number, AgentDatabaseQueryConfiguration>),
+    user && configurationIds.length > 0
+      ? AgentUserRelation.findAll({
+          where: {
+            agentConfiguration: { [Op.in]: configurationSIds },
+            userId: user.id,
+          },
+        }).then((relations) =>
+          relations.reduce((acc, relation) => {
+            acc[relation.agentConfiguration] = relation;
+            return acc;
+          }, {} as Record<string, AgentUserRelation>)
         )
-      )
-    ).filter((a) => a !== null) as AgentConfigurationType[];
-  };
+      : Promise.resolve({} as Record<string, AgentUserRelation>),
+  ]);
 
-  // Superuser view (all agents, to be used internally from poke).
-  if (agentsGetView === "admin_internal") {
-    if (!auth.isDustSuperUser() && !auth.isAdmin()) {
-      throw new Error(
-        "superuser view is for dust superusers or internal admin auths only."
-      );
+  const agentDatasourceConfigurations = (
+    Object.values(retrievalConfigs).length
+      ? await AgentDataSourceConfiguration.findAll({
+          where: {
+            retrievalConfigurationId: {
+              [Op.in]: Object.values(retrievalConfigs).map((r) => r.id),
+            },
+          },
+        })
+      : []
+  ).reduce((acc, dsConfig) => {
+    acc[dsConfig.retrievalConfigurationId] =
+      acc[dsConfig.retrievalConfigurationId] || [];
+    acc[dsConfig.retrievalConfigurationId].push(dsConfig);
+    return acc;
+  }, {} as Record<number, AgentDataSourceConfiguration[]>);
+
+  const dataSourceIds = Object.values(agentDatasourceConfigurations)
+    .flat()
+    .map((dsConfig) => dsConfig.dataSourceId);
+  const dataSources = (
+    dataSourceIds.length
+      ? await DataSource.findAll({
+          where: {
+            id: {
+              [Op.in]: dataSourceIds,
+            },
+          },
+        })
+      : []
+  ).reduce((acc, ds) => {
+    acc[ds.id] = ds;
+    return acc;
+  }, {} as Record<number, DataSource>);
+
+  const workspaceIds = Object.values(dataSources).map((ds) => ds.workspaceId);
+  const dataSourceWorkspaces = (
+    workspaceIds.length
+      ? await Workspace.findAll({
+          where: {
+            id: {
+              [Op.in]: workspaceIds,
+            },
+          },
+        })
+      : []
+  ).reduce((acc, ws) => {
+    acc[ws.id] = ws;
+    return acc;
+  }, {} as Record<number, Workspace>);
+
+  let agentConfigurationTypes: AgentConfigurationType[] = [];
+  for (const agent of agentConfigurations) {
+    let action:
+      | RetrievalConfigurationType
+      | DustAppRunConfigurationType
+      | DatabaseQueryConfigurationType
+      | null = null;
+
+    if (variant === "full") {
+      if (agent.retrievalConfigurationId) {
+        const retrievalConfig =
+          retrievalConfigs[agent.retrievalConfigurationId];
+
+        if (!retrievalConfig) {
+          throw new Error(
+            `Couldn't find action configuration for retrieval configuration ${agent.retrievalConfigurationId}}`
+          );
+        }
+
+        const dataSourcesConfig =
+          agentDatasourceConfigurations[retrievalConfig.id];
+        let topK: number | "auto" = "auto";
+        if (retrievalConfig.topKMode === "custom") {
+          if (!retrievalConfig.topK) {
+            // unreachable
+            throw new Error(
+              `Couldn't find topK for retrieval configuration ${agent.retrievalConfigurationId}} with 'custom' topK mode`
+            );
+          }
+
+          topK = retrievalConfig.topK;
+        }
+
+        action = {
+          id: retrievalConfig.id,
+          sId: retrievalConfig.sId,
+          type: "retrieval_configuration",
+          query: renderRetrievalQueryType(retrievalConfig),
+          relativeTimeFrame: renderRetrievalTimeframeType(retrievalConfig),
+          topK,
+          dataSources: dataSourcesConfig.map((dsConfig) => {
+            const dataSource = dataSources[dsConfig.dataSourceId];
+            const workspace = dataSourceWorkspaces[dataSource.workspaceId];
+            return {
+              dataSourceId: dataSource.name,
+              workspaceId: workspace.sId,
+              filter: {
+                tags:
+                  dsConfig.tagsIn && dsConfig.tagsNotIn
+                    ? { in: dsConfig.tagsIn, not: dsConfig.tagsNotIn }
+                    : null,
+                parents:
+                  dsConfig.parentsIn && dsConfig.parentsNotIn
+                    ? { in: dsConfig.parentsIn, not: dsConfig.parentsNotIn }
+                    : null,
+              },
+            };
+          }),
+        };
+      } else if (agent.dustAppRunConfigurationId) {
+        const dustAppRunConfig =
+          dustAppRunConfigs[agent.dustAppRunConfigurationId];
+
+        if (!dustAppRunConfig) {
+          throw new Error(
+            `Couldn't find action configuration for DustAppRun configuration ${agent.dustAppRunConfigurationId}}`
+          );
+        }
+
+        action = {
+          id: dustAppRunConfig.id,
+          sId: dustAppRunConfig.sId,
+          type: "dust_app_run_configuration",
+          appWorkspaceId: dustAppRunConfig.appWorkspaceId,
+          appId: dustAppRunConfig.appId,
+        };
+      } else if (agent.databaseQueryConfigurationId) {
+        const databaseQueryConfig =
+          databaseQueryConfigs[agent.databaseQueryConfigurationId];
+
+        if (!databaseQueryConfig) {
+          throw new Error(
+            `Couldn't find action configuration for Database configuration ${agent.databaseQueryConfigurationId}}`
+          );
+        }
+
+        action = {
+          id: databaseQueryConfig.id,
+          sId: databaseQueryConfig.sId,
+          type: "database_query_configuration",
+          dataSourceWorkspaceId: databaseQueryConfig.dataSourceWorkspaceId,
+          dataSourceId: databaseQueryConfig.dataSourceId,
+          databaseId: databaseQueryConfig.databaseId,
+        };
+      }
     }
-    return (
-      await Promise.all([
-        getAgentConfigurationsForQuery(baseAgentsSequelizeQuery),
-        getGlobalAgentConfigurations({ activeOnly: true }),
-      ])
-    ).flat();
-  }
 
-  // All view (published + workspace agents + globals).
-  if (agentsGetView === "all") {
-    const allAgentsSequelizeQuery = {
-      ...baseAgentsSequelizeQuery,
-      where: {
-        ...baseAgentsSequelizeQuery.where,
-        scope: { [Op.in]: ["published", "workspace"] },
-      },
+    let generation: AgentGenerationConfigurationType | null = null;
+
+    if (agent.generationConfigurationId) {
+      const generationConfig =
+        generationConfigs[agent.generationConfigurationId];
+      const model = {
+        providerId: generationConfig.providerId,
+        modelId: generationConfig.modelId,
+      };
+      if (!isSupportedModel(model)) {
+        throw new Error(`Unknown model ${model.providerId}/${model.modelId}`);
+      }
+      generation = {
+        id: generationConfig.id,
+        prompt: generationConfig.prompt,
+        temperature: generationConfig.temperature,
+        model,
+      };
+    }
+
+    const agentConfigurationType: AgentConfigurationType = {
+      id: agent.id,
+      sId: agent.sId,
+      version: agent.version,
+      scope: agent.scope,
+      userListStatus: null,
+      name: agent.name,
+      pictureUrl: agent.pictureUrl,
+      description: agent.description,
+      status: agent.status,
+      action,
+      generation,
+      versionAuthorId: agent.authorId,
     };
-    return (
-      await Promise.all([
-        getAgentConfigurationsForQuery(allAgentsSequelizeQuery),
-        getGlobalAgentConfigurations({ activeOnly: true }),
-      ])
-    ).flat();
+
+    agentConfigurationType.userListStatus = agentUserListStatus({
+      agentConfiguration: agentConfigurationType,
+      listStatusOverride:
+        agentUserRelations[agent.sId]?.listStatusOverride ?? null,
+    });
+
+    agentConfigurationTypes.push(agentConfigurationType);
   }
 
-  // Workspace view (only workspace agents).
-  if (agentsGetView === "workspace") {
-    const workspaceAgentsSequelizeQuery = {
-      ...baseAgentsSequelizeQuery,
-      where: {
-        ...baseAgentsSequelizeQuery.where,
-        scope: { [Op.in]: ["workspace"] },
-      },
-    };
-    return (
-      await Promise.all([
-        getAgentConfigurationsForQuery(workspaceAgentsSequelizeQuery),
-        [],
-      ])
-    ).flat();
-  }
-
-  // Published view (only published agents).
-  if (agentsGetView === "published") {
-    const publishedAgentsSequelizeQuery = {
-      ...baseAgentsSequelizeQuery,
-      where: {
-        ...baseAgentsSequelizeQuery.where,
-        scope: { [Op.in]: ["published"] },
-      },
-    };
-    return (
-      await Promise.all([
-        getAgentConfigurationsForQuery(publishedAgentsSequelizeQuery),
-        [],
-      ])
-    ).flat();
-  }
-
-  if (agentsGetView === "global") {
-    return (
-      await Promise.all([
-        [],
-        getGlobalAgentConfigurations({ activeOnly: false }),
-      ])
-    ).flat();
-  }
-
-  // List view (user agents list).
   if (agentsGetView === "list") {
-    const user = auth.user();
-    if (!user) {
-      throw new Error("List view is specific to a user.");
-    }
-
-    const listAgentsSequelizeQuery = {
-      ...baseAgentsSequelizeQuery,
-      where: {
-        ...baseAgentsSequelizeQuery.where,
-        [Op.or]: [
-          { scope: { [Op.in]: ["published", "workspace"] } },
-          { authorId: user.id },
-        ],
-      },
-    };
-
-    const listAgentsPromise = getAgentConfigurationsForQuery(
-      listAgentsSequelizeQuery
-    ).then(
-      (agents) =>
-        agents.filter((a) => {
-          return a.userListStatus === "in-list";
-        }) as AgentConfigurationType[]
-    );
-
-    return (
-      await Promise.all([
-        listAgentsPromise,
-        getGlobalAgentConfigurations({ activeOnly: true }),
-      ])
-    ).flat();
+    agentConfigurationTypes = agentConfigurationTypes.filter((a) => {
+      return a.userListStatus === "in-list";
+    });
   }
 
-  // Conversation view (user agents list + agents mentioned in the conversation).
-  if (typeof agentsGetView === "object" && agentsGetView.conversationId) {
-    const user = auth.user();
-    if (!user) {
-      throw new Error("Conversation view is specific to a user.");
-    }
-    const conversationAgentsSequelizeQuery = {
-      ...baseAgentsSequelizeQuery,
-      where: {
-        ...baseAgentsSequelizeQuery.where,
-        [Op.or]: [
-          { scope: { [Op.in]: ["published", "workspace"] } },
-          { authorId: user.id },
-        ],
-      },
-    };
-    const [agents, mentions, globalAgents] = await Promise.all([
-      getAgentConfigurationsForQuery(conversationAgentsSequelizeQuery),
-      getConversationMentions(agentsGetView.conversationId),
-      getGlobalAgentConfigurations({ activeOnly: true }),
-    ]);
+  if (typeof agentsGetView === "object" && "conversationId" in agentsGetView) {
+    const mentions = await getConversationMentions(
+      agentsGetView.conversationId
+    );
     const mentionedAgentIds = mentions.map((m) => m.configurationId);
-    const localAgents = agents.filter((a) => {
+    agentConfigurationTypes = agentConfigurationTypes.filter((a) => {
       if (mentionedAgentIds.includes(a.sId)) {
         return true;
       }
       return a.userListStatus === "in-list";
-    }) as AgentConfigurationType[];
-    return [...localAgents, ...globalAgents];
+    });
   }
 
-  throw new Error(`Unknown agentsGetView ${agentsGetView}`);
+  return globalAgentsPromise.then((globalAgents) => [
+    ...agentConfigurationTypes,
+    ...globalAgents,
+  ]);
 }
+
 async function getConversationMentions(
   conversationId: string
 ): Promise<AgentMention[]> {
@@ -1127,4 +1059,40 @@ export async function agentNameIsAvailable(
   });
 
   return !agent;
+}
+
+export async function setAgentScope(
+  auth: Authenticator,
+  agentId: string,
+  scope: AgentConfigurationScope
+): Promise<Result<{ agentId: string; scope: AgentConfigurationScope }, Error>> {
+  const owner = auth.workspace();
+  if (!owner) {
+    throw new Error("Unexpected `auth` without `workspace`.");
+  }
+
+  if (scope === "global") {
+    return new Err(new Error("Cannot set scope to global"));
+  }
+
+  const agent = await AgentConfiguration.findOne({
+    where: {
+      workspaceId: owner.id,
+      sId: agentId,
+      status: "active",
+    },
+  });
+
+  if (!agent) {
+    return new Err(new Error(`Could not find agent ${agentId}`));
+  }
+
+  if (agent.scope === scope) {
+    return new Ok({ agentId, scope });
+  }
+
+  agent.scope = scope;
+  await agent.save();
+
+  return new Ok({ agentId, scope });
 }

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -7,7 +7,7 @@ import {
   WorkspaceType,
 } from "@dust-tt/types";
 import { GPT_3_5_TURBO_MODEL_CONFIG } from "@dust-tt/types";
-import { AgentConfigurationType } from "@dust-tt/types";
+import { LightAgentConfigurationType } from "@dust-tt/types";
 import {
   AgentMessageType,
   ContentFragmentContentType,
@@ -305,7 +305,7 @@ async function batchRenderAgentMessages(
             return getAgentConfiguration(auth, agentConfigId);
           })
         )
-      ).filter((a) => a !== null) as AgentConfigurationType[];
+      ).filter((a) => a !== null) as LightAgentConfigurationType[];
       return agents;
     })(),
     (async () => {

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -1,4 +1,5 @@
 import {
+  AgentConfigurationType,
   GenerationCancelEvent,
   GenerationErrorEvent,
   GenerationSuccessEvent,
@@ -10,7 +11,6 @@ import {
   ModelConversationType,
   ModelMessageType,
 } from "@dust-tt/types";
-import { AgentConfigurationType } from "@dust-tt/types";
 import {
   isRetrievalActionType,
   isRetrievalConfiguration,
@@ -243,10 +243,11 @@ export async function constructPrompt(
   if (meta.includes("{ASSISTANTS_LIST}")) {
     if (!auth.isUser())
       throw new Error("Unexpected unauthenticated call to `constructPrompt`");
-    const agents = await getAgentConfigurations(
+    const agents = await getAgentConfigurations({
       auth,
-      auth.user() ? "list" : "all"
-    );
+      agentsGetView: auth.user() ? "list" : "all",
+      variant: "light",
+    });
     meta = meta.replaceAll(
       "{ASSISTANTS_LIST}",
       agents

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -5,6 +5,7 @@ import { promisify } from "util";
 const readFileAsync = promisify(fs.readFile);
 
 import {
+  AgentConfigurationType,
   ConnectorProvider,
   DataSourceType,
   GEMINI_PRO_DEFAULT_MODEL_CONFIG,
@@ -17,9 +18,8 @@ import {
   MISTRAL_MEDIUM_MODEL_CONFIG,
   MISTRAL_SMALL_MODEL_CONFIG,
 } from "@dust-tt/types";
-import { AgentConfigurationType, GlobalAgentStatus } from "@dust-tt/types";
-import { PlanType } from "@dust-tt/types";
-import { DustAPI } from "@dust-tt/types";
+import {} from "@dust-tt/types";
+import { DustAPI, GlobalAgentStatus, PlanType } from "@dust-tt/types";
 
 import { GLOBAL_AGENTS_SID } from "@app/lib/assistant";
 import { Authenticator, prodAPICredentialsForOwner } from "@app/lib/auth";
@@ -761,8 +761,13 @@ export async function getGlobalAgent(
 }
 
 export async function getGlobalAgents(
-  auth: Authenticator
+  auth: Authenticator,
+  agentIds?: string[]
 ): Promise<AgentConfigurationType[]> {
+  if (agentIds !== undefined && agentIds.some((sId) => !isGlobalAgentId(sId))) {
+    throw new Error("Invalid agentIds.");
+  }
+
   const owner = auth.workspace();
   if (!owner) {
     throw new Error("Cannot find Global Agent Configuration: no workspace.");
@@ -786,7 +791,7 @@ export async function getGlobalAgents(
   // For now we retrieve them all
   // We will store them in the database later to allow admin enable them or not
   const agentCandidates = await Promise.all(
-    Object.values(GLOBAL_AGENTS_SID).map((sId) =>
+    Object.values(agentIds ?? GLOBAL_AGENTS_SID).map((sId) =>
       getGlobalAgent(auth, sId, preFetchedDataSources)
     )
   );

--- a/front/lib/api/assistant/recent_authors.ts
+++ b/front/lib/api/assistant/recent_authors.ts
@@ -1,6 +1,6 @@
 import {
-  AgentConfigurationType,
   AgentRecentAuthors,
+  LightAgentConfigurationType,
   UserType,
 } from "@dust-tt/types";
 import { Sequelize } from "sequelize";
@@ -129,7 +129,7 @@ export async function getAgentRecentAuthors(
     agent,
     auth,
   }: {
-    agent: AgentConfigurationType;
+    agent: LightAgentConfigurationType;
     auth: Authenticator;
   },
   members: UserType[]
@@ -171,7 +171,7 @@ export async function agentConfigurationWasUpdatedBy({
   agent,
   auth,
 }: {
-  agent: AgentConfigurationType;
+  agent: LightAgentConfigurationType;
   auth: Authenticator;
 }) {
   const owner = auth.workspace();

--- a/front/lib/api/assistant/user_relation.ts
+++ b/front/lib/api/assistant/user_relation.ts
@@ -1,8 +1,8 @@
 import {
-  AgentConfigurationType,
   AgentUserListStatus,
   assertNever,
   Err,
+  LightAgentConfigurationType,
   Ok,
   Result,
 } from "@dust-tt/types";
@@ -15,7 +15,7 @@ export function agentUserListStatus({
   agentConfiguration,
   listStatusOverride,
 }: {
-  agentConfiguration: AgentConfigurationType;
+  agentConfiguration: LightAgentConfigurationType;
   listStatusOverride: AgentUserListStatus | null;
 }): AgentUserListStatus {
   if (listStatusOverride === null) {

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -1,4 +1,4 @@
-import { AgentConfigurationType } from "@dust-tt/types";
+import { LightAgentConfigurationType } from "@dust-tt/types";
 import { SUPPORTED_MODEL_CONFIGS, SupportedModel } from "@dust-tt/types";
 
 export function isLargeModel(model: unknown): model is SupportedModel {
@@ -66,8 +66,8 @@ const CUSTOM_ORDER: string[] = [
 // This function implements our general strategy to sort agents to users (input bar, assistant list,
 // agent suggestions...).
 export function compareAgentsForSort(
-  a: AgentConfigurationType,
-  b: AgentConfigurationType
+  a: LightAgentConfigurationType,
+  b: LightAgentConfigurationType
 ) {
   // Check for 'dust'
   if (a.sId === GLOBAL_AGENTS_SID.DUST) return -1;

--- a/front/lib/swr.ts
+++ b/front/lib/swr.ts
@@ -1,4 +1,8 @@
-import { AgentsGetViewType, DataSourceType } from "@dust-tt/types";
+import {
+  AgentConfigurationType,
+  AgentsGetViewType,
+  DataSourceType,
+} from "@dust-tt/types";
 import { WorkspaceType } from "@dust-tt/types";
 import { ConversationMessageReactions, ConversationType } from "@dust-tt/types";
 import { AppType } from "@dust-tt/types";
@@ -454,7 +458,9 @@ export function useAgentConfigurations({
     if (typeof agentsGetView === "string") {
       params.append("view", agentsGetView);
     } else {
-      params.append("conversationId", agentsGetView.conversationId);
+      if ("conversationId" in agentsGetView) {
+        params.append("conversationId", agentsGetView.conversationId);
+      }
     }
     if (includes.includes("usage")) {
       params.append("withUsage", "true");
@@ -476,6 +482,30 @@ export function useAgentConfigurations({
     isAgentConfigurationsLoading: !error && !data,
     isAgentConfigurationsError: error,
     mutateAgentConfigurations: mutate,
+  };
+}
+
+export function useAgentConfiguration({
+  workspaceId,
+  agentConfigurationId,
+}: {
+  workspaceId: string;
+  agentConfigurationId: string;
+}) {
+  const agentConfigurationFetcher: Fetcher<{
+    agentConfiguration: AgentConfigurationType;
+  }> = fetcher;
+
+  const { data, error, mutate } = useSWR(
+    `/api/w/${workspaceId}/assistant/agent_configurations/${agentConfigurationId}`,
+    agentConfigurationFetcher
+  );
+
+  return {
+    agentConfiguration: data ? data.agentConfiguration : null,
+    isAgentConfigurationLoading: !error && !data,
+    isAgentConfigurationError: error,
+    mutateAgentConfiguration: mutate,
   };
 }
 

--- a/front/lib/utils.ts
+++ b/front/lib/utils.ts
@@ -1,4 +1,4 @@
-import { AgentConfigurationType } from "@dust-tt/types";
+import { LightAgentConfigurationType } from "@dust-tt/types";
 import { hash as blake3 } from "blake3";
 import { v4 as uuidv4 } from "uuid";
 
@@ -150,7 +150,7 @@ export function compareForFuzzySort(query: string, a: string, b: string) {
 }
 
 export function filterAndSortAgents(
-  agents: AgentConfigurationType[],
+  agents: LightAgentConfigurationType[],
   searchText: string
 ) {
   const lowerCaseSearchText = searchText.toLowerCase();

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -584,10 +584,12 @@ async function revokeUsersForDowngrade(auth: Authenticator) {
 }
 
 async function archiveConnectedAgents(auth: Authenticator) {
-  const agentConfigurations = await getAgentConfigurations(
+  const agentConfigurations = await getAgentConfigurations({
     auth,
-    "admin_internal"
-  );
+    agentsGetView: "admin_internal",
+    variant: "full",
+  });
+
   // agentconfigurations with a retrieval action with at least a managed
   // data source
   const agentConfigurationsToArchive = agentConfigurations.filter(

--- a/front/pages/api/v1/w/[wId]/assistant/agent_configurations.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/agent_configurations.ts
@@ -34,7 +34,11 @@ async function handler(
 
   switch (req.method) {
     case "GET": {
-      const agentConfigurations = await getAgentConfigurations(auth, "all");
+      const agentConfigurations = await getAgentConfigurations({
+        auth,
+        agentsGetView: "all",
+        variant: "light",
+      });
       return res.status(200).json({
         agentConfigurations,
       });

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/scope.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/scope.ts
@@ -1,0 +1,132 @@
+import { ReturnedAPIErrorType } from "@dust-tt/types";
+import { isLeft } from "fp-ts/lib/Either";
+import * as t from "io-ts";
+import * as reporter from "io-ts-reporters";
+import { NextApiRequest, NextApiResponse } from "next";
+
+import {
+  getAgentConfiguration,
+  setAgentScope,
+} from "@app/lib/api/assistant/configuration";
+import { Authenticator, getSession } from "@app/lib/auth";
+import { apiError, withLogging } from "@app/logger/withlogging";
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<ReturnedAPIErrorType | void>
+): Promise<void> {
+  const session = await getSession(req, res);
+  const auth = await Authenticator.fromSession(
+    session,
+    req.query.wId as string
+  );
+  const owner = auth.workspace();
+  if (!owner) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "The workspace you're trying to modify was not found.",
+      },
+    });
+  }
+  if (!auth.isUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "app_auth_error",
+        message:
+          "Only users of the current workspace can access its assistants.",
+      },
+    });
+  }
+  const assistant = await getAgentConfiguration(auth, req.query.aId as string);
+  if (
+    !assistant ||
+    (assistant.scope === "private" &&
+      assistant.versionAuthorId !== auth.user()?.id)
+  ) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "agent_configuration_not_found",
+        message: "The Assistant you're trying to access was not found.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "POST":
+      const bodyValidation = t
+        .type({
+          scope: t.union([
+            t.literal("workspace"),
+            t.literal("published"),
+            t.literal("private"),
+          ]),
+        })
+        .decode(req.body);
+      if (isLeft(bodyValidation)) {
+        const pathError = reporter.formatValidationErrors(bodyValidation.left);
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid request body: ${pathError}`,
+          },
+        });
+      }
+
+      if (assistant.scope === "workspace" && !auth.isBuilder()) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "app_auth_error",
+            message: "Only builders can modify workspace assistants.",
+          },
+        });
+      }
+      if (
+        assistant.scope !== "private" &&
+        bodyValidation.right.scope === "private"
+      ) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Non-private assistants cannot be set back to private.",
+          },
+        });
+      }
+
+      const result = await setAgentScope(
+        auth,
+        assistant.sId,
+        bodyValidation.right.scope
+      );
+
+      if (result.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: result.error.message,
+          },
+        });
+      }
+
+      res.status(200).end();
+      return;
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, POST is expected.",
+        },
+      });
+  }
+}
+
+export default withLogging(handler);

--- a/front/pages/poke/[wId]/index.tsx
+++ b/front/pages/poke/[wId]/index.tsx
@@ -10,6 +10,7 @@ import {
   DataSourceType,
   isDustAppRunConfiguration,
   isRetrievalConfiguration,
+  LightAgentConfigurationType,
   WorkspaceSegmentationType,
 } from "@dust-tt/types";
 import { UserType, WorkspaceType } from "@dust-tt/types";
@@ -84,8 +85,13 @@ export const getServerSideProps: GetServerSideProps<{
   }
 
   const dataSources = await getDataSources(auth);
+
   const agentConfigurations = (
-    await getAgentConfigurations(auth, "admin_internal")
+    await getAgentConfigurations({
+      auth,
+      agentsGetView: "admin_internal",
+      variant: "full",
+    })
   ).filter(
     (a) =>
       !Object.values(GLOBAL_AGENTS_SID).includes(a.sId as GLOBAL_AGENTS_SID)
@@ -169,7 +175,7 @@ export const getServerSideProps: GetServerSideProps<{
       subscription,
       planInvitation: planInvitation ?? null,
       dataSources,
-      agentConfigurations,
+      agentConfigurations: agentConfigurations,
       slackbotEnabled,
       gdrivePDFEnabled,
       dataSourcesSynchronizedAgo: synchronizedAgoByDsName,
@@ -309,7 +315,7 @@ const WorkspacePage = ({
   );
 
   const { submit: onAssistantArchive } = useSubmitFunction(
-    async (agentConfiguration: AgentConfigurationType) => {
+    async (agentConfiguration: LightAgentConfigurationType) => {
       if (
         !window.confirm(
           `Are you sure you want to archive the ${agentConfiguration.name} assistant? There is no going back.`

--- a/front/pages/w/[wId]/assistant/assistants.tsx
+++ b/front/pages/w/[wId]/assistant/assistants.tsx
@@ -19,8 +19,8 @@ import {
   XMarkIcon,
 } from "@dust-tt/sparkle";
 import {
-  AgentConfigurationType,
   AgentUserListStatus,
+  LightAgentConfigurationType,
   UserType,
   WorkspaceType,
 } from "@dust-tt/types";
@@ -107,9 +107,8 @@ export default function PersonalAssistants({
     });
 
   const [assistantSearch, setAssistantSearch] = useState<string>("");
-  const [showDetails, setShowDetails] = useState<AgentConfigurationType | null>(
-    null
-  );
+  const [showDetails, setShowDetails] =
+    useState<LightAgentConfigurationType | null>(null);
 
   const viewAssistants = agentConfigurations.filter((a) => {
     if (view === "personal") {
@@ -125,9 +124,9 @@ export default function PersonalAssistants({
   });
 
   const [showRemovalModal, setShowRemovalModal] =
-    useState<AgentConfigurationType | null>(null);
+    useState<LightAgentConfigurationType | null>(null);
   const [showDeletionModal, setShowDeletionModal] =
-    useState<AgentConfigurationType | null>(null);
+    useState<LightAgentConfigurationType | null>(null);
 
   const tabs = [
     {
@@ -145,7 +144,7 @@ export default function PersonalAssistants({
   const sendNotification = useContext(SendNotificationsContext);
 
   const updateAgentUserListStatus = async (
-    agentConfiguration: AgentConfigurationType,
+    agentConfiguration: LightAgentConfigurationType,
     listStatus: AgentUserListStatus
   ) => {
     const body: PostAgentListStatusRequestBody = {

--- a/front/pages/w/[wId]/assistant/gallery.tsx
+++ b/front/pages/w/[wId]/assistant/gallery.tsx
@@ -1,8 +1,8 @@
 import { Button, DropdownMenu, Page, Searchbar, Tab } from "@dust-tt/sparkle";
 import {
-  AgentConfigurationType,
   AgentsGetViewType,
   assertNever,
+  LightAgentConfigurationType,
   PlanType,
   SubscriptionType,
   UserType,
@@ -102,7 +102,7 @@ export default function AssistantsGallery({
 
   const [assistantSearch, setAssistantSearch] = useState<string>("");
 
-  let agentsToDisplay: AgentConfigurationType[] = [];
+  let agentsToDisplay: LightAgentConfigurationType[] = [];
 
   switch (orderBy) {
     case "name": {
@@ -147,11 +147,10 @@ export default function AssistantsGallery({
       assertNever(orderBy);
   }
 
-  const [showDetails, setShowDetails] = useState<AgentConfigurationType | null>(
-    null
-  );
+  const [showDetails, setShowDetails] =
+    useState<LightAgentConfigurationType | null>(null);
   const [testModalAssistant, setTestModalAssistant] =
-    useState<AgentConfigurationType | null>(null);
+    useState<LightAgentConfigurationType | null>(null);
 
   const tabs = [
     {

--- a/front/pages/w/[wId]/assistant/new.tsx
+++ b/front/pages/w/[wId]/assistant/new.tsx
@@ -10,10 +10,10 @@ import {
   Popup,
 } from "@dust-tt/sparkle";
 import {
-  AgentConfigurationType,
   AgentMention,
   ContentFragmentContentType,
   ConversationType,
+  LightAgentConfigurationType,
   MentionType,
   SubscriptionType,
   UserType,
@@ -149,9 +149,8 @@ export default function AssistantNew({
   const [greeting, setGreeting] = useState<string>("");
   const [selectedAssistant, setSelectedAssistant] =
     useState<AgentMention | null>(null);
-  const [showDetails, setShowDetails] = useState<AgentConfigurationType | null>(
-    null
-  );
+  const [showDetails, setShowDetails] =
+    useState<LightAgentConfigurationType | null>(null);
 
   const triggerInputAnimation = () => {
     setShouldAnimateInput(true);

--- a/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
@@ -1,8 +1,12 @@
-import { DataSourceType, UserType, WorkspaceType } from "@dust-tt/types";
+import {
+  AgentConfigurationType,
+  DataSourceType,
+  UserType,
+  WorkspaceType,
+} from "@dust-tt/types";
 import { isDatabaseQueryConfiguration } from "@dust-tt/types";
 import { isDustAppRunConfiguration } from "@dust-tt/types";
 import { isRetrievalConfiguration } from "@dust-tt/types";
-import { AgentConfigurationType } from "@dust-tt/types";
 import { AppType } from "@dust-tt/types";
 import { PlanType, SubscriptionType } from "@dust-tt/types";
 import { ConnectorsAPI } from "@dust-tt/types";

--- a/front/pages/w/[wId]/builder/assistants/dust.tsx
+++ b/front/pages/w/[wId]/builder/assistants/dust.tsx
@@ -7,11 +7,14 @@ import {
   PlusIcon,
   SliderToggle,
 } from "@dust-tt/sparkle";
-import { DataSourceType } from "@dust-tt/types";
-import { UserType, WorkspaceType } from "@dust-tt/types";
-import { AgentConfigurationType } from "@dust-tt/types";
-import { SubscriptionType } from "@dust-tt/types";
-import { APIError } from "@dust-tt/types";
+import {
+  APIError,
+  DataSourceType,
+  LightAgentConfigurationType,
+  SubscriptionType,
+  UserType,
+  WorkspaceType,
+} from "@dust-tt/types";
 import { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 import { useContext } from "react";
@@ -90,7 +93,9 @@ export default function EditDustAssistant({
     return null;
   }
 
-  const handleToggleAgentStatus = async (agent: AgentConfigurationType) => {
+  const handleToggleAgentStatus = async (
+    agent: LightAgentConfigurationType
+  ) => {
     if (agent.status === "disabled_missing_datasource") {
       sendNotification({
         title: "Dust Assistant",

--- a/front/pages/w/[wId]/builder/assistants/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/index.tsx
@@ -15,8 +15,11 @@ import {
   TrashIcon,
   XMarkIcon,
 } from "@dust-tt/sparkle";
-import { UserType, WorkspaceType } from "@dust-tt/types";
-import { AgentConfigurationType } from "@dust-tt/types";
+import {
+  LightAgentConfigurationType,
+  UserType,
+  WorkspaceType,
+} from "@dust-tt/types";
 import { SubscriptionType } from "@dust-tt/types";
 import { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import Link from "next/link";
@@ -104,7 +107,9 @@ export default function WorkspaceAssistants({
 
   const isBuilder = owner.role === "builder" || owner.role === "admin";
 
-  const handleToggleAgentStatus = async (agent: AgentConfigurationType) => {
+  const handleToggleAgentStatus = async (
+    agent: LightAgentConfigurationType
+  ) => {
     if (agent.status === "disabled_free_workspace") {
       setShowDisabledFreeWorkspacePopup(agent.sId);
       return;
@@ -135,9 +140,9 @@ export default function WorkspaceAssistants({
   };
 
   const [showDeletionModal, setShowDeletionModal] =
-    useState<AgentConfigurationType | null>(null);
+    useState<LightAgentConfigurationType | null>(null);
   const [showRemoveFromWorkspaceModal, setShowRemoveFromWorkspaceModal] =
-    useState<AgentConfigurationType | null>(null);
+    useState<LightAgentConfigurationType | null>(null);
 
   return (
     <AppLayout

--- a/types/src/front/assistant/agent.ts
+++ b/types/src/front/assistant/agent.ts
@@ -98,6 +98,7 @@ export type AgentUserListStatus = "in-list" | "not-in-list";
  * Global agents enabled for the workspace are always returned with all the views.
  */
 export type AgentsGetViewType =
+  | { agentId: string }
   | "list"
   | { conversationId: string }
   | "all"
@@ -116,13 +117,16 @@ export type AgentUsageType = {
 
 export type AgentRecentAuthors = readonly string[];
 
-export type AgentConfigurationType = {
+export type LightAgentConfigurationType = {
   id: ModelId;
 
   sId: string;
   version: number;
   // Global agents have a null authorId, others have a non-null authorId
   versionAuthorId: ModelId | null;
+
+  // If undefined, no text generation.
+  generation: AgentGenerationConfigurationType | null;
 
   status: AgentConfigurationStatus;
   scope: AgentConfigurationScope;
@@ -135,16 +139,14 @@ export type AgentConfigurationType = {
   description: string;
   pictureUrl: string;
 
+  // `lastAuthors` is expensive to compute, so we only compute it when needed.
+  lastAuthors?: AgentRecentAuthors;
+  // Usage is expensive to compute, so we only compute it when needed.
+  usage?: AgentUsageType;
+};
+
+export type AgentConfigurationType = LightAgentConfigurationType & {
   // If undefined, no action performed, otherwise the action is
   // performed (potentially NoOp eg autoSkip above).
   action: AgentActionConfigurationType | null;
-
-  // If undefined, no text generation.
-  generation: AgentGenerationConfigurationType | null;
-
-  // Usage is expensive to compute, so we only compute it when needed.
-  usage?: AgentUsageType;
-
-  // `lastAuthors` is expensive to compute, so we only compute it when needed.
-  lastAuthors?: AgentRecentAuthors;
 };

--- a/types/src/front/assistant/conversation.ts
+++ b/types/src/front/assistant/conversation.ts
@@ -1,7 +1,7 @@
 import { DatabaseQueryActionType } from "../../front/assistant/actions/database_query";
 import { DustAppRunActionType } from "../../front/assistant/actions/dust_app_run";
 import { RetrievalActionType } from "../../front/assistant/actions/retrieval";
-import { AgentConfigurationType } from "../../front/assistant/agent";
+import { LightAgentConfigurationType } from "../../front/assistant/agent";
 import { UserType, WorkspaceType } from "../../front/user";
 import { ModelId } from "../../shared/model_id";
 
@@ -109,7 +109,7 @@ export type AgentMessageType = {
   version: number;
   parentMessageId: string | null;
 
-  configuration: AgentConfigurationType;
+  configuration: LightAgentConfigurationType;
   status: AgentMessageStatus;
   action: AgentActionType | null;
   content: string | null;

--- a/types/src/front/lib/dust_api.ts
+++ b/types/src/front/lib/dust_api.ts
@@ -6,7 +6,7 @@ import {
   PublicPostConversationsRequestBodySchema,
   PublicPostMessagesRequestBodySchema,
 } from "../../front/api_handlers/public/assistant";
-import { AgentConfigurationType } from "../../front/assistant/agent";
+import { LightAgentConfigurationType } from "../../front/assistant/agent";
 import {
   AgentMessageType,
   ContentFragmentType,
@@ -464,7 +464,7 @@ export class DustAPI {
     if (json.error) {
       return new Err(json.error as DustAPIErrorResponse);
     }
-    return new Ok(json.agentConfigurations as AgentConfigurationType[]);
+    return new Ok(json.agentConfigurations as LightAgentConfigurationType[]);
   }
 
   async postContentFragment({


### PR DESCRIPTION
The same as the (already approved, merged, deployed, reverted) buggy refacto PR, but includes the fix for global agents. The `getAgentConfiguration` was failing when trying to get a a global agent.