### PR TITLE
feat: switch all notion conns to dual WF setup

### DIFF
--- a/connectors/migrations/20230505_add_notion_connector_state.ts
+++ b/connectors/migrations/20230505_add_notion_connector_state.ts
@@ -27,7 +27,10 @@ async function main() {
         console.log(
           `Creating NotionConnectorState for connector ${connector.id}...`
         );
-        await NotionConnectorState.create({ connectorId: connector.id });
+        await NotionConnectorState.create({
+          connectorId: connector.id,
+          useDualWorkflow: true,
+        });
       }
     }
   }

--- a/connectors/migrations/20240131_migrate_all_notion_connectors_to_dual_workflow.ts
+++ b/connectors/migrations/20240131_migrate_all_notion_connectors_to_dual_workflow.ts
@@ -1,0 +1,18 @@
+import { sequelize_conn } from "@connectors/lib/models";
+
+async function main() {
+  await sequelize_conn.query(`
+        UPDATE notion_connector_states SET "useDualWorkflow" = true;
+    `);
+}
+
+main()
+  .then(() => {
+    console.error("\x1b[32m%s\x1b[0m", `Done`);
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error("\x1b[31m%s\x1b[0m", `Error: ${err.message}`);
+    console.log(err);
+    process.exit(1);
+  });

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -70,6 +70,7 @@ export async function createNotionConnector(
       const connectorState = await NotionConnectorState.create(
         {
           connectorId: connector.id,
+          useDualWorkflow: true,
         },
         { transaction }
       );

--- a/connectors/src/lib/models/notion.ts
+++ b/connectors/src/lib/models/notion.ts
@@ -20,7 +20,7 @@ export class NotionConnectorState extends Model<
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
-  declare useDualWorkflow: CreationOptional<boolean>;
+  declare useDualWorkflow: boolean;
   declare fullResyncStartTime?: CreationOptional<Date>;
 
   declare lastGarbageCollectionFinishTime?: Date;
@@ -47,7 +47,6 @@ NotionConnectorState.init(
     useDualWorkflow: {
       type: DataTypes.BOOLEAN,
       allowNull: false,
-      defaultValue: false,
     },
     fullResyncStartTime: {
       type: DataTypes.DATE,


### PR DESCRIPTION
## Description

We have been experimenting with using 2 separate "infinite" workflows for notion connectors: one to handle the "live" incremental sync, and the other one to "garbage collect", i.e go through all pages using the search endpoint to find pages that have been deleted on the remote. We also use this opportunity to detect new pages that we don't have.

It has been running pretty smoothly for the workspaces that have it, so we're now rolling out to all workspaces.
 
## Risk

- more rate limit errors
- more pressure on DB
Should be fine though. Easy to revert as well.


## Deploy Plan

- initdb (small change in default value for `useDualWorkflow`).
- deploy code
- run migration file
- restart all notion workflows