### PR TITLE
Connector: implement retrieveContentNodes for Confluence

### DIFF
--- a/connectors/src/connectors/confluence/lib/permissions.ts
+++ b/connectors/src/connectors/confluence/lib/permissions.ts
@@ -82,7 +82,10 @@ export function createConnectorNodeFromPage(
   };
 }
 
-async function checkPageHasChildren(connectorId: ModelId, pageId: string) {
+export async function checkPageHasChildren(
+  connectorId: ModelId,
+  pageId: string
+) {
   const childrenPage = await ConfluencePage.findOne({
     attributes: ["id"],
     where: {

--- a/connectors/src/connectors/confluence/lib/permissions.ts
+++ b/connectors/src/connectors/confluence/lib/permissions.ts
@@ -34,7 +34,7 @@ function isConfluenceSpaceModel(
   );
 }
 
-function createConnectorNodeFromSpace(
+export function createConnectorNodeFromSpace(
   space: ConfluenceSpace | ConfluenceSpaceType,
   baseUrl: string,
   permission: ConnectorPermission,
@@ -59,7 +59,7 @@ function createConnectorNodeFromSpace(
   };
 }
 
-function createConnectorNodeFromPage(
+export function createConnectorNodeFromPage(
   parent: { id: string; type: "page" | "space" },
   baseUrl: string,
   page: ConfluencePage,

--- a/connectors/src/connectors/index.ts
+++ b/connectors/src/connectors/index.ts
@@ -5,6 +5,7 @@ import {
   createConfluenceConnector,
   resumeConfluenceConnector,
   retrieveConfluenceConnectorPermissions,
+  retrieveConfluenceContentNodes,
   retrieveConfluenceObjectsTitles,
   retrieveConfluenceResourceParents,
   setConfluenceConnectorPermissions,
@@ -252,9 +253,7 @@ export const BATCH_RETRIEVE_CONTENT_NODES_BY_TYPE: Record<
   ConnectorProvider,
   ConnectorBatchContentNodesRetriever
 > = {
-  confluence: (connectorId: ModelId) => {
-    throw new Error(`Not implemented ${connectorId}`);
-  },
+  confluence: retrieveConfluenceContentNodes,
   slack: retrieveSlackContentNodes,
   notion: retrieveNotionContentNodes,
   github: retrieveGithubReposContentNodes,


### PR DESCRIPTION
## Description

We're implementing a "retrieve content nodes" for each connector. 
It is meant to replace "retrieve resource titles". 
More context here: https://github.com/dust-tt/dust/pull/4044

This is the PR for Confluence. 

## Risk

Low as not used yet.

## Deploy Plan

Nothing special. 
