### PR TITLE
Increase structured data slice length for improved slugification

### DIFF
--- a/types/src/shared/utils/structured_data.ts
+++ b/types/src/shared/utils/structured_data.ts
@@ -1,7 +1,7 @@
 import { slugify } from "./string_utils";
 
 export function makeStructuredDataTableName(name: string, tableId: string) {
-  return slugify(`${name}_${tableId.slice(-4)}`);
+  return slugify(`${name}_${tableId.slice(-12)}`);
 }
 
 export function getSanitizedHeaders(rawHeaders: string[]) {


### PR DESCRIPTION
## Description

This PR corrects the method used for generating the slugified table name for structured data. Previously, we relied on the last 4 characters of the table ID, but this approach resulted in a conflict. To prevent any further conflicts, this PR extends the slice length of the table ID to the last 12 characters.

See Slack thread: [here](https://dust4ai.slack.com/archives/C05F84CFP0E/p1709105866018119).

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
