### PR TITLE
feat: workflow to schedule scrub of workspace data

### DIFF
--- a/front/lib/email.ts
+++ b/front/lib/email.ts
@@ -163,22 +163,27 @@ export async function sendAdminDataDeletionEmail({
   firstName,
   workspaceName,
   remainingDays,
+  isLast,
 }: {
   email: string;
   firstName: string;
   workspaceName: string;
   remainingDays: number;
+  isLast: boolean;
 }): Promise<void> {
   const msg = {
     from: {
       name: "Dust team",
       email: "team@dust.tt",
     },
-    subject: `Your Dust data will be deleted in ${remainingDays} days`,
+    subject: `${
+      isLast ? "Last Reminder: " : ""
+    }Your Dust data will be deleted in ${remainingDays} days`,
     html: `<p>Hello ${firstName},</p>
     <p>You're receiving this as Admin of the Dust workspace ${workspaceName}. You recently canceled your Dust subscription.</p>
     <p>As a result, your data will be deleted in ${remainingDays} days. Once your data is deleted, it cannot be recovered.</p>
     <p>If you have any question about Dust, or would like to recover your account, simply reply to this email.</p>
+    ${isLast ? "<p>This is our last message before data deletion.</p>" : ""}
     <p>Best,</p>
     <p>The Dust team</p>`,
   };

--- a/front/lib/email.ts
+++ b/front/lib/email.ts
@@ -157,3 +157,25 @@ export async function sendAdminSubscriptionPaymentFailedEmail(
   };
   return sendEmail(email, message);
 }
+
+export async function sendAdminDataDeletionEmail({
+  email,
+  remainingDays,
+}: {
+  email: string;
+  remainingDays: number;
+}): Promise<void> {
+  const msg = {
+    from: {
+      name: "Dust team",
+      email: "team@dust.tt",
+    },
+    subject: `[Dust] Your data wil be deleted in ${remainingDays} days`,
+    html: `<p>You have cancel your Dust subscription.</p>
+    <p>Therefore, your data will be deleted in ${remainingDays}, unless you reactivate your subscription.</p>
+    <p>If you have any questions, we'll gladly answer at team@dust.tt.</p>
+    <p>Best,</p>
+    <p>The Dust team</p>`,
+  };
+  return sendEmail(email, msg);
+}

