### PR TITLE
Assistant Builder action screen take II

### DIFF
--- a/front/components/EmptyCallToAction.tsx
+++ b/front/components/EmptyCallToAction.tsx
@@ -1,4 +1,4 @@
-import { Button, PlusIcon } from "@dust-tt/sparkle";
+import { Button } from "@dust-tt/sparkle";
 import Link from "next/link";
 import type { ComponentType, MouseEvent } from "react";
 import React from "react";
@@ -8,13 +8,13 @@ import { classNames } from "@app/lib/utils";
 export function EmptyCallToAction({
   label,
   disabled = false,
-  icon = PlusIcon,
+  icon,
   href,
   onClick,
 }: {
   label: string;
   disabled?: boolean;
-  icon?: ComponentType | null;
+  icon?: ComponentType;
   href?: string;
   onClick?: (event: MouseEvent<HTMLButtonElement>) => void;
 }) {

--- a/front/components/EmptyCallToAction.tsx
+++ b/front/components/EmptyCallToAction.tsx
@@ -14,24 +14,24 @@ export function EmptyCallToAction({
 }: {
   label: string;
   disabled?: boolean;
-  icon?: ComponentType;
+  icon?: ComponentType | null;
   href?: string;
   onClick?: (event: MouseEvent<HTMLButtonElement>) => void;
 }) {
   const button = (
     <Button
       disabled={disabled}
-      size="md"
+      size="sm"
       label={label}
       variant="primary"
-      icon={icon}
+      icon={icon || undefined}
       onClick={onClick}
     />
   );
   return (
     <div
       className={classNames(
-        "flex h-full min-h-48 items-center justify-center rounded-lg bg-structure-50"
+        "flex h-full min-h-40 items-center justify-center rounded-lg bg-structure-50"
       )}
     >
       {href ? <Link href={href}>{button}</Link> : button}

--- a/front/components/assistant_builder/ActionScreen.tsx
+++ b/front/components/assistant_builder/ActionScreen.tsx
@@ -195,9 +195,10 @@ export default function ActionScreen({
     }
   };
 
-  const noDataSources =
+  const noDataSources = !(
     configurableDataSources.length === 0 &&
-    Object.keys(builderState.dataSourceConfigurations).length === 0;
+    Object.keys(builderState.dataSourceConfigurations).length === 0
+  );
   const noDustApp = dustApps.length === 0;
 
   return (
@@ -361,11 +362,9 @@ export default function ActionScreen({
                         return (
                           <div>
                             <strong>
-                              Only Admins can activate Connections.
-                              <br />
-                              You can add Data Sources by visiting the
-                              "Websites" and "Folders" sections in the Build
-                              panel.
+                              Only Admins can activate Connections. You can add
+                              Data Sources by visiting the "Websites" and
+                              "Folders" sections in the Build panel.
                             </strong>
                           </div>
                         );
@@ -373,8 +372,9 @@ export default function ActionScreen({
                         return (
                           <div>
                             <strong>
-                              Only Admins and Builders can activate Connections,
-                              add public Websites or create Folders.
+                              Contact an Admin or Builder to activate
+                              Connections, add public Websites or create
+                              Folders.
                             </strong>
                           </div>
                         );

--- a/front/components/assistant_builder/ActionScreen.tsx
+++ b/front/components/assistant_builder/ActionScreen.tsx
@@ -6,7 +6,6 @@ import {
   DropdownMenu,
   MagnifyingGlassIcon,
   Page,
-  QuestionMarkCircleIcon,
   Square3Stack3DIcon,
   TableIcon,
   TimeIcon,
@@ -442,12 +441,7 @@ export default function ActionScreen({
         )}
 
         <ActionModeSection show={builderState.actionMode === "GENERIC"}>
-          <div className="pb-16 text-sm text-element-700">
-            {/**
-            No action is set. The assistant will use the instructions only to
-            answer.
-            */}
-          </div>
+          <div className="pb-16"></div>
         </ActionModeSection>
 
         <ActionModeSection
@@ -455,39 +449,6 @@ export default function ActionScreen({
             builderState.actionMode === "RETRIEVAL_SEARCH" && !noDataSources
           }
         >
-          {/**
-          <div>
-            The assistant will perform a search on the selected data sources,
-            and run the instructions on the results.{" "}
-            <span className="font-semibold">
-              It’s the best approach with large quantities of data.
-            </span>
-          </div>
-          <div className="grid grid-cols-2 gap-4">
-            <div>
-              <p>
-                <strong>Select your sources with care</strong> The quality of
-                the answers to specific questions will depend on the quality of
-                the data.
-              </p>
-              <p className="mt-1">
-                <strong>
-                  You can narrow your search on most recent documents
-                </strong>{" "}
-                by adding instructions in your prompt such as 'Only search in
-                documents from the last 3 months', 'Only look at data from the
-                last 2 days', etc.
-              </p>
-            </div>
-            <div>
-              <p>
-                <strong>Note:</strong> The available data sources are managed by
-                administrators.
-              </p>
-            </div>
-          </div>
-          */}
-
           <DataSourceSelectionSection
             dataSourceConfigurations={builderState.dataSourceConfigurations}
             openDataSourceModal={() => {
@@ -509,26 +470,6 @@ export default function ActionScreen({
             builderState.actionMode === "RETRIEVAL_EXHAUSTIVE" && !noDataSources
           }
         >
-          {/**
-          <div>
-            The assistant will include as many documents as possible from the
-            data sources, using reverse chronological order.
-          </div>
-          <div className="grid grid-cols-2 gap-8">
-            <div className="col-span-1">
-              <strong>
-                <span className="text-warning-500">Warning!</span> Assistants
-                are limited in the amount of data they can process.
-              </strong>{" "}
-              Select data sources with care, and limit processing to the
-              shortest relevant time frame.
-            </div>
-            <div className="col-span-1">
-              <strong>Note:</strong> The available data sources are managed by
-              administrators.
-            </div>
-          </div>
-          */}
           <DataSourceSelectionSection
             dataSourceConfigurations={builderState.dataSourceConfigurations}
             openDataSourceModal={() => {

--- a/front/components/assistant_builder/ActionScreen.tsx
+++ b/front/components/assistant_builder/ActionScreen.tsx
@@ -6,6 +6,7 @@ import {
   DropdownMenu,
   MagnifyingGlassIcon,
   Page,
+  QuestionMarkCircleIcon,
   Square3Stack3DIcon,
   TableIcon,
   TimeIcon,
@@ -195,6 +196,10 @@ export default function ActionScreen({
     }
   };
 
+  const noDataSources =
+    configurableDataSources.length === 0 &&
+    Object.keys(builderState.dataSourceConfigurations).length === 0;
+
   return (
     <>
       <AssistantBuilderDustAppModal
@@ -334,124 +339,177 @@ export default function ActionScreen({
 
         {getActionType(builderState.actionMode) === "USE_DATA_SOURCES" && (
           <>
-            <div className="flex flex-row items-center space-x-2">
-              <div className="text-sm font-semibold text-element-900">
-                Method:
-              </div>
-              <DropdownMenu>
-                <DropdownMenu.Button>
-                  <Button
-                    type="select"
-                    labelVisible={true}
-                    label={
-                      SEARCH_MODE_SPECIFICATIONS[
-                        getSearchMode(builderState.actionMode)
-                      ].label
+            {noDataSources ? (
+              <ContentMessage
+                title="You don't have any Data source available"
+                variant="warning"
+              >
+                <div className="flex flex-col gap-y-3">
+                  {(() => {
+                    switch (owner.role) {
+                      case "admin":
+                        return (
+                          <div>
+                            <strong>
+                              Visit the "Connections", "Websites" and "Folders"
+                              sections in the Build panel to add new data
+                              sources.
+                            </strong>
+                          </div>
+                        );
+                      case "builder":
+                        return (
+                          <div>
+                            <strong>
+                              Only Admins can activate Connections.
+                              <br />
+                              You can add Data Sources by visiting the
+                              "Websites" and "Folders" sections in the Build
+                              panel.
+                            </strong>
+                          </div>
+                        );
+                      case "user":
+                        return (
+                          <div>
+                            <strong>
+                              Only Admins and Builders can activate Connections,
+                              add public Websites or create Folders.
+                            </strong>
+                          </div>
+                        );
+                      case "none":
+                        return <></>;
+                      default:
+                        assertNever(owner.role);
                     }
-                    icon={
-                      SEARCH_MODE_SPECIFICATIONS[
-                        getSearchMode(builderState.actionMode)
-                      ].icon
-                    }
-                    variant="tertiary"
-                    hasMagnifying={false}
-                    size="sm"
-                  />
-                </DropdownMenu.Button>
-                <DropdownMenu.Items origin="topLeft" width={260}>
-                  {SEARCH_MODES.filter((key) => {
-                    const flag = SEARCH_MODE_SPECIFICATIONS[key].flag;
-                    console.log(owner.flags);
-                    return flag === null || owner.flags.includes(flag);
-                  }).map((key) => (
-                    <DropdownMenu.Item
-                      key={key}
-                      label={SEARCH_MODE_SPECIFICATIONS[key].label}
-                      icon={SEARCH_MODE_SPECIFICATIONS[key].icon}
-                      description={SEARCH_MODE_SPECIFICATIONS[key].description}
-                      onClick={() => {
-                        setEdited(true);
-                        setBuilderState((state) => ({
-                          ...state,
-                          actionMode:
-                            SEARCH_MODE_SPECIFICATIONS[key].actionMode,
-                        }));
-                      }}
-                    />
-                  ))}
-                </DropdownMenu.Items>
-              </DropdownMenu>
-            </div>
-            {configurableDataSources.length === 0 &&
-              Object.keys(builderState.dataSourceConfigurations).length ===
-                0 && (
-                <ContentMessage title="You don't have any active Data source">
-                  <div className="flex flex-col gap-y-3">
-                    <div>
-                      Assistants can incorporate existing company data and
-                      knowledge to formulate answers.
-                    </div>
-                    <div>
-                      There are two types of data sources:{" "}
-                      <strong>Folders</strong> (Files you can upload) and{" "}
-                      <strong>Connections</strong> (Automatically synchronized
-                      with platforms like Notion, Slack, ...).
-                    </div>
-                    {(() => {
-                      switch (owner.role) {
-                        case "admin":
-                          return (
-                            <div>
-                              <strong>
-                                Visit the "Connections" and "Folders" sections
-                                in the Assistants panel to add new data sources.
-                              </strong>
-                            </div>
-                          );
-                        case "builder":
-                          return (
-                            <div>
-                              <strong>
-                                Only Admins can activate Connections.
-                                <br />
-                                You can add Data Sources by visiting "Folders"
-                                in the Assistants panel.
-                              </strong>
-                            </div>
-                          );
-                        case "user":
-                          return (
-                            <div>
-                              <strong>
-                                Only Admins and Builders can activate
-                                Connections or create Folders.
-                              </strong>
-                            </div>
-                          );
-                        case "none":
-                          return <></>;
-                        default:
-                          ((x: never) => {
-                            throw new Error("Unkonwn role " + x);
-                          })(owner.role);
+                  })()}
+                </div>
+              </ContentMessage>
+            ) : (
+              <div className="flex flex-row items-center space-x-2">
+                <div className="text-sm font-semibold text-element-900">
+                  Method:
+                </div>
+                <DropdownMenu>
+                  <DropdownMenu.Button>
+                    <Button
+                      type="select"
+                      labelVisible={true}
+                      label={
+                        SEARCH_MODE_SPECIFICATIONS[
+                          getSearchMode(builderState.actionMode)
+                        ].label
                       }
-                    })()}
-                  </div>
-                </ContentMessage>
-              )}
+                      icon={
+                        SEARCH_MODE_SPECIFICATIONS[
+                          getSearchMode(builderState.actionMode)
+                        ].icon
+                      }
+                      variant="tertiary"
+                      hasMagnifying={false}
+                      size="sm"
+                    />
+                  </DropdownMenu.Button>
+                  <DropdownMenu.Items origin="topLeft" width={260}>
+                    {SEARCH_MODES.filter((key) => {
+                      const flag = SEARCH_MODE_SPECIFICATIONS[key].flag;
+                      console.log(owner.flags);
+                      return flag === null || owner.flags.includes(flag);
+                    }).map((key) => (
+                      <DropdownMenu.Item
+                        key={key}
+                        label={SEARCH_MODE_SPECIFICATIONS[key].label}
+                        icon={SEARCH_MODE_SPECIFICATIONS[key].icon}
+                        description={
+                          SEARCH_MODE_SPECIFICATIONS[key].description
+                        }
+                        onClick={() => {
+                          setEdited(true);
+                          setBuilderState((state) => ({
+                            ...state,
+                            actionMode:
+                              SEARCH_MODE_SPECIFICATIONS[key].actionMode,
+                          }));
+                        }}
+                      />
+                    ))}
+                  </DropdownMenu.Items>
+                </DropdownMenu>
+              </div>
+            )}
           </>
         )}
 
         <ActionModeSection show={builderState.actionMode === "GENERIC"}>
-          <div className="text-sm text-element-700">
+          <div className="pb-16 text-sm text-element-700">
+            {/**
             No action is set. The assistant will use the instructions only to
             answer.
+            */}
           </div>
         </ActionModeSection>
 
         <ActionModeSection
-          show={builderState.actionMode === "RETRIEVAL_EXHAUSTIVE"}
+          show={
+            builderState.actionMode === "RETRIEVAL_SEARCH" && !noDataSources
+          }
         >
+          {/**
+          <div>
+            The assistant will perform a search on the selected data sources,
+            and run the instructions on the results.{" "}
+            <span className="font-semibold">
+              It’s the best approach with large quantities of data.
+            </span>
+          </div>
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <p>
+                <strong>Select your sources with care</strong> The quality of
+                the answers to specific questions will depend on the quality of
+                the data.
+              </p>
+              <p className="mt-1">
+                <strong>
+                  You can narrow your search on most recent documents
+                </strong>{" "}
+                by adding instructions in your prompt such as 'Only search in
+                documents from the last 3 months', 'Only look at data from the
+                last 2 days', etc.
+              </p>
+            </div>
+            <div>
+              <p>
+                <strong>Note:</strong> The available data sources are managed by
+                administrators.
+              </p>
+            </div>
+          </div>
+          */}
+
+          <DataSourceSelectionSection
+            dataSourceConfigurations={builderState.dataSourceConfigurations}
+            openDataSourceModal={() => {
+              setShowDataSourcesModal(true);
+            }}
+            canAddDataSource={configurableDataSources.length > 0}
+            onManageDataSource={(name) => {
+              setDataSourceToManage(
+                builderState.dataSourceConfigurations[name]
+              );
+              setShowDataSourcesModal(true);
+            }}
+            onDelete={deleteDataSource}
+          />
+        </ActionModeSection>
+
+        <ActionModeSection
+          show={
+            builderState.actionMode === "RETRIEVAL_EXHAUSTIVE" && !noDataSources
+          }
+        >
+          {/**
           <div>
             The assistant will include as many documents as possible from the
             data sources, using reverse chronological order.
@@ -470,6 +528,7 @@ export default function ActionScreen({
               administrators.
             </div>
           </div>
+          */}
           <DataSourceSelectionSection
             dataSourceConfigurations={builderState.dataSourceConfigurations}
             openDataSourceModal={() => {
@@ -547,52 +606,31 @@ export default function ActionScreen({
         </ActionModeSection>
 
         <ActionModeSection
-          show={builderState.actionMode === "RETRIEVAL_SEARCH"}
+          show={builderState.actionMode === "TABLES_QUERY" && !noDataSources}
         >
-          <div>
-            The assistant will perform a search on the selected data sources,
-            and run the instructions on the results.{" "}
-            <span className="font-semibold">
-              It’s the best approach with large quantities of data.
-            </span>
-          </div>
-          <div className="grid grid-cols-2 gap-4">
-            <div>
-              <p>
-                <strong>Select your sources with care</strong> The quality of
-                the answers to specific questions will depend on the quality of
-                the data.
-              </p>
-              <p className="mt-1">
-                <strong>
-                  You can narrow your search on most recent documents
-                </strong>{" "}
-                by adding instructions in your prompt such as 'Only search in
-                documents from the last 3 months', 'Only look at data from the
-                last 2 days', etc.
-              </p>
-            </div>
-            <div>
-              <p>
-                <strong>Note:</strong> The available data sources are managed by
-                administrators.
-              </p>
-            </div>
+          <div className="text-sm text-element-700">
+            The assistant will generate a SQL query from your request, execute
+            it on the tables selected and use the results to generate an answer.
           </div>
 
-          <DataSourceSelectionSection
-            dataSourceConfigurations={builderState.dataSourceConfigurations}
-            openDataSourceModal={() => {
-              setShowDataSourcesModal(true);
+          <TablesSelectionSection
+            show={builderState.actionMode === "TABLES_QUERY"}
+            tablesQueryConfiguration={builderState.tablesQueryConfiguration}
+            openTableModal={() => {
+              setShowTableModal(true);
             }}
-            canAddDataSource={configurableDataSources.length > 0}
-            onManageDataSource={(name) => {
-              setDataSourceToManage(
-                builderState.dataSourceConfigurations[name]
-              );
-              setShowDataSourcesModal(true);
+            onDelete={(key) => {
+              setEdited(true);
+              setBuilderState((state) => {
+                const tablesQueryConfiguration = state.tablesQueryConfiguration;
+                delete tablesQueryConfiguration[key];
+                return {
+                  ...state,
+                  tablesQueryConfiguration,
+                };
+              });
             }}
-            onDelete={deleteDataSource}
+            canSelectTable={dataSources.length !== 0}
           />
         </ActionModeSection>
 
@@ -613,32 +651,6 @@ export default function ActionScreen({
             }}
             onDelete={deleteDustApp}
             canSelectDustApp={dustApps.length !== 0}
-          />
-        </ActionModeSection>
-
-        <ActionModeSection show={builderState.actionMode === "TABLES_QUERY"}>
-          <div className="text-sm text-element-700">
-            The assistant will generate a SQL query from your request, execute
-            it on the tables selected and use the results to generate an answer.
-          </div>
-          <TablesSelectionSection
-            show={builderState.actionMode === "TABLES_QUERY"}
-            tablesQueryConfiguration={builderState.tablesQueryConfiguration}
-            openTableModal={() => {
-              setShowTableModal(true);
-            }}
-            onDelete={(key) => {
-              setEdited(true);
-              setBuilderState((state) => {
-                const tablesQueryConfiguration = state.tablesQueryConfiguration;
-                delete tablesQueryConfiguration[key];
-                return {
-                  ...state,
-                  tablesQueryConfiguration,
-                };
-              });
-            }}
-            canSelectTable={dataSources.length !== 0}
           />
         </ActionModeSection>
       </div>

--- a/front/components/assistant_builder/ActionScreen.tsx
+++ b/front/components/assistant_builder/ActionScreen.tsx
@@ -198,6 +198,7 @@ export default function ActionScreen({
   const noDataSources =
     configurableDataSources.length === 0 &&
     Object.keys(builderState.dataSourceConfigurations).length === 0;
+  const noDustApp = dustApps.length === 0;
 
   return (
     <>
@@ -576,23 +577,69 @@ export default function ActionScreen({
         </ActionModeSection>
 
         <ActionModeSection show={builderState.actionMode === "DUST_APP_RUN"}>
-          <div className="text-sm text-element-700">
-            The assistant will execute a Dust Application of your design before
-            answering. The output of the app (last block) is injected in context
-            for the model to generate an answer. The inputs of the app will be
-            automatically generated from the context of the conversation based
-            on the descriptions you provided in the application's input block
-            dataset schema.
-          </div>
-          <DustAppSelectionSection
-            show={builderState.actionMode === "DUST_APP_RUN"}
-            dustAppConfiguration={builderState.dustAppConfiguration}
-            openDustAppModal={() => {
-              setShowDustAppsModal(true);
-            }}
-            onDelete={deleteDustApp}
-            canSelectDustApp={dustApps.length !== 0}
-          />
+          {noDustApp ? (
+            <ContentMessage
+              title="You don't have any Dust Application available"
+              variant="warning"
+            >
+              <div className="flex flex-col gap-y-3">
+                {(() => {
+                  switch (owner.role) {
+                    case "admin":
+                    case "builder":
+                      return (
+                        <div>
+                          <strong>
+                            Visit the "Developer Tools" section in the Build
+                            panel to build your first Dust Application.
+                          </strong>
+                        </div>
+                      );
+                    case "user":
+                      return (
+                        <div>
+                          <strong>
+                            Only Admins and Builders can build Dust
+                            Applications.
+                          </strong>
+                        </div>
+                      );
+                    case "none":
+                      return <></>;
+                    default:
+                      assertNever(owner.role);
+                  }
+                })()}
+              </div>
+            </ContentMessage>
+          ) : (
+            <>
+              <div className="text-sm text-element-700">
+                The assistant will execute a{" "}
+                <a
+                  className="font-bold"
+                  href="https://docs.dust.tt"
+                  target="_blank"
+                >
+                  Dust Application
+                </a>{" "}
+                of your design before replying. The output of the app (last
+                block) is injected in context for the model to generate an
+                answer. The inputs of the app will be automatically generated
+                from the context of the conversation based on the descriptions
+                you provided in the application's input block dataset schema.
+              </div>
+              <DustAppSelectionSection
+                show={builderState.actionMode === "DUST_APP_RUN"}
+                dustAppConfiguration={builderState.dustAppConfiguration}
+                openDustAppModal={() => {
+                  setShowDustAppsModal(true);
+                }}
+                onDelete={deleteDustApp}
+                canSelectDustApp={dustApps.length !== 0}
+              />
+            </>
+          )}
         </ActionModeSection>
       </div>
     </>

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -552,36 +552,15 @@ export default function AssistantBuilder({
                 );
               case "actions":
                 return (
-                  <>
-                    <ActionScreen
-                      owner={owner}
-                      builderState={builderState}
-                      setBuilderState={setBuilderState}
-                      setEdited={setEdited}
-                      dataSources={dataSources}
-                      dustApps={dustApps}
-                      timeFrameError={timeFrameError}
-                    />
-                    <div className="flex flex-row items-start pt-8">
-                      <div className="flex flex-col gap-4">
-                        {slackDataSource &&
-                          isBuilder(owner) &&
-                          builderState.scope !== "private" &&
-                          initialBuilderState?.scope !== "private" && (
-                            <SlackIntegration
-                              slackDataSource={slackDataSource}
-                              owner={owner}
-                              onSave={(channels) => {
-                                setEdited(true);
-                                setSelectedSlackChannels(channels);
-                              }}
-                              existingSelection={selectedSlackChannels}
-                              assistantHandle={builderState.handle ?? undefined}
-                            />
-                          )}
-                      </div>
-                    </div>
-                  </>
+                  <ActionScreen
+                    owner={owner}
+                    builderState={builderState}
+                    setBuilderState={setBuilderState}
+                    setEdited={setEdited}
+                    dataSources={dataSources}
+                    dustApps={dustApps}
+                    timeFrameError={timeFrameError}
+                  />
                 );
               case "naming":
                 return (

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -1035,6 +1035,7 @@ function TryModalInBuilder({
   );
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function SlackIntegration({
   slackDataSource,
   owner,

--- a/front/components/assistant_builder/DataSourceSelectionSection.tsx
+++ b/front/components/assistant_builder/DataSourceSelectionSection.tsx
@@ -8,10 +8,9 @@ import {
 
 import { CONNECTOR_PROVIDER_TO_RESOURCE_NAME } from "@app/components/assistant_builder/shared";
 import type { AssistantBuilderDataSourceConfiguration } from "@app/components/assistant_builder/types";
+import { EmptyCallToAction } from "@app/components/EmptyCallToAction";
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 import { getDisplayNameForDataSource } from "@app/lib/data_sources";
-
-import { EmptyCallToAction } from "../EmptyCallToAction";
 
 export default function DataSourceSelectionSection({
   dataSourceConfigurations,

--- a/front/components/assistant_builder/DataSourceSelectionSection.tsx
+++ b/front/components/assistant_builder/DataSourceSelectionSection.tsx
@@ -3,15 +3,15 @@ import {
   CloudArrowDownIcon,
   Cog6ToothIcon,
   ContextItem,
-  PlusIcon,
   TrashIcon,
 } from "@dust-tt/sparkle";
 
 import { CONNECTOR_PROVIDER_TO_RESOURCE_NAME } from "@app/components/assistant_builder/shared";
 import type { AssistantBuilderDataSourceConfiguration } from "@app/components/assistant_builder/types";
-import { EmptyCallToAction } from "@app/components/EmptyCallToAction";
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 import { getDisplayNameForDataSource } from "@app/lib/data_sources";
+
+import { EmptyCallToAction } from "../EmptyCallToAction";
 
 export default function DataSourceSelectionSection({
   dataSourceConfigurations,
@@ -30,11 +30,8 @@ export default function DataSourceSelectionSection({
   onDelete?: (name: string) => void;
 }) {
   return (
-    <div className="overflow-hidden">
+    <div className="overflow-hidden pt-6">
       <div className="flex flex-row items-start">
-        <div className="pb-3 text-sm font-bold text-element-900">
-          Select Data Sources:
-        </div>
         <div className="flex-grow" />
         {Object.keys(dataSourceConfigurations).length > 0 && (
           <Button
@@ -42,7 +39,6 @@ export default function DataSourceSelectionSection({
             label="Add data sources"
             variant="primary"
             size="sm"
-            icon={PlusIcon}
             onClick={openDataSourceModal}
             disabled={!canAddDataSource}
             hasMagnifying={false}
@@ -51,9 +47,10 @@ export default function DataSourceSelectionSection({
       </div>
       {!Object.keys(dataSourceConfigurations).length ? (
         <EmptyCallToAction
-          label="Add Data Sources"
-          disabled={!canAddDataSource}
+          label="Select Data Sources"
           onClick={openDataSourceModal}
+          disabled={!canAddDataSource}
+          icon={null}
         />
       ) : (
         <ContextItem.List className="mt-6 border-b border-t border-structure-200">

--- a/front/components/assistant_builder/DataSourceSelectionSection.tsx
+++ b/front/components/assistant_builder/DataSourceSelectionSection.tsx
@@ -49,7 +49,6 @@ export default function DataSourceSelectionSection({
           label="Select Data Sources"
           onClick={openDataSourceModal}
           disabled={!canAddDataSource}
-          icon={null}
         />
       ) : (
         <ContextItem.List className="mt-6 border-b border-t border-structure-200">

--- a/front/components/assistant_builder/DustAppSelectionSection.tsx
+++ b/front/components/assistant_builder/DustAppSelectionSection.tsx
@@ -46,7 +46,6 @@ export default function DustAppSelectionSection({
             label="Select Dust App"
             disabled={!canSelectDustApp}
             onClick={openDustAppModal}
-            icon={null}
           />
         ) : (
           <ContextItem.List className="mt-6 border-b border-t border-structure-200">

--- a/front/components/assistant_builder/DustAppSelectionSection.tsx
+++ b/front/components/assistant_builder/DustAppSelectionSection.tsx
@@ -41,16 +41,12 @@ export default function DustAppSelectionSection({
       }}
     >
       <div>
-        <div className="flex flex-row items-start">
-          <div className="pb-3 text-sm font-bold text-element-900">
-            Select a Dust App:
-          </div>
-        </div>
         {!dustAppConfiguration ? (
           <EmptyCallToAction
             label="Select Dust App"
             disabled={!canSelectDustApp}
             onClick={openDustAppModal}
+            icon={null}
           />
         ) : (
           <ContextItem.List className="mt-6 border-b border-t border-structure-200">

--- a/front/components/assistant_builder/TablesSelectionSection.tsx
+++ b/front/components/assistant_builder/TablesSelectionSection.tsx
@@ -63,7 +63,6 @@ export default function TablesSelectionSection({
             label="Select Tables"
             disabled={!canSelectTable}
             onClick={openTableModal}
-            icon={null}
           />
         ) : (
           <ContextItem.List className="mt-6 border-b border-t border-structure-200">

--- a/front/components/assistant_builder/TablesSelectionSection.tsx
+++ b/front/components/assistant_builder/TablesSelectionSection.tsx
@@ -44,9 +44,6 @@ export default function TablesSelectionSection({
     >
       <div>
         <div className="flex flex-row items-start">
-          <div className="pb-3 text-sm font-bold text-element-900">
-            Select Tables:
-          </div>
           <div className="flex-grow" />
           {Object.keys(tablesQueryConfiguration).length > 0 && (
             <Button
@@ -63,9 +60,10 @@ export default function TablesSelectionSection({
         </div>
         {!Object.keys(tablesQueryConfiguration).length ? (
           <EmptyCallToAction
-            label="Add Tables"
+            label="Select Tables"
             disabled={!canSelectTable}
             onClick={openTableModal}
+            icon={null}
           />
         ) : (
           <ContextItem.List className="mt-6 border-b border-t border-structure-200">

--- a/front/pages/w/[wId]/builder/assistants/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/index.tsx
@@ -251,6 +251,7 @@ export default function WorkspaceAssistants({
                   <EmptyCallToAction
                     href={`/w/${owner.sId}/builder/assistants/new?flow=workspace_assistants`}
                     label="Create an Assistant"
+                    icon={PlusIcon}
                   />
                 </div>
               )

--- a/front/pages/w/[wId]/builder/data-sources/public-urls.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/public-urls.tsx
@@ -174,6 +174,7 @@ export default function DataSourcesView({
           <EmptyCallToAction
             label="Create a new Public URL"
             onClick={handleCreateDataSource}
+            icon={PlusIcon}
           />
         )}
 

--- a/front/pages/w/[wId]/builder/data-sources/static.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/static.tsx
@@ -146,6 +146,7 @@ export default function DataSourcesView({
         ) : (
           <EmptyCallToAction
             label="Create a new Folder"
+            icon={PlusIcon}
             onClick={async () => {
               await handleCreateDataSource();
             }}


### PR DESCRIPTION
## Description

Closes: https://github.com/dust-tt/dust/issues/3783

- Finish applying the design changes
- Updates the ContentMessage when no data source are visible + hides components as needed
- Remove most description text (TBD if we want to re-introduce it with a side modal)
- Add ContentMessage for Dust Apps (when there is none)

![Screenshot from 2024-02-26 11-52-28](https://github.com/dust-tt/dust/assets/15067/e2b42221-dec0-428b-a5f2-a81aca8c8eaf)
![Screenshot from 2024-02-26 11-52-33](https://github.com/dust-tt/dust/assets/15067/bad4f732-51ec-4531-90d3-ddc5a66a4618)
![Screenshot from 2024-02-26 11-52-48](https://github.com/dust-tt/dust/assets/15067/4615ec63-3394-45ab-bd6a-9abc1819ff4a)
![Screenshot from 2024-02-26 11-52-54](https://github.com/dust-tt/dust/assets/15067/ef650f24-eceb-4a7f-8e5c-7c279dc7ab80)
![Screenshot from 2024-02-26 11-52-23](https://github.com/dust-tt/dust/assets/15067/c84a18db-0700-4c79-8afe-c926c2f078ac)


## Risk

N/A

## Deploy Plan

- deploy `front`