### PR TITLE
Add TemplateItem in Sparkle

### DIFF
--- a/sparkle/src/_index.ts
+++ b/sparkle/src/_index.ts
@@ -115,6 +115,9 @@ export { RadioButton };
 import { Popup } from "./components/Popup";
 export { Popup };
 
+import { TemplateItem } from "./components/TemplateItem";
+export { TemplateItem };
+
 import {
   LogoHorizontalColor as LogoHorizontalColorLogo,
   LogoHorizontalColorLayer1 as LogoHorizontalColorLogoLayer1,

--- a/sparkle/src/components/CardButton.tsx
+++ b/sparkle/src/components/CardButton.tsx
@@ -1,5 +1,10 @@
 import React, { ReactNode } from "react";
 
+import {
+  noHrefLink,
+  SparkleContext,
+  SparkleContextLinkType,
+} from "@sparkle/context";
 import { classNames } from "@sparkle/lib/utils";
 
 interface CardButtonProps {
@@ -42,6 +47,10 @@ export function CardButton({
   target = "_blank",
   rel = "",
 }: CardButtonProps) {
+  const { components } = React.useContext(SparkleContext);
+
+  const Link: SparkleContextLinkType = href ? components.link : noHrefLink;
+
   const commonClasses = classNames(
     "s-flex s-cursor-pointer s-transition s-duration-200",
     variantClasses[variant],
@@ -49,10 +58,18 @@ export function CardButton({
     className
   );
   if (href) {
+    if (target) {
+      return (
+        <a href={href} target={target} rel={rel} className={commonClasses}>
+          {children}
+        </a>
+      );
+    }
+
     return (
-      <a href={href} target={target} rel={rel} className={commonClasses}>
+      <Link href={href} className={commonClasses}>
         {children}
-      </a>
+      </Link>
     );
   } else {
     return (

--- a/sparkle/src/components/TemplateItem.tsx
+++ b/sparkle/src/components/TemplateItem.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { Avatar } from "@sparkle/_index";
+import { Avatar, CardButton } from "@sparkle/_index";
 
 interface TemplateItemProps {
   description: string;
@@ -23,9 +23,10 @@ export function TemplateItem({
   const { backgroundColor, emoji } = visual;
 
   return (
-    <div
+    <CardButton
       className="s-flex s-max-h-32 s-max-w-lg s-flex-row s-gap-5 s-p-4"
       onClick={() => onClick(id)}
+      variant="tertiary"
     >
       <Avatar
         emoji={emoji}
@@ -41,6 +42,6 @@ export function TemplateItem({
           {description}
         </p>
       </div>
-    </div>
+    </CardButton>
   );
 }

--- a/sparkle/src/components/TemplateItem.tsx
+++ b/sparkle/src/components/TemplateItem.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+
+import { Avatar } from "@sparkle/_index";
+
+interface TemplateItemProps {
+  description: string;
+  id: string;
+  name: string;
+  onClick: (id: string) => void;
+  visual: {
+    backgroundColor: string;
+    emoji: string;
+  };
+}
+
+export function TemplateItem({
+  description,
+  id,
+  name,
+  onClick,
+  visual,
+}: TemplateItemProps) {
+  const { backgroundColor, emoji } = visual;
+
+  return (
+    <div
+      className="s-flex s-max-h-32 s-max-w-lg s-flex-row s-gap-5 s-p-4"
+      onClick={() => onClick(id)}
+    >
+      <Avatar
+        emoji={emoji}
+        size="lg"
+        isRounded
+        backgroundColor={backgroundColor}
+      />
+      <div className="s-flex s-flex-col s-gap-2">
+        <span className="s-text-bold s-text-lg s-font-medium s-text-element-900">
+          {name}
+        </span>
+        <p className="s-line-clamp-2 s-w-full s-text-base s-font-normal s-text-element-800">
+          {description}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/sparkle/src/stories/TemplateItem.stories.tsx
+++ b/sparkle/src/stories/TemplateItem.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta } from "@storybook/react";
+import React from "react";
+
+import { TemplateItem } from "../index_with_tw_base";
+
+const meta = {
+  title: "Primitives/TemplateItem",
+  component: TemplateItem,
+} satisfies Meta<typeof TemplateItem>;
+
+export default meta;
+
+export const TemplateItemExample = () => (
+  <div className="s-grid s-grid-cols-2 s-gap-4">
+    <TemplateItem
+      name="Hiring"
+      id="1"
+      description="The specialist for coverage, insurance, process related questions"
+      visual={{ backgroundColor: "s-bg-red-100", emoji: "🫶" }}
+      onClick={function (): void {
+        alert("Onclick fn");
+      }}
+    />
+
+    <TemplateItem
+      name="Training"
+      id="2"
+      description="The specialist for coverage, insurance, process related questions with a very long description that does not bring any value"
+      visual={{ backgroundColor: "s-bg-blue-100", emoji: "🐴" }}
+      onClick={function (): void {
+        alert("Onclick fn");
+      }}
+    />
+
+    <TemplateItem
+      name="Hiring"
+      id="1"
+      description="The specialist for coverage, insurance, process related questions"
+      visual={{ backgroundColor: "s-bg-red-100", emoji: "🫶" }}
+      onClick={function (): void {
+        alert("Onclick fn");
+      }}
+    />
+  </div>
+);


### PR DESCRIPTION
## Description

This PR adds the `TemplateItem` component in Sparkle.

<img width="1089" alt="image" src="https://github.com/dust-tt/dust/assets/7428970/eb60dc6c-283b-4702-be2a-b8d5c1d6887f">

I'll bump Sparkle version once I'm done adding all the template stuff.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
