### PR TITLE
Connector: implement retrieveContentNodes for Slack

### DIFF
--- a/connectors/src/connectors/index.ts
+++ b/connectors/src/connectors/index.ts
@@ -87,6 +87,7 @@ import {
   getSlackConfig,
   retrieveSlackChannelsTitles,
   retrieveSlackConnectorPermissions,
+  retrieveSlackContentNodes,
   setSlackConfig,
   setSlackConnectorPermissions,
   updateSlackConnector,
@@ -253,9 +254,7 @@ export const BATCH_RETRIEVE_CONTENT_NODES_BY_TYPE: Record<
   confluence: (connectorId: ModelId) => {
     throw new Error(`Not implemented ${connectorId}`);
   },
-  slack: (connectorId: ModelId) => {
-    throw new Error(`Not implemented ${connectorId}`);
-  },
+  slack: retrieveSlackContentNodes,
   notion: retrieveNotionContentNodes,
   github: (connectorId: ModelId) => {
     throw new Error(`Not implemented ${connectorId}`);


### PR DESCRIPTION
## Description

We're implementing a "retrieve content nodes" for each connector. 
It is meant to replace "retrieve resource titles". 
More context here: https://github.com/dust-tt/dust/pull/4044

This is the PR for Slack. 
-> tested in local, seems to work as expected. 

## Risk

Low as not used yet.

## Deploy Plan

Nothing special. 