### PR TITLE
Introducing Subscription.trialing

### DIFF
--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -22,7 +22,6 @@ import type {
   NextApiRequest,
   NextApiResponse,
 } from "next";
-import { Op } from "sequelize";
 
 import { isDevelopment } from "@app/lib/development";
 import type { SessionWithUser } from "@app/lib/iam/provider";
@@ -532,7 +531,7 @@ export async function subscriptionForWorkspace(
       "stripeCustomerId",
       "stripeSubscriptionId",
     ],
-    where: { workspaceId: w.id, status: { [Op.in]: ["active", "trialing"] } },
+    where: { workspaceId: w.id, status: "active" },
     include: [
       {
         model: Plan,

--- a/front/lib/models/plan.ts
+++ b/front/lib/models/plan.ts
@@ -172,6 +172,7 @@ export class Subscription extends Model<
 
   declare sId: string; // unique
   declare status: SubscriptionStatusType;
+  declare trialing: boolean | null;
   declare paymentFailingSince: Date | null;
 
   declare startDate: Date;
@@ -213,6 +214,11 @@ Subscription.init(
       validate: {
         isIn: [SUBSCRIPTION_STATUSES],
       },
+    },
+    trialing: {
+      type: DataTypes.BOOLEAN,
+      allowNull: true,
+      defaultValue: false,
     },
     paymentFailingSince: {
       type: DataTypes.DATE,

--- a/front/lib/plans/subscription.ts
+++ b/front/lib/plans/subscription.ts
@@ -83,6 +83,7 @@ export function renderSubscriptionFromModels({
 }): SubscriptionType {
   return {
     status: activeSubscription?.status ?? "active",
+    trialing: activeSubscription?.trialing === true,
     sId: activeSubscription?.sId || null,
     stripeSubscriptionId: activeSubscription?.stripeSubscriptionId || null,
     stripeCustomerId: activeSubscription?.stripeCustomerId || null,

--- a/front/lib/plans/trial.ts
+++ b/front/lib/plans/trial.ts
@@ -15,6 +15,8 @@ export function getTrialVersionForPlan(plan: Plan): PlanAttributes {
   };
 }
 
-export function isTrial(subscription: SubscriptionType | Subscription) {
-  return subscription.status === "trialing";
+export function isTrial(
+  subscription: SubscriptionType | Subscription
+): boolean {
+  return subscription.trialing === true;
 }

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -281,10 +281,8 @@ async function handler(
                   sId: generateModelSId(),
                   workspaceId: workspace.id,
                   planId: plan.id,
-                  status:
-                    stripeSubscription.status === "trialing"
-                      ? "trialing"
-                      : "active",
+                  status: "active",
+                  trialing: stripeSubscription.status === "trialing",
                   startDate: now,
                   stripeSubscriptionId: stripeSubscriptionId,
                   stripeCustomerId: stripeCustomerId,
@@ -466,7 +464,7 @@ async function handler(
               });
             }
 
-            await subscription.update({ status: "active" });
+            await subscription.update({ status: "active", trialing: false });
           } else if (
             // The subscription is canceled (but not yet ended) or reactivated
             stripeSubscription.status === "active" &&

--- a/front/pages/w/[wId]/subscription/index.tsx
+++ b/front/pages/w/[wId]/subscription/index.tsx
@@ -52,7 +52,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   const planInvitation = await getPlanInvitation(auth);
 
   let trialDaysRemaining = null;
-  if (subscription.status === "trialing" && subscription.stripeSubscriptionId) {
+  if (subscription.trialing && subscription.stripeSubscriptionId) {
     const stripeSubscription = await getStripeSubscription(
       subscription.stripeSubscriptionId
     );

--- a/types/src/front/plan.ts
+++ b/types/src/front/plan.ts
@@ -41,7 +41,7 @@ export const PAID_BILLING_TYPES = [
 export type FreeBillingType = (typeof FREE_BILLING_TYPES)[number];
 export type PaidBillingType = (typeof PAID_BILLING_TYPES)[number];
 
-export const SUBSCRIPTION_STATUSES = ["active", "ended", "trialing"] as const;
+export const SUBSCRIPTION_STATUSES = ["active", "ended"] as const;
 export type SubscriptionStatusType = (typeof SUBSCRIPTION_STATUSES)[number];
 
 export type PlanType = {
@@ -54,9 +54,9 @@ export type PlanType = {
 };
 
 export type SubscriptionType = {
-  // null for FREE_NO_PLAN which is the default plan when there is no Subscription in DB.
-  sId: string | null;
-  status: "active" | "ended" | "trialing";
+  sId: string | null; // null for FREE_NO_PLAN which is the default plan when there is no Subscription in DB.
+  status: "active" | "ended";
+  trialing: boolean;
   stripeSubscriptionId: string | null;
   stripeCustomerId: string | null;
   startDate: number | null;

--- a/types/src/front/plan.ts
+++ b/types/src/front/plan.ts
@@ -54,7 +54,8 @@ export type PlanType = {
 };
 
 export type SubscriptionType = {
-  sId: string | null; // null for FREE_NO_PLAN which is the default plan when there is no Subscription in DB.
+  // null for FREE_NO_PLAN which is the default plan when there is no Subscription in DB.
+  sId: string | null;
   status: "active" | "ended";
   trialing: boolean;
   stripeSubscriptionId: string | null;


### PR DESCRIPTION
## Description

Implements https://github.com/dust-tt/dust/issues/4299

After the introduction of `Subscription.status = trialing` in [this PR](https://github.com/dust-tt/dust/pull/4279), we decided that keeping a simple notion of `active` for a subscription made more sense, and decided to handle the `trailing` case of a subscription using a different property. That way a subscription can be `active` or `cancel` regardless of the underlying reason for being active, making our code easier to maintain.



<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk


## Deploy Plan
- lock deployments
- go to prod box: `front> npm run initdb`
- deploy main to front
- unlock deployments