### PR TITLE
Add info to log 'Unexpected exception answering to Slack Chat Bot message'

### DIFF
--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -137,6 +137,8 @@ export async function botAnswerMessageWithErrorHandling(
     logger.error(
       {
         error: e,
+        connectorId: connector.id,
+        slackTeamId,
       },
       `Unexpected exception answering to Slack Chat Bot message`
     );


### PR DESCRIPTION
## Description

The log was not containing info to identify the workspace (had to navigate on Datadog traces)
https://github.com/dust-tt/tasks/issues/590

## Risk

/

## Deploy Plan

/
