### PR TITLE
Adding users.auth0Sub unique index

### DIFF
--- a/front/lib/models/user.ts
+++ b/front/lib/models/user.ts
@@ -93,7 +93,11 @@ User.init(
   {
     modelName: "user",
     sequelize: frontSequelize,
-    indexes: [{ fields: ["username"] }, { fields: ["provider", "providerId"] }],
+    indexes: [
+      { fields: ["username"] },
+      { fields: ["provider", "providerId"] },
+      { fields: ["auth0Sub"], unique: true, concurrently: true },
+    ],
   }
 );
 


### PR DESCRIPTION
## Description

Adding `users.auth0Sub` unique index to improve this query:
```
SELECT
  "id",
  "createdAt",
  "updatedAt",
  "provider",
  "providerId",
  "auth0Sub",
  "username",
  "email",
  "name",
  "firstName",
  "lastName",
  "imageUrl",
  "isDustSuperUser"
FROM
  "users" AS "user"
WHERE
  "user"."auth0Sub" = $1
LIMIT
  $2
```

![Screenshot 2024-03-26 at 15 04 18](https://github.com/dust-tt/dust/assets/358965/3dbfd84c-977a-45a8-a662-d68638eb3875)


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- deploy prod box
- `front> npm run initdb`
- wait for index to complete (since it's marked as `concurrently:true`)


<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
