### PR TITLE
enh: display proper error in front

### DIFF
--- a/front/lib/api/assistant/actions/tables_query.ts
+++ b/front/lib/api/assistant/actions/tables_query.ts
@@ -256,6 +256,7 @@ export async function* runTablesQuery({
       };
       return;
     }
+
     if (event.type === "block_execution") {
       const e = event.content.execution[0][0];
 
@@ -268,15 +269,24 @@ export async function* runTablesQuery({
           },
           "Error running query_tables app"
         );
+
+        const error =
+          e.error === "too_many_result_rows"
+            ? {
+                code: "too_many_result_rows" as const,
+                message: `The query returned too many rows. Please refine your query.`,
+              }
+            : {
+                code: "tables_query_error" as const,
+                message: `Error running TablesQuery app: ${e.error}`,
+              };
+
         yield {
           type: "tables_query_error",
           created: Date.now(),
           configurationId: configuration.sId,
           messageId: agentMessage.sId,
-          error: {
-            code: "tables_query_error",
-            message: `Error running TablesQuery app: ${e.error}`,
-          },
+          error,
         };
         return;
       }

--- a/types/src/front/lib/api/assistant/actions/tables_query.ts
+++ b/types/src/front/lib/api/assistant/actions/tables_query.ts
@@ -6,7 +6,10 @@ export type TablesQueryErrorEvent = {
   configurationId: string;
   messageId: string;
   error: {
-    code: string;
+    code:
+      | "tables_query_error"
+      | "tables_query_parameters_generation_error"
+      | "too_many_result_rows";
     message: string;
   };
 };


### PR DESCRIPTION
## Description

fixes https://github.com/dust-tt/dust/issues/3678

User-friendly error message for the `too_many_result_rows` error code.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
