### PR TITLE
[Linter] Allow _, _0, ... , _9 as unused variable names

### DIFF
--- a/front/.eslintrc.js
+++ b/front/.eslintrc.js
@@ -20,7 +20,10 @@ module.exports = {
     "@typescript-eslint/consistent-type-imports": "error",
     "import/consistent-type-specifier-style": ["error", "prefer-top-level"],
     "@typescript-eslint/no-explicit-any": 0,
-    "@typescript-eslint/no-unused-vars": "error",
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      { argsIgnorePattern: "^_[0-9]$" },
+    ],
     "no-case-declarations": 0,
     "react-hooks/rules-of-hooks": 0,
     "@next/next/no-img-element": 0,


### PR DESCRIPTION
## Description
Linting to avoid unused variables is great. However, there are cases where unused variables are not avoidable. For instance when using destructuring, such as in the
following function

```
([_, scope]) => isBuilder(owner) || scope !== "workspace"
```

The following code is IMHO cleaner than not destructuring or adding a linting ignore -- but does not pass the branch check

While there are multiple solutions, the underscore is a common convention for "allowed" unused variables

This is the goal of this PR
## Deploy plan
To be proposed to eng team monday
