### PR TITLE
Autojoin workspace on signup

### DIFF
--- a/front/lib/models/workspace.ts
+++ b/front/lib/models/workspace.ts
@@ -88,6 +88,7 @@ export class WorkspaceHasDomain extends Model<
   declare updatedAt: CreationOptional<Date>;
 
   declare workspaceId: ForeignKey<Workspace["id"]>;
+  declare workspace?: NonAttribute<Workspace>;
 }
 WorkspaceHasDomain.init(
   {

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -66,275 +66,269 @@ async function handler(
     return;
   }
 
-  switch (req.method) {
-    case "GET":
-      // `workspaceInvite` is set to a `Workspace` if the query includes a `wId`. It means the user
-      // is going through the flow of whitelisted domain to join the workspace.
-      let workspaceInvite: null | Workspace = null;
-      let isAdminOnboarding = false;
-
-      if (req.query.wId) {
-        workspaceInvite = await Workspace.findOne({
-          where: {
-            sId: req.query.wId as string,
-          },
-        });
-
-        if (workspaceInvite) {
-          const allowedDomain = workspaceInvite.allowedDomain;
-          if (!allowedDomain) {
-            return apiError(req, res, {
-              status_code: 400,
-              api_error: {
-                type: "invalid_request_error",
-                message:
-                  "The workspace you are trying to join does not allow your domain name, contact us at team@dust.tt for assistance.",
-              },
-            });
-          }
-
-          if (
-            session.provider.provider !== "google" ||
-            !session.user.email_verified
-          ) {
-            return apiError(req, res, {
-              status_code: 401,
-              api_error: {
-                type: "workspace_auth_error",
-                message:
-                  "You can only join a workspace using Google sign-in with a verified email, contact us at team@dust.tt for assistance.",
-              },
-            });
-          }
-
-          if (allowedDomain !== session.user.email.split("@")[1]) {
-            res.redirect(
-              `/login-error?domain=${session.user.email.split("@")[1]}`
-            );
-            return;
-          }
-        }
-      }
-
-      // `membershipInvite` is set to a `MembeshipInvitation` if the query includes an
-      // `inviteToken`, meaning the user is going through the invite by email flow.
-      let membershipInvite: MembershipInvitation | null = null;
-
-      if (req.query.inviteToken) {
-        const inviteToken = req.query.inviteToken as string;
-        const decodedToken = verify(inviteToken, DUST_INVITE_TOKEN_SECRET) as {
-          membershipInvitationId: number;
-        };
-
-        membershipInvite = await MembershipInvitation.findOne({
-          where: {
-            id: decodedToken.membershipInvitationId,
-          },
-        });
-        if (!membershipInvite) {
-          return apiError(req, res, {
-            status_code: 400,
-            api_error: {
-              type: "invalid_request_error",
-              message:
-                "The invite token is invalid, please ask your admin to resend an invitation.",
-            },
-          });
-        }
-        if (membershipInvite.status !== "pending") {
-          membershipInvite = null;
-        }
-      }
-
-      // Login flow: first step is to attempt to find the user.
-      let user = await User.findOne({
-        where: {
-          provider: session.provider.provider,
-          providerId: session.provider.id.toString(),
-        },
-      });
-
-      // The user already exists, we create memberships as needed given the values of
-      // `workspaceInvite` and `membershipInvite`.
-      if (user) {
-        // Update the user object from the updated session information.
-        user.username = session.user.username;
-        user.email = session.user.email;
-        user.name = session.user.name;
-
-        if (!user.firstName && !user.lastName) {
-          const { firstName, lastName } = guessFirstandLastNameFromFullName(
-            session.user.name
-          );
-          user.firstName = firstName;
-          user.lastName = lastName;
-        }
-
-        await user.save();
-      }
-
-      // The user does not exist. We create it and create a personal workspace if there is no invite
-      // associated with the login request.
-      if (!user) {
-        const { firstName, lastName } = guessFirstandLastNameFromFullName(
-          session.user.name
-        );
-
-        user = await User.create({
-          provider: session.provider.provider,
-          providerId: session.provider.id.toString(),
-          username: session.user.username,
-          email: session.user.email,
-          name: session.user.name,
-          firstName,
-          lastName,
-        });
-
-        // If there is no invte, we create a personal workspace for the user, otherwise the user
-        // will be added to the workspace they were invited to (either by email or by domain) below.
-        if (!workspaceInvite && !membershipInvite) {
-          const workspace = await createWorkspace(session);
-          await _createAndLogMembership({
-            workspace,
-            userId: user.id,
-            role: "admin",
-          });
-
-          await internalSubscribeWorkspaceToFreeTestPlan({
-            workspaceId: workspace.sId,
-          });
-          isAdminOnboarding = true;
-        }
-      }
-
-      let targetWorkspace: Workspace | null = null;
-
-      // `workspaceInvite` flow: we know we can add the user to the workspace as all the checks
-      // have been run. Simply create the membership if does not alreayd exist.
-      if (workspaceInvite) {
-        let m = await Membership.findOne({
-          where: {
-            userId: user.id,
-            workspaceId: workspaceInvite.id,
-          },
-        });
-
-        if (!m) {
-          m = await _createAndLogMembership({
-            workspace: workspaceInvite,
-            userId: user.id,
-            role: "user",
-          });
-        }
-
-        if (m.role === "revoked") {
-          return apiError(req, res, {
-            status_code: 400,
-            api_error: {
-              type: "invalid_request_error",
-              message:
-                "Your access to the workspace has been revoked, please contact the workspace admin to update your role.",
-            },
-          });
-        }
-
-        targetWorkspace = workspaceInvite;
-      }
-
-      // `membershipInvite` flow: we know we can add the user to the associated `workspaceId` as
-      // all the checkcs (decoding the JWT) have been run before. Simply create the membership if
-      // it does not already exist and mark the invitation as consumed.
-      if (membershipInvite) {
-        let m = await Membership.findOne({
-          where: {
-            userId: user.id,
-            workspaceId: membershipInvite.workspaceId,
-          },
-        });
-
-        targetWorkspace = await Workspace.findOne({
-          where: {
-            id: membershipInvite.workspaceId,
-          },
-        });
-
-        if (!targetWorkspace) {
-          return apiError(req, res, {
-            status_code: 400,
-            api_error: {
-              type: "invalid_request_error",
-              message:
-                "The invite token is invalid, please ask your admin to resend an invitation.",
-            },
-          });
-        }
-
-        if (!m) {
-          m = await _createAndLogMembership({
-            workspace: targetWorkspace,
-            userId: user.id,
-            role: "user",
-          });
-        }
-        membershipInvite.status = "consumed";
-        membershipInvite.invitedUserId = user.id;
-        await membershipInvite.save();
-
-        if (m.role === "revoked") {
-          return apiError(req, res, {
-            status_code: 400,
-            api_error: {
-              type: "invalid_request_error",
-              message:
-                "Your access to the workspace has been revoked, please contact the workspace admin to update your role.",
-            },
-          });
-        }
-      }
-
-      const u = await getUserFromSession(session);
-
-      if (!u || u.workspaces.length === 0) {
-        return apiError(req, res, {
-          status_code: 500,
-          api_error: {
-            type: "internal_server_error",
-            message:
-              "Could not find user or workspace for user, contact us at team@dust.tt for assistance.",
-          },
-        });
-      }
-
-      if (targetWorkspace) {
-        // For users joining a workspace from trying to access a conversation, we redirect to this conversation after signing in.
-        if (req.query.join === "true" && req.query.cId) {
-          res.redirect(
-            `/w/${targetWorkspace.sId}/welcome?cId=${req.query.cId}`
-          );
-          return;
-        }
-        res.redirect(`/w/${targetWorkspace.sId}/welcome`);
-        return;
-      }
-
-      if (isAdminOnboarding) {
-        res.redirect(`/w/${u.workspaces[0].sId}/welcome`);
-        return;
-      }
-
-      res.redirect(`/w/${u.workspaces[0].sId}`);
-
-      return;
-
-    default:
-      return apiError(req, res, {
-        status_code: 405,
-        api_error: {
-          type: "method_not_supported_error",
-          message: "The method passed is not supported, GET is expected.",
-        },
-      });
+  if (req.method !== "GET") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, GET is expected.",
+      },
+    });
   }
