### PR TITLE
runner: bump limits for paid users + refactor paid plan conditions

### DIFF
--- a/front/components/assistant/GalleryAssistantPreviewContainer.tsx
+++ b/front/components/assistant/GalleryAssistantPreviewContainer.tsx
@@ -1,7 +1,6 @@
 import { AssistantPreview } from "@dust-tt/sparkle";
 import {
   AgentUserListStatus,
-  isPaidPlanType,
   LightAgentConfigurationType,
   PlanType,
   WorkspaceType,
@@ -13,6 +12,7 @@ import {
   SendNotificationsContext,
 } from "@app/components/sparkle/Notification";
 import { isLargeModel } from "@app/lib/assistant";
+import { isUpgraded } from "@app/lib/plans/free_plans";
 import { PostAgentListStatusRequestBody } from "@app/pages/api/w/[wId]/members/me/agent_list_status";
 
 type AssistantPreviewFlow = "personal" | "workspace";
@@ -176,7 +176,7 @@ export function GalleryAssistantPreviewContainer({
 
   const isGlobal = scope === "global";
   const isAddedToWorkspace = flow === "workspace" && isAdded;
-  const hasAccessToLargeModels = isPaidPlanType(plan);
+  const hasAccessToLargeModels = isUpgraded(plan);
   const eligibleForTesting =
     hasAccessToLargeModels || !isLargeModel(generation?.model);
   const isTestable = !isGlobal && !isAdded && eligibleForTesting;

--- a/front/components/assistant/GalleryAssistantPreviewContainer.tsx
+++ b/front/components/assistant/GalleryAssistantPreviewContainer.tsx
@@ -1,6 +1,7 @@
 import { AssistantPreview } from "@dust-tt/sparkle";
 import {
   AgentUserListStatus,
+  isPaidPlanType,
   LightAgentConfigurationType,
   PlanType,
   WorkspaceType,
@@ -12,7 +13,6 @@ import {
   SendNotificationsContext,
 } from "@app/components/sparkle/Notification";
 import { isLargeModel } from "@app/lib/assistant";
-import { FREE_TEST_PLAN_CODE } from "@app/lib/plans/plan_codes";
 import { PostAgentListStatusRequestBody } from "@app/pages/api/w/[wId]/members/me/agent_list_status";
 
 type AssistantPreviewFlow = "personal" | "workspace";
@@ -176,7 +176,7 @@ export function GalleryAssistantPreviewContainer({
 
   const isGlobal = scope === "global";
   const isAddedToWorkspace = flow === "workspace" && isAdded;
-  const hasAccessToLargeModels = plan?.code !== FREE_TEST_PLAN_CODE;
+  const hasAccessToLargeModels = isPaidPlanType(plan);
   const eligibleForTesting =
     hasAccessToLargeModels || !isLargeModel(generation?.model);
   const isTestable = !isGlobal && !isAdded && eligibleForTesting;

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -20,6 +20,7 @@ import {
   ConnectorProvider,
   DataSourceType,
   GEMINI_PRO_DEFAULT_MODEL_CONFIG,
+  isPaidPlanType,
 } from "@dust-tt/types";
 import { UserType, WorkspaceType } from "@dust-tt/types";
 import {
@@ -67,7 +68,6 @@ import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { getSupportedModelConfig } from "@app/lib/assistant";
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 import { isActivatedStructuredDB } from "@app/lib/development";
-import { FREE_TEST_PLAN_CODE } from "@app/lib/plans/plan_codes";
 import { useSlackChannelsLinkedWithAgent } from "@app/lib/swr";
 import { classNames } from "@app/lib/utils";
 
@@ -307,10 +307,9 @@ export default function AssistantBuilder({
           scope: defaultScope,
           generationSettings: {
             ...DEFAULT_ASSISTANT_STATE.generationSettings,
-            modelSettings:
-              plan.code === FREE_TEST_PLAN_CODE
-                ? GPT_3_5_TURBO_MODEL_CONFIG
-                : GPT_4_TURBO_MODEL_CONFIG,
+            modelSettings: !isPaidPlanType(plan)
+              ? GPT_3_5_TURBO_MODEL_CONFIG
+              : GPT_4_TURBO_MODEL_CONFIG,
           },
         }
   );
@@ -1531,9 +1530,7 @@ function AdvancedSettings({
               </DropdownMenu.Button>
               <DropdownMenu.Items origin="bottomRight">
                 {usedModelConfigs
-                  .filter(
-                    (m) => !(m.largeModel && plan.code === FREE_TEST_PLAN_CODE)
-                  )
+                  .filter((m) => !(m.largeModel && !isPaidPlanType(plan)))
                   .map((modelConfig) => (
                     <DropdownMenu.Item
                       key={modelConfig.modelId}

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -20,7 +20,6 @@ import {
   ConnectorProvider,
   DataSourceType,
   GEMINI_PRO_DEFAULT_MODEL_CONFIG,
-  isPaidPlanType,
 } from "@dust-tt/types";
 import { UserType, WorkspaceType } from "@dust-tt/types";
 import {
@@ -68,6 +67,7 @@ import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { getSupportedModelConfig } from "@app/lib/assistant";
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 import { isActivatedStructuredDB } from "@app/lib/development";
+import { isUpgraded } from "@app/lib/plans/free_plans";
 import { useSlackChannelsLinkedWithAgent } from "@app/lib/swr";
 import { classNames } from "@app/lib/utils";
 
@@ -307,7 +307,7 @@ export default function AssistantBuilder({
           scope: defaultScope,
           generationSettings: {
             ...DEFAULT_ASSISTANT_STATE.generationSettings,
-            modelSettings: !isPaidPlanType(plan)
+            modelSettings: !isUpgraded(plan)
               ? GPT_3_5_TURBO_MODEL_CONFIG
               : GPT_4_TURBO_MODEL_CONFIG,
           },
@@ -1530,7 +1530,7 @@ function AdvancedSettings({
               </DropdownMenu.Button>
               <DropdownMenu.Items origin="bottomRight">
                 {usedModelConfigs
-                  .filter((m) => !(m.largeModel && !isPaidPlanType(plan)))
+                  .filter((m) => !(m.largeModel && !isUpgraded(plan)))
                   .map((modelConfig) => (
                     <DropdownMenu.Item
                       key={modelConfig.modelId}

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -64,7 +64,7 @@ export async function generateActionInputs(
 
   const MIN_GENERATION_TOKENS = 2048;
 
-  let model: { providerId: string; modelId: string } = !auth.isOnPaidPlan()
+  let model: { providerId: string; modelId: string } = !auth.isUpgraded()
     ? {
         providerId: GPT_3_5_TURBO_MODEL_CONFIG.providerId,
         modelId: GPT_3_5_TURBO_MODEL_CONFIG.modelId,
@@ -74,7 +74,7 @@ export async function generateActionInputs(
         modelId: GPT_4_32K_MODEL_CONFIG.modelId,
       };
 
-  const contextSize = !auth.isOnPaidPlan()
+  const contextSize = !auth.isUpgraded()
     ? GPT_3_5_TURBO_MODEL_CONFIG.contextSize
     : GPT_4_32K_MODEL_CONFIG.contextSize;
 

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -38,7 +38,6 @@ import {
   runGeneration,
 } from "@app/lib/api/assistant/generation";
 import { Authenticator } from "@app/lib/auth";
-import { FREE_TEST_PLAN_CODE } from "@app/lib/plans/plan_codes";
 import logger from "@app/logger/logger";
 
 /**
@@ -65,10 +64,7 @@ export async function generateActionInputs(
 
   const MIN_GENERATION_TOKENS = 2048;
 
-  const plan = auth.plan();
-  const isFree = !plan || plan.code === FREE_TEST_PLAN_CODE;
-
-  let model: { providerId: string; modelId: string } = isFree
+  let model: { providerId: string; modelId: string } = !auth.isOnPaidPlan()
     ? {
         providerId: GPT_3_5_TURBO_MODEL_CONFIG.providerId,
         modelId: GPT_3_5_TURBO_MODEL_CONFIG.modelId,
@@ -78,7 +74,7 @@ export async function generateActionInputs(
         modelId: GPT_4_32K_MODEL_CONFIG.modelId,
       };
 
-  const contextSize = isFree
+  const contextSize = !auth.isOnPaidPlan()
     ? GPT_3_5_TURBO_MODEL_CONFIG.contextSize
     : GPT_4_32K_MODEL_CONFIG.contextSize;
 

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -302,7 +302,7 @@ export async function* runGeneration(
 
   let model = c.model;
 
-  if (isLargeModel(model) && !auth.isOnPaidPlan()) {
+  if (isLargeModel(model) && !auth.isUpgraded()) {
     yield {
       type: "generation_error",
       created: Date.now(),

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -38,7 +38,6 @@ import {
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
 import { getSupportedModelConfig, isLargeModel } from "@app/lib/assistant";
 import { Authenticator } from "@app/lib/auth";
-import { FREE_TEST_PLAN_CODE } from "@app/lib/plans/plan_codes";
 import { redisClient } from "@app/lib/redis";
 import logger from "@app/logger/logger";
 const CANCELLATION_CHECK_INTERVAL = 500;
@@ -280,8 +279,7 @@ export async function* runGeneration(
   void
 > {
   const owner = auth.workspace();
-  const plan = auth.plan();
-  if (!owner || !plan) {
+  if (!owner) {
     throw new Error("Unexpected unauthenticated call to `runGeneration`");
   }
 
@@ -304,7 +302,7 @@ export async function* runGeneration(
 
   let model = c.model;
 
-  if (isLargeModel(model) && plan.code === FREE_TEST_PLAN_CODE) {
+  if (isLargeModel(model) && !auth.isOnPaidPlan()) {
     yield {
       type: "generation_error",
       created: Date.now(),

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -18,12 +18,11 @@ import {
   MISTRAL_MEDIUM_MODEL_CONFIG,
   MISTRAL_SMALL_MODEL_CONFIG,
 } from "@dust-tt/types";
-import { DustAPI, GlobalAgentStatus, PlanType } from "@dust-tt/types";
+import { DustAPI, GlobalAgentStatus } from "@dust-tt/types";
 
 import { GLOBAL_AGENTS_SID } from "@app/lib/assistant";
 import { Authenticator, prodAPICredentialsForOwner } from "@app/lib/auth";
 import { GlobalAgentSettings } from "@app/lib/models/assistant/agent";
-import { FREE_TEST_PLAN_CODE } from "@app/lib/plans/plan_codes";
 import logger from "@app/logger/logger";
 
 class HelperAssistantPrompt {
@@ -82,20 +81,15 @@ async function _getHelperGlobalAgent(
   if (!owner) {
     throw new Error("Unexpected `auth` without `workspace`.");
   }
-  const plan = auth.plan();
-  if (!plan) {
-    throw new Error("Unexpected `auth` without `plan`.");
-  }
-  const model =
-    plan.code === FREE_TEST_PLAN_CODE
-      ? {
-          providerId: GPT_3_5_TURBO_MODEL_CONFIG.providerId,
-          modelId: GPT_3_5_TURBO_MODEL_CONFIG.modelId,
-        }
-      : {
-          providerId: GPT_4_TURBO_MODEL_CONFIG.providerId,
-          modelId: GPT_4_TURBO_MODEL_CONFIG.modelId,
-        };
+  const model = !auth.isOnPaidPlan()
+    ? {
+        providerId: GPT_3_5_TURBO_MODEL_CONFIG.providerId,
+        modelId: GPT_3_5_TURBO_MODEL_CONFIG.modelId,
+      }
+    : {
+        providerId: GPT_4_TURBO_MODEL_CONFIG.providerId,
+        modelId: GPT_4_TURBO_MODEL_CONFIG.modelId,
+      };
   return {
     id: -1,
     sId: GLOBAL_AGENTS_SID.HELPER,
@@ -151,12 +145,11 @@ async function _getGPT35TurboGlobalAgent({
 }
 
 async function _getGPT4GlobalAgent({
-  plan,
+  auth,
 }: {
-  plan: PlanType;
+  auth: Authenticator;
 }): Promise<AgentConfigurationType> {
-  const status =
-    plan.code === FREE_TEST_PLAN_CODE ? "disabled_free_workspace" : "active";
+  const status = !auth.isOnPaidPlan() ? "disabled_free_workspace" : "active";
   return {
     id: -1,
     sId: GLOBAL_AGENTS_SID.GPT4,
@@ -216,14 +209,13 @@ async function _getClaudeInstantGlobalAgent({
 }
 
 async function _getClaudeGlobalAgent({
+  auth,
   settings,
-  plan,
 }: {
+  auth: Authenticator;
   settings: GlobalAgentSettings | null;
-  plan: PlanType;
 }): Promise<AgentConfigurationType> {
-  const status =
-    plan.code === FREE_TEST_PLAN_CODE ? "disabled_free_workspace" : "active";
+  const status = !auth.isOnPaidPlan() ? "disabled_free_workspace" : "active";
   return {
     id: -1,
     sId: GLOBAL_AGENTS_SID.CLAUDE,
@@ -250,14 +242,14 @@ async function _getClaudeGlobalAgent({
 }
 
 async function _getMistralMediumGlobalAgent({
-  plan,
+  auth,
   settings,
 }: {
-  plan: PlanType;
+  auth: Authenticator;
   settings: GlobalAgentSettings | null;
 }): Promise<AgentConfigurationType> {
   let status = settings?.status ?? "disabled_by_admin";
-  if (plan.code === FREE_TEST_PLAN_CODE) {
+  if (!auth.isOnPaidPlan()) {
     status = "disabled_free_workspace";
   }
 
@@ -376,11 +368,6 @@ async function _getManagedDataSourceAgent(
     throw new Error("Unexpected `auth` without `workspace`.");
   }
 
-  const plan = auth.plan();
-  if (!plan) {
-    throw new Error("Unexpected `auth` without `plan`.");
-  }
-
   const prodCredentials = await prodAPICredentialsForOwner(owner);
 
   // Check if deactivated by an admin
@@ -439,16 +426,15 @@ async function _getManagedDataSourceAgent(
     generation: {
       id: -1,
       prompt,
-      model:
-        plan.code === FREE_TEST_PLAN_CODE
-          ? {
-              providerId: GPT_3_5_TURBO_MODEL_CONFIG.providerId,
-              modelId: GPT_3_5_TURBO_MODEL_CONFIG.modelId,
-            }
-          : {
-              providerId: GPT_4_TURBO_MODEL_CONFIG.providerId,
-              modelId: GPT_4_TURBO_MODEL_CONFIG.modelId,
-            },
+      model: !auth.isOnPaidPlan()
+        ? {
+            providerId: GPT_3_5_TURBO_MODEL_CONFIG.providerId,
+            modelId: GPT_3_5_TURBO_MODEL_CONFIG.modelId,
+          }
+        : {
+            providerId: GPT_4_TURBO_MODEL_CONFIG.providerId,
+            modelId: GPT_4_TURBO_MODEL_CONFIG.modelId,
+          },
       temperature: 0.4,
     },
     action: {
@@ -565,10 +551,8 @@ async function _getNotionGlobalAgent(
 async function _getDustGlobalAgent(
   auth: Authenticator,
   {
-    plan,
     settings,
   }: {
-    plan: PlanType;
     settings: GlobalAgentSettings | null;
   }
 ): Promise<AgentConfigurationType | null> {
@@ -645,16 +629,15 @@ async function _getDustGlobalAgent(
       id: -1,
       prompt:
         "Assist the user based on the retrieved data from their workspace. Unlesss the user explicitely asks for a detailed answer, you goal is to provide a quick answer to their question.",
-      model:
-        plan.code === FREE_TEST_PLAN_CODE
-          ? {
-              providerId: GPT_3_5_TURBO_MODEL_CONFIG.providerId,
-              modelId: GPT_3_5_TURBO_MODEL_CONFIG.modelId,
-            }
-          : {
-              providerId: GPT_4_TURBO_MODEL_CONFIG.providerId,
-              modelId: GPT_4_TURBO_MODEL_CONFIG.modelId,
-            },
+      model: !auth.isOnPaidPlan()
+        ? {
+            providerId: GPT_3_5_TURBO_MODEL_CONFIG.providerId,
+            modelId: GPT_3_5_TURBO_MODEL_CONFIG.modelId,
+          }
+        : {
+            providerId: GPT_4_TURBO_MODEL_CONFIG.providerId,
+            modelId: GPT_4_TURBO_MODEL_CONFIG.modelId,
+          },
       temperature: 0.4,
     },
     action: {
@@ -691,11 +674,6 @@ export async function getGlobalAgent(
     throw new Error("Cannot find Global Agent Configuration: no workspace.");
   }
 
-  const plan = auth.plan();
-  if (!plan) {
-    throw new Error("Unexpected `auth` without `plan`.");
-  }
-
   if (preFetchedDataSources === null) {
     const prodCredentials = await prodAPICredentialsForOwner(owner);
     const api = new DustAPI(prodCredentials, logger);
@@ -719,18 +697,18 @@ export async function getGlobalAgent(
       agentConfiguration = await _getGPT35TurboGlobalAgent({ settings });
       break;
     case GLOBAL_AGENTS_SID.GPT4:
-      agentConfiguration = await _getGPT4GlobalAgent({ plan });
+      agentConfiguration = await _getGPT4GlobalAgent({ auth });
       break;
     case GLOBAL_AGENTS_SID.CLAUDE_INSTANT:
       agentConfiguration = await _getClaudeInstantGlobalAgent({ settings });
       break;
     case GLOBAL_AGENTS_SID.CLAUDE:
-      agentConfiguration = await _getClaudeGlobalAgent({ settings, plan });
+      agentConfiguration = await _getClaudeGlobalAgent({ auth, settings });
       break;
     case GLOBAL_AGENTS_SID.MISTRAL_MEDIUM:
       agentConfiguration = await _getMistralMediumGlobalAgent({
-        plan,
         settings,
+        auth,
       });
       break;
     case GLOBAL_AGENTS_SID.MISTRAL_SMALL:
@@ -764,7 +742,7 @@ export async function getGlobalAgent(
       });
       break;
     case GLOBAL_AGENTS_SID.DUST:
-      agentConfiguration = await _getDustGlobalAgent(auth, { plan, settings });
+      agentConfiguration = await _getDustGlobalAgent(auth, { settings });
       break;
     default:
       return null;

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -81,7 +81,7 @@ async function _getHelperGlobalAgent(
   if (!owner) {
     throw new Error("Unexpected `auth` without `workspace`.");
   }
-  const model = !auth.isOnPaidPlan()
+  const model = !auth.isUpgraded()
     ? {
         providerId: GPT_3_5_TURBO_MODEL_CONFIG.providerId,
         modelId: GPT_3_5_TURBO_MODEL_CONFIG.modelId,
@@ -149,7 +149,7 @@ async function _getGPT4GlobalAgent({
 }: {
   auth: Authenticator;
 }): Promise<AgentConfigurationType> {
-  const status = !auth.isOnPaidPlan() ? "disabled_free_workspace" : "active";
+  const status = !auth.isUpgraded() ? "disabled_free_workspace" : "active";
   return {
     id: -1,
     sId: GLOBAL_AGENTS_SID.GPT4,
@@ -215,7 +215,7 @@ async function _getClaudeGlobalAgent({
   auth: Authenticator;
   settings: GlobalAgentSettings | null;
 }): Promise<AgentConfigurationType> {
-  const status = !auth.isOnPaidPlan() ? "disabled_free_workspace" : "active";
+  const status = !auth.isUpgraded() ? "disabled_free_workspace" : "active";
   return {
     id: -1,
     sId: GLOBAL_AGENTS_SID.CLAUDE,
@@ -249,7 +249,7 @@ async function _getMistralMediumGlobalAgent({
   settings: GlobalAgentSettings | null;
 }): Promise<AgentConfigurationType> {
   let status = settings?.status ?? "disabled_by_admin";
-  if (!auth.isOnPaidPlan()) {
+  if (!auth.isUpgraded()) {
     status = "disabled_free_workspace";
   }
 
@@ -426,7 +426,7 @@ async function _getManagedDataSourceAgent(
     generation: {
       id: -1,
       prompt,
-      model: !auth.isOnPaidPlan()
+      model: !auth.isUpgraded()
         ? {
             providerId: GPT_3_5_TURBO_MODEL_CONFIG.providerId,
             modelId: GPT_3_5_TURBO_MODEL_CONFIG.modelId,
@@ -629,7 +629,7 @@ async function _getDustGlobalAgent(
       id: -1,
       prompt:
         "Assist the user based on the retrieved data from their workspace. Unlesss the user explicitely asks for a detailed answer, you goal is to provide a quick answer to their question.",
-      model: !auth.isOnPaidPlan()
+      model: !auth.isUpgraded()
         ? {
             providerId: GPT_3_5_TURBO_MODEL_CONFIG.providerId,
             modelId: GPT_3_5_TURBO_MODEL_CONFIG.modelId,

--- a/front/lib/api/assistant/pubsub.ts
+++ b/front/lib/api/assistant/pubsub.ts
@@ -35,6 +35,7 @@ import {
   postUserMessage,
   retryAgentMessage,
 } from "./conversation";
+import { FREE_TEST_PLAN_CODE } from "@app/lib/plans/plan_codes";
 
 export async function postUserMessageWithPubSub(
   auth: Authenticator,
@@ -55,6 +56,9 @@ export async function postUserMessageWithPubSub(
   let rateLimitKey: string | undefined = "";
   if (auth.user()?.id) {
     maxPerTimeframe = 50;
+    if (auth.plan() && auth.plan()?.code !== FREE_TEST_PLAN_CODE) {
+      maxPerTimeframe = 200;
+    }
     timeframeSeconds = 60 * 60 * 3;
     rateLimitKey = `postUserMessageUser:${auth.user()?.id}`;
   } else {

--- a/front/lib/api/assistant/pubsub.ts
+++ b/front/lib/api/assistant/pubsub.ts
@@ -35,7 +35,6 @@ import {
   postUserMessage,
   retryAgentMessage,
 } from "./conversation";
-import { FREE_TEST_PLAN_CODE } from "@app/lib/plans/plan_codes";
 
 export async function postUserMessageWithPubSub(
   auth: Authenticator,
@@ -56,7 +55,7 @@ export async function postUserMessageWithPubSub(
   let rateLimitKey: string | undefined = "";
   if (auth.user()?.id) {
     maxPerTimeframe = 50;
-    if (auth.plan() && auth.plan()?.code !== FREE_TEST_PLAN_CODE) {
+    if (auth.isOnPaidPlan()) {
       maxPerTimeframe = 200;
     }
     timeframeSeconds = 60 * 60 * 3;

--- a/front/lib/api/assistant/pubsub.ts
+++ b/front/lib/api/assistant/pubsub.ts
@@ -55,7 +55,7 @@ export async function postUserMessageWithPubSub(
   let rateLimitKey: string | undefined = "";
   if (auth.user()?.id) {
     maxPerTimeframe = 50;
-    if (auth.isOnPaidPlan()) {
+    if (auth.isUpgraded()) {
       maxPerTimeframe = 200;
     }
     timeframeSeconds = 60 * 60 * 3;

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -1,9 +1,8 @@
 import {
-  FREE_BILLING_TYPES,
+  isPaidPlanType,
   RoleType,
   UserType,
   WorkspaceType,
-  isPaidPlanType,
 } from "@dust-tt/types";
 import { PlanType, SubscriptionType } from "@dust-tt/types";
 import { DustAPICredentials } from "@dust-tt/types";

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -1,4 +1,10 @@
-import { RoleType, UserType, WorkspaceType } from "@dust-tt/types";
+import {
+  FREE_BILLING_TYPES,
+  RoleType,
+  UserType,
+  WorkspaceType,
+  isPaidPlanType,
+} from "@dust-tt/types";
 import { PlanType, SubscriptionType } from "@dust-tt/types";
 import { DustAPICredentials } from "@dust-tt/types";
 import { Err, Ok, Result } from "@dust-tt/types";
@@ -324,6 +330,10 @@ export class Authenticator {
 
   plan(): PlanType | null {
     return this._subscription ? this._subscription.plan : null;
+  }
+
+  isOnPaidPlan(): boolean {
+    return isPaidPlanType(this.plan());
   }
 
   /**

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -28,6 +28,7 @@ import { FREE_TEST_PLAN_DATA, PlanAttributes } from "@app/lib/plans/free_plans";
 import { new_id } from "@app/lib/utils";
 import logger from "@app/logger/logger";
 import { authOptions } from "@app/pages/api/auth/[...nextauth]";
+import { FREE_TEST_PLAN_CODE } from "./plans/plan_codes";
 
 const {
   DUST_DEVELOPMENT_WORKSPACE_ID,
@@ -331,8 +332,12 @@ export class Authenticator {
     return this._subscription ? this._subscription.plan : null;
   }
 
-  isOnPaidPlan(): boolean {
-    return isPaidPlanType(this.plan());
+  isUpgraded(): boolean {
+    const plan = this.plan();
+    if (!plan) {
+      return false;
+    }
+    return plan.code !== FREE_TEST_PLAN_CODE;
   }
 
   /**

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -1,9 +1,4 @@
-import {
-  isPaidPlanType,
-  RoleType,
-  UserType,
-  WorkspaceType,
-} from "@dust-tt/types";
+import { RoleType, UserType, WorkspaceType } from "@dust-tt/types";
 import { PlanType, SubscriptionType } from "@dust-tt/types";
 import { DustAPICredentials } from "@dust-tt/types";
 import { Err, Ok, Result } from "@dust-tt/types";
@@ -25,10 +20,10 @@ import {
   Workspace,
 } from "@app/lib/models";
 import { FREE_TEST_PLAN_DATA, PlanAttributes } from "@app/lib/plans/free_plans";
+import { FREE_TEST_PLAN_CODE } from "@app/lib/plans/plan_codes";
 import { new_id } from "@app/lib/utils";
 import logger from "@app/logger/logger";
 import { authOptions } from "@app/pages/api/auth/[...nextauth]";
-import { FREE_TEST_PLAN_CODE } from "./plans/plan_codes";
 
 const {
   DUST_DEVELOPMENT_WORKSPACE_ID,

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -19,7 +19,11 @@ import {
   User,
   Workspace,
 } from "@app/lib/models";
-import { FREE_TEST_PLAN_DATA, PlanAttributes } from "@app/lib/plans/free_plans";
+import {
+  FREE_TEST_PLAN_DATA,
+  PlanAttributes,
+  isUpgraded,
+} from "@app/lib/plans/free_plans";
 import { FREE_TEST_PLAN_CODE } from "@app/lib/plans/plan_codes";
 import { new_id } from "@app/lib/utils";
 import logger from "@app/logger/logger";
@@ -328,11 +332,7 @@ export class Authenticator {
   }
 
   isUpgraded(): boolean {
-    const plan = this.plan();
-    if (!plan) {
-      return false;
-    }
-    return plan.code !== FREE_TEST_PLAN_CODE;
+    return isUpgraded(this.plan());
   }
 
   /**

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -21,10 +21,9 @@ import {
 } from "@app/lib/models";
 import {
   FREE_TEST_PLAN_DATA,
-  PlanAttributes,
   isUpgraded,
+  PlanAttributes,
 } from "@app/lib/plans/free_plans";
-import { FREE_TEST_PLAN_CODE } from "@app/lib/plans/plan_codes";
 import { new_id } from "@app/lib/utils";
 import logger from "@app/logger/logger";
 import { authOptions } from "@app/pages/api/auth/[...nextauth]";

--- a/front/lib/plans/free_plans.ts
+++ b/front/lib/plans/free_plans.ts
@@ -5,6 +5,7 @@ import {
   FREE_TEST_PLAN_CODE,
   FREE_UPGRADED_PLAN_CODE,
 } from "@app/lib/plans/plan_codes";
+import { PlanType } from "@dust-tt/types";
 
 export type PlanAttributes = Omit<
   Attributes<Plan>,
@@ -89,4 +90,9 @@ export const upsertFreePlans = async () => {
       console.log(`Free plan ${planData.code} updated.`);
     }
   }
+};
+
+export const isUpgraded = (plan: PlanType | null): boolean => {
+  if (!plan) return false;
+  return plan.code !== FREE_UPGRADED_PLAN_CODE;
 };

--- a/front/lib/plans/free_plans.ts
+++ b/front/lib/plans/free_plans.ts
@@ -92,6 +92,13 @@ export const upsertFreePlans = async () => {
   }
 };
 
+/**
+ * `isUpgraded` returns true if the plan has access to all features of Dust, including large
+ * language models (meaning it's either a paid plan or free plan with (eg friends and family, or
+ * free trial plan)).
+ *
+ * Note: We didn't go for isFree or isPayingWorkspace as we have "upgraded" plans that are free.
+ */
 export const isUpgraded = (plan: PlanType | null): boolean => {
   if (!plan) return false;
   return plan.code !== FREE_TEST_PLAN_CODE;

--- a/front/lib/plans/free_plans.ts
+++ b/front/lib/plans/free_plans.ts
@@ -1,3 +1,4 @@
+import { PlanType } from "@dust-tt/types";
 import { Attributes } from "sequelize";
 
 import { Plan } from "@app/lib/models";
@@ -5,7 +6,6 @@ import {
   FREE_TEST_PLAN_CODE,
   FREE_UPGRADED_PLAN_CODE,
 } from "@app/lib/plans/plan_codes";
-import { PlanType } from "@dust-tt/types";
 
 export type PlanAttributes = Omit<
   Attributes<Plan>,
@@ -94,5 +94,5 @@ export const upsertFreePlans = async () => {
 
 export const isUpgraded = (plan: PlanType | null): boolean => {
   if (!plan) return false;
-  return plan.code !== FREE_UPGRADED_PLAN_CODE;
+  return plan.code !== FREE_TEST_PLAN_CODE;
 };

--- a/front/pages/api/w/[wId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/index.ts
@@ -139,7 +139,7 @@ async function handler(
           splitter_id: "base_v0",
           max_chunk_size: dataSourceMaxChunkSize,
           qdrant_config:
-            !auth.isOnPaidPlan() && NODE_ENV === "production"
+            auth.isOnPaidPlan() && NODE_ENV === "production"
               ? {
                   cluster: "dedicated-1",
                   shadow_write_cluster: null,

--- a/front/pages/api/w/[wId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/index.ts
@@ -139,7 +139,7 @@ async function handler(
           splitter_id: "base_v0",
           max_chunk_size: dataSourceMaxChunkSize,
           qdrant_config:
-            auth.isOnPaidPlan() && NODE_ENV === "production"
+            auth.isUpgraded() && NODE_ENV === "production"
               ? {
                   cluster: "dedicated-1",
                   shadow_write_cluster: null,

--- a/front/pages/api/w/[wId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/index.ts
@@ -7,7 +7,6 @@ import { NextApiRequest, NextApiResponse } from "next";
 import { getDataSources } from "@app/lib/api/data_sources";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { DataSource } from "@app/lib/models";
-import { FREE_TEST_PLAN_CODE } from "@app/lib/plans/plan_codes";
 import logger from "@app/logger/logger";
 import { apiError, withLogging } from "@app/logger/withlogging";
 
@@ -140,7 +139,7 @@ async function handler(
           splitter_id: "base_v0",
           max_chunk_size: dataSourceMaxChunkSize,
           qdrant_config:
-            plan.code !== FREE_TEST_PLAN_CODE && NODE_ENV === "production"
+            !auth.isOnPaidPlan() && NODE_ENV === "production"
               ? {
                   cluster: "dedicated-1",
                   shadow_write_cluster: null,

--- a/front/pages/poke/[wId]/index.tsx
+++ b/front/pages/poke/[wId]/index.tsx
@@ -9,6 +9,7 @@ import {
   AgentConfigurationType,
   DataSourceType,
   isDustAppRunConfiguration,
+  isPaidPlanType,
   isRetrievalConfiguration,
   LightAgentConfigurationType,
   WorkspaceSegmentationType,
@@ -651,7 +652,7 @@ const WorkspacePage = ({
                           variant="secondaryWarning"
                           onClick={onDowngrade}
                           disabled={
-                            subscription.plan.code === FREE_TEST_PLAN_CODE ||
+                            !isPaidPlanType(subscription.plan) ||
                             workspaceHasManagedDataSources
                           }
                         />
@@ -661,9 +662,7 @@ const WorkspacePage = ({
                           label="Upgrade to free upgraded plan"
                           variant="tertiary"
                           onClick={onUpgrade}
-                          disabled={
-                            subscription.plan.code !== FREE_TEST_PLAN_CODE
-                          }
+                          disabled={isPaidPlanType(subscription.plan)}
                         />
                       </div>
                     </div>

--- a/front/pages/poke/[wId]/index.tsx
+++ b/front/pages/poke/[wId]/index.tsx
@@ -9,7 +9,6 @@ import {
   AgentConfigurationType,
   DataSourceType,
   isDustAppRunConfiguration,
-  isPaidPlanType,
   isRetrievalConfiguration,
   LightAgentConfigurationType,
   WorkspaceSegmentationType,
@@ -30,6 +29,7 @@ import { getDataSources } from "@app/lib/api/data_sources";
 import { GLOBAL_AGENTS_SID } from "@app/lib/assistant";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { useSubmitFunction } from "@app/lib/client/utils";
+import { isUpgraded } from "@app/lib/plans/free_plans";
 import {
   FREE_TEST_PLAN_CODE,
   FREE_UPGRADED_PLAN_CODE,
@@ -652,7 +652,7 @@ const WorkspacePage = ({
                           variant="secondaryWarning"
                           onClick={onDowngrade}
                           disabled={
-                            !isPaidPlanType(subscription.plan) ||
+                            !isUpgraded(subscription.plan) ||
                             workspaceHasManagedDataSources
                           }
                         />
@@ -662,7 +662,7 @@ const WorkspacePage = ({
                           label="Upgrade to free upgraded plan"
                           variant="tertiary"
                           onClick={onUpgrade}
-                          disabled={isPaidPlanType(subscription.plan)}
+                          disabled={isUpgraded(subscription.plan)}
                         />
                       </div>
                     </div>

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -15,12 +15,7 @@ import {
   Popup,
   Searchbar,
 } from "@dust-tt/sparkle";
-import {
-  isPaidPlanType,
-  RoleType,
-  UserType,
-  WorkspaceType,
-} from "@dust-tt/types";
+import { RoleType, UserType, WorkspaceType } from "@dust-tt/types";
 import { MembershipInvitationType } from "@dust-tt/types";
 import { PlanType, SubscriptionType } from "@dust-tt/types";
 import { UsersIcon } from "@heroicons/react/20/solid";
@@ -33,6 +28,7 @@ import AppLayout from "@app/components/sparkle/AppLayout";
 import { subNavigationAdmin } from "@app/components/sparkle/navigation";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
+import { isUpgraded } from "@app/lib/plans/free_plans";
 import { useMembers, useWorkspaceInvitations } from "@app/lib/swr";
 import { classNames, isEmailValid } from "@app/lib/utils";
 
@@ -157,7 +153,7 @@ export default function WorkspaceAdmin({
                     size="sm"
                     icon={Cog6ToothIcon}
                     onClick={() => {
-                      if (!isPaidPlanType(plan)) setShowNoInviteLinkPopup(true);
+                      if (!isUpgraded(plan)) setShowNoInviteLinkPopup(true);
                       else setInviteSettingsModalOpen(true);
                     }}
                   />
@@ -281,7 +277,7 @@ export default function WorkspaceAdmin({
                 size="sm"
                 icon={PlusIcon}
                 onClick={() => {
-                  if (!isPaidPlanType(plan)) setShowNoInviteFreePlanPopup(true);
+                  if (!isUpgraded(plan)) setShowNoInviteFreePlanPopup(true);
                   else if (subscription.paymentFailingSince)
                     setShowNoInviteFailedPaymentPopup(true);
                   else setInviteEmailModalOpen(true);

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -33,7 +33,6 @@ import AppLayout from "@app/components/sparkle/AppLayout";
 import { subNavigationAdmin } from "@app/components/sparkle/navigation";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
-import { FREE_TEST_PLAN_CODE } from "@app/lib/plans/plan_codes";
 import { useMembers, useWorkspaceInvitations } from "@app/lib/swr";
 import { classNames, isEmailValid } from "@app/lib/utils";
 

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -15,7 +15,12 @@ import {
   Popup,
   Searchbar,
 } from "@dust-tt/sparkle";
-import { RoleType, UserType, WorkspaceType } from "@dust-tt/types";
+import {
+  isPaidPlanType,
+  RoleType,
+  UserType,
+  WorkspaceType,
+} from "@dust-tt/types";
 import { MembershipInvitationType } from "@dust-tt/types";
 import { PlanType, SubscriptionType } from "@dust-tt/types";
 import { UsersIcon } from "@heroicons/react/20/solid";
@@ -153,8 +158,7 @@ export default function WorkspaceAdmin({
                     size="sm"
                     icon={Cog6ToothIcon}
                     onClick={() => {
-                      if (plan.code === FREE_TEST_PLAN_CODE)
-                        setShowNoInviteLinkPopup(true);
+                      if (!isPaidPlanType(plan)) setShowNoInviteLinkPopup(true);
                       else setInviteSettingsModalOpen(true);
                     }}
                   />
@@ -278,8 +282,7 @@ export default function WorkspaceAdmin({
                 size="sm"
                 icon={PlusIcon}
                 onClick={() => {
-                  if (plan.code === FREE_TEST_PLAN_CODE)
-                    setShowNoInviteFreePlanPopup(true);
+                  if (!isPaidPlanType(plan)) setShowNoInviteFreePlanPopup(true);
                   else if (subscription.paymentFailingSince)
                     setShowNoInviteFailedPaymentPopup(true);
                   else setInviteEmailModalOpen(true);

--- a/front/pages/w/[wId]/subscription/index.tsx
+++ b/front/pages/w/[wId]/subscription/index.tsx
@@ -7,7 +7,7 @@ import {
   ShapesIcon,
   Spinner,
 } from "@dust-tt/sparkle";
-import { isPaidPlanType, UserType, WorkspaceType } from "@dust-tt/types";
+import { UserType, WorkspaceType } from "@dust-tt/types";
 import { PlanInvitationType, SubscriptionType } from "@dust-tt/types";
 import { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import Link from "next/link";
@@ -20,6 +20,7 @@ import { subNavigationAdmin } from "@app/components/sparkle/navigation";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
 import { useSubmitFunction } from "@app/lib/client/utils";
+import { isUpgraded } from "@app/lib/plans/free_plans";
 import {
   FREE_TEST_PLAN_CODE,
   FREE_UPGRADED_PLAN_CODE,
@@ -166,7 +167,7 @@ export default function Subscription({
   const isProcessing = isSubscribingPlan || isGoingToStripePortal;
 
   const plan = subscription.plan;
-  const chipColor = !isPaidPlanType(plan) ? "emerald" : "sky";
+  const chipColor = !isUpgraded(plan) ? "emerald" : "sky";
 
   const onClickProPlan = async () => handleSubscribePlan();
   const onClickEnterprisePlan = () => {

--- a/front/pages/w/[wId]/subscription/index.tsx
+++ b/front/pages/w/[wId]/subscription/index.tsx
@@ -7,7 +7,7 @@ import {
   ShapesIcon,
   Spinner,
 } from "@dust-tt/sparkle";
-import { UserType, WorkspaceType } from "@dust-tt/types";
+import { isPaidPlanType, UserType, WorkspaceType } from "@dust-tt/types";
 import { PlanInvitationType, SubscriptionType } from "@dust-tt/types";
 import { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import Link from "next/link";
@@ -131,7 +131,7 @@ export default function Subscription({
         if (content.checkoutUrl) {
           await router.push(content.checkoutUrl);
         } else if (content.success) {
-          await router.reload(); // We cannot swr the plan so we just reload the page.
+          router.reload(); // We cannot swr the plan so we just reload the page.
         }
       }
     });
@@ -166,7 +166,7 @@ export default function Subscription({
   const isProcessing = isSubscribingPlan || isGoingToStripePortal;
 
   const plan = subscription.plan;
-  const chipColor = plan.code === FREE_TEST_PLAN_CODE ? "emerald" : "sky";
+  const chipColor = !isPaidPlanType(plan) ? "emerald" : "sky";
 
   const onClickProPlan = async () => handleSubscribePlan();
   const onClickEnterprisePlan = () => {

--- a/types/src/front/plan.ts
+++ b/types/src/front/plan.ts
@@ -43,25 +43,6 @@ export type PaidBillingType = (typeof PAID_BILLING_TYPES)[number];
 export const SUBSCRIPTION_STATUSES = ["active", "ended"] as const;
 export type SubscriptionStatusType = (typeof SUBSCRIPTION_STATUSES)[number];
 
-export function isFreeBillingType(
-  billingType: FreeBillingType | PaidBillingType
-): billingType is FreeBillingType {
-  return billingType in FREE_BILLING_TYPES;
-}
-
-export function isPaidBillingType(
-  billingType: FreeBillingType | PaidBillingType
-): billingType is PaidBillingType {
-  return billingType in PAID_BILLING_TYPES;
-}
-
-export function isPaidPlanType(plan: PlanType | null): boolean {
-  if (!plan) {
-    return false;
-  }
-  return isPaidBillingType(plan.billingType);
-}
-
 export type PlanType = {
   code: string;
   name: string;

--- a/types/src/front/plan.ts
+++ b/types/src/front/plan.ts
@@ -43,6 +43,25 @@ export type PaidBillingType = (typeof PAID_BILLING_TYPES)[number];
 export const SUBSCRIPTION_STATUSES = ["active", "ended"] as const;
 export type SubscriptionStatusType = (typeof SUBSCRIPTION_STATUSES)[number];
 
+export function isFreeBillingType(
+  billingType: FreeBillingType | PaidBillingType
+): billingType is FreeBillingType {
+  return billingType in FREE_BILLING_TYPES;
+}
+
+export function isPaidBillingType(
+  billingType: FreeBillingType | PaidBillingType
+): billingType is PaidBillingType {
+  return billingType in PAID_BILLING_TYPES;
+}
+
+export function isPaidPlanType(plan: PlanType | null): boolean {
+  if (!plan) {
+    return false;
+  }
+  return isPaidBillingType(plan.billingType);
+}
+
 export type PlanType = {
   code: string;
   name: string;


### PR DESCRIPTION
- Refactor way to test if a plan is paid or not
- Remove as may references to FREE_TEST_PLAN_CODE as possible
- bump limits of paid users from 50 to 200 messages / 3h