### PR TITLE
Sparkle Fix Textarea auto scroll when text is very long

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.131",
+  "version": "0.2.132",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.131",
+      "version": "0.2.132",
       "license": "ISC",
       "dependencies": {
         "@headlessui/react": "^1.7.17",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.131",
+  "version": "0.2.132",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/components/TextArea.tsx
+++ b/sparkle/src/components/TextArea.tsx
@@ -43,6 +43,15 @@ export function TextArea({
         placeholder={placeholder}
         value={value ?? ""}
         onChange={(e) => {
+          const newValue = e.target.value;
+          const textAreaComponent = textareaRef.current;
+          if (
+            textAreaComponent &&
+            value?.length &&
+            newValue.length < value.length
+          ) {
+            textAreaComponent.style.height = "auto"; // Reset height to recalculate
+          }
           onChange(e.target.value);
         }}
       />

--- a/sparkle/src/components/TextArea.tsx
+++ b/sparkle/src/components/TextArea.tsx
@@ -24,7 +24,6 @@ export function TextArea({
   useEffect(() => {
     const textarea = textareaRef.current;
     if (textarea) {
-      textarea.style.height = "auto"; // Reset height to recalculate
       textarea.style.height = `${textarea.scrollHeight}px`; // Set to scroll height
     }
   }, [value]); // Re-run when value changes
@@ -33,7 +32,7 @@ export function TextArea({
       <textarea
         ref={textareaRef}
         className={classNames(
-          "s-min-h-60 overflow-y-auto s-block s-w-full s-min-w-0 s-rounded-xl s-text-sm s-transition-all s-duration-200 s-scrollbar-hide",
+          "overflow-y-auto s-block s-min-h-60 s-w-full s-min-w-0 s-rounded-xl s-text-sm s-transition-all s-duration-200 s-scrollbar-hide",
           !error
             ? "s-border-structure-100 focus:s-border-action-300 focus:s-ring-action-300"
             : "s-border-red-500 focus:s-border-red-500 focus:s-ring-red-500",


### PR DESCRIPTION
## Description

Eng runner card: https://github.com/dust-tt/tasks/issues/593

This fixes an auto-scroll weird behavior when text is very long on a text area. 


## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
