### PR TITLE
Don't query on `botEnabled` in listForTeamId

### DIFF
--- a/connectors/src/resources/slack_configuration_resource.ts
+++ b/connectors/src/resources/slack_configuration_resource.ts
@@ -115,7 +115,6 @@ export class SlackConfigurationResource extends BaseResource<SlackConfigurationM
     const blobs = await this.model.findAll({
       where: {
         slackTeamId,
-        botEnabled: true,
       },
     });
 


### PR DESCRIPTION
## Description

https://github.com/dust-tt/dust/pull/4417/files#diff-c9ac1afc79d5f738a1545e94aafb085ef19cd24da13425471115be0677c1cc0b introduced a regression where we added a clause on `botEnabled: true` when listing slack configuration.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
