### PR TITLE
front: fix navigation for builders

### DIFF
--- a/front/components/sparkle/navigation.tsx
+++ b/front/components/sparkle/navigation.tsx
@@ -105,12 +105,14 @@ export const topNavigation = ({
       current: current === "assistants",
       sizing: "expand",
     });
+  }
+  if (isAdmin(owner)) {
     nav.push({
       id: "settings",
       label: "Admin",
       hideLabel: true,
       icon: Cog6ToothIcon,
-      href: isAdmin(owner) ? `/w/${owner.sId}/members` : `/w/${owner.sId}/a`,
+      href: `/w/${owner.sId}/members`,
       current: current === "admin",
       sizing: "hug",
     });


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/tasks/issues/353

Admin was visible for builders (but would redirect to apps)

## Risk

N/A

## Deploy Plan

- deploy front