### PR TITLE
[Meru][Easier Onboarding] Invitations API handles existing members/invitations

### DIFF
--- a/front/lib/api/invitation.ts
+++ b/front/lib/api/invitation.ts
@@ -40,7 +40,7 @@ export async function updateOrCreateInvitation(
   });
 
   if (existingInvitation) {
-    existingInvitation.update({
+    await existingInvitation.update({
       initialRole,
     });
     return typeFromModel(existingInvitation);

--- a/front/pages/api/w/[wId]/invitations/index.ts
+++ b/front/pages/api/w/[wId]/invitations/index.ts
@@ -22,7 +22,6 @@ import {
 import { Authenticator, getSession } from "@app/lib/auth";
 import { isEmailValid } from "@app/lib/utils";
 import { apiError, withLogging } from "@app/logger/withlogging";
-import { update } from "lodash";
 
 export type GetWorkspaceInvitationsResponseBody = {
   invitations: MembershipInvitationType[];

--- a/front/pages/api/w/[wId]/invitations/index.ts
+++ b/front/pages/api/w/[wId]/invitations/index.ts
@@ -9,10 +9,8 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import {
-  updateOrCreateInvitation,
-  deleteInvitation,
   sendWorkspaceInvitationEmail,
-  updateInvitation,
+  updateOrCreateInvitation,
 } from "@app/lib/api/invitation";
 import { getPendingInvitations } from "@app/lib/api/invitation";
 import {
@@ -21,8 +19,8 @@ import {
 } from "@app/lib/api/workspace";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { isEmailValid } from "@app/lib/utils";
-import { apiError, withLogging } from "@app/logger/withlogging";
 import logger from "@app/logger/logger";
+import { apiError, withLogging } from "@app/logger/withlogging";
 
 export type GetWorkspaceInvitationsResponseBody = {
   invitations: MembershipInvitationType[];


### PR DESCRIPTION

Description
---
Context: this is part of task #4419

Following discussions with ed, the invitations API is changed as follows:
- if an invitation is sent for an existing member (revoked or not) => return error (cannot send invitation to existing)
- if there is an existing pending invitation, mark it as revoked & create a new one, so that we re-send an email

Deploy
---
Deploy front
