### PR TITLE
Support workspace with SSO enforced

### DIFF
--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -395,6 +395,7 @@ export class Authenticator {
             ACTIVATE_ALL_FEATURES_DEV && isDevelopment()
               ? [...WHITELISTABLE_FEATURES]
               : this._flags,
+          ssoEnforced: this._workspace.ssoEnforced,
         }
       : null;
   }

--- a/front/lib/models/workspace.ts
+++ b/front/lib/models/workspace.ts
@@ -25,7 +25,7 @@ export class Workspace extends Model<
   declare name: string;
   declare description: string | null;
   declare segmentation: WorkspaceSegmentationType;
-  declare ssoEnforced: boolean;
+  declare ssoEnforced?: boolean;
   declare subscriptions: NonAttribute<Subscription[]>;
 }
 Workspace.init(

--- a/front/lib/models/workspace.ts
+++ b/front/lib/models/workspace.ts
@@ -25,6 +25,7 @@ export class Workspace extends Model<
   declare name: string;
   declare description: string | null;
   declare segmentation: WorkspaceSegmentationType;
+  declare ssoEnforced: boolean;
   declare subscriptions: NonAttribute<Subscription[]>;
 }
 Workspace.init(
@@ -62,6 +63,10 @@ Workspace.init(
     segmentation: {
       type: DataTypes.STRING,
       allowNull: true,
+    },
+    ssoEnforced: {
+      type: DataTypes.BOOLEAN,
+      defaultValue: false,
     },
   },
   {

--- a/types/src/front/user.ts
+++ b/types/src/front/user.ts
@@ -15,6 +15,7 @@ export type LightWorkspaceType = {
 
 export type WorkspaceType = LightWorkspaceType & {
   flags: WhitelistableFeature[];
+  ssoEnforced: boolean;
 };
 
 export type UserProviderType = "github" | "google" | null;

--- a/types/src/front/user.ts
+++ b/types/src/front/user.ts
@@ -15,7 +15,7 @@ export type LightWorkspaceType = {
 
 export type WorkspaceType = LightWorkspaceType & {
   flags: WhitelistableFeature[];
-  ssoEnforced: boolean;
+  ssoEnforced?: boolean;
 };
 
 export type UserProviderType = "github" | "google" | null;

--- a/types/src/front/workspace.ts
+++ b/types/src/front/workspace.ts
@@ -8,3 +8,15 @@ export interface WorkspaceEnterpriseConnection {
 }
 
 export type SupportedEnterpriseConnectionStrategies = "okta";
+export const supportedEnterpriseConnectionStrategies: SupportedEnterpriseConnectionStrategies[] =
+  ["okta"];
+
+export function isEnterpriseConnectionSub(
+  sub: string
+): sub is SupportedEnterpriseConnectionStrategies {
+  const [provider] = sub.split("|");
+
+  return supportedEnterpriseConnectionStrategies.includes(
+    provider as SupportedEnterpriseConnectionStrategies
+  );
+}


### PR DESCRIPTION
## Description

This PR introduces a new feature that allows workspace administrators to enforce Single Sign-On (SSO) for all users within their workspace. By enabling the SSO enforcement option, admins can ensure that every user logs in exclusively through the designated SSO provider.

This check needs to happen at the server side rendering time to ensure that the check applies anytime an admin update the settings.

This does not expose this setting yet in the UI. We first need to be able to merge accounts before doing so.

<img width="1203" alt="image" src="https://github.com/dust-tt/dust/assets/7428970/28bbe3c0-c7d4-4594-8268-d59df8d77d85">


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

This requires to run a migration to add the `ssoEnforced` field on the `Workspace` model.

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
