### PR TITLE
make subscriptionForWorkspace() take a workspace.sId vs a Workspace

### DIFF
--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -60,7 +60,7 @@ const workspace = async (command: string, args: parseArgs.ParsedArgs) => {
       console.log(`  wId: ${w.sId}`);
       console.log(`  name: ${w.name}`);
 
-      const subscription = await subscriptionForWorkspace(w);
+      const subscription = await subscriptionForWorkspace(w.id);
       const plan = subscription.plan;
       console.log(`  plan:`);
       console.log(`    limits:`);

--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -60,7 +60,7 @@ const workspace = async (command: string, args: parseArgs.ParsedArgs) => {
       console.log(`  wId: ${w.sId}`);
       console.log(`  name: ${w.name}`);
 
-      const subscription = await subscriptionForWorkspace(w.id);
+      const subscription = await subscriptionForWorkspace(w.sId);
       const plan = subscription.plan;
       console.log(`  plan:`);
       console.log(`    limits:`);

--- a/front/lib/amplitude/back/index.ts
+++ b/front/lib/amplitude/back/index.ts
@@ -85,7 +85,7 @@ export async function populateWorkspaceProperties(workspace: Workspace) {
   }
   const amplitude = getBackendClient();
 
-  const subscription = await subscriptionForWorkspace(workspace.id);
+  const subscription = await subscriptionForWorkspace(workspace.sId);
   const memberCount = await countActiveSeatsInWorkspace(workspace.sId);
   const groupProperties = new Identify();
   groupProperties.set("name", workspace.name);

--- a/front/lib/amplitude/back/index.ts
+++ b/front/lib/amplitude/back/index.ts
@@ -85,7 +85,7 @@ export async function populateWorkspaceProperties(workspace: Workspace) {
   }
   const amplitude = getBackendClient();
 
-  const subscription = await subscriptionForWorkspace(workspace);
+  const subscription = await subscriptionForWorkspace(workspace.id);
   const memberCount = await countActiveSeatsInWorkspace(workspace.sId);
   const groupProperties = new Identify();
   groupProperties.set("name", workspace.name);

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -138,7 +138,7 @@ export class Authenticator {
             ? (membership.role as RoleType)
             : "none";
         })(),
-        subscriptionForWorkspace(workspace),
+        subscriptionForWorkspace(workspace.id),
         (async () => {
           return (
             await FeatureFlag.findAll({
@@ -202,7 +202,7 @@ export class Authenticator {
 
     if (workspace) {
       [subscription, flags] = await Promise.all([
-        subscriptionForWorkspace(workspace),
+        subscriptionForWorkspace(workspace.id),
         (async () => {
           return (
             await FeatureFlag.findAll({
@@ -268,7 +268,7 @@ export class Authenticator {
 
     if (workspace) {
       [subscription, flags] = await Promise.all([
-        subscriptionForWorkspace(workspace),
+        subscriptionForWorkspace(workspace.id),
         (async () => {
           return (
             await FeatureFlag.findAll({
@@ -313,7 +313,7 @@ export class Authenticator {
     let flags: WhitelistableFeature[] = [];
 
     [subscription, flags] = await Promise.all([
-      subscriptionForWorkspace(workspace),
+      subscriptionForWorkspace(workspace.id),
       (async () => {
         return (
           await FeatureFlag.findAll({
@@ -350,7 +350,7 @@ export class Authenticator {
     let flags: WhitelistableFeature[] = [];
 
     [subscription, flags] = await Promise.all([
-      subscriptionForWorkspace(workspace),
+      subscriptionForWorkspace(workspace.id),
       (async () => {
         return (
           await FeatureFlag.findAll({
@@ -518,7 +518,7 @@ export async function getAPIKey(
  * @returns SubscriptionType
  */
 export async function subscriptionForWorkspace(
-  w: Workspace
+  workspaceId: Workspace["id"]
 ): Promise<Promise<SubscriptionType>> {
   const activeSubscription = await Subscription.findOne({
     attributes: [
@@ -532,7 +532,7 @@ export async function subscriptionForWorkspace(
       "stripeSubscriptionId",
       "trialing",
     ],
-    where: { workspaceId: w.id, status: "active" },
+    where: { workspaceId: workspaceId, status: "active" },
     include: [
       {
         model: Plan,
@@ -554,7 +554,7 @@ export async function subscriptionForWorkspace(
     } else {
       logger.error(
         {
-          workspaceId: w.id,
+          workspaceId: workspaceId,
           activeSubscription,
         },
         "Cannot find plan for active subscription. Will use limits of FREE_TEST_PLAN instead. Please check and fix."

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -138,7 +138,7 @@ export class Authenticator {
             ? (membership.role as RoleType)
             : "none";
         })(),
-        subscriptionForWorkspace(workspace.id),
+        subscriptionForWorkspace(workspace.sId),
         (async () => {
           return (
             await FeatureFlag.findAll({
@@ -202,7 +202,7 @@ export class Authenticator {
 
     if (workspace) {
       [subscription, flags] = await Promise.all([
-        subscriptionForWorkspace(workspace.id),
+        subscriptionForWorkspace(workspace.sId),
         (async () => {
           return (
             await FeatureFlag.findAll({
@@ -268,7 +268,7 @@ export class Authenticator {
 
     if (workspace) {
       [subscription, flags] = await Promise.all([
-        subscriptionForWorkspace(workspace.id),
+        subscriptionForWorkspace(workspace.sId),
         (async () => {
           return (
             await FeatureFlag.findAll({
@@ -313,7 +313,7 @@ export class Authenticator {
     let flags: WhitelistableFeature[] = [];
 
     [subscription, flags] = await Promise.all([
-      subscriptionForWorkspace(workspace.id),
+      subscriptionForWorkspace(workspace.sId),
       (async () => {
         return (
           await FeatureFlag.findAll({
@@ -350,7 +350,7 @@ export class Authenticator {
     let flags: WhitelistableFeature[] = [];
 
     [subscription, flags] = await Promise.all([
-      subscriptionForWorkspace(workspace.id),
+      subscriptionForWorkspace(workspace.sId),
       (async () => {
         return (
           await FeatureFlag.findAll({
@@ -518,8 +518,17 @@ export async function getAPIKey(
  * @returns SubscriptionType
  */
 export async function subscriptionForWorkspace(
-  workspaceId: Workspace["id"]
-): Promise<Promise<SubscriptionType>> {
+  workspaceId: string
+): Promise<SubscriptionType> {
+  const workspace = await Workspace.findOne({
+    where: {
+      sId: workspaceId,
+    },
+  });
+  if (!workspace) {
+    throw new Error(`Could not find workspace with sId ${workspaceId}`);
+  }
+
   const activeSubscription = await Subscription.findOne({
     attributes: [
       "endDate",
@@ -532,7 +541,7 @@ export async function subscriptionForWorkspace(
       "stripeSubscriptionId",
       "trialing",
     ],
-    where: { workspaceId: workspaceId, status: "active" },
+    where: { workspaceId: workspace.id, status: "active" },
     include: [
       {
         model: Plan,

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -219,7 +219,7 @@ async function handleRegularSignupFlow(
     }
 
     const workspaceSubscription = await subscriptionForWorkspace(
-      existingWorkspace.id
+      existingWorkspace.sId
     );
     const hasAvailableSeats = await evaluateWorkspaceSeatAvailability(
       existingWorkspace,

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -219,7 +219,7 @@ async function handleRegularSignupFlow(
     }
 
     const workspaceSubscription = await subscriptionForWorkspace(
-      existingWorkspace
+      existingWorkspace.id
     );
     const hasAvailableSeats = await evaluateWorkspaceSeatAvailability(
       existingWorkspace,


### PR DESCRIPTION
## Description

`subscriptionForWorkspace(w:Workspace)` is taking a Sequelize workspace where all it actually needs is a workspace.sId, 
making it hard to use in various use cases (revamp of the Pro plan previously, now in Amplitude tracking).

It means that when you have a `WorkspaceType` object, and want to get a `SubscriptionType` for that workspace, you have to go through `Workspace.findByPk()`.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
