### PR TITLE
enh(gdrive incremental sync): cancel running activity on timeout

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -34,6 +34,7 @@ import {
   GoogleDriveWebhook,
 } from "@connectors/lib/models/google_drive";
 import { syncFailed } from "@connectors/lib/sync_status";
+import { heartbeat } from "@connectors/lib/temporal";
 import mainLogger from "@connectors/logger/logger";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
@@ -294,6 +295,8 @@ export async function incrementalSync(
       `Got changes.`
     );
     for (const change of changesRes.data.changes) {
+      await heartbeat();
+
       if (change.changeType !== "file" || !change.file) {
         continue;
       }
@@ -356,6 +359,7 @@ export async function incrementalSync(
 
         continue;
       }
+
       await syncOneFile(
         connectorId,
         authCredentials,

--- a/connectors/src/connectors/google_drive/temporal/workflows.ts
+++ b/connectors/src/connectors/google_drive/temporal/workflows.ts
@@ -30,6 +30,7 @@ const {
 // Hotfix: increase timeout on incrementalSync to avoid restarting ongoing activities
 const { incrementalSync } = proxyActivities<typeof activities>({
   startToCloseTimeout: "60 minutes",
+  heartbeatTimeout: "5 minutes",
 });
 
 // Temporarily increase timeout on syncFiles until table upsertion is moved to the upsert queue.

--- a/connectors/src/lib/temporal.ts
+++ b/connectors/src/lib/temporal.ts
@@ -1,4 +1,5 @@
 import type { ModelId } from "@dust-tt/types";
+import { Context } from "@temporalio/activity";
 import type { ConnectionOptions } from "@temporalio/client";
 import { Client, Connection, WorkflowNotFoundError } from "@temporalio/client";
 import { NativeConnection } from "@temporalio/worker";
@@ -128,4 +129,11 @@ export async function terminateAllWorkflowsForConnectorId(
   }
 
   return;
+}
+
+// This function allows to heartbeat back to the temporal workflow, but also
+// awaits a temporal sleep(0), which allows to throw an exception if the activity should be cancelled.
+export async function heartbeat() {
+  Context.current().heartbeat();
+  await Context.current().sleep(0);
 }


### PR DESCRIPTION
## Description

### The problem

Today, when a workflow is terminated/cancelled or when an activity runs longer than its `startToCloseTimeout`, the activity is considered failed/cancelled on temporal's side, but the actual process continues to run on the worker. This is because our activities currently only communicate with the temporal server when they begin and when they end, so temporal cannot communicate them when they need to stop their work.

This is an issue:
- long activities that timeout might run for a veeeeeery long time on the worker, consuming resources, doing API calls, and squatting a worker slot (while temporal is already retrying them)
- activites with a short timeout, when they timeout, can be running multiple times concurrently because they are being retried immediately after timing out (but original execution i s still actually running on the worker). These take worker slots as well.

### the solution

Temporal has something that is called a `heartbeat`. This is used for 2 reasons:
- let temporal know that the activity is still running
- let the activity know if it got "cancelled" (timed out or parent workflow cancelled / terminated)

When we import activities in the workflow, we can set a `heartbeatTimeout`: if the activity doesn't send any heartbeat for longer than this duration, the activity will be considered as failed by temporal.

in practice, to send a heartbeat, an activity must call `Context.current().heartbeat()`. But this function doesn't directly send a heartbeat: instead, **it queues a heartbeat**. Indeed, heartbeats in temporal are throttled using `heartbeatTimeout`. If `heartbeatTimeout` is 100ms, then the activity will send at most one heartbeat every 100ms, even if `Context.current().heartbeat()` was called many times during the period. It's also important to not that even if the activity is cancelled, calling `Context.current().heartbeat()` will not throw any exception. When the heartbeat actually happens (which happens when the "heartbeat queue" next execution takes place, not upon calling `Context.current().heartbeat()`), the information that the activity is cancelled will start being available in the activity's context.
This information is accessible is two ways:
- `Context.current().cancelled` -> this promise never resolves, but rejects if the activity is marked as cancelled. it's not super practical to use, because awaiting it is blocking.
-  `Context.current().sleep()` will reject


For this reason, I am introducing this helper:
```
// This function allows to heartbeat back to the temporal workflow, but also
// awaits a temporal sleep(0), which allows to throw an exception if the activity should be cancelled.
export async function heartbeat() {
  Context.current().heartbeat();
  await Context.current().sleep(0);
}
```

This can be awaited instead of `Context.current().heartbeat()` in order to heartbeat but also get an exception if the activity is timed-out. 
I have no idea why temporal doesn't provide something like this out of the box.

It's important to note that activity cancellation will be effective on the call to `heartbeat` that immediately follows the first temporal heartbeat (remember, this is throttled by `heartbeatTimeout`) after the activity was cancelled. 
So picking a short `heartbeatTimeout` is important, if the `heartbeatTimeout` is 30 minutes, the activity might spin in the void for more than 30 minutes before stopping.

## Risk

Unless API calls to Gdrive take more than 5 minutes we should be fine.


## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
