### PR TITLE
Fix: on creation, company assistant is in user's list by default

### DIFF
--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -683,10 +683,9 @@ export async function createAgentConfiguration(
         }
         const sId = agentConfigurationId || generateModelSId();
 
-        // If creating a new private or published agent, it should be in the user's list, so it
-        // appears in their 'assistants' page (at creation for assistants created published, or at
-        // publication once a private assistant gets published).
-        if (["private", "published"].includes(scope) && !agentConfigurationId) {
+        // If creating a new agent, we include it in the user's list by default.
+        // This is so it doesn't disappear from their list on scope change
+        if (!agentConfigurationId) {
           listStatusOverride = "in-list";
           await AgentUserRelation.create(
             {

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/scope.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/scope.ts
@@ -106,17 +106,7 @@ async function handler(
           });
         }
 
-        if (assistant.scope === "workspace" && !auth.isBuilder()) {
-          return apiError(req, res, {
-            status_code: 404,
-            api_error: {
-              type: "app_auth_error",
-              message: "Only builders can modify workspace assistants.",
-            },
-          });
-        }
-
-        // ensure the assistant is not in the list of the user otherwise
+        // ensure the assistant is in the list of the user otherwise
         // switching it back to private will make it disappear
         const setRes = await setAgentUserListStatus({
           auth,


### PR DESCRIPTION
## Description
Formerly, if you created a company assistant, you could not switch it
to personal. And if you switched it to shared, it disappeared from
your list

