### PR TITLE
chore: upgrade to hyper 1.2.0 (step 1)

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -25,7 +25,7 @@ pest_derive = "2.0"
 shellexpand = "2.1"
 blake3 = "1.3"
 async-trait = "0.1"
-hyper = { version = "0.14", features = ["full"] }
+hyper = { version = "0.14", features = ["full", "backports", "deprecated"] }
 tokio = { version = "1.33", features = ["full"] }
 tokio-stream = "0.1"
 hyper-tls = "0.5"

--- a/core/src/blocks/helpers.rs
+++ b/core/src/blocks/helpers.rs
@@ -1,6 +1,7 @@
 use super::block::Env;
 use crate::project::Project;
 use anyhow::{anyhow, Result};
+use hyper::body::HttpBody;
 use hyper::header;
 use hyper::{body::Buf, http::StatusCode, Body, Client, Method, Request};
 use hyper_tls::HttpsConnector;
@@ -84,7 +85,8 @@ pub async fn get_data_source_project(
         ))?;
     }
 
-    let body = hyper::body::aggregate(res).await?;
+    let body = res.collect().await?.aggregate();
+
     let mut b: Vec<u8> = vec![];
     body.reader().read_to_end(&mut b)?;
 

--- a/core/src/http/request.rs
+++ b/core/src/http/request.rs
@@ -3,6 +3,7 @@ use crate::stores::store::Store;
 use crate::utils;
 use anyhow::{anyhow, Result};
 use dns_lookup::lookup_host;
+use hyper::body::HttpBody;
 use hyper::header;
 use hyper::{body::Buf, Body, Client, Method, Request};
 use hyper_tls::HttpsConnector;
@@ -157,7 +158,7 @@ impl HttpRequest {
         let status = res.status();
         let headers = res.headers().clone();
 
-        let body = hyper::body::aggregate(res).await?;
+        let body = res.collect().await?.to_bytes();
         let mut b: Vec<u8> = vec![];
         body.reader().read_to_end(&mut b)?;
 

--- a/core/src/providers/ai21.rs
+++ b/core/src/providers/ai21.rs
@@ -6,6 +6,7 @@ use crate::run::Credentials;
 use crate::utils;
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
+use hyper::body::HttpBody;
 use hyper::{body::Buf, Body, Client, Method, Request, Uri};
 use hyper_tls::HttpsConnector;
 use serde::{Deserialize, Serialize};
@@ -120,7 +121,7 @@ impl AI21LLM {
 
         let res = cli.request(req).await?;
         let status = res.status();
-        let body = hyper::body::aggregate(res).await?;
+        let body = res.collect().await?.aggregate();
         let mut b: Vec<u8> = vec![];
         body.reader().read_to_end(&mut b)?;
         let c: &[u8] = &b;

--- a/core/src/providers/anthropic.rs
+++ b/core/src/providers/anthropic.rs
@@ -11,6 +11,7 @@ use async_trait::async_trait;
 use eventsource_client as es;
 use eventsource_client::Client as ESClient;
 use futures::TryStreamExt;
+use hyper::body::HttpBody;
 use hyper::{body::Buf, Body, Client, Method, Request, Uri};
 use hyper_tls::HttpsConnector;
 use serde::{Deserialize, Serialize};
@@ -398,7 +399,7 @@ impl AnthropicLLM {
 
         let status = res.status();
 
-        let body = hyper::body::aggregate(res).await?;
+        let body = res.collect().await?.to_bytes();
         let mut b: Vec<u8> = vec![];
         body.reader().read_to_end(&mut b)?;
         let c: &[u8] = &b;

--- a/core/src/providers/azure_openai.rs
+++ b/core/src/providers/azure_openai.rs
@@ -13,6 +13,7 @@ use crate::run::Credentials;
 use crate::utils;
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
+use hyper::body::HttpBody;
 use hyper::header;
 use hyper::{body::Buf, http::StatusCode, Body, Client, Method, Request, Uri};
 use hyper_tls::HttpsConnector;
@@ -76,7 +77,7 @@ async fn get_deployments(endpoint: &str, api_key: &str) -> Result<Vec<AzureOpenA
         ))?;
     }
 
