### PR TITLE
Rerevert 3434 + fix agent message ordering issue

### DIFF
--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -78,6 +78,13 @@ export async function renderConversationForModel({
     const m = versions[versions.length - 1];
 
     if (isAgentMessageType(m)) {
+      if (m.content) {
+        messages.unshift({
+          role: "agent" as const,
+          name: m.configuration.name,
+          content: m.content,
+        });
+      }
       if (m.action) {
         if (isRetrievalActionType(m.action)) {
           if (!retrievalFound) {
@@ -91,13 +98,6 @@ export async function renderConversationForModel({
         } else {
           assertNever(m.action);
         }
-      }
-      if (m.content) {
-        messages.unshift({
-          role: "agent" as const,
-          name: m.configuration.name,
-          content: m.content,
-        });
       }
     } else if (isUserMessageType(m)) {
       // Replace all `:mention[{name}]{.*}` with `@name`.


### PR DESCRIPTION
Re-revert of  #3434  (reverted by #3493 )

## Description
Nice one. Long story short
- PR 3434 's goal was to improve the way we render contentFragments to models for message generation. 
- it also fixed issue 1 that was discovered in the process:  when a message was too large to add to the context window, we skipped it but still added the older messages to the conversation (which we shouldn't because it results in conversations with holes)
- but we also had a prior issue 2 (that was discovered here) that we put an agent's action result *after* the agent message (while it should come before in the conversation history)
- the title generation, which had a fixed context window at 12k (issue 3), could not use retrievals  for large models (who get > 16k tokens retrievals);

In a conversation starting with large retrievals, e.g. `@dust what did I do last year`:
- title generation was first presented with the big "retrieval" (because of issue 2)
- because of issue 3, it did not fit its context window
- but because of issue 1, it looked past it and used prior messages to generate a title

But when merging #3434, issue 1 was fixed. So because of issue 3 and 2, no messages were fed to the title generator => OpenAI failure, incident :fearful: 

This PR reinstates #3434 (fixing issue 1) and adds a fix for issue 2. Issue 3 was fixed in the meantime by #3492 

Cheers !

## Risk
Given the above, we never know !
