### PR TITLE
[Multi-Actions] Move instructions out of AgentGenerationConfiguration up to AgentConfiguration. 3/3

### DIFF
--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -967,11 +967,9 @@ export async function restoreAgentConfiguration(
 export async function createAgentGenerationConfiguration(
   auth: Authenticator,
   {
-    prompt, // @todo Daph remove this field
     model,
     temperature,
   }: {
-    prompt: string; // @todo Daph remove this field
     model: SupportedModel;
     temperature: number;
   }
@@ -990,7 +988,6 @@ export async function createAgentGenerationConfiguration(
   }
 
   const genConfig = await AgentGenerationConfiguration.create({
-    prompt: prompt, // @todo Daph remove this field
     providerId: model.providerId,
     modelId: model.modelId,
     temperature: temperature,

--- a/front/lib/models/assistant/agent.ts
+++ b/front/lib/models/assistant/agent.ts
@@ -28,7 +28,6 @@ export class AgentGenerationConfiguration extends Model<
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
-  declare prompt: string; // @daph to deprecate for multi-actions
   declare providerId: string;
   declare modelId: string;
   declare temperature: number;
@@ -49,10 +48,6 @@ AgentGenerationConfiguration.init(
       type: DataTypes.DATE,
       allowNull: false,
       defaultValue: DataTypes.NOW,
-    },
-    prompt: {
-      type: DataTypes.TEXT,
-      allowNull: false,
     },
     providerId: {
       type: DataTypes.STRING,

--- a/front/migrations/20240411_agent_config_instructions.ts
+++ b/front/migrations/20240411_agent_config_instructions.ts
@@ -9,7 +9,7 @@ const backfillAgentConfiguration = async (
   agent: AgentConfiguration,
   execute: boolean
 ): Promise<void> => {
-  const prompt = agent.generationConfiguration?.prompt;
+  const prompt = null; //const prompt = agent.generationConfiguration?.prompt;
   if (!prompt) {
     logger.info(`Skipping agent (no generation configuration) ${agent.id}`);
     return;
@@ -55,5 +55,8 @@ const backfillAgentConfigurations = async (execute: boolean) => {
 };
 
 makeScript({}, async ({ execute }) => {
+  throw new Error(
+    "Can't be run anymore since we've revmoved the prompt field from the agent generation configuration"
+  );
   await backfillAgentConfigurations(execute);
 });

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -254,7 +254,6 @@ export async function createOrUpgradeAgentConfiguration(
   let generationConfig: AgentGenerationConfigurationType | null = null;
   if (generation) {
     generationConfig = await createAgentGenerationConfiguration(auth, {
-      prompt: instructions || "", // @todo Daph remove this field
       model: generation.model,
       temperature: generation.temperature,
     });


### PR DESCRIPTION
## Description

Task: https://github.com/dust-tt/dust/issues/4596

We're moving out prompt out of AgentGenerationConfiguration up to AgentConfiguration.
This is the last PR, to remove the column.

New fiel introduced here: https://github.com/dust-tt/dust/pull/4684
Then code calls new field here: https://github.com/dust-tt/dust/pull/4689

## Risk

Can't be rolled back.

## Deploy Plan

Deploy to prod **then** run init_db.
