### PR TITLE
enh: increase retrieval chunks to 64 for Claude 3 Opus

### DIFF
--- a/types/src/front/lib/assistant.ts
+++ b/types/src/front/lib/assistant.ts
@@ -57,7 +57,7 @@ export const CLAUDE_3_OPUS_DEFAULT_MODEL_CONFIG = {
   modelId: CLAUDE_3_OPUS_2024029_MODEL_ID,
   displayName: "Claude 3 Opus",
   contextSize: 200000,
-  recommendedTopK: 32,
+  recommendedTopK: 64,
   largeModel: true,
   description:
     "Anthropic's Claude 3 Opus model, most powerful model for highly complex tasks.",


### PR DESCRIPTION
## Description

Claude 3 Opus has a nice 200k tokens context window. Given that it is almost 2x the context size of GPT-4, it makes sense to experiment with increasing the number of retrieved chunks. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
