### PR TITLE
enh(notion) change how we process dbs

### DIFF
--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -410,8 +410,8 @@ export async function retrieveNotionConnectorPermissions({
       sourceUrl: db.notionUrl || null,
       expandable: true,
       permission: "read",
-      dustDocumentId: null,
-      lastUpdatedAt: null,
+      dustDocumentId: `notion-database-${db.notionDatabaseId}`,
+      lastUpdatedAt: db.lastSeenTs.getTime(),
     };
   };
 

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -411,7 +411,7 @@ export async function retrieveNotionConnectorPermissions({
       expandable: true,
       permission: "read",
       dustDocumentId: `notion-database-${db.notionDatabaseId}`,
-      lastUpdatedAt: db.lastSeenTs.getTime(),
+      lastUpdatedAt: db.structuredDataUpsertedTs?.getTime() ?? null,
     };
   };
 

--- a/connectors/src/connectors/notion/lib/notion_api.ts
+++ b/connectors/src/connectors/notion/lib/notion_api.ts
@@ -1043,7 +1043,9 @@ export function parsePageBlock(block: BlockObjectResponse): ParsedNotionBlock {
     case "child_database":
       return {
         ...commonFields,
-        text: `Child Database: ${block.child_database.title}`,
+        text: `Child Database: ${
+          block.child_database.title ?? "Untitled Database"
+        }`,
         childDatabaseTitle: block.child_database.title,
       };
 

--- a/connectors/src/connectors/notion/lib/notion_api.ts
+++ b/connectors/src/connectors/notion/lib/notion_api.ts
@@ -1043,7 +1043,7 @@ export function parsePageBlock(block: BlockObjectResponse): ParsedNotionBlock {
     case "child_database":
       return {
         ...commonFields,
-        text: null,
+        text: `Child Database: ${block.child_database.title}`,
         childDatabaseTitle: block.child_database.title,
       };
 

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -50,6 +50,8 @@ import {
   deleteTable,
   deleteTableRow,
   MAX_DOCUMENT_TXT_LEN,
+  MAX_PREFIX_CHARS,
+  MAX_PREFIX_TOKENS,
   renderDocumentTitleAndContent,
   renderPrefixSection,
   sectionLength,
@@ -2221,7 +2223,10 @@ async function renderPageSection({
     // Prefix for depths 0 and 1, and only if children
     const blockSection =
       depth < 2 && adaptedBlocksByParentId[b.notionBlockId]?.length
-        ? await renderPrefixSection(dsConfig, renderedBlock)
+        ? await renderPrefixSection({
+            dataSourceConfig: dsConfig,
+            prefix: renderedBlock,
+          })
         : {
             prefix: null,
             content: renderedBlock,
@@ -2356,7 +2361,12 @@ export async function upsertDatabaseStructuredDataFromCache({
     );
     localLogger.info("Upserting Notion Database as Document.");
     const prefix = `${databaseName}\n${csvHeader}`;
-    const prefixSection = await renderPrefixSection(dataSourceConfig, prefix);
+    const prefixSection = await renderPrefixSection({
+      dataSourceConfig,
+      prefix,
+      maxPrefixTokens: MAX_PREFIX_TOKENS * 2,
+      maxPrefixChars: MAX_PREFIX_CHARS * 2,
+    });
     if (!prefixSection.content) {
       await upsertToDatasource({
         dataSourceConfig,

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -50,7 +50,6 @@ import {
   deleteTable,
   deleteTableRow,
   MAX_DOCUMENT_TXT_LEN,
-  MIN_FREE_TEXT_PROPERTY_LEN,
   renderDocumentTitleAndContent,
   renderPrefixSection,
   sectionLength,
@@ -1850,7 +1849,7 @@ export async function renderAndUpsertPageFromCache({
   const createdAt = new Date(pageCacheEntry.createdTime);
   const updatedAt = new Date(pageCacheEntry.lastEditedTime);
 
-  if (documentLength === 0 && maxPropertyLength < MIN_FREE_TEXT_PROPERTY_LEN) {
+  if (documentLength === 0 && maxPropertyLength < 256) {
     localLogger.info(
       { maxPropertyLength },
       "notionRenderAndUpsertPageFromCache: Not upserting page without body and free text properties."

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -1738,7 +1738,7 @@ export async function renderAndUpsertPageFromCache({
   const parsedProperties = parsePageProperties(
     JSON.parse(pageCacheEntry.pagePropertiesText) as PageObjectProperties
   );
-  for (const p of parsedProperties.filter((p) => p.key !== "title" && p.text)) {
+  for (const p of parsedProperties.filter((p) => p.key !== "title")) {
     if (!p.text) {
       continue;
     }

--- a/connectors/src/connectors/notion/temporal/config.ts
+++ b/connectors/src/connectors/notion/temporal/config.ts
@@ -1,2 +1,2 @@
-export const WORKFLOW_VERSION = 33;
+export const WORKFLOW_VERSION = 34;
 export const QUEUE_NAME = `notion-queue-v${WORKFLOW_VERSION}`;

--- a/connectors/src/connectors/notion/temporal/workflows.ts
+++ b/connectors/src/connectors/notion/temporal/workflows.ts
@@ -434,7 +434,7 @@ export async function upsertPageChildWorkflow({
   let cursor: string | null = null;
   let blockIndexInPage = 0;
   do {
-    const { nextCursor, blocksWithChildren, childDatabases, blocksCount } =
+    const { nextCursor, blocksWithChildren, blocksCount } =
       await cacheBlockChildren({
         connectorId,
         pageId,
@@ -454,17 +454,6 @@ export async function upsertPageChildWorkflow({
           connectorId: [connectorId],
         },
         args: [{ connectorId, pageId, blockId: block, topLevelWorkflowId }],
-        parentClosePolicy: ParentClosePolicy.PARENT_CLOSE_POLICY_TERMINATE,
-        memo: workflowInfo().memo,
-      });
-    }
-    for (const databaseId of childDatabases) {
-      await executeChild(processChildDatabaseChildWorkflow, {
-        workflowId: `${topLevelWorkflowId}-page-${pageId}-child-database-${databaseId}`,
-        searchAttributes: {
-          connectorId: [connectorId],
-        },
-        args: [{ connectorId, databaseId, topLevelWorkflowId }],
         parentClosePolicy: ParentClosePolicy.PARENT_CLOSE_POLICY_TERMINATE,
         memo: workflowInfo().memo,
       });
@@ -504,7 +493,7 @@ export async function notionProcessBlockChildrenChildWorkflow({
   let blockIndexInParent = 0;
 
   do {
-    const { nextCursor, blocksWithChildren, childDatabases, blocksCount } =
+    const { nextCursor, blocksWithChildren, blocksCount } =
       await cacheBlockChildren({
         connectorId,
         pageId,
@@ -528,45 +517,6 @@ export async function notionProcessBlockChildrenChildWorkflow({
         memo: workflowInfo().memo,
       });
     }
-    for (const databaseId of childDatabases) {
-      await executeChild(processChildDatabaseChildWorkflow, {
-        workflowId: `${topLevelWorkflowId}-page-${pageId}-child-database-${databaseId}`,
-        searchAttributes: {
-          connectorId: [connectorId],
-        },
-        args: [{ connectorId, databaseId, topLevelWorkflowId }],
-        parentClosePolicy: ParentClosePolicy.PARENT_CLOSE_POLICY_TERMINATE,
-        memo: workflowInfo().memo,
-      });
-    }
-  } while (cursor);
-}
-
-export async function processChildDatabaseChildWorkflow({
-  connectorId,
-  databaseId,
-  topLevelWorkflowId,
-}: {
-  connectorId: ModelId;
-  databaseId: string;
-  topLevelWorkflowId: string;
-}): Promise<void> {
-  const loggerArgs = {
-    connectorId,
-  };
-
-  let cursor: string | null = null;
-  do {
-    const { nextCursor } = await fetchDatabaseChildPages({
-      connectorId,
-      databaseId,
-      cursor,
-      loggerArgs,
-      topLevelWorkflowId,
-      storeInCache: true,
-      returnUpToDatePageIdsForExistingDatabase: true,
-    });
-    cursor = nextCursor;
   } while (cursor);
 }
 
@@ -753,6 +703,7 @@ async function upsertDatabase({
       connectorId,
       topLevelWorkflowId,
       loggerArgs,
+      runTimestamp,
     })
   );
 

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -30,6 +30,10 @@ if (!DUST_FRONT_API) {
 // and large files are generally less useful anyway.
 export const MAX_DOCUMENT_TXT_LEN = 750000;
 
+// Size above which a property value is considered to be "free text" (which will trigger an upsert of the page
+// even if the page has not actual body)
+export const MIN_FREE_TEXT_PROPERTY_LEN = 256;
+
 type UpsertContext = {
   sync_type: "batch" | "incremental";
 };

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -30,10 +30,6 @@ if (!DUST_FRONT_API) {
 // and large files are generally less useful anyway.
 export const MAX_DOCUMENT_TXT_LEN = 750000;
 
-// Size above which a property value is considered to be "free text" (which will trigger an upsert of the page
-// even if the page has not actual body)
-export const MIN_FREE_TEXT_PROPERTY_LEN = 256;
-
 type UpsertContext = {
   sync_type: "batch" | "incremental";
 };


### PR DESCRIPTION
## Description

- Remove all the inline database logic (which was broken anyway...). This may save quite a bit of requests to notion 🤔. We continue to add child databases we don't know about to "resources to check"
- Insert inline placeholders (`Child Database ${DB_TITLE}`) for databases that are children of a block
- upsert databases to semantic store as CSV files (using header as prefix)
- upsert pages that don't have a body if one of their properies has over 256 characters

## Risk

Notion sync could get stuck, but easy to rollback

## Deploy Plan

Requires a queue bump + restart of workflows
