### PR TITLE
Handle subscription upgraded before the end of the trial

### DIFF
--- a/front/lib/plans/subscription.ts
+++ b/front/lib/plans/subscription.ts
@@ -370,6 +370,7 @@ export async function maybeCancelInactiveTrials(
     include: [Workspace],
   });
 
+  // Bail early if the DB subscription is not in trial mode.
   if (!subscription || !subscription.trialing) {
     return;
   }
@@ -382,7 +383,7 @@ export async function maybeCancelInactiveTrials(
   if (!stripeSubscription || stripeSubscription.status !== "trialing") {
     logger.info(
       { action: "cancelling-trial", workspaceId: workspace.sId },
-      "Skipping cancel trial for active subscription."
+      "Proactive trial cancellation skipped due to active subscription."
     );
 
     return;

--- a/front/lib/plans/subscription.ts
+++ b/front/lib/plans/subscription.ts
@@ -15,6 +15,7 @@ import { PRO_PLAN_SEAT_29_CODE } from "@app/lib/plans/plan_codes";
 import {
   cancelSubscriptionImmediately,
   createProPlanCheckoutSession,
+  getStripeSubscription,
 } from "@app/lib/plans/stripe";
 import { countActiveSeatsInWorkspace } from "@app/lib/plans/usage/seats";
 import { frontSequelize } from "@app/lib/resources/storage";
@@ -360,9 +361,9 @@ export const getCheckoutUrlForUpgrade = async (
  * Proactively cancel inactive trials.
  */
 export async function maybeCancelInactiveTrials(
-  stripeSubscription: Stripe.Subscription
+  eventStripeSubscription: Stripe.Subscription
 ) {
-  const { id: stripeSubscriptionId } = stripeSubscription;
+  const { id: stripeSubscriptionId } = eventStripeSubscription;
 
   const subscription = await Subscription.findOne({
     where: { stripeSubscriptionId },
@@ -374,6 +375,17 @@ export async function maybeCancelInactiveTrials(
   }
 
   const { workspace } = subscription;
+
+  // This function can get called if the subscription is upgraded before the end of the trial.
+  // Ensure that the Stripe subscription still has a status set to `trialing`.
+  const stripeSubscription = await getStripeSubscription(stripeSubscriptionId);
+  if (!stripeSubscription || stripeSubscription.status !== "trialing") {
+    logger.info(
+      { action: "cancelling-trial", workspaceId: workspace.sId },
+      "Skipping cancel trial for active subscription."
+    );
+  }
+
   const isWorkspaceActive = await checkWorkspaceActivity(workspace);
 
   if (!isWorkspaceActive) {

--- a/front/lib/plans/subscription.ts
+++ b/front/lib/plans/subscription.ts
@@ -384,6 +384,8 @@ export async function maybeCancelInactiveTrials(
       { action: "cancelling-trial", workspaceId: workspace.sId },
       "Skipping cancel trial for active subscription."
     );
+
+    return;
   }
 
   const isWorkspaceActive = await checkWorkspaceActivity(workspace);


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
In recent observations, we've identified that if customers upgrade their subscriptions before the trial period ends, we will still receive a `customer.subscription.trial_will_end` webhook event. This webhook often competes with the `subscription.updated` event, causing both to be received simultaneously. Relying only on the subscription data in the database to confirm trial status is insufficient.

This PR introduces an additional check based on the Stripe subscription status (it does not rely on the status attached to the event, as it remains "trialing"). This new check ensures that the remote revision of the subscription is still in the trial phase.

This change should be enough, but if we continue to encounter race conditions, I will consider moving this process to a delayed Temporal workflow.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
