### PR TITLE
Feature flag: Allow all in dev by default

### DIFF
--- a/front/lib/api/feature_flags.ts
+++ b/front/lib/api/feature_flags.ts
@@ -1,11 +1,18 @@
 import type { WhitelistableFeature, WorkspaceType } from "@dust-tt/types";
+import { WHITELISTABLE_FEATURES } from "@dust-tt/types";
 
+import { isDevelopment } from "@app/lib/development";
 import { FeatureFlag } from "@app/lib/models/feature_flag";
+
+const { ACTIVATE_ALL_FEATURES_DEV = true } = process.env;
 
 export async function isFeatureEnabled(
   owner: WorkspaceType,
   feature: WhitelistableFeature
 ): Promise<boolean> {
+  if (ACTIVATE_ALL_FEATURES_DEV && isDevelopment()) {
+    return true;
+  }
   return !!(await FeatureFlag.count({
     where: {
       workspaceId: owner.id,
@@ -17,11 +24,13 @@ export async function isFeatureEnabled(
 export async function getFeatureFlags(
   owner: WorkspaceType
 ): Promise<WhitelistableFeature[]> {
+  if (ACTIVATE_ALL_FEATURES_DEV && isDevelopment()) {
+    return [...WHITELISTABLE_FEATURES];
+  }
   const flags = await FeatureFlag.findAll({
     where: {
       workspaceId: owner.id,
     },
   });
-
   return flags.map((flag) => flag.name);
 }


### PR DESCRIPTION
## Description

By default, activate all feature flags. This should be more convenient as we regularly wipe our local db.
If someone does not want this, they can set  `ACTIVATE_ALL_FEATURES_DEV` to false in their env var. 

## Risk

Low, rollback if issue. 

## Deploy Plan

Nothing special.
