### PR TITLE
Webcrawler skip private ip addresses

### DIFF
--- a/connectors/src/connectors/webcrawler/lib/utils.ts
+++ b/connectors/src/connectors/webcrawler/lib/utils.ts
@@ -1,5 +1,6 @@
 import type { ContentNodeType } from "@dust-tt/types";
 import { hash as blake3 } from "blake3";
+import dns from "dns";
 
 // Generate a stable id for a given url and ressource type
 // That way we don't have to send URL as documentId to the front API.
@@ -100,4 +101,20 @@ export function getDisplayNameForPage(url: string): string {
   }
 
   return result;
+}
+
+export async function getIpAddressForUrl(url: string) {
+  const host = new URL(url).hostname;
+  return dns.promises.lookup(host);
+}
+
+export function isPrivateIp(ip: string) {
+  const privatePrefixes = ["0", "127", "10", "192.168"];
+  for (const prefix of privatePrefixes) {
+    if (ip.startsWith(prefix)) {
+      return true;
+    }
+  }
+
+  return false;
 }


### PR DESCRIPTION
## Description

This serves as the baseline security measure that prevents our crawler from talking to any sorts of  local network interface.

There are other layers that prevented the crawler from talking locally already, but this is more future proof.

task: https://github.com/dust-tt/tasks/issues/579

cc @spolu 

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
