### PR TITLE
Retrieve userAccountId when connecting Confluence

### DIFF
--- a/connectors/src/connectors/confluence/index.ts
+++ b/connectors/src/connectors/confluence/index.ts
@@ -8,6 +8,7 @@ import type { ConnectorsAPIErrorResponse } from "@dust-tt/types";
 import { confluenceConfig } from "@connectors/connectors/confluence/lib/config";
 import {
   getConfluenceCloudInformation,
+  getConfluenceUserAccountId,
   listConfluenceSpaces,
 } from "@connectors/connectors/confluence/lib/confluence_api";
 import type { ConfluenceSpaceType } from "@connectors/connectors/confluence/lib/confluence_client";
@@ -52,6 +53,8 @@ export async function createConfluenceConnector(
     return new Err(new Error("Confluence access token is invalid"));
   }
 
+  const userAccountId = await getConfluenceUserAccountId(confluenceAccessToken);
+
   const { id: cloudId, url: cloudUrl } = confluenceCloudInformation;
   try {
     const connector = await sequelize_conn.transaction(async (transaction) => {
@@ -70,6 +73,7 @@ export async function createConfluenceConnector(
           cloudId,
           connectorId: connector.id,
           url: cloudUrl,
+          userAccountId,
         },
         { transaction }
       );

--- a/connectors/src/connectors/confluence/lib/confluence_api.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_api.ts
@@ -18,6 +18,14 @@ export async function getConfluenceCloudInformation(accessToken: string) {
   }
 }
 
+export async function getConfluenceUserAccountId(accessToken: string) {
+  const client = new ConfluenceClient(accessToken);
+
+  const userAccount = await client.getUserAccount();
+
+  return userAccount.account_id;
+}
+
 async function fetchConfluenceConfiguration(connectorId: ModelId) {
   const confluenceConfig = await ConfluenceConfiguration.findOne({
     where: {

--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -69,6 +69,13 @@ const ConfluenceListPagesCodec = t.type({
   }),
 });
 
+const ConfluenceUserProfileCodec = t.intersection([
+  t.type({
+    account_id: t.string,
+  }),
+  CatchAllCodec,
+]);
+
 function extractCursorFromLinks(links: { next?: string }): string | null {
   if (!links.next) {
     return null;
@@ -181,5 +188,9 @@ export class ConfluenceClient {
       `${this.restApiBaseUrl}/pages/${pageId}?${params.toString()}`,
       ConfluencePageWithBodyCodec
     );
+  }
+
+  async getUserAccount() {
+    return this.request("/me", ConfluenceUserProfileCodec);
   }
 }

--- a/connectors/src/lib/models/confluence.ts
+++ b/connectors/src/lib/models/confluence.ts
@@ -18,6 +18,7 @@ export class ConfluenceConfiguration extends Model<
 
   declare cloudId: string;
   declare url: string;
+  declare userAccountId: string;
 
   declare connectorId: ForeignKey<Connector["id"]>;
 }
@@ -46,11 +47,18 @@ ConfluenceConfiguration.init(
       type: DataTypes.STRING,
       allowNull: false,
     },
+    userAccountId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
   },
   {
     sequelize: sequelize_conn,
     modelName: "confluence_configurations",
-    indexes: [{ fields: ["connectorId"], unique: true }],
+    indexes: [
+      { fields: ["connectorId"], unique: true },
+      { fields: ["userAccountId"] },
+    ],
   }
 );
 Connector.hasOne(ConfluenceConfiguration);


### PR DESCRIPTION
## Description
This PR establishes the groundwork for setting up the Personal Data Reporting API, which is necessary to comply with Atlassian's GDPR obligations. It captures the `userAccountId` linked with the OAuth token and stores it, allowing us to later on verify if the retention of the data is permissible.
 
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
This PR adds a new field in `ConfluenceConfiguration`. It will require to run a migration before deploying in production.

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
