### PR TITLE
bump dd-trace to 0.5.1 (prep for audit fix)

### DIFF
--- a/alerting/temporal/package-lock.json
+++ b/alerting/temporal/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@datadog/datadog-api-client": "^1.17.0",
         "axios": "^1.5.1",
-        "dd-trace": "^4.16.0",
+        "dd-trace": "^5.1.0",
         "zod": "^3.22.4"
       },
       "devDependencies": {
@@ -52,21 +52,21 @@
       }
     },
     "node_modules/@datadog/native-appsec": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@datadog/native-appsec/-/native-appsec-4.0.0.tgz",
-      "integrity": "sha512-myTguXJ3VQHS2E1ylNsSF1avNpDmq5t+K4Q47wdzeakGc3sDIDDyEbvuFTujl9c9wBIkup94O1mZj5DR37ajzA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@datadog/native-appsec/-/native-appsec-7.0.0.tgz",
+      "integrity": "sha512-bywstWFW2hWxzPuS0+mFMVHHL0geulx5yQFtsjfszaH2LTAgk2D+Rt40MKbAoZ8q3tRw2dy6aYQ7svO3ca8jpA==",
       "hasInstallScript": true,
       "dependencies": {
         "node-gyp-build": "^3.9.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/@datadog/native-iast-rewriter": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@datadog/native-iast-rewriter/-/native-iast-rewriter-2.1.3.tgz",
-      "integrity": "sha512-4oxMFz5ZEpOK3pRc9KjquMgkRP6D+oPQVIzOk4dgG8fl2iepHtCa3gna/fQBfdWIiX5a2j65O3R1zNp2ckk8JA==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@datadog/native-iast-rewriter/-/native-iast-rewriter-2.2.2.tgz",
+      "integrity": "sha512-13ZBhJpjZ/tiV6rYfyAf/ITye9cyd3x12M/2NKhD4Ivev4N4uKBREAjpArOtzKtPXZ5b6oXwVV4ofT1SHoYyzA==",
       "dependencies": {
         "lru-cache": "^7.14.0",
         "node-gyp-build": "^4.5.0"
@@ -76,9 +76,9 @@
       }
     },
     "node_modules/@datadog/native-iast-rewriter/node_modules/node-gyp-build": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.1.tgz",
-      "integrity": "sha512-24vnklJmyRS8ViBNI8KbtK/r/DmXQMRiOMXTNz2nrTnAYUwjmEEbnnpB/+kt+yWRv73bPsSPRFddrcIbAxSiMQ==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.0.tgz",
+      "integrity": "sha512-u6fs2AEUljNho3EYTJNBfImO5QTo/J/1Etd+NVdCj7qWKUSN/bSLkZwhDv7I+w/MSC6qJ4cknepkAYykDdK8og==",
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
@@ -86,9 +86,10 @@
       }
     },
     "node_modules/@datadog/native-iast-taint-tracking": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-1.5.0.tgz",
-      "integrity": "sha512-SOWIk1M6PZH0osNB191Voz2rKBPoF5hISWVSK9GiJPrD40+xjib1Z/bFDV7EkDn3kjOyordSBdNPG5zOqZJdyg==",
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-1.6.4.tgz",
+      "integrity": "sha512-Owxk7hQ4Dxwv4zJAoMjRga0IvE6lhvxnNc8pJCHsemCWBXchjr/9bqg05Zy5JnMbKUWn4XuZeJD6RFZpRa8bfw==",
+      "hasInstallScript": true,
       "dependencies": {
         "node-gyp-build": "^3.9.0"
       }
@@ -107,9 +108,9 @@
       }
     },
     "node_modules/@datadog/pprof": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@datadog/pprof/-/pprof-3.2.0.tgz",
-      "integrity": "sha512-kOhWHCWB80djnMCr5KNKBAy1Ih/jK/PIj6yqnZwL1Wqni/h6IBPRUMhtIxcYJMRgsZVYrFXUV20AVXTZCzFokw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@datadog/pprof/-/pprof-5.0.0.tgz",
+      "integrity": "sha512-vhNan4SBuNWLpexunDJQ+hNbRAgWdk2qy5Iyh7Nn94uSSHXigAJMAvu4jwMKKQKFfchtobOkWT8GQUWW3tgpFg==",
       "hasInstallScript": true,
       "dependencies": {
         "delay": "^5.0.0",
@@ -119,7 +120,7 @@
         "source-map": "^0.7.4"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/@datadog/sketches-js": {
@@ -367,29 +368,38 @@
       "resolved": "https://registry.npmjs.org/crypto-randomuuid/-/crypto-randomuuid-1.0.0.tgz",
       "integrity": "sha512-/RC5F4l1SCqD/jazwUF6+t34Cd8zTSAGZ7rvvZu1whZUhD2a5MOGKjSGowoGcpj/cbVZk1ZODIooJEQQq3nNAA=="
     },
+    "node_modules/dc-polyfill": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/dc-polyfill/-/dc-polyfill-0.1.3.tgz",
+      "integrity": "sha512-Wyk5n/5KUj3GfVKV2jtDbtChC/Ff9fjKsBcg4ZtYW1yQe3DXNHcGURvmoxhqQdfOQ9TwyMjnfyv1lyYcOkFkFA==",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
     "node_modules/dd-trace": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-4.16.0.tgz",
