### PR TITLE
Slack: Add logs to understand why some Slack thread in datasource documents have no sourceUrl

### DIFF
--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -445,6 +445,17 @@ export async function syncNonThreaded(
     });
     if (linkRes.ok && linkRes.permalink) {
       sourceUrl = linkRes.permalink;
+    } else {
+      logger.error(
+        {
+          connectorId,
+          channelId,
+          channelName,
+          messageTs: firstMessage.ts,
+          linkRes,
+        },
+        "No documentUrl for Slack non threaded: Failed to get permalink"
+      );
     }
   }
   const lastMessage = messages.at(-1);
@@ -593,6 +604,18 @@ export async function syncThread(
     });
     if (linkRes.ok && linkRes.permalink) {
       sourceUrl = linkRes.permalink;
+    } else {
+      logger.error(
+        {
+          connectorId,
+          channelId,
+          channelName,
+          threadTs,
+          messageTs: firstMessage.ts,
+          linkRes,
+        },
+        "No documentUrl for Slack thread: Failed to get permalink"
+      );
     }
   }
   const lastMessage = allMessages.at(-1);


### PR DESCRIPTION
## Description

https://github.com/dust-tt/tasks/issues/586
Some Slack thread on our datasource documents have no sourceUrl.
-> First step is to add logs to understand why Slack does not provide a link for those. 

## Risk

/

## Deploy Plan

/
