### PR TITLE
Ensure slack users are active members

### DIFF
--- a/connectors/src/connectors/slack/lib/slack_client.ts
+++ b/connectors/src/connectors/slack/lib/slack_client.ts
@@ -1,13 +1,11 @@
 import type { ModelId } from "@dust-tt/types";
 import type {
   CodedError,
-  UsersInfoResponse,
   WebAPIHTTPError,
   WebAPIPlatformError,
 } from "@slack/web-api";
 import { ErrorCode, WebClient } from "@slack/web-api";
 
-import { isMemberOfWorkspace } from "@connectors/connectors/slack/lib/workspace_limits";
 import type { WorkflowError } from "@connectors/lib/error";
 import { ExternalOauthTokenError } from "@connectors/lib/error";
 import { Connector } from "@connectors/lib/models";

--- a/connectors/src/connectors/slack/lib/slack_client.ts
+++ b/connectors/src/connectors/slack/lib/slack_client.ts
@@ -7,6 +7,7 @@ import type {
 } from "@slack/web-api";
 import { ErrorCode, WebClient } from "@slack/web-api";
 
+import { isMemberOfWorkspace } from "@connectors/connectors/slack/lib/workspace_limits";
 import type { WorkflowError } from "@connectors/lib/error";
 import { ExternalOauthTokenError } from "@connectors/lib/error";
 import { Connector } from "@connectors/lib/models";
@@ -109,60 +110,11 @@ export async function getSlackUserInfo(slackClient: WebClient, userId: string) {
   });
 }
 
