### PR TITLE
feat(multi-actions): Update business logic to use action config -> agent config FK

### DIFF
--- a/front/components/assistant/AssistantActions.tsx
+++ b/front/components/assistant/AssistantActions.tsx
@@ -194,7 +194,7 @@ export function RemoveAssistantFromWorkspaceDialog({
             pictureUrl: agentConfiguration.pictureUrl,
             status: "active",
             scope: "published",
-            action: detailedConfig.action,
+            actions: detailedConfig.actions,
             generation: agentConfiguration.generation,
           },
         };

--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -205,35 +205,39 @@ export function AssistantDetails({
       "This assistant has no instructions."
     );
 
-  const ActionSection = ({
-    action,
+  const ActionsSection = ({
+    actions,
   }: {
-    action: AgentConfigurationType["action"];
+    actions: AgentConfigurationType["actions"];
   }) =>
-    action ? (
-      isDustAppRunConfiguration(action) ? (
-        <div className="flex flex-col gap-2">
-          <div className="text-lg font-bold text-element-800">Action</div>
-          <DustAppSection dustApp={action} owner={owner} />
-        </div>
-      ) : isRetrievalConfiguration(action) ? (
-        <div className="flex flex-col gap-2">
-          <div className="text-lg font-bold text-element-800">
-            Data source(s)
-          </div>
-          <DataSourcesSection
-            owner={owner}
-            dataSources={dataSources}
-            dataSourceConfigurations={action.dataSources}
-          />
-        </div>
-      ) : isTablesQueryConfiguration(action) ? (
-        <div className="flex flex-col gap-2">
-          <div className="text-lg font-bold text-element-800">Tables</div>
-          <TablesQuerySection tablesQueryConfig={action} />
-        </div>
-      ) : null
-    ) : null;
+    !!actions.length && (
+      <>
+        {actions.map((action, index) =>
+          isDustAppRunConfiguration(action) ? (
+            <div className="flex flex-col gap-2" key={`action-${index}`}>
+              <div className="text-lg font-bold text-element-800">Action</div>
+              <DustAppSection dustApp={action} owner={owner} />
+            </div>
+          ) : isRetrievalConfiguration(action) ? (
+            <div className="flex flex-col gap-2" key={`action-${index}`}>
+              <div className="text-lg font-bold text-element-800">
+                Data source(s)
+              </div>
+              <DataSourcesSection
+                owner={owner}
+                dataSources={dataSources}
+                dataSourceConfigurations={action.dataSources}
+              />
+            </div>
+          ) : isTablesQueryConfiguration(action) ? (
+            <div className="flex flex-col gap-2" key={`action-${index}`}>
+              <div className="text-lg font-bold text-element-800">Tables</div>
+              <TablesQuerySection tablesQueryConfig={action} />
+            </div>
+          ) : null
+        )}
+      </>
+    );
 
   return (
     <ElementModal
@@ -246,7 +250,7 @@ export function AssistantDetails({
       <div className="flex flex-col gap-5 pt-6 text-sm text-element-700">
         <DescriptionSection />
         <InstructionsSection />
-        <ActionSection action={agentConfiguration?.action || null} />
+        <ActionsSection actions={agentConfiguration?.actions ?? []} />
       </div>
     </ElementModal>
   );

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -23,6 +23,7 @@ import {
   GPT_3_5_TURBO_MODEL_CONFIG,
   GPT_4_TURBO_MODEL_CONFIG,
   isBuilder,
+  removeNulls,
 } from "@dust-tt/types";
 import type * as t from "io-ts";
 import { useRouter } from "next/router";
@@ -638,7 +639,9 @@ export async function submitAssistantBuilderForm({
     typeof PostOrPatchAgentConfigurationRequestBodySchema
   >;
 
-  let actionParam: BodyType["assistant"]["action"] | null = null;
+  let actionParam:
+    | NonNullable<BodyType["assistant"]["actions"]>[number]
+    | null = null;
 
   switch (builderState.actionMode) {
     case "GENERIC":
@@ -709,7 +712,7 @@ export async function submitAssistantBuilderForm({
         description: description,
         status: isDraft ? "draft" : "active",
         scope: builderState.scope,
-        action: actionParam,
+        actions: removeNulls([actionParam]),
         generation: {
           prompt: instructions.trim(),
           model: builderState.generationSettings.modelSettings,

--- a/front/components/assistant_builder/server_side_props_helpers.ts
+++ b/front/components/assistant_builder/server_side_props_helpers.ts
@@ -1,5 +1,4 @@
 import type {
-  AgentActionConfigurationType,
   AgentConfigurationType,
   AppType,
   CoreAPITable,
@@ -18,6 +17,7 @@ import type {
   AssistantBuilderDataSourceConfiguration,
   AssistantBuilderInitialState,
 } from "@app/components/assistant_builder/types";
+import { deprecatedGetFirstActionConfiguration } from "@app/lib/action_configurations";
 import { tableKey } from "@app/lib/client/tables_query";
 import logger from "@app/logger/logger";
 
@@ -38,13 +38,7 @@ export async function buildInitialState({
     isSelectAll: boolean;
   }[] = [];
 
-  let action: AgentActionConfigurationType | null = null;
-  if (config.actions.length > 1) {
-    logger.warn("Multiple actions in assistant builder are not supported yet");
-  }
-  if (config.actions.length) {
-    action = config.actions[0];
-  }
+  const action = deprecatedGetFirstActionConfiguration(config);
 
   if (isRetrievalConfiguration(action)) {
     for (const ds of action.dataSources) {

--- a/front/components/poke/data_sources/columns.tsx
+++ b/front/components/poke/data_sources/columns.tsx
@@ -119,14 +119,13 @@ async function deleteDataSource(
   dataSourceName: string,
   reload: () => void
 ) {
-  const retrievalAgents = agentConfigurations.filter((a) => {
-    if (isRetrievalConfiguration(a.action)) {
-      return a.action.dataSources.some(
-        (ds) => ds.dataSourceId === dataSourceName
-      );
-    }
-    return false;
-  });
+  const retrievalAgents = agentConfigurations.filter((agt) =>
+    agt.actions.some(
+      (a) =>
+        isRetrievalConfiguration(a) &&
+        a.dataSources.some((ds) => ds.dataSourceId === dataSourceName)
+    )
+  );
   if (retrievalAgents.length > 0) {
     window.alert(
       "Please archive agents using this data source first: " +

--- a/front/lib/action_configurations.ts
+++ b/front/lib/action_configurations.ts
@@ -1,0 +1,24 @@
+import type {
+  AgentConfigurationType,
+  TemplateAgentConfigurationType,
+} from "@dust-tt/types";
+
+import logger from "@app/logger/logger";
+
+export function deprecatedGetFirstActionConfiguration(
+  config: AgentConfigurationType | TemplateAgentConfigurationType
+) {
+  if (config.actions.length > 1) {
+    logger.warn(
+      {
+        agentConfigurationId: "sId" in config ? config.sId : "template",
+        agentConfigurationName: config.name,
+      },
+      "Multiple actions are not supported yet. The first action will be used."
+    );
+  }
+  if (config.actions.length) {
+    return config.actions[0];
+  }
+  return null;
+}

--- a/front/lib/action_configurations.ts
+++ b/front/lib/action_configurations.ts
@@ -1,8 +1,12 @@
 import type {
+  AgentActionConfigurationType,
   AgentConfigurationType,
   TemplateAgentConfigurationType,
 } from "@dust-tt/types";
+import { assertNever } from "@dust-tt/types";
 
+import type { AgentConfigurationWithoutActionsType } from "@app/lib/api/assistant/configuration";
+import { AgentConfiguration } from "@app/lib/models";
 import logger from "@app/logger/logger";
 
 export function deprecatedGetFirstActionConfiguration(
@@ -21,4 +25,40 @@ export function deprecatedGetFirstActionConfiguration(
     return config.actions[0];
   }
   return null;
+}
+
+// TODO(@fontanierh) Temporary, to remove.
+// This is a shadow write while we invert the relationship between configuration and actions.
+export async function deprecatedMaybeShadowWriteFirstActionOnAgentConfiguration(
+  actions: AgentActionConfigurationType[],
+  agentConfiguration: AgentConfigurationWithoutActionsType
+): Promise<void> {
+  if (actions.length > 1) {
+    logger.info(
+      "Multiple actions found. Only the first action will be shadow written on the agent configuration."
+    );
+  }
+  const firstActionConfig = actions.length ? actions[0] : null;
+  if (firstActionConfig) {
+    await AgentConfiguration.update(
+      firstActionConfig.type === "retrieval_configuration"
+        ? {
+            retrievalConfigurationId: firstActionConfig.id,
+          }
+        : firstActionConfig.type === "tables_query_configuration"
+        ? {
+            tablesQueryConfigurationId: firstActionConfig.id,
+          }
+        : firstActionConfig.type === "dust_app_run_configuration"
+        ? {
+            dustAppRunConfigurationId: firstActionConfig.id,
+          }
+        : assertNever(firstActionConfig),
+      {
+        where: {
+          id: agentConfiguration.id,
+        },
+      }
+    );
+  }
 }

--- a/front/lib/amplitude/node/index.ts
+++ b/front/lib/amplitude/node/index.ts
@@ -10,6 +10,7 @@ import type {
 } from "@dust-tt/types";
 import { rateLimiter, removeNulls } from "@dust-tt/types";
 
+import { deprecatedGetFirstActionConfiguration } from "@app/lib/action_configurations";
 import {
   AMPLITUDE_PUBLIC_API_KEY,
   GROUP_TYPE,
@@ -235,7 +236,7 @@ export function trackAssistantCreated(
     return;
   }
   const amplitude = getBackendClient();
-  const action = assistant.actions[0] ?? null;
+  const action = deprecatedGetFirstActionConfiguration(assistant);
   const event = new AssistantCreated({
     assistantId: assistant.sId,
     assistantName: assistant.name,

--- a/front/lib/amplitude/node/index.ts
+++ b/front/lib/amplitude/node/index.ts
@@ -235,13 +235,14 @@ export function trackAssistantCreated(
     return;
   }
   const amplitude = getBackendClient();
+  const action = assistant.actions[0] ?? null;
   const event = new AssistantCreated({
     assistantId: assistant.sId,
     assistantName: assistant.name,
     workspaceName: workspace.name,
     workspaceId: workspace.sId,
     assistantScope: assistant.scope,
-    assistantActionType: assistant.action?.type || "",
+    assistantActionType: action?.type || "",
     assistantVersion: assistant.version,
     assistantModel: assistant.generation?.model.modelId,
   });

--- a/front/lib/api/assistant/actions/dust_app_run.ts
+++ b/front/lib/api/assistant/actions/dust_app_run.ts
@@ -23,6 +23,7 @@ import { isDustAppRunConfiguration } from "@dust-tt/types";
 import { DustAPI } from "@dust-tt/types";
 import { Err, Ok } from "@dust-tt/types";
 
+import { deprecatedGetFirstActionConfiguration } from "@app/lib/action_configurations";
 import type { Authenticator } from "@app/lib/auth";
 import { prodAPICredentialsForOwner } from "@app/lib/auth";
 import { extractConfig } from "@app/lib/config";
@@ -114,15 +115,9 @@ export async function generateDustAppRunParams(
   app: AppType,
   schema: DatasetSchema | null
 ): Promise<Result<DustAppParameters, Error>> {
-  if (configuration.actions.length > 1) {
-    logger.warn(
-      { agentConfigurationId: configuration.sId },
-      "Agent configuration has more than one action, only the first one will be executed."
-    );
-  }
-  const c = configuration.actions.length ? configuration.actions[0] : null;
+  const action = deprecatedGetFirstActionConfiguration(configuration);
 
-  if (!isDustAppRunConfiguration(c)) {
+  if (!isDustAppRunConfiguration(action)) {
     throw new Error(
       "Unexpected action configuration received in `generateDustAppRunParams`"
     );
@@ -245,18 +240,13 @@ export async function* runDustApp(
     throw new Error("Unexpected unauthenticated call to `runDustApp`");
   }
 
-  if (configuration.actions.length > 1) {
-    logger.warn(
-      { agentConfigurationId: configuration.sId },
-      "Agent configuration has more than one action, only the first one will be executed."
-    );
-  }
-  const c = configuration.actions.length ? configuration.actions[0] : null;
-  if (!isDustAppRunConfiguration(c)) {
+  const actionConfig = deprecatedGetFirstActionConfiguration(configuration);
+
+  if (!isDustAppRunConfiguration(actionConfig)) {
     throw new Error("Unexpected action configuration received in `runDustApp`");
   }
 
-  if (owner.sId !== c.appWorkspaceId) {
+  if (owner.sId !== actionConfig.appWorkspaceId) {
     yield {
       type: "dust_app_run_error",
       created: Date.now(),
@@ -271,7 +261,7 @@ export async function* runDustApp(
     return;
   }
 
-  const app = await getApp(auth, c.appId);
+  const app = await getApp(auth, actionConfig.appId);
   if (!app) {
     yield {
       type: "dust_app_run_error",
@@ -280,7 +270,7 @@ export async function* runDustApp(
       messageId: agentMessage.sId,
       error: {
         code: "dust_app_run_app_error",
-        message: `Failed to retrieve Dust app ${c.appWorkspaceId}/${c.appId}`,
+        message: `Failed to retrieve Dust app ${actionConfig.appWorkspaceId}/${actionConfig.appId}`,
       },
     };
     return;
@@ -311,7 +301,7 @@ export async function* runDustApp(
         error: {
           code: "dust_app_run_app_schema_error",
           message:
-            `Failed to retrieve schema for Dust app: ${c.appWorkspaceId}/${c.appId} dataset=${datasetName}` +
+            `Failed to retrieve schema for Dust app: ${actionConfig.appWorkspaceId}/${actionConfig.appId} dataset=${datasetName}` +
             " (make sure you have set descriptions in your app input block dataset)",
         },
       };
@@ -349,9 +339,9 @@ export async function* runDustApp(
   // later on, the action won't have an output but the error will be stored on the parent agent
   // message.
   const action = await AgentDustAppRunAction.create({
-    dustAppRunConfigurationId: c.sId,
-    appWorkspaceId: c.appWorkspaceId,
-    appId: c.appId,
+    dustAppRunConfigurationId: actionConfig.sId,
+    appWorkspaceId: actionConfig.appWorkspaceId,
+    appId: actionConfig.appId,
     appName: app.name,
     params,
   });
@@ -364,8 +354,8 @@ export async function* runDustApp(
     action: {
       id: action.id,
       type: "dust_app_run_action",
-      appWorkspaceId: c.appWorkspaceId,
-      appId: c.appId,
+      appWorkspaceId: actionConfig.appWorkspaceId,
+      appId: actionConfig.appId,
       appName: app.name,
       params,
       runningBlock: null,
@@ -387,8 +377,8 @@ export async function* runDustApp(
   // that the app executes in the exact same conditions in which they were developed.
   const runRes = await api.runAppStreamed(
     {
-      workspaceId: c.appWorkspaceId,
-      appId: c.appId,
+      workspaceId: actionConfig.appWorkspaceId,
+      appId: actionConfig.appId,
       appHash: "latest",
     },
     appConfig,
@@ -437,8 +427,8 @@ export async function* runDustApp(
         action: {
           id: action.id,
           type: "dust_app_run_action",
-          appWorkspaceId: c.appWorkspaceId,
-          appId: c.appId,
+          appWorkspaceId: actionConfig.appWorkspaceId,
+          appId: actionConfig.appId,
           appName: app.name,
           params,
           runningBlock: {
@@ -493,8 +483,8 @@ export async function* runDustApp(
     action: {
       id: action.id,
       type: "dust_app_run_action",
-      appWorkspaceId: c.appWorkspaceId,
-      appId: c.appId,
+      appWorkspaceId: actionConfig.appWorkspaceId,
+      appId: actionConfig.appId,
       appName: app.name,
       params,
       runningBlock: null,

--- a/front/lib/api/assistant/actions/dust_app_run.ts
+++ b/front/lib/api/assistant/actions/dust_app_run.ts
@@ -115,9 +115,9 @@ export async function generateDustAppRunParams(
   app: AppType,
   schema: DatasetSchema | null
 ): Promise<Result<DustAppParameters, Error>> {
-  const action = deprecatedGetFirstActionConfiguration(configuration);
+  const actionConfig = deprecatedGetFirstActionConfiguration(configuration);
 
-  if (!isDustAppRunConfiguration(action)) {
+  if (!isDustAppRunConfiguration(actionConfig)) {
     throw new Error(
       "Unexpected action configuration received in `generateDustAppRunParams`"
     );

--- a/front/lib/api/assistant/actions/dust_app_run.ts
+++ b/front/lib/api/assistant/actions/dust_app_run.ts
@@ -114,7 +114,14 @@ export async function generateDustAppRunParams(
   app: AppType,
   schema: DatasetSchema | null
 ): Promise<Result<DustAppParameters, Error>> {
-  const c = configuration.action;
+  if (configuration.actions.length > 1) {
+    logger.warn(
+      { agentConfigurationId: configuration.sId },
+      "Agent configuration has more than one action, only the first one will be executed."
+    );
+  }
+  const c = configuration.actions.length ? configuration.actions[0] : null;
+
   if (!isDustAppRunConfiguration(c)) {
     throw new Error(
       "Unexpected action configuration received in `generateDustAppRunParams`"
@@ -235,10 +242,16 @@ export async function* runDustApp(
 > {
   const owner = auth.workspace();
   if (!owner) {
-    throw new Error("Unexpected unauthenticated call to `runRetrieval`");
+    throw new Error("Unexpected unauthenticated call to `runDustApp`");
   }
 
-  const c = configuration.action;
+  if (configuration.actions.length > 1) {
+    logger.warn(
+      { agentConfigurationId: configuration.sId },
+      "Agent configuration has more than one action, only the first one will be executed."
+    );
+  }
+  const c = configuration.actions.length ? configuration.actions[0] : null;
   if (!isDustAppRunConfiguration(c)) {
     throw new Error("Unexpected action configuration received in `runDustApp`");
   }

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -25,6 +25,7 @@ import { isRetrievalConfiguration } from "@dust-tt/types";
 import { cloneBaseConfig, DustProdActionRegistry } from "@dust-tt/types";
 import { Err, Ok } from "@dust-tt/types";
 
+import { deprecatedGetFirstActionConfiguration } from "@app/lib/action_configurations";
 import { runActionStreamed } from "@app/lib/actions/server";
 import { generateActionInputs } from "@app/lib/api/assistant/agent";
 import { getSupportedModelConfig } from "@app/lib/assistant";
@@ -206,15 +207,9 @@ export async function generateRetrievalParams(
     Error
   >
 > {
-  if (configuration.actions.length > 1) {
-    logger.warn(
-      { agentConfigurationId: configuration.sId },
-      "Agent configuration has more than one action, only the first one will be executed."
-    );
-  }
-  const c = configuration.actions.length ? configuration.actions[0] : null;
+  const actionConfig = deprecatedGetFirstActionConfiguration(configuration);
 
-  if (!isRetrievalConfiguration(c)) {
+  if (!isRetrievalConfiguration(actionConfig)) {
     throw new Error(
       "Unexpected action configuration received in `generateRetrievalParams`"
     );
@@ -223,15 +218,21 @@ export async function generateRetrievalParams(
   let query: string | null = null;
   let relativeTimeFrame: TimeFrame | null = null;
 
-  if (c.relativeTimeFrame !== "none" && c.relativeTimeFrame !== "auto") {
-    relativeTimeFrame = c.relativeTimeFrame;
+  if (
+    actionConfig.relativeTimeFrame !== "none" &&
+    actionConfig.relativeTimeFrame !== "auto"
+  ) {
+    relativeTimeFrame = actionConfig.relativeTimeFrame;
   }
 
-  if (c.query !== "none" && c.query !== "auto") {
-    query = c.query.template.replace("_USER_MESSAGE_", userMessage.content);
+  if (actionConfig.query !== "none" && actionConfig.query !== "auto") {
+    query = actionConfig.query.template.replace(
+      "_USER_MESSAGE_",
+      userMessage.content
+    );
   }
 
-  const spec = await retrievalActionSpecification(c);
+  const spec = await retrievalActionSpecification(actionConfig);
 
   if (spec.inputs.length > 0) {
     const now = Date.now();
@@ -256,7 +257,7 @@ export async function generateRetrievalParams(
         "[ASSISTANT_TRACE] Retrieval action inputs generation"
       );
 
-      if (c.query === "auto") {
+      if (actionConfig.query === "auto") {
         if (!rawInputs.query || typeof rawInputs.query !== "string") {
           return new Err(
             new Error("Failed to generate a valid retrieval query.")
@@ -265,7 +266,7 @@ export async function generateRetrievalParams(
         query = rawInputs.query as string;
       }
 
-      if (c.relativeTimeFrame === "auto") {
+      if (actionConfig.relativeTimeFrame === "auto") {
         if (
           rawInputs.relativeTimeFrame &&
           typeof rawInputs.relativeTimeFrame === "string"
@@ -286,7 +287,7 @@ export async function generateRetrievalParams(
 
       // We fail the rerieval only if we had to generate a query but failed to do so, if the
       // relativeTimeFrame failed, we'll just use `null`.
-      if (c.query === "auto") {
+      if (actionConfig.query === "auto") {
         return rawInputsRes;
       }
     }
@@ -295,7 +296,7 @@ export async function generateRetrievalParams(
   return new Ok({
     query,
     relativeTimeFrame,
-    topK: c.topK,
+    topK: actionConfig.topK,
   });
 }
 
@@ -502,14 +503,9 @@ export async function* runRetrieval(
     throw new Error("Unexpected unauthenticated call to `runRetrieval`");
   }
 
-  if (configuration.actions.length > 1) {
-    logger.warn(
-      { agentConfigurationId: configuration.sId },
-      "Agent configuration has more than one action, only the first one will be executed."
-    );
-  }
-  const c = configuration.actions.length ? configuration.actions[0] : null;
-  if (!isRetrievalConfiguration(c)) {
+  const actionConfig = deprecatedGetFirstActionConfiguration(configuration);
+
+  if (!isRetrievalConfiguration(actionConfig)) {
     throw new Error(
       "Unexpected action configuration received in `runRetrieval`"
     );
@@ -576,7 +572,7 @@ export async function* runRetrieval(
     relativeTimeFrameDuration: params.relativeTimeFrame?.duration ?? null,
     relativeTimeFrameUnit: params.relativeTimeFrame?.unit ?? null,
     topK,
-    retrievalConfigurationId: c.sId,
+    retrievalConfigurationId: actionConfig.sId,
   });
 
   yield {
@@ -584,7 +580,7 @@ export async function* runRetrieval(
     created: Date.now(),
     configurationId: configuration.sId,
     messageId: agentMessage.sId,
-    dataSources: c.dataSources,
+    dataSources: actionConfig.dataSources,
     action: {
       id: action.id,
       type: "retrieval_action",
@@ -604,12 +600,12 @@ export async function* runRetrieval(
   );
 
   // Handle data sources list and parents/tags filtering.
-  config.DATASOURCE.data_sources = c.dataSources.map((d) => ({
+  config.DATASOURCE.data_sources = actionConfig.dataSources.map((d) => ({
     workspace_id: d.workspaceId,
     data_source_id: d.dataSourceId,
   }));
 
-  for (const ds of c.dataSources) {
+  for (const ds of actionConfig.dataSources) {
     /** Caveat: empty array in tags.in means "no document match" since no
      * documents has any tags that is in the tags.in array (same for parents)*/
     if (!config.DATASOURCE.filter.tags) {
@@ -692,7 +688,7 @@ export async function* runRetrieval(
   // want `core` to return the `workspace_id` that was used eventualy.
   // TODO(spolu): make `core` return data source workspace id.
   const dataSourcesIdToWorkspaceId: { [key: string]: string } = {};
-  for (const ds of c.dataSources) {
+  for (const ds of actionConfig.dataSources) {
     dataSourcesIdToWorkspaceId[ds.dataSourceId] = ds.workspaceId;
   }
 

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -206,7 +206,14 @@ export async function generateRetrievalParams(
     Error
   >
 > {
-  const c = configuration.action;
+  if (configuration.actions.length > 1) {
+    logger.warn(
+      { agentConfigurationId: configuration.sId },
+      "Agent configuration has more than one action, only the first one will be executed."
+    );
+  }
+  const c = configuration.actions.length ? configuration.actions[0] : null;
+
   if (!isRetrievalConfiguration(c)) {
     throw new Error(
       "Unexpected action configuration received in `generateRetrievalParams`"
@@ -495,7 +502,13 @@ export async function* runRetrieval(
     throw new Error("Unexpected unauthenticated call to `runRetrieval`");
   }
 
-  const c = configuration.action;
+  if (configuration.actions.length > 1) {
+    logger.warn(
+      { agentConfigurationId: configuration.sId },
+      "Agent configuration has more than one action, only the first one will be executed."
+    );
+  }
+  const c = configuration.actions.length ? configuration.actions[0] : null;
   if (!isRetrievalConfiguration(c)) {
     throw new Error(
       "Unexpected action configuration received in `runRetrieval`"

--- a/front/lib/api/assistant/actions/tables_query.ts
+++ b/front/lib/api/assistant/actions/tables_query.ts
@@ -20,6 +20,7 @@ import {
   Ok,
 } from "@dust-tt/types";
 
+import { deprecatedGetFirstActionConfiguration } from "@app/lib/action_configurations";
 import { runActionStreamed } from "@app/lib/actions/server";
 import { generateActionInputs } from "@app/lib/api/assistant/agent";
 import type { Authenticator } from "@app/lib/auth";
@@ -85,15 +86,9 @@ export async function generateTablesQueryAppParams(
     Error
   >
 > {
-  if (configuration.actions.length > 1) {
-    logger.warn(
-      { agentConfigurationId: configuration.sId },
-      "Agent configuration has more than one action, only the first one will be executed."
-    );
-  }
-  const c = configuration.actions.length ? configuration.actions[0] : null;
+  const actionConfig = deprecatedGetFirstActionConfiguration(configuration);
 
-  if (!isTablesQueryConfiguration(c)) {
+  if (!isTablesQueryConfiguration(actionConfig)) {
     throw new Error(
       "Unexpected action configuration received in `runQueryTables`"
     );
@@ -141,15 +136,9 @@ export async function* runTablesQuery({
     throw new Error("Unexpected unauthenticated call to `runQueryTables`");
   }
 
-  if (configuration.actions.length > 1) {
-    logger.warn(
-      { agentConfigurationId: configuration.sId },
-      "Agent configuration has more than one action, only the first one will be executed."
-    );
-  }
-  const c = configuration.actions.length ? configuration.actions[0] : null;
+  const actionConfig = deprecatedGetFirstActionConfiguration(configuration);
 
-  if (!isTablesQueryConfiguration(c)) {
+  if (!isTablesQueryConfiguration(actionConfig)) {
     throw new Error(
       "Unexpected action configuration received in `runQueryTables`"
     );
@@ -202,7 +191,7 @@ export async function* runTablesQuery({
   const config = cloneBaseConfig(
     DustProdActionRegistry["assistant-v2-query-tables"].config
   );
-  const tables = c.tables.map((t) => ({
+  const tables = actionConfig.tables.map((t) => ({
     workspace_id: t.workspaceId,
     table_id: t.tableId,
     data_source_id: t.dataSourceId,

--- a/front/lib/api/assistant/actions/tables_query.ts
+++ b/front/lib/api/assistant/actions/tables_query.ts
@@ -85,7 +85,14 @@ export async function generateTablesQueryAppParams(
     Error
   >
 > {
-  const c = configuration.action;
+  if (configuration.actions.length > 1) {
+    logger.warn(
+      { agentConfigurationId: configuration.sId },
+      "Agent configuration has more than one action, only the first one will be executed."
+    );
+  }
+  const c = configuration.actions.length ? configuration.actions[0] : null;
+
   if (!isTablesQueryConfiguration(c)) {
     throw new Error(
       "Unexpected action configuration received in `runQueryTables`"
@@ -133,7 +140,15 @@ export async function* runTablesQuery({
   if (!owner) {
     throw new Error("Unexpected unauthenticated call to `runQueryTables`");
   }
-  const c = configuration.action;
+
+  if (configuration.actions.length > 1) {
+    logger.warn(
+      { agentConfigurationId: configuration.sId },
+      "Agent configuration has more than one action, only the first one will be executed."
+    );
+  }
+  const c = configuration.actions.length ? configuration.actions[0] : null;
+
   if (!isTablesQueryConfiguration(c)) {
     throw new Error(
       "Unexpected action configuration received in `runQueryTables`"

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -188,8 +188,18 @@ export async function* runAgent(
   }
 
   // First run the action if a configuration is present.
-  if (fullConfiguration.action !== null) {
-    if (isRetrievalConfiguration(fullConfiguration.action)) {
+  if (fullConfiguration.actions.length > 1) {
+    logger.warn(
+      { agentConfigurationId: configuration.sId },
+      "Agent configuration has more than one action, only the first one will be executed."
+    );
+  }
+  const action = fullConfiguration.actions.length
+    ? fullConfiguration.actions[0]
+    : null;
+
+  if (action !== null) {
+    if (isRetrievalConfiguration(action)) {
       const eventStream = runRetrieval(
         auth,
         fullConfiguration,
@@ -236,7 +246,7 @@ export async function* runAgent(
             return;
         }
       }
-    } else if (isDustAppRunConfiguration(fullConfiguration.action)) {
+    } else if (isDustAppRunConfiguration(action)) {
       const eventStream = runDustApp(
         auth,
         fullConfiguration,
@@ -286,7 +296,7 @@ export async function* runAgent(
             return;
         }
       }
-    } else if (isTablesQueryConfiguration(fullConfiguration.action)) {
+    } else if (isTablesQueryConfiguration(action)) {
       const eventStream = runTablesQuery({
         auth,
         configuration: fullConfiguration,
@@ -335,7 +345,7 @@ export async function* runAgent(
     } else {
       ((a: never) => {
         throw new Error(`Unexpected action type: ${a}`);
-      })(fullConfiguration.action);
+      })(action);
     }
   }
 

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -27,6 +27,7 @@ import {
   Ok,
 } from "@dust-tt/types";
 
+import { deprecatedGetFirstActionConfiguration } from "@app/lib/action_configurations";
 import { runActionStreamed } from "@app/lib/actions/server";
 import { runDustApp } from "@app/lib/api/assistant/actions/dust_app_run";
 import { runRetrieval } from "@app/lib/api/assistant/actions/retrieval";
@@ -187,16 +188,7 @@ export async function* runAgent(
     );
   }
 
-  // First run the action if a configuration is present.
-  if (fullConfiguration.actions.length > 1) {
-    logger.warn(
-      { agentConfigurationId: configuration.sId },
-      "Agent configuration has more than one action, only the first one will be executed."
-    );
-  }
-  const action = fullConfiguration.actions.length
-    ? fullConfiguration.actions[0]
-    : null;
+  const action = deprecatedGetFirstActionConfiguration(fullConfiguration);
 
   if (action !== null) {
     if (isRetrievalConfiguration(action)) {

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -53,7 +53,6 @@ import {
 } from "@app/lib/models";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { generateModelSId } from "@app/lib/utils";
-import logger from "@app/logger/logger";
 
 type SortStrategyType = "alphabetical" | "priority" | "updatedAt";
 
@@ -736,7 +735,7 @@ async function isSelfHostedImageWithValidContentType(pictureUrl: string) {
   return contentType.includes("image");
 }
 
-type AgentConfigurationWithoutActionsType = Omit<
+export type AgentConfigurationWithoutActionsType = Omit<
   AgentConfigurationType,
   "actions"
 >;
@@ -900,42 +899,6 @@ export async function createAgentConfiguration(
       return new Err(new Error("An agent with this name already exists."));
     }
     throw error;
-  }
-}
-
-// TODO(@fontanierh) Temporary, to remove.
-// This is a shadow write while we invert the relationship between configuration and actions.
-export async function deprecatedMaybeShadowWriteFirstActionOnAgentConfiguration(
-  actions: AgentActionConfigurationType[],
-  agentConfiguration: AgentConfigurationWithoutActionsType
-): Promise<void> {
-  if (actions.length > 1) {
-    logger.info(
-      "Multiple actions found. Only the first action will be shadow written on the agent configuration."
-    );
-  }
-  const firstActionConfig = actions.length ? actions[0] : null;
-  if (firstActionConfig) {
-    await AgentConfiguration.update(
-      firstActionConfig.type === "retrieval_configuration"
-        ? {
-            retrievalConfigurationId: firstActionConfig.id,
-          }
-        : firstActionConfig.type === "tables_query_configuration"
-        ? {
-            tablesQueryConfigurationId: firstActionConfig.id,
-          }
-        : firstActionConfig.type === "dust_app_run_configuration"
-        ? {
-            dustAppRunConfigurationId: firstActionConfig.id,
-          }
-        : assertNever(firstActionConfig),
-      {
-        where: {
-          id: agentConfiguration.id,
-        },
-      }
-    );
   }
 }
 

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -349,15 +349,6 @@ async function fetchWorkspaceAgentConfigurationsForView(
   const generationConfigIds = agentConfigurations
     .filter((a) => a.generationConfigurationId !== null)
     .map((a) => a.generationConfigurationId as number);
-  // const retrievalConfigIds = agentConfigurations
-  //   .filter((a) => a.retrievalConfigurationId !== null)
-  //   .map((a) => a.retrievalConfigurationId as number);
-  // const dustAppRunConfigIds = agentConfigurations
-  //   .filter((a) => a.dustAppRunConfigurationId !== null)
-  //   .map((a) => a.dustAppRunConfigurationId as number);
-  // const tablesQueryConfigurationsIds = agentConfigurations
-  //   .filter((a) => a.tablesQueryConfigurationId !== null)
-  //   .map((a) => a.tablesQueryConfigurationId as number);
 
   function keyById<T extends { id: number }>(list: T[]): Record<number, T> {
     return _.keyBy(list, "id");

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -27,6 +27,7 @@ import {
 } from "@dust-tt/types";
 import moment from "moment-timezone";
 
+import { deprecatedGetFirstActionConfiguration } from "@app/lib/action_configurations";
 import { runActionStreamed } from "@app/lib/actions/server";
 import { renderDustAppRunActionForModel } from "@app/lib/api/assistant/actions/dust_app_run";
 import {
@@ -263,15 +264,9 @@ export async function constructPrompt(
     instructions += `\n${fallbackPrompt}`;
   }
 
-  if (configuration.actions.length > 1) {
-    logger.warn(
-      { agentConfigurationId: configuration.sId },
-      "Agent configuration has more than one action, only the first one will be executed."
-    );
-  }
-  const action = configuration.actions.length ? configuration.actions[0] : null;
+  const actionConfig = deprecatedGetFirstActionConfiguration(configuration);
 
-  if (isRetrievalConfiguration(action)) {
+  if (isRetrievalConfiguration(actionConfig)) {
     instructions += `\n${retrievalMetaPrompt()}`;
   }
   if (instructions.length > 0) {

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -262,7 +262,16 @@ export async function constructPrompt(
   } else if (fallbackPrompt) {
     instructions += `\n${fallbackPrompt}`;
   }
-  if (isRetrievalConfiguration(configuration.action)) {
+
+  if (configuration.actions.length > 1) {
+    logger.warn(
+      { agentConfigurationId: configuration.sId },
+      "Agent configuration has more than one action, only the first one will be executed."
+    );
+  }
+  const action = configuration.actions.length ? configuration.actions[0] : null;
+
+  if (isRetrievalConfiguration(action)) {
     instructions += `\n${retrievalMetaPrompt()}`;
   }
   if (instructions.length > 0) {

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -114,7 +114,7 @@ async function _getHelperGlobalAgent(
       model,
       temperature: 0.2,
     },
-    action: null,
+    actions: [],
   };
 }
 
@@ -145,7 +145,7 @@ async function _getGPT35TurboGlobalAgent({
       },
       temperature: 0.7,
     },
-    action: null,
+    actions: [],
   };
 }
 
@@ -177,7 +177,7 @@ async function _getGPT4GlobalAgent({
 
       temperature: 0.7,
     },
-    action: null,
+    actions: [],
   };
 }
 
@@ -208,7 +208,7 @@ async function _getClaudeInstantGlobalAgent({
       },
       temperature: 0.7,
     },
-    action: null,
+    actions: [],
   };
 }
 
@@ -245,7 +245,7 @@ async function _getClaude2GlobalAgent({
       },
       temperature: 0.7,
     },
-    action: null,
+    actions: [],
   };
 }
 
@@ -284,7 +284,7 @@ async function _getClaude3HaikuGlobalAgent({
       },
       temperature: 0.7,
     },
-    action: null,
+    actions: [],
   };
 }
 
@@ -322,7 +322,7 @@ async function _getClaude3SonnetGlobalAgent({
       },
       temperature: 0.7,
     },
-    action: null,
+    actions: [],
   };
 }
 
@@ -359,7 +359,7 @@ async function _getClaude3OpusGlobalAgent({
       },
       temperature: 0.7,
     },
-    action: null,
+    actions: [],
   };
 }
 
@@ -396,7 +396,7 @@ async function _getMistralLargeGlobalAgent({
       },
       temperature: 0.7,
     },
-    action: null,
+    actions: [],
   };
 }
 
@@ -433,7 +433,7 @@ async function _getMistralMediumGlobalAgent({
       },
       temperature: 0.7,
     },
-    action: null,
+    actions: [],
   };
 }
 
@@ -464,7 +464,7 @@ async function _getMistralSmallGlobalAgent({
       },
       temperature: 0.7,
     },
-    action: null,
+    actions: [],
   };
 }
 
@@ -500,7 +500,7 @@ async function _getGeminiProGlobalAgent({
       },
       temperature: 0.7,
     },
-    action: null,
+    actions: [],
   };
 }
 
@@ -552,7 +552,7 @@ async function _getManagedDataSourceAgent(
       scope: "global",
       userListStatus: "not-in-list",
       generation: null,
-      action: null,
+      actions: [],
     };
   }
 
@@ -574,7 +574,7 @@ async function _getManagedDataSourceAgent(
       scope: "global",
       userListStatus: "not-in-list",
       generation: null,
-      action: null,
+      actions: [],
     };
   }
 
@@ -604,21 +604,23 @@ async function _getManagedDataSourceAgent(
           },
       temperature: 0.4,
     },
-    action: {
-      id: -1,
-      sId: agentId + "-action",
-      type: "retrieval_configuration",
-      query: "auto",
-      relativeTimeFrame: "auto",
-      topK: "auto",
-      dataSources: filteredDataSources.map((ds) => ({
-        dataSourceId: ds.name,
-        // We use prodCredentials to make sure we are using the right workspaceId. In development
-        // this is the production Dust use case, in production this is the auth's workspace.
-        workspaceId: prodCredentials.workspaceId,
-        filter: { tags: null, parents: null },
-      })),
-    },
+    actions: [
+      {
+        id: -1,
+        sId: agentId + "-action",
+        type: "retrieval_configuration",
+        query: "auto",
+        relativeTimeFrame: "auto",
+        topK: "auto",
+        dataSources: filteredDataSources.map((ds) => ({
+          dataSourceId: ds.name,
+          // We use prodCredentials to make sure we are using the right workspaceId. In development
+          // this is the production Dust use case, in production this is the auth's workspace.
+          workspaceId: prodCredentials.workspaceId,
+          filter: { tags: null, parents: null },
+        })),
+      },
+    ],
   };
 }
 
@@ -774,7 +776,7 @@ async function _getDustGlobalAgent(
       scope: "global",
       userListStatus: "not-in-list",
       generation: null,
-      action: null,
+      actions: [],
     };
   }
 
@@ -804,7 +806,7 @@ async function _getDustGlobalAgent(
       scope: "global",
       userListStatus: "not-in-list",
       generation: null,
-      action: null,
+      actions: [],
     };
   }
 
@@ -836,19 +838,21 @@ async function _getDustGlobalAgent(
           },
       temperature: 0.4,
     },
-    action: {
-      id: -1,
-      sId: GLOBAL_AGENTS_SID.DUST + "-action",
-      type: "retrieval_configuration",
-      query: "auto",
-      relativeTimeFrame: "auto",
-      topK: "auto",
-      dataSources: dataSources.map((ds) => ({
-        dataSourceId: ds.name,
-        workspaceId: prodCredentials.workspaceId,
-        filter: { tags: null, parents: null },
-      })),
-    },
+    actions: [
+      {
+        id: -1,
+        sId: GLOBAL_AGENTS_SID.DUST + "-action",
+        type: "retrieval_configuration",
+        query: "auto",
+        relativeTimeFrame: "auto",
+        topK: "auto",
+        dataSources: dataSources.map((ds) => ({
+          dataSourceId: ds.name,
+          workspaceId: prodCredentials.workspaceId,
+          filter: { tags: null, parents: null },
+        })),
+      },
+    ],
   };
 }
 

--- a/front/lib/api/assistant/templates.ts
+++ b/front/lib/api/assistant/templates.ts
@@ -12,6 +12,7 @@ import {
   ASSISTANT_CREATIVITY_LEVEL_TEMPERATURES,
   Err,
   Ok,
+  removeNulls,
 } from "@dust-tt/types";
 
 import type { BuilderFlow } from "@app/components/assistant_builder/AssistantBuilder";
@@ -27,7 +28,7 @@ export async function generateMockAgentConfigurationFromTemplate(
   }
 
   return new Ok({
-    action: getAction(template.presetAction),
+    actions: removeNulls([getAction(template.presetAction)]),
     description: template.description ?? "",
     generation: {
       prompt: template.presetInstructions ?? "",

--- a/front/lib/models/assistant/agent.ts
+++ b/front/lib/models/assistant/agent.ts
@@ -1,8 +1,4 @@
-import type {
-  AgentUserListStatus,
-  DustAppRunConfigurationType,
-  TimeframeUnit,
-} from "@dust-tt/types";
+import type { AgentUserListStatus, TimeframeUnit } from "@dust-tt/types";
 import type {
   AgentConfigurationScope,
   AgentStatus,
@@ -104,22 +100,22 @@ export class AgentConfiguration extends Model<
   declare generationConfigurationId: ForeignKey<
     AgentGenerationConfiguration["id"]
   > | null;
-  declare retrievalConfigurationId: ForeignKey<
-    AgentRetrievalConfiguration["id"]
-  > | null;
-  declare dustAppRunConfigurationId: ForeignKey<
-    AgentDustAppRunConfiguration["id"]
-  > | null;
+  // declare retrievalConfigurationId: ForeignKey<
+  //   AgentRetrievalConfiguration["id"]
+  // > | null;
+  // declare dustAppRunConfigurationId: ForeignKey<
+  //   AgentDustAppRunConfiguration["id"]
+  // > | null;
 
-  declare tablesQueryConfigurationId: ForeignKey<
-    AgentTablesQueryConfiguration["id"]
-  > | null;
+  // declare tablesQueryConfigurationId: ForeignKey<
+  //   AgentTablesQueryConfiguration["id"]
+  // > | null;
 
   declare author: NonAttribute<User>;
   declare generationConfiguration: NonAttribute<AgentGenerationConfiguration>;
-  declare retrievalConfiguration: NonAttribute<AgentRetrievalConfiguration>;
-  declare dustAppRunConfiguration: NonAttribute<DustAppRunConfigurationType>;
-  declare tablesQueryConfiguration: NonAttribute<AgentTablesQueryConfiguration>;
+  // declare retrievalConfiguration: NonAttribute<AgentRetrievalConfiguration>;
+  // declare dustAppRunConfiguration: NonAttribute<DustAppRunConfigurationType>;
+  // declare tablesQueryConfiguration: NonAttribute<AgentTablesQueryConfiguration>;
 }
 AgentConfiguration.init(
   {
@@ -189,23 +185,6 @@ AgentConfiguration.init(
         },
       },
     ],
-    hooks: {
-      beforeValidate: (agentConfiguration: AgentConfiguration) => {
-        const actionsTypes: (keyof AgentConfiguration)[] = [
-          "retrievalConfigurationId",
-          "dustAppRunConfigurationId",
-          "tablesQueryConfigurationId",
-        ];
-        const nonNullActionTypes = actionsTypes.filter(
-          (field) => agentConfiguration[field] != null
-        );
-        if (nonNullActionTypes.length > 1) {
-          throw new Error(
-            "Only one of retrievalConfigurationId, dustAppRunConfigurationId, tablesQueryConfigurationId can be set"
-          );
-        }
-      },
-    },
   }
 );
 

--- a/front/lib/models/assistant/agent.ts
+++ b/front/lib/models/assistant/agent.ts
@@ -1,4 +1,8 @@
-import type { AgentUserListStatus, TimeframeUnit } from "@dust-tt/types";
+import type {
+  AgentUserListStatus,
+  DustAppRunConfigurationType,
+  TimeframeUnit,
+} from "@dust-tt/types";
 import type {
   AgentConfigurationScope,
   AgentStatus,
@@ -100,22 +104,22 @@ export class AgentConfiguration extends Model<
   declare generationConfigurationId: ForeignKey<
     AgentGenerationConfiguration["id"]
   > | null;
-  // declare retrievalConfigurationId: ForeignKey<
-  //   AgentRetrievalConfiguration["id"]
-  // > | null;
-  // declare dustAppRunConfigurationId: ForeignKey<
-  //   AgentDustAppRunConfiguration["id"]
-  // > | null;
+  declare retrievalConfigurationId: ForeignKey<
+    AgentRetrievalConfiguration["id"]
+  > | null;
+  declare dustAppRunConfigurationId: ForeignKey<
+    AgentDustAppRunConfiguration["id"]
+  > | null;
 
-  // declare tablesQueryConfigurationId: ForeignKey<
-  //   AgentTablesQueryConfiguration["id"]
-  // > | null;
+  declare tablesQueryConfigurationId: ForeignKey<
+    AgentTablesQueryConfiguration["id"]
+  > | null;
 
   declare author: NonAttribute<User>;
   declare generationConfiguration: NonAttribute<AgentGenerationConfiguration>;
-  // declare retrievalConfiguration: NonAttribute<AgentRetrievalConfiguration>;
-  // declare dustAppRunConfiguration: NonAttribute<DustAppRunConfigurationType>;
-  // declare tablesQueryConfiguration: NonAttribute<AgentTablesQueryConfiguration>;
+  declare retrievalConfiguration: NonAttribute<AgentRetrievalConfiguration>;
+  declare dustAppRunConfiguration: NonAttribute<DustAppRunConfigurationType>;
+  declare tablesQueryConfiguration: NonAttribute<AgentTablesQueryConfiguration>;
 }
 AgentConfiguration.init(
   {

--- a/front/lib/models/assistant/agent.ts
+++ b/front/lib/models/assistant/agent.ts
@@ -360,7 +360,7 @@ export class AgentTablesQueryConfiguration extends Model<
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
-  declare agentConfigurationId: ForeignKey<AgentConfiguration["id"] | null>;
+  declare agentConfigurationId: ForeignKey<AgentConfiguration["id"]>;
 
   declare sId: string;
 }
@@ -412,14 +412,11 @@ AgentConfiguration.belongsTo(AgentTablesQueryConfiguration, {
 
 // NEW -- AgentConfig -> TablesQueryConfig (1:N)
 AgentConfiguration.hasMany(AgentTablesQueryConfiguration, {
-  // TODO(@fontanierh) make it non-nullable
-  foreignKey: { name: "agentConfigurationId", allowNull: true },
-  onDelete: "CASCADE",
+  foreignKey: { name: "agentConfigurationId", allowNull: false },
 });
 AgentTablesQueryConfiguration.belongsTo(AgentConfiguration, {
   // TODO(@fontanierh) make it non-nullable
-  foreignKey: { name: "agentConfigurationId", allowNull: true },
-  onDelete: "CASCADE",
+  foreignKey: { name: "agentConfigurationId", allowNull: false },
 });
 
 // TODO(@fontanierh) TO BE MOVED TO THE retrieval.ts file -- inlined during multi actions migration
@@ -433,7 +430,7 @@ export class AgentRetrievalConfiguration extends Model<
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
-  declare agentConfigurationId: ForeignKey<AgentConfiguration["id"] | null>;
+  declare agentConfigurationId: ForeignKey<AgentConfiguration["id"]>;
 
   declare sId: string;
 
@@ -550,14 +547,10 @@ AgentConfiguration.belongsTo(AgentRetrievalConfiguration, {
 
 // NEW -- AgentConfig -> RetrievalConfig (1:N)
 AgentConfiguration.hasMany(AgentRetrievalConfiguration, {
-  // TODO(@fontanierh) make it non-nullable
-  foreignKey: { name: "agentConfigurationId", allowNull: true },
-  onDelete: "CASCADE",
+  foreignKey: { name: "agentConfigurationId", allowNull: false },
 });
 AgentRetrievalConfiguration.belongsTo(AgentConfiguration, {
-  // TODO(@fontanierh) make it non-nullable
-  foreignKey: { name: "agentConfigurationId", allowNull: true },
-  onDelete: "CASCADE",
+  foreignKey: { name: "agentConfigurationId", allowNull: false },
 });
 
 // TODO(@fontanierh) TO BE MOVED TO THE dust_app_run.ts file -- inlined during multi actions migration
@@ -571,7 +564,7 @@ export class AgentDustAppRunConfiguration extends Model<
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
-  declare agentConfigurationId: ForeignKey<AgentConfiguration["id"] | null>;
+  declare agentConfigurationId: ForeignKey<AgentConfiguration["id"]>;
 
   declare sId: string;
 
@@ -633,12 +626,8 @@ AgentConfiguration.belongsTo(AgentDustAppRunConfiguration, {
 
 // NEW -- AgentConfig -> DustAppRunConfig (1:N)
 AgentConfiguration.hasMany(AgentDustAppRunConfiguration, {
-  // TODO(@fontanierh): make it non-nullable
-  foreignKey: { name: "agentConfigurationId", allowNull: true },
-  onDelete: "CASCADE",
+  foreignKey: { name: "agentConfigurationId", allowNull: false },
 });
 AgentDustAppRunConfiguration.belongsTo(AgentConfiguration, {
-  // TODO(@fontanierh): make it non-nullable
-  foreignKey: { name: "agentConfigurationId", allowNull: true },
-  onDelete: "CASCADE",
+  foreignKey: { name: "agentConfigurationId", allowNull: false },
 });

--- a/front/lib/models/assistant/agent.ts
+++ b/front/lib/models/assistant/agent.ts
@@ -419,7 +419,6 @@ AgentConfiguration.hasMany(AgentTablesQueryConfiguration, {
   foreignKey: { name: "agentConfigurationId", allowNull: false },
 });
 AgentTablesQueryConfiguration.belongsTo(AgentConfiguration, {
-  // TODO(@fontanierh) make it non-nullable
   foreignKey: { name: "agentConfigurationId", allowNull: false },
 });
 

--- a/front/lib/models/index.ts
+++ b/front/lib/models/index.ts
@@ -7,13 +7,15 @@ import {
   RetrievalDocumentChunk,
 } from "@app/lib/models/assistant/actions/retrieval";
 import {
+  AgentTablesQueryAction,
+  AgentTablesQueryConfigurationTable,
+} from "@app/lib/models/assistant/actions/tables_query";
+import {
   AgentConfiguration,
   AgentDustAppRunConfiguration,
   AgentGenerationConfiguration,
   AgentRetrievalConfiguration,
-  AgentTablesQueryAction,
   AgentTablesQueryConfiguration,
-  AgentTablesQueryConfigurationTable,
   AgentUserRelation,
   GlobalAgentSettings,
 } from "@app/lib/models/assistant/agent";

--- a/front/lib/models/index.ts
+++ b/front/lib/models/index.ts
@@ -7,15 +7,13 @@ import {
   RetrievalDocumentChunk,
 } from "@app/lib/models/assistant/actions/retrieval";
 import {
-  AgentTablesQueryAction,
-  AgentTablesQueryConfigurationTable,
-} from "@app/lib/models/assistant/actions/tables_query";
-import {
   AgentConfiguration,
   AgentDustAppRunConfiguration,
   AgentGenerationConfiguration,
   AgentRetrievalConfiguration,
+  AgentTablesQueryAction,
   AgentTablesQueryConfiguration,
+  AgentTablesQueryConfigurationTable,
   AgentUserRelation,
   GlobalAgentSettings,
 } from "@app/lib/models/assistant/agent";

--- a/front/migrations/20240119_migrate_pre_code_github_assistants.ts
+++ b/front/migrations/20240119_migrate_pre_code_github_assistants.ts
@@ -1,5 +1,6 @@
 import { ConnectorsAPI, isRetrievalConfiguration } from "@dust-tt/types";
 
+import { deprecatedGetFirstActionConfiguration } from "@app/lib/action_configurations";
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
 import { getDataSource } from "@app/lib/api/data_sources";
 import { GLOBAL_AGENTS_SID } from "@app/lib/assistant";
@@ -79,7 +80,7 @@ makeScript(
 
     for (const a of agents) {
       // NOTE: this migration will NOT work with multi-actions
-      const action = a.actions[0] ?? null;
+      const action = deprecatedGetFirstActionConfiguration(a);
       if (isRetrievalConfiguration(action)) {
         const retrievalConfiguration =
           await AgentRetrievalConfiguration.findOne({

--- a/front/migrations/20240119_migrate_pre_code_github_assistants.ts
+++ b/front/migrations/20240119_migrate_pre_code_github_assistants.ts
@@ -1,158 +1,148 @@
-import { ConnectorsAPI, isRetrievalConfiguration } from "@dust-tt/types";
-
-import { deprecatedGetFirstActionConfiguration } from "@app/lib/action_configurations";
-import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
-import { getDataSource } from "@app/lib/api/data_sources";
-import { GLOBAL_AGENTS_SID } from "@app/lib/assistant";
-import { Authenticator } from "@app/lib/auth";
-import {
-  AgentDataSourceConfiguration,
-  AgentRetrievalConfiguration,
-  DataSource,
-} from "@app/lib/models";
-import logger from "@app/logger/logger";
 import { makeScript } from "@app/scripts/helpers";
 
 makeScript(
   {
     wId: { type: "string", demandOption: true },
   },
-  async ({ execute, wId }) => {
-    const auth = await Authenticator.internalAdminForWorkspace(wId);
-    const agents = (
-      await getAgentConfigurations({
-        auth,
-        agentsGetView: "admin_internal",
-        variant: "full",
-      })
-    ).filter(
-      (a) =>
-        !Object.values(GLOBAL_AGENTS_SID).includes(a.sId as GLOBAL_AGENTS_SID)
+  async () => {
+    throw new Error(
+      "This migration cannot be ran since migration to multi-actions"
     );
+    // const auth = await Authenticator.internalAdminForWorkspace(wId);
+    // const agents = (
+    //   await getAgentConfigurations({
+    //     auth,
+    //     agentsGetView: "admin_internal",
+    //     variant: "full",
+    //   })
+    // ).filter(
+    //   (a) =>
+    //     !Object.values(GLOBAL_AGENTS_SID).includes(a.sId as GLOBAL_AGENTS_SID)
+    // );
 
-    const dataSource = await getDataSource(auth, "managed-github");
-    const connectorId = dataSource?.connectorId;
-    if (!dataSource || !connectorId) {
-      throw new Error("No managed-github data source found");
-    }
-    const dsModel = await DataSource.findOne({
-      where: {
-        id: dataSource.id,
-      },
-    });
-    if (!dsModel) {
-      throw new Error(`Could not find data source ${dataSource.id}`);
-    }
+    // const dataSource = await getDataSource(auth, "managed-github");
+    // const connectorId = dataSource?.connectorId;
+    // if (!dataSource || !connectorId) {
+    //   throw new Error("No managed-github data source found");
+    // }
+    // const dsModel = await DataSource.findOne({
+    //   where: {
+    //     id: dataSource.id,
+    //   },
+    // });
+    // if (!dsModel) {
+    //   throw new Error(`Could not find data source ${dataSource.id}`);
+    // }
 
-    const connectorsAPI = new ConnectorsAPI(logger);
-    const pRes = await connectorsAPI.getConnectorPermissions({
-      connectorId,
-      filterPermission: "read",
-    });
-    if (pRes.isErr()) {
-      throw new Error("Could not fetch connector permissions");
-    }
-    const { resources: permissions } = pRes.value;
+    // const connectorsAPI = new ConnectorsAPI(logger);
+    // const pRes = await connectorsAPI.getConnectorPermissions({
+    //   connectorId,
+    //   filterPermission: "read",
+    // });
+    // if (pRes.isErr()) {
+    //   throw new Error("Could not fetch connector permissions");
+    // }
+    // const { resources: permissions } = pRes.value;
 
-    const repoToSubPermissions: {
-      [key: string]: { name: string; subPermissions: string[] };
-    } = {};
+    // const repoToSubPermissions: {
+    //   [key: string]: { name: string; subPermissions: string[] };
+    // } = {};
 
-    await Promise.all(
-      permissions.map(async (p) => {
-        const pRes = await connectorsAPI.getConnectorPermissions({
-          connectorId,
-          filterPermission: "read",
-          parentId: p.internalId,
-        });
-        if (pRes.isErr()) {
-          throw new Error("Could not fetch connector permissions");
-        }
-        const { resources: permissions } = pRes.value;
-        repoToSubPermissions[p.internalId] = {
-          name: p.title,
-          subPermissions: permissions.map((p) => p.internalId),
-        };
-      })
-    );
+    // await Promise.all(
+    //   permissions.map(async (p) => {
+    //     const pRes = await connectorsAPI.getConnectorPermissions({
+    //       connectorId,
+    //       filterPermission: "read",
+    //       parentId: p.internalId,
+    //     });
+    //     if (pRes.isErr()) {
+    //       throw new Error("Could not fetch connector permissions");
+    //     }
+    //     const { resources: permissions } = pRes.value;
+    //     repoToSubPermissions[p.internalId] = {
+    //       name: p.title,
+    //       subPermissions: permissions.map((p) => p.internalId),
+    //     };
+    //   })
+    // );
 
-    console.log(repoToSubPermissions);
+    // console.log(repoToSubPermissions);
 
-    for (const a of agents) {
-      // NOTE: this migration will NOT work with multi-actions
-      const action = deprecatedGetFirstActionConfiguration(a);
-      if (isRetrievalConfiguration(action)) {
-        const retrievalConfiguration =
-          await AgentRetrievalConfiguration.findOne({
-            where: {
-              id: action.id,
-            },
-          });
-        if (!retrievalConfiguration) {
-          throw new Error(
-            `Could not find retrieval configuration ${action.id}`
-          );
-        }
+    // for (const a of agents) {
+    //   // NOTE: this migration will NOT work with multi-actions
+    //   const action = deprecatedGetFirstActionConfiguration(a);
+    //   if (isRetrievalConfiguration(action)) {
+    //     const retrievalConfiguration =
+    //       await AgentRetrievalConfiguration.findOne({
+    //         where: {
+    //           id: action.id,
+    //         },
+    //       });
+    //     if (!retrievalConfiguration) {
+    //       throw new Error(
+    //         `Could not find retrieval configuration ${action.id}`
+    //       );
+    //     }
 
-        const githubDs = action.dataSources.filter(
-          (ds) => ds.dataSourceId === "managed-github"
-        );
-        if (githubDs.length > 0) {
-          if (githubDs.length > 1) {
-            throw new Error(
-              `Found more than one github data source for ${a.sId}`
-            );
-          }
-          const dataSourceConfiguration =
-            await AgentDataSourceConfiguration.findOne({
-              where: {
-                dataSourceId: dsModel.id,
-                retrievalConfigurationId: retrievalConfiguration.id,
-              },
-            });
-          if (!dataSourceConfiguration) {
-            throw new Error(
-              `Could not find data source configuration for ${dsModel.id} and ${retrievalConfiguration.id}`
-            );
-          }
+    //     const githubDs = action.dataSources.filter(
+    //       (ds) => ds.dataSourceId === "managed-github"
+    //     );
+    //     if (githubDs.length > 0) {
+    //       if (githubDs.length > 1) {
+    //         throw new Error(
+    //           `Found more than one github data source for ${a.sId}`
+    //         );
+    //       }
+    //       const dataSourceConfiguration =
+    //         await AgentDataSourceConfiguration.findOne({
+    //           where: {
+    //             dataSourceId: dsModel.id,
+    //             retrievalConfigurationId: retrievalConfiguration.id,
+    //           },
+    //         });
+    //       if (!dataSourceConfiguration) {
+    //         throw new Error(
+    //           `Could not find data source configuration for ${dsModel.id} and ${retrievalConfiguration.id}`
+    //         );
+    //       }
 
-          const dsConfig = githubDs[0];
-          let newParentsIn: string[] = [];
-          const oldParentsIn = dataSourceConfiguration.parentsIn;
+    //       const dsConfig = githubDs[0];
+    //       let newParentsIn: string[] = [];
+    //       const oldParentsIn = dataSourceConfiguration.parentsIn;
 
-          if (dsConfig.filter.parents) {
-            dsConfig.filter.parents.in.forEach((p) => {
-              const repo = repoToSubPermissions[p];
-              if (!repo) {
-                newParentsIn.push(p);
-              } else {
-                newParentsIn = [
-                  ...new Set(newParentsIn.concat(repo.subPermissions)),
-                ];
-              }
-            });
-          } else {
-            newParentsIn = Object.values(repoToSubPermissions).flatMap(
-              (r) => r.subPermissions
-            );
-          }
+    //       if (dsConfig.filter.parents) {
+    //         dsConfig.filter.parents.in.forEach((p) => {
+    //           const repo = repoToSubPermissions[p];
+    //           if (!repo) {
+    //             newParentsIn.push(p);
+    //           } else {
+    //             newParentsIn = [
+    //               ...new Set(newParentsIn.concat(repo.subPermissions)),
+    //             ];
+    //           }
+    //         });
+    //       } else {
+    //         newParentsIn = Object.values(repoToSubPermissions).flatMap(
+    //           (r) => r.subPermissions
+    //         );
+    //       }
 
-          console.log(
-            `ASSISTANT ${a.sId} [${a.scope}] ${oldParentsIn} -> ${newParentsIn}`
-          );
+    //       console.log(
+    //         `ASSISTANT ${a.sId} [${a.scope}] ${oldParentsIn} -> ${newParentsIn}`
+    //       );
 
-          if (execute) {
-            dataSourceConfiguration.parentsIn = newParentsIn;
-            if (
-              newParentsIn !== null &&
-              dataSourceConfiguration.parentsNotIn === null
-            ) {
-              dataSourceConfiguration.parentsNotIn = [];
-            }
-            await dataSourceConfiguration.save();
-          }
-        }
-      }
-    }
+    //       if (execute) {
+    //         dataSourceConfiguration.parentsIn = newParentsIn;
+    //         if (
+    //           newParentsIn !== null &&
+    //           dataSourceConfiguration.parentsNotIn === null
+    //         ) {
+    //           dataSourceConfiguration.parentsNotIn = [];
+    //         }
+    //         await dataSourceConfiguration.save();
+    //       }
+    //     }
+    //   }
+    // }
   }
 );

--- a/front/migrations/20240119_migrate_pre_code_github_assistants.ts
+++ b/front/migrations/20240119_migrate_pre_code_github_assistants.ts
@@ -78,7 +78,8 @@ makeScript(
     console.log(repoToSubPermissions);
 
     for (const a of agents) {
-      const action = a.action;
+      // NOTE: this migration will NOT work with multi-actions
+      const action = a.actions[0] ?? null;
       if (isRetrievalConfiguration(action)) {
         const retrievalConfiguration =
           await AgentRetrievalConfiguration.findOne({

--- a/front/migrations/20240410_invert_agent_actions_configs_fkeys_step_1.ts
+++ b/front/migrations/20240410_invert_agent_actions_configs_fkeys_step_1.ts
@@ -11,6 +11,7 @@ import { makeScript } from "@app/scripts/helpers";
 
 const backfillActionConfigs = async (execute: boolean) => {
   const retrievalConfigs = await AgentRetrievalConfiguration.findAll({
+    // @ts-expect-error agentConfigurationId is marked as required in the model, but we are looking for null values
     where: {
       agentConfigurationId: null,
     },
@@ -25,7 +26,7 @@ const backfillActionConfigs = async (execute: boolean) => {
       chunk.map(async (rc) => {
         const agent = await AgentConfiguration.findOne({
           where: {
-            retrievalConfigurationId: rc.id,
+            retrievalConfigurationId: rc.id as number,
           },
         });
         if (!agent) {
@@ -43,6 +44,7 @@ const backfillActionConfigs = async (execute: boolean) => {
   }
 
   const tablesQueryConfigs = await AgentTablesQueryConfiguration.findAll({
+    // @ts-expect-error agentConfigurationId is marked as required in the model, but we are looking for null values
     where: {
       agentConfigurationId: null,
     },
@@ -77,6 +79,7 @@ const backfillActionConfigs = async (execute: boolean) => {
   }
 
   const dustAppRunConfigs = await AgentDustAppRunConfiguration.findAll({
+    // @ts-expect-error agentConfigurationId is marked as required in the model, but we are looking for null values
     where: {
       agentConfigurationId: null,
     },

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -309,48 +309,50 @@ export async function createOrUpgradeAgentConfiguration(
     if (agentConfigurationRes.value.status === "active") {
       trackAssistantCreated(auth, { assistant: agentConfigurationRes.value });
     }
-    if (actionConfig) {
+    if (actionConfigs.length) {
       // TODO(@fontanierh) Temporary, to remove.
       // This is a shadow write while we invert the relationship between configuration and actions.
-      switch (actionConfig.type) {
-        case "retrieval_configuration":
-          await AgentRetrievalConfiguration.update(
-            {
-              agentConfigurationId: agentConfigurationRes.value.id,
-            },
-            {
-              where: {
-                id: actionConfig.id,
+      for (const actionConfig of actionConfigs) {
+        switch (actionConfig.type) {
+          case "retrieval_configuration":
+            await AgentRetrievalConfiguration.update(
+              {
+                agentConfigurationId: agentConfigurationRes.value.id,
               },
-            }
-          );
-          break;
-        case "tables_query_configuration":
-          await AgentTablesQueryConfiguration.update(
-            {
-              agentConfigurationId: agentConfigurationRes.value.id,
-            },
-            {
-              where: {
-                id: actionConfig.id,
+              {
+                where: {
+                  id: actionConfig.id,
+                },
+              }
+            );
+            break;
+          case "tables_query_configuration":
+            await AgentTablesQueryConfiguration.update(
+              {
+                agentConfigurationId: agentConfigurationRes.value.id,
               },
-            }
-          );
-          break;
-        case "dust_app_run_configuration":
-          await AgentDustAppRunConfiguration.update(
-            {
-              agentConfigurationId: agentConfigurationRes.value.id,
-            },
-            {
-              where: {
-                id: actionConfig.id,
+              {
+                where: {
+                  id: actionConfig.id,
+                },
+              }
+            );
+            break;
+          case "dust_app_run_configuration":
+            await AgentDustAppRunConfiguration.update(
+              {
+                agentConfigurationId: agentConfigurationRes.value.id,
               },
-            }
-          );
-          break;
-        default:
-          assertNever(actionConfig);
+              {
+                where: {
+                  id: actionConfig.id,
+                },
+              }
+            );
+            break;
+          default:
+            assertNever(actionConfig);
+        }
       }
     }
   }

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -17,13 +17,13 @@ import type * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import { deprecatedMaybeShadowWriteFirstActionOnAgentConfiguration } from "@app/lib/action_configurations";
 import { trackAssistantCreated } from "@app/lib/amplitude/node";
 import { getAgentUsage } from "@app/lib/api/assistant/agent_usage";
 import {
   createAgentActionConfiguration,
   createAgentConfiguration,
   createAgentGenerationConfiguration,
-  deprecatedMaybeShadowWriteFirstActionOnAgentConfiguration,
   getAgentConfigurations,
   unsafeHardDeleteAgentConfiguration,
 } from "@app/lib/api/assistant/configuration";

--- a/front/pages/poke/[wId]/assistants/[aId]/index.tsx
+++ b/front/pages/poke/[wId]/assistants/[aId]/index.tsx
@@ -66,31 +66,40 @@ const DataSourcePage = ({
                       <div className="font-bold">model:</div>
                       {JSON.stringify(a.generation?.model, null, 2)}
                     </div>
-                    {a.action && isRetrievalConfiguration(a.action) && (
-                      <div className="mb-2 ml-4 flex-col text-sm text-gray-600">
-                        <div className="font-bold">Data Sources:</div>
-                        {JSON.stringify(a.action.dataSources, null, 2)}
-                      </div>
-                    )}
-                    {a.action && isDustAppRunConfiguration(a.action) && (
-                      <div className="mb-2 ml-4 flex-col text-sm text-gray-600">
-                        <div className="font-bold">Dust app:</div>
-                        <div>
-                          {a.action.appWorkspaceId}/{a.action.appId}
+                    {a.actions.map((action, index) =>
+                      isRetrievalConfiguration(action) ? (
+                        <div
+                          className="mb-2 ml-4 flex-col text-sm text-gray-600"
+                          key={`action-${index}`}
+                        >
+                          <div className="font-bold">Data Sources:</div>
+                          {JSON.stringify(action.dataSources, null, 2)}
                         </div>
-                      </div>
-                    )}
-                    {a.action && isTablesQueryConfiguration(a.action) && (
-                      <div className="mb-2 ml-4 flex-col text-sm text-gray-600">
-                        <div className="font-bold">Tables:</div>
-                        {a.action.tables.map((t) => (
-                          <div
-                            key={`${t.workspaceId}/${t.dataSourceId}/${t.tableId}`}
-                          >
-                            {t.workspaceId}/{t.dataSourceId}/{t.tableId}
+                      ) : isDustAppRunConfiguration(action) ? (
+                        <div
+                          className="mb-2 ml-4 flex-col text-sm text-gray-600"
+                          key={`action-${index}`}
+                        >
+                          <div className="font-bold">Dust app:</div>
+                          <div>
+                            {action.appWorkspaceId}/{action.appId}
                           </div>
-                        ))}
-                      </div>
+                        </div>
+                      ) : isTablesQueryConfiguration(action) ? (
+                        <div
+                          className="mb-2 ml-4 flex-col text-sm text-gray-600"
+                          key={`action-${index}`}
+                        >
+                          <div className="font-bold">Tables:</div>
+                          {action.tables.map((t) => (
+                            <div
+                              key={`${t.workspaceId}/${t.dataSourceId}/${t.tableId}`}
+                            >
+                              {t.workspaceId}/{t.dataSourceId}/{t.tableId}
+                            </div>
+                          ))}
+                        </div>
+                      ) : null
                     )}
                   </div>
                 </ContextItem.Description>

--- a/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
@@ -22,6 +22,7 @@ import type {
   AssistantBuilderDataSourceConfiguration,
   AssistantBuilderInitialState,
 } from "@app/components/assistant_builder/types";
+import { deprecatedGetFirstActionConfiguration } from "@app/lib/action_configurations";
 import { getApps } from "@app/lib/api/app";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
 import { getDataSources } from "@app/lib/api/data_sources";
@@ -137,7 +138,7 @@ export default function EditAssistant({
 
   let timeFrame: AssistantBuilderInitialState["timeFrame"] = null;
 
-  const action = agentConfiguration.actions[0] ?? null;
+  const action = deprecatedGetFirstActionConfiguration(agentConfiguration);
 
   if (isRetrievalConfiguration(action)) {
     if (action.query === "none") {

--- a/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
@@ -137,11 +137,13 @@ export default function EditAssistant({
 
   let timeFrame: AssistantBuilderInitialState["timeFrame"] = null;
 
-  if (isRetrievalConfiguration(agentConfiguration.action)) {
-    if (agentConfiguration.action.query === "none") {
+  const action = agentConfiguration.actions[0] ?? null;
+
+  if (isRetrievalConfiguration(action)) {
+    if (action.query === "none") {
       if (
-        agentConfiguration.action.relativeTimeFrame === "auto" ||
-        agentConfiguration.action.relativeTimeFrame === "none"
+        action.relativeTimeFrame === "auto" ||
+        action.relativeTimeFrame === "none"
       ) {
         /** Should never happen. Throw loudly if it does */
         throw new Error(
@@ -150,20 +152,20 @@ export default function EditAssistant({
       }
       actionMode = "RETRIEVAL_EXHAUSTIVE";
       timeFrame = {
-        value: agentConfiguration.action.relativeTimeFrame.duration,
-        unit: agentConfiguration.action.relativeTimeFrame.unit,
+        value: action.relativeTimeFrame.duration,
+        unit: action.relativeTimeFrame.unit,
       };
     }
-    if (agentConfiguration.action.query === "auto") {
+    if (action.query === "auto") {
       actionMode = "RETRIEVAL_SEARCH";
     }
   }
 
-  if (isDustAppRunConfiguration(agentConfiguration.action)) {
+  if (isDustAppRunConfiguration(action)) {
     actionMode = "DUST_APP_RUN";
   }
 
-  if (isTablesQueryConfiguration(agentConfiguration.action)) {
+  if (isTablesQueryConfiguration(action)) {
     actionMode = "TABLES_QUERY";
   }
   if (agentConfiguration.scope === "global") {

--- a/front/pages/w/[wId]/builder/assistants/new.tsx
+++ b/front/pages/w/[wId]/builder/assistants/new.tsx
@@ -174,11 +174,12 @@ export default function CreateAssistant({
   let timeFrame: AssistantBuilderInitialState["timeFrame"] = null;
 
   if (agentConfiguration) {
-    if (isRetrievalConfiguration(agentConfiguration.action)) {
-      if (agentConfiguration.action.query === "none") {
+    const action = agentConfiguration.actions[0] ?? null;
+    if (isRetrievalConfiguration(action)) {
+      if (action.query === "none") {
         if (
-          agentConfiguration.action.relativeTimeFrame === "auto" ||
-          agentConfiguration.action.relativeTimeFrame === "none"
+          action.relativeTimeFrame === "auto" ||
+          action.relativeTimeFrame === "none"
         ) {
           /** Should never happen. Throw loudly if it does */
           throw new Error(
@@ -187,20 +188,20 @@ export default function CreateAssistant({
         }
         actionMode = "RETRIEVAL_EXHAUSTIVE";
         timeFrame = {
-          value: agentConfiguration.action.relativeTimeFrame.duration,
-          unit: agentConfiguration.action.relativeTimeFrame.unit,
+          value: action.relativeTimeFrame.duration,
+          unit: action.relativeTimeFrame.unit,
         };
       }
-      if (agentConfiguration.action.query === "auto") {
+      if (action.query === "auto") {
         actionMode = "RETRIEVAL_SEARCH";
       }
     }
 
-    if (isDustAppRunConfiguration(agentConfiguration.action)) {
+    if (isDustAppRunConfiguration(action)) {
       actionMode = "DUST_APP_RUN";
     }
 
-    if (isTablesQueryConfiguration(agentConfiguration.action)) {
+    if (isTablesQueryConfiguration(action)) {
       actionMode = "TABLES_QUERY";
     }
     if (agentConfiguration.scope === "global") {

--- a/front/pages/w/[wId]/builder/assistants/new.tsx
+++ b/front/pages/w/[wId]/builder/assistants/new.tsx
@@ -24,6 +24,7 @@ import type {
   AssistantBuilderDataSourceConfiguration,
   AssistantBuilderInitialState,
 } from "@app/components/assistant_builder/types";
+import { deprecatedGetFirstActionConfiguration } from "@app/lib/action_configurations";
 import { getApps } from "@app/lib/api/app";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
 import { generateMockAgentConfigurationFromTemplate } from "@app/lib/api/assistant/templates";
@@ -174,7 +175,8 @@ export default function CreateAssistant({
   let timeFrame: AssistantBuilderInitialState["timeFrame"] = null;
 
   if (agentConfiguration) {
-    const action = agentConfiguration.actions[0] ?? null;
+    const action = deprecatedGetFirstActionConfiguration(agentConfiguration);
+
     if (isRetrievalConfiguration(action)) {
       if (action.query === "none") {
         if (

--- a/types/src/front/api_handlers/internal/agent_configuration.ts
+++ b/types/src/front/api_handlers/internal/agent_configuration.ts
@@ -57,65 +57,66 @@ export const PostOrPatchAgentConfigurationRequestBodySchema = t.type({
       t.literal("published"),
       t.literal("private"),
     ]),
-    action: t.union([
-      t.null,
-      t.type({
-        type: t.literal("retrieval_configuration"),
-        query: t.union([
-          t.type({
-            template: t.string,
-          }),
-          t.literal("auto"),
-          t.literal("none"),
-        ]),
-        relativeTimeFrame: t.union([
-          t.literal("auto"),
-          t.literal("none"),
-          t.type({
-            duration: t.number,
-            unit: TimeframeUnitCodec,
-          }),
-        ]),
-        topK: t.union([t.number, t.literal("auto")]),
-        dataSources: t.array(
-          t.type({
-            dataSourceId: t.string,
-            workspaceId: t.string,
-            filter: t.type({
-              tags: t.union([
-                t.type({
-                  in: t.array(t.string),
-                  not: t.array(t.string),
-                }),
-                t.null,
-              ]),
-              parents: t.union([
-                t.type({
-                  in: t.array(t.string),
-                  not: t.array(t.string),
-                }),
-                t.null,
-              ]),
+    actions: t.array(
+      t.union([
+        t.type({
+          type: t.literal("retrieval_configuration"),
+          query: t.union([
+            t.type({
+              template: t.string,
             }),
-          })
-        ),
-      }),
-      t.type({
-        type: t.literal("dust_app_run_configuration"),
-        appWorkspaceId: t.string,
-        appId: t.string,
-      }),
-      t.type({
-        type: t.literal("tables_query_configuration"),
-        tables: t.array(
-          t.type({
-            workspaceId: t.string,
-            dataSourceId: t.string,
-            tableId: t.string,
-          })
-        ),
-      }),
-    ]),
+            t.literal("auto"),
+            t.literal("none"),
+          ]),
+          relativeTimeFrame: t.union([
+            t.literal("auto"),
+            t.literal("none"),
+            t.type({
+              duration: t.number,
+              unit: TimeframeUnitCodec,
+            }),
+          ]),
+          topK: t.union([t.number, t.literal("auto")]),
+          dataSources: t.array(
+            t.type({
+              dataSourceId: t.string,
+              workspaceId: t.string,
+              filter: t.type({
+                tags: t.union([
+                  t.type({
+                    in: t.array(t.string),
+                    not: t.array(t.string),
+                  }),
+                  t.null,
+                ]),
+                parents: t.union([
+                  t.type({
+                    in: t.array(t.string),
+                    not: t.array(t.string),
+                  }),
+                  t.null,
+                ]),
+              }),
+            })
+          ),
+        }),
+        t.type({
+          type: t.literal("dust_app_run_configuration"),
+          appWorkspaceId: t.string,
+          appId: t.string,
+        }),
+        t.type({
+          type: t.literal("tables_query_configuration"),
+          tables: t.array(
+            t.type({
+              workspaceId: t.string,
+              dataSourceId: t.string,
+              tableId: t.string,
+            })
+          ),
+        }),
+      ])
+    ),
     generation: t.union([
       t.null,
       t.type({

--- a/types/src/front/assistant/agent.ts
+++ b/types/src/front/assistant/agent.ts
@@ -176,9 +176,9 @@ export type LightAgentConfigurationType = {
 };
 
 export type AgentConfigurationType = LightAgentConfigurationType & {
-  // If undefined, no action performed, otherwise the action is
-  // performed (potentially NoOp eg autoSkip above).
-  action: AgentActionConfigurationType | null;
+  // If empty, no actions are performed, otherwise the actions are
+  // performed.
+  actions: AgentActionConfigurationType[];
 };
 
 export interface TemplateAgentConfigurationType {
@@ -192,6 +192,6 @@ export interface TemplateAgentConfigurationType {
   name: string;
   scope: AgentConfigurationScope;
   description: string;
-  action: AgentActionConfigurationType | null;
+  actions: AgentActionConfigurationType[];
   isTemplate: true;
 }


### PR DESCRIPTION
## Description

Next step for https://github.com/dust-tt/dust/issues/4594

- Previous PR created and backfill the new foreign keys from action configurations to agent configuration (in order to make the relationship 1-many).
- We still have and use the old 1-1 relationship, and the new relationship is only shadow written
- With this new change, we start using the new relationship instead of the old one. The old one is still shadow written for now in case we need to rollback


The last step of this migration will be to stop shadow writing to the old foreign key, and finally drop it entirely.


While this adds support for creating assistants with several actions, we don't really support multi actions yet:
- assistant builder doesn't allow to add multiple actions
- running an assistant with multiple actions is not supported (first action will be picked)

So this is really only changing the business logic to use the new data model, but there's no change in practice for users. 

## Risk

Quite risky but extensively tested.

## Deploy Plan

First deploy the code, then apply initdb on front -- will make the new FKs non-nullable.