### PR TITLE
assistant bulder template help

### DIFF
--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -621,7 +621,7 @@ export default function AssistantBuilder({
                       </li>
                     ),
                   }}
-                  className="pt-4"
+                  className="pr-8 pt-4"
                 >
                   {template?.helpInstructions ?? ""}
                 </ReactMarkdown>

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -62,6 +62,7 @@ import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { isUpgraded } from "@app/lib/plans/plan_codes";
 import { useSlackChannelsLinkedWithAgent } from "@app/lib/swr";
 import { classNames } from "@app/lib/utils";
+import type { FetchAssistantTemplateResponse } from "@app/pages/api/w/[wId]/assistant/builder/templates/[tId]";
 
 type SlackChannel = { slackChannelId: string; slackChannelName: string };
 type SlackChannelLinkedWithAgent = SlackChannel & {
@@ -85,6 +86,7 @@ type AssistantBuilderProps = {
   flow: BuilderFlow;
   defaultIsEdited?: boolean;
   baseUrl: string;
+  template: FetchAssistantTemplateResponse | null;
 };
 
 const DEFAULT_ASSISTANT_STATE: AssistantBuilderState = {
@@ -168,9 +170,8 @@ export default function AssistantBuilder({
   flow,
   defaultIsEdited,
   baseUrl,
+  template,
 }: AssistantBuilderProps) {
-  const hasTemplate = true;
-
   const router = useRouter();
   const { mutate } = useSWRConfig();
   const sendNotification = React.useContext(SendNotificationsContext);
@@ -231,7 +232,7 @@ export default function AssistantBuilder({
 
   const [previewDrawerOpenedAt, setPreviewDrawerOpenedAt] = useState<
     number | null
-  >(hasTemplate ? Date.now() : null);
+  >(template ? Date.now() : null);
 
   const openPreviewDrawer = () => {
     setPreviewDrawerOpenedAt(Date.now());
@@ -426,7 +427,7 @@ export default function AssistantBuilder({
 
   const [previewDrawerCurrentTab, setPreviewDrawerCurrentTab] = useState<
     "Preview" | "Template"
-  >(hasTemplate ? "Template" : "Preview");
+  >(template ? "Template" : "Preview");
 
   const previewDrawerTabs = useMemo(
     () => [
@@ -555,7 +556,7 @@ export default function AssistantBuilder({
           }
           rightPanel={
             <div className="h-full pb-5">
-              {hasTemplate ? (
+              {template ? (
                 <Tab
                   tabs={previewDrawerTabs}
                   variant="default"
@@ -604,8 +605,26 @@ export default function AssistantBuilder({
                         {children}
                       </strong>
                     ),
+                    ul: ({ children }) => (
+                      <ul className="list-disc py-2 pl-8 text-element-800 first:pt-0 last:pb-0">
+                        {children}
+                      </ul>
+                    ),
+                    ol: ({ children }) => (
+                      <ol className="list-decimal py-3 pl-8 text-element-800 first:pt-0 last:pb-0">
+                        {children}
+                      </ol>
+                    ),
+                    li: ({ children }) => (
+                      <li className="py-2 text-element-800 first:pt-0 last:pb-0">
+                        {children}
+                      </li>
+                    ),
                   }}
-                >{`# Template\n## hello`}</ReactMarkdown>
+                  className="pt-4"
+                >
+                  {template?.helpInstructions ?? ""}
+                </ReactMarkdown>
               )}
             </div>
           }

--- a/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
@@ -199,6 +199,7 @@ export default function EditAssistant({
       }}
       agentConfigurationId={agentConfiguration.sId}
       baseUrl={baseUrl}
+      template={null}
     />
   );
 }

--- a/front/pages/w/[wId]/builder/assistants/new.tsx
+++ b/front/pages/w/[wId]/builder/assistants/new.tsx
@@ -30,6 +30,7 @@ import { generateMockAgentConfigurationFromTemplate } from "@app/lib/api/assista
 import config from "@app/lib/api/config";
 import { getDataSources } from "@app/lib/api/data_sources";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
+import { useAssistantTemplate } from "@app/lib/swr";
 
 function getDuplicateAndTemplateIdFromQuery(query: ParsedUrlQuery) {
   const { duplicate, templateId } = query;
@@ -162,7 +163,12 @@ export default function CreateAssistant({
   agentConfiguration,
   flow,
   baseUrl,
+  templateId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  const { assistantTemplate } = useAssistantTemplate({
+    templateId,
+    workspaceId: owner.sId,
+  });
   let actionMode: AssistantBuilderInitialState["actionMode"] = "GENERIC";
 
   let timeFrame: AssistantBuilderInitialState["timeFrame"] = null;
@@ -201,7 +207,9 @@ export default function CreateAssistant({
       throw new Error("Cannot edit global assistant");
     }
   }
-
+  if (templateId && !assistantTemplate) {
+    return null;
+  }
   return (
     <AssistantBuilder
       owner={owner}
@@ -238,6 +246,7 @@ export default function CreateAssistant({
       agentConfigurationId={null}
       defaultIsEdited={true}
       baseUrl={baseUrl}
+      template={assistantTemplate}
     />
   );
 }


### PR DESCRIPTION
## Description
<img width="1738" alt="Screenshot 2024-03-28 at 10 05 10" src="https://github.com/dust-tt/dust/assets/14199823/52a8e214-3a40-443f-a2d9-7f86d6b5266e">


When there is a templateId, the assistant builder "preview" drawer is automatically opened, has 2 tabs, and automatically goes to the new "template" tab that displays the template's "instructions help".
If there is no template, behaviour is unchanged.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
