### PR TITLE
Assistant builder: Fix position of next button on instruction page

### DIFF
--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -452,7 +452,7 @@ export default function AssistantBuilder({
       >
         <BuilderLayout
           leftPanel={
-            <div className="flex min-h-[64vh] flex-col gap-5 py-4">
+            <div className="flex min-h-[64vh] flex-col gap-5 pb-16 pt-4">
               <div className="flex flex-col flex-wrap justify-between gap-4 sm:flex-row">
                 <Tab tabs={tabs} variant="stepper" />
                 <div className="self-end pt-0.5">
@@ -548,7 +548,7 @@ function PrevNextButtons({
   setScreen: (screen: BuilderScreen) => void;
 }) {
   return (
-    <div className="flex flex-grow items-end pt-6">
+    <div className="flex flex-grow pt-6">
       {screen !== "instructions" && (
         <Button
           label="Previous"


### PR DESCRIPTION
## Description

Fixes the position of the next button (removes the big blank space between instruction text area & button). 
- Removes the "item_ends" class that was pushing the button at the bottom of the div. 
-  Add a big bottom padding to make sure there's still some blank space even when the Textarea is really big. 

Note: not perfect when suggestions are loaded the buttons is pushed below but @Duncid said ok since internal only and going to get reworked! 

<img width="1049" alt="Screenshot 2024-04-08 at 17 10 05" src="https://github.com/dust-tt/dust/assets/3803406/371fd6e0-c095-406d-a594-c6f9599efb1a">


## Risk

/

## Deploy Plan

/
