### PR TITLE
Poké: Move Actions to modals & cleanup

### DIFF
--- a/front/components/poke/assistants/table.tsx
+++ b/front/components/poke/assistants/table.tsx
@@ -8,6 +8,7 @@ import { useRouter } from "next/router";
 import { useState } from "react";
 
 import { makeColumnsForAssistants } from "@app/components/poke/assistants/columns";
+import { PokeButton } from "@app/components/poke/shadcn/ui/button";
 import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
 import { GLOBAL_AGENTS_SID } from "@app/lib/assistant";
 import { usePokeAgentConfigurations } from "@app/lib/swr";
@@ -42,15 +43,18 @@ export function AssistantsDataTable({
         owner={owner}
       />
       <div className="border-material-200 my-4 flex flex-col rounded-lg border p-4">
-        <a
-          className="mb-4 cursor-pointer text-xs text-action-400"
-          onClick={() => {
-            setShowRestoreAssistantModal(true);
-          }}
-        >
-          restore an assistant
-        </a>
-        <h2 className="text-md mb-4 font-bold">Assistants:</h2>
+        <div className="flex justify-between gap-3">
+          <h2 className="text-md mb-4 flex-grow font-bold">Assistants:</h2>
+          <PokeButton
+            aria-label="Restore an assistant"
+            variant="outline"
+            size="sm"
+            onClick={() => setShowRestoreAssistantModal(true)}
+          >
+            🔥 Restore an assistant
+          </PokeButton>
+        </div>
+
         <PokeDataTable
           columns={makeColumnsForAssistants(
             owner,

--- a/front/components/poke/subscriptions/table.tsx
+++ b/front/components/poke/subscriptions/table.tsx
@@ -28,7 +28,10 @@ import {
 import { makeColumnsForSubscriptions } from "@app/components/poke/subscriptions/columns";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { isDevelopment } from "@app/lib/development";
-import { FREE_NO_PLAN_CODE } from "@app/lib/plans/plan_codes";
+import {
+  FREE_NO_PLAN_CODE,
+  PRO_PLAN_SEAT_29_CODE,
+} from "@app/lib/plans/plan_codes";
 import { usePokePlans } from "@app/lib/swr";
 
 interface SubscriptionsDataTableProps {
@@ -375,7 +378,8 @@ function UpgradeDowngradeModal({
         />
         <div>
           {plans
-            .filter((p) => p.code.startsWith("FREE_"))
+            // Daph Uncomment this line when Enteprise billing Form is ready
+            .filter((p) => p.code !== PRO_PLAN_SEAT_29_CODE) // to be replaced with .filter((p) => p.code.startsWith("FREE_"))
             .map((p) => {
               return (
                 <div key={p.code} className="pt-2">

--- a/front/components/poke/subscriptions/table.tsx
+++ b/front/components/poke/subscriptions/table.tsx
@@ -77,14 +77,14 @@ export function ActiveSubscriptionTable({
 }) {
   const activePlan = subscription.plan;
 
-  const [showManageSubscriptionModal, setShowManageSubscriptionModal] =
+  const [showUpgradeDowngradeModal, setShowUpgradeDowngradeModal] =
     useState(false);
 
   return (
     <>
-      <ManageSubscriptionModal
-        show={showManageSubscriptionModal}
-        onClose={() => setShowManageSubscriptionModal(false)}
+      <UpgradeDowngradeModal
+        show={showUpgradeDowngradeModal}
+        onClose={() => setShowUpgradeDowngradeModal(false)}
         owner={owner}
         subscription={subscription}
       />
@@ -96,12 +96,12 @@ export function ActiveSubscriptionTable({
                 Active Subscription:
               </h2>
               <PokeButton
-                aria-label="Manage Subscription"
+                aria-label="Upgrade / Downgrade"
                 variant="outline"
                 size="sm"
-                onClick={() => setShowManageSubscriptionModal(true)}
+                onClick={() => setShowUpgradeDowngradeModal(true)}
               >
-                🔥 Manage Subscription
+                🔥 Upgrade / Downgrade
               </PokeButton>
             </div>
             <PokeTable>
@@ -275,7 +275,7 @@ export function ActiveSubscriptionTable({
   );
 }
 
-function ManageSubscriptionModal({
+function UpgradeDowngradeModal({
   show,
   onClose,
   owner,
@@ -351,7 +351,7 @@ function ManageSubscriptionModal({
       isOpen={show}
       onClose={onClose}
       hasChanged={false}
-      title="Manage Subscription"
+      title="Upgrade / Downgrade Workspace"
       variant="full-screen"
     >
       <Page>

--- a/front/components/poke/subscriptions/table.tsx
+++ b/front/components/poke/subscriptions/table.tsx
@@ -1,16 +1,23 @@
 import {
+  Button,
   CloudArrowDownIcon,
   ConfluenceLogo,
   GithubLogo,
   GoogleLogo,
   IntercomLogo,
+  Modal,
   NotionLogo,
+  Page,
   SlackLogo,
 } from "@dust-tt/sparkle";
-import type { SubscriptionType, WorkspaceType } from "@dust-tt/types";
+import type { PlanType, SubscriptionType, WorkspaceType } from "@dust-tt/types";
+import { Separator } from "@radix-ui/react-select";
 import { format } from "date-fns/format";
 import Link from "next/link";
+import { useRouter } from "next/router";
+import { useState } from "react";
 
+import { PokeButton } from "@app/components/poke/shadcn/ui/button";
 import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
 import {
   PokeTable,
@@ -19,7 +26,10 @@ import {
   PokeTableRow,
 } from "@app/components/poke/shadcn/ui/table";
 import { makeColumnsForSubscriptions } from "@app/components/poke/subscriptions/columns";
+import { useSubmitFunction } from "@app/lib/client/utils";
 import { isDevelopment } from "@app/lib/development";
+import { FREE_NO_PLAN_CODE } from "@app/lib/plans/plan_codes";
+import { usePokePlans } from "@app/lib/swr";
 
 interface SubscriptionsDataTableProps {
   owner: WorkspaceType;
@@ -59,180 +69,328 @@ export function SubscriptionsDataTable({
 }
 
 export function ActiveSubscriptionTable({
+  owner,
   subscription,
 }: {
+  owner: WorkspaceType;
   subscription: SubscriptionType;
 }) {
   const activePlan = subscription.plan;
+
+  const [showManageSubscriptionModal, setShowManageSubscriptionModal] =
+    useState(false);
+
   return (
-    <div className="flex flex-col space-y-8 pt-4">
-      <div className="flex justify-between gap-3">
-        <div className="border-material-200 my-4 flex flex-grow flex-col rounded-lg border p-4">
-          <h2 className="text-md pb-4 font-bold">Active Subscription:</h2>
-          <PokeTable>
-            <PokeTableBody>
-              <PokeTableRow>
-                <PokeTableCell>Plan Name</PokeTableCell>
-                <PokeTableCell>{subscription.plan.name}</PokeTableCell>
-              </PokeTableRow>
-              <PokeTableRow>
-                <PokeTableCell>Plan Code</PokeTableCell>
-                <PokeTableCell>{subscription.plan.code}</PokeTableCell>
-              </PokeTableRow>
-              <PokeTableRow>
-                <PokeTableCell>Is in Trial?</PokeTableCell>
-                <PokeTableCell>
-                  {subscription.trialing ? "✅" : "❌"}
-                </PokeTableCell>
-              </PokeTableRow>
-              <PokeTableRow>
-                <PokeTableCell>Stripe Subscription Id</PokeTableCell>
-                <PokeTableCell>
-                  {subscription.stripeSubscriptionId ? (
-                    <Link
-                      href={
-                        isDevelopment()
-                          ? `https://dashboard.stripe.com/test/subscriptions/${subscription.stripeSubscriptionId}`
-                          : `https://dashboard.stripe.com/subscriptions/${subscription.stripeSubscriptionId}`
-                      }
-                      target="_blank"
-                      className="text-xs text-action-400"
-                    >
-                      {subscription.stripeSubscriptionId}
-                    </Link>
-                  ) : (
-                    "No subscription id"
-                  )}
-                </PokeTableCell>
-              </PokeTableRow>
-              <PokeTableRow>
-                <PokeTableCell>Stripe Customer Id</PokeTableCell>
-                <PokeTableCell>
-                  {subscription.stripeCustomerId ? (
-                    <Link
-                      href={
-                        isDevelopment()
-                          ? `https://dashboard.stripe.com/test/customers/${subscription.stripeCustomerId}`
-                          : `https://dashboard.stripe.com/customers/${subscription.stripeCustomerId}`
-                      }
-                      target="_blank"
-                      className="text-xs text-action-400"
-                    >
-                      {subscription.stripeCustomerId}
-                    </Link>
-                  ) : (
-                    "No customer id"
-                  )}
-                </PokeTableCell>
-              </PokeTableRow>
-              <PokeTableRow>
-                <PokeTableCell>Start Date</PokeTableCell>
-                <PokeTableCell>
-                  {subscription.startDate
-                    ? format(subscription.startDate, "yyyy-MM-dd")
-                    : "/"}
-                </PokeTableCell>
-              </PokeTableRow>
-              <PokeTableRow>
-                <PokeTableCell>End Date</PokeTableCell>
-                <PokeTableCell>
-                  {subscription.endDate
-                    ? format(subscription.endDate, "yyyy-MM-dd")
-                    : "/"}
-                </PokeTableCell>
-              </PokeTableRow>
-            </PokeTableBody>
-          </PokeTable>
-        </div>
-        <div className="border-material-200 my-4 flex flex-grow flex-col rounded-lg border p-4">
-          <h2 className="text-md pb-4 font-bold">Plan limitations:</h2>
-          <PokeTable>
-            <PokeTableBody>
-              <PokeTableRow>
-                <PokeTableCell>SlackBot allowed</PokeTableCell>
-                <PokeTableCell>
-                  {activePlan.limits.assistant.isSlackBotAllowed ? "✅" : "❌"}
-                </PokeTableCell>
-              </PokeTableRow>
-              <PokeTableRow>
-                <PokeTableCell>Connections allowed</PokeTableCell>
-                <PokeTableCell>
-                  <div className="flex gap-2">
-                    {activePlan.limits.connections.isSlackAllowed ? (
-                      <SlackLogo />
-                    ) : null}
-                    {activePlan.limits.connections.isGoogleDriveAllowed ? (
-                      <GoogleLogo />
-                    ) : null}
-                    {activePlan.limits.connections.isGithubAllowed ? (
-                      <GithubLogo />
-                    ) : null}
-                    {activePlan.limits.connections.isNotionAllowed ? (
-                      <NotionLogo />
-                    ) : null}
-                    {activePlan.limits.connections.isIntercomAllowed ? (
-                      <IntercomLogo />
-                    ) : null}
-                    {activePlan.limits.connections.isConfluenceAllowed ? (
-                      <ConfluenceLogo />
-                    ) : null}
-                    {activePlan.limits.connections.isWebCrawlerAllowed ? (
-                      <CloudArrowDownIcon />
-                    ) : null}
-                  </div>
-                </PokeTableCell>
-              </PokeTableRow>
+    <>
+      <ManageSubscriptionModal
+        show={showManageSubscriptionModal}
+        onClose={() => setShowManageSubscriptionModal(false)}
+        owner={owner}
+        subscription={subscription}
+      />
+      <div className="flex flex-col space-y-8 pt-4">
+        <div className="flex justify-between gap-3">
+          <div className="border-material-200 my-4 flex flex-grow flex-col rounded-lg border p-4">
+            <div className="flex items-center justify-between gap-3">
+              <h2 className="text-md flex-grow pb-4 font-bold">
+                Active Subscription:
+              </h2>
+              <PokeButton
+                aria-label="Manage Subscription"
+                variant="outline"
+                size="sm"
+                onClick={() => setShowManageSubscriptionModal(true)}
+              >
+                🔥 Manage Subscription
+              </PokeButton>
+            </div>
+            <PokeTable>
+              <PokeTableBody>
+                <PokeTableRow>
+                  <PokeTableCell>Plan Name</PokeTableCell>
+                  <PokeTableCell>{subscription.plan.name}</PokeTableCell>
+                </PokeTableRow>
+                <PokeTableRow>
+                  <PokeTableCell>Plan Code</PokeTableCell>
+                  <PokeTableCell>{subscription.plan.code}</PokeTableCell>
+                </PokeTableRow>
+                <PokeTableRow>
+                  <PokeTableCell>Is in Trial?</PokeTableCell>
+                  <PokeTableCell>
+                    {subscription.trialing ? "✅" : "❌"}
+                  </PokeTableCell>
+                </PokeTableRow>
+                <PokeTableRow>
+                  <PokeTableCell>Stripe Subscription Id</PokeTableCell>
+                  <PokeTableCell>
+                    {subscription.stripeSubscriptionId ? (
+                      <Link
+                        href={
+                          isDevelopment()
+                            ? `https://dashboard.stripe.com/test/subscriptions/${subscription.stripeSubscriptionId}`
+                            : `https://dashboard.stripe.com/subscriptions/${subscription.stripeSubscriptionId}`
+                        }
+                        target="_blank"
+                        className="text-xs text-action-400"
+                      >
+                        {subscription.stripeSubscriptionId}
+                      </Link>
+                    ) : (
+                      "No subscription id"
+                    )}
+                  </PokeTableCell>
+                </PokeTableRow>
+                <PokeTableRow>
+                  <PokeTableCell>Stripe Customer Id</PokeTableCell>
+                  <PokeTableCell>
+                    {subscription.stripeCustomerId ? (
+                      <Link
+                        href={
+                          isDevelopment()
+                            ? `https://dashboard.stripe.com/test/customers/${subscription.stripeCustomerId}`
+                            : `https://dashboard.stripe.com/customers/${subscription.stripeCustomerId}`
+                        }
+                        target="_blank"
+                        className="text-xs text-action-400"
+                      >
+                        {subscription.stripeCustomerId}
+                      </Link>
+                    ) : (
+                      "No customer id"
+                    )}
+                  </PokeTableCell>
+                </PokeTableRow>
+                <PokeTableRow>
+                  <PokeTableCell>Start Date</PokeTableCell>
+                  <PokeTableCell>
+                    {subscription.startDate
+                      ? format(subscription.startDate, "yyyy-MM-dd")
+                      : "/"}
+                  </PokeTableCell>
+                </PokeTableRow>
+                <PokeTableRow>
+                  <PokeTableCell>End Date</PokeTableCell>
+                  <PokeTableCell>
+                    {subscription.endDate
+                      ? format(subscription.endDate, "yyyy-MM-dd")
+                      : "/"}
+                  </PokeTableCell>
+                </PokeTableRow>
+              </PokeTableBody>
+            </PokeTable>
+          </div>
+          <div className="border-material-200 my-4 flex flex-grow flex-col rounded-lg border p-4">
+            <h2 className="text-md pb-4 font-bold">Plan limitations:</h2>
+            <PokeTable>
+              <PokeTableBody>
+                <PokeTableRow>
+                  <PokeTableCell>SlackBot allowed</PokeTableCell>
+                  <PokeTableCell>
+                    {activePlan.limits.assistant.isSlackBotAllowed
+                      ? "✅"
+                      : "❌"}
+                  </PokeTableCell>
+                </PokeTableRow>
+                <PokeTableRow>
+                  <PokeTableCell>Connections allowed</PokeTableCell>
+                  <PokeTableCell>
+                    <div className="flex gap-2">
+                      {activePlan.limits.connections.isSlackAllowed ? (
+                        <SlackLogo />
+                      ) : null}
+                      {activePlan.limits.connections.isGoogleDriveAllowed ? (
+                        <GoogleLogo />
+                      ) : null}
+                      {activePlan.limits.connections.isGithubAllowed ? (
+                        <GithubLogo />
+                      ) : null}
+                      {activePlan.limits.connections.isNotionAllowed ? (
+                        <NotionLogo />
+                      ) : null}
+                      {activePlan.limits.connections.isIntercomAllowed ? (
+                        <IntercomLogo />
+                      ) : null}
+                      {activePlan.limits.connections.isConfluenceAllowed ? (
+                        <ConfluenceLogo />
+                      ) : null}
+                      {activePlan.limits.connections.isWebCrawlerAllowed ? (
+                        <CloudArrowDownIcon />
+                      ) : null}
+                    </div>
+                  </PokeTableCell>
+                </PokeTableRow>
 
-              <PokeTableRow>
-                <PokeTableCell>Max number of users</PokeTableCell>
-                <PokeTableCell>
-                  {activePlan.limits.users.maxUsers === -1
-                    ? "unlimited"
-                    : activePlan.limits.users.maxUsers}
-                </PokeTableCell>
-              </PokeTableRow>
+                <PokeTableRow>
+                  <PokeTableCell>Max number of users</PokeTableCell>
+                  <PokeTableCell>
+                    {activePlan.limits.users.maxUsers === -1
+                      ? "unlimited"
+                      : activePlan.limits.users.maxUsers}
+                  </PokeTableCell>
+                </PokeTableRow>
 
-              <PokeTableRow>
-                <PokeTableCell>Max number of messages</PokeTableCell>
-                <PokeTableCell>
-                  {activePlan.limits.assistant.maxMessages === -1
-                    ? "unlimited"
-                    : `${activePlan.limits.assistant.maxMessages} / ${activePlan.limits.assistant.maxMessagesTimeframe}`}
-                </PokeTableCell>
-              </PokeTableRow>
+                <PokeTableRow>
+                  <PokeTableCell>Max number of messages</PokeTableCell>
+                  <PokeTableCell>
+                    {activePlan.limits.assistant.maxMessages === -1
+                      ? "unlimited"
+                      : `${activePlan.limits.assistant.maxMessages} / ${activePlan.limits.assistant.maxMessagesTimeframe}`}
+                  </PokeTableCell>
+                </PokeTableRow>
 
-              <PokeTableRow>
-                <PokeTableCell>Max number of data sources</PokeTableCell>
-                <PokeTableCell>
-                  {activePlan.limits.dataSources.count === -1
-                    ? "unlimited"
-                    : activePlan.limits.dataSources.count}
-                </PokeTableCell>
-              </PokeTableRow>
+                <PokeTableRow>
+                  <PokeTableCell>Max number of data sources</PokeTableCell>
+                  <PokeTableCell>
+                    {activePlan.limits.dataSources.count === -1
+                      ? "unlimited"
+                      : activePlan.limits.dataSources.count}
+                  </PokeTableCell>
+                </PokeTableRow>
 
-              <PokeTableRow>
-                <PokeTableCell>
-                  Max number of documents in data sources
-                </PokeTableCell>
-                <PokeTableCell>
-                  {activePlan.limits.dataSources.documents.count === -1
-                    ? "unlimited"
-                    : activePlan.limits.dataSources.documents.count}
-                </PokeTableCell>
-              </PokeTableRow>
+                <PokeTableRow>
+                  <PokeTableCell>
+                    Max number of documents in data sources
+                  </PokeTableCell>
+                  <PokeTableCell>
+                    {activePlan.limits.dataSources.documents.count === -1
+                      ? "unlimited"
+                      : activePlan.limits.dataSources.documents.count}
+                  </PokeTableCell>
+                </PokeTableRow>
 
-              <PokeTableRow>
-                <PokeTableCell>Max documents size</PokeTableCell>
-                <PokeTableCell>
-                  {activePlan.limits.dataSources.documents.sizeMb === -1
-                    ? "unlimited"
-                    : `${activePlan.limits.dataSources.documents.sizeMb}Mb`}
-                </PokeTableCell>
-              </PokeTableRow>
-            </PokeTableBody>
-          </PokeTable>
+                <PokeTableRow>
+                  <PokeTableCell>Max documents size</PokeTableCell>
+                  <PokeTableCell>
+                    {activePlan.limits.dataSources.documents.sizeMb === -1
+                      ? "unlimited"
+                      : `${activePlan.limits.dataSources.documents.sizeMb}Mb`}
+                  </PokeTableCell>
+                </PokeTableRow>
+              </PokeTableBody>
+            </PokeTable>
+          </div>
         </div>
       </div>
-    </div>
+    </>
+  );
+}
+
+function ManageSubscriptionModal({
+  show,
+  onClose,
+  owner,
+  subscription,
+}: {
+  show: boolean;
+  onClose: () => void;
+  owner: WorkspaceType;
+  subscription: SubscriptionType;
+}) {
+  const router = useRouter();
+  const { plans } = usePokePlans();
+
+  const { submit: onDowngrade } = useSubmitFunction(async () => {
+    if (
+      !window.confirm(
+        "Are you sure you want to downgrade this workspace to no plan?"
+      )
+    ) {
+      return;
+    }
+    try {
+      const r = await fetch(`/api/poke/workspaces/${owner.sId}/downgrade`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+      if (!r.ok) {
+        throw new Error("Failed to downgrade workspace.");
+      }
+      router.reload();
+    } catch (e) {
+      console.error(e);
+      window.alert("An error occurred while downgrading the workspace.");
+    }
+  });
+
+  const { submit: onUpgradeToPlan } = useSubmitFunction(
+    async (plan: PlanType) => {
+      if (
+        !window.confirm(
+          `Are you sure you want to upgrade ${owner.name} (${owner.sId}) to plan ${plan.name} (${plan.code}) ?.`
+        )
+      ) {
+        return;
+      }
+      try {
+        const r = await fetch(
+          `/api/poke/workspaces/${owner.sId}/upgrade?planCode=${plan.code}`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+          }
+        );
+        if (!r.ok) {
+          throw new Error("Failed to upgrade workspace to plan.");
+        }
+        router.reload();
+      } catch (e) {
+        console.error(e);
+        window.alert(
+          "An error occurred while upgrading the workspace to plan."
+        );
+      }
+    }
+  );
+
+  return (
+    <Modal
+      isOpen={show}
+      onClose={onClose}
+      hasChanged={false}
+      title="Manage Subscription"
+      variant="full-screen"
+    >
+      <Page>
+        <Page.SectionHeader
+          title="Downgrade Workspace"
+          description="This action will downgrade the workspace to having no plan. This means that all the features will be disabled and members of
+          the workspaces will be redirected to the paywall page. After 15 days, the workspace data will be deleted."
+        />
+        <div>
+          <Button
+            label="Downgrade to NO PLAN"
+            variant="secondaryWarning"
+            onClick={onDowngrade}
+            disabled={subscription.plan.code === FREE_NO_PLAN_CODE}
+          />
+        </div>
+        <Separator />
+        <Page.SectionHeader
+          title="Upgrade Workspace to a Free Plan"
+          description="This action will upgrade the workspace to a free plan. This means that all the features will be enabled and members of the workspace will be able to use the workspace according to the selected plan product limitations."
+        />
+        <div>
+          {plans
+            .filter((p) => p.billingType === "free")
+            .map((p) => {
+              return (
+                <div key={p.code} className="pt-2">
+                  <Button
+                    variant="secondary"
+                    label={`Upgrade to ${p.code}`}
+                    onClick={() => onUpgradeToPlan(p)}
+                    disabled={subscription.plan.code === p.code}
+                  />
+                </div>
+              );
+            })}
+        </div>
+      </Page>
+      ;
+    </Modal>
   );
 }

--- a/front/components/poke/subscriptions/table.tsx
+++ b/front/components/poke/subscriptions/table.tsx
@@ -375,7 +375,7 @@ function ManageSubscriptionModal({
         />
         <div>
           {plans
-            .filter((p) => p.billingType === "free")
+            .filter((p) => p.code.startsWith("FREE_"))
             .map((p) => {
               return (
                 <div key={p.code} className="pt-2">


### PR DESCRIPTION
## Description


Some changes in Poké to move some actions from Collapsible buttons to modals -> most of the code in the diff was just moved. 
Review with hidden whitespaces recommended: https://github.com/dust-tt/dust/pull/4591/files?diff=split&w=1

### Cleanup a bit main buttons styles, move segmentation to right

<kbd>

<img width="1677" alt="Screenshot 2024-04-05 at 15 01 57" src="https://github.com/dust-tt/dust/assets/3803406/c101ae27-97ed-466a-a5b1-d65219f9fbf3">

</kbd>

### Move manage subscription to a dedicated modal + filter free plan based on code name.

=> Actually I renamed the modal title to "Upgrade / Downgrade workspace" without updating the screenshot)

<kbd>
<img width="1675" alt="Screenshot 2024-04-05 at 14 49 56" src="https://github.com/dust-tt/dust/assets/3803406/d534886b-e498-4685-a428-228cdadc8e2d">
</kbd>

### Move "Delete Workspace (GDPR) to a side modal.

<kbd>
<img width="1678" alt="Screenshot 2024-04-05 at 14 50 05" src="https://github.com/dust-tt/dust/assets/3803406/7f8ecae5-b2a6-4f2e-a8f0-b81d623a765a">
</kbd>


### Use Poké button to restore an assistant

<kbd>
<img width="1647" alt="Screenshot 2024-04-05 at 14 50 13" src="https://github.com/dust-tt/dust/assets/3803406/2daa1135-cbd6-4807-9e54-514e3a9386ad">
</kbd>


## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
