### PR TITLE
Notion: always send an url for a database

### DIFF
--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -2406,7 +2406,9 @@ export async function upsertDatabaseStructuredDataFromCache({
           content: csvRows,
           sections: [],
         },
-        documentUrl: dbModel.notionUrl ?? undefined,
+        documentUrl:
+          dbModel.notionUrl ??
+          `https://www.notion.so/${databaseId.replace(/-/g, "")}`,
         // TODO: see if we actually want to use the Notion last edited time of the database
         // we currently don't have it because we don't fetch the DB object from notion.
         timestampMs: upsertAt.getTime(),


### PR DESCRIPTION
## Description

pageUrl is nullable on both Notion models (pages & db) but when we upsert the datasource for pages we use pageCacheEntry.url that is always a string. 

This PR make sure we always send an url also for dbs: https://github.com/dust-tt/dust/blob/main/connectors/src/connectors/notion/temporal/activities.ts#L1910

I think I would keep it as is and not change the NotionDatabases object in connectors. 
WDYT?

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
