### PR TITLE
Showing the subscription.trialing flag on #user-operations logs

### DIFF
--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -419,7 +419,9 @@ async function handler(
           owner.name
         }\` sId: \`${owner.sId}\` connectorId: \`${
           connectorsRes.value.id
-        }\` provider: \`${provider}\``,
+        }\` provider: \`${provider}\` trialing: \`${
+          auth.subscription()?.trialing ? "true" : "false"
+        }}\``,
       });
 
       dataSource = await dataSource.update({


### PR DESCRIPTION
## Description

Showing the subscription.trialing flag on #user-operations logs #4397


Adding the `subscription.trialing` flag to these Slack logs:

![Screenshot 2024-03-22 at 10 08 00](https://github.com/dust-tt/dust/assets/358965/dfb66bd0-5fc9-4d3f-b705-9d62d57fe341)


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
