### PR TITLE
Upsert Queue: tweak concurrency

### DIFF
--- a/front/upsert_queue/temporal/worker.ts
+++ b/front/upsert_queue/temporal/worker.ts
@@ -14,7 +14,8 @@ export async function runUpsertQueueWorker() {
     workflowsPath: require.resolve("./workflows"),
     activities,
     taskQueue: QUEUE_NAME,
-    maxConcurrentActivityTaskExecutions: 64,
+    // At the time of edit we have 2 front-worker. We target 64 overall concurrency.
+    maxConcurrentActivityTaskExecutions: 32,
     connection,
     namespace,
     interceptors: {


### PR DESCRIPTION
## Description

Target 64 overall concurrency.
We have 2 front-worker right now so 2x32

## Risk

N/A

## Deploy Plan

- deploy `front`