### PR TITLE
Link to assistant (assistant gallery) with panel open

### DIFF
--- a/front/pages/w/[wId]/assistant/assistants.tsx
+++ b/front/pages/w/[wId]/assistant/assistants.tsx
@@ -130,7 +130,7 @@ export default function MyAssistants({
               </Link>
             </Tooltip>
           )}
-          <Link href={`/w/${owner.sId}/assistant/gallery?flow=personal_add`}>
+          <Link href={`/w/${owner.sId}/assistant/gallery`}>
             <Button
               variant="primary"
               icon={BookOpenIcon}

--- a/front/pages/w/[wId]/assistant/gallery.tsx
+++ b/front/pages/w/[wId]/assistant/gallery.tsx
@@ -20,7 +20,7 @@ import { assertNever } from "@dust-tt/types";
 import type { InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 import type { ComponentType } from "react";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { AssistantDetails } from "@app/components/assistant/AssistantDetails";
 import { GalleryAssistantPreviewContainer } from "@app/components/assistant/GalleryAssistantPreviewContainer";
@@ -135,10 +135,42 @@ export default function AssistantsGallery({
       assertNever(orderBy);
   }
 
-  const [showDetails, setShowDetails] =
-    useState<LightAgentConfigurationType | null>(null);
   const [testModalAssistant, setTestModalAssistant] =
     useState<LightAgentConfigurationType | null>(null);
+
+  const [showDetails, setShowDetails] = useState<string | null>(null);
+
+  useEffect(() => {
+    const handleRouteChange = () => {
+      const assistantSId = router.query.assistantDetails ?? [];
+      if (assistantSId && typeof assistantSId === "string") {
+        setShowDetails(assistantSId);
+      } else {
+        setShowDetails(null);
+      }
+    };
+
+    // Initial check in case the component mounts with the query already set.
+    handleRouteChange();
+
+    router.events.on("routeChangeComplete", handleRouteChange);
+    return () => {
+      router.events.off("routeChangeComplete", handleRouteChange);
+    };
+  }, [router.query, router.events]);
+
+  const handleCloseAssistantDetails = () => {
+    const currentPathname = router.pathname;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { assistantDetails, ...restQuery } = router.query;
+    void router.push(
+      { pathname: currentPathname, query: restQuery },
+      undefined,
+      {
+        shallow: true,
+      }
+    );
+  };
 
   const tabs: {
     label: string;
@@ -224,8 +256,8 @@ export default function AssistantsGallery({
     >
       <AssistantDetails
         owner={owner}
-        assistantId={showDetails?.sId || null}
-        onClose={() => setShowDetails(null)}
+        assistantId={showDetails}
+        onClose={handleCloseAssistantDetails}
         mutateAgentConfigurations={mutateAgentConfigurations}
       />
       {testModalAssistant && (
@@ -263,8 +295,15 @@ export default function AssistantsGallery({
                   owner={owner}
                   plan={plan}
                   agentConfiguration={a}
-                  onShowDetails={() => {
-                    setShowDetails(a);
+                  onShowDetails={async () => {
+                    const href = {
+                      pathname: router.pathname,
+                      query: {
+                        ...router.query,
+                        assistantDetails: a.sId,
+                      },
+                    };
+                    await router.push(href);
                   }}
                   onUpdate={() => {
                     void mutateAgentConfigurations();


### PR DESCRIPTION
## Description

As part of https://github.com/dust-tt/dust/issues/3857
Allow to link to an assistant (assistant gallery with assistant open)
Also removes the unused flow argument to gallery in on of the links to it.

## Risk

N/A

## Deploy Plan

- deploy `front`