### PR TITLE
assistants: truncate description when too long

### DIFF
--- a/connectors/package-lock.json
+++ b/connectors/package-lock.json
@@ -10833,9 +10833,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.0.tgz",
-      "integrity": "sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
       "dependencies": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -30947,8 +30947,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "6.2.0",
-      "license": "ISC",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
       "dependencies": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",

--- a/front/pages/w/[wId]/assistant/assistants.tsx
+++ b/front/pages/w/[wId]/assistant/assistants.tsx
@@ -177,10 +177,8 @@ function ScopeSection({
           onClick={onAssistantClick(agent)}
         >
           <ContextItem.Description>
-            <div className="text-element-700">
-              {agent.description.length < 200
-                ? agent.description
-                : agent.description.slice(0, 200) + "..."}
+            <div className="line-clamp-2 text-element-700">
+              {agent.description}
             </div>
           </ContextItem.Description>
         </ContextItem>

--- a/front/pages/w/[wId]/assistant/assistants.tsx
+++ b/front/pages/w/[wId]/assistant/assistants.tsx
@@ -106,20 +106,18 @@ export default function MyAssistants({
           }}
         />
         <Button.List>
-          {searchFilteredAssistants.length > 0 && (
-            <Tooltip label="Create your own assistant">
-              <Link
-                href={`/w/${owner.sId}/builder/assistants/new?flow=personal_assistants`}
-              >
-                <Button
-                  variant="primary"
-                  icon={PlusIcon}
-                  label="Create An Assistant"
-                  size="sm"
-                />
-              </Link>
-            </Tooltip>
-          )}
+          <Tooltip label="Create your own assistant">
+            <Link
+              href={`/w/${owner.sId}/builder/assistants/new?flow=personal_assistants`}
+            >
+              <Button
+                variant="primary"
+                icon={PlusIcon}
+                label="Create An Assistant"
+                size="sm"
+              />
+            </Link>
+          </Tooltip>
           <Link href={`/w/${owner.sId}/assistant/gallery`}>
             <Button
               variant="primary"
@@ -179,7 +177,11 @@ function ScopeSection({
           onClick={onAssistantClick(agent)}
         >
           <ContextItem.Description>
-            <div className="text-element-700">{agent.description}</div>
+            <div className="text-element-700">
+              {agent.description.length < 200
+                ? agent.description
+                : agent.description.slice(0, 200) + "..."}
+            </div>
           </ContextItem.Description>
         </ContextItem>
       ))}

--- a/front/pages/w/[wId]/builder/assistants/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/index.tsx
@@ -320,7 +320,9 @@ function AgentViewForScope({
           }
         >
           <ContextItem.Description>
-            <div className="text-element-700">{agent.description}</div>
+            <div className="line-clamp-2 text-element-700">
+              {agent.description}
+            </div>
           </ContextItem.Description>
         </ContextItem>
       ))}

--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -25071,9 +25071,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.0.tgz",
-      "integrity": "sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
       "dev": true,
       "dependencies": {
         "chownr": "^2.0.0",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.136",
+  "version": "0.2.137",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/components/AssistantPreview.tsx
+++ b/sparkle/src/components/AssistantPreview.tsx
@@ -161,9 +161,7 @@ const ListVariantContent = ({
             descriptionClassNames.list
           )}
         >
-          {description.length < 200
-            ? description
-            : description.slice(0, 200) + "..."}
+          {description}
         </div>
       </div>
     </div>

--- a/sparkle/src/components/AssistantPreview.tsx
+++ b/sparkle/src/components/AssistantPreview.tsx
@@ -50,8 +50,8 @@ const subtitleClassNames = {
 const descriptionClassNames = {
   base: "s-font-normal s-mb-1",
   item: "s-text-xs s-text-element-700 s-pl-1 s-line-clamp-3",
-  list: "s-text-base s-text-element-800",
-  gallery: "s-text-base s-text-element-800",
+  list: "s-text-base s-text-element-800 s-line-clamp-3",
+  gallery: "s-text-base s-text-element-800 s-line-clamp-3",
 };
 
 function renderVariantContent(
@@ -161,7 +161,9 @@ const ListVariantContent = ({
             descriptionClassNames.list
           )}
         >
-          {description}
+          {description.length < 200
+            ? description
+            : description.slice(0, 200) + "..."}
         </div>
       </div>
     </div>

--- a/sparkle/src/stories/AssistantPreview.stories.tsx
+++ b/sparkle/src/stories/AssistantPreview.stories.tsx
@@ -78,7 +78,9 @@ export const AssistantPreviewExample = () => (
       />
       <AssistantPreview
         title={"SQLGod"}
-        description={"OpenAI's most powerful and recent model (128k context)."}
+        description={
+          "OpenAI's most powerful and recent model (128k context). With a very long description that starts to repeat itself here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here"
+        }
         onClick={() => console.log("clicked")}
         pictureUrl={"https://dust.tt/static/droidavatar/Droid_Pink_2.jpg"}
         subtitle={"Pauline Pham, Henry Fontanier"}
@@ -127,7 +129,9 @@ export const AssistantPreviewExample = () => (
       />
       <AssistantPreview
         title={"salesFr"}
-        description={"OpenAI's most powerful and recent model (128k context)."}
+        description={
+          "OpenAI's most powerful and recent model (128k context). With a very long description that starts to repeat itself here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here"
+        }
         pictureUrl={"https://dust.tt/static/droidavatar/Droid_Yellow_2.jpg"}
         subtitle={"Stanislas Polu"}
         variant={"list"}
@@ -155,7 +159,9 @@ export const AssistantPreviewExample = () => (
     <div className="s-grid s-grid-cols-2">
       <AssistantPreview
         title={"gpt4"}
-        description={"OpenAI's most powerful and recent model (128k context)."}
+        description={
+          "OpenAI's most powerful and recent model (128k context). With a very long description that starts to repeat itself here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here here"
+        }
         onClick={() => console.log("clicked")}
         pictureUrl="https://dust.tt/static/systemavatar/gpt4_avatar_full.png"
         subtitle="Stanislas Polu, Pauline Pham"


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/629

- Remove condition to not show the create assistant button when list is empty (?? why). It created latency for the button to appear at page load.
- Truncate description if too long
- Update sparkle to clamp AssistantPreview.
- Some `npm audit fix`

## Risk

N/A

## Deploy Plan

- build sparkle
- ship PR to bump sparkle
- deploy `front`