### PR TITLE
Bump Front CPU to 2000m

### DIFF
--- a/k8s/deployments/front-deployment.yaml
+++ b/k8s/deployments/front-deployment.yaml
@@ -60,11 +60,11 @@ spec:
 
           resources:
             requests:
-              cpu: 1000m
+              cpu: 2000m
               memory: 2.5Gi
 
             limits:
-              cpu: 1000m
+              cpu: 2000m
               memory: 2.5Gi
 
       volumes:


### PR DESCRIPTION
## Description

After investigating the 502 error on the `/tokenize` endpoint, it appears that the queries are not reaching the Front's API, or they might be lost in the NextJS layer's magic beyond our instrumentation capabilities.

This PR increases the front deployment's CPU count from 1 to 2.
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Apply infra.

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
