### PR TITLE
Assistant new: Help button on Try modal

### DIFF
--- a/front/components/assistant/TryAssistantModal.tsx
+++ b/front/components/assistant/TryAssistantModal.tsx
@@ -22,11 +22,15 @@ import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 export function TryAssistantModal({
   owner,
   user,
+  title,
   assistant,
+  openWithConversation,
   onClose,
 }: {
   owner: WorkspaceType;
   user: UserType;
+  title?: string;
+  openWithConversation?: ConversationType;
   assistant: LightAgentConfigurationType;
   onClose: () => void;
 }) {
@@ -34,7 +38,7 @@ export function TryAssistantModal({
     { configurationId: assistant?.sId as string },
   ]);
   const [conversation, setConversation] = useState<ConversationType | null>(
-    null
+    openWithConversation ?? null
   );
   const sendNotification = useContext(SendNotificationsContext);
 
@@ -87,7 +91,7 @@ export function TryAssistantModal({
   return (
     <Modal
       isOpen={!!assistant}
-      title={`Trying @${assistant?.name}`}
+      title={title ?? `Trying @${assistant?.name}`}
       onClose={async () => {
         onClose();
         if (conversation && "sId" in conversation) {

--- a/front/pages/w/[wId]/assistant/new.tsx
+++ b/front/pages/w/[wId]/assistant/new.tsx
@@ -170,6 +170,34 @@ export default function AssistantNew({
     }
   );
 
+  const { submit: handleOpenHelpConversation } = useSubmitFunction(
+    async (content: string) => {
+      // We create a new test conversation with the helper and we open it in the Drawer
+      const conversationRes = await createConversationWithMessage({
+        owner,
+        user,
+        messageData: {
+          input: content.replace("@help", ":mention[help]{sId=helper}"),
+          mentions: [{ configurationId: "helper" }],
+        },
+        visibility: "test",
+      });
+      if (conversationRes.isErr()) {
+        if (conversationRes.error.type === "plan_limit_reached_error") {
+          setPlanLimitReached(true);
+        } else {
+          sendNotification({
+            title: conversationRes.error.title,
+            description: conversationRes.error.message,
+            type: "error",
+          });
+        }
+      } else {
+        setConversationHelperModal(conversationRes.value);
+      }
+    }
+  );
+
   const [shouldAnimateInput, setShouldAnimateInput] = useState<boolean>(false);
   const [greeting, setGreeting] = useState<string>("");
   const [selectedAssistant, setSelectedAssistant] =
@@ -190,51 +218,6 @@ export default function AssistantNew({
   useEffect(() => {
     setGreeting(getRandomGreetingForName(user.firstName));
   }, [user]);
-
-  function StartHelperConversationButton({
-    content,
-    variant = "tertiary",
-    size = "xs",
-  }: {
-    content: string;
-    variant?: "primary" | "secondary" | "tertiary";
-    size?: "sm" | "xs";
-  }) {
-    return (
-      <Button
-        variant={variant}
-        icon={ChatBubbleBottomCenterTextIcon}
-        label={content}
-        size={size}
-        hasMagnifying={false}
-        onClick={async () => {
-          // We create a new test conversation with the helper and we open it in the Drawer
-          const conversationRes = await createConversationWithMessage({
-            owner,
-            user,
-            messageData: {
-              input: content.replace("@help", ":mention[help]{sId=helper}"),
-              mentions: [{ configurationId: "helper" }],
-            },
-            visibility: "test",
-          });
-          if (conversationRes.isErr()) {
-            if (conversationRes.error.type === "plan_limit_reached_error") {
-              setPlanLimitReached(true);
-            } else {
-              sendNotification({
-                title: conversationRes.error.title,
-                description: conversationRes.error.message,
-                type: "error",
-              });
-            }
-          } else {
-            setConversationHelperModal(conversationRes.value);
-          }
-        }}
-      />
-    );
-  }
 
   return (
     <InputBarContext.Provider
@@ -347,8 +330,34 @@ export default function AssistantNew({
                         </div>
                         <Button.List isWrapping={true}>
                           <div className="flex flex-wrap gap-2">
-                            <StartHelperConversationButton content="@help, what can I use the assistants for?" />
-                            <StartHelperConversationButton content="@help, what are the limitations of assistants?" />
+                            <Button
+                              variant="tertiary"
+                              icon={ChatBubbleBottomCenterTextIcon}
+                              label={
+                                "@help, what can I use the assistants for?"
+                              }
+                              size="xs"
+                              hasMagnifying={false}
+                              onClick={async () => {
+                                await handleOpenHelpConversation(
+                                  "@help, what can I use the assistants for?"
+                                );
+                              }}
+                            />
+                            <Button
+                              variant="tertiary"
+                              icon={ChatBubbleBottomCenterTextIcon}
+                              label={
+                                "@help, what are the limitations of assistants?"
+                              }
+                              size="xs"
+                              hasMagnifying={false}
+                              onClick={async () => {
+                                await handleOpenHelpConversation(
+                                  "@help, what are the limitations of assistants?"
+                                );
+                              }}
+                            />
                           </div>
                         </Button.List>
                       </div>
@@ -413,7 +422,18 @@ export default function AssistantNew({
                           </div>
                           <Button.List isWrapping={true}>
                             <div className="flex flex-wrap gap-2">
-                              <StartHelperConversationButton content="@help, tell me about Data Sources" />
+                              <Button
+                                variant="tertiary"
+                                icon={ChatBubbleBottomCenterTextIcon}
+                                label={"@help, tell me about Data Sources"}
+                                size="xs"
+                                hasMagnifying={false}
+                                onClick={async () => {
+                                  await handleOpenHelpConversation(
+                                    "@help, tell me about Data Sources"
+                                  );
+                                }}
+                              />
                             </div>
                           </Button.List>
                         </div>


### PR DESCRIPTION
## Description

https://github.com/dust-tt/tasks/issues/418
Buttons to open conversations with help should open the drawer. 
Deploying on Edge to make it validated by Ed. 

Nothing is preventing the user from continuing the conversation in the drawer with another assistant, but even tho they visibility is to "test", the messages should be counted in `isMessagesLimitReached` so it's not a way to bypass the Free plan.

It's on https://front-edge.dust.tt/w/0ec9852c2f/assistant/new

## Risk

Low.

## Deploy Plan

Nothing special 
