### PR TITLE
Abstract Slack user to allow Slack bots and real users

### DIFF
--- a/connectors/src/api/webhooks/webhook_slack.ts
+++ b/connectors/src/api/webhooks/webhook_slack.ts
@@ -46,6 +46,7 @@ async function handleChatBot(req: Request, res: Response, logger: Logger) {
   const slackTeamId = req.body.team_id;
   const slackChannel = event.channel;
   const slackUserId = event.user;
+  const slackBotId = event.bot_id || null;
   const slackMessageTs = event.ts;
   const slackThreadTs = event.thread_ts || null;
 
@@ -65,8 +66,20 @@ async function handleChatBot(req: Request, res: Response, logger: Logger) {
     !slackTeamId ||
     !slackChannel ||
     !slackUserId ||
-    !slackMessageTs
+    !slackMessageTs ||
+    (!slackBotId && !slackUserId)
   ) {
+    logger.error(
+      {
+        slackMessage,
+        slackTeamId,
+        slackChannel,
+        slackUserId,
+        slackBotId,
+        slackMessageTs,
+      },
+      "Missing required fields in request body"
+    );
     return apiError(req, res, {
       api_error: {
         type: "invalid_request_error",
@@ -84,6 +97,7 @@ async function handleChatBot(req: Request, res: Response, logger: Logger) {
     slackTeamId,
     slackChannel,
     slackUserId,
+    slackBotId,
     slackMessageTs,
     slackThreadTs
   );

--- a/connectors/src/api/webhooks/webhook_slack.ts
+++ b/connectors/src/api/webhooks/webhook_slack.ts
@@ -65,7 +65,6 @@ async function handleChatBot(req: Request, res: Response, logger: Logger) {
     !slackMessage ||
     !slackTeamId ||
     !slackChannel ||
-    !slackUserId ||
     !slackMessageTs ||
     (!slackBotId && !slackUserId)
   ) {

--- a/connectors/src/connectors/slack/lib/workspace_limits.ts
+++ b/connectors/src/connectors/slack/lib/workspace_limits.ts
@@ -1,17 +1,15 @@
 import type { WorkspaceDomain } from "@dust-tt/types";
 import { cacheWithRedis, DustAPI } from "@dust-tt/types";
-import type { UsersInfoResponse, WebClient } from "@slack/web-api";
-import type {
-  Profile,
-  User,
-} from "@slack/web-api/dist/response/UsersInfoResponse";
+import type { WebClient } from "@slack/web-api";
+import type {} from "@slack/web-api/dist/response/UsersInfoResponse";
 
+import type { SlackUserInfo } from "@connectors/connectors/slack/lib/slack_client";
 import { getSlackConversationInfo } from "@connectors/connectors/slack/lib/slack_client";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import logger from "@connectors/logger/logger";
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
 
-const WHITELISTED_BOT_NAME = ["Beaver", "feedback-hackaton", "Dust"];
+const WHITELISTED_BOT_NAME = ["Beaver", "feedback-hackaton", "Dust", "Retool"];
 
 async function getActiveMemberEmails(
   connector: ConnectorResource
@@ -89,27 +87,22 @@ export const getVerifiedDomainsForWorkspaceMemoized = cacheWithRedis(
 );
 
 function getSlackUserEmailFromProfile(
-  profile: Profile | undefined
+  slackUserInfo: SlackUserInfo | undefined
 ): string | undefined {
-  return profile?.email?.toLowerCase();
+  return slackUserInfo?.email?.toLowerCase();
 }
 
 function getSlackUserEmailDomainFromProfile(
-  profile: Profile | undefined
+  slackUserInfo: SlackUserInfo | undefined
 ): string | undefined {
-  return getSlackUserEmailFromProfile(profile)?.split("@")[1];
+  return getSlackUserEmailFromProfile(slackUserInfo)?.split("@")[1];
 }
 
 async function isAutoJoinEnabledForDomain(
   connector: ConnectorResource,
-  slackUserInfo: UsersInfoResponse
+  slackUserInfo: SlackUserInfo
 ): Promise<boolean> {
-  const { user } = slackUserInfo;
-  if (!user || !user.profile) {
-    return false;
-  }
-
-  const userDomain = getSlackUserEmailDomainFromProfile(user.profile);
+  const userDomain = getSlackUserEmailDomainFromProfile(slackUserInfo);
   if (!userDomain) {
     return false;
   }
@@ -171,7 +164,7 @@ function makeSlackMembershipAccessBlocksForConnector(
 async function postMessageForUnhautorizedUser(
   connector: ConnectorResource,
   slackClient: WebClient,
-  slackUserInfo: UsersInfoResponse,
+  slackUserInfo: SlackUserInfo,
   slackInfos: SlackInfos
 ) {
   const { slackChannelId, slackMessageTs } = slackInfos;
@@ -208,18 +201,16 @@ export async function isActiveMemberOfWorkspace(
   return workspaceActiveMemberEmails.includes(slackUserEmail);
 }
 
-function isBotAllowed(user: User) {
-  const { profile } = user;
-
-  const displayName = profile?.display_name ?? "";
-  const realName = profile?.real_name ?? "";
+function isBotAllowed(slackUserInfo: SlackUserInfo) {
+  const displayName = slackUserInfo.display_name ?? "";
+  const realName = slackUserInfo.real_name ?? "";
 
   const isWhitelistedBotName =
     WHITELISTED_BOT_NAME.includes(displayName) ||
     WHITELISTED_BOT_NAME.includes(realName);
 
   if (!isWhitelistedBotName) {
-    logger.info({ user }, "Ignoring bot message");
+    logger.info({ user: slackUserInfo }, "Ignoring bot message");
   }
 
   return isWhitelistedBotName;
@@ -237,13 +228,13 @@ interface SlackInfos {
 // See incident: https://dust4ai.slack.com/archives/C05B529FHV1/p1704799263814619.
 async function isExternalUserAllowed(
   slackClient: WebClient,
-  profile: Profile,
+  slackUserInfo: SlackUserInfo,
   slackInfos: SlackInfos,
   whitelistedDomains?: readonly string[]
 ) {
   const { slackChannelId } = slackInfos;
 
-  const userDomain = getSlackUserEmailDomainFromProfile(profile);
+  const userDomain = getSlackUserEmailDomainFromProfile(slackUserInfo);
   // Ensure the domain matches exactly.
   const isWhitelistedDomain = userDomain
     ? whitelistedDomains?.includes(userDomain) ?? false
@@ -260,12 +251,12 @@ async function isExternalUserAllowed(
 
 async function isUserAllowed(
   connector: ConnectorResource,
-  profile: Profile,
+  slackUserInfo: SlackUserInfo,
   whitelistedDomains?: readonly string[]
 ) {
   const isMember = await isActiveMemberOfWorkspace(
     connector,
-    getSlackUserEmailFromProfile(profile)
+    getSlackUserEmailFromProfile(slackUserInfo)
   );
   if (isMember) {
     return true;
@@ -274,7 +265,7 @@ async function isUserAllowed(
   // To de-risk while releasing, we relies on an array of whitelisted domains.
   // TODO(2024-02-08 flav) Remove once released is completed.
   if (whitelistedDomains && whitelistedDomains.length > 0) {
-    const userDomain = getSlackUserEmailDomainFromProfile(profile);
+    const userDomain = getSlackUserEmailDomainFromProfile(slackUserInfo);
 
     if (userDomain) {
       return whitelistedDomains.includes(userDomain);
@@ -285,7 +276,7 @@ async function isUserAllowed(
 }
 
 async function isSlackUserAllowed(
-  user: User,
+  slackUserInfo: SlackUserInfo,
   connector: ConnectorResource,
   slackClient: WebClient,
   slackInfos: SlackInfos,
@@ -295,10 +286,10 @@ async function isSlackUserAllowed(
     is_restricted,
     is_stranger: isStranger,
     is_ultra_restricted,
-    profile,
-  } = user;
+    teamId,
+  } = slackUserInfo;
 
-  const isInWorkspace = profile?.team === slackInfos.slackTeamId;
+  const isInWorkspace = teamId === slackInfos.slackTeamId;
   if (!isInWorkspace) {
     return false;
   }
@@ -309,7 +300,7 @@ async function isSlackUserAllowed(
     isExternal &&
     (await isExternalUserAllowed(
       slackClient,
-      profile,
+      slackUserInfo,
       slackInfos,
       whitelistedDomains
     ));
@@ -319,27 +310,26 @@ async function isSlackUserAllowed(
   }
 
   // Otherwise, ensure that the slack user is an active member in the workspace.
-  return isUserAllowed(connector, profile, whitelistedDomains);
+  return isUserAllowed(connector, slackUserInfo, whitelistedDomains);
 }
 
 export async function notifyIfSlackUserIsNotAllowed(
   connector: ConnectorResource,
   slackClient: WebClient,
-  slackUserInfo: UsersInfoResponse,
+  slackUserInfo: SlackUserInfo,
   slackInfos: SlackInfos,
   whitelistedDomains?: readonly string[]
 ): Promise<boolean> {
-  const { user } = slackUserInfo;
-  if (!user) {
+  if (!slackUserInfo) {
     return false;
   }
 
-  if (user.is_bot) {
-    return isBotAllowed(user);
+  if (slackUserInfo.is_bot) {
+    return isBotAllowed(slackUserInfo);
   }
 
   const isAllowed = await isSlackUserAllowed(
-    user,
+    slackUserInfo,
     connector,
     slackClient,
     slackInfos,
@@ -351,9 +341,7 @@ export async function notifyIfSlackUserIsNotAllowed(
       {
         connectorId: connector.id,
         slackInfos,
-        slackUserEmail: getSlackUserEmailFromProfile(
-          slackUserInfo.user?.profile
-        ),
+        slackUserEmail: getSlackUserEmailFromProfile(slackUserInfo),
       },
       "Unauthorized Slack user attempted to access webhook."
     );

--- a/connectors/src/connectors/slack/lib/workspace_limits.ts
+++ b/connectors/src/connectors/slack/lib/workspace_limits.ts
@@ -9,6 +9,9 @@ import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_c
 import logger from "@connectors/logger/logger";
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
 
+// Whitelisted bot names that are allowed to interact with the bot.
+// This is just a workaround to allow our customers to use their own bot to talk to our @Dust Slack bot.
+// There is a more elaborated version in the work.
 const WHITELISTED_BOT_NAME = ["Beaver", "feedback-hackaton", "Dust", "Retool"];
 
 async function getActiveMemberEmails(

--- a/connectors/src/connectors/slack/lib/workspace_limits.ts
+++ b/connectors/src/connectors/slack/lib/workspace_limits.ts
@@ -9,9 +9,10 @@ import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_c
 import logger from "@connectors/logger/logger";
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
 
-// Whitelisted bot names that are allowed to interact with the bot.
-// This is just a workaround to allow our customers to use their own bot to talk to our @Dust Slack bot.
-// There is a more elaborated version in the work.
+//Whitelisting a bot will accept any message from this bot.
+// This means that we rely on the bot security measures
+// to not ping Dust from actions done by non verified members of the workspace.
+// Make sure to be explicit about this with users as you whitelist a new bot.
 const WHITELISTED_BOT_NAME = ["Beaver", "feedback-hackaton", "Dust", "Retool"];
 
 async function getActiveMemberEmails(


### PR DESCRIPTION
## Description

Today, users who want to use Slack workflows to trigger a message from our Slack bot are being rejected for two reasons:
- We explicitly banned bots, minus a whitelist.
- We stopped supporting bot a long time ago, when we started requiring a Slack user for talking to our Slack bot.

This PR abstract the Slack user into a `SlackUserInfo`, which can be built from a Slack user and a Slack bot. From there,
we can talk to our bot.
The whitelist is still needed, and this PR adds a whitelist of the bot called `Retool`, which is the one who triggered this PR initially.

I think we should revisit blocking Slack bots, as it enabled powerful automation around Dust. But that's for another day :)

A concrete example of what this would allow:

A workflow that ask a question to our bot whenever a specific emoji is added to a message.

![Screenshot 2024-03-16 at 00 52 57](https://github.com/dust-tt/dust/assets/358965/872e9c19-b993-453b-9bcb-a605599c2ff9)


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
