### PR TITLE
Intercom fetch collections

### DIFF
--- a/connectors/package-lock.json
+++ b/connectors/package-lock.json
@@ -31,7 +31,6 @@
         "fs-extra": "^11.1.1",
         "googleapis": "^118.0.0",
         "hot-shots": "^10.0.0",
-        "intercom-client": "^5.0.0",
         "io-ts": "^2.2.20",
         "io-ts-reporters": "^2.0.1",
         "lodash.get": "^4.4.2",
@@ -6214,11 +6213,6 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
       "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ=="
     },
-    "node_modules/htmlencode": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/htmlencode/-/htmlencode-0.0.4.tgz",
-      "integrity": "sha512-0uDvNVpzj/E2TfvLLyyXhKBRvF1y84aZsyRxRXFsQobnHaL4pcaXk+Y9cnFlvnxrBLeXDNq/VJBD+ngdBgQG1w=="
-    },
     "node_modules/htmlparser2": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
@@ -6473,19 +6467,6 @@
       "version": "0.1.10",
       "resolved": "https://registry.npmjs.org/int64-buffer/-/int64-buffer-0.1.10.tgz",
       "integrity": "sha512-v7cSY1J8ydZ0GyjUHqF+1bshJ6cnEVLo9EnjB8p+4HDRPZc9N5jjmvUV7NvEsqQOKyH0pmIBFWXVQbiS0+OBbA=="
