### PR TITLE
Connector: implement retrieve content nodes for Gdrive

### DIFF
--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -575,6 +575,15 @@ export async function retrieveGoogleDriveContentNodes(
   const nodes = await concurrentExecutor(
     folderOrFiles,
     async (f): Promise<ConnectorNode> => {
+      const type = getPermissionViewType(f);
+      let sourceUrl = null;
+      if (type === "file") {
+        sourceUrl = `https://drive.google.com/file/d/${f.driveFileId}/view`;
+      } else if (type === "folder") {
+        sourceUrl = `https://drive.google.com/drive/folders/${f.driveFileId}`;
+      } else if (type === "database") {
+        sourceUrl = `https://docs.google.com/spreadsheets/d/${f.driveFileId}/edit`;
+      }
       return {
         provider: "google_drive",
         internalId: f.driveFileId,
@@ -583,7 +592,7 @@ export async function retrieveGoogleDriveContentNodes(
         title: f.name || "",
         dustDocumentId: getGoogleDriveEntityDocumentId(f),
         lastUpdatedAt: f.lastUpsertedTs?.getTime() || null,
-        sourceUrl: null,
+        sourceUrl,
         expandable:
           (await GoogleDriveFiles.findOne({
             attributes: ["id"],

--- a/connectors/src/connectors/index.ts
+++ b/connectors/src/connectors/index.ts
@@ -33,6 +33,7 @@ import {
   getGoogleDriveConfig,
   googleDriveGarbageCollect,
   retrieveGoogleDriveConnectorPermissions,
+  retrieveGoogleDriveContentNodes,
   retrieveGoogleDriveObjectsParents,
   retrieveGoogleDriveObjectsTitles,
   setGoogleDriveConfig,
@@ -258,9 +259,7 @@ export const BATCH_RETRIEVE_CONTENT_NODES_BY_TYPE: Record<
   slack: retrieveSlackContentNodes,
   notion: retrieveNotionContentNodes,
   github: retrieveGithubReposContentNodes,
-  google_drive: (connectorId: ModelId) => {
-    throw new Error(`Not implemented ${connectorId}`);
-  },
+  google_drive: retrieveGoogleDriveContentNodes,
   intercom: retrieveIntercomContentNodes,
   webcrawler: retrieveWebCrawlerContentNodes,
 };


### PR DESCRIPTION
## Description

We're implementing a "retrieve content nodes" for each connector. 
It is meant to replace "retrieve resource titles". 
More context here: https://github.com/dust-tt/dust/pull/4044

This is the PR for Gdrive. 

## Risk

Low as not used yet.

## Deploy Plan

Nothing special. 
