### PR TITLE
feat: download tables query results as CSV

### DIFF
--- a/core/src/sqlite_workers/sqlite_database.rs
+++ b/core/src/sqlite_workers/sqlite_database.rs
@@ -54,7 +54,7 @@ impl SqliteDatabase {
             let time_query_start = utils::now();
 
             // Execute the query and collect results
-            let mut stmt = conn.prepare(&query).unwrap();
+            let mut stmt = conn.prepare(&query)?;
             let column_names = stmt
                 .column_names()
                 .into_iter()

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -32,6 +32,7 @@
         "ajv": "^8.12.0",
         "blake3": "^2.1.7",
         "csv-parse": "^5.5.2",
+        "csv-stringify": "^6.4.5",
         "dd-trace": "^3.16.0",
         "emoji-mart": "^5.5.2",
         "eventsource-parser": "^1.0.0",
@@ -5726,6 +5727,11 @@
       "version": "5.5.2",
       "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.5.2.tgz",
       "integrity": "sha512-YRVtvdtUNXZCMyK5zd5Wty1W6dNTpGKdqQd4EQ8tl/c6KW1aMBB1Kg1ppky5FONKmEqGJ/8WjLlTNLPne4ioVA=="
+    },
+    "node_modules/csv-stringify": {
+      "version": "6.4.5",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.4.5.tgz",
+      "integrity": "sha512-SPu1Vnh8U5EnzpNOi1NDBL5jU5Rx7DVHr15DNg9LXDTAbQlAVAmEbVt16wZvEW9Fu9Qt4Ji8kmeCJ2B1+4rFTQ=="
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",

--- a/front/package.json
+++ b/front/package.json
@@ -40,6 +40,7 @@
     "ajv": "^8.12.0",
     "blake3": "^2.1.7",
     "csv-parse": "^5.5.2",
+    "csv-stringify": "^6.4.5",
     "dd-trace": "^3.16.0",
     "emoji-mart": "^5.5.2",
     "eventsource-parser": "^1.0.0",

--- a/types/src/front/lib/actions/registry.ts
+++ b/types/src/front/lib/actions/registry.ts
@@ -138,7 +138,7 @@ export const DustProdActionRegistry = createActionRegistry({
       workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
       appId: "b4f205e453",
       appHash:
-        "5f814f091a270cc56e2120a21dbf5fba7b64360868cc2dea1da53af3a2b9cc3b",
+        "3a4dc976412180b7aa596de606bc1b3d7c1642c91775e56db14d6ec1c2aa27bd",
     },
     config: {
       MODEL: {


### PR DESCRIPTION
## Description
<img width="928" alt="Screenshot 2024-01-19 at 11 27 33" src="https://github.com/dust-tt/dust/assets/14199823/18ad39fa-6877-4f1b-b8c1-8dd5d756975b">

Adds a "download as CSV" button to tables query action. 
Also updates the dust app so the model also generates a "query_title" arg that we use as the downloaded file name.

## Risk

Not yet