### PR TITLE
[Enterprise billing] Update subscription validity check + add check in stripe webhook

### DIFF
--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -332,11 +332,22 @@ export function assertStripeSubscriptionItemIsValid({
     }
 
     if (item.price.recurring.usage_type === "licensed") {
-      if (reportUsage !== "PER_SEAT") {
-        return new Err({
-          invalidity_message:
-            "Subscription recurring price has usage_type 'licensed' but has a REPORT_USAGE different from PER_SEAT.",
-        });
+      switch (reportUsage) {
+        case "PER_SEAT":
+          break;
+        case "FIXED":
+          if (item.quantity !== 1) {
+            return new Err({
+              invalidity_message:
+                "Subscription recurring price has REPORT_USAGE set to 'FIXED' but has a quantity different from 1.",
+            });
+          }
+          break;
+        default:
+          return new Err({
+            invalidity_message:
+              "Subscription recurring price has usage_type 'licensed' but has a REPORT_USAGE different from PER_SEAT or FIXED.",
+          });
       }
     }
 

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -285,12 +285,6 @@ export function assertStripeSubscriptionIsValid(
     }
   }
 
-  // the subscription is not active
-  if (stripeSubscription.status !== "active") {
-    return new Err({
-      invalidity_message: "Subscription is not active.",
-    });
-  }
   return new Ok(true);
 } // TODO(2024-04-05,pr): immediately after flav's merge, use the global constant
 

--- a/front/lib/plans/usage/index.ts
+++ b/front/lib/plans/usage/index.ts
@@ -70,6 +70,10 @@ export async function reportUsageForSubscriptionItems(
         await reportActiveSeats(item, workspace);
         break;
 
+      case "FIXED":
+        // fixed price, nothing to report
+        break;
+
       default:
         assertNever(usageToReport);
     }

--- a/front/lib/plans/usage/types.ts
+++ b/front/lib/plans/usage/types.ts
@@ -8,6 +8,7 @@ export const SUPPORTED_REPORT_USAGE = [
   "MAU_5",
   "MAU_10",
   "PER_SEAT",
+  "FIXED",
 ] as const;
 export type SupportedReportUsage = (typeof SUPPORTED_REPORT_USAGE)[number];
 

--- a/front/lib/plans/usage/types.ts
+++ b/front/lib/plans/usage/types.ts
@@ -23,4 +23,10 @@ export function isSupportedReportUsage(
 
 export type MauReportUsageType = `MAU_${number}`;
 
+export function isMauReportUsage(
+  usage: string | undefined
+): usage is MauReportUsageType {
+  return usage?.startsWith("MAU_") ?? false;
+}
+
 export class InvalidRecurringPriceError extends Error {}

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -397,9 +397,16 @@ async function handler(
         case "customer.subscription.created": {
           const stripeSubscription = event.data.object as Stripe.Subscription;
           // on the odd chance the change is not compatible with our logic, we panic
-          if (assertStripeSubscriptionIsValid(stripeSubscription).isErr()) {
+          const validStatus =
+            assertStripeSubscriptionIsValid(stripeSubscription);
+          if (validStatus.isErr()) {
             logger.error(
-              { panic: true, event },
+              {
+                panic: true,
+                event,
+                stripeSubscriptionId: stripeSubscription.id,
+                invalidity_message: validStatus.error.invalidity_message,
+              },
               "[Stripe Webhook] Received customer.subscription.created event with invalid subscription."
             );
           }
@@ -500,13 +507,19 @@ async function handler(
           }
 
           // on the odd chance the change is not compatible with our logic, we panic
-          if (assertStripeSubscriptionIsValid(stripeSubscription).isErr()) {
+          const validStatus =
+            assertStripeSubscriptionIsValid(stripeSubscription);
+          if (validStatus.isErr()) {
             logger.error(
-              { panic: true, event },
+              {
+                panic: true,
+                event,
+                stripeSubscriptionId: stripeSubscription.id,
+                invalidity_message: validStatus.error.invalidity_message,
+              },
               "[Stripe Webhook] Received customer.subscription.updated event with invalid subscription."
             );
           }
-
           break;
 
         // Occurs when the subscription is canceled by the user or by us.


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/571

On failure, panic flag to ping us, but do not act / break flow in any way (backwards compatibility window)

Includes update of logic of validate subscription
  - remove check of 'metered'
  - report_usage => per seat should be set for all prices 'licensed', mau_x should be set for prices 'metered'
  - aggregate_usage => should not be checked for licensed pricing

## Risk
- Tested on test mode subscriptions, to be tested on prodbox on a couple of real pro plan subscriptions
- On failure, panic flag to ping us, but do not act / break flow in any way => mitigates risks

## Deploy Plan
- add customer.subscription.created webhook listener on stripe GUI
- prodbox test on real pro plan subs
- :warning: **Add REPORT_USAGE PER_SEAT** to existing prices
- deploy front
