### PR TITLE
Upsert Queue: logs and monitors

### DIFF
--- a/front/upsert_queue/temporal/client.ts
+++ b/front/upsert_queue/temporal/client.ts
@@ -11,10 +11,12 @@ export async function launchUpsertDocumentWorkflow({
   workspaceId,
   dataSourceName,
   upsertQueueId,
+  enqueueTimestamp,
 }: {
   workspaceId: string;
   dataSourceName: string;
   upsertQueueId: string;
+  enqueueTimestamp: number;
 }): Promise<Result<string, Error>> {
   const client = await getTemporalClient();
 
@@ -22,7 +24,7 @@ export async function launchUpsertDocumentWorkflow({
 
   try {
     await client.workflow.start(upsertDocumentWorkflow, {
-      args: [upsertQueueId],
+      args: [upsertQueueId, enqueueTimestamp],
       taskQueue: QUEUE_NAME,
       workflowId: workflowId,
       memo: {

--- a/front/upsert_queue/temporal/workflows.ts
+++ b/front/upsert_queue/temporal/workflows.ts
@@ -6,6 +6,9 @@ const { upsertDocumentActivity } = proxyActivities<typeof activities>({
   startToCloseTimeout: "10 minutes",
 });
 
-export async function upsertDocumentWorkflow(upsertQueueId: string) {
-  await upsertDocumentActivity(upsertQueueId);
+export async function upsertDocumentWorkflow(
+  upsertQueueId: string,
+  enqueueTimestamp: number
+) {
+  await upsertDocumentActivity(upsertQueueId, enqueueTimestamp);
 }


### PR DESCRIPTION
## Description

Added delay from enqueue to execution to logs + statsd counter and distributions
We are also covered by the default temporal monitoring which should catch activity failing 20 times

This is a good start. We won't have the queue size (other than looking at temporal) but the delay will be a good first indication on which we can create a monitor.

## Risk

N/A

## Deploy Plan

- deploy `front`