### PR TITLE
fix: get last version of agent config

### DIFF
--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -192,6 +192,8 @@ export async function getAgentConfigurations<V extends "light" | "full">({
                 : {}),
               sId: agentsGetView.agentId,
             },
+            order: [["version", "DESC"]],
+            limit: 1,
           });
         }
         if (


### PR DESCRIPTION
When getting a single agentConfiguration, we must get the last version