### PR TITLE
Add auth0 sub in user model

### DIFF
--- a/front/lib/models/user.ts
+++ b/front/lib/models/user.ts
@@ -1,3 +1,4 @@
+import type { UserProviderType } from "@dust-tt/types";
 import type {
   CreationOptional,
   ForeignKey,
@@ -15,8 +16,11 @@ export class User extends Model<
   declare id: CreationOptional<number>;
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
-  declare provider: "github" | "google";
-  declare providerId: string;
+
+  declare auth0Sub: string | null;
+  declare provider: UserProviderType;
+  declare providerId: string | null;
+
   declare username: string;
   declare email: string;
   declare name: string;
@@ -45,11 +49,16 @@ User.init(
     },
     provider: {
       type: DataTypes.STRING,
-      allowNull: false,
+      allowNull: true,
     },
     providerId: {
       type: DataTypes.STRING,
-      allowNull: false,
+      allowNull: true,
+    },
+    auth0Sub: {
+      type: DataTypes.STRING,
+      // TODO(2024-03-01 flav) Set to false once new login flow is released.
+      allowNull: true,
     },
     username: {
       type: DataTypes.STRING,


### PR DESCRIPTION
## Description

This PR adds a new field in our `User` model to store the sub of auth0. It also update `provider` and `providerId` to allow nullable values.
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

It requires to run a migration to update our User model. Run the migration from the front-edge pods.

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
