### PR TITLE
Handle large Confluence workflows

### DIFF
--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -412,9 +412,12 @@ export async function confluenceGetTopLevelPageIdsActivity({
     pageCursor
   );
 
-  localLogger.info("Found Confluence top-level pages in space.", {
-    topLevelPagesCount: childPageIds.length,
-  });
+  localLogger.info(
+    {
+      topLevelPagesCount: childPageIds.length,
+    },
+    "Found Confluence top-level pages in space."
+  );
 
   return { topLevelPageIds: childPageIds, nextPageCursor };
 }
@@ -554,9 +557,12 @@ export async function confluenceRemoveSpaceActivity(
     },
   });
 
-  localLogger.info("Delete Confluence space", {
-    numberOfPages: allPages.length,
-  });
+  localLogger.info(
+    {
+      numberOfPages: allPages.length,
+    },
+    "Delete Confluence space"
+  );
 
   for (const page of allPages) {
     await deletePage(connectorId, page.pageId, dataSourceConfig);

--- a/connectors/src/connectors/confluence/temporal/workflows.ts
+++ b/connectors/src/connectors/confluence/temporal/workflows.ts
@@ -40,7 +40,10 @@ const {
   startToCloseTimeout: "20 minutes",
 });
 
-const MAX_HISTORY_LENGTH = 30_000;
+// Set a conservative threshold to start a new workflow and
+// avoid exceeding Temporal's max workflow size limit,
+// since a Confluence page can have an unbounded number of pages.
+const TEMPORAL_WORKFLOW_MAX_HISTORY_LENGTH = 30_000;
 
 export async function confluenceSyncWorkflow({
   connectorId,
@@ -283,7 +286,10 @@ export async function confluenceSyncTopLevelChildPagesWorkflow(
     } while (nextPageCursor !== null);
 
     // If additional pages are pending and workflow limits are reached, continue in a new workflow.
-    if (stack.length > 0 && workflowInfo().historyLength > MAX_HISTORY_LENGTH) {
+    if (
+      stack.length > 0 &&
+      workflowInfo().historyLength > TEMPORAL_WORKFLOW_MAX_HISTORY_LENGTH
+    ) {
       await continueAsNew<typeof confluenceSyncTopLevelChildPagesWorkflow>({
         ...params,
         topLevelPageIds: stack,


### PR DESCRIPTION
## Description

This PR addresses a problem where certain Confluence connectors exceed the maximum allowed size for Temporal workflows. Currently, the maximum workflow history size is approximately 50,000 events. To prevent reaching this limit and potentially causing issues, this PR introduces a mechanism to continue the workflow in a new instance once the history size reaches 30,000 events.
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
