### PR TITLE
enh: dont share notion conn cache between workflows

### DIFF
--- a/connectors/migrations/20240129_drop_notion_connector_caches_indexes.ts
+++ b/connectors/migrations/20240129_drop_notion_connector_caches_indexes.ts
@@ -1,0 +1,20 @@
+import { sequelize_conn } from "@connectors/lib/models";
+
+async function main() {
+  await sequelize_conn.query(`
+        DROP INDEX IF EXISTS "uq_notion_block_id_conn_id_page_id";
+        DROP INDEX IF EXISTS "notion_connector_page_cache_entries_notion_page_id_connector_id";
+        DROP INDEX IF EXISTS "uq_notion_to_check_notion_id_conn_id";
+    `);
+}
+
+main()
+  .then(() => {
+    console.error("\x1b[32m%s\x1b[0m", `Done`);
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error("\x1b[31m%s\x1b[0m", `Error: ${err.message}`);
+    console.log(err);
+    process.exit(1);
+  });

--- a/connectors/src/admin/cli.ts
+++ b/connectors/src/admin/cli.ts
@@ -474,6 +474,9 @@ const notion = async (command: string, args: parseArgs.ParsedArgs) => {
             runTimestamp: new Date().getTime(),
             isBatchSync: false,
             pageIndex: -1,
+            // NOTE: this workflow cache is not automatically cleared.
+            // TODO: clear it.
+            topLevelWorkflowId: "notion-test-upsert-page",
           },
         ],
         taskQueue: QUEUE_NAME,

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -1034,7 +1034,10 @@ export async function cachePage({
     where: {
       notionPageId: pageId,
       connectorId: connector.id,
-      workflowId: topLevelWorkflowId,
+      workflowId: {
+        // TODO(@fontanierh): remove `null` case.
+        [Op.or]: [topLevelWorkflowId, null],
+      },
     },
   });
   if (pageInCache) {
@@ -1188,7 +1191,10 @@ export async function cacheBlockChildren({
         notionPageId: pageId,
         notionBlockId: parsedBlocks.map((b) => b.id),
         connectorId: connector.id,
-        workflowId: topLevelWorkflowId,
+        workflowId: {
+          // TODO(@fontanierh): remove `null` case.
+          [Op.or]: [topLevelWorkflowId, null],
+        },
       },
       attributes: ["notionBlockId"],
     });
@@ -1334,7 +1340,10 @@ export async function cacheDatabaseChildren({
     where: {
       notionPageId: resultPage.results.map((r) => r.id),
       connectorId: connector.id,
-      workflowId: topLevelWorkflowId,
+      workflowId: {
+        // TODO(@fontanierh): remove `null` case.
+        [Op.or]: [topLevelWorkflowId, null],
+      },
     },
     attributes: ["notionPageId"],
   });
@@ -1567,7 +1576,10 @@ export async function renderAndUpsertPageFromCache({
     where: {
       notionPageId: pageId,
       connectorId: connector.id,
-      workflowId: topLevelWorkflowId,
+      workflowId: {
+        // TODO(@fontanierh): remove `null` case.
+        [Op.or]: [topLevelWorkflowId, null],
+      },
     },
   });
   if (!pageCacheEntry) {
@@ -1581,7 +1593,10 @@ export async function renderAndUpsertPageFromCache({
     where: {
       notionPageId: pageId,
       connectorId: connector.id,
-      workflowId: topLevelWorkflowId,
+      workflowId: {
+        // TODO(@fontanierh): remove `null` case.
+        [Op.or]: [topLevelWorkflowId, null],
+      },
     },
   });
 
@@ -1613,7 +1628,10 @@ export async function renderAndUpsertPageFromCache({
     where: {
       parentId: Object.keys(blocksByParentId),
       connectorId: connector.id,
-      workflowId: topLevelWorkflowId,
+      workflowId: {
+        // TODO(@fontanierh): remove `null` case.
+        [Op.or]: [topLevelWorkflowId, null],
+      },
     },
   });
   const childDatabases: Record<string, NotionConnectorPageCacheEntry[]> = {};
@@ -1882,6 +1900,10 @@ export async function renderAndUpsertPageFromCache({
           notionId: childDatabaseIdsToCheck,
           resourceType: "database",
           connectorId: connector.id,
+          workflowId: {
+            // TODO(@fontanierh): remove `null` case.
+            [Op.or]: [topLevelWorkflowId, null],
+          },
         },
         attributes: ["notionId"],
       })
