### PR TITLE
Add workflow to record workspace usage

### DIFF
--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -239,25 +239,21 @@ export const updateStripeSubscriptionQuantity = async ({
 
 /**
  * Calls the Stripe API to update the usage of a subscription.
- * Used for our "monthly active users" billing.
+ * Used for our metered prices.
  * For those plans Stripe price is configured with: "Usage type = Metered usage, Aggregation mode = Last value during period"
  * https://stripe.com/docs/products-prices/pricing-models#reporting-usage
  */
-export const updateStripeSubscriptionUsage = async ({
-  stripeSubscription,
-  quantity,
-}: {
-  stripeSubscription: Stripe.Subscription;
-  quantity: number;
-}): Promise<void> => {
-  const subscriptionItemId = stripeSubscription.items.data[0].id;
-  await stripe.subscriptionItems.createUsageRecord(subscriptionItemId, {
+export async function updateStripeActiveUsersForSubscriptionItem(
+  subscriptionItem: Stripe.SubscriptionItem,
+  quantity: number
+) {
+  await stripe.subscriptionItems.createUsageRecord(subscriptionItem.id, {
     // We do not send a timestamp, because we want to use the current time.
     // We use action = "set" to override the previous usage (as opposed to "increment")
     action: "set",
-    quantity: quantity,
+    quantity,
   });
-};
+}
 
 /**
  *

--- a/front/lib/plans/usage/index.ts
+++ b/front/lib/plans/usage/index.ts
@@ -1,0 +1,74 @@
+import type { LightWorkspaceType, Result } from "@dust-tt/types";
+import { assertNever, Err, Ok } from "@dust-tt/types";
+import type Stripe from "stripe";
+
+import { reportMonthlyActiveUsers } from "@app/lib/plans/usage/mau";
+import type {
+  InvalidRecurringPriceError,
+  SupportedReportUsage,
+} from "@app/lib/plans/usage/types";
+import {
+  InvalidReportUsageError,
+  isSupportedReportUsage,
+  REPORT_USAGE_METADATA_KEY,
+} from "@app/lib/plans/usage/types";
+
+function getUsageToReportForSubscriptionItem(
+  item: Stripe.SubscriptionItem
+): Result<SupportedReportUsage | null, InvalidReportUsageError> {
+  const usageToReport = item.price.metadata[REPORT_USAGE_METADATA_KEY];
+
+  if (!usageToReport) {
+    return new Ok(null);
+  }
+
+  if (isSupportedReportUsage(usageToReport)) {
+    return new Ok(usageToReport);
+  }
+
+  return new Err(new InvalidReportUsageError());
+}
+
+export async function reportUsageForSubscriptionItems(
+  stripeSubscription: Stripe.Subscription,
+  workspace: LightWorkspaceType
+): Promise<
+  Result<undefined, InvalidRecurringPriceError | InvalidReportUsageError>
+> {
+  const { data: subscriptionItems } = stripeSubscription.items;
+
+  for (const item of subscriptionItems) {
+    const usageToReportRes = getUsageToReportForSubscriptionItem(item);
+    if (usageToReportRes.isErr()) {
+      return new Err(usageToReportRes.error);
+    }
+
+    const usageToReport = usageToReportRes.value;
+    if (!usageToReport) {
+      return new Ok(undefined);
+    }
+
+    switch (usageToReport) {
+      case "MAU_1":
+      case "MAU_5":
+      case "MAU_10":
+        const res = await reportMonthlyActiveUsers(
+          stripeSubscription,
+          item,
+          workspace,
+          usageToReport
+        );
+
+        if (res.isErr()) {
+          return res;
+        }
+
+        break;
+
+      default:
+        assertNever(usageToReport);
+    }
+  }
+
+  return new Ok(undefined);
+}

--- a/front/lib/plans/usage/mau.ts
+++ b/front/lib/plans/usage/mau.ts
@@ -1,0 +1,90 @@
+import type { LightWorkspaceType, Result } from "@dust-tt/types";
+import { Err, Ok } from "@dust-tt/types";
+import { QueryTypes } from "sequelize";
+import type Stripe from "stripe";
+
+import { updateStripeActiveUsersForSubscriptionItem } from "@app/lib/plans/stripe";
+import type { MauReportUsageType } from "@app/lib/plans/usage/types";
+import { InvalidRecurringPriceError } from "@app/lib/plans/usage/types";
+import { getFrontReplicaDbConnection } from "@app/lib/resources/storage";
+
+export async function getActiveUsersInWorkspaceForPeriod({
+  messagesPerMonthForMau,
+  since,
+  to,
+  workspace,
+}: {
+  messagesPerMonthForMau: number;
+  since: Date;
+  to?: Date;
+  workspace: LightWorkspaceType;
+}): Promise<number> {
+  // Use the replica database to compute this avoid impacting production performances.
+  const result = await getFrontReplicaDbConnection().query(
+    `
+    SELECT "user_messages"."userId", COUNT(mentions.id) AS count
+    FROM messages
+    INNER JOIN conversations ON messages."conversationId" = conversations.id
+    INNER JOIN user_messages ON messages."userMessageId" = user_messages.id
+    INNER JOIN mentions ON mentions."messageId" = messages.id
+    WHERE conversations."workspaceId" = :workspaceId
+    AND "user_messages"."userId" IS NOT NULL
+    AND "mentions"."createdAt" BETWEEN :startDate AND :endDate
+    GROUP BY "user_messages"."userId"
+    HAVING COUNT(mentions.*) >= :minNumberOfRows
+  `,
+    {
+      replacements: {
+        workspaceId: workspace.id,
+        startDate: since,
+        endDate: to ?? new Date(),
+        minNumberOfRows: messagesPerMonthForMau,
+      },
+      type: QueryTypes.SELECT,
+    }
+  );
+
+  return result.length;
+}
+
+export async function reportMonthlyActiveUsers(
+  stripeSubscription: Stripe.Subscription,
+  stripeSubscriptionItem: Stripe.SubscriptionItem,
+  workspace: LightWorkspaceType,
+  usage: MauReportUsageType
+): Promise<Result<undefined, InvalidRecurringPriceError>> {
+  const [, rawMessagesPerMonthForMau] = usage.split("_");
+  const messagesPerMonthForMau = parseInt(rawMessagesPerMonthForMau, 10);
+
+  const { recurring } = stripeSubscriptionItem.price;
+  if (!recurring) {
+    return new Err(
+      new InvalidRecurringPriceError(
+        "MAU Usage base price only supports prices with monthly recurring."
+      )
+    );
+  }
+
+  const { interval, interval_count: intervalCount } = recurring;
+  if (interval !== "month" || intervalCount !== 1) {
+    return new Err(
+      new InvalidRecurringPriceError(
+        `Expected 1 month recurring, found ${intervalCount} ${interval}(s) instead.`
+      )
+    );
+  }
+
+  const activeUsers = await getActiveUsersInWorkspaceForPeriod({
+    messagesPerMonthForMau,
+    since: new Date(stripeSubscription.current_period_start * 1000),
+    to: new Date(stripeSubscription.current_period_end * 1000),
+    workspace,
+  });
+
+  await updateStripeActiveUsersForSubscriptionItem(
+    stripeSubscriptionItem,
+    activeUsers
+  );
+
+  return new Ok(undefined);
+}

--- a/front/lib/plans/usage/types.ts
+++ b/front/lib/plans/usage/types.ts
@@ -1,0 +1,53 @@
+import type { Result } from "@dust-tt/types";
+import { Err, Ok } from "@dust-tt/types";
+import type Stripe from "stripe";
+
+// This is the key used in Stripe's metadata to indicate that this is a usage-based price.
+export const REPORT_USAGE_METADATA_KEY = "REPORT_USAGE";
+
+export class InvalidReportUsageError extends Error {}
+
+export const SUPPORTED_REPORT_USAGE = ["MAU_1", "MAU_5", "MAU_10"] as const;
+export type SupportedReportUsage = (typeof SUPPORTED_REPORT_USAGE)[number];
+
+export function isSupportedReportUsage(
+  usage: string | undefined
+): usage is SupportedReportUsage {
+  return SUPPORTED_REPORT_USAGE.includes(usage as SupportedReportUsage);
+}
+
+/**
+ * Monthly active users logic.
+ */
+
+export type MauReportUsageType = `MAU_${number}`;
+
+/**
+ * Validates that the subscription has a valid recurring price.
+ */
+
+export class InvalidRecurringPriceError extends Error {}
+
+export function validateSubscriptionRecurringPrice(
+  stripeSubscriptionItem: Stripe.SubscriptionItem
+): Result<undefined, InvalidRecurringPriceError> {
+  const { recurring } = stripeSubscriptionItem.price;
+  if (!recurring) {
+    return new Err(
+      new InvalidRecurringPriceError(
+        "MAU Usage base price only supports prices with monthly recurring."
+      )
+    );
+  }
+
+  const { interval, interval_count: intervalCount } = recurring;
+  if (interval !== "month" || intervalCount !== 1) {
+    return new Err(
+      new InvalidRecurringPriceError(
+        `Expected 1 month recurring, found ${intervalCount} ${interval}(s) instead.`
+      )
+    );
+  }
+
+  return new Ok(undefined);
+}

--- a/front/lib/resources/storage/config.ts
+++ b/front/lib/resources/storage/config.ts
@@ -4,6 +4,9 @@ export const dbConfig = {
   getRequiredFrontDatabaseURI: (): string => {
     return EnvironmentConfig.getEnvVariable("FRONT_DATABASE_URI");
   },
+  getRequiredFrontReplicaDatabaseURI: (): string => {
+    return EnvironmentConfig.getEnvVariable("FRONT_DATABASE_READ_REPLICA_URI");
+  },
 };
 
 export const gcsConfig = {

--- a/front/lib/resources/storage/index.ts
+++ b/front/lib/resources/storage/index.ts
@@ -33,3 +33,18 @@ export const frontSequelize = new Sequelize(
     },
   }
 );
+
+let frontReplicaDbInstance: Sequelize | null = null;
+
+export function getFrontReplicaDbConnection() {
+  if (!frontReplicaDbInstance) {
+    frontReplicaDbInstance = new Sequelize(
+      dbConfig.getRequiredFrontReplicaDatabaseURI() as string,
+      {
+        logging: false,
+      }
+    );
+  }
+
+  return frontReplicaDbInstance;
+}

--- a/front/start_worker.ts
+++ b/front/start_worker.ts
@@ -5,23 +5,28 @@ import logger from "@app/logger/logger";
 import { runPokeWorker } from "@app/poke/temporal/worker";
 import { runProductionChecksWorker } from "@app/production_checks/temporal/worker";
 import { runScrubWorkspaceQueueWorker } from "@app/scrub_workspace/temporal/worker";
+import { runUpdateWorkspaceUsageWorker } from "@app/temporal/usage_queue/worker";
 import { runUpsertQueueWorker } from "@app/upsert_queue/temporal/worker";
 
 setupGlobalErrorHandler(logger);
 
 runPostUpsertHooksWorker().catch((err) =>
-  logger.error({ error: err }, "Error running post upsert hooks worker")
+  logger.error({ error: err }, "Error running post upsert hooks worker.")
 );
 runPokeWorker().catch((err) =>
-  logger.error({ error: err }, "Error running poke worker")
+  logger.error({ error: err }, "Error running poke worker.")
 );
 
 runProductionChecksWorker().catch((err) =>
-  logger.error({ error: err }, "Error running production checks worker")
+  logger.error({ error: err }, "Error running production checks worker.")
 );
 
 runUpsertQueueWorker().catch((err) =>
-  logger.error({ error: err }, "Error running upsert queue worker")
+  logger.error({ error: err }, "Error running upsert queue worker.")
+);
+
+runUpdateWorkspaceUsageWorker().catch((err) =>
+  logger.error({ error: err }, "Error running usage queue worker.")
 );
 
 runScrubWorkspaceQueueWorker().catch((err) =>

--- a/front/temporal/usage_queue/activities.ts
+++ b/front/temporal/usage_queue/activities.ts
@@ -1,0 +1,50 @@
+import { Subscription, Workspace } from "@app/lib/models";
+import { getStripeSubscription } from "@app/lib/plans/stripe";
+import { reportUsageForSubscriptionItems } from "@app/lib/plans/usage";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
+import mainLogger from "@app/logger/logger";
+
+export async function recordUsageActivity(workspaceId: string) {
+  const workspace = await Workspace.findOne({
+    where: {
+      sId: workspaceId,
+    },
+  });
+  if (!workspace) {
+    throw new Error("Workspace not found.");
+  }
+
+  const subscription = await Subscription.findOne({
+    where: {
+      workspaceId: workspace.id,
+    },
+  });
+
+  const logger = mainLogger.child({ workspaceId });
+  logger.info({}, "[UsageQueue] Recording usage for worskpace.");
+
+  if (
+    !subscription ||
+    !workspace ||
+    !subscription.stripeSubscriptionId ||
+    !subscription.stripeCustomerId
+  ) {
+    throw new Error(
+      "Cannot record usage of subscription: missing Stripe subscription Id or Stripe customer Id."
+    );
+  }
+
+  const stripeSubscription = await getStripeSubscription(
+    subscription.stripeSubscriptionId
+  );
+  if (!stripeSubscription) {
+    throw new Error(
+      `Cannot update usage in subscription: Stripe subscription ${subscription.stripeSubscriptionId} not found.`
+    );
+  }
+
+  await reportUsageForSubscriptionItems(
+    stripeSubscription,
+    renderLightWorkspaceType({ workspace })
+  );
+}

--- a/front/temporal/usage_queue/client.ts
+++ b/front/temporal/usage_queue/client.ts
@@ -1,0 +1,66 @@
+import type { Result } from "@dust-tt/types";
+import { Err, Ok, rateLimiter } from "@dust-tt/types";
+
+import { getTemporalClient } from "@app/lib/temporal";
+import logger from "@app/logger/logger";
+import { QUEUE_NAME } from "@app/temporal/usage_queue/config";
+import { updateWorkspaceUsageWorkflow } from "@app/temporal/usage_queue/workflows";
+
+async function shouldProcessUsageUpdate(workflowId: string) {
+  // Compute the max usage of the workspace once per hour.
+  const hasRunInPastHour = await rateLimiter({
+    key: workflowId,
+    maxPerTimeframe: 1,
+    timeframeSeconds: 60 * 60, // 1 hour.
+    logger: logger,
+  });
+
+  return hasRunInPastHour === 0;
+}
+
+/**
+ * This function starts a workflow to compute the maximum usage of a workspace once per hour per workspace.
+ */
+export async function launchUpdateUsageWorkflow({
+  workspaceId,
+}: {
+  workspaceId: string;
+}): Promise<Result<undefined, Error>> {
+  const workflowId = `workflow-usage-queue-${workspaceId}`;
+
+  const shouldProcess = await shouldProcessUsageUpdate(workflowId);
+  if (!shouldProcess) {
+    return new Ok(undefined);
+  }
+
+  const client = await getTemporalClient();
+
+  try {
+    await client.workflow.start(updateWorkspaceUsageWorkflow, {
+      args: [workspaceId],
+      taskQueue: QUEUE_NAME,
+      workflowId: workflowId,
+      memo: {
+        workspaceId,
+      },
+    });
+
+    logger.info(
+      {
+        workflowId,
+      },
+      "Started usage workflow."
+    );
+
+    return new Ok(undefined);
+  } catch (e) {
+    logger.error(
+      {
+        workflowId,
+        error: e,
+      },
+      "Failed starting usage workflow."
+    );
+    return new Err(e as Error);
+  }
+}

--- a/front/temporal/usage_queue/config.ts
+++ b/front/temporal/usage_queue/config.ts
@@ -1,0 +1,3 @@
+const QUEUE_VERSION = 1;
+
+export const QUEUE_NAME = `usage-queue-v${QUEUE_VERSION}`;

--- a/front/temporal/usage_queue/worker.ts
+++ b/front/temporal/usage_queue/worker.ts
@@ -1,0 +1,30 @@
+import type { Context } from "@temporalio/activity";
+import { Worker } from "@temporalio/worker";
+
+import { getTemporalWorkerConnection } from "@app/lib/temporal";
+import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
+import logger from "@app/logger/logger";
+import * as activities from "@app/temporal/usage_queue/activities";
+
+import { QUEUE_NAME } from "./config";
+
+export async function runUpdateWorkspaceUsageWorker() {
+  const { connection, namespace } = await getTemporalWorkerConnection();
+  const worker = await Worker.create({
+    workflowsPath: require.resolve("./workflows"),
+    activities,
+    taskQueue: QUEUE_NAME,
+    maxConcurrentActivityTaskExecutions: 32,
+    connection,
+    namespace,
+    interceptors: {
+      activityInbound: [
+        (ctx: Context) => {
+          return new ActivityInboundLogInterceptor(ctx, logger);
+        },
+      ],
+    },
+  });
+
+  await worker.run();
+}

--- a/front/temporal/usage_queue/workflows.ts
+++ b/front/temporal/usage_queue/workflows.ts
@@ -1,0 +1,14 @@
+import { proxyActivities, sleep } from "@temporalio/workflow";
+
+import type * as activities from "@app/temporal/usage_queue/activities";
+
+const { recordUsageActivity } = proxyActivities<typeof activities>({
+  startToCloseTimeout: "10 minutes",
+});
+
+export async function updateWorkspaceUsageWorkflow(workspaceId: string) {
+  // Sleep for one hour before computing usage.
+  await sleep(60 * 60 * 1000);
+
+  await recordUsageActivity(workspaceId);
+}


### PR DESCRIPTION
## Description

See https://github.com/dust-tt/tasks/issues/567.

This PR sets the groundwork for implementing usage-based pricing. It introduces a new temporal workflow to track usage on a per-workspace basis, with all logic contained within the workflow.

The initial focus of this PR is on Monthly Active Users (MAUs). With every new agent message, a workflow is initiated to update the usage in Stripe. To prevent excessive workflow executions, it is limited to run at most once per hour for each workspace.

There are several considerations to keep in mind with this code:
- The supported usage metadata is strictly enforced. If the Stripe prices are not correctly configured, the activity will intentionally fail repeatedly.
- Events are enqueued for all workspace types, and the Stripe subscription determines whether usage needs to be reported.
- Some previously unused code related to the `monthly_active_users` billing type has been removed.
- Calculating the number of users who have received at least one agent message over a given time period is not a straightforward task. For now, we use extensive joins and the `mentions` table as our source of truth. Since this process will run a maximum of once per hour for usage-based workspaces, this approach is acceptable.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
