### PR TITLE
feat: add GH workflow to apply infra

### DIFF
--- a/.github/workflows/apply-infra.yml
+++ b/.github/workflows/apply-infra.yml
@@ -1,0 +1,52 @@
+name: Apply Infra
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: apply_infra
+  cancel-in-progress: false
+
+env:
+  GCLOUD_PROJECT_ID: ${{ secrets.GCLOUD_PROJECT_ID }}
+  DD_API_KEY: ${{ secrets.DD_API_KEY }}
+  DD_APP_KEY: ${{ secrets.DD_APP_KEY }}
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Get short sha
+        id: short_sha
+        run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      - name: "Authenticate with Google Cloud"
+        uses: "google-github-actions/auth@v1"
+        with:
+          credentials_json: "${{ secrets.GCLOUD_SA_KEY }}"
+
+      - name: "Set up Cloud SDK"
+        uses: "google-github-actions/setup-gcloud@v1"
+
+      - name: Install gke-gcloud-auth-plugin
+        run: |
+          gcloud components install gke-gcloud-auth-plugin
+
+      - name: Setup kubectl
+        run: |
+          gcloud container clusters get-credentials dust-kube --region us-central1
+
+      - name: Install yq
+        run: |
+          wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          chmod a+x /usr/local/bin/yq
+
+      - name: Run Apply Infra
+        run: |
+          cd k8s
+          ./apply_infra.sh

--- a/.github/workflows/apply-infra.yml
+++ b/.github/workflows/apply-infra.yml
@@ -15,7 +15,6 @@ env:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
 
     steps:
       - name: Checkout code

--- a/.github/workflows/apply-infra.yml
+++ b/.github/workflows/apply-infra.yml
@@ -15,6 +15,7 @@ env:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Description

When we change infra files, we currently run the appy infra files locally on our laptops. This requires everyone to have the tooling properly setup, but more importantly it creates a risk that the person running the script does so without pulling upstream changes first (which might then revert some recent infra changes)


## Risk

This hasn't been tested (can't test without merging into main). The blast radius is virtually infinite (every single service 🤯 ). In practice though, this is the same script we've been running forever, it will either work or not work, but it's unlikely to break anything.

## Deploy Plan

Merge and then run it and hope it works.