### PR TITLE
Clamp notification content

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.132",
+  "version": "0.2.133",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.132",
+      "version": "0.2.133",
       "license": "ISC",
       "dependencies": {
         "@headlessui/react": "^1.7.17",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.132",
+  "version": "0.2.133",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/components/Notification.tsx
+++ b/sparkle/src/components/Notification.tsx
@@ -28,7 +28,7 @@ export function Notification({
   return (
     <div
       className={classNames(
-        "s-pointer-events-auto s-flex s-max-w-[260px] s-flex-row s-items-center s-gap-2 s-rounded-xl s-border s-border-structure-100 s-bg-structure-0 s-p-4 s-shadow-xl",
+        "s-pointer-events-auto s-flex s-max-w-[320px] s-flex-row s-items-center s-gap-2 s-rounded-xl s-border s-border-structure-100 s-bg-structure-0 s-p-4 s-shadow-xl",
         className
       )}
     >

--- a/sparkle/src/components/Notification.tsx
+++ b/sparkle/src/components/Notification.tsx
@@ -50,7 +50,7 @@ export function Notification({
         <div className="s-flex s-grow s-flex-row s-gap-6">
           <div
             className={classNames(
-              "s-text-md s-grow  s-font-semibold",
+              "s-text-md s-line-clamp-1 s-grow s-font-semibold",
               variant === "success"
                 ? "s-text-success-500"
                 : "s-text-warning-500"
@@ -66,7 +66,7 @@ export function Notification({
           />
         </div>
         {description && (
-          <div className="s-pr-2 s-text-sm s-font-normal s-text-element-700">
+          <div className="s-line-clamp-3 s-pr-2 s-text-sm s-font-normal s-text-element-700">
             {description}
           </div>
         )}

--- a/sparkle/src/components/Notification.tsx
+++ b/sparkle/src/components/Notification.tsx
@@ -28,7 +28,7 @@ export function Notification({
   return (
     <div
       className={classNames(
-        "s-pointer-events-auto s-flex s-max-w-[320px] s-flex-row s-items-center s-gap-2 s-rounded-xl s-border s-border-structure-100 s-bg-structure-0 s-p-4 s-shadow-xl",
+        "s-pointer-events-auto s-flex s-max-w-[400px] s-flex-row s-items-center s-gap-2 s-rounded-xl s-border s-border-structure-100 s-bg-structure-0 s-p-4 s-shadow-xl",
         className
       )}
     >

--- a/sparkle/src/stories/Notification.stories.tsx
+++ b/sparkle/src/stories/Notification.stories.tsx
@@ -27,6 +27,11 @@ export const DropdownExample = () => {
         <div>
           <Notification title="Failure" variant="error" />
         </div>
+        <Notification
+          title="Failure with a very long title clamped on one line."
+          description="This is a very long failure notification with some messy content. Hopefully it should be truncated in the UI after 3 very long lines!"
+          variant="error"
+        />
       </div>
     </>
   );

--- a/sparkle/src/stories/Notification.stories.tsx
+++ b/sparkle/src/stories/Notification.stories.tsx
@@ -29,7 +29,7 @@ export const DropdownExample = () => {
         </div>
         <Notification
           title="Failure with a very long title clamped on one line."
-          description="This is a very long failure notification with some messy content. Hopefully it should be truncated in the UI after 3 very long lines!"
+          description='Got: {"error":{"type":"invalid_request_error","message":"Invalid request body: Expecting string at name but instead got: undefined"}}'
           variant="error"
         />
       </div>


### PR DESCRIPTION
## Description

Resolves https://github.com/dust-tt/tasks/issues/594.

This PR clamps notification's content since we don't always control what's being displayed there. This is a dirty hack since this text isn't easy to split (no whitespaces). We should instead improve our error handling to avoid logging those types of errors.

<img width="347" alt="image" src="https://github.com/dust-tt/dust/assets/7428970/16b06492-44ec-4b0b-af69-fecc8b008521">
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
