### PR TITLE
[Ahuna] 'Try' button in Assistant Builder

### DIFF
--- a/front/components/assistant/RenderMessageMarkdown.tsx
+++ b/front/components/assistant/RenderMessageMarkdown.tsx
@@ -24,7 +24,7 @@ import {
 } from "tailwindcss/colors";
 import { visit } from "unist-util-visit";
 
-import { linkFromDocument } from "./conversation/RetrievalAction";
+import { linkFromDocument } from "@app/components/assistant/conversation/RetrievalAction";
 
 const SyntaxHighlighter = dynamic(
   () => import("react-syntax-highlighter").then((mod) => mod.Light),

--- a/front/components/assistant/RenderMessageMarkdown.tsx
+++ b/front/components/assistant/RenderMessageMarkdown.tsx
@@ -269,7 +269,7 @@ function MentionBlock({
       ? "(This assistant was deleted)"
       : agentConfiguration?.status === "active"
       ? ""
-      : "(This assistant is deactivated for this workspace)";
+      : "(This assistant is either deactivated or being tested)";
   const tooltipLabel = agentConfiguration?.description || "" + " " + statusText;
   return (
     <span className="inline-block cursor-default font-medium text-brand">

--- a/front/components/assistant/TryAssistantModal.tsx
+++ b/front/components/assistant/TryAssistantModal.tsx
@@ -96,7 +96,7 @@ export function TryAssistantModal({
       hasChanged={false}
       variant="side-md"
     >
-      <div id="modal-content">
+      <div id="modal-content" className="h-full overflow-y-auto">
         <GenerationContextProvider>
           {conversation && (
             <Conversation

--- a/front/components/assistant/TryAssistantModal.tsx
+++ b/front/components/assistant/TryAssistantModal.tsx
@@ -13,6 +13,7 @@ import Conversation from "@app/components/assistant/conversation/Conversation";
 import { GenerationContextProvider } from "@app/components/assistant/conversation/GenerationContextProvider";
 import { FixedAssistantInputBar } from "@app/components/assistant/conversation/input_bar/InputBar";
 import {
+  CONVERSATION_PARENT_SCROLL_DIV_ID as CONVERSATION_PARENT_SCROLL_DIV_ID,
   createConversationWithMessage,
   submitMessage,
 } from "@app/components/assistant/conversation/lib";
@@ -96,7 +97,10 @@ export function TryAssistantModal({
       hasChanged={false}
       variant="side-md"
     >
-      <div id="modal-content" className="h-full overflow-y-auto">
+      <div
+        id={CONVERSATION_PARENT_SCROLL_DIV_ID.modal}
+        className="h-full overflow-y-auto"
+      >
         <GenerationContextProvider>
           {conversation && (
             <Conversation

--- a/front/components/assistant/TryAssistantModal.tsx
+++ b/front/components/assistant/TryAssistantModal.tsx
@@ -96,26 +96,29 @@ export function TryAssistantModal({
       hasChanged={false}
       variant="side-md"
     >
-      <GenerationContextProvider>
-        {conversation && (
-          <Conversation
-            owner={owner}
-            user={user}
-            conversationId={conversation.sId}
-            onStickyMentionsChange={setStickyMentions}
-          />
-        )}
+      <div id="modal-content">
+        <GenerationContextProvider>
+          {conversation && (
+            <Conversation
+              owner={owner}
+              user={user}
+              conversationId={conversation.sId}
+              onStickyMentionsChange={setStickyMentions}
+              isInModal
+            />
+          )}
 
-        <div className="lg:[&>*]:left-0">
-          <FixedAssistantInputBar
-            owner={owner}
-            onSubmit={handleSubmit}
-            stickyMentions={stickyMentions}
-            conversationId={conversation?.sId || null}
-            additionalAgentConfigurations={[assistant]}
-          />
-        </div>
-      </GenerationContextProvider>
+          <div className="lg:[&>*]:left-0">
+            <FixedAssistantInputBar
+              owner={owner}
+              onSubmit={handleSubmit}
+              stickyMentions={stickyMentions}
+              conversationId={conversation?.sId || null}
+              additionalAgentConfigurations={[assistant]}
+            />
+          </div>
+        </GenerationContextProvider>
+      </div>
     </Modal>
   );
 }

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -32,6 +32,7 @@ import { AgentAction } from "@app/components/assistant/conversation/AgentAction"
 import { AssistantEditionMenu } from "@app/components/assistant/conversation/AssistantEditionMenu";
 import { ConversationMessage } from "@app/components/assistant/conversation/ConversationMessage";
 import { GenerationContext } from "@app/components/assistant/conversation/GenerationContextProvider";
+import { CONVERSATION_PARENT_SCROLL_DIV_ID } from "@app/components/assistant/conversation/lib";
 import {
   linkFromDocument,
   providerFromDocument,
@@ -40,7 +41,6 @@ import {
 import { RenderMessageMarkdown } from "@app/components/assistant/RenderMessageMarkdown";
 import { useEventSource } from "@app/hooks/useEventSource";
 import { useSubmitFunction } from "@app/lib/client/utils";
-import { CONVERSATION_PARENT_DIV } from "@app/components/assistant/conversation/lib";
 
 function cleanUpCitations(message: string): string {
   const regex = / ?:cite\[[a-zA-Z0-9, ]+\]/g;
@@ -226,7 +226,7 @@ export function AgentMessage({
     const previousHeight = messageHeight.current || 0;
     messageHeight.current = messageRef.current?.scrollHeight || previousHeight;
     const mainTag = document.getElementById(
-      CONVERSATION_PARENT_DIV[isInModal ? "modal" : "page"]
+      CONVERSATION_PARENT_SCROLL_DIV_ID[isInModal ? "modal" : "page"]
     );
     if (mainTag && agentMessageToRender.status === "created") {
       if (
@@ -241,6 +241,7 @@ export function AgentMessage({
     agentMessageToRender.status,
     agentMessageToRender.action,
     activeReferences.length,
+    isInModal,
   ]);
 
   // GenerationContext: to know if we are generating or not

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -40,24 +40,33 @@ import {
 import { RenderMessageMarkdown } from "@app/components/assistant/RenderMessageMarkdown";
 import { useEventSource } from "@app/hooks/useEventSource";
 import { useSubmitFunction } from "@app/lib/client/utils";
+import { CONVERSATION_PARENT_DIV } from "@app/components/assistant/conversation/lib";
 
 function cleanUpCitations(message: string): string {
   const regex = / ?:cite\[[a-zA-Z0-9, ]+\]/g;
   return message.replace(regex, "");
 }
 
+/**
+ *
+ * @param isInModal is the conversation happening in a side modal, i.e. when
+ * testing an assistant? see conversation/Conversation.tsx
+ * @returns
+ */
 export function AgentMessage({
   message,
   owner,
   user,
   conversationId,
   reactions,
+  isInModal,
 }: {
   message: AgentMessageType;
   owner: WorkspaceType;
   user: UserType;
   conversationId: string;
   reactions: MessageReactionType[];
+  isInModal?: boolean;
 }) {
   const [streamedAgentMessage, setStreamedAgentMessage] =
     useState<AgentMessageType>(message);
@@ -216,7 +225,9 @@ export function AgentMessage({
   useEffect(() => {
     const previousHeight = messageHeight.current || 0;
     messageHeight.current = messageRef.current?.scrollHeight || previousHeight;
-    const mainTag = document.getElementById("main-content");
+    const mainTag = document.getElementById(
+      CONVERSATION_PARENT_DIV[isInModal ? "modal" : "page"]
+    );
     if (mainTag && agentMessageToRender.status === "created") {
       if (
         mainTag.offsetHeight + mainTag.scrollTop >=

--- a/front/components/assistant/conversation/Conversation.tsx
+++ b/front/components/assistant/conversation/Conversation.tsx
@@ -10,6 +10,8 @@ import { isAgentMention, isUserMessageType } from "@dust-tt/types";
 import { useCallback, useEffect, useRef } from "react";
 
 import { AgentMessage } from "@app/components/assistant/conversation/AgentMessage";
+import { ContentFragment } from "@app/components/assistant/conversation/ContentFragment";
+import { CONVERSATION_PARENT_SCROLL_DIV_ID } from "@app/components/assistant/conversation/lib";
 import { UserMessage } from "@app/components/assistant/conversation/UserMessage";
 import { useEventSource } from "@app/hooks/useEventSource";
 import {
@@ -17,9 +19,6 @@ import {
   useConversationReactions,
   useConversations,
 } from "@app/lib/swr";
-
-import { ContentFragment } from "@app/components/assistant/conversation/ContentFragment";
-import { CONVERSATION_PARENT_DIV } from "@app/components/assistant/conversation/lib";
 
 /**
  *
@@ -60,12 +59,12 @@ export default function Conversation({
 
   useEffect(() => {
     const mainTag = document.getElementById(
-      CONVERSATION_PARENT_DIV[isInModal ? "modal" : "page"]
+      CONVERSATION_PARENT_SCROLL_DIV_ID[isInModal ? "modal" : "page"]
     );
     if (mainTag) {
       mainTag.scrollTo(0, mainTag.scrollHeight);
     }
-  }, [conversation?.content.length]);
+  }, [conversation?.content.length, isInModal]);
 
   useEffect(() => {
     if (!onStickyMentionsChange) {

--- a/front/components/assistant/conversation/Conversation.tsx
+++ b/front/components/assistant/conversation/Conversation.tsx
@@ -18,18 +18,26 @@ import {
   useConversations,
 } from "@app/lib/swr";
 
-import { ContentFragment } from "./ContentFragment";
+import { ContentFragment } from "@app/components/assistant/conversation/ContentFragment";
+import { CONVERSATION_PARENT_DIV } from "@app/components/assistant/conversation/lib";
 
+/**
+ *
+ * @param isInModal is the conversation happening in a side modal, i.e. when testing an assistant?
+ * @returns
+ */
 export default function Conversation({
   owner,
   user,
   conversationId,
   onStickyMentionsChange,
+  isInModal,
 }: {
   owner: WorkspaceType;
   user: UserType;
   conversationId: string;
   onStickyMentionsChange?: (mentions: AgentMention[]) => void;
+  isInModal?: boolean;
 }) {
   const {
     conversation,
@@ -51,7 +59,9 @@ export default function Conversation({
   });
 
   useEffect(() => {
-    const mainTag = document.getElementById("main-content");
+    const mainTag = document.getElementById(
+      CONVERSATION_PARENT_DIV[isInModal ? "modal" : "page"]
+    );
     if (mainTag) {
       mainTag.scrollTo(0, mainTag.scrollHeight);
     }
@@ -210,6 +220,7 @@ export default function Conversation({
                     user={user}
                     conversationId={conversationId}
                     reactions={messageReactions}
+                    isInModal={isInModal}
                   />
                 </div>
               </div>

--- a/front/components/assistant/conversation/lib.ts
+++ b/front/components/assistant/conversation/lib.ts
@@ -13,7 +13,11 @@ import type * as t from "io-ts";
 import type { NotificationType } from "@app/components/sparkle/Notification";
 import type { PostConversationsResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations";
 
-export const CONVERSATION_PARENT_DIV = {
+/**
+ * id of the parent div that should be scrolled for autosrcolling to work on
+ * conversations
+ */
+export const CONVERSATION_PARENT_SCROLL_DIV_ID = {
   modal: "modal-content",
   page: "main-content",
 };

--- a/front/components/assistant/conversation/lib.ts
+++ b/front/components/assistant/conversation/lib.ts
@@ -13,6 +13,11 @@ import type * as t from "io-ts";
 import type { NotificationType } from "@app/components/sparkle/Notification";
 import type { PostConversationsResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations";
 
+export const CONVERSATION_PARENT_DIV = {
+  modal: "modal-content",
+  page: "main-content",
+};
+
 export type ConversationErrorType = {
   type:
     | "attachment_upload_error"

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -1143,6 +1143,7 @@ async function submitForm({
   builderState,
   agentConfigurationId,
   slackData,
+  isDraft,
 }: {
   owner: WorkspaceType;
   builderState: AssistantBuilderState;
@@ -1151,6 +1152,7 @@ async function submitForm({
     selectedSlackChannels: SlackChannel[];
     slackChannelsLinkedWithAgent: SlackChannelLinkedWithAgent[];
   };
+  isDraft?: boolean;
 }): Promise<LightAgentConfigurationType | AgentConfigurationType> {
   const { selectedSlackChannels, slackChannelsLinkedWithAgent } = slackData;
   if (
@@ -1232,7 +1234,7 @@ async function submitForm({
         name: removeLeadingAt(builderState.handle),
         pictureUrl: builderState.avatarUrl,
         description: builderState.description.trim(),
-        status: "active",
+        status: isDraft ? "draft" : "active",
         scope: builderState.scope,
         action: actionParam,
         generation: {
@@ -1323,6 +1325,7 @@ function TryModalInBuilder({
           selectedSlackChannels: [],
           slackChannelsLinkedWithAgent: [],
         },
+        isDraft: true,
       })
     );
   }
@@ -1333,7 +1336,9 @@ function TryModalInBuilder({
           owner={owner}
           user={user}
           assistant={assistant}
-          onClose={() => setAssistant(null)}
+          onClose={() => {
+            setAssistant(null);
+          }}
         />
       )}
       <Button

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -18,8 +18,10 @@ import {
 } from "@dust-tt/sparkle";
 import type {
   AgentConfigurationScope,
+  AgentConfigurationType,
   ConnectorProvider,
   DataSourceType,
+  LightAgentConfigurationType,
 } from "@dust-tt/types";
 import type { WorkspaceType } from "@dust-tt/types";
 import type { SupportedModel } from "@dust-tt/types";
@@ -89,6 +91,7 @@ import {
 } from "@app/lib/swr";
 import { classNames } from "@app/lib/utils";
 import { TryAssistantModal } from "@app/components/assistant/TryAssistantModal";
+import { Agent } from "http";
 
 type SlackChannel = { slackChannelId: string; slackChannelName: string };
 type SlackChannelLinkedWithAgent = SlackChannel & {
@@ -1152,7 +1155,7 @@ async function submitForm({
     slackChannelsLinkedWithAgent: SlackChannelLinkedWithAgent[];
     slackDataSource?: DataSourceType;
   };
-}) {
+}): Promise<LightAgentConfigurationType | AgentConfigurationType> {
   const { mutate } = useSWRConfig();
   const {
     selectedSlackChannels,
@@ -1266,7 +1269,9 @@ async function submitForm({
     throw new Error("An error occurred while saving the configuration.");
   }
 
-  const newAgentConfiguration = await res.json();
+  const newAgentConfiguration: {
+    agentConfiguration: LightAgentConfigurationType | AgentConfigurationType;
+  } = await res.json();
   const agentConfigurationSid = newAgentConfiguration.agentConfiguration.sId;
 
   // PATCH the linked slack channels if either:
@@ -1304,7 +1309,7 @@ async function submitForm({
     );
   }
 
-  return newAgentConfiguration;
+  return newAgentConfiguration.agentConfiguration;
 }
 
 function TryModalInBuilder({

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -1316,6 +1316,8 @@ function TryModalInBuilder({
   >(null);
 
   async function onTryClick() {
+    // A new assistant is created on the fly with status 'draft'
+    // so that the user can try it out while creating it.
     setAssistant(
       await submitForm({
         owner,

--- a/front/components/sparkle/AppLayout.tsx
+++ b/front/components/sparkle/AppLayout.tsx
@@ -16,6 +16,7 @@ import Script from "next/script";
 import { signOut } from "next-auth/react";
 import React, { Fragment, useContext, useEffect, useState } from "react";
 
+import { CONVERSATION_PARENT_SCROLL_DIV_ID } from "@app/components/assistant/conversation/lib";
 import type {
   SidebarNavigation,
   TopNavigationId,
@@ -425,7 +426,7 @@ export default function AppLayout({
           {/** END Incident Banner */}
 
           <main
-            id="main-content"
+            id={CONVERSATION_PARENT_SCROLL_DIV_ID.page}
             className={classNames(
               "h-full overflow-x-hidden pt-16",
               titleChildren ? "" : "lg:pt-8"

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/scope.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/scope.ts
@@ -1,4 +1,4 @@
-import type { WithAPIErrorReponse } from "@dust-tt/types";
+import type { AgentStatus, WithAPIErrorReponse } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
@@ -131,7 +131,7 @@ async function handler(
           assistant: {
             ...assistant,
             scope: bodyValidation.right.scope,
-            status: assistant.status as "active" | "archived", // type adjustment
+            status: assistant.status as AgentStatus,
           },
         },
         assistant.sId

--- a/types/src/front/api_handlers/internal/agent_configuration.ts
+++ b/types/src/front/api_handlers/internal/agent_configuration.ts
@@ -47,7 +47,11 @@ export const PostOrPatchAgentConfigurationRequestBodySchema = t.type({
     name: t.string,
     description: t.string,
     pictureUrl: t.string,
-    status: t.union([t.literal("active"), t.literal("archived")]),
+    status: t.union([
+      t.literal("active"),
+      t.literal("archived"),
+      t.literal("draft"),
+    ]),
     scope: t.union([
       t.literal("workspace"),
       t.literal("published"),

--- a/types/src/front/assistant/agent.ts
+++ b/types/src/front/assistant/agent.ts
@@ -66,7 +66,16 @@ export type GlobalAgentStatus =
   | "disabled_by_admin"
   | "disabled_missing_datasource"
   | "disabled_free_workspace";
-export type AgentStatus = "active" | "archived";
+
+/**
+ * Agent statuses:
+ * - "active" means the agent can be used directly
+ * - "archived" means the agent was either deleted, or that there is a newer
+ *   version
+ * - "draft" is used for the "try" button in builder, when the agent is not yet
+ *   fully created / updated
+ */
+export type AgentStatus = "active" | "archived" | "draft";
 export type AgentConfigurationStatus = AgentStatus | GlobalAgentStatus;
 
 /**


### PR DESCRIPTION
## Description
Fixes issue #3273 

The button allows a user to test an assistant version they are currently creating in the builder. It is only available if the assitant is valid (i.e. enough properties have been set for it to make sense).

### Pending issue
Scrolling: when talking in the modal to the assistant, the assistant builder screen is scrolled all the way down

### Technical notes
- Creates a new `AgentStatus` called `draft`
- extracts & reuse `submitForm` from the Assistant builder
- when clicking on "Try", creates a new 'draft' agent configuration based on the current builder state

Currently, a new 'draft' agent is created each time the modal is used. The goal of not doing that would be to save DB calls & DB space, but other immediately available options would not impact that:
  - deleting => doesn't change anything since currently we don't delete, we mark archived
  - keeping the same agent => we update versions, by recreating everything so that would also not change anything

### Screenshots
![image](https://github.com/dust-tt/dust/assets/5437393/600dee3a-f6a3-4743-8b9e-c4ce26b07818)
![image](https://github.com/dust-tt/dust/assets/5437393/322d7d8d-27d9-40bb-9d35-b74f5fa17d70)


## Risk
Inteferes with assitant creation => will be tested on front edge

## Deploy Plan
- No migration needed for the new status.
- deployed first on front edge.

