### PR TITLE
Fix error doc doc tracker

### DIFF
--- a/front/documents_post_process_hooks/hooks/document_tracker/suggest_changes/actions/doc_tracker_retrieval.ts
+++ b/front/documents_post_process_hooks/hooks/document_tracker/suggest_changes/actions/doc_tracker_retrieval.ts
@@ -35,6 +35,7 @@ export async function callDocTrackerRetrievalAction(
   return res.value;
 }
 
+// Must map CoreAPIDocument
 const DocTrackerRetrievalActionValueSchema = t.array(
   t.type({
     data_source_id: t.string,
@@ -42,7 +43,8 @@ const DocTrackerRetrievalActionValueSchema = t.array(
     document_id: t.string,
     timestamp: t.Integer,
     tags: t.array(t.string),
-    source_url: t.string,
+    parents: t.array(t.string),
+    source_url: t.union([t.string, t.null]),
     hash: t.string,
     text_size: t.Integer,
     text: t.union([t.string, t.null, t.undefined]),

--- a/front/documents_post_process_hooks/hooks/document_tracker/suggest_changes/lib.ts
+++ b/front/documents_post_process_hooks/hooks/document_tracker/suggest_changes/lib.ts
@@ -434,7 +434,7 @@ async function sendSuggestionEmail({
 }: {
   recipientEmail: string;
   matchedDocumentTitle: string | null;
-  matchedDocumentUrl: string;
+  matchedDocumentUrl: string | null;
   incomingDocumentTitle: string | null;
   incomingDocumentUrl: string;
   suggestedChanges: string;
@@ -457,7 +457,9 @@ async function sendSuggestionEmail({
   const matchedDocumentName = matchedDocumentTitle || matchedDocumentUrl;
   const incomingDocumentName = incomingDocumentTitle || incomingDocumentUrl;
 
-  const matchedDocumentLink = `<a href="${matchedDocumentUrl}">${matchedDocumentName}</a>`;
+  const matchedDocumentLink = matchedDocumentUrl
+    ? `<a href="${matchedDocumentUrl}">${matchedDocumentName}</a>`
+    : "<No link>";
   const incomingDocumentLink = `<a href="${incomingDocumentUrl}">${incomingDocumentName}</a>`;
 
   const htmlSuggestion = new showdown.Converter().makeHtml(suggestedChanges);


### PR DESCRIPTION
## Description

We are getting a lot of errors from the postupserthooks: https://app.datadoghq.eu/logs?query=%22Action%20failed%20response%22%20&cols=service%2C%40workflowName%2C%40activityName%2C%40error.__is_dust_error&fromUser=true&index=%2A&messageDisplay=inline&refresh_mode=sliding&saved-view-id=99802&storage=hot&stream_sort=%40duration%2Cdesc&viz=stream&from_ts=1711025093833&to_ts=1711629893833&live=true

```
Object: Action failed response: {"run":"succeeded","blocks":[{"block_type":"input","name":"INPUT","status":"succeeded","success_count":1,"error_count":0},{"block_type":"data_source","name":"SEMANTIC_SEARCH","status":"succeeded","success_count":1,"error_count":0}]}
```

I added some logic to get a better error log: 
```
{
  type: 'action_failed',
  message: 'Action failed response: Expecting string at 1.results.0.0.value.21.source_url but instead got: null'
}
```

And I edited the type to put source_url nullable which at least in my local was the reason it was failing. 
It would be weird if that was the cause of the issue on prod since this field was nullable for a long time on the Type.

But even if it's not the same reason in prod, thanks to the log we should be able to identify the problem 🤞🏻 

## Risk

/

## Deploy Plan

/
