### PR TITLE
Flav/support joining workspace

### DIFF
--- a/connectors/src/connectors/slack/lib/workspace_limits.ts
+++ b/connectors/src/connectors/slack/lib/workspace_limits.ts
@@ -125,43 +125,48 @@ async function isAutoJoinEnabledForDomain(
   return isDomainAutoJoinEnabled?.domainAutoJoinEnabled ?? false;
 }
 
-const slackMembershipAccessBlocks = {
-  autojoin_enabled: [
-    {
-      type: "section",
-      text: {
-        type: "mrkdwn",
-        text: "The Slack integration is accessible to members of your company's Dust workspace. Click 'Join My Workspace' to get started. For help, contact an administrator.",
-      },
-    },
-    {
-      type: "actions",
-      elements: [
-        {
-          type: "button",
-          text: {
-            type: "plain_text",
-            text: "Join My Workspace",
-            emoji: true,
-          },
-          style: "primary",
-          value: "join_my_workspace_cta",
-          action_id: "actionId-0",
-          url: "https://dust.tt/",
+function makeSlackMembershipAccessBlocksForConnector(
+  connector: ConnectorResource
+) {
+  return {
+    autojoin_enabled: [
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: "The Slack integration is accessible to members of your company's Dust workspace. Click 'Join My Workspace' to get started. For help, contact an administrator.",
         },
-      ],
-    },
-  ],
-  autojoin_disabled: [
-    {
-      type: "section",
-      text: {
-        type: "mrkdwn",
-        text: "It looks like you're not a member of your company's Dust workspace yet. Please reach out to an administrator to join and start using Dust on Slack.",
       },
-    },
-  ],
-};
+      {
+        type: "actions",
+        elements: [
+          {
+            type: "button",
+            text: {
+              type: "plain_text",
+              text: "Join My Workspace",
+              emoji: true,
+            },
+            style: "primary",
+            value: "join_my_workspace_cta",
+            action_id: "actionId-0",
+            // TODO(2024-02-01 flav) don't hardcode URL.
+            url: `https://dust.tt/w/${connector.workspaceId}/join?wId=${connector.workspaceId}`,
+          },
+        ],
+      },
+    ],
+    autojoin_disabled: [
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: "It looks like you're not a member of your company's Dust workspace yet. Please reach out to an administrator to join and start using Dust on Slack.",
+        },
+      },
+    ],
+  };
+}
 
 async function postMessageForUnhautorizedUser(
   connector: ConnectorResource,
@@ -177,7 +182,7 @@ async function postMessageForUnhautorizedUser(
   );
 
   const slackMessageBlocks =
-    slackMembershipAccessBlocks[
+    makeSlackMembershipAccessBlocksForConnector(connector)[
       autoJoinEnabled ? "autojoin_enabled" : "autojoin_disabled"
     ];
 

--- a/front/lib/models/workspace.ts
+++ b/front/lib/models/workspace.ts
@@ -182,7 +182,7 @@ export class MembershipInvitation extends Model<
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
-  declare inviteEmail: "string";
+  declare inviteEmail: string;
   declare status: "pending" | "consumed" | "revoked";
 
   declare workspaceId: ForeignKey<Workspace["id"]>;

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -256,12 +256,16 @@ async function handleRegularSignupFlow(
   const { workspace: existingWorkspace } = workspaceWithVerifiedDomain ?? {};
 
   // Verify that the user is allowed to join the specified workspace.
-  const isAllowed = canJoinTargetWorkspace(
+  const joinTargetWorkspaceAllowed = canJoinTargetWorkspace(
     targetWorkspaceId,
     existingWorkspace,
     activeMemberships
   );
-  if (workspaceWithVerifiedDomain && existingWorkspace && isAllowed) {
+  if (
+    workspaceWithVerifiedDomain &&
+    existingWorkspace &&
+    joinTargetWorkspaceAllowed
+  ) {
     const workspaceSubscription = await subscriptionForWorkspace(
       existingWorkspace
     );

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -1,4 +1,4 @@
-import type { WithAPIErrorReponse } from "@dust-tt/types";
+import type { ModelId, WithAPIErrorReponse } from "@dust-tt/types";
 import { FrontApiError } from "@dust-tt/types";
 import { verify } from "jsonwebtoken";
 import type { NextApiRequest, NextApiResponse } from "next";
@@ -194,26 +194,56 @@ async function handleMembershipInvite(
   return workspace;
 }
 
-// Regular flow, only if the user is a newly created user.
-// Verify if there's an existing workspace with the same verified domain that allows auto-joining.
-// The user will join this workspace if it exists; otherwise, a new workspace is created.
-async function handleRegularSignupFlow(
-  session: any,
-  user: User
-): Promise<{
-  flow: "no-auto-join" | "revoked" | null;
-  workspace: Workspace | null;
-}> {
-  // If the user already has an active membership in a workspace, return early.
-  const allMemberships = await Membership.findOne({
+async function getActiveMembershipsForUser(userId: ModelId) {
+  return Membership.findAll({
     where: {
-      userId: user.id,
+      userId,
       role: {
         [Op.ne]: "revoked",
       },
     },
   });
-  if (allMemberships) {
+}
+
+function canJoinTargetWorkspace(
+  targetWorkspaceId: string | undefined,
+  workspace: Workspace | undefined,
+  activeMemberships: Membership[]
+) {
+  // If there is no target workspace id, return true.
+  if (!targetWorkspaceId) {
+    return true;
+  }
+
+  if (!workspace) {
+    return false;
+  }
+
+  // Verify that the user is not already a member of the workspace.
+  const alreadyInWorkspace = activeMemberships.find(
+    (m) => m.workspaceId === workspace.id
+  );
+  if (alreadyInWorkspace) {
+    return false;
+  }
+
+  return targetWorkspaceId === workspace.sId;
+}
+
+// Regular flow, only if the user is a newly created user.
+// Verify if there's an existing workspace with the same verified domain that allows auto-joining.
+// The user will join this workspace if it exists; otherwise, a new workspace is created.
+async function handleRegularSignupFlow(
+  session: any,
+  user: User,
+  targetWorkspaceId?: string
+): Promise<{
+  flow: "no-auto-join" | "revoked" | null;
+  workspace: Workspace | null;
+}> {
+  const activeMemberships = await getActiveMembershipsForUser(user.id);
+  // Return early if the user is already a member of a workspace and is not attempting to join another one.
+  if (activeMemberships.length === 0 && !targetWorkspaceId) {
     return {
       flow: null,
       workspace: null,
@@ -223,9 +253,15 @@ async function handleRegularSignupFlow(
   const workspaceWithVerifiedDomain = await findWorkspaceWithVerifiedDomain(
     session
   );
-
   const { workspace: existingWorkspace } = workspaceWithVerifiedDomain ?? {};
-  if (workspaceWithVerifiedDomain && existingWorkspace) {
+
+  // Verify that the user is allowed to join the specified workspace.
+  const isAllowed = canJoinTargetWorkspace(
+    targetWorkspaceId,
+    existingWorkspace,
+    activeMemberships
+  );
+  if (workspaceWithVerifiedDomain && existingWorkspace && isAllowed) {
     const workspaceSubscription = await subscriptionForWorkspace(
       existingWorkspace
     );
@@ -261,7 +297,7 @@ async function handleRegularSignupFlow(
     }
 
     return { flow: null, workspace: existingWorkspace };
-  } else {
+  } else if (!targetWorkspaceId) {
     const workspace = await createWorkspace(session);
     await createAndLogMembership({
       workspace,
@@ -274,6 +310,9 @@ async function handleRegularSignupFlow(
     });
 
     return { flow: null, workspace };
+  } else {
+    // Redirect the user to their existing workspace if they are not allowed to join the target workspace.
+    return { flow: null, workspace: null };
   }
 }
 
@@ -297,7 +336,8 @@ async function handler(
     });
   }
 
-  const { inviteToken } = req.query;
+  const { inviteToken, wId } = req.query;
+  const targetWorkspaceId = typeof wId === "string" ? wId : undefined;
 
   // `membershipInvite` is set to a `MembeshipInvitation` if the query includes an
   // `inviteToken`, meaning the user is going through the invite by email flow.
@@ -333,7 +373,11 @@ async function handler(
     if (membershipInvite) {
       targetWorkspace = await handleMembershipInvite(user, membershipInvite);
     } else {
-      const { flow, workspace } = await handleRegularSignupFlow(session, user);
+      const { flow, workspace } = await handleRegularSignupFlow(
+        session,
+        user,
+        targetWorkspaceId
+      );
       if (flow) {
         res.redirect(`/no-workspace?flow=${flow}`);
         return;


### PR DESCRIPTION
## Description

This PR resolves https://github.com/dust-tt/tasks/issues/445.

This PR introduces a new login flow that enables the generation of an invitation link to join a specific workspace, provided that auto-join is activated. The goal is to enhance the user experience for those who receive a Slack invitation by clearly indicating which workspace they will be joining.
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

I fully tested all the scenarios locally. Safe to rollback.
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Due to the drive-by change made to the `Membership` model definition, the CI incorrectly flagged this PR as having a migration. Not the case!

Deploy `front` first, then `connectors`.
<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
