### PR TITLE
enh: increase maxConcurrentActivityTaskExecutions on notion worker

### DIFF
--- a/connectors/src/connectors/notion/temporal/worker.ts
+++ b/connectors/src/connectors/notion/temporal/worker.ts
@@ -17,7 +17,7 @@ export async function runNotionWorker() {
     connection,
     reuseV8Context: true,
     namespace,
-    maxConcurrentActivityTaskExecutions: 8,
+    maxConcurrentActivityTaskExecutions: 16,
     interceptors: {
       activityInbound: [
         (ctx: Context) => {


### PR DESCRIPTION
## Description

We control concurrency at the workflow level, so in terms of rate limit we are fine. Number of upserts is no longer a concern thanks to the upsert queue.



## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
