### PR TITLE
Increase GDrive startToCloseTimeout on full sync

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/workflows.ts
+++ b/connectors/src/connectors/google_drive/temporal/workflows.ts
@@ -16,7 +16,6 @@ import { GDRIVE_INCREMENTAL_SYNC_DEBOUNCE_SEC } from "./config";
 import { newWebhookSignal } from "./signals";
 
 const {
-  syncFiles,
   getDrivesIds,
   garbageCollector,
   getFoldersToSync,
@@ -27,6 +26,11 @@ const {
   markFolderAsVisited,
 } = proxyActivities<typeof activities>({
   startToCloseTimeout: "20 minutes",
+});
+
+// Temporarily increase timeout on syncFiles until table upsertion is moved to the upsert queue.
+const { syncFiles } = proxyActivities<typeof activities>({
+  startToCloseTimeout: "30 minutes",
 });
 
 const { reportInitialSyncProgress, syncSucceeded } = proxyActivities<


### PR DESCRIPTION
## Description

This PR increases the Google Drive full sync timeout to accommodate the release of the Google Spreadsheet as structured data. This is temporary until we move upsertion to the upsert queue. 
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
