### PR TITLE
feat: implement dual workflow mode Notion connector

### DIFF
--- a/connectors/src/connectors/notion/temporal/utils.ts
+++ b/connectors/src/connectors/notion/temporal/utils.ts
@@ -3,10 +3,19 @@ import type { ModelId } from "@dust-tt/types";
 import type { DataSourceInfo } from "@connectors/types/data_source_config";
 
 // Changes made here should be reflected in the production environment checks.
-export function getWorkflowId(dataSourceInfo: DataSourceInfo) {
-  return `workflow-notion-${dataSourceInfo.workspaceId}-${dataSourceInfo.dataSourceName}`;
+export function getWorkflowId(
+  dataSourceInfo: DataSourceInfo,
+  gargbageCollectionMode: GarbageCollectionMode = "auto"
+) {
+  let wfName = "workflow-notion";
+  if (gargbageCollectionMode === "always") {
+    wfName += "-garbage-collector";
+  }
+  return `${wfName}-${dataSourceInfo.workspaceId}-${dataSourceInfo.dataSourceName}`;
 }
 
 export function getWorkflowIdV2(connectorId: ModelId) {
   return `notion-${connectorId}`;
 }
+
+export type GarbageCollectionMode = "always" | "auto" | "never";

--- a/connectors/src/lib/models/notion.ts
+++ b/connectors/src/lib/models/notion.ts
@@ -20,6 +20,8 @@ export class NotionConnectorState extends Model<
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
+  declare useDualWorkflow: boolean;
+
   declare lastGarbageCollectionFinishTime?: Date;
 
   declare connectorId: ForeignKey<Connector["id"]>;
@@ -40,6 +42,11 @@ NotionConnectorState.init(
       type: DataTypes.DATE,
       allowNull: false,
       defaultValue: DataTypes.NOW,
+    },
+    useDualWorkflow: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
     },
     lastGarbageCollectionFinishTime: {
       type: DataTypes.DATE,

--- a/connectors/src/lib/models/notion.ts
+++ b/connectors/src/lib/models/notion.ts
@@ -20,7 +20,7 @@ export class NotionConnectorState extends Model<
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
-  declare useDualWorkflow: boolean;
+  declare useDualWorkflow: CreationOptional<boolean>;
 
   declare lastGarbageCollectionFinishTime?: Date;
 


### PR DESCRIPTION
## Description

We want to experiment with having 2 concurrent notion WF per workspace -- one that garbage collects and the other one that handles the "live" sync.

This PR build on top of the recent changes that implemented per-worfklow caching (instead of a global connector-level cache) to optionally support the 2 workflow setup. It will require flipping a (new) boolean column on `NotionConnectorState`.

## Risk

Maximum blast radius is the whole connectors worker (there's a migration).

## Deploy Plan

1. initdb (new column)
2. deploy connectors
3. set `useDualWorkflow` to true for dust notion connector
4. restart all notion connectors
5. 🤞 