### PR TITLE
enh: link to new chat from gallery play btn

### DIFF
--- a/front/components/assistant/GalleryAssistantPreviewContainer.tsx
+++ b/front/components/assistant/GalleryAssistantPreviewContainer.tsx
@@ -38,11 +38,10 @@ export function GalleryAssistantPreviewContainer({
   const { description, generation, lastAuthors, name, pictureUrl, scope } =
     agentConfiguration;
 
-  const isGlobal = scope === "global";
   const hasAccessToLargeModels = isUpgraded(plan);
   const eligibleForTesting =
     hasAccessToLargeModels || !isLargeModel(generation?.model);
-  const isTestable = !isGlobal && eligibleForTesting;
+
   return (
     <AssistantPreview
       title={name}
@@ -51,7 +50,7 @@ export function GalleryAssistantPreviewContainer({
       description={description}
       variant="gallery"
       onClick={onShowDetails}
-      onPlayClick={isTestable ? handleTestClick : undefined}
+      onPlayClick={eligibleForTesting ? handleTestClick : undefined}
       renderActions={(isParentHovered) => {
         return (
           <div className="s-flex s-gap-2">

--- a/front/components/assistant/GalleryAssistantPreviewContainer.tsx
+++ b/front/components/assistant/GalleryAssistantPreviewContainer.tsx
@@ -4,6 +4,7 @@ import type {
   PlanType,
   WorkspaceType,
 } from "@dust-tt/types";
+import { useRouter } from "next/router";
 import type { SyntheticEvent } from "react";
 
 import AssistantListActions from "@app/components/assistant/AssistantListActions";
@@ -17,9 +18,6 @@ interface GalleryAssistantPreviewContainerProps {
   onUpdate: () => void;
   owner: WorkspaceType;
   plan: PlanType | null;
-  setTestModalAssistant?: (
-    agentConfiguration: LightAgentConfigurationType
-  ) => void;
 }
 
 export function GalleryAssistantPreviewContainer({
@@ -27,11 +25,14 @@ export function GalleryAssistantPreviewContainer({
   onShowDetails,
   owner,
   plan,
-  setTestModalAssistant,
 }: GalleryAssistantPreviewContainerProps) {
+  const router = useRouter();
+
   const handleTestClick = (e: SyntheticEvent) => {
     e.stopPropagation();
-    setTestModalAssistant?.(agentConfiguration);
+    void router.push(
+      `/w/${owner.sId}/assistant/new?mention=${agentConfiguration.sId}`
+    );
   };
 
   const { description, generation, lastAuthors, name, pictureUrl, scope } =

--- a/front/pages/w/[wId]/assistant/gallery.tsx
+++ b/front/pages/w/[wId]/assistant/gallery.tsx
@@ -13,7 +13,6 @@ import type {
   LightAgentConfigurationType,
   PlanType,
   SubscriptionType,
-  UserType,
   WorkspaceType,
 } from "@dust-tt/types";
 import { assertNever } from "@dust-tt/types";
@@ -24,7 +23,6 @@ import { useEffect, useMemo, useState } from "react";
 
 import { AssistantDetails } from "@app/components/assistant/AssistantDetails";
 import { GalleryAssistantPreviewContainer } from "@app/components/assistant/GalleryAssistantPreviewContainer";
-import { TryAssistantModal } from "@app/components/assistant/TryAssistant";
 import AppLayout, { appLayoutBack } from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { Authenticator } from "@app/lib/auth";
@@ -35,7 +33,6 @@ import { subFilter } from "@app/lib/utils";
 const { GA_TRACKING_ID = "" } = process.env;
 
 export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
-  user: UserType;
   owner: WorkspaceType;
   plan: PlanType | null;
   subscription: SubscriptionType;
@@ -59,7 +56,6 @@ export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
 
   return {
     props: {
-      user,
       owner,
       plan,
       subscription,
@@ -69,7 +65,6 @@ export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
 });
 
 export default function AssistantsGallery({
-  user,
   owner,
   plan,
   subscription,
@@ -133,9 +128,6 @@ export default function AssistantsGallery({
     default:
       assertNever(orderBy);
   }
-
-  const [testModalAssistant, setTestModalAssistant] =
-    useState<LightAgentConfigurationType | null>(null);
 
   const [showDetails, setShowDetails] = useState<string | null>(null);
 
@@ -261,14 +253,6 @@ export default function AssistantsGallery({
         onClose={handleCloseAssistantDetails}
         mutateAgentConfigurations={mutateAgentConfigurations}
       />
-      {testModalAssistant && (
-        <TryAssistantModal
-          owner={owner}
-          user={user}
-          assistant={testModalAssistant}
-          onClose={() => setTestModalAssistant(null)}
-        />
-      )}
       <div className="pb-16 pt-6">
         <Page.Vertical gap="md" align="stretch">
           <div className="flex flex-row gap-2">
@@ -311,7 +295,6 @@ export default function AssistantsGallery({
                   onUpdate={() => {
                     void mutateAgentConfigurations();
                   }}
-                  setTestModalAssistant={setTestModalAssistant}
                 />
               ))}
             </div>

--- a/front/pages/w/[wId]/assistant/new.tsx
+++ b/front/pages/w/[wId]/assistant/new.tsx
@@ -54,6 +54,7 @@ export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
   owner: WorkspaceType;
   helper: LightAgentConfigurationType | null;
   gaTrackingId: string;
+  mentionedAgentId: string | null;
 }>(async (context, session) => {
   const auth = await Authenticator.fromSession(
     session,
@@ -73,6 +74,8 @@ export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
     };
   }
 
+  const mentionedAgentId = context.query.mention as string | null;
+
   const helper = await getAgentConfiguration(auth, "helper");
 
   return {
@@ -83,6 +86,7 @@ export const getServerSideProps = withDefaultGetServerSidePropsRequirements<{
       helper,
       subscription,
       gaTrackingId: GA_TRACKING_ID,
+      mentionedAgentId,
     },
   };
 });
@@ -94,6 +98,7 @@ export default function AssistantNew({
   helper,
   subscription,
   gaTrackingId,
+  mentionedAgentId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const router = useRouter();
   const [planLimitReached, setPlanLimitReached] = useState<boolean>(false);
@@ -505,6 +510,11 @@ export default function AssistantNew({
             owner={owner}
             onSubmit={handleSubmit}
             conversationId={conversation?.sId || null}
+            stickyMentions={
+              mentionedAgentId
+                ? [{ configurationId: mentionedAgentId }]
+                : undefined
+            }
           />
           <LimitReachedPopup
             planLimitReached={planLimitReached}


### PR DESCRIPTION
## Description
<img width="884" alt="Screenshot 2024-03-08 at 15 29 24" src="https://github.com/dust-tt/dust/assets/14199823/2a54df5b-ba94-45de-bf65-b7c866549c5d">


Users are confused -> they think this is how you talk to an assistant. They get frustrated because they leave the page and convo is gone forever.

This changes the behaviour to link to `/new` with an assitant mention pre-filled.

Also adds the play button for global agents (why not)

some context here too: https://dust4ai.slack.com/archives/C050A0S2Z7F/p1709908275742339

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
