### PR TITLE
Don't include content when fetching conversation

### DIFF
--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -1,4 +1,4 @@
-import { Spinner2 } from "@dust-tt/sparkle";
+import { Spinner } from "@dust-tt/sparkle";
 import type { UserType, WorkspaceType } from "@dust-tt/types";
 import type { AgentMention } from "@dust-tt/types";
 import type { AgentGenerationCancelledEvent } from "@dust-tt/types";
@@ -354,7 +354,7 @@ export default function ConversationViewer({
       )}
       {(isMessagesLoading || prevFirstMessageId) && (
         <div className="flex justify-center py-4">
-          <Spinner2 variant="color" size="xs" />
+          <Spinner variant="color" size="xs" />
         </div>
       )}
       {messages.map((page) => {

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -1,4 +1,4 @@
-import { Spinner } from "@dust-tt/sparkle";
+import { Spinner2 } from "@dust-tt/sparkle";
 import type { UserType, WorkspaceType } from "@dust-tt/types";
 import type { AgentMention } from "@dust-tt/types";
 import type { AgentGenerationCancelledEvent } from "@dust-tt/types";
@@ -354,7 +354,7 @@ export default function ConversationViewer({
       )}
       {(isMessagesLoading || prevFirstMessageId) && (
         <div className="flex justify-center py-4">
-          <Spinner variant="color" size="xs" />
+          <Spinner2 variant="color" size="xs" />
         </div>
       )}
       {messages.map((page) => {

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -1,5 +1,4 @@
 import type {
-  ConversationType,
   ConversationWithoutContentType,
   WithAPIErrorReponse,
 } from "@dust-tt/types";
@@ -10,7 +9,6 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import {
   deleteConversation,
-  getConversation,
   getConversationWithoutContent,
   updateConversation,
 } from "@app/lib/api/assistant/conversation";

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -1,4 +1,8 @@
-import type { ConversationType, WithAPIErrorReponse } from "@dust-tt/types";
+import type {
+  ConversationType,
+  ConversationWithoutContentType,
+  WithAPIErrorReponse,
+} from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
@@ -7,6 +11,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import {
   deleteConversation,
   getConversation,
+  getConversationWithoutContent,
   updateConversation,
 } from "@app/lib/api/assistant/conversation";
 import { Authenticator, getSession } from "@app/lib/auth";
@@ -23,7 +28,7 @@ export const PatchConversationsRequestBodySchema = t.type({
 });
 
 export type GetConversationsResponseBody = {
-  conversation: ConversationType;
+  conversation: ConversationWithoutContentType;
 };
 
 async function handler(
@@ -77,7 +82,7 @@ async function handler(
     });
   }
 
-  const conversation = await getConversation(auth, req.query.cId);
+  const conversation = await getConversationWithoutContent(auth, req.query.cId);
   if (!conversation) {
     return apiError(req, res, {
       status_code: 404,


### PR DESCRIPTION
## Description

This PR is the final step in removing the need to fetch conversation content when rendering the conversation UI. All the codepaths that previously relied on this logic have been updated to use alternative solutions. To note: the public API still uses this logic, and we don't have any plans to change it at the moment!
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
