### PR TITLE
dust apps: private by default, remove unlisted option

### DIFF
--- a/front/lib/actions/helpers.ts
+++ b/front/lib/actions/helpers.ts
@@ -1,6 +1,5 @@
-import type { Action } from "@dust-tt/types";
-import type { DustAPIErrorResponse, DustAppConfigType } from "@dust-tt/types";
-import type { Result } from "@dust-tt/types";
+import type { Action, DustAPIResponse } from "@dust-tt/types";
+import type { DustAppConfigType } from "@dust-tt/types";
 import { cloneBaseConfig } from "@dust-tt/types";
 import { DustAPI } from "@dust-tt/types";
 import { Err, Ok } from "@dust-tt/types";
@@ -45,7 +44,7 @@ export async function callAction<V extends t.Mixed>({
   config,
   responseValueSchema,
 }: CallActionParams<V>): Promise<
-  Result<t.TypeOf<typeof responseValueSchema>, DustAPIErrorResponse>
+  DustAPIResponse<t.TypeOf<typeof responseValueSchema>>
 > {
   const app = cloneBaseConfig(action.app);
 
@@ -61,13 +60,15 @@ export async function callAction<V extends t.Mixed>({
 
   const prodAPI = new DustAPI(prodCredentials, logger);
 
-  const response = (await prodAPI.runApp(app, config, [input])) as Result<
-    unknown,
-    DustAPIErrorResponse
-  >;
+  const r = await prodAPI.runApp(app, config, [input]);
 
-  if (response.isErr()) {
-    return response;
+  // const response = (await prodAPI.runApp(app, config, [input])) as Result<
+  //   unknown,
+  //   APIError
+  // >;
+
+  if (r.isErr()) {
+    return r;
   }
 
   // create a schema validator using the provided schema + the base response schema
@@ -81,18 +82,18 @@ export async function callAction<V extends t.Mixed>({
   const responseChecker = (response: unknown): response is responseType =>
     isRight(responseSchema.decode(response));
 
-  if (responseChecker(response.value)) {
+  if (responseChecker(r.value)) {
     // the response is a valid success response for the action
     // return the "value" field of the first result
-    return new Ok(response.value.results[0][0].value);
+    return new Ok(r.value.results[0][0].value);
   }
 
-  if (isActionResponseBase(response.value)) {
+  if (isActionResponseBase(r.value)) {
     // the response is of the right shape, but it's not a success response
     return new Err({
       type: "action_failed",
       message: `Doc Tracker action failed response: ${JSON.stringify(
-        response.value.status
+        r.value.status
       )}`,
     });
   }

--- a/front/lib/actions/helpers.ts
+++ b/front/lib/actions/helpers.ts
@@ -62,11 +62,6 @@ export async function callAction<V extends t.Mixed>({
 
   const r = await prodAPI.runApp(app, config, [input]);
 
-  // const response = (await prodAPI.runApp(app, config, [input])) as Result<
-  //   unknown,
-  //   APIError
-  // >;
-
   if (r.isErr()) {
     return r;
   }

--- a/front/pages/w/[wId]/a/new.tsx
+++ b/front/pages/w/[wId]/a/new.tsx
@@ -54,7 +54,7 @@ export default function NewApp({
   const [appName, setAppName] = useState("");
   const [appNameError, setAppNameError] = useState("");
   const [appDescription, setAppDescription] = useState("");
-  const [appVisibility, setAppVisibility] = useState("public");
+  const [appVisibility, setAppVisibility] = useState("private");
 
   const [creating, setCreating] = useState(false);
 
@@ -204,7 +204,8 @@ export default function NewApp({
                   >
                     Public
                     <p className="mt-0 text-sm font-normal text-gray-500">
-                      Anyone on the Internet can see the app. Only you can edit.
+                      Anyone on the Internet can see the app. Only builders of
+                      your workspace can edit.
                     </p>
                   </label>
                 </div>
@@ -228,31 +229,7 @@ export default function NewApp({
                   >
                     Private
                     <p className="mt-0 text-sm font-normal text-gray-500">
-                      Only you can see and edit the app.
-                    </p>
-                  </label>
-                </div>
-                <div className="flex items-center">
-                  <input
-                    id="appVisibilityUnlisted"
-                    name="visibility"
-                    type="radio"
-                    value="unlisted"
-                    className="h-4 w-4 cursor-pointer border-gray-300 text-action-600 focus:ring-action-500"
-                    checked={appVisibility == "unlisted"}
-                    onChange={(e) => {
-                      if (e.target.value != appVisibility) {
-                        setAppVisibility(e.target.value);
-                      }
-                    }}
-                  />
-                  <label
-                    htmlFor="app-visibility-unlisted"
-                    className="ml-3 block text-sm font-medium text-gray-700"
-                  >
-                    Unlisted
-                    <p className="mt-0 text-sm font-normal text-gray-500">
-                      Anyone with the link can see the app. Only you can edit.
+                      Only builders of your workspace can see and edit the app.
                     </p>
                   </label>
                 </div>

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -1074,8 +1074,6 @@ export class CoreAPI {
     // body is already consumed by response.json() if used otherwise).
     const text = await response.text();
 
-    console.log("TEXT", text);
-
     let json = null;
     try {
       json = JSON.parse(text);

--- a/types/src/front/lib/error.ts
+++ b/types/src/front/lib/error.ts
@@ -52,7 +52,10 @@ export type APIErrorType =
   | "subscription_payment_failed"
   // Used in the DustAPI client:
   | "unexpected_error_format"
-  | "unexpected_response_format";
+  | "unexpected_response_format"
+  // Used by callAction client:
+  | "action_failed"
+  | "unexpected_action_response";
 
 export type APIError = {
   type: APIErrorType;


### PR DESCRIPTION
## Description

Move default to private for apps. Remove unlisted (which does not have much meaning anymore).

Also some type fixing

## Risk

N/A

## Deploy Plan

- deploy `front`