### PR TITLE
Fix: handle chunking documents with arbitray prefix

### DIFF
--- a/connectors/src/connectors/github/temporal/activities.ts
+++ b/connectors/src/connectors/github/temporal/activities.ts
@@ -94,6 +94,7 @@ export async function githubGetRepoIssuesResultPageActivity(
 }
 
 async function renderIssue(
+  dataSourceConfig: DataSourceConfig,
   installationId: string,
   repoName: string,
   repoId: number,
@@ -113,10 +114,13 @@ async function renderIssue(
   const issue = await getIssue(installationId, repoName, login, issueNumber);
 
   const content = await renderDocumentTitleAndContent({
+    dataSourceConfig,
     title: `Issue #${issue.number} [${repoName}]: ${issue.title}`,
     createdAt: issue.createdAt,
     updatedAt: issue.updatedAt,
-    content: await renderMarkdownSection(issue.body ?? "", { flavor: "gfm" }),
+    content: await renderMarkdownSection(dataSourceConfig, issue.body ?? "", {
+      flavor: "gfm",
+    }),
   });
 
   let resultPage = 1;
@@ -156,7 +160,9 @@ async function renderIssue(
           prefix: `>> ${renderGithubUser(comment.creator)}:\n`,
           content: null,
           sections: [
-            await renderMarkdownSection(comment.body, { flavor: "gfm" }),
+            await renderMarkdownSection(dataSourceConfig, comment.body, {
+              flavor: "gfm",
+            }),
           ],
         };
         content.sections.push(c);
@@ -206,6 +212,7 @@ export async function githubUpsertIssueActivity(
     updatedAtTimestamp,
     content: renderedIssue,
   } = await renderIssue(
+    dataSourceConfig,
     installationId,
     repoName,
     repoId,
@@ -269,9 +276,9 @@ export async function githubUpsertIssueActivity(
 }
 
 async function renderDiscussion(
+  dataSourceConfig: DataSourceConfig,
   installationId: string,
   repoName: string,
-  repoId: number,
   login: string,
   discussionNumber: number,
   loggerArgs: Record<string, string | number>
@@ -289,12 +296,17 @@ async function renderDiscussion(
   );
 
   const content = await renderDocumentTitleAndContent({
+    dataSourceConfig,
     title: `Discussion #${discussion.number} [${repoName}]: ${discussion.title}`,
     createdAt: new Date(discussion.createdAt),
     updatedAt: new Date(discussion.updatedAt),
-    content: await renderMarkdownSection(discussion.bodyText, {
-      flavor: "gfm",
-    }),
+    content: await renderMarkdownSection(
+      dataSourceConfig,
+      discussion.bodyText,
+      {
+        flavor: "gfm",
+      }
+    ),
   });
 
   let nextCursor: string | null = null;
@@ -326,7 +338,9 @@ async function renderDiscussion(
         prefix,
         content: null,
         sections: [
-          await renderMarkdownSection(comment.bodyText, { flavor: "gfm" }),
+          await renderMarkdownSection(dataSourceConfig, comment.bodyText, {
+            flavor: "gfm",
+          }),
         ],
       };
       content.sections.push(c);
@@ -352,7 +366,9 @@ async function renderDiscussion(
             prefix: `>> ${childComment.author?.login || "Unknown author"}:\n`,
             content: null,
             sections: [
-              await renderMarkdownSection(comment.bodyText, { flavor: "gfm" }),
+              await renderMarkdownSection(dataSourceConfig, comment.bodyText, {
+                flavor: "gfm",
+              }),
             ],
           };
           c.sections.push(cc);
@@ -397,9 +413,9 @@ export async function githubUpsertDiscussionActivity(
   localLogger.info("Upserting GitHub discussion.");
 
   const { discussion, content: renderedDiscussion } = await renderDiscussion(
+    dataSourceConfig,
     installationId,
     repoName,
-    repoId,
     login,
     discussionNumber,
     loggerArgs

--- a/connectors/src/connectors/github/temporal/activities.ts
+++ b/connectors/src/connectors/github/temporal/activities.ts
@@ -112,11 +112,11 @@ async function renderIssue(
 
   const issue = await getIssue(installationId, repoName, login, issueNumber);
 
-  const content = renderDocumentTitleAndContent({
+  const content = await renderDocumentTitleAndContent({
     title: `Issue #${issue.number} [${repoName}]: ${issue.title}`,
     createdAt: issue.createdAt,
     updatedAt: issue.updatedAt,
-    content: renderMarkdownSection(issue.body ?? "", { flavor: "gfm" }),
+    content: await renderMarkdownSection(issue.body ?? "", { flavor: "gfm" }),
   });
 
   let resultPage = 1;
@@ -155,7 +155,9 @@ async function renderIssue(
         const c = {
           prefix: `>> ${renderGithubUser(comment.creator)}:\n`,
           content: null,
-          sections: [renderMarkdownSection(comment.body, { flavor: "gfm" })],
+          sections: [
+            await renderMarkdownSection(comment.body, { flavor: "gfm" }),
+          ],
         };
         content.sections.push(c);
       }
@@ -286,11 +288,13 @@ async function renderDiscussion(
     discussionNumber
   );
 
-  const content = renderDocumentTitleAndContent({
+  const content = await renderDocumentTitleAndContent({
     title: `Discussion #${discussion.number} [${repoName}]: ${discussion.title}`,
     createdAt: new Date(discussion.createdAt),
     updatedAt: new Date(discussion.updatedAt),
-    content: renderMarkdownSection(discussion.bodyText, { flavor: "gfm" }),
+    content: await renderMarkdownSection(discussion.bodyText, {
+      flavor: "gfm",
+    }),
   });
 
   let nextCursor: string | null = null;
@@ -321,7 +325,9 @@ async function renderDiscussion(
       const c = {
         prefix,
         content: null,
-        sections: [renderMarkdownSection(comment.bodyText, { flavor: "gfm" })],
+        sections: [
+          await renderMarkdownSection(comment.bodyText, { flavor: "gfm" }),
+        ],
       };
       content.sections.push(c);
 
@@ -346,7 +352,7 @@ async function renderDiscussion(
             prefix: `>> ${childComment.author?.login || "Unknown author"}:\n`,
             content: null,
             sections: [
-              renderMarkdownSection(comment.bodyText, { flavor: "gfm" }),
+              await renderMarkdownSection(comment.bodyText, { flavor: "gfm" }),
             ],
           };
           c.sections.push(cc);

--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -514,7 +514,7 @@ async function syncOneFile(
 
   documentContent = documentContent?.trim();
 
-  const content = renderDocumentTitleAndContent({
+  const content = await renderDocumentTitleAndContent({
     title: file.name,
     updatedAt: file.updatedAtMs ? new Date(file.updatedAtMs) : undefined,
     createdAt: file.createdAtMs ? new Date(file.createdAtMs) : undefined,

--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -515,6 +515,7 @@ async function syncOneFile(
   documentContent = documentContent?.trim();
 
   const content = await renderDocumentTitleAndContent({
+    dataSourceConfig,
     title: file.name,
     updatedAt: file.updatedAtMs ? new Date(file.updatedAtMs) : undefined,
     createdAt: file.createdAtMs ? new Date(file.createdAtMs) : undefined,

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -1610,7 +1610,7 @@ export async function renderAndUpsertPageFromCache({
   }
 
   localLogger.info("notionRenderAndUpsertPageFromCache: Rendering page.");
-  const renderedPageSection = renderPageSection({ blocksByParentId });
+  const renderedPageSection = await renderPageSection({ blocksByParentId });
   const documentLength = sectionLength(renderedPageSection);
 
   // add a newline to separate the page from the metadata above (title, author...)
@@ -1784,7 +1784,7 @@ export async function renderAndUpsertPageFromCache({
       runTimestamp.toString()
     );
 
-    const content = renderDocumentTitleAndContent({
+    const content = await renderDocumentTitleAndContent({
       title: title ?? null,
       createdAt: createdAt,
       updatedAt: updatedAt,
@@ -2022,11 +2022,11 @@ export async function getDiscoveredResourcesFromCache(
  * - only the 2 first levels of nesting are used to create prefixes, similarly
  *   to github, to avoid too many prefixes
  */
-function renderPageSection({
+async function renderPageSection({
   blocksByParentId,
 }: {
   blocksByParentId: Record<string, NotionConnectorBlockCacheEntry[]>;
-}): CoreAPIDataSourceDocumentSection {
+}): Promise<CoreAPIDataSourceDocumentSection> {
   const renderedPageSection: CoreAPIDataSourceDocumentSection = {
     prefix: null,
     content: null,
@@ -2087,11 +2087,11 @@ function renderPageSection({
     }
   }
 
-  const renderBlockSection = (
+  const renderBlockSection = async (
     b: NotionConnectorBlockCacheEntry,
     depth: number,
     indent = ""
-  ): CoreAPIDataSourceDocumentSection => {
+  ): Promise<CoreAPIDataSourceDocumentSection> => {
     // Initial rendering (remove base64 images from rendered block)
     let renderedBlock = b.blockText ? `${indent}${b.blockText}` : "";
     renderedBlock = renderedBlock
@@ -2105,7 +2105,7 @@ function renderPageSection({
     // Prefix for depths 0 and 1, and only if children
     const blockSection =
       depth < 1 && adaptedBlocksByParentId[b.notionBlockId]?.length
-        ? renderPrefixSection(renderedBlock)
+        ? await renderPrefixSection(renderedBlock)
         : {
             prefix: null,
             content: renderedBlock,
@@ -2119,7 +2119,9 @@ function renderPageSection({
       indent = `- ${indent}`;
     }
     for (const child of children) {
-      blockSection.sections.push(renderBlockSection(child, depth + 1, indent));
+      blockSection.sections.push(
+        await renderBlockSection(child, depth + 1, indent)
+      );
     }
     return blockSection;
   };
@@ -2127,7 +2129,7 @@ function renderPageSection({
   const topLevelBlocks = adaptedBlocksByParentId["root"] || [];
   topLevelBlocks.sort((a, b) => a.indexInParent - b.indexInParent);
   for (const block of topLevelBlocks) {
-    renderedPageSection.sections.push(renderBlockSection(block, 0));
+    renderedPageSection.sections.push(await renderBlockSection(block, 0));
   }
   return renderedPageSection;
 }

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -60,7 +60,7 @@ import {
 import { getAccessTokenFromNango } from "@connectors/lib/nango_helpers";
 import { syncStarted, syncSucceeded } from "@connectors/lib/sync_status";
 import mainLogger from "@connectors/logger/logger";
-import { DataSourceConfig } from "@connectors/types/data_source_config";
+import type { DataSourceConfig } from "@connectors/types/data_source_config";
 
 const { getRequiredNangoNotionConnectorId } = notionConfig;
 

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -2109,7 +2109,7 @@ async function renderPageSection({
 
     // Prefix for depths 0 and 1, and only if children
     const blockSection =
-      depth < 1 && adaptedBlocksByParentId[b.notionBlockId]?.length
+      depth < 2 && adaptedBlocksByParentId[b.notionBlockId]?.length
         ? await renderPrefixSection(dsConfig, renderedBlock)
         : {
             prefix: null,

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -24,6 +24,7 @@ import {
   isUserAllowedToUseChatbot,
 } from "@connectors/connectors/slack/lib/slack_client";
 import { getRepliesFromThread } from "@connectors/connectors/slack/lib/thread";
+import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { Connector } from "@connectors/lib/models";
 import {
   SlackChannel,
@@ -734,6 +735,7 @@ async function makeContentFragment(
   }
 
   const content = await formatMessagesForUpsert({
+    dataSourceConfig: dataSourceConfigFromConnector(connector),
     channelName: channel.channel.name,
     messages: allMessages,
     isThread: true,

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -422,6 +422,7 @@ export async function syncNonThreaded(
   messages.reverse();
 
   const content = await formatMessagesForUpsert({
+    dataSourceConfig,
     channelName,
     messages,
     isThread: false,
@@ -573,6 +574,7 @@ export async function syncThread(
   }
 
   const content = await formatMessagesForUpsert({
+    dataSourceConfig,
     channelName,
     messages: allMessages,
     isThread: true,
@@ -645,12 +647,14 @@ async function processMessageForMentions(
 }
 
 export async function formatMessagesForUpsert({
+  dataSourceConfig,
   channelName,
   messages,
   isThread,
   connectorId,
   slackClient,
 }: {
+  dataSourceConfig: DataSourceConfig;
   channelName: string;
   messages: MessageElement[];
   isThread: boolean;
@@ -697,6 +701,7 @@ export async function formatMessagesForUpsert({
     : `Messages in #${channelName}`;
 
   return renderDocumentTitleAndContent({
+    dataSourceConfig,
     title,
     createdAt: first.messageDate,
     updatedAt: last.messageDate,

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -256,6 +256,7 @@ export async function renderPrefixSection(
       sections: [],
     };
   }
+  prefix = prefix.trim();
   const tokens = (
     await tokenize(prefix.substring(0, MAX_PREFIX_CHARS), dataSourceConfig)
   ).map((token) => token[1]);

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -1,11 +1,13 @@
 import type {
-  cacheWithRedis,
   CoreAPIDataSourceDocumentSection,
-  DustAPI,
-  EMBEDDING_CONFIG,
   PostDataSourceDocumentRequestBody,
 } from "@dust-tt/types";
-import { sectionFullText } from "@dust-tt/types";
+import {
+  cacheWithRedis,
+  DustAPI,
+  EMBEDDING_CONFIG,
+  sectionFullText,
+} from "@dust-tt/types";
 import type { AxiosRequestConfig, AxiosResponse } from "axios";
 import axios from "axios";
 import { fromMarkdown } from "mdast-util-from-markdown";

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -2,12 +2,7 @@ import type {
   CoreAPIDataSourceDocumentSection,
   PostDataSourceDocumentRequestBody,
 } from "@dust-tt/types";
-import {
-  cacheWithRedis,
-  DustAPI,
-  EMBEDDING_CONFIG,
-  sectionFullText,
-} from "@dust-tt/types";
+import { DustAPI, EMBEDDING_CONFIG, sectionFullText } from "@dust-tt/types";
 import type { AxiosRequestConfig, AxiosResponse } from "axios";
 import axios from "axios";
 import { fromMarkdown } from "mdast-util-from-markdown";

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -256,7 +256,6 @@ export async function renderPrefixSection(
       sections: [],
     };
   }
-  prefix = prefix.trim();
   const tokens = (
     await tokenize(prefix.substring(0, MAX_PREFIX_CHARS), dataSourceConfig)
   ).map((token) => token[1]);
@@ -294,7 +293,8 @@ export const tokenize = cacheWithRedis(
         apiKey: ds.workspaceAPIKey,
         workspaceId: ds.workspaceId,
       },
-      logger
+      logger,
+      { useLocalInDev: true }
     );
     const tokensRes = await dustAPI.tokenize(text, ds.dataSourceName);
     if (tokensRes.isErr()) {

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -451,17 +451,3 @@ export function sectionLength(
     section.sections.reduce((acc, s) => acc + sectionLength(s), 0)
   );
 }
-
-async function test() {
-  const res = await _tokenize(
-    "had to be redone from scratch following markdown parsing issuehad to be redone from scratch following markdown parsing issuehad to be redone from scratch following markdown parsing issuehad to be redone from scratch following markdown parsing issuehad to be redone from scratch following markdown parsing issuehad to be redone from scratch following markdown parsing issuehad to be redone from scratch following markdown parsing issuehad to be redone from scratch following markdown parsing issue",
-    {
-      workspaceAPIKey: "sk-e5a6952ea5561e0044ad6590a87f7374",
-      workspaceId: "d64b211dc7",
-      dataSourceName: "managed-notion",
-    }
-  );
-  console.log(res);
-  console.log(res.length);
-}
-test();

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -256,32 +256,53 @@ export async function renderPrefixSection(
       sections: [],
     };
   }
-  const tokens = (
-    await tokenize(prefix.substring(0, MAX_PREFIX_CHARS), dataSourceConfig)
-  ).map((token) => token[1]);
 
-  if (tokens.length <= MAX_PREFIX_TOKENS && prefix.length <= MAX_PREFIX_CHARS) {
+  // if too many chars in the prefix, we have to split AND check for tokens
+  if (prefix.length > MAX_PREFIX_CHARS) {
+    const tokens = (
+      await tokenize(prefix.substring(0, MAX_PREFIX_CHARS), dataSourceConfig)
+    ).map((token) => token[1]);
+
+    // if in truncated prefix, we don't have too many tokens, we can split
+    // directly via chars
+    if (tokens.length <= MAX_PREFIX_TOKENS) {
+      return {
+        prefix: prefix.substring(0, MAX_PREFIX_CHARS - 4) + "...\n", // account for the ellipsis
+        content: "..." + prefix.substring(MAX_PREFIX_CHARS - 4),
+        sections: [],
+      };
+    }
+
+    // otherwise, we split via tokens
+    const prefixTextLength = tokens
+      .slice(0, MAX_PREFIX_TOKENS)
+      .reduce((acc, t) => acc + t.length, 0);
     return {
-      prefix,
-      content: null,
-      sections: [],
-    };
-  } else if (
-    tokens.length <= MAX_PREFIX_TOKENS &&
-    prefix.length > MAX_PREFIX_CHARS
-  ) {
-    return {
-      prefix: prefix.substring(0, prefix.length - 4) + "...\n", // account for the ellipsis
-      content: `...${prefix.substring(prefix.length - 4)}`,
+      prefix: prefix.substring(0, prefixTextLength - 4) + "...\n", // account for the ellipsis
+      content: `...${prefix.substring(prefixTextLength - 4)}`,
       sections: [],
     };
   }
-  const prefixTextLength =
-    tokens.slice(0, MAX_PREFIX_TOKENS).reduce((acc, t) => acc + t.length, 0) -
-    4; // account for the ellipsis
+
+  // if not too many chars, we split only if too many tokens
+  const tokens = (await tokenize(prefix, dataSourceConfig)).map(
+    (token) => token[1]
+  );
+
+  if (tokens.length <= MAX_PREFIX_TOKENS) {
+    return {
+      prefix: prefix,
+      content: null,
+      sections: [],
+    };
+  }
+
+  const prefixTextLength = tokens
+    .slice(0, MAX_PREFIX_TOKENS)
+    .reduce((acc, t) => acc + t.length, 0);
   return {
-    prefix: prefix.substring(0, prefixTextLength) + "...\n",
-    content: `...${prefix.substring(prefixTextLength)}`,
+    prefix: prefix.substring(0, prefixTextLength - 4) + "...\n",
+    content: `...${prefix.substring(prefixTextLength - 4)}`,
     sections: [],
   };
 }

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -1,7 +1,6 @@
 import type {
   cacheWithRedis,
   CoreAPIDataSourceDocumentSection,
-  CoreAPITokenType,
   DustAPI,
   EMBEDDING_CONFIG,
   PostDataSourceDocumentRequestBody,

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -259,20 +259,18 @@ export async function renderPrefixSection(
 
   const tokens = await tokenize(targetPrefix, dataSourceConfig);
 
-  if (tokens.length > MAX_PREFIX_TOKENS) {
-    targetPrefix = tokens
-      .slice(0, MAX_PREFIX_TOKENS)
+  targetPrefix = tokens
+    .slice(0, MAX_PREFIX_TOKENS)
+    .map((t) => t[1])
+    .join("");
+  targetContent =
+    tokens
+      .slice(MAX_PREFIX_TOKENS)
       .map((t) => t[1])
-      .join("");
-    targetContent =
-      tokens
-        .slice(MAX_PREFIX_TOKENS)
-        .map((t) => t[1])
-        .join("") + targetContent;
-  }
+      .join("") + targetContent;
 
   return {
-    prefix: targetContent ? targetPrefix + "..." : targetPrefix,
+    prefix: targetContent ? targetPrefix + "...\n" : targetPrefix,
     content: targetContent ? "..." + targetContent : null,
     sections: [],
   };

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -402,7 +402,7 @@ export async function renderDocumentTitleAndContent({
     }
   }
   if (metaPrefix) {
-    c.prefix += metaPrefix;
+    c.prefix = c.prefix ? c.prefix + metaPrefix : metaPrefix;
   }
   if (content) {
     c.sections.push(content);

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -278,7 +278,7 @@ export async function renderPrefixSection(
 }
 
 async function _getTokens(text: string) {
-  const tokensRes = (await new CoreAPI(logger)).tokenize({
+  const tokensRes = await new CoreAPI(logger).tokenize({
     text: text,
     modelId: EMBEDDING_CONFIG.model_id,
     providerId: EMBEDDING_CONFIG.provider_id,

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -1,6 +1,5 @@
 import type {
   cacheWithRedis,
-  CoreAPI,
   CoreAPIDataSourceDocumentSection,
   CoreAPITokenType,
   EMBEDDING_CONFIG,

--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -2293,6 +2293,30 @@ async fn tokenize(
     }
 }
 
+#[derive(serde::Deserialize)]
+struct FakeTokenize {
+    text: String,
+    ds_name: String,
+    credentials: Option<run::Credentials>,
+}
+async fn fake_tokenize(
+    extract::Json(payload): extract::Json<FakeTokenize>,
+) -> (StatusCode, Json<APIResponse>) {
+    // Just log the text and ds name
+    utils::info(&format!(
+        "Fake tokenize: text: {}, ds_name: {}",
+        payload.text, payload.ds_name
+    ));
+
+    (
+        StatusCode::OK,
+        Json(APIResponse {
+            error: None,
+            response: Some(json!({ "text": payload.text })),
+        }),
+    )
+}
+
 fn main() {
     let rt = tokio::runtime::Builder::new_multi_thread()
         .worker_threads(32)
@@ -2462,6 +2486,7 @@ fn main() {
         .route("/sqlite_workers", delete(sqlite_workers_delete))
         // Misc
         .route("/tokenize", post(tokenize))
+        .route("/fake_tokenize", post(fake_tokenize))
 
         // Extensions
         .layer(DefaultBodyLimit::disable())

--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -2293,30 +2293,6 @@ async fn tokenize(
     }
 }
 
-#[derive(serde::Deserialize)]
-struct FakeTokenize {
-    text: String,
-    ds_name: String,
-    credentials: Option<run::Credentials>,
-}
-async fn fake_tokenize(
-    extract::Json(payload): extract::Json<FakeTokenize>,
-) -> (StatusCode, Json<APIResponse>) {
-    // Just log the text and ds name
-    utils::info(&format!(
-        "Fake tokenize: text: {}, ds_name: {}",
-        payload.text, payload.ds_name
-    ));
-
-    (
-        StatusCode::OK,
-        Json(APIResponse {
-            error: None,
-            response: Some(json!({ "text": payload.text })),
-        }),
-    )
-}
-
 fn main() {
     let rt = tokio::runtime::Builder::new_multi_thread()
         .worker_threads(32)
@@ -2486,7 +2462,6 @@ fn main() {
         .route("/sqlite_workers", delete(sqlite_workers_delete))
         // Misc
         .route("/tokenize", post(tokenize))
-        .route("/fake_tokenize", post(fake_tokenize))
 
         // Extensions
         .layer(DefaultBodyLimit::disable())

--- a/front/pages/api/w/[wId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/index.ts
@@ -1,6 +1,6 @@
-import type { DataSourceType, EMBEDDING_CONFIG } from "@dust-tt/types";
+import type { DataSourceType } from "@dust-tt/types";
 import type { ReturnedAPIErrorType } from "@dust-tt/types";
-import { dustManagedCredentials } from "@dust-tt/types";
+import { dustManagedCredentials, EMBEDDING_CONFIG } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 

--- a/front/pages/api/w/[wId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/index.ts
@@ -1,4 +1,4 @@
-import type { DataSourceType } from "@dust-tt/types";
+import type { DataSourceType, EMBEDDING_CONFIG } from "@dust-tt/types";
 import type { ReturnedAPIErrorType } from "@dust-tt/types";
 import { dustManagedCredentials } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
@@ -107,10 +107,6 @@ async function handler(
         });
       }
 
-      const dataSourceProviderId = "openai";
-      const dataSourceModelId = "text-embedding-ada-002";
-      const dataSourceMaxChunkSize = 512;
-
       const coreAPI = new CoreAPI(logger);
 
       const dustProject = await coreAPI.createProject();
@@ -134,10 +130,10 @@ async function handler(
         projectId: dustProject.value.project.project_id.toString(),
         dataSourceId: req.body.name as string,
         config: {
-          provider_id: dataSourceProviderId,
-          model_id: dataSourceModelId,
-          splitter_id: "base_v0",
-          max_chunk_size: dataSourceMaxChunkSize,
+          provider_id: EMBEDDING_CONFIG.provider_id,
+          model_id: EMBEDDING_CONFIG.model_id,
+          splitter_id: EMBEDDING_CONFIG.splitter_id,
+          max_chunk_size: EMBEDDING_CONFIG.max_chunk_size,
           qdrant_config:
             auth.isUpgraded() && NODE_ENV === "production"
               ? {

--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -1,7 +1,12 @@
 import type { DataSourceType } from "@dust-tt/types";
 import type { ConnectorType } from "@dust-tt/types";
 import type { ReturnedAPIErrorType } from "@dust-tt/types";
-import { assertNever, isConnectorProvider } from "@dust-tt/types";
+import {
+  assertNever,
+  DataSourceType,
+  EMBEDDING_CONFIG,
+  isConnectorProvider,
+} from "@dust-tt/types";
 import { dustManagedCredentials } from "@dust-tt/types";
 import { ConnectorsAPI } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
@@ -138,10 +143,6 @@ async function handler(
           assertNever(type);
       }
 
-      const dataSourceProviderId = "openai";
-      const dataSourceModelId = "text-embedding-ada-002";
-      const dataSourceMaxChunkSize = 512;
-
       let isDataSourceAllowedInPlan: boolean;
       switch (provider) {
         case "confluence":
@@ -222,10 +223,10 @@ async function handler(
         projectId: dustProject.value.project.project_id.toString(),
         dataSourceId: dataSourceName,
         config: {
-          provider_id: dataSourceProviderId,
-          model_id: dataSourceModelId,
-          splitter_id: "base_v0",
-          max_chunk_size: dataSourceMaxChunkSize,
+          provider_id: EMBEDDING_CONFIG.provider_id,
+          model_id: EMBEDDING_CONFIG.model_id,
+          splitter_id: EMBEDDING_CONFIG.splitter_id,
+          max_chunk_size: EMBEDDING_CONFIG.max_chunk_size,
           qdrant_config:
             NODE_ENV === "production"
               ? {

--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -3,7 +3,6 @@ import type { ConnectorType } from "@dust-tt/types";
 import type { ReturnedAPIErrorType } from "@dust-tt/types";
 import {
   assertNever,
-  DataSourceType,
   EMBEDDING_CONFIG,
   isConnectorProvider,
 } from "@dust-tt/types";

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -22,6 +22,13 @@ import { LoggerInterface } from "../../shared/logger";
 
 const { CORE_API = "http://127.0.0.1:3001" } = process.env;
 
+export const EMBEDDING_CONFIG = {
+  model_id: "text-embedding-ada-002",
+  provider_id: "openai",
+  splitter_id: "base_v0",
+  max_chunk_size: 512,
+};
+
 export type CoreAPIErrorResponse = {
   message: string;
   code: string;

--- a/types/src/front/lib/dust_api.ts
+++ b/types/src/front/lib/dust_api.ts
@@ -699,6 +699,7 @@ export class DustAPI {
     }
     return new Ok(json.conversation as ConversationType);
   }
+
   async tokenize(
     text: string,
     dataSourceName: string

--- a/types/src/front/lib/dust_api.ts
+++ b/types/src/front/lib/dust_api.ts
@@ -1,4 +1,5 @@
 import { createParser } from "eventsource-parser";
+import { CoreAPITokenType } from "front/lib/core_api";
 import * as t from "io-ts";
 
 import {
@@ -24,7 +25,6 @@ import {
 } from "./api/assistant/agent";
 import { UserMessageErrorEvent } from "./api/assistant/conversation";
 import { GenerationTokensEvent } from "./api/assistant/generation";
-import { CoreAPITokenType } from "front/lib/core_api";
 
 const { DUST_PROD_API = "https://dust.tt", NODE_ENV } = process.env;
 

--- a/types/src/front/lib/dust_api.ts
+++ b/types/src/front/lib/dust_api.ts
@@ -24,6 +24,7 @@ import {
 } from "./api/assistant/agent";
 import { UserMessageErrorEvent } from "./api/assistant/conversation";
 import { GenerationTokensEvent } from "./api/assistant/generation";
+import { CoreAPITokenType } from "front/lib/core_api";
 
 const { DUST_PROD_API = "https://dust.tt", NODE_ENV } = process.env;
 
@@ -697,5 +698,28 @@ export class DustAPI {
       return new Err(json.error as DustAPIErrorResponse);
     }
     return new Ok(json.conversation as ConversationType);
+  }
+  async tokenize(
+    text: string,
+    dataSourceName: string
+  ): Promise<Result<CoreAPITokenType[], DustAPIErrorResponse>> {
+    const urlSafeName = encodeURIComponent(dataSourceName);
+    const endpoint = `${this.apiUrl()}/api/v1/w/${this.workspaceId()}/data_sources/${urlSafeName}/tokenize`;
+
+    const res = await fetch(endpoint, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${this._credentials.apiKey}`,
+      },
+      body: JSON.stringify({
+        text,
+      }),
+    });
+    const dustRequestResult = await res.json();
+    if (dustRequestResult.error) {
+      return new Err(dustRequestResult.error as DustAPIErrorResponse);
+    }
+    return new Ok(dustRequestResult.tokens as CoreAPITokenType[]);
   }
 }


### PR DESCRIPTION
This fixes issues with chunking where upserts may fail in Core due to prefix size being more than half chunk size.

Related [discussion](https://dust4ai.slack.com/archives/C05F84CFP0E/p1705337410044789)

## Notes
- allows for 4 full prefixes
- memoizes the tokenization
- splits title and metadata as 2 prefixes (to make the count work)
- ~currently, tokenization is in `connectors`, TBD~ uses the new tokenize route in front v1 api