### PR TITLE
Double cancel/save action in new assistant builder

### DIFF
--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -609,6 +609,32 @@ export default function AssistantBuilder({
     return newAgentConfiguration;
   };
 
+  const onAssistantCancel = async () => {
+    if (flow === "workspace_assistants")
+      await router.push(`/w/${owner.sId}/builder/assistants`);
+    else await router.push(`/w/${owner.sId}/assistant/assistants`);
+  };
+
+  const onAssistantSave = async () => {
+    setIsSavingOrDeleting(true);
+    submitForm()
+      .then(async () => {
+        if (flow === "workspace_assistants")
+          await router.push(`/w/${owner.sId}/builder/assistants`);
+        else await router.push(`/w/${owner.sId}/assistant/assistants`);
+        setIsSavingOrDeleting(false);
+      })
+      .catch((e) => {
+        console.error(e);
+        sendNotification({
+          title: "Error saving Assistant",
+          description: `Please try again. If the error persists, reach out to team@dust.tt (error ${e.message})`,
+          type: "error",
+        });
+        setIsSavingOrDeleting(false);
+      });
+  };
+
   return (
     <>
       <AssistantBuilderDataSourceModal
@@ -710,39 +736,8 @@ export default function AssistantBuilder({
           ) : (
             <AppLayoutSimpleSaveCancelTitle
               title="Edit an Assistant"
-              onCancel={async () => {
-                if (flow === "workspace_assistants")
-                  await router.push(`/w/${owner.sId}/builder/assistants`);
-                else await router.push(`/w/${owner.sId}/assistant/assistants`);
-              }}
-              onSave={
-                submitEnabled
-                  ? () => {
-                      setIsSavingOrDeleting(true);
-                      submitForm()
-                        .then(async () => {
-                          if (flow === "workspace_assistants")
-                            await router.push(
-                              `/w/${owner.sId}/builder/assistants`
-                            );
-                          else
-                            await router.push(
-                              `/w/${owner.sId}/assistant/assistants`
-                            );
-                          setIsSavingOrDeleting(false);
-                        })
-                        .catch((e) => {
-                          console.error(e);
-                          sendNotification({
-                            title: "Error saving Assistant",
-                            description: `Please try again. If the error persists, reach out to team@dust.tt (error ${e.message})`,
-                            type: "error",
-                          });
-                          setIsSavingOrDeleting(false);
-                        });
-                    }
-                  : undefined
-              }
+              onCancel={onAssistantCancel}
+              onSave={submitEnabled ? onAssistantSave : undefined}
               isSaving={isSavingOrDeleting}
             />
           )
@@ -1230,7 +1225,7 @@ export default function AssistantBuilder({
             </div>
           </div>
 
-          {agentConfigurationId && (
+          {agentConfigurationId ? (
             <div className="flex w-full justify-center pt-8">
               <DeleteAssistantDialog
                 owner={owner}
@@ -1251,6 +1246,24 @@ export default function AssistantBuilder({
                   setShowDeletionModal(true);
                 }}
               />
+            </div>
+          ) : (
+            <div className="flex w-full justify-end pt-4">
+              <Button.List>
+                <Button
+                  size="md"
+                  variant="secondaryWarning"
+                  label="Cancel"
+                  onClick={onAssistantCancel}
+                />
+                <Button
+                  size="md"
+                  variant="primary"
+                  label="Save"
+                  disabled={!submitEnabled}
+                  onClick={onAssistantSave}
+                />
+              </Button.List>
             </div>
           )}
         </div>

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -1225,8 +1225,8 @@ export default function AssistantBuilder({
             </div>
           </div>
 
-          {agentConfigurationId ? (
-            <div className="flex w-full justify-center pt-8">
+          {agentConfigurationId && (
+            <div className="flex w-full justify-start pt-8">
               <DeleteAssistantDialog
                 owner={owner}
                 agentConfigurationId={agentConfigurationId}
@@ -1247,25 +1247,24 @@ export default function AssistantBuilder({
                 }}
               />
             </div>
-          ) : (
-            <div className="flex w-full justify-end pt-4">
-              <Button.List>
-                <Button
-                  size="md"
-                  variant="secondaryWarning"
-                  label="Cancel"
-                  onClick={onAssistantCancel}
-                />
-                <Button
-                  size="md"
-                  variant="primary"
-                  label="Save"
-                  disabled={!submitEnabled}
-                  onClick={onAssistantSave}
-                />
-              </Button.List>
-            </div>
           )}
+          <div className="flex w-full justify-end pt-4">
+            <Button.List>
+              <Button
+                size="md"
+                variant="tertiary"
+                label="Cancel"
+                onClick={onAssistantCancel}
+              />
+              <Button
+                size="md"
+                variant="primary"
+                label="Save"
+                disabled={!edited || !submitEnabled}
+                onClick={onAssistantSave}
+              />
+            </Button.List>
+          </div>
         </div>
       </AppLayout>
     </>


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/decisions/issues/150

Adds a cancel/save pair of button at the bottom of the Assistant Builder when creating a new assistant. Did not add it when editing an assistant since we already have a Delete Assistant button there.

![Screenshot from 2024-01-22 18-08-57](https://github.com/dust-tt/dust/assets/15067/36eb00bd-e8fc-4910-a00b-7356683b8538)
![Screenshot from 2024-01-22 18-09-04](https://github.com/dust-tt/dust/assets/15067/91493f84-b3cd-412c-ae9b-ab6ce26de93f)
![Screenshot from 2024-01-22 18-09-10](https://github.com/dust-tt/dust/assets/15067/127345b3-6385-4fe2-9940-d6a0bc9ae47d)


## Risk

N/A

## Deploy Plan

- deploy front