### PR TITLE
Temporary fix for double menu issue

### DIFF
--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -953,7 +953,7 @@ export default function AssistantBuilder({
                     size="sm"
                   />
                 </DropdownMenu.Button>
-                <DropdownMenu.Items origin="auto" width={200}>
+                <DropdownMenu.Items origin="topLeft" width={260}>
                   {BASIC_ACTION_MODES.map((key) => (
                     <DropdownMenu.Item
                       key={key}
@@ -967,35 +967,24 @@ export default function AssistantBuilder({
                       }}
                     />
                   ))}
-                  <DropdownMenu.Item
-                    label="Advanced actions"
-                    hasChildren={true}
-                  >
-                    <DropdownMenu.Items
-                      origin="topLeft"
-                      width={250}
-                      marginLeft={40}
-                    >
-                      {ADVANCED_ACTION_MODES.filter((key) => {
-                        return (
-                          key !== "TABLES_QUERY" ||
-                          isActivatedStructuredDB(owner)
-                        );
-                      }).map((key) => (
-                        <DropdownMenu.Item
-                          key={key}
-                          label={ACTION_MODE_TO_LABEL[key]}
-                          onClick={() => {
-                            setEdited(true);
-                            setBuilderState((state) => ({
-                              ...state,
-                              actionMode: key,
-                            }));
-                          }}
-                        />
-                      ))}
-                    </DropdownMenu.Items>
-                  </DropdownMenu.Item>
+                  <DropdownMenu.SectionHeader label="Advanced actions" />
+                  {ADVANCED_ACTION_MODES.filter((key) => {
+                    return (
+                      key !== "TABLES_QUERY" || isActivatedStructuredDB(owner)
+                    );
+                  }).map((key) => (
+                    <DropdownMenu.Item
+                      key={key}
+                      label={ACTION_MODE_TO_LABEL[key]}
+                      onClick={() => {
+                        setEdited(true);
+                        setBuilderState((state) => ({
+                          ...state,
+                          actionMode: key,
+                        }));
+                      }}
+                    />
+                  ))}
                 </DropdownMenu.Items>
               </DropdownMenu>
             </div>


### PR DESCRIPTION
## Description

I introduced a bug in a very specific and none intended use of DropdownMenu:
<img width="363" alt="image" src="https://github.com/dust-tt/dust/assets/4435185/344c4123-6985-4da1-90b4-359f3cfc1239">

Here is a temporary fix that modifies the menu so it's not on two levels:
<img width="397" alt="image" src="https://github.com/dust-tt/dust/assets/4435185/2a7a361f-ec5a-4c09-b09f-d7d88e47b041">

I plan to update Dropdown to solve the issue or to iterate on the menu design.