### PR TITLE
Add custom date format parser for Google Spreadsheet dates

### DIFF
--- a/front/lib/api/tables.ts
+++ b/front/lib/api/tables.ts
@@ -337,6 +337,8 @@ async function rowsFromCsv(
             DateTime.fromRFC2822,
             DateTime.fromHTTP,
             DateTime.fromSQL,
+            // Google Spreadsheet date format parser.
+            (text: string) => DateTime.fromFormat(text, "d-MMM-yyyy"),
           ];
           const trimmedV = v.trim();
           for (const parse of dateParsers) {


### PR DESCRIPTION
## Description

See https://github.com/dust-tt/tasks/issues/555.

This PR introduces the ability to handle the date format `d-MMM-yyyy` (e.g. 6-jan-2023) in our table schemas, which is commonly used in Google Spreadsheets.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
