### PR TITLE
Increase table name prefix to reduce likelihood of conflict on table name

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
+++ b/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
@@ -3,7 +3,6 @@ import {
   getGoogleSheetTableId,
   getSanitizedHeaders,
   InvalidStructuredDataHeaderError,
-  makeStructuredDataTableName,
 } from "@dust-tt/types";
 import { Context } from "@temporalio/activity";
 import { stringify } from "csv-stringify/sync";
@@ -16,6 +15,7 @@ import { concurrentExecutor } from "@connectors/lib/async_utils";
 import { deleteTable, upsertTableFromCsv } from "@connectors/lib/data_sources";
 import type { GoogleDriveFiles } from "@connectors/lib/models/google_drive";
 import { GoogleDriveSheet } from "@connectors/lib/models/google_drive";
+import { makeStructuredDataTableName } from "@connectors/lib/structured_data";
 import type { Logger } from "@connectors/logger/logger";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -4,11 +4,7 @@ import type {
   NotionGarbageCollectionMode,
 } from "@dust-tt/types";
 import type { PageObjectProperties, ParsedNotionBlock } from "@dust-tt/types";
-import {
-  assertNever,
-  getNotionDatabaseTableId,
-  makeStructuredDataTableName,
-} from "@dust-tt/types";
+import { assertNever, getNotionDatabaseTableId } from "@dust-tt/types";
 import { isFullBlock, isFullPage, isNotionClientError } from "@notionhq/client";
 import type { PageObjectResponse } from "@notionhq/client/build/src/api-endpoints";
 import { Context } from "@temporalio/activity";
@@ -69,6 +65,7 @@ import {
 } from "@connectors/lib/models/notion";
 import { getAccessTokenFromNango } from "@connectors/lib/nango_helpers";
 import { redisClient } from "@connectors/lib/redis";
+import { makeStructuredDataTableName } from "@connectors/lib/structured_data";
 import { syncStarted, syncSucceeded } from "@connectors/lib/sync_status";
 import mainLogger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";

--- a/connectors/src/lib/structured_data.ts
+++ b/connectors/src/lib/structured_data.ts
@@ -1,0 +1,21 @@
+import { slugify } from "@dust-tt/types";
+import { hash as blake3 } from "blake3";
+
+// Extracting this helper due to incompatibility with blake3 in types.
+
+export function makeStructuredDataTableName(name: string, externalId: string) {
+  // Compute a blake3 hash of the externalId and name to avoid conflicts.
+  const hash = blake3(`${externalId}-${name}`).toString("hex");
+
+  // Define the prefix as the first 6 characters of the hash.
+  const externalIdPrefix = hash.substring(0, 6);
+
+  // Use the 6 last characters of the external id as a suffix (for user mapping to external data).
+  const externalIdSuffix = externalId.toLowerCase().slice(-6);
+
+  // Keep a maximum of 32 characters of the name.
+  const truncatedName = name.substring(0, 32);
+
+  // Concatenate everything.
+  return slugify(`${truncatedName}_${externalIdPrefix}_${externalIdSuffix}`);
+}

--- a/types/src/shared/utils/structured_data.ts
+++ b/types/src/shared/utils/structured_data.ts
@@ -1,15 +1,5 @@
 import { slugify } from "./string_utils";
 
-export function makeStructuredDataTableName(name: string, externalId: string) {
-  const lowercasedExternalId = externalId.toLowerCase();
-  const externalIdPrefix = lowercasedExternalId.substring(0, 6);
-  const externalIdSuffix = lowercasedExternalId.slice(-6);
-
-  const truncatedName = name.substring(0, 32);
-
-  return slugify(`${truncatedName}_${externalIdPrefix}_${externalIdSuffix}`);
-}
-
 export class InvalidStructuredDataHeaderError extends Error {}
 
 export function getSanitizedHeaders(rawHeaders: string[]) {

--- a/types/src/shared/utils/structured_data.ts
+++ b/types/src/shared/utils/structured_data.ts
@@ -2,7 +2,7 @@ import { slugify } from "./string_utils";
 
 export function makeStructuredDataTableName(name: string, externalId: string) {
   const lowercasedExternalId = externalId.toLowerCase();
-  const externalIdPrefix = lowercasedExternalId.substring(0, 4);
+  const externalIdPrefix = lowercasedExternalId.substring(0, 6);
   const externalIdSuffix = lowercasedExternalId.slice(-6);
 
   const truncatedName = name.substring(0, 32);


### PR DESCRIPTION
## Description

In our observations, there is some overlap with Google Drive resources, which makes it challenging to create a short, unique table name across a data source. Despite our efforts in https://github.com/dust-tt/dust/pull/4588, we still face some conflicts where the combination of the first four characters of a spreadsheet + the first 32 characters of the spreadsheet title + the last six digits of the sheet ID can result in conflicts.

We've logged the conflicts from the past two days, and analyzed the distribution:
* Using the first 4 characters of the spreadsheet: 30 conflicts
* Using the first 5 characters of the spreadsheet: 2 conflicts
* Using the first 6 characters of the spreadsheet: 0 conflicts

Although we wanted to minimize randomness in our table names to help the model in generating accurate queries, we still want to use determinist Ids. This PR uses `blake3` to generate a hash of the entire table id and we keep only the first 6 characters of the hash.
 
We will prioritize working on a longer term fix to use proper table names, more human friendly as we expose them in our application. This requires some changes do dedup them when spinning up the SQLite worker.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
