### PR TITLE
Remove file attachment 10MB limit

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -170,6 +170,17 @@ export function AssistantInputBar({
         if (!file) {
           return;
         }
+        if (file.size > 100_000_000) {
+          // Even though we don't display the file size limit in the UI, we still check it here to prevent
+          // processing files that are too large.
+          sendNotification({
+            type: "error",
+            title: "File too large.",
+            description:
+              "PDF uploads are limited to 100Mb per file. Please consider uploading a smaller file.",
+          });
+          return;
+        }
         const res = await handleFileUploadToText(file);
 
         if (res.isErr()) {
@@ -186,7 +197,7 @@ export function AssistantInputBar({
             type: "error",
             title: "File too large.",
             description:
-              "The extracted text from your PDF has more than 500 000 characters. This will overflow the assistant context. Please consider uploading a smaller file.",
+              "The extracted text from your PDF has more than 500,000 characters. This will overflow the assistant context. Please consider uploading a smaller file.",
           });
           return;
         }

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -170,15 +170,6 @@ export function AssistantInputBar({
         if (!file) {
           return;
         }
-        if (file.size > 10_000_000) {
-          sendNotification({
-            type: "error",
-            title: "File too large.",
-            description:
-              "PDF uploads are limited to 10Mb per file. Please consider uploading a smaller file.",
-          });
-          return;
-        }
         const res = await handleFileUploadToText(file);
 
         if (res.isErr()) {
@@ -189,13 +180,13 @@ export function AssistantInputBar({
           });
           return;
         }
-        if (res.value.content.length > 1_000_000) {
+        if (res.value.content.length > 500_000) {
           // This error should pretty much never be triggered but it is a possible case, so here it is.
           sendNotification({
             type: "error",
             title: "File too large.",
             description:
-              "The extracted text from your PDF has more than 1 million characters. This will overflow the assistant context. Please consider uploading a smaller file.",
+              "The extracted text from your PDF has more than 500 000 characters. This will overflow the assistant context. Please consider uploading a smaller file.",
           });
           return;
         }

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -128,7 +128,7 @@ const InputBarContainer = ({
             icon={AttachmentIcon}
             size="sm"
             disabled={disableAttachment}
-            tooltip="Add a document to the conversation (10MB maximum, only .txt, .pdf, .md, .csv)."
+            tooltip="Add a document to the conversation (only .txt, .pdf, .md, .csv)."
             tooltipPosition="above"
             className="flex"
             onClick={() => {


### PR DESCRIPTION
## Description

Changing the file upload limits in the input bar:

- Remove the 10MB file attachement limit in the UI.
- Set the file size limit to 100MB to prevent us from processing files that are obviously not suited for this feature.
- Lower the limit from 1_000_000 to 500_000 for characters count.

Context is here:
https://dust4ai.slack.com/archives/C066R3PMUAU/p1712667508684809?thread_ts=1712248127.209609&cid=C066R3PMUAU

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
