### PR TITLE
Always get first the default Price of a Stripe product if set

### DIFF
--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -29,6 +29,13 @@ const stripe = new Stripe(STRIPE_SECRET_KEY, {
  * Calls the Stripe API to get the price ID for a given product ID.
  */
 async function getPriceId(productId: string): Promise<string | null> {
+  // Return the default price if set
+  const product = await stripe.products.retrieve(productId);
+  if (product.default_price && typeof product.default_price === "string") {
+    return product.default_price;
+  }
+
+  // Otherwise, return the first active price
   const prices = await stripe.prices.list({ product: productId, active: true });
   if (prices.data.length > 0) {
     const [firstActivePrice] = prices.data;


### PR DESCRIPTION
## Description

`getPriceId` was fetching all active prices of a product and returning the first one. 

This PR adds some baby logic to retrieve the one marked as default is set: 

<img width="318" alt="Screenshot 2024-04-10 at 15 52 05" src="https://github.com/dust-tt/dust/assets/3803406/3485d4e2-5e92-4819-ab90-67af272e25e2">

 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
