### PR TITLE
[Content Fragment] Deprecate old fields

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1555,7 +1555,6 @@ export async function postNewContentFragment(
 
       const contentFragment = await ContentFragmentResource.makeNew(
         {
-          content,
           title,
           url,
           sourceUrl,

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1530,12 +1530,6 @@ export async function postNewContentFragment(
   }
 
   const messageId = generateModelSId();
-  const textUrl = await storeContentFragmentText({
-    workspaceId: owner.sId,
-    conversationId: conversation.sId,
-    messageId,
-    content,
-  });
 
   const sourceUrl =
     contentType === "file_attachment"
@@ -1547,7 +1541,12 @@ export async function postNewContentFragment(
         }).downloadUrl
       : url;
 
-  const textBytes = textUrl ? Buffer.byteLength(content, "utf8") : null;
+  const textBytes = await storeContentFragmentText({
+    workspaceId: owner.sId,
+    conversationId: conversation.sId,
+    messageId,
+    content,
+  });
 
   const { contentFragment, messageRow } = await frontSequelize.transaction(
     async (t) => {
@@ -1556,9 +1555,7 @@ export async function postNewContentFragment(
       const contentFragment = await ContentFragmentResource.makeNew(
         {
           title,
-          url,
           sourceUrl,
-          textUrl,
           textBytes,
           contentType,
           userId: auth.user()?.id,

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -97,8 +97,6 @@ export class ContentFragmentResource extends BaseResource<ContentFragmentModel> 
       visibility: message.visibility,
       version: message.version,
       title: this.title,
-      content: this.content,
-      url: this.url,
       sourceUrl: this.sourceUrl,
       textBytes: this.textBytes,
       contentType: this.contentType,

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -96,9 +96,9 @@ export class ContentFragmentResource extends BaseResource<ContentFragmentModel> 
       type: "content_fragment",
       visibility: message.visibility,
       version: message.version,
-      title: this.title,
       sourceUrl: this.sourceUrl,
       textBytes: this.textBytes,
+      title: this.title,
       contentType: this.contentType,
       context: {
         profilePictureUrl: this.userContextProfilePictureUrl,
@@ -142,12 +142,12 @@ export async function storeContentFragmentText({
   conversationId: string;
   messageId: string;
   content: string;
-}): Promise<string | null> {
+}): Promise<number | null> {
   if (content === "") {
     return null;
   }
 
-  const { filePath, internalUrl } = fileAttachmentLocation({
+  const { filePath } = fileAttachmentLocation({
     workspaceId,
     conversationId,
     messageId,
@@ -164,7 +164,7 @@ export async function storeContentFragmentText({
     contentType: "text/plain",
   });
 
-  return internalUrl;
+  return Buffer.byteLength(content);
 }
 
 export async function getContentFragmentText({

--- a/front/lib/resources/storage/models/content_fragment.ts
+++ b/front/lib/resources/storage/models/content_fragment.ts
@@ -19,8 +19,6 @@ export class ContentFragmentModel extends Model<
   declare updatedAt: CreationOptional<Date>;
 
   declare title: string;
-  declare content: string;
-  declare url: string | null;
   declare contentType: ContentFragmentContentType;
   declare sourceUrl: string | null; // GCS (upload) or Slack or ...
 
@@ -58,14 +56,6 @@ ContentFragmentModel.init(
     title: {
       type: DataTypes.TEXT,
       allowNull: false,
-    },
-    content: {
-      type: DataTypes.TEXT,
-      allowNull: false,
-    },
-    url: {
-      type: DataTypes.TEXT,
-      allowNull: true,
     },
     contentType: {
       type: DataTypes.STRING,

--- a/front/lib/resources/storage/models/content_fragment.ts
+++ b/front/lib/resources/storage/models/content_fragment.ts
@@ -22,10 +22,9 @@ export class ContentFragmentModel extends Model<
   declare contentType: ContentFragmentContentType;
   declare sourceUrl: string | null; // GCS (upload) or Slack or ...
 
-  // Fields below are set of all types that can be transduced to text or
-  // are textual in nature (PDF, text, CSV, future: .docx...)
-  declare textUrl: string | null; // url to GCS
-  declare textBytes: number | null; // number of textUrl bytes
+  // The field below should be set for all fragments that are converted to text
+  // before being put in model context (PDF, text, CSV, future: .docx...)
+  declare textBytes: number | null;
 
   // user-related context
   declare userContextUsername: string | null;
@@ -62,10 +61,6 @@ ContentFragmentModel.init(
       allowNull: false,
     },
     sourceUrl: {
-      type: DataTypes.TEXT,
-      allowNull: true,
-    },
-    textUrl: {
       type: DataTypes.TEXT,
       allowNull: true,
     },

--- a/front/migrations/20240322_content_fragments_refactor.ts
+++ b/front/migrations/20240322_content_fragments_refactor.ts
@@ -21,10 +21,12 @@ async function migrateContentFragment(
       workspaceId,
       conversationId,
       messageId: cfMessage.sId,
+      // @ts-ignore content was removed from ContentFragmentResource
       content: cf.content,
     });
     await cf.update({
       textUrl: fileUrl,
+      // @ts-ignore content was removed from ContentFragmentResource
       textBytes: Buffer.byteLength(cf.content),
     });
   }
@@ -33,6 +35,7 @@ async function migrateContentFragment(
   // is null, set sourceUrl to textUrl
   if (!cf.sourceUrl) {
     await cf.update({
+      // @ts-ignore url was removed from ContentFragmentResource
       sourceUrl: cf.url ?? cf.textUrl,
     });
   }
@@ -112,6 +115,13 @@ async function migrateContentFragmentsForWorkspace(workspace: Workspace) {
 }
 
 async function main() {
+  if (LIVE) {
+    throw new Error(
+      `This script was used to migrate columns that are now removed.
+      Manually disable this error and check the tslint ignores if you
+      really need to run it`
+    );
+  }
   // get all ids and sIds of workspaces
   const workspaces = await Workspace.findAll({
     attributes: ["id", "sId"],

--- a/front/migrations/20240322_content_fragments_refactor.ts
+++ b/front/migrations/20240322_content_fragments_refactor.ts
@@ -1,10 +1,11 @@
+import { Op } from "sequelize";
+
 import { Conversation, Message, Workspace } from "@app/lib/models";
 import {
   ContentFragmentResource,
   storeContentFragmentText,
 } from "@app/lib/resources/content_fragment_resource";
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
-import { Op } from "sequelize";
 
 const { LIVE } = process.env;
 
@@ -21,12 +22,12 @@ async function migrateContentFragment(
       workspaceId,
       conversationId,
       messageId: cfMessage.sId,
-      // @ts-ignore content was removed from ContentFragmentResource
+      // @ts-expect-error content was removed from ContentFragmentResource
       content: cf.content,
     });
     await cf.update({
       textUrl: fileUrl,
-      // @ts-ignore content was removed from ContentFragmentResource
+      // @ts-expect-error content was removed from ContentFragmentResource
       textBytes: Buffer.byteLength(cf.content),
     });
   }
@@ -35,7 +36,7 @@ async function migrateContentFragment(
   // is null, set sourceUrl to textUrl
   if (!cf.sourceUrl) {
     await cf.update({
-      // @ts-ignore url was removed from ContentFragmentResource
+      // @ts-expect-error url was removed from ContentFragmentResource
       sourceUrl: cf.url ?? cf.textUrl,
     });
   }

--- a/front/migrations/20240322_content_fragments_refactor.ts
+++ b/front/migrations/20240322_content_fragments_refactor.ts
@@ -17,6 +17,7 @@ async function migrateContentFragment(
   const cf = ContentFragmentResource.fromMessage(cfMessage);
   // if textUrl is null, upload content to GCS and set textUrl to the uploaded file
   // value (also set textBytes to the number of bytes in the content)
+  // @ts-expect-error textUrl was removed from ContentFragmentResource
   if (!cf.textUrl) {
     const fileUrl = await storeContentFragmentText({
       workspaceId,
@@ -26,6 +27,7 @@ async function migrateContentFragment(
       content: cf.content,
     });
     await cf.update({
+      // @ts-expect-error textUrl was removed from ContentFragmentResource
       textUrl: fileUrl,
       // @ts-expect-error content was removed from ContentFragmentResource
       textBytes: Buffer.byteLength(cf.content),

--- a/front/migrations/20240325_deprecate_columns_from_cf.sql
+++ b/front/migrations/20240325_deprecate_columns_from_cf.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "content_fragments" DROP COLUMN IF EXISTS "url";
+ALTER TABLE "content_fragments" DROP COLUMN IF EXISTS "content";
+ALTER TABLE "content_fragments" DROP COLUMN IF EXISTS "textUrl";

--- a/front/migrations/20240325_deprecate_columns_from_cf.sql
+++ b/front/migrations/20240325_deprecate_columns_from_cf.sql
@@ -1,3 +1,0 @@
-ALTER TABLE "content_fragments" DROP COLUMN IF EXISTS "url";
-ALTER TABLE "content_fragments" DROP COLUMN IF EXISTS "content";
-ALTER TABLE "content_fragments" DROP COLUMN IF EXISTS "textUrl";

--- a/types/src/front/assistant/conversation.ts
+++ b/types/src/front/assistant/conversation.ts
@@ -145,8 +145,6 @@ export type ContentFragmentType = {
   sourceUrl: string | null;
   textBytes: number | null;
   title: string;
-  content: string;
-  url: string | null;
   contentType: ContentFragmentContentType;
   context: ContentFragmentContextType;
 };


### PR DESCRIPTION
## Description

Fixes #4242 

As discussed in PR #4415 `textUrl` field is also removed cc @spolu 

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk
Risk from dropping column: Losing content from old attachments
- a migration was run and went well to store old content text on GCS
-  checked manually on 2 old content fragments that content had been properly stored as text so was still accessible
- ifever some content was lost, there would be no user-facing impact since old content fragments were not available for download in former conversation
- the only risk would be a lack of auditability for us for past conversations, only if for some reason some content was not migrated despite the above checks

=> For these reasons, it is decided safe to delete the columns

## Deploy Plan
- merge
- run `init_db` on prodbox
- deploy front
