### PR TITLE
chore: remove mentions of Doc Tracker in callAction

### DIFF
--- a/front/lib/actions/helpers.ts
+++ b/front/lib/actions/helpers.ts
@@ -87,15 +87,13 @@ export async function callAction<V extends t.Mixed>({
     // the response is of the right shape, but it's not a success response
     return new Err({
       type: "action_failed",
-      message: `Doc Tracker action failed response: ${JSON.stringify(
-        r.value.status
-      )}`,
+      message: `Action failed response: ${JSON.stringify(r.value.status)}`,
     });
   }
 
   // the response is not of a known shape, so we can't assume anything about it
   return new Err({
     type: "unexpected_action_response",
-    message: "Unexpected Doc Tracker action response.",
+    message: "Unexpected action response.",
   });
 }


### PR DESCRIPTION
## Description

The error messages were outdated, and wrongly mentioned Doc Tracker even though `callAction` is a library function that isn't specific to doc tracker.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
