### PR TITLE
Hack to display when no conversation can be sync

### DIFF
--- a/connectors/src/connectors/intercom/lib/conversation_permissions.ts
+++ b/connectors/src/connectors/intercom/lib/conversation_permissions.ts
@@ -141,11 +141,18 @@ export async function retrieveIntercomConversationsPermissions({
       });
     }
   } else {
+    const teams = await fetchIntercomTeams(intercomClient);
     if (isRootLevel) {
+      // This is an ugly hack
+      // Since we only sync conversations attached to a Team, if there are no teams, we display "No conversations"
+      if (teams.length === 0) {
+        rootConversationNode.title =
+          "No conversations available for sync (Dust only supports conversations attached to a Team)";
+        rootConversationNode.expandable = false;
+      }
       nodes.push(rootConversationNode);
     }
     if (parentInternalId === teamsInternalId) {
-      const teams = await fetchIntercomTeams(intercomClient);
       teams.forEach((team) => {
         const isTeamInDb = teamsWithReadPermission.some((teamFromDb) => {
           return teamFromDb.teamId === team.id;

--- a/connectors/src/connectors/intercom/lib/conversation_permissions.ts
+++ b/connectors/src/connectors/intercom/lib/conversation_permissions.ts
@@ -146,8 +146,7 @@ export async function retrieveIntercomConversationsPermissions({
       // This is an ugly hack
       // Since we only sync conversations attached to a Team, if there are no teams, we display "No conversations"
       if (teams.length === 0) {
-        rootConversationNode.title =
-          "No conversations available for sync (Dust only supports conversations attached to a Team)";
+        rootConversationNode.title = "No conversations available for sync";
         rootConversationNode.expandable = false;
       }
       nodes.push(rootConversationNode);


### PR DESCRIPTION
## Description

We decided to sync only conversation attached to a given Team. We could decide at some point to offer the ability to sync all conversations, but until we know it's a feature expected by our users, this is a hack to clearly say when we can't sync any conversation. This is the permission modal when no Team is available on Intercom. 

<img width="1424" alt="Screenshot 2024-02-21 at 11 00 47" src="https://github.com/dust-tt/dust/assets/3803406/6afc7aef-00ab-46a0-af5f-f02eca01139f">

## Risk

Low

## Deploy Plan

Nothing special.
