### PR TITLE
fix(csv upload): don't alter empty header cells

### DIFF
--- a/types/src/shared/utils/structured_data.ts
+++ b/types/src/shared/utils/structured_data.ts
@@ -11,7 +11,7 @@ export function getSanitizedHeaders(rawHeaders: string[]) {
   return rawHeaders.reduce<string[]>((acc, curr) => {
     const slugifiedName = slugify(curr);
 
-    if (!acc.includes(slugifiedName)) {
+    if (!acc.includes(slugifiedName) || !slugifiedName.length) {
       acc.push(slugifiedName);
     } else {
       let conflictResolved = false;


### PR DESCRIPTION
## Description

CSV upload from front currently breaks when there are empty columns, because we attempt to sanitize empty header cells (as if they were duplicates).

```
my_cool_column;;
2022-01-01;;
```

would result in 

```
my_cool_column,"","_2"
2022-01-01,,
```


We just skip sanitizing empty cells on the frontend (it's properly handled downstream)

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
