### PR TITLE
enh: migrate notion connector cache tables to UNLOGGED

### DIFF
--- a/connectors/migrations/20240216_make_notion_cache_tables_unlogged.ts
+++ b/connectors/migrations/20240216_make_notion_cache_tables_unlogged.ts
@@ -1,0 +1,20 @@
+import { sequelizeConnection } from "@connectors/resources/storage";
+
+async function main() {
+  await sequelizeConnection.query(`
+        ALTER TABLE notion_connector_page_cache_entries SET UNLOGGED;
+        ALTER TABLE notion_connector_block_cache_entries SET UNLOGGED;
+        ALTER TABLE notion_connector_resources_to_check_cache_entries SET UNLOGGED;
+    `);
+}
+
+main()
+  .then(() => {
+    console.error("\x1b[32m%s\x1b[0m", `Done`);
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error("\x1b[31m%s\x1b[0m", `Error: ${err.message}`);
+    console.log(err);
+    process.exit(1);
+  });

--- a/connectors/src/lib/models/notion.ts
+++ b/connectors/src/lib/models/notion.ts
@@ -272,6 +272,10 @@ NotionDatabase.init(
 );
 ConnectorModel.hasMany(NotionDatabase);
 
+// This table is unlogged, meaning it doesn't generate WAL entries.
+// This is because it's a cache table that generates a lot of writes and we don't want to fill up the WAL.
+// It's also a cache table, so we don't care if we lose data.
+// This table is not replicated to the read replica, and all data is lost on a failover.
 export class NotionConnectorPageCacheEntry extends Model<
   InferAttributes<NotionConnectorPageCacheEntry>,
   InferCreationAttributes<NotionConnectorPageCacheEntry>
@@ -375,6 +379,10 @@ NotionConnectorPageCacheEntry.init(
 );
 ConnectorModel.hasMany(NotionConnectorPageCacheEntry);
 
+// This table is unlogged, meaning it doesn't generate WAL entries.
+// This is because it's a cache table that generates a lot of writes and we don't want to fill up the WAL.
+// It's also a cache table, so we don't care if we lose data.
+// This table is not replicated to the read replica, and all data is lost on a failover.
 export class NotionConnectorBlockCacheEntry extends Model<
   InferAttributes<NotionConnectorBlockCacheEntry>,
   InferCreationAttributes<NotionConnectorBlockCacheEntry>
@@ -465,6 +473,10 @@ NotionConnectorBlockCacheEntry.init(
 );
 ConnectorModel.hasMany(NotionConnectorBlockCacheEntry);
 
+// This table is unlogged, meaning it doesn't generate WAL entries.
+// This is because it's a cache table that generates a lot of writes and we don't want to fill up the WAL.
+// It's also a cache table, so we don't care if we lose data.
+// This table is not replicated to the read replica, and all data is lost on a failover.
 export class NotionConnectorResourcesToCheckCacheEntry extends Model<
   InferAttributes<NotionConnectorResourcesToCheckCacheEntry>,
   InferCreationAttributes<NotionConnectorResourcesToCheckCacheEntry>


### PR DESCRIPTION
## Description

These tables contain data that is totally non-critical and that is deleted at the beginning of each sync run. 
This generates a lot of write, and fills-up the WAL archive with a lot of useless garbage.

This change will cause the tables to become UNLOGGED tables, meaning they won't generate any WAL, won't be replicated to the RR and won't survive a postgres crash (or switch to a failover). They also won't be included in any backup.
This of course is all fine, since a simple restart of notion temporal workflows (which is part of normal operations) will bring everything back to normal.

## Risk

Easy to rollback if that causes issues. It should not be an issue though.
I also think this is quite fast to run 

## Deploy Plan

We just need to run the migration