### PR TITLE
Intercom: uninstall app on connector clean-up

### DIFF
--- a/connectors/src/api/webhooks/webhook_intercom.ts
+++ b/connectors/src/api/webhooks/webhook_intercom.ts
@@ -221,19 +221,20 @@ const _webhookIntercomUninstallAPIHandler = async (
   await syncFailed(connector.id, "oauth_token_revoked");
 
   // Attempt to delete the nango connection Id. But fail silently if it fails.
-  nangoDeleteConnection(
+  const nangoRes = await nangoDeleteConnection(
     connector.connectionId,
     NANGO_INTERCOM_CONNECTOR_ID
-  ).catch((e) => {
+  );
+  if (nangoRes.isErr()) {
     logger.error(
       {
-        error: e,
+        error: nangoRes.error,
         connectorId: connector.id,
         connectionId: connector.connectionId,
       },
       "Error deleting old Nango connection (intercom uninstall webhook)"
     );
-  });
+  }
 
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
   const loggerArgs = {

--- a/connectors/src/api_server.ts
+++ b/connectors/src/api_server.ts
@@ -20,7 +20,10 @@ import { syncConnectorAPIHandler } from "@connectors/api/sync_connector";
 import { getConnectorUpdateAPIHandler } from "@connectors/api/update_connector";
 import { webhookGithubAPIHandler } from "@connectors/api/webhooks/webhook_github";
 import { webhookGoogleDriveAPIHandler } from "@connectors/api/webhooks/webhook_google_drive";
-import { webhookIntercomAPIHandler, webhookIntercomUninstallAPIHandler } from "@connectors/api/webhooks/webhook_intercom";
+import {
+  webhookIntercomAPIHandler,
+  webhookIntercomUninstallAPIHandler,
+} from "@connectors/api/webhooks/webhook_intercom";
 import { webhookSlackAPIHandler } from "@connectors/api/webhooks/webhook_slack";
 import { getWebcrawlerConfiguration } from "@connectors/connectors/webcrawler";
 import logger from "@connectors/logger/logger";
@@ -130,7 +133,7 @@ export function startServer(port: number) {
   app.post(
     "/webhooks/:webhooks_secret/intercom/uninstall",
     bodyParser.raw({ type: "application/json" }),
-    webhookIntercomUninstallAPIHandler,
+    webhookIntercomUninstallAPIHandler
   );
 
   app.post(

--- a/connectors/src/connectors/intercom/index.ts
+++ b/connectors/src/connectors/intercom/index.ts
@@ -47,13 +47,13 @@ import {
   IntercomWorkspace,
 } from "@connectors/lib/models/intercom";
 import { nangoDeleteConnection } from "@connectors/lib/nango_client";
+import { getAccessTokenFromNango } from "@connectors/lib/nango_helpers";
 import { Err, Ok } from "@connectors/lib/result";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
 import type { DataSourceConfig } from "@connectors/types/data_source_config";
 import type { NangoConnectionId } from "@connectors/types/nango_connection_id";
-import { getAccessTokenFromNango } from "@connectors/lib/nango_helpers";
 
 const { NANGO_INTERCOM_CONNECTOR_ID } = process.env;
 


### PR DESCRIPTION
Fixes: https://github.com/dust-tt/tasks/issues/433

## Description

- When cleaning up the connector (delete from poke), attempt to uninstall the app. Do not fail if not possible (may have already been done if the app was uninstalled from Intercom)

## Risk

N/A

## Deploy Plan

- deploy `connector`