### PR TITLE
types: improve CoreAPI error handling

### DIFF
--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tokenize.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tokenize.ts
@@ -87,6 +87,7 @@ async function handler(
           api_error: {
             type: "internal_server_error",
             message: `Error tokenizing text: ${coreTokenizeRes.error.message}`,
+            data_source_error: coreTokenizeRes.error,
           },
         });
       }

--- a/front/pages/w/[wId]/a/[aId]/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/index.tsx
@@ -6,7 +6,7 @@ import {
   SparklesIcon,
   Tab,
 } from "@dust-tt/sparkle";
-import type { UserType, WorkspaceType } from "@dust-tt/types";
+import type { CoreAPIError, UserType, WorkspaceType } from "@dust-tt/types";
 import type {
   AppType,
   BlockRunConfig,
@@ -15,7 +15,6 @@ import type {
 } from "@dust-tt/types";
 import type { SubscriptionType } from "@dust-tt/types";
 import type { BlockType } from "@dust-tt/types";
-import type { CoreAPIErrorResponse } from "@dust-tt/types";
 import type { ReturnedAPIErrorType } from "@dust-tt/types";
 import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
@@ -162,7 +161,7 @@ export default function AppView({
   );
   const [runnable, setRunnable] = useState(isRunnable(readOnly, spec, config));
   const [runRequested, setRunRequested] = useState(false);
-  const [runError, setRunError] = useState(null as null | CoreAPIErrorResponse);
+  const [runError, setRunError] = useState(null as null | CoreAPIError);
 
   const { run } = useSavedRunStatus(owner, app, (data) => {
     if (data && data.run) {
@@ -286,8 +285,8 @@ export default function AppView({
       ]);
 
       if (!runRes.ok) {
-        const error: ReturnedAPIErrorType = await runRes.json();
-        setRunError(error.error.run_error as CoreAPIErrorResponse);
+        const r: ReturnedAPIErrorType = await runRes.json();
+        setRunError(r.error.run_error as CoreAPIError);
       } else {
         setRunError(null);
         const [run] = await Promise.all([runRes.json()]);

--- a/types/src/front/lib/connectors_api.ts
+++ b/types/src/front/lib/connectors_api.ts
@@ -405,7 +405,7 @@ export class ConnectorsAPI {
 
       const err: ConnectorsAPIError = {
         type: "unexpected_response_format",
-        message: `Unexpected response format from ConnectorAPI: ${error}`,
+        message: `Unexpected response format from ConnectorsAPI: ${error}`,
       };
       this._logger.error(
         { error: err, parseError: error, status: response.status },
@@ -426,7 +426,7 @@ export class ConnectorsAPI {
         if (isConnectorsAPIError(err)) {
           this._logger.error(
             { error: err, status: response.status },
-            "ConnectorAPI error"
+            "ConnectorsAPI error"
           );
           return new Err(err);
         } else {
@@ -443,13 +443,13 @@ export class ConnectorsAPI {
       } catch (e) {
         return parseError(response, e as SyntaxError);
       }
-    }
-
-    try {
-      const json = await response.json();
-      return new Ok(json);
-    } catch (e) {
-      return parseError(response, e as SyntaxError);
+    } else {
+      try {
+        const json = await response.json();
+        return new Ok(json);
+      } catch (e) {
+        return parseError(response, e as SyntaxError);
+      }
     }
   }
 }

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -1120,6 +1120,10 @@ export class CoreAPI {
         const res = json?.response;
 
         if (err && isCoreAPIError(err)) {
+          this._logger.error(
+            { error: err, status: response.status },
+            "CoreAPI error"
+          );
           return new Err(err);
         } else if (res) {
           return new Ok(res);

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -29,11 +29,23 @@ export const EMBEDDING_CONFIG = {
   max_chunk_size: 512,
 };
 
-export type CoreAPIErrorResponse = {
+export type CoreAPIError = {
   message: string;
   code: string;
 };
-export type CoreAPIResponse<T> = Result<T, CoreAPIErrorResponse>;
+
+export function isCoreAPIError(obj: unknown): obj is CoreAPIError {
+  return (
+    typeof obj === "object" &&
+    obj !== null &&
+    "message" in obj &&
+    typeof obj.message === "string" &&
+    "code" in obj &&
+    typeof obj.code === "string"
+  );
+}
+
+export type CoreAPIResponse<T> = Result<T, CoreAPIError>;
 
 export type CoreAPIDatasetVersion = {
   hash: string;
@@ -1058,23 +1070,73 @@ export class CoreAPI {
   private async _resultFromResponse<T>(
     response: Response
   ): Promise<CoreAPIResponse<T>> {
-    try {
-      const jsonResponse = await response.json();
+    const parseError = async (response: Response, error: SyntaxError) => {
+      const text = await response.text();
 
-      if (jsonResponse.error) {
-        return new Err(jsonResponse.error);
-      }
-      return new Ok(jsonResponse.response);
-    } catch (err) {
-      const rawResponse = await response.text();
-
-      const message = `Dust Core API responded with status: ${response.status}.`;
+      const err: CoreAPIError = {
+        code: "unexpected_response_format",
+        message: `Unexpected response format from CoreAPI: ${error}`,
+      };
       this._logger.error(
-        { status: response.status, response: rawResponse },
-        message
+        { error: err, parseError: error, status: response.status },
+        "CoreAPI error"
       );
+      this._logger.error(
+        { error: err, parseError: error, status: response.status },
+        `CoreAPI error, raw response text: ${text}`
+      );
+      return new Err(err);
+    };
 
-      return new Err({ code: response.status.toString(), message });
+    if (!response.ok) {
+      try {
+        const json = await response.json();
+        const err = json?.error;
+
+        if (isCoreAPIError(err)) {
+          this._logger.error(
+            { error: err, status: response.status },
+            "CoreAPI error"
+          );
+          return new Err(err);
+        } else {
+          const err: CoreAPIError = {
+            code: "unexpected_error_format",
+            message: "Unexpected error format from CoreAPI",
+          };
+          this._logger.error(
+            { error: err, json, status: response.status },
+            "CoreAPI error"
+          );
+          return new Err(err);
+        }
+      } catch (e) {
+        return parseError(response, e as SyntaxError);
+      }
+    } else {
+      try {
+        const json = await response.json();
+        const err = json?.error;
+        const res = json?.response;
+
+        if (err && isCoreAPIError(err)) {
+          return new Err(err);
+        } else if (res) {
+          return new Ok(res);
+        } else {
+          const err: CoreAPIError = {
+            code: "unexpected_response_format",
+            message: "Unexpected response format from CoreAPI",
+          };
+          this._logger.error(
+            { error: err, json, status: response.status },
+            "CoreAPI error"
+          );
+          return new Err(err);
+        }
+      } catch (e) {
+        return parseError(response, e as SyntaxError);
+      }
     }
   }
 }

--- a/types/src/front/lib/error.ts
+++ b/types/src/front/lib/error.ts
@@ -1,5 +1,5 @@
 import { ConnectorsAPIError } from "../../connectors/api";
-import { CoreAPIErrorResponse } from "./core_api";
+import { CoreAPIError } from "./core_api";
 
 export type InternalErrorWithStatusCode = {
   status_code: number;
@@ -54,9 +54,9 @@ export type APIErrorType =
 export type APIError = {
   type: APIErrorType;
   message: string;
-  data_source_error?: CoreAPIErrorResponse;
-  run_error?: CoreAPIErrorResponse;
-  app_error?: CoreAPIErrorResponse;
+  data_source_error?: CoreAPIError;
+  run_error?: CoreAPIError;
+  app_error?: CoreAPIError;
   connectors_error?: ConnectorsAPIError;
 };
 


### PR DESCRIPTION
## Description

- Rename `CoreAPIErrorResponse` to `CoreAPIError`
- Stricter parsing of `core` responses with more logging

## Risk

Minor risk of messing with front/core with the added parsing but low.

## Deploy Plan

- deploy `front`