### PR TITLE
Patch GH issue date, only use if valid

### DIFF
--- a/connectors/src/connectors/github/temporal/activities.ts
+++ b/connectors/src/connectors/github/temporal/activities.ts
@@ -117,7 +117,7 @@ async function renderIssue(
   const content = await renderDocumentTitleAndContent({
     dataSourceConfig,
     title: `Issue #${issue.number} [${repoName}]: ${issue.title}`,
-    createdAt: issue.createdAt,
+    createdAt: issue.createdAt || issue.updatedAt,
     updatedAt: issue.updatedAt,
     content: await renderMarkdownSection(dataSourceConfig, issue.body ?? "", {
       flavor: "gfm",

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -5,6 +5,7 @@ import type {
 import {
   DustAPI,
   EMBEDDING_CONFIG,
+  isValidDate,
   safeSubstring,
   sectionFullText,
 } from "@dust-tt/types";
@@ -396,10 +397,10 @@ export async function renderDocumentTitleAndContent({
   }
   const c = await renderPrefixSection(dataSourceConfig, title);
   let metaPrefix: string | null = "";
-  if (createdAt) {
+  if (createdAt && isValidDate(createdAt)) {
     metaPrefix += `$createdAt: ${createdAt.toISOString()}\n`;
   }
-  if (updatedAt) {
+  if (updatedAt && isValidDate(updatedAt)) {
     metaPrefix += `$updatedAt: ${updatedAt.toISOString()}\n`;
   }
   if (author && lastEditor && author === lastEditor) {

--- a/types/src/index.ts
+++ b/types/src/index.ts
@@ -54,6 +54,7 @@ export * from "./shared/rate_limiter";
 export * from "./shared/user_operation";
 export * from "./shared/utils/assert_never";
 export * from "./shared/utils/config";
+export * from "./shared/utils/date_utils";
 export * from "./shared/utils/general";
 export * from "./shared/utils/global_error_handler";
 export * from "./shared/utils/hashing";

--- a/types/src/shared/utils/date_utils.ts
+++ b/types/src/shared/utils/date_utils.ts
@@ -1,0 +1,3 @@
+export function isValidDate(date: Date) {
+  return !isNaN(date.valueOf());
+}


### PR DESCRIPTION
## Description

This PR fixes the ongoing issue with a GH issue that does not have a valid `createdAt`. Looking at GH API's documentation `created_at` **is not nullable**.

Error observed in production:
```
RangeError: Invalid time value
    at Date.toISOString (<anonymous>)
    at renderDocumentTitleAndContent (/app/src/lib/data_sources.ts:400:44)
    at process.processTicksAndRejections 
```

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
