### PR TITLE
Flav/eslint no misused promises

### DIFF
--- a/connectors/.eslintrc.js
+++ b/connectors/.eslintrc.js
@@ -32,6 +32,12 @@ module.exports = {
     "@typescript-eslint/consistent-type-imports": "error",
     "import/consistent-type-specifier-style": ["error", "prefer-top-level"],
     "@typescript-eslint/no-floating-promises": "error",
+    "@typescript-eslint/no-misused-promises": [
+      "error",
+      {
+        checksVoidReturn: false,
+      },
+    ],
     "@typescript-eslint/no-unused-vars": "error",
     "@typescript-eslint/return-await": ["error", "in-try-catch"],
   },

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -46,7 +46,8 @@ export async function createNotionConnector(
     useCache: false,
   });
 
-  if (!validateAccessToken(notionAccessToken)) {
+  const isValidToken = await validateAccessToken(notionAccessToken);
+  if (!isValidToken) {
     return new Err(new Error("Notion access token is invalid"));
   }
 

--- a/front/.eslintrc.js
+++ b/front/.eslintrc.js
@@ -12,7 +12,7 @@ module.exports = {
       "error",
       {
         "selector": "variableLike",
-        "format": ["camelCase"]x
+        "format": ["camelCase"]
       }
     ],
     */

--- a/front/.eslintrc.js
+++ b/front/.eslintrc.js
@@ -12,7 +12,7 @@ module.exports = {
       "error",
       {
         "selector": "variableLike",
-        "format": ["camelCase"]
+        "format": ["camelCase"]x
       }
     ],
     */
@@ -25,6 +25,12 @@ module.exports = {
     "react-hooks/rules-of-hooks": 0,
     "@next/next/no-img-element": 0,
     "@typescript-eslint/no-floating-promises": "error",
+    "@typescript-eslint/no-misused-promises": [
+      "error",
+      {
+        checksVoidReturn: false,
+      },
+    ],
     "jsx-a11y/alt-text": 0,
     "simple-import-sort/imports": [
       "error",


### PR DESCRIPTION
## Description
This PR introduces the ESLint [rule](https://typescript-eslint.io/rules/no-misused-promises) aimed at identifying improper use of promises. I have turned off the `checksVoidReturn` option for the time being as it currently triggers numerous lint errors. Our primary goal is to prevent the accidental exclusion of 'Promise' in `if()`. Here's an example of what we're trying to prevent:
```
async function query() {
  // My async code.
}

const res = query();
if (res) {
  // Conditional logic.
}
```
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
