### PR TITLE
Sparkle: Allow Intercom citations

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.79",
+  "version": "0.2.80",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.79",
+      "version": "0.2.80",
       "license": "ISC",
       "dependencies": {
         "@headlessui/react": "^1.7.17"

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.79",
+  "version": "0.2.80",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/components/Citation.tsx
+++ b/sparkle/src/components/Citation.tsx
@@ -6,6 +6,7 @@ import {
   Confluence,
   Drive,
   Github,
+  Intercom,
   Notion,
   Slack,
 } from "@sparkle/logo/platforms";
@@ -26,6 +27,7 @@ interface CitationProps {
     | "google_drive"
     | "github"
     | "notion"
+    | "intercom"
     | "document";
   title: string;
   description?: string;
@@ -41,6 +43,7 @@ const typeIcons = {
   document: DocumentText,
   github: Github,
   google_drive: Drive,
+  intercom: Intercom,
   notion: Notion,
   slack: Slack,
 };

--- a/sparkle/src/stories/Citation.stories.tsx
+++ b/sparkle/src/stories/Citation.stories.tsx
@@ -51,6 +51,8 @@ export const CitationsExample = () => (
         href="https://www.google.com"
         description="Write a 120 character description of the citation here to be displayed in the citation list."
       />
+    </div>
+    <div className="s-flex s-gap-2">
       <Citation
         title="Title"
         type="google_drive"
@@ -58,6 +60,14 @@ export const CitationsExample = () => (
         href="https://www.google.com"
         description="Write a 120 character description of the citation here to be displayed in the citation list."
         isBlinking={true}
+      />
+      <Citation
+        title="Awesome article"
+        type="intercom"
+        index="3"
+        href="https://www.google.com"
+        description="Write a 120 character description of the citation here to be displayed in the citation list."
+        isBlinking={false}
       />
     </div>
   </div>


### PR DESCRIPTION
## Description

Bumping Sparkle to allow citation for provider Intercom.

<img width="605" alt="Screenshot 2024-01-30 at 11 25 39" src="https://github.com/dust-tt/dust/assets/3803406/6181e231-15df-4386-a469-5b1b72cbc3a7">


## Risk

Low.

## Deploy Plan

Nothing special.
