### PR TITLE
Track user memberships and workspace properties in /api/user

### DIFF
--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -7,7 +7,6 @@ import type {
 import { Err, Ok } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { trackUserMemberships } from "@app/lib/amplitude/node";
 import { deleteUser } from "@app/lib/api/user";
 import { evaluateWorkspaceSeatAvailability } from "@app/lib/api/workspace";
 import { getSession, subscriptionForWorkspace } from "@app/lib/auth";
@@ -27,7 +26,6 @@ import type { MembershipInvitation } from "@app/lib/models";
 import { Workspace } from "@app/lib/models";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
-import logger from "@app/logger/logger";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import { launchUpdateUsageWorkflow } from "@app/temporal/usage_queue/client";
 
@@ -414,7 +412,6 @@ export async function createAndLogMembership({
     user,
     workspace: renderLightWorkspaceType({ workspace }),
   });
-  trackUserMemberships(user).catch(logger.error);
 
   // Update workspace subscription usage when a new user joins.
   await launchUpdateUsageWorkflow({ workspaceId: workspace.sId });

--- a/front/pages/api/user/index.ts
+++ b/front/pages/api/user/index.ts
@@ -7,9 +7,11 @@ import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import { trackUserMemberships } from "@app/lib/amplitude/node";
 import { updateUserFullName } from "@app/lib/api/user";
 import { getSession } from "@app/lib/auth";
 import { getUserFromSession } from "@app/lib/iam/session";
+import logger from "@app/logger/logger";
 import { apiError, withLogging } from "@app/logger/withlogging";
 
 export type PostUserMetadataResponseBody = {
@@ -48,6 +50,12 @@ async function handler(
 
   switch (req.method) {
     case "GET":
+      trackUserMemberships(user).catch((err) => {
+        logger.error(
+          { err: err, userId: user.sId },
+          "Failed to track user memberships"
+        );
+      });
       return res.status(200).json({ user });
 
     case "PATCH":


### PR DESCRIPTION
## Description

Task: https://github.com/dust-tt/tasks/issues/533

- Stop using database models in `front/lib/amplitude/node/`
- Call `trackUserMemberships()` in `GET /api/user` once per day at most.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
