### PR TITLE
Fix/types no absolute

### DIFF
--- a/types/src/front/api_handlers/public/data_sources.ts
+++ b/types/src/front/api_handlers/public/data_sources.ts
@@ -1,5 +1,6 @@
-import { CoreAPIDataSourceDocumentSection } from "core/data_source";
 import * as t from "io-ts";
+
+import { CoreAPIDataSourceDocumentSection } from "../../../core/data_source";
 
 const UpsertContextSchema = t.type({
   sync_type: t.union([

--- a/types/src/front/assistant/actions/tables_query.ts
+++ b/types/src/front/assistant/actions/tables_query.ts
@@ -1,5 +1,4 @@
-import { DustAppParameters } from "front/assistant/actions/dust_app_run";
-
+import { DustAppParameters } from "../../../front/assistant/actions/dust_app_run";
 import { ModelId } from "../../../shared/model_id";
 
 export type TablesQueryConfigurationType = {

--- a/types/src/front/lib/dust_api.ts
+++ b/types/src/front/lib/dust_api.ts
@@ -1,5 +1,4 @@
 import { createParser } from "eventsource-parser";
-import { CoreAPITokenType } from "front/lib/core_api";
 import * as t from "io-ts";
 
 import {
@@ -15,6 +14,7 @@ import {
   UserMessageType,
 } from "../../front/assistant/conversation";
 import { DataSourceType } from "../../front/data_source";
+import { CoreAPITokenType } from "../../front/lib/core_api";
 import { Err, Ok, Result } from "../../front/lib/result";
 import { RunType } from "../../front/run";
 import { LoggerInterface } from "../../shared/logger";

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -6,7 +6,6 @@
     "moduleResolution": "node",
     "emitDeclarationOnly": false,
     "declaration": true,
-    "baseUrl": "./src",
     "sourceMap": true,
     "declarationMap": true
   }


### PR DESCRIPTION
fixes https://github.com/dust-tt/tasks/issues/336

My other PR (https://github.com/dust-tt/dust/pull/3147) need to be merged first -- several of those imports are being fixed there and I wanted to avoid a painful rebase.

For context, those baseDir imports in `types` cause some very sneaky issues where some types are silently widened as `any`. 