### PR TITLE
Intercom: Get/Set permissions to sync Teams for conversations

### DIFF
--- a/connectors/src/connectors/intercom/lib/conversation_permissions.ts
+++ b/connectors/src/connectors/intercom/lib/conversation_permissions.ts
@@ -1,0 +1,144 @@
+import type { ConnectorResource } from "@dust-tt/types";
+import type { Client as IntercomClient } from "intercom-client";
+
+import {
+  fetchIntercomTeam,
+  fetchIntercomTeams,
+  getIntercomClient,
+} from "@connectors/connectors/intercom/lib/intercom_api";
+import { getTeamInternalId } from "@connectors/connectors/intercom/lib/utils";
+import type { ConnectorPermissionRetriever } from "@connectors/connectors/interface";
+import { Connector } from "@connectors/lib/models";
+import { IntercomTeam } from "@connectors/lib/models/intercom";
+import logger from "@connectors/logger/logger";
+
+export async function allowSyncTeam({
+  connector,
+  intercomClient,
+  teamId,
+}: {
+  connector: Connector;
+  intercomClient: IntercomClient;
+  teamId: string;
+}): Promise<IntercomTeam> {
+  let team = await IntercomTeam.findOne({
+    where: {
+      connectorId: connector.id,
+      teamId: teamId,
+    },
+  });
+  if (team?.permission === "none") {
+    await team.update({
+      permission: "read",
+    });
+  }
+  if (!team) {
+    const teamOnIntercom = await fetchIntercomTeam(intercomClient, teamId);
+    if (teamOnIntercom) {
+      team = await IntercomTeam.create({
+        connectorId: connector.id,
+        teamId: teamOnIntercom.id,
+        name: teamOnIntercom.name,
+        permission: "read",
+      });
+    }
+  }
+
+  if (!team) {
+    logger.error(
+      { connector, teamId },
+      "[Intercom] Failed to sync team. Team not found."
+    );
+    throw new Error("Team not found.");
+  }
+
+  return team;
+}
+
+export async function revokeSyncTeam({
+  connector,
+  teamId,
+}: {
+  connector: Connector;
+  teamId: string;
+}): Promise<IntercomTeam | null> {
+  const team = await IntercomTeam.findOne({
+    where: {
+      connectorId: connector.id,
+      teamId: teamId,
+    },
+  });
+  if (team?.permission === "read") {
+    await team.update({
+      permission: "none",
+    });
+  }
+  return team;
+}
+
+export async function retrieveIntercomConversationsPermissions({
+  connectorId,
+  parentInternalId,
+  filterPermission,
+}: Parameters<ConnectorPermissionRetriever>[0]): Promise<ConnectorResource[]> {
+  const connector = await Connector.findByPk(connectorId);
+  if (!connector) {
+    logger.error({ connectorId }, "[Intercom] Connector not found.");
+    throw new Error("Connector not found");
+  }
+
+  const intercomClient = await getIntercomClient(connector.connectionId);
+  const isReadPermissionsOnly = filterPermission === "read";
+  const isRootLevel = !parentInternalId;
+  let resources: ConnectorResource[] = [];
+
+  // If Root level we retrieve the list of Help Centers.
+  // If isReadPermissionsOnly = true, we retrieve the list of Teams from DB that have permission = "read"
+  // If isReadPermissionsOnly = false, we retrieve the list of Teams from Intercom
+  if (isRootLevel) {
+    const teamsFromDb = await IntercomTeam.findAll({
+      where: {
+        connectorId: connectorId,
+        permission: "read",
+      },
+    });
+
+    if (isReadPermissionsOnly) {
+      resources = teamsFromDb.map((team) => ({
+        provider: connector.type,
+        internalId: getTeamInternalId(connectorId, team.teamId),
+        parentInternalId: null,
+        type: "channel",
+        title: team.name,
+        sourceUrl: null,
+        expandable: false,
+        permission: team.permission,
+        dustDocumentId: null,
+        lastUpdatedAt: null,
+      }));
+    } else {
+      const teams = await fetchIntercomTeams(intercomClient);
+      resources = teams.map((team) => {
+        const isTeamInDb = teamsFromDb.some((teamFromDb) => {
+          return teamFromDb.teamId === team.id;
+        });
+        return {
+          provider: connector.type,
+          internalId: getTeamInternalId(connectorId, team.id),
+          parentInternalId: null,
+          type: "channel",
+          title: team.name,
+          sourceUrl: null,
+          expandable: false,
+          permission: isTeamInDb ? "read" : "none",
+          dustDocumentId: null,
+          lastUpdatedAt: null,
+        };
+      });
+    }
+    resources.sort((a, b) => {
+      return a.title.localeCompare(b.title);
+    });
+  }
+  return resources;
+}

