### PR TITLE
Move to ConnectorType.configuration

### DIFF
--- a/connectors/package-lock.json
+++ b/connectors/package-lock.json
@@ -87,6 +87,7 @@
         "eventsource-parser": "^1.1.1",
         "hot-shots": "^10.0.0",
         "io-ts": "^2.2.20",
+        "io-ts-reporters": "^2.0.1",
         "io-ts-types": "^0.5.19",
         "redis": "^4.6.8",
         "uuid": "^9.0.1"

--- a/connectors/src/api/configuration.ts
+++ b/connectors/src/api/configuration.ts
@@ -1,0 +1,111 @@
+import type {
+  ConnectorType,
+  Result,
+  UpdateConnectorConfigurationType,
+  WithConnectorsAPIErrorReponse,
+} from "@dust-tt/types";
+import {
+  assertNever,
+  ioTsParsePayload,
+  WebCrawlerConfigurationTypeSchema,
+} from "@dust-tt/types";
+import type { Request, Response } from "express";
+
+import { SET_CONNECTOR_CONFIGURATION_BY_TYPE } from "@connectors/connectors";
+import { renderConnectorType } from "@connectors/lib/renderers/connector";
+import { apiError, withLogging } from "@connectors/logger/withlogging";
+import { ConnectorResource } from "@connectors/resources/connector_resource";
+
+type PatchConnectorConfigurationResBody =
+  WithConnectorsAPIErrorReponse<ConnectorType>;
+
+const _patchConnectorConfiguration = async (
+  req: Request<
+    { connector_id: string },
+    PatchConnectorConfigurationResBody,
+    UpdateConnectorConfigurationType
+  >,
+  res: Response<PatchConnectorConfigurationResBody>
+) => {
+  const connector = await ConnectorResource.fetchById(req.params.connector_id);
+  if (!connector) {
+    return apiError(req, res, {
+      api_error: {
+        type: "connector_not_found",
+        message: "Connector not found",
+      },
+      status_code: 404,
+    });
+  }
+
+  let patchRes: Result<void, Error> | null = null;
+  switch (connector.type) {
+    case "webcrawler": {
+      const parseRes = ioTsParsePayload(
+        req.body.configuration,
+        WebCrawlerConfigurationTypeSchema
+      );
+      if (parseRes.isErr()) {
+        return apiError(req, res, {
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid configuration: ${parseRes.error.join(", ")}`,
+          },
+          status_code: 400,
+        });
+      }
+      const setConfiguration =
+        SET_CONNECTOR_CONFIGURATION_BY_TYPE[connector.type];
+      patchRes = await setConfiguration(connector.id, parseRes.value);
+      break;
+    }
+
+    case "notion":
+    case "confluence":
+    case "github":
+    case "google_drive":
+    case "intercom":
+    case "slack": {
+      throw new Error(
+        `Connector type ${connector.type} does not support configuration patching`
+      );
+    }
+
+    default: {
+      assertNever(connector.type);
+    }
+  }
+
+  if (patchRes.isErr()) {
+    return apiError(
+      req,
+      res,
+      {
+        api_error: {
+          type: "internal_server_error",
+          message: patchRes.error.message,
+        },
+        status_code: 500,
+      },
+      patchRes.error
+    );
+  }
+
+  const updatedConnector = await ConnectorResource.fetchById(
+    req.params.connector_id
+  );
+  if (!updatedConnector) {
+    return apiError(req, res, {
+      api_error: {
+        type: "connector_not_found",
+        message: "Connector not found",
+      },
+      status_code: 404,
+    });
+  }
+  return res.status(200).json(await renderConnectorType(updatedConnector));
+};
+
+export const patchConnectorConfigurationAPIHandler = withLogging(
+  _patchConnectorConfiguration
+);

--- a/connectors/src/api/get_connector.ts
+++ b/connectors/src/api/get_connector.ts
@@ -6,6 +6,7 @@ import type { Request, Response } from "express";
 
 import { GithubDiscussion, GithubIssue } from "@connectors/lib/models/github";
 import { NotionPage } from "@connectors/lib/models/notion";
+import { renderConnectorType } from "@connectors/lib/renderers/connector";
 import { apiError, withLogging } from "@connectors/logger/withlogging";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 
@@ -68,19 +69,7 @@ const _getConnector = async (
     }
   }
 
-  return res.status(200).json({
-    id: connector.id.toString(),
-    type: connector.type,
-    workspaceId: connector.workspaceId,
-    dataSourceName: connector.dataSourceName,
-    lastSyncStatus: connector.lastSyncStatus,
-    lastSyncStartTime: connector.lastSyncStartTime?.getTime(),
-    lastSyncFinishTime: connector.lastSyncFinishTime?.getTime(),
-    lastSyncSuccessfulTime: connector.lastSyncSuccessfulTime?.getTime(),
-    firstSuccessfulSyncTime: connector.firstSuccessfulSyncTime?.getTime(),
-    firstSyncProgress,
-    errorType: connector.errorType || undefined,
-  });
+  return res.status(200).json(await renderConnectorType(connector));
 };
 
 export const getConnectorAPIHandler = withLogging(_getConnector);

--- a/connectors/src/api_server.ts
+++ b/connectors/src/api_server.ts
@@ -5,6 +5,7 @@ import express from "express";
 import morgan from "morgan";
 
 import { adminAPIHandler } from "@connectors/api/admin";
+import { patchConnectorConfigurationAPIHandler } from "@connectors/api/configuration";
 import { createConnectorAPIHandler } from "@connectors/api/create_connector";
 import { deleteConnectorAPIHandler } from "@connectors/api/delete_connector";
 import { getConnectorAPIHandler } from "@connectors/api/get_connector";
@@ -20,7 +21,7 @@ import {
 } from "@connectors/api/slack_channels_linked_with_agent";
 import { stopConnectorAPIHandler } from "@connectors/api/stop_connector";
 import { syncConnectorAPIHandler } from "@connectors/api/sync_connector";
-import { getConnectorUpdateAPIHandler } from "@connectors/api/update_connector";
+import { postConnectorUpdateAPIHandler } from "@connectors/api/update_connector";
 import { webhookGithubAPIHandler } from "@connectors/api/webhooks/webhook_github";
 import { webhookGoogleDriveAPIHandler } from "@connectors/api/webhooks/webhook_google_drive";
 import {
@@ -28,7 +29,6 @@ import {
   webhookIntercomUninstallAPIHandler,
 } from "@connectors/api/webhooks/webhook_intercom";
 import { webhookSlackAPIHandler } from "@connectors/api/webhooks/webhook_slack";
-import { getWebcrawlerConfiguration } from "@connectors/connectors/webcrawler";
 import logger from "@connectors/logger/logger";
 import { authMiddleware } from "@connectors/middleware/auth";
 
@@ -88,7 +88,7 @@ export function startServer(port: number) {
   app.use(authMiddleware);
 
   app.post("/connectors/create/:connector_provider", createConnectorAPIHandler);
-  app.post("/connectors/update/:connector_id/", getConnectorUpdateAPIHandler);
+  app.post("/connectors/update/:connector_id/", postConnectorUpdateAPIHandler);
   app.post("/connectors/stop/:connector_id", stopConnectorAPIHandler);
   app.post("/connectors/pause/:connector_id", pauseConnectorAPIHandler);
   app.post("/connectors/resume/:connector_id", resumeConnectorAPIHandler);
@@ -144,6 +144,13 @@ export function startServer(port: number) {
     webhookIntercomUninstallAPIHandler
   );
 
+  // /configuration/ is the new configration method, replacing the old /config/ method
+  app.patch(
+    "/connectors/:connector_id/configuration",
+    patchConnectorConfigurationAPIHandler
+  );
+
+  // /config/ is the old configuration method, will disappear in the future
   app.post(
     "/connectors/:connector_id/config/:config_key",
     setConnectorConfigAPIHandler
@@ -152,11 +159,6 @@ export function startServer(port: number) {
   app.get(
     "/connectors/:connector_id/config/:config_key",
     getConnectorConfigAPIHandler
-  );
-
-  app.get(
-    "/connectors/webcrawler/:connector_id/configuration",
-    getWebcrawlerConfiguration
   );
 
   app.post("/connectors/admin", adminAPIHandler);

--- a/connectors/src/connectors/index.ts
+++ b/connectors/src/connectors/index.ts
@@ -1,4 +1,8 @@
-import type { ConnectorProvider, ModelId } from "@dust-tt/types";
+import type {
+  ConnectorProvider,
+  ModelId,
+  WebCrawlerConfigurationType,
+} from "@dust-tt/types";
 import { Err, Ok } from "@dust-tt/types";
 
 import {
@@ -59,16 +63,15 @@ import type {
   ConnectorCleaner,
   ConnectorConfigGetter,
   ConnectorConfigSetter,
-  ConnectorCreatorOAuth,
-  ConnectorCreatorUrl,
   ConnectorGarbageCollector,
   ConnectorPauser,
   ConnectorPermissionRetriever,
   ConnectorPermissionSetter,
+  ConnectorProviderCreateConnectorMapping,
+  ConnectorProviderUpdateConfigurationMapping,
   ConnectorResumer,
   ConnectorStopper,
-  ConnectorUpdaterOAuth,
-  ConnectorUpdaterUrl,
+  ConnectorUpdater,
   ContentNodeParentsRetriever,
   SyncConnector,
 } from "@connectors/connectors/interface";
@@ -105,27 +108,25 @@ import {
   retrieveWebcrawlerConnectorPermissions,
   retrieveWebCrawlerContentNodeParents,
   retrieveWebCrawlerContentNodes,
+  setWebcrawlerConfiguration,
   stopWebcrawlerConnector,
-  updateWebcrawlerConnector,
 } from "./webcrawler";
 import { launchCrawlWebsiteWorkflow } from "./webcrawler/temporal/client";
 
-export const CREATE_CONNECTOR_BY_TYPE: Record<
-  ConnectorProvider,
-  ConnectorCreatorOAuth | ConnectorCreatorUrl
-> = {
-  confluence: createConfluenceConnector,
-  github: createGithubConnector,
-  google_drive: createGoogleDriveConnector,
-  intercom: createIntercomConnector,
-  notion: createNotionConnector,
-  slack: createSlackConnector,
-  webcrawler: createWebcrawlerConnector,
-};
+export const CREATE_CONNECTOR_BY_TYPE: ConnectorProviderCreateConnectorMapping =
+  {
+    confluence: createConfluenceConnector,
+    github: createGithubConnector,
+    google_drive: createGoogleDriveConnector,
+    intercom: createIntercomConnector,
+    notion: createNotionConnector,
+    slack: createSlackConnector,
+    webcrawler: createWebcrawlerConnector,
+  };
 
 export const UPDATE_CONNECTOR_BY_TYPE: Record<
   ConnectorProvider,
-  ConnectorUpdaterOAuth | ConnectorUpdaterUrl
+  ConnectorUpdater
 > = {
   confluence: updateConfluenceConnector,
   slack: updateSlackConnector,
@@ -133,7 +134,9 @@ export const UPDATE_CONNECTOR_BY_TYPE: Record<
   github: updateGithubConnector,
   google_drive: updateGoogleDriveConnector,
   intercom: updateIntercomConnector,
-  webcrawler: updateWebcrawlerConnector,
+  webcrawler: () => {
+    throw new Error(`Not implemented`);
+  },
 };
 
 export const STOP_CONNECTOR_BY_TYPE: Record<
@@ -263,6 +266,7 @@ export const RETRIEVE_CONTENT_NODE_PARENTS_BY_TYPE: Record<
   webcrawler: retrieveWebCrawlerContentNodeParents,
 };
 
+// Old configuration interface that allows to set one config key at a time.
 export const SET_CONNECTOR_CONFIG_BY_TYPE: Record<
   ConnectorProvider,
   ConnectorConfigSetter
@@ -284,6 +288,7 @@ export const SET_CONNECTOR_CONFIG_BY_TYPE: Record<
   },
 };
 
+// Old configuration interface that allows to get one config key at a time.
 export const GET_CONNECTOR_CONFIG_BY_TYPE: Record<
   ConnectorProvider,
   ConnectorConfigGetter
@@ -304,6 +309,32 @@ export const GET_CONNECTOR_CONFIG_BY_TYPE: Record<
     throw new Error("Not implemented");
   },
 };
+
+export const SET_CONNECTOR_CONFIGURATION_BY_TYPE: ConnectorProviderUpdateConfigurationMapping =
+  {
+    webcrawler: (
+      connectorId: ModelId,
+      configuration: WebCrawlerConfigurationType
+    ) => setWebcrawlerConfiguration(connectorId, configuration),
+    intercom: () => {
+      throw new Error("Not implemented");
+    },
+    slack: () => {
+      throw new Error("Not implemented");
+    },
+    notion: () => {
+      throw new Error("Not implemented");
+    },
+    github: () => {
+      throw new Error("Not implemented");
+    },
+    google_drive: () => {
+      throw new Error("Not implemented");
+    },
+    confluence: () => {
+      throw new Error("Not implemented");
+    },
+  };
 
 export const GARBAGE_COLLECT_BY_TYPE: Record<
   ConnectorProvider,

--- a/connectors/src/connectors/interface.ts
+++ b/connectors/src/connectors/interface.ts
@@ -1,35 +1,32 @@
 import type {
+  ConnectorConfigurations,
   ConnectorPermission,
+  ConnectorProvider,
   ConnectorsAPIError,
   ContentNode,
   ContentNodesViewType,
-  CreateConnectorUrlRequestBody,
   ModelId,
   Result,
 } from "@dust-tt/types";
+import type { ConnectorConfiguration } from "@dust-tt/types";
 
 import type { DataSourceConfig } from "@connectors/types/data_source_config";
 
-export type ConnectorCreatorOAuth = (
-  dataSourceConfig: DataSourceConfig,
-  connectionId: string
+export type ConnectorCreate<T extends ConnectorConfiguration> = (
+  DataSourceConfig: DataSourceConfig,
+  connectionid: string,
+  configuration: T
 ) => Promise<Result<string, Error>>;
 
-export type ConnectorCreatorUrl = (
-  dataSourceConfig: DataSourceConfig,
-  urlConfig: CreateConnectorUrlRequestBody
-) => Promise<Result<string, Error>>;
+export type ConnectorProviderCreateConnectorMapping = {
+  [K in ConnectorProvider]: ConnectorCreate<ConnectorConfigurations[K]>;
+};
 
-export type ConnectorUpdaterOAuth = (
+export type ConnectorUpdater = (
   connectorId: ModelId,
   params: {
     connectionId?: string | null;
   }
-) => Promise<Result<string, ConnectorsAPIError>>;
-
-export type ConnectorUpdaterUrl = (
-  connectorId: ModelId,
-  urlConfig: CreateConnectorUrlRequestBody
 ) => Promise<Result<string, ConnectorsAPIError>>;
 
 export type ConnectorStopper = (
@@ -94,3 +91,13 @@ export type ConnectorGarbageCollector = (
 export type ConnectorPauser = (
   connectorId: ModelId
 ) => Promise<Result<undefined, Error>>;
+export type ConnectorConfigurationSetter<T extends ConnectorConfiguration> = (
+  connectorId: ModelId,
+  configuration: T
+) => Promise<Result<void, Error>>;
+
+export type ConnectorProviderUpdateConfigurationMapping = {
+  [K in keyof ConnectorConfigurations]: ConnectorConfigurationSetter<
+    ConnectorConfigurations[K]
+  >;
+};

--- a/connectors/src/lib/renderers/connector.ts
+++ b/connectors/src/lib/renderers/connector.ts
@@ -1,0 +1,56 @@
+import type {
+  ConnectorType,
+  WebCrawlerConfigurationType,
+} from "@dust-tt/types";
+
+import { WebCrawlerConfiguration } from "@connectors/lib/models/webcrawler";
+import type { ConnectorResource } from "@connectors/resources/connector_resource";
+
+export async function renderConnectorType(
+  connector: ConnectorResource
+): Promise<ConnectorType> {
+  return {
+    id: connector.id.toString(),
+    type: connector.type,
+    workspaceId: connector.workspaceId,
+    dataSourceName: connector.dataSourceName,
+    lastSyncStatus: connector.lastSyncStatus,
+    lastSyncStartTime: connector.lastSyncStartTime?.getTime(),
+    lastSyncSuccessfulTime: connector.lastSyncSuccessfulTime?.getTime(),
+    firstSuccessfulSyncTime: connector.firstSuccessfulSyncTime?.getTime(),
+    firstSyncProgress: connector.firstSyncProgress,
+    configuration: await renderConfiguration(connector),
+  };
+}
+
+async function renderConfiguration(connector: ConnectorResource) {
+  switch (connector.type) {
+    case "webcrawler": {
+      const config = await WebCrawlerConfiguration.findOne({
+        where: {
+          connectorId: connector.id,
+        },
+      });
+      if (!config) {
+        throw new Error(
+          `Webcrawler configuration not found for connector ${connector.id}`
+        );
+      }
+      return renderWebcrawlerConfiguration(config);
+    }
+    default:
+      return undefined;
+  }
+}
+
+async function renderWebcrawlerConfiguration(
+  webCrawlerConfiguration: WebCrawlerConfiguration
+): Promise<WebCrawlerConfigurationType> {
+  return {
+    url: webCrawlerConfiguration.url,
+    maxPageToCrawl: webCrawlerConfiguration.maxPageToCrawl,
+    crawlMode: webCrawlerConfiguration.crawlMode,
+    depth: webCrawlerConfiguration.depth,
+    crawlFrequency: webCrawlerConfiguration.crawlFrequency,
+  };
+}

--- a/front/components/data_source/WebsiteConfiguration.tsx
+++ b/front/components/data_source/WebsiteConfiguration.tsx
@@ -149,7 +149,7 @@ export default function WebsiteConfiguration({
         },
         body: JSON.stringify({
           provider: "webcrawler",
-          connectionId: undefined,
+          connectionId: "none",
           name: dataSourceName,
           configuration: {
             url: dataSourceUrl,

--- a/front/components/data_source/WebsiteConfiguration.tsx
+++ b/front/components/data_source/WebsiteConfiguration.tsx
@@ -12,7 +12,7 @@ import type {
   DataSourceType,
   DepthOption,
   SubscriptionType,
-  UpdateConnectorRequestBodySchema,
+  UpdateConnectorConfigurationType,
   WebCrawlerConfigurationType,
   WorkspaceType,
 } from "@dust-tt/types";
@@ -148,17 +148,16 @@ export default function WebsiteConfiguration({
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          urlConfig: {
-            url: dataSourceUrl,
-            maxPages: maxPages || WEBCRAWLER_MAX_PAGES,
-            depth: maxDepth,
-            crawlMode: crawlMode,
-            crawlFrequency: selectedCrawlFrequency,
-          },
-          type: "url",
           provider: "webcrawler",
           connectionId: undefined,
           name: dataSourceName,
+          configuration: {
+            url: dataSourceUrl,
+            maxPageToCrawl: maxPages || WEBCRAWLER_MAX_PAGES,
+            depth: maxDepth,
+            crawlMode: crawlMode,
+            crawlFrequency: selectedCrawlFrequency,
+          } satisfies WebCrawlerConfigurationType,
         } satisfies t.TypeOf<typeof PostManagedDataSourceRequestBodySchema>),
       });
       if (res.ok) {
@@ -172,21 +171,21 @@ export default function WebsiteConfiguration({
       const res = await fetch(
         `/api/w/${owner.sId}/data_sources/${encodeURIComponent(
           dataSource.name
-        )}/managed/update`,
+        )}/configuration`,
         {
-          method: "POST",
+          method: "PATCH",
           headers: {
             "Content-Type": "application/json",
           },
           body: JSON.stringify({
-            connectorParams: {
+            configuration: {
               url: dataSourceUrl,
-              maxPages: maxPages || WEBCRAWLER_MAX_PAGES,
+              maxPageToCrawl: maxPages || WEBCRAWLER_MAX_PAGES,
               depth: maxDepth,
               crawlMode: crawlMode,
               crawlFrequency: selectedCrawlFrequency,
-            },
-          } satisfies t.TypeOf<typeof UpdateConnectorRequestBodySchema>),
+            } satisfies WebCrawlerConfigurationType,
+          } satisfies UpdateConnectorConfigurationType),
         }
       );
       if (res.ok) {

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -155,6 +155,7 @@
         "eventsource-parser": "^1.1.1",
         "hot-shots": "^10.0.0",
         "io-ts": "^2.2.20",
+        "io-ts-reporters": "^2.0.1",
         "io-ts-types": "^0.5.19",
         "redis": "^4.6.8",
         "uuid": "^9.0.1"

--- a/front/pages/api/w/[wId]/data_sources/[name]/configuration.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/configuration.ts
@@ -1,0 +1,185 @@
+import type { ConnectorType, WithAPIErrorReponse } from "@dust-tt/types";
+import {
+  assertNever,
+  ConnectorsAPI,
+  ioTsParsePayload,
+  UpdateConnectorConfigurationTypeSchema,
+} from "@dust-tt/types";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { getDataSource } from "@app/lib/api/data_sources";
+import { Authenticator, getSession } from "@app/lib/auth";
+import logger from "@app/logger/logger";
+import { apiError, withLogging } from "@app/logger/withlogging";
+
+export type PostDataSourceConfigurationResBody = {
+  connector: ConnectorType;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorReponse<PostDataSourceConfigurationResBody | void>
+  >
+): Promise<void> {
+  const session = await getSession(req, res);
+  const auth = await Authenticator.fromSession(
+    session,
+    req.query.wId as string
+  );
+
+  const owner = auth.workspace();
+  if (!owner) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "The workspace you requested was not found.",
+      },
+    });
+  }
+
+  if (!auth.isBuilder()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "data_source_auth_error",
+        message:
+          "Only the users that are `builders` for the current workspace can access Data Source configuration.",
+      },
+    });
+  }
+
+  const dataSource = await getDataSource(auth, req.query.name as string);
+  if (!dataSource) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "data_source_not_found",
+        message: "The data source you requested was not found.",
+      },
+    });
+  }
+
+  if (!dataSource.connectorProvider || !dataSource.connectorId) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "data_source_not_managed",
+        message:
+          "Cannot update the configuration of this Data Source because it is not managed.",
+      },
+    });
+  }
+
+  switch (dataSource.connectorProvider) {
+    case "webcrawler": {
+      if (!auth.isBuilder()) {
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "data_source_auth_error",
+            message:
+              "Only the users that are `builders` for the current workspace can update the configuration of this Data Source.",
+          },
+        });
+      }
+      break;
+    }
+    case "confluence":
+    case "github":
+    case "google_drive":
+    case "intercom":
+    case "notion":
+    case "slack":
+      if (!auth.isAdmin()) {
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "data_source_auth_error",
+            message:
+              "Only the users that are `admins` for the current workspace can update the configuration of this Data Source.",
+          },
+        });
+      }
+      break;
+
+    default:
+      assertNever(dataSource.connectorProvider);
+  }
+
+  switch (req.method) {
+    case "PATCH":
+      switch (dataSource.connectorProvider) {
+        // Check which parameters are being updated here.
+        // Eg: For WebCrawler, all parameters can be updated, but the
+        // SlackConfiguration.pdfEnabled can only be updated
+        // from Poke (once this settings is moved to the new configuration system).
+        case "webcrawler": {
+          // Webcrawler configuration can be updated.
+          break;
+        }
+        default: {
+          return apiError(req, res, {
+            status_code: 404,
+            api_error: {
+              type: "data_source_error",
+              message:
+                "The configuration of this Data Source cannot be updated.",
+            },
+          });
+        }
+      }
+
+      const parseRes = ioTsParsePayload(
+        req.body,
+        UpdateConnectorConfigurationTypeSchema
+      );
+      if (parseRes.isErr()) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid request body: ${parseRes.error}`,
+          },
+        });
+      }
+
+      const connectorsAPI = new ConnectorsAPI(logger);
+
+      const updateRes = await connectorsAPI.updateConfiguration({
+        connectorId: dataSource.connectorId.toString(),
+        configuration: { configuration: parseRes.value.configuration },
+      });
+      if (updateRes.isErr()) {
+        return apiError(
+          req,
+          res,
+          {
+            status_code: 500,
+            api_error: {
+              type: "connector_update_error",
+              message: `An error occured while updating the connector's configuration`,
+            },
+          },
+          new Error(updateRes.error.message)
+        );
+      }
+
+      res.status(200).json({
+        connector: updateRes.value,
+      });
+      return;
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, PATCH is expected.",
+        },
+      });
+  }
+}
+
+export default withLogging(handler);

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/update.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/update.ts
@@ -96,7 +96,7 @@ async function handler(
       const connectorsAPI = new ConnectorsAPI(logger);
       const updateRes = await connectorsAPI.updateConnector({
         connectorId: dataSource.connectorId.toString(),
-        params: bodyValidation.right,
+        connectionId: bodyValidation.right.connectionId,
       });
       const email = auth.user()?.email;
       if (email && !isDisposableEmailDomain(email)) {

--- a/front/pages/w/[wId]/builder/data-sources/[name]/edit-public-url.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/edit-public-url.tsx
@@ -50,13 +50,11 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     };
   }
 
