### PR TITLE
[Ahuna] Add/remove from list component in assistant details

### DIFF
--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -133,8 +133,8 @@ export function AssistantDetails({
             variant="button"
             tryButton={showTryButtonInMenu}
             onAgentDeletion={() => {
-              onClose();
               void mutateAgentConfiguration();
+              onClose({ shouldMutateAgentConfigurations: true });
             }}
           />
         </div>

--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -94,9 +94,6 @@ export function AssistantDetails({
     setIsUpdatingScope(false);
   };
 
-  const showTryButtonInMenu =
-    agentConfiguration.scope === "published" &&
-    agentConfiguration.userListStatus === "not-in-list";
   const usageSentence =
     agentUsage.agentUsage &&
     `${agentUsage.agentUsage.messageCount} message(s) over the last ${
@@ -138,7 +135,7 @@ export function AssistantDetails({
             agentConfigurationId={agentConfiguration.sId}
             owner={owner}
             variant="button"
-            tryButton={showTryButtonInMenu}
+            tryButton
             onAgentDeletion={() => {
               void mutateAgentConfiguration();
               void mutateAgentConfigurations?.();

--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -23,7 +23,9 @@ import {
 } from "@dust-tt/types";
 import { useCallback, useContext, useEffect, useState } from "react";
 import ReactMarkdown from "react-markdown";
+import type { KeyedMutator } from "swr";
 
+import AssistantListActions from "@app/components/assistant/AssistantListActions";
 import { AssistantEditionMenu } from "@app/components/assistant/conversation/AssistantEditionMenu";
 import { SharingDropdown } from "@app/components/assistant/Sharing";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
@@ -31,21 +33,20 @@ import { updateAgentScope } from "@app/lib/client/dust_api";
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 import { useAgentConfiguration, useAgentUsage, useApp } from "@app/lib/swr";
 import { timeAgoFrom } from "@app/lib/utils";
+import type { GetAgentConfigurationsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
 
 type AssistantDetailsProps = {
   owner: WorkspaceType;
   show: boolean;
-  onClose: ({
-    shouldMutateAgentConfigurations,
-  }: {
-    shouldMutateAgentConfigurations: boolean;
-  }) => void | (() => void);
+  onClose: () => void;
+  mutateAgentConfigurations?: KeyedMutator<GetAgentConfigurationsResponseBody>;
   assistantId: string;
 };
 
 export function AssistantDetails({
   assistantId,
   onClose,
+  mutateAgentConfigurations,
   owner,
   show,
 }: AssistantDetailsProps) {
@@ -125,6 +126,12 @@ export function AssistantDetails({
             disabled={isUpdatingScope}
             setNewScope={(scope) => updateScope(scope)}
           />
+          <AssistantListActions
+            agentConfiguration={agentConfiguration}
+            owner={owner}
+            isParentHovered={true}
+            onAssistantListUpdate={() => void mutateAgentConfigurations?.()}
+          />
         </div>
         <div>
           <AssistantEditionMenu
@@ -134,7 +141,7 @@ export function AssistantDetails({
             tryButton={showTryButtonInMenu}
             onAgentDeletion={() => {
               void mutateAgentConfiguration();
-              onClose({ shouldMutateAgentConfigurations: true });
+              void mutateAgentConfigurations?.();
             }}
           />
         </div>
@@ -201,7 +208,7 @@ export function AssistantDetails({
     <Modal
       isOpen={show}
       title=""
-      onClose={() => onClose({ shouldMutateAgentConfigurations: false })}
+      onClose={() => onClose()}
       hasChanged={false}
       variant="side-sm"
     >

--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -55,11 +55,13 @@ export function AssistantDetails({
     workspaceId: owner.sId,
     agentConfigurationId: assistantId,
   });
-  const { agentConfiguration, mutateAgentConfiguration } =
-    useAgentConfiguration({
-      workspaceId: owner.sId,
-      agentConfigurationId: assistantId,
-    });
+  const {
+    agentConfiguration,
+    mutateAgentConfiguration: mutateCurrentAgentConfiguration,
+  } = useAgentConfiguration({
+    workspaceId: owner.sId,
+    agentConfigurationId: assistantId,
+  });
   const [isUpdatingScope, setIsUpdatingScope] = useState(false);
 
   if (!agentConfiguration) {
@@ -82,7 +84,7 @@ export function AssistantDetails({
         type: "success",
       });
 
-      await mutateAgentConfiguration();
+      await mutateCurrentAgentConfiguration();
     } else {
       sendNotification({
         title: `Error updating assistant sharing.`,
@@ -137,7 +139,7 @@ export function AssistantDetails({
             variant="button"
             tryButton
             onAgentDeletion={() => {
-              void mutateAgentConfiguration();
+              void mutateCurrentAgentConfiguration();
               void mutateAgentConfigurations?.();
             }}
           />

--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -133,8 +133,8 @@ export function AssistantDetails({
             variant="button"
             tryButton={showTryButtonInMenu}
             onAgentDeletion={() => {
+              onClose();
               void mutateAgentConfiguration();
-              onClose({ shouldMutateAgentConfigurations: true });
             }}
           />
         </div>

--- a/front/components/assistant/AssistantListActions.tsx
+++ b/front/components/assistant/AssistantListActions.tsx
@@ -20,12 +20,14 @@ interface AssistantListActions {
   agentConfiguration: LightAgentConfigurationType;
   owner: WorkspaceType;
   isParentHovered: boolean;
+  onAssistantListUpdate?: () => void;
 }
 
 export default function AssistantListActions({
   agentConfiguration,
   isParentHovered,
   owner,
+  onAssistantListUpdate,
 }: AssistantListActions) {
   const { scope } = agentConfiguration;
 
@@ -53,6 +55,7 @@ export default function AssistantListActions({
         title: `Assistant sharing updated.`,
         type: "success",
       });
+      onAssistantListUpdate?.();
     } else {
       sendNotification({
         title: `Error updating assistant sharing.`,

--- a/front/components/assistant/AssistantListActions.tsx
+++ b/front/components/assistant/AssistantListActions.tsx
@@ -55,7 +55,7 @@ export default function AssistantListActions({
         title: `Assistant sharing updated.`,
         type: "success",
       });
-      onAssistantListUpdate?.();
+      onAssistantListUpdate && onAssistantListUpdate();
     } else {
       sendNotification({
         title: `Error updating assistant sharing.`,

--- a/front/components/assistant/conversation/AssistantEditionMenu.tsx
+++ b/front/components/assistant/conversation/AssistantEditionMenu.tsx
@@ -30,10 +30,12 @@ interface AssistantEditionMenuProps {
   variant: "button" | "plain";
   onAgentDeletion?: () => void;
   tryButton?: boolean;
+  showAddRemoveToList: boolean;
 }
 
 AssistantEditionMenu.defaultProps = {
   variant: "plain",
+  showAddRemoveToList: false,
 };
 
 export function AssistantEditionMenu({
@@ -44,6 +46,7 @@ export function AssistantEditionMenu({
   owner,
   variant,
   onAgentDeletion,
+  showAddRemoveToList,
   tryButton,
 }: AssistantEditionMenuProps) {
   const [isUpdatingList, setIsUpdatingList] = useState(false);
@@ -105,7 +108,7 @@ export function AssistantEditionMenu({
 
     setIsUpdatingList(false);
   };
-  const showEditionHeader = isAgentPublished || tryButton;
+  const showEditionHeader = showAddRemoveToList || tryButton;
 
   const dropdownButton = (() => {
     switch (variant) {
@@ -188,7 +191,7 @@ export function AssistantEditionMenu({
             />
           )}
 
-          {isAgentPublished && (
+          {isAgentPublished && showAddRemoveToList && (
             <>
               <DropdownMenu.SectionHeader label="MY ASSISTANTS" />
               <DropdownMenu.Item

--- a/front/pages/w/[wId]/assistant/assistants.tsx
+++ b/front/pages/w/[wId]/assistant/assistants.tsx
@@ -179,10 +179,8 @@ export default function PersonalAssistants({
           owner={owner}
           assistantId={showDetails.sId}
           show={showDetails !== null}
-          onClose={({ shouldMutateAgentConfigurations }) => {
-            setShowDetails(null);
-            shouldMutateAgentConfigurations && void mutateAgentConfigurations();
-          }}
+          onClose={() => setShowDetails(null)}
+          mutateAgentConfigurations={mutateAgentConfigurations}
         />
       )}
 

--- a/front/pages/w/[wId]/assistant/assistants.tsx
+++ b/front/pages/w/[wId]/assistant/assistants.tsx
@@ -181,7 +181,7 @@ export default function PersonalAssistants({
           show={showDetails !== null}
           onClose={({ shouldMutateAgentConfigurations }) => {
             setShowDetails(null);
-            void mutateAgentConfigurations();
+            shouldMutateAgentConfigurations && void mutateAgentConfigurations();
           }}
         />
       )}

--- a/front/pages/w/[wId]/assistant/assistants.tsx
+++ b/front/pages/w/[wId]/assistant/assistants.tsx
@@ -181,7 +181,7 @@ export default function PersonalAssistants({
           show={showDetails !== null}
           onClose={({ shouldMutateAgentConfigurations }) => {
             setShowDetails(null);
-            shouldMutateAgentConfigurations && void mutateAgentConfigurations();
+            void mutateAgentConfigurations();
           }}
         />
       )}

--- a/front/pages/w/[wId]/assistant/gallery.tsx
+++ b/front/pages/w/[wId]/assistant/gallery.tsx
@@ -212,6 +212,7 @@ export default function AssistantsGallery({
           onClose={() => {
             setShowDetails(null);
           }}
+          mutateAgentConfigurations={mutateAgentConfigurations}
         />
       )}
       {testModalAssistant && (


### PR DESCRIPTION
## Description
 "Add/remove from list" component in assistant details
Therefore, add/remove is removed from the edition menu in assistantdetails (but can be added in other uses of the menu if needed)
Also, "try" button appears all the time now in assistant details (except for global assistants)
Also  ensures mutations of agentconfigrations are properly done

![image](https://github.com/dust-tt/dust/assets/5437393/60247eeb-1ad6-4f38-bca9-045a831ff7e7)
![Screenshot from 2024-02-05 22-59-08](https://github.com/dust-tt/dust/assets/5437393/f367c5ec-6278-4b11-8a99-c5708d03caf6)
![Screenshot from 2024-02-05 22-58-59](https://github.com/dust-tt/dust/assets/5437393/73f3b39a-87be-4fa3-8d69-cf77f450d112)



## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
