### PR TITLE
Add enterprise connection setup flow

### DIFF
--- a/front/components/workspace/connection.tsx
+++ b/front/components/workspace/connection.tsx
@@ -195,7 +195,7 @@ function CreateOktaEnterpriseConnectionModal({
       sendNotification({
         type: "success",
         title: "SSO configuration created",
-        description: "Single Sign On configuration created.",
+        description: "Okta Single Sign On configuration created.",
       });
     }
   };

--- a/front/components/workspace/connection.tsx
+++ b/front/components/workspace/connection.tsx
@@ -54,6 +54,10 @@ export function EnterpriseConnectionDetails({
       workspaceId: owner.sId,
     });
 
+  if (!owner.flags.includes("okta_enterprise_connection")) {
+    return <></>;
+  }
+
   const { strategy } = strategyDetails;
 
   return (

--- a/front/components/workspace/connection.tsx
+++ b/front/components/workspace/connection.tsx
@@ -1,0 +1,337 @@
+import {
+  Button,
+  Dialog,
+  ExternalLinkIcon,
+  IconButton,
+  Input,
+  LockIcon,
+  Modal,
+  Page,
+  Popup,
+} from "@dust-tt/sparkle";
+import type {
+  PlanType,
+  SupportedEnterpriseConnectionStrategies,
+  WorkspaceType,
+} from "@dust-tt/types";
+import { useRouter } from "next/router";
+import { useContext, useState } from "react";
+
+import { SendNotificationsContext } from "@app/components/sparkle/Notification";
+import { isUpgraded } from "@app/lib/plans/plan_codes";
+import { useWorkspaceEnterpriseConnection } from "@app/lib/swr";
+
+interface EnterpriseConnectionDetailsProps {
+  owner: WorkspaceType;
+  plan: PlanType;
+  strategy?: SupportedEnterpriseConnectionStrategies;
+}
+
+export function EnterpriseConnectionDetails({
+  owner,
+  plan,
+  strategy = "okta",
+}: EnterpriseConnectionDetailsProps) {
+  const [showNoInviteLinkPopup, setShowNoInviteLinkPopup] = useState(false);
+  const [
+    isEnterpriseConnectionModalOpened,
+    setIsEnterpriseConnectionModalOpened,
+  ] = useState(false);
+  const [
+    isDisableEnterpriseConnectionModalOpened,
+    setIsDisableEnterpriseConnectionModalOpened,
+  ] = useState(false);
+
+  const router = useRouter();
+
+  const { enterpriseConnection, mutateEnterpriseConnection } =
+    useWorkspaceEnterpriseConnection({
+      workspaceId: owner.sId,
+    });
+
+  return (
+    <Page.Vertical gap="sm">
+      <Page.H variant="h5">Single Sign On</Page.H>
+      <CreateEnterpriseConnectionModal
+        owner={owner}
+        isOpen={isEnterpriseConnectionModalOpened}
+        onClose={async (created: boolean) => {
+          if (created) {
+            await mutateEnterpriseConnection();
+          }
+
+          setIsEnterpriseConnectionModalOpened(false);
+        }}
+        strategy={strategy}
+      />
+      <DisableEnterpriseConnectionModal
+        enterpriseConnectionEnabled={!!enterpriseConnection}
+        isOpen={isDisableEnterpriseConnectionModalOpened}
+        onClose={async (updated: boolean) => {
+          setIsDisableEnterpriseConnectionModalOpened(false);
+
+          if (updated) {
+            await mutateEnterpriseConnection();
+          }
+        }}
+        owner={owner}
+        strategy={strategy}
+      />
+      <Page.P variant="secondary">
+        Easily integrate {strategy} to enable Single Sign-On (SSO) for your
+        team.
+      </Page.P>
+      <div className="flex flex-col items-start gap-3">
+        {enterpriseConnection ? (
+          <Button
+            label="De-activate Single Sign On"
+            size="sm"
+            variant="secondaryWarning"
+            disabled={!enterpriseConnection}
+            onClick={() => {
+              setIsDisableEnterpriseConnectionModalOpened(true);
+            }}
+          />
+        ) : (
+          <Button
+            label="Activate Single Sign On"
+            size="sm"
+            variant="primary"
+            disabled={!!enterpriseConnection}
+            onClick={() => {
+              if (!isUpgraded(plan)) {
+                setShowNoInviteLinkPopup(true);
+              } else {
+                setIsEnterpriseConnectionModalOpened(true);
+              }
+            }}
+          />
+        )}
+        <Popup
+          show={showNoInviteLinkPopup}
+          chipLabel="Free plan"
+          description="You cannot enable auto-join with the free plan. Upgrade your plan to invite other members."
+          buttonLabel="Check Dust plans"
+          buttonClick={() => {
+            void router.push(`/w/${owner.sId}/subscription`);
+          }}
+          className="absolute bottom-8 right-0"
+          onClose={() => setShowNoInviteLinkPopup(false)}
+        />
+      </div>
+    </Page.Vertical>
+  );
+}
+
+function OktaHelpLink({ hint, link }: { hint: string; link: string }) {
+  return (
+    <div className="flex flex-row items-center space-x-2 text-element-700">
+      <span>{hint}</span>
+      <IconButton
+        icon={ExternalLinkIcon}
+        onClick={() =>
+          window.open(
+            `https://developer.okta.com/docs/guides/${link}`,
+            "_blank"
+          )
+        }
+        aria-label={`Open ${link} in a new tab`}
+      />
+    </div>
+  );
+}
+
+function CreateEnterpriseConnectionModal({
+  isOpen,
+  onClose,
+  owner,
+  strategy,
+}: {
+  isOpen: boolean;
+  onClose: (created: boolean) => void;
+  owner: WorkspaceType;
+  strategy: SupportedEnterpriseConnectionStrategies;
+}) {
+  const [enterpriseConnectionDetails, setEnterpriseConnectionDetails] =
+    useState<{
+      clientId?: string;
+      clientSecret?: string;
+      domain?: string;
+    }>({});
+
+  const sendNotification = useContext(SendNotificationsContext);
+
+  const createEnterpriseConnection = async () => {
+    const res = await fetch(`/api/w/${owner.sId}/enterprise-connection`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        strategy,
+        ...enterpriseConnectionDetails,
+      }),
+    });
+    if (!res.ok) {
+      sendNotification({
+        type: "error",
+        title: "Update failed",
+        description: `Failed to create ${strategy} Single Sign On configuration.`,
+      });
+    } else {
+      sendNotification({
+        type: "success",
+        title: "SSO configuration created",
+        description: "Single Sign On configuration created.",
+      });
+    }
+  };
+
+  // TODO: Make Generic!
+  return (
+    <Modal
+      isOpen={isOpen}
+      title={`Create ${strategy} Single Sign On configuration`}
+      onClose={() => onClose(false)}
+      hasChanged={false}
+      variant="side-sm"
+    >
+      <Page variant="modal">
+        <Page.Layout direction="vertical">
+          <Page.P>
+            Okta Domain:
+            <Input
+              name="Okta Domain"
+              placeholder="mydomain.okta.com"
+              value={enterpriseConnectionDetails.domain ?? ""}
+              onChange={(value) =>
+                setEnterpriseConnectionDetails({
+                  ...enterpriseConnectionDetails,
+                  domain: value,
+                })
+              }
+              className="max-w-sm"
+            />
+            <OktaHelpLink
+              hint="See Okta docs for obtaining your Okta Domain"
+              link="find-your-domain/main"
+            />
+          </Page.P>
+          <Page.P>
+            Okta Client Id:
+            <Input
+              name="Okta Client Id"
+              placeholder="okta-client-id"
+              value={enterpriseConnectionDetails.clientId ?? ""}
+              onChange={(value) =>
+                setEnterpriseConnectionDetails({
+                  ...enterpriseConnectionDetails,
+                  clientId: value,
+                })
+              }
+              className="max-w-sm"
+            />
+            <OktaHelpLink
+              hint="How to obtain your Okta Client ID?"
+              link="find-your-app-credentials/main"
+            />
+          </Page.P>
+          <Page.P>
+            Okta Client Secret:
+            <Input
+              name="Okta Client Secret"
+              placeholder="okta-client-secret"
+              value={enterpriseConnectionDetails.clientSecret ?? ""}
+              onChange={(value) =>
+                setEnterpriseConnectionDetails({
+                  ...enterpriseConnectionDetails,
+                  clientSecret: value,
+                })
+              }
+              className="max-w-sm"
+            />
+            <OktaHelpLink
+              hint="How to obtain your Okta Client ID?"
+              link="find-your-app-credentials/main"
+            />
+          </Page.P>
+          <Page.Separator />
+          <div className="flex items-start">
+            <Button
+              variant="primaryWarning"
+              size="sm"
+              disabled={
+                !(
+                  enterpriseConnectionDetails.clientId &&
+                  enterpriseConnectionDetails.clientSecret &&
+                  enterpriseConnectionDetails.domain
+                )
+              }
+              icon={LockIcon}
+              label="Create Okta Configuration"
+              onClick={async () => {
+                await createEnterpriseConnection();
+                onClose(true);
+              }}
+              hasMagnifying={true}
+            />
+          </div>
+        </Page.Layout>
+      </Page>
+    </Modal>
+  );
+}
+
+function DisableEnterpriseConnectionModal({
+  isOpen,
+  onClose,
+  owner,
+  strategy,
+}: {
+  enterpriseConnectionEnabled: boolean;
+  isOpen: boolean;
+  onClose: (updated: boolean) => void;
+  owner: WorkspaceType;
+  strategy: SupportedEnterpriseConnectionStrategies;
+}) {
+  const sendNotification = useContext(SendNotificationsContext);
+
+  async function handleUpdateWorkspace(): Promise<void> {
+    const res = await fetch(`/api/w/${owner.sId}/enterprise-connection`, {
+      method: "DELETE",
+    });
+    if (!res.ok) {
+      sendNotification({
+        type: "error",
+        title: "Disable Single Sign On failed",
+        description: `Failed to disable ${strategy} Single Sign On.`,
+      });
+    } else {
+      sendNotification({
+        type: "success",
+        title: "Single Sign On disabled",
+        description: `${strategy} Single Sign On disable.`,
+      });
+    }
+
+    onClose(true);
+  }
+
+  return (
+    <Dialog
+      isOpen={isOpen}
+      title={`Disable ${strategy} Single Sign On`}
+      onValidate={async () => {
+        await handleUpdateWorkspace();
+      }}
+      onCancel={() => onClose(false)}
+      validateLabel={`Disable ${strategy} Single Sign On`}
+      validateVariant="primaryWarning"
+    >
+      <div>
+        Anyone with an {strategy} account won't be able to access your Dust
+        workspace anymore.
+      </div>
+    </Dialog>
+  );
+}

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -1,0 +1,18 @@
+import { EnvironmentConfig } from "@dust-tt/types";
+
+const config = {
+  getAuth0IssuerBaseUrl: (): string => {
+    return EnvironmentConfig.getEnvVariable("AUTH0_TENANT_DOMAIN_URL");
+  },
+  getAuth0M2MClientId: (): string => {
+    return EnvironmentConfig.getEnvVariable("AUTH0_M2M_CLIENT_ID");
+  },
+  getAuth0M2MClientSecret: (): string => {
+    return EnvironmentConfig.getEnvVariable("AUTH0_M2M_CLIENT_SECRET");
+  },
+  getAuth0WebApplicationId: (): string => {
+    return EnvironmentConfig.getEnvVariable("AUTH0_WEB_APP_CLIENT_ID");
+  },
+};
+
+export default config;

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -1,7 +1,7 @@
 import { EnvironmentConfig } from "@dust-tt/types";
 
 const config = {
-  getAuth0IssuerBaseUrl: (): string => {
+  getAuth0TenantUrl: (): string => {
     return EnvironmentConfig.getEnvVariable("AUTH0_TENANT_DOMAIN_URL");
   },
   getAuth0M2MClientId: (): string => {

--- a/front/lib/api/enterprise_connection.ts
+++ b/front/lib/api/enterprise_connection.ts
@@ -1,0 +1,82 @@
+import type { SupportedEnterpriseConnectionStrategies } from "@dust-tt/types";
+import type { Connection } from "auth0";
+import { ManagementClient } from "auth0";
+
+import config from "@app/lib/api/config";
+
+const management = new ManagementClient({
+  domain: config.getAuth0IssuerBaseUrl(),
+  clientId: config.getAuth0M2MClientId(),
+  clientSecret: config.getAuth0M2MClientSecret(),
+});
+
+function makeEnterpriseConnectionName(workspaceId: string) {
+  return `workspace-${workspaceId}`;
+}
+
+export async function getEnterpriseConnectionForWorkspace(
+  workspaceId: string,
+  strategy: SupportedEnterpriseConnectionStrategies = "okta"
+) {
+  // This endpoint supports fetching up to 1000 connections in one page.
+  // In the future, consider implementing pagination to handle larger datasets.
+  const connections = await management.connections.getAll({
+    strategy: [strategy],
+  });
+
+  const expectedConnectionName = makeEnterpriseConnectionName(workspaceId);
+  return connections.data.find((c) => c.name === expectedConnectionName);
+}
+
+interface EnterpriseConnectionDetails {
+  clientId: string;
+  clientSecret: string;
+  domain: string;
+  strategy: SupportedEnterpriseConnectionStrategies;
+}
+
+export async function createEnterpriseConnection(
+  {
+    workspaceId,
+    verifiedDomain,
+  }: {
+    workspaceId: string;
+    verifiedDomain: string | null;
+  },
+  connectionDetails: EnterpriseConnectionDetails
+): Promise<Connection> {
+  const connection = await management.connections.create({
+    name: makeEnterpriseConnectionName(workspaceId),
+    display_name: makeEnterpriseConnectionName(workspaceId),
+    strategy: connectionDetails.strategy,
+    options: {
+      domain: connectionDetails.domain,
+      client_id: connectionDetails.clientId,
+      client_secret: connectionDetails.clientSecret,
+      domain_aliases: verifiedDomain ? [verifiedDomain] : [],
+    },
+    is_domain_connection: false,
+    realms: [],
+    enabled_clients: [config.getAuth0WebApplicationId()],
+    metadata: {},
+  });
+
+  return connection.data;
+}
+
+export async function deleteEnterpriseConnection(
+  workspaceId: string,
+  strategy: SupportedEnterpriseConnectionStrategies = "okta"
+) {
+  const existingConnection = await getEnterpriseConnectionForWorkspace(
+    workspaceId,
+    strategy
+  );
+  if (!existingConnection) {
+    throw new Error("Enterprise connection not found.");
+  }
+
+  return management.connections.delete({
+    id: existingConnection.id,
+  });
+}

--- a/front/lib/api/enterprise_connection.ts
+++ b/front/lib/api/enterprise_connection.ts
@@ -5,7 +5,7 @@ import { ManagementClient } from "auth0";
 import config from "@app/lib/api/config";
 
 const management = new ManagementClient({
-  domain: config.getAuth0IssuerBaseUrl(),
+  domain: config.getAuth0TenantUrl(),
   clientId: config.getAuth0M2MClientId(),
   clientSecret: config.getAuth0M2MClientSecret(),
 });

--- a/front/lib/api/enterprise_connection.ts
+++ b/front/lib/api/enterprise_connection.ts
@@ -50,10 +50,11 @@ export async function createEnterpriseConnection(
     display_name: makeEnterpriseConnectionName(workspaceId),
     strategy: connectionDetails.strategy,
     options: {
-      domain: connectionDetails.domain,
       client_id: connectionDetails.clientId,
       client_secret: connectionDetails.clientSecret,
       domain_aliases: verifiedDomain ? [verifiedDomain] : [],
+      domain: connectionDetails.domain,
+      scope: "email profile openid",
     },
     is_domain_connection: false,
     realms: [],

--- a/front/lib/swr.ts
+++ b/front/lib/swr.ts
@@ -7,6 +7,7 @@ import type {
   ConversationType,
   DataSourceType,
   RunRunType,
+  WorkspaceEnterpriseConnection,
   WorkspaceType,
 } from "@dust-tt/types";
 import { useMemo } from "react";
@@ -759,5 +760,27 @@ export function useWorkspaceAnalytics({
     analytics: data ? data : null,
     isMemberCountLoading: !error && !data,
     isMemberCountError: error,
+  };
+}
+
+export function useWorkspaceEnterpriseConnection({
+  workspaceId,
+}: {
+  workspaceId: string;
+}) {
+  const workspaceEnterpriseConnectionFetcher: Fetcher<{
+    connection: WorkspaceEnterpriseConnection;
+  }> = fetcher;
+
+  const { data, error, mutate } = useSWR(
+    workspaceId ? `/api/w/${workspaceId}/enterprise-connection` : null,
+    workspaceEnterpriseConnectionFetcher
+  );
+
+  return {
+    enterpriseConnection: data ? data.connection : null,
+    isEnterpriseConnectionLoading: !error && !data,
+    isEnterpriseConnectionError: error,
+    mutateEnterpriseConnection: mutate,
   };
 }

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -35,6 +35,7 @@
         "@types/emoji-mart": "^3.0.10",
         "@uiw/react-textarea-code-editor": "^2.1.7",
         "ajv": "^8.12.0",
+        "auth0": "^4.3.1",
         "blake3": "^2.1.7",
         "csv-parse": "^5.5.2",
         "csv-stringify": "^6.4.5",
@@ -14811,6 +14812,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/auth0": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/auth0/-/auth0-4.3.1.tgz",
+      "integrity": "sha512-VuR/PdNHwXD9QiYUZf8UN0qiv07yJWHKfF2yEhePaPCrpwbEm6lHM6dkN7ylOdseogCkGmvchxYGMga0IPNrCA==",
+      "dependencies": {
+        "jose": "^4.13.2",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/autoprefixer": {

--- a/front/package.json
+++ b/front/package.json
@@ -43,6 +43,7 @@
     "@types/emoji-mart": "^3.0.10",
     "@uiw/react-textarea-code-editor": "^2.1.7",
     "ajv": "^8.12.0",
+    "auth0": "^4.3.1",
     "blake3": "^2.1.7",
     "csv-parse": "^5.5.2",
     "csv-stringify": "^6.4.5",

--- a/front/pages/api/w/[wId]/enterprise-connection.ts
+++ b/front/pages/api/w/[wId]/enterprise-connection.ts
@@ -1,0 +1,174 @@
+import type {
+  WithAPIErrorReponse,
+  WorkspaceEnterpriseConnection,
+} from "@dust-tt/types";
+import { isLeft } from "fp-ts/lib/Either";
+import * as t from "io-ts";
+import * as reporter from "io-ts-reporters";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import {
+  createEnterpriseConnection,
+  deleteEnterpriseConnection,
+  getEnterpriseConnectionForWorkspace,
+} from "@app/lib/api/enterprise_connection";
+import { Authenticator, getSession } from "@app/lib/auth";
+import { Workspace, WorkspaceHasDomain } from "@app/lib/models";
+import logger from "@app/logger/logger";
+import { apiError, withLogging } from "@app/logger/withlogging";
+
+export type GetEnterpriseConnectionResponseBody = {
+  connection: WorkspaceEnterpriseConnection;
+};
+
+const PostCreateEnterpriseConnectionRequestBodySchema = t.type({
+  clientId: t.string,
+  clientSecret: t.string,
+  domain: t.string,
+  strategy: t.literal("okta"),
+});
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorReponse<GetEnterpriseConnectionResponseBody>>
+): Promise<void> {
+  const session = await getSession(req, res);
+  const auth = await Authenticator.fromSession(
+    session,
+    req.query.wId as string
+  );
+
+  const owner = auth.workspace();
+  const user = auth.user();
+  if (!owner || !user) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "The workspace you're trying to modify was not found.",
+      },
+    });
+  }
+
+  if (!auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "Only users that are `admins` for the current workspace can modify it.",
+      },
+    });
+  }
+
+  const workspace = await Workspace.findOne({
+    where: { id: owner.id },
+  });
+  if (!workspace) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "The workspace you're trying to modify was not found.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET":
+      const enterpriseConnection = await getEnterpriseConnectionForWorkspace(
+        workspace.sId
+      );
+      if (enterpriseConnection) {
+        return res
+          .status(200)
+          .json({ connection: { name: enterpriseConnection.name } });
+      }
+      break;
+
+    case "DELETE":
+      try {
+        await deleteEnterpriseConnection(workspace.sId);
+
+        res.status(204).end();
+        return;
+      } catch (err) {
+        logger.info(
+          {
+            workspaceId: workspace.sId,
+            err,
+          },
+          "Failed to delete enterprise connection."
+        );
+
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Failed to delete enterprise connection.",
+          },
+        });
+      }
+
+    case "POST":
+      const bodyValidation =
+        PostCreateEnterpriseConnectionRequestBodySchema.decode(req.body);
+      if (isLeft(bodyValidation)) {
+        const pathError = reporter.formatValidationErrors(bodyValidation.left);
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid request body: ${pathError}`,
+          },
+        });
+      }
+      const { right: body } = bodyValidation;
+
+      const workspaceWithVerifiedDomain = await WorkspaceHasDomain.findOne({
+        where: {
+          workspaceId: workspace.id,
+        },
+      });
+
+      try {
+        await createEnterpriseConnection(
+          {
+            workspaceId: workspace.sId,
+            verifiedDomain: workspaceWithVerifiedDomain?.domain ?? null,
+          },
+          body
+        );
+      } catch (err) {
+        logger.info(
+          {
+            workspaceId: workspace.sId,
+            err,
+          },
+          "Failed to create enterprise connection."
+        );
+
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Failed to create enterprise connection.",
+          },
+        });
+      }
+
+      res.status(201).end();
+      return;
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, POST is expected.",
+        },
+      });
+  }
+}
+
+export default withLogging(handler);

--- a/front/pages/api/w/[wId]/enterprise-connection.ts
+++ b/front/pages/api/w/[wId]/enterprise-connection.ts
@@ -77,7 +77,7 @@ async function handler(
   switch (req.method) {
     case "GET":
       const enterpriseConnection = await getEnterpriseConnectionForWorkspace(
-        workspace.sId
+        auth
       );
       if (enterpriseConnection) {
         return res
@@ -88,7 +88,7 @@ async function handler(
 
     case "DELETE":
       try {
-        await deleteEnterpriseConnection(workspace.sId);
+        await deleteEnterpriseConnection(auth);
 
         res.status(204).end();
         return;
@@ -133,10 +133,8 @@ async function handler(
 
       try {
         await createEnterpriseConnection(
-          {
-            workspaceId: workspace.sId,
-            verifiedDomain: workspaceWithVerifiedDomain?.domain ?? null,
-          },
+          auth,
+          workspaceWithVerifiedDomain?.domain ?? null,
           body
         );
       } catch (err) {

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -32,11 +32,13 @@ import { useSWRConfig } from "swr";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { subNavigationAdmin } from "@app/components/sparkle/navigation";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
+import { EnterpriseConnectionDetails } from "@app/components/workspace/connection";
 import {
   checkWorkspaceSeatAvailabilityUsingAuth,
   getWorkspaceVerifiedDomain,
 } from "@app/lib/api/workspace";
 import { Authenticator } from "@app/lib/auth";
+import { isDevelopmentOrDustWorkspace } from "@app/lib/development";
 import { withDefaultGetServerSidePropsRequirements } from "@app/lib/iam/session";
 import { isUpgraded } from "@app/lib/plans/plan_codes";
 import { useMembers, useWorkspaceInvitations } from "@app/lib/swr";
@@ -196,7 +198,9 @@ export default function WorkspaceAdmin({
             </div>
           </Page.Vertical>
         )}
-
+        {isDevelopmentOrDustWorkspace(owner) && (
+          <EnterpriseConnectionDetails owner={owner} plan={plan} />
+        )}
         <MemberList />
       </Page.Vertical>
     </AppLayout>
@@ -627,8 +631,6 @@ function DomainAutoJoinModal({
         domainAutoJoinEnabled: !domainAutoJoinEnabled,
       }),
     });
-
-    console.log(">> res:", await res.json());
 
     if (!res.ok) {
       sendNotification({

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -40,7 +40,6 @@ import {
   getWorkspaceVerifiedDomain,
 } from "@app/lib/api/workspace";
 import { Authenticator } from "@app/lib/auth";
-import { isDevelopmentOrDustWorkspace } from "@app/lib/development";
 import { withDefaultGetServerSidePropsRequirements } from "@app/lib/iam/session";
 import { isUpgraded } from "@app/lib/plans/plan_codes";
 import { useMembers, useWorkspaceInvitations } from "@app/lib/swr";

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -32,7 +32,9 @@ import { useSWRConfig } from "swr";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { subNavigationAdmin } from "@app/components/sparkle/navigation";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
+import type { EnterpriseConnectionStrategyDetails } from "@app/components/workspace/connection";
 import { EnterpriseConnectionDetails } from "@app/components/workspace/connection";
+import config from "@app/lib/api/config";
 import {
   checkWorkspaceSeatAvailabilityUsingAuth,
   getWorkspaceVerifiedDomain,
@@ -52,6 +54,7 @@ export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
   user: UserType;
   owner: WorkspaceType;
   subscription: SubscriptionType;
+  enterpriseConnectionStrategyDetails: EnterpriseConnectionStrategyDetails;
   plan: PlanType;
   gaTrackingId: string;
   workspaceHasAvailableSeats: boolean;
@@ -75,11 +78,18 @@ export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
   const workspaceVerifiedDomain = await getWorkspaceVerifiedDomain(owner);
   const workspaceHasAvailableSeats =
     await checkWorkspaceSeatAvailabilityUsingAuth(auth);
+
+  const enterpriseConnectionStrategyDetails: EnterpriseConnectionStrategyDetails =
+    {
+      strategy: "okta",
+      callbackUrl: config.getAuth0TenantUrl(),
+    };
   return {
     props: {
       user,
       owner,
       subscription,
+      enterpriseConnectionStrategyDetails,
       plan,
       gaTrackingId: GA_TRACKING_ID,
       workspaceHasAvailableSeats,
@@ -110,6 +120,7 @@ export default function WorkspaceAdmin({
   user,
   owner,
   subscription,
+  enterpriseConnectionStrategyDetails,
   plan,
   gaTrackingId,
   workspaceVerifiedDomain,
@@ -199,7 +210,11 @@ export default function WorkspaceAdmin({
           </Page.Vertical>
         )}
         {isDevelopmentOrDustWorkspace(owner) && (
-          <EnterpriseConnectionDetails owner={owner} plan={plan} />
+          <EnterpriseConnectionDetails
+            owner={owner}
+            plan={plan}
+            strategyDetails={enterpriseConnectionStrategyDetails}
+          />
         )}
         <MemberList />
       </Page.Vertical>

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -209,13 +209,11 @@ export default function WorkspaceAdmin({
             </div>
           </Page.Vertical>
         )}
-        {isDevelopmentOrDustWorkspace(owner) && (
-          <EnterpriseConnectionDetails
-            owner={owner}
-            plan={plan}
-            strategyDetails={enterpriseConnectionStrategyDetails}
-          />
-        )}
+        <EnterpriseConnectionDetails
+          owner={owner}
+          plan={plan}
+          strategyDetails={enterpriseConnectionStrategyDetails}
+        />
         <MemberList />
       </Page.Vertical>
     </AppLayout>

--- a/types/src/front/feature_flags.ts
+++ b/types/src/front/feature_flags.ts
@@ -1,6 +1,7 @@
 export const WHITELISTABLE_FEATURES = [
   "workspace_analytics",
   "usage_data_api",
+  "okta_enterprise_connection",
 ] as const;
 export type WhitelistableFeature = (typeof WHITELISTABLE_FEATURES)[number];
 export function isWhitelistableFeature(

--- a/types/src/front/workspace.ts
+++ b/types/src/front/workspace.ts
@@ -2,3 +2,9 @@ export interface WorkspaceDomain {
   domain: string;
   domainAutoJoinEnabled: boolean;
 }
+
+export interface WorkspaceEnterpriseConnection {
+  name: string;
+}
+
+export type SupportedEnterpriseConnectionStrategies = "okta";


### PR DESCRIPTION
## Description

This PR introduces the ability for admins to enable Okta Enterprise Connection Single Sign-On (SSO) directly from the workspace member view. At the moment, this feature is accessible only through a Feature Flag, and it will be included in our enterprise plan once it's available.

This implementation relies heavily on Auth0, which manages the connection for us.

![setup-okta-sso](https://github.com/dust-tt/dust/assets/7428970/7ab6c1fe-f785-4ddd-853d-6fbdd7103e74)

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

<img width="1839" alt="image" src="https://github.com/dust-tt/dust/assets/7428970/ec1d15aa-9e5a-4bb2-9c1e-e228d7f9dc97">

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Add the following environment variables:
- [x] `AUTH0_TENANT_DOMAIN_URL`
- [x] `AUTH0_M2M_CLIENT_ID`
- [x] `AUTH0_M2M_CLIENT_SECRET`
- [x] `AUTH0_WEB_APP_CLIENT_ID`
<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
