### PR TITLE
Ignore missing stripeCustomerId in usage queue

### DIFF
--- a/front/temporal/usage_queue/activities.ts
+++ b/front/temporal/usage_queue/activities.ts
@@ -44,14 +44,14 @@ export async function recordUsageActivity(workspaceId: string) {
     return;
   }
 
-  if (!subscription.stripeSubscriptionId || !subscription.stripeCustomerId) {
+  if (!subscription.stripeSubscriptionId) {
     // TODO(2024-04-05 flav) Uncomment once all workspaces have a valid stripe subscription.
     // throw new Error(
     //   "Cannot record usage of subscription: missing Stripe subscription Id or Stripe customer Id."
     // );
     logger.info(
       { subscription },
-      "[UsageQueue] Cannot record usage of subscription: missing Stripe subscription Id or Stripe customer Id."
+      "[UsageQueue] Cannot record usage of subscription: missing Stripe subscription Id."
     );
 
     return;


### PR DESCRIPTION
## Description

We are slowly deprecating `stripeCustomerId` from our internal modelization of `Subscription`. This PR removes the check in the usage workflow.
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
