### PR TITLE
Github: process issue/discussion pages in their own workflows

### DIFF
--- a/connectors/src/api/webhooks/webhook_github.ts
+++ b/connectors/src/api/webhooks/webhook_github.ts
@@ -331,20 +331,18 @@ async function syncRepos(
   let hasErrors = false;
   await Promise.all(
     connectors.map((c) =>
-      launchGithubReposSyncWorkflow(c.id, orgLogin, repos).catch(
-        (err) => {
-          logger.error(
-            {
-              err,
-              connectorId: c.id,
-              orgLogin,
-              repos,
-            },
-            "Failed to launch github repos sync workflow"
-          );
-          hasErrors = true;
-        }
-      )
+      launchGithubReposSyncWorkflow(c.id, orgLogin, repos).catch((err) => {
+        logger.error(
+          {
+            err,
+            connectorId: c.id,
+            orgLogin,
+            repos,
+          },
+          "Failed to launch github repos sync workflow"
+        );
+        hasErrors = true;
+      })
     )
   );
   if (hasErrors) {

--- a/connectors/src/api/webhooks/webhook_github.ts
+++ b/connectors/src/api/webhooks/webhook_github.ts
@@ -331,7 +331,7 @@ async function syncRepos(
   let hasErrors = false;
   await Promise.all(
     connectors.map((c) =>
-      launchGithubReposSyncWorkflow(c.id.toString(), orgLogin, repos).catch(
+      launchGithubReposSyncWorkflow(c.id, orgLogin, repos).catch(
         (err) => {
           logger.error(
             {

--- a/connectors/src/connectors/github/temporal/client.ts
+++ b/connectors/src/connectors/github/temporal/client.ts
@@ -106,7 +106,7 @@ export async function getGithubFullSyncWorkflow(connectorId: ModelId): Promise<{
 }
 
 export async function launchGithubReposSyncWorkflow(
-  connectorId: string,
+  connectorId: ModelId,
   orgLogin: string,
   repos: { name: string; id: number }[]
 ) {
@@ -130,7 +130,7 @@ export async function launchGithubReposSyncWorkflow(
     taskQueue: QUEUE_NAME,
     workflowId: getReposSyncWorkflowId(dataSourceConfig),
     searchAttributes: {
-      connectorId: [parseInt(connectorId)],
+      connectorId: [connectorId],
     },
     memo: {
       connectorId: connectorId,

--- a/connectors/src/connectors/github/temporal/workflows.ts
+++ b/connectors/src/connectors/github/temporal/workflows.ts
@@ -53,7 +53,7 @@ const { githubCodeSyncActivity } = proxyActivities<typeof activities>({
 });
 
 const MAX_CONCURRENT_REPO_SYNC_WORKFLOWS = 3;
-const MAX_CONCURRENT_ISSUE_SYNC_ACTIVITIES_PER_WORKFLOW = 3;
+const MAX_CONCURRENT_ISSUE_SYNC_ACTIVITIES_PER_WORKFLOW = 8;
 
 export async function githubFullSyncWorkflow(
   dataSourceConfig: DataSourceConfig,


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/dust/issues/3992

Move issues/discussions page processing in their own workflow to prevent `Workflow history size / count exceeds limit.`
Also bumps concurrency of processing issues/discussions to 8

Command to restart the full-sync:

```
./admin/cli.ts connectors full-resync --wId 2ddbc0204d --dataSourceName managed-github
```

Original cancelled workflow: https://cloud.temporal.io/namespaces/dust-prod.gmnlm/workflows/workflow-github-full-sync-2ddbc0204d-managed-github-repo-452716694-syncCodeOnly-false/b62c531e-c0c7-4dee-82a6-5cfca3b346e6/history

## Risk

N/A

## Deploy Plan

- deploy connectors and prodbox
- restart full sync workflow from issue related