+
+  // `workspaceInvite` is set to a `Workspace` if the query includes a `wId`. It means the user
+  // is going through the flow of whitelisted domain to join the workspace.
+  let workspaceInvite: null | Workspace = null;
+  let isAdminOnboarding = false;
+
+  if (req.query.wId) {
+    workspaceInvite = await Workspace.findOne({
+      where: {
+        sId: req.query.wId as string,
+      },
+    });
+
+    if (workspaceInvite) {
+      const allowedDomain = workspaceInvite.allowedDomain;
+      if (!allowedDomain) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              "The workspace you are trying to join does not allow your domain name, contact us at team@dust.tt for assistance.",
+          },
+        });
+      }
+
+      if (
+        session.provider.provider !== "google" ||
+        !session.user.email_verified
+      ) {
+        return apiError(req, res, {
+          status_code: 401,
+          api_error: {
+            type: "workspace_auth_error",
+            message:
+              "You can only join a workspace using Google sign-in with a verified email, contact us at team@dust.tt for assistance.",
+          },
+        });
+      }
+
+      if (allowedDomain !== session.user.email.split("@")[1]) {
+        res.redirect(`/login-error?domain=${session.user.email.split("@")[1]}`);
+        return;
+      }
+    }
+  }
+
+  // `membershipInvite` is set to a `MembeshipInvitation` if the query includes an
+  // `inviteToken`, meaning the user is going through the invite by email flow.
+  let membershipInvite: MembershipInvitation | null = null;
+
+  if (req.query.inviteToken) {
+    const inviteToken = req.query.inviteToken as string;
+    const decodedToken = verify(inviteToken, DUST_INVITE_TOKEN_SECRET) as {
+      membershipInvitationId: number;
+    };
+
+    membershipInvite = await MembershipInvitation.findOne({
+      where: {
+        id: decodedToken.membershipInvitationId,
+      },
+    });
+    if (!membershipInvite) {
+      return apiError(req, res, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message:
+            "The invite token is invalid, please ask your admin to resend an invitation.",
+        },
+      });
+    }
+    if (membershipInvite.status !== "pending") {
+      membershipInvite = null;
+    }
+  }
+
+  // Login flow: first step is to attempt to find the user.
+  let user = await User.findOne({
+    where: {
+      provider: session.provider.provider,
+      providerId: session.provider.id.toString(),
+    },
+  });
+
+  // The user already exists, we create memberships as needed given the values of
+  // `workspaceInvite` and `membershipInvite`.
+  if (user) {
+    // Update the user object from the updated session information.
+    user.username = session.user.username;
+    user.email = session.user.email;
+    user.name = session.user.name;
+
+    if (!user.firstName && !user.lastName) {
+      const { firstName, lastName } = guessFirstandLastNameFromFullName(
+        session.user.name
+      );
+      user.firstName = firstName;
+      user.lastName = lastName;
+    }
+
+    await user.save();
+  }
+
+  // The user does not exist. We create it and create a personal workspace if there is no invite
+  // associated with the login request.
+  if (!user) {
+    const { firstName, lastName } = guessFirstandLastNameFromFullName(
+      session.user.name
+    );
+
+    user = await User.create({
+      provider: session.provider.provider,
+      providerId: session.provider.id.toString(),
+      username: session.user.username,
+      email: session.user.email,
+      name: session.user.name,
+      firstName,
+      lastName,
+    });
+
+    // If there is no invte, we create a personal workspace for the user, otherwise the user
+    // will be added to the workspace they were invited to (either by email or by domain) below.
+    if (!workspaceInvite && !membershipInvite) {
+      const workspace = await createWorkspace(session);
+      await _createAndLogMembership({
+        workspace,
+        userId: user.id,
+        role: "admin",
+      });
+
+      await internalSubscribeWorkspaceToFreeTestPlan({
+        workspaceId: workspace.sId,
+      });
+      isAdminOnboarding = true;
+    }
+  }
+
+  let targetWorkspace: Workspace | null = null;
+
+  // `workspaceInvite` flow: we know we can add the user to the workspace as all the checks
+  // have been run. Simply create the membership if does not alreayd exist.
+  if (workspaceInvite) {
+    let m = await Membership.findOne({
+      where: {
+        userId: user.id,
+        workspaceId: workspaceInvite.id,
+      },
+    });
+
+    if (!m) {
+      m = await _createAndLogMembership({
+        workspace: workspaceInvite,
+        userId: user.id,
+        role: "user",
+      });
+    }
+
+    if (m.role === "revoked") {
+      return apiError(req, res, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message:
+            "Your access to the workspace has been revoked, please contact the workspace admin to update your role.",
+        },
+      });
+    }
+
+    targetWorkspace = workspaceInvite;
+  }
+
+  // `membershipInvite` flow: we know we can add the user to the associated `workspaceId` as
+  // all the checkcs (decoding the JWT) have been run before. Simply create the membership if
+  // it does not already exist and mark the invitation as consumed.
+  if (membershipInvite) {
+    let m = await Membership.findOne({
+      where: {
+        userId: user.id,
+        workspaceId: membershipInvite.workspaceId,
+      },
+    });
+
+    targetWorkspace = await Workspace.findOne({
+      where: {
+        id: membershipInvite.workspaceId,
+      },
+    });
+
+    if (!targetWorkspace) {
+      return apiError(req, res, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message:
+            "The invite token is invalid, please ask your admin to resend an invitation.",
+        },
+      });
+    }
+
+    if (!m) {
+      m = await _createAndLogMembership({
+        workspace: targetWorkspace,
+        userId: user.id,
+        role: "user",
+      });
+    }
+    membershipInvite.status = "consumed";
+    membershipInvite.invitedUserId = user.id;
+    await membershipInvite.save();
+
+    if (m.role === "revoked") {
+      return apiError(req, res, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message:
+            "Your access to the workspace has been revoked, please contact the workspace admin to update your role.",
+        },
+      });
+    }
+  }
+
+  const u = await getUserFromSession(session);
+
+  if (!u || u.workspaces.length === 0) {
+    return apiError(req, res, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message:
+          "Could not find user or workspace for user, contact us at team@dust.tt for assistance.",
+      },
+    });
+  }
+
+  if (targetWorkspace) {
+    // For users joining a workspace from trying to access a conversation, we redirect to this conversation after signing in.
+    if (req.query.join === "true" && req.query.cId) {
+      res.redirect(`/w/${targetWorkspace.sId}/welcome?cId=${req.query.cId}`);
+      return;
+    }
+    res.redirect(`/w/${targetWorkspace.sId}/welcome`);
+    return;
+  }
+
+  if (isAdminOnboarding) {
+    res.redirect(`/w/${u.workspaces[0].sId}/welcome`);
+    return;
+  }
+
+  res.redirect(`/w/${u.workspaces[0].sId}`);
+
+  return;
 }
 
 async function _createAndLogMembership({

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -50,6 +50,8 @@ async function createWorkspace(session: any) {
     try {
       await WorkspaceHasDomain.create({
         domain: verifiedDomain,
+        domainAutoJoinEnabled: false,
+        workspaceId: workspace.id,
       });
     } catch (err) {
       // `WorkspaceHasDomain` table has a unique constraint on the domain column.

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -66,7 +66,7 @@ async function findWorkspaceWithWhitelistedDomain(session: any) {
   const { user } = session;
 
   if (!isGoogleSession(session) || !user.email_verified) {
-    return;
+    return undefined;
   }
 
   const [, userEmailDomain] = user.email.split("@");
@@ -135,10 +135,7 @@ async function handler(
         });
       }
 
-      if (
-        session.provider.provider !== "google" ||
-        !session.user.email_verified
-      ) {
+      if (!isGoogleSession(session) || !session.user.email_verified) {
         return apiError(req, res, {
           status_code: 401,
           api_error: {

--- a/front/pages/w/[wId]/welcome.tsx
+++ b/front/pages/w/[wId]/welcome.tsx
@@ -149,11 +149,14 @@ export default function Welcome({
               Let's check a few things.
             </p>
           </div>
-          <div>
-            <p>
-              Your email is <span className="font-bold">{user.email}</span>.
-            </p>
-          </div>
+          {!isAdmin && (
+            <div>
+              <p>
+                Your will be joining the workspace of{" "}
+                <span className="font-bold">{owner.name}</span>.
+              </p>
+            </div>
+          )}
           <div>
             <p className="pb-2">Your name is:</p>
             <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">

--- a/front/pages/w/[wId]/welcome.tsx
+++ b/front/pages/w/[wId]/welcome.tsx
@@ -152,7 +152,7 @@ export default function Welcome({
           {!isAdmin && (
             <div>
               <p>
-                Your will be joining the workspace of{" "}
+                You will be joining the workspace:{" "}
                 <span className="font-bold">{owner.name}</span>.
               </p>
             </div>


### PR DESCRIPTION
This PR implements a check that, during the sign-up of a new user, determines if there is an existing and whitelisted workspace corresponding to the domain of the user's email, provided the email has been verified by Google Workspace. If such a workspace exists, the user will be automatically added to their company's workspace.

This PR has a significant blast radius, with the ability to disrupt the sign-up and sign-in processes. Tested both workflows locally, no issues arose.

![image](https://github.com/dust-tt/dust/assets/7428970/b6341ecc-f194-4fdf-b5a7-df3fa1883ba8)

## Test
- [x] Member invite
- [x] Workspace invite
- [x] Regular login
- [x] New user without workspace
- [x] Auto join disabled
- [x] Auto join enabled
