### PR TITLE
[Sparkle] Fix: sizing classes on tabs work

### DIFF
--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.70",
+  "version": "0.2.71",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/components/Tab.tsx
+++ b/sparkle/src/components/Tab.tsx
@@ -86,7 +86,6 @@ export function Tab({ tabs, onTabClick, className = "" }: TabProps) {
         tabStateClasses.hover,
         tabStateClasses.dark.base,
         tabStateClasses.dark.hover,
-        tabSizingClasses[tab.sizing ?? "hug"],
         className
       );
 
@@ -128,7 +127,7 @@ export function Tab({ tabs, onTabClick, className = "" }: TabProps) {
       return tab.hideLabel ? (
         tab.label ? (
           <React.Fragment key={`tab-${i}`}>
-            <div>
+            <div className={tabSizingClasses[tab.sizing ?? "hug"]}>
               <Tooltip label={tab.label}>{content}</Tooltip>
             </div>
             {tab.hasSeparator && (
@@ -137,7 +136,9 @@ export function Tab({ tabs, onTabClick, className = "" }: TabProps) {
           </React.Fragment>
         ) : (
           <React.Fragment key={`tab-${i}`}>
-            <div>{content}</div>
+            <div className={tabSizingClasses[tab.sizing ?? "hug"]}>
+              {content}
+            </div>
             {tab.hasSeparator && (
               <div className="s-flex s-h-full s-grow" key={`sep-${i}`} />
             )}
@@ -145,7 +146,7 @@ export function Tab({ tabs, onTabClick, className = "" }: TabProps) {
         )
       ) : (
         <React.Fragment key={`tab-${i}`}>
-          <div>{content}</div>
+          <div className={tabSizingClasses[tab.sizing ?? "hug"]}>{content}</div>
           {tab.hasSeparator && (
             <div className="s-flex s-h-full s-grow" key={`sep-${i}`} />
           )}


### PR DESCRIPTION
## Description
Sizing classes ("hug", "expand") on tab had no effect. This PR fixes it cc @Duncid 

Before:
![image](https://github.com/dust-tt/dust/assets/5437393/620d8f21-9c5f-49a9-a1ff-866c5415ed2b)

After:
![image](https://github.com/dust-tt/dust/assets/5437393/0d718c13-00c3-4aa6-a3f7-509577ce7214)


## Risk
Risk that it affects some existing tabs in the app => i checked the main suspects (my assistants, sidebar of course, dust apps)

<!-- Your content here -->

<!-- ## Deploy Plan -->
<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

<!-- Your content here -->
