### PR TITLE
Add log for Event Stripe charge dispute created

### DIFF
--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -419,6 +419,13 @@ async function handler(
             );
           }
           break;
+        case "charge.dispute.created":
+          const dispute = event.data.object as Stripe.Dispute;
+          logger.error(
+            { dispute },
+            "[Stripe Webhook] Received charge.dispute.created event. Please make sure the subscription is now marked as 'ended' in our database and canceled on Stripe."
+          );
+          break;
         case "customer.subscription.updated":
           // Occurs when the subscription is updated:
           // - when the number of seats changes for a metered billing.


### PR DESCRIPTION
## Description

Just add a log to be notified if there's a new dispute. 
Stripe is configured here to end the subscription: https://dashboard.stripe.com/settings/billing/automatic

## Risk

Low, it's just a new log. 

## Deploy Plan

Activate the new topic on the prod webhook: Done ✅ 
Nothing special. 
