### PR TITLE
enh: unpause connectors on resubscribe

### DIFF
--- a/front/scrub_workspace/temporal/client.ts
+++ b/front/scrub_workspace/temporal/client.ts
@@ -1,8 +1,11 @@
 import type { Result } from "@dust-tt/types";
 import { Err, Ok } from "@dust-tt/types";
+import type { WorkflowHandle } from "@temporalio/client";
+import { WorkflowNotFoundError } from "@temporalio/client";
 
 import { getTemporalClient } from "@app/lib/temporal";
 import logger from "@app/logger/logger";
+import type { scheduleWorkspaceScrubWorkflow } from "@app/scrub_workspace/temporal/workflows";
 import { scheduleWorkspaceScrubWorkflowV2 } from "@app/scrub_workspace/temporal/workflows";
 
 import { QUEUE_NAME } from "./config";
@@ -13,8 +16,7 @@ export async function launchScheduleWorkspaceScrubWorkflow({
   workspaceId: string;
 }): Promise<Result<string, Error>> {
   const client = await getTemporalClient();
-
-  const workflowId = `schedule-workspace-scrub-${workspaceId}`;
+  const workflowId = getWorkflowId(workspaceId);
 
   try {
     await client.workflow.start(scheduleWorkspaceScrubWorkflowV2, {
@@ -42,4 +44,43 @@ export async function launchScheduleWorkspaceScrubWorkflow({
     );
     return new Err(e as Error);
   }
+}
+
+export async function terminateScheduleWorkspaceScrubWorkflow({
+  workspaceId,
+}: {
+  workspaceId: string;
+}): Promise<Result<void, Error>> {
+  const client = await getTemporalClient();
+  const workflowId = getWorkflowId(workspaceId);
+  try {
+    const handle: WorkflowHandle<
+      | typeof scheduleWorkspaceScrubWorkflowV2
+      | typeof scheduleWorkspaceScrubWorkflow
+    > = client.workflow.getHandle(workflowId);
+    await handle.terminate();
+    logger.info(
+      {
+        workflowId,
+      },
+      `Terminated workflow.`
+    );
+    return new Ok(undefined);
+  } catch (e) {
+    if (e instanceof WorkflowNotFoundError) {
+      return new Ok(undefined);
+    }
+    logger.error(
+      {
+        workflowId,
+        error: e,
+      },
+      `Failed terminating workflow.`
+    );
+    return new Err(e as Error);
+  }
+}
+
+function getWorkflowId(workspaceId: string) {
+  return `schedule-workspace-scrub-${workspaceId}`;
 }


### PR DESCRIPTION
## Description

When a workspace churns, their datasources are kept around for 15 days and their connectors are paused.
If the workspace re-subs during this 15 days grace period, we need to unpause the connectors.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
