### PR TITLE
fix: skip confluence space if 403 on GET

### DIFF
--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -1,4 +1,5 @@
 import type { ModelId } from "@dust-tt/types";
+import { ConfluenceClientError } from "@dust-tt/types";
 import { Op } from "sequelize";
 import TurndownService from "turndown";
 
@@ -170,6 +171,14 @@ export async function confluenceGetSpaceNameActivity({
   } catch (err) {
     if (isNotFoundError(err)) {
       localLogger.info("Deleting stale Confluence space.");
+
+      return null;
+    }
+
+    if (err instanceof ConfluenceClientError && err.status === 403) {
+      localLogger.info(
+        "Confluence space is not accessible (status code 403). Deleting."
+      );
 
       return null;
     }


### PR DESCRIPTION
## Description

We have a workflow consistently stuck. If getting the space is 403, then it's fair to assume it's non-retryable and should be skipped

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
