### PR TITLE
GitHub: resource parents retrieval

### DIFF
--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -5,7 +5,12 @@ import {
   getReposPage,
   validateInstallationId,
 } from "@connectors/connectors/github/lib/github_api";
+import { getGithubCodeOrDirectoryParentIds } from "@connectors/connectors/github/lib/hierarchy";
 import { launchGithubFullSyncWorkflow } from "@connectors/connectors/github/temporal/client";
+import type {
+  ConnectorConfigGetter,
+  ConnectorPermissionRetriever,
+} from "@connectors/connectors/interface";
 import { Connector, sequelize_conn } from "@connectors/lib/models";
 import {
   GithubCodeDirectory,
@@ -23,12 +28,6 @@ import type {
   ConnectorPermission,
   ConnectorResource,
 } from "@connectors/types/resources";
-
-import type {
-  ConnectorConfigGetter,
-  ConnectorPermissionRetriever,
-} from "../interface";
-import { getGithubCodeOrDirectoryParentIds } from "./lib/hierarchy";
 
 type GithubInstallationId = string;
 

--- a/connectors/src/connectors/github/lib/hierarchy.ts
+++ b/connectors/src/connectors/github/lib/hierarchy.ts
@@ -1,0 +1,80 @@
+import type { ModelId } from "@dust-tt/types";
+
+import {
+  GithubCodeDirectory,
+  GithubCodeFile,
+} from "@connectors/lib/models/github";
+
+export async function getGithubCodeOrDirectoryParentIds(
+  connectorId: ModelId,
+  internalId: string,
+  repoId: number
+): Promise<string[]> {
+  if (internalId.startsWith(`github-code-${repoId}-dir`)) {
+    return getGithubCodeDirectoryParentIds(connectorId, internalId, repoId);
+  }
+  if (internalId.startsWith(`github-code-${repoId}-file`)) {
+    return getGithubCodeFileParentIds(connectorId, internalId, repoId);
+  }
+  return [];
+}
+
+async function getGithubCodeDirectoryParentIds(
+  connectorId: ModelId,
+  internalId: string,
+  repoId: number
+): Promise<string[]> {
+  const directory = await GithubCodeDirectory.findOne({
+    where: {
+      connectorId,
+      internalId,
+    },
+  });
+
+  if (!directory) {
+    return [];
+  }
+
+  if (directory.parentInternalId.startsWith(`github-code-${repoId}-dir`)) {
+    // Pull the directory.
+    const parents = await getGithubCodeDirectoryParentIds(
+      connectorId,
+      directory.parentInternalId,
+      repoId
+    );
+    return [...parents, directory.parentInternalId];
+  } else if (directory.parentInternalId === `github-code-${repoId}`) {
+    return [`${repoId}`, `github-code-${repoId}`];
+  }
+  return [];
+}
+
+async function getGithubCodeFileParentIds(
+  connectorId: ModelId,
+  internalId: string,
+  repoId: number
+): Promise<string[]> {
+  const file = await GithubCodeFile.findOne({
+    where: {
+      connectorId,
+      documentId: internalId,
+    },
+  });
+
+  if (!file) {
+    return [];
+  }
+
+  if (file.parentInternalId.startsWith(`github-code-${repoId}-dir`)) {
+    // Pull the directory.
+    const parents = await getGithubCodeDirectoryParentIds(
+      connectorId,
+      file.parentInternalId,
+      repoId
+    );
+    return [...parents, file.parentInternalId];
+  } else if (file.parentInternalId === `github-code-${repoId}`) {
+    return [`${repoId}`, `github-code-${repoId}`];
+  }
+  return [];
+}

--- a/connectors/src/connectors/index.ts
+++ b/connectors/src/connectors/index.ts
@@ -20,6 +20,7 @@ import {
   resumeGithubConnector,
   retrieveGithubConnectorPermissions,
   retrieveGithubReposTitles,
+  retrieveGithubResourceParents,
   setGithubConfig,
   stopGithubConnector,
   updateGithubConnector,
@@ -261,7 +262,7 @@ export const RETRIEVE_RESOURCE_PARENTS_BY_TYPE: Record<
   notion: retrieveNotionResourceParents,
   google_drive: retrieveGoogleDriveObjectsParents,
   slack: async () => new Ok([]), // Slack is flat
-  github: async () => new Ok([]), // Github is flat,
+  github: retrieveGithubResourceParents,
   intercom: retrieveIntercomObjectsParents,
   webcrawler: retrieveWebCrawlerObjectsParents,
 };

--- a/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
+++ b/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
@@ -277,11 +277,11 @@ function DataSourceResourceSelector({
           <div className="flex flex-row gap-32">
             <div className="flex-1">
               <div className="flex gap-4 pb-8 text-lg font-semibold text-element-900">
-                Select all:{" "}
+                Select all
                 <SliderToggle
                   selected={isSelectAll}
                   onClick={toggleSelectAll}
-                  size="sm"
+                  size="xs"
                 />
               </div>
               <div className="flex flex-row pb-4 text-lg font-semibold text-element-900">


### PR DESCRIPTION
## Description

Fixes #3425 

- Adds support for `RETRIEVE_RESOURCE_PARENTS_BY_TYPE` for Github (which is not flat anymore).
- Moves to use a `concurrentExecutor` vs Promise.all to parallelize parent retrieval (avoid N >> 1 SQL work)
- UI nit (select All toggle was too big)

## Risk

N/A

## Deploy Plan

- deploy `connectors`  `front`