### PR TITLE
Fix Slack full sync await on childs

### DIFF
--- a/connectors/src/connectors/slack/temporal/workflows.ts
+++ b/connectors/src/connectors/slack/temporal/workflows.ts
@@ -46,29 +46,26 @@ export async function workspaceFullSync(
   fromTs: number | null
 ): Promise<void> {
   let i = 1;
-  const promises: Promise<void>[] = [];
   const childWorkflowQueue = new PQueue({
     concurrency: 1,
   });
   setHandler(syncChannelSignal, async (input) => {
     for (const channelId of input.channelIds) {
-      promises.push(
-        childWorkflowQueue.add(async () => {
-          await reportInitialSyncProgressActivity(
-            connectorId,
-            `${i - 1}/${input.channelIds.length} channels`
-          );
-          await executeChild(syncOneChannel, {
-            workflowId: syncOneChanneWorkflowlId(connectorId, channelId),
-            searchAttributes: {
-              connectorId: [connectorId],
-            },
-            args: [connectorId, channelId, false, fromTs],
-            memo: workflowInfo().memo,
-          });
-          i++;
-        })
-      );
+      void childWorkflowQueue.add(async () => {
+        await reportInitialSyncProgressActivity(
+          connectorId,
+          `${i - 1}/${input.channelIds.length} channels`
+        );
+        await executeChild(syncOneChannel, {
+          workflowId: syncOneChanneWorkflowlId(connectorId, channelId),
+          searchAttributes: {
+            connectorId: [connectorId],
+          },
+          args: [connectorId, channelId, false, fromTs],
+          memo: workflowInfo().memo,
+        });
+        i++;
+      });
     }
   });
   await fetchUsers(connectorId);

--- a/connectors/src/connectors/slack/temporal/workflows.ts
+++ b/connectors/src/connectors/slack/temporal/workflows.ts
@@ -72,7 +72,7 @@ export async function workspaceFullSync(
     }
   });
   await fetchUsers(connectorId);
-  await Promise.all(promises);
+  await childWorkflowQueue.onIdle();
 
   await executeChild(slackGarbageCollectorWorkflow, {
     workflowId: slackGarbageCollectorWorkflowId(connectorId),


### PR DESCRIPTION
## Description

The Slack fullsync workflow was not properly waiting on child workflows added after the first batch (via signals).

This PR fixes that issue.

I was able to reproduce the bug locally:
- Add Slack channels A and B
- Add Slack channels C and D
- The child workflows C and D shows as "terminated by parents policy" once the workflows for channels A and B are completed.



<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
