### PR TITLE
fix: close picker when clicking on assistant details button

### DIFF
--- a/front/components/assistant/AssistantPicker.tsx
+++ b/front/components/assistant/AssistantPicker.tsx
@@ -44,104 +44,114 @@ export function AssistantPicker({
 
   return (
     <DropdownMenu>
-      {showDetails && (
-        <AssistantDetails
-          owner={owner}
-          assistantId={showDetails.sId}
-          show={showDetails !== null}
-          onClose={() => {
-            setShowDetails(null);
-          }}
-        />
-      )}
+      {({ close }) => (
+        <>
+          {showDetails && (
+            <AssistantDetails
+              owner={owner}
+              assistantId={showDetails.sId}
+              show={showDetails !== null}
+              onClose={() => {
+                setShowDetails(null);
+              }}
+            />
+          )}
 
-      <div onClick={() => setSearchText("")} className="flex">
-        {pickerButton ? (
-          <DropdownMenu.Button size={size}>{pickerButton}</DropdownMenu.Button>
-        ) : (
-          <DropdownMenu.Button
-            icon={RobotIcon}
-            size={size}
-            tooltip="Pick an assistant"
-            tooltipPosition="above"
-          />
-        )}
-      </div>
-      <DropdownMenu.Items
-        origin="auto"
-        width={280}
-        topBar={
-          <>
-            {assistants.length > 7 && (
-              <div className="flex flex-grow flex-row border-b border-structure-50 p-2">
-                <Searchbar
-                  placeholder="Search"
-                  name="input"
-                  size="xs"
-                  value={searchText}
-                  onChange={setSearchText}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter" && searchedAssistants.length > 0) {
-                      onItemClick(searchedAssistants[0]);
-                      setSearchText("");
-                    }
+          <div onClick={() => setSearchText("")} className="flex">
+            {pickerButton ? (
+              <DropdownMenu.Button size={size}>
+                {pickerButton}
+              </DropdownMenu.Button>
+            ) : (
+              <DropdownMenu.Button
+                icon={RobotIcon}
+                size={size}
+                tooltip="Pick an assistant"
+                tooltipPosition="above"
+              />
+            )}
+          </div>
+          <DropdownMenu.Items
+            origin="auto"
+            width={280}
+            topBar={
+              <>
+                {assistants.length > 7 && (
+                  <div className="flex flex-grow flex-row border-b border-structure-50 p-2">
+                    <Searchbar
+                      placeholder="Search"
+                      name="input"
+                      size="xs"
+                      value={searchText}
+                      onChange={setSearchText}
+                      onKeyDown={(e) => {
+                        if (
+                          e.key === "Enter" &&
+                          searchedAssistants.length > 0
+                        ) {
+                          onItemClick(searchedAssistants[0]);
+                          setSearchText("");
+                        }
+                      }}
+                    />
+                  </div>
+                )}
+              </>
+            }
+            bottomBar={
+              <div className="flex border-t border-structure-50 p-2">
+                <Link
+                  href={`/w/${owner.sId}/builder/assistants/new?flow=personal_assistants`}
+                >
+                  <Button
+                    label="Create"
+                    size="xs"
+                    variant="primary"
+                    icon={PlusIcon}
+                    className="mr-2"
+                  />
+                </Link>
+                <div className="s-flex-grow" />
+                <Link href={`/w/${owner.sId}/assistant/assistants`}>
+                  <Button
+                    label="My Assistants"
+                    size="xs"
+                    variant="tertiary"
+                    icon={ListIcon}
+                  />
+                </Link>
+              </div>
+            }
+          >
+            {searchedAssistants.map((c) => (
+              <div
+                key={`assistant-picker-container-${c.sId}`}
+                className="flex flex-row items-center justify-between pr-2"
+              >
+                <Item.Avatar
+                  key={`assistant-picker-${c.sId}`}
+                  label={"@" + c.name}
+                  visual={c.pictureUrl}
+                  hasAction={false}
+                  onClick={() => {
+                    onItemClick(c);
+                    setSearchText("");
                   }}
                 />
+                <IconButton
+                  icon={MoreIcon}
+                  onClick={() => {
+                    close();
+                    setShowDetails(c);
+                  }}
+                  variant="tertiary"
+                  size="sm"
+                />
               </div>
-            )}
-          </>
-        }
-        bottomBar={
-          <div className="flex border-t border-structure-50 p-2">
-            <Link
-              href={`/w/${owner.sId}/builder/assistants/new?flow=personal_assistants`}
-            >
-              <Button
-                label="Create"
-                size="xs"
-                variant="primary"
-                icon={PlusIcon}
-                className="mr-2"
-              />
-            </Link>
-            <div className="s-flex-grow" />
-            <Link href={`/w/${owner.sId}/assistant/assistants`}>
-              <Button
-                label="My Assistants"
-                size="xs"
-                variant="tertiary"
-                icon={ListIcon}
-              />
-            </Link>
-          </div>
-        }
-      >
-        {searchedAssistants.map((c) => (
-          <div
-            key={`assistant-picker-container-${c.sId}`}
-            className="flex flex-row items-center justify-between pr-2"
-          >
-            <Item.Avatar
-              key={`assistant-picker-${c.sId}`}
-              label={"@" + c.name}
-              visual={c.pictureUrl}
-              hasAction={false}
-              onClick={() => {
-                onItemClick(c);
-                setSearchText("");
-              }}
-            />
-            <IconButton
-              icon={MoreIcon}
-              onClick={() => {
-                setShowDetails(c);
-              }}
-              variant="tertiary"
-              size="sm"
-            />
-          </div>
-        ))}
-      </DropdownMenu.Items>
+            ))}
+          </DropdownMenu.Items>
+        </>
+      )}
     </DropdownMenu>
   );
 }

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@dust-tt/sparkle": "^0.2.86",
+        "@dust-tt/sparkle": "^0.2.87",
         "@dust-tt/types": "file:../types",
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",
@@ -933,9 +933,9 @@
       "integrity": "sha512-smLocSfrt3s53H/XSVP3/1kP42oqvrkjUPtyaFd1F79ux24oE31BKt+q0c6lsa6hOYrFzsIwyc5GXAI5JmfOew=="
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.86",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.86.tgz",
-      "integrity": "sha512-scjSx6Bgmiai86FfyLjuOxaGKle1ag/nvFsrqQghW03h6lZOlsbeid8YDfpftJufqTify7mq4X6NdjmqZKAPHQ==",
+      "version": "0.2.87",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.87.tgz",
+      "integrity": "sha512-m7B7X3e7+pQJbC8PJTG8BDGl5HRWC62Ng5dmYsOzO31JOq05wKDbm7B9L/niNbzQVIH4mYllaCsdAiRYsHfC2Q==",
       "dependencies": {
         "@headlessui/react": "^1.7.17"
       },

--- a/front/package.json
+++ b/front/package.json
@@ -13,7 +13,7 @@
     "initdb": "npx tsx admin/db.ts"
   },
   "dependencies": {
-    "@dust-tt/sparkle": "^0.2.86",
+    "@dust-tt/sparkle": "^0.2.87",
     "@dust-tt/types": "file:../types",
     "@emoji-mart/data": "^1.1.2",
     "@emoji-mart/react": "^1.1.1",


### PR DESCRIPTION
## Description

The picker would not close when clicking on assistant details leading to an overlap of  "modals" which felt unatural (first clock would close the picker even if it was behind the blur of the assistant details modal view, and only the second click would close the assistant details)

This PR fixes the behavior by closing the picker when clicking on assistant details buttons.

Related to: https://github.com/dust-tt/dust/pull/3628

## Risk

N/A

## Deploy Plan

- deploy `front`