### PR TITLE
enh: increase nextjs body size limit on /csv

### DIFF
--- a/front/pages/api/w/[wId]/data_sources/[name]/tables/csv.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/tables/csv.ts
@@ -16,6 +16,14 @@ import { generateModelSId } from "@app/lib/utils";
 import logger from "@app/logger/logger";
 import { apiError, withLogging } from "@app/logger/withlogging";
 
+export const config = {
+  api: {
+    bodyParser: {
+      sizeLimit: "10mb",
+    },
+  },
+};
+
 const CreateTableFromCsvSchema = t.type({
   name: t.string,
   description: t.string,


### PR DESCRIPTION
## Description

We want to allow uploading CSVs bigger than 1MB

## Risk

For now, this is limited to dust-only. We might want to upload differently in the future.