### PR TITLE
fix getAgentConfiguration for archived agents

### DIFF
--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -185,9 +185,11 @@ export async function getAgentConfigurations<V extends "light" | "full">({
             return Promise.resolve([]);
           }
           return AgentConfiguration.findAll({
-            ...baseAgentsSequelizeQuery,
             where: {
-              ...baseAgentsSequelizeQuery.where,
+              workspaceId: owner.id,
+              ...(agentPrefix
+                ? { name: { [Op.iLike]: `${agentPrefix}%` } }
+                : {}),
               sId: agentsGetView.agentId,
             },
           });


### PR DESCRIPTION
We were using the base query (that has a filter on active) when getting a single agentConfiguration by sId.
This changes the where clause to not filter on status.

