### PR TITLE
[Multi-Actions] Move instructions out of AgentGenerationConfiguration up to AgentConfiguration. 2/3

### DIFF
--- a/front/components/assistant/AssistantActions.tsx
+++ b/front/components/assistant/AssistantActions.tsx
@@ -191,6 +191,7 @@ export function RemoveAssistantFromWorkspaceDialog({
           assistant: {
             name: agentConfiguration.name,
             description: agentConfiguration.description,
+            instructions: agentConfiguration.instructions,
             pictureUrl: agentConfiguration.pictureUrl,
             status: "active",
             scope: "published",

--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -196,10 +196,10 @@ export function AssistantDetails({
   );
 
   const InstructionsSection = () =>
-    agentConfiguration.generation?.prompt ? (
+    agentConfiguration.instructions ? (
       <div className="flex flex-col gap-2">
         <div className="text-lg font-bold text-element-800">Instructions</div>
-        <ReactMarkdown>{agentConfiguration.generation.prompt}</ReactMarkdown>
+        <ReactMarkdown>{agentConfiguration.instructions}</ReactMarkdown>
       </div>
     ) : (
       "This assistant has no instructions."

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -710,11 +710,11 @@ export async function submitAssistantBuilderForm({
         name: removeLeadingAt(handle),
         pictureUrl: avatarUrl,
         description: description,
+        instructions: instructions.trim(),
         status: isDraft ? "draft" : "active",
         scope: builderState.scope,
         actions: removeNulls([actionParam]),
         generation: {
-          prompt: instructions.trim(),
           model: builderState.generationSettings.modelSettings,
           temperature: builderState.generationSettings.temperature,
         },

--- a/front/lib/api/assistant/actions/tables_query.ts
+++ b/front/lib/api/assistant/actions/tables_query.ts
@@ -217,7 +217,7 @@ export async function* runTablesQuery({
     [
       {
         question: input.question,
-        instructions: configuration.generation?.prompt,
+        instructions: configuration.instructions,
       },
     ]
   );

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -967,9 +967,11 @@ export async function restoreAgentConfiguration(
 export async function createAgentGenerationConfiguration(
   auth: Authenticator,
   {
+    prompt, // @todo Daph remove this field
     model,
     temperature,
   }: {
+    prompt: string; // @todo Daph remove this field
     model: SupportedModel;
     temperature: number;
   }
@@ -988,7 +990,7 @@ export async function createAgentGenerationConfiguration(
   }
 
   const genConfig = await AgentGenerationConfiguration.create({
-    prompt: "Deprecated", // @todo Daph remove this field
+    prompt: prompt, // @todo Daph remove this field
     providerId: model.providerId,
     modelId: model.modelId,
     temperature: temperature,

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -532,7 +532,6 @@ async function fetchWorkspaceAgentConfigurationsForView(
       }
       generation = {
         id: generationConfig.id,
-        prompt: generationConfig.prompt,
         temperature: generationConfig.temperature,
         model,
       };
@@ -548,6 +547,7 @@ async function fetchWorkspaceAgentConfigurationsForView(
       name: agent.name,
       pictureUrl: agent.pictureUrl,
       description: agent.description,
+      instructions: agent.instructions,
       status: agent.status,
       actions,
       generation,
@@ -881,6 +881,7 @@ export async function createAgentConfiguration(
       userListStatus: null,
       name: agent.name,
       description: agent.description,
+      instructions: agent.instructions,
       pictureUrl: agent.pictureUrl,
       status: agent.status,
       generation: generation,
@@ -966,11 +967,9 @@ export async function restoreAgentConfiguration(
 export async function createAgentGenerationConfiguration(
   auth: Authenticator,
   {
-    prompt,
     model,
     temperature,
   }: {
-    prompt: string;
     model: SupportedModel;
     temperature: number;
   }
@@ -989,7 +988,7 @@ export async function createAgentGenerationConfiguration(
   }
 
   const genConfig = await AgentGenerationConfiguration.create({
-    prompt: prompt,
+    prompt: "Deprecated", // @todo Daph remove this field
     providerId: model.providerId,
     modelId: model.modelId,
     temperature: temperature,
@@ -997,7 +996,6 @@ export async function createAgentGenerationConfiguration(
 
   return {
     id: genConfig.id,
-    prompt: genConfig.prompt,
     temperature: genConfig.temperature,
     model,
   };

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -258,8 +258,8 @@ export async function constructPrompt(
   context += "}\n";
 
   let instructions = "";
-  if (configuration.generation) {
-    instructions += `\n${configuration.generation.prompt}`;
+  if (configuration.instructions) {
+    instructions += `\n${configuration.instructions}`;
   } else if (fallbackPrompt) {
     instructions += `\n${fallbackPrompt}`;
   }

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -104,13 +104,13 @@ async function _getHelperGlobalAgent(
     versionAuthorId: null,
     name: "help",
     description: "Help on how to use Dust",
+    instructions: prompt,
     pictureUrl: "https://dust.tt/static/systemavatar/helper_avatar_full.png",
     status: "active",
     userListStatus: "in-list",
     scope: "global",
     generation: {
       id: -1,
-      prompt: prompt,
       model,
       temperature: 0.2,
     },
@@ -132,13 +132,13 @@ async function _getGPT35TurboGlobalAgent({
     versionAuthorId: null,
     name: "gpt3.5-turbo",
     description: GPT_3_5_TURBO_MODEL_CONFIG.description,
+    instructions: null,
     pictureUrl: "https://dust.tt/static/systemavatar/gpt3_avatar_full.png",
     status,
     scope: "global",
     userListStatus: status === "active" ? "in-list" : "not-in-list",
     generation: {
       id: -1,
-      prompt: "",
       model: {
         providerId: GPT_3_5_TURBO_MODEL_CONFIG.providerId,
         modelId: GPT_3_5_TURBO_MODEL_CONFIG.modelId,
@@ -163,13 +163,13 @@ async function _getGPT4GlobalAgent({
     versionAuthorId: null,
     name: "gpt4",
     description: GPT_4_TURBO_MODEL_CONFIG.description,
+    instructions: null,
     pictureUrl: "https://dust.tt/static/systemavatar/gpt4_avatar_full.png",
     status,
     scope: "global",
     userListStatus: status === "active" ? "in-list" : "not-in-list",
     generation: {
       id: -1,
-      prompt: "",
       model: {
         providerId: GPT_4_TURBO_MODEL_CONFIG.providerId,
         modelId: GPT_4_TURBO_MODEL_CONFIG.modelId,
@@ -195,13 +195,13 @@ async function _getClaudeInstantGlobalAgent({
     versionAuthorId: null,
     name: "claude-instant",
     description: CLAUDE_INSTANT_DEFAULT_MODEL_CONFIG.description,
+    instructions: null,
     pictureUrl: "https://dust.tt/static/systemavatar/claude_avatar_full.png",
     status,
     scope: "global",
     userListStatus: status === "active" ? "in-list" : "not-in-list",
     generation: {
       id: -1,
-      prompt: "",
       model: {
         providerId: CLAUDE_INSTANT_DEFAULT_MODEL_CONFIG.providerId,
         modelId: CLAUDE_INSTANT_DEFAULT_MODEL_CONFIG.modelId,
@@ -232,13 +232,13 @@ async function _getClaude2GlobalAgent({
     versionAuthorId: null,
     name: "claude-2",
     description: CLAUDE_2_DEFAULT_MODEL_CONFIG.description,
+    instructions: null,
     pictureUrl: "https://dust.tt/static/systemavatar/claude_avatar_full.png",
     status,
     scope: "global",
     userListStatus: status === "active" ? "in-list" : "not-in-list",
     generation: {
       id: -1,
-      prompt: "",
       model: {
         providerId: CLAUDE_2_DEFAULT_MODEL_CONFIG.providerId,
         modelId: CLAUDE_2_DEFAULT_MODEL_CONFIG.modelId,
@@ -264,20 +264,20 @@ async function _getClaude3HaikuGlobalAgent({
     versionAuthorId: null,
     name: "claude-3-haiku",
     description: CLAUDE_3_HAIKU_DEFAULT_MODEL_CONFIG.description,
+    instructions:
+      "Your name is claude-3-haiku, but you are not meant to generate haikus." +
+      " Users will mention you using @claude-3-haiku, but this does not mean" +
+      " they are asking you to generate a haiku. Just answer their questions" +
+      " and ignore the fact that they are referring to you as claude-3-haiku." +
+      " Do not ever talk about haikus or the fact that you have been asked to" +
+      " never generate haikus. Just answer the questions as if they were not" +
+      " mentioning haikus at all.",
     pictureUrl: "https://dust.tt/static/systemavatar/claude_avatar_full.png",
     status,
     scope: "global",
     userListStatus: status === "active" ? "in-list" : "not-in-list",
     generation: {
       id: -1,
-      prompt:
-        "Your name is claude-3-haiku, but you are not meant to generate haikus." +
-        " Users will mention you using @claude-3-haiku, but this does not mean" +
-        " they are asking you to generate a haiku. Just answer their questions" +
-        " and ignore the fact that they are referring to you as claude-3-haiku." +
-        " Do not ever talk about haikus or the fact that you have been asked to" +
-        " never generate haikus. Just answer the questions as if they were not" +
-        " mentioning haikus at all.",
       model: {
         providerId: CLAUDE_3_HAIKU_DEFAULT_MODEL_CONFIG.providerId,
         modelId: CLAUDE_3_HAIKU_DEFAULT_MODEL_CONFIG.modelId,
@@ -308,14 +308,14 @@ async function _getClaude3SonnetGlobalAgent({
     versionAuthorId: null,
     name: "claude-3-sonnet",
     description: CLAUDE_3_SONNET_DEFAULT_MODEL_CONFIG.description,
+    instructions:
+      "Your name is claude-3-sonnet, but that does not mean you're expected to generate sonnets unless instructed.",
     pictureUrl: "https://dust.tt/static/systemavatar/claude_avatar_full.png",
     status,
     scope: "global",
     userListStatus: status === "active" ? "in-list" : "not-in-list",
     generation: {
       id: -1,
-      prompt:
-        "Your name is claude-3-sonnet, but that does not mean you're expected to generate sonnets unless instructed.",
       model: {
         providerId: CLAUDE_3_SONNET_DEFAULT_MODEL_CONFIG.providerId,
         modelId: CLAUDE_3_SONNET_DEFAULT_MODEL_CONFIG.modelId,
@@ -346,13 +346,13 @@ async function _getClaude3OpusGlobalAgent({
     versionAuthorId: null,
     name: "claude-3",
     description: CLAUDE_3_OPUS_DEFAULT_MODEL_CONFIG.description,
+    instructions: null,
     pictureUrl: "https://dust.tt/static/systemavatar/claude_avatar_full.png",
     status,
     scope: "global",
     userListStatus: status === "active" ? "in-list" : "not-in-list",
     generation: {
       id: -1,
-      prompt: "",
       model: {
         providerId: CLAUDE_3_OPUS_DEFAULT_MODEL_CONFIG.providerId,
         modelId: CLAUDE_3_OPUS_DEFAULT_MODEL_CONFIG.modelId,
@@ -383,13 +383,13 @@ async function _getMistralLargeGlobalAgent({
     versionAuthorId: null,
     name: "mistral-large",
     description: MISTRAL_LARGE_MODEL_CONFIG.description,
+    instructions: null,
     pictureUrl: "https://dust.tt/static/systemavatar/mistral_avatar_full.png",
     status,
     scope: "global",
     userListStatus: status === "active" ? "in-list" : "not-in-list",
     generation: {
       id: -1,
-      prompt: "",
       model: {
         providerId: MISTRAL_LARGE_MODEL_CONFIG.providerId,
         modelId: MISTRAL_LARGE_MODEL_CONFIG.modelId,
@@ -420,13 +420,13 @@ async function _getMistralMediumGlobalAgent({
     versionAuthorId: null,
     name: "mistral-medium",
     description: MISTRAL_MEDIUM_MODEL_CONFIG.description,
+    instructions: null,
     pictureUrl: "https://dust.tt/static/systemavatar/mistral_avatar_full.png",
     status,
     scope: "global",
     userListStatus: status === "active" ? "in-list" : "not-in-list",
     generation: {
       id: -1,
-      prompt: "",
       model: {
         providerId: MISTRAL_MEDIUM_MODEL_CONFIG.providerId,
         modelId: MISTRAL_MEDIUM_MODEL_CONFIG.modelId,
@@ -451,13 +451,13 @@ async function _getMistralSmallGlobalAgent({
     versionAuthorId: null,
     name: "mistral-small",
     description: MISTRAL_SMALL_MODEL_CONFIG.description,
+    instructions: null,
     pictureUrl: "https://dust.tt/static/systemavatar/mistral_avatar_full.png",
     status,
     scope: "global",
     userListStatus: status === "active" ? "in-list" : "not-in-list",
     generation: {
       id: -1,
-      prompt: "",
       model: {
         providerId: MISTRAL_SMALL_MODEL_CONFIG.providerId,
         modelId: MISTRAL_SMALL_MODEL_CONFIG.modelId,
@@ -487,13 +487,13 @@ async function _getGeminiProGlobalAgent({
     versionAuthorId: null,
     name: "gemini-pro",
     description: GEMINI_PRO_DEFAULT_MODEL_CONFIG.description,
+    instructions: `Never start your messages with "[assistant:"`,
     pictureUrl: "https://dust.tt/static/systemavatar/gemini_avatar_full.png",
     status,
     scope: "global",
     userListStatus: status === "active" ? "in-list" : "not-in-list",
     generation: {
       id: -1,
-      prompt: `Never start your messages with "[assistant:"`,
       model: {
         providerId: GEMINI_PRO_DEFAULT_MODEL_CONFIG.providerId,
         modelId: GEMINI_PRO_DEFAULT_MODEL_CONFIG.modelId,
@@ -516,8 +516,8 @@ async function _getManagedDataSourceAgent(
     agentId,
     name,
     description,
+    instructions,
     pictureUrl,
-    prompt,
     dataSources,
   }: {
     settings: GlobalAgentSettings | null;
@@ -525,8 +525,8 @@ async function _getManagedDataSourceAgent(
     agentId: GLOBAL_AGENTS_SID;
     name: string;
     description: string;
+    instructions: string | null;
     pictureUrl: string;
-    prompt: string;
     dataSources: DataSourceType[];
   }
 ): Promise<AgentConfigurationType | null> {
@@ -547,6 +547,7 @@ async function _getManagedDataSourceAgent(
       versionAuthorId: null,
       name: name,
       description,
+      instructions: null,
       pictureUrl,
       status: "disabled_by_admin",
       scope: "global",
@@ -569,6 +570,7 @@ async function _getManagedDataSourceAgent(
       versionAuthorId: null,
       name: name,
       description,
+      instructions: null,
       pictureUrl,
       status: "disabled_missing_datasource",
       scope: "global",
@@ -586,13 +588,13 @@ async function _getManagedDataSourceAgent(
     versionAuthorId: null,
     name: name,
     description,
+    instructions,
     pictureUrl,
     status: "active",
     scope: "global",
     userListStatus: "in-list",
     generation: {
       id: -1,
-      prompt,
       model: !auth.isUpgraded()
         ? {
             providerId: GPT_3_5_TURBO_MODEL_CONFIG.providerId,
@@ -641,7 +643,7 @@ async function _getGoogleDriveGlobalAgent(
     name: "googledrive",
     description: "An assistant with context on your Google Drives.",
     pictureUrl: "https://dust.tt/static/systemavatar/drive_avatar_full.png",
-    prompt:
+    instructions:
       "Assist the user based on the retrieved data from their Google Drives." +
       `\n${BREVITY_PROMPT}`,
     dataSources,
@@ -665,7 +667,7 @@ async function _getSlackGlobalAgent(
     name: "slack",
     description: "An assistant with context on your Slack Channels.",
     pictureUrl: "https://dust.tt/static/systemavatar/slack_avatar_full.png",
-    prompt:
+    instructions:
       "Assist the user based on the retrieved data from their Slack channels." +
       `\n${BREVITY_PROMPT}`,
     dataSources,
@@ -690,7 +692,7 @@ async function _getGithubGlobalAgent(
     description:
       "An assistant with context on your Github Issues and Discussions.",
     pictureUrl: "https://dust.tt/static/systemavatar/github_avatar_full.png",
-    prompt:
+    instructions:
       "Assist the user based on the retrieved data from their Github Issues and Discussions." +
       `\n${BREVITY_PROMPT}`,
     dataSources,
@@ -714,7 +716,7 @@ async function _getNotionGlobalAgent(
     name: "notion",
     description: "An assistant with context on your Notion Spaces.",
     pictureUrl: "https://dust.tt/static/systemavatar/notion_avatar_full.png",
-    prompt:
+    instructions:
       "Assist the user based on the retrieved data from their Notion Spaces." +
       `\n${BREVITY_PROMPT}`,
     dataSources,
@@ -738,7 +740,7 @@ async function _getIntercomGlobalAgent(
     name: "intercom",
     description: "An assistant with context on your Intercom Help Center data.",
     pictureUrl: "https://dust.tt/static/systemavatar/intercom_avatar_full.png",
-    prompt:
+    instructions:
       "Assist the user based on the retrieved data from their Intercom Workspace." +
       `\n${BREVITY_PROMPT}`,
     dataSources,
@@ -771,6 +773,7 @@ async function _getDustGlobalAgent(
       versionAuthorId: null,
       name,
       description,
+      instructions: null,
       pictureUrl,
       status: "disabled_by_admin",
       scope: "global",
@@ -801,6 +804,7 @@ async function _getDustGlobalAgent(
       versionAuthorId: null,
       name,
       description,
+      instructions: null,
       pictureUrl,
       status: "disabled_missing_datasource",
       scope: "global",
@@ -818,15 +822,15 @@ async function _getDustGlobalAgent(
     versionAuthorId: null,
     name,
     description,
+    instructions:
+      "Assist the user based on the retrieved data from their workspace." +
+      `\n${BREVITY_PROMPT}`,
     pictureUrl,
     status: "active",
     scope: "global",
     userListStatus: "in-list",
     generation: {
       id: -1,
-      prompt:
-        "Assist the user based on the retrieved data from their workspace." +
-        `\n${BREVITY_PROMPT}`,
       model: !auth.isUpgraded()
         ? {
             providerId: GPT_3_5_TURBO_MODEL_CONFIG.providerId,

--- a/front/lib/api/assistant/templates.ts
+++ b/front/lib/api/assistant/templates.ts
@@ -30,8 +30,8 @@ export async function generateMockAgentConfigurationFromTemplate(
   return new Ok({
     actions: removeNulls([getAction(template.presetAction)]),
     description: template.description ?? "",
+    instructions: template.presetInstructions ?? "",
     generation: {
-      prompt: template.presetInstructions ?? "",
       model: {
         providerId: template.presetProviderId,
         modelId: template.presetModelId,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -244,6 +244,7 @@ export async function createOrUpgradeAgentConfiguration(
       actions,
       name,
       description,
+      instructions,
       scope,
       pictureUrl,
       status,
@@ -254,7 +255,6 @@ export async function createOrUpgradeAgentConfiguration(
   let generationConfig: AgentGenerationConfigurationType | null = null;
   if (generation) {
     generationConfig = await createAgentGenerationConfiguration(auth, {
-      prompt: generation.prompt,
       model: generation.model,
       temperature: generation.temperature,
     });
@@ -263,7 +263,7 @@ export async function createOrUpgradeAgentConfiguration(
   const agentConfigurationRes = await createAgentConfiguration(auth, {
     name,
     description,
-    instructions: generation?.prompt ?? null,
+    instructions: instructions ?? null,
     pictureUrl,
     status,
     scope,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -255,6 +255,7 @@ export async function createOrUpgradeAgentConfiguration(
   let generationConfig: AgentGenerationConfigurationType | null = null;
   if (generation) {
     generationConfig = await createAgentGenerationConfiguration(auth, {
+      prompt: instructions || "", // @todo Daph remove this field
       model: generation.model,
       temperature: generation.temperature,
     });

--- a/front/pages/poke/[wId]/assistants/[aId]/index.tsx
+++ b/front/pages/poke/[wId]/assistants/[aId]/index.tsx
@@ -60,7 +60,7 @@ const DataSourcePage = ({
                     </div>
                     <div className="ml-4 text-sm text-element-700">
                       <div className="font-bold">Instructions:</div>
-                      {a.generation?.prompt}
+                      {a.instructions}
                     </div>
                     <div className="ml-4 text-sm text-element-700">
                       <div className="font-bold">model:</div>

--- a/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
@@ -191,7 +191,7 @@ export default function EditAssistant({
         scope: agentConfiguration.scope,
         handle: agentConfiguration.name,
         description: agentConfiguration.description,
-        instructions: agentConfiguration.generation?.prompt || "", // TODO we don't support null in the UI yet
+        instructions: agentConfiguration.instructions || "", // TODO we don't support null in the UI yet
         avatarUrl: agentConfiguration.pictureUrl,
         generationSettings: agentConfiguration.generation
           ? {

--- a/front/pages/w/[wId]/builder/assistants/new.tsx
+++ b/front/pages/w/[wId]/builder/assistants/new.tsx
@@ -238,7 +238,7 @@ export default function CreateAssistant({
                 "isTemplate" in agentConfiguration ? "" : "_Copy"
               }`,
               description: agentConfiguration.description,
-              instructions: agentConfiguration.generation?.prompt || "", // TODO we don't support null in the UI yet
+              instructions: agentConfiguration.instructions || "", // TODO we don't support null in the UI yet
               avatarUrl: null,
               generationSettings: agentConfiguration.generation
                 ? {

--- a/types/src/front/api_handlers/internal/agent_configuration.ts
+++ b/types/src/front/api_handlers/internal/agent_configuration.ts
@@ -46,6 +46,7 @@ export const PostOrPatchAgentConfigurationRequestBodySchema = t.type({
   assistant: t.type({
     name: t.string,
     description: t.string,
+    instructions: t.union([t.string, t.null]),
     pictureUrl: t.string,
     status: t.union([
       t.literal("active"),
@@ -120,7 +121,6 @@ export const PostOrPatchAgentConfigurationRequestBodySchema = t.type({
     generation: t.union([
       t.null,
       t.type({
-        prompt: t.string,
         // enforce that the model is a supported model
         // the modelId and providerId are checked together, so
         // (gpt-4, anthropic) won't pass

--- a/types/src/front/assistant/agent.ts
+++ b/types/src/front/assistant/agent.ts
@@ -54,7 +54,6 @@ export type AgentActionSpecification = {
 
 export type AgentGenerationConfigurationType = {
   id: ModelId;
-  prompt: string;
   model: SupportedModel;
   temperature: number;
 };
@@ -155,6 +154,8 @@ export type LightAgentConfigurationType = {
   // Global agents have a null authorId, others have a non-null authorId
   versionAuthorId: ModelId | null;
 
+  instructions: string | null;
+
   // If undefined, no text generation.
   generation: AgentGenerationConfigurationType | null;
 
@@ -184,7 +185,6 @@ export type AgentConfigurationType = LightAgentConfigurationType & {
 export interface TemplateAgentConfigurationType {
   // If undefined, no text generation.
   generation: {
-    prompt: string;
     model: SupportedModel;
     temperature: number;
   } | null;
@@ -193,5 +193,6 @@ export interface TemplateAgentConfigurationType {
   scope: AgentConfigurationScope;
   description: string;
   actions: AgentActionConfigurationType[];
+  instructions: string | null;
   isTemplate: true;
 }


### PR DESCRIPTION
## Description

Task: https://github.com/dust-tt/dust/issues/4596

**PR number 1:** https://github.com/dust-tt/dust/pull/4684
- Adds new instructions field to the AgentGeneration model.
- Shadow-write it for new & updated agent configurations.
- Add a script to backfill for all agents.

**This PR**
- Replace all usages of agentConfiguration.prompt by calling the new agentConfiguration.instructions.

**Next PR**
-> Remove the column.

## Risk

Break agent configuration builder and the chat. 

## Deploy Plan

https://github.com/dust-tt/dust/pull/4684 must be deployed first. 
