### PR TITLE
Invitation revocation sId refactor

### DIFF
--- a/front/lib/api/invitation.ts
+++ b/front/lib/api/invitation.ts
@@ -27,13 +27,14 @@ function typeFromModel(
   };
 }
 
-export async function getInvitation({
-  auth,
-  invitationId,
-}: {
-  auth: Authenticator;
-  invitationId: string;
-}): Promise<MembershipInvitationType | null> {
+export async function getInvitation(
+  auth: Authenticator,
+  {
+    invitationId,
+  }: {
+    invitationId: string;
+  }
+): Promise<MembershipInvitationType | null> {
   const owner = auth.workspace();
   if (!owner || !auth.isAdmin()) {
     return null;
@@ -53,15 +54,16 @@ export async function getInvitation({
   return typeFromModel(invitation);
 }
 
-export async function updateInvitationStatus({
-  auth,
-  invitation,
-  status,
-}: {
-  auth: Authenticator;
-  invitation: MembershipInvitationType;
-  status: "pending" | "consumed" | "revoked";
-}): Promise<MembershipInvitationType> {
+export async function updateInvitationStatus(
+  auth: Authenticator,
+  {
+    invitation,
+    status,
+  }: {
+    invitation: MembershipInvitationType;
+    status: "pending" | "consumed" | "revoked";
+  }
+): Promise<MembershipInvitationType> {
   const owner = auth.workspace();
   if (!owner || !auth.isAdmin()) {
     throw new Error("Unauthorized attempt to update invitation status.");

--- a/front/lib/api/invitation.ts
+++ b/front/lib/api/invitation.ts
@@ -4,7 +4,7 @@ import type {
   UserType,
   WorkspaceType,
 } from "@dust-tt/types";
-import { sanitizeString } from "@dust-tt/types";
+import { Err, sanitizeString } from "@dust-tt/types";
 import sgMail from "@sendgrid/mail";
 import { sign } from "jsonwebtoken";
 
@@ -19,11 +19,68 @@ function typeFromModel(
   invitation: MembershipInvitation
 ): MembershipInvitationType {
   return {
+    sId: invitation.sId,
     id: invitation.id,
     inviteEmail: invitation.inviteEmail,
     status: invitation.status,
     initialRole: invitation.initialRole,
   };
+}
+
+export async function getInvitation({
+  auth,
+  invitationId,
+}: {
+  auth: Authenticator;
+  invitationId: string;
+}): Promise<MembershipInvitationType | null> {
+  const owner = auth.workspace();
+  if (!owner || !auth.isAdmin()) {
+    return null;
+  }
+
+  const invitation = await MembershipInvitation.findOne({
+    where: {
+      workspaceId: owner.id,
+      sId: invitationId,
+    },
+  });
+
+  if (!invitation) {
+    return null;
+  }
+
+  return typeFromModel(invitation);
+}
+
+export async function updateInvitationStatus({
+  auth,
+  invitation,
+  status,
+}: {
+  auth: Authenticator;
+  invitation: MembershipInvitationType;
+  status: "pending" | "consumed" | "revoked";
+}): Promise<MembershipInvitationType> {
+  const owner = auth.workspace();
+  if (!owner || !auth.isAdmin()) {
+    throw new Error("Unauthorized attempt to update invitation status.");
+  }
+
+  const existingInvitation = await MembershipInvitation.findOne({
+    where: {
+      workspaceId: owner.id,
+      id: invitation.id,
+    },
+  });
+
+  if (!existingInvitation) {
+    throw new Err("Invitaion unexpectedly not found.");
+  }
+
+  await existingInvitation.update({ status });
+
+  return typeFromModel(existingInvitation);
 }
 
 export async function updateOrCreateInvitation(
@@ -56,41 +113,6 @@ export async function updateOrCreateInvitation(
       initialRole,
     })
   );
-}
-
-export async function updateInvitation(
-  owner: WorkspaceType,
-  id: number,
-  status: "pending" | "consumed" | "revoked"
-): Promise<MembershipInvitationType> {
-  const invitation = await MembershipInvitation.findOne({
-    where: {
-      id,
-      workspaceId: owner.id,
-    },
-  });
-
-  if (!invitation) {
-    throw new Error("Invitation not found");
-  }
-
-  await invitation.update({
-    status,
-  });
-
-  return typeFromModel(invitation);
-}
-
-export async function deleteInvitation(
-  owner: WorkspaceType,
-  id: number
-): Promise<void> {
-  await MembershipInvitation.destroy({
-    where: {
-      id,
-      workspaceId: owner.id,
-    },
-  });
 }
 
 export async function sendWorkspaceInvitationEmail(
@@ -146,6 +168,7 @@ export async function getPendingInvitations(
 
   return invitations.map((i) => {
     return {
+      sId: i.sId,
       id: i.id,
       status: i.status,
       inviteEmail: i.inviteEmail,

--- a/front/lib/models/user.ts
+++ b/front/lib/models/user.ts
@@ -50,7 +50,7 @@ User.init(
     },
     sId: {
       type: DataTypes.STRING,
-      allowNull: true,
+      allowNull: false,
     },
     provider: {
       type: DataTypes.STRING,

--- a/front/lib/models/workspace.ts
+++ b/front/lib/models/workspace.ts
@@ -162,7 +162,7 @@ MembershipInvitation.init(
     },
     sId: {
       type: DataTypes.STRING,
-      allowNull: true,
+      allowNull: false,
     },
     inviteEmail: {
       type: DataTypes.STRING,

--- a/front/pages/api/w/[wId]/invitations/[iId]/index.ts
+++ b/front/pages/api/w/[wId]/invitations/[iId]/index.ts
@@ -62,7 +62,7 @@ async function handler(
   }
 
   const invitationId = req.query.iId;
-  let invitation = await getInvitation({ auth, invitationId });
+  let invitation = await getInvitation(auth, { invitationId });
   if (!invitation) {
     return apiError(req, res, {
       status_code: 404,
@@ -88,8 +88,7 @@ async function handler(
       }
       const body = bodyValidation.right;
 
-      invitation = await updateInvitationStatus({
-        auth,
+      invitation = await updateInvitationStatus(auth, {
         invitation,
         status: body.status,
       });

--- a/front/pages/api/w/[wId]/invitations/[iId]/index.ts
+++ b/front/pages/api/w/[wId]/invitations/[iId]/index.ts
@@ -2,19 +2,26 @@ import type {
   MembershipInvitationType,
   WithAPIErrorReponse,
 } from "@dust-tt/types";
+import { isLeft } from "fp-ts/lib/Either";
+import * as t from "io-ts";
+import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import { getInvitation, updateInvitationStatus } from "@app/lib/api/invitation";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { MembershipInvitation } from "@app/lib/models";
 import { apiError, withLogging } from "@app/logger/withlogging";
 
-export type GetMemberInvitationsResponseBody = {
-  invitations: MembershipInvitationType[];
+export type PostMemberInvitationsResponseBody = {
+  invitation: MembershipInvitationType;
 };
+
+export const PostMemberInvitationBodySchema = t.type({
+  status: t.literal("revoked"),
+});
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorReponse<GetMemberInvitationsResponseBody>>
+  res: NextApiResponse<WithAPIErrorReponse<PostMemberInvitationsResponseBody>>
 ): Promise<void> {
   const session = await getSession(req, res);
   const auth = await Authenticator.fromSession(
@@ -44,8 +51,19 @@ async function handler(
     });
   }
 
-  const invitationId = parseInt(req.query.invitationId as string);
-  if (isNaN(invitationId)) {
+  if (!(typeof req.query.iId === "string")) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid query parameters, `iId` (string) is required.",
+      },
+    });
+  }
+
+  const invitationId = req.query.iId;
+  let invitation = await getInvitation({ auth, invitationId });
+  if (!invitation) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
@@ -57,47 +75,27 @@ async function handler(
 
   switch (req.method) {
     case "POST":
-      if (
-        !req.body ||
-        !typeof (req.body.status === "string") ||
-        // For now we only allow revoking invitations.
-        req.body.status !== "revoked"
-      ) {
+      const bodyValidation = PostMemberInvitationBodySchema.decode(req.body);
+      if (isLeft(bodyValidation)) {
+        const pathError = reporter.formatValidationErrors(bodyValidation.left);
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message:
-              'The request body is invalid, expects { status: "revoked" }.',
+            message: `The request body is invalid: ${pathError}`,
           },
         });
       }
+      const body = bodyValidation.right;
 
-      const invitation = await MembershipInvitation.findOne({
-        where: { id: invitationId },
+      invitation = await updateInvitationStatus({
+        auth,
+        invitation,
+        status: body.status,
       });
 
-      if (!invitation) {
-        return apiError(req, res, {
-          status_code: 404,
-          api_error: {
-            type: "invitation_not_found",
-            message: "The invitation requested was not found.",
-          },
-        });
-      }
-
-      invitation.status = req.body.status;
-      await invitation.save();
       res.status(200).json({
-        invitations: [
-          {
-            id: invitation.id,
-            status: invitation.status,
-            inviteEmail: invitation.inviteEmail,
-            initialRole: invitation.initialRole,
-          },
-        ],
+        invitation,
       });
       return;
 

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -809,7 +809,7 @@ function RevokeInvitationModal({
     invitation: MembershipInvitationType
   ): Promise<void> {
     const res = await fetch(
-      `/api/w/${owner.sId}/invitations/${invitation.id}`,
+      `/api/w/${owner.sId}/invitations/${invitation.sId}`,
       {
         method: "POST",
         headers: {

--- a/types/src/front/membership_invitation.ts
+++ b/types/src/front/membership_invitation.ts
@@ -2,6 +2,7 @@ import { ModelId } from "../shared/model_id";
 import { ActiveRoleType } from "./user";
 
 export type MembershipInvitationType = {
+  sId: string;
   id: ModelId;
   status: "pending" | "consumed" | "revoked";
   inviteEmail: string;


### PR DESCRIPTION
## Description

Move to use `sId` in membership invitations (revocation route). Also move the route to iots + better lib/api handling.

## Risk

N/A (tested locally)

## Deploy Plan

- deploy `front`
- run `init_db.sh`