### PR TITLE
Confluence report accounts workflow

### DIFF
--- a/connectors/src/connectors/confluence/index.ts
+++ b/connectors/src/connectors/confluence/index.ts
@@ -13,6 +13,7 @@ import {
 } from "@connectors/connectors/confluence/lib/confluence_api";
 import type { ConfluenceSpaceType } from "@connectors/connectors/confluence/lib/confluence_client";
 import {
+  launchConfluencePersonalDataReportingSchedule,
   launchConfluenceRemoveSpacesSyncWorkflow,
   launchConfluenceSyncWorkflow,
 } from "@connectors/connectors/confluence/temporal/client";
@@ -85,6 +86,8 @@ export async function createConfluenceConnector(
     if (workflowStarted.isErr()) {
       return new Err(workflowStarted.error);
     }
+
+    await launchConfluencePersonalDataReportingSchedule();
 
     return new Ok(connector.id.toString());
   } catch (e) {

--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -1,6 +1,5 @@
 import { isLeft } from "fp-ts/Either";
 import * as t from "io-ts";
-import { PathReporter } from "io-ts/PathReporter";
 
 import { HTTPError } from "@connectors/lib/error";
 

--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -49,7 +49,7 @@ async function getConfluenceAccessToken(connectionId: string) {
 }
 
 async function getConfluenceClient(config: {
-  cloudId: string;
+  cloudId?: string;
   connectionId: string;
 }) {
   const accessToken = await getConfluenceAccessToken(config.connectionId);
@@ -438,4 +438,79 @@ export async function confluenceRemoveSpaceActivity(
   for (const page of allPages) {
     await deletePage(connectorId, page.pageId, dataSourceConfig);
   }
+}
+
+export async function fetchConfluenceSpaceIdsForConnectorActivity({
+  connectorId,
+}: {
+  connectorId: ModelId;
+}) {
+  const spacesForConnector = await ConfluenceSpace.findAll({
+    attributes: ["spaceId"],
+    where: {
+      connectorId,
+    },
+  });
+
+  return spacesForConnector.map((s) => s.spaceId);
+}
+
+// Personal Data Reporting logic.
+
+interface ConfluenceUserAccountAndConnectorId {
+  connectorId: ModelId;
+  userAccountId: string;
+}
+
+export async function fetchConfluenceUserAccountAndConnectorIdsActivity(): Promise<
+  ConfluenceUserAccountAndConnectorId[]
+> {
+  return ConfluenceConfiguration.findAll({
+    attributes: ["connectorId", "userAccountId"],
+  });
+}
+
+export async function confluenceGetReportPersonalActionActivity(
+  config: ConfluenceUserAccountAndConnectorId
+) {
+  const { connectorId, userAccountId } = config;
+
+  const connector = await Connector.findOne({
+    attributes: ["connectionId"],
+    where: {
+      id: connectorId,
+    },
+  });
+  if (!connector) {
+    throw new Error(`Connector not found (connectorId: ${connectorId})`);
+  }
+
+  // We look for the oldest updated data.
+  const oldestPageSync = await ConfluencePage.findOne({
+    where: {
+      connectorId,
+    },
+    order: [["lastVisitedAt", "ASC"]],
+  });
+
+  if (oldestPageSync) {
+    const client = await getConfluenceClient({
+      connectionId: connector.connectionId,
+    });
+
+    const result = await client.reportAccount({
+      accountId: userAccountId,
+      updatedAt: oldestPageSync.lastVisitedAt,
+    });
+
+    if (result && result.status === "closed") {
+      logger.info(
+        { connectorId, userAccountId },
+        "Confluence data reporting API, account closed."
+      );
+      return true;
+    }
+  }
+
+  return false;
 }

--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -471,9 +471,9 @@ export async function fetchConfluenceUserAccountAndConnectorIdsActivity(): Promi
 }
 
 export async function confluenceGetReportPersonalActionActivity(
-  config: ConfluenceUserAccountAndConnectorId
+  params: ConfluenceUserAccountAndConnectorId
 ) {
-  const { connectorId, userAccountId } = config;
+  const { connectorId, userAccountId } = params;
 
   const connector = await Connector.findOne({
     attributes: ["connectionId"],
@@ -506,7 +506,7 @@ export async function confluenceGetReportPersonalActionActivity(
     if (result && result.status === "closed") {
       logger.info(
         { connectorId, userAccountId },
-        "Confluence data reporting API, account closed."
+        "Confluence report accounts API, account closed."
       );
       return true;
     }

--- a/connectors/src/connectors/confluence/temporal/client.ts
+++ b/connectors/src/connectors/confluence/temporal/client.ts
@@ -137,6 +137,7 @@ export async function launchConfluencePersonalDataReportingSchedule() {
       },
     });
   } catch (err) {
+    // If the schedule is already running, ignore the error.
     if (!isScheduleAlreadyRunning(err)) {
       throw err;
     }

--- a/connectors/src/connectors/confluence/temporal/utils.ts
+++ b/connectors/src/connectors/confluence/temporal/utils.ts
@@ -22,6 +22,10 @@ export function makeConfluenceRemoveSpaceWorkflowIdFromParentId(
   return `${parentWorkflowId}-space-${spaceId}`;
 }
 
+export function makeConfluencePersonalDataWorkflowId() {
+  return `confluence-personal-data-reporting`;
+}
+
 export function makeConfluencePageId(pageId: string) {
   // Omit space reference in the ID to accommodate Confluence pages moving between spaces.
   return `confluence-page-${pageId}`;

--- a/connectors/src/types/errors.ts
+++ b/connectors/src/types/errors.ts
@@ -4,3 +4,12 @@ export type ConnectorsAPIErrorResponse = {
     type?: string;
   };
 };
+
+export function isScheduleAlreadyRunning(err: unknown) {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "name" in err &&
+    err.name === "ScheduleAlreadyRunning"
+  );
+}


### PR DESCRIPTION
## Description

Resolves https://github.com/dust-tt/dust/issues/3351.

This PR fulfills the necessary steps to make our Dust App available within the Atlassian community, enabling everyone to link their Confluence (and soon Jira) accounts with Dust. As part of the app-sharing prerequisites, we must adhere to Atlassian's GDPR guidelines (see [documentation](https://developer.atlassian.com/cloud/jira/platform/user-privacy-developer-guide/#user-privacy-guide-for-app-developers)).

The specified endpoint, `/app/report-accounts`, takes a list of user account IDs and their oldest updated times and determines whether we can retain those accounts' data in our infrastructure. If an account is deactivated, we are required to purge all its associated data. This account status check must be conducted every 7 days.

To comply with the 7-day cycle, this PR introduces a Temporal schedule. This schedule will trigger a routine to verify the status of all user accounts. Additionally, we will implement checks in production to guarantee the proper execution of this schedule.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
