### PR TITLE
fix: allow passing any type into a string field

### DIFF
--- a/core/src/databases/table_schema.rs
+++ b/core/src/databases/table_schema.rs
@@ -321,8 +321,10 @@ impl TableSchema {
                         our_column.value_type =
                             match (&our_column.value_type, &other_column.value_type) {
                                 // Ints and Floats can be merged into Floats.
-                                // Other types are incompatible.
                                 (Int, Float) | (Float, Int) => TableSchemaFieldType::Float,
+                                // If the existing type is text, then any other type can be merged into it.
+                                (Text, _) => Text,
+                                // Other types are incompatible.
                                 _ => Err(anyhow!(
                                     "Cannot merge types {:?} and {:?}",
                                     our_column.value_type,


### PR DESCRIPTION
## Description

When inserting non-string data into a string column, we currently throw an error.

Imagine the following case:

**initial upsert**
```
number_of_employees
5 employees
20
30 (approx)
40
```

inferred schema:
```
{
    number_of_employees: "text"
}
```

**incremental upsert**
```
number_of_employees
40
```

inferred schema:

```
{
    number_of_employees: "int"
}
```

=> the problem is that we'll try to merge an integer field into a text field, which will be an error.

It's fine to allow merging any type into a text field, since anything can be a string.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
