### PR TITLE
[Sparkle] ElementDialog component

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.135",
+  "version": "0.2.136",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.135",
+      "version": "0.2.136",
       "license": "ISC",
       "dependencies": {
         "@headlessui/react": "^1.7.17",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.135",
+  "version": "0.2.136",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/_index.ts
+++ b/sparkle/src/_index.ts
@@ -103,6 +103,9 @@ export { ElementModal };
 import { Dialog } from "./components/Dialog";
 export { Dialog };
 
+import { ElementDialog } from "./components/ElementDialog";
+export { ElementDialog };
+
 import { Input } from "./components/Input";
 export { Input };
 

--- a/sparkle/src/components/Dialog.tsx
+++ b/sparkle/src/components/Dialog.tsx
@@ -6,7 +6,7 @@ import { classNames } from "@sparkle/lib/utils";
 
 import { Button } from "./Button";
 
-type ModalProps = {
+export type ModalProps = {
   title: string;
   children: React.ReactNode;
   isOpen: boolean;

--- a/sparkle/src/components/ElementDialog.tsx
+++ b/sparkle/src/components/ElementDialog.tsx
@@ -1,0 +1,36 @@
+import React, { useCallback, useState } from "react";
+
+import { Dialog, ModalProps } from "./Dialog";
+
+type ElementDialogProps<T> = Omit<
+  ModalProps,
+  "isOpen" | "onValidate" | "onCancel"
+> & {
+  openOnElement: T | null;
+  onValidate: (closeDialogFn: () => void) => void;
+  closeDialogFn: () => void;
+};
+
+export function ElementDialog<T>({
+  openOnElement,
+  closeDialogFn,
+  onValidate,
+  ...props
+}: ElementDialogProps<T>) {
+  const [isClosingTransition, setIsClosingTransition] = useState(false);
+  const transitionOnClose = useCallback(() => {
+    setIsClosingTransition(true);
+    setTimeout(() => {
+      closeDialogFn();
+      setIsClosingTransition(false);
+    }, 200);
+  }, [closeDialogFn]);
+  return (
+    <Dialog
+      isOpen={openOnElement !== null && !isClosingTransition}
+      onCancel={transitionOnClose}
+      onValidate={() => onValidate(transitionOnClose)}
+      {...props}
+    />
+  );
+}

--- a/sparkle/src/components/ElementDialog.tsx
+++ b/sparkle/src/components/ElementDialog.tsx
@@ -8,6 +8,7 @@ type ElementDialogProps<T> = Omit<
 > & {
   openOnElement: T | null;
   onValidate: (closeDialogFn: () => void) => void;
+  onCancel: (closeDialogFn: () => void) => void;
   closeDialogFn: () => void;
 };
 
@@ -15,6 +16,7 @@ export function ElementDialog<T>({
   openOnElement,
   closeDialogFn,
   onValidate,
+  onCancel,
   ...props
 }: ElementDialogProps<T>) {
   const [isClosingTransition, setIsClosingTransition] = useState(false);
@@ -28,7 +30,7 @@ export function ElementDialog<T>({
   return (
     <Dialog
       isOpen={openOnElement !== null && !isClosingTransition}
-      onCancel={transitionOnClose}
+      onCancel={() => onCancel(transitionOnClose)}
       onValidate={() => onValidate(transitionOnClose)}
       {...props}
     />

--- a/sparkle/src/stories/ElementDialog.stories.tsx
+++ b/sparkle/src/stories/ElementDialog.stories.tsx
@@ -17,6 +17,10 @@ export const ElementDialogExample = () => {
       <ElementDialog
         openOnElement={element}
         closeDialogFn={() => setElement(null)}
+        onCancel={(closeDialogFn) => {
+          console.log("canceled!");
+          closeDialogFn();
+        }}
         title="Element Modal title"
         onValidate={(closeDialogFn) => {
           console.log("validated!");

--- a/sparkle/src/stories/ElementDialog.stories.tsx
+++ b/sparkle/src/stories/ElementDialog.stories.tsx
@@ -1,35 +1,37 @@
 import type { Meta } from "@storybook/react";
 import React, { useState } from "react";
 
-import { Button, ElementModal, Page } from "../index_with_tw_base";
+import { Button, ElementDialog, Page } from "../index_with_tw_base";
 
 const meta = {
-  title: "Modules/ElementModal",
-  component: ElementModal,
-} satisfies Meta<typeof ElementModal>;
+  title: "Modules/ElementDialog",
+  component: ElementDialog,
+} satisfies Meta<typeof ElementDialog>;
 
 export default meta;
 
-export const ElementModalExample = () => {
+export const ElementDialogExample = () => {
   const [element, setElement] = useState<{ text: string } | null>(null);
   return (
     <Page.Layout gap="md">
-      <ElementModal
+      <ElementDialog
         openOnElement={element}
-        onClose={() => setElement(null)}
-        variant="side-sm"
+        closeDialogFn={() => setElement(null)}
         title="Element Modal title"
-        hasChanged={false}
+        onValidate={(closeDialogFn) => {
+          console.log("validated!");
+          closeDialogFn();
+        }}
       >
         <div className="s-flex s-flex-col s-gap-3">
           <div className="s-mt-4 s-flex-none s-text-left">
-            I'm the modal content
+            I'm the dialog content
           </div>
           <div className="s-w-64">
             The text is: <span className="font-bold">{element?.text}</span>
           </div>
         </div>
-      </ElementModal>
+      </ElementDialog>
       <div className="s-flex s-flex-col s-items-start s-gap-3">
         <div className="s-text-lg s-font-bold">Fullscreen</div>
         <Button


### PR DESCRIPTION
Description
---
ElementDialog fixes the issue of missing closing transitions on dialogs with content based on a variable "element" (e.g. a list item, an agent configuration...). It is to `Dialog` what `ElementModal` is to `Modal`

**Why**
- fixes the "missing closing transition bug" for dialogs (see screencasts below, or storybook)
- reduces boilerplate when using dialogs based on a variable element

**How**
Props for ElementDialog change from Dialog as follows
```
new prop-> closeDialogFn: () => void
isOpen : boolean -> openOnElement : T | null
onCancel : () => void -> onCancel : (closeDialogFn: () => void) => void
onValidate(void) -> onValidate : (closeDialogFn: () => void) => void
```

- Instead of having a prop for opening/closing the dialog, the variable element is used (dialog will open if non-null, close if null)
- onCancel/onValidate expose as an arg a closing function `closingFn`. When implementing onValidate/onCancel, use `closingFn` to close the modal. It's what will take care of letting the transition happen smoothly
(drawback: a bit unusual; benefit: helps enforcing that the closing logic is implemented only once)

Before: https://www.loom.com/share/e5ccad8531454752a206cf9f2c3e3629?sid=5ac6dcd8-0168-4470-a337-e2a93cc70020 

After: https://www.loom.com/share/2e5d2314c221406ba1705eb87554b85b?sid=f46a0dbb-204a-4817-85e4-e69e0312243b

Risks
---
None here

Deploy
---
- publish sparkle