### PR TITLE
fix: stop all connectors at beginning of scrub wf

### DIFF
--- a/front/scrub_workspace/temporal/activities.ts
+++ b/front/scrub_workspace/temporal/activities.ts
@@ -1,4 +1,4 @@
-import { removeNulls } from "@dust-tt/types";
+import { ConnectorsAPI, removeNulls } from "@dust-tt/types";
 import { chunk } from "lodash";
 
 import {
@@ -70,6 +70,22 @@ export async function scrubWorkspaceData({
   await deleteAllConversations(auth);
   await archiveAssistants(auth);
   await deleteDatasources(auth);
+}
+
+export async function pauseAllConnectors({
+  workspaceId,
+}: {
+  workspaceId: string;
+}) {
+  const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
+  const dataSources = await getDataSources(auth);
+  const connectorsApi = new ConnectorsAPI(logger);
+  for (const ds of dataSources) {
+    if (!ds.connectorId) {
+      continue;
+    }
+    await connectorsApi.pauseConnector(ds.connectorId);
+  }
 }
 
 async function deleteAllConversations(auth: Authenticator) {

--- a/front/scrub_workspace/temporal/client.ts
+++ b/front/scrub_workspace/temporal/client.ts
@@ -3,7 +3,7 @@ import { Err, Ok } from "@dust-tt/types";
 
 import { getTemporalClient } from "@app/lib/temporal";
 import logger from "@app/logger/logger";
-import { scheduleWorkspaceScrubWorkflow } from "@app/scrub_workspace/temporal/workflows";
+import { scheduleWorkspaceScrubWorkflowV2 } from "@app/scrub_workspace/temporal/workflows";
 
 import { QUEUE_NAME } from "./config";
 
@@ -17,7 +17,7 @@ export async function launchScheduleWorkspaceScrubWorkflow({
   const workflowId = `schedule-workspace-scrub-${workspaceId}`;
 
   try {
-    await client.workflow.start(scheduleWorkspaceScrubWorkflow, {
+    await client.workflow.start(scheduleWorkspaceScrubWorkflowV2, {
       args: [{ workspaceId }],
       taskQueue: QUEUE_NAME,
       workflowId: workflowId,

--- a/front/scrub_workspace/temporal/workflows.ts
+++ b/front/scrub_workspace/temporal/workflows.ts
@@ -13,15 +13,44 @@ const { sendDataDeletionEmail } = proxyActivities<typeof activities>({
   },
 });
 
-const { scrubWorkspaceData } = proxyActivities<typeof activities>({
+const { scrubWorkspaceData, pauseAllConnectors } = proxyActivities<
+  typeof activities
+>({
   startToCloseTimeout: "60 minutes",
 });
 
+// DEPRECATED
+// TODO(@fontanierh): remove this workflow once the new one is deployed and no instances are still running.
 export async function scheduleWorkspaceScrubWorkflow({
   workspaceId,
 }: {
   workspaceId: string;
 }): Promise<boolean> {
+  await sendDataDeletionEmail({
+    remainingDays: 15,
+    workspaceId,
+    isLast: false,
+  });
+  await sleep("12 days");
+  if (!(await shouldStillScrubData({ workspaceId }))) {
+    return false;
+  }
+  await sendDataDeletionEmail({ remainingDays: 3, workspaceId, isLast: true });
+  await sleep("3 days");
+  if (!(await shouldStillScrubData({ workspaceId }))) {
+    return false;
+  }
+
+  await scrubWorkspaceData({ workspaceId });
+  return true;
+}
+
+export async function scheduleWorkspaceScrubWorkflowV2({
+  workspaceId,
+}: {
+  workspaceId: string;
+}): Promise<boolean> {
+  await pauseAllConnectors({ workspaceId });
   await sendDataDeletionEmail({
     remainingDays: 15,
     workspaceId,


### PR DESCRIPTION
## Description

fixes https://github.com/dust-tt/tasks/issues/599

When a workspace churns, we cut their limits (not allowed to upsert, query etc) and we start a workflow that last 15 days. At the end of this workflow, all the workspace's data is deleted (unless they re-subbed in the meantime).

The problem is that during those 15 days, the connectors try to upsert into their data sources which triggers errors.

With this change, connectors are paused at the beginning, so they won't be trying to upsert anything.

There change in the workflow is not backwards compatible and the workflows are not restartable. So I made a "v2" version, and will kill the original one once no longer used.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
