### PR TITLE
feat(historicize memberships): data model + backfill script

### DIFF
--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -217,6 +217,7 @@ const workspace = async (command: string, args: parseArgs.ParsedArgs) => {
         role,
         workspaceId: w.id,
         userId: u.id,
+        startAt: new Date(),
       });
       return;
     }

--- a/front/lib/models/workspace.ts
+++ b/front/lib/models/workspace.ts
@@ -179,7 +179,11 @@ Membership.init(
   {
     modelName: "membership",
     sequelize: frontSequelize,
-    indexes: [{ fields: ["userId", "role"] }],
+    indexes: [
+      { fields: ["userId", "role"] },
+      { fields: ["startAt"] },
+      { fields: ["endAt"] },
+    ],
   }
 );
 User.hasMany(Membership, {

--- a/front/lib/models/workspace.ts
+++ b/front/lib/models/workspace.ts
@@ -1,4 +1,8 @@
-import type { RoleType, WorkspaceSegmentationType } from "@dust-tt/types";
+import type {
+  MembershipRoleType,
+  RoleType,
+  WorkspaceSegmentationType,
+} from "@dust-tt/types";
 import type {
   CreationOptional,
   ForeignKey,
@@ -135,7 +139,9 @@ export class Membership extends Model<
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
-  declare role: "admin" | "builder" | "user" | "revoked";
+  declare role: MembershipRoleType;
+  declare startAt: Date | null;
+  declare endAt: Date | null;
 
   declare userId: ForeignKey<User["id"]>;
   declare workspaceId: ForeignKey<Workspace["id"]>;
@@ -160,6 +166,14 @@ Membership.init(
     role: {
       type: DataTypes.STRING,
       allowNull: false,
+    },
+    startAt: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    },
+    endAt: {
+      type: DataTypes.DATE,
+      allowNull: true,
     },
   },
   {

--- a/front/migrations/20230413_workspaces_memberships.ts
+++ b/front/migrations/20230413_workspaces_memberships.ts
@@ -35,6 +35,7 @@ async function main() {
               role: "admin",
               userId: u.id,
               workspaceId: w.id,
+              startAt: new Date(),
             });
             console.log(`+ ${u.id}`);
           } else {

--- a/front/migrations/20240329_membership_start_end_date.ts
+++ b/front/migrations/20240329_membership_start_end_date.ts
@@ -1,0 +1,35 @@
+import { Op } from "sequelize";
+
+import { Message } from "@app/lib/models";
+import { ContentFragmentResource } from "@app/lib/resources/content_fragment_resource";
+import { frontSequelize } from "@app/lib/resources/storage";
+import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
+
+const { LIVE } = process.env;
+
+async function main() {
+  // For every membership object, we set a startAt equal to the `createdAt` field of the membership object.
+
+  await frontSequelize.query(`
+    UPDATE memberships
+    SET "startAt" = memberships."createdAt"
+    WHERE memberships."startAt" IS NULL;
+  `);
+
+  // For every "revoked" role membership object, we set an endAt equal to the `updatedAt` field of the membership object.
+  await frontSequelize.query(`
+    UPDATE memberships
+    SET "endAt" = memberships."updatedAt"
+    WHERE memberships."endAt" IS NULL AND memberships.role = 'revoked';
+  `);
+}
+
+main()
+  .then(() => {
+    console.log("Done");
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -410,6 +410,7 @@ export async function createAndLogMembership({
     role: role,
     userId: userId,
     workspaceId: workspace.id,
+    startAt: new Date(),
   });
   trackUserMemberships(m.userId).catch(logger.error);
 

--- a/front/pages/api/w/[wId]/members/[userId]/index.ts
+++ b/front/pages/api/w/[wId]/members/[userId]/index.ts
@@ -95,6 +95,7 @@ async function handler(
 
       await membership.update({
         role: req.body.role,
+        endAt: req.body.role === "revoked" ? new Date() : null,
       });
       if (req.body.role === "revoked") {
         await updateWorkspacePerSeatSubscriptionUsage({

--- a/types/src/front/memberships.ts
+++ b/types/src/front/memberships.ts
@@ -1,0 +1,1 @@
+export type MembershipRoleType = "admin" | "builder" | "user" | "revoked";

--- a/types/src/index.ts
+++ b/types/src/index.ts
@@ -46,6 +46,7 @@ export * from "./front/lib/dust_api";
 export * from "./front/lib/error";
 export * from "./front/lib/extract_event_app";
 export * from "./front/membership_invitation";
+export * from "./front/memberships";
 export * from "./front/plan";
 export * from "./front/project";
 export * from "./front/provider";


### PR DESCRIPTION
## Description

https://github.com/dust-tt/tasks/issues/548

This is step 1/n: I am adding the new columns, making sure they are filled-in from business logic when creating new memberships or revoking them, and adding a migration script to backfill the values on old objects.

Next step: start relying on `endDate` instead of `role="revoked"`, remove "revoked" role from DB (will assume "revoked" people were users)

## Risk

Not much here, besides the schema migration (functionally everything is the same)

## Deploy Plan

- deploy prodbox, migrate schema (initdb)
- deploy `front`
- execute migration script