### PR TITLE
Slugify structured data table name in connector workers

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
+++ b/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
@@ -9,7 +9,10 @@ import { concurrentExecutor } from "@connectors/lib/async_utils";
 import { deleteTable, upsertTableFromCsv } from "@connectors/lib/data_sources";
 import type { GoogleDriveFiles } from "@connectors/lib/models/google_drive";
 import { GoogleDriveSheet } from "@connectors/lib/models/google_drive";
-import { makeStructuredDataTableName } from "@connectors/lib/structured_data/helpers";
+import {
+  getSanitizedHeaders,
+  makeStructuredDataTableName,
+} from "@connectors/lib/structured_data/helpers";
 import { connectorHasAutoPreIngestAllDatabasesFF } from "@connectors/lib/workspace";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
@@ -102,14 +105,16 @@ function getValidRows(allRows: string[][], loggerArgs: object) {
 
   // We assume that the first row is always the headers.
   // Headers are used to assert the number of cells per row.
-  const [headers] = filteredRows;
-  if (!headers || headers.length === 0) {
+  const [rawHeaders] = filteredRows;
+  if (!rawHeaders || rawHeaders.length === 0) {
     logger.info(
       loggerArgs,
       "[Spreadsheet] Skipping due to empty initial rows."
     );
     return [];
   }
+
+  const headers = getSanitizedHeaders(rawHeaders);
 
   const validRows: string[][] = filteredRows.map((row, index) => {
     // Return raw headers.

--- a/connectors/src/connectors/notion/lib/notion_api.ts
+++ b/connectors/src/connectors/notion/lib/notion_api.ts
@@ -20,6 +20,7 @@ import type {
 import { stringify } from "csv-stringify";
 import type { Logger } from "pino";
 
+import { saveIntercomConnectorStartSync } from "@connectors/connectors/intercom/temporal/activities";
 import type {
   PageObjectProperties,
   ParsedNotionBlock,
@@ -29,6 +30,7 @@ import type {
 } from "@connectors/connectors/notion/lib/types";
 import { cacheGet, cacheSet } from "@connectors/lib/cache";
 import { ExternalOauthTokenError } from "@connectors/lib/error";
+import { getSanitizedHeaders } from "@connectors/lib/structured_data/helpers";
 import mainLogger from "@connectors/logger/logger";
 
 const logger = mainLogger.child({ provider: "notion" });
@@ -873,10 +875,19 @@ export async function renderDatabaseFromPages({
     )
   );
 
+  const sanitizedHeaders = getSanitizedHeaders(header);
+
   let csv = await new Promise<string>((resolve, reject) => {
     stringify(
       content,
-      { header: true, delimiter: cellSeparator },
+      {
+        header: true,
+        delimiter: cellSeparator,
+        columns: header.map((h, idx) => ({
+          key: h,
+          header: sanitizedHeaders[idx],
+        })),
+      },
       (err, output) => {
         if (err) {
           reject(err);

--- a/connectors/src/connectors/notion/lib/notion_api.ts
+++ b/connectors/src/connectors/notion/lib/notion_api.ts
@@ -20,7 +20,6 @@ import type {
 import { stringify } from "csv-stringify";
 import type { Logger } from "pino";
 
-import { saveIntercomConnectorStartSync } from "@connectors/connectors/intercom/temporal/activities";
 import type {
   PageObjectProperties,
   ParsedNotionBlock,

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -66,6 +66,7 @@ import {
 } from "@connectors/lib/models/notion";
 import { getAccessTokenFromNango } from "@connectors/lib/nango_helpers";
 import { redisClient } from "@connectors/lib/redis";
+import { makeStructuredDataTableName } from "@connectors/lib/structured_data/helpers";
 import { syncStarted, syncSucceeded } from "@connectors/lib/sync_status";
 import { connectorHasAutoPreIngestAllDatabasesFF } from "@connectors/lib/workspace";
 import mainLogger from "@connectors/logger/logger";
@@ -2391,8 +2392,10 @@ function getTableInfoFromDatabase(database: NotionDatabase): {
   tableDescription: string;
 } {
   const tableId = `notion-${database.notionDatabaseId}`;
-  const tableName =
+  const name =
     database.title ?? `Untitled Database (${database.notionDatabaseId})`;
+  const tableName = makeStructuredDataTableName(name, tableId);
+
   const tableDescription = `Structured data from Notion Database ${tableName}`;
   return { tableId, tableName, tableDescription };
 }

--- a/connectors/src/lib/structured_data/helpers.ts
+++ b/connectors/src/lib/structured_data/helpers.ts
@@ -1,0 +1,5 @@
+import { slugify } from "@dust-tt/types";
+
+export function makeStructuredDataTableName(name: string, tableId: string) {
+  return slugify(`${name}_${tableId.slice(-4)}`);
+}

--- a/connectors/src/lib/structured_data/helpers.ts
+++ b/connectors/src/lib/structured_data/helpers.ts
@@ -3,3 +3,29 @@ import { slugify } from "@dust-tt/types";
 export function makeStructuredDataTableName(name: string, tableId: string) {
   return slugify(`${name}_${tableId.slice(-4)}`);
 }
+
+export function getSanitizedHeaders(rawHeaders: string[]) {
+  return rawHeaders.reduce<string[]>((acc, curr) => {
+    const slugifiedName = slugify(curr);
+
+    if (!acc.includes(slugifiedName)) {
+      acc.push(slugifiedName);
+    } else {
+      let conflictResolved = false;
+      for (let i = 2; i < 64; i++) {
+        if (!acc.includes(slugify(`${slugifiedName}_${i}`))) {
+          acc.push(slugify(`${slugifiedName}_${i}`));
+          conflictResolved = true;
+          break;
+        }
+      }
+
+      if (!conflictResolved) {
+        throw new Error(
+          `Failed to generate unique slugified name for header "${curr}" after multiple attempts.`
+        );
+      }
+    }
+    return acc;
+  }, []);
+}

--- a/front/lib/api/tables.ts
+++ b/front/lib/api/tables.ts
@@ -5,7 +5,7 @@ import type {
   Result,
   WorkspaceType,
 } from "@dust-tt/types";
-import { CoreAPI, Err, Ok, slugify } from "@dust-tt/types";
+import { CoreAPI, Err, isSlugified, Ok } from "@dust-tt/types";
 import { parse } from "csv-parse";
 
 import { AgentTablesQueryConfigurationTable } from "@app/lib/models/assistant/actions/tables_query";
@@ -307,9 +307,15 @@ async function rowsFromCsv(
         0,
         firstEmptyCellIndex === -1 ? undefined : firstEmptyCellIndex
       );
-      header = getSanitizedHeader(header);
       const headerSet = new Set<string>();
       for (const h of header) {
+        if (!isSlugified(h)) {
+          return new Err({
+            type: "invalid_header",
+            message: `Header '${h}' is not a valid slug. A header should only contain lowercase letters, numbers, or underscores.`,
+          });
+        }
+
         if (headerSet.has(h)) {
           return new Err({
             type: "duplicate_header",
@@ -438,30 +444,4 @@ async function rowsFromCsv(
   }
 
   return new Ok(rows);
-}
-
-function getSanitizedHeader(rawHeader: string[]) {
-  return rawHeader.reduce<string[]>((acc, curr) => {
-    const slugifiedName = slugify(curr);
-
-    if (!acc.includes(slugifiedName)) {
-      acc.push(slugifiedName);
-    } else {
-      let conflictResolved = false;
-      for (let i = 2; i < 64; i++) {
-        if (!acc.includes(slugify(`${slugifiedName}_${i}`))) {
-          acc.push(slugify(`${slugifiedName}_${i}`));
-          conflictResolved = true;
-          break;
-        }
-      }
-
-      if (!conflictResolved) {
-        throw new Error(
-          `Could not resolve conflict for header ${curr} in table creation.`
-        );
-      }
-    }
-    return acc;
-  }, []);
 }

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/csv.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/csv.ts
@@ -21,8 +21,15 @@ async function handler(
     return apiError(req, res, keyRes.error);
   }
 
+  const { auth } = await Authenticator.fromKey(
+    keyRes.value,
+    req.query.wId as string
+  );
+
+  const owner = auth.workspace();
+  const plan = auth.plan();
   const isSystemKey = keyRes.value.isSystem;
-  if (!isSystemKey) {
+  if (!owner || !plan || !auth.isBuilder() || !isSystemKey) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
@@ -31,11 +38,6 @@ async function handler(
       },
     });
   }
-
-  const { auth } = await Authenticator.fromKey(
-    keyRes.value,
-    req.query.wId as string
-  );
 
   switch (req.method) {
     case "POST":

--- a/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/csv.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[name]/tables/csv.ts
@@ -21,6 +21,17 @@ async function handler(
     return apiError(req, res, keyRes.error);
   }
 
+  const isSystemKey = keyRes.value.isSystem;
+  if (!isSystemKey) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "The workspace was not found.",
+      },
+    });
+  }
+
   const { auth } = await Authenticator.fromKey(
     keyRes.value,
     req.query.wId as string

--- a/front/pages/api/w/[wId]/data_sources/[name]/tables/csv.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/tables/csv.ts
@@ -1,4 +1,4 @@
-import { assertNever, slugify } from "@dust-tt/types";
+import { assertNever, SlugifiedString, slugify } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
@@ -20,7 +20,7 @@ export const config = {
 
 export const UpsertTableFromCsvSchema = t.intersection([
   t.type({
-    name: t.string,
+    name: SlugifiedString,
     description: t.string,
     truncate: t.boolean,
   }),
@@ -163,14 +163,12 @@ export async function handlePostTableCsvUpsertRequest(
     });
   }
   const tableId = bodyValidation.right.tableId ?? generateModelSId();
-  // Generate a slug combining the name and the last 4 characters of tableId for uniqueness.
-  const slugifyName = slugify(`${name}_${tableId.slice(-4)}`);
 
   const tableRes = await upsertTableFromCsv({
     owner,
     projectId: dataSource.dustAPIProjectId,
     dataSourceName,
-    tableName: slugifyName,
+    tableName: name,
     tableDescription: description,
     tableId,
     csv: csv ?? null,

--- a/front/pages/api/w/[wId]/data_sources/[name]/tables/csv.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/tables/csv.ts
@@ -1,4 +1,4 @@
-import { assertNever, SlugifiedString, slugify } from "@dust-tt/types";
+import { assertNever, SlugifiedString } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
@@ -34,9 +34,16 @@ export const UpsertTableFromCsvSchema = t.intersection([
   ]),
 ]);
 
-export type UpsertTableFromCsvRequestBody = t.TypeOf<
+type UpsertTableFromCsvRequestBodyRaw = t.TypeOf<
   typeof UpsertTableFromCsvSchema
 >;
+
+export type UpsertTableFromCsvRequestBody = Omit<
+  UpsertTableFromCsvRequestBodyRaw,
+  "name"
+> & {
+  name: string; // Manually map the 'name' field from SlugifiedString to string.
+};
 
 async function handler(
   req: NextApiRequest,

--- a/types/src/shared/utils/iots_utils.ts
+++ b/types/src/shared/utils/iots_utils.ts
@@ -29,3 +29,13 @@ export function createRangeCodec(min: number, max: number) {
     "Range"
   );
 }
+
+interface SlugifiedStringBrand {
+  readonly SlugifiedString: unique symbol;
+}
+
+export const SlugifiedString = t.brand(
+  t.string,
+  (s): s is t.Branded<string, SlugifiedStringBrand> => /^[a-z0-9_]+$/.test(s),
+  "SlugifiedString"
+);

--- a/types/src/shared/utils/string_utils.ts
+++ b/types/src/shared/utils/string_utils.ts
@@ -48,3 +48,7 @@ export function slugify(text: string) {
     .replace(/[\W]+/g, "_") // Replace all non-word characters with _.
     .replace(/__+/g, "_"); // Replace multiple _ with single _.
 }
+
+export function isSlugified(text: string) {
+  return /^[a-z0-9_]+$/.test(text);
+}


### PR DESCRIPTION
## Description

See https://github.com/dust-tt/dust/issues/3950.

This PR transfers the logic responsible for slugifying the structured data table's name and sanitizing the headers. Previously, this logic was located in the `front` component. However, as we intend to make this endpoint publicly accessible, it's essential to maintain the integrity of the user's input data.
In this PR, the logic for slugifying the table name and sanitizing headers has been moved to the connectors.Plus, stricter checks have been implemented on the public endpoint to ensure data consistency.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

Worst case it breaks some structured data. Safe to rollback.
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

First release `connectors` then `front`. This will temporary break the CSV import from the UI.

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
