### PR TITLE
Handle Slack user not found.

### DIFF
--- a/connectors/src/connectors/slack/lib/errors.ts
+++ b/connectors/src/connectors/slack/lib/errors.ts
@@ -1,0 +1,12 @@
+import { ErrorCode, WebAPIPlatformError } from "@slack/web-api";
+
+export function isSlackWebAPIPlatformError(
+  err: unknown
+): err is WebAPIPlatformError {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "code" in err &&
+    err.code === ErrorCode.PlatformError
+  );
+}

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -24,6 +24,7 @@ import {
   joinChannel,
   updateSlackChannelInConnectorsDb,
 } from "@connectors/connectors/slack/lib/channels";
+import { isSlackWebAPIPlatformError } from "@connectors/connectors/slack/lib/errors";
 import { getSlackClient } from "@connectors/connectors/slack/lib/slack_client";
 import { getRepliesFromThread } from "@connectors/connectors/slack/lib/thread";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
@@ -802,9 +803,15 @@ export async function getUserName(
 
     return undefined;
   } catch (err) {
-    logger.info({ connectorId, slackUserId }, "Slack user not found.");
+    if (isSlackWebAPIPlatformError(err)) {
+      if (err.data.error === "user_not_found") {
+        logger.info({ connectorId, slackUserId }, "Slack user not found.");
 
-    return undefined;
+        return undefined;
+      }
+    }
+
+    throw err;
   }
 }
 

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -786,19 +786,26 @@ export async function getUserName(
     return fromCache;
   }
 
-  const info = await slackClient.users.info({ user: slackUserId });
+  try {
+    const info = await slackClient.users.info({ user: slackUserId });
 
-  if (info && info.user) {
-    const displayName = info.user.profile?.display_name;
-    const realName = info.user.profile?.real_name;
-    const userName = displayName || realName || info.user.name;
+    if (info && info.user) {
+      const displayName = info.user.profile?.display_name;
+      const realName = info.user.profile?.real_name;
+      const userName = displayName || realName || info.user.name;
 
-    if (userName) {
-      await cacheSet(getUserCacheKey(slackUserId, connectorId), userName);
-      return info.user.name;
+      if (userName) {
+        await cacheSet(getUserCacheKey(slackUserId, connectorId), userName);
+        return info.user.name;
+      }
     }
+
+    return undefined;
+  } catch (err) {
+    logger.info({ connectorId, slackUserId }, "Slack user not found.");
+
+    return undefined;
   }
-  return;
 }
 
 function getUserCacheKey(userId: string, connectorId: ModelId) {


### PR DESCRIPTION
This PR addresses the issue of 'Slack user not found,' which occurs quite frequently and create noise in the unhandled activities. Reviewing the call sites where the function is called, it appears that this modification is okay since there is already a check for the presence of the username where the function is invoked.