### PR TITLE
Remove useless Sequelize relationship

### DIFF
--- a/front/lib/models/data_source.ts
+++ b/front/lib/models/data_source.ts
@@ -104,7 +104,7 @@ DataSource.belongsTo(Workspace, {
 User.hasMany(DataSource, {
   as: "dataSources",
   // TODO(2024-01-25 flav) Set `allowNull` to `false` once backfilled.
-  foreignKey: { name: "workspaceId", allowNull: true },
+  foreignKey: { name: "editedByUserId", allowNull: true },
   // /!\ We don't want to delete the data source when a user gets deleted.
   onDelete: "SET NULL",
 });

--- a/front/lib/models/data_source.ts
+++ b/front/lib/models/data_source.ts
@@ -101,13 +101,6 @@ DataSource.belongsTo(Workspace, {
   foreignKey: { name: "workspaceId", allowNull: false },
 });
 
-User.hasMany(DataSource, {
-  as: "dataSources",
-  // TODO(2024-01-25 flav) Set `allowNull` to `false` once backfilled.
-  foreignKey: { name: "editedByUserId", allowNull: true },
-  // /!\ We don't want to delete the data source when a user gets deleted.
-  onDelete: "SET NULL",
-});
 DataSource.belongsTo(User, {
   as: "editedByUser",
   // TODO(2024-01-25 flav) Set `allowNull` to `false` once backfilled.


### PR DESCRIPTION
## Description
This PR removes the useless Sequelize relationship introduced in https://github.com/dust-tt/dust/pull/3435.

This relationship would guide Sequelize on formulating a query to fetch all data sources edited by a user. However, this is not a requirement for us at moment, and it is unlikely that we will ever need it.
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
This PR does not require a proper migration since it only removes instructions to guide Sequelize.

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
