### PR TITLE
Fix: mouse pointer in sharing dropdown in assistant details

### DIFF
--- a/front/components/assistant/Sharing.tsx
+++ b/front/components/assistant/Sharing.tsx
@@ -287,12 +287,9 @@ export function SharingDropdown({
 
 export function SharingChip({ scope }: { scope: AgentConfigurationScope }) {
   return (
-    <Chip
-      label={SCOPE_INFO[scope].label}
-      color={SCOPE_INFO[scope].color}
-      icon={SCOPE_INFO[scope].icon}
-      className="cursor-default"
-    />
+    <Chip color={SCOPE_INFO[scope].color} icon={SCOPE_INFO[scope].icon}>
+      {SCOPE_INFO[scope].label}
+    </Chip>
   );
 }
 

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@dust-tt/sparkle": "^0.2.88",
+        "@dust-tt/sparkle": "^0.2.90",
         "@dust-tt/types": "file:../types",
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",
@@ -933,9 +933,9 @@
       "integrity": "sha512-smLocSfrt3s53H/XSVP3/1kP42oqvrkjUPtyaFd1F79ux24oE31BKt+q0c6lsa6hOYrFzsIwyc5GXAI5JmfOew=="
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.88",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.88.tgz",
-      "integrity": "sha512-299c472v0a6BgeT5RqROH6NCsUULafW+bqe10qjQXnSAqoGpkJCX85A7CZSTuGmt0e6vug/ClS+yNnS3kIx8xA==",
+      "version": "0.2.90",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.90.tgz",
+      "integrity": "sha512-ve83hEd9L3wsnkjIZ6xlnBWfvnafThXukLoaTOzY4p4IFlB7enEpDwDKH9ccy6xskpAK6M3iVnuWhQwE4zAI3Q==",
       "dependencies": {
         "@headlessui/react": "^1.7.17"
       },

--- a/front/package.json
+++ b/front/package.json
@@ -13,7 +13,7 @@
     "initdb": "npx tsx admin/db.ts"
   },
   "dependencies": {
-    "@dust-tt/sparkle": "^0.2.88",
+    "@dust-tt/sparkle": "^0.2.90",
     "@dust-tt/types": "file:../types",
     "@emoji-mart/data": "^1.1.2",
     "@emoji-mart/react": "^1.1.1",


### PR DESCRIPTION
## Description
When hovering on dropdown below, mouse pointer was default. It is now pointer

The cursor-pointer styling that took place in the parent dropdown of `SharingChip` could not happen before because of the use of 'label' in the chip (in addition to the explicit styling). 'label' forces the chip to be cursor-default, which is in general good (otherwise they have text cursor) hence the revert of #3645 by #3646

![image](https://github.com/dust-tt/dust/assets/5437393/f008350b-73a0-4787-ac7b-08a70c65b273)
## Risk
None
## Deploy
Bumps sparkle for front
