### PR TITLE
[core] - fix: handle empty arrays in map block output

### DIFF
--- a/core/src/blocks/map.rs
+++ b/core/src/blocks/map.rs
@@ -105,10 +105,10 @@ impl Block for Map {
                             ))?;
                         }
                         match arr.len() {
-                            0 => Err(anyhow::anyhow!(
-                                "Map `from` block `{}` output must be a non-empty array",
-                                self.from
-                            )),
+                            0 => Ok(BlockResult {
+                                 value: serde_json::Value::Array(Vec::new()),
+                                 meta: None,
+                             }),
                             _ => Ok(BlockResult {
                                 value: v.clone(),
                                 meta: None, // do I need to take the meta here

--- a/core/src/blocks/map.rs
+++ b/core/src/blocks/map.rs
@@ -104,16 +104,14 @@ impl Block for Map {
                                 MAP_MAX_ITERATIONS
                             ))?;
                         }
-                        match arr.len() {
-                            0 => Ok(BlockResult {
-                                 value: serde_json::Value::Array(Vec::new()),
-                                 meta: None,
-                             }),
-                            _ => Ok(BlockResult {
-                                value: v.clone(),
-                                meta: None, // do I need to take the meta here
-                            }),
-                        }
+                        Ok(BlockResult {
+                            value: if arr.is_empty() {
+                                serde_json::Value::Array(Vec::new())
+                            } else {
+                                v.clone()
+                            },
+                            meta: None,
+                        })
                     }
                 },
                 Some(repeat) => match repeat {


### PR DESCRIPTION
## Description
 - Gracefully handle empty arrays when map block output is processed
 - Prevents errors and ensures correct execution of the reduce block
