### PR TITLE
Intercom: Fix help center id can be null for sub collections

### DIFF
--- a/connectors/src/connectors/intercom/lib/help_center_permissions.ts
+++ b/connectors/src/connectors/intercom/lib/help_center_permissions.ts
@@ -96,6 +96,7 @@ export async function allowSyncHelpCenter({
         connectorId,
         connectionId,
         collectionId: c1.id,
+        helpCenterId,
         region,
       })
     );
@@ -171,11 +172,13 @@ export async function allowSyncCollection({
   connectorId,
   connectionId,
   collectionId,
+  helpCenterId,
   region,
 }: {
   connectorId: ModelId;
   connectionId: string;
   collectionId: string;
+  helpCenterId?: string;
   region: string;
 }): Promise<IntercomCollection | null> {
   let collection = await IntercomCollection.findOne({
@@ -194,12 +197,15 @@ export async function allowSyncCollection({
       connectionId,
       collectionId
     );
-    if (intercomCollection && intercomCollection.help_center_id) {
+
+    const hpId = helpCenterId || intercomCollection?.help_center_id;
+
+    if (intercomCollection && hpId) {
       collection = await IntercomCollection.create({
         connectorId,
         collectionId: intercomCollection.id,
         intercomWorkspaceId: intercomCollection.workspace_id,
-        helpCenterId: intercomCollection.help_center_id,
+        helpCenterId: hpId,
         parentId: intercomCollection.parent_id,
         name: intercomCollection.name,
         description: intercomCollection.description,
@@ -239,6 +245,7 @@ export async function allowSyncCollection({
       connectorId,
       connectionId,
       collectionId: c.id,
+      helpCenterId,
       region,
     })
   );

--- a/connectors/src/connectors/intercom/lib/intercom_api.ts
+++ b/connectors/src/connectors/intercom/lib/intercom_api.ts
@@ -185,8 +185,8 @@ export async function fetchIntercomCollections(
 
   return collections.filter(
     (collection) =>
-      collection.help_center_id == helpCenterId &&
-      collection.parent_id == parentId
+      collection.parent_id == parentId &&
+      (parentId === null ? collection.help_center_id == helpCenterId : true)
   );
 }
 

--- a/connectors/src/connectors/intercom/lib/utils.ts
+++ b/connectors/src/connectors/intercom/lib/utils.ts
@@ -74,10 +74,10 @@ export function getTeamIdFromInternalId(
 }
 
 function getIntercomDomain(region: string): string {
-  if (region === "EU") {
+  if (region === "Europe") {
     return "https://app.eu.intercom.com";
   }
-  if (region === "AU") {
+  if (region === "Australia") {
     return "https://app.au.intercom.com";
   }
   return "https://app.intercom.com";

--- a/connectors/src/connectors/intercom/temporal/sync_help_center.ts
+++ b/connectors/src/connectors/intercom/temporal/sync_help_center.ts
@@ -350,7 +350,7 @@ export async function upsertArticle({
       getHelpCenterInternalId(connectorId, helpCenterId)
     );
 
-    return upsertToDatasource({
+    await upsertToDatasource({
       dataSourceConfig,
       documentId: getHelpCenterArticleInternalId(connectorId, article.id),
       documentContent: renderedPage,


### PR DESCRIPTION
## Description


We were missing some Collections and articles on prod for a user: https://github.com/dust-tt/tasks/issues/464

2 fixes: 
- A collection "help_center_id" can be null even if a collection was added to a help center: we keep the filter on help_center_id only for level 1 collections (= those who parents is null), otherwise we only filter by parent_id.

Unrelated: 
- Set the region name for EU based intercom is "Europe". No issue on prod with it as the one for our EU based client was set manually by me. 


## Risk

Low.

## Deploy Plan

Need to update connector 809 to set IntercomWorkspace region to "Europe" instead of "EU".
No need to full resync, Help Centers are automatically resynced every hour. 
