### PR TITLE
Poké - search by email

### DIFF
--- a/front/lib/models/user.ts
+++ b/front/lib/models/user.ts
@@ -3,10 +3,12 @@ import type {
   ForeignKey,
   InferAttributes,
   InferCreationAttributes,
+  NonAttribute,
 } from "sequelize";
 import { DataTypes, Model } from "sequelize";
 
 import { front_sequelize } from "@app/lib/databases";
+import type { Membership } from "@app/lib/models";
 
 export class User extends Model<
   InferAttributes<User>,
@@ -25,6 +27,8 @@ export class User extends Model<
   declare imageUrl: string | null;
 
   declare isDustSuperUser: CreationOptional<boolean>;
+
+  declare memberships: NonAttribute<Membership[]>;
 }
 User.init(
   {


### PR DESCRIPTION
## Description

Eng runner card: https://github.com/dust-tt/tasks/issues/438
If we paste an email on the search bar we would like to search by email. 
I did not filter by role in the memberships to exclude revoked members because in case we're searching for a specific user, we still want to find his workspaces even if revoke.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

I don't think we need to run a migration for the `NonAttribute` added to the user model, so nothing special. 
