### PR TITLE
sparkle: overflow visible on DropdownMenu.Items to allow nested Dropdown

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "front",
       "dependencies": {
         "@dust-tt/sparkle": "^0.2.98",
         "@dust-tt/types": "file:../types",
@@ -24153,9 +24154,10 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "5.28.2",
+      "version": "5.28.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.3.tgz",
+      "integrity": "sha512-3ItfzbrhDlINjaP0duwnNsKpDQk3acHI3gVJ1z4fmwMK31k5G9OVIAMLSIaP6w4FaGkaAkN6zaQO9LUvZ1t7VA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@fastify/busboy": "^2.0.0"
       },

--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.98",
+  "version": "0.2.99",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.98",
+      "version": "0.2.99",
       "license": "ISC",
       "dependencies": {
         "@headlessui/react": "^1.7.17",
@@ -15636,9 +15636,9 @@
       }
     },
     "node_modules/ip": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
-      "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
+      "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==",
       "dev": true
     },
     "node_modules/ipaddr.js": {

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.98",
+  "version": "0.2.99",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/components/DropdownMenu.tsx
+++ b/sparkle/src/components/DropdownMenu.tsx
@@ -369,9 +369,9 @@ DropdownMenu.Items = function ({
       case "visible":
         return "s-overflow-visible";
       case "auto":
-        return "s-overflow-auto s-max-h-[344px]";
+        return "s-max-h-[344px] s-overflow-auto";
       default:
-        return "s-overflow-auto";
+        return "s-max-h-[344px] s-overflow-auto";
     }
   };
 

--- a/sparkle/src/components/DropdownMenu.tsx
+++ b/sparkle/src/components/DropdownMenu.tsx
@@ -311,6 +311,7 @@ interface DropdownItemsProps {
   children: React.ReactNode;
   topBar?: React.ReactNode;
   bottomBar?: React.ReactNode;
+  overflow?: "visible" | "auto";
 }
 
 DropdownMenu.Items = function ({
@@ -320,6 +321,7 @@ DropdownMenu.Items = function ({
   children,
   topBar,
   bottomBar,
+  overflow = "auto",
 }: DropdownItemsProps) {
   const buttonRef = useContext(ButtonRefContext);
   const [buttonHeight, setButtonHeight] = useState(0);
@@ -362,6 +364,17 @@ DropdownMenu.Items = function ({
     }
   };
 
+  const getOverflowClass = (overflow: string) => {
+    switch (overflow) {
+      case "visible":
+        return "s-overflow-visible";
+      case "auto":
+        return "s-overflow-auto";
+      default:
+        return "s-overflow-auto";
+    }
+  };
+
   const styleInsert = (origin: string, marginLeft?: number) => {
     const style: { width: string; top?: string; left?: string } = {
       width: `${width}px`,
@@ -397,7 +410,12 @@ DropdownMenu.Items = function ({
         style={styleInsert(origin, marginLeft)}
       >
         {topBar}
-        <div className="s-max-h-[344px] s-overflow-auto s-px-5 s-py-1.5">
+        <div
+          className={classNames(
+            "s-max-h-[344px] s-px-5 s-py-1.5",
+            getOverflowClass(overflow)
+          )}
+        >
           <StandardItem.List>{children}</StandardItem.List>
         </div>
         {bottomBar}

--- a/sparkle/src/components/DropdownMenu.tsx
+++ b/sparkle/src/components/DropdownMenu.tsx
@@ -369,7 +369,7 @@ DropdownMenu.Items = function ({
       case "visible":
         return "s-overflow-visible";
       case "auto":
-        return "s-overflow-auto";
+        return "s-overflow-auto s-max-h-[344px]";
       default:
         return "s-overflow-auto";
     }
@@ -411,10 +411,7 @@ DropdownMenu.Items = function ({
       >
         {topBar}
         <div
-          className={classNames(
-            "s-max-h-[344px] s-px-5 s-py-1.5",
-            getOverflowClass(overflow)
-          )}
+          className={classNames("s-px-5 s-py-1.5", getOverflowClass(overflow))}
         >
           <StandardItem.List>{children}</StandardItem.List>
         </div>

--- a/sparkle/src/stories/DropdownMenu.stories.tsx
+++ b/sparkle/src/stories/DropdownMenu.stories.tsx
@@ -388,6 +388,22 @@ export const DropdownExample = () => {
           </DropdownMenu.Items>
         </DropdownMenu>
       </div>
+      <div className="s-h-12" />
+      <div className="s-flex s-gap-6">
+        <div className="s-text-sm">With nested dropdown</div>
+        <DropdownMenu>
+          <DropdownMenu.Button icon={RobotIcon} />
+          <DropdownMenu.Items origin="topRight" overflow="visible">
+            <DropdownMenu>
+              <DropdownMenu.Button label="Nested" />
+              <DropdownMenu.Items origin="topRight">
+                <DropdownMenu.Item label="item 1" href="#" />
+                <DropdownMenu.Item label="item 2" href="#" />
+              </DropdownMenu.Items>
+            </DropdownMenu>
+          </DropdownMenu.Items>
+        </DropdownMenu>
+      </div>
       <div className="w-full s-flex s-justify-end s-gap-6">
         <div className="s-text-sm">Auto menu</div>
         <DropdownMenu>


### PR DESCRIPTION
## Description

Allow overflow to be set to `visible` on Dropdown.Items to allow nested dropdown menus
Required for Meru in 2 places.

![Screenshot from 2024-02-21 16-58-47](https://github.com/dust-tt/dust/assets/15067/c8ad2b5b-61a7-4289-8a29-a106190c05d3)


## Risk

N/A

## Deploy Plan

- rollout sparkle