### PR TITLE
[Connectors] Fix: github code files should have themselves as parent

### DIFF
--- a/connectors/src/connectors/github/lib/github_api.ts
+++ b/connectors/src/connectors/github/lib/github_api.ts
@@ -789,7 +789,7 @@ export async function processRepository({
           sizeBytes: size,
           documentId,
           parentInternalId,
-          parents: parents.map((p) => p.internalId),
+          parents: [documentId, ...parents.map((p) => p.internalId)],
           localFilePath: file,
         });
 


### PR DESCRIPTION
First step to fix https://github.com/dust-tt/tasks/issues/520

Next step : migration to resync existing repos (PR to follow shortly)