### PR TITLE
Do not import Google Sheets that exceed rows limit

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
+++ b/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
@@ -142,7 +142,7 @@ function getValidRows(allRows: string[][], loggerArgs: object): string[][] {
   if (validRows.length > MAXIMUM_NUMBER_OF_GSHEET_ROWS) {
     logger.info(
       { ...loggerArgs, rowCount: validRows.length },
-      `[Spreadsheet] Found sheet with more than ${MAXIMUM_NUMBER_OF_GSHEET_ROWS}`
+      `[Spreadsheet] Found sheet with more than ${MAXIMUM_NUMBER_OF_GSHEET_ROWS}, skipping further processing.`
     );
 
     // If the sheet has too many rows, return an empty array to ignore it.

--- a/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
+++ b/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
@@ -103,7 +103,7 @@ function findDataRangeAndSelectRows(allRows: string[][]): string[][] {
     .filter((row) => row.some((cell) => cell.trim() !== ""));
 }
 
-function getValidRows(allRows: string[][], loggerArgs: object) {
+function getValidRows(allRows: string[][], loggerArgs: object): string[][] {
   const filteredRows = findDataRangeAndSelectRows(allRows);
 
   // We assume that the first row is always the headers.
@@ -144,14 +144,20 @@ function getValidRows(allRows: string[][], loggerArgs: object) {
       { ...loggerArgs, rowCount: validRows.length },
       `[Spreadsheet] Found sheet with more than ${MAXIMUM_NUMBER_OF_GSHEET_ROWS}`
     );
+
+    // If the sheet has too many rows, return an empty array to ignore it.
+    return [];
   }
 
   return validRows.slice(0, MAXIMUM_NUMBER_OF_GSHEET_ROWS);
 }
 
-async function processSheet(connector: ConnectorResource, sheet: Sheet) {
+async function processSheet(
+  connector: ConnectorResource,
+  sheet: Sheet
+): Promise<boolean> {
   if (!sheet.values) {
-    return;
+    return false;
   }
 
   const { id, spreadsheet, title } = sheet;
@@ -175,7 +181,11 @@ async function processSheet(connector: ConnectorResource, sheet: Sheet) {
     await upsertTable(connector, sheet, rows);
 
     await upsertSheetInDb(connector, sheet);
+
+    return true;
   }
+
+  return false;
 }
 
 async function batchGetSheets(
@@ -370,13 +380,21 @@ export async function syncSpreadSheet(
     },
   });
 
+  const successfulSheetIdImports: number[] = [];
   for (const sheet of sheets) {
-    await processSheet(connector, sheet);
+    const isImported = await processSheet(connector, sheet);
+    if (isImported) {
+      successfulSheetIdImports.push(sheet.id);
+    }
   }
 
-  // Delete any previously synced sheets that no longer exist in the current spreadsheet.
+  // Delete any previously synced sheets that no longer exist in the current spreadsheet
+  // or have exceeded the maximum number of rows.
   const deletedSyncedSheets = syncedSheets.filter(
-    (synced) => !sheets.find((s) => s.id === synced.driveSheetId)
+    (synced) =>
+      !successfulSheetIdImports.find(
+        (sheetId) => sheetId === synced.driveSheetId
+      )
   );
   if (deletedSyncedSheets.length > 0) {
     await deleteAllSheets(connector, deletedSyncedSheets, {

--- a/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
+++ b/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
@@ -149,7 +149,7 @@ function getValidRows(allRows: string[][], loggerArgs: object): string[][] {
     return [];
   }
 
-  return validRows.slice(0, MAXIMUM_NUMBER_OF_GSHEET_ROWS);
+  return validRows;
 }
 
 async function processSheet(


### PR DESCRIPTION
## Description

This PR modifies the Google Spreadsheet import flow to ignore sheets with more than 10k rows (the current limit). Previously, we imported only the first 10k rows, which wasn't useful. The new flow will delete already imported truncated sheets. Any changes to the spreadsheet will trigger a new import attempt.
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
