### PR TITLE
Fix: Members page: member dropdown initial value correctly set

### DIFF
--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -841,7 +841,8 @@ function ChangeMemberModal({
       openOnElement={member}
       onClose={() => {
         onClose();
-        setIsSaving(false); // reset isSaving when closing the modal
+        setSelectedRole(null);
+        setIsSaving(false);
       }}
       isSaving={isSaving}
       hasChanged={selectedRole !== member.workspaces[0].role}

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -849,7 +849,9 @@ function ChangeMemberModal({
       title={member.fullName || "Unreachable"}
       variant="side-sm"
       onSave={async (closeModalFn: () => void) => {
-        if (!selectedRole) return;
+        if (!selectedRole) {
+          return;
+        }
         setIsSaving(true);
         await handleMemberRoleChange({
           member,

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -831,9 +831,7 @@ function ChangeMemberModal({
   const { mutate } = useSWRConfig();
   const sendNotification = useContext(SendNotificationsContext);
   const [revokeMemberModalOpen, setRevokeMemberModalOpen] = useState(false);
-  const [selectedRole, setSelectedRole] = useState<ActiveRoleType>(
-    member?.workspaces[0].role || "user"
-  );
+  const [selectedRole, setSelectedRole] = useState<ActiveRoleType | null>(null);
   const [isSaving, setIsSaving] = useState(false);
 
   if (!member) return null;
@@ -850,6 +848,7 @@ function ChangeMemberModal({
       title={member.fullName || "Unreachable"}
       variant="side-sm"
       onSave={async (closeModalFn: () => void) => {
+        if (!selectedRole) return;
         setIsSaving(true);
         await handleMemberRoleChange({
           member,
@@ -875,7 +874,7 @@ function ChangeMemberModal({
           <div className="flex items-center gap-2">
             <div className="font-bold text-element-900">Role:</div>
             <RoleDropDown
-              selectedRole={selectedRole}
+              selectedRole={selectedRole || member.workspaces[0].role}
               onChange={setSelectedRole}
             />
           </div>


### PR DESCRIPTION
Description
---
A regression previously introduced made the member role side modal always set the member role dropdown to 'Member' as initial position (rather than the user's actual role)

This PR fixes that
![image](https://github.com/dust-tt/dust/assets/5437393/307cd289-7b3b-4735-91c0-e03d827c5268)