### PR TITLE
[Webcrawler] Adding a Temporal heartbeat in the crawler error handler

### DIFF
--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -241,6 +241,12 @@ export async function crawlWebsiteByConnectorId(connectorId: ModelId) {
         );
         crawlingError++;
       },
+      errorHandler: () => {
+        // Errors are already logged by the crawler, so we are not re-logging them here.
+        Context.current().heartbeat({
+          type: "error_handler",
+        });
+      },
     },
     new Configuration({
       purgeOnStart: true,


### PR DESCRIPTION
## Description

When all pages of a websites are taking more than our http request timeout (30 seconds), we endup retrying them (up to 3 times) and therefore not heartbeating on time in the request handler.
This PR adds a heartbeat in the error handler to make sure Temporal does not starts another activity in parrallel.


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
