### PR TITLE
enh: catch GaxiosError Google Drive internal error

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/google_drive/temporal/cast_known_errors.ts
@@ -1,0 +1,42 @@
+import type {
+  ActivityExecuteInput,
+  ActivityInboundCallsInterceptor,
+  Next,
+} from "@temporalio/worker";
+
+export class GoogleDriveCastKnownErrorsInterceptor
+  implements ActivityInboundCallsInterceptor
+{
+  async execute(
+    input: ActivityExecuteInput,
+    next: Next<ActivityInboundCallsInterceptor, "execute">
+  ): Promise<unknown> {
+    try {
+      return await next(input);
+    } catch (err: unknown) {
+      const maybeGoogleInternalError = err as {
+        code: number;
+        type: string;
+        config: {
+          url: string;
+        };
+      };
+
+      if (
+        maybeGoogleInternalError.code === 500 &&
+        maybeGoogleInternalError.config.url.startsWith(
+          "https://www.googleapis.com"
+        ) &&
+        maybeGoogleInternalError.type === "GaxiosError"
+      ) {
+        throw {
+          __is_dust_error: true,
+          message: "Google Drive Internal Error",
+          type: "google_drive_internal_error",
+        };
+      }
+
+      throw err;
+    }
+  }
+}

--- a/connectors/src/connectors/google_drive/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/google_drive/temporal/cast_known_errors.ts
@@ -25,7 +25,7 @@ export class GoogleDriveCastKnownErrorsInterceptor
       if (
         maybeGoogleInternalError.code === 500 &&
         maybeGoogleInternalError.config.url.startsWith(
-          "https://www.googleapis.com"
+          "https://www.googleapis.com/"
         ) &&
         maybeGoogleInternalError.type === "GaxiosError"
       ) {

--- a/connectors/src/connectors/google_drive/temporal/worker.ts
+++ b/connectors/src/connectors/google_drive/temporal/worker.ts
@@ -2,6 +2,7 @@ import type { Context } from "@temporalio/activity";
 import { Worker } from "@temporalio/worker";
 
 import * as activities from "@connectors/connectors/google_drive/temporal/activities";
+import { GoogleDriveCastKnownErrorsInterceptor } from "@connectors/connectors/google_drive/temporal/cast_known_errors";
 import * as sync_status from "@connectors/lib/sync_status";
 import { getTemporalWorkerConnection } from "@connectors/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@connectors/lib/temporal_monitoring";
@@ -23,6 +24,7 @@ export async function runGoogleWorker() {
         (ctx: Context) => {
           return new ActivityInboundLogInterceptor(ctx, logger);
         },
+        () => new GoogleDriveCastKnownErrorsInterceptor(),
       ],
     },
   });


### PR DESCRIPTION
## Description

fixes https://github.com/dust-tt/tasks/issues/415

We have these internal error quite regularly. They seem transient so far, and aren't actionable so they're creating noise in our monitors (see DD link in issue).

If we had a non-transient internal error, we'd be warned by our "stuck activity" monitor after 20 attempts.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
