### PR TITLE
Change name of contentfragment in conversation rendering for model

### DIFF
--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -112,9 +112,9 @@ export async function renderConversationForModel({
       });
     } else if (isContentFragmentType(m)) {
       messages.unshift({
-        role: "content_fragment" as const,
-        name: "inject_content_fragment",
-        content: `${m.title}\nCONTENT:\n${m.content}`,
+        role: "content_fragment",
+        name: m.contentType,
+        content: `TITLE: ${m.title}\nCONTENT:\n${m.content}`,
       });
     } else {
       ((x: never) => {

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -113,8 +113,8 @@ export async function renderConversationForModel({
     } else if (isContentFragmentType(m)) {
       messages.unshift({
         role: "content_fragment",
-        name: m.contentType,
-        content: `TITLE: ${m.title}\nCONTENT:\n${m.content}`,
+        name: "inject_content",
+        content: `TITLE: ${m.title}\nORIGIN: User provided content (${m.contentType})\nCONTENT:\n${m.content}`,
       });
     } else {
       ((x: never) => {

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -113,8 +113,13 @@ export async function renderConversationForModel({
     } else if (isContentFragmentType(m)) {
       messages.unshift({
         role: "content_fragment",
-        name: "inject_content",
-        content: `TITLE: ${m.title}\nORIGIN: User provided content (${m.contentType})\nCONTENT:\n${m.content}`,
+        name: `inject_${m.contentType}`,
+        content:
+          `TITLE: ${m.title}\n` +
+          `TYPE: ${m.contentType}${
+            m.contentType === "file_attachment" ? " (user provided)" : ""
+          }\n` +
+          `CONTENT:\n${m.content}`,
       });
     } else {
       ((x: never) => {


### PR DESCRIPTION
Related [discussion](https://dust4ai.slack.com/archives/C050A0S2Z7F/p1706189052158989)

## Description
Users often say "I shared you this file" when attaching a file. Previous way of working dumped content without explaining to the model that it was a file attachment. This PR fixes it

## Risk
No foreseeable risk

