### PR TITLE
WebCrawlerConfigurationResource

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,8 +3,8 @@
   "rust-analyzer.linkedProjects": ["./core/Cargo.toml"],
 
   "editor.codeActionsOnSave": {
-    "source.organizeImports": false,
-    "source.fixAll.eslint": true
+    "source.organizeImports": "never",
+    "source.fixAll.eslint": "explicit"
   },
   "eslint.run": "onSave",
   "typescript.preferences.importModuleSpecifier": "non-relative"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,8 +3,8 @@
   "rust-analyzer.linkedProjects": ["./core/Cargo.toml"],
 
   "editor.codeActionsOnSave": {
-    "source.organizeImports": "never",
-    "source.fixAll.eslint": "explicit"
+    "source.organizeImports": false,
+    "source.fixAll.eslint": true
   },
   "eslint.run": "onSave",
   "typescript.preferences.importModuleSpecifier": "non-relative"

--- a/connectors/src/admin/db.ts
+++ b/connectors/src/admin/db.ts
@@ -45,7 +45,7 @@ import {
   SlackMessages,
 } from "@connectors/lib/models/slack";
 import {
-  WebCrawlerConfiguration,
+  WebCrawlerConfigurationModel,
   WebCrawlerFolder,
   WebCrawlerPage,
 } from "@connectors/lib/models/webcrawler";
@@ -87,7 +87,7 @@ async function main(): Promise<void> {
   await IntercomArticle.sync({ alter: true });
   await IntercomTeam.sync({ alter: true });
   await IntercomConversation.sync({ alter: true });
-  await WebCrawlerConfiguration.sync({ alter: true });
+  await WebCrawlerConfigurationModel.sync({ alter: true });
   await WebCrawlerFolder.sync({ alter: true });
   await WebCrawlerPage.sync({ alter: true });
 

--- a/connectors/src/admin/db.ts
+++ b/connectors/src/admin/db.ts
@@ -45,6 +45,7 @@ import {
   SlackMessages,
 } from "@connectors/lib/models/slack";
 import {
+  WebCrawlerConfigurationHeader,
   WebCrawlerConfigurationModel,
   WebCrawlerFolder,
   WebCrawlerPage,
@@ -90,6 +91,7 @@ async function main(): Promise<void> {
   await WebCrawlerConfigurationModel.sync({ alter: true });
   await WebCrawlerFolder.sync({ alter: true });
   await WebCrawlerPage.sync({ alter: true });
+  await WebCrawlerConfigurationHeader.sync({ alter: true });
 
   // enable the `unaccent` extension
   await sequelizeConnection.query("CREATE EXTENSION IF NOT EXISTS unaccent;");

--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -95,8 +95,8 @@ export async function crawlWebsiteByConnectorId(connectorId: ModelId) {
           if (!crawlingContext.request.headers) {
             crawlingContext.request.headers = {};
           }
-          for (const ch of Object.entries(customHeaders)) {
-            crawlingContext.request.headers[ch[0]] = ch[1];
+          for (const [header, value] of Object.entries(customHeaders)) {
+            crawlingContext.request.headers[header] = value;
           }
         },
       ],

--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -54,7 +54,7 @@ export async function crawlWebsiteByConnectorId(connectorId: ModelId) {
     connectorId: connector.id,
   });
 
-  // Immeditaley marking the config as crawled to avoid having the scheduler seeing it as a candidate for crawling
+  // Immediately marking the config as crawled to avoid having the scheduler seeing it as a candidate for crawling
   // in case of the crawling takes too long or fails.
   await webCrawlerConfig.markedAsCrawled();
 
@@ -387,6 +387,6 @@ export async function webCrawlerGarbageCollector(
   } while (foldersToDelete.length > 0);
 }
 
-export async function getWebsitesToCrawl() {
-  return WebCrawlerConfigurationResource.getWebsitesToCrawl();
+export async function getWebsitesToCrawlConnectorIds() {
+  return WebCrawlerConfigurationResource.getWebsitesToCrawlConnectorIds();
 }

--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -58,6 +58,8 @@ export async function crawlWebsiteByConnectorId(connectorId: ModelId) {
   // in case of the crawling takes too long or fails.
   await webCrawlerConfig.markedAsCrawled();
 
+  const customHeaders = await webCrawlerConfig.getCustomHeaders();
+
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
   let pageCount = 0;
   let crawlingError = 0;
@@ -88,6 +90,13 @@ export async function crawlWebsiteByConnectorId(connectorId: ModelId) {
               },
               `Private IP address detected. Skipping.`
             );
+          }
+
+          if (!crawlingContext.request.headers) {
+            crawlingContext.request.headers = {};
+          }
+          for (const ch of Object.entries(customHeaders)) {
+            crawlingContext.request.headers[ch[0]] = ch[1];
           }
         },
       ],

