### PR TITLE
fix: hide Mistral models from LLM block

### DIFF
--- a/front/pages/api/w/[wId]/providers/[pId]/models.ts
+++ b/front/pages/api/w/[wId]/providers/[pId]/models.ts
@@ -235,6 +235,10 @@ async function handler(
           return;
 
         case "mistral":
+          if (!chat) {
+            res.status(200).json({ models: [] });
+            return;
+          }
           const mistralModelRes = await fetch(
             "https://api.mistral.ai/v1/models",
             {


### PR DESCRIPTION
## Description

We don't actually implement the `generate` LLM block interface for mistral models, so using an `LLM` block with a mistral model just panicks the thread and the dust app is stuck.

This fix hides mistral models from the LLM block.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
