### PR TITLE
Fix: temporary: raise heartbeat timeout for webcrawler

### DIFF
--- a/connectors/src/connectors/webcrawler/temporal/workflows.ts
+++ b/connectors/src/connectors/webcrawler/temporal/workflows.ts
@@ -5,7 +5,7 @@ import type * as activities from "@connectors/connectors/webcrawler/temporal/act
 
 const { crawlWebsiteByConnectorId } = proxyActivities<typeof activities>({
   startToCloseTimeout: "120 minutes",
-  heartbeatTimeout: "120 seconds",
+  heartbeatTimeout: "600 seconds",
 });
 
 export async function crawlWebsiteWorkflow(


### PR DESCRIPTION
to avoid burst of crawlings when there is a heartbeat timeout, cf [here](https://dust4ai.slack.com/archives/C05B529FHV1/p1706342128775499)


