### PR TITLE
Fix invite members regression

### DIFF
--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -561,21 +561,7 @@ function InviteEmailModal({
       </div>
     );
 
-    if (
-      !shouldWarnAboutExistingMembers(invitesByCase) ||
-      (await confirm({
-        title: "Some users are already in the workspace",
-        message: ReinviteUsersMessage,
-        validateLabel: "Yes, proceed",
-        validateVariant: "primaryWarning",
-      }))
-    ) {
-      await handleMembersRoleChange({
-        members: [...activeDifferentRole, ...revoked],
-        role: invitationRole,
-        mutate,
-        sendNotification,
-      });
+    if (!shouldWarnAboutExistingMembers(invitesByCase)) {
       await sendInvitations({
         owner,
         emails: notInWorkspace,
@@ -584,6 +570,25 @@ function InviteEmailModal({
       });
       await mutate(`/api/w/${owner.sId}/invitations`);
       onClose();
+    } else {
+      const shouldProceed = await confirm({
+        title: "Some users are already in the workspace",
+        message: ReinviteUsersMessage,
+        validateLabel: "Yes, proceed",
+        validateVariant: "primaryWarning",
+      });
+
+      if (shouldProceed) {
+        await handleMembersRoleChange({
+          members: [...activeDifferentRole, ...revoked],
+          role: invitationRole,
+          mutate,
+          sendNotification,
+        });
+
+        await mutate(`/api/w/${owner.sId}/invitations`);
+        onClose();
+      }
     }
   }
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
In https://github.com/dust-tt/dust/pull/4671, a regression was introduced that affected the invite members feature. As a result, we can no longer invite new members, as we tried to refactor the code to handle both the regular invite flow and when members are already in the workspace. This lead to calling function with an empty array which is not supported.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
