### PR TITLE
Intercom: Fix in-app url when intercom hosted in EU

### DIFF
--- a/connectors/src/connectors/intercom/index.ts
+++ b/connectors/src/connectors/intercom/index.ts
@@ -90,6 +90,7 @@ export async function createIntercomConnector(
       intercomWorkspaceId: intercomWorkspace.id,
       name: intercomWorkspace.name,
       conversationsSlidingWindow: 90,
+      region: intercomWorkspace.region,
     });
 
     const workflowStarted = await launchIntercomSyncWorkflow(
@@ -188,6 +189,7 @@ export async function updateIntercomConnector(
       {
         intercomWorkspaceId: newIntercomWorkspace.id,
         name: newIntercomWorkspace.name,
+        region: newIntercomWorkspace.region,
       },
       {
         where: { connectorId: connector.id },
@@ -389,6 +391,20 @@ export async function setIntercomConnectorPermissions(
     logger.error({ connectorId }, "[Intercom] Connector not found.");
     return new Err(new Error("Connector not found"));
   }
+
+  const intercomWorkspace = await IntercomWorkspace.findOne({
+    where: {
+      connectorId,
+    },
+  });
+  if (!intercomWorkspace) {
+    logger.error(
+      { connectorId },
+      "[Intercom] IntercomWorkspace not found. Cannot set permissions."
+    );
+    return new Err(new Error("IntercomWorkspace not found"));
+  }
+
   const connectionId = connector.connectionId;
 
   const toBeSignaledHelpCenterIds = new Set<string>();
@@ -424,6 +440,7 @@ export async function setIntercomConnectorPermissions(
             connectorId,
             connectionId,
             helpCenterId,
+            region: intercomWorkspace.region,
             withChildren: true,
           });
         }
@@ -442,6 +459,7 @@ export async function setIntercomConnectorPermissions(
             connectorId,
             connectionId,
             collectionId,
+            region: intercomWorkspace.region,
           });
           if (newCollection) {
             toBeSignaledHelpCenterIds.add(newCollection.helpCenterId);

--- a/connectors/src/connectors/intercom/lib/help_center_permissions.ts
+++ b/connectors/src/connectors/intercom/lib/help_center_permissions.ts
@@ -40,11 +40,13 @@ export async function allowSyncHelpCenter({
   connectorId,
   connectionId,
   helpCenterId,
+  region,
   withChildren = false,
 }: {
   connectorId: ModelId;
   connectionId: string;
   helpCenterId: string;
+  region: string;
   withChildren?: boolean;
 }): Promise<IntercomHelpCenter> {
   let helpCenter = await IntercomHelpCenter.findOne({
@@ -94,6 +96,7 @@ export async function allowSyncHelpCenter({
         connectorId,
         connectionId,
         collectionId: c1.id,
+        region,
       })
     );
     await Promise.all(permissionUpdatePromises);
@@ -168,10 +171,12 @@ export async function allowSyncCollection({
   connectorId,
   connectionId,
   collectionId,
+  region,
 }: {
   connectorId: ModelId;
   connectionId: string;
   collectionId: string;
+  region: string;
 }): Promise<IntercomCollection | null> {
   let collection = await IntercomCollection.findOne({
     where: {
@@ -199,7 +204,8 @@ export async function allowSyncCollection({
         name: intercomCollection.name,
         description: intercomCollection.description,
         url:
-          intercomCollection.url || getCollectionInAppUrl(intercomCollection),
+          intercomCollection.url ||
+          getCollectionInAppUrl(intercomCollection, region),
         permission: "read",
       });
     }
@@ -219,6 +225,7 @@ export async function allowSyncCollection({
       connectorId,
       connectionId,
       helpCenterId: collection.helpCenterId,
+      region,
     }),
     fetchIntercomCollections(
       connectionId,
@@ -232,6 +239,7 @@ export async function allowSyncCollection({
       connectorId,
       connectionId,
       collectionId: c.id,
+      region,
     })
   );
   await Promise.all(collectionPermissionPromises);

--- a/connectors/src/connectors/intercom/lib/intercom_api.ts
+++ b/connectors/src/connectors/intercom/lib/intercom_api.ts
@@ -50,6 +50,8 @@ async function queryIntercomAPI({
     useCache: true,
   });
 
+  // Intercom will route to the correct region based on the token.
+  // https://developers.intercom.com/docs/build-an-integration/learn-more/rest-apis/#regional-hosting
   const rawResponse = await fetch(`https://api.intercom.io/${path}`, {
     method,
     headers: {
@@ -91,6 +93,7 @@ export async function fetchIntercomWorkspace(
 ): Promise<{
   id: string;
   name: string;
+  region: string;
 } | null> {
   const response = await queryIntercomAPI({
     nangoConnectionId,
@@ -100,14 +103,16 @@ export async function fetchIntercomWorkspace(
 
   const workspaceId = response?.app?.id_code;
   const workspaceName = response?.app?.name;
+  const region = response?.app?.region;
 
-  if (!workspaceId || !workspaceName) {
+  if (!workspaceId || !workspaceName || !region) {
     return null;
   }
 
   return {
     id: workspaceId,
     name: workspaceName,
+    region,
   };
 }
 

--- a/connectors/src/connectors/intercom/lib/utils.ts
+++ b/connectors/src/connectors/intercom/lib/utils.ts
@@ -73,10 +73,37 @@ export function getTeamIdFromInternalId(
   return _getIdFromInternal(internalId, `intercom-team-${connectorId}-`);
 }
 
-export function getArticleInAppUrl(article: IntercomArticleType) {
-  return `https://app.intercom.com/a/apps/${article.workspace_id}/articles/articles/${article.id}/show`;
+function getIntercomDomain(region: string): string {
+  if (region === "EU") {
+    return "https://app.eu.intercom.com";
+  }
+  if (region === "AU") {
+    return "https://app.au.intercom.com";
+  }
+  return "https://app.intercom.com";
 }
 
-export function getCollectionInAppUrl(collection: IntercomCollectionType) {
-  return `https://app.intercom.com/a/apps/${collection.workspace_id}/articles/site/collections`;
+export function getArticleInAppUrl(
+  article: IntercomArticleType,
+  region: string
+): string {
+  const domain = getIntercomDomain(region);
+  return `${domain}/a/apps/${article.workspace_id}/articles/articles/${article.id}/show`;
+}
+
+export function getCollectionInAppUrl(
+  collection: IntercomCollectionType,
+  region: string
+): string {
+  const domain = getIntercomDomain(region);
+  return `${domain}/a/apps/${collection.workspace_id}/articles/site/collections`;
+}
+
+export function getConversationInAppUrl(
+  workspaceId: string,
+  conversationId: string,
+  region: string
+): string {
+  const domain = getIntercomDomain(region);
+  return `${domain}/a/inbox/${workspaceId}/inbox/conversation/${conversationId}`;
 }

--- a/connectors/src/connectors/intercom/temporal/activities.ts
+++ b/connectors/src/connectors/intercom/temporal/activities.ts
@@ -238,6 +238,22 @@ export async function syncLevel1CollectionWithChildrenActivity({
     dataSourceName: dataSourceConfig.dataSourceName,
   };
 
+  const intercomWorkspace = await IntercomWorkspace.findOne({
+    where: {
+      connectorId,
+    },
+  });
+  if (!intercomWorkspace) {
+    logger.error(
+      { loggerArgs, collectionId },
+      "[Intercom] IntercomWorkspace not found"
+    );
+    return {
+      collectionId,
+      action: "not_found_db",
+    };
+  }
+
   const collectionOnDB = await IntercomCollection.findOne({
     where: {
       connectorId,
@@ -294,6 +310,7 @@ export async function syncLevel1CollectionWithChildrenActivity({
     connectionId: connector.connectionId,
     helpCenterId,
     collection: collectionOnIntercom,
+    region: intercomWorkspace.region,
     currentSyncMs,
   });
   return {
@@ -321,6 +338,15 @@ export async function syncArticleBatchActivity({
     provider: "intercom",
     dataSourceName: dataSourceConfig.dataSourceName,
   };
+
+  const intercomWorkspace = await IntercomWorkspace.findOne({
+    where: {
+      connectorId,
+    },
+  });
+  if (!intercomWorkspace) {
+    throw new Error("[Intercom] IntercomWorkspace not found");
+  }
 
   const helpCenter = await IntercomHelpCenter.findOne({
     where: {
@@ -372,6 +398,7 @@ export async function syncArticleBatchActivity({
           helpCenterId,
           article,
           parentCollection,
+          region: intercomWorkspace.region,
           isHelpCenterWebsiteTurnedOn: helpCenter.websiteTurnedOn,
           currentSyncMs,
           dataSourceConfig,

--- a/connectors/src/connectors/intercom/temporal/sync_conversation.ts
+++ b/connectors/src/connectors/intercom/temporal/sync_conversation.ts
@@ -8,6 +8,7 @@ import type {
   IntercomTagType,
 } from "@connectors/connectors/intercom/lib/types";
 import {
+  getConversationInAppUrl,
   getConversationInternalId,
   getTeamInternalId,
 } from "@connectors/connectors/intercom/lib/utils";
@@ -253,7 +254,11 @@ export async function syncConversation({
     updatedAt: updatedAtDate,
   });
 
-  const conversationUrl = `https://app.intercom.com/a/inbox/${intercomWorkspace.intercomWorkspaceId}/inbox/conversation/${conversation.id}`;
+  const conversationUrl = getConversationInAppUrl(
+    intercomWorkspace.intercomWorkspaceId,
+    conversation.id,
+    intercomWorkspace.region
+  );
 
   await upsertToDatasource({
     dataSourceConfig,

--- a/connectors/src/connectors/intercom/temporal/sync_help_center.ts
+++ b/connectors/src/connectors/intercom/temporal/sync_help_center.ts
@@ -148,12 +148,14 @@ export async function upsertCollectionWithChildren({
   connectionId,
   helpCenterId,
   collection,
+  region,
   currentSyncMs,
 }: {
   connectorId: ModelId;
   connectionId: string;
   helpCenterId: string;
   collection: IntercomCollectionType;
+  region: string;
   currentSyncMs: number;
 }) {
   const collectionId = collection.id;
@@ -173,7 +175,7 @@ export async function upsertCollectionWithChildren({
     },
   });
 
-  const fallbackCollectionUrl = getCollectionInAppUrl(collection);
+  const fallbackCollectionUrl = getCollectionInAppUrl(collection, region);
 
   if (collectionOnDb) {
     await collectionOnDb.update({
@@ -212,6 +214,7 @@ export async function upsertCollectionWithChildren({
         connectionId,
         helpCenterId,
         collection: collectionOnIntercom,
+        region,
         currentSyncMs,
       });
     })
@@ -225,6 +228,7 @@ export async function upsertArticle({
   connectorId,
   helpCenterId,
   article,
+  region,
   parentCollection,
   isHelpCenterWebsiteTurnedOn,
   currentSyncMs,
@@ -234,6 +238,7 @@ export async function upsertArticle({
   connectorId: ModelId;
   helpCenterId: string;
   article: IntercomArticleType;
+  region: string;
   parentCollection: IntercomCollection;
   isHelpCenterWebsiteTurnedOn: boolean;
   currentSyncMs: number;
@@ -257,7 +262,7 @@ export async function upsertArticle({
   // So as a workaround we use the url of the article in the intercom app
   const articleUrl = isHelpCenterWebsiteTurnedOn
     ? article.url
-    : getArticleInAppUrl(article);
+    : getArticleInAppUrl(article, region);
 
   const parentCollectionId = article.parent_id?.toString();
   const parentCollectionIds = article.parent_ids.map((id) => id.toString());

--- a/connectors/src/lib/models/intercom.ts
+++ b/connectors/src/lib/models/intercom.ts
@@ -20,6 +20,7 @@ export class IntercomWorkspace extends Model<
   declare intercomWorkspaceId: string;
   declare name: string;
   declare conversationsSlidingWindow: number;
+  declare region: string;
 
   declare connectorId: ForeignKey<ConnectorModel["id"]>;
 }
@@ -52,6 +53,11 @@ IntercomWorkspace.init(
       type: DataTypes.INTEGER,
       allowNull: false,
       defaultValue: 90,
+    },
+    region: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      defaultValue: "US",
     },
   },
   {


### PR DESCRIPTION
## Description

When Intercom is hosted in EU, domain is "https://app.eu.intercom.com" and not "https://app.intercom.com" as hardcoded.

We can get a region when calling the `/me` route. We get US for ours, I know it can be hosted in US/EU/Australia but I could not confirm from an Intercom doc that the string in /me will be `EU` and `AU`. 
I will confirm it's valid before merging. 

## Risk

Can be rolled back.

## Deploy Plan

Deploying to Edge first to run the migration. 
