### PR TITLE
Allow importing GDrive spreadsheet with only one sheet

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
+++ b/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
@@ -218,7 +218,13 @@ async function getAllSheetsFromSpreadSheet(
 
     const { sheetId, sheetType, title } = properties;
     // We only support "GRID" sheet.
-    if (sheetType !== "GRID" || !title || !sheetId) {
+    // For spreadsheet with one unique sheet, sheetId will be zero.
+    if (
+      sheetType !== "GRID" ||
+      !title ||
+      sheetId === undefined ||
+      sheetId === null
+    ) {
       continue;
     }
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR makes importing GSheet more resilient. For Google Drive spreadsheet with one unique sheet, the `sheetId` is set to 0. This case was captured by the if block.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
