### PR TITLE
[Sparkle] Updated interface for tab component (onclick, setcurrenttab)

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.97",
+  "version": "0.2.98",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.97",
+      "version": "0.2.98",
       "license": "ISC",
       "dependencies": {
         "@headlessui/react": "^1.7.17",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.97",
+  "version": "0.2.98",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/components/Tab.tsx
+++ b/sparkle/src/components/Tab.tsx
@@ -11,9 +11,9 @@ import { classNames } from "@sparkle/lib/utils";
 import { Icon } from "./Icon";
 import { Tooltip } from "./Tooltip";
 
-type TabType = {
+type TabType<E> = {
   label: string;
-  id?: string;
+  id?: E;
   hideLabel?: boolean;
   current: boolean;
   sizing?: "hug" | "expand";
@@ -24,10 +24,10 @@ type TabType = {
   | { onClick?: never; href: string }
 );
 
-type TabProps = {
+type TabProps<E> = {
   variant?: "default" | "stepper";
-  tabs: Array<TabType>;
-  setCurrentTab?: (tabId: string, e: MouseEvent<HTMLAnchorElement>) => void;
+  tabs: Array<TabType<E>>;
+  setCurrentTab?: (tabId: E, e: MouseEvent<HTMLAnchorElement>) => void;
   className?: string;
 };
 
@@ -99,12 +99,12 @@ const tabSizingClasses = {
  * - or globally, by providing a setCurrentTab function.
  * Both per-tab and global actions can be set, the per-tab action taking precedence.
  */
-export function Tab({
+export function Tab<E>({
   variant = "default",
   tabs,
   setCurrentTab,
   className = "",
-}: TabProps) {
+}: TabProps<E>) {
   const { components } = React.useContext(SparkleContext);
 
   const renderTabs = () =>

--- a/sparkle/src/components/Tab.tsx
+++ b/sparkle/src/components/Tab.tsx
@@ -11,18 +11,23 @@ import { classNames } from "@sparkle/lib/utils";
 import { Icon } from "./Icon";
 import { Tooltip } from "./Tooltip";
 
+type TabType = {
+  label: string;
+  id?: string;
+  hideLabel?: boolean;
+  current: boolean;
+  sizing?: "hug" | "expand";
+  icon?: ComponentType<{ className?: string }>;
+  hasSeparator?: boolean;
+} & (
+  | { onClick?: (event: MouseEvent<HTMLAnchorElement>) => void; href?: never }
+  | { onClick?: never; href: string }
+);
+
 type TabProps = {
   variant?: "default" | "stepper";
-  tabs: Array<{
-    label: string;
-    hideLabel?: boolean;
-    current: boolean;
-    sizing?: "hug" | "expand";
-    icon?: ComponentType<{ className?: string }>;
-    href?: string;
-    hasSeparator?: boolean;
-  }>;
-  onTabClick?: (tabName: string, event: MouseEvent<HTMLAnchorElement>) => void;
+  tabs: Array<TabType>;
+  setCurrentTab?: (tabId: string, e: MouseEvent<HTMLAnchorElement>) => void;
   className?: string;
 };
 
@@ -85,10 +90,19 @@ const tabSizingClasses = {
   expand: "s-flex-1",
 };
 
+/**
+ * Tab component displaying a list of tabs.
+ *
+ * Tab click action is specified:
+ * - either per tab, by providing either an href or an onClick handler in tab
+ *   data (mutually exclusive);
+ * - or globally, by providing a setCurrentTab function.
+ * Both per-tab and global actions can be set, the per-tab action taking precedence.
+ */
 export function Tab({
   variant = "default",
   tabs,
-  onTabClick,
+  setCurrentTab,
   className = "",
 }: TabProps) {
   const { components } = React.useContext(SparkleContext);
@@ -137,12 +151,23 @@ export function Tab({
         ? components.link
         : noHrefLink;
 
+      // precedence on href and onClick (mutually exclusive), then setCurrentTab
+      const setCurrentTabFn = (e: MouseEvent<HTMLAnchorElement>) => {
+        if (!tab.id) {
+          throw new Error("Tab id is required to use setCurrentTab");
+        }
+        setCurrentTab?.(tab.id, e);
+      };
+      const onClickAction = tab.href
+        ? undefined
+        : tab.onClick ?? setCurrentTabFn;
+
       const content: ReactNode = (
         <Link
           key={tab.label}
           className={finalTabClasses}
           aria-current={tab.current ? "page" : undefined}
-          onClick={(event) => onTabClick?.(tab.label ? tab.label : "", event)}
+          onClick={onClickAction}
           href={tab.href || "#"}
         >
           <div

--- a/sparkle/src/stories/Tab.stories.tsx
+++ b/sparkle/src/stories/Tab.stories.tsx
@@ -20,67 +20,77 @@ const meta = {
 
 export default meta;
 
-export const TabExample = () => (
-  <div className="s-flex s-flex-col s-gap-10">
-    <div className="s-w-[320px]">
-      <Tab
-        tabs={[
-          {
-            label: "Chat",
-            current: true,
-            icon: ChatBubbleBottomCenterTextIcon,
-            sizing: "expand",
-          },
-          {
-            label: "Build",
-            current: false,
-            icon: RobotIcon,
-            sizing: "expand",
-            hasSeparator: true,
-          },
-          {
-            label: "Settings",
-            hideLabel: true,
-            current: false,
-            icon: Cog6ToothIcon,
-          },
-        ]}
-        onTabClick={(tabName, event) => {
-          // add logic here
-          event.preventDefault();
-          console.log(tabName);
-        }}
-      />
+export const TabExample = () => {
+  const [currentTab, setCurrentTab] = React.useState("chat");
+  const [currentTab2, setCurrentTab2] = React.useState("instructions");
+  return (
+    <div className="s-flex s-flex-col s-gap-10">
+      <div className="s-w-[320px]">
+        <Tab
+          tabs={[
+            {
+              label: "Chat",
+              id: "chat",
+              current: currentTab === "chat",
+              icon: ChatBubbleBottomCenterTextIcon,
+              sizing: "expand",
+            },
+            {
+              label: "Build",
+              id: "build",
+              current: currentTab === "build",
+              icon: RobotIcon,
+              sizing: "expand",
+              hasSeparator: true,
+            },
+            {
+              label: "Settings",
+              id: "settings",
+              hideLabel: true,
+              current: false,
+              icon: Cog6ToothIcon,
+            },
+          ]}
+          setCurrentTab={(tabId, event) => {
+            // add logic here
+            event.preventDefault();
+            setCurrentTab(tabId);
+          }}
+        />
+      </div>
+      <div className="s-w-full">
+        <Tab
+          variant="stepper"
+          tabs={[
+            {
+              label: "Instructions",
+              id: "instructions",
+              current: currentTab2 === "instructions",
+              icon: SquareIcon,
+              sizing: "hug",
+            },
+            {
+              label: "Data sources & Actions",
+              id: "data",
+              current: currentTab2 === "data",
+              icon: CircleIcon,
+              sizing: "hug",
+            },
+            {
+              label: "Naming",
+              id: "naming",
+              current: currentTab2 === "naming",
+              icon: TriangleIcon,
+              sizing: "hug",
+            },
+          ]}
+          setCurrentTab={(tabId, event) => {
+            // add logic here
+            event.preventDefault();
+            setCurrentTab2(tabId);
+          }}
+        />
+      </div>
     </div>
-    <div className="s-w-full">
-      <Tab
-        variant="stepper"
-        tabs={[
-          {
-            label: "Instructions",
-            current: true,
-            icon: SquareIcon,
-            sizing: "hug",
-          },
-          {
-            label: "Data sources & Actions",
-            current: false,
-            icon: CircleIcon,
-            sizing: "hug",
-          },
-          {
-            label: "Naming",
-            current: false,
-            icon: TriangleIcon,
-            sizing: "hug",
-          },
-        ]}
-        onTabClick={(tabName, event) => {
-          // add logic here
-          event.preventDefault();
-          console.log(tabName);
-        }}
-      />
-    </div>
-  </div>
-);
+  );
+};


### PR DESCRIPTION
## Description

Tabs now have an id (optional for backwards compatibility). Tab click action is now specified:
- either per tab, by providing either an href or an onClick handler in tab data (mutually exclusive);
- or globally, by providing a setCurrentTab function using tab id.

Both per-tab and global actions can be set, the per-tab action taking precedence.

Previous interface did not allow per-tab onClick, and required boilerplate code when implementing now-deprecated `onTabClick`

Various places in code looked messy because of this, and a new need for tabs in Meru led to this PR.

## Deploy
- Ensure sparkle version is bumped correctly
- **Merge before PR #3790 **
- Deploy sparkle (then PR 3790 can be merged)
