### PR TITLE
enh(notion): track when parents were last updated

### DIFF
--- a/connectors/src/connectors/notion/temporal/config.ts
+++ b/connectors/src/connectors/notion/temporal/config.ts
@@ -1,2 +1,2 @@
-export const WORKFLOW_VERSION = 35;
+export const WORKFLOW_VERSION = 36;
 export const QUEUE_NAME = `notion-queue-v${WORKFLOW_VERSION}`;

--- a/connectors/src/connectors/notion/temporal/workflows.ts
+++ b/connectors/src/connectors/notion/temporal/workflows.ts
@@ -211,11 +211,7 @@ export async function notionSyncWorkflow({
     // Compute parents after all documents are added/updated.
     // We only do this if it's not a garbage collection run, to prevent race conditions.
     if (!isGarbageCollectionRun) {
-      await updateParentsFields(
-        connectorId,
-        lastSyncedPeriodTs || 0,
-        new Date().getTime()
-      );
+      await updateParentsFields(connectorId);
     }
 
     if (!isGarbageCollectionRun) {

--- a/connectors/src/lib/cli.ts
+++ b/connectors/src/lib/cli.ts
@@ -51,10 +51,7 @@ import {
   checkNotionUrl,
   searchNotionPagesForQuery,
 } from "@connectors/connectors/notion/lib/cli";
-import {
-  getNotionAccessToken,
-  updateParentsFields,
-} from "@connectors/connectors/notion/temporal/activities";
+import { getNotionAccessToken } from "@connectors/connectors/notion/temporal/activities";
 import { stopNotionGarbageCollectorWorkflow } from "@connectors/connectors/notion/temporal/client";
 import { QUEUE_NAME } from "@connectors/connectors/notion/temporal/config";
 import {
@@ -705,29 +702,6 @@ export const notion = async ({
         await stopNotionGarbageCollectorWorkflow(connector.id);
       }
       return { success: true };
-    }
-
-    case "update-parents-fields": {
-      const { wId } = args;
-      const connectors = await ConnectorModel.findAll({
-        where: {
-          type: "notion",
-          ...(wId ? { workspaceId: wId } : {}),
-        },
-      });
-
-      for (const c of connectors) {
-        console.log(
-          "\n----------\n",
-          `Updating parents for connector ${c.id}`,
-          "\n----------\n"
-        );
-        await updateParentsFields(c.id, 0, new Date().getTime());
-      }
-
-      return {
-        success: true,
-      };
     }
 
     default:

--- a/connectors/src/lib/models/notion.ts
+++ b/connectors/src/lib/models/notion.ts
@@ -22,6 +22,7 @@ export class NotionConnectorState extends Model<
   declare fullResyncStartTime?: CreationOptional<Date>;
 
   declare lastGarbageCollectionFinishTime?: Date;
+  declare parentsLastUpdatedAt?: Date;
 
   declare connectorId: ForeignKey<ConnectorModel["id"]>;
 }
@@ -51,6 +52,10 @@ NotionConnectorState.init(
       allowNull: true,
     },
     lastGarbageCollectionFinishTime: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    },
+    parentsLastUpdatedAt: {
       type: DataTypes.DATE,
       allowNull: true,
     },


### PR DESCRIPTION
## Description

We need to track in the database when the parents fields were last updated for a notion connector.
It is the only way to:
- make this resilient to workflow restarts at arbitrary point in time
- make this resilient to race conditions between multiple workflows updating `lastCreatedOrMovedRunTs` on notion connector nodes

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

requires:
- initdb (connectors)
- workflow restarts (queue version bump)
