### PR TITLE
fix(tables): col names must be case-insensitive  + clear schema on truncate

### DIFF
--- a/front/pages/api/w/[wId]/data_sources/[name]/tables/csv.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/tables/csv.ts
@@ -258,6 +258,18 @@ async function rowsFromCsv(
       continue;
     }
 
+    header = header.map((h) => h.trim().toLowerCase());
+    const headerSet = new Set<string>();
+    for (const h of header) {
+      if (headerSet.has(h)) {
+        return new Err({
+          type: "invalid_request_error",
+          message: `Duplicate header: ${h}.`,
+        });
+      }
+      headerSet.add(h);
+    }
+
     for (const [i, h] of header.entries()) {
       const col = record[i];
       if (col === undefined) {


### PR DESCRIPTION


## Description

2 related issues addressed here:

1: column names in SQLite must be case-insensitive. Therefore, you cannot have a `Content` column name and a `content` one. Before sending the rows over to `core`, we lower-case all keys (`core` errors if keys aren't lower-cased).
Front `/rows` API ensures there are no duplicates and lower-cases the keys. Same for csv.

2: when upserting rows in "truncate" mode (i.e, when you want to replace all existing rows), then we should clear the existing schema

## Risk

low blast radius

## Deploy Plan

nothing special