### PR TITLE
Enhance external image hosting in agent configuration

### DIFF
--- a/front/components/assistant_builder/AssistantBuilderAvatarPicker.tsx
+++ b/front/components/assistant_builder/AssistantBuilderAvatarPicker.tsx
@@ -194,6 +194,7 @@ export function AvatarPicker({
         style={{ display: "none" }}
         onChange={onFileChange}
         ref={fileInputRef}
+        accept=".png,.jpg,.jpeg"
       />
 
       <div className="h-full w-full overflow-visible">

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -756,6 +756,11 @@ export async function getAgentNames(auth: Authenticator): Promise<string[]> {
 }
 
 async function isSelfHostedImageWithValidContentType(pictureUrl: string) {
+  // Accept static Dust avatars.
+  if (pictureUrl.startsWith("https://dust.tt/static/")) {
+    return true;
+  }
+
   const filename = pictureUrl.split("/").at(-1);
   if (!filename) {
     return false;

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -34,7 +34,7 @@ import { agentConfigurationWasUpdatedBy } from "@app/lib/api/assistant/recent_au
 import { agentUserListStatus } from "@app/lib/api/assistant/user_relation";
 import { compareAgentsForSort } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
-import { getFileContentType, getPublicUploadBucket } from "@app/lib/dfs";
+import { getFileContentType } from "@app/lib/dfs";
 import {
   AgentConfiguration,
   AgentDataSourceConfiguration,

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -34,7 +34,7 @@ import { agentConfigurationWasUpdatedBy } from "@app/lib/api/assistant/recent_au
 import { agentUserListStatus } from "@app/lib/api/assistant/user_relation";
 import { compareAgentsForSort } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
-import { getFileContentType } from "@app/lib/dfs";
+import { getPublicUploadBucket } from "@app/lib/dfs";
 import {
   AgentConfiguration,
   AgentDataSourceConfiguration,
@@ -761,7 +761,9 @@ async function isSelfHostedImageWithValidContentType(pictureUrl: string) {
     return false;
   }
 
-  const contentType = await getFileContentType("PUBLIC_UPLOAD", filename);
+  const contentType = await getPublicUploadBucket().getFileContentType(
+    filename
+  );
   if (!contentType) {
     return false;
   }

--- a/front/lib/dfs/config.ts
+++ b/front/lib/dfs/config.ts
@@ -4,8 +4,11 @@ const config = {
   getServiceAccount: (): string => {
     return EnvironmentConfig.getEnvVariable("SERVICE_ACCOUNT");
   },
-  getPublicUploadBucket: (): string => {
+  getGcsPublicUploadBucket: (): string => {
     return EnvironmentConfig.getEnvVariable("DUST_UPLOAD_BUCKET");
+  },
+  getGcsPrivateUploadsBucket: (): string => {
+    return EnvironmentConfig.getEnvVariable("DUST_PRIVATE_UPLOADS_BUCKET");
   },
 };
 

--- a/front/lib/dfs/config.ts
+++ b/front/lib/dfs/config.ts
@@ -1,0 +1,12 @@
+import { EnvironmentConfig } from "@dust-tt/types";
+
+const config = {
+  getServiceAccount: (): string => {
+    return EnvironmentConfig.getEnvVariable("SERVICE_ACCOUNT");
+  },
+  getPublicUploadBucket: (): string => {
+    return EnvironmentConfig.getEnvVariable("DUST_UPLOAD_BUCKET");
+  },
+};
+
+export default config;

--- a/front/lib/dfs/index.ts
+++ b/front/lib/dfs/index.ts
@@ -15,10 +15,6 @@ const bucketKeysToBucket: Record<SupportedBucketKeyType, Bucket> = {
   PUBLIC_UPLOAD: storage.bucket(config.getPublicUploadBucket()),
 };
 
-export function getPublicUploadBucket() {
-  return storage.bucket(config.getPublicUploadBucket());
-}
-
 export async function uploadToBucket(
   bucketKey: SupportedBucketKeyType,
   file: formidable.File

--- a/front/lib/dfs/index.ts
+++ b/front/lib/dfs/index.ts
@@ -2,51 +2,91 @@ import type { Bucket } from "@google-cloud/storage";
 import { Storage } from "@google-cloud/storage";
 import type formidable from "formidable";
 import fs from "fs";
+import { pipeline } from "stream/promises";
 
 import config from "@app/lib/dfs/config";
 
-type SupportedBucketKeyType = "PUBLIC_UPLOAD";
+type BucketKeyType = "PRIVATE_UPLOAD" | "PUBLIC_UPLOAD";
 
 const storage = new Storage({
   keyFilename: config.getServiceAccount(),
 });
 
-const bucketKeysToBucket: Record<SupportedBucketKeyType, Bucket> = {
-  PUBLIC_UPLOAD: storage.bucket(config.getPublicUploadBucket()),
+const bucketKeysToBucket: Record<BucketKeyType, Bucket> = {
+  PRIVATE_UPLOAD: storage.bucket(config.getGcsPrivateUploadsBucket()),
+  PUBLIC_UPLOAD: storage.bucket(config.getGcsPublicUploadBucket()),
 };
 
-export async function uploadToBucket(
-  bucketKey: SupportedBucketKeyType,
-  file: formidable.File
-) {
-  const bucket = bucketKeysToBucket[bucketKey];
+class DFS {
+  private readonly bucket: Bucket;
 
-  const gcsFile = bucket.file(file.newFilename);
-  const fileStream = fs.createReadStream(file.filepath);
+  constructor(bucketKey: BucketKeyType) {
+    this.bucket = bucketKeysToBucket[bucketKey];
+  }
 
-  return new Promise((resolve, reject) =>
-    fileStream
-      .pipe(
-        gcsFile.createWriteStream({
-          metadata: {
-            contentType: file.mimetype,
-          },
-        })
-      )
-      .on("error", reject)
-      .on("finish", () => resolve(gcsFile))
-  );
+  /**
+   * Upload functions.
+   */
+
+  async uploadFileToBucket(file: formidable.File, destPath: string) {
+    const gcsFile = this.file(destPath);
+    const fileStream = fs.createReadStream(file.filepath);
+
+    await pipeline(
+      fileStream,
+      gcsFile.createWriteStream({
+        metadata: {
+          contentType: file.mimetype,
+        },
+      })
+    );
+  }
+
+  async uploadRawContentToBucket({
+    content,
+    contentType,
+    filePath,
+  }: {
+    content: string;
+    contentType: string;
+    filePath: string;
+  }) {
+    const gcsFile = this.file(filePath);
+
+    await gcsFile.save(content, {
+      contentType,
+    });
+  }
+
+  /**
+   * Download functions.
+   */
+
+  async fetchFileContent(filePath: string) {
+    const gcsFile = this.file(filePath);
+
+    const [content] = await gcsFile.download();
+
+    return content.toString();
+  }
+
+  async getFileContentType(filename: string): Promise<string | null> {
+    const gcsFile = this.file(filename);
+
+    const [metadata] = await gcsFile.getMetadata();
+
+    return metadata.contentType;
+  }
+
+  file(filename: string) {
+    return this.bucket.file(filename);
+  }
+
+  get name() {
+    return this.bucket.name;
+  }
 }
 
-export async function getFileContentType(
-  bucketKey: SupportedBucketKeyType,
-  filename: string
-): Promise<string | null> {
-  const bucket = bucketKeysToBucket[bucketKey];
+export const getPrivateUploadBucket = () => new DFS("PRIVATE_UPLOAD");
 
-  const gcsFile = bucket.file(filename);
-
-  const [metadata] = await gcsFile.getMetadata();
-
-  return metadata.contentType;
-}
+export const getPublicUploadBucket = () => new DFS("PUBLIC_UPLOAD");

--- a/front/lib/dfs/index.ts
+++ b/front/lib/dfs/index.ts
@@ -1,0 +1,56 @@
+import type { Bucket } from "@google-cloud/storage";
+import { Storage } from "@google-cloud/storage";
+import type formidable from "formidable";
+import fs from "fs";
+
+import config from "@app/lib/dfs/config";
+
+type SupportedBucketKeyType = "PUBLIC_UPLOAD";
+
+const storage = new Storage({
+  keyFilename: config.getServiceAccount(),
+});
+
+const bucketKeysToBucket: Record<SupportedBucketKeyType, Bucket> = {
+  PUBLIC_UPLOAD: storage.bucket(config.getPublicUploadBucket()),
+};
+
+export function getPublicUploadBucket() {
+  return storage.bucket(config.getPublicUploadBucket());
+}
+
+export async function uploadToBucket(
+  bucketKey: SupportedBucketKeyType,
+  file: formidable.File
+) {
+  const bucket = bucketKeysToBucket[bucketKey];
+
+  const gcsFile = bucket.file(file.newFilename);
+  const fileStream = fs.createReadStream(file.filepath);
+
+  return new Promise((resolve, reject) =>
+    fileStream
+      .pipe(
+        gcsFile.createWriteStream({
+          metadata: {
+            contentType: file.mimetype,
+          },
+        })
+      )
+      .on("error", reject)
+      .on("finish", () => resolve(gcsFile))
+  );
+}
+
+export async function getFileContentType(
+  bucketKey: SupportedBucketKeyType,
+  filename: string
+): Promise<string | null> {
+  const bucket = bucketKeysToBucket[bucketKey];
+
+  const gcsFile = bucket.file(filename);
+
+  const [metadata] = await gcsFile.getMetadata();
+
+  return metadata.contentType;
+}

--- a/front/lib/resources/storage/config.ts
+++ b/front/lib/resources/storage/config.ts
@@ -5,9 +5,3 @@ export const dbConfig = {
     return EnvironmentConfig.getEnvVariable("FRONT_DATABASE_URI");
   },
 };
-
-export const gcsConfig = {
-  getGcsPrivateUploadsBucket: (): string => {
-    return EnvironmentConfig.getEnvVariable("DUST_PRIVATE_UPLOADS_BUCKET");
-  },
-};

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/avatar.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/avatar.ts
@@ -1,16 +1,16 @@
 import { IncomingForm } from "formidable";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { uploadToBucket } from "@app/lib/dfs";
+import { getPublicUploadBucket } from "@app/lib/dfs";
 import { withLogging } from "@app/logger/withlogging";
-
-const { DUST_UPLOAD_BUCKET = "" } = process.env;
 
 export const config = {
   api: {
     bodyParser: false, // Disabling Next.js's body parser as formidable has its own
   },
 };
+
+const publicUploadGcs = getPublicUploadBucket();
 
 async function handler(
   req: NextApiRequest,
@@ -41,9 +41,9 @@ async function handler(
 
       const [file] = maybeFiles;
 
-      await uploadToBucket("PUBLIC_UPLOAD", file);
+      await publicUploadGcs.uploadFileToBucket(file, file.newFilename);
 
-      const fileUrl = `https://storage.googleapis.com/${DUST_UPLOAD_BUCKET}/${file.newFilename}`;
+      const fileUrl = `https://storage.googleapis.com/${publicUploadGcs.name}/${file.newFilename}`;
 
       res.status(200).json({ fileUrl });
     } catch (error) {

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/avatar.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/avatar.ts
@@ -1,42 +1,16 @@
-import { Storage } from "@google-cloud/storage";
 import { IncomingForm } from "formidable";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { uploadToBucket } from "@app/lib/dfs";
 import { withLogging } from "@app/logger/withlogging";
 
-const { DUST_UPLOAD_BUCKET = "", SERVICE_ACCOUNT } = process.env;
+const { DUST_UPLOAD_BUCKET = "" } = process.env;
 
 export const config = {
   api: {
     bodyParser: false, // Disabling Next.js's body parser as formidable has its own
   },
 };
-
-export async function assertIsSelfHostedPictureUrl(pictureUrl: string) {
-  const isSelfHosted = pictureUrl.startsWith(
-    `https://storage.googleapis.com/${DUST_UPLOAD_BUCKET}/`
-  );
-
-  const storage = new Storage({
-    keyFilename: SERVICE_ACCOUNT,
-  });
-
-  const filename = pictureUrl.split("/").at(-1);
-  if (!filename) {
-    return false;
-  }
-
-  const bucket = storage.bucket(DUST_UPLOAD_BUCKET);
-  const gcsFile = await bucket.file(filename);
-
-  const [metadata] = await gcsFile.getMetadata();
-
-  const isImageContentType =
-    metadata.contentType && metadata.contentType.includes("image");
-
-  return isSelfHosted && isImageContentType;
-}
 
 async function handler(
   req: NextApiRequest,


### PR DESCRIPTION
## Description

This PR fixes https://github.com/dust-tt/dust/issues/4556.

This PR addresses a security issue by improving the way we handle image uploads. It ensures that uploaded files have an image* mimeType, are less than 3MB in size, and restricts the accepted file types in the file picker.

In the agent configuration creation, it verifies that the file is self-hosted on our GCS and has the proper mime type, or it will yield an error.

To make this solution more resilient in the future, this PR starts centralizing the DFS (Distributed File System) logic in one single place.

It also applies some refactoring to the existing logic of content fragment, to use the newly introduced `DFS` class.
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

Worst case it breaks avatar upload on agent configuration or the content fragment (uploading file, downloading file, ...), but it has been well tested locally.
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
