### PR TITLE
fix: dont filter on active configs in conversation or agent view

### DIFF
--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -157,12 +157,15 @@ async function fetchGlobalAgentConfigurationForView(
       !agentPrefix || a.name.toLowerCase().startsWith(agentPrefix.toLowerCase())
   );
 
-  if (agentsGetView === "global") {
-    // Only global agents in global view.`
+  if (
+    agentsGetView === "global" ||
+    (typeof agentsGetView === "object" && "agentId" in agentsGetView)
+  ) {
+    // All global agents in global and agent views.
     return matchingGlobalAgents;
   }
 
-  // If not in global view, filter out global agents that are not active.
+  // If not in global or agent view, filter out global agents that are not active.
   return matchingGlobalAgents.filter((a) => a.status === "active");
 }
 


### PR DESCRIPTION
## Description

fixes https://github.com/dust-tt/tasks/issues/405

In agent view, inactive global agents should still be returned

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
