### PR TITLE
Add Slack rate limiter

### DIFF
--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -11,7 +11,7 @@ import type {
   AgentGenerationSuccessEvent,
   PublicPostContentFragmentRequestBodySchema,
 } from "@dust-tt/types";
-import { RateLimitError, sectionFullText } from "@dust-tt/types";
+import { sectionFullText } from "@dust-tt/types";
 import { DustAPI } from "@dust-tt/types";
 import type { WebClient } from "@slack/web-api";
 import type { MessageElement } from "@slack/web-api/dist/response/ConversationsHistoryResponse";
@@ -91,7 +91,6 @@ export async function botAnswerMessageWithErrorHandling(
     return new Ok(undefined);
   }
 
-  // Apply rate limit here!
   try {
     const res = await botAnswerMessage(
       message,

--- a/connectors/src/connectors/slack/lib/workspace_rate_limit.ts
+++ b/connectors/src/connectors/slack/lib/workspace_rate_limit.ts
@@ -1,0 +1,159 @@
+import type { ModelId, Result } from "@dust-tt/types";
+import {
+  cacheWithRedis,
+  DustAPI,
+  Err,
+  Ok,
+  RateLimitError,
+} from "@dust-tt/types";
+
+import { getSlackClient } from "@connectors/connectors/slack/lib/slack_client";
+import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
+import {
+  addEntityToRateLimiter,
+  isEntityRateLimited,
+} from "@connectors/lib/entity_rate_limiter";
+import type { Connector } from "@connectors/lib/models";
+import { redisClient } from "@connectors/lib/redis";
+import logger from "@connectors/logger/logger";
+
+export async function safeRedisClient<T>(
+  fn: (client: Awaited<ReturnType<typeof redisClient>>) => PromiseLike<T>
+): Promise<T> {
+  const client = await redisClient();
+  try {
+    return await fn(client);
+  } finally {
+    await client.quit();
+  }
+}
+
+async function getActiveMembersCount(connector: Connector): Promise<number> {
+  const ds = dataSourceConfigFromConnector(connector);
+
+  // The number of active members in the workspace.
+  const dustAPI = new DustAPI(
+    {
+      apiKey: ds.workspaceAPIKey,
+      workspaceId: ds.workspaceId,
+    },
+    logger,
+    { useLocalInDev: true }
+  );
+
+  const membersRes = await dustAPI.getAllMembersInWorkspace();
+  if (membersRes.isErr()) {
+    logger.error("Error getting all members in workspace.", {
+      error: membersRes.error,
+    });
+
+    throw new Error("Error getting all members in workspace.");
+  }
+
+  return membersRes.value.length;
+}
+
+function makeSlackRateLimiterForConnectoreKey(connectorId: ModelId): string {
+  return `slack-rate-limiter-connector-${connectorId}`;
+}
+
+export const getActiveMembersCountMemoized = cacheWithRedis(
+  getActiveMembersCount,
+  (connector: Connector) => {
+    return `active-members-connector-${connector.id}`;
+  },
+  // Caches data for 15 minutes to limit frequent fetches.
+  // Note: Updates (e.g., new seats added by an admin) may take up to 15 minutes to be reflected.
+  15 * 10 * 1000
+);
+
+async function postWorkspaceRateLimitedMessage(
+  connector: Connector,
+  {
+    slackChannel,
+    slackMessageTs,
+    maxAllowed,
+  }: { slackChannel: string; slackMessageTs: string; maxAllowed: number }
+) {
+  const slackClient = await getSlackClient(connector.id);
+  await slackClient.chat.postMessage({
+    channel: slackChannel,
+    blocks: [
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: `Your Slack integration is limited to the number of active members in your workspace, which is currently ${maxAllowed} users. To allow more users to access the app, please increase your active member count.`,
+        },
+      },
+      {
+        type: "actions",
+        elements: [
+          {
+            type: "button",
+            text: {
+              type: "plain_text",
+              text: "Add More Seats",
+              emoji: true,
+            },
+            style: "primary",
+            value: "add_more_seats_cta",
+            action_id: "actionId-0",
+            url: `https://dust.tt/w/${connector.workspaceId}/members`,
+          },
+        ],
+      },
+    ],
+    thread_ts: slackMessageTs,
+  });
+}
+
+export async function notifyIfUserRateLimited(
+  connector: Connector,
+  {
+    slackUserId,
+    slackChannel,
+    slackMessageTs,
+  }: { slackUserId: string; slackChannel: string; slackMessageTs: string }
+): Promise<boolean> {
+  const maxAllowed = 1;
+  await getActiveMembersCountMemoized(connector);
+  const connectorRateLimiterKey = makeSlackRateLimiterForConnectoreKey(
+    connector.id
+  );
+  const rateLimiterOptions = {
+    key: connectorRateLimiterKey,
+    windowSizeInSeconds: 86400, // 24 hours.
+    maxAllowed,
+  };
+
+  return safeRedisClient(async (redis) => {
+    const isRateLimited = await isEntityRateLimited(slackUserId, {
+      redis,
+      ...rateLimiterOptions,
+    });
+
+    if (isRateLimited) {
+      await postWorkspaceRateLimitedMessage(connector, {
+        slackChannel,
+        slackMessageTs,
+        maxAllowed,
+      });
+
+      logger.error("Workspace rate limited.", {
+        maxAllowed,
+        connectorId: connector.id,
+        slackUserId,
+      });
+
+      return true;
+    } else {
+      await addEntityToRateLimiter(slackUserId, {
+        redis,
+        ...rateLimiterOptions,
+      });
+
+      return false;
+    }
+  });
+}

