### PR TITLE
Assistant Builder: Tree component for datasources

### DIFF
--- a/front/components/DataSourceResourceSelectorTree.tsx
+++ b/front/components/DataSourceResourceSelectorTree.tsx
@@ -6,7 +6,11 @@ import {
   DocumentTextIcon,
   Spinner,
 } from "@dust-tt/sparkle";
-import type { DataSourceType, WorkspaceType } from "@dust-tt/types";
+import type {
+  ConnectorNode,
+  DataSourceType,
+  WorkspaceType,
+} from "@dust-tt/types";
 import type { ConnectorNodeType, ConnectorPermission } from "@dust-tt/types";
 import { CircleStackIcon, FolderIcon } from "@heroicons/react/20/solid";
 import { useState } from "react";
@@ -29,7 +33,8 @@ export default function DataSourceResourceSelectorTree({
   expandable: boolean;
   selectedParentIds: Set<string>;
   onSelectChange: (
-    resource: { resourceId: string; resourceName: string; parents: string[] },
+    resource: ConnectorNode,
+    parents: string[],
     selected: boolean
   ) => void;
   parentsById: Record<string, Set<string>>;
@@ -99,7 +104,8 @@ function DataSourceResourceSelectorChildren({
   selectedParentIds: Set<string>;
   parents: string[];
   onSelectChange: (
-    resource: { resourceId: string; resourceName: string; parents: string[] },
+    resource: ConnectorNode,
+    parents: string[],
     selected: boolean
   ) => void;
   parentsById: Record<string, Set<string>>;
@@ -201,14 +207,7 @@ function DataSourceResourceSelectorChildren({
                       checked={checkStatus === "checked"}
                       partialChecked={checkStatus === "partial"}
                       onChange={(checked) =>
-                        onSelectChange(
-                          {
-                            resourceId: r.internalId,
-                            resourceName: r.title,
-                            parents: parents,
-                          },
-                          checked
-                        )
+                        onSelectChange(r, parents, checked)
                       }
                       disabled={isChecked || fullySelected}
                     />

--- a/front/components/ManagedDataSourceDocumentModal.tsx
+++ b/front/components/ManagedDataSourceDocumentModal.tsx
@@ -10,7 +10,7 @@ export default function ManagedDataSourceDocumentModal({
   setOpen,
 }: {
   owner: WorkspaceType;
-  dataSource: DataSourceType;
+  dataSource: DataSourceType | null;
   documentId: string | null;
   isOpen: boolean;
   setOpen: (open: boolean) => void;
@@ -20,7 +20,7 @@ export default function ManagedDataSourceDocumentModal({
   const [downloading, setDownloading] = useState(false);
 
   useEffect(() => {
-    if (documentId) {
+    if (documentId && dataSource?.name) {
       setDownloading(true);
       fetch(
         `/api/w/${owner.sId}/data_sources/${encodeURIComponent(
@@ -42,7 +42,7 @@ export default function ManagedDataSourceDocumentModal({
         })
         .catch((e) => console.error(e));
     }
-  }, [dataSource.name, documentId, owner.sId]);
+  }, [dataSource, documentId, owner.sId]);
 
   function closeModal() {
     setOpen(false);

--- a/front/components/assistant/SlackIntegration.tsx
+++ b/front/components/assistant/SlackIntegration.tsx
@@ -71,7 +71,7 @@ export function SlackIntegration({
             dataSource={slackDataSource}
             selectedParentIds={selectedChannelIds}
             parentsById={{}}
-            onSelectChange={({ resourceId, resourceName }, selected) => {
+            onSelectChange={(node, selected) => {
               setHasChanged(true);
 
               if (selected) {
@@ -81,8 +81,8 @@ export function SlackIntegration({
                     finalState.push(...sel);
                   }
                   finalState.push({
-                    slackChannelId: resourceId,
-                    slackChannelName: resourceName,
+                    slackChannelId: node.internalId,
+                    slackChannelName: node.title,
                   });
 
                   return finalState;
@@ -95,7 +95,7 @@ export function SlackIntegration({
                   }
                   finalState.splice(
                     finalState.findIndex(
-                      (c) => c.slackChannelId === resourceId
+                      (c) => c.slackChannelId === node.internalId
                     ),
                     1
                   );

--- a/front/components/assistant_builder/ActionScreen.tsx
+++ b/front/components/assistant_builder/ActionScreen.tsx
@@ -30,7 +30,6 @@ import { TIME_FRAME_UNIT_TO_LABEL } from "@app/components/assistant_builder/shar
 import TablesSelectionSection from "@app/components/assistant_builder/TablesSelectionSection";
 import type {
   ActionMode,
-  AssistantBuilderDataSourceConfiguration,
   AssistantBuilderState,
 } from "@app/components/assistant_builder/types";
 import { tableKey } from "@app/lib/client/tables_query";
@@ -142,14 +141,8 @@ export default function ActionScreen({
   timeFrameError: string | null;
 }) {
   const [showDataSourcesModal, setShowDataSourcesModal] = useState(false);
-  const [dataSourceToManage, setDataSourceToManage] =
-    useState<AssistantBuilderDataSourceConfiguration | null>(null);
   const [showDustAppsModal, setShowDustAppsModal] = useState(false);
   const [showTableModal, setShowTableModal] = useState(false);
-
-  const configurableDataSources = dataSources.filter(
-    (dataSource) => !builderState.dataSourceConfigurations[dataSource.name]
-  );
 
   const deleteDataSource = (name: string) => {
     setEdited(true);
@@ -197,7 +190,7 @@ export default function ActionScreen({
   };
 
   const noDataSources =
-    configurableDataSources.length === 0 &&
+    dataSources.length === 0 &&
     Object.keys(builderState.dataSourceConfigurations).length === 0;
   const noDustApp = dustApps.length === 0;
 
@@ -207,9 +200,6 @@ export default function ActionScreen({
         isOpen={showDustAppsModal}
         setOpen={(isOpen) => {
           setShowDustAppsModal(isOpen);
-          if (!isOpen) {
-            setDataSourceToManage(null);
-          }
         }}
         dustApps={dustApps}
         onSave={({ app }) => {
@@ -243,12 +233,9 @@ export default function ActionScreen({
         isOpen={showDataSourcesModal}
         setOpen={(isOpen) => {
           setShowDataSourcesModal(isOpen);
-          if (!isOpen) {
-            setDataSourceToManage(null);
-          }
         }}
         owner={owner}
-        dataSources={configurableDataSources}
+        dataSources={dataSources}
         onSave={({ dataSource, selectedResources, isSelectAll }) => {
           setEdited(true);
           setBuilderState((state) => ({
@@ -263,7 +250,8 @@ export default function ActionScreen({
             },
           }));
         }}
-        dataSourceToManage={dataSourceToManage}
+        onDelete={deleteDataSource}
+        dataSourceConfigurations={builderState.dataSourceConfigurations}
       />
       <div className="flex flex-col gap-4 text-sm text-element-700">
         <div className="flex flex-col gap-2">
@@ -414,7 +402,6 @@ export default function ActionScreen({
                   <DropdownMenu.Items origin="topLeft" width={260}>
                     {SEARCH_MODES.filter((key) => {
                       const flag = SEARCH_MODE_SPECIFICATIONS[key].flag;
-                      console.log(owner.flags);
                       return flag === null || owner.flags.includes(flag);
                     }).map((key) => (
                       <DropdownMenu.Item
@@ -451,17 +438,12 @@ export default function ActionScreen({
           }
         >
           <DataSourceSelectionSection
+            owner={owner}
             dataSourceConfigurations={builderState.dataSourceConfigurations}
             openDataSourceModal={() => {
               setShowDataSourcesModal(true);
             }}
-            canAddDataSource={configurableDataSources.length > 0}
-            onManageDataSource={(name) => {
-              setDataSourceToManage(
-                builderState.dataSourceConfigurations[name]
-              );
-              setShowDataSourcesModal(true);
-            }}
+            canAddDataSource={dataSources.length > 0}
             onDelete={deleteDataSource}
           />
         </ActionModeSection>
@@ -472,17 +454,12 @@ export default function ActionScreen({
           }
         >
           <DataSourceSelectionSection
+            owner={owner}
             dataSourceConfigurations={builderState.dataSourceConfigurations}
             openDataSourceModal={() => {
               setShowDataSourcesModal(true);
             }}
-            canAddDataSource={configurableDataSources.length > 0}
-            onManageDataSource={(name) => {
-              setDataSourceToManage(
-                builderState.dataSourceConfigurations[name]
-              );
-              setShowDataSourcesModal(true);
-            }}
+            canAddDataSource={dataSources.length > 0}
             onDelete={deleteDataSource}
           />
           <div className={"flex flex-row items-center gap-4 pb-4"}>

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -603,7 +603,12 @@ async function submitForm({
             workspaceId: owner.sId,
             filter: {
               parents: !isSelectAll
-                ? { in: Object.keys(selectedResources), not: [] }
+                ? {
+                    in: selectedResources.map(
+                      (resource) => resource.internalId
+                    ),
+                    not: [],
+                  }
                 : null,
               tags: null,
             },

--- a/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
+++ b/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
@@ -7,14 +7,21 @@ import {
   Searchbar,
   SliderToggle,
 } from "@dust-tt/sparkle";
-import type { ConnectorProvider, DataSourceType } from "@dust-tt/types";
+import type {
+  ConnectorNode,
+  ConnectorProvider,
+  DataSourceType,
+} from "@dust-tt/types";
 import type { WorkspaceType } from "@dust-tt/types";
 import { assertNever } from "@dust-tt/types";
 import { Transition } from "@headlessui/react";
 import * as React from "react";
 import { useCallback, useEffect, useState } from "react";
 
-import type { AssistantBuilderDataSourceConfiguration } from "@app/components/assistant_builder/types";
+import type {
+  AssistantBuilderDataSourceConfiguration,
+  AssistantBuilderDataSourceConfigurations,
+} from "@app/components/assistant_builder/types";
 import DataSourceResourceSelectorTree from "@app/components/DataSourceResourceSelectorTree";
 import { orderDatasourceByImportance } from "@app/lib/assistant";
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
@@ -43,33 +50,27 @@ export default function AssistantBuilderDataSourceModal({
   owner,
   dataSources,
   onSave,
-  dataSourceToManage,
+  onDelete,
+  dataSourceConfigurations,
 }: {
   isOpen: boolean;
   setOpen: (isOpen: boolean) => void;
   owner: WorkspaceType;
   dataSources: DataSourceType[];
   onSave: (params: AssistantBuilderDataSourceConfiguration) => void;
-  dataSourceToManage: AssistantBuilderDataSourceConfiguration | null;
+  onDelete: (name: string) => void;
+  dataSourceConfigurations: AssistantBuilderDataSourceConfigurations;
 }) {
   const [selectedDataSource, setSelectedDataSource] =
     useState<DataSourceType | null>(null);
-  const [selectedResources, setSelectedResources] = useState<
-    Record<string, string>
-  >({});
+  const [selectedResources, setSelectedResources] = useState<ConnectorNode[]>(
+    []
+  );
   const [isSelectAll, setIsSelectAll] = useState(false);
-
-  useEffect(() => {
-    if (dataSourceToManage) {
-      setSelectedDataSource(dataSourceToManage.dataSource);
-      setSelectedResources(dataSourceToManage.selectedResources);
-      setIsSelectAll(dataSourceToManage.isSelectAll);
-    }
-  }, [dataSourceToManage]);
 
   const onReset = () => {
     setSelectedDataSource(null);
-    setSelectedResources({});
+    setSelectedResources([]);
     setIsSelectAll(false);
   };
 
@@ -81,43 +82,48 @@ export default function AssistantBuilderDataSourceModal({
   };
 
   const onSaveLocal = ({ isSelectAll }: { isSelectAll: boolean }) => {
-    if (
-      !selectedDataSource ||
-      (Object.keys(selectedResources).length === 0 && !isSelectAll)
-    ) {
+    if (!selectedDataSource) {
       throw new Error("Cannot save an incomplete configuration");
     }
-    onSave({
-      dataSource: selectedDataSource,
-      selectedResources,
-      isSelectAll,
-    });
+    if (selectedResources.length) {
+      onSave({
+        dataSource: selectedDataSource,
+        selectedResources,
+        isSelectAll,
+      });
+    } else {
+      onDelete(selectedDataSource.name);
+    }
+
     onClose();
   };
 
   return (
     <Modal
       isOpen={isOpen}
-      onClose={selectedDataSource && !dataSourceToManage ? onReset : onClose}
+      onClose={selectedDataSource !== null ? onReset : onClose}
       onSave={() => onSaveLocal({ isSelectAll })}
-      hasChanged={
-        !!selectedDataSource &&
-        (Object.keys(selectedResources).length > 0 || isSelectAll)
-      }
+      hasChanged={selectedDataSource !== null}
       variant="full-screen"
-      title="Add data sources"
+      title="Manage data sources selection"
     >
       <div className="w-full pt-12">
         {!selectedDataSource || !selectedDataSource.connectorProvider ? (
           <PickDataSource
             dataSources={dataSources}
-            show={!dataSourceToManage}
+            show={!selectedDataSource}
             onPick={(ds) => {
               setSelectedDataSource(ds);
+              setSelectedResources(
+                dataSourceConfigurations[ds.name]?.selectedResources || []
+              );
+              setIsSelectAll(
+                dataSourceConfigurations[ds.name]?.isSelectAll || false
+              );
               if (!ds.connectorProvider) {
                 onSave({
                   dataSource: ds,
-                  selectedResources: {},
+                  selectedResources: [],
                   isSelectAll: true,
                 });
                 onClose();
@@ -126,22 +132,34 @@ export default function AssistantBuilderDataSourceModal({
           />
         ) : (
           <DataSourceResourceSelector
-            dataSource={dataSourceToManage?.dataSource ?? selectedDataSource}
+            dataSource={selectedDataSource}
             owner={owner}
             selectedResources={selectedResources}
             isSelectAll={isSelectAll}
-            onSelectChange={({ resourceId, resourceName }, selected) => {
-              const newSelectedResources = { ...selectedResources };
-              if (selected) {
-                newSelectedResources[resourceId] = resourceName;
-              } else {
-                delete newSelectedResources[resourceId];
-              }
-
-              setSelectedResources(newSelectedResources);
+            onSelectChange={(node, selected) => {
+              setSelectedResources((currentResources) => {
+                const isNodeAlreadySelected = currentResources.some(
+                  (resource) => resource.internalId === node.internalId
+                );
+                if (selected) {
+                  if (!isNodeAlreadySelected) {
+                    return [...currentResources, node];
+                  }
+                } else {
+                  if (isNodeAlreadySelected) {
+                    return currentResources.filter(
+                      (resource) => resource.internalId !== node.internalId
+                    );
+                  }
+                }
+                return currentResources;
+              });
             }}
             toggleSelectAll={() => {
               const selectAll = !isSelectAll;
+              if (isSelectAll === false) {
+                setSelectedResources([]);
+              }
               setIsSelectAll(selectAll);
             }}
           />
@@ -208,12 +226,9 @@ function DataSourceResourceSelector({
 }: {
   dataSource: DataSourceType | null;
   owner: WorkspaceType;
-  selectedResources: Record<string, string>;
+  selectedResources: ConnectorNode[];
   isSelectAll: boolean;
-  onSelectChange: (
-    resource: { resourceId: string; resourceName: string },
-    selected: boolean
-  ) => void;
+  onSelectChange: (resource: ConnectorNode, selected: boolean) => void;
   toggleSelectAll: () => void;
 }) {
   const [parentsById, setParentsById] = useState<Record<string, Set<string>>>(
@@ -235,7 +250,9 @@ function DataSourceResourceSelector({
             "Content-Type": "application/json",
           },
           body: JSON.stringify({
-            internalIds: Object.keys(selectedResources),
+            internalIds: selectedResources.map((resource) => {
+              return resource.internalId;
+            }),
           }),
         }
       );
@@ -257,7 +274,7 @@ function DataSourceResourceSelector({
   }, [owner, dataSource?.name, selectedResources]);
 
   const hasParentsById = Object.keys(parentsById || {}).length > 0;
-  const hasSelectedResources = Object.keys(selectedResources).length > 0;
+  const hasSelectedResources = selectedResources.length > 0;
 
   useEffect(() => {
     if (parentsAreLoading || parentsAreError) {
@@ -316,21 +333,21 @@ function DataSourceResourceSelector({
                     dataSource.connectorProvider as ConnectorProvider
                   ]?.isNested
                 }
-                selectedParentIds={new Set(Object.keys(selectedResources))}
+                selectedParentIds={
+                  new Set(
+                    selectedResources.map((resource) => resource.internalId)
+                  )
+                }
                 parentsById={parentsById}
-                onSelectChange={(
-                  { resourceId, resourceName, parents },
-                  selected
-                ) => {
+                onSelectChange={(node, parents, selected) => {
                   const newParentsById = { ...parentsById };
                   if (selected) {
-                    newParentsById[resourceId] = new Set(parents);
+                    newParentsById[node.internalId] = new Set(parents);
                   } else {
-                    delete newParentsById[resourceId];
+                    delete newParentsById[node.internalId];
                   }
-
                   setParentsById(newParentsById);
-                  onSelectChange({ resourceId, resourceName }, selected);
+                  onSelectChange(node, selected);
                 }}
                 fullySelected={isSelectAll}
               />

--- a/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
+++ b/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
@@ -85,7 +85,7 @@ export default function AssistantBuilderDataSourceModal({
     if (!selectedDataSource) {
       throw new Error("Cannot save an incomplete configuration");
     }
-    if (selectedResources.length) {
+    if (selectedResources.length || isSelectAll) {
       onSave({
         dataSource: selectedDataSource,
         selectedResources,

--- a/front/components/assistant_builder/DataSourceSelectionSection.tsx
+++ b/front/components/assistant_builder/DataSourceSelectionSection.tsx
@@ -131,7 +131,10 @@ export default function DataSourceSelectionSection({
                               : true,
                           }));
                         }}
-                        label={selectedResource.title}
+                        label={
+                          selectedResource.titleWithParentsContext ??
+                          selectedResource.title
+                        }
                         type={selectedResource.expandable ? "node" : "leaf"}
                         variant={selectedResource.type}
                         className="whitespace-nowrap"

--- a/front/components/assistant_builder/DataSourceSelectionSection.tsx
+++ b/front/components/assistant_builder/DataSourceSelectionSection.tsx
@@ -1,122 +1,162 @@
-import {
-  Button,
-  CloudArrowDownIcon,
-  Cog6ToothIcon,
-  ContextItem,
-  TrashIcon,
-} from "@dust-tt/sparkle";
+import { Button, Tree } from "@dust-tt/sparkle";
+import type { DataSourceType, WorkspaceType } from "@dust-tt/types";
+import { useState } from "react";
 
-import { CONNECTOR_PROVIDER_TO_RESOURCE_NAME } from "@app/components/assistant_builder/shared";
 import type { AssistantBuilderDataSourceConfiguration } from "@app/components/assistant_builder/types";
+import { PermissionTreeChildren } from "@app/components/ConnectorPermissionsTree";
 import { EmptyCallToAction } from "@app/components/EmptyCallToAction";
+import ManagedDataSourceDocumentModal from "@app/components/ManagedDataSourceDocumentModal";
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 import { getDisplayNameForDataSource } from "@app/lib/data_sources";
+import { useConnectorPermissions } from "@app/lib/swr";
 
 export default function DataSourceSelectionSection({
+  owner,
   dataSourceConfigurations,
   openDataSourceModal,
   canAddDataSource,
-  onManageDataSource,
-  onDelete,
 }: {
+  owner: WorkspaceType;
   dataSourceConfigurations: Record<
     string,
     AssistantBuilderDataSourceConfiguration
   >;
   openDataSourceModal: () => void;
   canAddDataSource: boolean;
-  onManageDataSource: (name: string) => void;
   onDelete?: (name: string) => void;
 }) {
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+  const [documentToDisplay, setDocumentToDisplay] = useState<string | null>(
+    null
+  );
+  const [dataSourceToDisplay, setDataSourceToDisplay] =
+    useState<DataSourceType | null>();
+
   return (
-    <div className="overflow-hidden pt-6">
-      <div className="flex flex-row items-start">
-        <div className="flex-grow" />
-        {Object.keys(dataSourceConfigurations).length > 0 && (
-          <Button
-            labelVisible={true}
-            label="Add data sources"
-            variant="primary"
-            size="sm"
+    <>
+      {dataSourceToDisplay && (
+        <ManagedDataSourceDocumentModal
+          owner={owner}
+          dataSource={dataSourceToDisplay}
+          documentId={documentToDisplay}
+          isOpen={!!documentToDisplay}
+          setOpen={(open) => {
+            if (!open) {
+              setDocumentToDisplay(null);
+            }
+          }}
+        />
+      )}
+      <div className="overflow-hidden pt-6">
+        <div className="flex flex-row items-start">
+          <div className="flex-grow text-sm font-semibold text-element-900">
+            Data sources:
+          </div>
+          <div>
+            {Object.keys(dataSourceConfigurations).length > 0 && (
+              <Button
+                labelVisible={true}
+                label="Manage selection"
+                variant="primary"
+                size="sm"
+                onClick={openDataSourceModal}
+                disabled={!canAddDataSource}
+                hasMagnifying={false}
+              />
+            )}
+          </div>
+        </div>
+        {!Object.keys(dataSourceConfigurations).length ? (
+          <EmptyCallToAction
+            label="Select Data Sources"
             onClick={openDataSourceModal}
             disabled={!canAddDataSource}
-            hasMagnifying={false}
           />
+        ) : (
+          <Tree>
+            {Object.values(dataSourceConfigurations).map((dsConfig) => {
+              const LogoComponent = dsConfig.dataSource?.connectorProvider
+                ? CONNECTOR_CONFIGURATIONS[
+                    dsConfig.dataSource.connectorProvider
+                  ].logoComponent
+                : null;
+              return (
+                <Tree.Item
+                  key={dsConfig.dataSource.id}
+                  collapsed={!expanded[dsConfig.dataSource.id]}
+                  onChevronClick={() => {
+                    setExpanded((prev) => ({
+                      ...prev,
+                      [dsConfig.dataSource.id]: prev[dsConfig.dataSource.id]
+                        ? false
+                        : true,
+                    }));
+                  }}
+                  type="node"
+                  label={getDisplayNameForDataSource(dsConfig.dataSource)}
+                  visual={
+                    LogoComponent ? (
+                      <LogoComponent className="s-h-5 s-w-5" />
+                    ) : null
+                  }
+                  variant="folder" // in case LogoComponent is null
+                  className="whitespace-nowrap"
+                >
+                  {dsConfig.isSelectAll && (
+                    <PermissionTreeChildren
+                      owner={owner}
+                      dataSource={dsConfig.dataSource}
+                      parentId={null}
+                      permissionFilter="read"
+                      canUpdatePermissions={true}
+                      displayDocumentSource={(documentId: string) => {
+                        setDataSourceToDisplay(dsConfig.dataSource);
+                        setDocumentToDisplay(documentId);
+                      }}
+                      useConnectorPermissionsHook={useConnectorPermissions}
+                    />
+                  )}
+                  {dsConfig.selectedResources.map((selectedResource) => {
+                    return (
+                      <Tree.Item
+                        key={selectedResource.internalId}
+                        collapsed={!expanded[selectedResource.internalId]}
+                        onChevronClick={() => {
+                          setExpanded((prev) => ({
+                            ...prev,
+                            [selectedResource.internalId]: prev[
+                              selectedResource.internalId
+                            ]
+                              ? false
+                              : true,
+                          }));
+                        }}
+                        label={selectedResource.title}
+                        type={selectedResource.expandable ? "node" : "leaf"}
+                        variant={selectedResource.type}
+                        className="whitespace-nowrap"
+                      >
+                        <PermissionTreeChildren
+                          owner={owner}
+                          dataSource={dsConfig.dataSource}
+                          parentId={selectedResource.internalId}
+                          permissionFilter="read"
+                          canUpdatePermissions={true}
+                          displayDocumentSource={(documentId: string) => {
+                            setDataSourceToDisplay(dsConfig.dataSource);
+                            setDocumentToDisplay(documentId);
+                          }}
+                          useConnectorPermissionsHook={useConnectorPermissions}
+                        />
+                      </Tree.Item>
+                    );
+                  })}
+                </Tree.Item>
+              );
+            })}
+          </Tree>
         )}
       </div>
-      {!Object.keys(dataSourceConfigurations).length ? (
-        <EmptyCallToAction
-          label="Select Data Sources"
-          onClick={openDataSourceModal}
-          disabled={!canAddDataSource}
-        />
-      ) : (
-        <ContextItem.List className="mt-6 border-b border-t border-structure-200">
-          {Object.entries(dataSourceConfigurations).map(
-            ([key, { dataSource, selectedResources, isSelectAll }]) => {
-              const selectedParentIds = Object.keys(selectedResources);
-              return (
-                <ContextItem
-                  key={key}
-                  title={getDisplayNameForDataSource(dataSource)}
-                  visual={
-                    <ContextItem.Visual
-                      visual={
-                        dataSource.connectorProvider
-                          ? CONNECTOR_CONFIGURATIONS[
-                              dataSource.connectorProvider
-                            ].logoComponent
-                          : CloudArrowDownIcon
-                      }
-                    />
-                  }
-                  action={
-                    <Button.List>
-                      <Button
-                        icon={TrashIcon}
-                        variant="secondaryWarning"
-                        label="Remove"
-                        labelVisible={false}
-                        onClick={() => {
-                          onDelete?.(key);
-                        }}
-                      />
-                      <Button
-                        variant="secondary"
-                        icon={Cog6ToothIcon}
-                        label="Manage"
-                        size="sm"
-                        onClick={() => {
-                          onManageDataSource(key);
-                        }}
-                        disabled={dataSource.connectorProvider === null}
-                      />
-                    </Button.List>
-                  }
-                >
-                  <ContextItem.Description
-                    description={
-                      dataSource.connectorProvider && !isSelectAll
-                        ? `Assistant has access to ${
-                            selectedParentIds.length
-                          } ${
-                            selectedParentIds.length === 1
-                              ? CONNECTOR_PROVIDER_TO_RESOURCE_NAME[
-                                  dataSource.connectorProvider
-                                ].singular
-                              : CONNECTOR_PROVIDER_TO_RESOURCE_NAME[
-                                  dataSource.connectorProvider
-                                ].plural
-                          }`
-                        : "Assistant has access to all documents"
-                    }
-                  />
-                </ContextItem>
-              );
-            }
-          )}
-        </ContextItem.List>
-      )}
-    </div>
+    </>
   );
 }

--- a/front/components/assistant_builder/DataSourceSelectionSection.tsx
+++ b/front/components/assistant_builder/DataSourceSelectionSection.tsx
@@ -1,4 +1,10 @@
-import { Button, Tree } from "@dust-tt/sparkle";
+import {
+  BracesIcon,
+  Button,
+  ExternalLinkIcon,
+  IconButton,
+  Tree,
+} from "@dust-tt/sparkle";
 import type { DataSourceType, WorkspaceType } from "@dust-tt/types";
 import { useState } from "react";
 
@@ -9,6 +15,7 @@ import ManagedDataSourceDocumentModal from "@app/components/ManagedDataSourceDoc
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 import { getDisplayNameForDataSource } from "@app/lib/data_sources";
 import { useConnectorPermissions } from "@app/lib/swr";
+import { classNames } from "@app/lib/utils";
 
 export default function DataSourceSelectionSection({
   owner,
@@ -30,23 +37,22 @@ export default function DataSourceSelectionSection({
     null
   );
   const [dataSourceToDisplay, setDataSourceToDisplay] =
-    useState<DataSourceType | null>();
+    useState<DataSourceType | null>(null);
 
   return (
     <>
-      {dataSourceToDisplay && (
-        <ManagedDataSourceDocumentModal
-          owner={owner}
-          dataSource={dataSourceToDisplay}
-          documentId={documentToDisplay}
-          isOpen={!!documentToDisplay}
-          setOpen={(open) => {
-            if (!open) {
-              setDocumentToDisplay(null);
-            }
-          }}
-        />
-      )}
+      <ManagedDataSourceDocumentModal
+        owner={owner}
+        dataSource={dataSourceToDisplay}
+        documentId={documentToDisplay}
+        isOpen={!!documentToDisplay}
+        setOpen={(open) => {
+          if (!open) {
+            setDocumentToDisplay(null);
+          }
+        }}
+      />
+
       <div className="overflow-hidden pt-6">
         <div className="flex flex-row items-start">
           <div className="flex-grow text-sm font-semibold text-element-900">
@@ -116,33 +122,63 @@ export default function DataSourceSelectionSection({
                       useConnectorPermissionsHook={useConnectorPermissions}
                     />
                   )}
-                  {dsConfig.selectedResources.map((selectedResource) => {
+                  {dsConfig.selectedResources.map((node) => {
                     return (
                       <Tree.Item
-                        key={selectedResource.internalId}
-                        collapsed={!expanded[selectedResource.internalId]}
+                        key={node.internalId}
+                        collapsed={!expanded[node.internalId]}
                         onChevronClick={() => {
                           setExpanded((prev) => ({
                             ...prev,
-                            [selectedResource.internalId]: prev[
-                              selectedResource.internalId
-                            ]
+                            [node.internalId]: prev[node.internalId]
                               ? false
                               : true,
                           }));
                         }}
-                        label={
-                          selectedResource.titleWithParentsContext ??
-                          selectedResource.title
-                        }
-                        type={selectedResource.expandable ? "node" : "leaf"}
-                        variant={selectedResource.type}
+                        label={node.titleWithParentsContext ?? node.title}
+                        type={node.expandable ? "node" : "leaf"}
+                        variant={node.type}
                         className="whitespace-nowrap"
+                        actions={
+                          <div className="mr-8 flex flex-row gap-2">
+                            <IconButton
+                              size="xs"
+                              icon={ExternalLinkIcon}
+                              onClick={() => {
+                                if (node.sourceUrl) {
+                                  window.open(node.sourceUrl, "_blank");
+                                }
+                              }}
+                              className={classNames(
+                                node.sourceUrl
+                                  ? ""
+                                  : "pointer-events-none opacity-0"
+                              )}
+                              disabled={!node.sourceUrl}
+                            />
+                            <IconButton
+                              size="xs"
+                              icon={BracesIcon}
+                              onClick={() => {
+                                if (node.dustDocumentId) {
+                                  setDataSourceToDisplay(dsConfig.dataSource);
+                                  setDocumentToDisplay(node.dustDocumentId);
+                                }
+                              }}
+                              className={classNames(
+                                node.dustDocumentId
+                                  ? ""
+                                  : "pointer-events-none opacity-0"
+                              )}
+                              disabled={!node.dustDocumentId}
+                            />
+                          </div>
+                        }
                       >
                         <PermissionTreeChildren
                           owner={owner}
                           dataSource={dsConfig.dataSource}
-                          parentId={selectedResource.internalId}
+                          parentId={node.internalId}
                           permissionFilter="read"
                           canUpdatePermissions={true}
                           displayDocumentSource={(documentId: string) => {

--- a/front/components/assistant_builder/server_side_props_helpers.ts
+++ b/front/components/assistant_builder/server_side_props_helpers.ts
@@ -55,29 +55,23 @@ export async function buildInitialState({
         if (!dataSource.connectorId || !ds.resources) {
           return {
             dataSource: dataSource,
-            selectedResources: {},
+            selectedResources: [],
             isSelectAll: ds.isSelectAll,
           };
         }
         const connectorsAPI = new ConnectorsAPI(logger);
-        const response = await connectorsAPI.getResourcesTitles({
+        const response = await connectorsAPI.getContentNodes({
           connectorId: dataSource.connectorId,
-          resourceInternalIds: ds.resources,
+          internalIds: ds.resources,
         });
 
         if (response.isErr()) {
           throw response.error;
         }
 
-        // key: interalId, value: title
-        const selectedResources: Record<string, string> = {};
-        for (const resource of response.value.resources) {
-          selectedResources[resource.internalId] = resource.title;
-        }
-
         return {
           dataSource: dataSource,
-          selectedResources,
+          selectedResources: response.value.nodes,
           isSelectAll: ds.isSelectAll,
         };
       }

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -1,6 +1,7 @@
 import type {
   AgentConfigurationScope,
   AppType,
+  ConnectorNode,
   DataSourceType,
   SupportedModel,
   TimeframeUnit,
@@ -18,7 +19,7 @@ export type ActionMode = (typeof ACTION_MODES)[number];
 
 export type AssistantBuilderDataSourceConfiguration = {
   dataSource: DataSourceType;
-  selectedResources: Record<string, string>;
+  selectedResources: ConnectorNode[];
   isSelectAll: boolean;
 };
 
@@ -33,13 +34,15 @@ export type AssistantBuilderTableConfiguration = {
   tableName: string;
 };
 
+export type AssistantBuilderDataSourceConfigurations = Record<
+  string,
+  AssistantBuilderDataSourceConfiguration
+>;
+
 // Builder State
 export type AssistantBuilderState = {
   actionMode: ActionMode;
-  dataSourceConfigurations: Record<
-    string,
-    AssistantBuilderDataSourceConfiguration
-  >;
+  dataSourceConfigurations: AssistantBuilderDataSourceConfigurations;
   timeFrame: {
     value: number;
     unit: TimeframeUnit;

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -10301,15 +10301,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@dust-tt/sparkle": {
-<<<<<<< HEAD
       "version": "0.2.105",
       "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.105.tgz",
       "integrity": "sha512-HKeV8pPP/OyY/xJcnI0fZN5wVZZ+Mfyu5q1anuOhHL9O8Xy7SqQrsaFrY5NOsGpz+Qv0olRNvu6BsI/RpmpUfA==",
-=======
-      "version": "0.2.103",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.103.tgz",
-      "integrity": "sha512-QKtBuVShj/WmtrTmkOkn/a6cy7wweh4aFjtx6CV87gAubI/mB4v/KVhjBnBHmbK25QreElKDUaH2/rQjtEO5/w==",
->>>>>>> 0b1041e8 (Assistant Builder: Tree component for datasources)
       "dependencies": {
         "@headlessui/react": "^1.7.17",
         "esbuild": "^0.20.0",

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -10301,9 +10301,15 @@
       "license": "Apache-2.0"
     },
     "node_modules/@dust-tt/sparkle": {
+<<<<<<< HEAD
       "version": "0.2.105",
       "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.105.tgz",
       "integrity": "sha512-HKeV8pPP/OyY/xJcnI0fZN5wVZZ+Mfyu5q1anuOhHL9O8Xy7SqQrsaFrY5NOsGpz+Qv0olRNvu6BsI/RpmpUfA==",
+=======
+      "version": "0.2.103",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.103.tgz",
+      "integrity": "sha512-QKtBuVShj/WmtrTmkOkn/a6cy7wweh4aFjtx6CV87gAubI/mB4v/KVhjBnBHmbK25QreElKDUaH2/rQjtEO5/w==",
+>>>>>>> 0b1041e8 (Assistant Builder: Tree component for datasources)
       "dependencies": {
         "@headlessui/react": "^1.7.17",
         "esbuild": "^0.20.0",

--- a/types/src/front/lib/connectors_api.ts
+++ b/types/src/front/lib/connectors_api.ts
@@ -394,6 +394,33 @@ export class ConnectorsAPI {
     return this._resultFromResponse(res);
   }
 
+  async getContentNodes({
+    connectorId,
+    internalIds,
+  }: {
+    connectorId: string;
+    internalIds: string[];
+  }): Promise<
+    ConnectorsAPIResponse<{
+      nodes: ConnectorNode[];
+    }>
+  > {
+    const res = await fetch(
+      `${CONNECTORS_API}/connectors/${encodeURIComponent(
+        connectorId
+      )}/content_nodes`,
+      {
+        method: "POST",
+        headers: this.getDefaultHeaders(),
+        body: JSON.stringify({
+          internalIds,
+        }),
+      }
+    );
+
+    return this._resultFromResponse(res);
+  }
+
   async linkSlackChannelsWithAgent({
     connectorId,
     slackChannelIds,


### PR DESCRIPTION
## Description

This PR implements the new Tree view in the Assistant Builder, as part of https://github.com/dust-tt/decisions/issues/164

To be tested on Front Edge: https://front-edge.dust.tt/

To be able to build a Tree view, each connector has been updated to expose a function retrieving the ContentNodes linked to a list of internalIds.

There's now a single button to manage all datasources selection (as opposed to a button to add a new, and 2 buttons per connection to edit or remove the selection). 

Here are the changes in the PR: 
- We're calling connector `getContentNodes` over `getResourcesTitles` to retrieve the content associated to the internalIds saved on the AssistantBuilderConfiguration. That means everywhere we now deal with `ConnectorNode[]` over `Record<string, string>`.
- Edit the "Add datasource modal" to be a "Manage selection modal".
- As we don't have a remove button anymore, the "unselect all" with untick all selected resources and if we save with nothing it removes the provider from the selected ones.
- Display the selected datasources as a Tree.

We discussed it IRL so I implemented as discussed but I still think that it will be confusing for users that we display the list of selected items not taking into account that an item is also selected by a parent selection. 


PRs related to this change (no need to look at them, linked for posterity if needed someday): 
https://github.com/dust-tt/dust/pull/4031
https://github.com/dust-tt/dust/pull/4044
https://github.com/dust-tt/dust/pull/4050
https://github.com/dust-tt/dust/pull/4083
https://github.com/dust-tt/dust/pull/4084
https://github.com/dust-tt/dust/pull/4118
https://github.com/dust-tt/dust/pull/4119
https://github.com/dust-tt/dust/pull/4122
https://github.com/dust-tt/dust/pull/4125
https://github.com/dust-tt/dust/pull/4132
https://github.com/dust-tt/dust/pull/4134
https://github.com/dust-tt/dust/pull/4136
https://github.com/dust-tt/dust/pull/4138
https://github.com/dust-tt/dust/pull/4139

## Risk

Easy to rollback until we remove the getResourcesTitles connector route. 

## Deploy Plan

Nothing special, just deploy front. 
