### PR TITLE
core: `filter_code`

### DIFF
--- a/core/src/blocks/data_source.rs
+++ b/core/src/blocks/data_source.rs
@@ -3,11 +3,12 @@ use crate::blocks::block::{
 };
 use crate::blocks::helpers::get_data_source_project;
 use crate::data_sources::data_source::{Document, SearchFilter};
+use crate::deno::script::Script;
 use crate::Rule;
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use pest::iterators::Pair;
-use serde_json::Value;
+use serde_json::{json, Value};
 use std::collections::HashMap;
 use tokio::sync::mpsc::UnboundedSender;
 
@@ -15,12 +16,14 @@ use tokio::sync::mpsc::UnboundedSender;
 pub struct DataSource {
     query: String,
     full_text: bool,
+    filter_code: Option<String>,
 }
 
 impl DataSource {
     pub fn parse(block_pair: Pair<Rule>) -> Result<Self> {
         let mut query: Option<String> = None;
         let mut full_text: bool = false;
+        let mut filter_code: Option<String> = None;
 
         for pair in block_pair.into_inner() {
             match pair.as_rule() {
@@ -35,6 +38,7 @@ impl DataSource {
                                 "Invalid value for `full_text`, must be `true` or `false`"
                             ))?,
                         },
+                        "filter_code" => filter_code = Some(value),
                         _ => Err(anyhow!("Unexpected `{}` in `data_source` block", key))?,
                     }
                 }
@@ -52,6 +56,7 @@ impl DataSource {
         Ok(DataSource {
             query: query.unwrap(),
             full_text,
+            filter_code,
         })
     }
 
@@ -233,12 +238,47 @@ impl Block for DataSource {
             None => None,
         };
 
