### PR TITLE
Add Intercom Team model

### DIFF
--- a/connectors/src/admin/db.ts
+++ b/connectors/src/admin/db.ts
@@ -25,6 +25,7 @@ import {
   IntercomArticle,
   IntercomCollection,
   IntercomHelpCenter,
+  IntercomTeam,
 } from "@connectors/lib/models/intercom";
 import {
   NotionConnectorBlockCacheEntry,
@@ -76,6 +77,7 @@ async function main(): Promise<void> {
   await IntercomHelpCenter.sync({ alter: true });
   await IntercomCollection.sync({ alter: true });
   await IntercomArticle.sync({ alter: true });
+  await IntercomTeam.sync({ alter: true });
   await WebCrawlerConfiguration.sync({ alter: true });
   await WebCrawlerFolder.sync({ alter: true });
   await WebCrawlerPage.sync({ alter: true });

--- a/connectors/src/lib/models/intercom.ts
+++ b/connectors/src/lib/models/intercom.ts
@@ -342,8 +342,6 @@ IntercomTeam.init(
         unique: true,
         name: "intercom_connector_team_idx",
       },
-      { fields: ["connectorId"] },
-      { fields: ["teamId"] },
     ],
     modelName: "intercom_teams",
   }

--- a/connectors/src/lib/models/intercom.ts
+++ b/connectors/src/lib/models/intercom.ts
@@ -282,3 +282,70 @@ IntercomArticle.init(
   }
 );
 Connector.hasMany(IntercomArticle);
+
+export class IntercomTeam extends Model<
+  InferAttributes<IntercomTeam>,
+  InferCreationAttributes<IntercomTeam>
+> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare teamId: string;
+  declare name: string;
+
+  declare lastUpsertedTs?: Date;
+  declare permission: "read" | "none";
+
+  declare connectorId: ForeignKey<Connector["id"]>;
+}
+
+IntercomTeam.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    teamId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    name: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    lastUpsertedTs: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    },
+    permission: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+  },
+  {
+    sequelize: sequelize_conn,
+    indexes: [
+      {
+        fields: ["connectorId", "teamId"],
+        unique: true,
+        name: "intercom_connector_team_idx",
+      },
+      { fields: ["connectorId"] },
+      { fields: ["teamId"] },
+    ],
+    modelName: "intercom_teams",
+  }
+);
+Connector.hasMany(IntercomTeam);


### PR DESCRIPTION
## Description

Conversation on Intercom can be attached to "Teams" which are basically folders for conversations. 
For the sync of conversations, we will allow admins to select for which Team they want to sync the conversations.
Hence, we need a new `IntercomTeam` model.

## Risk

The model is unused yet, I'm separating the PR creating the model and using it. 

## Deploy Plan

Run init_db on connector db. 
