### PR TITLE
Intercom Connector: core functions

### DIFF
--- a/connectors/src/connectors/index.ts
+++ b/connectors/src/connectors/index.ts
@@ -35,13 +35,15 @@ import { launchGoogleDriveFullSyncWorkflow } from "@connectors/connectors/google
 import {
   cleanupIntercomConnector,
   createIntercomConnector,
-  fullResyncIntercomConnector,
   resumeIntercomConnector,
   retrieveIntercomConnectorPermissions,
+  retrieveIntercomObjectsParents,
   retrieveIntercomResourcesTitles,
+  setIntercomConnectorPermissions,
   stopIntercomConnector,
   updateIntercomConnector,
 } from "@connectors/connectors/intercom";
+import { launchIntercomHelpCentersSyncWorkflow } from "@connectors/connectors/intercom/temporal/client";
 import type {
   ConnectorBatchResourceTitleRetriever,
   ConnectorCleaner,
@@ -190,7 +192,7 @@ export const SYNC_CONNECTOR_BY_TYPE: Record<ConnectorProvider, SyncConnector> =
     notion: fullResyncNotionConnector,
     github: fullResyncGithubConnector,
     google_drive: launchGoogleDriveFullSyncWorkflow,
-    intercom: fullResyncIntercomConnector,
+    intercom: launchIntercomHelpCentersSyncWorkflow,
     webcrawler: (connectorId: string) =>
       launchCrawlWebsiteWorkflow(parseInt(connectorId)),
   };
@@ -225,13 +227,7 @@ export const SET_CONNECTOR_PERMISSIONS_BY_TYPE: Record<
     );
   },
   google_drive: setGoogleDriveConnectorPermissions,
