### PR TITLE
Skip reporting Confluence data if oauth token error

### DIFF
--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -614,7 +614,7 @@ export async function confluenceGetReportPersonalActionActivity(
   const { connectorId, userAccountId } = params;
 
   const connector = await fetchConfluenceConnector(connectorId);
-  if (connector.errorType === "oauth_token_revoked") {
+  if (connector.hasExternalAuthError()) {
     return false;
   }
 

--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -614,6 +614,9 @@ export async function confluenceGetReportPersonalActionActivity(
   const { connectorId, userAccountId } = params;
 
   const connector = await fetchConfluenceConnector(connectorId);
+  if (connector.errorType === "oauth_token_revoked") {
+    return false;
+  }
 
   // We look for the oldest updated data.
   const oldestPageSync = await ConfluencePage.findOne({

--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -614,7 +614,7 @@ export async function confluenceGetReportPersonalActionActivity(
   const { connectorId, userAccountId } = params;
 
   const connector = await fetchConfluenceConnector(connectorId);
-  if (connector.hasExternalAuthError()) {
+  if (connector.isAuthTokenRevoked) {
     return false;
   }
 

--- a/connectors/src/resources/connector_resource.ts
+++ b/connectors/src/resources/connector_resource.ts
@@ -152,4 +152,8 @@ export class ConnectorResource extends BaseResource<ConnectorModel> {
   async markAsPaused() {
     return this.update({ pausedAt: new Date() });
   }
+
+  hasExternalAuthError() {
+    return this.errorType === "oauth_token_revoked";
+  }
 }

--- a/connectors/src/resources/connector_resource.ts
+++ b/connectors/src/resources/connector_resource.ts
@@ -153,7 +153,7 @@ export class ConnectorResource extends BaseResource<ConnectorModel> {
     return this.update({ pausedAt: new Date() });
   }
 
-  hasExternalAuthError() {
+  get isAuthTokenRevoked() {
     return this.errorType === "oauth_token_revoked";
   }
 }


### PR DESCRIPTION
## Description

This PR skips reporting data for Confluence connector with `oauth_external_error`.
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
