### PR TITLE
Intercom: Add buttons to guide

### DIFF
--- a/front/lib/connector_providers.ts
+++ b/front/lib/connector_providers.ts
@@ -20,6 +20,7 @@ export const CONNECTOR_CONFIGURATIONS: Record<
     logoComponent: (props: React.SVGProps<SVGSVGElement>) => React.JSX.Element;
     description: string;
     limitations: string | null;
+    guideLink: string | null;
     isNested: boolean;
   }
 > = {
@@ -32,6 +33,7 @@ export const CONNECTOR_CONFIGURATIONS: Record<
       "Grant tailored access to your organization's Confluence shared spaces.",
     limitations:
       "Dust indexes pages in selected global spaces without any view restrictions. If a page, or its parent pages, have view restrictions, it won't be indexed.",
+    guideLink: null,
     logoComponent: ConfluenceLogo,
     isNested: true,
   },
@@ -43,6 +45,7 @@ export const CONNECTOR_CONFIGURATIONS: Record<
     description:
       "Authorize granular access to your company's Notion workspace, by top-level pages.",
     limitations: "External files and content behind links are not indexed.",
+    guideLink: null,
     logoComponent: NotionLogo,
     isNested: true,
   },
@@ -55,6 +58,7 @@ export const CONNECTOR_CONFIGURATIONS: Record<
       "Authorize granular access to your company's Google Drive, by drives and folders. Supported files include GDocs, GSlides, and .txt files. Email us for .pdf indexing.",
     limitations:
       "Files with empty text content or with more than 750KB of extracted text are ignored. By default, PDF files are not indexed. Email us at team@dust.tt to enable PDF indexing.",
+    guideLink: null,
     logoComponent: DriveLogo,
     isNested: true,
   },
@@ -66,6 +70,7 @@ export const CONNECTOR_CONFIGURATIONS: Record<
     description:
       "Authorize granular access to your Slack workspace on a channel-by-channel basis.",
     limitations: "External files and content behind links are not indexed.",
+    guideLink: null,
     logoComponent: SlackLogo,
     isNested: false,
   },
@@ -78,6 +83,7 @@ export const CONNECTOR_CONFIGURATIONS: Record<
       "Authorize access to your company's GitHub on a repository-by-repository basis. Dust can access Issues, Discussions, and Pull Request threads. Code indexing can be controlled on-demand.",
     limitations:
       "Dust gathers data from issues, discussions, and pull-requests (top-level discussion, but not in-code comments). It synchronizes your code only if enabled.",
+    guideLink: null,
     logoComponent: GithubLogo,
     isNested: true,
   },
@@ -91,6 +97,8 @@ export const CONNECTOR_CONFIGURATIONS: Record<
       "Authorize granular access to your Intercom workspace. Access your Conversations at the Team level and Help Center Articles at the main Collection level.",
     limitations:
       "Dust will index only the conversations from the selected Teams that were initiated within the past 90 days and concluded (marked as closed). For the Help Center data, Dust will index every Article published within a selected Collection.",
+    guideLink:
+      "https://dust-tt.notion.site/Intercom-connection-on-Dust-193f0670d39a44de85cd472c6035ea84",
     logoComponent: IntercomLogo,
     isNested: true,
   },
@@ -101,6 +109,7 @@ export const CONNECTOR_CONFIGURATIONS: Record<
     hide: true,
     description: "Crawl a website.",
     limitations: null,
+    guideLink: null,
     logoComponent: GlobeAltIcon,
     isNested: true,
   },

