### PR TITLE
Confluence: Fix get content node logic

### DIFF
--- a/connectors/src/connectors/confluence/index.ts
+++ b/connectors/src/connectors/confluence/index.ts
@@ -448,14 +448,15 @@ export async function retrieveConfluenceContentNodes(
   const pageContentNodes: ConnectorNode[] = await concurrentExecutor(
     confluencePages,
     async (page) => {
-      const parentId = page.parentId ?? page.spaceId;
+      let parentId: string;
       let parentType: "page" | "space";
-      if (isConfluenceInternalSpaceId(parentId)) {
-        parentType = "space";
-      } else if (isConfluenceInternalPageId(parentId)) {
+
+      if (page.parentId) {
+        parentId = page.parentId;
         parentType = "page";
       } else {
-        throw new Error("Invalid parent type");
+        parentId = page.spaceId;
+        parentType = "space";
       }
       const isExpandable = await checkPageHasChildren(connectorId, page.pageId);
 


### PR DESCRIPTION
## Description

The last commit on my PR https://github.com/dust-tt/dust/pull/4083 was not good as I was using isConfluenceInternalSpaceId & isConfluenceInternalPageId on the id directly 🤦🏻‍♀️ 
Could refactor to have shorter code but this is imo the most readable

I fixed it: if there's a parentId -> it's a page, if not the space is the parent. 

## Risk

Low, not used in prod yet. 

## Deploy Plan

/