### PR TITLE
enh(notion structured) dont do incremental sync until initial sync

### DIFF
--- a/connectors/src/lib/models/notion.ts
+++ b/connectors/src/lib/models/notion.ts
@@ -187,6 +187,8 @@ export class NotionDatabase extends Model<
   declare notionUrl?: string | null;
 
   declare structuredDataEnabled: CreationOptional<boolean>;
+  declare structuredDataUpsertedTs: CreationOptional<Date | null>;
+
   declare connectorId: ForeignKey<ConnectorModel["id"]> | null;
 }
 
@@ -251,6 +253,11 @@ NotionDatabase.init(
       type: DataTypes.BOOLEAN,
       allowNull: false,
       defaultValue: false,
+    },
+    structuredDataUpsertedTs: {
+      type: DataTypes.DATE,
+      allowNull: true,
+      defaultValue: null,
     },
   },
   {


### PR DESCRIPTION
## Description

fixes https://github.com/dust-tt/dust/issues/3815

We'd rather have nothing than an incomplete DB, so we don't want to start doing incremental DB syncs before we did a full sync for it.

## Risk

⚠️ DB schema migration

## Deploy Plan


initdb (connectors) then deploy.