### PR TITLE
Make retrieveGoogleDriveContentNodes() resilient to missing nodes

### DIFF
--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -704,13 +704,15 @@ export async function retrieveGoogleDriveContentNodes(
     [...folderOrFileNodes, ...sheetNodes].map((n) => [n.internalId, n])
   );
   return new Ok(
-    internalIds.map((id) => {
-      const node = nodeByInternalId.get(id);
-      if (!node) {
-        throw new Error(`Could not find node with internalId ${id}`);
-      }
-      return node;
-    })
+    internalIds
+      .filter((id) => nodeByInternalId.has(id))
+      .map((id) => {
+        const node = nodeByInternalId.get(id);
+        if (!node) {
+          throw new Error(`Could not find node with internalId ${id}`);
+        }
+        return node;
+      })
   );
 }
 


### PR DESCRIPTION
## Description

The function `retrieveGoogleDriveContentNodes()` returns an error on unknown internalId, which is a new behavior introduced by [this](https://github.com/dust-tt/dust/pull/4305/files) PR.

We need this case to silently just not return the document, to make sure the assistant builder keeps working in the case a deleted node was previously selected.



<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
