### PR TITLE
enh: remove uses of global mutate

### DIFF
--- a/front/components/assistant/conversation/ConversationMessage.tsx
+++ b/front/components/assistant/conversation/ConversationMessage.tsx
@@ -7,7 +7,7 @@ import Picker from "@emoji-mart/react";
 import type { ComponentType, MouseEventHandler } from "react";
 import { useEffect, useRef, useState } from "react";
 import React from "react";
-import { mutate } from "swr";
+import { useSWRConfig } from "swr";
 
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { classNames } from "@app/lib/utils";
@@ -117,6 +117,8 @@ export function ConversationMessage({
   enableEmojis: boolean;
   renderName: (name: string | null) => React.ReactNode;
 }) {
+  const { mutate } = useSWRConfig();
+
   const [emojiData, setEmojiData] = useState<EmojiMartData | null>(null);
 
   useEffect(() => {

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -3,7 +3,7 @@ import type { WorkspaceType } from "@dust-tt/types";
 import type { LightAgentConfigurationType } from "@dust-tt/types";
 import type { AgentMention, MentionType } from "@dust-tt/types";
 import { useContext, useEffect, useMemo, useRef, useState } from "react";
-import { mutate } from "swr";
+import { useSWRConfig } from "swr";
 
 import { GenerationContext } from "@app/components/assistant/conversation/GenerationContextProvider";
 import type { InputBarContainerProps } from "@app/components/assistant/conversation/input_bar/InputBarContainer";
@@ -51,6 +51,8 @@ export function AssistantInputBar({
   stickyMentions?: AgentMention[];
   additionalAgentConfigurations?: LightAgentConfigurationType[];
 }) {
+  const { mutate } = useSWRConfig();
+
   const [contentFragmentBody, setContentFragmentBody] = useState<
     string | undefined
   >(undefined);

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -41,7 +41,7 @@ import type { ReactNode } from "react";
 import { useCallback, useEffect, useState } from "react";
 import React from "react";
 import ReactTextareaAutosize from "react-textarea-autosize";
-import { mutate } from "swr";
+import { useSWRConfig } from "swr";
 
 import { DeleteAssistantDialog } from "@app/components/assistant/AssistantActions";
 import { AvatarPicker } from "@app/components/assistant_builder/AssistantBuilderAvatarPicker";
@@ -201,6 +201,8 @@ export default function AssistantBuilder({
   defaultIsEdited,
 }: AssistantBuilderProps) {
   const router = useRouter();
+  const { mutate } = useSWRConfig();
+
   const sendNotification = React.useContext(SendNotificationsContext);
   const slackDataSource = dataSources.find(
     (ds) => ds.connectorProvider === "slack"

--- a/front/pages/poke/[wId]/index.tsx
+++ b/front/pages/poke/[wId]/index.tsx
@@ -23,7 +23,7 @@ import type { InferGetServerSidePropsType } from "next";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import React, { useContext } from "react";
-import { mutate } from "swr";
+import { useSWRConfig } from "swr";
 
 import PokeNavbar from "@app/components/poke/PokeNavbar";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
@@ -106,6 +106,8 @@ const WorkspacePage = ({
   whitelistableFeatures,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
   const router = useRouter();
+  const { mutate } = useSWRConfig();
+
   const sendNotification = useContext(SendNotificationsContext);
   const [isLoading, setIsLoading] = React.useState<boolean>(false);
 

--- a/front/pages/w/[wId]/builder/data-sources/[name]/tables/upsert.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/tables/upsert.tsx
@@ -13,7 +13,7 @@ import { Err, Ok } from "@dust-tt/types";
 import type { InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 import { useContext, useEffect, useRef, useState } from "react";
-import { mutate } from "swr";
+import { useSWRConfig } from "swr";
 
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleSaveCancelTitle } from "@app/components/sparkle/AppLayoutTitle";
@@ -89,6 +89,8 @@ export default function TableUpsert({
   gaTrackingId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const router = useRouter();
+  const { mutate } = useSWRConfig();
+
   const sendNotification = useContext(SendNotificationsContext);
   const fileInputRef = useRef<HTMLInputElement>(null);
 


### PR DESCRIPTION
## Description

We should avoid global mutate whenever possible (eg. not compatible with custom caches)

## Risk

N/A

## Deploy Plan

- deploy `front`