### PR TITLE
Adding Webcrawler settings - backend only

### DIFF
--- a/connectors/src/connectors/webcrawler/index.ts
+++ b/connectors/src/connectors/webcrawler/index.ts
@@ -1,4 +1,5 @@
 import type { ConnectorResource, ModelId } from "@dust-tt/types";
+import { WEBCRAWLER_MAX_DEPTH, WEBCRAWLER_MAX_PAGES } from "@dust-tt/types";
 
 import {
   getDisplayNameForPage,
@@ -43,6 +44,9 @@ export async function createWebcrawlerConnector(
         {
           connectorId: connector.id,
           url,
+          maxPageToCrawl: WEBCRAWLER_MAX_PAGES,
+          depth: WEBCRAWLER_MAX_DEPTH,
+          crawlMode: "website",
         },
         {
           transaction: t,

--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -1,5 +1,6 @@
-import type { ModelId } from "@dust-tt/types";
 import type { CoreAPIDataSourceDocumentSection } from "@dust-tt/types";
+import type { ModelId } from "@dust-tt/types";
+import { WEBCRAWLER_MAX_DEPTH, WEBCRAWLER_MAX_PAGES } from "@dust-tt/types";
 import { Context } from "@temporalio/activity";
 import { isCancellation } from "@temporalio/workflow";
 import { CheerioCrawler, Configuration } from "crawlee";
@@ -30,8 +31,6 @@ import {
 } from "@connectors/lib/sync_status";
 import logger from "@connectors/logger/logger";
 
-const MAX_DEPTH = 5;
-const MAX_PAGES = 512;
 const CONCURRENCY = 4;
 
 export async function crawlWebsiteByConnectorId(connectorId: ModelId) {
@@ -56,7 +55,10 @@ export async function crawlWebsiteByConnectorId(connectorId: ModelId) {
 
   const crawler = new CheerioCrawler(
     {
-      maxRequestsPerCrawl: MAX_PAGES,
+      maxRequestsPerCrawl: Math.min(
+        webCrawlerConfig.maxPageToCrawl || WEBCRAWLER_MAX_PAGES,
+        WEBCRAWLER_MAX_PAGES
+      ),
       maxConcurrency: CONCURRENCY,
       maxRequestsPerMinute: 60, // 5 requests per second to avoid overloading the target website
       requestHandlerTimeoutSecs: REQUEST_HANDLING_TIMEOUT,
@@ -86,7 +88,22 @@ export async function crawlWebsiteByConnectorId(connectorId: ModelId) {
             depth: request.userData.depth ? request.userData.depth + 1 : 1,
           },
           transformRequestFunction: (req) => {
-            if (request.userData.depth > MAX_DEPTH) {
+            if (webCrawlerConfig.crawlMode === "childs") {
+              // We only want to crawl children of the original url
+              if (
+                !new URL(req.url).pathname.startsWith(
+                  new URL(webCrawlerConfig.url).pathname
+                )
+              ) {
+                // path is not a child of the original url
+                return false;
+              }
+            }
+            if (
+              request.userData.depth > WEBCRAWLER_MAX_DEPTH ||
+              (webCrawlerConfig.depth &&
+                request.userData.depth > webCrawlerConfig.depth)
+            ) {
               logger.info(
                 {
                   depth: request.userData.depth,

--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -88,7 +88,7 @@ export async function crawlWebsiteByConnectorId(connectorId: ModelId) {
             depth: request.userData.depth ? request.userData.depth + 1 : 1,
           },
           transformRequestFunction: (req) => {
-            if (webCrawlerConfig.crawlMode === "childs") {
+            if (webCrawlerConfig.crawlMode === "child") {
               // We only want to crawl children of the original url
               if (
                 !new URL(req.url).pathname.startsWith(

--- a/connectors/src/lib/models/webcrawler.ts
+++ b/connectors/src/lib/models/webcrawler.ts
@@ -17,6 +17,9 @@ export class WebCrawlerConfiguration extends Model<
   declare updatedAt: CreationOptional<Date>;
   declare url: string;
   declare connectorId: ForeignKey<Connector["id"]>;
+  declare maxPageToCrawl: number | null;
+  declare crawlMode: "childs" | "website";
+  declare depth: number | null;
 }
 
 WebCrawlerConfiguration.init(
@@ -39,6 +42,19 @@ WebCrawlerConfiguration.init(
     url: {
       type: DataTypes.STRING,
       allowNull: false,
+    },
+    maxPageToCrawl: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+    },
+    crawlMode: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      defaultValue: true,
+    },
+    depth: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
     },
   },
   {

--- a/connectors/src/lib/models/webcrawler.ts
+++ b/connectors/src/lib/models/webcrawler.ts
@@ -18,7 +18,7 @@ export class WebCrawlerConfiguration extends Model<
   declare url: string;
   declare connectorId: ForeignKey<Connector["id"]>;
   declare maxPageToCrawl: number | null;
-  declare crawlMode: "childs" | "website";
+  declare crawlMode: "child" | "website";
   declare depth: number | null;
 }
 
@@ -48,7 +48,7 @@ WebCrawlerConfiguration.init(
       allowNull: true,
     },
     crawlMode: {
-      type: DataTypes.STRING,
+      type: DataTypes.STRING(20),
       allowNull: false,
       defaultValue: true,
     },

--- a/types/src/connectors/webcrawler.ts
+++ b/types/src/connectors/webcrawler.ts
@@ -1,0 +1,2 @@
+export const WEBCRAWLER_MAX_DEPTH = 5;
+export const WEBCRAWLER_MAX_PAGES = 512;

--- a/types/src/index.ts
+++ b/types/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./connectors/api";
 export * from "./connectors/api_handlers/create_connector";
 export * from "./connectors/notion";
+export * from "./connectors/webcrawler";
 export * from "./core/data_source";
 export * from "./front/api_handlers/internal/agent_configuration";
 export * from "./front/api_handlers/internal/assistant";


### PR DESCRIPTION
## Description

Adding web crawler settings at the connector level.
Settings added:
- Max pages to crawl
- Max depth
- Crawl only childs of the provided URL or the full website.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- Deploy connectors edge
- Run initdb from connectors edege
- Deploy connector
