### PR TITLE
fix: poke fromSuperUserSession:

### DIFF
--- a/front/pages/poke/[wId]/assistants/[aId]/index.tsx
+++ b/front/pages/poke/[wId]/assistants/[aId]/index.tsx
@@ -14,7 +14,7 @@ export const getServerSideProps: GetServerSideProps<{
   agentConfigurations: AgentConfigurationType[];
 }> = async (context) => {
   const session = await getSession(context.req, context.res);
-  const auth = await Authenticator.fromSession(
+  const auth = await Authenticator.fromSuperUserSession(
     session,
     context.params?.wId as string
   );

--- a/front/pages/poke/[wId]/data_sources/[name]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[name]/index.tsx
@@ -30,7 +30,7 @@ export const getServerSideProps: GetServerSideProps<{
   connector: ConnectorType | null;
 }> = async (context) => {
   const session = await getSession(context.req, context.res);
-  const auth = await Authenticator.fromSession(
+  const auth = await Authenticator.fromSuperUserSession(
     session,
     context.params?.wId as string
   );

--- a/front/pages/poke/[wId]/data_sources/[name]/view.tsx
+++ b/front/pages/poke/[wId]/data_sources/[name]/view.tsx
@@ -13,7 +13,7 @@ export const getServerSideProps: GetServerSideProps<{
   document: CoreAPIDocument;
 }> = async (context) => {
   const session = await getSession(context.req, context.res);
-  const auth = await Authenticator.fromSession(
+  const auth = await Authenticator.fromSuperUserSession(
     session,
     context.params?.wId as string
   );

--- a/front/pages/poke/[wId]/index.tsx
+++ b/front/pages/poke/[wId]/index.tsx
@@ -57,7 +57,7 @@ export const getServerSideProps: GetServerSideProps<{
   dataSourcesSynchronizedAgo: Record<string, string>;
 }> = async (context) => {
   const session = await getSession(context.req, context.res);
-  const auth = await Authenticator.fromSession(
+  const auth = await Authenticator.fromSuperUserSession(
     session,
     context.params?.wId as string
   );

--- a/front/pages/poke/[wId]/memberships.tsx
+++ b/front/pages/poke/[wId]/memberships.tsx
@@ -17,7 +17,7 @@ export const getServerSideProps: GetServerSideProps<{
   members: UserTypeWithWorkspaces[];
 }> = async (context) => {
   const session = await getSession(context.req, context.res);
-  const auth = await Authenticator.fromSession(
+  const auth = await Authenticator.fromSuperUserSession(
     session,
     context.params?.wId as string
   );

--- a/front/pages/poke/plans.tsx
+++ b/front/pages/poke/plans.tsx
@@ -29,10 +29,7 @@ export const getServerSideProps: GetServerSideProps<object> = async (
   context
 ) => {
   const session = await getSession(context.req, context.res);
-  const auth = await Authenticator.fromSession(
-    session,
-    context.params?.wId as string
-  );
+  const auth = await Authenticator.fromSuperUserSession(session, null);
 
   if (!auth.isDustSuperUser()) {
     return {


### PR DESCRIPTION
## Description
Follow-up from #3295 which erroneously attempted to use fromSession instead of fromSuperUserSession for poke pags.

## Risk
Touches authentication but pretty clear change

## Deploy Plan 
- Deploy front
