### PR TITLE
Move ContentFragment to the Resource pattern

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -47,7 +47,7 @@ import {
 import { ConversationClassification } from "@app/lib/models/conversation_classification";
 import { FeatureFlag } from "@app/lib/models/feature_flag";
 import { PlanInvitation } from "@app/lib/models/plan";
-import { ContentFragment } from "@app/lib/resources/storage/models/content_fragment";
+import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
 
 async function main() {
   await User.sync({ alter: true });
@@ -93,7 +93,7 @@ async function main() {
   await ConversationParticipant.sync({ alter: true });
   await UserMessage.sync({ alter: true });
   await AgentMessage.sync({ alter: true });
-  await ContentFragment.sync({ alter: true });
+  await ContentFragmentModel.sync({ alter: true });
   await Message.sync({ alter: true });
   await MessageReaction.sync({ alter: true });
   await Mention.sync({ alter: true });

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -568,8 +568,8 @@ export async function getConversation(
         as: "agentMessage",
         required: false,
       },
-      // We skip ContentFragmentResource here for efficiency reasons (retrieving contentFragment
-      // along with messgaes in one query). Only once we move to a MessageResource will we be able
+      // We skip ContentFragmentResource here for efficiency reasons (retrieving contentFragments
+      // along with messages in one query). Only once we move to a MessageResource will we be able
       // to properly abstract this.
       {
         model: ContentFragmentModel,

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -448,20 +448,11 @@ async function batchRenderContentFragment(
     );
   }
 
-  return messagesWithContentFragment.map((message) => {
-    if (!message.contentFragment) {
-      throw new Error(
-        "Unreachable: batchRenderContentFragment must be called with only content fragments"
-      );
-    }
-
-    const contentFragment = new ContentFragmentResource(
-      ContentFragmentModel,
-      message.contentFragment
-    );
+  return messagesWithContentFragment.map((message: Message) => {
+    const contentFragment = ContentFragmentResource.fromMessage(message);
 
     return {
-      m: contentFragment.renderFromMessage({ message }),
+      m: contentFragment.renderFromMessage(message),
       rank: message.rank,
       version: message.version,
     };
@@ -1841,7 +1832,7 @@ export async function postNewContentFragment(
     }
   );
 
-  return contentFragment.renderFromMessage({ message: messageRow });
+  return contentFragment.renderFromMessage(messageRow);
 }
 
 async function* streamRunAgentEvents(

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -73,7 +73,7 @@ import { AgentTablesQueryAction } from "@app/lib/models/assistant/actions/tables
 import { updateWorkspacePerMonthlyActiveUsersSubscriptionUsage } from "@app/lib/plans/subscription";
 import { isTrial } from "@app/lib/plans/trial";
 import { frontSequelize } from "@app/lib/resources/storage";
-import { ContentFragment } from "@app/lib/resources/storage/models/content_fragment";
+import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
 import { generateModelSId } from "@app/lib/utils";
 import logger from "@app/logger/logger";
 /**
@@ -440,7 +440,7 @@ function renderContentFragment({
   contentFragment,
 }: {
   message: Message;
-  contentFragment: ContentFragment;
+  contentFragment: ContentFragmentModel;
 }): ContentFragmentType {
   return {
     id: message.id,
@@ -591,7 +591,7 @@ export async function getConversation(
         required: false,
       },
       {
-        model: ContentFragment,
+        model: ContentFragmentModel,
         as: "contentFragment",
         required: false,
       },
@@ -1824,7 +1824,7 @@ export async function postNewContentFragment(
     async (t) => {
       await getConversationRankVersionLock(conversation, t);
 
-      const contentFragmentRow = await ContentFragment.create(
+      const contentFragmentRow = await ContentFragmentModel.create(
         {
           content,
           title,

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -19,7 +19,7 @@ import { AgentTablesQueryAction } from "@app/lib/models/assistant/actions/tables
 import { User } from "@app/lib/models/user";
 import { Workspace } from "@app/lib/models/workspace";
 import { frontSequelize } from "@app/lib/resources/storage";
-import { ContentFragment } from "@app/lib/resources/storage/models/content_fragment";
+import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
 
 export class Conversation extends Model<
   InferAttributes<Conversation>,
@@ -373,11 +373,11 @@ export class Message extends Model<
   declare parentId: ForeignKey<Message["id"]> | null;
   declare userMessageId: ForeignKey<UserMessage["id"]> | null;
   declare agentMessageId: ForeignKey<AgentMessage["id"]> | null;
-  declare contentFragmentId: ForeignKey<ContentFragment["id"]> | null;
+  declare contentFragmentId: ForeignKey<ContentFragmentModel["id"]> | null;
 
   declare userMessage?: NonAttribute<UserMessage>;
   declare agentMessage?: NonAttribute<AgentMessage>;
-  declare contentFragment?: NonAttribute<ContentFragment>;
+  declare contentFragment?: NonAttribute<ContentFragmentModel>;
   declare reactions?: NonAttribute<MessageReaction[]>;
 }
 
@@ -477,11 +477,11 @@ Message.belongsTo(AgentMessage, {
 Message.belongsTo(Message, {
   foreignKey: { name: "parentId", allowNull: true },
 });
-ContentFragment.hasOne(Message, {
+ContentFragmentModel.hasOne(Message, {
   as: "contentFragment",
   foreignKey: { name: "contentFragmentId", allowNull: true },
 });
-Message.belongsTo(ContentFragment, {
+Message.belongsTo(ContentFragmentModel, {
   as: "contentFragment",
   foreignKey: { name: "contentFragmentId", allowNull: true },
 });

--- a/front/lib/resources/base_resource.ts
+++ b/front/lib/resources/base_resource.ts
@@ -29,10 +29,11 @@ export abstract class BaseResource<M extends Model> {
     this: BaseResourceConstructor<T, M> & {
       model: ModelStatic<M>;
     },
-    id: number | string
+    id: number | string,
+    transaction?: Transaction
   ): Promise<T | null> {
     const parsedId = typeof id === "string" ? parseInt(id, 10) : id;
-    const blob = await this.model.findByPk(parsedId);
+    const blob = await this.model.findByPk(parsedId, { transaction });
     if (!blob) {
       return null;
     }
@@ -44,13 +45,15 @@ export abstract class BaseResource<M extends Model> {
   abstract delete(transaction?: Transaction): Promise<Result<undefined, Error>>;
 
   async update(
-    blob: Partial<Attributes<M>>
+    blob: Partial<Attributes<M>>,
+    transaction?: Transaction
   ): Promise<[affectedCount: number, affectedRows: M[]]> {
     return this.model.update(blob, {
       // @ts-expect-error TS cannot infer the presence of 'id' in Sequelize models, but our models always include 'id'.
       where: {
         id: this.id,
       },
+      transaction,
     });
   }
 }

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -1,0 +1,52 @@
+import type { Result } from "@dust-tt/types";
+import { Err, Ok } from "@dust-tt/types";
+import type { Attributes, CreationAttributes, ModelStatic } from "sequelize";
+
+import { BaseResource } from "@app/lib/resources/base_resource";
+import { frontSequelize } from "@app/lib/resources/storage";
+import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
+import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+
+// Attributes are marked as read-only to reflect the stateless nature of our Resource.
+// This design will be moved up to BaseResource once we transition away from Sequelize.
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface ContentFragmentResource
+  extends ReadonlyAttributesType<ContentFragmentModel> {}
+export class ContentFragmentResource extends BaseResource<ContentFragmentModel> {
+  static model: ModelStatic<ContentFragmentModel> = ContentFragmentModel;
+
+  // TODO(2024-02-20 flav): Delete Model from the constructor, once `update` has been migrated.
+  constructor(blob: Attributes<ContentFragmentModel>) {
+    super(ContentFragmentModel, blob);
+  }
+
+  static async makeNew(blob: CreationAttributes<ContentFragmentModel>) {
+    return frontSequelize.transaction(async (transaction) => {
+      const contentFragment = await ContentFragmentModel.create(
+        {
+          ...blob,
+        },
+        { transaction }
+      );
+
+      return new this(contentFragment.get());
+    });
+  }
+
+  async delete(): Promise<Result<undefined, Error>> {
+    return frontSequelize.transaction(async (transaction) => {
+      try {
+        await this.model.destroy({
+          where: {
+            id: this.id,
+          },
+          transaction,
+        });
+
+        return new Ok(undefined);
+      } catch (err) {
+        return new Err(err as Error);
+      }
+    });
+  }
+}

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -44,6 +44,20 @@ export class ContentFragmentResource extends BaseResource<ContentFragmentModel> 
     return new this(ContentFragmentModel, contentFragment.get());
   }
 
+  static fromMessage(
+    message: Message & { contentFragment?: ContentFragmentModel }
+  ) {
+    if (!message.contentFragment) {
+      throw new Error(
+        "ContentFragmentResource.fromMessage must be called with a content fragment"
+      );
+    }
+    return new ContentFragmentResource(
+      ContentFragmentModel,
+      message.contentFragment.get()
+    );
+  }
+
   async delete(transaction?: Transaction): Promise<Result<undefined, Error>> {
     try {
       await this.model.destroy({
@@ -59,7 +73,7 @@ export class ContentFragmentResource extends BaseResource<ContentFragmentModel> 
     }
   }
 
-  renderFromMessage({ message }: { message: Message }): ContentFragmentType {
+  renderFromMessage(message: Message): ContentFragmentType {
     return {
       id: message.id,
       sId: message.sId,

--- a/front/lib/resources/storage/models/content_fragment.ts
+++ b/front/lib/resources/storage/models/content_fragment.ts
@@ -10,9 +10,9 @@ import { DataTypes, Model } from "sequelize";
 import { User } from "@app/lib/models/user";
 import { frontSequelize } from "@app/lib/resources/storage";
 
-export class ContentFragment extends Model<
-  InferAttributes<ContentFragment>,
-  InferCreationAttributes<ContentFragment>
+export class ContentFragmentModel extends Model<
+  InferAttributes<ContentFragmentModel>,
+  InferCreationAttributes<ContentFragmentModel>
 > {
   declare id: CreationOptional<number>;
   declare createdAt: CreationOptional<Date>;
@@ -31,7 +31,7 @@ export class ContentFragment extends Model<
   declare userId: ForeignKey<User["id"]> | null;
 }
 
-ContentFragment.init(
+ContentFragmentModel.init(
   {
     id: {
       type: DataTypes.INTEGER,
@@ -87,9 +87,9 @@ ContentFragment.init(
   }
 );
 
-User.hasMany(ContentFragment, {
+User.hasMany(ContentFragmentModel, {
   foreignKey: { name: "userId", allowNull: true }, // null = ContentFragment is not associated with a user
 });
-ContentFragment.belongsTo(User, {
+ContentFragmentModel.belongsTo(User, {
   foreignKey: { name: "userId", allowNull: true },
 });

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -41,8 +41,8 @@ import {
   MessageReaction,
 } from "@app/lib/models/assistant/conversation";
 import { PlanInvitation } from "@app/lib/models/plan";
+import { ContentFragmentResource } from "@app/lib/resources/content_fragment_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
-import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
 import logger from "@app/logger/logger";
 
 const { DUST_DATA_SOURCES_BUCKET, SERVICE_ACCOUNT } = process.env;
@@ -151,7 +151,7 @@ export async function deleteConversationsActivity({
       }
       await Promise.all(
         chunk.map((c) => {
-          return (async () => {
+          return (async (): Promise<void> => {
             const messages = await Message.findAll({
               where: { conversationId: c.id },
               transaction: t,
@@ -194,10 +194,13 @@ export async function deleteConversationsActivity({
                 }
               }
               if (msg.contentFragmentId) {
-                await ContentFragmentModel.destroy({
-                  where: { id: msg.contentFragmentId },
-                  transaction: t,
-                });
+                const contentFragment = await ContentFragmentResource.fetchById(
+                  msg.contentFragmentId,
+                  t
+                );
+                if (contentFragment) {
+                  await contentFragment.delete(t);
+                }
               }
               await MessageReaction.destroy({
                 where: { messageId: msg.id },

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -42,7 +42,7 @@ import {
 } from "@app/lib/models/assistant/conversation";
 import { PlanInvitation } from "@app/lib/models/plan";
 import { frontSequelize } from "@app/lib/resources/storage";
-import { ContentFragment } from "@app/lib/resources/storage/models/content_fragment";
+import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
 import logger from "@app/logger/logger";
 
 const { DUST_DATA_SOURCES_BUCKET, SERVICE_ACCOUNT } = process.env;
@@ -194,7 +194,7 @@ export async function deleteConversationsActivity({
                 }
               }
               if (msg.contentFragmentId) {
-                await ContentFragment.destroy({
+                await ContentFragmentModel.destroy({
                   where: { id: msg.contentFragmentId },
                   transaction: t,
                 });


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/dust/issues/4332

- Introduce the ContentFragmentResource
- Move code to using it whenever possible

We still have a direct use of ContentFragmentModel in the rendering of conversations. I think the real killer will be when we move Message to the MessageResource pattern.

## Risk

limited: mostly shuffling code around

## Deploy Plan

- deploy `front`