### PR TITLE
[Confluence] Swallow occasional 500 errors from confluence api

### DIFF
--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -1,7 +1,6 @@
+import { ConfluenceClientError } from "@dust-tt/types";
 import { isLeft } from "fp-ts/Either";
 import * as t from "io-ts";
-
-import { HTTPError } from "@connectors/lib/error";
 
 const CatchAllCodec = t.record(t.string, t.unknown); // Catch-all for unknown properties.
 
@@ -164,9 +163,13 @@ export class ConfluenceClient {
     });
 
     if (!response.ok) {
-      throw new HTTPError(
+      throw new ConfluenceClientError(
         `Confluence API responded with status: ${response.status}: ${this.apiUrl}${endpoint}`,
-        response.status
+        {
+          type: "http_response_error",
+          status: response.status,
+          data: { url: `${this.apiUrl}${endpoint}`, response },
+        }
       );
     }
 
@@ -174,7 +177,9 @@ export class ConfluenceClient {
     const result = codec.decode(responseBody);
 
     if (isLeft(result)) {
-      throw new Error("Response validation failed");
+      throw new ConfluenceClientError("Response validation failed", {
+        type: "validation_error",
+      });
     }
 
     return result.right;
@@ -195,9 +200,13 @@ export class ConfluenceClient {
     });
 
     if (!response.ok) {
-      throw new HTTPError(
+      throw new ConfluenceClientError(
         `Confluence API responded with status: ${response.status}: ${this.apiUrl}${endpoint}`,
-        response.status
+        {
+          type: "http_response_error",
+          status: response.status,
+          data: { url: `${this.apiUrl}${endpoint}`, response },
+        }
       );
     }
 
@@ -209,7 +218,9 @@ export class ConfluenceClient {
     const result = codec.decode(responseBody);
 
     if (isLeft(result)) {
-      throw new Error("Response validation failed");
+      throw new ConfluenceClientError("Response validation failed", {
+        type: "validation_error",
+      });
     }
 
     return result.right;

--- a/connectors/src/connectors/confluence/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/confluence/temporal/cast_known_errors.ts
@@ -1,0 +1,36 @@
+import type {
+  ActivityExecuteInput,
+  ActivityInboundCallsInterceptor,
+  Next,
+} from "@temporalio/worker";
+
+function isConfluenceError(err: unknown): err is { statusCode: number } {
+  return (
+    err instanceof Error &&
+    typeof (err as { statusCode?: unknown }).statusCode === "number" &&
+    err.message.includes("Confluence")
+  );
+}
+
+export class ConfluenceCastKnownErrorsInterceptor
+  implements ActivityInboundCallsInterceptor
+{
+  async execute(
+    input: ActivityExecuteInput,
+    next: Next<ActivityInboundCallsInterceptor, "execute">
+  ): Promise<unknown> {
+    try {
+      return await next(input);
+    } catch (err: unknown) {
+      if (isConfluenceError(err) && err.statusCode === 500) {
+        throw {
+          __is_dust_error: true,
+          message: "Confluence Internal Error",
+          type: "confluence_internal_error",
+          error: err,
+        };
+      }
+      throw err;
+    }
+  }
+}

--- a/connectors/src/connectors/confluence/temporal/worker.ts
+++ b/connectors/src/connectors/confluence/temporal/worker.ts
@@ -8,6 +8,7 @@ import * as sync_status from "@connectors/lib/sync_status";
 import { getTemporalWorkerConnection } from "@connectors/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@connectors/lib/temporal_monitoring";
 import logger from "@connectors/logger/logger";
+import { ConfluenceCastKnownErrorsInterceptor } from "@connectors/connectors/confluence/temporal/cast_known_errors";
 
 export async function runConfluenceWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();
@@ -23,6 +24,7 @@ export async function runConfluenceWorker() {
         (ctx: Context) => {
           return new ActivityInboundLogInterceptor(ctx, logger);
         },
+        () => new ConfluenceCastKnownErrorsInterceptor(),
       ],
     },
     bundlerOptions: {

--- a/connectors/src/connectors/confluence/temporal/worker.ts
+++ b/connectors/src/connectors/confluence/temporal/worker.ts
@@ -3,12 +3,12 @@ import { Worker } from "@temporalio/worker";
 import TsconfigPathsPlugin from "tsconfig-paths-webpack-plugin";
 
 import * as activities from "@connectors/connectors/confluence/temporal/activities";
+import { ConfluenceCastKnownErrorsInterceptor } from "@connectors/connectors/confluence/temporal/cast_known_errors";
 import { QUEUE_NAME } from "@connectors/connectors/confluence/temporal/config";
 import * as sync_status from "@connectors/lib/sync_status";
 import { getTemporalWorkerConnection } from "@connectors/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@connectors/lib/temporal_monitoring";
 import logger from "@connectors/logger/logger";
-import { ConfluenceCastKnownErrorsInterceptor } from "@connectors/connectors/confluence/temporal/cast_known_errors";
 
 export async function runConfluenceWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();

--- a/types/src/connectors/confluence.ts
+++ b/types/src/connectors/confluence.ts
@@ -3,3 +3,22 @@ import { ModelId } from "../shared/model_id";
 export function makeConfluenceSyncWorkflowId(connectorId: ModelId) {
   return `confluence-sync-${connectorId}`;
 }
+
+export class ConfluenceClientError extends Error {
+  readonly type: "validation_error" | "http_response_error";
+  readonly status?: number;
+  readonly data?: object;
+  constructor(
+    message: string,
+    error_data: (
+      | { type: "http_response_error"; status: number }
+      | { type: "validation_error" }
+    ) & { data?: object }
+  ) {
+    super(message);
+    this.type = error_data.type;
+    this.status =
+      error_data.type === "http_response_error" ? error_data.status : undefined;
+    this.data = error_data.data;
+  }
+}


### PR DESCRIPTION
Related
[thread](https://dust4ai.slack.com/archives/C05F84CFP0E/p1710226529834279)

Followed the convention of github/notion/google_drive with cast_known_errors

@flvndvd Confirm it looks fine to swallow those for now and rely on the activity failure monitor?


