### PR TITLE
usage_queue: skip if workspace downgraded

### DIFF
--- a/front/temporal/usage_queue/activities.ts
+++ b/front/temporal/usage_queue/activities.ts
@@ -27,8 +27,10 @@ export async function recordUsageActivity(workspaceId: string) {
   logger.info({}, "[UsageQueue] Recording usage for worskpace.");
 
   if (!subscription) {
-    throw new Error(
-      "Cannot record usage of subscription: missing subscription."
+    // The workspace likely downgraded during the debouncing period of usage reporting.
+    logger.info(
+      { workspaceId },
+      "[UsageQueue] Cannot record usage of subscription: missing subscription."
     );
 
     return;
@@ -37,7 +39,7 @@ export async function recordUsageActivity(workspaceId: string) {
   // Legacy free test plans don't have a Stripe subscription.
   if (subscription.plan.code === FREE_TEST_PLAN_CODE) {
     logger.info(
-      { subscription },
+      { subscription, workspaceId },
       "[UsageQueue] Subscription is on free test plan -- skipping reporting usage."
     );
 
@@ -50,7 +52,7 @@ export async function recordUsageActivity(workspaceId: string) {
     //   "Cannot record usage of subscription: missing Stripe subscription Id or Stripe customer Id."
     // );
     logger.info(
-      { subscription },
+      { subscription, workspaceId },
       "[UsageQueue] Cannot record usage of subscription: missing Stripe subscription Id."
     );
 


### PR DESCRIPTION
## Description

- We can land in usage queue reporting with a FREE_NO_PLAN workspace (no subscription) if the workspace downgraded while the workflow was debouncing. Exit early instead of failing.

Context: https://dust4ai.slack.com/archives/C05F84CFP0E/p1712794722898379

## Risk

N/A

## Deploy Plan

- deploy `front`