### PR TITLE
Conversation citations: add right padding

### DIFF
--- a/front/components/assistant/RenderMessageMarkdown.tsx
+++ b/front/components/assistant/RenderMessageMarkdown.tsx
@@ -310,19 +310,18 @@ function CiteBlock(props: ReactMarkdownProps) {
 
   if (refs) {
     return (
-      <>
+      <span className="inline-flex space-x-1">
         {refs.map((r, i) => {
           const document = references[r.ref];
           const link = linkFromDocument(document);
 
           return (
-            <sup key={`${r.ref}-${i}`} className="inline-flex">
+            <sup key={`${r.ref}-${i}`}>
               <a
                 href={link}
                 target="_blank"
                 rel="noopener noreferrer"
                 onMouseEnter={() => setHoveredReference(r.counter)}
-                className={`${i !== 0 ? "pl-1" : ""}`}
               >
                 <div className="flex h-4 w-4 items-center justify-center rounded-full border border-violet-200 bg-violet-100 text-xs font-semibold text-element-800 hover:border-violet-400">
                   {r.counter}
@@ -331,7 +330,7 @@ function CiteBlock(props: ReactMarkdownProps) {
             </sup>
           );
         })}
-      </>
+      </span>
     );
   } else {
     const { children } = props;

--- a/front/components/assistant/RenderMessageMarkdown.tsx
+++ b/front/components/assistant/RenderMessageMarkdown.tsx
@@ -316,12 +316,13 @@ function CiteBlock(props: ReactMarkdownProps) {
           const link = linkFromDocument(document);
 
           return (
-            <sup key={`${r.ref}-${i}`} className="inline-block">
+            <sup key={`${r.ref}-${i}`} className="inline-flex">
               <a
                 href={link}
                 target="_blank"
                 rel="noopener noreferrer"
                 onMouseEnter={() => setHoveredReference(r.counter)}
+                className={`${i !== 0 ? "pl-1" : ""}`}
               >
                 <div className="flex h-4 w-4 items-center justify-center rounded-full border border-violet-200 bg-violet-100 text-xs font-semibold text-element-800 hover:border-violet-400">
                   {r.counter}


### PR DESCRIPTION
## Description

Adding a small right padding between two citations. I'm sure there's a better way to do that, but it works 😄 

Before: 
<img width="103" alt="Screenshot 2024-03-06 at 16 23 05" src="https://github.com/dust-tt/dust/assets/3803406/fb8c1ef5-0031-4d00-9045-32c0a3d907b1">

After: 
<img width="96" alt="Screenshot 2024-03-06 at 16 56 16" src="https://github.com/dust-tt/dust/assets/3803406/c1ba1a43-d2b6-4eb4-bc6c-d4940961b6d2">


## Risk

/

## Deploy Plan

/
