### PR TITLE
notion: attempt relaunch workflows on connector update

### DIFF
--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -164,6 +164,24 @@ export async function updateNotionConnector(
         "Error deleting old Nango connection"
       );
     });
+
+    const dataSourceConfig = dataSourceConfigFromConnector(c);
+    try {
+      await launchNotionSyncWorkflow(c.id);
+    } catch (e) {
+      logger.error(
+        {
+          workspaceId: dataSourceConfig.workspaceId,
+          dataSourceName: dataSourceConfig.dataSourceName,
+          error: e,
+        },
+        "Error launching notion sync workflow post update."
+      );
+      return new Err({
+        type: "connector_update_error",
+        message: "Error restarting sync workflow after updating connector",
+      });
+    }
   }
 
   return new Ok(c.id.toString());


### PR DESCRIPTION
## Description

When a Notion connection is disabled we generally pause the workflows. This enables restarting them automatically if the user reconnects a token.

## Risk

N/A

## Deploy Plan

- deploy `connector`