### PR TITLE
Flav/confluence upsert parent ids

### DIFF
--- a/connectors/src/connectors/confluence/lib/hierarchy.ts
+++ b/connectors/src/connectors/confluence/lib/hierarchy.ts
@@ -34,11 +34,6 @@ export async function getConfluencePageParentIds(
     allPages.map((page) => [page.pageId, page.parentId])
   );
 
-  console.log(
-    ">> pageIdToParentIdMap:",
-    JSON.stringify([...pageIdToParentIdMap], null, 2)
-  );
-
   const parentIds = [];
   let currentId = page.pageId;
 

--- a/connectors/src/connectors/confluence/lib/hierarchy.ts
+++ b/connectors/src/connectors/confluence/lib/hierarchy.ts
@@ -1,0 +1,68 @@
+import type { ModelId } from "@dust-tt/types";
+
+import {
+  makeConfluenceInternalPageId,
+  makeConfluenceInternalSpaceId,
+} from "@connectors/connectors/confluence/lib/internal_ids";
+import { ConfluencePage } from "@connectors/lib/models/confluence";
+
+interface RawConfluencePage {
+  pageId: string;
+  parentId: string | null;
+  spaceId: string;
+}
+
+export async function getConfluencePageParentIds(
+  connectorId: ModelId,
+  page: RawConfluencePage
+) {
+  // Currently opting for a best-effort strategy to reduce database queries,
+  // this logic may be enhanced later for important Confluence connections.
+  // By fetching all pages within a space, we reconstruct parent-child
+  // relationships in-app, minimizing database interactions.
+  // If needed we could move the same approach as Notion and cache the results in Redis.
+  const allPages = await ConfluencePage.findAll({
+    attributes: ["pageId", "parentId"],
+    where: {
+      connectorId,
+      spaceId: page.spaceId,
+    },
+  });
+
+  // Map each pageId to its respective parentId.
+  const pageIdToParentIdMap = new Map(
+    allPages.map((page) => [page.pageId, page.parentId])
+  );
+
+  console.log(
+    ">> pageIdToParentIdMap:",
+    JSON.stringify([...pageIdToParentIdMap], null, 2)
+  );
+
+  const parentIds = [];
+  let currentId = page.pageId;
+
+  // If the page has not been saved yet. Let's add it to the set.
+  if (!pageIdToParentIdMap.has(currentId)) {
+    pageIdToParentIdMap.set(currentId, page.parentId);
+  }
+
+  // Traverse the hierarchy upwards until no further parent IDs are found.
+  while (pageIdToParentIdMap.has(currentId)) {
+    const parentId = pageIdToParentIdMap.get(currentId);
+    if (parentId) {
+      parentIds.push(parentId);
+      // Move up the hierarchy.
+      currentId = parentId;
+    } else {
+      // No more parents, exit the loop.
+      break;
+    }
+  }
+
+  return [
+    // Add the space id at the beginning.
+    makeConfluenceInternalSpaceId(page.spaceId),
+    ...parentIds.map((p) => makeConfluenceInternalPageId(p)),
+  ];
+}

--- a/connectors/src/connectors/confluence/lib/hierarchy.ts
+++ b/connectors/src/connectors/confluence/lib/hierarchy.ts
@@ -59,5 +59,7 @@ export async function getConfluencePageParentIds(
     // Add the space id at the beginning.
     makeConfluenceInternalSpaceId(page.spaceId),
     ...parentIds.map((p) => makeConfluenceInternalPageId(p)),
+    // Add the current page.
+    makeConfluenceInternalPageId(page.pageId),
   ];
 }

--- a/connectors/src/connectors/confluence/lib/internal_ids.ts
+++ b/connectors/src/connectors/confluence/lib/internal_ids.ts
@@ -1,6 +1,6 @@
 enum ConfluenceInternalIdPrefix {
-  Space = "space_",
-  Page = "page_",
+  Space = "cspace_",
+  Page = "cpage_",
 }
 
 export function makeConfluenceInternalSpaceId(confluenceSpaceId: string) {

--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -322,7 +322,7 @@ export async function confluenceUpsertPageActivity({
       documentUrl,
       loggerArgs,
       // Parent Ids will be computed after all page imports within the space have been completed.
-      parents: [makeConfluenceInternalPageId(page.id)],
+      parents: [],
       retries: 3,
       tags,
       timestampMs: lastPageVersionCreatedAt.getTime(),
@@ -370,10 +370,9 @@ export async function confluenceUpdatePagesParentIdsActivity(
   for (const page of pages) {
     // Retrieve parents using the internal ID, which aligns with the permissions
     // view rendering and RAG requirements.
-    const parents = [makeConfluenceInternalPageId(page.pageId)];
+
     // TODO:(2023-01-26 flav) We can cache the map used in `getConfluencePageParentIds`.
     const parentIds = await getConfluencePageParentIds(connectorId, page);
-    parents.push(...parentIds);
 
     await updateDocumentParentsField({
       dataSourceConfig: {
@@ -382,7 +381,7 @@ export async function confluenceUpdatePagesParentIdsActivity(
         workspaceAPIKey: connector.workspaceAPIKey,
       },
       documentId: makeConfluencePageId(page.pageId),
-      parents,
+      parents: parentIds,
     });
   }
 

--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -7,7 +7,6 @@ import type { ConfluencePageWithBodyType } from "@connectors/connectors/confluen
 import { ConfluenceClient } from "@connectors/connectors/confluence/lib/confluence_client";
 import { isConfluencePageSkipped } from "@connectors/connectors/confluence/lib/confluence_page";
 import { getConfluencePageParentIds } from "@connectors/connectors/confluence/lib/hierarchy";
-import { makeConfluenceInternalPageId } from "@connectors/connectors/confluence/lib/internal_ids";
 import {
   makeConfluenceDocumentUrl,
   makeConfluencePageId,

--- a/connectors/src/connectors/confluence/temporal/workflows.ts
+++ b/connectors/src/connectors/confluence/temporal/workflows.ts
@@ -22,12 +22,13 @@ import {
 const {
   confluenceGetSpaceNameActivity,
   confluenceListPageIdsInSpaceActivity,
-  confluenceRemoveUnvisitedPagesActivity,
-  fetchConfluenceSpaceIdsForConnectorActivity,
   confluenceRemoveSpaceActivity,
+  confluenceRemoveUnvisitedPagesActivity,
   confluenceSaveStartSyncActivity,
   confluenceSaveSuccessSyncActivity,
+  confluenceUpdatePagesParentIdsActivity,
   confluenceUpsertPageActivity,
+  fetchConfluenceSpaceIdsForConnectorActivity,
 
   confluenceGetReportPersonalActionActivity,
   fetchConfluenceUserAccountAndConnectorIdsActivity,
@@ -172,6 +173,12 @@ export async function confluenceSpaceSyncWorkflow(
     lastVisitedAt: visitedAtMs,
     spaceId,
   });
+
+  await confluenceUpdatePagesParentIdsActivity(
+    connectorId,
+    spaceId,
+    visitedAtMs
+  );
 
   return uniquePageIds.size;
 }


### PR DESCRIPTION
## Description

This PR introduces the missing parents brick to the initial Confluence integration, which intentionally omitted parent page details to get a chance to understand the RAG workflow first. The ensures that parent Ids are now included in the data source documents maintained within the core. These Ids are calculated and assigned after all pages from a given space have been synced.

For posterity, the parent Ids stored in the core document should match those used in the rendered permissions view. This is to allow a custom assistant with an action to use a data source to map and retrieve these Ids during the RAG process (as outlined in https://github.com/dust-tt/dust/pull/3445).

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
