### PR TITLE
Proactively cancel inactive trials 3 days before end

### DIFF
--- a/front/lib/email.ts
+++ b/front/lib/email.ts
@@ -206,8 +206,7 @@ export async function sendProactiveTrialCancelledEmail(
     <p>You've not used core features of the product (adding data sources, creating custom assistants) and you haven't used assistant conversations in the past 7 days.
     As a result, to avoid keeping your payment method on file while you may not intend to convert to our paid plan, we've cancelled your trial ahead of time and won't be charging you.</p>
 
-    <p>If you did intend to continue on Dust, you can sign up again and your trial will pick up where you left off, with 3 days to go before converting to our paid plan.
-    If you'd like to extend further, feel free to just email me.</p>
+    <p>If you did intend to continue on Dust, you can subscribe again. If you'd like to extend further, feel free to just email me.</p>
 
     <p>Thanks again for trying Dust out. If you have a second, please let me know if you have any thoughts about what we could do to improve Dust for your needs!</p>
 

--- a/front/lib/email.ts
+++ b/front/lib/email.ts
@@ -189,3 +189,30 @@ export async function sendAdminDataDeletionEmail({
   };
   return sendEmail(email, msg);
 }
+
+export async function sendProactiveTrialCancelledEmail(
+  email: string
+): Promise<void> {
+  const message = {
+    from: {
+      name: "Gabriel Hubert",
+      email: "gabriel@dust.tt",
+    },
+    subject: "[Dust] Your Pro plan trial has been cancelled early",
+    html: `<p>Hi,</p>
+
+    <p>I'm Gabriel, a cofounder of Dust. Thanks for trying us out with a free trial of the Pro Plan.</p>
+
+    <p>You've not used core features of the product (adding data sources, creating custom assistants) and you haven't used assistant conversations in the past 7 days.
+    As a result, to avoid keeping your payment method on file while you may not intend to convert to our paid plan, we've cancelled your trial ahead of time and won't be charging you.</p>
+
+    <p>If you did intend to continue on Dust, you can sign up again and your trial will pick up where you left off, with 3 days to go before converting to our paid plan.
+    If you'd like to extend further, feel free to just email me.</p>
+
+    <p>Thanks again for trying Dust out. If you have a second, please let me know if you have any thoughts about what we could do to improve Dust for your needs!</p>
+
+    Gabriel`,
+  };
+
+  return sendEmail(email, message);
+}

--- a/front/lib/plans/subscription.ts
+++ b/front/lib/plans/subscription.ts
@@ -1,5 +1,6 @@
-import type { WorkspaceType } from "@dust-tt/types";
 import type { PlanType, SubscriptionType } from "@dust-tt/types";
+import type { WorkspaceType } from "@dust-tt/types";
+import { sendUserOperationMessage } from "@dust-tt/types";
 import type Stripe from "stripe";
 
 import type { Authenticator } from "@app/lib/auth";
@@ -506,8 +507,13 @@ export async function maybeCancelInactiveTrials(
       );
 
       return;
+    } else {
+      await sendProactiveTrialCancelledEmail(firstAdmin.email);
     }
 
-    await sendProactiveTrialCancelledEmail(firstAdmin.email);
+    await sendUserOperationMessage({
+      logger,
+      message: `Trial for workspace ${workspace.sId} cancelled proactively!`,
+    });
   }
 }

--- a/front/lib/workspace.ts
+++ b/front/lib/workspace.ts
@@ -5,6 +5,8 @@ import type {
 } from "@dust-tt/types";
 
 import type { Workspace } from "@app/lib/models";
