### PR TITLE
Set timeout to 30 seconds on all GET requests on Confluence API

### DIFF
--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -163,6 +163,8 @@ export class ConfluenceClient {
         Authorization: `Bearer ${this.authToken}`,
         "Content-Type": "application/json",
       },
+      // Timeout after 30 seconds.
+      signal: AbortSignal.timeout(30000),
     });
 
     if (!response.ok) {


### PR DESCRIPTION
## Description

This PR fixes an issue where GET requests on the Confluence API lead to `Headers Timeout Error`, which results from a connection that lasted more than 5 minutes. This error seems to be sporadic, since the same query succeed a few minutes later. This PR enforces a timeout of 30 seconds on all those queries. 
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