-      "integrity": "sha512-pDAZgJ9hYrRHztpSM7hcO6bAXj/Jrf1EMW/O6BiDsQS6GMzXho3rqOHIGMBeB7+pzM6/chncio1KkwOKP+d4bQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-5.1.0.tgz",
+      "integrity": "sha512-7wE0+Q3xUVk1tRrxFtWYXJeI1SSuAgN0czchNmDPjIsQl+7CZacVMgcucwj1j3Pa8nG+RQUxbBsM+BkJF1Ki3Q==",
       "hasInstallScript": true,
       "dependencies": {
-        "@datadog/native-appsec": "^4.0.0",
-        "@datadog/native-iast-rewriter": "2.1.3",
-        "@datadog/native-iast-taint-tracking": "1.5.0",
+        "@datadog/native-appsec": "7.0.0",
+        "@datadog/native-iast-rewriter": "2.2.2",
+        "@datadog/native-iast-taint-tracking": "1.6.4",
         "@datadog/native-metrics": "^2.0.0",
-        "@datadog/pprof": "3.2.0",
+        "@datadog/pprof": "5.0.0",
         "@datadog/sketches-js": "^2.1.0",
         "@opentelemetry/api": "^1.0.0",
         "@opentelemetry/core": "^1.14.0",
         "crypto-randomuuid": "^1.0.0",
-        "diagnostics_channel": "^1.1.0",
+        "dc-polyfill": "^0.1.2",
         "ignore": "^5.2.4",
-        "import-in-the-middle": "^1.4.2",
+        "import-in-the-middle": "^1.7.3",
         "int64-buffer": "^0.1.9",
         "ipaddr.js": "^2.1.0",
         "istanbul-lib-coverage": "3.2.0",
+        "jest-docblock": "^29.7.0",
         "koalas": "^1.0.2",
-        "limiter": "^1.1.4",
+        "limiter": "1.1.5",
         "lodash.kebabcase": "^4.1.1",
         "lodash.pick": "^4.4.0",
         "lodash.sortby": "^4.7.0",
@@ -401,12 +411,14 @@
         "node-abort-controller": "^3.1.1",
         "opentracing": ">=0.12.1",
         "path-to-regexp": "^0.1.2",
-        "protobufjs": "^7.2.4",
+        "pprof-format": "^2.0.7",
+        "protobufjs": "^7.2.5",
         "retry": "^0.13.1",
-        "semver": "^7.5.4"
+        "semver": "^7.5.4",
+        "tlhunter-sorted-set": "^0.1.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/delay": {
@@ -428,12 +440,12 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/diagnostics_channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/diagnostics_channel/-/diagnostics_channel-1.1.0.tgz",
-      "integrity": "sha512-OE1ngLDjSBPG6Tx0YATELzYzy3RKHC+7veQ8gLa8yS7AAgw65mFbVdcsu3501abqOZCEZqZyAIemB0zXlqDSuw==",
+    "node_modules/detect-newline": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
       "engines": {
-        "node": ">=4"
+        "node": ">=8"
       }
     },
     "node_modules/diff": {
@@ -515,9 +527,9 @@
       }
     },
     "node_modules/import-in-the-middle": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.4.2.tgz",
-      "integrity": "sha512-9WOz1Yh/cvO/p69sxRmhyQwrIGGSp7EIdcb+fFNVi7CzQGQB8U1/1XrKVSbEd/GNOAeM0peJtmi7+qphe7NvAw==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.7.3.tgz",
+      "integrity": "sha512-R2I11NRi0lI3jD2+qjqyVlVEahsejw7LDnYEbGb47QEFjczE3bZYsmWheCTQA+LFs2DzOQxR7Pms7naHW1V4bQ==",
       "dependencies": {
         "acorn": "^8.8.2",
         "acorn-import-assertions": "^1.9.0",
@@ -549,6 +561,17 @@
       "integrity": "sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/jest-docblock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
+      "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
+      "dependencies": {
+        "detect-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/koalas": {
@@ -815,6 +838,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/tlhunter-sorted-set": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/tlhunter-sorted-set/-/tlhunter-sorted-set-0.1.0.tgz",
+      "integrity": "sha512-eGYW4bjf1DtrHzUYxYfAcSytpOkA44zsr7G2n3PV7yOUR23vmkGe3LL4R+1jL9OsXtbsFOwe8XtbCrabeaEFnw=="
     },
     "node_modules/tr46": {
       "version": "0.0.3",

--- a/alerting/temporal/package.json
+++ b/alerting/temporal/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@datadog/datadog-api-client": "^1.17.0",
     "axios": "^1.5.1",
-    "dd-trace": "^4.16.0",
+    "dd-trace": "^5.1.0",
     "zod": "^3.22.4"
   }
 }

--- a/connectors/package-lock.json
+++ b/connectors/package-lock.json
@@ -24,7 +24,7 @@
         "blake3": "^2.1.7",
         "body-parser": "^1.20.2",
         "crawlee": "^3.7.1",
-        "dd-trace": "^3.16.0",
+        "dd-trace": "^5.1.0",
         "eventsource-parser": "^1.0.0",
         "express": "^4.18.2",
         "fp-ts": "^2.16.0",
@@ -753,32 +753,41 @@
       }
     },
     "node_modules/@datadog/native-appsec": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@datadog/native-appsec/-/native-appsec-3.1.0.tgz",
-      "integrity": "sha512-YSso/MWlphS5F0KDja42Oe5wGRL0CplremEf0fWE7OcoTQiHZKEPFtKAfT8bDQI+x8N4MRAVQGk4ew7AG2ICgQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@datadog/native-appsec/-/native-appsec-7.0.0.tgz",
+      "integrity": "sha512-bywstWFW2hWxzPuS0+mFMVHHL0geulx5yQFtsjfszaH2LTAgk2D+Rt40MKbAoZ8q3tRw2dy6aYQ7svO3ca8jpA==",
       "hasInstallScript": true,
       "dependencies": {
         "node-gyp-build": "^3.9.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/@datadog/native-iast-rewriter": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@datadog/native-iast-rewriter/-/native-iast-rewriter-2.0.1.tgz",
-      "integrity": "sha512-Mm+FG3XxEbPrAfJQPOMHts7iZZXRvg9gnGeeFRGkyirmRcQcOpZO4wFe/8K61DUVa5pXpgAJQ2ZkBGYF1O9STg==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@datadog/native-iast-rewriter/-/native-iast-rewriter-2.2.2.tgz",
+      "integrity": "sha512-13ZBhJpjZ/tiV6rYfyAf/ITye9cyd3x12M/2NKhD4Ivev4N4uKBREAjpArOtzKtPXZ5b6oXwVV4ofT1SHoYyzA==",
       "dependencies": {
+        "lru-cache": "^7.14.0",
         "node-gyp-build": "^4.5.0"
       },
       "engines": {
         "node": ">= 10"
       }
     },
