### PR TITLE
Infra: raise sequelize connection pool to 50

### DIFF
--- a/front/lib/databases.ts
+++ b/front/lib/databases.ts
@@ -9,7 +9,7 @@ const acquireAttempts = new WeakMap();
 export const front_sequelize = new Sequelize(FRONT_DATABASE_URI as string, {
   pool: {
     // default is 5
-    max: 20,
+    max: 50,
   },
   logging: false,
   hooks: {


### PR DESCRIPTION
## Description
`SHOW max_connections; => 500` on our sql server
This adds 90 potential connections vs the previous setting of 20 (since we have 3 pods)
Cf discussion below, this should be fine since no more than 290 connections on the server


## Risk
