### PR TITLE
Flav/do not sync confluence restricted pages

### DIFF
--- a/connectors/src/connectors/confluence/lib/confluence_api.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_api.ts
@@ -59,3 +59,17 @@ export async function listConfluenceSpaces(
 
   return client.getGlobalSpaces();
 }
+
+export async function pageHasReadRestrictions(
+  client: ConfluenceClient,
+  pageId: string
+) {
+  const pageReadRestrictions = await client.getPageReadRestrictions(pageId);
+
+  const hasGroupReadPermissions =
+    pageReadRestrictions.restrictions.group.results.length > 0;
+  const hasUserReadPermissions =
+    pageReadRestrictions.restrictions.user.results.length > 0;
+
+  return hasGroupReadPermissions || hasUserReadPermissions;
+}

--- a/connectors/src/connectors/confluence/lib/confluence_api.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_api.ts
@@ -74,7 +74,7 @@ export async function pageHasReadRestrictions(
   return hasGroupReadPermissions || hasUserReadPermissions;
 }
 
-export async function getActivityPageIds(
+export async function getActiveChildPageIds(
   client: ConfluenceClient,
   parentPageId: string,
   pageCursor?: string

--- a/connectors/src/connectors/confluence/lib/confluence_api.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_api.ts
@@ -73,3 +73,20 @@ export async function pageHasReadRestrictions(
 
   return hasGroupReadPermissions || hasUserReadPermissions;
 }
+
+export async function getActivityPageIds(
+  client: ConfluenceClient,
+  parentPageId: string,
+  pageCursor?: string
+) {
+  const { pages: childPages, nextPageCursor } = await client.getChildPages(
+    parentPageId,
+    pageCursor
+  );
+
+  const childPageIds = childPages
+    .filter((p) => p.status === "current")
+    .map((p) => p.id);
+
+  return { childPageIds, nextPageCursor };
+}

--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -312,12 +312,10 @@ export class ConfluenceClient {
   }
 
   async getPageReadRestrictions(pageId: string) {
-    const res = await this.request(
+    return this.request(
       `${this.legacyRestApiBaseUrl}/content/${pageId}/restriction/byOperation/read`,
       ConfluenceReadOperationRestrictionsCodec
     );
-
-    return res;
   }
 
   async getUserAccount() {

--- a/connectors/src/connectors/confluence/lib/permissions.ts
+++ b/connectors/src/connectors/confluence/lib/permissions.ts
@@ -191,7 +191,6 @@ export async function retrieveHierarchyForParent(
 ) {
   const { id: connectorId } = connector;
 
-  console.log(">> parentInternalId:", parentInternalId);
   if (parentInternalId) {
     if (isConfluenceInternalSpaceId(parentInternalId)) {
       const resources = await getSynchronizedSpaces(

--- a/connectors/src/connectors/confluence/lib/permissions.ts
+++ b/connectors/src/connectors/confluence/lib/permissions.ts
@@ -191,6 +191,7 @@ export async function retrieveHierarchyForParent(
 ) {
   const { id: connectorId } = connector;
 
+  console.log(">> parentInternalId:", parentInternalId);
   if (parentInternalId) {
     if (isConfluenceInternalSpaceId(parentInternalId)) {
       const resources = await getSynchronizedSpaces(

--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -4,7 +4,7 @@ import TurndownService from "turndown";
 
 import { confluenceConfig } from "@connectors/connectors/confluence/lib/config";
 import {
-  getActivityPageIds,
+  getActiveChildPageIds,
   pageHasReadRestrictions,
 } from "@connectors/connectors/confluence/lib/confluence_api";
 import type { ConfluencePageWithBodyType } from "@connectors/connectors/confluence/lib/confluence_client";
@@ -355,7 +355,7 @@ export async function confluenceGetActiveChildPageIdsActivity({
 
   localLogger.info("Fetching Confluence child pages in space.");
 
-  return getActivityPageIds(client, parentPageId, pageCursor);
+  return getActiveChildPageIds(client, parentPageId, pageCursor);
 }
 
 export async function confluenceGetRootPageIdActivity({
@@ -406,6 +406,7 @@ export async function confluenceGetTopLevelPageIdsActivity({
 }) {
   const localLogger = logger.child({
     connectorId,
+    rootPageId,
     spaceId,
   });
 
@@ -416,7 +417,7 @@ export async function confluenceGetTopLevelPageIdsActivity({
 
   localLogger.info("Fetching Confluence top-level page in space.");
 
-  const { childPageIds, nextPageCursor } = await getActivityPageIds(
+  const { childPageIds, nextPageCursor } = await getActiveChildPageIds(
     client,
     rootPageId
   );

--- a/connectors/src/connectors/confluence/temporal/utils.ts
+++ b/connectors/src/connectors/confluence/temporal/utils.ts
@@ -11,6 +11,13 @@ export function makeConfluenceSpaceSyncWorkflowIdFromParentId(
   return `${parentWorkflowId}-space-${spaceId}`;
 }
 
+export function makeConfluenceSyncTopLevelChildPagesWorkflowIdFromParentId(
+  parentWorkflowId: string,
+  topLevelPageId: string
+) {
+  return `${parentWorkflowId}-top-level-page-${topLevelPageId}`;
+}
+
 export function makeConfluenceRemoveSpacesWorkflowId(connectorId: ModelId) {
   return `confluence-remove-${connectorId}`;
 }


### PR DESCRIPTION
## Description

In our initial, simple approach to integrate Confluence, we overlooked the role of Confluence page restrictions in determining which pages should be imported into Dust. We assume that Confluence was used primarily for storing static data, which hasn't quite matched reality. Since we haven't provided admins the option to select specific Confluence pages for importation, our permission system appeared overly restrictive.

This PR refactors the synchronization workflow for a Confluence space. Rather than naively importing all pages in a flat structure, it adopts a DFS strategy, stopping to import child pages when it encounters a parent page with read restrictions (either group or users). This method kind of delegates the handling of permissions to Confluence, simplifying the process for us.

Confluence spaces are organized with a root page and multiple top-level pages, each of which can branch into many sub-pages. This new implementation is designed to navigate Temporal's limitations efficiently, initiating one workflow per space for synchronization and an additional workflow for each top-level page.
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
