### PR TITLE
feat: add support for plans with trial periods

### DIFF
--- a/front/components/poke/plans/form.tsx
+++ b/front/components/poke/plans/form.tsx
@@ -39,7 +39,7 @@ export type EditingPlanType = {
   maxUsers: string | number;
   billingType: FreeBillingType | PaidBillingType;
   isNewPlan?: boolean;
-  trialPeriodDays: number;
+  trialPeriodDays: string | number;
 };
 
 export const fromPlanType = (plan: PlanType): EditingPlanType => {
@@ -61,11 +61,17 @@ export const fromPlanType = (plan: PlanType): EditingPlanType => {
     dataSourcesDocumentsSizeMb: plan.limits.dataSources.documents.sizeMb,
     maxUsers: plan.limits.users.maxUsers,
     billingType: plan.billingType,
-    trialPeriodDays: plan.trialPeriodDays ?? 0,
+    trialPeriodDays: plan.trialPeriodDays,
   };
 };
 
 export const toPlanType = (editingPlan: EditingPlanType): PlanType => {
+  const parseMaybeNumber = (x: string | number) => {
+    if (typeof x === "string") {
+      return parseInt(x, 10);
+    }
+    return x;
+  };
   return {
     code: editingPlan.code.trim(),
     name: editingPlan.name.trim(),
@@ -73,7 +79,7 @@ export const toPlanType = (editingPlan: EditingPlanType): PlanType => {
     limits: {
       assistant: {
         isSlackBotAllowed: editingPlan.isSlackBotAllowed,
-        maxMessages: parseInt(editingPlan.maxMessages.toString(), 10),
+        maxMessages: parseMaybeNumber(editingPlan.maxMessages),
       },
       connections: {
         isConfluenceAllowed: editingPlan.isConfluenceAllowed,
@@ -85,21 +91,18 @@ export const toPlanType = (editingPlan: EditingPlanType): PlanType => {
         isWebCrawlerAllowed: editingPlan.isWebCrawlerAllowed,
       },
       dataSources: {
-        count: parseInt(editingPlan.dataSourcesCount.toString(), 10),
+        count: parseMaybeNumber(editingPlan.dataSourcesCount),
         documents: {
-          count: parseInt(editingPlan.dataSourcesDocumentsCount.toString(), 10),
-          sizeMb: parseInt(
-            editingPlan.dataSourcesDocumentsSizeMb.toString(),
-            10
-          ),
+          count: parseMaybeNumber(editingPlan.dataSourcesDocumentsCount),
+          sizeMb: parseMaybeNumber(editingPlan.dataSourcesDocumentsSizeMb),
         },
       },
       users: {
-        maxUsers: parseInt(editingPlan.maxUsers.toString(), 10),
+        maxUsers: parseMaybeNumber(editingPlan.maxUsers),
       },
     },
     billingType: editingPlan.billingType,
-    trialPeriodDays: parseInt(editingPlan.trialPeriodDays.toString(), 10),
+    trialPeriodDays: parseMaybeNumber(editingPlan.trialPeriodDays),
   };
 };
 

--- a/front/components/poke/plans/form.tsx
+++ b/front/components/poke/plans/form.tsx
@@ -39,6 +39,7 @@ export type EditingPlanType = {
   maxUsers: string | number;
   billingType: FreeBillingType | PaidBillingType;
   isNewPlan?: boolean;
+  trialPeriodDays: number;
 };
 
 export const fromPlanType = (plan: PlanType): EditingPlanType => {
@@ -60,6 +61,7 @@ export const fromPlanType = (plan: PlanType): EditingPlanType => {
     dataSourcesDocumentsSizeMb: plan.limits.dataSources.documents.sizeMb,
     maxUsers: plan.limits.users.maxUsers,
     billingType: plan.billingType,
+    trialPeriodDays: plan.trialPeriodDays ?? 0,
   };
 };
 
@@ -97,6 +99,7 @@ export const toPlanType = (editingPlan: EditingPlanType): PlanType => {
       },
     },
     billingType: editingPlan.billingType,
+    trialPeriodDays: parseInt(editingPlan.trialPeriodDays.toString(), 10),
   };
 };
 
