### PR TITLE
Remove all FFs for structured data

### DIFF
--- a/front/components/app/NewBlock.tsx
+++ b/front/components/app/NewBlock.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@dust-tt/sparkle";
-import type { SpecificationType, WorkspaceType } from "@dust-tt/types";
+import type { SpecificationType } from "@dust-tt/types";
 import type { BlockType } from "@dust-tt/types";
 import { Menu } from "@headlessui/react";
 import { PlusIcon } from "@heroicons/react/20/solid";
@@ -7,14 +7,12 @@ import { PlusIcon } from "@heroicons/react/20/solid";
 import { classNames } from "@app/lib/utils";
 
 export default function NewBlock({
-  owner,
   spec,
   disabled,
   onClick,
   direction,
   small,
 }: {
-  owner: WorkspaceType;
   spec: SpecificationType;
   disabled: boolean;
   onClick: (type: BlockType | "map_reduce" | "while_end") => void;
@@ -97,24 +95,19 @@ export default function NewBlock({
       name: "While End",
       description: "Loop over a set of blocks until a condition is met.",
     },
+    {
+      type: "database_schema",
+      typeNames: ["database_schema"],
+      name: "Database Schema",
+      description: "Retrieve the schema of a database.",
+    },
+    {
+      type: "database",
+      typeNames: ["database"],
+      name: "Database",
+      description: "Query a database.",
+    },
   ];
-
-  if (owner.flags.includes("structured_data")) {
-    blocks.push(
-      {
-        type: "database_schema",
-        typeNames: ["database_schema"],
-        name: "Database Schema",
-        description: "Retrieve the schema of a database.",
-      },
-      {
-        type: "database",
-        typeNames: ["database"],
-        name: "Database",
-        description: "Query a database.",
-      }
-    );
-  }
 
   if (!containsInput) {
     blocks.splice(0, 0, {

--- a/front/components/app/blocks/Block.tsx
+++ b/front/components/app/blocks/Block.tsx
@@ -158,7 +158,6 @@ export default function Block({
           >
             <div className="mr-1 mt-1 flex-initial text-gray-400">
               <NewBlock
-                owner={owner}
                 disabled={readOnly}
                 onClick={onBlockNew}
                 spec={spec}

--- a/front/components/assistant_builder/ActionScreen.tsx
+++ b/front/components/assistant_builder/ActionScreen.tsx
@@ -108,7 +108,7 @@ const SEARCH_MODE_SPECIFICATIONS: Record<
     icon: TableIcon,
     label: "Query Tables",
     description: "Tables, Spreadsheets, Notion DBs",
-    flag: "structured_data",
+    flag: null,
   },
 };
 

--- a/front/pages/w/[wId]/a/[aId]/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/index.tsx
@@ -341,7 +341,6 @@ export default function AppView({
         <div className="mt-8 flex flex-auto flex-col">
           <div className="mb-4 flex flex-row items-center space-x-2">
             <NewBlock
-              owner={owner}
               disabled={readOnly}
               onClick={async (blockType) => {
                 await handleNewBlock(null, blockType);
@@ -447,7 +446,6 @@ export default function AppView({
             <div className="my-4 flex flex-row items-center space-x-2">
               <div className="flex">
                 <NewBlock
-                  owner={owner}
                   disabled={readOnly}
                   onClick={async (blockType) => {
                     await handleNewBlock(null, blockType);

--- a/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
@@ -197,17 +197,13 @@ function StandardDataSourceView({
     }
   }, [router]);
 
-  const structuredDataEnabled = owner.flags.includes("structured_data");
-
   return (
     <div className="pt-6">
       <Page.Vertical gap="xl" align="stretch">
         <Page.SectionHeader
           title={dataSource.name}
           description={
-            structuredDataEnabled
-              ? "Use this page to view and upload documents and tables to your Folder."
-              : "Use this page to view and upload documents to your Folder."
+            "Use this page to view and upload documents and tables to your Folder."
           }
           action={
             readOnly
@@ -225,9 +221,7 @@ function StandardDataSourceView({
           }
         />
 
-        {structuredDataEnabled && (
-          <Tab tabs={tabs} setCurrentTab={setCurrentTab} />
-        )}
+        <Tab tabs={tabs} setCurrentTab={setCurrentTab} />
 
         {currentTab === "documents" && (
           <DatasourceDocumentsTabView

--- a/front/pages/w/[wId]/builder/data-sources/[name]/tables/upsert.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/tables/upsert.tsx
@@ -61,7 +61,7 @@ export const getServerSideProps = withGetServerSidePropsLogging<{
 
   const dataSource = await getDataSource(auth, context.params?.name as string);
 
-  if (!dataSource || !owner.flags.includes("structured_data")) {
+  if (!dataSource) {
     return {
       notFound: true,
     };

--- a/front/prompt/global_agent_helper_prompt.md
+++ b/front/prompt/global_agent_helper_prompt.md
@@ -137,9 +137,9 @@ As an admin, ️ ️`Build` > `Connections` > Select the desired Connection, 
 
 Slack: Dust doesn't take into account private channels, group direct messages, external files, or content behind a URL.
 Notion: Dust doesn't take into account external files or content behind a URL.
-Google Drive: Dust doesn't take into account files with more than 750Kb of extracted text. Supported files include GDocs, GSlides, and .txt files but not PDFs. 
+Google Drive: Dust doesn't take into account files with more than 750Kb of extracted text. Supported files include GDocs, GSlides, and .txt files but not PDFs.
 Github: Dust only gathers data from issues, discussions, and top-level pull request comments (but not in-code comments in pull requests, nor the actual source code or other GitHub data)
-Public Websites: Up to 500 web pages from a public website can be synchronized. 
+Public Websites: Up to 500 web pages from a public website can be synchronized.
 Confluence: Dust does not synchronize private spaces. Dust does not access pages with view limitations and will not capture any content from a restricted page. This restriction also applies to all the child pages of such pages.
 Intercom: Dust will index only the conversations from the selected Teams that were initiated within the past 90 days and concluded (marked as closed). For the Help Center data, Dust will index every Article published within a selected Collection.
 

--- a/types/src/front/feature_flags.ts
+++ b/types/src/front/feature_flags.ts
@@ -1,6 +1,4 @@
 export const WHITELISTABLE_FEATURES = [
-  "auto_pre_ingest_all_databases",
-  "structured_data",
   "workspace_analytics",
   "usage_data_api",
   "brieviety_prompt",


### PR DESCRIPTION
## Description

This is a follow up of https://github.com/dust-tt/dust/pull/4058.

It removes all remaining structured data feature flags in `front`. 
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Once deploy, we will need to remove those legacy FFs from our database.

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
