### PR TITLE
Ignore notion formula with expression

### DIFF
--- a/connectors/src/connectors/notion/lib/notion_api.ts
+++ b/connectors/src/connectors/notion/lib/notion_api.ts
@@ -723,7 +723,7 @@ export function parsePropertyText(
         ? property.people.map((p) => ("name" in p ? p.name : p.id)).join(", ")
         : null;
     case "formula":
-      return (() => {
+      if (property.formula.type) {
         switch (property.formula.type) {
           case "string":
             return property.formula.string;
@@ -736,7 +736,12 @@ export function parsePropertyText(
           default:
             assertNever(property.formula);
         }
-      })();
+      } else {
+        // If the formula is an expression type, return null.
+        return null;
+      }
+      break;
+
     case "relation":
     case "rollup":
     // @ts-expect-error missing from Notion package

--- a/connectors/src/connectors/notion/lib/notion_api.ts
+++ b/connectors/src/connectors/notion/lib/notion_api.ts
@@ -722,7 +722,7 @@ export function parsePropertyText(
       return property.people.length > 0
         ? property.people.map((p) => ("name" in p ? p.name : p.id)).join(", ")
         : null;
-    case "formula":
+    case "formula": {
       if (property.formula.type) {
         switch (property.formula.type) {
           case "string":
@@ -741,6 +741,7 @@ export function parsePropertyText(
         return null;
       }
       break;
+    }
 
     case "relation":
     case "rollup":


### PR DESCRIPTION
## Description

We noticed that Notion uses extensively advanced formula (see [doc](https://www.notion.so/help/formulas)). We got the following error in production:
```
{"expression":"dateAdd({{notion:block_property:%3BXSp:00000000-0000-0000-0000-000000000000:53ecd16d-47a6-4451-ade3-7185e686110c}}, ceil(dateBetween(now(), {{notion:block_property:%3BXSp:00000000-0000-0000-0000-000000000000:53ecd16d-47a6-4451-ade3-7185e686110c}}, \"years\")), \"years\")"} is not of type never. This should never happen.
```

This PR ignore the unsupported formula types not defined in TS types. 
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
