### PR TITLE
Support mutli root pages in Confluence

### DIFF
--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -358,7 +358,10 @@ export async function confluenceGetActiveChildPageIdsActivity({
   return getActiveChildPageIds(client, parentPageId, pageCursor);
 }
 
-export async function confluenceGetRootPageIdActivity({
+// Confluence has a single main landing page.
+// However, users have the ability to create "orphaned" root pages that don't link from the main landing.
+// It's important to ensure these pages are also imported.
+export async function confluenceGetRootPageIdsActivity({
   connectorId,
   confluenceCloudId,
   spaceId,
@@ -366,7 +369,7 @@ export async function confluenceGetRootPageIdActivity({
   connectorId: ModelId;
   confluenceCloudId: string;
   spaceId: string;
-}) {
+}): Promise<string[]> {
   const localLogger = logger.child({
     connectorId,
     spaceId,
@@ -380,20 +383,7 @@ export async function confluenceGetRootPageIdActivity({
   localLogger.info("Fetching Confluence root page in space.");
 
   const { pages: rootPages } = await client.getPagesInSpace(spaceId, "root");
-  const [rootPage] = rootPages;
-  if (!rootPage) {
-    return undefined;
-  }
-
-  // TODO(2024-01-31 flav) Find a better way to deal with spaces
-  // that have many root pages.
-  if (rootPages.length > 1) {
-    localLogger.error("Found Confluence space with many root pages.", {
-      rootPagesCount: rootPages.length,
-    });
-  }
-
-  return rootPage.id;
+  return rootPages.map((rp) => rp.id);
 }
 
 export async function confluenceGetTopLevelPageIdsActivity({


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
In our first Confluence implementation we were pretty prescriptive about what we wanted to support. There is a hacky-way to support multi root pages (that goes against Confluence first approach). Curiously some of our current customers fall in this bucket.

This PR adds support for those multi-root pages. The underlying process stays largely the same: for each root page, we verify the absence of read permissions. If confirmed, we retrieve all top-level pages and initiate an individual workflow for each one. This approach helps us bypass the maximum workflow size limit of Temporal.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
