### PR TITLE
feat(structured data): invalidate schema cache on incremental update

### DIFF
--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -112,13 +112,18 @@ impl APIState {
             };
             apps.into_iter().for_each(|mut app| {
                 let store = self.store.clone();
+                let databases_store = self.databases_store.clone();
                 let qdrant_clients = self.qdrant_clients.clone();
                 let manager = self.run_manager.clone();
 
                 // Start a task that will run the app in the background.
                 tokio::task::spawn(async move {
                     let now = std::time::Instant::now();
-                    match app.0.run(app.1, store, qdrant_clients, None).await {
+                    match app
+                        .0
+                        .run(app.1, store, databases_store, qdrant_clients, None)
+                        .await
+                    {
                         Ok(()) => {
                             info!(
                                 run = app.0.run_ref().unwrap().run_id(),
@@ -807,13 +812,20 @@ async fn runs_create_stream(
             // The run is empty for now, we can clone it for the response.
             // let run = app.run_ref().unwrap().clone();
             let store = state.store.clone();
+            let databases_store = state.databases_store.clone();
             let qdrant_clients = state.qdrant_clients.clone();
 
             // Start a task that will run the app in the background.
             tokio::task::spawn(async move {
                 let now = std::time::Instant::now();
                 match app
-                    .run(credentials, store, qdrant_clients, Some(tx.clone()))
+                    .run(
+                        credentials,
+                        store,
+                        databases_store,
+                        qdrant_clients,
+                        Some(tx.clone()),
+                    )
                     .await
                 {
                     Ok(()) => {

--- a/core/src/app.rs
+++ b/core/src/app.rs
@@ -1,5 +1,6 @@
 use crate::blocks::block::{parse_block, Block, BlockResult, BlockType, Env, InputState, MapState};
 use crate::data_sources::qdrant::QdrantClients;
+use crate::databases_store::store::DatabasesStore;
 use crate::dataset::Dataset;
 use crate::project::Project;
 use crate::run::{BlockExecution, BlockStatus, Credentials, Run, RunConfig, RunType, Status};
@@ -303,6 +304,7 @@ impl App {
         &mut self,
         credentials: Credentials,
         store: Box<dyn Store + Sync + Send>,
+        databases_store: Box<dyn DatabasesStore + Sync + Send>,
         qdrant_clients: QdrantClients,
         event_sender: Option<UnboundedSender<Value>>,
     ) -> Result<()> {
@@ -345,6 +347,7 @@ impl App {
             map: None,
             project: project.clone(),
             store: store.clone(),
+            databases_store: databases_store.clone(),
             qdrant_clients: qdrant_clients,
             credentials: credentials.clone(),
         }]];

--- a/core/src/blocks/block.rs
+++ b/core/src/blocks/block.rs
@@ -4,6 +4,7 @@ use crate::blocks::{
     map::Map, r#while::While, reduce::Reduce, search::Search,
 };
 use crate::data_sources::qdrant::QdrantClients;
+use crate::databases_store::store::DatabasesStore;
 use crate::project::Project;
 use crate::run::{Credentials, RunConfig};
 use crate::stores::store::Store;
@@ -44,6 +45,8 @@ pub struct Env {
     pub map: Option<MapState>,
     #[serde(skip_serializing)]
     pub store: Box<dyn Store + Sync + Send>,
+    #[serde(skip_serializing)]
+    pub databases_store: Box<dyn DatabasesStore + Sync + Send>,
     #[serde(skip_serializing)]
     pub qdrant_clients: QdrantClients,
     #[serde(skip_serializing)]

--- a/core/src/sqlite_workers/sqlite_database.rs
+++ b/core/src/sqlite_workers/sqlite_database.rs
@@ -208,7 +208,7 @@ async fn create_in_memory_sqlite_db(
         let generate_create_table_sql_start = utils::now();
         let create_tables_sql: String = tables
             .into_iter()
-            .filter_map(|t| match t.schema() {
+            .filter_map(|t| match t.schema_cached() {
                 Some(s) => {
                     if s.is_empty() {
                         None
@@ -240,10 +240,10 @@ async fn create_in_memory_sqlite_db(
             .iter()
             .filter(|(_, rows)| !rows.is_empty())
             .map(|(table, rows)| {
-                if table.schema().is_none() {
-                    Err(anyhow!("No schema found for table {}", table.name()))?;
+                if table.schema_cached().is_none() {
+                    Err(anyhow!("No cached schema found for table {}", table.name()))?;
                 }
-                let table_schema = table.schema().unwrap();
+                let table_schema = table.schema_cached().unwrap();
                 let (sql, field_names) = table_schema.get_insert_sql(table.name());
                 let mut stmt = conn.prepare(&sql)?;
 

--- a/core/src/stores/migrations/20240221_tables_add_schema_stale_at
+++ b/core/src/stores/migrations/20240221_tables_add_schema_stale_at
@@ -1,0 +1,4 @@
+ALTER TABLE
+    tables
+ADD
+    COLUMN schema_stale_at BIGINT;

--- a/core/src/stores/postgres.rs
+++ b/core/src/stores/postgres.rs
@@ -2198,6 +2198,7 @@ impl Store for PostgresStore {
             &table_name,
             &table_description,
             &None,
+            None,
         ))
     }
 
@@ -2231,7 +2232,7 @@ impl Store for PostgresStore {
         // Update the schema.
         let stmt = c
             .prepare(
-                "UPDATE tables SET schema = $1 \
+                "UPDATE tables SET schema = $1, schema_stale_at = NULL \
                    WHERE data_source = $2 AND table_id = $3",
             )
             .await?;
@@ -2244,6 +2245,46 @@ impl Store for PostgresStore {
             ],
         )
         .await?;
+
+        Ok(())
+    }
+
+    async fn invalidate_table_schema(
+        &self,
+        project: &Project,
+        data_source_id: &str,
+        table_id: &str,
+    ) -> Result<()> {
+        let project_id = project.project_id();
+        let data_source_id = data_source_id.to_string();
+        let table_id = table_id.to_string();
+
+        let pool = self.pool.clone();
+        let c = pool.get().await?;
+
+        // Get the data source row id.
+        let stmt = c
+            .prepare(
+                "SELECT id FROM data_sources WHERE project = $1 AND data_source_id = $2 LIMIT 1",
+            )
+            .await?;
+        let r = c.query(&stmt, &[&project_id, &data_source_id]).await?;
+        let data_source_row_id: i64 = match r.len() {
+            0 => Err(anyhow!("Unknown DataSource: {}", data_source_id))?,
+            1 => r[0].get(0),
+            _ => unreachable!(),
+        };
+
+        // Invalidate the schema.
+        let schema_stale_at = utils::now() as i64;
+        let stmt = c
+            .prepare(
+                "UPDATE tables SET schema_stale_at = $1 \
+                   WHERE data_source = $1 AND table_id = $2",
+            )
+            .await?;
+        c.query(&stmt, &[&data_source_row_id, &table_id, &schema_stale_at])
+            .await?;
 
         Ok(())
     }
@@ -2276,13 +2317,13 @@ impl Store for PostgresStore {
 
         let stmt = c
             .prepare(
-                "SELECT created, table_id, name, description, schema FROM tables \
+                "SELECT created, table_id, name, description, schema, schema_stale_at FROM tables \
                 WHERE data_source = $1 AND table_id = $2 LIMIT 1",
             )
             .await?;
         let r = c.query(&stmt, &[&data_source_row_id, &table_id]).await?;
 
-        let d: Option<(i64, String, String, String, Option<String>)> = match r.len() {
+        let d: Option<(i64, String, String, String, Option<String>, Option<i64>)> = match r.len() {
             0 => None,
             1 => Some((
                 r[0].get(0),
@@ -2290,13 +2331,14 @@ impl Store for PostgresStore {
                 r[0].get(2),
                 r[0].get(3),
                 r[0].get(4),
+                r[0].get(5),
             )),
             _ => unreachable!(),
         };
 
         match d {
             None => Ok(None),
-            Some((created, table_id, name, description, schema)) => {
+            Some((created, table_id, name, description, schema, schema_stale_at)) => {
                 let parsed_schema: Option<TableSchema> = match schema {
                     None => None,
                     Some(schema) => {
@@ -2315,6 +2357,7 @@ impl Store for PostgresStore {
                     &name,
                     &description,
                     &parsed_schema,
+                    schema_stale_at.map(|t| t as u64),
                 )))
             }
         }
@@ -2359,7 +2402,7 @@ impl Store for PostgresStore {
             Some((limit, offset)) => {
                 let stmt = c
                     .prepare(
-                        "SELECT created, table_id, name, description, schema FROM tables \
+                        "SELECT created, table_id, name, description, schema, schema_stale_at FROM tables \
                         WHERE data_source = $1 LIMIT $2 OFFSET $3",
                     )
                     .await?;
@@ -2379,6 +2422,7 @@ impl Store for PostgresStore {
                 let name: String = r.get(2);
                 let description: String = r.get(3);
                 let schema: Option<String> = r.get(4);
+                let schema_stale_at: Option<i64> = r.get(5);
 
                 let parsed_schema: Option<TableSchema> = match schema {
                     None => None,
@@ -2399,6 +2443,7 @@ impl Store for PostgresStore {
                     &name,
                     &description,
                     &parsed_schema,
+                    schema_stale_at.map(|t| t as u64),
                 ))
             })
             .collect::<Result<Vec<_>>>()?;

--- a/core/src/stores/postgres.rs
+++ b/core/src/stores/postgres.rs
@@ -2280,10 +2280,10 @@ impl Store for PostgresStore {
         let stmt = c
             .prepare(
                 "UPDATE tables SET schema_stale_at = $1 \
-                   WHERE data_source = $1 AND table_id = $2",
+                   WHERE data_source = $2 AND table_id = $3",
             )
             .await?;
-        c.query(&stmt, &[&data_source_row_id, &table_id, &schema_stale_at])
+        c.query(&stmt, &[&schema_stale_at, &data_source_row_id, &table_id])
             .await?;
 
         Ok(())
@@ -2393,7 +2393,7 @@ impl Store for PostgresStore {
             None => {
                 let stmt = c
                     .prepare(
-                        "SELECT created, table_id, name, description, schema FROM tables \
+                        "SELECT created, table_id, name, description, schema, schema_stale_at FROM tables \
                         WHERE data_source = $1",
                     )
                     .await?;

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -189,6 +189,12 @@ pub trait Store {
         table_id: &str,
         schema: &TableSchema,
     ) -> Result<()>;
+    async fn invalidate_table_schema(
+        &self,
+        project: &Project,
+        data_source_id: &str,
+        table_id: &str,
+    ) -> Result<()>;
     async fn load_table(
         &self,
         project: &Project,
@@ -403,6 +409,7 @@ pub const POSTGRES_TABLES: [&'static str; 14] = [
        name                     TEXT NOT NULL, -- unique within datasource
        description              TEXT NOT NULL,
        schema                   TEXT, -- json, kept up-to-date automatically with the last insert
+       schema_stale_at          BIGINT, -- timestamp when the schema was last invalidated
        data_source              BIGINT NOT NULL,
        FOREIGN KEY(data_source) REFERENCES data_sources(id)
     );",


### PR DESCRIPTION
## Description

When doing incremental updates to structured data tables, we cannot guarantee that the cached schema types are as narrow as possible.

Consider the following example.

First, this data is inserted:
```
{row_id: 1, value: {col_1: 42}}
```
`col_1` is correctly inferred as `integer`

Then:

```
{row_id: 2, value: {col_1: "Hello !"}}
```

`col_1` is now widened as `text`

Then:

```
{row_id: 2, value: {col_1: 42}}
```

Row with `row_id=2` is being updated. `col_1` now only contains valid integers, but the column type remains `text`, as there is no way to narrow it back to `integer` without looking at every rows.

While this may seem like an esoteric edge case, this is actually quite common for connected data sources such as Notion Databases that don't enforce strong types on cells. People can typo some values, leading to temporary string values being inserted. These values are often fixed later, but the harm is already done.

With this change, every incremental update to a table causes the schema cache to be marked as "stale" (setting `schema_stale_at` timestamp on the table). Whenever a schema is requested in a `DatabaseSchema`  dust app block, we check whether it is stale. If it is, we recompute it from scratch by iterating over the DB rows (in `core`, not `sqlite-worker`).


## Risk

- Migration to add the new field
- `DatabaseSchema` block will be slower than previously. This should however remain quite fast (much faster than generating the query via the LLM)
- This puts more load on core (loading all the rows). This is mitigated by fetching rows chunk by chunk, not storing all of them in-memory at any given time.

## Deploy Plan

Execute the migration and then deploy core.