-        let filter = match config {
+        // Process filter code.
+        let (mut filter, filter_logs) = match self.filter_code.as_ref() {
+            None => (None, vec![]),
+            Some(c) => {
+                let e = env.clone();
+                let filter_code = c.clone().replace("<DUST_TRIPLE_BACKTICKS>", "```");
+                let (filter_value, filter_logs): (Value, Vec<Value>) =
+                    match tokio::task::spawn_blocking(move || {
+                        let mut script = Script::from_string(filter_code.as_str())?
+                            .with_timeout(std::time::Duration::from_secs(10));
+                        script.call("_fun", &e)
+                    })
+                    .await?
+                    {
+                        Ok((v, l)) => (v, l),
+                        Err(e) => Err(anyhow!("Error in filter code: {}", e))?,
+                    };
+
+                (
+                    match filter_value {
+                        Value::Null => None,
+                        Value::Object(o) => {
+                            println!("FILTER CODE OUTPUT: {:?}", o);
+                            Some(SearchFilter::from_json(&Value::Object(o))?)
+                        }
+                        _ => Err(anyhow!(
+                            "Invalid filter code output, expecting a filter objects with
+                             fields `tags`, `parents`, and `timestamp`."
+                        ))?,
+                    },
+                    filter_logs,
+                )
+            }
+        };
+
+        match config {
             Some(v) => match v.get("filter") {
                 Some(v) => {
-                    let mut filter = SearchFilter::from_json_str(v.to_string().as_str())?;
+                    let mut f = SearchFilter::from_json_str(v.to_string().as_str())?;
 
-                    match filter.tags.as_mut() {
+                    match f.tags.as_mut() {
                         Some(tags) => {
                             let replace_tags = |tags: &mut Vec<String>, field: &str| {
                                 *tags = tags
@@ -276,11 +316,16 @@ impl Block for DataSource {
                         None => (),
                     };
 
-                    Some(filter)
+                    // Update the filter retrieved from code with the filter extracted from the
+                    // configuration.
+                    match filter.as_mut() {
+                        Some(ff) => ff.apply(&f),
+                        None => filter = Some(f),
+                    }
                 }
-                _ => None,
+                _ => (),
             },
-            _ => None,
+            _ => (),
         };
 
         // For each data_sources, retrieve documents concurrently.
@@ -308,7 +353,9 @@ impl Block for DataSource {
 
         Ok(BlockResult {
             value: serde_json::to_value(Self::top_k_sorted_documents(top_k, &documents))?,
-            meta: None,
+            meta: Some(json!({
+                "logs": filter_logs,
+            })),
         })
     }
 

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -23,7 +23,7 @@ use qdrant_client::{
     prelude::{Payload, QdrantClient},
     qdrant,
 };
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -63,6 +63,29 @@ pub struct TimestampFilter {
     pub lt: Option<u64>,
 }
 
+// Custom deserializer for `TimestampFilter`
+fn deserialize_timestamp_filter<'de, D>(
+    deserializer: D,
+) -> Result<Option<TimestampFilter>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    struct InnerTimestampFilter {
+        gt: Option<f64>,
+        lt: Option<f64>,
+    }
+
+    let f = Option::<InnerTimestampFilter>::deserialize(deserializer)?.map(|inner_filter| {
+        TimestampFilter {
+            gt: inner_filter.gt.map(|value| value as u64), // Convert f64 to u64
+            lt: inner_filter.lt.map(|value| value as u64), // Convert f64 to u64
+        }
+    });
+
+    Ok(f)
+}
+
 /// Filter argument to perform semantic search or simple reverse-chron querying.
 /// It is used to filter the search results based on the
 /// presence of tags, parents, or time spans for timestamps.
@@ -70,6 +93,7 @@ pub struct TimestampFilter {
 pub struct SearchFilter {
     pub tags: Option<TagsFilter>,
     pub parents: Option<ParentsFilter>,
+    #[serde(deserialize_with = "deserialize_timestamp_filter")]
     pub timestamp: Option<TimestampFilter>,
 }
 
@@ -77,6 +101,104 @@ impl SearchFilter {
     pub fn from_json_str(json: &str) -> Result<Self> {
         let filter: SearchFilter = serde_json::from_str(json)?;
         Ok(filter)
+    }
+
+    pub fn from_json(json: &Value) -> Result<Self> {
+        let filter: SearchFilter = serde_json::from_value(json.clone())?;
+        Ok(filter)
+    }
+
+    // This function applies the passed SearchFilter to the current SearchFilter. Applying means
+    // merging the tags, parents, filters arrays or overriding the timestamp values.
+    pub fn apply(&mut self, other: &SearchFilter) -> () {
+        match other.tags {
+            None => (),
+            Some(ref tags) => match &mut self.tags {
+                None => self.tags = Some(tags.clone()),
+                Some(ref mut self_tags) => {
+                    match &tags.is_in {
+                        None => (),
+                        Some(ref is_in) => match &mut self_tags.is_in {
+                            None => self_tags.is_in = Some(is_in.clone()),
+                            Some(ref mut self_is_in) => {
+                                self_is_in.extend(is_in.clone());
+                            }
+                        },
+                    }
+                    match &tags.is_not {
+                        None => (),
+                        Some(ref is_not) => match &mut self_tags.is_not {
+                            None => self_tags.is_not = Some(is_not.clone()),
+                            Some(ref mut self_is_not) => {
+                                self_is_not.extend(is_not.clone());
+                            }
+                        },
+                    }
+                }
+            },
+        }
+
+        match other.parents {
+            None => (),
+            Some(ref parents) => match &mut self.parents {
+                None => self.parents = Some(parents.clone()),
+                Some(ref mut self_parents) => {
+                    match &parents.is_in {
+                        None => (),
+                        Some(ref is_in) => match &mut self_parents.is_in {
+                            None => self_parents.is_in = Some(is_in.clone()),
+                            Some(ref mut self_is_in) => {
+                                self_is_in.extend(is_in.clone());
+                            }
+                        },
+                    }
+                    match &parents.is_in_map {
+                        None => (),
+                        Some(ref is_in_map) => match &mut self_parents.is_in_map {
+                            None => self_parents.is_in_map = Some(is_in_map.clone()),
+                            Some(ref mut self_is_in_map) => {
+                                for (k, v) in is_in_map.iter() {
+                                    match self_is_in_map.get_mut(k) {
+                                        None => {
+                                            self_is_in_map.insert(k.clone(), v.clone());
+                                        }
+                                        Some(ref mut self_v) => {
+                                            self_v.extend(v.clone());
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                    }
+                    match &parents.is_not {
+                        None => (),
+                        Some(ref is_not) => match &mut self_parents.is_not {
+                            None => self_parents.is_not = Some(is_not.clone()),
+                            Some(ref mut self_is_not) => {
+                                self_is_not.extend(is_not.clone());
+                            }
+                        },
+                    }
+                }
+            },
+        }
+
+        match other.timestamp {
+            None => (),
+            Some(ref timestamp) => match &mut self.timestamp {
+                None => self.timestamp = Some(timestamp.clone()),
+                Some(ref mut self_timestamp) => {
+                    match &timestamp.gt {
+                        None => (),
+                        Some(ref gt) => self_timestamp.gt = Some(gt.clone()),
+                    }
+                    match &timestamp.lt {
+                        None => (),
+                        Some(ref lt) => self_timestamp.lt = Some(lt.clone()),
+                    }
+                }
+            },
+        }
     }
 
     // We postprocess `parents.is_in_map` if it is set to augment or set `parents.is_in` based on

--- a/front/components/app/blocks/DataSource.tsx
+++ b/front/components/app/blocks/DataSource.tsx
@@ -136,31 +136,6 @@ export default function DataSource({
     setNewTagsNot("");
   };
 
-  const handleTimestampGtChange = (gt: string) => {
-    const b = shallowBlockClone(block);
-    if (!b.config.filter) {
-      b.config.filter = {};
-    }
-    b.config.filter.timestamp = {
-      gt: gt ? gt : null,
-      lt: b.config.filter.timestamp?.lt,
-    };
-    onBlockUpdate(b);
-  };
-
-  const handleTimestampLtChange = (lt: string) => {
-    const b = shallowBlockClone(block);
-    if (!b.config.filter) {
-      b.config.filter = {};
-    }
-    b.config.filter.timestamp = {
-      lt: lt ? lt : null,
-      gt: b.config.filter.timestamp?.gt,
-    };
-    console.log("LT", b);
-    onBlockUpdate(b);
-  };
-
   const handleDataSourcesChange = (
     dataSources: { workspace_id: string; data_source_id: string }[]
   ) => {
@@ -185,6 +160,12 @@ export default function DataSource({
   const handleQueryChange = (query: string) => {
     const b = shallowBlockClone(block);
     b.spec.query = query;
+    onBlockUpdate(b);
+  };
+
+  const handleFilterCodeChange = (filterCode: string) => {
+    const b = shallowBlockClone(block);
+    b.spec.filter_code = filterCode;
     onBlockUpdate(b);
   };
 
@@ -281,7 +262,36 @@ export default function DataSource({
             </div>
           )}
           {filtersExpanded ? (
-            <>
+            <div className="flex flex-col space-y-1">
+              <div className="flex flex-col space-y-1 text-sm font-medium leading-8 text-gray-700">
+                <div className="flex w-full font-normal">
+                  <div className="w-full leading-4">
+                    <div
+                      className={classNames(
+                        "border bg-slate-100",
+                        "border-slate-100"
+                      )}
+                    >
+                      <CodeEditor
+                        data-color-mode="light"
+                        readOnly={readOnly}
+                        value={block.spec.filter_code}
+                        language="js"
+                        placeholder=""
+                        onChange={(e) => handleFilterCodeChange(e.target.value)}
+                        padding={15}
+                        style={{
+                          fontSize: 12,
+                          fontFamily:
+                            "ui-monospace, SFMono-Regular, SF Mono, Consolas, Liberation Mono, Menlo, monospace",
+                          backgroundColor: "rgb(241 245 249)",
+                        }}
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+
               <div className="flex flex-col xl:flex-row xl:space-x-2">
                 <div className="flex flex-initial flex-row items-center space-x-1 text-sm font-medium leading-8 text-gray-700">
                   <div className="flex flex-initial">tags.in:</div>
@@ -406,43 +416,8 @@ export default function DataSource({
                     </div>
                   </div>
                 </div>
-                <div className="flex flex-initial flex-row items-center space-x-1 text-sm font-medium leading-8 text-gray-700">
-                  <div className="flex flex-initial">timestamp.gt:</div>
-                  <div className="flex flex-initial font-normal">
-                    <input
-                      type="text"
-                      className={classNames(
-                        "block w-16 flex-1 rounded-md px-1 py-1 text-sm font-normal",
-                        readOnly
-                          ? "border-white ring-0 focus:border-white focus:ring-0"
-                          : "border-white focus:border-gray-300 focus:ring-0"
-                      )}
-                      readOnly={readOnly}
-                      value={block.config.filter.timestamp?.gt}
-                      onChange={(e) => handleTimestampGtChange(e.target.value)}
-                    />
-                  </div>
-                </div>
-
-                <div className="flex flex-initial flex-row items-center space-x-1 text-sm font-medium leading-8 text-gray-700">
-                  <div className="flex flex-initial">timestamp.lt:</div>
-                  <div className="flex flex-initial font-normal">
-                    <input
-                      type="text"
-                      className={classNames(
-                        "block w-16 flex-1 rounded-md px-1 py-1 text-sm font-normal",
-                        readOnly
-                          ? "border-white ring-0 focus:border-white focus:ring-0"
-                          : "border-white focus:border-gray-300 focus:ring-0"
-                      )}
-                      readOnly={readOnly}
-                      value={block.config.filter.timestamp?.lt}
-                      onChange={(e) => handleTimestampLtChange(e.target.value)}
-                    />
-                  </div>
-                </div>
               </div>
-            </>
+            </div>
           ) : null}
         </div>
 

--- a/front/components/app/blocks/DataSource.tsx
+++ b/front/components/app/blocks/DataSource.tsx
@@ -136,6 +136,31 @@ export default function DataSource({
     setNewTagsNot("");
   };
 
+  const handleTimestampGtChange = (gt: string) => {
+    const b = shallowBlockClone(block);
+    if (!b.config.filter) {
+      b.config.filter = {};
+    }
+    b.config.filter.timestamp = {
+      gt: gt ? gt : null,
+      lt: b.config.filter.timestamp?.lt,
+    };
+    onBlockUpdate(b);
+  };
+
+  const handleTimestampLtChange = (lt: string) => {
+    const b = shallowBlockClone(block);
+    if (!b.config.filter) {
+      b.config.filter = {};
+    }
+    b.config.filter.timestamp = {
+      lt: lt ? lt : null,
+      gt: b.config.filter.timestamp?.gt,
+    };
+    console.log("LT", b);
+    onBlockUpdate(b);
+  };
+
   const handleDataSourcesChange = (
     dataSources: { workspace_id: string; data_source_id: string }[]
   ) => {
@@ -379,6 +404,41 @@ export default function DataSource({
                         />
                       )}
                     </div>
+                  </div>
+                </div>
+                <div className="flex flex-initial flex-row items-center space-x-1 text-sm font-medium leading-8 text-gray-700">
+                  <div className="flex flex-initial">timestamp.gt:</div>
+                  <div className="flex flex-initial font-normal">
+                    <input
+                      type="text"
+                      className={classNames(
+                        "block w-16 flex-1 rounded-md px-1 py-1 text-sm font-normal",
+                        readOnly
+                          ? "border-white ring-0 focus:border-white focus:ring-0"
+                          : "border-white focus:border-gray-300 focus:ring-0"
+                      )}
+                      readOnly={readOnly}
+                      value={block.config.filter.timestamp?.gt}
+                      onChange={(e) => handleTimestampGtChange(e.target.value)}
+                    />
+                  </div>
+                </div>
+
+                <div className="flex flex-initial flex-row items-center space-x-1 text-sm font-medium leading-8 text-gray-700">
+                  <div className="flex flex-initial">timestamp.lt:</div>
+                  <div className="flex flex-initial font-normal">
+                    <input
+                      type="text"
+                      className={classNames(
+                        "block w-16 flex-1 rounded-md px-1 py-1 text-sm font-normal",
+                        readOnly
+                          ? "border-white ring-0 focus:border-white focus:ring-0"
+                          : "border-white focus:border-gray-300 focus:ring-0"
+                      )}
+                      readOnly={readOnly}
+                      value={block.config.filter.timestamp?.lt}
+                      onChange={(e) => handleTimestampLtChange(e.target.value)}
+                    />
                   </div>
                 </div>
               </div>

--- a/front/lib/config.ts
+++ b/front/lib/config.ts
@@ -1,6 +1,7 @@
 import type { BlockRunConfig, SpecificationType } from "@dust-tt/types";
 
 export function extractConfig(spec: SpecificationType): BlockRunConfig {
+  console.log("extractConfig", spec);
   const c = {} as { [key: string]: any };
   for (let i = 0; i < spec.length; i++) {
     const type = spec[i].type;

--- a/front/lib/config.ts
+++ b/front/lib/config.ts
@@ -1,7 +1,6 @@
 import type { BlockRunConfig, SpecificationType } from "@dust-tt/types";
 
 export function extractConfig(spec: SpecificationType): BlockRunConfig {
-  console.log("extractConfig", spec);
   const c = {} as { [key: string]: any };
   for (let i = 0; i < spec.length; i++) {
     const type = spec[i].type;

--- a/front/lib/specification.ts
+++ b/front/lib/specification.ts
@@ -233,6 +233,14 @@ export function addBlock(
         spec: {
           query: "",
           full_text: false,
+          filter_code:
+            "_fun = (env) => {\n" +
+            "  // return {\n" +
+            "  //   tags: { in: env.state.INPUT.tags, not: null },\n" +
+            "  //   parents: { in: null, not: null },\n" +
+            "  //   timestamp: { gt: 1711377963110, lt: env.state.CODE.lt }\n" +
+            "  // };\n" +
+            "}",
         },
         config: {
           data_sources: null,
@@ -493,6 +501,11 @@ export function dumpSpecification(
           block.spec.query
         )}\n\`\`\`\n`;
         out += `  full_text: ${block.spec.full_text ? "true" : "false"}\n`;
+        if (block.spec.filter_code) {
+          out += `  filter_code: \n\`\`\`\n${escapeTripleBackticks(
+            block.spec.filter_code
+          )}\n\`\`\`\n`;
+        }
         out += `}\n`;
         out += "\n";
         break;


### PR DESCRIPTION
## Description

Adds a `filter_code` field to the specification of data source blocks. If specified and if returns a non empty value, parse it as a `SearchFilter` and then attempt to merge the one we got from the config of the app call.

Merge merges all arrays and overrides `timestamp.gt\lt`. If no code is specified or returns null/undefined, the behavior of merging on top of this empty SearchFilter the one we get from configurations preserves the behavior. 

Tests:
- [x] take an old app and check that the move does not break the data source block
- [x] add a filter_code on that old app and check that everything works as expected
- [x] build a fresh data_source block and check that everything works as expected.

![Screenshot from 2024-03-26 14-01-50](https://github.com/dust-tt/dust/assets/15067/50f39584-3dd7-4417-ad3a-ac4f9ebc5dfe)

## Risk

Messing with existing apps. Will check our assistant with RAG are not impacted post deploy.

## Deploy Plan

- deploy `core`
- test existing assistants
- deploy `front`
- test existing assistants