### PR TITLE
Update package date fns to fix getUsageData

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "front",
       "dependencies": {
         "@amplitude/ampli": "^1.35.0",
         "@amplitude/analytics-browser": "^2.5.2",
@@ -18248,8 +18247,9 @@
       "license": "MIT"
     },
     "node_modules/date-fns": {
-      "version": "3.2.0",
-      "license": "MIT",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"


### PR DESCRIPTION
## Description

Fixes getUsageData feature broken on prod.

Logs
https://app.datadoghq.eu/logs?query=%22Unhandled%20API%20Error%22%20%40route%3A%22%2Fapi%2Fw%2F%5BwId%5D%2Fworkspace-usage%22%20&agg_m=count&agg_t=count&cols=host%2Cservice&event=AgAAAY6AibfeGq36nQAAAAAAAAAYAAAAAEFZNkFpYjBJQUFEMHA1clNaS2JWeVFBagAAACQAAAAAMDE4ZTgwOGYtYTcyZC00MjQyLThmNjctNGQ0NjMxY2M3NzZl&fromUser=true&index=%2A&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=host%2Casc&viz=stream&from_ts=1711539159114&to_ts=1711553559114&live=true




Error was
```
error: {
      "type": "TypeError",
      "message": "date_fns_format__WEBPACK_IMPORTED_MODULE_0___default(...) is not a function",
      "stack":
          TypeError: date_fns_format__WEBPACK_IMPORTED_MODULE_0___default(...) is not a function
              at unsafeGetUsageData (webpack-internal:///(api)/./lib/workspace_usage.ts:67:78)
              at handler (webpack-internal:///(api)/./pages/api/w/[wId]/workspace-usage.ts:102:111)
              at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
              at async eval (webpack-internal:///(api)/./logger/withlogging.ts:39:13)
    }
    error_stack: "TypeError: date_fns_format__WEBPACK_IMPORTED_MODULE_0___default(...) is not a function\n    at unsafeGetUsageData (webpack-internal:///(api)/./lib/workspace_usage.ts:67:78)\n    at handler (webpack-internal:///(api)/./pages/api/w/[wId]/workspace-usage.ts:102:111)\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at async eval (webpack-internal:///(api)/./logger/withlogging.ts:39:13)"
```

## Risk

/

## Deploy Plan

/
