### PR TITLE
Intercom: improve connector permission selection

### DIFF
--- a/connectors/src/connectors/intercom/lib/conversation_permissions.ts
+++ b/connectors/src/connectors/intercom/lib/conversation_permissions.ts
@@ -110,7 +110,7 @@ export async function retrieveIntercomConversationsPermissions({
     lastUpdatedAt: null,
   };
 
-  const teamswithReadPermission = await IntercomTeam.findAll({
+  const teamsWithReadPermission = await IntercomTeam.findAll({
     where: {
       connectorId: connectorId,
       permission: "read",
@@ -121,11 +121,11 @@ export async function retrieveIntercomConversationsPermissions({
   // If isReadPermissionsOnly = true, we retrieve the list of Teams from DB that have permission = "read"
   // If isReadPermissionsOnly = false, we retrieve the list of Teams from Intercom
   if (isReadPermissionsOnly) {
-    if (isRootLevel && teamswithReadPermission.length > 0) {
+    if (isRootLevel && teamsWithReadPermission.length > 0) {
       resources.push(rootConversationRessource);
     }
     if (parentInternalId === teamsInternalId) {
-      teamswithReadPermission.forEach((team) => {
+      teamsWithReadPermission.forEach((team) => {
         resources.push({
           provider: connector.type,
           internalId: getTeamInternalId(connectorId, team.teamId),
@@ -147,7 +147,7 @@ export async function retrieveIntercomConversationsPermissions({
     if (parentInternalId === teamsInternalId) {
       const teams = await fetchIntercomTeams(intercomClient);
       teams.forEach((team) => {
-        const isTeamInDb = teamswithReadPermission.some((teamFromDb) => {
+        const isTeamInDb = teamsWithReadPermission.some((teamFromDb) => {
           return teamFromDb.teamId === team.id;
         });
         resources.push({

--- a/connectors/src/connectors/intercom/lib/conversation_permissions.ts
+++ b/connectors/src/connectors/intercom/lib/conversation_permissions.ts
@@ -5,7 +5,10 @@ import {
   fetchIntercomTeams,
   getIntercomClient,
 } from "@connectors/connectors/intercom/lib/intercom_api";
-import { getTeamInternalId } from "@connectors/connectors/intercom/lib/utils";
+import {
+  getTeamInternalId,
+  getTeamsInternalId,
+} from "@connectors/connectors/intercom/lib/utils";
 import type { ConnectorPermissionRetriever } from "@connectors/connectors/interface";
 import { Connector } from "@connectors/lib/models";
 import { IntercomTeam } from "@connectors/lib/models/intercom";
@@ -90,55 +93,81 @@ export async function retrieveIntercomConversationsPermissions({
   const intercomClient = await getIntercomClient(connector.connectionId);
   const isReadPermissionsOnly = filterPermission === "read";
   const isRootLevel = !parentInternalId;
-  let resources: ConnectorResource[] = [];
+  const teamsInternalId = getTeamsInternalId(connectorId);
+  const resources: ConnectorResource[] = [];
 
-  // If Root level we retrieve the list of Help Centers.
+  const rootConversationRessource: ConnectorResource = {
+    provider: "intercom",
+    internalId: teamsInternalId,
+    parentInternalId: null,
+    type: "channel",
+    title: "Conversations",
+    sourceUrl: null,
+    expandable: true,
+    preventSelection: true,
+    permission: "none",
+    dustDocumentId: null,
+    lastUpdatedAt: null,
+  };
+
+  const teamswithReadPermission = await IntercomTeam.findAll({
+    where: {
+      connectorId: connectorId,
+      permission: "read",
+    },
+  });
+
+  // If Root level we display the fake parent "Conversations"
   // If isReadPermissionsOnly = true, we retrieve the list of Teams from DB that have permission = "read"
   // If isReadPermissionsOnly = false, we retrieve the list of Teams from Intercom
-  if (isRootLevel) {
-    const teamsFromDb = await IntercomTeam.findAll({
-      where: {
-        connectorId: connectorId,
-        permission: "read",
-      },
-    });
-
-    if (isReadPermissionsOnly) {
-      resources = teamsFromDb.map((team) => ({
-        provider: connector.type,
-        internalId: getTeamInternalId(connectorId, team.teamId),
-        parentInternalId: null,
-        type: "channel",
-        title: team.name,
-        sourceUrl: null,
-        expandable: false,
-        permission: team.permission,
-        dustDocumentId: null,
-        lastUpdatedAt: null,
-      }));
-    } else {
+  if (isReadPermissionsOnly) {
+    if (isRootLevel && teamswithReadPermission.length > 0) {
+      resources.push(rootConversationRessource);
+    }
+    if (parentInternalId === teamsInternalId) {
+      teamswithReadPermission.forEach((team) => {
+        resources.push({
+          provider: connector.type,
+          internalId: getTeamInternalId(connectorId, team.teamId),
+          parentInternalId: teamsInternalId,
+          type: "folder",
+          title: team.name,
+          sourceUrl: null,
+          expandable: false,
+          permission: team.permission,
+          dustDocumentId: null,
+          lastUpdatedAt: null,
+        });
+      });
+    }
+  } else {
+    if (isRootLevel) {
+      resources.push(rootConversationRessource);
+    }
+    if (parentInternalId === teamsInternalId) {
       const teams = await fetchIntercomTeams(intercomClient);
-      resources = teams.map((team) => {
-        const isTeamInDb = teamsFromDb.some((teamFromDb) => {
+      teams.forEach((team) => {
+        const isTeamInDb = teamswithReadPermission.some((teamFromDb) => {
           return teamFromDb.teamId === team.id;
         });
-        return {
+        resources.push({
           provider: connector.type,
           internalId: getTeamInternalId(connectorId, team.id),
-          parentInternalId: null,
-          type: "channel",
+          parentInternalId: teamsInternalId,
+          type: "folder",
           title: team.name,
           sourceUrl: null,
           expandable: false,
           permission: isTeamInDb ? "read" : "none",
           dustDocumentId: null,
           lastUpdatedAt: null,
-        };
+        });
       });
     }
-    resources.sort((a, b) => {
-      return a.title.localeCompare(b.title);
-    });
   }
+  resources.sort((a, b) => {
+    return a.title.localeCompare(b.title);
+  });
+
   return resources;
 }

--- a/connectors/src/connectors/intercom/lib/intercom_api.ts
+++ b/connectors/src/connectors/intercom/lib/intercom_api.ts
@@ -22,7 +22,7 @@ type IntercomMeResponseType = {
   };
 };
 
-type IntercomHelpCenterType = {
+export type IntercomHelpCenterType = {
   id: string;
   workspace_id: string;
   created_at: number;

--- a/connectors/src/connectors/intercom/lib/utils.ts
+++ b/connectors/src/connectors/intercom/lib/utils.ts
@@ -21,6 +21,9 @@ export function getHelpCenterArticleInternalId(
 ): string {
   return `intercom-article-${connectorId}-${articleId}`;
 }
+export function getTeamsInternalId(connectorId: ModelId): string {
+  return `intercom-teams-${connectorId}`;
+}
 export function getTeamInternalId(
   connectorId: ModelId,
   teamId: string

--- a/front/components/ConnectorPermissionsTree.tsx
+++ b/front/components/ConnectorPermissionsTree.tsx
@@ -120,7 +120,9 @@ export function PermissionTreeChildren({
             variant={r.type}
             className="whitespace-nowrap"
             checkbox={
-              canUpdatePermissions && onPermissionUpdate
+              r.preventSelection !== true &&
+              canUpdatePermissions &&
+              onPermissionUpdate
                 ? {
                     disabled: parentIsSelected,
                     checked:

--- a/types/src/front/lib/connectors_api.ts
+++ b/types/src/front/lib/connectors_api.ts
@@ -67,6 +67,7 @@ export type ConnectorResource = {
   title: string;
   sourceUrl: string | null;
   expandable: boolean;
+  preventSelection?: boolean;
   permission: ConnectorPermission;
   dustDocumentId: string | null;
   lastUpdatedAt: number | null;


### PR DESCRIPTION
## Description

This PR edits the set / get permissions logic of the Intercom connector. Nothing fancy, I just added the possibility to set a parent resource as not selectable so that we can have a top level for Help Center and Conversations.

I could have decided to have this top level resources selected meaning that the user can decide that all conversations are synced, even if they create a new Team on Intercom, but this solution was quicker to implement and I'd rather have admins tick each Team they want to give access to. No problem to change that in the future. 

<img width="941" alt="Screenshot 2024-02-13 at 14 52 54" src="https://github.com/dust-tt/dust/assets/3803406/3e719ed2-9b5d-41a8-842f-32bc104b6951">


## Risk

Low, connector unused at the moment. 

## Deploy Plan

Nothing special. 