### PR TITLE
Fix: timeAgoFrom displays 'mn' for minutes

### DIFF
--- a/front/lib/utils.ts
+++ b/front/lib/utils.ts
@@ -69,7 +69,9 @@ export const timeAgoFrom = (
     return `${hours}${useLongFormat ? maybePlural(hours, " hour") : "h"}`;
   }
   if (minutes > 0) {
-    return `${minutes}${useLongFormat ? maybePlural(minutes, " minute") : "m"}`;
+    return `${minutes}${
+      useLongFormat ? maybePlural(minutes, " minute") : "mn"
+    }`;
   }
   return seconds + "s";
 };


### PR DESCRIPTION
Description
---
Fixes https://github.com/dust-tt/tasks/issues/643

As mentioned in issue, will write '4mn ago' (no 's')

So this is not confused with 'm' for 'month'

Risk
---
Limited, I checked places where this is displayed, works fine

Deploy Plan
---
Deploy front