### PR TITLE
nits to poke

### DIFF
--- a/front/pages/poke/[wId]/data_sources/[name]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[name]/index.tsx
@@ -24,11 +24,14 @@ import { useDocuments } from "@app/lib/swr";
 import { timeAgoFrom } from "@app/lib/utils";
 import logger from "@app/logger/logger";
 
+const { TEMPORAL_CONNECTORS_NAMESPACE = "" } = process.env;
+
 export const getServerSideProps: GetServerSideProps<{
   owner: WorkspaceType;
   dataSource: DataSourceType;
   coreDataSource: CoreAPIDataSource;
   connector: ConnectorType | null;
+  temporalWorkspace: string;
 }> = async (context) => {
   const session = await getSession(context.req, context.res);
   const auth = await Authenticator.fromSuperUserSession(
@@ -87,6 +90,7 @@ export const getServerSideProps: GetServerSideProps<{
       dataSource,
       coreDataSource: coreDataSourceRes.value.data_source,
       connector,
+      temporalWorkspace: TEMPORAL_CONNECTORS_NAMESPACE,
     },
   };
 };
@@ -96,6 +100,7 @@ const DataSourcePage = ({
   dataSource,
   coreDataSource,
   connector,
+  temporalWorkspace,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
   const [limit] = useState(10);
   const [offset, setOffset] = useState(0);
@@ -145,7 +150,7 @@ const DataSourcePage = ({
           {dataSource.connectorId && (
             <div className="flex flex-col text-sm text-action-500">
               <Link
-                href={`https://cloud.temporal.io/namespaces/dust-prod.gmnlm/workflows?query=connectorId%3D%22${dataSource.connectorId}%22`}
+                href={`https://cloud.temporal.io/namespaces/${temporalWorkspace}/workflows?query=connectorId%3D%22${dataSource.connectorId}%22`}
               >
                 Temporal: ConnectorId
               </Link>

--- a/front/pages/poke/[wId]/data_sources/[name]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[name]/index.tsx
@@ -147,12 +147,12 @@ const DataSourcePage = ({
               <Link
                 href={`https://cloud.temporal.io/namespaces/dust-prod.gmnlm/workflows?query=connectorId%3D%22${dataSource.connectorId}%22`}
               >
-                Temporal (ConnectorId)
+                Temporal: ConnectorId
               </Link>
               <Link
                 href={`https://app.datadoghq.eu/logs?query=service%3Acore%20%22DSSTAT%20Finished%20searching%20Qdrant%20documents%22%20%22${coreDataSource.qdrant_collection}%22%20&cols=host%2Cservice&index=%2A&messageDisplay=inline&refresh_mode=sliding&stream_sort=desc&view=spans&viz=stream&live=true`}
               >
-                Datadog: Logs DSSTAT Qdrant search
+                Datadog: DSSTAT Qdrant search logs
               </Link>
             </div>
           )}

--- a/front/pages/poke/[wId]/data_sources/[name]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[name]/index.tsx
@@ -12,6 +12,7 @@ import { ConnectorsAPI } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
 import { JsonViewer } from "@textea/json-viewer";
 import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
+import Link from "next/link";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 
@@ -137,20 +138,29 @@ const DataSourcePage = ({
         <div className="px-8 py-8"></div>
         <Page.Vertical align="stretch">
           <Page.SectionHeader title={`${dataSource.name}`} />
+          <div className="text-sm font-bold text-action-500">
+            <Link href={`/poke/${owner.sId}`}>&laquo; workspace</Link>
+          </div>
 
-          <div className="my-8 flex flex-col gap-y-4">
+          {dataSource.connectorId && (
+            <div className="flex flex-col text-sm text-action-500">
+              <Link
+                href={`https://cloud.temporal.io/namespaces/dust-prod.gmnlm/workflows?query=connectorId%3D%22${dataSource.connectorId}%22`}
+              >
+                Temporal (ConnectorId)
+              </Link>
+              <Link
+                href={`https://app.datadoghq.eu/logs?query=service%3Acore%20%22DSSTAT%20Finished%20searching%20Qdrant%20documents%22%20%22${coreDataSource.qdrant_collection}%22%20&cols=host%2Cservice&index=%2A&messageDisplay=inline&refresh_mode=sliding&stream_sort=desc&view=spans&viz=stream&live=true`}
+              >
+                Datadog: Logs DSSTAT Qdrant search
+              </Link>
+            </div>
+          )}
+
+          <div className="my-4 flex flex-col gap-y-4">
             <JsonViewer value={dataSource} rootName={false} />
             <JsonViewer value={coreDataSource} rootName={false} />
             <JsonViewer value={connector} rootName={false} />
-          </div>
-
-          <div className="flex flex-row">
-            <a
-              href={`https://app.datadoghq.eu/logs?query=service%3Acore%20%22DSSTAT%20Finished%20searching%20Qdrant%20documents%22%20%22${coreDataSource.qdrant_collection}%22%20&cols=host%2Cservice&index=%2A&messageDisplay=inline&refresh_mode=sliding&stream_sort=desc&view=spans&viz=stream&live=true`}
-              className="text-sm text-blue-500"
-            >
-              Datadog: Logs DSSTAT Qdrant search
-            </a>
           </div>
 
           <div className="mt-4 flex flex-row">


### PR DESCRIPTION
## Description

- Adds return to workspace on data source page (when coming from poke/connectors/xxx)
- Adds link to the temporal view for the connectorId for connected data sources

![Screenshot from 2024-01-25 15-11-28](https://github.com/dust-tt/dust/assets/15067/39138186-f24c-45f0-b2d3-8902e70a2e01)

## Risk

N/A

## Deploy Plan

- deploy `front`