### PR TITLE
Add sort and limit on the /agent_configurations endpoint

### DIFF
--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -608,15 +608,6 @@ export async function getAgentConfigurations<V extends "light" | "full">({
 }): Promise<
   V extends "light" ? LightAgentConfigurationType[] : AgentConfigurationType[]
 > {
-  // {agentId: string} view: get a specific agent configuration.
-  // list view: specific to a user. Get all agents that are in the user's list (either they created it and it is private, or via AgentUserRelation).
-  // {conversationId: string} view: specific to a conversation. Get all agents that are in the user's list + workspace/published agents in the current conversation.
-  // all view: workspace + published agents (not private ones), eg. for agent gallery
-  // workspace view: only workspace agents (not published ones)
-  // published view: only published agents (not workspace ones)
-  // global view: only global agents (not workspace or published ones)
-  // admin_internal view: all agents, including private ones => this is only for internal use (eg poke). Requires superuser or admin auth.
-
   const owner = auth.workspace();
   if (!owner || !auth.isUser()) {
     throw new Error("Unexpected `auth` without `workspace`.");

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -13,6 +13,7 @@ import type {
   RetrievalQuery,
   RetrievalTimeframe,
   SupportedModel,
+  WorkspaceType,
 } from "@dust-tt/types";
 import {
   assertNever,
@@ -22,7 +23,7 @@ import {
   isTimeFrame,
   Ok,
 } from "@dust-tt/types";
-import type { Transaction } from "sequelize";
+import type { FindOptions, Order, Transaction } from "sequelize";
 import { Op, UniqueConstraintError } from "sequelize";
 
 import {
@@ -53,11 +54,27 @@ import {
 import { AgentUserRelation } from "@app/lib/models/assistant/agent";
 import { generateModelSId } from "@app/lib/utils";
 
-const sortStrategies = {
-  alphabetical: (a: AgentConfigurationType, b: AgentConfigurationType) =>
-    a.name.localeCompare(b.name),
-  priority: compareAgentsForSort,
+interface SortStrategyType {
+  dbOrder: Order | undefined;
+  compareFunction: (
+    a: AgentConfigurationType,
+    b: AgentConfigurationType
+  ) => number;
+}
+
+const sortStrategies: Record<"alphabetical" | "priority", SortStrategyType> = {
+  alphabetical: {
+    dbOrder: [["name", "ASC"]],
+    compareFunction: (a: AgentConfigurationType, b: AgentConfigurationType) =>
+      a.name.localeCompare(b.name),
+  },
+  priority: {
+    dbOrder: undefined,
+    compareFunction: compareAgentsForSort,
+  },
 } as const;
+
+type SortStrategy = keyof typeof sortStrategies;
 
 /**
  * Get an agent configuration
@@ -75,96 +92,65 @@ export async function getAgentConfiguration(
   return res[0] || null;
 }
 
-export async function getAgentConfigurations<V extends "light" | "full">({
-  auth,
-  agentsGetView,
-  agentPrefix,
-  variant,
-  limit,
-  sort,
-}: {
-  auth: Authenticator;
-  agentsGetView: AgentsGetViewType;
-  agentPrefix?: string;
-  variant: V;
-  limit?: number;
-  sort?: keyof typeof sortStrategies;
-}): Promise<
-  V extends "light" ? LightAgentConfigurationType[] : AgentConfigurationType[]
-> {
-  // {agentId: string} view: get a specific agent configuration.
-  // list view: specific to a user. Get all agents that are in the user's list (either they created it and it is private, or via AgentUserRelation).
-  // {conversationId: string} view: specific to a conversation. Get all agents that are in the user's list + workspace/published agents in the current conversation.
-  // all view: workspace + published agents (not private ones), eg. for agent gallery
-  // workspace view: only workspace agents (not published ones)
-  // published view: only published agents (not workspace ones)
-  // global view: only global agents (not workspace or published ones)
-  // admin_internal view: all agents, including private ones => this is only for internal use (eg poke). Requires superuser or admin auth.
-
-  const owner = auth.workspace();
-  if (!owner || !auth.isUser()) {
-    throw new Error("Unexpected `auth` without `workspace`.");
-  }
-  const plan = auth.plan();
-  if (!plan) {
-    throw new Error("Unexpected `auth` without `plan`.");
-  }
-
-  const user = auth.user();
-
-  if (
-    agentsGetView === "admin_internal" &&
-    !auth.isDustSuperUser() &&
-    !auth.isAdmin()
-  ) {
-    throw new Error(
-      "Superuser view is for dust superusers or internal admin auths only."
-    );
-  }
-  if (agentsGetView === "list" && !user) {
-    throw new Error("List view is specific to a user.");
-  }
-
-  const globalAgentIdsToFetch: string[] | undefined = (() => {
-    switch (agentsGetView) {
-      case "workspace":
-      case "published":
-        // No global agents in workspace & published view.
-        return [];
-      case "global":
-      case "list":
-      case "all":
-      case "admin_internal":
-        // All global agents in global, list, all, admin_internal views.
-        return undefined;
-      default:
-        if (
-          typeof agentsGetView === "object" &&
-          "conversationId" in agentsGetView
-        ) {
-          // All global agents in conversation view.
-          return undefined;
-        }
-        if (typeof agentsGetView === "object" && "agentId" in agentsGetView) {
-          if (isGlobalAgentId(agentsGetView.agentId)) {
-            // In agentId view, only get the global agent with the provided id if it is a global agent.
-            return [agentsGetView.agentId];
-          }
-          // In agentId view, don't get any global agents if it is not a global agent.
-          return [];
-        }
-        assertNever(agentsGetView);
-    }
-  })();
-
-  const applySortAndLimit = (results: AgentConfigurationType[]) => {
+function makeApplySortAndLimit(sort?: SortStrategy, limit?: number) {
+  return (results: AgentConfigurationType[]) => {
     const sortStrategy = sort && sortStrategies[sort];
 
-    const sortedResults = sortStrategy ? results.sort(sortStrategy) : results;
+    const sortedResults = sortStrategy
+      ? results.sort(sortStrategy.compareFunction)
+      : results;
 
     return limit ? sortedResults.slice(0, limit) : sortedResults;
   };
+}
 
+// Global agent configurations.
+
+function determineGlobalAgentIdsToFetch(
+  agentsGetView: AgentsGetViewType
+): string[] | undefined {
+  switch (agentsGetView) {
+    case "workspace":
+    case "published":
+      // No global agents in workspace & published view.
+      return [];
+    case "global":
+    case "list":
+    case "all":
+    case "admin_internal":
+      // All global agents in global, list, all, admin_internal views.
+      return undefined;
+    default:
+      if (
+        typeof agentsGetView === "object" &&
+        "conversationId" in agentsGetView
+      ) {
+        // All global agents in conversation view.
+        return undefined;
+      }
+      if (typeof agentsGetView === "object" && "agentId" in agentsGetView) {
+        if (isGlobalAgentId(agentsGetView.agentId)) {
+          // In agentId view, only get the global agent with the provided id if it is a global agent.
+          return [agentsGetView.agentId];
+        }
+        // In agentId view, don't get any global agents if it is not a global agent.
+        return [];
+      }
+      assertNever(agentsGetView);
+  }
+}
+
+async function fetchGlobalAgentConfigurationForView(
+  auth: Authenticator,
+  {
+    agentPrefix,
+    agentsGetView,
+  }: {
+    agentPrefix?: string;
+    agentsGetView: AgentsGetViewType;
+  }
+) {
+  const globalAgentIdsToFetch = determineGlobalAgentIdsToFetch(agentsGetView);
   const allGlobalAgents = await getGlobalAgents(auth, globalAgentIdsToFetch);
   const matchingGlobalAgents = allGlobalAgents.filter(
     (a) =>
@@ -173,106 +159,156 @@ export async function getAgentConfigurations<V extends "light" | "full">({
 
   if (agentsGetView === "global") {
     // Only global agents in global view.`
-    return applySortAndLimit(matchingGlobalAgents);
+    return matchingGlobalAgents;
   }
 
   // If not in global view, filter out global agents that are not active.
-  const activeMatchingGlobalAgents = matchingGlobalAgents.filter(
-    (a) => a.status === "active"
-  );
+  return matchingGlobalAgents.filter((a) => a.status === "active");
+}
 
-  const baseAgentsSequelizeQuery = {
-    where: {
-      workspaceId: owner.id,
-      status: "active",
-      ...(agentPrefix ? { name: { [Op.iLike]: `${agentPrefix}%` } } : {}),
-    },
+// Workspace agent configurations.
+
+function byId<T extends { id: number }>(list: T[]): Record<string, T> {
+  return list.reduce((acc, item) => {
+    acc[item.id] = item;
+    return acc;
+  }, {} as Record<number, T>);
+}
+
+async function fetchAgentConfigurationsForView(
+  auth: Authenticator,
+  {
+    agentPrefix,
+    agentsGetView,
     limit,
+    owner,
+    sort,
+  }: {
+    agentPrefix?: string;
+    agentsGetView: Exclude<AgentsGetViewType, "global">;
+    limit?: number;
+    owner: WorkspaceType;
+    sort?: SortStrategy;
+  }
+): Promise<AgentConfiguration[]> {
+  const sortStrategy = sort && sortStrategies[sort];
+
+  const baseWhereConditions = {
+    workspaceId: owner.id,
+    status: "active",
+    ...(agentPrefix ? { name: { [Op.iLike]: `${agentPrefix}%` } } : {}),
   };
 
-  const agentConfigurations: AgentConfiguration[] = await (() => {
-    switch (agentsGetView) {
-      case "admin_internal":
+  const baseAgentsSequelizeQuery: FindOptions = {
+    limit,
+    order: sortStrategy?.dbOrder,
+  };
+
+  const scopeConditions = (scopes: string[]) => ({
+    ...baseWhereConditions,
+    scope: { [Op.in]: scopes },
+  });
+
+  switch (agentsGetView) {
+    case "admin_internal":
+      return AgentConfiguration.findAll({
+        ...baseAgentsSequelizeQuery,
+        where: baseWhereConditions,
+      });
+
+    case "all":
+      return AgentConfiguration.findAll({
+        ...baseAgentsSequelizeQuery,
+        where: scopeConditions(["workspace", "published"]),
+      });
+
+    case "workspace":
+      return AgentConfiguration.findAll({
+        ...baseAgentsSequelizeQuery,
+        where: scopeConditions(["workspace"]),
+      });
+
+    case "published":
+      return AgentConfiguration.findAll({
+        ...baseAgentsSequelizeQuery,
+        where: scopeConditions(["published"]),
+      });
+
+    case "list":
+      const user = auth.user();
+
+      return AgentConfiguration.findAll({
+        ...baseAgentsSequelizeQuery,
+        where: {
+          ...baseWhereConditions,
+          [Op.or]: [
+            { scope: { [Op.in]: ["workspace", "published"] } },
+            { authorId: user?.id },
+          ],
+        },
+      });
+
+    default:
+      if (typeof agentsGetView === "object" && "agentId" in agentsGetView) {
+        if (isGlobalAgentId(agentsGetView.agentId)) {
+          return Promise.resolve([]);
+        }
         return AgentConfiguration.findAll({
-          ...baseAgentsSequelizeQuery,
-        });
-      case "all":
-        return AgentConfiguration.findAll({
-          ...baseAgentsSequelizeQuery,
           where: {
-            ...baseAgentsSequelizeQuery.where,
-            scope: { [Op.in]: ["workspace", "published"] },
+            workspaceId: owner.id,
+            ...(agentPrefix ? { name: { [Op.iLike]: `${agentPrefix}%` } } : {}),
+            sId: agentsGetView.agentId,
           },
+          order: [["version", "DESC"]],
+          ...(agentsGetView.allVersions ? {} : { limit: 1 }),
         });
-      case "workspace":
+      } else if (
+        typeof agentsGetView === "object" &&
+        "conversationId" in agentsGetView
+      ) {
+        const user = auth.user();
+
         return AgentConfiguration.findAll({
           ...baseAgentsSequelizeQuery,
           where: {
-            ...baseAgentsSequelizeQuery.where,
-            scope: { [Op.in]: ["workspace"] },
-          },
-        });
-      case "published":
-        return AgentConfiguration.findAll({
-          ...baseAgentsSequelizeQuery,
-          where: {
-            ...baseAgentsSequelizeQuery.where,
-            scope: { [Op.in]: ["published"] },
-          },
-        });
-      case "list":
-        return AgentConfiguration.findAll({
-          ...baseAgentsSequelizeQuery,
-          where: {
-            ...baseAgentsSequelizeQuery.where,
+            ...baseWhereConditions,
             [Op.or]: [
               { scope: { [Op.in]: ["workspace", "published"] } },
               { authorId: user?.id },
             ],
           },
         });
-      default:
-        if (typeof agentsGetView === "object" && "agentId" in agentsGetView) {
-          if (isGlobalAgentId(agentsGetView.agentId)) {
-            return Promise.resolve([]);
-          }
-          return AgentConfiguration.findAll({
-            where: {
-              workspaceId: owner.id,
-              ...(agentPrefix
-                ? { name: { [Op.iLike]: `${agentPrefix}%` } }
-                : {}),
-              sId: agentsGetView.agentId,
-            },
-            order: [["version", "DESC"]],
-            ...(agentsGetView.allVersions ? {} : { limit: 1 }),
-          });
-        }
-        if (
-          typeof agentsGetView === "object" &&
-          "conversationId" in agentsGetView
-        ) {
-          return AgentConfiguration.findAll({
-            ...baseAgentsSequelizeQuery,
-            where: {
-              ...baseAgentsSequelizeQuery.where,
-              [Op.or]: [
-                { scope: { [Op.in]: ["workspace", "published"] } },
-                { authorId: user?.id },
-              ],
-            },
-          });
-        }
-        assertNever(agentsGetView);
-    }
-  })();
-
-  function byId<T extends { id: number }>(list: T[]): Record<string, T> {
-    return list.reduce((acc, item) => {
-      acc[item.id] = item;
-      return acc;
-    }, {} as Record<number, T>);
+      }
+      assertNever(agentsGetView);
   }
+}
+
+async function fetchWorkspaceAgentConfigurations(
+  auth: Authenticator,
+  owner: WorkspaceType,
+  {
+    agentPrefix,
+    agentsGetView,
+    limit,
+    sort,
+    variant,
+  }: {
+    agentPrefix?: string;
+    agentsGetView: Exclude<AgentsGetViewType, "global">;
+    limit?: number;
+    sort?: SortStrategy;
+    variant: "light" | "full";
+  }
+) {
+  const user = auth.user();
+
+  const agentConfigurations = await fetchAgentConfigurationsForView(auth, {
+    agentPrefix,
+    agentsGetView,
+    limit,
+    owner,
+    sort,
+  });
 
   const configurationIds = agentConfigurations.map((a) => a.id);
   const configurationSIds = agentConfigurations.map((a) => a.sId);
@@ -552,10 +588,85 @@ export async function getAgentConfigurations<V extends "light" | "full">({
     });
   }
 
-  return applySortAndLimit([
-    ...agentConfigurationTypes,
-    ...activeMatchingGlobalAgents,
+  return agentConfigurationTypes;
+}
+
+export async function getAgentConfigurations<V extends "light" | "full">({
+  auth,
+  agentsGetView,
+  agentPrefix,
+  variant,
+  limit,
+  sort,
+}: {
+  auth: Authenticator;
+  agentsGetView: AgentsGetViewType;
+  agentPrefix?: string;
+  variant: V;
+  limit?: number;
+  sort?: SortStrategy;
+}): Promise<
+  V extends "light" ? LightAgentConfigurationType[] : AgentConfigurationType[]
+> {
+  // {agentId: string} view: get a specific agent configuration.
+  // list view: specific to a user. Get all agents that are in the user's list (either they created it and it is private, or via AgentUserRelation).
+  // {conversationId: string} view: specific to a conversation. Get all agents that are in the user's list + workspace/published agents in the current conversation.
+  // all view: workspace + published agents (not private ones), eg. for agent gallery
+  // workspace view: only workspace agents (not published ones)
+  // published view: only published agents (not workspace ones)
+  // global view: only global agents (not workspace or published ones)
+  // admin_internal view: all agents, including private ones => this is only for internal use (eg poke). Requires superuser or admin auth.
+
+  const owner = auth.workspace();
+  if (!owner || !auth.isUser()) {
+    throw new Error("Unexpected `auth` without `workspace`.");
+  }
+  const plan = auth.plan();
+  if (!plan) {
+    throw new Error("Unexpected `auth` without `plan`.");
+  }
+
+  const user = auth.user();
+
+  if (
+    agentsGetView === "admin_internal" &&
+    !auth.isDustSuperUser() &&
+    !auth.isAdmin()
+  ) {
+    throw new Error(
+      "Superuser view is for dust superusers or internal admin auths only."
+    );
+  }
+  if (agentsGetView === "list" && !user) {
+    throw new Error("List view is specific to a user.");
+  }
+
+  const applySortAndLimit = makeApplySortAndLimit(sort, limit);
+
+  if (agentsGetView === "global") {
+    const allGlobalAgents = await fetchGlobalAgentConfigurationForView(auth, {
+      agentPrefix,
+      agentsGetView,
+    });
+
+    return applySortAndLimit(allGlobalAgents);
+  }
+
+  const allAgentConfigurations = await Promise.all([
+    fetchGlobalAgentConfigurationForView(auth, {
+      agentPrefix,
+      agentsGetView,
+    }),
+    fetchWorkspaceAgentConfigurations(auth, owner, {
+      agentPrefix,
+      agentsGetView,
+      limit,
+      sort,
+      variant,
+    }),
   ]);
+
+  return applySortAndLimit(allAgentConfigurations.flat());
 }
 
 async function getConversationMentions(

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -283,7 +283,7 @@ async function fetchAgentConfigurationsForView(
   }
 }
 
-async function fetchWorkspaceAgentConfigurations(
+async function fetchWorkspaceAgentConfigurationsForView(
   auth: Authenticator,
   owner: WorkspaceType,
   {
@@ -648,7 +648,7 @@ export async function getAgentConfigurations<V extends "light" | "full">({
       agentPrefix,
       agentsGetView,
     }),
-    fetchWorkspaceAgentConfigurations(auth, owner, {
+    fetchWorkspaceAgentConfigurationsForView(auth, owner, {
       agentPrefix,
       agentsGetView,
       limit,

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -23,7 +23,7 @@ import {
   isTimeFrame,
   Ok,
 } from "@dust-tt/types";
-import type { FindOptions, Order, Transaction } from "sequelize";
+import type { Order, Transaction } from "sequelize";
 import { Op, UniqueConstraintError } from "sequelize";
 
 import {
@@ -199,9 +199,9 @@ async function fetchAgentConfigurationsForView(
     ...(agentPrefix ? { name: { [Op.iLike]: `${agentPrefix}%` } } : {}),
   };
 
-  const baseAgentsSequelizeQuery: FindOptions = {
+  const baseAgentsSequelizeQuery = {
     limit,
-    order: sortStrategy?.dbOrder,
+    order: sortStrategy ? sortStrategy.dbOrder : undefined,
   };
 
   const scopeConditions = (scopes: string[]) => ({

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -64,7 +64,7 @@ interface SortStrategyType {
 
 const sortStrategies: Record<"alphabetical" | "priority", SortStrategyType> = {
   alphabetical: {
-    dbOrder: [["name", "ASC"]],
+    dbOrder: [["name", "ASC"]] as const,
     compareFunction: (a: AgentConfigurationType, b: AgentConfigurationType) =>
       a.name.localeCompare(b.name),
   },

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -64,7 +64,7 @@ interface SortStrategyType {
 
 const sortStrategies: Record<"alphabetical" | "priority", SortStrategyType> = {
   alphabetical: {
-    dbOrder: [["name", "ASC"]] as const,
+    dbOrder: [["name", "ASC"]],
     compareFunction: (a: AgentConfigurationType, b: AgentConfigurationType) =>
       a.name.localeCompare(b.name),
   },
@@ -72,7 +72,7 @@ const sortStrategies: Record<"alphabetical" | "priority", SortStrategyType> = {
     dbOrder: undefined,
     compareFunction: compareAgentsForSort,
   },
-} as const;
+};
 
 type SortStrategy = keyof typeof sortStrategies;
 

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -222,8 +222,6 @@ async function handler(
 
 export default withLogging(handler);
 
-async function listAgentConfigurations(req, res) {}
-
 /**
  * Create Or Upgrade Agent Configuration If an agentConfigurationId is provided,
  * it will create a new version of the agent configuration with the same

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -72,9 +72,13 @@ async function handler(
         });
       }
       // extract the view from the query parameters
-      const queryValidation = GetAgentConfigurationsQuerySchema.decode(
-        req.query
-      );
+      const queryValidation = GetAgentConfigurationsQuerySchema.decode({
+        ...req.query,
+        limit:
+          typeof req.query.limit === "string"
+            ? parseInt(req.query.limit, 10)
+            : undefined,
+      });
       if (isLeft(queryValidation)) {
         const pathError = reporter.formatValidationErrors(queryValidation.left);
         return apiError(req, res, {
@@ -86,7 +90,7 @@ async function handler(
         });
       }
 
-      const { view, conversationId, withUsage, withAuthors } =
+      const { view, conversationId, limit, withUsage, withAuthors, sort } =
         queryValidation.right;
       const viewParam = view
         ? view
@@ -106,6 +110,8 @@ async function handler(
         auth,
         agentsGetView: viewParam,
         variant: "light",
+        limit,
+        sort,
       });
       if (withUsage === "true") {
         agentConfigurations = await safeRedisClient(async (redis) => {
@@ -215,6 +221,8 @@ async function handler(
 }
 
 export default withLogging(handler);
+
+async function listAgentConfigurations(req, res) {}
 
 /**
  * Create Or Upgrade Agent Configuration If an agentConfigurationId is provided,

--- a/types/src/front/api_handlers/internal/agent_configuration.ts
+++ b/types/src/front/api_handlers/internal/agent_configuration.ts
@@ -1,7 +1,10 @@
 import * as t from "io-ts";
 
+import { createRangeCodec } from "../../../shared/utils/iots_utils";
 import { TimeframeUnitCodec } from "../../assistant/actions/retrieval";
 import { isSupportedModel, SupportedModel } from "../../lib/assistant";
+
+const LimitCodec = createRangeCodec(0, 100);
 
 // Get schema for the url query parameters: a view parameter with all the types
 // of AgentGetViewType
@@ -18,6 +21,12 @@ export const GetAgentConfigurationsQuerySchema = t.type({
   conversationId: t.union([t.string, t.undefined]),
   withUsage: t.union([t.literal("true"), t.literal("false"), t.undefined]),
   withAuthors: t.union([t.literal("true"), t.literal("false"), t.undefined]),
+  limit: t.union([LimitCodec, t.undefined]),
+  sort: t.union([
+    t.literal("priority"),
+    t.literal("alphabetical"),
+    t.undefined,
+  ]),
 });
 
 export const GetAgentConfigurationsLeaderboardQuerySchema = t.type({

--- a/types/src/front/assistant/agent.ts
+++ b/types/src/front/assistant/agent.ts
@@ -89,13 +89,15 @@ export type AgentConfigurationScope =
 export type AgentUserListStatus = "in-list" | "not-in-list";
 
 /**
- * Agents can be retrieved according to different 'views':
- * - list: all agents in the user's list
- * - conversation: all agents in the user's list + agents in the current conversation (requries a
- *   conversation sId)
- * - all: workspace + published agents (not private ones), eg. for agent gallery
- * - admin_internal: all agents, including private ones => CAREFUL, this is only for internal use.
- * Global agents enabled for the workspace are always returned with all the views.
+ * Defines strategies for fetching agent configurations based on various 'views':
+ * - {agentId: string}: Retrieves a single agent by its ID.
+ * - {conversationId: string}: Targets agents relevant to a specific conversation, including user-listed agents and workspace/published agents.
+ * - 'list': User-centric view, fetches agents in the user's list, including both privately created and those added via AgentUserRelation.
+ * - 'all': Combines workspace and published agents, excluding private agents. Typically used in agent galleries.
+ * - 'workspace': Limits to agents within the workspace, excluding published agents.
+ * - 'published': Fetches only published agents, excluding those associated with a workspace.
+ * - 'global': Retrieves global agents, excluding workspace and published agents.
+ * - 'admin_internal': Grants access to all agents, including private ones. Intended strictly for internal use with necessary superuser or admin authorization.
  */
 export type AgentsGetViewType =
   | { agentId: string; allVersions?: boolean }

--- a/types/src/front/assistant/agent.ts
+++ b/types/src/front/assistant/agent.ts
@@ -90,13 +90,14 @@ export type AgentUserListStatus = "in-list" | "not-in-list";
 
 /**
  * Defines strategies for fetching agent configurations based on various 'views':
+ * - 'list': Retrieves all agents within the user's list, including their private agents, agents from the workspace and global scope,
+ * plus any published agents they've added to their list (refer to AgentUserRelationTable).
  * - {agentId: string}: Retrieves a single agent by its ID.
- * - {conversationId: string}: Targets agents relevant to a specific conversation, including user-listed agents and workspace/published agents.
- * - 'list': User-centric view, fetches agents in the user's list, including both privately created and those added via AgentUserRelation.
+ * - {conversationId: string}: all agent from the user's list view, plus the agents mentioned in the conversation with the provided Id.
  * - 'all': Combines workspace and published agents, excluding private agents. Typically used in agent galleries.
- * - 'workspace': Limits to agents within the workspace, excluding published agents.
- * - 'published': Fetches only published agents, excluding those associated with a workspace.
- * - 'global': Retrieves global agents, excluding workspace and published agents.
+ * - 'workspace': Retrieves all agents exclusively with a 'workspace' scope.
+ * - 'published': Retrieves all agents exclusively with a 'published' scope.
+ * - 'global': Retrieves all agents exclusively with a 'global' scope.
  * - 'admin_internal': Grants access to all agents, including private ones. Intended strictly for internal use with necessary superuser or admin authorization.
  */
 export type AgentsGetViewType =

--- a/types/src/shared/utils/iots_utils.ts
+++ b/types/src/shared/utils/iots_utils.ts
@@ -16,3 +16,16 @@ export function ioTsEnum<EnumType>(
     t.identity
   );
 }
+
+export interface BrandedRange {
+  readonly Range: unique symbol;
+}
+
+// Defines a function to generate a branded codec for validating numbers within a specific range.
+export function createRangeCodec(min: number, max: number) {
+  return t.brand(
+    t.number,
+    (n): n is t.Branded<number, BrandedRange> => n >= min && n <= max,
+    "Range"
+  );
+}


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
In the new [designs](https://www.figma.com/file/QOxHwppG64GtPocpDhS6Y7/Product?type=design&node-id=4050-22252&mode=design&t=vJyMdxcQlth3L0W4-0), showcasing authors is a key feature across various scenarios, including our new landing page where we want to highlight four assistants. Given that computing the most recent authors can be quite demanding on resources, we're looking to avoid this computation for every assistant. This PR introduces a way for sorting and limiting within the `/agent_configurations` endpoint. It's important to note that the intention here isn't to support full pagination, as our primary sorting (`priority`) method doesn't align with MySQL. We might want to reconsider our our sorting to lean toward a usage-based sort.

With this update, we will execute two separate queries to populate the new conversation view:
- one for the top two global assistants sorted by `priority`
- another for two custom assistants sorted by `alphabetical` order.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
Some risk lies in this PR as it comes with some refactoring. Tested properly on front-edge infrastructure. Safe to rollback.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
