### PR TITLE
core: fix bug upsert failures

### DIFF
--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -793,26 +793,27 @@ impl DataSource {
             format!("gs://{}/{}", bucket, content_path)
         ));
 
-        match document_id {
-            "notion-95804d6b-0274-43f6-8957-5b024234e3bf" => {
-                let debug_path = format!("{}/{}/debug.json", bucket_path, document_hash);
-                Object::create(
-                    &bucket,
-                    serde_json::to_string(&text).unwrap().into_bytes(),
-                    &debug_path,
-                    "application/json",
-                )
-                .await?;
-                utils::done(&format!(
-                    "Uploaded buggy document: data_source_id={} document_id={} debug_blob_url={}",
-                    self.data_source_id,
-                    document_id,
-                    format!("gs://{}/{}", bucket, debug_path)
-                ));
-                panic!("BUGGY document `{}`", document_id);
-            }
-            _ => (),
-        };
+        // Commented for future debug use
+        // match document_id {
+        //     "notion-95804d6b-0274-43f6-8957-5b024234e3bf" => {
+        //         let debug_path = format!("{}/{}/debug.json", bucket_path, document_hash);
+        //         Object::create(
+        //             &bucket,
+        //             serde_json::to_string(&text).unwrap().into_bytes(),
+        //             &debug_path,
+        //             "application/json",
+        //         )
+        //         .await?;
+        //         utils::done(&format!(
+        //             "Uploaded buggy document: data_source_id={} document_id={} debug_blob_url={}",
+        //             self.data_source_id,
+        //             document_id,
+        //             format!("gs://{}/{}", bucket, debug_path)
+        //         ));
+        //         panic!("BUGGY document `{}`", document_id);
+        //     }
+        //     _ => (),
+        // };
 
         let now = utils::now();
 

--- a/core/src/data_sources/splitter.rs
+++ b/core/src/data_sources/splitter.rs
@@ -250,7 +250,7 @@ impl TokenizedSection {
                     max_chunk_size,
                     prefixes.clone(),
                     s,
-                    Some(format!("{}{}", path, i)),
+                    Some(format!("{}/{}", path, i)),
                 )
             }))
             .await
@@ -269,7 +269,10 @@ impl TokenizedSection {
             // if we were to reconstruct that node as a full chunk
             tokens_count: prefixes_tokens_count
                 + match content.as_ref() {
-                    Some(c) => c.tokens.len(),
+                    Some(c) => {
+                        assert!(sections.is_empty());
+                        c.tokens.len()
+                    }
                     None => {
                         sections.iter().map(|s| s.tokens_count).sum::<usize>()
                             - sections.len() * prefixes_tokens_count
@@ -1020,7 +1023,6 @@ mod tests {
         let model_id = "text-embedding-ada-002";
         let credentials = Credentials::from([("OPENAI_API_KEY".to_string(), "abc".to_string())]);
 
-        // Before the fix, this would fail (assertion failure in TokenizedSection.chunk).
         splitter(SplitterID::BaseV0)
             .split(credentials, provider_id, model_id, 256, section)
             .await


### PR DESCRIPTION
## Description

Addresses failures reported here: https://github.com/dust-tt/tasks/issues/346

The splitter would collapse prefix "path" when there was many prefixes onto non-unique string (eg `0 4 0` vs `0 40`), which in turn when two similar prefixes existed on collapsed pathes would trigger the assert between token_counts and rendered tokens.len(). 

This fixes the prefix path rendering and in turn fixes the issue as tested on live user data (no test was created to avoid leaking data + reproducing the test case is quite involved).

## Risk

Limited, well covered by tests.

## Deploy Plan

- Deploy `core` + un-skip files in https://github.com/dust-tt/tasks/issues/346