### PR TITLE
Adapt wording of subscription page for role non-admin

### DIFF
--- a/front/pages/w/[wId]/subscribe.tsx
+++ b/front/pages/w/[wId]/subscribe.tsx
@@ -1,4 +1,4 @@
-import { BarHeader, Button, Page } from "@dust-tt/sparkle";
+import { BarHeader, Button, LockIcon, Page } from "@dust-tt/sparkle";
 import type { WorkspaceType } from "@dust-tt/types";
 import { CreditCardIcon } from "@heroicons/react/20/solid";
 import type { InferGetServerSidePropsType } from "next";
@@ -18,6 +18,7 @@ const { GA_TRACKING_ID = "" } = process.env;
 
 export const getServerSideProps = withDefaultUserAuthPaywallWhitelisted<{
   owner: WorkspaceType;
+  isAdmin: boolean;
   gaTrackingId: string;
 }>(async (context, auth) => {
   const owner = auth.workspace();
@@ -30,6 +31,7 @@ export const getServerSideProps = withDefaultUserAuthPaywallWhitelisted<{
   return {
     props: {
       owner,
+      isAdmin: auth.isAdmin(),
       gaTrackingId: GA_TRACKING_ID,
     },
   };
@@ -37,6 +39,7 @@ export const getServerSideProps = withDefaultUserAuthPaywallWhitelisted<{
 
 export default function Subscribe({
   owner,
+  isAdmin,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const router = useRouter();
   const sendNotification = useContext(SendNotificationsContext);
@@ -118,35 +121,55 @@ export default function Subscribe({
         />
       </div>
       <Page>
-        <Page.Horizontal>
-          <Page.Vertical sizing="grow" gap="lg">
-            <Page.Header
-              icon={CreditCardIcon}
-              title="Setting up your subscription"
-            />
-            <Page.P>
-              <span className="font-bold">
-                You can try the Pro plan for free for two weeks.
-              </span>
-            </Page.P>
-            <Page.P>
-              After your trial ends, you will be charged monthly. You can cancel
-              at any time.
-            </Page.P>
-            <Button
-              variant="primary"
-              label="Start your trial"
-              icon={CreditCardIcon}
-              size="md"
-              onClick={() => {
-                void handleSubscribePlan();
-              }}
-            ></Button>
-          </Page.Vertical>
-          <Page.Vertical sizing="grow">
-            <ProPriceTable display="subscribe" size="xs"></ProPriceTable>
-          </Page.Vertical>
-        </Page.Horizontal>
+        {isAdmin ? (
+          <Page.Horizontal>
+            <Page.Vertical sizing="grow" gap="lg">
+              <Page.Header
+                icon={CreditCardIcon}
+                title="Setting up your subscription"
+              />
+              <Page.P>
+                <span className="font-bold">
+                  You can try the Pro plan for free for two weeks.
+                </span>
+              </Page.P>
+              <Page.P>
+                After your trial ends, you will be charged monthly. You can
+                cancel at any time.
+              </Page.P>
+              <Button
+                variant="primary"
+                label="Start your trial"
+                icon={CreditCardIcon}
+                size="md"
+                onClick={() => {
+                  void handleSubscribePlan();
+                }}
+              ></Button>
+            </Page.Vertical>
+            <Page.Vertical sizing="grow">
+              <ProPriceTable display="subscribe" size="xs"></ProPriceTable>
+            </Page.Vertical>
+          </Page.Horizontal>
+        ) : (
+          <Page.Horizontal>
+            <Page.Vertical sizing="grow" gap="lg">
+              <Page.Header icon={LockIcon} title="Workspace locked" />
+              <Page.P>
+                <span className="font-bold">
+                  The subscription for this workspace is not active.
+                </span>
+              </Page.P>
+              <Page.P>
+                To unlock premium features, your workspace needs to be upgraded
+                by an admin.
+              </Page.P>
+            </Page.Vertical>
+            <Page.Vertical sizing="grow">
+              <ProPriceTable display="subscribe" size="xs"></ProPriceTable>
+            </Page.Vertical>
+          </Page.Horizontal>
+        )}
       </Page>
     </>
   );


### PR DESCRIPTION
## Description

If the workspace is downgraded, all users will be redirected to the paywall page. 
Context: https://dust4ai.slack.com/archives/C050A0S2Z7F/p1711460944506429

This PRs adapts the wording for role = non admin in the workspace. 
First screenshot is for users, second is for admins. 


<kbd>
<img width="964" alt="Screenshot 2024-04-02 at 21 55 01" src="https://github.com/dust-tt/dust/assets/3803406/90bc124d-b669-4d20-85cd-90905a15b67c">
<kbd>
</ kbd>
<img width="948" alt="Screenshot 2024-04-02 at 21 54 53" src="https://github.com/dust-tt/dust/assets/3803406/4804c2ef-becb-498a-a98c-fba6b3944e6f">
</kbd>
