### PR TITLE
[Slack connector deletion] Skip app uninstall if nango conn. unknown

### DIFF
--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -1,6 +1,5 @@
 import type { ModelId } from "@dust-tt/types";
 import { WebClient } from "@slack/web-api";
-import { AxiosError } from "axios";
 import PQueue from "p-queue";
 
 import type {
@@ -18,7 +17,7 @@ import {
   getSlackClient,
 } from "@connectors/connectors/slack/lib/slack_client";
 import { launchSlackSyncWorkflow } from "@connectors/connectors/slack/temporal/client.js";
-import { ExternalOauthTokenError } from "@connectors/lib/error";
+import { ExternalOauthTokenError, NangoError } from "@connectors/lib/error";
 import { Connector, sequelize_conn } from "@connectors/lib/models";
 import {
   SlackChannel,
@@ -265,15 +264,11 @@ export async function uninstallSlack(nangoConnectionId: string) {
       );
     }
   } catch (e) {
-    if (
-      e instanceof AxiosError &&
-      e.response?.status === 400 &&
-      e.response?.data?.type === "unknown_connection"
-    ) {
+    if (e instanceof NangoError && e.type === "unknown_connection") {
       logger.info(
         {
           nangoConnectionId,
-          error: `Unknown nango connection: ${e.response.data.error}`,
+          error: `Nango error: unknown connection: ${e.message}`,
         },
         "Unknown nango connection, skipping uninstallation of the Slack app"
       );

--- a/connectors/src/lib/error.ts
+++ b/connectors/src/lib/error.ts
@@ -63,6 +63,19 @@ export class ExternalOauthTokenError extends Error {
   }
 }
 
+export const NANGO_ERROR_TYPES = ["unknown_connection"];
+export type NangoErrorType = (typeof NANGO_ERROR_TYPES)[number];
+export class NangoError extends Error {
+  readonly type: NangoErrorType;
+
+  constructor(type: NangoErrorType, readonly innerError?: Error) {
+    super(innerError?.message);
+    this.name = "NangoError";
+    this.type = type;
+    this.innerError = innerError;
+  }
+}
+
 export function isNotFoundError(err: unknown): err is NotFoundError {
   return err instanceof HTTPError && err.statusCode === 404;
 }

--- a/connectors/src/lib/nango_client.ts
+++ b/connectors/src/lib/nango_client.ts
@@ -2,10 +2,14 @@ import { Nango } from "@nangohq/node";
 import axios from "axios";
 
 import type { WorkflowError } from "@connectors/lib/error";
-import { ExternalOauthTokenError } from "@connectors/lib/error";
+import {
+  ExternalOauthTokenError,
+  NANGO_ERROR_TYPES,
+  NangoError,
+} from "@connectors/lib/error";
 
-import type { Result } from "./result";
-import { Err, Ok } from "./result";
+import type { Result } from "@connectors/lib/result";
+import { Err, Ok } from "@connectors/lib/result";
 
 const { NANGO_SECRET_KEY } = process.env;
 
@@ -34,6 +38,10 @@ class CustomNango extends Nango {
               errorText.includes("invalid_grant")
             ) {
               throw new ExternalOauthTokenError();
+            }
+            const errorType = e.response.data.type;
+            if (NANGO_ERROR_TYPES.includes(errorType)) {
+              throw new NangoError(errorType, e);
             }
           }
         }

--- a/connectors/src/lib/nango_client.ts
+++ b/connectors/src/lib/nango_client.ts
@@ -7,7 +7,6 @@ import {
   NANGO_ERROR_TYPES,
   NangoError,
 } from "@connectors/lib/error";
-
 import type { Result } from "@connectors/lib/result";
 import { Err, Ok } from "@connectors/lib/result";
 


### PR DESCRIPTION
## Description
It can happen that when we delete a slack datasource, the nango connection does not exist anymore 

Previously, this  resulted in an error when trying to uninstall the slack app, cancelling the slack datasource deletion, and if done via stripe webhooks (e.g. for a downgrade) triggered monitors indefinitely, since stripe retries webhooks

This PR handles the issue by skipping the app uninstall if the nango connection is unknown--we then complete the datasource deletion

Related [discussion](https://dust4ai.slack.com/archives/C05F84CFP0E/p1706008431775259?thread_ts=1706007633.055059&cid=C05F84CFP0E)

## Risk
- On the PR, risk was mitigated by testing on connectors edge on the actual workspace & slack connection that triggered the error in the above discussion
- In general, TBD whether we want to warn the user so they ensure the app is uninstalled
