### PR TITLE
enh: remove `stripeProductId` and `billingType`

### DIFF
--- a/front/components/poke/plans/form.tsx
+++ b/front/components/poke/plans/form.tsx
@@ -22,7 +22,6 @@ import { classNames } from "@app/lib/utils";
 
 export type EditingPlanType = {
   name: string;
-  stripeProductId: string;
   code: string;
   isConfluenceAllowed: boolean;
   isSlackBotAllowed: boolean;
@@ -45,7 +44,6 @@ export type EditingPlanType = {
 export const fromPlanType = (plan: PlanType): EditingPlanType => {
   return {
     name: plan.name,
-    stripeProductId: plan.stripeProductId || "",
     code: plan.code,
     isConfluenceAllowed: plan.limits.connections.isConfluenceAllowed,
     isSlackBotAllowed: plan.limits.assistant.isSlackBotAllowed,
@@ -75,7 +73,6 @@ export const toPlanType = (editingPlan: EditingPlanType): PlanType => {
   return {
     code: editingPlan.code.trim(),
     name: editingPlan.name.trim(),
-    stripeProductId: editingPlan.stripeProductId.trim() || null,
     limits: {
       assistant: {
         isSlackBotAllowed: editingPlan.isSlackBotAllowed,
@@ -110,7 +107,6 @@ export const toPlanType = (editingPlan: EditingPlanType): PlanType => {
 
 const getEmptyPlan = (): EditingPlanType => ({
   name: "",
-  stripeProductId: "",
   code: "",
   isConfluenceAllowed: false,
   isSlackBotAllowed: false,
@@ -160,28 +156,6 @@ export const PLAN_FIELDS = {
     width: "medium",
     title: "Name",
     error: (plan: EditingPlanType) => (plan.name ? null : "Name is required"),
-  },
-  stripeProductId: {
-    type: "string",
-    width: "large",
-    title: "Stripe Product ID",
-    targetUrl: (plan: EditingPlanType) =>
-      plan.stripeProductId
-        ? `https://dashboard.stripe.com/products/${plan.stripeProductId}`
-        : null,
-
-    error: (plan: EditingPlanType) => {
-      if (!plan.stripeProductId) {
-        return null;
-      }
-
-      // only alphanumeric and underscore
-      if (!/^[a-zA-Z0-9_]+$/.test(plan.stripeProductId)) {
-        return "Stripe Product ID must only contain alphanumeric characters and underscores";
-      }
-
-      return null;
-    },
   },
   code: {
     type: "string",
@@ -322,11 +296,10 @@ export const Field: React.FC<FieldProps> = ({
   const field = PLAN_FIELDS[fieldName];
   const isImmutable = "immutable" in field && field.immutable;
   const disabled = !editingPlan?.isNewPlan && isImmutable;
-  const targetUrl = "targetUrl" in field && field.targetUrl(plan);
 
   const renderPlanFieldValue = (x: unknown) => {
     let strValue: string = x?.toString() || "";
-    let classes = targetUrl ? "cursor-pointer text-action-600" : "";
+    let classes = "";
     if (typeof x === "string") {
       if (!x) {
         strValue = "NULL";
@@ -339,14 +312,7 @@ export const Field: React.FC<FieldProps> = ({
       }
     }
 
-    return (
-      <div
-        className={classes}
-        onClick={targetUrl ? () => window.open(targetUrl, "_blank") : undefined}
-      >
-        {strValue}
-      </div>
-    );
+    return <div className={classes}>{strValue}</div>;
   };
 
   const fieldNode = (() => {
@@ -435,8 +401,6 @@ export const Field: React.FC<FieldProps> = ({
     switch (field.width) {
       case "small":
         return "w-24 min-w-[6rem]";
-      case "large":
-        return "w-72 min-w-[12rem]";
       case "medium":
         return "max-w-48 min-w-[8rem]";
       case "tiny":

--- a/front/lib/models/plan.ts
+++ b/front/lib/models/plan.ts
@@ -1,14 +1,8 @@
 import type {
-  FreeBillingType,
   MaxMessagesTimeframeType,
-  PaidBillingType,
   SubscriptionStatusType,
 } from "@dust-tt/types";
-import {
-  FREE_BILLING_TYPES,
-  PAID_BILLING_TYPES,
-  SUBSCRIPTION_STATUSES,
-} from "@dust-tt/types";
+import { SUBSCRIPTION_STATUSES } from "@dust-tt/types";
 import type {
   CreationOptional,
   ForeignKey,
@@ -32,7 +26,6 @@ export class Plan extends Model<
 
   declare code: string; // unique
   declare name: string;
-  declare billingType: FreeBillingType | PaidBillingType;
   declare trialPeriodDays: number;
   declare canUseProduct: boolean;
 
@@ -76,14 +69,6 @@ Plan.init(
     name: {
       type: DataTypes.STRING,
       allowNull: false,
-    },
-    billingType: {
-      type: DataTypes.STRING,
-      allowNull: false,
-      defaultValue: "fixed",
-      validate: {
-        isIn: [[...FREE_BILLING_TYPES, ...PAID_BILLING_TYPES]],
-      },
     },
     trialPeriodDays: {
       type: DataTypes.INTEGER,

--- a/front/lib/models/plan.ts
+++ b/front/lib/models/plan.ts
@@ -32,7 +32,6 @@ export class Plan extends Model<
 
   declare code: string; // unique
   declare name: string;
-  declare stripeProductId: string | null;
   declare billingType: FreeBillingType | PaidBillingType;
   declare trialPeriodDays: number;
   declare canUseProduct: boolean;
@@ -77,10 +76,6 @@ Plan.init(
     name: {
       type: DataTypes.STRING,
       allowNull: false,
-    },
-    stripeProductId: {
-      type: DataTypes.STRING,
-      allowNull: true,
     },
     billingType: {
       type: DataTypes.STRING,

--- a/front/lib/plans/enterprise_plans.ts
+++ b/front/lib/plans/enterprise_plans.ts
@@ -21,7 +21,6 @@ export type PlanAttributes = Omit<
 export const ENT_PLAN_FAKE_DATA: PlanAttributes = {
   code: ENT_PLAN_FAKE_CODE,
   name: "Entreprise",
-  stripeProductId: null,
   billingType: "fixed",
   maxMessages: -1,
   maxMessagesTimeframe: "lifetime",

--- a/front/lib/plans/enterprise_plans.ts
+++ b/front/lib/plans/enterprise_plans.ts
@@ -21,7 +21,6 @@ export type PlanAttributes = Omit<
 export const ENT_PLAN_FAKE_DATA: PlanAttributes = {
   code: ENT_PLAN_FAKE_CODE,
   name: "Entreprise",
-  billingType: "fixed",
   maxMessages: -1,
   maxMessagesTimeframe: "lifetime",
   maxUsersInWorkspace: -1,

--- a/front/lib/plans/free_plans.ts
+++ b/front/lib/plans/free_plans.ts
@@ -30,7 +30,6 @@ export type PlanAttributes = Omit<
 export const FREE_NO_PLAN_DATA: PlanAttributes = {
   code: FREE_NO_PLAN_CODE,
   name: "No Plan",
-  stripeProductId: null,
   billingType: "free",
   maxMessages: 0,
   maxMessagesTimeframe: "lifetime",
@@ -58,7 +57,6 @@ const FREE_PLANS_DATA: PlanAttributes[] = [
   {
     code: FREE_TEST_PLAN_CODE,
     name: "Free",
-    stripeProductId: null,
     billingType: "free",
     maxMessages: 50,
     maxMessagesTimeframe: "lifetime",
@@ -80,7 +78,6 @@ const FREE_PLANS_DATA: PlanAttributes[] = [
   {
     code: FREE_UPGRADED_PLAN_CODE,
     name: "Free Trial",
-    stripeProductId: null,
     billingType: "free",
     maxMessages: -1,
     maxUsersInWorkspace: -1,

--- a/front/lib/plans/free_plans.ts
+++ b/front/lib/plans/free_plans.ts
@@ -30,7 +30,6 @@ export type PlanAttributes = Omit<
 export const FREE_NO_PLAN_DATA: PlanAttributes = {
   code: FREE_NO_PLAN_CODE,
   name: "No Plan",
-  billingType: "free",
   maxMessages: 0,
   maxMessagesTimeframe: "lifetime",
   maxUsersInWorkspace: 1,
@@ -57,7 +56,6 @@ const FREE_PLANS_DATA: PlanAttributes[] = [
   {
     code: FREE_TEST_PLAN_CODE,
     name: "Free",
-    billingType: "free",
     maxMessages: 50,
     maxMessagesTimeframe: "lifetime",
     maxUsersInWorkspace: 1,
@@ -78,7 +76,6 @@ const FREE_PLANS_DATA: PlanAttributes[] = [
   {
     code: FREE_UPGRADED_PLAN_CODE,
     name: "Free Trial",
-    billingType: "free",
     maxMessages: -1,
     maxUsersInWorkspace: -1,
     maxMessagesTimeframe: "lifetime",

--- a/front/lib/plans/pro_plans.ts
+++ b/front/lib/plans/pro_plans.ts
@@ -30,7 +30,6 @@ if (isDevelopment()) {
   PRO_PLANS_DATA.push({
     code: PRO_PLAN_SEAT_29_CODE,
     name: "Pro",
-    billingType: "per_seat",
     maxMessages: -1,
     maxMessagesTimeframe: "lifetime",
     maxUsersInWorkspace: 1000,

--- a/front/lib/plans/pro_plans.ts
+++ b/front/lib/plans/pro_plans.ts
@@ -30,7 +30,6 @@ if (isDevelopment()) {
   PRO_PLANS_DATA.push({
     code: PRO_PLAN_SEAT_29_CODE,
     name: "Pro",
-    stripeProductId: "prod_OwKvN4XrUwFw5a",
     billingType: "per_seat",
     maxMessages: -1,
     maxMessagesTimeframe: "lifetime",

--- a/front/lib/plans/subscription.ts
+++ b/front/lib/plans/subscription.ts
@@ -32,7 +32,6 @@ export function renderPlanFromModel({
   return {
     code: plan.code,
     name: plan.name,
-    billingType: plan.billingType,
     limits: {
       assistant: {
         isSlackBotAllowed: plan.isSlackbotAllowed,
@@ -178,13 +177,6 @@ export const internalSubscribeWorkspaceToFreePlan = async ({
   if (activeSubscription && activeSubscription.planId === newPlan.id) {
     throw new Error(
       `Cannot subscribe to plan ${planCode}: already subscribed.`
-    );
-  }
-
-  // Prevent subscribing if the new plan is not a free plan
-  if (newPlan.billingType !== "free") {
-    throw new Error(
-      `Cannot subscribe to plan ${planCode}: billingType is not "free".`
     );
   }
 

--- a/front/lib/plans/subscription.ts
+++ b/front/lib/plans/subscription.ts
@@ -248,8 +248,6 @@ export const pokeUpgradeWorkspaceToEnterprise = async (
   const newPlan = await Plan.create({
     code: newPlanData.code,
     name: newPlanData.name,
-    stripeProductId: null,
-    billingType: "free", // Setting free per default but should be killed
     trialPeriodDays: 0,
     isSlackbotAllowed: newPlanData.isSlackbotAllowed,
     isManagedSlackAllowed: newPlanData.isSlackAllowed,

--- a/front/pages/api/poke/plans.ts
+++ b/front/pages/api/poke/plans.ts
@@ -85,29 +85,8 @@ async function handler(
         renderPlanFromModel({ plan })
       );
 
-      const stripeProductIds = plans
-        .filter(
-          (plan): plan is PlanType & { stripeProductId: string } =>
-            !!plan.stripeProductId
-        )
-        .map((plan) => plan.stripeProductId);
-
-      const productById = (
-        await Promise.all(
-          stripeProductIds.map((stripeProductId) => getProduct(stripeProductId))
-        )
-      ).reduce((acc, product) => {
-        acc[product.id] = product;
-        return acc;
-      }, {} as { [key: string]: Stripe.Product });
-
       res.status(200).json({
-        plans: plans.map((plan) => ({
-          ...plan,
-          stripeProduct: plan.stripeProductId
-            ? productById[plan.stripeProductId]
-            : null,
-        })),
+        plans,
       });
       return;
 
@@ -149,7 +128,6 @@ async function handler(
       await Plan.upsert({
         code: body.code,
         name: body.name,
-        stripeProductId: body.stripeProductId,
         isSlackbotAllowed: body.limits.assistant.isSlackBotAllowed,
         maxMessages: body.limits.assistant.maxMessages,
         maxMessagesTimeframe: body.limits.assistant.maxMessagesTimeframe,

--- a/front/pages/api/poke/plans.ts
+++ b/front/pages/api/poke/plans.ts
@@ -143,7 +143,6 @@ async function handler(
         maxDataSourcesDocumentsCount: body.limits.dataSources.documents.count,
         maxDataSourcesDocumentsSizeMb: body.limits.dataSources.documents.sizeMb,
         maxUsersInWorkspace: body.limits.users.maxUsers,
-        billingType: body.billingType,
         trialPeriodDays: body.trialPeriodDays,
         canUseProduct: body.limits.canUseProduct,
       });

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -15,6 +15,7 @@ import {
   sendReactivateSubscriptionEmail,
 } from "@app/lib/email";
 import { Plan, Subscription, Workspace } from "@app/lib/models";
+import { PRO_PLAN_SEAT_29_CODE } from "@app/lib/plans/plan_codes";
 import { createCustomerPortalSession } from "@app/lib/plans/stripe";
 import { maybeCancelInactiveTrials } from "@app/lib/plans/subscription";
 import { countActiveSeatsInWorkspace } from "@app/lib/plans/usage/seats";
@@ -189,7 +190,7 @@ async function handler(
               // We block a new subscription if the active one is with payment
               if (
                 activeSubscription &&
-                activeSubscription.plan.stripeProductId !== null
+                activeSubscription.plan.code === PRO_PLAN_SEAT_29_CODE
               ) {
                 logger.error(
                   {
@@ -198,7 +199,7 @@ async function handler(
                     stripeSubscriptionId,
                     planCode,
                   },
-                  "[Stripe Webhook] Received checkout.session.completed when we already have a subscription with payment on the workspace. Check on Stripe dashboard."
+                  "[Stripe Webhook] Received checkout.session.completed when we already have a pro plan subscription on the workspace. Check on Stripe dashboard."
                 );
 
                 return res.status(200).json({

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -15,7 +15,6 @@ import {
   sendReactivateSubscriptionEmail,
 } from "@app/lib/email";
 import { Plan, Subscription, Workspace } from "@app/lib/models";
-import { PRO_PLAN_SEAT_29_CODE } from "@app/lib/plans/plan_codes";
 import { createCustomerPortalSession } from "@app/lib/plans/stripe";
 import { maybeCancelInactiveTrials } from "@app/lib/plans/subscription";
 import { countActiveSeatsInWorkspace } from "@app/lib/plans/usage/seats";
@@ -190,7 +189,7 @@ async function handler(
               // We block a new subscription if the active one is with payment
               if (
                 activeSubscription &&
-                activeSubscription.plan.code === PRO_PLAN_SEAT_29_CODE
+                activeSubscription.stripeSubscriptionId !== null
               ) {
                 logger.error(
                   {
@@ -199,7 +198,7 @@ async function handler(
                     stripeSubscriptionId,
                     planCode,
                   },
-                  "[Stripe Webhook] Received checkout.session.completed when we already have a pro plan subscription on the workspace. Check on Stripe dashboard."
+                  "[Stripe Webhook] Received checkout.session.completed when we already have a paid subscription on the workspace. Check on Stripe dashboard."
                 );
 
                 return res.status(200).json({

--- a/front/pages/poke/plans.tsx
+++ b/front/pages/poke/plans.tsx
@@ -85,26 +85,6 @@ const PlansPage = () => {
       return;
     }
 
-    // check if stripe product id is unique
-    if (editingPlan.stripeProductId) {
-      const plansWithSameStripeProductId = plans?.filter(
-        (plan) =>
-          plan.stripeProductId &&
-          plan.stripeProductId.trim() === editingPlan.stripeProductId?.trim()
-      );
-      if (
-        (editingPlan.isNewPlan && plansWithSameStripeProductId.length > 0) ||
-        (!editingPlan.isNewPlan && plansWithSameStripeProductId.length > 1)
-      ) {
-        sendNotification({
-          title: "Error saving plan",
-          type: "error",
-          description: "Stripe Product ID must be unique",
-        });
-        return;
-      }
-    }
-
     const requestBody: PlanType = toPlanType(editingPlan);
 
     const r = await fetch("/api/poke/plans", {

--- a/front/pages/w/[wId]/subscription/index.tsx
+++ b/front/pages/w/[wId]/subscription/index.tsx
@@ -32,6 +32,7 @@ import {
   FREE_TEST_PLAN_CODE,
   FREE_UPGRADED_PLAN_CODE,
   isUpgraded,
+  PRO_PLAN_SEAT_29_CODE,
 } from "@app/lib/plans/plan_codes";
 import { getStripeSubscription } from "@app/lib/plans/stripe";
 import { countActiveSeatsInWorkspace } from "@app/lib/plans/usage/seats";
@@ -364,7 +365,7 @@ export default function Subscription({
           {subscription.stripeSubscriptionId && (
             <Page.Vertical gap="sm">
               <Page.H variant="h5">Billing</Page.H>
-              {plan.billingType === "per_seat" && (
+              {plan.code === PRO_PLAN_SEAT_29_CODE && (
                 <>
                   <Page.P>
                     Estimated monthly billing:{" "}

--- a/types/src/front/plan.ts
+++ b/types/src/front/plan.ts
@@ -58,7 +58,6 @@ export type PlanType = {
   code: string;
   name: string;
   limits: LimitsType;
-  stripeProductId: string | null;
   billingType: FreeBillingType | PaidBillingType;
   trialPeriodDays: number;
 };

--- a/types/src/front/plan.ts
+++ b/types/src/front/plan.ts
@@ -37,16 +37,6 @@ export type LimitsType = {
   canUseProduct: boolean;
 };
 
-export const FREE_BILLING_TYPES = ["free"] as const;
-export const PAID_BILLING_TYPES = [
-  "fixed",
-  "monthly_active_users",
-  "per_seat",
-] as const;
-
-export type FreeBillingType = (typeof FREE_BILLING_TYPES)[number];
-export type PaidBillingType = (typeof PAID_BILLING_TYPES)[number];
-
 export const SUBSCRIPTION_STATUSES = [
   "active",
   "ended",
@@ -58,7 +48,6 @@ export type PlanType = {
   code: string;
   name: string;
   limits: LimitsType;
-  billingType: FreeBillingType | PaidBillingType;
   trialPeriodDays: number;
 };
 


### PR DESCRIPTION
## Description

fixes https://github.com/dust-tt/tasks/issues/568

`stripeProductId` is no longer needed. Enterprise subscriptions get created through poke with a stripeSubscriptionId already set up. We're hard-coding the Pro plan product ID so there is no need to store it on the plan table.
`billingType` also is no longer needed. The fact that people pay is determined by the presence of a stripeSubscriptionId on their subscription. How they pay is determined on Stripe's side.

## Risk

inverted 80/20. Locally tested.

## Deploy Plan

First deploy code, then initdb. Migration is destructive.