### PR TITLE
fix dangling run migration timeout

### DIFF
--- a/front/migrations/20230601_fix_dangling_running_runs.ts
+++ b/front/migrations/20230601_fix_dangling_running_runs.ts
@@ -8,7 +8,7 @@ async function main() {
   });
   console.log("Retrieving core runs");
   const data = await core_sequelize.query(
-    "SELECT id, run_id, created, status_json FROM runs"
+    `SELECT id, run_id, created, status_json FROM runs WHERE status_json LIKE '{"run":"running%'`
   );
   const coreRuns = data[0];
   console.log(`Retrieved ${coreRuns.length}`);


### PR DESCRIPTION
## Description

The migration would timeout due to too-much data. This query while not optimized is fast and fixes it.

## Risk

N/A

## Deploy Plan

- deploy `front`