@@ -1894,6 +1916,10 @@ export async function renderAndUpsertPageFromCache({
           notionId: childPageIdsToCheck,
           resourceType: "page",
           connectorId: connector.id,
+          workflowId: {
+            // TODO(@fontanierh): remove `null` case.
+            [Op.or]: [topLevelWorkflowId, null],
+          },
         },
         attributes: ["notionId"],
       })
@@ -1953,26 +1979,39 @@ export async function clearConnectorCache({
   await NotionConnectorPageCacheEntry.destroy({
     where: {
       connectorId: connector.id,
-      workflowId: topLevelWorkflowId,
+      workflowId: {
+        // TODO(@fontanierh): remove `null` case.
+        [Op.or]: [topLevelWorkflowId, null],
+      },
     },
   });
   await NotionConnectorBlockCacheEntry.destroy({
     where: {
       connectorId: connector.id,
-      workflowId: topLevelWorkflowId,
+      workflowId: {
+        // TODO(@fontanierh): remove `null` case.
+        [Op.or]: [topLevelWorkflowId, null],
+      },
     },
   });
   await NotionConnectorResourcesToCheckCacheEntry.destroy({
     where: {
       connectorId: connector.id,
-      workflowId: topLevelWorkflowId,
+      workflowId: {
+        // TODO(@fontanierh): remove `null` case.
+        [Op.or]: [topLevelWorkflowId, null],
+      },
     },
   });
 }
 
-export async function getDiscoveredResourcesFromCache(
-  connectorId: ModelId
-): Promise<{ pageIds: string[]; databaseIds: string[] }> {
+export async function getDiscoveredResourcesFromCache({
+  connectorId,
+  topLevelWorkflowId,
+}: {
+  connectorId: ModelId;
+  topLevelWorkflowId: string;
+}): Promise<{ pageIds: string[]; databaseIds: string[] }> {
   const connector = await Connector.findOne({
     where: {
       type: "notion",
@@ -1996,6 +2035,10 @@ export async function getDiscoveredResourcesFromCache(
     await NotionConnectorResourcesToCheckCacheEntry.findAll({
       where: {
         connectorId: connector.id,
+        workflowId: {
+          // TODO: remove `null` case.
+          [Op.or]: [null, topLevelWorkflowId],
+        },
       },
     });
 

--- a/connectors/src/connectors/notion/temporal/config.ts
+++ b/connectors/src/connectors/notion/temporal/config.ts
@@ -1,2 +1,2 @@
-export const WORKFLOW_VERSION = 27;
+export const WORKFLOW_VERSION = 28;
 export const QUEUE_NAME = `notion-queue-v${WORKFLOW_VERSION}`;

--- a/connectors/src/connectors/notion/temporal/workflows.ts
+++ b/connectors/src/connectors/notion/temporal/workflows.ts
@@ -160,9 +160,10 @@ export async function notionSyncWorkflow({
     // these are resources (pages/DBs) that we didn't get from the search API but that are child pages/DBs
     // of other pages that we did get from the search API.
     // We upsert those as well.
-    const discoveredResources = await getDiscoveredResourcesFromCache(
-      connectorId
-    );
+    const discoveredResources = await getDiscoveredResourcesFromCache({
+      connectorId,
+      topLevelWorkflowId,
+    });
     await performUpserts({
       connectorId,
       pageIds: discoveredResources.pageIds,

--- a/connectors/src/lib/models/notion.ts
+++ b/connectors/src/lib/models/notion.ts
@@ -273,7 +273,7 @@ export class NotionConnectorPageCacheEntry extends Model<
   declare lastEditedTime: string;
   declare url: string;
 
-  declare workflowId: string;
+  declare workflowId: string | null;
 
   declare connectorId: ForeignKey<Connector["id"]>;
 }
@@ -375,7 +375,7 @@ export class NotionConnectorBlockCacheEntry extends Model<
   // special case for child DBs
   declare childDatabaseTitle?: string | null;
 
-  declare workflowId: string;
+  declare workflowId: string | null;
 
   declare connectorId: ForeignKey<Connector["id"]>;
 }
@@ -458,7 +458,7 @@ export class NotionConnectorResourcesToCheckCacheEntry extends Model<
   declare notionId: string;
   declare resourceType: "page" | "database";
 
-  declare workflowId: string;
+  declare workflowId: string | null;
 
   declare connectorId: ForeignKey<Connector["id"]>;
 }

--- a/connectors/src/lib/models/notion.ts
+++ b/connectors/src/lib/models/notion.ts
@@ -273,6 +273,8 @@ export class NotionConnectorPageCacheEntry extends Model<
   declare lastEditedTime: string;
   declare url: string;
 
+  declare workflowId: string;
+
   declare connectorId: ForeignKey<Connector["id"]>;
 }
 NotionConnectorPageCacheEntry.init(
@@ -333,14 +335,23 @@ NotionConnectorPageCacheEntry.init(
       type: DataTypes.STRING,
       allowNull: false,
     },
+    workflowId: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
   },
   {
     sequelize: sequelize_conn,
     modelName: "notion_connector_page_cache_entries",
     indexes: [
-      { fields: ["notionPageId", "connectorId"], unique: true },
+      {
+        fields: ["notionPageId", "connectorId", "workflowId"],
+        unique: true,
+        name: "uq_notion_page_id_conn_id_wf_id",
+      },
       { fields: ["connectorId"] },
       { fields: ["parentId"] },
+      { fields: ["workflowId"] },
     ],
   }
 );
@@ -363,6 +374,8 @@ export class NotionConnectorBlockCacheEntry extends Model<
 
   // special case for child DBs
   declare childDatabaseTitle?: string | null;
+
+  declare workflowId: string;
 
   declare connectorId: ForeignKey<Connector["id"]>;
 }
@@ -411,19 +424,24 @@ NotionConnectorBlockCacheEntry.init(
       type: DataTypes.STRING,
       allowNull: true,
     },
+    workflowId: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
   },
   {
     sequelize: sequelize_conn,
     modelName: "notion_connector_block_cache_entries",
     indexes: [
       {
-        fields: ["notionBlockId", "connectorId", "notionPageId"],
+        fields: ["notionBlockId", "connectorId", "notionPageId", "workflowId"],
         unique: true,
-        name: "uq_notion_block_id_conn_id_page_id",
+        name: "uq_notion_block_id_conn_id_page_id_wf_id",
       },
       { fields: ["connectorId"] },
       { fields: ["parentBlockId"] },
       { fields: ["notionPageId"] },
+      { fields: ["workflowId"] },
     ],
   }
 );
@@ -439,6 +457,9 @@ export class NotionConnectorResourcesToCheckCacheEntry extends Model<
 
   declare notionId: string;
   declare resourceType: "page" | "database";
+
+  declare workflowId: string;
+
   declare connectorId: ForeignKey<Connector["id"]>;
 }
 NotionConnectorResourcesToCheckCacheEntry.init(
@@ -466,17 +487,22 @@ NotionConnectorResourcesToCheckCacheEntry.init(
       type: DataTypes.STRING,
       allowNull: false,
     },
+    workflowId: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
   },
   {
     sequelize: sequelize_conn,
     modelName: "notion_connector_resources_to_check_cache_entries",
     indexes: [
       {
-        fields: ["notionId", "connectorId"],
+        fields: ["notionId", "connectorId", "workflowId"],
         unique: true,
-        name: "uq_notion_to_check_notion_id_conn_id",
+        name: "uq_notion_to_check_notion_id_conn_id_wf_id",
       },
       { fields: ["connectorId"] },
+      { fields: ["workflowId"] },
     ],
   }
 );


### PR DESCRIPTION
## Description

the Notion connector relies on caching results from API calls in the postgres database before re-constructing content from the cache before upserting. This cache is cleared at the start of each temporal workflow run.

So far, the Notion connector works with the assumption that only one single top-level workflow runs at any given time. 
We want to experiment with having 2 workflows running concurrently (one in "live sync" mode, and a second one in "garbage collect" mode). 
This requires a change in the caching system to allow each workflow to have its own cache (the 2 caches should not have much overlap).


## Risk

Blast radius is the whole notion connector.

## Deploy Plan

⚠️ Not super straightforward

1. run initdb: will add the new column, and create new unique indexes using that new column. Will NOT drop the existing indexes.
2. deploy the code
3. restart all notion workflows -- at this point, the new colunn and the new indexes start being used. Old indexes are no longer used in the ON CONFLICT clauses.
4. run the migration script to delete the old indexes
5. create another PR to make the `workflowId` column non-nullable