### PR TITLE
Use concurrentExecutor in GDrive permissions view

### DIFF
--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -391,12 +391,12 @@ export async function retrieveGoogleDriveConnectorPermissions({
             dustDocumentId: null,
             lastUpdatedAt: fd.updatedAtMs || null,
             expandable:
-              (await GoogleDriveFiles.findOne({
+              (await GoogleDriveFiles.count({
                 where: {
                   connectorId: connectorId,
                   parentId: f.folderId,
                 },
-              })) !== null,
+              })) > 0,
             permission: "read",
           };
         },
@@ -441,12 +441,12 @@ export async function retrieveGoogleDriveConnectorPermissions({
             lastUpdatedAt: f.lastUpsertedTs?.getTime() || null,
             sourceUrl: null,
             expandable:
-              (await GoogleDriveFiles.findOne({
+              (await GoogleDriveFiles.count({
                 where: {
                   connectorId: connectorId,
                   parentId: f.driveFileId,
                 },
-              })) !== null,
+              })) > 0,
             permission: "read",
           };
         },

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -372,34 +372,39 @@ export async function retrieveGoogleDriveConnectorPermissions({
         },
       });
 
-      const resources = (
-        await Promise.all(
-          folders.map(async (f): Promise<ConnectorResource | null> => {
-            const fd = await getGoogleDriveObject(authCredentials, f.folderId);
-            if (!fd) {
-              return null;
-            }
-            return {
-              provider: c.type,
-              internalId: f.folderId,
-              parentInternalId: null,
-              type: "folder",
-              title: fd.name || "",
-              sourceUrl: null, // Out of consistency we don't send `fd.webViewLink`.
-              dustDocumentId: null,
-              lastUpdatedAt: fd.updatedAtMs || null,
-              expandable:
-                (await GoogleDriveFiles.findOne({
-                  where: {
-                    connectorId: connectorId,
-                    parentId: f.folderId,
-                  },
-                })) !== null,
-              permission: "read",
-            };
-          })
-        )
-      ).flatMap((f) => (f ? [f] : []));
+      const folderAsConnectorResources = await concurrentExecutor(
+        folders,
+        async (f): Promise<ConnectorResource | null> => {
+          const fd = await getGoogleDriveObject(authCredentials, f.folderId);
+          if (!fd) {
+            return null;
+          }
+          return {
+            provider: c.type,
+            internalId: f.folderId,
+            parentInternalId: null,
+            type: "folder",
+            title: fd.name || "",
+            sourceUrl: null, // Out of consistency we don't send `fd.webViewLink`.
+            dustDocumentId: null,
+            lastUpdatedAt: fd.updatedAtMs || null,
+            expandable:
+              (await GoogleDriveFiles.findOne({
+                where: {
+                  connectorId: connectorId,
+                  parentId: f.folderId,
+                },
+              })) !== null,
+            permission: "read",
+          };
+        },
+        { concurrency: 4 }
+      );
+
+      // Filter out the `null`.
+      const resources = folderAsConnectorResources.flatMap((f) =>
+        f ? [f] : []
+      );
 
       resources.sort((a, b) => {
         return a.title.localeCompare(b.title);
@@ -415,35 +420,35 @@ export async function retrieveGoogleDriveConnectorPermissions({
         },
       });
 
-      const resources: ConnectorResource[] = await Promise.all(
-        folderOrFiles.map((f) => {
-          return (async () => {
-            return {
-              provider: c.type,
-              internalId: f.driveFileId,
-              parentInternalId: null,
-              type:
-                f.mimeType === "application/vnd.google-apps.folder"
-                  ? "folder"
-                  : "file",
-              title: f.name || "",
-              dustDocumentId:
-                f.mimeType === "application/vnd.google-apps.folder"
-                  ? null
-                  : getDocumentId(f.driveFileId),
-              lastUpdatedAt: f.lastUpsertedTs?.getTime() || null,
-              sourceUrl: null,
-              expandable:
-                (await GoogleDriveFiles.findOne({
-                  where: {
-                    connectorId: connectorId,
-                    parentId: f.driveFileId,
-                  },
-                })) !== null,
-              permission: "read",
-            };
-          })();
-        })
+      const resources = await concurrentExecutor(
+        folderOrFiles,
+        async (f): Promise<ConnectorResource> => {
+          return {
+            provider: c.type,
+            internalId: f.driveFileId,
+            parentInternalId: null,
+            type:
+              f.mimeType === "application/vnd.google-apps.folder"
+                ? "folder"
+                : "file",
+            title: f.name || "",
+            dustDocumentId:
+              f.mimeType === "application/vnd.google-apps.folder"
+                ? null
+                : getDocumentId(f.driveFileId),
+            lastUpdatedAt: f.lastUpsertedTs?.getTime() || null,
+            sourceUrl: null,
+            expandable:
+              (await GoogleDriveFiles.findOne({
+                where: {
+                  connectorId: connectorId,
+                  parentId: f.driveFileId,
+                },
+              })) !== null,
+            permission: "read",
+          };
+        },
+        { concurrency: 4 }
       );
 
       // Sorting resources, folders first then alphabetically.

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -44,6 +44,8 @@ export type NangoConnectionId = string;
 import type { ConnectorsAPIError, ModelId } from "@dust-tt/types";
 import { v4 as uuidv4 } from "uuid";
 
+import { concurrentExecutor } from "@connectors/lib/async_utils";
+
 const {
   NANGO_GOOGLE_DRIVE_CONNECTOR_ID,
   GOOGLE_CLIENT_ID,

--- a/connectors/src/lib/async_utils.ts
+++ b/connectors/src/lib/async_utils.ts
@@ -1,18 +1,20 @@
 import PQueue from "p-queue";
 
-export async function concurrentExecutor<T>(
+export async function concurrentExecutor<T, V>(
   items: T[],
-  iterator: (item: T, idx: number) => Promise<void>,
+  iterator: (item: T, idx: number) => Promise<V>,
   { concurrency = 8 }: { concurrency: number }
 ) {
   const queue = new PQueue({ concurrency });
-
-  const promises = [];
+  const promises: Promise<V>[] = [];
 
   for (const [idx, item] of items.entries()) {
     // Queue each task. The queue manages concurrency.
     // Each task is wrapped in a promise to capture its completion.
-    promises.push(queue.add(async () => iterator(item, idx)));
+    const p = queue.add(async () => iterator(item, idx));
+
+    // Cast the promise to Promise<R> to fix the return type from P-Queue.
+    promises.push(p as Promise<V>);
   }
 
   // `Promise.all` will throw at the first rejection, but all tasks will continue to process.


### PR DESCRIPTION
## Description

This PR aims at reducing parallelism on the same Sequelize connection (see [logs](https://app.datadoghq.eu/apm/traces?query=%40_top_level%3A1%20env%3A%22prod%22%20service%3A%22front%22%20resource_name%3A%22GET%20%2Fapi%2Fw%2F%5BwId%5D%2Fdata_sources%2F%5Bname%5D%2Fmanaged%2Fpermissions%22%20host%3A%22gk3-dust-kube-pool-2-27bb32e3-x85m.c.or1g1n-186209.internal%22&cols=core_service%2Ccore_resource_name%2Clog_duration%2Clog_http.method%2Clog_http.status_code&env=prod&graphType=span_list&historicalData=true&messageDisplay=inline&query_translation_version=v0&shouldShowLegend=true&sort=time&spanID=38818728884013768&spanType=service-entry&trace=ab15f51358f25bfb&traceID=4936245591272446082&traceQuery=&view=spans&start=1706303659314&end=1706303719314&paused=true))
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