-  intercom: async () => {
-    return new Err(
-      new Error(
-        `Setting Intercom connector permissions is not implemented yet.`
-      )
-    );
-  },
+  intercom: setIntercomConnectorPermissions,
   webcrawler: async () => {
     return new Err(
       new Error(`Setting Webcrawler connector permissions is not applicable.`)
@@ -261,7 +257,7 @@ export const RETRIEVE_RESOURCE_PARENTS_BY_TYPE: Record<
   google_drive: retrieveGoogleDriveObjectsParents,
   slack: async () => new Ok([]), // Slack is flat
   github: async () => new Ok([]), // Github is flat,
-  intercom: async () => new Ok([]), // Intercom is not truly flat as we can put articles & collections inside collections but will handle this later
+  intercom: retrieveIntercomObjectsParents,
   webcrawler: retrieveWebCrawlerObjectsParents,
 };
 

--- a/connectors/src/connectors/intercom/index.ts
+++ b/connectors/src/connectors/intercom/index.ts
@@ -1,10 +1,30 @@
-import type { ModelId } from "@dust-tt/types";
+import type { ConnectorPermission, ModelId, Result } from "@dust-tt/types";
+import { Op } from "sequelize";
 
-import { validateAccessToken } from "@connectors/connectors/intercom/lib/intercom_api";
+import {
+  allowSyncCollection,
+  allowSyncHelpCenter,
+  retrieveIntercomHelpCentersPermissions,
+  revokeSyncCollection,
+  revokeSyncHelpCenter,
+} from "@connectors/connectors/intercom/lib/help_center_permissions";
+import {
+  fetchIntercomWorkspaceId,
+  getIntercomClient,
+} from "@connectors/connectors/intercom/lib/intercom_api";
+import {
+  launchIntercomHelpCentersSyncWorkflow,
+  stopIntercomHelpCentersSyncWorkflow,
+} from "@connectors/connectors/intercom/temporal/client";
 import type { ConnectorPermissionRetriever } from "@connectors/connectors/interface";
-import { Connector } from "@connectors/lib/models";
-import { getAccessTokenFromNango } from "@connectors/lib/nango_helpers";
-import type { Result } from "@connectors/lib/result";
+import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
+import { Connector, sequelize_conn } from "@connectors/lib/models";
+import {
+  IntercomArticle,
+  IntercomCollection,
+  IntercomHelpCenter,
+} from "@connectors/lib/models/intercom";
+import { nangoDeleteConnection } from "@connectors/lib/nango_client";
 import { Err, Ok } from "@connectors/lib/result";
 import logger from "@connectors/logger/logger";
 import type { DataSourceConfig } from "@connectors/types/data_source_config";
@@ -24,16 +44,6 @@ export async function createIntercomConnector(
     throw new Error("NANGO_INTERCOM_CONNECTOR_ID not set");
   }
 
-  const accessToken = await getAccessTokenFromNango({
-    connectionId: nangoConnectionId,
-    integrationId: NANGO_INTERCOM_CONNECTOR_ID,
-    useCache: false,
-  });
-
-  if (!validateAccessToken(accessToken)) {
-    return new Err(new Error("Intercom access token is invalid"));
-  }
-
   try {
     const connector = await Connector.create({
       type: "intercom",
@@ -42,10 +52,13 @@ export async function createIntercomConnector(
       workspaceId: dataSourceConfig.workspaceId,
       dataSourceName: dataSourceConfig.dataSourceName,
     });
-    // @todo Daph lauch workflow await launchIntercomSyncWorkflow(connector.id);
-    return new Ok(connector.id.toString());
+
+    const connectorIdAsString = connector.id.toString();
+    await launchIntercomHelpCentersSyncWorkflow(connectorIdAsString);
+
+    return new Ok(connectorIdAsString);
   } catch (e) {
-    logger.error({ error: e }, "Error creating Intercom connector.");
+    logger.error({ error: e }, "[Intercom] Error creating connector.");
     return new Err(e as Error);
   }
 }
@@ -58,53 +71,353 @@ export async function updateIntercomConnector(
     connectionId?: NangoConnectionId | null;
   }
 ): Promise<Result<string, ConnectorsAPIErrorResponse>> {
-  console.log({ connectorId, connectionId });
-  throw new Error("Not implemented");
+  if (!NANGO_INTERCOM_CONNECTOR_ID) {
+    throw new Error("NANGO_INTERCOM_CONNECTOR_ID not set");
+  }
+
+  const connector = await Connector.findByPk(connectorId);
+  if (!connector) {
+    logger.error({ connectorId }, "[Intercom] Connector not found.");
+    return new Err({
+      error: {
+        message: "Connector not found",
+        type: "connector_not_found",
+      },
+    });
+  }
+
+  if (connectionId) {
+    const oldConnectionId = connector.connectionId;
+    const oldIntercomWorkspaceId = await fetchIntercomWorkspaceId(
+      oldConnectionId
+    );
+
+    const newConnectionId = connectionId;
+    const newIntercomWorkspaceId = await fetchIntercomWorkspaceId(
+      newConnectionId
+    );
+
+    if (!oldIntercomWorkspaceId || !newIntercomWorkspaceId) {
+      return new Err({
+        error: {
+          type: "connector_update_error",
+          message: "Error retrieving nango connection info to update connector",
+        },
+      });
+    }
+    if (oldIntercomWorkspaceId !== newIntercomWorkspaceId) {
+      nangoDeleteConnection(newConnectionId, NANGO_INTERCOM_CONNECTOR_ID).catch(
+        (e) => {
+          logger.error(
+            { error: e, oldConnectionId },
+            "Error deleting old Nango connection"
+          );
+        }
+      );
+      return new Err({
+        error: {
+          type: "connector_oauth_target_mismatch",
+          message: "Cannot change workspace of a Notion connector",
+        },
+      });
+    }
+
+    await connector.update({
+      connectionId: newConnectionId,
+    });
+    nangoDeleteConnection(oldConnectionId, NANGO_INTERCOM_CONNECTOR_ID).catch(
+      (e) => {
+        logger.error(
+          { error: e, oldConnectionId },
+          "Error deleting old Nango connection"
+        );
+      }
+    );
+  }
+  return new Ok(connector.id.toString());
 }
 
 export async function cleanupIntercomConnector(
   connectorId: string
 ): Promise<Result<void, Error>> {
-  console.log({ connectorId });
-  throw new Error("Not implemented");
+  if (!NANGO_INTERCOM_CONNECTOR_ID) {
+    throw new Error("INTERCOM_NANGO_CONNECTOR_ID not set");
+  }
+
+  const connector = await Connector.findOne({
+    where: { type: "intercom", id: connectorId },
+  });
+  if (!connector) {
+    logger.error({ connectorId }, "Intercom connector not found.");
+    return new Err(new Error("Connector not found"));
+  }
+
+  return sequelize_conn.transaction(async (transaction) => {
+    await Promise.all([
+      IntercomHelpCenter.destroy({
+        where: {
+          connectorId: connector.id,
+        },
+        transaction: transaction,
+      }),
+      IntercomCollection.destroy({
+        where: {
+          connectorId: connector.id,
+        },
+        transaction: transaction,
+      }),
+      IntercomArticle.destroy({
+        where: {
+          connectorId: connector.id,
+        },
+        transaction: transaction,
+      }),
+    ]);
+
+    const nangoRes = await nangoDeleteConnection(
+      connector.connectionId,
+      NANGO_INTERCOM_CONNECTOR_ID
+    );
+    if (nangoRes.isErr()) {
+      throw nangoRes.error;
+    }
+
+    await connector.destroy({
+      transaction: transaction,
+    });
+
+    return new Ok(undefined);
+  });
 }
 
 export async function stopIntercomConnector(
   connectorId: string
 ): Promise<Result<string, Error>> {
-  console.log({ connectorId });
-  throw new Error("Not implemented");
+  const res = await stopIntercomHelpCentersSyncWorkflow(connectorId);
+  if (res.isErr()) {
+    return res;
+  }
+
+  return new Ok(connectorId);
 }
 
 export async function resumeIntercomConnector(
   connectorId: string
 ): Promise<Result<string, Error>> {
-  console.log({ connectorId });
-  throw new Error("Not implemented");
-}
+  const connector = await Connector.findByPk(connectorId);
+  if (!connector) {
+    logger.error({ connectorId }, "[Intercom] Connector not found.");
+    return new Err(new Error("Connector not found"));
+  }
 
