### PR TITLE
enh: allow dual WF notion conn to full resync

### DIFF
--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -251,6 +251,17 @@ export async function fullResyncNotionConnector(
     return new Err(new Error("Connector not found"));
   }
 
+  const notionConnectorState = await NotionConnectorState.findOne({
+    where: {
+      connectorId,
+    },
+  });
+
+  if (!notionConnectorState) {
+    logger.error({ connectorId }, "Notion connector state not found.");
+    return new Err(new Error("Connector state not found"));
+  }
+
   try {
     await stopNotionConnector(connector.id.toString());
   } catch (e) {
@@ -266,6 +277,9 @@ export async function fullResyncNotionConnector(
 
     return new Err(e as Error);
   }
+
+  notionConnectorState.fullResyncStartTime = new Date();
+  await notionConnectorState.save();
 
   try {
     await launchNotionSyncWorkflow(

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -539,6 +539,15 @@ export async function shouldGarbageCollect({
     return false;
   }
 
+  if (
+    notionConnectorState.fullResyncStartTime &&
+    connector.lastSyncFinishTime &&
+    notionConnectorState.fullResyncStartTime > connector.lastSyncFinishTime
+  ) {
+    // If we are currently doing a full resync, we should not garbage collect
+    return false;
+  }
+
   if (garbageCollectionMode === "never") {
     return false;
   }

--- a/connectors/src/connectors/notion/temporal/client.ts
+++ b/connectors/src/connectors/notion/temporal/client.ts
@@ -43,12 +43,6 @@ export async function launchNotionSyncWorkflow(
 
   const useDualWorkflow = notionConnectorState.useDualWorkflow;
 
-  if (useDualWorkflow && forceResync) {
-    throw new Error(
-      "Force resync not implemented for dual workflow enabled workspaces."
-    );
-  }
-
   const workflow = await getNotionWorkflow(dataSourceConfig);
 
   if (workflow && workflow.executionDescription.status.name === "RUNNING") {

--- a/connectors/src/connectors/notion/temporal/workflows.ts
+++ b/connectors/src/connectors/notion/temporal/workflows.ts
@@ -93,9 +93,9 @@ export async function notionSyncWorkflow({
   });
 
   if (!isGarbageCollectionRun && garbageCollectionMode === "always") {
-    // If this is a "perpetual garbage collection" workflow but we have never
-    // completed a full sync yet, we'll just wait for the initial sync to complete
-    // and check every 5 minutes if we're good to start garbage collecting.
+    // If this is a "perpetual garbage collection" workflow but we cannot garbage collect (eg, we have never completed
+    // a full sync, or there is a full resync in progress), we wait until we can garbage collect (and check every 5 minute).
+
     await sleep(60_000 * 5); // 5 minutes
     await continueAsNew<typeof notionSyncWorkflow>({
       connectorId,

--- a/connectors/src/lib/models/notion.ts
+++ b/connectors/src/lib/models/notion.ts
@@ -21,6 +21,7 @@ export class NotionConnectorState extends Model<
   declare updatedAt: CreationOptional<Date>;
 
   declare useDualWorkflow: CreationOptional<boolean>;
+  declare fullResyncStartTime?: CreationOptional<Date>;
 
   declare lastGarbageCollectionFinishTime?: Date;
 
@@ -47,6 +48,10 @@ NotionConnectorState.init(
       type: DataTypes.BOOLEAN,
       allowNull: false,
       defaultValue: false,
+    },
+    fullResyncStartTime: {
+      type: DataTypes.DATE,
+      allowNull: true,
     },
     lastGarbageCollectionFinishTime: {
       type: DataTypes.DATE,


### PR DESCRIPTION
## Description

We're currently experimenting with a new "dual workflow" setup for notion connectors.
The ability to full resync notion connectors that are in dual workflow setup wasn't implemented. This commit makes it possible to full resync by recording the last full resync start time and pausing the GC workflow until the full resync is complete.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
