### PR TITLE
Show Slack integration only for published and workspace assistants

### DIFF
--- a/front/components/assistant/Sharing.tsx
+++ b/front/components/assistant/Sharing.tsx
@@ -109,6 +109,7 @@ export function SharingButton({
   newScope,
   setNewScope,
   baseUrl,
+  showSlackIntegration,
   slackDataSource,
   slackChannelSelected,
   setNewLinkedSlackChannels,
@@ -119,6 +120,7 @@ export function SharingButton({
   newScope: NonGlobalScope;
   setNewScope: (scope: NonGlobalScope) => void;
   baseUrl: string;
+  showSlackIntegration: boolean;
   slackDataSource: DataSourceType | null;
   slackChannelSelected: SlackChannel[];
   setNewLinkedSlackChannels: (channels: SlackChannel[]) => void;
@@ -193,48 +195,50 @@ export function SharingButton({
               </div>
             </div>
 
-            <div className="flex flex-row justify-between">
-              <div>
-                <div className="text-base font-bold text-element-800">
-                  Slack integration
-                </div>
-                <div className="text-sm text-element-700">
-                  {slackChannelSelected.length === 0 ? (
-                    <>Set as default assistant for specific channels.</>
-                  ) : (
-                    <>
-                      Default assistant for{" "}
-                      {slackChannelSelected
-                        .map((c) => c.slackChannelName)
-                        .join(", ")}
-                    </>
-                  )}
-                </div>
+            {showSlackIntegration && (
+              <div className="flex flex-row justify-between">
+                <div>
+                  <div className="text-base font-bold text-element-800">
+                    Slack integration
+                  </div>
+                  <div className="text-sm text-element-700">
+                    {slackChannelSelected.length === 0 ? (
+                      <>Set as default assistant for specific channels.</>
+                    ) : (
+                      <>
+                        Default assistant for{" "}
+                        {slackChannelSelected
+                          .map((c) => c.slackChannelName)
+                          .join(", ")}
+                      </>
+                    )}
+                  </div>
 
-                <div className="pt-3">
-                  {slackChannelSelected.length > 0 && (
-                    <Button
-                      size="xs"
-                      variant="secondary"
-                      label="Manage channels"
-                      onClick={() => setSlackDrawerOpened(true)}
-                    />
-                  )}
+                  <div className="pt-3">
+                    {slackChannelSelected.length > 0 && (
+                      <Button
+                        size="xs"
+                        variant="secondary"
+                        label="Manage channels"
+                        onClick={() => setSlackDrawerOpened(true)}
+                      />
+                    )}
+                  </div>
+                </div>
+                <div className="">
+                  <SliderToggle
+                    selected={slackChannelSelected.length > 0}
+                    onClick={() => {
+                      if (slackChannelSelected.length > 0) {
+                        setNewLinkedSlackChannels([]);
+                      } else {
+                        setSlackDrawerOpened(true);
+                      }
+                    }}
+                  />
                 </div>
               </div>
-              <div className="">
-                <SliderToggle
-                  selected={slackChannelSelected.length > 0}
-                  onClick={() => {
-                    if (slackChannelSelected.length > 0) {
-                      setNewLinkedSlackChannels([]);
-                    } else {
-                      setSlackDrawerOpened(true);
-                    }
-                  }}
-                />
-              </div>
-            </div>
+            )}
             {agentConfigurationId && (
               <div className="flex flex-row justify-between">
                 <div>

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -203,6 +203,9 @@ export default function AssistantBuilder({
         }
   );
 
+  const showSlackIntegration =
+    builderState.scope === "workspace" || builderState.scope === "published";
+
   const [edited, setEdited] = useState(defaultIsEdited ?? false);
   const [isSavingOrDeleting, setIsSavingOrDeleting] = useState(false);
   const [submitEnabled, setSubmitEnabled] = useState(false);
@@ -434,6 +437,7 @@ export default function AssistantBuilder({
             <Tab tabs={tabs} variant="stepper" />
             <div className="self-end pt-0.5">
               <SharingButton
+                showSlackIntegration={showSlackIntegration}
                 slackDataSource={slackDataSource || null}
                 owner={owner}
                 agentConfigurationId={agentConfigurationId}


### PR DESCRIPTION
## Description

Slack integration is shown even for personal assistant in assistant builder. This PR fixes it and displays the slack integration only for `published` and `workspace` assistants.


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
