### PR TITLE
Intercom: support uninstall webhook

### DIFF
--- a/connectors/src/api_server.ts
+++ b/connectors/src/api_server.ts
@@ -20,7 +20,7 @@ import { syncConnectorAPIHandler } from "@connectors/api/sync_connector";
 import { getConnectorUpdateAPIHandler } from "@connectors/api/update_connector";
 import { webhookGithubAPIHandler } from "@connectors/api/webhooks/webhook_github";
 import { webhookGoogleDriveAPIHandler } from "@connectors/api/webhooks/webhook_google_drive";
-import { webhookIntercomAPIHandler } from "@connectors/api/webhooks/webhook_intercom";
+import { webhookIntercomAPIHandler, webhookIntercomUninstallAPIHandler } from "@connectors/api/webhooks/webhook_intercom";
 import { webhookSlackAPIHandler } from "@connectors/api/webhooks/webhook_slack";
 import { getWebcrawlerConfiguration } from "@connectors/connectors/webcrawler";
 import logger from "@connectors/logger/logger";
@@ -126,6 +126,11 @@ export function startServer(port: number) {
     "/webhooks/:webhooks_secret/intercom",
     bodyParser.raw({ type: "application/json" }),
     webhookIntercomAPIHandler
+  );
+  app.post(
+    "/webhooks/:webhooks_secret/intercom/uninstall",
+    bodyParser.raw({ type: "application/json" }),
+    webhookIntercomUninstallAPIHandler,
   );
 
   app.post(

--- a/connectors/src/connectors/intercom/temporal/workflows.ts
+++ b/connectors/src/connectors/intercom/temporal/workflows.ts
@@ -139,7 +139,7 @@ export async function intercomSyncWorkflow({
     connectorId,
   });
 
-  await await saveIntercomConnectorSuccessSync({ connectorId });
+  await saveIntercomConnectorSuccessSync({ connectorId });
 }
 
 /**

--- a/front/components/data_source/DataSourceSyncChip.tsx
+++ b/front/components/data_source/DataSourceSyncChip.tsx
@@ -42,23 +42,21 @@ export default function ConnectorSyncingChip({
             case "oauth_token_revoked":
               return (
                 <>
-                  Oops! It seems that our access to your account has been
-                  revoked. Please re-authorize this Data Source to keep your
-                  data up to date on Dust.
+                  Our access to your account has been revoked. Re-authorize to
+                  keep the connection up-to-date.
                 </>
               );
             case "third_party_internal_error":
               return (
                 <>
-                  We have encountered an error talking to{" "}
+                  We have encountered an error with{" "}
                   {CONNECTOR_CONFIGURATIONS[connector.type].name}. We sent you
-                  an email with more details to resolve the issue.
+                  an email to resolve the issue.
                 </>
               );
             default:
               assertNever(connector.errorType);
           }
-          return <></>;
         })()}
       </Chip>
     );


### PR DESCRIPTION
Fixes https://github.com/dust-tt/tasks/issues/424

## Description

- Add supports for Intercom uninstall webhook
- Solely relies on the webhook secret since signing is not documented for this webhook
- When received:
  - Cancels the workflow
  - Mark the connector as errored
  - delete the nango connection

![Screenshot from 2024-02-21 14-38-57](https://github.com/dust-tt/dust/assets/15067/ba96c7c8-e91c-4455-9826-2bd05ae4ce27)

## Risk

N/A

## Deploy Plan

- [x] Add secret `INTERCOM_CLIENT_SECRET` to `connectors-secret`
- [x] Remove secret `INTERCOM_WEBHOOK_SECRET` from `connectors-secret`
- [x] deploy `front`
- [x] deploy `connectors`
- [x] Set uninstall URL in Intercom prod app