### PR TITLE
Flav/table workspace has domains

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -35,6 +35,7 @@ import {
   UserMessage,
   UserMetadata,
   Workspace,
+  WorkspaceHasDomain,
   XP1Run,
   XP1User,
 } from "@app/lib/models";
@@ -49,6 +50,7 @@ async function main() {
   await User.sync({ alter: true });
   await UserMetadata.sync({ alter: true });
   await Workspace.sync({ alter: true });
+  await WorkspaceHasDomain.sync({ alter: true });
   await Membership.sync({ alter: true });
   await MembershipInvitation.sync({ alter: true });
   await App.sync({ alter: true });

--- a/front/lib/models/index.ts
+++ b/front/lib/models/index.ts
@@ -41,6 +41,7 @@ import {
   Membership,
   MembershipInvitation,
   Workspace,
+  WorkspaceHasDomain,
 } from "@app/lib/models/workspace";
 import { XP1Run, XP1User } from "@app/lib/models/xp1";
 
@@ -82,6 +83,7 @@ export {
   UserMessage,
   UserMetadata,
   Workspace,
+  WorkspaceHasDomain,
   XP1Run,
   XP1User,
 };

--- a/front/lib/models/workspace.ts
+++ b/front/lib/models/workspace.ts
@@ -108,7 +108,7 @@ WorkspaceHasDomain.init(
     },
     domainAutoJoinEnabled: {
       type: DataTypes.BOOLEAN,
-      defaultValue: "false",
+      defaultValue: false,
     },
     domain: {
       type: DataTypes.STRING,

--- a/front/lib/models/workspace.ts
+++ b/front/lib/models/workspace.ts
@@ -77,6 +77,56 @@ Workspace.init(
   }
 );
 
+export class WorkspaceHasDomain extends Model<
+  InferAttributes<WorkspaceHasDomain>,
+  InferCreationAttributes<WorkspaceHasDomain>
+> {
+  declare createdAt: CreationOptional<Date>;
+  declare domain: string;
+  declare domainAutoJoinEnabled: CreationOptional<boolean>;
+  declare id: CreationOptional<number>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare workspaceId: ForeignKey<Workspace["id"]>;
+}
+WorkspaceHasDomain.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    domainAutoJoinEnabled: {
+      type: DataTypes.BOOLEAN,
+      defaultValue: "false",
+    },
+    domain: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+  },
+  {
+    modelName: "workspace_has_domains",
+    sequelize: front_sequelize,
+    indexes: [{ unique: true, fields: ["domain", "domainAutoJoinEnabled"] }],
+  }
+);
+Workspace.hasMany(WorkspaceHasDomain, {
+  foreignKey: { allowNull: false },
+  onDelete: "CASCADE",
+});
+WorkspaceHasDomain.belongsTo(Workspace);
+
 export class Membership extends Model<
   InferAttributes<Membership>,
   InferCreationAttributes<Membership>

