### PR TITLE
Fix: move pointer class to top of Chip component

### DIFF
--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.88",
+  "version": "0.2.89",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/components/Chip.tsx
+++ b/sparkle/src/components/Chip.tsx
@@ -49,6 +49,7 @@ export function Chip({
     sizeClasses[size],
     backgroundColor,
     textColor,
+    "s-cursor-default",
     className
   );
 
@@ -57,12 +58,7 @@ export function Chip({
       {icon && <Icon visual={icon} size={size as IconProps["size"]} />}
       {isBusy && <Spinner size={size} variant="darkGrey" />}
       {label && (
-        <span
-          className={classNames(
-            textColor,
-            "s-pointer s-grow s-cursor-default s-truncate"
-          )}
-        >
+        <span className={classNames(textColor, "s-grow s-truncate")}>
           {label}
         </span>
       )}


### PR DESCRIPTION
## Description

Allows callers to set the pointer in the chip if needed

## Risk
Check chips are fine afterwards
