### PR TITLE
Slugify CSV table name

### DIFF
--- a/front/pages/api/w/[wId]/data_sources/[name]/tables/csv.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/tables/csv.ts
@@ -1,4 +1,4 @@
-import { assertNever } from "@dust-tt/types";
+import { assertNever, slugify } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
@@ -147,12 +147,13 @@ export async function handlePostTableCsvUpsertRequest(
 
   const { name, description, csv } = bodyValidation.right;
   const tableId = bodyValidation.right.tableId ?? generateModelSId();
+  const slugifyName = slugify(name);
 
   const tableRes = await upsertTableFromCsv({
     owner,
     projectId: dataSource.dustAPIProjectId,
     dataSourceName,
-    tableName: name,
+    tableName: slugifyName,
     tableDescription: description,
     tableId,
     csv: csv ?? null,

--- a/types/src/shared/utils/string_utils.ts
+++ b/types/src/shared/utils/string_utils.ts
@@ -41,6 +41,7 @@ export function pluralize(count: number) {
 
 export function slugify(text: string) {
   return text
+    .replace(/([a-z])([A-Z0-9])/g, "$1_$2") // Get all lowercase letters that are near to uppercase ones and replace with _.
     .toLowerCase()
     .trim()
     .replace(/\s+/g, "_") // Replace spaces with _.

--- a/types/src/shared/utils/string_utils.ts
+++ b/types/src/shared/utils/string_utils.ts
@@ -38,3 +38,12 @@ function isTrailingLoneSurrogate(code: number): boolean {
 export function pluralize(count: number) {
   return count !== 1 ? "s" : "";
 }
+
+export function slugify(text: string) {
+  return text
+    .toLowerCase()
+    .trim()
+    .replace(/\s+/g, "_") // Replace spaces with _.
+    .replace(/[\W]+/g, "") // Replace all non-word characters with _.
+    .replace(/__+/g, "_"); // Replace multiple _ with single _.
+}


### PR DESCRIPTION
## Description

See https://github.com/dust-tt/dust/issues/3760.

This PR slugifies the CSV / table name for structured data so it's easier to query.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

### Examples

```
> slugify("Slack usage per workspace id - [VIEW] Slack missing membership per workspace")
'slack_usage_per_workspace_id_view_slack_missing_membership_per_workspace'

> slugify("MySqlTable")
'my_sql_table'

> slugify("My Table            Name")
'my_table_name'

> slugify("MyTest123")
'my_test_123'
```

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
