### PR TITLE
[Ahuna] Update 'Manage assistants' page for builders

### DIFF
--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -34,6 +34,7 @@ import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 import { useAgentConfiguration, useAgentUsage, useApp } from "@app/lib/swr";
 import { timeAgoFrom } from "@app/lib/utils";
 import type { GetAgentConfigurationsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
+import { assistantUsageMessage } from "@app/lib/assistant";
 
 type AssistantDetailsProps = {
   owner: WorkspaceType;
@@ -98,11 +99,13 @@ export function AssistantDetails({
     setIsUpdatingScope(false);
   };
 
-  const usageSentence =
-    agentUsage.agentUsage &&
-    `${agentUsage.agentUsage.messageCount} message(s) over the last ${
-      agentUsage.agentUsage.timePeriodSec / (60 * 60 * 24)
-    } days`;
+  const usageSentence = assistantUsageMessage({
+    assistantName: agentConfiguration.name,
+    usage: agentUsage.agentUsage,
+    isLoading: agentUsage.isAgentUsageLoading,
+    isError: agentUsage.isAgentUsageError,
+    shortVersion: true,
+  });
   const editedSentence =
     agentConfiguration.versionCreatedAt &&
     `Last edited ${timeAgoFrom(

--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -29,12 +29,12 @@ import AssistantListActions from "@app/components/assistant/AssistantListActions
 import { AssistantEditionMenu } from "@app/components/assistant/conversation/AssistantEditionMenu";
 import { SharingDropdown } from "@app/components/assistant/Sharing";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
+import { assistantUsageMessage } from "@app/lib/assistant";
 import { updateAgentScope } from "@app/lib/client/dust_api";
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 import { useAgentConfiguration, useAgentUsage, useApp } from "@app/lib/swr";
 import { timeAgoFrom } from "@app/lib/utils";
 import type { GetAgentConfigurationsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
-import { assistantUsageMessage } from "@app/lib/assistant";
 
 type AssistantDetailsProps = {
   owner: WorkspaceType;

--- a/front/components/assistant/Sharing.tsx
+++ b/front/components/assistant/Sharing.tsx
@@ -31,6 +31,7 @@ type ConfirmationModalDataType = {
 export const SCOPE_INFO: Record<
   AgentConfigurationScope,
   {
+    shortLabel: string;
     label: string;
     color: "pink" | "amber" | "sky" | "slate";
     icon: typeof UserGroupIcon | typeof PlanetIcon | typeof LockIcon;
@@ -39,6 +40,7 @@ export const SCOPE_INFO: Record<
   }
 > = {
   published: {
+    shortLabel: "Shared",
     label: "Shared Assistant",
     color: "pink",
     icon: UserGroupIcon,
@@ -51,6 +53,7 @@ export const SCOPE_INFO: Record<
     },
   },
   workspace: {
+    shortLabel: "Company",
     label: "Company Assistant",
     color: "amber",
     icon: PlanetIcon,
@@ -63,6 +66,7 @@ export const SCOPE_INFO: Record<
     },
   },
   private: {
+    shortLabel: "Personal",
     label: "Personal Assistant",
     color: "sky",
     icon: LockIcon,
@@ -76,6 +80,7 @@ export const SCOPE_INFO: Record<
     },
   },
   global: {
+    shortLabel: "Default",
     label: "Default Assistant",
     color: "slate",
     icon: DustIcon,

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -109,17 +109,24 @@ export function assistantUsageMessage({
   usage,
   isLoading,
   isError,
+  shortVersion,
 }: {
   assistantName: string;
   usage: AgentUsageType | null;
   isLoading: boolean;
   isError: boolean;
+  shortVersion?: boolean;
 }) {
   if (isError) {
     return "Error loading usage data.";
   } else if (isLoading) {
     return "Loading usage data...";
   } else if (usage) {
+    if (shortVersion) {
+      return `${usage.messageCount} message(s) over the last ${
+        usage.timePeriodSec / (60 * 60 * 24)
+      } days`;
+    }
     return `@${assistantName} has been used by ${usage.userCount} ${
       usage.userCount > 1 ? "people" : "person"
     } in ${usage.messageCount} message${

--- a/front/pages/w/[wId]/builder/assistants/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/index.tsx
@@ -5,18 +5,13 @@ import {
   Button,
   Cog6ToothIcon,
   ContextItem,
-  DropdownMenu,
   Page,
-  PencilSquareIcon,
   PlusIcon,
   Popup,
-  RobotIcon,
   RobotSharedIcon,
   Searchbar,
   SliderToggle,
   Tab,
-  TrashIcon,
-  XMarkIcon,
 } from "@dust-tt/sparkle";
 import type { AgentConfigurationScope, SubscriptionType } from "@dust-tt/types";
 import type {
@@ -29,10 +24,8 @@ import Link from "next/link";
 import { useRouter } from "next/router";
 import { useState } from "react";
 
-import {
-  DeleteAssistantDialog,
-  RemoveAssistantFromWorkspaceDialog,
-} from "@app/components/assistant/AssistantActions";
+import { AssistantDetails } from "@app/components/assistant/AssistantDetails";
+import { SCOPE_INFO } from "@app/components/assistant/Sharing";
 import { EmptyCallToAction } from "@app/components/EmptyCallToAction";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { subNavigationBuild } from "@app/components/sparkle/navigation";
@@ -44,9 +37,6 @@ import { Authenticator, getSession } from "@app/lib/auth";
 import { useAgentConfigurations, useFeatures } from "@app/lib/swr";
 import { subFilter } from "@app/lib/utils";
 import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
-import { SCOPE_INFO } from "@app/components/assistant/Sharing";
-import { AssistantDetails } from "@app/components/assistant/AssistantDetails";
-import def from "ajv/dist/vocabularies/discriminator";
 
 const { GA_TRACKING_ID = "" } = process.env;
 

--- a/front/pages/w/[wId]/builder/assistants/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/index.tsx
@@ -55,7 +55,7 @@ export const getServerSideProps = withGetServerSidePropsLogging<{
   const owner = auth.workspace();
   const subscription = auth.subscription();
 
-  if (!owner || !auth.isUser() || !subscription) {
+  if (!owner || !auth.isBuilder() || !subscription) {
     return {
       notFound: true,
     };

--- a/front/pages/w/[wId]/builder/assistants/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/index.tsx
@@ -1,4 +1,5 @@
 import {
+  AssistantPreview2,
   Avatar,
   BookOpenIcon,
   Button,
@@ -272,6 +273,23 @@ function AgentViewForScope({
   setShowDisabledFreeWorkspacePopup: (s: string | null) => void;
 }) {
   const router = useRouter();
+  if (tabScope === "published") {
+    return (
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+        {agents.map((a) => (
+          <AssistantPreview2
+            key={a.sId}
+            title={a.name}
+            pictureUrl={a.pictureUrl}
+            subtitle={a.lastAuthors?.join(", ") ?? ""}
+            description={a.description}
+            variant="list"
+            onClick={() => setShowDetails(a)}
+          />
+        ))}
+      </div>
+    );
+  }
 
   return (
     <ContextItem.List>
@@ -323,7 +341,8 @@ function AgentViewForScope({
           label="Manage"
           size="sm"
           disabled={!isBuilder(owner)}
-          onClick={() => {
+          onClick={(e) => {
+            e.stopPropagation();
             void router.push(`/w/${owner.sId}/builder/assistants/dust`);
           }}
         />


### PR DESCRIPTION
## Description
Fixes #3266 

@Duncid two things regarding the tab subtitles
- Sparkle over figma => page.p larger, darker than figma
- Copy => reuses same text that's used in builder & modals (~ different in figma)

![image](https://github.com/dust-tt/dust/assets/5437393/071419d9-c446-4a50-a3d1-81bda30029ee)
![image](https://github.com/dust-tt/dust/assets/5437393/a56a0a91-d9f6-4bb5-8583-32f803a2416b)
![image](https://github.com/dust-tt/dust/assets/5437393/71d061d8-042c-4518-87f3-9f38d97567b3)
