### PR TITLE
enh(gdrive): make all activities heartbeat

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/workflows.ts
+++ b/connectors/src/connectors/google_drive/temporal/workflows.ts
@@ -36,12 +36,14 @@ const { incrementalSync } = proxyActivities<typeof activities>({
 // Temporarily increase timeout on syncFiles until table upsertion is moved to the upsert queue.
 const { syncFiles } = proxyActivities<typeof activities>({
   startToCloseTimeout: "30 minutes",
+  heartbeatTimeout: "5 minutes",
 });
 
 const { reportInitialSyncProgress, syncSucceeded } = proxyActivities<
   typeof sync_status
 >({
-  startToCloseTimeout: "10 minutes",
+  startToCloseTimeout: "5 minutes",
+  heartbeatTimeout: "5 minutes",
 });
 
 export async function googleDriveFullSync(

--- a/connectors/src/lib/sync_status.ts
+++ b/connectors/src/lib/sync_status.ts
@@ -6,6 +6,7 @@ import type {
 
 import type { Result } from "@connectors/lib/result";
 import { Err, Ok } from "@connectors/lib/result";
+import { heartbeat } from "@connectors/lib/temporal";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 
 async function syncFinished({
@@ -56,7 +57,7 @@ export async function reportInitialSyncProgress(
     firstSyncProgress: progress,
     lastSyncSuccessfulTime: null,
   });
-
+  await heartbeat();
   return new Ok(undefined);
 }
 
@@ -68,7 +69,7 @@ export async function syncSucceeded(connectorId: ModelId, at?: Date) {
   if (!at) {
     at = new Date();
   }
-
+  await heartbeat();
   return syncFinished({
     connectorId: connectorId,
     status: "succeeded",


### PR DESCRIPTION
## Description

For the reasons outlined in https://github.com/dust-tt/dust/pull/4272, activities should heartbeat.

We also currently have no visibility on how many activities actually time out. So I am working on ensuring every activity heartbeats.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
