### PR TITLE
Fix: temp remove non-null constraint on genconfig fpk

### DIFF
--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -360,7 +360,9 @@ async function fetchWorkspaceAgentConfigurationsForView(
   ] = await Promise.all([
     AgentGenerationConfiguration.findAll({
       where: { agentConfigurationId: { [Op.in]: configurationIds } },
-    }).then(groupByAgentConfigurationId),
+      // TODO(pr 20240415) temporary inlined for type checking
+      // this should be refactored to use the groupByAgentConfigurationId function
+    }).then((list) => _.groupBy(list, "agentConfigurationId")),
     variant === "full"
       ? AgentRetrievalConfiguration.findAll({
           where: { agentConfigurationId: { [Op.in]: configurationIds } },

--- a/front/lib/models/assistant/agent.ts
+++ b/front/lib/models/assistant/agent.ts
@@ -28,7 +28,7 @@ export class AgentGenerationConfiguration extends Model<
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
-  declare agentConfigurationId: ForeignKey<AgentConfiguration["id"]>;
+  declare agentConfigurationId: ForeignKey<AgentConfiguration["id"] | null>;
 
   declare prompt: string; // @daph to deprecate for multi-actions
   declare providerId: string;
@@ -193,10 +193,10 @@ AgentConfiguration.init(
 
 // AgentGenerationConfiguration <> AgentConfiguration
 AgentConfiguration.hasMany(AgentGenerationConfiguration, {
-  foreignKey: { name: "agentConfigurationId", allowNull: false },
+  foreignKey: { name: "agentConfigurationId", allowNull: true },
 });
 AgentGenerationConfiguration.belongsTo(AgentConfiguration, {
-  foreignKey: { name: "agentConfigurationId", allowNull: false },
+  foreignKey: { name: "agentConfigurationId", allowNull: true },
 });
 
 //  Agent config <> Workspace

--- a/front/migrations/20240415_invert_agent_generation_config_fkey.ts
+++ b/front/migrations/20240415_invert_agent_generation_config_fkey.ts
@@ -9,7 +9,6 @@ import { makeScript } from "@app/scripts/helpers";
 
 const backfillGenerationConfigs = async (execute: boolean) => {
   const generationConfigs = await AgentGenerationConfiguration.findAll({
-    // @ts-expect-error agentConfigurationId was rendered non-nullable by #4712
     where: {
       agentConfigurationId: null,
     },


### PR DESCRIPTION
See this [thread](https://dust4ai.slack.com/archives/C05B529FHV1/p1713175186602859)

Removing non-null constraint on `agentConfigurationId` for `AgentGenerationConfiguration` model

Plan is to reinstate the constraint by reverting this PR and running `init_db` later today cf thread