### PR TITLE
Fix connector creation

### DIFF
--- a/connectors/src/resources/connector_resource.ts
+++ b/connectors/src/resources/connector_resource.ts
@@ -53,7 +53,7 @@ export class ConnectorResource extends BaseResource<ConnectorModel> {
         { transaction }
       );
 
-      const connectorRes = new this(ConnectorModel, connector);
+      const connectorRes = new this(ConnectorModel, connector.get());
 
       await connectorRes.providerStrategy.makeNew(
         connectorRes,


### PR DESCRIPTION
## Description

In https://github.com/dust-tt/dust/pull/4007 we introduced a regression where we returned an instance of a `ConnectorModel` rather than an instance of a `ConnectorResource`. This PR fixes it.
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
