### PR TITLE
Intercom: Add conversation tags & custom attributes to datasource tags

### DIFF
--- a/connectors/src/connectors/intercom/lib/types.ts
+++ b/connectors/src/connectors/intercom/lib/types.ts
@@ -59,6 +59,9 @@ export type IntercomConversationType = {
     type: "tag.list";
     tags: IntercomTagType[];
   };
+  custom_attributes: {
+    [key: string]: unknown; // string | number | boolean | custom intercom object
+  };
   source: {
     type: string;
     id: number;


### PR DESCRIPTION
## Description

On top of tags, Intercom allow you to define "Conversation attributes" to qualify conversations, accessible from the `custom_attributes` key of the [Conversation Model](https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Conversations/conversation/).

They look like that: 
<img width="1164" alt="Screenshot 2024-03-06 at 11 31 20" src="https://github.com/dust-tt/dust/assets/3803406/e2dd5b74-79cf-4219-838d-89ebde74b286">

This PR does 2 things: 
- Adds the custom attributes to the content of the datasource so it's accessible with semantic search. 
- Adds both the custom attributes and the tags to the TAGS of the datasources, so that with a Dust app we can filter conversations with both. 


Tags will look like that: 
```
[
  'title:<p>Another request!</p>',
  'createdAt:1707342428000',
  'updatedAt:1707919004000',
  'attribute:Language:English',
  'attribute:Product Feedback:true',
  'attribute:End of pilot date:2024-03-06T10:17:11.718Z',
  'attribute:Score:8.9',
  'tag:soupinou',
  'tag:soupinousoupinou'
]
```



## Risk

Technically there's no limit in the number of tags or custom attributes -> should I add some safeguards? I could limit the size of the string and limit the number of tags/custom attributes added as tags. WDYT?

If they change the name of a custom attribute, it won't be updated in all past convos. I think it's okay tho.

## Deploy Plan

I won't resync all workspaces as it's an advanced use case -> I'll resync Dust so I can check it's working properly and then it's for one specific workspace who asked for this feature. 
