### PR TITLE
Flav/rework assistant usage

### DIFF
--- a/front/lib/api/assistant/agent_usage.ts
+++ b/front/lib/api/assistant/agent_usage.ts
@@ -2,7 +2,6 @@ import type {
   AgentUsageType,
   LightAgentConfigurationType,
   ModelId,
-  WorkspaceType,
 } from "@dust-tt/types";
 import { literal, Op } from "sequelize";
 import { v4 as uuidv4 } from "uuid";
@@ -17,7 +16,6 @@ import {
   UserMessage,
   Workspace,
 } from "@app/lib/models";
-import { AgentUserRelation } from "@app/lib/models/assistant/agent";
 import { redisClient } from "@app/lib/redis";
 
 // Ranking of agents is done over a 30 days period.

--- a/front/lib/api/assistant/agent_usage.ts
+++ b/front/lib/api/assistant/agent_usage.ts
@@ -121,7 +121,7 @@ async function populateUsageIfNeeded({
     }
 
     // We are safe to populate the sorted sets until the Redis populateLockKey expires.
-    // Get all mentions for this agent that have a messageModelId smaller than messageModelId
+    // Get all mentions for this agent that have a messageId smaller than messageId
     // and that happened within the last 30 days.
     const mentions = await Mention.findAll({
       where: {
@@ -131,9 +131,7 @@ async function populateUsageIfNeeded({
             [Op.gt]: literal(`NOW() - INTERVAL '30 days'`),
           },
         },
-        ...(messageModelId
-          ? { messageModelId: { [Op.lt]: messageModelId } }
-          : {}),
+        ...(messageModelId ? { messageId: { [Op.lt]: messageModelId } } : {}),
       },
       include: [
         {

--- a/front/lib/api/assistant/agent_usage.ts
+++ b/front/lib/api/assistant/agent_usage.ts
@@ -3,6 +3,7 @@ import type {
   LightAgentConfigurationType,
   ModelId,
 } from "@dust-tt/types";
+import { assertNever } from "@dust-tt/types";
 import { literal, Op } from "sequelize";
 import { v4 as uuidv4 } from "uuid";
 
@@ -216,8 +217,11 @@ async function getAgentInListCount(
       return calculateAndCacheCount(
         getMembersCount(auth, { activeOnly: true })
       );
-    default:
+    case "global":
+    case "private":
       return 0;
+    default:
+      assertNever(agentConfiguration.scope);
   }
 }
 

--- a/front/lib/api/assistant/agent_usage.ts
+++ b/front/lib/api/assistant/agent_usage.ts
@@ -183,9 +183,13 @@ async function getAgentInListCount(
 ) {
   if (agentConfiguration.scope === "published") {
     return getUsersWithAgentInListCount(auth, agentConfiguration.sId);
-  } else {
+  }
+
+  if (agentConfiguration.scope === "workspace") {
     return getMembersCount(auth, { activeOnly: true });
   }
+
+  return 0;
 }
 
 export async function getAgentUsage(

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1060,9 +1060,9 @@ export async function* postUserMessage(
     for (const agentMessage of agentMessages) {
       void signalAgentUsage({
         userId: user?.id.toString() || context.email || context.username,
-        agentConfigurationSId: agentMessage.configuration.sId,
+        agentConfigurationId: agentMessage.configuration.sId,
         workspaceId: owner.sId,
-        messageId: agentMessage.id,
+        messageModelId: agentMessage.id,
         timestamp: agentMessage.created,
       });
     }
@@ -1552,8 +1552,8 @@ export async function* editUserMessage(
           user?.id.toString() ||
           message.context.email ||
           message.context.username,
-        agentConfigurationSId: agentMessage.configuration.sId,
-        messageId: agentMessage.id,
+        agentConfigurationId: agentMessage.configuration.sId,
+        messageModelId: agentMessage.id,
         timestamp: agentMessage.created,
         workspaceId: owner.sId,
       });

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1060,8 +1060,8 @@ export async function* postUserMessage(
     for (const agentMessage of agentMessages) {
       void signalAgentUsage({
         userId: user?.id.toString() || context.email || context.username,
-        agentConfigurationId: agentMessage.configuration.sId,
-        workspaceId: owner.sId,
+        agentConfigurationSId: agentMessage.configuration.sId,
+        workspaceSId: owner.sId,
         messageId: agentMessage.id,
         timestamp: agentMessage.created,
       });
@@ -1552,10 +1552,10 @@ export async function* editUserMessage(
           user?.id.toString() ||
           message.context.email ||
           message.context.username,
-        agentConfigurationId: agentMessage.configuration.sId,
+        agentConfigurationSId: agentMessage.configuration.sId,
         messageId: agentMessage.id,
         timestamp: agentMessage.created,
-        workspaceId: owner.sId,
+        workspaceSId: owner.sId,
       });
     }
   }

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1061,7 +1061,7 @@ export async function* postUserMessage(
       void signalAgentUsage({
         userId: user?.id.toString() || context.email || context.username,
         agentConfigurationSId: agentMessage.configuration.sId,
-        workspaceSId: owner.sId,
+        workspaceId: owner.sId,
         messageId: agentMessage.id,
         timestamp: agentMessage.created,
       });
@@ -1555,7 +1555,7 @@ export async function* editUserMessage(
         agentConfigurationSId: agentMessage.configuration.sId,
         messageId: agentMessage.id,
         timestamp: agentMessage.created,
-        workspaceSId: owner.sId,
+        workspaceId: owner.sId,
       });
     }
   }

--- a/front/lib/api/assistant/user_relation.ts
+++ b/front/lib/api/assistant/user_relation.ts
@@ -119,7 +119,7 @@ export async function getUsersWithAgentInListCount(
 ) {
   const owner = auth.workspace();
   if (!owner || !auth.isUser()) {
-    throw new Error("Workspace not found");
+    throw new Error("Workspace not found.");
   }
 
   return AgentUserRelation.count({

--- a/front/lib/api/assistant/user_relation.ts
+++ b/front/lib/api/assistant/user_relation.ts
@@ -112,3 +112,21 @@ export async function setAgentUserListStatus({
     listStatus,
   });
 }
+
+export async function getUsersWithAgentInListCount(
+  auth: Authenticator,
+  agentSId: string
+) {
+  const owner = auth.workspace();
+  if (!owner || !auth.isUser()) {
+    throw new Error("Workspace not found");
+  }
+
+  return AgentUserRelation.count({
+    where: {
+      workspaceId: owner.id,
+      agentConfiguration: agentSId,
+      listStatusOverride: "in-list",
+    },
+  });
+}

--- a/front/lib/api/assistant/user_relation.ts
+++ b/front/lib/api/assistant/user_relation.ts
@@ -115,7 +115,7 @@ export async function setAgentUserListStatus({
 
 export async function getUsersWithAgentInListCount(
   auth: Authenticator,
-  agentSId: string
+  agentId: string
 ) {
   const owner = auth.workspace();
   if (!owner || !auth.isUser()) {
@@ -125,7 +125,7 @@ export async function getUsersWithAgentInListCount(
   return AgentUserRelation.count({
     where: {
       workspaceId: owner.id,
-      agentConfiguration: agentSId,
+      agentConfiguration: agentId,
       listStatusOverride: "in-list",
     },
   });

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -188,14 +188,12 @@ export async function getMembersCount(
       }
     : {};
 
-  const membershipsCount = await Membership.count({
+  return Membership.count({
     where: {
       workspaceId: owner.id,
       ...whereClause,
     },
   });
-
-  return membershipsCount;
 }
 
 /**

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -7,6 +7,7 @@ import type {
   WorkspaceType,
 } from "@dust-tt/types";
 import type { MembershipInvitationType } from "@dust-tt/types";
+import { Op } from "sequelize";
 
 import type { Authenticator } from "@app/lib/auth";
 import {
@@ -168,6 +169,33 @@ export async function getMembers(
       workspaces: [{ ...owner, role }],
     };
   });
+}
+
+export async function getMembersCount(
+  auth: Authenticator,
+  { activeOnly }: { activeOnly?: boolean } = {}
+): Promise<number> {
+  const owner = auth.workspace();
+  if (!owner) {
+    return 0;
+  }
+
+  const whereClause = activeOnly
+    ? {
+        role: {
+          [Op.ne]: "revoked",
+        },
+      }
+    : {};
+
+  const membershipsCount = await Membership.count({
+    where: {
+      workspaceId: owner.id,
+      ...whereClause,
+    },
+  });
+
+  return membershipsCount;
 }
 
 /**

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -4,7 +4,7 @@ import type {
   LightAgentConfigurationType,
 } from "@dust-tt/types";
 import type { SupportedModel } from "@dust-tt/types";
-import { SUPPORTED_MODEL_CONFIGS } from "@dust-tt/types";
+import { pluralize, SUPPORTED_MODEL_CONFIGS } from "@dust-tt/types";
 
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 
@@ -119,19 +119,34 @@ export function assistantUsageMessage({
 }) {
   if (isError) {
     return "Error loading usage data.";
-  } else if (isLoading) {
+  }
+
+  if (isLoading) {
     return "Loading usage data...";
-  } else if (usage) {
+  }
+
+  if (usage) {
+    const days = usage.timePeriodSec / (60 * 60 * 24);
+
     if (shortVersion) {
-      return `${usage.messageCount} message(s) over the last ${
-        usage.timePeriodSec / (60 * 60 * 24)
-      } days`;
+      const messageCount = `${usage.messageCount} message${pluralize(
+        usage.messageCount
+      )}`;
+
+      return `${messageCount} over the last ${days} days`;
     }
-    return `@${assistantName} has been used by ${usage.userCount} ${
-      usage.userCount > 1 ? "people" : "person"
-    } in ${usage.messageCount} message${
-      usage.messageCount > 1 ? "s" : ""
-    } over the last ${usage.timePeriodSec / (60 * 60 * 24)} days.`;
+
+    const usersWithAgentInListCount = `${
+      usage.usersWithAgentInListCount
+    } member${pluralize(usage.usersWithAgentInListCount)}`;
+    const messageCount = `${usage.messageCount} time${pluralize(
+      usage.messageCount
+    )}`;
+    const userCount = `${usage.userCount} member${pluralize(usage.userCount)}`;
+
+    return `@${assistantName} is active for ${usersWithAgentInListCount} and has been used ${messageCount} by ${userCount} in the last ${
+      usage.timePeriodSec / (60 * 60 * 24)
+    } days.`;
   }
 }
 

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/usage.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/usage.ts
@@ -56,9 +56,9 @@ async function handler(
           },
         });
       }
-      const agentUsage = await getAgentUsage({
+      const agentUsage = await getAgentUsage(auth, {
         agentConfiguration,
-        workspace: owner,
+        workspaceSId: owner.sId,
       });
       return res.status(200).json({ agentUsage });
 

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/usage.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/usage.ts
@@ -57,8 +57,8 @@ async function handler(
         });
       }
       const agentUsage = await getAgentUsage({
-        agentConfigurationId: agentConfiguration.sId,
-        workspaceId: owner.sId,
+        agentConfiguration,
+        workspace: owner,
       });
       return res.status(200).json({ agentUsage });
 

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/usage.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/usage.ts
@@ -58,7 +58,7 @@ async function handler(
       }
       const agentUsage = await getAgentUsage(auth, {
         agentConfiguration,
-        workspaceSId: owner.sId,
+        workspaceId: owner.sId,
       });
       return res.status(200).json({ agentUsage });
 

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -124,8 +124,8 @@ async function handler(
                   ...agentConfiguration,
                   usage: await getAgentUsage({
                     providedRedis: redis,
-                    agentConfigurationId: agentConfiguration.sId,
-                    workspaceId: owner.sId,
+                    agentConfiguration,
+                    workspace: owner,
                   }),
                 };
               }

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -125,7 +125,7 @@ async function handler(
                   usage: await getAgentUsage(auth, {
                     providedRedis: redis,
                     agentConfiguration,
-                    workspaceSId: owner.sId,
+                    workspaceId: owner.sId,
                   }),
                 };
               }

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -122,10 +122,10 @@ async function handler(
               ): Promise<LightAgentConfigurationType> => {
                 return {
                   ...agentConfiguration,
-                  usage: await getAgentUsage({
+                  usage: await getAgentUsage(auth, {
                     providedRedis: redis,
                     agentConfiguration,
-                    workspace: owner,
+                    workspaceSId: owner.sId,
                   }),
                 };
               }

--- a/types/src/front/assistant/agent.ts
+++ b/types/src/front/assistant/agent.ts
@@ -113,6 +113,7 @@ export type AgentsGetViewType =
 export type AgentUsageType = {
   userCount: number;
   messageCount: number;
+  usersWithAgentInListCount: number;
 
   // userCount and messageCount are over the last `timePeriodSec` seconds
   timePeriodSec: number;

--- a/types/src/shared/utils/string_utils.ts
+++ b/types/src/shared/utils/string_utils.ts
@@ -36,5 +36,5 @@ function isTrailingLoneSurrogate(code: number): boolean {
 }
 
 export function pluralize(count: number) {
-  return count > 1 ? "s" : "";
+  return count !== 1 ? "s" : "";
 }

--- a/types/src/shared/utils/string_utils.ts
+++ b/types/src/shared/utils/string_utils.ts
@@ -34,3 +34,7 @@ function isLeadingLoneSurrogate(code: number): boolean {
 function isTrailingLoneSurrogate(code: number): boolean {
   return code >= 0xdc00 && code <= 0xdfff;
 }
+
+export function pluralize(count: number) {
+  return count > 1 ? "s" : "";
+}


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR solves https://github.com/dust-tt/dust/issues/3330.

It refactors the agent usage logic to also return the number of members that have the assistant within their list. This adds one more query per assistant to gather their usage as the data lives in the DB. To avoid doing the extra query everywhere, we only perform a query for assistant that are either in the `workspace` or `published`.

It caches this new value for one entire day.

<img width="605" alt="image" src="https://github.com/dust-tt/dust/assets/7428970/a650f507-11e0-4f1a-853d-9df7a677c170">

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
