### PR TITLE
Fix Conversation title regression

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -378,6 +378,7 @@ export async function getConversationWithoutContent(
     sId: conversation.sId,
     owner,
     title: conversation.title,
+    visibility: conversation.visibility,
   };
 }
 

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -250,6 +250,7 @@ export async function getUserConversations(
         sId: p.conversation.sId,
         owner,
         title: p.conversation.title,
+        visibility: p.conversation.visibility,
       };
 
       return [...acc, conversation];

--- a/types/src/front/assistant/conversation.ts
+++ b/types/src/front/assistant/conversation.ts
@@ -199,11 +199,12 @@ export type AgentParticipant = {
  * A lighter version of Conversation without the content (for menu display).
  */
 export type ConversationWithoutContentType = {
-  id: ModelId;
   created: number;
-  sId: string;
+  id: ModelId;
   owner: WorkspaceType;
+  sId: string;
   title: string | null;
+  visibility: ConversationVisibility;
 };
 
 export type ParticipantActionType = "posted" | "reacted" | "subscribed";


### PR DESCRIPTION
## Description

This PR fixes the regression introduced in https://github.com/dust-tt/dust/pull/4432 (see context [here](https://github.com/dust-tt/tasks/issues/576)). The new method did not return the `visibility` which is required to update the conversation's title.
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
