### PR TITLE
fix: allow copy md table with empty cells

### DIFF
--- a/front/components/assistant/RenderMessageMarkdown.tsx
+++ b/front/components/assistant/RenderMessageMarkdown.tsx
@@ -349,7 +349,7 @@ function TableBlock({ children }: { children: React.ReactNode }) {
         return getNodeText(node.props.children);
       }
 
-      throw new Error(`Unexpected node type: ${typeof node}`);
+      return "";
     };
 
     const [headNode, bodyNode] = Array.from(children as [any, any]);


### PR DESCRIPTION
## Description

fixes https://github.com/dust-tt/dust/issues/4256

Mardown table copy button doesn't work when the table contains empty cells.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
