### PR TITLE
Fix focus end on input bar

### DIFF
--- a/front/components/assistant/conversation/input_bar/editor/useCustomEditor.tsx
+++ b/front/components/assistant/conversation/input_bar/editor/useCustomEditor.tsx
@@ -158,7 +158,7 @@ const useCustomEditor = ({
 
   const editor = useEditor(
     {
-      autofocus: !disableAutoFocus,
+      autofocus: disableAutoFocus ? false : "end",
       enableInputRules: false, // Disable Markdown when typing.
       enablePasteRules: false, // Disable Markdown when pasting.
       extensions: [


### PR DESCRIPTION
## Description

This PR fixes a regression introduced in https://github.com/dust-tt/dust/pull/4144, where the focus is not placed at the end of the input bar.
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
