### PR TITLE
webcrawl: add search atttributes

### DIFF
--- a/connectors/src/connectors/webcrawler/temporal/client.ts
+++ b/connectors/src/connectors/webcrawler/temporal/client.ts
@@ -35,7 +35,9 @@ export async function launchCrawlWebsiteWorkflow(
       args: [connectorId],
       taskQueue: QUEUE_NAME,
       workflowId: workflowId,
-
+      searchAttributes: {
+        connectorId: [connectorId],
+      },
       memo: {
         connectorId: connectorId,
       },


### PR DESCRIPTION
## Description

Webcrawl does not comply to our search attributes (connectorId). This PR fixes that.

## Risk

N/A

## Deploy Plan

- deploy `connectors`