### PR TITLE
Adding missing indexes for GdriveFiles and NotionPages

### DIFF
--- a/connectors/src/lib/models/google_drive.ts
+++ b/connectors/src/lib/models/google_drive.ts
@@ -176,7 +176,7 @@ GoogleDriveFiles.init(
     modelName: "google_drive_files",
     indexes: [
       { fields: ["connectorId", "driveFileId"], unique: true },
-      { fields: ["connectorId", "parentId"] },
+      { fields: ["connectorId", "parentId"], concurrently: true },
     ],
   }
 );

--- a/connectors/src/lib/models/google_drive.ts
+++ b/connectors/src/lib/models/google_drive.ts
@@ -174,7 +174,10 @@ GoogleDriveFiles.init(
   {
     sequelize: sequelize_conn,
     modelName: "google_drive_files",
-    indexes: [{ fields: ["connectorId", "driveFileId"], unique: true }],
+    indexes: [
+      { fields: ["connectorId", "driveFileId"], unique: true },
+      { fields: ["connectorId", "parentId"] },
+    ],
   }
 );
 Connector.hasOne(GoogleDriveFiles);

--- a/connectors/src/lib/models/notion.ts
+++ b/connectors/src/lib/models/notion.ts
@@ -150,7 +150,6 @@ NotionPage.init(
     sequelize: sequelize_conn,
     indexes: [
       { fields: ["notionPageId", "connectorId"], unique: true },
-      { fields: ["connectorId"] },
       { fields: ["connectorId", "lastSeenTs"], concurrently: true },
       { fields: ["parentId"] },
       { fields: ["lastCreatedOrMovedRunTs"] },

--- a/connectors/src/lib/models/notion.ts
+++ b/connectors/src/lib/models/notion.ts
@@ -151,7 +151,7 @@ NotionPage.init(
     indexes: [
       { fields: ["notionPageId", "connectorId"], unique: true },
       { fields: ["connectorId"] },
-      { fields: ["connectorId", "lastSeenTs"] },
+      { fields: ["connectorId", "lastSeenTs"], concurrently: true },
       { fields: ["parentId"] },
       { fields: ["lastCreatedOrMovedRunTs"] },
       {

--- a/connectors/src/lib/models/notion.ts
+++ b/connectors/src/lib/models/notion.ts
@@ -151,7 +151,7 @@ NotionPage.init(
     indexes: [
       { fields: ["notionPageId", "connectorId"], unique: true },
       { fields: ["connectorId"] },
-      { fields: ["lastSeenTs"] },
+      { fields: ["connectorId", "lastSeenTs"] },
       { fields: ["parentId"] },
       { fields: ["lastCreatedOrMovedRunTs"] },
       {


### PR DESCRIPTION
## Description

Adding two missing indexes to speed up two slow  queries on connectors:

``` 
# Ran 53k times today with an average of 48ms
SELECT "lastSeenTs", "notionPageId", "skipReason" FROM "notion_pages" AS "notion_pages" WHERE "notion_pages"."connectorId" = $1 AND "notion_pages"."lastSeenTs" < $2 LIMIT $3 OFFSET $4


# Ran 7k times today with an average of 42ms
SELECT count(*) AS "count" FROM "google_drive_files" AS "google_drive_files" WHERE "google_drive_files"."connectorId" = $1 AND "google_drive_files"."parentId" = $2
```

There are about ~500k google_drive_files and ~1.5 millions Notion pages, hence the concurrently:true;
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan


- Deploy code
- `npm run initdb` on connectors.


