### PR TITLE
Connector: getContentNodes for Github

### DIFF
--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -1,9 +1,9 @@
 import type {
   ConnectorNode,
-  ConnectorPermission,
   ConnectorsAPIError,
   ModelId,
 } from "@dust-tt/types";
+import { assertNever } from "@dust-tt/types";
 
 import type { GithubRepo } from "@connectors/connectors/github/lib/github_api";
 import {
@@ -259,7 +259,7 @@ export async function retrieveGithubConnectorPermissions({
           title: repo.name,
           sourceUrl: repo.url,
           expandable: true,
-          permission: "read" as ConnectorPermission,
+          permission: "read",
           dustDocumentId: null,
           lastUpdatedAt: null,
         }))
@@ -310,7 +310,7 @@ export async function retrieveGithubConnectorPermissions({
           title: directory.dirName,
           sourceUrl: directory.sourceUrl,
           expandable: true,
-          permission: "read" as ConnectorPermission,
+          permission: "read",
           dustDocumentId: null,
           lastUpdatedAt: directory.codeUpdatedAt.getTime(),
         });
@@ -325,7 +325,7 @@ export async function retrieveGithubConnectorPermissions({
           title: file.fileName,
           sourceUrl: file.sourceUrl,
           expandable: false,
-          permission: "read" as ConnectorPermission,
+          permission: "read",
           dustDocumentId: file.documentId,
           lastUpdatedAt: file.codeUpdatedAt.getTime(),
         });
@@ -386,7 +386,7 @@ export async function retrieveGithubConnectorPermissions({
           title: "Issues",
           sourceUrl: repo.url + "/issues",
           expandable: false,
-          permission: "read" as ConnectorPermission,
+          permission: "read",
           dustDocumentId: null,
           lastUpdatedAt: latestIssue.updatedAt.getTime(),
         });
@@ -401,7 +401,7 @@ export async function retrieveGithubConnectorPermissions({
           title: "Discussions",
           sourceUrl: repo.url + "/discussions",
           expandable: false,
-          permission: "read" as ConnectorPermission,
+          permission: "read",
           dustDocumentId: null,
           lastUpdatedAt: latestDiscussion.updatedAt.getTime(),
         });
@@ -416,7 +416,7 @@ export async function retrieveGithubConnectorPermissions({
           title: "Code",
           sourceUrl: repo.url,
           expandable: true,
-          permission: "read" as ConnectorPermission,
+          permission: "read",
           dustDocumentId: null,
           lastUpdatedAt: codeRepo.codeUpdatedAt.getTime(),
         });
@@ -514,7 +514,7 @@ export async function retrieveGithubReposContentNodes(
         codeFileIds.push(internalId);
         break;
       default:
-        throw new Error(`Invalid type: ${type}`);
+        assertNever(type);
     }
   });
 
@@ -567,7 +567,7 @@ export async function retrieveGithubReposContentNodes(
       titleWithParentsContext: `[${repo.name}] - Full repository`,
       sourceUrl: repo.url,
       expandable: true,
-      permission: "read" as ConnectorPermission,
+      permission: "read",
       dustDocumentId: null,
       lastUpdatedAt: null,
     });
@@ -588,7 +588,7 @@ export async function retrieveGithubReposContentNodes(
       titleWithParentsContext: `${repo.name} - Issues`,
       sourceUrl: repo.url + "/issues",
       expandable: false,
-      permission: "read" as ConnectorPermission,
+      permission: "read",
       dustDocumentId: null,
       lastUpdatedAt: null,
     });
@@ -607,7 +607,7 @@ export async function retrieveGithubReposContentNodes(
       titleWithParentsContext: `${repo.name} - Discussions`,
       sourceUrl: repo.url + "/discussions",
       expandable: false,
-      permission: "read" as ConnectorPermission,
+      permission: "read",
       dustDocumentId: null,
       lastUpdatedAt: null,
     });
@@ -625,7 +625,7 @@ export async function retrieveGithubReposContentNodes(
       titleWithParentsContext: repo ? `[${repo.name}] - Code` : "Code",
       sourceUrl: codeRepo.sourceUrl,
       expandable: true,
-      permission: "read" as ConnectorPermission,
+      permission: "read",
       dustDocumentId: null,
       lastUpdatedAt: codeRepo.codeUpdatedAt.getTime(),
     });
@@ -645,7 +645,7 @@ export async function retrieveGithubReposContentNodes(
         : directory.dirName,
       sourceUrl: directory.sourceUrl,
       expandable: true,
-      permission: "read" as ConnectorPermission,
+      permission: "read",
       dustDocumentId: null,
       lastUpdatedAt: directory.codeUpdatedAt.getTime(),
     });
@@ -665,7 +665,7 @@ export async function retrieveGithubReposContentNodes(
         : file.fileName,
       sourceUrl: file.sourceUrl,
       expandable: false,
-      permission: "read" as ConnectorPermission,
+      permission: "read",
       dustDocumentId: file.documentId,
       lastUpdatedAt: file.codeUpdatedAt.getTime(),
     });

