### PR TITLE
Only start consuming conversation stream when conversation has been loaded

### DIFF
--- a/front/hooks/useEventSource.ts
+++ b/front/hooks/useEventSource.ts
@@ -2,7 +2,10 @@ import { useEffect, useRef, useState } from "react";
 
 export function useEventSource(
   buildURL: (lastMessage: string | null) => string | null,
-  onEventCallback: (event: string) => void
+  onEventCallback: (event: string) => void,
+  { isReadyToConsumeStream }: { isReadyToConsumeStream: boolean } = {
+    isReadyToConsumeStream: true,
+  }
 ) {
   // State used to re-connect to the events stream; this is a hack to re-trigger
   // the useEffect that set-up the EventSource to the streaming endpoint.
@@ -12,6 +15,10 @@ export function useEventSource(
   const [isError, setIsError] = useState<Error | null>(null);
 
   useEffect(() => {
+    if (!isReadyToConsumeStream) {
+      return;
+    }
+
     const url = buildURL(lastEvent.current);
     if (!url) {
       return;
@@ -54,7 +61,7 @@ export function useEventSource(
       }
       es.close();
     };
-  }, [buildURL, onEventCallback, reconnectCounter]);
+  }, [buildURL, onEventCallback, reconnectCounter, isReadyToConsumeStream]);
 
   return { isError };
 }


### PR DESCRIPTION
## Description

See parent issue: https://github.com/dust-tt/tasks/issues/387.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR improves the efficiency and reliability of our conversation stream consumption by implementing a conditional operation that delays the stream initiation until the conversation data becomes available. The goal is to avoid unnecessary network requests and potential performance issues. Without this solution, each event within the stream calls `mutateConversation`, ultimately triggering repetitive fetch operations for the conversation data. 

With the introduction of a conditional check, we now ensure that the conversation stream only starts once we have successfully retrieved the conversation, and we only call `mutateConversation` if the event is not already in the conversation.

**Without the fix**
![conversationStreamBeforeFix](https://github.com/dust-tt/dust/assets/7428970/ff741f04-bcb8-4cd7-9650-38389ba9ddeb)

**With the fix**
![conversationStreamAfterFix](https://github.com/dust-tt/dust/assets/7428970/9244d59b-2d58-4bc9-afba-501a7ebfcd57)

## Risk

It might slow down a bit the consumption of the stream since it requires the fetch conversation call to be done. I will monitor the performance of this endpoint. Safe to rollback.
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
