### PR TITLE
Intercom: Upsert article only if updated or full resync

### DIFF
--- a/connectors/src/connectors/intercom/index.ts
+++ b/connectors/src/connectors/intercom/index.ts
@@ -93,10 +93,9 @@ export async function createIntercomConnector(
       region: intercomWorkspace.region,
     });
 
-    const workflowStarted = await launchIntercomSyncWorkflow(
-      connector.id,
-      null
-    );
+    const workflowStarted = await launchIntercomSyncWorkflow({
+      connectorId: connector.id,
+    });
     if (workflowStarted.isErr()) {
       await connector.destroy();
       await intercomWorkpace.destroy();
@@ -299,7 +298,9 @@ export async function resumeIntercomConnector(
 
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
   try {
-    await launchIntercomSyncWorkflow(connector.id, null);
+    await launchIntercomSyncWorkflow({
+      connectorId,
+    });
   } catch (e) {
     logger.error(
       {
@@ -339,13 +340,12 @@ export async function fullResyncIntercomSyncWorkflow(
   const toBeSignaledHelpCenterIds = helpCentersIds.map((hc) => hc.helpCenterId);
   const toBeSignaledTeamIds = teamsIds.map((team) => team.teamId);
 
-  const sendSignalToWorkflowResult = await launchIntercomSyncWorkflow(
+  const sendSignalToWorkflowResult = await launchIntercomSyncWorkflow({
     connectorId,
-    null,
-    toBeSignaledHelpCenterIds,
-    toBeSignaledTeamIds,
-    true
-  );
+    helpCenterIds: toBeSignaledHelpCenterIds,
+    teamIds: toBeSignaledTeamIds,
+    forceResync: true,
+  });
   if (sendSignalToWorkflowResult.isErr()) {
     return new Err(sendSignalToWorkflowResult.error);
   }
@@ -490,12 +490,11 @@ export async function setIntercomConnectorPermissions(
     }
 
     if (toBeSignaledHelpCenterIds.size > 0 || toBeSignaledTeamIds.size > 0) {
-      const sendSignalToWorkflowResult = await launchIntercomSyncWorkflow(
+      const sendSignalToWorkflowResult = await launchIntercomSyncWorkflow({
         connectorId,
-        null,
-        [...toBeSignaledHelpCenterIds],
-        [...toBeSignaledTeamIds]
-      );
+        helpCenterIds: [...toBeSignaledHelpCenterIds],
+        teamIds: [...toBeSignaledTeamIds],
+      });
       if (sendSignalToWorkflowResult.isErr()) {
         return new Err(sendSignalToWorkflowResult.error);
       }

--- a/connectors/src/connectors/intercom/index.ts
+++ b/connectors/src/connectors/intercom/index.ts
@@ -339,17 +339,12 @@ export async function fullResyncIntercomSyncWorkflow(
   const toBeSignaledHelpCenterIds = helpCentersIds.map((hc) => hc.helpCenterId);
   const toBeSignaledTeamIds = teamsIds.map((team) => team.teamId);
 
-  // We reset the lastUpsertedTs of all Help Center articles to make sure they are resynced
-  await IntercomArticle.update(
-    { lastUpsertedTs: null },
-    { where: { connectorId: connector.id } }
-  );
-
   const sendSignalToWorkflowResult = await launchIntercomSyncWorkflow(
     connectorId,
     null,
     toBeSignaledHelpCenterIds,
-    toBeSignaledTeamIds
+    toBeSignaledTeamIds,
+    true
   );
   if (sendSignalToWorkflowResult.isErr()) {
     return new Err(sendSignalToWorkflowResult.error);

--- a/connectors/src/connectors/intercom/index.ts
+++ b/connectors/src/connectors/intercom/index.ts
@@ -339,6 +339,12 @@ export async function fullResyncIntercomSyncWorkflow(
   const toBeSignaledHelpCenterIds = helpCentersIds.map((hc) => hc.helpCenterId);
   const toBeSignaledTeamIds = teamsIds.map((team) => team.teamId);
 
+  // We reset the lastUpsertedTs of all Help Center articles to make sure they are resynced
+  await IntercomArticle.update(
+    { lastUpsertedTs: null },
+    { where: { connectorId: connector.id } }
+  );
+
   const sendSignalToWorkflowResult = await launchIntercomSyncWorkflow(
     connectorId,
     null,

--- a/connectors/src/connectors/intercom/temporal/activities.ts
+++ b/connectors/src/connectors/intercom/temporal/activities.ts
@@ -324,11 +324,13 @@ export async function syncArticleBatchActivity({
   helpCenterId,
   page,
   currentSyncMs,
+  forceResync,
 }: {
   connectorId: ModelId;
   helpCenterId: string;
   page: number;
   currentSyncMs: number;
+  forceResync: boolean;
 }): Promise<{ nextPage: number | null }> {
   const connector = await _getIntercomConnectorOrRaise(connectorId);
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
@@ -401,6 +403,7 @@ export async function syncArticleBatchActivity({
           region: intercomWorkspace.region,
           isHelpCenterWebsiteTurnedOn: helpCenter.websiteTurnedOn,
           currentSyncMs,
+          forceResync,
           dataSourceConfig,
           loggerArgs,
         });

--- a/connectors/src/connectors/intercom/temporal/client.ts
+++ b/connectors/src/connectors/intercom/temporal/client.ts
@@ -11,13 +11,19 @@ import { getTemporalClient } from "@connectors/lib/temporal";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 
-export async function launchIntercomSyncWorkflow(
-  connectorId: ModelId,
-  fromTs: number | null,
-  helpCenterIds: string[] = [],
-  teamIds: string[] = [],
-  forceResync = false
-): Promise<Result<string, Error>> {
+export async function launchIntercomSyncWorkflow({
+  connectorId,
+  fromTs = null,
+  helpCenterIds = [],
+  teamIds = [],
+  forceResync = false,
+}: {
+  connectorId: ModelId;
+  fromTs?: number | null;
+  helpCenterIds?: string[];
+  teamIds?: string[];
+  forceResync?: boolean;
+}): Promise<Result<string, Error>> {
   if (fromTs) {
     throw new Error("[Intercom] Workflow does not support fromTs.");
   }

--- a/connectors/src/connectors/intercom/temporal/client.ts
+++ b/connectors/src/connectors/intercom/temporal/client.ts
@@ -41,18 +41,20 @@ export async function launchIntercomSyncWorkflow({
     (helpCenterId) => ({
       type: "help_center",
       intercomId: helpCenterId,
+      forceResync,
     })
   );
   const signaledTeamIds: IntercomUpdateSignal[] = teamIds.map((teamId) => ({
     type: "team",
     intercomId: teamId,
+    forceResync,
   }));
   const signals = [...signaledHelpCenterIds, ...signaledTeamIds];
 
   // When the workflow is inactive, we omit passing helpCenterIds as they are only used to signal modifications within a currently active full sync workflow.
   try {
     await client.workflow.signalWithStart(intercomSyncWorkflow, {
-      args: [{ connectorId: connector.id, forceResync }],
+      args: [{ connectorId: connector.id }],
       taskQueue: QUEUE_NAME,
       workflowId,
       searchAttributes: {

--- a/connectors/src/connectors/intercom/temporal/client.ts
+++ b/connectors/src/connectors/intercom/temporal/client.ts
@@ -15,7 +15,8 @@ export async function launchIntercomSyncWorkflow(
   connectorId: ModelId,
   fromTs: number | null,
   helpCenterIds: string[] = [],
-  teamIds: string[] = []
+  teamIds: string[] = [],
+  forceResync = false
 ): Promise<Result<string, Error>> {
   if (fromTs) {
     throw new Error("[Intercom] Workflow does not support fromTs.");
@@ -45,7 +46,7 @@ export async function launchIntercomSyncWorkflow(
   // When the workflow is inactive, we omit passing helpCenterIds as they are only used to signal modifications within a currently active full sync workflow.
   try {
     await client.workflow.signalWithStart(intercomSyncWorkflow, {
-      args: [{ connectorId: connector.id }],
+      args: [{ connectorId: connector.id, forceResync }],
       taskQueue: QUEUE_NAME,
       workflowId,
       searchAttributes: {

--- a/connectors/src/connectors/intercom/temporal/config.ts
+++ b/connectors/src/connectors/intercom/temporal/config.ts
@@ -1,2 +1,2 @@
-export const WORKFLOW_VERSION = 1;
+export const WORKFLOW_VERSION = 2;
 export const QUEUE_NAME = `intercom-queue-v${WORKFLOW_VERSION}`;

--- a/connectors/src/connectors/intercom/temporal/signals.ts
+++ b/connectors/src/connectors/intercom/temporal/signals.ts
@@ -3,6 +3,7 @@ import { defineSignal } from "@temporalio/workflow";
 export interface IntercomUpdateSignal {
   intercomId: string;
   type: "help_center" | "team";
+  forceResync: boolean;
 }
 
 export const intercomUpdatesSignal = defineSignal<[IntercomUpdateSignal[]]>(

--- a/connectors/src/connectors/intercom/temporal/sync_help_center.ts
+++ b/connectors/src/connectors/intercom/temporal/sync_help_center.ts
@@ -232,6 +232,7 @@ export async function upsertArticle({
   parentCollection,
   isHelpCenterWebsiteTurnedOn,
   currentSyncMs,
+  forceResync,
   dataSourceConfig,
   loggerArgs,
 }: {
@@ -242,6 +243,7 @@ export async function upsertArticle({
   parentCollection: IntercomCollection;
   isHelpCenterWebsiteTurnedOn: boolean;
   currentSyncMs: number;
+  forceResync: boolean;
   dataSourceConfig: DataSourceConfig;
   loggerArgs: Record<string, string | number>;
 }) {
@@ -255,6 +257,7 @@ export async function upsertArticle({
   const articleUpdatedAtDate = new Date(article.updated_at * 1000);
 
   const shouldUpsertDatasource =
+    forceResync ||
     !articleOnDb ||
     !articleOnDb.lastUpsertedTs ||
     articleOnDb.lastUpsertedTs < articleUpdatedAtDate;

--- a/connectors/src/connectors/intercom/temporal/sync_help_center.ts
+++ b/connectors/src/connectors/intercom/temporal/sync_help_center.ts
@@ -252,6 +252,13 @@ export async function upsertArticle({
     },
   });
 
+  const articleUpdatedAtDate = new Date(article.updated_at * 1000);
+
+  const shouldUpsertDatasource =
+    !articleOnDb ||
+    !articleOnDb.lastUpsertedTs ||
+    articleOnDb.lastUpsertedTs < articleUpdatedAtDate;
+
   // Article url is working only if the help center has activated the website feature
   // Otherwise they generate an url that is not working
   // So as a workaround we use the url of the article in the intercom app
@@ -298,6 +305,32 @@ export async function upsertArticle({
       state: article.state === "published" ? "published" : "draft",
       permission: "read",
     });
+  }
+
+  if (!shouldUpsertDatasource) {
+    // Article is already up to date, we don't need to update the datasource
+    logger.info(
+      {
+        ...loggerArgs,
+        connectorId,
+        articleId: article.id,
+        articleUpdatedAt: articleUpdatedAtDate,
+        dataSourcelastUpsertedAt: articleOnDb?.lastUpsertedTs ?? null,
+      },
+      "[Intercom] Article already up to date. Skipping sync."
+    );
+    return;
+  } else {
+    logger.info(
+      {
+        ...loggerArgs,
+        connectorId,
+        articleId: article.id,
+        articleUpdatedAt: articleUpdatedAtDate,
+        dataSourcelastUpsertedAt: articleOnDb?.lastUpsertedTs ?? null,
+      },
+      "[Intercom] Article to sync."
+    );
   }
 
   const categoryContent =

--- a/connectors/src/connectors/intercom/temporal/workflows.ts
+++ b/connectors/src/connectors/intercom/temporal/workflows.ts
@@ -44,8 +44,10 @@ const { saveIntercomConnectorStartSync, saveIntercomConnectorSuccessSync } =
  */
 export async function intercomSyncWorkflow({
   connectorId,
+  forceResync,
 }: {
   connectorId: ModelId;
+  forceResync: boolean;
 }) {
   await saveIntercomConnectorStartSync({ connectorId });
 
@@ -100,6 +102,7 @@ export async function intercomSyncWorkflow({
             connectorId,
             helpCenterId,
             currentSyncMs,
+            forceResync,
           },
         ],
         memo,
@@ -152,10 +155,12 @@ export async function intercomHelpCenterSyncWorklow({
   connectorId,
   helpCenterId,
   currentSyncMs,
+  forceResync,
 }: {
   connectorId: ModelId;
   helpCenterId: string;
   currentSyncMs: number;
+  forceResync: boolean;
 }) {
   const hasPermission = await syncHelpCenterOnlyActivity({
     connectorId,
@@ -191,6 +196,7 @@ export async function intercomHelpCenterSyncWorklow({
       helpCenterId,
       page,
       currentSyncMs,
+      forceResync,
     });
     page = nextPage;
   } while (page);

--- a/connectors/src/connectors/intercom/temporal/workflows.ts
+++ b/connectors/src/connectors/intercom/temporal/workflows.ts
@@ -44,28 +44,28 @@ const { saveIntercomConnectorStartSync, saveIntercomConnectorSuccessSync } =
  */
 export async function intercomSyncWorkflow({
   connectorId,
-  forceResync,
 }: {
   connectorId: ModelId;
-  forceResync: boolean;
 }) {
   await saveIntercomConnectorStartSync({ connectorId });
 
   const uniqueHelpCenterIds = new Set<string>();
   const uniqueTeamIds = new Set<string>();
+  const signaledHelpCenters: IntercomUpdateSignal[] = [];
 
   // If we get a signal, update the workflow state by adding help center ids.
   // We send a signal when permissions are updated by the admin.
   setHandler(
     intercomUpdatesSignal,
     (intercomUpdates: IntercomUpdateSignal[]) => {
-      for (const { type, intercomId } of intercomUpdates) {
-        if (type === "help_center") {
-          uniqueHelpCenterIds.add(intercomId);
-        } else if (type === "team") {
-          uniqueTeamIds.add(intercomId);
+      intercomUpdates.forEach((signal) => {
+        if (signal.type === "help_center") {
+          uniqueHelpCenterIds.add(signal.intercomId);
+          signaledHelpCenters.push(signal);
+        } else if (signal.type === "team") {
+          uniqueTeamIds.add(signal.intercomId);
         }
-      }
+      });
     }
   );
 
@@ -93,6 +93,11 @@ export async function intercomSyncWorkflow({
       if (!uniqueHelpCenterIds.has(helpCenterId)) {
         continue;
       }
+
+      const relatedSignal = signaledHelpCenters.find((signaledHelpCenter) => {
+        return signaledHelpCenter.intercomId === helpCenterId;
+      });
+
       // Async operation yielding control to the Temporal runtime.
       await executeChild(intercomHelpCenterSyncWorklow, {
         workflowId: `${workflowId}-help-center-${helpCenterId}`,
@@ -102,7 +107,7 @@ export async function intercomSyncWorkflow({
             connectorId,
             helpCenterId,
             currentSyncMs,
-            forceResync,
+            forceResync: relatedSignal?.forceResync || false,
           },
         ],
         memo,

--- a/connectors/src/lib/models/intercom.ts
+++ b/connectors/src/lib/models/intercom.ts
@@ -271,7 +271,7 @@ export class IntercomArticle extends Model<
 
   declare state: "draft" | "published";
 
-  declare lastUpsertedTs?: Date;
+  declare lastUpsertedTs?: Date | null;
   declare permission: "read" | "none";
 
   declare connectorId: ForeignKey<ConnectorModel["id"]>;


### PR DESCRIPTION
## Description

- Only upsert an Article if it was updated since last upsert
- In case of a full resync -> we use the `signaledArgs` and not the `args` to notify the children workflows that we are in a fullResync, cf https://github.com/dust-tt/dust/pull/4006#discussion_r1506135158
- Add temp logs to monitor

## Risk

/

## Deploy Plan

Nothing special, there's a change on a model file but the field was already nullable. 
