### PR TITLE
Intercom: Allow Article null url and Help Center default name

### DIFF
--- a/connectors/src/connectors/intercom/lib/help_center_permissions.ts
+++ b/connectors/src/connectors/intercom/lib/help_center_permissions.ts
@@ -71,7 +71,7 @@ export async function allowSyncHelpCenter({
       helpCenter = await IntercomHelpCenter.create({
         connectorId: connector.id,
         helpCenterId: helpCenterOnIntercom.id,
-        name: helpCenterOnIntercom.display_name,
+        name: helpCenterOnIntercom.display_name || "Help Center",
         identifier: helpCenterOnIntercom.identifier,
         intercomWorkspaceId: helpCenterOnIntercom.workspace_id,
         permission: "read",
@@ -417,7 +417,7 @@ export async function retrieveIntercomHelpCentersPermissions({
         internalId: getHelpCenterInternalId(connectorId, helpCenter.id),
         parentInternalId: null,
         type: "database",
-        title: helpCenter.display_name,
+        title: helpCenter.display_name || "Help Center",
         sourceUrl: null,
         expandable: true,
         permission: "none",

--- a/connectors/src/connectors/intercom/lib/intercom_api.ts
+++ b/connectors/src/connectors/intercom/lib/intercom_api.ts
@@ -25,7 +25,7 @@ type IntercomHelpCenterType = {
   updated_at: number;
   identifier: string;
   website_turned_on: boolean;
-  display_name: string;
+  display_name: string | null;
 };
 
 export type IntercomCollectionType = CollectionObject & {

--- a/connectors/src/connectors/intercom/temporal/activities.ts
+++ b/connectors/src/connectors/intercom/temporal/activities.ts
@@ -124,7 +124,7 @@ export async function syncHelpCenterOnlyActivity({
       shouldRemoveHelpCenter = true;
     } else {
       await helpCenterOnDb.update({
-        name: helpCenterOnIntercom.display_name,
+        name: helpCenterOnIntercom.display_name || "Help Center",
         lastUpsertedTs: new Date(currentSyncMs),
       });
     }

--- a/connectors/src/connectors/intercom/temporal/sync_help_center.ts
+++ b/connectors/src/connectors/intercom/temporal/sync_help_center.ts
@@ -214,6 +214,8 @@ export async function _upsertCollection({
     await collectionOnDb.update({
       name: collection.name,
       description: collection.description,
+      parentId: collection.parent_id,
+      url: collection.url,
       lastUpsertedTs: new Date(currentSyncMs),
     });
   } else {
@@ -248,6 +250,12 @@ export async function _upsertCollection({
       article = await matchingArticleOnDb.update({
         title: articleOnIntercom.title,
         url: articleOnIntercom.url,
+        authorId: articleOnIntercom.author_id,
+        parentId: articleOnIntercom.parent_id,
+        parentType:
+          articleOnIntercom.parent_type === "collection" ? "collection" : null,
+        parents: articleOnIntercom.parent_ids,
+        state: articleOnIntercom.state === "published" ? "published" : "draft",
         lastUpsertedTs: new Date(currentSyncMs),
       });
     } else {

--- a/connectors/src/lib/models/intercom.ts
+++ b/connectors/src/lib/models/intercom.ts
@@ -236,7 +236,7 @@ IntercomArticle.init(
     },
     url: {
       type: DataTypes.STRING,
-      allowNull: false,
+      allowNull: true,
     },
     authorId: {
       type: DataTypes.STRING,


### PR DESCRIPTION
This PR aims at fixing two errors I got this afternoon on the Intercom sync of our test Help Center: 

### Context

We got these `SequelizeValidationError ` errors: 
- `ValidationError: notNull Violation: intercom_help_centers.name cannot be null` on prod. 
- `ValidationError: notNull Violation: intercom_articles.url cannot be null`

So in this PR I am: 
- Adding a default name to Help Center because despite the [Intercom API doc](https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Help-Center/help_center) it sometimes is null.
- Allowing null url for Articles, which was specified in the [Intercom API doc](https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Articles/article/). I'll check to confirm but I think url is null when the Help Center was not published. 


## Deploy Plan

This requires running a migration on connector.