### PR TITLE
feat: add feature_flags tables

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -45,6 +45,7 @@ import {
   GlobalAgentSettings,
 } from "@app/lib/models/assistant/agent";
 import { ContentFragment } from "@app/lib/models/assistant/conversation";
+import { FeatureFlag } from "@app/lib/models/feature_flag";
 import { PlanInvitation } from "@app/lib/models/plan";
 
 async function main() {
@@ -95,6 +96,8 @@ async function main() {
   await Message.sync({ alter: true });
   await MessageReaction.sync({ alter: true });
   await Mention.sync({ alter: true });
+
+  await FeatureFlag.sync({ alter: true });
 
   process.exit(0);
 }

--- a/front/lib/models/feature_flag.ts
+++ b/front/lib/models/feature_flag.ts
@@ -1,3 +1,4 @@
+import type { WhitelistableFeature } from "@dust-tt/types";
 import type {
   CreationOptional,
   ForeignKey,
@@ -17,7 +18,7 @@ export class FeatureFlag extends Model<
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
-  declare name: string;
+  declare name: WhitelistableFeature;
 
   declare workspaceId: ForeignKey<Workspace["id"]>;
 }

--- a/front/lib/models/feature_flag.ts
+++ b/front/lib/models/feature_flag.ts
@@ -1,0 +1,63 @@
+import type {
+  CreationOptional,
+  ForeignKey,
+  InferAttributes,
+  InferCreationAttributes,
+} from "sequelize";
+import { DataTypes, Model } from "sequelize";
+
+import { front_sequelize } from "@app/lib/databases";
+import { Workspace } from "@app/lib/models/workspace";
+
+export class FeatureFlag extends Model<
+  InferAttributes<FeatureFlag>,
+  InferCreationAttributes<FeatureFlag>
+> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare name: string;
+
+  declare workspaceId: ForeignKey<Workspace["id"]>;
+}
+
+FeatureFlag.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    name: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+  },
+  {
+    sequelize: front_sequelize,
+    modelName: "feature_flags",
+    indexes: [
+      {
+        unique: true,
+        fields: ["workspaceId", "name"],
+      },
+    ],
+  }
+);
+
+Workspace.hasMany(FeatureFlag, {
+  foreignKey: { allowNull: false },
+  onDelete: "CASCADE",
+});
+FeatureFlag.belongsTo(Workspace);

--- a/types/src/front/feature_flags.ts
+++ b/types/src/front/feature_flags.ts
@@ -1,0 +1,1 @@
+export type WhitelistableFeature = "crawler" | "structured_data";

--- a/types/src/index.ts
+++ b/types/src/index.ts
@@ -16,6 +16,7 @@ export * from "./front/data_source";
 export * from "./front/dataset";
 export * from "./front/document";
 export * from "./front/extract";
+export * from "./front/feature_flags";
 export * from "./front/key";
 export * from "./front/lib/actions/registry";
 export * from "./front/lib/actions/types";


### PR DESCRIPTION
## Description

We are currently relying on hard-coded list of md5'd workspace IDs to whitelist access to features. This approach requires deploying everytime we want to whitelist a new workspace, which is time-consuming, slow and more expensive than it needs to be.

This also prevents us from building tooling in Poké to allow non-engineers to whitelist more workspaces.

This commit introduces a new `feature_flags` table that will be used instead.

## Risk

For now, the table is simply being added, there is no usage of it. Risk should be pretty low.

## Deploy Plan

- `initdb` must be ran for front. This can be done before or after deploying, as the new model isn't being used anywhere.