### PR TITLE
Flav/add v1 endpoint to list workspace ff

### DIFF
--- a/connectors/src/lib/workspace.ts
+++ b/connectors/src/lib/workspace.ts
@@ -9,7 +9,7 @@ async function getEnabledFeatureFlags(
 ): Promise<string[]> {
   const ds = dataSourceConfigFromConnector(connector);
 
-  // List the emails of all active members in the workspace.
+  // List the feature flags enabled for the workspace.
   const dustAPI = new DustAPI(
     {
       apiKey: ds.workspaceAPIKey,

--- a/connectors/src/lib/workspace.ts
+++ b/connectors/src/lib/workspace.ts
@@ -1,0 +1,42 @@
+import { cacheWithRedis, DustAPI } from "@dust-tt/types";
+
+import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
+import logger from "@connectors/logger/logger";
+import type { ConnectorResource } from "@connectors/resources/connector_resource";
+
+async function getEnabledFeatureFlags(
+  connector: ConnectorResource
+): Promise<string[]> {
+  const ds = dataSourceConfigFromConnector(connector);
+
+  // List the emails of all active members in the workspace.
+  const dustAPI = new DustAPI(
+    {
+      apiKey: ds.workspaceAPIKey,
+      workspaceId: ds.workspaceId,
+    },
+    logger,
+    { useLocalInDev: true }
+  );
+
+  const workspaceFeatureFlags = await dustAPI.getWorkspaceFeatureFlags();
+  if (workspaceFeatureFlags.isErr()) {
+    logger.error("Error getting enabled feature flags for workspace.", {
+      error: workspaceFeatureFlags.error,
+    });
+
+    throw new Error("Error getting enabled feature flags for workspace.");
+  }
+
+  return workspaceFeatureFlags.value;
+}
+
+export const getEnabledFeatureFlagsMemoized = cacheWithRedis(
+  getEnabledFeatureFlags,
+  (connector: ConnectorResource) => {
+    return `enabled-feature-flags-for-workspace-${connector.workspaceId}`;
+  },
+  // Caches data for 15 minutes to limit frequent API calls.
+  // Note: Updates (e.g., feature flags update) may take up to 15 minutes to be reflected.
+  15 * 10 * 1000
+);

--- a/connectors/src/lib/workspace.ts
+++ b/connectors/src/lib/workspace.ts
@@ -1,3 +1,4 @@
+import type { WhitelistableFeature } from "@dust-tt/types";
 import { cacheWithRedis, DustAPI } from "@dust-tt/types";
 
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
@@ -6,7 +7,7 @@ import type { ConnectorResource } from "@connectors/resources/connector_resource
 
 async function getEnabledFeatureFlags(
   connector: ConnectorResource
-): Promise<string[]> {
+): Promise<WhitelistableFeature[]> {
   const ds = dataSourceConfigFromConnector(connector);
 
   // List the feature flags enabled for the workspace.
@@ -40,3 +41,11 @@ export const getEnabledFeatureFlagsMemoized = cacheWithRedis(
   // Note: Updates (e.g., feature flags update) may take up to 15 minutes to be reflected.
   15 * 10 * 1000
 );
+
+export async function connectorHasAutoPreIngestAllDatabasesFF(
+  connector: ConnectorResource
+) {
+  const workspaceFeatureFlags = await getEnabledFeatureFlagsMemoized(connector);
+
+  return workspaceFeatureFlags.includes("auto_pre_ingest_all_databases");
+}

--- a/front/pages/api/v1/w/[wId]/feature_flags.ts
+++ b/front/pages/api/v1/w/[wId]/feature_flags.ts
@@ -1,0 +1,51 @@
+import type { WhitelistableFeature, WithAPIErrorReponse } from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { Authenticator, getAPIKey } from "@app/lib/auth";
+import { apiError, withLogging } from "@app/logger/withlogging";
+
+export type WorkspaceFeatureFlagsResponseBody = {
+  feature_flags: WhitelistableFeature[];
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorReponse<WorkspaceFeatureFlagsResponseBody>>
+): Promise<void> {
+  const keyRes = await getAPIKey(req);
+  if (keyRes.isErr()) {
+    return apiError(req, res, keyRes.error);
+  }
+  const { auth } = await Authenticator.fromKey(
+    keyRes.value,
+    req.query.wId as string
+  );
+
+  const owner = auth.workspace();
+  const isSystemKey = keyRes.value.isSystem;
+  if (!owner || !isSystemKey || !auth.isBuilder()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "The workspace was not found.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET":
+      return res.status(200).json({ feature_flags: owner.flags });
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withLogging(handler);

--- a/types/src/front/feature_flags.ts
+++ b/types/src/front/feature_flags.ts
@@ -1,9 +1,10 @@
 export const WHITELISTABLE_FEATURES = [
+  "auto_pre_ingest_all_databases",
   "crawler",
+  "intercom_connection",
+  "mistral_next",
   "structured_data",
   "workspace_analytics",
-  "mistral_next",
-  "intercom_connection",
 ] as const;
 export type WhitelistableFeature = (typeof WHITELISTABLE_FEATURES)[number];
 export function isWhitelistableFeature(

--- a/types/src/front/lib/dust_api.ts
+++ b/types/src/front/lib/dust_api.ts
@@ -18,6 +18,7 @@ import { CoreAPITokenType } from "../../front/lib/core_api";
 import { Err, Ok, Result } from "../../front/lib/result";
 import { RunType } from "../../front/run";
 import { LoggerInterface } from "../../shared/logger";
+import { WhitelistableFeature } from "../feature_flags";
 import { WorkspaceDomain } from "../workspace";
 import {
   AgentActionSuccessEvent,
@@ -768,6 +769,26 @@ export class DustAPI {
     }
 
     return new Ok(r.value.verified_domains);
+  }
+
+  async getWorkspaceFeatureFlags() {
+    const endpoint = `${this.apiUrl()}/api/v1/w/${this.workspaceId()}/feature_flags`;
+
+    const res = await fetch(endpoint, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${this._credentials.apiKey}`,
+      },
+    });
+
+    const r: DustAPIResponse<{ feature_flags: WhitelistableFeature[] }> =
+      await this._resultFromResponse(res);
+    if (r.isErr()) {
+      return r;
+    }
+
+    return new Ok(r.value.feature_flags);
   }
 
   private async _resultFromResponse<T>(

--- a/types/src/front/lib/dust_api.ts
+++ b/types/src/front/lib/dust_api.ts
@@ -771,7 +771,9 @@ export class DustAPI {
     return new Ok(r.value.verified_domains);
   }
 
-  async getWorkspaceFeatureFlags() {
+  async getWorkspaceFeatureFlags(): Promise<
+    DustAPIResponse<WhitelistableFeature[]>
+  > {
     const endpoint = `${this.apiUrl()}/api/v1/w/${this.workspaceId()}/feature_flags`;
 
     const res = await fetch(endpoint, {


### PR DESCRIPTION
## Description

This PR resolves https://github.com/dust-tt/dust/issues/3762.

It adds a new V1 endpoint that to list the feature flags enabled for a workspace. It also add some wrapper around this logic to cache it and abstract it.
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
