### PR TITLE
Refactor Google Drive Spreadsheet sync

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/workflows.ts
+++ b/connectors/src/connectors/google_drive/temporal/workflows.ts
@@ -27,12 +27,6 @@ const {
   markFolderAsVisited,
 } = proxyActivities<typeof activities>({
   startToCloseTimeout: "20 minutes",
-  retry: {
-    initialInterval: "10s",
-    backoffCoefficient: 2,
-    maximumAttempts: Infinity,
-    nonRetryableErrorTypes: [],
-  },
 });
 
 const { reportInitialSyncProgress, syncSucceeded } = proxyActivities<

--- a/connectors/src/connectors/google_drive/temporal/workflows.ts
+++ b/connectors/src/connectors/google_drive/temporal/workflows.ts
@@ -27,6 +27,12 @@ const {
   markFolderAsVisited,
 } = proxyActivities<typeof activities>({
   startToCloseTimeout: "20 minutes",
+  retry: {
+    initialInterval: "10s",
+    backoffCoefficient: 2,
+    maximumAttempts: Infinity,
+    nonRetryableErrorTypes: [],
+  },
 });
 
 const { reportInitialSyncProgress, syncSucceeded } = proxyActivities<


### PR DESCRIPTION
## Description

With the release of structured data to more customers, we've encountered rate limits on the Google Sheets API, which currently allows 60 calls per minute per user. We've observed that most spreadsheets contain more than one sheet, leading to potentially n-calls ([link](https://app.datadoghq.eu/logs?query=List%20sheets%20&agg_m=count&agg_t=count&cols=host%2Cservice%2C%40attempt%2C%40sheetCount&fromUser=true&index=%2A&messageDisplay=inline&refresh_mode=sliding&source=monitor_notif&stream_sort=desc&viz=stream&from_ts=1709110316930&to_ts=1709124716930&live=true)).

To reduce the number of calls, this PR changes the current implementation from one call per sheet to a single batch get call that retrieves all the values for all sheets within a spreadsheet. This should improve the API usage and make the Google Drive incremental sync flow smoother.

In addition to this, we will contact Google to request an increase in the rate limit.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
