### PR TITLE
User server side props for Poke assistants

### DIFF
--- a/front/components/poke/assistants/columns.tsx
+++ b/front/components/poke/assistants/columns.tsx
@@ -1,15 +1,10 @@
 import { IconButton, TrashIcon } from "@dust-tt/sparkle";
-import type {
-  LightAgentConfigurationType,
-  WorkspaceType,
-} from "@dust-tt/types";
+import type { AgentConfigurationType, WorkspaceType } from "@dust-tt/types";
 import { ArrowsUpDownIcon } from "@heroicons/react/20/solid";
 import type { ColumnDef } from "@tanstack/react-table";
 import Link from "next/link";
-import type { KeyedMutator } from "swr";
 
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
-import type { GetAgentConfigurationsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
 
 type AgentConfigurationDisplayType = {
   // TODO(2024-02-28 flav) Add description preview.
@@ -23,8 +18,8 @@ type AgentConfigurationDisplayType = {
 
 export function makeColumnsForAssistants(
   owner: WorkspaceType,
-  agentConfigurations: LightAgentConfigurationType[],
-  mutate: KeyedMutator<GetAgentConfigurationsResponseBody>
+  agentConfigurations: AgentConfigurationType[],
+  reload: () => void
 ): ColumnDef<AgentConfigurationDisplayType>[] {
   return [
     {
@@ -98,7 +93,7 @@ export function makeColumnsForAssistants(
             size="xs"
             variant="tertiary"
             onClick={async () => {
-              await archiveAssistant(owner, mutate, assistant);
+              await archiveAssistant(owner, reload, assistant);
             }}
           />
         );
@@ -109,7 +104,7 @@ export function makeColumnsForAssistants(
 
 async function archiveAssistant(
   owner: WorkspaceType,
-  mutate: KeyedMutator<GetAgentConfigurationsResponseBody>,
+  reload: () => void,
   agentConfiguration: AgentConfigurationDisplayType
 ) {
   if (
@@ -134,7 +129,7 @@ async function archiveAssistant(
       throw new Error("Failed to archive agent configuration.");
     }
 
-    await mutate();
+    reload();
   } catch (e) {
     console.error(e);
     window.alert("An error occurred while archiving the agent configuration.");

--- a/front/components/poke/assistants/table.tsx
+++ b/front/components/poke/assistants/table.tsx
@@ -1,14 +1,16 @@
 import type {
+  AgentConfigurationType,
   LightAgentConfigurationType,
   WorkspaceType,
 } from "@dust-tt/types";
+import { useRouter } from "next/router";
 
 import { makeColumnsForAssistants } from "@app/components/poke/assistants/columns";
 import { DataTable } from "@app/components/poke/shadcn/ui/data_table";
 import { GLOBAL_AGENTS_SID } from "@app/lib/assistant";
-import { useAgentConfigurations } from "@app/lib/swr";
 
 interface AssistantsDataTableProps {
+  agentConfigurations: AgentConfigurationType[];
   owner: WorkspaceType;
 }
 
@@ -21,15 +23,11 @@ function prepareAgentConfigurationForDisplay(
   );
 }
 
-export function AssistantsDataTable({ owner }: AssistantsDataTableProps) {
-  const {
-    agentConfigurations,
-    isAgentConfigurationsLoading,
-    mutateAgentConfigurations,
-  } = useAgentConfigurations({
-    workspaceId: owner.sId,
-    agentsGetView: "admin_internal",
-  });
+export function AssistantsDataTable({
+  owner,
+  agentConfigurations,
+}: AssistantsDataTableProps) {
+  const router = useRouter();
 
   return (
     <div className="border-material-200 my-4 flex flex-col rounded-lg border p-4">
@@ -38,10 +36,9 @@ export function AssistantsDataTable({ owner }: AssistantsDataTableProps) {
         columns={makeColumnsForAssistants(
           owner,
           agentConfigurations,
-          mutateAgentConfigurations
+          router.reload
         )}
         data={prepareAgentConfigurationForDisplay(agentConfigurations)}
-        isLoading={isAgentConfigurationsLoading}
       />
     </div>
   );

--- a/front/pages/poke/[wId]/index.tsx
+++ b/front/pages/poke/[wId]/index.tsx
@@ -558,7 +558,10 @@ const WorkspacePage = ({
                 dataSources={dataSources}
                 agentConfigurations={agentConfigurations}
               />
-              <AssistantsDataTable owner={owner} />
+              <AssistantsDataTable
+                owner={owner}
+                agentConfigurations={agentConfigurations}
+              />
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Description

This PR resolves the broken assistants table in Poke, introduced in [https://github.com/dust-tt/dust/pull/4038](https://github.com/dust-tt/dust/pull/4038). The issue arises from using hooks that do not support dust admin access. This PR updates the code to use the previous server-side props.
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
