### PR TITLE
aric-gdrive_2_activities_per_worker

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/worker.ts
+++ b/connectors/src/connectors/google_drive/temporal/worker.ts
@@ -16,7 +16,7 @@ export async function runGoogleWorker() {
     workflowsPath: require.resolve("./workflows"),
     activities: { ...activities, ...sync_status },
     taskQueue: QUEUE_NAME,
-    maxConcurrentActivityTaskExecutions: 4,
+    maxConcurrentActivityTaskExecutions: 1,
     connection,
     reuseV8Context: true,
     namespace,


### PR DESCRIPTION
## Description

Moving Gdrive worker to 1 per pod, in order to lower the concurrency level issue we are currently facing.

Context:
We triggered a Gdrive garbage collect workflow for all Gdrive connectors, leading to a global  Gdrive rate limit issue.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