+    "node_modules/@datadog/native-iast-rewriter/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@datadog/native-iast-rewriter/node_modules/node-gyp-build": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
-      "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.0.tgz",
+      "integrity": "sha512-u6fs2AEUljNho3EYTJNBfImO5QTo/J/1Etd+NVdCj7qWKUSN/bSLkZwhDv7I+w/MSC6qJ4cknepkAYykDdK8og==",
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
@@ -786,19 +795,21 @@
       }
     },
     "node_modules/@datadog/native-iast-taint-tracking": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-1.4.0.tgz",
-      "integrity": "sha512-lIX9HZmScAOjXHdJyCRJS9may806LxGvm/qb52cUa8Ni4sIRyEhT5Fe4mv+WDB2fT2SMFFKUC3iSlU1iBIENgw==",
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-1.6.4.tgz",
+      "integrity": "sha512-Owxk7hQ4Dxwv4zJAoMjRga0IvE6lhvxnNc8pJCHsemCWBXchjr/9bqg05Zy5JnMbKUWn4XuZeJD6RFZpRa8bfw==",
+      "hasInstallScript": true,
       "dependencies": {
         "node-gyp-build": "^3.9.0"
       }
     },
     "node_modules/@datadog/native-metrics": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@datadog/native-metrics/-/native-metrics-1.6.0.tgz",
-      "integrity": "sha512-+8jBzd0nlLV+ay3Vb87DLwz8JHAS817hRhSRQ6zxhud9TyvvcNTNN+VA2sb2fe5UK4aMDvj/sGVJjEtgr4RHew==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@datadog/native-metrics/-/native-metrics-2.0.0.tgz",
+      "integrity": "sha512-YklGVwUtmKGYqFf1MNZuOHvTYdKuR4+Af1XkWcMD8BwOAjxmd9Z+97328rCOY8TFUJzlGUPaXzB8j2qgG/BMwA==",
       "hasInstallScript": true,
       "dependencies": {
+        "node-addon-api": "^6.1.0",
         "node-gyp-build": "^3.9.0"
       },
       "engines": {
@@ -806,21 +817,19 @@
       }
     },
     "node_modules/@datadog/pprof": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@datadog/pprof/-/pprof-2.2.0.tgz",
-      "integrity": "sha512-8Ske3TeeqPV3WZFdOfhQMCF8z95jzO7krC1/W1BD5bPkYw6AqD3izfxEV4t8DKyi63IJHeN1LSj2lw2juL0k8Q==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@datadog/pprof/-/pprof-5.0.0.tgz",
+      "integrity": "sha512-vhNan4SBuNWLpexunDJQ+hNbRAgWdk2qy5Iyh7Nn94uSSHXigAJMAvu4jwMKKQKFfchtobOkWT8GQUWW3tgpFg==",
       "hasInstallScript": true,
       "dependencies": {
         "delay": "^5.0.0",
-        "node-gyp-build": "^3.9.0",
+        "node-gyp-build": "<4.0",
         "p-limit": "^3.1.0",
-        "pify": "^5.0.0",
-        "pprof-format": "^2.0.6",
-        "source-map": "^0.7.3",
-        "split": "^1.0.1"
+        "pprof-format": "^2.0.7",
+        "source-map": "^0.7.4"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/@datadog/sketches-js": {
@@ -1796,6 +1805,28 @@
       "integrity": "sha512-O2yRJce1GOc6PAy3QxFM4NzFiWzvScDC1/5ihYBL6BUEVdq0XMWN01sppE+H6bBXbaFYipjwFLEWLg5PaSOThA==",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.20.0.tgz",
+      "integrity": "sha512-lSRvk5AIdD6CtgYJcJXh0wGibQ3S/8bC2qbqKs9wK8e0K1tsWV6YkGFOqVc+jIRlCbZoIBeZzDe5UI+vb94uvg==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.20.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.20.0.tgz",
+      "integrity": "sha512-3zLJJCgTKYpbqFX8drl8hOCHtdchELC+kGqlVcV4mHW1DiElTtv1Nt9EKBptTd1IfL56QkuYnWJ3DeHd2Gtu/A==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -4069,26 +4100,38 @@
         "node": "*"
       }
     },
