### PR TITLE
Add endpoints for assistant templates

### DIFF
--- a/front/lib/resources/template_resource.ts
+++ b/front/lib/resources/template_resource.ts
@@ -3,7 +3,6 @@ import { Err, Ok } from "@dust-tt/types";
 import type {
   Attributes,
   CreationAttributes,
-  Model,
   ModelStatic,
   Transaction,
 } from "sequelize";
@@ -54,7 +53,7 @@ export class TemplateResource extends BaseResource<TemplateModel> {
     return new TemplateResource(this.model, blob.get());
   }
 
-  static async listAll() {
+  static async listAllPublished() {
     const blobs = await TemplateResource.model.findAll({
       where: {
         visibility: "published",

--- a/front/lib/swr.ts
+++ b/front/lib/swr.ts
@@ -28,6 +28,8 @@ import type { GetRunBlockResponseBody } from "@app/pages/api/w/[wId]/apps/[aId]/
 import type { GetRunStatusResponseBody } from "@app/pages/api/w/[wId]/apps/[aId]/runs/[runId]/status";
 import type { GetAgentConfigurationsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
 import type { GetAgentUsageResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/usage";
+import type { FetchAssistantTemplatesResponse } from "@app/pages/api/w/[wId]/assistant/builder/templates";
+import type { FetchAssistantTemplateResponse } from "@app/pages/api/w/[wId]/assistant/builder/templates/[tId]";
 import type { FetchConversationParticipantsResponse } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/participants";
 import type { GetDataSourcesResponseBody } from "@app/pages/api/w/[wId]/data_sources";
 import type { GetConnectorResponseBody } from "@app/pages/api/w/[wId]/data_sources/[name]/connector";
@@ -656,6 +658,52 @@ export function useConversationParticipants({
     isConversationParticipantsLoading: !error && !data,
     isConversationParticipantsError: error,
     mutateConversationParticipants: mutate,
+  };
+}
+
+export function useAssistantTemplates({
+  workspaceId,
+}: {
+  workspaceId: string;
+}) {
+  const assistantTemplatesFetcher: Fetcher<FetchAssistantTemplatesResponse> =
+    fetcher;
+
+  const { data, error, mutate } = useSWR(
+    `/api/w/${workspaceId}/assistant/builder/templates`,
+    assistantTemplatesFetcher
+  );
+
+  return {
+    assistantTemplates: useMemo(() => (data ? data.templates : []), [data]),
+    isAssistantTemplatesLoading: !error && !data,
+    isAssistantTemplatesError: error,
+    mutateAssistantTemplates: mutate,
+  };
+}
+
+export function useAssistantTemplate({
+  templateId,
+  workspaceId,
+}: {
+  templateId: string | null;
+  workspaceId: string;
+}) {
+  const assistantTemplateFetcher: Fetcher<FetchAssistantTemplateResponse> =
+    fetcher;
+
+  const { data, error, mutate } = useSWR(
+    templateId !== null
+      ? `/api/w/${workspaceId}/assistant/builder/templates/${templateId}`
+      : null,
+    assistantTemplateFetcher
+  );
+
+  return {
+    assistantTemplate: useMemo(() => (data ? data : null), [data]),
+    isAssistantTemplateLoading: !error && !data,
+    isAssistantTemplateError: error,
+    mutateAssistantTemplate: mutate,
   };
 }
 

--- a/front/pages/api/w/[wId]/assistant/builder/templates/[tId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/builder/templates/[tId]/index.ts
@@ -1,0 +1,70 @@
+import type { WithAPIErrorReponse } from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { Authenticator, getSession } from "@app/lib/auth";
+import { TemplateResource } from "@app/lib/resources/template_resource";
+import { apiError, withLogging } from "@app/logger/withlogging";
+
+export type FetchAssistantTemplateResponse = ReturnType<
+  TemplateResource["toJSON"]
+>;
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorReponse<FetchAssistantTemplateResponse>>
+): Promise<void> {
+  const session = await getSession(req, res);
+  const auth = await Authenticator.fromSession(
+    session,
+    req.query.wId as string
+  );
+  const owner = auth.workspace();
+  if (!owner || !auth.isUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "app_auth_error",
+        message:
+          "Workspace not found or user not authenticated to this workspace.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET":
+      const { tId: templateId } = req.query;
+      if (!templateId || typeof templateId !== "string") {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "template_not_found",
+            message: "Template not found.",
+          },
+        });
+      }
+
+      const template = await TemplateResource.fetchByExternalId(templateId);
+      if (!template || !template.isPublished()) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "template_not_found",
+            message: "Template not found.",
+          },
+        });
+      }
+
+      return res.status(200).json(template.toJSON());
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, POST is expected.",
+        },
+      });
+  }
+}
+
+export default withLogging(handler);

--- a/front/pages/api/w/[wId]/assistant/builder/templates/index.ts
+++ b/front/pages/api/w/[wId]/assistant/builder/templates/index.ts
@@ -1,0 +1,54 @@
+import type { WithAPIErrorReponse } from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { Authenticator, getSession } from "@app/lib/auth";
+import { TemplateResource } from "@app/lib/resources/template_resource";
+import { apiError, withLogging } from "@app/logger/withlogging";
+
+export type AssistantTemplate = ReturnType<TemplateResource["toListJSON"]>;
+
+export interface FetchAssistantTemplatesResponse {
+  templates: AssistantTemplate[];
+}
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorReponse<FetchAssistantTemplatesResponse>>
+): Promise<void> {
+  const session = await getSession(req, res);
+  const auth = await Authenticator.fromSession(
+    session,
+    req.query.wId as string
+  );
+  const owner = auth.workspace();
+  if (!owner || !auth.isUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "app_auth_error",
+        message:
+          "Workspace not found or user not authenticated to this workspace.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET":
+      const templates = await TemplateResource.listAll();
+
+      return res
+        .status(200)
+        .json({ templates: templates.map((t) => t.toListJSON()) });
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, POST is expected.",
+        },
+      });
+  }
+}
+
+export default withLogging(handler);

--- a/front/pages/api/w/[wId]/assistant/builder/templates/index.ts
+++ b/front/pages/api/w/[wId]/assistant/builder/templates/index.ts
@@ -34,7 +34,7 @@ async function handler(
 
   switch (req.method) {
     case "GET":
-      const templates = await TemplateResource.listAll();
+      const templates = await TemplateResource.listAllPublished();
 
       return res
         .status(200)

--- a/types/src/front/lib/error.ts
+++ b/types/src/front/lib/error.ts
@@ -64,7 +64,9 @@ export type APIErrorType =
   | "feature_flag_already_exists"
   // Pagination:
   | "invalid_pagination_parameters"
-  | "table_not_found";
+  | "table_not_found"
+  // Templates:
+  | "template_not_found";
 
 export type APIError = {
   type: APIErrorType;


### PR DESCRIPTION
## Description

This PR introduces two new endpoints that are essential for the assistant builder templates:
1. An endpoint to provide a list of all available templates.
2. An endpoint to retrieve a specific single template.

Additionally, it enhances the `TemplateResource` to consolidate some logic.
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
