### PR TITLE
Refactor: ContextItem uses css for last item separator + ContextItem.List allows wrappers

### DIFF
--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.87",
+  "version": "0.2.88",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/components/ContextItem.tsx
+++ b/sparkle/src/components/ContextItem.tsx
@@ -8,6 +8,7 @@ type ContextItemProps = {
   action?: ReactNode;
   children?: ReactNode;
   hasSeparator?: boolean;
+  hasSeparatorIfLast?: boolean;
   subElement?: ReactNode;
   title: ReactNode;
   visual: ReactNode;
@@ -18,6 +19,7 @@ export function ContextItem({
   action,
   children,
   hasSeparator = true,
+  hasSeparatorIfLast = false,
   subElement,
   title,
   visual,
@@ -27,7 +29,8 @@ export function ContextItem({
     <div
       className={classNames(
         hasSeparator ? "s-border-b s-border-structure-200" : "",
-        "s-flex s-w-full s-flex-col"
+        "s-flex s-w-full s-flex-col",
+        hasSeparatorIfLast ? "" : "last:s-border-none"
       )}
     >
       <div
@@ -72,26 +75,20 @@ ContextItem.List = function ({
   React.Children.forEach(children, (child) => {
     if (
       !React.isValidElement(child) ||
-      (child.type !== ContextItem && child.type !== ContextItem.SectionHeader)
+      (child.type !== ContextItem &&
+        child.type !== ContextItem.SectionHeader) ||
+      // all children of child must be of type ContextItem or ContextItem.SectionHeader
+      React.Children.toArray(child.props.children).some(
+        (c) =>
+          !React.isValidElement(c) ||
+          (c.type !== ContextItem && c.type !== ContextItem.SectionHeader)
+      )
     ) {
       throw new Error(
         "All children of ContextItem.List must be of type ContextItem or ContextItem.SectionHeader"
       );
     }
   });
-
-  // Convert children into an array and modify the last child's props
-  const modifiedChildren = React.Children.toArray(children).map(
-    (child, index, array) => {
-      if (React.isValidElement(child) && index === array.length - 1) {
-        return React.cloneElement(child, {
-          ...child.props,
-          hasSeparator: false,
-        });
-      }
-      return child;
-    }
-  );
 
   return (
     <div
@@ -101,7 +98,7 @@ ContextItem.List = function ({
         "s-flex s-flex-col"
       )}
     >
-      {modifiedChildren}
+      {children}
     </div>
   );
 };

--- a/sparkle/src/components/ContextItem.tsx
+++ b/sparkle/src/components/ContextItem.tsx
@@ -73,16 +73,17 @@ ContextItem.List = function ({
 }: ContextItemListProps) {
   // Ensure all children are of type ContextItem or ContextItem.SectionHeader
   React.Children.forEach(children, (child) => {
+    if (child === null || child === undefined) return;
     if (
       !React.isValidElement(child) ||
       (child.type !== ContextItem &&
-        child.type !== ContextItem.SectionHeader) ||
-      // all children of child must be of type ContextItem or ContextItem.SectionHeader
-      React.Children.toArray(child.props.children).some(
-        (c) =>
-          !React.isValidElement(c) ||
-          (c.type !== ContextItem && c.type !== ContextItem.SectionHeader)
-      )
+        child.type !== ContextItem.SectionHeader &&
+        // all children of child must be of type ContextItem or ContextItem.SectionHeader
+        React.Children.toArray(child.props.children).some(
+          (c) =>
+            !React.isValidElement(c) ||
+            (c.type !== ContextItem && c.type !== ContextItem.SectionHeader)
+        ))
     ) {
       throw new Error(
         "All children of ContextItem.List must be of type ContextItem or ContextItem.SectionHeader"

--- a/sparkle/src/stories/ContextItem.stories.tsx
+++ b/sparkle/src/stories/ContextItem.stories.tsx
@@ -134,6 +134,7 @@ export const ListItemExample = () => (
       >
         <ContextItem.Description description="Lats, pricing, history of contacts, contact message" />
       </ContextItem>
+      {undefined}
     </ContextItem.List>
   </div>
 );


### PR DESCRIPTION
## Description
The way separator was removed from last item in contextitem.list prevented the list to have wrappers of ContextItems & sectionHeaders, which was  needed by issue #3261. See PR #3261 more specifically [here](https://github.com/dust-tt/dust/blob/f6b42b1af4cae2b2113ca2a16ae5d79dbe2e8fcb/front/pages/w/%5BwId%5D/assistant/assistants.tsx#L165) => it's not possible to have alternating contextitem / sectionheaders in a for loop in a single context list---while this is what the design required

Furthermore it looked ~costly (iterating over react elements + cloning at each rendering);

This PR switches to CSS to remove the list separator, and allows CI.List to have children that are direct wrappers of ContextItems / ContextItem.SectionHeaders

### Further note
The check that children of CI.List are ok seems kind of overkill too; maybe this could be done via types / interfaces?

## Risk
Places where ContextItems are used => I checked them out
