### PR TITLE
front: fix emoji picker visuals

### DIFF
--- a/front/components/assistant/conversation/ConversationMessage.tsx
+++ b/front/components/assistant/conversation/ConversationMessage.tsx
@@ -51,7 +51,7 @@ export function EmojiSelector({
           />
         </div>
       </DropdownMenu.Button>
-      <DropdownMenu.Items width={280} origin="topRight">
+      <DropdownMenu.Items width={400} origin="topRight" overflow="visible">
         <Picker
           theme="light"
           previewPosition="none"


### PR DESCRIPTION
## Description

Fixes the emoji picker (partially).

Before:
![Screenshot from 2024-03-05 13-41-20](https://github.com/dust-tt/dust/assets/15067/73397488-502f-4731-9d7b-feb3e5e46db8)


After:
![Screenshot from 2024-03-05 13-41-05](https://github.com/dust-tt/dust/assets/15067/2d5e9d47-002b-48f7-88bb-465e0271dc9e)


Still quite broken and artisanal with the double borders and the overflow on mobile. 

## Risk

N/A

## Deploy Plan

- deploy `front`