### PR TITLE
GoogleDrive largeFiles flag

### DIFF
--- a/connectors/migrations/20231109_2_create_gdrive_config.ts
+++ b/connectors/migrations/20231109_2_create_gdrive_config.ts
@@ -12,6 +12,7 @@ async function main() {
     const config = await GoogleDriveConfig.create({
       connectorId: connector.id,
       pdfEnabled: false,
+      largeFilesEnabled: false,
     });
     console.log(
       `Created config for connector ${config.connectorId} with id ${config.id} and pdfEnabled ${config.pdfEnabled}`

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -117,6 +117,7 @@ export async function createGoogleDriveConnector(
 
   const googleDriveConfigurationBlob = {
     pdfEnabled: false,
+    largeFilesEnabled: false,
   };
 
   const connector = await ConnectorResource.makeNew(

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -769,17 +769,31 @@ export async function setGoogleDriveConfig(
       new Error(`Google Drive config not found with connectorId ${connectorId}`)
     );
   }
+
+  if (!["true", "false"].includes(configValue)) {
+    return new Err(
+      new Error(`Invalid config value ${configValue}, must be true or false`)
+    );
+  }
+
   switch (configKey) {
     case "pdfEnabled": {
-      if (!["true", "false"].includes(configValue)) {
-        return new Err(
-          new Error(
-            `Invalid config value ${configValue}, must be true or false`
-          )
-        );
-      }
       await config.update({
         pdfEnabled: configValue === "true",
+      });
+      const workflowRes = await launchGoogleDriveFullSyncWorkflow(
+        connectorId,
+        null
+      );
+      if (workflowRes.isErr()) {
+        return workflowRes;
+      }
+      return new Ok(void 0);
+    }
+
+    case "largeFilesEnabled": {
+      await config.update({
+        largeFilesEnabled: configValue === "true",
       });
       const workflowRes = await launchGoogleDriveFullSyncWorkflow(
         connectorId,

--- a/connectors/src/connectors/google_drive/temporal/file.ts
+++ b/connectors/src/connectors/google_drive/temporal/file.ts
@@ -18,11 +18,15 @@ import {
 } from "@connectors/connectors/google_drive/temporal/utils";
 import {
   MAX_DOCUMENT_TXT_LEN,
+  MAX_LARGE_DOCUMENT_TXT_LEN,
   renderDocumentTitleAndContent,
   upsertToDatasource,
 } from "@connectors/lib/data_sources";
 import { dpdf2text } from "@connectors/lib/dpdf2text";
-import { GoogleDriveFiles } from "@connectors/lib/models/google_drive";
+import {
+  GoogleDriveConfig,
+  GoogleDriveFiles,
+} from "@connectors/lib/models/google_drive";
 import logger from "@connectors/logger/logger";
 import type { DataSourceConfig } from "@connectors/types/data_source_config";
 import type { GoogleDriveObjectType } from "@connectors/types/google_drive";
@@ -35,6 +39,15 @@ export async function syncOneFile(
   startSyncTs: number,
   isBatchSync = false
 ): Promise<boolean> {
+  const config = await GoogleDriveConfig.findOne({
+    where: {
+      connectorId: connectorId,
+    },
+  });
+  const maxDocumentLen = config?.largeFilesEnabled
+    ? MAX_LARGE_DOCUMENT_TXT_LEN
+    : MAX_DOCUMENT_TXT_LEN;
+
   const mimeTypesToDownload = await getMimeTypesToDownload(connectorId);
   const documentId = getDocumentId(file.id);
   let documentContent: string | undefined = undefined;
@@ -183,7 +196,7 @@ export async function syncOneFile(
         // converted to utf-8 it will overcome the limit enforced below. This
         // avoids operations on very long text files, that can cause
         // Buffer.toString to crash if the file is > 500MB
-        if (res.data.byteLength > 4 * MAX_DOCUMENT_TXT_LEN) {
+        if (res.data.byteLength > 4 * maxDocumentLen) {
           logger.info(
             {
               file_id: file.id,
@@ -311,7 +324,7 @@ export async function syncOneFile(
 
     if (
       documentContent.length > 0 &&
-      documentContent.length <= MAX_DOCUMENT_TXT_LEN
+      documentContent.length <= maxDocumentLen
     ) {
       const parents = (
         await getFileParentsMemoized(

--- a/connectors/src/connectors/google_drive/temporal/file.ts
+++ b/connectors/src/connectors/google_drive/temporal/file.ts
@@ -48,7 +48,9 @@ export async function syncOneFile(
     ? MAX_LARGE_DOCUMENT_TXT_LEN
     : MAX_DOCUMENT_TXT_LEN;
 
-  const mimeTypesToDownload = await getMimeTypesToDownload(connectorId);
+  const mimeTypesToDownload = getMimeTypesToDownload({
+    pdfEnabled: config?.pdfEnabled || false,
+  });
   const documentId = getDocumentId(file.id);
   let documentContent: string | undefined = undefined;
 

--- a/connectors/src/connectors/google_drive/temporal/mime_types.ts
+++ b/connectors/src/connectors/google_drive/temporal/mime_types.ts
@@ -1,29 +1,27 @@
-import type { ModelId } from "@dust-tt/types";
-
 import type { GoogleDriveFiles } from "@connectors/lib/models/google_drive";
-import { GoogleDriveConfig } from "@connectors/lib/models/google_drive";
 
 export const MIME_TYPES_TO_EXPORT: { [key: string]: string } = {
   "application/vnd.google-apps.document": "text/plain",
   "application/vnd.google-apps.presentation": "text/plain",
 };
 
-export async function getMimeTypesToDownload(connectorId: ModelId) {
+export function getMimeTypesToDownload({
+  pdfEnabled,
+}: {
+  pdfEnabled: boolean;
+}) {
   const mimeTypes = ["text/plain"];
-  const config = await GoogleDriveConfig.findOne({
-    where: {
-      connectorId: connectorId,
-    },
-  });
-  if (config?.pdfEnabled) {
+  if (pdfEnabled) {
     mimeTypes.push("application/pdf");
   }
 
   return mimeTypes;
 }
 
-export async function getMimesTypeToSync(connectorId: ModelId) {
-  const mimeTypes = await getMimeTypesToDownload(connectorId);
+export function getMimeTypesToSync({ pdfEnabled }: { pdfEnabled: boolean }) {
+  const mimeTypes = getMimeTypesToDownload({
+    pdfEnabled,
+  });
   mimeTypes.push(...Object.keys(MIME_TYPES_TO_EXPORT));
   mimeTypes.push("application/vnd.google-apps.folder");
   mimeTypes.push("application/vnd.google-apps.spreadsheet");

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -29,6 +29,8 @@ if (!DUST_FRONT_API) {
 // We limit the document size we support. Beyond a certain size, upsert is simply too slow (>300s)
 // and large files are generally less useful anyway.
 export const MAX_DOCUMENT_TXT_LEN = 750000;
+// For some data sources we allow large documents (5mb) to be processed (behind flag).
+export const MAX_LARGE_DOCUMENT_TXT_LEN = 5000000;
 
 type UpsertContext = {
   sync_type: "batch" | "incremental";

--- a/connectors/src/lib/models/google_drive.ts
+++ b/connectors/src/lib/models/google_drive.ts
@@ -18,6 +18,7 @@ export class GoogleDriveConfig extends Model<
   declare updatedAt: CreationOptional<Date>;
   declare connectorId: ForeignKey<ConnectorModel["id"]>;
   declare pdfEnabled: boolean;
+  declare largeFilesEnabled: boolean;
 }
 GoogleDriveConfig.init(
   {
@@ -41,6 +42,11 @@ GoogleDriveConfig.init(
       allowNull: false,
     },
     pdfEnabled: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    },
+    largeFilesEnabled: {
       type: DataTypes.BOOLEAN,
       allowNull: false,
       defaultValue: false,


### PR DESCRIPTION
## Description

- Adds a largeFilesEnabled flag on Google Drive to allow support for up to 5MB files (will require a plan that accepts that)
- Adds poke toggle for this flag

Watershed is looking to aggregated PDF whose textual value go up to 3MB.

## Risk

N/A

## Deploy Plan

- deploy `prodbox`
- run init_db
- deploy `connectors`
- deploy `front`