### PR TITLE
Use INTEGER instead of MEDIUMINT

### DIFF
--- a/connectors/src/lib/models/confluence.ts
+++ b/connectors/src/lib/models/confluence.ts
@@ -147,7 +147,7 @@ ConfluencePage.init(
       defaultValue: DataTypes.NOW,
     },
     version: {
-      type: DataTypes.MEDIUMINT,
+      type: DataTypes.INTEGER,
       allowNull: false,
     },
     skipReason: {


### PR DESCRIPTION
## Description
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->

<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

<!-- Your content here -->
This PR fixes the `ConfluencePage` model introduced https://github.com/dust-tt/dust/pull/3303 since our production DB does not support `mediumint`.

## Risk
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

<!-- Your content here -->

## Deploy Plan
Merge this PR on main and then apply the migration from the edge infrastructure.

<!-- Your content here -->
