### PR TITLE
[Front Search] Better, stabler, cooler, stronger sort order for results

### DIFF
--- a/front/lib/utils.ts
+++ b/front/lib/utils.ts
@@ -239,30 +239,3 @@ export function filterAndSortAgents(
 
   return filtered;
 }
-
-function testCompareForFuzzySort() {
-  // a is always closer to the query than b
-  const data = [
-    { query: "eng", a: "eng", b: "ContentMarketing" },
-    { query: "sql", a: "sqlGod", b: "sqlCoreGod" },
-    { query: "sql", a: "sql", b: "sqlGod" },
-    { query: "sql", a: "sql", b: "SEOQualityRater" },
-    { query: "gp", a: "gpt-4", b: "GabHelp" },
-    { query: "gp", a: "gpt-4", b: "gemni-pro" },
-    { query: "start", a: "robotstart", b: "strongrt" },
-    { query: "mygod", a: "ohmygodbot", b: "moatmode" },
-    { query: "test", a: "test", b: "testlong" },
-    { query: "test", a: "testlonger", b: "longtest" },
-  ];
-  console.log(
-    "Testing compareForFuzzySort, expected first then expected second"
-  );
-  for (const d of data) {
-    console.log(
-      compareForFuzzySort(d.query, d.a, d.b) < 0 ? "PASS" : "FAIL",
-      d
-    );
-  }
-}
-
-testCompareForFuzzySort();

--- a/front/lib/utils.ts
+++ b/front/lib/utils.ts
@@ -135,6 +135,17 @@ export const objectToMarkdown = (obj: any, indent = 0) => {
   return markdown;
 };
 
+/**
+ * Checks if a is a subfilter of b, i.e. all characters in a are present in b in
+ * the same order, and returns the smallest index of the last character of a in
+ * b.
+ *
+ * Used in conjunction with subFilterFirstIndex to compare how much a is 'spread
+ * out' in b. e.g.
+ * - 'god' and 'sqlGod', spread is 3 (index of d minus index of g in 'sqlGod')
+ * - 'gp4' and 'gpt-4', spread is 5
+ * - 'gp4' and 'gemni-pro4', spread is 10
+ */
 function subFilterLastIndex(a: string, b: string) {
   let i = 0;
   let j = 0;
@@ -147,6 +158,15 @@ function subFilterLastIndex(a: string, b: string) {
   return i === a.length ? j : -1;
 }
 
+/**
+ * Checks if a is a subfilter of b, i.e. all characters in a are present in b in
+ * the same order, and returns the biggest index of the first character of a in b.
+ * Used in conjunction with subFilterFirstIndex to compare how much a is 'spread
+ * out' in b. e.g.
+ * - 'god' and 'sqlGod', spread is 3 (index of d minus index of g in 'sqlGod')
+ * - 'gp4' and 'gpt-4', spread is 5
+ * - 'gp4' and 'gemni-pro4', spread is 10
+ */
 function subFilterFirstIndex(a: string, b: string) {
   let i = a.length - 1;
   let j = b.length - 1;

--- a/front/lib/utils.ts
+++ b/front/lib/utils.ts
@@ -173,25 +173,28 @@ export function subFilter(a: string, b: string) {
  * lexicographic order
  */
 export function compareForFuzzySort(query: string, a: string, b: string) {
-  const distanceToQuery = (s: string) =>
-    subFilterLastIndex(query, s) - subFilterFirstIndex(query, s);
-  const distanceA = distanceToQuery(a);
-  if (distanceA === 0) {
+  const subFilterFirstIndexA = subFilterFirstIndex(query, a);
+  if (subFilterFirstIndexA === -1) {
     return 1;
   }
-  const distanceB = distanceToQuery(b);
-  if (distanceB === 0) {
+
+  const subFilterFirstIndexB = subFilterFirstIndex(query, b);
+  if (subFilterFirstIndexB === -1) {
     return -1;
   }
 
+  const subFilterLastIndexA = subFilterLastIndex(query, a);
+  const subFilterLastIndexB = subFilterLastIndex(query, b);
+  const distanceA = subFilterLastIndexA - subFilterFirstIndexA;
+  const distanceB = subFilterLastIndexB - subFilterFirstIndexB;
   if (distanceA !== distanceB) {
     return distanceA - distanceB;
   }
-  const firstCharA = a.indexOf(query.charAt(0));
-  const firstCharB = b.indexOf(query.charAt(0));
-  if (firstCharA !== firstCharB) {
-    return firstCharA - firstCharB;
+
+  if (subFilterFirstIndexA !== subFilterFirstIndexB) {
+    return subFilterFirstIndexA - subFilterFirstIndexB;
   }
+
   if (a.length !== b.length) {
     return a.length - b.length;
   }

--- a/front/tests/lib/utils.test.ts
+++ b/front/tests/lib/utils.test.ts
@@ -1,0 +1,20 @@
+import { compareForFuzzySort } from "@app/lib/utils";
+
+test("compareForFuzzySort should correctly compare strings", () => {
+  const data = [
+    { query: "eng", a: "eng", b: "ContentMarketing" },
+    { query: "sql", a: "sqlGod", b: "sqlCoreGod" },
+    { query: "sql", a: "sql", b: "sqlGod" },
+    { query: "sql", a: "sql", b: "SEOQualityRater" },
+    { query: "gp", a: "gpt-4", b: "GabHelp" },
+    { query: "gp", a: "gpt-4", b: "gemni-pro" },
+    { query: "start", a: "robotstart", b: "strongrt" },
+    { query: "mygod", a: "ohmygodbot", b: "moatmode" },
+    { query: "test", a: "test", b: "testlong" },
+    { query: "test", a: "testlonger", b: "longtest" },
+  ];
+
+  for (const d of data) {
+    expect(compareForFuzzySort(d.query, d.a, d.b)).toBeLessThan(0);
+  }
+});


### PR DESCRIPTION
Improvement over the previous version, cf test cases

WIP: need to move the tests to a good place. I'm thinking
- utils.test.ts in the same directory
- npm run test in the build

#### Before
![Screenshot from 2024-03-07 22-33-55](https://github.com/dust-tt/dust/assets/5437393/4fe174f8-f64a-4197-b687-e42c918198b2)
#### After
![Screenshot from 2024-03-07 22-42-28](https://github.com/dust-tt/dust/assets/5437393/053a5690-cf45-4c5d-89bc-a595d12f7aaa)

## Risk & deploy plan
Assistant autocomplete in blast radius
=> Test on front edge
