### PR TITLE
Flav/start notion connector worker on its own

### DIFF
--- a/connectors/package-lock.json
+++ b/connectors/package-lock.json
@@ -52,7 +52,8 @@
         "tar": "^6.2.0",
         "tsconfig-paths-webpack-plugin": "^4.1.0",
         "turndown": "^7.1.2",
-        "uuid": "^9.0.0"
+        "uuid": "^9.0.0",
+        "yargs": "^17.7.2"
       },
       "devDependencies": {
         "@types/eslint": "^8.21.3",
@@ -61,6 +62,7 @@
         "@types/node": "^18.15.5",
         "@types/tar": "^6.1.10",
         "@types/turndown": "^5.0.4",
+        "@types/yargs": "^17.0.32",
         "@typescript-eslint/eslint-plugin": "^5.56.0",
         "@typescript-eslint/parser": "^5.56.0",
         "eslint": "^8.36.0",
@@ -287,44 +289,6 @@
       },
       "engines": {
         "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@crawlee/cli/node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@crawlee/cli/node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@crawlee/cli/node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/@crawlee/core": {
@@ -578,35 +542,6 @@
         "node": ">= 12"
       }
     },
-    "node_modules/@crawlee/templates/node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@crawlee/templates/node_modules/cliui/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
     "node_modules/@crawlee/templates/node_modules/escape-string-regexp": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
@@ -696,31 +631,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@crawlee/templates/node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@crawlee/templates/node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/@crawlee/types": {
@@ -1311,10 +1221,45 @@
         "node": ">=6"
       }
     },
+    "node_modules/@grpc/proto-loader/node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
     "node_modules/@grpc/proto-loader/node_modules/long": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+    },
+    "node_modules/@grpc/proto-loader/node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.8",
@@ -2660,6 +2605,21 @@
       "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.7.15.tgz",
       "integrity": "sha512-yeinDVQunb03AEP8luErFcyf/7Lf7AzKCD0NXfgVoGCCQDNpZET8Jgq74oBgqKld3hafLbfzt/3inUdQvaFeXQ=="
     },
+    "node_modules/@types/yargs": {
+      "version": "17.0.32",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
+      "integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+      "dev": true
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.59.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.59.0.tgz",
@@ -3859,13 +3819,16 @@
       }
     },
     "node_modules/cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "dependencies": {
         "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
+        "strip-ansi": "^6.0.1",
         "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/clone": {
@@ -11183,28 +11146,28 @@
       }
     },
     "node_modules/yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "dependencies": {
-        "cliui": "^7.0.2",
+        "cliui": "^8.0.1",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
+        "string-width": "^4.2.3",
         "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
