### PR TITLE
Flav/fix input bar send button

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -159,7 +159,7 @@ const InputBarContainer = ({
           size="sm"
           icon={ArrowUpIcon}
           label="Send"
-          disabled={!editorService.isFocused() || editorService.isEmpty()}
+          disabled={editorService.isEmpty()}
           labelVisible={false}
           disabledTooltip
           onClick={async () => {

--- a/front/components/assistant/conversation/input_bar/editor/useCustomEditor.tsx
+++ b/front/components/assistant/conversation/input_bar/editor/useCustomEditor.tsx
@@ -103,10 +103,6 @@ const useEditorService = (editor: Editor | null) => {
         return editor?.isEmpty ?? true;
       },
 
-      isFocused() {
-        return editor?.isFocused;
-      },
-
       getJSONContent() {
         return editor?.getJSON();
       },


### PR DESCRIPTION
## Description

See https://github.com/dust-tt/tasks/issues/511.

This PR resolves an issue with the input bar's "send" button. A regression was inadvertently introduced in https://github.com/dust-tt/dust/pull/4144 while addressing the focus of the input bar for assistant preview.

Currently, when clicking on the "send" button, the input bar loses focus and fails to send the payload. I've tested the preview and could not reproduce the blinking issue occurring on the assistant preview.
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
