### PR TITLE
fix: add missing index on dust-db-store

### DIFF
--- a/core/src/databases_store/store.rs
+++ b/core/src/databases_store/store.rs
@@ -236,5 +236,7 @@ pub const POSTGRES_TABLES: [&'static str; 1] = [
  );",
 ];
 
-pub const SQL_INDEXES: [&'static str; 1] =
-    ["CREATE UNIQUE INDEX IF NOT EXISTS tables_rows_unique ON tables_rows (row_id, table_id);"];
+pub const SQL_INDEXES: [&'static str; 2] = [
+    "CREATE UNIQUE INDEX IF NOT EXISTS tables_rows_unique ON tables_rows (row_id, table_id);",
+    "CREATE INDEX IF NOT EXISTS tables_rows_table_id ON tables_rows (table_id);",
+];


### PR DESCRIPTION
## Description

CPU for db store is very high, because the `DELETE` we do is based on `table_id` and we don't have an index on it.
This PR simply adds the index, but the right (future) fix is to change the unique index to have `table_id` first, so we won't need the second index

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
