### PR TITLE
Remove userId from MembershipResource interface

### DIFF
--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -13,6 +13,7 @@ import {
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { generateModelSId } from "@app/lib/utils";
 import logger from "@app/logger/logger";
+import { renderUserType } from "@app/lib/api/user";
 
 const { DUST_DATA_SOURCES_BUCKET = "", SERVICE_ACCOUNT } = process.env;
 
@@ -127,7 +128,7 @@ const user = async (command: string, args: parseArgs.ParsedArgs) => {
       console.log(`  email: ${u.email}`);
 
       const memberships = await MembershipResource.getLatestMemberships({
-        userIds: [u.id],
+        users: [renderUserType(u)],
       });
 
       const workspaces = await Workspace.findAll({

--- a/front/lib/api/assistant/recent_authors.ts
+++ b/front/lib/api/assistant/recent_authors.ts
@@ -2,15 +2,14 @@ import type {
   AgentRecentAuthors,
   LightAgentConfigurationType,
   UserType,
-  UserTypeWithWorkspaces,
 } from "@dust-tt/types";
 import { removeNulls } from "@dust-tt/types";
 import { Sequelize } from "sequelize";
 
-import { getMembers } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
-import { AgentConfiguration } from "@app/lib/models";
+import { AgentConfiguration, User } from "@app/lib/models";
 import { safeRedisClient } from "@app/lib/redis";
+import { renderUserType } from "@app/lib/user";
 
 // We keep the most recent authorIds for 3 days.
 const recentAuthorIdsKeyTTL = 60 * 60 * 24 * 3; // 3 days.
@@ -173,14 +172,16 @@ export async function getAgentsRecentAuthors({
     {}
   );
 
-  const authorByUserId: Record<number, UserTypeWithWorkspaces> = (
-    await getMembers(auth, {
-      userIds: removeNulls(
-        Array.from(new Set(Object.values(recentAuthorsIdsByAgentId).flat()))
-      ),
+  const authorByUserId: Record<number, UserType> = (
+    await User.findAll({
+      where: {
+        id: removeNulls(
+          Array.from(new Set(Object.values(recentAuthorsIdsByAgentId).flat()))
+        ),
+      },
     })
-  ).reduce<Record<number, UserTypeWithWorkspaces>>((acc, member) => {
-    acc[member.id] = member;
+  ).reduce<Record<number, UserType>>((acc, user) => {
+    acc[user.id] = renderUserType(user);
     return acc;
   }, {});
 
@@ -190,7 +191,7 @@ export async function getAgentsRecentAuthors({
       return [DUST_OWNED_ASSISTANTS_AUTHOR_NAME];
     }
     return renderAuthors(
-      recentAuthorIds.map((id) => authorByUserId[id]),
+      removeNulls(recentAuthorIds.map((id) => authorByUserId[id])),
       currentUserId
     );
   });

--- a/front/lib/api/assistant/recent_authors.ts
+++ b/front/lib/api/assistant/recent_authors.ts
@@ -6,10 +6,10 @@ import type {
 import { removeNulls } from "@dust-tt/types";
 import { Sequelize } from "sequelize";
 
+import { renderUserType } from "@app/lib/api/user";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentConfiguration, User } from "@app/lib/models";
 import { safeRedisClient } from "@app/lib/redis";
-import { renderUserType } from "@app/lib/user";
 
 // We keep the most recent authorIds for 3 days.
 const recentAuthorIdsKeyTTL = 60 * 60 * 24 * 3; // 3 days.

--- a/front/lib/api/user.ts
+++ b/front/lib/api/user.ts
@@ -5,6 +5,21 @@ import { User, UserMetadata } from "@app/lib/models";
 
 import { MembershipResource } from "../resources/membership_resource";
 
+export function renderUserType(user: User): UserType {
+  return {
+    sId: user.sId,
+    id: user.id,
+    createdAt: user.createdAt.getTime(),
+    provider: user.provider,
+    username: user.username,
+    email: user.email,
+    firstName: user.firstName,
+    lastName: user.lastName,
+    fullName: user.firstName + (user.lastName ? ` ${user.lastName}` : ""),
+    image: user.imageUrl,
+  };
+}
+
 /**
  * This function checks that the user had at least one membership in the past for this workspace
  * otherwise returns null, preventing retrieving user information from their sId.
@@ -30,7 +45,7 @@ export async function getUserForWorkspace(
 
   const membership =
     await MembershipResource.getLatestMembershipOfUserInWorkspace({
-      userId: user.id,
+      user: renderUserType(user),
       workspace: owner,
     });
 
@@ -38,18 +53,15 @@ export async function getUserForWorkspace(
     return null;
   }
 
-  return {
-    sId: user.sId,
-    id: user.id,
-    createdAt: user.createdAt.getTime(),
-    provider: user.provider,
-    username: user.username,
-    email: user.email,
-    firstName: user.firstName,
-    lastName: user.lastName,
-    fullName: user.firstName + (user.lastName ? ` ${user.lastName}` : ""),
-    image: user.imageUrl,
-  };
+  return renderUserType(user);
+}
+
+export async function deleteUser(user: UserType): Promise<void> {
+  await User.destroy({
+    where: {
+      id: user.id,
+    },
+  });
 }
 
 /**

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -105,11 +105,9 @@ export async function getMembers(
   {
     roles,
     activeOnly,
-    userIds,
   }: {
     roles?: MembershipRoleType[];
     activeOnly?: boolean;
-    userIds?: ModelId[];
   } = {}
 ): Promise<UserTypeWithWorkspaces[]> {
   const owner = auth.workspace();
@@ -121,12 +119,10 @@ export async function getMembers(
     ? await MembershipResource.getActiveMemberships({
         workspace: owner,
         roles,
-        userIds,
       })
     : await MembershipResource.getLatestMemberships({
         workspace: owner,
         roles,
-        userIds,
       });
 
   const users = await User.findAll({

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -1,7 +1,6 @@
 import type {
   LightWorkspaceType,
   MembershipRoleType,
-  ModelId,
   RoleType,
   SubscriptionType,
   UserTypeWithWorkspaces,

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -23,6 +23,7 @@ import type {
   NextApiResponse,
 } from "next";
 
+import { renderUserType } from "@app/lib/api/user";
 import { isDevelopment } from "@app/lib/development";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { isValidSession } from "@app/lib/iam/provider";
@@ -37,13 +38,12 @@ import {
 import type { PlanAttributes } from "@app/lib/plans/free_plans";
 import { FREE_NO_PLAN_DATA } from "@app/lib/plans/free_plans";
 import { isUpgraded } from "@app/lib/plans/plan_codes";
+import { renderSubscriptionFromModels } from "@app/lib/plans/subscription";
 import { getTrialVersionForPlan, isTrial } from "@app/lib/plans/trial";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { new_id } from "@app/lib/utils";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
-
-import { renderSubscriptionFromModels } from "./plans/subscription";
 
 const {
   DUST_DEVELOPMENT_WORKSPACE_ID,
@@ -132,7 +132,7 @@ export class Authenticator {
         (async (): Promise<RoleType> => {
           const membership =
             await MembershipResource.getActiveMembershipOfUserInWorkspace({
-              userId: user.id,
+              user: renderUserType(user),
               workspace: renderLightWorkspaceType({ workspace }),
             });
           return membership &&
@@ -424,22 +424,7 @@ export class Authenticator {
    * @returns
    */
   user(): UserType | null {
-    return this._user
-      ? {
-          sId: this._user.sId,
-          id: this._user.id,
-          createdAt: this._user.createdAt.getTime(),
-          provider: this._user.provider,
-          username: this._user.username,
-          email: this._user.email,
-          fullName:
-            this._user.firstName +
-            (this._user.lastName ? ` ${this._user.lastName}` : ""),
-          firstName: this._user.firstName,
-          lastName: this._user.lastName || null,
-          image: this._user.imageUrl,
-        }
-      : null;
+    return this._user ? renderUserType(this._user) : null;
   }
 
   isDustSuperUser(): boolean {

--- a/front/lib/iam/invitations.ts
+++ b/front/lib/iam/invitations.ts
@@ -1,9 +1,8 @@
-import type { Result } from "@dust-tt/types";
+import type { Result, UserType } from "@dust-tt/types";
 import { Err, Ok } from "@dust-tt/types";
 import { verify } from "jsonwebtoken";
 
 import { AuthFlowError } from "@app/lib/iam/errors";
-import type { User } from "@app/lib/models";
 import { MembershipInvitation } from "@app/lib/models";
 
 const { DUST_INVITE_TOKEN_SECRET = "" } = process.env;
@@ -38,7 +37,7 @@ export async function getPendingMembershipInvitationForToken(
 
 export async function markInvitationAsConsumed(
   membershipInvite: MembershipInvitation,
-  user: User
+  user: UserType
 ) {
   membershipInvite.status = "consumed";
   membershipInvite.invitedUserId = user.id;

--- a/front/lib/iam/session.ts
+++ b/front/lib/iam/session.ts
@@ -7,6 +7,7 @@ import type {
 } from "next";
 import type { ParsedUrlQuery } from "querystring";
 
+import { renderUserType } from "@app/lib/api/user";
 import { Authenticator, getSession } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { isValidSession } from "@app/lib/iam/provider";
@@ -37,7 +38,7 @@ export async function getUserFromSession(
   }
 
   const memberships = await MembershipResource.getActiveMemberships({
-    userIds: [user.id],
+    users: [renderUserType(user)],
   });
   const workspaces = await Workspace.findAll({
     where: {

--- a/front/lib/iam/users.ts
+++ b/front/lib/iam/users.ts
@@ -3,6 +3,7 @@ import type { UserProviderType, UserType } from "@dust-tt/types";
 import { sanitizeString } from "@dust-tt/types";
 
 import { trackSignup } from "@app/lib/amplitude/node";
+import { renderUserType } from "@app/lib/api/user";
 import type { ExternalUser, SessionWithUser } from "@app/lib/iam/provider";
 import { User } from "@app/lib/models/user";
 import { guessFirstandLastNameFromFullName } from "@app/lib/user";
@@ -94,7 +95,7 @@ export async function maybeUpdateFromExternalUser(
 
 export async function createOrUpdateUser(
   session: SessionWithUser
-): Promise<{ user: User; created: boolean }> {
+): Promise<{ user: UserType; created: boolean }> {
   const { user: externalUser } = session;
 
   const user = await fetchUserFromSession(session);
@@ -124,7 +125,7 @@ export async function createOrUpdateUser(
 
     await user.save();
 
-    return { user, created: false };
+    return { user: renderUserType(user), created: false };
   } else {
     const { firstName, lastName } = guessFirstandLastNameFromFullName(
       externalUser.name
@@ -154,6 +155,6 @@ export async function createOrUpdateUser(
       fullName: u.name,
     } satisfies UserType);
 
-    return { user: u, created: true };
+    return { user: renderUserType(u), created: true };
   }
 }

--- a/front/pages/api/create-new-workspace.ts
+++ b/front/pages/api/create-new-workspace.ts
@@ -51,8 +51,8 @@ async function handler(
 
   const workspace = await createWorkspace(session);
   await createAndLogMembership({
+    user,
     workspace,
-    userId: user.id,
     role: "admin",
   });
 

--- a/front/pages/api/poke/workspaces/index.ts
+++ b/front/pages/api/poke/workspaces/index.ts
@@ -3,6 +3,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import type { FindOptions, WhereOptions } from "sequelize";
 import { Op } from "sequelize";
 
+import { renderUserType } from "@app/lib/api/user";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { Plan, Subscription, User, Workspace } from "@app/lib/models";
 import { FREE_TEST_PLAN_CODE } from "@app/lib/plans/plan_codes";
@@ -131,7 +132,7 @@ async function handler(
           });
           if (users.length) {
             const memberships = await MembershipResource.getLatestMemberships({
-              userIds: users.map((u) => u.id),
+              users: users.map((u) => renderUserType(u)),
             });
             if (memberships.length) {
               conditions.push({

--- a/front/pages/api/w/[wId]/members/[uId]/index.ts
+++ b/front/pages/api/w/[wId]/members/[uId]/index.ts
@@ -74,7 +74,7 @@ async function handler(
       // TODO(@fontanierh): use DELETE for revoking membership
       if (req.body.role === "revoked") {
         const revokeResult = await MembershipResource.revokeMembership({
-          userId: user.id,
+          user,
           workspace: owner,
         });
         if (revokeResult.isErr()) {

--- a/front/pages/api/w/[wId]/members/[uId]/index.ts
+++ b/front/pages/api/w/[wId]/members/[uId]/index.ts
@@ -111,7 +111,7 @@ async function handler(
           });
         }
         const updateRoleResult = await MembershipResource.updateMembershipRole({
-          userId: user.id,
+          user,
           workspace: owner,
           newRole: role,
           // We allow to re-activate a terminated membership when updating the role here.

--- a/front/pages/no-workspace.tsx
+++ b/front/pages/no-workspace.tsx
@@ -45,7 +45,7 @@ async function fetchRevokedWorkspace(
   // TODO(@fontanierh): this doesn't look very solid as it will start to behave
   // weirdly if a user has multiple revoked memberships.
   const memberships = await MembershipResource.getLatestMemberships({
-    userIds: [user.id],
+    users: [user],
   });
 
   if (!memberships.length) {

--- a/front/pages/poke/[wId]/memberships.tsx
+++ b/front/pages/poke/[wId]/memberships.tsx
@@ -52,7 +52,7 @@ const MembershipsPage = ({
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          userId: m.id,
+          userId: m.sId,
         }),
       });
       if (!r.ok) {

--- a/types/src/shared/utils/general.ts
+++ b/types/src/shared/utils/general.ts
@@ -1,6 +1,6 @@
 /**
  *  Filters out nulls & undefineds from an array by correclty narrowing the type
  */
-export function removeNulls<T>(arr: (T | null)[]): T[] {
-  return arr.filter((v): v is T => v !== null);
+export function removeNulls<T>(arr: (T | null | undefined)[]): T[] {
+  return arr.filter((v): v is T => v !== null && v !== undefined);
 }


### PR DESCRIPTION
## Description

We cut the MembershipResource with `userId(s)` (number) in its interface which breaks our invariants.

This PR refactors parts of the code to use `UserType` everywhere.

Behavior change:
- When rendering the authors of an assistant we don't filter along membership, showing authors that may have been revoked.
- When deleting memberships of a workspace (GDPR scrubbing) the logic is changed to properly delete users if they only belonged to that workspace (otherwise they would be dangling with no membership, I think that's what we want) (r? @PopDaph)
 
## Risk

Risky as it touches many parts of the code, will run tests on all touched parts (esp. agent author display)

Test plan:
- [x] poke revoke
- [x] Login
- [x] recent authors display
- [x] Invite user / revoke user
- [x] general use of the app

## Deploy Plan

- deploy `front`