### PR TITLE
:pig: Use node to start connectors

### DIFF
--- a/k8s/deployments/connectors-deployment.yaml
+++ b/k8s/deployments/connectors-deployment.yaml
@@ -20,7 +20,14 @@ spec:
       containers:
         - name: web
           image: gcr.io/or1g1n-186209/connectors-image:latest
-          command: ["npm", "run", "start:web"]
+          command: ["node"]
+          args:
+            [
+              "/app/node_modules/.bin/tsx",
+              "./src/start_server.ts",
+              "-p",
+              "3002",
+            ]
           imagePullPolicy: Always
           ports:
             - containerPort: 3002


### PR DESCRIPTION
## Description

In our production environment, we initiate `connectors` by executing `npm run start:web` within our pods. This method leads to an inefficient process chain where npm initiates a tsx process, which in turn initiates a node process. The process hierarchy is illustrated below:
```
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root           1  0.1  0.2 11222560 85048 ?      Ssl  08:25   0:03 npm run start:web
root          17  0.0  0.0   2488   588 ?        S    08:25   0:00 sh -c tsx ./src/start_server.ts -p 3002
root          18  0.1  0.1 11140640 65184 ?      Sl   08:25   0:02 node /app/node_modules/.bin/tsx ./src/start_server.ts -p 3002
root          29  1.5  1.5 53719656 503852 ?     Sl   08:25   0:32 /usr/local/bin/node --require /app/node_modules/tsx/dist/preflight.cjs --loader file:///app/node_modules/tsx/dist/loader.js ./src/start_server.ts -p 3002
root          41  0.8  0.0 723104 16112 ?        Sl   08:25   0:18 /app/node_modules/@esbuild/linux-x64/bin/esbuild --service=0.17.18 --ping
root          53  0.0  0.0   4168  3516 pts/0    Ss   08:51   0:00 bash
root          60  0.0  0.0   6764  2852 pts/0    R+   09:01   0:00 ps aux
```

During deployment or when a pod is terminated, Kubernetes sends a SIGTERM signal to allow the pod to release resources and stop processing queries before shutdown. Unfortunately, both `npm` and `tsx` are known not to forward signals. Those tools should not be used in production environments.

Today, we can notice that some of our in-flight queries to the connectors API are being killed abruptly when the a deploy happens leading to inconsistent state in the DB (example of connectors partially created).

After extensive experimentation with converting our TypeScript code to JavaScript to simplify execution to purely rely on Node, I just opened the Pandora box. One significant obstacle is dealing with pure [ESM packages](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c) like `p-queue`, which force us to either:
1. Convert our codebase to ESM by specifying `"type": "module"` in our `package.json`.
2. Revert to using the latest CommonJS versions of such libraries, although `[p-queue](https://github.com/sindresorhus/p-queue)` lacks a CommonJS version.

Worth mentioning as well that , transitioning connectors to a pure ESM package imposes explicit extension declaration during imports, such as:
```javascript
// INCORRECT
import { startServer } from "@connectors/api_server";
// INCORRECT
import { startServer } from "@connectors/api_server.ts";
// CORRECT
import { startServer } from "@connectors/api_server.js";
```

I attempted to use swc transformers to append the necessary `.js` extension when compiling, but it's not as simple as appending `.js` to the import because of Node's flexible import conventions. For instance:
```javascript
// BAD
import { sequelizeConnection } from "@connectors/resources/storage";

// GOOD
import { sequelizeConnection } from "@connectors/resources/storage/index.js";
```

This is only the beginning of the journey, cause once you'v solved this, you enter the magical world of Temporal and webpack.

IMHO, undertaking a major refactoring effort just to enable graceful shutdowns on our pods doesn't seem justified at the moment 🤯 . As an alternative, this PR proposes a hack to initiate `tsx` through `node` directly by leveraging the `node_modules` directory, specifically with the command `node /app/node_modules/.bin/tsx ./src/start_server.ts -p 3002`.

This approach was tested on `connectors-edge` (https://github.com/dust-tt/dust/pull/3864), resulting in the following process hierarchy:
```
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root           1  0.7  0.1 11140640 64156 ?      Ssl  19:32   0:01 node /app/node_modules/.bin/tsx .
root          17  9.6  1.6 53749264 540892 ?     Sl   19:32   0:20 /usr/local/bin/node --require /ap
root          29  7.4  0.0 722848 18040 ?        Sl   19:32   0:15 /app/node_modules/@esbuild/linux-
root         312 11.5  0.0   4168  3268 pts/1    Ss   19:36   0:00 bash
root         318  0.0  0.0   6764  2972 pts/1    R+   19:36   0:00 ps aux
```

And when deleting the pod, we can see the graceful shutdown (already implemented happen):
```
> kctl logs -f connectors-edge-deployment-6d449548b9-brxwk
{"level":"info","time":1708544366906,"pid":17,"hostname":"connectors-edge-deployment-6d449548b9-brxwk","dd":{"service":"connectors-edge","version":"0.1.0","env":"prod"},"msg":"Connectors API listening on port 3002"}
{"level":"info","time":1708549934189,"pid":17,"hostname":"connectors-edge-deployment-6d449548b9-brxwk","dd":{"service":"connectors-edge","version":"0.1.0","env":"prod"},"msg":"[GRACEFUL] Received kill signal, shutting down gracefully."}
{"level":"info","time":1708549934193,"pid":17,"hostname":"connectors-edge-deployment-6d449548b9-brxwk","dd":{"service":"connectors-edge","version":"0.1.0","env":"prod"},"msg":"[GRACEFUL] Closed out remaining connections."}
```

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

We first need to run the apply-infra Github Action before deploying connectors*.

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
