### PR TITLE
Fix filtering of deleted synced sheets

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
+++ b/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
@@ -435,6 +435,7 @@ export async function syncSpreadSheet(
   // List synced sheets.
   const syncedSheets = await GoogleDriveSheet.findAll({
     where: {
+      connectorId: connector.id,
       driveFileId: file.id,
     },
   });
@@ -451,9 +452,11 @@ export async function syncSpreadSheet(
   // or have exceeded the maximum number of rows.
   const deletedSyncedSheets = syncedSheets.filter(
     (synced) =>
-      !successfulSheetIdImports.find(
+      // Check for undefined explicitly, avoiding incorrect filtering
+      // due to falsy values (0 can be a valid sheet ID).
+      successfulSheetIdImports.find(
         (sheetId) => sheetId === synced.driveSheetId
-      )
+      ) === undefined
   );
   if (deletedSyncedSheets.length > 0) {
     await deleteAllSheets(connector, deletedSyncedSheets, {

--- a/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
+++ b/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
@@ -478,7 +478,9 @@ async function deleteSheetForSpreadsheet(
     {
       connectorId: connector.id,
       sheet,
-      spreadsheetFileId,
+      spreadsheet: {
+        id: spreadsheetFileId,
+      },
     },
     "[Spreadsheet] Deleting google drive sheet."
   );


### PR DESCRIPTION
## Description

This PR addresses an issue with the filtering logic used to determine deleted synced sheets. Previously, the code relied on the truthiness of the `find()` result to filter out synced sheets that were successfully imported. However, this approach could lead to incorrect filtering if a sheet ID contained the value `0`, as `0` is falsy in JavaScript.
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
