### PR TITLE
Mark connectors as errored.

### DIFF
--- a/connectors/src/admin/cli.ts
+++ b/connectors/src/admin/cli.ts
@@ -1,3 +1,4 @@
+import { isConnectorError } from "@dust-tt/types";
 import parseArgs from "minimist";
 import PQueue from "p-queue";
 import readline from "readline";
@@ -127,6 +128,18 @@ const connectors = async (command: string, args: parseArgs.ParsedArgs) => {
       await throwOnError(
         SYNC_CONNECTOR_BY_TYPE[provider](connector.id.toString(), fromTs)
       );
+      return;
+    }
+
+    case "set-error": {
+      if (!args.error) {
+        throw new Error("Missing --error argument");
+      }
+      if (!isConnectorError(args.error)) {
+        throw new Error(`Invalid error: ${args.error}`);
+      }
+      connector.errorType = args.error;
+      await connector.save();
       return;
     }
 

--- a/connectors/src/admin/cli.ts
+++ b/connectors/src/admin/cli.ts
@@ -276,6 +276,7 @@ const notion = async (command: string, args: parseArgs.ParsedArgs) => {
       const connectors = await Connector.findAll({
         where: {
           type: "notion",
+          errorType: null,
         },
       });
       for (const connector of connectors) {

--- a/front/components/data_source/DataSourceSyncChip.tsx
+++ b/front/components/data_source/DataSourceSyncChip.tsx
@@ -1,7 +1,9 @@
 import { Chip } from "@dust-tt/sparkle";
 import type { ConnectorType } from "@dust-tt/types";
+import { assertNever } from "@dust-tt/types";
 import { useEffect, useState } from "react";
 
+import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 import { timeAgoFrom } from "@app/lib/utils";
 
 export default function ConnectorSyncingChip({
@@ -19,14 +21,35 @@ export default function ConnectorSyncingChip({
   if (connector.errorType) {
     return (
       <Chip color="warning">
-        Oops! It seems that our access to your account has been revoked. Please
-        re-authorize this Data Source to keep your data up to date on Dust.
+        {(() => {
+          switch (connector.errorType) {
+            case "oauth_token_revoked":
+              return (
+                <>
+                  Oops! It seems that our access to your account has been
+                  revoked. Please re-authorize this Data Source to keep your
+                  data up to date on Dust.
+                </>
+              );
+            case "third_party_internal_error":
+              return (
+                <>
+                  We have ecountered an error talking to{" "}
+                  {CONNECTOR_CONFIGURATIONS[connector.type].name}. We sent you
+                  an email with more details to resolve the issue.
+                </>
+              );
+            default:
+              assertNever(connector.errorType);
+          }
+          return <></>;
+        })()}
       </Chip>
     );
   } else if (!connector.lastSyncSuccessfulTime) {
     return (
       <Chip color="amber" isBusy>
-        Synchronizing
+        {connector.errorType} Synchronizing
         {connector?.firstSyncProgress
           ? ` (${connector?.firstSyncProgress})`
           : null}

--- a/front/components/data_source/DataSourceSyncChip.tsx
+++ b/front/components/data_source/DataSourceSyncChip.tsx
@@ -49,7 +49,7 @@ export default function ConnectorSyncingChip({
   } else if (!connector.lastSyncSuccessfulTime) {
     return (
       <Chip color="amber" isBusy>
-        {connector.errorType} Synchronizing
+        Synchronizing
         {connector?.firstSyncProgress
           ? ` (${connector?.firstSyncProgress})`
           : null}

--- a/types/src/front/lib/connectors_api.ts
+++ b/types/src/front/lib/connectors_api.ts
@@ -10,7 +10,15 @@ const {
 
 export type ConnectorsAPIResponse<T> = Result<T, ConnectorsAPIError>;
 export type ConnectorSyncStatus = "succeeded" | "failed";
-export type ConnectorErrorType = "oauth_token_revoked";
+const CONNECTORS_ERROR_TYPES = [
+  "oauth_token_revoked",
+  "third_party_internal_error",
+] as const;
+
+export type ConnectorErrorType = (typeof CONNECTORS_ERROR_TYPES)[number];
+export function isConnectorError(val: string): val is ConnectorErrorType {
+  return (CONNECTORS_ERROR_TYPES as unknown as string[]).includes(val);
+}
 
 export const CONNECTOR_PROVIDERS_USING_NANGO = [
   "confluence",


### PR DESCRIPTION
## Description

- Adding a CLI to mark a connector as errored. That way we can stop the sync workflow without deleting the connector.
- Adding a new `connectors.errorType` case: `third_party_internal_error`
- Adding support for this error in the UI.

This is to handle the Notion case that errors with the message below:

```
APIResponseError: The schema for the database with the following ID is malformed: .....
```


Here is what it looks like:

![Screenshot 2024-02-05 at 14 21 15](https://github.com/dust-tt/dust/assets/358965/d94e7c4d-57ff-414e-8cc2-806a5f022f1c)


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
