### PR TITLE
gdrive: do not delete webhook objects on token revoked

### DIFF
--- a/connectors/src/admin/cli.ts
+++ b/connectors/src/admin/cli.ts
@@ -16,6 +16,7 @@ import {
   launchGithubCodeSyncWorkflow,
   launchGithubFullSyncWorkflow,
 } from "@connectors/connectors/github/temporal/client";
+import { registerWebhook } from "@connectors/connectors/google_drive/lib";
 import {
   launchGoogleDriveIncrementalSyncWorkflow,
   launchGoogleDriveRenewWebhooksWorkflow,
@@ -58,7 +59,6 @@ import {
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
-import { registerWebhook } from "@connectors/connectors/google_drive/lib";
 
 const { NANGO_SLACK_CONNECTOR_ID } = process.env;
 

--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -572,23 +572,10 @@ export async function renewOneWebhook(webhookId: ModelId) {
         });
       }
     } catch (e) {
-      if (e instanceof ExternalOauthTokenError) {
-        logger.info(
-          {
-            error: e,
-            connectorId: wh.connectorId,
-            workspaceId: connector.workspaceId,
-            id: wh.id,
-          },
-          `Deleting webhook because the oauth token was revoked.`
-        );
-        await wh.destroy();
-        return;
-      }
-
       if (
-        e instanceof HTTPError &&
-        e.message === "The caller does not have permission"
+        e instanceof ExternalOauthTokenError ||
+        (e instanceof HTTPError &&
+          e.message === "The caller does not have permission")
       ) {
         await syncFailed(connector.id, "oauth_token_revoked");
         logger.error(
@@ -598,7 +585,7 @@ export async function renewOneWebhook(webhookId: ModelId) {
             workspaceId: connector.workspaceId,
             id: wh.id,
           },
-          `Failed to renew webhook: Received "The caller does not have permission" from Google.`
+          `Failed to renew webhook: Oauth token revoked .`
         );
         return;
       }


### PR DESCRIPTION
## Description

We don't want to delete webhooks when we get an authorization error otherwise we might loose track of the user and never renew their webhooks even across re-auth

Adds a cli to recreate webhook objects for connectors that are missing it (if we have access)

## Risk

N/A

## Deploy Plan

- deploy `connectors`
- deploy `prodbox`
- run commands for workspaces