### PR TITLE
enh: increase resources of core-sqlite-workers

### DIFF
--- a/k8s/deployments/core-sqlite-worker-deployment.yaml
+++ b/k8s/deployments/core-sqlite-worker-deployment.yaml
@@ -46,8 +46,8 @@ spec:
 
           resources:
             requests:
-              cpu: 500m
-              memory: 250Mi
+              cpu: 1000m
+              memory: 1Gi
             limits:
-              cpu: 500m
-              memory: 250Mi
+              cpu: 1000m
+              memory: 1Gi


### PR DESCRIPTION
## Description

Large CSVs are crashing core-sqlite-worker pods.
This commit increases their RAM allocation (and their CPU so we stay within GCP requirements)

## Risk

None

## Deploy Plan

Run the apply infra github action