### PR TITLE
[Websites] Allow naming a website

### DIFF
--- a/front/components/data_source/WebsiteConfiguration.tsx
+++ b/front/components/data_source/WebsiteConfiguration.tsx
@@ -31,6 +31,7 @@ import { useSWRConfig } from "swr";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleSaveCancelTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { subNavigationBuild } from "@app/components/sparkle/navigation";
+import { isUrlValid, urlToDataSourceName } from "@app/lib/webcrawler";
 import type { PostManagedDataSourceRequestBodySchema } from "@app/pages/api/w/[wId]/data_sources/managed";
 
 export default function WebsiteConfiguration({
@@ -90,23 +91,21 @@ export default function WebsiteConfiguration({
     5: "5 levels",
   };
 
-  const formValidation = useCallback(() => {
-    let urlIsValid = true;
-    try {
-      if (dataSourceUrl.trim().length > 0) {
-        new URL(dataSourceUrl);
-      }
-      setDataSourceUrlError("");
-    } catch (e) {
-      urlIsValid = false;
-    }
+  useEffect(() => {
+    setDataSourceName(urlToDataSourceName(dataSourceUrl));
+  }, [dataSourceUrl]);
 
+  const formValidation = useCallback(() => {
     let valid = true;
 
-    if (!urlIsValid) {
-      setDataSourceUrlError(
-        "Please provide a valid URL (e.g. https://example.com or https://example.com/a/b/c))"
-      );
+    if (isUrlValid(dataSourceUrl)) {
+      setDataSourceUrlError("");
+    } else {
+      if (dataSourceUrl.length > 0) {
+        setDataSourceUrlError(
+          "Please provide a valid URL (e.g. https://example.com or https://example.com/a/b/c))"
+        );
+      }
       valid = false;
     }
 
@@ -249,20 +248,6 @@ export default function WebsiteConfiguration({
     >
       <div className="py-8">
         <Page.Layout direction="vertical" gap="xl">
-          <Page.Layout direction="vertical" gap="md">
-            <Page.H variant="h3">Data Source Name</Page.H>
-            <Page.P>Give a name to this Data Source</Page.P>
-            <Input
-              placeholder=""
-              value={dataSourceName}
-              onChange={(value) => setDataSourceName(value)}
-              error={dataSourceNameError}
-              name="dataSourceName"
-              showErrorLabel={true}
-              className="text-sm"
-              disabled={webCrawlerConfiguration !== null}
-            />
-          </Page.Layout>
           <Page.Layout direction="vertical" gap="md">
             <Page.H variant="h3">Website Entry Point</Page.H>
             <Page.P>
@@ -408,6 +393,20 @@ export default function WebsiteConfiguration({
               />
             </Page.Layout>
           </div>
+          <Page.Layout direction="vertical" gap="md">
+            <Page.H variant="h3">Name</Page.H>
+            <Page.P>Give a name to this Data Source.</Page.P>
+            <Input
+              placeholder=""
+              value={dataSourceName}
+              onChange={(value) => setDataSourceName(value)}
+              error={dataSourceNameError}
+              name="dataSourceName"
+              showErrorLabel={true}
+              className="text-sm"
+              disabled={webCrawlerConfiguration !== null}
+            />
+          </Page.Layout>
           {webCrawlerConfiguration && (
             <div className="flex">
               <DropdownMenu>

--- a/front/components/data_source/WebsiteConfiguration.tsx
+++ b/front/components/data_source/WebsiteConfiguration.tsx
@@ -260,6 +260,7 @@ export default function WebsiteConfiguration({
               name="dataSourceName"
               showErrorLabel={true}
               className="text-sm"
+              disabled={webCrawlerConfiguration !== null}
             />
           </Page.Layout>
           <Page.Layout direction="vertical" gap="md">

--- a/front/lib/webcrawler.ts
+++ b/front/lib/webcrawler.ts
@@ -1,8 +1,0 @@
-export function urlToDataSourceName(url: string) {
-  return url
-    .trim()
-    .replace(/https?:\/\//, "")
-    .replace(/\/$/, "")
-    .replace(/\//g, "-")
-    .replace(/\?/g, "-");
-}

--- a/front/lib/webcrawler.ts
+++ b/front/lib/webcrawler.ts
@@ -1,0 +1,43 @@
+export function urlToDataSourceName(url: string) {
+  function sanitizeString(inputString: string): string {
+    // Regular expression to match characters that are NOT letters, numbers, '.', '_', or '-'
+    // ^ outside of character set negates the set, matching anything not in the set
+    const regex = /[^a-zA-Z0-9._-]/g;
+
+    // Replace characters that match the regex with '-'
+    const sanitizedString = inputString.replace(regex, "_");
+
+    return sanitizedString;
+  }
+
+  let name = "";
+  try {
+    const parsed = new URL(url);
+    if (parsed.pathname === "/") {
+      // no path after the hostname
+      name += parsed.hostname;
+    } else {
+      // We have a path after the hostname
+      name +=
+        parsed.hostname +
+        decodeURIComponent(parsed.pathname).replaceAll("/", "-");
+    }
+    name = name.substring(0, 60);
+    return sanitizeString(name);
+  } catch (e) {
+    // We failed to parse the URL, we are going to return an empty string
+    return "";
+  }
+}
+
+export function isUrlValid(url: string) {
+  try {
+    if (url.trim().length === 0) {
+      return false;
+    }
+    new URL(url);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}

--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -26,7 +26,6 @@ import {
 } from "@app/lib/auth";
 import { DataSource } from "@app/lib/models";
 import { isDisposableEmailDomain } from "@app/lib/utils/disposable_email_domains";
-import { urlToDataSourceName } from "@app/lib/webcrawler";
 import logger from "@app/logger/logger";
 import { apiError, withLogging } from "@app/logger/withlogging";
 
@@ -36,6 +35,7 @@ export const PostManagedDataSourceRequestBodySchema = t.type({
   provider: t.string,
   connectionId: t.union([t.string, t.undefined]),
   type: t.union([t.literal("oauth"), t.literal("url")]),
+  name: t.string,
   urlConfig: t.union([CreateConnectorUrlRequestBodySchema, t.undefined]),
 });
 
@@ -92,7 +92,8 @@ async function handler(
         });
       }
 
-      const { type, connectionId, urlConfig, provider } = bodyValidation.right;
+      const { type, connectionId, urlConfig, provider, name } =
+        bodyValidation.right;
 
       if (!isConnectorProvider(provider)) {
         return apiError(req, res, {
@@ -186,7 +187,7 @@ async function handler(
             });
           }
 
-          dataSourceName = urlToDataSourceName(urlConfig.url);
+          dataSourceName = name;
           if (!dataSourceName.length) {
             return apiError(req, res, {
               status_code: 400,

--- a/front/pages/w/[wId]/builder/data-sources/new.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/new.tsx
@@ -1,7 +1,8 @@
 import { Page } from "@dust-tt/sparkle";
-import type { DataSourceType, WorkspaceType } from "@dust-tt/types";
 import type { SubscriptionType } from "@dust-tt/types";
 import type { APIError } from "@dust-tt/types";
+import type { DataSourceType, WorkspaceType } from "@dust-tt/types";
+import { isDataSourceNameValid } from "@dust-tt/types";
 import { ChevronRightIcon } from "@heroicons/react/20/solid";
 import type { InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
@@ -67,23 +68,12 @@ export default function DataSourceNew({
         exists = true;
       }
     });
+    const nameValidRes = isDataSourceNameValid(dataSourceName);
     if (exists) {
       setDataSourceNameError("A Folder with the same name already exists");
       valid = false;
-    } else if (dataSourceName.length == 0) {
-      valid = false;
-      setDataSourceNameError("");
-    } else if (dataSourceName.startsWith("managed-")) {
-      setDataSourceNameError(
-        "DataSource name cannot start with the prefix `managed-`"
-      );
-      valid = false;
-      // eslint-disable-next-line no-useless-escape
-    } else if (!dataSourceName.match(/^[a-zA-Z0-9\._\-]+$/)) {
-      setDataSourceNameError(
-        "DataSource name must only contain letters, numbers, and the characters `._-`"
-      );
-      valid = false;
+    } else if (nameValidRes.isErr()) {
+      setDataSourceNameError(nameValidRes.error);
     } else {
       edited = true;
       setDataSourceNameError("");

--- a/types/src/front/data_source.ts
+++ b/types/src/front/data_source.ts
@@ -1,4 +1,5 @@
 import { ModelId } from "../shared/model_id";
+import { Err, Ok, Result } from "../shared/result";
 
 export const CONNECTOR_PROVIDERS = [
   "confluence",
@@ -47,3 +48,21 @@ export type DataSourceType = {
   connectorProvider: ConnectorProvider | null;
   editedByUser?: EditedByUser | null;
 };
+
+export function isDataSourceNameValid(name: string): Result<void, string> {
+  const trimmed = name.trim();
+  if (trimmed.length === 0) {
+    return new Err("");
+  }
+  if (name.startsWith("managed-")) {
+    return new Err("DataSource name cannot start with the prefix `managed-`");
+  }
+  // eslint-disable-next-line no-useless-escape
+  if (!name.match(/^[a-zA-Z0-9\._\-]+$/)) {
+    return new Err(
+      "DataSource name must only contain letters, numbers, and the characters `._-`"
+    );
+  }
+
+  return new Ok(undefined);
+}


### PR DESCRIPTION
## Description

- Websites do not allow to specify a Data Source name, leading to a bad user experience.
- Data Source names are generated from URL, leading to very long names, which breaks the UI.
- The Data Source name is used in the server route to edit / delete it, leading to some error when the Data Source name was not properly encoded using `encodeURIComponent()`.

So this PR allows for setting a data source name for a website, and properly encode the data source url when calling DELETE /data_source.



<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
