### PR TITLE
Fix route computation + streaming in logs

### DIFF
--- a/front/logger/withlogging.ts
+++ b/front/logger/withlogging.ts
@@ -55,6 +55,7 @@ export function withLogging<T>(
           url: req.url,
           route,
           durationMs: elapsed,
+          streaming,
           error: err,
           // @ts-expect-error best effort to get err.stack if it exists
           error_stack: err?.stack,

--- a/front/logger/withlogging.ts
+++ b/front/logger/withlogging.ts
@@ -39,7 +39,7 @@ export function withLogging<T>(
       route = route.split("?")[0];
       for (const key in req.query) {
         const value = req.query[key];
-        if (typeof value === "string") {
+        if (typeof value === "string" && value.length > 0) {
           route = route.replaceAll(value, `[${key}]`);
         }
       }
@@ -100,6 +100,7 @@ export function withLogging<T>(
         route,
         statusCode: res.statusCode,
         durationMs: elapsed,
+        streaming,
       },
       "Processed request"
     );
@@ -149,7 +150,7 @@ export function withGetServerSidePropsLogging<T extends { [key: string]: any }>(
     let route = context.resolvedUrl.split("?")[0];
     for (const key in context.params) {
       const value = context.params[key];
-      if (typeof value === "string") {
+      if (typeof value === "string" && value.length > 0) {
         route = route.replaceAll(value, `[${key}]`);
       }
     }


### PR DESCRIPTION
## Description

Fixes small bug in route computation when the value is empty
Example: https://app.datadoghq.eu/logs?query=%22Processed%20request%22%20service%3Afront%20%40method%3AGET%20&cols=host%2Cservice%2C%40durationMs&event=AgAAAY2M8JBbhyOLTgAAAAAAAAAYAAAAAEFZMk04SlJHQUFEbGxzYXM1VTNTeXdBOAAAACQAAAAAMDE4ZDhjZjAtOTZiMC00Nzk0LTg5NzMtNjZkOTY4MWZlOWEz&index=%2A&messageDisplay=inline&refresh_mode=sliding&sort=time&stream_sort=desc&view=spans&viz=stream&from_ts=1706283512877&to_ts=1706297912877&live=true

Also adds streaming flag to logs

## Risk

N/A

## Deploy Plan

- deploy `front`