### PR TITLE
Introduce FREE_NO_PLAN. Make FREE_TEST_PLAN an in-db plan

### DIFF
--- a/front/components/poke/plans/form.tsx
+++ b/front/components/poke/plans/form.tsx
@@ -100,6 +100,7 @@ export const toPlanType = (editingPlan: EditingPlanType): PlanType => {
       users: {
         maxUsers: parseMaybeNumber(editingPlan.maxUsers),
       },
+      canUseProduct: true,
     },
     billingType: editingPlan.billingType,
     trialPeriodDays: parseMaybeNumber(editingPlan.trialPeriodDays),

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -37,7 +37,7 @@ import {
   Workspace,
 } from "@app/lib/models";
 import type { PlanAttributes } from "@app/lib/plans/free_plans";
-import { FREE_TEST_PLAN_DATA } from "@app/lib/plans/free_plans";
+import { FREE_NO_PLAN_DATA } from "@app/lib/plans/free_plans";
 import { isUpgraded } from "@app/lib/plans/plan_codes";
 import { getTrialVersionForPlan, isTrial } from "@app/lib/plans/trial";
 import { new_id } from "@app/lib/utils";
@@ -541,7 +541,7 @@ export async function subscriptionForWorkspace(
   });
 
   // Default values when no subscription
-  let plan: PlanAttributes = FREE_TEST_PLAN_DATA;
+  let plan: PlanAttributes = FREE_NO_PLAN_DATA;
   let startDate = null;
   let endDate = null;
 