--- a/connectors/src/connectors/github/lib/github_api.ts
+++ b/connectors/src/connectors/github/lib/github_api.ts
@@ -34,7 +34,7 @@ type GithubOrg = {
   login: string;
 };
 
-type GithubRepo = {
+export type GithubRepo = {
   id: number;
   name: string;
   private: boolean;

--- a/connectors/src/connectors/github/lib/utils.ts
+++ b/connectors/src/connectors/github/lib/utils.ts
@@ -1,0 +1,67 @@
+export const GITHUB_CONTENT_NODE_TYPES = [
+  "REPO_FULL",
+  "REPO_ISSUES",
+  "REPO_DISCUSSIONS",
+  "REPO_CODE",
+  "REPO_CODE_DIR",
+  "REPO_CODE_FILE",
+] as const;
+export type GithubContentNodeType = (typeof GITHUB_CONTENT_NODE_TYPES)[number];
+
+/**
+ * Gets the type of the Github content node from its internal id.
+ */
+export function matchGithubInternalIdType(internalId: string): {
+  type: GithubContentNodeType;
+  repoId: number;
+} {
+  // Full repo is selected, format = "12345678"
+  if (/^\d+$/.test(internalId)) {
+    return {
+      type: "REPO_FULL",
+      repoId: parseInt(internalId, 10),
+    };
+  }
+  // All issues from repo are selected, format = "12345678-issues"
+  if (/\d+-issues$/.test(internalId)) {
+    return {
+      type: "REPO_ISSUES",
+      repoId: parseInt(internalId.replace(/-issues$/, ""), 10),
+    };
+  }
+  // All discussions from repo are selected, format = "12345678-discussions"
+  if (/\d+-discussions$/.test(internalId)) {
+    return {
+      type: "REPO_DISCUSSIONS",
+      repoId: parseInt(internalId.replace(/-discussions$/, ""), 10),
+    };
+  }
+  // All code from repo is selected, format = "github-code-12345678"
+  if (/^github-code-\d+$/.test(internalId)) {
+    return {
+      type: "REPO_CODE",
+      repoId: parseInt(internalId.replace(/^github-code-/, ""), 10),
+    };
+  }
+  // A code directory is selected, format = "github-code-12345678-dir-s0Up1n0u"
+  if (/^github-code-\d+-dir-[a-f0-9]+$/.test(internalId)) {
+    return {
+      type: "REPO_CODE_DIR",
+      repoId: parseInt(
+        internalId.replace(/^github-code-(\d+)-dir-.*/, "$1"),
+        10
+      ),
+    };
+  }
+  // A code file is selected, format = "github-code-12345678-file-s0Up1n0u"
+  if (/^github-code-\d+-file-[a-f0-9]+$/.test(internalId)) {
+    return {
+      type: "REPO_CODE_FILE",
+      repoId: parseInt(
+        internalId.replace(/^github-code-(\d+)-file-.*/, "$1"),
+        10
+      ),
+    };
+  }
+  throw new Error(`Invalid Github internal id: ${internalId}`);
+}

--- a/connectors/src/connectors/index.ts
+++ b/connectors/src/connectors/index.ts
@@ -19,6 +19,7 @@ import {
   getGithubConfig,
   resumeGithubConnector,
   retrieveGithubConnectorPermissions,
+  retrieveGithubReposContentNodes,
   retrieveGithubReposTitles,
   retrieveGithubResourceParents,
   setGithubConfig,
@@ -256,9 +257,7 @@ export const BATCH_RETRIEVE_CONTENT_NODES_BY_TYPE: Record<
   },
   slack: retrieveSlackContentNodes,
   notion: retrieveNotionContentNodes,
-  github: (connectorId: ModelId) => {
-    throw new Error(`Not implemented ${connectorId}`);
-  },
+  github: retrieveGithubReposContentNodes,
   google_drive: (connectorId: ModelId) => {
     throw new Error(`Not implemented ${connectorId}`);
   },

--- a/types/src/front/lib/connectors_api.ts
+++ b/types/src/front/lib/connectors_api.ts
@@ -93,6 +93,7 @@ export type ConnectorNode = {
   parentInternalId: string | null;
   type: ConnectorNodeType;
   title: string;
+  titleWithParentsContext?: string;
   sourceUrl: string | null;
   expandable: boolean;
   preventSelection?: boolean;


### PR DESCRIPTION
## Description

This PR implements the Content Nodes retriever for Github: `retrieveGithubReposContentNodes`.

On Github we can pick: 
- A full Repo
- All the Issues of a Repo
- All the Discussions of a Repo
- All the Code of a Repo
- A specific directly in the Code
- A specific file in the Code

I added a `titleWithParentsContext` to the type `ConnectorNode` to be able to display a specific name with more context, as displaying just "Code" or "Issues" can be very confusing if we don't display the name of the repo. 

Looks like this: 

![Screenshot 2024-03-04 at 15 29 15](https://github.com/dust-tt/dust/assets/3803406/b47c81fe-a269-4f0f-8108-9a899d76ba72)




## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