--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -387,6 +387,6 @@ export async function webCrawlerGarbageCollector(
   } while (foldersToDelete.length > 0);
 }
 
-export async function getWebsitesToCrawlConnectorIds() {
-  return WebCrawlerConfigurationResource.getWebsitesToCrawlConnectorIds();
+export async function getConnectorIdsForWebsitesToCrawl() {
+  return WebCrawlerConfigurationResource.getConnectorIdsForWebsitesToCrawl();
 }

--- a/connectors/src/connectors/webcrawler/temporal/workflows.ts
+++ b/connectors/src/connectors/webcrawler/temporal/workflows.ts
@@ -26,7 +26,9 @@ const { crawlWebsiteByConnectorId, webCrawlerGarbageCollector } =
     },
   });
 
-const { getWebsitesToCrawl } = proxyActivities<typeof activities>({
+const { getWebsitesToCrawlConnectorIds: getWebsitesToCrawl } = proxyActivities<
+  typeof activities
+>({
   startToCloseTimeout: "2 minutes",
 });
 

--- a/connectors/src/connectors/webcrawler/temporal/workflows.ts
+++ b/connectors/src/connectors/webcrawler/temporal/workflows.ts
@@ -26,7 +26,7 @@ const { crawlWebsiteByConnectorId, webCrawlerGarbageCollector } =
     },
   });
 
