### PR TITLE
[Sparkle] TextArea component

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.126",
+  "version": "0.2.127",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.126",
+      "version": "0.2.127",
       "license": "ISC",
       "dependencies": {
         "@headlessui/react": "^1.7.17",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.126",
+  "version": "0.2.127",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/_index.ts
+++ b/sparkle/src/_index.ts
@@ -121,6 +121,9 @@ export { TemplateItem };
 import { FilterChips } from "./components/FilterChips";
 export { FilterChips };
 
+import { TextArea } from "./components/TextArea";
+export { TextArea };
+
 import {
   LogoHorizontalColor as LogoHorizontalColorLogo,
   LogoHorizontalColorLayer1 as LogoHorizontalColorLogoLayer1,

--- a/sparkle/src/components/TextArea.tsx
+++ b/sparkle/src/components/TextArea.tsx
@@ -1,0 +1,53 @@
+import React, { useEffect, useRef } from "react";
+
+import { classNames } from "@sparkle/lib/utils";
+
+type TextAreaProps = {
+  placeholder: string;
+  value: string | null;
+  onChange: (value: string) => void;
+  error?: string | null;
+  showErrorLabel?: boolean;
+};
+
+export function TextArea({
+  placeholder,
+  value,
+  onChange,
+  error,
+  showErrorLabel = false,
+}: TextAreaProps) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    const textarea = textareaRef.current;
+    if (textarea) {
+      textarea.style.height = "auto"; // Reset height to recalculate
+      textarea.style.height = `${textarea.scrollHeight}px`; // Set to scroll height
+    }
+  }, [value]); // Re-run when value changes
+  return (
+    <div className="s-flex s-flex-col s-gap-1 s-p-px">
+      <textarea
+        ref={textareaRef}
+        name="name"
+        className={classNames(
+          "s-min-h-60 s-block s-w-full s-min-w-0 s-rounded-xl s-text-sm s-transition-all s-duration-200",
+          !error
+            ? "s-border-structure-100 focus:s-border-action-300 focus:s-ring-action-300"
+            : "s-border-red-500 focus:s-border-red-500 focus:s-ring-red-500",
+          "s-border-structure-200 s-bg-structure-50",
+          "s-resize-y"
+        )}
+        placeholder={placeholder}
+        value={value ?? ""}
+        onChange={(e) => {
+          onChange(e.target.value);
+        }}
+      />
+      {error && showErrorLabel && (
+        <div className="s-ml-2 s-text-sm s-text-warning-500">{error}</div>
+      )}
+    </div>
+  );
+}

--- a/sparkle/src/stories/TextArea.stories.tsx
+++ b/sparkle/src/stories/TextArea.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta } from "@storybook/react";
+import React, { useState } from "react";
+
+import { TextArea } from "../index_with_tw_base";
+
+const meta = {
+  title: "Primitives/TextArea",
+  component: TextArea,
+} satisfies Meta<typeof TextArea>;
+
+export default meta;
+
+export const TextAreaExample = () => {
+  const [textValues, setTextValues] = useState([
+    "Normal",
+    "Error with label",
+    "Error no label",
+    "",
+  ]);
+  return (
+    <div className="s-flex s-flex-col s-gap-20">
+      <div className="s-grid s-grid-cols-3 s-gap-4">
+        <TextArea
+          placeholder="placeholder"
+          value={textValues[0]}
+          onChange={(v) =>
+            setTextValues([v, textValues[1], textValues[2], textValues[3]])
+          }
+        />
+        <TextArea
+          placeholder="placeholder"
+          value={textValues[1]}
+          error={"errored because blah"}
+          onChange={(v) =>
+            setTextValues([textValues[0], v, textValues[2], textValues[3]])
+          }
+          showErrorLabel
+        />
+        <TextArea
+          placeholder="placeholder"
+          value={textValues[2]}
+          onChange={(v) =>
+            setTextValues([textValues[0], textValues[1], v, textValues[3]])
+          }
+          error={"errored because blah"}
+        />
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
Description
---
Fixes https://github.com/dust-tt/tasks/issues/515
![image](https://github.com/dust-tt/dust/assets/5437393/c9ed14b0-bb7a-4bd1-9dd7-c52d0aa10307)

Deploy
---
Deploy sparkle

The component will replace AssistantBuilderTextArea in instructions screen, and be reused for invitations

Use in front will be done in a following PR