### PR TITLE
Move new paid data sources to dedicated-2

### DIFF
--- a/front/pages/api/w/[wId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/index.ts
@@ -1,6 +1,11 @@
 import type { DataSourceType } from "@dust-tt/types";
 import type { ReturnedAPIErrorType } from "@dust-tt/types";
-import { dustManagedCredentials, EMBEDDING_CONFIG } from "@dust-tt/types";
+import {
+  DEFAULT_FREE_QDRANT_CLUSTER,
+  DEFAULT_PAID_QDRANT_CLUSTER,
+  dustManagedCredentials,
+  EMBEDDING_CONFIG,
+} from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -137,11 +142,11 @@ async function handler(
           qdrant_config:
             auth.isUpgraded() && NODE_ENV === "production"
               ? {
-                  cluster: "dedicated-1",
+                  cluster: DEFAULT_PAID_QDRANT_CLUSTER,
                   shadow_write_cluster: null,
                 }
               : {
-                  cluster: "main-0",
+                  cluster: DEFAULT_FREE_QDRANT_CLUSTER,
                   shadow_write_cluster: null,
                 },
         },

--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -3,6 +3,8 @@ import type { ConnectorType } from "@dust-tt/types";
 import type { ReturnedAPIErrorType } from "@dust-tt/types";
 import {
   assertNever,
+  DEFAULT_FREE_QDRANT_CLUSTER,
+  DEFAULT_PAID_QDRANT_CLUSTER,
   EMBEDDING_CONFIG,
   isConnectorProvider,
 } from "@dust-tt/types";
@@ -271,11 +273,11 @@ async function handler(
           qdrant_config:
             NODE_ENV === "production"
               ? {
-                  cluster: "dedicated-1",
+                  cluster: DEFAULT_PAID_QDRANT_CLUSTER,
                   shadow_write_cluster: null,
                 }
               : {
-                  cluster: "main-0",
+                  cluster: DEFAULT_FREE_QDRANT_CLUSTER,
                   shadow_write_cluster: null,
                 },
         },

--- a/types/src/core/data_source.ts
+++ b/types/src/core/data_source.ts
@@ -1,4 +1,11 @@
-export type QdrantCluster = "main-0" | "dedicated-0" | "dedicated-1";
+export type QdrantCluster =
+  | "main-0"
+  | "dedicated-0"
+  | "dedicated-1"
+  | "dedicated-2";
+
+export const DEFAULT_FREE_QDRANT_CLUSTER: QdrantCluster = "main-0";
+export const DEFAULT_PAID_QDRANT_CLUSTER: QdrantCluster = "dedicated-2";
 
 export type CoreAPIDataSourceConfig = {
   provider_id: string;


### PR DESCRIPTION
## Description

dedicated-2 is live. Move all new paid collections to it.

## Risk

N/A dedicated-2 liveness and readiness has been tested.

## Deploy Plan

- deploy `front`