### PR TITLE
Add support for 1106 and unsuffixed gpt-3.5-turbo

### DIFF
--- a/types/src/front/lib/assistant.ts
+++ b/types/src/front/lib/assistant.ts
@@ -5,7 +5,8 @@
 import { ExtractSpecificKeys } from "../../shared/typescipt_utils";
 
 export const GPT_4_TURBO_PREVIEW_MODEL_ID = "gpt-4-turbo-preview" as const;
-export const GPT_3_5_TURBO_MODEL_ID = "gpt-3.5-turbo-1106" as const;
+export const GPT_3_5_TURBO_MODEL_ID = "gpt-3.5-turbo" as const;
+export const GPT_3_5_TURBO_1106_MODEL_ID = "gpt-3.5-turbo-1106" as const;
 
 const GPT_4_DESCRIPTION =
   "OpenAI's most powerful and recent model (128k context).";
@@ -20,6 +21,18 @@ export const GPT_4_TURBO_MODEL_CONFIG = {
   largeModel: true,
   description: GPT_4_DESCRIPTION,
   shortDescription: GPT_4_SHORT_DESCRIPTION,
+} as const;
+
+export const GPT_3_5_TURBO_1106_MODEL_CONFIG = {
+  providerId: "openai" as const,
+  modelId: GPT_3_5_TURBO_1106_MODEL_ID,
+  displayName: "GPT 3.5 Turbo",
+  contextSize: 16384,
+  recommendedTopK: 16,
+  largeModel: false,
+  description:
+    "OpenAI's cost-effective and high throughput model (16k context).",
+  shortDescription: "OpenAI's fast model.",
 } as const;
 
 export const GPT_3_5_TURBO_MODEL_CONFIG = {
@@ -154,6 +167,7 @@ export const GEMINI_PRO_DEFAULT_MODEL_CONFIG = {
 
 export const SUPPORTED_MODEL_CONFIGS = [
   GPT_3_5_TURBO_MODEL_CONFIG,
+  GPT_3_5_TURBO_1106_MODEL_CONFIG,
   GPT_4_TURBO_MODEL_CONFIG,
   CLAUDE_3_OPUS_DEFAULT_MODEL_CONFIG,
   CLAUDE_3_SONNET_DEFAULT_MODEL_CONFIG,


### PR DESCRIPTION
## Description

Move default GPT 3.5 Turbo to `gpt-3.5-turbo`. Add temporary support for `gpt-3.5-turbo-1106` (to support legacy assistant before migration).

Goal is then to migrate all assistants from  `gpt-3.5-turbo-1106` to `gpt-3.5-turbo` and then follow-up with a PR that removes `GPT_3_5_TURBO_1106_MODEL_CONFIG`

## Risk

N/A tested locally

## Deploy Plan

- deploy `front`
- run model migration for asssitants: `npx tsx scripts/update_assistants_models.ts --fromModel gpt-3.5-turbo-1106 --toModel gpt-3.5-turbo`