### PR TITLE
Allow a workspace on a paid plan to be upgraded to another plan without loosing all its data

### DIFF
--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -12,9 +12,10 @@ import {
   User,
   Workspace,
 } from "@app/lib/models";
+import { FREE_UPGRADED_PLAN_CODE } from "@app/lib/plans/plan_codes";
 import {
-  internalSubscribeWorkspaceToFreeTestPlan,
-  internalSubscribeWorkspaceToFreeUpgradedPlan,
+  internalSubscribeWorkspaceToFreeNoPlan,
+  internalSubscribeWorkspaceToFreePlan,
 } from "@app/lib/plans/subscription";
 import { generateModelSId } from "@app/lib/utils";
 import logger from "@app/logger/logger";
@@ -133,10 +134,6 @@ const workspace = async (command: string, args: parseArgs.ParsedArgs) => {
         name: args.name,
       });
 
-      await internalSubscribeWorkspaceToFreeTestPlan({
-        workspaceId: w.sId,
-      });
-
       args.wId = w.sId;
       await workspace("show", args);
       return;
@@ -156,8 +153,9 @@ const workspace = async (command: string, args: parseArgs.ParsedArgs) => {
         throw new Error(`Workspace not found: wId='${args.wId}'`);
       }
 
-      await internalSubscribeWorkspaceToFreeUpgradedPlan({
+      await internalSubscribeWorkspaceToFreePlan({
         workspaceId: w.sId,
+        planCode: FREE_UPGRADED_PLAN_CODE,
       });
       await workspace("show", args);
       return;
@@ -177,7 +175,7 @@ const workspace = async (command: string, args: parseArgs.ParsedArgs) => {
         throw new Error(`Workspace not found: wId='${args.wId}'`);
       }
 
-      await internalSubscribeWorkspaceToFreeTestPlan({
+      await internalSubscribeWorkspaceToFreeNoPlan({
         workspaceId: w.sId,
       });
       await workspace("show", args);

--- a/front/lib/plans/subscription.ts
+++ b/front/lib/plans/subscription.ts
@@ -4,19 +4,17 @@ import type {
   PlanType,
   SubscriptionType,
 } from "@dust-tt/types";
+import { Op } from "sequelize";
 import { v4 as uuidv4 } from "uuid";
 
 import type { Authenticator } from "@app/lib/auth";
-import { Plan, Subscription, Workspace } from "@app/lib/models";
+import { Membership, Plan, Subscription, Workspace } from "@app/lib/models";
 import { PlanInvitation } from "@app/lib/models/plan";
 import type { PlanAttributes } from "@app/lib/plans/free_plans";
 import { FREE_NO_PLAN_DATA } from "@app/lib/plans/free_plans";
+import { PRO_PLAN_SEAT_29_CODE } from "@app/lib/plans/plan_codes";
 import {
-  FREE_TEST_PLAN_CODE,
-  FREE_UPGRADED_PLAN_CODE,
-  PRO_PLAN_SEAT_29_CODE,
-} from "@app/lib/plans/plan_codes";
-import {
+  cancelSubscriptionImmediately,
   createCheckoutSession,
   getStripeSubscription,
   updateStripeSubscriptionQuantity,
@@ -113,40 +111,81 @@ export const internalSubscribeWorkspaceToFreeNoPlan = async ({
   }
   const now = new Date();
 
-  return frontSequelize.transaction(async (t) => {
-    // We end the active subscription if any
-    const activeSubscription = await Subscription.findOne({
-      where: { workspaceId: workspace.id, status: "active" },
-      transaction: t,
-    });
+  const activeSubscription = await Subscription.findOne({
+    where: { workspaceId: workspace.id, status: "active" },
+  });
 
-    if (activeSubscription) {
+  if (activeSubscription) {
+    await frontSequelize.transaction(async (t) => {
+      // Revoke all users
+      const oldestAdminMembership = await Membership.findOne({
+        where: { workspaceId: workspace.id, role: "admin" },
+        order: [["createdAt", "ASC"]],
+        transaction: t,
+      });
+      if (!oldestAdminMembership) {
+        throw new Error(
+          `Cannot find an admin membership for workspace ${workspaceId}`
+        );
+      }
+      const allMembershipsButOldestAdmin = await Membership.findAll({
+        where: {
+          workspaceId: workspace.id,
+          id: {
+            [Op.ne]: oldestAdminMembership.id,
+          },
+          role: {
+            [Op.not]: "revoked",
+          },
+        },
+        transaction: t,
+      });
+      await Promise.all(
+        allMembershipsButOldestAdmin.map((membership) => {
+          return membership.update({ role: "revoked" }, { transaction: t });
+        })
+      );
+
+      // End the subscription
+      const endedStatus = activeSubscription.stripeSubscriptionId
+        ? "ended_backend_only"
+        : "ended";
+
       await activeSubscription.update(
         {
-          status: "ended",
+          status: endedStatus,
           endDate: now,
         },
         { transaction: t }
       );
-    }
-
-    const plan: PlanAttributes = FREE_NO_PLAN_DATA;
-
-    return renderSubscriptionFromModels({
-      plan,
-      // No active subscription for FREE_NO_PLAN
-      activeSubscription: null,
     });
+
+    // Notify Stripe that we ended the subscription if the subscription was a paid one
+    if (activeSubscription?.stripeSubscriptionId) {
+      await cancelSubscriptionImmediately({
+        stripeSubscriptionId: activeSubscription.stripeSubscriptionId,
+      });
+    }
+  }
+
+  const plan: PlanAttributes = FREE_NO_PLAN_DATA;
+  return renderSubscriptionFromModels({
+    plan,
+    // No active subscription for FREE_NO_PLAN
+    activeSubscription: null,
   });
 };
 
 /**
- * Internal function to subscribe to the FREE_TEST_PLAN.
+ * Internal function to subscribe to a new Plan.
+ * The new plan must be a free plan because the new subscription is created without Stripe data.
  */
-export const internalSubscribeWorkspaceToFreeTestPlan = async ({
+export const internalSubscribeWorkspaceToFreePlan = async ({
   workspaceId,
+  planCode,
 }: {
   workspaceId: string;
+  planCode: string;
 }): Promise<SubscriptionType> => {
   const workspace = await Workspace.findOne({
     where: { sId: workspaceId },
@@ -154,75 +193,10 @@ export const internalSubscribeWorkspaceToFreeTestPlan = async ({
   if (!workspace) {
     throw new Error(`Cannot find workspace ${workspaceId}`);
   }
-  const plan = await Plan.findOne({
-    where: { code: FREE_TEST_PLAN_CODE },
-  });
-  if (!plan) {
-    throw new Error(
-      `Cannot subscribe to plan ${FREE_TEST_PLAN_CODE}:  not found.`
-    );
-  }
-
-  const now = new Date();
-
-  return frontSequelize.transaction(async (t) => {
-    // We end the active subscription if any
-    const activeSubscription = await Subscription.findOne({
-      where: { workspaceId: workspace.id, status: "active" },
-      transaction: t,
-    });
-
-    if (activeSubscription) {
-      await activeSubscription.update(
-        {
-          status: "ended",
-          endDate: now,
-        },
-        { transaction: t }
-      );
-    }
-
-    // We create a new subscription
-    const newSubscription = await Subscription.create(
-      {
-        sId: generateModelSId(),
-        workspaceId: workspace.id,
-        planId: plan.id,
-        status: "active",
-        startDate: now,
-        stripeCustomerId: activeSubscription?.stripeCustomerId || null,
-      },
-      { transaction: t }
-    );
-
-    return renderSubscriptionFromModels({
-      plan,
-      activeSubscription: newSubscription,
-    });
-  });
-};
-
-/**
- * Internal function to subscribe to the FREE_UPGRADED_PLAN.
- * This plan is free with no limitations, and should be used for Dust workspaces only (once we have paiement plans)
- */
-export const internalSubscribeWorkspaceToFreeUpgradedPlan = async ({
-  workspaceId,
-  planCode = FREE_UPGRADED_PLAN_CODE,
-}: {
-  workspaceId: string;
-  planCode?: string;
-}): Promise<SubscriptionType> => {
-  const workspace = await Workspace.findOne({
-    where: { sId: workspaceId },
-  });
-  if (!workspace) {
-    throw new Error(`Cannot find workspace ${workspaceId}`);
-  }
-  const plan = await Plan.findOne({
+  const newPlan = await Plan.findOne({
     where: { code: planCode },
   });
-  if (!plan) {
+  if (!newPlan) {
     throw new Error(`Cannot subscribe to plan ${planCode}:  not found.`);
   }
 
@@ -232,41 +206,70 @@ export const internalSubscribeWorkspaceToFreeUpgradedPlan = async ({
   const activeSubscription = await Subscription.findOne({
     where: { workspaceId: workspace.id, status: "active" },
   });
-  if (activeSubscription && activeSubscription.planId === plan.id) {
+
+  // Prevent subscribing to the same plan
+  if (activeSubscription && activeSubscription.planId === newPlan.id) {
     throw new Error(
       `Cannot subscribe to plan ${planCode}: already subscribed.`
     );
   }
 
-  return frontSequelize.transaction(async (t) => {
-    // We end the active subscription if any
+  // Prevent subscribing if the new plan is not a free plan
+  if (newPlan.billingType !== "free") {
+    throw new Error(
+      `Cannot subscribe to plan ${planCode}: billingType is not "free".`
+    );
+  }
+
+  // Prevent subscribing if the new plan has less users allowed then the current one on the workspace
+  if (newPlan.maxUsersInWorkspace !== -1) {
+    const activeSeats = await countActiveSeatsInWorkspace(workspace.sId);
+    if (activeSeats > newPlan.maxUsersInWorkspace) {
+      throw new Error(
+        `Cannot subscribe to plan ${planCode}: new plan has less users allowed than currently in workspace.`
+      );
+    }
+  }
+
+  // Proceed to the termination of the active subscription (if any) and creation of the new one
+  const newSubscription = await frontSequelize.transaction(async (t) => {
     if (activeSubscription) {
+      const endedStatus = activeSubscription.stripeSubscriptionId
+        ? "ended_backend_only"
+        : "ended";
+
       await activeSubscription.update(
         {
-          status: "ended",
+          status: endedStatus,
           endDate: now,
         },
         { transaction: t }
       );
     }
 
-    // We create a new subscription
-    const newSubscription = await Subscription.create(
+    return Subscription.create(
       {
         sId: generateModelSId(),
         workspaceId: workspace.id,
-        planId: plan.id,
+        planId: newPlan.id,
         status: "active",
         startDate: now,
         stripeCustomerId: activeSubscription?.stripeCustomerId || null,
       },
       { transaction: t }
     );
+  });
 
-    return renderSubscriptionFromModels({
-      plan,
-      activeSubscription: newSubscription,
+  // Notify Stripe that we ended the subscription if the subscription was a paid one
+  if (activeSubscription?.stripeSubscriptionId) {
+    await cancelSubscriptionImmediately({
+      stripeSubscriptionId: activeSubscription.stripeSubscriptionId,
     });
+  }
+
+  return renderSubscriptionFromModels({
+    plan: newPlan,
+    activeSubscription: newSubscription,
   });
 };
 
@@ -286,10 +289,10 @@ export const pokeUpgradeOrInviteWorkspaceToPlan = async (
     throw new Error("Cannot invite workspace to enterprise plan: not allowed.");
   }
 
-  const plan = await Plan.findOne({
+  const newPlan = await Plan.findOne({
     where: { code: planCode },
   });
-  if (!plan) {
+  if (!newPlan) {
     throw new Error(
       `Cannot invite workspace to plan ${planCode}: plan not found.`
     );
@@ -297,23 +300,23 @@ export const pokeUpgradeOrInviteWorkspaceToPlan = async (
 
   // We search for an active subscription for this workspace
   const activeSubscription = auth.subscription();
-  if (activeSubscription && activeSubscription.plan.code === plan.code) {
+  if (activeSubscription && activeSubscription.plan.code === newPlan.code) {
     throw new Error(
       `Cannot subscribe to plan ${planCode}: already subscribed.`
     );
   }
 
   // If plan is a free plan, we subscribe immediately no need for an invitation
-  if (plan.billingType === "free" && plan.stripeProductId === null) {
-    await internalSubscribeWorkspaceToFreeUpgradedPlan({
+  if (newPlan.stripeProductId === null) {
+    await internalSubscribeWorkspaceToFreePlan({
       workspaceId: owner.sId,
-      planCode: plan.code,
+      planCode: newPlan.code,
     });
     return;
   }
 
   const invitation = await getPlanInvitation(auth);
-  if (invitation?.planCode === plan.code) {
+  if (invitation?.planCode === newPlan.code) {
     return invitation;
   }
 
@@ -329,7 +332,7 @@ export const pokeUpgradeOrInviteWorkspaceToPlan = async (
       {
         secret: uuidv4(),
         workspaceId: owner.id,
-        planId: plan.id,
+        planId: newPlan.id,
       },
       {
         transaction: t,
@@ -338,8 +341,8 @@ export const pokeUpgradeOrInviteWorkspaceToPlan = async (
   });
 
   return {
-    planCode: plan.code,
-    planName: plan.name,
+    planCode: newPlan.code,
+    planName: newPlan.name,
     secret: model.secret,
   };
 };

--- a/front/migrations/20240314_backfill_free_plan_subscriptions.ts
+++ b/front/migrations/20240314_backfill_free_plan_subscriptions.ts
@@ -1,6 +1,7 @@
 import { QueryTypes, Sequelize } from "sequelize";
 
-import { internalSubscribeWorkspaceToFreeTestPlan } from "@app/lib/plans/subscription";
+import { FREE_TEST_PLAN_CODE } from "@app/lib/plans/plan_codes";
+import { internalSubscribeWorkspaceToFreePlan } from "@app/lib/plans/subscription";
 import logger from "@app/logger/logger";
 import { makeScript } from "@app/scripts/helpers";
 
@@ -42,8 +43,9 @@ makeScript({}, async ({ execute }) => {
 
           if (execute) {
             // This will create a new Subscription object for the FREE_TEST_PLAN.
-            await internalSubscribeWorkspaceToFreeTestPlan({
+            await internalSubscribeWorkspaceToFreePlan({
               workspaceId: w.sId,
+              planCode: FREE_TEST_PLAN_CODE,
             });
           }
         })();

--- a/front/pages/api/poke/workspaces/[wId]/upgrade.ts
+++ b/front/pages/api/poke/workspaces/[wId]/upgrade.ts
@@ -2,10 +2,7 @@ import type { LightWorkspaceType, WithAPIErrorReponse } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { Authenticator, getSession } from "@app/lib/auth";
-import {
-  internalSubscribeWorkspaceToFreeUpgradedPlan,
-  pokeUpgradeOrInviteWorkspaceToPlan,
-} from "@app/lib/plans/subscription";
+import { pokeUpgradeOrInviteWorkspaceToPlan } from "@app/lib/plans/subscription";
 import { apiError, withLogging } from "@app/logger/withlogging";
 
 export type UpgradeWorkspaceResponseBody = {
@@ -35,15 +32,18 @@ async function handler(
 
   switch (req.method) {
     case "POST":
-      const { planCode } = req.query;
-
+      const planCode = req.query.planCode;
       if (!planCode || typeof planCode !== "string") {
-        await internalSubscribeWorkspaceToFreeUpgradedPlan({
-          workspaceId: owner.sId,
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "The planCode parameter is missing.",
+          },
         });
-      } else {
-        await pokeUpgradeOrInviteWorkspaceToPlan(auth, planCode);
       }
+
+      await pokeUpgradeOrInviteWorkspaceToPlan(auth, planCode);
 
       return res.status(200).json({
         workspace: {

--- a/types/src/front/plan.ts
+++ b/types/src/front/plan.ts
@@ -43,7 +43,11 @@ export const PAID_BILLING_TYPES = [
 export type FreeBillingType = (typeof FREE_BILLING_TYPES)[number];
 export type PaidBillingType = (typeof PAID_BILLING_TYPES)[number];
 
-export const SUBSCRIPTION_STATUSES = ["active", "ended"] as const;
+export const SUBSCRIPTION_STATUSES = [
+  "active",
+  "ended",
+  "ended_backend_only", // Ended on the backend but not yet propagated to Stripe
+] as const;
 export type SubscriptionStatusType = (typeof SUBSCRIPTION_STATUSES)[number];
 
 export type PlanType = {
@@ -58,7 +62,7 @@ export type PlanType = {
 export type SubscriptionType = {
   // null for FREE_NO_PLAN which is the default plan when there is no Subscription in DB.
   sId: string | null;
-  status: "active" | "ended";
+  status: SubscriptionStatusType;
   trialing: boolean;
   stripeSubscriptionId: string | null;
   stripeCustomerId: string | null;


### PR DESCRIPTION
## Description

Task: https://github.com/dust-tt/tasks/issues/542
Goal: Allow a workspace to be migrated from a paid plan to another plan without removing all its data.

**Done that is unrelated with the goal:** 

- [x] internalSubscribeWorkspaceToFreeUpgradedPlan always takes a planCode.
- [x] internalSubscribeWorkspaceToFreeUpgradedPlan renamed to internalSubscribeWorkspaceToFreePlan
- [x] rename plan to newPlan for clarity on a few function. 

**Done related to the goal:**

Introduce a new status `ended_backend_only` for the subscription model. This allows us to know when a subscription has been ended on the backend but not yet on Stripe. 

Update internalSubscribeWorkspaceToFreePlan which the function called on a Poké upgrade:
- [x]  internalSubscribeWorkspaceToFreePlan blocks the migration if the new plan allows for less users that the current number of active users on the workspace.
- [x]  internalSubscribeWorkspaceToFreePlan ends the subscription with the new status `ended_backend_only` if the subscription is attached to a Stripe subscription. 
- [x] internalSubscribeWorkspaceToFreeUpgradedPlan calls the Stripe API to end the subscription if the the subscription is attached to a Stripe subscription. 

Update internalSubscribeWorkspaceToFreeNoPlan to manage properly a downgrade
- [x]  Remove all users
- [x]  properly ends the subscription (same logic as for upgrading to another free plan)

Update the Stripe webhook to rework the `"customer.subscription.deleted"` event. 
- [x] Better log messages
- [x] If status is  `ended_backend_only` on DB we properly end it (confirming that Stripe has ended the subscription also).
- [x] If status is `active` on DB we end it + we remove the data (same behavior as before the PR, no change on that).

Fix cli command workspace upgrade/downgrade.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
