### PR TITLE
fix: don't upsert DB when no rows

### DIFF
--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -2353,6 +2353,11 @@ export async function upsertDatabaseStructuredDataFromCache({
     },
   });
 
+  if (!pageCacheEntries.length) {
+    localLogger.info("No pages found in cache (skipping).");
+    return;
+  }
+
   const csv = await renderDatabaseFromPages({
     databaseTitle: null,
     pagesProperties: pageCacheEntries.map(


### PR DESCRIPTION
## Description

When no rows have changed, we shouldn't try to upsert

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
