### PR TITLE
Flav/add sparkle hoverable component

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.80",
+  "version": "0.2.81",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.80",
+      "version": "0.2.81",
       "license": "ISC",
       "dependencies": {
         "@headlessui/react": "^1.7.17"

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.80",
+  "version": "0.2.81",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/components/Hoverable.tsx
+++ b/sparkle/src/components/Hoverable.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { SyntheticEvent } from "react";
 import { ReactNode } from "react";
 
 import { classNames } from "@sparkle/lib/utils";
@@ -6,7 +6,7 @@ import { classNames } from "@sparkle/lib/utils";
 interface HoverableProps {
   children: ReactNode;
   className: string;
-  onClick: () => void;
+  onClick: (e: SyntheticEvent) => void;
 }
 
 export function Hoverable({ children, className, onClick }: HoverableProps) {

--- a/sparkle/src/components/Hoverable.tsx
+++ b/sparkle/src/components/Hoverable.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { ReactNode } from "react";
+
+import { classNames } from "@sparkle/lib/utils";
+
+interface HoverableProps {
+  children: ReactNode;
+  className: string;
+  onClick: () => void;
+}
+
+export function Hoverable({ children, className, onClick }: HoverableProps) {
+  return (
+    <span
+      className={classNames(
+        "s-cursor-pointer s-duration-300 hover:s-text-action-500 active:s-text-action-600",
+        className
+      )}
+      onClick={onClick}
+    >
+      {children}
+    </span>
+  );
+}

--- a/sparkle/src/components/Hoverable.tsx
+++ b/sparkle/src/components/Hoverable.tsx
@@ -9,6 +9,10 @@ interface HoverableProps {
   onClick: (e: SyntheticEvent) => void;
 }
 
+Hoverable.defaultProps = {
+  className: "",
+};
+
 export function Hoverable({ children, className, onClick }: HoverableProps) {
   return (
     <span

--- a/sparkle/src/stories/Hoverable.stories.tsx
+++ b/sparkle/src/stories/Hoverable.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta } from "@storybook/react";
+import React from "react";
+
+import { Hoverable } from "@sparkle/components/Hoverable";
+
+const meta = {
+  title: "Molecule/Hoverable",
+  component: Hoverable,
+} satisfies Meta<typeof Hoverable>;
+
+export default meta;
+
+export const HoverableExample = () => {
+  return (
+    <div className="items-start s-flex s-flex-col s-gap-10">
+      <div>
+        <Hoverable
+          onClick={() => {
+            alert("Clicked!");
+          }}
+        >
+          Coucou
+        </Hoverable>
+      </div>
+    </div>
+  );
+};

--- a/sparkle/src/stories/Hoverable.stories.tsx
+++ b/sparkle/src/stories/Hoverable.stories.tsx
@@ -19,7 +19,7 @@ export const HoverableExample = () => {
             alert("Clicked!");
           }}
         >
-          Coucou
+          You can hover me.
         </Hoverable>
       </div>
     </div>


### PR DESCRIPTION
## Description

Working on https://github.com/dust-tt/dust/issues/3262. We need an Hoverable component. This PR add a new component in Sparkle.

It looks like this (disclaimer the GIF does not capture the cursor):
![hoverableComponent](https://github.com/dust-tt/dust/assets/7428970/bb6eb471-fbae-4c54-94be-d457e5360ed8)

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
