### PR TITLE
connectors: bump ephemeral storage on connectors-workers

### DIFF
--- a/k8s/deployments/connectors-worker-deployment.yaml
+++ b/k8s/deployments/connectors-worker-deployment.yaml
@@ -43,10 +43,12 @@ spec:
             requests:
               cpu: 2000m
               memory: 8Gi
+              ephemeral-storage: 32Gi
 
             limits:
               cpu: 2000m
               memory: 8Gi
+              ephemeral-storage: 32Gi
 
       volumes:
         - name: cert-volume


### PR DESCRIPTION
## Description

Got the following error with github code sync:
```
  Normal   Started    16m   kubelet                                Started container web
  Warning  Evicted    11m   kubelet                                Pod ephemeral local storage usage exceeds the total limit of containers 1Gi.
  Normal   Killing    11m   kubelet                                Stopping container web
```

Leaving the container in error. This was successfully applied.

## Risk

N/A

## Deploy Plan

- apply infra (already done)