### PR TITLE
front: fix copy button for markdown tables

### DIFF
--- a/front/components/assistant/RenderMessageMarkdown.tsx
+++ b/front/components/assistant/RenderMessageMarkdown.tsx
@@ -395,23 +395,19 @@ function TableBlock({ children }: { children: React.ReactNode }) {
   };
 
   return (
-    <div className="relative w-auto overflow-x-auto rounded-lg border border-structure-200 dark:border-structure-200-dark">
-      <div className="absolute right-2 top-2">
-        <div className="flex gap-2">
-          <div className="text-xs text-slate-300">
-            <a onClick={handleCopyTable} className="cursor-pointer">
-              {isCopied ? "Copied!" : "Copy"}
-            </a>
-          </div>
-          <IconButton
-            variant="tertiary"
-            size="xs"
-            icon={isCopied ? ClipboardCheckIcon : ClipboardIcon}
-            onClick={handleCopyTable}
-          />
-        </div>
+    <div className="relative">
+      <div className="relative w-auto overflow-x-auto rounded-lg border border-structure-200 dark:border-structure-200-dark">
+        <table className="w-full table-auto">{children}</table>
       </div>
-      <table className="w-full table-auto">{children}</table>
+
+      <div className="absolute right-2 top-2 mx-2 rounded-xl bg-structure-50">
+        <IconButton
+          variant="tertiary"
+          size="xs"
+          icon={isCopied ? ClipboardCheckIcon : ClipboardIcon}
+          onClick={handleCopyTable}
+        />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/354

Before the copy text would overlap with column data with many column and the button would scroll with content as well.

Before:

![image](https://github.com/dust-tt/dust/assets/15067/eb95668a-12da-44e2-8749-4f1c96adc2f1)
![image](https://github.com/dust-tt/dust/assets/15067/904a8cbb-3218-4632-8743-65ceda064240)

After:

![Screenshot from 2024-01-23 13-46-15](https://github.com/dust-tt/dust/assets/15067/78348f22-4acb-4e9d-aa60-53351c007925)

## Risk

None

## Deploy Plan

- deploy `front`