### PR TITLE
Folders cannot be expanded in Tree View

### DIFF
--- a/front/components/assistant_builder/DataSourceSelectionSection.tsx
+++ b/front/components/assistant_builder/DataSourceSelectionSection.tsx
@@ -98,7 +98,7 @@ export default function DataSourceSelectionSection({
                         : true,
                     }));
                   }}
-                  type="node"
+                  type={dsConfig.dataSource.connectorId ? "node" : "leaf"} // todo make useConnectorPermissions hook work for non managed ds (Folders)
                   label={getDisplayNameForDataSource(dsConfig.dataSource)}
                   visual={
                     LogoComponent ? (


### PR DESCRIPTION
## Description

`useConnectorPermission` hook for the `PermissionTreeChildren` component is not working for non managed datasource. 
Expanding a Folder will result in an error with the default error message "Failed to retrieve permissions likely due to a revoked authorization."

It was reported by one of our users here: https://dust4ai.slack.com/archives/C05LP5CMY10/p1710839317299559

-> The real fix is to make the TreeView work with Folders and I'll create an eng runner card, but this is the quick fix. We don't want to display this misleading error message. 

## Risk

/

## Deploy Plan

/
