### PR TITLE
Google drive maxConcurrentActivityTaskExecutions back to 4

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/worker.ts
+++ b/connectors/src/connectors/google_drive/temporal/worker.ts
@@ -16,7 +16,7 @@ export async function runGoogleWorker() {
     workflowsPath: require.resolve("./workflows"),
     activities: { ...activities, ...sync_status },
     taskQueue: QUEUE_NAME,
-    maxConcurrentActivityTaskExecutions: 2,
+    maxConcurrentActivityTaskExecutions: 4,
     connection,
     reuseV8Context: true,
     namespace,


### PR DESCRIPTION
## Description

Context: https://github.com/dust-tt/dust/pull/4529
Setting it back to 4 where it was before we ran the start all garbage collect. 

We're currently at 16 running and out of working hours I expect less incrementalSync so I think we could put it back https://cloud.temporal.io/namespaces/dust-prod.gmnlm/workflows?query=WorkflowType%3D%22googleDriveGarbageCollectorWorkflow%22+AND+ExecutionStatus%3D%22Running%22

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
