### PR TITLE
Add `domainAutoJoinEnabled` field + index

### DIFF
--- a/front/lib/models/workspace.ts
+++ b/front/lib/models/workspace.ts
@@ -22,11 +22,12 @@ export class Workspace extends Model<
   declare updatedAt: CreationOptional<Date>;
   declare upgradedAt: Date | null;
 
-  declare sId: string;
-  declare name: string;
-  declare description: string | null;
   declare allowedDomain: string | null;
+  declare description: string | null;
+  declare domainAutoJoinEnabled: boolean;
+  declare name: string;
   declare segmentation: WorkspaceSegmentationType;
+  declare sId: string;
   declare subscriptions: NonAttribute<Subscription[]>;
 }
 Workspace.init(
@@ -54,6 +55,10 @@ Workspace.init(
       type: DataTypes.STRING,
       allowNull: false,
     },
+    domainAutoJoinEnabled: {
+      type: DataTypes.BOOLEAN,
+      defaultValue: "false",
+    },
     name: {
       type: DataTypes.STRING,
       allowNull: false,
@@ -73,7 +78,10 @@ Workspace.init(
   {
     modelName: "workspace",
     sequelize: front_sequelize,
-    indexes: [{ unique: true, fields: ["sId"] }],
+    indexes: [
+      { unique: true, fields: ["sId"] },
+      { fields: ["allowedDomain", "domainAutoJoinEnabled"] },
+    ],
   }
 );
 

--- a/front/lib/models/workspace.ts
+++ b/front/lib/models/workspace.ts
@@ -24,7 +24,7 @@ export class Workspace extends Model<
 
   declare allowedDomain: string | null;
   declare description: string | null;
-  declare domainAutoJoinEnabled: boolean;
+  declare domainAutoJoinEnabled: CreationOptional<boolean>;
   declare name: string;
   declare segmentation: WorkspaceSegmentationType;
   declare sId: string;


### PR DESCRIPTION
This PR introduces a new column `domainAutoJoinEnabled` to the `workspaces` table and creates a composite index by combining `allowedDomain` and `domainAutoJoinEnabled`. This addition is necessary to efficiently find a workspace that corresponds with the domain of a user's email during sign-up.