### PR TITLE
auth: isUser/Builder/Admin refactor

### DIFF
--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -23,6 +23,7 @@ import type {
   WorkspaceType,
 } from "@dust-tt/types";
 import {
+  isBuilder,
   isDustAppRunConfiguration,
   isRetrievalConfiguration,
   isTablesQueryConfiguration,
@@ -265,8 +266,7 @@ function ButtonsSection({
   const [showDeletionModal, setShowDeletionModal] = useState<boolean>(false);
 
   const canDelete =
-    (agentConfiguration.scope === "workspace" &&
-      ["builder", "admin"].includes(owner.role)) ||
+    (agentConfiguration.scope === "workspace" && isBuilder(owner)) ||
     ["published", "private"].includes(agentConfiguration.scope);
 
   const canAddRemoveList =
@@ -381,7 +381,7 @@ function ButtonsSection({
             icon={TrashIcon}
             variant="secondaryWarning"
             size="xs"
-            disabled={!["builder", "admin"].includes(owner.role)}
+            disabled={!isBuilder(owner)}
             onClick={() => setShowDeletionModal(true)}
             hasMagnifying={false}
           />

--- a/front/components/assistant/AssistantPicker.tsx
+++ b/front/components/assistant/AssistantPicker.tsx
@@ -7,9 +7,10 @@ import {
   Searchbar,
   WrenchIcon,
 } from "@dust-tt/sparkle";
-import type {
-  LightAgentConfigurationType,
-  WorkspaceType,
+import {
+  isBuilder,
+  type LightAgentConfigurationType,
+  type WorkspaceType,
 } from "@dust-tt/types";
 import Link from "next/link";
 import { useEffect, useState } from "react";
@@ -85,27 +86,26 @@ export function AssistantPicker({
             />
           ))}
         </div>
-        {(owner.role === "admin" || owner.role === "builder") &&
-          showBuilderButtons && (
-            <div className="flex flex-row justify-between border-t border-structure-100 px-3 pb-1 pt-2">
-              <Link href={`/w/${owner.sId}/builder/assistants/new`}>
-                <Button
-                  label="Create"
-                  size="xs"
-                  variant="secondary"
-                  icon={PlusIcon}
-                />
-              </Link>
-              <Link href={`/w/${owner.sId}/builder/assistants`}>
-                <Button
-                  label="Manage"
-                  size="xs"
-                  variant="tertiary"
-                  icon={WrenchIcon}
-                />
-              </Link>
-            </div>
-          )}
+        {isBuilder(owner) && showBuilderButtons && (
+          <div className="flex flex-row justify-between border-t border-structure-100 px-3 pb-1 pt-2">
+            <Link href={`/w/${owner.sId}/builder/assistants/new`}>
+              <Button
+                label="Create"
+                size="xs"
+                variant="secondary"
+                icon={PlusIcon}
+              />
+            </Link>
+            <Link href={`/w/${owner.sId}/builder/assistants`}>
+              <Button
+                label="Manage"
+                size="xs"
+                variant="tertiary"
+                icon={WrenchIcon}
+              />
+            </Link>
+          </div>
+        )}
       </DropdownMenu.Items>
     </DropdownMenu>
   );

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -1,5 +1,5 @@
 import { Button, ChatBubbleBottomCenterPlusIcon, Item } from "@dust-tt/sparkle";
-import type { WorkspaceType } from "@dust-tt/types";
+import { isOnlyUser, type WorkspaceType } from "@dust-tt/types";
 import type { ConversationWithoutContentType } from "@dust-tt/types";
 import moment from "moment";
 import Link from "next/link";
@@ -70,7 +70,7 @@ export function AssistantSidebarMenu({
     <div
       className={classNames(
         "flex grow flex-col",
-        owner.role === "user" ? "border-t border-structure-200" : ""
+        isOnlyUser(owner) ? "border-t border-structure-200" : ""
       )}
     >
       <div className="flex h-0 min-h-full w-full overflow-y-auto">

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -1,6 +1,6 @@
 import { Button, ChatBubbleBottomCenterPlusIcon, Item } from "@dust-tt/sparkle";
-import { isOnlyUser, type WorkspaceType } from "@dust-tt/types";
 import type { ConversationWithoutContentType } from "@dust-tt/types";
+import { isOnlyUser, type WorkspaceType } from "@dust-tt/types";
 import moment from "moment";
 import Link from "next/link";
 import { useRouter } from "next/router";

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -26,7 +26,7 @@ import type { TimeframeUnit } from "@dust-tt/types";
 import type { AppType } from "@dust-tt/types";
 import type { PlanType, SubscriptionType } from "@dust-tt/types";
 import type { PostOrPatchAgentConfigurationRequestBodySchema } from "@dust-tt/types";
-import { GEMINI_PRO_DEFAULT_MODEL_CONFIG } from "@dust-tt/types";
+import { GEMINI_PRO_DEFAULT_MODEL_CONFIG, isBuilder } from "@dust-tt/types";
 import {
   CLAUDE_DEFAULT_MODEL_CONFIG,
   CLAUDE_INSTANT_DEFAULT_MODEL_CONFIG,
@@ -356,6 +356,7 @@ export default function AssistantBuilder({
       channelName: string;
     }[]
   >([]);
+
   // Retrieve all the slack channels that are linked with an agent.
   const { slackChannels: slackChannelsLinkedWithAgent } =
     useSlackChannelsLinkedWithAgent({
@@ -1285,7 +1286,7 @@ export default function AssistantBuilder({
           <div className="flex flex-row items-start">
             <div className="flex flex-col gap-4">
               {slackDataSource &&
-                ["builder", "admin"].includes(owner.role) &&
+                isBuilder(owner) &&
                 builderState.scope !== "private" &&
                 initialBuilderState?.scope !== "private" && (
                   <SlackIntegration

--- a/front/components/assistant_builder/TeamSharingSection.tsx
+++ b/front/components/assistant_builder/TeamSharingSection.tsx
@@ -5,7 +5,11 @@ import {
   Dialog,
   Icon,
 } from "@dust-tt/sparkle";
-import type { AgentConfigurationScope, WorkspaceType } from "@dust-tt/types";
+import {
+  isBuilder,
+  type AgentConfigurationScope,
+  type WorkspaceType,
+} from "@dust-tt/types";
 import { useRouter } from "next/router";
 import { useState } from "react";
 
@@ -146,7 +150,7 @@ export function TeamSharingSection({
             <span className="font-bold">modify and delete</span> the assistant.
             It is included by default in every member's list.
           </div>
-          {(owner.role === "admin" || owner.role === "builder") && (
+          {isBuilder(owner) && (
             <Button
               variant="tertiary"
               size="sm"

--- a/front/components/assistant_builder/TeamSharingSection.tsx
+++ b/front/components/assistant_builder/TeamSharingSection.tsx
@@ -6,8 +6,8 @@ import {
   Icon,
 } from "@dust-tt/sparkle";
 import {
-  isBuilder,
   type AgentConfigurationScope,
+  isBuilder,
   type WorkspaceType,
 } from "@dust-tt/types";
 import { useRouter } from "next/router";

--- a/front/components/sparkle/navigation.tsx
+++ b/front/components/sparkle/navigation.tsx
@@ -14,8 +14,14 @@ import {
   ShapesIcon,
 } from "@dust-tt/sparkle";
 import { GlobeAltIcon } from "@dust-tt/sparkle";
-import type { WorkspaceType } from "@dust-tt/types";
 import type { AppType } from "@dust-tt/types";
+import {
+  isAdmin,
+  isBuilder,
+  isOnlyUser,
+  isUser,
+  type WorkspaceType,
+} from "@dust-tt/types";
 import { UsersIcon } from "@heroicons/react/20/solid";
 
 import {
@@ -97,7 +103,7 @@ export const topNavigation = ({
     current: current === "conversations",
   });
 
-  if (owner.role === "admin" || owner.role === "builder") {
+  if (isBuilder(owner)) {
     nav.push({
       id: "assistants",
       label: "Assistants",
@@ -112,10 +118,7 @@ export const topNavigation = ({
       label: "Admin",
       hideLabel: true,
       icon: Cog6ToothIcon,
-      href:
-        owner.role === "admin"
-          ? `/w/${owner.sId}/members`
-          : `/w/${owner.sId}/a`,
+      href: isAdmin(owner) ? `/w/${owner.sId}/members` : `/w/${owner.sId}/a`,
       current: current === "admin",
       sizing: "hug",
     });
@@ -139,7 +142,7 @@ export const subNavigationConversations = ({
 
   // To be added for personal assistants view.
 
-  if (owner.role === "user") {
+  if (isOnlyUser(owner)) {
     nav.push({
       id: "assistants",
       label: null,
@@ -177,7 +180,7 @@ export const subNavigationAssistants = ({
 
   const assistantMenus: SparkleAppLayoutNavigation[] = [];
 
-  if (owner.role === "builder" || owner.role === "admin") {
+  if (isBuilder(owner)) {
     assistantMenus.push({
       id: "personal_assistants",
       label: "My Assistants",
@@ -263,11 +266,11 @@ export const subNavigationAdmin = ({
 }) => {
   const nav: SidebarNavigation[] = [];
 
-  if (owner.role !== "admin" && owner.role !== "builder") {
+  if (!isBuilder(owner)) {
     return nav;
   }
 
-  if (owner.role === "admin") {
+  if (isAdmin(owner)) {
     nav.push({
       id: "workspace",
       label: null,
@@ -306,7 +309,7 @@ export const subNavigationAdmin = ({
 
   nav.push({
     id: "developers",
-    label: owner.role === "admin" ? "Developers" : null,
+    label: isAdmin(owner) ? "Developers" : null,
     variant: "secondary",
     menus: [
       {
@@ -376,11 +379,7 @@ export const subNavigationApp = ({
     },
   ];
 
-  if (
-    owner.role === "user" ||
-    owner.role === "builder" ||
-    owner.role === "admin"
-  ) {
+  if (isUser(owner)) {
     nav = nav.concat([
       {
         id: "execute",

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -3,7 +3,7 @@ import type { PlanType, SubscriptionType } from "@dust-tt/types";
 import type { DustAPICredentials } from "@dust-tt/types";
 import type { Result } from "@dust-tt/types";
 import type { APIErrorWithStatusCode } from "@dust-tt/types";
-import { Err, Ok } from "@dust-tt/types";
+import { Err, isAdmin, isBuilder, isUser, Ok } from "@dust-tt/types";
 import type {
   GetServerSidePropsContext,
   NextApiRequest,
@@ -279,33 +279,15 @@ export class Authenticator {
   }
 
   isUser(): boolean {
-    switch (this._role) {
-      case "admin":
-      case "builder":
-      case "user":
-        return true;
-      default:
-        return false;
-    }
+    return isUser(this.workspace());
   }
 
   isBuilder(): boolean {
-    switch (this._role) {
-      case "admin":
-      case "builder":
-        return true;
-      default:
-        return false;
-    }
+    return isBuilder(this.workspace());
   }
 
   isAdmin(): boolean {
-    switch (this._role) {
-      case "admin":
-        return true;
-      default:
-        return false;
-    }
+    return isAdmin(this.workspace());
   }
 
   workspace(): WorkspaceType | null {

--- a/front/lib/swr.ts
+++ b/front/lib/swr.ts
@@ -34,7 +34,6 @@ import type { GetMembersResponseBody } from "@app/pages/api/w/[wId]/members";
 import type { GetProvidersResponseBody } from "@app/pages/api/w/[wId]/providers";
 import type { GetExtractedEventsResponseBody } from "@app/pages/api/w/[wId]/use/extract/events/[sId]";
 import type { GetEventSchemasResponseBody } from "@app/pages/api/w/[wId]/use/extract/templates";
-import disable from "@app/pages/api/w/[wId]/keys/[secret]/disable";
 
 export const fetcher = async (...args: Parameters<typeof fetch>) =>
   fetch(...args).then(async (res) => {

--- a/front/lib/swr.ts
+++ b/front/lib/swr.ts
@@ -538,17 +538,15 @@ export function useAgentUsage({
 export function useSlackChannelsLinkedWithAgent({
   workspaceId,
   dataSourceName,
-  disabled,
 }: {
   workspaceId: string;
   dataSourceName?: string;
-  disabled?: boolean;
 }) {
   const slackChannelsLinkedWithAgentFetcher: Fetcher<GetSlackChannelsLinkedWithAgentResponseBody> =
     fetcher;
 
   const { data, error, mutate } = useSWR(
-    dataSourceName && !disabled
+    dataSourceName
       ? `/api/w/${workspaceId}/data_sources/${dataSourceName}/managed/slack/channels_linked_with_agent`
       : null,
     slackChannelsLinkedWithAgentFetcher

--- a/front/lib/swr.ts
+++ b/front/lib/swr.ts
@@ -34,6 +34,7 @@ import type { GetMembersResponseBody } from "@app/pages/api/w/[wId]/members";
 import type { GetProvidersResponseBody } from "@app/pages/api/w/[wId]/providers";
 import type { GetExtractedEventsResponseBody } from "@app/pages/api/w/[wId]/use/extract/events/[sId]";
 import type { GetEventSchemasResponseBody } from "@app/pages/api/w/[wId]/use/extract/templates";
+import disable from "@app/pages/api/w/[wId]/keys/[secret]/disable";
 
 export const fetcher = async (...args: Parameters<typeof fetch>) =>
   fetch(...args).then(async (res) => {
@@ -537,15 +538,17 @@ export function useAgentUsage({
 export function useSlackChannelsLinkedWithAgent({
   workspaceId,
   dataSourceName,
+  disabled,
 }: {
   workspaceId: string;
   dataSourceName?: string;
+  disabled?: boolean;
 }) {
   const slackChannelsLinkedWithAgentFetcher: Fetcher<GetSlackChannelsLinkedWithAgentResponseBody> =
     fetcher;
 
   const { data, error, mutate } = useSWR(
-    dataSourceName
+    dataSourceName && !disabled
       ? `/api/w/${workspaceId}/data_sources/${dataSourceName}/managed/slack/channels_linked_with_agent`
       : null,
     slackChannelsLinkedWithAgentFetcher

--- a/front/pages/w/[wId]/assistant/assistants.tsx
+++ b/front/pages/w/[wId]/assistant/assistants.tsx
@@ -18,13 +18,14 @@ import {
   UserIcon,
   XMarkIcon,
 } from "@dust-tt/sparkle";
-import type {
-  AgentUserListStatus,
-  LightAgentConfigurationType,
-  UserType,
-  WorkspaceType,
-} from "@dust-tt/types";
 import type { SubscriptionType } from "@dust-tt/types";
+import {
+  type AgentUserListStatus,
+  isOnlyUser,
+  type LightAgentConfigurationType,
+  type UserType,
+  type WorkspaceType,
+} from "@dust-tt/types";
 import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import Link from "next/link";
 import { useContext, useState } from "react";
@@ -188,11 +189,9 @@ export default function PersonalAssistants({
       user={user}
       owner={owner}
       gaTrackingId={gaTrackingId}
-      topNavigationCurrent={
-        owner.role === "user" ? "conversations" : "assistants"
-      }
+      topNavigationCurrent={isOnlyUser(owner) ? "conversations" : "assistants"}
       subNavigation={
-        owner.role === "user"
+        isOnlyUser(owner)
           ? subNavigationConversations({
               owner,
               current: "personal_assistants",
@@ -203,7 +202,7 @@ export default function PersonalAssistants({
             })
       }
       navChildren={
-        owner.role === "user" && (
+        isOnlyUser(owner) && (
           <AssistantSidebarMenu owner={owner} triggerInputAnimation={null} />
         )
       }

--- a/front/pages/w/[wId]/builder/assistants/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/index.tsx
@@ -15,10 +15,11 @@ import {
   TrashIcon,
   XMarkIcon,
 } from "@dust-tt/sparkle";
-import type {
-  LightAgentConfigurationType,
-  UserType,
-  WorkspaceType,
+import {
+  isBuilder,
+  type LightAgentConfigurationType,
+  type UserType,
+  type WorkspaceType,
 } from "@dust-tt/types";
 import type { SubscriptionType } from "@dust-tt/types";
 import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
@@ -104,8 +105,6 @@ export default function WorkspaceAssistants({
   });
 
   globalAgents.sort(compareAgentsForSort);
-
-  const isBuilder = owner.role === "builder" || owner.role === "admin";
 
   const handleToggleAgentStatus = async (
     agent: LightAgentConfigurationType
@@ -245,7 +244,7 @@ export default function WorkspaceAssistants({
                           icon={PencilSquareIcon}
                           label="Edit"
                           size="xs"
-                          disabled={!isBuilder}
+                          disabled={!isBuilder(owner)}
                         />
                       </Link>
                       <DropdownMenu>
@@ -317,7 +316,7 @@ export default function WorkspaceAssistants({
                       icon={Cog6ToothIcon}
                       label="Manage"
                       size="sm"
-                      disabled={!isBuilder}
+                      disabled={!isBuilder(owner)}
                       onClick={() => {
                         void router.push(
                           `/w/${owner.sId}/builder/assistants/dust`
@@ -334,7 +333,7 @@ export default function WorkspaceAssistants({
                         selected={agent.status === "active"}
                         disabled={
                           agent.status === "disabled_missing_datasource" ||
-                          !isBuilder
+                          !isBuilder(owner)
                         }
                       />
                       <Popup

--- a/front/pages/w/[wId]/builder/assistants/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/index.tsx
@@ -15,13 +15,13 @@ import {
   TrashIcon,
   XMarkIcon,
 } from "@dust-tt/sparkle";
+import type { SubscriptionType } from "@dust-tt/types";
 import {
   isBuilder,
   type LightAgentConfigurationType,
   type UserType,
   type WorkspaceType,
 } from "@dust-tt/types";
-import type { SubscriptionType } from "@dust-tt/types";
 import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import Link from "next/link";
 import { useRouter } from "next/router";

--- a/types/src/front/user.ts
+++ b/types/src/front/user.ts
@@ -96,16 +96,7 @@ export function isOnlyUser(
   if (!owner) {
     return false;
   }
-  switch (owner.role) {
-    case "user":
-      return true;
-    case "builder":
-    case "admin":
-    case "none":
-      return false;
-    default:
-      assertNever(owner.role);
-  }
+  return owner.role === "user";
 }
 
 export function isOnlyBuilder(
@@ -114,16 +105,7 @@ export function isOnlyBuilder(
   if (!owner) {
     return false;
   }
-  switch (owner.role) {
-    case "builder":
-      return true;
-    case "user":
-    case "admin":
-    case "none":
-      return false;
-    default:
-      assertNever(owner.role);
-  }
+  return owner.role === "builder";
 }
 
 export function isOnlyAdmin(
@@ -132,14 +114,5 @@ export function isOnlyAdmin(
   if (!owner) {
     return false;
   }
-  switch (owner.role) {
-    case "admin":
-      return true;
-    case "user":
-    case "builder":
-    case "none":
-      return false;
-    default:
-      assertNever(owner.role);
-  }
+  return owner.role === "admin";
 }

--- a/types/src/front/user.ts
+++ b/types/src/front/user.ts
@@ -1,4 +1,5 @@
 import { ModelId } from "../shared/model_id";
+import { assertNever } from "../shared/utils/assert_never";
 
 export type WorkspaceSegmentationType = "interesting" | null;
 export type RoleType = "admin" | "builder" | "user" | "none";
@@ -39,4 +40,68 @@ export function formatUserFullName(user?: {
   return user
     ? [user.firstName, user.lastName].filter(Boolean).join(" ")
     : null;
+}
+
+export function isAdmin(owner: WorkspaceType | null) {
+  if (!owner) {
+    return false;
+  }
+  switch (owner.role) {
+    case "admin":
+      return true;
+    case "builder":
+    case "user":
+    case "none":
+      return false;
+    default:
+      assertNever(owner.role);
+  }
+}
+
+export function isBuilder(owner: WorkspaceType | null) {
+  if (!owner) {
+    return false;
+  }
+  switch (owner.role) {
+    case "admin":
+    case "builder":
+      return true;
+    case "user":
+    case "none":
+      return false;
+    default:
+      assertNever(owner.role);
+  }
+}
+
+export function isUser(owner: WorkspaceType | null) {
+  if (!owner) {
+    return false;
+  }
+  switch (owner.role) {
+    case "admin":
+    case "builder":
+    case "user":
+      return true;
+    case "none":
+      return false;
+    default:
+      assertNever(owner.role);
+  }
+}
+
+export function isOnlyUser(owner: WorkspaceType | null) {
+  if (!owner) {
+    return false;
+  }
+  switch (owner.role) {
+    case "user":
+      return true;
+    case "builder":
+    case "admin":
+    case "none":
+      return false;
+    default:
+      assertNever(owner.role);
+  }
 }

--- a/types/src/front/user.ts
+++ b/types/src/front/user.ts
@@ -90,7 +90,9 @@ export function isUser(owner: WorkspaceType | null) {
   }
 }
 
-export function isOnlyUser(owner: WorkspaceType | null) {
+export function isOnlyUser(
+  owner: WorkspaceType | null
+): owner is WorkspaceType & { role: "user" } {
   if (!owner) {
     return false;
   }
@@ -99,6 +101,42 @@ export function isOnlyUser(owner: WorkspaceType | null) {
       return true;
     case "builder":
     case "admin":
+    case "none":
+      return false;
+    default:
+      assertNever(owner.role);
+  }
+}
+
+export function isOnlyBuilder(
+  owner: WorkspaceType | null
+): owner is WorkspaceType & { role: "builder" } {
+  if (!owner) {
+    return false;
+  }
+  switch (owner.role) {
+    case "builder":
+      return true;
+    case "user":
+    case "admin":
+    case "none":
+      return false;
+    default:
+      assertNever(owner.role);
+  }
+}
+
+export function isOnlyAdmin(
+  owner: WorkspaceType | null
+): owner is WorkspaceType & { role: "admin" } {
+  if (!owner) {
+    return false;
+  }
+  switch (owner.role) {
+    case "admin":
+      return true;
+    case "user":
+    case "builder":
     case "none":
       return false;
     default:


### PR DESCRIPTION
## Description
Introduce `isUser` `isBuilder` `isAdmin` helper function on `WorkspaceType` to avoid referring to particular role and in particular `role === "builder" || role === "admin"`. Also introduces `isOnlyUser` `isOnlyBuilder` `isOnlyAdmin` to test if a `WorkspaceType` has exactly this role.

The use of `assertNever` will make adding a new role in the future much safer.

Attempted to remove as many reference to actual roles in the code as possible

## Risk
Touches auth logic. Risk of error is low but impact of error is high.