### PR TITLE
githubCodeSync: incremental syncing

### DIFF
--- a/connectors/src/admin/db.ts
+++ b/connectors/src/admin/db.ts
@@ -8,6 +8,7 @@ import {
 import {
   GithubCodeDirectory,
   GithubCodeFile,
+  GithubCodeRepository,
   GithubConnectorState,
   GithubDiscussion,
   GithubIssue,
@@ -59,6 +60,7 @@ async function main(): Promise<void> {
   await GithubConnectorState.sync({ alter: true });
   await GithubIssue.sync({ alter: true });
   await GithubDiscussion.sync({ alter: true });
+  await GithubCodeRepository.sync({ alter: true });
   await GithubCodeFile.sync({ alter: true });
   await GithubCodeDirectory.sync({ alter: true });
   await GoogleDriveFolders.sync({ alter: true });

--- a/connectors/src/api/webhooks/webhook_github.ts
+++ b/connectors/src/api/webhooks/webhook_github.ts
@@ -255,13 +255,17 @@ const _webhookGithubAPIHandler = async (
             res
           );
         } else if (jsonBody.action === "closed") {
-          return syncCode(
-            enabledConnectors,
-            jsonBody.organization.login,
-            jsonBody.repository.name,
-            jsonBody.repository.id,
-            res
-          );
+          if (jsonBody.pull_request.merged) {
+            return syncCode(
+              enabledConnectors,
+              jsonBody.organization.login,
+              jsonBody.repository.name,
+              jsonBody.repository.id,
+              res
+            );
+          } else {
+            return res.status(200).end();
+          }
         } else {
           assertNever(jsonBody.action);
         }
@@ -426,7 +430,7 @@ async function syncCode(
         return;
       }
 
-      const SYNCING_INTERVAL = 1000 * 60 * 60 * 8; // 8 day
+      const SYNCING_INTERVAL = 1000 * 60 * 60 * 8; // 8h
       if (
         githubCodeRepository.lastSeenAt.getTime() >
         Date.now() - SYNCING_INTERVAL

--- a/connectors/src/api/webhooks/webhook_github.ts
+++ b/connectors/src/api/webhooks/webhook_github.ts
@@ -31,7 +31,7 @@ const HANDLED_WEBHOOKS = {
   installation_repositories: new Set(["added", "removed"]),
   issues: new Set(["opened", "edited", "deleted"]),
   issue_comment: new Set(["created", "edited", "deleted"]),
-  pull_request: new Set(["opened", "edited"]),
+  pull_request: new Set(["opened", "edited", "closed"]),
   discussion: new Set(["created", "edited", "deleted"]),
   discussion_comment: new Set(["created", "edited", "deleted"]),
 } as Record<string, Set<string>>;
@@ -250,6 +250,8 @@ const _webhookGithubAPIHandler = async (
             jsonBody.pull_request.number,
             res
           );
+        } else if (jsonBody.action === "closed") {
+          // Syncing logic
         } else {
           assertNever(jsonBody.action);
         }

--- a/connectors/src/connectors/github/lib/github_api.ts
+++ b/connectors/src/connectors/github/lib/github_api.ts
@@ -697,9 +697,7 @@ export async function processRepository({
 
     // Iterate over the files in the temp directory.
     for await (const file of getFiles(tempDir)) {
-      // get file extension
       const ext = extname(file).toLowerCase();
-      // get file size
       const { size } = await fs.stat(file);
 
       const isWithelisted =

--- a/connectors/src/connectors/github/lib/github_webhooks.ts
+++ b/connectors/src/connectors/github/lib/github_webhooks.ts
@@ -92,10 +92,15 @@ export function isCommentPayload(payload: unknown): payload is CommentPayload {
 const PullRequestSchema = t.type({
   id: t.number,
   number: t.number,
+  merged: t.boolean,
 });
 
 const PullRequestPayloadSchema = t.type({
-  action: t.union([t.literal("opened"), t.literal("edited")]),
+  action: t.union([
+    t.literal("opened"),
+    t.literal("edited"),
+    t.literal("closed"),
+  ]),
   pull_request: PullRequestSchema,
   organization: OrganizationSchema,
   repository: RepositorySchema,

--- a/connectors/src/connectors/github/temporal/client.ts
+++ b/connectors/src/connectors/github/temporal/client.ts
@@ -152,10 +152,15 @@ export async function launchGithubCodeSyncWorkflow(
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
   const githubInstallationId = connector.connectionId;
 
-  await client.workflow.start(githubCodeSyncWorkflow, {
+  await client.workflow.signalWithStart(githubCodeSyncWorkflow, {
     args: [dataSourceConfig, githubInstallationId, repoName, repoId, repoLogin],
     taskQueue: QUEUE_NAME,
     workflowId: getCodeSyncWorkflowId(dataSourceConfig, repoId),
+    searchAttributes: {
+      connectorId: [parseInt(connectorId)],
+    },
+    signal: newWebhookSignal,
+    signalArgs: undefined,
     memo: {
       connectorId: connectorId,
     },

--- a/connectors/src/lib/models/github.ts
+++ b/connectors/src/lib/models/github.ts
@@ -159,6 +159,70 @@ GithubDiscussion.init(
 );
 Connector.hasMany(GithubDiscussion);
 
+export class GithubCodeRepository extends Model<
+  InferAttributes<GithubCodeRepository>,
+  InferCreationAttributes<GithubCodeRepository>
+> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+  declare lastSeenAt: CreationOptional<Date>;
+
+  declare repoId: string;
+  declare repoLogin: string;
+  declare repoName: string;
+
+  declare sourceUrl: string;
+
+  declare connectorId: ForeignKey<Connector["id"]>;
+}
+GithubCodeRepository.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    lastSeenAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    repoId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    repoLogin: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    repoName: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    sourceUrl: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+  },
+  {
+    sequelize: sequelize_conn,
+    indexes: [{ fields: ["connectorId", "repoId"], unique: true }],
+    modelName: "github_code_repositories",
+  }
+);
+Connector.hasMany(GithubCodeRepository);
+
 export class GithubCodeFile extends Model<
   InferAttributes<GithubCodeFile>,
   InferCreationAttributes<GithubCodeFile>


### PR DESCRIPTION
Fixes [#3107](https://github.com/dust-tt/dust/issues/3107)

- Make codeSyncWorkflow signal based (10s debounce)
- Introduce GithubCodeRepository to track last sync times
- Signal the code syncing workflow based on PR webhooks only if repo was not synced for 8h

(the last step can race but since we debounce 10s the workflow, this will result in at most one workflow being started every 8h + no error if there are PR merge events racing through the code path)

Deploy:
- deploy connectors-edge, run init_db
- deploy connectors