-    let body = hyper::body::aggregate(res).await?;
+    let body = res.collect().await?.aggregate();
     let mut b: Vec<u8> = vec![];
     body.reader().read_to_end(&mut b)?;
     let c: &[u8] = &b;
@@ -125,7 +126,7 @@ async fn get_deployment(
         ))?;
     }
 
-    let body = hyper::body::aggregate(res).await?;
+    let body = res.collect().await?.aggregate();
     let mut b: Vec<u8> = vec![];
     body.reader().read_to_end(&mut b)?;
     let c: &[u8] = &b;

--- a/core/src/providers/cohere.rs
+++ b/core/src/providers/cohere.rs
@@ -6,6 +6,7 @@ use crate::run::Credentials;
 use crate::utils;
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
+use hyper::body::HttpBody;
 use hyper::{body::Buf, Body, Client, Method, Request, Uri};
 use hyper_tls::HttpsConnector;
 use serde::{Deserialize, Serialize};
@@ -46,7 +47,7 @@ async fn api_encode(api_key: &str, text: &str) -> Result<Vec<usize>> {
 
     let res = cli.request(req).await?;
     let status = res.status();
-    let body = hyper::body::aggregate(res).await?;
+    let body = res.collect().await?.aggregate();
     let mut b: Vec<u8> = vec![];
     body.reader().read_to_end(&mut b)?;
     let c: &[u8] = &b;
@@ -98,7 +99,7 @@ async fn api_decode(api_key: &str, tokens: Vec<usize>) -> Result<String> {
 
     let res = cli.request(req).await?;
     let status = res.status();
-    let body = hyper::body::aggregate(res).await?;
+    let body = res.collect().await?.aggregate();
     let mut b: Vec<u8> = vec![];
     body.reader().read_to_end(&mut b)?;
     let c: &[u8] = &b;
@@ -225,7 +226,7 @@ impl CohereLLM {
 
         let res = cli.request(req).await?;
         let status = res.status();
-        let body = hyper::body::aggregate(res).await?;
+        let body = res.collect().await?.aggregate();
         let mut b: Vec<u8> = vec![];
         body.reader().read_to_end(&mut b)?;
         let c: &[u8] = &b;
@@ -456,7 +457,7 @@ impl CohereEmbedder {
 
         let res = cli.request(req).await?;
         let status = res.status();
-        let body = hyper::body::aggregate(res).await?;
+        let body = res.collect().await?.aggregate();
         let mut b: Vec<u8> = vec![];
         body.reader().read_to_end(&mut b)?;
         let c: &[u8] = &b;

--- a/core/src/sqlite_workers/client.rs
+++ b/core/src/sqlite_workers/client.rs
@@ -1,4 +1,5 @@
 use anyhow::{anyhow, Result};
+use hyper::body::HttpBody;
 use hyper::{body::Bytes, Body, Client, Request};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -147,7 +148,7 @@ async fn get_response_body(req: hyper::Request<hyper::Body>) -> Result<Bytes, Sq
     let res = Client::new().request(req).await?;
 
     let status = res.status().as_u16();
-    let body = hyper::body::to_bytes(res.into_body()).await?;
+    let body = res.collect().await?.to_bytes();
 
     match status {
         200 => Ok(body),


### PR DESCRIPTION
## Description

We're using an outdated version of `hyper`. The 1.x.x `hyper` has a different API with several breaking changes.

As per [their upgrade guide](https://hyper.rs/guides/1/upgrading/), I am first enabling `backports` and `deprecated` cargo feature flags on `hyper` 0.14 so I can fix step by step.

This PR fixes the deprecation warnings for `aggregate` and `to_bytes`, replacing their use by what `hyper` is recommending: https://github.com/hyperium/hyper/commit/0888623d3764e887706d4e38f82f0fb57c50bd1a


## Risk

maximal blast radius, but tested locally and easy to revert

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
