### PR TITLE
fix(structured data): drop empty columns, sanitize header, dedup header

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
+++ b/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
@@ -98,8 +98,8 @@ function getValidRows(allRows: string[][], loggerArgs: object) {
 
   // We assume that the first row is always the headers.
   // Headers are used to assert the number of cells per row.
-  const [rawHeaders] = filteredRows;
-  if (!rawHeaders || rawHeaders.length === 0) {
+  const [headers] = filteredRows;
+  if (!headers || headers.length === 0) {
     logger.info(
       loggerArgs,
       "[Spreadsheet] Skipping due to empty initial rows."

--- a/front/lib/api/tables.ts
+++ b/front/lib/api/tables.ts
@@ -336,6 +336,14 @@ async function rowsFromCsv(
     }
   }
 
+  // Drop empty columns.
+  for (const [col, values] of Object.entries(valuesByCol)) {
+    if (values.every((v) => v === "")) {
+      delete valuesByCol[col];
+    }
+  }
+  header = header?.filter((h) => !!valuesByCol[h]?.length);
+
   if (!header || !Object.values(valuesByCol).some((vs) => vs.length > 0)) {
     return new Err({
       type: "empty_csv",

--- a/front/lib/api/tables.ts
+++ b/front/lib/api/tables.ts
@@ -337,14 +337,6 @@ async function rowsFromCsv(
     }
   }
 
-  // Drop empty columns.
-  for (const [col, values] of Object.entries(valuesByCol)) {
-    if (values.every((v) => v === "")) {
-      delete valuesByCol[col];
-    }
-  }
-  header = header?.filter((h) => !!valuesByCol[h]?.length);
-
   if (!header || !Object.values(valuesByCol).some((vs) => vs.length > 0)) {
     return new Err({
       type: "empty_csv",
@@ -354,7 +346,9 @@ async function rowsFromCsv(
 
   // Parse values and infer types for each column.
   const parsedValuesByCol: Record<string, RowValue[]> = {};
-  for (const [col, values] of Object.entries(valuesByCol)) {
+  for (const [col, valuesRaw] of Object.entries(valuesByCol)) {
+    const values = valuesRaw.map((v) => v.trim());
+
     if (values.every((v) => v === "")) {
       // All values are empty, we skip this column.
       continue;
@@ -454,7 +448,7 @@ function getSanitizedHeader(rawHeader: string[]) {
       acc.push(slugifiedName);
     } else {
       let conflictResolved = false;
-      for (let i = 2; i < 10000; i++) {
+      for (let i = 2; i < 64; i++) {
         if (!acc.includes(slugify(`${slugifiedName}_${i}`))) {
           acc.push(slugify(`${slugifiedName}_${i}`));
           conflictResolved = true;


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/dust/issues/3813 and https://github.com/dust-tt/dust/issues/3814

- we want to drop the empty columns because notion DBs typically have many unused properties
- we want to slugify the column names as it limits the need to do complex escaping at query time
- we want to dedup column names as we can easily end up with several column using the same name. We'll rely on order of columns for incremental sync (🤞)

## Risk

- **NOT** backwards compatible with the current notion incremental sync. It will require a "full resync" of notion DBs structured data. This will be done in a separate PR
- Ordering of header cells becomes important if there are duplicates

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
