### PR TITLE
front: type apiError

### DIFF
--- a/front/logger/withlogging.ts
+++ b/front/logger/withlogging.ts
@@ -1,4 +1,7 @@
-import type { APIErrorWithStatusCode } from "@dust-tt/types";
+import type {
+  APIErrorWithStatusCode,
+  WithAPIErrorReponse,
+} from "@dust-tt/types";
 import tracer from "dd-trace";
 import StatsD from "hot-shots";
 import type { NextApiRequest, NextApiResponse } from "next";
@@ -74,9 +77,9 @@ export const withLogging = (handler: any, streaming = false) => {
   };
 };
 
-export function apiError(
+export function apiError<T>(
   req: NextApiRequest,
-  res: NextApiResponse,
+  res: NextApiResponse<WithAPIErrorReponse<T>>,
   apiError: APIErrorWithStatusCode,
   error?: Error
 ): void {

--- a/front/pages/api/v1/w/[wId]/apps/index.ts
+++ b/front/pages/api/v1/w/[wId]/apps/index.ts
@@ -1,18 +1,17 @@
-import type { AppType } from "@dust-tt/types";
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { AppType, WithAPIErrorReponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getApps } from "@app/lib/api/app";
 import { Authenticator, getAPIKey } from "@app/lib/auth";
 import { apiError, withLogging } from "@app/logger/withlogging";
 
-export type GetAppsResponseBody = {
+export type GetAppsResponseBody = WithAPIErrorReponse<{
   apps: AppType[];
-};
+}>;
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<GetAppsResponseBody | ReturnedAPIErrorType>
+  res: NextApiResponse<GetAppsResponseBody>
 ): Promise<void> {
   const keyRes = await getAPIKey(req);
   if (keyRes.isErr()) {

--- a/front/pages/api/v1/w/[wId]/apps/index.ts
+++ b/front/pages/api/v1/w/[wId]/apps/index.ts
@@ -5,13 +5,13 @@ import { getApps } from "@app/lib/api/app";
 import { Authenticator, getAPIKey } from "@app/lib/auth";
 import { apiError, withLogging } from "@app/logger/withlogging";
 
-export type GetAppsResponseBody = WithAPIErrorReponse<{
+export type GetAppsResponseBody = {
   apps: AppType[];
-}>;
+};
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<GetAppsResponseBody>
+  res: NextApiResponse<WithAPIErrorReponse<GetAppsResponseBody>>
 ): Promise<void> {
   const keyRes = await getAPIKey(req);
   if (keyRes.isErr()) {

--- a/front/pages/api/v1/w/[wId]/assistant/agent_configurations.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/agent_configurations.ts
@@ -1,4 +1,4 @@
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { WithAPIErrorReponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
@@ -8,9 +8,7 @@ import type { GetAgentConfigurationsResponseBody } from "@app/pages/api/w/[wId]/
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<
-    GetAgentConfigurationsResponseBody | ReturnedAPIErrorType | void
-  >
+  res: NextApiResponse<WithAPIErrorReponse<GetAgentConfigurationsResponseBody>>
 ): Promise<void> {
   const keyRes = await getAPIKey(req);
   if (keyRes.isErr()) {

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/index.ts
@@ -1,4 +1,4 @@
-import type { CoreAPITable } from "@dust-tt/types";
+import type { CoreAPITable, WithAPIErrorReponse } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -14,7 +14,7 @@ export type GetTableResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<GetTableResponseBody>
+  res: NextApiResponse<WithAPIErrorReponse<GetTableResponseBody>>
 ): Promise<void> {
   const keyRes = await getAPIKey(req);
   if (keyRes.isErr()) {

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/rows/[rId].ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/rows/[rId].ts
@@ -1,4 +1,4 @@
-import type { CoreAPIRow } from "@dust-tt/types";
+import type { CoreAPIRow, WithAPIErrorReponse } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -14,7 +14,7 @@ type GetTableRowsResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<GetTableRowsResponseBody>
+  res: NextApiResponse<WithAPIErrorReponse<GetTableRowsResponseBody>>
 ): Promise<void> {
   const keyRes = await getAPIKey(req);
   if (keyRes.isErr()) {

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/rows/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/rows/index.ts
@@ -1,4 +1,4 @@
-import type { CoreAPIRow } from "@dust-tt/types";
+import type { CoreAPIRow, WithAPIErrorReponse } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
@@ -42,7 +42,9 @@ type ListTableRowsResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<UpsertTableRowsResponseBody | ListTableRowsResponseBody>
+  res: NextApiResponse<
+    WithAPIErrorReponse<UpsertTableRowsResponseBody | ListTableRowsResponseBody>
+  >
 ): Promise<void> {
   const keyRes = await getAPIKey(req);
   if (keyRes.isErr()) {

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/index.ts
@@ -1,4 +1,4 @@
-import type { CoreAPITable } from "@dust-tt/types";
+import type { CoreAPITable, WithAPIErrorReponse } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
@@ -28,7 +28,9 @@ type UpsertTableResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<ListTablesResponseBody | UpsertTableResponseBody>
+  res: NextApiResponse<
+    WithAPIErrorReponse<ListTablesResponseBody | UpsertTableResponseBody>
+  >
 ): Promise<void> {
   const keyRes = await getAPIKey(req);
   if (keyRes.isErr()) {

--- a/front/pages/api/w/[wId]/apps/[aId]/state.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/state.ts
@@ -1,4 +1,4 @@
-import type { AppType } from "@dust-tt/types";
+import type { AppType, WithAPIErrorReponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { Op } from "sequelize";
 
@@ -12,7 +12,7 @@ export type PostStateResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<PostStateResponseBody>
+  res: NextApiResponse<WithAPIErrorReponse<PostStateResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/data_sources/[name]/documents/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/documents/index.ts
@@ -1,4 +1,4 @@
-import type { DocumentType } from "@dust-tt/types";
+import type { DocumentType, WithAPIErrorReponse } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -14,7 +14,7 @@ export type GetDocumentsResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<GetDocumentsResponseBody>
+  res: NextApiResponse<WithAPIErrorReponse<GetDocumentsResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth =

--- a/front/pages/api/w/[wId]/data_sources/[name]/search.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/search.ts
@@ -1,4 +1,4 @@
-import type { DocumentType } from "@dust-tt/types";
+import type { DocumentType, WithAPIErrorReponse } from "@dust-tt/types";
 import { dustManagedCredentials } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
 import type { JSONSchemaType } from "ajv";
@@ -46,7 +46,7 @@ type DatasourceSearchResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<DatasourceSearchResponseBody>
+  res: NextApiResponse<WithAPIErrorReponse<DatasourceSearchResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/data_sources/[name]/tables/[tId]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/tables/[tId]/index.ts
@@ -1,4 +1,4 @@
-import type { CoreAPITable } from "@dust-tt/types";
+import type { CoreAPITable, WithAPIErrorReponse } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -14,7 +14,7 @@ export type GetTableResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<GetTableResponseBody>
+  res: NextApiResponse<WithAPIErrorReponse<GetTableResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/data_sources/[name]/tables/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/tables/index.ts
@@ -1,3 +1,4 @@
+import type { WithAPIErrorReponse } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -10,7 +11,7 @@ import type { ListTablesResponseBody } from "@app/pages/api/v1/w/[wId]/data_sour
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<ListTablesResponseBody>
+  res: NextApiResponse<WithAPIErrorReponse<ListTablesResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/invitations/[invitationId]/index.ts
+++ b/front/pages/api/w/[wId]/invitations/[invitationId]/index.ts
@@ -1,4 +1,7 @@
-import type { MembershipInvitationType } from "@dust-tt/types";
+import type {
+  MembershipInvitationType,
+  WithAPIErrorReponse,
+} from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { Authenticator, getSession } from "@app/lib/auth";
@@ -11,7 +14,7 @@ export type GetMemberInvitationsResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<GetMemberInvitationsResponseBody>
+  res: NextApiResponse<WithAPIErrorReponse<GetMemberInvitationsResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/invitations/index.ts
+++ b/front/pages/api/w/[wId]/invitations/index.ts
@@ -1,4 +1,7 @@
-import type { MembershipInvitationType } from "@dust-tt/types";
+import type {
+  MembershipInvitationType,
+  WithAPIErrorReponse,
+} from "@dust-tt/types";
 import sgMail from "@sendgrid/mail";
 import { sign } from "jsonwebtoken";
 import type { NextApiRequest, NextApiResponse } from "next";
@@ -19,7 +22,7 @@ export type GetWorkspaceInvitationsResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<GetWorkspaceInvitationsResponseBody>
+  res: NextApiResponse<WithAPIErrorReponse<GetWorkspaceInvitationsResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/members/[userId]/index.ts
+++ b/front/pages/api/w/[wId]/members/[userId]/index.ts
@@ -1,4 +1,4 @@
-import type { UserType } from "@dust-tt/types";
+import type { UserType, WithAPIErrorReponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { Authenticator, getSession } from "@app/lib/auth";
@@ -12,7 +12,7 @@ export type PostMemberResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<PostMemberResponseBody>
+  res: NextApiResponse<WithAPIErrorReponse<PostMemberResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/members/index.ts
+++ b/front/pages/api/w/[wId]/members/index.ts
@@ -1,4 +1,7 @@
-import type { UserTypeWithWorkspaces } from "@dust-tt/types";
+import type {
+  UserTypeWithWorkspaces,
+  WithAPIErrorReponse,
+} from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getMembers } from "@app/lib/api/workspace";
@@ -11,7 +14,7 @@ export type GetMembersResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<GetMembersResponseBody>
+  res: NextApiResponse<WithAPIErrorReponse<GetMembersResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/members/me/agent_list_status.ts
+++ b/front/pages/api/w/[wId]/members/me/agent_list_status.ts
@@ -1,4 +1,4 @@
-import type { AgentUserListStatus } from "@dust-tt/types";
+import type { AgentUserListStatus, WithAPIErrorReponse } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
@@ -25,7 +25,7 @@ export type PostAgentListStatusRequestBody = t.TypeOf<
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<PostAgentListStatusResponseBody | { success: boolean }>
+  res: NextApiResponse<WithAPIErrorReponse<PostAgentListStatusResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/providers/[pId]/check.ts
+++ b/front/pages/api/w/[wId]/providers/[pId]/check.ts
@@ -1,3 +1,4 @@
+import type { WithAPIErrorReponse } from "@dust-tt/types";
 import { GoogleAuth } from "google-auth-library";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -10,7 +11,7 @@ export type GetProvidersCheckResponseBody =
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<GetProvidersCheckResponseBody>
+  res: NextApiResponse<WithAPIErrorReponse<GetProvidersCheckResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/providers/[pId]/index.ts
+++ b/front/pages/api/w/[wId]/providers/[pId]/index.ts
@@ -1,4 +1,4 @@
-import type { ProviderType } from "@dust-tt/types";
+import type { ProviderType, WithAPIErrorReponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { Authenticator, getSession } from "@app/lib/auth";
@@ -17,7 +17,9 @@ export type DeleteProviderResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<PostProviderResponseBody | DeleteProviderResponseBody>
+  res: NextApiResponse<
+    WithAPIErrorReponse<PostProviderResponseBody | DeleteProviderResponseBody>
+  >
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/providers/[pId]/models.ts
+++ b/front/pages/api/w/[wId]/providers/[pId]/models.ts
@@ -1,3 +1,4 @@
+import type { WithAPIErrorReponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { Authenticator, getSession } from "@app/lib/auth";
@@ -14,7 +15,9 @@ export type GetProviderModelsErrorResponseBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    GetProviderModelsResponseBody | GetProviderModelsErrorResponseBody
+    WithAPIErrorReponse<
+      GetProviderModelsResponseBody | GetProviderModelsErrorResponseBody
+    >
   >
 ): Promise<void> {
   const session = await getSession(req, res);

--- a/front/pages/api/w/[wId]/providers/index.ts
+++ b/front/pages/api/w/[wId]/providers/index.ts
@@ -1,4 +1,4 @@
-import type { ProviderType } from "@dust-tt/types";
+import type { ProviderType, WithAPIErrorReponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { Authenticator, getSession } from "@app/lib/auth";
@@ -11,7 +11,7 @@ export type GetProvidersResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<GetProvidersResponseBody>
+  res: NextApiResponse<WithAPIErrorReponse<GetProvidersResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/types/src/front/lib/error.ts
+++ b/types/src/front/lib/error.ts
@@ -60,10 +60,6 @@ export type APIError = {
   connectors_error?: ConnectorsAPIError;
 };
 
-export type ReturnedAPIErrorType = {
-  error: APIError;
-};
-
 /**
  * Type to transport a HTTP error with its http status code (eg: 404)
  * and the error object returned by our public API endpoints (api/v1/*)
@@ -72,3 +68,9 @@ export type APIErrorWithStatusCode = {
   api_error: APIError;
   status_code: number;
 };
+
+export type ReturnedAPIErrorType = {
+  error: APIError;
+};
+
+export type WithAPIErrorReponse<T> = T | ReturnedAPIErrorType;


### PR DESCRIPTION
## Description

Add typing for `apiError` in front. Fix routes where the typing was missing.

100+ routes use `| ReturnedAPIErrorType` which is correct. Decided to not go and change all of these for `WithAPIErrorResponse`.

Convention: Add `WithAPIErrorResponse` in the `NextApiResponse<T>` so that it does not interfer with swr.ts typing if needed which should import `T` and not `WithAPIErrorResponse<T>` for the success case.

## Risk

N/A pure typing.

## Deploy Plan

N/A