### PR TITLE
front: show blinking token as soon as action is succeeded

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -127,6 +127,10 @@ export function AgentMessage({
     const event = eventPayload.data;
     switch (event.type) {
       case "agent_action_success":
+        setStreamedAgentMessage((m) => {
+          return { ...m, action: event.action, content: "" };
+        });
+        break;
       case "retrieval_params":
       case "dust_app_run_params":
       case "dust_app_run_block":
@@ -393,22 +397,30 @@ export function AgentMessage({
     return (
       <>
         {agentMessage.action && <AgentAction action={agentMessage.action} />}
-        {agentMessage.content && agentMessage.content !== "" && (
+        {agentMessage.content !== null && (
           <div>
-            <RenderMessageMarkdown
-              content={agentMessage.content}
-              blinkingCursor={streaming}
-              citationsContext={{
-                references,
-                updateActiveReferences,
-                setHoveredReference: setLastHoveredReference,
-              }}
-            />
-            {activeReferences.length > 0 && (
-              <Citations
-                activeReferences={activeReferences}
-                lastHoveredReference={lastHoveredReference}
-              />
+            {agentMessage.content === "" ? (
+              <div className="blinking-cursor">
+                <span></span>
+              </div>
+            ) : (
+              <>
+                <RenderMessageMarkdown
+                  content={agentMessage.content}
+                  blinkingCursor={streaming}
+                  citationsContext={{
+                    references,
+                    updateActiveReferences,
+                    setHoveredReference: setLastHoveredReference,
+                  }}
+                />
+                {activeReferences.length > 0 && (
+                  <Citations
+                    activeReferences={activeReferences}
+                    lastHoveredReference={lastHoveredReference}
+                  />
+                )}
+              </>
             )}
           </div>
         )}


### PR DESCRIPTION
## Description

We didn't show anything between the completion of the action and the first token generated. This PR shows the blinking cursor during that time frame that can be non-negligibly long.

## Risk

N/A

## Deploy Plan

- deploy `front`