### PR TITLE
poke: Show stripeSubscriptionId in subscriptions history

### DIFF
--- a/front/components/poke/subscriptions/columns.tsx
+++ b/front/components/poke/subscriptions/columns.tsx
@@ -64,6 +64,23 @@ export function makeColumnsForSubscriptions(): ColumnDef<SubscriptionsDisplayTyp
       },
     },
     {
+      accessorKey: "stripeSubscriptionId",
+      cell: ({ row }) => {
+        const sId: string = row.getValue("stripeSubscriptionId");
+
+        return (
+          <a
+            className="font-bold hover:underline"
+            target="_blank"
+            href={`https://dashboard.stripe.com/subscriptions/${sId}`}
+          >
+            {sId}
+          </a>
+        );
+      },
+      header: "stripeSubscriptionId",
+    },
+    {
       accessorKey: "startDate",
       header: ({ column }) => {
         return (

--- a/front/components/poke/subscriptions/table.tsx
+++ b/front/components/poke/subscriptions/table.tsx
@@ -46,6 +46,7 @@ function prepareSubscriptionsForDisplay(
       id: s.sId ?? "unknown",
       name: s.plan.code,
       status: s.status,
+      stripeSubscriptionId: s.stripeSubscriptionId,
       startDate: s.startDate
         ? `${new Date(s.startDate).toLocaleDateString()} ${new Date(
             s.startDate

--- a/types/src/front/plan.ts
+++ b/types/src/front/plan.ts
@@ -52,10 +52,12 @@ export type PlanType = {
 };
 
 export type SubscriptionType = {
-  // null for FREE_NO_PLAN which is the default plan when there is no Subscription in DB.
+  // `null` for FREE_NO_PLAN which is the default plan when there is no Subscription in DB, which
+  // means the workspace is not accessible.
   sId: string | null;
   status: SubscriptionStatusType;
   trialing: boolean;
+  // `null` means that this is a free plan. Otherwise, it's a paid plan.
   stripeSubscriptionId: string | null;
   stripeCustomerId: string | null;
   startDate: number | null;


### PR DESCRIPTION
## Description

- Adds link to stripeSubscriptionId in poke subscriptions history
- Add some clarifying comments on SubscriptionType

## Risk

- N/A poke

## Deploy Plan

- deploy `front`