### PR TITLE
Adding index name for WebcrawlerConfigurationHeader.{config, key}

### DIFF
--- a/connectors/src/lib/models/webcrawler.ts
+++ b/connectors/src/lib/models/webcrawler.ts
@@ -125,6 +125,7 @@ WebCrawlerConfigurationHeader.init(
       {
         unique: true,
         fields: ["webcrawlerConfigurationId", "key"],
+        name: "wch_webcrawlerConfigurationId_key",
       },
     ],
   }


### PR DESCRIPTION
## Description

Adding explicit index name because the auto generated one is too long, leading to an error while running initdb in connectors.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- deploy prod box
- run initdb in connectors>

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
