### PR TITLE
fix: unlink table from agent configuration on delete

### DIFF
--- a/front/pages/api/w/[wId]/data_sources/[name]/tables/[tId]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/tables/[tId]/index.ts
@@ -5,6 +5,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { getDataSource } from "@app/lib/api/data_sources";
 import { isFeatureEnabled } from "@app/lib/api/feature_flags";
 import { Authenticator, getSession } from "@app/lib/auth";
+import { AgentTablesQueryConfigurationTable } from "@app/lib/models/assistant/actions/tables_query";
 import logger from "@app/logger/logger";
 import { apiError, withLogging } from "@app/logger/withlogging";
 
@@ -113,6 +114,14 @@ async function handler(
       return res.status(200).json({ table });
 
     case "DELETE":
+      // Delete any AgentTableConfigurationTable that references this table
+      await AgentTablesQueryConfigurationTable.destroy({
+        where: {
+          dataSourceWorkspaceId: owner.sId,
+          dataSourceId: dataSource.name,
+          tableId,
+        },
+      });
       const deleteRes = await coreAPI.deleteTable({
         projectId: dataSource.dustAPIProjectId,
         dataSourceName: dataSource.name,


### PR DESCRIPTION
## Description

We currently have a bug where deleting a table that is used by an assistant causes the assistant to crash (can't edit from builder / can't talk to it).

The right solution is to delete the config row that links the table to the assistant when deleting the table. I will manually cleanup the existing assistants
## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
