### PR TITLE
Support trial on subscription

### DIFF
--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -431,6 +431,7 @@ async function handler(
           // - when the number of seats changes for a metered billing.
           // - when the subscription is canceled by the user: it is ended at the of the billing period, and we will receive a "customer.subscription.deleted" event.
           // - when the subscription is activated again after being canceled but before the end of the billing period.
+          // - when trial expires, and the subscription transitions to a paid plan.
           logger.info(
             { event },
             "[Stripe Webhook] Received customer.subscription.updated event."
@@ -440,6 +441,27 @@ async function handler(
           if (!previousAttributes) break; // should not happen by definition of the subscription.updated event
 
           if (
+            stripeSubscription.status === "active" &&
+            "status" in previousAttributes &&
+            previousAttributes.status === "trialing"
+          ) {
+            const subscription = await Subscription.findOne({
+              where: { stripeSubscriptionId: stripeSubscription.id },
+              include: [Workspace],
+            });
+            if (!subscription) {
+              return apiError(req, res, {
+                status_code: 500,
+                api_error: {
+                  type: "internal_server_error",
+                  message:
+                    "[Stripe Webhook] canceling subscription: Subscription not found.",
+                },
+              });
+            }
+
+            await subscription.update({ status: "active" });
+          } else if (
             // The subscription is canceled (but not yet ended) or reactivated
             stripeSubscription.status === "active" &&
             "cancel_at_period_end" in previousAttributes

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -447,7 +447,6 @@ async function handler(
           ) {
             const subscription = await Subscription.findOne({
               where: { stripeSubscriptionId: stripeSubscription.id },
-              include: [Workspace],
             });
             if (!subscription) {
               return apiError(req, res, {

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -454,7 +454,7 @@ async function handler(
                 api_error: {
                   type: "internal_server_error",
                   message:
-                    "[Stripe Webhook] canceling subscription: Subscription not found.",
+                    "[Stripe Webhook] Failed to update subscription after trial ended: Subscription not found.",
                 },
               });
             }

--- a/types/src/front/plan.ts
+++ b/types/src/front/plan.ts
@@ -40,7 +40,7 @@ export const PAID_BILLING_TYPES = [
 export type FreeBillingType = (typeof FREE_BILLING_TYPES)[number];
 export type PaidBillingType = (typeof PAID_BILLING_TYPES)[number];
 
-export const SUBSCRIPTION_STATUSES = ["active", "ended"] as const;
+export const SUBSCRIPTION_STATUSES = ["active", "ended", "trialing"] as const;
 export type SubscriptionStatusType = (typeof SUBSCRIPTION_STATUSES)[number];
 
 export type PlanType = {


### PR DESCRIPTION
## Description

This PR resolves https://github.com/dust-tt/dust/issues/4276.

This update enables our system to handle Stripe webhooks indicating the end of a trial period. It's important as we plan to enforce usage limits for free trials. With this update we can simply rely on the subscription to check if a workspace is in trial or not.
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
