### PR TITLE
UpsertQueue: enable more async upserts

### DIFF
--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -300,20 +300,18 @@ export async function confluenceCheckAndUpsertPageActivity({
 
     await upsertToDatasource({
       dataSourceConfig,
-      delayBetweenRetriesMs: 500,
       documentContent: renderedPage,
       documentId,
       documentUrl,
       loggerArgs,
       // Parent Ids will be computed after all page imports within the space have been completed.
       parents: [],
-      retries: 3,
       tags,
       timestampMs: lastPageVersionCreatedAt.getTime(),
       upsertContext: {
         sync_type: isBatchSync ? "batch" : "incremental",
       },
-      async: false,
+      async: true,
     });
   }
 

--- a/connectors/src/connectors/github/temporal/activities.ts
+++ b/connectors/src/connectors/github/temporal/activities.ts
@@ -253,9 +253,7 @@ export async function githubUpsertIssueActivity(
     upsertContext: {
       sync_type: isBatchSync ? "batch" : "incremental",
     },
-    async: false,
-    retries: 3,
-    delayBetweenRetriesMs: 500,
+    async: true,
   });
 
   const connector = await ConnectorResource.findByDataSourceAndConnection(
@@ -448,9 +446,7 @@ export async function githubUpsertDiscussionActivity(
     upsertContext: {
       sync_type: isBatchSync ? "batch" : "incremental",
     },
-    async: false,
-    retries: 3,
-    delayBetweenRetriesMs: 500,
+    async: true,
   });
 
   const connector = await ConnectorResource.findByDataSourceAndConnection(
@@ -1048,9 +1044,7 @@ export async function githubCodeSyncActivity({
             upsertContext: {
               sync_type: isBatchSync ? "batch" : "incremental",
             },
-            async: false,
-            retries: 3,
-            delayBetweenRetriesMs: 1000,
+            async: true,
           });
 
           // Finally update the file.

--- a/connectors/src/connectors/google_drive/temporal/file.ts
+++ b/connectors/src/connectors/google_drive/temporal/file.ts
@@ -314,7 +314,7 @@ export async function syncOneFile(
         upsertContext: {
           sync_type: isBatchSync ? "batch" : "incremental",
         },
-        async: false,
+        async: true,
       });
 
       upsertTimestampMs = file.updatedAtMs;

--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -203,7 +203,7 @@ export async function crawlWebsiteByConnectorId(connectorId: ModelId) {
               upsertContext: {
                 sync_type: "batch",
               },
-              async: false,
+              async: true,
             });
           } else {
             logger.info(


### PR DESCRIPTION
## Description

Enable async upsert queue for github, confluence, google_drive and webcrawler

## Risk

Limited slack is working

## Deploy Plan

- deploy `connectors`