### PR TITLE
Amplitude: track Data Source updated

### DIFF
--- a/front/lib/amplitude/node/generated/index.ts
+++ b/front/lib/amplitude/node/generated/index.ts
@@ -94,7 +94,15 @@ export interface AssistantCreatedProperties {
 export interface DataSourceCreatedProperties {
   assistantDefaultSelected: boolean;
   dataSourceName: string;
-  dataSourceProvider: string;
+  dataSourceProvider?: string;
+  workspaceId: string;
+  workspaceName: string;
+}
+
+export interface DataSourceUpdatedProperties {
+  assistantDefaultSelected: boolean;
+  dataSourceName: string;
+  dataSourceProvider?: string;
   workspaceId: string;
   workspaceName: string;
 }
@@ -164,6 +172,14 @@ export class DataSourceCreated implements BaseEvent {
   event_type = "DataSourceCreated";
 
   constructor(public event_properties: DataSourceCreatedProperties) {
+    this.event_properties = event_properties;
+  }
+}
+
+export class DataSourceUpdated implements BaseEvent {
+  event_type = "DataSourceUpdated";
+
+  constructor(public event_properties: DataSourceUpdatedProperties) {
     this.event_properties = event_properties;
   }
 }
@@ -349,6 +365,25 @@ export class Ampli {
     options?: EventOptions,
   ) {
     return this.track(userId, new DataSourceCreated(properties), options);
+  }
+
+  /**
+   * DataSourceUpdated
+   *
+   * [View in Tracking Plan](https://data.amplitude.com/dust-tt/dust-prod/events/main/latest/DataSourceUpdated)
+   *
+   * Event has no description in tracking plan.
+   *
+   * @param userId The user's ID.
+   * @param properties The event's properties (e.g. assistantDefaultSelected)
+   * @param options Amplitude event options.
+   */
+  dataSourceUpdated(
+    userId: string | undefined,
+    properties: DataSourceUpdatedProperties,
+    options?: EventOptions,
+  ) {
+    return this.track(userId, new DataSourceUpdated(properties), options);
   }
 
   /**

--- a/front/lib/amplitude/node/index.ts
+++ b/front/lib/amplitude/node/index.ts
@@ -213,7 +213,6 @@ export function trackDataSourceUpdated(
     { ...event, groups: { [GROUP_TYPE]: workspace.sId } },
     {
       time: Date.now(),
-      insert_id: `data_source_updated_${dataSource.id}_${Date.now()}`,
     }
   );
 }

--- a/front/lib/amplitude/node/index.ts
+++ b/front/lib/amplitude/node/index.ts
@@ -213,7 +213,7 @@ export function trackDataSourceUpdated(
     { ...event, groups: { [GROUP_TYPE]: workspace.sId } },
     {
       time: Date.now(),
-      insert_id: `data_source_updated_${dataSource.id}`,
+      insert_id: `data_source_updated_${dataSource.id}_${Date.now()}`,
     }
   );
 }

--- a/front/lib/amplitude/node/index.ts
+++ b/front/lib/amplitude/node/index.ts
@@ -19,6 +19,7 @@ import {
   ampli,
   AssistantCreated,
   DataSourceCreated,
+  DataSourceUpdated,
   UserMessagePosted,
 } from "@app/lib/amplitude/node/generated";
 import { isGlobalAgentId } from "@app/lib/api/assistant/global_agents";
@@ -181,6 +182,38 @@ export function trackDataSourceCreated(
     {
       time: dataSource.createdAt,
       insert_id: `data_source_created_${dataSource.id}`,
+    }
+  );
+}
+
+export function trackDataSourceUpdated(
+  auth: Authenticator,
+  {
+    dataSource,
+  }: {
+    dataSource: DataSourceType;
+  }
+) {
+  const userId = auth.user()?.id;
+  const workspace = auth.workspace();
+  if (!workspace || !userId) {
+    return;
+  }
+  const amplitude = getBackendClient();
+  const event = new DataSourceUpdated({
+    dataSourceName: dataSource.name,
+    dataSourceProvider: dataSource.connectorProvider || "",
+    workspaceName: workspace.name,
+    workspaceId: workspace.sId,
+    assistantDefaultSelected: dataSource.assistantDefaultSelected,
+  });
+
+  amplitude.track(
+    `user-${userId}`,
+    { ...event, groups: { [GROUP_TYPE]: workspace.sId } },
+    {
+      time: Date.now(),
+      insert_id: `data_source_updated_${dataSource.id}`,
     }
   );
 }

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/update.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/update.ts
@@ -8,6 +8,7 @@ import { isLeft } from "fp-ts/lib/Either";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import { trackDataSourceUpdated } from "@app/lib/amplitude/node";
 import {
   getDataSource,
   updateDataSourceEditedBy,
@@ -130,6 +131,7 @@ async function handler(
       }
 
       await updateDataSourceEditedBy(auth, dataSource);
+      trackDataSourceUpdated(auth, { dataSource });
 
       res.status(200).json(updateRes.value);
       return;


### PR DESCRIPTION
## Description

Adds a new DataSource updated event to Amplitude.
Context: https://github.com/dust-tt/tasks/issues/583

Event created from Amplitude and following the documentation on our Dev local runbook 🙏🏻 

## Risk

/

## Deploy Plan

/
