### PR TITLE
fix: dont use axios validate status

### DIFF
--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -574,6 +574,7 @@ export async function deleteTableRow({
     headers: {
       Authorization: `Bearer ${dataSourceConfig.workspaceAPIKey}`,
     },
+    validateStatus: null,
   };
 
   let dustRequestResult: AxiosResponse;
@@ -600,6 +601,11 @@ export async function deleteTableRow({
 
   const elapsed = new Date().getTime() - now.getTime();
 
+  if (dustRequestResult.status === 404) {
+    localLogger.info("Structured data doesn't exist on Dust. Ignoring.");
+    return;
+  }
+
   if (dustRequestResult.status >= 200 && dustRequestResult.status < 300) {
     statsDClient.increment(
       "data_source_structured_data_deletes_success.count",
@@ -609,10 +615,6 @@ export async function deleteTableRow({
 
     localLogger.info("Successfully deleted structured data from Dust.");
   } else {
-    if (dustRequestResult.status === 404) {
-      localLogger.info("Structured data doesn't exist on Dust. Ignoring.");
-      return;
-    }
     statsDClient.increment(
       "data_source_structured_data_deletes_error.count",
       1,
@@ -667,6 +669,7 @@ export async function deleteTable({
     headers: {
       Authorization: `Bearer ${dataSourceConfig.workspaceAPIKey}`,
     },
+    validateStatus: null,
   };
 
   let dustRequestResult: AxiosResponse;

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]/index.ts
@@ -115,7 +115,8 @@ async function handler(
         status_code: 405,
         api_error: {
           type: "method_not_supported_error",
-          message: "The method passed is not supported, GET is expected.",
+          message:
+            "The method passed is not supported, GET or DELETE is expected.",
         },
       });
   }


### PR DESCRIPTION
## Description

Axios wasn't letting us handle the error code (it throws an error by default for non 200s).
Disabling `validateStatus` allows to handle the error codes ourselves (the code was already expecting that)

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
