### PR TITLE
Improve spreadsheet value range matching in Google Sheets API response

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
+++ b/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
@@ -251,10 +251,11 @@ async function getAllSheetsFromSpreadSheet(
   const sheets: Sheet[] = [];
   for (const [sheetName, sheet] of sheetRanges) {
     // To locate the value range for the current sheet within the batch get response,
-    // we use the sheet name in the format 'Sheet1'!<range>. This notation helps us
+    // we use the sheet name in the format Sheet1!<range> or 'Details-View'!<range>. This notation helps us
     // match and extract the appropriate range from the response for the current sheet.
-    const valueRangeForSheet = valueRanges.find((s) =>
-      s.range?.startsWith(`'${sheetName}'`)
+    const valueRangeForSheet = valueRanges.find(
+      (s) =>
+        s.range?.startsWith(`'${sheetName}'`) || s.range?.startsWith(sheetName)
     );
     if (!valueRangeForSheet) {
       localLogger.info(


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See [thread](https://dust4ai.slack.com/archives/C050SM8NSPK/p1709134619045719).

In https://github.com/dust-tt/dust/pull/4009, we move to the batch endpoint which require us to use the sheet's name to find the value. I oversaw that the name isn't consistently escaped in single quote. This PR brings more flexibility. Tested locally.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
