### PR TITLE
fix: sqlite worker should always respond with a json body

### DIFF
--- a/core/bin/sqlite_worker.rs
+++ b/core/bin/sqlite_worker.rs
@@ -243,7 +243,9 @@ async fn databases_delete(
         axum::http::StatusCode::OK,
         Json(APIResponse {
             error: None,
-            response: None,
+            response: Some(json!({
+                "success": true,
+            })),
         }),
     )
 }
@@ -258,7 +260,9 @@ async fn expire_all(
         axum::http::StatusCode::OK,
         Json(APIResponse {
             error: None,
-            response: None,
+            response: Some(json!({
+                "success": true,
+            })),
         }),
     )
 }


### PR DESCRIPTION
## Description

It looks like when both error and response are None, there's no body

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
