### PR TITLE
connectors: getParents log and detect infinite loops

### DIFF
--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -496,7 +496,12 @@ export async function retrieveNotionResourceParents(
   const memo = memoizationKey || uuidv4();
 
   try {
-    const parents = await getParents(connectorId, internalId, memo);
+    const parents = await getParents(
+      connectorId,
+      internalId,
+      new Set<string>(),
+      memo
+    );
 
     return new Ok(parents);
   } catch (e) {

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -1788,6 +1788,7 @@ export async function renderAndUpsertPageFromCache({
     const parents = await getParents(
       connectorId,
       pageId,
+      new Set<string>(),
       runTimestamp.toString()
     );
 


### PR DESCRIPTION
## Description

We run into a situation where an infiinite loop was possible in the parents of a Notion page leading to thousands of Redis connections being opened through the recursion in getParents

## Risk

N/A

## Deploy Plan

- deploy `connectors`