### PR TITLE
[Sparkle] Add className to Modal

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.130",
+  "version": "0.2.131",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.130",
+      "version": "0.2.131",
       "license": "ISC",
       "dependencies": {
         "@headlessui/react": "^1.7.17",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.130",
+  "version": "0.2.131",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/components/Modal.tsx
+++ b/sparkle/src/components/Modal.tsx
@@ -72,6 +72,7 @@ export type ModalProps = {
   savingLabel?: string;
   title?: string;
   variant?: "full-screen" | "side-sm" | "side-md" | "dialogue";
+  className?: string;
 };
 
 const getModalClasses = (type: ModalType) => modalStyles[type] || {};
@@ -88,6 +89,7 @@ export function Modal({
   savingLabel,
   title,
   variant = "side-sm",
+  className,
 }: ModalProps) {
   const type = variantToType[variant];
 
@@ -165,7 +167,11 @@ export function Modal({
                 rightActions={<BarHeader.ButtonBar {...buttonBarProps} />}
               />
               <div
-                className={classNames("s-pb-6 s-pt-16", innerContainerClasses)}
+                className={classNames(
+                  "s-pb-6 s-pt-16",
+                  innerContainerClasses,
+                  className ?? ""
+                )}
               >
                 {children}
               </div>


### PR DESCRIPTION
## Description

We sometimes need to apply classes to the modal innercontainer that allows children to behave properly, e.g. `flex` to push an element to bottom with padding-awareness
