### PR TITLE
[Multi-Actions] Invert genConfig & agentConfig relationship: migration

### DIFF
--- a/front/migrations/20240415_invert_agent_generation_config_fkey.ts
+++ b/front/migrations/20240415_invert_agent_generation_config_fkey.ts
@@ -7,7 +7,7 @@ import {
 import logger from "@app/logger/logger";
 import { makeScript } from "@app/scripts/helpers";
 
-const backfillActionConfigs = async (execute: boolean) => {
+const backfillGenerationConfigs = async (execute: boolean) => {
   const generationConfigs = await AgentGenerationConfiguration.findAll({
     where: {
       agentConfigurationId: null,
@@ -47,5 +47,5 @@ const backfillActionConfigs = async (execute: boolean) => {
 };
 
 makeScript({}, async ({ execute }) => {
-  await backfillActionConfigs(execute);
+  await backfillGenerationConfigs(execute);
 });

--- a/front/migrations/20240415_invert_agent_generation_config_fkey.ts
+++ b/front/migrations/20240415_invert_agent_generation_config_fkey.ts
@@ -1,0 +1,51 @@
+import * as _ from "lodash";
+
+import {
+  AgentConfiguration,
+  AgentGenerationConfiguration,
+} from "@app/lib/models/assistant/agent";
+import logger from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+
+const backfillActionConfigs = async (execute: boolean) => {
+  const generationConfigs = await AgentGenerationConfiguration.findAll({
+    where: {
+      agentConfigurationId: null,
+    },
+  });
+
+  logger.info(
+    `Found ${generationConfigs.length} retrieval configurations without agent configuration`
+  );
+
+  for (const chunk of _.chunk(generationConfigs, 16)) {
+    await Promise.all(
+      chunk.map(async (g) => {
+        const agent = await AgentConfiguration.findOne({
+          where: {
+            generationConfigurationId: g.id,
+          },
+        });
+        if (!agent) {
+          logger.warn(
+            `No agent found for retrieval configuration ${g.id}, destroying it`
+          );
+          if (execute) {
+            await g.destroy();
+          }
+          return;
+        }
+        logger.info(
+          `Backfilling generation configuration ${g.id} with \`agentConfigurationId=${agent.id}\` [execute: ${execute}]`
+        );
+        if (execute) {
+          await g.update({ agentConfigurationId: agent.id });
+        }
+      })
+    );
+  }
+};
+
+makeScript({}, async ({ execute }) => {
+  await backfillActionConfigs(execute);
+});


### PR DESCRIPTION
Description
---
Comes after #4687  and precedes #4712

Backfill AgentGenerationConfigs with the right foreign pkey

Risk
---
The new backfilled PK is not yet used in prod, so no direct risk (but following PR #4712 will be risky)

To be noted: removes AgentGenerationConfigs for which no related agent config exist => seems warranted

Deploy plan
---
- Merge & run on prodbox
