### PR TITLE
:pig: fix router usage in Gallery

### DIFF
--- a/front/pages/w/[wId]/assistant/gallery.tsx
+++ b/front/pages/w/[wId]/assistant/gallery.tsx
@@ -145,24 +145,24 @@ export default function AssistantsGallery({
   const tabs = [
     {
       label: "All",
-      href: `/w/${owner.sId}/assistant/gallery?view=all`,
+      shallowHref: `/w/${owner.sId}/assistant/gallery?view=all`,
       current: agentsGetView === "all",
     },
     {
       label: "Shared",
-      href: `/w/${owner.sId}/assistant/gallery?view=published`,
+      shallowHref: `/w/${owner.sId}/assistant/gallery?view=published`,
       current: agentsGetView === "published",
       icon: UserGroupIcon,
     },
     {
       label: "Company",
-      href: `/w/${owner.sId}/assistant/gallery?view=workspace`,
+      shallowHref: `/w/${owner.sId}/assistant/gallery?view=workspace`,
       current: agentsGetView === "workspace",
       icon: PlanetIcon,
     },
     {
       label: "Default",
-      href: `/w/${owner.sId}/assistant/gallery?view=global`,
+      shallowHref: `/w/${owner.sId}/assistant/gallery?view=global`,
       current: agentsGetView === "global",
       icon: DustIcon,
     },
@@ -250,7 +250,19 @@ export default function AssistantsGallery({
           </div>
           <div className="flex flex-row space-x-4">
             <div className="grow overflow-x-auto scrollbar-hide">
-              <Tab tabs={tabs} />
+              <Tab
+                tabs={tabs}
+                // TODO(2024-02-08 flav) Improve our tab components to support NextJS router.
+                // Due to a limitation with our headless UI tabs implementation.
+                // We use this event handler to replace the current path in the router.
+                onTabClick={async (label) => {
+                  const [clickedTab] = tabs.filter((t) => t.label === label);
+
+                  if (clickedTab) {
+                    await router.replace(clickedTab.shallowHref);
+                  }
+                }}
+              />
             </div>
             <div className="hidden md:block">{SearchOrderDropdown}</div>
           </div>


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR fixes the router issue in the Gallery. As we use `router.back` when users click on the close CTA, if they browse the different tabs in the gallery, they end up going backward.

This PR implements a hack 🐷 that will temporary address the issue until our Tabs component gets refactored so it can support NextJS router properly.

![GalleryClose](https://github.com/dust-tt/dust/assets/7428970/16a1e345-f2cf-4a0c-bdab-6248aafd001b)

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
