### PR TITLE
Use last 6 digits of external ID

### DIFF
--- a/types/src/shared/utils/structured_data.ts
+++ b/types/src/shared/utils/structured_data.ts
@@ -3,7 +3,7 @@ import { slugify } from "./string_utils";
 export function makeStructuredDataTableName(name: string, externalId: string) {
   const lowercasedExternalId = externalId.toLowerCase();
   const externalIdPrefix = lowercasedExternalId.substring(0, 4);
-  const externalIdSuffix = lowercasedExternalId.slice(-4);
+  const externalIdSuffix = lowercasedExternalId.slice(-6);
 
   const truncatedName = name.substring(0, 32);
 


### PR DESCRIPTION
## Description

In https://github.com/dust-tt/dust/pull/4580, we limited the external table name to 32 characters. However, we've noticed conflicts where a single Google Spreadsheet can contain multiple sheets with the same last 4 trailing digits.

To address this, this PR allows for up to 6 trailing digits to be used when constructing the table name. This could potentially make it more challenging for the model to generate queries to target those tables.
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
