### PR TITLE
Intercom: Reduce startToCloseTimeout of activities to 10min

### DIFF
--- a/connectors/src/connectors/intercom/temporal/workflows.ts
+++ b/connectors/src/connectors/intercom/temporal/workflows.ts
@@ -18,7 +18,7 @@ const {
   syncLevel1CollectionWithChildrenActivity,
   syncArticleBatchActivity,
 } = proxyActivities<typeof activities>({
-  startToCloseTimeout: "30 minutes",
+  startToCloseTimeout: "5 minutes",
 });
 
 const {
@@ -28,7 +28,7 @@ const {
   getNextConversationsBatchToDeleteActivity,
   deleteConversationBatchActivity,
 } = proxyActivities<typeof activities>({
-  startToCloseTimeout: "30 minutes",
+  startToCloseTimeout: "5 minutes",
 });
 
 const { saveIntercomConnectorStartSync, saveIntercomConnectorSuccessSync } =


### PR DESCRIPTION
## Description

Activities are really small and takes a few seconds. 
-> I have one stuck here and there's no need to wait 30min to make it fail: https://cloud.temporal.io/namespaces/dust-prod.gmnlm/workflows/intercom-sync-809-team-50007005/548c5979-6dec-4d04-b00a-33e06096c211/history

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Will need to restart all Intercom workflows
