### PR TITLE
Sparkle: Tree item custom visual

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.102",
+  "version": "0.2.103",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.102",
+      "version": "0.2.103",
       "license": "ISC",
       "dependencies": {
         "@headlessui/react": "^1.7.17",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.102",
+  "version": "0.2.103",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/components/Tree.tsx
+++ b/sparkle/src/components/Tree.tsx
@@ -5,7 +5,7 @@ import {
   ChevronDown,
   ChevronRight,
   DocumentText,
-  FolderOpen,
+  Folder,
   Square3Stack3D,
 } from "@sparkle/icons/stroke";
 import { classNames } from "@sparkle/lib/utils";
@@ -34,7 +34,7 @@ export function Tree({ children, isLoading }: TreeProps) {
 
 const visualTable = {
   file: DocumentText,
-  folder: FolderOpen,
+  folder: Folder,
   database: Square3Stack3D,
   channel: ChatBubbleBottomCenterText,
 };
@@ -43,6 +43,7 @@ export interface TreeItemProps {
   label?: string;
   type?: "node" | "item" | "leaf";
   variant?: "file" | "folder" | "database" | "channel";
+  visual?: React.ReactNode;
   checkbox?: CheckboxProps;
   onChevronClick?: () => void;
   collapsed?: boolean;
@@ -56,6 +57,7 @@ Tree.Item = function ({
   type = "node",
   className = "",
   variant = "file",
+  visual,
   checkbox,
   onChevronClick,
   collapsed,
@@ -83,11 +85,16 @@ Tree.Item = function ({
 
         <div className="s-flex s-w-full s-items-center s-gap-1.5 s-text-sm s-font-medium s-text-element-900">
           <div className="s-grid s-w-full s-grid-cols-[auto,1fr,auto] s-items-center s-gap-1.5 s-text-sm s-font-medium s-text-element-900">
-            <Icon
-              visual={visualTable[variant]}
-              size="sm"
-              className="s-flex-shrink-0 s-text-element-700"
-            />
+            {visual ? (
+              visual
+            ) : (
+              <Icon
+                visual={visualTable[variant]}
+                size="sm"
+                className="s-flex-shrink-0 s-text-element-700"
+              />
+            )}
+
             <div className="s-truncate">{label}</div>
             {actions && <div className="s-inline-block s-pl-5">{actions}</div>}
           </div>

--- a/sparkle/src/stories/Tree.stories.tsx
+++ b/sparkle/src/stories/Tree.stories.tsx
@@ -2,10 +2,15 @@ import type { Meta } from "@storybook/react";
 import React, { useState } from "react";
 import { v4 as uuidv4 } from "uuid";
 
+import { Dust } from "@sparkle/icons/solid";
+
 import {
   CloudArrowDownIcon,
   IconButton,
+  IntercomLogo,
+  NotionLogo,
   PlusCircleIcon,
+  SlackLogo,
   Tree,
 } from "../index_with_tw_base";
 
@@ -183,6 +188,61 @@ export const TreeExample = () => {
               label="item 5"
               type="item"
               variant="channel"
+              checkbox={{
+                variant: "checkable",
+                checked: false,
+                onChange: () => {
+                  return;
+                },
+              }}
+            />
+          </Tree>
+        </div>
+      </div>
+      <div className="s-flex s-flex-col s-gap-3">
+        <div className="s-text-xl">With custom visual</div>
+        <div>
+          <Tree>
+            <Tree.Item
+              label="Intercom"
+              type="item"
+              visual={<IntercomLogo className="s-h-5 s-w-5" />}
+              checkbox={{
+                variant: "checkable",
+                checked: false,
+                onChange: () => {
+                  return;
+                },
+              }}
+            />
+            <Tree.Item
+              label="Notion"
+              type="item"
+              visual={<NotionLogo className="s-h-5 s-w-5" />}
+              checkbox={{
+                variant: "checkable",
+                checked: false,
+                onChange: () => {
+                  return;
+                },
+              }}
+            />
+            <Tree.Item
+              label="Slack"
+              type="item"
+              visual={<SlackLogo className="s-h-5 s-w-5" />}
+              checkbox={{
+                variant: "checkable",
+                checked: false,
+                onChange: () => {
+                  return;
+                },
+              }}
+            />
+            <Tree.Item
+              label="Dust"
+              type="item"
+              visual={<Dust color="pink" className="s-h-5 s-w-5" />}
               checkbox={{
                 variant: "checkable",
                 checked: false,


### PR DESCRIPTION
## Description

- Replace FolderOpen by Folder on Tree component (asked by @Duncid )
- Ability to add a custom visual to the Tree component. 
- Update the story to display it (new column "With custom visual")

<img width="937" alt="Screenshot 2024-02-28 at 21 09 42" src="https://github.com/dust-tt/dust/assets/3803406/74fde648-a160-4a7d-81a4-593bca1f0786">


## Risk

/

## Deploy Plan

Publish sparkle
