### PR TITLE
Put identical page path with different query string parameters as sib…

### DIFF
--- a/connectors/src/connectors/webcrawler/index.ts
+++ b/connectors/src/connectors/webcrawler/index.ts
@@ -1,6 +1,7 @@
 import type { ConnectorResource, ModelId } from "@dust-tt/types";
 
 import {
+  getDisplayNameForPage,
   normalizeFolderUrl,
   stableIdForUrl,
 } from "@connectors/connectors/webcrawler/lib/utils";
@@ -152,7 +153,6 @@ export async function retrieveWebcrawlerConnectorPermissions({
       })
       .concat(
         pages.map((page): ConnectorResource => {
-          const parsedUrl = new URL(page.url);
           const isFileAndFolder = excludedFoldersSet.has(
             normalizeFolderUrl(page.url)
           );
@@ -170,11 +170,7 @@ export async function retrieveWebcrawlerConnectorPermissions({
                   ressourceType: "folder",
                 })
               : null,
-            title:
-              parsedUrl.pathname
-                .split("/")
-                .filter((x) => x)
-                .pop() || parsedUrl.origin,
+            title: getDisplayNameForPage(page.url),
             sourceUrl: page.url,
             expandable: isFileAndFolder ? true : false,
             permission: "read",

--- a/connectors/src/connectors/webcrawler/lib/utils.ts
+++ b/connectors/src/connectors/webcrawler/lib/utils.ts
@@ -66,12 +66,37 @@ export function isTopFolder(url: string) {
 // Normalizes a url path by removing trailing slashes and empty path parts (eg: //)
 export function normalizeFolderUrl(url: string) {
   const parsed = new URL(url);
-  return (
+  let result =
     parsed.origin +
     "/" +
     parsed.pathname
       .split("/")
       .filter((x) => x)
-      .join("/")
-  );
+      .join("/");
+
+  if (parsed.search.length > 0) {
+    // Search string contains the initial '?
+    result += parsed.search;
+  }
+
+  return result;
+}
+
+export function getDisplayNameForPage(url: string): string {
+  const parsed = new URL(url);
+  let result = "";
+  const fragments = parsed.pathname.split("/").filter((x) => x);
+  const lastFragment = fragments.pop();
+  if (lastFragment) {
+    result += lastFragment;
+  }
+  if (parsed.search.length > 0) {
+    result += parsed.search;
+  }
+
+  if (!result) {
+    result = parsed.origin;
+  }
+
+  return result;
 }

--- a/connectors/src/connectors/webcrawler/lib/utils.ts
+++ b/connectors/src/connectors/webcrawler/lib/utils.ts
@@ -48,7 +48,8 @@ export function getAllFoldersForUrl(url: string) {
 // eg: https://example.com/foo/bar -> https://example.com/foo
 // eg: https://example.com/foo -> https://example.com/
 export function getFolderForUrl(url: string) {
-  const parsed = new URL(url);
+  const normalized = normalizeFolderUrl(url);
+  const parsed = new URL(normalized);
   const urlParts = parsed.pathname.split("/").filter((part) => part.length > 0);
   if (parsed.pathname === "/") {
     return null;
@@ -75,8 +76,8 @@ export function normalizeFolderUrl(url: string) {
       .join("/");
 
   if (parsed.search.length > 0) {
-    // Search string contains the initial '?
-    result += parsed.search;
+    // Replace the leading ? with a /
+    result += "/" + parsed.search.slice(1);
   }
 
   return result;


### PR DESCRIPTION
## Description
URL with the same path but different query string parameters were not properly handled by the URL normalization process used to group pages into folders.

This PR fixes that by using the query string as part of the normalization process and the display name of the page.

### Before
![Screenshot 2024-01-18 at 11 17 28](https://github.com/dust-tt/dust/assets/358965/24ced975-9353-480b-b1f9-3109ce2bcf58)


### After

![Screenshot 2024-01-18 at 11 52 42](https://github.com/dust-tt/dust/assets/358965/79ce84f3-122a-432a-827c-95d45594d142)



<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->

<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

<!-- Your content here -->

## Risk
Risk seems pretty low since the feature is only accessible to us for now, and we'll re-crawl all websites already added by our team before sending it to any external users.

I also tested this new code on 8 different websites and it worked well.

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

<!-- Your content here -->

<!-- ## Deploy Plan -->
<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

<!-- Your content here -->

- Deploy connectors.
- Empty the tables `webcrawler_folders` and `webcrawler_pages` and re-crawl all websites already added.
