### PR TITLE
[WIP] Add flags to WorkspaceType

### DIFF
--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -37,6 +37,8 @@ export async function getWorkspaceInfos(
     allowedDomain: workspace.allowedDomain,
     role: "none",
     segmentation: workspace.segmentation,
+    // Flags are not needed from outside of the workspace.
+    flags: [],
   };
 }
 
@@ -94,6 +96,7 @@ export async function setInternalWorkspaceSegmentation(
     allowedDomain: workspace.allowedDomain,
     role: "none",
     segmentation: workspace.segmentation,
+    flags: [],
   };
 }
 

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -19,7 +19,7 @@ import {
 
 export async function getWorkspaceInfos(
   wId: string
-): Promise<WorkspaceType | null> {
+): Promise<(WorkspaceType & { flags: null }) | null> {
   const workspace = await Workspace.findOne({
     where: {
       sId: wId,
@@ -38,7 +38,7 @@ export async function getWorkspaceInfos(
     role: "none",
     segmentation: workspace.segmentation,
     // Flags are not needed from outside of the workspace.
-    flags: [],
+    flags: null,
   };
 }
 
@@ -67,7 +67,7 @@ export async function getWorkspaceVerifiedDomain(
 export async function setInternalWorkspaceSegmentation(
   auth: Authenticator,
   segmentation: WorkspaceSegmentationType
-): Promise<WorkspaceType> {
+): Promise<WorkspaceType & { flags: null }> {
   const owner = auth.workspace();
   const user = auth.user();
 
@@ -96,7 +96,7 @@ export async function setInternalWorkspaceSegmentation(
     allowedDomain: workspace.allowedDomain,
     role: "none",
     segmentation: workspace.segmentation,
-    flags: [],
+    flags: null,
   };
 }
 

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -168,7 +168,7 @@ export async function getMembers(
       firstName: u.firstName,
       lastName: u.lastName,
       image: u.imageUrl,
-      workspaces: [{ ...owner, role }],
+      workspaces: [{ ...owner, role, flags: null }],
     };
   });
 }

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -375,7 +375,7 @@ export class Authenticator {
     return isAdmin(this.workspace());
   }
 
-  workspace(): WorkspaceType | null {
+  workspace(): (WorkspaceType & { flags: WhitelistableFeature[] }) | null {
     return this._workspace
       ? {
           id: this._workspace.id,
@@ -523,7 +523,7 @@ export async function getUserFromSession(
         allowedDomain: w.allowedDomain || null,
         role,
         segmentation: w.segmentation || null,
-        flags: [],
+        flags: null,
       };
     }),
   };

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -2,6 +2,7 @@ import type {
   RoleType,
   UserType,
   UserTypeWithWorkspaces,
+  WhitelistableFeature,
   WorkspaceType,
 } from "@dust-tt/types";
 import type { PlanType, SubscriptionType } from "@dust-tt/types";
@@ -32,6 +33,8 @@ import { new_id } from "@app/lib/utils";
 import logger from "@app/logger/logger";
 import { authOptions } from "@app/pages/api/auth/[...nextauth]";
 
+import { FeatureFlag } from "./models/feature_flag";
+
 const {
   DUST_DEVELOPMENT_WORKSPACE_ID,
   DUST_DEVELOPMENT_SYSTEM_API_KEY,
@@ -51,6 +54,7 @@ export class Authenticator {
   _user: User | null;
   _role: RoleType;
   _subscription: SubscriptionType | null;
+  _flags: WhitelistableFeature[];
 
   // Should only be called from the static methods below.
   constructor({
@@ -58,16 +62,19 @@ export class Authenticator {
     user,
     role,
     subscription,
+    flags,
   }: {
     workspace?: Workspace | null;
     user?: User | null;
     role: RoleType;
     subscription?: SubscriptionType | null;
+    flags: WhitelistableFeature[];
   }) {
     this._workspace = workspace || null;
     this._user = user || null;
     this._role = role;
     this._subscription = subscription || null;
+    this._flags = flags;
   }
 
   /**
@@ -103,9 +110,10 @@ export class Authenticator {
 
     let role = "none" as RoleType;
     let subscription: SubscriptionType | null = null;
+    let flags: WhitelistableFeature[] = [];
 
     if (user && workspace) {
-      [role, subscription] = await Promise.all([
+      [role, subscription, flags] = await Promise.all([
         (async (): Promise<RoleType> => {
           const membership = await Membership.findOne({
             where: {
@@ -119,6 +127,15 @@ export class Authenticator {
             : "none";
         })(),
         subscriptionForWorkspace(workspace),
+        (async () => {
+          return (
+            await FeatureFlag.findAll({
+              where: {
+                workspaceId: workspace.id,
+              },
+            })
+          ).map((flag) => flag.name);
+        })(),
       ]);
     }
 
@@ -127,6 +144,7 @@ export class Authenticator {
       user,
       role,
       subscription,
+      flags,
     });
   }
 
@@ -168,15 +186,30 @@ export class Authenticator {
       })(),
     ]);
 
-    const subscription = workspace
-      ? await subscriptionForWorkspace(workspace)
-      : null;
+    let subscription: SubscriptionType | null = null;
+    let flags: WhitelistableFeature[] = [];
+
+    if (workspace) {
+      [subscription, flags] = await Promise.all([
+        subscriptionForWorkspace(workspace),
+        (async () => {
+          return (
+            await FeatureFlag.findAll({
+              where: {
+                workspaceId: workspace?.id,
+              },
+            })
+          ).map((flag) => flag.name);
+        })(),
+      ]);
+    }
 
     return new Authenticator({
       workspace,
       user,
       role: user?.isDustSuperUser ? "admin" : "none",
       subscription,
+      flags,
     });
   }
 
@@ -219,15 +252,30 @@ export class Authenticator {
       }
     }
 
-    const subscription = workspace
-      ? await subscriptionForWorkspace(workspace)
-      : null;
+    let subscription: SubscriptionType | null = null;
+    let flags: WhitelistableFeature[] = [];
+
+    if (workspace) {
+      [subscription, flags] = await Promise.all([
+        subscriptionForWorkspace(workspace),
+        (async () => {
+          return (
+            await FeatureFlag.findAll({
+              where: {
+                workspaceId: workspace?.id,
+              },
+            })
+          ).map((flag) => flag.name);
+        })(),
+      ]);
+    }
 
     return {
       auth: new Authenticator({
         workspace,
         role,
         subscription,
+        flags,
       }),
       keyWorkspaceId: keyWorkspace.sId,
     };
@@ -250,11 +298,27 @@ export class Authenticator {
       throw new Error(`Could not find workspace with sId ${workspaceId}`);
     }
 
-    const subscription = await subscriptionForWorkspace(workspace);
+    let subscription: SubscriptionType | null = null;
+    let flags: WhitelistableFeature[] = [];
+
+    [subscription, flags] = await Promise.all([
+      subscriptionForWorkspace(workspace),
+      (async () => {
+        return (
+          await FeatureFlag.findAll({
+            where: {
+              workspaceId: workspace?.id,
+            },
+          })
+        ).map((flag) => flag.name);
+      })(),
+    ]);
+
     return new Authenticator({
       workspace,
       role: "builder",
       subscription,
+      flags,
     });
   }
 
@@ -271,11 +335,27 @@ export class Authenticator {
       throw new Error(`Could not find workspace with sId ${workspaceId}`);
     }
 
-    const subscription = await subscriptionForWorkspace(workspace);
+    let subscription: SubscriptionType | null = null;
+    let flags: WhitelistableFeature[] = [];
+
+    [subscription, flags] = await Promise.all([
+      subscriptionForWorkspace(workspace),
+      (async () => {
+        return (
+          await FeatureFlag.findAll({
+            where: {
+              workspaceId: workspace?.id,
+            },
+          })
+        ).map((flag) => flag.name);
+      })(),
+    ]);
+
     return new Authenticator({
       workspace,
       role: "admin",
       subscription,
+      flags,
     });
   }
 
@@ -304,6 +384,7 @@ export class Authenticator {
           allowedDomain: this._workspace.allowedDomain || null,
           role: this._role,
           segmentation: this._workspace.segmentation || null,
+          flags: this._flags,
         }
       : null;
   }
@@ -442,6 +523,7 @@ export async function getUserFromSession(
         allowedDomain: w.allowedDomain || null,
         role,
         segmentation: w.segmentation || null,
+        flags: [],
       };
     }),
   };

--- a/front/pages/api/poke/workspaces/[wId]/downgrade.ts
+++ b/front/pages/api/poke/workspaces/[wId]/downgrade.ts
@@ -45,6 +45,7 @@ async function handler(
           allowedDomain: owner.allowedDomain || null,
           role: "admin",
           segmentation: owner.segmentation || null,
+          flags: [],
         },
       });
 

--- a/front/pages/api/poke/workspaces/[wId]/downgrade.ts
+++ b/front/pages/api/poke/workspaces/[wId]/downgrade.ts
@@ -6,7 +6,7 @@ import { internalSubscribeWorkspaceToFreeTestPlan } from "@app/lib/plans/subscri
 import { apiError, withLogging } from "@app/logger/withlogging";
 
 export type DowngradeWorkspaceResponseBody = {
-  workspace: WorkspaceType;
+  workspace: WorkspaceType & { flags: null };
 };
 
 async function handler(
@@ -45,7 +45,7 @@ async function handler(
           allowedDomain: owner.allowedDomain || null,
           role: "admin",
           segmentation: owner.segmentation || null,
-          flags: [],
+          flags: null,
         },
       });
 

--- a/front/pages/api/poke/workspaces/[wId]/upgrade.ts
+++ b/front/pages/api/poke/workspaces/[wId]/upgrade.ts
@@ -9,7 +9,7 @@ import {
 import { apiError, withLogging } from "@app/logger/withlogging";
 
 export type UpgradeWorkspaceResponseBody = {
-  workspace: WorkspaceType;
+  workspace: WorkspaceType & { flags: null };
 };
 
 async function handler(
@@ -53,7 +53,7 @@ async function handler(
           allowedDomain: owner.allowedDomain || null,
           role: "admin",
           segmentation: owner.segmentation || null,
-          flags: [],
+          flags: null,
         },
       });
 

--- a/front/pages/api/poke/workspaces/[wId]/upgrade.ts
+++ b/front/pages/api/poke/workspaces/[wId]/upgrade.ts
@@ -53,6 +53,7 @@ async function handler(
           allowedDomain: owner.allowedDomain || null,
           role: "admin",
           segmentation: owner.segmentation || null,
+          flags: [],
         },
       });
 

--- a/front/pages/api/poke/workspaces/index.ts
+++ b/front/pages/api/poke/workspaces/index.ts
@@ -8,7 +8,7 @@ import { Subscription, Workspace } from "@app/lib/models";
 import { apiError, withLogging } from "@app/logger/withlogging";
 
 export type GetWorkspacesResponseBody = {
-  workspaces: WorkspaceType[];
+  workspaces: (WorkspaceType & { flags: null })[];
 };
 
 async function handler(
@@ -141,7 +141,7 @@ async function handler(
           allowedDomain: ws.allowedDomain || null,
           role: "admin",
           segmentation: ws.segmentation,
-          flags: [],
+          flags: null,
         })),
       });
     default:

--- a/front/pages/api/poke/workspaces/index.ts
+++ b/front/pages/api/poke/workspaces/index.ts
@@ -141,6 +141,7 @@ async function handler(
           allowedDomain: ws.allowedDomain || null,
           role: "admin",
           segmentation: ws.segmentation,
+          flags: [],
         })),
       });
     default:

--- a/front/pages/w/[wId]/a/[aId]/clone.tsx
+++ b/front/pages/w/[wId]/a/[aId]/clone.tsx
@@ -87,7 +87,9 @@ export default function CloneView({
   const [appNameError, setAppNameError] = useState("");
   const [appDescription, setAppDescription] = useState(app.description || "");
   const [appVisibility, setAppVisibility] = useState("public" as AppVisibility);
-  const [targetWorkspace, setTargetWorkspace] = useState(user.workspaces[0]);
+  const [targetWorkspace, setTargetWorkspace] = useState<WorkspaceType>(
+    user.workspaces[0]
+  );
   const [cloning, setCloning] = useState(false);
 
   const formValidation = () => {

--- a/front/pages/w/[wId]/a/[aId]/clone.tsx
+++ b/front/pages/w/[wId]/a/[aId]/clone.tsx
@@ -86,7 +86,7 @@ export default function CloneView({
   const [appName, setAppName] = useState(app.name);
   const [appNameError, setAppNameError] = useState("");
   const [appDescription, setAppDescription] = useState(app.description || "");
-  const [appVisibility, setAppVisibility] = useState("public" as AppVisibility);
+  const [appVisibility, setAppVisibility] = useState<AppVisibility>("private");
   const [targetWorkspace, setTargetWorkspace] = useState<WorkspaceType>(
     user.workspaces[0]
   );
@@ -298,8 +298,8 @@ export default function CloneView({
                           >
                             Public
                             <p className="mt-0 text-sm font-normal text-gray-500">
-                              Anyone on the Internet can see the app. Only you
-                              can edit.
+                              Anyone on the Internet can see the app. Only
+                              builders of your workspace can edit.
                             </p>
                           </label>
                         </div>
@@ -325,34 +325,8 @@ export default function CloneView({
                           >
                             Private
                             <p className="mt-0 text-sm font-normal text-gray-500">
-                              Only you can see and edit the app.
-                            </p>
-                          </label>
-                        </div>
-                        <div className="flex items-center">
-                          <input
-                            id="appVisibilityUnlisted"
-                            name="visibility"
-                            type="radio"
-                            value="unlisted"
-                            className="h-4 w-4 cursor-pointer border-gray-300 text-action-600 focus:ring-action-500"
-                            checked={appVisibility == "unlisted"}
-                            onChange={(e) => {
-                              if (e.target.value != appVisibility) {
-                                setAppVisibility(
-                                  e.target.value as AppVisibility
-                                );
-                              }
-                            }}
-                          />
-                          <label
-                            htmlFor="app-visibility-unlisted"
-                            className="ml-3 block text-sm font-medium text-gray-700"
-                          >
-                            Unlisted
-                            <p className="mt-0 text-sm font-normal text-gray-500">
-                              Anyone with the link can see the app. Only you can
-                              edit.
+                              Only builders of your workspace can see and edit
+                              the app.
                             </p>
                           </label>
                         </div>

--- a/front/pages/w/[wId]/a/new.tsx
+++ b/front/pages/w/[wId]/a/new.tsx
@@ -1,8 +1,8 @@
 import { Button, Page } from "@dust-tt/sparkle";
-import { AppVisibility, type WorkspaceType } from "@dust-tt/types";
-import type { AppType } from "@dust-tt/types";
+import type { AppType , AppVisibility} from "@dust-tt/types";
 import type { SubscriptionType } from "@dust-tt/types";
 import type { APIError } from "@dust-tt/types";
+import type {WorkspaceType} from "@dust-tt/types";
 import { ChevronRightIcon } from "@heroicons/react/20/solid";
 import type { InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";

--- a/front/pages/w/[wId]/a/new.tsx
+++ b/front/pages/w/[wId]/a/new.tsx
@@ -1,5 +1,5 @@
 import { Button, Page } from "@dust-tt/sparkle";
-import type { WorkspaceType } from "@dust-tt/types";
+import { AppVisibility, type WorkspaceType } from "@dust-tt/types";
 import type { AppType } from "@dust-tt/types";
 import type { SubscriptionType } from "@dust-tt/types";
 import type { APIError } from "@dust-tt/types";
@@ -55,7 +55,7 @@ export default function NewApp({
   const [appName, setAppName] = useState("");
   const [appNameError, setAppNameError] = useState("");
   const [appDescription, setAppDescription] = useState("");
-  const [appVisibility, setAppVisibility] = useState("private");
+  const [appVisibility, setAppVisibility] = useState<AppVisibility>("private");
 
   const [creating, setCreating] = useState(false);
 

--- a/front/pages/w/[wId]/a/new.tsx
+++ b/front/pages/w/[wId]/a/new.tsx
@@ -195,7 +195,7 @@ export default function NewApp({
                     checked={appVisibility == "public"}
                     onChange={(e) => {
                       if (e.target.value != appVisibility) {
-                        setAppVisibility(e.target.value);
+                        setAppVisibility(e.target.value as AppVisibility);
                       }
                     }}
                   />
@@ -220,7 +220,7 @@ export default function NewApp({
                     checked={appVisibility == "private"}
                     onChange={(e) => {
                       if (e.target.value != appVisibility) {
-                        setAppVisibility(e.target.value);
+                        setAppVisibility(e.target.value as AppVisibility);
                       }
                     }}
                   />

--- a/front/pages/w/[wId]/a/new.tsx
+++ b/front/pages/w/[wId]/a/new.tsx
@@ -1,8 +1,8 @@
 import { Button, Page } from "@dust-tt/sparkle";
-import type { AppType , AppVisibility} from "@dust-tt/types";
+import type { AppType, AppVisibility } from "@dust-tt/types";
 import type { SubscriptionType } from "@dust-tt/types";
 import type { APIError } from "@dust-tt/types";
-import type {WorkspaceType} from "@dust-tt/types";
+import type { WorkspaceType } from "@dust-tt/types";
 import { ChevronRightIcon } from "@heroicons/react/20/solid";
 import type { InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";

--- a/types/src/front/user.ts
+++ b/types/src/front/user.ts
@@ -1,5 +1,6 @@
 import { ModelId } from "../shared/model_id";
 import { assertNever } from "../shared/utils/assert_never";
+import { WhitelistableFeature } from "./feature_flags";
 
 export type WorkspaceSegmentationType = "interesting" | null;
 export type RoleType = "admin" | "builder" | "user" | "none";
@@ -11,6 +12,7 @@ export type WorkspaceType = {
   allowedDomain: string | null;
   role: RoleType;
   segmentation: WorkspaceSegmentationType;
+  flags: WhitelistableFeature[];
 };
 
 export type UserProviderType = "github" | "google";

--- a/types/src/front/user.ts
+++ b/types/src/front/user.ts
@@ -12,7 +12,7 @@ export type WorkspaceType = {
   allowedDomain: string | null;
   role: RoleType;
   segmentation: WorkspaceSegmentationType;
-  flags: WhitelistableFeature[];
+  flags: WhitelistableFeature[] | null;
 };
 
 export type UserProviderType = "github" | "google";
@@ -31,7 +31,7 @@ export type UserType = {
 };
 
 export type UserTypeWithWorkspaces = UserType & {
-  workspaces: WorkspaceType[];
+  workspaces: (WorkspaceType & { flags: null })[];
 };
 
 export type UserMetadataType = {


### PR DESCRIPTION
## Description

Experiment with adding flags to WorkspaceType.

Will attempt to deploy this PR without removing the old implementations. If latencies are confirmed to be good, I'll clean-up the hook + server-side code.

Graphs to keep track of:

GetServerSideProps: https://app.datadoghq.eu/logs?query=%22Processed%20getServerSideProps%22%20&agg_m=%40durationMs&agg_m_source=base&agg_t=avg&analyticsOptions=%5B%22line%22%2C%22dog_classic%22%2Cnull%2Cnull%5D&cols=host%2Cservice%2C%40durationMs&index=%2A&messageDisplay=inline&refresh_mode=sliding&stream_sort=desc&viz=timeseries&from_ts=1707463881266&to_ts=1707467481266&live=true

Processed Request (non-streaming GET): https://app.datadoghq.eu/logs?query=%22Processed%20request%22%20service%3Afront%20%40method%3AGET%20%40streaming%3Afalse&agg_m=%40durationMs&agg_m_source=base&agg_t=avg&analyticsOptions=%5B%22line%22%2C%22dog_classic%22%2Cnull%2Cnull%5D&cols=host%2Cservice%2C%40durationMs&index=%2A&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&view=spans&viz=timeseries&from_ts=1707466990868&to_ts=1707467890868&live=true

## Risk

Monitor latency of getServerSideProps / API routes

## Deploy Plan

- deploy `front`