### PR TITLE
WebCrawler: re-crawl on settings update + garbage collector

### DIFF
--- a/connectors/src/api_server.ts
+++ b/connectors/src/api_server.ts
@@ -22,6 +22,7 @@ import { webhookGithubAPIHandler } from "@connectors/api/webhooks/webhook_github
 import { webhookGoogleDriveAPIHandler } from "@connectors/api/webhooks/webhook_google_drive";
 import { webhookIntercomAPIHandler } from "@connectors/api/webhooks/webhook_intercom";
 import { webhookSlackAPIHandler } from "@connectors/api/webhooks/webhook_slack";
+import { getWebcrawlerConfiguration } from "@connectors/connectors/webcrawler";
 import logger from "@connectors/logger/logger";
 import { authMiddleware } from "@connectors/middleware/auth";
 
@@ -131,6 +132,11 @@ export function startServer(port: number) {
   app.get(
     "/connectors/:connector_id/config/:config_key",
     getConnectorConfigAPIHandler
+  );
+
+  app.get(
+    "/connectors/webcrawler/:connector_id/configuration",
+    getWebcrawlerConfiguration
   );
 
   const server = app.listen(port, () => {

--- a/connectors/src/connectors/webcrawler/index.ts
+++ b/connectors/src/connectors/webcrawler/index.ts
@@ -3,7 +3,11 @@ import type {
   ConnectorsAPIError,
   CreateConnectorUrlRequestBody,
   ModelId,
+  WebCrawlerConfigurationType,
+  WithConnectorsAPIErrorReponse,
 } from "@dust-tt/types";
+import { DepthOptions, isDepthOption } from "@dust-tt/types";
+import type { Request, Response } from "express";
 
 import {
   getDisplayNameForPage,
@@ -18,6 +22,7 @@ import {
 import type { Result } from "@connectors/lib/result.js";
 import { Err, Ok } from "@connectors/lib/result.js";
 import logger from "@connectors/logger/logger";
+import { apiError, withLogging } from "@connectors/logger/withlogging";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { sequelizeConnection } from "@connectors/resources/storage";
 import { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
@@ -33,6 +38,10 @@ export async function createWebcrawlerConnector(
   dataSourceConfig: DataSourceConfig,
   urlConfig: CreateConnectorUrlRequestBody
 ): Promise<Result<string, Error>> {
+  const depth = urlConfig.depth;
+  if (!isDepthOption(depth)) {
+    return new Err(new Error("Invalid depth option"));
+  }
   const res = await sequelizeConnection.transaction(
     async (t): Promise<Result<ConnectorModel, Error>> => {
       const connector = await ConnectorModel.create(
@@ -52,7 +61,7 @@ export async function createWebcrawlerConnector(
           url: urlConfig.url,
           maxPageToCrawl: urlConfig.maxPages,
           crawlMode: urlConfig.crawlMode,
-          depth: urlConfig.depth,
+          depth: depth,
           crawlFrequency: urlConfig.crawlFrequency,
         },
         {
@@ -91,13 +100,22 @@ export async function updateWebcrawlerConnector(
       type: "connector_not_found",
     });
   }
+  const depth = urlConfig.depth;
+  if (!isDepthOption(depth)) {
+    return new Err({
+      message: `Invalid depth option. Expected one of: (${DepthOptions.join(
+        ","
+      )})`,
+      type: "invalid_request_error",
+    });
+  }
 
   await WebCrawlerConfiguration.update(
     {
       url: urlConfig.url,
       maxPageToCrawl: urlConfig.maxPages,
       crawlMode: urlConfig.crawlMode,
-      depth: urlConfig.depth,
+      depth: depth,
       crawlFrequency: urlConfig.crawlFrequency,
     },
     {
@@ -106,6 +124,20 @@ export async function updateWebcrawlerConnector(
       },
     }
   );
+  const stopRes = await stopCrawlWebsiteWorkflow(connector.id);
+  if (stopRes.isErr()) {
+    return new Err({
+      message: stopRes.error.message,
+      type: "internal_server_error",
+    });
+  }
+  const startRes = await launchCrawlWebsiteWorkflow(connector.id);
+  if (startRes.isErr()) {
+    return new Err({
+      message: startRes.error.message,
+      type: "internal_server_error",
+    });
+  }
 
   return new Ok(connector.id.toString());
 }
@@ -327,3 +359,45 @@ export async function retrieveWebCrawlerObjectsParents(
 
   return new Ok(parents);
 }
+
+type GetWebCrawlerConfigurationResBody =
+  WithConnectorsAPIErrorReponse<WebCrawlerConfigurationType>;
+
+async function _getWebcrawlerConfiguration(
+  req: Request<{ connector_id: string }, GetWebCrawlerConfigurationResBody>,
+  res: Response<GetWebCrawlerConfigurationResBody>
+) {
+  const connector = await ConnectorModel.findByPk(req.params.connector_id);
+  if (!connector) {
+    return apiError(req, res, {
+      api_error: {
+        type: "connector_not_found",
+        message: "Connector not found",
+      },
+      status_code: 404,
+    });
+  }
+  const config = await WebCrawlerConfiguration.findOne({
+    where: { connectorId: connector.id },
+  });
+  if (!config) {
+    return apiError(req, res, {
+      api_error: {
+        type: "internal_server_error",
+        message: "Connector config not found",
+      },
+      status_code: 404,
+    });
+  }
+  return res.status(200).json({
+    url: config.url,
+    maxPageToCrawl: config.maxPageToCrawl,
+    crawlMode: config.crawlMode,
+    depth: config.depth,
+    crawlFrequency: config.crawlFrequency,
+  });
+}
+
+export const getWebcrawlerConfiguration = withLogging(
+  _getWebcrawlerConfiguration
+);

--- a/connectors/src/connectors/webcrawler/index.ts
+++ b/connectors/src/connectors/webcrawler/index.ts
@@ -93,7 +93,7 @@ export async function updateWebcrawlerConnector(
   connectorId: ModelId,
   urlConfig: CreateConnectorUrlRequestBody
 ): Promise<Result<string, ConnectorsAPIError>> {
-  const connector = await ConnectorModel.findByPk(connectorId);
+  const connector = await ConnectorResource.fetchById(connectorId);
   if (!connector) {
     return new Err({
       message: "Connector not found",
@@ -367,7 +367,7 @@ async function _getWebcrawlerConfiguration(
   req: Request<{ connector_id: string }, GetWebCrawlerConfigurationResBody>,
   res: Response<GetWebCrawlerConfigurationResBody>
 ) {
-  const connector = await ConnectorModel.findByPk(req.params.connector_id);
+  const connector = await ConnectorResource.fetchById(req.params.connector_id);
   if (!connector) {
     return apiError(req, res, {
       api_error: {

--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -4,6 +4,7 @@ import { WEBCRAWLER_MAX_DEPTH, WEBCRAWLER_MAX_PAGES } from "@dust-tt/types";
 import { Context } from "@temporalio/activity";
 import { isCancellation } from "@temporalio/workflow";
 import { CheerioCrawler, Configuration } from "crawlee";
+import { Op } from "sequelize";
 import turndown from "turndown";
 
 import {
@@ -16,6 +17,7 @@ import {
 import { REQUEST_HANDLING_TIMEOUT } from "@connectors/connectors/webcrawler/temporal/workflows";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import {
+  deleteFromDataSource,
   MAX_DOCUMENT_TXT_LEN,
   upsertToDatasource,
 } from "@connectors/lib/data_sources";
@@ -66,6 +68,7 @@ export async function crawlWebsiteByConnectorId(connectorId: ModelId) {
         Context.current().heartbeat({
           type: "http_request",
         });
+        const currentRequestDepth = request.userData.depth || 0;
 
         // try-catch allowing activity cancellation by temporal (timeout, or signal)
         try {
@@ -85,7 +88,7 @@ export async function crawlWebsiteByConnectorId(connectorId: ModelId) {
 
         await enqueueLinks({
           userData: {
-            depth: request.userData.depth ? request.userData.depth + 1 : 1,
+            depth: currentRequestDepth + 1,
           },
           transformRequestFunction: (req) => {
             if (webCrawlerConfig.crawlMode === "child") {
@@ -100,9 +103,8 @@ export async function crawlWebsiteByConnectorId(connectorId: ModelId) {
               }
             }
             if (
-              request.userData.depth > WEBCRAWLER_MAX_DEPTH ||
-              (webCrawlerConfig.depth &&
-                request.userData.depth > webCrawlerConfig.depth)
+              req.userData?.depth >= WEBCRAWLER_MAX_DEPTH ||
+              req.userData?.depth >= webCrawlerConfig.depth
             ) {
               logger.info(
                 {
@@ -142,6 +144,7 @@ export async function crawlWebsiteByConnectorId(connectorId: ModelId) {
               url: folder,
               ressourceType: "folder",
             }),
+            lastSeenAt: new Date(),
           });
 
           createdFolders.add(folder);
@@ -160,6 +163,8 @@ export async function crawlWebsiteByConnectorId(connectorId: ModelId) {
           webcrawlerConfigurationId: webCrawlerConfig.id,
           documentId: documentId,
           title: pageTitle,
+          depth: currentRequestDepth,
+          lastSeenAt: new Date(),
         });
 
         Context.current().heartbeat({
@@ -271,4 +276,63 @@ function formatDocumentContent({
     content: `TITLE: ${title.substring(0, TITLE_MAX_LENGTH)}\n${content}`,
     sections: [],
   };
+}
+
+export async function webCrawlerGarbageCollector(
+  connectorId: ModelId,
+  lastSyncStartTsMs: number
+) {
+  const connector = await ConnectorModel.findByPk(connectorId);
+  if (!connector) {
+    throw new Error(`Connector ${connectorId} not found.`);
+  }
+  const webCrawlerConfig = await WebCrawlerConfiguration.findOne({
+    where: {
+      connectorId,
+    },
+  });
+  if (!webCrawlerConfig) {
+    throw new Error(`Webcrawler configuration not found for connector.`);
+  }
+  const dataSourceConfig = dataSourceConfigFromConnector(connector);
+  let pagesToDelete: WebCrawlerPage[] = [];
+  do {
+    pagesToDelete = await WebCrawlerPage.findAll({
+      where: {
+        connectorId,
+        webcrawlerConfigurationId: webCrawlerConfig.id,
+        lastSeenAt: {
+          [Op.lt]: new Date(lastSyncStartTsMs),
+        },
+      },
+      limit: 100,
+    });
+    for (const page of pagesToDelete) {
+      Context.current().heartbeat({
+        type: "delete_page",
+      });
+      await deleteFromDataSource(dataSourceConfig, page.documentId);
+      await page.destroy();
+    }
+  } while (pagesToDelete.length > 0);
+
+  let foldersToDelete: WebCrawlerFolder[] = [];
+  do {
+    foldersToDelete = await WebCrawlerFolder.findAll({
+      where: {
+        connectorId,
+        webcrawlerConfigurationId: webCrawlerConfig.id,
+        lastSeenAt: {
+          [Op.lt]: new Date(lastSyncStartTsMs),
+        },
+      },
+      limit: 100,
+    });
+    Context.current().heartbeat({
+      type: "delete_folder",
+    });
+    for (const folder of foldersToDelete) {
+      await folder.destroy();
+    }
+  } while (foldersToDelete.length > 0);
 }

--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -282,7 +282,7 @@ export async function webCrawlerGarbageCollector(
   connectorId: ModelId,
   lastSyncStartTsMs: number
 ) {
-  const connector = await ConnectorModel.findByPk(connectorId);
+  const connector = await ConnectorResource.fetchById(connectorId);
   if (!connector) {
     throw new Error(`Connector ${connectorId} not found.`);
   }

--- a/connectors/src/lib/models/webcrawler.ts
+++ b/connectors/src/lib/models/webcrawler.ts
@@ -1,4 +1,4 @@
-import type { CrawlingFrequency } from "@dust-tt/types";
+import type { CrawlingFrequency, DepthOption } from "@dust-tt/types";
 import type {
   CreationOptional,
   ForeignKey,
@@ -19,9 +19,9 @@ export class WebCrawlerConfiguration extends Model<
   declare updatedAt: CreationOptional<Date>;
   declare url: string;
   declare connectorId: ForeignKey<ConnectorModel["id"]>;
-  declare maxPageToCrawl: number | null;
+  declare maxPageToCrawl: number;
   declare crawlMode: "child" | "website";
-  declare depth: number | null;
+  declare depth: DepthOption;
   declare crawlFrequency: CrawlingFrequency;
 }
 
@@ -57,7 +57,7 @@ WebCrawlerConfiguration.init(
     },
     depth: {
       type: DataTypes.INTEGER,
-      allowNull: true,
+      allowNull: false,
     },
     crawlFrequency: {
       type: DataTypes.STRING(20),
@@ -85,6 +85,7 @@ export class WebCrawlerFolder extends Model<
   // Folders are not upserted to the data source but their ids are
   // used as parent to WebCrawlerPage.
   declare internalId: string;
+  declare lastSeenAt: Date;
   declare connectorId: ForeignKey<ConnectorModel["id"]>;
   declare webcrawlerConfigurationId: ForeignKey<WebCrawlerConfiguration["id"]>;
 }
@@ -118,6 +119,11 @@ WebCrawlerFolder.init(
       type: DataTypes.STRING,
       allowNull: false,
     },
+    lastSeenAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
   },
   {
     sequelize: sequelizeConnection,
@@ -144,6 +150,8 @@ export class WebCrawlerPage extends Model<
   declare parentUrl: string | null;
   declare url: string;
   declare documentId: string;
+  declare depth: number;
+  declare lastSeenAt: Date;
   declare connectorId: ForeignKey<ConnectorModel["id"]>;
   declare webcrawlerConfigurationId: ForeignKey<WebCrawlerConfiguration["id"]>;
 }
@@ -180,6 +188,15 @@ WebCrawlerPage.init(
     documentId: {
       type: DataTypes.STRING,
       allowNull: false,
+    },
+    depth: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+    },
+    lastSeenAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
     },
   },
   {

--- a/front/components/data_source/WebsiteConfiguration.tsx
+++ b/front/components/data_source/WebsiteConfiguration.tsx
@@ -1,0 +1,365 @@
+import {
+  ContentMessage,
+  DropdownMenu,
+  Input,
+  Page,
+  RadioButton,
+} from "@dust-tt/sparkle";
+import type {
+  CrawlingFrequency,
+  DataSourceType,
+  DepthOption,
+  SubscriptionType,
+  UpdateConnectorRequestBodySchema,
+  WebCrawlerConfigurationType,
+  WorkspaceType,
+} from "@dust-tt/types";
+import type { APIError } from "@dust-tt/types";
+import {
+  CrawlingFrequencies,
+  DepthOptions,
+  WEBCRAWLER_MAX_PAGES,
+} from "@dust-tt/types";
+import type * as t from "io-ts";
+import { useRouter } from "next/router";
+import { useCallback, useEffect, useState } from "react";
+
+import AppLayout from "@app/components/sparkle/AppLayout";
+import { AppLayoutSimpleSaveCancelTitle } from "@app/components/sparkle/AppLayoutTitle";
+import { subNavigationBuild } from "@app/components/sparkle/navigation";
+import { urlToDataSourceName } from "@app/lib/webcrawler";
+import type { PostManagedDataSourceRequestBodySchema } from "@app/pages/api/w/[wId]/data_sources/managed";
+
+export default function WebsiteConfiguration({
+  owner,
+  subscription,
+  dataSources,
+  dataSource,
+  gaTrackingId,
+  webCrawlerConfiguration,
+}: {
+  owner: WorkspaceType;
+  subscription: SubscriptionType;
+  dataSources: DataSourceType[];
+  webCrawlerConfiguration: WebCrawlerConfigurationType | null;
+  dataSource: DataSourceType | null;
+  gaTrackingId: string;
+}) {
+  const [isSaving, setIsSaving] = useState(false);
+  const [isEdited, setIsEdited] = useState(false);
+  const [isValid, setIsValid] = useState(true);
+
+  const [dataSourceNameError, setDataSourceNameError] = useState("");
+  const [dataSourceUrl, setDataSourceUrl] = useState(
+    webCrawlerConfiguration?.url || ""
+  );
+  const [maxPages, setMaxPages] = useState<number | null>(
+    webCrawlerConfiguration?.maxPageToCrawl || 50
+  );
+  const [maxDepth, setMaxDepth] = useState<DepthOption>(
+    webCrawlerConfiguration ? webCrawlerConfiguration.depth : 2
+  );
+  const [crawlMode, setCrawlMode] = useState<"child" | "website">(
+    webCrawlerConfiguration?.crawlMode || "website"
+  );
+  const [selectedCrawlFrequency, setSelectedCrawlFrequency] =
+    useState<CrawlingFrequency>(
+      webCrawlerConfiguration?.crawlFrequency || "monthly"
+    );
+
+  const frequencyDisplayText: Record<CrawlingFrequency, string> = {
+    never: "Never",
+    daily: "Every day",
+    weekly: "Every week",
+    monthly: "Every month",
+  };
+
+  const depthDisplayText: Record<DepthOption, string> = {
+    0: "0 level",
+    1: "1 level",
+    2: "2 levels",
+    3: "3 levels",
+    4: "4 levels",
+    5: "5 levels",
+  };
+
+  const formValidation = useCallback(() => {
+    const urlRegex =
+      /^(https?:\/\/)?([\da-z.-]+)\.([a-z.]{2,6})([/\w .-]*)*\/?$/;
+
+    let edited = false;
+    let valid = true;
+
+    let exists = false;
+    const dsName = urlToDataSourceName(dataSourceUrl);
+    dataSources.forEach((d) => {
+      if (d.name == dsName && d.id != dataSource?.id) {
+        exists = true;
+      }
+    });
+    if (exists) {
+      setDataSourceNameError("A Folder with the same name already exists");
+      valid = false;
+    } else if (dataSourceUrl.length == 0) {
+      valid = false;
+      setDataSourceNameError("");
+    } else if (dataSourceUrl.startsWith("managed-")) {
+      setDataSourceNameError(
+        "DataSource name cannot start with the prefix `managed-`"
+      );
+      valid = false;
+    } else if (!dataSourceUrl.match(urlRegex)) {
+      setDataSourceNameError(
+        "Please provide a valid URL (e.g. https://example.com or https://example.com/a/b/c))"
+      );
+      valid = false;
+    } else {
+      edited = true;
+      setDataSourceNameError("");
+    }
+
+    setIsEdited(edited);
+    setIsValid(valid);
+  }, [dataSources, dataSourceUrl]);
+
+  useEffect(() => {
+    formValidation();
+  }, [formValidation]);
+
+  const router = useRouter();
+
+  const handleCreate = async () => {
+    setIsSaving(true);
+    if (webCrawlerConfiguration === null) {
+      const res = await fetch(`/api/w/${owner.sId}/data_sources/managed`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          urlConfig: {
+            url: dataSourceUrl,
+            maxPages: maxPages || WEBCRAWLER_MAX_PAGES,
+            depth: maxDepth,
+            crawlMode: crawlMode,
+            crawlFrequency: selectedCrawlFrequency,
+          },
+          type: "url",
+          provider: "webcrawler",
+          connectionId: undefined,
+        } satisfies t.TypeOf<typeof PostManagedDataSourceRequestBodySchema>),
+      });
+      if (res.ok) {
+        await router.push(`/w/${owner.sId}/builder/data-sources/public-urls`);
+      } else {
+        const err = (await res.json()) as { error: APIError };
+        setIsSaving(false);
+        window.alert(`Error creating DataSource: ${err.error.message}`);
+      }
+    } else if (dataSource) {
+      const res = await fetch(
+        `/api/w/${owner.sId}/data_sources/${encodeURIComponent(
+          dataSource.name
+        )}/managed/update`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            connectorParams: {
+              url: dataSourceUrl,
+              maxPages: maxPages || WEBCRAWLER_MAX_PAGES,
+              depth: maxDepth,
+              crawlMode: crawlMode,
+              crawlFrequency: selectedCrawlFrequency,
+            },
+          } satisfies t.TypeOf<typeof UpdateConnectorRequestBodySchema>),
+        }
+      );
+      if (res.ok) {
+        await router.push(`/w/${owner.sId}/builder/data-sources/public-urls`);
+      } else {
+        const err = (await res.json()) as { error: APIError };
+        setIsSaving(false);
+        window.alert(`Error creating DataSource: ${err.error.message}`);
+      }
+    }
+  };
+
+  return (
+    <AppLayout
+      subscription={subscription}
+      owner={owner}
+      gaTrackingId={gaTrackingId}
+      topNavigationCurrent="assistants"
+      subNavigation={subNavigationBuild({
+        owner,
+        current: "data_sources_static",
+      })}
+      titleChildren={
+        <AppLayoutSimpleSaveCancelTitle
+          title="Add a Website"
+          onSave={isValid && isEdited && !isSaving ? handleCreate : undefined}
+          onCancel={() => {
+            void router.push(
+              `/w/${owner.sId}/builder/data-sources/public-urls`
+            );
+          }}
+        />
+      }
+      hideSidebar={true}
+    >
+      <div className="py-8">
+        <Page.Layout direction="vertical" gap="xl">
+          <Page.Layout direction="vertical" gap="md">
+            <Page.H variant="h3">Website Entry Point</Page.H>
+            <Page.P>
+              Enter the address of the website you'd like to explore.
+            </Page.P>
+            <Input
+              placeholder="https://example.com/acticles"
+              value={dataSourceUrl}
+              onChange={(value) => setDataSourceUrl(value)}
+              error={dataSourceNameError}
+              name="dataSourceUrl"
+              showErrorLabel
+              className="text-sm"
+            />
+            <ContentMessage title="Ensure the webpage is public" variant="pink">
+              Only directly accessible (without authetification), public
+              websites will work here.
+            </ContentMessage>
+          </Page.Layout>
+
+          <Page.Layout direction="vertical" gap="md">
+            <Page.H variant="h3">Importation settings</Page.H>
+            <Page.P>
+              Adjust the settings in order to import only the data you are
+              interested in.
+            </Page.P>
+          </Page.Layout>
+          <div className="grid grid-cols-2 gap-x-6 gap-y-8">
+            <Page.Layout direction="vertical" sizing="grow">
+              <Page.SectionHeader
+                title="Crawling strategy"
+                description="Do you want to stay on the domain or expend outside?"
+              />
+              <RadioButton
+                value={crawlMode}
+                className="flex-col font-medium"
+                onChange={(value) => {
+                  setCrawlMode(value == "child" ? "child" : "website");
+                }}
+                name="crawlMode"
+                choices={[
+                  {
+                    label: "Only children pages",
+                    value: "child",
+                    disabled: false,
+                  },
+                  {
+                    label: "Follow all the links",
+                    value: "website",
+                    disabled: false,
+                  },
+                ]}
+              />
+            </Page.Layout>
+            <Page.Layout direction="vertical" sizing="grow">
+              <Page.SectionHeader
+                title="Refresh schedule"
+                description="How often would you like to check for updates?"
+              />
+              <div>
+                {(() => {
+                  return (
+                    <DropdownMenu>
+                      <DropdownMenu.Button
+                        label={frequencyDisplayText[selectedCrawlFrequency]}
+                      />
+                      <DropdownMenu.Items origin="topLeft">
+                        {CrawlingFrequencies.map((frequency) => {
+                          return (
+                            <DropdownMenu.Item
+                              selected={selectedCrawlFrequency == frequency}
+                              key={frequency}
+                              label={frequencyDisplayText[frequency]}
+                              onClick={() => {
+                                setSelectedCrawlFrequency(frequency);
+                              }}
+                            />
+                          );
+                        })}
+                      </DropdownMenu.Items>
+                    </DropdownMenu>
+                  );
+                })()}
+              </div>
+            </Page.Layout>
+            <Page.Layout direction="vertical" sizing="grow">
+              <Page.SectionHeader
+                title="Depth of Search"
+                description="How far from the starting page should we go?"
+              />
+              {(() => {
+                return (
+                  <DropdownMenu>
+                    <DropdownMenu.Button label={depthDisplayText[maxDepth]} />
+                    <DropdownMenu.Items origin="bottomLeft">
+                      {DepthOptions.map((depthOption) => {
+                        return (
+                          <DropdownMenu.Item
+                            selected={depthOption === maxDepth}
+                            key={depthOption}
+                            label={depthDisplayText[depthOption]}
+                            onClick={() => {
+                              setMaxDepth(depthOption);
+                            }}
+                          />
+                        );
+                      })}
+                    </DropdownMenu.Items>
+                  </DropdownMenu>
+                );
+              })()}
+            </Page.Layout>
+            <Page.Layout direction="vertical" sizing="grow">
+              <Page.SectionHeader
+                title="Page Limit"
+                description="What is the maximum number of pages you'd like to import?"
+              />
+              <Input
+                placeholder={WEBCRAWLER_MAX_PAGES.toString()}
+                value={maxPages?.toString() || ""}
+                onChange={(value) => {
+                  const parsed = parseInt(value);
+                  if (!isNaN(parsed)) {
+                    setMaxPages(parseInt(value));
+                  } else if (value == "") {
+                    setMaxPages(null);
+                  }
+                }}
+                showErrorLabel={
+                  maxPages &&
+                  maxPages > WEBCRAWLER_MAX_PAGES &&
+                  maxPages &&
+                  maxPages < 1
+                    ? false
+                    : true
+                }
+                error={
+                  (maxPages && maxPages > WEBCRAWLER_MAX_PAGES) ||
+                  (maxPages && maxPages < 1)
+                    ? `Maximum pages must be between 1 and ${WEBCRAWLER_MAX_PAGES}`
+                    : null
+                }
+                name="maxPages"
+              />
+            </Page.Layout>
+          </div>
+        </Page.Layout>
+      </div>
+    </AppLayout>
+  );
+}

--- a/front/components/data_source/WebsiteConfiguration.tsx
+++ b/front/components/data_source/WebsiteConfiguration.tsx
@@ -120,7 +120,7 @@ export default function WebsiteConfiguration({
 
     setIsEdited(edited);
     setIsValid(valid);
-  }, [dataSources, dataSourceUrl]);
+  }, [dataSourceUrl, dataSources, dataSource?.id]);
 
   useEffect(() => {
     formValidation();

--- a/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
@@ -27,6 +27,7 @@ import { assertNever } from "@dust-tt/types";
 import { connectorIsUsingNango, ConnectorsAPI } from "@dust-tt/types";
 import Nango from "@nangohq/frontend";
 import type { InferGetServerSidePropsType } from "next";
+import Link from "next/link";
 import { useRouter } from "next/router";
 import { useContext, useEffect, useState } from "react";
 
@@ -730,6 +731,7 @@ interface ConnectorUiConfig {
   displayDataSourceDetailsModal: boolean;
   displayManagePermissionButton: boolean;
   addDataButtonLabel: string | null;
+  displaySettingsButton: boolean;
 }
 
 function getRenderingConfigForConnectorProvider(
@@ -738,6 +740,7 @@ function getRenderingConfigForConnectorProvider(
   const commonConfig = {
     displayManagePermissionButton: true,
     addDataButtonLabel: "Add / Remove data",
+    displaySettingsButton: false,
   };
 
   switch (connectorProvider) {
@@ -759,18 +762,21 @@ function getRenderingConfigForConnectorProvider(
         displayDataSourceDetailsModal: true,
         displayManagePermissionButton: false,
         addDataButtonLabel: "Add / Remove data, manage permissions",
+        displaySettingsButton: false,
       };
     case "github":
       return {
         displayDataSourceDetailsModal: false,
         displayManagePermissionButton: false,
         addDataButtonLabel: "Add / Remove data, manage permissions",
+        displaySettingsButton: false,
       };
     case "webcrawler":
       return {
         displayDataSourceDetailsModal: false,
         displayManagePermissionButton: false,
         addDataButtonLabel: null,
+        displaySettingsButton: true,
       };
     default:
       assertNever(connectorProvider);
@@ -932,6 +938,7 @@ function ManagedDataSourceView({
     displayDataSourceDetailsModal,
     displayManagePermissionButton,
     addDataButtonLabel,
+    displaySettingsButton,
   } = getRenderingConfigForConnectorProvider(connectorProvider);
 
   return (
@@ -988,6 +995,23 @@ function ManagedDataSourceView({
                 }
               }}
             />
+          ) : (
+            <></>
+          )}
+          {isAdmin && displaySettingsButton ? (
+            <Link
+              className="ml-auto"
+              href={`/w/${owner.sId}/builder/data-sources/${encodeURIComponent(
+                dataSource.name
+              )}/edit-public-url`}
+            >
+              <Button
+                label="Settings"
+                variant="tertiary"
+                icon={LockIcon}
+                disabled={readOnly || !isAdmin}
+              />
+            </Link>
           ) : (
             <></>
           )}

--- a/types/src/connectors/api_handlers/create_connector.ts
+++ b/types/src/connectors/api_handlers/create_connector.ts
@@ -6,6 +6,7 @@ export const CreateConnectorUrlRequestBodySchema = t.type({
   maxPages: t.number,
   crawlMode: t.union([t.literal("child"), t.literal("website")]),
   crawlFrequency: t.union([
+    t.literal("never"),
     t.literal("daily"),
     t.literal("weekly"),
     t.literal("monthly"),

--- a/types/src/connectors/webcrawler.ts
+++ b/types/src/connectors/webcrawler.ts
@@ -1,5 +1,27 @@
 export const WEBCRAWLER_MAX_DEPTH = 5;
 export const WEBCRAWLER_MAX_PAGES = 512;
 
-export const CrawlingFrequencies = ["daily", "weekly", "monthly"] as const;
+export const CrawlingModes = ["child", "website"] as const;
+export type CrawlingMode = (typeof CrawlingModes)[number];
+
+export const CrawlingFrequencies = [
+  "never",
+  "daily",
+  "weekly",
+  "monthly",
+] as const;
 export type CrawlingFrequency = (typeof CrawlingFrequencies)[number];
+
+export const DepthOptions = [0, 1, 2, 3, 4, 5] as const;
+export type DepthOption = (typeof DepthOptions)[number];
+export type WebCrawlerConfigurationType = {
+  url: string;
+  maxPageToCrawl: number;
+  crawlMode: CrawlingMode;
+  depth: DepthOption;
+  crawlFrequency: CrawlingFrequency;
+};
+
+export function isDepthOption(value: unknown): value is DepthOption {
+  return DepthOptions.includes(value as DepthOption);
+}

--- a/types/src/front/lib/connectors_api.ts
+++ b/types/src/front/lib/connectors_api.ts
@@ -4,6 +4,7 @@ import {
   CreateConnectorUrlRequestBody,
 } from "../../connectors/api_handlers/create_connector";
 import { UpdateConnectorRequestBody } from "../../connectors/api_handlers/update_connector";
+import { WebCrawlerConfigurationType } from "../../connectors/webcrawler";
 import { ConnectorProvider } from "../../front/data_source";
 import { Err, Ok, Result } from "../../front/lib/result";
 import { LoggerInterface } from "../../shared/logger";
@@ -433,6 +434,24 @@ export class ConnectorsAPI {
       `${CONNECTORS_API}/slack/channels/linked_with_agent?connector_id=${encodeURIComponent(
         connectorId
       )}`,
+      {
+        method: "GET",
+        headers: this.getDefaultHeaders(),
+      }
+    );
+
+    return this._resultFromResponse(res);
+  }
+
+  async getWebCrawlerConfiguration({
+    connectorId,
+  }: {
+    connectorId: string;
+  }): Promise<ConnectorsAPIResponse<WebCrawlerConfigurationType>> {
+    const res = await fetch(
+      `${CONNECTORS_API}/connectors/webcrawler/${encodeURIComponent(
+        connectorId
+      )}/configuration`,
       {
         method: "GET",
         headers: this.getDefaultHeaders(),


### PR DESCRIPTION
## Description

Re-crawl a website when settings are changed.
This requires adding a garbage collector and factor the website creation UI as a React component to be re-used for website edition

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
- Lock deployments
- Deploy connectors edge
- run queries to set depth and max pages to all existing web crawler
- run connectors> initdb
- deploy connectors and front