### PR TITLE
API route: DataSource tokenization (V1)

### DIFF
--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -2240,6 +2240,30 @@ async fn tokenize(
     }
 }
 
+#[derive(serde::Deserialize)]
+struct FakeTokenize {
+    text: String,
+    ds_name: String,
+    credentials: Option<run::Credentials>,
+}
+async fn fake_tokenize(
+    extract::Json(payload): extract::Json<FakeTokenize>,
+) -> (StatusCode, Json<APIResponse>) {
+    // Just log the text and ds name
+    utils::info(&format!(
+        "Fake tokenize: text: {}, ds_name: {}",
+        payload.text, payload.ds_name
+    ));
+
+    (
+        StatusCode::OK,
+        Json(APIResponse {
+            error: None,
+            response: Some(json!({ "text": payload.text })),
+        }),
+    )
+}
+
 fn main() {
     let rt = tokio::runtime::Builder::new_multi_thread()
         .worker_threads(32)
@@ -2405,6 +2429,7 @@ fn main() {
         .route("/sqlite_workers", delete(sqlite_workers_delete))
         // Misc
         .route("/tokenize", post(tokenize))
+        .route("/fake_tokenize", post(fake_tokenize))
 
         // Extensions
         .layer(DefaultBodyLimit::disable())

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tokenize.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tokenize.ts
@@ -1,22 +1,13 @@
-import { CoreAPITokenType, DocumentType } from "@dust-tt/types";
-import { isLeft } from "fp-ts/lib/Either";
-import * as reporter from "io-ts-reporters";
-import * as t from "io-ts";
-
-import { CredentialsType } from "@dust-tt/types";
-import {
-  credentialsFromProviders,
-  dustManagedCredentials,
-} from "@dust-tt/types";
+import { CoreAPITokenType } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
 import { ReturnedAPIErrorType } from "@dust-tt/types";
-import { JSONSchemaType } from "ajv";
+import { isLeft } from "fp-ts/lib/Either";
+import * as t from "io-ts";
+import * as reporter from "io-ts-reporters";
 import { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSource } from "@app/lib/api/data_sources";
 import { Authenticator, getAPIKey } from "@app/lib/auth";
-import { parse_payload } from "@app/lib/http_utils";
-import { Provider } from "@app/lib/models";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 
@@ -107,7 +98,7 @@ export default async function handler(
         status_code: 405,
         api_error: {
           type: "method_not_supported_error",
-          message: "The method passed is not supported, GET is expected.",
+          message: "The method passed is not supported, POST is expected.",
         },
       });
   }

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tokenize.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tokenize.ts
@@ -1,0 +1,114 @@
+import { CoreAPITokenType, DocumentType } from "@dust-tt/types";
+import { isLeft } from "fp-ts/lib/Either";
+import * as reporter from "io-ts-reporters";
+import * as t from "io-ts";
+
+import { CredentialsType } from "@dust-tt/types";
+import {
+  credentialsFromProviders,
+  dustManagedCredentials,
+} from "@dust-tt/types";
+import { CoreAPI } from "@dust-tt/types";
+import { ReturnedAPIErrorType } from "@dust-tt/types";
+import { JSONSchemaType } from "ajv";
+import { NextApiRequest, NextApiResponse } from "next";
+
+import { getDataSource } from "@app/lib/api/data_sources";
+import { Authenticator, getAPIKey } from "@app/lib/auth";
+import { parse_payload } from "@app/lib/http_utils";
+import { Provider } from "@app/lib/models";
+import logger from "@app/logger/logger";
+import { apiError } from "@app/logger/withlogging";
+
+export type PostDatasourceTokenizeBody = {
+  text: string;
+};
+
+const PostDatasourceTokenizeBodySchema = t.type({
+  text: t.string,
+});
+
+type PostDatasourceTokenizeResponseBody = {
+  tokens: CoreAPITokenType[];
+};
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    PostDatasourceTokenizeResponseBody | ReturnedAPIErrorType
+  >
+): Promise<void> {
+  const keyRes = await getAPIKey(req);
+  if (keyRes.isErr()) {
+    return apiError(req, res, keyRes.error);
+  }
+  const { auth } = await Authenticator.fromKey(
+    keyRes.value,
+    req.query.wId as string
+  );
+
+  if (!auth.workspace() || !auth.isBuilder()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "You don't have permission to access this resource.",
+      },
+    });
+  }
+  const dataSource = await getDataSource(auth, req.query.name as string);
+
+  if (!dataSource) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "data_source_not_found",
+        message: "The data source you requested was not found.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "POST": {
+      const bodyValidation = PostDatasourceTokenizeBodySchema.decode(req.body);
+      if (isLeft(bodyValidation)) {
+        const pathError = reporter.formatValidationErrors(bodyValidation.left);
+
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid request body: ${pathError}`,
+          },
+        });
+      }
+      const text = bodyValidation.right.text;
+      const coreAPI = new CoreAPI(logger);
+      const coreTokenizeRes = await coreAPI.dataSourceTokenize({
+        projectId: dataSource.dustAPIProjectId,
+        dataSourceName: dataSource.name,
+        text,
+      });
+      if (coreTokenizeRes.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: `Error tokenizing text: ${coreTokenizeRes.error.message}`,
+          },
+        });
+      }
+      const tokens = coreTokenizeRes.value.tokens;
+      res.status(200).json({ tokens });
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tokenize.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tokenize.ts
@@ -91,6 +91,7 @@ export default async function handler(
       }
       const tokens = coreTokenizeRes.value.tokens;
       res.status(200).json({ tokens });
+      return;
     }
 
     default:

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -825,6 +825,28 @@ export class CoreAPI {
     return _resultFromResponse(response);
   }
 
+  async fakeTokenize({
+    text,
+    ds_name,
+  }: {
+    text: string;
+    ds_name: string;
+  }): Promise<CoreAPIResponse<{ data: string }>> {
+    const credentials = dustManagedCredentials();
+    const response = await fetch(`${CORE_API}/fake_tokenize`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        text,
+        ds_name,
+        credentials,
+      }),
+    });
+    return _resultFromResponse(response);
+  }
+
   async upsertTable({
     projectId,
     dataSourceName,

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -825,25 +825,25 @@ export class CoreAPI {
     return _resultFromResponse(response);
   }
 
-  async fakeTokenize({
+  async dataSourceTokenize({
     text,
-    ds_name,
+    projectId,
+    dataSourceName,
   }: {
     text: string;
-    ds_name: string;
+    projectId: string;
+    dataSourceName: string;
   }): Promise<CoreAPIResponse<{ data: string }>> {
-    const credentials = dustManagedCredentials();
-    const response = await fetch(`${CORE_API}/fake_tokenize`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        text,
-        ds_name,
-        credentials,
-      }),
-    });
+    const response = await fetch(
+      `${CORE_API}/projects/${projectId}/data_sources/${dataSourceName}/tokenize`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ text }),
+      }
+    );
     return _resultFromResponse(response);
   }
 

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -833,7 +833,7 @@ export class CoreAPI {
     text: string;
     projectId: string;
     dataSourceName: string;
-  }): Promise<CoreAPIResponse<{ data: string }>> {
+  }): Promise<CoreAPIResponse<{ tokens: CoreAPITokenType[] }>> {
     const response = await fetch(
       `${CORE_API}/projects/${projectId}/data_sources/${dataSourceName}/tokenize`,
       {


### PR DESCRIPTION
See #3237 
- Core API route to tokenize according to a given datasource setting
- Front API V1 route to call this