### PR TITLE
Intercom cli tooling

### DIFF
--- a/connectors/src/connectors/intercom/lib/intercom_api.ts
+++ b/connectors/src/connectors/intercom/lib/intercom_api.ts
@@ -338,6 +338,61 @@ export async function fetchIntercomConversationsForTeamId({
 }
 
 /**
+ * Return the paginated list of Conversation for a given day.
+ * Filtered on closed Conversations.
+ */
+export async function fetchIntercomConversationsForDay({
+  nangoConnectionId,
+  minCreatedAt,
+  maxCreatedAt,
+  cursor = null,
+  pageSize = 20,
+}: {
+  nangoConnectionId: string;
+  minCreatedAt: number;
+  maxCreatedAt: number;
+  cursor: string | null;
+  pageSize?: number;
+}): Promise<{
+  conversations: IntercomConversationType[];
+  pages: {
+    next?: {
+      page: number;
+      starting_after: string;
+    };
+  };
+}> {
+  const response = await queryIntercomAPI({
+    nangoConnectionId,
+    path: `conversations/search`,
+    method: "POST",
+    body: {
+      query: {
+        operator: "AND",
+        value: [
+          {
+            field: "created_at",
+            operator: ">",
+            value: minCreatedAt,
+          },
+          {
+            field: "created_at",
+            operator: "<",
+            value: maxCreatedAt,
+          },
+        ],
+      },
+      pagination: {
+        per_page: pageSize,
+        starting_after: cursor,
+      },
+    },
+  });
+
+  return response;
+}
+
+/**
  * Return the detail of a Conversation.
  */
 export async function fetchIntercomConversation({

--- a/connectors/src/lib/cli.ts
+++ b/connectors/src/lib/cli.ts
@@ -6,6 +6,11 @@ import type {
   GithubCommandType,
   GoogleDriveCheckFileResponseType,
   GoogleDriveCommandType,
+  IntercomCheckConversationResponseType,
+  IntercomCheckMissingConversationsResponseType,
+  IntercomCheckTeamsResponseType,
+  IntercomCommandType,
+  IntercomFetchConversationResponseType,
   NotionCheckUrlResponseType,
   NotionCommandType,
   NotionMeResponseType,
@@ -23,6 +28,7 @@ import { assertNever, isConnectorError } from "@dust-tt/types";
 import { Client } from "@notionhq/client";
 import PQueue from "p-queue";
 import readline from "readline";
+import { Op } from "sequelize";
 
 import {
   DELETE_CONNECTOR_BY_TYPE,
@@ -48,6 +54,11 @@ import {
   getDriveClient,
 } from "@connectors/connectors/google_drive/temporal/utils";
 import {
+  fetchIntercomConversation,
+  fetchIntercomConversationsForDay,
+  fetchIntercomTeams,
+} from "@connectors/connectors/intercom/lib/intercom_api";
+import {
   checkNotionUrl,
   searchNotionPagesForQuery,
 } from "@connectors/connectors/notion/lib/cli";
@@ -68,6 +79,10 @@ import {
   GoogleDriveFiles,
   GoogleDriveWebhook,
 } from "@connectors/lib/models/google_drive";
+import {
+  IntercomConversation,
+  IntercomTeam,
+} from "@connectors/lib/models/intercom";
 import { NotionDatabase, NotionPage } from "@connectors/lib/models/notion";
 import { SlackConfiguration } from "@connectors/lib/models/slack";
 import { nango_client } from "@connectors/lib/nango_client";
@@ -1209,6 +1224,161 @@ export const temporal = async ({
   }
 };
 
+export const intercom = async ({
+  command,
+  args,
+}: IntercomCommandType): Promise<
+  | IntercomCheckConversationResponseType
+  | IntercomFetchConversationResponseType
+  | IntercomCheckTeamsResponseType
+  | IntercomCheckMissingConversationsResponseType
+> => {
+  const logger = topLogger.child({ majorCommand: "intercom", command, args });
+
+  if (!args.connectorId) {
+    throw new Error("Missing --connectorId argument");
+  }
+  const connectorId = args.connectorId.toString();
+
+  const connector = await ConnectorResource.fetchById(connectorId);
+  if (!connector) {
+    throw new Error(`Connector ${connectorId} not found`);
+  }
+  if (connector.type !== "intercom") {
+    throw new Error(`Connector ${args.connectorId} is not of type intercom`);
+  }
+
+  switch (command) {
+    case "check-conversation": {
+      if (!args.conversationId) {
+        throw new Error("Missing --conversationId argument");
+      }
+      const conversationId = args.conversationId.toString();
+
+      logger.info("[Admin] Checking conversation");
+
+      const conversationOnIntercom = await fetchIntercomConversation({
+        nangoConnectionId: connector.connectionId,
+        conversationId,
+      });
+      const teamIdOnIntercom =
+        typeof conversationOnIntercom?.team_assignee_id === "number"
+          ? conversationOnIntercom.team_assignee_id.toString()
+          : undefined;
+
+      const conversationOnDB = await IntercomConversation.findOne({
+        where: {
+          conversationId,
+          connectorId,
+        },
+      });
+
+      return {
+        isConversationOnIntercom: conversationOnIntercom !== null,
+        isConversationOnDB: conversationOnDB !== null,
+        conversationTeamIdOnIntercom: teamIdOnIntercom,
+        conversationTeamIdOnDB: conversationOnDB?.teamId,
+      };
+    }
+    case "fetch-conversation": {
+      if (!args.conversationId) {
+        throw new Error("Missing --conversationId argument");
+      }
+      const conversationId = args.conversationId.toString();
+
+      logger.info("[Admin] Checking conversation");
+
+      const conversationOnIntercom = await fetchIntercomConversation({
+        nangoConnectionId: connector.connectionId,
+        conversationId,
+      });
+
+      return {
+        conversation: conversationOnIntercom,
+      };
+    }
+    case "check-missing-conversations": {
+      if (!args.day) {
+        throw new Error("Missing --day argument");
+      }
+      if (!args.day.match(/^\d{4}-\d{2}-\d{2}$/)) {
+        throw new Error("Invalid --day argument format");
+      }
+
+      const startOfDay = new Date(args.day);
+      startOfDay.setHours(0, 0, 0, 0);
+
+      const endOfDay = new Date(args.day);
+      endOfDay.setHours(23, 59, 59, 999);
+
+      logger.info("[Admin] Checking conversations for day");
+
+      // Fetch all conversations for the day from Intercom
+      const convosOnIntercom = [];
+      let cursor = null;
+      let convosOnIntercomRes;
+
+      do {
+        convosOnIntercomRes = await fetchIntercomConversationsForDay({
+          nangoConnectionId: connector.connectionId,
+          minCreatedAt: startOfDay.getTime() / 1000,
+          maxCreatedAt: endOfDay.getTime() / 1000,
+          cursor,
+          pageSize: 50,
+        });
+        convosOnIntercom.push(...convosOnIntercomRes.conversations);
+        cursor = convosOnIntercomRes.pages.next
+          ? convosOnIntercomRes.pages.next.starting_after
+          : null;
+      } while (cursor);
+
+      // Fetch all conversations for the day from DB
+      const convosOnDB = await IntercomConversation.findAll({
+        where: {
+          connectorId,
+          conversationCreatedAt: {
+            [Op.gte]: startOfDay,
+            [Op.lte]: endOfDay,
+          },
+        },
+      });
+
+      // Get missing conversations in DB
+      const missingConversations = convosOnIntercom.filter(
+        (convo) =>
+          !convosOnDB.some((c) => c.conversationId === convo.id.toString())
+      );
+
+      return {
+        missingConversations: missingConversations.map((convo) => ({
+          conversationId: convo.id,
+          teamId: convo.team_assignee_id,
+          open: convo.open,
+          createdAt: convo.created_at,
+        })),
+      };
+    }
+    case "check-teams": {
+      logger.info("[Admin] Checking teams");
+
+      const teamsOnIntercom = await fetchIntercomTeams(connector.connectionId);
+      const teamsOnDb = await IntercomTeam.findAll({
+        where: {
+          connectorId,
+        },
+      });
+
+      return {
+        teams: teamsOnIntercom.map((team) => ({
+          teamId: team.id,
+          name: team.name,
+          isTeamOnDB: teamsOnDb.some((t) => t.teamId === team.id),
+        })),
+      };
+    }
+  }
+};
+
 export async function runCommand(adminCommand: AdminCommandType) {
   switch (adminCommand.majorCommand) {
     case "connectors":
@@ -1227,6 +1397,8 @@ export async function runCommand(adminCommand: AdminCommandType) {
       return webcrawler(adminCommand);
     case "temporal":
       return temporal(adminCommand);
+    case "intercom":
+      return intercom(adminCommand);
     default:
       assertNever(adminCommand);
   }

--- a/types/src/connectors/admin/cli.ts
+++ b/types/src/connectors/admin/cli.ts
@@ -99,6 +99,69 @@ export const TemporalCommandSchema = t.type({
 
 export type TemporalCommandType = t.TypeOf<typeof TemporalCommandSchema>;
 
+/**
+ * <Intercom>
+ */
+export const IntercomCommandSchema = t.type({
+  majorCommand: t.literal("intercom"),
+  command: t.union([
+    t.literal("check-conversation"),
+    t.literal("fetch-conversation"),
+    t.literal("check-missing-conversations"),
+    t.literal("check-teams"),
+  ]),
+  args: t.type({
+    connectorId: t.number,
+    conversationId: t.union([t.string, t.undefined]),
+    day: t.union([t.string, t.undefined]),
+  }),
+});
+
+export type IntercomCommandType = t.TypeOf<typeof IntercomCommandSchema>;
+export const IntercomCheckConversationResponseSchema = t.type({
+  isConversationOnIntercom: t.boolean,
+  isConversationOnDB: t.boolean,
+  conversationTeamIdOnIntercom: t.union([t.string, t.undefined]),
+  conversationTeamIdOnDB: t.union([t.string, t.undefined]),
+});
+export type IntercomCheckConversationResponseType = t.TypeOf<
+  typeof IntercomCheckConversationResponseSchema
+>;
+export const IntercomFetchConversationResponseSchema = t.type({
+  conversation: t.union([t.UnknownRecord, t.null]), // intercom type, can't be iots'd
+});
+export type IntercomFetchConversationResponseType = t.TypeOf<
+  typeof IntercomFetchConversationResponseSchema
+>;
+export const IntercomCheckTeamsResponseSchema = t.type({
+  teams: t.array(
+    t.type({
+      teamId: t.string,
+      name: t.string,
+      isTeamOnDB: t.boolean,
+    })
+  ),
+});
+export type IntercomCheckTeamsResponseType = t.TypeOf<
+  typeof IntercomCheckTeamsResponseSchema
+>;
+export const IntercomCheckMissingConversationsResponseSchema = t.type({
+  missingConversations: t.array(
+    t.type({
+      conversationId: t.string,
+      teamId: t.union([t.number, t.null]),
+      open: t.boolean,
+      createdAt: t.number,
+    })
+  ),
+});
+export type IntercomCheckMissingConversationsResponseType = t.TypeOf<
+  typeof IntercomCheckMissingConversationsResponseSchema
+>;
+/**
+ * </ Intercom>
+ */
+
 export const AdminCommandSchema = t.union([
   ConnectorsCommandSchema,
   GithubCommandSchema,
@@ -108,6 +171,7 @@ export const AdminCommandSchema = t.union([
   BatchCommandSchema,
   WebcrawlerCommandSchema,
   TemporalCommandSchema,
+  IntercomCommandSchema,
 ]);
 
 export type AdminCommandType = t.TypeOf<typeof AdminCommandSchema>;
@@ -227,6 +291,10 @@ export const AdminResponseSchema = t.union([
   GoogleDriveCheckFileResponseSchema,
   TemporalCheckQueueResponseSchema,
   TemporalUnprocessedWorkflowsResponseSchema,
+  IntercomCheckConversationResponseSchema,
+  IntercomFetchConversationResponseSchema,
+  IntercomCheckTeamsResponseSchema,
+  IntercomCheckMissingConversationsResponseSchema,
 ]);
 
 export type AdminResponseType = t.TypeOf<typeof AdminResponseSchema>;


### PR DESCRIPTION
## Description

Adds some cli commands for Intercom:
- Check the list of teams on Intercom and the one the admin gaves us read permission.
- Check the list of conversations id on Intercom for a given day and returns the ones not in db (might be heavy if a workspace has thousands convo a day but problem for later).
- Check the state of a given conversation (it is on Intercom, is it on db)
- Fetch a conversation from Intercom.

```
./admin/cli.sh intercom check-teams --connectorId=74
./admin/cli.sh intercom check-missing-conversations --connectorId=74 --day=2024-04-03
./admin/cli.sh intercom check-conversation --connectorId=74 --conversationId=3
./admin/cli.sh intercom fetch-conversation --connectorId=74 --conversationId=3

```

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
