### PR TITLE
Allowing Slack workspace (Dust) to talk to our bot (Dust :))

### DIFF
--- a/connectors/src/connectors/slack/lib/workspace_limits.ts
+++ b/connectors/src/connectors/slack/lib/workspace_limits.ts
@@ -11,7 +11,7 @@ import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_c
 import logger from "@connectors/logger/logger";
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
 
-const WHITELISTED_BOT_NAME = ["Beaver", "feedback-hackaton"];
+const WHITELISTED_BOT_NAME = ["Beaver", "feedback-hackaton", "Dust"];
 
 async function getActiveMemberEmails(
   connector: ConnectorResource


### PR DESCRIPTION
## Description

We have a customer who wants to talk to Dust from a triggered workflow on Slack, and their messages are being rejected by our "No slack bot can talk to Dust" policy.

With this PR, I am allowing our workspace (Dust) to talk to our bot for debugging purpose.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
