### PR TITLE
Fix confluence list spaces

### DIFF
--- a/connectors/src/connectors/confluence/lib/confluence_api.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_api.ts
@@ -90,7 +90,7 @@ export async function pageHasReadRestrictions(
 export async function getActiveChildPageIds(
   client: ConfluenceClient,
   parentPageId: string,
-  pageCursor?: string
+  pageCursor: string | null
 ) {
   const { pages: childPages, nextPageCursor } = await client.getChildPages(
     parentPageId,

--- a/connectors/src/connectors/confluence/lib/confluence_api.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_api.ts
@@ -61,8 +61,9 @@ export async function listConfluenceSpaces(
   const allSpaces = new Map<string, ConfluenceSpaceType>();
   let nextPageCursor: string | null = "";
   do {
-    const { spaces, nextPageCursor: nextCursor } =
-      await client.getGlobalSpaces();
+    const { spaces, nextPageCursor: nextCursor } = await client.getGlobalSpaces(
+      nextPageCursor
+    );
 
     spaces.forEach((s) => allSpaces.set(s.id, s));
 

--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -258,13 +258,17 @@ export class ConfluenceClient {
     };
   }
 
-  async getGlobalSpaces() {
+  async getGlobalSpaces(pageCursor?: string) {
     const params = new URLSearchParams({
       limit: "250",
       type: "global",
       sort: "name",
       status: "current",
     });
+
+    if (pageCursor) {
+      params.append("cursor", pageCursor);
+    }
 
     const spaces = await this.request(
       `${this.restApiBaseUrl}/spaces?${params.toString()}`,

--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -234,7 +234,7 @@ export class ConfluenceClient {
     };
   }
 
-  async getChildPages(parentPageId: string, pageCursor?: string) {
+  async getChildPages(parentPageId: string, pageCursor: string | null) {
     const params = new URLSearchParams({
       sort: "id",
       limit: "100",

--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -258,7 +258,7 @@ export class ConfluenceClient {
     };
   }
 
-  async getGlobalSpaces(pageCursor?: string) {
+  async getGlobalSpaces(pageCursor: string | null) {
     const params = new URLSearchParams({
       limit: "250",
       type: "global",

--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -381,15 +381,17 @@ export async function confluenceGetRootPageIdsActivity({
 }
 
 export async function confluenceGetTopLevelPageIdsActivity({
-  connectorId,
   confluenceCloudId,
-  spaceId,
+  connectorId,
+  pageCursor,
   rootPageId,
+  spaceId,
 }: {
-  connectorId: ModelId;
   confluenceCloudId: string;
-  spaceId: string;
+  connectorId: ModelId;
+  pageCursor: string | null;
   rootPageId: string;
+  spaceId: string;
 }) {
   const localLogger = logger.child({
     connectorId,
@@ -406,7 +408,8 @@ export async function confluenceGetTopLevelPageIdsActivity({
 
   const { childPageIds, nextPageCursor } = await getActiveChildPageIds(
     client,
-    rootPageId
+    rootPageId,
+    pageCursor
   );
 
   localLogger.info("Found Confluence top-level pages in space.", {

--- a/connectors/src/connectors/confluence/temporal/workflows.ts
+++ b/connectors/src/connectors/confluence/temporal/workflows.ts
@@ -177,10 +177,11 @@ export async function confluenceSpaceSyncWorkflow(
     do {
       const { topLevelPageIds, nextPageCursor: nextCursor } =
         await confluenceGetTopLevelPageIdsActivity({
-          connectorId,
           confluenceCloudId,
-          spaceId,
+          connectorId,
+          pageCursor: nextPageCursor,
           rootPageId: allowedRootPageId,
+          spaceId,
         });
 
       nextPageCursor = nextCursor; // Prepare for the next iteration.


### PR DESCRIPTION
## Description

This PR resolves https://github.com/dust-tt/tasks/issues/484.

This PR corrects the Confluence list spaces API by including the page cursor, which was previously missing and causing an infinite loop.
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
