### PR TITLE
Add Banner component

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.67",
+  "version": "0.2.68",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.67",
+      "version": "0.2.68",
       "license": "ISC",
       "dependencies": {
         "@headlessui/react": "^1.7.17"

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.67",
+  "version": "0.2.68",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/_index.ts
+++ b/sparkle/src/_index.ts
@@ -25,6 +25,9 @@ export { ContextItem };
 import { AssistantPreview } from "./components/AssistantPreview";
 export { AssistantPreview };
 
+import { Banner } from "./components/Banner";
+export { Banner };
+
 import { Chip } from "./components/Chip";
 export { Chip };
 

--- a/sparkle/src/components/Banner.tsx
+++ b/sparkle/src/components/Banner.tsx
@@ -5,16 +5,19 @@ import { XMark } from "@sparkle/icons/solid";
 import { classNames } from "@sparkle/lib/utils";
 
 interface BannerProps {
+  allowDismiss: boolean;
   classNames: string;
   ctaLabel?: string;
   hidden: boolean;
   label: string;
   onClick?: () => void;
+  onDismiss?: () => void;
   title: string;
 }
 
 // Define defaultProps for the Banner component.
 Banner.defaultProps = {
+  allowDismiss: true,
   classNames: "",
   hidden: false,
 };
@@ -53,7 +56,12 @@ export function Banner(props: BannerProps) {
       <div className="s-flex s-flex-1 s-justify-end">
         <a
           className="focus-visible:outline-offset-[-4px] s--m-3 s-p-3"
-          onClick={() => setIsDismissed(true)}
+          onClick={() => {
+            setIsDismissed(true);
+            if (props.onDismiss) {
+              props.onDismiss();
+            }
+          }}
         >
           <span className="s-sr-only">Dismiss</span>
           <XMark className="s-h-5 s-w-5 s-text-white" aria-hidden="true" />

--- a/sparkle/src/components/Banner.tsx
+++ b/sparkle/src/components/Banner.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 
 import { Button } from "@sparkle/_index";
 import { XMark } from "@sparkle/icons/solid";
@@ -23,7 +23,11 @@ Banner.defaultProps = {
 };
 
 export function Banner(props: BannerProps) {
-  const [isDismissed, setIsDismissed] = useState(props.hidden ?? false);
+  const [isDismissed, setIsDismissed] = useState(true);
+
+  useEffect(() => {
+    setIsDismissed(props.hidden);
+  }, [props.hidden]);
 
   return isDismissed ? (
     <></>

--- a/sparkle/src/components/Banner.tsx
+++ b/sparkle/src/components/Banner.tsx
@@ -1,0 +1,64 @@
+import React, { useState } from "react";
+
+import { Button } from "@sparkle/_index";
+import { XMark } from "@sparkle/icons/solid";
+import { classNames } from "@sparkle/lib/utils";
+
+interface BannerProps {
+  classNames: string;
+  ctaLabel?: string;
+  hidden: boolean;
+  label: string;
+  onClick?: () => void;
+  title: string;
+}
+
+// Define defaultProps for the Banner component.
+Banner.defaultProps = {
+  classNames: "",
+  hidden: false,
+};
+
+export function Banner(props: BannerProps) {
+  const [isDismissed, setIsDismissed] = useState(props.hidden ?? false);
+
+  return isDismissed ? (
+    <></>
+  ) : (
+    <div
+      className={classNames(
+        "sm:s-before:flex-1 s-flex s-items-center s-gap-x-6 s-px-6 s-py-2.5 sm:s-px-3.5",
+        props.classNames
+      )}
+    >
+      <div className="s-flex s-flex-1"></div>
+      <div className="s-flex s-flex-row s-flex-wrap s-items-center s-gap-4">
+        <p className="s-gap-4 s-text-sm s-leading-6 s-text-white">
+          <strong className="s-font-semibold">{props.title}</strong>
+          <svg
+            viewBox="0 0 2 2"
+            className="s-mx-2 s-inline s-h-0.5 s-w-0.5 s-fill-current"
+            aria-hidden="true"
+          ></svg>
+          {props.label}
+        </p>
+        {props.ctaLabel && (
+          <Button
+            label={props.ctaLabel}
+            variant="tertiary"
+            onClick={props.onClick}
+          />
+        )}
+      </div>
+      <div className="s-flex s-flex-1 s-justify-end">
+        <a
+          className="focus-visible:outline-offset-[-4px] s--m-3 s-p-3"
+          onClick={() => setIsDismissed(true)}
+        >
+          <span className="s-sr-only">Dismiss</span>
+          <XMark className="s-h-5 s-w-5 s-text-white" aria-hidden="true" />
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/sparkle/src/stories/Banner.stories.tsx
+++ b/sparkle/src/stories/Banner.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta } from "@storybook/react";
+import React from "react";
+
+import { Banner } from "@sparkle/components/Banner";
+
+const meta = {
+  title: "Molecule/Banner",
+  component: Banner,
+} satisfies Meta<typeof Banner>;
+
+export default meta;
+
+export const BasicBanner = () => {
+  return (
+    <div className="s-h-full s-w-full">
+      <Banner
+        classNames="s-bg-indigo-600"
+        ctaLabel="Register now"
+        label="Join us in Denver from June 7 – 9 to see what’s coming next&nbsp;"
+        onClick={() => {
+          alert(`Button clicked`);
+        }}
+        title="GeneriCon 2023"
+      />
+    </div>
+  );
+};


### PR DESCRIPTION
This adds a new `Banner` component in our Sparkle library. This is needed for https://github.com/dust-tt/tasks/issues/330.

<img width="1066" alt="image" src="https://github.com/dust-tt/dust/assets/7428970/1f28db0c-ee94-4ac7-aa09-3b656c18a695">
