### PR TITLE
Display Intercom logo when retrieval is from Intercom

### DIFF
--- a/front/components/assistant/conversation/RetrievalAction.tsx
+++ b/front/components/assistant/conversation/RetrievalAction.tsx
@@ -220,7 +220,7 @@ function documentsSummary(documents: RetrievalDocumentType[]): {
 }
 
 type ConnectorProviderDocumentType =
-  | Exclude<ConnectorProvider, "intercom" | "webcrawler">
+  | Exclude<ConnectorProvider, "webcrawler">
   | "none";
 
 export function providerFromDocument(
@@ -232,6 +232,7 @@ export function providerFromDocument(
     "managed-google_drive": "google_drive",
     "managed-github": "github",
     "managed-confluence": "confluence",
+    "managed-intercom": "intercom",
   };
 
   for (const [key, value] of Object.entries(providerMap)) {

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@dust-tt/sparkle": "^0.2.78",
+        "@dust-tt/sparkle": "^0.2.80",
         "@dust-tt/types": "file:../types",
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",
@@ -899,9 +899,9 @@
       "integrity": "sha512-smLocSfrt3s53H/XSVP3/1kP42oqvrkjUPtyaFd1F79ux24oE31BKt+q0c6lsa6hOYrFzsIwyc5GXAI5JmfOew=="
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.78",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.78.tgz",
-      "integrity": "sha512-2RZCvAxkf4xQfESU6cPzpeShuz1k0hxsyHItLhWMOpsUZ8JVEsEvwoiq1lj2G36TgMj6ctEu1+h5fJNS5lHzgQ==",
+      "version": "0.2.80",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.80.tgz",
+      "integrity": "sha512-FiKqAztvRQKKmmR2qX1TohUVJUq6JJXwmYHTGIKbOhUVHqjSmKDZZ+tvFU4rxirzMheekma2MVS8b0LmMoC2Gw==",
       "dependencies": {
         "@headlessui/react": "^1.7.17"
       },

--- a/front/package.json
+++ b/front/package.json
@@ -13,7 +13,7 @@
     "initdb": "npx tsx admin/db.ts"
   },
   "dependencies": {
-    "@dust-tt/sparkle": "^0.2.78",
+    "@dust-tt/sparkle": "^0.2.80",
     "@dust-tt/types": "file:../types",
     "@emoji-mart/data": "^1.1.2",
     "@emoji-mart/react": "^1.1.1",


### PR DESCRIPTION
## Description


Display the intercom logo when a retrieval is from Intercom:
- on the Retrieval pill. 
- on the Citation.
 
<img width="268" alt="Screenshot 2024-01-30 at 11 41 54" src="https://github.com/dust-tt/dust/assets/3803406/348ce2cd-d3b7-40bd-8ab6-2f57edaff637">


I also had to update Sparkle for the citation component: https://github.com/dust-tt/dust/pull/3504

## Risk

Low.

## Deploy Plan

Nothing special.
