### PR TITLE
[Enterprise Billing] Refactor / reuse subscription validation lib

### DIFF
--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -8,6 +8,10 @@ import { isDevelopment } from "@app/lib/development";
 import { Plan, Subscription } from "@app/lib/models";
 import { PRO_PLAN_SEAT_29_CODE } from "@app/lib/plans/plan_codes";
 import { countActiveSeatsInWorkspace } from "@app/lib/plans/usage/seats";
+import {
+  SUPPORTED_REPORT_USAGE,
+  isSupportedReportUsage,
+} from "@app/lib/plans/usage/types";
 
 const { STRIPE_SECRET_KEY = "", URL = "" } = process.env;
 
@@ -249,8 +253,6 @@ export async function cancelSubscriptionImmediately({
   return true;
 }
 
-const REPORT_USAGE_VALUES = ["MAU_1", "MAU_5", "MAU_10", "PER_SEAT"];
-
 /**
  * Checks that a subscription created in Stripe is usable by Dust, returns an
  * error otherwise.
@@ -317,11 +319,11 @@ export function assertStripeSubscriptionItemValid({
       });
     }
 
-    if (!REPORT_USAGE_VALUES.includes(item.price.metadata?.REPORT_USAGE)) {
+    if (!isSupportedReportUsage(item.price.metadata?.REPORT_USAGE)) {
       return new Err({
         invalidity_message:
           "Subscription recurring price should have a REPORT_USAGE metadata with values in " +
-          JSON.stringify(REPORT_USAGE_VALUES),
+          JSON.stringify(SUPPORTED_REPORT_USAGE),
       });
     }
 

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -258,10 +258,6 @@ const REPORT_USAGE_VALUES = ["MAU_1", "MAU_5", "MAU_10", "PER_SEAT"];
 export function assertStripeSubscriptionValid(
   stripeSubscription: Stripe.Subscription
 ): Result<true, { invalidity_message: string }> {
-  if (stripeSubscription.items.data.length === 0) {
-    return new Err({ invalidity_message: "Subscription has no items." });
-  }
-
   // very unlikely, so handling is overkill at time of writing
   if (stripeSubscription.items.has_more) {
     return new Err({
@@ -269,44 +265,20 @@ export function assertStripeSubscriptionValid(
     });
   }
 
+  const itemsToCheck = stripeSubscription.items.data.filter(
+    (item) => !item.deleted
+  );
+
+  if (itemsToCheck.length === 0) {
+    return new Err({ invalidity_message: "Subscription has no items." });
+  }
+
   // All the business logic checks below are validating that the stripe
   // subscription doesn't have a configuration that we don't support
-  for (const item of stripeSubscription.items.data) {
-    if (item.deleted) {
-      continue;
-    }
-
-    if (item.price.recurring) {
-      if (item.price.recurring.usage_type !== "metered") {
-        return new Err({
-          invalidity_message: `Subscription recurring price has invalid usage_type '${item.price.recurring.usage_type}'. Only 'metered' usage_type is allowed.`,
-        });
-      }
-
-      if (!REPORT_USAGE_VALUES.includes(item.price.metadata?.REPORT_USAGE)) {
-        return new Err({
-          invalidity_message:
-            "Subscription recurring price should have a REPORT_USAGE metadata with values in " +
-            JSON.stringify(REPORT_USAGE_VALUES),
-        });
-      }
-
-      if (item.price.recurring.aggregate_usage !== "last_during_period") {
-        return new Err({
-          invalidity_message:
-            "Subscription recurring price has invalid aggregate_usage, should be last duing period",
-        });
-      }
-
-      if (
-        item.price.recurring.interval !== "month" ||
-        item.price.recurring.interval_count !== 1
-      ) {
-        return new Err({
-          invalidity_message:
-            "Subscription recurring price has invalid interval, only 1-month intervals are allowed.",
-        });
-      }
+  for (const item of itemsToCheck) {
+    const itemValidation = assertStripeSubscriptionItemValid({ item });
+    if (itemValidation.isErr()) {
+      return itemValidation;
     }
   }
 
@@ -318,3 +290,58 @@ export function assertStripeSubscriptionValid(
   }
   return new Ok(true);
 } // TODO(2024-04-05,pr): immediately after flav's merge, use the global constant
+
+export function assertStripeSubscriptionItemValid({
+  item,
+  recurringRequired,
+}: {
+  item: Stripe.SubscriptionItem;
+  recurringRequired?: boolean;
+}): Result<true, { invalidity_message: string }> {
+  if (!item.price) {
+    return new Err({
+      invalidity_message: "Subscription item has no price.",
+    });
+  }
+
+  if (recurringRequired && !item.price.recurring) {
+    return new Err({
+      invalidity_message: "Price must be recurring.",
+    });
+  }
+
+  if (item.price.recurring) {
+    if (item.price.recurring.usage_type !== "metered") {
+      return new Err({
+        invalidity_message: `Subscription recurring price has invalid usage_type '${item.price.recurring.usage_type}'. Only 'metered' usage_type is allowed.`,
+      });
+    }
+
+    if (!REPORT_USAGE_VALUES.includes(item.price.metadata?.REPORT_USAGE)) {
+      return new Err({
+        invalidity_message:
+          "Subscription recurring price should have a REPORT_USAGE metadata with values in " +
+          JSON.stringify(REPORT_USAGE_VALUES),
+      });
+    }
+
+    if (item.price.recurring.aggregate_usage !== "last_during_period") {
+      return new Err({
+        invalidity_message:
+          "Subscription recurring price has invalid aggregate_usage, should be last duing period",
+      });
+    }
+
+    if (
+      item.price.recurring.interval !== "month" ||
+      item.price.recurring.interval_count !== 1
+    ) {
+      return new Err({
+        invalidity_message:
+          "Subscription recurring price has invalid interval, only 1-month intervals are allowed.",
+      });
+    }
+  }
+
+  return new Ok(true);
+}

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -9,8 +9,8 @@ import { Plan, Subscription } from "@app/lib/models";
 import { PRO_PLAN_SEAT_29_CODE } from "@app/lib/plans/plan_codes";
 import { countActiveSeatsInWorkspace } from "@app/lib/plans/usage/seats";
 import {
-  SUPPORTED_REPORT_USAGE,
   isSupportedReportUsage,
+  SUPPORTED_REPORT_USAGE,
 } from "@app/lib/plans/usage/types";
 
 const { STRIPE_SECRET_KEY = "", URL = "" } = process.env;

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -257,7 +257,7 @@ export async function cancelSubscriptionImmediately({
  * Checks that a subscription created in Stripe is usable by Dust, returns an
  * error otherwise.
  */
-export function assertStripeSubscriptionValid(
+export function assertStripeSubscriptionIsValid(
   stripeSubscription: Stripe.Subscription
 ): Result<true, { invalidity_message: string }> {
   // very unlikely, so handling is overkill at time of writing
@@ -278,7 +278,7 @@ export function assertStripeSubscriptionValid(
   // All the business logic checks below are validating that the stripe
   // subscription doesn't have a configuration that we don't support
   for (const item of itemsToCheck) {
-    const itemValidation = assertStripeSubscriptionItemValid({ item });
+    const itemValidation = assertStripeSubscriptionItemIsValid({ item });
     if (itemValidation.isErr()) {
       return itemValidation;
     }
@@ -293,7 +293,7 @@ export function assertStripeSubscriptionValid(
   return new Ok(true);
 } // TODO(2024-04-05,pr): immediately after flav's merge, use the global constant
 
-export function assertStripeSubscriptionItemValid({
+export function assertStripeSubscriptionItemIsValid({
   item,
   recurringRequired,
 }: {

--- a/front/lib/plans/subscription.ts
+++ b/front/lib/plans/subscription.ts
@@ -422,7 +422,7 @@ export async function getSubscriptionForStripeId(
 ): Promise<SubscriptionType | null> {
   const res = await Subscription.findOne({
     where: { stripeSubscriptionId },
-    include: [Plan, Workspace],
+    include: [Plan],
   });
 
   if (!res) {

--- a/front/lib/plans/usage/mau.ts
+++ b/front/lib/plans/usage/mau.ts
@@ -4,7 +4,7 @@ import { QueryTypes } from "sequelize";
 import type Stripe from "stripe";
 
 import {
-  assertStripeSubscriptionItemValid,
+  assertStripeSubscriptionItemIsValid,
   updateStripeActiveUsersForSubscriptionItem,
 } from "@app/lib/plans/stripe";
 import type { MauReportUsageType } from "@app/lib/plans/usage/types";
@@ -59,7 +59,7 @@ export async function reportMonthlyActiveUsers(
   const [, rawMessagesPerMonthForMau] = usage.split("_");
   const messagesPerMonthForMau = parseInt(rawMessagesPerMonthForMau, 10);
 
-  const subscriptionItemValid = assertStripeSubscriptionItemValid({
+  const subscriptionItemValid = assertStripeSubscriptionItemIsValid({
     item: stripeSubscriptionItem,
     recurringRequired: true,
   });

--- a/front/lib/plans/usage/mau.ts
+++ b/front/lib/plans/usage/mau.ts
@@ -3,7 +3,10 @@ import { Err, Ok } from "@dust-tt/types";
 import { QueryTypes } from "sequelize";
 import type Stripe from "stripe";
 
-import { updateStripeActiveUsersForSubscriptionItem } from "@app/lib/plans/stripe";
+import {
+  assertStripeSubscriptionItemValid,
+  updateStripeActiveUsersForSubscriptionItem,
+} from "@app/lib/plans/stripe";
 import type { MauReportUsageType } from "@app/lib/plans/usage/types";
 import { InvalidRecurringPriceError } from "@app/lib/plans/usage/types";
 import { getFrontReplicaDbConnection } from "@app/lib/resources/storage";
@@ -56,20 +59,15 @@ export async function reportMonthlyActiveUsers(
   const [, rawMessagesPerMonthForMau] = usage.split("_");
   const messagesPerMonthForMau = parseInt(rawMessagesPerMonthForMau, 10);
 
-  const { recurring } = stripeSubscriptionItem.price;
-  if (!recurring) {
-    return new Err(
-      new InvalidRecurringPriceError(
-        "MAU Usage base price only supports prices with monthly recurring."
-      )
-    );
-  }
+  const subscriptionItemValid = assertStripeSubscriptionItemValid({
+    item: stripeSubscriptionItem,
+    recurringRequired: true,
+  });
 
-  const { interval, interval_count: intervalCount } = recurring;
-  if (interval !== "month" || intervalCount !== 1) {
+  if (subscriptionItemValid.isErr()) {
     return new Err(
       new InvalidRecurringPriceError(
-        `Expected 1 month recurring, found ${intervalCount} ${interval}(s) instead.`
+        subscriptionItemValid.error.invalidity_message
       )
     );
   }

--- a/front/lib/plans/usage/types.ts
+++ b/front/lib/plans/usage/types.ts
@@ -1,7 +1,3 @@
-import type { Result } from "@dust-tt/types";
-import { Err, Ok } from "@dust-tt/types";
-import type Stripe from "stripe";
-
 // This is the key used in Stripe's metadata to indicate that this is a usage-based price.
 export const REPORT_USAGE_METADATA_KEY = "REPORT_USAGE";
 
@@ -27,32 +23,4 @@ export function isSupportedReportUsage(
 
 export type MauReportUsageType = `MAU_${number}`;
 
-/**
- * Validates that the subscription has a valid recurring price.
- */
-
 export class InvalidRecurringPriceError extends Error {}
-
-export function validateSubscriptionRecurringPrice(
-  stripeSubscriptionItem: Stripe.SubscriptionItem
-): Result<undefined, InvalidRecurringPriceError> {
-  const { recurring } = stripeSubscriptionItem.price;
-  if (!recurring) {
-    return new Err(
-      new InvalidRecurringPriceError(
-        "MAU Usage base price only supports prices with monthly recurring."
-      )
-    );
-  }
-
-  const { interval, interval_count: intervalCount } = recurring;
-  if (interval !== "month" || intervalCount !== 1) {
-    return new Err(
-      new InvalidRecurringPriceError(
-        `Expected 1 month recurring, found ${intervalCount} ${interval}(s) instead.`
-      )
-    );
-  }
-
-  return new Ok(undefined);
-}

--- a/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.ts
+++ b/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.ts
@@ -9,7 +9,10 @@ import {
   assertStripeSubscriptionValid,
   getStripeSubscription,
 } from "@app/lib/plans/stripe";
-import { pokeUpgradeWorkspaceToEnterprise } from "@app/lib/plans/subscription";
+import {
+  getSubscriptionForStripeId,
+  pokeUpgradeWorkspaceToEnterprise,
+} from "@app/lib/plans/subscription";
 import { apiError, withLogging } from "@app/logger/withlogging";
 
 export interface UpgradeEnterpriseSuccessResponseBody {
@@ -77,6 +80,21 @@ async function handler(
           },
         });
       }
+
+      const subscription = await getSubscriptionForStripeId(
+        stripeSubscription.id
+      );
+
+      if (subscription) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "The subscription is already attached to a workspace.",
+          },
+        });
+      }
+
       const assertValidSubscription =
         assertStripeSubscriptionValid(stripeSubscription);
       if (assertValidSubscription.isErr()) {

--- a/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.ts
+++ b/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.ts
@@ -6,7 +6,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { Authenticator, getSession } from "@app/lib/auth";
 import {
-  assertStripeSubscriptionValid,
+  assertStripeSubscriptionIsValid,
   getStripeSubscription,
 } from "@app/lib/plans/stripe";
 import {
@@ -96,7 +96,7 @@ async function handler(
       }
 
       const assertValidSubscription =
-        assertStripeSubscriptionValid(stripeSubscription);
+        assertStripeSubscriptionIsValid(stripeSubscription);
       if (assertValidSubscription.isErr()) {
         return apiError(req, res, {
           status_code: 400,


### PR DESCRIPTION
## Description
- Switches validity checks from @flvndvd to the validation lib
- validation lib now uses the global constant defined by @flvndvd in types
- extra: checks the subscription is unassigned in poke enterprise upgrade logic, ping @PopDaph wdyt?

