### PR TITLE
feat: add CLI to stop all notion GCs

### DIFF
--- a/connectors/src/connectors/notion/temporal/client.ts
+++ b/connectors/src/connectors/notion/temporal/client.ts
@@ -193,7 +193,7 @@ export async function stopNotionSyncWorkflow(
   }
 }
 
-async function stopNotionGarbageCollectorWorkflow(
+export async function stopNotionGarbageCollectorWorkflow(
   connectorId: string
 ): Promise<void> {
   const connector = await Connector.findByPk(connectorId);


### PR DESCRIPTION
## Description

perpetual GC-ing seems to be the root cause of a rapidly growing WAL archive on our postgres master. 
Stopping all GC workflows for 30 minutes will allow confirming this hypothesis

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
