### PR TITLE
Fix: former migration type issue due to #4712

### DIFF
--- a/front/migrations/20240415_invert_agent_generation_config_fkey.ts
+++ b/front/migrations/20240415_invert_agent_generation_config_fkey.ts
@@ -9,6 +9,7 @@ import { makeScript } from "@app/scripts/helpers";
 
 const backfillGenerationConfigs = async (execute: boolean) => {
   const generationConfigs = await AgentGenerationConfiguration.findAll({
+    // @ts-expect-error agentConfigurationId was rendered non-nullable by #4712
     where: {
       agentConfigurationId: null,
     },


### PR DESCRIPTION
## Description

Looking for nulls became a type error when #4712 activated non-nullability of field "agentConfigurationId" in AgentGenerationConfiguration
