### PR TITLE
enh: add warning when uploading file > 5mb

### DIFF
--- a/front/pages/w/[wId]/builder/data-sources/[name]/tables/upsert.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/tables/upsert.tsx
@@ -2,6 +2,7 @@ import {
   Button,
   DocumentPlusIcon,
   DropdownMenu,
+  ExclamationCircleIcon,
   Input,
   Page,
   TrashIcon,
@@ -100,6 +101,7 @@ export default function TableUpsert({
   const [loading, setLoading] = useState(false);
   const [uploading, setUploading] = useState(false);
   const [upserting, setUpserting] = useState(false);
+  const [isBigFile, setIsBigFile] = useState(false);
 
   const { table } = useTable({
     workspaceId: owner.sId,
@@ -176,6 +178,12 @@ export default function TableUpsert({
             "Please upload a file containing less than 50 million characters.",
         });
         return;
+      }
+
+      if (res.value.content.length > 5_000_000) {
+        setIsBigFile(true);
+      } else {
+        setIsBigFile(false);
       }
 
       const body: CreateTableFromCsvRequestBody = {
@@ -308,6 +316,19 @@ export default function TableUpsert({
                     },
                   }}
                 />
+                {isBigFile && (
+                  <div className="pt-4">
+                    <div className="flex flex-col gap-y-2">
+                      <div className="flex grow flex-row items-center gap-1 text-sm font-medium text-element-800 text-warning-500">
+                        <ExclamationCircleIcon />
+                        Warning: Large file
+                      </div>
+                      <div className="text-sm font-normal text-element-700">
+                        This file is large and may take a while to upload.
+                      </div>
+                    </div>
+                  </div>
+                )}
                 <input
                   type="file"
                   ref={fileInputRef}

--- a/front/pages/w/[wId]/builder/data-sources/[name]/tables/upsert.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/tables/upsert.tsx
@@ -321,7 +321,7 @@ export default function TableUpsert({
                     <div className="flex flex-col gap-y-2">
                       <div className="flex grow flex-row items-center gap-1 text-sm font-medium text-element-800 text-warning-500">
                         <ExclamationCircleIcon />
-                        Warning: Large file
+                        Warning: Large file (5MB+)
                       </div>
                       <div className="text-sm font-normal text-element-700">
                         This file is large and may take a while to upload.


### PR DESCRIPTION
## Description

Uploading large-ish CSV files via the web UI can take a little while so it's useful to warn the user


<img width="1690" alt="Screenshot 2024-01-22 at 10 52 20" src="https://github.com/dust-tt/dust/assets/14199823/db5ad01f-b687-466b-8b2c-3c63a8d23423">



## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
