### PR TITLE
Display assistant detail in conversation view

### DIFF
--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -42,43 +42,63 @@ import type { PostAgentListStatusRequestBody } from "@app/pages/api/w/[wId]/memb
 
 type AssistantDetailsFlow = "personal" | "workspace";
 
-export function AssistantDetails({
-  owner,
-  assistant,
-  show,
-  onClose,
-  flow,
-}: {
+type AssistantDetailsProps = {
   owner: WorkspaceType;
-  assistant: LightAgentConfigurationType;
   show: boolean;
   onClose: () => void;
   flow: AssistantDetailsFlow;
-}) {
+} & (
+  | { assistantSId: string; assistant?: never }
+  | { assistant: LightAgentConfigurationType; assistantSId?: never }
+);
+
+export function AssistantDetails({
+  assistant,
+  assistantSId,
+  flow,
+  onClose,
+  owner,
+  show,
+}: AssistantDetailsProps) {
+  const assistantId = assistantSId ?? assistant.sId;
+
   const agentUsage = useAgentUsage({
     workspaceId: owner.sId,
-    agentConfigurationId: assistant.sId,
+    agentConfigurationId: assistantId,
   });
-  const detailedConfig = useAgentConfiguration({
+  const { agentConfiguration } = useAgentConfiguration({
     workspaceId: owner.sId,
-    agentConfigurationId: assistant.sId,
+    agentConfigurationId: assistantId,
   });
+
+  const { mutateAgentConfigurations } = useAgentConfigurations({
+    workspaceId: owner.sId,
+    agentsGetView: "list",
+    includes: ["authors"],
+  });
+
+  const effectiveAssistant = assistant ?? agentConfiguration;
+  if (!effectiveAssistant) {
+    return <></>;
+  }
 
   const DescriptionSection = () => (
     <div className="flex flex-col gap-4 sm:flex-row">
       <Avatar
-        visual={<img src={assistant.pictureUrl} alt="Assistant avatar" />}
+        visual={
+          <img src={effectiveAssistant.pictureUrl} alt="Assistant avatar" />
+        }
         size="md"
       />
-      <div>{assistant.description}</div>
+      <div>{effectiveAssistant.description}</div>
     </div>
   );
 
   const InstructionsSection = () =>
-    assistant.generation?.prompt ? (
+    effectiveAssistant.generation?.prompt ? (
       <div className="flex flex-col gap-2">
         <div className="text-lg font-bold text-element-800">Instructions</div>
-        <ReactMarkdown>{assistant.generation.prompt}</ReactMarkdown>
+        <ReactMarkdown>{effectiveAssistant.generation.prompt}</ReactMarkdown>
       </div>
     ) : (
       "This assistant has no instructions."
@@ -125,16 +145,10 @@ export function AssistantDetails({
       ) : null
     ) : null;
 
-  const { mutateAgentConfigurations } = useAgentConfigurations({
-    workspaceId: owner.sId,
-    agentsGetView: "list",
-    includes: ["authors"],
-  });
-
   return (
     <Modal
       isOpen={show}
-      title={`@${assistant.name}`}
+      title={`@${effectiveAssistant.name}`}
       onClose={onClose}
       hasChanged={false}
       variant="side-sm"
@@ -142,7 +156,7 @@ export function AssistantDetails({
       <div className="flex flex-col gap-5 pt-6 text-sm text-element-700">
         <ButtonsSection
           owner={owner}
-          agentConfiguration={assistant}
+          agentConfiguration={effectiveAssistant}
           detailsModalClose={onClose}
           onUpdate={mutateAgentConfigurations}
           onClose={onClose}
@@ -155,9 +169,7 @@ export function AssistantDetails({
           isLoading={agentUsage.isAgentUsageLoading}
           isError={agentUsage.isAgentUsageError}
         />
-        <ActionSection
-          action={detailedConfig.agentConfiguration?.action || null}
-        />
+        <ActionSection action={agentConfiguration?.action || null} />
       </div>
     </Modal>
   );

--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -60,6 +60,7 @@ export function AssistantDetails({
   owner,
   show,
 }: AssistantDetailsProps) {
+  // TODO(2024-02-01 flav) Remove `assistant` once all the call sites have been refactored.
   const assistantId = assistantSId ?? assistant.sId;
 
   const agentUsage = useAgentUsage({

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -39,6 +39,7 @@ import {
 import { RenderMessageMarkdown } from "@app/components/assistant/RenderMessageMarkdown";
 import { useEventSource } from "@app/hooks/useEventSource";
 import { useSubmitFunction } from "@app/lib/client/utils";
+import { isDevelopmentOrDustWorkspace } from "@app/lib/development";
 
 function cleanUpCitations(message: string): string {
   const regex = / ?:cite\[[a-zA-Z0-9, ]+\]/g;
@@ -327,11 +328,17 @@ export function AgentMessage({
       avatarBusy={agentMessageToRender.status === "created"}
       reactions={reactions}
       enableEmojis={true}
-      renderName={() => (
-        <div className="text-sm font-medium">
-          {AssitantDetailViewLink(agentMessageToRender.configuration)}
-        </div>
-      )}
+      renderName={() => {
+        return isDevelopmentOrDustWorkspace(owner) ? (
+          <div className="text-sm font-medium">
+            {AssitantDetailViewLink(agentMessageToRender.configuration)}
+          </div>
+        ) : (
+          <div className="text-sm font-medium">
+            {agentMessageToRender.configuration.name}
+          </div>
+        );
+      }}
     >
       <div ref={messageRef}>
         {renderMessage(agentMessageToRender, references, shouldStream)}

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -17,12 +17,15 @@ import type {
   AgentGenerationSuccessEvent,
   AgentMessageSuccessEvent,
   GenerationTokensEvent,
+  LightAgentConfigurationType,
   UserType,
   WorkspaceType,
 } from "@dust-tt/types";
 import type { RetrievalDocumentType } from "@dust-tt/types";
 import type { AgentMessageType, MessageReactionType } from "@dust-tt/types";
 import { assertNever, isRetrievalActionType } from "@dust-tt/types";
+import Link from "next/link";
+import { useRouter } from "next/router";
 import { useCallback, useContext, useEffect, useRef, useState } from "react";
 
 import { AgentAction } from "@app/components/assistant/conversation/AgentAction";
@@ -294,6 +297,24 @@ export function AgentMessage({
     }
   }, [agentMessageToRender.action]);
 
+  function AssitantDetailViewLink(assistant: LightAgentConfigurationType) {
+    const router = useRouter();
+    const href = {
+      pathname: router.pathname,
+      query: { ...router.query, assistantDetails: assistant.sId },
+    };
+
+    return (
+      <Link
+        href={href}
+        shallow
+        className="cursor-pointer duration-300 hover:text-action-500 active:text-action-600"
+      >
+        {assistant.name}
+      </Link>
+    );
+  }
+
   return (
     <ConversationMessage
       owner={owner}
@@ -306,6 +327,11 @@ export function AgentMessage({
       avatarBusy={agentMessageToRender.status === "created"}
       reactions={reactions}
       enableEmojis={true}
+      renderName={() => (
+        <div className="text-sm font-medium">
+          {AssitantDetailViewLink(agentMessageToRender.configuration)}
+        </div>
+      )}
     >
       <div ref={messageRef}>
         {renderMessage(agentMessageToRender, references, shouldStream)}

--- a/front/components/assistant/conversation/ConversationMessage.tsx
+++ b/front/components/assistant/conversation/ConversationMessage.tsx
@@ -79,6 +79,12 @@ export function EmojiSelector({
  * Parent component for both UserMessage and AgentMessage, to ensure avatar,
  * side buttons and spacing are consistent between the two
  */
+
+ConversationMessage.defaultProps = {
+  avatarBusy: false,
+  enableEmojis: true,
+};
+
 export function ConversationMessage({
   owner,
   user,
@@ -89,9 +95,9 @@ export function ConversationMessage({
   pictureUrl,
   buttons,
   reactions,
-  avatarBusy = false,
-  // avatarBackgroundColor,
-  enableEmojis = true,
+  avatarBusy,
+  enableEmojis,
+  renderName,
 }: {
   owner: WorkspaceType;
   user: UserType;
@@ -108,8 +114,8 @@ export function ConversationMessage({
   }[];
   reactions: MessageReactionType[];
   avatarBusy?: boolean;
-  avatarBackgroundColor?: string;
   enableEmojis: boolean;
+  renderName: (name: string | null) => React.ReactNode;
 }) {
   const [emojiData, setEmojiData] = useState<EmojiMartData | null>(null);
 
@@ -189,7 +195,7 @@ export function ConversationMessage({
                 className=""
               />
             </div>
-            <div className="text-sm font-medium">{name}</div>
+            {renderName(name)}
           </div>
           <div className="min-w-0 break-words pl-8 text-base font-normal sm:p-0">
             {children}
@@ -263,7 +269,6 @@ export function ConversationMessage({
     </>
   );
 }
-
 interface ButtonEmojiProps {
   variant?: "selected" | "unselected";
   count?: string;

--- a/front/components/assistant/conversation/UserMessage.tsx
+++ b/front/components/assistant/conversation/UserMessage.tsx
@@ -38,6 +38,7 @@ export function UserMessage({
       name={message.context.fullName}
       reactions={reactions}
       enableEmojis={true}
+      renderName={(name) => <div className="text-sm font-medium">{name}</div>}
     >
       <div className="flex flex-col gap-4">
         <div>


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR partially addresses the features listed in https://github.com/dust-tt/dust/issues/3262 by implementing functionality that allows users to click on an assistant's name to access its detailed view, utilizing Next.JS's router. The choice of Next.JS router is based on several advantages:
- Avoid the needs to instantiate AssistantDetails in many places.
- It supports accessing the Assistant Details from various locations within the conversation view by simply adding `assistantDetails=<assistant.sId>`.
- Next.JS efficiently prefetches links during server-side rendering, significantly speeding up load times.

This comes with some modifications, primarily in the `AssistantDetails` component that while we improve our overall layout (group all the conversations pages under the same layout) needs to support either an assistant sId or an assistant.

![assistantDetailView](https://github.com/dust-tt/dust/assets/7428970/391461de-0887-4eb0-9442-76ce26e159f9)

## Risk

Tested on front-edge but it remains pretty slow, to limit the blast-radius we gate this change for the Dust team only until we can check if it runs smoothly in production.

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Follow up action items:
- remove the double args for `AssistantDetails`
- remove isDust gate after a day of testing

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