+    "node_modules/dc-polyfill": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/dc-polyfill/-/dc-polyfill-0.1.3.tgz",
+      "integrity": "sha512-Wyk5n/5KUj3GfVKV2jtDbtChC/Ff9fjKsBcg4ZtYW1yQe3DXNHcGURvmoxhqQdfOQ9TwyMjnfyv1lyYcOkFkFA==",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
     "node_modules/dd-trace": {
-      "version": "3.19.0",
-      "resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-3.19.0.tgz",
-      "integrity": "sha512-4YruRpO3me2+zFya7WXujMsVFG9rKiDvl+qOVQhS04/6bW8iuvZ3g/siAkpSfYz9U+QdLLJ1KFt3XWogW1635w==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-5.1.0.tgz",
+      "integrity": "sha512-7wE0+Q3xUVk1tRrxFtWYXJeI1SSuAgN0czchNmDPjIsQl+7CZacVMgcucwj1j3Pa8nG+RQUxbBsM+BkJF1Ki3Q==",
       "hasInstallScript": true,
       "dependencies": {
-        "@datadog/native-appsec": "^3.1.0",
-        "@datadog/native-iast-rewriter": "2.0.1",
-        "@datadog/native-iast-taint-tracking": "^1.4.0",
-        "@datadog/native-metrics": "^1.6.0",
-        "@datadog/pprof": "^2.2.0",
+        "@datadog/native-appsec": "7.0.0",
+        "@datadog/native-iast-rewriter": "2.2.2",
+        "@datadog/native-iast-taint-tracking": "1.6.4",
+        "@datadog/native-metrics": "^2.0.0",
+        "@datadog/pprof": "5.0.0",
         "@datadog/sketches-js": "^2.1.0",
+        "@opentelemetry/api": "^1.0.0",
+        "@opentelemetry/core": "^1.14.0",
         "crypto-randomuuid": "^1.0.0",
-        "diagnostics_channel": "^1.1.0",
-        "ignore": "^5.2.0",
-        "import-in-the-middle": "^1.3.5",
-        "ipaddr.js": "^2.0.1",
+        "dc-polyfill": "^0.1.2",
+        "ignore": "^5.2.4",
+        "import-in-the-middle": "^1.7.3",
+        "int64-buffer": "^0.1.9",
+        "ipaddr.js": "^2.1.0",
         "istanbul-lib-coverage": "3.2.0",
+        "jest-docblock": "^29.7.0",
         "koalas": "^1.0.2",
-        "limiter": "^1.1.4",
+        "limiter": "1.1.5",
         "lodash.kebabcase": "^4.1.1",
         "lodash.pick": "^4.4.0",
         "lodash.sortby": "^4.7.0",
@@ -4096,21 +4139,24 @@
         "lru-cache": "^7.14.0",
         "methods": "^1.1.2",
         "module-details-from-path": "^1.0.3",
-        "node-abort-controller": "^3.0.1",
+        "msgpack-lite": "^0.1.26",
+        "node-abort-controller": "^3.1.1",
         "opentracing": ">=0.12.1",
         "path-to-regexp": "^0.1.2",
-        "protobufjs": "^7.1.2",
-        "retry": "^0.10.1",
-        "semver": "^7.3.8"
+        "pprof-format": "^2.0.7",
+        "protobufjs": "^7.2.5",
+        "retry": "^0.13.1",
+        "semver": "^7.5.4",
+        "tlhunter-sorted-set": "^0.1.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/dd-trace/node_modules/ipaddr.js": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.0.1.tgz",
-      "integrity": "sha512-1qTgH9NG+IIJ4yfKs2e6Pp1bZg8wbDbKHT21HrLIeYBTRLgMYKnMTPAuI3Lcs61nfx5h1xlXnbJtH1kX5/d/ng==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.1.0.tgz",
+      "integrity": "sha512-LlbxQ7xKzfBusov6UMi4MFpEg0m+mAm9xyNGEduwXMEDuf4WfzB/RZwMVYEd7IKGvh4IUkEXYxtAVu9T3OelJQ==",
       "engines": {
         "node": ">= 10"
       }
@@ -4121,14 +4167,6 @@
       "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/dd-trace/node_modules/retry": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
-      "integrity": "sha512-ZXUSQYTHdl3uS7IuCehYfMzKyIDBNoAuUblvy5oGO5UJSUTmStUUVPXbA9Qxd173Bgre53yCQczQuHgRWAdvJQ==",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/debug": {
@@ -4293,6 +4331,14 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/detect-newline": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/devlop": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
@@ -4309,14 +4355,6 @@
       "version": "0.0.1239539",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1239539.tgz",
       "integrity": "sha512-uS7hZVqZxGyZwR8lX/8wWyNLGEYs1wWWxN7qeRC+wBZ4VM5JXYwCJg8hofEna5yX0W2cavpjHOE4ukHXLHlEaA=="
-    },
-    "node_modules/diagnostics_channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/diagnostics_channel/-/diagnostics_channel-1.1.0.tgz",
-      "integrity": "sha512-OE1ngLDjSBPG6Tx0YATELzYzy3RKHC+7veQ8gLa8yS7AAgw65mFbVdcsu3501abqOZCEZqZyAIemB0zXlqDSuw==",
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -4936,6 +4974,11 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/event-lite": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/event-lite/-/event-lite-0.1.3.tgz",
+      "integrity": "sha512-8qz9nOz5VeD2z96elrEKD2U433+L3DWdUdDkOINLGOJvx1GsMBbMn0aCeu28y8/e85A6mCigBiFlYMnTBEGlSw=="
     },
     "node_modules/event-stream": {
       "version": "3.3.4",
@@ -6323,9 +6366,9 @@
       }
     },
     "node_modules/import-in-the-middle": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.4.2.tgz",
