### PR TITLE
GdriveRenewWebhook: fix error handling

### DIFF
--- a/connectors/src/connectors/google_drive/lib.ts
+++ b/connectors/src/connectors/google_drive/lib.ts
@@ -55,7 +55,15 @@ export async function registerWebhook(
     };
     return new Ok(result);
   } else {
-    return new Err(new HTTPError(await res.text(), res.status));
+    let errorMsg = await res.text();
+    try {
+      // Gdrive returns JSON errors, attempt to parse it.
+      const error = JSON.parse(errorMsg);
+      errorMsg = error.error.message;
+    } catch (e) {
+      // Keep the raw text as error message
+    }
+    return new Err(new HTTPError(errorMsg, res.status));
   }
 }
 


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/dust/issues/4101

GDrive returns JSON errors. We were not parsing it. Attempt to parse it and get the message so that the error handling code of renewWebhook work as expected here: https://github.com/dust-tt/dust/blob/main/connectors/src/connectors/google_drive/temporal/activities.ts#L589-L604

Log in the wild: https://app.datadoghq.eu/logs?query=%22Failed%20to%20renew%20webhook%22%20container_id%3A187ce51d1ccc5bf743fee6d92bce31024c21a1b270995b3e8a0888280af8ce8e%20&cols=host%2Cservice&event=AgAAAY4OfCtKw9OgyAAAAAAAAAAYAAAAAEFZNE9mQzN2QUFES2E0QVpHZmdHX0FCTwAAACQAAAAAMDE4ZTBlODItZTU5Yi00NjE1LThjOTItZmE0ZDI3M2Y5N2Mx&fromUser=true&index=%2A&messageDisplay=inline&refresh_mode=paused&sort=time&storage=hot&stream_sort=desc&view=spans&viz=stream&from_ts=1709639989271&to_ts=1709640013673&live=false

## Risk

N/A

## Deploy Plan

- deploy `connectors`