### PR TITLE
[Content Fragment] Migrate deprecated `sourceUrl` fields

### DIFF
--- a/front/migrations/20240325_content_fragments_sourceurl_migration.ts
+++ b/front/migrations/20240325_content_fragments_sourceurl_migration.ts
@@ -32,9 +32,9 @@ async function main() {
       ],
       limit: 128,
     });
-
     // reset sourceUrl to null for those content fragments in parallel
     if (LIVE) {
+      console.log(`Processing ${messages.length} messages`);
       await Promise.all(
         messages.map(async (message) => {
           const cf = ContentFragmentResource.fromMessage(message);
@@ -44,7 +44,7 @@ async function main() {
         })
       );
     }
-  } while (messages.length > 0);
+  } while (messages.length > 0 && LIVE);
 }
 
 main()

--- a/front/migrations/20240325_content_fragments_sourceurl_migration.ts
+++ b/front/migrations/20240325_content_fragments_sourceurl_migration.ts
@@ -1,0 +1,61 @@
+import { Op } from "sequelize";
+
+import { Conversation, Message, Workspace } from "@app/lib/models";
+import {
+  ContentFragmentResource,
+  storeContentFragmentText,
+} from "@app/lib/resources/content_fragment_resource";
+import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
+
+const { LIVE } = process.env;
+
+async function main() {
+  // get all messages that are content fragments, and whose content fragment's sourceUrl field starts with
+  // "https://storage.googleapis.com/"
+  // by batches of 128
+
+  let messages = [];
+  do {
+    messages = await Message.findAll({
+      where: {
+        contentFragmentId: {
+          [Op.not]: null,
+        },
+      },
+      include: [
+        {
+          model: ContentFragmentModel,
+          as: "contentFragment",
+          where: {
+            sourceUrl: {
+              [Op.startsWith]: "https://storage.googleapis.com/",
+            },
+          },
+        },
+      ],
+      limit: 128,
+    });
+
+    // reset sourceUrl to null for those content fragments in parallel
+    if (LIVE) {
+      await Promise.all(
+        messages.map(async (message) => {
+          const cf = ContentFragmentResource.fromMessage(message);
+          await cf.update({
+            sourceUrl: null,
+          });
+        })
+      );
+    }
+  } while (messages.length > 0);
+}
+
+main()
+  .then(() => {
+    console.log("Done");
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/front/migrations/20240325_content_fragments_sourceurl_migration.ts
+++ b/front/migrations/20240325_content_fragments_sourceurl_migration.ts
@@ -1,10 +1,7 @@
 import { Op } from "sequelize";
 
-import { Conversation, Message, Workspace } from "@app/lib/models";
-import {
-  ContentFragmentResource,
-  storeContentFragmentText,
-} from "@app/lib/resources/content_fragment_resource";
+import { Message } from "@app/lib/models";
+import { ContentFragmentResource } from "@app/lib/resources/content_fragment_resource";
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
 
 const { LIVE } = process.env;


### PR DESCRIPTION
## Description

Legacy content fragment messages may have a sourceUrl with a private GCS link, only accessible to Dust so non-downloadable. This PR resets those to a null sourceUrl, to enforce the invariant that sourceUrl is a user-accessible link to an original version of the content--which we do not have for old content fragment.

This handle the cases, among others, in which the sourceUrl was  set to textually extracted content (which was against the above invariant)
## Risk
None since there was no world in which sourceUrl set to GCS was relevant

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