-const { getWebsitesToCrawlConnectorIds: getWebsitesToCrawl } = proxyActivities<
+const { getConnectorIdsForWebsitesToCrawl } = proxyActivities<
   typeof activities
 >({
   startToCloseTimeout: "2 minutes",
@@ -47,7 +47,7 @@ export function crawlWebsiteWorkflowId(connectorId: ModelId) {
 }
 
 export async function crawlWebsiteSchedulerWorkflow() {
-  const connectorIds = await getWebsitesToCrawl();
+  const connectorIds = await getConnectorIdsForWebsitesToCrawl();
 
   for (const connectorId of connectorIds) {
     await executeChild(crawlWebsiteWorkflow, {

--- a/connectors/src/lib/models/webcrawler.ts
+++ b/connectors/src/lib/models/webcrawler.ts
@@ -87,7 +87,9 @@ export class WebCrawlerConfigurationHeader extends Model<
   declare updatedAt: CreationOptional<Date>;
   declare key: string;
   declare value: string;
-  declare configurationId: ForeignKey<WebCrawlerConfigurationModel["id"]>;
+  declare webcrawlerConfigurationId: ForeignKey<
+    WebCrawlerConfigurationModel["id"]
+  >;
 }
 
 WebCrawlerConfigurationHeader.init(
@@ -122,11 +124,13 @@ WebCrawlerConfigurationHeader.init(
     indexes: [
       {
         unique: true,
-        fields: ["key", "configurationId"],
+        fields: ["webcrawlerConfigurationId", "key"],
       },
     ],
   }
 );
+
+WebCrawlerConfigurationModel.hasMany(WebCrawlerConfigurationHeader);
 
 export class WebCrawlerFolder extends Model<
   InferAttributes<WebCrawlerFolder>,

--- a/connectors/src/lib/models/webcrawler.ts
+++ b/connectors/src/lib/models/webcrawler.ts
@@ -10,9 +10,9 @@ import { DataTypes, Model } from "sequelize";
 import { sequelizeConnection } from "@connectors/resources/storage";
 import { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
 
-export class WebCrawlerConfiguration extends Model<
-  InferAttributes<WebCrawlerConfiguration>,
-  InferCreationAttributes<WebCrawlerConfiguration>
+export class WebCrawlerConfigurationModel extends Model<
+  InferAttributes<WebCrawlerConfigurationModel>,
+  InferCreationAttributes<WebCrawlerConfigurationModel>
 > {
   declare id: CreationOptional<number>;
   declare createdAt: CreationOptional<Date>;
@@ -26,7 +26,7 @@ export class WebCrawlerConfiguration extends Model<
   declare lastCrawledAt: Date | null;
 }
 
-WebCrawlerConfiguration.init(
+WebCrawlerConfigurationModel.init(
   {
     id: {
       type: DataTypes.INTEGER,
@@ -76,7 +76,57 @@ WebCrawlerConfiguration.init(
     modelName: "webcrawler_configurations",
   }
 );
-ConnectorModel.hasMany(WebCrawlerConfiguration);
+ConnectorModel.hasMany(WebCrawlerConfigurationModel);
+
+export class WebCrawlerConfigurationHeader extends Model<
+  InferAttributes<WebCrawlerConfigurationHeader>,
+  InferCreationAttributes<WebCrawlerConfigurationHeader>
+> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+  declare key: string;
+  declare value: string;
+  declare configurationId: ForeignKey<WebCrawlerConfigurationModel["id"]>;
+}
+
+WebCrawlerConfigurationHeader.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    key: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    value: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+  },
+  {
+    sequelize: sequelizeConnection,
+    modelName: "webcrawler_configuration_headers",
+    indexes: [
+      {
+        unique: true,
+        fields: ["key", "configurationId"],
+      },
+    ],
+  }
+);
 
 export class WebCrawlerFolder extends Model<
   InferAttributes<WebCrawlerFolder>,
@@ -92,7 +142,9 @@ export class WebCrawlerFolder extends Model<
   declare internalId: string;
   declare lastSeenAt: Date;
   declare connectorId: ForeignKey<ConnectorModel["id"]>;
-  declare webcrawlerConfigurationId: ForeignKey<WebCrawlerConfiguration["id"]>;
+  declare webcrawlerConfigurationId: ForeignKey<
+    WebCrawlerConfigurationModel["id"]
+  >;
 }
 
 WebCrawlerFolder.init(
@@ -142,7 +194,7 @@ WebCrawlerFolder.init(
   }
 );
 ConnectorModel.hasMany(WebCrawlerFolder);
-WebCrawlerConfiguration.hasMany(WebCrawlerFolder);
+WebCrawlerConfigurationModel.hasMany(WebCrawlerFolder);
 
 export class WebCrawlerPage extends Model<
   InferAttributes<WebCrawlerPage>,
@@ -158,7 +210,9 @@ export class WebCrawlerPage extends Model<
   declare depth: number;
   declare lastSeenAt: Date;
   declare connectorId: ForeignKey<ConnectorModel["id"]>;
-  declare webcrawlerConfigurationId: ForeignKey<WebCrawlerConfiguration["id"]>;
+  declare webcrawlerConfigurationId: ForeignKey<
+    WebCrawlerConfigurationModel["id"]
+  >;
 }
 
 WebCrawlerPage.init(
@@ -216,4 +270,4 @@ WebCrawlerPage.init(
   }
 );
 ConnectorModel.hasMany(WebCrawlerPage);
-WebCrawlerConfiguration.hasMany(WebCrawlerPage);
+WebCrawlerConfigurationModel.hasMany(WebCrawlerPage);

--- a/connectors/src/lib/renderers/connector.ts
+++ b/connectors/src/lib/renderers/connector.ts
@@ -3,8 +3,8 @@ import type {
   WebCrawlerConfigurationType,
 } from "@dust-tt/types";
 
-import { WebCrawlerConfiguration } from "@connectors/lib/models/webcrawler";
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
+import { WebCrawlerConfigurationResource } from "@connectors/resources/webcrawler_resource";
 
 export async function renderConnectorType(
   connector: ConnectorResource
@@ -26,11 +26,9 @@ export async function renderConnectorType(
 async function renderConfiguration(connector: ConnectorResource) {
   switch (connector.type) {
     case "webcrawler": {
-      const config = await WebCrawlerConfiguration.findOne({
-        where: {
-          connectorId: connector.id,
-        },
-      });
+      const config = await WebCrawlerConfigurationResource.fetchByConnectorId(
+        connector.id
+      );
       if (!config) {
         throw new Error(
           `Webcrawler configuration not found for connector ${connector.id}`
@@ -44,7 +42,7 @@ async function renderConfiguration(connector: ConnectorResource) {
 }
 
 async function renderWebcrawlerConfiguration(
-  webCrawlerConfiguration: WebCrawlerConfiguration
+  webCrawlerConfiguration: WebCrawlerConfigurationResource
 ): Promise<WebCrawlerConfigurationType> {
   return {
     url: webCrawlerConfiguration.url,

--- a/connectors/src/lib/renderers/connector.ts
+++ b/connectors/src/lib/renderers/connector.ts
@@ -50,5 +50,6 @@ async function renderWebcrawlerConfiguration(
     crawlMode: webCrawlerConfiguration.crawlMode,
     depth: webCrawlerConfiguration.depth,
     crawlFrequency: webCrawlerConfiguration.crawlFrequency,
+    headers: await webCrawlerConfiguration.getCustomHeaders(),
   };
 }

--- a/connectors/src/resources/connector/strategy.ts
+++ b/connectors/src/resources/connector/strategy.ts
@@ -8,7 +8,7 @@ import type { GoogleDriveConfig } from "@connectors/lib/models/google_drive";
 import type { IntercomWorkspace } from "@connectors/lib/models/intercom";
 import type { NotionConnectorState } from "@connectors/lib/models/notion";
 import type { SlackConfigurationModel } from "@connectors/lib/models/slack";
-import type { WebCrawlerConfiguration } from "@connectors/lib/models/webcrawler";
+import type { WebCrawlerConfigurationModel } from "@connectors/lib/models/webcrawler";
 import { ConfluenceConnectorStrategy } from "@connectors/resources/connector/confluence";
 import { GithubConnectorStrategy } from "@connectors/resources/connector/github";
 import { GoogleDriveConnectorStrategy } from "@connectors/resources/connector/google_drive";
@@ -27,7 +27,7 @@ export interface ConnectorProviderModelM {
   intercom: IntercomWorkspace;
   notion: NotionConnectorState;
   slack: SlackConfigurationModel;
-  webcrawler: WebCrawlerConfiguration;
+  webcrawler: WebCrawlerConfigurationModel;
 }
 
 export type ConnectorProviderModelMapping = {

--- a/connectors/src/resources/connector/webcrawler.ts
+++ b/connectors/src/resources/connector/webcrawler.ts
@@ -1,10 +1,6 @@
 import type { Transaction } from "sequelize";
 
-import {
-  WebCrawlerConfigurationModel,
-  WebCrawlerFolder,
-  WebCrawlerPage,
-} from "@connectors/lib/models/webcrawler";
+import type { WebCrawlerConfigurationModel } from "@connectors/lib/models/webcrawler";
 import type {
   ConnectorProviderStrategy,
   WithCreationAttributes,
@@ -31,23 +27,14 @@ export class WebCrawlerStrategy implements ConnectorProviderStrategy {
     connector: ConnectorResource,
     transaction: Transaction
   ): Promise<void> {
-    await WebCrawlerPage.destroy({
-      where: {
-        connectorId: connector.id,
-      },
-      transaction,
-    });
-    await WebCrawlerFolder.destroy({
-      where: {
-        connectorId: connector.id,
-      },
-      transaction,
-    });
-    await WebCrawlerConfigurationModel.destroy({
-      where: {
-        connectorId: connector.id,
-      },
-      transaction,
-    });
+    const resource = await WebCrawlerConfigurationResource.fetchByConnectorId(
+      connector.id
+    );
+    if (!resource) {
+      throw new Error(
+        `No WebCrawlerConfiguration found for connector ${connector.id}`
+      );
+    }
+    await resource.delete(transaction);
   }
 }

--- a/connectors/src/resources/connector/webcrawler.ts
+++ b/connectors/src/resources/connector/webcrawler.ts
@@ -1,7 +1,7 @@
 import type { Transaction } from "sequelize";
 
 import {
-  WebCrawlerConfiguration,
+  WebCrawlerConfigurationModel,
   WebCrawlerFolder,
   WebCrawlerPage,
 } from "@connectors/lib/models/webcrawler";
@@ -10,19 +10,20 @@ import type {
   WithCreationAttributes,
 } from "@connectors/resources/connector/strategy";
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
+import { WebCrawlerConfigurationResource } from "@connectors/resources/webcrawler_resource";
 
 export class WebCrawlerStrategy implements ConnectorProviderStrategy {
   async makeNew(
     connector: ConnectorResource,
-    blob: WithCreationAttributes<WebCrawlerConfiguration>,
+    blob: WithCreationAttributes<WebCrawlerConfigurationModel>,
     transaction: Transaction
   ): Promise<void> {
-    await WebCrawlerConfiguration.create(
+    await WebCrawlerConfigurationResource.makeNew(
       {
         ...blob,
         connectorId: connector.id,
       },
-      { transaction }
+      transaction
     );
   }
 
@@ -42,7 +43,7 @@ export class WebCrawlerStrategy implements ConnectorProviderStrategy {
       },
       transaction,
     });
-    await WebCrawlerConfiguration.destroy({
+    await WebCrawlerConfigurationModel.destroy({
       where: {
         connectorId: connector.id,
       },

--- a/connectors/src/resources/webcrawler_resource.ts
+++ b/connectors/src/resources/webcrawler_resource.ts
@@ -62,7 +62,7 @@ export class WebCrawlerConfigurationResource extends BaseResource<WebCrawlerConf
     return new this(this.model, config.get());
   }
 
-  static async getWebsitesToCrawlConnectorIds() {
+  static async getConnectorIdsForWebsitesToCrawl() {
     const frequencyToSQLQuery: Record<CrawlingFrequency, string> = {
       never: "never",
       daily: "1 day",

--- a/connectors/src/resources/webcrawler_resource.ts
+++ b/connectors/src/resources/webcrawler_resource.ts
@@ -1,5 +1,5 @@
 import type { CrawlingFrequency, ModelId, Result } from "@dust-tt/types";
-import { CrawlingFrequencies, Err, Ok } from "@dust-tt/types";
+import { CrawlingFrequencies, Ok } from "@dust-tt/types";
 import type {
   Attributes,
   CreationAttributes,

--- a/connectors/src/resources/webcrawler_resource.ts
+++ b/connectors/src/resources/webcrawler_resource.ts
@@ -59,9 +59,7 @@ export class WebCrawlerConfigurationResource extends BaseResource<WebCrawlerConf
       { transaction }
     );
 
-    const res = new this(this.model, config.get());
-
-    return res;
+    return new this(this.model, config.get());
   }
 
   static async getWebsitesToCrawlConnectorIds() {

--- a/connectors/src/resources/webcrawler_resource.ts
+++ b/connectors/src/resources/webcrawler_resource.ts
@@ -9,6 +9,7 @@ import type {
 import { literal, Op } from "sequelize";
 
 import {
+  WebCrawlerConfigurationHeader,
   WebCrawlerConfigurationModel,
   WebCrawlerFolder,
   WebCrawlerPage,
@@ -107,6 +108,34 @@ export class WebCrawlerConfigurationResource extends BaseResource<WebCrawlerConf
         },
       }
     );
+  }
+
+  async addCustomeHeader(key: string, value: string) {
+    //regexp to validate http header name
+    const headerNameRegexp = /^[\w-]+$/;
+    if (!headerNameRegexp.test(key)) {
+      return new Error(`Invalid header name ${key}`);
+    }
+    await WebCrawlerConfigurationHeader.upsert({
+      webcrawlerConfigurationId: this.id,
+      key,
+      value,
+    });
+  }
+
+  async getCustomHeaders(): Promise<Record<string, string>> {
+    const result: Record<string, string> = {};
+    const headers = await WebCrawlerConfigurationHeader.findAll({
+      where: {
+        webcrawlerConfigurationId: this.id,
+      },
+    });
+
+    headers.forEach((header) => {
+      result[header.key] = header.value;
+    });
+
+    return result;
   }
 
   async delete(transaction?: Transaction): Promise<Result<undefined, Error>> {

--- a/connectors/src/resources/webcrawler_resource.ts
+++ b/connectors/src/resources/webcrawler_resource.ts
@@ -109,7 +109,10 @@ export class WebCrawlerConfigurationResource extends BaseResource<WebCrawlerConf
     );
   }
 
-  async addCustomeHeader(key: string, value: string) {
+  async addCustomHeader(
+    key: string,
+    value: string
+  ): Promise<Result<undefined, Error>> {
     //regexp to validate http header name
     const headerNameRegexp = /^[\w-]+$/;
     if (!headerNameRegexp.test(key)) {
@@ -120,6 +123,8 @@ export class WebCrawlerConfigurationResource extends BaseResource<WebCrawlerConf
       key,
       value,
     });
+
+    return new Ok(undefined);
   }
 
   async getCustomHeaders(): Promise<Record<string, string>> {

--- a/connectors/src/resources/webcrawler_resource.ts
+++ b/connectors/src/resources/webcrawler_resource.ts
@@ -1,0 +1,134 @@
+import type { CrawlingFrequency, ModelId, Result } from "@dust-tt/types";
+import { CrawlingFrequencies, Err, Ok } from "@dust-tt/types";
+import type {
+  Attributes,
+  CreationAttributes,
+  ModelStatic,
+  Transaction,
+} from "sequelize";
+import { literal, Op } from "sequelize";
+
+import {
+  WebCrawlerConfigurationModel,
+  WebCrawlerFolder,
+  WebCrawlerPage,
+} from "@connectors/lib/models/webcrawler";
+import { BaseResource } from "@connectors/resources/base_resource";
+import type {} from "@connectors/resources/connector/strategy";
+import { ConnectorResource } from "@connectors/resources/connector_resource";
+import type { ReadonlyAttributesType } from "@connectors/resources/storage/types";
+
+// Attributes are marked as read-only to reflect the stateless nature of our Resource.
+// This design will be moved up to BaseResource once we transition away from Sequelize.
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface WebCrawlerConfigurationResource
+  extends ReadonlyAttributesType<WebCrawlerConfigurationModel> {}
+export class WebCrawlerConfigurationResource extends BaseResource<WebCrawlerConfigurationModel> {
+  static model: ModelStatic<WebCrawlerConfigurationModel> =
+    WebCrawlerConfigurationModel;
+
+  constructor(
+    model: ModelStatic<WebCrawlerConfigurationModel>,
+    blob: Attributes<WebCrawlerConfigurationModel>
+  ) {
+    super(WebCrawlerConfigurationModel, blob);
+  }
+
+  static async fetchByConnectorId(connectorId: ModelId) {
+    const blob = await this.model.findOne({
+      where: {
+        connectorId: connectorId,
+      },
+    });
+    if (!blob) {
+      return null;
+    }
+
+    return new this(this.model, blob.get());
+  }
+
+  static async makeNew(
+    blob: CreationAttributes<WebCrawlerConfigurationModel>,
+    transaction: Transaction
+  ) {
+    const config = await WebCrawlerConfigurationModel.create(
+      {
+        ...blob,
+      },
+      { transaction }
+    );
+
+    const res = new this(this.model, config.get());
+
+    return res;
+  }
+
+  static async getWebsitesToCrawl() {
+    const frequencyToSQLQuery: Record<CrawlingFrequency, string> = {
+      never: "never",
+      daily: "1 day",
+      weekly: "1 week",
+      monthly: "1 month",
+    };
+    const allConnectorIds: ModelId[] = [];
+
+    for (const frequency of CrawlingFrequencies) {
+      if (frequency === "never") {
+        continue;
+      }
+      const sql = frequencyToSQLQuery[frequency];
+      const websites = await this.model.findAll({
+        where: {
+          lastCrawledAt: {
+            [Op.lt]: literal(`NOW() - INTERVAL '${sql}'`),
+          },
+          crawlFrequency: frequency,
+        },
+      });
+      allConnectorIds.push(...websites.map((w) => w.connectorId));
+    }
+
+    const connectors = await ConnectorResource.fetchByIds(allConnectorIds);
+    const unPausedConnectorIds = connectors
+      .filter((c) => !c.isPaused())
+      .map((c) => c.id);
+
+    return unPausedConnectorIds;
+  }
+
+  async markedAsCrawled() {
+    await this.model.update(
+      {
+        lastCrawledAt: new Date(),
+      },
+      {
+        where: {
+          id: this.id,
+        },
+      }
+    );
+  }
+
+  async delete(transaction?: Transaction): Promise<Result<undefined, Error>> {
+    await WebCrawlerPage.destroy({
+      where: {
+        connectorId: this.connectorId,
+      },
+      transaction,
+    });
+    await WebCrawlerFolder.destroy({
+      where: {
+        connectorId: this.connectorId,
+      },
+      transaction,
+    });
+    await this.model.destroy({
+      where: {
+        id: this.id,
+      },
+      transaction,
+    });
+
+    return new Ok(undefined);
+  }
+}

--- a/front/components/data_source/WebsiteConfiguration.tsx
+++ b/front/components/data_source/WebsiteConfiguration.tsx
@@ -157,6 +157,7 @@ export default function WebsiteConfiguration({
             depth: maxDepth,
             crawlMode: crawlMode,
             crawlFrequency: selectedCrawlFrequency,
+            headers: {},
           } satisfies WebCrawlerConfigurationType,
         } satisfies t.TypeOf<typeof PostManagedDataSourceRequestBodySchema>),
       });
@@ -184,6 +185,7 @@ export default function WebsiteConfiguration({
               depth: maxDepth,
               crawlMode: crawlMode,
               crawlFrequency: selectedCrawlFrequency,
+              headers: {},
             } satisfies WebCrawlerConfigurationType,
           } satisfies UpdateConnectorConfigurationType),
         }

--- a/types/src/connectors/api_handlers/connector_configuration.ts
+++ b/types/src/connectors/api_handlers/connector_configuration.ts
@@ -20,6 +20,7 @@ export const WebCrawlerConfigurationTypeSchema = t.type({
     t.literal("weekly"),
     t.literal("monthly"),
   ]),
+  headers: t.record(t.string, t.string),
 });
 
 export type ConnectorConfiguration = WebCrawlerConfigurationType | null;

--- a/types/src/connectors/webcrawler.ts
+++ b/types/src/connectors/webcrawler.ts
@@ -20,6 +20,7 @@ export type WebCrawlerConfigurationType = {
   crawlMode: CrawlingMode;
   depth: DepthOption;
   crawlFrequency: CrawlingFrequency;
+  headers: Record<string, string>;
 };
 
 export function isDepthOption(value: unknown): value is DepthOption {


### PR DESCRIPTION
## Description

This PR introduces `WebcrawlerConfigurationResource`, including the data model to manage the custom headers (which triggers this refactoring). The headers are used by the WebCrawler but the UI to add/edit them does not exists yet.

I am not moving WebcrawlerPages and WebcrawlerFolders yet because:
- out of this scope of this PR
- We discussed a concept of "WebcrawlerResource" and I think they belong there. Not sure why we are not moving there directly.
- I committed to shipping the custom webcrawler headers to a customer today so I can't move too slowly on that.


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
- deploy prod box
- `connectors> npm run initdb`
- deploy connectors