-async function getSlackConversationInfo(
+export async function getSlackConversationInfo(
   slackClient: WebClient,
   channelId: string
 ) {
   return slackClient.conversations.info({ channel: channelId });
-}
-
-// Verify the Slack user is not an external guest to the workspace.
-// An exception is made for users from domains on the whitelist,
-// allowing them to interact with the bot in public channels.
-// See incident: https://dust4ai.slack.com/archives/C05B529FHV1/p1704799263814619
-export async function isUserAllowedToUseChatbot(
-  slackClient: WebClient,
-  slackUserInfo: UsersInfoResponse,
-  slackChanneId: string,
-  slackTeamId: string,
-  whitelistedDomains?: readonly string[]
-): Promise<boolean> {
-  if (!slackUserInfo.user) {
-    return false;
-  }
-
-  const {
-    is_restricted,
-    is_stranger: isStranger,
-    is_ultra_restricted,
-    profile,
-  } = slackUserInfo.user;
-
-  const isInWorkspace = profile?.team === slackTeamId;
-  if (!isInWorkspace) {
-    return false;
-  }
-
-  const isGuest = is_restricted || is_ultra_restricted;
-  const isExternal = isGuest || isStranger;
-
-  if (isExternal) {
-    const userDomain = profile?.email?.split("@")[1];
-    // Ensure the domain matches exactly.
-    const isWhitelistedDomain = userDomain
-      ? whitelistedDomains?.includes(userDomain) ?? false
-      : false;
-
-    const slackConversationInfo = await getSlackConversationInfo(
-      slackClient,
-      slackChanneId
-    );
-
-    const isChannelPublic = !slackConversationInfo.channel?.is_private;
-    return isChannelPublic && isWhitelistedDomain;
-  }
-
-  return true;
 }
 
 export async function getSlackAccessToken(

--- a/connectors/src/connectors/slack/lib/workspace_limits.ts
+++ b/connectors/src/connectors/slack/lib/workspace_limits.ts
@@ -1,0 +1,340 @@
+import type { WorkspaceDomain } from "@dust-tt/types";
+import { cacheWithRedis, DustAPI } from "@dust-tt/types";
+import type { UsersInfoResponse, WebClient } from "@slack/web-api";
+import type {
+  Profile,
+  User,
+} from "@slack/web-api/dist/response/UsersInfoResponse";
+
+import { getSlackConversationInfo } from "@connectors/connectors/slack/lib/slack_client";
+import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
+import type { Connector } from "@connectors/lib/models";
+import { redisClient } from "@connectors/lib/redis";
+import logger from "@connectors/logger/logger";
+
+const WHITELISTED_BOT_NAME = ["Beaver", "feedback-hackaton"];
+
+export async function safeRedisClient<T>(
+  fn: (client: Awaited<ReturnType<typeof redisClient>>) => PromiseLike<T>
+): Promise<T> {
+  const client = await redisClient();
+  try {
+    return await fn(client);
+  } finally {
+    await client.quit();
+  }
+}
+
+async function getActiveMemberEmails(connector: Connector): Promise<string[]> {
+  const ds = dataSourceConfigFromConnector(connector);
+
+  // List the email of active members in the workspace.
+  const dustAPI = new DustAPI(
+    {
+      apiKey: ds.workspaceAPIKey,
+      workspaceId: ds.workspaceId,
+    },
+    logger,
+    { useLocalInDev: true }
+  );
+
+  const activeMemberEmailsRes =
+    await dustAPI.getActiveMemberEmailsInWorkspace();
+  if (activeMemberEmailsRes.isErr()) {
+    logger.error("Error getting all members in workspace.", {
+      error: activeMemberEmailsRes.error,
+    });
+
+    throw new Error("Error getting all members in workspace.");
+  }
+
+  return activeMemberEmailsRes.value;
+}
+
+export const getActiveMemberEmailsMemoized = cacheWithRedis(
+  getActiveMemberEmails,
+  (connector: Connector) => {
+    return `active-member-emails-connector-${connector.id}`;
+  },
+  // Caches data for 15 minutes to limit frequent API calls.
+  // Note: Updates (e.g., new members added by an admin) may take up to 15 minutes to be reflected.
+  15 * 10 * 1000
+);
+
+async function getVerifiedDomainsForWorkspace(
+  connector: Connector
+): Promise<WorkspaceDomain[]> {
+  const ds = dataSourceConfigFromConnector(connector);
+
+  const dustAPI = new DustAPI(
+    {
+      apiKey: ds.workspaceAPIKey,
+      workspaceId: ds.workspaceId,
+    },
+    logger,
+    { useLocalInDev: true }
+  );
+
+  const workspaceVerifiedDomainsRes =
+    await dustAPI.getWorkspaceVerifiedDomains();
+  if (workspaceVerifiedDomainsRes.isErr()) {
+    logger.error("Error getting verified domains for workspace.", {
+      error: workspaceVerifiedDomainsRes.error,
+    });
+
+    throw new Error("Error getting verified domains for workspace.");
+  }
+
+  return workspaceVerifiedDomainsRes.value;
+}
+
+export const getVerifiedDomainsForWorkspaceMemoized = cacheWithRedis(
+  getVerifiedDomainsForWorkspace,
+  (connector: Connector) => {
+    return `workspace-verified-domains-${connector.id}`;
+  },
+  // Caches data for 15 minutes to limit frequent API calls.
+  // Note: Updates (e.g., workspace verified domains) may take up to 15 minutes to be reflected.
+  15 * 10 * 1000
+);
+
+async function isAutoJoinEnabledForDomain(
+  connector: Connector,
+  slackUserInfo: UsersInfoResponse
+): Promise<boolean> {
+  const { user } = slackUserInfo;
+  if (!user || !user.profile) {
+    return false;
+  }
+
+  const userDomain = user.profile?.email?.split("@")[1];
+  if (!userDomain) {
+    return false;
+  }
+
+  const verifiedDomains = await getVerifiedDomainsForWorkspaceMemoized(
+    connector
+  );
+
+  const isDomainAutoJoinEnabled = verifiedDomains.find(
+    (vd) => vd.domain === userDomain
+  );
+
+  return isDomainAutoJoinEnabled?.domainAutoJoinEnabled ?? false;
+}
+
+const slackMembershipAccessBlocks = {
+  autojoin_enabled: [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: "Access the Slack integration by joining your Dust workspace. Only members can use this feature. Click 'Join My Workspace' to get started. For help, contact a Dust admin.",
+      },
+    },
+    {
+      type: "actions",
+      elements: [
+        {
+          type: "button",
+          text: {
+            type: "plain_text",
+            text: "Join My Workspace",
+            emoji: true,
+          },
+          style: "primary",
+          value: "join_my_workspace_cta",
+          action_id: "actionId-0",
+          url: "https://dust.tt/",
+        },
+      ],
+    },
+  ],
+  autojoin_disabled: [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: "Oops! It looks like you're not a member of Dust yet. Please reach out to a Dust admin to join the workspace and start using the Slack integration.",
+      },
+    },
+  ],
+};
+
+async function postMessageForUnhautorizedUser(
+  connector: Connector,
+  slackClient: WebClient,
+  slackUserInfo: UsersInfoResponse,
+  {
+    slackChannelId,
+    slackMessageTs,
+  }: { slackChannelId: string; slackMessageTs: string }
+) {
+  const autoJoinEnabled = await isAutoJoinEnabledForDomain(
+    connector,
+    slackUserInfo
+  );
+
+  const slackMessageBlocks =
+    slackMembershipAccessBlocks[
+      autoJoinEnabled ? "autojoin_enabled" : "autojoin_disabled"
+    ];
+
+  return slackClient.chat.postMessage({
+    channel: slackChannelId,
+    blocks: slackMessageBlocks,
+    thread_ts: slackMessageTs,
+  });
+}
+
+export async function isMemberOfWorkspace(
+  connector: Connector,
+  slackUserEmail: string | undefined
+) {
+  if (!slackUserEmail) {
+    return false;
+  }
+
+  const workspaceActiveMemberEmails = await getActiveMemberEmailsMemoized(
+    connector
+  );
+
+  if (workspaceActiveMemberEmails.includes(slackUserEmail)) {
+    return true;
+  }
+
+  return false;
+}
+
+function isBotAllowed(user: User) {
+  const { profile } = user;
+
+  const displayName = profile?.display_name ?? "";
+  const realName = profile?.real_name ?? "";
+
+  const isWhitelistedBotName =
+    WHITELISTED_BOT_NAME.includes(displayName) ||
+    WHITELISTED_BOT_NAME.includes(realName);
+
+  if (!isWhitelistedBotName) {
+    logger.info({ user }, "Ignoring bot message");
+  }
+
+  return isWhitelistedBotName;
+}
+
+interface SlackInfos {
+  slackChannelId: string;
+  slackMessageTs: string;
+  slackTeamId: string;
+}
+
+// Verify the Slack user is not an external guest to the workspace.
+// An exception is made for users from domains on the whitelist,
+// allowing them to interact with the bot in public channels.
+// See incident: https://dust4ai.slack.com/archives/C05B529FHV1/p1704799263814619.
+async function isExternalUserAllowed(
+  slackClient: WebClient,
+  profile: Profile,
+  slackInfos: SlackInfos,
+  whitelistedDomains?: readonly string[]
+) {
+  const { slackChannelId } = slackInfos;
+
+  const userDomain = profile?.email?.split("@")[1];
+  // Ensure the domain matches exactly.
+  const isWhitelistedDomain = userDomain
+    ? whitelistedDomains?.includes(userDomain) ?? false
+    : false;
+
+  const slackConversationInfo = await getSlackConversationInfo(
+    slackClient,
+    slackChannelId
+  );
+
+  const isChannelPublic = !slackConversationInfo.channel?.is_private;
+  return isChannelPublic && isWhitelistedDomain;
+}
+
+async function isUserAllowed(connector: Connector, profile: Profile) {
+  const isMember = await isMemberOfWorkspace(connector, profile?.email);
+  if (isMember) {
+    return true;
+  }
+
+  return false;
+}
+
+async function isSlackUserAllowed(
+  user: User,
+  connector: Connector,
+  slackClient: WebClient,
+  slackInfos: SlackInfos,
+  whitelistedDomains?: readonly string[]
+) {
+  const {
+    is_restricted,
+    is_stranger: isStranger,
+    is_ultra_restricted,
+    profile,
+  } = user;
+
+  const isInWorkspace = profile?.team === slackInfos.slackTeamId;
+  if (!isInWorkspace) {
+    return false;
+  }
+
+  const isGuest = is_restricted || is_ultra_restricted;
+  const isExternal = isGuest || isStranger;
+  const isExternalAllowed =
+    isExternal &&
+    (await isExternalUserAllowed(
+      slackClient,
+      profile,
+      slackInfos,
+      whitelistedDomains
+    ));
+
+  if (isExternalAllowed) {
+    return true;
+  }
+
+  // Otherwise, ensure that the slack user is an active member in the workspace.
+  return isUserAllowed(connector, profile);
+}
+
+export async function notifyIfSlackUserIsNotAllowed(
+  connector: Connector,
+  slackClient: WebClient,
+  slackUserInfo: UsersInfoResponse,
+  slackInfos: SlackInfos,
+  whitelistedDomains?: readonly string[]
+): Promise<boolean> {
+  const { user } = slackUserInfo;
+  if (!user) {
+    return false;
+  }
+
+  if (user.is_bot) {
+    return isBotAllowed(user);
+  }
+
+  const isAllowed = await isSlackUserAllowed(
+    user,
+    connector,
+    slackClient,
+    slackInfos,
+    whitelistedDomains
+  );
+
+  if (!isAllowed) {
+    await postMessageForUnhautorizedUser(
+      connector,
+      slackClient,
+      slackUserInfo,
+      slackInfos
+    );
+  }
+
+  return isAllowed;
+}