--- a/connectors/src/connectors/slack/lib/workspace_rate_limit.ts
+++ b/connectors/src/connectors/slack/lib/workspace_rate_limit.ts
@@ -1,11 +1,5 @@
-import type { ModelId, Result } from "@dust-tt/types";
-import {
-  cacheWithRedis,
-  DustAPI,
-  Err,
-  Ok,
-  RateLimitError,
-} from "@dust-tt/types";
+import type { ModelId } from "@dust-tt/types";
+import { cacheWithRedis, DustAPI } from "@dust-tt/types";
 
 import { getSlackClient } from "@connectors/connectors/slack/lib/slack_client";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
@@ -41,16 +35,16 @@ async function getActiveMembersCount(connector: Connector): Promise<number> {
     { useLocalInDev: true }
   );
 
-  const membersRes = await dustAPI.getActiveMembersCountInWorkspace();
-  if (membersRes.isErr()) {
+  const activeMembersRes = await dustAPI.getActiveMembersCountInWorkspace();
+  if (activeMembersRes.isErr()) {
     logger.error("Error getting all members in workspace.", {
-      error: membersRes.error,
+      error: activeMembersRes.error,
     });
 
     throw new Error("Error getting all members in workspace.");
   }
 
-  return membersRes.value;
+  return activeMembersRes.value;
 }
 
 function makeSlackRateLimiterForConnectorKey(connectorId: ModelId): string {

--- a/connectors/src/lib/entity_rate_limiter.ts
+++ b/connectors/src/lib/entity_rate_limiter.ts
@@ -1,0 +1,38 @@
+import type { redisClient } from "@connectors/lib/redis";
+
+export interface EntityRateLimiterOptions {
+  redis: Awaited<ReturnType<typeof redisClient>>;
+  key: string;
+  windowSizeInSeconds: number;
+  maxAllowed: number;
+}
+
+export async function isEntityRateLimited(
+  entity: string,
+  { redis, key, windowSizeInSeconds, maxAllowed }: EntityRateLimiterOptions
+) {
+  const currentTime = Math.floor(new Date().getTime() / 1000);
+  const windowStart = currentTime - windowSizeInSeconds;
+
+  const recentEntities = await redis.zRange(key, windowStart, currentTime, {
+    BY: "SCORE",
+  });
+
+  const entityAlreadyIncluded = recentEntities.includes(entity);
+  const hasReachedMaximumAllowed = recentEntities.length >= maxAllowed;
+
+  return hasReachedMaximumAllowed && !entityAlreadyIncluded;
+}
+
+export async function addEntityToRateLimiter(
+  entity: string,
+  { redis, key, windowSizeInSeconds }: EntityRateLimiterOptions
+): Promise<void> {
+  const currentTime = Math.floor(new Date().getTime() / 1000);
+  const windowStart = currentTime - windowSizeInSeconds;
+
+  await redis.zAdd(key, [{ value: entity, score: currentTime }]);
+
+  // Remove old entries outside of the current window.
+  await redis.zRemRangeByScore(key, -Infinity, windowStart.toString());
+}

--- a/front/pages/api/v1/w/[wId]/members.ts
+++ b/front/pages/api/v1/w/[wId]/members.ts
@@ -1,0 +1,58 @@
+import type {
+  DataSourceType,
+  UserTypeWithWorkspaces,
+  WithAPIErrorReponse,
+} from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { getMembers } from "@app/lib/api/workspace";
+import { Authenticator, getAPIKey } from "@app/lib/auth";
+import { apiError, withLogging } from "@app/logger/withlogging";
+
+export type GetMembersResponseBody = {
+  members: UserTypeWithWorkspaces[];
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorReponse<GetMembersResponseBody>>
+): Promise<void> {
+  const keyRes = await getAPIKey(req);
+  if (keyRes.isErr()) {
+    return apiError(req, res, keyRes.error);
+  }
+  const { auth } = await Authenticator.fromKey(
+    keyRes.value,
+    req.query.wId as string
+  );
+
+  const owner = auth.workspace();
+  if (!owner) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "The workspace was not found.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET":
+      const members = await getMembers(auth);
+
+      res.status(200).json({ members });
+      return;
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withLogging(handler);

--- a/front/pages/api/v1/w/[wId]/members/count.ts
+++ b/front/pages/api/v1/w/[wId]/members/count.ts
@@ -1,21 +1,17 @@
-import type {
-  DataSourceType,
-  UserTypeWithWorkspaces,
-  WithAPIErrorReponse,
-} from "@dust-tt/types";
+import type { WithAPIErrorReponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { getMembers } from "@app/lib/api/workspace";
+import { getMembersCount } from "@app/lib/api/workspace";
 import { Authenticator, getAPIKey } from "@app/lib/auth";
 import { apiError, withLogging } from "@app/logger/withlogging";
 
-export type GetMembersResponseBody = {
-  members: UserTypeWithWorkspaces[];
+export type GetMembersCountResponseBody = {
+  membersCount: number;
 };
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<GetMembersResponseBody>>
+  res: NextApiResponse<WithAPIErrorReponse<GetMembersCountResponseBody>>
 ): Promise<void> {
   const keyRes = await getAPIKey(req);
   if (keyRes.isErr()) {
@@ -37,11 +33,15 @@ async function handler(
     });
   }
 
+  const { activeOnly } = req.query;
+
   switch (req.method) {
     case "GET":
-      const members = await getMembers(auth);
+      const membersCount = await getMembersCount(auth, {
+        activeOnly: Boolean(activeOnly),
+      });
 
-      res.status(200).json({ members });
+      res.status(200).json({ membersCount });
       return;
 
     default:

--- a/front/pages/api/v1/w/[wId]/members/count.ts
+++ b/front/pages/api/v1/w/[wId]/members/count.ts
@@ -23,7 +23,8 @@ async function handler(
   );
 
   const owner = auth.workspace();
-  if (!owner) {
+  const isSystemKey = keyRes.value.isSystem;
+  if (!owner || !isSystemKey) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {

--- a/types/src/front/lib/dust_api.ts
+++ b/types/src/front/lib/dust_api.ts
@@ -729,8 +729,8 @@ export class DustAPI {
     return new Ok(r.value.tokens);
   }
 
-  async getAllMembersInWorkspace() {
-    const endpoint = `${this.apiUrl()}/api/v1/w/${this.workspaceId()}/members`;
+  async getActiveMembersCountInWorkspace() {
+    const endpoint = `${this.apiUrl()}/api/v1/w/${this.workspaceId()}/members/count?activeOnly=true`;
 
     const res = await fetch(endpoint, {
       method: "GET",
@@ -740,12 +740,13 @@ export class DustAPI {
       },
     });
 
-    const r: DustAPIResponse<{ members: unknown[] }> =
+    const r: DustAPIResponse<{ membersCount: number }> =
       await this._resultFromResponse(res);
     if (r.isErr()) {
       return r;
     }
-    return new Ok(r.value.members);
+
+    return new Ok(r.value.membersCount);
   }
 
   private async _resultFromResponse<T>(

--- a/types/src/front/lib/dust_api.ts
+++ b/types/src/front/lib/dust_api.ts
@@ -729,6 +729,25 @@ export class DustAPI {
     return new Ok(r.value.tokens);
   }
 
+  async getAllMembersInWorkspace() {
+    const endpoint = `${this.apiUrl()}/api/v1/w/${this.workspaceId()}/members`;
+
+    const res = await fetch(endpoint, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${this._credentials.apiKey}`,
+      },
+    });
+
+    const r: DustAPIResponse<{ members: unknown[] }> =
+      await this._resultFromResponse(res);
+    if (r.isErr()) {
+      return r;
+    }
+    return new Ok(r.value.members);
+  }
+
   private async _resultFromResponse<T>(
     response: Response
   ): Promise<DustAPIResponse<T>> {


### PR DESCRIPTION
## Description

See https://github.com/dust-tt/decisions/issues/153.

This PR introduces a rate limiter for our Slackbot, restricting the number of unique Slack users that can interact with it within a 24-hour sliding window to the total of active members in a Dust workspace. This means in a workspace with two users (A and B), Slack users A and C could access the Slackbot. However, if B tries to access it afterwards, they’d be prompted to add more users to their Dust workspace. This limitation operates on a rolling 24-hour period.

Key updates in this PR include:
- Introducing a "generic" entity rate limiter.
  - Simple implementation that  uses a Redis sorted set where the entity id is stored alongside the current time as its score. For managing the 24-hour sliding window, we use [zrange](https://redis.io/commands/zrange/) to fetch all entity ids between two scores (lower bound being 24 hours ago and upper bound being the current moment). With each new entity action recorded, we also try to clean up any old keys that are no longer within the score range with [zremrangebyscore](https://redis.io/commands/zremrangebyscore/).
- Expose the count of active users through the front API. While okay-ish for an initial version, we might want to consider using a read replica for the front to manage such cases in the future. For now, we're caching these results for 15 minutes.
- Returning a slack message to upsell workspaces that have hit the rate limit.

<img width="396" alt="image" src="https://github.com/dust-tt/dust/assets/7428970/a36447ce-4ac8-43a4-8cb5-15a6c63e3dd4">

## Risk

Pretty risky, tested locally with many users and mocking the maximum number of active users. Safe to rollback.
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Given the dependency on the Front api to get the count of active members within the workspace, we need to first deploy front and then deploy connectors.

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
