### PR TITLE
Temporary increase data source max document size

### DIFF
--- a/front/lib/plans/pro_plans.ts
+++ b/front/lib/plans/pro_plans.ts
@@ -45,7 +45,8 @@ if (isDevelopment()) {
     isManagedWebCrawlerAllowed: true,
     maxDataSourcesCount: -1,
     maxDataSourcesDocumentsCount: -1,
-    maxDataSourcesDocumentsSizeMb: 2,
+    // TODO(2024-04-05 flav) Decrease to 2 once GH fix is implemented.
+    maxDataSourcesDocumentsSizeMb: 3,
     trialPeriodDays: 0,
     canUseProduct: true,
   });


### PR DESCRIPTION
## Description

This PR temporary increases data source max document size from 2MB to 3MB for pro plan users. We will revert back to 2MB once we have a better error handling and skip strategy for those documents.
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