-      "integrity": "sha512-9WOz1Yh/cvO/p69sxRmhyQwrIGGSp7EIdcb+fFNVi7CzQGQB8U1/1XrKVSbEd/GNOAeM0peJtmi7+qphe7NvAw==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.7.3.tgz",
+      "integrity": "sha512-R2I11NRi0lI3jD2+qjqyVlVEahsejw7LDnYEbGb47QEFjczE3bZYsmWheCTQA+LFs2DzOQxR7Pms7naHW1V4bQ==",
       "dependencies": {
         "acorn": "^8.8.2",
         "acorn-import-assertions": "^1.9.0",
@@ -6427,6 +6470,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/int64-buffer": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/int64-buffer/-/int64-buffer-0.1.10.tgz",
+      "integrity": "sha512-v7cSY1J8ydZ0GyjUHqF+1bshJ6cnEVLo9EnjB8p+4HDRPZc9N5jjmvUV7NvEsqQOKyH0pmIBFWXVQbiS0+OBbA=="
     },
     "node_modules/intercom-client": {
       "version": "5.0.0",
@@ -6785,6 +6833,17 @@
       "integrity": "sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/jest-docblock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
+      "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
+      "dependencies": {
+        "detect-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-worker": {
@@ -8210,6 +8269,25 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
+    "node_modules/msgpack-lite": {
+      "version": "0.1.26",
+      "resolved": "https://registry.npmjs.org/msgpack-lite/-/msgpack-lite-0.1.26.tgz",
+      "integrity": "sha512-SZ2IxeqZ1oRFGo0xFGbvBJWMp3yLIY9rlIJyxy8CGrwZn1f0ZK4r6jV/AM1r0FZMDUkWkglOk/eeKIL9g77Nxw==",
+      "dependencies": {
+        "event-lite": "^0.1.1",
+        "ieee754": "^1.1.8",
+        "int64-buffer": "^0.1.9",
+        "isarray": "^1.0.0"
+      },
+      "bin": {
+        "msgpack": "bin/msgpack"
+      }
+    },
+    "node_modules/msgpack-lite/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+    },
     "node_modules/mute-stream": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
@@ -8267,6 +8345,11 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
       "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ=="
+    },
+    "node_modules/node-addon-api": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
+      "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA=="
     },
     "node_modules/node-fetch": {
       "version": "2.6.9",
@@ -8893,17 +8976,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/pify": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-5.0.0.tgz",
-      "integrity": "sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/pino": {
@@ -9940,17 +10012,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/split": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-      "dependencies": {
-        "through": "2"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/split2": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
@@ -10258,6 +10319,11 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.2.tgz",
       "integrity": "sha512-cFBCCSilkRe/7JkZrQlzqhWDE0r1irpEYRp5XiFLFGl8fTwN4eWqutyx9wfFaDfmVv7E7pQMUZnM1VHnOid5Vw=="
+    },
+    "node_modules/tlhunter-sorted-set": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/tlhunter-sorted-set/-/tlhunter-sorted-set-0.1.0.tgz",
+      "integrity": "sha512-eGYW4bjf1DtrHzUYxYfAcSytpOkA44zsr7G2n3PV7yOUR23vmkGe3LL4R+1jL9OsXtbsFOwe8XtbCrabeaEFnw=="
     },
     "node_modules/tmp": {
       "version": "0.0.33",

--- a/connectors/package.json
+++ b/connectors/package.json
@@ -29,7 +29,7 @@
     "blake3": "^2.1.7",
     "body-parser": "^1.20.2",
     "crawlee": "^3.7.1",
-    "dd-trace": "^3.16.0",
+    "dd-trace": "^5.1.0",
     "eventsource-parser": "^1.0.0",
     "express": "^4.18.2",
     "fp-ts": "^2.16.0",

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -21,7 +21,7 @@
         "algoliasearch": "^4.14.2",
         "autoprefixer": "^10.4.12",
         "clsx": "^1.2.0",
-        "dd-trace": "^3.16.0",
+        "dd-trace": "^5.1.0",
         "focus-visible": "^5.2.0",
         "framer-motion": "7.8.1",
         "mdast-util-to-string": "^3.1.0",
@@ -181,32 +181,41 @@
       }
     },
     "node_modules/@datadog/native-appsec": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@datadog/native-appsec/-/native-appsec-3.2.0.tgz",
-      "integrity": "sha512-biAa7EFfuavjSWgSQaCit9CqGzr6Af5nhzfNNGJ38Y/Y387hDvLivAR374kK1z6XoxGZEOa+XPbVogmV/2Bcjw==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@datadog/native-appsec/-/native-appsec-7.0.0.tgz",
+      "integrity": "sha512-bywstWFW2hWxzPuS0+mFMVHHL0geulx5yQFtsjfszaH2LTAgk2D+Rt40MKbAoZ8q3tRw2dy6aYQ7svO3ca8jpA==",
       "hasInstallScript": true,
       "dependencies": {
         "node-gyp-build": "^3.9.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/@datadog/native-iast-rewriter": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@datadog/native-iast-rewriter/-/native-iast-rewriter-2.0.1.tgz",
-      "integrity": "sha512-Mm+FG3XxEbPrAfJQPOMHts7iZZXRvg9gnGeeFRGkyirmRcQcOpZO4wFe/8K61DUVa5pXpgAJQ2ZkBGYF1O9STg==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@datadog/native-iast-rewriter/-/native-iast-rewriter-2.2.2.tgz",
+      "integrity": "sha512-13ZBhJpjZ/tiV6rYfyAf/ITye9cyd3x12M/2NKhD4Ivev4N4uKBREAjpArOtzKtPXZ5b6oXwVV4ofT1SHoYyzA==",
       "dependencies": {
+        "lru-cache": "^7.14.0",
         "node-gyp-build": "^4.5.0"
       },
       "engines": {
         "node": ">= 10"
       }
     },
+    "node_modules/@datadog/native-iast-rewriter/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@datadog/native-iast-rewriter/node_modules/node-gyp-build": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
-      "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.0.tgz",
+      "integrity": "sha512-u6fs2AEUljNho3EYTJNBfImO5QTo/J/1Etd+NVdCj7qWKUSN/bSLkZwhDv7I+w/MSC6qJ4cknepkAYykDdK8og==",
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
@@ -214,9 +223,10 @@
       }
     },
     "node_modules/@datadog/native-iast-taint-tracking": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-1.5.0.tgz",
-      "integrity": "sha512-SOWIk1M6PZH0osNB191Voz2rKBPoF5hISWVSK9GiJPrD40+xjib1Z/bFDV7EkDn3kjOyordSBdNPG5zOqZJdyg==",
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-1.6.4.tgz",
+      "integrity": "sha512-Owxk7hQ4Dxwv4zJAoMjRga0IvE6lhvxnNc8pJCHsemCWBXchjr/9bqg05Zy5JnMbKUWn4XuZeJD6RFZpRa8bfw==",
+      "hasInstallScript": true,
       "dependencies": {
         "node-gyp-build": "^3.9.0"
       }
@@ -235,9 +245,9 @@
       }
     },
     "node_modules/@datadog/pprof": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@datadog/pprof/-/pprof-3.1.0.tgz",
