### PR TITLE
Add removeNulls in types shared utils and use it instead of flat/map

### DIFF
--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -41,7 +41,11 @@ import {
   launchGoogleGarbageCollector,
 } from "./temporal/client";
 export type NangoConnectionId = string;
-import type { ConnectorsAPIError, ModelId } from "@dust-tt/types";
+import {
+  removeNulls,
+  type ConnectorsAPIError,
+  type ModelId,
+} from "@dust-tt/types";
 import { v4 as uuidv4 } from "uuid";
 
 import { concurrentExecutor } from "@connectors/lib/async_utils";
@@ -405,10 +409,7 @@ export async function retrieveGoogleDriveConnectorPermissions({
         { concurrency: 4 }
       );
 
-      // Filter out the `null`.
-      const resources = folderAsConnectorResources.flatMap((f) =>
-        f ? [f] : []
-      );
+      const resources = removeNulls(folderAsConnectorResources);
 
       resources.sort((a, b) => {
         return a.title.localeCompare(b.title);

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -41,11 +41,8 @@ import {
   launchGoogleGarbageCollector,
 } from "./temporal/client";
 export type NangoConnectionId = string;
-import {
-  removeNulls,
-  type ConnectorsAPIError,
-  type ModelId,
-} from "@dust-tt/types";
+import type { ConnectorsAPIError, ModelId } from "@dust-tt/types";
+import { removeNulls } from "@dust-tt/types";
 import { v4 as uuidv4 } from "uuid";
 
 import { concurrentExecutor } from "@connectors/lib/async_utils";

--- a/connectors/src/connectors/slack/temporal/client.ts
+++ b/connectors/src/connectors/slack/temporal/client.ts
@@ -1,4 +1,4 @@
-import type { ModelId } from "@dust-tt/types";
+import { removeNulls, type ModelId } from "@dust-tt/types";
 
 import { Connector } from "@connectors/lib/models";
 import { Err, Ok } from "@connectors/lib/result";
@@ -33,9 +33,9 @@ export async function launchSlackSyncWorkflow(
     return new Err(new Error(`Connector ${connectorId} not found`));
   }
   if (channelsToSync === null) {
-    channelsToSync = (await getChannelsToSync(connectorId))
-      .map((c) => c.id)
-      .flatMap((c) => (c ? [c] : []));
+    channelsToSync = removeNulls(
+      (await getChannelsToSync(connectorId)).map((c) => c.id || null)
+    );
   }
   const client = await getTemporalClient();
 

--- a/connectors/src/connectors/slack/temporal/client.ts
+++ b/connectors/src/connectors/slack/temporal/client.ts
@@ -1,4 +1,5 @@
-import { removeNulls, type ModelId } from "@dust-tt/types";
+import type { ModelId } from "@dust-tt/types";
+import { removeNulls } from "@dust-tt/types";
 
 import { Connector } from "@connectors/lib/models";
 import { Err, Ok } from "@connectors/lib/result";

--- a/front/lib/api/assistant/recent_authors.ts
+++ b/front/lib/api/assistant/recent_authors.ts
@@ -1,10 +1,10 @@
-import {
-  type AgentRecentAuthors,
-  type LightAgentConfigurationType,
-  type UserType,
-  type UserTypeWithWorkspaces,
-  removeNulls,
+import type {
+  AgentRecentAuthors,
+  LightAgentConfigurationType,
+  UserType,
+  UserTypeWithWorkspaces,
 } from "@dust-tt/types";
+import { removeNulls } from "@dust-tt/types";
 import { Sequelize } from "sequelize";
 
 import { getMembers } from "@app/lib/api/workspace";

--- a/front/lib/api/assistant/recent_authors.ts
+++ b/front/lib/api/assistant/recent_authors.ts
@@ -1,8 +1,9 @@
-import type {
-  AgentRecentAuthors,
-  LightAgentConfigurationType,
-  UserType,
-  UserTypeWithWorkspaces,
+import {
+  type AgentRecentAuthors,
+  type LightAgentConfigurationType,
+  type UserType,
+  type UserTypeWithWorkspaces,
+  removeNulls,
 } from "@dust-tt/types";
 import { Sequelize } from "sequelize";
 
@@ -174,12 +175,9 @@ export async function getAgentsRecentAuthors({
 
   const authorByUserId: Record<number, UserTypeWithWorkspaces> = (
     await getMembers(auth, {
-      userIds: Array.from(
-        new Set(Object.values(recentAuthorsIdsByAgentId).flat())
-      )
-        // Filter-out null IDs in a way that allows narrowing the type.
-        .map((id) => (id ? [id] : []))
-        .flat(),
+      userIds: removeNulls(
+        Array.from(new Set(Object.values(recentAuthorsIdsByAgentId).flat()))
+      ),
     })
   ).reduce<Record<number, UserTypeWithWorkspaces>>((acc, member) => {
     acc[member.id] = member;

--- a/types/src/index.ts
+++ b/types/src/index.ts
@@ -55,3 +55,4 @@ export * from "./shared/utils/global_error_handler";
 export * from "./shared/utils/hashing";
 export * from "./shared/utils/iots_utils";
 export * from "./shared/utils/string_utils";
+export * from "./shared/utils/general";

--- a/types/src/shared/utils/general.ts
+++ b/types/src/shared/utils/general.ts
@@ -1,0 +1,6 @@
+/**
+ *  Filters out nulls & undefineds from an array by correclty narrowing the type
+ */
+export function removeNulls<T>(arr: (T | null)[]): T[] {
+  return arr.filter((v): v is T => v !== null);
+}


### PR DESCRIPTION
## Description

Using `filter(t => t !== null)` on an array has the problem of not narrowing the type correctly.

Solutions involving `flat/map` are not readable and require runtime loop/array creation

This util allows to narrow type correctly at compile time while being clearly understandable

