### PR TITLE
Lowercase email for invitation

### DIFF
--- a/front/lib/api/invitation.ts
+++ b/front/lib/api/invitation.ts
@@ -1,4 +1,5 @@
 import type { UserType, WorkspaceType } from "@dust-tt/types";
+import { sanitizeString } from "@dust-tt/types";
 import sgMail from "@sendgrid/mail";
 import { sign } from "jsonwebtoken";
 
@@ -15,7 +16,7 @@ export async function sendWorkspaceInvitationEmail(
   // Create MembershipInvitation.
   const invitation = await MembershipInvitation.create({
     workspaceId: owner.id,
-    inviteEmail: inviteEmail.toLowerCase(),
+    inviteEmail: sanitizeString(inviteEmail),
     status: "pending",
   });
 

--- a/front/lib/api/invitation.ts
+++ b/front/lib/api/invitation.ts
@@ -15,7 +15,7 @@ export async function sendWorkspaceInvitationEmail(
   // Create MembershipInvitation.
   const invitation = await MembershipInvitation.create({
     workspaceId: owner.id,
-    inviteEmail,
+    inviteEmail: inviteEmail.toLowerCase(),
     status: "pending",
   });
 

--- a/front/lib/iam/users.ts
+++ b/front/lib/iam/users.ts
@@ -1,5 +1,6 @@
 import type { Session } from "@auth0/nextjs-auth0";
 import type { UserProviderType, UserType } from "@dust-tt/types";
+import { sanitizeString } from "@dust-tt/types";
 
 import { trackSignup } from "@app/lib/amplitude/back";
 import type { ExternalUser, SessionWithUser } from "@app/lib/iam/provider";
@@ -132,7 +133,7 @@ export async function createOrUpdateUser(
       auth0Sub: externalUser.sub,
       provider: mapAuth0ProviderToLegacy(session)?.provider,
       username: externalUser.nickname,
-      email: externalUser.email,
+      email: sanitizeString(externalUser.emai),
       name: externalUser.name,
       firstName: externalUser.given_name ?? firstName,
       lastName: externalUser.family_name ?? lastName,

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -39,7 +39,7 @@ async function handleMembershipInvite(
     AuthFlowError | SSOEnforcedError
   >
 > {
-  if (membershipInvite.inviteEmail !== user.email.toLowerCase()) {
+  if (membershipInvite.inviteEmail !== user.email) {
     return new Err(
       new AuthFlowError(
         "The invitation token is not intended for use with this email address."

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -39,7 +39,7 @@ async function handleMembershipInvite(
     AuthFlowError | SSOEnforcedError
   >
 > {
-  if (membershipInvite.inviteEmail !== user.email) {
+  if (membershipInvite.inviteEmail !== user.email.toLowerCase()) {
     return new Err(
       new AuthFlowError(
         "The invitation token is not intended for use with this email address."

--- a/types/src/shared/utils/string_utils.ts
+++ b/types/src/shared/utils/string_utils.ts
@@ -39,6 +39,10 @@ export function pluralize(count: number) {
   return count !== 1 ? "s" : "";
 }
 
+export function sanitizeString(rawString: string) {
+  return rawString.trim().toLowerCase();
+}
+
 export function slugify(text: string) {
   return text
     .replace(/([a-z])([A-Z0-9])/g, "$1_$2") // Get all lowercase letters that are near to uppercase ones and replace with _.


### PR DESCRIPTION
## Description

Currently, there's an issue where invitations cannot be used because email addresses aren't being sanitized before being saved. This results in an invalid request as the system assumes the invitation isn't intended for the account in question. This PR aims to address this problem by ensuring that email addresses associated with invitations are converted to lowercase when the invitation is generated.

I'm planning to run, to update all existing invitations:
```
UPDATE membership_invitations SET "inviteEmail" = LOWER("inviteEmail");
```
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
