### PR TITLE
githubCodeSync: bump requested volume + better logging

### DIFF
--- a/connectors/src/connectors/github/lib/github_api.ts
+++ b/connectors/src/connectors/github/lib/github_api.ts
@@ -681,7 +681,12 @@ export async function processRepository({
     // Save the tarball to the temp directory.
     await pipeline(tarballStream, createWriteStream(tarPath));
 
-    localLogger.info("Finished downloading tarball");
+    const { size } = await fs.stat(tarPath);
+
+    localLogger.info(
+      { tarSize: size, tarPath },
+      "Finished tarball download"
+    );
 
     // Extract the tarball.
     await extract({

--- a/connectors/src/connectors/github/lib/github_api.ts
+++ b/connectors/src/connectors/github/lib/github_api.ts
@@ -683,10 +683,7 @@ export async function processRepository({
 
     const { size } = await fs.stat(tarPath);
 
-    localLogger.info(
-      { tarSize: size, tarPath },
-      "Finished tarball download"
-    );
+    localLogger.info({ tarSize: size, tarPath }, "Finished tarball download");
 
     // Extract the tarball.
     await extract({

--- a/k8s/deployments/connectors-worker-deployment.yaml
+++ b/k8s/deployments/connectors-worker-deployment.yaml
@@ -43,10 +43,12 @@ spec:
             requests:
               cpu: 2000m
               memory: 8Gi
+              storage: 256Gi
 
             limits:
               cpu: 2000m
               memory: 8Gi
+              storage: 256Gi
 
       volumes:
         - name: cert-volume


### PR DESCRIPTION
## Description

- Bumps the requested volume size for connectors-worker
- Better logging around tarball download

## Risk

None

## Deploy Plan

- apply_infra.sh (only `apply_deployment connectors-worker-deployment`)
- Deploy connectors