### PR TITLE
Intercom: Add logs for undefined collectionId in syncLevel1CollectionWithChildrenActivity

### DIFF
--- a/connectors/src/connectors/intercom/temporal/sync_help_center.ts
+++ b/connectors/src/connectors/intercom/temporal/sync_help_center.ts
@@ -79,6 +79,14 @@ export async function deleteCollectionWithChildren({
 }) {
   const collectionId = collection.collectionId;
 
+  if (!collectionId) {
+    logger.error(
+      { connectorId, collection },
+      "[Intercom] Collection has no id. Skipping deleteCollectionWithChildren."
+    );
+    return;
+  }
+
   // We delete all articles in the collection
   const articles = await IntercomArticle.findAll({
     where: {
@@ -121,11 +129,11 @@ export async function deleteCollectionWithChildren({
     },
   });
   await Promise.all(
-    childrenCollections.map(async (collection) => {
+    childrenCollections.map(async (c) => {
       await deleteCollectionWithChildren({
         connectorId,
         dataSourceConfig,
-        collection,
+        collection: c,
         loggerArgs,
       });
     })
@@ -148,11 +156,20 @@ export async function upsertCollectionWithChildren({
   collection: IntercomCollectionType;
   currentSyncMs: number;
 }) {
+  const collectionId = collection.id;
+  if (!collectionId) {
+    logger.error(
+      { connectorId, helpCenterId, collection },
+      "[Intercom] Collection has no id. Skipping upsertCollectionWithChildren."
+    );
+    return;
+  }
+
   // Sync the Collection
   let collectionOnDb = await IntercomCollection.findOne({
     where: {
       connectorId,
-      collectionId: collection.id,
+      collectionId,
     },
   });
 


### PR DESCRIPTION
## Description

Adds logs to fix this: https://app.datadoghq.eu/logs?query=%22Unhandled%20activity%20error%22%20&cols=service%2C%40workflowName%2C%40activityName%2C%40error.__is_dust_error&event=AgAAAY3Ucnfq_rSBpQAAAAAAAAAYAAAAAEFZM1VjbjJyQUFDTDU0eEhpSVMyMFFFdQAAACQAAAAAMDE4ZGQ0OGMtOTZmOC00OWZkLWJlZjYtNTUxMjFjZGExNzJi&fromUser=true&index=%2A&messageDisplay=inline&refresh_mode=sliding&saved-view-id=99803&stream_sort=%40duration%2Cdesc&viz=stream&from_ts=1708594080445&to_ts=1708680480445&live=true

The workflow raising the error eventually succeeded: https://cloud.temporal.io/namespaces/dust-prod.gmnlm/workflows/intercom-sync-809-help-center-314/73c07755-6aa7-496b-89d9-11bb4364102a/history

-> I'm adding a return value for the activity just so it's convenient to look at the detail of the workflow on Temporal. 
-> Otherwise it's logs in `deleteCollectionWithChildren` and `upsertCollectionWithChildren`

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
