### PR TITLE
Wrap SSR with auth requirements

### DIFF
--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -446,7 +446,7 @@ export class Authenticator {
 export async function getSession(
   req: NextApiRequest | GetServerSidePropsContext["req"],
   res: NextApiResponse | GetServerSidePropsContext["res"]
-): Promise<any> {
+): Promise<any | null> {
   return getServerSession(req, res, authOptions);
 }
 

--- a/front/lib/iam/session.ts
+++ b/front/lib/iam/session.ts
@@ -2,11 +2,8 @@ import type { RoleType, UserTypeWithWorkspaces } from "@dust-tt/types";
 import type {
   GetServerSideProps,
   GetServerSidePropsContext,
-  GetServerSidePropsResult,
   PreviewData,
 } from "next";
-import { redirect } from "next/navigation";
-import type { P } from "pino";
 import type { ParsedUrlQuery } from "querystring";
 import { Op } from "sequelize";
 

--- a/front/lib/iam/session.ts
+++ b/front/lib/iam/session.ts
@@ -104,8 +104,10 @@ export function withGetServerSidePropsRequirements<
   return async (
     context: GetServerSidePropsContext<ParsedUrlQuery, PreviewData>
   ) => {
+    const { enableLogging, requireAuth } = opts;
+
     const session = await getSession(context.req, context.res);
-    if (!session) {
+    if (requireAuth && !session) {
       return {
         redirect: {
           permanent: false,
@@ -115,7 +117,6 @@ export function withGetServerSidePropsRequirements<
       };
     }
 
-    const { enableLogging } = opts;
     if (enableLogging) {
       return withGetServerSidePropsLogging(getServerSideProps)(context);
     }

--- a/front/lib/iam/session.ts
+++ b/front/lib/iam/session.ts
@@ -106,15 +106,17 @@ export function withGetServerSidePropsRequirements<
   ) => {
     const { enableLogging, requireAuth } = opts;
 
-    const session = await getSession(context.req, context.res);
-    if (requireAuth && !session) {
-      return {
-        redirect: {
-          permanent: false,
-          // TODO(2024-03-04 flav) Add support for `returnTo=`.
-          destination: "/",
-        },
-      };
+    if (requireAuth) {
+      const session = await getSession(context.req, context.res);
+      if (!session) {
+        return {
+          redirect: {
+            permanent: false,
+            // TODO(2024-03-04 flav) Add support for `returnTo=`.
+            destination: "/",
+          },
+        };
+      }
     }
 
     if (enableLogging) {

--- a/front/pages/login-error.tsx
+++ b/front/pages/login-error.tsx
@@ -2,23 +2,28 @@ import { Button, Logo } from "@dust-tt/sparkle";
 import type { InferGetServerSidePropsType } from "next";
 import Link from "next/link";
 
-import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
+import { withGetServerSidePropsRequirements } from "@app/lib/iam/session";
 
 const { URL = "", GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withGetServerSidePropsLogging<{
+export const getServerSideProps = withGetServerSidePropsRequirements<{
   domain?: string;
   gaTrackingId: string;
   baseUrl: string;
-}>(async (context) => {
-  return {
-    props: {
-      domain: context.query.domain as string,
-      baseUrl: URL,
-      gaTrackingId: GA_TRACKING_ID,
-    },
-  };
-});
+}>(
+  async (context) => {
+    return {
+      props: {
+        domain: context.query.domain as string,
+        baseUrl: URL,
+        gaTrackingId: GA_TRACKING_ID,
+      },
+    };
+  },
+  {
+    requireAuth: false,
+  }
+);
 
 export default function LoginError({
   domain,

--- a/front/pages/no-workspace.tsx
+++ b/front/pages/no-workspace.tsx
@@ -60,71 +60,66 @@ export const getServerSideProps = withGetServerSidePropsRequirements<{
   userFirstName: string;
   workspaceName: string;
   workspaceVerifiedDomain: string | null;
-}>(
-  async (context) => {
-    const session = await getSession(context.req, context.res);
-    const user = await getUserFromSession(session);
+}>(async (context) => {
+  const session = await getSession(context.req, context.res);
+  const user = await getUserFromSession(session);
 
-    if (!user) {
-      return {
-        notFound: true,
-      };
-    }
-
-    const flow =
-      context.query.flow && typeof context.query.flow === "string"
-        ? context.query.flow
-        : null;
-
-    let workspace: Workspace | null = null;
-    let workspaceVerifiedDomain: string | null = null;
-    let status: "auto-join-disabled" | "revoked";
-
-    if (flow === "no-auto-join") {
-      status = "auto-join-disabled";
-      const workspaceHasDomain = await fetchWorkspaceDetails(user);
-      workspace = workspaceHasDomain?.workspace ?? null;
-      workspaceVerifiedDomain = workspaceHasDomain?.domain ?? null;
-
-      if (!workspace || !workspaceVerifiedDomain) {
-        logger.error(
-          {
-            flow,
-            userId: user.id,
-            panic: true,
-          },
-          "Unreachable: workspace not found."
-        );
-        throw new Error("Workspace not found.");
-      }
-    } else if (flow === "revoked") {
-      status = "revoked";
-      workspace = await fetchRevokedWorkspace(user);
-
-      if (!workspace) {
-        logger.error(
-          { flow, userId: user.id, panic: true },
-          "Unreachable: workspace not found."
-        );
-        throw new Error("Workspace not found.");
-      }
-    } else {
-      throw new Error("No workspace found.");
-    }
-
+  if (!user) {
     return {
-      props: {
-        status,
-        userFirstName: user.firstName,
-        workspaceName: workspace.name,
-        workspaceVerifiedDomain,
-      },
+      notFound: true,
     };
-  },
-  {
-    requireAuth: false,
   }
-);
+
+  const flow =
+    context.query.flow && typeof context.query.flow === "string"
+      ? context.query.flow
+      : null;
+
+  let workspace: Workspace | null = null;
+  let workspaceVerifiedDomain: string | null = null;
+  let status: "auto-join-disabled" | "revoked";
+
+  if (flow === "no-auto-join") {
+    status = "auto-join-disabled";
+    const workspaceHasDomain = await fetchWorkspaceDetails(user);
+    workspace = workspaceHasDomain?.workspace ?? null;
+    workspaceVerifiedDomain = workspaceHasDomain?.domain ?? null;
+
+    if (!workspace || !workspaceVerifiedDomain) {
+      logger.error(
+        {
+          flow,
+          userId: user.id,
+          panic: true,
+        },
+        "Unreachable: workspace not found."
+      );
+      throw new Error("Workspace not found.");
+    }
+  } else if (flow === "revoked") {
+    status = "revoked";
+    workspace = await fetchRevokedWorkspace(user);
+
+    if (!workspace) {
+      logger.error(
+        { flow, userId: user.id, panic: true },
+        "Unreachable: workspace not found."
+      );
+      throw new Error("Workspace not found.");
+    }
+  } else {
+    throw new Error("No workspace found.");
+  }
+
+  return {
+    props: {
+      status,
+      userFirstName: user.firstName,
+      workspaceName: workspace.name,
+      workspaceVerifiedDomain,
+    },
+  };
+});
 
 export default function NoWorkspace({
   status,

--- a/front/pages/poke/[wId]/assistants/[aId]/index.tsx
+++ b/front/pages/poke/[wId]/assistants/[aId]/index.tsx
@@ -10,9 +10,9 @@ import type { InferGetServerSidePropsType } from "next";
 import PokeNavbar from "@app/components/poke/PokeNavbar";
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
+import { withGetServerSidePropsRequirements } from "@app/lib/iam/session";
 
-export const getServerSideProps = withGetServerSidePropsLogging<{
+export const getServerSideProps = withGetServerSidePropsRequirements<{
   agentConfigurations: AgentConfigurationType[];
 }>(async (context) => {
   const session = await getSession(context.req, context.res);

--- a/front/pages/poke/[wId]/data_sources/[name]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[name]/index.tsx
@@ -25,14 +25,14 @@ import { getDataSource } from "@app/lib/api/data_sources";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { getDisplayNameForDocument } from "@app/lib/data_sources";
+import { withGetServerSidePropsRequirements } from "@app/lib/iam/session";
 import { useDocuments } from "@app/lib/swr";
 import { formatTimestampToFriendlyDate, timeAgoFrom } from "@app/lib/utils";
 import logger from "@app/logger/logger";
-import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
 
 const { TEMPORAL_CONNECTORS_NAMESPACE = "" } = process.env;
 
-export const getServerSideProps = withGetServerSidePropsLogging<{
+export const getServerSideProps = withGetServerSidePropsRequirements<{
   owner: WorkspaceType;
   dataSource: DataSourceType;
   coreDataSource: CoreAPIDataSource;

--- a/front/pages/poke/[wId]/data_sources/[name]/search.tsx
+++ b/front/pages/poke/[wId]/data_sources/[name]/search.tsx
@@ -10,10 +10,10 @@ import PokeNavbar from "@app/components/poke/PokeNavbar";
 import { getDataSource } from "@app/lib/api/data_sources";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { getDisplayNameForDocument } from "@app/lib/data_sources";
+import { withGetServerSidePropsRequirements } from "@app/lib/iam/session";
 import { classNames, timeAgoFrom } from "@app/lib/utils";
-import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
 
-export const getServerSideProps = withGetServerSidePropsLogging<{
+export const getServerSideProps = withGetServerSidePropsRequirements<{
   owner: WorkspaceType;
   dataSource: DataSourceType;
 }>(async (context) => {

--- a/front/pages/poke/[wId]/data_sources/[name]/view.tsx
+++ b/front/pages/poke/[wId]/data_sources/[name]/view.tsx
@@ -6,11 +6,11 @@ import type { InferGetServerSidePropsType } from "next";
 import PokeNavbar from "@app/components/poke/PokeNavbar";
 import { getDataSource } from "@app/lib/api/data_sources";
 import { Authenticator, getSession } from "@app/lib/auth";
+import { withGetServerSidePropsRequirements } from "@app/lib/iam/session";
 import { classNames } from "@app/lib/utils";
 import logger from "@app/logger/logger";
-import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
 
-export const getServerSideProps = withGetServerSidePropsLogging<{
+export const getServerSideProps = withGetServerSidePropsRequirements<{
   document: CoreAPIDocument;
 }>(async (context) => {
   const session = await getSession(context.req, context.res);

--- a/front/pages/poke/[wId]/index.tsx
+++ b/front/pages/poke/[wId]/index.tsx
@@ -38,6 +38,7 @@ import {
 import { Authenticator, getSession } from "@app/lib/auth";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { isDevelopment } from "@app/lib/development";
+import { withGetServerSidePropsRequirements } from "@app/lib/iam/session";
 import {
   FREE_TEST_PLAN_CODE,
   FREE_UPGRADED_PLAN_CODE,
@@ -45,9 +46,8 @@ import {
 } from "@app/lib/plans/plan_codes";
 import { getPlanInvitation } from "@app/lib/plans/subscription";
 import { usePokePlans } from "@app/lib/swr";
-import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
 
-export const getServerSideProps = withGetServerSidePropsLogging<{
+export const getServerSideProps = withGetServerSidePropsRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   planInvitation: PlanInvitationType | null;

--- a/front/pages/poke/[wId]/memberships.tsx
+++ b/front/pages/poke/[wId]/memberships.tsx
@@ -11,9 +11,9 @@ import React from "react";
 import PokeNavbar from "@app/components/poke/PokeNavbar";
 import { getMembers } from "@app/lib/api/workspace";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
+import { withGetServerSidePropsRequirements } from "@app/lib/iam/session";
 
-export const getServerSideProps = withGetServerSidePropsLogging<{
+export const getServerSideProps = withGetServerSidePropsRequirements<{
   owner: WorkspaceType;
   members: UserTypeWithWorkspaces[];
 }>(async (context) => {

--- a/front/pages/poke/connectors/[connectorId]/index.tsx
+++ b/front/pages/poke/connectors/[connectorId]/index.tsx
@@ -2,10 +2,10 @@ import type { ConnectorType } from "@dust-tt/types";
 import { ConnectorsAPI } from "@dust-tt/types";
 
 import { Authenticator, getSession } from "@app/lib/auth";
+import { withGetServerSidePropsRequirements } from "@app/lib/iam/session";
 import logger from "@app/logger/logger";
-import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
 
-export const getServerSideProps = withGetServerSidePropsLogging<object>(
+export const getServerSideProps = withGetServerSidePropsRequirements<object>(
   async (context) => {
     const session = await getSession(context.req, context.res);
     const auth = await Authenticator.fromSuperUserSession(session, null);

--- a/front/pages/poke/index.tsx
+++ b/front/pages/poke/index.tsx
@@ -5,8 +5,8 @@ import React, { useState } from "react";
 
 import PokeNavbar from "@app/components/poke/PokeNavbar";
 import { Authenticator, getSession } from "@app/lib/auth";
+import { withGetServerSidePropsRequirements } from "@app/lib/iam/session";
 import { usePokeWorkspaces } from "@app/lib/swr";
-import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
 
 export const getServerSideProps = withGetServerSidePropsLogging<object>(
   async (context) => {

--- a/front/pages/poke/index.tsx
+++ b/front/pages/poke/index.tsx
@@ -8,7 +8,7 @@ import { Authenticator, getSession } from "@app/lib/auth";
 import { withGetServerSidePropsRequirements } from "@app/lib/iam/session";
 import { usePokeWorkspaces } from "@app/lib/swr";
 
-export const getServerSideProps = withGetServerSidePropsLogging<object>(
+export const getServerSideProps = withGetServerSidePropsRequirements<object>(
   async (context) => {
     const session = await getSession(context.req, context.res);
     const auth = await Authenticator.fromSuperUserSession(session, null);

--- a/front/pages/poke/plans.tsx
+++ b/front/pages/poke/plans.tsx
@@ -23,10 +23,10 @@ import {
 import PokeNavbar from "@app/components/poke/PokeNavbar";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { Authenticator, getSession } from "@app/lib/auth";
+import { withGetServerSidePropsRequirements } from "@app/lib/iam/session";
 import { usePokePlans } from "@app/lib/swr";
-import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
 
-export const getServerSideProps = withGetServerSidePropsLogging<object>(
+export const getServerSideProps = withGetServerSidePropsRequirements<object>(
   async (context) => {
     const session = await getSession(context.req, context.res);
     const auth = await Authenticator.fromSuperUserSession(session, null);

--- a/front/pages/w/[wId]/a/[aId]/clone.tsx
+++ b/front/pages/w/[wId]/a/[aId]/clone.tsx
@@ -23,8 +23,8 @@ import WorkspacePicker from "@app/components/WorkspacePicker";
 import { getApp } from "@app/lib/api/app";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { getUserFromSession } from "@app/lib/iam/session";
+import { withGetServerSidePropsRequirements } from "@app/lib/iam/session";
 import { classNames } from "@app/lib/utils";
-import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
 
 const { GA_TRACKING_ID = "" } = process.env;
 

--- a/front/pages/w/[wId]/a/[aId]/clone.tsx
+++ b/front/pages/w/[wId]/a/[aId]/clone.tsx
@@ -28,7 +28,7 @@ import { classNames } from "@app/lib/utils";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withGetServerSidePropsLogging<{
+export const getServerSideProps = withGetServerSidePropsRequirements<{
   user: UserTypeWithWorkspaces;
   owner: WorkspaceType;
   subscription: SubscriptionType;

--- a/front/pages/w/[wId]/a/[aId]/datasets/[name]/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/datasets/[name]/index.tsx
@@ -20,11 +20,11 @@ import { getApp } from "@app/lib/api/app";
 import { getDatasetHash, getDatasetSchema } from "@app/lib/api/datasets";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { useRegisterUnloadHandlers } from "@app/lib/front";
-import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
+import { withGetServerSidePropsRequirements } from "@app/lib/iam/session";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withGetServerSidePropsLogging<{
+export const getServerSideProps = withGetServerSidePropsRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   readOnly: boolean;

--- a/front/pages/w/[wId]/a/[aId]/datasets/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/datasets/index.tsx
@@ -16,12 +16,12 @@ import {
 import { getApp } from "@app/lib/api/app";
 import { getDatasets } from "@app/lib/api/datasets";
 import { Authenticator, getSession } from "@app/lib/auth";
+import { withGetServerSidePropsRequirements } from "@app/lib/iam/session";
 import { classNames } from "@app/lib/utils";
-import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withGetServerSidePropsLogging<{
+export const getServerSideProps = withGetServerSidePropsRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   readOnly: boolean;

--- a/front/pages/w/[wId]/a/[aId]/datasets/new.tsx
+++ b/front/pages/w/[wId]/a/[aId]/datasets/new.tsx
@@ -20,11 +20,11 @@ import { getApp } from "@app/lib/api/app";
 import { getDatasets } from "@app/lib/api/datasets";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { useRegisterUnloadHandlers } from "@app/lib/front";
-import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
+import { withGetServerSidePropsRequirements } from "@app/lib/iam/session";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withGetServerSidePropsLogging<{
+export const getServerSideProps = withGetServerSidePropsRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   app: AppType;

--- a/front/pages/w/[wId]/a/[aId]/execute/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/execute/index.tsx
@@ -40,9 +40,9 @@ import {
   getDatasetTypes,
   getValueType,
 } from "@app/lib/datasets";
+import { withGetServerSidePropsRequirements } from "@app/lib/iam/session";
 import { useSavedRunStatus } from "@app/lib/swr";
 import { classNames } from "@app/lib/utils";
-import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
 
 const CodeEditor = dynamic(
   () => import("@uiw/react-textarea-code-editor").then((mod) => mod.default),
@@ -57,7 +57,7 @@ type Event = {
   };
 };
 
-export const getServerSideProps = withGetServerSidePropsLogging<{
+export const getServerSideProps = withGetServerSidePropsRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   app: AppType;

--- a/front/pages/w/[wId]/a/[aId]/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/index.tsx
@@ -35,6 +35,7 @@ import {
 import { getApp } from "@app/lib/api/app";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { extractConfig } from "@app/lib/config";
+import { withGetServerSidePropsRequirements } from "@app/lib/iam/session";
 import {
   addBlock,
   deleteBlock,
@@ -42,11 +43,10 @@ import {
   moveBlockUp,
 } from "@app/lib/specification";
 import { useSavedRunStatus } from "@app/lib/swr";
-import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
 
 const { URL = "", GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withGetServerSidePropsLogging<{
+export const getServerSideProps = withGetServerSidePropsRequirements<{
   user: UserType | null;
   owner: WorkspaceType;
   subscription: SubscriptionType;

--- a/front/pages/w/[wId]/a/[aId]/runs/[runId]/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/runs/[runId]/index.tsx
@@ -17,11 +17,11 @@ import {
 import { getApp } from "@app/lib/api/app";
 import { getRun } from "@app/lib/api/run";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
+import { withGetServerSidePropsRequirements } from "@app/lib/iam/session";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withGetServerSidePropsLogging<{
+export const getServerSideProps = withGetServerSidePropsRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   readOnly: boolean;

--- a/front/pages/w/[wId]/a/[aId]/runs/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/runs/index.tsx
@@ -16,13 +16,13 @@ import {
 } from "@app/components/sparkle/navigation";
 import { getApp } from "@app/lib/api/app";
 import { Authenticator, getSession } from "@app/lib/auth";
+import { withGetServerSidePropsRequirements } from "@app/lib/iam/session";
 import { useRuns } from "@app/lib/swr";
 import { classNames, timeAgoFrom } from "@app/lib/utils";
-import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withGetServerSidePropsLogging<{
+export const getServerSideProps = withGetServerSidePropsRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   readOnly: boolean;

--- a/front/pages/w/[wId]/a/[aId]/settings.tsx
+++ b/front/pages/w/[wId]/a/[aId]/settings.tsx
@@ -17,12 +17,12 @@ import {
 } from "@app/components/sparkle/navigation";
 import { getApp } from "@app/lib/api/app";
 import { Authenticator, getSession } from "@app/lib/auth";
+import { withGetServerSidePropsRequirements } from "@app/lib/iam/session";
 import { classNames, MODELS_STRING_MAX_LENGTH } from "@app/lib/utils";
-import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withGetServerSidePropsLogging<{
+export const getServerSideProps = withGetServerSidePropsRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   app: AppType;

--- a/front/pages/w/[wId]/a/[aId]/specification.tsx
+++ b/front/pages/w/[wId]/a/[aId]/specification.tsx
@@ -12,13 +12,13 @@ import {
 } from "@app/components/sparkle/navigation";
 import { getApp } from "@app/lib/api/app";
 import { Authenticator, getSession } from "@app/lib/auth";
+import { withGetServerSidePropsRequirements } from "@app/lib/iam/session";
 import { dumpSpecification } from "@app/lib/specification";
 import logger from "@app/logger/logger";
-import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withGetServerSidePropsLogging<{
+export const getServerSideProps = withGetServerSidePropsRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   readOnly: boolean;

--- a/front/pages/w/[wId]/a/index.tsx
+++ b/front/pages/w/[wId]/a/index.tsx
@@ -26,14 +26,14 @@ import { subNavigationBuild } from "@app/components/sparkle/navigation";
 import { getApps } from "@app/lib/api/app";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { useSubmitFunction } from "@app/lib/client/utils";
+import { withGetServerSidePropsRequirements } from "@app/lib/iam/session";
 import { modelProviders, serviceProviders } from "@app/lib/providers";
 import { useKeys, useProviders } from "@app/lib/swr";
 import { classNames, timeAgoFrom } from "@app/lib/utils";
-import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withGetServerSidePropsLogging<{
+export const getServerSideProps = withGetServerSidePropsRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   apps: AppType[];

--- a/front/pages/w/[wId]/a/new.tsx
+++ b/front/pages/w/[wId]/a/new.tsx
@@ -11,12 +11,12 @@ import React, { useCallback, useEffect, useState } from "react";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { subNavigationBuild } from "@app/components/sparkle/navigation";
 import { Authenticator, getSession } from "@app/lib/auth";
+import { withGetServerSidePropsRequirements } from "@app/lib/iam/session";
 import { classNames, MODELS_STRING_MAX_LENGTH } from "@app/lib/utils";
-import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withGetServerSidePropsLogging<{
+export const getServerSideProps = withGetServerSidePropsRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   gaTrackingId: string;

--- a/front/pages/w/[wId]/assistant/[cId]/index.tsx
+++ b/front/pages/w/[wId]/assistant/[cId]/index.tsx
@@ -18,13 +18,13 @@ import { AssistantSidebarMenu } from "@app/components/assistant/conversation/Sid
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { Authenticator, getSession } from "@app/lib/auth";
+import { withGetServerSidePropsRequirements } from "@app/lib/iam/session";
 import { useConversation } from "@app/lib/swr";
-import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
 import { LimitReachedPopup } from "@app/pages/w/[wId]/assistant/new";
 
 const { URL = "", GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withGetServerSidePropsLogging<{
+export const getServerSideProps = withGetServerSidePropsRequirements<{
   user: UserType;
   owner: WorkspaceType;
   subscription: SubscriptionType;

--- a/front/pages/w/[wId]/assistant/assistants.tsx
+++ b/front/pages/w/[wId]/assistant/assistants.tsx
@@ -23,13 +23,13 @@ import { SCOPE_INFO } from "@app/components/assistant/Sharing";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { Authenticator, getSession } from "@app/lib/auth";
+import { withGetServerSidePropsRequirements } from "@app/lib/iam/session";
 import { useAgentConfigurations } from "@app/lib/swr";
 import { subFilter } from "@app/lib/utils";
-import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withGetServerSidePropsLogging<{
+export const getServerSideProps = withGetServerSidePropsRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   gaTrackingId: string;

--- a/front/pages/w/[wId]/assistant/gallery.tsx
+++ b/front/pages/w/[wId]/assistant/gallery.tsx
@@ -28,13 +28,13 @@ import { TryAssistantModal } from "@app/components/assistant/TryAssistantModal";
 import AppLayout, { appLayoutBack } from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { Authenticator, getSession } from "@app/lib/auth";
+import { withGetServerSidePropsRequirements } from "@app/lib/iam/session";
 import { useAgentConfigurations } from "@app/lib/swr";
 import { subFilter } from "@app/lib/utils";
-import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withGetServerSidePropsLogging<{
+export const getServerSideProps = withGetServerSidePropsRequirements<{
   user: UserType;
   owner: WorkspaceType;
   plan: PlanType | null;

--- a/front/pages/w/[wId]/assistant/new.tsx
+++ b/front/pages/w/[wId]/assistant/new.tsx
@@ -39,12 +39,12 @@ import { compareAgentsForSort } from "@app/lib/assistant";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { getRandomGreetingForName } from "@app/lib/client/greetings";
 import { useSubmitFunction } from "@app/lib/client/utils";
+import { withGetServerSidePropsRequirements } from "@app/lib/iam/session";
 import { useAgentConfigurations } from "@app/lib/swr";
-import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withGetServerSidePropsLogging<{
+export const getServerSideProps = withGetServerSidePropsRequirements<{
   user: UserType;
   isBuilder: boolean;
   subscription: SubscriptionType;

--- a/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
@@ -26,11 +26,11 @@ import { getApps } from "@app/lib/api/app";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
 import { getDataSources } from "@app/lib/api/data_sources";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
+import { withGetServerSidePropsRequirements } from "@app/lib/iam/session";
 
 const { GA_TRACKING_ID = "", URL = "" } = process.env;
 
-export const getServerSideProps = withGetServerSidePropsLogging<{
+export const getServerSideProps = withGetServerSidePropsRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   plan: PlanType;

--- a/front/pages/w/[wId]/builder/assistants/dust.tsx
+++ b/front/pages/w/[wId]/builder/assistants/dust.tsx
@@ -25,12 +25,12 @@ import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 import { getDisplayNameForDataSource } from "@app/lib/data_sources";
+import { withGetServerSidePropsRequirements } from "@app/lib/iam/session";
 import { useAgentConfigurations, useDataSources } from "@app/lib/swr";
-import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withGetServerSidePropsLogging<{
+export const getServerSideProps = withGetServerSidePropsRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   gaTrackingId: string;

--- a/front/pages/w/[wId]/builder/assistants/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/index.tsx
@@ -32,13 +32,13 @@ import AppLayout from "@app/components/sparkle/AppLayout";
 import { subNavigationBuild } from "@app/components/sparkle/navigation";
 import { compareAgentsForSort } from "@app/lib/assistant";
 import { Authenticator, getSession } from "@app/lib/auth";
+import { withGetServerSidePropsRequirements } from "@app/lib/iam/session";
 import { useAgentConfigurations } from "@app/lib/swr";
 import { classNames, subFilter } from "@app/lib/utils";
-import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withGetServerSidePropsLogging<{
+export const getServerSideProps = withGetServerSidePropsRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   tabScope: AgentConfigurationScope;

--- a/front/pages/w/[wId]/builder/assistants/new.tsx
+++ b/front/pages/w/[wId]/builder/assistants/new.tsx
@@ -26,11 +26,11 @@ import { getApps } from "@app/lib/api/app";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
 import { getDataSources } from "@app/lib/api/data_sources";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
+import { withGetServerSidePropsRequirements } from "@app/lib/iam/session";
 
 const { GA_TRACKING_ID = "", URL = "" } = process.env;
 
-export const getServerSideProps = withGetServerSidePropsLogging<{
+export const getServerSideProps = withGetServerSidePropsRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   plan: PlanType;

--- a/front/pages/w/[wId]/builder/data-sources/[name]/edit-public-url.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/edit-public-url.tsx
@@ -10,12 +10,12 @@ import type { InferGetServerSidePropsType } from "next";
 import WebsiteConfiguration from "@app/components/data_source/WebsiteConfiguration";
 import { getDataSource, getDataSources } from "@app/lib/api/data_sources";
 import { Authenticator, getSession } from "@app/lib/auth";
+import { withGetServerSidePropsRequirements } from "@app/lib/iam/session";
 import logger from "@app/logger/logger";
-import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withGetServerSidePropsLogging<{
+export const getServerSideProps = withGetServerSidePropsRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   dataSources: DataSourceType[];

--- a/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
@@ -47,10 +47,10 @@ import { buildConnectionId } from "@app/lib/connector_connection_id";
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 import { getDisplayNameForDocument } from "@app/lib/data_sources";
 import { githubAuth } from "@app/lib/github_auth";
+import { withGetServerSidePropsRequirements } from "@app/lib/iam/session";
 import { useConnectorConfig, useDocuments, useTables } from "@app/lib/swr";
 import { timeAgoFrom } from "@app/lib/utils";
 import logger from "@app/logger/logger";
-import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
 
 const {
   GA_TRACKING_ID = "",
@@ -63,7 +63,7 @@ const {
   NANGO_SLACK_CONNECTOR_ID = "",
 } = process.env;
 
-export const getServerSideProps = withGetServerSidePropsLogging<{
+export const getServerSideProps = withGetServerSidePropsRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   plan: PlanType;

--- a/front/pages/w/[wId]/builder/data-sources/[name]/search.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/search.tsx
@@ -15,12 +15,12 @@ import { subNavigationBuild } from "@app/components/sparkle/navigation";
 import { getDataSource } from "@app/lib/api/data_sources";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { getDisplayNameForDocument } from "@app/lib/data_sources";
+import { withGetServerSidePropsRequirements } from "@app/lib/iam/session";
 import { classNames, timeAgoFrom } from "@app/lib/utils";
-import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withGetServerSidePropsLogging<{
+export const getServerSideProps = withGetServerSidePropsRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   dataSource: DataSourceType;

--- a/front/pages/w/[wId]/builder/data-sources/[name]/settings.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/settings.tsx
@@ -17,12 +17,12 @@ import { AppLayoutSimpleSaveCancelTitle } from "@app/components/sparkle/AppLayou
 import { subNavigationBuild } from "@app/components/sparkle/navigation";
 import { getDataSource } from "@app/lib/api/data_sources";
 import { Authenticator, getSession } from "@app/lib/auth";
+import { withGetServerSidePropsRequirements } from "@app/lib/iam/session";
 import { classNames } from "@app/lib/utils";
-import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withGetServerSidePropsLogging<{
+export const getServerSideProps = withGetServerSidePropsRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   dataSource: DataSourceType;

--- a/front/pages/w/[wId]/builder/data-sources/[name]/tables/upsert.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/tables/upsert.tsx
@@ -28,14 +28,14 @@ import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { getDataSource } from "@app/lib/api/data_sources";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { handleFileUploadToText } from "@app/lib/client/handle_file_upload";
+import { withGetServerSidePropsRequirements } from "@app/lib/iam/session";
 import { useTable } from "@app/lib/swr";
 import { classNames } from "@app/lib/utils";
-import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
 import type { UpsertTableFromCsvRequestBody } from "@app/pages/api/w/[wId]/data_sources/[name]/tables/csv";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withGetServerSidePropsLogging<{
+export const getServerSideProps = withGetServerSidePropsRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   readOnly: boolean;

--- a/front/pages/w/[wId]/builder/data-sources/[name]/upsert.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/upsert.tsx
@@ -29,12 +29,12 @@ import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { getDataSource } from "@app/lib/api/data_sources";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { handleFileUploadToText } from "@app/lib/client/handle_file_upload";
+import { withGetServerSidePropsRequirements } from "@app/lib/iam/session";
 import { classNames } from "@app/lib/utils";
-import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withGetServerSidePropsLogging<{
+export const getServerSideProps = withGetServerSidePropsRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   plan: PlanType;

--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -35,9 +35,9 @@ import { Authenticator, getSession } from "@app/lib/auth";
 import { buildConnectionId } from "@app/lib/connector_connection_id";
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 import { githubAuth } from "@app/lib/github_auth";
+import { withGetServerSidePropsRequirements } from "@app/lib/iam/session";
 import { timeAgoFrom } from "@app/lib/utils";
 import logger from "@app/logger/logger";
-import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
 
 const {
   GA_TRACKING_ID = "",
@@ -73,7 +73,7 @@ const REDIRECT_TO_EDIT_PERMISSIONS = [
   "intercom",
 ];
 
-export const getServerSideProps = withGetServerSidePropsLogging<{
+export const getServerSideProps = withGetServerSidePropsRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   readOnly: boolean;

--- a/front/pages/w/[wId]/builder/data-sources/new-public-url.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/new-public-url.tsx
@@ -8,11 +8,11 @@ import type { InferGetServerSidePropsType } from "next";
 import WebsiteConfiguration from "@app/components/data_source/WebsiteConfiguration";
 import { getDataSources } from "@app/lib/api/data_sources";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
+import { withGetServerSidePropsRequirements } from "@app/lib/iam/session";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withGetServerSidePropsLogging<{
+export const getServerSideProps = withGetServerSidePropsRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   dataSources: DataSourceType[];

--- a/front/pages/w/[wId]/builder/data-sources/new.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/new.tsx
@@ -12,12 +12,12 @@ import { AppLayoutSimpleSaveCancelTitle } from "@app/components/sparkle/AppLayou
 import { subNavigationBuild } from "@app/components/sparkle/navigation";
 import { getDataSources } from "@app/lib/api/data_sources";
 import { Authenticator, getSession } from "@app/lib/auth";
+import { withGetServerSidePropsRequirements } from "@app/lib/iam/session";
 import { classNames } from "@app/lib/utils";
-import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withGetServerSidePropsLogging<{
+export const getServerSideProps = withGetServerSidePropsRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   dataSources: DataSourceType[];

--- a/front/pages/w/[wId]/builder/data-sources/public-urls.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/public-urls.tsx
@@ -26,8 +26,8 @@ import { subNavigationBuild } from "@app/components/sparkle/navigation";
 import { getDataSources } from "@app/lib/api/data_sources";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { useSubmitFunction } from "@app/lib/client/utils";
+import { withGetServerSidePropsRequirements } from "@app/lib/iam/session";
 import logger from "@app/logger/logger";
-import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
@@ -35,7 +35,7 @@ type DataSourceWithConnector = DataSourceType & {
   connector: ConnectorType;
 };
 
-export const getServerSideProps = withGetServerSidePropsLogging<{
+export const getServerSideProps = withGetServerSidePropsRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   plan: PlanType;

--- a/front/pages/w/[wId]/builder/data-sources/static.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/static.tsx
@@ -20,11 +20,11 @@ import { subNavigationBuild } from "@app/components/sparkle/navigation";
 import { getDataSources } from "@app/lib/api/data_sources";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { useSubmitFunction } from "@app/lib/client/utils";
-import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
+import { withGetServerSidePropsRequirements } from "@app/lib/iam/session";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withGetServerSidePropsLogging<{
+export const getServerSideProps = withGetServerSidePropsRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   plan: PlanType;

--- a/front/pages/w/[wId]/index.tsx
+++ b/front/pages/w/[wId]/index.tsx
@@ -1,7 +1,7 @@
 import { Authenticator, getSession } from "@app/lib/auth";
-import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
+import { withGetServerSidePropsRequirements } from "@app/lib/iam/session";
 
-export const getServerSideProps = withGetServerSidePropsLogging<object>(
+export const getServerSideProps = withGetServerSidePropsRequirements<object>(
   async (context) => {
     const session = await getSession(context.req, context.res);
     const auth = await Authenticator.fromSession(

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -37,16 +37,16 @@ import {
   getWorkspaceVerifiedDomain,
 } from "@app/lib/api/workspace";
 import { Authenticator, getSession } from "@app/lib/auth";
+import { withGetServerSidePropsRequirements } from "@app/lib/iam/session";
 import { isUpgraded } from "@app/lib/plans/plan_codes";
 import { useMembers, useWorkspaceInvitations } from "@app/lib/swr";
 import { classNames, isEmailValid } from "@app/lib/utils";
-import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
 const CLOSING_ANIMATION_DURATION = 200;
 
-export const getServerSideProps = withGetServerSidePropsLogging<{
+export const getServerSideProps = withGetServerSidePropsRequirements<{
   user: UserType;
   owner: WorkspaceType;
   subscription: SubscriptionType;

--- a/front/pages/w/[wId]/subscription/index.tsx
+++ b/front/pages/w/[wId]/subscription/index.tsx
@@ -20,6 +20,7 @@ import { subNavigationAdmin } from "@app/components/sparkle/navigation";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { useSubmitFunction } from "@app/lib/client/utils";
+import { withGetServerSidePropsRequirements } from "@app/lib/iam/session";
 import {
   FREE_TEST_PLAN_CODE,
   FREE_UPGRADED_PLAN_CODE,
@@ -27,11 +28,10 @@ import {
   PRO_PLAN_SEAT_29_CODE,
 } from "@app/lib/plans/plan_codes";
 import { getPlanInvitation } from "@app/lib/plans/subscription";
-import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withGetServerSidePropsLogging<{
+export const getServerSideProps = withGetServerSidePropsRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   planInvitation: PlanInvitationType | null;

--- a/front/pages/w/[wId]/subscription/upgrade-enterprise/[secret].tsx
+++ b/front/pages/w/[wId]/subscription/upgrade-enterprise/[secret].tsx
@@ -1,10 +1,10 @@
 import { Authenticator, getSession } from "@app/lib/auth";
+import { withGetServerSidePropsRequirements } from "@app/lib/iam/session";
 import { Workspace } from "@app/lib/models";
 import { PlanInvitation } from "@app/lib/models/plan";
 import { getCheckoutUrlForUpgrade } from "@app/lib/plans/subscription";
-import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
 
-export const getServerSideProps = withGetServerSidePropsLogging<object>(
+export const getServerSideProps = withGetServerSidePropsRequirements<object>(
   async (context) => {
     const session = await getSession(context.req, context.res);
     const auth = await Authenticator.fromSession(

--- a/front/pages/w/[wId]/u/extract/events/[sId]/edit.tsx
+++ b/front/pages/w/[wId]/u/extract/events/[sId]/edit.tsx
@@ -11,12 +11,12 @@ import AppLayout from "@app/components/sparkle/AppLayout";
 import { subNavigationBuild } from "@app/components/sparkle/navigation";
 import { getEventSchema, getExtractedEvent } from "@app/lib/api/extract";
 import { Authenticator, getSession } from "@app/lib/auth";
+import { withGetServerSidePropsRequirements } from "@app/lib/iam/session";
 import { classNames } from "@app/lib/utils";
-import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withGetServerSidePropsLogging<{
+export const getServerSideProps = withGetServerSidePropsRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   event: ExtractedEventType;

--- a/front/pages/w/[wId]/u/extract/index.tsx
+++ b/front/pages/w/[wId]/u/extract/index.tsx
@@ -9,11 +9,11 @@ import { useRouter } from "next/router";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { subNavigationBuild } from "@app/components/sparkle/navigation";
 import { Authenticator, getSession } from "@app/lib/auth";
+import { withGetServerSidePropsRequirements } from "@app/lib/iam/session";
 import { useEventSchemas } from "@app/lib/swr";
-import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
 
 const { GA_TRACKING_ID = "" } = process.env;
-export const getServerSideProps = withGetServerSidePropsLogging<{
+export const getServerSideProps = withGetServerSidePropsRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   readOnly: boolean;

--- a/front/pages/w/[wId]/u/extract/templates/[sId]/edit.tsx
+++ b/front/pages/w/[wId]/u/extract/templates/[sId]/edit.tsx
@@ -8,11 +8,11 @@ import { subNavigationBuild } from "@app/components/sparkle/navigation";
 import { ExtractEventSchemaForm } from "@app/components/use/EventSchemaForm";
 import { getEventSchema } from "@app/lib/api/extract";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
+import { withGetServerSidePropsRequirements } from "@app/lib/iam/session";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withGetServerSidePropsLogging<{
+export const getServerSideProps = withGetServerSidePropsRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   schema: EventSchemaType;

--- a/front/pages/w/[wId]/u/extract/templates/[sId]/index.tsx
+++ b/front/pages/w/[wId]/u/extract/templates/[sId]/index.tsx
@@ -26,13 +26,13 @@ import { subNavigationBuild } from "@app/components/sparkle/navigation";
 import { getEventSchema } from "@app/lib/api/extract";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
+import { withGetServerSidePropsRequirements } from "@app/lib/iam/session";
 import { useExtractedEvents } from "@app/lib/swr";
 import { classNames, objectToMarkdown } from "@app/lib/utils";
-import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withGetServerSidePropsLogging<{
+export const getServerSideProps = withGetServerSidePropsRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   schema: EventSchemaType;

--- a/front/pages/w/[wId]/u/extract/templates/new.tsx
+++ b/front/pages/w/[wId]/u/extract/templates/new.tsx
@@ -6,11 +6,11 @@ import AppLayout from "@app/components/sparkle/AppLayout";
 import { subNavigationBuild } from "@app/components/sparkle/navigation";
 import { ExtractEventSchemaForm } from "@app/components/use/EventSchemaForm";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
+import { withGetServerSidePropsRequirements } from "@app/lib/iam/session";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withGetServerSidePropsLogging<{
+export const getServerSideProps = withGetServerSidePropsRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   readOnly: boolean;

--- a/front/pages/w/[wId]/welcome.tsx
+++ b/front/pages/w/[wId]/welcome.tsx
@@ -8,14 +8,14 @@ import OnboardingLayout from "@app/components/sparkle/OnboardingLayout";
 import { getUserMetadata } from "@app/lib/api/user";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { useSubmitFunction } from "@app/lib/client/utils";
-import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
+import { withGetServerSidePropsRequirements } from "@app/lib/iam/session";
 
 const { URL = "", GA_TRACKING_ID = "" } = process.env;
 
 const ADMIN_YOUTUBE_ID = "f9n4mqBX2aw";
 const MEMBER_YOUTUBE_ID = null; // We don't have the video yet.
 
-export const getServerSideProps = withGetServerSidePropsLogging<{
+export const getServerSideProps = withGetServerSidePropsRequirements<{
   user: UserType;
   owner: WorkspaceType;
   isAdmin: boolean;

--- a/front/pages/w/[wId]/workspace/index.tsx
+++ b/front/pages/w/[wId]/workspace/index.tsx
@@ -15,12 +15,12 @@ import { useCallback, useEffect, useState } from "react";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { subNavigationAdmin } from "@app/components/sparkle/navigation";
 import { Authenticator, getSession } from "@app/lib/auth";
+import { withGetServerSidePropsRequirements } from "@app/lib/iam/session";
 import { useWorkspaceAnalytics } from "@app/lib/swr";
-import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withGetServerSidePropsLogging<{
+export const getServerSideProps = withGetServerSidePropsRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   gaTrackingId: string;


### PR DESCRIPTION
## Description

This PR resolves https://github.com/dust-tt/dust/issues/4130.

Design doc: [here](https://www.notion.so/dust-tt/Authentification-in-app-6a3e446898214ef7b6640a2257a24c94).

This PR introduces `withGetServerSidePropsRequirements`, which is designed to wrap all calls to `getServerSideProps`. It currently serves two main purposes:
1. Instrumentation: It calls `withGetServerSidePropsLogging` under the hood to record performance data.
2. Authentication: It ensures the user has a valid session or redirects them to the home page (future improvements will include a customizable `returnTo` feature).

Both options can be customized through an optional object. By default, both features are enabled, meaning that to access a page, users must be connected, and performance data will be recorded.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