-export async function fullResyncIntercomConnector(
-  connectorId: string,
-  fromTs: number | null
-): Promise<Result<string, Error>> {
-  console.log({ connectorId, fromTs });
-  throw new Error("Not implemented");
+  const dataSourceConfig = dataSourceConfigFromConnector(connector);
+  try {
+    await launchIntercomHelpCentersSyncWorkflow(connectorId);
+  } catch (e) {
+    logger.error(
+      {
+        workspaceId: dataSourceConfig.workspaceId,
+        dataSourceName: dataSourceConfig.dataSourceName,
+        error: e,
+      },
+      "Error launching Intercom sync workflow."
+    );
+  }
+
+  return new Ok(connector.id.toString());
 }
 
 export async function retrieveIntercomConnectorPermissions({
   connectorId,
   parentInternalId,
+  filterPermission,
 }: Parameters<ConnectorPermissionRetriever>[0]): Promise<
   Result<ConnectorResource[], Error>
 > {
-  console.log({ connectorId, parentInternalId });
-  throw new Error("Not implemented");
+  const connector = await Connector.findByPk(connectorId);
+  if (!connector) {
+    logger.error({ connectorId }, "[Intercom] Connector not found.");
+    return new Err(new Error("Connector not found"));
+  }
+
+  try {
+    const resources = await retrieveIntercomHelpCentersPermissions({
+      connectorId,
+      parentInternalId,
+      filterPermission,
+    });
+    return new Ok(resources);
+  } catch (e) {
+    return new Err(e as Error);
+  }
+}
+
+export async function setIntercomConnectorPermissions(
+  connectorId: ModelId,
+  permissions: Record<string, ConnectorPermission>
+): Promise<Result<void, Error>> {
+  const connector = await Connector.findByPk(connectorId);
+  if (!connector) {
+    logger.error({ connectorId }, "[Intercom] Connector not found.");
+    return new Err(new Error("Connector not found"));
+  }
+
+  const intercomClient = await getIntercomClient(connector.connectionId);
+  try {
+    for (const [id, permission] of Object.entries(permissions)) {
+      if (permission !== "none" && permission !== "read") {
+        return new Err(
+          new Error(
+            `Invalid permission ${permission} for connector ${connectorId}`
+          )
+        );
+      }
+      if (id.startsWith("help_center_")) {
+        const helpCenterId = id.replace("help_center_", "");
+        if (permission === "none") {
+          await revokeSyncHelpCenter({
+            connector,
+            intercomClient,
+            helpCenterId,
+          });
+        }
+        if (permission === "read") {
+          await allowSyncHelpCenter({
+            connector,
+            intercomClient,
+            helpCenterId,
+            withChildren: true,
+          });
+        }
+      } else if (id.startsWith("collection_")) {
+        const collectionId = id.replace("collection_", "");
+        if (permission === "none") {
+          await revokeSyncCollection({
+            connector,
+            collectionId,
+          });
+        }
+        if (permission === "read") {
+          await allowSyncCollection({
+            connector,
+            intercomClient,
+            collectionId,
+          });
+        }
+      }
+    }
+    return new Ok(undefined);
+  } catch (e) {
+    logger.error(
+      {
+        connectorId: connectorId,
+        error: e,
+      },
+      "Error setting connector permissions."
+    );
+    return new Err(new Error("Error setting permissions"));
+  }
 }
 
 export async function retrieveIntercomResourcesTitles(
   connectorId: ModelId,
   internalIds: string[]
 ): Promise<Result<Record<string, string | null>, Error>> {
-  console.log({ connectorId, internalIds });
-  throw new Error("Not implemented");
+  const [helpCenters, collections, articles] = await Promise.all([
+    IntercomHelpCenter.findAll({
+      where: {
+        connectorId: connectorId,
+        helpCenterId: {
+          [Op.in]: internalIds,
+        },
+      },
+    }),
+    IntercomCollection.findAll({
+      where: {
+        connectorId: connectorId,
+        collectionId: {
+          [Op.in]: internalIds,
+        },
+      },
+    }),
+    IntercomArticle.findAll({
+      where: {
+        connectorId: connectorId,
+        articleId: {
+          [Op.in]: internalIds,
+        },
+      },
+    }),
+  ]);
+
+  const titles: Record<string, string> = {};
+  for (const helpCenter of helpCenters) {
+    titles[`help_center_${helpCenter.helpCenterId}`] = helpCenter.name;
+  }
+  0;
+  for (const collection of collections) {
+    titles[`collection_${collection.collectionId}`] = collection.name;
+  }
+  for (const article of articles) {
+    titles[`article_${article.articleId}`] = article.title;
+  }
+
+  return new Ok(titles);
+}
+
+export async function retrieveIntercomObjectsParents(
+  connectorId: ModelId,
+  internalId: string
+): Promise<Result<string[], Error>> {
+  if (internalId.startsWith("help_center_")) {
+    return new Ok([]);
+  }
+
+  const parents: string[] = [];
+  let collection = null;
+
+  if (internalId.startsWith("collection_")) {
+    collection = await IntercomCollection.findOne({
+      where: {
+        connectorId: connectorId,
+        collectionId: internalId.replace("collection_", ""),
+      },
+    });
+  } else if (internalId.startsWith("article_")) {
+    const article = await IntercomArticle.findOne({
+      where: {
+        connectorId: connectorId,
+        articleId: internalId.replace("article_", ""),
+      },
+    });
+    if (article && article.parentType === "collection" && article.parentId) {
+      parents.push(`collection_${article.parentId}`);
+      collection = await IntercomCollection.findOne({
+        where: {
+          connectorId: connectorId,
+          collectionId: article.parentId,
+        },
+      });
+    }
+  }
+
+  if (collection && collection.parentId) {
+    parents.push(`collection_${collection.parentId}`);
+    const parentCollection = await IntercomCollection.findOne({
+      where: {
+        connectorId: connectorId,
+        collectionId: collection.parentId,
+      },
+    });
+    if (parentCollection && parentCollection.parentId) {
+      parents.push(`collection_${parentCollection.parentId}`);
+    }
+    // we can stop here as Intercom has max 3 levels of collections
+  }
+
+  if (collection && collection.helpCenterId) {
+    parents.push(`help_center_${collection.helpCenterId}`);
+  }
+
+  return new Ok(parents);
 }


### PR DESCRIPTION
This PR fills all the lib functions of the connector that were not implemented (start/stop/resume/get & set permission, ...)
Follows https://github.com/dust-tt/dust/pull/3359

// A Help Center contains collections and articles:
// - Level 1: Collections (parent_id is null)
// - Level 2: Collections (parent_id is a level 1 collection)
// - Level 3: Collections (parent_id is a level 2 collection)
// Articles can be put in any collection (level 1, 2 or 3), or none. If none we don't sync them.
// On Intercom API:
// - a collection is attached to a helpCenterId and a parent_id (which is a collectionId).
// - an article is attached to an optional parentId (which is a collectionId) and the list of parents are available on parentsId.

In terms of granularity, we allow selecting either the full Help Center, or a selection of the top level Collections of a Help Center.