--- a/front/lib/email.ts
+++ b/front/lib/email.ts
@@ -160,9 +160,13 @@ export async function sendAdminSubscriptionPaymentFailedEmail(
 
 export async function sendAdminDataDeletionEmail({
   email,
+  firstName,
+  workspaceName,
   remainingDays,
 }: {
   email: string;
+  firstName: string;
+  workspaceName: string;
   remainingDays: number;
 }): Promise<void> {
   const msg = {
@@ -170,10 +174,11 @@ export async function sendAdminDataDeletionEmail({
       name: "Dust team",
       email: "team@dust.tt",
     },
-    subject: `[Dust] Your data wil be deleted in ${remainingDays} days`,
-    html: `<p>You have cancel your Dust subscription.</p>
-    <p>Therefore, your data will be deleted in ${remainingDays}, unless you reactivate your subscription.</p>
-    <p>If you have any questions, we'll gladly answer at team@dust.tt.</p>
+    subject: `Your Dust data will be deleted in ${remainingDays} days`,
+    html: `<p>Hello ${firstName},</p>
+    <p>You're receiving this as Admin of the Dust workspace ${workspaceName}. You recently canceled your Dust subscription.</p>
+    <p>As a result, your data will be deleted in ${remainingDays} days. Once your data is deleted, it cannot be recovered.</p>
+    <p>If you have any question about Dust, or would like to recover your account, simply reply to this email.</p>
     <p>Best,</p>
     <p>The Dust team</p>`,
   };

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -544,6 +544,10 @@ async function handler(
                   workspaceId: matchingSubscription.workspace.sId,
                 });
               if (scheduleScrubRes.isErr()) {
+                logger.error(
+                  { panic: true, error: scheduleScrubRes.error },
+                  "Error launching scrub workspace workflow"
+                );
                 return apiError(req, res, {
                   status_code: 500,
                   api_error: {

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -1,39 +1,26 @@
 import type { WithAPIErrorReponse } from "@dust-tt/types";
-import { assertNever, CoreAPI, isRetrievalConfiguration } from "@dust-tt/types";
+import { assertNever } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { pipeline, Writable } from "stream";
 import Stripe from "stripe";
 import { promisify } from "util";
 
 import { getBackendClient } from "@app/lib/amplitude/back";
-import {
-  archiveAgentConfiguration,
-  getAgentConfigurations,
-} from "@app/lib/api/assistant/configuration";
-import { getDataSources } from "@app/lib/api/data_sources";
-import { deleteDataSource } from "@app/lib/api/data_sources";
 import { getMembers } from "@app/lib/api/workspace";
 import { Authenticator } from "@app/lib/auth";
 import {
-  sendAdminDowngradeTooMuchDataEmail,
   sendAdminSubscriptionPaymentFailedEmail,
   sendCancelSubscriptionEmail,
-  sendOpsDowngradeTooMuchDataEmail,
   sendReactivateSubscriptionEmail,
 } from "@app/lib/email";
-import {
-  Membership,
-  MembershipInvitation,
-  Plan,
-  Subscription,
-  Workspace,
-} from "@app/lib/models";
+import { Plan, Subscription, Workspace } from "@app/lib/models";
 import { createCustomerPortalSession } from "@app/lib/plans/stripe";
 import { countActiveSeatsInWorkspace } from "@app/lib/plans/workspace_usage";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { generateModelSId } from "@app/lib/utils";
 import logger from "@app/logger/logger";
 import { apiError, withLogging } from "@app/logger/withlogging";
+import { launchScheduleWorkspaceScrubWorkflow } from "@app/scrub_workspace/temporal/client";
 
 const { STRIPE_SECRET_KEY = "", STRIPE_SECRET_WEBHOOK_KEY = "" } = process.env;
 
@@ -551,14 +538,20 @@ async function handler(
                 status: "ended",
                 endDate: new Date(),
               });
-              const workspaceId = matchingSubscription.workspace.sId;
-              const auth = await Authenticator.internalAdminForWorkspace(
-                workspaceId
-              );
-              await revokeUsersForDowngrade(auth);
-              await archiveConnectedAgents(auth);
-              await deleteConnectedDatasources(auth);
-              await checkStaticDatasourcesSize(auth);
+
+              const scheduleScrubRes =
+                await launchScheduleWorkspaceScrubWorkflow({
+                  workspaceId: matchingSubscription.workspace.sId,
+                });
+              if (scheduleScrubRes.isErr()) {
+                return apiError(req, res, {
+                  status_code: 500,
+                  api_error: {
+                    type: "internal_server_error",
+                    message: `Error launching scrub workspace workflow: ${scheduleScrubRes.error.message}`,
+                  },
+                });
+              }
               break;
             default:
               assertNever(matchingSubscription.status);
@@ -596,129 +589,6 @@ function _returnStripeApiError(
       message: `[Stripe Webhook][${event}] ${message}`,
     },
   });
-}
-
-/**
- * Remove everybody except the most tenured admin
- * @param workspaceId
- */
-async function revokeUsersForDowngrade(auth: Authenticator) {
-  const memberships = await Membership.findAll({
-    where: { workspaceId: auth.workspace()?.id },
-    order: [["createdAt", "ASC"]],
-  });
-  const adminMemberships = memberships.filter((m) => m.role === "admin");
-  // the first membership with role admin will not be revoked
-  adminMemberships.shift();
-  const nonAdminMemberships = memberships.filter((m) => m.role !== "admin");
-  for (const membership of [...adminMemberships, ...nonAdminMemberships]) {
-    await membership.update({ role: "revoked" });
-  }
-
-  // revoke invitations
-  const workspaceId = auth.workspace()?.id;
-  if (!workspaceId) {
-    throw new Error("Cannot get workspace.");
-  }
-  await MembershipInvitation.update(
-    { status: "revoked" },
-    { where: { workspaceId } }
-  );
-}
-
-async function archiveConnectedAgents(auth: Authenticator) {
-  const agentConfigurations = await getAgentConfigurations({
-    auth,
-    agentsGetView: "admin_internal",
-    variant: "full",
-  });
-
-  // agentconfigurations with a retrieval action with at least a managed
-  // data source
-  const agentConfigurationsToArchive = agentConfigurations.filter(
-    (ac) =>
-      ac.action &&
-      isRetrievalConfiguration(ac.action) &&
-      ac.action.dataSources.length > 0 &&
-      ac.action.dataSources.some((ds) => ds.dataSourceId.startsWith("managed-"))
-  );
-  for (const agentConfiguration of agentConfigurationsToArchive) {
-    await archiveAgentConfiguration(auth, agentConfiguration.sId);
-  }
-}
-
-async function deleteConnectedDatasources(auth: Authenticator) {
-  const dataSources = await getDataSources(auth);
-  const managedDataSources = dataSources.filter((ds) => !!ds.connectorProvider);
-  for (const dataSource of managedDataSources) {
-    // call the poke delete datasource endpoint
-    const r = await deleteDataSource(auth, dataSource.name);
-    if (r.isErr()) {
-      throw new Error(`Failed to delete data source: ${r.error.message}`);
-    }
-  }
-}
-
-/**
- * Check the size of the static datasources and send an email to the user and us if it is too big.
- */
-async function checkStaticDatasourcesSize(auth: Authenticator) {
-  const dataSources = await getDataSources(auth);
-  const staticDataSources = dataSources.filter((ds) => !ds.connectorProvider);
-  const coreAPI = new CoreAPI(logger);
-  const datasourcesTooBig = [];
-  logger.info(
-    `Checking static datasources sizes for downgrade of ${
-      auth.workspace()?.sId
-    }`
-  );
-  for (const ds of staticDataSources) {
-    // count total size of all documents of the datasource
-    let totalSize = 0;
-    for (let i = 0; ; i++) {
-      const res = await coreAPI.getDataSourceDocuments({
-        projectId: ds.dustAPIProjectId,
-        dataSourceName: ds.name,
-        limit: 1000,
-        offset: 1000 * i,
-      });
-      if (res.isErr()) {
-        throw new Error("Error getting data source documents.");
-      }
-      totalSize += res.value.documents.reduce(
-        (acc, doc) => acc + doc.text_size,
-        0
-      );
-      if (res.value.documents.length < 1000) {
-        break;
-      }
-      i++;
-    }
-
-    if (totalSize > 50 * 1024 * 1024) {
-      datasourcesTooBig.push(ds.name);
-    }
-  }
-
-  // send email
-  if (datasourcesTooBig.length > 0) {
-    logger.info(
-      `Downgrade of ${
-        auth.workspace()?.sId
-      }: datasources too big: ${datasourcesTooBig.join(", ")}.`
-    );
-    const workspace = auth.workspace();
-    if (!workspace) {
-      throw new Error("Cannot get workspace.");
-    }
-    await sendOpsDowngradeTooMuchDataEmail(workspace.sId, datasourcesTooBig);
-    // for all admins
-    const adminEmails = (await getMembers(auth, { roles: ["admin"] })).map(
-      (u) => u.email
-    );
-    for (const adminEmail of adminEmails)
-      await sendAdminDowngradeTooMuchDataEmail(adminEmail, datasourcesTooBig);
-  }
 }
 
 export default withLogging(handler);

--- a/front/scrub_workspace/temporal/activities.ts
+++ b/front/scrub_workspace/temporal/activities.ts
@@ -1,0 +1,141 @@
+import { CoreAPI, isRetrievalConfiguration } from "@dust-tt/types";
+
+import {
+  archiveAgentConfiguration,
+  getAgentConfigurations,
+} from "@app/lib/api/assistant/configuration";
+import { deleteDataSource, getDataSources } from "@app/lib/api/data_sources";
+import { getMembers } from "@app/lib/api/workspace";
+import { Authenticator } from "@app/lib/auth";
+import {
+  sendAdminDowngradeTooMuchDataEmail,
+  sendOpsDowngradeTooMuchDataEmail,
+} from "@app/lib/email";
+import logger from "@app/logger/logger";
+
+export async function sendDataDeletionEmail({
+  remainingDays,
+  workspaceId,
+}: {
+  remainingDays: number;
+  workspaceId: string;
+}) {
+  void workspaceId;
+  void remainingDays;
+}
+
+export async function shouldStillScrubData({
+  workspaceId,
+}: {
+  workspaceId: string;
+}): Promise<boolean> {
+  return !(
+    await Authenticator.internalAdminForWorkspace(workspaceId)
+  ).isUpgraded();
+}
+
+export async function scrubWorkspaceData({
+  workspaceId,
+}: {
+  workspaceId: string;
+}) {
+  const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
+  await archiveConnectedAgents(auth);
+  await deleteConnectedDatasources(auth);
+  await checkStaticDatasourcesSize(auth);
+}
+
+async function archiveConnectedAgents(auth: Authenticator) {
+  const agentConfigurations = await getAgentConfigurations({
+    auth,
+    agentsGetView: "admin_internal",
+    variant: "full",
+  });
+
+  // agentconfigurations with a retrieval action with at least a managed
+  // data source
+  const agentConfigurationsToArchive = agentConfigurations.filter(
+    (ac) =>
+      ac.action &&
+      isRetrievalConfiguration(ac.action) &&
+      ac.action.dataSources.length > 0 &&
+      ac.action.dataSources.some((ds) => ds.dataSourceId.startsWith("managed-"))
+  );
+  for (const agentConfiguration of agentConfigurationsToArchive) {
+    await archiveAgentConfiguration(auth, agentConfiguration.sId);
+  }
+}
+
+async function deleteConnectedDatasources(auth: Authenticator) {
+  const dataSources = await getDataSources(auth);
+  const managedDataSources = dataSources.filter((ds) => !!ds.connectorProvider);
+  for (const dataSource of managedDataSources) {
+    // call the poke delete datasource endpoint
+    const r = await deleteDataSource(auth, dataSource.name);
+    if (r.isErr()) {
+      throw new Error(`Failed to delete data source: ${r.error.message}`);
+    }
+  }
+}
+
+/**
+ * Check the size of the static datasources and send an email to the user and us if it is too big.
+ */
+async function checkStaticDatasourcesSize(auth: Authenticator) {
+  const dataSources = await getDataSources(auth);
+  const staticDataSources = dataSources.filter((ds) => !ds.connectorProvider);
+  const coreAPI = new CoreAPI(logger);
+  const datasourcesTooBig = [];
+  logger.info(
+    `Checking static datasources sizes for downgrade of ${
+      auth.workspace()?.sId
+    }`
+  );
+  for (const ds of staticDataSources) {
+    // count total size of all documents of the datasource
+    let totalSize = 0;
+    for (let i = 0; ; i++) {
+      const res = await coreAPI.getDataSourceDocuments({
+        projectId: ds.dustAPIProjectId,
+        dataSourceName: ds.name,
+        limit: 1000,
+        offset: 1000 * i,
+      });
+      if (res.isErr()) {
+        throw new Error("Error getting data source documents.");
+      }
+      totalSize += res.value.documents.reduce(
+        (acc, doc) => acc + doc.text_size,
+        0
+      );
+      if (res.value.documents.length < 1000) {
+        break;
+      }
+      i++;
+    }
+
+    if (totalSize > 50 * 1024 * 1024) {
+      datasourcesTooBig.push(ds.name);
+    }
+  }
+
+  // send email
+  if (datasourcesTooBig.length > 0) {
+    logger.info(
+      `Downgrade of ${
+        auth.workspace()?.sId
+      }: datasources too big: ${datasourcesTooBig.join(", ")}.`
+    );
+    const workspace = auth.workspace();
+    if (!workspace) {
+      throw new Error("Cannot get workspace.");
+    }
+    await sendOpsDowngradeTooMuchDataEmail(workspace.sId, datasourcesTooBig);
+    // for all admins
+    const adminEmails = (await getMembers(auth, { roles: ["admin"] })).map(
+      (u) => u.email
+    );
+    for (const adminEmail of adminEmails)
+      await sendAdminDowngradeTooMuchDataEmail(adminEmail, datasourcesTooBig);
+  }
+}

--- a/front/scrub_workspace/temporal/activities.ts
+++ b/front/scrub_workspace/temporal/activities.ts
@@ -21,9 +21,11 @@ import logger from "@app/logger/logger";
 export async function sendDataDeletionEmail({
   remainingDays,
   workspaceId,
+  isLast,
 }: {
   remainingDays: number;
   workspaceId: string;
+  isLast: boolean;
 }) {
   try {
     const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
@@ -38,6 +40,7 @@ export async function sendDataDeletionEmail({
         firstName: a.firstName,
         workspaceName: ws.name,
         remainingDays,
+        isLast,
       });
   } catch (e) {
     logger.error(

--- a/front/scrub_workspace/temporal/activities.ts
+++ b/front/scrub_workspace/temporal/activities.ts
@@ -111,7 +111,7 @@ async function archiveAssistants(auth: Authenticator) {
   const agentConfigurations = await getAgentConfigurations({
     auth,
     agentsGetView: "admin_internal",
-    variant: "full",
+    variant: "light",
   });
 
   const agentConfigurationsToArchive = agentConfigurations.filter(

--- a/front/scrub_workspace/temporal/activities.ts
+++ b/front/scrub_workspace/temporal/activities.ts
@@ -1,17 +1,12 @@
-import { CoreAPI, isRetrievalConfiguration } from "@dust-tt/types";
-
 import {
   archiveAgentConfiguration,
   getAgentConfigurations,
 } from "@app/lib/api/assistant/configuration";
+import { isGlobalAgentId } from "@app/lib/api/assistant/global_agents";
 import { deleteDataSource, getDataSources } from "@app/lib/api/data_sources";
 import { getMembers } from "@app/lib/api/workspace";
 import { Authenticator } from "@app/lib/auth";
-import {
-  sendAdminDowngradeTooMuchDataEmail,
-  sendOpsDowngradeTooMuchDataEmail,
-} from "@app/lib/email";
-import logger from "@app/logger/logger";
+import { sendAdminDataDeletionEmail } from "@app/lib/email";
 
 export async function sendDataDeletionEmail({
   remainingDays,
@@ -20,8 +15,12 @@ export async function sendDataDeletionEmail({
   remainingDays: number;
   workspaceId: string;
 }) {
-  void workspaceId;
-  void remainingDays;
+  const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
+  const adminEmails = (await getMembers(auth, { roles: ["admin"] })).map(
+    (u) => u.email
+  );
+  for (const adminEmail of adminEmails)
+    await sendAdminDataDeletionEmail({ email: adminEmail, remainingDays });
 }
 
 export async function shouldStillScrubData({
@@ -40,102 +39,31 @@ export async function scrubWorkspaceData({
   workspaceId: string;
 }) {
   const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
-  await archiveConnectedAgents(auth);
-  await deleteConnectedDatasources(auth);
-  await checkStaticDatasourcesSize(auth);
+  await archiveAssistants(auth);
+  await deleteDatasources(auth);
 }
 
-async function archiveConnectedAgents(auth: Authenticator) {
+async function archiveAssistants(auth: Authenticator) {
   const agentConfigurations = await getAgentConfigurations({
     auth,
     agentsGetView: "admin_internal",
     variant: "full",
   });
 
-  // agentconfigurations with a retrieval action with at least a managed
-  // data source
   const agentConfigurationsToArchive = agentConfigurations.filter(
-    (ac) =>
-      ac.action &&
-      isRetrievalConfiguration(ac.action) &&
-      ac.action.dataSources.length > 0 &&
-      ac.action.dataSources.some((ds) => ds.dataSourceId.startsWith("managed-"))
+    (ac) => !isGlobalAgentId(ac.sId)
   );
   for (const agentConfiguration of agentConfigurationsToArchive) {
     await archiveAgentConfiguration(auth, agentConfiguration.sId);
   }
 }
 
-async function deleteConnectedDatasources(auth: Authenticator) {
+async function deleteDatasources(auth: Authenticator) {
   const dataSources = await getDataSources(auth);
-  const managedDataSources = dataSources.filter((ds) => !!ds.connectorProvider);
-  for (const dataSource of managedDataSources) {
-    // call the poke delete datasource endpoint
+  for (const dataSource of dataSources) {
     const r = await deleteDataSource(auth, dataSource.name);
     if (r.isErr()) {
       throw new Error(`Failed to delete data source: ${r.error.message}`);
     }
-  }
-}
-
-/**
- * Check the size of the static datasources and send an email to the user and us if it is too big.
- */
-async function checkStaticDatasourcesSize(auth: Authenticator) {
-  const dataSources = await getDataSources(auth);
-  const staticDataSources = dataSources.filter((ds) => !ds.connectorProvider);
-  const coreAPI = new CoreAPI(logger);
-  const datasourcesTooBig = [];
-  logger.info(
-    `Checking static datasources sizes for downgrade of ${
-      auth.workspace()?.sId
-    }`
-  );
-  for (const ds of staticDataSources) {
-    // count total size of all documents of the datasource
-    let totalSize = 0;
-    for (let i = 0; ; i++) {
-      const res = await coreAPI.getDataSourceDocuments({
-        projectId: ds.dustAPIProjectId,
-        dataSourceName: ds.name,
-        limit: 1000,
-        offset: 1000 * i,
-      });
-      if (res.isErr()) {
-        throw new Error("Error getting data source documents.");
-      }
-      totalSize += res.value.documents.reduce(
-        (acc, doc) => acc + doc.text_size,
-        0
-      );
-      if (res.value.documents.length < 1000) {
-        break;
-      }
-      i++;
-    }
-
-    if (totalSize > 50 * 1024 * 1024) {
-      datasourcesTooBig.push(ds.name);
-    }
-  }
-
-  // send email
-  if (datasourcesTooBig.length > 0) {
-    logger.info(
-      `Downgrade of ${
-        auth.workspace()?.sId
-      }: datasources too big: ${datasourcesTooBig.join(", ")}.`
-    );
-    const workspace = auth.workspace();
-    if (!workspace) {
-      throw new Error("Cannot get workspace.");
-    }
-    await sendOpsDowngradeTooMuchDataEmail(workspace.sId, datasourcesTooBig);
-    // for all admins
-    const adminEmails = (await getMembers(auth, { roles: ["admin"] })).map(
-      (u) => u.email
-    );
-    for (const adminEmail of adminEmails)
-      await sendAdminDowngradeTooMuchDataEmail(adminEmail, datasourcesTooBig);
   }
 }

--- a/front/scrub_workspace/temporal/activities.ts
+++ b/front/scrub_workspace/temporal/activities.ts
@@ -77,11 +77,14 @@ async function deleteAllConversations(auth: Authenticator) {
   const conversations = await Conversation.findAll({
     where: { workspaceId: workspace.id },
   });
+  logger.info(
+    { workspaceId: workspace.sId, conversationsCount: conversations.length },
+    "Deleting all conversations for workspace."
+  );
   const chunks = chunk(conversations, 4);
   for (const chunk of chunks) {
     await Promise.all(
       chunk.map(async (c) => {
-        logger.info({ conversationId: c.id }, "Deleting conversation");
         const messages = await Message.findAll({
           attributes: ["id", "userMessageId", "agentMessageId"],
           where: { conversationId: c.id },

--- a/front/scrub_workspace/temporal/client.ts
+++ b/front/scrub_workspace/temporal/client.ts
@@ -1,0 +1,45 @@
+import type { Result } from "@dust-tt/types";
+import { Err, Ok } from "@dust-tt/types";
+
+import { getTemporalClient } from "@app/lib/temporal";
+import logger from "@app/logger/logger";
+import { scheduleWorkspaceScrubWorkflow } from "@app/scrub_workspace/temporal/workflows";
+
+import { QUEUE_NAME } from "./config";
+
+export async function launchScheduleWorkspaceScrubWorkflow({
+  workspaceId,
+}: {
+  workspaceId: string;
+}): Promise<Result<string, Error>> {
+  const client = await getTemporalClient();
+
+  const workflowId = `schedule-workspace-scrub-${workspaceId}`;
+
+  try {
+    await client.workflow.start(scheduleWorkspaceScrubWorkflow, {
+      args: [{ workspaceId }],
+      taskQueue: QUEUE_NAME,
+      workflowId: workflowId,
+      memo: {
+        workspaceId,
+      },
+    });
+    logger.info(
+      {
+        workflowId,
+      },
+      `Started workflow.`
+    );
+    return new Ok(workflowId);
+  } catch (e) {
+    logger.error(
+      {
+        workflowId,
+        error: e,
+      },
+      `Failed starting workflow.`
+    );
+    return new Err(e as Error);
+  }
+}

--- a/front/scrub_workspace/temporal/config.ts
+++ b/front/scrub_workspace/temporal/config.ts
@@ -1,0 +1,2 @@
+const QUEUE_VERSION = 1;
+export const QUEUE_NAME = `scrub-workspace-queue-v${QUEUE_VERSION}`;

--- a/front/scrub_workspace/temporal/worker.ts
+++ b/front/scrub_workspace/temporal/worker.ts
@@ -1,0 +1,29 @@
+import type { Context } from "@temporalio/activity";
+import { Worker } from "@temporalio/worker";
+
+import { getTemporalWorkerConnection } from "@app/lib/temporal";
+import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
+import logger from "@app/logger/logger";
+import * as activities from "@app/scrub_workspace/temporal/activities";
+
+import { QUEUE_NAME } from "./config";
+
+export async function runScrubWorkspaceQueueWorker() {
+  const { connection, namespace } = await getTemporalWorkerConnection();
+  const worker = await Worker.create({
+    workflowsPath: require.resolve("./workflows"),
+    activities,
+    taskQueue: QUEUE_NAME,
+    connection,
+    namespace,
+    interceptors: {
+      activityInbound: [
+        (ctx: Context) => {
+          return new ActivityInboundLogInterceptor(ctx, logger);
+        },
+      ],
+    },
+  });
+
+  await worker.run();
+}

--- a/front/scrub_workspace/temporal/workflows.ts
+++ b/front/scrub_workspace/temporal/workflows.ts
@@ -14,7 +14,7 @@ const { sendDataDeletionEmail } = proxyActivities<typeof activities>({
 });
 
 const { scrubWorkspaceData } = proxyActivities<typeof activities>({
-  startToCloseTimeout: "20 minutes",
+  startToCloseTimeout: "60 minutes",
 });
 
 export async function scheduleWorkspaceScrubWorkflow({

--- a/front/scrub_workspace/temporal/workflows.ts
+++ b/front/scrub_workspace/temporal/workflows.ts
@@ -22,12 +22,16 @@ export async function scheduleWorkspaceScrubWorkflow({
 }: {
   workspaceId: string;
 }): Promise<boolean> {
-  await sendDataDeletionEmail({ remainingDays: 15, workspaceId });
+  await sendDataDeletionEmail({
+    remainingDays: 15,
+    workspaceId,
+    isLast: false,
+  });
   await sleep("12 days");
   if (!(await shouldStillScrubData({ workspaceId }))) {
     return false;
   }
-  await sendDataDeletionEmail({ remainingDays: 3, workspaceId });
+  await sendDataDeletionEmail({ remainingDays: 3, workspaceId, isLast: true });
   await sleep("3 days");
   if (!(await shouldStillScrubData({ workspaceId }))) {
     return false;

--- a/front/scrub_workspace/temporal/workflows.ts
+++ b/front/scrub_workspace/temporal/workflows.ts
@@ -1,0 +1,38 @@
+import { proxyActivities, sleep } from "@temporalio/workflow";
+
+import type * as activities from "@app/scrub_workspace/temporal/activities";
+
+const { shouldStillScrubData } = proxyActivities<typeof activities>({
+  startToCloseTimeout: "1 minutes",
+});
+const { sendDataDeletionEmail } = proxyActivities<typeof activities>({
+  startToCloseTimeout: "1 minutes",
+  retry: {
+    // We really want to avoid sending the email infinitely.
+    maximumAttempts: 1,
+  },
+});
+
+const { scrubWorkspaceData } = proxyActivities<typeof activities>({
+  startToCloseTimeout: "20 minutes",
+});
+
+export async function scheduleWorkspaceScrubWorkflow({
+  workspaceId,
+}: {
+  workspaceId: string;
+}): Promise<boolean> {
+  await sendDataDeletionEmail({ remainingDays: 15, workspaceId });
+  await sleep("12 days");
+  if (!(await shouldStillScrubData({ workspaceId }))) {
+    return false;
+  }
+  await sendDataDeletionEmail({ remainingDays: 3, workspaceId });
+  await sleep("3 days");
+  if (!(await shouldStillScrubData({ workspaceId }))) {
+    return false;
+  }
+
+  await scrubWorkspaceData({ workspaceId });
+  return true;
+}

--- a/front/start_worker.ts
+++ b/front/start_worker.ts
@@ -4,6 +4,7 @@ import { runPostUpsertHooksWorker } from "@app/documents_post_process_hooks/temp
 import logger from "@app/logger/logger";
 import { runPokeWorker } from "@app/poke/temporal/worker";
 import { runProductionChecksWorker } from "@app/production_checks/temporal/worker";
+import { runScrubWorkspaceQueueWorker } from "@app/scrub_workspace/temporal/worker";
 import { runUpsertQueueWorker } from "@app/upsert_queue/temporal/worker";
 
 setupGlobalErrorHandler(logger);
@@ -21,4 +22,8 @@ runProductionChecksWorker().catch((err) =>
 
 runUpsertQueueWorker().catch((err) =>
   logger.error({ error: err }, "Error running upsert queue worker")
+);
+
+runScrubWorkspaceQueueWorker().catch((err) =>
+  logger.error({ error: err }, "Error running scrub workspace queue worker")
 );


### PR DESCRIPTION
## Description

fixes https://github.com/dust-tt/dust/issues/4364

Once a subscription is ended, we start a workflow that lasts for 15 days.
During this workflow execution, emails are sent (right away and then after 12 days) to remind the admins that the workspace's data is going to be deleted.
At any point, if the workspace re-subscribes, the workflow returns and nothing happens.

If the workflow reaches the end, then all the workspace's data (conversations, messages, custom assistants, data sources) is deleted (technically, assistants are archived and not deleted)


## Risk

Obviously quite risky, inverted 80/20

## Deploy Plan

Deploy front