### PR TITLE
connectors: bump concurrency

### DIFF
--- a/connectors/src/connectors/confluence/temporal/worker.ts
+++ b/connectors/src/connectors/confluence/temporal/worker.ts
@@ -15,7 +15,7 @@ export async function runConfluenceWorker() {
     workflowsPath: require.resolve("./workflows"),
     activities: { ...activities, ...sync_status },
     taskQueue: QUEUE_NAME,
-    maxConcurrentActivityTaskExecutions: 4,
+    maxConcurrentActivityTaskExecutions: 16,
     connection,
     namespace,
     interceptors: {

--- a/connectors/src/connectors/github/temporal/worker.ts
+++ b/connectors/src/connectors/github/temporal/worker.ts
@@ -14,7 +14,7 @@ export async function runGithubWorker() {
     workflowsPath: require.resolve("./workflows"),
     activities,
     taskQueue: QUEUE_NAME,
-    maxConcurrentActivityTaskExecutions: 3,
+    maxConcurrentActivityTaskExecutions: 16,
     connection,
     namespace,
     interceptors: {

--- a/connectors/src/connectors/intercom/temporal/worker.ts
+++ b/connectors/src/connectors/intercom/temporal/worker.ts
@@ -13,7 +13,7 @@ export async function runIntercomWorker() {
     workflowsPath: require.resolve("./workflows"),
     activities,
     taskQueue: QUEUE_NAME,
-    maxConcurrentActivityTaskExecutions: 4,
+    maxConcurrentActivityTaskExecutions: 16,
     connection,
     namespace,
     interceptors: {

--- a/connectors/src/connectors/slack/temporal/worker.ts
+++ b/connectors/src/connectors/slack/temporal/worker.ts
@@ -16,7 +16,7 @@ export async function runSlackWorker() {
     taskQueue: QUEUE_NAME,
     connection,
     namespace,
-    maxConcurrentActivityTaskExecutions: 3,
+    maxConcurrentActivityTaskExecutions: 16,
     interceptors: {
       activityInbound: [
         (ctx: Context) => {

--- a/connectors/src/connectors/webcrawler/temporal/worker.ts
+++ b/connectors/src/connectors/webcrawler/temporal/worker.ts
@@ -16,7 +16,7 @@ export async function runWebCrawlerWorker() {
     taskQueue: QUEUE_NAME,
     connection,
     namespace,
-    maxConcurrentActivityTaskExecutions: 3,
+    maxConcurrentActivityTaskExecutions: 16,
     interceptors: {
       activityInbound: [
         (ctx: Context) => {


### PR DESCRIPTION
## Description

Following the roll-out of the uspert queue.

Bumps concurrency of
- Confluence
- Github
- Intercom
- Slack
- WebCrawler

Skipping Notion and GDrive for now due to Tables ingestion

## Risk

Might create some unexpected behavior we'll closely monitor

## Deploy Plan

- deploy `connectors`