### PR TITLE
[Fix - Chunking] Safely cut strings in middle of emojis

### DIFF
--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -1,5 +1,5 @@
 import type { CoreAPIDataSourceDocumentSection, ModelId } from "@dust-tt/types";
-import { cacheWithRedis } from "@dust-tt/types";
+import { cacheWithRedis, safeSubstring } from "@dust-tt/types";
 import type {
   CodedError,
   WebAPIPlatformError,
@@ -696,7 +696,7 @@ export async function formatMessagesForUpsert({
 
   const title = isThread
     ? `Thread in #${channelName}: ${
-        first.text.replace(/\s+/g, " ").trim().substring(0, 128) + "..."
+        safeSubstring(first.text.replace(/\s+/g, " ").trim(), 0, 128) + "..."
       }`
     : `Messages in #${channelName}`;
 

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -2,7 +2,12 @@ import type {
   CoreAPIDataSourceDocumentSection,
   PostDataSourceDocumentRequestBody,
 } from "@dust-tt/types";
-import { DustAPI, EMBEDDING_CONFIG, sectionFullText } from "@dust-tt/types";
+import {
+  DustAPI,
+  EMBEDDING_CONFIG,
+  safeSubstring,
+  sectionFullText,
+} from "@dust-tt/types";
 import type { AxiosRequestConfig, AxiosResponse } from "axios";
 import axios from "axios";
 import { fromMarkdown } from "mdast-util-from-markdown";
@@ -253,9 +258,11 @@ export async function renderPrefixSection(
       sections: [],
     };
   }
-  let targetPrefix = prefix.substring(0, MAX_PREFIX_CHARS);
+  let targetPrefix = safeSubstring(prefix, 0, MAX_PREFIX_CHARS);
   let targetContent =
-    prefix.length > MAX_PREFIX_CHARS ? prefix.substring(MAX_PREFIX_CHARS) : "";
+    prefix.length > MAX_PREFIX_CHARS
+      ? safeSubstring(prefix, MAX_PREFIX_CHARS)
+      : "";
 
   const tokens = await tokenize(targetPrefix, dataSourceConfig);
 
@@ -376,8 +383,12 @@ export async function renderDocumentTitleAndContent({
   lastEditor?: string;
   content: CoreAPIDataSourceDocumentSection | null;
 }): Promise<CoreAPIDataSourceDocumentSection> {
-  author = author?.substring(0, MAX_AUTHOR_CHAR_LENGTH);
-  lastEditor = lastEditor?.substring(0, MAX_AUTHOR_CHAR_LENGTH);
+  author = author
+    ? safeSubstring(author, 0, MAX_AUTHOR_CHAR_LENGTH)
+    : undefined;
+  lastEditor = lastEditor
+    ? safeSubstring(lastEditor, 0, MAX_AUTHOR_CHAR_LENGTH)
+    : undefined;
   if (title && title.trim()) {
     title = `$title: ${title}\n`;
   } else {

--- a/types/src/index.ts
+++ b/types/src/index.ts
@@ -47,5 +47,5 @@ export * from "./shared/nango_errors";
 export * from "./shared/rate_limiter";
 export * from "./shared/utils/assert_never";
 export * from "./shared/utils/hashing";
-export * from "./shared/utils/string_utils";
 export * from "./shared/utils/iots_utils";
+export * from "./shared/utils/string_utils";

--- a/types/src/index.ts
+++ b/types/src/index.ts
@@ -47,4 +47,5 @@ export * from "./shared/nango_errors";
 export * from "./shared/rate_limiter";
 export * from "./shared/utils/assert_never";
 export * from "./shared/utils/hashing";
+export * from "./shared/utils/string_utils";
 export * from "./shared/utils/iots_utils";

--- a/types/src/shared/utils/string_utils.ts
+++ b/types/src/shared/utils/string_utils.ts
@@ -1,6 +1,14 @@
 /**
- * Substring that ensures we don't cut a string in the middle of a unicode character.
- * Read more: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#utf-16_characters_unicode_code_points_and_grapheme_clusters
+ * Substring that ensures we don't cut a string in the middle of a unicode
+ * character.
+ *
+ * The split characters are removed from the result. As such the
+ * result may be shorter than the requested length. As a consequence,
+ * safeSubstring(0,K) + safeSubstring(K) may not be equal to the original
+ * string.
+ *
+ * Read more:
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#utf-16_characters_unicode_code_points_and_grapheme_clusters
  */
 export function safeSubstring(
   str: string,

--- a/types/src/shared/utils/string_utils.ts
+++ b/types/src/shared/utils/string_utils.ts
@@ -1,0 +1,24 @@
+/**
+ * Substring that ensures we don't cut a string in the middle of a unicode character.
+ * Read more: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#utf-16_characters_unicode_code_points_and_grapheme_clusters
+ */
+export function safeSubstring(
+  str: string,
+  start: number,
+  end?: number
+): string {
+  while (isTrailingLoneSurrogate(str.charCodeAt(start))) start++;
+  if (end === undefined) {
+    return str.substring(start);
+  }
+  while (isLeadingLoneSurrogate(str.charCodeAt(end - 1))) end--;
+  return str.substring(start, end);
+}
+
+function isLeadingLoneSurrogate(code: number): boolean {
+  return code >= 0xd800 && code <= 0xdbff;
+}
+
+function isTrailingLoneSurrogate(code: number): boolean {
+  return code >= 0xdc00 && code <= 0xdfff;
+}

--- a/types/src/shared/utils/string_utils.ts
+++ b/types/src/shared/utils/string_utils.ts
@@ -21,7 +21,9 @@ export function safeSubstring(
   if (end === undefined) {
     return str.substring(start);
   }
-  while (isLeadingLoneSurrogate(str.charCodeAt(end - 1))) end--;
+  while (isLeadingLoneSurrogate(str.charCodeAt(end - 1))) {
+    end--;
+  }
   return str.substring(start, end);
 }
 

--- a/types/src/shared/utils/string_utils.ts
+++ b/types/src/shared/utils/string_utils.ts
@@ -15,7 +15,9 @@ export function safeSubstring(
   start: number,
   end?: number
 ): string {
-  while (isTrailingLoneSurrogate(str.charCodeAt(start))) start++;
+  while (isTrailingLoneSurrogate(str.charCodeAt(start))) {
+    start++;
+  }
   if (end === undefined) {
     return str.substring(start);
   }


### PR DESCRIPTION
## Description

When chunking, we sometimes need to cut strings. If we cut in the middle of a 2-char (or more) unicode character, it falls apart. Cf this [discussion](https://dust4ai.slack.com/archives/C05F84CFP0E/p1706034315114889?thread_ts=1706009720.515859&cid=C05F84CFP0E) => this PR fixes by providing a `safeSubstring` method

## Risk
The function discards the cut emoji => a better version would ensure safeSubstring(0,128) + safeSubstring(128) = all the string even if

Scope is limited here, so risk is not high

## Notes
A later version coud directly change the substring prototype?

