### PR TITLE
Poké: Upgrade to Enteprise logic

### DIFF
--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -198,8 +198,12 @@ export const getProduct = async (
  */
 export const getStripeSubscription = async (
   stripeSubscriptionId: string
-): Promise<Stripe.Subscription> => {
-  return stripe.subscriptions.retrieve(stripeSubscriptionId);
+): Promise<Stripe.Subscription | null> => {
+  try {
+    return await stripe.subscriptions.retrieve(stripeSubscriptionId);
+  } catch (error) {
+    return null;
+  }
 };
 
 /**

--- a/front/pages/w/[wId]/subscription/index.tsx
+++ b/front/pages/w/[wId]/subscription/index.tsx
@@ -62,6 +62,11 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     const stripeSubscription = await getStripeSubscription(
       subscription.stripeSubscriptionId
     );
+    if (!stripeSubscription) {
+      return {
+        notFound: true,
+      };
+    }
     stripeSubscription;
     trialDaysRemaining = stripeSubscription.trial_end
       ? Math.ceil(


### PR DESCRIPTION
## Description

Handle upgrade to Enteprise. 
-> First we check that the subscription exists
-> Then that it is valid using the function created by @philipperolet  
-> Then we end and create a new plan & subscription. 

## Risk

Low since internal. 

## Deploy Plan

Nothing special.
