### PR TITLE
[Meru][Easier Onboarding] Allow admins to send multiple invites

### DIFF
--- a/front/components/assistant_builder/InstructionScreen.tsx
+++ b/front/components/assistant_builder/InstructionScreen.tsx
@@ -10,6 +10,7 @@ import {
   OpenaiLogo,
   Page,
   Spinner,
+  TextArea,
 } from "@dust-tt/sparkle";
 import type {
   APIError,
@@ -125,7 +126,7 @@ export function InstructionScreen({
           />
         </div>
       </div>
-      <AssistantBuilderTextArea
+      <TextArea
         placeholder="I want you to act as…"
         value={builderState.instructions}
         onChange={(value) => {
@@ -135,8 +136,6 @@ export function InstructionScreen({
             instructions: value,
           }));
         }}
-        error={null}
-        name="assistantInstructions"
       />
       {isDevelopmentOrDustWorkspace(owner) && (
         <Suggestions
@@ -260,50 +259,6 @@ function AdvancedSettings({
         </div>
       </DropdownMenu.Items>
     </DropdownMenu>
-  );
-}
-
-function AssistantBuilderTextArea({
-  placeholder,
-  value,
-  onChange,
-  error,
-  name,
-}: {
-  placeholder: string;
-  value: string | null;
-  onChange: (value: string) => void;
-  error?: string | null;
-  name: string;
-}) {
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
-
-  useEffect(() => {
-    const textarea = textareaRef.current;
-    if (textarea) {
-      textarea.style.height = "auto"; // Reset height to recalculate
-      textarea.style.height = `${textarea.scrollHeight}px`; // Set to scroll height
-    }
-  }, [value]); // Re-run when value changes
-  return (
-    <textarea
-      ref={textareaRef}
-      name="name"
-      id={name}
-      className={classNames(
-        "block min-h-60 w-full min-w-0 rounded-xl text-sm transition-all duration-200",
-        !error
-          ? "border-structure-100 focus:border-action-300 focus:ring-action-300"
-          : "border-red-500 focus:border-red-500 focus:ring-red-500",
-        "border-structure-200 bg-structure-50",
-        "resize-y"
-      )}
-      placeholder={placeholder}
-      value={value ?? ""}
-      onChange={(e) => {
-        onChange(e.target.value);
-      }}
-    />
   );
 }
 

--- a/front/components/assistant_builder/InstructionScreen.tsx
+++ b/front/components/assistant_builder/InstructionScreen.tsx
@@ -45,7 +45,6 @@ import type { AssistantBuilderState } from "@app/components/assistant_builder/ty
 import { getSupportedModelConfig } from "@app/lib/assistant";
 import { isDevelopmentOrDustWorkspace } from "@app/lib/development";
 import { isUpgraded } from "@app/lib/plans/plan_codes";
-import { classNames } from "@app/lib/utils";
 import { debounce } from "@app/lib/utils/debounce";
 
 export const CREATIVITY_LEVELS = Object.entries(

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -9,7 +9,7 @@
         "@amplitude/analytics-browser": "^2.5.2",
         "@amplitude/analytics-node": "^1.3.5",
         "@auth0/nextjs-auth0": "^3.5.0",
-        "@dust-tt/sparkle": "^0.2.128",
+        "@dust-tt/sparkle": "^0.2.130",
         "@dust-tt/types": "file:../types",
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",
@@ -10479,9 +10479,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.128",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.128.tgz",
-      "integrity": "sha512-ahg0Ng8vLtqT2H/2RCa42Cb+Vvigor0dAYnoG4ONshArTT2IvjP5CaXiLqY1HXw+gxSdVO+pED3LB6PTvCiWFA==",
+      "version": "0.2.130",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.130.tgz",
+      "integrity": "sha512-1Ja6HhRWfx6Sd8IYa5vVwW5/H4c12NoqEkVzB7hZVJaVMZQKxbdKgAmKo+lSJiEUl85SIOV8Na6yojJlFj5wvg==",
       "dependencies": {
         "@headlessui/react": "^1.7.17",
         "esbuild": "^0.20.0",

--- a/front/package.json
+++ b/front/package.json
@@ -17,7 +17,7 @@
     "@amplitude/analytics-browser": "^2.5.2",
     "@amplitude/analytics-node": "^1.3.5",
     "@auth0/nextjs-auth0": "^3.5.0",
-    "@dust-tt/sparkle": "^0.2.128",
+    "@dust-tt/sparkle": "^0.2.130",
     "@dust-tt/types": "file:../types",
     "@emoji-mart/data": "^1.1.2",
     "@emoji-mart/react": "^1.1.1",

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -451,6 +451,8 @@ function InviteEmailModal({
     revoked: [],
     notInWorkspace: [],
   });
+  const { mutate } = useSWRConfig();
+  const sendNotification = useContext(SendNotificationsContext);
   const [invitationRole, setInvitationRole] = useState<ActiveRoleType>("user");
   const [showReinviteUsersModal, setShowReinviteUsersModal] = useState(false);
 
@@ -503,6 +505,8 @@ function InviteEmailModal({
         owner,
         emails: invitesByCase.notInWorkspace,
         invitationRole,
+        mutate,
+        sendNotification,
       });
       onClose();
     } else {
@@ -665,8 +669,11 @@ function ReinviteUsersModal({
                 owner,
                 emails: notInWorkspace,
                 invitationRole: role,
+                mutate,
+                sendNotification,
               });
               onClose(false);
+              mutate(`/api/w/${owner.sId}/invitations`);
               /* Delay to let react close the modal before cleaning isSaving, to
                * avoid the user seeing the button change label again during the closing animation */
               setTimeout(() => {
@@ -1037,13 +1044,15 @@ async function sendInvitations({
   owner,
   emails,
   invitationRole,
+  mutate,
+  sendNotification,
 }: {
   owner: WorkspaceType;
   emails: string[];
   invitationRole: ActiveRoleType;
+  mutate?: any;
+  sendNotification: any;
 }) {
-  const { mutate } = useSWRConfig();
-  const sendNotification = useContext(SendNotificationsContext);
   const body: PostInvitationRequestBody = emails.map((email) => ({
     email,
     role: invitationRole,

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -673,7 +673,7 @@ function ReinviteUsersModal({
                 sendNotification,
               });
               onClose(false);
-              mutate(`/api/w/${owner.sId}/invitations`);
+              await mutate(`/api/w/${owner.sId}/invitations`);
               /* Delay to let react close the modal before cleaning isSaving, to
                * avoid the user seeing the button change label again during the closing animation */
               setTimeout(() => {

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -452,16 +452,22 @@ function InviteEmailModal({
     notInWorkspace: [],
   });
   const [invitationRole, setInvitationRole] = useState<ActiveRoleType>("user");
-  async function handleSendInvitations(): Promise<void> {
+
+  function getEmailsList(): string[] | null {
     const inviteEmailsList = inviteEmails.split(/[\n,]+/).map((e) => e.trim());
     if (inviteEmailsList.map(isEmailValid).includes(false)) {
       setEmailError(
         "Invalid email addresses: " +
           inviteEmailsList.filter((e) => !isEmailValid(e)).join(", ")
       );
-      return;
+      return null;
     }
+    return inviteEmailsList;
+  }
 
+  async function handleSendInvitations(
+    inviteEmailsList: string[]
+  ): Promise<void> {
     const invitesByCase = {
       activeSameRole: members.filter((m) =>
         inviteEmailsList.find(
@@ -520,18 +526,16 @@ function InviteEmailModal({
         saveLabel="Invite"
         isSaving={isSending}
         onSave={async () => {
+          const inviteEmailsList = getEmailsList();
+          if (!inviteEmailsList) return;
           setIsSending(true);
-          await handleSendInvitations();
+          await handleSendInvitations(inviteEmailsList);
           setIsSending(false);
           setInviteEmails("");
         }}
       >
         <div className="mt-6 flex flex-col gap-6 px-2 text-sm">
-          <Page.P>
-            Invite a new user to your workspace. They will receive an email with
-            a link to join your workspace.
-          </Page.P>
-          <div className="flex flex-grow flex-col gap-1.5">
+          <div className="flex flex-grow flex-col gap-5">
             <div className="font-semibold">
               Email addresses (comma or newline separated):
             </div>
@@ -545,6 +549,7 @@ function InviteEmailModal({
                     setEmailError("");
                   }}
                   error={emailError}
+                  showErrorLabel={true}
                 />
               </div>
             </div>

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -452,6 +452,7 @@ function InviteEmailModal({
     notInWorkspace: [],
   });
   const [invitationRole, setInvitationRole] = useState<ActiveRoleType>("user");
+  const [showReinviteUsersModal, setShowReinviteUsersModal] = useState(false);
 
   function getEmailsList(): string[] | null {
     const inviteEmailsList = inviteEmails
@@ -504,6 +505,8 @@ function InviteEmailModal({
         invitationRole,
       });
       onClose();
+    } else {
+      setShowReinviteUsersModal(true);
     }
   }
 
@@ -511,14 +514,8 @@ function InviteEmailModal({
     <>
       <ReinviteUsersModal
         owner={owner}
-        onClose={() =>
-          setInvitationsSegmentation({
-            activeSameRole: [],
-            activeDifferentRole: [],
-            revoked: [],
-            notInWorkspace: [],
-          })
-        }
+        show={showReinviteUsersModal}
+        onClose={() => setShowReinviteUsersModal(false)}
         invitationsSegmentation={invitationsSegmentation}
         role={invitationRole}
       />
@@ -579,11 +576,13 @@ function InviteEmailModal({
 
 function ReinviteUsersModal({
   owner,
+  show,
   onClose,
   invitationsSegmentation,
   role,
 }: {
   owner: WorkspaceType;
+  show: boolean;
   onClose: (show: boolean) => void;
   invitationsSegmentation: {
     activeSameRole: UserTypeWithWorkspaces[];
@@ -602,7 +601,7 @@ function ReinviteUsersModal({
 
   return (
     <Modal
-      isOpen={shouldWarnAboutExistingMembers(invitationsSegmentation)}
+      isOpen={show}
       onClose={() => onClose(false)}
       hasChanged={false}
       title="Some users are already in the workspace"

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -453,7 +453,7 @@ function InviteEmailModal({
   });
   const [invitationRole, setInvitationRole] = useState<ActiveRoleType>("user");
   async function handleSendInvitation(): Promise<void> {
-    const inviteEmailsList = inviteEmails.split(",").map((e) => e.trim());
+    const inviteEmailsList = inviteEmails.split(/[\n,]+/).map((e) => e.trim());
     if (inviteEmailsList.map(isEmailValid).includes(false)) {
       setEmailError(
         "Invalid email addresses: " +
@@ -532,12 +532,12 @@ function InviteEmailModal({
           </Page.P>
           <div className="flex flex-grow flex-col gap-1.5">
             <div className="font-semibold">
-              Email addresses (comma-separated):
+              Email addresses (comma or newline separated):
             </div>
             <div className="flex items-start gap-2">
               <div className="flex-grow">
                 <TextArea
-                  placeholder="Email addresses, comma-separated"
+                  placeholder="Email addresses, comma or newline separated"
                   value={inviteEmails}
                   onChange={(value) => {
                     setInviteEmails(value);

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -616,12 +616,11 @@ function ReinviteUsersModal({
               Reinstating them will also immediately reinstate their
               conversation history on Dust.
             </div>
-            <div className="flex max-h-48 flex-col gap-2 overflow-y-auto rounded border">
+            <div className="mt-2 flex max-h-48 flex-col gap-1 overflow-y-auto rounded border p-2 text-xs">
               {revoked.map((user) => (
                 <div
                   key={user.email}
-                  className="font-semibold text-element-900"
-                >{`${user.fullName} (${user.email})`}</div>
+                >{`- ${user.fullName} (${user.email})`}</div>
               ))}
             </div>
           </div>
@@ -631,14 +630,13 @@ function ReinviteUsersModal({
             <div>
               The user(s) below are already in your workspace with a different
               role. Moving forward will change their role to{" "}
-              <span className="bold">${displayRole(role)}</span>.
+              <span className="font-bold">{displayRole(role)}</span>.
             </div>
-            <div className="flex max-h-48 flex-col gap-2 overflow-y-auto rounded border">
+            <div className="mt-2 flex max-h-48 flex-col gap-1 overflow-y-auto rounded border p-2 text-xs">
               {activeDifferentRole.map((user) => (
-                <div
-                  key={user.email}
-                  className="font-semibold text-element-900"
-                >{`${user.fullName} (${user.email}, current role: ${displayRole(
+                <div key={user.email}>{`- ${
+                  user.fullName
+                } (current role: ${displayRole(
                   user.workspaces[0].role
                 )})`}</div>
               ))}

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -452,7 +452,7 @@ function InviteEmailModal({
     notInWorkspace: [],
   });
   const [invitationRole, setInvitationRole] = useState<ActiveRoleType>("user");
-  async function handleSendInvitation(): Promise<void> {
+  async function handleSendInvitations(): Promise<void> {
     const inviteEmailsList = inviteEmails.split(/[\n,]+/).map((e) => e.trim());
     if (inviteEmailsList.map(isEmailValid).includes(false)) {
       setEmailError(
@@ -498,7 +498,8 @@ function InviteEmailModal({
 
   return (
     <>
-      <ReinviteUserModal
+      <ReinviteUsersModal
+        owner={owner}
         onClose={() =>
           setInvitationsSegmentation({
             activeSameRole: [],
@@ -520,7 +521,7 @@ function InviteEmailModal({
         isSaving={isSending}
         onSave={async () => {
           setIsSending(true);
-          await handleSendInvitation();
+          await handleSendInvitations();
           setIsSending(false);
           setInviteEmails("");
         }}
@@ -566,11 +567,13 @@ function InviteEmailModal({
   );
 }
 
-function ReinviteUserModal({
+function ReinviteUsersModal({
+  owner,
   onClose,
   invitationsSegmentation,
   role,
 }: {
+  owner: WorkspaceType;
   onClose: (show: boolean) => void;
   invitationsSegmentation: {
     activeSameRole: UserTypeWithWorkspaces[];
@@ -584,7 +587,8 @@ function ReinviteUserModal({
   const sendNotification = useContext(SendNotificationsContext);
   const [isSaving, setIsSaving] = useState(false);
 
-  const { activeDifferentRole, revoked } = invitationsSegmentation;
+  const { notInWorkspace, activeDifferentRole, revoked } =
+    invitationsSegmentation;
 
   return (
     <Modal
@@ -649,6 +653,11 @@ function ReinviteUserModal({
                 role,
                 mutate,
                 sendNotification,
+              });
+              await sendInvitations({
+                owner,
+                emails: notInWorkspace,
+                invitationRole: role,
               });
               onClose(false);
               /* Delay to let react close the modal before cleaning isSaving, to

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -454,7 +454,12 @@ function InviteEmailModal({
   const [invitationRole, setInvitationRole] = useState<ActiveRoleType>("user");
 
   function getEmailsList(): string[] | null {
-    const inviteEmailsList = inviteEmails.split(/[\n,]+/).map((e) => e.trim());
+    const inviteEmailsList = inviteEmails
+      .split(/[\n,]+/)
+      .map((e) => e.trim())
+      .filter((e) => e !== "")
+      // remove duplicates
+      .filter((e, i, self) => self.indexOf(e) === i);
     if (inviteEmailsList.map(isEmailValid).includes(false)) {
       setEmailError(
         "Invalid email addresses: " +

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -14,6 +14,7 @@ import {
   PlusIcon,
   Popup,
   Searchbar,
+  TextArea,
 } from "@dust-tt/sparkle";
 import type { MembershipInvitationType } from "@dust-tt/types";
 import type { PlanType, SubscriptionType } from "@dust-tt/types";
@@ -535,18 +536,15 @@ function InviteEmailModal({
             </div>
             <div className="flex items-start gap-2">
               <div className="flex-grow">
-                <textarea
-                  placeholder={"Email addresses, comma-separated"}
-                  value={inviteEmails || ""}
-                  name={""}
-                  onChange={(e) => {
-                    setInviteEmails(e.target.value);
+                <TextArea
+                  placeholder="Email addresses, comma-separated"
+                  value={inviteEmails}
+                  onChange={(value) => {
+                    setInviteEmails(value);
                     setEmailError("");
                   }}
+                  error={emailError}
                 />
-                {emailError && (
-                  <div className="text-error-500">{emailError}</div>
-                )}
               </div>
             </div>
             <div className="flex flex-col gap-2">

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -500,7 +500,7 @@ function InviteEmailModal({
     if (!shouldWarnAboutExistingMembers(invitesByCase)) {
       await sendInvitations({
         owner,
-        emails: invitationsSegmentation.notInWorkspace,
+        emails: invitesByCase.notInWorkspace,
         invitationRole,
       });
       onClose();

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -971,8 +971,8 @@ function ChangeMemberModal({
         isOpen={revokeMemberModalOpen}
         title="Revoke member access"
         onValidate={async () => {
-          await handleMemberRoleChange({
-            member,
+          await handleMembersRoleChange({
+            members: [member],
             role: "none",
             mutate,
             sendNotification,
@@ -985,6 +985,7 @@ function ChangeMemberModal({
         onCancel={() => {
           setRevokeMemberModalOpen(false);
         }}
+        isSaving={isSaving}
       >
         <div>
           Revoke access for user{" "}


### PR DESCRIPTION
## Description

Fixes #4419 

Checks email validity before sending. Multiple paths are possible depending on the email list. Some users:
A. may already be in the workspace, with the same role as the one proposed for invitation,
B. may already be in the workspace, with a different role,
C. may be revoked from the workspace,
D. may not be in the workspace, but already invited,
E. may be first-time invitee

Here's how each is handled, after discussion with @Duncid (& @lasryaric for case D)
- A. is silently ignored
- B & C yield a confirmation popup (see screenshot); if confirmed, all invitees in case B & C are switched to the role chosen for invitation;
- D. is reinvited with the role chosen (previous invitation updated, email re-sent);
- E gets a regular email invitation

### Tech Note
- this PR also bumps sparkle for front, switching InstructionsScreen to the new TextArea component

#### State before inviting:
![Screenshot from 2024-03-28 16-56-20](https://github.com/dust-tt/dust/assets/5437393/ba00f9e4-1596-4a89-9779-b68b714b2a9c)

#### Invite modal
![Screenshot from 2024-03-28 16-57-08](https://github.com/dust-tt/dust/assets/5437393/e1376ab1-bb98-45b9-9a07-401422463f31)

#### Warning screen
![Screenshot from 2024-03-28 16-57-27](https://github.com/dust-tt/dust/assets/5437393/f6a39ee6-e53b-4fc0-aa7f-ee137925ef7d)

#### State after inviting
![Screenshot from 2024-03-28 16-57-49](https://github.com/dust-tt/dust/assets/5437393/cecb1b09-d37c-4eb8-a499-9837f9804950)


## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