@@ -119,6 +122,7 @@ const getEmptyPlan = (): EditingPlanType => ({
   maxUsers: "",
   isNewPlan: true,
   billingType: "fixed",
+  trialPeriodDays: 0,
 });
 
 export const useEditingPlan = () => {
@@ -280,6 +284,18 @@ export const PLAN_FIELDS = {
     width: "small",
     title: "Billing",
     error: (plan: EditingPlanType) => (plan.billingType ? null : "Required"),
+  },
+  trialPeriodDays: {
+    type: "number",
+    width: "small",
+    title: "Trial Days",
+    error: (plan: EditingPlanType) => {
+      if (plan.billingType === "free") {
+        return null;
+      }
+
+      return errorCheckNumber(plan.trialPeriodDays);
+    },
   },
 } as const;
 

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -597,6 +597,7 @@ export async function subscriptionForWorkspace(
           maxUsers: plan.maxUsersInWorkspace,
         },
       },
+      trialPeriodDays: plan.trialPeriodDays,
     },
   };
 }

--- a/front/lib/models/plan.ts
+++ b/front/lib/models/plan.ts
@@ -33,6 +33,7 @@ export class Plan extends Model<
   declare name: string;
   declare stripeProductId: string | null;
   declare billingType: FreeBillingType | PaidBillingType;
+  declare trialPeriodDays: number | null;
 
   // workspace limitations
   declare maxMessages: number;
