### PR TITLE
Use feature flag for Intercom rollout

### DIFF
--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -24,10 +24,10 @@ import {
 } from "@dust-tt/types";
 import { DustAPI } from "@dust-tt/types";
 
+import { isFeatureEnabled } from "@app/lib/api/feature_flags";
 import { GLOBAL_AGENTS_SID } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { prodAPICredentialsForOwner } from "@app/lib/auth";
-import { isDevelopmentOrDustWorkspace } from "@app/lib/development";
 import { GlobalAgentSettings } from "@app/lib/models/assistant/agent";
 import logger from "@app/logger/logger";
 
@@ -866,8 +866,7 @@ export async function getGlobalAgents(
     )
   );
 
-  // Rollout Intercom.
-  if (!isDevelopmentOrDustWorkspace(owner)) {
+  if (!owner.flags.includes("intercom_connection")) {
     agentCandidates = agentCandidates?.filter(
       (agent) => agent?.sId !== GLOBAL_AGENTS_SID.INTERCOM
     );

--- a/front/lib/connector_providers.ts
+++ b/front/lib/connector_providers.ts
@@ -14,7 +14,7 @@ export const CONNECTOR_CONFIGURATIONS: Record<
   {
     name: string;
     connectorProvider: ConnectorProvider;
-    status: "preview" | "built-dust-only" | "built";
+    status: "preview" | "built";
     hide: boolean;
     logoComponent: (props: React.SVGProps<SVGSVGElement>) => React.JSX.Element;
     description: string;
@@ -82,7 +82,7 @@ export const CONNECTOR_CONFIGURATIONS: Record<
   intercom: {
     name: "Intercom",
     connectorProvider: "intercom",
-    status: "built-dust-only", // ROLLOUT INTERCOM
+    status: "preview", // ROLLOUT intercom_connection
     hide: false,
     description:
       "Authorize granular access to your Intercom workspace. Access your Conversations at the Team level and Help Center Articles at the main Collection level.",

--- a/front/lib/connector_providers.ts
+++ b/front/lib/connector_providers.ts
@@ -7,14 +7,15 @@ import {
   NotionLogo,
   SlackLogo,
 } from "@dust-tt/sparkle";
-import type { ConnectorProvider } from "@dust-tt/types";
+import type { ConnectorProvider, WhitelistableFeature } from "@dust-tt/types";
 
 export const CONNECTOR_CONFIGURATIONS: Record<
   ConnectorProvider,
   {
     name: string;
     connectorProvider: ConnectorProvider;
-    status: "preview" | "built";
+    status: "preview" | "built" | "rolling_out";
+    rollingOutFlag?: WhitelistableFeature;
     hide: boolean;
     logoComponent: (props: React.SVGProps<SVGSVGElement>) => React.JSX.Element;
     description: string;
@@ -82,7 +83,8 @@ export const CONNECTOR_CONFIGURATIONS: Record<
   intercom: {
     name: "Intercom",
     connectorProvider: "intercom",
-    status: "preview", // ROLLOUT intercom_connection
+    status: "rolling_out",
+    rollingOutFlag: "intercom_connection",
     hide: false,
     description:
       "Authorize granular access to your Intercom workspace. Access your Conversations at the Team level and Help Center Articles at the main Collection level.",

--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -32,8 +32,8 @@ import { getDataSources } from "@app/lib/api/data_sources";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { buildConnectionId } from "@app/lib/connector_connection_id";
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
-import { isDevelopmentOrDustWorkspace } from "@app/lib/development";
 import { githubAuth } from "@app/lib/github_auth";
+import { useFeatures } from "@app/lib/swr";
 import { timeAgoFrom } from "@app/lib/utils";
 import logger from "@app/logger/logger";
 import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
@@ -55,7 +55,7 @@ type DataSourceIntegration = {
   connector: ConnectorType | null;
   fetchConnectorError: boolean;
   fetchConnectorErrorMessage?: string | null;
-  status: "preview" | "built-dust-only" | "built";
+  status: "preview" | "built";
   connectorProvider: ConnectorProvider;
   description: string;
   limitations: string | null;
@@ -477,6 +477,9 @@ export default function DataSourcesView({
 
   const router = useRouter();
 
+  const { features } = useFeatures(owner);
+  const isIntercomEnabled = features?.includes("intercom_connection");
+
   return (
     <AppLayout
       subscription={subscription}
@@ -520,8 +523,7 @@ export default function DataSourcesView({
             .map((ds) => {
               const isBuilt =
                 ds.status === "built" ||
-                (ds.status === "built-dust-only" &&
-                  isDevelopmentOrDustWorkspace(owner));
+                (ds.connectorProvider === "intercom" && isIntercomEnabled);
               return (
                 <ContextItem
                   key={

--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -34,7 +34,6 @@ import { Authenticator, getSession } from "@app/lib/auth";
 import { buildConnectionId } from "@app/lib/connector_connection_id";
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 import { githubAuth } from "@app/lib/github_auth";
-import { useFeatures } from "@app/lib/swr";
 import { timeAgoFrom } from "@app/lib/utils";
 import logger from "@app/logger/logger";
 import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
@@ -481,8 +480,6 @@ export default function DataSourcesView({
 
   const router = useRouter();
 
-  const { features } = useFeatures(owner);
-
   return (
     <AppLayout
       subscription={subscription}
@@ -528,7 +525,7 @@ export default function DataSourcesView({
                 ds.status === "built" ||
                 (ds.status === "rolling_out" &&
                   ds.rollingOutFlag &&
-                  features?.includes(ds.rollingOutFlag));
+                  owner.flags.includes(ds.rollingOutFlag));
               return (
                 <ContextItem
                   key={

--- a/types/src/front/feature_flags.ts
+++ b/types/src/front/feature_flags.ts
@@ -3,6 +3,7 @@ export const WHITELISTABLE_FEATURES = [
   "structured_data",
   "workspace_analytics",
   "mistral_next",
+  "intercom_connection",
 ] as const;
 export type WhitelistableFeature = (typeof WHITELISTABLE_FEATURES)[number];
 export function isWhitelistableFeature(


### PR DESCRIPTION
## Description

Rely on the new feature flag system over `isDevelopmentOrDustWorkspace` on the Intercom connection.


## Risk

Low, rollback is easy.

## Deploy Plan

Nothing special.
