### PR TITLE
Upsert Queue: rollout upsert queue to slack 

### DIFF
--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -313,6 +313,7 @@ export async function confluenceCheckAndUpsertPageActivity({
       upsertContext: {
         sync_type: isBatchSync ? "batch" : "incremental",
       },
+      async: false,
     });
   }
 

--- a/connectors/src/connectors/github/temporal/activities.ts
+++ b/connectors/src/connectors/github/temporal/activities.ts
@@ -249,12 +249,13 @@ export async function githubUpsertIssueActivity(
     // The repo id from github is globally unique so used as-is, as per
     // convention to use the external id string.
     parents: [documentId, `${repoId}-issues`, repoId.toString()],
-    retries: 3,
-    delayBetweenRetriesMs: 500,
     loggerArgs: { ...loggerArgs, provider: "github" },
     upsertContext: {
       sync_type: isBatchSync ? "batch" : "incremental",
     },
+    async: false,
+    retries: 3,
+    delayBetweenRetriesMs: 500,
   });
 
   const connector = await ConnectorResource.findByDataSourceAndConnection(
@@ -443,12 +444,13 @@ export async function githubUpsertDiscussionActivity(
     // The repo id from github is globally unique so used as-is, as per
     // convention to use the external id string.
     parents: [documentId, `${repoId}-discussions`, repoId.toString()],
-    retries: 3,
-    delayBetweenRetriesMs: 500,
     loggerArgs: { ...loggerArgs, provider: "github" },
     upsertContext: {
       sync_type: isBatchSync ? "batch" : "incremental",
     },
+    async: false,
+    retries: 3,
+    delayBetweenRetriesMs: 500,
   });
 
   const connector = await ConnectorResource.findByDataSourceAndConnection(
@@ -1042,12 +1044,13 @@ export async function githubCodeSyncActivity({
             timestampMs: codeSyncStartedAt.getTime(),
             tags,
             parents: [...f.parents, rootInternalId, repoId.toString()],
-            retries: 3,
-            delayBetweenRetriesMs: 1000,
             loggerArgs: { ...loggerArgs, provider: "github" },
             upsertContext: {
               sync_type: isBatchSync ? "batch" : "incremental",
             },
+            async: false,
+            retries: 3,
+            delayBetweenRetriesMs: 1000,
           });
 
           // Finally update the file.

--- a/connectors/src/connectors/google_drive/temporal/file.ts
+++ b/connectors/src/connectors/google_drive/temporal/file.ts
@@ -314,6 +314,7 @@ export async function syncOneFile(
         upsertContext: {
           sync_type: isBatchSync ? "batch" : "incremental",
         },
+        async: false,
       });
 
       upsertTimestampMs = file.updatedAtMs;

--- a/connectors/src/connectors/intercom/temporal/sync_conversation.ts
+++ b/connectors/src/connectors/intercom/temporal/sync_conversation.ts
@@ -289,5 +289,6 @@ export async function syncConversation({
     upsertContext: {
       sync_type: syncType,
     },
+    async: false,
   });
 }

--- a/connectors/src/connectors/intercom/temporal/sync_help_center.ts
+++ b/connectors/src/connectors/intercom/temporal/sync_help_center.ts
@@ -359,6 +359,7 @@ export async function upsertArticle({
       upsertContext: {
         sync_type: "batch",
       },
+      async: false,
     });
     await articleOnDb.update({
       lastUpsertedTs: new Date(currentSyncMs),

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -1946,12 +1946,13 @@ export async function renderAndUpsertPageFromCache({
       }),
 
       parents,
-      retries: 3,
-      delayBetweenRetriesMs: 5000,
       loggerArgs,
       upsertContext: {
         sync_type: isFullSync ? "batch" : "incremental",
       },
+      async: false,
+      retries: 3,
+      delayBetweenRetriesMs: 5000,
     });
   }
 

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -472,6 +472,7 @@ export async function syncNonThreaded(
     upsertContext: {
       sync_type: isBatchSync ? "batch" : "incremental",
     },
+    async: true,
   });
 }
 
@@ -619,6 +620,7 @@ export async function syncThread(
     upsertContext: {
       sync_type: isBatchSync ? "batch" : "incremental",
     },
+    async: true,
   });
 }
 

--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -203,6 +203,7 @@ export async function crawlWebsiteByConnectorId(connectorId: ModelId) {
               upsertContext: {
                 sync_type: "batch",
               },
+              async: false,
             });
           } else {
             logger.info(

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -44,6 +44,7 @@ type UpsertToDataSourceParams = {
   parents: string[];
   loggerArgs?: Record<string, string | number>;
   upsertContext: UpsertContext;
+  async: boolean;
 };
 
 export const upsertToDatasource = withRetries(_upsertToDatasource);
@@ -58,6 +59,7 @@ async function _upsertToDatasource({
   parents,
   loggerArgs = {},
   upsertContext,
+  async,
 }: UpsertToDataSourceParams) {
   const localLogger = logger.child({
     ...loggerArgs,
@@ -89,7 +91,7 @@ async function _upsertToDatasource({
     parents,
     light_document_output: true,
     upsert_context: upsertContext,
-    async: undefined,
+    async,
   };
 
   const dustRequestConfig: AxiosRequestConfig = {

--- a/front/upsert_queue/temporal/activities.ts
+++ b/front/upsert_queue/temporal/activities.ts
@@ -62,10 +62,17 @@ export async function upsertDocumentActivity(
     documentId: upsertQueueItem.documentId,
   });
 
+  const statsDTags = [
+    `data_source_name:${dataSource.name}`,
+    `workspace_id:${upsertQueueItem.workspaceId}`,
+  ];
+
   // Dust managed credentials: all data sources.
   const credentials = dustManagedCredentials();
 
   const coreAPI = new CoreAPI(logger);
+
+  const upsertTimestamp = Date.now();
 
   // Create document with the Dust internal API.
   const upsertRes = await coreAPI.upsertDataSourceDocument({
@@ -89,7 +96,12 @@ export async function upsertDocumentActivity(
       },
       "[UpsertQueue] Failed upsert"
     );
-    statsDClient.increment("upsert_queue.enqueue.error", 1, []);
+    statsDClient.increment("upsert_queue_error.count", 1, statsDTags);
+    statsDClient.distribution(
+      "upsert_queue_upsert_error.duration.distribution",
+      Date.now() - upsertTimestamp,
+      []
+    );
 
     throw new Error(`Upsert error: ${upsertRes.error}`);
   }
@@ -100,7 +112,12 @@ export async function upsertDocumentActivity(
     },
     "[UpsertQueue] Successful upsert"
   );
-  statsDClient.increment("upsert_queue.enqueue.success", 1, []);
+  statsDClient.increment("upsert_queue_success.count", 1, statsDTags);
+  statsDClient.distribution(
+    "upsert_queue_upsert_success.duration.distribution",
+    Date.now() - upsertTimestamp,
+    []
+  );
   statsDClient.distribution(
     "upsert_queue.duration.distribution",
     Date.now() - enqueueTimestamp,


### PR DESCRIPTION
## Description

Tweaks reporting to cover pure upsert latency (reproduce connectors dashboards which will become irrelevant)
Rollout upsert queue to the slack connector

## Risk

Blows to our face. Worst case scenario are upsert queue workflow piling but failing to move forward in which case we can revert and use GCS to run the upserts.

## Deploy Plan

- deploy `front`
- deploy `connectors`