### PR TITLE
Wait for notion workers rollout + don't start on legacy workers

### DIFF
--- a/.github/workflows/deploy-connectors.yml
+++ b/.github/workflows/deploy-connectors.yml
@@ -57,3 +57,5 @@ jobs:
           kubectl rollout status deployment/connectors-deployment --timeout=10m
           echo "Waiting for rollout to complete (worker)"
           kubectl rollout status deployment/connectors-worker-deployment --timeout=10m
+          echo "Waiting for rollout to complete (notion worker)"
+          kubectl rollout status deployment/connectors-worker-notion-deployment --timeout=10m

--- a/k8s/deployments/connectors-worker-deployment.yaml
+++ b/k8s/deployments/connectors-worker-deployment.yaml
@@ -20,6 +20,12 @@ spec:
         - name: web
           image: gcr.io/or1g1n-186209/connectors-image:latest
           command: ["npm", "run", "start:worker"]
+          args:
+            [
+              "--",
+              "--workers",
+              "confluence github google_drive intercom slack webcrawler",
+            ]
           imagePullPolicy: Always
           envFrom:
             - configMapRef:


### PR DESCRIPTION
## Description

We successfully move notion connectors to their own workers. This PR:
- waits for the roll out of those
- update the regular connector workers deployment to start everything except notion

Example of running notion workers [here](https://cloud.temporal.io/namespaces/dust-prod.gmnlm/workflows/workflow-notion-garbage-collector-0ec9852c2f-managed-notion-result-page-11-databases-0-gc/7e2b7d6f-346f-43fd-8e46-3de06319857d/workers).
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Apply infra and then deploy connectors.

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
