### PR TITLE
Sparkle: banner component update

### DIFF
--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.92",
+  "version": "0.2.93",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/components/Banner.tsx
+++ b/sparkle/src/components/Banner.tsx
@@ -8,11 +8,12 @@ interface BannerProps {
   allowDismiss: boolean;
   classNames: string;
   ctaLabel?: string;
-  hidden: boolean;
   label: string;
+  hidden: boolean;
   onClick?: () => void;
   onDismiss?: () => void;
-  title: string;
+  title: string | React.ReactNode;
+  children?: React.ReactNode;
 }
 
 // Define defaultProps for the Banner component.
@@ -47,7 +48,7 @@ export function Banner(props: BannerProps) {
             className="s-mx-2 s-inline s-h-0.5 s-w-0.5 s-fill-current"
             aria-hidden="true"
           ></svg>
-          {props.label}
+          {props.children ?? props.label}
         </p>
         {props.ctaLabel && (
           <Button
@@ -58,18 +59,20 @@ export function Banner(props: BannerProps) {
         )}
       </div>
       <div className="s-flex s-flex-1 s-justify-end">
-        <a
-          className="focus-visible:outline-offset-[-4px] s--m-3 s-p-3"
-          onClick={() => {
-            setIsDismissed(true);
-            if (props.onDismiss) {
-              props.onDismiss();
-            }
-          }}
-        >
-          <span className="s-sr-only">Dismiss</span>
-          <XMark className="s-h-5 s-w-5 s-text-white" aria-hidden="true" />
-        </a>
+        {props.allowDismiss && (
+          <a
+            className="focus-visible:outline-offset-[-4px] s--m-3 s-p-3"
+            onClick={() => {
+              setIsDismissed(true);
+              if (props.onDismiss) {
+                props.onDismiss();
+              }
+            }}
+          >
+            <span className="s-sr-only">Dismiss</span>
+            <XMark className="s-h-5 s-w-5 s-text-white" aria-hidden="true" />
+          </a>
+        )}
       </div>
     </div>
   );

--- a/sparkle/src/stories/Banner.stories.tsx
+++ b/sparkle/src/stories/Banner.stories.tsx
@@ -25,3 +25,40 @@ export const BasicBanner = () => {
     </div>
   );
 };
+
+export const IncidentBanner = () => {
+  return (
+    <div className="s-h-full s-w-full">
+      <Banner
+        allowDismiss={false}
+        classNames="s-bg-amber-600"
+        title={
+          <span className="font-bold">
+            OpenAI APIs are encountering a{" "}
+            <a
+              href="https://status.openai.com/"
+              target="_blank"
+              className="s-underline"
+            >
+              partial outage.
+            </a>
+          </span>
+        }
+        label=""
+      >
+        <span>
+          It may cause slowness and errors from assistants using GPT or data
+          retrieval. We are monitoring the situation{" "}
+          <a
+            href="http://status.dust.tt/"
+            target="_blank"
+            className="s-underline"
+          >
+            here
+          </a>
+          .
+        </span>
+      </Banner>
+    </div>
+  );
+};


### PR DESCRIPTION
## Description
- Enables `allowDismiss` that removes dismiss button if false
- Allows for children instead of label, and allows a ReactNode title

The goal is to reuse the component for our incident banner
![image](https://github.com/dust-tt/dust/assets/5437393/ca0dc33e-8f94-47fe-b650-b32fb31ad315)

