### PR TITLE
Production Check for GDriveWebhook records

### DIFF
--- a/front/production_checks/checks/managed_data_source_gdrive_webhooks.ts
+++ b/front/production_checks/checks/managed_data_source_gdrive_webhooks.ts
@@ -1,0 +1,34 @@
+import { QueryTypes } from "sequelize";
+
+import { getConnectorReplicaDbConnection } from "@app/production_checks/lib/utils";
+import type { CheckFunction } from "@app/production_checks/types/check";
+
+export const managedDataSourceGdriveWebhooksCheck: CheckFunction = async (
+  checkName,
+  logger,
+  reportSuccess,
+  reportFailure,
+  heartbeat
+) => {
+  const connectorsSequelize = getConnectorReplicaDbConnection();
+  heartbeat();
+
+  const gdriveConnectionsWithoutWebhooks: {
+    id: number;
+    dataSourceName: string;
+    workspaceId: string;
+  }[] = await connectorsSequelize.query(
+    `SELECT c.id, c."dataSourceName", c."workspaceId" FROM connectors c LEFT JOIN google_drive_webhooks gdw ON c.id = gdw."connectorId" WHERE c."dataSourceName" = 'managed-google_drive' GROUP BY c.id HAVING COUNT(gdw.id) = 0`,
+    { type: QueryTypes.SELECT }
+  );
+  heartbeat();
+
+  if (gdriveConnectionsWithoutWebhooks.length > 0) {
+    reportFailure(
+      { gdriveConnectionsWithoutWebhooks },
+      "Google Drive connectors are missing GoogleDriveWebhook records"
+    );
+  } else {
+    reportSuccess({});
+  }
+};

--- a/front/production_checks/temporal/activities.ts
+++ b/front/production_checks/temporal/activities.ts
@@ -5,6 +5,7 @@ import mainLogger from "@app/logger/logger";
 import { checkActiveWorkflows } from "@app/production_checks/checks/check_active_workflows_for_connectors";
 import { checkNotionActiveWorkflows } from "@app/production_checks/checks/check_notion_active_workflows";
 import { managedDataSourceGCGdriveCheck } from "@app/production_checks/checks/managed_data_source_gdrive_gc";
+import { managedDataSourceGdriveWebhooksCheck } from "@app/production_checks/checks/managed_data_source_gdrive_webhooks";
 import { nangoConnectionIdCleanupSlack } from "@app/production_checks/checks/nango_connection_id_cleanup_slack";
 import { scrubDeletedCoreDocumentVersionsCheck } from "@app/production_checks/checks/scrub_deleted_core_document_versions";
 import type { Check } from "@app/production_checks/types/check";
@@ -14,6 +15,11 @@ export async function runAllChecksActivity() {
     {
       name: "managed_data_source_gdrive_gc",
       check: managedDataSourceGCGdriveCheck,
+      everyHour: 1,
+    },
+    {
+      name: "managed_data_source_gdrive_webhooks",
+      check: managedDataSourceGdriveWebhooksCheck,
       everyHour: 1,
     },
     {


### PR DESCRIPTION
## Description

Aadd a production check to ensure all gdrive connectors GoogleDriveWebhook records. If a google drive connector has no such record, it means we won't renew the webhooks and won't receive updates.

## Risk

N/A

## Deploy Plan

- deploy `front`