### PR TITLE
fix: infinite recursion is sqlite worker error handling

### DIFF
--- a/core/src/databases/database.rs
+++ b/core/src/databases/database.rs
@@ -43,7 +43,7 @@ impl From<SqliteWorkerError> for QueryDatabaseError {
         match &e {
             SqliteWorkerError::ServerError(_, code, _) => match code.as_str() {
                 "too_many_result_rows" => QueryDatabaseError::TooManyResultRows,
-                _ => e.into(),
+                _ => QueryDatabaseError::GenericError(e.into()),
             },
             _ => e.into(),
         }


### PR DESCRIPTION
## Description

This issue caused the `from` function to be infinitely called recursively 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
