### PR TITLE
Enforce SSO control at signup / login

### DIFF
--- a/front/lib/iam/errors.ts
+++ b/front/lib/iam/errors.ts
@@ -1,0 +1,11 @@
+export class SSOEnforcedError extends Error {
+  constructor(message: string, readonly workspaceId: string) {
+    super(message);
+  }
+}
+
+export class AuthFlowError extends Error {
+  constructor(message: string) {
+    super(message);
+  }
+}

--- a/front/lib/iam/invitations.ts
+++ b/front/lib/iam/invitations.ts
@@ -1,7 +1,8 @@
 import type { Result } from "@dust-tt/types";
-import { Err, FrontApiError, Ok } from "@dust-tt/types";
+import { Err, Ok } from "@dust-tt/types";
 import { verify } from "jsonwebtoken";
 
+import { AuthFlowError } from "@app/lib/iam/errors";
 import type { User } from "@app/lib/models";
 import { MembershipInvitation } from "@app/lib/models";
 
@@ -9,7 +10,7 @@ const { DUST_INVITE_TOKEN_SECRET = "" } = process.env;
 
 export async function getPendingMembershipInvitationForToken(
   inviteToken: string | string[] | undefined
-): Promise<Result<MembershipInvitation | null, FrontApiError>> {
+): Promise<Result<MembershipInvitation | null, AuthFlowError>> {
   if (inviteToken && typeof inviteToken === "string") {
     const decodedToken = verify(inviteToken, DUST_INVITE_TOKEN_SECRET) as {
       membershipInvitationId: number;
@@ -23,10 +24,8 @@ export async function getPendingMembershipInvitationForToken(
     });
     if (!membershipInvite) {
       return new Err(
-        new FrontApiError(
-          "The invite token is invalid, please ask your admin to resend an invitation.",
-          400,
-          "invalid_request_error"
+        new AuthFlowError(
+          "The invite token is invalid, please ask your admin to resend an invitation."
         )
       );
     }

--- a/front/lib/iam/invitations.ts
+++ b/front/lib/iam/invitations.ts
@@ -1,4 +1,5 @@
-import { FrontApiError } from "@dust-tt/types";
+import type { Result } from "@dust-tt/types";
+import { Err, FrontApiError, Ok } from "@dust-tt/types";
 import { verify } from "jsonwebtoken";
 
 import type { User } from "@app/lib/models";
@@ -8,7 +9,7 @@ const { DUST_INVITE_TOKEN_SECRET = "" } = process.env;
 
 export async function getPendingMembershipInvitationForToken(
   inviteToken: string | string[] | undefined
-): Promise<MembershipInvitation | null> {
+): Promise<Result<MembershipInvitation | null, FrontApiError>> {
   if (inviteToken && typeof inviteToken === "string") {
     const decodedToken = verify(inviteToken, DUST_INVITE_TOKEN_SECRET) as {
       membershipInvitationId: number;
@@ -21,17 +22,19 @@ export async function getPendingMembershipInvitationForToken(
       },
     });
     if (!membershipInvite) {
-      throw new FrontApiError(
-        "The invite token is invalid, please ask your admin to resend an invitation.",
-        400,
-        "invalid_request_error"
+      return new Err(
+        new FrontApiError(
+          "The invite token is invalid, please ask your admin to resend an invitation.",
+          400,
+          "invalid_request_error"
+        )
       );
     }
 
-    return membershipInvite;
+    return new Ok(membershipInvite);
   }
 
-  return null;
+  return new Ok(null);
 }
 
 export async function markInvitationAsConsumed(

--- a/front/lib/iam/users.ts
+++ b/front/lib/iam/users.ts
@@ -92,7 +92,7 @@ export async function maybeUpdateFromExternalUser(
 
 export async function createOrUpdateUser(
   session: SessionWithUser
-): Promise<User> {
+): Promise<{ user: User; created: boolean }> {
   const { user: externalUser } = session;
 
   const user = await fetchUserFromSession(session);
@@ -122,7 +122,7 @@ export async function createOrUpdateUser(
 
     await user.save();
 
-    return user;
+    return { user, created: false };
   } else {
     const { firstName, lastName } = guessFirstandLastNameFromFullName(
       externalUser.name
@@ -150,6 +150,6 @@ export async function createOrUpdateUser(
       fullName: u.name,
     } satisfies UserType);
 
-    return u;
+    return { user: u, created: true };
   }
 }

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -11,10 +11,7 @@ import {
 } from "@app/lib/iam/invitations";
 import { getActiveMembershipsForUser } from "@app/lib/iam/memberships";
 import type { SessionWithUser } from "@app/lib/iam/provider";
-import {
-  getUserFromSession,
-  statisfiesEnforceEntrepriseConnection,
-} from "@app/lib/iam/session";
+import { getUserFromSession } from "@app/lib/iam/session";
 import { createOrUpdateUser } from "@app/lib/iam/users";
 import {
   createWorkspace,
@@ -322,7 +319,7 @@ async function handler(
     const membershipInvite = membershipInviteRes.value;
 
     // Login flow: first step is to attempt to find the user.
-    const user = await createOrUpdateUser(session);
+    const { created: userCreated, user } = await createOrUpdateUser(session);
 
     // Prioritize enterprise connections.
     if (enterpriseConnectionWorkspaceId) {
@@ -347,7 +344,7 @@ async function handler(
           throw result.error;
         }
 
-        if (user && user.isNewRecord) {
+        if (userCreated) {
           await user.destroy();
         }
 

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -346,6 +346,7 @@ async function handler(
         });
       }
 
+      // Delete newly created user if SSO is mandatory.
       if (userCreated) {
         await user.destroy();
       }

--- a/types/src/front/lib/error.ts
+++ b/types/src/front/lib/error.ts
@@ -96,19 +96,3 @@ export type APIErrorResponse = {
 };
 
 export type WithAPIErrorReponse<T> = T | APIErrorResponse;
-
-export class FrontApiError extends Error {
-  constructor(
-    message: string,
-    readonly statusCode: number,
-    readonly type: APIErrorType
-  ) {
-    super(message);
-  }
-}
-
-export class SSOEnforcedError extends Error {
-  constructor(message: string, readonly workspaceId: string) {
-    super(message);
-  }
-}

--- a/types/src/front/lib/error.ts
+++ b/types/src/front/lib/error.ts
@@ -106,3 +106,9 @@ export class FrontApiError extends Error {
     super(message);
   }
 }
+
+export class SSOEnforcedError extends Error {
+  constructor(message: string, readonly workspaceId: string) {
+    super(message);
+  }
+}


### PR DESCRIPTION
## Description

This PR goes one step further than https://github.com/dust-tt/dust/pull/4227 by enforcing SSO during login/signup. If SSO is required for a matching workspace, non-sso accounts will be redirected to the SSO login flow when signing up or logging in. This is needed to short circuit user creation and all related update on a workspace pricing.  
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [x] Whitelist logout url for `sso-enforced`.

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
