### PR TITLE
[Multi-Actions] Move instructions out of AgentGenerationConfiguration up to AgentConfiguration. 1/3

### DIFF
--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -782,6 +782,7 @@ export async function createAgentConfiguration(
   {
     name,
     description,
+    instructions,
     pictureUrl,
     status,
     scope,
@@ -791,6 +792,7 @@ export async function createAgentConfiguration(
   }: {
     name: string;
     description: string;
+    instructions: string | null;
     pictureUrl: string;
     status: AgentStatus;
     scope: Exclude<AgentConfigurationScope, "global">;
@@ -892,6 +894,7 @@ export async function createAgentConfiguration(
             scope,
             name,
             description,
+            instructions,
             pictureUrl,
             workspaceId: owner.id,
             generationConfigurationId: generation?.id || null,

--- a/front/lib/models/assistant/agent.ts
+++ b/front/lib/models/assistant/agent.ts
@@ -32,7 +32,7 @@ export class AgentGenerationConfiguration extends Model<
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
-  declare prompt: string;
+  declare prompt: string; // @daph to deprecate for multi-actions
   declare providerId: string;
   declare modelId: string;
   declare temperature: number;
@@ -95,7 +95,10 @@ export class AgentConfiguration extends Model<
   declare status: AgentStatus;
   declare scope: Exclude<AgentConfigurationScope, "global">;
   declare name: string;
+
   declare description: string;
+  declare instructions: string | null;
+
   declare pictureUrl: string;
 
   declare workspaceId: ForeignKey<Workspace["id"]>;
@@ -164,6 +167,10 @@ AgentConfiguration.init(
     description: {
       type: DataTypes.TEXT,
       allowNull: false,
+    },
+    instructions: {
+      type: DataTypes.TEXT,
+      allowNull: true,
     },
     pictureUrl: {
       type: DataTypes.TEXT,

--- a/front/migrations/20240411_agent_config_instructions.ts
+++ b/front/migrations/20240411_agent_config_instructions.ts
@@ -1,0 +1,59 @@
+import {
+  AgentConfiguration,
+  AgentGenerationConfiguration,
+} from "@app/lib/models";
+import logger from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+
+const backfillAgentConfiguration = async (
+  agent: AgentConfiguration,
+  execute: boolean
+): Promise<void> => {
+  const prompt = agent.generationConfiguration?.prompt;
+  if (!prompt) {
+    logger.info(`Skipping agent (no generation configuration) ${agent.id}`);
+    return;
+  }
+
+  if (execute) {
+    await agent.update({
+      instructions: prompt,
+    });
+  }
+};
+
+const backfillAgentConfigurations = async (execute: boolean) => {
+  // Fetch all agents that have no instructions
+  const agents = await AgentConfiguration.findAll({
+    where: {
+      instructions: null,
+    },
+    include: [
+      {
+        model: AgentGenerationConfiguration,
+        as: "generationConfiguration",
+        attributes: ["prompt"],
+      },
+    ],
+  });
+
+  // Split agents into chunks of 16
+  const chunks: AgentConfiguration[][] = [];
+  for (let i = 0; i < agents.length; i += 16) {
+    chunks.push(agents.slice(i, i + 16));
+  }
+
+  // Process each chunk in parallel
+  for (let i = 0; i < chunks.length; i++) {
+    const chunk = chunks[i];
+    await Promise.all(
+      chunk.map(async (agent) => {
+        return backfillAgentConfiguration(agent, execute);
+      })
+    );
+  }
+};
+
+makeScript({}, async ({ execute }) => {
+  await backfillAgentConfigurations(execute);
+});

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -289,6 +289,7 @@ export async function createOrUpgradeAgentConfiguration(
   const agentConfigurationRes = await createAgentConfiguration(auth, {
     name,
     description,
+    instructions: generation?.prompt ?? null,
     pictureUrl,
     status,
     scope,


### PR DESCRIPTION
## Description


Task https://github.com/dust-tt/dust/issues/4596

- Adds new `instructions` field to the `AgentGeneration` model.
- Shadow-write it for new & updated agent configurations.
- Add a script to backfill for all agents. 

Next PR is about removing all usages of agentConfiguration.prompt to be able to remove the field. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- Deploy on front edge to run init_db to have the new field
- Then run the migration script
- Then deploy front
