### PR TITLE
Stripe: Add workspace to subscription metadata

### DIFF
--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -106,6 +106,12 @@ export const createCheckoutSession = async ({
     client_reference_id: owner.sId,
     customer_email: user.email,
     customer: auth.subscription()?.stripeCustomerId || undefined,
+    subscription_data: {
+      metadata: {
+        planCode: planCode,
+        workspaceId: owner.sId,
+      },
+    },
     metadata: {
       planCode: planCode,
     },


### PR DESCRIPTION
## Description

This adds metadata to the subscription, to easily find the workspace associated to a subscription in Stripe. 
This will be only for newly created subscriptions.
I added the code of the plan and the id of the workspace (I tried directly adding the link to Poké but links are treated as strings)


Stripe doc: https://support.stripe.com/questions/how-metadata-works-with-related-objects

Here's how it look like: 
<img width="595" alt="Screenshot 2024-02-14 at 18 44 00" src="https://github.com/dust-tt/dust/assets/3803406/06302537-f568-47cb-a4ed-a471b1995b89">

(https://dashboard.stripe.com/test/subscriptions/sub_1OjmRMDKd2JRwZF6TclFbFcG)


## Risk

Break subscriptions, but I tested on my local. 

## Deploy Plan

Nothing special. 
