### PR TITLE
Intercom workflow: remove HP if all collection removed

### DIFF
--- a/connectors/src/connectors/intercom/temporal/activities.ts
+++ b/connectors/src/connectors/intercom/temporal/activities.ts
@@ -91,7 +91,7 @@ export async function syncHelpCenterOnlyActivity({
   connectorId: ModelId;
   helpCenterId: string;
   currentSyncMs: number;
-}) {
+}): Promise<boolean> {
   const connector = await _getIntercomConnectorOrRaise(connectorId);
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
   const loggerArgs = {
@@ -113,31 +113,57 @@ export async function syncHelpCenterOnlyActivity({
     );
   }
 
-  // If our rights were revoked or the help center is not on intercom anymore we delete it
-  let shouldRemoveHelpCenter = helpCenterOnDb.permission === "none";
-  if (!shouldRemoveHelpCenter) {
-    const helpCenterOnIntercom = await fetchIntercomHelpCenter(
-      connector.connectionId,
-      helpCenterOnDb.helpCenterId
-    );
-    if (!helpCenterOnIntercom) {
-      shouldRemoveHelpCenter = true;
-    } else {
-      await helpCenterOnDb.update({
-        name: helpCenterOnIntercom.display_name || "Help Center",
-        lastUpsertedTs: new Date(currentSyncMs),
-      });
-    }
-  }
-
-  if (shouldRemoveHelpCenter) {
+  // If our rights were revoked we delete the Help Center data
+  if (helpCenterOnDb.permission === "none") {
     await removeHelpCenter({
       connectorId,
       dataSourceConfig,
       helpCenter: helpCenterOnDb,
       loggerArgs,
     });
+    return false;
   }
+
+  // If the help center is not on intercom anymore we delete the Help Center data
+  const helpCenterOnIntercom = await fetchIntercomHelpCenter(
+    connector.connectionId,
+    helpCenterOnDb.helpCenterId
+  );
+  if (!helpCenterOnIntercom) {
+    await removeHelpCenter({
+      connectorId,
+      dataSourceConfig,
+      helpCenter: helpCenterOnDb,
+      loggerArgs,
+    });
+    return false;
+  }
+
+  // If all children collections are not allowed anymore we delete the Help Center data
+  const collectionsWithReadPermission = await IntercomCollection.findAll({
+    where: {
+      connectorId,
+      helpCenterId: helpCenterId,
+      permission: "read",
+      parentId: null,
+    },
+  });
+  if (collectionsWithReadPermission.length === 0) {
+    await removeHelpCenter({
+      connectorId,
+      dataSourceConfig,
+      helpCenter: helpCenterOnDb,
+      loggerArgs,
+    });
+    return false;
+  }
+
+  // Otherwise we update the help center name and lastUpsertedTs
+  await helpCenterOnDb.update({
+    name: helpCenterOnIntercom.display_name || "Help Center",
+    lastUpsertedTs: new Date(currentSyncMs),
+  });
+  return true;
 }
 
 /**

--- a/connectors/src/connectors/intercom/temporal/workflows.ts
+++ b/connectors/src/connectors/intercom/temporal/workflows.ts
@@ -106,11 +106,16 @@ export async function intercomHelpCenterSyncWorklow({
   helpCenterId: string;
   currentSyncMs: number;
 }) {
-  await syncHelpCenterOnlyActivity({
+  const hasPermission = await syncHelpCenterOnlyActivity({
     connectorId,
     helpCenterId,
     currentSyncMs,
   });
+
+  if (!hasPermission) {
+    // We don't have permission anymore on this help center, we don't sync it.
+    return;
+  }
 
   const collectionIds = await getCollectionsIdsToSyncActivity({
     connectorId,


### PR DESCRIPTION
## Description

Tiny refacto to be more readable and make sure we don't keep a Help Center if we're removing all the Children collections. 

## Risk

Low.

## Deploy Plan

Nothing special. 
