### PR TITLE
feat: add force_use_at_iteration on actions

### DIFF
--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -486,6 +486,7 @@ async function fetchWorkspaceAgentConfigurationsForView(
               },
             };
           }),
+          forceUseAtIteration: retrievalConfig.forceUseAtIteration,
         });
       }
 
@@ -497,6 +498,7 @@ async function fetchWorkspaceAgentConfigurationsForView(
           type: "dust_app_run_configuration",
           appWorkspaceId: dustAppRunConfig.appWorkspaceId,
           appId: dustAppRunConfig.appId,
+          forceUseAtIteration: dustAppRunConfig.forceUseAtIteration,
         });
       }
 
@@ -513,6 +515,7 @@ async function fetchWorkspaceAgentConfigurationsForView(
             workspaceId: tablesQueryConfigTable.dataSourceWorkspaceId,
             tableId: tablesQueryConfigTable.tableId,
           })),
+          forceUseAtIteration: tablesQueryConfig.forceUseAtIteration,
         });
       }
     }
@@ -545,6 +548,7 @@ async function fetchWorkspaceAgentConfigurationsForView(
         id: generationConfig.id,
         temperature: generationConfig.temperature,
         model,
+        forceUseAtIteration: generationConfig.forceUseAtIteration,
       };
     }
 
@@ -1020,6 +1024,7 @@ export async function createAgentGenerationConfiguration(
     id: genConfig.id,
     temperature: genConfig.temperature,
     model,
+    forceUseAtIteration,
   };
 }
 
@@ -1095,6 +1100,7 @@ export async function createAgentActionConfiguration(
         relativeTimeFrame: action.relativeTimeFrame,
         topK: action.topK,
         dataSources: action.dataSources,
+        forceUseAtIteration: action.forceUseAtIteration,
       };
     });
   } else if (action.type === "dust_app_run_configuration") {
@@ -1112,6 +1118,7 @@ export async function createAgentActionConfiguration(
       type: "dust_app_run_configuration",
       appWorkspaceId: action.appWorkspaceId,
       appId: action.appId,
+      forceUseAtIteration: action.forceUseAtIteration,
     };
   } else if (action.type === "tables_query_configuration") {
     return frontSequelize.transaction(async (t) => {
@@ -1142,6 +1149,7 @@ export async function createAgentActionConfiguration(
         sId: tablesQueryConfig.sId,
         type: "tables_query_configuration",
         tables: action.tables,
+        forceUseAtIteration: action.forceUseAtIteration,
       };
     });
   } else {

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -984,12 +984,15 @@ export async function createAgentGenerationConfiguration(
     prompt, // @todo Daph remove this field
     model,
     temperature,
+    agentConfiguration,
+    forceUseAtIteration,
   }: {
     prompt: string; // @todo Daph remove this field
     model: SupportedModel;
     temperature: number;
-  },
-  agentConfiguration: AgentConfigurationWithoutActionsType
+    agentConfiguration: AgentConfigurationWithoutActionsType;
+    forceUseAtIteration: number | null;
+  }
 ): Promise<AgentGenerationConfigurationType> {
   const owner = auth.workspace();
   if (!owner) {
@@ -1010,6 +1013,7 @@ export async function createAgentGenerationConfiguration(
     modelId: model.modelId,
     temperature: temperature,
     agentConfigurationId: agentConfiguration.id,
+    forceUseAtIteration: forceUseAtIteration,
   });
 
   return {
@@ -1024,7 +1028,7 @@ export async function createAgentGenerationConfiguration(
  */
 export async function createAgentActionConfiguration(
   auth: Authenticator,
-  action:
+  action: (
     | {
         type: "retrieval_configuration";
         query: RetrievalQuery;
@@ -1044,7 +1048,10 @@ export async function createAgentActionConfiguration(
           dataSourceId: string;
           tableId: string;
         }>;
-      },
+      }
+  ) & {
+    forceUseAtIteration: number | null;
+  },
   agentConfiguration: AgentConfigurationWithoutActionsType
 ): Promise<AgentActionConfigurationType> {
   const owner = auth.workspace();
@@ -1070,6 +1077,7 @@ export async function createAgentActionConfiguration(
           topK: action.topK !== "auto" ? action.topK : null,
           topKMode: action.topK === "auto" ? "auto" : "custom",
           agentConfigurationId: agentConfiguration.id,
+          forceUseAtIteration: action.forceUseAtIteration,
         },
         { transaction: t }
       );
@@ -1095,6 +1103,7 @@ export async function createAgentActionConfiguration(
       appWorkspaceId: action.appWorkspaceId,
       appId: action.appId,
       agentConfigurationId: agentConfiguration.id,
+      forceUseAtIteration: action.forceUseAtIteration,
     });
 
     return {
@@ -1110,6 +1119,7 @@ export async function createAgentActionConfiguration(
         {
           sId: generateModelSId(),
           agentConfigurationId: agentConfiguration.id,
+          forceUseAtIteration: action.forceUseAtIteration,
         },
         { transaction: t }
       );

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -113,6 +113,7 @@ async function _getHelperGlobalAgent(
       id: -1,
       model,
       temperature: 0.2,
+      forceUseAtIteration: 0,
     },
     actions: [],
   };
@@ -144,6 +145,7 @@ async function _getGPT35TurboGlobalAgent({
         modelId: GPT_3_5_TURBO_MODEL_CONFIG.modelId,
       },
       temperature: 0.7,
+      forceUseAtIteration: 0,
     },
     actions: [],
   };
