### PR TITLE
folders: add title: and author: tags as prefix of the document

### DIFF
--- a/front/pages/api/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
@@ -128,6 +128,21 @@ async function handler(
             }
           : bodyValidation.right.section || null;
 
+      const tags = bodyValidation.right.tags || [];
+
+      // Add selection of tags as prefix to the section if they are present.
+      let tagsPrefix = "";
+      tags.forEach((tag) => {
+        ["title", "author"].forEach((t) => {
+          if (tag.startsWith(t + ":") && tag.length > t.length + 1) {
+            tagsPrefix += `$${t} : ${tag.slice(t.length + 1)}\n`;
+          }
+        });
+      });
+      if (tagsPrefix && section) {
+        section.prefix = tagsPrefix;
+      }
+
       if (!section) {
         return apiError(req, res, {
           status_code: 400,
@@ -205,7 +220,7 @@ async function handler(
         projectId: dataSource.dustAPIProjectId,
         dataSourceName: dataSource.name,
         documentId: req.query.documentId as string,
-        tags: bodyValidation.right.tags || [],
+        tags,
         parents: bodyValidation.right.parents || [],
         sourceUrl,
         timestamp: bodyValidation.right.timestamp || null,

--- a/front/pages/api/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/documents/[documentId]/index.ts
@@ -132,8 +132,8 @@ async function handler(
 
       // Add selection of tags as prefix to the section if they are present.
       let tagsPrefix = "";
-      tags.forEach((tag) => {
-        ["title", "author"].forEach((t) => {
+      ["title", "author"].forEach((t) => {
+        tags.forEach((tag) => {
           if (tag.startsWith(t + ":") && tag.length > t.length + 1) {
             tagsPrefix += `$${t} : ${tag.slice(t.length + 1)}\n`;
           }


### PR DESCRIPTION
## Description

Adds `title:...` and `author:...` tags on folders documents as prefix to the document (making sure they are repeated in every chunks issued from the document).

## Risk

N/A

## Deploy Plan

- deploy `front`