### PR TITLE
fix: cast github known errors swallows unknown errors

### DIFF
--- a/connectors/src/connectors/github/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/github/temporal/cast_known_errors.ts
@@ -23,6 +23,8 @@ export class GithubCastKnownErrorsInterceptor
           type: "github_rate_limited",
         };
       }
+
+      throw err;
     }
   }
 }


### PR DESCRIPTION
## Description

The "cast known errors" activity interceptor for the Github Connector has been swallowing unknown errors since this PR: https://github.com/dust-tt/dust/pull/2546

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
