### PR TITLE
Remove all calls to subscription.stripeCustomerId

### DIFF
--- a/front/components/poke/subscriptions/table.tsx
+++ b/front/components/poke/subscriptions/table.tsx
@@ -166,26 +166,6 @@ export function ActiveSubscriptionTable({
                   </PokeTableCell>
                 </PokeTableRow>
                 <PokeTableRow>
-                  <PokeTableCell>Stripe Customer Id</PokeTableCell>
-                  <PokeTableCell>
-                    {subscription.stripeCustomerId ? (
-                      <Link
-                        href={
-                          isDevelopment()
-                            ? `https://dashboard.stripe.com/test/customers/${subscription.stripeCustomerId}`
-                            : `https://dashboard.stripe.com/customers/${subscription.stripeCustomerId}`
-                        }
-                        target="_blank"
-                        className="text-xs text-action-400"
-                      >
-                        {subscription.stripeCustomerId}
-                      </Link>
-                    ) : (
-                      "No customer id"
-                    )}
-                  </PokeTableCell>
-                </PokeTableRow>
-                <PokeTableRow>
                   <PokeTableCell>Start Date</PokeTableCell>
                   <PokeTableCell>
                     {subscription.startDate

--- a/front/lib/models/plan.ts
+++ b/front/lib/models/plan.ts
@@ -170,7 +170,7 @@ export class Subscription extends Model<
   declare planId: ForeignKey<Plan["id"]>;
   declare plan: NonAttribute<Plan>;
 
-  declare stripeCustomerId: string | null;
+  declare stripeCustomerId: string | null; // To be removed Daph
   declare stripeSubscriptionId: string | null;
 }
 Subscription.init(

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -91,7 +91,6 @@ export const createProPlanCheckoutSession = async ({
     mode: "subscription",
     client_reference_id: owner.sId,
     customer_email: user.email,
-    customer: auth.subscription()?.stripeCustomerId || undefined,
     subscription_data: {
       metadata: {
         planCode: PRO_PLAN_SEAT_29_CODE,

--- a/front/lib/plans/subscription.ts
+++ b/front/lib/plans/subscription.ts
@@ -77,7 +77,6 @@ export function renderSubscriptionFromModels({
     trialing: activeSubscription?.trialing === true,
     sId: activeSubscription?.sId || null,
     stripeSubscriptionId: activeSubscription?.stripeSubscriptionId || null,
-    stripeCustomerId: activeSubscription?.stripeCustomerId || null,
     startDate: activeSubscription?.startDate?.getTime() || null,
     endDate: activeSubscription?.endDate?.getTime() || null,
     paymentFailingSince:

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -100,7 +100,6 @@ async function handler(
           // We can create the new subscription and end the active one if any.
           const session = event.data.object as Stripe.Checkout.Session;
           const workspaceId = session.client_reference_id;
-          const stripeCustomerId = session.customer;
           const stripeSubscriptionId = session.subscription;
           const planCode = session?.metadata?.planCode || null;
           const userId = session?.metadata?.userId || null;
@@ -111,7 +110,6 @@ async function handler(
             logger.info(
               {
                 workspaceId,
-                stripeCustomerId,
                 stripeSubscriptionId,
                 planCode,
               },
@@ -123,7 +121,6 @@ async function handler(
             logger.error(
               {
                 workspaceId,
-                stripeCustomerId,
                 stripeSubscriptionId,
                 planCode,
               },
@@ -135,9 +132,7 @@ async function handler(
           try {
             if (
               workspaceId === null ||
-              stripeCustomerId === null ||
               planCode === null ||
-              typeof stripeCustomerId !== "string" ||
               typeof stripeSubscriptionId !== "string"
             ) {
               throw new Error("Missing required data in event.");
@@ -175,7 +170,6 @@ async function handler(
                 logger.error(
                   {
                     workspaceId,
-                    stripeCustomerId,
                     stripeSubscriptionId,
                     planCode,
                   },
@@ -197,7 +191,6 @@ async function handler(
                 logger.error(
                   {
                     workspaceId,
-                    stripeCustomerId,
                     stripeSubscriptionId,
                     planCode,
                   },
@@ -233,7 +226,6 @@ async function handler(
                   trialing: stripeSubscription.status === "trialing",
                   startDate: now,
                   stripeSubscriptionId: stripeSubscriptionId,
-                  stripeCustomerId: stripeCustomerId,
                 },
                 { transaction: t }
               );
@@ -259,7 +251,6 @@ async function handler(
               {
                 error,
                 workspaceId,
-                stripeCustomerId,
                 stripeSubscriptionId,
                 planCode,
               },

--- a/types/src/front/plan.ts
+++ b/types/src/front/plan.ts
@@ -59,7 +59,6 @@ export type SubscriptionType = {
   trialing: boolean;
   // `null` means that this is a free plan. Otherwise, it's a paid plan.
   stripeSubscriptionId: string | null;
-  stripeCustomerId: string | null;
   startDate: number | null;
   endDate: number | null;
   paymentFailingSince: number | null;


### PR DESCRIPTION
## Description

We want to get rid of `stripeCustomerId` on the subscription model.

- Add comment on the db model to notify it's going to be removed.
- Remove it from the Stripe webhook -> we were setting it on the subscription (and we were logging it on error logs)
- Remove it from `SubscriptionType`
- Remove it from Poké (was displayed on the Active subscription table).

Places we still use a Stripe customer id: 
-> When creating a Stripe checkout session, but it is fetched from Stripe from the stripeSubscriptionId.


## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
