### PR TITLE
Poké Form to Upgrade to Enterprise

### DIFF
--- a/front/components/poke/shadcn/ui/checkbox.tsx
+++ b/front/components/poke/shadcn/ui/checkbox.tsx
@@ -11,7 +11,7 @@ const PokeCheckbox = React.forwardRef<
   <CheckboxPrimitive.Root
     ref={ref}
     className={cn(
-      "border-primary ring-offset-background focus-visible:ring-ring data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground peer h-4 w-4 shrink-0 rounded-sm border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+      "border-primary ring-offset-background focus-visible:ring-ring data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground peer ml-2 h-4 w-4 shrink-0 rounded-sm border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
       className
     )}
     {...props}

--- a/front/components/poke/shadcn/ui/form.tsx
+++ b/front/components/poke/shadcn/ui/form.tsx
@@ -150,7 +150,7 @@ const FormMessage = React.forwardRef<
     <p
       ref={ref}
       id={formMessageId}
-      className={cn("text-destructive text-sm font-medium", className)}
+      className={cn("text-sm font-medium text-warning-500", className)}
       {...props}
     >
       {body}

--- a/front/components/poke/subscriptions/table.tsx
+++ b/front/components/poke/subscriptions/table.tsx
@@ -393,8 +393,20 @@ function UpgradeDowngradeModal({
               );
             })}
         </div>
+        <Separator />
+        <Page.SectionHeader
+          title="Upgrade Workspace to a new Enterprise Plan"
+          description="Go to the Enterprise billing form page to upgrade this workspace to a new Enterprise plan ."
+        />
+        <div>
+          <Button
+            label="Start upgrade to Enterprise plan"
+            variant="secondary"
+            onClick={() => router.push(`/poke/${owner.sId}/enterprise`)}
+            disabled={subscription.plan.code.startsWith("ENT_")}
+          />
+        </div>
       </Page>
-      ;
     </Modal>
   );
 }