@@ -176,6 +178,7 @@ async function _getGPT4GlobalAgent({
       },
 
       temperature: 0.7,
+      forceUseAtIteration: 0,
     },
     actions: [],
   };
@@ -207,6 +210,7 @@ async function _getClaudeInstantGlobalAgent({
         modelId: CLAUDE_INSTANT_DEFAULT_MODEL_CONFIG.modelId,
       },
       temperature: 0.7,
+      forceUseAtIteration: 0,
     },
     actions: [],
   };
@@ -244,6 +248,7 @@ async function _getClaude2GlobalAgent({
         modelId: CLAUDE_2_DEFAULT_MODEL_CONFIG.modelId,
       },
       temperature: 0.7,
+      forceUseAtIteration: 0,
     },
     actions: [],
   };
@@ -283,6 +288,7 @@ async function _getClaude3HaikuGlobalAgent({
         modelId: CLAUDE_3_HAIKU_DEFAULT_MODEL_CONFIG.modelId,
       },
       temperature: 0.7,
+      forceUseAtIteration: 0,
     },
     actions: [],
   };
@@ -321,6 +327,7 @@ async function _getClaude3SonnetGlobalAgent({
         modelId: CLAUDE_3_SONNET_DEFAULT_MODEL_CONFIG.modelId,
       },
       temperature: 0.7,
+      forceUseAtIteration: 0,
     },
     actions: [],
   };
@@ -358,6 +365,7 @@ async function _getClaude3OpusGlobalAgent({
         modelId: CLAUDE_3_OPUS_DEFAULT_MODEL_CONFIG.modelId,
       },
       temperature: 0.7,
+      forceUseAtIteration: 0,
     },
     actions: [],
   };
@@ -395,6 +403,7 @@ async function _getMistralLargeGlobalAgent({
         modelId: MISTRAL_LARGE_MODEL_CONFIG.modelId,
       },
       temperature: 0.7,
+      forceUseAtIteration: 0,
     },
     actions: [],
   };
@@ -432,6 +441,7 @@ async function _getMistralMediumGlobalAgent({
         modelId: MISTRAL_MEDIUM_MODEL_CONFIG.modelId,
       },
       temperature: 0.7,
+      forceUseAtIteration: 0,
     },
     actions: [],
   };
@@ -463,6 +473,7 @@ async function _getMistralSmallGlobalAgent({
         modelId: MISTRAL_SMALL_MODEL_CONFIG.modelId,
       },
       temperature: 0.7,
+      forceUseAtIteration: 0,
     },
     actions: [],
   };
@@ -499,6 +510,7 @@ async function _getGeminiProGlobalAgent({
         modelId: GEMINI_PRO_DEFAULT_MODEL_CONFIG.modelId,
       },
       temperature: 0.7,
+      forceUseAtIteration: 0,
     },
     actions: [],
   };
@@ -605,6 +617,7 @@ async function _getManagedDataSourceAgent(
             modelId: GPT_4_TURBO_MODEL_CONFIG.modelId,
           },
       temperature: 0.4,
