### PR TITLE
doc: Update model names & fix typo

### DIFF
--- a/docs/src/pages/conversations.mdx
+++ b/docs/src/pages/conversations.mdx
@@ -459,8 +459,8 @@ The `agent_error` event is sent whenever an error occured durint the AgentMessag
       <Property name="mentions" type="[]{configurationId}">
         Mentions are a way to trigger the response of an assistant in a message. They are an array
         of objects with a single `configurationId` field which points the assistant being mentioned.
-        Available global assistant `configurationId` are: `helper`, `dust`, `gpt3.5-turbo`,
-        `gpt4`, `claude`, `claude-instant`, `slack`, `google_drive`, `notion`, `github`. To
+        Available global assistant `configurationId` are: `helper`, `dust`, `gpt-3.5-turbo`,
+        `gpt-4`, `claude-3-opus`, `claude-3-sonnet`, `slack`, `google_drive`, `notion`, `github`. To
         mention custom assistants, you can find the assistant `configurationId` in the URL of the
         assistant page.
       </Property>

--- a/docs/src/pages/conversations.mdx
+++ b/docs/src/pages/conversations.mdx
@@ -84,7 +84,7 @@ The `AgentMessage` model contains all the information and data related to an age
     The unique identifier of the `UserMessage` this `AgentMessage` is a response
     to.
   </Property>
-  <Property name="configurtion" type="object">
+  <Property name="configuration" type="object">
     The configuration of the assistant that generated this message.
   </Property>
   <Property name="status" type="string">


### PR DESCRIPTION
## Description

This PR just updates the document. Some of the model names (e.g., `gpt4`) didn't work as `configurationId` for me, so I updated them to correct ones.

## Risk

No risk

## Deploy Plan

N/A
