### PR TITLE
Price table currency

### DIFF
--- a/front/components/PlansTables.tsx
+++ b/front/components/PlansTables.tsx
@@ -167,11 +167,15 @@ export function ProPriceTable({
   isProcessing?: boolean;
   display: PriceTableDisplay;
 }) {
+  const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const isLikelyInUS = timeZone.startsWith("America");
+  const currency = isLikelyInUS ? "$" : "€";
+
   const biggerButtonSize = size === "xs" ? "sm" : "md";
   return (
     <PriceTable
       title="Pro"
-      price={`${PRO_PLAN_29_COST_EUR}€`}
+      price={`${PRO_PLAN_29_COST_EUR}${currency}`}
       color="sky"
       priceLabel="/ month / user"
       size={size}


### PR DESCRIPTION
## Description

We want to show prices in $ for the US on the Price table displaying the Pro plan. 
If we wanted perfect accuracy we would use an IP Geolocation Services but I think this is a good quick win. WDYT?

Next step is to edit the Pro plan to allow multiple currencies on its default price. 

## Risk

Might not be 100% accurate, default is set to €.

## Deploy Plan

/
