### PR TITLE
fix: ignore 404s when deleting tables

### DIFF
--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -693,6 +693,11 @@ export async function deleteTable({
 
   const elapsed = new Date().getTime() - now.getTime();
 
+  if (dustRequestResult.status === 404) {
+    localLogger.info("Structured data doesn't exist on Dust. Ignoring.");
+    return;
+  }
+
   if (dustRequestResult.status >= 200 && dustRequestResult.status < 300) {
     statsDClient.increment(
       "data_source_structured_data_deletes_success.count",


### PR DESCRIPTION
## Description

Connectors doesn't know if the table already exists on `core`. When garbage collecting, it should ignore 404s.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
