### PR TITLE
Eslint consistent type import

### DIFF
--- a/connectors/.eslintrc.js
+++ b/connectors/.eslintrc.js
@@ -29,6 +29,7 @@ module.exports = {
       },
     ],
     "simple-import-sort/exports": "error",
+    "@typescript-eslint/consistent-type-imports": "error",
     "@typescript-eslint/no-floating-promises": "error",
     "@typescript-eslint/no-unused-vars": "error",
     "@typescript-eslint/return-await": ["error", "in-try-catch"],

--- a/connectors/migrations/20240110_batch_resync_notion_connectors.ts
+++ b/connectors/migrations/20240110_batch_resync_notion_connectors.ts
@@ -1,4 +1,4 @@
-import { Result } from "@dust-tt/types";
+import type { Result } from "@dust-tt/types";
 import parseArgs from "minimist";
 import readline from "readline";
 

--- a/connectors/migrations/20240111_batch_resync_google_drive_connectors.ts
+++ b/connectors/migrations/20240111_batch_resync_google_drive_connectors.ts
@@ -1,4 +1,4 @@
-import { Result } from "@dust-tt/types";
+import type { Result } from "@dust-tt/types";
 import parseArgs from "minimist";
 import readline from "readline";
 

--- a/connectors/src/admin/cli.ts
+++ b/connectors/src/admin/cli.ts
@@ -37,7 +37,7 @@ import { GoogleDriveFiles } from "@connectors/lib/models/google_drive";
 import { NotionDatabase, NotionPage } from "@connectors/lib/models/notion";
 import { SlackConfiguration } from "@connectors/lib/models/slack";
 import { nango_client } from "@connectors/lib/nango_client";
