### PR TITLE
[Sparkle] Fix: tab blue underline to 2px

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.113",
+  "version": "0.2.114",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.113",
+      "version": "0.2.114",
       "license": "ISC",
       "dependencies": {
         "@headlessui/react": "^1.7.17",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.113",
+  "version": "0.2.114",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/components/Tab.tsx
+++ b/sparkle/src/components/Tab.tsx
@@ -233,7 +233,7 @@ export function Tab<E>({
         "s-overflow-x-auto s-overflow-y-hidden s-scrollbar-hide"
       )}
     >
-      <nav className="-s-mb-px s-flex s-space-x-0" aria-label="Tabs">
+      <nav className="s-flex s-space-x-0" aria-label="Tabs">
         {renderTabs()}
       </nav>
     </div>


### PR DESCRIPTION
Fixes https://github.com/dust-tt/tasks/issues/513

Before:
![image](https://github.com/dust-tt/dust/assets/5437393/da9dab9a-ee13-45a0-b8f5-35f1b2fd7691)

After:
![image](https://github.com/dust-tt/dust/assets/5437393/418b352a-4e22-4387-beb2-2ae6529482dc)


## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
