### PR TITLE
chore: upgrade hyper to 1.2.0

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1066,7 +1066,6 @@ dependencies = [
  "bb8-postgres",
  "blake3",
  "bstr",
- "bytes",
  "chrono",
  "clap",
  "cloud-storage",
@@ -1076,10 +1075,8 @@ dependencies = [
  "eventsource-client",
  "fancy-regex",
  "futures",
- "http-body-util",
  "hyper 1.2.0",
  "hyper-tls",
- "hyper-util",
  "itertools 0.10.5",
  "lazy_static",
  "parking_lot",
@@ -1769,7 +1766,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
 dependencies = [
  "bytes",
- "futures-channel",
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.0",
@@ -1777,9 +1773,6 @@ dependencies = [
  "pin-project-lite",
  "socket2 0.5.6",
  "tokio",
- "tower",
- "tower-service",
- "tracing",
 ]
 
 [[package]]

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -370,37 +370,6 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.5.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acee9fd5073ab6b045a275b3e709c163dd36c90685219cb21804a147b58dba43"
-dependencies = [
- "async-trait",
- "axum-core 0.2.9",
- "bitflags 1.3.2",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "hyper",
- "itoa",
- "matchit 0.5.0",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tower",
- "tower-http 0.3.5",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
@@ -410,11 +379,11 @@ dependencies = [
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
  "itoa",
- "matchit 0.7.3",
+ "matchit",
  "memchr",
  "mime",
  "percent-encoding",
@@ -428,19 +397,37 @@ dependencies = [
 ]
 
 [[package]]
-name = "axum-core"
-version = "0.2.9"
+name = "axum"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e5939e02c56fecd5c017c37df4238c0a839fa76b7f97acdd7efb804fd181cc"
+checksum = "1236b4b292f6c4d6dc34604bb5120d85c3fe1d1aa596bd5cc52ca054d13e7b9e"
 dependencies = [
  "async-trait",
+ "axum-core 0.4.3",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.2.0",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
  "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -452,12 +439,33 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "mime",
  "rustversion",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15c63fd72d41492dc4f497196f5da1fb04fb7529e631d73630d1b491e47a2e3"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1052,12 +1060,13 @@ dependencies = [
  "async-std",
  "async-stream",
  "async-trait",
- "axum 0.5.17",
+ "axum 0.7.4",
  "base64 0.21.7",
  "bb8",
  "bb8-postgres",
  "blake3",
  "bstr",
+ "bytes",
  "chrono",
  "clap",
  "cloud-storage",
@@ -1067,8 +1076,10 @@ dependencies = [
  "eventsource-client",
  "fancy-regex",
  "futures",
- "hyper",
+ "http-body-util",
+ "hyper 1.2.0",
  "hyper-tls",
+ "hyper-util",
  "itertools 0.10.5",
  "lazy_static",
  "parking_lot",
@@ -1078,6 +1089,7 @@ dependencies = [
  "rand",
  "rayon",
  "regex",
+ "reqwest",
  "rusqlite",
  "rustc-hash",
  "serde",
@@ -1088,7 +1100,7 @@ dependencies = [
  "tokio",
  "tokio-postgres",
  "tokio-stream",
- "tower-http 0.4.4",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -1183,7 +1195,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b91e5ec5c794bbec5f639620f0bafe421b6d27dec66ac1ce3fdb6f009db3a6c"
 dependencies = [
  "futures",
- "hyper",
+ "hyper 0.14.28",
  "hyper-rustls 0.22.1",
  "hyper-timeout",
  "log",
@@ -1476,7 +1488,26 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.12",
+ "indexmap 2.2.5",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31d030e59af851932b72ceebadf4a2b5986dba4c3b99dd2493f8273a0f151943"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 1.1.0",
  "indexmap 2.2.5",
  "slab",
  "tokio",
@@ -1557,21 +1588,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41cb79eb393015dadd30fc252023adb0b2400a0caee0fa2a077e6e21a551e840"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "http-range-header"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
+checksum = "3ce4ef31cda248bbdb6e6820603b82dfcd9e833db65a43e997a0ccec777d11fe"
 
 [[package]]
 name = "httparse"
@@ -1604,9 +1669,9 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.3.24",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -1619,6 +1684,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186548d73ac615b32a73aafe38fb4f56c0d340e110e5a200bcadbaf2e199263a"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2 0.4.2",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1626,7 +1712,7 @@ checksum = "5f9f7a97316d44c0af9b0301e65010573a853a9fc97046d7331d7f6bc0fd5a64"
 dependencies = [
  "ct-logs",
  "futures-util",
- "hyper",
+ "hyper 0.14.28",
  "log",
  "rustls 0.19.1",
  "rustls-native-certs 0.5.0",
@@ -1642,8 +1728,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
- "http",
- "hyper",
+ "http 0.2.12",
+ "hyper 0.14.28",
  "log",
  "rustls 0.21.10",
  "rustls-native-certs 0.6.3",
@@ -1657,7 +1743,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper",
+ "hyper 0.14.28",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
@@ -1670,10 +1756,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper",
+ "hyper 0.14.28",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "hyper 1.2.0",
+ "pin-project-lite",
+ "socket2 0.5.6",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1954,12 +2060,6 @@ checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
  "regex-automata 0.1.10",
 ]
-
-[[package]]
-name = "matchit"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73cbba799671b762df5a175adf59ce145165747bb891505c43d09aefbbf38beb"
 
 [[package]]
 name = "matchit"
@@ -2702,10 +2802,10 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
+ "h2 0.3.24",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
  "hyper-rustls 0.24.2",
  "hyper-tls",
  "ipnet",
@@ -3081,6 +3181,16 @@ dependencies = [
  "indexmap 2.2.5",
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebd154a240de39fdebcf5775d2675c204d7c13cf39a4c697be6493c8e734337c"
+dependencies = [
+ "itoa",
  "serde",
 ]
 
@@ -3597,10 +3707,10 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
+ "h2 0.3.24",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
@@ -3638,28 +3748,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.3.5"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f873044bf02dd1e8239e9c1293ea39dad76dc594ec16185d0a1bf31d8dc8d858"
-dependencies = [
- "bitflags 1.3.2",
- "bytes",
- "futures-core",
- "futures-util",
- "http",
- "http-body",
- "http-range-header",
- "pin-project-lite",
- "tower",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
+checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
  "async-compression",
  "base64 0.21.7",
@@ -3667,8 +3758,9 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
  "http-range-header",
  "httpdate",
  "iri-string",
@@ -4337,8 +4429,8 @@ dependencies = [
  "async-trait",
  "base64 0.21.7",
  "futures",
- "http",
- "hyper",
+ "http 0.2.12",
+ "hyper 0.14.28",
  "hyper-rustls 0.24.2",
  "itertools 0.12.1",
  "log",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -66,7 +66,4 @@ chrono = "0.4.31"
 yup-oauth2 = "8.3.0"
 datadog-formatting-layer = "1.1"
 thiserror = "1.0.57"
-hyper-util = { version = "0.1.3", features = ["client", "client-legacy", "http1", "http2", "tokio"] }
-http-body-util = "0.1.0"
-bytes = "1.5.0"
 reqwest = "0.11.24"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -25,7 +25,7 @@ pest_derive = "2.0"
 shellexpand = "2.1"
 blake3 = "1.3"
 async-trait = "0.1"
-hyper = { version = "0.14", features = ["full", "backports", "deprecated"] }
+hyper = { version = "1.2.0", features = ["full"] }
 tokio = { version = "1.33", features = ["full"] }
 tokio-stream = "0.1"
 hyper-tls = "0.5"
@@ -38,7 +38,7 @@ regex = "1.8.3"
 rand = "0.8"
 uuid = { version = "1.1", features = ["v4"] }
 parking_lot = "0.12"
-axum = "0.5"
+axum = "0.7.4"
 rusqlite = { version = "0.29", features = ["bundled"] }
 tokio-postgres = "0.7"
 bb8 = "0.8"
@@ -55,7 +55,7 @@ bstr = "1.5"
 base64 = "0.21"
 cloud-storage = { version = "0.11", features = ["global-client"] }
 qdrant-client = "1.6"
-tower-http = {version = "0.4", features = ["full"]}
+tower-http = {version = "0.5.2", features = ["full"]}
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 deno_core = "0.200"
@@ -66,3 +66,7 @@ chrono = "0.4.31"
 yup-oauth2 = "8.3.0"
 datadog-formatting-layer = "1.1"
 thiserror = "1.0.57"
+hyper-util = { version = "0.1.3", features = ["client", "client-legacy", "http1", "http2", "tokio"] }
+http-body-util = "0.1.0"
+bytes = "1.5.0"
+reqwest = "0.11.24"

--- a/core/bin/sqlite_worker.rs
+++ b/core/bin/sqlite_worker.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, Result};
 use axum::{
-    extract::{self, Path, State},
+    extract::{Path, State},
     response::Json,
     routing::{delete, get, post},
     Router,
@@ -237,8 +237,8 @@ async fn databases_query(
 }
 
 async fn databases_delete(
-    extract::Path(database_id): extract::Path<String>,
-    extract::Extension(state): extract::Extension<Arc<WorkerState>>,
+    Path(database_id): Path<String>,
+    State(state): State<Arc<WorkerState>>,
 ) -> (StatusCode, Json<APIResponse>) {
     state.invalidate_database(&database_id).await;
 
@@ -253,9 +253,7 @@ async fn databases_delete(
     )
 }
 
-async fn expire_all(
-    extract::Extension(state): extract::Extension<Arc<WorkerState>>,
-) -> (StatusCode, Json<APIResponse>) {
+async fn expire_all(State(state): State<Arc<WorkerState>>) -> (StatusCode, Json<APIResponse>) {
     let mut registry = state.registry.lock().await;
     registry.clear();
 

--- a/core/bin/sqlite_worker.rs
+++ b/core/bin/sqlite_worker.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, Result};
 use axum::{
-    extract,
+    extract::{self, Path, State},
     response::Json,
     routing::{delete, get, post},
     Router,
@@ -12,7 +12,8 @@ use dust::{
     sqlite_workers::sqlite_database::{QueryError, SqliteDatabase},
     utils::{error_response, APIResponse},
 };
-use hyper::{Body, Client, Request, StatusCode};
+use hyper::StatusCode;
+use reqwest::Method;
 use serde::Deserialize;
 use serde_json::json;
 use std::{
@@ -23,8 +24,11 @@ use std::{
     },
     time::{Duration, Instant},
 };
-use tokio::signal::unix::{signal, SignalKind};
 use tokio::sync::Mutex;
+use tokio::{
+    net::TcpListener,
+    signal::unix::{signal, SignalKind},
+};
 use tower_http::trace::{self, TraceLayer};
 use tracing::{error, info, Level};
 use tracing_subscriber::prelude::*;
@@ -138,18 +142,17 @@ impl WorkerState {
             Err(_) => Err(anyhow!("CORE_API not set."))?,
         };
 
-        let req = Request::builder()
-            .method(method)
-            .uri(format!("{}/sqlite_workers", core_api))
+        let res = reqwest::Client::new()
+            .request(
+                Method::from_bytes(method.as_bytes())?,
+                format!("{}/sqlite_workers", core_api),
+            )
             .header("Content-Type", "application/json")
-            .body(Body::from(
-                json!({
-                    "url": worker_url,
-                })
-                .to_string(),
-            ))?;
-
-        let res = Client::new().request(req).await?;
+            .json(&json!({
+                "url": worker_url,
+            }))
+            .send()
+            .await?;
 
         match res.status().as_u16() {
             200 => Ok(()),
@@ -174,9 +177,9 @@ struct DbQueryPayload {
 }
 
 async fn databases_query(
-    extract::Path(database_id): extract::Path<String>,
-    extract::Json(payload): Json<DbQueryPayload>,
-    extract::Extension(state): extract::Extension<Arc<WorkerState>>,
+    Path(database_id): Path<String>,
+    State(state): State<Arc<WorkerState>>,
+    Json(payload): Json<DbQueryPayload>,
 ) -> (StatusCode, Json<APIResponse>) {
     let database = {
         let mut registry = state.registry.lock().await;
@@ -301,7 +304,7 @@ fn main() {
                     .make_span_with(trace::DefaultMakeSpan::new().level(Level::INFO))
                     .on_response(trace::DefaultOnResponse::new().level(Level::INFO)),
             )
-            .layer(extract::Extension(state.clone()));
+            .with_state(state.clone());
 
         let health_check_router = Router::new().route("/", get(index));
 
@@ -316,11 +319,13 @@ fn main() {
         let (tx1, rx1) = tokio::sync::oneshot::channel::<()>();
         let (tx2, rx2) = tokio::sync::oneshot::channel::<()>();
 
-        let srv = axum::Server::bind(&"[::]:3005".parse().unwrap())
-            .serve(app.into_make_service())
-            .with_graceful_shutdown(async {
-                rx1.await.ok();
-            });
+        let srv = axum::serve(
+            TcpListener::bind::<std::net::SocketAddr>("[::]:3005".parse().unwrap()).await?,
+            app.into_make_service(),
+        )
+        .with_graceful_shutdown(async {
+            rx1.await.ok();
+        });
 
         tokio::spawn(async move {
             if let Err(e) = srv.await {

--- a/core/src/providers/mistral.rs
+++ b/core/src/providers/mistral.rs
@@ -446,15 +446,12 @@ impl MistralAILLM {
         top_p: f32,
         max_tokens: i32,
     ) -> Result<ChatCompletion> {
-        // let https = HttpsConnector::new();
-        // let cli = Client::builder().build::<_, hyper::Body>(https);
-
         let mut body = json!({
             "messages": messages,
             "temperature": temperature,
             "top_p": top_p,
             "max_tokens": max_tokens,
-            "streamed": false
+            "stream": false
         });
 
         if model_id.is_some() {
@@ -464,11 +461,7 @@ impl MistralAILLM {
         let req = reqwest::Client::new()
             .post(uri.to_string())
             .header("Content-Type", "application/json")
-            .header(
-                "Authorization
-            ",
-                format!("Bearer {}", api_key.clone()),
-            )
+            .header("Authorization", format!("Bearer {}", api_key.clone()))
             .json(&body);
 
         let res = match timeout(Duration::new(180, 0), req.send()).await {

--- a/core/src/providers/mistral.rs
+++ b/core/src/providers/mistral.rs
@@ -11,9 +11,7 @@ use async_trait::async_trait;
 use eventsource_client as es;
 use eventsource_client::Client as ESClient;
 use futures::TryStreamExt;
-use hyper::body::HttpBody;
-use hyper::{body::Buf, Body, Client, Method, Request, Uri};
-use hyper_tls::HttpsConnector;
+use hyper::{body::Buf, Uri};
 use parking_lot::{Mutex, RwLock};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -448,8 +446,8 @@ impl MistralAILLM {
         top_p: f32,
         max_tokens: i32,
     ) -> Result<ChatCompletion> {
-        let https = HttpsConnector::new();
-        let cli = Client::builder().build::<_, hyper::Body>(https);
+        // let https = HttpsConnector::new();
+        // let cli = Client::builder().build::<_, hyper::Body>(https);
 
         let mut body = json!({
             "messages": messages,
@@ -463,27 +461,28 @@ impl MistralAILLM {
             body["model"] = json!(model_id);
         }
 
-        let req_builder = Request::builder()
-            .method(Method::POST)
-            .uri(uri)
+        let req = reqwest::Client::new()
+            .post(uri.to_string())
             .header("Content-Type", "application/json")
-            .header("Authorization", format!("Bearer {}", api_key.clone()));
+            .header(
+                "Authorization
+            ",
+                format!("Bearer {}", api_key.clone()),
+            )
+            .json(&body);
 
-        let req = req_builder.body(Body::from(body.to_string()))?;
-
-        let res = match timeout(Duration::new(180, 0), cli.request(req)).await {
+        let res = match timeout(Duration::new(180, 0), req.send()).await {
             Ok(Ok(res)) => res,
             Ok(Err(e)) => Err(e)?,
             Err(_) => Err(anyhow!("Timeout sending request to Mistral AI after 180s"))?,
         };
-        let collected = match timeout(Duration::new(180, 0), res.collect()).await {
+        let body = match timeout(Duration::new(180, 0), res.bytes()).await {
             Ok(Ok(body)) => body,
             Ok(Err(e)) => Err(e)?,
             Err(_) => Err(anyhow!(
                 "Timeout reading response from Mistral AI after 180s"
             ))?,
         };
-        let body = collected.aggregate();
 
         let mut b: Vec<u8> = vec![];
         body.reader().read_to_end(&mut b)?;

--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -1019,9 +1019,6 @@ pub async fn embed(
     text: Vec<&str>,
     user: Option<String>,
 ) -> Result<Embeddings> {
-    // let https = HttpsConnector::new();
-    // let cli = Client::builder().build::<_, hyper::Body>(https);
-
     let mut body = json!({
         "input": text,
     });

--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -12,9 +12,7 @@ use async_trait::async_trait;
 use eventsource_client as es;
 use eventsource_client::Client as ESClient;
 use futures::TryStreamExt;
-use hyper::body::HttpBody;
-use hyper::{body::Buf, Body, Client, Method, Request, Uri};
-use hyper_tls::HttpsConnector;
+use hyper::{body::Buf, Uri};
 use itertools::izip;
 use parking_lot::{Mutex, RwLock};
 use serde::{Deserialize, Serialize};
@@ -433,8 +431,8 @@ pub async fn completion(
     top_p: f32,
     user: Option<String>,
 ) -> Result<Completion> {
-    let https = HttpsConnector::new();
-    let cli = Client::builder().build::<_, hyper::Body>(https);
+    // let https = HttpsConnector::new();
+    // let cli = Client::builder().build::<_, hyper::Body>(https);
 
     let mut body = json!({
         "prompt": prompt,
@@ -467,34 +465,28 @@ pub async fn completion(
         }
     };
 
-    // println!("BODY: {}", body.to_string());
-
-    let mut req_builder = Request::builder()
-        .method(Method::POST)
-        .uri(uri)
+    let mut req = reqwest::Client::new()
+        .post(uri.to_string())
         .header("Content-Type", "application/json")
-        // This one is for `openai`.
         .header("Authorization", format!("Bearer {}", api_key.clone()))
-        // This one is for `azure_openai`.
         .header("api-key", api_key.clone());
 
     if let Some(organization_id) = organization_id {
-        req_builder = req_builder.header("OpenAI-Organization", organization_id);
+        req = req.header("OpenAI-Organization", organization_id);
     }
 
-    let req = req_builder.body(Body::from(body.to_string()))?;
+    req = req.json(&body);
 
-    let res = match timeout(Duration::new(180, 0), cli.request(req)).await {
+    let res = match timeout(Duration::new(180, 0), req.send()).await {
         Ok(Ok(res)) => res,
         Ok(Err(e)) => Err(e)?,
         Err(_) => Err(anyhow!("Timeout sending request to OpenAI after 180s"))?,
     };
-    let collected = match timeout(Duration::new(180, 0), res.collect()).await {
+    let body = match timeout(Duration::new(180, 0), res.bytes()).await {
         Ok(Ok(body)) => body,
         Ok(Err(e)) => Err(e)?,
         Err(_) => Err(anyhow!("Timeout reading response from OpenAI after 180s"))?,
     };
-    let body = collected.aggregate();
 
     let mut b: Vec<u8> = vec![];
     body.reader().read_to_end(&mut b)?;
@@ -907,9 +899,6 @@ pub async fn chat_completion(
     response_format: Option<String>,
     user: Option<String>,
 ) -> Result<ChatCompletion> {
-    let https = HttpsConnector::new();
-    let cli = Client::builder().build::<_, hyper::Body>(https);
-
     // Re-adapt to OpenAI string || object format.
     let function_call: Option<Value> = match function_call {
         None => None,
@@ -953,9 +942,8 @@ pub async fn chat_completion(
         body["function_call"] = function_call.unwrap();
     }
 
-    let mut req_builder = Request::builder()
-        .method(Method::POST)
-        .uri(uri)
+    let mut req = reqwest::Client::new()
+        .post(uri.to_string())
         .header("Content-Type", "application/json")
         // This one is for `openai`.
         .header("Authorization", format!("Bearer {}", api_key.clone()))
@@ -963,25 +951,24 @@ pub async fn chat_completion(
         .header("api-key", api_key.clone());
 
     if let Some(organization_id) = organization_id {
-        req_builder = req_builder.header(
+        req = req.header(
             "OpenAI-Organization",
             &format!("{}", organization_id.clone()),
         );
     }
 
-    let req = req_builder.body(Body::from(body.to_string()))?;
+    let req = req.json(&body);
 
-    let res = match timeout(Duration::new(180, 0), cli.request(req)).await {
+    let res = match timeout(Duration::new(180, 0), req.send()).await {
         Ok(Ok(res)) => res,
         Ok(Err(e)) => Err(e)?,
         Err(_) => Err(anyhow!("Timeout sending request to OpenAI after 180s"))?,
     };
-    let collected = match timeout(Duration::new(180, 0), res.collect()).await {
+    let body = match timeout(Duration::new(180, 0), res.bytes()).await {
         Ok(Ok(body)) => body,
         Ok(Err(e)) => Err(e)?,
         Err(_) => Err(anyhow!("Timeout reading response from OpenAI after 180s"))?,
     };
-    let body = collected.aggregate();
 
     let mut b: Vec<u8> = vec![];
     body.reader().read_to_end(&mut b)?;
@@ -1032,8 +1019,8 @@ pub async fn embed(
     text: Vec<&str>,
     user: Option<String>,
 ) -> Result<Embeddings> {
-    let https = HttpsConnector::new();
-    let cli = Client::builder().build::<_, hyper::Body>(https);
+    // let https = HttpsConnector::new();
+    // let cli = Client::builder().build::<_, hyper::Body>(https);
 
     let mut body = json!({
         "input": text,
@@ -1047,9 +1034,17 @@ pub async fn embed(
 
     // println!("BODY: {}", body.to_string());
 
-    let mut req_builder = Request::builder()
-        .method(Method::POST)
-        .uri(uri)
+    // let mut req_builder = Request::builder()
+    //     .method(Method::POST)
+    //     .uri(uri)
+    //     .header("Content-Type", "application/json")
+    //     // This one is for `openai`.
+    //     .header("Authorization", format!("Bearer {}", api_key.clone()))
+    //     // This one is for `azure_openai`.
+    //     .header("api-key", api_key.clone());
+
+    let mut req = reqwest::Client::new()
+        .post(uri.to_string())
         .header("Content-Type", "application/json")
         // This one is for `openai`.
         .header("Authorization", format!("Bearer {}", api_key.clone()))
@@ -1057,23 +1052,22 @@ pub async fn embed(
         .header("api-key", api_key.clone());
 
     if let Some(organization_id) = organization_id {
-        req_builder = req_builder.header("OpenAI-Organization", organization_id);
+        req = req.header("OpenAI-Organization", organization_id);
     }
 
-    let req = req_builder.body(Body::from(body.to_string()))?;
+    let req = req.json(&body);
 
-    let res = match timeout(Duration::new(60, 0), cli.request(req)).await {
+    let res = match timeout(Duration::new(60, 0), req.send()).await {
         Ok(Ok(res)) => res,
         Ok(Err(e)) => Err(e)?,
         Err(_) => Err(anyhow!("Timeout sending request to OpenAI after 60s"))?,
     };
 
-    let collected = match timeout(Duration::new(60, 0), res.collect()).await {
+    let body = match timeout(Duration::new(60, 0), res.bytes()).await {
         Ok(Ok(body)) => body,
         Ok(Err(e)) => Err(e)?,
         Err(_) => Err(anyhow!("Timeout reading response from OpenAI after 60s"))?,
     };
-    let body = collected.aggregate();
 
     let mut b: Vec<u8> = vec![];
     body.reader().read_to_end(&mut b)?;


### PR DESCRIPTION
## Description

Main changes:
- we have to upgrade `axum` as well to use latest hyper
- we have to upgrade `tower-http` as well
- there's no client in `hyper` anymore. `reqwest` does everything we were doing with `hyper` client + it's higher level (no need to worry about https adapter, simpler API etc..). Overall looks the same
- hyper `Body` is now a trait. This problem is also solved by using `reqwest`
- axum order of parameters in handlers is different (json is last now)
- remove use of `Extension` in favor of `State` (which is typesafe unlike `Extension`). `State` is the new preferred way.
- `axum` way to create the server is a tiny bit different, but that's minor

## Risk

inverted 80/20 type of deal

Tested every provider locally

## Deploy Plan

~~Test thoroughly~~
