### PR TITLE
Clean up fair limits SQL schema + remove legacy dialog

### DIFF
--- a/front/components/app/ReachedLimitPopup.tsx
+++ b/front/components/app/ReachedLimitPopup.tsx
@@ -1,0 +1,64 @@
+import { Dialog } from "@dust-tt/sparkle";
+import type { SubscriptionType } from "@dust-tt/types";
+import { useRouter } from "next/router";
+
+import { isTrial } from "@app/lib/plans/trial";
+
+function getUpsellDialogDetailsForFreeTrial() {
+  return {
+    title: "You’ve reach the Free Trial daily messages limit",
+    validateLabel: "Skip trial & upgrade now",
+    children: (
+      <p className="text-sm font-normal text-element-800">
+        Come back tomorrow for a fresh start or{" "}
+        <span className="font-bold">skip the trial and start paying now.</span>
+      </p>
+    ),
+  };
+}
+
+function getUpsellDialogDetailsForFreePlan() {
+  return {
+    title: "You’ve reach the messages limit",
+    validateLabel: "Check Dust plans",
+    children: (
+      <p className="text-sm font-normal text-element-800">
+        Looks like you've used up all your messages. Check out our paid plans to
+        get unlimited messages.
+      </p>
+    ),
+  };
+}
+
+export function ReachedLimitPopup({
+  isOpened,
+  onClose,
+  subscription,
+  workspaceId,
+}: {
+  isOpened: boolean;
+  onClose: () => void;
+  subscription: SubscriptionType;
+  workspaceId: string;
+}) {
+  const router = useRouter();
+
+  const { children, title, validateLabel } = isTrial(subscription)
+    ? getUpsellDialogDetailsForFreeTrial()
+    : getUpsellDialogDetailsForFreePlan();
+
+  return (
+    <Dialog
+      isOpen={isOpened}
+      title={title}
+      onValidate={() => {
+        void router.push(`/w/${workspaceId}/subscription`);
+      }}
+      onCancel={() => onClose()}
+      cancelLabel="Close"
+      validateLabel={validateLabel}
+    >
+      {children}
+    </Dialog>
+  );
+}

