### PR TITLE
Intercom: change string name of resource

### DIFF
--- a/front/components/assistant_builder/shared.ts
+++ b/front/components/assistant_builder/shared.ts
@@ -27,7 +27,7 @@ export const CONNECTOR_PROVIDER_TO_RESOURCE_NAME: Record<
   google_drive: { singular: "folder", plural: "folders" },
   slack: { singular: "channel", plural: "channels" },
   github: { singular: "repository", plural: "repositories" },
-  intercom: { singular: "article", plural: "articles" },
+  intercom: { singular: "element", plural: "elements" },
   webcrawler: { singular: "page", plural: "pages" },
 };
 


### PR DESCRIPTION
## Description

An Intercom resource can be an article, a collection of article(s), and soon a team or conversation.
Picking a generic name (the same as the one we have in the `AssistantDetails` modal) so that it works for all cases.

I don't think it deserves the complexity of putting the exact resources types in this form.

## Risk

Lower 9000

## Deploy Plan

Nothing special.
