### PR TITLE
Intercom: Workaround url if the Help Center website is not activated

### DIFF
--- a/connectors/src/connectors/intercom/lib/help_center_permissions.ts
+++ b/connectors/src/connectors/intercom/lib/help_center_permissions.ts
@@ -12,6 +12,7 @@ import {
   getIntercomClient,
 } from "@connectors/connectors/intercom/lib/intercom_api";
 import {
+  getArticleInAppUrl,
   getHelpCenterArticleInternalId,
   getHelpCenterCollectionIdFromInternalId,
   getHelpCenterCollectionInternalId,
@@ -49,7 +50,7 @@ export async function allowSyncHelpCenter({
   intercomClient: IntercomClient;
   helpCenterId: string;
   withChildren?: boolean;
-}): Promise<IntercomHelpCenter | null> {
+}): Promise<IntercomHelpCenter> {
   let helpCenter = await IntercomHelpCenter.findOne({
     where: {
       connectorId: connector.id,
@@ -74,6 +75,7 @@ export async function allowSyncHelpCenter({
         name: helpCenterOnIntercom.display_name || "Help Center",
         identifier: helpCenterOnIntercom.identifier,
         intercomWorkspaceId: helpCenterOnIntercom.workspace_id,
+        websiteTurnedOn: helpCenterOnIntercom.website_turned_on,
         permission: "read",
       });
     }
@@ -84,7 +86,7 @@ export async function allowSyncHelpCenter({
     throw new Error("Help Center not found.");
   }
 
-  // If withChilren we are allowing the full Help Center.
+  // If withChildren we are allowing the full Help Center.
   if (withChildren) {
     const level1Collections = await fetchIntercomCollections(
       intercomClient,
@@ -215,12 +217,13 @@ export async function allowSyncCollection({
   }
 
   // We create the Help Center if it doesn't exist.
-  await allowSyncHelpCenter({
+  const helpCenter = await allowSyncHelpCenter({
     connector,
     intercomClient,
     helpCenterId: collection.helpCenterId,
     withChildren: false,
   });
+  const isHelpCenterWebsiteTurnedOn = helpCenter.websiteTurnedOn;
 
   // We  set all children (collections & articles) to "read" and create them if they don't exist.
   const childrenArticles = await fetchIntercomArticles(
@@ -232,6 +235,7 @@ export async function allowSyncCollection({
       connector,
       intercomClient,
       articleId: a.id,
+      isHelpCenterWebsiteTurnedOn,
     })
   );
   await Promise.all(articlePermissionPromises);
@@ -348,10 +352,12 @@ export async function allowSyncArticle({
   connector,
   intercomClient,
   articleId,
+  isHelpCenterWebsiteTurnedOn,
 }: {
   connector: ConnectorModel;
   intercomClient: IntercomClient;
   articleId: string;
+  isHelpCenterWebsiteTurnedOn: boolean;
 }): Promise<IntercomArticle | null> {
   const article = await IntercomArticle.findOne({
     where: {
@@ -378,11 +384,19 @@ export async function allowSyncArticle({
     );
     return null;
   }
+
+  // Article url is working only if the help center has activated the website feature
+  // Otherwise they generate an url that is not working
+  // So as a workaround we use the url of the article in the intercom app
+  const articleUrl = isHelpCenterWebsiteTurnedOn
+    ? intercomArticle.url
+    : getArticleInAppUrl(intercomArticle);
+
   return IntercomArticle.create({
     connectorId: connector.id,
     articleId: intercomArticle.id,
     title: intercomArticle.title,
-    url: intercomArticle.url,
+    url: articleUrl,
     intercomWorkspaceId: intercomArticle.workspace_id,
     authorId: intercomArticle.author_id,
     parentId: intercomArticle.parent_id,

--- a/connectors/src/connectors/intercom/lib/intercom_api.ts
+++ b/connectors/src/connectors/intercom/lib/intercom_api.ts
@@ -37,7 +37,7 @@ export type IntercomCollectionType = CollectionObject & {
   parent_id: string;
 };
 
-type IntercomArticleType = ArticleObject & {
+export type IntercomArticleType = ArticleObject & {
   parent_ids: string[];
 };
 

--- a/connectors/src/connectors/intercom/lib/utils.ts
+++ b/connectors/src/connectors/intercom/lib/utils.ts
@@ -1,5 +1,7 @@
 import type { ModelId } from "@dust-tt/types";
 
+import type { IntercomArticleType } from "@connectors/connectors/intercom/lib/intercom_api";
+
 /**
  * From id to internalId
  */
@@ -66,4 +68,8 @@ export function getTeamIdFromInternalId(
   internalId: string
 ): string | null {
   return _getIdFromInternal(internalId, `intercom-team-${connectorId}-`);
+}
+
+export function getArticleInAppUrl(article: IntercomArticleType) {
+  return `https://app.intercom.com/a/apps/${article.workspace_id}/articles/articles/${article.id}/show`;
 }

--- a/connectors/src/connectors/intercom/temporal/activities.ts
+++ b/connectors/src/connectors/intercom/temporal/activities.ts
@@ -179,6 +179,7 @@ export async function syncHelpCenterOnlyActivity({
   // Otherwise we update the help center name and lastUpsertedTs
   await helpCenterOnDb.update({
     name: helpCenterOnIntercom.display_name || "Help Center",
+    websiteTurnedOn: helpCenterOnIntercom.website_turned_on,
     lastUpsertedTs: new Date(currentSyncMs),
   });
   return true;
@@ -231,6 +232,20 @@ export async function syncCollectionActivity({
     dataSourceName: dataSourceConfig.dataSourceName,
   };
 
+  const helpCenter = await IntercomHelpCenter.findOne({
+    where: {
+      connectorId,
+      helpCenterId,
+    },
+  });
+  if (!helpCenter) {
+    logger.error(
+      { loggerArgs, helpCenterId },
+      "[Intercom] Collection to sync is missing a Help Center"
+    );
+    return;
+  }
+
   const collection = await IntercomCollection.findOne({
     where: {
       connectorId,
@@ -248,9 +263,10 @@ export async function syncCollectionActivity({
   await syncCollection({
     connectorId,
     connectionId: connector.connectionId,
+    isHelpCenterWebsiteTurnedOn: helpCenter.websiteTurnedOn,
+    collection,
     dataSourceConfig,
     loggerArgs,
-    collection,
     currentSyncMs,
   });
 }

--- a/connectors/src/lib/models/intercom.ts
+++ b/connectors/src/lib/models/intercom.ts
@@ -81,6 +81,7 @@ export class IntercomHelpCenter extends Model<
 
   declare name: string;
   declare identifier: string;
+  declare websiteTurnedOn: boolean;
 
   declare lastUpsertedTs?: Date;
   declare permission: "read" | "none";
@@ -119,6 +120,11 @@ IntercomHelpCenter.init(
     identifier: {
       type: DataTypes.STRING,
       allowNull: false,
+    },
+    websiteTurnedOn: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
     },
     lastUpsertedTs: {
       type: DataTypes.DATE,


### PR DESCRIPTION
## Description

Intercom API expose a `url` field for articles, that is set when the article is published. 
Problem is when the help center website is not published, these url don't work. 

This PR manages a workaround to use the url of the article inside the intercom app if the help center website is not activated.

## Risk

Low, only Dust has an intercom connection at the moment. 

## Deploy Plan

Merge on Edge to run init_db before deploying to prod. 
