### PR TITLE
Intercom: convo sync

### DIFF
--- a/connectors/src/connectors/intercom/index.ts
+++ b/connectors/src/connectors/intercom/index.ts
@@ -404,11 +404,12 @@ export async function setIntercomConnectorPermissions(
       }
     }
 
-    if (toBeSignaledHelpCenterIds.size > 0) {
+    if (toBeSignaledHelpCenterIds.size > 0 || toBeSignaledTeamIds.size > 0) {
       const sendSignalToWorkflowResult = await launchIntercomSyncWorkflow(
         connectorId,
         null,
-        [...toBeSignaledHelpCenterIds]
+        [...toBeSignaledHelpCenterIds],
+        [...toBeSignaledTeamIds]
       );
       if (sendSignalToWorkflowResult.isErr()) {
         return new Err(sendSignalToWorkflowResult.error);

--- a/connectors/src/connectors/intercom/temporal/activities.ts
+++ b/connectors/src/connectors/intercom/temporal/activities.ts
@@ -1,18 +1,36 @@
 import type { ModelId } from "@dust-tt/types";
+import { Op } from "sequelize";
 
-import { fetchIntercomHelpCenter } from "@connectors/connectors/intercom/lib/intercom_api";
+import {
+  fetchIntercomConversationsForTeamId,
+  fetchIntercomHelpCenter,
+  fetchIntercomTeam,
+} from "@connectors/connectors/intercom/lib/intercom_api";
+import {
+  deleteConversation,
+  deleteTeamAndConversations,
+  syncConversation,
+} from "@connectors/connectors/intercom/temporal/sync_conversation";
 import {
   removeHelpCenter,
   syncCollection,
 } from "@connectors/connectors/intercom/temporal/sync_help_center";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
+import { concurrentExecutor } from "@connectors/lib/async_utils";
 import { Connector } from "@connectors/lib/models";
+import {
+  IntercomConversation,
+  IntercomWorkspace,
+} from "@connectors/lib/models/intercom";
 import {
   IntercomCollection,
   IntercomHelpCenter,
+  IntercomTeam,
 } from "@connectors/lib/models/intercom";
 import { syncStarted, syncSucceeded } from "@connectors/lib/sync_status";
 import logger from "@connectors/logger/logger";
+
+const INTERCOM_CONVO_BATCH_SIZE = 20;
 
 async function _getIntercomConnectorOrRaise(connectorId: ModelId) {
   const connector = await Connector.findOne({
@@ -209,4 +227,214 @@ export async function syncCollectionActivity({
     collection,
     currentSyncMs,
   });
+}
+
+/**
+ * This activity is responsible for retrieving the list
+ * of team ids to sync for a given connector.
+ */
+export async function getTeamIdsToSyncActivity(connectorId: ModelId) {
+  const teams = await IntercomTeam.findAll({
+    attributes: ["teamId"],
+    where: {
+      connectorId: connectorId,
+    },
+  });
+  return teams.map((t) => t.teamId);
+}
+
+/**
+ * This activity is responsible for syncing the conversations of a given Team.
+ * If the team is not allowed anymore, it will delete all its data.
+ * If the team is not present on Intercom anymore, it will delete all its data.
+ * If the team is present on Intercom and is allowed, it will sync its conversations.
+ */
+export async function syncTeamOnlyActivity({
+  connectorId,
+  teamId,
+  currentSyncMs,
+}: {
+  connectorId: ModelId;
+  teamId: string;
+  currentSyncMs: number;
+}): Promise<boolean> {
+  const connector = await _getIntercomConnectorOrRaise(connectorId);
+  const dataSourceConfig = dataSourceConfigFromConnector(connector);
+  const loggerArgs = {
+    workspaceId: dataSourceConfig.workspaceId,
+    connectorId,
+    provider: "intercom",
+    dataSourceName: dataSourceConfig.dataSourceName,
+  };
+
+  const teamOnDB = await IntercomTeam.findOne({
+    where: {
+      connectorId,
+      teamId,
+    },
+  });
+  if (!teamOnDB) {
+    logger.error({ loggerArgs, teamId }, "[Intercom] Team not found");
+    return false;
+  }
+
+  // If our rights were revoked we delete the team and its conversations
+  if (teamOnDB.permission === "none") {
+    await deleteTeamAndConversations({
+      connectorId,
+      dataSourceConfig,
+      team: teamOnDB,
+    });
+    return false;
+  }
+
+  // If the team does not exists on Intercom we delete the team and its conversations
+  const teamOnIntercom = await fetchIntercomTeam(
+    connector.connectionId,
+    teamId
+  );
+  if (!teamOnIntercom) {
+    await deleteTeamAndConversations({
+      connectorId,
+      dataSourceConfig,
+      team: teamOnDB,
+    });
+    return false;
+  }
+
+  // Otherwise we update the team name and lastUpsertedTs
+  await teamOnDB.update({
+    name: teamOnIntercom.name,
+    lastUpsertedTs: new Date(currentSyncMs),
+  });
+  return true;
+}
+
+/**
+ * This activity is responsible for getting the next batch
+ * of conversations to sync for a given team.
+ */
+export async function getNextConversationBatchToSyncActivity({
+  connectorId,
+  teamId,
+  cursor,
+}: {
+  connectorId: ModelId;
+  teamId: string;
+  cursor: string | null;
+}): Promise<{ conversationIds: string[]; nextPageCursor: string | null }> {
+  const connector = await _getIntercomConnectorOrRaise(connectorId);
+
+  const intercomWorkspace = await IntercomWorkspace.findOne({
+    where: {
+      connectorId,
+    },
+  });
+  if (!intercomWorkspace) {
+    throw new Error("[Intercom] Workspace not found");
+  }
+
+  const result = await fetchIntercomConversationsForTeamId({
+    nangoConnectionId: connector.connectionId,
+    teamId,
+    slidingWindow: intercomWorkspace.conversationsSlidingWindow,
+    cursor,
+    pageSize: INTERCOM_CONVO_BATCH_SIZE,
+  });
+
+  const conversationIds = result.conversations.map((c) => c.id);
+  const nextPageCursor = result.pages.next
+    ? result.pages.next.starting_after
+    : null;
+
+  return { conversationIds, nextPageCursor };
+}
+
+/**
+ * This activity is responsible for syncing a batch of conversations.
+ */
+export async function syncConversationBatchActivity({
+  connectorId,
+  teamId,
+  conversationIds,
+  currentSyncMs,
+}: {
+  connectorId: ModelId;
+  teamId: string;
+  conversationIds: string[];
+  currentSyncMs: number;
+}): Promise<void> {
+  const connector = await _getIntercomConnectorOrRaise(connectorId);
+  const nangoConnectionId = connector.connectionId;
+  const dataSourceConfig = dataSourceConfigFromConnector(connector);
+  const loggerArgs = {
+    workspaceId: dataSourceConfig.workspaceId,
+    connectorId,
+    provider: "intercom",
+    dataSourceName: dataSourceConfig.dataSourceName,
+    teamId,
+  };
+
+  await concurrentExecutor(
+    conversationIds,
+    (conversationId) =>
+      syncConversation({
+        connectorId,
+        nangoConnectionId,
+        dataSourceConfig,
+        teamId,
+        conversationId,
+        currentSyncMs,
+        loggerArgs,
+      }),
+    { concurrency: 10 }
+  );
+}
+
+/**
+ * This activity is responsible for fetching a batch of conversations
+ * that are older than 90 days and ready to be deleted.
+ */
+export async function getNextConversationsBatchToDeleteActivity({
+  connectorId,
+}: {
+  connectorId: ModelId;
+}): Promise<string[]> {
+  const conversations = await IntercomConversation.findAll({
+    attributes: ["conversationId"],
+    where: {
+      connectorId,
+      conversationCreatedAt: {
+        [Op.lt]: new Date(Date.now() - 90 * 24 * 60 * 60 * 1000), // 90 days ago
+      },
+    },
+    limit: INTERCOM_CONVO_BATCH_SIZE,
+  });
+
+  return conversations.map((c) => c.conversationId);
+}
+
+/**
+ * This activity is responsible for syncing a batch of conversations.
+ */
+export async function deleteConversationBatchActivity({
+  connectorId,
+  conversationIds,
+}: {
+  connectorId: ModelId;
+  conversationIds: string[];
+}): Promise<void> {
+  const connector = await _getIntercomConnectorOrRaise(connectorId);
+  const dataSourceConfig = dataSourceConfigFromConnector(connector);
+
+  await concurrentExecutor(
+    conversationIds,
+    (conversationId) =>
+      deleteConversation({
+        connectorId,
+        conversationId,
+        dataSourceConfig,
+      }),
+    { concurrency: 10 }
+  );
 }

--- a/connectors/src/connectors/intercom/temporal/client.ts
+++ b/connectors/src/connectors/intercom/temporal/client.ts
@@ -18,7 +18,8 @@ function getIntercomSyncWorkflowId(connectorId: ModelId) {
 export async function launchIntercomSyncWorkflow(
   connectorId: ModelId,
   fromTs: number | null,
-  helpCenterIds: string[] = []
+  helpCenterIds: string[] = [],
+  teamIds: string[] = []
 ): Promise<Result<string, Error>> {
   if (fromTs) {
     throw new Error("[Intercom] Workflow does not support fromTs.");
@@ -39,6 +40,10 @@ export async function launchIntercomSyncWorkflow(
       intercomId: helpCenterId,
     })
   );
+  const signaledTeamIds: IntercomUpdateSignal[] = teamIds.map((teamId) => ({
+    type: "team",
+    intercomId: teamId,
+  }));
 
   // When the workflow is inactive, we omit passing helpCenterIds as they are only used to signal modifications within a currently active full sync workflow.
   try {
@@ -50,7 +55,7 @@ export async function launchIntercomSyncWorkflow(
         connectorId: [connectorId],
       },
       signal: intercomUpdatesSignal,
-      signalArgs: [signaledHelpCenterIds],
+      signalArgs: [signaledHelpCenterIds, signaledTeamIds],
       memo: {
         connectorId,
       },

--- a/connectors/src/connectors/intercom/temporal/signals.ts
+++ b/connectors/src/connectors/intercom/temporal/signals.ts
@@ -2,7 +2,7 @@ import { defineSignal } from "@temporalio/workflow";
 
 export interface IntercomUpdateSignal {
   intercomId: string;
-  type: "help_center"; // we will add the "team" value for conversations
+  type: "help_center" | "team";
 }
 
 export const intercomUpdatesSignal = defineSignal<[IntercomUpdateSignal[]]>(

--- a/connectors/src/connectors/intercom/temporal/sync_conversation.ts
+++ b/connectors/src/connectors/intercom/temporal/sync_conversation.ts
@@ -1,0 +1,218 @@
+import type { ModelId } from "@dust-tt/types";
+import TurndownService from "turndown";
+
+import type {
+  ConversationPartType,
+  IntercomTagType,
+} from "@connectors/connectors/intercom/lib/intercom_api";
+import { fetchIntercomConversation } from "@connectors/connectors/intercom/lib/intercom_api";
+import {
+  getConversationInternalId,
+  getTeamInternalId,
+} from "@connectors/connectors/intercom/lib/utils";
+import { concurrentExecutor } from "@connectors/lib/async_utils";
+import {
+  deleteFromDataSource,
+  renderDocumentTitleAndContent,
+  renderMarkdownSection,
+  upsertToDatasource,
+} from "@connectors/lib/data_sources";
+import type { IntercomTeam } from "@connectors/lib/models/intercom";
+import {
+  IntercomConversation,
+  IntercomWorkspace,
+} from "@connectors/lib/models/intercom";
+import logger from "@connectors/logger/logger";
+import type { DataSourceConfig } from "@connectors/types/data_source_config";
+const turndownService = new TurndownService();
+
+export async function deleteTeamAndConversations({
+  connectorId,
+  dataSourceConfig,
+  team,
+}: {
+  connectorId: ModelId;
+  dataSourceConfig: DataSourceConfig;
+  team: IntercomTeam;
+}) {
+  const conversations = await IntercomConversation.findAll({
+    where: {
+      connectorId,
+      teamId: team.teamId,
+    },
+  });
+
+  await concurrentExecutor(
+    conversations,
+    (conversation) =>
+      deleteConversation({
+        connectorId,
+        conversationId: conversation.conversationId,
+        dataSourceConfig,
+      }),
+    { concurrency: 10 }
+  );
+
+  await team.destroy();
+}
+
+export async function deleteConversation({
+  connectorId,
+  conversationId,
+  dataSourceConfig,
+}: {
+  connectorId: ModelId;
+  conversationId: string;
+  dataSourceConfig: DataSourceConfig;
+}) {
+  const dsConversationId = getConversationInternalId(
+    connectorId,
+    conversationId
+  );
+  await Promise.all([
+    deleteFromDataSource(
+      {
+        dataSourceName: dataSourceConfig.dataSourceName,
+        workspaceId: dataSourceConfig.workspaceId,
+        workspaceAPIKey: dataSourceConfig.workspaceAPIKey,
+      },
+      dsConversationId
+    ),
+    IntercomConversation.destroy({
+      where: {
+        connectorId,
+        conversationId,
+      },
+    }),
+  ]);
+}
+
+export async function syncConversation({
+  connectorId,
+  nangoConnectionId,
+  dataSourceConfig,
+  teamId,
+  conversationId,
+  currentSyncMs,
+  loggerArgs,
+}: {
+  connectorId: ModelId;
+  nangoConnectionId: string;
+  dataSourceConfig: DataSourceConfig;
+  teamId: string;
+  conversationId: string;
+  currentSyncMs: number;
+  loggerArgs: Record<string, string | number>;
+}) {
+  const conversation = await fetchIntercomConversation({
+    nangoConnectionId,
+    conversationId,
+  });
+
+  if (!conversation) {
+    logger.error("[Intercom] Failed to fetch conversation", {
+      conversationId,
+      loggerArgs,
+    });
+    return;
+  }
+
+  const intercomWorkspace = await IntercomWorkspace.findOne({
+    where: {
+      connectorId,
+    },
+  });
+  if (!intercomWorkspace) {
+    logger.error("[Intercom] IntercomWorkspace not found", {
+      connectorId,
+      loggerArgs,
+    });
+    return;
+  }
+
+  let conversationOnDB = await IntercomConversation.findOne({
+    where: {
+      connectorId,
+      conversationId: conversation.id,
+    },
+  });
+
+  if (!conversationOnDB) {
+    conversationOnDB = await IntercomConversation.create({
+      connectorId,
+      conversationId: conversation.id,
+      teamId: conversation.team_assignee_id,
+      conversationCreatedAt: conversation.created_at,
+      lastUpsertedTs: new Date(currentSyncMs),
+    });
+  }
+
+  // Building the markdown content for the conversation
+  let markdown = "";
+  const convoTitle = turndownService.turndown(conversation.source.subject);
+  const tags = conversation.tags?.tags
+    .map((tag: IntercomTagType) => tag.name)
+    .join(", ");
+  const firstMessageAuthor = conversation.source.author;
+  const firstMessageContent = turndownService.turndown(
+    conversation.source.body
+  );
+
+  markdown += `# ${convoTitle}\n\n`;
+  markdown += `**TAGS: ${tags || "no tags"}**\n\n`;
+  markdown += `**[Message] ${firstMessageAuthor.name} (${firstMessageAuthor.type})**\n`;
+  markdown += `${firstMessageContent}\n\n`;
+
+  conversation.conversation_parts.conversation_parts.forEach(
+    (part: ConversationPartType) => {
+      const messageAuthor = part.author;
+      const messageContent = part.body
+        ? turndownService.turndown(part.body)
+        : null;
+      const type = part.part_type === "note" ? "Internal note" : "Message";
+
+      if (messageContent) {
+        markdown += `**[${type}] ${messageAuthor.name} (${messageAuthor.type})**\n`;
+        markdown += `${messageContent}\n\n`;
+      }
+    }
+  );
+
+  const renderedMarkdown = await renderMarkdownSection(
+    dataSourceConfig,
+    markdown
+  );
+
+  const renderedPage = await renderDocumentTitleAndContent({
+    dataSourceConfig,
+    title: conversation.title,
+    content: renderedMarkdown,
+    createdAt: new Date(conversation.created_at),
+    updatedAt: new Date(conversation.updated_at),
+  });
+
+  const conversationUrl = `https://app.intercom.com/a/apps/${intercomWorkspace.intercomWorkspaceId}/inbox/inbox/${conversation.id}`;
+
+  await upsertToDatasource({
+    dataSourceConfig,
+    documentId: getConversationInternalId(connectorId, conversation.id),
+    documentContent: renderedPage,
+    documentUrl: conversationUrl,
+    timestampMs: conversation.updated_at,
+    tags: [
+      `title:${conversation.title}`,
+      `createdAt:${conversation.created_at}`,
+      `updatedAt:${conversation.updated_at}`,
+    ],
+    parents: [getTeamInternalId(connectorId, teamId)],
+    retries: 3,
+    delayBetweenRetriesMs: 500,
+    loggerArgs: {
+      ...loggerArgs,
+      conversationId: conversation.id,
+    },
+    upsertContext: {
+      sync_type: "batch",
+    },
+  });
+}


### PR DESCRIPTION
## Description

This PR contains the code that will enable the full sync of a given Intercom team. 

Here's how it works: 
On the hourly Intercom workflow, we added some signal to be notified when permission has been updated on a given team and we will either sync or remove the Team and its conversation. 
We also added some logic to remove conversations that are older than 90 days (this delay can be challenged).

 The incremental sync will be handled in another PR by plugging on Intercom webhooks, where the logic should be simple -> If a conversation is closed from a team we have permission for, we will sync this conversation. 

Doc is here: https://www.notion.so/dust-tt/Design-doc-Intercom-Connector-fdab004d1fa34613ba6c9295369b417d?pvs=4#e9a012a4e3324f24b6a7176b03eaea96

## Risk

Should be low as no current connector on prod. 

## Deploy Plan

Nothing special, no migration in this PR. 
