### PR TITLE
front: fix client-side errors on selected refresh/pages

### DIFF
--- a/front/components/sparkle/navigation.tsx
+++ b/front/components/sparkle/navigation.tsx
@@ -19,7 +19,6 @@ import { isAdmin, isBuilder, isUser } from "@dust-tt/types";
 import { UsersIcon } from "@heroicons/react/20/solid";
 
 import { isDevelopmentOrDustWorkspace } from "@app/lib/development";
-import { useFeatures } from "@app/lib/swr";
 
 /**
  * NavigationIds are typed ids we use to identify which navigation item is currently active. We need
@@ -124,18 +123,17 @@ export const subNavigationBuild = ({
   current,
   subMenuLabel,
   subMenu,
+  crawlerEnabled,
 }: {
   owner: WorkspaceType;
   current: SubNavigationAssistantsId;
   subMenuLabel?: string;
   subMenu?: SparkleAppLayoutNavigation[];
+  crawlerEnabled?: boolean;
 }) => {
   const nav: SidebarNavigation[] = [];
 
   const assistantMenus: SparkleAppLayoutNavigation[] = [];
-
-  const { features } = useFeatures(owner);
-  const crawlerEnabled = features?.includes("crawler");
 
   assistantMenus.push({
     id: "workspace_assistants",

--- a/front/pages/w/[wId]/a/index.tsx
+++ b/front/pages/w/[wId]/a/index.tsx
@@ -27,7 +27,7 @@ import { getApps } from "@app/lib/api/app";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { modelProviders, serviceProviders } from "@app/lib/providers";
-import { useKeys, useProviders } from "@app/lib/swr";
+import { useFeatures, useKeys, useProviders } from "@app/lib/swr";
 import { classNames, timeAgoFrom } from "@app/lib/utils";
 import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
 
@@ -460,6 +460,7 @@ export default function Developers({
   gaTrackingId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const router = useRouter();
+  const { features } = useFeatures(owner);
 
   return (
     <AppLayout
@@ -467,7 +468,11 @@ export default function Developers({
       owner={owner}
       gaTrackingId={gaTrackingId}
       topNavigationCurrent="assistants"
-      subNavigation={subNavigationBuild({ owner, current: "developers" })}
+      subNavigation={subNavigationBuild({
+        owner,
+        current: "developers",
+        crawlerEnabled: features?.includes("crawler"),
+      })}
     >
       <Page.Vertical gap="xl" align="stretch">
         <Page.Header

--- a/front/pages/w/[wId]/builder/assistants/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/index.tsx
@@ -35,7 +35,7 @@ import AppLayout from "@app/components/sparkle/AppLayout";
 import { subNavigationBuild } from "@app/components/sparkle/navigation";
 import { compareAgentsForSort } from "@app/lib/assistant";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { useAgentConfigurations } from "@app/lib/swr";
+import { useAgentConfigurations, useFeatures } from "@app/lib/swr";
 import { subFilter } from "@app/lib/utils";
 import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
 
@@ -139,6 +139,8 @@ export default function WorkspaceAssistants({
   const [showRemoveFromWorkspaceModal, setShowRemoveFromWorkspaceModal] =
     useState<LightAgentConfigurationType | null>(null);
 
+  const { features } = useFeatures(owner);
+
   return (
     <AppLayout
       subscription={subscription}
@@ -148,6 +150,7 @@ export default function WorkspaceAssistants({
       subNavigation={subNavigationBuild({
         owner,
         current: "workspace_assistants",
+        crawlerEnabled: features?.includes("crawler"),
       })}
     >
       {showDeletionModal && (

--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -34,10 +34,10 @@ import { buildConnectionId } from "@app/lib/connector_connection_id";
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 import { isDevelopmentOrDustWorkspace } from "@app/lib/development";
 import { githubAuth } from "@app/lib/github_auth";
+import { useFeatures } from "@app/lib/swr";
 import { timeAgoFrom } from "@app/lib/utils";
 import logger from "@app/logger/logger";
 import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
-import { useFeatures } from "@app/lib/swr";
 
 const {
   GA_TRACKING_ID = "",

--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -37,6 +37,7 @@ import { githubAuth } from "@app/lib/github_auth";
 import { timeAgoFrom } from "@app/lib/utils";
 import logger from "@app/logger/logger";
 import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
+import { useFeatures } from "@app/lib/swr";
 
 const {
   GA_TRACKING_ID = "",
@@ -255,6 +256,7 @@ function ConfirmationModal({
   onConfirm: () => void;
 }) {
   const [isLoading, setIsLoading] = useState(false);
+
   return (
     <Modal
       isOpen={show}
@@ -476,6 +478,8 @@ export default function DataSourcesView({
 
   const router = useRouter();
 
+  const { features } = useFeatures(owner);
+
   return (
     <AppLayout
       subscription={subscription}
@@ -485,6 +489,7 @@ export default function DataSourcesView({
       subNavigation={subNavigationBuild({
         owner,
         current: "data_sources_managed",
+        crawlerEnabled: features?.includes("crawler"),
       })}
     >
       {showConfirmConnection && (

--- a/front/pages/w/[wId]/builder/data-sources/public-urls.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/public-urls.tsx
@@ -103,6 +103,7 @@ export default function DataSourcesView({
       subNavigation={subNavigationBuild({
         owner,
         current: "data_sources_url",
+        crawlerEnabled: true,
       })}
     >
       <Page.Vertical gap="xl" align="stretch">

--- a/front/pages/w/[wId]/builder/data-sources/static.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/static.tsx
@@ -20,8 +20,8 @@ import { subNavigationBuild } from "@app/components/sparkle/navigation";
 import { getDataSources } from "@app/lib/api/data_sources";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { useSubmitFunction } from "@app/lib/client/utils";
-import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
 import { useFeatures } from "@app/lib/swr";
+import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
 
 const { GA_TRACKING_ID = "" } = process.env;
 

--- a/front/pages/w/[wId]/builder/data-sources/static.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/static.tsx
@@ -21,6 +21,7 @@ import { getDataSources } from "@app/lib/api/data_sources";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
+import { useFeatures } from "@app/lib/swr";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
@@ -92,6 +93,8 @@ export default function DataSourcesView({
     }
   });
 
+  const { features } = useFeatures(owner);
+
   return (
     <AppLayout
       subscription={subscription}
@@ -101,6 +104,7 @@ export default function DataSourcesView({
       subNavigation={subNavigationBuild({
         owner,
         current: "data_sources_static",
+        crawlerEnabled: features?.includes("crawler"),
       })}
     >
       <Page.Vertical gap="xl" align="stretch">


### PR DESCRIPTION
## Description

useFeature was called inside `subNavigationBuild` which is not a component but a simple function leading to errors in the rendering of some pages (one reproducible case was to refresh the Dust assistant page, it would lead to a client-side exception in a repeatable way).

Move useFeatures outside of that function.

## Risk

N/A

## Deploy Plan

- deploy `front`