### PR TITLE
:pig_nose: Temporary hack to process first root page.

### DIFF
--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -381,13 +381,14 @@ export async function confluenceGetRootPageIdActivity({
 
   const { pages: rootPages } = await client.getPagesInSpace(spaceId, "root");
   const [rootPage] = rootPages;
-
   if (!rootPage) {
     return undefined;
   }
 
+  // TODO(2024-01-31 flav) Find a better way to deal with spaces
+  // that have many root pages.
   if (rootPages.length > 1) {
-    throw new Error("Confluence workflow only support one root page.");
+    logger.error("Found Confluence space with many root pages.");
   }
 
   return rootPage.id;

--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -388,7 +388,9 @@ export async function confluenceGetRootPageIdActivity({
   // TODO(2024-01-31 flav) Find a better way to deal with spaces
   // that have many root pages.
   if (rootPages.length > 1) {
-    logger.error("Found Confluence space with many root pages.");
+    logger.error("Found Confluence space with many root pages.", {
+      rootPagesCount: rootPages.length,
+    });
   }
 
   return rootPage.id;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
In https://github.com/dust-tt/dust/pull/3520, we assumed that Confluence had only one root page... 🥁 the reality is that there is a hack to hide a page rather than use restrictions, one can move it to a root page from the settings.

This PR adds a temporary hack (until I fixed it tomorrow) to only consider the first retrieved root page.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
