### PR TITLE
Improve enterprise connection sign up / login

### DIFF
--- a/front/lib/iam/provider.ts
+++ b/front/lib/iam/provider.ts
@@ -33,8 +33,7 @@ function isAuth0Session(session: unknown): session is Session {
 
 // We only expose generic types to ease phasing out.
 
-// Overrides the Auth0 type definition entirely, to only expose what we need.
-export type SessionWithUser = { user: ExternalUser };
+export type SessionWithUser = Session & { user: ExternalUser };
 
 export function isValidSession(
   session: Session | null

--- a/front/pages/api/auth/[auth0].ts
+++ b/front/pages/api/auth/[auth0].ts
@@ -3,10 +3,13 @@ import {
   handleAuth,
   handleCallback,
   handleLogin,
+  handleLogout,
   IdentityProviderError,
 } from "@auth0/nextjs-auth0";
 import type { AuthorizationParameters } from "@auth0/nextjs-auth0/dist/auth0-session";
 import type { NextApiRequest, NextApiResponse } from "next";
+
+import config from "@app/lib/api/config";
 
 export default handleAuth({
   login: handleLogin((req) => {
@@ -23,6 +26,7 @@ export default handleAuth({
 
     return {
       authorizationParams: defaultAuthorizationParams,
+      returnTo: "/api/login",
     };
   }),
   callback: async (req: NextApiRequest, res: NextApiResponse) => {
@@ -42,4 +46,10 @@ export default handleAuth({
       return res.redirect("/login-error");
     }
   },
+  logout: handleLogout((req) => {
+    return {
+      returnTo:
+        "query" in req ? (req.query.returnTo as string) : config.getAppUrl(),
+    };
+  }),
 });

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -125,12 +125,14 @@ async function handleEnterpriseSignUpFlow(
     }),
   ]);
 
-  console.log(">> activeMemberships:", activeMemberships);
-  console.log(">> workspace:", workspace);
-
-  // If active memberships exist or workspace does not exist, return early.
-  if (activeMemberships.length !== 0 || !workspace) {
+  // Early return if user is already a member of a workspace.
+  if (activeMemberships.length !== 0) {
     return { flow: null, workspace: null };
+  }
+
+  // Redirect to login error flow if workspace is not found.
+  if (!workspace) {
+    return { flow: "unauthorized", workspace: null };
   }
 
   const membership = await Membership.findOne({
@@ -140,7 +142,7 @@ async function handleEnterpriseSignUpFlow(
     },
   });
 
-  // Create membership if it does not exist
+  // Create membership if it does not exist.
   if (!membership) {
     await createAndLogMembership({
       workspace,


### PR DESCRIPTION
## Description

This PR separates the logic for verified domains and Enterprise connections. It introduces an Auth0 flow that adds a claim linking an Enterprise connection to an existing Dust workspace. This allows users to be added to the correct workspace without relying on verified domains and auto-join functionality.
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] Setup Auth0 flow to add the `workspaceId` claim.

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
