### PR TITLE
fix(notion structured): handle empty property names

### DIFF
--- a/connectors/src/connectors/notion/lib/notion_api.ts
+++ b/connectors/src/connectors/notion/lib/notion_api.ts
@@ -787,7 +787,11 @@ export async function renderDatabaseFromPages({
     );
   }
 
-  let header = Object.entries(pagesProperties[0]).map(([key]) => key);
+  let header = Object.entries(pagesProperties[0])
+    .map(([key]) => key)
+    // We remove empty keys.
+    .filter((k) => !!k.trim());
+
   if (dustIdColumn) {
     header = ["__dust_id", ...header];
   }


### PR DESCRIPTION
## Description

We don't allow empty headers. It can happen that a notion property name is empty or only whitespace. We won't render those.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