--- a/front/lib/models/workspace.ts
+++ b/front/lib/models/workspace.ts
@@ -118,7 +118,7 @@ WorkspaceHasDomain.init(
   {
     modelName: "workspace_has_domains",
     sequelize: front_sequelize,
-    indexes: [{ unique: true, fields: ["domain", "domainAutoJoinEnabled"] }],
+    indexes: [{ unique: true, fields: ["domain"] }],
   }
 );
 Workspace.hasMany(WorkspaceHasDomain, {

--- a/front/migrations/backfill_workspace_has_domains.ts
+++ b/front/migrations/backfill_workspace_has_domains.ts
@@ -25,6 +25,7 @@ makeScript({}, async ({ execute }) => {
       if (execute) {
         await WorkspaceHasDomain.create({
           domain: workspace.allowedDomain,
+          domainAutoJoinEnabled: true,
         });
       }
 

--- a/front/migrations/backfill_workspace_has_domains.ts
+++ b/front/migrations/backfill_workspace_has_domains.ts
@@ -1,8 +1,7 @@
 import { Op } from "sequelize";
 
-import { Membership, User, Workspace } from "@app/lib/models";
+import { Workspace } from "@app/lib/models";
 import { WorkspaceHasDomain } from "@app/lib/models/workspace";
-import { isDisposableEmailDomain } from "@app/lib/utils/disposable_email_domains";
 import { makeScript } from "@app/migrations/helpers";
 
 makeScript({}, async ({ execute }) => {
@@ -23,9 +22,12 @@ makeScript({}, async ({ execute }) => {
     }
 
     try {
-      await WorkspaceHasDomain.create({
-        domain: workspace.allowedDomain,
-      });
+      if (execute) {
+        await WorkspaceHasDomain.create({
+          domain: workspace.allowedDomain,
+        });
+      }
+
       updatedWorkspacesCount++;
     } catch (err) {
       console.log(

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -193,8 +193,6 @@ async function handler(
         // If there is no invte, we create a personal workspace for the user, otherwise the user
         // will be added to the workspace they were invited to (either by email or by domain) below.
         if (!workspaceInvite && !membershipInvite) {
-          // We keep `allowedDomain` until we have full support around `WorkspaceHasDomain`.
-
           const workspace = await createWorkspace(session);
           await _createAndLogMembership({
             workspace,

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -27,9 +27,11 @@ const { DUST_INVITE_TOKEN_SECRET = "" } = process.env;
 async function createWorkspace(session: any) {
   const [, emailDomain] = session.user.email.split("@");
 
-  // Use domain only when email is verified and non-disposable.
+  // Use domain only when email is verified on Google Workspace and non-disposable.
+  const isEmailVerified =
+    session.provider.provider !== "google" && session.user.email_verified;
   const verifiedDomain =
-    session.user.email_verified && !isDisposableEmailDomain(emailDomain)
+    isEmailVerified && !isDisposableEmailDomain(emailDomain)
       ? emailDomain
       : null;
 

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -10,6 +10,7 @@ import {
   User,
   Workspace,
 } from "@app/lib/models";
+import { WorkspaceHasDomain } from "@app/lib/models/workspace";
 import {
   internalSubscribeWorkspaceToFreeTestPlan,
   updateWorkspacePerSeatSubscriptionUsage,
@@ -22,6 +23,36 @@ import { apiError, withLogging } from "@app/logger/withlogging";
 import { authOptions } from "./auth/[...nextauth]";
 
 const { DUST_INVITE_TOKEN_SECRET = "" } = process.env;
+
+async function createWorkspace(session: any) {
+  const [, emailDomain] = session.user.email.split("@");
+
+  // Use domain only when email is verified and non-disposable.
+  const verifiedDomain =
+    session.user.email_verified && !isDisposableEmailDomain(emailDomain)
+      ? emailDomain
+      : null;
+
+  const workspace = await Workspace.create({
+    sId: generateModelSId(),
+    name: session.user.username,
+    // TODO(2024-01-15 flav) Deprecate after full release of `WorkflowHasDomain`.
+    allowedDomain: verifiedDomain,
+  });
+
+  if (verifiedDomain) {
+    try {
+      await WorkspaceHasDomain.create({
+        domain: verifiedDomain,
+      });
+    } catch (err) {
+      // `WorkspaceHasDomain` table has a unique constraint on the domain column.
+      // Suppress any creation errors to prevent disruption of the login process.
+    }
+  }
+
+  return workspace;
+}
 
 async function handler(
   req: NextApiRequest,
@@ -160,26 +191,17 @@ async function handler(
         // If there is no invte, we create a personal workspace for the user, otherwise the user
         // will be added to the workspace they were invited to (either by email or by domain) below.
         if (!workspaceInvite && !membershipInvite) {
-          const [, emailDomain] = session.user.email.split("@");
-          // Only set `allowedDomain` if the email is verified and not disposable.
-          const allowedDomain =
-            session.user.email_verified && !isDisposableEmailDomain(emailDomain)
-              ? emailDomain
-              : null;
-          const w = await Workspace.create({
-            sId: generateModelSId(),
-            name: session.user.username,
-            allowedDomain,
-          });
+          // We keep `allowedDomain` until we have full support around `WorkspaceHasDomain`.
 
+          const workspace = await createWorkspace(session);
           await _createAndLogMembership({
-            workspace: w,
+            workspace,
             userId: user.id,
             role: "admin",
           });
 
           await internalSubscribeWorkspaceToFreeTestPlan({
-            workspaceId: w.sId,
+            workspaceId: workspace.sId,
           });
           isAdminOnboarding = true;
         }


### PR DESCRIPTION
This PR marks a step forward in improving our onboarding process by establishing a clear association between workspaces and their corresponding domains. To achieve this, we're introducing a new table named `workspace_has_domains`. This table is designed to maintain the domain uniqueness, ensuring that each verified domain is exclusively linked to a single workspace.

A review of the database has been done to resolve any existing domain duplicates. This ensures we can confidently implement this new table without any conflicts.

The system is set up to automatically add an entry to this new table during the sign-up process whenever a user registers with a non-disposable and verified email address from Google Workspace.

Additionally, this PR includes a script to populate the `workspace_has_domains` table by transferring existing data from the `allowedDomain` field in the `workspaces` table.