### PR TITLE
Intercom: Add parent teams to parents of a conversation

### DIFF
--- a/connectors/src/connectors/intercom/temporal/sync_conversation.ts
+++ b/connectors/src/connectors/intercom/temporal/sync_conversation.ts
@@ -11,6 +11,7 @@ import {
   getConversationInAppUrl,
   getConversationInternalId,
   getTeamInternalId,
+  getTeamsInternalId,
 } from "@connectors/connectors/intercom/lib/utils";
 import { concurrentExecutor } from "@connectors/lib/async_utils";
 import {
@@ -279,7 +280,10 @@ export async function syncConversation({
       `createdAt:${createdAtDate.getTime()}`,
       `updatedAt:${updatedAtDate.getTime()}`,
     ],
-    parents: [getTeamInternalId(connectorId, team.teamId)],
+    parents: [
+      getTeamInternalId(connectorId, team.teamId),
+      getTeamsInternalId(connectorId),
+    ],
     loggerArgs: {
       ...loggerArgs,
       conversationId: conversation.id,


### PR DESCRIPTION
## Description

This fixes a bug on Intercom, when "Conversations" parent is selected and not the children Teams directly, it retrieves nothing. This is because my datasources are missing the Teams parent. 

A conversation has its Team as parent and it should also have all teams as parent. 

## Risk

Low

## Deploy Plan

Need to fully resync all Intercom connectors. 