### PR TITLE
Cancel Notion's workflows on invalid token

### DIFF
--- a/connectors/src/connectors/notion/lib/notion_api.ts
+++ b/connectors/src/connectors/notion/lib/notion_api.ts
@@ -6,6 +6,7 @@ import {
   isFullBlock,
   isFullDatabase,
   isFullPage,
+  isNotionClientError,
 } from "@notionhq/client";
 import type {
   BlockObjectResponse,
@@ -27,6 +28,7 @@ import type {
   PropertyKeys,
 } from "@connectors/connectors/notion/lib/types";
 import { cacheGet, cacheSet } from "@connectors/lib/cache";
+import { ExternalOauthTokenError } from "@connectors/lib/error";
 import mainLogger from "@connectors/logger/logger";
 
 const logger = mainLogger.child({ provider: "notion" });
@@ -38,6 +40,22 @@ const notionClientLogger = (
 ) => {
   logger.info(`[Log from Notion Client] Level ${level}: ${message}`, extraInfo);
 };
+
+async function wrapNotionAPITokenErrors<T>(
+  worker: () => Promise<T>
+): Promise<T> {
+  try {
+    return await worker();
+  } catch (err) {
+    if (isNotionClientError(err)) {
+      if (err.code === "unauthorized") {
+        throw new ExternalOauthTokenError(err);
+      }
+    }
+
+    throw err;
+  }
+}
 
 /**
  * @param notionAccessToken the access token to use to access the Notion API
@@ -80,14 +98,18 @@ export async function getPagesAndDatabasesEditedSince(
     const tryLogger = localLogger.child({ tries, maxTries: retry.retries });
     tryLogger.info("Fetching result page from Notion API.");
     try {
-      resultsPage = await notionClient.search({
-        sort: sinceTs
-          ? {
-              timestamp: "last_edited_time",
-              direction: "descending",
-            }
-          : undefined,
-        start_cursor: cursor || undefined,
+      resultsPage = await wrapNotionAPITokenErrors(async () => {
+        const t = notionClient.search({
+          sort: sinceTs
+            ? {
+                timestamp: "last_edited_time",
+                direction: "descending",
+              }
+            : undefined,
+          start_cursor: cursor || undefined,
+        });
+
+        return t;
       });
       tryLogger.info(
         { count: resultsPage.results.length },
@@ -243,16 +265,20 @@ export async function isAccessibleAndUnarchived(
     try {
       tryLogger.info("Checking if page is accessible and unarchived.");
       if (objectType === "page") {
-        const page = await notionClient.pages.retrieve({ page_id: objectId });
+        const page = await wrapNotionAPITokenErrors(async () =>
+          notionClient.pages.retrieve({ page_id: objectId })
+        );
         if (!isFullPage(page)) {
           return false;
         }
         return !page.archived;
       }
       if (objectType === "database") {
-        const db = await notionClient.databases.retrieve({
-          database_id: objectId,
-        });
+        const db = await wrapNotionAPITokenErrors(async () =>
+          notionClient.databases.retrieve({
+            database_id: objectId,
+          })
+        );
         if (!isFullDatabase(db)) {
           return false;
         }
@@ -317,9 +343,11 @@ async function getBlockParent(
   for (;;) {
     localLogger.info({ blockId }, "Looking up block parent");
     try {
-      const block = await notionClient.blocks.retrieve({
-        block_id: blockId,
-      });
+      const block = await wrapNotionAPITokenErrors(async () =>
+        notionClient.blocks.retrieve({
+          block_id: blockId,
+        })
+      );
 
       if (!isFullBlock(block)) {
         // Not much we can do here to get the parent page.
@@ -389,9 +417,11 @@ export async function getParsedDatabase(
 
   try {
     localLogger.info("Fetching database from Notion API.");
-    database = await notionClient.databases.retrieve({
-      database_id: databaseId,
-    });
+    database = await wrapNotionAPITokenErrors(async () =>
+      notionClient.databases.retrieve({
+        database_id: databaseId,
+      })
+    );
   } catch (e) {
     if (
       APIResponseError.isAPIResponseError(e) &&
@@ -482,7 +512,9 @@ export async function retrievePage({
   let page: GetPageResponse | null = null;
   try {
     localLogger.info("Fetching page from Notion API.");
-    page = await notionClient.pages.retrieve({ page_id: pageId });
+    page = await wrapNotionAPITokenErrors(async () =>
+      notionClient.pages.retrieve({ page_id: pageId })
+    );
   } catch (e) {
     if (
       APIResponseError.isAPIResponseError(e) &&
@@ -535,10 +567,12 @@ export async function retrieveBlockChildrenResultPage({
     localLogger.info(
       "Fetching block or page children result page from Notion API."
     );
-    const resultPage = await notionClient.blocks.children.list({
-      block_id: blockOrPageId,
-      start_cursor: cursor ?? undefined,
-    });
+    const resultPage = await wrapNotionAPITokenErrors(async () =>
+      notionClient.blocks.children.list({
+        block_id: blockOrPageId,
+        start_cursor: cursor ?? undefined,
+      })
+    );
     localLogger.info(
       { count: resultPage.results.length },
       "Received block or page children result page from Notion API."
@@ -743,10 +777,12 @@ export async function retrieveDatabaseChildrenResultPage({
 
   localLogger.info("Fetching database children result page from Notion API.");
   try {
-    const resultPage = await notionClient.databases.query({
-      database_id: databaseId,
-      start_cursor: cursor || undefined,
-    });
+    const resultPage = await wrapNotionAPITokenErrors(async () =>
+      notionClient.databases.query({
+        database_id: databaseId,
+        start_cursor: cursor || undefined,
+      })
+    );
 
     localLogger.info(
       { count: resultPage.results.length },
@@ -880,9 +916,11 @@ export async function getUserName(
 
   try {
     pageLogger.info({ user_id: userId }, "Fetching user name from Notion API.");
-    const user = await notionClient.users.retrieve({
-      user_id: userId,
-    });
+    const user = await wrapNotionAPITokenErrors(async () =>
+      notionClient.users.retrieve({
+        user_id: userId,
+      })
+    );
     if (!user) {
       return null;
     }

--- a/connectors/src/connectors/notion/lib/notion_api.ts
+++ b/connectors/src/connectors/notion/lib/notion_api.ts
@@ -99,7 +99,7 @@ export async function getPagesAndDatabasesEditedSince(
     tryLogger.info("Fetching result page from Notion API.");
     try {
       resultsPage = await wrapNotionAPITokenErrors(async () => {
-        const t = notionClient.search({
+        return notionClient.search({
           sort: sinceTs
             ? {
                 timestamp: "last_edited_time",
@@ -108,8 +108,6 @@ export async function getPagesAndDatabasesEditedSince(
             : undefined,
           start_cursor: cursor || undefined,
         });
-
-        return t;
       });
       tryLogger.info(
         { count: resultsPage.results.length },

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -344,9 +344,6 @@ export async function getPagesAndDatabasesToSync({
           }
           throw e;
 
-        case "unauthorized":
-          throw new ExternalOauthTokenError(e);
-
         default:
           throw e;
       }

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -56,7 +56,6 @@ import {
   upsertTableFromCsv,
   upsertToDatasource,
 } from "@connectors/lib/data_sources";
-import { ExternalOauthTokenError } from "@connectors/lib/error";
 import {
   NotionConnectorBlockCacheEntry,
   NotionConnectorPageCacheEntry,

--- a/connectors/src/connectors/notion/temporal/client.ts
+++ b/connectors/src/connectors/notion/temporal/client.ts
@@ -69,8 +69,7 @@ export async function launchNotionSyncWorkflow(
       connectorId: [connectorId],
     },
     memo: {
-      connectorId: connectorId,
-      doNotCancelOnTokenRevoked: true,
+      connectorId,
     },
   });
 
@@ -121,8 +120,7 @@ export async function launchNotionGarbageCollectorWorkflow(
       connectorId: [connectorId],
     },
     memo: {
-      connectorId: connectorId,
-      doNotCancelOnTokenRevoked: true,
+      connectorId,
     },
   });
 

--- a/connectors/src/lib/temporal.ts
+++ b/connectors/src/lib/temporal.ts
@@ -8,7 +8,6 @@ import fs from "fs-extra";
 let TEMPORAL_CLIENT: Client | undefined;
 
 const CONNECTOR_ID_CACHE: Record<string, ModelId> = {};
-const DO_NOT_CANCEL_ON_TOKEN_REVOKED_CACHE: Record<string, boolean> = {};
 
 export async function getTemporalClient(): Promise<Client> {
   if (TEMPORAL_CLIENT) {
@@ -90,26 +89,6 @@ export async function getConnectorId(
     }
   }
   return CONNECTOR_ID_CACHE[workflowRunId] || null;
-}
-
-export async function getDoNotCancelOnTokenRevoked(
-  workflowRunId: string
-): Promise<boolean> {
-  if (!(workflowRunId in DO_NOT_CANCEL_ON_TOKEN_REVOKED_CACHE)) {
-    const client = await getTemporalClient();
-    const workflowHandle = client.workflow.getHandle(workflowRunId);
-    const described = await workflowHandle.describe();
-    if (described.memo && described.memo.doNotCancelOnTokenRevoked) {
-      if (typeof described.memo.doNotCancelOnTokenRevoked === "boolean") {
-        DO_NOT_CANCEL_ON_TOKEN_REVOKED_CACHE[workflowRunId] =
-          described.memo.doNotCancelOnTokenRevoked;
-      } else if (typeof described.memo.doNotCancelOnTokenRevoked === "string") {
-        DO_NOT_CANCEL_ON_TOKEN_REVOKED_CACHE[workflowRunId] =
-          described.memo.doNotCancelOnTokenRevoked === "true";
-      }
-    }
-  }
-  return DO_NOT_CANCEL_ON_TOKEN_REVOKED_CACHE[workflowRunId] ?? false;
 }
 
 export async function cancelWorkflow(workflowId: string) {


### PR DESCRIPTION
## Description

Over the weekend, we encountered quite some Notion workflow disruptions due to invalid API tokens. As of now, Notion implements a unique method to manage failures resulting from revoked tokens (introduced in https://github.com/dust-tt/dust/pull/3146). It requires the eng runner to manually abort the workflows and contact the affected customers. This PR proposes align Notion's behavior on other connectors. In the event of revoked API token, we will terminate the Notion workflows like we do for any other connector. The user interface already present a warning message, notifying the customer that the synchronization has been deactivated.

<img width="952" alt="image" src="https://github.com/dust-tt/dust/assets/7428970/d9b859f6-5e5f-40e0-851b-4eca8619978d">

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
