### PR TITLE
Move model settings on AgentConfiguration

### DIFF
--- a/front/components/assistant/AssistantActions.tsx
+++ b/front/components/assistant/AssistantActions.tsx
@@ -196,7 +196,7 @@ export function RemoveAssistantFromWorkspaceDialog({
             status: "active",
             scope: "published",
             actions: detailedConfig.actions,
-            generation: agentConfiguration.generation,
+            generation: detailedConfig.generation,
             model: agentConfiguration.model,
           },
         };

--- a/front/components/assistant/AssistantActions.tsx
+++ b/front/components/assistant/AssistantActions.tsx
@@ -197,6 +197,7 @@ export function RemoveAssistantFromWorkspaceDialog({
             scope: "published",
             actions: detailedConfig.actions,
             generation: agentConfiguration.generation,
+            model: agentConfiguration.model,
           },
         };
 

--- a/front/components/assistant/GalleryAssistantPreviewContainer.tsx
+++ b/front/components/assistant/GalleryAssistantPreviewContainer.tsx
@@ -34,13 +34,12 @@ export function GalleryAssistantPreviewContainer({
     setTestModalAssistant?.(agentConfiguration);
   };
 
-  const { description, generation, lastAuthors, name, pictureUrl, scope } =
+  const { description, model, lastAuthors, name, pictureUrl, scope } =
     agentConfiguration;
 
   const isGlobal = scope === "global";
   const hasAccessToLargeModels = isUpgraded(plan);
-  const eligibleForTesting =
-    hasAccessToLargeModels || !isLargeModel(generation?.model);
+  const eligibleForTesting = hasAccessToLargeModels || !isLargeModel(model);
   const isTestable = !isGlobal && eligibleForTesting;
   return (
     <AssistantPreview

--- a/front/components/assistant/TryAssistant.tsx
+++ b/front/components/assistant/TryAssistant.tsx
@@ -223,7 +223,8 @@ export function usePreviewAssistant({
         tablesQueryConfiguration: builderState.tablesQueryConfiguration,
         scope: "private",
         dataSourceConfigurations: builderState.dataSourceConfigurations,
-        generationSettings: builderState.generationSettings,
+        modelConfiguration: builderState.modelConfiguration,
+        generationConfiguration: builderState.generationConfiguration,
       },
 
       agentConfigurationId: null,
@@ -251,7 +252,8 @@ export function usePreviewAssistant({
     builderState.dustAppConfiguration,
     builderState.tablesQueryConfiguration,
     builderState.dataSourceConfigurations,
-    builderState.generationSettings,
+    builderState.modelConfiguration,
+    builderState.generationConfiguration,
   ]);
 
   useEffect(() => {

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -18,7 +18,12 @@ import type { WorkspaceType } from "@dust-tt/types";
 import type { AppType } from "@dust-tt/types";
 import type { PlanType, SubscriptionType } from "@dust-tt/types";
 import type { PostOrPatchAgentConfigurationRequestBodySchema } from "@dust-tt/types";
-import { assertNever, isBuilder, removeNulls } from "@dust-tt/types";
+import {
+  assertNever,
+  GPT_3_5_TURBO_MODEL_CONFIG,
+  isBuilder,
+  removeNulls,
+} from "@dust-tt/types";
 import type * as t from "io-ts";
 import { useRouter } from "next/router";
 import { useCallback, useContext, useEffect, useMemo, useState } from "react";
@@ -50,6 +55,7 @@ import {
 } from "@app/components/sparkle/AppLayoutTitle";
 import { subNavigationBuild } from "@app/components/sparkle/navigation";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
+import { isUpgraded } from "@app/lib/plans/plan_codes";
 import { useSlackChannelsLinkedWithAgent } from "@app/lib/swr";
 import type { FetchAssistantTemplateResponse } from "@app/pages/api/w/[wId]/assistant/builder/templates/[tId]";
 
@@ -166,6 +172,15 @@ export default function AssistantBuilder({
   );
   const defaultScope =
     flow === "workspace_assistants" ? "workspace" : "private";
+
+  let modelConfiguration = initialBuilderState?.modelConfiguration ?? null;
+  if (modelConfiguration && !isUpgraded(plan)) {
+    modelConfiguration = {
+      providerId: GPT_3_5_TURBO_MODEL_CONFIG.providerId,
+      modelId: GPT_3_5_TURBO_MODEL_CONFIG.modelId,
+      temperature: 0.7,
+    };
+  }
 
   const [builderState, setBuilderState] = useState<AssistantBuilderState>(
     initialBuilderState

--- a/front/components/assistant_builder/InstructionScreen.tsx
+++ b/front/components/assistant_builder/InstructionScreen.tsx
@@ -20,7 +20,6 @@ import type {
   PlanType,
   Result,
   SUPPORTED_MODEL_CONFIGS,
-  SupportedModel,
 } from "@dust-tt/types";
 import type { WorkspaceType } from "@dust-tt/types";
 import {
@@ -32,6 +31,7 @@ import {
   GEMINI_PRO_DEFAULT_MODEL_CONFIG,
   GPT_3_5_TURBO_MODEL_CONFIG,
   GPT_4_TURBO_MODEL_CONFIG,
+  isSupportedModel,
   MISTRAL_LARGE_MODEL_CONFIG,
   MISTRAL_MEDIUM_MODEL_CONFIG,
   MISTRAL_SMALL_MODEL_CONFIG,
@@ -195,21 +195,25 @@ function AdvancedSettings({
                 <div className="z-[120]">
                   {USED_MODEL_CONFIGS.filter(
                     (m) => !(m.largeModel && !isUpgraded(plan))
-                  ).map((modelConfig) => (
+                  ).map((modelConfig: ModelConfig) => (
                     <DropdownMenu.Item
                       key={modelConfig.modelId}
                       icon={MODEL_PROVIDER_LOGOS[modelConfig.providerId]}
                       description={modelConfig.shortDescription}
                       label={modelConfig.displayName}
                       onClick={() => {
-                        setModelConfiguration({
-                          ...modelConfiguration,
-                          ...({
-                            modelId: modelConfig.modelId,
-                            providerId: modelConfig.providerId,
-                            // safe because the SupportedModel is derived from the SUPPORTED_MODEL_CONFIGS array
-                          } as SupportedModel),
-                        });
+                        const selectedModel = {
+                          providerId: modelConfig.providerId,
+                          modelId: modelConfig.modelId,
+                        };
+                        if (isSupportedModel(selectedModel)) {
+                          setModelConfiguration({
+                            ...modelConfiguration,
+                            ...modelConfig,
+                          });
+                        } else {
+                          console.error("Unsupported model"); // unreachable
+                        }
                       }}
                     />
                   ))}

--- a/front/components/assistant_builder/InstructionScreen.tsx
+++ b/front/components/assistant_builder/InstructionScreen.tsx
@@ -114,12 +114,12 @@ export function InstructionScreen({
         <div className="self-end">
           <AdvancedSettings
             plan={plan}
-            generationSettings={builderState.generationSettings}
-            setGenerationSettings={(generationSettings) => {
+            modelConfiguration={builderState.modelConfiguration}
+            setModelConfiguration={(modelConfiguration) => {
               setEdited(true);
               setBuilderState((state) => ({
                 ...state,
-                generationSettings,
+                modelConfiguration,
               }));
             }}
           />
@@ -148,18 +148,16 @@ export function InstructionScreen({
 
 function AdvancedSettings({
   plan,
-  generationSettings,
-  setGenerationSettings,
+  modelConfiguration,
+  setModelConfiguration,
 }: {
   plan: PlanType;
-  generationSettings: AssistantBuilderState["generationSettings"];
-  setGenerationSettings: (
-    generationSettingsSettings: AssistantBuilderState["generationSettings"]
+  modelConfiguration: AssistantBuilderState["modelConfiguration"];
+  setModelConfiguration: (
+    newModelConfig: AssistantBuilderState["modelConfiguration"]
   ) => void;
 }) {
-  const supportedModelConfig = getSupportedModelConfig(
-    generationSettings.modelSettings
-  );
+  const supportedModelConfig = getSupportedModelConfig(modelConfiguration);
   if (!supportedModelConfig) {
     // unreachable
     alert("Unsupported model");
@@ -186,8 +184,7 @@ function AdvancedSettings({
                   type="select"
                   labelVisible={true}
                   label={
-                    getSupportedModelConfig(generationSettings.modelSettings)
-                      .displayName
+                    getSupportedModelConfig(modelConfiguration).displayName
                   }
                   variant="secondary"
                   hasMagnifying={false}
@@ -205,13 +202,13 @@ function AdvancedSettings({
                       description={modelConfig.shortDescription}
                       label={modelConfig.displayName}
                       onClick={() => {
-                        setGenerationSettings({
-                          ...generationSettings,
-                          modelSettings: {
+                        setModelConfiguration({
+                          ...modelConfiguration,
+                          ...({
                             modelId: modelConfig.modelId,
                             providerId: modelConfig.providerId,
                             // safe because the SupportedModel is derived from the SUPPORTED_MODEL_CONFIGS array
-                          } as SupportedModel,
+                          } as SupportedModel),
                         });
                       }}
                     />
@@ -231,7 +228,7 @@ function AdvancedSettings({
                   labelVisible={true}
                   label={
                     getCreativityLevelFromTemperature(
-                      generationSettings?.temperature
+                      modelConfiguration.temperature
                     ).label
                   }
                   variant="secondary"
@@ -245,8 +242,8 @@ function AdvancedSettings({
                     key={label}
                     label={label}
                     onClick={() => {
-                      setGenerationSettings({
-                        ...generationSettings,
+                      setModelConfiguration({
+                        ...modelConfiguration,
                         temperature: value,
                       });
                     }}

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -1,11 +1,13 @@
 import type {
   AgentConfigurationScope,
+  AgentGenerationConfigurationType,
+  AgentModelConfigurationType,
   AppType,
   ContentNode,
   DataSourceType,
-  SupportedModel,
   TimeframeUnit,
 } from "@dust-tt/types";
+import { GPT_4_TURBO_MODEL_CONFIG } from "@dust-tt/types";
 
 export const ACTION_MODES = [
   "GENERIC",
@@ -50,15 +52,13 @@ export type AssistantBuilderState = {
   };
   dustAppConfiguration: AssistantBuilderDustAppConfiguration | null;
   tablesQueryConfiguration: Record<string, AssistantBuilderTableConfiguration>;
+  modelConfiguration: AgentModelConfigurationType;
+  generationConfiguration: AgentGenerationConfigurationType | null;
   handle: string | null;
   description: string | null;
   scope: Exclude<AgentConfigurationScope, "global">;
   instructions: string | null;
   avatarUrl: string | null;
-  generationSettings: {
-    modelSettings: SupportedModel;
-    temperature: number;
-  };
 };
 
 export type AssistantBuilderInitialState = {
@@ -69,13 +69,35 @@ export type AssistantBuilderInitialState = {
   timeFrame: AssistantBuilderState["timeFrame"] | null;
   dustAppConfiguration: AssistantBuilderState["dustAppConfiguration"];
   tablesQueryConfiguration: AssistantBuilderState["tablesQueryConfiguration"];
+  modelConfiguration: AssistantBuilderState["modelConfiguration"];
+  generationConfiguration: AssistantBuilderState["generationConfiguration"];
   handle: string;
   description: string;
   scope: Exclude<AgentConfigurationScope, "global">;
-  instructions: string;
   avatarUrl: string | null;
-  generationSettings: {
-    modelSettings: SupportedModel;
-    temperature: number;
-  } | null;
+  instructions: string;
+};
+
+export const DEFAULT_ASSISTANT_STATE: AssistantBuilderState = {
+  actionMode: "GENERIC",
+  dataSourceConfigurations: {},
+  timeFrame: {
+    value: 1,
+    unit: "month",
+  },
+  dustAppConfiguration: null,
+  tablesQueryConfiguration: {},
+  handle: null,
+  scope: "private",
+  description: null,
+  instructions: null,
+  avatarUrl: null,
+  modelConfiguration: {
+    modelId: GPT_4_TURBO_MODEL_CONFIG.modelId,
+    providerId: GPT_4_TURBO_MODEL_CONFIG.providerId,
+    temperature: 0.7,
+  },
+  generationConfiguration: {
+    forceUseAtIteration: null,
+  },
 };

--- a/front/lib/amplitude/node/index.ts
+++ b/front/lib/amplitude/node/index.ts
@@ -139,9 +139,7 @@ export function trackUserMessage({
     mentionsCount: userMessage.mentions.length,
     conversationId,
     generationModels: removeNulls(
-      agentMessages.map(
-        (am) => am.configuration.generation?.model.modelId || null
-      )
+      agentMessages.map((am) => am.configuration.model.modelId || null)
     ),
     // We are mostly interested in tracking the usage of non global agents,
     // so if there is at least one non global agent in the list, that's enough to set
@@ -245,7 +243,7 @@ export function trackAssistantCreated(
     assistantScope: assistant.scope,
     assistantActionType: action?.type || "",
     assistantVersion: assistant.version,
-    assistantModel: assistant.generation?.model.modelId,
+    assistantModel: assistant.model.modelId,
   });
   amplitude.track(
     `user-${userId}`,

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -535,7 +535,7 @@ export async function* runRetrieval(
 
   const params = paramsRes.value;
 
-  const model = configuration.generation?.model;
+  const model = configuration.model;
 
   let topK = 16;
 

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -342,7 +342,7 @@ export async function* runAgent(
   }
 
   // Then run the generation if a configuration is present.
-  if (configuration.generation !== null) {
+  if (fullConfiguration.generation !== null) {
     const eventStream = runGeneration(
       auth,
       fullConfiguration,

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -753,7 +753,7 @@ async function isSelfHostedImageWithValidContentType(pictureUrl: string) {
 
 type AgentConfigurationWithoutActionsType = Omit<
   AgentConfigurationType,
-  "actions"
+  "actions" | "generation"
 >;
 
 export async function createAgentConfiguration(
@@ -767,7 +767,6 @@ export async function createAgentConfiguration(
     status,
     scope,
     model,
-    generation,
     agentConfigurationId,
   }: {
     name: string;
@@ -778,7 +777,6 @@ export async function createAgentConfiguration(
     status: AgentStatus;
     scope: Exclude<AgentConfigurationScope, "global">;
     model: AgentModelConfigurationType;
-    generation: AgentGenerationConfigurationType | null;
     agentConfigurationId?: string;
   }
 ): Promise<Result<AgentConfigurationWithoutActionsType, Error>> {
@@ -882,7 +880,6 @@ export async function createAgentConfiguration(
             maxToolsUsePerRun: maxToolsUsePerRun,
             pictureUrl,
             workspaceId: owner.id,
-            generationConfigurationId: null,
             authorId: user.id,
           },
           {
@@ -922,7 +919,6 @@ export async function createAgentConfiguration(
         ...agentModel,
         temperature: agent.temperature,
       },
-      generation,
     };
 
     agentConfiguration.userListStatus = agentUserListStatus({

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -13,7 +13,6 @@ import type {
   Result,
   RetrievalQuery,
   RetrievalTimeframe,
-  SupportedModel,
   WorkspaceType,
 } from "@dust-tt/types";
 import {
@@ -894,12 +893,14 @@ export async function createAgentConfiguration(
     );
 
     const agentModel = {
-      ...({
-        providerId: agent.providerId,
-        modelId: agent.modelId,
-      } as SupportedModel),
-      temperature: agent.temperature,
+      providerId: agent.providerId,
+      modelId: agent.modelId,
     };
+    if (!isSupportedModel(agentModel)) {
+      throw new Error(
+        `Unknown model ${agentModel.providerId}/${agentModel.modelId}.`
+      );
+    }
 
     /*
      * Final rendering.
@@ -917,7 +918,10 @@ export async function createAgentConfiguration(
       instructions: agent.instructions,
       pictureUrl: agent.pictureUrl,
       status: agent.status,
-      model: agentModel,
+      model: {
+        ...agentModel,
+        temperature: agent.temperature,
+      },
       generation,
     };
 

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -325,9 +325,9 @@ export async function* runGeneration(
     throw new Error("Unexpected unauthenticated call to `runGeneration`");
   }
 
-  const c = configuration.generation;
+  const model = configuration.model;
 
-  if (!c) {
+  if (!model) {
     yield {
       type: "generation_error",
       created: Date.now(),
@@ -341,8 +341,6 @@ export async function* runGeneration(
     };
     return;
   }
-
-  const { model } = c;
 
   if (isLargeModel(model) && !auth.isUpgraded()) {
     yield {
@@ -358,7 +356,7 @@ export async function* runGeneration(
     return;
   }
 
-  const contextSize = getSupportedModelConfig(c.model).contextSize;
+  const contextSize = getSupportedModelConfig(model).contextSize;
 
   const MIN_GENERATION_TOKENS = 2048;
 
@@ -397,7 +395,7 @@ export async function* runGeneration(
   );
   config.MODEL.provider_id = model.providerId;
   config.MODEL.model_id = model.modelId;
-  config.MODEL.temperature = c.temperature;
+  config.MODEL.temperature = model.temperature;
 
   // This is the console.log you want to uncomment to generate inputs for the generator app.
   // console.log(
@@ -412,7 +410,6 @@ export async function* runGeneration(
       workspaceId: conversation.owner.sId,
       conversationId: conversation.sId,
       model: model,
-      temperature: c.temperature,
     },
     "[ASSISTANT_TRACE] Generation exection"
   );

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -25,6 +25,7 @@ import {
 } from "@dust-tt/types";
 import { DustAPI } from "@dust-tt/types";
 
+import { DEFAULT_ASSISTANT_STATE } from "@app/components/assistant_builder/types";
 import { GLOBAL_AGENTS_SID } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { prodAPICredentialsForOwner } from "@app/lib/auth";
@@ -91,10 +92,12 @@ async function _getHelperGlobalAgent(
     ? {
         providerId: GPT_3_5_TURBO_MODEL_CONFIG.providerId,
         modelId: GPT_3_5_TURBO_MODEL_CONFIG.modelId,
+        temperature: 0.2,
       }
     : {
         providerId: GPT_4_TURBO_MODEL_CONFIG.providerId,
         modelId: GPT_4_TURBO_MODEL_CONFIG.modelId,
+        temperature: 0.2,
       };
   return {
     id: -1,
@@ -109,10 +112,8 @@ async function _getHelperGlobalAgent(
     status: "active",
     userListStatus: "in-list",
     scope: "global",
+    model,
     generation: {
-      id: -1,
-      model,
-      temperature: 0.2,
       forceUseAtIteration: 0,
     },
     actions: [],
@@ -138,13 +139,12 @@ async function _getGPT35TurboGlobalAgent({
     status,
     scope: "global",
     userListStatus: status === "active" ? "in-list" : "not-in-list",
-    generation: {
-      id: -1,
-      model: {
-        providerId: GPT_3_5_TURBO_MODEL_CONFIG.providerId,
-        modelId: GPT_3_5_TURBO_MODEL_CONFIG.modelId,
-      },
+    model: {
+      providerId: GPT_3_5_TURBO_MODEL_CONFIG.providerId,
+      modelId: GPT_3_5_TURBO_MODEL_CONFIG.modelId,
       temperature: 0.7,
+    },
+    generation: {
       forceUseAtIteration: 0,
     },
     actions: [],
@@ -170,14 +170,12 @@ async function _getGPT4GlobalAgent({
     status,
     scope: "global",
     userListStatus: status === "active" ? "in-list" : "not-in-list",
-    generation: {
-      id: -1,
-      model: {
-        providerId: GPT_4_TURBO_MODEL_CONFIG.providerId,
-        modelId: GPT_4_TURBO_MODEL_CONFIG.modelId,
-      },
-
+    model: {
+      providerId: GPT_4_TURBO_MODEL_CONFIG.providerId,
+      modelId: GPT_4_TURBO_MODEL_CONFIG.modelId,
       temperature: 0.7,
+    },
+    generation: {
       forceUseAtIteration: 0,
     },
     actions: [],
@@ -203,13 +201,12 @@ async function _getClaudeInstantGlobalAgent({
     status,
     scope: "global",
     userListStatus: status === "active" ? "in-list" : "not-in-list",
-    generation: {
-      id: -1,
-      model: {
-        providerId: CLAUDE_INSTANT_DEFAULT_MODEL_CONFIG.providerId,
-        modelId: CLAUDE_INSTANT_DEFAULT_MODEL_CONFIG.modelId,
-      },
+    model: {
+      providerId: CLAUDE_INSTANT_DEFAULT_MODEL_CONFIG.providerId,
+      modelId: CLAUDE_INSTANT_DEFAULT_MODEL_CONFIG.modelId,
       temperature: 0.7,
+    },
+    generation: {
       forceUseAtIteration: 0,
     },
     actions: [],
@@ -241,13 +238,12 @@ async function _getClaude2GlobalAgent({
     status,
     scope: "global",
     userListStatus: status === "active" ? "in-list" : "not-in-list",
-    generation: {
-      id: -1,
-      model: {
-        providerId: CLAUDE_2_DEFAULT_MODEL_CONFIG.providerId,
-        modelId: CLAUDE_2_DEFAULT_MODEL_CONFIG.modelId,
-      },
+    model: {
+      providerId: CLAUDE_2_DEFAULT_MODEL_CONFIG.providerId,
+      modelId: CLAUDE_2_DEFAULT_MODEL_CONFIG.modelId,
       temperature: 0.7,
+    },
+    generation: {
       forceUseAtIteration: 0,
     },
     actions: [],
@@ -281,13 +277,12 @@ async function _getClaude3HaikuGlobalAgent({
     status,
     scope: "global",
     userListStatus: status === "active" ? "in-list" : "not-in-list",
-    generation: {
-      id: -1,
-      model: {
-        providerId: CLAUDE_3_HAIKU_DEFAULT_MODEL_CONFIG.providerId,
-        modelId: CLAUDE_3_HAIKU_DEFAULT_MODEL_CONFIG.modelId,
-      },
+    model: {
+      providerId: CLAUDE_3_HAIKU_DEFAULT_MODEL_CONFIG.providerId,
+      modelId: CLAUDE_3_HAIKU_DEFAULT_MODEL_CONFIG.modelId,
       temperature: 0.7,
+    },
+    generation: {
       forceUseAtIteration: 0,
     },
     actions: [],
@@ -320,13 +315,12 @@ async function _getClaude3SonnetGlobalAgent({
     status,
     scope: "global",
     userListStatus: status === "active" ? "in-list" : "not-in-list",
-    generation: {
-      id: -1,
-      model: {
-        providerId: CLAUDE_3_SONNET_DEFAULT_MODEL_CONFIG.providerId,
-        modelId: CLAUDE_3_SONNET_DEFAULT_MODEL_CONFIG.modelId,
-      },
+    model: {
+      providerId: CLAUDE_3_SONNET_DEFAULT_MODEL_CONFIG.providerId,
+      modelId: CLAUDE_3_SONNET_DEFAULT_MODEL_CONFIG.modelId,
       temperature: 0.7,
+    },
+    generation: {
       forceUseAtIteration: 0,
     },
     actions: [],
@@ -358,13 +352,12 @@ async function _getClaude3OpusGlobalAgent({
     status,
     scope: "global",
     userListStatus: status === "active" ? "in-list" : "not-in-list",
-    generation: {
-      id: -1,
-      model: {
-        providerId: CLAUDE_3_OPUS_DEFAULT_MODEL_CONFIG.providerId,
-        modelId: CLAUDE_3_OPUS_DEFAULT_MODEL_CONFIG.modelId,
-      },
+    model: {
+      providerId: CLAUDE_3_OPUS_DEFAULT_MODEL_CONFIG.providerId,
+      modelId: CLAUDE_3_OPUS_DEFAULT_MODEL_CONFIG.modelId,
       temperature: 0.7,
+    },
+    generation: {
       forceUseAtIteration: 0,
     },
     actions: [],
@@ -396,13 +389,12 @@ async function _getMistralLargeGlobalAgent({
     status,
     scope: "global",
     userListStatus: status === "active" ? "in-list" : "not-in-list",
-    generation: {
-      id: -1,
-      model: {
-        providerId: MISTRAL_LARGE_MODEL_CONFIG.providerId,
-        modelId: MISTRAL_LARGE_MODEL_CONFIG.modelId,
-      },
+    model: {
+      providerId: MISTRAL_LARGE_MODEL_CONFIG.providerId,
+      modelId: MISTRAL_LARGE_MODEL_CONFIG.modelId,
       temperature: 0.7,
+    },
+    generation: {
       forceUseAtIteration: 0,
     },
     actions: [],
@@ -434,13 +426,12 @@ async function _getMistralMediumGlobalAgent({
     status,
     scope: "global",
     userListStatus: status === "active" ? "in-list" : "not-in-list",
-    generation: {
-      id: -1,
-      model: {
-        providerId: MISTRAL_MEDIUM_MODEL_CONFIG.providerId,
-        modelId: MISTRAL_MEDIUM_MODEL_CONFIG.modelId,
-      },
+    model: {
+      providerId: MISTRAL_MEDIUM_MODEL_CONFIG.providerId,
+      modelId: MISTRAL_MEDIUM_MODEL_CONFIG.modelId,
       temperature: 0.7,
+    },
+    generation: {
       forceUseAtIteration: 0,
     },
     actions: [],
@@ -466,13 +457,12 @@ async function _getMistralSmallGlobalAgent({
     status,
     scope: "global",
     userListStatus: status === "active" ? "in-list" : "not-in-list",
-    generation: {
-      id: -1,
-      model: {
-        providerId: MISTRAL_SMALL_MODEL_CONFIG.providerId,
-        modelId: MISTRAL_SMALL_MODEL_CONFIG.modelId,
-      },
+    model: {
+      providerId: MISTRAL_SMALL_MODEL_CONFIG.providerId,
+      modelId: MISTRAL_SMALL_MODEL_CONFIG.modelId,
       temperature: 0.7,
+    },
+    generation: {
       forceUseAtIteration: 0,
     },
     actions: [],
@@ -503,13 +493,12 @@ async function _getGeminiProGlobalAgent({
     status,
     scope: "global",
     userListStatus: status === "active" ? "in-list" : "not-in-list",
-    generation: {
-      id: -1,
-      model: {
-        providerId: GEMINI_PRO_DEFAULT_MODEL_CONFIG.providerId,
-        modelId: GEMINI_PRO_DEFAULT_MODEL_CONFIG.modelId,
-      },
+    model: {
+      providerId: GEMINI_PRO_DEFAULT_MODEL_CONFIG.providerId,
+      modelId: GEMINI_PRO_DEFAULT_MODEL_CONFIG.modelId,
       temperature: 0.7,
+    },
+    generation: {
       forceUseAtIteration: 0,
     },
     actions: [],
@@ -564,7 +553,10 @@ async function _getManagedDataSourceAgent(
       status: "disabled_by_admin",
       scope: "global",
       userListStatus: "not-in-list",
-      generation: null,
+      model: DEFAULT_ASSISTANT_STATE.modelConfiguration,
+      generation: {
+        forceUseAtIteration: 1,
+      },
       actions: [],
     };
   }
@@ -587,6 +579,7 @@ async function _getManagedDataSourceAgent(
       status: "disabled_missing_datasource",
       scope: "global",
       userListStatus: "not-in-list",
+      model: DEFAULT_ASSISTANT_STATE.modelConfiguration,
       generation: null,
       actions: [],
     };
@@ -605,18 +598,11 @@ async function _getManagedDataSourceAgent(
     status: "active",
     scope: "global",
     userListStatus: "in-list",
-    generation: {
-      id: -1,
-      model: !auth.isUpgraded()
-        ? {
-            providerId: GPT_3_5_TURBO_MODEL_CONFIG.providerId,
-            modelId: GPT_3_5_TURBO_MODEL_CONFIG.modelId,
-          }
-        : {
-            providerId: GPT_4_TURBO_MODEL_CONFIG.providerId,
-            modelId: GPT_4_TURBO_MODEL_CONFIG.modelId,
-          },
+    model: {
+      ...DEFAULT_ASSISTANT_STATE.modelConfiguration,
       temperature: 0.4,
+    },
+    generation: {
       forceUseAtIteration: 1,
     },
     actions: [
@@ -792,6 +778,7 @@ async function _getDustGlobalAgent(
       status: "disabled_by_admin",
       scope: "global",
       userListStatus: "not-in-list",
+      model: DEFAULT_ASSISTANT_STATE.modelConfiguration,
       generation: null,
       actions: [],
     };
@@ -823,6 +810,7 @@ async function _getDustGlobalAgent(
       status: "disabled_missing_datasource",
       scope: "global",
       userListStatus: "not-in-list",
+      model: DEFAULT_ASSISTANT_STATE.modelConfiguration,
       generation: null,
       actions: [],
     };
@@ -843,18 +831,11 @@ async function _getDustGlobalAgent(
     status: "active",
     scope: "global",
     userListStatus: "in-list",
-    generation: {
-      id: -1,
-      model: !auth.isUpgraded()
-        ? {
-            providerId: GPT_3_5_TURBO_MODEL_CONFIG.providerId,
-            modelId: GPT_3_5_TURBO_MODEL_CONFIG.modelId,
-          }
-        : {
-            providerId: GPT_4_TURBO_MODEL_CONFIG.providerId,
-            modelId: GPT_4_TURBO_MODEL_CONFIG.modelId,
-          },
+    model: {
+      ...DEFAULT_ASSISTANT_STATE.modelConfiguration,
       temperature: 0.4,
+    },
+    generation: {
       forceUseAtIteration: 1,
     },
     actions: [

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -536,6 +536,26 @@ async function _getManagedDataSourceAgent(
     throw new Error("Unexpected `auth` without `workspace`.");
   }
 
+  if (!auth.isUpgraded()) {
+    return {
+      id: -1,
+      sId: agentId,
+      version: 0,
+      versionCreatedAt: null,
+      versionAuthorId: null,
+      name: name,
+      description,
+      instructions: null,
+      pictureUrl,
+      status: "disabled_free_workspace",
+      scope: "global",
+      userListStatus: "not-in-list",
+      model: DEFAULT_ASSISTANT_STATE.modelConfiguration,
+      generation: null,
+      actions: [],
+    };
+  }
+
   const prodCredentials = await prodAPICredentialsForOwner(owner);
 
   // Check if deactivated by an admin

--- a/front/lib/api/assistant/templates.ts
+++ b/front/lib/api/assistant/templates.ts
@@ -31,14 +31,17 @@ export async function generateMockAgentConfigurationFromTemplate(
     actions: removeNulls([getAction(template.presetAction)]),
     description: template.description ?? "",
     instructions: template.presetInstructions ?? "",
-    generation: {
-      model: {
+    model: {
+      ...({
         providerId: template.presetProviderId,
         modelId: template.presetModelId,
-      } as SupportedModel,
+      } as SupportedModel),
       temperature:
         ASSISTANT_CREATIVITY_LEVEL_TEMPERATURES[template.presetTemperature],
       forceUseAtIteration: 1,
+    },
+    generation: {
+      forceUseAtIteration: 0,
     },
     name: template.handle,
     scope: flow === "personal_assistants" ? "private" : "workspace",

--- a/front/lib/api/assistant/templates.ts
+++ b/front/lib/api/assistant/templates.ts
@@ -4,13 +4,13 @@ import type {
   DustAppRunConfigurationType,
   Result,
   RetrievalConfigurationType,
-  SupportedModel,
   TablesQueryConfigurationType,
   TemplateAgentConfigurationType,
 } from "@dust-tt/types";
 import {
   ASSISTANT_CREATIVITY_LEVEL_TEMPERATURES,
   Err,
+  isSupportedModel,
   Ok,
   removeNulls,
 } from "@dust-tt/types";
@@ -27,21 +27,26 @@ export async function generateMockAgentConfigurationFromTemplate(
     return new Err(new Error("Template not found"));
   }
 
+  const presetModel = {
+    providerId: template.presetProviderId,
+    modelId: template.presetModelId,
+  };
+
+  if (!isSupportedModel(presetModel)) {
+    return new Err(new Error("Unsupported model"));
+  }
+
   return new Ok({
     actions: removeNulls([getAction(template.presetAction)]),
     description: template.description ?? "",
     instructions: template.presetInstructions ?? "",
     model: {
-      ...({
-        providerId: template.presetProviderId,
-        modelId: template.presetModelId,
-      } as SupportedModel),
+      ...presetModel,
       temperature:
         ASSISTANT_CREATIVITY_LEVEL_TEMPERATURES[template.presetTemperature],
-      forceUseAtIteration: 1,
     },
     generation: {
-      forceUseAtIteration: 0,
+      forceUseAtIteration: null,
     },
     name: template.handle,
     scope: flow === "personal_assistants" ? "private" : "workspace",

--- a/front/lib/models/assistant/agent.ts
+++ b/front/lib/models/assistant/agent.ts
@@ -175,17 +175,17 @@ AgentConfiguration.init(
     providerId: {
       type: DataTypes.STRING,
       allowNull: false,
-      defaultValue: DEFAULT_ASSISTANT_STATE.modelConfiguration.providerId,
+      defaultValue: DEFAULT_ASSISTANT_STATE.modelConfiguration.providerId, // @todo MULTI_ACTIONS remove @daph
     },
     modelId: {
       type: DataTypes.STRING,
       allowNull: false,
-      defaultValue: DEFAULT_ASSISTANT_STATE.modelConfiguration.modelId,
+      defaultValue: DEFAULT_ASSISTANT_STATE.modelConfiguration.modelId, // @todo MULTI_ACTIONS remove @daph
     },
     temperature: {
       type: DataTypes.FLOAT,
       allowNull: false,
-      defaultValue: DEFAULT_ASSISTANT_STATE.modelConfiguration.temperature,
+      defaultValue: DEFAULT_ASSISTANT_STATE.modelConfiguration.temperature, // @todo MULTI_ACTIONS remove @daph
     },
     maxToolsUsePerRun: {
       type: DataTypes.INTEGER,

--- a/front/lib/models/assistant/agent.ts
+++ b/front/lib/models/assistant/agent.ts
@@ -13,6 +13,7 @@ import type {
 } from "sequelize";
 import { DataTypes, Model } from "sequelize";
 
+import { DEFAULT_ASSISTANT_STATE } from "@app/components/assistant_builder/types";
 import { User } from "@app/lib/models/user";
 import { Workspace } from "@app/lib/models/workspace";
 import { frontSequelize } from "@app/lib/resources/storage";
@@ -30,12 +31,11 @@ export class AgentGenerationConfiguration extends Model<
 
   declare agentConfigurationId: ForeignKey<AgentConfiguration["id"] | null>;
 
-  declare prompt: string; // @daph to deprecate for multi-actions
-  declare providerId: string;
-  declare modelId: string;
-  declare temperature: number;
-
   declare forceUseAtIteration: number | null;
+  declare prompt: string; // @todo MULTI_ACTIONS remove @daph
+  declare providerId: string; // @todo MULTI_ACTIONS remove @daph
+  declare modelId: string; // @todo MULTI_ACTIONS remove @daph
+  declare temperature: number; // @todo MULTI_ACTIONS remove @daph
 }
 AgentGenerationConfiguration.init(
   {
@@ -101,9 +101,12 @@ export class AgentConfiguration extends Model<
   declare name: string;
 
   declare description: string;
-  declare instructions: string | null;
-
   declare pictureUrl: string;
+
+  declare instructions: string | null;
+  declare providerId: string;
+  declare modelId: string;
+  declare temperature: number;
 
   declare workspaceId: ForeignKey<Workspace["id"]>;
   declare authorId: ForeignKey<User["id"]>;
@@ -161,18 +164,33 @@ AgentConfiguration.init(
       type: DataTypes.TEXT,
       allowNull: false,
     },
+    pictureUrl: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+    },
     instructions: {
       type: DataTypes.TEXT,
       allowNull: true,
+    },
+    providerId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      defaultValue: DEFAULT_ASSISTANT_STATE.modelConfiguration.providerId,
+    },
+    modelId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      defaultValue: DEFAULT_ASSISTANT_STATE.modelConfiguration.modelId,
+    },
+    temperature: {
+      type: DataTypes.FLOAT,
+      allowNull: false,
+      defaultValue: DEFAULT_ASSISTANT_STATE.modelConfiguration.temperature,
     },
     maxToolsUsePerRun: {
       type: DataTypes.INTEGER,
       allowNull: false,
       defaultValue: 1,
-    },
-    pictureUrl: {
-      type: DataTypes.TEXT,
-      allowNull: false,
     },
   },
   {

--- a/front/lib/models/assistant/agent.ts
+++ b/front/lib/models/assistant/agent.ts
@@ -113,10 +113,6 @@ export class AgentConfiguration extends Model<
 
   declare maxToolsUsePerRun: number;
 
-  declare generationConfigurationId: ForeignKey<
-    AgentGenerationConfiguration["id"]
-  > | null;
-
   declare author: NonAttribute<User>;
 }
 

--- a/front/migrations/20240415_invert_agent_generation_config_fkey.ts
+++ b/front/migrations/20240415_invert_agent_generation_config_fkey.ts
@@ -18,13 +18,17 @@ const backfillGenerationConfigs = async (execute: boolean) => {
     `Found ${generationConfigs.length} retrieval configurations without agent configuration`
   );
 
+  throw new Error(
+    "This should not be run anymore since generationConfigurationId has been removed from AgentConfiguration."
+  );
+
   for (const chunk of _.chunk(generationConfigs, 16)) {
     await Promise.all(
       chunk.map(async (g) => {
         const agent = await AgentConfiguration.findOne({
-          where: {
-            generationConfigurationId: g.id,
-          },
+          // where: {
+          //   generationConfigurationId: g.id,
+          // },
         });
         if (!agent) {
           logger.warn(

--- a/front/migrations/20240416_agent_config_model.ts
+++ b/front/migrations/20240416_agent_config_model.ts
@@ -1,0 +1,69 @@
+import {
+  AgentConfiguration,
+  AgentGenerationConfiguration,
+} from "@app/lib/models/assistant/agent";
+import logger from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+
+const backfillAgentConfiguration = async (
+  agent: AgentConfiguration,
+  execute: boolean
+): Promise<void> => {
+  const genConfigs = await AgentGenerationConfiguration.findAll({
+    where: {
+      id: agent.id,
+    },
+    attributes: ["id", "providerId", "modelId", "temperature"],
+  });
+
+  if (genConfigs.length > 1) {
+    throw new Error(
+      "Unexpected: legacy migration in which there could not be multiple generation configurations per agent"
+    );
+  }
+
+  if (genConfigs.length === 0) {
+    logger.info(
+      `Skipping agent (no generation configuration) ${agent.id}. --execute: ${execute}`
+    );
+    return;
+  }
+
+  const generation = genConfigs[0];
+
+  logger.info(
+    `Updating agent ${agent.id} from generation configuration ${generation.id}. --execute: ${execute}`
+  );
+  if (execute) {
+    await agent.update({
+      modelId: generation.modelId,
+      providerId: generation.providerId,
+      temperature: generation.temperature,
+    });
+  }
+};
+
+const backfillAgentConfigurations = async (execute: boolean) => {
+  // Fetch all agents that have no instructions
+  const agents = await AgentConfiguration.findAll({});
+
+  // Split agents into chunks of 16
+  const chunks: AgentConfiguration[][] = [];
+  for (let i = 0; i < agents.length; i += 16) {
+    chunks.push(agents.slice(i, i + 16));
+  }
+
+  // Process each chunk in parallel
+  for (let i = 0; i < chunks.length; i++) {
+    const chunk = chunks[i];
+    await Promise.all(
+      chunk.map(async (agent) => {
+        return backfillAgentConfiguration(agent, execute);
+      })
+    );
+  }
+};
+
+makeScript({}, async ({ execute }) => {
+  await backfillAgentConfigurations(execute);
+});

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -284,10 +284,8 @@ export async function createOrUpgradeAgentConfiguration({
     }
   }
 
-  let generationConfig: AgentGenerationConfigurationType | null = null;
-
   // @todo FIX MULTI ACTIONS
-  const maxToolsUsePerRun = actions.length + (generationConfig ? 1 : 0);
+  const maxToolsUsePerRun = actions.length + (generation !== null ? 1 : 0);
 
   const agentConfigurationRes = await createAgentConfiguration(auth, {
     name,
@@ -298,7 +296,6 @@ export async function createOrUpgradeAgentConfiguration({
     status,
     scope,
     model,
-    generation: generationConfig,
     agentConfigurationId,
   });
 
@@ -309,6 +306,8 @@ export async function createOrUpgradeAgentConfiguration({
   if (!isSupportedModel(model)) {
     return new Err(new Error("Unsupported model"));
   }
+
+  let generationConfig: AgentGenerationConfigurationType | null = null;
 
   if (generation) {
     generationConfig = await createAgentGenerationConfiguration(auth, {
@@ -384,6 +383,7 @@ export async function createOrUpgradeAgentConfiguration({
   const agentConfiguration: AgentConfigurationType = {
     ...agentConfigurationRes.value,
     actions: actionConfigs,
+    generation: generationConfig,
   };
 
   // We are not tracking draft agents

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -8,7 +8,9 @@ import type {
 } from "@dust-tt/types";
 import {
   assertNever,
+  Err,
   GetAgentConfigurationsQuerySchema,
+  isSupportedModel,
   Ok,
   PostOrPatchAgentConfigurationRequestBodySchema,
 } from "@dust-tt/types";
@@ -240,6 +242,7 @@ export async function createOrUpgradeAgentConfiguration({
   auth,
   assistant: {
     actions,
+    model,
     generation,
     name,
     description,
@@ -294,6 +297,7 @@ export async function createOrUpgradeAgentConfiguration({
     pictureUrl,
     status,
     scope,
+    model,
     generation: generationConfig,
     agentConfigurationId,
   });
@@ -302,11 +306,14 @@ export async function createOrUpgradeAgentConfiguration({
     return agentConfigurationRes;
   }
 
+  if (!isSupportedModel(model)) {
+    return new Err(new Error("Unsupported model"));
+  }
+
   if (generation) {
     generationConfig = await createAgentGenerationConfiguration(auth, {
       prompt: instructions || "", // @todo Daph remove this field
-      model: generation.model,
-      temperature: generation.temperature,
+      model,
       agentConfiguration: agentConfigurationRes.value,
       forceUseAtIteration:
         generation.forceUseAtIteration ?? legacyForceGenerationAtIteration,

--- a/front/pages/poke/[wId]/assistants/[aId]/index.tsx
+++ b/front/pages/poke/[wId]/assistants/[aId]/index.tsx
@@ -64,7 +64,7 @@ const DataSourcePage = ({
                     </div>
                     <div className="ml-4 text-sm text-element-700">
                       <div className="font-bold">model:</div>
-                      {JSON.stringify(a.generation?.model, null, 2)}
+                      {JSON.stringify(a.model, null, 2)}
                     </div>
                     {a.actions.map((action, index) =>
                       isRetrievalConfiguration(action) ? (

--- a/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
@@ -193,12 +193,8 @@ export default function EditAssistant({
         description: agentConfiguration.description,
         instructions: agentConfiguration.instructions || "", // TODO we don't support null in the UI yet
         avatarUrl: agentConfiguration.pictureUrl,
-        generationSettings: agentConfiguration.generation
-          ? {
-              modelSettings: agentConfiguration.generation.model,
-              temperature: agentConfiguration.generation.temperature,
-            }
-          : null,
+        modelConfiguration: agentConfiguration.model,
+        generationConfiguration: agentConfiguration.generation,
       }}
       agentConfigurationId={agentConfiguration.sId}
       baseUrl={baseUrl}

--- a/front/pages/w/[wId]/builder/assistants/new.tsx
+++ b/front/pages/w/[wId]/builder/assistants/new.tsx
@@ -240,12 +240,8 @@ export default function CreateAssistant({
               description: agentConfiguration.description,
               instructions: agentConfiguration.instructions || "", // TODO we don't support null in the UI yet
               avatarUrl: null,
-              generationSettings: agentConfiguration.generation
-                ? {
-                    modelSettings: agentConfiguration.generation.model,
-                    temperature: agentConfiguration.generation.temperature,
-                  }
-                : null,
+              modelConfiguration: agentConfiguration.model,
+              generationConfiguration: agentConfiguration.generation,
             }
           : null
       }

--- a/types/src/front/api_handlers/internal/agent_configuration.ts
+++ b/types/src/front/api_handlers/internal/agent_configuration.ts
@@ -119,23 +119,23 @@ export const PostOrPatchAgentConfigurationRequestBodySchema = t.type({
     ),
     generation: t.union([
       t.null,
-      t.intersection([
-        t.type({
-          // enforce that the model is a supported model
-          // the modelId and providerId are checked together, so
-          // (gpt-4, anthropic) won't pass
-          model: new t.Type<SupportedModel>(
-            "SupportedModel",
-            isSupportedModel,
-            (i, c) => (isSupportedModel(i) ? t.success(i) : t.failure(i, c)),
-            t.identity
-          ),
-          temperature: t.number,
-        }),
-        t.partial({
-          forceUseAtIteration: t.union([t.number, t.null]),
-        }),
-      ]),
+      t.partial({
+        forceUseAtIteration: t.union([t.number, t.null]),
+      }),
+    ]),
+    model: t.intersection([
+      // enforce that the model is a supported model
+      // the modelId and providerId are checked together, so
+      // (gpt-4, anthropic) won't pass
+      new t.Type<SupportedModel>(
+        "SupportedModel",
+        isSupportedModel,
+        (i, c) => (isSupportedModel(i) ? t.success(i) : t.failure(i, c)),
+        t.identity
+      ),
+      t.type({
+        temperature: t.number,
+      }),
     ]),
   }),
 });

--- a/types/src/front/assistant/agent.ts
+++ b/types/src/front/assistant/agent.ts
@@ -159,9 +159,6 @@ export type LightAgentConfigurationType = {
   instructions: string | null;
   model: AgentModelConfigurationType;
 
-  // If undefined, no text generation.
-  generation: AgentGenerationConfigurationType | null;
-
   status: AgentConfigurationStatus;
   scope: AgentConfigurationScope;
 
@@ -183,6 +180,8 @@ export type AgentConfigurationType = LightAgentConfigurationType & {
   // If empty, no actions are performed, otherwise the actions are
   // performed.
   actions: AgentActionConfigurationType[];
+  // If null, no text generation.
+  generation: AgentGenerationConfigurationType | null;
 };
 
 export interface TemplateAgentConfigurationType {

--- a/types/src/front/assistant/agent.ts
+++ b/types/src/front/assistant/agent.ts
@@ -52,10 +52,11 @@ export type AgentActionSpecification = {
  * Agent Message configuration
  */
 
-export type AgentGenerationConfigurationType = {
-  id: ModelId;
-  model: SupportedModel;
+export type AgentModelConfigurationType = SupportedModel & {
   temperature: number;
+};
+
+export type AgentGenerationConfigurationType = {
   forceUseAtIteration: number | null;
 };
 
@@ -156,6 +157,7 @@ export type LightAgentConfigurationType = {
   versionAuthorId: ModelId | null;
 
   instructions: string | null;
+  model: AgentModelConfigurationType;
 
   // If undefined, no text generation.
   generation: AgentGenerationConfigurationType | null;
@@ -185,12 +187,8 @@ export type AgentConfigurationType = LightAgentConfigurationType & {
 
 export interface TemplateAgentConfigurationType {
   // If undefined, no text generation.
-  generation: {
-    model: SupportedModel;
-    temperature: number;
-    forceUseAtIteration: number | null;
-  } | null;
-
+  generation: AgentGenerationConfigurationType | null;
+  model: AgentModelConfigurationType;
   name: string;
   scope: AgentConfigurationScope;
   description: string;


### PR DESCRIPTION
## Description

This moves the model definition (providerId, modelId, temperature) up to the `AgentConfiguration` level. 
Most of the diff is about adjusting the types. 

I'm adding those new column immediately non nullable with the default value using the one from `DEFAULT_ASSISTANT_STATE`. There is a migration file to set them with the proper values from the AgentGenerationConfiguration model. 

I realize I'm at the same time adding the new column, writing on them and calling the data from the new location. 
I think this should be ok, I can always re-run the migration if needed. 

-> This is going to collide with https://github.com/dust-tt/dust/pull/4694 🙈    (rebased ✅ )

## Risk

Can be rolled back, we're not deleting the old columns. 

## Deploy Plan

Must run init_db to create the new fields: 
- Deploy prodbox 
    - run `./admin/init_db.sh`
    - run `env $(cat .env.local) npx tsx migrations/20240416_agent_config_model.ts --execute`
- Deploy prod.
