### PR TITLE
User message passes full name to model if available (and username as fallback)

### DIFF
--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -107,7 +107,7 @@ export async function renderConversationForModel({
       );
       messages.unshift({
         role: "user" as const,
-        name: m.context.username,
+        name: m.context.fullName || m.context.username,
         content,
       });
     } else if (isContentFragmentType(m)) {


### PR DESCRIPTION
## Description

Formerly, we passed only username to the model

username is currently set by the provider and unchangeable by us (contrarily to first name / last name). In most cases it resembles the real user's name, but in some it doesn't. The full name is arguably better when available 

For instance, in the case of a google user pr@dust.tt called Philippe Rolet, it's better that the model thinks the message comes from 'Philippe Rolet' directly than from 'pr'.

In addition, there are edge cases that causes various issues. Notably, a user authing with google email marketing@toto.com was always getting marketing-related answers from the model. We could not change the username, determined by google as the first part of their email. This PR allows dealing with the issue, we use full name and can change those if needed.

## Tech details
I ensured that user.fullName is indeed computed from firstName + lastName

## Risk
There should be little. But since it's a core part, we mitigate by ccing @spolu :)
