### PR TITLE
Handle Google Sheet with invalid headers.

### DIFF
--- a/types/src/shared/utils/structured_data.ts
+++ b/types/src/shared/utils/structured_data.ts
@@ -7,6 +7,12 @@ export function makeStructuredDataTableName(name: string, externalId: string) {
   return slugify(`${name}_${externalIdPrefix}_${externalIdSuffix}`);
 }
 
+export class InvalidStructuredDataHeaderError extends Error {
+  constructor(message: string) {
+    super(message);
+  }
+}
+
 export function getSanitizedHeaders(rawHeaders: string[]) {
   return rawHeaders.reduce<string[]>((acc, curr) => {
     const slugifiedName = slugify(curr);
@@ -24,7 +30,7 @@ export function getSanitizedHeaders(rawHeaders: string[]) {
       }
 
       if (!conflictResolved) {
-        throw new Error(
+        throw new InvalidStructuredDataHeaderError(
           `Failed to generate unique slugified name for header "${curr}" after multiple attempts.`
         );
       }

--- a/types/src/shared/utils/structured_data.ts
+++ b/types/src/shared/utils/structured_data.ts
@@ -7,11 +7,7 @@ export function makeStructuredDataTableName(name: string, externalId: string) {
   return slugify(`${name}_${externalIdPrefix}_${externalIdSuffix}`);
 }
 
-export class InvalidStructuredDataHeaderError extends Error {
-  constructor(message: string) {
-    super(message);
-  }
-}
+export class InvalidStructuredDataHeaderError extends Error {}
 
 export function getSanitizedHeaders(rawHeaders: string[]) {
   return rawHeaders.reduce<string[]>((acc, curr) => {


### PR DESCRIPTION
## Description

This {R guarantees that we disregard any sheets with header name conflicts exceeding the limit of 64. Our current header conflict algorithm can handle up to 64 conflicts in header names.
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
