### PR TITLE
Github model: set sourceUrl as text over varchar(255)

### DIFF
--- a/connectors/src/lib/models/github.ts
+++ b/connectors/src/lib/models/github.ts
@@ -217,7 +217,7 @@ GithubCodeRepository.init(
       allowNull: false,
     },
     sourceUrl: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   },
@@ -293,7 +293,7 @@ GithubCodeFile.init(
       allowNull: false,
     },
     sourceUrl: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     contentHash: {
@@ -375,7 +375,7 @@ GithubCodeDirectory.init(
       allowNull: false,
     },
     sourceUrl: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   },


### PR DESCRIPTION
## Description

We got this error when trying to insert a Github code file: 

`Log: DatabaseError: value too long for type character varying(255)`

[https://app.datadoghq.eu/logs?query=%40panic%3Atrue%20&agg_m=count&agg_t=count&cols=h[…]z=stream&from_ts=1710948059833&to_ts=1710948959833&live=true](https://app.datadoghq.eu/logs?query=%40panic%3Atrue%20&agg_m=count&agg_t=count&cols=host%2Cservice&event=AgAAAY5cf1mRJrHcjAAAAAAAAAAYAAAAAEFZNWNmMXB1QUFCRUp1azF6TnJkaHdPcQAAACQAAAAAMDE4ZTVjN2YtN2E3Ni00ZWQwLWFkNzEtZjU2MDM5ODZlNWRk&fromUser=true&index=%2A&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1710948059833&to_ts=1710948959833&live=true)

Turns out the sourceUrl of the failing doc was 256 characters. 

## Risk

/

## Deploy Plan

Run init_db on connectors
