### PR TITLE
[Front] Use our sparkle `confirm` in a few places

### DIFF
--- a/front/pages/w/[wId]/a/[aId]/datasets/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/datasets/index.tsx
@@ -6,7 +6,9 @@ import type { SubscriptionType } from "@dust-tt/types";
 import type { InferGetServerSidePropsType } from "next";
 import Link from "next/link";
 import { useRouter } from "next/router";
+import { useContext } from "react";
 
+import { ConfirmContext } from "@app/components/Confirm";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
 import {
@@ -70,9 +72,16 @@ export default function DatasetsView({
   gaTrackingId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const router = useRouter();
+  const confirm = useContext(ConfirmContext);
 
   const handleDelete = async (datasetName: string) => {
-    if (confirm("Are you sure you want to delete this dataset entirely?")) {
+    if (
+      await confirm({
+        title: "Double checking",
+        message: "Are you sure you want to delete this dataset entirely?",
+        validateVariant: "primaryWarning",
+      })
+    ) {
       await fetch(
         `/api/w/${owner.sId}/apps/${app.sId}/datasets/${datasetName}`,
         {

--- a/front/pages/w/[wId]/a/[aId]/runs/[runId]/index.tsx
+++ b/front/pages/w/[wId]/a/[aId]/runs/[runId]/index.tsx
@@ -5,9 +5,10 @@ import type { SubscriptionType } from "@dust-tt/types";
 import type { RunType } from "@dust-tt/types";
 import type { InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
-import { useState } from "react";
+import { useContext, useState } from "react";
 
 import SpecRunView from "@app/components/app/SpecRunView";
+import { ConfirmContext } from "@app/components/Confirm";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
 import {
@@ -81,6 +82,7 @@ export default function AppRun({
     app.savedRun
   );
   const [isLoading, setIsLoading] = useState(false);
+  const confirm = useContext(ConfirmContext);
 
   const restore = async () => {
     if (readOnly) {
@@ -88,9 +90,11 @@ export default function AppRun({
     }
 
     if (
-      !confirm(
-        `This will revert the app specification to the state it was in when this run was saved (${run.run_id}). Are you sure?`
-      )
+      await confirm({
+        title: "Double checking",
+        message: `This will revert the app specification to the state it was in when this run was saved (${run.run_id}). Are you sure?`,
+        validateVariant: "primaryWarning",
+      })
     ) {
       return;
     }

--- a/front/pages/w/[wId]/a/[aId]/settings.tsx
+++ b/front/pages/w/[wId]/a/[aId]/settings.tsx
@@ -6,9 +6,10 @@ import type { APIError } from "@dust-tt/types";
 import { ChevronRightIcon } from "@heroicons/react/24/outline";
 import type { InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
-import { useState } from "react";
+import { useContext, useState } from "react";
 import { useEffect } from "react";
 
+import { ConfirmContext } from "@app/components/Confirm";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
 import {
@@ -78,6 +79,7 @@ export default function SettingsView({
 
   const [isDeleting, setIsDeleting] = useState(false);
   const [isUpdating, setIsUpdating] = useState(false);
+  const confirm = useContext(ConfirmContext);
 
   const formValidation = () => {
     if (appName.length == 0) {
@@ -98,7 +100,13 @@ export default function SettingsView({
   const router = useRouter();
 
   const handleDelete = async () => {
-    if (window.confirm("Are you sure you want to delete this app?")) {
+    if (
+      await confirm({
+        title: "Double checking",
+        message: "Are you sure you want to delete this app?",
+        validateVariant: "primaryWarning",
+      })
+    ) {
       setIsDeleting(true);
       const res = await fetch(`/api/w/${owner.sId}/apps/${app.sId}`, {
         method: "DELETE",


### PR DESCRIPTION
Description
---
- Refactors code from membership page to use `confirm` (shorter, easier)
- uses our confirm in a few places where we used system confirm (including back button in builder)

Note: the isSaving logic will be added in a following PR

Before:
![image](https://github.com/dust-tt/dust/assets/5437393/f4c03440-4197-4740-9c97-773f5a98d9d5)

After:
![image](https://github.com/dust-tt/dust/assets/5437393/d3863571-0d05-411c-9f7b-5cdd1087c088)

Risk
---
Breaking the confirms. They were tested

Deploy
---
Deploy front
