### PR TITLE
fix: don't prod check paused connectors

### DIFF
--- a/front/production_checks/checks/check_notion_active_workflows.ts
+++ b/front/production_checks/checks/check_notion_active_workflows.ts
@@ -10,13 +10,14 @@ interface NotionConnector {
   id: number;
   dataSourceName: string;
   workspaceId: string;
+  pausedAt: Date | null;
 }
 
 async function listAllNotionConnectors() {
   const connectorsReplica = getConnectorReplicaDbConnection();
 
   const notionConnectors: NotionConnector[] = await connectorsReplica.query(
-    `SELECT id, "dataSourceName", "workspaceId" FROM connectors WHERE "type" = 'notion' and  "errorType" IS NULL`,
+    `SELECT id, "dataSourceName", "workspaceId", "pausedAt" FROM connectors WHERE "type" = 'notion' and  "errorType" IS NULL`,
     {
       type: QueryTypes.SELECT,
     }
@@ -63,6 +64,9 @@ export const checkNotionActiveWorkflows: CheckFunction = async (
 
   const missingActiveWorkflows: any[] = [];
   for (const notionConnector of notionConnectors) {
+    if (notionConnector.pausedAt) {
+      continue;
+    }
     heartbeat();
 
     const isActive = await areTemporalWorkflowsRunning(client, notionConnector);


### PR DESCRIPTION
## Description

When connectors are paused, we kill their workflows. So we need to exclude the paused connectors from the active workflows production checks.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