-  const webCrawlerConfiguration = await new ConnectorsAPI(
-    logger
-  ).getWebCrawlerConfiguration({
-    connectorId: dataSource.connectorId,
-  });
-  if (webCrawlerConfiguration.isErr()) {
-    throw new Error(webCrawlerConfiguration.error.message);
+  const connectorRes = await new ConnectorsAPI(logger).getConnector(
+    dataSource.connectorId
+  );
+  if (connectorRes.isErr()) {
+    throw new Error(connectorRes.error.message);
   }
 
   return {
@@ -65,7 +63,8 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       subscription,
       dataSources,
       dataSource,
-      webCrawlerConfiguration: webCrawlerConfiguration.value,
+      webCrawlerConfiguration: connectorRes.value
+        .configuration as WebCrawlerConfigurationType,
       gaTrackingId: GA_TRACKING_ID,
     },
   };

--- a/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
@@ -21,6 +21,7 @@ import type {
   ConnectorProvider,
   DataSourceType,
   PostDataSourceDocumentRequestBody,
+  UpdateConnectorRequestBody,
   WorkspaceType,
 } from "@dust-tt/types";
 import type { PlanType, SubscriptionType } from "@dust-tt/types";
@@ -1055,8 +1056,8 @@ function ManagedDataSourceView({
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          connectorParams: { connectionId: newConnectionId },
-        }),
+          connectionId: newConnectionId,
+        } satisfies UpdateConnectorRequestBody),
       }
     );
 