--- a/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
@@ -1,4 +1,5 @@
 import {
+  BookOpenIcon,
   Button,
   Cog6ToothIcon,
   ContextItem,
@@ -729,6 +730,7 @@ interface ConnectorUiConfig {
   displayManagePermissionButton: boolean;
   addDataButtonLabel: string | null;
   displaySettingsButton: boolean;
+  guideLink?: string;
 }
 
 function getRenderingConfigForConnectorProvider(
@@ -753,6 +755,8 @@ function getRenderingConfigForConnectorProvider(
       return {
         ...commonConfig,
         displayDataSourceDetailsModal: false,
+        guideLink:
+          "https://dust-tt.notion.site/Intercom-connection-on-Dust-193f0670d39a44de85cd472c6035ea84",
       };
     case "notion":
       return {
@@ -938,6 +942,7 @@ function ManagedDataSourceView({
     displayManagePermissionButton,
     addDataButtonLabel,
     displaySettingsButton,
+    guideLink,
   } = getRenderingConfigForConnectorProvider(connectorProvider);
 
   return (
@@ -1044,6 +1049,17 @@ function ManagedDataSourceView({
                       } else {
                         void handleUpdatePermissions();
                       }
+                    }}
+                  />
+                )}
+
+                {guideLink && (
+                  <Button
+                    label="Read our guide"
+                    variant="tertiary"
+                    icon={BookOpenIcon}
+                    onClick={() => {
+                      window.open(guideLink, "_blank");
                     }}
                   />
                 )}

--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -1,4 +1,5 @@
 import {
+  BookOpenIcon,
   Button,
   Chip,
   CloudArrowLeftRightIcon,
@@ -60,6 +61,7 @@ type DataSourceIntegration = {
   connectorProvider: ConnectorProvider;
   description: string;
   limitations: string | null;
+  guideLink: string | null;
   synchronizedAgo: string | null;
   setupWithSuffix: string | null;
 };
@@ -170,6 +172,7 @@ export const getServerSideProps = withGetServerSidePropsLogging<{
       rollingOutFlag: integration.rollingOutFlag || null,
       description: integration.description,
       limitations: integration.limitations,
+      guideLink: integration.guideLink,
       dataSourceName: mc.dataSourceName,
       connector: mc.connector,
       fetchConnectorError: mc.fetchConnectorError,
@@ -214,6 +217,7 @@ export const getServerSideProps = withGetServerSidePropsLogging<{
         rollingOutFlag: integration.rollingOutFlag || null,
         description: integration.description,
         limitations: integration.limitations,
+        guideLink: integration.guideLink,
         dataSourceName: null,
         connector: null,
         fetchConnectorError: false,
@@ -331,24 +335,40 @@ function ConfirmationModal({
               </div>
             </>
           )}
+
           <div className="flex justify-center pt-2">
-            <Button
-              variant="primary"
-              size="md"
-              icon={CloudArrowLeftRightIcon}
-              onClick={() => {
-                setIsLoading(true);
-                onConfirm();
-              }}
-              disabled={isLoading}
-              label={
-                isLoading
-                  ? "Connecting..."
-                  : dataSource.connectorProvider === "google_drive"
-                  ? "Acknowledge and Connect"
-                  : "Connect"
-              }
-            />
+            <Button.List isWrapping={true}>
+              <Button
+                variant="primary"
+                size="md"
+                icon={CloudArrowLeftRightIcon}
+                onClick={() => {
+                  setIsLoading(true);
+                  onConfirm();
+                }}
+                disabled={isLoading}
+                label={
+                  isLoading
+                    ? "Connecting..."
+                    : dataSource.connectorProvider === "google_drive"
+                    ? "Acknowledge and Connect"
+                    : "Connect"
+                }
+              />
+              {dataSource.guideLink && (
+                <Button
+                  label="Read our guide"
+                  size="md"
+                  variant="tertiary"
+                  icon={BookOpenIcon}
+                  onClick={() => {
+                    if (dataSource.guideLink) {
+                      window.open(dataSource.guideLink, "_blank");
+                    }
+                  }}
+                />
+              )}
+            </Button.List>
           </div>
         </Page.Vertical>
       </div>


### PR DESCRIPTION
## Description

Adds the ability to add a guide for a connector. It opens a link to our Notion doc on another tab.



Displayed on the modal before setting up the connection: 

<kbd>
<img width="1415" alt="Screenshot 2024-02-22 at 19 15 47" src="https://github.com/dust-tt/dust/assets/3803406/aa93d2e8-05fc-4b39-9fe9-013c9f4f8de1">
</kbd>

And on the connection page (once connection is active);
<kbd>
<img width="1417" alt="Screenshot 2024-02-22 at 19 10 56" src="https://github.com/dust-tt/dust/assets/3803406/5337deae-8b4f-4c3b-bdeb-c6ea333af0d7">
</kbd>



## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
