### PR TITLE
feat: display subscriptions table on poke

### DIFF
--- a/front/components/poke/subscriptions/columns.tsx
+++ b/front/components/poke/subscriptions/columns.tsx
@@ -1,0 +1,101 @@
+import { IconButton } from "@dust-tt/sparkle";
+import { ArrowsUpDownIcon } from "@heroicons/react/20/solid";
+import type { ColumnDef } from "@tanstack/react-table";
+
+type SubscriptionsDisplayType = {
+  sId: string;
+  planCode: string;
+  status: string;
+  startDate: string | null;
+  endDate: string | null;
+};
+
+export function makeColumnsForSubscriptions(): ColumnDef<SubscriptionsDisplayType>[] {
+  return [
+    {
+      accessorKey: "sId",
+      header: ({ column }) => {
+        return (
+          <div className="flex space-x-2">
+            <p>SID</p>
+            <IconButton
+              variant="tertiary"
+              icon={ArrowsUpDownIcon}
+              onClick={() =>
+                column.toggleSorting(column.getIsSorted() === "asc")
+              }
+            />
+          </div>
+        );
+      },
+    },
+    {
+      accessorKey: "planCode",
+      header: ({ column }) => {
+        return (
+          <div className="flex space-x-2">
+            <p>Plan Code</p>
+            <IconButton
+              variant="tertiary"
+              icon={ArrowsUpDownIcon}
+              onClick={() =>
+                column.toggleSorting(column.getIsSorted() === "asc")
+              }
+            />
+          </div>
+        );
+      },
+    },
+    {
+      accessorKey: "status",
+      header: ({ column }) => {
+        return (
+          <div className="flex space-x-2">
+            <p>Status</p>
+            <IconButton
+              variant="tertiary"
+              icon={ArrowsUpDownIcon}
+              onClick={() =>
+                column.toggleSorting(column.getIsSorted() === "asc")
+              }
+            />
+          </div>
+        );
+      },
+    },
+    {
+      accessorKey: "startDate",
+      header: ({ column }) => {
+        return (
+          <div className="flex space-x-2">
+            <p>Start Date</p>
+            <IconButton
+              variant="tertiary"
+              icon={ArrowsUpDownIcon}
+              onClick={() =>
+                column.toggleSorting(column.getIsSorted() === "asc")
+              }
+            />
+          </div>
+        );
+      },
+    },
+    {
+      accessorKey: "endDate",
+      header: ({ column }) => {
+        return (
+          <div className="flex space-x-2">
+            <p>End Date</p>
+            <IconButton
+              variant="tertiary"
+              icon={ArrowsUpDownIcon}
+              onClick={() =>
+                column.toggleSorting(column.getIsSorted() === "asc")
+              }
+            />
+          </div>
+        );
+      },
+    },
+  ];
+}

--- a/front/components/poke/subscriptions/table.tsx
+++ b/front/components/poke/subscriptions/table.tsx
@@ -1,0 +1,41 @@
+import type { SubscriptionType, WorkspaceType } from "@dust-tt/types";
+
+import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
+import { makeColumnsForSubscriptions } from "@app/components/poke/subscriptions/columns";
+
+interface SubscriptionsDataTableProps {
+  owner: WorkspaceType;
+  subscriptions: SubscriptionType[];
+}
+
+function prepareSubscriptionsForDisplay(
+  owner: WorkspaceType,
+  subscriptions: SubscriptionType[]
+) {
+  return subscriptions.map((s) => {
+    return {
+      sId: s.sId ?? "unknown",
+      planCode: s.plan.code,
+      status: s.status,
+      startDate: s.startDate
+        ? new Date(s.startDate).toLocaleDateString()
+        : null,
+      endDate: s.endDate ? new Date(s.endDate).toLocaleDateString() : null,
+    };
+  });
+}
+
+export function SubscriptionsDataTable({
+  owner,
+  subscriptions,
+}: SubscriptionsDataTableProps) {
+  return (
+    <div className="border-material-200 my-4 flex flex-col rounded-lg border p-4">
+      <h2 className="text-md mb-4 font-bold">Subscriptions:</h2>
+      <PokeDataTable
+        columns={makeColumnsForSubscriptions()}
+        data={prepareSubscriptionsForDisplay(owner, subscriptions)}
+      />
+    </div>
+  );
+}

