### PR TITLE
Fix: allow long-running crawling activity to be canceled cleanly

### DIFF
--- a/connectors/src/connectors/webcrawler/lib/utils.ts
+++ b/connectors/src/connectors/webcrawler/lib/utils.ts
@@ -1,9 +1,6 @@
 import type { ConnectorResourceType } from "@dust-tt/types";
 import { hash as blake3 } from "blake3";
 
-// timeout for upserting is 5 minutes, + 2mn leeway to crawl on slow websites
-export const REQUEST_HANDLING_TIMEOUT = 420;
-
 // Generate a stable id for a given url and ressource type
 // That way we don't have to send URL as documentId to the front API.
 export function stableIdForUrl({

--- a/connectors/src/connectors/webcrawler/lib/utils.ts
+++ b/connectors/src/connectors/webcrawler/lib/utils.ts
@@ -1,6 +1,9 @@
 import type { ConnectorResourceType } from "@dust-tt/types";
 import { hash as blake3 } from "blake3";
 
+// timeout for upserting is 5 minutes, + 2mn leeway to crawl on slow websites
+export const REQUEST_HANDLING_TIMEOUT = 420;
+
 // Generate a stable id for a given url and ressource type
 // That way we don't have to send URL as documentId to the front API.
 export function stableIdForUrl({

--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -12,7 +12,6 @@ import {
   isTopFolder,
   stableIdForUrl,
 } from "@connectors/connectors/webcrawler/lib/utils";
-import { REQUEST_HANDLING_TIMEOUT } from "@connectors/connectors/webcrawler/lib/utils";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import {
   MAX_DOCUMENT_TXT_LEN,
@@ -29,6 +28,7 @@ import {
   syncSucceeded,
 } from "@connectors/lib/sync_status";
 import logger from "@connectors/logger/logger";
+import { REQUEST_HANDLING_TIMEOUT } from "@connectors/connectors/webcrawler/temporal/workflows";
 
 const MAX_DEPTH = 5;
 const MAX_PAGES = 512;

--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -56,7 +56,7 @@ export async function crawlWebsiteByConnectorId(connectorId: ModelId) {
     {
       maxRequestsPerCrawl: MAX_PAGES,
       maxConcurrency: CONCURRENCY,
-
+      maxRequestsPerMinute: 300, // 5 requests per second to avoid overloading the target website
       async requestHandler({ $, request, enqueueLinks }) {
         Context.current().heartbeat({
           type: "http_request",

--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -12,6 +12,7 @@ import {
   isTopFolder,
   stableIdForUrl,
 } from "@connectors/connectors/webcrawler/lib/utils";
+import { REQUEST_HANDLING_TIMEOUT } from "@connectors/connectors/webcrawler/temporal/workflows";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import {
   MAX_DOCUMENT_TXT_LEN,
@@ -28,7 +29,6 @@ import {
   syncSucceeded,
 } from "@connectors/lib/sync_status";
 import logger from "@connectors/logger/logger";
-import { REQUEST_HANDLING_TIMEOUT } from "@connectors/connectors/webcrawler/temporal/workflows";
 
 const MAX_DEPTH = 5;
 const MAX_PAGES = 512;

--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -32,6 +32,9 @@ const MAX_DEPTH = 5;
 const MAX_PAGES = 512;
 const CONCURRENCY = 4;
 
+// timeout for upserting is 5 minutes, + 2mn leeway to crawl on slow websites
+export const REQUEST_HANDLING_TIMEOUT = 420;
+
 export async function crawlWebsiteByConnectorId(connectorId: ModelId) {
   const connector = await Connector.findByPk(connectorId);
   if (!connector) {
@@ -57,6 +60,7 @@ export async function crawlWebsiteByConnectorId(connectorId: ModelId) {
       maxRequestsPerCrawl: MAX_PAGES,
       maxConcurrency: CONCURRENCY,
       maxRequestsPerMinute: 300, // 5 requests per second to avoid overloading the target website
+      requestHandlerTimeoutSecs: REQUEST_HANDLING_TIMEOUT,
       async requestHandler({ $, request, enqueueLinks }) {
         Context.current().heartbeat({
           type: "http_request",

--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -59,7 +59,7 @@ export async function crawlWebsiteByConnectorId(connectorId: ModelId) {
     {
       maxRequestsPerCrawl: MAX_PAGES,
       maxConcurrency: CONCURRENCY,
-      maxRequestsPerMinute: 300, // 5 requests per second to avoid overloading the target website
+      maxRequestsPerMinute: 60, // 5 requests per second to avoid overloading the target website
       requestHandlerTimeoutSecs: REQUEST_HANDLING_TIMEOUT,
       async requestHandler({ $, request, enqueueLinks }) {
         Context.current().heartbeat({

--- a/connectors/src/connectors/webcrawler/temporal/workflows.ts
+++ b/connectors/src/connectors/webcrawler/temporal/workflows.ts
@@ -1,5 +1,9 @@
 import type { ModelId } from "@dust-tt/types";
-import { CancellationScope, proxyActivities } from "@temporalio/workflow";
+import {
+  ActivityCancellationType,
+  CancellationScope,
+  proxyActivities,
+} from "@temporalio/workflow";
 
 import type * as activities from "@connectors/connectors/webcrawler/temporal/activities";
 
@@ -11,7 +15,13 @@ const { crawlWebsiteByConnectorId } = proxyActivities<typeof activities>({
   startToCloseTimeout: "120 minutes",
   // for each page crawl, there are heartbeats, but a page crawl can last at max
   // REQUEST_HANDLING_TIMEOUT seconds
-  heartbeatTimeout: `${REQUEST_HANDLING_TIMEOUT} seconds`,
+  heartbeatTimeout: "1 seconds", // `${REQUEST_HANDLING_TIMEOUT} seconds`,
+  cancellationType: ActivityCancellationType.TRY_CANCEL,
+  retry: {
+    initialInterval: `${REQUEST_HANDLING_TIMEOUT * 2} seconds`,
+    maximumInterval: "3600 seconds",
+    maximumAttempts: 20,
+  },
 });
 
 export async function crawlWebsiteWorkflow(

--- a/connectors/src/connectors/webcrawler/temporal/workflows.ts
+++ b/connectors/src/connectors/webcrawler/temporal/workflows.ts
@@ -15,7 +15,7 @@ const { crawlWebsiteByConnectorId } = proxyActivities<typeof activities>({
   startToCloseTimeout: "120 minutes",
   // for each page crawl, there are heartbeats, but a page crawl can last at max
   // REQUEST_HANDLING_TIMEOUT seconds
-  heartbeatTimeout: "1 seconds", // `${REQUEST_HANDLING_TIMEOUT} seconds`,
+  heartbeatTimeout: `${REQUEST_HANDLING_TIMEOUT} seconds`,
   cancellationType: ActivityCancellationType.TRY_CANCEL,
   retry: {
     initialInterval: `${REQUEST_HANDLING_TIMEOUT * 2} seconds`,

--- a/connectors/src/connectors/webcrawler/temporal/workflows.ts
+++ b/connectors/src/connectors/webcrawler/temporal/workflows.ts
@@ -20,7 +20,6 @@ const { crawlWebsiteByConnectorId } = proxyActivities<typeof activities>({
   retry: {
     initialInterval: `${REQUEST_HANDLING_TIMEOUT * 2} seconds`,
     maximumInterval: "3600 seconds",
-    maximumAttempts: 20,
   },
 });
 

--- a/connectors/src/connectors/webcrawler/temporal/workflows.ts
+++ b/connectors/src/connectors/webcrawler/temporal/workflows.ts
@@ -2,7 +2,8 @@ import type { ModelId } from "@dust-tt/types";
 import { CancellationScope, proxyActivities } from "@temporalio/workflow";
 
 import type * as activities from "@connectors/connectors/webcrawler/temporal/activities";
-import { REQUEST_HANDLING_TIMEOUT } from "./activities";
+
+import { REQUEST_HANDLING_TIMEOUT } from "../lib/utils";
 
 const { crawlWebsiteByConnectorId } = proxyActivities<typeof activities>({
   startToCloseTimeout: "120 minutes",
@@ -14,7 +15,7 @@ const { crawlWebsiteByConnectorId } = proxyActivities<typeof activities>({
 export async function crawlWebsiteWorkflow(
   connectorId: ModelId
 ): Promise<void> {
-  CancellationScope.cancellable(
+  await CancellationScope.cancellable(
     crawlWebsiteByConnectorId.bind(null, connectorId)
   );
 }

--- a/connectors/src/connectors/webcrawler/temporal/workflows.ts
+++ b/connectors/src/connectors/webcrawler/temporal/workflows.ts
@@ -3,7 +3,9 @@ import { CancellationScope, proxyActivities } from "@temporalio/workflow";
 
 import type * as activities from "@connectors/connectors/webcrawler/temporal/activities";
 
-import { REQUEST_HANDLING_TIMEOUT } from "../lib/utils";
+// timeout for crawling a single url = timeout for upserting (5 minutes) + 2mn
+// leeway to crawl on slow websites
+export const REQUEST_HANDLING_TIMEOUT = 420;
 
 const { crawlWebsiteByConnectorId } = proxyActivities<typeof activities>({
   startToCloseTimeout: "120 minutes",

--- a/connectors/src/connectors/webcrawler/temporal/workflows.ts
+++ b/connectors/src/connectors/webcrawler/temporal/workflows.ts
@@ -2,10 +2,13 @@ import type { ModelId } from "@dust-tt/types";
 import { proxyActivities } from "@temporalio/workflow";
 
 import type * as activities from "@connectors/connectors/webcrawler/temporal/activities";
+import { REQUEST_HANDLING_TIMEOUT } from "@connectors/connectors/webcrawler/temporal/activities";
 
 const { crawlWebsiteByConnectorId } = proxyActivities<typeof activities>({
   startToCloseTimeout: "120 minutes",
-  heartbeatTimeout: "600 seconds",
+  // for each page crawl, there are heartbeats, but a page crawl can last at max
+  // REQUEST_HANDLING_TIMEOUT seconds
+  heartbeatTimeout: `${REQUEST_HANDLING_TIMEOUT} seconds`,
 });
 
 export async function crawlWebsiteWorkflow(

--- a/connectors/src/connectors/webcrawler/temporal/workflows.ts
+++ b/connectors/src/connectors/webcrawler/temporal/workflows.ts
@@ -1,8 +1,8 @@
 import type { ModelId } from "@dust-tt/types";
-import { proxyActivities } from "@temporalio/workflow";
+import { CancellationScope, proxyActivities } from "@temporalio/workflow";
 
 import type * as activities from "@connectors/connectors/webcrawler/temporal/activities";
-import { REQUEST_HANDLING_TIMEOUT } from "@connectors/connectors/webcrawler/temporal/activities";
+import { REQUEST_HANDLING_TIMEOUT } from "./activities";
 
 const { crawlWebsiteByConnectorId } = proxyActivities<typeof activities>({
   startToCloseTimeout: "120 minutes",
@@ -14,7 +14,9 @@ const { crawlWebsiteByConnectorId } = proxyActivities<typeof activities>({
 export async function crawlWebsiteWorkflow(
   connectorId: ModelId
 ): Promise<void> {
-  await crawlWebsiteByConnectorId(connectorId);
+  CancellationScope.cancellable(
+    crawlWebsiteByConnectorId.bind(null, connectorId)
+  );
 }
 
 export function crawlWebsiteWorkflowId(connectorId: ModelId) {


### PR DESCRIPTION
Fixes [#383](https://github.com/dust-tt/tasks/issues/383)

Still WIP, not yet tested, but reviewing is worth it

## Description
Activities shouldn't be more than ~ 10-15mns. It is most often the case with the mono-activity crawling connector workflow, but sometimes not, mostly because:
- some pages can get more than 1mn to download due to slow / overcrowded website
- especially if the crawler actually downloads media
- some sites may feel DDOSed so many requests may fail, etc.

In that case the activity goes on indefinetely without us being notified and despite temporal cancellation. This is made worse by temporal restarting an activity in addition to the one already running.

The following [incident](https://dust4ai.slack.com/archives/C05B529FHV1/p1706342128775499) illustrated this, and was temporarily fixed by #3462

This PR provides a more durable fix.

### Splitting into multiple activities is hard
The most resilient way to stabilize web crawler would be to have an activity per page. But this is not straightforward to do with crawlee. The crawler is stateful and can't be shared across activities, while having it reside at the workflow level seems brittle, and the important point is that page downloads are pushed to activities anyways.


### An alternate path (this PR)
The next best, while keeping in a single activity, is to ensure that temporal timeouts are respected: the activity is stopped and we are notified of an activity failure.

This PR achieves this by allowing the activity to throw using temporal's sleep, as suggested in [temporal doc on cancellation](https://typescript.temporal.io/api/namespaces/activity#cancellation), [example here](https://typescript.temporal.io/api/namespaces/activity#examples)

It also reverts the heartbeat timeout

### Three additional fixes to be discussed:
- limit the number of requests per minute to the website for a given crawl (avoid the DDOS impression) (uncontroversial, done in the PR)
- ensure media is not downloaded (TBD, howto? @aric may know?)
- only crawl subpages. Most websites have links to their home in many pages, therefore if we don't limit the crawl to subpages, most of the 512 allowed pages won't be subpages, which feels like contrary to user intent. Also, we'll often crawl & store much more than needed by the user. (fix very easy to do using the `globs` param)

## Risks
None foreseable that are not mitigated by a local test
