### PR TITLE
core/connectors API: avoid dd magic with the err/error facets

### DIFF
--- a/types/src/front/lib/connectors_api.ts
+++ b/types/src/front/lib/connectors_api.ts
@@ -408,11 +408,11 @@ export class ConnectorsAPI {
         message: `Unexpected response format from ConnectorsAPI: ${error}`,
       };
       this._logger.error(
-        { error: err, parseError: error, status: response.status },
+        { connectorsError: err, parseError: error, status: response.status },
         "ConnectorsAPI error"
       );
       this._logger.error(
-        { error: err, parseError: error, status: response.status },
+        { connectorsError: err, parseError: error, status: response.status },
         `ConnectorsAPI error, raw response text: ${text}`
       );
       return new Err(err);
@@ -425,7 +425,7 @@ export class ConnectorsAPI {
 
         if (isConnectorsAPIError(err)) {
           this._logger.error(
-            { error: err, status: response.status },
+            { connectorsError: err, status: response.status },
             "ConnectorsAPI error"
           );
           return new Err(err);
@@ -435,7 +435,7 @@ export class ConnectorsAPI {
             message: "Unexpected error format from ConnectorAPI",
           };
           this._logger.error(
-            { error: err, json, status: response.status },
+            { connectorsError: err, json, status: response.status },
             "ConnectorsAPI error"
           );
           return new Err(err);

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -1078,11 +1078,11 @@ export class CoreAPI {
         message: `Unexpected response format from CoreAPI: ${error}`,
       };
       this._logger.error(
-        { error: err, parseError: error, status: response.status },
+        { coreError: err, parseError: error, status: response.status },
         "CoreAPI error"
       );
       this._logger.error(
-        { error: err, parseError: error, status: response.status },
+        { coreError: err, parseError: error, status: response.status },
         `CoreAPI error, raw response text: ${text}`
       );
       return new Err(err);
@@ -1095,7 +1095,7 @@ export class CoreAPI {
 
         if (isCoreAPIError(err)) {
           this._logger.error(
-            { error: err, status: response.status },
+            { coreError: err, json, status: response.status },
             "CoreAPI error"
           );
           return new Err(err);
@@ -1105,7 +1105,7 @@ export class CoreAPI {
             message: "Unexpected error format from CoreAPI",
           };
           this._logger.error(
-            { error: err, json, status: response.status },
+            { coreError: err, json, status: response.status },
             "CoreAPI error"
           );
           return new Err(err);
@@ -1121,7 +1121,7 @@ export class CoreAPI {
 
         if (err && isCoreAPIError(err)) {
           this._logger.error(
-            { error: err, status: response.status },
+            { coreError: err, json, status: response.status },
             "CoreAPI error"
           );
           return new Err(err);
@@ -1133,7 +1133,7 @@ export class CoreAPI {
             message: "Unexpected response format from CoreAPI",
           };
           this._logger.error(
-            { error: err, json, status: response.status },
+            { coreError: err, json, status: response.status },
             "CoreAPI error"
           );
           return new Err(err);


### PR DESCRIPTION
## Description

DD does some magic with `err` and `error` parameters:
eg: https://app.datadoghq.eu/logs?query=%22CoreAPI%20error%22%20&cols=host%2Cservice&event=AgAAAY1HWXmT25jTXgAAAAAAAAAYAAAAAEFZMUhXWHBDQUFDdHJTRFNaMzROY2dBbQAAACQAAAAAMDE4ZDQ3NTktOGQ3My00OGVkLThlNzMtMzBhYjQ2NDMzZmUz&index=%2A&messageDisplay=inline&refresh_mode=sliding&sort=time&stream_sort=desc&view=spans&viz=stream&from_ts=1706283512877&to_ts=1706297912877&live=true

Avoid it.

## Risk

None

## Deploy Plan

- deploy `front`