### PR TITLE
Intercom: fix wording and limit to published articles

### DIFF
--- a/connectors/src/connectors/intercom/lib/intercom_api.ts
+++ b/connectors/src/connectors/intercom/lib/intercom_api.ts
@@ -316,7 +316,9 @@ export async function fetchIntercomArticles(
     }
   } while (hasMore);
 
-  return articles.filter((article) => article.parent_id == parentId);
+  return articles.filter(
+    (article) => article.parent_id == parentId && article.state === "published"
+  );
 }
 
 /**

--- a/front/lib/connector_providers.ts
+++ b/front/lib/connector_providers.ts
@@ -85,8 +85,9 @@ export const CONNECTOR_CONFIGURATIONS: Record<
     status: "built-dust-only", // ROLLOUT INTERCOM
     hide: false,
     description:
-      "Authorize access to your Intercom Help Center Collections & Articles. Conversations coming soon.",
-    limitations: null,
+      "Authorize granular access to your Intercom workspace. Access your Conversations at the Team level and Help Center Articles at the main Collection level.",
+    limitations:
+      "Dust will index only the conversations from the selected Teams that were initiated within the past 90 days and concluded (marked as closed). For the Help Center data, Dust will index every Article published within a selected Collection.",
     logoComponent: IntercomLogo,
     isNested: true,
   },


### PR DESCRIPTION
## Description

- Add a check to sync only published articles
- Change the wording description in the Connection page

## Risk

Low.

## Deploy Plan

None.