--- a/front/pages/w/[wId]/builder/data-sources/managed.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/managed.tsx
@@ -442,9 +442,8 @@ export default function DataSourcesView({
           body: JSON.stringify({
             provider,
             connectionId,
-            type: "oauth",
-            urlConfig: undefined,
             name: undefined,
+            configuration: null,
           } satisfies PostManagedDataSourceRequestBody),
         }
       );

--- a/types/package-lock.json
+++ b/types/package-lock.json
@@ -14,6 +14,7 @@
         "eventsource-parser": "^1.1.1",
         "hot-shots": "^10.0.0",
         "io-ts": "^2.2.20",
+        "io-ts-reporters": "^2.0.1",
         "io-ts-types": "^0.5.19",
         "redis": "^4.6.8",
         "uuid": "^9.0.1"
@@ -2476,6 +2477,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.3.0.tgz",
+      "integrity": "sha512-lHKK8M5CTcpFj2hZDB3wIjb0KAbEOgDmiJGDv1WBRfQgRm/a8/XMEkG/N1iM01xgbUDsPQwi42D+dFo1XPAKew==",
+      "hasInstallScript": true
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
@@ -5506,6 +5513,18 @@
       "integrity": "sha512-Rq2BsYmtwS5vVttie4rqrOCIfHCS9TgpRLFpKQCM1wZBBRY9nWVGmEvm2FnDbSE2un1UE39DvFpTR5UL47YDcA==",
       "peerDependencies": {
         "fp-ts": "^2.5.0"
+      }
+    },
+    "node_modules/io-ts-reporters": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/io-ts-reporters/-/io-ts-reporters-2.0.1.tgz",
+      "integrity": "sha512-RVpLstYBsmTGgCW9wJ5KVyN/eRnRUDp87Flt4D1O3aJ7oAnd8csq8aXuu7ZeNK8qEDKmjUl9oUuzfwikaNAMKQ==",
+      "dependencies": {
+        "@scarf/scarf": "^1.1.1"
+      },
+      "peerDependencies": {
+        "fp-ts": "^2.10.5",
+        "io-ts": "^2.2.16"
       }
     },
     "node_modules/io-ts-types": {

--- a/types/package.json
+++ b/types/package.json
@@ -32,6 +32,7 @@
     "eventsource-parser": "^1.1.1",
     "hot-shots": "^10.0.0",
     "io-ts": "^2.2.20",
+    "io-ts-reporters": "^2.0.1",
     "io-ts-types": "^0.5.19",
     "redis": "^4.6.8",
     "uuid": "^9.0.1"

--- a/types/src/connectors/api_handlers/connector_configuration.ts
+++ b/types/src/connectors/api_handlers/connector_configuration.ts
@@ -1,0 +1,48 @@
+import * as t from "io-ts";
+
+import { WebCrawlerConfigurationType } from "../webcrawler";
+
+export const WebCrawlerConfigurationTypeSchema = t.type({
+  url: t.string,
+  depth: t.union([
+    t.literal(0),
+    t.literal(1),
+    t.literal(2),
+    t.literal(3),
+    t.literal(4),
+    t.literal(5),
+  ]),
+  maxPageToCrawl: t.number,
+  crawlMode: t.union([t.literal("child"), t.literal("website")]),
+  crawlFrequency: t.union([
+    t.literal("never"),
+    t.literal("daily"),
+    t.literal("weekly"),
+    t.literal("monthly"),
+  ]),
+});
+
+export type ConnectorConfiguration = WebCrawlerConfigurationType | null;
+
+export type ConnectorConfigurations = {
+  webcrawler: WebCrawlerConfigurationType;
+  notion: null;
+  slack: null;
+  google_drive: null;
+  github: null;
+  confluence: null;
+  intercom: null;
+};
+
+export const ConnectorConfigurationTypeSchema = t.union([
+  WebCrawlerConfigurationTypeSchema,
+  t.null,
+]);
+
+export const UpdateConnectorConfigurationTypeSchema = t.type({
+  configuration: ConnectorConfigurationTypeSchema,
+});
+
+export type UpdateConnectorConfigurationType = t.TypeOf<
+  typeof UpdateConnectorConfigurationTypeSchema
+>;

--- a/types/src/connectors/api_handlers/create_connector.ts
+++ b/types/src/connectors/api_handlers/create_connector.ts
@@ -1,36 +1,15 @@
 import * as t from "io-ts";
 
-export const CreateConnectorUrlRequestBodySchema = t.type({
-  url: t.string,
-  depth: t.number,
-  maxPages: t.number,
-  crawlMode: t.union([t.literal("child"), t.literal("website")]),
-  crawlFrequency: t.union([
-    t.literal("never"),
-    t.literal("daily"),
-    t.literal("weekly"),
-    t.literal("monthly"),
-  ]),
-});
-
-export const CreateConnectorOAuthRequestBodySchema = t.type({
-  connectionId: t.string,
-});
+import { ConnectorConfigurationTypeSchema } from "./connector_configuration";
 
 export const ConnectorCreateRequestBodySchema = t.type({
   workspaceAPIKey: t.string,
   dataSourceName: t.string,
   workspaceId: t.string,
-  connectorParams: t.union([
-    CreateConnectorUrlRequestBodySchema,
-    CreateConnectorOAuthRequestBodySchema,
-  ]),
+  connectionId: t.string,
+  configuration: ConnectorConfigurationTypeSchema,
 });
 
-export type CreateConnectorUrlRequestBody = t.TypeOf<
-  typeof CreateConnectorUrlRequestBodySchema
->;
-
-export type CreateConnectorOAuthRequestBody = t.TypeOf<
-  typeof CreateConnectorOAuthRequestBodySchema
+export type ConnectorCreateRequestBody = t.TypeOf<
+  typeof ConnectorCreateRequestBodySchema
 >;

--- a/types/src/connectors/api_handlers/update_connector.ts
+++ b/types/src/connectors/api_handlers/update_connector.ts
@@ -1,16 +1,7 @@
 import * as t from "io-ts";
 
-import { CreateConnectorUrlRequestBodySchema } from "../../connectors/api_handlers/create_connector";
-
-export const UpdateConnectorOAuthRequestBodySchema = t.type({
-  connectionId: t.union([t.string, t.null, t.undefined]),
-});
-
 export const UpdateConnectorRequestBodySchema = t.type({
-  connectorParams: t.union([
-    CreateConnectorUrlRequestBodySchema,
-    UpdateConnectorOAuthRequestBodySchema,
-  ]),
+  connectionId: t.string,
 });
 
 export type UpdateConnectorRequestBody = t.TypeOf<

--- a/types/src/front/data_source.ts
+++ b/types/src/front/data_source.ts
@@ -16,19 +16,6 @@ export function isConnectorProvider(val: string): val is ConnectorProvider {
   return (CONNECTOR_PROVIDERS as unknown as string[]).includes(val);
 }
 
-export const provider2createConnectorType: Record<
-  ConnectorProvider,
-  "oauth" | "url"
-> = {
-  confluence: "oauth",
-  github: "oauth",
-  google_drive: "oauth",
-  slack: "oauth",
-  notion: "oauth",
-  intercom: "oauth",
-  webcrawler: "url",
-} as const;
-
 export const PROVIDERS_WITH_SETTINGS: ConnectorProvider[] = ["webcrawler"];
 
 interface EditedByUser {

--- a/types/src/index.ts
+++ b/types/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./connectors/admin/cli";
 export * from "./connectors/api";
+export * from "./connectors/api_handlers/connector_configuration";
 export * from "./connectors/api_handlers/create_connector";
 export * from "./connectors/api_handlers/update_connector";
 export * from "./connectors/confluence";

--- a/types/src/shared/utils/iots_utils.ts
+++ b/types/src/shared/utils/iots_utils.ts
@@ -1,5 +1,9 @@
+import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
+import * as reporter from "io-ts-reporters";
 import { v4 as uuidv4 } from "uuid";
+
+import { Err, Ok, Result } from "../../shared/result";
 
 export function ioTsEnum<EnumType>(
   enumValues: readonly string[],
@@ -39,3 +43,16 @@ export const SlugifiedString = t.brand(
   (s): s is t.Branded<string, SlugifiedStringBrand> => /^[a-z0-9_]+$/.test(s),
   "SlugifiedString"
 );
+
+export function ioTsParsePayload<T>(
+  payload: unknown,
+  codec: t.Type<T>
+): Result<T, string[]> {
+  const bodyValidation = codec.decode(payload);
+  if (isLeft(bodyValidation)) {
+    const pathError = reporter.formatValidationErrors(bodyValidation.left);
+    return new Err(pathError);
+  }
+
+  return new Ok(bodyValidation.right);
+}


### PR DESCRIPTION
## Description

Task: https://github.com/dust-tt/tasks/issues/537

The goal of this PR is to introduce a new interface to manage connectors configurations.

`ConnectorType` now has a `configuration?:ConnectorConfiguration` field,  with `ConnectorConfiguration` defined like that as of today:
```typescript
export type ConnectorConfiguration = WebCrawlerConfigurationType;
```

and will be defined like that in the future:
```typescript
export type ConnectorConfiguration = WebCrawlerConfigurationType | SlackConfigurationType | GoogleDriveConfigurationType | ...
```

There is also a new `ConnectorsAPI.updateConfiguration(connectorId, configuration:unknown)` API.

Getting the configuration is achieved by getting the `ConnectorType`.

The configuration of the WebCrawler was moved to the new interface as part of this PR, Slack and GoogleDrive will come later.
The single key configuration system (`/connectors/:connector_id/config/:config_key`) is now deprecated and will be removed in the future.


This is a big PR, I did not find a way to slice it in smaller pieces. This would have involved keeping an over complicated interface on the connector side just to split the PR, and it was nearly impossible to do it because the types for the interface changed a lot.


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
