### PR TITLE
Optimize PDF pages support

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -36,7 +36,6 @@ import {
 } from "@connectors/lib/models/google_drive";
 import { syncFailed } from "@connectors/lib/sync_status";
 import { heartbeat } from "@connectors/lib/temporal";
-import mainLogger from "@connectors/logger/logger";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { sequelizeConnection } from "@connectors/resources/storage";
@@ -248,7 +247,7 @@ export async function incrementalSync(
   startSyncTs: number,
   nextPageToken?: string
 ): Promise<string | undefined> {
-  const logger = mainLogger.child({
+  const localLogger = logger.child({
     provider: "google_drive",
     connectorId: connectorId,
     driveId: driveId,
@@ -303,7 +302,7 @@ export async function incrementalSync(
       throw new Error(`changes list is undefined`);
     }
 
-    logger.info(
+    localLogger.info(
       {
         nbChanges: changesRes.data.changes.length,
       },
@@ -354,7 +353,7 @@ export async function incrementalSync(
           `Invalid file. File is: ${JSON.stringify(change.file)}`
         );
       }
-      logger.info({ file_id: change.file.id }, "will sync file");
+      localLogger.info({ file_id: change.file.id }, "will sync file");
 
       const driveFile: GoogleDriveObjectType = await driveObjectToDustType(
         change.file,
@@ -370,7 +369,7 @@ export async function incrementalSync(
           parentId: file.parent,
           lastSeenTs: new Date(),
         });
-        logger.info({ file_id: change.file.id }, "done syncing file");
+        localLogger.info({ file_id: change.file.id }, "done syncing file");
 
         continue;
       }
@@ -382,7 +381,7 @@ export async function incrementalSync(
         driveFile,
         startSyncTs
       );
-      logger.info({ file_id: change.file.id }, "done syncing file");
+      localLogger.info({ file_id: change.file.id }, "done syncing file");
     }
 
     nextPageToken = changesRes.data.nextPageToken
@@ -399,7 +398,7 @@ export async function incrementalSync(
     return nextPageToken;
   } catch (e) {
     if (e instanceof GaxiosError && e.response?.status === 403) {
-      logger.error(
+      localLogger.error(
         {
           error: e.message,
         },

--- a/connectors/src/connectors/google_drive/temporal/file.ts
+++ b/connectors/src/connectors/google_drive/temporal/file.ts
@@ -219,6 +219,7 @@ export async function syncOneFile(
                 prefix: null,
                 content: null,
                 sections: pages.map((page, i) => ({
+                  // We prefix with `\n` because page splitting  in `dpdf2text` removes the `\f`.
                   prefix: `\n$pdfPage: ${i + 1}/${pages.length}\n`,
                   content: page,
                   sections: [],

--- a/connectors/src/connectors/google_drive/temporal/file.ts
+++ b/connectors/src/connectors/google_drive/temporal/file.ts
@@ -62,6 +62,17 @@ export async function syncOneFile(
     },
   });
 
+  const localLogger = logger.child({
+    provider: "google_drive",
+    workspaceId: dataSourceConfig.workspaceId,
+    dataSourceName: dataSourceConfig.dataSourceName,
+    connectorId,
+    documentId,
+    fileId: file.id,
+    title: file.name,
+    mimeType: file.mimeType,
+  });
+
   // Early return if lastSeenTs is greater than workflow start.
   // This allows avoiding resyncing already-synced documents in case of activity failure
   if (fileInDb?.lastSeenTs && fileInDb.lastSeenTs > new Date(startSyncTs)) {
@@ -69,25 +80,15 @@ export async function syncOneFile(
   }
 
   if (fileInDb?.skipReason) {
-    logger.info(
-      {
-        documentId,
-        dataSourceConfig,
-        fileId: file.id,
-        title: file.name,
-      },
+    localLogger.info(
+      {},
       `Google Drive document skipped with skip reason ${fileInDb.skipReason}`
     );
     return false;
   }
   if (!file.capabilities.canDownload) {
-    logger.info(
-      {
-        documentId,
-        connectorId,
-        fileId: file.id,
-        title: file.name,
-      },
+    localLogger.info(
+      {},
       `Google Drive document skipped because it cannot be downloaded`
     );
     return false;
@@ -103,15 +104,7 @@ export async function syncOneFile(
         mimeType: MIME_TYPES_TO_EXPORT[file.mimeType],
       });
       if (res.status !== 200) {
-        logger.error(
-          {
-            documentId,
-            dataSourceConfig,
-            fileId: file.id,
-            title: file.name,
-          },
-          "Error exporting Google document"
-        );
+        localLogger.error({}, "Error exporting Google document");
         throw new Error(
           `Error exporting Google document. status_code: ${res.status}. status_text: ${res.statusText}`
         );
@@ -144,13 +137,8 @@ export async function syncOneFile(
               }
             : null;
       } else {
-        logger.error(
+        localLogger.error(
           {
-            connectorId: connectorId,
-            documentId,
-            fileMimeType: file.mimeType,
-            fileId: file.id,
-            title: file.name,
             resDataTypeOf: typeof res.data,
             type: "export",
           },
@@ -158,15 +146,7 @@ export async function syncOneFile(
         );
       }
     } catch (e) {
-      logger.error(
-        {
-          documentId,
-          dataSourceConfig,
-          fileId: file.id,
-          title: file.name,
-        },
-        "Error exporting Google document"
-      );
+      localLogger.error({}, "Error exporting Google document");
       throw e;
     }
   } else if (mimeTypesToDownload.includes(file.mimeType)) {
@@ -188,14 +168,7 @@ export async function syncOneFile(
       if (maybeErrorWithCode.code === "ERR_OUT_OF_RANGE") {
         // This error happens when the file is too big to be downloaded.
         // We skip this file.
-        logger.info(
-          {
-            file_id: file.id,
-            mimeType: file.mimeType,
-            title: file.name,
-          },
-          `File too big to be downloaded. Skipping`
-        );
+        localLogger.info({}, `File too big to be downloaded. Skipping`);
         return false;
       }
       throw e;
@@ -214,14 +187,7 @@ export async function syncOneFile(
         // avoids operations on very long text files, that can cause
         // Buffer.toString to crash if the file is > 500MB
         if (res.data.byteLength > 4 * maxDocumentLen) {
-          logger.info(
-            {
-              file_id: file.id,
-              mimeType: file.mimeType,
-              title: file.name,
-            },
-            `File too big to be chunked. Skipping`
-          );
+          localLogger.info({}, `File too big to be chunked. Skipping`);
           return false;
         }
         documentContent = {
@@ -230,13 +196,8 @@ export async function syncOneFile(
           sections: [],
         };
       } else {
-        logger.error(
+        localLogger.error(
           {
-            connectorId: connectorId,
-            documentId,
-            fileMimeType: file.mimeType,
-            fileId: file.id,
-            title: file.name,
             resDataTypeOf: typeof res.data,
             type: "download",
           },
@@ -258,29 +219,23 @@ export async function syncOneFile(
                 prefix: null,
                 content: null,
                 sections: pages.map((page, i) => ({
-                  prefix: `$pdfPage: ${i + 1}/${pages.length}\n`,
+                  prefix: `\n$pdfPage: ${i + 1}/${pages.length}\n`,
                   content: page,
                   sections: [],
                 })),
               }
             : null;
 
-        logger.info(
+        localLogger.info(
           {
-            file_id: file.id,
-            mimeType: file.mimeType,
             pagesCount: pages.length,
-            title: file.name,
           },
           `Successfully converted PDF to text`
         );
       } catch (err) {
-        logger.warn(
+        localLogger.warn(
           {
             error: err,
-            file_id: file.id,
-            mimeType: file.mimeType,
-            filename: file.name,
           },
           `Error while converting PDF to text`
         );
@@ -298,13 +253,8 @@ export async function syncOneFile(
       return false;
     } else {
       if (res.skipReason) {
-        logger.info(
-          {
-            documentId,
-            dataSourceConfig,
-            fileId: file.id,
-            title: file.name,
-          },
+        localLogger.info(
+          {},
           `Google Spreadsheet document skipped with skip reason ${res.skipReason}`
         );
         skipReason = res.skipReason;
@@ -328,16 +278,7 @@ export async function syncOneFile(
     });
 
     if (documentContent === undefined) {
-      logger.error(
-        {
-          connectorId: connectorId,
-          documentId,
-          fileMimeType: file.mimeType,
-          fileId: file.id,
-          title: file.name,
-        },
-        "documentContent is undefined"
-      );
+      localLogger.error({}, "documentContent is undefined");
       throw new Error("documentContent is undefined");
     }
     const tags = [`title:${file.name}`];
@@ -382,12 +323,9 @@ export async function syncOneFile(
 
       upsertTimestampMs = file.updatedAtMs;
     } else {
-      logger.info(
+      localLogger.info(
         {
-          documentId,
-          dataSourceConfig,
           documentLen: documentLen,
-          title: file.name,
         },
         `Document is empty or too big to be upserted. Skipping`
       );


### PR DESCRIPTION
## Description

Running one pdftotext command per page is super slow as it reparses the entire PDF each time (20x slow down when it was introduced on some workspace).

Instead rely on the fact that pdftotext introduces a form feed character between pages `\f`

Also clean-up logging in GDrive

## Risk

Some PDFs may have \f in their body which seems unlikely based on a rapid scanning on popper's source code (as it is considered a page break when parsing the PDF). We filter emtpy trimed pages even if that will mess with the page numbers for potentially problematic PDFs to mitigate the risk.

Tested locally on a variety of PDFs.

## Deploy Plan

- deploy `connectors`