### PR TITLE
enh: allow users to better steer SQL query generation

### DIFF
--- a/front/lib/api/assistant/actions/tables_query.ts
+++ b/front/lib/api/assistant/actions/tables_query.ts
@@ -210,7 +210,7 @@ export async function* runTablesQuery({
     auth,
     "assistant-v2-query-tables",
     config,
-    [{ question: input.question }]
+    [{ question: input.question, guidelines: input.guidelines }]
   );
 
   if (res.isErr()) {

--- a/types/src/front/lib/actions/registry.ts
+++ b/types/src/front/lib/actions/registry.ts
@@ -138,7 +138,7 @@ export const DustProdActionRegistry = createActionRegistry({
       workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
       appId: "b4f205e453",
       appHash:
-        "c0ed568e11d16d6f91247671a27a463bfb47a3a2c0f3a1ebd63c69550f8010f8",
+        "679a78892c38d42583cdcbff160daf83420eab537a40dd0b2e5f0a421cfa3cdc",
     },
     config: {
       MODEL: {


### PR DESCRIPTION
## Description

https://dust.tt/w/78bda07b39/a/b4f205e453

Changes the dust app's input dataset schema to include a "guidelines" optional parameter that is then rendered to the model as a user message (if defined) when generating the SQL.

This new param is described as such:
> Some additional guidelines and context that could help generate the right query. This could come from the assistant's instructions or from the conversation history. Return an empty string when not applicable.

The idea is to allow the user to better steer the SQL generation, either via assistant instructions or conversation. With only the "question" param, it's hard to give feedback on the SQL query (eg "join table X with table Y via field Z" or "only look at rows with active status"). This will definitely be useful for power users

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
