### PR TITLE
assistant builder: do not load slack links when not builder

### DIFF
--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -362,6 +362,7 @@ export default function AssistantBuilder({
     useSlackChannelsLinkedWithAgent({
       workspaceId: owner.sId,
       dataSourceName: slackDataSource?.name ?? undefined,
+      disabled: !isBuilder(owner),
     });
   const [slackChannelsInitialized, setSlackChannelsInitialized] =
     useState(false);

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -1461,7 +1461,7 @@ function SlackIntegration({
           <Button
             labelVisible={true}
             label={"Select channels"}
-            variant={"primary"}
+            variant={"secondary"}
             icon={PlusIcon}
             onClick={openModal}
           />

--- a/front/lib/swr.ts
+++ b/front/lib/swr.ts
@@ -537,15 +537,17 @@ export function useAgentUsage({
 export function useSlackChannelsLinkedWithAgent({
   workspaceId,
   dataSourceName,
+  disabled,
 }: {
   workspaceId: string;
   dataSourceName?: string;
+  disabled?: boolean;
 }) {
   const slackChannelsLinkedWithAgentFetcher: Fetcher<GetSlackChannelsLinkedWithAgentResponseBody> =
     fetcher;
 
   const { data, error, mutate } = useSWR(
-    dataSourceName
+    dataSourceName && !disabled
       ? `/api/w/${workspaceId}/data_sources/${dataSourceName}/managed/slack/channels_linked_with_agent`
       : null,
     slackChannelsLinkedWithAgentFetcher


### PR DESCRIPTION
## Description
Fixes: https://github.com/dust-tt/tasks/issues/337

We were seeing a large number of data_source_auth_error in production due to the assistant builder loading linked slack channels when editing personal assistants as non builder.

Also change the slack channel integration button to secondary (I myself got caught clicking it thinking I would save)

## Risk
None