### PR TITLE
Tree view modal assistant

### DIFF
--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -1,18 +1,22 @@
 import {
   Avatar,
-  CloudArrowDownIcon,
+  BracesIcon,
   CommandLineIcon,
   ElementModal,
+  ExternalLinkIcon,
+  IconButton,
   Page,
   ServerIcon,
   Spinner,
+  Tree,
 } from "@dust-tt/sparkle";
 import type {
   AgentConfigurationScope,
   AgentConfigurationType,
-  ConnectorProvider,
+  ContentNode,
   CoreAPITable,
   DataSourceConfiguration,
+  DataSourceType,
   DustAppRunConfigurationType,
   TablesQueryConfigurationType,
   WorkspaceType,
@@ -30,12 +34,22 @@ import AssistantListActions from "@app/components/assistant/AssistantListActions
 import { AssistantEditionMenu } from "@app/components/assistant/conversation/AssistantEditionMenu";
 import { SharingDropdown } from "@app/components/assistant/Sharing";
 import { assistantUsageMessage } from "@app/components/assistant/Usage";
+import { PermissionTreeChildren } from "@app/components/ConnectorPermissionsTree";
+import ManagedDataSourceDocumentModal from "@app/components/ManagedDataSourceDocumentModal";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { updateAgentScope } from "@app/lib/client/dust_api";
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
-import { useAgentConfiguration, useAgentUsage, useApp } from "@app/lib/swr";
+import { getDisplayNameForDataSource } from "@app/lib/data_sources";
+import {
+  useAgentConfiguration,
+  useAgentUsage,
+  useApp,
+  useConnectorPermissions,
+  useDataSources,
+} from "@app/lib/swr";
 import { classNames, timeAgoFrom } from "@app/lib/utils";
 import type { GetAgentConfigurationsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
+import type { GetContentNodeResponseBody } from "@app/pages/api/w/[wId]/data_sources/[name]/managed/content_nodes";
 
 type AssistantDetailsProps = {
   owner: WorkspaceType;
@@ -62,6 +76,9 @@ export function AssistantDetails({
     workspaceId: owner.sId,
     agentConfigurationId: assistantId,
   });
+
+  const { dataSources } = useDataSources(owner);
+
   const [isUpdatingScope, setIsUpdatingScope] = useState(false);
 
   if (!agentConfiguration) {
@@ -204,7 +221,11 @@ export function AssistantDetails({
           <div className="text-lg font-bold text-element-800">
             Data source(s)
           </div>
-          <DataSourcesSection dataSourceConfigurations={action.dataSources} />
+          <DataSourcesSection
+            owner={owner}
+            dataSources={dataSources}
+            dataSourceConfigurations={action.dataSources}
+          />
         </div>
       ) : isTablesQueryConfiguration(action) ? (
         <div className="flex flex-col gap-2">
@@ -232,57 +253,220 @@ export function AssistantDetails({
 }
 
 function DataSourcesSection({
+  owner,
+  dataSources,
   dataSourceConfigurations,
 }: {
+  owner: WorkspaceType;
+  dataSources: DataSourceType[];
   dataSourceConfigurations: DataSourceConfiguration[];
 }) {
-  const getProviderName = (ds: DataSourceConfiguration) =>
-    ds.dataSourceId.startsWith("managed-")
-      ? (ds.dataSourceId.slice(8) as ConnectorProvider)
-      : undefined;
-
-  const compareDatasourceNames = (
-    a: DataSourceConfiguration,
-    b: DataSourceConfiguration
-  ) => {
-    const aProviderName = getProviderName(a);
-    const bProviderName = getProviderName(b);
-    if (aProviderName && bProviderName) {
-      return aProviderName > bProviderName ? -1 : 1;
-    }
-    if (aProviderName) {
-      return -1;
-    }
-    if (bProviderName) {
-      return 1;
-    }
-    return a.dataSourceId > b.dataSourceId ? -1 : 1;
-  };
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+  const [documentToDisplay, setDocumentToDisplay] = useState<string | null>(
+    null
+  );
+  const [dataSourceToDisplay, setDataSourceToDisplay] =
+    useState<DataSourceType | null>(null);
 
   return (
     <div className="flex flex-col gap-1">
-      {dataSourceConfigurations.sort(compareDatasourceNames).map((ds) => {
-        const providerName = getProviderName(ds);
-        const DsLogo = providerName
-          ? CONNECTOR_CONFIGURATIONS[providerName].logoComponent
-          : CloudArrowDownIcon;
-        const dsDocumentNumberText = `(${
-          ds.filter.parents?.in.length ?? "all"
-        } element(s))`;
-        return (
-          <div className="flex flex-col gap-2" key={ds.dataSourceId}>
-            <div className="flex items-center gap-2">
-              <div>
-                <DsLogo />
-              </div>
-              <div>{`${
-                providerName ?? ds.dataSourceId
-              } ${dsDocumentNumberText}`}</div>
-            </div>
-          </div>
-        );
-      })}
+      <ManagedDataSourceDocumentModal
+        owner={owner}
+        dataSource={dataSourceToDisplay}
+        documentId={documentToDisplay}
+        isOpen={!!documentToDisplay}
+        setOpen={(open) => {
+          if (!open) {
+            setDocumentToDisplay(null);
+          }
+        }}
+      />
+      <Tree>
+        {dataSourceConfigurations.map((dsConfig) => {
+          const ds = dataSources.find(
+            (ds) => ds.name === dsConfig.dataSourceId
+          );
+
+          let DsLogo = null;
+          let dataSourceName = dsConfig.dataSourceId;
+
+          if (ds) {
+            DsLogo = ds.connectorProvider
+              ? CONNECTOR_CONFIGURATIONS[ds.connectorProvider].logoComponent
+              : null;
+            dataSourceName = getDisplayNameForDataSource(ds);
+          }
+
+          const isAllSelected = dsConfig.filter.parents === null;
+
+          return (
+            <Tree.Item
+              key={dsConfig.dataSourceId}
+              collapsed={!expanded[dsConfig.dataSourceId]}
+              onChevronClick={() => {
+                setExpanded((prev) => ({
+                  ...prev,
+                  [dsConfig.dataSourceId]: prev[dsConfig.dataSourceId]
+                    ? false
+                    : true,
+                }));
+              }}
+              type={ds ? "node" : "leaf"}
+              label={dataSourceName}
+              visual={DsLogo ? <DsLogo className="s-h-5 s-w-5" /> : null}
+              variant="folder" // in case LogoComponent is null
+              className="whitespace-nowrap"
+            >
+              {ds && isAllSelected && (
+                <PermissionTreeChildren
+                  owner={owner}
+                  dataSource={ds}
+                  parentId={null}
+                  permissionFilter="read"
+                  canUpdatePermissions={false}
+                  displayDocumentSource={(documentId: string) => {
+                    setDataSourceToDisplay(ds);
+                    setDocumentToDisplay(documentId);
+                  }}
+                  useConnectorPermissionsHook={useConnectorPermissions}
+                />
+              )}
+              {ds && !isAllSelected && (
+                <DataSourceSelectedNodes
+                  owner={owner}
+                  dataSource={ds}
+                  dataSourceConfiguration={dsConfig}
+                  setDataSourceToDisplay={setDataSourceToDisplay}
+                  setDocumentToDisplay={setDocumentToDisplay}
+                />
+              )}
+            </Tree.Item>
+          );
+        })}
+      </Tree>
     </div>
+  );
+}
+
+function DataSourceSelectedNodes({
+  owner,
+  dataSource,
+  dataSourceConfiguration,
+  setDataSourceToDisplay,
+  setDocumentToDisplay,
+}: {
+  owner: WorkspaceType;
+  dataSource: DataSourceType;
+  dataSourceConfiguration: DataSourceConfiguration;
+  setDataSourceToDisplay: (ds: DataSourceType) => void;
+  setDocumentToDisplay: (documentId: string) => void;
+}) {
+  const [isLoading, setIsLoading] = useState(false);
+  const [hasLoadingError, setHasLoadingError] = useState(false);
+  const [nodes, setNodes] = useState<ContentNode[]>([]);
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+
+  const fetchSelectedNodes = useCallback(async () => {
+    setIsLoading(true);
+    setHasLoadingError(false);
+    try {
+      const res = await fetch(
+        `/api/w/${owner.sId}/data_sources/${encodeURIComponent(
+          dataSource?.name || ""
+        )}/managed/content_nodes`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            internalIds: dataSourceConfiguration.filter.parents?.in ?? [],
+          }),
+        }
+      );
+      if (!res.ok) {
+        throw new Error("Failed to fetch nodes");
+      }
+      const json: GetContentNodeResponseBody = await res.json();
+      setNodes(json.nodes);
+    } catch (e) {
+      setHasLoadingError(true);
+      setNodes([]);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [owner, dataSource?.name, dataSourceConfiguration.filter.parents?.in]);
+
+  useEffect(() => {
+    if (isLoading || hasLoadingError || nodes.length) {
+      return;
+    }
+    fetchSelectedNodes().catch(console.error);
+  }, [fetchSelectedNodes, isLoading, hasLoadingError, nodes.length]);
+
+  return (
+    <>
+      {nodes.map((node) => (
+        <Tree.Item
+          key={node.internalId}
+          collapsed={!expanded[node.internalId]}
+          onChevronClick={() => {
+            setExpanded((prev) => ({
+              ...prev,
+              [node.internalId]: prev[node.internalId] ? false : true,
+            }));
+          }}
+          label={node.titleWithParentsContext ?? node.title}
+          type={node.expandable ? "node" : "leaf"}
+          variant={node.type}
+          className="whitespace-nowrap"
+          actions={
+            <div className="mr-8 flex flex-row gap-2">
+              <IconButton
+                size="xs"
+                icon={ExternalLinkIcon}
+                onClick={() => {
+                  if (node.sourceUrl) {
+                    window.open(node.sourceUrl, "_blank");
+                  }
+                }}
+                className={classNames(
+                  node.sourceUrl ? "" : "pointer-events-none opacity-0"
+                )}
+                disabled={!node.sourceUrl}
+              />
+              <IconButton
+                size="xs"
+                icon={BracesIcon}
+                onClick={() => {
+                  if (node.dustDocumentId) {
+                    setDataSourceToDisplay(dataSource);
+                    setDocumentToDisplay(node.dustDocumentId);
+                  }
+                }}
+                className={classNames(
+                  node.dustDocumentId ? "" : "pointer-events-none opacity-0"
+                )}
+                disabled={!node.dustDocumentId}
+              />
+            </div>
+          }
+        >
+          <PermissionTreeChildren
+            owner={owner}
+            dataSource={dataSource}
+            parentId={node.internalId}
+            permissionFilter="read"
+            canUpdatePermissions={true}
+            displayDocumentSource={(documentId: string) => {
+              setDataSourceToDisplay(dataSource);
+              setDocumentToDisplay(documentId);
+            }}
+            useConnectorPermissionsHook={useConnectorPermissions}
+          />
+        </Tree.Item>
+      ))}
+    </>
   );
 }
 

--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -311,7 +311,7 @@ function DataSourcesSection({
                     : true,
                 }));
               }}
-              type={ds ? "node" : "leaf"}
+              type={ds && ds.connectorId ? "node" : "leaf"}
               label={dataSourceName}
               visual={DsLogo ? <DsLogo className="s-h-5 s-w-5" /> : null}
               variant="folder" // in case LogoComponent is null

--- a/front/lib/swr.ts
+++ b/front/lib/swr.ts
@@ -29,6 +29,7 @@ import type { GetDataSourcesResponseBody } from "@app/pages/api/w/[wId]/data_sou
 import type { GetConnectorResponseBody } from "@app/pages/api/w/[wId]/data_sources/[name]/connector";
 import type { GetDocumentsResponseBody } from "@app/pages/api/w/[wId]/data_sources/[name]/documents";
 import type { GetOrPostManagedDataSourceConfigResponseBody } from "@app/pages/api/w/[wId]/data_sources/[name]/managed/config/[key]";
+import type { GetContentNodeResponseBody } from "@app/pages/api/w/[wId]/data_sources/[name]/managed/content_nodes";
 import type { GetDataSourcePermissionsResponseBody } from "@app/pages/api/w/[wId]/data_sources/[name]/managed/permissions";
 import type { GetSlackChannelsLinkedWithAgentResponseBody } from "@app/pages/api/w/[wId]/data_sources/[name]/managed/slack/channels_linked_with_agent";
 import type { ListTablesResponseBody } from "@app/pages/api/w/[wId]/data_sources/[name]/tables";
@@ -269,6 +270,44 @@ export function useEventSchemas(owner: WorkspaceType) {
     schemas: useMemo(() => (data ? data.schemas : []), [data]),
     isSchemasLoading: !error && !data,
     isSchemasError: error,
+  };
+}
+
+export function useDataSourceContentNodes({
+  owner,
+  dataSource,
+  internalIds,
+}: {
+  owner: WorkspaceType;
+  dataSource: DataSourceType;
+  internalIds: string[];
+}): {
+  nodes: GetContentNodeResponseBody["nodes"];
+  isNodesLoading: boolean;
+  isNodesError: boolean;
+} {
+  const url = `/api/w/${owner.sId}/data_sources/${encodeURIComponent(
+    dataSource.name
+  )}/managed/content_nodes`;
+  const body = JSON.stringify({ internalIds });
+
+  const fetchKey = useMemo(() => {
+    return JSON.stringify({ url, body }); // Serialize with body to ensure uniqueness
+  }, [url, body]);
+
+  const { data, error } = useSWR(fetchKey, async () => {
+    const options = {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body,
+    };
+    return fetcher(url, options);
+  });
+
+  return {
+    nodes: useMemo(() => (data ? data.nodes : []), [data]),
+    isNodesLoading: !error && !data,
+    isNodesError: !!error,
   };
 }
 

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/content_nodes.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/content_nodes.ts
@@ -1,0 +1,134 @@
+import type { ContentNode, WithAPIErrorReponse } from "@dust-tt/types";
+import { ConnectorsAPI } from "@dust-tt/types";
+import { isLeft } from "fp-ts/lib/Either";
+import * as t from "io-ts";
+import * as reporter from "io-ts-reporters";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { getDataSource } from "@app/lib/api/data_sources";
+import { Authenticator, getSession } from "@app/lib/auth";
+import logger from "@app/logger/logger";
+import { apiError, withLogging } from "@app/logger/withlogging";
+
+const GetContentNodeRequestBodySchema = t.type({
+  internalIds: t.array(t.string),
+});
+
+export type GetContentNodeResponseBody = {
+  nodes: ContentNode[];
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorReponse<GetContentNodeResponseBody>>
+): Promise<void> {
+  const session = await getSession(req, res);
+  const auth = await Authenticator.fromSession(
+    session,
+    req.query.wId as string
+  );
+
+  const owner = auth.workspace();
+  if (!owner) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "data_source_not_found",
+        message: "The data source you requested was not found.",
+      },
+    });
+  }
+
+  const dataSource = await getDataSource(auth, req.query.name as string);
+  if (!dataSource) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "data_source_not_found",
+        message: "The data source you requested was not found.",
+      },
+    });
+  }
+
+  if (!dataSource.connectorId) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "data_source_not_managed",
+        message: "The data source you requested is not managed.",
+      },
+    });
+  }
+
+  if (!auth.isUser()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "data_source_auth_error",
+        message:
+          "Only the users that are `users` for the current workspace can retrieve a list of connector resources.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "POST":
+      // We use post because we need a body, but we don't create anything
+
+      const body = req.body;
+      if (!body) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Missing required parameters. Required: resources",
+          },
+        });
+      }
+
+      const bodyValidation = GetContentNodeRequestBodySchema.decode(req.body);
+
+      if (isLeft(bodyValidation)) {
+        const pathError = reporter.formatValidationErrors(bodyValidation.left);
+        return apiError(req, res, {
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid request body: ${pathError}`,
+          },
+          status_code: 400,
+        });
+      }
+
+      const { internalIds } = bodyValidation.right;
+
+      const connectorsAPI = new ConnectorsAPI(logger);
+      const connectorsRes = await connectorsAPI.getContentNodes({
+        internalIds,
+        connectorId: dataSource.connectorId,
+      });
+
+      if (connectorsRes.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: `An error occurred while fetching the resources' content nodes.`,
+          },
+        });
+      }
+
+      res.status(200).json({ nodes: connectorsRes.value.nodes });
+      return;
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, POST is expected.",
+        },
+      });
+  }
+}
+
+export default withLogging(handler);

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/content_nodes.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/content_nodes.ts
@@ -29,7 +29,7 @@ async function handler(
   );
 
   const owner = auth.workspace();
-  if (!owner) {
+  if (!owner || !auth.isUser()) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
@@ -56,17 +56,6 @@ async function handler(
       api_error: {
         type: "data_source_not_managed",
         message: "The data source you requested is not managed.",
-      },
-    });
-  }
-
-  if (!auth.isUser()) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "data_source_auth_error",
-        message:
-          "Only the users that are `users` for the current workspace can retrieve a list of connector resources.",
       },
     });
   }


### PR DESCRIPTION
## Description

Adding the Tree View on the AssistantDetail modal. 

<img width="828" alt="Screenshot 2024-03-14 at 18 38 38" src="https://github.com/dust-tt/dust/assets/3803406/b048bd2a-1bee-4fe6-aec0-d474bfb57070">

- [x] Add new front API route to call connector getContentNodes
- [x] Add swr function to get the content nodes
- [x] Update the modal component to build a Tree instead of displaying the resources

## Risk

Display was already kind of broken, we were displaying only the managed ds and just the number of item selected.

## Deploy Plan

Nothing special. 
