### PR TITLE
Intercom: Handle error 'reponse.data not iterable'

### DIFF
--- a/connectors/src/connectors/intercom/lib/intercom_api.ts
+++ b/connectors/src/connectors/intercom/lib/intercom_api.ts
@@ -8,6 +8,7 @@ import type {
 } from "@connectors/connectors/intercom/lib/types";
 import { ExternalOauthTokenError } from "@connectors/lib/error";
 import { getAccessTokenFromNango } from "@connectors/lib/nango_helpers";
+import logger from "@connectors/logger/logger";
 
 const { NANGO_INTERCOM_CONNECTOR_ID } = process.env;
 
@@ -161,8 +162,14 @@ export async function fetchIntercomCollections(
       path: `help_center/collections?page=${page}&per_page=12`,
       method: "GET",
     });
-
-    collections.push(...response.data);
+    if (response?.data && Array.isArray(response.data)) {
+      collections.push(...response.data);
+    } else {
+      logger.error(
+        { helpCenterId, page, response },
+        "[Intercom] No collections found in the list collections response"
+      );
+    }
     if (response.pages.total_pages > page) {
       hasMore = true;
       page += 1;


### PR DESCRIPTION
## Description

Fixing this log: https://app.datadoghq.eu/logs?query=%22Intercom%22%20status%3Aerror%20%40dd.env%3Aprod&cols=service%2C%40workflowName%2C%40activityName%2C%40error.__is_dust_error&event=AgAAAY3No1YAYw-PkgAAAAAAAAAYAAAAAEFZM05vMmtKQUFEZGNWVUdJMTA5eEFCNQAAACQAAAAAMDE4ZGNkYWUtYzZiYS00Y2Y4LTgxNTEtM2JlMzFkMzIyNzNh&fromUser=true&index=%2A&messageDisplay=inline&refresh_mode=sliding&saved-view-id=99803&stream_sort=%40duration%2Cdesc&viz=stream&from_ts=1708500840863&to_ts=1708587240863&live=true

`TypeError: response.data is not iterable (cannot read property undefined)`

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
