### PR TITLE
[Assistant Builder] Improve UI and ungate Naming/Description Suggestions

### DIFF
--- a/types/src/front/lib/actions/registry.ts
+++ b/types/src/front/lib/actions/registry.ts
@@ -193,7 +193,7 @@ export const DustProdActionRegistry = createActionRegistry({
       workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
       appId: "aba0057f4c",
       appHash:
-        "51922001984d1c9a3b84ce1b0275b4925d13fc574a73f1b23fe865d2d1b56eb1",
+        "e4bda2ba50f160712c08309628b4a6bf2b68dd7e9709669cc29ac43e36d663f7",
     },
     config: {
       CREATE_SUGGESTIONS: {


### PR DESCRIPTION
Description
---
As discussed with @Duncid:
- The loader when generating a description replaces the sparkle button (that is otherwise used to generate a description)
- The `confirm` to avoid overwriting a description that the user modified now uses our style (it was previously a system js `confirm`)
- Prompt for description suggestion generation was improved
- Naming & descriptions suggestions are hereby ungated
![Screencast from 2024-04-09 17-49-31](https://github.com/dust-tt/dust/assets/5437393/e7eb7207-3408-44d9-9e76-8d44bb1b9a4d)

Risk
---
Limited, as we have been using it for a few weeks internally

Deploy
---
Deploy front