+import { User } from "@app/lib/models";
+import { MembershipModel } from "@app/lib/resources/storage/models/membership";
 
 export function renderLightWorkspaceType({
   workspace,
@@ -20,4 +22,21 @@ export function renderLightWorkspaceType({
     segmentation: workspace.segmentation,
     role,
   };
+}
+
+// TODO: This belong to the WorkspaceResource.
+export async function getWorkspaceFirstAdmin(workspace: Workspace) {
+  return User.findOne({
+    include: [
+      {
+        model: MembershipModel,
+        where: {
+          role: "admin",
+          workspaceId: workspace.id,
+        },
+        required: true,
+      },
+    ],
+    order: [["createdAt", "ASC"]],
+  });
 }

--- a/front/lib/workspace_usage.ts
+++ b/front/lib/workspace_usage.ts
@@ -2,12 +2,7 @@ import { format } from "date-fns/format";
 import { Op, QueryTypes } from "sequelize";
 
 import type { Workspace } from "@app/lib/models";
-import {
-  AgentConfiguration,
-  AgentMessage,
-  Conversation,
-  DataSource,
-} from "@app/lib/models";
+import { AgentConfiguration, Conversation, DataSource } from "@app/lib/models";
 
 import { frontSequelize } from "./resources/storage";
 

--- a/front/lib/workspace_usage.ts
+++ b/front/lib/workspace_usage.ts
@@ -1,5 +1,13 @@
 import { format } from "date-fns/format";
-import { QueryTypes } from "sequelize";
+import { Op, QueryTypes } from "sequelize";
+
+import type { Workspace } from "@app/lib/models";
+import {
+  AgentConfiguration,
+  AgentMessage,
+  Conversation,
+  DataSource,
+} from "@app/lib/models";
 
 import { frontSequelize } from "./resources/storage";
 
@@ -93,4 +101,29 @@ export async function unsafeGetUsageData(
     .join("\n");
 
   return csvHeader + csvContent;
+}
+
+/**
+ * Check if a workspace is active during a trial based on the following conditions:
+ *   - Existence of a connected data source
+ *   - Existence of a custom assistant
+ *   - A conversation occurred within the past 7 days
+ */
+export async function checkWorkspaceActivity(workspace: Workspace) {
+  const sevenDaysAgo = new Date();
+  sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
+
+  const hasConnectedDataSource = await DataSource.findOne({
+    where: { workspaceId: workspace.id },
+  });
+
+  const hasCreatedAssistant = await AgentConfiguration.findOne({
+    where: { workspaceId: workspace.id },
+  });
+
+  const hasRecentConversation = await Conversation.findOne({
+    where: { workspaceId: workspace.id, updatedAt: { [Op.gte]: sevenDaysAgo } },
+  });
+
+  return hasConnectedDataSource || hasCreatedAssistant || hasRecentConversation;
 }

--- a/front/lib/workspace_usage.ts
+++ b/front/lib/workspace_usage.ts
@@ -108,7 +108,7 @@ export async function checkWorkspaceActivity(workspace: Workspace) {
   const sevenDaysAgo = new Date();
   sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
 
-  const hasConnectedDataSource = await DataSource.findOne({
+  const hasDataSource = await DataSource.findOne({
     where: { workspaceId: workspace.id },
   });
 
@@ -120,5 +120,5 @@ export async function checkWorkspaceActivity(workspace: Workspace) {
     where: { workspaceId: workspace.id, updatedAt: { [Op.gte]: sevenDaysAgo } },
   });
 
-  return hasConnectedDataSource || hasCreatedAssistant || hasRecentConversation;
+  return hasDataSource || hasCreatedAssistant || hasRecentConversation;
 }

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -15,6 +15,7 @@ import {
 } from "@app/lib/email";
 import { Plan, Subscription, Workspace } from "@app/lib/models";
 import { createCustomerPortalSession } from "@app/lib/plans/stripe";
+import { maybeCancelInactiveTrials } from "@app/lib/plans/subscription";
 import { countActiveSeatsInWorkspace } from "@app/lib/plans/workspace_usage";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { generateModelSId } from "@app/lib/utils";
@@ -562,6 +563,14 @@ async function handler(
           }
 
           break;
+
+        case "customer.subscription.trial_will_end":
+          stripeSubscription = event.data.object as Stripe.Subscription;
+
+          await maybeCancelInactiveTrials(stripeSubscription);
+
+          break;
+
         default:
         // Unhandled event type
       }


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/608.

This PR introduces a listener for Stripe's `customer.subscription.trial_will_end` event, which is triggered 3 days before a trial ends. On this event, we assess whether the trial has been active, based on the following criteria:
- The presence of a connected data source
- The existence of a custom assistant
- A conversation that occurred within the past 7 days

If none of the above criteria are met, we will proactively cancel the subscription.

⚠️ However, this does not apply to trials that will end in less than 3 days, as those will be canceled manually.

We will also send an email when proactively canceling a trial, this will be done in a follow up PR.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
