### PR TITLE
Move logger for archived slack channels in activities

### DIFF
--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -980,10 +980,10 @@ export async function joinChannelAct(connectorId: ModelId, channelId: string) {
     throw res.error;
   }
 
-  const { result } = res.value;
+  const { channel, result } = res.value;
   if (result === "is_archived") {
     logger.info(`Channel ${channelId} is archived, skipping sync`, {
-      channel: channelId,
+      channel,
     });
     return;
   }

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -975,9 +975,16 @@ export async function deleteChannelsFromConnectorDb(
 
 export async function joinChannelAct(connectorId: ModelId, channelId: string) {
   const res = await joinChannel(connectorId, channelId);
+
   if (res.isErr()) {
     throw res.error;
   }
 
-  return res.value;
+  const { result } = res.value;
+  if (result === "is_archived") {
+    logger.info(`Channel ${channelId} is archived, skipping sync`, {
+      channel: channelId,
+    });
+    return;
+  }
 }

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -985,6 +985,8 @@ export async function joinChannelAct(connectorId: ModelId, channelId: string) {
     logger.info(`Channel ${channelId} is archived, skipping sync`, {
       channel,
     });
-    return;
+    return false;
   }
+
+  return true;
 }

--- a/connectors/src/connectors/slack/temporal/workflows.ts
+++ b/connectors/src/connectors/slack/temporal/workflows.ts
@@ -9,7 +9,6 @@ import {
 import PQueue from "p-queue";
 
 import type * as activities from "@connectors/connectors/slack/temporal/activities";
-import mainLogger from "@connectors/logger/logger";
 
 import { getWeekEnd, getWeekStart } from "../lib/utils";
 import { newWebhookSignal, syncChannelSignal } from "./signals";
@@ -29,8 +28,6 @@ const {
 } = proxyActivities<typeof activities>({
   startToCloseTimeout: "10 minutes",
 });
-
-const logger = mainLogger.child({ provider: "slack" });
 
 /**
  * - Concurrency model:
@@ -93,13 +90,8 @@ export async function syncOneChannel(
   updateSyncStatus: boolean,
   fromTs: number | null
 ) {
-  const res = await joinChannelAct(connectorId, channelId);
-  if (res.result === "is_archived") {
-    logger.info(`Channel ${channelId} is archived, skipping sync`, {
-      channel: res.channel,
-    });
-    return;
-  }
+  await joinChannelAct(connectorId, channelId);
+
   let messagesCursor: string | undefined = undefined;
   let weeksSynced: Record<number, boolean> = {};
 

--- a/connectors/src/connectors/slack/temporal/workflows.ts
+++ b/connectors/src/connectors/slack/temporal/workflows.ts
@@ -90,7 +90,10 @@ export async function syncOneChannel(
   updateSyncStatus: boolean,
   fromTs: number | null
 ) {
-  await joinChannelAct(connectorId, channelId);
+  const channelJoinSuccess = await joinChannelAct(connectorId, channelId);
+  if (!channelJoinSuccess) {
+    return;
+  }
 
   let messagesCursor: string | undefined = undefined;
   let weeksSynced: Record<number, boolean> = {};


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This [PR](https://github.com/dust-tt/dust/pull/3464) introduces a new logger dependency in the Slack workflow that led to failing the webpack step hence failing to start Slack workers in production.

This PR moves the log in the dedicated activity.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
