### PR TITLE
tables query action: fix chip

### DIFF
--- a/front/components/assistant/conversation/TablesQueryAction.tsx
+++ b/front/components/assistant/conversation/TablesQueryAction.tsx
@@ -131,17 +131,19 @@ export default function TablesQueryAction({
                 setIsOutputExpanded(!isOutputExpanded);
               }}
             >
-              <Chip color="purple">
-                {query ? query : "No query generated"}
-                {(noQuery || results) && (
-                  <Icon
-                    visual={
-                      isOutputExpanded ? ChevronDownIcon : ChevronRightIcon
-                    }
-                    size="xs"
-                  />
-                )}
-              </Chip>
+              <Tooltip label={query ? query : "No query generated"}>
+                <Chip color="purple">
+                  {query ? trimText(query) : "No query generated"}
+                  {(noQuery || results) && (
+                    <Icon
+                      visual={
+                        isOutputExpanded ? ChevronDownIcon : ChevronRightIcon
+                      }
+                      size="xs"
+                    />
+                  )}
+                </Chip>
+              </Tooltip>
             </div>
           </div>
           {isOutputExpanded && (


### PR DESCRIPTION
## Description

The chip containing the SQL query often overflows and it's sore for the eyes in demo:

![Screenshot from 2024-02-02 01-53-37](https://github.com/dust-tt/dust/assets/15067/38fc20c6-e77d-4aca-bd70-cabb213bc0d0)

Instead trim the SQL query and make it accessible through a ToolTip. The query is also accessible in the output of the action.

## Risk

N/A

## Deploy Plan

- deploy `front`