### PR TITLE
Add Confluence Page multi-columns index on lastVisitedAt

### DIFF
--- a/connectors/src/lib/models/confluence.ts
+++ b/connectors/src/lib/models/confluence.ts
@@ -194,6 +194,7 @@ ConfluencePage.init(
     indexes: [
       { fields: ["connectorId", "pageId"], unique: true },
       { fields: ["connectorId", "spaceId"] },
+      { fields: ["connectorId", "lastVisitedAt"] },
     ],
     modelName: "confluence_pages",
   }


### PR DESCRIPTION
## Description
This PR resolves https://github.com/dust-tt/dust/issues/3415.

This PR introduces a new multicolumns index for the `confluence_pages` table, intended to support the data reporting API (see https://github.com/dust-tt/dust/pull/3405) in retrieving the oldest updated time.

The query is `SELECT "lastUpdatedAt" FROM confluence_pages WHERE "connectorId" = X ORDER BY "lastVisitedAt" DESC LIMIT 1`. Based on PostgreSQL's [documentation](https://www.postgresql.org/docs/current/indexes-ordering.html), a composite index is effective for optimizing both the `WHERE` clause and the `ORDER BY` directive.

This PR adds a multicolumn index on `connectorId` and `lastVisitedAt`. While it's challenging to assess the index's efficiency on a very small table, by turning off sequential scans using `SET enable_seqscan = OFF;` on my local setup, I managed to execute an explain query that confirms the index is being correctly utilized.

```
dust_connectors=> SET enable_seqscan = OFF;
SET
dust_connectors=> EXPLAIN SELECT * FROM confluence_pages WHERE "connectorId" = 32 ORDER BY "lastVisitedAt" DESC LIMIT 1;
                                                               QUERY PLAN
----------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.13..2.15 rows=1 width=603)
   ->  Index Scan Backward using confluence_pages_connector_id_last_visited_at on confluence_pages  (cost=0.13..12.24 rows=6 width=603)
         Index Cond: ("connectorId" = 32)
(3 rows)
```

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
This PR requires a migration, but pretty safe since it only create an index. It's safe to deploy in production before running the migration.
<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
