### PR TITLE
Poké: Proper filter for button to upgrade to a free plan

### DIFF
--- a/front/components/poke/subscriptions/table.tsx
+++ b/front/components/poke/subscriptions/table.tsx
@@ -378,8 +378,7 @@ function UpgradeDowngradeModal({
         />
         <div>
           {plans
-            // Daph Uncomment this line when Enteprise billing Form is ready
-            .filter((p) => p.code !== PRO_PLAN_SEAT_29_CODE) // to be replaced with .filter((p) => p.code.startsWith("FREE_"))
+            .filter((p) => p.code.startsWith("FREE_")) // Hack to exclude The Pro and Enteprise plans
             .map((p) => {
               return (
                 <div key={p.code} className="pt-2">

--- a/front/components/poke/subscriptions/table.tsx
+++ b/front/components/poke/subscriptions/table.tsx
@@ -28,10 +28,7 @@ import {
 import { makeColumnsForSubscriptions } from "@app/components/poke/subscriptions/columns";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { isDevelopment } from "@app/lib/development";
-import {
-  FREE_NO_PLAN_CODE,
-  PRO_PLAN_SEAT_29_CODE,
-} from "@app/lib/plans/plan_codes";
+import { FREE_NO_PLAN_CODE } from "@app/lib/plans/plan_codes";
 import { usePokePlans } from "@app/lib/swr";
 
 interface SubscriptionsDataTableProps {


### PR DESCRIPTION
## Description

Stop showing all the Enterprise plans here. We now need to use the Enterprise flow to upgrade to Enterprise.


<img width="1028" alt="Screenshot 2024-04-08 at 16 02 11" src="https://github.com/dust-tt/dust/assets/3803406/24c6107c-c578-4508-89bb-a72433aed01d">


## Risk

/ 

## Deploy Plan

/ 
