### PR TITLE
Poké: Prevent Downgrade from a paid subscription

### DIFF
--- a/front/pages/poke/[wId]/index.tsx
+++ b/front/pages/poke/[wId]/index.tsx
@@ -490,6 +490,7 @@ const WorkspacePage = ({
                           onClick={onDowngrade}
                           disabled={
                             !isUpgraded(subscription.plan) ||
+                            subscription.stripeSubscriptionId !== null ||
                             workspaceHasManagedDataSources
                           }
                         />


### PR DESCRIPTION
## Description

Multiple workspaces have been downgraded from Pro plan to test plan from Poké. 
This is wrong because it won't end the Stripe subscription. 
Valid process is to end a subscription on Stripe, and the webhook will end it on our db.

Eng runner card: https://github.com/dust-tt/tasks/issues/396 (reading it is not required for the review)

## Risk

Very low.

## Deploy Plan

Nothing special. 