### PR TITLE
dustAPI: better error handling

### DIFF
--- a/types/src/front/lib/dust_api.ts
+++ b/types/src/front/lib/dust_api.ts
@@ -382,12 +382,6 @@ export class DustAPI {
       return r;
     }
     return new Ok(r.value.run);
-
-    // const json = await res.json();
-    // if (json.error) {
-    //   return new Err(json.error as DustAPIErrorResponse);
-    // }
-    // return new Ok(json.run as RunType);
   }
 
   /**
@@ -455,12 +449,6 @@ export class DustAPI {
       return r;
     }
     return new Ok(r.value.data_sources);
-
-    // const json = await res.json();
-    // if (json.error) {
-    //   return new Err(json.error as DustAPIErrorResponse);
-    // }
-    // return new Ok(json.data_sources as DataSourceType[]);
   }
 
   async getAgentConfigurations(): Promise<
@@ -484,13 +472,6 @@ export class DustAPI {
       return r;
     }
     return new Ok(r.value.agentConfigurations);
-
-    // const json = await res.json();
-
-    // if (json.error) {
-    //   return new Err(json.error as DustAPIErrorResponse);
-    // }
-    // return new Ok(json.agentConfigurations as LightAgentConfigurationType[]);
   }
 
   async postContentFragment({
@@ -520,13 +501,6 @@ export class DustAPI {
       return r;
     }
     return new Ok(r.value.contentFragment);
-
-    // const json = await res.json();
-
-    // if (json.error) {
-    //   return new Err(json.error as DustAPIErrorResponse);
-    // }
-    // return new Ok(json.contentFragment as ContentFragmentType);
   }
 
   // When creating a conversation with a user message, the API returns only after the user message
@@ -560,15 +534,6 @@ export class DustAPI {
     );
 
     return this._resultFromResponse(res);
-
-    // const json = await res.json();
-    // if (json.error) {
-    //   return new Err(json.error as DustAPIErrorResponse);
-    // }
-
-    // return new Ok(
-    //   json as { conversation: ConversationType; message: UserMessageType }
-    // );
   }
 
   async postUserMessage({
@@ -598,13 +563,6 @@ export class DustAPI {
       return r;
     }
     return new Ok(r.value.message);
-
-    // const json = await res.json();
-    // if (json.error) {
-    //   return new Err(json.error as DustAPIErrorResponse);
-    // }
-
-    // return new Ok(json.message as UserMessageType);
   }
 
   async streamAgentMessageEvents({
@@ -743,13 +701,6 @@ export class DustAPI {
       return r;
     }
     return new Ok(r.value.conversation);
-
-    // const json = await res.json();
-
-    // if (json.error) {
-    //   return new Err(json.error as DustAPIErrorResponse);
-    // }
-    // return new Ok(json.conversation as ConversationType);
   }
 
   async tokenize(
@@ -776,25 +727,6 @@ export class DustAPI {
       return r;
     }
     return new Ok(r.value.tokens);
-
-    // try {
-    //   const dustRequestResult = await res.json();
-
-    //   if (dustRequestResult.error) {
-    //     return new Err(dustRequestResult.error as DustAPIErrorResponse);
-    //   }
-    //   return new Ok(dustRequestResult.tokens as CoreAPITokenType[]);
-    // } catch (err) {
-    //   const rawResponse = await res.text();
-
-    //   const message = `Dust API /tokenize responded with status: ${res.status}.`;
-    //   this._logger.error(
-    //     { status: res.status, response: rawResponse },
-    //     message
-    //   );
-
-    //   return new Err({ type: "bad_request", message });
-    // }
   }
 
   private async _resultFromResponse<T>(

--- a/types/src/front/lib/dust_api.ts
+++ b/types/src/front/lib/dust_api.ts
@@ -25,13 +25,9 @@ import {
 } from "./api/assistant/agent";
 import { UserMessageErrorEvent } from "./api/assistant/conversation";
 import { GenerationTokensEvent } from "./api/assistant/generation";
+import { APIError, isAPIError } from "./error";
 
 const { DUST_PROD_API = "https://dust.tt", NODE_ENV } = process.env;
-
-export type DustAPIErrorResponse = {
-  type: string;
-  message: string;
-};
 
 export type DustAppType = {
   workspaceId: string;
@@ -145,6 +141,8 @@ export type DustAPICredentials = {
 type PublicPostContentFragmentRequestBody = t.TypeOf<
   typeof PublicPostContentFragmentRequestBodySchema
 >;
+
+export type DustAPIResponse<T> = Result<T, APIError>;
 
 /**
  * This help functions process a streamed response in the format of the Dust API for running
@@ -355,7 +353,7 @@ export class DustAPI {
     { useWorkspaceCredentials }: { useWorkspaceCredentials: boolean } = {
       useWorkspaceCredentials: false,
     }
-  ) {
+  ): Promise<DustAPIResponse<RunType>> {
     let url = `${this.apiUrl()}/api/v1/w/${app.workspaceId}/apps/${
       app.appId
     }/runs`;
@@ -377,11 +375,19 @@ export class DustAPI {
       }),
     });
 
-    const json = await res.json();
-    if (json.error) {
-      return new Err(json.error as DustAPIErrorResponse);
+    const r: DustAPIResponse<{ run: RunType }> = await this._resultFromResponse(
+      res
+    );
+    if (r.isErr()) {
+      return r;
     }
-    return new Ok(json.run as RunType);
+    return new Ok(r.value.run);
+
+    // const json = await res.json();
+    // if (json.error) {
+    //   return new Err(json.error as DustAPIErrorResponse);
+    // }
+    // return new Ok(json.run as RunType);
   }
 
   /**
@@ -430,7 +436,9 @@ export class DustAPI {
    *
    * @param workspaceId string the workspace id to fetch data sources for
    */