--- a/connectors/src/connectors/slack/lib/workspace_limits.ts
+++ b/connectors/src/connectors/slack/lib/workspace_limits.ts
@@ -117,7 +117,7 @@ const slackMembershipAccessBlocks = {
       type: "section",
       text: {
         type: "mrkdwn",
-        text: "Access the Slack integration by joining your Dust workspace. Only members can use this feature. Click 'Join My Workspace' to get started. For help, contact a Dust admin.",
+        text: "The Slack integration is accessible to members of your company's Dust workspace. Click 'Join My Workspace' to get started. For help, contact an administrator.",
       },
     },
     {
@@ -143,7 +143,7 @@ const slackMembershipAccessBlocks = {
       type: "section",
       text: {
         type: "mrkdwn",
-        text: "Oops! It looks like you're not a member of Dust yet. Please reach out to a Dust admin to join the workspace and start using the Slack integration.",
+        text: "It looks like you're not a member of your company's Dust workspace yet. Please reach out to an administrator to join and start using Dust on Slack.",
       },
     },
   ],

--- a/connectors/src/connectors/slack/lib/workspace_limits.ts
+++ b/connectors/src/connectors/slack/lib/workspace_limits.ts
@@ -242,7 +242,7 @@ async function isExternalUserAllowed(
 async function isUserAllowed(
   connector: Connector,
   profile: Profile,
-  whitelistedDomains?: string[]
+  whitelistedDomains?: readonly string[]
 ) {
   const isMember = await isActiveMemberOfWorkspace(connector, profile?.email);
   if (isMember) {
@@ -297,7 +297,7 @@ async function isSlackUserAllowed(
   }
 
   // Otherwise, ensure that the slack user is an active member in the workspace.
-  return isUserAllowed(connector, profile);
+  return isUserAllowed(connector, profile, whitelistedDomains);
 }
 
 export async function notifyIfSlackUserIsNotAllowed(

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -251,7 +251,7 @@ async function warnPostDeletion(
   switch (dataSourceProvider) {
     case "github":
       // get admin emails
-      const adminEmails = (await getMembers(auth, { role: "admin" })).map(
+      const adminEmails = (await getMembers(auth, { roles: ["admin"] })).map(
         (u) => u.email
       );
       // send email to admins

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -107,10 +107,10 @@ export async function setInternalWorkspaceSegmentation(
 export async function getMembers(
   auth: Authenticator,
   {
-    role,
+    roles,
     userIds,
   }: {
-    role?: RoleType;
+    roles?: RoleType[];
     userIds?: ModelId[];
   } = {}
 ): Promise<UserTypeWithWorkspaces[]> {
@@ -122,12 +122,12 @@ export async function getMembers(
   const whereClause: {
     workspaceId: ModelId;
     userId?: ModelId[];
-    role?: RoleType;
+    role?: RoleType[];
   } = userIds
     ? { workspaceId: owner.id, userId: userIds }
     : { workspaceId: owner.id };
-  if (role) {
-    whereClause.role = role;
+  if (roles) {
+    whereClause.role = roles;
   }
 
   const memberships = await Membership.findAll({

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -41,12 +41,12 @@ export async function getWorkspaceInfos(
 }
 
 export async function getWorkspaceVerifiedDomain(
-  workspaceId: ModelId
+  workspace: WorkspaceType
 ): Promise<WorkspaceDomain | null> {
   const workspaceDomain = await WorkspaceHasDomain.findOne({
     attributes: ["domain", "domainAutoJoinEnabled"],
     where: {
-      workspaceId: workspaceId,
+      workspaceId: workspace.id,
     },
     // For now, one workspace can only have one domain.
     limit: 1,

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -401,9 +401,9 @@ async function handler(
               "Couldn't get owner or subscription from `auth`."
             );
           }
-          const adminEmails = (await getMembers(auth, { role: "admin" })).map(
-            (u) => u.email
-          );
+          const adminEmails = (
+            await getMembers(auth, { roles: ["admin"] })
+          ).map((u) => u.email);
           const customerEmail = invoice.customer_email;
           if (customerEmail && !adminEmails.includes(customerEmail)) {
             adminEmails.push(customerEmail);
@@ -464,9 +464,9 @@ async function handler(
             );
 
             // then email admins
-            const adminEmails = (await getMembers(auth, { role: "admin" })).map(
-              (u) => u.email
-            );
+            const adminEmails = (
+              await getMembers(auth, { roles: ["admin"] })
+            ).map((u) => u.email);
             if (adminEmails.length === 0) {
               return apiError(req, res, {
                 status_code: 500,
@@ -679,7 +679,7 @@ async function checkStaticDatasourcesSize(auth: Authenticator) {
     }
     await sendOpsDowngradeTooMuchDataEmail(workspace.sId, datasourcesTooBig);
     // for all admins
-    const adminEmails = (await getMembers(auth, { role: "admin" })).map(
+    const adminEmails = (await getMembers(auth, { roles: ["admin"] })).map(
       (u) => u.email
     );
     for (const adminEmail of adminEmails)

--- a/front/pages/api/v1/w/[wId]/members/emails.ts
+++ b/front/pages/api/v1/w/[wId]/members/emails.ts
@@ -24,7 +24,7 @@ async function handler(
 
   const owner = auth.workspace();
   const isSystemKey = keyRes.value.isSystem;
-  if (!owner || !isSystemKey) {
+  if (!owner || !isSystemKey || !auth.isBuilder()) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {

--- a/front/pages/api/v1/w/[wId]/members/emails.ts
+++ b/front/pages/api/v1/w/[wId]/members/emails.ts
@@ -1,0 +1,60 @@
+import type { RoleType, WithAPIErrorReponse } from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { getMembers } from "@app/lib/api/workspace";
+import { Authenticator, getAPIKey } from "@app/lib/auth";
+import { apiError, withLogging } from "@app/logger/withlogging";
+
+export type ListMemberEmailsResponseBody = {
+  emails: string[];
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorReponse<ListMemberEmailsResponseBody>>
+): Promise<void> {
+  const keyRes = await getAPIKey(req);
+  if (keyRes.isErr()) {
+    return apiError(req, res, keyRes.error);
+  }
+  const { auth } = await Authenticator.fromKey(
+    keyRes.value,
+    req.query.wId as string
+  );
+
+  const owner = auth.workspace();
+  const isSystemKey = keyRes.value.isSystem;
+  if (!owner || !isSystemKey) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "The workspace was not found.",
+      },
+    });
+  }
+
+  const { activeOnly } = req.query;
+
+  switch (req.method) {
+    case "GET":
+      const roles: RoleType[] | undefined = activeOnly
+        ? ["admin", "builder", "user"]
+        : undefined;
+
+      const allMembers = await getMembers(auth, { roles });
+
+      return res.status(200).json({ emails: allMembers.map((m) => m.email) });
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withLogging(handler);

--- a/front/pages/api/v1/w/[wId]/verified_domains.ts
+++ b/front/pages/api/v1/w/[wId]/verified_domains.ts
@@ -1,0 +1,56 @@
+import type { WithAPIErrorReponse, WorkspaceDomain } from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { getWorkspaceVerifiedDomain } from "@app/lib/api/workspace";
+import { Authenticator, getAPIKey } from "@app/lib/auth";
+import { apiError, withLogging } from "@app/logger/withlogging";
+
+export type ListMemberEmailsResponseBody = {
+  verified_domains: WorkspaceDomain[];
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorReponse<ListMemberEmailsResponseBody>>
+): Promise<void> {
+  const keyRes = await getAPIKey(req);
+  if (keyRes.isErr()) {
+    return apiError(req, res, keyRes.error);
+  }
+  const { auth } = await Authenticator.fromKey(
+    keyRes.value,
+    req.query.wId as string
+  );
+
+  const owner = auth.workspace();
+  const isSystemKey = keyRes.value.isSystem;
+  if (!owner || !isSystemKey) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "The workspace was not found.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET":
+      const verifiedDomain = await getWorkspaceVerifiedDomain(owner.id);
+
+      return res
+        .status(200)
+        .json({ verified_domains: verifiedDomain ? [verifiedDomain] : [] });
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withLogging(handler);

--- a/front/pages/api/v1/w/[wId]/verified_domains.ts
+++ b/front/pages/api/v1/w/[wId]/verified_domains.ts
@@ -24,7 +24,7 @@ async function handler(
 
   const owner = auth.workspace();
   const isSystemKey = keyRes.value.isSystem;
-  if (!owner || !isSystemKey) {
+  if (!owner || !isSystemKey || !auth.isBuilder()) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
@@ -36,7 +36,7 @@ async function handler(
 
   switch (req.method) {
     case "GET":
-      const verifiedDomain = await getWorkspaceVerifiedDomain(owner.id);
+      const verifiedDomain = await getWorkspaceVerifiedDomain(owner);
 
       return res
         .status(200)

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -65,7 +65,7 @@ export const getServerSideProps = withGetServerSidePropsLogging<{
       notFound: true,
     };
   }
-  const workspaceVerifiedDomain = await getWorkspaceVerifiedDomain(owner.id);
+  const workspaceVerifiedDomain = await getWorkspaceVerifiedDomain(owner);
 
   return {
     props: {

--- a/types/src/front/lib/dust_api.ts
+++ b/types/src/front/lib/dust_api.ts
@@ -18,6 +18,7 @@ import { CoreAPITokenType } from "../../front/lib/core_api";
 import { Err, Ok, Result } from "../../front/lib/result";
 import { RunType } from "../../front/run";
 import { LoggerInterface } from "../../shared/logger";
+import { WorkspaceDomain } from "../workspace";
 import {
   AgentActionSuccessEvent,
   AgentErrorEvent,
@@ -727,6 +728,46 @@ export class DustAPI {
       return r;
     }
     return new Ok(r.value.tokens);
+  }
+
+  async getActiveMemberEmailsInWorkspace() {
+    const endpoint = `${this.apiUrl()}/api/v1/w/${this.workspaceId()}/members/emails?activeOnly=true`;
+
+    const res = await fetch(endpoint, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${this._credentials.apiKey}`,
+      },
+    });
+
+    const r: DustAPIResponse<{ emails: string[] }> =
+      await this._resultFromResponse(res);
+    if (r.isErr()) {
+      return r;
+    }
+
+    return new Ok(r.value.emails);
+  }
+
+  async getWorkspaceVerifiedDomains() {
+    const endpoint = `${this.apiUrl()}/api/v1/w/${this.workspaceId()}/verified_domains`;
+
+    const res = await fetch(endpoint, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${this._credentials.apiKey}`,
+      },
+    });
+
+    const r: DustAPIResponse<{ verified_domains: WorkspaceDomain[] }> =
+      await this._resultFromResponse(res);
+    if (r.isErr()) {
+      return r;
+    }
+
+    return new Ok(r.value.verified_domains);
   }
 
   private async _resultFromResponse<T>(


### PR DESCRIPTION
## Description

See https://github.com/dust-tt/decisions/issues/153.

Remake of https://github.com/dust-tt/dust/pull/3565.

This PR introduces a new layer to our Slackbot, restricting the usage of our Slack integrations to active members only.  The goal here is to prevent all users of a Slack workspace to use Dust without having an account.

This rules apply for everyone except for:
- Whitelisted chatbots.
- Dust workspaces with a Slack whitelisted domains.

## Key updates in this PR include:
- Refactoring the existing logic of guest users in a Slack workspace.
- Expose the list of all active members in a Dust workspace through the front API. To avoid doing API calls on every slack messages we're caching these results for 15 minutes.
- Expose the list of verified domains for a workspace through the front API. To avoid doing API calls on every slack messages we're caching these results for 15 minutes.
- Returning a slack message to invite users to sign up on Dust based on the workspace settings.
- A mechanism to safely release. In case things go wrong, using our CLI we will be able to circumvent the new implementation.
```
./admin/cli.sh slack whitelist-domains --wId <xxx> --whitelistedDomains <yyy>
```

Two scenarios:

1. The workspace has auto join enabled, the user gets:
<img width="300" alt="image" src="https://github.com/dust-tt/dust/assets/7428970/b8b6e685-02bf-4730-a034-905496787539">

2. The workspace does not have auto join enabled, the user get:
<img width="300" alt="image" src="https://github.com/dust-tt/dust/assets/7428970/9e2ec5f6-36ad-4a66-8079-aa9c98922d05">

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
Pretty risky, tested locally with many users and different scenarios. Rollout system in place in case we need to course correct. Safe to rollback.

## Deploy Plan

Given the dependency on the Front api to get the count of active members within the workspace, we need to first deploy front and then deploy connectors.

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
