### PR TITLE
Starting script + increase server size

### DIFF
--- a/connectors/package.json
+++ b/connectors/package.json
@@ -9,6 +9,7 @@
     "start": "tsx ./src/start.ts -p 3002",
     "start:web": "tsx ./src/start_server.ts -p 3002",
     "start:worker": "tsx ./src/start_worker.ts",
+    "start:worker:processes": "./src/start_all_workers.sh",
     "cli": "npx tsx src/admin/cli.ts",
     "initdb": "npx tsx src/admin/db.ts"
   },

--- a/connectors/src/start_all_workers.sh
+++ b/connectors/src/start_all_workers.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Bash scripts that starts all the workers in the background
+# and fails when any of them fails.
+# The return code of the first failing worker is returned 
+# as the return code of this script.
+
+fail() {
+    wait -n
+    exit $?
+}
+
+npm run start:worker -- --workers confluence & 
+npm run start:worker -- --workers github & 
+npm run start:worker -- --workers google_drive & 
+npm run start:worker -- --workers intercom & 
+# npm run start:worker -- --workers notion &  // notion is running on its own pod so no need to run it here
+npm run start:worker -- --workers slack &
+npm run start:worker -- --workers webcrawler & 
+
+
+fail

--- a/k8s/deployments/connectors-worker-deployment.yaml
+++ b/k8s/deployments/connectors-worker-deployment.yaml
@@ -19,18 +19,8 @@ spec:
       containers:
         - name: web
           image: gcr.io/or1g1n-186209/connectors-image:latest
-          command: ["npm", "run", "start:worker"]
-          args:
-            [
-              "--",
-              "--workers",
-              "confluence",
-              "github",
-              "google_drive",
-              "intercom",
-              "slack",
-              "webcrawler",
-            ]
+          command: ["npm", "run", "start:worker:processes"]
+          args: []
           imagePullPolicy: Always
           envFrom:
             - configMapRef:
@@ -53,12 +43,12 @@ spec:
           resources:
             requests:
               cpu: 3000m
-              memory: 8Gi
+              memory: 32Gi
               ephemeral-storage: 32Gi
 
             limits:
               cpu: 3000m
-              memory: 8Gi
+              memory: 32Gi
               ephemeral-storage: 32Gi
 
       volumes:


### PR DESCRIPTION
## Description

Task: https://github.com/dust-tt/tasks/issues/523

Starting all connectors workers in a different linux process to be able to check memory consumption
separately.
We also increase the RAM of the connector-worker pods to accommodate for this new running scheme.
This PR should be reverted once we observed which connector is leaking memory.

The plan is the following:
- Deploy this PR
- Connect to an instance.
- Get the memory used by all workers after a few minutes: `ps aux --sort=-%mem > mem_stats_1.txt`
- Wait about an hour
- Get the memory used by all workers after a few minutes: `ps aux --sort=-%mem > mem_stats_2.txt`


Check if there is an outlier in the memory usage change pattern.


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
