### PR TITLE
feat(meru templates): data model

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -47,8 +47,11 @@ import {
 import { ConversationClassification } from "@app/lib/models/conversation_classification";
 import { FeatureFlag } from "@app/lib/models/feature_flag";
 import { PlanInvitation } from "@app/lib/models/plan";
-import { Template, TemplateTag } from "@app/lib/models/templates";
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
+import {
+  TemplateModel,
+  TemplateTagModel,
+} from "@app/lib/resources/storage/models/templates";
 
 async function main() {
   await User.sync({ alter: true });
@@ -103,8 +106,8 @@ async function main() {
 
   await ConversationClassification.sync({ alter: true });
 
-  await Template.sync({ alter: true });
-  await TemplateTag.sync({ alter: true });
+  await TemplateModel.sync({ alter: true });
+  await TemplateTagModel.sync({ alter: true });
   process.exit(0);
 }
 

--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -47,6 +47,7 @@ import {
 import { ConversationClassification } from "@app/lib/models/conversation_classification";
 import { FeatureFlag } from "@app/lib/models/feature_flag";
 import { PlanInvitation } from "@app/lib/models/plan";
+import { Template, TemplateTag } from "@app/lib/models/templates";
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
 
 async function main() {
@@ -101,6 +102,9 @@ async function main() {
   await FeatureFlag.sync({ alter: true });
 
   await ConversationClassification.sync({ alter: true });
+
+  await Template.sync({ alter: true });
+  await TemplateTag.sync({ alter: true });
   process.exit(0);
 }
 

--- a/front/lib/models/templates.ts
+++ b/front/lib/models/templates.ts
@@ -1,0 +1,161 @@
+import type {
+  CreationOptional,
+  ForeignKey,
+  InferAttributes,
+  InferCreationAttributes,
+} from "sequelize";
+import { DataTypes, Model } from "sequelize";
+
+import { frontSequelize } from "@app/lib/resources/storage";
+
+export class Template extends Model<
+  InferAttributes<Template>,
+  InferCreationAttributes<Template>
+> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare sId: string;
+  declare name: string;
+  declare description: string | null;
+
+  declare visibility: "draft" | "published" | "disabled";
+
+  declare presetHandler: string | null;
+  declare presetDescription: string | null;
+  declare presetInstructions: string | null;
+  declare presetTemperature:
+    | "deterministic"
+    | "factual"
+    | "balanced"
+    | "creative"
+    | null;
+  declare presetModelId: string | null;
+  declare presetAction:
+    | "reply"
+    | "search_datasources"
+    | "process_datasources"
+    | "query_tables"
+    | null;
+
+  declare helpInstructions: string | null;
+  declare helpActions: string | null;
+}
+
+Template.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    sId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    name: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    description: {
+      type: DataTypes.STRING,
+    },
+    visibility: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    presetHandler: {
+      type: DataTypes.STRING,
+    },
+    presetDescription: {
+      type: DataTypes.STRING,
+    },
+    presetInstructions: {
+      type: DataTypes.STRING,
+    },
+    presetTemperature: {
+      type: DataTypes.STRING,
+    },
+    presetModelId: {
+      type: DataTypes.STRING,
+    },
+    presetAction: {
+      type: DataTypes.STRING,
+    },
+    helpInstructions: {
+      type: DataTypes.STRING,
+    },
+    helpActions: {
+      type: DataTypes.STRING,
+    },
+  },
+  {
+    sequelize: frontSequelize,
+    modelName: "template",
+    indexes: [
+      { unique: true, fields: ["sId"] },
+      {
+        fields: ["visibility"],
+      },
+    ],
+  }
+);
+
+export class TemplateTag extends Model<
+  InferAttributes<TemplateTag>,
+  InferCreationAttributes<TemplateTag>
+> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare templateId: ForeignKey<Template>;
+  declare tag: string;
+}
+
+TemplateTag.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    templateId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+    tag: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+  },
+  {
+    sequelize: frontSequelize,
+    modelName: "templateTag",
+    indexes: [
+      { fields: ["templateId", "tag"], unique: true },
+      { fields: ["tag"] },
+    ],
+  }
+);

--- a/front/lib/models/templates.ts
+++ b/front/lib/models/templates.ts
@@ -22,7 +22,7 @@ export class Template extends Model<
 
   declare visibility: "draft" | "published" | "disabled";
 
-  declare presetHandler: string | null;
+  declare presetHandle: string | null;
   declare presetDescription: string | null;
   declare presetInstructions: string | null;
   declare presetTemperature:
@@ -75,7 +75,7 @@ Template.init(
       type: DataTypes.STRING,
       allowNull: false,
     },
