### PR TITLE
front: remove data sources visibility

### DIFF
--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -116,6 +116,14 @@ export async function deleteDataSource(
   const dustAPIProjectId = dataSource.dustAPIProjectId;
 
   if (dataSource.connectorId) {
+    if (!auth.isAdmin()) {
+      return new Err({
+        type: "workspace_auth_error",
+        message:
+          "Only users that are `admins` for the current workspace can delete connected data sources.",
+      });
+    }
+
     const connectorsAPI = new ConnectorsAPI(logger);
     const connDeleteRes = await connectorsAPI.deleteConnector(
       dataSource.connectorId.toString(),

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -5,7 +5,6 @@ import type {
   Result,
 } from "@dust-tt/types";
 import { ConnectorsAPI, CoreAPI, Err, Ok } from "@dust-tt/types";
-import { Op } from "sequelize";
 
 import { getMembers } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
@@ -19,25 +18,19 @@ export async function getDataSource(
   name: string
 ): Promise<DataSourceType | null> {
   const owner = auth.workspace();
-  if (!owner) {
+
+  // This condition is critical it checks that we can identify the workspace and that the current
+  // auth is a user for this workspace. Checking `auth.isUser()` is critical as it would otherwise
+  // be possible to access data sources without being authenticated.
+  if (!owner || !auth.isUser()) {
     return null;
   }
 
   const dataSource = await DataSource.findOne({
-    where: auth.isUser()
-      ? {
-          workspaceId: owner.id,
-          visibility: {
-            [Op.or]: ["public", "private", "unlisted"],
-          },
-          name,
-        }
-      : {
-          workspaceId: owner.id,
-          // Do not include 'unlisted' here.
-          visibility: "public",
-          name,
-        },
+    where: {
+      workspaceId: owner.id,
+      name,
+    },
   });
 
   if (!dataSource) {
@@ -48,7 +41,6 @@ export async function getDataSource(
     id: dataSource.id,
     name: dataSource.name,
     description: dataSource.description,
-    visibility: dataSource.visibility,
     dustAPIProjectId: dataSource.dustAPIProjectId,
     connectorId: dataSource.connectorId,
     connectorProvider: dataSource.connectorProvider,
@@ -60,23 +52,18 @@ export async function getDataSources(
   auth: Authenticator
 ): Promise<DataSourceType[]> {
   const owner = auth.workspace();
-  if (!owner) {
+
+  // This condition is critical it checks that we can identify the workspace and that the current
+  // auth is a user for this workspace. Checking `auth.isUser()` is critical as it would otherwise
+  // be possible to access data sources without being authenticated.
+  if (!owner || !auth.isUser()) {
     return [];
   }
 
   const dataSources = await DataSource.findAll({
-    where: auth.isUser()
-      ? {
-          workspaceId: owner.id,
-          visibility: {
-            [Op.or]: ["public", "private", "unlisted"],
-          },
-        }
-      : {
-          workspaceId: owner.id,
-          // Do not include 'unlisted' here.
-          visibility: "public",
-        },
+    where: {
+      workspaceId: owner.id,
+    },
     order: [["updatedAt", "DESC"]],
   });
 
@@ -85,7 +72,6 @@ export async function getDataSources(
       id: dataSource.id,
       name: dataSource.name,
       description: dataSource.description,
-      visibility: dataSource.visibility,
       dustAPIProjectId: dataSource.dustAPIProjectId,
       connectorId: dataSource.connectorId,
       connectorProvider: dataSource.connectorProvider,
@@ -93,27 +79,30 @@ export async function getDataSources(
     };
   });
 }
+
 export async function deleteDataSource(
   auth: Authenticator,
   dataSourceName: string
 ): Promise<Result<{ success: true }, APIError>> {
-  const workspace = auth.workspace();
-  if (!workspace) {
+  const owner = auth.workspace();
+  if (!owner) {
     return new Err({
       type: "workspace_not_found",
       message: "Could not find the workspace.",
     });
   }
-  if (!auth.isAdmin()) {
+
+  if (!auth.isBuilder()) {
     return new Err({
       type: "workspace_auth_error",
       message:
-        "Only users that are `admins` for the current workspace can delete data sources.",
+        "Only users that are `builders` for the current workspace can delete data sources.",
     });
   }
+
   const dataSource = await DataSource.findOne({
     where: {
-      workspaceId: workspace.id,
+      workspaceId: owner.id,
       name: dataSourceName,
     },
   });
@@ -126,8 +115,8 @@ export async function deleteDataSource(
 
   const dustAPIProjectId = dataSource.dustAPIProjectId;
 
-  const connectorsAPI = new ConnectorsAPI(logger);
   if (dataSource.connectorId) {
+    const connectorsAPI = new ConnectorsAPI(logger);
     const connDeleteRes = await connectorsAPI.deleteConnector(
       dataSource.connectorId.toString(),
       true
@@ -139,6 +128,7 @@ export async function deleteDataSource(
         return new Err({
           type: "internal_server_error",
           message: `Error deleting connector: ${connDeleteRes.error.error.message}`,
+          connectors_error: connDeleteRes.error,
         });
       }
     }
@@ -153,13 +143,14 @@ export async function deleteDataSource(
     return new Err({
       type: "internal_server_error",
       message: `Error deleting core data source: ${coreDeleteRes.error.message}`,
+      data_source_error: coreDeleteRes.error,
     });
   }
 
   await dataSource.destroy();
 
   await launchScrubDataSourceWorkflow({
-    wId: workspace.sId,
+    wId: owner.sId,
     dustAPIProjectId,
   });
   if (dataSource.connectorProvider)

--- a/front/lib/models/data_source.ts
+++ b/front/lib/models/data_source.ts
@@ -21,7 +21,6 @@ export class DataSource extends Model<
 
   declare name: string;
   declare description: string | null;
-  declare visibility: "public" | "private";
   declare assistantDefaultSelected: boolean;
   declare dustAPIProjectId: string;
   declare connectorId: string | null;
@@ -54,10 +53,6 @@ DataSource.init(
     },
     description: {
       type: DataTypes.TEXT,
-    },
-    visibility: {
-      type: DataTypes.STRING,
-      allowNull: false,
     },
     assistantDefaultSelected: {
       type: DataTypes.BOOLEAN,

--- a/front/lib/models/data_source.ts
+++ b/front/lib/models/data_source.ts
@@ -74,8 +74,7 @@ DataSource.init(
     modelName: "data_source",
     sequelize: front_sequelize,
     indexes: [
-      { fields: ["workspaceId", "visibility"] },
-      { fields: ["workspaceId", "name", "visibility"] },
+      { fields: ["workspaceId", "name"] },
       { fields: ["workspaceId", "name"], unique: true },
     ],
   }

--- a/front/migrations/20230522_slack_doc_rename_incident.ts
+++ b/front/migrations/20230522_slack_doc_rename_incident.ts
@@ -74,7 +74,6 @@ async function main() {
         let dataSource = await DataSource.create({
           name: dataSourceName,
           description: dataSourceDescription,
-          visibility: "private",
           dustAPIProjectId: dustProject.value.project.project_id.toString(),
           workspaceId: workspaceId,
         });

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
@@ -67,7 +67,7 @@ async function handler(
 
   const owner = auth.workspace();
   const plan = auth.plan();
-  if (!owner || !plan) {
+  if (!owner || !plan || !auth.isBuilder()) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
@@ -115,17 +115,6 @@ async function handler(
       return;
 
     case "POST":
-      if (!auth.isBuilder()) {
-        return apiError(req, res, {
-          status_code: 403,
-          api_error: {
-            type: "data_source_auth_error",
-            message:
-              "You can only alter the data souces of the workspaces for which you are a builder.",
-          },
-        });
-      }
-
       if (dataSource.connectorId && !keyRes.value.isSystem) {
         return apiError(req, res, {
           status_code: 403,

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/parents.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/parents.ts
@@ -25,7 +25,7 @@ async function handler(
   );
 
   const owner = auth.workspace();
-  if (!owner) {
+  if (!owner || !auth.isBuilder()) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
@@ -49,17 +49,6 @@ async function handler(
 
   switch (req.method) {
     case "POST":
-      if (!auth.isBuilder()) {
-        return apiError(req, res, {
-          status_code: 403,
-          api_error: {
-            type: "data_source_auth_error",
-            message:
-              "You can only alter the data souces of the workspaces for which you are a builder.",
-          },
-        });
-      }
-
       if (
         !req.body ||
         !Array.isArray(req.body.parents) ||

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/index.ts
@@ -26,6 +26,16 @@ async function handler(
     req.query.wId as string
   );
 
+  if (!auth.isBuilder()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "data_source_not_found",
+        message: "The data source you requested was not found.",
+      },
+    });
+  }
+
   const dataSource = await getDataSource(auth, req.query.name as string);
 
   if (!dataSource) {

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/search.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/search.ts
@@ -63,6 +63,16 @@ async function handler(
     req.query.wId as string
   );
 
+  if (!auth.isBuilder()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "data_source_not_found",
+        message: "The data source you requested was not found.",
+      },
+    });
+  }
+
   const dataSource = await getDataSource(auth, req.query.name as string);
 
   if (!dataSource) {

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/index.ts
@@ -28,19 +28,24 @@ async function handler(
 
   const owner = auth.workspace();
   const plan = auth.plan();
-  if (!owner || !plan) {
+  if (!owner || !plan || !auth.isBuilder()) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
-        type: "workspace_not_found",
-        message: "The workspace you requested was not found.",
+        type: "data_source_not_found",
+        message: "The data source you requested was not found.",
       },
     });
   }
 
   if (!isActivatedStructuredDB(owner)) {
-    res.status(404).end();
-    return;
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "data_source_not_found",
+        message: "The data source you requested was not found.",
+      },
+    });
   }
 
   const dataSource = await getDataSource(auth, req.query.name as string);

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/rows/[rId].ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/rows/[rId].ts
@@ -28,12 +28,12 @@ async function handler(
 
   const owner = auth.workspace();
   const plan = auth.plan();
-  if (!owner || !plan) {
+  if (!owner || !plan || !auth.isBuilder()) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
-        type: "workspace_not_found",
-        message: "The workspace you requested was not found.",
+        type: "data_source_not_found",
+        message: "The data source you requested was not found.",
       },
     });
   }

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/rows/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/rows/index.ts
@@ -56,12 +56,12 @@ async function handler(
 
   const owner = auth.workspace();
   const plan = auth.plan();
-  if (!owner || !plan) {
+  if (!owner || !plan || !auth.isBuilder()) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
-        type: "workspace_not_found",
-        message: "The workspace you requested was not found.",
+        type: "data_source_not_found",
+        message: "The data source you requested was not found.",
       },
     });
   }

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/index.ts
@@ -42,19 +42,24 @@ async function handler(
 
   const owner = auth.workspace();
   const plan = auth.plan();
-  if (!owner || !plan) {
+  if (!owner || !plan || !auth.isBuilder()) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
-        type: "workspace_not_found",
-        message: "The workspace you requested was not found.",
+        type: "data_source_not_found",
+        message: "The data source you requested was not found.",
       },
     });
   }
 
   if (!isActivatedStructuredDB(owner)) {
-    res.status(404).end();
-    return;
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "data_source_not_found",
+        message: "The data source you requested was not found.",
+      },
+    });
   }
 
   const dataSource = await getDataSource(auth, req.query.name as string);

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tokenize.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tokenize.ts
@@ -40,13 +40,14 @@ async function handler(
 
   if (!auth.workspace() || !auth.isBuilder()) {
     return apiError(req, res, {
-      status_code: 403,
+      status_code: 404,
       api_error: {
-        type: "workspace_auth_error",
-        message: "You don't have permission to access this resource.",
+        type: "workspace_not_found",
+        message: "The workspace you requested was not found.",
       },
     });
   }
+
   const dataSource = await getDataSource(auth, req.query.name as string);
 
   if (!dataSource) {

--- a/front/pages/api/v1/w/[wId]/data_sources/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/index.ts
@@ -23,6 +23,16 @@ async function handler(
     req.query.wId as string
   );
 
+  if (!auth.isBuilder()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "The workspace you requested was not found.",
+      },
+    });
+  }
+
   const dataSources = await getDataSources(auth);
 
   switch (req.method) {

--- a/front/pages/api/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
@@ -33,7 +33,8 @@ async function handler(
 
   const owner = auth.workspace();
   const plan = auth.plan();
-  if (!owner || !plan) {
+
+  if (!owner || !plan || !auth.isUser()) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {

--- a/front/pages/api/w/[wId]/data_sources/[name]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/index.ts
@@ -169,7 +169,7 @@ async function handler(
         });
       }
 
-      // We only expose deleting non-managed data sources.
+      // We only expose deleted non-managed data sources.
       if (dataSource.connectorId) {
         return apiError(req, res, {
           status_code: 400,

--- a/front/pages/api/w/[wId]/data_sources/[name]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/index.ts
@@ -1,12 +1,10 @@
 import type { DataSourceType } from "@dust-tt/types";
 import type { ReturnedAPIErrorType } from "@dust-tt/types";
-import { CoreAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { getDataSource } from "@app/lib/api/data_sources";
+import { deleteDataSource, getDataSource } from "@app/lib/api/data_sources";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { DataSource } from "@app/lib/models";
-import logger from "@app/logger/logger";
 import { apiError, withLogging } from "@app/logger/withlogging";
 
 export type GetOrPostDataSourceResponseBody = {
@@ -26,7 +24,7 @@ async function handler(
   );
 
   const owner = auth.workspace();
-  if (!owner) {
+  if (!owner || !auth.isUser()) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
@@ -56,16 +54,6 @@ async function handler(
       },
     });
   }
-  const dataSourceModel = await DataSource.findByPk(dataSource.id);
-  if (!dataSourceModel) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "data_source_not_found",
-        message: "The data source you requested was not found.",
-      },
-    });
-  }
 
   switch (req.method) {
     case "GET":
@@ -74,7 +62,6 @@ async function handler(
           id: dataSource.id,
           name: dataSource.name,
           description: dataSource.description,
-          visibility: dataSource.visibility,
           dustAPIProjectId: dataSource.dustAPIProjectId,
           connectorId: dataSource.connectorId,
           connectorProvider: dataSource.connectorProvider,
@@ -91,6 +78,17 @@ async function handler(
             type: "data_source_auth_error",
             message:
               "Only the users that are `builders` for the current workspace can update a data source.",
+          },
+        });
+      }
+
+      const dataSourceModel = await DataSource.findByPk(dataSource.id);
+      if (!dataSourceModel) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "data_source_not_found",
+            message: "The data source you requested was not found.",
           },
         });
       }
@@ -120,7 +118,6 @@ async function handler(
         if (
           !req.body ||
           (typeof req.body.description !== "string" &&
-            typeof req.body.visibility !== "string" &&
             typeof req.body.assistantDefaultSelected !== "boolean")
         ) {
           return apiError(req, res, {
@@ -134,26 +131,11 @@ async function handler(
 
         const toUpdate: {
           description?: string | null;
-          visibility?: "public" | "private";
           assistantDefaultSelected?: boolean;
         } = {};
 
         if (typeof req.body.description === "string") {
           toUpdate.description = req.body.description || null;
-        }
-
-        if (typeof req.body.visibility === "string") {
-          if (!["public", "private"].includes(req.body.visibility)) {
-            return apiError(req, res, {
-              status_code: 400,
-              api_error: {
-                type: "invalid_request_error",
-                message:
-                  "The visibility field must be either `public` or `private` if provided.",
-              },
-            });
-          }
-          toUpdate.visibility = req.body.visibility;
         }
 
         if (typeof req.body.assistantDefaultSelected === "boolean") {
@@ -168,7 +150,6 @@ async function handler(
           id: ds.id,
           name: ds.name,
           description: ds.description,
-          visibility: ds.visibility,
           assistantDefaultSelected: ds.assistantDefaultSelected,
           dustAPIProjectId: ds.dustAPIProjectId,
           connectorId: ds.connectorId,
@@ -188,6 +169,7 @@ async function handler(
         });
       }
 
+      // We only expose deleting non-managed data sources.
       if (dataSource.connectorId) {
         return apiError(req, res, {
           status_code: 400,
@@ -198,24 +180,13 @@ async function handler(
         });
       }
 
-      const coreAPI = new CoreAPI(logger);
-      const dustDataSource = await coreAPI.deleteDataSource({
-        projectId: dataSource.dustAPIProjectId,
-        dataSourceName: dataSource.name,
-      });
-
-      if (dustDataSource.isErr()) {
+      const dRes = await deleteDataSource(auth, dataSource.name);
+      if (dRes.isErr()) {
         return apiError(req, res, {
           status_code: 500,
-          api_error: {
-            type: "internal_server_error",
-            message: "Failed to delete the data source.",
-            data_source_error: dustDataSource.error,
-          },
+          api_error: dRes.error,
         });
       }
-
-      await dataSourceModel.destroy();
 
       res.status(204).end();
       return;

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/bot_enabled.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/bot_enabled.ts
@@ -31,7 +31,7 @@ async function handler(
   );
 
   const owner = auth.workspace();
-  if (!owner) {
+  if (!owner || !auth.isUser()) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/permissions/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/permissions/index.ts
@@ -48,7 +48,8 @@ async function handler(
   );
 
   const owner = auth.workspace();
-  if (!owner) {
+
+  if (!owner || !auth.isUser()) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/update.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/update.ts
@@ -43,6 +43,17 @@ async function handler(
     });
   }
 
+  if (!auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "data_source_auth_error",
+        message:
+          "Only the users that are `admins` for the current workspace can edit the permissions of a data source.",
+      },
+    });
+  }
+
   const dataSource = await getDataSource(auth, req.query.name as string);
   if (!dataSource) {
     return apiError(req, res, {
@@ -60,17 +71,6 @@ async function handler(
       api_error: {
         type: "data_source_not_managed",
         message: "The data source you requested is not managed.",
-      },
-    });
-  }
-
-  if (!auth.isAdmin()) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "data_source_auth_error",
-        message:
-          "Only the users that are `admins` for the current workspace can edit the permissions of a data source.",
       },
     });
   }

--- a/front/pages/api/w/[wId]/data_sources/[name]/search.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/search.ts
@@ -55,7 +55,7 @@ async function handler(
   );
 
   const owner = auth.workspace();
-  if (!owner) {
+  if (!owner || !auth.isUser()) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
@@ -79,17 +79,6 @@ async function handler(
 
   switch (req.method) {
     case "GET": {
-      // Only member of the workspace can search a DataSource since it costs money for embedding.
-      if (!auth.isUser()) {
-        return apiError(req, res, {
-          status_code: 404,
-          api_error: {
-            type: "data_source_not_found",
-            message: "The data source you requested was not found.",
-          },
-        });
-      }
-
       // I could not find a way to make the query params be an array if there is only one tag.
       if (req.query.tags_in && typeof req.query.tags_in === "string") {
         req.query.tags_in = [req.query.tags_in];

--- a/front/pages/api/w/[wId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/index.ts
@@ -36,7 +36,7 @@ async function handler(
 
   const owner = auth.workspace();
   const plan = auth.plan();
-  if (!owner || !plan) {
+  if (!owner || !plan || !auth.isUser()) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
@@ -69,7 +69,6 @@ async function handler(
         !req.body ||
         !(typeof req.body.name == "string") ||
         !(typeof req.body.description == "string") ||
-        !["public", "private"].includes(req.body.visibility) ||
         !(typeof req.body.assistantDefaultSelected === "boolean")
       ) {
         return apiError(req, res, {
@@ -162,7 +161,6 @@ async function handler(
       const ds = await DataSource.create({
         name: req.body.name,
         description: description,
-        visibility: req.body.visibility,
         dustAPIProjectId: dustProject.value.project.project_id.toString(),
         workspaceId: owner.id,
         assistantDefaultSelected: req.body.assistantDefaultSelected,
@@ -173,7 +171,6 @@ async function handler(
           id: ds.id,
           name: ds.name,
           description: ds.description,
-          visibility: ds.visibility,
           dustAPIProjectId: ds.dustAPIProjectId,
           assistantDefaultSelected: ds.assistantDefaultSelected,
           connectorId: null,

--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -294,7 +294,6 @@ async function handler(
       let dataSource = await DataSource.create({
         name: dataSourceName,
         description: dataSourceDescription,
-        visibility: "private",
         dustAPIProjectId: dustProject.value.project.project_id.toString(),
         workspaceId: owner.id,
         assistantDefaultSelected,
@@ -390,7 +389,6 @@ async function handler(
           id: dataSource.id,
           name: dataSource.name,
           description: dataSource.description,
-          visibility: dataSource.visibility,
           dustAPIProjectId: dataSource.dustAPIProjectId,
           connectorId: connectorsRes.value.id,
           connectorProvider: provider,

--- a/front/pages/w/[wId]/builder/data-sources/[name]/settings.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/settings.tsx
@@ -1,9 +1,5 @@
 import { Button, DropdownMenu, TrashIcon } from "@dust-tt/sparkle";
-import type {
-  DataSourceType,
-  DataSourceVisibility,
-  WorkspaceType,
-} from "@dust-tt/types";
+import type { DataSourceType, WorkspaceType } from "@dust-tt/types";
 import type { SubscriptionType } from "@dust-tt/types";
 import type { APIError } from "@dust-tt/types";
 import { ChevronRightIcon } from "@heroicons/react/20/solid";
@@ -72,7 +68,6 @@ export default function DataSourceSettings({
     settings:
       | {
           description: string;
-          visibility: DataSourceVisibility;
           assistantDefaultSelected: boolean;
         }
       | { assistantDefaultSelected: boolean }
@@ -105,7 +100,6 @@ export default function DataSourceSettings({
       dataSource={dataSource}
       handleUpdate={(settings: {
         description: string;
-        visibility: DataSourceVisibility;
         assistantDefaultSelected: boolean;
       }) => handleUpdate(settings)}
       gaTrackingId={gaTrackingId}
@@ -125,7 +119,6 @@ function StandardDataSourceSettings({
   dataSource: DataSourceType;
   handleUpdate: (settings: {
     description: string;
-    visibility: DataSourceVisibility;
     assistantDefaultSelected: boolean;
   }) => Promise<void>;
   gaTrackingId: string;
@@ -197,7 +190,6 @@ function StandardDataSourceSettings({
                   setIsSavingOrDeleting(true);
                   await handleUpdate({
                     description: dataSourceDescription,
-                    visibility: "private",
                     assistantDefaultSelected:
                       dataSource.assistantDefaultSelected,
                   });

--- a/front/pages/w/[wId]/builder/data-sources/new.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/new.tsx
@@ -119,7 +119,6 @@ export default function DataSourceNew({
       body: JSON.stringify({
         name: dataSourceName,
         description: dataSourceDescription,
-        visibility: "private",
         assistantDefaultSelected: false,
       }),
     });

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -101,9 +101,6 @@ export async function isWorkflowDeletableActivity({
   const dataSources = await DataSource.findAll({
     where: {
       workspaceId: workspace.id,
-      visibility: {
-        [Op.or]: ["public", "private", "unlisted"],
-      },
     },
     limit: 1,
   });

--- a/types/src/front/data_source.ts
+++ b/types/src/front/data_source.ts
@@ -1,7 +1,5 @@
 import { ModelId } from "../shared/model_id";
 
-export type DataSourceVisibility = "public" | "private";
-
 export const CONNECTOR_PROVIDERS = [
   "confluence",
   "github",
@@ -21,7 +19,6 @@ export type DataSourceType = {
   id: ModelId;
   name: string;
   description: string | null;
-  visibility: DataSourceVisibility;
   assistantDefaultSelected: boolean;
   dustAPIProjectId: string;
   connectorId: string | null;


### PR DESCRIPTION
## Description

This PR removes the visibility column from data sources, making all data sources private (we had support for a notion of public data source that is not used today and represents a security risk that is not worth the value).

Disallowing public data sources allow us to require auth.iUser/Builder on all routes even GET ones (previously the authentication relied on the implementation of getDataSource that would return null if the data source was not accessible by the current user). `getDataSource` still makes sure to not return data sources that are not accessible by the current user but adding a auth check in the route implementation seems like a desirable defense in depth.

## Risk

Touches authentication. Requires careful review.

## Deploy Plan

- deploy `front`
- run `init_db` (column deletion so must come after deploy)

(I replayed this deploy procedure locallly to test it)