### PR TITLE
core: improve logging by moving to tracing functions

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -768,6 +768,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "176dc175b78f56c0f321911d9c8eb2b77a78a4860b9c19db83835fea1a46649b"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -793,12 +802,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.16"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
-dependencies = [
- "cfg-if",
-]
+checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
 name = "crypto-common"
@@ -824,6 +830,21 @@ name = "data-encoding"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
+
+[[package]]
+name = "datadog-formatting-layer"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c24bee29a5df84b892c932572622ebe8e4769d5c528db5cad928edb7a8d1f6cc"
+dependencies = [
+ "chrono",
+ "opentelemetry",
+ "serde",
+ "serde_json",
+ "tracing",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "debugid"
@@ -1011,6 +1032,7 @@ dependencies = [
  "chrono",
  "clap",
  "cloud-storage",
+ "datadog-formatting-layer",
  "deno_core",
  "dns-lookup",
  "eventsource-client",
@@ -2048,6 +2070,60 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "opentelemetry"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9591d937bc0e6d2feb6f71a559540ab300ea49955229c347a517a28d27784c54"
+dependencies = [
+ "opentelemetry_api",
+ "opentelemetry_sdk",
+]
+
+[[package]]
+name = "opentelemetry_api"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a81f725323db1b1206ca3da8bb19874bbd3f57c3bcd59471bfb04525b265b9b"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "indexmap 1.9.3",
+ "js-sys",
+ "once_cell",
+ "pin-project-lite",
+ "thiserror",
+ "urlencoding",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa8e705a0612d48139799fcbaba0d4a90f06277153e43dd2bdc16c6f0edd8026"
+dependencies = [
+ "async-trait",
+ "crossbeam-channel",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "once_cell",
+ "opentelemetry_api",
+ "ordered-float",
+ "percent-encoding",
+ "rand",
+ "thiserror",
+]
+
+[[package]]
+name = "ordered-float"
+version = "3.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1e1c390732d15f1d48471625cd92d154e66db2c56645e29a9cd26f4699f72dc"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -3526,6 +3602,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-opentelemetry"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75327c6b667828ddc28f5e3f169036cb793c3f588d83bf0f262a7f062ffed3c8"
+dependencies = [
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3535,12 +3635,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -56,10 +56,11 @@ cloud-storage = { version = "0.11", features = ["global-client"] }
 qdrant-client = "1.6"
 tower-http = {version = "0.4", features = ["full"]}
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 deno_core = "0.200"
 rayon = "1.8.0"
 clap = { version = "4.4", features = ["derive"] }
 async-recursion = "1.0"
 chrono = "0.4.31"
 yup-oauth2 = "8.3.0"
+datadog-formatting-layer = "1.1"

--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -42,8 +42,7 @@ use tokio::{
 };
 use tokio_stream::Stream;
 use tower_http::trace::{self, TraceLayer};
-use tracing::Level;
-use tracing::{error, info};
+use tracing::{error, info, Level};
 use tracing_subscriber::prelude::*;
 
 /// API State

--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -10,6 +10,7 @@ use axum::{
     routing::{delete, get, patch, post},
     Router,
 };
+use datadog_formatting_layer::DatadogFormattingLayer;
 use dust::{
     app,
     blocks::block::BlockType,
@@ -26,7 +27,7 @@ use dust::{
     sqlite_workers::client::{self, HEARTBEAT_INTERVAL_MS},
     stores::postgres,
     stores::store,
-    utils::{self, error_response, APIError, APIResponse},
+    utils::{error_response, APIError, APIResponse},
 };
 use futures::future::try_join_all;
 use hyper::http::StatusCode;
@@ -42,6 +43,8 @@ use tokio::{
 use tokio_stream::Stream;
 use tower_http::trace::{self, TraceLayer};
 use tracing::Level;
+use tracing::{error, info};
+use tracing_subscriber::prelude::*;
 
 /// API State
 
@@ -84,10 +87,10 @@ impl APIState {
         loop {
             let pending_runs = {
                 let manager = self.run_manager.lock();
-                utils::info(&format!(
-                    "[GRACEFUL] {} stop_loop pending runs",
-                    manager.pending_runs.len()
-                ));
+                info!(
+                    pending_runs = manager.pending_runs.len(),
+                    "[GRACEFUL] stop_loop pending runs",
+                );
                 manager.pending_runs.len()
             };
             if pending_runs == 0 {
@@ -120,15 +123,15 @@ impl APIState {
                     let now = std::time::Instant::now();
                     match app.0.run(app.1, store, qdrant_clients, None).await {
                         Ok(()) => {
-                            utils::done(&format!(
-                                "Run finished: run=`{}` app_version=`{}` elapsed=`{} ms`",
-                                app.0.run_ref().unwrap().run_id(),
-                                app.0.hash(),
-                                now.elapsed().as_millis(),
-                            ));
+                            info!(
+                                run = app.0.run_ref().unwrap().run_id(),
+                                app_version = app.0.hash(),
+                                elapsed = now.elapsed().as_millis(),
+                                "Run finished"
+                            );
                         }
                         Err(e) => {
-                            utils::error(&format!("Run error: {}", e));
+                            error!(error = %e, "Run error");
                         }
                     }
                     {
@@ -143,7 +146,7 @@ impl APIState {
             tokio::time::sleep(std::time::Duration::from_millis(4)).await;
             if loop_count % 1024 == 0 {
                 let manager = self.run_manager.lock();
-                utils::info(&format!("{} pending runs", manager.pending_runs.len()));
+                info!(pending_runs = manager.pending_runs.len(), "Pending runs");
             }
             // Roughly every 4 minutes, cleanup dead SQLite workers if any.
             if loop_count % 65536 == 0 {
@@ -154,7 +157,7 @@ impl APIState {
                         .await
                     {
                         Err(e) => {
-                            utils::error(&format!("Failed to cleanup SQLite workers: {}", e));
+                            error!(error = %e, "Failed to cleanup SQLite workers");
                         }
                         Ok(_) => (),
                     }
@@ -685,13 +688,10 @@ async fn run_helper(
             ))?
         }
 
-        utils::info(
-            format!(
-                "Retrieved {} records from latest data version for `{}`.",
-                d.as_ref().unwrap().len(),
-                payload.dataset_id.as_ref().unwrap(),
-            )
-            .as_str(),
+        info!(
+            dataset_id = payload.dataset_id.as_ref().unwrap(),
+            records = d.as_ref().unwrap().len(),
+            "Retrieved latest version of dataset"
         );
     }
 
@@ -705,8 +705,7 @@ async fn run_helper(
             ))?,
             Ok(d) => Some(d),
         };
-
-        utils::info(format!("Received {} inputs.", d.as_ref().unwrap().len(),).as_str());
+        info!(records = d.as_ref().unwrap().len(), "Received inputs");
     }
 
     // Only register the specification if it was not passed by hash.
@@ -821,15 +820,15 @@ async fn runs_create_stream(
                     .await
                 {
                     Ok(()) => {
-                        utils::done(&format!(
-                            "Run finished: run=`{}` app_version=`{}` elapsed=`{} ms`",
-                            app.run_ref().unwrap().run_id(),
-                            app.hash(),
-                            now.elapsed().as_millis(),
-                        ));
+                        info!(
+                            run = app.run_ref().unwrap().run_id(),
+                            app_version = app.hash(),
+                            elapsed = now.elapsed().as_millis(),
+                            "Run finished"
+                        );
                     }
                     Err(e) => {
-                        utils::error(&format!("Run error: {}", e));
+                        error!(error = %e, "Run error");
                     }
                 }
             });
@@ -857,7 +856,7 @@ async fn runs_create_stream(
             match Event::default().json_data(v) {
                 Ok(event) => yield Ok(event),
                 Err(e) => {
-                    utils::error(&format!("Failed to create SSE event: {}", e));
+                    error!(error = %e, "Failed to create SSE event");
                 }
             };
         }
@@ -867,7 +866,7 @@ async fn runs_create_stream(
         })) {
             Ok(event) => yield Ok(event),
             Err(e) => {
-                utils::error(&format!("Failed to create SSE event: {}", e));
+                error!(error = %e, "Failed to create SSE event");
             }
         };
     };
@@ -2353,10 +2352,9 @@ fn main() {
         .unwrap();
 
     let r = rt.block_on(async {
-        tracing_subscriber::fmt()
-            .with_target(false)
-            .compact()
-            .with_ansi(false)
+        tracing_subscriber::registry()
+            .with(DatadogFormattingLayer)
+            .with(tracing_subscriber::EnvFilter::new("info"))
             .init();
 
         let store: Box<dyn store::Store + Sync + Send> = match std::env::var("CORE_DATABASE_URI") {
@@ -2548,30 +2546,30 @@ fn main() {
 
         tokio::spawn(async move {
             if let Err(e) = srv.await {
-                utils::error(&format!("server error: {}", e));
+                error!(error = %e, "Server error");
             }
-            utils::info("[GRACEFUL] Server stopped");
+            info!("[GRACEFUL] Server stopped");
             tx2.send(()).ok();
         });
 
-        utils::info(&format!("Current PID: {}", std::process::id()));
+        info!(pid = std::process::id() as u64, "API server started");
 
         let mut stream = signal(SignalKind::terminate()).unwrap();
         stream.recv().await;
 
         // Gracefully shut down the server
-        utils::info("[GRACEFUL] SIGTERM received, stopping server...");
+        info!("[GRACEFUL] SIGTERM received, stopping server...");
         tx1.send(()).ok();
 
         // Wait for the server to shutdown
-        utils::info("[GRACEFUL] Awaiting server shutdown...");
+        info!("[GRACEFUL] Awaiting server shutdown...");
         rx2.await.ok();
 
         // Wait for the run loop to finish.
-        utils::info("[GRACEFUL] Awaiting stop loop...");
+        info!("[GRACEFUL] Awaiting stop loop...");
         state.stop_loop().await;
 
-        utils::info("[GRACEFUL] Exiting!");
+        info!("[GRACEFUL] Exiting!");
 
         // sleep for 1 second to allow the logger to flush
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
@@ -2582,7 +2580,7 @@ fn main() {
     match r {
         Ok(_) => (),
         Err(e) => {
-            utils::error(&format!("Error: {:?}", e));
+            error!(error = %e, "API Server error");
             std::process::exit(1);
         }
     }

--- a/core/bin/sqlite_worker.rs
+++ b/core/bin/sqlite_worker.rs
@@ -9,7 +9,7 @@ use dust::{
     databases::database::Table,
     databases_store::{self, store::DatabasesStore},
     sqlite_workers::sqlite_database::SqliteDatabase,
-    utils::{self, error_response, APIResponse},
+    utils::{error_response, APIResponse},
 };
 use hyper::{Body, Client, Request, StatusCode};
 use serde::Deserialize;
@@ -25,7 +25,7 @@ use std::{
 use tokio::signal::unix::{signal, SignalKind};
 use tokio::sync::Mutex;
 use tower_http::trace::{self, TraceLayer};
-use tracing::Level;
+use tracing::{error, info, Level};
 
 // Duration after which a database is considered inactive and can be removed from the registry.
 const DATABASE_TIMEOUT_DURATION: Duration = std::time::Duration::from_secs(5 * 60); // 5 minutes
@@ -64,7 +64,12 @@ impl WorkerState {
 
             match self.heartbeat().await {
                 Ok(_) => (),
-                Err(e) => utils::error(&format!("Failed to send heartbeat: {:?}", e)),
+                Err(e) => {
+                    error!(
+                        error = %e,
+                        "Failed to send heartbeat."
+                    );
+                }
             }
 
             self.cleanup_inactive_databases().await;
@@ -306,39 +311,50 @@ fn main() {
 
         tokio::spawn(async move {
             if let Err(e) = srv.await {
-                utils::error(&format!("server error: {}", e));
+                error!(
+                    error = %e,
+                    "Server error."
+                );
             }
-            utils::info("[GRACEFUL] Server stopped");
+            info!("[GRACEFUL] Server stopped");
             tx2.send(()).ok();
         });
 
-        utils::info(&format!("Current PID: {}", std::process::id()));
+        info!(
+            pid = std::process::id() as u64,
+            "SQLITE WORKER server started"
+        );
 
         let mut stream = signal(SignalKind::terminate()).unwrap();
         stream.recv().await;
 
         // Gracefully shut down the server.
-        utils::info("[GRACEFUL] SIGTERM received.");
+        info!("[GRACEFUL] SIGTERM received");
 
         // Tell core to stop sending requests.
-        utils::info("[GRACEFUL] Sending shutdown request to core...");
+        info!("[GRACEFUL] Sending shutdown request to core...");
         match state.shutdown().await {
-            Ok(_) => utils::info("[GRACEFUL] Shutdown request sent."),
-            Err(e) => utils::error(&format!("Failed to send shutdown request: {:?}", e)),
+            Ok(_) => info!("[GRACEFUL] Shutdown request sent."),
+            Err(e) => {
+                error!(
+                    error = %e,
+                    "Failed to send shutdown request."
+                );
+            }
         }
 
-        utils::info("[GRACEFUL] Shutting down server...");
+        info!("[GRACEFUL] Shutting down server...");
         tx1.send(()).ok();
 
         // Wait for the server to shutdown
-        utils::info("[GRACEFUL] Awaiting server shutdown...");
+        info!("[GRACEFUL] Awaiting server shutdown...");
         rx2.await.ok();
 
         // Wait for the SQLite queries to finish.
-        utils::info("[GRACEFUL] Awaiting database queries to finish...");
+        info!("[GRACEFUL] Awaiting database queries to finish...");
         state.await_pending_queries().await;
 
-        utils::info("[GRACEFUL] Exiting in 1 second...");
+        info!("[GRACEFUL] Exiting in 1 second...");
 
         // sleep for 1 second to allow the logger to flush
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
@@ -349,7 +365,7 @@ fn main() {
     match r {
         Ok(_) => (),
         Err(e) => {
-            utils::error(&format!("Error: {:?}", e));
+            error!(error = %e, "SQLITE WORKER Server error");
             std::process::exit(1);
         }
     }

--- a/core/bin/sqlite_worker.rs
+++ b/core/bin/sqlite_worker.rs
@@ -69,7 +69,7 @@ impl WorkerState {
                 Err(e) => {
                     error!(
                         error = %e,
-                        "Failed to send heartbeat."
+                        "Failed to send heartbeat"
                     );
                 }
             }
@@ -312,10 +312,7 @@ fn main() {
 
         tokio::spawn(async move {
             if let Err(e) = srv.await {
-                error!(
-                    error = %e,
-                    "Server error."
-                );
+                error!(error = %e, "Server error");
             }
             info!("[GRACEFUL] Server stopped");
             tx2.send(()).ok();
@@ -335,11 +332,11 @@ fn main() {
         // Tell core to stop sending requests.
         info!("[GRACEFUL] Sending shutdown request to core...");
         match state.shutdown().await {
-            Ok(_) => info!("[GRACEFUL] Shutdown request sent."),
+            Ok(_) => info!("[GRACEFUL] Shutdown request sent"),
             Err(e) => {
                 error!(
                     error = %e,
-                    "Failed to send shutdown request."
+                    "Failed to send shutdown request"
                 );
             }
         }

--- a/core/src/data_sources/splitter.rs
+++ b/core/src/data_sources/splitter.rs
@@ -11,6 +11,7 @@ use std::collections::HashSet;
 use std::fmt;
 use std::{cmp, str::FromStr};
 use tokio::try_join;
+use tracing::info;
 
 #[derive(Debug, Clone)]
 pub struct TokenizedText {
@@ -492,11 +493,11 @@ impl Splitter for BaseV0Splitter {
         let tokenized_section =
             TokenizedSection::from(&embedder, max_chunk_size, vec![], &section, None).await?;
 
-        utils::info(&format!(
-            "Splitter: tokenized_section_tree_size={} duration={}",
-            tokenized_section.size(),
-            utils::now() - now
-        ));
+        info!(
+            tokenized_section_tree_size = tokenized_section.size(),
+            duration = utils::now() - now,
+            "Splitter tokenized section"
+        );
 
         now = utils::now();
 
@@ -509,11 +510,11 @@ impl Splitter for BaseV0Splitter {
             .map(|t| t.text)
             .collect();
 
-        utils::info(&format!(
-            "Splitter: chunks_count={} duration={}",
-            chunks.len(),
-            utils::now() - now
-        ));
+        info!(
+            chunks_count = chunks.len(),
+            duration = utils::now() - now,
+            "Splitter generated chunks"
+        );
 
         Ok(chunks)
     }

--- a/core/src/databases/database.rs
+++ b/core/src/databases/database.rs
@@ -11,6 +11,7 @@ use futures::future::try_join_all;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use tracing::info;
 
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -53,22 +54,22 @@ pub async fn query_database(
         ))?,
     };
 
-    utils::done(&format!(
-        "DSSTRUCTSTAT Finished executing user query on worker: duration={}ms",
-        utils::now() - time_query_start
-    ));
+    info!(
+        duration = utils::now() - time_query_start,
+        "DSSTRUCTSTAT Finished executing user query on worker"
+    );
 
     let infer_result_schema_start = utils::now();
     let table_schema = TableSchema::from_rows(&result_rows)?;
-    utils::done(&format!(
-        "DSSTRUCTSTAT Finished inferring schema: duration={}ms",
-        utils::now() - infer_result_schema_start
-    ));
 
-    utils::done(&format!(
-        "DSSTRUCTSTAT Finished query database: duration={}ms",
-        utils::now() - time_query_start
-    ));
+    info!(
+        duration = utils::now() - infer_result_schema_start,
+        "DSSTRUCTSTAT Finished inferring schema"
+    );
+    info!(
+        duration = utils::now() - time_query_start,
+        "DSSTRUCTSTAT Finished query database"
+    );
 
     Ok((result_rows, table_schema))
 }

--- a/core/src/http/request.rs
+++ b/core/src/http/request.rs
@@ -11,6 +11,7 @@ use regex::Regex;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::io::prelude::*;
+use tracing::info;
 use url::{Host, Url};
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
@@ -204,18 +205,22 @@ impl HttpRequest {
 
         match response {
             Some(response) => {
-                utils::done(&format!(
-                    "Retrieved cached HTTPRequest cached: method={} url={} hash={}",
-                    self.method, self.url, self.hash,
-                ));
+                info!(
+                    method = self.method.as_str(),
+                    url = self.url.as_str(),
+                    hash = self.hash.as_str(),
+                    "Retrieved cached HTTPRequest"
+                );
                 Ok(response)
             }
             None => {
                 let response = self.execute().await?;
-                utils::done(&format!(
-                    "Performed fresh HTTPRequest: method={} url={} hash={}",
-                    self.method, self.url, self.hash,
-                ));
+                info!(
+                    method = self.method.as_str(),
+                    url = self.url.as_str(),
+                    hash = self.hash.as_str(),
+                    "Performed fresh HTTPRequest"
+                );
                 store.http_cache_store(&project, self, &response).await?;
                 Ok(response)
             }

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -72,7 +72,6 @@ pub fn now() -> u64 {
         .as_millis() as u64
 }
 
-// TODO(spolu): maybe make async eventually
 pub fn info(msg: &str) {
     println!("{} {}", "[i]", msg);
 }


### PR DESCRIPTION
## Description

- Move all server logs to using tracing info/error
- Add a datadog formater to the tracing_subscriber

The goal is to move `core` logs to be datadog parseable.

Kept `utils::{info, done, error}` for all command line operations (eg: qdrant_migrator)

## Risk

Logs get messed up

## Deploy Plan

- deploy `core`