### PR TITLE
Add `sId` to UserType + move user route to use `sId`

### DIFF
--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -87,6 +87,7 @@ export async function batchRenderUserMessages(
       created: message.createdAt.getTime(),
       user: user
         ? {
+            sId: user.sId,
             id: user.id,
             createdAt: user.createdAt.getTime(),
             username: user.username,

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -151,6 +151,7 @@ export async function getMembers(
     }
 
     return {
+      sId: u.sId,
       id: u.id,
       createdAt: u.createdAt.getTime(),
       provider: u.provider,

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -426,6 +426,7 @@ export class Authenticator {
   user(): UserType | null {
     return this._user
       ? {
+          sId: this._user.sId,
           id: this._user.id,
           createdAt: this._user.createdAt.getTime(),
           provider: this._user.provider,

--- a/front/lib/iam/session.ts
+++ b/front/lib/iam/session.ts
@@ -48,6 +48,7 @@ export async function getUserFromSession(
   await maybeUpdateFromExternalUser(user, session.user);
 
   return {
+    sId: user.sId,
     id: user.id,
     createdAt: user.createdAt.getTime(),
     provider: user.provider,

--- a/front/lib/iam/users.ts
+++ b/front/lib/iam/users.ts
@@ -142,6 +142,7 @@ export async function createOrUpdateUser(
     });
 
     trackSignup({
+      sId: u.sId,
       id: u.id,
       createdAt: u.createdAt.getTime(),
       provider: u.provider,

--- a/front/pages/api/w/[wId]/invitations/[iId]/index.ts
+++ b/front/pages/api/w/[wId]/invitations/[iId]/index.ts
@@ -51,7 +51,8 @@ async function handler(
     });
   }
 
-  if (!(typeof req.query.iId === "string")) {
+  const invitationId = req.query.iId;
+  if (!(typeof invitationId === "string")) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
@@ -61,7 +62,7 @@ async function handler(
     });
   }
 
-  let invitation = await getInvitation(auth, { invitationId: req.query.iId });
+  let invitation = await getInvitation(auth, { invitationId });
   if (!invitation) {
     return apiError(req, res, {
       status_code: 404,

--- a/front/pages/api/w/[wId]/invitations/[iId]/index.ts
+++ b/front/pages/api/w/[wId]/invitations/[iId]/index.ts
@@ -61,8 +61,7 @@ async function handler(
     });
   }
 
-  const invitationId = req.query.iId;
-  let invitation = await getInvitation(auth, { invitationId });
+  let invitation = await getInvitation(auth, { invitationId: req.query.iId });
   if (!invitation) {
     return apiError(req, res, {
       status_code: 404,

--- a/front/pages/api/w/[wId]/members/[uId]/index.ts
+++ b/front/pages/api/w/[wId]/members/[uId]/index.ts
@@ -47,7 +47,8 @@ async function handler(
     });
   }
 
-  if (!(typeof req.query.uId === "string")) {
+  const userId = req.query.uId;
+  if (!(typeof userId === "string")) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
@@ -57,7 +58,7 @@ async function handler(
     });
   }
 
-  const user = await getUserForWorkspace(auth, { userId: req.query.uId });
+  const user = await getUserForWorkspace(auth, { userId });
   if (!user) {
     return apiError(req, res, {
       status_code: 404,

--- a/front/pages/api/w/[wId]/members/[uId]/index.ts
+++ b/front/pages/api/w/[wId]/members/[uId]/index.ts
@@ -1,15 +1,18 @@
-import type { UserType, WithAPIErrorReponse } from "@dust-tt/types";
+import type {
+  UserTypeWithWorkspaces,
+  WithAPIErrorReponse,
+} from "@dust-tt/types";
 import { assertNever, isMembershipRoleType } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import { getUserForWorkspace } from "@app/lib/api/user";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { User } from "@app/lib/models";
 import { updateWorkspacePerSeatSubscriptionUsage } from "@app/lib/plans/subscription";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { apiError, withLogging } from "@app/logger/withlogging";
 
 export type PostMemberResponseBody = {
-  member: UserType;
+  member: UserTypeWithWorkspaces;
 };
 
 async function handler(
@@ -44,30 +47,18 @@ async function handler(
     });
   }
 
-  const userId = parseInt(req.query.userId as string);
-  if (isNaN(userId)) {
+  if (!(typeof req.query.uId === "string")) {
     return apiError(req, res, {
-      status_code: 404,
+      status_code: 400,
       api_error: {
-        type: "workspace_user_not_found",
-        message: "The user requested was not found.",
+        type: "invalid_request_error",
+        message: "Invalid query parameters, `uId` (string) is required.",
       },
     });
   }
 
-  const [user, membership] = await Promise.all([
-    User.findOne({
-      where: {
-        id: userId,
-      },
-    }),
-    MembershipResource.getLatestMembershipOfUserInWorkspace({
-      userId,
-      workspace: owner,
-    }),
-  ]);
-
-  if (!user || !membership) {
+  const user = await getUserForWorkspace(auth, { userId: req.query.uId });
+  if (!user) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
@@ -82,7 +73,7 @@ async function handler(
       // TODO(@fontanierh): use DELETE for revoking membership
       if (req.body.role === "revoked") {
         const revokeResult = await MembershipResource.revokeMembership({
-          userId,
+          userId: user.id,
           workspace: owner,
         });
         if (revokeResult.isErr()) {
@@ -119,7 +110,7 @@ async function handler(
           });
         }
         const updateRoleResult = await MembershipResource.updateMembershipRole({
-          userId,
+          userId: user.id,
           workspace: owner,
           newRole: role,
           // We allow to re-activate a terminated membership when updating the role here.
@@ -162,15 +153,7 @@ async function handler(
       }
 
       const member = {
-        id: user.id,
-        createdAt: user.createdAt.getTime(),
-        provider: user.provider,
-        username: user.username,
-        email: user.email,
-        firstName: user.firstName,
-        lastName: user.lastName,
-        fullName: user.firstName + (user.lastName ? ` ${user.lastName}` : ""),
-        image: null,
+        ...user,
         workspaces: [w],
       };
 

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -884,7 +884,7 @@ async function handleMembersRoleChange({
   sendNotification: any;
 }): Promise<void> {
   const promises = members.map((member) =>
-    fetch(`/api/w/${member.workspaces[0].sId}/members/${member.id}`, {
+    fetch(`/api/w/${member.workspaces[0].sId}/members/${member.sId}`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/types/src/front/user.ts
+++ b/types/src/front/user.ts
@@ -41,6 +41,7 @@ export type WorkspaceType = LightWorkspaceType & {
 export type UserProviderType = "github" | "google" | null;
 
 export type UserType = {
+  sId: string;
   id: ModelId;
   createdAt: number;
   provider: UserProviderType;


### PR DESCRIPTION
## Description

- Add `sId` to UserType
- Move `pages/api/w/[wId]/members/[uId]/index` to using sId instead of ModelId
- Refactor implementation to use a new `lib/api/user.ts` `getUserForWorkspace`
- Update call-sites

## Risk

High-ish given that it touches UserType. Mitigated by local tests of touched route (members role change) and general login

Tested:
- Login
- Invite by email
- Change role
- Run a conversation

## Deploy Plan

- deploy `front`