### PR TITLE
Set `allowedDomain` on Workspace's creation.

### DIFF
--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -159,9 +159,12 @@ async function handler(
         // If there is no invte, we create a personal workspace for the user, otherwise the user
         // will be added to the workspace they were invited to (either by email or by domain) below.
         if (!workspaceInvite && !membershipInvite) {
+          const [, emailDomain] = session.user.email.split("@");
           const w = await Workspace.create({
             sId: generateModelSId(),
             name: session.user.username,
+            // Only set allowedDomain if the email was verified.
+            allowedDomain: session.user.email_verified ? emailDomain : null,
           });
 
           await _createAndLogMembership({

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -161,14 +161,15 @@ async function handler(
         // will be added to the workspace they were invited to (either by email or by domain) below.
         if (!workspaceInvite && !membershipInvite) {
           const [, emailDomain] = session.user.email.split("@");
+          // Only set `allowedDomain` if the email is verified and not disposable.
           const allowedDomain =
-            session.user.email_verified &&
-            !isDisposableEmailDomain(emailDomain);
+            session.user.email_verified && !isDisposableEmailDomain(emailDomain)
+              ? emailDomain
+              : null;
           const w = await Workspace.create({
             sId: generateModelSId(),
             name: session.user.username,
-            // Only set allowedDomain if the email was verified.
-            allowedDomain: allowedDomain ?? null,
+            allowedDomain,
           });
 
           await _createAndLogMembership({


### PR DESCRIPTION
Continuing with enhancements to the onboarding process, this PR configures the `allowedDomain` during workspace creation when the user's email has been verified.