### PR TITLE
[Front] Confirm Dialog

### DIFF
--- a/front/components/Confirm.tsx
+++ b/front/components/Confirm.tsx
@@ -1,0 +1,84 @@
+import { ElementDialog } from "@dust-tt/sparkle";
+import React from "react";
+import { createPortal } from "react-dom";
+
+export type ConfirmDataType = {
+  title: string;
+  message: string | React.ReactNode;
+  validateLabel?: string;
+  validateVariant?: "primary" | "primaryWarning";
+};
+
+export const ConfirmContext = React.createContext<
+  (n: ConfirmDataType) => Promise<boolean>
+>((n) => new Promise((resolve) => resolve(!!n))); // dummy function
+
+export function ConfirmPopupArea({ children }: { children: React.ReactNode }) {
+  const [confirmData, setConfirmData] = React.useState<ConfirmDataType | null>(
+    null
+  );
+
+  const resolveConfirmRef = React.useRef<(result: boolean) => void>(
+    () => undefined
+  );
+
+  const confirm = (confirm: ConfirmDataType) => {
+    setConfirmData(confirm);
+    return new Promise<boolean>((resolve) => {
+      resolveConfirmRef.current = (t: boolean) => resolve(t);
+    });
+  };
+
+  return (
+    <ConfirmContext.Provider value={confirm}>
+      {children}
+      {typeof window === "object" ? (
+        createPortal(
+          <ConfirmDialog
+            confirmData={confirmData}
+            resolveConfirm={resolveConfirmRef.current}
+            closeDialogFn={() => setConfirmData(null)}
+          />,
+          document.body
+        )
+      ) : (
+        // SSR (otherwise hydration issues)
+        <ConfirmDialog
+          confirmData={confirmData}
+          resolveConfirm={resolveConfirmRef.current}
+          closeDialogFn={() => setConfirmData(null)}
+        />
+      )}
+    </ConfirmContext.Provider>
+  );
+}
+
+export function ConfirmDialog({
+  confirmData,
+  resolveConfirm,
+  closeDialogFn,
+}: {
+  confirmData: ConfirmDataType | null;
+  resolveConfirm: (result: boolean) => void;
+  closeDialogFn: () => void;
+}) {
+  return (
+    <ElementDialog
+      openOnElement={confirmData}
+      title={confirmData?.title || ""}
+      closeDialogFn={closeDialogFn}
+      onCancel={(closingFn) => {
+        resolveConfirm(false);
+        closingFn();
+      }}
+      onValidate={(closingFn) => {
+        resolveConfirm(true);
+        closingFn();
+      }}
+      validateLabel={confirmData?.validateLabel}
+      validateVariant={confirmData?.validateVariant}
+    >
+      {confirmData?.message}
+    </ElementDialog>
+  );
+}

--- a/front/components/app/RootLayout.tsx
+++ b/front/components/app/RootLayout.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import type { MouseEvent } from "react";
 import type { UrlObject } from "url";
 
+import { ConfirmPopupArea } from "@app/components/Confirm";
 import { SidebarProvider } from "@app/components/sparkle/AppLayout";
 import { NotificationArea } from "@app/components/sparkle/Notification";
 
