### PR TITLE
Connector: Fix logic getParents for WebCrawler & Intercom

### DIFF
--- a/connectors/src/connectors/intercom/index.ts
+++ b/connectors/src/connectors/intercom/index.ts
@@ -757,7 +757,7 @@ export async function retrieveIntercomContentNodeParents(
   }
   const teamId = getTeamIdFromInternalId(connectorId, internalId);
   if (teamId) {
-    return new Ok([]);
+    return new Ok([getTeamsInternalId(connectorId)]);
   }
 
   const parents: string[] = [];

--- a/connectors/src/connectors/webcrawler/index.ts
+++ b/connectors/src/connectors/webcrawler/index.ts
@@ -349,23 +349,52 @@ export async function retrieveWebCrawlerContentNodeParents(
   connectorId: ModelId,
   internalId: string
 ): Promise<Result<string[], Error>> {
-  const parents: string[] = [internalId];
-  let ptr = internalId;
+  const parents: string[] = [];
+  let parentUrl: string | null = null;
 
-  const visited = new Set<string>();
-
-  do {
+  // First we get the Page or Folder for which we want to retrieve the parents
+  const page = await WebCrawlerPage.findOne({
+    where: {
+      connectorId: connectorId,
+      documentId: internalId,
+    },
+  });
+  if (page && page.parentUrl) {
+    parentUrl = page.parentUrl;
+  } else {
     const folder = await WebCrawlerFolder.findOne({
       where: {
         connectorId: connectorId,
-        url: ptr,
+        internalId: internalId,
       },
     });
-    if (!folder || !folder.parentUrl) {
-      return new Ok(parents);
+    if (folder && folder.parentUrl) {
+      parentUrl = folder.parentUrl;
+    }
+  }
+
+  // If the Page or Folder has no parentUrl, we return an empty array
+  if (!parentUrl) {
+    return new Ok([]);
+  }
+
+  // Otherwise we loop on the parentUrl to retrieve all the parents
+  const visitedUrls = new Set<string>();
+  while (parentUrl) {
+    const parentFolder: WebCrawlerFolder | null =
+      await WebCrawlerFolder.findOne({
+        where: {
+          connectorId: connectorId,
+          url: parentUrl,
+        },
+      });
+
+    if (!parentFolder) {
+      parentUrl = null;
+      continue;
     }
 
-    if (visited.has(folder.parentUrl)) {
+    if (visitedUrls.has(parentFolder.url)) {
       logger.error(
         {
           connectorId,
@@ -374,12 +403,13 @@ export async function retrieveWebCrawlerContentNodeParents(
         },
         "Found a cycle in the parents tree"
       );
-      return new Ok(parents);
+      parentUrl = null;
+      continue;
     }
-    parents.push(folder.parentUrl);
-    ptr = folder.parentUrl;
-    visited.add(ptr);
-  } while (ptr);
+    parents.push(parentFolder.internalId);
+    visitedUrls.add(parentFolder.url);
+    parentUrl = parentFolder.parentUrl;
+  }
 
   return new Ok(parents);
 }


### PR DESCRIPTION
## Description

**For Intercom:** 
-> If the content is a Team, then it's parents is the static "Conversations" node. 

**For WebCrawler:** 
Logic was not working, what we receive is an internalId so first we need to fetch the associated Page or Folder, and then we retrieve the parents and puts their internal ids in the returned parents array. 

The parents logic is used to grey tick the checkbox here when selecting the datasources of an Assistant: 

<img width="1015" alt="Screenshot 2024-03-05 at 11 33 18" src="https://github.com/dust-tt/dust/assets/3803406/6cb6db14-a9ad-486d-9130-11e9e10f411f">



## Risk

/

## Deploy Plan

/
