### PR TITLE
refactor handling of notion DBs

### DIFF
--- a/connectors/src/connectors/notion/temporal/config.ts
+++ b/connectors/src/connectors/notion/temporal/config.ts
@@ -1,2 +1,2 @@
-export const WORKFLOW_VERSION = 28;
+export const WORKFLOW_VERSION = 29;
 export const QUEUE_NAME = `notion-queue-v${WORKFLOW_VERSION}`;


### PR DESCRIPTION
## Description

- removes some code duplication between `fetchDatabaseChildPages` and `cacheDatabaseChildren` -> now a single entrypoint with more options
- make `renderChildDatabaseFromPages` more flexible (ability to render as CSV, which is groundwork for structured data connector)


## Risk

blast radius whole notion connector

## Deploy Plan

Workflow change + queue bump -> requires a restart of notion WFs