### PR TITLE
Intercom: Better conversation title if empty

### DIFF
--- a/connectors/src/connectors/intercom/temporal/sync_conversation.ts
+++ b/connectors/src/connectors/intercom/temporal/sync_conversation.ts
@@ -209,8 +209,16 @@ export async function syncConversation({
 
   // Building the markdown content for the conversation
   let markdown = "";
-  const convoTitle = conversation.title || "No title";
+  let convoTitle = conversation.title;
 
+  if (!convoTitle) {
+    const formattedDate = createdAtDate.toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    });
+    convoTitle = `Conversation from ${formattedDate}`;
+  }
   const tags = conversation.tags?.tags
     .map((tag: IntercomTagType) => tag.name)
     .join(", ");
@@ -267,7 +275,7 @@ export async function syncConversation({
     documentUrl: conversationUrl,
     timestampMs: updatedAtDate.getTime(),
     tags: [
-      `title:${conversation.title}`,
+      `title:${convoTitle}`,
       `createdAt:${createdAtDate.getTime()}`,
       `updatedAt:${updatedAtDate.getTime()}`,
     ],


### PR DESCRIPTION
## Description

This sets "Conversation from Feb 7, 2024" over "No title" for a conversation without title in the datasource. 

## Risk

Low

## Deploy Plan

Full resync of existing connectors needed to be applied on existing conversations. 
