### PR TITLE
Introduce sId on User and MembershipInvitation

### DIFF
--- a/front/lib/api/invitation.ts
+++ b/front/lib/api/invitation.ts
@@ -11,8 +11,7 @@ import { sign } from "jsonwebtoken";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
 import { MembershipInvitation } from "@app/lib/models";
-
-import { generateModelSId } from "../utils";
+import { generateModelSId } from "@app/lib/utils";
 
 sgMail.setApiKey(config.getSendgridApiKey());
 

--- a/front/lib/api/invitation.ts
+++ b/front/lib/api/invitation.ts
@@ -12,6 +12,8 @@ import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
 import { MembershipInvitation } from "@app/lib/models";
 
+import { generateModelSId } from "../utils";
+
 sgMail.setApiKey(config.getSendgridApiKey());
 
 function typeFromModel(
@@ -48,6 +50,7 @@ export async function updateOrCreateInvitation(
 
   return typeFromModel(
     await MembershipInvitation.create({
+      sId: generateModelSId(),
       workspaceId: owner.id,
       inviteEmail: sanitizeString(inviteEmail),
       status: "pending",

--- a/front/lib/iam/users.ts
+++ b/front/lib/iam/users.ts
@@ -6,8 +6,7 @@ import { trackSignup } from "@app/lib/amplitude/node";
 import type { ExternalUser, SessionWithUser } from "@app/lib/iam/provider";
 import { User } from "@app/lib/models/user";
 import { guessFirstandLastNameFromFullName } from "@app/lib/user";
-
-import { generateModelSId } from "../utils";
+import { generateModelSId } from "@app/lib/utils";
 
 interface LegacyProviderInfo {
   provider: UserProviderType;

--- a/front/lib/iam/users.ts
+++ b/front/lib/iam/users.ts
@@ -130,6 +130,7 @@ export async function createOrUpdateUser(
     );
 
     const u = await User.create({
+      sId: generateModelSId(),
       auth0Sub: externalUser.sub,
       provider: mapAuth0ProviderToLegacy(session)?.provider,
       username: externalUser.nickname,

--- a/front/lib/iam/users.ts
+++ b/front/lib/iam/users.ts
@@ -7,6 +7,8 @@ import type { ExternalUser, SessionWithUser } from "@app/lib/iam/provider";
 import { User } from "@app/lib/models/user";
 import { guessFirstandLastNameFromFullName } from "@app/lib/user";
 
+import { generateModelSId } from "../utils";
+
 interface LegacyProviderInfo {
   provider: UserProviderType;
   providerId: number | string;

--- a/front/lib/models/user.ts
+++ b/front/lib/models/user.ts
@@ -17,6 +17,7 @@ export class User extends Model<
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
+  declare sId: string;
   declare auth0Sub: string | null;
   declare provider: UserProviderType;
   declare providerId: string | null;
@@ -46,6 +47,10 @@ User.init(
       type: DataTypes.DATE,
       allowNull: false,
       defaultValue: DataTypes.NOW,
+    },
+    sId: {
+      type: DataTypes.STRING,
+      allowNull: true,
     },
     provider: {
       type: DataTypes.STRING,
@@ -97,6 +102,7 @@ User.init(
       { fields: ["username"] },
       { fields: ["provider", "providerId"] },
       { fields: ["auth0Sub"], unique: true, concurrently: true },
+      { unique: true, fields: ["sId"] },
     ],
   }
 );

--- a/front/lib/models/workspace.ts
+++ b/front/lib/models/workspace.ts
@@ -135,6 +135,7 @@ export class MembershipInvitation extends Model<
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
+  declare sId: string;
   declare inviteEmail: string;
   declare status: "pending" | "consumed" | "revoked";
   declare initialRole: Exclude<RoleType, "none">;
@@ -158,6 +159,10 @@ MembershipInvitation.init(
       type: DataTypes.DATE,
       allowNull: false,
       defaultValue: DataTypes.NOW,
+    },
+    sId: {
+      type: DataTypes.STRING,
+      allowNull: true,
     },
     inviteEmail: {
       type: DataTypes.STRING,
@@ -184,7 +189,10 @@ MembershipInvitation.init(
   {
     modelName: "membership_invitation",
     sequelize: frontSequelize,
-    indexes: [{ fields: ["workspaceId", "status"] }],
+    indexes: [
+      { fields: ["workspaceId", "status"] },
+      { unique: true, fields: ["sId"] },
+    ],
   }
 );
 Workspace.hasMany(MembershipInvitation, {

--- a/front/migrations/20240404_backfill_users_and_invitations_sid.ts
+++ b/front/migrations/20240404_backfill_users_and_invitations_sid.ts
@@ -1,0 +1,63 @@
+import { MembershipInvitation, User } from "@app/lib/models";
+import { generateModelSId } from "@app/lib/utils";
+import logger from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+
+const backfillUsers = async (execute: boolean) => {
+  const users = await User.findAll({});
+
+  const chunks: User[][] = [];
+  for (let i = 0; i < users.length; i += 16) {
+    chunks.push(users.slice(i, i + 16));
+  }
+
+  for (let i = 0; i < chunks.length; i++) {
+    const chunk = chunks[i];
+    await Promise.all(
+      chunk.map((u) => {
+        return (async () => {
+          const sId = generateModelSId();
+          logger.info(
+            `Backfilling user ${u.id} with \`sId=${sId}\` [execute: ${execute}]`
+          );
+
+          if (execute) {
+            await u.update({ sId });
+          }
+        })();
+      })
+    );
+  }
+};
+
+const backfillInvitations = async (execute: boolean) => {
+  const invitations = await MembershipInvitation.findAll({});
+
+  const chunks: MembershipInvitation[][] = [];
+  for (let i = 0; i < invitations.length; i += 16) {
+    chunks.push(invitations.slice(i, i + 16));
+  }
+
+  for (let i = 0; i < chunks.length; i++) {
+    const chunk = chunks[i];
+    await Promise.all(
+      chunk.map((i) => {
+        return (async () => {
+          const sId = generateModelSId();
+          logger.info(
+            `Backfilling invitation ${i.id} with \`sId=${sId}\` [execute: ${execute}]`
+          );
+
+          if (execute) {
+            await i.update({ sId });
+          }
+        })();
+      })
+    );
+  }
+};
+
+makeScript({}, async ({ execute }) => {
+  await backfillUsers(execute);
+  await backfillInvitations(execute);
+});


### PR DESCRIPTION
## Description

- Adds `sId` to both User and MembershipInvitation (null OK for now)
- Introduce migration to backfill the values

The goal is to avoid any route relying on ModelId in `front`

Follow-up PR will rely on sId for the route.

## Risk

Low if deploy plan is followed.

## Deploy Plan

- deploy to prodbox
- run init_db for `front`
- run migration
- deploy front