### PR TITLE
Patch stripe webhook for payment failed

### DIFF
--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -786,19 +786,26 @@ export async function getUserName(
     return fromCache;
   }
 
-  const info = await slackClient.users.info({ user: slackUserId });
+  try {
+    const info = await slackClient.users.info({ user: slackUserId });
 
-  if (info && info.user) {
-    const displayName = info.user.profile?.display_name;
-    const realName = info.user.profile?.real_name;
-    const userName = displayName || realName || info.user.name;
+    if (info && info.user) {
+      const displayName = info.user.profile?.display_name;
+      const realName = info.user.profile?.real_name;
+      const userName = displayName || realName || info.user.name;
 
-    if (userName) {
-      await cacheSet(getUserCacheKey(slackUserId, connectorId), userName);
-      return info.user.name;
+      if (userName) {
+        await cacheSet(getUserCacheKey(slackUserId, connectorId), userName);
+        return info.user.name;
+      }
     }
+
+    return undefined;
+  } catch (err) {
+    logger.info({ connectorId, slackUserId }, "Slack user not found.");
+
+    return undefined;
   }
-  return;
 }
 
 function getUserCacheKey(userId: string, connectorId: ModelId) {

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -786,26 +786,19 @@ export async function getUserName(
     return fromCache;
   }
 
-  try {
-    const info = await slackClient.users.info({ user: slackUserId });
+  const info = await slackClient.users.info({ user: slackUserId });
 
-    if (info && info.user) {
-      const displayName = info.user.profile?.display_name;
-      const realName = info.user.profile?.real_name;
-      const userName = displayName || realName || info.user.name;
+  if (info && info.user) {
+    const displayName = info.user.profile?.display_name;
+    const realName = info.user.profile?.real_name;
+    const userName = displayName || realName || info.user.name;
 
-      if (userName) {
-        await cacheSet(getUserCacheKey(slackUserId, connectorId), userName);
-        return info.user.name;
-      }
+    if (userName) {
+      await cacheSet(getUserCacheKey(slackUserId, connectorId), userName);
+      return info.user.name;
     }
-
-    return undefined;
-  } catch (err) {
-    logger.info({ connectorId, slackUserId }, "Slack user not found.");
-
-    return undefined;
   }
+  return;
 }
 
 function getUserCacheKey(userId: string, connectorId: ModelId) {

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -378,6 +378,14 @@ async function handler(
               "Subscription not found."
             );
           }
+
+          // TODO(2024-01-16 by flav) This line should be removed after all Stripe webhooks have been retried.
+          // Previously, there was an error in how we handled the cancellation of subscriptions.
+          // This change ensures that we return a success status if the subscription is already marked as "ended".
+          if (subscription.status === "ended") {
+            return res.status(200).json({ success: true });
+          }
+
           if (subscription.paymentFailingSince === null) {
             await subscription.update({ paymentFailingSince: now });
           }


### PR DESCRIPTION
We observed an influx of Stripe webhook events that did not process correctly, specifically those related to `payment_failure`. It appears the root of the problem was a race condition occurring while attempting to cancel Temporal workflows associated with a workspace. The issue has since been resolved (https://github.com/dust-tt/dust/pull/3201), and this serves as a temporary patch to ensure webhook events are handled correctly.