--- a/front/components/poke/subscriptions/table.tsx
+++ b/front/components/poke/subscriptions/table.tsx
@@ -399,12 +399,13 @@ function UpgradeDowngradeModal({
           description="Go to the Enterprise billing form page to upgrade this workspace to a new Enterprise plan ."
         />
         <div>
-          <Button
-            label="Start upgrade to Enterprise plan"
-            variant="secondary"
-            onClick={() => router.push(`/poke/${owner.sId}/enterprise`)}
-            disabled={subscription.plan.code.startsWith("ENT_")}
-          />
+          <Link href={`/poke/${owner.sId}/upgrade_enterprise`}>
+            <Button
+              variant="secondary"
+              label="Start upgrade to Enterprise plan"
+              disabled={subscription.plan.code.startsWith("ENT_")}
+            />
+          </Link>
         </div>
       </Page>
     </Modal>

--- a/front/lib/plans/subscription.ts
+++ b/front/lib/plans/subscription.ts
@@ -1,4 +1,8 @@
-import type { PlanType, SubscriptionType } from "@dust-tt/types";
+import type {
+  NewEnterpriseSubscriptionType,
+  PlanType,
+  SubscriptionType,
+} from "@dust-tt/types";
 import { sendUserOperationMessage } from "@dust-tt/types";
 import type Stripe from "stripe";
 
@@ -232,6 +236,14 @@ export const internalSubscribeWorkspaceToFreePlan = async ({
     plan: newPlan,
     activeSubscription: newSubscription,
   });
+};
+
+export const pokeUpgradeWorkspaceToEnterprise = async (
+  auth: Authenticator,
+  newPlanData: NewEnterpriseSubscriptionType
+) => {
+  console.log(auth, newPlanData);
+  throw new Error("Not implemented");
 };
 
 /**

--- a/front/lib/plans/subscription.ts
+++ b/front/lib/plans/subscription.ts
@@ -1,5 +1,5 @@
 import type {
-  NewEnterpriseSubscriptionType,
+  EnterpriseSubscriptionFormType,
   PlanType,
   SubscriptionType,
 } from "@dust-tt/types";
@@ -240,7 +240,7 @@ export const internalSubscribeWorkspaceToFreePlan = async ({
 
 export const pokeUpgradeWorkspaceToEnterprise = async (
   auth: Authenticator,
-  newPlanData: NewEnterpriseSubscriptionType
+  newPlanData: EnterpriseSubscriptionFormType
 ) => {
   console.log(auth, newPlanData);
   throw new Error("Not implemented");

--- a/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.ts
+++ b/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.ts
@@ -1,0 +1,97 @@
+import type { WithAPIErrorReponse } from "@dust-tt/types";
+import { NewEnterpriseSubscriptionSchema } from "@dust-tt/types";
+import { isLeft } from "fp-ts/lib/Either";
+import * as reporter from "io-ts-reporters";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { Authenticator, getSession } from "@app/lib/auth";
+import { pokeUpgradeWorkspaceToEnterprise } from "@app/lib/plans/subscription";
+import { apiError, withLogging } from "@app/logger/withlogging";
+
+export interface UpgradeEnterpriseSuccessResponseBody {
+  success: boolean;
+}
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorReponse<UpgradeEnterpriseSuccessResponseBody>
+  >
+): Promise<void> {
+  const session = await getSession(req, res);
+  const auth = await Authenticator.fromSuperUserSession(session, null);
+
+  if (!auth.isDustSuperUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "user_not_found",
+        message: "Could not find the user.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "POST":
+      const bodyValidation = NewEnterpriseSubscriptionSchema.decode(req.body);
+      if (isLeft(bodyValidation)) {
+        const pathError = reporter.formatValidationErrors(bodyValidation.left);
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `The request body is invalid: ${pathError}`,
+          },
+        });
+      }
+      const body = bodyValidation.right;
+
+      const stripeSubscriptionId = body.stripeSubscriptionId;
+
+      // We validate that the stripe subscription is correctly configured
+      const isValidStripeSubscriptionId = stripeSubscriptionId === "soupinou"; // Todo replace with actual stripe subscription id business logic
+      if (!isValidStripeSubscriptionId) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "The stripe subscription id is invalid.",
+          },
+        });
+      }
+
+      // If yes, we will create the new plan and attach it to the workspace with a new subscription
+      try {
+        await pokeUpgradeWorkspaceToEnterprise(auth, body);
+      } catch (error) {
+        const errorString =
+          error instanceof Error
+            ? error.message
+            : JSON.stringify(error, null, 2);
+
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: errorString,
+          },
+        });
+      }
+
+      res.status(200).json({
+        success: true,
+      });
+      break;
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, POST is expected.",
+        },
+      });
+  }
+}
+
+export default withLogging(handler);

--- a/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.ts
+++ b/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.ts
@@ -1,5 +1,5 @@
 import type { WithAPIErrorReponse } from "@dust-tt/types";
-import { NewEnterpriseSubscriptionSchema } from "@dust-tt/types";
+import { EnterpriseSubscriptionFormSchema } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
@@ -33,7 +33,7 @@ async function handler(
 
   switch (req.method) {
     case "POST":
-      const bodyValidation = NewEnterpriseSubscriptionSchema.decode(req.body);
+      const bodyValidation = EnterpriseSubscriptionFormSchema.decode(req.body);
       if (isLeft(bodyValidation)) {
         const pathError = reporter.formatValidationErrors(bodyValidation.left);
         return apiError(req, res, {

--- a/front/pages/poke/[wId]/upgrade_enterprise/index.tsx
+++ b/front/pages/poke/[wId]/upgrade_enterprise/index.tsx
@@ -1,9 +1,9 @@
 import { Spinner } from "@dust-tt/sparkle";
 import type {
-  NewEnterpriseSubscriptionType,
+  EnterpriseSubscriptionFormType,
   WorkspaceType,
 } from "@dust-tt/types";
-import { NewEnterpriseSubscriptionSchema, removeNulls } from "@dust-tt/types";
+import { EnterpriseSubscriptionFormSchema, removeNulls } from "@dust-tt/types";
 import { ioTsResolver } from "@hookform/resolvers/io-ts";
 import { useRouter } from "next/router";
 import React from "react";
@@ -22,6 +22,13 @@ import {
   PokeFormMessage,
 } from "@app/components/poke/shadcn/ui/form";
 import { PokeInput } from "@app/components/poke/shadcn/ui/input";
+import {
+  PokeSelect,
+  PokeSelectContent,
+  PokeSelectItem,
+  PokeSelectTrigger,
+  PokeSelectValue,
+} from "@app/components/poke/shadcn/ui/select";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 
 export const getServerSideProps = withSuperUserAuthRequirements<{
@@ -50,8 +57,8 @@ export default function EnterpriseSubscriptionForm({
   const [isSubmitting, setIsSubmitting] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
 
-  const form = useForm<NewEnterpriseSubscriptionType>({
-    resolver: ioTsResolver(NewEnterpriseSubscriptionSchema),
+  const form = useForm<EnterpriseSubscriptionFormType>({
+    resolver: ioTsResolver(EnterpriseSubscriptionFormSchema),
     defaultValues: {
       stripeSubscriptionId: "",
       code: "",
@@ -65,6 +72,7 @@ export default function EnterpriseSubscriptionForm({
       isConfluenceAllowed: true,
       isWebCrawlerAllowed: true,
       maxMessages: -1,
+      maxMessagesTimeframe: "lifetime",
       dataSourcesCount: -1,
       dataSourcesDocumentsCount: -1,
       dataSourcesDocumentsSizeMb: 2,
@@ -72,7 +80,7 @@ export default function EnterpriseSubscriptionForm({
     },
   });
 
-  const onSubmit = (values: NewEnterpriseSubscriptionType) => {
+  const onSubmit = (values: EnterpriseSubscriptionFormType) => {
     const cleanedValues = Object.fromEntries(
       removeNulls(
         Object.entries(values).map(([key, value]) => {
@@ -192,6 +200,15 @@ export default function EnterpriseSubscriptionForm({
               type="number"
               placeholder="1000"
             />
+            <SelectField
+              control={form.control}
+              name="maxMessagesTimeframe"
+              title="Max messages timeframe"
+              options={[
+                { value: "lifetime", display: "Lifetime" },
+                { value: "day", display: "Per day" },
+              ]}
+            />
             <InputField
               control={form.control}
               name="dataSourcesCount"
@@ -239,8 +256,8 @@ function InputField({
   type,
   placeholder,
 }: {
-  control: Control<NewEnterpriseSubscriptionType>;
-  name: keyof NewEnterpriseSubscriptionType;
+  control: Control<EnterpriseSubscriptionFormType>;
+  name: keyof EnterpriseSubscriptionFormType;
   title?: string;
   type?: "text" | "number";
   placeholder?: string;
@@ -276,8 +293,8 @@ function CheckboxField({
   name,
   title,
 }: {
-  control: Control<NewEnterpriseSubscriptionType>;
-  name: keyof NewEnterpriseSubscriptionType;
+  control: Control<EnterpriseSubscriptionFormType>;
+  name: keyof EnterpriseSubscriptionFormType;
   title?: string;
   placeholder?: string;
 }) {
@@ -293,6 +310,57 @@ function CheckboxField({
               checked={!!field.value}
               onCheckedChange={field.onChange}
             />
+          </PokeFormControl>
+          <PokeFormMessage />
+        </PokeFormItem>
+      )}
+    />
+  );
+}
+
+interface SelectFieldOption {
+  value: string;
+  display?: string;
+}
+
+function SelectField({
+  control,
+  name,
+  title,
+  options,
+}: {
+  control: Control<EnterpriseSubscriptionFormType>;
+  name: keyof EnterpriseSubscriptionFormType;
+  title?: string;
+  options: SelectFieldOption[];
+}) {
+  return (
+    <PokeFormField
+      control={control}
+      name={name}
+      render={({ field }) => (
+        <PokeFormItem>
+          <PokeFormLabel className="capitalize">{title ?? name}</PokeFormLabel>
+          <PokeFormControl>
+            <PokeSelect
+              onValueChange={field.onChange}
+              defaultValue={field.value as string}
+            >
+              <PokeFormControl>
+                <PokeSelectTrigger>
+                  <PokeSelectValue placeholder={title ?? name} />
+                </PokeSelectTrigger>
+              </PokeFormControl>
+              <PokeSelectContent>
+                <div className="bg-slate-100">
+                  {options.map((option) => (
+                    <PokeSelectItem key={option.value} value={option.value}>
+                      {option.display ? option.display : option.value}
+                    </PokeSelectItem>
+                  ))}
+                </div>
+              </PokeSelectContent>
+            </PokeSelect>
           </PokeFormControl>
           <PokeFormMessage />
         </PokeFormItem>

--- a/front/pages/poke/[wId]/upgrade_enterprise/index.tsx
+++ b/front/pages/poke/[wId]/upgrade_enterprise/index.tsx
@@ -1,4 +1,4 @@
-import { Spinner } from "@dust-tt/sparkle";
+import { Spinner2 } from "@dust-tt/sparkle";
 import type {
   EnterpriseSubscriptionFormType,
   WorkspaceType,
@@ -240,7 +240,7 @@ export default function EnterpriseSubscriptionForm({
               placeholder="1000"
             />
             <PokeButton type="submit" variant="outline">
-              {isSubmitting && <Spinner size="sm" />} Submit
+              {isSubmitting && <Spinner2 size="sm" />} Submit
             </PokeButton>
 
             {error && <div className="text-red-500">{error}</div>}

--- a/front/pages/poke/[wId]/upgrade_enterprise/index.tsx
+++ b/front/pages/poke/[wId]/upgrade_enterprise/index.tsx
@@ -126,8 +126,10 @@ export default function EnterpriseSubscriptionForm({
     void submit();
   };
 
-  // If your form does not submit, uncomment the following line to see the form errors
-  //console.log("Form errors", form.formState.errors);
+  if (Object.keys(form.formState.errors).length > 0) {
+    // Useful to debug in case you have an error on a field that is not rendered
+    console.log("Form errors", form.formState.errors);
+  }
 
   return (
     <div className="min-h-screen bg-structure-50 pb-48">

--- a/front/pages/poke/[wId]/upgrade_enterprise/index.tsx
+++ b/front/pages/poke/[wId]/upgrade_enterprise/index.tsx
@@ -41,7 +41,7 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
   };
 });
 
-export default function NewEnterpriseSubscriptionForm({
+export default function EnterpriseSubscriptionForm({
   owner,
 }: {
   owner: WorkspaceType;
@@ -88,8 +88,7 @@ export default function NewEnterpriseSubscriptionForm({
       )
     );
 
-    void submit();
-    async function submit() {
+    const submit = async () => {
       setIsSubmitting(true);
       try {
         const r = await fetch(
@@ -108,8 +107,6 @@ export default function NewEnterpriseSubscriptionForm({
             `Something went wrong: ${r.status} ${await r.text()}`
           );
         }
-
-        await new Promise((resolve) => setTimeout(resolve, 1000));
         void router.push(`/poke/${owner.sId}`);
       } catch (e) {
         setIsSubmitting(false);
@@ -117,10 +114,12 @@ export default function NewEnterpriseSubscriptionForm({
           setError(e.message);
         }
       }
-    }
+    };
+    void submit();
   };
 
-  console.log("Form errors", form.formState.errors);
+  // If your form does not submit, uncomment the following line to see the form errors
+  //console.log("Form errors", form.formState.errors);
 
   return (
     <div className="min-h-screen bg-structure-50 pb-48">
@@ -138,13 +137,13 @@ export default function NewEnterpriseSubscriptionForm({
               control={form.control}
               name="code"
               title="Plan Code"
-              placeholder="ENT_COMPANY_NAME_PLAN_NAME"
+              placeholder="ENT_Soupinou_MAU10_FLOOR500"
             />
             <InputField
               control={form.control}
               name="name"
               title="Plan Name (user facing)"
-              placeholder="ENT_COMPANY_NAME_PLAN_NAME"
+              placeholder="Soupinou Corp"
             />
             <CheckboxField
               control={form.control}

--- a/front/pages/poke/[wId]/upgrade_enterprise/index.tsx
+++ b/front/pages/poke/[wId]/upgrade_enterprise/index.tsx
@@ -1,0 +1,303 @@
+import { Spinner } from "@dust-tt/sparkle";
+import type {
+  NewEnterpriseSubscriptionType,
+  WorkspaceType,
+} from "@dust-tt/types";
+import { NewEnterpriseSubscriptionSchema, removeNulls } from "@dust-tt/types";
+import { ioTsResolver } from "@hookform/resolvers/io-ts";
+import { useRouter } from "next/router";
+import React from "react";
+import type { Control } from "react-hook-form";
+import { useForm } from "react-hook-form";
+
+import PokeNavbar from "@app/components/poke/PokeNavbar";
+import { PokeButton } from "@app/components/poke/shadcn/ui/button";
+import { PokeCheckbox } from "@app/components/poke/shadcn/ui/checkbox";
+import {
+  PokeForm,
+  PokeFormControl,
+  PokeFormField,
+  PokeFormItem,
+  PokeFormLabel,
+  PokeFormMessage,
+} from "@app/components/poke/shadcn/ui/form";
+import { PokeInput } from "@app/components/poke/shadcn/ui/input";
+import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
+
+export const getServerSideProps = withSuperUserAuthRequirements<{
+  owner: WorkspaceType;
+}>(async (context, auth) => {
+  const owner = auth.workspace();
+  if (!owner) {
+    return {
+      notFound: true,
+    };
+  }
+
+  return {
+    props: {
+      owner,
+    },
+  };
+});
+
+export default function NewEnterpriseSubscriptionForm({
+  owner,
+}: {
+  owner: WorkspaceType;
+}) {
+  const router = useRouter();
+  const [isSubmitting, setIsSubmitting] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const form = useForm<NewEnterpriseSubscriptionType>({
+    resolver: ioTsResolver(NewEnterpriseSubscriptionSchema),
+    defaultValues: {
+      stripeSubscriptionId: "",
+      code: "",
+      name: "",
+      isSlackbotAllowed: true,
+      isSlackAllowed: true,
+      isNotionAllowed: true,
+      isGoogleDriveAllowed: true,
+      isGithubAllowed: true,
+      isIntercomAllowed: true,
+      isConfluenceAllowed: true,
+      isWebCrawlerAllowed: true,
+      maxMessages: -1,
+      dataSourcesCount: -1,
+      dataSourcesDocumentsCount: -1,
+      dataSourcesDocumentsSizeMb: 2,
+      maxUsers: 1000,
+    },
+  });
+
+  const onSubmit = (values: NewEnterpriseSubscriptionType) => {
+    const cleanedValues = Object.fromEntries(
+      removeNulls(
+        Object.entries(values).map(([key, value]) => {
+          if (typeof value !== "string") {
+            return [key, value];
+          }
+          const cleanedValue = value.trim();
+          if (!cleanedValue) {
+            return null;
+          }
+          return [key, cleanedValue];
+        })
+      )
+    );
+
+    void submit();
+    async function submit() {
+      setIsSubmitting(true);
+      try {
+        const r = await fetch(
+          `/api/poke/workspaces/${owner.sId}/upgrade_enterprise`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify(cleanedValues),
+          }
+        );
+
+        if (!r.ok) {
+          throw new Error(
+            `Something went wrong: ${r.status} ${await r.text()}`
+          );
+        }
+
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+        void router.push(`/poke/${owner.sId}`);
+      } catch (e) {
+        setIsSubmitting(false);
+        if (e instanceof Error) {
+          setError(e.message);
+        }
+      }
+    }
+  };
+
+  console.log("Form errors", form.formState.errors);
+
+  return (
+    <div className="min-h-screen bg-structure-50 pb-48">
+      <PokeNavbar />
+      <div className="mx-auto h-full max-w-2xl flex-grow flex-col items-center justify-center pt-8">
+        <PokeForm {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+            <InputField
+              control={form.control}
+              name="stripeSubscriptionId"
+              title="Stripe Subscription id"
+              placeholder="sub_1234567890"
+            />
+            <InputField
+              control={form.control}
+              name="code"
+              title="Plan Code"
+              placeholder="ENT_COMPANY_NAME_PLAN_NAME"
+            />
+            <InputField
+              control={form.control}
+              name="name"
+              title="Plan Name (user facing)"
+              placeholder="ENT_COMPANY_NAME_PLAN_NAME"
+            />
+            <CheckboxField
+              control={form.control}
+              name="isSlackbotAllowed"
+              title="Is Slackbot allowed?"
+            />
+            <CheckboxField
+              control={form.control}
+              name="isSlackAllowed"
+              title="Is Slack connection allowed?"
+            />
+            <CheckboxField
+              control={form.control}
+              name="isNotionAllowed"
+              title="Is Notion connection allowed?"
+            />
+            <CheckboxField
+              control={form.control}
+              name="isGoogleDriveAllowed"
+              title="Is Google Drive connection allowed?"
+            />
+            <CheckboxField
+              control={form.control}
+              name="isGithubAllowed"
+              title="Is Github connection allowed?"
+            />
+            <CheckboxField
+              control={form.control}
+              name="isIntercomAllowed"
+              title="Is Intercom connection allowed?"
+            />
+            <CheckboxField
+              control={form.control}
+              name="isConfluenceAllowed"
+              title="Is Confluence connection allowed?"
+            />
+            <CheckboxField
+              control={form.control}
+              name="isWebCrawlerAllowed"
+              title="Is Web Crawler connection allowed?"
+            />
+            <InputField
+              control={form.control}
+              name="maxMessages"
+              title="Max messages"
+              type="number"
+              placeholder="1000"
+            />
+            <InputField
+              control={form.control}
+              name="dataSourcesCount"
+              title="Data sources count"
+              type="number"
+              placeholder="10"
+            />
+            <InputField
+              control={form.control}
+              name="dataSourcesDocumentsCount"
+              title="Data sources documents count"
+              type="number"
+              placeholder="100"
+            />
+            <InputField
+              control={form.control}
+              name="dataSourcesDocumentsSizeMb"
+              title="Data sources documents size (MB)"
+              type="number"
+              placeholder="2"
+            />
+            <InputField
+              control={form.control}
+              name="maxUsers"
+              title="Max users"
+              type="number"
+              placeholder="1000"
+            />
+            <PokeButton type="submit" variant="outline">
+              {isSubmitting && <Spinner size="sm" />} Submit
+            </PokeButton>
+
+            {error && <div className="text-red-500">{error}</div>}
+          </form>
+        </PokeForm>
+      </div>
+    </div>
+  );
+}
+
+function InputField({
+  control,
+  name,
+  title,
+  type,
+  placeholder,
+}: {
+  control: Control<NewEnterpriseSubscriptionType>;
+  name: keyof NewEnterpriseSubscriptionType;
+  title?: string;
+  type?: "text" | "number";
+  placeholder?: string;
+}) {
+  return (
+    <PokeFormField
+      control={control}
+      name={name}
+      render={({ field }) => (
+        <PokeFormItem>
+          <PokeFormLabel className="capitalize">{title ?? name}</PokeFormLabel>
+          <PokeFormControl>
+            <PokeInput
+              placeholder={placeholder ?? name}
+              type={type}
+              {...field}
+              value={
+                typeof field.value === "boolean"
+                  ? field.value.toString()
+                  : field.value
+              }
+            />
+          </PokeFormControl>
+          <PokeFormMessage />
+        </PokeFormItem>
+      )}
+    />
+  );
+}
+
+function CheckboxField({
+  control,
+  name,
+  title,
+}: {
+  control: Control<NewEnterpriseSubscriptionType>;
+  name: keyof NewEnterpriseSubscriptionType;
+  title?: string;
+  placeholder?: string;
+}) {
+  return (
+    <PokeFormField
+      control={control}
+      name={name}
+      render={({ field }) => (
+        <PokeFormItem>
+          <PokeFormLabel className="capitalize">{title ?? name}</PokeFormLabel>
+          <PokeFormControl>
+            <PokeCheckbox
+              checked={!!field.value}
+              onCheckedChange={field.onChange}
+            />
+          </PokeFormControl>
+          <PokeFormMessage />
+        </PokeFormItem>
+      )}
+    />
+  );
+}

--- a/types/src/front/plan.ts
+++ b/types/src/front/plan.ts
@@ -76,7 +76,7 @@ export type SubscriptionType = {
   plan: PlanType;
 };
 
-export const NewEnterpriseSubscriptionSchema = t.type({
+export const EnterpriseSubscriptionFormSchema = t.type({
   stripeSubscriptionId: NonEmptyString,
   code: NonEmptyString,
   name: NonEmptyString,
@@ -89,12 +89,16 @@ export const NewEnterpriseSubscriptionSchema = t.type({
   isConfluenceAllowed: t.boolean,
   isWebCrawlerAllowed: t.boolean,
   maxMessages: t.union([t.number, NumberFromString]),
+  maxMessagesTimeframe: t.keyof({
+    day: null,
+    lifetime: null,
+  }),
   dataSourcesCount: t.union([t.number, NumberFromString]),
   dataSourcesDocumentsCount: t.union([t.number, NumberFromString]),
   dataSourcesDocumentsSizeMb: t.union([t.number, NumberFromString]),
   maxUsers: t.union([t.number, NumberFromString]),
 });
 
-export type NewEnterpriseSubscriptionType = t.TypeOf<
-  typeof NewEnterpriseSubscriptionSchema
+export type EnterpriseSubscriptionFormType = t.TypeOf<
+  typeof EnterpriseSubscriptionFormSchema
 >;

--- a/types/src/front/plan.ts
+++ b/types/src/front/plan.ts
@@ -1,3 +1,7 @@
+import * as t from "io-ts";
+import { NonEmptyString } from "io-ts-types/lib/NonEmptyString";
+import { NumberFromString } from "io-ts-types/lib/NumberFromString";
+
 export type MaxMessagesTimeframeType = "day" | "lifetime";
 
 /**
@@ -71,3 +75,26 @@ export type SubscriptionType = {
   paymentFailingSince: number | null;
   plan: PlanType;
 };
+
+export const NewEnterpriseSubscriptionSchema = t.type({
+  stripeSubscriptionId: NonEmptyString,
+  code: NonEmptyString,
+  name: NonEmptyString,
+  isSlackbotAllowed: t.boolean,
+  isSlackAllowed: t.boolean,
+  isNotionAllowed: t.boolean,
+  isGoogleDriveAllowed: t.boolean,
+  isGithubAllowed: t.boolean,
+  isIntercomAllowed: t.boolean,
+  isConfluenceAllowed: t.boolean,
+  isWebCrawlerAllowed: t.boolean,
+  maxMessages: t.union([t.number, NumberFromString]),
+  dataSourcesCount: t.union([t.number, NumberFromString]),
+  dataSourcesDocumentsCount: t.union([t.number, NumberFromString]),
+  dataSourcesDocumentsSizeMb: t.union([t.number, NumberFromString]),
+  maxUsers: t.union([t.number, NumberFromString]),
+});
+
+export type NewEnterpriseSubscriptionType = t.TypeOf<
+  typeof NewEnterpriseSubscriptionSchema
+>;


### PR DESCRIPTION
## Description

This adds a new link on the Upgrade/Downgrade modal to redirect to a new page hosting a new Enterprise form.
The form is plugged to a new API route but logic is this route will be implemented in the next PR. 

- [x] Update modal upgrade/downgrade to display link to enterprise page.
- [x] Add new page with form.
- [x] Create submit route with skeletton.

=> Next steps:
- [ ] API route calls `assertStripeSubscriptionValid`  
- [ ] Implement pokeUpgradeWorkspaceToEnterprise 
- [ ] Factorize some code that was duplicated on the Form 

## Risk

/

## Deploy Plan

Just deploying Front. 
