### PR TITLE
Add max_tools_use_per_run to AgentConfiguration

### DIFF
--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -746,6 +746,7 @@ export async function createAgentConfiguration(
     name,
     description,
     instructions,
+    maxToolsUseForRun,
     pictureUrl,
     status,
     scope,
@@ -755,6 +756,7 @@ export async function createAgentConfiguration(
     name: string;
     description: string;
     instructions: string | null;
+    maxToolsUseForRun: number;
     pictureUrl: string;
     status: AgentStatus;
     scope: Exclude<AgentConfigurationScope, "global">;
@@ -856,6 +858,7 @@ export async function createAgentConfiguration(
             name,
             description,
             instructions,
+            maxToolsUseForRun,
             pictureUrl,
             workspaceId: owner.id,
             generationConfigurationId: generation?.id || null,

--- a/front/lib/models/assistant/agent.ts
+++ b/front/lib/models/assistant/agent.ts
@@ -100,6 +100,8 @@ export class AgentConfiguration extends Model<
   declare workspaceId: ForeignKey<Workspace["id"]>;
   declare authorId: ForeignKey<User["id"]>;
 
+  declare maxToolsUseForRun: number;
+
   declare generationConfigurationId: ForeignKey<
     AgentGenerationConfiguration["id"]
   > | null;
@@ -154,6 +156,11 @@ AgentConfiguration.init(
     instructions: {
       type: DataTypes.TEXT,
       allowNull: true,
+    },
+    maxToolsUseForRun: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      defaultValue: 1,
     },
     pictureUrl: {
       type: DataTypes.TEXT,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -15,7 +15,6 @@ import {
 import { isLeft } from "fp-ts/lib/Either";
 import type * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
-import { max } from "lodash";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { trackAssistantCreated } from "@app/lib/amplitude/node";
@@ -252,8 +251,6 @@ export async function createOrUpgradeAgentConfiguration(
   }: t.TypeOf<typeof PostOrPatchAgentConfigurationRequestBodySchema>,
   agentConfigurationId?: string
 ): Promise<Result<AgentConfigurationType, Error>> {
-  let maxToolsUseForRun = actions.length;
-
   let generationConfig: AgentGenerationConfigurationType | null = null;
   if (generation) {
     generationConfig = await createAgentGenerationConfiguration(auth, {
@@ -261,8 +258,10 @@ export async function createOrUpgradeAgentConfiguration(
       model: generation.model,
       temperature: generation.temperature,
     });
-    maxToolsUseForRun += 1;
   }
+
+  // @todo FIX MULTI ACTIONS
+  const maxToolsUseForRun = actions.length + (generationConfig ? 1 : 0);
 
   const agentConfigurationRes = await createAgentConfiguration(auth, {
     name,


### PR DESCRIPTION
## Description

Just adds the new field with default value = 1
This will be backfilled here from front/migrations/20240412_force_use_at_iteration.ts

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Run init_db
