### PR TITLE
Manage assistants page: search across all assistants, not only tab

### DIFF
--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -118,6 +118,7 @@ function determineGlobalAgentIdsToFetch(
     case "list":
     case "all":
     case "admin_internal":
+    case "manage-assistants-search":
       // All global agents in global, list, all, admin_internal views.
       return undefined;
     default:
@@ -237,6 +238,7 @@ async function fetchAgentConfigurationsForView(
         where: baseConditionsAndScopesIn(["published"]),
       });
 
+    case "manage-assistants-search":
     case "list":
       const user = auth.user();
 

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -112,15 +112,13 @@ function determineGlobalAgentIdsToFetch(
   switch (agentsGetView) {
     case "workspace":
     case "published":
-      // No global agents in workspace & published view.
-      return [];
+      return []; // fetch no global agents
     case "global":
     case "list":
     case "all":
     case "admin_internal":
     case "manage-assistants-search":
-      // All global agents in global, list, all, admin_internal views.
-      return undefined;
+      return undefined; // undefined means all global agents will be fetched
     default:
       if (
         typeof agentsGetView === "object" &&

--- a/front/lib/swr.ts
+++ b/front/lib/swr.ts
@@ -493,6 +493,9 @@ export function useConversationReactions({
   };
 }
 
+/*
+ * Agent configurations. A null agentsGetView means no fetching
+ */
 export function useAgentConfigurations({
   workspaceId,
   agentsGetView,
@@ -501,7 +504,7 @@ export function useAgentConfigurations({
   sort,
 }: {
   workspaceId: string;
-  agentsGetView: AgentsGetViewType;
+  agentsGetView: AgentsGetViewType | null;
   includes?: ("authors" | "usage")[];
   limit?: number;
   sort?: "alphabetical" | "priority";
@@ -515,7 +518,7 @@ export function useAgentConfigurations({
     if (typeof agentsGetView === "string") {
       params.append("view", agentsGetView);
     } else {
-      if ("conversationId" in agentsGetView) {
+      if (agentsGetView && "conversationId" in agentsGetView) {
         params.append("conversationId", agentsGetView.conversationId);
       }
     }
@@ -539,7 +542,9 @@ export function useAgentConfigurations({
 
   const queryString = getQueryString();
   const { data, error, mutate } = useSWR(
-    `/api/w/${workspaceId}/assistant/agent_configurations?${queryString}`,
+    agentsGetView
+      ? `/api/w/${workspaceId}/assistant/agent_configurations?${queryString}`
+      : null,
     agentConfigurationsFetcher
   );
 

--- a/front/pages/w/[wId]/builder/assistants/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/index.tsx
@@ -34,7 +34,7 @@ import {
   compareAgentsForSort,
 } from "@app/lib/assistant";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { useAgentConfigurations, useFeatures } from "@app/lib/swr";
+import { useAgentConfigurations } from "@app/lib/swr";
 import { classNames, subFilter } from "@app/lib/utils";
 import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
 
@@ -171,7 +171,7 @@ export default function WorkspaceAssistants({
     icon: SCOPE_INFO[scope].icon,
     href: `/w/${owner.sId}/builder/assistants?tabScope=${scope}`,
   }));
-  const { features } = useFeatures(owner);
+
   const disabledTablineClass =
     "!border-element-500 !text-element-500 !cursor-default";
 

--- a/types/src/front/api_handlers/internal/agent_configuration.ts
+++ b/types/src/front/api_handlers/internal/agent_configuration.ts
@@ -16,6 +16,7 @@ export const GetAgentConfigurationsQuerySchema = t.type({
     t.literal("global"),
     t.literal("admin_internal"),
     t.literal("all"),
+    t.literal("manage-assistants-search"),
     t.undefined,
   ]),
   conversationId: t.union([t.string, t.undefined]),
@@ -36,6 +37,7 @@ export const GetAgentConfigurationsLeaderboardQuerySchema = t.type({
     t.literal("published"),
     t.literal("global"),
     t.literal("admin_internal"),
+    t.literal("manage-assistants-search"),
     t.literal("all"),
   ]),
 });

--- a/types/src/front/assistant/agent.ts
+++ b/types/src/front/assistant/agent.ts
@@ -89,22 +89,33 @@ export type AgentConfigurationScope =
 export type AgentUserListStatus = "in-list" | "not-in-list";
 
 /**
- * Defines strategies for fetching agent configurations based on various 'views':
- * - 'list': Retrieves all agents within the user's list, including their private agents, agents from the workspace and global scope,
- * plus any published agents they've added to their list (refer to AgentUserRelationTable).
+ * Defines strategies for fetching agent configurations based on various
+ * 'views':
+ * - 'list': Retrieves all agents within the user's list, including their
+ *   private agents, agents from the workspace and global scope, plus any
+ *   published agents they've added to their list (refer to
+ *   AgentUserRelationTable).
  * - {agentId: string}: Retrieves a single agent by its ID.
- * - {conversationId: string}: all agent from the user's list view, plus the agents mentioned in the conversation with the provided Id.
- * - 'all': Combines workspace and published agents, excluding private agents. Typically used in agent galleries.
+ * - {conversationId: string}: all agent from the user's list view, plus the
+ *   agents mentioned in the conversation with the provided Id.
+ * - 'all': Combines workspace and published agents, excluding private agents.
+ *   Typically used in agent galleries.
+ * - 'manage-assistants-search': specific to the manage-assistants page,
+ *   retrieves all global agents including inactive ones, all workspace, all
+ *   published and the user's private agents.
  * - 'workspace': Retrieves all agents exclusively with a 'workspace' scope.
  * - 'published': Retrieves all agents exclusively with a 'published' scope.
  * - 'global': Retrieves all agents exclusively with a 'global' scope.
- * - 'admin_internal': Grants access to all agents, including private ones. Intended strictly for internal use with necessary superuser or admin authorization.
+ * - 'admin_internal': Grants access to all agents, including private ones.
+ *   Intended strictly for internal use with necessary superuser or admin
+ *   authorization.
  */
 export type AgentsGetViewType =
   | { agentId: string; allVersions?: boolean }
   | "list"
   | { conversationId: string }
   | "all"
+  | "manage-assistants-search"
   | "workspace"
   | "published"
   | "global"


### PR DESCRIPTION
## Description
As discussed [here](https://dust4ai.slack.com/archives/C050A0S2Z7F/p1707410227188539)

Creates a new view for this search, which is quite specific (all global agents including inactive ones, private agents from the user, all published agents including those not in list, etc.)

![image](https://github.com/dust-tt/dust/assets/5437393/eb8b6a80-ce61-4743-a25c-360f29be9e67)
![image](https://github.com/dust-tt/dust/assets/5437393/c00ae210-2746-435c-86b3-514176d2a4ee)

## Risk
New view, but not altering others so it should be fine.
