### PR TITLE
feat: use feature flags instead of hard-coded arrays

### DIFF
--- a/front/components/app/NewBlock.tsx
+++ b/front/components/app/NewBlock.tsx
@@ -22,7 +22,7 @@ export default function NewBlock({
   direction: "up" | "down";
   small: boolean;
 }) {
-  const { features } = useFeatures({ workspaceId: owner.sId });
+  const { features } = useFeatures(owner);
 
   const containsInput =
     spec.filter((block) => block.type == "input").length > 0;

--- a/front/components/app/NewBlock.tsx
+++ b/front/components/app/NewBlock.tsx
@@ -4,7 +4,7 @@ import type { BlockType } from "@dust-tt/types";
 import { Menu } from "@headlessui/react";
 import { PlusIcon } from "@heroicons/react/20/solid";
 
-import { isActivatedStructuredDB } from "@app/lib/development";
+import { useFeatures } from "@app/lib/swr";
 import { classNames } from "@app/lib/utils";
 
 export default function NewBlock({
@@ -22,6 +22,8 @@ export default function NewBlock({
   direction: "up" | "down";
   small: boolean;
 }) {
+  const { features } = useFeatures({ workspaceId: owner.sId });
+
   const containsInput =
     spec.filter((block) => block.type == "input").length > 0;
   const blocks: {
@@ -100,7 +102,7 @@ export default function NewBlock({
     },
   ];
 
-  if (isActivatedStructuredDB(owner)) {
+  if (features?.includes("structured_data")) {
     blocks.push(
       {
         type: "database_schema",

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -207,7 +207,7 @@ export default function AssistantBuilder({
   );
   const defaultScope =
     flow === "workspace_assistants" ? "workspace" : "private";
-  const { features } = useFeatures({ workspaceId: owner.sId });
+  const { features } = useFeatures(owner);
   const structuredDataEnabled = features?.includes("structured_data");
 
   const [builderState, setBuilderState] = useState<AssistantBuilderState>(

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -80,9 +80,8 @@ import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { getSupportedModelConfig } from "@app/lib/assistant";
 import { tableKey } from "@app/lib/client/tables_query";
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
-import { isActivatedStructuredDB } from "@app/lib/development";
 import { isUpgraded } from "@app/lib/plans/plan_codes";
-import { useSlackChannelsLinkedWithAgent } from "@app/lib/swr";
+import { useFeatures, useSlackChannelsLinkedWithAgent } from "@app/lib/swr";
 import { classNames } from "@app/lib/utils";
 
 const usedModelConfigs = [
@@ -208,6 +207,8 @@ export default function AssistantBuilder({
   );
   const defaultScope =
     flow === "workspace_assistants" ? "workspace" : "private";
+  const { features } = useFeatures({ workspaceId: owner.sId });
+  const structuredDataEnabled = features?.includes("structured_data");
 
   const [builderState, setBuilderState] = useState<AssistantBuilderState>(
     initialBuilderState
@@ -969,9 +970,7 @@ export default function AssistantBuilder({
                   ))}
                   <DropdownMenu.SectionHeader label="Advanced actions" />
                   {ADVANCED_ACTION_MODES.filter((key) => {
-                    return (
-                      key !== "TABLES_QUERY" || isActivatedStructuredDB(owner)
-                    );
+                    return key !== "TABLES_QUERY" || structuredDataEnabled;
                   }).map((key) => (
                     <DropdownMenu.Item
                       key={key}

--- a/front/components/sparkle/navigation.tsx
+++ b/front/components/sparkle/navigation.tsx
@@ -134,7 +134,7 @@ export const subNavigationBuild = ({
 
   const assistantMenus: SparkleAppLayoutNavigation[] = [];
 
-  const { features } = useFeatures({ workspaceId: owner.sId });
+  const { features } = useFeatures(owner);
   const crawlerEnabled = features?.includes("crawler");
 
   assistantMenus.push({

--- a/front/components/sparkle/navigation.tsx
+++ b/front/components/sparkle/navigation.tsx
@@ -18,10 +18,8 @@ import type { WorkspaceType } from "@dust-tt/types";
 import { isAdmin, isBuilder, isUser } from "@dust-tt/types";
 import { UsersIcon } from "@heroicons/react/20/solid";
 
-import {
-  isActivatedPublicURLs,
-  isDevelopmentOrDustWorkspace,
-} from "@app/lib/development";
+import { isDevelopmentOrDustWorkspace } from "@app/lib/development";
+import { useFeatures } from "@app/lib/swr";
 
 /**
  * NavigationIds are typed ids we use to identify which navigation item is currently active. We need
@@ -136,6 +134,9 @@ export const subNavigationBuild = ({
 
   const assistantMenus: SparkleAppLayoutNavigation[] = [];
 
+  const { features } = useFeatures({ workspaceId: owner.sId });
+  const crawlerEnabled = features?.includes("crawler");
+
   assistantMenus.push({
     id: "workspace_assistants",
     label: "Manage Assistants",
@@ -175,7 +176,7 @@ export const subNavigationBuild = ({
       subMenu: current === "data_sources_static" ? subMenu : undefined,
     },
   ];
-  if (isActivatedPublicURLs(owner)) {
+  if (crawlerEnabled) {
     dataSourceItems.push({
       id: "data_sources_url",
       label: "Websites",

--- a/front/lib/api/feature_flags.ts
+++ b/front/lib/api/feature_flags.ts
@@ -1,0 +1,27 @@
+import type { WhitelistableFeature, WorkspaceType } from "@dust-tt/types";
+
+import { FeatureFlag } from "@app/lib/models/feature_flag";
+
+export async function isFeatureEnabled(
+  owner: WorkspaceType,
+  feature: WhitelistableFeature
+): Promise<boolean> {
+  return !!(await FeatureFlag.count({
+    where: {
+      workspaceId: owner.id,
+      name: feature,
+    },
+  }));
+}
+
+export async function getFeatureFlags(
+  owner: WorkspaceType
+): Promise<WhitelistableFeature[]> {
+  const flags = await FeatureFlag.findAll({
+    where: {
+      workspaceId: owner.id,
+    },
+  });
+
+  return flags.map((flag) => flag.name);
+}

--- a/front/lib/development.ts
+++ b/front/lib/development.ts
@@ -1,5 +1,4 @@
 import type { WorkspaceType } from "@dust-tt/types";
-import { md5 } from "@dust-tt/types";
 
 const PRODUCTION_DUST_WORKSPACE_ID = "0ec9852c2f";
 const PRODUCTION_DUST_APPS_WORKSPACE_ID = "78bda07b39";
@@ -13,45 +12,5 @@ export function isDevelopmentOrDustWorkspace(owner: WorkspaceType) {
     isDevelopment() ||
     owner.sId === PRODUCTION_DUST_WORKSPACE_ID ||
     owner.sId === PRODUCTION_DUST_APPS_WORKSPACE_ID
-  );
-}
-
-export function isActivatedStructuredDB(owner: WorkspaceType) {
-  const hashedWorkspaceId = md5(owner.sId);
-
-  // We will manually add workspace ids here.
-  return (
-    isDevelopmentOrDustWorkspace(owner) ||
-    [
-      "2ef36b1a3192e9500bfe99e1541c38e1",
-      "995e775623ee35cc23f7295862b52f61",
-      "a29e7fb74f329d26a16785989f6efb80",
-      "02da873b8c9404f9005d724ea02b84b1",
-      "f441aae51356fbd85718c5b259884af5",
-      "9904970eeaa283f18656c6e60b66cb19",
-      "8b346e11096cb6d60435c843d24b3583",
-    ].includes(hashedWorkspaceId)
-  );
-}
-
-export function isActivatedPublicURLs(owner: WorkspaceType) {
-  // We will manually add workspace ids here.
-  const hashedWorkspaceId = md5(owner.sId);
-
-  return (
-    isDevelopmentOrDustWorkspace(owner) ||
-    [
-      // Customers workspace.
-      // You can find them in the Database with the following query:
-      // select * from workspaces where md5("sId") = 'XXX';
-      "9904970eeaa283f18656c6e60b66cb19",
-      "2ef36b1a3192e9500bfe99e1541c38e1",
-      "1d37889d4d9eb29bd24409ad7d183d44",
-      "02da873b8c9404f9005d724ea02b84b1",
-      "a29e7fb74f329d26a16785989f6efb80",
-      "2b121e50d0a35014c6057d1241c4448c",
-      "f441aae51356fbd85718c5b259884af5",
-      "8dfd4e7ab0db100b5041f2f56b5106ef", // pauline
-    ].includes(hashedWorkspaceId)
   );
 }

--- a/front/lib/models/feature_flag.ts
+++ b/front/lib/models/feature_flag.ts
@@ -53,6 +53,9 @@ FeatureFlag.init(
         unique: true,
         fields: ["workspaceId", "name"],
       },
+      {
+        fields: ["workspaceId"],
+      },
     ],
   }
 );

--- a/front/lib/swr.ts
+++ b/front/lib/swr.ts
@@ -408,11 +408,11 @@ export function usePokeFeatures({ workspaceId }: { workspaceId: string }) {
   };
 }
 
-export function useFeatures({ workspaceId }: { workspaceId: string }) {
+export function useFeatures(owner: WorkspaceType) {
   const featuresFetcher: Fetcher<GetFeaturesResponseBody> = fetcher;
 
   const { data, error } = useSWR(
-    `/api/w/${workspaceId}/features`,
+    `/api/w/${owner.sId}/features`,
     featuresFetcher
   );
 

--- a/front/lib/swr.ts
+++ b/front/lib/swr.ts
@@ -14,7 +14,7 @@ import useSWR from "swr";
 
 import type { GetPokePlansResponseBody } from "@app/pages/api/poke/plans";
 import type { GetWorkspacesResponseBody } from "@app/pages/api/poke/workspaces";
-import type { GetFeatureFlagsResponseBody } from "@app/pages/api/poke/workspaces/[wId]/features";
+import type { GetPokeFeaturesResponseBody } from "@app/pages/api/poke/workspaces/[wId]/features";
 import type { GetUserResponseBody } from "@app/pages/api/user";
 import type { GetUserMetadataResponseBody } from "@app/pages/api/user/metadata/[key]";
 import type { ListTablesResponseBody } from "@app/pages/api/v1/w/[wId]/data_sources/[name]/tables";
@@ -30,6 +30,7 @@ import type { GetDocumentsResponseBody } from "@app/pages/api/w/[wId]/data_sourc
 import type { GetOrPostBotEnabledResponseBody } from "@app/pages/api/w/[wId]/data_sources/[name]/managed/bot_enabled";
 import type { GetDataSourcePermissionsResponseBody } from "@app/pages/api/w/[wId]/data_sources/[name]/managed/permissions";
 import type { GetSlackChannelsLinkedWithAgentResponseBody } from "@app/pages/api/w/[wId]/data_sources/[name]/managed/slack/channels_linked_with_agent";
+import type { GetFeaturesResponseBody } from "@app/pages/api/w/[wId]/features";
 import type { GetWorkspaceInvitationsResponseBody } from "@app/pages/api/w/[wId]/invitations";
 import type { GetKeysResponseBody } from "@app/pages/api/w/[wId]/keys";
 import type { GetMembersResponseBody } from "@app/pages/api/w/[wId]/members";
@@ -393,10 +394,25 @@ export function usePokePlans() {
 }
 
 export function usePokeFeatures({ workspaceId }: { workspaceId: string }) {
-  const featuresFetcher: Fetcher<GetFeatureFlagsResponseBody> = fetcher;
+  const featuresFetcher: Fetcher<GetPokeFeaturesResponseBody> = fetcher;
 
   const { data, error } = useSWR(
     `/api/poke/workspaces/${workspaceId}/features`,
+    featuresFetcher
+  );
+
+  return {
+    features: data ? data.features : [],
+    isFeaturesLoading: !error && !data,
+    isFeaturesError: error,
+  };
+}
+
+export function useFeatures({ workspaceId }: { workspaceId: string }) {
+  const featuresFetcher: Fetcher<GetFeaturesResponseBody> = fetcher;
+
+  const { data, error } = useSWR(
+    `/api/w/${workspaceId}/features`,
     featuresFetcher
   );
 

--- a/front/pages/api/poke/workspaces/[wId]/features.ts
+++ b/front/pages/api/poke/workspaces/[wId]/features.ts
@@ -9,7 +9,7 @@ import { Authenticator, getSession } from "@app/lib/auth";
 import { FeatureFlag } from "@app/lib/models/feature_flag";
 import { apiError, withLogging } from "@app/logger/withlogging";
 
-export type GetFeatureFlagsResponseBody = {
+export type GetPokeFeaturesResponseBody = {
   features: WhitelistableFeature[];
 };
 
@@ -21,7 +21,7 @@ async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
     | CreateOrDeleteFeatureFlagResponseBody
-    | GetFeatureFlagsResponseBody
+    | GetPokeFeaturesResponseBody
     | ReturnedAPIErrorType
   >
 ): Promise<void> {

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/index.ts
@@ -3,8 +3,8 @@ import { CoreAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSource } from "@app/lib/api/data_sources";
+import { isFeatureEnabled } from "@app/lib/api/feature_flags";
 import { Authenticator, getAPIKey } from "@app/lib/auth";
-import { isActivatedStructuredDB } from "@app/lib/development";
 import logger from "@app/logger/logger";
 import { apiError, withLogging } from "@app/logger/withlogging";
 
@@ -38,7 +38,7 @@ async function handler(
     });
   }
 
-  if (!isActivatedStructuredDB(owner)) {
+  if (!(await isFeatureEnabled(owner, "structured_data"))) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/rows/[rId].ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/rows/[rId].ts
@@ -3,8 +3,8 @@ import { CoreAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSource } from "@app/lib/api/data_sources";
+import { isFeatureEnabled } from "@app/lib/api/feature_flags";
 import { Authenticator, getAPIKey } from "@app/lib/auth";
-import { isActivatedStructuredDB } from "@app/lib/development";
 import logger from "@app/logger/logger";
 import { apiError, withLogging } from "@app/logger/withlogging";
 
@@ -38,7 +38,7 @@ async function handler(
     });
   }
 
-  if (!isActivatedStructuredDB(owner)) {
+  if (!(await isFeatureEnabled(owner, "structured_data"))) {
     res.status(404).end();
     return;
   }

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/rows/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/rows/index.ts
@@ -6,8 +6,8 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSource } from "@app/lib/api/data_sources";
+import { isFeatureEnabled } from "@app/lib/api/feature_flags";
 import { Authenticator, getAPIKey } from "@app/lib/auth";
-import { isActivatedStructuredDB } from "@app/lib/development";
 import logger from "@app/logger/logger";
 import { apiError, withLogging } from "@app/logger/withlogging";
 
@@ -68,7 +68,7 @@ async function handler(
     });
   }
 
-  if (!isActivatedStructuredDB(owner)) {
+  if (!(await isFeatureEnabled(owner, "structured_data"))) {
     res.status(404).end();
     return;
   }

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/index.ts
@@ -6,8 +6,8 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSource } from "@app/lib/api/data_sources";
+import { isFeatureEnabled } from "@app/lib/api/feature_flags";
 import { Authenticator, getAPIKey } from "@app/lib/auth";
-import { isActivatedStructuredDB } from "@app/lib/development";
 import { generateModelSId } from "@app/lib/utils";
 import logger from "@app/logger/logger";
 import { apiError, withLogging } from "@app/logger/withlogging";
@@ -54,7 +54,7 @@ async function handler(
     });
   }
 
-  if (!isActivatedStructuredDB(owner)) {
+  if (!(await isFeatureEnabled(owner, "structured_data"))) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {

--- a/front/pages/api/w/[wId]/data_sources/[name]/tables/[tId]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/tables/[tId]/index.ts
@@ -3,8 +3,8 @@ import { CoreAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSource } from "@app/lib/api/data_sources";
+import { isFeatureEnabled } from "@app/lib/api/feature_flags";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { isActivatedStructuredDB } from "@app/lib/development";
 import logger from "@app/logger/logger";
 import { apiError, withLogging } from "@app/logger/withlogging";
 
@@ -44,7 +44,7 @@ async function handler(
     });
   }
 
-  if (!isActivatedStructuredDB(owner)) {
+  if (!(await isFeatureEnabled(owner, "structured_data"))) {
     res.status(404).end();
     return;
   }

--- a/front/pages/api/w/[wId]/data_sources/[name]/tables/csv.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/tables/csv.ts
@@ -10,8 +10,8 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSource } from "@app/lib/api/data_sources";
+import { isFeatureEnabled } from "@app/lib/api/feature_flags";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { isActivatedStructuredDB } from "@app/lib/development";
 import { generateModelSId } from "@app/lib/utils";
 import logger from "@app/logger/logger";
 import { apiError, withLogging } from "@app/logger/withlogging";
@@ -69,7 +69,7 @@ async function handler(
     });
   }
 
-  if (!isActivatedStructuredDB(owner)) {
+  if (!(await isFeatureEnabled(owner, "structured_data"))) {
     res.status(404).end();
     return;
   }

--- a/front/pages/api/w/[wId]/data_sources/[name]/tables/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/tables/index.ts
@@ -3,8 +3,8 @@ import { CoreAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSource } from "@app/lib/api/data_sources";
+import { isFeatureEnabled } from "@app/lib/api/feature_flags";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { isActivatedStructuredDB } from "@app/lib/development";
 import logger from "@app/logger/logger";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import type { ListTablesResponseBody } from "@app/pages/api/v1/w/[wId]/data_sources/[name]/tables";
@@ -41,7 +41,7 @@ async function handler(
     });
   }
 
-  if (!isActivatedStructuredDB(owner)) {
+  if (!(await isFeatureEnabled(owner, "structured_data"))) {
     res.status(404).end();
     return;
   }

--- a/front/pages/api/w/[wId]/features.ts
+++ b/front/pages/api/w/[wId]/features.ts
@@ -1,0 +1,65 @@
+import type {
+  ReturnedAPIErrorType,
+  WhitelistableFeature,
+} from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { getFeatureFlags } from "@app/lib/api/feature_flags";
+import { Authenticator, getSession } from "@app/lib/auth";
+import { apiError, withLogging } from "@app/logger/withlogging";
+
+export type GetFeaturesResponseBody = {
+  features: WhitelistableFeature[];
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<GetFeaturesResponseBody | ReturnedAPIErrorType>
+): Promise<void> {
+  const session = await getSession(req, res);
+  const auth = await Authenticator.fromSession(
+    session,
+    req.query.wId as string
+  );
+
+  const owner = auth.workspace();
+  const user = auth.user();
+  if (!owner || !user) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "Could not find the workspace.",
+      },
+    });
+  }
+
+  if (!auth.isUser()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "Only users of the current workspace are authorized to access this endpoint.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET":
+      const features = await getFeatureFlags(owner);
+      res.status(200).json({ features });
+      return;
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withLogging(handler);


### PR DESCRIPTION
## Description

Next step for https://github.com/dust-tt/dust/pull/3488.

Now that we have a feature_flags table, that we can configure them via poke and that the existing hard-coded whitelists are backfilled into the new system, we can now start relying on them and we can delete the hard-coded ones.

## Risk

Potentially wide blast radius (some of the code replaced where we create the app left pane menu items )

## Deploy Plan

Simple deploy. There's also an initdb to run (new index) but order doesn't matter.
