### PR TITLE
front: fix new animation + focus

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -2,20 +2,13 @@ import { Button, Citation, StopIcon } from "@dust-tt/sparkle";
 import type { WorkspaceType } from "@dust-tt/types";
 import type { LightAgentConfigurationType } from "@dust-tt/types";
 import type { AgentMention, MentionType } from "@dust-tt/types";
-import {
-  createContext,
-  Fragment,
-  useContext,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { useContext, useEffect, useMemo, useRef, useState } from "react";
 import { mutate } from "swr";
 
 import { GenerationContext } from "@app/components/assistant/conversation/GenerationContextProvider";
 import type { InputBarContainerProps } from "@app/components/assistant/conversation/input_bar/InputBarContainer";
 import InputBarContainer from "@app/components/assistant/conversation/input_bar/InputBarContainer";
+import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { compareAgentsForSort } from "@app/lib/assistant";
 import { handleFileUploadToText } from "@app/lib/client/handle_file_upload";
@@ -324,11 +317,3 @@ export function FixedAssistantInputBar({
     </div>
   );
 }
-
-export const InputBarContext = createContext<{
-  animate: boolean;
-  selectedAssistant: AgentMention | null;
-}>({
-  animate: false,
-  selectedAssistant: null,
-});

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -83,18 +83,10 @@ export function AssistantInputBar({
   const [isAnimating, setIsAnimating] = useState<boolean>(false);
   const { animate, selectedAssistant } = useContext(InputBarContext);
   useEffect(() => {
-    let timeoutId: NodeJS.Timeout;
     if (animate && !isAnimating) {
       setIsAnimating(true);
-      timeoutId = setTimeout(() => setIsAnimating(false), 1500);
+      setTimeout(() => setIsAnimating(false), 1500);
     }
-
-    // Cleanup function to clear the timeout
-    return () => {
-      if (timeoutId) {
-        clearTimeout(timeoutId);
-      }
-    };
   }, [animate, isAnimating]);
 
   const activeAgents = agentConfigurations.filter((a) => a.status === "active");
@@ -236,9 +228,7 @@ export function AssistantInputBar({
               "relative flex w-full flex-1 flex-col items-stretch gap-0 self-stretch pl-4 sm:flex-row",
               "border-struture-200 border-t bg-white/80 shadow-[0_0_36px_-15px_rgba(0,0,0,0.3)] backdrop-blur focus-within:border-structure-300 sm:rounded-3xl sm:border-2 sm:border-element-500 sm:shadow-[0_12px_36px_-15px_rgba(0,0,0,0.3)] sm:focus-within:border-element-600",
               "transition-all duration-300",
-              isAnimating
-                ? "animate-shake border-action-500 focus-within:border-action-800"
-                : ""
+              isAnimating ? "animate-shake" : ""
             )}
           >
             <div className="relative flex w-full flex-1 flex-col">

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -8,6 +8,7 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import { mutate } from "swr";
@@ -82,6 +83,35 @@ export function AssistantInputBar({
 
   const [isAnimating, setIsAnimating] = useState<boolean>(false);
   const { animate, selectedAssistant } = useContext(InputBarContext);
+  const animationTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  useEffect(() => {
+    if (animate && !isAnimating) {
+      setIsAnimating(true);
+
+      // Clear any existing timeout to ensure animations do not overlap.
+      if (animationTimeoutRef.current) {
+        clearTimeout(animationTimeoutRef.current);
+      }
+
+      // Set timeout to set setIsAnimating to false after the duration.
+      animationTimeoutRef.current = setTimeout(() => {
+        setIsAnimating(false);
+        // Reset the ref after the timeout clears.
+        animationTimeoutRef.current = null;
+      }, 700);
+    }
+  }, [animate, isAnimating]);
+
+  // Cleanup timeout on component unmount.
+  useEffect(() => {
+    return () => {
+      if (animationTimeoutRef.current) {
+        clearTimeout(animationTimeoutRef.current);
+      }
+    };
+  }, []);
+
   useEffect(() => {
     if (animate && !isAnimating) {
       setIsAnimating(true);

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -19,9 +19,9 @@ import useAssistantSuggestions from "@app/components/assistant/conversation/inpu
 import type { CustomEditorProps } from "@app/components/assistant/conversation/input_bar/editor/useCustomEditor";
 import useCustomEditor from "@app/components/assistant/conversation/input_bar/editor/useCustomEditor";
 import useHandleMentions from "@app/components/assistant/conversation/input_bar/editor/useHandleMentions";
+import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import { classNames } from "@app/lib/utils";
 
-import { InputBarContext } from "./InputBar";
 
 export interface InputBarContainerProps {
   allAssistants: LightAgentConfigurationType[];

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -12,7 +12,7 @@ import type {
   WorkspaceType,
 } from "@dust-tt/types";
 import { EditorContent } from "@tiptap/react";
-import React, { useRef, useState } from "react";
+import React, { useContext, useEffect, useRef, useState } from "react";
 
 import { AssistantPicker } from "@app/components/assistant/AssistantPicker";
 import useAssistantSuggestions from "@app/components/assistant/conversation/input_bar/editor/useAssistantSuggestions";
@@ -20,6 +20,8 @@ import type { CustomEditorProps } from "@app/components/assistant/conversation/i
 import useCustomEditor from "@app/components/assistant/conversation/input_bar/editor/useCustomEditor";
 import useHandleMentions from "@app/components/assistant/conversation/input_bar/editor/useHandleMentions";
 import { classNames } from "@app/lib/utils";
+
+import { InputBarContext } from "./InputBar";
 
 export interface InputBarContainerProps {
   allAssistants: LightAgentConfigurationType[];
@@ -61,6 +63,15 @@ const InputBarContainer = ({
     onEnterKeyDown,
     resetEditorContainerSize,
   });
+
+  // When input bar animation is requested it means the new button was clicked (removing focus from
+  // the input bar), we grab it back.
+  const { animate } = useContext(InputBarContext);
+  useEffect(() => {
+    if (animate) {
+      editorService.focusEnd();
+    }
+  }, [animate, editorService]);
 
   useHandleMentions(
     editorService,

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -22,7 +22,6 @@ import useHandleMentions from "@app/components/assistant/conversation/input_bar/
 import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import { classNames } from "@app/lib/utils";
 
-
 export interface InputBarContainerProps {
   allAssistants: LightAgentConfigurationType[];
   agentConfigurations: LightAgentConfigurationType[];

--- a/front/components/assistant/conversation/input_bar/InputBarContext.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContext.tsx
@@ -1,0 +1,10 @@
+import type { AgentMention } from "@dust-tt/types";
+import { createContext } from "react";
+
+export const InputBarContext = createContext<{
+  animate: boolean;
+  selectedAssistant: AgentMention | null;
+}>({
+  animate: false,
+  selectedAssistant: null,
+});

--- a/front/pages/w/[wId]/assistant/new.tsx
+++ b/front/pages/w/[wId]/assistant/new.tsx
@@ -27,10 +27,8 @@ import { useContext, useEffect, useState } from "react";
 import { AssistantDetails } from "@app/components/assistant/AssistantDetails";
 import Conversation from "@app/components/assistant/conversation/Conversation";
 import { GenerationContextProvider } from "@app/components/assistant/conversation/GenerationContextProvider";
-import {
-  FixedAssistantInputBar,
-  InputBarContext,
-} from "@app/components/assistant/conversation/input_bar/InputBar";
+import { FixedAssistantInputBar } from "@app/components/assistant/conversation/input_bar/InputBar";
+import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import { createConversationWithMessage } from "@app/components/assistant/conversation/lib";
 import { AssistantSidebarMenu } from "@app/components/assistant/conversation/SidebarMenu";
 import AppLayout from "@app/components/sparkle/AppLayout";


### PR DESCRIPTION
## Description

Animation was broken if clicked multiple time because setAnimating was never set back to false (the clean-up would be executed as animate was set back I believe) + we were not setting the focus on the Input bar anymore meaning that clicking multiple times on new would loose focus on the input bar.

This PR fixes these 2 issues.

## Risk

N/A

## Deploy Plan

- deploy `front`