-    },
-    "node_modules/intercom-client": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/intercom-client/-/intercom-client-5.0.0.tgz",
-      "integrity": "sha512-fEzM9w+apUwK6roDyZPvfXqmI9mrdM5Nz0QmCeDTM/8G2I0464SzJDfLTDRvz+ZkY6EIeTHEaQnK09DmYgqRhA==",
-      "dependencies": {
-        "axios": "^1.6.0",
-        "htmlencode": "^0.0.4",
-        "lodash": "^4.17.21"
-      },
-      "engines": {
-        "node": ">= v8.0.0"
-      }
     },
     "node_modules/internal-slot": {
       "version": "1.0.6",

--- a/connectors/package.json
+++ b/connectors/package.json
@@ -36,7 +36,6 @@
     "fs-extra": "^11.1.1",
     "googleapis": "^118.0.0",
     "hot-shots": "^10.0.0",
-    "intercom-client": "^5.0.0",
     "io-ts": "^2.2.20",
     "io-ts-reporters": "^2.0.1",
     "lodash.get": "^4.4.2",

--- a/connectors/src/api/webhooks/webhook_intercom.ts
+++ b/connectors/src/api/webhooks/webhook_intercom.ts
@@ -1,7 +1,7 @@
 import type { WithConnectorsAPIErrorReponse } from "@dust-tt/types";
 import type { Request, Response } from "express";
 
-import type { IntercomConversationWithPartsType } from "@connectors/connectors/intercom/lib/intercom_api";
+import type { IntercomConversationWithPartsType } from "@connectors/connectors/intercom/lib/types";
 import { stopIntercomSyncWorkflow } from "@connectors/connectors/intercom/temporal/client";
 import { syncConversation } from "@connectors/connectors/intercom/temporal/sync_conversation";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";

--- a/connectors/src/connectors/intercom/index.ts
+++ b/connectors/src/connectors/intercom/index.ts
@@ -19,10 +19,7 @@ import {
   revokeSyncCollection,
   revokeSyncHelpCenter,
 } from "@connectors/connectors/intercom/lib/help_center_permissions";
-import {
-  fetchIntercomWorkspace,
-  getIntercomClient,
-} from "@connectors/connectors/intercom/lib/intercom_api";
+import { fetchIntercomWorkspace } from "@connectors/connectors/intercom/lib/intercom_api";
 import {
   getHelpCenterArticleIdFromInternalId,
   getHelpCenterArticleInternalId,
@@ -355,8 +352,8 @@ export async function setIntercomConnectorPermissions(
     logger.error({ connectorId }, "[Intercom] Connector not found.");
     return new Err(new Error("Connector not found"));
   }
+  const connectionId = connector.connectionId;
 
-  const intercomClient = await getIntercomClient(connector.connectionId);
   const toBeSignaledHelpCenterIds = new Set<string>();
   const toBeSignaledTeamIds = new Set<string>();
 
@@ -381,14 +378,14 @@ export async function setIntercomConnectorPermissions(
         toBeSignaledHelpCenterIds.add(helpCenterId);
         if (permission === "none") {
           await revokeSyncHelpCenter({
-            connector,
+            connectorId,
             helpCenterId,
           });
         }
         if (permission === "read") {
           await allowSyncHelpCenter({
-            connector,
-            intercomClient,
+            connectorId,
+            connectionId,
             helpCenterId,
             withChildren: true,
           });
@@ -396,7 +393,7 @@ export async function setIntercomConnectorPermissions(
       } else if (collectionId) {
         if (permission === "none") {
           const revokedCollection = await revokeSyncCollection({
-            connector,
+            connectorId,
             collectionId,
           });
           if (revokedCollection) {
@@ -405,8 +402,8 @@ export async function setIntercomConnectorPermissions(
         }
         if (permission === "read") {
           const newCollection = await allowSyncCollection({
-            connector,
-            intercomClient,
+            connectorId,
+            connectionId,
             collectionId,
           });
           if (newCollection) {
@@ -416,7 +413,7 @@ export async function setIntercomConnectorPermissions(
       } else if (teamId) {
         if (permission === "none") {
           const revokedTeam = await revokeSyncTeam({
-            connector,
+            connectorId,
             teamId,
           });
           if (revokedTeam) {
@@ -425,7 +422,8 @@ export async function setIntercomConnectorPermissions(
         }
         if (permission === "read") {
           const newTeam = await allowSyncTeam({
-            connector,
+            connectorId,
+            connectionId,
             teamId,
           });
           if (newTeam) {

--- a/connectors/src/connectors/intercom/lib/help_center_permissions.ts
+++ b/connectors/src/connectors/intercom/lib/help_center_permissions.ts
@@ -1,5 +1,4 @@
-import type { ConnectorNode } from "@dust-tt/types";
-import type { Client as IntercomClient } from "intercom-client";
+import type { ConnectorNode, ModelId } from "@dust-tt/types";
 import { Op } from "sequelize";
 
 import {
@@ -9,6 +8,7 @@ import {
   fetchIntercomHelpCenters,
 } from "@connectors/connectors/intercom/lib/intercom_api";
 import {
+  getCollectionInAppUrl,
   getHelpCenterArticleInternalId,
   getHelpCenterCollectionIdFromInternalId,
   getHelpCenterCollectionInternalId,
@@ -37,19 +37,19 @@ import { ConnectorResource } from "@connectors/resources/connector_resource";
  * Mark a help center as permission "read" and all children (collections & articles) if specified.
  */
 export async function allowSyncHelpCenter({
-  connector,
-  intercomClient,
+  connectorId,
+  connectionId,
   helpCenterId,
   withChildren = false,
 }: {
-  connector: ConnectorResource;
-  intercomClient: IntercomClient;
+  connectorId: ModelId;
+  connectionId: string;
   helpCenterId: string;
   withChildren?: boolean;
 }): Promise<IntercomHelpCenter> {
   let helpCenter = await IntercomHelpCenter.findOne({
     where: {
-      connectorId: connector.id,
+      connectorId,
       helpCenterId,
     },
   });
@@ -61,12 +61,12 @@ export async function allowSyncHelpCenter({
   }
   if (!helpCenter) {
     const helpCenterOnIntercom = await fetchIntercomHelpCenter(
-      connector.connectionId,
+      connectionId,
       helpCenterId
     );
     if (helpCenterOnIntercom) {
       helpCenter = await IntercomHelpCenter.create({
-        connectorId: connector.id,
+        connectorId: connectorId,
         helpCenterId: helpCenterOnIntercom.id,
         name: helpCenterOnIntercom.display_name || "Help Center",
         identifier: helpCenterOnIntercom.identifier,
@@ -85,14 +85,14 @@ export async function allowSyncHelpCenter({
   // If withChildren we are allowing the full Help Center.
   if (withChildren) {
     const level1Collections = await fetchIntercomCollections(
-      connector.connectionId,
+      connectionId,
       helpCenter.helpCenterId,
       null
     );
     const permissionUpdatePromises = level1Collections.map((c1) =>
       allowSyncCollection({
-        connector,
-        intercomClient,
+        connectorId,
+        connectionId,
         collectionId: c1.id,
       })
     );
@@ -106,15 +106,15 @@ export async function allowSyncHelpCenter({
  * Mark a help center as permission "none" and all children (collections & articles).
  */
 export async function revokeSyncHelpCenter({
-  connector,
+  connectorId,
   helpCenterId,
 }: {
-  connector: ConnectorResource;
+  connectorId: ModelId;
   helpCenterId: string;
 }): Promise<IntercomHelpCenter | null> {
   const helpCenter = await IntercomHelpCenter.findOne({
     where: {
-      connectorId: connector.id,
+      connectorId,
       helpCenterId,
     },
   });
@@ -165,17 +165,17 @@ export async function revokeSyncHelpCenter({
  * Mark a collection as permission "read" and all children (collections & articles)
  */
 export async function allowSyncCollection({
-  connector,
-  intercomClient,
+  connectorId,
+  connectionId,
   collectionId,
 }: {
-  connector: ConnectorResource;
-  intercomClient: IntercomClient;
+  connectorId: ModelId;
+  connectionId: string;
   collectionId: string;
 }): Promise<IntercomCollection | null> {
   let collection = await IntercomCollection.findOne({
     where: {
-      connectorId: connector.id,
+      connectorId: connectorId,
       collectionId,
     },
   });
@@ -186,19 +186,20 @@ export async function allowSyncCollection({
     });
   } else if (!collection) {
     const intercomCollection = await fetchIntercomCollection(
-      intercomClient,
+      connectionId,
       collectionId
     );
-    if (intercomCollection) {
+    if (intercomCollection && intercomCollection.help_center_id) {
       collection = await IntercomCollection.create({
-        connectorId: connector.id,
+        connectorId,
         collectionId: intercomCollection.id,
         intercomWorkspaceId: intercomCollection.workspace_id,
         helpCenterId: intercomCollection.help_center_id,
         parentId: intercomCollection.parent_id,
         name: intercomCollection.name,
         description: intercomCollection.description,
-        url: intercomCollection.url,
+        url:
+          intercomCollection.url || getCollectionInAppUrl(intercomCollection),
         permission: "read",
       });
     }
@@ -215,12 +216,12 @@ export async function allowSyncCollection({
   // We create the Help Center if it doesn't exist and fetch the children collections
   const [, childrenCollections] = await Promise.all([
     allowSyncHelpCenter({
-      connector,
-      intercomClient,
+      connectorId,
+      connectionId,
       helpCenterId: collection.helpCenterId,
     }),
     fetchIntercomCollections(
-      connector.connectionId,
+      connectionId,
       collection.helpCenterId,
       collection.collectionId
     ),
@@ -228,8 +229,8 @@ export async function allowSyncCollection({
 
   const collectionPermissionPromises = childrenCollections.map((c) =>
     allowSyncCollection({
-      connector,
-      intercomClient,
+      connectorId,
+      connectionId,
       collectionId: c.id,
     })
   );
@@ -242,16 +243,16 @@ export async function allowSyncCollection({
  * Mark a collection as permission "none" and all children (collections & articles)
  */
 export async function revokeSyncCollection({
-  connector,
+  connectorId,
   collectionId,
 }: {
-  connector: ConnectorResource;
+  connectorId: ModelId;
   collectionId: string;
 }): Promise<IntercomCollection | null> {
   // Revoke permission for this level 1 collection
   const collection = await IntercomCollection.findOne({
     where: {
-      connectorId: connector.id,
+      connectorId,
       collectionId,
     },
   });
@@ -318,7 +319,7 @@ export async function revokeSyncCollection({
   });
   if (level1Collections.length === 0) {
     await revokeSyncHelpCenter({
-      connector,
+      connectorId,
       helpCenterId: collection.helpCenterId,
     });
   }

--- a/connectors/src/connectors/intercom/lib/help_center_permissions.ts
+++ b/connectors/src/connectors/intercom/lib/help_center_permissions.ts
@@ -7,7 +7,6 @@ import {
   fetchIntercomCollections,
   fetchIntercomHelpCenter,
   fetchIntercomHelpCenters,
-  getIntercomClient,
 } from "@connectors/connectors/intercom/lib/intercom_api";
 import {
   getHelpCenterArticleInternalId,
@@ -86,7 +85,7 @@ export async function allowSyncHelpCenter({
   // If withChildren we are allowing the full Help Center.
   if (withChildren) {
     const level1Collections = await fetchIntercomCollections(
-      intercomClient,
+      connector.connectionId,
       helpCenter.helpCenterId,
       null
     );
@@ -221,7 +220,7 @@ export async function allowSyncCollection({
       helpCenterId: collection.helpCenterId,
     }),
     fetchIntercomCollections(
-      intercomClient,
+      connector.connectionId,
       collection.helpCenterId,
       collection.collectionId
     ),
@@ -338,7 +337,6 @@ export async function retrieveIntercomHelpCentersPermissions({
     throw new Error("Connector not found");
   }
 
-  const intercomClient = await getIntercomClient(connector.connectionId);
   const isReadPermissionsOnly = filterPermission === "read";
   const isRootLevel = !parentInternalId;
   let nodes: ConnectorNode[] = [];
@@ -436,7 +434,7 @@ export async function retrieveIntercomHelpCentersPermissions({
       }));
     } else {
       const collectionsInIntercom = await fetchIntercomCollections(
-        intercomClient,
+        connector.connectionId,
         helpCenterParentId,
         parentId
       );

--- a/connectors/src/connectors/intercom/lib/intercom_api.ts
+++ b/connectors/src/connectors/intercom/lib/intercom_api.ts
@@ -1,121 +1,44 @@
 import type {
-  ArticleObject,
-  CollectionObject,
-  TeamObject,
-} from "intercom-client";
-import { Client } from "intercom-client";
-
-import { HTTPError } from "@connectors/lib/error";
+  IntercomArticleType,
+  IntercomCollectionType,
+  IntercomConversationType,
+  IntercomConversationWithPartsType,
+  IntercomHelpCenterType,
+  IntercomTeamType,
+} from "@connectors/connectors/intercom/lib/types";
+import { ExternalOauthTokenError } from "@connectors/lib/error";
 import { getAccessTokenFromNango } from "@connectors/lib/nango_helpers";
 
 const { NANGO_INTERCOM_CONNECTOR_ID } = process.env;
 
-type IntercomMeResponseType = {
-  type: string;
-  id: string;
-  email: string;
-  name: string;
-  app: {
-    type: "app";
-    id_code: string;
-    name: string;
-  };
-};
-
-export type IntercomHelpCenterType = {
-  id: string;
-  workspace_id: string;
-  created_at: number;
-  updated_at: number;
-  identifier: string;
-  website_turned_on: boolean;
-  display_name: string | null;
-};
-
-export type IntercomCollectionType = CollectionObject & {
-  help_center_id: string;
-  parent_id: string;
-};
-
-export type IntercomArticleType = ArticleObject & {
-  parent_ids: string[];
-};
-
-export type IntercomTeamType = {
-  type: "team";
-  id: string;
-  name: string;
-  admin_ids: string[];
-};
-
-export type IntercomConversationType = {
-  type: "conversation";
-  id: string;
-  created_at: number;
-  updated_at: number;
-  title: string | null;
-  admin_assignee_id: number | null;
-  team_assignee_id: number | null; // it says string in the API doc but it's actually a number
-  open: boolean;
-  tags: {
-    type: "tag.list";
-    tags: IntercomTagType[];
-  };
-  source: {
-    type: string;
-    id: number;
-    delivered_as: string;
-    subject: string;
-    body: string;
-    author: IntercomAuthor;
-  };
-};
-
-export type IntercomConversationWithPartsType = IntercomConversationType & {
-  conversation_parts: {
-    type: "conversation_part.list";
-    conversation_parts: ConversationPartType[];
-    total_count: number;
-  };
-};
-
-export type IntercomTagType = {
-  type: "tag";
-  id: string;
-  name: string;
-};
-
-export type ConversationPartType = {
-  type: "conversation_part";
-  id: string;
-  part_type: string;
-  body: string;
-  created_at: Date;
-  updated_at: Date;
-  notified_at: Date;
-  assigned_to: {
-    type: string;
-    id: string;
-  };
-  author: IntercomAuthor;
-  attachments: [];
-  redacted: boolean;
-};
-
-type IntercomAuthor = {
-  id: string;
-  type: "user" | "admin" | "bot" | "team";
-  name: string;
-  email: string;
-};
-
 /**
- * Return the Intercom Access Token that was defined in the Dust Intercom App.
- * We store it in Nango.
+ * Utility function to call the Intercom API.
+ * It centralizes fetching the Access Token from Nango, calling the API and handling global errors.
  */
-export async function getIntercomClient(
-  nangoConnectionId: string
-): Promise<Client> {
+async function queryIntercomAPI({
+  nangoConnectionId,
+  path,
+  method,
+  body,
+}: {
+  nangoConnectionId: string;
+  path: string;
+  method: "GET" | "POST";
+  body?: {
+    query: {
+      operator: "AND" | "OR";
+      value: {
+        field: string;
+        operator: string;
+        value: string | number | boolean | [] | null;
+      }[];
+    };
+    pagination: {
+      per_page: number;
+      starting_after: string | null;
+    };
+  };
+}) {
   if (!NANGO_INTERCOM_CONNECTOR_ID) {
     throw new Error("NANGO_NOTION_CONNECTOR_ID not set");
   }
@@ -126,115 +49,98 @@ export async function getIntercomClient(
     useCache: true,
   });
 
-  return new Client({
-    tokenAuth: { token: accessToken },
+  const rawResponse = await fetch(`https://api.intercom.io/${path}`, {
+    method,
+    headers: {
+      "Intercom-Version": "2.10",
+      Authorization: `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+    },
+    body: body ? JSON.stringify(body) : undefined,
   });
+
+  const response = await rawResponse.json();
+
+  if (!rawResponse.ok) {
+    if (
+      response.type === "error.list" &&
+      response.errors &&
+      response.errors.length > 0
+    ) {
+      const error = response.errors[0];
+      // This error is thrown when we are dealing with a revoked OAuth token.
+      if (error.code === "unauthorized") {
+        throw new ExternalOauthTokenError();
+      }
+      // We return null for 404 errors.
+      if (error.code === "not_found") {
+        return null;
+      }
+    }
+  }
+
+  return response;
 }
 
 /**
- * Return the Intercom Workspace Id.
- * Not available via the Node SDK, calling the API directly.
+ * Return the Intercom Workspace.
  */
 export async function fetchIntercomWorkspace(
   nangoConnectionId: string
 ): Promise<{
   id: string;
   name: string;
-}> {
-  if (!NANGO_INTERCOM_CONNECTOR_ID) {
-    throw new Error("NANGO_NOTION_CONNECTOR_ID not set");
-  }
-
-  const accessToken = await getAccessTokenFromNango({
-    connectionId: nangoConnectionId,
-    integrationId: NANGO_INTERCOM_CONNECTOR_ID,
-    useCache: true,
-  });
-
-  const resp = await fetch(`https://api.intercom.io/me`, {
+} | null> {
+  const response = await queryIntercomAPI({
+    nangoConnectionId,
+    path: "me",
     method: "GET",
-    headers: {
-      "Intercom-Version": "2.10",
-      Authorization: `Bearer ${accessToken}`,
-    },
   });
 
-  const data: IntercomMeResponseType = await resp.json();
-  const workspaceId = data.app.id_code;
+  const workspaceId = response?.app?.id_code;
+  const workspaceName = response?.app?.name;
 
-  if (!workspaceId) {
-    throw new Error("No Intercom Workspace Id found.");
+  if (!workspaceId || !workspaceName) {
+    return null;
   }
+
   return {
     id: workspaceId,
-    name: data.app.name,
+    name: workspaceName,
   };
 }
 
 /**
  * Return the list of Help Centers of the Intercom workspace
- * Not available via the Node SDK, calling the API directly.
  */
 export async function fetchIntercomHelpCenters(
   nangoConnectionId: string
 ): Promise<IntercomHelpCenterType[]> {
-  if (!NANGO_INTERCOM_CONNECTOR_ID) {
-    throw new Error("NANGO_NOTION_CONNECTOR_ID not set");
-  }
-
-  const accessToken = await getAccessTokenFromNango({
-    connectionId: nangoConnectionId,
-    integrationId: NANGO_INTERCOM_CONNECTOR_ID,
-    useCache: true,
-  });
-
-  const resp = await fetch(`https://api.intercom.io/help_center/help_centers`, {
-    method: "GET",
-    headers: {
-      "Intercom-Version": "2.10",
-      Authorization: `Bearer ${accessToken}`,
-    },
-  });
-
-  type HelpCentersGetResponseType = {
+  const response: {
     type: "list";
     data: IntercomHelpCenterType[];
-  };
+  } = await queryIntercomAPI({
+    nangoConnectionId,
+    path: "help_center/help_centers",
+    method: "GET",
+  });
 
-  const response: HelpCentersGetResponseType = await resp.json();
   return response.data;
 }
 
 /**
  * Return the detail of Help Center
- * Not available via the Node SDK, calling the API directly.
  */
 export async function fetchIntercomHelpCenter(
   nangoConnectionId: string,
   helpCenterId: string
-): Promise<IntercomHelpCenterType> {
-  if (!NANGO_INTERCOM_CONNECTOR_ID) {
-    throw new Error("NANGO_NOTION_CONNECTOR_ID not set");
-  }
-
-  const accessToken = await getAccessTokenFromNango({
-    connectionId: nangoConnectionId,
-    integrationId: NANGO_INTERCOM_CONNECTOR_ID,
-    useCache: true,
+): Promise<IntercomHelpCenterType | null> {
+  const response = await queryIntercomAPI({
+    nangoConnectionId,
+    path: `help_center/help_centers/${helpCenterId}`,
+    method: "GET",
   });
 
-  const resp = await fetch(
-    `https://api.intercom.io/help_center/help_centers/${helpCenterId}`,
-    {
-      method: "GET",
-      headers: {
-        "Intercom-Version": "2.10",
-        Authorization: `Bearer ${accessToken}`,
-      },
-    }
-  );
-
-  const response: IntercomHelpCenterType = await resp.json();
   return response;
 }
 
@@ -246,32 +152,15 @@ export async function fetchIntercomCollections(
   helpCenterId: string,
   parentId: string | null
 ): Promise<IntercomCollectionType[]> {
-  if (!NANGO_INTERCOM_CONNECTOR_ID) {
-    throw new Error("NANGO_NOTION_CONNECTOR_ID not set");
-  }
-
-  const accessToken = await getAccessTokenFromNango({
-    connectionId: nangoConnectionId,
-    integrationId: NANGO_INTERCOM_CONNECTOR_ID,
-    useCache: true,
-  });
-
   let response, hasMore;
   let page = 1;
   const collections: IntercomCollectionType[] = [];
   do {
-    const resp = await fetch(
-      `https://api.intercom.io/help_center/collections?page=${page}&per_page=12`,
-      {
-        method: "GET",
-        headers: {
-          "Intercom-Version": "2.10",
-          Authorization: `Bearer ${accessToken}`,
-          "Content-Type": "application/json",
-        },
-      }
-    );
-    response = await resp.json();
+    response = await queryIntercomAPI({
+      nangoConnectionId,
+      path: `help_center/collections?page=${page}&per_page=12`,
+      method: "GET",
+    });
 
     collections.push(...response.data);
     if (response.pages.total_pages > page) {
@@ -293,39 +182,36 @@ export async function fetchIntercomCollections(
  * Return the detail of a Collection.
  */
 export async function fetchIntercomCollection(
-  intercomClient: Client,
+  nangoConnectionId: string,
   collectionId: string
 ): Promise<IntercomCollectionType | null> {
-  try {
-    // @ts-expect-error Property "parent_id" does not exist on type "CollectioObject".
-    return await intercomClient.helpCenter.collections.find({
-      id: collectionId,
-    });
-  } catch (error: unknown) {
-    if (error instanceof HTTPError && error.statusCode === 404) {
-      return null;
-    }
-    throw error;
-  }
+  const response = await queryIntercomAPI({
+    nangoConnectionId,
+    path: `help_center/collections/${collectionId}`,
+    method: "GET",
+  });
+
+  return response;
 }
 
 /**
  * Return the Articles that are children of a given Collection.
  */
 export async function fetchIntercomArticles(
-  intercomClient: Client,
+  nangoConnectionId: string,
+  helpCenterId: string,
   parentId: string | null
 ): Promise<IntercomArticleType[]> {
   let response, hasMore;
   let page = 1;
   const articles: IntercomArticleType[] = [];
   do {
-    response = await intercomClient.articles.list({
-      page,
-      perPage: 12,
+    response = await queryIntercomAPI({
+      nangoConnectionId,
+      path: `articles/search?help_center_id=${helpCenterId}&state=published&page=${page}&per_page=12`,
+      method: "GET",
     });
-    // @ts-expect-error Property "parent_ids" does not exist on type "ArticleObject".
-    articles.push(...response.data);
+    articles.push(...response.data.articles);
     if (response.pages.total_pages > page) {
       hasMore = true;
       page += 1;
@@ -334,39 +220,22 @@ export async function fetchIntercomArticles(
     }
   } while (hasMore);
 
-  return articles.filter(
-    (article) => article.parent_id == parentId && article.state === "published"
-  );
-}
-
-/**
- * Return the detail of an Article.
- */
-export async function fetchIntercomArticle(
-  intercomClient: Client,
-  articleId: string
-): Promise<IntercomArticleType | null> {
-  try {
-    // @ts-expect-error Property "parent_ids" does not exist on type "ArticleObject".
-    return await intercomClient.articles.find({
-      id: articleId,
-    });
-  } catch (error: unknown) {
-    if (error instanceof HTTPError && error.statusCode === 404) {
-      return null;
-    }
-    throw error;
-  }
+  return articles.filter((article) => article.parent_id == parentId);
 }
 
 /**
  * Return the list of Teams.
  */
 export async function fetchIntercomTeams(
-  intercomClient: Client
-): Promise<TeamObject[]> {
-  const teamsResponse = await intercomClient.teams.list();
-  return teamsResponse.teams ?? [];
+  nangoConnectionId: string
+): Promise<IntercomTeamType[]> {
+  const response = await queryIntercomAPI({
+    nangoConnectionId,
+    path: `teams`,
+    method: "GET",
+  });
+
+  return response.teams;
 }
 
 /**
@@ -376,32 +245,18 @@ export async function fetchIntercomTeam(
   nangoConnectionId: string,
   teamId: string
 ): Promise<IntercomTeamType | null> {
-  if (!NANGO_INTERCOM_CONNECTOR_ID) {
-    throw new Error("NANGO_NOTION_CONNECTOR_ID not set");
-  }
-
-  const accessToken = await getAccessTokenFromNango({
-    connectionId: nangoConnectionId,
-    integrationId: NANGO_INTERCOM_CONNECTOR_ID,
-    useCache: true,
-  });
-
-  const resp = await fetch(`https://api.intercom.io/teams/${teamId}`, {
+  const response = await queryIntercomAPI({
+    nangoConnectionId,
+    path: `teams/${teamId}`,
     method: "GET",
-    headers: {
-      "Intercom-Version": "2.10",
-      Authorization: `Bearer ${accessToken}`,
-      "Content-Type": "application/json",
-    },
   });
 
-  const response = await resp.json();
   return response;
 }
 
 /**
  * Return the paginated list of Conversation for a given Team.
- * Filtered on the last 3 months and closed Conversations.
+ * Filtered on a slidingWindow and closed Conversations.
  */
 export async function fetchIntercomConversationsForTeamId({
   nangoConnectionId,
@@ -424,29 +279,16 @@ export async function fetchIntercomConversationsForTeamId({
     };
   };
 }> {
-  if (!NANGO_INTERCOM_CONNECTOR_ID) {
-    throw new Error("NANGO_NOTION_CONNECTOR_ID not set");
-  }
-
-  const accessToken = await getAccessTokenFromNango({
-    connectionId: nangoConnectionId,
-    integrationId: NANGO_INTERCOM_CONNECTOR_ID,
-    useCache: true,
-  });
-
   const minCreatedAtDate = new Date(
     Date.now() - slidingWindow * 24 * 60 * 60 * 1000
   );
   const minCreatedAt = Math.floor(minCreatedAtDate.getTime() / 1000);
 
-  const resp = await fetch(`https://api.intercom.io/conversations/search`, {
+  const response = await queryIntercomAPI({
+    nangoConnectionId,
+    path: `conversations/search`,
     method: "POST",
-    headers: {
-      "Intercom-Version": "2.10",
-      Authorization: `Bearer ${accessToken}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
+    body: {
       query: {
         operator: "AND",
         value: [
@@ -471,10 +313,9 @@ export async function fetchIntercomConversationsForTeamId({
         per_page: pageSize,
         starting_after: cursor,
       },
-    }),
+    },
   });
 
-  const response = await resp.json();
   return response;
 }
 
@@ -487,29 +328,12 @@ export async function fetchIntercomConversation({
 }: {
   nangoConnectionId: string;
   conversationId: string;
-}) {
-  if (!NANGO_INTERCOM_CONNECTOR_ID) {
-    throw new Error("NANGO_NOTION_CONNECTOR_ID not set");
-  }
-
-  const accessToken = await getAccessTokenFromNango({
-    connectionId: nangoConnectionId,
-    integrationId: NANGO_INTERCOM_CONNECTOR_ID,
-    useCache: true,
+}): Promise<IntercomConversationWithPartsType | null> {
+  const response = await queryIntercomAPI({
+    nangoConnectionId,
+    path: `conversations/${conversationId}`,
+    method: "GET",
   });
 
-  const resp = await fetch(
-    `https://api.intercom.io/conversations/${conversationId}`,
-    {
-      method: "GET",
-      headers: {
-        "Intercom-Version": "2.10",
-        Authorization: `Bearer ${accessToken}`,
-        "Content-Type": "application/json",
-      },
-    }
-  );
-
-  const response = await resp.json();
   return response;
 }

--- a/connectors/src/connectors/intercom/lib/types.ts
+++ b/connectors/src/connectors/intercom/lib/types.ts
@@ -1,0 +1,108 @@
+export type IntercomHelpCenterType = {
+  id: string;
+  workspace_id: string;
+  created_at: number;
+  updated_at: number;
+  identifier: string;
+  website_turned_on: boolean;
+  display_name: string | null;
+};
+
+export type IntercomCollectionType = {
+  id: string;
+  workspace_id: string;
+  name: string;
+  url: string | null;
+  order: number;
+  created_at: number;
+  updated_at: number;
+  description: string | null;
+  icon: string | null;
+  help_center_id: string | null;
+  parent_id: string | null;
+};
+
+export type IntercomArticleType = {
+  type: "article";
+  id: string;
+  workspace_id: string;
+  title: string;
+  description: string;
+  body: string;
+  author_id: string;
+  state: string;
+  created_at: number;
+  updated_at: number;
+  url: string;
+  parent_id: string;
+  parent_type: string;
+  parent_ids: string[];
+};
+
+export type IntercomTeamType = {
+  type: "team";
+  id: string;
+  name: string;
+  admin_ids: string[];
+};
+
+export type IntercomConversationType = {
+  type: "conversation";
+  id: string;
+  created_at: number;
+  updated_at: number;
+  title: string | null;
+  admin_assignee_id: number | null;
+  team_assignee_id: number | null; // it says string in the API doc but it's actually a number
+  open: boolean;
+  tags: {
+    type: "tag.list";
+    tags: IntercomTagType[];
+  };
+  source: {
+    type: string;
+    id: number;
+    delivered_as: string;
+    subject: string;
+    body: string;
+    author: IntercomAuthor;
+  };
+};
+
+export type IntercomConversationWithPartsType = IntercomConversationType & {
+  conversation_parts: {
+    type: "conversation_part.list";
+    conversation_parts: ConversationPartType[];
+    total_count: number;
+  };
+};
+
+export type IntercomTagType = {
+  type: "tag";
+  id: string;
+  name: string;
+};
+
+export type ConversationPartType = {
+  type: "conversation_part";
+  id: string;
+  part_type: string;
+  body: string;
+  created_at: Date;
+  updated_at: Date;
+  notified_at: Date;
+  assigned_to: {
+    type: string;
+    id: string;
+  };
+  author: IntercomAuthor;
+  attachments: [];
+  redacted: boolean;
+};
+
+export type IntercomAuthor = {
+  id: string;
+  type: "user" | "admin" | "bot" | "team";
+  name: string;
+  email: string;
+};

--- a/connectors/src/connectors/intercom/lib/utils.ts
+++ b/connectors/src/connectors/intercom/lib/utils.ts
@@ -1,6 +1,9 @@
 import type { ModelId } from "@dust-tt/types";
 
-import type { IntercomArticleType } from "@connectors/connectors/intercom/lib/intercom_api";
+import type {
+  IntercomArticleType,
+  IntercomCollectionType,
+} from "@connectors/connectors/intercom/lib/types";
 
 /**
  * From id to internalId
@@ -72,4 +75,8 @@ export function getTeamIdFromInternalId(
 
 export function getArticleInAppUrl(article: IntercomArticleType) {
   return `https://app.intercom.com/a/apps/${article.workspace_id}/articles/articles/${article.id}/show`;
+}
+
+export function getCollectionInAppUrl(collection: IntercomCollectionType) {
+  return `https://app.intercom.com/a/apps/${collection.workspace_id}/articles/site/collections`;
 }

--- a/connectors/src/connectors/intercom/temporal/activities.ts
+++ b/connectors/src/connectors/intercom/temporal/activities.ts
@@ -258,6 +258,7 @@ export async function syncCollectionActivity({
   await syncCollection({
     connectorId,
     connectionId: connector.connectionId,
+    helpCenterId,
     isHelpCenterWebsiteTurnedOn: helpCenter.websiteTurnedOn,
     collection,
     dataSourceConfig,

--- a/connectors/src/connectors/intercom/temporal/sync_conversation.ts
+++ b/connectors/src/connectors/intercom/temporal/sync_conversation.ts
@@ -1,12 +1,12 @@
 import type { ModelId } from "@dust-tt/types";
 import TurndownService from "turndown";
 
+import { fetchIntercomConversation } from "@connectors/connectors/intercom/lib/intercom_api";
 import type {
   ConversationPartType,
   IntercomConversationWithPartsType,
   IntercomTagType,
-} from "@connectors/connectors/intercom/lib/intercom_api";
-import { fetchIntercomConversation } from "@connectors/connectors/intercom/lib/intercom_api";
+} from "@connectors/connectors/intercom/lib/types";
 import {
   getConversationInternalId,
   getTeamInternalId,

--- a/connectors/src/connectors/intercom/temporal/sync_help_center.ts
+++ b/connectors/src/connectors/intercom/temporal/sync_help_center.ts
@@ -1,16 +1,15 @@
 import type { ModelId } from "@dust-tt/types";
-import type { Client as IntercomClient } from "intercom-client";
 import TurndownService from "turndown";
 
-import type { IntercomCollectionType } from "@connectors/connectors/intercom/lib/intercom_api";
 import {
   fetchIntercomArticles,
   fetchIntercomCollection,
   fetchIntercomCollections,
-  getIntercomClient,
 } from "@connectors/connectors/intercom/lib/intercom_api";
+import type { IntercomCollectionType } from "@connectors/connectors/intercom/lib/types";
 import {
   getArticleInAppUrl,
+  getCollectionInAppUrl,
   getHelpCenterArticleInternalId,
   getHelpCenterCollectionInternalId,
   getHelpCenterInternalId,
@@ -68,6 +67,7 @@ export async function removeHelpCenter({
 export async function syncCollection({
   connectorId,
   connectionId,
+  helpCenterId,
   isHelpCenterWebsiteTurnedOn,
   collection,
   dataSourceConfig,
@@ -76,6 +76,7 @@ export async function syncCollection({
 }: {
   connectorId: ModelId;
   connectionId: string;
+  helpCenterId: string;
   isHelpCenterWebsiteTurnedOn: boolean;
   collection: IntercomCollection;
   dataSourceConfig: DataSourceConfig;
@@ -90,20 +91,19 @@ export async function syncCollection({
       loggerArgs,
     });
   } else {
-    const intercomClient = await getIntercomClient(connectionId);
     const collectionOnIntercom = await fetchIntercomCollection(
-      intercomClient,
+      connectionId,
       collection.collectionId
     );
     if (collectionOnIntercom) {
       await _upsertCollection({
         connectorId,
         connectionId,
+        helpCenterId,
         collection: collectionOnIntercom,
         isHelpCenterWebsiteTurnedOn,
         parents: [],
         dataSourceConfig,
-        intercomClient,
         loggerArgs,
         currentSyncMs,
       });
@@ -192,8 +192,8 @@ export async function _deleteCollection({
  */
 export async function _upsertCollection({
   connectorId,
-  intercomClient,
   connectionId,
+  helpCenterId,
   dataSourceConfig,
   loggerArgs,
   collection,
@@ -203,7 +203,7 @@ export async function _upsertCollection({
 }: {
   connectorId: ModelId;
   connectionId: string;
-  intercomClient: IntercomClient;
+  helpCenterId: string;
   dataSourceConfig: DataSourceConfig;
   collection: IntercomCollectionType;
   isHelpCenterWebsiteTurnedOn: boolean;
@@ -219,12 +219,14 @@ export async function _upsertCollection({
     },
   });
 
+  const fallbackCollectionUrl = getCollectionInAppUrl(collection);
+
   if (collectionOnDb) {
     await collectionOnDb.update({
       name: collection.name,
       description: collection.description,
       parentId: collection.parent_id,
-      url: collection.url,
+      url: collection.url || fallbackCollectionUrl,
       lastUpsertedTs: new Date(currentSyncMs),
     });
   } else {
@@ -232,11 +234,11 @@ export async function _upsertCollection({
       connectorId: connectorId,
       collectionId: collection.id,
       intercomWorkspaceId: collection.workspace_id,
-      helpCenterId: collection.help_center_id,
+      helpCenterId: helpCenterId,
       parentId: collection.parent_id,
       name: collection.name,
       description: collection.description,
-      url: collection.url,
+      url: collection.url || fallbackCollectionUrl,
       permission: "read",
       lastUpsertedTs: new Date(currentSyncMs),
     });
@@ -244,7 +246,7 @@ export async function _upsertCollection({
 
   // Sync the Collection's articles
   const [childrenArticlesOnIntercom, childrenArticlesOnDb] = await Promise.all([
-    fetchIntercomArticles(intercomClient, collection.id),
+    fetchIntercomArticles(connectionId, helpCenterId, collection.id),
     IntercomArticle.findAll({
       where: { connectorId, parentId: collection.id },
     }),
@@ -321,7 +323,7 @@ export async function _upsertCollection({
         getHelpCenterCollectionInternalId(connectorId, id)
       );
       parentsInternalsIds.push(
-        getHelpCenterInternalId(connectorId, collection.help_center_id)
+        getHelpCenterInternalId(connectorId, helpCenterId)
       );
 
       return upsertToDatasource({
@@ -361,7 +363,7 @@ export async function _upsertCollection({
   // Then we call ourself recursively on the children collections
   const childrenCollectionsOnIntercom = await fetchIntercomCollections(
     connectionId,
-    collection.help_center_id,
+    helpCenterId,
     collection.id
   );
 
@@ -370,7 +372,7 @@ export async function _upsertCollection({
       await _upsertCollection({
         connectorId,
         connectionId,
-        intercomClient,
+        helpCenterId,
         dataSourceConfig,
         loggerArgs,
         collection: collectionOnIntercom,

--- a/connectors/src/connectors/intercom/temporal/sync_help_center.ts
+++ b/connectors/src/connectors/intercom/temporal/sync_help_center.ts
@@ -98,6 +98,7 @@ export async function syncCollection({
     if (collectionOnIntercom) {
       await _upsertCollection({
         connectorId,
+        connectionId,
         collection: collectionOnIntercom,
         isHelpCenterWebsiteTurnedOn,
         parents: [],
@@ -192,6 +193,7 @@ export async function _deleteCollection({
 export async function _upsertCollection({
   connectorId,
   intercomClient,
+  connectionId,
   dataSourceConfig,
   loggerArgs,
   collection,
@@ -200,6 +202,7 @@ export async function _upsertCollection({
   currentSyncMs,
 }: {
   connectorId: ModelId;
+  connectionId: string;
   intercomClient: IntercomClient;
   dataSourceConfig: DataSourceConfig;
   collection: IntercomCollectionType;
@@ -357,7 +360,7 @@ export async function _upsertCollection({
 
   // Then we call ourself recursively on the children collections
   const childrenCollectionsOnIntercom = await fetchIntercomCollections(
-    intercomClient,
+    connectionId,
     collection.help_center_id,
     collection.id
   );
@@ -366,6 +369,7 @@ export async function _upsertCollection({
     childrenCollectionsOnIntercom.map(async (collectionOnIntercom) => {
       await _upsertCollection({
         connectorId,
+        connectionId,
         intercomClient,
         dataSourceConfig,
         loggerArgs,


### PR DESCRIPTION
## Description

I decided to stop using https://github.com/intercom/intercom-node SDK and call directly the Intercom api, because the lib has gone under maintenance mode. It has been updated to support API version 2.6 while we're using 2.10 now (latest) -> much better model for the Help Center ([changelog](https://developers.intercom.com/docs/references/changelog/))

5 function needed to be slightly refactored to get rid of it: 
- `fetchIntercomCollections` & `fetchIntercomCollection`
- `fetchIntercomArticles` & `fetchIntercomArticle`
- `fetchIntercomTeams`

Done in this PR: 
- Remove usage of IntercomNode -> refactored intercom_api with a util function to centralize the API calls. 
- Manage revoked token error
- Moved intercom types into a type file
- Managed a fallback url for collections when they don't have one 
- Pass the connectorId & connectionId instead of full connector on some BL functions

## Risk

Break the connector, I'm making some tests.

## Deploy Plan

Nothing special, just deploy connectors.
