### PR TITLE
Remove isDevelopmentOrDustWorkspace for AgentMessage

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -40,7 +40,6 @@ import {
 import { RenderMessageMarkdown } from "@app/components/assistant/RenderMessageMarkdown";
 import { useEventSource } from "@app/hooks/useEventSource";
 import { useSubmitFunction } from "@app/lib/client/utils";
-import { isDevelopmentOrDustWorkspace } from "@app/lib/development";
 
 function cleanUpCitations(message: string): string {
   const regex = / ?:cite\[[a-zA-Z0-9, ]+\]/g;
@@ -336,7 +335,7 @@ export function AgentMessage({
       reactions={reactions}
       enableEmojis={true}
       renderName={() => {
-        return isDevelopmentOrDustWorkspace(owner) ? (
+        return (
           <div className="flex flex-row gap-2">
             <div className="text-sm font-medium">
               {AssitantDetailViewLink(agentConfiguration)}
@@ -346,8 +345,6 @@ export function AgentMessage({
               owner={owner}
             />
           </div>
-        ) : (
-          <div className="text-sm font-medium">{agentConfiguration.name}</div>
         );
       }}
     >


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Now that `AssistantDetails` does not rely on the `flow` attribute anymore. This PR remove the `isDevelopmentOrDustWorkspace` that was hiding the changes around the `AgentMessage` from everyone (except the Dust team).

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