-    presetHandler: {
+    presetHandle: {
       type: DataTypes.STRING,
     },
     presetDescription: {

--- a/front/lib/models/templates.ts
+++ b/front/lib/models/templates.ts
@@ -31,6 +31,7 @@ export class Template extends Model<
     | "balanced"
     | "creative"
     | null;
+  declare presetProviderId: string | null;
   declare presetModelId: string | null;
   declare presetAction:
     | "reply"
@@ -85,6 +86,9 @@ Template.init(
       type: DataTypes.STRING,
     },
     presetTemperature: {
+      type: DataTypes.STRING,
+    },
+    presetProviderId: {
       type: DataTypes.STRING,
     },
     presetModelId: {

--- a/front/lib/models/templates.ts
+++ b/front/lib/models/templates.ts
@@ -153,9 +153,6 @@ TemplateTag.init(
   {
     sequelize: frontSequelize,
     modelName: "templateTag",
-    indexes: [
-      { fields: ["templateId", "tag"], unique: true },
-      { fields: ["tag"] },
-    ],
+    indexes: [{ fields: ["tag", "templateId"], unique: true }],
   }
 );

--- a/front/lib/resources/storage/models/templates.ts
+++ b/front/lib/resources/storage/models/templates.ts
@@ -8,9 +8,9 @@ import { DataTypes, Model } from "sequelize";
 
 import { frontSequelize } from "@app/lib/resources/storage";
 
-export class Template extends Model<
-  InferAttributes<Template>,
-  InferCreationAttributes<Template>
+export class TemplateModel extends Model<
+  InferAttributes<TemplateModel>,
+  InferCreationAttributes<TemplateModel>
 > {
   declare id: CreationOptional<number>;
   declare createdAt: CreationOptional<Date>;
@@ -44,7 +44,7 @@ export class Template extends Model<
   declare helpActions: string | null;
 }
 
-Template.init(
+TemplateModel.init(
   {
     id: {
       type: DataTypes.INTEGER,
@@ -116,19 +116,19 @@ Template.init(
   }
 );
 
-export class TemplateTag extends Model<
-  InferAttributes<TemplateTag>,
-  InferCreationAttributes<TemplateTag>
+export class TemplateTagModel extends Model<
+  InferAttributes<TemplateTagModel>,
+  InferCreationAttributes<TemplateTagModel>
 > {
   declare id: CreationOptional<number>;
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
-  declare templateId: ForeignKey<Template>;
+  declare templateId: ForeignKey<TemplateModel>;
   declare tag: string;
 }
 
-TemplateTag.init(
+TemplateTagModel.init(
   {
     id: {
       type: DataTypes.INTEGER,
@@ -160,3 +160,12 @@ TemplateTag.init(
     indexes: [{ fields: ["tag", "templateId"], unique: true }],
   }
 );
+
+TemplateModel.hasMany(TemplateTagModel, {
+  foreignKey: { allowNull: false },
+  onDelete: "CASCADE",
+});
+TemplateTagModel.belongsTo(TemplateModel, {
+  foreignKey: { allowNull: false },
+  onDelete: "CASCADE",
+});

--- a/front/lib/resources/template_resource.ts
+++ b/front/lib/resources/template_resource.ts
@@ -1,0 +1,46 @@
+import type { Result } from "@dust-tt/types";
+import { Err, Ok } from "@dust-tt/types";
+import type { Attributes, ModelStatic, Transaction } from "sequelize";
+
+import { BaseResource } from "@app/lib/resources/base_resource";
+import { TemplateModel } from "@app/lib/resources/storage/models/templates";
+import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+
+// Attributes are marked as read-only to reflect the stateless nature of our Resource.
+// This design will be moved up to BaseResource once we transition away from Sequelize.
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface TemplateResource
+  extends ReadonlyAttributesType<TemplateModel> {}
+export class TemplateResource extends BaseResource<TemplateModel> {
+  static model: ModelStatic<TemplateModel> = TemplateModel;
+
+  constructor(
+    model: ModelStatic<TemplateModel>,
+    blob: Attributes<TemplateModel>
+  ) {
+    super(TemplateModel, blob);
+  }
+
+  static async makeNew(blob: Attributes<TemplateModel>) {
+    const template = await TemplateModel.create({
+      ...blob,
+    });
+
+    return new this(TemplateModel, template.get());
+  }
+
+  async delete(transaction?: Transaction): Promise<Result<undefined, Error>> {
+    try {
+      await this.model.destroy({
+        where: {
+          id: this.id,
+        },
+        transaction,
+      });
+
+      return new Ok(undefined);
+    } catch (err) {
+      return new Err(err as Error);
+    }
+  }
+}


### PR DESCRIPTION
## Description

First step towards https://github.com/dust-tt/dust/issues/4373

Will likely evolve in the future. This first draft is based on examples from here: https://www.notion.so/dust-tt/Templates-33c161f77a7d4015b1fae83e29a391a8.

Each template has its own name and optionally a description (which will be displayed in the new "Create Assistant" modal that comes right before the builder). 
There are fields to store the presets for the action type, the instructions, the model, the temperature, the handle and the description.
There are fields to store the "help" bubble for the instructions and actions steps of the builder. This will maybe change -- maybe we want several bubbles at each step. Maybe we'll want info bubbles at sharing and naming steps. Doesn't matter yet.

There's also another table to store the tags.



## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

requires migrating the DB.