### PR TITLE
notion: bump timeout from 60s to 120s for search

### DIFF
--- a/connectors/src/connectors/notion/lib/notion_api.ts
+++ b/connectors/src/connectors/notion/lib/notion_api.ts
@@ -92,6 +92,9 @@ export async function getPagesAndDatabasesEditedSince(
   const notionClient = new Client({
     auth: notionAccessToken,
     logger: notionClientLogger,
+    // Default is 60_000: https://github.com/makenotion/notion-sdk-js/blob/main/src/Client.ts#L135
+    // Bumped as we observed some timeouts with the default value.
+    timeoutMs: 120_000,
   });
   const editedPages: Record<string, number> = {};
   const editedDbs: Record<string, number> = {};


### PR DESCRIPTION
## Description

Context: https://dust4ai.slack.com/archives/C05F84CFP0E/p1711771070995149
We're observing timeouts in production on search which are handled client-side (60s):
https://github.com/makenotion/notion-sdk-js/blob/main/src/Client.ts#L206-L213

Attempting to bump to 120s

## Risk

N/A

## Deploy Plan

- deploy `connectors`