-      "integrity": "sha512-Bg8O8yrHeL2KKHXhLoAAT33ZfzLnZ6rWfOjy8PkcNhUJy3UwNVLbUoApf+99EyLjqpzpk/kZXrIAMBzMMB8ilg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@datadog/pprof/-/pprof-5.0.0.tgz",
+      "integrity": "sha512-vhNan4SBuNWLpexunDJQ+hNbRAgWdk2qy5Iyh7Nn94uSSHXigAJMAvu4jwMKKQKFfchtobOkWT8GQUWW3tgpFg==",
       "hasInstallScript": true,
       "dependencies": {
         "delay": "^5.0.0",
@@ -247,7 +257,7 @@
         "source-map": "^0.7.4"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/@datadog/sketches-js": {
@@ -1847,29 +1857,38 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
+    "node_modules/dc-polyfill": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/dc-polyfill/-/dc-polyfill-0.1.3.tgz",
+      "integrity": "sha512-Wyk5n/5KUj3GfVKV2jtDbtChC/Ff9fjKsBcg4ZtYW1yQe3DXNHcGURvmoxhqQdfOQ9TwyMjnfyv1lyYcOkFkFA==",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
     "node_modules/dd-trace": {
-      "version": "3.31.0",
-      "resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-3.31.0.tgz",
-      "integrity": "sha512-c12qdJ/ydPnjc3BbiOBG/t6U+B4roVqSrUKdLNijr1R/Hwc2ftbNdToqo+6gAw8MY1uIm1xgHYPJ7agCLACglQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-5.1.0.tgz",
+      "integrity": "sha512-7wE0+Q3xUVk1tRrxFtWYXJeI1SSuAgN0czchNmDPjIsQl+7CZacVMgcucwj1j3Pa8nG+RQUxbBsM+BkJF1Ki3Q==",
       "hasInstallScript": true,
       "dependencies": {
-        "@datadog/native-appsec": "^3.2.0",
-        "@datadog/native-iast-rewriter": "2.0.1",
-        "@datadog/native-iast-taint-tracking": "1.5.0",
+        "@datadog/native-appsec": "7.0.0",
+        "@datadog/native-iast-rewriter": "2.2.2",
+        "@datadog/native-iast-taint-tracking": "1.6.4",
         "@datadog/native-metrics": "^2.0.0",
-        "@datadog/pprof": "3.1.0",
+        "@datadog/pprof": "5.0.0",
         "@datadog/sketches-js": "^2.1.0",
         "@opentelemetry/api": "^1.0.0",
         "@opentelemetry/core": "^1.14.0",
         "crypto-randomuuid": "^1.0.0",
-        "diagnostics_channel": "^1.1.0",
+        "dc-polyfill": "^0.1.2",
         "ignore": "^5.2.4",
-        "import-in-the-middle": "^1.4.1",
+        "import-in-the-middle": "^1.7.3",
         "int64-buffer": "^0.1.9",
         "ipaddr.js": "^2.1.0",
         "istanbul-lib-coverage": "3.2.0",
+        "jest-docblock": "^29.7.0",
         "koalas": "^1.0.2",
-        "limiter": "^1.1.4",
+        "limiter": "1.1.5",
         "lodash.kebabcase": "^4.1.1",
         "lodash.pick": "^4.4.0",
         "lodash.sortby": "^4.7.0",
@@ -1881,12 +1900,14 @@
         "node-abort-controller": "^3.1.1",
         "opentracing": ">=0.12.1",
         "path-to-regexp": "^0.1.2",
-        "protobufjs": "^7.2.4",
+        "pprof-format": "^2.0.7",
+        "protobufjs": "^7.2.5",
         "retry": "^0.13.1",
-        "semver": "^7.5.4"
+        "semver": "^7.5.4",
+        "tlhunter-sorted-set": "^0.1.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/dd-trace/node_modules/lru-cache": {
@@ -1995,6 +2016,14 @@
         "node": ">=6"
       }
     },
+    "node_modules/detect-newline": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/detective": {
       "version": "5.2.1",
       "license": "MIT",
@@ -2008,14 +2037,6 @@
       },
       "engines": {
         "node": ">=0.8.0"
-      }
-    },
-    "node_modules/diagnostics_channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/diagnostics_channel/-/diagnostics_channel-1.1.0.tgz",
-      "integrity": "sha512-OE1ngLDjSBPG6Tx0YATELzYzy3RKHC+7veQ8gLa8yS7AAgw65mFbVdcsu3501abqOZCEZqZyAIemB0zXlqDSuw==",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/didyoumean": {
@@ -3177,9 +3198,9 @@
       }
     },
     "node_modules/import-in-the-middle": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.4.2.tgz",
