### PR TITLE
Delete column subsciption > stripeCustomerId

### DIFF
--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -521,7 +521,6 @@ export async function subscriptionForWorkspace(
       "sId",
       "startDate",
       "status",
-      "stripeCustomerId",
       "stripeSubscriptionId",
       "trialing",
     ],

--- a/front/lib/models/plan.ts
+++ b/front/lib/models/plan.ts
@@ -170,7 +170,6 @@ export class Subscription extends Model<
   declare planId: ForeignKey<Plan["id"]>;
   declare plan: NonAttribute<Plan>;
 
-  declare stripeCustomerId: string | null; // To be removed Daph
   declare stripeSubscriptionId: string | null;
 }
 Subscription.init(
@@ -216,10 +215,6 @@ Subscription.init(
     },
     endDate: {
       type: DataTypes.DATE,
-      allowNull: true,
-    },
-    stripeCustomerId: {
-      type: DataTypes.STRING,
       allowNull: true,
     },
     stripeSubscriptionId: {


### PR DESCRIPTION
## Description

All calls to this column were removed in: https://github.com/dust-tt/dust/pull/4664
Now we can remove the column from db

## Risk

/

## Deploy Plan

Run init_db **after** the code is deployed. 
