### PR TITLE
enh: heartbeat from long-running notion activiteis

### DIFF
--- a/connectors/src/connectors/notion/lib/parents.ts
+++ b/connectors/src/connectors/notion/lib/parents.ts
@@ -10,6 +10,7 @@ import {
 } from "@connectors/connectors/notion/lib/connectors_db_helpers";
 import { updateDocumentParentsField } from "@connectors/lib/data_sources";
 import type { NotionDatabase, NotionPage } from "@connectors/lib/models/notion";
+import { heartbeat } from "@connectors/lib/temporal";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 
@@ -107,7 +108,8 @@ export async function updateAllParentsFields(
   connectorId: ModelId,
   createdOrMovedNotionPageIds: string[],
   createdOrMovedNotionDatabaseIds: string[],
-  memoizationKey?: string
+  memoizationKey?: string,
+  shouldHeartbeat = false
 ): Promise<number> {
   const connector = await ConnectorResource.fetchById(connectorId);
   if (!connector) {
@@ -160,6 +162,9 @@ export async function updateAllParentsFields(
           documentId: `notion-${pageId}`,
           parents,
         });
+        if (shouldHeartbeat) {
+          await heartbeat();
+        }
       })
     );
   }

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -67,6 +67,7 @@ import { getAccessTokenFromNango } from "@connectors/lib/nango_helpers";
 import { redisClient } from "@connectors/lib/redis";
 import { makeStructuredDataTableName } from "@connectors/lib/structured_data";
 import { syncStarted, syncSucceeded } from "@connectors/lib/sync_status";
+import { heartbeat } from "@connectors/lib/temporal";
 import mainLogger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { DataSourceConfig } from "@connectors/types/data_source_config";
@@ -770,6 +771,8 @@ export async function garbageCollect({
   let stillAccessibleDatabasesCount = 0;
 
   for (const [i, x] of resourcesToCheck.entries()) {
+    await heartbeat();
+
     const iterationLogger = localLogger.child({
       pageId: x.resourceType === "page" ? x.resourceId : undefined,
       databaseId: x.resourceType === "database" ? x.resourceId : undefined,

--- a/connectors/src/connectors/notion/temporal/workflows.ts
+++ b/connectors/src/connectors/notion/temporal/workflows.ts
@@ -15,12 +15,12 @@ import type * as activities from "@connectors/connectors/notion/temporal/activit
 
 const { garbageCollect } = proxyActivities<typeof activities>({
   startToCloseTimeout: "120 minute",
+  heartbeatTimeout: "5 minute",
 });
 
-const { upsertDatabaseInConnectorsDb, updateParentsFields } = proxyActivities<
-  typeof activities
->({
+const { updateParentsFields } = proxyActivities<typeof activities>({
   startToCloseTimeout: "60 minute",
+  heartbeatTimeout: "5 minute",
 });
 
 const {
@@ -33,6 +33,7 @@ const {
   clearWorkflowCache,
   getDiscoveredResourcesFromCache,
   upsertDatabaseStructuredDataFromCache,
+  upsertDatabaseInConnectorsDb,
 } = proxyActivities<typeof activities>({
   startToCloseTimeout: "10 minute",
 });


### PR DESCRIPTION
## Description

We're seeing increased delays between `ActivityScheduled` and `ActivityStarted` which may be a sign that zombie activies are starving notion workers. 

A theory is that long-running activities may be silently timing out and re-scheduled without being properly cancelled on the worker due to the lack of heart-beating.

## Risk

N/A

## Deploy Plan

deploy + restart notion workflows.