### PR TITLE
github code sync: heartbeat the code sync activity

### DIFF
--- a/connectors/src/connectors/github/temporal/workflows.ts
+++ b/connectors/src/connectors/github/temporal/workflows.ts
@@ -41,7 +41,14 @@ const { githubUpsertIssueActivity, githubUpsertDiscussionActivity } =
   });
 
 const { githubCodeSyncActivity } = proxyActivities<typeof activities>({
-  startToCloseTimeout: "120 minute",
+  startToCloseTimeout: "180 minute",
+  // We use a rather large heartbeat as we have to allow enough time for the initial code tar
+  // download to complete (should be less than a few GB). But this is nonetheless valuable compared
+  // to just relying on startToCloseTimeout (which has to be large enough to allow the full initial
+  // sync, which can only be done in one activity since it is stateful (download of tar file to
+  // local temp storage)). Basically In case of a deploy or crash of the worker node we will retry
+  // the activity after 15mn and not 180 as defined by the startToCloseTimeout.
+  heartbeatTimeout: "15 minute",
 });
 
 const MAX_CONCURRENT_REPO_SYNC_WORKFLOWS = 3;


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/dust/issues/3377

We need a long startToCloseTimeout since the activity is statefull (local tmp storage dependency) and has to do the full code sync. In case of crash or deploy that means we restart the activity only after the startToCloseTimeout which is not desirable.

This code adds heartbeats to enforce a shorter timeout of the activity in case of deploy or failure.

We keep the heartbeat a bit long as we can't heartbeat during initial tar code download (15mn seems ample enough and is yet a big win compared to the startToCloseTimeout).

## Risk

N/A

## Deploy Plan

- deploy `connectors`