### PR TITLE
qdrant incident: Move collection creation to dedicated-1

### DIFF
--- a/types/src/core/data_source.ts
+++ b/types/src/core/data_source.ts
@@ -5,7 +5,7 @@ export type QdrantCluster =
   | "dedicated-2";
 
 export const DEFAULT_FREE_QDRANT_CLUSTER: QdrantCluster = "main-0";
-export const DEFAULT_PAID_QDRANT_CLUSTER: QdrantCluster = "dedicated-2";
+export const DEFAULT_PAID_QDRANT_CLUSTER: QdrantCluster = "dedicated-1";
 
 export type CoreAPIDataSourceConfig = {
   provider_id: string;


### PR DESCRIPTION
## Description

- Move collection creation to `dedicated-1` as new collection creation can crash `dedicated-2`

Context: https://dust4ai.slack.com/archives/C05B529FHV1/p1712759598846309

## Risk

N/A

## Deploy Plan

- deploy `front`