### PR TITLE
Fix: handle undefined 'file' in notion block rendering

### DIFF
--- a/connectors/src/connectors/notion/lib/notion_api.ts
+++ b/connectors/src/connectors/notion/lib/notion_api.ts
@@ -938,7 +938,7 @@ export function parsePageBlock(block: BlockObjectResponse): ParsedNotionBlock {
     const fileUrl =
       "external" in fileContainer
         ? fileContainer.external.url
-        : fileContainer.file.url;
+        : fileContainer.file?.url || "NO_URL";
     const caption = parseRichText(fileContainer.caption);
     const fileText =
       caption && caption.length


### PR DESCRIPTION
## Description
A monitor failed because the image-type block retrieved by notion did not have `file` set (although it should have according to notion doc). Details [here](https://dust4ai.slack.com/archives/C05F84CFP0E/p1706211445242809)

This PR handles that situation.