+      forceUseAtIteration: 1,
     },
     actions: [
       {
@@ -621,6 +634,7 @@ async function _getManagedDataSourceAgent(
           workspaceId: prodCredentials.workspaceId,
           filter: { tags: null, parents: null },
         })),
+        forceUseAtIteration: 0,
       },
     ],
   };
@@ -841,6 +855,7 @@ async function _getDustGlobalAgent(
             modelId: GPT_4_TURBO_MODEL_CONFIG.modelId,
           },
       temperature: 0.4,
+      forceUseAtIteration: 1,
     },
     actions: [
       {
@@ -855,6 +870,7 @@ async function _getDustGlobalAgent(
           workspaceId: prodCredentials.workspaceId,
           filter: { tags: null, parents: null },
         })),
+        forceUseAtIteration: 0,
       },
     ],
   };

--- a/front/lib/api/assistant/templates.ts
+++ b/front/lib/api/assistant/templates.ts
@@ -38,6 +38,7 @@ export async function generateMockAgentConfigurationFromTemplate(
       } as SupportedModel,
       temperature:
         ASSISTANT_CREATIVITY_LEVEL_TEMPERATURES[template.presetTemperature],
+      forceUseAtIteration: 1,
     },
     name: template.handle,
     scope: flow === "personal_assistants" ? "private" : "workspace",
@@ -59,6 +60,7 @@ function getAction(action: ActionPreset): AgentActionConfigurationType | null {
         sId: "template",
         topK: "auto",
         type: "retrieval_configuration",
+        forceUseAtIteration: 0,
       } satisfies RetrievalConfigurationType;
 
     case "tables_query_configuration":
@@ -67,6 +69,7 @@ function getAction(action: ActionPreset): AgentActionConfigurationType | null {
         sId: "template",
         tables: [],
         type: "tables_query_configuration",
+        forceUseAtIteration: 0,
       } satisfies TablesQueryConfigurationType;
 
     case "dust_app_run_configuration":
@@ -76,6 +79,7 @@ function getAction(action: ActionPreset): AgentActionConfigurationType | null {
         type: "dust_app_run_configuration",
         appWorkspaceId: "template",
         appId: "template",
+        forceUseAtIteration: 0,
       } satisfies DustAppRunConfigurationType;
 
     default:

--- a/front/lib/models/assistant/actions/dust_app_run.ts
+++ b/front/lib/models/assistant/actions/dust_app_run.ts
@@ -24,6 +24,8 @@ export class AgentDustAppRunConfiguration extends Model<
 
   declare appWorkspaceId: string;
   declare appId: string;
