### PR TITLE
New intercom model: Conversations

### DIFF
--- a/connectors/src/admin/db.ts
+++ b/connectors/src/admin/db.ts
@@ -24,6 +24,7 @@ import {
 import {
   IntercomArticle,
   IntercomCollection,
+  IntercomConversation,
   IntercomHelpCenter,
   IntercomTeam,
 } from "@connectors/lib/models/intercom";
@@ -78,6 +79,7 @@ async function main(): Promise<void> {
   await IntercomCollection.sync({ alter: true });
   await IntercomArticle.sync({ alter: true });
   await IntercomTeam.sync({ alter: true });
+  await IntercomConversation.sync({ alter: true });
   await WebCrawlerConfiguration.sync({ alter: true });
   await WebCrawlerFolder.sync({ alter: true });
   await WebCrawlerPage.sync({ alter: true });

--- a/connectors/src/admin/db.ts
+++ b/connectors/src/admin/db.ts
@@ -27,6 +27,7 @@ import {
   IntercomConversation,
   IntercomHelpCenter,
   IntercomTeam,
+  IntercomWorkspace,
 } from "@connectors/lib/models/intercom";
 import {
   NotionConnectorBlockCacheEntry,
@@ -75,6 +76,7 @@ async function main(): Promise<void> {
   await NotionConnectorPageCacheEntry.sync({ alter: true });
   await NotionConnectorResourcesToCheckCacheEntry.sync({ alter: true });
   await GoogleDriveConfig.sync({ alter: true });
+  await IntercomWorkspace.sync({ alter: true });
   await IntercomHelpCenter.sync({ alter: true });
   await IntercomCollection.sync({ alter: true });
   await IntercomArticle.sync({ alter: true });

--- a/connectors/src/lib/models/intercom.ts
+++ b/connectors/src/lib/models/intercom.ts
@@ -347,3 +347,68 @@ IntercomTeam.init(
   }
 );
 Connector.hasMany(IntercomTeam);
+
+export class IntercomConversation extends Model<
+  InferAttributes<IntercomConversation>,
+  InferCreationAttributes<IntercomConversation>
+> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare conversationId: string;
+  declare teamId: string;
+  declare conversationCreatedAt: Date;
+
+  declare lastUpsertedTs: Date;
+
+  declare connectorId: ForeignKey<Connector["id"]>;
+}
+
+IntercomConversation.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    conversationId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    teamId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    conversationCreatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+    },
+    lastUpsertedTs: {
+      type: DataTypes.DATE,
+      allowNull: false,
+    },
+  },
+  {
+    sequelize: sequelize_conn,
+    indexes: [
+      {
+        fields: ["connectorId", "conversationId"],
+        unique: true,
+        name: "intercom_connector_conversation_idx",
+      },
+    ],
+    modelName: "intercom_conversations",
+  }
+);
+Connector.hasMany(IntercomConversation);

--- a/connectors/src/lib/models/intercom.ts
+++ b/connectors/src/lib/models/intercom.ts
@@ -8,6 +8,59 @@ import { DataTypes, Model } from "sequelize";
 
 import { Connector, sequelize_conn } from "@connectors/lib/models";
 
+export class IntercomWorkspace extends Model<
+  InferAttributes<IntercomWorkspace>,
+  InferCreationAttributes<IntercomWorkspace>
+> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare intercomWorkspaceId: string;
+  declare name: string;
+
+  declare connectorId: ForeignKey<Connector["id"]>;
+}
+IntercomWorkspace.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    intercomWorkspaceId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    name: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+  },
+  {
+    sequelize: sequelize_conn,
+    indexes: [
+      {
+        fields: ["connectorId", "intercomWorkspaceId"],
+        unique: true,
+        name: "intercom_connector_workspace_idx",
+      },
+    ],
+    modelName: "intercom_workspaces",
+  }
+);
+Connector.hasMany(IntercomWorkspace);
+
 export class IntercomHelpCenter extends Model<
   InferAttributes<IntercomHelpCenter>,
   InferCreationAttributes<IntercomHelpCenter>

--- a/connectors/src/lib/models/intercom.ts
+++ b/connectors/src/lib/models/intercom.ts
@@ -18,6 +18,7 @@ export class IntercomWorkspace extends Model<
 
   declare intercomWorkspaceId: string;
   declare name: string;
+  declare conversationsSlidingWindow: number;
 
   declare connectorId: ForeignKey<Connector["id"]>;
 }
@@ -45,6 +46,11 @@ IntercomWorkspace.init(
     name: {
       type: DataTypes.STRING,
       allowNull: false,
+    },
+    conversationsSlidingWindow: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      defaultValue: 90,
     },
   },
   {


### PR DESCRIPTION
## Description

Creates news model required for the conversation sync, coming in the next PRs.

**Intercom Conversation**
We store the id of the team the conversation is attached to, the id of the conversation, and the creation date of the conversation which we'll use on our workflow to remove old conversations from the connector.

**Intercom Workspace**
I managed to do without it for the Help Center sync but to build the url of the conversation I need the id of the workspace stored somewhere. 


## Risk

Models are not used yet. 

## Deploy Plan

Run init_db on connectors.
