### PR TITLE
Sparkle: ElementModal component for modals with variable content

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.94",
+  "version": "0.2.95",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.94",
+      "version": "0.2.95",
       "license": "ISC",
       "dependencies": {
         "@headlessui/react": "^1.7.17",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.94",
+  "version": "0.2.95",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/_index.ts
+++ b/sparkle/src/_index.ts
@@ -85,6 +85,9 @@ export { Spinner };
 import { Modal } from "./components/Modal";
 export { Modal };
 
+import { ElementModal } from "./components/ElementModal";
+export { ElementModal };
+
 import { Dialog } from "./components/Dialog";
 export { Dialog };
 

--- a/sparkle/src/components/ElementModal.tsx
+++ b/sparkle/src/components/ElementModal.tsx
@@ -1,26 +1,32 @@
-import React, { useState } from "react";
+import React, { useCallback, useState } from "react";
 
 import { Modal, ModalProps } from "./Modal";
 
-type ElementModalProps<T> = Omit<ModalProps, "isOpen"> & {
+type ElementModalProps<T> = Omit<ModalProps, "isOpen" | "onSave"> & {
   openOnElement: T | null;
+  onSave?: (closeModalFn: () => void) => void;
 };
 
 export function ElementModal<T>({
   openOnElement,
+  onClose,
+  onSave,
   ...props
 }: ElementModalProps<T>) {
-  const { onClose } = props;
   const [isClosingTransition, setIsClosingTransition] = useState(false);
-  const realOnClose = () => {
+  const transitionOnClose = useCallback(() => {
     setIsClosingTransition(true);
     setTimeout(() => {
       onClose();
       setIsClosingTransition(false);
     }, 200);
-  };
-  props.onClose = realOnClose;
+  }, [onClose]);
   return (
-    <Modal isOpen={openOnElement !== null && !isClosingTransition} {...props} />
+    <Modal
+      isOpen={openOnElement !== null && !isClosingTransition}
+      onClose={transitionOnClose}
+      onSave={onSave ? () => onSave(transitionOnClose) : undefined}
+      {...props}
+    />
   );
 }

--- a/sparkle/src/components/ElementModal.tsx
+++ b/sparkle/src/components/ElementModal.tsx
@@ -1,0 +1,26 @@
+import React, { useState } from "react";
+
+import { Modal, ModalProps } from "./Modal";
+
+type ElementModalProps<T> = Omit<ModalProps, "isOpen"> & {
+  openOnElement: T | null;
+};
+
+export function ElementModal<T>({
+  openOnElement,
+  ...props
+}: ElementModalProps<T>) {
+  const { onClose } = props;
+  const [isClosingTransition, setIsClosingTransition] = useState(false);
+  const realOnClose = () => {
+    setIsClosingTransition(true);
+    setTimeout(() => {
+      onClose();
+      setIsClosingTransition(false);
+    }, 200);
+  };
+  props.onClose = realOnClose;
+  return (
+    <Modal isOpen={openOnElement !== null && !isClosingTransition} {...props} />
+  );
+}

--- a/sparkle/src/components/Modal.tsx
+++ b/sparkle/src/components/Modal.tsx
@@ -60,7 +60,7 @@ const modalStyles = {
   },
 };
 
-type ModalProps = {
+export type ModalProps = {
   isOpen: boolean;
   onClose: () => void;
   action?: ButtonProps;

--- a/sparkle/src/stories/ElementModal.stories.tsx
+++ b/sparkle/src/stories/ElementModal.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta } from "@storybook/react";
+import React, { useState } from "react";
+
+import { Button, ElementModal, Page } from "../index_with_tw_base";
+
+const meta = {
+  title: "Molecule/ElementModal",
+  component: ElementModal,
+} satisfies Meta<typeof ElementModal>;
+
+export default meta;
+
+export const ElementModalExample = () => {
+  const [element, setElement] = useState<{ text: string } | null>(null);
+  return (
+    <Page.Layout gap="md">
+      <ElementModal
+        openOnElement={element}
+        onClose={() => setElement(null)}
+        variant="side-sm"
+        title="Element Modal title"
+        hasChanged={false}
+      >
+        <div className="s-flex s-flex-col s-gap-3">
+          <div className="s-mt-4 s-flex-none s-text-left">
+            I'm the modal content
+          </div>
+          <div className="s-w-64">
+            The text is: <span className="font-bold">{element?.text}</span>
+          </div>
+        </div>
+      </ElementModal>
+      <div className="s-flex s-flex-col s-items-start s-gap-3">
+        <div className="s-text-lg s-font-bold">Fullscreen</div>
+        <Button
+          onClick={() => setElement({ text: "Element 1" })}
+          label="Element 1"
+        />
+        <Button
+          onClick={() => setElement({ text: "Element 2" })}
+          label="Element 2"
+        />
+        <Button
+          onClick={() => setElement({ text: "Element 3" })}
+          label="Element 3"
+        />
+      </div>
+    </Page.Layout>
+  );
+};


### PR DESCRIPTION
## Description

This component, based on `Modal`, is for modals that render based on a given variable
element--e.g. AssistantDetails (e.g. [here](https://github.com/dust-tt/dust/blob/0ad44c420f3e2087ccbced72f689b848f9516292/front/pages/w/%5BwId%5D/assistant/assistants.tsx#L103), renders given an assistant, and does not render if null) or `ChangeRoleMember` (e.g. [here](https://github.com/dust-tt/dust/blob/70246756d122dca3ee7b8b72c823ddceec198c4d/front/pages/w/%5BwId%5D/members/index.tsx#L319), renders given a member, and does not render if null),

The existing way of doing this relies either
- on conditional rendering (as in AssistantDetails) => the problem with this approach is 'snap closing', the animation when closing the modal is skipped because it's derendered;

- on closing using two states (open/close + element to show, as in ChangeRoleMember) & a setTimeout to set the element to show to null after a timeout. The timeout is necessary

The new `ElementModal` abstracts this complexity and allows clean closing with transition

## Usage
To use, instead of
```
<Modal isOpen={modalBoolean} onClose={() => setModalBoolean(false)>
modal children
</Modal>
```

you can do
```
<ElementModal 
   openOnElement={modalElement} 
   onClose{() =>setModalElement(null)>
modal children (that renders according to element)
</ElementModal>
```
## Example Element Modals (Assitant Details and ChangeRoleMember)
![image](https://github.com/dust-tt/dust/assets/5437393/2aa10a1b-a6f4-4b9b-a7b6-8507e23c28a9) 
![image](https://github.com/dust-tt/dust/assets/5437393/eafc3dfb-55d2-489f-a02c-dd6e8632142b)
## Smooth closing
https://www.loom.com/share/1a3aedfefdbe43238ff73d51b83da8c5?sid=ebd5b9f7-3ccc-47f2-92e2-7227f0e4db52

## Risk
None
## Deploy
A follow-up PR will bump sparkle & update the example modals in front
