### PR TITLE
Intercom webhook

### DIFF
--- a/connectors/src/api/webhooks/webhook_intercom.ts
+++ b/connectors/src/api/webhooks/webhook_intercom.ts
@@ -34,6 +34,12 @@ const _webhookIntercomAPIHandler = async (
   const event = req.body;
   logger.info("[Intercom] Received Intercom webhook", { event });
 
+  if (event.topic !== "conversation.admin.closed") {
+    logger.error("[Intercom] Received Intercom webhook with unknown topic", {
+      event,
+    });
+  }
+
   const intercomWorkspaceId = event.app_id;
   if (!intercomWorkspaceId) {
     logger.error("[Intercom] Received Intercom webhook with no workspace id", {
@@ -79,7 +85,7 @@ const _webhookIntercomAPIHandler = async (
 
   // Check we have the permissions to sync this conversation
   if (!conversation.team_assignee_id) {
-    logger.error(
+    logger.info(
       "[Intercom] Received webhook for conversation without team, skipping."
     );
     return res.status(200).end();
@@ -91,7 +97,7 @@ const _webhookIntercomAPIHandler = async (
       },
     });
     if (!team || team.permission !== "read") {
-      logger.error(
+      logger.info(
         "[Intercom] Received webhook for conversation attached to team without read permission, skipping."
       );
       return res.status(200).end();

--- a/connectors/src/api/webhooks/webhook_intercom.ts
+++ b/connectors/src/api/webhooks/webhook_intercom.ts
@@ -1,0 +1,128 @@
+import type { WithConnectorsAPIErrorReponse } from "@dust-tt/types";
+import type { Request, Response } from "express";
+
+import type { IntercomConversationWithPartsType } from "@connectors/connectors/intercom/lib/intercom_api";
+import { syncConversation } from "@connectors/connectors/intercom/temporal/sync_conversation";
+import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
+import { Connector } from "@connectors/lib/models";
+import {
+  IntercomTeam,
+  IntercomWorkspace,
+} from "@connectors/lib/models/intercom";
+import mainLogger from "@connectors/logger/logger";
+import { withLogging } from "@connectors/logger/withlogging";
+
+const logger = mainLogger.child({ provider: "intercom" });
+
+type IntercombWebhookResBody = WithConnectorsAPIErrorReponse<null>;
+
+const _webhookIntercomAPIHandler = async (
+  req: Request<
+    Record<string, string>,
+    IntercombWebhookResBody,
+    {
+      topic?: string;
+      type: "notification_event";
+      app_id: string; // That's the Intercom workspace id
+      data?: {
+        item: IntercomConversationWithPartsType;
+      };
+    }
+  >,
+  res: Response<IntercombWebhookResBody>
+) => {
+  const event = req.body;
+  logger.info("[Intercom] Received Intercom webhook", { event });
+
+  const intercomWorkspaceId = event.app_id;
+  if (!intercomWorkspaceId) {
+    logger.error("[Intercom] Received Intercom webhook with no workspace id", {
+      event,
+    });
+    return res.status(200).end();
+  }
+
+  const conversation = event.data?.item;
+  if (!conversation) {
+    logger.error("[Intercom] Received Intercom webhook with no conversation", {
+      event,
+    });
+    return res.status(200).end();
+  }
+
+  // Find IntercomWorkspace
+  const intercomWorskpace = await IntercomWorkspace.findOne({
+    where: {
+      intercomWorkspaceId,
+    },
+  });
+  if (!intercomWorskpace) {
+    logger.error("[Intercom] Received Intercom webhook for unknown workspace", {
+      event,
+    });
+    return res.status(200).end();
+  }
+
+  // Find Connector
+  const connector = await Connector.findOne({
+    where: {
+      id: intercomWorskpace.connectorId,
+      type: "intercom",
+    },
+  });
+  if (!connector) {
+    logger.error("[Intercom] Received Intercom webhook for unknown connector", {
+      event,
+    });
+    return res.status(200).end();
+  }
+
+  // Check we have the permissions to sync this conversation
+  if (!conversation.team_assignee_id) {
+    logger.error(
+      "[Intercom] Received webhook for conversation without team, skipping."
+    );
+    return res.status(200).end();
+  } else {
+    const team = await IntercomTeam.findOne({
+      where: {
+        connectorId: connector.id,
+        teamId: conversation.team_assignee_id.toString(),
+      },
+    });
+    if (!team || team.permission !== "read") {
+      logger.error(
+        "[Intercom] Received webhook for conversation attached to team without read permission, skipping."
+      );
+      return res.status(200).end();
+    }
+  }
+
+  // Sync conversation
+  const connectorId = connector.id;
+  const dataSourceConfig = dataSourceConfigFromConnector(connector);
+  const loggerArgs = {
+    workspaceId: dataSourceConfig.workspaceId,
+    connectorId,
+    provider: "intercom",
+    dataSourceName: dataSourceConfig.dataSourceName,
+    intercomWorkspaceId,
+    conversationId: conversation.id,
+  };
+  await syncConversation({
+    connectorId: connector.id,
+    dataSourceConfig,
+    conversation,
+    currentSyncMs: Date.now(),
+    syncType: "incremental",
+    loggerArgs,
+  });
+
+  logger.info("[Intercom] Upserted conversation from webhook", { loggerArgs });
+
+  return res.status(200).end();
+};
+
+export const webhookIntercomAPIHandler = withLogging(
+  _webhookIntercomAPIHandler
+);

--- a/connectors/src/api_server.ts
+++ b/connectors/src/api_server.ts
@@ -19,6 +19,7 @@ import { syncConnectorAPIHandler } from "@connectors/api/sync_connector";
 import { getConnectorUpdateAPIHandler } from "@connectors/api/update_connector";
 import { webhookGithubAPIHandler } from "@connectors/api/webhooks/webhook_github";
 import { webhookGoogleDriveAPIHandler } from "@connectors/api/webhooks/webhook_google_drive";
+import { webhookIntercomAPIHandler } from "@connectors/api/webhooks/webhook_intercom";
 import { webhookSlackAPIHandler } from "@connectors/api/webhooks/webhook_slack";
 import logger from "@connectors/logger/logger";
 import { authMiddleware } from "@connectors/middleware/auth";
@@ -93,6 +94,11 @@ export function startServer(port: number) {
     "/webhooks/:webhooks_secret/github",
     bodyParser.raw({ type: "application/json" }),
     webhookGithubAPIHandler
+  );
+  app.post(
+    "/webhooks/:webhooks_secret/intercom",
+    bodyParser.raw({ type: "application/json" }),
+    webhookIntercomAPIHandler
   );
 
   app.post(

--- a/connectors/src/connectors/intercom/lib/intercom_api.ts
+++ b/connectors/src/connectors/intercom/lib/intercom_api.ts
@@ -51,14 +51,32 @@ export type IntercomTeamType = {
 export type IntercomConversationType = {
   type: "conversation";
   id: string;
-  created_at: Date;
-  updated_at: Date;
+  created_at: number;
+  updated_at: number;
   title: string;
-  admin_assignee_id: number;
-  team_assignee_id: number;
+  admin_assignee_id: number | null;
+  team_assignee_id: number | null; // it says string in the API doc but it's actually a number
   open: boolean;
-  tags: IntercomTagType[];
-  conversation_parts?: ConversationPartType;
+  tags: {
+    type: "tag.list";
+    tags: IntercomTagType[];
+  };
+  source: {
+    type: "conversation";
+    id: number;
+    delivered_as: string;
+    subject: string;
+    body: string;
+    author: IntercomAuthor;
+  };
+};
+
+export type IntercomConversationWithPartsType = IntercomConversationType & {
+  conversation_parts: {
+    type: "conversation_part.list";
+    conversation_parts: ConversationPartType[];
+    total_count: number;
+  };
 };
 
 export type IntercomTagType = {
@@ -68,13 +86,17 @@ export type IntercomTagType = {
 };
 
 export type ConversationPartType = {
+  type: "conversation_part";
   id: string;
   part_type: string;
   body: string;
   created_at: Date;
   updated_at: Date;
   notified_at: Date;
-  assigned_to: string | null;
+  assigned_to: {
+    type: string;
+    id: string;
+  };
   author: IntercomAuthor;
   attachments: [];
   redacted: boolean;
@@ -84,6 +106,7 @@ type IntercomAuthor = {
   id: string;
   type: "user" | "admin" | "bot" | "team";
   name: string;
+  email: string;
 };
 
 /**

--- a/connectors/src/connectors/intercom/temporal/activities.ts
+++ b/connectors/src/connectors/intercom/temporal/activities.ts
@@ -9,7 +9,7 @@ import {
 import {
   deleteConversation,
   deleteTeamAndConversations,
-  syncConversation,
+  fetchAndSyncConversation,
 } from "@connectors/connectors/intercom/temporal/sync_conversation";
 import {
   removeHelpCenter,
@@ -378,13 +378,13 @@ export async function syncConversationBatchActivity({
   await concurrentExecutor(
     conversationIds,
     (conversationId) =>
-      syncConversation({
+      fetchAndSyncConversation({
         connectorId,
         nangoConnectionId,
         dataSourceConfig,
-        teamId,
         conversationId,
         currentSyncMs,
+        syncType: "batch",
         loggerArgs,
       }),
     { concurrency: 10 }

--- a/connectors/src/connectors/intercom/temporal/sync_conversation.ts
+++ b/connectors/src/connectors/intercom/temporal/sync_conversation.ts
@@ -146,7 +146,10 @@ export async function syncConversation({
   if (!conversation.team_assignee_id) {
     logger.error(
       "[Intercom] Conversation has no team assignee. Skipping sync",
-      { conversationId: conversation.id, loggerArgs }
+      {
+        conversationId: conversation.id,
+        loggerArgs,
+      }
     );
     return;
   }
@@ -158,7 +161,7 @@ export async function syncConversation({
   });
   if (!team || team.permission !== "read") {
     logger.error(
-      "[Intercom] Team not found or has no read permission. Skipping sync",
+      "[Intercom] Conversation team unknown or non allowed. Skipping sync",
       { conversationId: conversation.id, loggerArgs }
     );
     return;

--- a/connectors/src/connectors/intercom/temporal/sync_conversation.ts
+++ b/connectors/src/connectors/intercom/temporal/sync_conversation.ts
@@ -3,6 +3,7 @@ import TurndownService from "turndown";
 
 import type {
   ConversationPartType,
+  IntercomConversationWithPartsType,
   IntercomTagType,
 } from "@connectors/connectors/intercom/lib/intercom_api";
 import { fetchIntercomConversation } from "@connectors/connectors/intercom/lib/intercom_api";
@@ -17,7 +18,7 @@ import {
   renderMarkdownSection,
   upsertToDatasource,
 } from "@connectors/lib/data_sources";
-import type { IntercomTeam } from "@connectors/lib/models/intercom";
+import { IntercomTeam } from "@connectors/lib/models/intercom";
 import {
   IntercomConversation,
   IntercomWorkspace,
@@ -87,21 +88,21 @@ export async function deleteConversation({
   ]);
 }
 
-export async function syncConversation({
+export async function fetchAndSyncConversation({
   connectorId,
   nangoConnectionId,
   dataSourceConfig,
-  teamId,
   conversationId,
   currentSyncMs,
+  syncType,
   loggerArgs,
 }: {
   connectorId: ModelId;
   nangoConnectionId: string;
   dataSourceConfig: DataSourceConfig;
-  teamId: string;
   conversationId: string;
   currentSyncMs: number;
+  syncType: "incremental" | "batch";
   loggerArgs: Record<string, string | number>;
 }) {
   const conversation = await fetchIntercomConversation({
@@ -114,6 +115,52 @@ export async function syncConversation({
       conversationId,
       loggerArgs,
     });
+    return;
+  }
+
+  await syncConversation({
+    connectorId,
+    dataSourceConfig,
+    conversation,
+    currentSyncMs,
+    syncType,
+    loggerArgs,
+  });
+}
+
+export async function syncConversation({
+  connectorId,
+  dataSourceConfig,
+  conversation,
+  currentSyncMs,
+  syncType,
+  loggerArgs,
+}: {
+  connectorId: ModelId;
+  dataSourceConfig: DataSourceConfig;
+  conversation: IntercomConversationWithPartsType;
+  currentSyncMs: number;
+  syncType: "incremental" | "batch";
+  loggerArgs: Record<string, string | number>;
+}) {
+  if (!conversation.team_assignee_id) {
+    logger.error(
+      "[Intercom] Conversation has no team assignee. Skipping sync",
+      { conversationId: conversation.id, loggerArgs }
+    );
+    return;
+  }
+  const team = await IntercomTeam.findOne({
+    where: {
+      connectorId,
+      teamId: conversation.team_assignee_id.toString(),
+    },
+  });
+  if (!team || team.permission !== "read") {
+    logger.error(
+      "[Intercom] Team not found or has no read permission. Skipping sync",
+      { conversationId: conversation.id, loggerArgs }
+    );
     return;
   }
 
@@ -141,8 +188,14 @@ export async function syncConversation({
     conversationOnDB = await IntercomConversation.create({
       connectorId,
       conversationId: conversation.id,
-      teamId: conversation.team_assignee_id,
-      conversationCreatedAt: conversation.created_at,
+      teamId: conversation.team_assignee_id.toString(),
+      conversationCreatedAt: new Date(conversation.created_at * 1000),
+      lastUpsertedTs: new Date(currentSyncMs),
+    });
+  } else {
+    await conversationOnDB.update({
+      teamId: conversation.team_assignee_id.toString(),
+      conversationCreatedAt: new Date(conversation.created_at * 1000),
       lastUpsertedTs: new Date(currentSyncMs),
     });
   }
@@ -204,7 +257,7 @@ export async function syncConversation({
       `createdAt:${conversation.created_at}`,
       `updatedAt:${conversation.updated_at}`,
     ],
-    parents: [getTeamInternalId(connectorId, teamId)],
+    parents: [getTeamInternalId(connectorId, team.teamId)],
     retries: 3,
     delayBetweenRetriesMs: 500,
     loggerArgs: {
@@ -212,7 +265,7 @@ export async function syncConversation({
       conversationId: conversation.id,
     },
     upsertContext: {
-      sync_type: "batch",
+      sync_type: syncType,
     },
   });
 }


### PR DESCRIPTION
## Description

New webhook for Intercom. We subscribe only to the even `"conversation.admin.closed"` to sync new closed conversations. The webhook simply check we have the sync right for this conversation and process if we do.

## Risk

Low, connector not used yet. 

## Deploy Plan

- Create secret `INTERCOM_WEBHOOK_SECRET` on connectors prod
- Deploy PR
- Update the Intercom prod app to setup the webhook. 

