### PR TITLE
Fix: assistant picker broken if some assistant names > 20 chars

### DIFF
--- a/front/components/assistant/AssistantPicker.tsx
+++ b/front/components/assistant/AssistantPicker.tsx
@@ -130,13 +130,14 @@ export function AssistantPicker({
               >
                 <Item.Avatar
                   key={`assistant-picker-${c.sId}`}
-                  label={ellipsis("@" + c.name, 20)}
+                  label={c.name}
                   visual={c.pictureUrl}
                   hasAction={false}
                   onClick={() => {
                     onItemClick(c);
                     setSearchText("");
                   }}
+                  className="truncate"
                 />
                 <IconButton
                   icon={MoreIcon}

--- a/front/components/assistant/AssistantPicker.tsx
+++ b/front/components/assistant/AssistantPicker.tsx
@@ -13,7 +13,6 @@ import type {
   LightAgentConfigurationType,
   WorkspaceType,
 } from "@dust-tt/types";
-import { ellipsis } from "@dust-tt/types";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 

--- a/front/components/assistant/AssistantPicker.tsx
+++ b/front/components/assistant/AssistantPicker.tsx
@@ -13,6 +13,7 @@ import type {
   LightAgentConfigurationType,
   WorkspaceType,
 } from "@dust-tt/types";
+import { ellipsis } from "@dust-tt/types";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 
@@ -129,7 +130,7 @@ export function AssistantPicker({
               >
                 <Item.Avatar
                   key={`assistant-picker-${c.sId}`}
-                  label={"@" + c.name}
+                  label={ellipsis("@" + c.name, 20)}
                   visual={c.pictureUrl}
                   hasAction={false}
                   onClick={() => {

--- a/front/components/assistant_builder/InstructionScreen.tsx
+++ b/front/components/assistant_builder/InstructionScreen.tsx
@@ -9,7 +9,7 @@ import {
   MistralLogo,
   OpenaiLogo,
   Page,
-  Spinner,
+  Spinner2,
   TextArea,
 } from "@dust-tt/sparkle";
 import type {
@@ -335,7 +335,7 @@ function Suggestions({
       <div className="flex flex-col gap-2">
         <div className="flex gap-1 text-base font-bold text-element-800">
           <div>Tips</div>
-          {loading && <Spinner size="sm" />}
+          {loading && <Spinner2 size="sm" />}
         </div>
         <div>
           {(() => {

--- a/types/src/shared/utils/string_utils.ts
+++ b/types/src/shared/utils/string_utils.ts
@@ -69,14 +69,3 @@ export function redactString(str: string, n: number) {
   const redacted = "*".repeat(str.length - n) + str.slice(-n);
   return redacted;
 }
-
-/**
- * Returns an ellipsis if the string is too long, so it's never longer than
- * `maxStringLength`.
- * @param str The string to truncate.
- */
-export function ellipsis(str: string, maxStringLength: number) {
-  return str.length > maxStringLength - 3
-    ? `${str.slice(0, maxStringLength - 3)}...`
-    : str;
-}

--- a/types/src/shared/utils/string_utils.ts
+++ b/types/src/shared/utils/string_utils.ts
@@ -69,3 +69,14 @@ export function redactString(str: string, n: number) {
   const redacted = "*".repeat(str.length - n) + str.slice(-n);
   return redacted;
 }
+
+/**
+ * Returns an ellipsis if the string is too long, so it's never longer than
+ * `maxStringLength`.
+ * @param str The string to truncate.
+ */
+export function ellipsis(str: string, maxStringLength: number) {
+  return str.length > maxStringLength - 3
+    ? `${str.slice(0, maxStringLength - 3)}...`
+    : str;
+}


### PR DESCRIPTION
## Description
See title & screenshot
Note: also switches spinner to spinner2 in instructions, which fixes https://github.com/dust-tt/tasks/issues/612
![Screenshot from 2024-04-04 14-30-07](https://github.com/dust-tt/dust/assets/5437393/f407dcc7-5dd1-4b5c-878c-43f4d178d5f8)
![Screenshot from 2024-04-04 14-35-55](https://github.com/dust-tt/dust/assets/5437393/7c78cbbc-e32f-4a6d-b779-dda03ee638d9)


## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
