### PR TITLE
Poké: display plan name + code on the dropdown to upgrade to Enterprise

### DIFF
--- a/front/components/poke/subscriptions/EnterpriseUpgradeDialog.tsx
+++ b/front/components/poke/subscriptions/EnterpriseUpgradeDialog.tsx
@@ -200,7 +200,7 @@ export default function EnterpriseUpgradeDialog({
           🏢 Upgrade to Enterprise
         </PokeButton>
       </PokeDialogTrigger>
-      <PokeDialogContent className="bg-structure-50 sm:max-w-[425px]">
+      <PokeDialogContent className="bg-structure-50 sm:max-w-[600px]">
         <PokeDialogHeader>
           <PokeDialogTitle>Upgrade {owner.name} to Enterprise.</PokeDialogTitle>
           <PokeDialogDescription>
@@ -223,7 +223,7 @@ export default function EnterpriseUpgradeDialog({
                       .filter((plan) => plan.code.startsWith("ENT_"))
                       .map((plan) => ({
                         value: plan.code,
-                        display: plan.name,
+                        display: `${plan.name} (${plan.code})`,
                       }))}
                   />
                 </div>


### PR DESCRIPTION
## Description

Since only "code" is unique, we better display it on the dropdown. 
We had the case they use the same name for 2 plans. 

<img width="681" alt="Screenshot 2024-04-16 at 10 01 57" src="https://github.com/dust-tt/dust/assets/3803406/6fe8eb5c-e99a-4dd0-a9eb-bf5b4d10853d">



## Risk

/

## Deploy Plan

/ 
