### PR TITLE
feat(notion): multi select custom document tags

### DIFF
--- a/connectors/src/connectors/notion/lib/tags.ts
+++ b/connectors/src/connectors/notion/lib/tags.ts
@@ -22,8 +22,14 @@ export function getTagsForPage({
 
   const customTags = [];
   for (const property of parsedProperties) {
-    if (property.key.startsWith("__dust") && property.text) {
-      customTags.push(`${property.key}:${property.text}`);
+    if (property.key.startsWith("__dust") && property.value?.length) {
+      if (!Array.isArray(property.value)) {
+        customTags.push(`${property.key}:${property.value}`);
+      } else {
+        for (const v of property.value) {
+          customTags.push(`${property.key}:${v}`);
+        }
+      }
     }
   }
 

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -1741,11 +1741,12 @@ export async function renderAndUpsertPageFromCache({
     JSON.parse(pageCacheEntry.pagePropertiesText) as PageObjectProperties
   );
   for (const p of parsedProperties.filter((p) => p.key !== "title")) {
-    if (!p.text) {
+    if (!p.value) {
       continue;
     }
-    const propertyContent = `$${p.key}: ${p.text}\n`;
-    maxPropertyLength = Math.max(maxPropertyLength, p.text.length);
+    const propertyValue = Array.isArray(p.value) ? p.value.join(", ") : p.value;
+    const propertyContent = `$${p.key}: ${propertyValue}\n`;
+    maxPropertyLength = Math.max(maxPropertyLength, propertyValue.length);
     renderedPageSection.sections.unshift({
       prefix: null,
       content: propertyContent,
@@ -1833,7 +1834,10 @@ export async function renderAndUpsertPageFromCache({
     parsedProperties.find((p) => p.type === "title") ??
     parsedProperties.find((p) => p.key === "title");
 
-  const title = titleProperty?.text ?? undefined;
+  let title = titleProperty?.value ?? undefined;
+  if (Array.isArray(title)) {
+    title = title.join(" ");
+  }
 
   let upsertTs: number | undefined = undefined;
   let skipReason: string | null = null;


### PR DESCRIPTION
## Description

We previously added ability for users to add custom tags to notion documents:
https://github.com/dust-tt/dust/pull/3720.

Any property with a name starting with `__dust` is being added as a tag on the QDrant document.

This commit adds improved support for properties that are multi-select: instead of a single tag, multi-select properties will generate N tags (one for each array value).

## Risk

Well tested. Risk is limited to notion sync.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
