### PR TITLE
Stripe checkout portal fetched customer from subscription

### DIFF
--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -146,12 +146,32 @@ export const createCustomerPortalSession = async ({
   owner: WorkspaceType;
   subscription: SubscriptionType;
 }): Promise<string | null> => {
-  if (!subscription.stripeCustomerId) {
-    throw new Error(`No customer ID found for the workspace: ${owner.sId}`);
+  if (!subscription.stripeSubscriptionId) {
+    throw new Error(
+      `No stripeSubscriptionId ID found for the workspace: ${owner.sId}`
+    );
+  }
+
+  const stripeSubscription = await getStripeSubscription(
+    subscription.stripeSubscriptionId
+  );
+
+  if (!stripeSubscription) {
+    throw new Error(
+      `No stripeSubscription found for the workspace: ${owner.sId}`
+    );
+  }
+
+  const stripeCustomerId = stripeSubscription.customer;
+
+  if (!stripeCustomerId || typeof stripeCustomerId !== "string") {
+    throw new Error(
+      `No stripeCustomerId found for the workspace: ${owner.sId}`
+    );
   }
 
   const portalSession = await stripe.billingPortal.sessions.create({
-    customer: subscription.stripeCustomerId,
+    customer: stripeCustomerId,
     return_url: `${URL}/w/${owner.sId}/subscription`,
   });
 


### PR DESCRIPTION
## Description

Stop using the field `subscription.stripeCustomerId` to create the customerPortal on Stripe.
-> This field is not set anymore for Enterprise customer and we don't need to store it since it is attached to the Stripe subscription. 


## Risk

/

## Deploy Plan

/
