### PR TITLE
Aric fix no workspace page

### DIFF
--- a/front/lib/iam/session.ts
+++ b/front/lib/iam/session.ts
@@ -16,6 +16,7 @@ import {
   maybeUpdateFromExternalUser,
 } from "@app/lib/iam/users";
 import { Membership, Workspace } from "@app/lib/models";
+import logger from "@app/logger/logger";
 import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
 
 /**
@@ -181,6 +182,10 @@ export function makeGetServerSidePropsRequirementsWrapper<
       ) {
         if (typeof context.query.wId !== "string") {
           // this should never happen.
+          logger.error(
+            { panic: true, path: context.resolvedUrl },
+            "canUseProduct should never be true outside of a workspace context."
+          );
           throw new Error(
             "canUseProduct should never be true outside of a workspace context."
           );

--- a/front/pages/no-workspace.tsx
+++ b/front/pages/no-workspace.tsx
@@ -11,7 +11,7 @@ import { useRouter } from "next/router";
 
 import {
   getUserFromSession,
-  makeGetServerSidePropsRequirementsWrapper,
+  withDefaultUserAuthPaywallWhitelisted,
 } from "@app/lib/iam/session";
 import { Membership, Workspace, WorkspaceHasDomain } from "@app/lib/models";
 import logger from "@app/logger/logger";
@@ -56,10 +56,7 @@ async function fetchRevokedWorkspace(
   return Workspace.findByPk(revokedWorkspaceId);
 }
 
-export const getServerSideProps = makeGetServerSidePropsRequirementsWrapper({
-  requireUserPrivilege: "user",
-  requireCanUseProduct: false,
-})<{
+export const getServerSideProps = withDefaultUserAuthPaywallWhitelisted<{
   status: "auto-join-disabled" | "revoked";
   userFirstName: string;
   workspaceName: string;

--- a/front/pages/no-workspace.tsx
+++ b/front/pages/no-workspace.tsx
@@ -11,7 +11,7 @@ import { useRouter } from "next/router";
 
 import {
   getUserFromSession,
-  withDefaultUserAuthRequirements,
+  makeGetServerSidePropsRequirementsWrapper,
 } from "@app/lib/iam/session";
 import { Membership, Workspace, WorkspaceHasDomain } from "@app/lib/models";
 import logger from "@app/logger/logger";
@@ -56,7 +56,10 @@ async function fetchRevokedWorkspace(
   return Workspace.findByPk(revokedWorkspaceId);
 }
 
-export const getServerSideProps = withDefaultUserAuthRequirements<{
+export const getServerSideProps = makeGetServerSidePropsRequirementsWrapper({
+  requireUserPrivilege: "user",
+  requireCanUseProduct: false,
+})<{
   status: "auto-join-disabled" | "revoked";
   userFirstName: string;
   workspaceName: string;


### PR DESCRIPTION
## Description

The page no-workspace which the user is redirected to when signup without joining a workspace was gated by the wrong serverSidePRopsWrapper, leading to a 500 errors, leading to the impossibility of users to signup (apparently, to be confirmed).
This PR fixes it.

cc @spolu @flvndvd 

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
