### PR TITLE
Don't serialize undefined connectionId

### DIFF
--- a/connectors/src/resources/connector_resource.ts
+++ b/connectors/src/resources/connector_resource.ts
@@ -1,6 +1,11 @@
 import type { ConnectorProvider, Result } from "@dust-tt/types";
 import { Err, Ok } from "@dust-tt/types";
-import type { Attributes, ModelStatic } from "sequelize";
+import type {
+  Attributes,
+  FindOptions,
+  ModelStatic,
+  WhereOptions,
+} from "sequelize";
 
 import { BaseResource } from "@connectors/resources/base_resource";
 import type { ConnectorProviderStrategy } from "@connectors/resources/connector/strategy";
@@ -35,11 +40,16 @@ export class ConnectorResource extends BaseResource<ConnectorModel> {
     type: ConnectorProvider,
     { connectionId }: { connectionId?: string }
   ) {
+    const where: WhereOptions<ConnectorModel> = {
+      type,
+    };
+
+    if (connectionId) {
+      where.connectionId = connectionId;
+    }
+
     const blobs = await ConnectorResource.model.findAll({
-      where: {
-        type,
-        connectionId,
-      },
+      where,
     });
 
     return blobs.map(
@@ -55,12 +65,17 @@ export class ConnectorResource extends BaseResource<ConnectorModel> {
     },
     { connectionId }: { connectionId?: string } = {}
   ) {
+    const where: WhereOptions<ConnectorModel> = {
+      workspaceId: dataSource.workspaceId,
+      dataSourceName: dataSource.dataSourceName,
+    };
+
+    if (connectionId) {
+      where.connectionId = connectionId;
+    }
+
     const blob = await ConnectorResource.model.findOne({
-      where: {
-        workspaceId: dataSource.workspaceId,
-        dataSourceName: dataSource.dataSourceName,
-        connectionId,
-      },
+      where,
     });
     if (!blob) {
       return null;

--- a/connectors/src/resources/connector_resource.ts
+++ b/connectors/src/resources/connector_resource.ts
@@ -1,11 +1,6 @@
 import type { ConnectorProvider, Result } from "@dust-tt/types";
 import { Err, Ok } from "@dust-tt/types";
-import type {
-  Attributes,
-  FindOptions,
-  ModelStatic,
-  WhereOptions,
-} from "sequelize";
+import type { Attributes, ModelStatic, WhereOptions } from "sequelize";
 
 import { BaseResource } from "@connectors/resources/base_resource";
 import type { ConnectorProviderStrategy } from "@connectors/resources/connector/strategy";


### PR DESCRIPTION
## Description

This PR fixes the regression introduced by https://github.com/dust-tt/dust/pull/3821.

Sequelize does not support undefined properties in the where clause.
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
