### PR TITLE
fix(notion GC): dont reprocess DBs we already have

### DIFF
--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -695,7 +695,7 @@ export async function garbageCollectorMarkAsSeen({
     (
       await NotionDatabase.findAll({
         where: {
-          notionDatabaseId: pageIds,
+          notionDatabaseId: databaseIds,
           connectorId: connector.id,
           skipReason: {
             [Op.is]: null,
@@ -703,7 +703,7 @@ export async function garbageCollectorMarkAsSeen({
         },
         attributes: ["notionDatabaseId"],
       })
-    ).map((page) => page.notionDatabaseId)
+    ).map((database) => database.notionDatabaseId)
   );
 
   const newDatabaseIds = databaseIds.filter(


### PR DESCRIPTION
## Description

Due to this bug, databases were always upserted during GC runs.
Prior to structured data, this was a minor issue as we were not actually upserting anything. Now, it's a much bigger issue because we:
- upsert the structured data to Tables
- upsert the structured data to Documents

This causes the upserts to increase quite a bit.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
