### PR TITLE
fix Tables types

### DIFF
--- a/front/lib/swr.ts
+++ b/front/lib/swr.ts
@@ -17,7 +17,6 @@ import type { GetPokePlansResponseBody } from "@app/pages/api/poke/plans";
 import type { GetWorkspacesResponseBody } from "@app/pages/api/poke/workspaces";
 import type { GetUserResponseBody } from "@app/pages/api/user";
 import type { GetUserMetadataResponseBody } from "@app/pages/api/user/metadata/[key]";
-import type { ListTablesResponseBody } from "@app/pages/api/v1/w/[wId]/data_sources/[name]/tables";
 import type { GetTableResponseBody } from "@app/pages/api/v1/w/[wId]/data_sources/[name]/tables/[tId]";
 import type { GetDatasetsResponseBody } from "@app/pages/api/w/[wId]/apps/[aId]/datasets";
 import type { GetRunsResponseBody } from "@app/pages/api/w/[wId]/apps/[aId]/runs";
@@ -31,6 +30,7 @@ import type { GetDocumentsResponseBody } from "@app/pages/api/w/[wId]/data_sourc
 import type { GetOrPostManagedDataSourceConfigResponseBody } from "@app/pages/api/w/[wId]/data_sources/[name]/managed/config/[key]";
 import type { GetDataSourcePermissionsResponseBody } from "@app/pages/api/w/[wId]/data_sources/[name]/managed/permissions";
 import type { GetSlackChannelsLinkedWithAgentResponseBody } from "@app/pages/api/w/[wId]/data_sources/[name]/managed/slack/channels_linked_with_agent";
+import type { ListTablesResponseBody } from "@app/pages/api/w/[wId]/data_sources/[name]/tables";
 import type { GetWorkspaceInvitationsResponseBody } from "@app/pages/api/w/[wId]/invitations";
 import type { GetKeysResponseBody } from "@app/pages/api/w/[wId]/keys";
 import type { GetMembersResponseBody } from "@app/pages/api/w/[wId]/members";

--- a/front/pages/api/w/[wId]/data_sources/[name]/tables/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/tables/index.ts
@@ -1,4 +1,4 @@
-import type { WithAPIErrorReponse } from "@dust-tt/types";
+import type { CoreAPITable, WithAPIErrorReponse } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -6,7 +6,10 @@ import { getDataSource } from "@app/lib/api/data_sources";
 import { Authenticator, getSession } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import { apiError, withLogging } from "@app/logger/withlogging";
-import type { ListTablesResponseBody } from "@app/pages/api/v1/w/[wId]/data_sources/[name]/tables";
+
+export type ListTablesResponseBody = {
+  tables: CoreAPITable[];
+};
 
 async function handler(
   req: NextApiRequest,


### PR DESCRIPTION
## Description

For v1 endpoint we don't expose directly CoreAPITable (don't want to expose types). Doing so we messed with a sharead type that is used with internal routes that depend on that type

This PR breaks the type in two.

## Risk

N/A

## Deploy Plan

- deploy `front`