### PR TITLE
Fix: getAgentConfigs 'published' does not return global agents

### DIFF
--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -117,14 +117,14 @@ export async function getAgentConfigurations<V extends "light" | "full">({
   const globalAgentIdsToFetch: string[] | undefined = (() => {
     switch (agentsGetView) {
       case "workspace":
-        // No global agents in workspace view.
+      case "published":
+        // No global agents in workspace & published view.
         return [];
       case "global":
       case "list":
       case "all":
       case "admin_internal":
-      case "published":
-        // All global agents in global, list, all, admin_internal, published views.
+        // All global agents in global, list, all, admin_internal views.
         return undefined;
       default:
         if (


### PR DESCRIPTION
## Description
Global agents were shown in the "By teammates " tab of gallery (cf screenshot)
"published" view should only returns agents that have the "published" scope
![image](https://github.com/dust-tt/dust/assets/5437393/8d8b1b04-7f78-43ee-84e2-cfc50f5e5a06)




<!-- ## Deploy Plan -->
<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

<!-- Your content here -->