@@ -64,7 +65,9 @@ export default function RootLayout({
     <SparkleContext.Provider value={{ components: { link: NextLinkWrapper } }}>
       <UserProvider>
         <SidebarProvider>
-          <NotificationArea>{children}</NotificationArea>
+          <ConfirmPopupArea>
+            <NotificationArea>{children}</NotificationArea>
+          </ConfirmPopupArea>
         </SidebarProvider>
       </UserProvider>
     </SparkleContext.Provider>

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -9,7 +9,7 @@
         "@amplitude/analytics-browser": "^2.5.2",
         "@amplitude/analytics-node": "^1.3.5",
         "@auth0/nextjs-auth0": "^3.5.0",
-        "@dust-tt/sparkle": "0.2.136-pr2",
+        "@dust-tt/sparkle": "0.2.136",
         "@dust-tt/types": "file:../types",
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",
@@ -10480,9 +10480,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.136-pr2",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.136-pr2.tgz",
-      "integrity": "sha512-LvtA7DDpkUDBLg0UcH2lU7u9vebjwpUex9dxdeBdgnWM1xx79ZSliELOOFp8tE4qJmGahSOYOdZlkRe8I2A7QA==",
+      "version": "0.2.136",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.136.tgz",
+      "integrity": "sha512-Gf4hIo/fe1KUD4C4I95irVCc0sefPiV+2sl7DhMZ6VSnz9yd8kybQZH4Q7kS3mbP+4kNBREryLv4byO7gk45dg==",
       "dependencies": {
         "@headlessui/react": "^1.7.17",
         "esbuild": "^0.20.0",

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -9,7 +9,7 @@
         "@amplitude/analytics-browser": "^2.5.2",
         "@amplitude/analytics-node": "^1.3.5",
         "@auth0/nextjs-auth0": "^3.5.0",
-        "@dust-tt/sparkle": "0.2.132",
+        "@dust-tt/sparkle": "0.2.136-pr2",
         "@dust-tt/types": "file:../types",
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",
@@ -10480,9 +10480,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.132",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.132.tgz",
-      "integrity": "sha512-x/XzxXtcuecw5FyRNQM0WzmcRs5FUC8pUYB4qBd0UDVr5w7oDxMkpKEZ8XbR1GP+PYAu9E0n0MqNiSLCXUEukw==",
+      "version": "0.2.136-pr2",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.136-pr2.tgz",
+      "integrity": "sha512-LvtA7DDpkUDBLg0UcH2lU7u9vebjwpUex9dxdeBdgnWM1xx79ZSliELOOFp8tE4qJmGahSOYOdZlkRe8I2A7QA==",
       "dependencies": {
         "@headlessui/react": "^1.7.17",
         "esbuild": "^0.20.0",

--- a/front/package.json
+++ b/front/package.json
@@ -17,7 +17,7 @@
     "@amplitude/analytics-browser": "^2.5.2",
     "@amplitude/analytics-node": "^1.3.5",
     "@auth0/nextjs-auth0": "^3.5.0",
-    "@dust-tt/sparkle": "0.2.132",
+    "@dust-tt/sparkle": "0.2.136",
     "@dust-tt/types": "file:../types",
     "@emoji-mart/data": "^1.1.2",
     "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -17,7 +17,7 @@
     "@amplitude/analytics-browser": "^2.5.2",
     "@amplitude/analytics-node": "^1.3.5",
     "@auth0/nextjs-auth0": "^3.5.0",
-    "@dust-tt/sparkle": "0.2.136",
+    "@dust-tt/sparkle": "0.2.136-pr2",
     "@dust-tt/types": "file:../types",
     "@emoji-mart/data": "^1.1.2",
     "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -17,7 +17,7 @@
     "@amplitude/analytics-browser": "^2.5.2",
     "@amplitude/analytics-node": "^1.3.5",
     "@auth0/nextjs-auth0": "^3.5.0",
-    "@dust-tt/sparkle": "0.2.136-pr2",
+    "@dust-tt/sparkle": "0.2.136",
     "@dust-tt/types": "file:../types",
     "@emoji-mart/data": "^1.1.2",
     "@emoji-mart/react": "^1.1.1",


### PR DESCRIPTION
Description
---
Reproduces javascipt `confirm` to display confirmation dialogs, but with our sparkle dialogs instead. The goal is to reduce confirmation dialog code and make it more readable.

Example - in a component requiring such a dialog, e.g. deleting an assistant. Turns this:

```
// top of component
const [showDeletionDialog, setShowDeletionDialog] = useState<boolean>(false);

// when confirmation needed
setShowDeletionDialog(true); // and the validationlogic is elsewhere

// at rendering site
<Dialog
  isOpen={showDeletionDialog}
  title={`Deleting the assistant`}
  onCancel={()=> setShowDeletionDialog(false)}
  onValidate={() => {
    validateLogicFn();
    setShowDeletionDialog(false)
}}>
  Are you sure?
</Dialog>

```

Into this:
```
// top of component
const confirm = useContext(ConfirmContext);

// when confirmation needed
if (await confirm({ title: "Deleting the assistant", message: "Are you sure?")) {
   validateLogicFn();
}

```

Risk
---
None on this PR, does not change existing confirmation modals

