### PR TITLE
enh: hide global agents that are disabled_missing_datasource

### DIFF
--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -153,7 +153,9 @@ async function fetchGlobalAgentConfigurationForView(
   const allGlobalAgents = await getGlobalAgents(auth, globalAgentIdsToFetch);
   const matchingGlobalAgents = allGlobalAgents.filter(
     (a) =>
-      !agentPrefix || a.name.toLowerCase().startsWith(agentPrefix.toLowerCase())
+      (!agentPrefix ||
+        a.name.toLowerCase().startsWith(agentPrefix.toLowerCase())) &&
+      !(a.status === "disabled_missing_datasource")
   );
 
   if (


### PR DESCRIPTION
## Description

fixes https://github.com/dust-tt/tasks/issues/409

We don't want to show "disabled" toggles for global assistants that can't be enabled due to a missing datasource.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
