### PR TITLE
fix: prevent potential email abuse on invitations endpoint

### DIFF
--- a/front/lib/api/invitation.ts
+++ b/front/lib/api/invitation.ts
@@ -161,6 +161,11 @@ export async function getPendingInvitations(
   if (!owner) {
     return [];
   }
+  if (!auth.isAdmin()) {
+    throw new Error(
+      "Only users that are `admins` for the current workspace can see membership invitations or modify it."
+    );
+  }
 
   const invitations = await MembershipInvitation.findAll({
     where: {
@@ -193,6 +198,11 @@ export async function getRecentPendingOrRevokedInvitations(
   const owner = auth.workspace();
   if (!owner) {
     return [];
+  }
+  if (!auth.isAdmin()) {
+    throw new Error(
+      "Only users that are `admins` for the current workspace can see membership invitations or modify it."
+    );
   }
   const oneDayAgo = new Date();
   oneDayAgo.setDate(oneDayAgo.getDate() - 1);

--- a/front/lib/invitations.ts
+++ b/front/lib/invitations.ts
@@ -1,5 +1,2 @@
-// Maxmimum allowed number of unconsumed invitations per workspace.
-export const MAX_UNCONSUMED_INVITATIONS = 50;
-// If the user already received an invitation from this workspace and hasn't consumed it yet, we won't send another one
-// before this cooldown period.
-export const UNCONSUMED_INVITATION_COOLDOWN_PER_EMAIL_MS = 1000 * 60 * 60 * 24; // 1 day
+// Maxmimum allowed number of unconsumed invitations per workspace per day.
+export const MAX_UNCONSUMED_INVITATIONS_PER_WORKSPACE_PER_DAY = 50;

--- a/front/lib/invitations.ts
+++ b/front/lib/invitations.ts
@@ -1,0 +1,5 @@
+// Maxmimum allowed number of unconsumed invitations per workspace.
+export const MAX_UNCONSUMED_INVITATIONS = 50;
+// If the user already received an invitation from this workspace and hasn't consumed it yet, we won't send another one
+// before this cooldown period.
+export const UNCONSUMED_INVITATION_COOLDOWN_PER_EMAIL_MS = 1000 * 60 * 60 * 24; // 1 day

--- a/front/pages/api/w/[wId]/invitations/index.ts
+++ b/front/pages/api/w/[wId]/invitations/index.ts
@@ -158,12 +158,14 @@ async function handler(
         });
       }
       const existingMembers = await getMembers(auth);
+      const startOfDay = new Date();
+      startOfDay.setHours(0, 0, 0, 0);
       const unconsumedInvitations = await MembershipInvitation.findAll({
         where: {
           workspaceId: owner.id,
           status: ["pending", "revoked"],
           createdAt: {
-            [Op.gte]: new Date(new Date().setHours(0, 0, 0, 0)),
+            [Op.gte]: startOfDay,
           },
         },
       });

--- a/front/pages/api/w/[wId]/invitations/index.ts
+++ b/front/pages/api/w/[wId]/invitations/index.ts
@@ -158,7 +158,7 @@ async function handler(
         auth
       );
       if (
-        unconsumedInvitations.length >
+        unconsumedInvitations.length >=
         MAX_UNCONSUMED_INVITATIONS_PER_WORKSPACE_PER_DAY
       ) {
         return apiError(req, res, {

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -53,6 +53,7 @@ import {
   PRO_PLAN_29_COST,
 } from "@app/lib/client/subscription";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
+import { MAX_UNCONSUMED_INVITATIONS } from "@app/lib/invitations";
 import { isUpgraded, PRO_PLAN_SEAT_29_CODE } from "@app/lib/plans/plan_codes";
 import { useMembers, useWorkspaceInvitations } from "@app/lib/swr";
 import { classNames, isEmailValid } from "@app/lib/utils";
@@ -484,6 +485,15 @@ function InviteEmailModal({
   async function handleSendInvitations(
     inviteEmailsList: string[]
   ): Promise<void> {
+    if (inviteEmailsList.length > MAX_UNCONSUMED_INVITATIONS) {
+      sendNotification({
+        type: "error",
+        title: "Too many invitations",
+        description: `Your cannot send more than ${MAX_UNCONSUMED_INVITATIONS} invitations.`,
+      });
+      return;
+    }
+
     const invitesByCase = {
       activeSameRole: members.filter((m) =>
         inviteEmailsList.find(

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -53,7 +53,7 @@ import {
   PRO_PLAN_29_COST,
 } from "@app/lib/client/subscription";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
-import { MAX_UNCONSUMED_INVITATIONS } from "@app/lib/invitations";
+import { MAX_UNCONSUMED_INVITATIONS_PER_WORKSPACE_PER_DAY } from "@app/lib/invitations";
 import { isUpgraded, PRO_PLAN_SEAT_29_CODE } from "@app/lib/plans/plan_codes";
 import { useMembers, useWorkspaceInvitations } from "@app/lib/swr";
 import { classNames, isEmailValid } from "@app/lib/utils";
@@ -485,11 +485,13 @@ function InviteEmailModal({
   async function handleSendInvitations(
     inviteEmailsList: string[]
   ): Promise<void> {
-    if (inviteEmailsList.length > MAX_UNCONSUMED_INVITATIONS) {
+    if (
+      inviteEmailsList.length > MAX_UNCONSUMED_INVITATIONS_PER_WORKSPACE_PER_DAY
+    ) {
       sendNotification({
         type: "error",
         title: "Too many invitations",
-        description: `Your cannot send more than ${MAX_UNCONSUMED_INVITATIONS} invitations.`,
+        description: `Your cannot send more than ${MAX_UNCONSUMED_INVITATIONS_PER_WORKSPACE_PER_DAY} invitations per day.`,
       });
       return;
     }


### PR DESCRIPTION
## Description

fixes https://github.com/dust-tt/dust/issues/4555

Limits the # of email invitations a workspace can send every day (50). 
Prevents sending several invitations to the same email for the same workspace within a day

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
