### PR TITLE
Augment session wrapper SSR

### DIFF
--- a/front/lib/iam/provider.ts
+++ b/front/lib/iam/provider.ts
@@ -33,7 +33,8 @@ function isAuth0Session(session: unknown): session is Session {
 
 // We only expose generic types to ease phasing out.
 
-export type SessionWithUser = Omit<Session, "user"> & { user: ExternalUser };
+// Overrides the Auth0 type definition entirely, to only expose what we need.
+export type SessionWithUser = { user: ExternalUser };
 
 export function isValidSession(
   session: Session | null

--- a/front/lib/iam/session.ts
+++ b/front/lib/iam/session.ts
@@ -83,6 +83,8 @@ export async function getUserFromSession(
   };
 }
 
+export type AuthLevel = "none" | "user" | "superuser";
+
 interface MakeGetServerSidePropsRequirementsWrapperOptions<
   R extends AuthLevel = "user"
 > {
@@ -101,8 +103,6 @@ export type CustomGetServerSideProps<
   session: RequireAuthLevel extends "none" ? null : SessionWithUser
 ) => Promise<GetServerSidePropsResult<Props>>;
 
-export type AuthLevel = "none" | "user" | "superuser";
-
 async function getAuthenticator(
   context: GetServerSidePropsContext<ParsedUrlQuery, PreviewData>,
   session: SessionWithUser | null,
@@ -113,13 +113,16 @@ async function getAuthenticator(
   }
 
   const { wId } = context.params ?? {};
+  const workspaceId = typeof wId === "string" ? wId : null;
 
   switch (requireAuthLevel) {
     case "user":
-      return Authenticator.fromSession(session, wId as string);
+      return workspaceId
+        ? Authenticator.fromSession(session, workspaceId)
+        : null;
 
     case "superuser":
-      return Authenticator.fromSuperUserSession(session, wId as string);
+      return Authenticator.fromSuperUserSession(session, workspaceId);
 
     default:
       return null;

--- a/front/lib/iam/session.ts
+++ b/front/lib/iam/session.ts
@@ -113,16 +113,13 @@ async function getAuthenticator(
   }
 
   const { wId } = context.params ?? {};
-  if (typeof wId !== "string") {
-    return null;
-  }
 
   switch (requireAuthLevel) {
     case "user":
-      return Authenticator.fromSession(session, wId);
+      return Authenticator.fromSession(session, wId as string);
 
     case "superuser":
-      return Authenticator.fromSuperUserSession(session, wId);
+      return Authenticator.fromSuperUserSession(session, wId as string);
 
     default:
       return null;
@@ -151,7 +148,6 @@ export function makeGetServerSidePropsRequirementsWrapper<
         requireAuthLevel !== "none" &&
         (!session || !isValidSession(session))
       ) {
-        // TODO: Check if the user has a workspace.
         return {
           redirect: {
             permanent: false,

--- a/front/lib/iam/session.ts
+++ b/front/lib/iam/session.ts
@@ -97,8 +97,8 @@ export type CustomGetServerSideProps<
   RequireAuthLevel extends AuthLevel = "user"
 > = (
   context: GetServerSidePropsContext<Params, Preview>,
-  session: RequireAuthLevel extends "none" ? null : SessionWithUser,
-  auth: RequireAuthLevel extends "none" ? null : Authenticator
+  auth: RequireAuthLevel extends "none" ? null : Authenticator,
+  session: RequireAuthLevel extends "none" ? null : SessionWithUser
 ) => Promise<GetServerSidePropsResult<Props>>;
 
 export type AuthLevel = "none" | "user" | "superuser";
@@ -164,25 +164,25 @@ export function makeGetServerSidePropsRequirementsWrapper<
       const userSession = session as RequireAuthLevel extends "none"
         ? null
         : SessionWithUser;
-      const currentAuth = auth as RequireAuthLevel extends "none"
+      const userAuth = auth as RequireAuthLevel extends "none"
         ? null
         : Authenticator;
 
       if (enableLogging) {
         return withGetServerSidePropsLogging(getServerSideProps)(
           context,
-          userSession,
-          currentAuth
+          userAuth,
+          userSession
         );
       }
 
-      return getServerSideProps(context, userSession, currentAuth);
+      return getServerSideProps(context, userAuth, userSession);
     };
   };
 }
 
-export const withDefaultGetServerSidePropsRequirements =
+export const withDefaultUserAuthRequirements =
   makeGetServerSidePropsRequirementsWrapper({ requireAuthLevel: "user" });
 
-export const withSuperUserGetServerSidePropsRequirements =
+export const withSuperUserAuthRequirements =
   makeGetServerSidePropsRequirementsWrapper({ requireAuthLevel: "superuser" });

--- a/front/logger/withlogging.ts
+++ b/front/logger/withlogging.ts
@@ -149,7 +149,7 @@ export function withGetServerSidePropsLogging<
 >(
   getServerSideProps: CustomGetServerSideProps<T, any, any, RequireAuthLevel>
 ): CustomGetServerSideProps<T, any, any, RequireAuthLevel> {
-  return async (context, session, auth) => {
+  return async (context, auth, session) => {
     const now = new Date();
 
     let route = context.resolvedUrl.split("?")[0];
@@ -161,7 +161,7 @@ export function withGetServerSidePropsLogging<
     }
 
     try {
-      const res = await getServerSideProps(context, session, auth);
+      const res = await getServerSideProps(context, auth, session);
 
       const elapsed = new Date().getTime() - now.getTime();
 

--- a/front/logger/withlogging.ts
+++ b/front/logger/withlogging.ts
@@ -6,7 +6,7 @@ import tracer from "dd-trace";
 import StatsD from "hot-shots";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import type { CustomGetServerSideProps } from "@app/lib/iam/session";
+import type { AuthLevel, CustomGetServerSideProps } from "@app/lib/iam/session";
 
 import logger from "./logger";
 
@@ -145,11 +145,11 @@ export function apiError<T>(
 
 export function withGetServerSidePropsLogging<
   T extends { [key: string]: any },
-  RequireAuth extends boolean = true
+  RequireAuthLevel extends AuthLevel = "user"
 >(
-  getServerSideProps: CustomGetServerSideProps<T, any, any, RequireAuth>
-): CustomGetServerSideProps<T, any, any, RequireAuth> {
-  return async (context, session) => {
+  getServerSideProps: CustomGetServerSideProps<T, any, any, RequireAuthLevel>
+): CustomGetServerSideProps<T, any, any, RequireAuthLevel> {
+  return async (context, session, auth) => {
     const now = new Date();
 
     let route = context.resolvedUrl.split("?")[0];
@@ -161,7 +161,7 @@ export function withGetServerSidePropsLogging<
     }
 
     try {
-      const res = await getServerSideProps(context, session);
+      const res = await getServerSideProps(context, session, auth);
 
       const elapsed = new Date().getTime() - now.getTime();
 

--- a/front/logger/withlogging.ts
+++ b/front/logger/withlogging.ts
@@ -6,7 +6,10 @@ import tracer from "dd-trace";
 import StatsD from "hot-shots";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import type { AuthLevel, CustomGetServerSideProps } from "@app/lib/iam/session";
+import type {
+  CustomGetServerSideProps,
+  UserPrivilege,
+} from "@app/lib/iam/session";
 
 import logger from "./logger";
 
@@ -145,10 +148,15 @@ export function apiError<T>(
 
 export function withGetServerSidePropsLogging<
   T extends { [key: string]: any },
-  RequireAuthLevel extends AuthLevel = "user"
+  RequireUserPrivilege extends UserPrivilege = "user"
 >(
-  getServerSideProps: CustomGetServerSideProps<T, any, any, RequireAuthLevel>
-): CustomGetServerSideProps<T, any, any, RequireAuthLevel> {
+  getServerSideProps: CustomGetServerSideProps<
+    T,
+    any,
+    any,
+    RequireUserPrivilege
+  >
+): CustomGetServerSideProps<T, any, any, RequireUserPrivilege> {
   return async (context, auth, session) => {
     const now = new Date();
 

--- a/front/pages/index.tsx
+++ b/front/pages/index.tsx
@@ -55,7 +55,7 @@ import { classNames } from "@app/lib/utils";
 const { GA_TRACKING_ID = "" } = process.env;
 
 export const getServerSideProps = makeGetServerSidePropsRequirementsWrapper({
-  requireAuth: false,
+  requireAuthLevel: "none",
 })<{
   gaTrackingId: string;
 }>(async (context) => {

--- a/front/pages/index.tsx
+++ b/front/pages/index.tsx
@@ -55,7 +55,7 @@ import { classNames } from "@app/lib/utils";
 const { GA_TRACKING_ID = "" } = process.env;
 
 export const getServerSideProps = makeGetServerSidePropsRequirementsWrapper({
-  requireAuthLevel: "none",
+  requireUserPrivilege: "none",
 })<{
   gaTrackingId: string;
 }>(async (context) => {

--- a/front/pages/login-error.tsx
+++ b/front/pages/login-error.tsx
@@ -7,7 +7,7 @@ import { makeGetServerSidePropsRequirementsWrapper } from "@app/lib/iam/session"
 const { GA_TRACKING_ID = "" } = process.env;
 
 export const getServerSideProps = makeGetServerSidePropsRequirementsWrapper({
-  requireAuth: false,
+  requireAuthLevel: "none",
 })<{
   domain: string | null;
   gaTrackingId: string;

--- a/front/pages/no-workspace.tsx
+++ b/front/pages/no-workspace.tsx
@@ -11,7 +11,7 @@ import { useRouter } from "next/router";
 
 import {
   getUserFromSession,
-  withDefaultGetServerSidePropsRequirements,
+  withDefaultUserAuthRequirements,
 } from "@app/lib/iam/session";
 import { Membership, Workspace, WorkspaceHasDomain } from "@app/lib/models";
 import logger from "@app/logger/logger";
@@ -56,12 +56,12 @@ async function fetchRevokedWorkspace(
   return Workspace.findByPk(revokedWorkspaceId);
 }
 
-export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
+export const getServerSideProps = withDefaultUserAuthRequirements<{
   status: "auto-join-disabled" | "revoked";
   userFirstName: string;
   workspaceName: string;
   workspaceVerifiedDomain: string | null;
-}>(async (context, session) => {
+}>(async (context, auth, session) => {
   const user = await getUserFromSession(session);
 
   if (!user) {

--- a/front/pages/poke/[wId]/assistants/[aId]/index.tsx
+++ b/front/pages/poke/[wId]/assistants/[aId]/index.tsx
@@ -9,17 +9,11 @@ import type { InferGetServerSidePropsType } from "next";
 
 import PokeNavbar from "@app/components/poke/PokeNavbar";
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
-import { Authenticator } from "@app/lib/auth";
-import { withDefaultGetServerSidePropsRequirements } from "@app/lib/iam/session";
+import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 
-export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
+export const getServerSideProps = withSuperUserAuthRequirements<{
   agentConfigurations: AgentConfigurationType[];
-}>(async (context, session) => {
-  const auth = await Authenticator.fromSuperUserSession(
-    session,
-    context.params?.wId as string
-  );
-
+}>(async (context, session, auth) => {
   if (!auth.isDustSuperUser()) {
     return {
       notFound: true,

--- a/front/pages/poke/[wId]/assistants/[aId]/index.tsx
+++ b/front/pages/poke/[wId]/assistants/[aId]/index.tsx
@@ -13,7 +13,7 @@ import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 
 export const getServerSideProps = withSuperUserAuthRequirements<{
   agentConfigurations: AgentConfigurationType[];
-}>(async (context, session, auth) => {
+}>(async (context, auth) => {
   if (!auth.isDustSuperUser()) {
     return {
       notFound: true,

--- a/front/pages/poke/[wId]/data_sources/[name]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[name]/index.tsx
@@ -22,17 +22,16 @@ import { useEffect, useState } from "react";
 import { PokePermissionTree } from "@app/components/poke/PokeConnectorPermissionsTree";
 import PokeNavbar from "@app/components/poke/PokeNavbar";
 import { getDataSource } from "@app/lib/api/data_sources";
-import { Authenticator } from "@app/lib/auth";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { getDisplayNameForDocument } from "@app/lib/data_sources";
-import { withDefaultGetServerSidePropsRequirements } from "@app/lib/iam/session";
+import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import { useDocuments } from "@app/lib/swr";
 import { formatTimestampToFriendlyDate, timeAgoFrom } from "@app/lib/utils";
 import logger from "@app/logger/logger";
 
 const { TEMPORAL_CONNECTORS_NAMESPACE = "" } = process.env;
 
-export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
+export const getServerSideProps = withSuperUserAuthRequirements<{
   owner: WorkspaceType;
   dataSource: DataSourceType;
   coreDataSource: CoreAPIDataSource;
@@ -43,12 +42,7 @@ export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
     githubCodeSyncEnabled: boolean;
   };
   temporalWorkspace: string;
-}>(async (context, session) => {
-  const auth = await Authenticator.fromSuperUserSession(
-    session,
-    context.params?.wId as string
-  );
-
+}>(async (context, session, auth) => {
   const owner = auth.workspace();
 
   if (!owner || !auth.isDustSuperUser()) {

--- a/front/pages/poke/[wId]/data_sources/[name]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[name]/index.tsx
@@ -42,7 +42,7 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
     githubCodeSyncEnabled: boolean;
   };
   temporalWorkspace: string;
-}>(async (context, session, auth) => {
+}>(async (context, auth) => {
   const owner = auth.workspace();
 
   if (!owner || !auth.isDustSuperUser()) {

--- a/front/pages/poke/[wId]/data_sources/[name]/search.tsx
+++ b/front/pages/poke/[wId]/data_sources/[name]/search.tsx
@@ -8,20 +8,14 @@ import { useEffect, useState } from "react";
 
 import PokeNavbar from "@app/components/poke/PokeNavbar";
 import { getDataSource } from "@app/lib/api/data_sources";
-import { Authenticator } from "@app/lib/auth";
 import { getDisplayNameForDocument } from "@app/lib/data_sources";
-import { withDefaultGetServerSidePropsRequirements } from "@app/lib/iam/session";
+import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import { classNames, timeAgoFrom } from "@app/lib/utils";
 
-export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
+export const getServerSideProps = withSuperUserAuthRequirements<{
   owner: WorkspaceType;
   dataSource: DataSourceType;
-}>(async (context, session) => {
-  const auth = await Authenticator.fromSuperUserSession(
-    session,
-    context.params?.wId as string
-  );
-
+}>(async (context, session, auth) => {
   const owner = auth.workspace();
 
   if (!owner || !auth.isAdmin()) {

--- a/front/pages/poke/[wId]/data_sources/[name]/search.tsx
+++ b/front/pages/poke/[wId]/data_sources/[name]/search.tsx
@@ -15,7 +15,7 @@ import { classNames, timeAgoFrom } from "@app/lib/utils";
 export const getServerSideProps = withSuperUserAuthRequirements<{
   owner: WorkspaceType;
   dataSource: DataSourceType;
-}>(async (context, session, auth) => {
+}>(async (context, auth) => {
   const owner = auth.workspace();
 
   if (!owner || !auth.isAdmin()) {

--- a/front/pages/poke/[wId]/data_sources/[name]/view.tsx
+++ b/front/pages/poke/[wId]/data_sources/[name]/view.tsx
@@ -12,7 +12,7 @@ import logger from "@app/logger/logger";
 
 export const getServerSideProps = withSuperUserAuthRequirements<{
   document: CoreAPIDocument;
-}>(async (context, session, auth) => {
+}>(async (context, auth) => {
   if (!auth.isDustSuperUser()) {
     return {
       notFound: true,

--- a/front/pages/poke/[wId]/data_sources/[name]/view.tsx
+++ b/front/pages/poke/[wId]/data_sources/[name]/view.tsx
@@ -5,7 +5,6 @@ import type { InferGetServerSidePropsType } from "next";
 
 import PokeNavbar from "@app/components/poke/PokeNavbar";
 import { getDataSource } from "@app/lib/api/data_sources";
-import { Authenticator } from "@app/lib/auth";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import { classNames } from "@app/lib/utils";
 import logger from "@app/logger/logger";

--- a/front/pages/poke/[wId]/data_sources/[name]/view.tsx
+++ b/front/pages/poke/[wId]/data_sources/[name]/view.tsx
@@ -6,18 +6,13 @@ import type { InferGetServerSidePropsType } from "next";
 import PokeNavbar from "@app/components/poke/PokeNavbar";
 import { getDataSource } from "@app/lib/api/data_sources";
 import { Authenticator } from "@app/lib/auth";
-import { withDefaultGetServerSidePropsRequirements } from "@app/lib/iam/session";
+import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import { classNames } from "@app/lib/utils";
 import logger from "@app/logger/logger";
 
-export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
+export const getServerSideProps = withSuperUserAuthRequirements<{
   document: CoreAPIDocument;
-}>(async (context, session) => {
-  const auth = await Authenticator.fromSuperUserSession(
-    session,
-    context.params?.wId as string
-  );
-
+}>(async (context, session, auth) => {
   if (!auth.isDustSuperUser()) {
     return {
       notFound: true,

--- a/front/pages/poke/[wId]/index.tsx
+++ b/front/pages/poke/[wId]/index.tsx
@@ -35,10 +35,9 @@ import {
   GLOBAL_AGENTS_SID,
   orderDatasourceByImportance,
 } from "@app/lib/assistant";
-import { Authenticator } from "@app/lib/auth";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { isDevelopment } from "@app/lib/development";
-import { withDefaultGetServerSidePropsRequirements } from "@app/lib/iam/session";
+import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import {
   FREE_TEST_PLAN_CODE,
   FREE_UPGRADED_PLAN_CODE,
@@ -47,7 +46,7 @@ import {
 import { getPlanInvitation } from "@app/lib/plans/subscription";
 import { usePokePlans } from "@app/lib/swr";
 
-export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
+export const getServerSideProps = withSuperUserAuthRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   planInvitation: PlanInvitationType | null;
@@ -55,12 +54,7 @@ export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
   agentConfigurations: AgentConfigurationType[];
   whitelistableFeatures: WhitelistableFeature[];
   registry: typeof DustProdActionRegistry;
-}>(async (context, session) => {
-  const auth = await Authenticator.fromSuperUserSession(
-    session,
-    context.params?.wId as string
-  );
-
+}>(async (context, session, auth) => {
   const owner = auth.workspace();
   const subscription = auth.subscription();
 

--- a/front/pages/poke/[wId]/index.tsx
+++ b/front/pages/poke/[wId]/index.tsx
@@ -54,7 +54,7 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
   agentConfigurations: AgentConfigurationType[];
   whitelistableFeatures: WhitelistableFeature[];
   registry: typeof DustProdActionRegistry;
-}>(async (context, session, auth) => {
+}>(async (context, auth) => {
   const owner = auth.workspace();
   const subscription = auth.subscription();
 

--- a/front/pages/poke/[wId]/memberships.tsx
+++ b/front/pages/poke/[wId]/memberships.tsx
@@ -15,7 +15,7 @@ import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 export const getServerSideProps = withSuperUserAuthRequirements<{
   owner: WorkspaceType;
   members: UserTypeWithWorkspaces[];
-}>(async (context, session, auth) => {
+}>(async (context, auth) => {
   const owner = auth.workspace();
 
   if (!owner || !auth.isDustSuperUser()) {

--- a/front/pages/poke/[wId]/memberships.tsx
+++ b/front/pages/poke/[wId]/memberships.tsx
@@ -10,18 +10,12 @@ import React from "react";
 
 import PokeNavbar from "@app/components/poke/PokeNavbar";
 import { getMembers } from "@app/lib/api/workspace";
-import { Authenticator } from "@app/lib/auth";
-import { withDefaultGetServerSidePropsRequirements } from "@app/lib/iam/session";
+import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 
-export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
+export const getServerSideProps = withSuperUserAuthRequirements<{
   owner: WorkspaceType;
   members: UserTypeWithWorkspaces[];
-}>(async (context, session) => {
-  const auth = await Authenticator.fromSuperUserSession(
-    session,
-    context.params?.wId as string
-  );
-
+}>(async (context, session, auth) => {
   const owner = auth.workspace();
 
   if (!owner || !auth.isDustSuperUser()) {

--- a/front/pages/poke/connectors/[connectorId]/index.tsx
+++ b/front/pages/poke/connectors/[connectorId]/index.tsx
@@ -5,7 +5,7 @@ import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import logger from "@app/logger/logger";
 
 export const getServerSideProps = withSuperUserAuthRequirements<object>(
-  async (context, session, auth) => {
+  async (context, auth) => {
     if (!auth.isDustSuperUser()) {
       return {
         notFound: true,

--- a/front/pages/poke/connectors/[connectorId]/index.tsx
+++ b/front/pages/poke/connectors/[connectorId]/index.tsx
@@ -1,47 +1,43 @@
 import type { ConnectorType } from "@dust-tt/types";
 import { ConnectorsAPI } from "@dust-tt/types";
 
-import { Authenticator } from "@app/lib/auth";
-import { withDefaultGetServerSidePropsRequirements } from "@app/lib/iam/session";
+import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import logger from "@app/logger/logger";
 
-export const getServerSideProps =
-  withDefaultGetServerSidePropsRequirements<object>(
-    async (context, session) => {
-      const auth = await Authenticator.fromSuperUserSession(session, null);
-
-      if (!auth.isDustSuperUser()) {
-        return {
-          notFound: true,
-        };
-      }
-
-      const connectorId = context.params?.connectorId;
-
-      if (!connectorId || typeof connectorId !== "string") {
-        return {
-          notFound: true,
-        };
-      }
-
-      const connectorsAPI = new ConnectorsAPI(logger);
-      const cRes = await connectorsAPI.getConnector(connectorId);
-      if (cRes.isErr()) {
-        return {
-          notFound: true,
-        };
-      }
-
-      const connector: ConnectorType = cRes.value;
-
+export const getServerSideProps = withSuperUserAuthRequirements<object>(
+  async (context, session, auth) => {
+    if (!auth.isDustSuperUser()) {
       return {
-        redirect: {
-          destination: `/poke/${connector.workspaceId}/data_sources/${connector.dataSourceName}`,
-          permanent: false,
-        },
+        notFound: true,
       };
     }
-  );
+
+    const connectorId = context.params?.connectorId;
+
+    if (!connectorId || typeof connectorId !== "string") {
+      return {
+        notFound: true,
+      };
+    }
+
+    const connectorsAPI = new ConnectorsAPI(logger);
+    const cRes = await connectorsAPI.getConnector(connectorId);
+    if (cRes.isErr()) {
+      return {
+        notFound: true,
+      };
+    }
+
+    const connector: ConnectorType = cRes.value;
+
+    return {
+      redirect: {
+        destination: `/poke/${connector.workspaceId}/data_sources/${connector.dataSourceName}`,
+        permanent: false,
+      },
+    };
+  }
+);
 
 export default function Redirect() {
   return <></>;

--- a/front/pages/poke/index.tsx
+++ b/front/pages/poke/index.tsx
@@ -8,7 +8,7 @@ import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import { usePokeWorkspaces } from "@app/lib/swr";
 
 export const getServerSideProps = withSuperUserAuthRequirements<object>(
-  async (context, session, auth) => {
+  async (context, auth) => {
     if (!auth.isDustSuperUser()) {
       return {
         notFound: true,

--- a/front/pages/poke/index.tsx
+++ b/front/pages/poke/index.tsx
@@ -4,26 +4,22 @@ import type { ChangeEvent } from "react";
 import React, { useState } from "react";
 
 import PokeNavbar from "@app/components/poke/PokeNavbar";
-import { Authenticator } from "@app/lib/auth";
-import { withDefaultGetServerSidePropsRequirements } from "@app/lib/iam/session";
+import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import { usePokeWorkspaces } from "@app/lib/swr";
 
-export const getServerSideProps =
-  withDefaultGetServerSidePropsRequirements<object>(
-    async (context, session) => {
-      const auth = await Authenticator.fromSuperUserSession(session, null);
-
-      if (!auth.isDustSuperUser()) {
-        return {
-          notFound: true,
-        };
-      }
-
+export const getServerSideProps = withSuperUserAuthRequirements<object>(
+  async (context, session, auth) => {
+    if (!auth.isDustSuperUser()) {
       return {
-        props: {},
+        notFound: true,
       };
     }
-  );
+
+    return {
+      props: {},
+    };
+  }
+);
 
 const Dashboard = (
   _props: InferGetServerSidePropsType<typeof getServerSideProps>

--- a/front/pages/poke/plans.tsx
+++ b/front/pages/poke/plans.tsx
@@ -26,7 +26,7 @@ import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import { usePokePlans } from "@app/lib/swr";
 
 export const getServerSideProps = withSuperUserAuthRequirements<object>(
-  async (context, session, auth) => {
+  async (context, auth) => {
     if (!auth.isDustSuperUser()) {
       return {
         notFound: true,

--- a/front/pages/poke/plans.tsx
+++ b/front/pages/poke/plans.tsx
@@ -22,26 +22,22 @@ import {
 } from "@app/components/poke/plans/form";
 import PokeNavbar from "@app/components/poke/PokeNavbar";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
-import { Authenticator } from "@app/lib/auth";
-import { withDefaultGetServerSidePropsRequirements } from "@app/lib/iam/session";
+import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import { usePokePlans } from "@app/lib/swr";
 
-export const getServerSideProps =
-  withDefaultGetServerSidePropsRequirements<object>(
-    async (context, session) => {
-      const auth = await Authenticator.fromSuperUserSession(session, null);
-
-      if (!auth.isDustSuperUser()) {
-        return {
-          notFound: true,
-        };
-      }
-
+export const getServerSideProps = withSuperUserAuthRequirements<object>(
+  async (context, session, auth) => {
+    if (!auth.isDustSuperUser()) {
       return {
-        props: {},
+        notFound: true,
       };
     }
-  );
+
+    return {
+      props: {},
+    };
+  }
+);
 
 const PlansPage = (
   _props: InferGetServerSidePropsType<typeof getServerSideProps>

--- a/front/pages/w/[wId]/a/[aId]/clone.tsx
+++ b/front/pages/w/[wId]/a/[aId]/clone.tsx
@@ -21,20 +21,19 @@ import {
 } from "@app/components/sparkle/navigation";
 import WorkspacePicker from "@app/components/WorkspacePicker";
 import { getApp } from "@app/lib/api/app";
-import { Authenticator } from "@app/lib/auth";
 import { getUserFromSession } from "@app/lib/iam/session";
-import { withDefaultGetServerSidePropsRequirements } from "@app/lib/iam/session";
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { classNames } from "@app/lib/utils";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
+export const getServerSideProps = withDefaultUserAuthRequirements<{
   user: UserTypeWithWorkspaces;
   owner: WorkspaceType;
   subscription: SubscriptionType;
   app: AppType;
   gaTrackingId: string;
-}>(async (context, session) => {
+}>(async (context, auth, session) => {
   // This is a rare case where we need the full user object as we need to know the user available
   // workspaces to clone the app into.
   const user = await getUserFromSession(session);
@@ -43,11 +42,6 @@ export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
       notFound: true,
     };
   }
-
-  const auth = await Authenticator.fromSession(
-    session,
-    context.params?.wId as string
-  );
 
   const owner = auth.workspace();
   const subscription = auth.subscription();

--- a/front/pages/w/[wId]/a/[aId]/datasets/[name]/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/datasets/[name]/index.tsx
@@ -18,13 +18,12 @@ import {
 } from "@app/components/sparkle/navigation";
 import { getApp } from "@app/lib/api/app";
 import { getDatasetHash, getDatasetSchema } from "@app/lib/api/datasets";
-import { Authenticator } from "@app/lib/auth";
 import { useRegisterUnloadHandlers } from "@app/lib/front";
-import { withDefaultGetServerSidePropsRequirements } from "@app/lib/iam/session";
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
+export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   readOnly: boolean;
@@ -32,12 +31,7 @@ export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
   dataset: DatasetType;
   schema: DatasetSchema | null;
   gaTrackingId: string;
-}>(async (context, session) => {
-  const auth = await Authenticator.fromSession(
-    session,
-    context.params?.wId as string
-  );
-
+}>(async (context, auth) => {
   const owner = auth.workspace();
   const subscription = auth.subscription();
 

--- a/front/pages/w/[wId]/a/[aId]/datasets/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/datasets/index.tsx
@@ -15,25 +15,19 @@ import {
 } from "@app/components/sparkle/navigation";
 import { getApp } from "@app/lib/api/app";
 import { getDatasets } from "@app/lib/api/datasets";
-import { Authenticator } from "@app/lib/auth";
-import { withDefaultGetServerSidePropsRequirements } from "@app/lib/iam/session";
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { classNames } from "@app/lib/utils";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
+export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   readOnly: boolean;
   app: AppType;
   datasets: DatasetType[];
   gaTrackingId: string;
-}>(async (context, session) => {
-  const auth = await Authenticator.fromSession(
-    session,
-    context.params?.wId as string
-  );
-
+}>(async (context, auth) => {
   const owner = auth.workspace();
   const subscription = auth.subscription();
 

--- a/front/pages/w/[wId]/a/[aId]/datasets/new.tsx
+++ b/front/pages/w/[wId]/a/[aId]/datasets/new.tsx
@@ -18,24 +18,18 @@ import {
 } from "@app/components/sparkle/navigation";
 import { getApp } from "@app/lib/api/app";
 import { getDatasets } from "@app/lib/api/datasets";
-import { Authenticator } from "@app/lib/auth";
 import { useRegisterUnloadHandlers } from "@app/lib/front";
-import { withDefaultGetServerSidePropsRequirements } from "@app/lib/iam/session";
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
+export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   app: AppType;
   datasets: DatasetType[];
   gaTrackingId: string;
-}>(async (context, session) => {
-  const auth = await Authenticator.fromSession(
-    session,
-    context.params?.wId as string
-  );
-
+}>(async (context, auth) => {
   const owner = auth.workspace();
   const subscription = auth.subscription();
 

--- a/front/pages/w/[wId]/a/[aId]/execute/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/execute/index.tsx
@@ -33,14 +33,13 @@ import {
 import { Spinner } from "@app/components/Spinner";
 import { getApp } from "@app/lib/api/app";
 import { getDatasetHash } from "@app/lib/api/datasets";
-import { Authenticator } from "@app/lib/auth";
 import { extractConfig } from "@app/lib/config";
 import {
   checkDatasetData,
   getDatasetTypes,
   getValueType,
 } from "@app/lib/datasets";
-import { withDefaultGetServerSidePropsRequirements } from "@app/lib/iam/session";
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { useSavedRunStatus } from "@app/lib/swr";
 import { classNames } from "@app/lib/utils";
 
@@ -57,7 +56,7 @@ type Event = {
   };
 };
 
-export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
+export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   app: AppType;
@@ -65,12 +64,7 @@ export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
   inputDataset: DatasetType | null;
   readOnly: boolean;
   gaTrackingId: string;
-}>(async (context, session) => {
-  const auth = await Authenticator.fromSession(
-    session,
-    context.params?.wId as string
-  );
-
+}>(async (context, auth) => {
   const owner = auth.workspace();
   const subscription = auth.subscription();
 

--- a/front/pages/w/[wId]/a/[aId]/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/index.tsx
@@ -33,9 +33,8 @@ import {
   subNavigationBuild,
 } from "@app/components/sparkle/navigation";
 import { getApp } from "@app/lib/api/app";
-import { Authenticator } from "@app/lib/auth";
 import { extractConfig } from "@app/lib/config";
-import { withDefaultGetServerSidePropsRequirements } from "@app/lib/iam/session";
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import {
   addBlock,
   deleteBlock,
@@ -46,7 +45,7 @@ import { useSavedRunStatus } from "@app/lib/swr";
 
 const { URL = "", GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
+export const getServerSideProps = withDefaultUserAuthRequirements<{
   user: UserType | null;
   owner: WorkspaceType;
   subscription: SubscriptionType;
@@ -54,12 +53,7 @@ export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
   url: string;
   app: AppType;
   gaTrackingId: string;
-}>(async (context, session) => {
-  const auth = await Authenticator.fromSession(
-    session,
-    context.params?.wId as string
-  );
-
+}>(async (context, auth) => {
   const owner = auth.workspace();
   const subscription = auth.subscription();
 

--- a/front/pages/w/[wId]/a/[aId]/runs/[runId]/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/runs/[runId]/index.tsx
@@ -16,12 +16,11 @@ import {
 } from "@app/components/sparkle/navigation";
 import { getApp } from "@app/lib/api/app";
 import { getRun } from "@app/lib/api/run";
-import { Authenticator, getSession } from "@app/lib/auth";
-import { withDefaultGetServerSidePropsRequirements } from "@app/lib/iam/session";
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
+export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   readOnly: boolean;
@@ -29,13 +28,7 @@ export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
   run: RunType;
   spec: SpecificationType;
   gaTrackingId: string;
-}>(async (context) => {
-  const session = await getSession(context.req, context.res);
-  const auth = await Authenticator.fromSession(
-    session,
-    context.params?.wId as string
-  );
-
+}>(async (context, auth) => {
   const owner = auth.workspace();
   const subscription = auth.subscription();
 

--- a/front/pages/w/[wId]/a/[aId]/runs/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/runs/index.tsx
@@ -15,26 +15,20 @@ import {
   subNavigationBuild,
 } from "@app/components/sparkle/navigation";
 import { getApp } from "@app/lib/api/app";
-import { Authenticator } from "@app/lib/auth";
-import { withDefaultGetServerSidePropsRequirements } from "@app/lib/iam/session";
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { useRuns } from "@app/lib/swr";
 import { classNames, timeAgoFrom } from "@app/lib/utils";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
+export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   readOnly: boolean;
   app: AppType;
   wIdTarget: string | null;
   gaTrackingId: string;
-}>(async (context, session) => {
-  const auth = await Authenticator.fromSession(
-    session,
-    context.params?.wId as string
-  );
-
+}>(async (context, auth) => {
   const owner = auth.workspace();
   const subscription = auth.subscription();
 

--- a/front/pages/w/[wId]/a/[aId]/settings.tsx
+++ b/front/pages/w/[wId]/a/[aId]/settings.tsx
@@ -16,23 +16,17 @@ import {
   subNavigationBuild,
 } from "@app/components/sparkle/navigation";
 import { getApp } from "@app/lib/api/app";
-import { Authenticator } from "@app/lib/auth";
-import { withDefaultGetServerSidePropsRequirements } from "@app/lib/iam/session";
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { classNames, MODELS_STRING_MAX_LENGTH } from "@app/lib/utils";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
+export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   app: AppType;
   gaTrackingId: string;
-}>(async (context, session) => {
-  const auth = await Authenticator.fromSession(
-    session,
-    context.params?.wId as string
-  );
-
+}>(async (context, auth) => {
   const owner = auth.workspace();
   const subscription = auth.subscription();
   if (!owner || !subscription) {

--- a/front/pages/w/[wId]/a/[aId]/specification.tsx
+++ b/front/pages/w/[wId]/a/[aId]/specification.tsx
@@ -11,26 +11,20 @@ import {
   subNavigationBuild,
 } from "@app/components/sparkle/navigation";
 import { getApp } from "@app/lib/api/app";
-import { Authenticator } from "@app/lib/auth";
-import { withDefaultGetServerSidePropsRequirements } from "@app/lib/iam/session";
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { dumpSpecification } from "@app/lib/specification";
 import logger from "@app/logger/logger";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
+export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   readOnly: boolean;
   app: AppType;
   specification: string;
   gaTrackingId: string;
-}>(async (context, session) => {
-  const auth = await Authenticator.fromSession(
-    session,
-    context.params?.wId as string
-  );
-
+}>(async (context, auth) => {
   const owner = auth.workspace();
   const subscription = auth.subscription();
 

--- a/front/pages/w/[wId]/a/index.tsx
+++ b/front/pages/w/[wId]/a/index.tsx
@@ -24,26 +24,20 @@ import SerperSetup from "@app/components/providers/SerperSetup";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { subNavigationBuild } from "@app/components/sparkle/navigation";
 import { getApps } from "@app/lib/api/app";
-import { Authenticator } from "@app/lib/auth";
 import { useSubmitFunction } from "@app/lib/client/utils";
-import { withDefaultGetServerSidePropsRequirements } from "@app/lib/iam/session";
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { modelProviders, serviceProviders } from "@app/lib/providers";
 import { useKeys, useProviders } from "@app/lib/swr";
 import { classNames, timeAgoFrom } from "@app/lib/utils";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
+export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   apps: AppType[];
   gaTrackingId: string;
-}>(async (context, session) => {
-  const auth = await Authenticator.fromSession(
-    session,
-    context.params?.wId as string
-  );
-
+}>(async (context, auth) => {
   const owner = auth.workspace();
   const subscription = auth.subscription();
 

--- a/front/pages/w/[wId]/a/new.tsx
+++ b/front/pages/w/[wId]/a/new.tsx
@@ -10,22 +10,16 @@ import React, { useCallback, useEffect, useState } from "react";
 
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { subNavigationBuild } from "@app/components/sparkle/navigation";
-import { Authenticator } from "@app/lib/auth";
-import { withDefaultGetServerSidePropsRequirements } from "@app/lib/iam/session";
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { classNames, MODELS_STRING_MAX_LENGTH } from "@app/lib/utils";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
+export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   gaTrackingId: string;
-}>(async (context, session) => {
-  const auth = await Authenticator.fromSession(
-    session,
-    context.params?.wId as string
-  );
-
+}>(async (context, auth) => {
   const owner = auth.workspace();
   const subscription = auth.subscription();
 

--- a/front/pages/w/[wId]/assistant/[cId]/index.tsx
+++ b/front/pages/w/[wId]/assistant/[cId]/index.tsx
@@ -17,26 +17,20 @@ import {
 import { AssistantSidebarMenu } from "@app/components/assistant/conversation/SidebarMenu";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
-import { Authenticator } from "@app/lib/auth";
-import { withDefaultGetServerSidePropsRequirements } from "@app/lib/iam/session";
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { useConversation } from "@app/lib/swr";
 import { LimitReachedPopup } from "@app/pages/w/[wId]/assistant/new";
 
 const { URL = "", GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
+export const getServerSideProps = withDefaultUserAuthRequirements<{
   user: UserType;
   owner: WorkspaceType;
   subscription: SubscriptionType;
   gaTrackingId: string;
   baseUrl: string;
   conversationId: string;
-}>(async (context, session) => {
-  const auth = await Authenticator.fromSession(
-    session,
-    context.params?.wId as string
-  );
-
+}>(async (context, auth) => {
   const owner = auth.workspace();
   const user = auth.user();
   const subscription = auth.subscription();

--- a/front/pages/w/[wId]/assistant/assistants.tsx
+++ b/front/pages/w/[wId]/assistant/assistants.tsx
@@ -22,23 +22,17 @@ import { AssistantSidebarMenu } from "@app/components/assistant/conversation/Sid
 import { SCOPE_INFO } from "@app/components/assistant/Sharing";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
-import { Authenticator } from "@app/lib/auth";
-import { withDefaultGetServerSidePropsRequirements } from "@app/lib/iam/session";
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { useAgentConfigurations } from "@app/lib/swr";
 import { subFilter } from "@app/lib/utils";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
+export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   gaTrackingId: string;
-}>(async (context, session) => {
-  const auth = await Authenticator.fromSession(
-    session,
-    context.params?.wId as string
-  );
-
+}>(async (context, auth) => {
   const owner = auth.workspace();
   const subscription = auth.subscription();
   if (!owner || !auth.isUser() || !subscription) {

--- a/front/pages/w/[wId]/assistant/gallery.tsx
+++ b/front/pages/w/[wId]/assistant/gallery.tsx
@@ -27,25 +27,19 @@ import { GalleryAssistantPreviewContainer } from "@app/components/assistant/Gall
 import { TryAssistantModal } from "@app/components/assistant/TryAssistant";
 import AppLayout, { appLayoutBack } from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
-import { Authenticator } from "@app/lib/auth";
-import { withDefaultGetServerSidePropsRequirements } from "@app/lib/iam/session";
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { useAgentConfigurations } from "@app/lib/swr";
 import { subFilter } from "@app/lib/utils";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
+export const getServerSideProps = withDefaultUserAuthRequirements<{
   user: UserType;
   owner: WorkspaceType;
   plan: PlanType | null;
   subscription: SubscriptionType;
   gaTrackingId: string;
-}>(async (context, session) => {
-  const auth = await Authenticator.fromSession(
-    session,
-    context.params?.wId as string
-  );
-
+}>(async (context, auth) => {
   const owner = auth.workspace();
   const user = auth.user();
   const plan = auth.plan();

--- a/front/pages/w/[wId]/assistant/new.tsx
+++ b/front/pages/w/[wId]/assistant/new.tsx
@@ -38,28 +38,22 @@ import AppLayout from "@app/components/sparkle/AppLayout";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
 import { compareAgentsForSort } from "@app/lib/assistant";
-import { Authenticator } from "@app/lib/auth";
 import { getRandomGreetingForName } from "@app/lib/client/greetings";
 import { useSubmitFunction } from "@app/lib/client/utils";
-import { withDefaultGetServerSidePropsRequirements } from "@app/lib/iam/session";
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { useAgentConfigurations, useUserMetadata } from "@app/lib/swr";
 import { setUserMetadataFromClient } from "@app/lib/user";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
+export const getServerSideProps = withDefaultUserAuthRequirements<{
   user: UserType;
   isBuilder: boolean;
   subscription: SubscriptionType;
   owner: WorkspaceType;
   helper: LightAgentConfigurationType | null;
   gaTrackingId: string;
-}>(async (context, session) => {
-  const auth = await Authenticator.fromSession(
-    session,
-    context.params?.wId as string
-  );
-
+}>(async (context, auth) => {
   const owner = auth.workspace();
   const user = auth.user();
   const subscription = auth.subscription();

--- a/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
@@ -25,12 +25,11 @@ import type {
 import { getApps } from "@app/lib/api/app";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
 import { getDataSources } from "@app/lib/api/data_sources";
-import { Authenticator } from "@app/lib/auth";
-import { withDefaultGetServerSidePropsRequirements } from "@app/lib/iam/session";
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 
 const { GA_TRACKING_ID = "", URL = "" } = process.env;
 
-export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
+export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   plan: PlanType;
@@ -46,12 +45,7 @@ export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
   agentConfiguration: AgentConfigurationType;
   flow: BuilderFlow;
   baseUrl: string;
-}>(async (context, session) => {
-  const auth = await Authenticator.fromSession(
-    session,
-    context.params?.wId as string
-  );
-
+}>(async (context, auth) => {
   const owner = auth.workspace();
   const plan = auth.plan();
   const subscription = auth.subscription();

--- a/front/pages/w/[wId]/builder/assistants/dust.tsx
+++ b/front/pages/w/[wId]/builder/assistants/dust.tsx
@@ -22,24 +22,18 @@ import AppLayout from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { subNavigationBuild } from "@app/components/sparkle/navigation";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
-import { Authenticator } from "@app/lib/auth";
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 import { getDisplayNameForDataSource } from "@app/lib/data_sources";
-import { withDefaultGetServerSidePropsRequirements } from "@app/lib/iam/session";
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { useAgentConfigurations, useDataSources } from "@app/lib/swr";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
+export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   gaTrackingId: string;
-}>(async (context, session) => {
-  const auth = await Authenticator.fromSession(
-    session,
-    context.params?.wId as string
-  );
-
+}>(async (context, auth) => {
   const owner = auth.workspace();
   const subscription = auth.subscription();
 

--- a/front/pages/w/[wId]/builder/assistants/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/index.tsx
@@ -31,24 +31,18 @@ import { EmptyCallToAction } from "@app/components/EmptyCallToAction";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { subNavigationBuild } from "@app/components/sparkle/navigation";
 import { compareAgentsForSort } from "@app/lib/assistant";
-import { Authenticator } from "@app/lib/auth";
-import { withDefaultGetServerSidePropsRequirements } from "@app/lib/iam/session";
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { useAgentConfigurations } from "@app/lib/swr";
 import { classNames, subFilter } from "@app/lib/utils";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
+export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   tabScope: AgentConfigurationScope;
   gaTrackingId: string;
-}>(async (context, session) => {
-  const auth = await Authenticator.fromSession(
-    session,
-    context.params?.wId as string
-  );
-
+}>(async (context, auth) => {
   const owner = auth.workspace();
   const subscription = auth.subscription();
 

--- a/front/pages/w/[wId]/builder/assistants/new.tsx
+++ b/front/pages/w/[wId]/builder/assistants/new.tsx
@@ -25,12 +25,11 @@ import type {
 import { getApps } from "@app/lib/api/app";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
 import { getDataSources } from "@app/lib/api/data_sources";
-import { Authenticator } from "@app/lib/auth";
-import { withDefaultGetServerSidePropsRequirements } from "@app/lib/iam/session";
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 
 const { GA_TRACKING_ID = "", URL = "" } = process.env;
 
-export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
+export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   plan: PlanType;
@@ -46,12 +45,7 @@ export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
   agentConfiguration: AgentConfigurationType | null;
   flow: BuilderFlow;
   baseUrl: string;
-}>(async (context, session) => {
-  const auth = await Authenticator.fromSession(
-    session,
-    context.params?.wId as string
-  );
-
+}>(async (context, auth) => {
   const owner = auth.workspace();
   const plan = auth.plan();
   const subscription = auth.subscription();

--- a/front/pages/w/[wId]/builder/data-sources/[name]/edit-public-url.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/edit-public-url.tsx
@@ -9,25 +9,19 @@ import type { InferGetServerSidePropsType } from "next";
 
 import WebsiteConfiguration from "@app/components/data_source/WebsiteConfiguration";
 import { getDataSource, getDataSources } from "@app/lib/api/data_sources";
-import { Authenticator } from "@app/lib/auth";
-import { withDefaultGetServerSidePropsRequirements } from "@app/lib/iam/session";
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import logger from "@app/logger/logger";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
+export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   dataSources: DataSourceType[];
   dataSource: DataSourceType;
   webCrawlerConfiguration: WebCrawlerConfigurationType;
   gaTrackingId: string;
-}>(async (context, session) => {
-  const auth = await Authenticator.fromSession(
-    session,
-    context.params?.wId as string
-  );
-
+}>(async (context, auth) => {
   const owner = auth.workspace();
   const subscription = auth.subscription();
 

--- a/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
@@ -41,13 +41,12 @@ import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitl
 import { subNavigationBuild } from "@app/components/sparkle/navigation";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { getDataSource } from "@app/lib/api/data_sources";
-import { Authenticator, getSession } from "@app/lib/auth";
 import { tableKey } from "@app/lib/client/tables_query";
 import { buildConnectionId } from "@app/lib/connector_connection_id";
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 import { getDisplayNameForDocument } from "@app/lib/data_sources";
 import { githubAuth } from "@app/lib/github_auth";
-import { withDefaultGetServerSidePropsRequirements } from "@app/lib/iam/session";
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { useConnectorConfig, useDocuments, useTables } from "@app/lib/swr";
 import { timeAgoFrom } from "@app/lib/utils";
 import logger from "@app/logger/logger";
@@ -63,7 +62,7 @@ const {
   NANGO_SLACK_CONNECTOR_ID = "",
 } = process.env;
 
-export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
+export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   plan: PlanType;
@@ -83,13 +82,7 @@ export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
   };
   githubAppUrl: string;
   gaTrackingId: string;
-}>(async (context) => {
-  const session = await getSession(context.req, context.res);
-  const auth = await Authenticator.fromSession(
-    session,
-    context.params?.wId as string
-  );
-
+}>(async (context, auth) => {
   const owner = auth.workspace();
   const plan = auth.plan();
   const subscription = auth.subscription();

--- a/front/pages/w/[wId]/builder/data-sources/[name]/search.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/search.tsx
@@ -13,24 +13,18 @@ import AppLayout from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { subNavigationBuild } from "@app/components/sparkle/navigation";
 import { getDataSource } from "@app/lib/api/data_sources";
-import { Authenticator } from "@app/lib/auth";
 import { getDisplayNameForDocument } from "@app/lib/data_sources";
-import { withDefaultGetServerSidePropsRequirements } from "@app/lib/iam/session";
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { classNames, timeAgoFrom } from "@app/lib/utils";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
+export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   dataSource: DataSourceType;
   gaTrackingId: string;
-}>(async (context, session) => {
-  const auth = await Authenticator.fromSession(
-    session,
-    context.params?.wId as string
-  );
-
+}>(async (context, auth) => {
   const owner = auth.workspace();
   const subscription = auth.subscription();
 

--- a/front/pages/w/[wId]/builder/data-sources/[name]/settings.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/settings.tsx
@@ -16,24 +16,18 @@ import AppLayout from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleSaveCancelTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { subNavigationBuild } from "@app/components/sparkle/navigation";
 import { getDataSource } from "@app/lib/api/data_sources";
-import { Authenticator } from "@app/lib/auth";
-import { withDefaultGetServerSidePropsRequirements } from "@app/lib/iam/session";
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { classNames } from "@app/lib/utils";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
+export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   dataSource: DataSourceType;
   fetchConnectorError?: boolean;
   gaTrackingId: string;
-}>(async (context, session) => {
-  const auth = await Authenticator.fromSession(
-    session,
-    context.params?.wId as string
-  );
-
+}>(async (context, auth) => {
   const owner = auth.workspace();
   const subscription = auth.subscription();
 

--- a/front/pages/w/[wId]/builder/data-sources/[name]/tables/upsert.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/tables/upsert.tsx
@@ -26,28 +26,22 @@ import { AppLayoutSimpleSaveCancelTitle } from "@app/components/sparkle/AppLayou
 import { subNavigationBuild } from "@app/components/sparkle/navigation";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { getDataSource } from "@app/lib/api/data_sources";
-import { Authenticator } from "@app/lib/auth";
 import { handleFileUploadToText } from "@app/lib/client/handle_file_upload";
-import { withDefaultGetServerSidePropsRequirements } from "@app/lib/iam/session";
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { useTable } from "@app/lib/swr";
 import { classNames } from "@app/lib/utils";
 import type { UpsertTableFromCsvRequestBody } from "@app/pages/api/w/[wId]/data_sources/[name]/tables/csv";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
+export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   readOnly: boolean;
   dataSource: DataSourceType;
   loadTableId: string | null;
   gaTrackingId: string;
-}>(async (context, session) => {
-  const auth = await Authenticator.fromSession(
-    session,
-    context.params?.wId as string
-  );
-
+}>(async (context, auth) => {
   const owner = auth.workspace();
   const plan = auth.plan();
   const subscription = auth.subscription();

--- a/front/pages/w/[wId]/builder/data-sources/[name]/upsert.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/upsert.tsx
@@ -27,14 +27,13 @@ import { AppLayoutSimpleSaveCancelTitle } from "@app/components/sparkle/AppLayou
 import { subNavigationBuild } from "@app/components/sparkle/navigation";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { getDataSource } from "@app/lib/api/data_sources";
-import { Authenticator } from "@app/lib/auth";
 import { handleFileUploadToText } from "@app/lib/client/handle_file_upload";
-import { withDefaultGetServerSidePropsRequirements } from "@app/lib/iam/session";
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { classNames } from "@app/lib/utils";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
+export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   plan: PlanType;
@@ -42,12 +41,7 @@ export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
   dataSource: DataSourceType;
   loadDocumentId: string | null;
   gaTrackingId: string;
-}>(async (context, session) => {
-  const auth = await Authenticator.fromSession(
-    session,
-    context.params?.wId as string
-  );
-
+}>(async (context, auth) => {
   const owner = auth.workspace();
   const plan = auth.plan();
   const subscription = auth.subscription();

--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -35,7 +35,7 @@ import { Authenticator } from "@app/lib/auth";
 import { buildConnectionId } from "@app/lib/connector_connection_id";
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 import { githubAuth } from "@app/lib/github_auth";
-import { withDefaultGetServerSidePropsRequirements } from "@app/lib/iam/session";
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { timeAgoFrom } from "@app/lib/utils";
 import logger from "@app/logger/logger";
 
@@ -73,7 +73,7 @@ const REDIRECT_TO_EDIT_PERMISSIONS = [
   "intercom",
 ];
 
-export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
+export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   readOnly: boolean;
@@ -90,12 +90,7 @@ export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
     intercomConnectorId: string;
   };
   githubAppUrl: string;
-}>(async (context, session) => {
-  const auth = await Authenticator.fromSession(
-    session,
-    context.params?.wId as string
-  );
-
+}>(async (context, auth) => {
   const owner = auth.workspace();
   const plan = auth.plan();
   const subscription = auth.subscription();

--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -31,7 +31,6 @@ import AppLayout from "@app/components/sparkle/AppLayout";
 import { subNavigationBuild } from "@app/components/sparkle/navigation";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { getDataSources } from "@app/lib/api/data_sources";
-import { Authenticator } from "@app/lib/auth";
 import { buildConnectionId } from "@app/lib/connector_connection_id";
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 import { githubAuth } from "@app/lib/github_auth";

--- a/front/pages/w/[wId]/builder/data-sources/new-public-url.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/new-public-url.tsx
@@ -7,22 +7,16 @@ import type { InferGetServerSidePropsType } from "next";
 
 import WebsiteConfiguration from "@app/components/data_source/WebsiteConfiguration";
 import { getDataSources } from "@app/lib/api/data_sources";
-import { Authenticator } from "@app/lib/auth";
-import { withDefaultGetServerSidePropsRequirements } from "@app/lib/iam/session";
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
+export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   dataSources: DataSourceType[];
   gaTrackingId: string;
-}>(async (context, session) => {
-  const auth = await Authenticator.fromSession(
-    session,
-    context.params?.wId as string
-  );
-
+}>(async (context, auth) => {
   const owner = auth.workspace();
   const subscription = auth.subscription();
 

--- a/front/pages/w/[wId]/builder/data-sources/new.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/new.tsx
@@ -12,12 +12,12 @@ import { AppLayoutSimpleSaveCancelTitle } from "@app/components/sparkle/AppLayou
 import { subNavigationBuild } from "@app/components/sparkle/navigation";
 import { getDataSources } from "@app/lib/api/data_sources";
 import { Authenticator } from "@app/lib/auth";
-import { withDefaultGetServerSidePropsRequirements } from "@app/lib/iam/session";
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { classNames } from "@app/lib/utils";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
+export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   dataSources: DataSourceType[];

--- a/front/pages/w/[wId]/builder/data-sources/new.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/new.tsx
@@ -11,7 +11,6 @@ import AppLayout from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleSaveCancelTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { subNavigationBuild } from "@app/components/sparkle/navigation";
 import { getDataSources } from "@app/lib/api/data_sources";
-import { Authenticator } from "@app/lib/auth";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { classNames } from "@app/lib/utils";
 
@@ -22,12 +21,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   subscription: SubscriptionType;
   dataSources: DataSourceType[];
   gaTrackingId: string;
-}>(async (context, session) => {
-  const auth = await Authenticator.fromSession(
-    session,
-    context.params?.wId as string
-  );
-
+}>(async (context, auth) => {
   const owner = auth.workspace();
   const subscription = auth.subscription();
 

--- a/front/pages/w/[wId]/builder/data-sources/public-urls.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/public-urls.tsx
@@ -24,9 +24,8 @@ import { EmptyCallToAction } from "@app/components/EmptyCallToAction";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { subNavigationBuild } from "@app/components/sparkle/navigation";
 import { getDataSources } from "@app/lib/api/data_sources";
-import { Authenticator } from "@app/lib/auth";
 import { useSubmitFunction } from "@app/lib/client/utils";
-import { withDefaultGetServerSidePropsRequirements } from "@app/lib/iam/session";
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import logger from "@app/logger/logger";
 
 const { GA_TRACKING_ID = "" } = process.env;
@@ -35,19 +34,14 @@ type DataSourceWithConnector = DataSourceType & {
   connector: ConnectorType;
 };
 
-export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
+export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   plan: PlanType;
   readOnly: boolean;
   dataSources: DataSourceWithConnector[];
   gaTrackingId: string;
-}>(async (context, session) => {
-  const auth = await Authenticator.fromSession(
-    session,
-    context.params?.wId as string
-  );
-
+}>(async (context, auth) => {
   const owner = auth.workspace();
   const plan = auth.plan();
   const subscription = auth.subscription();

--- a/front/pages/w/[wId]/builder/data-sources/static.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/static.tsx
@@ -18,25 +18,19 @@ import { EmptyCallToAction } from "@app/components/EmptyCallToAction";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { subNavigationBuild } from "@app/components/sparkle/navigation";
 import { getDataSources } from "@app/lib/api/data_sources";
-import { Authenticator } from "@app/lib/auth";
 import { useSubmitFunction } from "@app/lib/client/utils";
-import { withDefaultGetServerSidePropsRequirements } from "@app/lib/iam/session";
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
+export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   plan: PlanType;
   readOnly: boolean;
   dataSources: DataSourceType[];
   gaTrackingId: string;
-}>(async (context, session) => {
-  const auth = await Authenticator.fromSession(
-    session,
-    context.params?.wId as string
-  );
-
+}>(async (context, auth) => {
   const owner = auth.workspace();
   const plan = auth.plan();
   const subscription = auth.subscription();

--- a/front/pages/w/[wId]/index.tsx
+++ b/front/pages/w/[wId]/index.tsx
@@ -1,28 +1,21 @@
-import { Authenticator } from "@app/lib/auth";
-import { withDefaultGetServerSidePropsRequirements } from "@app/lib/iam/session";
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 
-export const getServerSideProps =
-  withDefaultGetServerSidePropsRequirements<object>(
-    async (context, session) => {
-      const auth = await Authenticator.fromSession(
-        session,
-        context.params?.wId as string
-      );
-
-      if (!auth.workspace() || !auth.user()) {
-        return {
-          notFound: true,
-        };
-      }
-
+export const getServerSideProps = withDefaultUserAuthRequirements<object>(
+  async (context, auth) => {
+    if (!auth.workspace() || !auth.user()) {
       return {
-        redirect: {
-          destination: `/w/${context.query.wId}/assistant/new`,
-          permanent: false,
-        },
+        notFound: true,
       };
     }
-  );
+
+    return {
+      redirect: {
+        destination: `/w/${context.query.wId}/assistant/new`,
+        permanent: false,
+      },
+    };
+  }
+);
 
 export default function Redirect() {
   return <></>;

--- a/front/pages/w/[wId]/join.tsx
+++ b/front/pages/w/[wId]/join.tsx
@@ -37,7 +37,7 @@ type OnboardingType =
   | "domain_invite_link";
 
 export const getServerSideProps = makeGetServerSidePropsRequirementsWrapper({
-  requireAuth: false,
+  requireAuthLevel: "none",
 })<{
   onboardingType: OnboardingType;
   workspace: LightWorkspaceType;

--- a/front/pages/w/[wId]/join.tsx
+++ b/front/pages/w/[wId]/join.tsx
@@ -37,7 +37,7 @@ type OnboardingType =
   | "domain_invite_link";
 
 export const getServerSideProps = makeGetServerSidePropsRequirementsWrapper({
-  requireAuthLevel: "none",
+  requireUserPrivilege: "none",
 })<{
   onboardingType: OnboardingType;
   workspace: LightWorkspaceType;

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -40,8 +40,7 @@ import {
   checkWorkspaceSeatAvailabilityUsingAuth,
   getWorkspaceVerifiedDomain,
 } from "@app/lib/api/workspace";
-import { Authenticator } from "@app/lib/auth";
-import { withDefaultGetServerSidePropsRequirements } from "@app/lib/iam/session";
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { isUpgraded } from "@app/lib/plans/plan_codes";
 import { useMembers, useWorkspaceInvitations } from "@app/lib/swr";
 import { classNames, isEmailValid } from "@app/lib/utils";
@@ -50,7 +49,7 @@ const { GA_TRACKING_ID = "" } = process.env;
 
 const CLOSING_ANIMATION_DURATION = 200;
 
-export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
+export const getServerSideProps = withDefaultUserAuthRequirements<{
   user: UserType;
   owner: WorkspaceType;
   subscription: SubscriptionType;
@@ -59,11 +58,7 @@ export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
   gaTrackingId: string;
   workspaceHasAvailableSeats: boolean;
   workspaceVerifiedDomain: WorkspaceDomain | null;
-}>(async (context, session) => {
-  const auth = await Authenticator.fromSession(
-    session,
-    context.params?.wId as string
-  );
+}>(async (context, auth) => {
   const plan = auth.plan();
   const owner = auth.workspace();
   const user = auth.user();

--- a/front/pages/w/[wId]/subscription/index.tsx
+++ b/front/pages/w/[wId]/subscription/index.tsx
@@ -18,9 +18,8 @@ import { PricePlans } from "@app/components/PlansTables";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { subNavigationAdmin } from "@app/components/sparkle/navigation";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
-import { Authenticator } from "@app/lib/auth";
 import { useSubmitFunction } from "@app/lib/client/utils";
-import { withDefaultGetServerSidePropsRequirements } from "@app/lib/iam/session";
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import {
   FREE_TEST_PLAN_CODE,
   FREE_UPGRADED_PLAN_CODE,
@@ -31,17 +30,12 @@ import { getPlanInvitation } from "@app/lib/plans/subscription";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
+export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   planInvitation: PlanInvitationType | null;
   gaTrackingId: string;
-}>(async (context, session) => {
-  const auth = await Authenticator.fromSession(
-    session,
-    context.params?.wId as string
-  );
-
+}>(async (context, auth) => {
   const owner = auth.workspace();
   const subscription = auth.subscription();
   if (!owner || !auth.isAdmin() || !subscription) {

--- a/front/pages/w/[wId]/subscription/upgrade-enterprise/[secret].tsx
+++ b/front/pages/w/[wId]/subscription/upgrade-enterprise/[secret].tsx
@@ -1,69 +1,62 @@
-import { Authenticator } from "@app/lib/auth";
-import { withDefaultGetServerSidePropsRequirements } from "@app/lib/iam/session";
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { Workspace } from "@app/lib/models";
 import { PlanInvitation } from "@app/lib/models/plan";
 import { getCheckoutUrlForUpgrade } from "@app/lib/plans/subscription";
 
-export const getServerSideProps =
-  withDefaultGetServerSidePropsRequirements<object>(
-    async (context, session) => {
-      const auth = await Authenticator.fromSession(
-        session,
-        context.params?.wId as string
-      );
-
-      const owner = auth.workspace();
-      if (!owner) {
-        return {
-          notFound: true,
-        };
-      }
-
-      const token = context.params?.secret as string;
-      if (!token) {
-        return {
-          notFound: true,
-        };
-      }
-
-      const invitation = await PlanInvitation.findOne({
-        where: {
-          secret: token,
-        },
-      });
-
-      if (!invitation) {
-        return {
-          notFound: true,
-        };
-      }
-
-      const targetWorkspace = await Workspace.findOne({
-        where: {
-          id: invitation.workspaceId,
-        },
-      });
-      if (!targetWorkspace || targetWorkspace.sId !== owner.sId) {
-        return {
-          notFound: true,
-        };
-      }
-
-      const { checkoutUrl } = await getCheckoutUrlForUpgrade(auth);
-      if (!checkoutUrl) {
-        return {
-          notFound: true,
-        };
-      }
-
+export const getServerSideProps = withDefaultUserAuthRequirements<object>(
+  async (context, auth) => {
+    const owner = auth.workspace();
+    if (!owner) {
       return {
-        redirect: {
-          destination: checkoutUrl,
-          permanent: false,
-        },
+        notFound: true,
       };
     }
-  );
+
+    const token = context.params?.secret as string;
+    if (!token) {
+      return {
+        notFound: true,
+      };
+    }
+
+    const invitation = await PlanInvitation.findOne({
+      where: {
+        secret: token,
+      },
+    });
+
+    if (!invitation) {
+      return {
+        notFound: true,
+      };
+    }
+
+    const targetWorkspace = await Workspace.findOne({
+      where: {
+        id: invitation.workspaceId,
+      },
+    });
+    if (!targetWorkspace || targetWorkspace.sId !== owner.sId) {
+      return {
+        notFound: true,
+      };
+    }
+
+    const { checkoutUrl } = await getCheckoutUrlForUpgrade(auth);
+    if (!checkoutUrl) {
+      return {
+        notFound: true,
+      };
+    }
+
+    return {
+      redirect: {
+        destination: checkoutUrl,
+        permanent: false,
+      },
+    };
+  }
+);
 
 export default function Redirect() {
   return <></>;

--- a/front/pages/w/[wId]/u/extract/events/[sId]/edit.tsx
+++ b/front/pages/w/[wId]/u/extract/events/[sId]/edit.tsx
@@ -10,25 +10,19 @@ import React, { useEffect, useRef, useState } from "react";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { subNavigationBuild } from "@app/components/sparkle/navigation";
 import { getEventSchema, getExtractedEvent } from "@app/lib/api/extract";
-import { Authenticator } from "@app/lib/auth";
-import { withDefaultGetServerSidePropsRequirements } from "@app/lib/iam/session";
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { classNames } from "@app/lib/utils";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
+export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   event: ExtractedEventType;
   schema: EventSchemaType;
   readOnly: boolean;
   gaTrackingId: string;
-}>(async (context, session) => {
-  const auth = await Authenticator.fromSession(
-    session,
-    context.params?.wId as string
-  );
-
+}>(async (context, auth) => {
   const owner = auth.workspace();
   const subscription = auth.subscription();
 

--- a/front/pages/w/[wId]/u/extract/index.tsx
+++ b/front/pages/w/[wId]/u/extract/index.tsx
@@ -8,22 +8,16 @@ import { useRouter } from "next/router";
 
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { subNavigationBuild } from "@app/components/sparkle/navigation";
-import { Authenticator } from "@app/lib/auth";
-import { withDefaultGetServerSidePropsRequirements } from "@app/lib/iam/session";
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { useEventSchemas } from "@app/lib/swr";
 
 const { GA_TRACKING_ID = "" } = process.env;
-export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
+export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   readOnly: boolean;
   gaTrackingId: string;
-}>(async (context, session) => {
-  const auth = await Authenticator.fromSession(
-    session,
-    context.params?.wId as string
-  );
-
+}>(async (context, auth) => {
   const owner = auth.workspace();
   const subscription = auth.subscription();
 

--- a/front/pages/w/[wId]/u/extract/templates/[sId]/edit.tsx
+++ b/front/pages/w/[wId]/u/extract/templates/[sId]/edit.tsx
@@ -7,23 +7,17 @@ import AppLayout from "@app/components/sparkle/AppLayout";
 import { subNavigationBuild } from "@app/components/sparkle/navigation";
 import { ExtractEventSchemaForm } from "@app/components/use/EventSchemaForm";
 import { getEventSchema } from "@app/lib/api/extract";
-import { Authenticator } from "@app/lib/auth";
-import { withDefaultGetServerSidePropsRequirements } from "@app/lib/iam/session";
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
+export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   schema: EventSchemaType;
   readOnly: boolean;
   gaTrackingId: string;
-}>(async (context, session) => {
-  const auth = await Authenticator.fromSession(
-    session,
-    context.params?.wId as string
-  );
-
+}>(async (context, auth) => {
   const owner = auth.workspace();
   const subscription = auth.subscription();
 

--- a/front/pages/w/[wId]/u/extract/templates/[sId]/index.tsx
+++ b/front/pages/w/[wId]/u/extract/templates/[sId]/index.tsx
@@ -24,25 +24,20 @@ import { useSWRConfig } from "swr";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { subNavigationBuild } from "@app/components/sparkle/navigation";
 import { getEventSchema } from "@app/lib/api/extract";
-import { Authenticator } from "@app/lib/auth";
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
-import { withDefaultGetServerSidePropsRequirements } from "@app/lib/iam/session";
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { useExtractedEvents } from "@app/lib/swr";
 import { classNames, objectToMarkdown } from "@app/lib/utils";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
+export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   schema: EventSchemaType;
   readOnly: boolean;
   gaTrackingId: string;
-}>(async (context, session) => {
-  const auth = await Authenticator.fromSession(
-    session,
-    context.params?.wId as string
-  );
+}>(async (context, auth) => {
   const owner = auth.workspace();
   const subscription = auth.subscription();
 

--- a/front/pages/w/[wId]/u/extract/templates/new.tsx
+++ b/front/pages/w/[wId]/u/extract/templates/new.tsx
@@ -5,22 +5,16 @@ import type { InferGetServerSidePropsType } from "next";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { subNavigationBuild } from "@app/components/sparkle/navigation";
 import { ExtractEventSchemaForm } from "@app/components/use/EventSchemaForm";
-import { Authenticator } from "@app/lib/auth";
-import { withDefaultGetServerSidePropsRequirements } from "@app/lib/iam/session";
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
+export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   readOnly: boolean;
   gaTrackingId: string;
-}>(async (context, session) => {
-  const auth = await Authenticator.fromSession(
-    session,
-    context.params?.wId as string
-  );
-
+}>(async (context, auth) => {
   const owner = auth.workspace();
   const subscription = auth.subscription();
 

--- a/front/pages/w/[wId]/welcome.tsx
+++ b/front/pages/w/[wId]/welcome.tsx
@@ -13,16 +13,15 @@ import { useEffect, useState } from "react";
 
 import OnboardingLayout from "@app/components/sparkle/OnboardingLayout";
 import { getUserMetadata } from "@app/lib/api/user";
-import { Authenticator } from "@app/lib/auth";
 import { useSubmitFunction } from "@app/lib/client/utils";
-import { withDefaultGetServerSidePropsRequirements } from "@app/lib/iam/session";
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 
 const { URL = "", GA_TRACKING_ID = "" } = process.env;
 
 const ADMIN_YOUTUBE_ID = "f9n4mqBX2aw";
 const MEMBER_YOUTUBE_ID = null; // We don't have the video yet.
 
-export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
+export const getServerSideProps = withDefaultUserAuthRequirements<{
   user: UserType;
   owner: WorkspaceType;
   isAdmin: boolean;
@@ -31,12 +30,7 @@ export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
   conversationId: string | null;
   gaTrackingId: string;
   baseUrl: string;
-}>(async (context, session) => {
-  const auth = await Authenticator.fromSession(
-    session,
-    context.params?.wId as string
-  );
-
+}>(async (context, auth) => {
   const owner = auth.workspace();
   const user = auth.user();
 

--- a/front/pages/w/[wId]/workspace/index.tsx
+++ b/front/pages/w/[wId]/workspace/index.tsx
@@ -14,22 +14,16 @@ import { useCallback, useEffect, useState } from "react";
 
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { subNavigationAdmin } from "@app/components/sparkle/navigation";
-import { Authenticator } from "@app/lib/auth";
-import { withDefaultGetServerSidePropsRequirements } from "@app/lib/iam/session";
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { useWorkspaceAnalytics } from "@app/lib/swr";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
-export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
+export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   gaTrackingId: string;
-}>(async (context, session) => {
-  const auth = await Authenticator.fromSession(
-    session,
-    context.params?.wId as string
-  );
-
+}>(async (context, auth) => {
   const owner = auth.workspace();
   const subscription = auth.subscription();
   if (!owner || !auth.isAdmin() || !subscription) {


### PR DESCRIPTION
## Description

This PR improves the wrapper introduced in  to go one step further and create the authenticator object needed to check and access resources.

This PR enhances the SSR wrapper from https://github.com/dust-tt/dust/pull/4140 by creating the authenticator object required for checking and accessing resources in a centralized place. It also introduces a new wrapper `withSuperUserAuthRequirements` use to gate all poke server side rendering to superuser.
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
