### PR TITLE
Handle existing workspace with verified domain in sign up flow

### DIFF
--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -1,4 +1,4 @@
-import type { WithAPIErrorReponse } from "@dust-tt/types";
+import type { WithAPIErrorReponse, WorkspaceDomain } from "@dust-tt/types";
 import { verify } from "jsonwebtoken";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { getServerSession } from "next-auth/next";
@@ -60,19 +60,17 @@ export async function createWorkspace(session: any) {
   return workspace;
 }
 
-async function findWorkspaceWithWhitelistedDomain(session: any) {
+async function findWorkspaceWithVerifiedDomain(session: any) {
   const { user } = session;
 
   if (!isGoogleSession(session) || !user.email_verified) {
-    return undefined;
+    return null;
   }
 
   const [, userEmailDomain] = user.email.split("@");
-  const workspaceWithWhitelistedDomain = await WorkspaceHasDomain.findOne({
-    attributes: ["workspaceId"],
+  const workspaceWithVerifiedDomain = await WorkspaceHasDomain.findOne({
     where: {
       domain: userEmailDomain,
-      domainAutoJoinEnabled: true,
     },
     include: [
       {
@@ -83,7 +81,7 @@ async function findWorkspaceWithWhitelistedDomain(session: any) {
     ],
   });
 
-  return workspaceWithWhitelistedDomain?.workspace;
+  return workspaceWithVerifiedDomain;
 }
 
 async function handler(
@@ -187,13 +185,24 @@ async function handler(
       lastName,
     });
 
-    autoJoinWorkspaceWithDomain = await findWorkspaceWithWhitelistedDomain(
+    const workspaceWithVerifiedDomain = await findWorkspaceWithVerifiedDomain(
       session
     );
 
-    // If there is no invite, we create a personal workspace for the user, otherwise the user
+    // Redirect the user to a different screen if a workspace with a verified domain exists.
+    const workspaceHasAutoJoin =
+      workspaceWithVerifiedDomain?.domainAutoJoinEnabled === true;
+    if (workspaceHasAutoJoin) {
+      autoJoinWorkspaceWithDomain = workspaceWithVerifiedDomain.workspace;
+    } else if (workspaceWithVerifiedDomain) {
+      res.redirect("/no-workspace?flow=no-auto-join");
+      return;
+    }
+
+    // If there is no invite or no existing workspace with the email's domain,
+    // we create a personal workspace for the user, otherwise the user
     // will be added to the workspace they were invited to (by domain) below.
-    if (!membershipInvite && !autoJoinWorkspaceWithDomain) {
+    if (!membershipInvite && !workspaceWithVerifiedDomain) {
       const workspace = await createWorkspace(session);
       await createAndLogMembership({
         workspace,
@@ -296,7 +305,7 @@ async function handler(
   const u = await getUserFromSession(session);
 
   if (!u || u.workspaces.length === 0) {
-    res.redirect(`/no-workspace`);
+    res.redirect("/no-workspace?flow=revoked");
     return;
   }
 

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -1,4 +1,4 @@
-import type { WithAPIErrorReponse, WorkspaceDomain } from "@dust-tt/types";
+import type { WithAPIErrorReponse } from "@dust-tt/types";
 import { verify } from "jsonwebtoken";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { getServerSession } from "next-auth/next";

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -60,7 +60,9 @@ export async function createWorkspace(session: any) {
   return workspace;
 }
 
-async function findWorkspaceWithVerifiedDomain(session: any) {
+async function findWorkspaceWithVerifiedDomain(
+  session: any
+): Promise<WorkspaceHasDomain | null> {
   const { user } = session;
 
   if (!isGoogleSession(session) || !user.email_verified) {
@@ -189,7 +191,8 @@ async function handler(
       session
     );
 
-    // Redirect the user to a different screen if a workspace with a verified domain exists.
+    // Redirect the user to a different screen if a workspace with
+    // a verified domain exists but auto join is not enabled.
     const workspaceHasAutoJoin =
       workspaceWithVerifiedDomain?.domainAutoJoinEnabled === true;
     if (workspaceHasAutoJoin) {

--- a/front/pages/no-workspace.tsx
+++ b/front/pages/no-workspace.tsx
@@ -5,17 +5,60 @@ import {
   LogoSquareColorLogo,
   Page,
 } from "@dust-tt/sparkle";
+import type { UserTypeWithWorkspaces } from "@dust-tt/types";
 import type { InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 
 import { getSession, getUserFromSession } from "@app/lib/auth";
-import { Membership, Workspace } from "@app/lib/models";
+import { Membership, Workspace, WorkspaceHasDomain } from "@app/lib/models";
 import logger from "@app/logger/logger";
 import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
 
+// Fetch workspace details for scenarios where auto-join is disabled.
+async function fetchWorkspaceDetails(
+  user: UserTypeWithWorkspaces
+): Promise<WorkspaceHasDomain | null> {
+  const [, userEmailDomain] = user.email.split("@");
+  const workspaceWithVerifiedDomain = await WorkspaceHasDomain.findOne({
+    where: {
+      domain: userEmailDomain,
+    },
+    include: [
+      {
+        model: Workspace,
+        as: "workspace",
+        required: true,
+      },
+    ],
+  });
+
+  return workspaceWithVerifiedDomain;
+}
+
+// Fetch workspace details for users whose membership has been revoked.
+async function fetchRevokedWorkspace(
+  user: UserTypeWithWorkspaces
+): Promise<Workspace | null> {
+  const memberships = await Membership.findAll({
+    where: { userId: user.id },
+  });
+
+  if (!memberships.length) {
+    const message = "Unreachable: user has no memberships.";
+    logger.error({ userId: user.id, panic: true }, message);
+    throw new Error(message);
+  }
+
+  const revokedWorkspaceId = memberships[0].workspaceId;
+
+  return Workspace.findByPk(revokedWorkspaceId);
+}
+
 export const getServerSideProps = withGetServerSidePropsLogging<{
-  revokedWorkspaceName?: string;
+  status: "auto-join-disabled" | "revoked";
   userFirstName: string;
+  workspaceName: string;
+  workspaceVerifiedDomain: string | null;
 }>(async (context) => {
   const session = await getSession(context.req, context.res);
   const user = await getUserFromSession(session);
@@ -26,48 +69,65 @@ export const getServerSideProps = withGetServerSidePropsLogging<{
     };
   }
 
-  const memberships = await Membership.findAll({
-    where: { userId: user.id },
-  });
-
-  if (!memberships.length) {
-    const message = "Unreachable: user has no memberships";
-    logger.error({ userId: user.id, panic: true }, message);
-    throw new Error(message);
-  }
-
   if (user.workspaces.length) {
-    const message = "Unreachable: user already has a workspace";
+    const message = "Unreachable: user already has a workspace.";
     logger.error({ userId: user.id, panic: true }, message);
     return {
       notFound: true,
     };
   }
 
-  const revokedWorkspaceId = memberships[0].workspaceId;
+  const flow =
+    context.query.flow && typeof context.query.flow === "string"
+      ? context.query.flow
+      : null;
+  let workspace: Workspace | null = null;
+  let workspaceVerifiedDomain: string | null = null;
+  let status: "auto-join-disabled" | "revoked";
 
-  const workspace = await Workspace.findByPk(revokedWorkspaceId);
+  if (flow === "no-auto-join") {
+    status = "auto-join-disabled";
+    const workspaceHasDomain = await fetchWorkspaceDetails(user);
+    workspace = workspaceHasDomain?.workspace ?? null;
+    workspaceVerifiedDomain = workspaceHasDomain?.domain ?? null;
 
-  if (!workspace) {
-    const message = "Unreachable: workspace not found";
-    logger.error(
-      { userId: user.id, workspaceId: revokedWorkspaceId, panic: true },
-      message
-    );
-    throw new Error(message);
+    if (!workspace) {
+      logger.error(
+        { userId: user.id, panic: true },
+        "Unreachable: workspace not found."
+      );
+      throw new Error("Workspace not found");
+    }
+  } else if (flow === "revoked") {
+    status = "revoked";
+    workspace = await fetchRevokedWorkspace(user);
+
+    if (!workspace) {
+      logger.error(
+        { userId: user.id, panic: true },
+        "Unreachable: workspace not found."
+      );
+      throw new Error("Workspace not found");
+    }
+  } else {
+    throw new Error("No workspace found.");
   }
 
   return {
     props: {
-      revokedWorkspaceName: workspace.name,
+      status,
       userFirstName: user.firstName,
+      workspaceName: workspace.name,
+      workspaceVerifiedDomain,
     },
   };
 });
 
 export default function NoWorkspace({
-  revokedWorkspaceName,
+  status,
   userFirstName,
+  workspaceName,
+  workspaceVerifiedDomain,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const router = useRouter();
 
@@ -109,26 +169,47 @@ export default function NoWorkspace({
           </span>
         </div>
         <div>
-          <div className="flex flex-col gap-4">
-            <span className="text-lg font-semibold text-element-700">
-              You no longer have access to {revokedWorkspaceName}'s Dust
-              workspace.
-            </span>
-            <span className="text-md text-element-700">
-              You may have been removed from the workspace or the workspace may
-              have reached its maximum number of users.
-              <br />
-              Please{" "}
-              <span className="font-semibold">
-                contact the administrator in {revokedWorkspaceName}
-              </span>{" "}
-              for more informations or to add you again.
-            </span>
-            <span className="text-md text-element-700">
-              If you're looking to establish a new, separate workspace, continue
-              with the following step:
-            </span>
-          </div>
+          {status === "auto-join-disabled" && (
+            <div className="flex flex-col gap-4">
+              <span className="text-lg font-semibold text-element-700">
+                {workspaceVerifiedDomain ?? workspaceName} already has a Dust
+                workspace.
+              </span>
+              <span className="text-md text-element-700">
+                To join the existing workspace of your company, <br />
+                <span className="font-semibold">
+                  please request an invitation from your colleagues,{" "}
+                </span>{" "}
+                then use the link provided in the invitation email to access the
+                workspace.
+              </span>
+              <span className="text-md text-element-700">
+                If you're looking to establish a new, separate workspace,
+                continue with the following step:
+              </span>
+            </div>
+          )}
+          {status === "revoked" && (
+            <div className="flex flex-col gap-4">
+              <span className="text-lg font-semibold text-element-700">
+                You no longer have access to {workspaceName}'s Dust workspace.
+              </span>
+              <span className="text-md text-element-700">
+                You may have been removed from the workspace or the workspace
+                may have reached its maximum number of users.
+                <br />
+                Please{" "}
+                <span className="font-semibold">
+                  contact the administrator in {workspaceName}
+                </span>{" "}
+                for more informations or to add you again.
+              </span>
+              <span className="text-md text-element-700">
+                If you're looking to establish a new, separate workspace,
+                continue with the following step:
+              </span>
+            </div>
+          )}
         </div>
         <div className="flex flex-row justify-end">
           <Button

--- a/front/pages/no-workspace.tsx
+++ b/front/pages/no-workspace.tsx
@@ -91,12 +91,12 @@ export const getServerSideProps = withGetServerSidePropsLogging<{
     workspace = workspaceHasDomain?.workspace ?? null;
     workspaceVerifiedDomain = workspaceHasDomain?.domain ?? null;
 
-    if (!workspace) {
+    if (!workspace || !workspaceVerifiedDomain) {
       logger.error(
         { userId: user.id, panic: true },
         "Unreachable: workspace not found."
       );
-      throw new Error("Workspace not found");
+      throw new Error("Workspace not found.");
     }
   } else if (flow === "revoked") {
     status = "revoked";
@@ -107,7 +107,7 @@ export const getServerSideProps = withGetServerSidePropsLogging<{
         { userId: user.id, panic: true },
         "Unreachable: workspace not found."
       );
-      throw new Error("Workspace not found");
+      throw new Error("Workspace not found.");
     }
   } else {
     throw new Error("No workspace found.");


### PR DESCRIPTION
## Description

This PR implements the design outlined in this Figma [link](https://www.figma.com/file/QOxHwppG64GtPocpDhS6Y7/Product?type=design&node-id=3928-158097&mode=design&t=xqWdJFzVRoFw7c9J-0). It introduces an enhanced sign-up process where users signin up with an email domain from a workspace already on Dust are redirected to a dedicated screen. This update aims at minimizing the chances of users creating new workspaces.

<img width="1839" alt="image" src="https://github.com/dust-tt/dust/assets/7428970/f0440a35-1d1d-4bc9-b526-86d0b04be6de">

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

It's always a bit risky to work round the sign-up login part. Well tested locally.
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