--- a/front/lib/models/plan.ts
+++ b/front/lib/models/plan.ts
@@ -106,8 +106,7 @@ Plan.init(
     },
     maxMessagesTimeframe: {
       type: DataTypes.ENUM("day", "lifetime"),
-      // TODO(2024-03-18 flav) Set to false, once migrated.
-      allowNull: true,
+      allowNull: false,
     },
     maxUsersInWorkspace: {
       type: DataTypes.INTEGER,

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -150,7 +150,6 @@
       "devDependencies": {
         "@tsconfig/recommended": "^1.0.3",
         "@types/uuid": "^9.0.7",
-        "sequelize": "^6.31.0",
         "tslib": "^2.6.2",
         "typescript": "^5.0.3"
       },

--- a/front/pages/w/[wId]/assistant/[cId]/index.tsx
+++ b/front/pages/w/[wId]/assistant/[cId]/index.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/router";
 import type { ReactElement } from "react";
 import { useContext, useEffect, useState } from "react";
 
+import { ReachedLimitPopup } from "@app/components/app/ReachedLimitPopup";
 import { AssistantDetails } from "@app/components/assistant/AssistantDetails";
 import Conversation from "@app/components/assistant/conversation/Conversation";
 import type { ConversationLayoutProps } from "@app/components/assistant/conversation/ConversationLayout";
@@ -13,7 +14,6 @@ import { FixedAssistantInputBar } from "@app/components/assistant/conversation/i
 import { submitMessage } from "@app/components/assistant/conversation/lib";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
-import { LimitReachedPopup } from "@app/pages/w/[wId]/assistant/new";
 
 const { URL = "", GA_TRACKING_ID = "" } = process.env;
 
@@ -154,7 +154,7 @@ export default function AssistantConversation({
         stickyMentions={stickyMentions}
         conversationId={conversationId}
       />
-      <LimitReachedPopup
+      <ReachedLimitPopup
         isOpened={planLimitReached}
         onClose={() => setPlanLimitReached(false)}
         subscription={subscription}

--- a/front/pages/w/[wId]/assistant/new.tsx
+++ b/front/pages/w/[wId]/assistant/new.tsx
@@ -24,6 +24,7 @@ import { useRouter } from "next/router";
 import type { ReactElement } from "react";
 import { useContext, useEffect, useState } from "react";
 
+import { ReachedLimitPopup } from "@app/components/app/ReachedLimitPopup";
 import { AssistantDetails } from "@app/components/assistant/AssistantDetails";
 import type { ConversationLayoutProps } from "@app/components/assistant/conversation/ConversationLayout";
 import ConversationLayout from "@app/components/assistant/conversation/ConversationLayout";
@@ -446,72 +447,13 @@ export default function AssistantNew({
         onSubmit={handleSubmit}
         conversationId={null}
       />
-      <LimitReachedPopup
+      <ReachedLimitPopup
         isOpened={planLimitReached}
         onClose={() => setPlanLimitReached(false)}
         subscription={subscription}
         workspaceId={owner.sId}
       />
     </>
-  );
-}
-
-function getUpsellDialogDetailsForFreeTrial() {
-  return {
-    title: "You’ve reach the Free Trial daily messages limit",
-    validateLabel: "Skip trial & upgrade now",
-    children: (
-      <p className="text-sm font-normal text-element-800">
-        Come back tomorrow for a fresh start or{" "}
-        <span className="font-bold">skip the trial and start paying now.</span>
-      </p>
-    ),
-  };
-}
-
-function getUpsellDialogDetailsForFreePlan() {
-  return {
-    title: "You’ve reach the messages limit",
-    validateLabel: "Check Dust plans",
-    children: (
-      <p className="text-sm font-normal text-element-800">
-        Looks like you've used up all your messages. Check out our paid plans to
-        get unlimited messages.
-      </p>
-    ),
-  };
-}
-
-export function LimitReachedPopup({
-  isOpened,
-  onClose,
-  subscription,
-  workspaceId,
-}: {
-  isOpened: boolean;
-  onClose: () => void;
-  subscription: SubscriptionType;
-  workspaceId: string;
-}) {
-  const router = useRouter();
-
-  const { children, title, validateLabel } = isTrial(subscription)
-    ? getUpsellDialogDetailsForFreeTrial()
-    : getUpsellDialogDetailsForFreePlan();
-
-  return (
-    <Dialog
-      isOpen={isOpened}
-      title={title}
-      onValidate={() => {
-        void router.push(`/w/${workspaceId}/subscription`);
-      }}
-      onCancel={() => onClose()}
-      cancelLabel="Close"
-      validateLabel={validateLabel}
-    >
-      {children}
-    </Dialog>
   );
 }
 

--- a/front/pages/w/[wId]/assistant/new.tsx
+++ b/front/pages/w/[wId]/assistant/new.tsx
@@ -456,6 +456,32 @@ export default function AssistantNew({
   );
 }
 
+function getUpsellDialogDetailsForFreeTrial() {
+  return {
+    title: "You’ve reach the Free Trial daily messages limit",
+    validateLabel: "Skip trial & upgrade now",
+    children: (
+      <p className="text-sm font-normal text-element-800">
+        Come back tomorrow for a fresh start or{" "}
+        <span className="font-bold">skip the trial and start paying now.</span>
+      </p>
+    ),
+  };
+}
+
+function getUpsellDialogDetailsForFreePlan() {
+  return {
+    title: "You’ve reach the messages limit",
+    validateLabel: "Check Dust plans",
+    children: (
+      <p className="text-sm font-normal text-element-800">
+        Looks like you've used up all your messages. Check out our paid plans to
+        get unlimited messages.
+      </p>
+    ),
+  };
+}
+
 export function LimitReachedPopup({
   isOpened,
   onClose,
@@ -469,39 +495,23 @@ export function LimitReachedPopup({
 }) {
   const router = useRouter();
 
-  if (isTrial(subscription)) {
-    return (
-      <Dialog
-        isOpen={isOpened}
-        title="You’ve reach the Free Trial daily messages limit"
-        onValidate={() => {
-          void router.push(`/w/${workspaceId}/subscription`);
-        }}
-        onCancel={() => onClose()}
-        cancelLabel="Close"
-        validateLabel="Skip trial & upgrade now"
-      >
-        <p className="text-sm font-normal text-element-800">
-          Come back tomorrow for a fresh start or{" "}
-          <span className="font-bold">
-            skip the trial and start paying now.
-          </span>
-        </p>
-      </Dialog>
-    );
-  }
+  const { children, title, validateLabel } = isTrial(subscription)
+    ? getUpsellDialogDetailsForFreeTrial()
+    : getUpsellDialogDetailsForFreePlan();
 
   return (
-    <Popup
-      show={isOpened}
-      chipLabel="Free plan"
-      description="Looks like you've used up all your messages. Check out our paid plans to get unlimited messages."
-      buttonLabel="Check Dust plans"
-      buttonClick={() => {
+    <Dialog
+      isOpen={isOpened}
+      title={title}
+      onValidate={() => {
         void router.push(`/w/${workspaceId}/subscription`);
       }}
-      className="fixed bottom-16 right-16"
-    />
+      onCancel={() => onClose()}
+      cancelLabel="Close"
+      validateLabel={validateLabel}
+    >
+      {children}
+    </Dialog>
   );
 }
 

--- a/front/pages/w/[wId]/assistant/new.tsx
+++ b/front/pages/w/[wId]/assistant/new.tsx
@@ -4,10 +4,8 @@ import {
   Button,
   ChatBubbleBottomCenterTextIcon,
   CloudArrowLeftRightIcon,
-  Dialog,
   FolderOpenIcon,
   Page,
-  Popup,
   QuestionMarkCircleIcon,
   RobotSharedIcon,
 } from "@dust-tt/sparkle";
@@ -15,7 +13,6 @@ import type {
   ConversationType,
   LightAgentConfigurationType,
   MentionType,
-  SubscriptionType,
   UserType,
 } from "@dust-tt/types";
 import type { InferGetServerSidePropsType } from "next";
@@ -40,7 +37,6 @@ import { compareAgentsForSort } from "@app/lib/assistant";
 import { getRandomGreetingForName } from "@app/lib/client/greetings";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
-import { isTrial } from "@app/lib/plans/trial";
 import { useAgentConfigurations, useUserMetadata } from "@app/lib/swr";
 import { setUserMetadataFromClient } from "@app/lib/user";
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR cleans up the SQL schema introduced in https://github.com/dust-tt/dust/pull/4347. Since the column has been successfully backfilled, we can now confidently change `allowedNull` to `false`.
Additionally, it eliminates the pop-up used for the legacy plan limit, ensuring the new dialog is consistently used instead.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

I'll run the migration from front-edge to update the field `maxMessagesTimeframe`.

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
