### PR TITLE
Update Temporal webpack config to use tsconfig.json aliases

### DIFF
--- a/connectors/package-lock.json
+++ b/connectors/package-lock.json
@@ -50,6 +50,7 @@
         "sequelize": "^6.31.0",
         "talisman": "^1.1.4",
         "tar": "^6.2.0",
+        "tsconfig-paths-webpack-plugin": "^4.1.0",
         "turndown": "^7.1.2",
         "uuid": "^9.0.0"
       },
@@ -10117,7 +10118,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -10380,6 +10380,32 @@
         "json5": "^1.0.2",
         "minimist": "^1.2.6",
         "strip-bom": "^3.0.0"
+      }
+    },
+    "node_modules/tsconfig-paths-webpack-plugin": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-4.1.0.tgz",
+      "integrity": "sha512-xWFISjviPydmtmgeUAuXp4N1fky+VCtfhOkDUFIv5ea7p4wuTomI4QTrXvFBX2S4jZsmyTSrStQl+E+4w+RzxA==",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "enhanced-resolve": "^5.7.0",
+        "tsconfig-paths": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/tsconfig-paths-webpack-plugin/node_modules/tsconfig-paths": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
+      "dependencies": {
+        "json5": "^2.2.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tsconfig-paths/node_modules/json5": {

--- a/connectors/package.json
+++ b/connectors/package.json
@@ -55,6 +55,7 @@
     "sequelize": "^6.31.0",
     "talisman": "^1.1.4",
     "tar": "^6.2.0",
+    "tsconfig-paths-webpack-plugin": "^4.1.0",
     "turndown": "^7.1.2",
     "uuid": "^9.0.0"
   },

--- a/connectors/src/connectors/confluence/temporal/worker.ts
+++ b/connectors/src/connectors/confluence/temporal/worker.ts
@@ -1,5 +1,6 @@
 import type { Context } from "@temporalio/activity";
 import { Worker } from "@temporalio/worker";
+import TsconfigPathsPlugin from "tsconfig-paths-webpack-plugin";
 
 import * as activities from "@connectors/connectors/confluence/temporal/activities";
 import { QUEUE_NAME } from "@connectors/connectors/confluence/temporal/config";
@@ -23,6 +24,15 @@ export async function runConfluenceWorker() {
           return new ActivityInboundLogInterceptor(ctx, logger);
         },
       ],
+    },
+    bundlerOptions: {
+      // Update the webpack config to use aliases from our tsconfig.json.
+      webpackConfigHook: (config) => {
+        const plugins = config.resolve?.plugins ?? [];
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        config.resolve!.plugins = [...plugins, new TsconfigPathsPlugin({})];
+        return config;
+      },
     },
   });
 

--- a/connectors/src/connectors/confluence/temporal/workflows.ts
+++ b/connectors/src/connectors/confluence/temporal/workflows.ts
@@ -9,15 +9,13 @@ import {
 
 import type * as activities from "@connectors/connectors/confluence/temporal/activities";
 import type { SpaceUpdatesSignal } from "@connectors/connectors/confluence/temporal/signals";
-import type { DataSourceConfig } from "@connectors/types/data_source_config";
-
-// The Temporal bundle does not support the use of aliases in import statements.
-import { spaceUpdatesSignal } from "./signals";
+import { spaceUpdatesSignal } from "@connectors/connectors/confluence/temporal/signals";
 import {
   makeConfluenceRemoveSpacesWorkflowId,
   makeConfluenceRemoveSpaceWorkflowIdFromParentId,
   makeConfluenceSpaceSyncWorkflowIdFromParentId,
-} from "./utils";
+} from "@connectors/connectors/confluence/temporal/utils";
+import type { DataSourceConfig } from "@connectors/types/data_source_config";
 
 const {
   confluenceGetSpaceNameActivity,


### PR DESCRIPTION
## Description

After the incident this morning involving the importation of the logger through our aliases defined in the `tsconfig.json` file, this PR modifies the webpack configuration used by Temporal to relies on our `tsconfig.json` for alias resolution during the build process.

Longer term we should build in the CI or on a GitHub action to avoid this hack and improve worker start up time (see [doc](https://docs.temporal.io/dev-guide/typescript/foundations#prebuilt-workflow-bundles)).
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

This changes is pretty risky, it applies only to Confluence workflows (only used by one customer for now). It works locally, the goal here is to ensure a smooth rollout in production.

If this PR proves to work in production, I'll create a generic helper to add this hack in all our workers.

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
