### PR TITLE
notion: give up on repeated validation_error in search

### DIFF
--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -285,6 +285,7 @@ export async function getPagesAndDatabasesToSync({
       // Notion workspaces are resynced daily so nothing is lost forever.
       switch (e.code) {
         case "internal_server_error":
+        case "validation_error":
           if (Context.current().info.attempt > 20) {
             localLogger.error(
               {
@@ -299,7 +300,7 @@ export async function getPagesAndDatabasesToSync({
               nextCursor: null,
             };
           }
-          break;
+          throw e;
 
         case "unauthorized":
           throw new ExternalOauthTokenError(e);


### PR DESCRIPTION
## Description

Context: https://dust4ai.slack.com/archives/C05F84CFP0E/p1705911582228709

Notion can return consistently 400 on some search queries. These are `validation_error`. When that happens just give up since there is nothing else we can do :/

Also added a `throw e` (the break would lead to a throw but it makes the code more explicit)

## Risk

N/A

## Deploy Plan

Deploy connectors