### PR TITLE
Add dedicated endpoint for conversation participants

### DIFF
--- a/front/components/assistant/conversation/ConversationParticipants.tsx
+++ b/front/components/assistant/conversation/ConversationParticipants.tsx
@@ -19,7 +19,7 @@ export function ConversationParticipants({
   });
 
   if (!conversationParticipants) {
-    return <></>;
+    return null;
   }
 
   const { agents, users } = conversationParticipants;
@@ -39,10 +39,7 @@ export function ConversationParticipants({
           />
         ))}
       </Avatar.Stack>
-      <Avatar.Stack
-        size="sm"
-        nbMoreItems={users.length > 4 ? users.length - 4 : 0}
-      >
+      <Avatar.Stack size="sm" nbMoreItems={Math.max(users.length - 4, 0)}>
         {users.slice(0, 4).map((user, i) => (
           <Avatar
             name={user.fullName || user.username}

--- a/front/components/assistant/conversation/ConversationParticipants.tsx
+++ b/front/components/assistant/conversation/ConversationParticipants.tsx
@@ -1,59 +1,36 @@
 import { Avatar } from "@dust-tt/sparkle";
-import type { ConversationType } from "@dust-tt/types";
+import type { WorkspaceType } from "@dust-tt/types";
 import React from "react";
 
+import { useConversationParticipants } from "@app/lib/swr";
+
+interface ConversationParticipantsProps {
+  conversationId: string;
+  owner: WorkspaceType;
+}
+
 export function ConversationParticipants({
-  conversation,
-}: {
-  conversation: ConversationType;
-}) {
-  type UserParticipant = {
-    username: string;
-    fullName: string | null;
-    pictureUrl: string | null;
-  };
-  type AgentParticipant = {
-    configurationId: string;
-    name: string;
-    pictureUrl: string;
-  };
-  const userParticipantsMap = new Map<string, UserParticipant>();
-  const agentParticipantsMap = new Map<string, AgentParticipant>();
-  conversation.content.map((messages) => {
-    messages.map((m) => {
-      if (m.type === "user_message") {
-        const key = `${m.context.username}-${m.context.profilePictureUrl}`;
-        if (!userParticipantsMap.has(key)) {
-          userParticipantsMap.set(key, {
-            username: m.context.username,
-            fullName: m.context.fullName,
-            pictureUrl: m.user?.image || m.context.profilePictureUrl,
-          });
-        }
-      } else if (m.type === "agent_message") {
-        const key = `${m.configuration.sId}`;
-        if (!agentParticipantsMap.has(key)) {
-          agentParticipantsMap.set(key, {
-            configurationId: m.configuration.sId,
-            name: m.configuration.name,
-            pictureUrl: m.configuration.pictureUrl,
-          });
-        }
-      }
-    });
+  conversationId,
+  owner,
+}: ConversationParticipantsProps) {
+  const { conversationParticipants } = useConversationParticipants({
+    conversationId,
+    workspaceId: owner.sId,
   });
-  const userParticipants = Array.from(userParticipantsMap.values());
-  const agentParticipants = Array.from(agentParticipantsMap.values());
+
+  if (!conversationParticipants) {
+    return <></>;
+  }
+
+  const { agents, users } = conversationParticipants;
 
   return (
     <div className="flex gap-6">
       <Avatar.Stack
         size="sm"
-        nbMoreItems={
-          agentParticipants.length > 4 ? agentParticipants.length - 4 : 0
-        }
+        nbMoreItems={agents.length > 4 ? agents.length - 4 : 0}
       >
-        {agentParticipants.slice(0, 4).map((agent) => (
+        {agents.slice(0, 4).map((agent) => (
           <Avatar
             name={agent.name}
             visual={agent.pictureUrl}
@@ -64,11 +41,9 @@ export function ConversationParticipants({
       </Avatar.Stack>
       <Avatar.Stack
         size="sm"
-        nbMoreItems={
-          userParticipants.length > 4 ? userParticipants.length - 4 : 0
-        }
+        nbMoreItems={users.length > 4 ? users.length - 4 : 0}
       >
-        {userParticipants.slice(0, 4).map((user, i) => (
+        {users.slice(0, 4).map((user, i) => (
           <Avatar
             name={user.fullName || user.username}
             visual={user.pictureUrl}

--- a/front/components/assistant/conversation/ConversationTitle.tsx
+++ b/front/components/assistant/conversation/ConversationTitle.tsx
@@ -172,7 +172,10 @@ export function ConversationTitle({
         </div>
         <div className="flex items-center">
           <div className="hidden pr-6 lg:flex">
-            <ConversationParticipants conversation={conversation} />
+            <ConversationParticipants
+              conversationId={conversation.sId}
+              owner={owner}
+            />
           </div>
           <Button.List>
             <div className="hidden lg:flex">

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -18,6 +18,7 @@ import type { FetchConversationMessagesResponse } from "@app/lib/api/assistant/m
 import {
   useConversation,
   useConversationMessages,
+  useConversationParticipants,
   useConversationReactions,
   useConversations,
 } from "@app/lib/swr";
@@ -99,6 +100,11 @@ export default function ConversationViewer({
   const { reactions } = useConversationReactions({
     workspaceId: owner.sId,
     conversationId,
+  });
+
+  const { mutateConversationParticipants } = useConversationParticipants({
+    conversationId,
+    workspaceId: owner.sId,
   });
 
   const { hasMore, latestPage, oldestPage } = useMemo(() => {
@@ -273,6 +279,7 @@ export default function ConversationViewer({
 
                 return currentMessagePages;
               });
+              void mutateConversationParticipants();
             }
             break;
 
@@ -293,7 +300,13 @@ export default function ConversationViewer({
         }
       }
     },
-    [mutateConversation, mutateConversations, messages, mutateMessages]
+    [
+      mutateConversation,
+      mutateConversations,
+      messages,
+      mutateMessages,
+      mutateConversationParticipants,
+    ]
   );
 
   useEventSource(buildEventSourceURL, onEventCallback, {

--- a/front/lib/api/assistant/participants.ts
+++ b/front/lib/api/assistant/participants.ts
@@ -1,0 +1,148 @@
+import type {
+  LightAgentConfigurationType,
+  ModelId,
+  Result,
+} from "@dust-tt/types";
+import { Err, formatUserFullName, Ok } from "@dust-tt/types";
+import { Op } from "sequelize";
+
+import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
+import type { Authenticator } from "@app/lib/auth";
+import {
+  AgentMessage,
+  Conversation,
+  Message,
+  User,
+  UserMessage,
+} from "@app/lib/models";
+
+interface AgentParticipant {
+  configurationId: string;
+  name: string;
+  pictureUrl: string;
+}
+
+interface UserParticipant {
+  fullName: string | null;
+  pictureUrl: string | null;
+  username: string;
+}
+
+export interface FetchConversationParticipantsResponse {
+  participants: {
+    agents: AgentParticipant[];
+    users: UserParticipant[];
+  };
+}
+
+async function fetchAllUsersById(
+  userIds: ModelId[]
+): Promise<UserParticipant[]> {
+  const users = (
+    await User.findAll({
+      attributes: ["firstName", "lastName", "imageUrl", "username"],
+      where: {
+        id: {
+          [Op.in]: userIds,
+        },
+      },
+    })
+  ).filter((u) => u !== null) as User[];
+
+  return users.map((u) => ({
+    fullName: formatUserFullName(u),
+    pictureUrl: u.imageUrl,
+    username: u.username,
+  }));
+}
+
+async function fetchAllAgentsById(
+  auth: Authenticator,
+  agentConfigurationIds: string[]
+): Promise<AgentParticipant[]> {
+  // TODO(2024-3-25 flav) Support fetching many agents by id.
+  const agents = (
+    await Promise.all(
+      agentConfigurationIds.map((agentConfigId) => {
+        return getAgentConfiguration(auth, agentConfigId);
+      })
+    )
+  ).filter((a) => a !== null) as LightAgentConfigurationType[];
+
+  return agents.map((a) => ({
+    configurationId: a.sId,
+    name: a.name,
+    pictureUrl: a.pictureUrl,
+  }));
+}
+
+export async function fetchConversationParticipants(
+  auth: Authenticator,
+  conversationId: string
+): Promise<Result<FetchConversationParticipantsResponse, Error>> {
+  const owner = auth.workspace();
+  if (!owner) {
+    return new Err(new Error("Unexpected `auth` without `workspace`."));
+  }
+
+  const conversation = await Conversation.findOne({
+    where: {
+      sId: conversationId,
+      workspaceId: owner.id,
+    },
+  });
+  if (!conversation) {
+    return new Err(new Error("Conversation not found."));
+  }
+
+  const messages = await Message.findAll({
+    where: {
+      conversationId: conversation.id,
+    },
+    order: [["rank", "ASC"]],
+    include: [
+      {
+        model: UserMessage,
+        as: "userMessage",
+        required: false,
+        attributes: ["userId"],
+      },
+      {
+        model: AgentMessage,
+        as: "agentMessage",
+        required: false,
+        attributes: ["agentConfigurationId"],
+      },
+    ],
+  });
+
+  const { agentConfigurationIds, userIds } = messages.reduce<{
+    agentConfigurationIds: Set<string>;
+    userIds: Set<ModelId>;
+  }>(
+    (acc, m) => {
+      const { agentMessage, userMessage } = m;
+
+      if (agentMessage) {
+        acc.agentConfigurationIds.add(agentMessage.agentConfigurationId);
+      } else if (userMessage && userMessage.userId) {
+        acc.userIds.add(userMessage.userId);
+      }
+
+      return acc;
+    },
+    { agentConfigurationIds: new Set(), userIds: new Set() }
+  );
+
+  const [users, agents] = await Promise.all([
+    fetchAllUsersById([...userIds]),
+    fetchAllAgentsById(auth, [...agentConfigurationIds]),
+  ]);
+
+  return new Ok({
+    participants: {
+      agents,
+      users,
+    },
+  });
+}

--- a/front/lib/swr.ts
+++ b/front/lib/swr.ts
@@ -17,6 +17,7 @@ import useSWR from "swr";
 import useSWRInfinite from "swr/infinite";
 
 import type { FetchConversationMessagesResponse } from "@app/lib/api/assistant/messages";
+import type { FetchConversationParticipantsResponse } from "@app/lib/api/assistant/participants";
 import type { GetPokePlansResponseBody } from "@app/pages/api/poke/plans";
 import type { GetWorkspacesResponseBody } from "@app/pages/api/poke/workspaces";
 import type { GetUserResponseBody } from "@app/pages/api/user";
@@ -627,6 +628,34 @@ export function useConversationMessages({
     mutateMessages: mutate,
     setSize,
     size,
+  };
+}
+
+export function useConversationParticipants({
+  conversationId,
+  workspaceId,
+}: {
+  conversationId: string | null;
+  workspaceId: string;
+}) {
+  const conversationParticipantsFetcher: Fetcher<FetchConversationParticipantsResponse> =
+    fetcher;
+
+  const { data, error, mutate } = useSWR(
+    conversationId
+      ? `/api/w/${workspaceId}/assistant/conversations/${conversationId}/participants`
+      : null,
+    conversationParticipantsFetcher
+  );
+
+  return {
+    conversationParticipants: useMemo(
+      () => (data ? data.participants : undefined),
+      [data]
+    ),
+    isConversationParticipantsLoading: !error && !data,
+    isConversationParticipantsError: error,
+    mutateConversationParticipants: mutate,
   };
 }
 

--- a/front/lib/swr.ts
+++ b/front/lib/swr.ts
@@ -17,7 +17,6 @@ import useSWR from "swr";
 import useSWRInfinite from "swr/infinite";
 
 import type { FetchConversationMessagesResponse } from "@app/lib/api/assistant/messages";
-import type { FetchConversationParticipantsResponse } from "@app/lib/api/assistant/participants";
 import type { GetPokePlansResponseBody } from "@app/pages/api/poke/plans";
 import type { GetWorkspacesResponseBody } from "@app/pages/api/poke/workspaces";
 import type { GetUserResponseBody } from "@app/pages/api/user";
@@ -29,6 +28,7 @@ import type { GetRunBlockResponseBody } from "@app/pages/api/w/[wId]/apps/[aId]/
 import type { GetRunStatusResponseBody } from "@app/pages/api/w/[wId]/apps/[aId]/runs/[runId]/status";
 import type { GetAgentConfigurationsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
 import type { GetAgentUsageResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/usage";
+import type { FetchConversationParticipantsResponse } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/participants";
 import type { GetDataSourcesResponseBody } from "@app/pages/api/w/[wId]/data_sources";
 import type { GetConnectorResponseBody } from "@app/pages/api/w/[wId]/data_sources/[name]/connector";
 import type { GetDocumentsResponseBody } from "@app/pages/api/w/[wId]/data_sources/[name]/documents";

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/participants.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/participants.ts
@@ -1,0 +1,112 @@
+import type { UserMessageType, WithAPIErrorReponse } from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation";
+import type { FetchConversationParticipantsResponse } from "@app/lib/api/assistant/participants";
+import { fetchConversationParticipants } from "@app/lib/api/assistant/participants";
+import { Authenticator, getSession } from "@app/lib/auth";
+import { apiError, withLogging } from "@app/logger/withlogging";
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorReponse<
+      { message: UserMessageType } | FetchConversationParticipantsResponse
+    >
+  >
+): Promise<void> {
+  const session = await getSession(req, res);
+  const auth = await Authenticator.fromSession(
+    session,
+    req.query.wId as string
+  );
+
+  const owner = auth.workspace();
+  if (!owner) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "The workspace you're trying to modify was not found.",
+      },
+    });
+  }
+
+  const user = auth.user();
+  if (!user) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_user_not_found",
+        message: "Could not find the user of the current session.",
+      },
+    });
+  }
+
+  if (!auth.isUser()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "Only users of the current workspace can update chat sessions.",
+      },
+    });
+  }
+
+  if (!(typeof req.query.cId === "string")) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid query parameters, `cId` (string) is required.",
+      },
+    });
+  }
+
+  const conversationId = req.query.cId;
+  const conversationWithoutContent = await getConversationWithoutContent(
+    auth,
+    conversationId
+  );
+  if (!conversationWithoutContent) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "conversation_not_found",
+        message: "Conversation not found.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET":
+      const participantsRes = await fetchConversationParticipants(
+        auth,
+        conversationId
+      );
+      if (participantsRes.isErr()) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "conversation_not_found",
+            message: "Conversation not found",
+          },
+        });
+      }
+
+      res.status(200).json(participantsRes.value);
+      break;
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, POST is expected.",
+        },
+      });
+  }
+}
+
+export default withLogging(handler);

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/participants.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/participants.ts
@@ -1,11 +1,18 @@
-import type { UserMessageType, WithAPIErrorReponse } from "@dust-tt/types";
+import type {
+  ConversationParticipantsType,
+  UserMessageType,
+  WithAPIErrorReponse,
+} from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getConversationWithoutContent } from "@app/lib/api/assistant/conversation";
-import type { FetchConversationParticipantsResponse } from "@app/lib/api/assistant/participants";
 import { fetchConversationParticipants } from "@app/lib/api/assistant/participants";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { apiError, withLogging } from "@app/logger/withlogging";
+
+export type FetchConversationParticipantsResponse = {
+  participants: ConversationParticipantsType;
+};
 
 async function handler(
   req: NextApiRequest,
@@ -83,7 +90,7 @@ async function handler(
     case "GET":
       const participantsRes = await fetchConversationParticipants(
         auth,
-        conversationId
+        conversationWithoutContent
       );
       if (participantsRes.isErr()) {
         return apiError(req, res, {
@@ -95,7 +102,7 @@ async function handler(
         });
       }
 
-      res.status(200).json(participantsRes.value);
+      res.status(200).json({ participants: participantsRes.value });
       break;
 
     default:

--- a/types/src/front/assistant/conversation.ts
+++ b/types/src/front/assistant/conversation.ts
@@ -208,3 +208,24 @@ export type ConversationWithoutContentType = {
 };
 
 export type ParticipantActionType = "posted" | "reacted" | "subscribed";
+
+/**
+ * Conversation participants.
+ */
+
+export interface AgentParticipantType {
+  configurationId: string;
+  name: string;
+  pictureUrl: string;
+}
+
+export interface UserParticipantType {
+  fullName: string | null;
+  pictureUrl: string | null;
+  username: string;
+}
+
+export interface ConversationParticipantsType {
+  agents: AgentParticipant[];
+  users: UserParticipant[];
+}


### PR DESCRIPTION
## Description

This PR introduces a specialized endpoint to retrieve the conversation participants, which includes both users and agents. By doing so, we can finally eliminate the need to fetch the conversation's content to render the conversation.
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