+
+  declare forceUseAtIteration: number | null;
 }
 
 AgentDustAppRunConfiguration.init(
@@ -54,6 +56,10 @@ AgentDustAppRunConfiguration.init(
     appId: {
       type: DataTypes.STRING,
       allowNull: false,
+    },
+    forceUseAtIteration: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
     },
   },
   {

--- a/front/lib/models/assistant/actions/retrieval.ts
+++ b/front/lib/models/assistant/actions/retrieval.ts
@@ -30,6 +30,8 @@ export class AgentRetrievalConfiguration extends Model<
   declare relativeTimeFrameUnit: TimeframeUnit | null;
   declare topK: number | null;
   declare topKMode: "auto" | "custom";
+
+  declare forceUseAtIteration: number | null;
 }
 
 AgentRetrievalConfiguration.init(
@@ -79,6 +81,10 @@ AgentRetrievalConfiguration.init(
       type: DataTypes.STRING,
       allowNull: false,
       defaultValue: "auto",
+    },
+    forceUseAtIteration: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
     },
   },
   {

--- a/front/lib/models/assistant/actions/tables_query.ts
+++ b/front/lib/models/assistant/actions/tables_query.ts
@@ -20,6 +20,8 @@ export class AgentTablesQueryConfiguration extends Model<
   declare agentConfigurationId: ForeignKey<AgentConfiguration["id"]>;
 
   declare sId: string;
+
+  declare forceUseAtIteration: number | null;
 }
 
 AgentTablesQueryConfiguration.init(
@@ -42,6 +44,10 @@ AgentTablesQueryConfiguration.init(
     sId: {
       type: DataTypes.STRING,
       allowNull: false,
+    },
+    forceUseAtIteration: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
     },
   },
   {

--- a/front/lib/models/assistant/agent.ts
+++ b/front/lib/models/assistant/agent.ts
@@ -35,7 +35,7 @@ export class AgentGenerationConfiguration extends Model<
   declare modelId: string;
   declare temperature: number;
 
-  declare force_use_at_iteration: number | null;
+  declare forceUseAtIteration: number | null;
 }
 AgentGenerationConfiguration.init(
   {
@@ -71,7 +71,7 @@ AgentGenerationConfiguration.init(
       allowNull: false,
       defaultValue: 0.7,
     },
-    force_use_at_iteration: {
+    forceUseAtIteration: {
       type: DataTypes.INTEGER,
       allowNull: true,
     },

--- a/front/lib/models/assistant/agent.ts
+++ b/front/lib/models/assistant/agent.ts
@@ -34,6 +34,8 @@ export class AgentGenerationConfiguration extends Model<
   declare providerId: string;
   declare modelId: string;
   declare temperature: number;
+
+  declare force_use_at_iteration: number | null;
 }
 AgentGenerationConfiguration.init(
   {
@@ -68,6 +70,10 @@ AgentGenerationConfiguration.init(
       type: DataTypes.FLOAT,
       allowNull: false,
       defaultValue: 0.7,
+    },
+    force_use_at_iteration: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
     },
   },
   {

--- a/front/migrations/20240412_force_use_at_iteration.ts
+++ b/front/migrations/20240412_force_use_at_iteration.ts
@@ -62,6 +62,17 @@ const backfillAgentConfigurations = async (execute: boolean) => {
     for (const aId of c) {
       const generation = generationConfigByAgentId[aId];
       const actions = actionsByAgentId[aId] ?? [];
+      if (execute) {
+        const nbFixedIterations = (generation ? 1 : 0) + actions.length;
+        await AgentConfiguration.update(
+          { maxToolsUsePerRun: nbFixedIterations },
+          {
+            where: {
+              id: aId,
+            },
+          }
+        );
+      }
       if (!generation) {
         logger.info(`Skipping agent (no generation configuration) ${aId}`);
         continue;

--- a/front/migrations/20240412_force_use_at_iteration.ts
+++ b/front/migrations/20240412_force_use_at_iteration.ts
@@ -18,9 +18,6 @@ import { makeScript } from "@app/scripts/helpers";
 
 const backfillAgentConfigurations = async (execute: boolean) => {
   const agents = await AgentConfiguration.findAll({
-    where: {
-      instructions: null,
-    },
     include: [
       {
         model: AgentGenerationConfiguration,

--- a/front/migrations/20240412_force_use_at_iteration.ts
+++ b/front/migrations/20240412_force_use_at_iteration.ts
@@ -1,0 +1,147 @@
+import { assertNever } from "@dust-tt/types";
+import * as _ from "lodash";
+
+import { AgentConfiguration } from "@app/lib/models";
+import {
+  AgentDustAppRunConfiguration,
+  AgentRetrievalConfiguration,
+  AgentTablesQueryConfiguration,
+} from "@app/lib/models";
+import { AgentGenerationConfiguration } from "@app/lib/models";
+import logger from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+
+// Fetch all agents, with all generation configs and all actions.
+// Goal is to backfill forceUseAtIteration for all generations and actions.
+// If there is an action, its forceUseAtIteration will be 0 and the generation's will be 1.
+// If there is no action, the generation's will be 0.
+
+const backfillAgentConfigurations = async (execute: boolean) => {
+  const agents = await AgentConfiguration.findAll({
+    where: {
+      instructions: null,
+    },
+    include: [
+      {
+        model: AgentGenerationConfiguration,
+        as: "generationConfiguration",
+      },
+    ],
+  });
+  const generationConfigByAgentId: Record<
+    number,
+    AgentGenerationConfiguration
+  > = {};
+  for (const agent of agents) {
+    generationConfigByAgentId[agent.id] = agent.generationConfiguration;
+  }
+
+  const retrievalConfigs = await AgentRetrievalConfiguration.findAll();
+  const tablesQueryConfigs = await AgentTablesQueryConfiguration.findAll();
+  const dustAppRunConfigs = await AgentDustAppRunConfiguration.findAll();
+
+  const actionsByAgentId: Record<
+    number,
+    (
+      | AgentRetrievalConfiguration
+      | AgentDustAppRunConfiguration
+      | AgentTablesQueryConfiguration
+    )[]
+  > = _.groupBy(
+    [...retrievalConfigs, ...dustAppRunConfigs, ...tablesQueryConfigs],
+    (action) => action.agentConfigurationId
+  );
+
+  const allAgentIds: number[] = Array.from(
+    new Set<number>([
+      ...Object.keys(actionsByAgentId).map(Number),
+      ...Object.keys(generationConfigByAgentId).map(Number),
+    ])
+  );
+
+  const chunks = _.chunk(allAgentIds, 16);
+
+  for (const c of chunks) {
+    for (const aId of c) {
+      const generation = generationConfigByAgentId[aId];
+      const actions = actionsByAgentId[aId] ?? [];
+      if (!generation) {
+        logger.info(`Skipping agent (no generation configuration) ${aId}`);
+        continue;
+      }
+      if (actions.length > 1) {
+        logger.info("Agent has multiple actions, skipping");
+        continue;
+      }
+      let forceUseAtIteration = 0;
+      if (actions.length) {
+        const action = actions[0];
+        if (action instanceof AgentRetrievalConfiguration) {
+          logger.info(
+            `Backfilling retrieval action ${action.id} for agent ${aId} with forceUseAtIteration... [execute: ${execute}]`
+          );
+          if (execute) {
+            await AgentRetrievalConfiguration.update(
+              { forceUseAtIteration },
+              {
+                where: {
+                  id: action.id,
+                },
+              }
+            );
+          }
+        } else if (action instanceof AgentDustAppRunConfiguration) {
+          logger.info(
+            `Backfilling dust app run action ${action.id} for agent ${aId} with forceUseAtIteration... [execute: ${execute}]`
+          );
+          if (execute) {
+            await AgentDustAppRunConfiguration.update(
+              { forceUseAtIteration },
+              {
+                where: {
+                  id: action.id,
+                },
+              }
+            );
+          }
+        } else if (action instanceof AgentTablesQueryConfiguration) {
+          logger.info(
+            `Backfilling tables query action ${action.id} for agent ${aId} with forceUseAtIteration... [execute: ${execute}]`
+          );
+          if (execute) {
+            await AgentTablesQueryConfiguration.update(
+              { forceUseAtIteration },
+              {
+                where: {
+                  id: action.id,
+                },
+              }
+            );
+          }
+        } else {
+          assertNever(action);
+        }
+
+        forceUseAtIteration += 1;
+      }
+
+      logger.info(
+        `Backfilling generation configuration ${generation.id} for agent ${aId} with forceUseAtIteration... [execute: ${execute}]`
+      );
+      if (execute) {
+        await AgentGenerationConfiguration.update(
+          { forceUseAtIteration },
+          {
+            where: {
+              id: generation.id,
+            },
+          }
+        );
+      }
+    }
+  }
+};
+
+makeScript({}, async ({ execute }) => {
+  await backfillAgentConfigurations(execute);
+});

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/index.ts
@@ -108,11 +108,12 @@ async function handler(
           },
         });
       }
-      const agentConfiguration = await createOrUpgradeAgentConfiguration(
+      const agentConfiguration = await createOrUpgradeAgentConfiguration({
         auth,
-        bodyValidation.right,
-        req.query.aId as string
-      );
+        assistant: bodyValidation.right.assistant,
+        agentConfigurationId: req.query.aId as string,
+        legacySingleActionMode: true,
+      });
       if (agentConfiguration.isErr()) {
         return apiError(req, res, {
           status_code: 500,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/scope.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/scope.ts
@@ -125,17 +125,16 @@ async function handler(
         }
       }
 
-      const result = await createOrUpgradeAgentConfiguration(
+      const result = await createOrUpgradeAgentConfiguration({
         auth,
-        {
-          assistant: {
-            ...assistant,
-            scope: bodyValidation.right.scope,
-            status: assistant.status as AgentStatus,
-          },
+        assistant: {
+          ...assistant,
+          scope: bodyValidation.right.scope,
+          status: assistant.status as AgentStatus,
         },
-        assistant.sId
-      );
+        agentConfigurationId: assistant.sId,
+        legacySingleActionMode: true,
+      });
       if (result.isErr()) {
         return apiError(req, res, {
           status_code: 500,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -283,16 +283,6 @@ export async function createOrUpgradeAgentConfiguration({
 
   let generationConfig: AgentGenerationConfigurationType | null = null;
 
-  if (generation) {
-    generationConfig = await createAgentGenerationConfiguration(auth, {
-      prompt: instructions || "", // @todo Daph remove this field
-      model: generation.model,
-      temperature: generation.temperature,
-      forceUseAtIteration:
-        generation.forceUseAtIteration ?? legacyForceGenerationAtIteration,
-    });
-  }
-
   // @todo FIX MULTI ACTIONS
   const maxToolsUsePerRun = actions.length + (generationConfig ? 1 : 0);
 
@@ -313,15 +303,14 @@ export async function createOrUpgradeAgentConfiguration({
   }
 
   if (generation) {
-    generationConfig = await createAgentGenerationConfiguration(
-      auth,
-      {
-        prompt: instructions || "", // @todo Daph remove this field
-        model: generation.model,
-        temperature: generation.temperature,
-      },
-      agentConfigurationRes.value
-    );
+    generationConfig = await createAgentGenerationConfiguration(auth, {
+      prompt: instructions || "", // @todo Daph remove this field
+      model: generation.model,
+      temperature: generation.temperature,
+      agentConfiguration: agentConfigurationRes.value,
+      forceUseAtIteration:
+        generation.forceUseAtIteration ?? legacyForceGenerationAtIteration,
+    });
   }
 
   const actionConfigs: AgentActionConfigurationType[] = [];

--- a/types/src/front/api_handlers/internal/agent_configuration.ts
+++ b/types/src/front/api_handlers/internal/agent_configuration.ts
@@ -59,73 +59,89 @@ export const PostOrPatchAgentConfigurationRequestBodySchema = t.type({
       t.literal("private"),
     ]),
     actions: t.array(
-      t.union([
-        t.type({
-          type: t.literal("retrieval_configuration"),
-          query: t.union([t.literal("auto"), t.literal("none")]),
-          relativeTimeFrame: t.union([
-            t.literal("auto"),
-            t.literal("none"),
-            t.type({
-              duration: t.number,
-              unit: TimeframeUnitCodec,
-            }),
-          ]),
-          topK: t.union([t.number, t.literal("auto")]),
-          dataSources: t.array(
-            t.type({
-              dataSourceId: t.string,
-              workspaceId: t.string,
-              filter: t.type({
-                tags: t.union([
-                  t.type({
-                    in: t.array(t.string),
-                    not: t.array(t.string),
-                  }),
-                  t.null,
-                ]),
-                parents: t.union([
-                  t.type({
-                    in: t.array(t.string),
-                    not: t.array(t.string),
-                  }),
-                  t.null,
-                ]),
+      t.intersection([
+        t.union([
+          t.type({
+            type: t.literal("retrieval_configuration"),
+            query: t.union([
+              t.type({
+                template: t.string,
               }),
-            })
-          ),
-        }),
-        t.type({
-          type: t.literal("dust_app_run_configuration"),
-          appWorkspaceId: t.string,
-          appId: t.string,
-        }),
-        t.type({
-          type: t.literal("tables_query_configuration"),
-          tables: t.array(
-            t.type({
-              workspaceId: t.string,
-              dataSourceId: t.string,
-              tableId: t.string,
-            })
-          ),
+              t.literal("auto"),
+              t.literal("none"),
+            ]),
+            relativeTimeFrame: t.union([
+              t.literal("auto"),
+              t.literal("none"),
+              t.type({
+                duration: t.number,
+                unit: TimeframeUnitCodec,
+              }),
+            ]),
+            topK: t.union([t.number, t.literal("auto")]),
+            dataSources: t.array(
+              t.type({
+                dataSourceId: t.string,
+                workspaceId: t.string,
+                filter: t.type({
+                  tags: t.union([
+                    t.type({
+                      in: t.array(t.string),
+                      not: t.array(t.string),
+                    }),
+                    t.null,
+                  ]),
+                  parents: t.union([
+                    t.type({
+                      in: t.array(t.string),
+                      not: t.array(t.string),
+                    }),
+                    t.null,
+                  ]),
+                }),
+              })
+            ),
+          }),
+          t.type({
+            type: t.literal("dust_app_run_configuration"),
+            appWorkspaceId: t.string,
+            appId: t.string,
+          }),
+          t.type({
+            type: t.literal("tables_query_configuration"),
+            tables: t.array(
+              t.type({
+                workspaceId: t.string,
+                dataSourceId: t.string,
+                tableId: t.string,
+              })
+            ),
+          }),
+        ]),
+        t.partial({
+          forceUseAtIteration: t.union([t.number, t.null]),
         }),
       ])
     ),
     generation: t.union([
       t.null,
-      t.type({
-        // enforce that the model is a supported model
-        // the modelId and providerId are checked together, so
-        // (gpt-4, anthropic) won't pass
-        model: new t.Type<SupportedModel>(
-          "SupportedModel",
-          isSupportedModel,
-          (i, c) => (isSupportedModel(i) ? t.success(i) : t.failure(i, c)),
-          t.identity
-        ),
-        temperature: t.number,
-      }),
+      t.intersection([
+        t.type({
+          // enforce that the model is a supported model
+          // the modelId and providerId are checked together, so
+          // (gpt-4, anthropic) won't pass
+          model: new t.Type<SupportedModel>(
+            "SupportedModel",
+            isSupportedModel,
+            (i, c) => (isSupportedModel(i) ? t.success(i) : t.failure(i, c)),
+            t.identity
+          ),
+          temperature: t.number,
+        }),
+        t.partial({
+          forceUseAtIteration: t.union([t.number, t.null]),
+        }),
+      ]),
     ]),
   }),
 });

--- a/types/src/front/api_handlers/internal/agent_configuration.ts
+++ b/types/src/front/api_handlers/internal/agent_configuration.ts
@@ -63,13 +63,7 @@ export const PostOrPatchAgentConfigurationRequestBodySchema = t.type({
         t.union([
           t.type({
             type: t.literal("retrieval_configuration"),
-            query: t.union([
-              t.type({
-                template: t.string,
-              }),
-              t.literal("auto"),
-              t.literal("none"),
-            ]),
+            query: t.union([t.literal("auto"), t.literal("none")]),
             relativeTimeFrame: t.union([
               t.literal("auto"),
               t.literal("none"),

--- a/types/src/front/assistant/actions/dust_app_run.ts
+++ b/types/src/front/assistant/actions/dust_app_run.ts
@@ -8,6 +8,8 @@ export type DustAppRunConfigurationType = {
 
   appWorkspaceId: string;
   appId: string;
+
+  forceUseAtIteration: number | null;
 };
 
 export type DustAppParameters = {

--- a/types/src/front/assistant/actions/retrieval.ts
+++ b/types/src/front/assistant/actions/retrieval.ts
@@ -60,6 +60,8 @@ export type RetrievalConfigurationType = {
   query: RetrievalQuery;
   relativeTimeFrame: RetrievalTimeframe;
   topK: number | "auto";
+
+  forceUseAtIteration: number | null;
 };
 
 /**

--- a/types/src/front/assistant/actions/tables_query.ts
+++ b/types/src/front/assistant/actions/tables_query.ts
@@ -10,6 +10,7 @@ export type TablesQueryConfigurationType = {
     dataSourceId: string;
     tableId: string;
   }>;
+  forceUseAtIteration: number | null;
 };
 
 export type TablesQueryActionType = {

--- a/types/src/front/assistant/agent.ts
+++ b/types/src/front/assistant/agent.ts
@@ -56,6 +56,7 @@ export type AgentGenerationConfigurationType = {
   id: ModelId;
   model: SupportedModel;
   temperature: number;
+  forceUseAtIteration: number | null;
 };
 
 /**
@@ -187,6 +188,7 @@ export interface TemplateAgentConfigurationType {
   generation: {
     model: SupportedModel;
     temperature: number;
+    forceUseAtIteration: number | null;
   } | null;
 
   name: string;


### PR DESCRIPTION
## Description

fixes https://github.com/dust-tt/dust/issues/4597

We're adding `forceUseAtIteration` on all our action configurations. This will allow to support "legacy" single action assistants in the new multi-actions model.

this PR adds the field (both in DB and in the types / input schemas) and also adds a new "legacyMode" flag when creating/updating assistants that automatically populates the field with the right values.

There is also a migration script so every actions and generation configs gets its backfilled `forceUseAtIteration`

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

First, initdb. Then deploy code. Then, run the migration script.