### PR TITLE
fix: use correct column types for template fields

### DIFF
--- a/front/lib/resources/storage/models/templates.ts
+++ b/front/lib/resources/storage/models/templates.ts
@@ -67,7 +67,7 @@ TemplateModel.init(
       allowNull: false,
     },
     description: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
     },
     visibility: {
       type: DataTypes.STRING,
@@ -77,10 +77,10 @@ TemplateModel.init(
       type: DataTypes.STRING,
     },
     presetDescription: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
     },
     presetInstructions: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
     },
     presetTemperature: {
       type: DataTypes.STRING,
@@ -95,10 +95,10 @@ TemplateModel.init(
       type: DataTypes.STRING,
     },
     helpInstructions: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
     },
     helpActions: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
     },
     tags: {
       type: DataTypes.ARRAY(DataTypes.STRING),


### PR DESCRIPTION
## Description

- `DataTypes.String` means `varchar(255)`, so limited to 255 characters
- `DataTypes.TEXT` means `text`
- a bunch of the fields may contain more than 255 chars, so we were using the wrong col type

I tested locally, and initdb appropriately switches the column type to the right one 

## Risk

`initdb` can be done after or before deploy, doesn't matter

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
