### PR TITLE
Intercom connector: Upsert Articles by Batch in dedicated activity

### DIFF
--- a/connectors/src/connectors/intercom/lib/intercom_api.ts
+++ b/connectors/src/connectors/intercom/lib/intercom_api.ts
@@ -197,30 +197,36 @@ export async function fetchIntercomCollection(
 /**
  * Return the Articles that are children of a given Collection.
  */
-export async function fetchIntercomArticles(
-  nangoConnectionId: string,
-  helpCenterId: string,
-  parentId: string | null
-): Promise<IntercomArticleType[]> {
-  let response, hasMore;
-  let page = 1;
-  const articles: IntercomArticleType[] = [];
-  do {
-    response = await queryIntercomAPI({
-      nangoConnectionId,
-      path: `articles/search?help_center_id=${helpCenterId}&state=published&page=${page}&per_page=12`,
-      method: "GET",
-    });
-    articles.push(...response.data.articles);
-    if (response.pages.total_pages > page) {
-      hasMore = true;
-      page += 1;
-    } else {
-      hasMore = false;
-    }
-  } while (hasMore);
+export async function fetchIntercomArticles({
+  nangoConnectionId,
+  helpCenterId,
+  page = 1,
+  pageSize = 12,
+}: {
+  nangoConnectionId: string;
+  helpCenterId: string;
+  page: number;
+  pageSize?: number;
+}): Promise<{
+  data: {
+    articles: IntercomArticleType[];
+  };
+  pages: {
+    type: "pages";
+    prev?: "string";
+    next?: "string";
+    page: number;
+    total_pages: number;
+    per_page: number;
+  };
+}> {
+  const response = await queryIntercomAPI({
+    nangoConnectionId,
+    path: `articles/search?help_center_id=${helpCenterId}&state=published&page=${page}&per_page=${pageSize}`,
+    method: "GET",
+  });
 
-  return articles.filter((article) => article.parent_id == parentId);
+  return response;
 }
 
 /**

--- a/connectors/src/connectors/intercom/lib/types.ts
+++ b/connectors/src/connectors/intercom/lib/types.ts
@@ -34,9 +34,9 @@ export type IntercomArticleType = {
   created_at: number;
   updated_at: number;
   url: string;
-  parent_id: string;
+  parent_id: number | null;
   parent_type: string;
-  parent_ids: string[];
+  parent_ids: number[];
 };
 
 export type IntercomTeamType = {


### PR DESCRIPTION
## Description

Some Help Center are really big, like 500 articles and collections with +350 articles. The current split of activities does not make sense and needs to be reworked. 

Workflow logic before: 
1/ An activity to fetch all ids of level 1 collection
2/ An activity for each level 1 collection in charge of syncing the collection + the children collections and articles. Meaning that I realized that this activity could become quite big. 

Workflow logic now: 
1/ An activity to fetch all ids of level 1 collection
2/ An activity for each level 1 collection is in charge of syncing only the children collections (but not the articles inside, so it's basically about keeping the collections title/description up to date in db).
3/ An activity in a loop that loops over all the articles of the help center to sync the one we're allowed to sync. It makes much more sense to handle it this way, especially as Intercom API does not allow to search for the articles of a given collection, we can only filter on the help center id, and publication status. 

https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Articles/searchArticles/

Also, we do not upsert the datasource anymore if its createdAt was before our lastUpdsertedAt.

## Risk

Break the intercom workflows. 

## Deploy Plan

No change on DB but I changed the activities on my workflow -> I might have to restart all Intercom workflows. 