-  async getDataSources(workspaceId: string) {
+  async getDataSources(
+    workspaceId: string
+  ): Promise<DustAPIResponse<DataSourceType[]>> {
     const res = await fetch(
       `${this.apiUrl()}/api/v1/w/${workspaceId}/data_sources`,
       {
@@ -441,14 +449,23 @@ export class DustAPI {
       }
     );
 
-    const json = await res.json();
-    if (json.error) {
-      return new Err(json.error as DustAPIErrorResponse);
+    const r: DustAPIResponse<{ data_sources: DataSourceType[] }> =
+      await this._resultFromResponse(res);
+    if (r.isErr()) {
+      return r;
     }
-    return new Ok(json.data_sources as DataSourceType[]);
+    return new Ok(r.value.data_sources);
+
+    // const json = await res.json();
+    // if (json.error) {
+    //   return new Err(json.error as DustAPIErrorResponse);
+    // }
+    // return new Ok(json.data_sources as DataSourceType[]);
   }
 
-  async getAgentConfigurations() {
+  async getAgentConfigurations(): Promise<
+    DustAPIResponse<LightAgentConfigurationType[]>
+  > {
     const res = await fetch(
       `${this.apiUrl()}/api/v1/w/${this.workspaceId()}/assistant/agent_configurations`,
       {
@@ -460,12 +477,20 @@ export class DustAPI {
       }
     );
 
-    const json = await res.json();
-
-    if (json.error) {
-      return new Err(json.error as DustAPIErrorResponse);
+    const r: DustAPIResponse<{
+      agentConfigurations: LightAgentConfigurationType[];
+    }> = await this._resultFromResponse(res);
+    if (r.isErr()) {
+      return r;
     }
-    return new Ok(json.agentConfigurations as LightAgentConfigurationType[]);
+    return new Ok(r.value.agentConfigurations);
+
+    // const json = await res.json();
+
+    // if (json.error) {
+    //   return new Err(json.error as DustAPIErrorResponse);
+    // }
+    // return new Ok(json.agentConfigurations as LightAgentConfigurationType[]);
   }
 
   async postContentFragment({
@@ -474,7 +499,7 @@ export class DustAPI {
   }: {
     conversationId: string;
     contentFragment: PublicPostContentFragmentRequestBody;
-  }) {
+  }): Promise<DustAPIResponse<ContentFragmentType>> {
     const res = await fetch(
       `${this.apiUrl()}/api/v1/w/${this.workspaceId()}/assistant/conversations/${conversationId}/content_fragments`,
       {
@@ -489,12 +514,19 @@ export class DustAPI {
       }
     );
 
-    const json = await res.json();
-
-    if (json.error) {
-      return new Err(json.error as DustAPIErrorResponse);
+    const r: DustAPIResponse<{ contentFragment: ContentFragmentType }> =
+      await this._resultFromResponse(res);
+    if (r.isErr()) {
+      return r;
     }
-    return new Ok(json.contentFragment as ContentFragmentType);
+    return new Ok(r.value.contentFragment);
+
+    // const json = await res.json();
+
+    // if (json.error) {
+    //   return new Err(json.error as DustAPIErrorResponse);
+    // }
+    // return new Ok(json.contentFragment as ContentFragmentType);
   }
 
   // When creating a conversation with a user message, the API returns only after the user message
@@ -505,10 +537,10 @@ export class DustAPI {
     message,
     contentFragment,
   }: t.TypeOf<typeof PublicPostConversationsRequestBodySchema>): Promise<
-    Result<
-      { conversation: ConversationType; message: UserMessageType },
-      DustAPIErrorResponse
-    >
+    DustAPIResponse<{
+      conversation: ConversationType;
+      message: UserMessageType;
+    }>
   > {
     const res = await fetch(
       `${this.apiUrl()}/api/v1/w/${this.workspaceId()}/assistant/conversations`,
@@ -527,14 +559,16 @@ export class DustAPI {
       }
     );
 
-    const json = await res.json();
-    if (json.error) {
-      return new Err(json.error as DustAPIErrorResponse);
-    }
+    return this._resultFromResponse(res);
 
-    return new Ok(
-      json as { conversation: ConversationType; message: UserMessageType }
-    );
+    // const json = await res.json();
+    // if (json.error) {
+    //   return new Err(json.error as DustAPIErrorResponse);
+    // }
+
+    // return new Ok(
+    //   json as { conversation: ConversationType; message: UserMessageType }
+    // );
   }
 
   async postUserMessage({
@@ -543,7 +577,7 @@ export class DustAPI {
   }: {
     conversationId: string;
     message: t.TypeOf<typeof PublicPostMessagesRequestBodySchema>;
-  }) {
+  }): Promise<DustAPIResponse<UserMessageType>> {
     const res = await fetch(
       `${this.apiUrl()}/api/v1/w/${this.workspaceId()}/assistant/conversations/${conversationId}/messages`,
       {
@@ -558,12 +592,19 @@ export class DustAPI {
       }
     );
 
-    const json = await res.json();
-    if (json.error) {
-      return new Err(json.error as DustAPIErrorResponse);
+    const r: DustAPIResponse<{ message: UserMessageType }> =
+      await this._resultFromResponse(res);
+    if (r.isErr()) {
+      return r;
     }
+    return new Ok(r.value.message);
 
-    return new Ok(json.message as UserMessageType);
+    // const json = await res.json();
+    // if (json.error) {
+    //   return new Err(json.error as DustAPIErrorResponse);
+    // }
+
+    // return new Ok(json.message as UserMessageType);
   }
 
   async streamAgentMessageEvents({
@@ -680,7 +721,11 @@ export class DustAPI {
     return new Ok({ eventStream: streamEvents() });
   }
 
-  async getConversation({ conversationId }: { conversationId: string }) {
+  async getConversation({
+    conversationId,
+  }: {
+    conversationId: string;
+  }): Promise<DustAPIResponse<ConversationType>> {
     const res = await fetch(
       `${this.apiUrl()}/api/v1/w/${this.workspaceId()}/assistant/conversations/${conversationId}`,
       {
@@ -692,18 +737,25 @@ export class DustAPI {
       }
     );
 
-    const json = await res.json();
-
-    if (json.error) {
-      return new Err(json.error as DustAPIErrorResponse);
+    const r: DustAPIResponse<{ conversation: ConversationType }> =
+      await this._resultFromResponse(res);
+    if (r.isErr()) {
+      return r;
     }
-    return new Ok(json.conversation as ConversationType);
+    return new Ok(r.value.conversation);
+
+    // const json = await res.json();
+
+    // if (json.error) {
+    //   return new Err(json.error as DustAPIErrorResponse);
+    // }
+    // return new Ok(json.conversation as ConversationType);
   }
 
   async tokenize(
     text: string,
     dataSourceName: string
-  ): Promise<Result<CoreAPITokenType[], DustAPIErrorResponse>> {
+  ): Promise<DustAPIResponse<CoreAPITokenType[]>> {
     const urlSafeName = encodeURIComponent(dataSourceName);
     const endpoint = `${this.apiUrl()}/api/v1/w/${this.workspaceId()}/data_sources/${urlSafeName}/tokenize`;
 
@@ -718,23 +770,81 @@ export class DustAPI {
       }),
     });
 
+    const r: DustAPIResponse<{ tokens: CoreAPITokenType[] }> =
+      await this._resultFromResponse(res);
+    if (r.isErr()) {
+      return r;
+    }
+    return new Ok(r.value.tokens);
+
+    // try {
+    //   const dustRequestResult = await res.json();
+
+    //   if (dustRequestResult.error) {
+    //     return new Err(dustRequestResult.error as DustAPIErrorResponse);
+    //   }
+    //   return new Ok(dustRequestResult.tokens as CoreAPITokenType[]);
+    // } catch (err) {
+    //   const rawResponse = await res.text();
+
+    //   const message = `Dust API /tokenize responded with status: ${res.status}.`;
+    //   this._logger.error(
+    //     { status: res.status, response: rawResponse },
+    //     message
+    //   );
+
+    //   return new Err({ type: "bad_request", message });
+    // }
+  }
+
+  private async _resultFromResponse<T>(
+    response: Response
+  ): Promise<DustAPIResponse<T>> {
+    // We get the text and attempt to parse so that we can log the raw text in case of error (the
+    // body is already consumed by response.json() if used otherwise).
+    const text = await response.text();
+
+    let json = null;
     try {
-      const dustRequestResult = await res.json();
-
-      if (dustRequestResult.error) {
-        return new Err(dustRequestResult.error as DustAPIErrorResponse);
-      }
-      return new Ok(dustRequestResult.tokens as CoreAPITokenType[]);
-    } catch (err) {
-      const rawResponse = await res.text();
-
-      const message = `Dust API /tokenize responded with status: ${res.status}.`;
+      json = JSON.parse(text);
+    } catch (e) {
+      const err: APIError = {
+        type: "unexpected_response_format",
+        message: `Unexpected response format from ConnectorsAPI: ${e}`,
+      };
       this._logger.error(
-        { status: res.status, response: rawResponse },
-        message
+        {
+          connectorsError: err,
+          parseError: e,
+          rawText: text,
+          status: response.status,
+        },
+        "DustAPI error"
       );
+      return new Err(err);
+    }
 
-      return new Err({ type: "bad_request", message });
+    if (!response.ok) {
+      const err = json?.error;
+      if (isAPIError(err)) {
+        this._logger.error(
+          { connectorsError: err, status: response.status },
+          "DustAPI error"
+        );
+        return new Err(err);
+      } else {
+        const err: APIError = {
+          type: "unexpected_error_format",
+          message: "Unexpected error format from ConnectorAPI",
+        };
+        this._logger.error(
+          { connectorsError: err, json, status: response.status },
+          "DustAPI error"
+        );
+        return new Err(err);
+      }
+    } else {
+      return new Ok(json);
     }
   }
 }

--- a/types/src/front/lib/error.ts
+++ b/types/src/front/lib/error.ts
@@ -49,7 +49,10 @@ export type APIErrorType =
   | "global_agent_error"
   | "stripe_invalid_product_id_error"
   | "rate_limit_error"
-  | "subscription_payment_failed";
+  | "subscription_payment_failed"
+  // Used in the DustAPI client:
+  | "unexpected_error_format"
+  | "unexpected_response_format";
 
 export type APIError = {
   type: APIErrorType;
@@ -59,6 +62,17 @@ export type APIError = {
   app_error?: CoreAPIError;
   connectors_error?: ConnectorsAPIError;
 };
+
+export function isAPIError(obj: unknown): obj is APIError {
+  return (
+    typeof obj === "object" &&
+    obj !== null &&
+    "message" in obj &&
+    typeof obj.message === "string" &&
+    "type" in obj &&
+    typeof obj.type === "string"
+  );
+}
 
 /**
  * Type to transport a HTTP error with its http status code (eg: 404)

--- a/types/src/front/lib/error.ts
+++ b/types/src/front/lib/error.ts
@@ -71,6 +71,7 @@ export function isAPIError(obj: unknown): obj is APIError {
     typeof obj.message === "string" &&
     "type" in obj &&
     typeof obj.type === "string"
+    // TODO(spolu): check type is a valid APIErrorType
   );
 }
 


### PR DESCRIPTION
## Description

Introduce `_resultFromResponse` in DustAPI and non streamed functions to use it.

## Risk

Double check typing.

## Deploy Plan

- deploy `connectors` `front`
- watch connectors, test slack bot