-import { Result } from "@connectors/lib/result";
+import type { Result } from "@connectors/lib/result";
 import {
   getTemporalClient,
   terminateAllWorkflowsForConnectorId,

--- a/connectors/src/admin/db.ts
+++ b/connectors/src/admin/db.ts
@@ -1,4 +1,4 @@
-import { Sequelize } from "sequelize";
+import type { Sequelize } from "sequelize";
 
 import { Connector, sequelize_conn } from "@connectors/lib/models";
 import {

--- a/connectors/src/api/connector_config.ts
+++ b/connectors/src/api/connector_config.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from "express";
+import type { Request, Response } from "express";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
@@ -9,7 +9,7 @@ import {
 } from "@connectors/connectors";
 import { Connector } from "@connectors/lib/models";
 import { apiError, withLogging } from "@connectors/logger/withlogging";
-import { ConnectorsAPIErrorResponse } from "@connectors/types/errors";
+import type { ConnectorsAPIErrorResponse } from "@connectors/types/errors";
 
 const ConfigSetReqBodySchema = t.type({
   configValue: t.string,

--- a/connectors/src/api/create_connector.ts
+++ b/connectors/src/api/create_connector.ts
@@ -1,19 +1,21 @@
-import {
-  assertNever,
-  ConnectorCreateRequestBodySchema,
+import type {
   ConnectorProvider,
   CreateConnectorOAuthRequestBodySchema,
   CreateConnectorUrlRequestBodySchema,
-  isConnectorProvider,
   Result,
 } from "@dust-tt/types";
-import { Request, Response } from "express";
+import {
+  assertNever,
+  ConnectorCreateRequestBodySchema,
+  isConnectorProvider,
+} from "@dust-tt/types";
+import type { Request, Response } from "express";
 import { isLeft } from "fp-ts/lib/Either";
-import * as t from "io-ts";
+import type * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 
 import { CREATE_CONNECTOR_BY_TYPE } from "@connectors/connectors";
-import {
+import type {
   ConnectorCreatorOAuth,
   ConnectorCreatorUrl,
 } from "@connectors/connectors/interface";
@@ -21,8 +23,8 @@ import { errorFromAny } from "@connectors/lib/error";
 import { Connector } from "@connectors/lib/models";
 import logger from "@connectors/logger/logger";
 import { apiError, withLogging } from "@connectors/logger/withlogging";
-import { ConnectorType } from "@connectors/types/connector";
-import { ConnectorsAPIErrorResponse } from "@connectors/types/errors";
+import type { ConnectorType } from "@connectors/types/connector";
+import type { ConnectorsAPIErrorResponse } from "@connectors/types/errors";
 
 type ConnectorCreateResBody = ConnectorType | ConnectorsAPIErrorResponse;
 

--- a/connectors/src/api/delete_connector.ts
+++ b/connectors/src/api/delete_connector.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from "express";
+import type { Request, Response } from "express";
 
 import {
   DELETE_CONNECTOR_BY_TYPE,
@@ -7,7 +7,7 @@ import {
 import { Connector } from "@connectors/lib/models";
 import { terminateAllWorkflowsForConnectorId } from "@connectors/lib/temporal";
 import { apiError, withLogging } from "@connectors/logger/withlogging";
-import { ConnectorsAPIErrorResponse } from "@connectors/types/errors";
+import type { ConnectorsAPIErrorResponse } from "@connectors/types/errors";
 
 type ConnectorDeleteReqBody = {
   dataSourceName: string;

--- a/connectors/src/api/get_connector.ts
+++ b/connectors/src/api/get_connector.ts
@@ -1,11 +1,11 @@
-import { Request, Response } from "express";
+import type { Request, Response } from "express";
 
 import { Connector } from "@connectors/lib/models";
 import { GithubDiscussion, GithubIssue } from "@connectors/lib/models/github";
 import { NotionPage } from "@connectors/lib/models/notion";
 import { apiError, withLogging } from "@connectors/logger/withlogging";
-import { ConnectorType } from "@connectors/types/connector";
-import { ConnectorsAPIErrorResponse } from "@connectors/types/errors";
+import type { ConnectorType } from "@connectors/types/connector";
+import type { ConnectorsAPIErrorResponse } from "@connectors/types/errors";
 
 type GetConnectorRes = ConnectorType | ConnectorsAPIErrorResponse;
 

--- a/connectors/src/api/get_connector_permissions.ts
+++ b/connectors/src/api/get_connector_permissions.ts
@@ -1,10 +1,10 @@
-import { Request, Response } from "express";
+import type { Request, Response } from "express";
 
 import { RETRIEVE_CONNECTOR_PERMISSIONS_BY_TYPE } from "@connectors/connectors";
 import { Connector } from "@connectors/lib/models";
 import { apiError, withLogging } from "@connectors/logger/withlogging";
-import { ConnectorsAPIErrorResponse } from "@connectors/types/errors";
-import {
+import type { ConnectorsAPIErrorResponse } from "@connectors/types/errors";
+import type {
   ConnectorPermission,
   ConnectorResource,
 } from "@connectors/types/resources";

--- a/connectors/src/api/get_resources_parents.ts
+++ b/connectors/src/api/get_resources_parents.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from "express";
+import type { Request, Response } from "express";
 import { zip } from "fp-ts/lib/Array";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";

--- a/connectors/src/api/get_resources_titles.ts
+++ b/connectors/src/api/get_resources_titles.ts
@@ -1,11 +1,11 @@
-import { Request, Response } from "express";
+import type { Request, Response } from "express";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 
 import { BATCH_RETRIEVE_RESOURCE_TITLE_BY_TYPE } from "@connectors/connectors";
 import { Connector } from "@connectors/lib/models";
-import { Result } from "@connectors/lib/result";
+import type { Result } from "@connectors/lib/result";
 import { apiError, withLogging } from "@connectors/logger/withlogging";
 
 const GetResourcesTitlesRequestBodySchema = t.type({

--- a/connectors/src/api/resume_connector.ts
+++ b/connectors/src/api/resume_connector.ts
@@ -1,11 +1,11 @@
-import { Request, Response } from "express";
+import type { Request, Response } from "express";
 
 import { RESUME_CONNECTOR_BY_TYPE } from "@connectors/connectors";
 import { errorFromAny } from "@connectors/lib/error";
 import { Connector } from "@connectors/lib/models";
 import logger from "@connectors/logger/logger";
 import { apiError, withLogging } from "@connectors/logger/withlogging";
-import { ConnectorsAPIErrorResponse } from "@connectors/types/errors";
+import type { ConnectorsAPIErrorResponse } from "@connectors/types/errors";
 
 type ConnectorResumeResBody =
   | { connectorId: string }

--- a/connectors/src/api/set_connector_permissions.ts
+++ b/connectors/src/api/set_connector_permissions.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from "express";
+import type { Request, Response } from "express";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
@@ -6,7 +6,7 @@ import * as reporter from "io-ts-reporters";
 import { SET_CONNECTOR_PERMISSIONS_BY_TYPE } from "@connectors/connectors";
 import { Connector } from "@connectors/lib/models";
 import { apiError, withLogging } from "@connectors/logger/withlogging";
-import { ConnectorsAPIErrorResponse } from "@connectors/types/errors";
+import type { ConnectorsAPIErrorResponse } from "@connectors/types/errors";
 
 type SetConnectorPermissionsRes =
   | { success: true }

--- a/connectors/src/api/slack_channels_linked_with_agent.ts
+++ b/connectors/src/api/slack_channels_linked_with_agent.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from "express";
+import type { Request, Response } from "express";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
@@ -6,7 +6,7 @@ import { Op } from "sequelize";
 
 import { joinChannel } from "@connectors/connectors/slack/lib/channels";
 import { getChannels } from "@connectors/connectors/slack/temporal/activities";
-import { APIErrorWithStatusCode } from "@connectors/lib/error";
+import type { APIErrorWithStatusCode } from "@connectors/lib/error";
 import { sequelize_conn } from "@connectors/lib/models";
 import { SlackChannel } from "@connectors/lib/models/slack";
 import { apiError, withLogging } from "@connectors/logger/withlogging";

--- a/connectors/src/api/stop_connector.ts
+++ b/connectors/src/api/stop_connector.ts
@@ -1,11 +1,11 @@
-import { Request, Response } from "express";
+import type { Request, Response } from "express";
 
 import { STOP_CONNECTOR_BY_TYPE } from "@connectors/connectors";
 import { errorFromAny } from "@connectors/lib/error";
 import { Connector } from "@connectors/lib/models";
 import logger from "@connectors/logger/logger";
 import { apiError, withLogging } from "@connectors/logger/withlogging";
-import { ConnectorsAPIErrorResponse } from "@connectors/types/errors";
+import type { ConnectorsAPIErrorResponse } from "@connectors/types/errors";
 
 type ConnectorStopResBody =
   | { connectorId: string }

--- a/connectors/src/api/sync_connector.ts
+++ b/connectors/src/api/sync_connector.ts
@@ -1,9 +1,9 @@
-import { Request, Response } from "express";
+import type { Request, Response } from "express";
 
 import { SYNC_CONNECTOR_BY_TYPE } from "@connectors/connectors";
 import { Connector } from "@connectors/lib/models";
 import { withLogging } from "@connectors/logger/withlogging";
-import { ConnectorsAPIErrorResponse } from "@connectors/types/errors";
+import type { ConnectorsAPIErrorResponse } from "@connectors/types/errors";
 
 type GetSyncStatusRes = { workflowId: string } | ConnectorsAPIErrorResponse;
 

--- a/connectors/src/api/update_connector.ts
+++ b/connectors/src/api/update_connector.ts
@@ -1,9 +1,9 @@
-import { Request, Response } from "express";
+import type { Request, Response } from "express";
 
 import { UPDATE_CONNECTOR_BY_TYPE } from "@connectors/connectors";
 import { Connector } from "@connectors/lib/models";
 import { apiError, withLogging } from "@connectors/logger/withlogging";
-import { ConnectorsAPIErrorResponse } from "@connectors/types/errors";
+import type { ConnectorsAPIErrorResponse } from "@connectors/types/errors";
 
 type ConnectorUpdateReqBody = {
   connectionId?: string | null;

--- a/connectors/src/api/webhooks/webhook_github.ts
+++ b/connectors/src/api/webhooks/webhook_github.ts
@@ -1,5 +1,5 @@
 import { assertNever } from "@dust-tt/types";
-import { Request, Response } from "express";
+import type { Request, Response } from "express";
 import { isLeft } from "fp-ts/lib/Either";
 import * as reporter from "io-ts-reporters";
 import { Op } from "sequelize";
@@ -29,7 +29,7 @@ import {
 } from "@connectors/lib/models/github";
 import mainLogger from "@connectors/logger/logger";
 import { withLogging } from "@connectors/logger/withlogging";
-import { ConnectorsAPIErrorResponse } from "@connectors/types/errors";
+import type { ConnectorsAPIErrorResponse } from "@connectors/types/errors";
 
 const HANDLED_WEBHOOKS = {
   installation_repositories: new Set(["added", "removed"]),

--- a/connectors/src/api/webhooks/webhook_google_drive.ts
+++ b/connectors/src/api/webhooks/webhook_google_drive.ts
@@ -1,8 +1,8 @@
 import { RateLimitError } from "@dust-tt/types";
-import { Request, Response } from "express";
+import type { Request, Response } from "express";
 
 import { launchGoogleDriveIncrementalSyncWorkflow } from "@connectors/connectors/google_drive/temporal/client";
-import { APIErrorWithStatusCode } from "@connectors/lib/error";
+import type { APIErrorWithStatusCode } from "@connectors/lib/error";
 import { GoogleDriveWebhook } from "@connectors/lib/models/google_drive";
 import logger from "@connectors/logger/logger";
 import { apiError, withLogging } from "@connectors/logger/withlogging";

--- a/connectors/src/api/webhooks/webhook_slack.ts
+++ b/connectors/src/api/webhooks/webhook_slack.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from "express";
+import type { Request, Response } from "express";
 
 import { botAnswerMessageWithErrorHandling } from "@connectors/connectors/slack/bot";
 import { getBotUserIdMemoized } from "@connectors/connectors/slack/temporal/activities";
@@ -7,11 +7,12 @@ import {
   launchSlackSyncOneThreadWorkflow,
 } from "@connectors/connectors/slack/temporal/client";
 import { launchSlackGarbageCollectWorkflow } from "@connectors/connectors/slack/temporal/client";
-import { APIErrorWithStatusCode } from "@connectors/lib/error";
+import type { APIErrorWithStatusCode } from "@connectors/lib/error";
 import { Connector } from "@connectors/lib/models";
 import { SlackChannel, SlackConfiguration } from "@connectors/lib/models/slack";
 import { Ok } from "@connectors/lib/result";
-import mainLogger, { Logger } from "@connectors/logger/logger";
+import type { Logger } from "@connectors/logger/logger";
+import mainLogger from "@connectors/logger/logger";
 import { apiError, withLogging } from "@connectors/logger/withlogging";
 
 type SlackWebhookReqBody = {

--- a/connectors/src/connectors/confluence/index.ts
+++ b/connectors/src/connectors/confluence/index.ts
@@ -1,27 +1,28 @@
-import {
+import type {
   ConnectorPermission,
   ConnectorResource,
   ModelId,
 } from "@dust-tt/types";
-import { ConnectorsAPIErrorResponse } from "@dust-tt/types";
+import type { ConnectorsAPIErrorResponse } from "@dust-tt/types";
 
 import { confluenceConfig } from "@connectors/connectors/confluence/lib/config";
 import {
   getConfluenceCloudInformation,
   listConfluenceSpaces,
 } from "@connectors/connectors/confluence/lib/confluence_api";
-import { ConfluenceSpaceType } from "@connectors/connectors/confluence/lib/confluence_client";
-import { ConnectorPermissionRetriever } from "@connectors/connectors/interface";
+import type { ConfluenceSpaceType } from "@connectors/connectors/confluence/lib/confluence_client";
+import type { ConnectorPermissionRetriever } from "@connectors/connectors/interface";
 import { Connector, sequelize_conn } from "@connectors/lib/models";
 import {
   ConfluenceConfiguration,
   ConfluenceSpace,
 } from "@connectors/lib/models/confluence";
 import { getAccessTokenFromNango } from "@connectors/lib/nango_helpers";
-import { Err, Ok, Result } from "@connectors/lib/result";
+import type { Result } from "@connectors/lib/result";
+import { Err, Ok } from "@connectors/lib/result";
 import mainLogger from "@connectors/logger/logger";
-import { DataSourceConfig } from "@connectors/types/data_source_config";
-import { NangoConnectionId } from "@connectors/types/nango_connection_id";
+import type { DataSourceConfig } from "@connectors/types/data_source_config";
+import type { NangoConnectionId } from "@connectors/types/nango_connection_id";
 
 const { getRequiredNangoConfluenceConnectorId } = confluenceConfig;
 

--- a/connectors/src/connectors/confluence/lib/confluence_api.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_api.ts
@@ -1,8 +1,8 @@
-import { ModelId } from "@dust-tt/types";
+import type { ModelId } from "@dust-tt/types";
 
 import { confluenceConfig } from "@connectors/connectors/confluence/lib/config";
 import { ConfluenceClient } from "@connectors/connectors/confluence/lib/confluence_client";
-import { Connector } from "@connectors/lib/models";
+import type { Connector } from "@connectors/lib/models";
 import { ConfluenceConfiguration } from "@connectors/lib/models/confluence";
 import { getConnectionFromNango } from "@connectors/lib/nango_helpers";
 

--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -1,4 +1,4 @@
-import { ModelId } from "@dust-tt/types";
+import type { ModelId } from "@dust-tt/types";
 
 import {
   getRepo,
@@ -15,16 +15,17 @@ import {
   GithubDiscussion,
   GithubIssue,
 } from "@connectors/lib/models/github";
-import { Err, Ok, Result } from "@connectors/lib/result";
+import type { Result } from "@connectors/lib/result";
+import { Err, Ok } from "@connectors/lib/result";
 import mainLogger from "@connectors/logger/logger";
-import { DataSourceConfig } from "@connectors/types/data_source_config";
-import { ConnectorsAPIErrorResponse } from "@connectors/types/errors";
-import {
+import type { DataSourceConfig } from "@connectors/types/data_source_config";
+import type { ConnectorsAPIErrorResponse } from "@connectors/types/errors";
+import type {
   ConnectorPermission,
   ConnectorResource,
 } from "@connectors/types/resources";
 
-import {
+import type {
   ConnectorConfigGetter,
   ConnectorPermissionRetriever,
 } from "../interface";

--- a/connectors/src/connectors/github/lib/github_api.ts
+++ b/connectors/src/connectors/github/lib/github_api.ts
@@ -8,13 +8,15 @@ import * as reporter from "io-ts-reporters";
 import { Octokit } from "octokit";
 import { tmpdir } from "os";
 import { basename, extname, join, resolve } from "path";
-import { Readable } from "stream";
+import type { Readable } from "stream";
 import { pipeline } from "stream/promises";
 import { extract } from "tar";
 
-import {
+import type {
   DiscussionCommentNode,
   DiscussionNode,
+} from "@connectors/connectors/github/lib/github_graphql";
+import {
   ErrorPayloadSchema,
   GetDiscussionCommentRepliesPayloadSchema,
   GetDiscussionCommentsPayloadSchema,

--- a/connectors/src/connectors/github/temporal/activities.ts
+++ b/connectors/src/connectors/github/temporal/activities.ts
@@ -1,9 +1,13 @@
-import { CoreAPIDataSourceDocumentSection } from "@dust-tt/types";
+import type { CoreAPIDataSourceDocumentSection } from "@dust-tt/types";
 import { hash as blake3 } from "blake3";
 import { promises as fs } from "fs";
 import PQueue from "p-queue";
 import { Op } from "sequelize";
 
+import type {
+  GithubIssue as GithubIssueType,
+  GithubUser,
+} from "@connectors/connectors/github/lib/github_api";
 import {
   cleanUpProcessRepository,
   getDiscussion,
@@ -14,8 +18,6 @@ import {
   getRepoDiscussionsPage,
   getRepoIssuesPage,
   getReposPage,
-  GithubIssue as GithubIssueType,
-  GithubUser,
   processRepository,
 } from "@connectors/connectors/github/lib/github_api";
 import {
@@ -35,7 +37,7 @@ import {
 } from "@connectors/lib/models/github";
 import { syncStarted, syncSucceeded } from "@connectors/lib/sync_status";
 import mainLogger from "@connectors/logger/logger";
-import { DataSourceConfig } from "@connectors/types/data_source_config";
+import type { DataSourceConfig } from "@connectors/types/data_source_config";
 
 const logger = mainLogger.child({
   provider: "github",

--- a/connectors/src/connectors/github/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/github/temporal/cast_known_errors.ts
@@ -1,5 +1,5 @@
-import { RequestError } from "@octokit/types";
-import {
+import type { RequestError } from "@octokit/types";
+import type {
   ActivityExecuteInput,
   ActivityInboundCallsInterceptor,
   Next,

--- a/connectors/src/connectors/github/temporal/client.ts
+++ b/connectors/src/connectors/github/temporal/client.ts
@@ -1,8 +1,8 @@
-import {
+import type {
   WorkflowExecutionDescription,
   WorkflowHandle,
-  WorkflowNotFoundError,
 } from "@temporalio/client";
+import { WorkflowNotFoundError } from "@temporalio/client";
 
 import { QUEUE_NAME } from "@connectors/connectors/github/temporal/config";
 import { newWebhookSignal } from "@connectors/connectors/github/temporal/signals";

--- a/connectors/src/connectors/github/temporal/utils.ts
+++ b/connectors/src/connectors/github/temporal/utils.ts
@@ -1,4 +1,4 @@
-import { DataSourceInfo } from "@connectors/types/data_source_config";
+import type { DataSourceInfo } from "@connectors/types/data_source_config";
 
 export function getFullSyncWorkflowId(dataSourceInfo: DataSourceInfo) {
   return `workflow-github-full-sync-${dataSourceInfo.workspaceId}-${dataSourceInfo.dataSourceName}`;

--- a/connectors/src/connectors/github/temporal/worker.ts
+++ b/connectors/src/connectors/github/temporal/worker.ts
@@ -1,4 +1,4 @@
-import { Context } from "@temporalio/activity";
+import type { Context } from "@temporalio/activity";
 import { Worker } from "@temporalio/worker";
 
 import * as activities from "@connectors/connectors/github/temporal/activities";

--- a/connectors/src/connectors/github/temporal/workflows.ts
+++ b/connectors/src/connectors/github/temporal/workflows.ts
@@ -9,7 +9,7 @@ import {
 import PQueue from "p-queue";
 
 import type * as activities from "@connectors/connectors/github/temporal/activities";
-import { DataSourceConfig } from "@connectors/types/data_source_config";
+import type { DataSourceConfig } from "@connectors/types/data_source_config";
 
 import { newWebhookSignal } from "./signals";
 import { getFullSyncWorkflowId, getReposSyncWorkflowId } from "./utils";

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -1,12 +1,12 @@
+import type { drive_v3 } from "googleapis";
 import { google } from "googleapis";
-import { drive_v3 } from "googleapis";
-import { GaxiosResponse } from "googleapis-common";
+import type { GaxiosResponse } from "googleapis-common";
 
 import {
   getLocalParents,
   registerWebhook,
 } from "@connectors/connectors/google_drive/lib";
-import { ConnectorPermissionRetriever } from "@connectors/connectors/interface";
+import type { ConnectorPermissionRetriever } from "@connectors/connectors/interface";
 import { Connector, sequelize_conn } from "@connectors/lib/models";
 import {
   GoogleDriveConfig,
@@ -19,8 +19,8 @@ import { nangoDeleteConnection } from "@connectors/lib/nango_client";
 import { Err, Ok, type Result } from "@connectors/lib/result.js";
 import logger from "@connectors/logger/logger";
 import type { DataSourceConfig } from "@connectors/types/data_source_config.js";
-import { ConnectorsAPIErrorResponse } from "@connectors/types/errors";
-import {
+import type { ConnectorsAPIErrorResponse } from "@connectors/types/errors";
+import type {
   ConnectorPermission,
   ConnectorResource,
   ConnectorResourceType,
@@ -41,7 +41,7 @@ import {
   launchGoogleGarbageCollector,
 } from "./temporal/client";
 export type NangoConnectionId = string;
-import { ModelId } from "@dust-tt/types";
+import type { ModelId } from "@dust-tt/types";
 import { v4 as uuidv4 } from "uuid";
 
 const {

--- a/connectors/src/connectors/google_drive/lib.ts
+++ b/connectors/src/connectors/google_drive/lib.ts
@@ -1,8 +1,9 @@
-import { cacheWithRedis, ModelId } from "@dust-tt/types";
+import type { ModelId } from "@dust-tt/types";
+import { cacheWithRedis } from "@dust-tt/types";
 import { v4 as uuidv4 } from "uuid";
 
 import { HTTPError } from "@connectors/lib/error";
-import { Connector } from "@connectors/lib/models";
+import type { Connector } from "@connectors/lib/models";
 import { GoogleDriveFiles } from "@connectors/lib/models/google_drive";
 import { Err, Ok, type Result } from "@connectors/lib/result.js";
 

--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -1,5 +1,6 @@
 import fs from "fs/promises";
-import { GaxiosError, GaxiosResponse } from "googleapis-common";
+import type { GaxiosResponse } from "googleapis-common";
+import { GaxiosError } from "googleapis-common";
 import StatsD from "hot-shots";
 import os from "os";
 import PQueue from "p-queue";
@@ -13,15 +14,17 @@ import {
 import { HTTPError } from "@connectors/lib/error";
 import { nango_client } from "@connectors/lib/nango_client";
 import mainLogger from "@connectors/logger/logger";
-import { DataSourceConfig } from "@connectors/types/data_source_config";
-import { GoogleDriveObjectType } from "@connectors/types/google_drive";
+import type { DataSourceConfig } from "@connectors/types/data_source_config";
+import type { GoogleDriveObjectType } from "@connectors/types/google_drive";
 const { NANGO_GOOGLE_DRIVE_CONNECTOR_ID = "google" } = process.env;
-import { cacheWithRedis, ModelId } from "@dust-tt/types";
+import type { ModelId } from "@dust-tt/types";
+import { cacheWithRedis } from "@dust-tt/types";
 import { uuid4 } from "@temporalio/workflow";
+import type { drive_v3 } from "googleapis";
 import { google } from "googleapis";
-import { drive_v3 } from "googleapis";
 import { OAuth2Client } from "googleapis-common";
-import { CreationAttributes, literal, Op } from "sequelize";
+import type { CreationAttributes } from "sequelize";
+import { literal, Op } from "sequelize";
 
 import { registerWebhook } from "@connectors/connectors/google_drive/lib";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";

--- a/connectors/src/connectors/google_drive/temporal/client.ts
+++ b/connectors/src/connectors/google_drive/temporal/client.ts
@@ -1,10 +1,12 @@
-import { ModelId } from "@dust-tt/types";
+import type { ModelId } from "@dust-tt/types";
 import { rateLimiter, RateLimitError } from "@dust-tt/types";
-import { WorkflowHandle, WorkflowNotFoundError } from "@temporalio/client";
+import type { WorkflowHandle } from "@temporalio/client";
+import { WorkflowNotFoundError } from "@temporalio/client";
 
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { Connector } from "@connectors/lib/models";
-import { Err, Ok, Result } from "@connectors/lib/result";
+import type { Result } from "@connectors/lib/result";
+import { Err, Ok } from "@connectors/lib/result";
 import { getTemporalClient } from "@connectors/lib/temporal";
 import mainLogger from "@connectors/logger/logger";
 

--- a/connectors/src/connectors/google_drive/temporal/worker.ts
+++ b/connectors/src/connectors/google_drive/temporal/worker.ts
@@ -1,4 +1,4 @@
-import { Context } from "@temporalio/activity";
+import type { Context } from "@temporalio/activity";
 import { Worker } from "@temporalio/worker";
 
 import * as activities from "@connectors/connectors/google_drive/temporal/activities";

--- a/connectors/src/connectors/google_drive/temporal/workflows.ts
+++ b/connectors/src/connectors/google_drive/temporal/workflows.ts
@@ -1,4 +1,4 @@
-import { ModelId } from "@dust-tt/types";
+import type { ModelId } from "@dust-tt/types";
 import {
   continueAsNew,
   executeChild,
@@ -10,7 +10,7 @@ import {
 
 import type * as activities from "@connectors/connectors/google_drive/temporal/activities";
 import type * as sync_status from "@connectors/lib/sync_status";
-import { DataSourceConfig } from "@connectors/types/data_source_config";
+import type { DataSourceConfig } from "@connectors/types/data_source_config";
 
 import { GDRIVE_INCREMENTAL_SYNC_DEBOUNCE_SEC } from "./config";
 import { newWebhookSignal } from "./signals";

--- a/connectors/src/connectors/index.ts
+++ b/connectors/src/connectors/index.ts
@@ -1,4 +1,4 @@
-import { ConnectorProvider } from "@dust-tt/types";
+import type { ConnectorProvider } from "@dust-tt/types";
 
 import {
   createConfluenceConnector,
@@ -42,7 +42,7 @@ import {
   stopIntercomConnector,
   updateIntercomConnector,
 } from "@connectors/connectors/intercom";
-import {
+import type {
   ConnectorBatchResourceTitleRetriever,
   ConnectorCleaner,
   ConnectorConfigGetter,

--- a/connectors/src/connectors/intercom/index.ts
+++ b/connectors/src/connectors/intercom/index.ts
@@ -1,15 +1,16 @@
-import { ModelId } from "@dust-tt/types";
+import type { ModelId } from "@dust-tt/types";
 
 import { validateAccessToken } from "@connectors/connectors/intercom/lib/intercom_api";
-import { ConnectorPermissionRetriever } from "@connectors/connectors/interface";
+import type { ConnectorPermissionRetriever } from "@connectors/connectors/interface";
 import { Connector } from "@connectors/lib/models";
 import { getAccessTokenFromNango } from "@connectors/lib/nango_helpers";
-import { Err, Ok, Result } from "@connectors/lib/result";
+import type { Result } from "@connectors/lib/result";
+import { Err, Ok } from "@connectors/lib/result";
 import logger from "@connectors/logger/logger";
-import { DataSourceConfig } from "@connectors/types/data_source_config";
-import { ConnectorsAPIErrorResponse } from "@connectors/types/errors";
-import { NangoConnectionId } from "@connectors/types/nango_connection_id";
-import { ConnectorResource } from "@connectors/types/resources";
+import type { DataSourceConfig } from "@connectors/types/data_source_config";
+import type { ConnectorsAPIErrorResponse } from "@connectors/types/errors";
+import type { NangoConnectionId } from "@connectors/types/nango_connection_id";
+import type { ConnectorResource } from "@connectors/types/resources";
 
 const { NANGO_INTERCOM_CONNECTOR_ID } = process.env;
 

--- a/connectors/src/connectors/intercom/lib/intercom_api.ts
+++ b/connectors/src/connectors/intercom/lib/intercom_api.ts
@@ -1,4 +1,5 @@
-import { ArticleObject, Client, CollectionObject } from "intercom-client";
+import type { ArticleObject, CollectionObject } from "intercom-client";
+import { Client } from "intercom-client";
 
 import { HTTPError } from "@connectors/lib/error";
 import { getAccessTokenFromNango } from "@connectors/lib/nango_helpers";

--- a/connectors/src/connectors/interface.ts
+++ b/connectors/src/connectors/interface.ts
@@ -1,9 +1,9 @@
-import { ModelId } from "@dust-tt/types";
+import type { ModelId } from "@dust-tt/types";
 
-import { Result } from "@connectors/lib/result";
-import { DataSourceConfig } from "@connectors/types/data_source_config";
-import { ConnectorsAPIErrorResponse } from "@connectors/types/errors";
-import {
+import type { Result } from "@connectors/lib/result";
+import type { DataSourceConfig } from "@connectors/types/data_source_config";
+import type { ConnectorsAPIErrorResponse } from "@connectors/types/errors";
+import type {
   ConnectorPermission,
   ConnectorResource,
 } from "@connectors/types/resources";

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -1,4 +1,4 @@
-import { ModelId } from "@dust-tt/types";
+import type { ModelId } from "@dust-tt/types";
 import { v4 as uuidv4 } from "uuid";
 
 import { notionConfig } from "@connectors/connectors/notion/lib/config";
@@ -19,14 +19,15 @@ import {
   nangoDeleteConnection,
 } from "@connectors/lib/nango_client";
 import { getAccessTokenFromNango } from "@connectors/lib/nango_helpers";
-import { Err, Ok, Result } from "@connectors/lib/result";
+import type { Result } from "@connectors/lib/result";
+import { Err, Ok } from "@connectors/lib/result";
 import mainLogger from "@connectors/logger/logger";
-import { DataSourceConfig } from "@connectors/types/data_source_config";
-import { ConnectorsAPIErrorResponse } from "@connectors/types/errors";
-import { NangoConnectionId } from "@connectors/types/nango_connection_id";
-import { ConnectorResource } from "@connectors/types/resources";
+import type { DataSourceConfig } from "@connectors/types/data_source_config";
+import type { ConnectorsAPIErrorResponse } from "@connectors/types/errors";
+import type { NangoConnectionId } from "@connectors/types/nango_connection_id";
+import type { ConnectorResource } from "@connectors/types/resources";
 
-import { ConnectorPermissionRetriever } from "../interface";
+import type { ConnectorPermissionRetriever } from "../interface";
 import { getParents } from "./lib/parents";
 
 const { getRequiredNangoNotionConnectorId } = notionConfig;

--- a/connectors/src/connectors/notion/lib/cli.ts
+++ b/connectors/src/connectors/notion/lib/cli.ts
@@ -1,4 +1,4 @@
-import { ModelId } from "@dust-tt/types";
+import type { ModelId } from "@dust-tt/types";
 import { Client, isFullDatabase, isFullPage } from "@notionhq/client";
 import { Op } from "sequelize";
 

--- a/connectors/src/connectors/notion/lib/connectors_db_helpers.ts
+++ b/connectors/src/connectors/notion/lib/connectors_db_helpers.ts
@@ -1,8 +1,8 @@
-import { ModelId } from "@dust-tt/types";
+import type { ModelId } from "@dust-tt/types";
 
 import { Connector } from "@connectors/lib/models";
 import { NotionDatabase, NotionPage } from "@connectors/lib/models/notion";
-import { DataSourceInfo } from "@connectors/types/data_source_config";
+import type { DataSourceInfo } from "@connectors/types/data_source_config";
 
 // Note: this function does not let you "remove" a skipReason.
 export async function upsertNotionPageInConnectorsDb({

--- a/connectors/src/connectors/notion/lib/notion_api.ts
+++ b/connectors/src/connectors/notion/lib/notion_api.ts
@@ -1,13 +1,13 @@
 import { cacheWithRedis } from "@dust-tt/types";
+import type { LogLevel } from "@notionhq/client";
 import {
   APIResponseError,
   Client,
   isFullBlock,
   isFullDatabase,
   isFullPage,
-  LogLevel,
 } from "@notionhq/client";
-import {
+import type {
   BlockObjectResponse,
   GetDatabaseResponse,
   GetPageResponse,
@@ -17,9 +17,9 @@ import {
   RichTextItemResponse,
   SearchResponse,
 } from "@notionhq/client/build/src/api-endpoints";
-import { Logger } from "pino";
+import type { Logger } from "pino";
 
-import {
+import type {
   PageObjectProperties,
   ParsedNotionBlock,
   ParsedNotionDatabase,

--- a/connectors/src/connectors/notion/lib/parents.ts
+++ b/connectors/src/connectors/notion/lib/parents.ts
@@ -1,4 +1,5 @@
-import { cacheWithRedis, ModelId } from "@dust-tt/types";
+import type { ModelId } from "@dust-tt/types";
+import { cacheWithRedis } from "@dust-tt/types";
 import PQueue from "p-queue";
 
 import {
@@ -9,7 +10,7 @@ import {
 } from "@connectors/connectors/notion/lib/connectors_db_helpers";
 import { updateDocumentParentsField } from "@connectors/lib/data_sources";
 import { Connector } from "@connectors/lib/models";
-import { NotionDatabase, NotionPage } from "@connectors/lib/models/notion";
+import type { NotionDatabase, NotionPage } from "@connectors/lib/models/notion";
 import logger from "@connectors/logger/logger";
 
 /** Compute the parents field for a notion pageOrDb See the [Design

--- a/connectors/src/connectors/notion/lib/types.ts
+++ b/connectors/src/connectors/notion/lib/types.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   BlockObjectResponse,
   PageObjectResponse,
 } from "@notionhq/client/build/src/api-endpoints";

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -1,4 +1,4 @@
-import { CoreAPIDataSourceDocumentSection, ModelId } from "@dust-tt/types";
+import type { CoreAPIDataSourceDocumentSection, ModelId } from "@dust-tt/types";
 import { isFullBlock, isFullPage, isNotionClientError } from "@notionhq/client";
 import { Context } from "@temporalio/activity";
 import { Op } from "sequelize";
@@ -34,7 +34,7 @@ import {
   updateAllParentsFields,
 } from "@connectors/connectors/notion/lib/parents";
 import { getTagsForPage } from "@connectors/connectors/notion/lib/tags";
-import {
+import type {
   PageObjectProperties,
   ParsedNotionBlock,
 } from "@connectors/connectors/notion/lib/types";

--- a/connectors/src/connectors/notion/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/notion/temporal/cast_known_errors.ts
@@ -3,7 +3,7 @@ import {
   UnknownHTTPResponseError,
 } from "@notionhq/client";
 import { APIErrorCode, APIResponseError } from "@notionhq/client";
-import {
+import type {
   ActivityExecuteInput,
   ActivityInboundCallsInterceptor,
   Next,

--- a/connectors/src/connectors/notion/temporal/client.ts
+++ b/connectors/src/connectors/notion/temporal/client.ts
@@ -1,9 +1,9 @@
-import { ModelId } from "@dust-tt/types";
-import {
+import type { ModelId } from "@dust-tt/types";
+import type {
   WorkflowExecutionDescription,
   WorkflowHandle,
-  WorkflowNotFoundError,
 } from "@temporalio/client";
+import { WorkflowNotFoundError } from "@temporalio/client";
 
 import { QUEUE_NAME } from "@connectors/connectors/notion/temporal/config";
 import { getWorkflowId } from "@connectors/connectors/notion/temporal/utils";
@@ -12,7 +12,7 @@ import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_c
 import { Connector } from "@connectors/lib/models";
 import { getTemporalClient } from "@connectors/lib/temporal";
 import mainLogger from "@connectors/logger/logger";
-import { DataSourceInfo } from "@connectors/types/data_source_config";
+import type { DataSourceInfo } from "@connectors/types/data_source_config";
 
 const logger = mainLogger.child({ provider: "notion" });
 

--- a/connectors/src/connectors/notion/temporal/utils.ts
+++ b/connectors/src/connectors/notion/temporal/utils.ts
@@ -1,6 +1,6 @@
-import { ModelId } from "@dust-tt/types";
+import type { ModelId } from "@dust-tt/types";
 
-import { DataSourceInfo } from "@connectors/types/data_source_config";
+import type { DataSourceInfo } from "@connectors/types/data_source_config";
 
 // Changes made here should be reflected in the production environment checks.
 export function getWorkflowId(dataSourceInfo: DataSourceInfo) {

--- a/connectors/src/connectors/notion/temporal/worker.ts
+++ b/connectors/src/connectors/notion/temporal/worker.ts
@@ -1,4 +1,4 @@
-import { Context } from "@temporalio/activity";
+import type { Context } from "@temporalio/activity";
 import { Worker } from "@temporalio/worker";
 
 import * as activities from "@connectors/connectors/notion/temporal/activities";

--- a/connectors/src/connectors/notion/temporal/workflows.ts
+++ b/connectors/src/connectors/notion/temporal/workflows.ts
@@ -1,4 +1,4 @@
-import { ModelId } from "@dust-tt/types";
+import type { ModelId } from "@dust-tt/types";
 import {
   continueAsNew,
   defineQuery,

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -1,21 +1,21 @@
-import {
+import type {
   AgentActionType,
   AgentMessageType,
   ConversationType,
   LightAgentConfigurationType,
   ModelId,
   RetrievalDocumentType,
-  sectionFullText,
   UserMessageType,
 } from "@dust-tt/types";
-import {
+import type {
   AgentGenerationSuccessEvent,
-  DustAPI,
   PublicPostContentFragmentRequestBodySchema,
 } from "@dust-tt/types";
-import { WebClient } from "@slack/web-api";
-import { MessageElement } from "@slack/web-api/dist/response/ConversationsHistoryResponse";
-import * as t from "io-ts";
+import { sectionFullText } from "@dust-tt/types";
+import { DustAPI } from "@dust-tt/types";
+import type { WebClient } from "@slack/web-api";
+import type { MessageElement } from "@slack/web-api/dist/response/ConversationsHistoryResponse";
+import type * as t from "io-ts";
 import jaroWinkler from "talisman/metrics/jaro-winkler";
 
 import {
@@ -30,7 +30,8 @@ import {
   SlackChatBotMessage,
   SlackConfiguration,
 } from "@connectors/lib/models/slack";
-import { Err, Ok, Result } from "@connectors/lib/result";
+import type { Result } from "@connectors/lib/result";
+import { Err, Ok } from "@connectors/lib/result";
 import logger from "@connectors/logger/logger";
 
 import {

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -1,8 +1,8 @@
-import { ModelId } from "@dust-tt/types";
+import type { ModelId } from "@dust-tt/types";
 import { WebClient } from "@slack/web-api";
 import PQueue from "p-queue";
 
-import {
+import type {
   ConnectorConfigGetter,
   ConnectorPermissionRetriever,
 } from "@connectors/connectors/interface";
@@ -31,9 +31,9 @@ import {
 import { Err, Ok, type Result } from "@connectors/lib/result.js";
 import logger from "@connectors/logger/logger";
 import type { DataSourceConfig } from "@connectors/types/data_source_config.js";
-import { ConnectorsAPIErrorResponse } from "@connectors/types/errors";
-import { NangoConnectionId } from "@connectors/types/nango_connection_id";
-import {
+import type { ConnectorsAPIErrorResponse } from "@connectors/types/errors";
+import type { NangoConnectionId } from "@connectors/types/nango_connection_id";
+import type {
   ConnectorPermission,
   ConnectorResource,
 } from "@connectors/types/resources";

--- a/connectors/src/connectors/slack/lib/channels.ts
+++ b/connectors/src/connectors/slack/lib/channels.ts
@@ -1,12 +1,14 @@
-import { ModelId } from "@dust-tt/types";
-import { CodedError, ErrorCode, WebAPIPlatformError } from "@slack/web-api";
-import { Channel } from "@slack/web-api/dist/response/ConversationsListResponse";
+import type { ModelId } from "@dust-tt/types";
+import type { CodedError, WebAPIPlatformError } from "@slack/web-api";
+import { ErrorCode } from "@slack/web-api";
+import type { Channel } from "@slack/web-api/dist/response/ConversationsListResponse";
 
 import { Connector, sequelize_conn } from "@connectors/lib/models";
 import { SlackChannel } from "@connectors/lib/models/slack";
-import { Err, Ok, Result } from "@connectors/lib/result";
+import type { Result } from "@connectors/lib/result";
+import { Err, Ok } from "@connectors/lib/result";
 import logger from "@connectors/logger/logger";
-import { ConnectorPermission } from "@connectors/types/resources";
+import type { ConnectorPermission } from "@connectors/types/resources";
 
 import { getSlackClient } from "./slack_client";
 

--- a/connectors/src/connectors/slack/lib/errors.ts
+++ b/connectors/src/connectors/slack/lib/errors.ts
@@ -1,4 +1,5 @@
-import { ErrorCode, WebAPIPlatformError } from "@slack/web-api";
+import type { WebAPIPlatformError } from "@slack/web-api";
+import { ErrorCode } from "@slack/web-api";
 
 export function isSlackWebAPIPlatformError(
   err: unknown

--- a/connectors/src/connectors/slack/lib/slack_client.ts
+++ b/connectors/src/connectors/slack/lib/slack_client.ts
@@ -1,14 +1,14 @@
-import { ModelId } from "@dust-tt/types";
-import {
+import type { ModelId } from "@dust-tt/types";
+import type {
   CodedError,
-  ErrorCode,
   UsersInfoResponse,
   WebAPIHTTPError,
   WebAPIPlatformError,
-  WebClient,
 } from "@slack/web-api";
+import { ErrorCode, WebClient } from "@slack/web-api";
 
-import { ExternalOauthTokenError, WorkflowError } from "@connectors/lib/error";
+import type { WorkflowError } from "@connectors/lib/error";
+import { ExternalOauthTokenError } from "@connectors/lib/error";
 import { Connector } from "@connectors/lib/models";
 import { getAccessTokenFromNango } from "@connectors/lib/nango_helpers";
 const { NANGO_SLACK_CONNECTOR_ID } = process.env;

--- a/connectors/src/connectors/slack/lib/thread.ts
+++ b/connectors/src/connectors/slack/lib/thread.ts
@@ -1,6 +1,6 @@
-import { WebClient } from "@slack/web-api";
-import { MessageElement } from "@slack/web-api/dist/response/ConversationsHistoryResponse";
-import { ConversationsRepliesResponse } from "@slack/web-api/dist/response/ConversationsRepliesResponse";
+import type { WebClient } from "@slack/web-api";
+import type { MessageElement } from "@slack/web-api/dist/response/ConversationsHistoryResponse";
+import type { ConversationsRepliesResponse } from "@slack/web-api/dist/response/ConversationsRepliesResponse";
 
 // The pagination logic for getting all the messages of a Slack thread
 // is a bit complicated, so we put it in a separate function.

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -1,19 +1,16 @@
-import {
-  cacheWithRedis,
-  CoreAPIDataSourceDocumentSection,
-  ModelId,
-} from "@dust-tt/types";
-import {
+import type { CoreAPIDataSourceDocumentSection, ModelId } from "@dust-tt/types";
+import { cacheWithRedis } from "@dust-tt/types";
+import type {
   CodedError,
-  ErrorCode,
   WebAPIPlatformError,
   WebClient,
 } from "@slack/web-api";
-import {
+import { ErrorCode } from "@slack/web-api";
+import type {
   ConversationsHistoryResponse,
   MessageElement,
 } from "@slack/web-api/dist/response/ConversationsHistoryResponse";
-import {
+import type {
   Channel,
   ConversationsListResponse,
 } from "@slack/web-api/dist/response/ConversationsListResponse";
@@ -34,7 +31,7 @@ import {
   renderDocumentTitleAndContent,
   upsertToDatasource,
 } from "@connectors/lib/data_sources";
-import { WorkflowError } from "@connectors/lib/error";
+import type { WorkflowError } from "@connectors/lib/error";
 import { Connector } from "@connectors/lib/models";
 import { SlackChannel, SlackMessages } from "@connectors/lib/models/slack";
 import {
@@ -42,7 +39,7 @@ import {
   syncSucceeded,
 } from "@connectors/lib/sync_status";
 import mainLogger from "@connectors/logger/logger";
-import { DataSourceConfig } from "@connectors/types/data_source_config";
+import type { DataSourceConfig } from "@connectors/types/data_source_config";
 
 import { getWeekEnd, getWeekStart } from "../lib/utils";
 

--- a/connectors/src/connectors/slack/temporal/client.ts
+++ b/connectors/src/connectors/slack/temporal/client.ts
@@ -1,10 +1,10 @@
-import { ModelId } from "@dust-tt/types";
+import type { ModelId } from "@dust-tt/types";
 
 import { Connector } from "@connectors/lib/models";
 import { Err, Ok } from "@connectors/lib/result";
 import { getTemporalClient } from "@connectors/lib/temporal";
 import mainLogger from "@connectors/logger/logger";
-import { DataSourceConfig } from "@connectors/types/data_source_config";
+import type { DataSourceConfig } from "@connectors/types/data_source_config";
 
 import { getWeekStart } from "../lib/utils";
 import { getChannelsToSync } from "./activities";

--- a/connectors/src/connectors/slack/temporal/worker.ts
+++ b/connectors/src/connectors/slack/temporal/worker.ts
@@ -1,4 +1,4 @@
-import { Context } from "@temporalio/activity";
+import type { Context } from "@temporalio/activity";
 import { Worker } from "@temporalio/worker";
 
 import * as activities from "@connectors/connectors/slack/temporal/activities";

--- a/connectors/src/connectors/slack/temporal/workflows.ts
+++ b/connectors/src/connectors/slack/temporal/workflows.ts
@@ -1,4 +1,4 @@
-import { ModelId } from "@dust-tt/types";
+import type { ModelId } from "@dust-tt/types";
 import {
   executeChild,
   proxyActivities,

--- a/connectors/src/connectors/webcrawler/index.ts
+++ b/connectors/src/connectors/webcrawler/index.ts
@@ -1,4 +1,4 @@
-import { ConnectorResource, ModelId } from "@dust-tt/types";
+import type { ConnectorResource, ModelId } from "@dust-tt/types";
 
 import { stableIdForUrl } from "@connectors/connectors/webcrawler/lib/utils";
 import { Connector, sequelize_conn } from "@connectors/lib/models";
@@ -11,7 +11,7 @@ import { Err, Ok, type Result } from "@connectors/lib/result.js";
 import logger from "@connectors/logger/logger";
 import type { DataSourceConfig } from "@connectors/types/data_source_config.js";
 
-import { ConnectorPermissionRetriever } from "../interface";
+import type { ConnectorPermissionRetriever } from "../interface";
 import {
   launchCrawlWebsiteWorkflow,
   stopCrawlWebsiteWorkflow,

--- a/connectors/src/connectors/webcrawler/lib/utils.ts
+++ b/connectors/src/connectors/webcrawler/lib/utils.ts
@@ -1,4 +1,4 @@
-import { ConnectorResourceType } from "@dust-tt/types";
+import type { ConnectorResourceType } from "@dust-tt/types";
 import { hash as blake3 } from "blake3";
 
 // Generate a stable id for a given url and ressource type

--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -1,4 +1,4 @@
-import { ModelId } from "@dust-tt/types";
+import type { ModelId } from "@dust-tt/types";
 import { Context } from "@temporalio/activity";
 import { CheerioCrawler, Configuration } from "crawlee";
 import turndown from "turndown";

--- a/connectors/src/connectors/webcrawler/temporal/client.ts
+++ b/connectors/src/connectors/webcrawler/temporal/client.ts
@@ -1,5 +1,7 @@
-import { Err, ModelId, Ok, Result } from "@dust-tt/types";
-import { WorkflowHandle, WorkflowNotFoundError } from "@temporalio/client";
+import type { ModelId, Result } from "@dust-tt/types";
+import { Err, Ok } from "@dust-tt/types";
+import type { WorkflowHandle } from "@temporalio/client";
+import { WorkflowNotFoundError } from "@temporalio/client";
 
 import { Connector } from "@connectors/lib/models";
 import { getTemporalClient } from "@connectors/lib/temporal";

--- a/connectors/src/connectors/webcrawler/temporal/worker.ts
+++ b/connectors/src/connectors/webcrawler/temporal/worker.ts
@@ -1,4 +1,4 @@
-import { Context } from "@temporalio/activity";
+import type { Context } from "@temporalio/activity";
 import { Worker } from "@temporalio/worker";
 
 import * as activities from "@connectors/connectors/webcrawler/temporal/activities";

--- a/connectors/src/connectors/webcrawler/temporal/workflows.ts
+++ b/connectors/src/connectors/webcrawler/temporal/workflows.ts
@@ -1,4 +1,4 @@
-import { ModelId } from "@dust-tt/types";
+import type { ModelId } from "@dust-tt/types";
 import { proxyActivities } from "@temporalio/workflow";
 
 import type * as activities from "@connectors/connectors/webcrawler/temporal/activities";

--- a/connectors/src/lib/api/data_source_config.ts
+++ b/connectors/src/lib/api/data_source_config.ts
@@ -1,5 +1,5 @@
-import { Connector } from "@connectors/lib/models";
-import { DataSourceConfig } from "@connectors/types/data_source_config";
+import type { Connector } from "@connectors/lib/models";
+import type { DataSourceConfig } from "@connectors/types/data_source_config";
 
 export function dataSourceConfigFromConnector(
   connector: Connector

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -1,9 +1,10 @@
-import {
+import type {
   CoreAPIDataSourceDocumentSection,
   PostDataSourceDocumentRequestBody,
-  sectionFullText,
 } from "@dust-tt/types";
-import axios, { AxiosRequestConfig, AxiosResponse } from "axios";
+import { sectionFullText } from "@dust-tt/types";
+import type { AxiosRequestConfig, AxiosResponse } from "axios";
+import axios from "axios";
 import { fromMarkdown } from "mdast-util-from-markdown";
 import { gfmFromMarkdown, gfmToMarkdown } from "mdast-util-gfm";
 import { toMarkdown } from "mdast-util-to-markdown";
@@ -12,7 +13,7 @@ import { gfm } from "micromark-extension-gfm";
 import { withRetries } from "@connectors/lib/dust_front_api_helpers";
 import logger from "@connectors/logger/logger";
 import { statsDClient } from "@connectors/logger/withlogging";
-import { DataSourceConfig } from "@connectors/types/data_source_config";
+import type { DataSourceConfig } from "@connectors/types/data_source_config";
 
 const { DUST_FRONT_API } = process.env;
 if (!DUST_FRONT_API) {

--- a/connectors/src/lib/databases.ts
+++ b/connectors/src/lib/databases.ts
@@ -1,4 +1,4 @@
-import { DataSourceConfig } from "@connectors/types/data_source_config";
+import type { DataSourceConfig } from "@connectors/types/data_source_config";
 
 import { withRetries } from "./dust_front_api_helpers";
 

--- a/connectors/src/lib/models/confluence.ts
+++ b/connectors/src/lib/models/confluence.ts
@@ -1,11 +1,10 @@
-import {
+import type {
   CreationOptional,
-  DataTypes,
   ForeignKey,
   InferAttributes,
   InferCreationAttributes,
-  Model,
 } from "sequelize";
+import { DataTypes, Model } from "sequelize";
 
 import { Connector, sequelize_conn } from "@connectors/lib/models";
 

--- a/connectors/src/lib/models/index.ts
+++ b/connectors/src/lib/models/index.ts
@@ -8,7 +8,7 @@ import {
   Sequelize,
 } from "sequelize";
 
-import {
+import type {
   ConnectorErrorType,
   ConnectorSyncStatus,
 } from "@connectors/types/connector";

--- a/connectors/src/lib/models/intercom.ts
+++ b/connectors/src/lib/models/intercom.ts
@@ -1,11 +1,10 @@
-import {
+import type {
   CreationOptional,
-  DataTypes,
   ForeignKey,
   InferAttributes,
   InferCreationAttributes,
-  Model,
 } from "sequelize";
+import { DataTypes, Model } from "sequelize";
 
 import { Connector, sequelize_conn } from "@connectors/lib/models";
 

--- a/connectors/src/lib/models/notion.ts
+++ b/connectors/src/lib/models/notion.ts
@@ -7,7 +7,7 @@ import {
   Model,
 } from "sequelize";
 
-import {
+import type {
   NotionBlockType,
   PageObjectProperties,
 } from "@connectors/connectors/notion/lib/types";

--- a/connectors/src/lib/models/slack.ts
+++ b/connectors/src/lib/models/slack.ts
@@ -8,7 +8,7 @@ import {
 } from "sequelize";
 
 import { Connector, sequelize_conn } from "@connectors/lib/models";
-import { ConnectorPermission } from "@connectors/types/resources";
+import type { ConnectorPermission } from "@connectors/types/resources";
 
 export class SlackConfiguration extends Model<
   InferAttributes<SlackConfiguration>,

--- a/connectors/src/lib/nango_client.ts
+++ b/connectors/src/lib/nango_client.ts
@@ -1,9 +1,11 @@
 import { Nango } from "@nangohq/node";
 import axios from "axios";
 
-import { ExternalOauthTokenError, WorkflowError } from "@connectors/lib/error";
+import type { WorkflowError } from "@connectors/lib/error";
+import { ExternalOauthTokenError } from "@connectors/lib/error";
 
-import { Err, Ok, Result } from "./result";
+import type { Result } from "./result";
+import { Err, Ok } from "./result";
 
 const { NANGO_SECRET_KEY } = process.env;
 

--- a/connectors/src/lib/nango_helpers.ts
+++ b/connectors/src/lib/nango_helpers.ts
@@ -1,6 +1,6 @@
 import { cacheWithRedis } from "@dust-tt/types";
 
-import { NangoConnectionId } from "@connectors/types/nango_connection_id";
+import type { NangoConnectionId } from "@connectors/types/nango_connection_id";
 
 import { nango_client } from "./nango_client";
 

--- a/connectors/src/lib/sync_status.ts
+++ b/connectors/src/lib/sync_status.ts
@@ -1,8 +1,9 @@
-import { ModelId } from "@dust-tt/types";
+import type { ModelId } from "@dust-tt/types";
 
 import { Connector } from "@connectors/lib/models";
-import { Err, Ok, Result } from "@connectors/lib/result";
-import {
+import type { Result } from "@connectors/lib/result";
+import { Err, Ok } from "@connectors/lib/result";
+import type {
   ConnectorErrorType,
   ConnectorSyncStatus,
 } from "@connectors/types/connector";

--- a/connectors/src/lib/temporal.ts
+++ b/connectors/src/lib/temporal.ts
@@ -1,10 +1,6 @@
-import { ModelId } from "@dust-tt/types";
-import {
-  Client,
-  Connection,
-  ConnectionOptions,
-  WorkflowNotFoundError,
-} from "@temporalio/client";
+import type { ModelId } from "@dust-tt/types";
+import type { ConnectionOptions } from "@temporalio/client";
+import { Client, Connection, WorkflowNotFoundError } from "@temporalio/client";
 import { NativeConnection } from "@temporalio/worker";
 import fs from "fs-extra";
 

--- a/connectors/src/lib/temporal_monitoring.ts
+++ b/connectors/src/lib/temporal_monitoring.ts
@@ -1,13 +1,14 @@
 import { isNangoError } from "@dust-tt/types";
-import { Context } from "@temporalio/activity";
-import {
+import type { Context } from "@temporalio/activity";
+import type {
   ActivityExecuteInput,
   ActivityInboundCallsInterceptor,
   Next,
 } from "@temporalio/worker";
 import tracer from "dd-trace";
 
-import logger, { Logger } from "@connectors/logger/logger";
+import type { Logger } from "@connectors/logger/logger";
+import type logger from "@connectors/logger/logger";
 import { statsDClient } from "@connectors/logger/withlogging";
 
 import { ExternalOauthTokenError } from "./error";

--- a/connectors/src/logger/logger.ts
+++ b/connectors/src/logger/logger.ts
@@ -1,4 +1,5 @@
-import pino, { LoggerOptions } from "pino";
+import type { LoggerOptions } from "pino";
+import pino from "pino";
 
 const NODE_ENV = process.env.NODE_ENV;
 const LOG_LEVEL = process.env.LOG_LEVEL || "info";

--- a/connectors/src/logger/withlogging.ts
+++ b/connectors/src/logger/withlogging.ts
@@ -1,7 +1,7 @@
-import { Request, Response } from "express";
+import type { Request, Response } from "express";
 import StatsD from "hot-shots";
 
-import { APIErrorWithStatusCode } from "@connectors/lib/error";
+import type { APIErrorWithStatusCode } from "@connectors/lib/error";
 
 import logger from "./logger";
 

--- a/connectors/src/middleware/auth.ts
+++ b/connectors/src/middleware/auth.ts
@@ -1,9 +1,9 @@
 import crypto from "crypto";
-import { NextFunction, Request, Response } from "express";
+import type { NextFunction, Request, Response } from "express";
 
 import logger from "@connectors/logger/logger";
 import { apiError } from "@connectors/logger/withlogging";
-import { ConnectorsAPIErrorResponse } from "@connectors/types/errors";
+import type { ConnectorsAPIErrorResponse } from "@connectors/types/errors";
 
 const {
   DUST_CONNECTORS_SECRET,

--- a/connectors/src/types/connector.ts
+++ b/connectors/src/types/connector.ts
@@ -1,4 +1,4 @@
-import { ConnectorProvider } from "@dust-tt/types";
+import type { ConnectorProvider } from "@dust-tt/types";
 
 export type ConnectorSyncStatus = "succeeded" | "failed";
 export type ConnectorErrorType = "oauth_token_revoked";

--- a/connectors/src/types/resources.ts
+++ b/connectors/src/types/resources.ts
@@ -1,4 +1,4 @@
-import { ConnectorProvider } from "@dust-tt/types";
+import type { ConnectorProvider } from "@dust-tt/types";
 
 /**
  * This type represents the permission associated with a ConnectorResource. For now the only

--- a/front/.eslintrc.js
+++ b/front/.eslintrc.js
@@ -17,8 +17,9 @@ module.exports = {
     ],
     */
     "react/no-unescaped-entities": 0,
-    "@typescript-eslint/no-unused-vars": "error",
+    "@typescript-eslint/consistent-type-imports": "error",
     "@typescript-eslint/no-explicit-any": 0,
+    "@typescript-eslint/no-unused-vars": "error",
     "no-case-declarations": 0,
     "react-hooks/rules-of-hooks": 0,
     "@next/next/no-img-element": 0,

--- a/front/components/Button.tsx
+++ b/front/components/Button.tsx
@@ -1,9 +1,9 @@
+import type { Icon } from "@dust-tt/sparkle";
 import {
   Button,
   DropdownMenu,
   GithubLogo,
   GoogleLogo,
-  Icon,
   LoginIcon,
   Modal,
   RocketIcon,

--- a/front/components/ConnectorPermissionsModal.tsx
+++ b/front/components/ConnectorPermissionsModal.tsx
@@ -1,10 +1,10 @@
 import { Modal, Page } from "@dust-tt/sparkle";
-import {
+import type {
   ConnectorProvider,
   DataSourceType,
   WorkspaceType,
 } from "@dust-tt/types";
-import { ConnectorPermission, ConnectorType } from "@dust-tt/types";
+import type { ConnectorPermission, ConnectorType } from "@dust-tt/types";
 import { useContext, useState } from "react";
 import { useSWRConfig } from "swr";
 

--- a/front/components/ConnectorPermissionsTree.tsx
+++ b/front/components/ConnectorPermissionsTree.tsx
@@ -5,12 +5,12 @@ import {
   Tooltip,
   Tree,
 } from "@dust-tt/sparkle";
-import {
+import type {
   ConnectorProvider,
   DataSourceType,
   WorkspaceType,
 } from "@dust-tt/types";
-import { ConnectorPermission } from "@dust-tt/types";
+import type { ConnectorPermission } from "@dust-tt/types";
 import { useState } from "react";
 
 import ManagedDataSourceDocumentModal from "@app/components/ManagedDataSourceDocumentModal";

--- a/front/components/DataSourceResourceSelectorTree.tsx
+++ b/front/components/DataSourceResourceSelectorTree.tsx
@@ -6,8 +6,11 @@ import {
   DocumentTextIcon,
   Spinner,
 } from "@dust-tt/sparkle";
-import { DataSourceType, WorkspaceType } from "@dust-tt/types";
-import { ConnectorPermission, ConnectorResourceType } from "@dust-tt/types";
+import type { DataSourceType, WorkspaceType } from "@dust-tt/types";
+import type {
+  ConnectorPermission,
+  ConnectorResourceType,
+} from "@dust-tt/types";
 import { CircleStackIcon, FolderIcon } from "@heroicons/react/20/solid";
 import { useState } from "react";
 

--- a/front/components/EmptyCallToAction.tsx
+++ b/front/components/EmptyCallToAction.tsx
@@ -1,6 +1,7 @@
 import { Button, PlusIcon } from "@dust-tt/sparkle";
 import Link from "next/link";
-import React, { ComponentType, MouseEvent } from "react";
+import type { ComponentType, MouseEvent } from "react";
+import React from "react";
 
 import { classNames } from "@app/lib/utils";
 

--- a/front/components/ManagedDataSourceDocumentModal.tsx
+++ b/front/components/ManagedDataSourceDocumentModal.tsx
@@ -1,5 +1,5 @@
 import { Modal } from "@dust-tt/sparkle";
-import { DataSourceType, WorkspaceType } from "@dust-tt/types";
+import type { DataSourceType, WorkspaceType } from "@dust-tt/types";
 import { useEffect, useState } from "react";
 
 export default function ManagedDataSourceDocumentModal({

--- a/front/components/PlansTables.tsx
+++ b/front/components/PlansTables.tsx
@@ -1,5 +1,5 @@
 import { Button, PriceTable, RocketIcon, SparklesIcon } from "@dust-tt/sparkle";
-import { PlanType } from "@dust-tt/types";
+import type { PlanType } from "@dust-tt/types";
 import { Tab } from "@headlessui/react";
 import React from "react";
 

--- a/front/components/WorkspacePicker.tsx
+++ b/front/components/WorkspacePicker.tsx
@@ -1,5 +1,5 @@
 import { DropdownMenu } from "@dust-tt/sparkle";
-import { UserType, WorkspaceType } from "@dust-tt/types";
+import type { UserType, WorkspaceType } from "@dust-tt/types";
 
 export default function WorkspacePicker({
   user,

--- a/front/components/app/DatasetPicker.tsx
+++ b/front/components/app/DatasetPicker.tsx
@@ -1,6 +1,6 @@
 import { ChevronDownIcon } from "@dust-tt/sparkle";
-import { WorkspaceType } from "@dust-tt/types";
-import { AppType } from "@dust-tt/types";
+import type { WorkspaceType } from "@dust-tt/types";
+import type { AppType } from "@dust-tt/types";
 import { Menu } from "@headlessui/react";
 import Link from "next/link";
 

--- a/front/components/app/DatasetView.tsx
+++ b/front/components/app/DatasetView.tsx
@@ -8,7 +8,7 @@ import {
   PlusIcon,
   XCircleIcon,
 } from "@dust-tt/sparkle";
-import { DatasetEntry, DatasetSchema, DatasetType } from "@dust-tt/types";
+import type { DatasetEntry, DatasetSchema, DatasetType } from "@dust-tt/types";
 import dynamic from "next/dynamic";
 import { useEffect, useRef, useState } from "react";
 import TextareaAutosize from "react-textarea-autosize";

--- a/front/components/app/Deploy.tsx
+++ b/front/components/app/Deploy.tsx
@@ -6,9 +6,9 @@ import {
   CubeIcon,
   DocumentTextIcon,
 } from "@dust-tt/sparkle";
-import { WorkspaceType } from "@dust-tt/types";
-import { AppType, SpecificationType } from "@dust-tt/types";
-import { RunConfig, RunType } from "@dust-tt/types";
+import type { WorkspaceType } from "@dust-tt/types";
+import type { AppType, SpecificationType } from "@dust-tt/types";
+import type { RunConfig, RunType } from "@dust-tt/types";
 import { Dialog, Transition } from "@headlessui/react";
 import dynamic from "next/dynamic";
 import Link from "next/link";

--- a/front/components/app/ModelPicker.tsx
+++ b/front/components/app/ModelPicker.tsx
@@ -1,5 +1,5 @@
 import { ChevronDownIcon } from "@dust-tt/sparkle";
-import { WorkspaceType } from "@dust-tt/types";
+import type { WorkspaceType } from "@dust-tt/types";
 import { Menu } from "@headlessui/react";
 import Link from "next/link";
 import { useEffect, useState } from "react";

--- a/front/components/app/NewBlock.tsx
+++ b/front/components/app/NewBlock.tsx
@@ -1,6 +1,6 @@
 import { Button } from "@dust-tt/sparkle";
-import { SpecificationType, WorkspaceType } from "@dust-tt/types";
-import { BlockType } from "@dust-tt/types";
+import type { SpecificationType, WorkspaceType } from "@dust-tt/types";
+import type { BlockType } from "@dust-tt/types";
 import { Menu } from "@headlessui/react";
 import { PlusIcon } from "@heroicons/react/20/solid";
 

--- a/front/components/app/SpecRunView.tsx
+++ b/front/components/app/SpecRunView.tsx
@@ -1,10 +1,10 @@
-import { WorkspaceType } from "@dust-tt/types";
-import {
+import type { WorkspaceType } from "@dust-tt/types";
+import type {
   AppType,
   SpecificationBlockType,
   SpecificationType,
 } from "@dust-tt/types";
-import { BlockType, RunType } from "@dust-tt/types";
+import type { BlockType, RunType } from "@dust-tt/types";
 import TextareaAutosize from "react-textarea-autosize";
 
 import Database from "@app/components/app/blocks/Database";

--- a/front/components/app/blocks/Block.tsx
+++ b/front/components/app/blocks/Block.tsx
@@ -5,13 +5,13 @@ import {
   Square3Stack3DStrokeIcon,
   TrashIcon,
 } from "@dust-tt/sparkle";
-import { WorkspaceType } from "@dust-tt/types";
-import {
+import type { WorkspaceType } from "@dust-tt/types";
+import type {
   AppType,
   SpecificationBlockType,
   SpecificationType,
 } from "@dust-tt/types";
-import { BlockType, RunType } from "@dust-tt/types";
+import type { BlockType, RunType } from "@dust-tt/types";
 import { useEffect, useState } from "react";
 
 import NewBlock from "@app/components/app/NewBlock";

--- a/front/components/app/blocks/Browser.tsx
+++ b/front/components/app/blocks/Browser.tsx
@@ -1,11 +1,11 @@
 import { ChevronDownIcon, ChevronRightIcon } from "@dust-tt/sparkle";
-import { WorkspaceType } from "@dust-tt/types";
-import {
+import type { WorkspaceType } from "@dust-tt/types";
+import type {
   AppType,
   SpecificationBlockType,
   SpecificationType,
 } from "@dust-tt/types";
-import { BlockType, RunType } from "@dust-tt/types";
+import type { BlockType, RunType } from "@dust-tt/types";
 import Link from "next/link";
 import { useState } from "react";
 

--- a/front/components/app/blocks/Chat.tsx
+++ b/front/components/app/blocks/Chat.tsx
@@ -1,11 +1,11 @@
 import "@uiw/react-textarea-code-editor/dist.css";
 
 import { ChevronDownIcon, ChevronRightIcon } from "@dust-tt/sparkle";
-import { WorkspaceType } from "@dust-tt/types";
-import { SpecificationBlockType, SpecificationType } from "@dust-tt/types";
-import { AppType } from "@dust-tt/types";
-import { BlockType } from "@dust-tt/types";
-import { RunType } from "@dust-tt/types";
+import type { WorkspaceType } from "@dust-tt/types";
+import type { SpecificationBlockType, SpecificationType } from "@dust-tt/types";
+import type { AppType } from "@dust-tt/types";
+import type { BlockType } from "@dust-tt/types";
+import type { RunType } from "@dust-tt/types";
 import dynamic from "next/dynamic";
 import { useState } from "react";
 

--- a/front/components/app/blocks/Code.tsx
+++ b/front/components/app/blocks/Code.tsx
@@ -1,12 +1,12 @@
 import "@uiw/react-textarea-code-editor/dist.css";
 
-import { WorkspaceType } from "@dust-tt/types";
-import {
+import type { WorkspaceType } from "@dust-tt/types";
+import type {
   AppType,
   SpecificationBlockType,
   SpecificationType,
 } from "@dust-tt/types";
-import { BlockType, RunType } from "@dust-tt/types";
+import type { BlockType, RunType } from "@dust-tt/types";
 import dynamic from "next/dynamic";
 
 import { classNames, shallowBlockClone } from "@app/lib/utils";

--- a/front/components/app/blocks/Curl.tsx
+++ b/front/components/app/blocks/Curl.tsx
@@ -1,13 +1,13 @@
 import "@uiw/react-textarea-code-editor/dist.css";
 
 import { ChevronDownIcon } from "@dust-tt/sparkle";
-import { WorkspaceType } from "@dust-tt/types";
-import {
+import type { WorkspaceType } from "@dust-tt/types";
+import type {
   AppType,
   SpecificationBlockType,
   SpecificationType,
 } from "@dust-tt/types";
-import { BlockType, RunType } from "@dust-tt/types";
+import type { BlockType, RunType } from "@dust-tt/types";
 import { Menu } from "@headlessui/react";
 import dynamic from "next/dynamic";
 import { useEffect } from "react";

--- a/front/components/app/blocks/Data.tsx
+++ b/front/components/app/blocks/Data.tsx
@@ -1,10 +1,10 @@
-import { WorkspaceType } from "@dust-tt/types";
-import {
+import type { WorkspaceType } from "@dust-tt/types";
+import type {
   AppType,
   SpecificationBlockType,
   SpecificationType,
 } from "@dust-tt/types";
-import { BlockType, RunType } from "@dust-tt/types";
+import type { BlockType, RunType } from "@dust-tt/types";
 
 import DatasetPicker from "@app/components/app/DatasetPicker";
 import { shallowBlockClone } from "@app/lib/utils";

--- a/front/components/app/blocks/DataSource.tsx
+++ b/front/components/app/blocks/DataSource.tsx
@@ -1,12 +1,12 @@
 import "@uiw/react-textarea-code-editor/dist.css";
 
-import { WorkspaceType } from "@dust-tt/types";
-import {
+import type { WorkspaceType } from "@dust-tt/types";
+import type {
   AppType,
   SpecificationBlockType,
   SpecificationType,
 } from "@dust-tt/types";
-import { BlockType, RunType } from "@dust-tt/types";
+import type { BlockType, RunType } from "@dust-tt/types";
 import { ChevronDownIcon, ChevronRightIcon } from "@heroicons/react/20/solid";
 import dynamic from "next/dynamic";
 import { useState } from "react";

--- a/front/components/app/blocks/Database.tsx
+++ b/front/components/app/blocks/Database.tsx
@@ -1,12 +1,12 @@
 import "@uiw/react-textarea-code-editor/dist.css";
 
-import { WorkspaceType } from "@dust-tt/types";
-import {
+import type { WorkspaceType } from "@dust-tt/types";
+import type {
   AppType,
   SpecificationBlockType,
   SpecificationType,
 } from "@dust-tt/types";
-import { BlockType, RunType } from "@dust-tt/types";
+import type { BlockType, RunType } from "@dust-tt/types";
 import dynamic from "next/dynamic";
 
 import DataSourcePicker from "@app/components/data_source/DataSourcePicker";

--- a/front/components/app/blocks/DatabaseSchema.tsx
+++ b/front/components/app/blocks/DatabaseSchema.tsx
@@ -1,12 +1,12 @@
 import "@uiw/react-textarea-code-editor/dist.css";
 
-import { WorkspaceType } from "@dust-tt/types";
-import {
+import type { WorkspaceType } from "@dust-tt/types";
+import type {
   AppType,
   SpecificationBlockType,
   SpecificationType,
 } from "@dust-tt/types";
-import { BlockType, RunType } from "@dust-tt/types";
+import type { BlockType, RunType } from "@dust-tt/types";
 
 import DataSourcePicker from "@app/components/data_source/DataSourcePicker";
 import TablePicker from "@app/components/tables/TablePicker";

--- a/front/components/app/blocks/Input.tsx
+++ b/front/components/app/blocks/Input.tsx
@@ -1,10 +1,10 @@
-import { WorkspaceType } from "@dust-tt/types";
-import {
+import type { WorkspaceType } from "@dust-tt/types";
+import type {
   AppType,
   SpecificationBlockType,
   SpecificationType,
 } from "@dust-tt/types";
-import { BlockType, RunType } from "@dust-tt/types";
+import type { BlockType, RunType } from "@dust-tt/types";
 
 import DatasetPicker from "@app/components/app/DatasetPicker";
 import { shallowBlockClone } from "@app/lib/utils";

--- a/front/components/app/blocks/LLM.tsx
+++ b/front/components/app/blocks/LLM.tsx
@@ -1,12 +1,12 @@
 import "@uiw/react-textarea-code-editor/dist.css";
 
-import { WorkspaceType } from "@dust-tt/types";
-import {
+import type { WorkspaceType } from "@dust-tt/types";
+import type {
   AppType,
   SpecificationBlockType,
   SpecificationType,
 } from "@dust-tt/types";
-import { BlockType, RunType } from "@dust-tt/types";
+import type { BlockType, RunType } from "@dust-tt/types";
 import { ChevronDownIcon, ChevronRightIcon } from "@heroicons/react/20/solid";
 import dynamic from "next/dynamic";
 import { useState } from "react";

--- a/front/components/app/blocks/MapReduce.tsx
+++ b/front/components/app/blocks/MapReduce.tsx
@@ -1,10 +1,10 @@
-import { WorkspaceType } from "@dust-tt/types";
-import {
+import type { WorkspaceType } from "@dust-tt/types";
+import type {
   AppType,
   SpecificationBlockType,
   SpecificationType,
 } from "@dust-tt/types";
-import { BlockType, RunType } from "@dust-tt/types";
+import type { BlockType, RunType } from "@dust-tt/types";
 
 import { classNames, shallowBlockClone } from "@app/lib/utils";
 

--- a/front/components/app/blocks/Output.tsx
+++ b/front/components/app/blocks/Output.tsx
@@ -1,6 +1,6 @@
-import { WorkspaceType } from "@dust-tt/types";
-import { AppType, SpecificationBlockType } from "@dust-tt/types";
-import { TraceType } from "@dust-tt/types";
+import type { WorkspaceType } from "@dust-tt/types";
+import type { AppType, SpecificationBlockType } from "@dust-tt/types";
+import type { TraceType } from "@dust-tt/types";
 import {
   CheckCircleIcon,
   ChevronDownIcon,

--- a/front/components/app/blocks/Search.tsx
+++ b/front/components/app/blocks/Search.tsx
@@ -1,8 +1,8 @@
-import { WorkspaceType } from "@dust-tt/types";
-import { SpecificationBlockType, SpecificationType } from "@dust-tt/types";
-import { AppType } from "@dust-tt/types";
-import { BlockType } from "@dust-tt/types";
-import { RunType } from "@dust-tt/types";
+import type { WorkspaceType } from "@dust-tt/types";
+import type { SpecificationBlockType, SpecificationType } from "@dust-tt/types";
+import type { AppType } from "@dust-tt/types";
+import type { BlockType } from "@dust-tt/types";
+import type { RunType } from "@dust-tt/types";
 import { Menu } from "@headlessui/react";
 import { ChevronDownIcon } from "@heroicons/react/20/solid";
 import Link from "next/link";

--- a/front/components/app/blocks/WhileEnd.tsx
+++ b/front/components/app/blocks/WhileEnd.tsx
@@ -1,10 +1,10 @@
 import "@uiw/react-textarea-code-editor/dist.css";
 
-import { WorkspaceType } from "@dust-tt/types";
-import { SpecificationBlockType, SpecificationType } from "@dust-tt/types";
-import { AppType } from "@dust-tt/types";
-import { BlockType } from "@dust-tt/types";
-import { RunType } from "@dust-tt/types";
+import type { WorkspaceType } from "@dust-tt/types";
+import type { SpecificationBlockType, SpecificationType } from "@dust-tt/types";
+import type { AppType } from "@dust-tt/types";
+import type { BlockType } from "@dust-tt/types";
+import type { RunType } from "@dust-tt/types";
 import dynamic from "next/dynamic";
 
 import { classNames, shallowBlockClone } from "@app/lib/utils";

--- a/front/components/assistant/AssistantActions.tsx
+++ b/front/components/assistant/AssistantActions.tsx
@@ -1,14 +1,14 @@
 import { Dialog } from "@dust-tt/sparkle";
-import {
+import type {
   LightAgentConfigurationType,
   PostOrPatchAgentConfigurationRequestBody,
 } from "@dust-tt/types";
-import { WorkspaceType } from "@dust-tt/types";
+import type { WorkspaceType } from "@dust-tt/types";
 import { useContext } from "react";
 
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { useAgentConfiguration } from "@app/lib/swr";
-import { PostAgentListStatusRequestBody } from "@app/pages/api/w/[wId]/members/me/agent_list_status";
+import type { PostAgentListStatusRequestBody } from "@app/pages/api/w/[wId]/members/me/agent_list_status";
 
 export function DeleteAssistantDialog({
   owner,

--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -9,22 +9,18 @@ import {
   TrashIcon,
   XMarkIcon,
 } from "@dust-tt/sparkle";
-import {
+import type {
   AgentUsageType,
   AgentUserListStatus,
   ConnectorProvider,
   LightAgentConfigurationType,
 } from "@dust-tt/types";
-import {
-  DustAppRunConfigurationType,
-  isDustAppRunConfiguration,
-} from "@dust-tt/types";
-import {
-  DataSourceConfiguration,
-  isRetrievalConfiguration,
-} from "@dust-tt/types";
-import { AgentConfigurationType } from "@dust-tt/types";
-import { WorkspaceType } from "@dust-tt/types";
+import type { DustAppRunConfigurationType } from "@dust-tt/types";
+import type { DataSourceConfiguration } from "@dust-tt/types";
+import type { AgentConfigurationType } from "@dust-tt/types";
+import type { WorkspaceType } from "@dust-tt/types";
+import { isDustAppRunConfiguration } from "@dust-tt/types";
+import { isRetrievalConfiguration } from "@dust-tt/types";
 import Link from "next/link";
 import { useContext, useState } from "react";
 import ReactMarkdown from "react-markdown";
@@ -33,7 +29,7 @@ import { DeleteAssistantDialog } from "@app/components/assistant/AssistantAction
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 import { useAgentConfiguration, useAgentUsage, useApp } from "@app/lib/swr";
-import { PostAgentListStatusRequestBody } from "@app/pages/api/w/[wId]/members/me/agent_list_status";
+import type { PostAgentListStatusRequestBody } from "@app/pages/api/w/[wId]/members/me/agent_list_status";
 
 type AssistantDetailsFlow = "personal" | "workspace";
 

--- a/front/components/assistant/AssistantPicker.tsx
+++ b/front/components/assistant/AssistantPicker.tsx
@@ -7,7 +7,10 @@ import {
   Searchbar,
   WrenchIcon,
 } from "@dust-tt/sparkle";
-import { LightAgentConfigurationType, WorkspaceType } from "@dust-tt/types";
+import type {
+  LightAgentConfigurationType,
+  WorkspaceType,
+} from "@dust-tt/types";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 

--- a/front/components/assistant/GalleryAssistantPreviewContainer.tsx
+++ b/front/components/assistant/GalleryAssistantPreviewContainer.tsx
@@ -1,5 +1,5 @@
 import { AssistantPreview } from "@dust-tt/sparkle";
-import {
+import type {
   AgentUserListStatus,
   LightAgentConfigurationType,
   PlanType,
@@ -7,13 +7,11 @@ import {
 } from "@dust-tt/types";
 import { useContext, useEffect, useState } from "react";
 
-import {
-  NotificationType,
-  SendNotificationsContext,
-} from "@app/components/sparkle/Notification";
+import type { NotificationType } from "@app/components/sparkle/Notification";
+import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { isLargeModel } from "@app/lib/assistant";
 import { isUpgraded } from "@app/lib/plans/plan_codes";
-import { PostAgentListStatusRequestBody } from "@app/pages/api/w/[wId]/members/me/agent_list_status";
+import type { PostAgentListStatusRequestBody } from "@app/pages/api/w/[wId]/members/me/agent_list_status";
 
 type AssistantPreviewFlow = "personal" | "workspace";
 

--- a/front/components/assistant/RenderMessageMarkdown.tsx
+++ b/front/components/assistant/RenderMessageMarkdown.tsx
@@ -4,12 +4,13 @@ import {
   IconButton,
   Tooltip,
 } from "@dust-tt/sparkle";
-import { LightAgentConfigurationType } from "@dust-tt/types";
-import { RetrievalDocumentType } from "@dust-tt/types";
+import type { LightAgentConfigurationType } from "@dust-tt/types";
+import type { RetrievalDocumentType } from "@dust-tt/types";
 import dynamic from "next/dynamic";
-import React, { ReactNode, useCallback, useEffect, useState } from "react";
+import type { ReactNode } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import ReactMarkdown from "react-markdown";
-import { ReactMarkdownProps } from "react-markdown/lib/complex-types";
+import type { ReactMarkdownProps } from "react-markdown/lib/complex-types";
 import remarkDirective from "remark-directive";
 import remarkGfm from "remark-gfm";
 import {

--- a/front/components/assistant/TryAssistantModal.tsx
+++ b/front/components/assistant/TryAssistantModal.tsx
@@ -1,12 +1,12 @@
 import { Modal } from "@dust-tt/sparkle";
-import {
+import type {
   AgentMention,
   ConversationType,
   LightAgentConfigurationType,
   MentionType,
   UserType,
 } from "@dust-tt/types";
-import { WorkspaceType } from "@dust-tt/types";
+import type { WorkspaceType } from "@dust-tt/types";
 import { useContext, useEffect, useState } from "react";
 
 import Conversation from "@app/components/assistant/conversation/Conversation";

--- a/front/components/assistant/conversation/AgentAction.tsx
+++ b/front/components/assistant/conversation/AgentAction.tsx
@@ -1,9 +1,9 @@
+import type { AgentActionType } from "@dust-tt/types";
 import {
   isDatabaseQueryActionType,
   isDustAppRunActionType,
 } from "@dust-tt/types";
 import { isRetrievalActionType } from "@dust-tt/types";
-import { AgentActionType } from "@dust-tt/types";
 
 import DatabaseQueryAction from "@app/components/assistant/conversation/DatabaseQueryAction";
 import DustAppRunAction from "@app/components/assistant/conversation/DustAppRunAction";

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -9,7 +9,7 @@ import {
   EyeIcon,
   Spinner,
 } from "@dust-tt/sparkle";
-import {
+import type {
   AgentActionEvent,
   AgentActionSuccessEvent,
   AgentErrorEvent,
@@ -20,8 +20,9 @@ import {
   UserType,
   WorkspaceType,
 } from "@dust-tt/types";
-import { isRetrievalActionType, RetrievalDocumentType } from "@dust-tt/types";
-import { AgentMessageType, MessageReactionType } from "@dust-tt/types";
+import type { RetrievalDocumentType } from "@dust-tt/types";
+import type { AgentMessageType, MessageReactionType } from "@dust-tt/types";
+import { isRetrievalActionType } from "@dust-tt/types";
 import { useCallback, useContext, useEffect, useRef, useState } from "react";
 
 import { AgentAction } from "@app/components/assistant/conversation/AgentAction";

--- a/front/components/assistant/conversation/AgentSuggestion.tsx
+++ b/front/components/assistant/conversation/AgentSuggestion.tsx
@@ -1,12 +1,11 @@
 import { Button, RobotIcon } from "@dust-tt/sparkle";
-import {
+import type {
   ConversationType,
-  isAgentMention,
-  isUserMessageType,
   LightAgentConfigurationType,
   UserMessageType,
   WorkspaceType,
 } from "@dust-tt/types";
+import { isAgentMention, isUserMessageType } from "@dust-tt/types";
 import { useContext, useState } from "react";
 
 import { AssistantPicker } from "@app/components/assistant/AssistantPicker";

--- a/front/components/assistant/conversation/ContentFragment.tsx
+++ b/front/components/assistant/conversation/ContentFragment.tsx
@@ -1,5 +1,6 @@
 import { Citation } from "@dust-tt/sparkle";
-import { assertNever, ContentFragmentType } from "@dust-tt/types";
+import type { ContentFragmentType } from "@dust-tt/types";
+import { assertNever } from "@dust-tt/types";
 
 export function ContentFragment({ message }: { message: ContentFragmentType }) {
   let logoType: "document" | "slack" = "document";

--- a/front/components/assistant/conversation/Conversation.tsx
+++ b/front/components/assistant/conversation/Conversation.tsx
@@ -1,15 +1,12 @@
-import { UserType, WorkspaceType } from "@dust-tt/types";
-import {
-  AgentMention,
-  isAgentMention,
-  isUserMessageType,
-} from "@dust-tt/types";
-import { AgentGenerationCancelledEvent } from "@dust-tt/types";
-import {
+import type { UserType, WorkspaceType } from "@dust-tt/types";
+import type { AgentMention } from "@dust-tt/types";
+import type { AgentGenerationCancelledEvent } from "@dust-tt/types";
+import type {
   AgentMessageNewEvent,
   ConversationTitleEvent,
   UserMessageNewEvent,
 } from "@dust-tt/types";
+import { isAgentMention, isUserMessageType } from "@dust-tt/types";
 import { useCallback, useEffect, useRef } from "react";
 
 import { AgentMessage } from "@app/components/assistant/conversation/AgentMessage";

--- a/front/components/assistant/conversation/ConversationMessage.tsx
+++ b/front/components/assistant/conversation/ConversationMessage.tsx
@@ -1,16 +1,11 @@
 import { Avatar, Button, DropdownMenu } from "@dust-tt/sparkle";
 import { ReactionIcon } from "@dust-tt/sparkle";
-import { UserType, WorkspaceType } from "@dust-tt/types";
-import { MessageReactionType } from "@dust-tt/types";
-import { Emoji, EmojiMartData } from "@emoji-mart/data";
+import type { UserType, WorkspaceType } from "@dust-tt/types";
+import type { MessageReactionType } from "@dust-tt/types";
+import type { Emoji, EmojiMartData } from "@emoji-mart/data";
 import Picker from "@emoji-mart/react";
-import {
-  ComponentType,
-  MouseEventHandler,
-  useEffect,
-  useRef,
-  useState,
-} from "react";
+import type { ComponentType, MouseEventHandler } from "react";
+import { useEffect, useRef, useState } from "react";
 import React from "react";
 import { mutate } from "swr";
 

--- a/front/components/assistant/conversation/ConversationParticipants.tsx
+++ b/front/components/assistant/conversation/ConversationParticipants.tsx
@@ -1,5 +1,5 @@
 import { Avatar } from "@dust-tt/sparkle";
-import { ConversationType } from "@dust-tt/types";
+import type { ConversationType } from "@dust-tt/types";
 import React from "react";
 
 export function ConversationParticipants({

--- a/front/components/assistant/conversation/ConversationTitle.tsx
+++ b/front/components/assistant/conversation/ConversationTitle.tsx
@@ -10,9 +10,10 @@ import {
   TrashIcon,
   XMarkIcon,
 } from "@dust-tt/sparkle";
-import { WorkspaceType } from "@dust-tt/types";
-import { ConversationType } from "@dust-tt/types";
-import React, { MouseEvent, useRef, useState } from "react";
+import type { WorkspaceType } from "@dust-tt/types";
+import type { ConversationType } from "@dust-tt/types";
+import type { MouseEvent } from "react";
+import React, { useRef, useState } from "react";
 import { useSWRConfig } from "swr";
 
 import { ConversationParticipants } from "@app/components/assistant/conversation/ConversationParticipants";

--- a/front/components/assistant/conversation/DatabaseQueryAction.tsx
+++ b/front/components/assistant/conversation/DatabaseQueryAction.tsx
@@ -6,7 +6,7 @@ import {
   Spinner,
   Tooltip,
 } from "@dust-tt/sparkle";
-import { DatabaseQueryActionType } from "@dust-tt/types";
+import type { DatabaseQueryActionType } from "@dust-tt/types";
 import dynamic from "next/dynamic";
 import { useState } from "react";
 import { amber, emerald, slate } from "tailwindcss/colors";

--- a/front/components/assistant/conversation/DustAppRunAction.tsx
+++ b/front/components/assistant/conversation/DustAppRunAction.tsx
@@ -6,7 +6,7 @@ import {
   Spinner,
   Tooltip,
 } from "@dust-tt/sparkle";
-import { DustAppRunActionType } from "@dust-tt/types";
+import type { DustAppRunActionType } from "@dust-tt/types";
 import dynamic from "next/dynamic";
 import { useState } from "react";
 import { amber, emerald, slate } from "tailwindcss/colors";

--- a/front/components/assistant/conversation/RetrievalAction.tsx
+++ b/front/components/assistant/conversation/RetrievalAction.tsx
@@ -7,7 +7,10 @@ import {
   Spinner,
   Tooltip,
 } from "@dust-tt/sparkle";
-import { RetrievalActionType, RetrievalDocumentType } from "@dust-tt/types";
+import type {
+  RetrievalActionType,
+  RetrievalDocumentType,
+} from "@dust-tt/types";
 import { Transition } from "@headlessui/react";
 import { useState } from "react";
 

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -1,6 +1,6 @@
 import { Button, ChatBubbleBottomCenterPlusIcon, Item } from "@dust-tt/sparkle";
-import { WorkspaceType } from "@dust-tt/types";
-import { ConversationWithoutContentType } from "@dust-tt/types";
+import type { WorkspaceType } from "@dust-tt/types";
+import type { ConversationWithoutContentType } from "@dust-tt/types";
 import moment from "moment";
 import Link from "next/link";
 import { useRouter } from "next/router";

--- a/front/components/assistant/conversation/UserMessage.tsx
+++ b/front/components/assistant/conversation/UserMessage.tsx
@@ -1,5 +1,5 @@
-import { UserType, WorkspaceType } from "@dust-tt/types";
-import {
+import type { UserType, WorkspaceType } from "@dust-tt/types";
+import type {
   ConversationType,
   MessageReactionType,
   UserMessageType,

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -1,7 +1,7 @@
 import { Button, Citation, StopIcon } from "@dust-tt/sparkle";
-import { WorkspaceType } from "@dust-tt/types";
-import { LightAgentConfigurationType } from "@dust-tt/types";
-import { AgentMention, MentionType } from "@dust-tt/types";
+import type { WorkspaceType } from "@dust-tt/types";
+import type { LightAgentConfigurationType } from "@dust-tt/types";
+import type { AgentMention, MentionType } from "@dust-tt/types";
 import {
   createContext,
   Fragment,
@@ -13,9 +13,8 @@ import {
 import { mutate } from "swr";
 
 import { GenerationContext } from "@app/components/assistant/conversation/GenerationContextProvider";
-import InputBarContainer, {
-  InputBarContainerProps,
-} from "@app/components/assistant/conversation/input_bar/InputBarContainer";
+import type { InputBarContainerProps } from "@app/components/assistant/conversation/input_bar/InputBarContainer";
+import InputBarContainer from "@app/components/assistant/conversation/input_bar/InputBarContainer";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { compareAgentsForSort } from "@app/lib/assistant";
 import { handleFileUploadToText } from "@app/lib/client/handle_file_upload";

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -6,7 +6,7 @@ import {
   FullscreenIcon,
   IconButton,
 } from "@dust-tt/sparkle";
-import {
+import type {
   AgentMention,
   LightAgentConfigurationType,
   WorkspaceType,
@@ -16,9 +16,8 @@ import React, { useRef, useState } from "react";
 
 import { AssistantPicker } from "@app/components/assistant/AssistantPicker";
 import useAssistantSuggestions from "@app/components/assistant/conversation/input_bar/editor/useAssistantSuggestions";
-import useCustomEditor, {
-  CustomEditorProps,
-} from "@app/components/assistant/conversation/input_bar/editor/useCustomEditor";
+import type { CustomEditorProps } from "@app/components/assistant/conversation/input_bar/editor/useCustomEditor";
+import useCustomEditor from "@app/components/assistant/conversation/input_bar/editor/useCustomEditor";
 import useHandleMentions from "@app/components/assistant/conversation/input_bar/editor/useHandleMentions";
 import { classNames } from "@app/lib/utils";
 

--- a/front/components/assistant/conversation/input_bar/editor/MentionList.tsx
+++ b/front/components/assistant/conversation/input_bar/editor/MentionList.tsx
@@ -6,7 +6,7 @@ import React, {
   useState,
 } from "react";
 
-import { EditorSuggestion } from "@app/components/assistant/conversation/input_bar/editor/suggestion";
+import type { EditorSuggestion } from "@app/components/assistant/conversation/input_bar/editor/suggestion";
 import { classNames } from "@app/lib/utils";
 
 interface MentionListProps {

--- a/front/components/assistant/conversation/input_bar/editor/useAssistantSuggestions.ts
+++ b/front/components/assistant/conversation/input_bar/editor/useAssistantSuggestions.ts
@@ -1,4 +1,4 @@
-import { LightAgentConfigurationType } from "@dust-tt/types";
+import type { LightAgentConfigurationType } from "@dust-tt/types";
 import { useMemo } from "react";
 
 import { compareAgentsForSort } from "@app/lib/assistant";

--- a/front/components/assistant/conversation/input_bar/editor/useCustomEditor.tsx
+++ b/front/components/assistant/conversation/input_bar/editor/useCustomEditor.tsx
@@ -1,13 +1,12 @@
 import Mention, { MentionPluginKey } from "@tiptap/extension-mention";
 import Placeholder from "@tiptap/extension-placeholder";
-import { Editor, JSONContent, useEditor } from "@tiptap/react";
+import type { Editor, JSONContent } from "@tiptap/react";
+import { useEditor } from "@tiptap/react";
 import { StarterKit } from "@tiptap/starter-kit";
 import { useMemo } from "react";
 
-import {
-  EditorSuggestion,
-  makeGetAssistantSuggestions,
-} from "@app/components/assistant/conversation/input_bar/editor/suggestion";
+import type { EditorSuggestion } from "@app/components/assistant/conversation/input_bar/editor/suggestion";
+import { makeGetAssistantSuggestions } from "@app/components/assistant/conversation/input_bar/editor/suggestion";
 
 export interface EditorMention {
   id: string;

--- a/front/components/assistant/conversation/input_bar/editor/useHandleMentions.tsx
+++ b/front/components/assistant/conversation/input_bar/editor/useHandleMentions.tsx
@@ -1,4 +1,4 @@
-import { AgentMention, LightAgentConfigurationType } from "@dust-tt/types";
+import type { AgentMention, LightAgentConfigurationType } from "@dust-tt/types";
 import { useEffect, useMemo, useRef } from "react";
 
 import type {

--- a/front/components/assistant/conversation/lib.ts
+++ b/front/components/assistant/conversation/lib.ts
@@ -1,18 +1,17 @@
-import {
+import type {
   ConversationType,
   ConversationVisibility,
-  Err,
   InternalPostConversationsRequestBodySchema,
   MentionType,
-  Ok,
   Result,
   UserType,
   WorkspaceType,
 } from "@dust-tt/types";
-import * as t from "io-ts";
+import { Err, Ok } from "@dust-tt/types";
+import type * as t from "io-ts";
 
-import { NotificationType } from "@app/components/sparkle/Notification";
-import { PostConversationsResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations";
+import type { NotificationType } from "@app/components/sparkle/Notification";
+import type { PostConversationsResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations";
 
 export type ConversationErrorType = {
   type:

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -15,13 +15,18 @@ import {
   SlackLogo,
   TrashIcon,
 } from "@dust-tt/sparkle";
-import {
+import type {
   AgentConfigurationScope,
   ConnectorProvider,
   DataSourceType,
-  GEMINI_PRO_DEFAULT_MODEL_CONFIG,
 } from "@dust-tt/types";
-import { UserType, WorkspaceType } from "@dust-tt/types";
+import type { UserType, WorkspaceType } from "@dust-tt/types";
+import type { SupportedModel } from "@dust-tt/types";
+import type { TimeframeUnit } from "@dust-tt/types";
+import type { AppType } from "@dust-tt/types";
+import type { PlanType, SubscriptionType } from "@dust-tt/types";
+import type { PostOrPatchAgentConfigurationRequestBodySchema } from "@dust-tt/types";
+import { GEMINI_PRO_DEFAULT_MODEL_CONFIG } from "@dust-tt/types";
 import {
   CLAUDE_DEFAULT_MODEL_CONFIG,
   CLAUDE_INSTANT_DEFAULT_MODEL_CONFIG,
@@ -29,15 +34,11 @@ import {
   GPT_4_TURBO_MODEL_CONFIG,
   MISTRAL_MEDIUM_MODEL_CONFIG,
   MISTRAL_SMALL_MODEL_CONFIG,
-  SupportedModel,
 } from "@dust-tt/types";
-import { TimeframeUnit } from "@dust-tt/types";
-import { AppType } from "@dust-tt/types";
-import { PlanType, SubscriptionType } from "@dust-tt/types";
-import { PostOrPatchAgentConfigurationRequestBodySchema } from "@dust-tt/types";
-import * as t from "io-ts";
+import type * as t from "io-ts";
 import { useRouter } from "next/router";
-import { ReactNode, useCallback, useEffect, useState } from "react";
+import type { ReactNode } from "react";
+import { useCallback, useEffect, useState } from "react";
 import React from "react";
 import ReactTextareaAutosize from "react-textarea-autosize";
 import { mutate } from "swr";

--- a/front/components/assistant_builder/AssistantBuilderAvatarPicker.tsx
+++ b/front/components/assistant_builder/AssistantBuilderAvatarPicker.tsx
@@ -8,10 +8,12 @@ import {
   Modal,
   Tab,
 } from "@dust-tt/sparkle";
-import { WorkspaceType } from "@dust-tt/types";
-import { ChangeEvent, useRef, useState } from "react";
+import type { WorkspaceType } from "@dust-tt/types";
+import type { ChangeEvent } from "react";
+import { useRef, useState } from "react";
 import React from "react";
-import ReactCrop, { centerCrop, Crop, makeAspectCrop } from "react-image-crop";
+import type { Crop } from "react-image-crop";
+import ReactCrop, { centerCrop, makeAspectCrop } from "react-image-crop";
 
 import { classNames } from "@app/lib/utils";
 

--- a/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
+++ b/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
@@ -6,19 +6,18 @@ import {
   Page,
   SliderToggle,
 } from "@dust-tt/sparkle";
-import { assertNever, ConnectorProvider, DataSourceType } from "@dust-tt/types";
-import { WorkspaceType } from "@dust-tt/types";
+import type { ConnectorProvider, DataSourceType } from "@dust-tt/types";
+import type { WorkspaceType } from "@dust-tt/types";
+import { assertNever } from "@dust-tt/types";
 import { Transition } from "@headlessui/react";
-import type * as React from "react";
+import * as React from "react";
 import { useCallback, useEffect, useState } from "react";
 
-import {
-  AssistantBuilderDataSourceConfiguration,
-  CONNECTOR_PROVIDER_TO_RESOURCE_NAME,
-} from "@app/components/assistant_builder/AssistantBuilder";
+import type { AssistantBuilderDataSourceConfiguration } from "@app/components/assistant_builder/AssistantBuilder";
+import { CONNECTOR_PROVIDER_TO_RESOURCE_NAME } from "@app/components/assistant_builder/AssistantBuilder";
 import DataSourceResourceSelectorTree from "@app/components/DataSourceResourceSelectorTree";
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
-import { GetConnectorResourceParentsResponseBody } from "@app/pages/api/w/[wId]/data_sources/[name]/managed/parents";
+import type { GetConnectorResourceParentsResponseBody } from "@app/pages/api/w/[wId]/data_sources/[name]/managed/parents";
 
 export default function AssistantBuilderDataSourceModal({
   isOpen,

--- a/front/components/assistant_builder/AssistantBuilderDustAppModal.tsx
+++ b/front/components/assistant_builder/AssistantBuilderDustAppModal.tsx
@@ -5,10 +5,10 @@ import {
   Modal,
   Page,
 } from "@dust-tt/sparkle";
-import { AppType } from "@dust-tt/types";
+import type { AppType } from "@dust-tt/types";
 import { Transition } from "@headlessui/react";
 
-import { AssistantBuilderDustAppConfiguration } from "@app/components/assistant_builder/AssistantBuilder";
+import type { AssistantBuilderDustAppConfiguration } from "@app/components/assistant_builder/AssistantBuilder";
 
 export default function AssistantBuilderDustAppModal({
   isOpen,

--- a/front/components/assistant_builder/DataSourceSelectionSection.tsx
+++ b/front/components/assistant_builder/DataSourceSelectionSection.tsx
@@ -7,7 +7,7 @@ import {
   TrashIcon,
 } from "@dust-tt/sparkle";
 
-import { AssistantBuilderDataSourceConfiguration } from "@app/components/assistant_builder/AssistantBuilder";
+import type { AssistantBuilderDataSourceConfiguration } from "@app/components/assistant_builder/AssistantBuilder";
 import { CONNECTOR_PROVIDER_TO_RESOURCE_NAME } from "@app/components/assistant_builder/shared";
 import { EmptyCallToAction } from "@app/components/EmptyCallToAction";
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";

--- a/front/components/assistant_builder/DustAppSelectionSection.tsx
+++ b/front/components/assistant_builder/DustAppSelectionSection.tsx
@@ -6,7 +6,7 @@ import {
 } from "@dust-tt/sparkle";
 import { Transition } from "@headlessui/react";
 
-import { AssistantBuilderDustAppConfiguration } from "@app/components/assistant_builder/AssistantBuilder";
+import type { AssistantBuilderDustAppConfiguration } from "@app/components/assistant_builder/AssistantBuilder";
 import { EmptyCallToAction } from "@app/components/EmptyCallToAction";
 
 export default function DustAppSelectionSection({

--- a/front/components/assistant_builder/TeamSharingSection.tsx
+++ b/front/components/assistant_builder/TeamSharingSection.tsx
@@ -5,7 +5,7 @@ import {
   Dialog,
   Icon,
 } from "@dust-tt/sparkle";
-import { AgentConfigurationScope, WorkspaceType } from "@dust-tt/types";
+import type { AgentConfigurationScope, WorkspaceType } from "@dust-tt/types";
 import { useRouter } from "next/router";
 import { useState } from "react";
 

--- a/front/components/assistant_builder/shared.ts
+++ b/front/components/assistant_builder/shared.ts
@@ -1,5 +1,5 @@
-import { ConnectorProvider } from "@dust-tt/types";
-import { TimeframeUnit } from "@dust-tt/types";
+import type { ConnectorProvider } from "@dust-tt/types";
+import type { TimeframeUnit } from "@dust-tt/types";
 
 export const FILTERING_MODES = ["SEARCH", "TIMEFRAME"] as const;
 export type FilteringMode = (typeof FILTERING_MODES)[number];

--- a/front/components/data_source/DataSourcePicker.tsx
+++ b/front/components/data_source/DataSourcePicker.tsx
@@ -1,4 +1,4 @@
-import { WorkspaceType } from "@dust-tt/types";
+import type { WorkspaceType } from "@dust-tt/types";
 import { Menu } from "@headlessui/react";
 import { ChevronDownIcon } from "@heroicons/react/20/solid";
 import Link from "next/link";

--- a/front/components/home/carousel.tsx
+++ b/front/components/home/carousel.tsx
@@ -11,7 +11,8 @@ import {
   NotionLogo,
   SlackLogo,
 } from "@dust-tt/sparkle";
-import React, { Component, createRef, ReactNode, RefObject } from "react";
+import type { ReactNode, RefObject } from "react";
+import React, { Component, createRef } from "react";
 import Slider from "react-slick";
 
 import { classNames } from "@app/lib/utils";

--- a/front/components/home/contentComponents.tsx
+++ b/front/components/home/contentComponents.tsx
@@ -10,7 +10,8 @@ import {
   TriangleIcon,
 } from "@dust-tt/sparkle";
 import classNames from "classnames";
-import React, { AnchorHTMLAttributes, ReactElement, ReactNode } from "react";
+import type { AnchorHTMLAttributes, ReactElement, ReactNode } from "react";
+import React from "react";
 
 const defaultGridClasses =
   "grid grid-cols-12 gap-x-6 gap-y-8 px-6 md:px-12 lg:px-20 2xl:px-0";

--- a/front/components/home/particles.tsx
+++ b/front/components/home/particles.tsx
@@ -1,4 +1,5 @@
-import { RefObject, useEffect } from "react";
+import type { RefObject } from "react";
+import { useEffect } from "react";
 import * as THREE from "three";
 
 const hasScrollBehavior = true;

--- a/front/components/home/scrollingHeader.tsx
+++ b/front/components/home/scrollingHeader.tsx
@@ -1,5 +1,6 @@
 import classNames from "classnames";
-import React, { ReactNode, useCallback, useEffect, useState } from "react";
+import type { ReactNode } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 
 // Define your scroll limit here
 const SCROLL_LIMIT_1 = 12;

--- a/front/components/poke/plans/form.tsx
+++ b/front/components/poke/plans/form.tsx
@@ -9,12 +9,12 @@ import {
   NotionLogo,
   SlackLogo,
 } from "@dust-tt/sparkle";
-import {
-  assertNever,
+import type {
   FreeBillingType,
   PaidBillingType,
   PlanType,
 } from "@dust-tt/types";
+import { assertNever } from "@dust-tt/types";
 import { useCallback, useState } from "react";
 
 import { classNames } from "@app/lib/utils";

--- a/front/components/providers/AI21Setup.tsx
+++ b/front/components/providers/AI21Setup.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@dust-tt/sparkle";
-import { WorkspaceType } from "@dust-tt/types";
+import type { WorkspaceType } from "@dust-tt/types";
 import { Dialog, Transition } from "@headlessui/react";
 import { Fragment, useEffect, useState } from "react";
 import { useSWRConfig } from "swr";

--- a/front/components/providers/AnthropicSetup.tsx
+++ b/front/components/providers/AnthropicSetup.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@dust-tt/sparkle";
-import { WorkspaceType } from "@dust-tt/types";
+import type { WorkspaceType } from "@dust-tt/types";
 import { Dialog, Transition } from "@headlessui/react";
 import { Fragment, useEffect, useState } from "react";
 import { useSWRConfig } from "swr";

--- a/front/components/providers/AzureOpenAISetup.tsx
+++ b/front/components/providers/AzureOpenAISetup.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@dust-tt/sparkle";
-import { WorkspaceType } from "@dust-tt/types";
+import type { WorkspaceType } from "@dust-tt/types";
 import { Dialog, Transition } from "@headlessui/react";
 import { Fragment, useEffect, useState } from "react";
 import { useSWRConfig } from "swr";

--- a/front/components/providers/BrowserlessAPISetup.tsx
+++ b/front/components/providers/BrowserlessAPISetup.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@dust-tt/sparkle";
-import { WorkspaceType } from "@dust-tt/types";
+import type { WorkspaceType } from "@dust-tt/types";
 import { Dialog, Transition } from "@headlessui/react";
 import { Fragment, useEffect, useState } from "react";
 import { useSWRConfig } from "swr";

--- a/front/components/providers/CohereSetup.tsx
+++ b/front/components/providers/CohereSetup.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@dust-tt/sparkle";
-import { WorkspaceType } from "@dust-tt/types";
+import type { WorkspaceType } from "@dust-tt/types";
 import { Dialog, Transition } from "@headlessui/react";
 import { Fragment, useEffect, useState } from "react";
 import { useSWRConfig } from "swr";

--- a/front/components/providers/GoogleVertexAISetup.tsx
+++ b/front/components/providers/GoogleVertexAISetup.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@dust-tt/sparkle";
-import { WorkspaceType } from "@dust-tt/types";
+import type { WorkspaceType } from "@dust-tt/types";
 import { Dialog, Transition } from "@headlessui/react";
 import { Fragment, useEffect, useState } from "react";
 import { useSWRConfig } from "swr";

--- a/front/components/providers/MistralAISetup.tsx
+++ b/front/components/providers/MistralAISetup.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@dust-tt/sparkle";
-import { WorkspaceType } from "@dust-tt/types";
+import type { WorkspaceType } from "@dust-tt/types";
 import { Dialog, Transition } from "@headlessui/react";
 import { Fragment, useEffect, useState } from "react";
 import { useSWRConfig } from "swr";

--- a/front/components/providers/OpenAISetup.tsx
+++ b/front/components/providers/OpenAISetup.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@dust-tt/sparkle";
-import { WorkspaceType } from "@dust-tt/types";
+import type { WorkspaceType } from "@dust-tt/types";
 import { Dialog, Transition } from "@headlessui/react";
 import { Fragment, useEffect, useState } from "react";
 import { useSWRConfig } from "swr";

--- a/front/components/providers/SerpAPISetup.tsx
+++ b/front/components/providers/SerpAPISetup.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@dust-tt/sparkle";
-import { WorkspaceType } from "@dust-tt/types";
+import type { WorkspaceType } from "@dust-tt/types";
 import { Dialog, Transition } from "@headlessui/react";
 import { Fragment, useEffect, useState } from "react";
 import { useSWRConfig } from "swr";

--- a/front/components/providers/SerperSetup.tsx
+++ b/front/components/providers/SerperSetup.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@dust-tt/sparkle";
-import { WorkspaceType } from "@dust-tt/types";
+import type { WorkspaceType } from "@dust-tt/types";
 import { Dialog, Transition } from "@headlessui/react";
 import { Fragment, useEffect, useState } from "react";
 import { useSWRConfig } from "swr";

--- a/front/components/providers/TextSynthSetup.tsx
+++ b/front/components/providers/TextSynthSetup.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@dust-tt/sparkle";
-import { WorkspaceType } from "@dust-tt/types";
+import type { WorkspaceType } from "@dust-tt/types";
 import { Dialog, Transition } from "@headlessui/react";
 import { Fragment, useEffect, useState } from "react";
 import { useSWRConfig } from "swr";

--- a/front/components/sparkle/AppLayout.tsx
+++ b/front/components/sparkle/AppLayout.tsx
@@ -6,8 +6,8 @@ import {
   Tab,
   XMarkIcon,
 } from "@dust-tt/sparkle";
-import { UserType, WorkspaceType } from "@dust-tt/types";
-import { SubscriptionType } from "@dust-tt/types";
+import type { UserType, WorkspaceType } from "@dust-tt/types";
+import type { SubscriptionType } from "@dust-tt/types";
 import { Dialog, Transition } from "@headlessui/react";
 import { Bars3Icon } from "@heroicons/react/20/solid";
 import Head from "next/head";
@@ -21,11 +21,8 @@ import React from "react";
 import WorkspacePicker from "@app/components/WorkspacePicker";
 import { classNames } from "@app/lib/utils";
 
-import {
-  SidebarNavigation,
-  topNavigation,
-  TopNavigationId,
-} from "./navigation";
+import type { SidebarNavigation, TopNavigationId } from "./navigation";
+import { topNavigation } from "./navigation";
 
 function NavigationBar({
   user,

--- a/front/components/sparkle/OnboardingLayout.tsx
+++ b/front/components/sparkle/OnboardingLayout.tsx
@@ -1,4 +1,4 @@
-import { WorkspaceType } from "@dust-tt/types";
+import type { WorkspaceType } from "@dust-tt/types";
 import Head from "next/head";
 import Script from "next/script";
 import { useRef } from "react";

--- a/front/components/sparkle/navigation.tsx
+++ b/front/components/sparkle/navigation.tsx
@@ -14,8 +14,8 @@ import {
   ServerIcon,
   ShapesIcon,
 } from "@dust-tt/sparkle";
-import { WorkspaceType } from "@dust-tt/types";
-import { AppType } from "@dust-tt/types";
+import type { WorkspaceType } from "@dust-tt/types";
+import type { AppType } from "@dust-tt/types";
 import { UsersIcon } from "@heroicons/react/20/solid";
 
 import { isDevelopmentOrDustWorkspace } from "@app/lib/development";

--- a/front/components/tables/TablePicker.tsx
+++ b/front/components/tables/TablePicker.tsx
@@ -1,5 +1,5 @@
-import { WorkspaceType } from "@dust-tt/types";
-import { CoreAPITable } from "@dust-tt/types";
+import type { WorkspaceType } from "@dust-tt/types";
+import type { CoreAPITable } from "@dust-tt/types";
 import { Menu } from "@headlessui/react";
 import { ChevronDownIcon } from "@heroicons/react/20/solid";
 

--- a/front/components/use/EventSchemaForm.tsx
+++ b/front/components/use/EventSchemaForm.tsx
@@ -5,9 +5,10 @@ import {
   Page,
   XCircleIcon,
 } from "@dust-tt/sparkle";
-import { WorkspaceType } from "@dust-tt/types";
-import { eventSchemaPropertyAllTypes, EventSchemaType } from "@dust-tt/types";
-import { APIError } from "@dust-tt/types";
+import type { WorkspaceType } from "@dust-tt/types";
+import type { EventSchemaType } from "@dust-tt/types";
+import type { APIError } from "@dust-tt/types";
+import { eventSchemaPropertyAllTypes } from "@dust-tt/types";
 import { PlusIcon } from "@heroicons/react/24/outline";
 import { useRouter } from "next/router";
 import React, { useState } from "react";

--- a/front/lib/actions/helpers.ts
+++ b/front/lib/actions/helpers.ts
@@ -1,10 +1,9 @@
-import { Action, cloneBaseConfig } from "@dust-tt/types";
-import {
-  DustAPI,
-  DustAPIErrorResponse,
-  DustAppConfigType,
-} from "@dust-tt/types";
-import { Err, Ok, Result } from "@dust-tt/types";
+import type { Action } from "@dust-tt/types";
+import type { DustAPIErrorResponse, DustAppConfigType } from "@dust-tt/types";
+import type { Result } from "@dust-tt/types";
+import { cloneBaseConfig } from "@dust-tt/types";
+import { DustAPI } from "@dust-tt/types";
+import { Err, Ok } from "@dust-tt/types";
 import { isRight } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 

--- a/front/lib/actions/server.ts
+++ b/front/lib/actions/server.ts
@@ -1,8 +1,11 @@
-import { DustProdActionRegistry, DustRegistryActionName } from "@dust-tt/types";
-import { DustAPI, DustAppConfigType, DustAppType } from "@dust-tt/types";
+import type { DustRegistryActionName } from "@dust-tt/types";
+import type { DustAppConfigType, DustAppType } from "@dust-tt/types";
+import { DustProdActionRegistry } from "@dust-tt/types";
+import { DustAPI } from "@dust-tt/types";
 import { Err, Ok } from "@dust-tt/types";
 
-import { Authenticator, prodAPICredentialsForOwner } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
+import { prodAPICredentialsForOwner } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import { statsDClient } from "@app/logger/withlogging";
 

--- a/front/lib/actions/types.ts
+++ b/front/lib/actions/types.ts
@@ -1,4 +1,4 @@
-import { ActionResponseBase } from "@dust-tt/types";
+import type { ActionResponseBase } from "@dust-tt/types";
 import { isRight } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 

--- a/front/lib/api/app.ts
+++ b/front/lib/api/app.ts
@@ -1,7 +1,7 @@
-import { AppType } from "@dust-tt/types";
+import type { AppType } from "@dust-tt/types";
 import { Op } from "sequelize";
 
-import { Authenticator } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import { App } from "@app/lib/models";
 
 export async function getApp(

--- a/front/lib/api/assistant/actions/database_query.ts
+++ b/front/lib/api/assistant/actions/database_query.ts
@@ -1,25 +1,27 @@
-import {
+import type {
   AgentConfigurationType,
   AgentMessageType,
-  cloneBaseConfig,
   ConversationType,
   DatabaseQueryActionType,
   DatabaseQueryErrorEvent,
   DatabaseQueryOutputEvent,
   DatabaseQueryParamsEvent,
   DatabaseQuerySuccessEvent,
+  ModelMessageType,
+  Result,
+  UserMessageType,
+} from "@dust-tt/types";
+import {
+  cloneBaseConfig,
   DustProdActionRegistry,
   Err,
   isDatabaseQueryConfiguration,
-  ModelMessageType,
   Ok,
-  Result,
-  UserMessageType,
 } from "@dust-tt/types";
 
 import { runActionStreamed } from "@app/lib/actions/server";
 import { generateActionInputs } from "@app/lib/api/assistant/agent";
-import { Authenticator } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import { AgentDatabaseQueryAction } from "@app/lib/models";
 import logger from "@app/logger/logger";
 

--- a/front/lib/api/assistant/actions/dust_app_run.ts
+++ b/front/lib/api/assistant/actions/dust_app_run.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   DustAppRunBlockEvent,
   DustAppRunErrorEvent,
   DustAppRunParamsEvent,
@@ -6,26 +6,25 @@ import {
   ModelId,
   ModelMessageType,
 } from "@dust-tt/types";
-import {
-  DustAppParameters,
-  DustAppRunActionType,
-  isDustAppRunConfiguration,
-} from "@dust-tt/types";
-import {
+import type { DustAppParameters, DustAppRunActionType } from "@dust-tt/types";
+import type {
   AgentActionSpecification,
   AgentConfigurationType,
 } from "@dust-tt/types";
-import {
+import type {
   AgentMessageType,
   ConversationType,
   UserMessageType,
 } from "@dust-tt/types";
-import { AppType, SpecificationType } from "@dust-tt/types";
-import { DatasetSchema } from "@dust-tt/types";
+import type { AppType, SpecificationType } from "@dust-tt/types";
+import type { DatasetSchema } from "@dust-tt/types";
+import type { Result } from "@dust-tt/types";
+import { isDustAppRunConfiguration } from "@dust-tt/types";
 import { DustAPI } from "@dust-tt/types";
-import { Err, Ok, Result } from "@dust-tt/types";
+import { Err, Ok } from "@dust-tt/types";
 
-import { Authenticator, prodAPICredentialsForOwner } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
+import { prodAPICredentialsForOwner } from "@app/lib/auth";
 import { extractConfig } from "@app/lib/config";
 import { AgentDustAppRunAction } from "@app/lib/models";
 import logger from "@app/logger/logger";

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -1,33 +1,34 @@
-import {
+import type {
   ModelId,
   ModelMessageType,
   RetrievalErrorEvent,
   RetrievalParamsEvent,
   RetrievalSuccessEvent,
 } from "@dust-tt/types";
-import {
-  isRetrievalConfiguration,
+import type {
   RetrievalActionType,
   RetrievalConfigurationType,
   RetrievalDocumentType,
   TimeFrame,
 } from "@dust-tt/types";
-import {
+import type {
   AgentActionSpecification,
   AgentConfigurationType,
 } from "@dust-tt/types";
-import {
+import type {
   AgentMessageType,
   ConversationType,
   UserMessageType,
 } from "@dust-tt/types";
+import type { Result } from "@dust-tt/types";
+import { isRetrievalConfiguration } from "@dust-tt/types";
 import { cloneBaseConfig, DustProdActionRegistry } from "@dust-tt/types";
-import { Err, Ok, Result } from "@dust-tt/types";
+import { Err, Ok } from "@dust-tt/types";
 
 import { runActionStreamed } from "@app/lib/actions/server";
 import { generateActionInputs } from "@app/lib/api/assistant/agent";
 import { getSupportedModelConfig } from "@app/lib/assistant";
-import { Authenticator } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import { front_sequelize } from "@app/lib/databases";
 import {
   AgentRetrievalAction,

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   AgentActionEvent,
   AgentActionSuccessEvent,
   AgentConfigurationType,
@@ -8,24 +8,27 @@ import {
   AgentMessageSuccessEvent,
   DatabaseQueryParamsEvent,
   GenerationTokensEvent,
+} from "@dust-tt/types";
+import type {
+  AgentActionSpecification,
+  LightAgentConfigurationType,
+} from "@dust-tt/types";
+import type {
+  AgentMessageType,
+  ConversationType,
+  UserMessageType,
+} from "@dust-tt/types";
+import type { Result } from "@dust-tt/types";
+import {
   GPT_3_5_TURBO_MODEL_CONFIG,
   GPT_4_32K_MODEL_CONFIG,
   GPT_4_MODEL_CONFIG,
   isDatabaseQueryConfiguration,
 } from "@dust-tt/types";
-import {
-  AgentActionSpecification,
-  LightAgentConfigurationType,
-} from "@dust-tt/types";
-import {
-  AgentMessageType,
-  ConversationType,
-  UserMessageType,
-} from "@dust-tt/types";
 import { isDustAppRunConfiguration } from "@dust-tt/types";
 import { isRetrievalConfiguration } from "@dust-tt/types";
 import { cloneBaseConfig, DustProdActionRegistry } from "@dust-tt/types";
-import { Err, Ok, Result } from "@dust-tt/types";
+import { Err, Ok } from "@dust-tt/types";
 
 import { runActionStreamed } from "@app/lib/actions/server";
 import { runDatabaseQuery } from "@app/lib/api/assistant/actions/database_query";
@@ -37,7 +40,7 @@ import {
   renderConversationForModel,
   runGeneration,
 } from "@app/lib/api/assistant/generation";
-import { Authenticator } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 
 /**

--- a/front/lib/api/assistant/agent_usage.ts
+++ b/front/lib/api/assistant/agent_usage.ts
@@ -1,4 +1,4 @@
-import { AgentUsageType, ModelId } from "@dust-tt/types";
+import type { AgentUsageType, ModelId } from "@dust-tt/types";
 import { literal, Op } from "sequelize";
 import { v4 as uuidv4 } from "uuid";
 

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -1,33 +1,31 @@
-import {
+import type {
   AgentMention,
   AgentUserListStatus,
-  assertNever,
-  Err,
   LightAgentConfigurationType,
-  Ok,
   Result,
   SupportedModel,
 } from "@dust-tt/types";
-import { DustAppRunConfigurationType } from "@dust-tt/types";
-import {
+import type { DustAppRunConfigurationType } from "@dust-tt/types";
+import type {
   AgentsGetViewType,
   DataSourceConfiguration,
-  isTemplatedQuery,
-  isTimeFrame,
   RetrievalConfigurationType,
   RetrievalQuery,
   RetrievalTimeframe,
 } from "@dust-tt/types";
-import {
+import type {
   AgentActionConfigurationType,
   AgentConfigurationScope,
   AgentConfigurationType,
   AgentGenerationConfigurationType,
   AgentStatus,
 } from "@dust-tt/types";
+import type { DatabaseQueryConfigurationType } from "@dust-tt/types";
+import { assertNever, Err, Ok } from "@dust-tt/types";
+import { isTemplatedQuery, isTimeFrame } from "@dust-tt/types";
 import { isSupportedModel } from "@dust-tt/types";
-import { DatabaseQueryConfigurationType } from "@dust-tt/types";
-import { Op, Transaction, UniqueConstraintError } from "sequelize";
+import type { Transaction } from "sequelize";
+import { Op, UniqueConstraintError } from "sequelize";
 
 import {
   getGlobalAgents,
@@ -35,7 +33,7 @@ import {
 } from "@app/lib/api/assistant/global_agents";
 import { agentConfigurationWasUpdatedBy } from "@app/lib/api/assistant/recent_authors";
 import { agentUserListStatus } from "@app/lib/api/assistant/user_relation";
-import { Authenticator } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import { front_sequelize } from "@app/lib/databases";
 import {
   AgentConfiguration,

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   AgentMessageNewEvent,
   ConversationTitleEvent,
   GenerationTokensEvent,
@@ -6,9 +6,8 @@ import {
   UserMessageNewEvent,
   WorkspaceType,
 } from "@dust-tt/types";
-import { GPT_3_5_TURBO_MODEL_CONFIG } from "@dust-tt/types";
-import { LightAgentConfigurationType } from "@dust-tt/types";
-import {
+import type { LightAgentConfigurationType } from "@dust-tt/types";
+import type {
   AgentMessageType,
   ContentFragmentContentType,
   ContentFragmentContextType,
@@ -16,18 +15,13 @@ import {
   ConversationType,
   ConversationVisibility,
   ConversationWithoutContentType,
-  isAgentMention,
-  isAgentMessageType,
-  isUserMention,
-  isUserMessageType,
   MentionType,
   UserMessageContext,
   UserMessageType,
 } from "@dust-tt/types";
-import { PlanType } from "@dust-tt/types";
-import { cloneBaseConfig, DustProdActionRegistry } from "@dust-tt/types";
-import { Err, Ok, Result } from "@dust-tt/types";
-import {
+import type { PlanType } from "@dust-tt/types";
+import type { Result } from "@dust-tt/types";
+import type {
   AgentActionEvent,
   AgentActionSuccessEvent,
   AgentErrorEvent,
@@ -36,8 +30,18 @@ import {
   AgentMessageErrorEvent,
   AgentMessageSuccessEvent,
 } from "@dust-tt/types";
+import { GPT_3_5_TURBO_MODEL_CONFIG } from "@dust-tt/types";
+import {
+  isAgentMention,
+  isAgentMessageType,
+  isUserMention,
+  isUserMessageType,
+} from "@dust-tt/types";
+import { cloneBaseConfig, DustProdActionRegistry } from "@dust-tt/types";
+import { Err, Ok } from "@dust-tt/types";
 import crypto from "crypto";
-import { Op, Transaction } from "sequelize";
+import type { Transaction } from "sequelize";
+import { Op } from "sequelize";
 
 import { runActionStreamed } from "@app/lib/actions/server";
 import { renderRetrievalActionByModelId } from "@app/lib/api/assistant/actions/retrieval";
@@ -45,7 +49,7 @@ import { runAgent } from "@app/lib/api/assistant/agent";
 import { signalAgentUsage } from "@app/lib/api/assistant/agent_usage";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
 import { renderConversationForModel } from "@app/lib/api/assistant/generation";
-import { Authenticator } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import { front_sequelize } from "@app/lib/databases";
 import {
   AgentDatabaseQueryAction,

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -1,31 +1,36 @@
-import {
+import type {
   AgentConfigurationType,
   GenerationCancelEvent,
   GenerationErrorEvent,
   GenerationSuccessEvent,
   GenerationTokensEvent,
+  ModelConversationType,
+  ModelMessageType,
+} from "@dust-tt/types";
+import type {
+  AgentMessageType,
+  ConversationType,
+  UserMessageType,
+} from "@dust-tt/types";
+import type { Result } from "@dust-tt/types";
+import {
   GPT_4_32K_MODEL_ID,
   GPT_4_MODEL_CONFIG,
   isDatabaseQueryActionType,
   isDustAppRunActionType,
-  ModelConversationType,
-  ModelMessageType,
 } from "@dust-tt/types";
 import {
   isRetrievalActionType,
   isRetrievalConfiguration,
 } from "@dust-tt/types";
 import {
-  AgentMessageType,
-  ConversationType,
   isAgentMessageType,
   isContentFragmentType,
   isUserMessageType,
-  UserMessageType,
 } from "@dust-tt/types";
 import { cloneBaseConfig, DustProdActionRegistry } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
-import { Err, Ok, Result } from "@dust-tt/types";
+import { Err, Ok } from "@dust-tt/types";
 import moment from "moment-timezone";
 
 import { runActionStreamed } from "@app/lib/actions/server";
@@ -37,7 +42,7 @@ import {
 } from "@app/lib/api/assistant/actions/retrieval";
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
 import { getSupportedModelConfig, isLargeModel } from "@app/lib/assistant";
-import { Authenticator } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import { redisClient } from "@app/lib/redis";
 import logger from "@app/logger/logger";
 const CANCELLATION_CHECK_INTERVAL = 500;

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -4,12 +4,13 @@ import { promisify } from "util";
 
 const readFileAsync = promisify(fs.readFile);
 
-import {
+import type {
   AgentConfigurationType,
   ConnectorProvider,
   DataSourceType,
-  GEMINI_PRO_DEFAULT_MODEL_CONFIG,
 } from "@dust-tt/types";
+import type { GlobalAgentStatus } from "@dust-tt/types";
+import { GEMINI_PRO_DEFAULT_MODEL_CONFIG } from "@dust-tt/types";
 import {
   CLAUDE_DEFAULT_MODEL_CONFIG,
   CLAUDE_INSTANT_DEFAULT_MODEL_CONFIG,
@@ -18,10 +19,11 @@ import {
   MISTRAL_MEDIUM_MODEL_CONFIG,
   MISTRAL_SMALL_MODEL_CONFIG,
 } from "@dust-tt/types";
-import { DustAPI, GlobalAgentStatus } from "@dust-tt/types";
+import { DustAPI } from "@dust-tt/types";
 
 import { GLOBAL_AGENTS_SID } from "@app/lib/assistant";
-import { Authenticator, prodAPICredentialsForOwner } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
+import { prodAPICredentialsForOwner } from "@app/lib/auth";
 import { GlobalAgentSettings } from "@app/lib/models/assistant/agent";
 import logger from "@app/logger/logger";
 

--- a/front/lib/api/assistant/pubsub.ts
+++ b/front/lib/api/assistant/pubsub.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   AgentMessageType,
   ConversationType,
   GenerationTokensEvent,
@@ -7,8 +7,8 @@ import {
   UserMessageContext,
   UserMessageType,
 } from "@dust-tt/types";
-import { Err, Ok, Result } from "@dust-tt/types";
-import {
+import type { Result } from "@dust-tt/types";
+import type {
   AgentActionEvent,
   AgentActionSuccessEvent,
   AgentErrorEvent,
@@ -16,15 +16,16 @@ import {
   AgentGenerationSuccessEvent,
   AgentMessageSuccessEvent,
 } from "@dust-tt/types";
-import {
+import type {
   AgentMessageNewEvent,
   ConversationTitleEvent,
   UserMessageErrorEvent,
   UserMessageNewEvent,
 } from "@dust-tt/types";
+import { Err, Ok } from "@dust-tt/types";
 import { rateLimiter } from "@dust-tt/types";
 
-import { Authenticator } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import { AgentMessage, Message } from "@app/lib/models";
 import { redisClient } from "@app/lib/redis";
 import { wakeLock } from "@app/lib/wake_lock";

--- a/front/lib/api/assistant/reaction.ts
+++ b/front/lib/api/assistant/reaction.ts
@@ -1,12 +1,12 @@
-import { UserType } from "@dust-tt/types";
-import {
+import type { UserType } from "@dust-tt/types";
+import type {
   ConversationMessageReactions,
   ConversationType,
   ConversationWithoutContentType,
   MessageReactionType,
 } from "@dust-tt/types";
 
-import { Authenticator } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import { Message, MessageReaction } from "@app/lib/models";
 
 /**

--- a/front/lib/api/assistant/recent_authors.ts
+++ b/front/lib/api/assistant/recent_authors.ts
@@ -1,11 +1,11 @@
-import {
+import type {
   AgentRecentAuthors,
   LightAgentConfigurationType,
   UserType,
 } from "@dust-tt/types";
 import { Sequelize } from "sequelize";
 
-import { Authenticator } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import { AgentConfiguration } from "@app/lib/models";
 import { safeRedisClient } from "@app/lib/redis";
 

--- a/front/lib/api/assistant/user_relation.ts
+++ b/front/lib/api/assistant/user_relation.ts
@@ -1,14 +1,12 @@
-import {
+import type {
   AgentUserListStatus,
-  assertNever,
-  Err,
   LightAgentConfigurationType,
-  Ok,
   Result,
 } from "@dust-tt/types";
+import { assertNever, Err, Ok } from "@dust-tt/types";
 
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
-import { Authenticator } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import { AgentUserRelation } from "@app/lib/models/assistant/agent";
 
 export function agentUserListStatus({

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -1,17 +1,14 @@
-import {
+import type {
   APIError,
   ConnectorProvider,
-  ConnectorsAPI,
-  CoreAPI,
   DataSourceType,
-  Err,
-  Ok,
   Result,
 } from "@dust-tt/types";
+import { ConnectorsAPI, CoreAPI, Err, Ok } from "@dust-tt/types";
 import { Op } from "sequelize";
 
 import { getMembers } from "@app/lib/api/workspace";
-import { Authenticator } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import { sendGithubDeletionEmail } from "@app/lib/email";
 import { DataSource } from "@app/lib/models";
 import logger from "@app/logger/logger";

--- a/front/lib/api/datasets.ts
+++ b/front/lib/api/datasets.ts
@@ -1,8 +1,8 @@
-import { AppType } from "@dust-tt/types";
-import { DatasetSchema, DatasetType } from "@dust-tt/types";
+import type { AppType } from "@dust-tt/types";
+import type { DatasetSchema, DatasetType } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
 
-import { Authenticator } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import { Dataset } from "@app/lib/models";
 import logger from "@app/logger/logger";
 

--- a/front/lib/api/extract.ts
+++ b/front/lib/api/extract.ts
@@ -1,8 +1,8 @@
-import { ModelId } from "@dust-tt/types";
-import { EventSchemaType, ExtractedEventType } from "@dust-tt/types";
+import type { ModelId } from "@dust-tt/types";
+import type { EventSchemaType, ExtractedEventType } from "@dust-tt/types";
 import { Op } from "sequelize";
 
-import { Authenticator } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import { isDevelopmentOrDustWorkspace } from "@app/lib/development";
 import { sortedEventProperties } from "@app/lib/extract_events_properties";
 import { EventSchema, ExtractedEvent } from "@app/lib/models";

--- a/front/lib/api/run.ts
+++ b/front/lib/api/run.ts
@@ -1,11 +1,11 @@
-import { AppType, SpecificationType } from "@dust-tt/types";
-import { RunConfig, RunType } from "@dust-tt/types";
+import type { AppType, SpecificationType } from "@dust-tt/types";
+import type { RunConfig, RunType } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
 import fs from "fs";
 import path from "path";
 import peg from "pegjs";
 
-import { Authenticator } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 
 import { recomputeIndents, restoreTripleBackticks } from "../specification";

--- a/front/lib/api/user.ts
+++ b/front/lib/api/user.ts
@@ -1,4 +1,4 @@
-import { UserMetadataType, UserType } from "@dust-tt/types";
+import type { UserMetadataType, UserType } from "@dust-tt/types";
 
 import { User, UserMetadata } from "@app/lib/models";
 

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -1,12 +1,12 @@
-import {
+import type {
   RoleType,
   UserType,
   WorkspaceSegmentationType,
   WorkspaceType,
 } from "@dust-tt/types";
-import { MembershipInvitationType } from "@dust-tt/types";
+import type { MembershipInvitationType } from "@dust-tt/types";
 
-import { Authenticator } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import {
   Membership,
   MembershipInvitation,

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -1,5 +1,6 @@
-import { LightAgentConfigurationType } from "@dust-tt/types";
-import { SUPPORTED_MODEL_CONFIGS, SupportedModel } from "@dust-tt/types";
+import type { LightAgentConfigurationType } from "@dust-tt/types";
+import type { SupportedModel } from "@dust-tt/types";
+import { SUPPORTED_MODEL_CONFIGS } from "@dust-tt/types";
 
 export function isLargeModel(model: unknown): model is SupportedModel {
   const maybeSupportedModel = model as SupportedModel;

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -1,9 +1,10 @@
-import { RoleType, UserType, WorkspaceType } from "@dust-tt/types";
-import { PlanType, SubscriptionType } from "@dust-tt/types";
-import { DustAPICredentials } from "@dust-tt/types";
-import { Err, Ok, Result } from "@dust-tt/types";
-import { APIErrorWithStatusCode } from "@dust-tt/types";
-import {
+import type { RoleType, UserType, WorkspaceType } from "@dust-tt/types";
+import type { PlanType, SubscriptionType } from "@dust-tt/types";
+import type { DustAPICredentials } from "@dust-tt/types";
+import type { Result } from "@dust-tt/types";
+import type { APIErrorWithStatusCode } from "@dust-tt/types";
+import { Err, Ok } from "@dust-tt/types";
+import type {
   GetServerSidePropsContext,
   NextApiRequest,
   NextApiResponse,
@@ -19,7 +20,8 @@ import {
   User,
   Workspace,
 } from "@app/lib/models";
-import { FREE_TEST_PLAN_DATA, PlanAttributes } from "@app/lib/plans/free_plans";
+import type { PlanAttributes } from "@app/lib/plans/free_plans";
+import { FREE_TEST_PLAN_DATA } from "@app/lib/plans/free_plans";
 import { isUpgraded } from "@app/lib/plans/plan_codes";
 import { new_id } from "@app/lib/utils";
 import logger from "@app/logger/logger";

--- a/front/lib/client/handle_file_upload.ts
+++ b/front/lib/client/handle_file_upload.ts
@@ -1,4 +1,5 @@
-import { Err, Ok, Result } from "@dust-tt/types";
+import type { Result } from "@dust-tt/types";
+import { Err, Ok } from "@dust-tt/types";
 // @ts-expect-error: type package doesn't load properly because of how we are loading pdfjs
 import * as PDFJS from "pdfjs-dist/build/pdf";
 PDFJS.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${PDFJS.version}/pdf.worker.min.js`;

--- a/front/lib/config.ts
+++ b/front/lib/config.ts
@@ -1,4 +1,4 @@
-import { BlockRunConfig, SpecificationType } from "@dust-tt/types";
+import type { BlockRunConfig, SpecificationType } from "@dust-tt/types";
 
 export function extractConfig(spec: SpecificationType): BlockRunConfig {
   const c = {} as { [key: string]: any };

--- a/front/lib/connector_connection_id.ts
+++ b/front/lib/connector_connection_id.ts
@@ -1,4 +1,4 @@
-import { ConnectorProvider } from "@dust-tt/types";
+import type { ConnectorProvider } from "@dust-tt/types";
 
 import { client_side_new_id } from "@app/lib/utils";
 

--- a/front/lib/connector_providers.ts
+++ b/front/lib/connector_providers.ts
@@ -6,7 +6,7 @@ import {
   NotionLogo,
   SlackLogo,
 } from "@dust-tt/sparkle";
-import { ConnectorProvider } from "@dust-tt/types";
+import type { ConnectorProvider } from "@dust-tt/types";
 
 export const CONNECTOR_CONFIGURATIONS: Record<
   ConnectorProvider,

--- a/front/lib/data_sources.ts
+++ b/front/lib/data_sources.ts
@@ -1,4 +1,4 @@
-import { CoreAPIDocument } from "@dust-tt/types";
+import type { CoreAPIDocument } from "@dust-tt/types";
 
 export function getDisplayNameForDocument(document: CoreAPIDocument): string {
   const titleTagPrefix = "title:";

--- a/front/lib/datasets.ts
+++ b/front/lib/datasets.ts
@@ -1,4 +1,4 @@
-import { DatasetEntry, DatasetSchema } from "@dust-tt/types";
+import type { DatasetEntry, DatasetSchema } from "@dust-tt/types";
 
 function areSetsEqual(a: Set<any>, b: Set<any>): boolean {
   if (a.size !== b.size) {

--- a/front/lib/development.ts
+++ b/front/lib/development.ts
@@ -1,4 +1,4 @@
-import { WorkspaceType } from "@dust-tt/types";
+import type { WorkspaceType } from "@dust-tt/types";
 
 const PRODUCTION_DUST_WORKSPACE_ID = "0ec9852c2f";
 const PRODUCTION_DUST_APPS_WORKSPACE_ID = "78bda07b39";

--- a/front/lib/diff.ts
+++ b/front/lib/diff.ts
@@ -1,4 +1,4 @@
-import { Diff } from "@dust-tt/types";
+import type { Diff } from "@dust-tt/types";
 import diff from "fast-diff";
 
 export function diffStrings(text1: string, text2: string): Diff[] {

--- a/front/lib/email.ts
+++ b/front/lib/email.ts
@@ -4,7 +4,7 @@
  */
 import sgMail from "@sendgrid/mail";
 
-import { XP1User } from "@app/lib/models";
+import type { XP1User } from "@app/lib/models";
 import logger from "@app/logger/logger";
 
 const { SENDGRID_API_KEY = "", XP1_CHROME_WEB_STORE_URL } = process.env;

--- a/front/lib/extract_event_app.ts
+++ b/front/lib/extract_event_app.ts
@@ -1,12 +1,13 @@
-import {
+import type {
   EventSchemaType,
   ExtractEventAppResponseResults,
 } from "@dust-tt/types";
+import type { CoreAPITokenType } from "@dust-tt/types";
 import { cloneBaseConfig, DustProdActionRegistry } from "@dust-tt/types";
-import { CoreAPI, CoreAPITokenType } from "@dust-tt/types";
+import { CoreAPI } from "@dust-tt/types";
 
 import { runAction } from "@app/lib/actions/server";
-import { Authenticator } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import { findMarkersIndexes } from "@app/lib/extract_event_markers";
 import { formatPropertiesForModel } from "@app/lib/extract_events_properties";
 import logger from "@app/logger/logger";

--- a/front/lib/extract_event_markers.ts
+++ b/front/lib/extract_event_markers.ts
@@ -1,4 +1,4 @@
-import { CoreAPITokenType } from "@dust-tt/types";
+import type { CoreAPITokenType } from "@dust-tt/types";
 import { Op } from "sequelize";
 
 import { ExtractedEvent } from "@app/lib/models";

--- a/front/lib/extract_events.ts
+++ b/front/lib/extract_events.ts
@@ -1,11 +1,11 @@
 import { Op } from "sequelize";
 
-import {
+import type {
   DocumentsPostProcessHookFilterParams,
   DocumentsPostProcessHookOnUpsertParams,
 } from "@app/documents_post_process_hooks/hooks";
 import { getDatasource } from "@app/documents_post_process_hooks/hooks/lib/data_source_helpers";
-import { Authenticator } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import {
   _getMaxTextContentToProcess,
   _runExtractEventApp,

--- a/front/lib/extract_events_properties.ts
+++ b/front/lib/extract_events_properties.ts
@@ -1,9 +1,9 @@
-import {
+import type {
   EventSchemaPropertiesTypeForModel,
-  eventSchemaPropertyAllTypes,
   EventSchemaPropertyType,
   ExtractedEventPropertyType,
 } from "@dust-tt/types";
+import { eventSchemaPropertyAllTypes } from "@dust-tt/types";
 
 /**
  * We start with: 

--- a/front/lib/http_utils.ts
+++ b/front/lib/http_utils.ts
@@ -1,5 +1,7 @@
-import { Err, Ok, Result } from "@dust-tt/types";
-import Ajv, { JSONSchemaType } from "ajv";
+import type { Result } from "@dust-tt/types";
+import { Err, Ok } from "@dust-tt/types";
+import type { JSONSchemaType } from "ajv";
+import Ajv from "ajv";
 
 const ajv = new Ajv({
   coerceTypes: true,

--- a/front/lib/models/apps.ts
+++ b/front/lib/models/apps.ts
@@ -1,13 +1,12 @@
-import { DatasetSchema } from "@dust-tt/types";
-import {
+import type { DatasetSchema } from "@dust-tt/types";
+import type {
   CreationOptional,
-  DataTypes,
   ForeignKey,
   InferAttributes,
   InferCreationAttributes,
-  Model,
   NonAttribute,
 } from "sequelize";
+import { DataTypes, Model } from "sequelize";
 
 import { front_sequelize } from "@app/lib/databases";
 import { Workspace } from "@app/lib/models/workspace";

--- a/front/lib/models/assistant/actions/database_query.ts
+++ b/front/lib/models/assistant/actions/database_query.ts
@@ -1,10 +1,9 @@
-import {
+import type {
   CreationOptional,
-  DataTypes,
   InferAttributes,
   InferCreationAttributes,
-  Model,
 } from "sequelize";
+import { DataTypes, Model } from "sequelize";
 
 import { front_sequelize } from "@app/lib/databases";
 

--- a/front/lib/models/assistant/actions/dust_app_run.ts
+++ b/front/lib/models/assistant/actions/dust_app_run.ts
@@ -1,11 +1,10 @@
-import { DustAppParameters } from "@dust-tt/types";
-import {
+import type { DustAppParameters } from "@dust-tt/types";
+import type {
   CreationOptional,
-  DataTypes,
   InferAttributes,
   InferCreationAttributes,
-  Model,
 } from "sequelize";
+import { DataTypes, Model } from "sequelize";
 
 import { front_sequelize } from "@app/lib/databases";
 

--- a/front/lib/models/assistant/actions/retrieval.ts
+++ b/front/lib/models/assistant/actions/retrieval.ts
@@ -1,13 +1,12 @@
-import { TimeframeUnit } from "@dust-tt/types";
-import {
+import type { TimeframeUnit } from "@dust-tt/types";
+import type {
   CreationOptional,
-  DataTypes,
   ForeignKey,
   InferAttributes,
   InferCreationAttributes,
-  Model,
   NonAttribute,
 } from "sequelize";
+import { DataTypes, Model } from "sequelize";
 
 import { front_sequelize } from "@app/lib/databases";
 import { DataSource } from "@app/lib/models/data_source";

--- a/front/lib/models/assistant/agent.ts
+++ b/front/lib/models/assistant/agent.ts
@@ -1,21 +1,20 @@
-import {
+import type {
   AgentUserListStatus,
   DustAppRunConfigurationType,
 } from "@dust-tt/types";
-import {
+import type {
   AgentConfigurationScope,
   AgentStatus,
   GlobalAgentStatus,
 } from "@dust-tt/types";
-import {
+import type {
   CreationOptional,
-  DataTypes,
   ForeignKey,
   InferAttributes,
   InferCreationAttributes,
-  Model,
   NonAttribute,
 } from "sequelize";
+import { DataTypes, Model } from "sequelize";
 
 import { front_sequelize } from "@app/lib/databases";
 import { AgentDatabaseQueryConfiguration } from "@app/lib/models/assistant/actions/database_query";

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -1,19 +1,18 @@
-import {
+import type {
   AgentMessageStatus,
   ContentFragmentContentType,
   ConversationVisibility,
   MessageVisibility,
   ParticipantActionType,
 } from "@dust-tt/types";
-import {
+import type {
   CreationOptional,
-  DataTypes,
   ForeignKey,
   InferAttributes,
   InferCreationAttributes,
-  Model,
   NonAttribute,
 } from "sequelize";
+import { DataTypes, Model } from "sequelize";
 
 import { front_sequelize } from "@app/lib/databases";
 import { AgentDatabaseQueryAction } from "@app/lib/models/assistant/actions/database_query";

--- a/front/lib/models/data_source.ts
+++ b/front/lib/models/data_source.ts
@@ -1,13 +1,12 @@
-import { ConnectorProvider } from "@dust-tt/types";
-import {
+import type { ConnectorProvider } from "@dust-tt/types";
+import type {
   CreationOptional,
-  DataTypes,
   ForeignKey,
   InferAttributes,
   InferCreationAttributes,
-  Model,
   NonAttribute,
 } from "sequelize";
+import { DataTypes, Model } from "sequelize";
 
 import { front_sequelize } from "@app/lib/databases";
 import { Workspace } from "@app/lib/models/workspace";

--- a/front/lib/models/doc_tracker.ts
+++ b/front/lib/models/doc_tracker.ts
@@ -1,11 +1,10 @@
-import {
+import type {
   CreationOptional,
-  DataTypes,
   ForeignKey,
   InferAttributes,
   InferCreationAttributes,
-  Model,
 } from "sequelize";
+import { DataTypes, Model } from "sequelize";
 
 import { front_sequelize } from "@app/lib/databases";
 import { DataSource } from "@app/lib/models/data_source";

--- a/front/lib/models/extract.ts
+++ b/front/lib/models/extract.ts
@@ -1,12 +1,14 @@
-import { EventSchemaPropertyType, EventSchemaStatus } from "@dust-tt/types";
-import {
+import type {
+  EventSchemaPropertyType,
+  EventSchemaStatus,
+} from "@dust-tt/types";
+import type {
   CreationOptional,
-  DataTypes,
   ForeignKey,
   InferAttributes,
   InferCreationAttributes,
-  Model,
 } from "sequelize";
+import { DataTypes, Model } from "sequelize";
 
 import { front_sequelize } from "@app/lib/databases";
 import { User } from "@app/lib/models/user";

--- a/front/lib/models/plan.ts
+++ b/front/lib/models/plan.ts
@@ -1,21 +1,22 @@
-import {
-  FREE_BILLING_TYPES,
+import type {
   FreeBillingType,
-  PAID_BILLING_TYPES,
   PaidBillingType,
-  SUBSCRIPTION_STATUSES,
   SubscriptionStatusType,
 } from "@dust-tt/types";
 import {
+  FREE_BILLING_TYPES,
+  PAID_BILLING_TYPES,
+  SUBSCRIPTION_STATUSES,
+} from "@dust-tt/types";
+import type {
   CreationOptional,
-  DataTypes,
   ForeignKey,
   InferAttributes,
   InferCreationAttributes,
-  Model,
   NonAttribute,
   Transaction,
 } from "sequelize";
+import { DataTypes, Model } from "sequelize";
 
 import { front_sequelize } from "@app/lib/databases";
 import { Workspace } from "@app/lib/models/workspace";

--- a/front/lib/models/user.ts
+++ b/front/lib/models/user.ts
@@ -1,11 +1,10 @@
-import {
+import type {
   CreationOptional,
-  DataTypes,
   ForeignKey,
   InferAttributes,
   InferCreationAttributes,
-  Model,
 } from "sequelize";
+import { DataTypes, Model } from "sequelize";
 
 import { front_sequelize } from "@app/lib/databases";
 

--- a/front/lib/models/workspace.ts
+++ b/front/lib/models/workspace.ts
@@ -1,16 +1,15 @@
-import { WorkspaceSegmentationType } from "@dust-tt/types";
-import {
+import type { WorkspaceSegmentationType } from "@dust-tt/types";
+import type {
   CreationOptional,
-  DataTypes,
   ForeignKey,
   InferAttributes,
   InferCreationAttributes,
-  Model,
   NonAttribute,
 } from "sequelize";
+import { DataTypes, Model } from "sequelize";
 
 import { front_sequelize } from "@app/lib/databases";
-import { Subscription } from "@app/lib/models/plan";
+import type { Subscription } from "@app/lib/models/plan";
 import { User } from "@app/lib/models/user";
 
 export class Workspace extends Model<

--- a/front/lib/models/xp1.ts
+++ b/front/lib/models/xp1.ts
@@ -1,11 +1,10 @@
-import {
+import type {
   CreationOptional,
-  DataTypes,
   ForeignKey,
   InferAttributes,
   InferCreationAttributes,
-  Model,
 } from "sequelize";
+import { DataTypes, Model } from "sequelize";
 
 import { xp1_sequelize } from "@app/lib/databases";
 

--- a/front/lib/plans/enterprise_plans.ts
+++ b/front/lib/plans/enterprise_plans.ts
@@ -1,6 +1,6 @@
-import { Attributes } from "sequelize";
+import type { Attributes } from "sequelize";
 
-import { Plan } from "@app/lib/models";
+import type { Plan } from "@app/lib/models";
 import { ENT_PLAN_FAKE_CODE } from "@app/lib/plans/plan_codes";
 
 export type PlanAttributes = Omit<

--- a/front/lib/plans/free_plans.ts
+++ b/front/lib/plans/free_plans.ts
@@ -1,4 +1,4 @@
-import { Attributes } from "sequelize";
+import type { Attributes } from "sequelize";
 
 import { Plan } from "@app/lib/models";
 import {

--- a/front/lib/plans/plan_codes.ts
+++ b/front/lib/plans/plan_codes.ts
@@ -1,4 +1,4 @@
-import { PlanType } from "@dust-tt/types";
+import type { PlanType } from "@dust-tt/types";
 
 // Current free plans:
 export const FREE_UPGRADED_PLAN_CODE = "FREE_UPGRADED_PLAN";

--- a/front/lib/plans/pro_plans.ts
+++ b/front/lib/plans/pro_plans.ts
@@ -1,4 +1,4 @@
-import { Attributes } from "sequelize";
+import type { Attributes } from "sequelize";
 
 import { isDevelopment } from "@app/lib/development";
 import { Plan } from "@app/lib/models";

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -1,8 +1,9 @@
-import { assertNever, WorkspaceType } from "@dust-tt/types";
-import { SubscriptionType } from "@dust-tt/types";
+import type { WorkspaceType } from "@dust-tt/types";
+import type { SubscriptionType } from "@dust-tt/types";
+import { assertNever } from "@dust-tt/types";
 import Stripe from "stripe";
 
-import { Authenticator } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import { Plan } from "@app/lib/models";
 import { countActiveSeatsInWorkspace } from "@app/lib/plans/workspace_usage";
 

--- a/front/lib/plans/subscription.ts
+++ b/front/lib/plans/subscription.ts
@@ -1,12 +1,17 @@
-import { WorkspaceType } from "@dust-tt/types";
-import { PlanInvitationType, PlanType, SubscriptionType } from "@dust-tt/types";
+import type { WorkspaceType } from "@dust-tt/types";
+import type {
+  PlanInvitationType,
+  PlanType,
+  SubscriptionType,
+} from "@dust-tt/types";
 import { v4 as uuidv4 } from "uuid";
 
-import { Authenticator } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import { front_sequelize } from "@app/lib/databases";
 import { Plan, Subscription, Workspace } from "@app/lib/models";
 import { PlanInvitation } from "@app/lib/models/plan";
-import { FREE_TEST_PLAN_DATA, PlanAttributes } from "@app/lib/plans/free_plans";
+import type { PlanAttributes } from "@app/lib/plans/free_plans";
+import { FREE_TEST_PLAN_DATA } from "@app/lib/plans/free_plans";
 import {
   FREE_TEST_PLAN_CODE,
   FREE_UPGRADED_PLAN_CODE,

--- a/front/lib/plans/workspace_usage.ts
+++ b/front/lib/plans/workspace_usage.ts
@@ -1,4 +1,4 @@
-import { WorkspaceType } from "@dust-tt/types";
+import type { WorkspaceType } from "@dust-tt/types";
 import { Op, QueryTypes } from "sequelize";
 
 import { front_sequelize } from "@app/lib/databases";

--- a/front/lib/providers.ts
+++ b/front/lib/providers.ts
@@ -1,8 +1,8 @@
-import { WorkspaceType } from "@dust-tt/types";
+import type { WorkspaceType } from "@dust-tt/types";
 
-import { GetProvidersCheckResponseBody } from "@app/pages/api/w/[wId]/providers/[pId]/check";
+import type { GetProvidersCheckResponseBody } from "@app/pages/api/w/[wId]/providers/[pId]/check";
 
-import { useProviders } from "./swr";
+import type { useProviders } from "./swr";
 
 type ModelProvider = {
   providerId: string;

--- a/front/lib/specification.ts
+++ b/front/lib/specification.ts
@@ -1,5 +1,5 @@
-import { SpecificationType } from "@dust-tt/types";
-import { BlockType } from "@dust-tt/types";
+import type { SpecificationType } from "@dust-tt/types";
+import type { BlockType } from "@dust-tt/types";
 
 export function recomputeIndents(spec: SpecificationType): SpecificationType {
   let indent = 0;

--- a/front/lib/swr.ts
+++ b/front/lib/swr.ts
@@ -1,36 +1,40 @@
-import {
+import type {
   AgentConfigurationType,
   AgentsGetViewType,
   DataSourceType,
 } from "@dust-tt/types";
-import { WorkspaceType } from "@dust-tt/types";
-import { ConversationMessageReactions, ConversationType } from "@dust-tt/types";
-import { AppType } from "@dust-tt/types";
-import { RunRunType } from "@dust-tt/types";
-import { ConnectorPermission } from "@dust-tt/types";
-import useSWR, { Fetcher } from "swr";
+import type { WorkspaceType } from "@dust-tt/types";
+import type {
+  ConversationMessageReactions,
+  ConversationType,
+} from "@dust-tt/types";
+import type { AppType } from "@dust-tt/types";
+import type { RunRunType } from "@dust-tt/types";
+import type { ConnectorPermission } from "@dust-tt/types";
+import type { Fetcher } from "swr";
+import useSWR from "swr";
 
-import { GetPokePlansResponseBody } from "@app/pages/api/poke/plans";
-import { GetWorkspacesResponseBody } from "@app/pages/api/poke/workspaces";
-import { GetUserMetadataResponseBody } from "@app/pages/api/user/metadata/[key]";
-import { ListTablesResponseBody } from "@app/pages/api/v1/w/[wId]/data_sources/[name]/tables";
-import { GetDatasetsResponseBody } from "@app/pages/api/w/[wId]/apps/[aId]/datasets";
-import { GetRunsResponseBody } from "@app/pages/api/w/[wId]/apps/[aId]/runs";
-import { GetRunBlockResponseBody } from "@app/pages/api/w/[wId]/apps/[aId]/runs/[runId]/blocks/[type]/[name]";
-import { GetRunStatusResponseBody } from "@app/pages/api/w/[wId]/apps/[aId]/runs/[runId]/status";
-import { GetAgentConfigurationsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
-import { GetAgentUsageResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/usage";
-import { GetDataSourcesResponseBody } from "@app/pages/api/w/[wId]/data_sources";
-import { GetDocumentsResponseBody } from "@app/pages/api/w/[wId]/data_sources/[name]/documents";
-import { GetOrPostBotEnabledResponseBody } from "@app/pages/api/w/[wId]/data_sources/[name]/managed/bot_enabled";
-import { GetDataSourcePermissionsResponseBody } from "@app/pages/api/w/[wId]/data_sources/[name]/managed/permissions";
-import { GetSlackChannelsLinkedWithAgentResponseBody } from "@app/pages/api/w/[wId]/data_sources/[name]/managed/slack/channels_linked_with_agent";
-import { GetWorkspaceInvitationsResponseBody } from "@app/pages/api/w/[wId]/invitations";
-import { GetKeysResponseBody } from "@app/pages/api/w/[wId]/keys";
-import { GetMembersResponseBody } from "@app/pages/api/w/[wId]/members";
-import { GetProvidersResponseBody } from "@app/pages/api/w/[wId]/providers";
-import { GetExtractedEventsResponseBody } from "@app/pages/api/w/[wId]/use/extract/events/[sId]";
-import { GetEventSchemasResponseBody } from "@app/pages/api/w/[wId]/use/extract/templates";
+import type { GetPokePlansResponseBody } from "@app/pages/api/poke/plans";
+import type { GetWorkspacesResponseBody } from "@app/pages/api/poke/workspaces";
+import type { GetUserMetadataResponseBody } from "@app/pages/api/user/metadata/[key]";
+import type { ListTablesResponseBody } from "@app/pages/api/v1/w/[wId]/data_sources/[name]/tables";
+import type { GetDatasetsResponseBody } from "@app/pages/api/w/[wId]/apps/[aId]/datasets";
+import type { GetRunsResponseBody } from "@app/pages/api/w/[wId]/apps/[aId]/runs";
+import type { GetRunBlockResponseBody } from "@app/pages/api/w/[wId]/apps/[aId]/runs/[runId]/blocks/[type]/[name]";
+import type { GetRunStatusResponseBody } from "@app/pages/api/w/[wId]/apps/[aId]/runs/[runId]/status";
+import type { GetAgentConfigurationsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
+import type { GetAgentUsageResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/usage";
+import type { GetDataSourcesResponseBody } from "@app/pages/api/w/[wId]/data_sources";
+import type { GetDocumentsResponseBody } from "@app/pages/api/w/[wId]/data_sources/[name]/documents";
+import type { GetOrPostBotEnabledResponseBody } from "@app/pages/api/w/[wId]/data_sources/[name]/managed/bot_enabled";
+import type { GetDataSourcePermissionsResponseBody } from "@app/pages/api/w/[wId]/data_sources/[name]/managed/permissions";
+import type { GetSlackChannelsLinkedWithAgentResponseBody } from "@app/pages/api/w/[wId]/data_sources/[name]/managed/slack/channels_linked_with_agent";
+import type { GetWorkspaceInvitationsResponseBody } from "@app/pages/api/w/[wId]/invitations";
+import type { GetKeysResponseBody } from "@app/pages/api/w/[wId]/keys";
+import type { GetMembersResponseBody } from "@app/pages/api/w/[wId]/members";
+import type { GetProvidersResponseBody } from "@app/pages/api/w/[wId]/providers";
+import type { GetExtractedEventsResponseBody } from "@app/pages/api/w/[wId]/use/extract/events/[sId]";
+import type { GetEventSchemasResponseBody } from "@app/pages/api/w/[wId]/use/extract/templates";
 
 export const fetcher = async (...args: Parameters<typeof fetch>) =>
   fetch(...args).then(async (res) => {

--- a/front/lib/temporal.ts
+++ b/front/lib/temporal.ts
@@ -1,4 +1,5 @@
-import { Client, Connection, ConnectionOptions } from "@temporalio/client";
+import type { ConnectionOptions } from "@temporalio/client";
+import { Client, Connection } from "@temporalio/client";
 import { NativeConnection } from "@temporalio/worker";
 import fs from "fs-extra";
 

--- a/front/lib/temporal_monitoring.ts
+++ b/front/lib/temporal_monitoring.ts
@@ -1,13 +1,13 @@
 import { isNangoError } from "@dust-tt/types";
-import { Context } from "@temporalio/activity";
-import {
+import type { Context } from "@temporalio/activity";
+import type {
   ActivityExecuteInput,
   ActivityInboundCallsInterceptor,
   Next,
 } from "@temporalio/worker";
 
 import type { Logger } from "@app/logger/logger";
-import logger from "@app/logger/logger";
+import type logger from "@app/logger/logger";
 import { statsDClient } from "@app/logger/withlogging";
 
 /** An Activity Context with an attached logger */

--- a/front/lib/user.ts
+++ b/front/lib/user.ts
@@ -1,7 +1,7 @@
-import { UserMetadataType } from "@dust-tt/types";
+import type { UserMetadataType } from "@dust-tt/types";
 import { useSWRConfig } from "swr";
 
-import { GetUserMetadataResponseBody } from "@app/pages/api/user/metadata/[key]";
+import type { GetUserMetadataResponseBody } from "@app/pages/api/user/metadata/[key]";
 
 /**
  * Client-side: retrieves a metadata value for the current user. See also `useUserMetadata` for an

--- a/front/lib/utils.ts
+++ b/front/lib/utils.ts
@@ -1,4 +1,4 @@
-import { LightAgentConfigurationType } from "@dust-tt/types";
+import type { LightAgentConfigurationType } from "@dust-tt/types";
 import { hash as blake3 } from "blake3";
 import { v4 as uuidv4 } from "uuid";
 

--- a/front/pages/_app.tsx
+++ b/front/pages/_app.tsx
@@ -1,10 +1,10 @@
 import "@app/styles/global.css";
 
 import { SparkleContext } from "@dust-tt/sparkle";
-import { AppProps } from "next/app";
+import type { AppProps } from "next/app";
 import Link from "next/link";
 import { SessionProvider } from "next-auth/react";
-import { MouseEvent, ReactNode } from "react";
+import type { MouseEvent, ReactNode } from "react";
 
 import { NotificationArea } from "@app/components/sparkle/Notification";
 

--- a/front/pages/api/[preStopSecret]/prestop.ts
+++ b/front/pages/api/[preStopSecret]/prestop.ts
@@ -1,4 +1,4 @@
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { wakeLockIsFree } from "@app/lib/wake_lock";
 import logger from "@app/logger/logger";

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -1,6 +1,6 @@
-import { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
 import { verify } from "jsonwebtoken";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 import { getServerSession } from "next-auth/next";
 
 import { getUserFromSession } from "@app/lib/auth";

--- a/front/pages/api/poke/plans.ts
+++ b/front/pages/api/poke/plans.ts
@@ -1,9 +1,9 @@
-import { PlanType } from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { PlanType } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 import Stripe from "stripe";
 
 import { Authenticator, getSession } from "@app/lib/auth";

--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/index.ts
@@ -1,5 +1,5 @@
-import { ReturnedAPIErrorType } from "@dust-tt/types";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import {
   archiveAgentConfiguration,

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/config.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/config.ts
@@ -1,6 +1,6 @@
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
 import { ConnectorsAPI } from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { Authenticator, getSession } from "@app/lib/auth";
 import { DataSource } from "@app/lib/models";

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/index.ts
@@ -1,5 +1,5 @@
-import { ReturnedAPIErrorType } from "@dust-tt/types";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { deleteDataSource } from "@app/lib/api/data_sources";
 import { Authenticator, getSession } from "@app/lib/auth";

--- a/front/pages/api/poke/workspaces/[wId]/downgrade.ts
+++ b/front/pages/api/poke/workspaces/[wId]/downgrade.ts
@@ -1,6 +1,6 @@
-import { WorkspaceType } from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { WorkspaceType } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { Authenticator, getSession } from "@app/lib/auth";
 import { internalSubscribeWorkspaceToFreeTestPlan } from "@app/lib/plans/subscription";

--- a/front/pages/api/poke/workspaces/[wId]/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/index.ts
@@ -1,9 +1,9 @@
-import { WorkspaceType } from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { WorkspaceType } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { setInternalWorkspaceSegmentation } from "@app/lib/api/workspace";
 import { Authenticator, getSession } from "@app/lib/auth";

--- a/front/pages/api/poke/workspaces/[wId]/revoke.ts
+++ b/front/pages/api/poke/workspaces/[wId]/revoke.ts
@@ -1,5 +1,5 @@
-import { ReturnedAPIErrorType } from "@dust-tt/types";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { Authenticator, getSession } from "@app/lib/auth";
 import { Membership } from "@app/lib/models";

--- a/front/pages/api/poke/workspaces/[wId]/upgrade.ts
+++ b/front/pages/api/poke/workspaces/[wId]/upgrade.ts
@@ -1,6 +1,6 @@
-import { WorkspaceType } from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { WorkspaceType } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { Authenticator, getSession } from "@app/lib/auth";
 import {

--- a/front/pages/api/poke/workspaces/index.ts
+++ b/front/pages/api/poke/workspaces/index.ts
@@ -1,7 +1,8 @@
-import { WorkspaceType } from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
-import { NextApiRequest, NextApiResponse } from "next";
-import { FindOptions, Op, WhereOptions } from "sequelize";
+import type { WorkspaceType } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
+import type { FindOptions, WhereOptions } from "sequelize";
+import { Op } from "sequelize";
 
 import { Authenticator, getSession } from "@app/lib/auth";
 import { Subscription, Workspace } from "@app/lib/models";

--- a/front/pages/api/registry/[type]/lookup.ts
+++ b/front/pages/api/registry/[type]/lookup.ts
@@ -1,4 +1,4 @@
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { DataSource, Workspace } from "@app/lib/models";
 import { withLogging } from "@app/logger/withlogging";

--- a/front/pages/api/stripe/portal.ts
+++ b/front/pages/api/stripe/portal.ts
@@ -1,8 +1,8 @@
-import { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { Authenticator, getSession } from "@app/lib/auth";
 import { createCustomerPortalSession } from "@app/lib/plans/stripe";

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -1,9 +1,6 @@
-import {
-  CoreAPI,
-  isRetrievalConfiguration,
-  ReturnedAPIErrorType,
-} from "@dust-tt/types";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import { CoreAPI, isRetrievalConfiguration } from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
 import { pipeline, Writable } from "stream";
 import Stripe from "stripe";
 import { promisify } from "util";

--- a/front/pages/api/user/index.ts
+++ b/front/pages/api/user/index.ts
@@ -1,8 +1,8 @@
-import { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { updateUserFullName } from "@app/lib/api/user";
 import { getSession, getUserFromSession } from "@app/lib/auth";

--- a/front/pages/api/user/metadata/[key]/index.ts
+++ b/front/pages/api/user/metadata/[key]/index.ts
@@ -1,6 +1,6 @@
-import { UserMetadataType } from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { UserMetadataType } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getUserMetadata, setUserMetadata } from "@app/lib/api/user";
 import { getSession, getUserFromSession } from "@app/lib/auth";

--- a/front/pages/api/v1/apps/[user]/[sId]/runs/[runId]/index.ts
+++ b/front/pages/api/v1/apps/[user]/[sId]/runs/[runId]/index.ts
@@ -1,6 +1,6 @@
-import { RunType } from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { RunType } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import logger from "@app/logger/logger";
 import { apiError, statsDClient, withLogging } from "@app/logger/withlogging";

--- a/front/pages/api/v1/apps/[user]/[sId]/runs/index.ts
+++ b/front/pages/api/v1/apps/[user]/[sId]/runs/index.ts
@@ -1,6 +1,6 @@
-import { RunType } from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { RunType } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import logger from "@app/logger/logger";
 import { apiError, statsDClient, withLogging } from "@app/logger/withlogging";

--- a/front/pages/api/v1/apps/[user]/index.ts
+++ b/front/pages/api/v1/apps/[user]/index.ts
@@ -1,6 +1,6 @@
-import { AppType } from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { AppType } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import logger from "@app/logger/logger";
 import { apiError, statsDClient, withLogging } from "@app/logger/withlogging";

--- a/front/pages/api/v1/data_sources/[user]/[name]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/data_sources/[user]/[name]/documents/[documentId]/index.ts
@@ -1,7 +1,7 @@
-import { DataSourceType } from "@dust-tt/types";
-import { DocumentType } from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { DataSourceType } from "@dust-tt/types";
+import type { DocumentType } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import logger from "@app/logger/logger";
 import { apiError, statsDClient, withLogging } from "@app/logger/withlogging";

--- a/front/pages/api/v1/data_sources/[user]/[name]/documents/index.ts
+++ b/front/pages/api/v1/data_sources/[user]/[name]/documents/index.ts
@@ -1,6 +1,6 @@
-import { DocumentType } from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { DocumentType } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import logger from "@app/logger/logger";
 import { apiError, statsDClient, withLogging } from "@app/logger/withlogging";

--- a/front/pages/api/v1/data_sources/[user]/[name]/search.ts
+++ b/front/pages/api/v1/data_sources/[user]/[name]/search.ts
@@ -1,6 +1,6 @@
-import { DocumentType } from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { DocumentType } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import logger from "@app/logger/logger";
 import { apiError, statsDClient, withLogging } from "@app/logger/withlogging";

--- a/front/pages/api/v1/w/[wId]/apps/[aId]/runs/[runId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/apps/[aId]/runs/[runId]/index.ts
@@ -1,7 +1,7 @@
-import { RunType } from "@dust-tt/types";
+import type { RunType } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getApp } from "@app/lib/api/app";
 import { Authenticator, getAPIKey } from "@app/lib/auth";

--- a/front/pages/api/v1/w/[wId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/v1/w/[wId]/apps/[aId]/runs/index.ts
@@ -1,12 +1,12 @@
-import { CredentialsType } from "@dust-tt/types";
-import { RunType } from "@dust-tt/types";
+import type { CredentialsType } from "@dust-tt/types";
+import type { RunType } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
 import {
   credentialsFromProviders,
   dustManagedCredentials,
 } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getApp } from "@app/lib/api/app";
 import { Authenticator, getAPIKey } from "@app/lib/auth";

--- a/front/pages/api/v1/w/[wId]/apps/index.ts
+++ b/front/pages/api/v1/w/[wId]/apps/index.ts
@@ -1,6 +1,6 @@
-import { AppType } from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { AppType } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getApps } from "@app/lib/api/app";
 import { Authenticator, getAPIKey } from "@app/lib/auth";

--- a/front/pages/api/v1/w/[wId]/assistant/agent_configurations.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/agent_configurations.ts
@@ -1,10 +1,10 @@
-import { ReturnedAPIErrorType } from "@dust-tt/types";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
 import { Authenticator, getAPIKey } from "@app/lib/auth";
 import { apiError, withLogging } from "@app/logger/withlogging";
-import { GetAgentConfigurationsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
+import type { GetAgentConfigurationsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
@@ -1,10 +1,10 @@
+import type { ContentFragmentType } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
 import { PublicPostContentFragmentRequestBodySchema } from "@dust-tt/types";
-import { ContentFragmentType } from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
-import * as t from "io-ts";
+import type * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import {
   getConversation,

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/events.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/events.ts
@@ -1,5 +1,5 @@
-import { ReturnedAPIErrorType } from "@dust-tt/types";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation";
 import { getConversationEvents } from "@app/lib/api/assistant/pubsub";

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -1,6 +1,6 @@
-import { ConversationType } from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { ConversationType } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getConversation } from "@app/lib/api/assistant/conversation";
 import { Authenticator, getAPIKey } from "@app/lib/auth";

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.ts
@@ -1,5 +1,5 @@
-import { ReturnedAPIErrorType } from "@dust-tt/types";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import {
   getConversationMessageType,

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -1,9 +1,9 @@
+import type { UserMessageType } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
 import { PublicPostMessagesRequestBodySchema } from "@dust-tt/types";
-import { UserMessageType } from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as reporter from "io-ts-reporters";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getConversation } from "@app/lib/api/assistant/conversation";
 import { postUserMessageWithPubSub } from "@app/lib/api/assistant/pubsub";

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -1,13 +1,13 @@
-import { PublicPostConversationsRequestBodySchema } from "@dust-tt/types";
-import {
+import type {
   ContentFragmentType,
   ConversationType,
   UserMessageType,
 } from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import { PublicPostConversationsRequestBodySchema } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as reporter from "io-ts-reporters";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import {
   createConversation,

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
@@ -1,16 +1,15 @@
+import type { CoreAPILightDocument, DataSourceType } from "@dust-tt/types";
+import type { DocumentType } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
 import {
-  CoreAPILightDocument,
-  DataSourceType,
   PostDataSourceDocumentRequestBodySchema,
   sectionFullText,
 } from "@dust-tt/types";
-import { DocumentType } from "@dust-tt/types";
 import { dustManagedCredentials } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as reporter from "io-ts-reporters";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import {
   getDocumentsPostDeleteHooksToRun,

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/parents.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/parents.ts
@@ -1,6 +1,6 @@
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSource } from "@app/lib/api/data_sources";
 import { Authenticator, getAPIKey } from "@app/lib/auth";

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/index.ts
@@ -1,7 +1,7 @@
-import { DocumentType } from "@dust-tt/types";
+import type { DocumentType } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSource } from "@app/lib/api/data_sources";
 import { Authenticator, getAPIKey } from "@app/lib/auth";

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/search.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/search.ts
@@ -1,13 +1,13 @@
-import { DocumentType } from "@dust-tt/types";
-import { CredentialsType } from "@dust-tt/types";
+import type { DocumentType } from "@dust-tt/types";
+import type { CredentialsType } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
 import {
   credentialsFromProviders,
   dustManagedCredentials,
 } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
-import { JSONSchemaType } from "ajv";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { JSONSchemaType } from "ajv";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSource } from "@app/lib/api/data_sources";
 import { Authenticator, getAPIKey } from "@app/lib/auth";

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/index.ts
@@ -1,5 +1,6 @@
-import { CoreAPI, CoreAPITable } from "@dust-tt/types";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { CoreAPITable } from "@dust-tt/types";
+import { CoreAPI } from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSource } from "@app/lib/api/data_sources";
 import { Authenticator, getAPIKey } from "@app/lib/auth";

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/rows/[rId].ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/rows/[rId].ts
@@ -1,5 +1,6 @@
-import { CoreAPI, CoreAPIRow } from "@dust-tt/types";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { CoreAPIRow } from "@dust-tt/types";
+import { CoreAPI } from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSource } from "@app/lib/api/data_sources";
 import { Authenticator, getAPIKey } from "@app/lib/auth";

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/rows/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/rows/index.ts
@@ -1,8 +1,9 @@
-import { CoreAPI, CoreAPIRow } from "@dust-tt/types";
+import type { CoreAPIRow } from "@dust-tt/types";
+import { CoreAPI } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSource } from "@app/lib/api/data_sources";
 import { Authenticator, getAPIKey } from "@app/lib/auth";

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/index.ts
@@ -1,8 +1,9 @@
-import { CoreAPI, CoreAPITable } from "@dust-tt/types";
+import type { CoreAPITable } from "@dust-tt/types";
+import { CoreAPI } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSource } from "@app/lib/api/data_sources";
 import { Authenticator, getAPIKey } from "@app/lib/auth";

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tokenize.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tokenize.ts
@@ -1,10 +1,10 @@
-import { CoreAPITokenType } from "@dust-tt/types";
+import type { CoreAPITokenType } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSource } from "@app/lib/api/data_sources";
 import { Authenticator, getAPIKey } from "@app/lib/auth";

--- a/front/pages/api/v1/w/[wId]/data_sources/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/index.ts
@@ -1,6 +1,6 @@
-import { DataSourceType } from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { DataSourceType } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSources } from "@app/lib/api/data_sources";
 import { Authenticator, getAPIKey } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/apps/[aId]/clone.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/clone.ts
@@ -1,7 +1,7 @@
-import { AppType } from "@dust-tt/types";
+import type { AppType } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getApp } from "@app/lib/api/app";
 import { getDatasets } from "@app/lib/api/datasets";

--- a/front/pages/api/w/[wId]/apps/[aId]/datasets/[name]/index.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/datasets/[name]/index.ts
@@ -1,9 +1,9 @@
-import { DatasetType } from "@dust-tt/types";
+import type { DatasetType } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as reporter from "io-ts-reporters";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getApp } from "@app/lib/api/app";
 import { Authenticator, getSession } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/apps/[aId]/datasets/index.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/datasets/index.ts
@@ -1,10 +1,10 @@
-import { DatasetType } from "@dust-tt/types";
+import type { DatasetType } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getApp } from "@app/lib/api/app";
 import { getDatasets } from "@app/lib/api/datasets";

--- a/front/pages/api/w/[wId]/apps/[aId]/index.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/index.ts
@@ -1,6 +1,6 @@
-import { AppType } from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { AppType } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
 import { Op } from "sequelize";
 
 import { Authenticator, getSession } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/apps/[aId]/runs/[runId]/blocks/[type]/[name]/index.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/runs/[runId]/blocks/[type]/[name]/index.ts
@@ -1,7 +1,7 @@
-import { BlockType, RunType } from "@dust-tt/types";
+import type { BlockType, RunType } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getApp } from "@app/lib/api/app";
 import { Authenticator, getSession } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/apps/[aId]/runs/[runId]/status.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/runs/[runId]/status.ts
@@ -1,7 +1,7 @@
-import { RunType } from "@dust-tt/types";
+import type { RunType } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getApp } from "@app/lib/api/app";
 import { Authenticator, getSession } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/runs/index.ts
@@ -1,8 +1,8 @@
-import { RunType } from "@dust-tt/types";
+import type { RunType } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
 import { credentialsFromProviders } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getApp } from "@app/lib/api/app";
 import { Authenticator, getSession } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/apps/[aId]/state.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/state.ts
@@ -1,5 +1,5 @@
-import { AppType } from "@dust-tt/types";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { AppType } from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
 import { Op } from "sequelize";
 
 import { Authenticator, getSession } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/apps/index.ts
+++ b/front/pages/api/w/[wId]/apps/index.ts
@@ -1,7 +1,7 @@
-import { AppType } from "@dust-tt/types";
+import type { AppType } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { Authenticator, getSession } from "@app/lib/auth";
 import { App } from "@app/lib/models";

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/index.ts
@@ -1,11 +1,9 @@
-import {
-  AgentConfigurationType,
-  PostOrPatchAgentConfigurationRequestBodySchema,
-} from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { AgentConfigurationType } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import { PostOrPatchAgentConfigurationRequestBodySchema } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as reporter from "io-ts-reporters";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import {
   archiveAgentConfiguration,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/linked_slack_channels.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/linked_slack_channels.ts
@@ -1,9 +1,9 @@
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
 import { ConnectorsAPI } from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
 import { Authenticator, getSession } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/scope.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/scope.ts
@@ -1,8 +1,8 @@
-import { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import {
   getAgentConfiguration,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/usage.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/usage.ts
@@ -1,6 +1,6 @@
-import { AgentUsageType } from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { AgentUsageType } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getAgentUsage } from "@app/lib/api/assistant/agent_usage";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/avatar.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/avatar.ts
@@ -1,7 +1,7 @@
 import { Storage } from "@google-cloud/storage";
 import { IncomingForm } from "formidable";
 import fs from "fs";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withLogging } from "@app/logger/withlogging";
 

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -1,17 +1,19 @@
-import {
+import type {
   AgentActionConfigurationType,
   AgentConfigurationType,
   AgentGenerationConfigurationType,
-  GetAgentConfigurationsQuerySchema,
   LightAgentConfigurationType,
-  PostOrPatchAgentConfigurationRequestBodySchema,
   Result,
 } from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import {
+  GetAgentConfigurationsQuerySchema,
+  PostOrPatchAgentConfigurationRequestBodySchema,
+} from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
-import * as t from "io-ts";
+import type * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getAgentUsage } from "@app/lib/api/assistant/agent_usage";
 import {

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/name_available.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/name_available.ts
@@ -1,8 +1,8 @@
-import { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { agentNameIsAvailable } from "@app/lib/api/assistant/configuration";
 import { Authenticator, getSession } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/cancel.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/cancel.ts
@@ -1,8 +1,8 @@
-import { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation";
 import { cancelMessageGenerationEvent } from "@app/lib/api/assistant/pubsub";

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/content_fragment/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/content_fragment/index.ts
@@ -1,12 +1,10 @@
-import {
-  ContentFragmentType,
-  InternalPostContentFragmentRequestBodySchema,
-} from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { ContentFragmentType } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import { InternalPostContentFragmentRequestBodySchema } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
-import * as t from "io-ts";
+import type * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import {
   getConversation,

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/events.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/events.ts
@@ -1,5 +1,5 @@
-import { ReturnedAPIErrorType } from "@dust-tt/types";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation";
 import { getConversationEvents } from "@app/lib/api/assistant/pubsub";

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -1,9 +1,9 @@
-import { ConversationType } from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { ConversationType } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import {
   deleteConversation,

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit.ts
@@ -1,9 +1,10 @@
-import { isUserMessageType, UserMessageType } from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { UserMessageType } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import { isUserMessageType } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getConversation } from "@app/lib/api/assistant/conversation";
 import { editUserMessageWithPubSub } from "@app/lib/api/assistant/pubsub";

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.ts
@@ -1,5 +1,5 @@
-import { ReturnedAPIErrorType } from "@dust-tt/types";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import {
   getConversationMessageType,

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/reactions/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/reactions/index.ts
@@ -1,9 +1,9 @@
-import { MessageReactionType } from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { MessageReactionType } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation";
 import {

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/retry.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/retry.ts
@@ -1,9 +1,10 @@
-import { AgentMessageType, isAgentMessageType } from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { AgentMessageType } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import { isAgentMessageType } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getConversation } from "@app/lib/api/assistant/conversation";
 import { retryAgentMessageWithPubSub } from "@app/lib/api/assistant/pubsub";

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -1,11 +1,9 @@
-import {
-  InternalPostMessagesRequestBodySchema,
-  UserMessageType,
-} from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { UserMessageType } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import { InternalPostMessagesRequestBodySchema } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as reporter from "io-ts-reporters";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getConversation } from "@app/lib/api/assistant/conversation";
 import { postUserMessageWithPubSub } from "@app/lib/api/assistant/pubsub";

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/reactions.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/reactions.ts
@@ -1,6 +1,6 @@
-import { ConversationMessageReactions } from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { ConversationMessageReactions } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation";
 import { getMessageReactions } from "@app/lib/api/assistant/reaction";

--- a/front/pages/api/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/index.ts
@@ -1,14 +1,14 @@
-import {
+import type {
   ContentFragmentType,
   ConversationType,
   ConversationWithoutContentType,
-  InternalPostConversationsRequestBodySchema,
   UserMessageType,
 } from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import { InternalPostConversationsRequestBodySchema } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as reporter from "io-ts-reporters";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import {
   createConversation,

--- a/front/pages/api/w/[wId]/assistant/global_agents/[aId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/global_agents/[aId]/index.ts
@@ -1,8 +1,8 @@
-import { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { upsertGlobalAgentSettings } from "@app/lib/api/assistant/global_agents";
 import { Authenticator, getSession } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
@@ -1,15 +1,15 @@
+import type { CoreAPILightDocument } from "@dust-tt/types";
+import type { DocumentType } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
 import {
-  CoreAPILightDocument,
   PostDataSourceDocumentRequestBodySchema,
   sectionFullText,
 } from "@dust-tt/types";
-import { DocumentType } from "@dust-tt/types";
 import { dustManagedCredentials } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as reporter from "io-ts-reporters";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSource } from "@app/lib/api/data_sources";
 import { Authenticator, getSession } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/data_sources/[name]/documents/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/documents/index.ts
@@ -1,6 +1,6 @@
-import { DocumentType } from "@dust-tt/types";
+import type { DocumentType } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSource } from "@app/lib/api/data_sources";
 import { Authenticator, getSession } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/data_sources/[name]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/index.ts
@@ -1,7 +1,7 @@
-import { DataSourceType } from "@dust-tt/types";
+import type { DataSourceType } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSource } from "@app/lib/api/data_sources";
 import { Authenticator, getSession } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/bot_enabled.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/bot_enabled.ts
@@ -1,9 +1,9 @@
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
 import { ConnectorsAPI } from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSource } from "@app/lib/api/data_sources";
 import { Authenticator, getSession } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/parents.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/parents.ts
@@ -1,9 +1,9 @@
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
 import { ConnectorsAPI } from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSource } from "@app/lib/api/data_sources";
 import { Authenticator, getSession } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/permissions/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/permissions/index.ts
@@ -1,14 +1,10 @@
-import {
-  assertNever,
-  ConnectorPermission,
-  ConnectorResource,
-  ConnectorsAPI,
-} from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { ConnectorPermission, ConnectorResource } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import { assertNever, ConnectorsAPI } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSource } from "@app/lib/api/data_sources";
 import { Authenticator, getSession } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/slack/channels_linked_with_agent.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/slack/channels_linked_with_agent.ts
@@ -1,6 +1,6 @@
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
 import { ConnectorsAPI } from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSource } from "@app/lib/api/data_sources";
 import { Authenticator, getSession } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/update.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/update.ts
@@ -1,9 +1,10 @@
-import { ConnectorsAPI, ConnectorsAPIErrorResponse } from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { ConnectorsAPIErrorResponse } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import { ConnectorsAPI } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSource } from "@app/lib/api/data_sources";
 import { Authenticator, getSession } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/data_sources/[name]/search.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/search.ts
@@ -1,8 +1,8 @@
-import { DocumentType } from "@dust-tt/types";
+import type { DocumentType } from "@dust-tt/types";
 import { dustManagedCredentials } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
-import { JSONSchemaType } from "ajv";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { JSONSchemaType } from "ajv";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSource } from "@app/lib/api/data_sources";
 import { Authenticator, getSession } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/data_sources/[name]/tables/csv.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/tables/csv.ts
@@ -1,11 +1,13 @@
-import { CoreAPI, CoreAPIRow } from "@dust-tt/types";
-import { Err, Ok, Result } from "@dust-tt/types";
-import { APIError } from "@dust-tt/types";
+import type { CoreAPIRow } from "@dust-tt/types";
+import type { Result } from "@dust-tt/types";
+import type { APIError } from "@dust-tt/types";
+import { CoreAPI } from "@dust-tt/types";
+import { Err, Ok } from "@dust-tt/types";
 import { parse } from "csv-parse";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSource } from "@app/lib/api/data_sources";
 import { Authenticator, getSession } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/data_sources/[name]/tables/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/tables/index.ts
@@ -1,12 +1,12 @@
 import { CoreAPI } from "@dust-tt/types";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSource } from "@app/lib/api/data_sources";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { isActivatedStructuredDB } from "@app/lib/development";
 import logger from "@app/logger/logger";
 import { apiError, withLogging } from "@app/logger/withlogging";
-import { ListTablesResponseBody } from "@app/pages/api/v1/w/[wId]/data_sources/[name]/tables";
+import type { ListTablesResponseBody } from "@app/pages/api/v1/w/[wId]/data_sources/[name]/tables";
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/index.ts
@@ -1,8 +1,8 @@
-import { DataSourceType } from "@dust-tt/types";
+import type { DataSourceType } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
 import { dustManagedCredentials } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSources } from "@app/lib/api/data_sources";
 import { Authenticator, getSession } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -1,16 +1,14 @@
-import {
-  assertNever,
-  DataSourceType,
-  isConnectorProvider,
-} from "@dust-tt/types";
+import type { DataSourceType } from "@dust-tt/types";
+import type { ConnectorType } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import { assertNever, isConnectorProvider } from "@dust-tt/types";
 import { dustManagedCredentials } from "@dust-tt/types";
-import { ConnectorsAPI, ConnectorType } from "@dust-tt/types";
+import { ConnectorsAPI } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import {
   Authenticator,

--- a/front/pages/api/w/[wId]/index.ts
+++ b/front/pages/api/w/[wId]/index.ts
@@ -1,9 +1,9 @@
-import { WorkspaceType } from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { WorkspaceType } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { Authenticator, getSession } from "@app/lib/auth";
 import { Workspace } from "@app/lib/models";

--- a/front/pages/api/w/[wId]/invitations/[invitationId]/index.ts
+++ b/front/pages/api/w/[wId]/invitations/[invitationId]/index.ts
@@ -1,5 +1,5 @@
-import { MembershipInvitationType } from "@dust-tt/types";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { MembershipInvitationType } from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { Authenticator, getSession } from "@app/lib/auth";
 import { MembershipInvitation } from "@app/lib/models";

--- a/front/pages/api/w/[wId]/invitations/index.ts
+++ b/front/pages/api/w/[wId]/invitations/index.ts
@@ -1,7 +1,7 @@
-import { MembershipInvitationType } from "@dust-tt/types";
+import type { MembershipInvitationType } from "@dust-tt/types";
 import sgMail from "@sendgrid/mail";
 import { sign } from "jsonwebtoken";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getPendingInvitations } from "@app/lib/api/workspace";
 import { Authenticator, getSession } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/keys/[secret]/disable.ts
+++ b/front/pages/api/w/[wId]/keys/[secret]/disable.ts
@@ -1,5 +1,5 @@
-import { KeyType } from "@dust-tt/types";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { KeyType } from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { Authenticator, getSession } from "@app/lib/auth";
 import { Key } from "@app/lib/models";

--- a/front/pages/api/w/[wId]/keys/index.ts
+++ b/front/pages/api/w/[wId]/keys/index.ts
@@ -1,5 +1,6 @@
-import { formatUserFullName, KeyType } from "@dust-tt/types";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { KeyType } from "@dust-tt/types";
+import { formatUserFullName } from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { Authenticator, getSession } from "@app/lib/auth";
 import { Key, User } from "@app/lib/models";

--- a/front/pages/api/w/[wId]/members/[userId]/index.ts
+++ b/front/pages/api/w/[wId]/members/[userId]/index.ts
@@ -1,5 +1,5 @@
-import { UserType } from "@dust-tt/types";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { UserType } from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { Authenticator, getSession } from "@app/lib/auth";
 import { Membership, User } from "@app/lib/models";

--- a/front/pages/api/w/[wId]/members/index.ts
+++ b/front/pages/api/w/[wId]/members/index.ts
@@ -1,5 +1,5 @@
-import { UserType } from "@dust-tt/types";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { UserType } from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getMembers } from "@app/lib/api/workspace";
 import { Authenticator, getSession } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/members/me/agent_list_status.ts
+++ b/front/pages/api/w/[wId]/members/me/agent_list_status.ts
@@ -1,8 +1,8 @@
-import { AgentUserListStatus } from "@dust-tt/types";
+import type { AgentUserListStatus } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
 import { setAgentUserListstatus } from "@app/lib/api/assistant/user_relation";

--- a/front/pages/api/w/[wId]/monthly-usage.ts
+++ b/front/pages/api/w/[wId]/monthly-usage.ts
@@ -1,4 +1,4 @@
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 import { QueryTypes } from "sequelize";
 
 import { Authenticator, getSession } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/providers/[pId]/check.ts
+++ b/front/pages/api/w/[wId]/providers/[pId]/check.ts
@@ -1,5 +1,5 @@
 import { GoogleAuth } from "google-auth-library";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { Authenticator, getSession } from "@app/lib/auth";
 import { apiError, withLogging } from "@app/logger/withlogging";

--- a/front/pages/api/w/[wId]/providers/[pId]/index.ts
+++ b/front/pages/api/w/[wId]/providers/[pId]/index.ts
@@ -1,5 +1,5 @@
-import { ProviderType } from "@dust-tt/types";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { ProviderType } from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { Authenticator, getSession } from "@app/lib/auth";
 import { Provider } from "@app/lib/models";

--- a/front/pages/api/w/[wId]/providers/[pId]/models.ts
+++ b/front/pages/api/w/[wId]/providers/[pId]/models.ts
@@ -1,4 +1,4 @@
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { Authenticator, getSession } from "@app/lib/auth";
 import { Provider } from "@app/lib/models";

--- a/front/pages/api/w/[wId]/providers/index.ts
+++ b/front/pages/api/w/[wId]/providers/index.ts
@@ -1,5 +1,5 @@
-import { ProviderType } from "@dust-tt/types";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { ProviderType } from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { Authenticator, getSession } from "@app/lib/auth";
 import { Provider } from "@app/lib/models";

--- a/front/pages/api/w/[wId]/subscriptions/index.ts
+++ b/front/pages/api/w/[wId]/subscriptions/index.ts
@@ -1,6 +1,6 @@
-import { PlanType } from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { PlanType } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { Authenticator, getSession } from "@app/lib/auth";
 import {

--- a/front/pages/api/w/[wId]/use/extract/events/[sId]/index.ts
+++ b/front/pages/api/w/[wId]/use/extract/events/[sId]/index.ts
@@ -1,6 +1,6 @@
-import { ExtractedEventType } from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { ExtractedEventType } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getExtractedEvent, updateExtractedEvent } from "@app/lib/api/extract";
 import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/use/extract/templates/[sId]/events/index.ts
+++ b/front/pages/api/w/[wId]/use/extract/templates/[sId]/events/index.ts
@@ -1,6 +1,6 @@
-import { ExtractedEventType } from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { ExtractedEventType } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getExtractedEvents } from "@app/lib/api/extract";
 import { getEventSchema } from "@app/lib/api/extract";

--- a/front/pages/api/w/[wId]/use/extract/templates/[sId]/index.ts
+++ b/front/pages/api/w/[wId]/use/extract/templates/[sId]/index.ts
@@ -1,6 +1,6 @@
-import { EventSchemaType } from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { EventSchemaType } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getEventSchema, updateEventSchema } from "@app/lib/api/extract";
 import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/use/extract/templates/index.ts
+++ b/front/pages/api/w/[wId]/use/extract/templates/index.ts
@@ -1,6 +1,6 @@
-import { EventSchemaType } from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { EventSchemaType } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import { createEventSchema, getEventSchemas } from "@app/lib/api/extract";
 import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";

--- a/front/pages/index.tsx
+++ b/front/pages/index.tsx
@@ -16,13 +16,13 @@ import {
   OpenaiWhiteLogo,
   SlackLogo,
 } from "@dust-tt/sparkle";
-import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import Head from "next/head";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import Script from "next/script";
 import { signIn } from "next-auth/react";
-import { ParsedUrlQuery } from "querystring";
+import type { ParsedUrlQuery } from "querystring";
 import React, { useEffect, useRef, useState } from "react";
 import { useCookies } from "react-cookie";
 

--- a/front/pages/login-error.tsx
+++ b/front/pages/login-error.tsx
@@ -1,5 +1,5 @@
 import { Button, Logo } from "@dust-tt/sparkle";
-import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import Link from "next/link";
 
 const { URL = "", GA_TRACKING_ID = "" } = process.env;

--- a/front/pages/poke/[wId]/assistants/[aId]/index.tsx
+++ b/front/pages/poke/[wId]/assistants/[aId]/index.tsx
@@ -1,11 +1,11 @@
 import { Avatar, ContextItem, Page } from "@dust-tt/sparkle";
+import type { AgentConfigurationType } from "@dust-tt/types";
+import type { WorkspaceType } from "@dust-tt/types";
 import {
-  AgentConfigurationType,
   isDustAppRunConfiguration,
   isRetrievalConfiguration,
 } from "@dust-tt/types";
-import { WorkspaceType } from "@dust-tt/types";
-import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
 
 import PokeNavbar from "@app/components/poke/PokeNavbar";
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";

--- a/front/pages/poke/[wId]/data_sources/[name]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[name]/index.tsx
@@ -5,12 +5,13 @@ import {
   EyeIcon,
   Page,
 } from "@dust-tt/sparkle";
-import { CoreAPIDataSource, DataSourceType } from "@dust-tt/types";
-import { WorkspaceType } from "@dust-tt/types";
-import { ConnectorsAPI, ConnectorType } from "@dust-tt/types";
+import type { CoreAPIDataSource, DataSourceType } from "@dust-tt/types";
+import type { WorkspaceType } from "@dust-tt/types";
+import type { ConnectorType } from "@dust-tt/types";
+import { ConnectorsAPI } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
 import { JsonViewer } from "@textea/json-viewer";
-import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 

--- a/front/pages/poke/[wId]/data_sources/[name]/view.tsx
+++ b/front/pages/poke/[wId]/data_sources/[name]/view.tsx
@@ -1,7 +1,7 @@
 import { Input, Page } from "@dust-tt/sparkle";
-import { CoreAPIDocument } from "@dust-tt/types";
+import type { CoreAPIDocument } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
-import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
 
 import PokeNavbar from "@app/components/poke/PokeNavbar";
 import { getDataSource } from "@app/lib/api/data_sources";

--- a/front/pages/poke/[wId]/index.tsx
+++ b/front/pages/poke/[wId]/index.tsx
@@ -5,19 +5,25 @@ import {
   SliderToggle,
   Spinner,
 } from "@dust-tt/sparkle";
-import {
+import type {
   AgentConfigurationType,
   DataSourceType,
-  isDustAppRunConfiguration,
-  isRetrievalConfiguration,
   LightAgentConfigurationType,
   WorkspaceSegmentationType,
 } from "@dust-tt/types";
-import { UserType, WorkspaceType } from "@dust-tt/types";
-import { PlanInvitationType, PlanType, SubscriptionType } from "@dust-tt/types";
+import type { UserType, WorkspaceType } from "@dust-tt/types";
+import type {
+  PlanInvitationType,
+  PlanType,
+  SubscriptionType,
+} from "@dust-tt/types";
+import {
+  isDustAppRunConfiguration,
+  isRetrievalConfiguration,
+} from "@dust-tt/types";
 import { ConnectorsAPI } from "@dust-tt/types";
 import { JsonViewer } from "@textea/json-viewer";
-import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import React, { useContext } from "react";

--- a/front/pages/poke/[wId]/memberships.tsx
+++ b/front/pages/poke/[wId]/memberships.tsx
@@ -1,6 +1,6 @@
 import { Button } from "@dust-tt/sparkle";
-import { UserType, WorkspaceType } from "@dust-tt/types";
-import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import type { UserType, WorkspaceType } from "@dust-tt/types";
+import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 import React from "react";
 

--- a/front/pages/poke/index.tsx
+++ b/front/pages/poke/index.tsx
@@ -1,6 +1,7 @@
-import { UserType } from "@dust-tt/types";
-import { GetServerSideProps, InferGetServerSidePropsType } from "next";
-import React, { ChangeEvent, useState } from "react";
+import type { UserType } from "@dust-tt/types";
+import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import type { ChangeEvent } from "react";
+import React, { useState } from "react";
 
 import PokeNavbar from "@app/components/poke/PokeNavbar";
 import { Authenticator, getSession } from "@app/lib/auth";

--- a/front/pages/poke/plans.tsx
+++ b/front/pages/poke/plans.tsx
@@ -7,13 +7,13 @@ import {
   Spinner,
   XMarkIcon,
 } from "@dust-tt/sparkle";
-import { PlanType } from "@dust-tt/types";
-import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import type { PlanType } from "@dust-tt/types";
+import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import React from "react";
 import { useSWRConfig } from "swr";
 
+import type { EditingPlanType } from "@app/components/poke/plans/form";
 import {
-  EditingPlanType,
   Field,
   fromPlanType,
   PLAN_FIELDS,

--- a/front/pages/w/[wId]/a/[aId]/clone.tsx
+++ b/front/pages/w/[wId]/a/[aId]/clone.tsx
@@ -1,10 +1,10 @@
 import { Button, Tab } from "@dust-tt/sparkle";
-import { UserType, WorkspaceType } from "@dust-tt/types";
-import { AppType, AppVisibility } from "@dust-tt/types";
-import { SubscriptionType } from "@dust-tt/types";
-import { APIError } from "@dust-tt/types";
+import type { UserType, WorkspaceType } from "@dust-tt/types";
+import type { AppType, AppVisibility } from "@dust-tt/types";
+import type { SubscriptionType } from "@dust-tt/types";
+import type { APIError } from "@dust-tt/types";
 import { ChevronRightIcon } from "@heroicons/react/20/solid";
-import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";

--- a/front/pages/w/[wId]/a/[aId]/datasets/[name]/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/datasets/[name]/index.tsx
@@ -1,11 +1,11 @@
 import "@uiw/react-textarea-code-editor/dist.css";
 
 import { Button, Tab } from "@dust-tt/sparkle";
-import { UserType, WorkspaceType } from "@dust-tt/types";
-import { AppType } from "@dust-tt/types";
-import { DatasetSchema, DatasetType } from "@dust-tt/types";
-import { SubscriptionType } from "@dust-tt/types";
-import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import type { UserType, WorkspaceType } from "@dust-tt/types";
+import type { AppType } from "@dust-tt/types";
+import type { DatasetSchema, DatasetType } from "@dust-tt/types";
+import type { SubscriptionType } from "@dust-tt/types";
+import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 

--- a/front/pages/w/[wId]/a/[aId]/datasets/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/datasets/index.tsx
@@ -1,9 +1,9 @@
 import { Button, PlusIcon, Tab, TrashIcon } from "@dust-tt/sparkle";
-import { UserType, WorkspaceType } from "@dust-tt/types";
-import { AppType } from "@dust-tt/types";
-import { DatasetType } from "@dust-tt/types";
-import { SubscriptionType } from "@dust-tt/types";
-import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import type { UserType, WorkspaceType } from "@dust-tt/types";
+import type { AppType } from "@dust-tt/types";
+import type { DatasetType } from "@dust-tt/types";
+import type { SubscriptionType } from "@dust-tt/types";
+import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import Link from "next/link";
 import { useRouter } from "next/router";
 

--- a/front/pages/w/[wId]/a/[aId]/datasets/new.tsx
+++ b/front/pages/w/[wId]/a/[aId]/datasets/new.tsx
@@ -1,11 +1,11 @@
 import "@uiw/react-textarea-code-editor/dist.css";
 
 import { Button, Tab } from "@dust-tt/sparkle";
-import { UserType, WorkspaceType } from "@dust-tt/types";
-import { AppType } from "@dust-tt/types";
-import { DatasetSchema, DatasetType } from "@dust-tt/types";
-import { SubscriptionType } from "@dust-tt/types";
-import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import type { UserType, WorkspaceType } from "@dust-tt/types";
+import type { AppType } from "@dust-tt/types";
+import type { DatasetSchema, DatasetType } from "@dust-tt/types";
+import type { SubscriptionType } from "@dust-tt/types";
+import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 

--- a/front/pages/w/[wId]/a/[aId]/execute/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/execute/index.tsx
@@ -1,16 +1,20 @@
 import { Button, Tab } from "@dust-tt/sparkle";
-import { UserType, WorkspaceType } from "@dust-tt/types";
-import { AppType, BlockRunConfig, SpecificationType } from "@dust-tt/types";
-import { DatasetType } from "@dust-tt/types";
-import { SubscriptionType } from "@dust-tt/types";
-import { TraceType } from "@dust-tt/types";
+import type { UserType, WorkspaceType } from "@dust-tt/types";
+import type {
+  AppType,
+  BlockRunConfig,
+  SpecificationType,
+} from "@dust-tt/types";
+import type { DatasetType } from "@dust-tt/types";
+import type { SubscriptionType } from "@dust-tt/types";
+import type { TraceType } from "@dust-tt/types";
 import {
   ChevronDownIcon,
   ChevronRightIcon,
   ExclamationCircleIcon,
   PlayCircleIcon,
 } from "@heroicons/react/20/solid";
-import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import dynamic from "next/dynamic";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";

--- a/front/pages/w/[wId]/a/[aId]/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/index.tsx
@@ -6,18 +6,18 @@ import {
   SparklesIcon,
   Tab,
 } from "@dust-tt/sparkle";
-import { UserType, WorkspaceType } from "@dust-tt/types";
-import {
+import type { UserType, WorkspaceType } from "@dust-tt/types";
+import type {
   AppType,
   BlockRunConfig,
   SpecificationBlockType,
   SpecificationType,
 } from "@dust-tt/types";
-import { SubscriptionType } from "@dust-tt/types";
-import { BlockType } from "@dust-tt/types";
-import { CoreAPIErrorResponse } from "@dust-tt/types";
-import { ReturnedAPIErrorType } from "@dust-tt/types";
-import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import type { SubscriptionType } from "@dust-tt/types";
+import type { BlockType } from "@dust-tt/types";
+import type { CoreAPIErrorResponse } from "@dust-tt/types";
+import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 import { useRef, useState } from "react";
 import { useSWRConfig } from "swr";

--- a/front/pages/w/[wId]/a/[aId]/runs/[runId]/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/runs/[runId]/index.tsx
@@ -1,9 +1,9 @@
 import { Button, CheckCircleIcon, ClockIcon, Tab } from "@dust-tt/sparkle";
-import { UserType, WorkspaceType } from "@dust-tt/types";
-import { AppType, SpecificationType } from "@dust-tt/types";
-import { SubscriptionType } from "@dust-tt/types";
-import { RunType } from "@dust-tt/types";
-import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import type { UserType, WorkspaceType } from "@dust-tt/types";
+import type { AppType, SpecificationType } from "@dust-tt/types";
+import type { SubscriptionType } from "@dust-tt/types";
+import type { RunType } from "@dust-tt/types";
+import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 import { useState } from "react";
 

--- a/front/pages/w/[wId]/a/[aId]/runs/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/runs/index.tsx
@@ -1,9 +1,9 @@
 import { Button, Tab } from "@dust-tt/sparkle";
-import { UserType, WorkspaceType } from "@dust-tt/types";
-import { AppType } from "@dust-tt/types";
-import { SubscriptionType } from "@dust-tt/types";
-import { RunRunType, RunStatus } from "@dust-tt/types";
-import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import type { UserType, WorkspaceType } from "@dust-tt/types";
+import type { AppType } from "@dust-tt/types";
+import type { SubscriptionType } from "@dust-tt/types";
+import type { RunRunType, RunStatus } from "@dust-tt/types";
+import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";

--- a/front/pages/w/[wId]/a/[aId]/settings.tsx
+++ b/front/pages/w/[wId]/a/[aId]/settings.tsx
@@ -1,10 +1,10 @@
 import { Button, Tab } from "@dust-tt/sparkle";
-import { UserType, WorkspaceType } from "@dust-tt/types";
-import { AppType, AppVisibility } from "@dust-tt/types";
-import { SubscriptionType } from "@dust-tt/types";
-import { APIError } from "@dust-tt/types";
+import type { UserType, WorkspaceType } from "@dust-tt/types";
+import type { AppType, AppVisibility } from "@dust-tt/types";
+import type { SubscriptionType } from "@dust-tt/types";
+import type { APIError } from "@dust-tt/types";
 import { ChevronRightIcon } from "@heroicons/react/24/outline";
-import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 import { useState } from "react";
 import { useEffect } from "react";

--- a/front/pages/w/[wId]/a/[aId]/specification.tsx
+++ b/front/pages/w/[wId]/a/[aId]/specification.tsx
@@ -1,9 +1,9 @@
 import { Tab } from "@dust-tt/sparkle";
-import { UserType, WorkspaceType } from "@dust-tt/types";
-import { AppType } from "@dust-tt/types";
-import { SubscriptionType } from "@dust-tt/types";
+import type { UserType, WorkspaceType } from "@dust-tt/types";
+import type { AppType } from "@dust-tt/types";
+import type { SubscriptionType } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
-import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 
 import AppLayout from "@app/components/sparkle/AppLayout";

--- a/front/pages/w/[wId]/a/index.tsx
+++ b/front/pages/w/[wId]/a/index.tsx
@@ -1,10 +1,10 @@
 import { Button, CommandLineIcon, Page, PlusIcon } from "@dust-tt/sparkle";
-import { KeyType } from "@dust-tt/types";
-import { UserType, WorkspaceType } from "@dust-tt/types";
-import { AppType } from "@dust-tt/types";
-import { SubscriptionType } from "@dust-tt/types";
+import type { KeyType } from "@dust-tt/types";
+import type { UserType, WorkspaceType } from "@dust-tt/types";
+import type { AppType } from "@dust-tt/types";
+import type { SubscriptionType } from "@dust-tt/types";
 import { EyeIcon, EyeSlashIcon } from "@heroicons/react/24/outline";
-import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { useState } from "react";

--- a/front/pages/w/[wId]/a/new.tsx
+++ b/front/pages/w/[wId]/a/new.tsx
@@ -1,10 +1,10 @@
 import { Button, Page } from "@dust-tt/sparkle";
-import { UserType, WorkspaceType } from "@dust-tt/types";
-import { AppType } from "@dust-tt/types";
-import { SubscriptionType } from "@dust-tt/types";
-import { APIError } from "@dust-tt/types";
+import type { UserType, WorkspaceType } from "@dust-tt/types";
+import type { AppType } from "@dust-tt/types";
+import type { SubscriptionType } from "@dust-tt/types";
+import type { APIError } from "@dust-tt/types";
 import { ChevronRightIcon } from "@heroicons/react/20/solid";
-import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 import React, { useCallback, useEffect, useState } from "react";
 

--- a/front/pages/w/[wId]/assistant/[cId]/index.tsx
+++ b/front/pages/w/[wId]/assistant/[cId]/index.tsx
@@ -1,7 +1,7 @@
-import { UserType, WorkspaceType } from "@dust-tt/types";
-import { AgentMention, MentionType } from "@dust-tt/types";
-import { SubscriptionType } from "@dust-tt/types";
-import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import type { UserType, WorkspaceType } from "@dust-tt/types";
+import type { AgentMention, MentionType } from "@dust-tt/types";
+import type { SubscriptionType } from "@dust-tt/types";
+import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 import { useContext, useEffect, useState } from "react";
 

--- a/front/pages/w/[wId]/assistant/assistants.tsx
+++ b/front/pages/w/[wId]/assistant/assistants.tsx
@@ -18,14 +18,14 @@ import {
   UserIcon,
   XMarkIcon,
 } from "@dust-tt/sparkle";
-import {
+import type {
   AgentUserListStatus,
   LightAgentConfigurationType,
   UserType,
   WorkspaceType,
 } from "@dust-tt/types";
-import { SubscriptionType } from "@dust-tt/types";
-import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import type { SubscriptionType } from "@dust-tt/types";
+import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import Link from "next/link";
 import { useContext, useState } from "react";
 
@@ -45,7 +45,7 @@ import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
 import { useAgentConfigurations } from "@app/lib/swr";
 import { subFilter } from "@app/lib/utils";
-import { PostAgentListStatusRequestBody } from "@app/pages/api/w/[wId]/members/me/agent_list_status";
+import type { PostAgentListStatusRequestBody } from "@app/pages/api/w/[wId]/members/me/agent_list_status";
 
 const { GA_TRACKING_ID = "" } = process.env;
 

--- a/front/pages/w/[wId]/assistant/gallery.tsx
+++ b/front/pages/w/[wId]/assistant/gallery.tsx
@@ -1,14 +1,14 @@
 import { Button, DropdownMenu, Page, Searchbar, Tab } from "@dust-tt/sparkle";
-import {
+import type {
   AgentsGetViewType,
-  assertNever,
   LightAgentConfigurationType,
   PlanType,
   SubscriptionType,
   UserType,
   WorkspaceType,
 } from "@dust-tt/types";
-import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import { assertNever } from "@dust-tt/types";
+import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 import { useState } from "react";
 

--- a/front/pages/w/[wId]/assistant/new.tsx
+++ b/front/pages/w/[wId]/assistant/new.tsx
@@ -9,7 +9,7 @@ import {
   Page,
   Popup,
 } from "@dust-tt/sparkle";
-import {
+import type {
   AgentMention,
   ContentFragmentContentType,
   ConversationType,
@@ -19,7 +19,7 @@ import {
   UserType,
   WorkspaceType,
 } from "@dust-tt/types";
-import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { useContext, useEffect, useState } from "react";

--- a/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
@@ -1,21 +1,23 @@
-import {
+import type {
   AgentConfigurationType,
   DataSourceType,
   UserType,
   WorkspaceType,
 } from "@dust-tt/types";
+import type { AppType } from "@dust-tt/types";
+import type { PlanType, SubscriptionType } from "@dust-tt/types";
 import { isDatabaseQueryConfiguration } from "@dust-tt/types";
 import { isDustAppRunConfiguration } from "@dust-tt/types";
 import { isRetrievalConfiguration } from "@dust-tt/types";
-import { AppType } from "@dust-tt/types";
-import { PlanType, SubscriptionType } from "@dust-tt/types";
 import { ConnectorsAPI } from "@dust-tt/types";
-import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
 
-import AssistantBuilder, {
+import type {
   AssistantBuilderInitialState,
-  BUILDER_FLOWS,
   BuilderFlow,
+} from "@app/components/assistant_builder/AssistantBuilder";
+import AssistantBuilder, {
+  BUILDER_FLOWS,
 } from "@app/components/assistant_builder/AssistantBuilder";
 import { getApps } from "@app/lib/api/app";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";

--- a/front/pages/w/[wId]/builder/assistants/dust.tsx
+++ b/front/pages/w/[wId]/builder/assistants/dust.tsx
@@ -7,7 +7,7 @@ import {
   PlusIcon,
   SliderToggle,
 } from "@dust-tt/sparkle";
-import {
+import type {
   APIError,
   DataSourceType,
   LightAgentConfigurationType,
@@ -15,7 +15,7 @@ import {
   UserType,
   WorkspaceType,
 } from "@dust-tt/types";
-import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 import { useContext } from "react";
 

--- a/front/pages/w/[wId]/builder/assistants/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/index.tsx
@@ -15,13 +15,13 @@ import {
   TrashIcon,
   XMarkIcon,
 } from "@dust-tt/sparkle";
-import {
+import type {
   LightAgentConfigurationType,
   UserType,
   WorkspaceType,
 } from "@dust-tt/types";
-import { SubscriptionType } from "@dust-tt/types";
-import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import type { SubscriptionType } from "@dust-tt/types";
+import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { useState } from "react";

--- a/front/pages/w/[wId]/builder/assistants/new.tsx
+++ b/front/pages/w/[wId]/builder/assistants/new.tsx
@@ -1,21 +1,25 @@
-import {
+import type {
   AgentConfigurationType,
   AppType,
   DataSourceType,
-  isDatabaseQueryConfiguration,
-  isDustAppRunConfiguration,
-  isRetrievalConfiguration,
   PlanType,
   SubscriptionType,
   UserType,
   WorkspaceType,
 } from "@dust-tt/types";
-import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import {
+  isDatabaseQueryConfiguration,
+  isDustAppRunConfiguration,
+  isRetrievalConfiguration,
+} from "@dust-tt/types";
+import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
 
-import AssistantBuilder, {
+import type {
   AssistantBuilderInitialState,
-  BUILDER_FLOWS,
   BuilderFlow,
+} from "@app/components/assistant_builder/AssistantBuilder";
+import AssistantBuilder, {
+  BUILDER_FLOWS,
 } from "@app/components/assistant_builder/AssistantBuilder";
 import { getApps } from "@app/lib/api/app";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";

--- a/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
@@ -13,22 +13,19 @@ import {
   SlackLogo,
   SliderToggle,
 } from "@dust-tt/sparkle";
-import {
-  assertNever,
+import type {
   ConnectorProvider,
   DataSourceType,
   UserType,
   WorkspaceType,
 } from "@dust-tt/types";
-import { PlanType, SubscriptionType } from "@dust-tt/types";
-import {
-  connectorIsUsingNango,
-  ConnectorsAPI,
-  ConnectorType,
-} from "@dust-tt/types";
-import { APIError } from "@dust-tt/types";
+import type { PlanType, SubscriptionType } from "@dust-tt/types";
+import type { ConnectorType } from "@dust-tt/types";
+import type { APIError } from "@dust-tt/types";
+import { assertNever } from "@dust-tt/types";
+import { connectorIsUsingNango, ConnectorsAPI } from "@dust-tt/types";
 import Nango from "@nangohq/frontend";
-import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 import { useContext, useEffect, useState } from "react";
 

--- a/front/pages/w/[wId]/builder/data-sources/[name]/search.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/search.tsx
@@ -1,7 +1,7 @@
-import { DataSourceType, UserType, WorkspaceType } from "@dust-tt/types";
-import { DocumentType } from "@dust-tt/types";
-import { SubscriptionType } from "@dust-tt/types";
-import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import type { DataSourceType, UserType, WorkspaceType } from "@dust-tt/types";
+import type { DocumentType } from "@dust-tt/types";
+import type { SubscriptionType } from "@dust-tt/types";
+import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";

--- a/front/pages/w/[wId]/builder/data-sources/[name]/settings.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/settings.tsx
@@ -1,14 +1,14 @@
 import { Button, DropdownMenu, TrashIcon } from "@dust-tt/sparkle";
-import {
+import type {
   DataSourceType,
   DataSourceVisibility,
   UserType,
   WorkspaceType,
 } from "@dust-tt/types";
-import { SubscriptionType } from "@dust-tt/types";
-import { APIError } from "@dust-tt/types";
+import type { SubscriptionType } from "@dust-tt/types";
+import type { APIError } from "@dust-tt/types";
 import { ChevronRightIcon } from "@heroicons/react/20/solid";
-import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 import { useCallback, useEffect, useState } from "react";
 import { useSWRConfig } from "swr";

--- a/front/pages/w/[wId]/builder/data-sources/[name]/upsert.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/upsert.tsx
@@ -1,4 +1,4 @@
-import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 // @ts-expect-error: type package doesn't load properly because of how we are loading pdfjs
 import * as PDFJS from "pdfjs-dist/build/pdf";
@@ -15,13 +15,13 @@ import {
   PlusIcon,
   TrashIcon,
 } from "@dust-tt/sparkle";
-import {
+import type {
   DataSourceType,
   PostDataSourceDocumentRequestBody,
   UserType,
   WorkspaceType,
 } from "@dust-tt/types";
-import { PlanType, SubscriptionType } from "@dust-tt/types";
+import type { PlanType, SubscriptionType } from "@dust-tt/types";
 
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleSaveCancelTitle } from "@app/components/sparkle/AppLayoutTitle";

--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -10,20 +10,17 @@ import {
   Page,
   Popup,
 } from "@dust-tt/sparkle";
-import {
+import type {
   ConnectorProvider,
   DataSourceType,
   UserType,
   WorkspaceType,
 } from "@dust-tt/types";
-import { PlanType, SubscriptionType } from "@dust-tt/types";
-import {
-  connectorIsUsingNango,
-  ConnectorsAPI,
-  ConnectorType,
-} from "@dust-tt/types";
+import type { PlanType, SubscriptionType } from "@dust-tt/types";
+import type { ConnectorType } from "@dust-tt/types";
+import { connectorIsUsingNango, ConnectorsAPI } from "@dust-tt/types";
 import Nango from "@nangohq/frontend";
-import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { useContext, useEffect, useState } from "react";

--- a/front/pages/w/[wId]/builder/data-sources/new-public-url.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/new-public-url.tsx
@@ -1,8 +1,8 @@
 import { Checkbox, Page } from "@dust-tt/sparkle";
-import { DataSourceType, UserType, WorkspaceType } from "@dust-tt/types";
-import { SubscriptionType } from "@dust-tt/types";
-import { APIError } from "@dust-tt/types";
-import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import type { DataSourceType, UserType, WorkspaceType } from "@dust-tt/types";
+import type { SubscriptionType } from "@dust-tt/types";
+import type { APIError } from "@dust-tt/types";
+import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 import { useCallback, useEffect, useState } from "react";
 

--- a/front/pages/w/[wId]/builder/data-sources/new.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/new.tsx
@@ -1,9 +1,9 @@
 import { Checkbox, Page } from "@dust-tt/sparkle";
-import { DataSourceType, UserType, WorkspaceType } from "@dust-tt/types";
-import { SubscriptionType } from "@dust-tt/types";
-import { APIError } from "@dust-tt/types";
+import type { DataSourceType, UserType, WorkspaceType } from "@dust-tt/types";
+import type { SubscriptionType } from "@dust-tt/types";
+import type { APIError } from "@dust-tt/types";
 import { ChevronRightIcon } from "@heroicons/react/20/solid";
-import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 import { useCallback, useEffect, useState } from "react";
 

--- a/front/pages/w/[wId]/builder/data-sources/public-urls.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/public-urls.tsx
@@ -8,9 +8,9 @@ import {
   PlusIcon,
   Popup,
 } from "@dust-tt/sparkle";
-import { DataSourceType, UserType, WorkspaceType } from "@dust-tt/types";
-import { PlanType, SubscriptionType } from "@dust-tt/types";
-import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import type { DataSourceType, UserType, WorkspaceType } from "@dust-tt/types";
+import type { PlanType, SubscriptionType } from "@dust-tt/types";
+import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 import { useState } from "react";
 

--- a/front/pages/w/[wId]/builder/data-sources/static.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/static.tsx
@@ -8,9 +8,9 @@ import {
   PlusIcon,
   Popup,
 } from "@dust-tt/sparkle";
-import { DataSourceType, UserType, WorkspaceType } from "@dust-tt/types";
-import { PlanType, SubscriptionType } from "@dust-tt/types";
-import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import type { DataSourceType, UserType, WorkspaceType } from "@dust-tt/types";
+import type { PlanType, SubscriptionType } from "@dust-tt/types";
+import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 import { useState } from "react";
 

--- a/front/pages/w/[wId]/index.tsx
+++ b/front/pages/w/[wId]/index.tsx
@@ -1,4 +1,4 @@
-import { GetServerSideProps } from "next";
+import type { GetServerSideProps } from "next";
 
 import { Authenticator, getSession, getUserFromSession } from "@app/lib/auth";
 

--- a/front/pages/w/[wId]/join.tsx
+++ b/front/pages/w/[wId]/join.tsx
@@ -1,6 +1,6 @@
 import { GoogleLogo, Logo } from "@dust-tt/sparkle";
-import { WorkspaceType } from "@dust-tt/types";
-import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import type { WorkspaceType } from "@dust-tt/types";
+import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import { signIn } from "next-auth/react";
 
 import { SignInButton } from "@app/components/Button";

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -15,11 +15,11 @@ import {
   Popup,
   Searchbar,
 } from "@dust-tt/sparkle";
-import { RoleType, UserType, WorkspaceType } from "@dust-tt/types";
-import { MembershipInvitationType } from "@dust-tt/types";
-import { PlanType, SubscriptionType } from "@dust-tt/types";
+import type { RoleType, UserType, WorkspaceType } from "@dust-tt/types";
+import type { MembershipInvitationType } from "@dust-tt/types";
+import type { PlanType, SubscriptionType } from "@dust-tt/types";
 import { UsersIcon } from "@heroicons/react/20/solid";
-import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 import { useContext, useState } from "react";
 import { useSWRConfig } from "swr";

--- a/front/pages/w/[wId]/subscription/index.tsx
+++ b/front/pages/w/[wId]/subscription/index.tsx
@@ -7,9 +7,9 @@ import {
   ShapesIcon,
   Spinner,
 } from "@dust-tt/sparkle";
-import { UserType, WorkspaceType } from "@dust-tt/types";
-import { PlanInvitationType, SubscriptionType } from "@dust-tt/types";
-import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import type { UserType, WorkspaceType } from "@dust-tt/types";
+import type { PlanInvitationType, SubscriptionType } from "@dust-tt/types";
+import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import React, { useContext, useEffect } from "react";

--- a/front/pages/w/[wId]/subscription/upgrade-enterprise/[secret].tsx
+++ b/front/pages/w/[wId]/subscription/upgrade-enterprise/[secret].tsx
@@ -1,4 +1,4 @@
-import { GetServerSideProps } from "next";
+import type { GetServerSideProps } from "next";
 
 import { Authenticator, getSession } from "@app/lib/auth";
 import { Workspace } from "@app/lib/models";

--- a/front/pages/w/[wId]/tables/index.tsx
+++ b/front/pages/w/[wId]/tables/index.tsx
@@ -9,15 +9,15 @@ import {
   Modal,
   Page,
 } from "@dust-tt/sparkle";
-import {
+import type {
   CoreAPITable,
   DataSourceType,
   UserType,
   WorkspaceType,
 } from "@dust-tt/types";
-import { SubscriptionType } from "@dust-tt/types";
+import type { SubscriptionType } from "@dust-tt/types";
 import { PlusIcon } from "@heroicons/react/24/outline";
-import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import React, { useContext, useRef } from "react";
 import { useSWRConfig } from "swr";
 

--- a/front/pages/w/[wId]/u/extract/events/[sId]/edit.tsx
+++ b/front/pages/w/[wId]/u/extract/events/[sId]/edit.tsx
@@ -1,9 +1,9 @@
 import { ArrowUpOnSquareIcon, Button, Page } from "@dust-tt/sparkle";
-import { UserType, WorkspaceType } from "@dust-tt/types";
-import { EventSchemaType, ExtractedEventType } from "@dust-tt/types";
-import { SubscriptionType } from "@dust-tt/types";
-import { APIError } from "@dust-tt/types";
-import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import type { UserType, WorkspaceType } from "@dust-tt/types";
+import type { EventSchemaType, ExtractedEventType } from "@dust-tt/types";
+import type { SubscriptionType } from "@dust-tt/types";
+import type { APIError } from "@dust-tt/types";
+import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 import React, { useEffect, useRef, useState } from "react";
 

--- a/front/pages/w/[wId]/u/extract/index.tsx
+++ b/front/pages/w/[wId]/u/extract/index.tsx
@@ -1,8 +1,8 @@
 import { ArrowUpOnSquareIcon, Button, Page } from "@dust-tt/sparkle";
-import { UserType, WorkspaceType } from "@dust-tt/types";
-import { SubscriptionType } from "@dust-tt/types";
+import type { UserType, WorkspaceType } from "@dust-tt/types";
+import type { SubscriptionType } from "@dust-tt/types";
 import { PlusIcon } from "@heroicons/react/24/outline";
-import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import Link from "next/link";
 import { useRouter } from "next/router";
 

--- a/front/pages/w/[wId]/u/extract/templates/[sId]/edit.tsx
+++ b/front/pages/w/[wId]/u/extract/templates/[sId]/edit.tsx
@@ -1,7 +1,7 @@
-import { UserType, WorkspaceType } from "@dust-tt/types";
-import { EventSchemaType } from "@dust-tt/types";
-import { SubscriptionType } from "@dust-tt/types";
-import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import type { UserType, WorkspaceType } from "@dust-tt/types";
+import type { EventSchemaType } from "@dust-tt/types";
+import type { SubscriptionType } from "@dust-tt/types";
+import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
 
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { subNavigationAdmin } from "@app/components/sparkle/navigation";

--- a/front/pages/w/[wId]/u/extract/templates/[sId]/index.tsx
+++ b/front/pages/w/[wId]/u/extract/templates/[sId]/index.tsx
@@ -9,12 +9,12 @@ import {
   PencilSquareIcon,
   XCircleIcon,
 } from "@dust-tt/sparkle";
-import { UserType, WorkspaceType } from "@dust-tt/types";
-import { EventSchemaType, ExtractedEventType } from "@dust-tt/types";
-import { SubscriptionType } from "@dust-tt/types";
-import { APIError } from "@dust-tt/types";
+import type { UserType, WorkspaceType } from "@dust-tt/types";
+import type { EventSchemaType, ExtractedEventType } from "@dust-tt/types";
+import type { SubscriptionType } from "@dust-tt/types";
+import type { APIError } from "@dust-tt/types";
 import { Dialog, Transition } from "@headlessui/react";
-import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { Fragment, useState } from "react";

--- a/front/pages/w/[wId]/u/extract/templates/new.tsx
+++ b/front/pages/w/[wId]/u/extract/templates/new.tsx
@@ -1,6 +1,6 @@
-import { UserType, WorkspaceType } from "@dust-tt/types";
-import { SubscriptionType } from "@dust-tt/types";
-import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import type { UserType, WorkspaceType } from "@dust-tt/types";
+import type { SubscriptionType } from "@dust-tt/types";
+import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
 
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { subNavigationAdmin } from "@app/components/sparkle/navigation";

--- a/front/pages/w/[wId]/u/index.tsx
+++ b/front/pages/w/[wId]/u/index.tsx
@@ -1,4 +1,4 @@
-import { GetServerSideProps } from "next";
+import type { GetServerSideProps } from "next";
 
 import { getSession, getUserFromSession } from "@app/lib/auth";
 

--- a/front/pages/w/[wId]/welcome.tsx
+++ b/front/pages/w/[wId]/welcome.tsx
@@ -1,6 +1,6 @@
 import { Button, Input, RadioButton } from "@dust-tt/sparkle";
-import { UserType, WorkspaceType } from "@dust-tt/types";
-import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import type { UserType, WorkspaceType } from "@dust-tt/types";
+import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 

--- a/front/pages/w/[wId]/workspace/index.tsx
+++ b/front/pages/w/[wId]/workspace/index.tsx
@@ -6,9 +6,9 @@ import {
   Page,
   PlanetIcon,
 } from "@dust-tt/sparkle";
-import { UserType, WorkspaceType } from "@dust-tt/types";
-import { SubscriptionType } from "@dust-tt/types";
-import { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import type { UserType, WorkspaceType } from "@dust-tt/types";
+import type { SubscriptionType } from "@dust-tt/types";
+import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import { useCallback, useEffect, useState } from "react";
 
 import AppLayout from "@app/components/sparkle/AppLayout";


### PR DESCRIPTION
The recent incidents where we've imported types from Sequelize into files subsequently used in the front end have caused Dust to fail to load. One way to mitigate this is by utilizing import type, which ensures type imports are stripped out at runtime. This PR introduces a [rule](https://typescript-eslint.io/rules/consistent-type-imports/) enforcing this practice and corrects all the associated errors until we find a more robust linter rule.