### PR TITLE
Move to new Pro plan

### DIFF
--- a/front/components/PlansTables.tsx
+++ b/front/components/PlansTables.tsx
@@ -154,31 +154,6 @@ const ENTERPRISE_PLAN_ITEMS: PriceTableItem[] = [
   },
 ];
 
-function FreePriceTable({ size }: { size: "sm" | "xs" }) {
-  return (
-    <PriceTable
-      title="Free"
-      price="0€"
-      priceLabel=""
-      color="emerald"
-      size={size}
-      magnified={false}
-    >
-      <PriceTable.Item size={size} label="One user" variant="dash" />
-      <PriceTable.Item size={size} label="One workspace" variant="dash" />
-      <PriceTable.Item label="Privacy and Data Security" />
-      <PriceTable.Item
-        label="Regular models (GPT-3.5, Claude instant...)"
-        variant="dash"
-      />
-      <PriceTable.Item label="Unlimited custom assistants" />
-      <PriceTable.Item label="50 assistant messages" variant="dash" />
-      <PriceTable.Item label="50 documents as data sources" variant="dash" />
-      <PriceTable.Item label="No connections" variant="xmark" />
-    </PriceTable>
-  );
-}
-
 export function ProPriceTable({
   size,
   plan,
@@ -296,21 +271,6 @@ export function PricePlans({
                   "md:py-3 md:text-lg",
                   "ring-0 focus:outline-none",
                   selected
-                    ? "bg-emerald-400 text-white shadow dark:bg-emerald-500"
-                    : "dark:s-text-element-700-dark text-element-700 hover:bg-white/20 hover:text-white"
-                )
-              }
-            >
-              Free
-            </Tab>
-            <Tab
-              className={({ selected }) =>
-                classNames(
-                  "w-full rounded-full font-semibold transition-all duration-300 ease-out",
-                  "py-2 text-sm",
-                  "md:py-3 md:text-lg",
-                  "ring-0 focus:outline-none",
-                  selected
                     ? "bg-sky-400 text-white shadow dark:bg-sky-500"
                     : "dark:s-text-element-700-dark text-element-700 hover:bg-white/20 hover:text-white"
                 )
@@ -336,9 +296,6 @@ export function PricePlans({
           </Tab.List>
           <Tab.Panels className="mt-8">
             <Tab.Panel>
-              <FreePriceTable size={size} />
-            </Tab.Panel>
-            <Tab.Panel>
               <ProPriceTable
                 display={display}
                 size={size}
@@ -361,7 +318,6 @@ export function PricePlans({
   } else {
     return (
       <div className={classNames(flexCSS, className)}>
-        <FreePriceTable size={size} />
         <ProPriceTable
           size={size}
           plan={plan}

--- a/front/pages/api/create-new-workspace.ts
+++ b/front/pages/api/create-new-workspace.ts
@@ -4,7 +4,6 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { getSession } from "@app/lib/auth";
 import { getUserFromSession } from "@app/lib/iam/session";
 import { createWorkspace } from "@app/lib/iam/workspaces";
-import { internalSubscribeWorkspaceToFreeTestPlan } from "@app/lib/plans/subscription";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import { createAndLogMembership } from "@app/pages/api/login";
 
@@ -55,10 +54,6 @@ async function handler(
     workspace,
     userId: user.id,
     role: "admin",
-  });
-
-  await internalSubscribeWorkspaceToFreeTestPlan({
-    workspaceId: workspace.sId,
   });
 
   res.status(200).json({ sId: workspace.sId });

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -20,10 +20,7 @@ import {
 } from "@app/lib/iam/workspaces";
 import type { MembershipInvitation, User } from "@app/lib/models";
 import { Membership, Workspace } from "@app/lib/models";
-import {
-  internalSubscribeWorkspaceToFreeTestPlan,
-  updateWorkspacePerSeatSubscriptionUsage,
-} from "@app/lib/plans/subscription";
+import { updateWorkspacePerSeatSubscriptionUsage } from "@app/lib/plans/subscription";
 import logger from "@app/logger/logger";
 import { apiError, withLogging } from "@app/logger/withlogging";
 
@@ -262,10 +259,6 @@ async function handleRegularSignupFlow(
       workspace,
       userId: user.id,
       role: "admin",
-    });
-
-    await internalSubscribeWorkspaceToFreeTestPlan({
-      workspaceId: workspace.sId,
     });
 
     return new Ok({ flow: null, workspace });


### PR DESCRIPTION
## Description

This is the final PR to release the new Pro plan.
This will:
- Stop putting new users on the FREE_TEST_PLAN. Instead, they will have no subscription in the database and they will be put on the FREE_NO_PLAN.
- Right before deploying this PR, the trial days for the plan `PRO_PLAN_SEAT_29` should be set to 14 in Poke.

## Testing

Here are all the tests I conducted with this exact commit:
https://github.com/dust-tt/dust/issues/4356


## Screenshots


![Screenshot 2024-03-20 at 13 56 08](https://github.com/dust-tt/dust/assets/358965/c3616866-a3e4-41c3-bc62-dbe54349b204)

![Screenshot 2024-03-20 at 13 56 26](https://github.com/dust-tt/dust/assets/358965/e390f5f6-a4b4-4e89-bf05-4a7346e4bf7a)
![Screenshot 2024-03-20 at 13 56 22](https://github.com/dust-tt/dust/assets/358965/93eee704-2f9f-47fd-a7f6-a12a290cae3d)



<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
