### PR TITLE
github code: fix last updated at

### DIFF
--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -357,7 +357,7 @@ export async function retrieveGithubConnectorPermissions({
           expandable: true,
           permission: "read" as ConnectorPermission,
           dustDocumentId: null,
-          lastUpdatedAt: directory.updatedAt.getTime(),
+          lastUpdatedAt: directory.codeUpdatedAt.getTime(),
         });
       });
 
@@ -372,7 +372,7 @@ export async function retrieveGithubConnectorPermissions({
           expandable: false,
           permission: "read" as ConnectorPermission,
           dustDocumentId: file.documentId,
-          lastUpdatedAt: file.updatedAt.getTime(),
+          lastUpdatedAt: file.codeUpdatedAt.getTime(),
         });
       });
 
@@ -463,7 +463,7 @@ export async function retrieveGithubConnectorPermissions({
           expandable: true,
           permission: "read" as ConnectorPermission,
           dustDocumentId: null,
-          lastUpdatedAt: codeRepo.updatedAt.getTime(),
+          lastUpdatedAt: codeRepo.codeUpdatedAt.getTime(),
         });
       }
 

--- a/connectors/src/connectors/github/temporal/activities.ts
+++ b/connectors/src/connectors/github/temporal/activities.ts
@@ -1003,6 +1003,7 @@ export async function githubCodeSyncActivity({
             createdAt: codeSyncStartedAt,
             updatedAt: codeSyncStartedAt,
             lastSeenAt: codeSyncStartedAt,
+            codeUpdatedAt: codeSyncStartedAt,
           });
         }
 
@@ -1057,7 +1058,7 @@ export async function githubCodeSyncActivity({
           githubCodeFile.fileName = f.fileName;
           githubCodeFile.sourceUrl = f.sourceUrl;
           githubCodeFile.contentHash = contentHash;
-          githubCodeFile.updatedAt = codeSyncStartedAt;
+          githubCodeFile.codeUpdatedAt = codeSyncStartedAt;
         } else {
           localLogger.info(
             {
@@ -1101,6 +1102,7 @@ export async function githubCodeSyncActivity({
             createdAt: codeSyncStartedAt,
             updatedAt: codeSyncStartedAt,
             lastSeenAt: codeSyncStartedAt,
+            codeUpdatedAt: codeSyncStartedAt,
           });
         }
 
@@ -1118,7 +1120,7 @@ export async function githubCodeSyncActivity({
 
         // If some files were updated as part of the sync, refresh the directory updatedAt.
         if (updatedDirectories[d.internalId]) {
-          githubCodeDirectory.updatedAt = codeSyncStartedAt;
+          githubCodeDirectory.codeUpdatedAt = codeSyncStartedAt;
         }
 
         // Update everything else.
@@ -1143,7 +1145,7 @@ export async function githubCodeSyncActivity({
 
     // Finally we update the repository updatedAt value.
     if (repoUpdatedAt) {
-      githubCodeRepository.updatedAt = repoUpdatedAt;
+      githubCodeRepository.codeUpdatedAt = repoUpdatedAt;
       await githubCodeRepository.save();
     }
   } finally {

--- a/connectors/src/lib/models/github.ts
+++ b/connectors/src/lib/models/github.ts
@@ -166,6 +166,7 @@ export class GithubCodeRepository extends Model<
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
   declare lastSeenAt: CreationOptional<Date>;
+  declare codeUpdatedAt: CreationOptional<Date>;
 
   declare repoId: string;
   declare repoLogin: string;
@@ -193,6 +194,11 @@ GithubCodeRepository.init(
       defaultValue: DataTypes.NOW,
     },
     lastSeenAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    codeUpdatedAt: {
       type: DataTypes.DATE,
       allowNull: false,
       defaultValue: DataTypes.NOW,
@@ -230,6 +236,7 @@ export class GithubCodeFile extends Model<
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
   declare lastSeenAt: CreationOptional<Date>;
+  declare codeUpdatedAt: CreationOptional<Date>;
 
   declare repoId: string;
   declare documentId: string;
@@ -259,6 +266,11 @@ GithubCodeFile.init(
       defaultValue: DataTypes.NOW,
     },
     lastSeenAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    codeUpdatedAt: {
       type: DataTypes.DATE,
       allowNull: false,
       defaultValue: DataTypes.NOW,
@@ -307,6 +319,7 @@ export class GithubCodeDirectory extends Model<
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
   declare lastSeenAt: CreationOptional<Date>;
+  declare codeUpdatedAt: CreationOptional<Date>;
 
   declare repoId: string;
   declare internalId: string;
@@ -335,6 +348,11 @@ GithubCodeDirectory.init(
       defaultValue: DataTypes.NOW,
     },
     lastSeenAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    codeUpdatedAt: {
       type: DataTypes.DATE,
       allowNull: false,
       defaultValue: DataTypes.NOW,


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/tasks/issues/348

- updatedAt is automatically updated by sequelize so we can't rely on it to display the last update time for file/directory/repo. Introduce a new field codeUpdatedAt on each of these 3 models and rely on it in getConnectorPermissions.

## Risk

None modulo migration deploy

## Deploy Plan

- Deploy connectors-edge and run init_db
- Deploy connectors