### PR TITLE
cli to update all parents fields

### DIFF
--- a/connectors/src/lib/cli.ts
+++ b/connectors/src/lib/cli.ts
@@ -51,7 +51,10 @@ import {
   checkNotionUrl,
   searchNotionPagesForQuery,
 } from "@connectors/connectors/notion/lib/cli";
-import { getNotionAccessToken } from "@connectors/connectors/notion/temporal/activities";
+import {
+  getNotionAccessToken,
+  updateParentsFields,
+} from "@connectors/connectors/notion/temporal/activities";
 import { stopNotionGarbageCollectorWorkflow } from "@connectors/connectors/notion/temporal/client";
 import { QUEUE_NAME } from "@connectors/connectors/notion/temporal/config";
 import {
@@ -702,6 +705,29 @@ export const notion = async ({
         await stopNotionGarbageCollectorWorkflow(connector.id);
       }
       return { success: true };
+    }
+
+    case "update-parents-fields": {
+      const { wId } = args;
+      const connectors = await ConnectorModel.findAll({
+        where: {
+          type: "notion",
+          ...(wId ? { workspaceId: wId } : {}),
+        },
+      });
+
+      for (const c of connectors) {
+        console.log(
+          "\n----------\n",
+          `Updating parents for connector ${c.id}`,
+          "\n----------\n"
+        );
+        await updateParentsFields(c.id, 0, new Date().getTime());
+      }
+
+      return {
+        success: true,
+      };
     }
 
     default:

--- a/types/src/connectors/admin/cli.ts
+++ b/types/src/connectors/admin/cli.ts
@@ -37,6 +37,7 @@ export const NotionCommandSchema = t.type({
     t.literal("check-url"),
     t.literal("me"),
     t.literal("stop-all-garbage-collectors"),
+    t.literal("update-parents-fields"),
   ]),
   args: t.record(t.string, t.union([t.string, t.undefined])),
 });


### PR DESCRIPTION
## Description

a very naive CLI that updates parents fields "from scratch" for all notion connectors
## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
