### PR TITLE
front: Move all routes to use WithAPIErrorResponse

### DIFF
--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -1,4 +1,4 @@
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { WithAPIErrorReponse } from "@dust-tt/types";
 import { verify } from "jsonwebtoken";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { getServerSession } from "next-auth/next";
@@ -90,7 +90,7 @@ async function findWorkspaceWithWhitelistedDomain(session: any) {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<ReturnedAPIErrorType>
+  res: NextApiResponse<WithAPIErrorReponse<void>>
 ): Promise<void> {
   const session = await getServerSession(req, res, authOptions);
   if (!session) {

--- a/front/pages/api/poke/plans.ts
+++ b/front/pages/api/poke/plans.ts
@@ -1,5 +1,4 @@
-import type { PlanType } from "@dust-tt/types";
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { PlanType, WithAPIErrorReponse } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
@@ -59,7 +58,7 @@ export type GetPokePlansResponseBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    GetPokePlansResponseBody | UpsertPokePlanResponseBody | ReturnedAPIErrorType
+    WithAPIErrorReponse<GetPokePlansResponseBody | UpsertPokePlanResponseBody>
   >
 ): Promise<void> {
   const session = await getSession(req, res);

--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/index.ts
@@ -1,4 +1,4 @@
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { WithAPIErrorReponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import {
@@ -15,7 +15,7 @@ export type DeleteAgentConfigurationResponseBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    DeleteAgentConfigurationResponseBody | ReturnedAPIErrorType
+    WithAPIErrorReponse<DeleteAgentConfigurationResponseBody>
   >
 ): Promise<void> {
   const session = await getSession(req, res);

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/config.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/config.ts
@@ -1,4 +1,4 @@
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { WithAPIErrorReponse } from "@dust-tt/types";
 import { ConnectorsAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -14,7 +14,7 @@ export type SetConfigResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<SetConfigResponseBody | ReturnedAPIErrorType>
+  res: NextApiResponse<WithAPIErrorReponse<SetConfigResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSuperUserSession(

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[name]/index.ts
@@ -1,4 +1,4 @@
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { WithAPIErrorReponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { deleteDataSource } from "@app/lib/api/data_sources";
@@ -11,7 +11,7 @@ export type DeleteDataSourceResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<DeleteDataSourceResponseBody | ReturnedAPIErrorType>
+  res: NextApiResponse<WithAPIErrorReponse<DeleteDataSourceResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSuperUserSession(

--- a/front/pages/api/poke/workspaces/[wId]/downgrade.ts
+++ b/front/pages/api/poke/workspaces/[wId]/downgrade.ts
@@ -1,5 +1,4 @@
-import type { WorkspaceType } from "@dust-tt/types";
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { WithAPIErrorReponse, WorkspaceType } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { Authenticator, getSession } from "@app/lib/auth";
@@ -12,7 +11,7 @@ export type DowngradeWorkspaceResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<DowngradeWorkspaceResponseBody | ReturnedAPIErrorType>
+  res: NextApiResponse<WithAPIErrorReponse<DowngradeWorkspaceResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSuperUserSession(

--- a/front/pages/api/poke/workspaces/[wId]/features.ts
+++ b/front/pages/api/poke/workspaces/[wId]/features.ts
@@ -1,7 +1,4 @@
-import type {
-  ReturnedAPIErrorType,
-  WhitelistableFeature,
-} from "@dust-tt/types";
+import type { WhitelistableFeature, WithAPIErrorReponse } from "@dust-tt/types";
 import { isWhitelistableFeature } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -20,9 +17,9 @@ export type CreateOrDeleteFeatureFlagResponseBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    | CreateOrDeleteFeatureFlagResponseBody
-    | GetPokeFeaturesResponseBody
-    | ReturnedAPIErrorType
+    WithAPIErrorReponse<
+      CreateOrDeleteFeatureFlagResponseBody | GetPokeFeaturesResponseBody
+    >
   >
 ): Promise<void> {
   const session = await getSession(req, res);

--- a/front/pages/api/poke/workspaces/[wId]/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/index.ts
@@ -1,5 +1,4 @@
-import type { WorkspaceType } from "@dust-tt/types";
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { WithAPIErrorReponse, WorkspaceType } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
@@ -25,9 +24,9 @@ export type DeleteWorkspaceResponseBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    | SegmentWorkspaceResponseBody
-    | DeleteWorkspaceResponseBody
-    | ReturnedAPIErrorType
+    WithAPIErrorReponse<
+      SegmentWorkspaceResponseBody | DeleteWorkspaceResponseBody
+    >
   >
 ): Promise<void> {
   const session = await getSession(req, res);

--- a/front/pages/api/poke/workspaces/[wId]/revoke.ts
+++ b/front/pages/api/poke/workspaces/[wId]/revoke.ts
@@ -1,4 +1,4 @@
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { WithAPIErrorReponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { Authenticator, getSession } from "@app/lib/auth";
@@ -12,7 +12,7 @@ export type RevokeUserResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<RevokeUserResponseBody | ReturnedAPIErrorType>
+  res: NextApiResponse<WithAPIErrorReponse<RevokeUserResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSuperUserSession(

--- a/front/pages/api/poke/workspaces/[wId]/upgrade.ts
+++ b/front/pages/api/poke/workspaces/[wId]/upgrade.ts
@@ -1,5 +1,4 @@
-import type { WorkspaceType } from "@dust-tt/types";
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { WithAPIErrorReponse, WorkspaceType } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { Authenticator, getSession } from "@app/lib/auth";
@@ -15,7 +14,7 @@ export type UpgradeWorkspaceResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<UpgradeWorkspaceResponseBody | ReturnedAPIErrorType>
+  res: NextApiResponse<WithAPIErrorReponse<UpgradeWorkspaceResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSuperUserSession(

--- a/front/pages/api/poke/workspaces/index.ts
+++ b/front/pages/api/poke/workspaces/index.ts
@@ -1,5 +1,4 @@
-import type { WorkspaceType } from "@dust-tt/types";
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { WithAPIErrorReponse, WorkspaceType } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 import type { FindOptions, WhereOptions } from "sequelize";
 import { Op } from "sequelize";
@@ -14,7 +13,7 @@ export type GetWorkspacesResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<GetWorkspacesResponseBody | ReturnedAPIErrorType>
+  res: NextApiResponse<WithAPIErrorReponse<GetWorkspacesResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSuperUserSession(session, null);

--- a/front/pages/api/stripe/portal.ts
+++ b/front/pages/api/stripe/portal.ts
@@ -1,4 +1,4 @@
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { WithAPIErrorReponse } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
@@ -16,7 +16,7 @@ type PostStripePortalResponseBody = {
 };
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<PostStripePortalResponseBody | ReturnedAPIErrorType>
+  res: NextApiResponse<WithAPIErrorReponse<PostStripePortalResponseBody>>
 ): Promise<void> {
   const bodyValidation = PostStripePortalRequestBody.decode(req.body);
   if (isLeft(bodyValidation)) {

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -1,4 +1,4 @@
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { WithAPIErrorReponse } from "@dust-tt/types";
 import { CoreAPI, isRetrievalConfiguration } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { pipeline, Writable } from "stream";
@@ -49,7 +49,7 @@ export const config = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<GetResponseBody | ReturnedAPIErrorType>
+  res: NextApiResponse<WithAPIErrorReponse<GetResponseBody>>
 ): Promise<void> {
   const stripe = new Stripe(STRIPE_SECRET_KEY, {
     apiVersion: "2023-10-16",
@@ -547,7 +547,7 @@ async function handler(
 
 function _returnStripeApiError(
   req: NextApiRequest,
-  res: NextApiResponse<GetResponseBody | ReturnedAPIErrorType>,
+  res: NextApiResponse<WithAPIErrorReponse<GetResponseBody>>,
   event: string,
   message: string
 ) {

--- a/front/pages/api/user/index.ts
+++ b/front/pages/api/user/index.ts
@@ -1,6 +1,6 @@
 import type {
-  ReturnedAPIErrorType,
   UserTypeWithWorkspaces,
+  WithAPIErrorReponse,
 } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
@@ -27,7 +27,7 @@ export type GetUserResponseBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    PostUserMetadataResponseBody | GetUserResponseBody | ReturnedAPIErrorType
+    WithAPIErrorReponse<PostUserMetadataResponseBody | GetUserResponseBody>
   >
 ): Promise<void> {
   const session = await getSession(req, res);

--- a/front/pages/api/user/metadata/[key]/index.ts
+++ b/front/pages/api/user/metadata/[key]/index.ts
@@ -1,5 +1,4 @@
-import type { UserMetadataType } from "@dust-tt/types";
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { UserMetadataType, WithAPIErrorReponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getUserMetadata, setUserMetadata } from "@app/lib/api/user";
@@ -16,9 +15,9 @@ export type GetUserMetadataResponseBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    | PostUserMetadataResponseBody
-    | GetUserMetadataResponseBody
-    | ReturnedAPIErrorType
+    WithAPIErrorReponse<
+      PostUserMetadataResponseBody | GetUserMetadataResponseBody
+    >
   >
 ): Promise<void> {
   const session = await getSession(req, res);

--- a/front/pages/api/v1/w/[wId]/apps/[aId]/runs/[runId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/apps/[aId]/runs/[runId]/index.ts
@@ -1,5 +1,4 @@
-import type { RunType } from "@dust-tt/types";
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { RunType, WithAPIErrorReponse } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -20,7 +19,7 @@ export type GetRunResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<GetRunResponseBody | ReturnedAPIErrorType>
+  res: NextApiResponse<WithAPIErrorReponse<GetRunResponseBody>>
 ): Promise<void> {
   const keyRes = await getAPIKey(req);
   if (keyRes.isErr()) {

--- a/front/pages/api/v1/w/[wId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/v1/w/[wId]/apps/[aId]/runs/index.ts
@@ -1,6 +1,5 @@
-import type { CredentialsType } from "@dust-tt/types";
+import type { CredentialsType, WithAPIErrorReponse } from "@dust-tt/types";
 import type { RunType } from "@dust-tt/types";
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
 import {
   credentialsFromProviders,
   dustManagedCredentials,
@@ -77,7 +76,7 @@ const poll = async ({
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<PostRunResponseBody | ReturnedAPIErrorType>
+  res: NextApiResponse<WithAPIErrorReponse<PostRunResponseBody>>
 ): Promise<void> {
   const keyRes = await getAPIKey(req);
   if (keyRes.isErr()) {

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
@@ -1,5 +1,4 @@
-import type { ContentFragmentType } from "@dust-tt/types";
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { ContentFragmentType, WithAPIErrorReponse } from "@dust-tt/types";
 import { PublicPostContentFragmentRequestBodySchema } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import type * as t from "io-ts";
@@ -23,7 +22,7 @@ export type PostContentFragmentRequestBody = t.TypeOf<
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<PostContentFragmentsResponseBody | ReturnedAPIErrorType>
+  res: NextApiResponse<WithAPIErrorReponse<PostContentFragmentsResponseBody>>
 ): Promise<void> {
   const keyRes = await getAPIKey(req);
   if (keyRes.isErr()) {

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/events.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/events.ts
@@ -1,4 +1,4 @@
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { WithAPIErrorReponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation";
@@ -8,7 +8,7 @@ import { apiError, withLogging } from "@app/logger/withlogging";
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<ReturnedAPIErrorType>
+  res: NextApiResponse<WithAPIErrorReponse<void>>
 ): Promise<void> {
   const keyRes = await getAPIKey(req);
   if (keyRes.isErr()) {

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -1,5 +1,4 @@
-import type { ConversationType } from "@dust-tt/types";
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { ConversationType, WithAPIErrorReponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getConversation } from "@app/lib/api/assistant/conversation";
@@ -8,9 +7,7 @@ import { apiError, withLogging } from "@app/logger/withlogging";
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<
-    { conversation: ConversationType } | ReturnedAPIErrorType
-  >
+  res: NextApiResponse<WithAPIErrorReponse<{ conversation: ConversationType }>>
 ): Promise<void> {
   const keyRes = await getAPIKey(req);
   if (keyRes.isErr()) {

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.ts
@@ -1,4 +1,4 @@
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { WithAPIErrorReponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import {
@@ -11,7 +11,7 @@ import { apiError, withLogging } from "@app/logger/withlogging";
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<ReturnedAPIErrorType>
+  res: NextApiResponse<WithAPIErrorReponse<void>>
 ): Promise<void> {
   const keyRes = await getAPIKey(req);
   if (keyRes.isErr()) {

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -1,5 +1,4 @@
-import type { UserMessageType } from "@dust-tt/types";
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { UserMessageType, WithAPIErrorReponse } from "@dust-tt/types";
 import { PublicPostMessagesRequestBodySchema } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as reporter from "io-ts-reporters";
@@ -16,7 +15,7 @@ export type PostMessagesResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<{ message: UserMessageType } | ReturnedAPIErrorType>
+  res: NextApiResponse<WithAPIErrorReponse<{ message: UserMessageType }>>
 ): Promise<void> {
   const keyRes = await getAPIKey(req);
   if (keyRes.isErr()) {

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -2,8 +2,8 @@ import type {
   ContentFragmentType,
   ConversationType,
   UserMessageType,
+  WithAPIErrorReponse,
 } from "@dust-tt/types";
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
 import { PublicPostConversationsRequestBodySchema } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as reporter from "io-ts-reporters";
@@ -26,7 +26,7 @@ export type PostConversationsResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<PostConversationsResponseBody | ReturnedAPIErrorType>
+  res: NextApiResponse<WithAPIErrorReponse<PostConversationsResponseBody>>
 ): Promise<void> {
   const keyRes = await getAPIKey(req);
   if (keyRes.isErr()) {

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
@@ -1,6 +1,9 @@
-import type { CoreAPILightDocument, DataSourceType } from "@dust-tt/types";
-import type { DocumentType } from "@dust-tt/types";
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type {
+  CoreAPILightDocument,
+  DataSourceType,
+  DocumentType,
+  WithAPIErrorReponse,
+} from "@dust-tt/types";
 import {
   PostDataSourceDocumentRequestBodySchema,
   sectionFullText,
@@ -50,10 +53,11 @@ export type UpsertDocumentResponseBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    | GetDocumentResponseBody
-    | DeleteDocumentResponseBody
-    | UpsertDocumentResponseBody
-    | ReturnedAPIErrorType
+    WithAPIErrorReponse<
+      | GetDocumentResponseBody
+      | DeleteDocumentResponseBody
+      | UpsertDocumentResponseBody
+    >
   >
 ): Promise<void> {
   const keyRes = await getAPIKey(req);

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/parents.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/[documentId]/parents.ts
@@ -1,4 +1,4 @@
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { WithAPIErrorReponse } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -13,7 +13,7 @@ export type PostParentsResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<PostParentsResponseBody | ReturnedAPIErrorType>
+  res: NextApiResponse<WithAPIErrorReponse<PostParentsResponseBody>>
 ): Promise<void> {
   const keyRes = await getAPIKey(req);
   if (keyRes.isErr()) {

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/documents/index.ts
@@ -1,5 +1,4 @@
-import type { DocumentType } from "@dust-tt/types";
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { DocumentType, WithAPIErrorReponse } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -15,7 +14,7 @@ export type GetDocumentsResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<GetDocumentsResponseBody | ReturnedAPIErrorType>
+  res: NextApiResponse<WithAPIErrorReponse<GetDocumentsResponseBody>>
 ): Promise<void> {
   const keyRes = await getAPIKey(req);
   if (keyRes.isErr()) {

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/search.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/search.ts
@@ -1,6 +1,5 @@
-import type { DocumentType } from "@dust-tt/types";
+import type { DocumentType, WithAPIErrorReponse } from "@dust-tt/types";
 import type { CredentialsType } from "@dust-tt/types";
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
 import {
   credentialsFromProviders,
   dustManagedCredentials,
@@ -52,7 +51,7 @@ type DatasourceSearchResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<DatasourceSearchResponseBody | ReturnedAPIErrorType>
+  res: NextApiResponse<WithAPIErrorReponse<DatasourceSearchResponseBody>>
 ): Promise<void> {
   const keyRes = await getAPIKey(req);
   if (keyRes.isErr()) {

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tokenize.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tokenize.ts
@@ -1,5 +1,4 @@
-import type { CoreAPITokenType } from "@dust-tt/types";
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { CoreAPITokenType, WithAPIErrorReponse } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
@@ -25,9 +24,7 @@ type PostDatasourceTokenizeResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<
-    PostDatasourceTokenizeResponseBody | ReturnedAPIErrorType
-  >
+  res: NextApiResponse<WithAPIErrorReponse<PostDatasourceTokenizeResponseBody>>
 ): Promise<void> {
   const keyRes = await getAPIKey(req);
   if (keyRes.isErr()) {

--- a/front/pages/api/v1/w/[wId]/data_sources/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/index.ts
@@ -1,5 +1,4 @@
-import type { DataSourceType } from "@dust-tt/types";
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { DataSourceType, WithAPIErrorReponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSources } from "@app/lib/api/data_sources";
@@ -12,7 +11,7 @@ export type GetDataSourcesResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<GetDataSourcesResponseBody | ReturnedAPIErrorType>
+  res: NextApiResponse<WithAPIErrorReponse<GetDataSourcesResponseBody>>
 ): Promise<void> {
   const keyRes = await getAPIKey(req);
   if (keyRes.isErr()) {

--- a/front/pages/api/w/[wId]/apps/[aId]/clone.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/clone.ts
@@ -1,5 +1,4 @@
-import type { AppType } from "@dust-tt/types";
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { AppType, WithAPIErrorReponse } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -17,7 +16,7 @@ export type PostAppResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<PostAppResponseBody | ReturnedAPIErrorType>
+  res: NextApiResponse<WithAPIErrorReponse<PostAppResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/apps/[aId]/datasets/[name]/index.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/datasets/[name]/index.ts
@@ -1,5 +1,4 @@
-import type { DatasetType } from "@dust-tt/types";
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { DatasetType, WithAPIErrorReponse } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as reporter from "io-ts-reporters";
@@ -18,7 +17,7 @@ type GetDatasetResponseBody = { dataset: DatasetType };
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<GetDatasetResponseBody | ReturnedAPIErrorType>
+  res: NextApiResponse<WithAPIErrorReponse<GetDatasetResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/apps/[aId]/datasets/index.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/datasets/index.ts
@@ -1,5 +1,4 @@
-import type { DatasetType } from "@dust-tt/types";
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { DatasetType, WithAPIErrorReponse } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
@@ -45,7 +44,7 @@ export const PostDatasetRequestBodySchema = t.type({
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    GetDatasetsResponseBody | PostDatasetResponseBody | ReturnedAPIErrorType
+    WithAPIErrorReponse<GetDatasetsResponseBody | PostDatasetResponseBody>
   >
 ): Promise<void> {
   const session = await getSession(req, res);

--- a/front/pages/api/w/[wId]/apps/[aId]/index.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/index.ts
@@ -1,5 +1,4 @@
-import type { AppType } from "@dust-tt/types";
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { AppType, WithAPIErrorReponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { Op } from "sequelize";
 
@@ -13,7 +12,7 @@ export type GetOrPostAppResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<GetOrPostAppResponseBody | ReturnedAPIErrorType>
+  res: NextApiResponse<WithAPIErrorReponse<GetOrPostAppResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/apps/[aId]/runs/[runId]/blocks/[type]/[name]/index.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/runs/[runId]/blocks/[type]/[name]/index.ts
@@ -1,5 +1,4 @@
-import type { BlockType, RunType } from "@dust-tt/types";
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { BlockType, RunType, WithAPIErrorReponse } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -20,7 +19,7 @@ export type GetRunBlockResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<GetRunBlockResponseBody | ReturnedAPIErrorType>
+  res: NextApiResponse<WithAPIErrorReponse<GetRunBlockResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/apps/[aId]/runs/[runId]/status.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/runs/[runId]/status.ts
@@ -1,5 +1,4 @@
-import type { RunType } from "@dust-tt/types";
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { RunType, WithAPIErrorReponse } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -14,7 +13,7 @@ export type GetRunStatusResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<GetRunStatusResponseBody | ReturnedAPIErrorType>
+  res: NextApiResponse<WithAPIErrorReponse<GetRunStatusResponseBody>>
 ) {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/runs/index.ts
@@ -1,5 +1,4 @@
-import type { RunType } from "@dust-tt/types";
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { RunType, WithAPIErrorReponse } from "@dust-tt/types";
 import { credentialsFromProviders } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
@@ -23,7 +22,7 @@ export type PostRunsResponseBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    GetRunsResponseBody | PostRunsResponseBody | ReturnedAPIErrorType
+    WithAPIErrorReponse<GetRunsResponseBody | PostRunsResponseBody>
   >
 ) {
   const session = await getSession(req, res);

--- a/front/pages/api/w/[wId]/apps/index.ts
+++ b/front/pages/api/w/[wId]/apps/index.ts
@@ -1,5 +1,4 @@
-import type { AppType } from "@dust-tt/types";
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { AppType, WithAPIErrorReponse } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -15,7 +14,7 @@ export type PostAppResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<PostAppResponseBody | ReturnedAPIErrorType>
+  res: NextApiResponse<WithAPIErrorReponse<PostAppResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/index.ts
@@ -1,5 +1,7 @@
-import type { AgentConfigurationType } from "@dust-tt/types";
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type {
+  AgentConfigurationType,
+  WithAPIErrorReponse,
+} from "@dust-tt/types";
 import { PostOrPatchAgentConfigurationRequestBodySchema } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as reporter from "io-ts-reporters";
@@ -23,10 +25,11 @@ export type DeleteAgentConfigurationResponseBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    | GetAgentConfigurationResponseBody
-    | DeleteAgentConfigurationResponseBody
-    | ReturnedAPIErrorType
-    | void
+    WithAPIErrorReponse<
+      | GetAgentConfigurationResponseBody
+      | DeleteAgentConfigurationResponseBody
+      | void
+    >
   >
 ): Promise<void> {
   const session = await getSession(req, res);

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/linked_slack_channels.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/linked_slack_channels.ts
@@ -1,4 +1,4 @@
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { WithAPIErrorReponse } from "@dust-tt/types";
 import { ConnectorsAPI } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
@@ -22,7 +22,7 @@ export const PatchLinkedSlackChannelsRequestBodySchema = t.type({
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    PatchLinkedSlackChannelsResponseBody | ReturnedAPIErrorType | void
+    WithAPIErrorReponse<PatchLinkedSlackChannelsResponseBody | void>
   >
 ): Promise<void> {
   const session = await getSession(req, res);

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/scope.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/scope.ts
@@ -1,4 +1,4 @@
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { WithAPIErrorReponse } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
@@ -12,7 +12,7 @@ import { createOrUpgradeAgentConfiguration } from "@app/pages/api/w/[wId]/assist
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<ReturnedAPIErrorType | void>
+  res: NextApiResponse<WithAPIErrorReponse<void>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/usage.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/usage.ts
@@ -1,5 +1,4 @@
-import type { AgentUsageType } from "@dust-tt/types";
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { AgentUsageType, WithAPIErrorReponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getAgentUsage } from "@app/lib/api/assistant/agent_usage";
@@ -13,7 +12,7 @@ export type GetAgentUsageResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<GetAgentUsageResponseBody | ReturnedAPIErrorType>
+  res: NextApiResponse<WithAPIErrorReponse<GetAgentUsageResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -4,8 +4,8 @@ import type {
   AgentGenerationConfigurationType,
   LightAgentConfigurationType,
   Result,
+  WithAPIErrorReponse,
 } from "@dust-tt/types";
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
 import {
   GetAgentConfigurationsQuerySchema,
   PostOrPatchAgentConfigurationRequestBodySchema,
@@ -38,10 +38,11 @@ export type PostAgentConfigurationResponseBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    | GetAgentConfigurationsResponseBody
-    | PostAgentConfigurationResponseBody
-    | ReturnedAPIErrorType
-    | void
+    WithAPIErrorReponse<
+      | GetAgentConfigurationsResponseBody
+      | PostAgentConfigurationResponseBody
+      | void
+    >
   >
 ): Promise<void> {
   const session = await getSession(req, res);

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/name_available.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/name_available.ts
@@ -1,4 +1,4 @@
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { WithAPIErrorReponse } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
@@ -19,7 +19,7 @@ export const GetAgentConfigurationNameIsAvailable = t.type({
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    GetAgentNameIsAvailableResponseBody | ReturnedAPIErrorType | void
+    WithAPIErrorReponse<GetAgentNameIsAvailableResponseBody | void>
   >
 ): Promise<void> {
   const session = await getSession(req, res);

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/cancel.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/cancel.ts
@@ -1,4 +1,4 @@
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { WithAPIErrorReponse } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
@@ -19,7 +19,7 @@ const PostMessageEventBodySchema = t.type({
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<PostMessageEventResponseBody | ReturnedAPIErrorType>
+  res: NextApiResponse<WithAPIErrorReponse<PostMessageEventResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/content_fragment/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/content_fragment/index.ts
@@ -1,5 +1,4 @@
-import type { ContentFragmentType } from "@dust-tt/types";
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { ContentFragmentType, WithAPIErrorReponse } from "@dust-tt/types";
 import { InternalPostContentFragmentRequestBodySchema } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import type * as t from "io-ts";
@@ -20,7 +19,7 @@ export type PostContentFragmentRequestBody = t.TypeOf<
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    { contentFragment: ContentFragmentType } | ReturnedAPIErrorType
+    WithAPIErrorReponse<{ contentFragment: ContentFragmentType }>
   >
 ): Promise<void> {
   const session = await getSession(req, res);

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/events.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/events.ts
@@ -1,4 +1,4 @@
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { WithAPIErrorReponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation";
@@ -8,7 +8,7 @@ import { apiError, withLogging } from "@app/logger/withlogging";
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<ReturnedAPIErrorType>
+  res: NextApiResponse<WithAPIErrorReponse<void>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -1,5 +1,4 @@
-import type { ConversationType } from "@dust-tt/types";
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { ConversationType, WithAPIErrorReponse } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
@@ -29,9 +28,7 @@ export type GetConversationsResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<
-    GetConversationsResponseBody | ReturnedAPIErrorType | void
-  >
+  res: NextApiResponse<WithAPIErrorReponse<GetConversationsResponseBody | void>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit.ts
@@ -1,5 +1,4 @@
-import type { UserMessageType } from "@dust-tt/types";
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { UserMessageType, WithAPIErrorReponse } from "@dust-tt/types";
 import { isUserMessageType } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
@@ -26,7 +25,7 @@ export const PostEditRequestBodySchema = t.type({
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<{ message: UserMessageType } | ReturnedAPIErrorType>
+  res: NextApiResponse<WithAPIErrorReponse<{ message: UserMessageType }>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.ts
@@ -1,4 +1,4 @@
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { WithAPIErrorReponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import {
@@ -11,7 +11,7 @@ import { apiError, withLogging } from "@app/logger/withlogging";
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<ReturnedAPIErrorType>
+  res: NextApiResponse<WithAPIErrorReponse<void>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/reactions/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/reactions/index.ts
@@ -1,5 +1,4 @@
-import type { MessageReactionType } from "@dust-tt/types";
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { MessageReactionType, WithAPIErrorReponse } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
@@ -20,9 +19,9 @@ export const MessageReactionRequestBodySchema = t.type({
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    | { reactions: MessageReactionType[] }
-    | { success: boolean }
-    | ReturnedAPIErrorType
+    WithAPIErrorReponse<
+      { reactions: MessageReactionType[] } | { success: boolean }
+    >
   >
 ): Promise<void> {
   const session = await getSession(req, res);

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/retry.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/retry.ts
@@ -1,5 +1,4 @@
-import type { AgentMessageType } from "@dust-tt/types";
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { AgentMessageType, WithAPIErrorReponse } from "@dust-tt/types";
 import { isAgentMessageType } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
@@ -20,7 +19,7 @@ export const PostRetryRequestBodySchema = t.union([
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<{ message: AgentMessageType } | ReturnedAPIErrorType>
+  res: NextApiResponse<WithAPIErrorReponse<{ message: AgentMessageType }>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -1,5 +1,4 @@
-import type { UserMessageType } from "@dust-tt/types";
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { UserMessageType, WithAPIErrorReponse } from "@dust-tt/types";
 import { InternalPostMessagesRequestBodySchema } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as reporter from "io-ts-reporters";
@@ -12,7 +11,7 @@ import { apiError, withLogging } from "@app/logger/withlogging";
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<{ message: UserMessageType } | ReturnedAPIErrorType>
+  res: NextApiResponse<WithAPIErrorReponse<{ message: UserMessageType }>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/reactions.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/reactions.ts
@@ -1,5 +1,7 @@
-import type { ConversationMessageReactions } from "@dust-tt/types";
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type {
+  ConversationMessageReactions,
+  WithAPIErrorReponse,
+} from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation";
@@ -10,7 +12,7 @@ import { apiError, withLogging } from "@app/logger/withlogging";
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    { reactions: ConversationMessageReactions } | ReturnedAPIErrorType
+    WithAPIErrorReponse<{ reactions: ConversationMessageReactions }>
   >
 ): Promise<void> {
   const session = await getSession(req, res);

--- a/front/pages/api/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/index.ts
@@ -3,8 +3,8 @@ import type {
   ConversationType,
   ConversationWithoutContentType,
   UserMessageType,
+  WithAPIErrorReponse,
 } from "@dust-tt/types";
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
 import { InternalPostConversationsRequestBodySchema } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as reporter from "io-ts-reporters";
@@ -32,10 +32,9 @@ export type PostConversationsResponseBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    | GetConversationsResponseBody
-    | PostConversationsResponseBody
-    | ReturnedAPIErrorType
-    | void
+    WithAPIErrorReponse<
+      GetConversationsResponseBody | PostConversationsResponseBody | void
+    >
   >
 ): Promise<void> {
   const session = await getSession(req, res);

--- a/front/pages/api/w/[wId]/assistant/global_agents/[aId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/global_agents/[aId]/index.ts
@@ -1,4 +1,4 @@
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { WithAPIErrorReponse } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
@@ -18,7 +18,7 @@ const PatchGlobalAgentSettingsRequestBodySchema = t.type({
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    PatchGlobalAgentSettingResponseBody | ReturnedAPIErrorType | void
+    WithAPIErrorReponse<PatchGlobalAgentSettingResponseBody | void>
   >
 ): Promise<void> {
   const session = await getSession(req, res);

--- a/front/pages/api/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
@@ -1,6 +1,5 @@
-import type { CoreAPILightDocument } from "@dust-tt/types";
+import type { CoreAPILightDocument, WithAPIErrorReponse } from "@dust-tt/types";
 import type { DocumentType } from "@dust-tt/types";
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
 import {
   PostDataSourceDocumentRequestBodySchema,
   sectionFullText,
@@ -23,7 +22,7 @@ export type GetDocumentResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<GetDocumentResponseBody | ReturnedAPIErrorType>
+  res: NextApiResponse<WithAPIErrorReponse<GetDocumentResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/data_sources/[name]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/index.ts
@@ -1,5 +1,4 @@
-import type { DataSourceType } from "@dust-tt/types";
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { DataSourceType, WithAPIErrorReponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { deleteDataSource, getDataSource } from "@app/lib/api/data_sources";
@@ -14,7 +13,7 @@ export type GetOrPostDataSourceResponseBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    GetOrPostDataSourceResponseBody | ReturnedAPIErrorType | void
+    WithAPIErrorReponse<GetOrPostDataSourceResponseBody | void>
   >
 ): Promise<void> {
   const session = await getSession(req, res);

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/bot_enabled.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/bot_enabled.ts
@@ -1,4 +1,4 @@
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { WithAPIErrorReponse } from "@dust-tt/types";
 import { ConnectorsAPI } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
@@ -21,7 +21,7 @@ export type GetOrPostBotEnabledResponseBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    GetOrPostBotEnabledResponseBody | ReturnedAPIErrorType | void
+    WithAPIErrorReponse<GetOrPostBotEnabledResponseBody | void>
   >
 ): Promise<void> {
   const session = await getSession(req, res);

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/parents.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/parents.ts
@@ -1,4 +1,4 @@
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { WithAPIErrorReponse } from "@dust-tt/types";
 import { ConnectorsAPI } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
@@ -21,7 +21,7 @@ export type GetConnectorResourceParentsResponseBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    GetConnectorResourceParentsResponseBody | ReturnedAPIErrorType
+    WithAPIErrorReponse<GetConnectorResourceParentsResponseBody>
   >
 ): Promise<void> {
   const session = await getSession(req, res);

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/permissions/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/permissions/index.ts
@@ -1,5 +1,8 @@
-import type { ConnectorPermission, ConnectorResource } from "@dust-tt/types";
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type {
+  ConnectorPermission,
+  ConnectorResource,
+  WithAPIErrorReponse,
+} from "@dust-tt/types";
 import { assertNever, ConnectorsAPI } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
@@ -36,9 +39,10 @@ export type SetDataSourcePermissionsResponseBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    | GetDataSourcePermissionsResponseBody
-    | ReturnedAPIErrorType
-    | SetDataSourcePermissionsResponseBody
+    WithAPIErrorReponse<
+      | GetDataSourcePermissionsResponseBody
+      | SetDataSourcePermissionsResponseBody
+    >
   >
 ): Promise<void> {
   const session = await getSession(req, res);

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/slack/channels_linked_with_agent.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/slack/channels_linked_with_agent.ts
@@ -1,4 +1,4 @@
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { WithAPIErrorReponse } from "@dust-tt/types";
 import { ConnectorsAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -18,7 +18,7 @@ export type GetSlackChannelsLinkedWithAgentResponseBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    GetSlackChannelsLinkedWithAgentResponseBody | ReturnedAPIErrorType
+    WithAPIErrorReponse<GetSlackChannelsLinkedWithAgentResponseBody>
   >
 ): Promise<void> {
   const session = await getSession(req, res);

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/update.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/update.ts
@@ -1,4 +1,4 @@
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { WithAPIErrorReponse } from "@dust-tt/types";
 import { ConnectorsAPI } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
@@ -25,7 +25,7 @@ export type GetDataSourceUpdateResponseBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    GetDataSourceUpdateResponseBody | ReturnedAPIErrorType | void
+    WithAPIErrorReponse<GetDataSourceUpdateResponseBody | void>
   >
 ): Promise<void> {
   const session = await getSession(req, res);

--- a/front/pages/api/w/[wId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/index.ts
@@ -1,5 +1,4 @@
-import type { DataSourceType } from "@dust-tt/types";
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { DataSourceType, WithAPIErrorReponse } from "@dust-tt/types";
 import {
   DEFAULT_FREE_QDRANT_CLUSTER,
   DEFAULT_PAID_QDRANT_CLUSTER,
@@ -28,9 +27,7 @@ export type PostDataSourceResponseBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    | GetDataSourcesResponseBody
-    | PostDataSourceResponseBody
-    | ReturnedAPIErrorType
+    WithAPIErrorReponse<GetDataSourcesResponseBody | PostDataSourceResponseBody>
   >
 ): Promise<void> {
   const session = await getSession(req, res);

--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -1,6 +1,5 @@
-import type { DataSourceType } from "@dust-tt/types";
+import type { DataSourceType, WithAPIErrorReponse } from "@dust-tt/types";
 import type { ConnectorType } from "@dust-tt/types";
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
 import {
   assertNever,
   DEFAULT_FREE_QDRANT_CLUSTER,
@@ -48,7 +47,7 @@ export type PostManagedDataSourceResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<PostManagedDataSourceResponseBody | ReturnedAPIErrorType>
+  res: NextApiResponse<WithAPIErrorReponse<PostManagedDataSourceResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/features.ts
+++ b/front/pages/api/w/[wId]/features.ts
@@ -1,7 +1,4 @@
-import type {
-  ReturnedAPIErrorType,
-  WhitelistableFeature,
-} from "@dust-tt/types";
+import type { WhitelistableFeature, WithAPIErrorReponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getFeatureFlags } from "@app/lib/api/feature_flags";
@@ -14,7 +11,7 @@ export type GetFeaturesResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<GetFeaturesResponseBody | ReturnedAPIErrorType>
+  res: NextApiResponse<WithAPIErrorReponse<GetFeaturesResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/index.ts
+++ b/front/pages/api/w/[wId]/index.ts
@@ -1,5 +1,4 @@
-import type { WorkspaceType } from "@dust-tt/types";
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { WithAPIErrorReponse, WorkspaceType } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
@@ -27,7 +26,7 @@ const PostWorkspaceRequestBodySchema = t.union([
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<PostWorkspaceResponseBody | ReturnedAPIErrorType>
+  res: NextApiResponse<WithAPIErrorReponse<PostWorkspaceResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/subscriptions/index.ts
+++ b/front/pages/api/w/[wId]/subscriptions/index.ts
@@ -1,5 +1,4 @@
-import type { PlanType } from "@dust-tt/types";
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { PlanType, WithAPIErrorReponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { Authenticator, getSession } from "@app/lib/auth";
@@ -17,7 +16,7 @@ export type PostSubscriptionResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<PostSubscriptionResponseBody | ReturnedAPIErrorType>
+  res: NextApiResponse<WithAPIErrorReponse<PostSubscriptionResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/use/extract/events/[sId]/index.ts
+++ b/front/pages/api/w/[wId]/use/extract/events/[sId]/index.ts
@@ -1,5 +1,4 @@
-import type { ExtractedEventType } from "@dust-tt/types";
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { ExtractedEventType, WithAPIErrorReponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getExtractedEvent, updateExtractedEvent } from "@app/lib/api/extract";
@@ -15,7 +14,7 @@ export type GetExtractedEventsResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<GetExtractedEventResponseBody | ReturnedAPIErrorType>
+  res: NextApiResponse<WithAPIErrorReponse<GetExtractedEventResponseBody>>
 ) {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/use/extract/templates/[sId]/events/index.ts
+++ b/front/pages/api/w/[wId]/use/extract/templates/[sId]/events/index.ts
@@ -1,5 +1,4 @@
-import type { ExtractedEventType } from "@dust-tt/types";
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { ExtractedEventType, WithAPIErrorReponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getExtractedEvents } from "@app/lib/api/extract";
@@ -13,7 +12,7 @@ export type GetExtractedEventsResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<GetExtractedEventsResponseBody | ReturnedAPIErrorType>
+  res: NextApiResponse<WithAPIErrorReponse<GetExtractedEventsResponseBody>>
 ) {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/use/extract/templates/[sId]/index.ts
+++ b/front/pages/api/w/[wId]/use/extract/templates/[sId]/index.ts
@@ -1,5 +1,4 @@
-import type { EventSchemaType } from "@dust-tt/types";
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { EventSchemaType, WithAPIErrorReponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getEventSchema, updateEventSchema } from "@app/lib/api/extract";
@@ -12,7 +11,7 @@ export type GetEventSchemaResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<GetEventSchemaResponseBody | ReturnedAPIErrorType>
+  res: NextApiResponse<WithAPIErrorReponse<GetEventSchemaResponseBody>>
 ) {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(

--- a/front/pages/api/w/[wId]/use/extract/templates/index.ts
+++ b/front/pages/api/w/[wId]/use/extract/templates/index.ts
@@ -1,5 +1,4 @@
-import type { EventSchemaType } from "@dust-tt/types";
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
+import type { EventSchemaType, WithAPIErrorReponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { createEventSchema, getEventSchemas } from "@app/lib/api/extract";
@@ -16,9 +15,9 @@ export type CreateEventSchemaResponseBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    | GetEventSchemasResponseBody
-    | CreateEventSchemaResponseBody
-    | ReturnedAPIErrorType
+    WithAPIErrorReponse<
+      GetEventSchemasResponseBody | CreateEventSchemaResponseBody
+    >
   >
 ) {
   const session = await getSession(req, res);

--- a/front/pages/w/[wId]/a/[aId]/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/index.tsx
@@ -6,16 +6,18 @@ import {
   SparklesIcon,
   Tab,
 } from "@dust-tt/sparkle";
-import type { CoreAPIError, UserType, WorkspaceType } from "@dust-tt/types";
 import type {
+  APIErrorResponse,
   AppType,
   BlockRunConfig,
+  BlockType,
+  CoreAPIError,
   SpecificationBlockType,
   SpecificationType,
+  SubscriptionType,
+  UserType,
+  WorkspaceType,
 } from "@dust-tt/types";
-import type { SubscriptionType } from "@dust-tt/types";
-import type { BlockType } from "@dust-tt/types";
-import type { ReturnedAPIErrorType } from "@dust-tt/types";
 import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 import { useRef, useState } from "react";
@@ -285,7 +287,7 @@ export default function AppView({
       ]);
 
       if (!runRes.ok) {
-        const r: ReturnedAPIErrorType = await runRes.json();
+        const r: APIErrorResponse = await runRes.json();
         setRunError(r.error.run_error as CoreAPIError);
       } else {
         setRunError(null);

--- a/types/src/front/lib/error.ts
+++ b/types/src/front/lib/error.ts
@@ -89,8 +89,8 @@ export type APIErrorWithStatusCode = {
   status_code: number;
 };
 
-export type ReturnedAPIErrorType = {
+export type APIErrorResponse = {
   error: APIError;
 };
 
-export type WithAPIErrorReponse<T> = T | ReturnedAPIErrorType;
+export type WithAPIErrorReponse<T> = T | APIErrorResponse;


### PR DESCRIPTION
## Description

We introduced `WithAPIErrorResponse` but didn't move all routes to use it. This PR achieves that.

## Risk

N/A typing only.

## Deploy Plan

N/A