### PR TITLE
Adding a #user-operation message for each managed Data Source created…

### DIFF
--- a/connectors/package-lock.json
+++ b/connectors/package-lock.json
@@ -75,7 +75,6 @@
       "name": "@dust-tt/types",
       "version": "0.1.0",
       "dependencies": {
-        "@slack/web-api": "^6.12.0",
         "dts-cli": "^2.0.3",
         "eslint-plugin-simple-import-sort": "^10.0.0",
         "eventsource-parser": "^1.1.1",

--- a/connectors/package-lock.json
+++ b/connectors/package-lock.json
@@ -75,6 +75,7 @@
       "name": "@dust-tt/types",
       "version": "0.1.0",
       "dependencies": {
+        "@slack/web-api": "^6.12.0",
         "dts-cli": "^2.0.3",
         "eslint-plugin-simple-import-sort": "^10.0.0",
         "eventsource-parser": "^1.1.1",

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/update.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/update.ts
@@ -1,5 +1,5 @@
 import type { WithAPIErrorReponse } from "@dust-tt/types";
-import { ConnectorsAPI } from "@dust-tt/types";
+import { ConnectorsAPI, sendUserOperationMessage } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
@@ -102,6 +102,15 @@ async function handler(
         params: {
           connectionId,
         },
+      });
+
+      void sendUserOperationMessage({
+        logger: logger,
+        message: `${
+          auth.user()?.email || "unknown user"
+        } updated the data source \`${dataSource.name}\`  for workspace \`${
+          owner.name
+        }\` sId: \`${owner.sId}\` connectorId: \`${dataSource.connectorId}\``,
       });
 
       if (updateRes.isErr()) {

--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_PAID_QDRANT_CLUSTER,
   EMBEDDING_CONFIG,
   isConnectorProvider,
+  sendUserOperationMessage,
 } from "@dust-tt/types";
 import { dustManagedCredentials } from "@dust-tt/types";
 import { ConnectorsAPI } from "@dust-tt/types";
@@ -382,6 +383,16 @@ async function handler(
           },
         });
       }
+      void sendUserOperationMessage({
+        logger,
+        message: `${
+          auth.user()?.email || "unknown user"
+        } created Data Source \`${dataSource.name}\`  for workspace \`${
+          owner.name
+        }\` sId: \`${owner.sId}\` connectorId: \`${
+          connectorsRes.value.id
+        }\` provider: \`${provider}\``,
+      });
 
       dataSource = await dataSource.update({
         connectorId: connectorsRes.value.id,

--- a/types/src/index.ts
+++ b/types/src/index.ts
@@ -48,6 +48,7 @@ export * from "./shared/cache";
 export * from "./shared/model_id";
 export * from "./shared/nango_errors";
 export * from "./shared/rate_limiter";
+export * from "./shared/user_operation";
 export * from "./shared/utils/assert_never";
 export * from "./shared/utils/global_error_handler";
 export * from "./shared/utils/hashing";

--- a/types/src/shared/user_operation.ts
+++ b/types/src/shared/user_operation.ts
@@ -1,0 +1,48 @@
+import { LoggerInterface } from "./logger";
+
+export async function sendUserOperationMessage({
+  message,
+  logger,
+}: {
+  message: string;
+  logger: LoggerInterface;
+}) {
+  const { SLACK_USER_OPERATION_BOT_TOKEN, SLACK_USER_OPERATION_CHANNEL_ID } =
+    process.env;
+
+  if (!SLACK_USER_OPERATION_BOT_TOKEN || !SLACK_USER_OPERATION_CHANNEL_ID) {
+    console.log(
+      "SLACK_USER_OPERATION_BOT_TOKEN or SLACK_USER_OPERATION_CHANNEL_ID is not set"
+    );
+    return;
+  }
+
+  try {
+    const res = await fetch("https://slack.com/api/chat.postMessage", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${SLACK_USER_OPERATION_BOT_TOKEN}`,
+      },
+      body: JSON.stringify({
+        channel: SLACK_USER_OPERATION_CHANNEL_ID,
+        text: message,
+      }),
+    });
+
+    const jsonRes = await res.json();
+    if (!jsonRes.ok) {
+      logger.error(
+        { error: jsonRes.error },
+        "Failed to send slack message to user operation channel (1)."
+      );
+    }
+
+    // Log the result
+  } catch (error) {
+    logger.error(
+      { error: error },
+      "Failed to send slack message to user operation channel (2)."
+    );
+  }
+}

--- a/types/src/shared/user_operation.ts
+++ b/types/src/shared/user_operation.ts
@@ -11,7 +11,8 @@ export async function sendUserOperationMessage({
     process.env;
 
   if (!SLACK_USER_OPERATION_BOT_TOKEN || !SLACK_USER_OPERATION_CHANNEL_ID) {
-    console.log(
+    logger.info(
+      {},
       "SLACK_USER_OPERATION_BOT_TOKEN or SLACK_USER_OPERATION_CHANNEL_ID is not set"
     );
     return;


### PR DESCRIPTION
# Description

Adding a #user-operation message for each managed Data Source created or updated.
The goal is to add visibility to the life of managed data sources as we often have issue where our users modified something on the connector side and we spend a lot of time tracking that down.

This is a "best effort" posting to Slack, as we don't want to rely on the Slack API for the creation of all managed Data Sources.





![Screenshot 2024-02-01 at 13 09 09](https://github.com/dust-tt/dust/assets/358965/8d29abfc-2ab3-4309-99ec-156fb56ac816)



<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Set the two var envs to front and deploy front:
```
SLACK_USER_OPERATION_BOT_TOKEN
SLACK_USER_OPERATION_CHANNEL_ID
```

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