+        "yargs-parser": "^21.1.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/yocto-queue": {

--- a/connectors/package.json
+++ b/connectors/package.json
@@ -57,7 +57,8 @@
     "tar": "^6.2.0",
     "tsconfig-paths-webpack-plugin": "^4.1.0",
     "turndown": "^7.1.2",
-    "uuid": "^9.0.0"
+    "uuid": "^9.0.0",
+    "yargs": "^17.7.2"
   },
   "devDependencies": {
     "@types/eslint": "^8.21.3",
@@ -66,6 +67,7 @@
     "@types/node": "^18.15.5",
     "@types/tar": "^6.1.10",
     "@types/turndown": "^5.0.4",
+    "@types/yargs": "^17.0.32",
     "@typescript-eslint/eslint-plugin": "^5.56.0",
     "@typescript-eslint/parser": "^5.56.0",
     "eslint": "^8.36.0",

--- a/connectors/src/start_worker.ts
+++ b/connectors/src/start_worker.ts
@@ -16,27 +16,19 @@ import logger from "./logger/logger";
 
 setupGlobalErrorHandler(logger);
 
-const ALL_WORKERS: ConnectorProvider[] = [
-  "confluence",
-  "slack",
-  "notion",
-  "github",
-  "google_drive",
-  "intercom",
-  "webcrawler",
-];
+const workerFunctions: Record<ConnectorProvider, () => Promise<void>> = {
+  confluence: runConfluenceWorker,
+  github: runGithubWorker,
+  google_drive: runGoogleWorker,
+  intercom: runIntercomWorker,
+  notion: runNotionWorker,
+  slack: runSlackWorker,
+  webcrawler: runWebCrawlerWorker,
+};
+
+const ALL_WORKERS = Object.keys(workerFunctions) as ConnectorProvider[];
 
 async function runWorkers(workers: ConnectorProvider[]) {
-  const workerFunctions: Record<ConnectorProvider, () => Promise<void>> = {
-    confluence: runConfluenceWorker,
-    github: runGithubWorker,
-    google_drive: runGoogleWorker,
-    intercom: runIntercomWorker,
-    notion: runNotionWorker,
-    slack: runSlackWorker,
-    webcrawler: runWebCrawlerWorker,
-  };
-
   for (const worker of workers) {
     workerFunctions[worker]().catch((err) =>
       logger.error(errorFromAny(err), `Error running ${worker} worker.`)

--- a/connectors/src/start_worker.ts
+++ b/connectors/src/start_worker.ts
@@ -1,4 +1,8 @@
+import type { ConnectorProvider } from "@dust-tt/types";
 import { setupGlobalErrorHandler } from "@dust-tt/types";
+import type { Options } from "yargs";
+import yargs from "yargs";
+import { hideBin } from "yargs/helpers";
 
 import { runConfluenceWorker } from "@connectors/connectors/confluence/temporal/worker";
 import { runWebCrawlerWorker } from "@connectors/connectors/webcrawler/temporal/worker";
@@ -13,24 +17,48 @@ import logger from "./logger/logger";
 
 setupGlobalErrorHandler(logger);
 
-runConfluenceWorker().catch((err) =>
-  logger.error(errorFromAny(err), "Error running confluence worker")
-);
-runSlackWorker().catch((err) =>
-  logger.error(errorFromAny(err), "Error running slack worker")
-);
-runNotionWorker().catch((err) =>
-  logger.error(errorFromAny(err), "Error running notion worker")
-);
-runGithubWorker().catch((err) =>
-  logger.error(errorFromAny(err), "Error running github worker")
-);
-runGoogleWorker().catch((err) =>
-  logger.error(errorFromAny(err), "Error running google worker")
-);
-runIntercomWorker().catch((err) =>
-  logger.error(errorFromAny(err), "Error running intercom worker")
-);
-runWebCrawlerWorker().catch((err) =>
-  logger.error(errorFromAny(err), "Error running webcrawler worker")
-);
+const ALL_WORKERS: ConnectorProvider[] = [
+  "confluence",
+  "slack",
+  "notion",
+  "github",
+  "google_drive",
+  "intercom",
+  "webcrawler",
+];
+
+async function runWorkers(workers: ConnectorProvider[]) {
+  const workerFunctions: Record<ConnectorProvider, () => Promise<void>> = {
+    confluence: runConfluenceWorker,
+    github: runGithubWorker,
+    google_drive: runGoogleWorker,
+    intercom: runIntercomWorker,
+    notion: runNotionWorker,
+    slack: runSlackWorker,
+    webcrawler: runWebCrawlerWorker,
+  };
+
+  for (const worker of workers) {
+    workerFunctions[worker]().catch((err) =>
+      logger.error(errorFromAny(err), `Error running ${worker} worker.`)
+    );
+  }
+}
+
+yargs(hideBin(process.argv))
+  .option("workers", {
+    alias: "w",
+    type: "array",
+    choices: ALL_WORKERS,
+    default: ALL_WORKERS,
+    demandOption: true,
+    description: "Choose one or multiple workers to run.",
+  })
+  .help()
+  .alias("help", "h")
+  .parseAsync()
+  .then(async (args) => runWorkers(args.workers as ConnectorProvider[]))
+  .catch((err) => {
+    logger.error(errorFromAny(err), "Error running workers");
+    process.exit(1);
+  });

--- a/connectors/src/start_worker.ts
+++ b/connectors/src/start_worker.ts
@@ -1,6 +1,5 @@
 import type { ConnectorProvider } from "@dust-tt/types";
 import { setupGlobalErrorHandler } from "@dust-tt/types";
-import type { Options } from "yargs";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 

--- a/k8s/apply_infra.sh
+++ b/k8s/apply_infra.sh
@@ -52,6 +52,7 @@ kubectl apply -f "$(dirname "$0")/configmaps/front-worker-configmap.yaml"
 kubectl apply -f "$(dirname "$0")/configmaps/front-edge-configmap.yaml"
 kubectl apply -f "$(dirname "$0")/configmaps/connectors-configmap.yaml"
 kubectl apply -f "$(dirname "$0")/configmaps/connectors-worker-configmap.yaml"
+kubectl apply -f "$(dirname "$0")/configmaps/connectors-worker-specific-configmap.yaml"
 kubectl apply -f "$(dirname "$0")/configmaps/connectors-edge-configmap.yaml"
 kubectl apply -f "$(dirname "$0")/configmaps/docs-configmap.yaml"
 kubectl apply -f "$(dirname "$0")/configmaps/alerting-temporal-configmap.yaml"
@@ -94,6 +95,7 @@ apply_deployment front-worker-deployment
 apply_deployment front-edge-deployment
 apply_deployment connectors-deployment
 apply_deployment connectors-worker-deployment
+apply_deployment connectors-worker-notion-deployment
 apply_deployment connectors-edge-deployment
 apply_deployment docs-deployment
 apply_deployment metabase-deployment

--- a/k8s/configmaps/connectors-worker-specific-configmap.yaml
+++ b/k8s/configmaps/connectors-worker-specific-configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: connectors-worker-specific-config
+data:
+  DD_ENV: "prod"
+  DD_SERVICE: "connectors-worker"
+  NODE_OPTIONS: "-r dd-trace/init --max-old-space-size=3276"
+  DD_LOGS_INJECTION: "true"
+  DD_RUNTIME_METRICS_ENABLED: "true"
+  NODE_ENV: "production"

--- a/k8s/deployments/connectors-worker-notion-deployment.yaml
+++ b/k8s/deployments/connectors-worker-notion-deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: connectors-worker-notion-deployment
 spec:
-  replicas: 4
+  replicas: 2
   selector:
     matchLabels:
       app: connectors-worker

--- a/k8s/deployments/connectors-worker-notion-deployment.yaml
+++ b/k8s/deployments/connectors-worker-notion-deployment.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: connectors-worker-notion-deployment
+spec:
+  replicas: 4
+  selector:
+    matchLabels:
+      app: connectors-worker
+      worker: notion
+  template:
+    metadata:
+      labels:
+        app: connectors-worker
+        name: connectors-worker-pod
+        worker: notion
+        admission.datadoghq.com/enabled: "true"
+      annotations:
+        ad.datadoghq.com/web.logs: '[{"source": "connectors-worker","service": "connectors-worker","tags": ["env:prod"]}]'
+    spec:
+      containers:
+        - name: web
+          image: gcr.io/or1g1n-186209/connectors-image:latest
+          args: ["--workers", "$WORKERS"]
+          imagePullPolicy: Always
+          envFrom:
+            - configMapRef:
+                name: connectors-worker-specific-config
+            - secretRef:
+                name: connectors-secrets
+          env:
+            - name: DD_AGENT_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: WORKERS
+              value: notion
+
+          volumeMounts:
+            - name: cert-volume
+              mountPath: /etc/certs
+            - name: private-key-volume
+              mountPath: /etc/private-keys
+
+          resources:
+            requests:
+              cpu: 2000m
+              memory: 4Gi
+              ephemeral-storage: 4Gi
+
+            limits:
+              cpu: 2000m
+              memory: 4Gi
+              ephemeral-storage: 4Gi
+
+      volumes:
+        - name: cert-volume
+          secret:
+            secretName: temporal-cert
+
+        - name: private-key-volume
+          secret:
+            secretName: github-app-private-key

--- a/k8s/deployments/connectors-worker-notion-deployment.yaml
+++ b/k8s/deployments/connectors-worker-notion-deployment.yaml
@@ -34,7 +34,7 @@ spec:
                 fieldRef:
                   fieldPath: status.hostIP
             - name: WORKERS
-              value: notion
+              value: "notion"
 
           volumeMounts:
             - name: cert-volume


### PR DESCRIPTION
## Description

Over the week end we observed some CPU issue around our connector workers. We are suspicious about Notion and Github. The goal of this PR is to start by running Notion workers on their own pods.

Since we don't have any sandbox environment to test our k8s deployments. This PR does not update the existing connectors-worker deployment (they will still run all workflows including Notion). We add a new specific deployment for Notion with less resources (both CPUs and Memory).
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Run apply-infra, then update deploy connectors GA to deploy notion specific deployment.

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
