### PR TITLE
Enh/only forbid uppercase ascii

### DIFF
--- a/core/src/databases/database.rs
+++ b/core/src/databases/database.rs
@@ -231,11 +231,11 @@ impl Table {
                 None => Err(anyhow!("Row {} is not an object", row_index,))?,
             };
             match object.keys().find(|key| match key.chars().next() {
-                Some(c) => !c.is_ascii_lowercase(),
+                Some(c) => c.is_ascii_uppercase(),
                 None => false,
             }) {
                 Some(key) => Err(anyhow!(
-                    "Row {} has a key '{}' that is not lowercase",
+                    "Row {} has a key '{}' that contains uppercase characters",
                     row_index,
                     key
                 ))?,

--- a/front/pages/api/w/[wId]/data_sources/[name]/tables/csv.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/tables/csv.ts
@@ -175,6 +175,25 @@ async function handler(
             "Failed to upsert rows."
           );
 
+          const delRes = await coreAPI.deleteTable({
+            projectId: dataSource.dustAPIProjectId,
+            dataSourceName: dataSource.name,
+            tableId,
+          });
+
+          if (delRes.isErr()) {
+            logger.error(
+              {
+                dataSourceName: dataSource.name,
+                workspaceId: owner.id,
+                tableId,
+                tableName: name,
+                error: delRes.error,
+              },
+              "Failed to delete table after failed upsert."
+            );
+          }
+
           return apiError(req, res, {
             status_code: 500,
             api_error: {


### PR DESCRIPTION
## Description

- We don't allow uppsecase letters in column names (in core). However, we want to allow symbols numbers etc..  The condition was broken because it required only ascii lowercase
- in CSV upload, if upserting rows fails, we want to delete the table we just created, otherwise we end up with an empty useless table and when the user attempts to re-upload it then it fails.

## Risk

blast radius limited to tables queries.

## Deploy Plan

simple core + front deploy