### PR TITLE
Add connectors temporal namespace to front production checks

### DIFF
--- a/front/lib/temporal.ts
+++ b/front/lib/temporal.ts
@@ -26,7 +26,7 @@ export async function getTemporalClientForNamespace(
   const connection = await Connection.connect(connectionOptions);
   const client = new Client({
     connection,
-    namespace: process.env.TEMPORAL_NAMESPACE,
+    namespace: process.env[envVarForTemporalNamespace],
   });
   TEMPORAL_CLIENTS[namespace] = client;
 
@@ -53,7 +53,7 @@ async function getConnectionOptions(
   const TEMPORAL_NAMESPACE = process.env[envVarForTemporalNamespace];
   if (!TEMPORAL_CERT_PATH || !TEMPORAL_CERT_KEY_PATH || !TEMPORAL_NAMESPACE) {
     throw new Error(
-      "TEMPORAL_CERT_PATH, TEMPORAL_CERT_KEY_PATH and TEMPORAL_NAMESPACE are required " +
+      `TEMPORAL_CERT_PATH, TEMPORAL_CERT_KEY_PATH and ${envVarForTemporalNamespace} are required ` +
         `when NODE_ENV=${NODE_ENV}, but not found in the environment`
     );
   }

--- a/front/lib/temporal.ts
+++ b/front/lib/temporal.ts
@@ -1,5 +1,6 @@
 import type { ConnectionOptions } from "@temporalio/client";
 import { Client, Connection } from "@temporalio/client";
+import { NativeConnection } from "@temporalio/worker";
 import fs from "fs-extra";
 
 type TemporalNamespaces = "connectors" | "front";
@@ -33,7 +34,7 @@ export async function getTemporalClientForNamespace(
 }
 
 async function getConnectionOptions(
-  envVarForTemporalNamespace: string
+  envVarForTemporalNamespace: string = temporalWorkspaceToEnvVar["front"]
 ): Promise<
   | {
       address: string;
@@ -69,6 +70,15 @@ async function getConnectionOptions(
       },
     },
   };
+}
+
+export async function getTemporalWorkerConnection(): Promise<{
+  connection: NativeConnection;
+  namespace: string | undefined;
+}> {
+  const connectionOptions = await getConnectionOptions();
+  const connection = await NativeConnection.connect(connectionOptions);
+  return { connection, namespace: process.env.TEMPORAL_NAMESPACE };
 }
 
 export async function getTemporalClient() {

--- a/front/production_checks/checks/check_notion_active_workflows.ts
+++ b/front/production_checks/checks/check_notion_active_workflows.ts
@@ -1,7 +1,7 @@
 import type { Client, WorkflowHandle } from "@temporalio/client";
 import { QueryTypes } from "sequelize";
 
-import { getTemporalClient } from "@app/lib/temporal";
+import { getTemporalConnectorsNamespaceConnection } from "@app/lib/temporal";
 import { getConnectorReplicaDbConnection } from "@app/production_checks/lib/utils";
 import type { CheckFunction } from "@app/production_checks/types/check";
 
@@ -58,7 +58,7 @@ export const checkNotionActiveWorkflows: CheckFunction = async (
 ) => {
   const notionConnectors = await listAllNotionConnectors();
 
-  const client = await getTemporalClient();
+  const client = await getTemporalConnectorsNamespaceConnection();
 
   logger.info(`Found ${notionConnectors.length} Notion connectors.`);
 
@@ -66,7 +66,7 @@ export const checkNotionActiveWorkflows: CheckFunction = async (
   for (const notionConnector of notionConnectors) {
     heartbeat();
 
-    const isActive = isTemporalWorkflowRunning(client, notionConnector);
+    const isActive = await isTemporalWorkflowRunning(client, notionConnector);
     if (!isActive) {
       missingActiveWorkflows.push({
         connectorId: notionConnector.id,


### PR DESCRIPTION
## Description

We've identified an issue where certain Temporal workflows for Notion synchronization have ceased to operate. This should have been caught by our production checks. However, they did not flag the issue due to two issues:
1. An 'await' was omitted (🙈 I'll add a rule to lint misused promises).
2. Front runs within a distinct Temporal workspace. To address this, the PR necessitates the introduction of a new environment variable, `TEMPORAL_CONNECTORS_NAMESPACE`, which will enable queries to the Temporal namespace specifically for connectors.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Add `TEMPORAL_CONNECTORS_NAMESPACE` to the k8s `front-secrets`.

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
