### PR TITLE
fix(notion DB structured conn): use csv endpoint for incremental sync

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
+++ b/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
@@ -73,6 +73,7 @@ async function upsertTable(
       sheetId: id,
       spreadsheetId: spreadsheet.id,
     },
+    truncate: true,
   });
 }
 

--- a/front/lib/api/tables.ts
+++ b/front/lib/api/tables.ts
@@ -119,6 +119,7 @@ export async function upsertTableFromCsv({
   tableDescription,
   tableId,
   csv,
+  truncate,
 }: {
   owner: WorkspaceType;
   projectId: string;
@@ -127,6 +128,7 @@ export async function upsertTableFromCsv({
   tableDescription: string;
   tableId: string;
   csv: string | null;
+  truncate: boolean;
 }): Promise<Result<{ table: CoreAPITable }, TableOperationError>> {
   const csvRowsRes = csv ? await rowsFromCsv(csv) : null;
 
@@ -186,7 +188,7 @@ export async function upsertTableFromCsv({
       dataSourceName,
       tableId,
       rows: csvRows,
-      truncate: true,
+      truncate,
     });
     if (rowsRes.isErr()) {
       logger.error(

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/rows/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/rows/index.ts
@@ -16,12 +16,25 @@ const UpsertTableRowsRequestBodySchema = t.type({
       row_id: t.string,
       value: t.record(
         t.string,
-        t.union([t.string, t.null, t.number, t.boolean])
+        t.union([
+          t.string,
+          t.null,
+          t.number,
+          t.boolean,
+          t.type({
+            type: t.literal("datetime"),
+            epoch: t.number,
+          }),
+        ])
       ),
     })
   ),
   truncate: t.union([t.boolean, t.undefined]),
 });
+
+type CellValueType = t.TypeOf<
+  typeof UpsertTableRowsRequestBodySchema
+>["rows"][number]["value"][string];
 
 type UpsertTableRowsResponseBody = {
   success: true;
@@ -174,7 +187,7 @@ async function handler(
         keysSet.add(key);
       }
       rowsToUpsert = rowsToUpsert.map((row) => {
-        const value: Record<string, string | number | boolean | null> = {};
+        const value: Record<string, CellValueType> = {};
         for (const [key, val] of Object.entries(row.value)) {
           value[key.toLowerCase()] = val;
         }

--- a/front/pages/w/[wId]/builder/data-sources/[name]/tables/upsert.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/tables/upsert.tsx
@@ -215,6 +215,7 @@ export default function TableUpsert({
           description: description,
           csv: fileContent,
           tableId: loadTableId ?? undefined,
+          truncate: true,
         };
       } else if (tableId) {
         body = {
@@ -222,6 +223,7 @@ export default function TableUpsert({
           description: description,
           tableId: tableId,
           csv: undefined,
+          truncate: false,
         };
       } else {
         throw new Error("Unreachable: fileContent is null");


### PR DESCRIPTION
## Description

For the initial sync of a DB, we use the `csv` endpoint that allows uploading the rows of the table in CSV format. CSVs are just strings, so this effectively pushes the type inference of the tables to `front`.

However, the notion incremental sync was relying on the row upsert public API endpoint, which requires type inference to be done upstream. This caused for example datetime strings to not be correctly parsed as datetimes.

In order to keep all type inference in the same place, I updated the `csv` endpoint to take a `truncate` parameter -- the endpoint will only truncate the table if truncate is true, which makes it possible to use it for incremental updates as well (we can pass a CSV with a single data line).

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
