### PR TITLE
Flav/fair limits free trial max messages

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -872,14 +872,25 @@ export async function* postUserMessage(
     subscription,
   });
   if (isAboveMessageLimit) {
-    yield {
-      type: "user_message_error",
-      created: Date.now(),
-      error: {
-        code: "test_plan_message_limit_reached",
-        message: "The free plan message limit has been reached.",
-      },
-    };
+    if (isTrial(subscription)) {
+      yield {
+        type: "user_message_error",
+        created: Date.now(),
+        error: {
+          code: "free_trial_message_limit_reached",
+          message: "The free trial message limit has been reached.",
+        },
+      };
+    } else {
+      yield {
+        type: "user_message_error",
+        created: Date.now(),
+        error: {
+          code: "test_plan_message_limit_reached",
+          message: "The free plan message limit has been reached.",
+        },
+      };
+    }
     return;
   }
 
@@ -1995,7 +2006,7 @@ async function isMessagesLimitReached({
     // For trials, the limit applies to the last 24 hours.
     const remaining = await rateLimiter({
       key: `workspace:${owner.id}:agent_message_count:last_24_hours`,
-      maxPerTimeframe: plan.limits.assistant.maxMessages,
+      maxPerTimeframe: 25,
       timeframeSeconds: 60 * 60 * 24, // 1 day.
       logger,
     });

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -48,7 +48,7 @@ import {
 } from "@dust-tt/types";
 import { cloneBaseConfig, DustProdActionRegistry } from "@dust-tt/types";
 import { Err, Ok } from "@dust-tt/types";
-import type { Transaction, WhereOptions } from "sequelize";
+import type { Transaction } from "sequelize";
 import { Op } from "sequelize";
 
 import { runActionStreamed } from "@app/lib/actions/server";

--- a/front/lib/plans/trial.ts
+++ b/front/lib/plans/trial.ts
@@ -6,8 +6,6 @@ import type { PlanAttributes } from "@app/lib/plans/free_plans";
 // These limits are applied to all plans during the trial period.
 const TRIAL_LIMITS: Partial<PlanAttributes> = {
   maxUsersInWorkspace: 5,
-  // The maxMessages limit applies to the last 24 hours.
-  maxMessages: 25,
 };
 
 export function getTrialVersionForPlan(plan: Plan): PlanAttributes {

--- a/front/lib/plans/trial.ts
+++ b/front/lib/plans/trial.ts
@@ -6,6 +6,8 @@ import type { PlanAttributes } from "@app/lib/plans/free_plans";
 // These limits are applied to all plans during the trial period.
 const TRIAL_LIMITS: Partial<PlanAttributes> = {
   maxUsersInWorkspace: 5,
+  // The maxMessages limit applies to the last 24 hours.
+  maxMessages: 25,
 };
 
 export function getTrialVersionForPlan(plan: Plan): PlanAttributes {


### PR DESCRIPTION
## Description

See https://github.com/dust-tt/dust/issues/4263.

This PR implements a fair cap on the number of agent messages allowed within a 24-hour period for workspaces in their free trial phase. When the limit is exceeded, the system will enforce the following constraints:

- Workspace members will be restricted from mentioning agents or assistants in their messages. Attempting to do so will trigger a free plan pop-up notification.
- The message limit is calculated based on a sliding 24-hour window.
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
