### PR TITLE
AssitantBuilder: Edit @handle

### DIFF
--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -570,7 +570,9 @@ export default function AssistantBuilder({
       })),
     [screen]
   );
-  const modalTitle = agentConfigurationId ? "Edit Assistant" : "New Assistant";
+  const modalTitle = agentConfigurationId
+    ? `Edit @${builderState.handle}`
+    : "New Assistant";
 
   function ActionScreen() {
     return (


### PR DESCRIPTION
## Description

Now that Identity/name is in one tab, when coming back to edit an assistant it's nice to know which one it is. Show the handle in the modal name.

## Risk

N/A 

## Deploy Plan

- deploy `front`