### PR TITLE
fix(notion update parents): look at moved/created more recent than current run

### DIFF
--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -1061,7 +1061,7 @@ async function findResourcesNotSeenInGarbageCollectionRun(
 
 export async function updateParentsFields(
   connectorId: ModelId,
-  runTimestamp: number,
+  lastSuccessRunTimestamp: number,
   activityExecutionTimestamp: number
 ) {
   const connector = await ConnectorResource.fetchById(connectorId);
@@ -1078,7 +1078,7 @@ export async function updateParentsFields(
       where: {
         connectorId: connector.id,
         lastCreatedOrMovedRunTs: {
-          [Op.gte]: runTimestamp,
+          [Op.gt]: lastSuccessRunTimestamp,
         },
       },
       attributes: ["notionPageId"],
@@ -1090,7 +1090,7 @@ export async function updateParentsFields(
       where: {
         connectorId: connector.id,
         lastCreatedOrMovedRunTs: {
-          [Op.gte]: runTimestamp,
+          [Op.gt]: lastSuccessRunTimestamp,
         },
       },
       attributes: ["notionDatabaseId"],

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -1077,7 +1077,9 @@ export async function updateParentsFields(
     await NotionPage.findAll({
       where: {
         connectorId: connector.id,
-        lastCreatedOrMovedRunTs: runTimestamp,
+        lastCreatedOrMovedRunTs: {
+          [Op.gte]: runTimestamp,
+        },
       },
       attributes: ["notionPageId"],
     })
@@ -1087,7 +1089,9 @@ export async function updateParentsFields(
     await NotionDatabase.findAll({
       where: {
         connectorId: connector.id,
-        lastCreatedOrMovedRunTs: runTimestamp,
+        lastCreatedOrMovedRunTs: {
+          [Op.gte]: runTimestamp,
+        },
       },
       attributes: ["notionDatabaseId"],
     })

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -1061,7 +1061,7 @@ async function findResourcesNotSeenInGarbageCollectionRun(
 
 export async function updateParentsFields(
   connectorId: ModelId,
-  lastSuccessRunTimestamp: number,
+  lastSuccessfulSyncTs: number,
   activityExecutionTimestamp: number
 ) {
   const connector = await ConnectorResource.fetchById(connectorId);
@@ -1078,7 +1078,7 @@ export async function updateParentsFields(
       where: {
         connectorId: connector.id,
         lastCreatedOrMovedRunTs: {
-          [Op.gt]: lastSuccessRunTimestamp,
+          [Op.gt]: lastSuccessfulSyncTs,
         },
       },
       attributes: ["notionPageId"],
@@ -1090,7 +1090,7 @@ export async function updateParentsFields(
       where: {
         connectorId: connector.id,
         lastCreatedOrMovedRunTs: {
-          [Op.gt]: lastSuccessRunTimestamp,
+          [Op.gt]: lastSuccessfulSyncTs,
         },
       },
       attributes: ["notionDatabaseId"],

--- a/connectors/src/connectors/notion/temporal/workflows.ts
+++ b/connectors/src/connectors/notion/temporal/workflows.ts
@@ -210,8 +210,15 @@ export async function notionSyncWorkflow({
       connectorId === 137
     );
 
-    // Compute parents after all documents are added/updated
-    await updateParentsFields(connectorId, runTimestamp, new Date().getTime());
+    // Compute parents after all documents are added/updated.
+    // We only do this if it's not a garbage collection run, to prevent race conditions.
+    if (!isGarbageCollectionRun) {
+      await updateParentsFields(
+        connectorId,
+        lastSyncedPeriodTs || 0,
+        new Date().getTime()
+      );
+    }
 
     if (!isGarbageCollectionRun) {
       await saveSuccessSync(connectorId);


### PR DESCRIPTION
## Description

related to https://github.com/dust-tt/tasks/issues/558

Now that we have 2 workflows, it's possible that some resources are created / moved after the start of the run

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
