### PR TITLE
Google drive maxConcurrentActivityTaskExecutions to 2

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/worker.ts
+++ b/connectors/src/connectors/google_drive/temporal/worker.ts
@@ -16,7 +16,7 @@ export async function runGoogleWorker() {
     workflowsPath: require.resolve("./workflows"),
     activities: { ...activities, ...sync_status },
     taskQueue: QUEUE_NAME,
-    maxConcurrentActivityTaskExecutions: 1,
+    maxConcurrentActivityTaskExecutions: 2,
     connection,
     reuseV8Context: true,
     namespace,


### PR DESCRIPTION
## Description

Context: https://github.com/dust-tt/dust/pull/4522

https://cloud.temporal.io/namespaces/dust-prod.gmnlm/workflows?query=WorkflowType%3D%22googleDriveGarbageCollectorWorkflow%22+AND+ExecutionStatus%3D%22Running%22
Now on the queue we are starting to get new workflows (not the one started at 11:52).

I'd like to try 2 workers to decrease the queue, before reverting to 4.


## Risk

Hitting the limit but we would still be twice as less workers as the usual config. 

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
