### PR TITLE
Skip webhooks on paused Slack connectors

### DIFF
--- a/connectors/src/connectors/slack/temporal/client.ts
+++ b/connectors/src/connectors/slack/temporal/client.ts
@@ -90,6 +90,18 @@ export async function launchSlackSyncOneThreadWorkflow(
   if (!connector) {
     return new Err(new Error(`Connector ${connectorId} not found`));
   }
+
+  if (connector.isPaused()) {
+    logger.info(
+      {
+        connectorId: connector.id,
+      },
+      "Skipping webhook for Slack connector because it is paused (thread sync)."
+    );
+
+    return new Ok(undefined);
+  }
+
   const client = await getTemporalClient();
 
   const workflowId = syncOneThreadDebouncedWorkflowId(
@@ -130,6 +142,18 @@ export async function launchSlackSyncOneMessageWorkflow(
   if (!connector) {
     return new Err(new Error(`Connector ${connectorId} not found`));
   }
+
+  if (connector.isPaused()) {
+    logger.info(
+      {
+        connectorId: connector.id,
+      },
+      "Skipping webhook for Slack connector because it is paused (message sync)."
+    );
+
+    return new Ok(undefined);
+  }
+
   const client = await getTemporalClient();
 
   const messageTs = parseInt(threadTs as string) * 1000;


### PR DESCRIPTION
## Description

We introduced paused status on connectors in https://github.com/dust-tt/dust/pull/4558 but overlooked the Slack webhooks. Considering the complexity associated with Slack webhooks, this PR prevents the start of incremental workflows when the connector is in a paused state (for message and thread synchronization).
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
