### PR TITLE
Intercom: Fix workflow signal logic

### DIFF
--- a/connectors/src/connectors/intercom/temporal/activities.ts
+++ b/connectors/src/connectors/intercom/temporal/activities.ts
@@ -256,20 +256,6 @@ export async function syncCollectionActivity({
 }
 
 /**
- * This activity is responsible for retrieving the list
- * of team ids to sync for a given connector.
- */
-export async function getTeamIdsToSyncActivity(connectorId: ModelId) {
-  const teams = await IntercomTeam.findAll({
-    attributes: ["teamId"],
-    where: {
-      connectorId: connectorId,
-    },
-  });
-  return teams.map((t) => t.teamId);
-}
-
-/**
  * This activity is responsible for syncing the conversations of a given Team.
  * If the team is not allowed anymore, it will delete all its data.
  * If the team is not present on Intercom anymore, it will delete all its data.

--- a/connectors/src/connectors/intercom/temporal/client.ts
+++ b/connectors/src/connectors/intercom/temporal/client.ts
@@ -44,6 +44,7 @@ export async function launchIntercomSyncWorkflow(
     type: "team",
     intercomId: teamId,
   }));
+  const signals = [...signaledHelpCenterIds, ...signaledTeamIds];
 
   // When the workflow is inactive, we omit passing helpCenterIds as they are only used to signal modifications within a currently active full sync workflow.
   try {
@@ -55,7 +56,7 @@ export async function launchIntercomSyncWorkflow(
         connectorId: [connectorId],
       },
       signal: intercomUpdatesSignal,
-      signalArgs: [signaledHelpCenterIds, signaledTeamIds],
+      signalArgs: [signals],
       memo: {
         connectorId,
       },


### PR DESCRIPTION
## Description

This PR fixes the logic to send signals to the Intercom sync workflow. 

What we want: 
- When permissions are updated we send a signal to sync the updated Help Center or Team (folder of conversations). 
- When no signal, the workflow is launched every hour to sync the help center data.

## Risk

Low, not used yet. 

## Deploy Plan

Nothing special. 
