### PR TITLE
enh(csv parsing): add support for trailing empty cols

### DIFF
--- a/front/lib/api/tables.ts
+++ b/front/lib/api/tables.ts
@@ -286,20 +286,20 @@ async function rowsFromCsv(
     if (!header) {
       header = [];
       const firstRecordCells = record.map((h) => h.trim().toLocaleLowerCase());
-      let emptyHeaderCellFound = false;
-      for (const r of firstRecordCells) {
-        if (r === "") {
-          emptyHeaderCellFound = true;
-        } else {
-          if (emptyHeaderCellFound) {
-            return new Err({
-              type: "invalid_header",
-              message: `Invalid header: found non-empty cell after empty cell.`,
-            });
-          }
-          header.push(r);
+      const firstEmptyCellIndex = firstRecordCells.indexOf("");
+      if (firstEmptyCellIndex !== -1) {
+        // Ensure there are no non-empty cells after the first empty cell.
+        if (firstRecordCells.slice(firstEmptyCellIndex).some((c) => c !== "")) {
+          return new Err({
+            type: "invalid_header",
+            message: `Invalid header: found non-empty cell after empty cell.`,
+          });
         }
       }
+      header = firstRecordCells.slice(
+        0,
+        firstEmptyCellIndex === -1 ? undefined : firstEmptyCellIndex
+      );
       const headerSet = new Set<string>();
       for (const h of header) {
         if (headerSet.has(h)) {

--- a/front/lib/api/tables.ts
+++ b/front/lib/api/tables.ts
@@ -14,6 +14,7 @@ import logger from "@app/logger/logger";
 type CsvParsingError = {
   type:
     | "invalid_delimiter"
+    | "invalid_header"
     | "duplicate_header"
     | "invalid_record_length"
     | "empty_csv"
@@ -283,20 +284,33 @@ async function rowsFromCsv(
     const record = anyRecord as string[];
 
     if (!header) {
-      header = record;
-      continue;
-    }
-
-    header = header.map((h) => h.trim().toLowerCase());
-    const headerSet = new Set<string>();
-    for (const h of header) {
-      if (headerSet.has(h)) {
-        return new Err({
-          type: "duplicate_header",
-          message: `Duplicate header: ${h}.`,
-        });
+      header = [];
+      const firstRecordCells = record.map((h) => h.trim().toLocaleLowerCase());
+      let emptyHeaderCellFound = false;
+      for (const r of firstRecordCells) {
+        if (r === "") {
+          emptyHeaderCellFound = true;
+        } else {
+          if (emptyHeaderCellFound) {
+            return new Err({
+              type: "invalid_header",
+              message: `Invalid header: found non-empty cell after empty cell.`,
+            });
+          }
+          header.push(r);
+        }
       }
-      headerSet.add(h);
+      const headerSet = new Set<string>();
+      for (const h of header) {
+        if (headerSet.has(h)) {
+          return new Err({
+            type: "duplicate_header",
+            message: `Duplicate header: ${h}.`,
+          });
+        }
+        headerSet.add(h);
+      }
+      continue;
     }
 
     for (const [i, h] of header.entries()) {


### PR DESCRIPTION
## Description

https://dust4ai.slack.com/archives/C050A0S2Z7F/p1707900458602159

The idea is to add support for CSVs that look like this:
<img width="515" alt="Screenshot 2024-02-14 at 13 12 01" src="https://github.com/dust-tt/dust/assets/14199823/a1c3be75-a058-4120-adfe-fb9fb6a99fa4">

It appears that apple numbers tends to generate such CSVs, so this might actually be fairly common.

Caveat:
- if only the header is empty but the column itself contains non-empty values, the whole column will still be ignored (we can't easily work without a header anyway)
- We still don't support empty (as in header-empty) columns that are in the middle of non-empty columns (it's unclear if this is desirable or not)

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
