### PR TITLE
enh: allow up to 30 chars in assistant handle

### DIFF
--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -323,7 +323,7 @@ export default function AssistantBuilder({
   ]);
 
   const assistantHandleIsValid = useCallback((handle: string) => {
-    return /^[a-zA-Z0-9_-]{1,20}$/.test(removeLeadingAt(handle));
+    return /^[a-zA-Z0-9_-]{1,30}$/.test(removeLeadingAt(handle));
   }, []);
 
   const assistantHandleIsAvailable = useCallback(
@@ -368,8 +368,8 @@ export default function AssistantBuilder({
       valid = false;
     } else {
       if (!assistantHandleIsValid(builderState.handle)) {
-        if (builderState.handle.length > 20) {
-          setAssistantHandleError("The name must be 20 characters or less");
+        if (builderState.handle.length > 30) {
+          setAssistantHandleError("The name must be 30 characters or less");
         } else {
           setAssistantHandleError("Only letters, numbers, _ and - allowed");
         }


### PR DESCRIPTION
## Description

People have been complaining about the 20 chars limit. @Duncid  said we could bump to 30

https://dust4ai.slack.com/archives/C050A0S2Z7F/p1706005141288409

## Risk

High blast radius code path, but pretty low-risk change.

## Deploy Plan

simple front deploy