### PR TITLE
Add fallback assistant suggestions

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -43,7 +43,7 @@ const InputBarContainer = ({
   selectedAssistant,
   stickyMentions,
 }: InputBarContainerProps) => {
-  const suggestions = useAssistantSuggestions(agentConfigurations);
+  const suggestions = useAssistantSuggestions(agentConfigurations, owner);
 
   const [isExpanded, setIsExpanded] = useState(false);
   function handleExpansionToggle() {

--- a/front/components/assistant/conversation/input_bar/editor/useCustomEditor.tsx
+++ b/front/components/assistant/conversation/input_bar/editor/useCustomEditor.tsx
@@ -5,10 +5,7 @@ import { useEditor } from "@tiptap/react";
 import { StarterKit } from "@tiptap/starter-kit";
 import { useMemo } from "react";
 
-import type {
-  EditorSuggestion,
-  EditorSuggestions,
-} from "@app/components/assistant/conversation/input_bar/editor/suggestion";
+import type { EditorSuggestions } from "@app/components/assistant/conversation/input_bar/editor/suggestion";
 import { makeGetAssistantSuggestions } from "@app/components/assistant/conversation/input_bar/editor/suggestion";
 
 export interface EditorMention {

--- a/front/components/assistant/conversation/input_bar/editor/useCustomEditor.tsx
+++ b/front/components/assistant/conversation/input_bar/editor/useCustomEditor.tsx
@@ -5,7 +5,10 @@ import { useEditor } from "@tiptap/react";
 import { StarterKit } from "@tiptap/starter-kit";
 import { useMemo } from "react";
 
-import type { EditorSuggestion } from "@app/components/assistant/conversation/input_bar/editor/suggestion";
+import type {
+  EditorSuggestion,
+  EditorSuggestions,
+} from "@app/components/assistant/conversation/input_bar/editor/suggestion";
 import { makeGetAssistantSuggestions } from "@app/components/assistant/conversation/input_bar/editor/suggestion";
 
 export interface EditorMention {
@@ -130,7 +133,7 @@ export interface CustomEditorProps {
     textAndMentions: ReturnType<typeof getTextAndMentionsFromNode>,
     clearEditor: () => void
   ) => void;
-  suggestions: EditorSuggestion[];
+  suggestions: EditorSuggestions;
   resetEditorContainerSize: () => void;
 }
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR resolves https://github.com/dust-tt/dust/issues/3277.

This PR introduces the concept of fallback suggestions to the assistant suggestions in our input bar. The primary goal is to initially recommend assistants from the user's personal list. If the list yields less than 7 suggestions, it then includes accessible assistants not present on the user’s list. The two sets of suggestions will be sorted respectively. We may revisit this sorting approach in the future.

This enhancement does not impact the speed of suggestions. Initially, as we fetch all suggestions, only those from the user's list will be displayed.

![assistantSuggestions](https://github.com/dust-tt/dust/assets/7428970/7a511266-03fc-4a26-92a1-ce2e91867814)
In this GIF, `dusttestflavien` isn't in my list, but is suggested when we have less than 7 suggestions.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