@@ -567,7 +567,7 @@ export async function subscriptionForWorkspace(
 
   return {
     status: activeSubscription?.status ?? "active",
-    subscriptionId: activeSubscription?.sId || null,
+    sId: activeSubscription?.sId || null,
     stripeSubscriptionId: activeSubscription?.stripeSubscriptionId || null,
     stripeCustomerId: activeSubscription?.stripeCustomerId || null,
     startDate: startDate?.getTime() || null,
@@ -603,6 +603,7 @@ export async function subscriptionForWorkspace(
         users: {
           maxUsers: plan.maxUsersInWorkspace,
         },
+        canUseProduct: plan.canUseProduct,
       },
       trialPeriodDays: plan.trialPeriodDays,
     },

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -42,6 +42,7 @@ import { isUpgraded } from "@app/lib/plans/plan_codes";
 import { getTrialVersionForPlan, isTrial } from "@app/lib/plans/trial";
 import { new_id } from "@app/lib/utils";
 import logger from "@app/logger/logger";
+
 import { renderSubscriptionFromModels } from "./plans/subscription";
 
 const {

--- a/front/lib/models/plan.ts
+++ b/front/lib/models/plan.ts
@@ -34,6 +34,7 @@ export class Plan extends Model<
   declare stripeProductId: string | null;
   declare billingType: FreeBillingType | PaidBillingType;
   declare trialPeriodDays: number;
+  declare canUseProduct: boolean;
 
   // workspace limitations
   declare maxMessages: number;
@@ -91,6 +92,11 @@ Plan.init(
       type: DataTypes.INTEGER,
       allowNull: false,
       defaultValue: 0,
+    },
+    canUseProduct: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: true,
     },
     maxMessages: {
       type: DataTypes.INTEGER,

--- a/front/lib/plans/enterprise_plans.ts
+++ b/front/lib/plans/enterprise_plans.ts
@@ -37,4 +37,5 @@ export const ENT_PLAN_FAKE_DATA: PlanAttributes = {
   maxDataSourcesDocumentsCount: -1,
   maxDataSourcesDocumentsSizeMb: 2,
   trialPeriodDays: 0,
+  canUseProduct: true,
 };

--- a/front/lib/plans/free_plans.ts
+++ b/front/lib/plans/free_plans.ts
@@ -2,6 +2,7 @@ import type { Attributes } from "sequelize";
 
 import { Plan } from "@app/lib/models";
 import {
+  FREE_NO_PLAN_CODE,
   FREE_TEST_PLAN_CODE,
   FREE_UPGRADED_PLAN_CODE,
 } from "@app/lib/plans/plan_codes";
@@ -14,22 +15,24 @@ export type PlanAttributes = Omit<
 /**
  * We have 3 categories of plans:
  * - Free: plans with no paid subscription.
- * - Pro: plans with a paid subscription, not tailored. -> i.e. the same plan is used by all Pro workspaces.
- * - Entreprise: plans with a paid subscription, tailored to the needs of the entreprise. -> i.e. we will have one plan per "Entreprise".
+ * - Pro: plans with a paid subscription, not tailored. -> i.e. the same plan is used by all Pro
+ *        workspaces.
+ * - Entreprise: plans with a paid subscription, tailored to the needs of the entreprise.
+ *               -> i.e. we will have one plan per "Entreprise".
  *
  * This file about Free plans.
  */
 
 /**
- * FREE_TEST plan is our default plan: this is the plan used by all workspaces until they subscribe to a plan.
- * It is not stored in the database (as we don't create a subsription).
+ * FREE_NO_PLAN is the plan used for workspaces that are being created and have not yet subscribed
+ * to a plan (card has not been entered yet for free trial). It prevents using the product entirely.
  */
-export const FREE_TEST_PLAN_DATA: PlanAttributes = {
-  code: FREE_TEST_PLAN_CODE,
-  name: "Free",
+export const FREE_NO_PLAN_DATA: PlanAttributes = {
+  code: FREE_NO_PLAN_CODE,
+  name: "No Plan",
   stripeProductId: null,
   billingType: "free",
-  maxMessages: 50,
+  maxMessages: 0,
   maxUsersInWorkspace: 1,
   isSlackbotAllowed: false,
   isManagedConfluenceAllowed: false,
@@ -39,17 +42,39 @@ export const FREE_TEST_PLAN_DATA: PlanAttributes = {
   isManagedGithubAllowed: false,
   isManagedIntercomAllowed: false,
   isManagedWebCrawlerAllowed: false,
-  maxDataSourcesCount: 5,
-  maxDataSourcesDocumentsCount: 10,
-  maxDataSourcesDocumentsSizeMb: 2,
+  maxDataSourcesCount: 0,
+  maxDataSourcesDocumentsCount: 0,
+  maxDataSourcesDocumentsSizeMb: 0,
   trialPeriodDays: 0,
+  canUseProduct: false,
 };
 
 /**
- * Other FREE plans are stored in the database.
+ * FREE plans are stored in the database.
  * We can update existing plans or add new one but never remove anything from this list.
  */
 const FREE_PLANS_DATA: PlanAttributes[] = [
+  {
+    code: FREE_TEST_PLAN_CODE,
+    name: "Free",
+    stripeProductId: null,
+    billingType: "free",
+    maxMessages: 50,
+    maxUsersInWorkspace: 1,
+    isSlackbotAllowed: false,
+    isManagedConfluenceAllowed: false,
+    isManagedSlackAllowed: false,
+    isManagedNotionAllowed: false,
+    isManagedGoogleDriveAllowed: false,
+    isManagedGithubAllowed: false,
+    isManagedIntercomAllowed: false,
+    isManagedWebCrawlerAllowed: false,
+    maxDataSourcesCount: 5,
+    maxDataSourcesDocumentsCount: 10,
+    maxDataSourcesDocumentsSizeMb: 2,
+    trialPeriodDays: 0,
+    canUseProduct: true,
+  },
   {
     code: FREE_UPGRADED_PLAN_CODE,
     name: "Free Trial",
@@ -69,6 +94,7 @@ const FREE_PLANS_DATA: PlanAttributes[] = [
     maxDataSourcesDocumentsCount: -1,
     maxDataSourcesDocumentsSizeMb: 2,
     trialPeriodDays: 0,
+    canUseProduct: true,
   },
 ];
 

--- a/front/lib/plans/plan_codes.ts
+++ b/front/lib/plans/plan_codes.ts
@@ -1,6 +1,7 @@
 import type { PlanType } from "@dust-tt/types";
 
 // Current free plans:
+export const FREE_NO_PLAN_CODE = "FREE_NO_PLAN";
 export const FREE_UPGRADED_PLAN_CODE = "FREE_UPGRADED_PLAN";
 export const FREE_TEST_PLAN_CODE = "FREE_TEST_PLAN";
 export const TRIAL_PLAN_CODE = "TRIAL_PLAN_CODE";

--- a/front/lib/plans/pro_plans.ts
+++ b/front/lib/plans/pro_plans.ts
@@ -2,8 +2,7 @@ import type { Attributes } from "sequelize";
 
 import { isDevelopment } from "@app/lib/development";
 import { Plan } from "@app/lib/models";
-
-import { PRO_PLAN_SEAT_29_CODE } from "./plan_codes";
+import { PRO_PLAN_SEAT_29_CODE } from "@app/lib/plans/plan_codes";
 
 export type PlanAttributes = Omit<
   Attributes<Plan>,
@@ -47,6 +46,7 @@ if (isDevelopment()) {
     maxDataSourcesDocumentsCount: -1,
     maxDataSourcesDocumentsSizeMb: 2,
     trialPeriodDays: 0,
+    canUseProduct: true,
   });
 }
 

--- a/front/migrations/20240314_backfill_free_plan_subscriptions.ts
+++ b/front/migrations/20240314_backfill_free_plan_subscriptions.ts
@@ -1,0 +1,53 @@
+import { QueryTypes, Sequelize } from "sequelize";
+
+import { internalSubscribeWorkspaceToFreeTestPlan } from "@app/lib/plans/subscription";
+import logger from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+
+const { FRONT_DATABASE_URI } = process.env;
+
+interface WorkspaceRow {
+  id: number;
+  sId: string;
+  name: string;
+}
+
+makeScript({}, async ({ execute }) => {
+  const front_sequelize = new Sequelize(FRONT_DATABASE_URI as string, {
+    logging: false,
+  });
+
+  // Find all workspaces without subscriptions.
+  const workspaces = await front_sequelize.query<WorkspaceRow>(
+    `SELECT "workspaces"."id", "workspaces"."sId", "workspaces"."name"
+       FROM "workspaces"
+       LEFT JOIN "subscriptions" ON "workspaces"."id" = "subscriptions"."workspaceId"
+       WHERE "subscriptions"."id" IS NULL`,
+    { type: QueryTypes.SELECT }
+  );
+
+  const chunks: WorkspaceRow[][] = [];
+  for (let i = 0; i < workspaces.length; i += 16) {
+    chunks.push(workspaces.slice(i, i + 16));
+  }
+
+  for (let i = 0; i < chunks.length; i++) {
+    const chunk = chunks[i];
+    await Promise.all(
+      chunk.map((w) => {
+        return (async () => {
+          logger.info(
+            `Subscribing workspace ${w.sId} to FREE_TEST_PLAN [execute: ${execute}]`
+          );
+
+          if (execute) {
+            // This will create a new Subscription object for the FREE_TEST_PLAN.
+            await internalSubscribeWorkspaceToFreeTestPlan({
+              workspaceId: w.sId,
+            });
+          }
+        })();
+      })
+    );
+  }
+});

--- a/front/pages/api/create-new-workspace.ts
+++ b/front/pages/api/create-new-workspace.ts
@@ -56,6 +56,7 @@ async function handler(
     userId: user.id,
     role: "admin",
   });
+
   await internalSubscribeWorkspaceToFreeTestPlan({
     workspaceId: workspace.sId,
   });

--- a/front/pages/api/poke/plans.ts
+++ b/front/pages/api/poke/plans.ts
@@ -8,6 +8,7 @@ import Stripe from "stripe";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { Plan } from "@app/lib/models";
 import { getProduct } from "@app/lib/plans/stripe";
+import { renderPlanFromModel } from "@app/lib/plans/subscription";
 import { apiError, withLogging } from "@app/logger/withlogging";
 
 export const PlanTypeSchema = t.type({
@@ -79,40 +80,9 @@ async function handler(
   switch (req.method) {
     case "GET":
       const planModels = await Plan.findAll({ order: [["createdAt", "ASC"]] });
-      const plans: PlanType[] = planModels.map((plan) => ({
-        code: plan.code,
-        name: plan.name,
-        stripeProductId: plan.stripeProductId,
-        status: "active",
-        limits: {
-          assistant: {
-            isSlackBotAllowed: plan.isSlackbotAllowed,
-            maxMessages: plan.maxMessages,
-          },
-          connections: {
-            isConfluenceAllowed: plan.isManagedConfluenceAllowed,
-            isSlackAllowed: plan.isManagedSlackAllowed,
-            isNotionAllowed: plan.isManagedNotionAllowed,
-            isGoogleDriveAllowed: plan.isManagedGoogleDriveAllowed,
-            isGithubAllowed: plan.isManagedGithubAllowed,
-            isIntercomAllowed: plan.isManagedIntercomAllowed,
-            isWebCrawlerAllowed: plan.isManagedWebCrawlerAllowed,
-          },
-          dataSources: {
-            count: plan.maxDataSourcesCount,
-            documents: {
-              count: plan.maxDataSourcesDocumentsCount,
-              sizeMb: plan.maxDataSourcesDocumentsSizeMb,
-            },
-          },
-          users: {
-            maxUsers: plan.maxUsersInWorkspace,
-          },
-          canUseProduct: plan.canUseProduct,
-        },
-        billingType: plan.billingType,
-        trialPeriodDays: plan.trialPeriodDays,
-      }));
+      const plans: PlanType[] = planModels.map((plan) =>
+        renderPlanFromModel({ plan })
+      );
 
       const stripeProductIds = plans
         .filter(

--- a/front/pages/api/poke/plans.ts
+++ b/front/pages/api/poke/plans.ts
@@ -37,6 +37,7 @@ export const PlanTypeSchema = t.type({
     users: t.type({
       maxUsers: t.number,
     }),
+    canUseProduct: t.boolean,
   }),
   stripeProductId: t.union([t.string, t.null]),
   billingType: t.union([
@@ -107,6 +108,7 @@ async function handler(
           users: {
             maxUsers: plan.maxUsersInWorkspace,
           },
+          canUseProduct: plan.canUseProduct,
         },
         billingType: plan.billingType,
         trialPeriodDays: plan.trialPeriodDays,
@@ -193,6 +195,7 @@ async function handler(
         maxUsersInWorkspace: body.limits.users.maxUsers,
         billingType: body.billingType,
         trialPeriodDays: body.trialPeriodDays,
+        canUseProduct: body.limits.canUseProduct,
       });
       res.status(200).json({
         plan: body,

--- a/front/pages/api/poke/workspaces/index.ts
+++ b/front/pages/api/poke/workspaces/index.ts
@@ -4,9 +4,16 @@ import type { FindOptions, WhereOptions } from "sequelize";
 import { Op } from "sequelize";
 
 import { Authenticator, getSession } from "@app/lib/auth";
-import { Membership, Subscription, User, Workspace } from "@app/lib/models";
+import {
+  Membership,
+  Plan,
+  Subscription,
+  User,
+  Workspace,
+} from "@app/lib/models";
 import { isEmailValid } from "@app/lib/utils";
 import { apiError, withLogging } from "@app/logger/withlogging";
+import { FREE_TEST_PLAN_CODE } from "@app/lib/plans/plan_codes";
 
 export type GetWorkspacesResponseBody = {
   workspaces: LightWorkspaceType[];
@@ -92,6 +99,15 @@ async function handler(
             status: "active",
           },
           attributes: ["workspaceId"],
+          include: [
+            {
+              model: Plan,
+              as: "plan",
+              where: {
+                code: { [Op.ne]: FREE_TEST_PLAN_CODE },
+              },
+            },
+          ],
         });
         const workspaceIds = subscriptions.map((s) => s.workspaceId);
         if (upgraded) {

--- a/front/pages/api/poke/workspaces/index.ts
+++ b/front/pages/api/poke/workspaces/index.ts
@@ -11,9 +11,9 @@ import {
   User,
   Workspace,
 } from "@app/lib/models";
+import { FREE_TEST_PLAN_CODE } from "@app/lib/plans/plan_codes";
 import { isEmailValid } from "@app/lib/utils";
 import { apiError, withLogging } from "@app/logger/withlogging";
-import { FREE_TEST_PLAN_CODE } from "@app/lib/plans/plan_codes";
 
 export type GetWorkspacesResponseBody = {
   workspaces: LightWorkspaceType[];

--- a/types/src/front/plan.ts
+++ b/types/src/front/plan.ts
@@ -28,6 +28,7 @@ export type LimitsType = {
   users: {
     maxUsers: number;
   };
+  canUseProduct: boolean;
 };
 
 export const FREE_BILLING_TYPES = ["free"] as const;
@@ -53,7 +54,7 @@ export type PlanType = {
 };
 
 export type SubscriptionType = {
-  subscriptionId: string | null; // null for the free test plan that is not in the database
+  sId: string | null;
   status: "active" | "ended" | "trialing";
   stripeSubscriptionId: string | null;
   stripeCustomerId: string | null;

--- a/types/src/front/plan.ts
+++ b/types/src/front/plan.ts
@@ -54,6 +54,7 @@ export type PlanType = {
 };
 
 export type SubscriptionType = {
+  // null for FREE_NO_PLAN which is the default plan when there is no Subscription in DB.
   sId: string | null;
   status: "active" | "ended" | "trialing";
   stripeSubscriptionId: string | null;


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/dust/issues/4270

- [x] Make FREE_TEST_PLAN an in-db plan
- [x] Introduce `canUseProduct` limit (to redirect to subscribe page)
- [x] Introduce FREE_NO_PLAN (default plan (not in DB), canUseProduct: false)
- [x] Introspect all call-sites to `Subscription.find{One|All}`
- [x] Migration to subscribe all users to `FREE_TEST_PLAN`
- [x] local tests
  - [x] make sure to have a free workspace and a paid workspace
  - [x] rollout the PR
  - [x] check workspaces are unaffected
  - [x] try create a new workspace to verify it's creates the Subscription

`FREE_NO_PLAN` will not be used yet as we will create `FREE_TEST_PLAN` for all users until we kill it.

`internalSubscribeWorkspaceToFreeTestPlan` is called when the Workspace gets created. Today it does nothing as the default plan `FREE_TEST_PLAN` is not in DB and is returned by `lib/auth` if there is no `Subscription` for the workspace.

After this PR this function will create a `Subscription` to `FREE_TEST_PLAN` (+ we migrate all users without Subscription) for all Workspace creations. lib/auth will return `FREE_NO_PLAN` if there is no `Subscription` but this should never happen.

## Risk

High as this touches to our default plan subscription and deeply change the logic of the free plan. Needs a lot of testing locally.

## Deploy Plan

- [x] deploy `prodbox`
- [x] run front `init_db`
- [x] run front `init_plan` (will add `FREE_TEST_PLAN` to `front`)
- [x] Run migration to move all users without subscription to `FREE_TEST_PLAN`
- [x] deploy `front`
- [x] Run migration to move all users without subscription to `FREE_TEST_PLAN`