### PR TITLE
enh: add parentMessageId to monthly-usage CSV

### DIFF
--- a/front/pages/api/w/[wId]/monthly-usage.ts
+++ b/front/pages/api/w/[wId]/monthly-usage.ts
@@ -105,6 +105,7 @@ async function getMonthlyUsage(
       TO_CHAR(m."createdAt"::timestamp, 'YYYY-MM-DD HH24:MI:SS') AS "createdAt",
       c."id" AS "conversationInternalId",
       m."sId" AS "messageId",
+      p."sId" AS "parentMessageId",
       CASE
         WHEN um."id" IS NOT NULL THEN 'user'
         WHEN am."id" IS NOT NULL THEN 'assistant'
@@ -142,6 +143,8 @@ async function getMonthlyUsage(
       "content_fragments" cf ON m."contentFragmentId" = cf."id"
   LEFT JOIN
       "agent_configurations" ac ON am."agentConfigurationId" = ac."sId" AND am."agentConfigurationVersion" = ac."version"
+  LEFT JOIN
+      "messages" p ON m."parentId" = p."id"
   WHERE
       w."sId" = :wId AND
       DATE_TRUNC('month', m."createdAt") = DATE_TRUNC('month', :referenceDate::timestamp)


### PR DESCRIPTION
## Description

this simply adds a `parentMessageId` column to the monthly-usage CSV. This column will be null for user messages, and populated with the parent message's SID for agent messages.

This should help analyze the CSV to answer questions such as "What assistant was most often pinged by John Does last week ?"

## Risk

Not much. Tested locally, works fine.