### PR TITLE
Do not sync freshly synced GDrive file

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/file.ts
+++ b/connectors/src/connectors/google_drive/temporal/file.ts
@@ -46,7 +46,8 @@ export async function syncOneFile(
     },
   });
 
-  // Early return if lastSeenTs is greater than activity start, indicating probable failure.
+  // Early return if lastSeenTs is greater than workflow start.
+  // This allows avoiding resyncing already-synced documents in case of activity failure
   if (fileInDb?.lastSeenTs && fileInDb.lastSeenTs > new Date(startSyncTs)) {
     return true;
   }

--- a/connectors/src/connectors/google_drive/temporal/file.ts
+++ b/connectors/src/connectors/google_drive/temporal/file.ts
@@ -46,6 +46,11 @@ export async function syncOneFile(
     },
   });
 
+  // Early return if lastSeenTs is greater than activity start, indicating probable failure.
+  if (fileInDb?.lastSeenTs && fileInDb.lastSeenTs > new Date(startSyncTs)) {
+    return true;
+  }
+
   if (fileInDb?.skipReason) {
     logger.info(
       {


### PR DESCRIPTION
## Description

This PR addresses Google Drive Spreadsheet API rate limiting issues. We hit the limit due to parallel file processing and fast table upserting. The problem is we keep reprocessing the same files without progress. This change adds an early return to skip files synced in previous runs of the same activity.
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
