### PR TITLE
Fix: Notion -  parents computation moved to end

### DIFF
--- a/connectors/src/connectors/notion/temporal/workflows.ts
+++ b/connectors/src/connectors/notion/temporal/workflows.ts
@@ -176,8 +176,6 @@ export async function notionSyncWorkflow({
     // wait for all child workflows to finish
     await Promise.all(promises);
 
-    await updateParentsFields(connectorId, runTimestamp, new Date().getTime());
-
     // these are resources (pages/DBs) that we didn't get from the search API but that are child pages/DBs
     // of other pages that we did get from the search API.
     // We upsert those as well.
@@ -198,6 +196,9 @@ export async function notionSyncWorkflow({
       topLevelWorkflowId,
       forceResync,
     });
+
+    // Compute parents after all documents are added/updated
+    await updateParentsFields(connectorId, runTimestamp, new Date().getTime());
 
     if (!isGarbageCollectionRun) {
       await saveSuccessSync(connectorId);


### PR DESCRIPTION
## Description

Parents computation relies on the assumption that it is done after all documents are discovered/updated

We added logic to process undiscovered page/dbs => parents computation should be done after that, otherwise they risk staying in an incoherent parent state

Related issue: https://github.com/dust-tt/tasks/issues/375