### PR TITLE
enh: remove link to gallery in /new

### DIFF
--- a/front/pages/w/[wId]/assistant/new.tsx
+++ b/front/pages/w/[wId]/assistant/new.tsx
@@ -1,7 +1,6 @@
 import {
   AssistantPreview,
   Avatar,
-  BookOpenIcon,
   Button,
   ChatBubbleBottomCenterTextIcon,
   CloudArrowLeftRightIcon,
@@ -303,18 +302,6 @@ export default function AssistantNew({
                               }}
                             />
                           </div>
-                          {!isBuilder && (
-                            <div>
-                              <Link href={`/w/${owner.sId}/assistant/gallery`}>
-                                <Button
-                                  variant="primary"
-                                  icon={BookOpenIcon}
-                                  size="xs"
-                                  label="Explore the Assistants Gallery"
-                                />
-                              </Link>
-                            </div>
-                          )}
                         </div>
                       </div>
                     </div>


### PR DESCRIPTION
## Description

Replaces https://github.com/dust-tt/dust/pull/4225.
After chatting with @Duncid, we decided to remove to avoid people ending up using "TRY" mode (in modal) from the gallery instead of the intended path.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
