### PR TITLE
Refacto Assistant Data Source selection: folders & website under a parent

### DIFF
--- a/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
+++ b/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
@@ -1,6 +1,8 @@
 import {
+  Checkbox,
   CloudArrowDownIcon,
   CloudArrowLeftRightIcon,
+  FolderIcon,
   Item,
   Modal,
   Page,
@@ -66,6 +68,28 @@ export default function AssistantBuilderDataSourceModal({
   const [selectedResources, setSelectedResources] = useState<ContentNode[]>([]);
   const [isSelectAll, setIsSelectAll] = useState(false);
 
+  // Hack to filter out Folders from the list of data sources
+  const [shouldDisplayFoldersScreen, setShouldDisplayFoldersScreen] =
+    useState(false);
+  const allFolders = dataSources.filter((ds) => !ds.connectorProvider);
+  const selectedFolders = Object.values(dataSourceConfigurations)
+    .map((config) => {
+      return config.dataSource;
+    })
+    .filter((ds) => !ds.connectorProvider);
+
+  // Hack to filter out Websites from the list of data sources
+  const [shouldDisplayWebsitesScreen, setShouldDisplayWebsitesScreen] =
+    useState(false);
+  const allWebsites = dataSources.filter(
+    (ds) => ds.connectorProvider === "webcrawler"
+  );
+  const selectedWebsites = Object.values(dataSourceConfigurations)
+    .map((config) => {
+      return config.dataSource;
+    })
+    .filter((ds) => ds.connectorProvider === "webcrawler");
+
   const onReset = () => {
     setSelectedDataSource(null);
     setSelectedResources([]);
@@ -75,14 +99,23 @@ export default function AssistantBuilderDataSourceModal({
   const onClose = () => {
     setOpen(false);
     setTimeout(() => {
+      setShouldDisplayFoldersScreen(false);
+      setShouldDisplayWebsitesScreen(false);
       onReset();
     }, 200);
   };
 
   const onSaveLocal = ({ isSelectAll }: { isSelectAll: boolean }) => {
+    if (shouldDisplayFoldersScreen || shouldDisplayWebsitesScreen) {
+      // We can just close the modal since the folders & websites are instantly saved
+      onClose();
+      return;
+    }
+
     if (!selectedDataSource) {
       throw new Error("Cannot save an incomplete configuration");
     }
+
     if (selectedResources.length || isSelectAll) {
       onSave({
         dataSource: selectedDataSource,
@@ -101,34 +134,62 @@ export default function AssistantBuilderDataSourceModal({
       isOpen={isOpen}
       onClose={selectedDataSource !== null ? onReset : onClose}
       onSave={() => onSaveLocal({ isSelectAll })}
-      hasChanged={selectedDataSource !== null}
+      hasChanged={
+        selectedDataSource !== null ||
+        shouldDisplayFoldersScreen ||
+        shouldDisplayWebsitesScreen
+      }
       variant="full-screen"
       title="Manage data sources selection"
     >
       <div className="w-full pt-12">
-        {!selectedDataSource || !selectedDataSource.connectorProvider ? (
-          <PickDataSource
-            dataSources={dataSources}
-            show={!selectedDataSource}
-            onPick={(ds) => {
-              setSelectedDataSource(ds);
-              setSelectedResources(
-                dataSourceConfigurations[ds.name]?.selectedResources || []
-              );
-              setIsSelectAll(
-                dataSourceConfigurations[ds.name]?.isSelectAll || false
-              );
-              if (!ds.connectorProvider) {
-                onSave({
-                  dataSource: ds,
-                  selectedResources: [],
-                  isSelectAll: true,
-                });
-                onClose();
-              }
-            }}
+        {!selectedDataSource &&
+          !shouldDisplayFoldersScreen &&
+          !shouldDisplayWebsitesScreen && (
+            <PickDataSource
+              dataSources={dataSources}
+              show={!selectedDataSource}
+              onPick={(ds) => {
+                setSelectedDataSource(ds);
+                setSelectedResources(
+                  dataSourceConfigurations[ds.name]?.selectedResources || []
+                );
+                setIsSelectAll(
+                  dataSourceConfigurations[ds.name]?.isSelectAll || false
+                );
+              }}
+              onPickFolders={() => {
+                setShouldDisplayFoldersScreen(true);
+              }}
+              onPickWebsites={() => {
+                setShouldDisplayWebsitesScreen(true);
+              }}
+            />
+          )}
+
+        {!selectedDataSource && shouldDisplayFoldersScreen && (
+          <FolderOrWebsiteResourceSelector
+            owner={owner}
+            type="folder"
+            dataSources={allFolders}
+            selectedDataSources={selectedFolders}
+            onSave={onSave}
+            onDelete={onDelete}
           />
-        ) : (
+        )}
+
+        {!selectedDataSource && shouldDisplayWebsitesScreen && (
+          <FolderOrWebsiteResourceSelector
+            type="website"
+            owner={owner}
+            dataSources={allWebsites}
+            selectedDataSources={selectedWebsites}
+            onSave={onSave}
+            onDelete={onDelete}
+          />
+        )}
+
+        {selectedDataSource && (
           <DataSourceResourceSelector
             dataSource={selectedDataSource}
             owner={owner}
@@ -171,16 +232,33 @@ function PickDataSource({
   dataSources,
   show,
   onPick,
+  onPickFolders,
+  onPickWebsites,
 }: {
   dataSources: DataSourceType[];
   show: boolean;
   onPick: (dataSource: DataSourceType) => void;
+  onPickFolders: () => void;
+  onPickWebsites: () => void;
 }) {
   const [query, setQuery] = useState<string>("");
 
-  const filtered = dataSources.filter((ds) => {
+  const filteredDataSources = dataSources.filter((ds) => {
     return subFilter(query.toLowerCase(), ds.name.toLowerCase());
   });
+
+  const filteredManagedDataSourxes = filteredDataSources.filter(
+    (ds) => ds.connectorProvider && ds.connectorProvider !== "webcrawler"
+  );
+
+  // We want to display the folders & websites as a single parent entry
+  // so we take them out of the list of data sources
+  const shouldDisplayFolderEntry = filteredDataSources.some(
+    (ds) => !ds.connectorProvider
+  );
+  const shouldDisplayWebsiteEntry = filteredDataSources.some(
+    (ds) => ds.connectorProvider === "webcrawler"
+  );
 
   return (
     <Transition show={show} className="mx-auto max-w-6xl">
@@ -195,7 +273,7 @@ function PickDataSource({
           value={query}
           placeholder="Search..."
         />
-        {orderDatasourceByImportance(filtered).map((ds) => (
+        {orderDatasourceByImportance(filteredManagedDataSourxes).map((ds) => (
           <Item.Navigation
             label={getDisplayNameForDataSource(ds)}
             icon={
@@ -209,6 +287,20 @@ function PickDataSource({
             }}
           />
         ))}
+        {shouldDisplayFolderEntry && (
+          <Item.Navigation
+            label="Folders"
+            icon={FolderIcon}
+            onClick={onPickFolders}
+          />
+        )}
+        {shouldDisplayWebsiteEntry && (
+          <Item.Navigation
+            label="Websites"
+            icon={CloudArrowDownIcon}
+            onClick={onPickWebsites}
+          />
+        )}
       </Page>
     </Transition>
   );
@@ -352,6 +444,88 @@ function DataSourceResourceSelector({
             </div>
           </div>
         )}
+      </Page>
+    </Transition>
+  );
+}
+
+function FolderOrWebsiteResourceSelector({
+  owner,
+  type,
+  dataSources,
+  selectedDataSources,
+  onSave,
+  onDelete,
+}: {
+  owner: WorkspaceType;
+  type: "folder" | "website";
+  dataSources: DataSourceType[];
+  selectedDataSources: DataSourceType[];
+  onSave: (params: AssistantBuilderDataSourceConfiguration) => void;
+  onDelete: (name: string) => void;
+}) {
+  return (
+    <Transition show={!!owner} className="mx-auto max-w-6xl pb-8">
+      <Page>
+        <Page.Header
+          title={type === "folder" ? "Select Folders" : "Select Websites"}
+          icon={type === "folder" ? FolderIcon : CloudArrowDownIcon}
+          description={`Select the ${
+            type === "folder" ? "folders" : "websites"
+          } that will be used by the assistant as a source for its answers.`}
+        />
+        <div className="flex flex-row gap-32">
+          <div className="flex-1">
+            <div className="flex flex-row pb-4 text-lg font-semibold text-element-900">
+              <div>Select from available folders:</div>
+            </div>
+          </div>
+        </div>
+        <div>
+          {dataSources.map((ds) => {
+            const isSelected = selectedDataSources.some(
+              (selectedDs) => selectedDs.name === ds.name
+            );
+            return (
+              <div key={ds.name}>
+                <div className="flex flex-row items-center rounded-md p-1 text-sm transition duration-200 hover:bg-structure-100">
+                  <div>
+                    {type === "folder" ? (
+                      <FolderIcon className="h-5 w-5 text-slate-300" />
+                    ) : (
+                      <CloudArrowDownIcon className="h-5 w-5 text-slate-300" />
+                    )}
+                  </div>
+                  <span className="ml-2 line-clamp-1 text-sm font-medium text-element-900">
+                    {ds.name}
+                  </span>
+                  <div className="ml-32 flex-grow">
+                    <Checkbox
+                      variant="checkable"
+                      className="ml-auto"
+                      checked={isSelected}
+                      partialChecked={false}
+                      onChange={(checked) => {
+                        const isSelected = selectedDataSources.some(
+                          (selectedDs) => selectedDs.name === ds.name
+                        );
+                        if (checked && !isSelected) {
+                          onSave({
+                            dataSource: ds,
+                            selectedResources: [],
+                            isSelectAll: true,
+                          });
+                        } else if (!checked && isSelected) {
+                          onDelete(ds.name);
+                        }
+                      }}
+                    />
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
       </Page>
     </Transition>
   );


### PR DESCRIPTION
## Description

Today there are several issues on our Assistant Data Sources selection modal: 
- If you have a lot of folders or websites the modal is not super easy to use.
- There is no way to unselect a folder. 
- We allow on the UX to select a subpage of a website while in reality we select the full website resulting in a weird UX bug.

After a [Slack thread](https://dust4ai.slack.com/archives/C050A0S2Z7F/p1711709171687149) with Ed he shared the Figma showing that for websites and folders it should be one Folder entry grouping all Folders & then a list of checkboxes.: https://www.figma.com/file/QOxHwppG64GtPocpDhS6Y7/Product?type=design&node-id=4225-28162&mode=design&t=arGAa9c9HJkzH1IH-0

<kbd>
<img width="1001" alt="Screenshot 2024-03-30 at 02 32 14" src="https://github.com/dust-tt/dust/assets/3803406/ef6eb58c-4a05-443d-9668-74fc47d1090c">
</kbd>

If I click on Folders: 
<kbd>
<img width="971" alt="Screenshot 2024-03-30 at 02 33 38" src="https://github.com/dust-tt/dust/assets/3803406/9c909d2c-560e-4369-887f-8b8e5ce854a0">
</kbd>

If I click on Websites: 
<kbd>
<img width="972" alt="Screenshot 2024-03-30 at 02 33 59" src="https://github.com/dust-tt/dust/assets/3803406/e156fb27-16a2-431d-ab8f-372d7dab2cf9">
</kbd>

PR is deployed on Front Edge 🙇🏻‍♀️ 


It's not perfect because there's no search bar on the subscreens websites & folders but I think it's better than the bugs and we can add a search bar later if we get some user requests.

## Risk

/

## Deploy Plan

/
