### PR TITLE
Truncate table name to 32 characters

### DIFF
--- a/types/src/shared/utils/structured_data.ts
+++ b/types/src/shared/utils/structured_data.ts
@@ -4,7 +4,10 @@ export function makeStructuredDataTableName(name: string, externalId: string) {
   const lowercasedExternalId = externalId.toLowerCase();
   const externalIdPrefix = lowercasedExternalId.substring(0, 4);
   const externalIdSuffix = lowercasedExternalId.slice(-4);
-  return slugify(`${name}_${externalIdPrefix}_${externalIdSuffix}`);
+
+  const truncatedName = name.substring(0, 32);
+
+  return slugify(`${truncatedName}_${externalIdPrefix}_${externalIdSuffix}`);
 }
 
 export class InvalidStructuredDataHeaderError extends Error {}

--- a/types/src/shared/utils/structured_data.ts
+++ b/types/src/shared/utils/structured_data.ts
@@ -5,7 +5,7 @@ export function makeStructuredDataTableName(name: string, externalId: string) {
   const externalIdPrefix = lowercasedExternalId.substring(0, 4);
   const externalIdSuffix = lowercasedExternalId.slice(-4);
 
-  const truncatedName = name.substring(0, 64);
+  const truncatedName = name.substring(0, 32);
 
   return slugify(`${truncatedName}_${externalIdPrefix}_${externalIdSuffix}`);
 }

--- a/types/src/shared/utils/structured_data.ts
+++ b/types/src/shared/utils/structured_data.ts
@@ -5,7 +5,7 @@ export function makeStructuredDataTableName(name: string, externalId: string) {
   const externalIdPrefix = lowercasedExternalId.substring(0, 4);
   const externalIdSuffix = lowercasedExternalId.slice(-4);
 
-  const truncatedName = name.substring(0, 32);
+  const truncatedName = name.substring(0, 64);
 
   return slugify(`${truncatedName}_${externalIdPrefix}_${externalIdSuffix}`);
 }


### PR DESCRIPTION
## Description

This PR truncates table names to a maximum of 32 characters, as we've encountered instances where the name of some Google Spreadsheets exceeded 8k+ characters. Although the Dust app relies on the table name, all application-side uses the tableId. I've run some queries on our database and found that no Dust apps are currently using database blocks with table names longer than 32 characters. Therefore, it should be safe to deploy this change.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