-      "integrity": "sha512-9WOz1Yh/cvO/p69sxRmhyQwrIGGSp7EIdcb+fFNVi7CzQGQB8U1/1XrKVSbEd/GNOAeM0peJtmi7+qphe7NvAw==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.7.3.tgz",
+      "integrity": "sha512-R2I11NRi0lI3jD2+qjqyVlVEahsejw7LDnYEbGb47QEFjczE3bZYsmWheCTQA+LFs2DzOQxR7Pms7naHW1V4bQ==",
       "dependencies": {
         "acorn": "^8.8.2",
         "acorn-import-assertions": "^1.9.0",
@@ -3604,6 +3625,17 @@
       "integrity": "sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/jest-docblock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
+      "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
+      "dependencies": {
+        "detect-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-worker": {
@@ -5524,9 +5556,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.4.tgz",
-      "integrity": "sha512-AT+RJgD2sH8phPmCf7OUZR8xGdcJRga4+1cOaXJ64hvcSkVhNcRHOwIxUatPH15+nj59WAGTDv3LSGZPEQbJaQ==",
+      "version": "7.2.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.6.tgz",
+      "integrity": "sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -6288,6 +6320,11 @@
       "version": "0.2.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tlhunter-sorted-set": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/tlhunter-sorted-set/-/tlhunter-sorted-set-0.1.0.tgz",
+      "integrity": "sha512-eGYW4bjf1DtrHzUYxYfAcSytpOkA44zsr7G2n3PV7yOUR23vmkGe3LL4R+1jL9OsXtbsFOwe8XtbCrabeaEFnw=="
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",

--- a/docs/package.json
+++ b/docs/package.json
@@ -24,7 +24,7 @@
     "algoliasearch": "^4.14.2",
     "autoprefixer": "^10.4.12",
     "clsx": "^1.2.0",
-    "dd-trace": "^3.16.0",
+    "dd-trace": "^5.1.0",
     "@dust-tt/sparkle": "0.1.26",
     "focus-visible": "^5.2.0",
     "framer-motion": "7.8.1",

--- a/front/logger/withlogging.ts
+++ b/front/logger/withlogging.ts
@@ -1,7 +1,7 @@
-import { APIErrorWithStatusCode } from "@dust-tt/types";
+import type { APIErrorWithStatusCode } from "@dust-tt/types";
 import tracer from "dd-trace";
 import StatsD from "hot-shots";
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 import logger from "./logger";
 

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -34,7 +34,7 @@
         "csv-parse": "^5.5.2",
         "csv-stringify": "^6.4.5",
         "date-fns": "^3.2.0",
-        "dd-trace": "^3.16.0",
+        "dd-trace": "^5.1.0",
         "emoji-mart": "^5.5.2",
         "eventsource-parser": "^1.0.0",
         "fast-diff": "^1.3.0",
@@ -814,21 +814,21 @@
       "dev": true
     },
     "node_modules/@datadog/native-appsec": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@datadog/native-appsec/-/native-appsec-4.0.0.tgz",
-      "integrity": "sha512-myTguXJ3VQHS2E1ylNsSF1avNpDmq5t+K4Q47wdzeakGc3sDIDDyEbvuFTujl9c9wBIkup94O1mZj5DR37ajzA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@datadog/native-appsec/-/native-appsec-7.0.0.tgz",
+      "integrity": "sha512-bywstWFW2hWxzPuS0+mFMVHHL0geulx5yQFtsjfszaH2LTAgk2D+Rt40MKbAoZ8q3tRw2dy6aYQ7svO3ca8jpA==",
       "hasInstallScript": true,
       "dependencies": {
         "node-gyp-build": "^3.9.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/@datadog/native-iast-rewriter": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@datadog/native-iast-rewriter/-/native-iast-rewriter-2.1.3.tgz",
-      "integrity": "sha512-4oxMFz5ZEpOK3pRc9KjquMgkRP6D+oPQVIzOk4dgG8fl2iepHtCa3gna/fQBfdWIiX5a2j65O3R1zNp2ckk8JA==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@datadog/native-iast-rewriter/-/native-iast-rewriter-2.2.2.tgz",
+      "integrity": "sha512-13ZBhJpjZ/tiV6rYfyAf/ITye9cyd3x12M/2NKhD4Ivev4N4uKBREAjpArOtzKtPXZ5b6oXwVV4ofT1SHoYyzA==",
       "dependencies": {
         "lru-cache": "^7.14.0",
         "node-gyp-build": "^4.5.0"
@@ -838,9 +838,9 @@
       }
     },
     "node_modules/@datadog/native-iast-rewriter/node_modules/node-gyp-build": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.1.tgz",
-      "integrity": "sha512-24vnklJmyRS8ViBNI8KbtK/r/DmXQMRiOMXTNz2nrTnAYUwjmEEbnnpB/+kt+yWRv73bPsSPRFddrcIbAxSiMQ==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.0.tgz",
+      "integrity": "sha512-u6fs2AEUljNho3EYTJNBfImO5QTo/J/1Etd+NVdCj7qWKUSN/bSLkZwhDv7I+w/MSC6qJ4cknepkAYykDdK8og==",
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
@@ -848,9 +848,10 @@
       }
     },
     "node_modules/@datadog/native-iast-taint-tracking": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-1.5.0.tgz",
-      "integrity": "sha512-SOWIk1M6PZH0osNB191Voz2rKBPoF5hISWVSK9GiJPrD40+xjib1Z/bFDV7EkDn3kjOyordSBdNPG5zOqZJdyg==",
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-1.6.4.tgz",
+      "integrity": "sha512-Owxk7hQ4Dxwv4zJAoMjRga0IvE6lhvxnNc8pJCHsemCWBXchjr/9bqg05Zy5JnMbKUWn4XuZeJD6RFZpRa8bfw==",
+      "hasInstallScript": true,
       "dependencies": {
         "node-gyp-build": "^3.9.0"
       }
@@ -869,9 +870,9 @@
       }
     },
     "node_modules/@datadog/pprof": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@datadog/pprof/-/pprof-3.2.0.tgz",
-      "integrity": "sha512-kOhWHCWB80djnMCr5KNKBAy1Ih/jK/PIj6yqnZwL1Wqni/h6IBPRUMhtIxcYJMRgsZVYrFXUV20AVXTZCzFokw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@datadog/pprof/-/pprof-5.0.0.tgz",
+      "integrity": "sha512-vhNan4SBuNWLpexunDJQ+hNbRAgWdk2qy5Iyh7Nn94uSSHXigAJMAvu4jwMKKQKFfchtobOkWT8GQUWW3tgpFg==",
       "hasInstallScript": true,
       "dependencies": {
         "delay": "^5.0.0",
@@ -881,7 +882,7 @@
         "source-map": "^0.7.4"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/@datadog/pprof/node_modules/source-map": {
@@ -5961,29 +5962,38 @@
         "node": "*"
       }
     },
