### PR TITLE
Set Error update seat to warn level

### DIFF
--- a/front/lib/plans/subscription.ts
+++ b/front/lib/plans/subscription.ts
@@ -470,7 +470,7 @@ export const updateWorkspacePerSeatSubscriptionUsage = async ({
       quantity: activeSeats,
     });
   } catch (err) {
-    logger.error(
+    logger.warn(
       `Error while updating Stripe subscription quantity for workspace ${workspaceId}: ${err}`
     );
   }


### PR DESCRIPTION
## Description

We lately had this error multiple time because we paused the payment collection of a given workspace. Until I manage that, this error can be lowered to warn to not trigger a Monitor each time. 

## Risk

/

## Deploy Plan

Nothing special!
