### PR TITLE
enh: use specific error variant for exceed max rows error.

### DIFF
--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -2309,7 +2309,7 @@ async fn sqlite_workers_heartbeat(
                             StatusCode::INTERNAL_SERVER_ERROR,
                             "internal_server_error",
                             "Failed to expire SQLite worker databases",
-                            Some(e),
+                            Some(e.into()),
                         )
                     }
                     Ok(_) => (),

--- a/core/src/sqlite_workers/client.rs
+++ b/core/src/sqlite_workers/client.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, Result};
-use hyper::{Body, Client, Request};
+use hyper::{body::Bytes, Body, Client, Request};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use urlencoding::encode;
@@ -16,6 +16,31 @@ pub struct SqliteWorker {
     last_heartbeat: u64,
     url: String,
 }
+
+#[derive(Debug)]
+pub enum SqliteWorkerError {
+    ClientError(anyhow::Error),
+    ServerError(anyhow::Error, Option<String>, u16),
+}
+
+impl std::fmt::Display for SqliteWorkerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Self::ClientError(e) => write!(f, "SqliteWorkerError: Client error: {}", e),
+            Self::ServerError(e, code, status) => {
+                write!(
+                    f,
+                    "SqliteWorkerError (code={}, status={}): Server error: {}",
+                    code.clone().unwrap_or_default(),
+                    status,
+                    e
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for SqliteWorkerError {}
 
 impl SqliteWorker {
     pub fn new(url: String, last_heartbeat: u64) -> Self {
@@ -41,7 +66,7 @@ impl SqliteWorker {
         database_unique_id: &str,
         tables: &Vec<Table>,
         query: &str,
-    ) -> Result<Vec<QueryResult>> {
+    ) -> Result<Vec<QueryResult>, SqliteWorkerError> {
         let worker_url = self.url();
 
         let req = Request::builder()
@@ -58,9 +83,16 @@ impl SqliteWorker {
                     "query": query,
                 })
                 .to_string(),
-            ))?;
+            ))
+            .map_err(|e| {
+                SqliteWorkerError::ClientError(anyhow!("Failed to build request: {}", e))
+            })?;
 
-        let res = Client::new().request(req).await?;
+        let res = Client::new().request(req).await.map_err(|e| {
+            SqliteWorkerError::ClientError(anyhow!("Failed to execute request: {}", e))
+        })?;
+
+        let body_bytes = get_response_body(res).await?;
 
         #[derive(Deserialize)]
         struct ExecuteQueryResponseBody {
@@ -68,60 +100,92 @@ impl SqliteWorker {
             response: Option<Vec<QueryResult>>,
         }
 
-        match res.status().as_u16() {
-            200 => {
-                let body = hyper::body::to_bytes(res.into_body()).await?;
-                let res: ExecuteQueryResponseBody = serde_json::from_slice(&body)?;
-                match res.error {
-                    Some(e) => Err(anyhow!("Error executing query: {}", e))?,
-                    None => match res.response {
-                        Some(r) => Ok(r),
-                        None => Err(anyhow!("No response found"))?,
-                    },
-                }
-            }
-            s => Err(anyhow!(
-                "Failed to execute query on sqlite worker. Status: {}",
-                s
-            ))?,
+        let body: ExecuteQueryResponseBody = serde_json::from_slice(&body_bytes).map_err(|e| {
+            SqliteWorkerError::ClientError(anyhow!("Failed to parse response: {}", e))
+        })?;
+
+        match body.error {
+            Some(e) => Err(SqliteWorkerError::ServerError(anyhow!(e), None, 200))?,
+            None => match body.response {
+                Some(r) => Ok(r),
+                None => Err(SqliteWorkerError::ServerError(
+                    anyhow!("No response in body"),
+                    None,
+                    200,
+                ))?,
+            },
         }
     }
 
-    pub async fn invalidate_database(&self, database_unique_id: &str) -> Result<()> {
+    pub async fn invalidate_database(
+        &self,
+        database_unique_id: &str,
+    ) -> Result<(), SqliteWorkerError> {
         let worker_url = self.url();
 
         let req = Request::builder()
             .method("DELETE")
             .uri(format!("{}/databases/{}", worker_url, database_unique_id))
-            .body(Body::from(""))?;
+            .body(Body::from(""))
+            .map_err(|e| {
+                SqliteWorkerError::ClientError(anyhow!("Failed to build request: {}", e))
+            })?;
 
-        let res = Client::new().request(req).await?;
+        let res = Client::new().request(req).await.map_err(|e| {
+            SqliteWorkerError::ClientError(anyhow!("Failed to execute request: {}", e))
+        })?;
 
-        match res.status().as_u16() {
-            200 => Ok(()),
-            s => Err(anyhow!(
-                "Failed to invalidate database on sqlite worker. Status: {}",
-                s
-            ))?,
-        }
+        let _ = get_response_body(res).await?;
+
+        Ok(())
     }
 
-    pub async fn expire_all(&self) -> Result<()> {
+    pub async fn expire_all(&self) -> Result<(), SqliteWorkerError> {
         let worker_url = self.url();
 
         let req = Request::builder()
             .method("DELETE")
             .uri(format!("{}/databases", worker_url))
-            .body(Body::from(""))?;
+            .body(Body::from(""))
+            .map_err(|e| {
+                SqliteWorkerError::ClientError(anyhow!("Failed to build request: {}", e))
+            })?;
 
-        let res = Client::new().request(req).await?;
+        let res = Client::new().request(req).await.map_err(|e| {
+            SqliteWorkerError::ClientError(anyhow!("Failed to execute request: {}", e))
+        })?;
+        let _ = get_response_body(res).await?;
 
-        match res.status().as_u16() {
-            200 => Ok(()),
-            s => Err(anyhow!(
-                "Failed to expire all databases on sqlite worker. Status: {}",
-                s
-            ))?,
+        Ok(())
+    }
+}
+
+async fn get_response_body(res: hyper::Response<hyper::Body>) -> Result<Bytes, SqliteWorkerError> {
+    let status = res.status().as_u16();
+    let body = hyper::body::to_bytes(res.into_body())
+        .await
+        .map_err(|e| SqliteWorkerError::ClientError(anyhow!("Failed to read response: {}", e)))?;
+
+    match status {
+        200 => Ok(body),
+        s => {
+            let body_json: serde_json::Value = serde_json::from_slice(&body).map_err(|e| {
+                SqliteWorkerError::ClientError(anyhow!("Failed to parse response: {}", e))
+            })?;
+            let error = body_json.get("error");
+            let error_code = match error {
+                Some(e) => e
+                    .get("code")
+                    .map(|c| c.as_str())
+                    .flatten()
+                    .map(|s| s.to_string()),
+                None => None,
+            };
+            Err(SqliteWorkerError::ServerError(
+                anyhow!("Received error response from SQLite worker",),
+                error_code,
+                s,
+            ))?
         }
     }
 }


### PR DESCRIPTION
## Description

first step towards https://github.com/dust-tt/dust/issues/3678

We want to:
- prompt the assistant to limit query results to 128 rows (above that, it becomes costly in terms of context size + heavy on the core database + likely useless)
- display a user-facing error when more than 128 rows are returned

This commit removes the simple truncating and replaces it with an error. Most of the diff is the ground work to make a typed error bubble-up all the way through `database.rs`.

Next, I will work on:
- passing the error through the block execution
- add specific error events to the dust app so we can display something on the frontend
- add specific errors in the public API 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
