### PR TITLE
Connector: rename resource parents to content node parents (1/2)

### DIFF
--- a/connectors/src/api/get_content_node_parents.ts
+++ b/connectors/src/api/get_content_node_parents.ts
@@ -71,7 +71,7 @@ const _getContentNodesParents = async (
 
   for (const [internalId, parentsResult] of zip(internalIds, parentsResults)) {
     if (parentsResult.isErr()) {
-      logger.error(parentsResult.error, "Failed to get resource parents");
+      logger.error(parentsResult.error, "Failed to get content node parents");
       return apiError(req, res, {
         status_code: 500,
         api_error: {

--- a/connectors/src/api/get_content_node_parents.ts
+++ b/connectors/src/api/get_content_node_parents.ts
@@ -11,28 +11,28 @@ import logger from "@connectors/logger/logger";
 import { apiError, withLogging } from "@connectors/logger/withlogging";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 
-const GetResourcesParentsRequestBodySchema = t.type({
-  resourceInternalIds: t.array(t.string),
+const GetContentNodesParentsRequestBodySchema = t.type({
+  internalIds: t.array(t.string),
 });
 
-export type GetResourcesParentsRequestBody = t.TypeOf<
-  typeof GetResourcesParentsRequestBodySchema
+export type GetContentNodesParentsRequestBody = t.TypeOf<
+  typeof GetContentNodesParentsRequestBodySchema
 >;
 
-type GetResourcesParentsResponseBody = WithConnectorsAPIErrorReponse<{
-  resources: {
+type GetContentNodesResponseBody = WithConnectorsAPIErrorReponse<{
+  nodes: {
     internalId: string;
     parents: string[] | null;
   }[];
 }>;
 
-const _getResourcesParents = async (
+const _getContentNodesParents = async (
   req: Request<
     { connector_id: string },
-    GetResourcesParentsResponseBody,
-    GetResourcesParentsRequestBody
+    GetContentNodesResponseBody,
+    GetContentNodesParentsRequestBody
   >,
-  res: Response<GetResourcesParentsResponseBody>
+  res: Response<GetContentNodesResponseBody>
 ) => {
   const connector = await ConnectorResource.fetchById(req.params.connector_id);
   if (!connector) {
@@ -45,7 +45,9 @@ const _getResourcesParents = async (
     });
   }
 
-  const bodyValidation = GetResourcesParentsRequestBodySchema.decode(req.body);
+  const bodyValidation = GetContentNodesParentsRequestBodySchema.decode(
+    req.body
+  );
   if (isLeft(bodyValidation)) {
     const pathError = reporter.formatValidationErrors(bodyValidation.left);
     return apiError(req, res, {
@@ -57,20 +59,17 @@ const _getResourcesParents = async (
     });
   }
 
-  const { resourceInternalIds } = bodyValidation.right;
+  const { internalIds } = bodyValidation.right;
 
   const parentsGetter = RETRIEVE_CONTENT_NODE_PARENTS_BY_TYPE[connector.type];
   const parentsResults = await concurrentExecutor(
-    resourceInternalIds,
-    (resourceInternalId) => parentsGetter(connector.id, resourceInternalId),
+    internalIds,
+    (internalId) => parentsGetter(connector.id, internalId),
     { concurrency: 4 }
   );
-  const resources: { internalId: string; parents: string[] }[] = [];
+  const nodes: { internalId: string; parents: string[] }[] = [];
 
-  for (const [internalId, parentsResult] of zip(
-    resourceInternalIds,
-    parentsResults
-  )) {
+  for (const [internalId, parentsResult] of zip(internalIds, parentsResults)) {
     if (parentsResult.isErr()) {
       logger.error(parentsResult.error, "Failed to get resource parents");
       return apiError(req, res, {
@@ -82,13 +81,15 @@ const _getResourcesParents = async (
       });
     }
 
-    resources.push({
+    nodes.push({
       internalId,
       parents: parentsResult.value,
     });
   }
 
-  return res.status(200).json({ resources });
+  return res.status(200).json({ nodes });
 };
 
-export const getResourcesParentsAPIHandler = withLogging(_getResourcesParents);
+export const getContentNodesParentsAPIHandler = withLogging(
+  _getContentNodesParents
+);

--- a/connectors/src/api_server.ts
+++ b/connectors/src/api_server.ts
@@ -98,6 +98,7 @@ export function startServer(port: number) {
     "/connectors/:connector_id/permissions",
     getConnectorPermissionsAPIHandler
   );
+  // @deprecated Daph to remove
   app.post(
     // must be POST because of body
     "/connectors/:connector_id/resources/parents",

--- a/connectors/src/api_server.ts
+++ b/connectors/src/api_server.ts
@@ -8,6 +8,7 @@ import { createConnectorAPIHandler } from "@connectors/api/create_connector";
 import { deleteConnectorAPIHandler } from "@connectors/api/delete_connector";
 import { getConnectorAPIHandler } from "@connectors/api/get_connector";
 import { getConnectorPermissionsAPIHandler } from "@connectors/api/get_connector_permissions";
+import { getContentNodesParentsAPIHandler } from "@connectors/api/get_content_node_parents";
 import { getConnectorNodesAPIHandler } from "@connectors/api/get_content_nodes";
 import { getResourcesParentsAPIHandler } from "@connectors/api/get_resources_parents";
 import { getResourcesTitlesAPIHandler } from "@connectors/api/get_resources_titles";
@@ -101,6 +102,11 @@ export function startServer(port: number) {
     // must be POST because of body
     "/connectors/:connector_id/resources/parents",
     getResourcesParentsAPIHandler
+  );
+  app.post(
+    // must be POST because of body
+    "/connectors/:connector_id/content_nodes/parents",
+    getContentNodesParentsAPIHandler
   );
   app.post(
     // must be POST because of body

--- a/connectors/src/connectors/confluence/index.ts
+++ b/connectors/src/connectors/confluence/index.ts
@@ -473,7 +473,7 @@ export async function retrieveConfluenceContentNodes(
   return new Ok(contentNodes);
 }
 
-export async function retrieveConfluenceResourceParents(
+export async function retrieveConfluenceContentNodeParents(
   connectorId: ModelId,
   internalId: string
 ): Promise<Result<string[], Error>> {

--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -750,7 +750,7 @@ export async function setGithubConfig(
   }
 }
 
-export async function retrieveGithubResourceParents(
+export async function retrieveGithubContentNodeParents(
   connectorId: ModelId,
   internalId: string
 ): Promise<Result<string[], Error>> {

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -610,7 +610,7 @@ export async function retrieveGoogleDriveContentNodes(
   return new Ok(nodes);
 }
 
-export async function retrieveGoogleDriveObjectsParents(
+export async function retrieveGoogleDriveContentNodeParents(
   connectorId: ModelId,
   internalId: string,
   memoizationKey?: string

--- a/connectors/src/connectors/index.ts
+++ b/connectors/src/connectors/index.ts
@@ -5,9 +5,9 @@ import {
   createConfluenceConnector,
   resumeConfluenceConnector,
   retrieveConfluenceConnectorPermissions,
+  retrieveConfluenceContentNodeParents,
   retrieveConfluenceContentNodes,
   retrieveConfluenceObjectsTitles,
-  retrieveConfluenceResourceParents,
   setConfluenceConnectorPermissions,
   stopConfluenceConnector,
   updateConfluenceConnector,
@@ -20,9 +20,9 @@ import {
   getGithubConfig,
   resumeGithubConnector,
   retrieveGithubConnectorPermissions,
+  retrieveGithubContentNodeParents,
   retrieveGithubReposContentNodes,
   retrieveGithubReposTitles,
-  retrieveGithubResourceParents,
   setGithubConfig,
   stopGithubConnector,
   updateGithubConnector,
@@ -33,8 +33,8 @@ import {
   getGoogleDriveConfig,
   googleDriveGarbageCollect,
   retrieveGoogleDriveConnectorPermissions,
+  retrieveGoogleDriveContentNodeParents,
   retrieveGoogleDriveContentNodes,
-  retrieveGoogleDriveObjectsParents,
   retrieveGoogleDriveObjectsTitles,
   setGoogleDriveConfig,
   setGoogleDriveConnectorPermissions,
@@ -47,9 +47,9 @@ import {
   fullResyncIntercomSyncWorkflow,
   resumeIntercomConnector,
   retrieveIntercomConnectorPermissions,
+  retrieveIntercomContentNodeParents,
   retrieveIntercomContentNodes,
   retrieveIntercomNodesTitles,
-  retrieveIntercomObjectsParents,
   setIntercomConnectorPermissions,
   stopIntercomConnector,
   updateIntercomConnector,
@@ -78,9 +78,9 @@ import {
   fullResyncNotionConnector,
   resumeNotionConnector,
   retrieveNotionConnectorPermissions,
+  retrieveNotionContentNodeParents,
   retrieveNotionContentNodes,
   retrieveNotionNodesTitles,
-  retrieveNotionResourceParents,
   stopNotionConnector,
   updateNotionConnector,
 } from "@connectors/connectors/notion";
@@ -103,8 +103,8 @@ import {
   cleanupWebcrawlerConnector,
   createWebcrawlerConnector,
   retrieveWebcrawlerConnectorPermissions,
+  retrieveWebCrawlerContentNodeParents,
   retrieveWebCrawlerContentNodes,
-  retrieveWebCrawlerObjectsParents,
   retrieveWebCrawlerObjectsTitles,
   stopWebcrawlerConnector,
   updateWebcrawlerConnector,
@@ -264,17 +264,17 @@ export const BATCH_RETRIEVE_CONTENT_NODES_BY_TYPE: Record<
   webcrawler: retrieveWebCrawlerContentNodes,
 };
 
-export const RETRIEVE_RESOURCE_PARENTS_BY_TYPE: Record<
+export const RETRIEVE_CONTENT_NODE_PARENTS_BY_TYPE: Record<
   ConnectorProvider,
   ConnectorNodeParentsRetriever
 > = {
-  confluence: retrieveConfluenceResourceParents,
-  notion: retrieveNotionResourceParents,
-  google_drive: retrieveGoogleDriveObjectsParents,
+  confluence: retrieveConfluenceContentNodeParents,
+  notion: retrieveNotionContentNodeParents,
+  google_drive: retrieveGoogleDriveContentNodeParents,
   slack: async () => new Ok([]), // Slack is flat
-  github: retrieveGithubResourceParents,
-  intercom: retrieveIntercomObjectsParents,
-  webcrawler: retrieveWebCrawlerObjectsParents,
+  github: retrieveGithubContentNodeParents,
+  intercom: retrieveIntercomContentNodeParents,
+  webcrawler: retrieveWebCrawlerContentNodeParents,
 };
 
 export const SET_CONNECTOR_CONFIG_BY_TYPE: Record<

--- a/connectors/src/connectors/intercom/index.ts
+++ b/connectors/src/connectors/intercom/index.ts
@@ -746,7 +746,7 @@ export async function retrieveIntercomContentNodes(
   return new Ok(nodes);
 }
 
-export async function retrieveIntercomObjectsParents(
+export async function retrieveIntercomContentNodeParents(
   connectorId: ModelId,
   internalId: string
 ): Promise<Result<string[], Error>> {

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -497,7 +497,7 @@ export async function retrieveNotionNodesTitles(
   return new Ok(titles);
 }
 
-export async function retrieveNotionResourceParents(
+export async function retrieveNotionContentNodeParents(
   connectorId: ModelId,
   internalId: string,
   memoizationKey?: string

--- a/connectors/src/connectors/webcrawler/index.ts
+++ b/connectors/src/connectors/webcrawler/index.ts
@@ -345,7 +345,7 @@ export async function retrieveWebCrawlerContentNodes(
   return new Ok(nodes);
 }
 
-export async function retrieveWebCrawlerObjectsParents(
+export async function retrieveWebCrawlerContentNodeParents(
   connectorId: ModelId,
   internalId: string
 ): Promise<Result<string[], Error>> {

--- a/types/src/front/lib/connectors_api.ts
+++ b/types/src/front/lib/connectors_api.ts
@@ -334,6 +334,37 @@ export class ConnectorsAPI {
     return this._resultFromResponse(res);
   }
 
+  async getContentNodesParents({
+    connectorId,
+    internalIds,
+  }: {
+    connectorId: string;
+    internalIds: string[];
+  }): Promise<
+    ConnectorsAPIResponse<{
+      nodes: {
+        internalId: string;
+        parents: string[];
+      }[];
+    }>
+  > {
+    const res = await fetch(
+      `${CONNECTORS_API}/connectors/${encodeURIComponent(
+        connectorId
+      )}/content_nodes/parents`,
+      {
+        method: "POST",
+        headers: this.getDefaultHeaders(),
+        body: JSON.stringify({
+          internalIds,
+        }),
+      }
+    );
+
+    return this._resultFromResponse(res);
+  }
+
+  // @deprecated
   async getResourcesParents({
     connectorId,
     resourceInternalIds,


### PR DESCRIPTION
## Description

- Rename RETRIEVE_RESOURCE_PARENTS_BY_TYPE by RETRIEVE_CONTENT_NODE_PARENTS_BY_TYPE + name of all functions per connector
- Duplicate `connectors/src/api/get_resources_parents.ts` to  `connectors/src/api/get_content_node_parents.ts` with changes in naming not logic. 
- Add new route `/connectors/:connector_id/content_nodes/parents` on top of `/connectors/:connector_id/resources/parents` that will be removed afterward

Next: 
- Front PR that calls the new URL .
- Connector PR to remove the deprecated code.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
