### PR TITLE
Internal Downgrade should be to FREE_NO_PLAN

### DIFF
--- a/front/lib/plans/subscription.ts
+++ b/front/lib/plans/subscription.ts
@@ -405,55 +405,6 @@ export const getCheckoutUrlForUpgrade = async (
   };
 };
 
-export const downgradeWorkspaceToFreePlan = async (
-  auth: Authenticator
-): Promise<PlanType> => {
-  const user = auth.user();
-  const owner = auth.workspace();
-  const activePlan = auth.plan();
-
-  if (!user || !auth.isAdmin() || !owner || !activePlan) {
-    throw new Error(
-      "Unauthorized `auth` data: cannot process to subscription of new Plan."
-    );
-  }
-
-  const freeTestPlan = await Plan.findOne({
-    where: { code: FREE_TEST_PLAN_CODE },
-  });
-  if (!freeTestPlan) {
-    throw new Error(
-      `Cannot downgrade to free plan ${FREE_TEST_PLAN_CODE}: not found.`
-    );
-  }
-  if (freeTestPlan.stripeProductId) {
-    throw new Error(
-      `Cannot downgrade to free plan ${FREE_TEST_PLAN_CODE}: has a Stripe Product ID.`
-    );
-  }
-  if (freeTestPlan.billingType !== "free") {
-    throw new Error(
-      `Cannot downgrade to free plan ${FREE_TEST_PLAN_CODE}: billingType is not "free".`
-    );
-  }
-
-  const existingSubscription = auth.subscription();
-  if (
-    existingSubscription &&
-    existingSubscription.plan.code === freeTestPlan.code
-  ) {
-    throw new Error(
-      `Cannot downgrade to free plan ${FREE_TEST_PLAN_CODE}: already subscribed.`
-    );
-  }
-
-  const sub = await internalSubscribeWorkspaceToFreeTestPlan({
-    workspaceId: owner.sId,
-  });
-
-  return sub.plan;
-};
-
 export const updateWorkspacePerSeatSubscriptionUsage = async ({
   workspaceId,
 }: {

--- a/front/pages/api/poke/workspaces/[wId]/downgrade.ts
+++ b/front/pages/api/poke/workspaces/[wId]/downgrade.ts
@@ -2,7 +2,7 @@ import type { LightWorkspaceType, WithAPIErrorReponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { Authenticator, getSession } from "@app/lib/auth";
-import { internalSubscribeWorkspaceToFreeTestPlan } from "@app/lib/plans/subscription";
+import { internalSubscribeWorkspaceToFreeNoPlan } from "@app/lib/plans/subscription";
 import { apiError, withLogging } from "@app/logger/withlogging";
 
 export type DowngradeWorkspaceResponseBody = {
@@ -33,7 +33,7 @@ async function handler(
 
   switch (req.method) {
     case "POST":
-      await internalSubscribeWorkspaceToFreeTestPlan({
+      await internalSubscribeWorkspaceToFreeNoPlan({
         workspaceId: owner.sId,
       });
 

--- a/front/pages/api/w/[wId]/subscriptions/index.ts
+++ b/front/pages/api/w/[wId]/subscriptions/index.ts
@@ -10,10 +10,7 @@ import {
   cancelSubscriptionImmediately,
   skipSubscriptionFreeTrial,
 } from "@app/lib/plans/stripe";
-import {
-  downgradeWorkspaceToFreePlan,
-  getCheckoutUrlForUpgrade,
-} from "@app/lib/plans/subscription";
+import { getCheckoutUrlForUpgrade } from "@app/lib/plans/subscription";
 import logger from "@app/logger/logger";
 import { apiError, withLogging } from "@app/logger/withlogging";
 
@@ -171,23 +168,6 @@ async function handler(
       res.status(200).json({ success: true });
       break;
     }
-    case "DELETE":
-      try {
-        const newPlan = await downgradeWorkspaceToFreePlan(auth);
-        return res.status(200).json({ plan: newPlan });
-      } catch (error) {
-        logger.error(
-          { error },
-          "Error while downgrading workspace to free plan"
-        );
-        return apiError(req, res, {
-          status_code: 500,
-          api_error: {
-            type: "internal_server_error",
-            message: "Error while downgrading workspace to free plan",
-          },
-        });
-      }
 
     default:
       return apiError(req, res, {


### PR DESCRIPTION
## Description

Task: https://github.com/dust-tt/dust/issues/4286

When we downgrade a workspace, it needs to be downgraded to `FREE_NO_PLAN` and not `FREE_TEST_PLAN`.
Two ways to be downgraded: 
1/ The user ends their subscription to the PRO plan (during of after trial period) -> Nothing to do for me, the Stripe webhook ends the Subscription on db and does not create a new one so we're on default in FREE_NO_PLAN
2/ Someone from Dust wants to downgrade a workspace that was in Pilot or Friends Plan -> Edit Poké so that the poké downgrade route puts the workspace on FREE_NO_PLAN.

So, done on this PR: 
- Edit Poké downgrade route `front/pages/api/poke/workspaces/[wId]/downgrade.ts` to call `internalSubscribeWorkspaceToFreeNoPlan` over `internalSubscribeWorkspaceToFreeTestPlan`
- UX simplification: Rename the Poké button "Invite or Upgrade to plan" to "Manage Plan" and put alls plan edition button inside it. This allowed me to remove the "Legacy workspace action" dropdown.
- Remove DELETE from `front/pages/api/w/[wId]/subscriptions/index.ts` along with `downgradeWorkspaceToFreePlan` that does not seem used anywhere. 

 
<img width="463" alt="Screenshot 2024-03-18 at 16 29 09" src="https://github.com/dust-tt/dust/assets/3803406/a25f10b0-ce0b-4ee3-b9e6-e26b1016c699">


## Risk

/

## Deploy Plan

Nothing special. 
