### PR TITLE
Flav/display synced confluence resources

### DIFF
--- a/connectors/src/connectors/confluence/index.ts
+++ b/connectors/src/connectors/confluence/index.ts
@@ -20,7 +20,7 @@ import {
 } from "@connectors/connectors/confluence/lib/internal_ids";
 import {
   retrieveAvailableSpaces,
-  retrieveSynchronizedData,
+  retrieveHierarchyForParent,
 } from "@connectors/connectors/confluence/lib/permissions";
 import {
   launchConfluencePersonalDataReportingSchedule,
@@ -243,8 +243,10 @@ export async function retrieveConfluenceConnectorPermissions({
     return new Err(new Error("Confluence configuration not found"));
   }
 
+  // When the filter permission is set to 'read', the full hierarchy of spaces
+  // and pages that Dust can access is displayed to the user.
   if (filterPermission === "read") {
-    const data = await retrieveSynchronizedData(
+    const data = await retrieveHierarchyForParent(
       connector,
       confluenceConfig,
       parentInternalId
@@ -256,6 +258,8 @@ export async function retrieveConfluenceConnectorPermissions({
 
     return new Ok(data.value);
   } else {
+    // If the permission is not set to 'read', users are limited to selecting only
+    // spaces for synchronization with Dust.
     const allSpaces = await retrieveAvailableSpaces(
       connector,
       confluenceConfig

--- a/connectors/src/connectors/confluence/index.ts
+++ b/connectors/src/connectors/confluence/index.ts
@@ -299,8 +299,8 @@ export async function setConfluenceConnectorPermissions(
 
   const addedSpaceIds = [];
   const removedSpaceIds = [];
-  for (const [publicId, permission] of Object.entries(permissions)) {
-    const confluenceId = getIdFromConfluenceInternalId(publicId);
+  for (const [internalId, permission] of Object.entries(permissions)) {
+    const confluenceId = getIdFromConfluenceInternalId(internalId);
     if (permission === "none") {
       await ConfluenceSpace.destroy({
         where: {
@@ -380,11 +380,11 @@ export async function retrieveConfluenceObjectsTitles(
 
 export async function retrieveConfluenceResourceParents(
   connectorId: ModelId,
-  publicId: string
+  internalId: string
 ): Promise<Result<string[], Error>> {
-  const confluenceId = getIdFromConfluenceInternalId(publicId);
+  const confluenceId = getIdFromConfluenceInternalId(internalId);
 
-  if (isConfluenceInternalPageId(publicId)) {
+  if (isConfluenceInternalPageId(internalId)) {
     const currentPage = await ConfluencePage.findOne({
       attributes: ["pageId", "parentId", "spaceId"],
       where: {
@@ -406,6 +406,7 @@ export async function retrieveConfluenceResourceParents(
     // this logic may be enhanced later for important Confluence connections.
     // By fetching all pages within a space, we reconstruct parent-child
     // relationships in-app, minimizing database interactions.
+    // If needed we could move the same approach as Notion and cache the results in Redis.
     const allPages = await ConfluencePage.findAll({
       attributes: ["pageId", "parentId"],
       where: {

--- a/connectors/src/connectors/confluence/lib/internal_ids.ts
+++ b/connectors/src/connectors/confluence/lib/internal_ids.ts
@@ -3,29 +3,26 @@ enum ConfluenceInternalIdPrefix {
   Page = "page_",
 }
 
-export function makeConfluenceInternalSpaceId(spaceId: string) {
-  return `${ConfluenceInternalIdPrefix.Space}${spaceId}`;
+export function makeConfluencePublicSpaceId(confluenceSpaceId: string) {
+  return `${ConfluenceInternalIdPrefix.Space}${confluenceSpaceId}`;
 }
 
-export function makeConfluenceInternalPageId(pageId: number) {
-  return `${ConfluenceInternalIdPrefix.Page}${pageId}`;
+export function makeConfluencePublicPageId(confluencePageId: string) {
+  return `${ConfluenceInternalIdPrefix.Page}${confluencePageId}`;
 }
 
-export function getIdFromConfluenceInternalId(internalId: string) {
+export function getIdFromConfluencePublicId(internalId: string) {
   const prefixPattern = `^(${ConfluenceInternalIdPrefix.Space}|${ConfluenceInternalIdPrefix.Page})`;
-  const id = internalId.replace(new RegExp(prefixPattern), "");
-
-  const parsedInt = parseInt(id, 10);
-  return isNaN(parsedInt) ? null : parsedInt;
+  return internalId.replace(new RegExp(prefixPattern), "");
 }
 
-export function isConfluenceInternalSpaceId(
+export function isConfluencePublicSpaceId(
   internalId: string
 ): internalId is `${ConfluenceInternalIdPrefix.Space}${string}` {
   return internalId.startsWith(ConfluenceInternalIdPrefix.Space);
 }
 
-export function isConfluenceInternalPageId(
+export function isConfluencePublicPageId(
   internalId: string
 ): internalId is `${ConfluenceInternalIdPrefix.Page}${string}` {
   return internalId.startsWith(ConfluenceInternalIdPrefix.Page);

--- a/connectors/src/connectors/confluence/lib/internal_ids.ts
+++ b/connectors/src/connectors/confluence/lib/internal_ids.ts
@@ -1,0 +1,32 @@
+enum ConfluenceInternalIdPrefix {
+  Space = "space_",
+  Page = "page_",
+}
+
+export function makeConfluenceInternalSpaceId(spaceId: string) {
+  return `${ConfluenceInternalIdPrefix.Space}${spaceId}`;
+}
+
+export function makeConfluenceInternalPageId(pageId: number) {
+  return `${ConfluenceInternalIdPrefix.Page}${pageId}`;
+}
+
+export function getIdFromConfluenceInternalId(internalId: string) {
+  const prefixPattern = `^(${ConfluenceInternalIdPrefix.Space}|${ConfluenceInternalIdPrefix.Page})`;
+  const id = internalId.replace(new RegExp(prefixPattern), "");
+
+  const parsedInt = parseInt(id, 10);
+  return isNaN(parsedInt) ? null : parsedInt;
+}
+
+export function isConfluenceInternalSpaceId(
+  internalId: string
+): internalId is `${ConfluenceInternalIdPrefix.Space}${string}` {
+  return internalId.startsWith(ConfluenceInternalIdPrefix.Space);
+}
+
+export function isConfluenceInternalPageId(
+  internalId: string
+): internalId is `${ConfluenceInternalIdPrefix.Page}${string}` {
+  return internalId.startsWith(ConfluenceInternalIdPrefix.Page);
+}

--- a/connectors/src/connectors/confluence/lib/internal_ids.ts
+++ b/connectors/src/connectors/confluence/lib/internal_ids.ts
@@ -3,26 +3,26 @@ enum ConfluenceInternalIdPrefix {
   Page = "page_",
 }
 
-export function makeConfluencePublicSpaceId(confluenceSpaceId: string) {
+export function makeConfluenceInternalSpaceId(confluenceSpaceId: string) {
   return `${ConfluenceInternalIdPrefix.Space}${confluenceSpaceId}`;
 }
 
-export function makeConfluencePublicPageId(confluencePageId: string) {
+export function makeConfluenceInternalPageId(confluencePageId: string) {
   return `${ConfluenceInternalIdPrefix.Page}${confluencePageId}`;
 }
 
-export function getIdFromConfluencePublicId(internalId: string) {
+export function getIdFromConfluenceInternalId(internalId: string) {
   const prefixPattern = `^(${ConfluenceInternalIdPrefix.Space}|${ConfluenceInternalIdPrefix.Page})`;
   return internalId.replace(new RegExp(prefixPattern), "");
 }
 
-export function isConfluencePublicSpaceId(
+export function isConfluenceInternalSpaceId(
   internalId: string
 ): internalId is `${ConfluenceInternalIdPrefix.Space}${string}` {
   return internalId.startsWith(ConfluenceInternalIdPrefix.Space);
 }
 
-export function isConfluencePublicPageId(
+export function isConfluenceInternalPageId(
   internalId: string
 ): internalId is `${ConfluenceInternalIdPrefix.Page}${string}` {
   return internalId.startsWith(ConfluenceInternalIdPrefix.Page);

--- a/connectors/src/connectors/confluence/lib/permissions.ts
+++ b/connectors/src/connectors/confluence/lib/permissions.ts
@@ -38,19 +38,16 @@ function createConnectorResourceFromSpace(
   space: ConfluenceSpace | ConfluenceSpaceType,
   baseUrl: string,
   permission: ConnectorPermission,
-  {
-    isExpandable,
-    useInternalId,
-  }: { isExpandable: boolean; useInternalId: boolean }
+  { isExpandable }: { isExpandable: boolean }
 ): ConnectorResource {
-  const urlSuffix = "_links" in space ? space._links.webui : space.urlSuffix;
+  const urlSuffix = isConfluenceSpaceModel(space)
+    ? space.urlSuffix
+    : space._links.webui;
   const spaceId = isConfluenceSpaceModel(space) ? space.spaceId : space.id;
 
   return {
     provider: "confluence",
-    internalId: useInternalId
-      ? makeConfluenceInternalSpaceId(spaceId)
-      : space.id.toString(),
+    internalId: makeConfluenceInternalSpaceId(spaceId),
     parentInternalId: null,
     type: "folder",
     title: space.name || "Unnamed Space",
@@ -233,7 +230,6 @@ export async function retrieveSynchronizedData(
   const allSpaces = syncedSpaces.map((space) =>
     createConnectorResourceFromSpace(space, confluenceConfig.url, "read", {
       isExpandable: true,
-      useInternalId: true,
     })
   );
 
@@ -261,7 +257,7 @@ export async function retrieveAvailableSpaces(
       space,
       confluenceConfig.url,
       isSynced ? "read" : "none",
-      { isExpandable: false, useInternalId: false }
+      { isExpandable: false }
     );
   });
 }

--- a/connectors/src/connectors/confluence/lib/permissions.ts
+++ b/connectors/src/connectors/confluence/lib/permissions.ts
@@ -184,7 +184,7 @@ async function getSynchronizedChildrenPages(
   return new Ok(allPages);
 }
 
-export async function retrieveSynchronizedData(
+export async function retrieveHierarchyForParent(
   connector: Connector,
   confluenceConfig: ConfluenceConfiguration,
   parentInternalId: string | null

--- a/connectors/src/connectors/confluence/lib/permissions.ts
+++ b/connectors/src/connectors/confluence/lib/permissions.ts
@@ -1,0 +1,261 @@
+import type {
+  ConnectorPermission,
+  ConnectorResource,
+  ModelId,
+  Result,
+} from "@dust-tt/types";
+import { Err, Ok } from "@dust-tt/types";
+import { Op } from "sequelize";
+
+import { listConfluenceSpaces } from "@connectors/connectors/confluence/lib/confluence_api";
+import type { ConfluenceSpaceType } from "@connectors/connectors/confluence/lib/confluence_client";
+import {
+  getIdFromConfluenceInternalId,
+  isConfluenceInternalPageId,
+  isConfluenceInternalSpaceId,
+  makeConfluenceInternalPageId,
+  makeConfluenceInternalSpaceId,
+} from "@connectors/connectors/confluence/lib/internal_ids";
+import type { Connector } from "@connectors/lib/models";
+import type { ConfluenceConfiguration } from "@connectors/lib/models/confluence";
+import {
+  ConfluencePage,
+  ConfluenceSpace,
+} from "@connectors/lib/models/confluence";
+
+function createConnectorResourceFromSpace(
+  space: ConfluenceSpace | ConfluenceSpaceType,
+  baseUrl: string,
+  permission: ConnectorPermission,
+  {
+    isExpandable,
+    usesInternalId,
+  }: { isExpandable: boolean; usesInternalId: boolean }
+): ConnectorResource {
+  const urlSuffix = "_links" in space ? space._links.webui : space.urlSuffix;
+
+  return {
+    provider: "confluence",
+    internalId: usesInternalId
+      ? makeConfluenceInternalSpaceId(space.id.toString())
+      : space.id.toString(),
+    parentInternalId: null,
+    type: "folder",
+    title: space.name || "Unnamed Space",
+    sourceUrl: `${baseUrl}/wiki${urlSuffix}`,
+    expandable: isExpandable,
+    permission,
+    dustDocumentId: null,
+    lastUpdatedAt: null,
+  };
+}
+
+function createConnectorResourceFromPage(
+  parent: { id: ModelId; type: "page" | "space" },
+  baseUrl: string,
+  page: ConfluencePage,
+  isExpandable = false
+): ConnectorResource {
+  return {
+    provider: "confluence",
+    internalId: makeConfluenceInternalPageId(page.id),
+    parentInternalId:
+      parent.type === "space"
+        ? makeConfluenceInternalSpaceId(parent.id.toString())
+        : makeConfluenceInternalPageId(parent.id),
+    type: "file",
+    title: page.title,
+    sourceUrl: `${baseUrl}/wiki${page.externalUrl}`,
+    expandable: isExpandable,
+    permission: "read",
+    dustDocumentId: null,
+    lastUpdatedAt: null,
+  };
+}
+
+async function checkPageHasChildren(connectorId: ModelId, pageId: string) {
+  const childrenPagesCount = await ConfluencePage.count({
+    where: {
+      connectorId,
+      parentId: pageId,
+    },
+  });
+
+  return childrenPagesCount > 0;
+}
+
+async function getSynchronizedSpaces(
+  connectorId: ModelId,
+  confluenceConfig: ConfluenceConfiguration,
+  parentInternalId: string
+): Promise<Result<ConnectorResource[], Error>> {
+  const internalId = getIdFromConfluenceInternalId(parentInternalId);
+  if (!internalId) {
+    return new Err(new Error("Invalid Confluence internal id."));
+  }
+
+  const parentSpace = await ConfluenceSpace.findOne({
+    attributes: ["id", "spaceId"],
+    where: {
+      connectorId,
+      id: internalId,
+    },
+  });
+
+  if (!parentSpace) {
+    return new Err(new Error(`Confluence space not found.`));
+  }
+
+  const pagesWithinSpace = await ConfluencePage.findAll({
+    attributes: ["id", "pageId", "title", "externalUrl"],
+    where: {
+      connectorId,
+      spaceId: parentSpace.spaceId,
+      parentId: {
+        [Op.is]: null,
+      },
+    },
+  });
+
+  const allPages: ConnectorResource[] = [];
+  for (const page of pagesWithinSpace) {
+    const hasChildren = await checkPageHasChildren(connectorId, page.pageId);
+
+    const res = createConnectorResourceFromPage(
+      { id: parentSpace.id, type: "space" },
+      confluenceConfig.url,
+      page,
+      hasChildren
+    );
+
+    allPages.push(res);
+  }
+
+  return new Ok(allPages);
+}
+
+async function getSynchronizedChildrenPages(
+  connectorId: ModelId,
+  confluenceConfig: ConfluenceConfiguration,
+  parentInternalId: string
+): Promise<Result<ConnectorResource[], Error>> {
+  const internalId = getIdFromConfluenceInternalId(parentInternalId);
+  if (!internalId) {
+    return new Err(new Error("Invalid Confluence internal id."));
+  }
+
+  const parentPage = await ConfluencePage.findOne({
+    attributes: ["id", "pageId"],
+    where: {
+      connectorId,
+      id: internalId,
+    },
+  });
+
+  if (!parentPage) {
+    return new Err(new Error(`Confluence page not found.`));
+  }
+
+  const pagesWithinSpace = await ConfluencePage.findAll({
+    attributes: ["id", "pageId", "title", "externalUrl"],
+    where: {
+      connectorId,
+      parentId: parentPage.pageId,
+    },
+  });
+
+  const allPages: ConnectorResource[] = [];
+  for (const page of pagesWithinSpace) {
+    const hasChildren = await checkPageHasChildren(connectorId, page.pageId);
+
+    const res = createConnectorResourceFromPage(
+      { id: parentPage.id, type: "page" },
+      confluenceConfig.url,
+      page,
+      hasChildren
+    );
+
+    allPages.push(res);
+  }
+
+  return new Ok(allPages);
+}
+
+export async function retrieveSynchronizedData(
+  connector: Connector,
+  confluenceConfig: ConfluenceConfiguration,
+  parentInternalId: string | null
+) {
+  const { id: connectorId } = connector;
+
+  if (parentInternalId) {
+    if (isConfluenceInternalSpaceId(parentInternalId)) {
+      const resources = await getSynchronizedSpaces(
+        connectorId,
+        confluenceConfig,
+        parentInternalId
+      );
+
+      if (resources.isErr()) {
+        return new Err(resources.error);
+      }
+
+      return new Ok(resources.value);
+    } else if (isConfluenceInternalPageId(parentInternalId)) {
+      const resources = await getSynchronizedChildrenPages(
+        connectorId,
+        confluenceConfig,
+        parentInternalId
+      );
+
+      if (resources.isErr()) {
+        return new Err(resources.error);
+      }
+
+      return new Ok(resources.value);
+    } else {
+      return new Err(new Error("Invalid Confluence internal id."));
+    }
+  }
+
+  const syncedSpaces = await ConfluenceSpace.findAll({
+    where: {
+      connectorId,
+    },
+  });
+
+  const allSpaces = syncedSpaces.map((space) =>
+    createConnectorResourceFromSpace(space, confluenceConfig.url, "read", {
+      isExpandable: true,
+      usesInternalId: true,
+    })
+  );
+
+  return new Ok(allSpaces);
+}
+
+export async function retrieveAvailableSpaces(
+  connector: Connector,
+  confluenceConfig: ConfluenceConfiguration
+) {
+  const { id: connectorId } = connector;
+
+  const syncedSpaces = await ConfluenceSpace.findAll({
+    where: {
+      connectorId: connectorId,
+    },
+  });
+
+  const spaces = await listConfluenceSpaces(connector, confluenceConfig);
+
+  return spaces.map((space) => {
+    const isSynced = syncedSpaces.some((ss) => ss.spaceId === space.id);
+
+    return createConnectorResourceFromSpace(
+      space,
+      confluenceConfig.url,
+      isSynced ? "read" : "none",
+      { isExpandable: false, usesInternalId: false }
+    );
+  });
+}

--- a/connectors/src/connectors/index.ts
+++ b/connectors/src/connectors/index.ts
@@ -6,6 +6,7 @@ import {
   resumeConfluenceConnector,
   retrieveConfluenceConnectorPermissions,
   retrieveConfluenceObjectsTitles,
+  retrieveConfluenceResourceParents,
   setConfluenceConnectorPermissions,
   stopConfluenceConnector,
   updateConfluenceConnector,
@@ -252,7 +253,7 @@ export const RETRIEVE_RESOURCE_PARENTS_BY_TYPE: Record<
   ConnectorProvider,
   ConnectorResourceParentsRetriever
 > = {
-  confluence: async () => new Ok([]), // Confluence is flat.
+  confluence: retrieveConfluenceResourceParents,
   notion: retrieveNotionResourceParents,
   google_drive: retrieveGoogleDriveObjectsParents,
   slack: async () => new Ok([]), // Slack is flat

--- a/connectors/src/lib/models/confluence.ts
+++ b/connectors/src/lib/models/confluence.ts
@@ -171,6 +171,7 @@ ConfluencePage.init(
     parentId: {
       type: DataTypes.STRING,
       allowNull: true,
+      defaultValue: null,
     },
     pageId: {
       type: DataTypes.STRING,
@@ -193,7 +194,7 @@ ConfluencePage.init(
     sequelize: sequelize_conn,
     indexes: [
       { fields: ["connectorId", "pageId"], unique: true },
-      { fields: ["connectorId", "spaceId"] },
+      { fields: ["connectorId", "spaceId", "parentId"] },
     ],
     modelName: "confluence_pages",
   }

--- a/front/lib/connector_providers.ts
+++ b/front/lib/connector_providers.ts
@@ -32,7 +32,7 @@ export const CONNECTOR_CONFIGURATIONS: Record<
       "Grant tailored access to your organization's Confluence shared spaces.",
     limitations: null,
     logoComponent: ConfluenceLogo,
-    isNested: false,
+    isNested: true,
     dustWorkspaceOnly: true,
   },
   notion: {


### PR DESCRIPTION
## Description

This PR implements the necessary functionality to display data from Confluence in Dust. While data synchronization is currently confined to Confluence Spaces, our goal is to present the complete hierarchy to users, both when viewing accessible data in Dust and when selecting a data source for an assistant.

A bit like Notion, which allows infinite nesting of pages, Confluence has some nesting but with limitation. This PR is built on the assumption that initially, we won't encounter excessively deep hierarchies. However, we may need to re-evaluate this as we gain more understanding of Confluence usage throughout the customer base.

To streamline the display process and reduce database queries, we're implementing custom internal IDs like `space_xxx` or `page_yyy`.

⚠️ Please note the current method of identifying all parent pages to minimize database calls. While this approach is efficient, we remain open to refining this process based on future requirements.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

**View of the synchronized data:**

<img width="870" alt="image" src="https://github.com/dust-tt/dust/assets/7428970/b5aa3f50-c574-4a4e-b05d-6f169beb8574">

**View of a selected Confluence Page in the assistant builder:**

<img width="908" alt="image" src="https://github.com/dust-tt/dust/assets/7428970/6ba72605-e009-4972-8cd9-4c0c9b924689">

**View of Confluence spaces that can be selected**

<img width="952" alt="image" src="https://github.com/dust-tt/dust/assets/7428970/6299584d-52a4-4b1d-a463-b716b5bdf7a5">
 
## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

This PR requires a migration to add `parentId` to an existing index. This migration can be safely run once the PR is deployed in production.
<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