@@ -85,6 +86,10 @@ Plan.init(
       validate: {
         isIn: [[...FREE_BILLING_TYPES, ...PAID_BILLING_TYPES]],
       },
+    },
+    trialPeriodDays: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
     },
     maxMessages: {
       type: DataTypes.INTEGER,

--- a/front/lib/models/plan.ts
+++ b/front/lib/models/plan.ts
@@ -33,7 +33,7 @@ export class Plan extends Model<
   declare name: string;
   declare stripeProductId: string | null;
   declare billingType: FreeBillingType | PaidBillingType;
-  declare trialPeriodDays: number | null;
+  declare trialPeriodDays: number;
 
   // workspace limitations
   declare maxMessages: number;
@@ -89,7 +89,8 @@ Plan.init(
     },
     trialPeriodDays: {
       type: DataTypes.INTEGER,
-      allowNull: true,
+      allowNull: false,
+      defaultValue: 0,
     },
     maxMessages: {
       type: DataTypes.INTEGER,

--- a/front/lib/plans/enterprise_plans.ts
+++ b/front/lib/plans/enterprise_plans.ts
@@ -36,4 +36,5 @@ export const ENT_PLAN_FAKE_DATA: PlanAttributes = {
   maxDataSourcesCount: -1,
   maxDataSourcesDocumentsCount: -1,
   maxDataSourcesDocumentsSizeMb: 2,
+  trialPeriodDays: 0,
 };

--- a/front/lib/plans/free_plans.ts
+++ b/front/lib/plans/free_plans.ts
@@ -42,6 +42,7 @@ export const FREE_TEST_PLAN_DATA: PlanAttributes = {
   maxDataSourcesCount: 5,
   maxDataSourcesDocumentsCount: 10,
   maxDataSourcesDocumentsSizeMb: 2,
+  trialPeriodDays: 0,
 };
 
 /**
@@ -67,6 +68,7 @@ const FREE_PLANS_DATA: PlanAttributes[] = [
     maxDataSourcesCount: -1,
     maxDataSourcesDocumentsCount: -1,
     maxDataSourcesDocumentsSizeMb: 2,
+    trialPeriodDays: 0,
   },
 ];
 

--- a/front/lib/plans/pro_plans.ts
+++ b/front/lib/plans/pro_plans.ts
@@ -46,6 +46,7 @@ if (isDevelopment()) {
     maxDataSourcesCount: -1,
     maxDataSourcesDocumentsCount: -1,
     maxDataSourcesDocumentsSizeMb: 2,
+    trialPeriodDays: 0,
   });
 }
 

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -111,6 +111,7 @@ export const createCheckoutSession = async ({
         planCode: planCode,
         workspaceId: owner.sId,
       },
+      trial_period_days: plan.trialPeriodDays || undefined,
     },
     metadata: {
       planCode: planCode,

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -111,6 +111,7 @@ export const createCheckoutSession = async ({
         planCode: planCode,
         workspaceId: owner.sId,
       },
+      // If trialPeriodDays is 0, we send "undefined" to Stripe.
       trial_period_days: plan.trialPeriodDays || undefined,
     },
     metadata: {

--- a/front/lib/plans/subscription.ts
+++ b/front/lib/plans/subscription.ts
@@ -99,6 +99,7 @@ export const internalSubscribeWorkspaceToFreeTestPlan = async ({
           maxUsers: freeTestPlan.maxUsersInWorkspace,
         },
       },
+      trialPeriodDays: freeTestPlan.trialPeriodDays,
     },
   };
 };
@@ -199,6 +200,7 @@ export const internalSubscribeWorkspaceToFreeUpgradedPlan = async ({
             maxUsers: plan.maxUsersInWorkspace,
           },
         },
+        trialPeriodDays: plan.trialPeriodDays,
       },
     };
   });
@@ -365,6 +367,7 @@ export const getCheckoutUrlForUpgrade = async (
           maxUsers: plan.maxUsersInWorkspace,
         },
       },
+      trialPeriodDays: plan.trialPeriodDays,
     },
   };
 };

--- a/front/pages/api/poke/plans.ts
+++ b/front/pages/api/poke/plans.ts
@@ -45,6 +45,7 @@ export const PlanTypeSchema = t.type({
     t.literal("per_seat"),
     t.literal("free"),
   ]),
+  trialPeriodDays: t.union([t.number, t.null]),
 });
 
 export type UpsertPokePlanResponseBody = {
@@ -108,6 +109,7 @@ async function handler(
           },
         },
         billingType: plan.billingType,
+        trialPeriodDays: plan.trialPeriodDays,
       }));
 
       const stripeProductIds = plans
@@ -190,6 +192,7 @@ async function handler(
         maxDataSourcesDocumentsSizeMb: body.limits.dataSources.documents.sizeMb,
         maxUsersInWorkspace: body.limits.users.maxUsers,
         billingType: body.billingType,
+        trialPeriodDays: body.trialPeriodDays || null,
       });
       res.status(200).json({
         plan: body,

--- a/front/pages/api/poke/plans.ts
+++ b/front/pages/api/poke/plans.ts
@@ -45,7 +45,7 @@ export const PlanTypeSchema = t.type({
     t.literal("per_seat"),
     t.literal("free"),
   ]),
-  trialPeriodDays: t.union([t.number, t.null]),
+  trialPeriodDays: t.number,
 });
 
 export type UpsertPokePlanResponseBody = {
@@ -192,7 +192,7 @@ async function handler(
         maxDataSourcesDocumentsSizeMb: body.limits.dataSources.documents.sizeMb,
         maxUsersInWorkspace: body.limits.users.maxUsers,
         billingType: body.billingType,
-        trialPeriodDays: body.trialPeriodDays || null,
+        trialPeriodDays: body.trialPeriodDays,
       });
       res.status(200).json({
         plan: body,

--- a/types/src/front/plan.ts
+++ b/types/src/front/plan.ts
@@ -49,7 +49,7 @@ export type PlanType = {
   limits: LimitsType;
   stripeProductId: string | null;
   billingType: FreeBillingType | PaidBillingType;
-  trialPeriodDays: number | null;
+  trialPeriodDays: number;
 };
 
 export type SubscriptionType = {

--- a/types/src/front/plan.ts
+++ b/types/src/front/plan.ts
@@ -49,6 +49,7 @@ export type PlanType = {
   limits: LimitsType;
   stripeProductId: string | null;
   billingType: FreeBillingType | PaidBillingType;
+  trialPeriodDays: number | null;
 };
 
 export type SubscriptionType = {


### PR DESCRIPTION
## Description

Add support for plans with trial periods (in days).

additive: support in data model, support in poke, pass the value (if any) to stripe when creating the checkout session.

Won't do anything until we actually have plans that use it.

## Risk

- migration

## Deploy Plan

front initdb then deploy front