### PR TITLE
Implement Confluence continuous sync

### DIFF
--- a/connectors/src/connectors/confluence/index.ts
+++ b/connectors/src/connectors/confluence/index.ts
@@ -108,13 +108,15 @@ function createConnectorResourceFromSpace(
   baseUrl: string,
   permission: ConnectorPermission
 ): ConnectorResource {
+  const urlSuffix = "_links" in space ? space._links.webui : space.urlSuffix;
+
   return {
     provider: "confluence",
     internalId: space.id.toString(),
     parentInternalId: null,
     type: "folder",
     title: space.name || "Unnamed Space",
-    sourceUrl: `${baseUrl}/wiki${space.urlSuffix}`,
+    sourceUrl: `${baseUrl}/wiki${urlSuffix}`,
     expandable: false,
     permission: permission,
     dustDocumentId: null,

--- a/connectors/src/connectors/confluence/index.ts
+++ b/connectors/src/connectors/confluence/index.ts
@@ -12,8 +12,8 @@ import {
 } from "@connectors/connectors/confluence/lib/confluence_api";
 import type { ConfluenceSpaceType } from "@connectors/connectors/confluence/lib/confluence_client";
 import {
-  launchConfluenceFullSyncWorkflow,
   launchConfluenceRemoveSpacesSyncWorkflow,
+  launchConfluenceSyncWorkflow,
 } from "@connectors/connectors/confluence/temporal/client";
 import type { ConnectorPermissionRetriever } from "@connectors/connectors/interface";
 import { Connector, sequelize_conn } from "@connectors/lib/models";
@@ -77,9 +77,7 @@ export async function createConfluenceConnector(
       return connector;
     });
 
-    const workflowStarted = await launchConfluenceFullSyncWorkflow(
-      connector.id
-    );
+    const workflowStarted = await launchConfluenceSyncWorkflow(connector.id);
     if (workflowStarted.isErr()) {
       return new Err(workflowStarted.error);
     }
@@ -259,7 +257,7 @@ export async function setConfluenceConnectorPermissions(
 
   const addedSpacesResult = await startWorkflowIfNecessary(
     addedSpaceIds,
-    launchConfluenceFullSyncWorkflow,
+    launchConfluenceSyncWorkflow,
     connectorId
   );
   if (addedSpacesResult.isErr()) {

--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -2,6 +2,8 @@ import { isLeft } from "fp-ts/Either";
 import * as t from "io-ts";
 import { PathReporter } from "io-ts/PathReporter";
 
+import { HTTPError } from "@connectors/lib/error";
+
 const CatchAllCodec = t.record(t.string, t.unknown); // Catch-all for unknown properties.
 
 const ConfluenceAccessibleResourcesCodec = t.array(
@@ -98,8 +100,9 @@ export class ConfluenceClient {
     });
 
     if (!response.ok) {
-      throw new Error(
-        `Confluence API responded with status: ${response.status}: ${this.apiUrl}${endpoint}`
+      throw new HTTPError(
+        `Confluence API responded with status: ${response.status}: ${this.apiUrl}${endpoint}`,
+        response.status
       );
     }
 

--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -211,7 +211,7 @@ interface ConfluenceUpsertPageActivityInput {
   pageId: string;
   spaceId: string;
   spaceName: string;
-  upsert: boolean;
+  forceUpsert: boolean;
   visitedAtMs: number;
 }
 
@@ -223,7 +223,7 @@ export async function confluenceUpsertPageActivity({
   pageId,
   spaceId,
   spaceName,
-  upsert,
+  forceUpsert,
   visitedAtMs,
 }: ConfluenceUpsertPageActivityInput) {
   const loggerArgs = {
@@ -276,7 +276,7 @@ export async function confluenceUpsertPageActivity({
   const isSameVersion =
     pageAlreadyInDb && pageAlreadyInDb.version === page.version.number;
   // Only index in DB if the page does not exist or we want to upsert.
-  if (isSameVersion && !upsert) {
+  if (isSameVersion && !forceUpsert) {
     // Simply record that we visited the page.
     return upsertConfluencePageInDb(connectorId, page, visitedAtMs);
   }

--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -128,6 +128,10 @@ export async function confluenceGetSpaceNameActivity({
   connectionId: string;
   spaceId: string;
 }) {
+  const localLogger = logger.child({
+    spaceId,
+  });
+
   const client = await getConfluenceClient({
     cloudId: confluenceCloudId,
     connectionId: connectionId,
@@ -139,6 +143,8 @@ export async function confluenceGetSpaceNameActivity({
     return space.name;
   } catch (err) {
     if (isNotFoundError(err)) {
+      localLogger.info("Deleting stale Confluence space.");
+
       return null;
     }
 

--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -1,4 +1,5 @@
 import type { ModelId } from "@dust-tt/types";
+import { Op } from "sequelize";
 import TurndownService from "turndown";
 
 import { confluenceConfig } from "@connectors/connectors/confluence/lib/config";
@@ -16,6 +17,7 @@ import {
   renderMarkdownSection,
   upsertToDatasource,
 } from "@connectors/lib/data_sources";
+import { isNotFoundError } from "@connectors/lib/error";
 import { Connector } from "@connectors/lib/models";
 import {
   ConfluenceConfiguration,
@@ -131,9 +133,17 @@ export async function confluenceGetSpaceNameActivity({
     connectionId: connectionId,
   });
 
-  const space = await client.getSpaceById(spaceId);
+  try {
+    const space = await client.getSpaceById(spaceId);
 
-  return space.name;
+    return space.name;
+  } catch (err) {
+    if (isNotFoundError(err)) {
+      return null;
+    }
+
+    throw err;
+  }
 }
 
 export async function confluenceListPageIdsInSpaceActivity({
@@ -171,10 +181,54 @@ export async function confluenceListPageIdsInSpaceActivity({
 }
 
 async function upsertConfluencePageInDb(
-  connectionId: string,
-  dataSourceConfig: DataSourceConfig,
-  page: ConfluencePageWithBodyType
+  connectorId: ModelId,
+  page: ConfluencePageWithBodyType,
+  visitedAtMs: number
 ) {
+  await ConfluencePage.upsert({
+    connectorId,
+    pageId: page.id,
+    spaceId: page.spaceId,
+    parentId: page.parentId,
+    title: page.title,
+    externalUrl: page._links.tinyui,
+    version: page.version.number,
+    lastVisitedAt: new Date(visitedAtMs),
+  });
+}
+
+interface ConfluenceUpsertPageActivityInput {
+  connectionId: string;
+  connectorId: ModelId;
+  dataSourceConfig: DataSourceConfig;
+  isBatchSync: boolean;
+  pageId: string;
+  spaceId: string;
+  spaceName: string;
+  upsert: boolean;
+  visitedAtMs: number;
+}
+
+export async function confluenceUpsertPageActivity({
+  connectionId,
+  connectorId,
+  dataSourceConfig,
+  isBatchSync,
+  pageId,
+  spaceId,
+  spaceName,
+  upsert,
+  visitedAtMs,
+}: ConfluenceUpsertPageActivityInput) {
+  const loggerArgs = {
+    connectorId,
+    dataSourceName: dataSourceConfig.dataSourceName,
+    pageId,
+    spaceId,
+    workspaceId: dataSourceConfig.workspaceId,
+  };
+  const localLogger = logger.child(loggerArgs);
+
   const connector = await Connector.findOne({
     where: {
       connectionId,
@@ -186,45 +240,6 @@ async function upsertConfluencePageInDb(
   if (!connector) {
     throw new Error(`Connector not found (connectionId: ${connectionId})`);
   }
-
-  await ConfluencePage.upsert({
-    connectorId: connector.id,
-    pageId: page.id,
-    spaceId: page.spaceId,
-    parentId: page.parentId,
-    title: page.title,
-    externalUrl: page._links.tinyui,
-    version: page.version.number,
-  });
-}
-
-interface ConfluenceUpsertPageActivityInput {
-  spaceId: string;
-  spaceName: string;
-  pageId: string;
-  dataSourceConfig: DataSourceConfig;
-  isBatchSync: boolean;
-  connectionId: string;
-  connectorId: ModelId;
-}
-
-export async function confluenceUpsertPageActivity({
-  spaceId,
-  spaceName,
-  connectorId,
-  pageId,
-  dataSourceConfig,
-  connectionId,
-  isBatchSync,
-}: ConfluenceUpsertPageActivityInput) {
-  const loggerArgs = {
-    connectorId,
-    dataSourceName: dataSourceConfig.dataSourceName,
-    pageId,
-    spaceId,
-    workspaceId: dataSourceConfig.workspaceId,
-  };
-  const localLogger = logger.child(loggerArgs);
 
   const isPageSkipped = await isConfluencePageSkipped(connectorId, pageId);
   if (isPageSkipped) {
@@ -244,6 +259,22 @@ export async function confluenceUpsertPageActivity({
   localLogger.info("Upserting Confluence page.");
 
   const page = await client.getPageById(pageId);
+
+  const pageAlreadyInDb = await ConfluencePage.findOne({
+    attributes: ["version"],
+    where: {
+      connectorId,
+      pageId,
+    },
+  });
+  const isSameVersion =
+    pageAlreadyInDb && pageAlreadyInDb.version === page.version.number;
+  // Only index in DB if the page does not exist or we want to upsert.
+  if (isSameVersion && !upsert) {
+    // Simply record that we visited the page.
+    return upsertConfluencePageInDb(connectorId, page, visitedAtMs);
+  }
+
   const markdown = turndownService.turndown(page.body.storage.value);
   const pageCreatedAt = new Date(page.createdAt);
   const lastPageVersionCreatedAt = new Date(page.version.createdAt);
@@ -294,7 +325,44 @@ export async function confluenceUpsertPageActivity({
 
   localLogger.info("Upserting Confluence page in DB.");
 
-  await upsertConfluencePageInDb(connectionId, dataSourceConfig, page);
+  await upsertConfluencePageInDb(connector.id, page, visitedAtMs);
+}
+
+export async function confluenceRemoveUnvisitedPagesActivity({
+  connectorId,
+  lastVisitedAt,
+  spaceId,
+}: {
+  connectorId: ModelId;
+  lastVisitedAt: number;
+  spaceId: string;
+}) {
+  const connector = await Connector.findOne({
+    where: {
+      id: connectorId,
+    },
+  });
+  if (!connector) {
+    throw new Error(`Connector not found (id: ${connectorId})`);
+  }
+
+  const unvisitedPages = await ConfluencePage.findAll({
+    attributes: ["pageId"],
+    where: {
+      connectorId,
+      spaceId,
+      lastVisitedAt: {
+        [Op.ne]: new Date(lastVisitedAt),
+      },
+    },
+  });
+
+  const dataSourceConfig = dataSourceConfigFromConnector(connector);
+
+  for (const page of unvisitedPages) {
+    // TODO(2024-01-22 flav) Add an extra check to ensure that the page does not exist anymore in Confluence.
+    await deletePage(connectorId, page.pageId, dataSourceConfig);
+  }
 }
 
 async function deletePage(

--- a/connectors/src/connectors/confluence/temporal/client.ts
+++ b/connectors/src/connectors/confluence/temporal/client.ts
@@ -1,5 +1,6 @@
 import type { ModelId, Result } from "@dust-tt/types";
 import { Err, Ok } from "@dust-tt/types";
+import { ScheduleOptionsAction } from "@temporalio/client";
 
 import { QUEUE_NAME } from "@connectors/connectors/confluence/temporal/config";
 import type { SpaceUpdatesSignal } from "@connectors/connectors/confluence/temporal/signals";
@@ -55,6 +56,7 @@ export async function launchConfluenceFullSyncWorkflow(
       memo: {
         connectorId,
       },
+      cronSchedule: "0 * * * *", // Every hour.
     });
   } catch (err) {
     return new Err(err as Error);

--- a/connectors/src/connectors/confluence/temporal/client.ts
+++ b/connectors/src/connectors/confluence/temporal/client.ts
@@ -18,7 +18,8 @@ import { getTemporalClient } from "@connectors/lib/temporal";
 
 export async function launchConfluenceFullSyncWorkflow(
   connectorId: ModelId,
-  spaceIds: string[] = []
+  spaceIds: string[] = [],
+  upsert = false
 ): Promise<Result<undefined, Error>> {
   const connector = await Connector.findByPk(connectorId);
   if (!connector) {
@@ -41,6 +42,7 @@ export async function launchConfluenceFullSyncWorkflow(
           connectorId: connector.id,
           dataSourceConfig,
           connectionId: connector.connectionId,
+          upsert,
         },
       ],
       taskQueue: QUEUE_NAME,

--- a/connectors/src/connectors/confluence/temporal/client.ts
+++ b/connectors/src/connectors/confluence/temporal/client.ts
@@ -1,6 +1,5 @@
 import type { ModelId, Result } from "@dust-tt/types";
 import { Err, Ok } from "@dust-tt/types";
-import { ScheduleOptionsAction } from "@temporalio/client";
 
 import { QUEUE_NAME } from "@connectors/connectors/confluence/temporal/config";
 import type { SpaceUpdatesSignal } from "@connectors/connectors/confluence/temporal/signals";

--- a/connectors/src/connectors/confluence/temporal/client.ts
+++ b/connectors/src/connectors/confluence/temporal/client.ts
@@ -5,18 +5,18 @@ import { QUEUE_NAME } from "@connectors/connectors/confluence/temporal/config";
 import type { SpaceUpdatesSignal } from "@connectors/connectors/confluence/temporal/signals";
 import { spaceUpdatesSignal } from "@connectors/connectors/confluence/temporal/signals";
 import {
-  makeConfluenceFullSyncWorkflowId,
   makeConfluenceRemoveSpacesWorkflowId,
+  makeConfluenceSyncWorkflowId,
 } from "@connectors/connectors/confluence/temporal/utils";
 import {
-  confluenceFullSyncWorkflow,
   confluenceRemoveSpacesWorkflow,
+  confluenceSyncWorkflow,
 } from "@connectors/connectors/confluence/temporal/workflows";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { Connector } from "@connectors/lib/models";
 import { getTemporalClient } from "@connectors/lib/temporal";
 
-export async function launchConfluenceFullSyncWorkflow(
+export async function launchConfluenceSyncWorkflow(
   connectorId: ModelId,
   spaceIds: string[] = [],
   upsert = false
@@ -36,7 +36,7 @@ export async function launchConfluenceFullSyncWorkflow(
 
   // When the workflow is inactive, we omit passing spaceIds as they are only used to signal modifications within a currently active full sync workflow.
   try {
-    await client.workflow.signalWithStart(confluenceFullSyncWorkflow, {
+    await client.workflow.signalWithStart(confluenceSyncWorkflow, {
       args: [
         {
           connectorId: connector.id,
@@ -46,7 +46,7 @@ export async function launchConfluenceFullSyncWorkflow(
         },
       ],
       taskQueue: QUEUE_NAME,
-      workflowId: makeConfluenceFullSyncWorkflowId(connector.id),
+      workflowId: makeConfluenceSyncWorkflowId(connector.id),
       searchAttributes: {
         connectorId: [connectorId],
       },

--- a/connectors/src/connectors/confluence/temporal/client.ts
+++ b/connectors/src/connectors/confluence/temporal/client.ts
@@ -19,7 +19,7 @@ import { getTemporalClient } from "@connectors/lib/temporal";
 export async function launchConfluenceSyncWorkflow(
   connectorId: ModelId,
   spaceIds: string[] = [],
-  upsert = false
+  forceUpsert = false
 ): Promise<Result<undefined, Error>> {
   const connector = await Connector.findByPk(connectorId);
   if (!connector) {
@@ -42,7 +42,7 @@ export async function launchConfluenceSyncWorkflow(
           connectorId: connector.id,
           dataSourceConfig,
           connectionId: connector.connectionId,
-          upsert,
+          forceUpsert,
         },
       ],
       taskQueue: QUEUE_NAME,

--- a/connectors/src/connectors/confluence/temporal/utils.ts
+++ b/connectors/src/connectors/confluence/temporal/utils.ts
@@ -1,7 +1,7 @@
 import type { ModelId } from "@dust-tt/types";
 
-export function makeConfluenceFullSyncWorkflowId(connectorId: ModelId) {
-  return `confluence-fullsync-${connectorId}`;
+export function makeConfluenceSyncWorkflowId(connectorId: ModelId) {
+  return `confluence-sync-${connectorId}`;
 }
 
 export function makeConfluenceSpaceSyncWorkflowIdFromParentId(

--- a/connectors/src/connectors/confluence/temporal/workflows.ts
+++ b/connectors/src/connectors/confluence/temporal/workflows.ts
@@ -1,4 +1,5 @@
 import type { ModelId } from "@dust-tt/types";
+import type { WorkflowInfo } from "@temporalio/workflow";
 import {
   executeChild,
   proxyActivities,
@@ -20,6 +21,7 @@ import {
 const {
   confluenceGetSpaceNameActivity,
   confluenceListPageIdsInSpaceActivity,
+  confluenceRemoveUnvisitedPagesActivity,
   confluenceRemoveSpaceActivity,
   confluenceSaveStartSyncActivity,
   confluenceSaveSuccessSyncActivity,
@@ -36,11 +38,13 @@ export async function confluenceFullSyncWorkflow({
   connectorId,
   dataSourceConfig,
   spaceIdsToBrowse,
+  upsert = false,
 }: {
   connectionId: string;
   connectorId: ModelId;
   dataSourceConfig: DataSourceConfig;
   spaceIdsToBrowse?: string[];
+  upsert: boolean;
 }) {
   await confluenceSaveStartSyncActivity(connectorId);
 
@@ -86,6 +90,7 @@ export async function confluenceFullSyncWorkflow({
             dataSourceConfig,
             isBatchSync: true,
             spaceId,
+            upsert,
           },
         ],
         memo,
@@ -105,12 +110,16 @@ interface ConfluenceSpaceSyncWorkflowInput {
   dataSourceConfig: DataSourceConfig;
   isBatchSync: boolean;
   spaceId: string;
+  upsert: boolean;
 }
 
 export async function confluenceSpaceSyncWorkflow(
   params: ConfluenceSpaceSyncWorkflowInput
 ) {
   const uniquePageIds = new Set<string>();
+  const visitedAtMs = new Date().getTime();
+
+  const { connectorId, spaceId } = params;
 
   const confluenceConfig = await fetchConfluenceConfigurationActivity(
     params.connectorId
@@ -122,6 +131,11 @@ export async function confluenceSpaceSyncWorkflow(
     ...params,
     confluenceCloudId: confluenceConfig?.cloudId,
   });
+  // If the space does not exist, launch a workflow to remove the space.
+  if (spaceName === null) {
+    const wInfo = workflowInfo();
+    return startConfluenceRemoveSpaceWorkflow(wInfo, connectorId, spaceId);
+  }
 
   // Retrieve and loop through all pages for a given space.
   let nextPageCursor: string | null = "";
@@ -144,10 +158,44 @@ export async function confluenceSpaceSyncWorkflow(
       ...params,
       spaceName,
       pageId,
+      visitedAtMs,
     });
   }
 
+  await confluenceRemoveUnvisitedPagesActivity({
+    connectorId,
+    lastVisitedAt: visitedAtMs,
+    spaceId,
+  });
+
   return uniquePageIds.size;
+}
+
+async function startConfluenceRemoveSpaceWorkflow(
+  parentWorkflowInfo: WorkflowInfo,
+  connectorId: ModelId,
+  spaceId: string
+) {
+  const {
+    memo,
+    searchAttributes: parentSearchAttributes,
+    workflowId,
+  } = parentWorkflowInfo;
+
+  await executeChild(confluenceRemoveSpaceWorkflow, {
+    workflowId: makeConfluenceRemoveSpaceWorkflowIdFromParentId(
+      workflowId,
+      spaceId
+    ),
+    searchAttributes: parentSearchAttributes,
+    args: [
+      {
+        connectorId,
+        spaceId,
+      },
+    ],
+    memo,
+  });
 }
 
 // TODO(2024-01-19 flav) Build a factory to make workspace with a signal handler.
@@ -171,11 +219,7 @@ export async function confluenceRemoveSpacesWorkflow({
     }
   });
 
-  const {
-    workflowId,
-    searchAttributes: parentSearchAttributes,
-    memo,
-  } = workflowInfo();
+  const wInfo = workflowInfo();
 
   // Async operations allow Temporal's event loop to process signals.
   // If a signal arrives during an async operation, it will update the set before the next iteration.
@@ -184,20 +228,7 @@ export async function confluenceRemoveSpacesWorkflow({
     const spaceIdsToProcess = new Set(uniqueSpaceIds);
     for (const spaceId of spaceIdsToProcess) {
       // Async operation yielding control to the Temporal runtime.
-      await executeChild(confluenceRemoveSpaceWorkflow, {
-        workflowId: makeConfluenceRemoveSpaceWorkflowIdFromParentId(
-          workflowId,
-          spaceId
-        ),
-        searchAttributes: parentSearchAttributes,
-        args: [
-          {
-            connectorId,
-            spaceId,
-          },
-        ],
-        memo,
-      });
+      await startConfluenceRemoveSpaceWorkflow(wInfo, connectorId, spaceId);
 
       // Remove the processed space from the original set after the async operation.
       uniqueSpaceIds.delete(spaceId);

--- a/connectors/src/connectors/confluence/temporal/workflows.ts
+++ b/connectors/src/connectors/confluence/temporal/workflows.ts
@@ -38,13 +38,13 @@ export async function confluenceSyncWorkflow({
   connectorId,
   dataSourceConfig,
   spaceIdsToBrowse,
-  upsert = false,
+  forceUpsert = false,
 }: {
   connectionId: string;
   connectorId: ModelId;
   dataSourceConfig: DataSourceConfig;
   spaceIdsToBrowse?: string[];
-  upsert: boolean;
+  forceUpsert: boolean;
 }) {
   await confluenceSaveStartSyncActivity(connectorId);
 
@@ -90,7 +90,7 @@ export async function confluenceSyncWorkflow({
             dataSourceConfig,
             isBatchSync: true,
             spaceId,
-            upsert,
+            forceUpsert,
           },
         ],
         memo,
@@ -110,7 +110,7 @@ interface ConfluenceSpaceSyncWorkflowInput {
   dataSourceConfig: DataSourceConfig;
   isBatchSync: boolean;
   spaceId: string;
-  upsert: boolean;
+  forceUpsert: boolean;
 }
 
 export async function confluenceSpaceSyncWorkflow(

--- a/connectors/src/connectors/confluence/temporal/workflows.ts
+++ b/connectors/src/connectors/confluence/temporal/workflows.ts
@@ -33,7 +33,7 @@ const {
   startToCloseTimeout: "20 minutes",
 });
 
-export async function confluenceFullSyncWorkflow({
+export async function confluenceSyncWorkflow({
   connectionId,
   connectorId,
   dataSourceConfig,

--- a/connectors/src/lib/error.ts
+++ b/connectors/src/lib/error.ts
@@ -51,10 +51,18 @@ export class HTTPError extends Error {
   }
 }
 
+export interface NotFoundError extends HTTPError {
+  statusCode: 404;
+}
+
 // This error is thrown when we are dealing with a revoked OAuth token.
 export class ExternalOauthTokenError extends Error {
   constructor(readonly innerError?: Error) {
     super(innerError?.message);
     this.name = "ExternalOauthTokenError";
   }
+}
+
+export function isNotFoundError(err: unknown): err is NotFoundError {
+  return err instanceof HTTPError && err.statusCode === 404;
 }

--- a/connectors/src/lib/models/confluence.ts
+++ b/connectors/src/lib/models/confluence.ts
@@ -118,6 +118,7 @@ export class ConfluencePage extends Model<
   declare id: CreationOptional<number>;
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
+  declare lastVisitedAt: CreationOptional<Date>;
 
   declare externalUrl: string;
   declare pageId: string;
@@ -142,6 +143,11 @@ ConfluencePage.init(
       defaultValue: DataTypes.NOW,
     },
     updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    lastVisitedAt: {
       type: DataTypes.DATE,
       allowNull: false,
       defaultValue: DataTypes.NOW,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Currently, Confluence doesn't support webhook creation through their REST API. There's an internal endpoint available, but it's not accessible with a Bearer token. To overcome this limitation, a potential solution is to develop our own Atlassian add-on that would serve as a proxy, funneling webhook events to our infrastructure.

However, since our Confluence connector isn't actively used by customers yet, this PR adopts a more straightforward method. It sets up a process to periodically poll the Confluence API (every hour) to synchronize data with Dust. While this method could be optimized further, for instance, by ordering pages by the date of modification rather than by ID, the current strategy is to maintain simplicity and ensure no updates are missed. We sort by ID for a deterministic order.

This synchronization relies on Temporal's cron scheduling to guarantee that only one Confluence workflow per workspace is running at any given time. These workflows are initiated hourly. If a workflow for a workspace is already in progress, the system will not start another, allowing the existing one to continue uninterrupted.

A MySQL migration is part of this PR because it introduces a new column, `lastVisitedAt`. This is essential for tracking which pages no longer exist, under the assumption that the API always returns all pages from a space. So we can safely remove those from Dust infrastructure.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Merge this PR, apply the migration from `connectors-edge` and then deploy.
<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
