### PR TITLE
qdrant incident: move back to dedicated-2

### DIFF
--- a/types/src/core/data_source.ts
+++ b/types/src/core/data_source.ts
@@ -5,7 +5,7 @@ export type QdrantCluster =
   | "dedicated-2";
 
 export const DEFAULT_FREE_QDRANT_CLUSTER: QdrantCluster = "main-0";
-export const DEFAULT_PAID_QDRANT_CLUSTER: QdrantCluster = "dedicated-1";
+export const DEFAULT_PAID_QDRANT_CLUSTER: QdrantCluster = "dedicated-2";
 
 export type CoreAPIDataSourceConfig = {
   provider_id: string;


### PR DESCRIPTION
## Description

Context: https://dust4ai.slack.com/archives/C05B529FHV1/p1712759598846309

Reverts https://github.com/dust-tt/dust/pull/4674

## Risk

Low has we gave a lot of breathing room in # of collections to `dedicated-2`

## Deploy Plan

- deploy `front`