--- a/front/pages/poke/[wId]/index.tsx
+++ b/front/pages/poke/[wId]/index.tsx
@@ -15,6 +15,7 @@ import type { WorkspaceType } from "@dust-tt/types";
 import type { PlanType, SubscriptionType } from "@dust-tt/types";
 import { DustProdActionRegistry, WHITELISTABLE_FEATURES } from "@dust-tt/types";
 import { JsonViewer } from "@textea/json-viewer";
+import { keyBy } from "lodash";
 import type { InferGetServerSidePropsType } from "next";
 import Link from "next/link";
 import { useRouter } from "next/router";
@@ -24,6 +25,7 @@ import { AssistantsDataTable } from "@app/components/poke/assistants/table";
 import { DataSourceDataTable } from "@app/components/poke/data_sources/table";
 import { FeatureFlagsDataTable } from "@app/components/poke/features/table";
 import PokeNavbar from "@app/components/poke/PokeNavbar";
+import { SubscriptionsDataTable } from "@app/components/poke/subscriptions/table";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
 import { getDataSources } from "@app/lib/api/data_sources";
@@ -34,47 +36,73 @@ import {
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { isDevelopment } from "@app/lib/development";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
+import { Plan, Subscription } from "@app/lib/models";
 import { FREE_NO_PLAN_CODE } from "@app/lib/plans/plan_codes";
+import { renderSubscriptionFromModels } from "@app/lib/plans/subscription";
 import { usePokePlans } from "@app/lib/swr";
 
 export const getServerSideProps = withSuperUserAuthRequirements<{
   owner: WorkspaceType;
-  subscription: SubscriptionType;
+  activeSubscription: SubscriptionType;
+  subscriptions: SubscriptionType[];
   dataSources: DataSourceType[];
   agentConfigurations: AgentConfigurationType[];
   whitelistableFeatures: WhitelistableFeature[];
   registry: typeof DustProdActionRegistry;
 }>(async (context, auth) => {
   const owner = auth.workspace();
-  const subscription = auth.subscription();
+  const activeSubscription = auth.subscription();
 
-  if (!owner || !subscription) {
+  if (!owner || !activeSubscription) {
     return {
       notFound: true,
     };
   }
 
   // TODO(2024-02-28 flav) Stop fetching agent configurations on the server side.
-  const [dataSources, agentConfigurations] = await Promise.all([
-    getDataSources(auth, { includeEditedBy: true }),
-    (async () => {
-      return (
-        await getAgentConfigurations({
-          auth,
-          agentsGetView: "admin_internal",
-          variant: "full",
-        })
-      ).filter(
-        (a) =>
-          !Object.values(GLOBAL_AGENTS_SID).includes(a.sId as GLOBAL_AGENTS_SID)
-      );
-    })(),
-  ]);
+  const [dataSources, agentConfigurations, subscriptionModels] =
+    await Promise.all([
+      getDataSources(auth, { includeEditedBy: true }),
+      (async () => {
+        return (
+          await getAgentConfigurations({
+            auth,
+            agentsGetView: "admin_internal",
+            variant: "full",
+          })
+        ).filter(
+          (a) =>
+            !Object.values(GLOBAL_AGENTS_SID).includes(
+              a.sId as GLOBAL_AGENTS_SID
+            )
+        );
+      })(),
+      Subscription.findAll({
+        where: { workspaceId: owner.id },
+      }),
+    ]);
+
+  const plans = keyBy(
+    await Plan.findAll({
+      where: {
+        id: subscriptionModels.map((s) => s.planId),
+      },
+    }),
+    "id"
+  );
+
+  const subscriptions = subscriptionModels.map((s) =>
+    renderSubscriptionFromModels({
+      plan: plans[s.planId],
+      activeSubscription: s,
+    })
+  );
 
   return {
     props: {
       owner,
-      subscription,
+      activeSubscription,
+      subscriptions,
       dataSources: orderDatasourceByImportance(dataSources),
       agentConfigurations: agentConfigurations,
       whitelistableFeatures:
@@ -86,12 +114,14 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
 
 const WorkspacePage = ({
   owner,
-  subscription,
+  activeSubscription,
+  subscriptions,
   dataSources,
   agentConfigurations,
   whitelistableFeatures,
   registry,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
+  console.log({ subscriptions });
   const router = useRouter();
 
   const sendNotification = useContext(SendNotificationsContext);
@@ -253,13 +283,13 @@ const WorkspacePage = ({
                 View dust app logs
               </a>
             </div>
-            {subscription.stripeSubscriptionId && (
+            {activeSubscription.stripeSubscriptionId && (
               <div>
                 <Link
                   href={
                     isDevelopment()
-                      ? `https://dashboard.stripe.com/test/subscriptions/${subscription.stripeSubscriptionId}`
-                      : `https://dashboard.stripe.com/subscriptions/${subscription.stripeSubscriptionId}`
+                      ? `https://dashboard.stripe.com/test/subscriptions/${activeSubscription.stripeSubscriptionId}`
+                      : `https://dashboard.stripe.com/subscriptions/${activeSubscription.stripeSubscriptionId}`
                   }
                   target="_blank"
                   className="text-xs text-action-400"
@@ -302,7 +332,7 @@ const WorkspacePage = ({
               </div>
 
               <h2 className="text-md mb-4 mt-8 font-bold">Plan:</h2>
-              <JsonViewer value={subscription} rootName={false} />
+              <JsonViewer value={activeSubscription} rootName={false} />
               <div className="flex flex-col gap-8">
                 {plans && (
                   <div className="pt-8">
@@ -319,7 +349,9 @@ const WorkspacePage = ({
                                     variant="secondary"
                                     label={`Upgrade to free plan: ${p.code}`}
                                     onClick={() => onUpgradeToPlan(p)}
-                                    disabled={subscription.plan.code === p.code}
+                                    disabled={
+                                      activeSubscription.plan.code === p.code
+                                    }
                                   />
                                 </div>
                               );
@@ -330,8 +362,10 @@ const WorkspacePage = ({
                               variant="secondaryWarning"
                               onClick={onDowngrade}
                               disabled={
-                                subscription.plan.code === FREE_NO_PLAN_CODE ||
-                                subscription.stripeSubscriptionId !== null ||
+                                activeSubscription.plan.code ===
+                                  FREE_NO_PLAN_CODE ||
+                                activeSubscription.stripeSubscriptionId !==
+                                  null ||
                                 workspaceHasManagedDataSources
                               }
                             />
@@ -352,7 +386,8 @@ const WorkspacePage = ({
                               Delete data sources before deleting the workspace.
                             </p>
                           )}
-                          {subscription.plan.code !== FREE_NO_PLAN_CODE && (
+                          {activeSubscription.plan.code !==
+                            FREE_NO_PLAN_CODE && (
                             <p className="text-warning mb-4 text-sm ">
                               Downgrade to free test plan before deleting the
                               workspace.
@@ -369,7 +404,8 @@ const WorkspacePage = ({
                               variant="secondaryWarning"
                               onClick={onDeleteWorkspace}
                               disabled={
-                                subscription.plan.code !== FREE_NO_PLAN_CODE ||
+                                activeSubscription.plan.code !==
+                                  FREE_NO_PLAN_CODE ||
                                 workspaceHasManagedDataSources
                               }
                             />
@@ -380,7 +416,7 @@ const WorkspacePage = ({
                   </Collapsible>
                 </div>
               </div>
-              {subscription.plan.code !== FREE_NO_PLAN_CODE &&
+              {activeSubscription.plan.code !== FREE_NO_PLAN_CODE &&
                 workspaceHasManagedDataSources && (
                   <div className="pl-2 pt-4">
                     <p className="text-warning mb-4 text-sm">
@@ -391,6 +427,10 @@ const WorkspacePage = ({
             </div>
 
             <div className="flex flex-col space-y-8 pt-4">
+              <SubscriptionsDataTable
+                owner={owner}
+                subscriptions={subscriptions}
+              />
               <FeatureFlagsDataTable
                 owner={owner}
                 whitelistableFeatures={whitelistableFeatures}

--- a/front/pages/poke/[wId]/index.tsx
+++ b/front/pages/poke/[wId]/index.tsx
@@ -121,7 +121,6 @@ const WorkspacePage = ({
   whitelistableFeatures,
   registry,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
-  console.log({ subscriptions });
   const router = useRouter();
 
   const sendNotification = useContext(SendNotificationsContext);


### PR DESCRIPTION
## Description

https://github.com/dust-tt/tasks/issues/572

<img width="1242" alt="Screenshot 2024-03-28 at 19 45 21" src="https://github.com/dust-tt/dust/assets/14199823/e54794ac-eeed-43cd-bfd8-e21da6aaebf2">



displays a list of all subscriptions on Poke. For now, the whole JSON of the active subscription is kept. We'll likely want to get rid of it or at least collapse it by default


## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
