### PR TITLE
Enforce Dust emails on Poke

### DIFF
--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -439,7 +439,14 @@ export class Authenticator {
   }
 
   isDustSuperUser(): boolean {
-    return this._user ? this._user.isDustSuperUser : false;
+    if (!this._user) {
+      return false;
+    }
+
+    const { email, isDustSuperUser = false } = this._user;
+    const isDustInternal = email.endsWith("@dust.tt");
+
+    return isDustInternal && isDustSuperUser;
   }
 }
 

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -52,6 +52,8 @@ const {
   ACTIVATE_ALL_FEATURES_DEV = false,
 } = process.env;
 
+const DUST_INTERNAL_EMAIL_REGEXP = /^[^@]+@dust\.tt$/;
+
 /**
  * This is a class that will be used to check if a user can perform an action on a resource.
  * It acts as a central place to enforce permissioning across all of Dust.
@@ -444,7 +446,7 @@ export class Authenticator {
     }
 
     const { email, isDustSuperUser = false } = this._user;
-    const isDustInternal = email.endsWith("@dust.tt");
+    const isDustInternal = DUST_INTERNAL_EMAIL_REGEXP.test(email);
 
     return isDustInternal && isDustSuperUser;
   }

--- a/front/middleware.ts
+++ b/front/middleware.ts
@@ -1,0 +1,58 @@
+import type { Claims } from "@auth0/nextjs-auth0/edge";
+import {
+  getSession,
+  withMiddlewareAuthRequired,
+} from "@auth0/nextjs-auth0/edge";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+
+/**
+ * Middleware currently only supports the Edge runtime. The Node.js runtime can not be used.
+ * This file should not have any dependencies.
+ */
+
+const DUST_INTERNAL_EMAIL_REGEXP = /^[^@]+@dust.tt$/;
+const { AUTH0_CLAIM_NAMESPACE } = process.env;
+
+function hasPokeAccessClaim(user: Claims) {
+  const pokeAccessClaim = `${AUTH0_CLAIM_NAMESPACE}authorization.has_poke_access`;
+
+  return user[pokeAccessClaim] || false;
+}
+
+/**
+ * Accessing Poke requires Authorization Claim and internal email address.
+ */
+async function handlePokeAuthRequirements(req: NextRequest, res: NextResponse) {
+  const session = await getSession(req, res);
+
+  if (session && session.user) {
+    const { email } = session.user;
+
+    if (
+      DUST_INTERNAL_EMAIL_REGEXP.test(email) &&
+      hasPokeAccessClaim(session.user)
+    ) {
+      return res;
+    }
+  }
+
+  // Redirect to the landing page.
+  return NextResponse.redirect(new URL("/", req.url));
+}
+
+export default withMiddlewareAuthRequired(async (req: NextRequest) => {
+  const res = NextResponse.next();
+
+  // Gate poke pages and API endpoints.
+  if (req.nextUrl.pathname.startsWith("/poke")) {
+    return handlePokeAuthRequirements(req, res);
+  }
+
+  return res;
+});
+
+export const config = {
+  // Run the middleware for all Poke pages / endpoints.
+  matcher: "/poke/:path*",
+};


### PR DESCRIPTION
## Description

This PR implements a stricter verification process, ensuring that only internal Dust email addresses can access Poke.
It also leverage our login provider to gate some pages only accessible if a Dust custom claim is set. 
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

This PR changes the security around Poke. Everyone will loose access to Poke until we backfill the claims. They will need to re-authenticate.
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

It requires to add the env variable: `AUTH0_CLAIM_NAMESPACE` in `front-secrets`.

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
