### PR TITLE
Flav/collect google spreadsheets

### DIFF
--- a/connectors/src/admin/db.ts
+++ b/connectors/src/admin/db.ts
@@ -17,6 +17,7 @@ import {
   GoogleDriveConfig,
   GoogleDriveFiles,
   GoogleDriveFolders,
+  GoogleDriveSheet,
   GoogleDriveSyncToken,
   GoogleDriveWebhook,
 } from "@connectors/lib/models/google_drive";
@@ -71,6 +72,7 @@ async function main(): Promise<void> {
   await GithubCodeDirectory.sync({ alter: true });
   await GoogleDriveFolders.sync({ alter: true });
   await GoogleDriveFiles.sync({ alter: true });
+  await GoogleDriveSheet.sync({ alter: true });
   await GoogleDriveSyncToken.sync({ alter: true });
   await GoogleDriveWebhook.sync({ alter: true });
   await NotionConnectorBlockCacheEntry.sync({ alter: true });

--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -14,6 +14,10 @@ import { getFileParentsMemoized } from "@connectors/connectors/google_drive/lib/
 import { syncOneFile } from "@connectors/connectors/google_drive/temporal/file";
 import { getMimesTypeToSync } from "@connectors/connectors/google_drive/temporal/mime_types";
 import {
+  deleteSpreadsheet,
+  isGoogleDriveSpreadSheetFile,
+} from "@connectors/connectors/google_drive/temporal/spreadsheets";
+import {
   driveObjectToDustType,
   getAuthObject,
   getDocumentId,
@@ -692,7 +696,11 @@ async function deleteFile(googleDriveFile: GoogleDriveFiles) {
     `Deleting Google Drive file.`
   );
 
-  if (googleDriveFile.mimeType !== "application/vnd.google-apps.folder") {
+  if (isGoogleDriveSpreadSheetFile(googleDriveFile)) {
+    await deleteSpreadsheet(connector, googleDriveFile);
+  } else if (
+    googleDriveFile.mimeType !== "application/vnd.google-apps.folder"
+  ) {
     const dataSourceConfig = dataSourceConfigFromConnector(connector);
     await deleteFromDataSource(dataSourceConfig, googleDriveFile.dustFileId);
   }

--- a/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
+++ b/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
@@ -10,6 +10,7 @@ import { concurrentExecutor } from "@connectors/lib/async_utils";
 import { deleteTable, upsertTableFromCsv } from "@connectors/lib/data_sources";
 import type { GoogleDriveFiles } from "@connectors/lib/models/google_drive";
 import { GoogleDriveSheet } from "@connectors/lib/models/google_drive";
+import { connectorHasAutoPreIngestAllDatabasesFF } from "@connectors/lib/workspace";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { GoogleDriveObjectType } from "@connectors/types/google_drive";
@@ -202,7 +203,10 @@ export async function syncSpreadSheet(
     throw new Error("Connector not found.");
   }
 
-  // TODO(2024-02-16 flav) Add check for FF.
+  const hasFF = await connectorHasAutoPreIngestAllDatabasesFF(connector);
+  if (!hasFF) {
+    return false;
+  }
 
   const loggerArgs = {
     connectorId,

--- a/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
+++ b/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
@@ -16,7 +16,7 @@ import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { GoogleDriveObjectType } from "@connectors/types/google_drive";
 
-const MAXIMUM_NUMBER_OF_GSHEET_ROWS = 1000;
+const MAXIMUM_NUMBER_OF_GSHEET_ROWS = 10000;
 
 type Sheet = sheets_v4.Schema$ValueRange & {
   id: number;

--- a/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
+++ b/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
@@ -1,0 +1,322 @@
+import type { ModelId, Result } from "@dust-tt/types";
+import { slugify } from "@dust-tt/types";
+import { stringify } from "csv-stringify/sync";
+import type { sheets_v4 } from "googleapis";
+import { google } from "googleapis";
+import type { OAuth2Client } from "googleapis-common";
+
+import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
+import { concurrentExecutor } from "@connectors/lib/async_utils";
+import { deleteTable, upsertTableFromCsv } from "@connectors/lib/data_sources";
+import type { GoogleDriveFiles } from "@connectors/lib/models/google_drive";
+import { GoogleDriveSheet } from "@connectors/lib/models/google_drive";
+import logger from "@connectors/logger/logger";
+import { ConnectorResource } from "@connectors/resources/connector_resource";
+import type { GoogleDriveObjectType } from "@connectors/types/google_drive";
+
+const MAXIMUM_NUMBER_OF_GSHEET_ROWS = 1000;
+
+type Sheet = sheets_v4.Schema$ValueRange & {
+  id: number;
+  spreadsheet: {
+    id: string;
+    title: string;
+  };
+  title: string;
+};
+
+export function isGoogleDriveSpreadSheetFile(
+  file: GoogleDriveObjectType | GoogleDriveFiles
+) {
+  return file.mimeType === "application/vnd.google-apps.spreadsheet";
+}
+
+function makeTableIdFromSheetId(spreadsheetId: string, sheetId: number) {
+  return `google-spreadsheet-${spreadsheetId}-sheet-${sheetId}`;
+}
+
+async function upsertSheetInDb(connector: ConnectorResource, sheet: Sheet) {
+  await GoogleDriveSheet.upsert({
+    connectorId: connector.id,
+    driveFileId: sheet.spreadsheet.id,
+    driveSheetId: sheet.id,
+    name: sheet.title,
+  });
+}
+
+async function upsertTable(
+  connector: ConnectorResource,
+  sheet: Sheet,
+  rows: string[][]
+) {
+  const dataSourceConfig = await dataSourceConfigFromConnector(connector);
+
+  const { id, spreadsheet, title } = sheet;
+  // Table name will be slugify in front.
+  const tableName = `${spreadsheet.title} - ${title}`;
+  const tableDescription = `Structured data from the Google Spreadsheet (${spreadsheet.title}) and sheet (${title}`;
+
+  const csv = stringify(rows);
+
+  await upsertTableFromCsv({
+    dataSourceConfig,
+    tableId: makeTableIdFromSheetId(spreadsheet.id, id),
+    tableName,
+    tableDescription,
+    tableCsv: csv,
+    loggerArgs: {
+      connectorId: connector.id,
+      sheetId: id,
+      spreadsheetId: spreadsheet.id,
+    },
+  });
+}
+
+function getValidRows(allRows: string[][], loggerArgs: object) {
+  // We assume that the first row is always the headers.
+  // Headers are used to assert the number of cells per row.
+  const [headers] = allRows;
+  if (!headers || headers.length === 0) {
+    return [];
+  }
+
+  const validRows: string[][] = allRows.map((row, index) => {
+    // We slugify the headers.
+    if (index === 0) {
+      // TODO(2024-02-16 flav) Move this to another place to slugify all table headers.
+      return row.map(slugify);
+    }
+
+    // If a row has less cells than headers, we fill the gap with empty strings.
+    if (row.length < headers.length) {
+      const shortfall = headers.length - row.length;
+      return [...row, ...Array(shortfall).fill("")];
+    }
+
+    // If a row has more cells than headers we truncate the row.
+    if (row.length > headers.length) {
+      return row.slice(0, headers.length);
+    }
+
+    return row;
+  });
+
+  if (validRows.length > MAXIMUM_NUMBER_OF_GSHEET_ROWS) {
+    logger.info(
+      { ...loggerArgs, rowCount: validRows.length },
+      `Found sheet with more than ${MAXIMUM_NUMBER_OF_GSHEET_ROWS}`
+    );
+  }
+
+  return validRows.slice(0, MAXIMUM_NUMBER_OF_GSHEET_ROWS);
+}
+
+async function processSheet(connector: ConnectorResource, sheet: Sheet) {
+  if (!sheet.values) {
+    return;
+  }
+
+  const { id, spreadsheet, title } = sheet;
+  const loggerArgs = {
+    connectorId: connector.id,
+    sheet: {
+      id,
+      spreadsheet,
+      title,
+    },
+  };
+
+  logger.info(loggerArgs, "Processing sheet in Google Spreadsheet.");
+
+  const rows = await getValidRows(sheet.values, loggerArgs);
+  if (rows.length > 0) {
+    await upsertTable(connector, sheet, rows);
+
+    await upsertSheetInDb(connector, sheet);
+  }
+}
+
+async function getAllSheetsFromSpreadSheet(
+  sheetsAPI: sheets_v4.Sheets,
+  spreadsheet: sheets_v4.Schema$Spreadsheet,
+  loggerArgs: object
+): Promise<Sheet[]> {
+  const { spreadsheetId, properties } = spreadsheet;
+  if (!spreadsheetId || !properties) {
+    return [];
+  }
+
+  const { title: spreadsheetTitle } = properties;
+
+  logger.info(
+    {
+      ...loggerArgs,
+      spreadsheet: {
+        id: spreadsheet.spreadsheetId,
+      },
+      sheetCount: spreadsheet.sheets?.length,
+    },
+    "List sheets in spreadsheet."
+  );
+
+  const sheets: Sheet[] = [];
+  for (const sheet of spreadsheet.sheets ?? []) {
+    const { properties } = sheet;
+    if (!properties) {
+      continue;
+    }
+
+    const { sheetId, sheetType, title } = properties;
+    // We only support "GRID" sheet.
+    if (sheetType !== "GRID" || !title || !sheetId) {
+      continue;
+    }
+
+    const s = await sheetsAPI.spreadsheets.values.get({
+      range: title,
+      spreadsheetId,
+      valueRenderOption: "FORMATTED_VALUE",
+    });
+
+    sheets.push({
+      ...s.data,
+      id: sheetId,
+      spreadsheet: {
+        id: spreadsheetId,
+        title: spreadsheetTitle ?? "Untitled Spreadsheet",
+      },
+      title,
+    });
+  }
+
+  return sheets;
+}
+
+export async function syncSpreadSheet(
+  oauth2client: OAuth2Client,
+  connectorId: ModelId,
+  file: GoogleDriveObjectType
+): Promise<boolean> {
+  const connector = await ConnectorResource.fetchById(connectorId);
+  if (!connector) {
+    throw new Error("Connector not found.");
+  }
+
+  // TODO(2024-02-16 flav) Add check for FF.
+
+  const loggerArgs = {
+    connectorId,
+  };
+
+  logger.info(
+    {
+      ...loggerArgs,
+      spreadsheet: {
+        id: file.id,
+      },
+    },
+    "Syncing Google Spreadsheet."
+  );
+
+  const sheetsAPI = google.sheets({ version: "v4", auth: oauth2client });
+  const spreadsheet = await sheetsAPI.spreadsheets.get({
+    spreadsheetId: file.id,
+  });
+  const sheets = await getAllSheetsFromSpreadSheet(
+    sheetsAPI,
+    spreadsheet.data,
+    loggerArgs
+  );
+
+  // List synced sheets.
+  const syncedSheets = await GoogleDriveSheet.findAll({
+    where: {
+      driveFileId: file.id,
+    },
+  });
+
+  for (const sheet of sheets) {
+    await processSheet(connector, sheet);
+  }
+
+  // Delete any previously synced sheets that no longer exist in the current spreadsheet.
+  const deletedSyncedSheets = syncedSheets.filter(
+    (synced) => !sheets.find((s) => s.id === synced.driveSheetId)
+  );
+  if (deletedSyncedSheets.length > 0) {
+    await deleteAllSheets(connector, deletedSyncedSheets, {
+      driveFileId: spreadsheet.data.spreadsheetId ?? "",
+    });
+  }
+
+  return true;
+}
+
+async function deleteSheetForSpreadsheet(
+  connector: ConnectorResource,
+  sheet: GoogleDriveSheet,
+  spreadsheetFileId: string
+) {
+  const dataSourceConfig = dataSourceConfigFromConnector(connector);
+
+  logger.info(
+    {
+      connectorId: connector.id,
+      sheet,
+      spreadsheetFileId,
+    },
+    "Deleting google drive sheet."
+  );
+
+  // First remove the upserted table in core.
+  await deleteTable({
+    dataSourceConfig,
+    tableId: makeTableIdFromSheetId(spreadsheetFileId, sheet.driveSheetId),
+    loggerArgs: {
+      connectorId: connector.id,
+      sheetId: sheet.driveSheetId,
+      spreadsheetId: spreadsheetFileId,
+    },
+  });
+
+  // Then delete the row in DB.
+  await sheet.destroy();
+}
+
+async function deleteAllSheets(
+  connector: ConnectorResource,
+  sheetsToDelete: GoogleDriveSheet[],
+  spreadsheetFile: { driveFileId: string }
+) {
+  await concurrentExecutor(
+    sheetsToDelete,
+    async (sheet) =>
+      deleteSheetForSpreadsheet(connector, sheet, spreadsheetFile.driveFileId),
+    {
+      concurrency: 5,
+    }
+  );
+}
+
+export async function deleteSpreadsheet(
+  connector: ConnectorResource,
+  file: GoogleDriveFiles
+) {
+  const sheetsInSpreadsheet = await GoogleDriveSheet.findAll({
+    where: {
+      driveFileId: file.driveFileId,
+    },
+  });
+
+  logger.info(
+    {
+      connectorId: connector.id,
+      spreadsheet: file,
+    },
+    "Deleting Google Spreadsheet."
+  );
+
+  if (sheetsInSpreadsheet.length > 0) {
+    await deleteAllSheets(connector, sheetsInSpreadsheet, file);
+  }
+}

--- a/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
+++ b/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
@@ -1,4 +1,4 @@
-import type { ModelId, Result } from "@dust-tt/types";
+import type { ModelId } from "@dust-tt/types";
 import { slugify } from "@dust-tt/types";
 import { stringify } from "csv-stringify/sync";
 import type { sheets_v4 } from "googleapis";
@@ -59,6 +59,8 @@ async function upsertTable(
 
   const csv = stringify(rows);
 
+  // Upserting is safe: Core truncates any previous table with the same Id before
+  // the operation. Note: Renaming a sheet in Google Drive retains its original Id.
   await upsertTableFromCsv({
     dataSourceConfig,
     tableId: makeTableIdFromSheetId(spreadsheet.id, id),

--- a/connectors/src/lib/models/google_drive.ts
+++ b/connectors/src/lib/models/google_drive.ts
@@ -182,6 +182,63 @@ GoogleDriveFiles.init(
   }
 );
 ConnectorModel.hasOne(GoogleDriveFiles);
+
+export class GoogleDriveSheet extends Model<
+  InferAttributes<GoogleDriveSheet>,
+  InferCreationAttributes<GoogleDriveSheet>
+> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+  declare connectorId: ForeignKey<ConnectorModel["id"]>;
+  declare driveFileId: string;
+  declare driveSheetId: number;
+  declare name: string;
+}
+GoogleDriveSheet.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    connectorId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+    driveFileId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    driveSheetId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+    name: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+    },
+  },
+  {
+    sequelize: sequelizeConnection,
+    modelName: "google_drive_sheets",
+    indexes: [
+      { fields: ["connectorId", "driveFileId", "driveSheetId"], unique: true },
+    ],
+  }
+);
+ConnectorModel.hasOne(GoogleDriveSheet);
+
 // Sync Token are the equivalent of a timestamp for syncing the delta
 // between the last sync and the current sync.
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR introduces functionality to integrate structured data from Google Spreadsheets into our system. Unlike other Google Drive files stored in the `google_drive_files` table, Spreadsheets will be processed differently:
1. Spreadsheet content is not upserted as a single document.
2. We list all sheets within the spreadsheet.
3. It assumes the first row of each sheet contains headers and extracts the largest data set possible based on these, applying the following rules:
   - Rows shorter than the header count are padded with empty strings, which convert to `null` in the core system.
   - Rows exceeding the header count are truncated.
   - A maximum of 1000 rows will be initially extracted from each sheet (with plans to increase this limit in the future).
4. Data from each sheet is upserted into a structured table.
5. Spreadsheet sheet details are stored in a new SQL table named `google_drive_sheets`.
6. The Spreadsheet is stored in `google_drive_files` like other supported files.

Garbage collection mechanisms will remain largely unchanged, with the system deleting associated tables and SQL records upon spreadsheet deletion.

Incremental synchronization will manage the removal of sheets that no longer exist within a spreadsheet. Sheet renaming in Google Sheets does not alter its Id, ensuring consistency as the core system relies on table Ids to clear existing data before upserting new data through the table API endpoint.

## Risk

Low risk, 90 % of the changes are gated behind a FF. Safe to rollback.

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [x] This PR requires to run a migration to add a new SQL table (`google_drive_sheets`). It first needs to be applied from `connectors-edge` before we can safely merge this PR.
- [ ] Enable Google Spreadsheet API on Dust prod.

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
