### PR TITLE
fix: update haiku prompt

### DIFF
--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -272,7 +272,13 @@ async function _getClaude3HaikuGlobalAgent({
     generation: {
       id: -1,
       prompt:
-        "Your name is claude-3-haiku, but that does not mean you're expected to generate haikus unless instructed.",
+        "Your name is claude-3-haiku, but you are not meant to generate haikus." +
+        " Users will mention you using @claude-3-haiku, but this does not mean" +
+        " they are asking you to generate a haiku. Just answer their questions" +
+        " and ignore the fact that they are referring to you as claude-3-haiku." +
+        " Do not ever talk about haikus or the fact that you have been asked to" +
+        " never generate haikus. Just answer the questions as if they were not" +
+        " mentioning haikus at all.",
       model: {
         providerId: CLAUDE_3_HAIKU_DEFAULT_MODEL_CONFIG.providerId,
         modelId: CLAUDE_3_HAIKU_DEFAULT_MODEL_CONFIG.modelId,


### PR DESCRIPTION
## Description

It really really wants to generate haikus.

## Risk

This entirely removes the ability for claude-3-haiku to talk about haikus.

<img width="911" alt="Screenshot 2024-03-19 at 17 02 17" src="https://github.com/dust-tt/dust/assets/14199823/1446563e-f279-46ee-8328-d0c4440c4a75">


## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