+    "node_modules/dc-polyfill": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/dc-polyfill/-/dc-polyfill-0.1.3.tgz",
+      "integrity": "sha512-Wyk5n/5KUj3GfVKV2jtDbtChC/Ff9fjKsBcg4ZtYW1yQe3DXNHcGURvmoxhqQdfOQ9TwyMjnfyv1lyYcOkFkFA==",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
     "node_modules/dd-trace": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-3.37.0.tgz",
-      "integrity": "sha512-0F/mM+T3ayNxu//Cfqh+NajC4F/6Hn7QMVPIR4Gsn2gK7DfaOHXh0/cPI5mWNANA04vES73GVpUkDhGQAtFnVw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-5.1.0.tgz",
+      "integrity": "sha512-7wE0+Q3xUVk1tRrxFtWYXJeI1SSuAgN0czchNmDPjIsQl+7CZacVMgcucwj1j3Pa8nG+RQUxbBsM+BkJF1Ki3Q==",
       "hasInstallScript": true,
       "dependencies": {
-        "@datadog/native-appsec": "^4.0.0",
-        "@datadog/native-iast-rewriter": "2.1.3",
-        "@datadog/native-iast-taint-tracking": "1.5.0",
+        "@datadog/native-appsec": "7.0.0",
+        "@datadog/native-iast-rewriter": "2.2.2",
+        "@datadog/native-iast-taint-tracking": "1.6.4",
         "@datadog/native-metrics": "^2.0.0",
-        "@datadog/pprof": "3.2.0",
+        "@datadog/pprof": "5.0.0",
         "@datadog/sketches-js": "^2.1.0",
         "@opentelemetry/api": "^1.0.0",
         "@opentelemetry/core": "^1.14.0",
         "crypto-randomuuid": "^1.0.0",
-        "diagnostics_channel": "^1.1.0",
+        "dc-polyfill": "^0.1.2",
         "ignore": "^5.2.4",
-        "import-in-the-middle": "^1.4.2",
+        "import-in-the-middle": "^1.7.3",
         "int64-buffer": "^0.1.9",
         "ipaddr.js": "^2.1.0",
         "istanbul-lib-coverage": "3.2.0",
+        "jest-docblock": "^29.7.0",
         "koalas": "^1.0.2",
-        "limiter": "^1.1.4",
+        "limiter": "1.1.5",
         "lodash.kebabcase": "^4.1.1",
         "lodash.pick": "^4.4.0",
         "lodash.sortby": "^4.7.0",
@@ -5995,12 +6005,14 @@
         "node-abort-controller": "^3.1.1",
         "opentracing": ">=0.12.1",
         "path-to-regexp": "^0.1.2",
-        "protobufjs": "^7.2.4",
+        "pprof-format": "^2.0.7",
+        "protobufjs": "^7.2.5",
         "retry": "^0.13.1",
-        "semver": "^7.5.4"
+        "semver": "^7.5.4",
+        "tlhunter-sorted-set": "^0.1.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/debug": {
@@ -6184,7 +6196,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -6196,14 +6207,6 @@
       "dependencies": {
         "asap": "^2.0.0",
         "wrappy": "1"
-      }
-    },
-    "node_modules/diagnostics_channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/diagnostics_channel/-/diagnostics_channel-1.1.0.tgz",
-      "integrity": "sha512-OE1ngLDjSBPG6Tx0YATELzYzy3RKHC+7veQ8gLa8yS7AAgw65mFbVdcsu3501abqOZCEZqZyAIemB0zXlqDSuw==",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/didyoumean": {
@@ -8624,9 +8627,9 @@
       }
     },
     "node_modules/import-in-the-middle": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.4.2.tgz",
-      "integrity": "sha512-9WOz1Yh/cvO/p69sxRmhyQwrIGGSp7EIdcb+fFNVi7CzQGQB8U1/1XrKVSbEd/GNOAeM0peJtmi7+qphe7NvAw==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.7.3.tgz",
+      "integrity": "sha512-R2I11NRi0lI3jD2+qjqyVlVEahsejw7LDnYEbGb47QEFjczE3bZYsmWheCTQA+LFs2DzOQxR7Pms7naHW1V4bQ==",
       "dependencies": {
         "acorn": "^8.8.2",
         "acorn-import-assertions": "^1.9.0",
@@ -9504,7 +9507,6 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
       "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
-      "dev": true,
       "dependencies": {
         "detect-newline": "^3.0.0"
       },
@@ -15732,6 +15734,11 @@
       "dependencies": {
         "@popperjs/core": "^2.9.0"
       }
+    },
+    "node_modules/tlhunter-sorted-set": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/tlhunter-sorted-set/-/tlhunter-sorted-set-0.1.0.tgz",
+      "integrity": "sha512-eGYW4bjf1DtrHzUYxYfAcSytpOkA44zsr7G2n3PV7yOUR23vmkGe3LL4R+1jL9OsXtbsFOwe8XtbCrabeaEFnw=="
     },
     "node_modules/tmpl": {
       "version": "1.0.5",

--- a/front/package.json
+++ b/front/package.json
@@ -42,7 +42,7 @@
     "csv-parse": "^5.5.2",
     "csv-stringify": "^6.4.5",
     "date-fns": "^3.2.0",
-    "dd-trace": "^3.16.0",
+    "dd-trace": "^5.1.0",
     "emoji-mart": "^5.5.2",
     "eventsource-parser": "^1.0.0",
     "fast-diff": "^1.3.0",


### PR DESCRIPTION
## Description

We have 4 dependabot security issues. The fix is not yet released by dd-trace but their support for v3 is coming to an end. This PR bumps all dd-trace (whose usage is pretty basic in our codebase) to v5.

## Risk

Guarded by type-system but there is still a chance we break our datadog setup. Will monitor deployment and check all logs and metrics are working as expected

## Deploy Plan

- deploy `front`
- deploy `connectors`
- deploy `temporal/alserting`
- deploy `doc`