### PR TITLE
Connector: implement retrieve content nodes for WebCrawler

### DIFF
--- a/connectors/src/connectors/index.ts
+++ b/connectors/src/connectors/index.ts
@@ -101,6 +101,7 @@ import {
   cleanupWebcrawlerConnector,
   createWebcrawlerConnector,
   retrieveWebcrawlerConnectorPermissions,
+  retrieveWebCrawlerContentNodes,
   retrieveWebCrawlerObjectsParents,
   retrieveWebCrawlerObjectsTitles,
   stopWebcrawlerConnector,
@@ -262,9 +263,7 @@ export const BATCH_RETRIEVE_CONTENT_NODES_BY_TYPE: Record<
     throw new Error(`Not implemented ${connectorId}`);
   },
   intercom: retrieveIntercomContentNodes,
-  webcrawler: (connectorId: ModelId) => {
-    throw new Error(`Not implemented ${connectorId}`);
-  },
+  webcrawler: retrieveWebCrawlerContentNodes,
 };
 
 export const RETRIEVE_RESOURCE_PARENTS_BY_TYPE: Record<


### PR DESCRIPTION
## Description

We're implementing a "retrieve content nodes" for each connector. 
It is meant to replace "retrieve resource titles". 
This is used to display the list of datasources selected for an agent. 


More context here: https://github.com/dust-tt/dust/pull/4044

This is the PR for Webcrawler. 

## Risk

Low as not used yet.

## Deploy Plan

Nothing special. 
