### PR TITLE
fix: use gpt4 turbo 128k for tables query app

### DIFF
--- a/types/src/front/lib/actions/registry.ts
+++ b/types/src/front/lib/actions/registry.ts
@@ -1,4 +1,5 @@
 import { DustAppType } from "../../../front/lib/dust_api";
+import { GPT_4_TURBO_MODEL_CONFIG } from "../assistant";
 
 const PRODUCTION_DUST_APPS_WORKSPACE_ID = "78bda07b39";
 
@@ -143,7 +144,7 @@ export const DustProdActionRegistry = createActionRegistry({
     config: {
       MODEL: {
         provider_id: "openai",
-        model_id: "gpt-4",
+        model_id: GPT_4_TURBO_MODEL_CONFIG.modelId,
         use_cache: false,
         function_call: "execute_sql_query",
       },


### PR DESCRIPTION
## Description

I initially thought "gpt4" was 128k turbo. It turns out it is not.

fixes https://github.com/dust-tt/tasks/issues/549

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
