### PR TITLE
Setting metabase http timeout to 10 minutes

### DIFF
--- a/k8s/backend-configs/metabase-backend-config.yaml
+++ b/k8s/backend-configs/metabase-backend-config.yaml
@@ -7,3 +7,4 @@ spec:
     enabled: true
     oauthclientCredentials:
       secretName: iap-creds
+  timeoutSec: 600


### PR DESCRIPTION
## Description

Metabase fails on long running query if the HTTP connection fails. So we need to increase the HTTP timeout of Metabase
to allow running longer than 30 seconds query on it.
These query run on the read only replica so there is no risk.
The analytics team needs it.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