--- a/connectors/src/connectors/intercom/lib/help_center_permissions.ts
+++ b/connectors/src/connectors/intercom/lib/help_center_permissions.ts
@@ -112,7 +112,6 @@ export async function revokeSyncHelpCenter({
   helpCenterId,
 }: {
   connector: Connector;
-  intercomClient: IntercomClient;
   helpCenterId: string;
 }): Promise<IntercomHelpCenter | null> {
   const helpCenter = await IntercomHelpCenter.findOne({

--- a/connectors/src/connectors/intercom/lib/intercom_api.ts
+++ b/connectors/src/connectors/intercom/lib/intercom_api.ts
@@ -1,4 +1,8 @@
-import type { ArticleObject, CollectionObject } from "intercom-client";
+import type {
+  ArticleObject,
+  CollectionObject,
+  TeamObject,
+} from "intercom-client";
 import { Client } from "intercom-client";
 
 import { HTTPError } from "@connectors/lib/error";
@@ -270,4 +274,27 @@ export async function fetchIntercomArticle(
     }
     throw error;
   }
+}
+
+/**
+ * Return the list of Teams.
+ */
+export async function fetchIntercomTeams(
+  intercomClient: Client
+): Promise<TeamObject[]> {
+  const teamsResponse = await intercomClient.teams.list();
+  return teamsResponse.teams ?? [];
+}
+
+/**
+ * Return the detail of a Team.
+ */
+export async function fetchIntercomTeam(
+  intercomClient: Client,
+  teamId: string
+): Promise<TeamObject | null> {
+  const teamsResponse = await intercomClient.teams.find({
+    id: teamId,
+  });
+  return teamsResponse ?? null;
 }

--- a/connectors/src/connectors/intercom/lib/utils.ts
+++ b/connectors/src/connectors/intercom/lib/utils.ts
@@ -1,55 +1,60 @@
 import type { ModelId } from "@dust-tt/types";
 
+/**
+ * From id to internalId
+ */
 export function getHelpCenterInternalId(
   connectorId: ModelId,
   helpCenterId: string
 ): string {
-  return `intercom-${connectorId}-help-center-${helpCenterId}`;
+  return `intercom-help-center-${connectorId}-${helpCenterId}`;
 }
-
 export function getHelpCenterCollectionInternalId(
   connectorId: ModelId,
   collectionId: string
 ): string {
-  return `intercom-${connectorId}-collection-${collectionId}`;
+  return `intercom-collection-${connectorId}-${collectionId}`;
 }
-
 export function getHelpCenterArticleInternalId(
   connectorId: ModelId,
   articleId: string
 ): string {
-  return `intercom-${connectorId}-article-${articleId}`;
+  return `intercom-article-${connectorId}-${articleId}`;
+}
+export function getTeamInternalId(
+  connectorId: ModelId,
+  teamId: string
+): string {
+  return `intercom-team-${connectorId}-${teamId}`;
 }
 
+/**
+ * From internalId to id
+ */
+function _getIdFromInternal(internalId: string, prefix: string): string | null {
+  return internalId.startsWith(prefix) ? internalId.replace(prefix, "") : null;
+}
 export function getHelpCenterIdFromInternalId(
   connectorId: ModelId,
   internalId: string
 ): string | null {
-  const prefix = `intercom-${connectorId}-help-center-`;
-  if (!internalId.startsWith(prefix)) {
-    return null;
-  }
-  return internalId.replace(prefix, "");
+  return _getIdFromInternal(internalId, `intercom-help-center-${connectorId}-`);
 }
-
 export function getHelpCenterCollectionIdFromInternalId(
   connectorId: ModelId,
   internalId: string
 ): string | null {
-  const prefix = `intercom-${connectorId}-collection-`;
-  if (!internalId.startsWith(prefix)) {
-    return null;
-  }
-  return internalId.replace(prefix, "");
+  return _getIdFromInternal(internalId, `intercom-collection-${connectorId}-`);
 }
-
 export function getHelpCenterArticleIdFromInternalId(
   connectorId: ModelId,
   internalId: string
 ): string | null {
-  const prefix = `intercom-${connectorId}-article-`;
-  if (!internalId.startsWith(prefix)) {
-    return null;
-  }
-  return internalId.replace(prefix, "");
+  return _getIdFromInternal(internalId, `intercom-article-${connectorId}-`);
+}
+export function getTeamIdFromInternalId(
+  connectorId: ModelId,
+  internalId: string
+): string | null {
+  return _getIdFromInternal(internalId, `intercom-team-${connectorId}-`);
 }


### PR DESCRIPTION
## Description

This PR is about editing the Intercom connector to manage permissions regarding Conversations.
We had two choices: syncing all convo or giving the admin some kind of granularity. Intercom convos can be stored in Teams, which are basically folders of conversations. In my experience and from the feedback we had from design partners, they all use Teams to manage conversations. 

I kept it flat, on the permission modal we display the Help Centers and below the Intercom Teams.
<img width="706" alt="Screenshot 2024-02-01 at 17 39 10" src="https://github.com/dust-tt/dust/assets/3803406/51e359d8-ef90-4a41-aa1d-459997c789fa">


Next step is working on the workflow to sync the conversations that belongs in a Team for which we have a read permission (and remove those for which we don't have permission anymore). 


## Risk

Feature is still under a feature flag so no big risk about this. 

## Deploy Plan

Nothing special. 
