### PR TITLE
Intercom cli: Fix type for arg conversationId

### DIFF
--- a/types/src/connectors/admin/cli.ts
+++ b/types/src/connectors/admin/cli.ts
@@ -112,7 +112,7 @@ export const IntercomCommandSchema = t.type({
   ]),
   args: t.type({
     connectorId: t.number,
-    conversationId: t.union([t.string, t.undefined]),
+    conversationId: t.union([t.number, t.undefined]),
     day: t.union([t.string, t.undefined]),
   }),
 });


### PR DESCRIPTION
## Description

Arg conversationId for Intercom cli commands is a number not a string.

## Risk

None.

## Deploy Plan

Nothing special required. 
