### PR TITLE
Fix Accept CSV in content Fragment

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -114,7 +114,7 @@ const InputBarContainer = ({
       <div className="flex flex-row items-end justify-between gap-2 self-stretch py-2 pr-2 sm:flex-col sm:border-0">
         <div className="flex gap-5 rounded-full border border-structure-200/60 px-4 py-2 sm:gap-3 sm:px-2">
           <input
-            accept=".txt,.pdf,.md"
+            accept=".txt,.pdf,.md,.csv"
             onChange={async (e) => {
               await onInputFileChange(e);
               editorService.focusEnd();
@@ -128,7 +128,7 @@ const InputBarContainer = ({
             icon={AttachmentIcon}
             size="sm"
             disabled={disableAttachment}
-            tooltip="Add a document to the conversation (10MB maximum, only .txt, .pdf, .md)."
+            tooltip="Add a document to the conversation (10MB maximum, only .txt, .pdf, .md, .csv)."
             tooltipPosition="above"
             className="flex"
             onClick={() => {


### PR DESCRIPTION
## Description

Eng runner card: https://github.com/dust-tt/tasks/issues/550
Slack thread: https://dust4ai.slack.com/archives/C050A0S2Z7F/p1710930161901619

Chrome was already accepting csv but Firefox it seems like Firefox respect the "accept" property of the Input 😄 

## Risk

/

## Deploy Plan

/
