### PR TITLE
Intercom: Save Intercom workspace and add function for conversation api

### DIFF
--- a/connectors/src/connectors/intercom/index.ts
+++ b/connectors/src/connectors/intercom/index.ts
@@ -84,6 +84,7 @@ export async function createIntercomConnector(
       connectorId: connector.id,
       intercomWorkspaceId: intercomWorkspace.id,
       name: intercomWorkspace.name,
+      conversationsSlidingWindow: 90,
     });
 
     const workflowStarted = await launchIntercomSyncWorkflow(

--- a/connectors/src/connectors/intercom/index.ts
+++ b/connectors/src/connectors/intercom/index.ts
@@ -197,7 +197,7 @@ export async function cleanupIntercomConnector(
     return new Err(new Error("Connector not found"));
   }
 
-  return sequelize_conn.transaction(async (transaction) => {
+  await sequelize_conn.transaction(async (transaction) => {
     await Promise.all([
       IntercomWorkspace.destroy({
         where: {
@@ -229,22 +229,21 @@ export async function cleanupIntercomConnector(
         },
         transaction: transaction,
       }),
+      connector.destroy({
+        transaction: transaction,
+      }),
     ]);
-
-    const nangoRes = await nangoDeleteConnection(
-      connector.connectionId,
-      NANGO_INTERCOM_CONNECTOR_ID
-    );
-    if (nangoRes.isErr()) {
-      throw nangoRes.error;
-    }
-
-    await connector.destroy({
-      transaction: transaction,
-    });
-
-    return new Ok(undefined);
   });
+
+  const nangoRes = await nangoDeleteConnection(
+    connector.connectionId,
+    NANGO_INTERCOM_CONNECTOR_ID
+  );
+  if (nangoRes.isErr()) {
+    throw nangoRes.error;
+  }
+
+  return new Ok(undefined);
 }
 
 export async function stopIntercomConnector(

--- a/connectors/src/connectors/intercom/lib/conversation_permissions.ts
+++ b/connectors/src/connectors/intercom/lib/conversation_permissions.ts
@@ -1,5 +1,4 @@
 import type { ConnectorResource } from "@dust-tt/types";
-import type { Client as IntercomClient } from "intercom-client";
 
 import {
   fetchIntercomTeam,
@@ -14,11 +13,9 @@ import logger from "@connectors/logger/logger";
 
 export async function allowSyncTeam({
   connector,
-  intercomClient,
   teamId,
 }: {
   connector: Connector;
-  intercomClient: IntercomClient;
   teamId: string;
 }): Promise<IntercomTeam> {
   let team = await IntercomTeam.findOne({
@@ -33,7 +30,10 @@ export async function allowSyncTeam({
     });
   }
   if (!team) {
-    const teamOnIntercom = await fetchIntercomTeam(intercomClient, teamId);
+    const teamOnIntercom = await fetchIntercomTeam(
+      connector.connectionId,
+      teamId
+    );
     if (teamOnIntercom) {
       team = await IntercomTeam.create({
         connectorId: connector.id,

--- a/connectors/src/connectors/intercom/lib/intercom_api.ts
+++ b/connectors/src/connectors/intercom/lib/intercom_api.ts
@@ -363,11 +363,13 @@ export async function fetchIntercomTeam(
 export async function fetchIntercomConversationsForTeamId({
   nangoConnectionId,
   teamId,
+  slidingWindow,
   cursor = null,
   pageSize = 20,
 }: {
   nangoConnectionId: string;
   teamId: string;
+  slidingWindow: number;
   cursor: string | null;
   pageSize?: number;
 }): Promise<{
@@ -389,8 +391,10 @@ export async function fetchIntercomConversationsForTeamId({
     useCache: true,
   });
 
-  const ninetyDaysAgo = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000);
-  const minCreatedAt = Math.floor(ninetyDaysAgo.getTime() / 1000);
+  const minCreatedAtDate = new Date(
+    Date.now() - slidingWindow * 24 * 60 * 60 * 1000
+  );
+  const minCreatedAt = Math.floor(minCreatedAtDate.getTime() / 1000);
 
   const resp = await fetch(`https://api.intercom.io/conversations/search`, {
     method: "POST",

--- a/connectors/src/connectors/intercom/lib/intercom_api.ts
+++ b/connectors/src/connectors/intercom/lib/intercom_api.ts
@@ -41,18 +41,50 @@ type IntercomArticleType = ArticleObject & {
   parent_ids: string[];
 };
 
-// TO BE REMOVED IN A NEXT PR
-export async function validateAccessToken(intercomAccessToken: string) {
-  const intercomClient = new Client({
-    tokenAuth: { token: intercomAccessToken },
-  });
-  try {
-    await intercomClient.admins.list(); // trying a simple request
-  } catch (e) {
-    return false;
-  }
-  return true;
-}
+export type IntercomTeamType = {
+  type: "team";
+  id: string;
+  name: string;
+  admin_ids: string[];
+};
+
+export type IntercomConversationType = {
+  type: "conversation";
+  id: string;
+  created_at: Date;
+  updated_at: Date;
+  title: string;
+  admin_assignee_id: number;
+  team_assignee_id: number;
+  open: boolean;
+  tags: IntercomTagType[];
+  conversation_parts?: ConversationPartType;
+};
+
+export type IntercomTagType = {
+  type: "tag";
+  id: string;
+  name: string;
+};
+
+export type ConversationPartType = {
+  id: string;
+  part_type: string;
+  body: string;
+  created_at: Date;
+  updated_at: Date;
+  notified_at: Date;
+  assigned_to: string | null;
+  author: IntercomAuthor;
+  attachments: [];
+  redacted: boolean;
+};
+
+type IntercomAuthor = {
+  id: string;
+  type: "user" | "admin" | "bot" | "team";
+  name: string;
+};
 
 /**
  * Return the Intercom Access Token that was defined in the Dust Intercom App.
@@ -80,7 +112,12 @@ export async function getIntercomClient(
  * Return the Intercom Workspace Id.
  * Not available via the Node SDK, calling the API directly.
  */
-export async function fetchIntercomWorkspaceId(nangoConnectionId: string) {
+export async function fetchIntercomWorkspace(
+  nangoConnectionId: string
+): Promise<{
+  id: string;
+  name: string;
+}> {
   if (!NANGO_INTERCOM_CONNECTOR_ID) {
     throw new Error("NANGO_NOTION_CONNECTOR_ID not set");
   }
@@ -105,7 +142,10 @@ export async function fetchIntercomWorkspaceId(nangoConnectionId: string) {
   if (!workspaceId) {
     throw new Error("No Intercom Workspace Id found.");
   }
-  return workspaceId;
+  return {
+    id: workspaceId,
+    name: data.app.name,
+  };
 }
 
 /**
@@ -290,11 +330,139 @@ export async function fetchIntercomTeams(
  * Return the detail of a Team.
  */
 export async function fetchIntercomTeam(
-  intercomClient: Client,
+  nangoConnectionId: string,
   teamId: string
-): Promise<TeamObject | null> {
-  const teamsResponse = await intercomClient.teams.find({
-    id: teamId,
+): Promise<IntercomTeamType | null> {
+  if (!NANGO_INTERCOM_CONNECTOR_ID) {
+    throw new Error("NANGO_NOTION_CONNECTOR_ID not set");
+  }
+
+  const accessToken = await getAccessTokenFromNango({
+    connectionId: nangoConnectionId,
+    integrationId: NANGO_INTERCOM_CONNECTOR_ID,
+    useCache: true,
   });
-  return teamsResponse ?? null;
+
+  const resp = await fetch(`https://api.intercom.io/teams/${teamId}`, {
+    method: "GET",
+    headers: {
+      "Intercom-Version": "2.10",
+      Authorization: `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+    },
+  });
+
+  const response = await resp.json();
+  return response;
+}
+
+/**
+ * Return the paginated list of Conversation for a given Team.
+ * Filtered on the last 3 months and closed Conversations.
+ */
+export async function fetchIntercomConversationsForTeamId({
+  nangoConnectionId,
+  teamId,
+  cursor = null,
+  pageSize = 20,
+}: {
+  nangoConnectionId: string;
+  teamId: string;
+  cursor: string | null;
+  pageSize?: number;
+}): Promise<{
+  conversations: IntercomConversationType[];
+  pages: {
+    next?: {
+      page: number;
+      starting_after: string;
+    };
+  };
+}> {
+  if (!NANGO_INTERCOM_CONNECTOR_ID) {
+    throw new Error("NANGO_NOTION_CONNECTOR_ID not set");
+  }
+
+  const accessToken = await getAccessTokenFromNango({
+    connectionId: nangoConnectionId,
+    integrationId: NANGO_INTERCOM_CONNECTOR_ID,
+    useCache: true,
+  });
+
+  const ninetyDaysAgo = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000);
+  const minCreatedAt = Math.floor(ninetyDaysAgo.getTime() / 1000);
+
+  const resp = await fetch(`https://api.intercom.io/conversations/search`, {
+    method: "POST",
+    headers: {
+      "Intercom-Version": "2.10",
+      Authorization: `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      query: {
+        operator: "AND",
+        value: [
+          {
+            field: "open",
+            operator: "=",
+            value: false,
+          },
+          {
+            field: "team_assignee_id",
+            operator: "=",
+            value: teamId,
+          },
+          {
+            field: "created_at",
+            operator: ">",
+            value: minCreatedAt,
+          },
+        ],
+      },
+      pagination: {
+        per_page: pageSize,
+        starting_after: cursor,
+      },
+    }),
+  });
+
+  const response = await resp.json();
+  return response;
+}
+
+/**
+ * Return the detail of a Conversation.
+ */
+export async function fetchIntercomConversation({
+  nangoConnectionId,
+  conversationId,
+}: {
+  nangoConnectionId: string;
+  conversationId: string;
+}) {
+  if (!NANGO_INTERCOM_CONNECTOR_ID) {
+    throw new Error("NANGO_NOTION_CONNECTOR_ID not set");
+  }
+
+  const accessToken = await getAccessTokenFromNango({
+    connectionId: nangoConnectionId,
+    integrationId: NANGO_INTERCOM_CONNECTOR_ID,
+    useCache: true,
+  });
+
+  const resp = await fetch(
+    `https://api.intercom.io/conversations/${conversationId}`,
+    {
+      method: "GET",
+      headers: {
+        "Intercom-Version": "2.10",
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+    }
+  );
+
+  const response = await resp.json();
+  return response;
 }

--- a/connectors/src/connectors/intercom/lib/utils.ts
+++ b/connectors/src/connectors/intercom/lib/utils.ts
@@ -27,6 +27,12 @@ export function getTeamInternalId(
 ): string {
   return `intercom-team-${connectorId}-${teamId}`;
 }
+export function getConversationInternalId(
+  connectorId: ModelId,
+  conversationId: string
+): string {
+  return `intercom-conversation-${connectorId}-${conversationId}`;
+}
 
 /**
  * From internalId to id


### PR DESCRIPTION
## Description

This PR contains: 
- refactor of `fetchIntercomWorkspaceId` into `fetchIntercomWorkspace` to retrieve both the workspace id and the workspace name
- Edition of `createIntercomConnector` to save the new `IntercomWorkspace` object for the connector. 
- Edition of `updateIntercomConnector` to use the `IntercomWorkspace` object and update it if necessary.
- Edition of `cleanupIntercomConnector` to delete the `IntercomWorkspace`object. 
- Some new function on Intercom_api to fetch conversations, to be used in the next PR -> Note that I realized the intercom node API has been announced to be unmaintained so I'm switching to use directly the API. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Nothing special. 
