### PR TITLE
enh: start refactoring runAgent

### DIFF
--- a/front/lib/api/assistant/actions/dust_app_run.ts
+++ b/front/lib/api/assistant/actions/dust_app_run.ts
@@ -222,13 +222,19 @@ export async function renderDustAppRunActionByModelId(
 // to fail, in which case an error event will be emitted and the AgentDustAppRunAction won't have
 // any output associated. The error is expected to be stored by the caller on the parent agent
 // message.
-export async function* runDustApp(
-  auth: Authenticator,
-  configuration: AgentConfigurationType,
-  conversation: ConversationType,
-  userMessage: UserMessageType,
-  agentMessage: AgentMessageType
-): AsyncGenerator<
+export async function* runDustApp({
+  auth,
+  configuration,
+  conversation,
+  userMessage,
+  agentMessage,
+}: {
+  auth: Authenticator;
+  configuration: AgentConfigurationType;
+  conversation: ConversationType;
+  userMessage: UserMessageType;
+  agentMessage: AgentMessageType;
+}): AsyncGenerator<
   | DustAppRunParamsEvent
   | DustAppRunBlockEvent
   | DustAppRunSuccessEvent

--- a/front/lib/api/assistant/actions/dust_app_run.ts
+++ b/front/lib/api/assistant/actions/dust_app_run.ts
@@ -222,19 +222,20 @@ export async function renderDustAppRunActionByModelId(
 // to fail, in which case an error event will be emitted and the AgentDustAppRunAction won't have
 // any output associated. The error is expected to be stored by the caller on the parent agent
 // message.
-export async function* runDustApp({
-  auth,
-  configuration,
-  conversation,
-  userMessage,
-  agentMessage,
-}: {
-  auth: Authenticator;
-  configuration: AgentConfigurationType;
-  conversation: ConversationType;
-  userMessage: UserMessageType;
-  agentMessage: AgentMessageType;
-}): AsyncGenerator<
+export async function* runDustApp(
+  auth: Authenticator,
+  {
+    configuration,
+    conversation,
+    userMessage,
+    agentMessage,
+  }: {
+    configuration: AgentConfigurationType;
+    conversation: ConversationType;
+    userMessage: UserMessageType;
+    agentMessage: AgentMessageType;
+  }
+): AsyncGenerator<
   | DustAppRunParamsEvent
   | DustAppRunBlockEvent
   | DustAppRunSuccessEvent

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -481,13 +481,19 @@ const getRefs = () => {
 // to be stored (once the query params are infered) but for the retrieval to fail, in which case an
 // error event will be emitted and the AgentRetrievalAction won't have any documents associated. The
 // error is expected to be stored by the caller on the parent agent message.
-export async function* runRetrieval(
-  auth: Authenticator,
-  configuration: AgentConfigurationType,
-  conversation: ConversationType,
-  userMessage: UserMessageType,
-  agentMessage: AgentMessageType
-): AsyncGenerator<
+export async function* runRetrieval({
+  auth,
+  configuration,
+  conversation,
+  userMessage,
+  agentMessage,
+}: {
+  auth: Authenticator;
+  configuration: AgentConfigurationType;
+  conversation: ConversationType;
+  userMessage: UserMessageType;
+  agentMessage: AgentMessageType;
+}): AsyncGenerator<
   RetrievalParamsEvent | RetrievalSuccessEvent | RetrievalErrorEvent,
   void
 > {

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -481,19 +481,20 @@ const getRefs = () => {
 // to be stored (once the query params are infered) but for the retrieval to fail, in which case an
 // error event will be emitted and the AgentRetrievalAction won't have any documents associated. The
 // error is expected to be stored by the caller on the parent agent message.
-export async function* runRetrieval({
-  auth,
-  configuration,
-  conversation,
-  userMessage,
-  agentMessage,
-}: {
-  auth: Authenticator;
-  configuration: AgentConfigurationType;
-  conversation: ConversationType;
-  userMessage: UserMessageType;
-  agentMessage: AgentMessageType;
-}): AsyncGenerator<
+export async function* runRetrieval(
+  auth: Authenticator,
+  {
+    configuration,
+    conversation,
+    userMessage,
+    agentMessage,
+  }: {
+    configuration: AgentConfigurationType;
+    conversation: ConversationType;
+    userMessage: UserMessageType;
+    agentMessage: AgentMessageType;
+  }
+): AsyncGenerator<
   RetrievalParamsEvent | RetrievalSuccessEvent | RetrievalErrorEvent,
   void
 > {

--- a/front/lib/api/assistant/actions/tables_query.ts
+++ b/front/lib/api/assistant/actions/tables_query.ts
@@ -112,19 +112,20 @@ export async function generateTablesQueryAppParams(
 /**
  * Run the TablesQuery app.
  */
-export async function* runTablesQuery({
-  auth,
-  configuration,
-  conversation,
-  userMessage,
-  agentMessage,
-}: {
-  auth: Authenticator;
-  configuration: AgentConfigurationType;
-  conversation: ConversationType;
-  userMessage: UserMessageType;
-  agentMessage: AgentMessageType;
-}): AsyncGenerator<
+export async function* runTablesQuery(
+  auth: Authenticator,
+  {
+    configuration,
+    conversation,
+    userMessage,
+    agentMessage,
+  }: {
+    configuration: AgentConfigurationType;
+    conversation: ConversationType;
+    userMessage: UserMessageType;
+    agentMessage: AgentMessageType;
+  }
+): AsyncGenerator<
   | TablesQueryErrorEvent
   | TablesQuerySuccessEvent
   | TablesQueryParamsEvent

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -1,4 +1,5 @@
 import type {
+  AgentActionConfigurationType,
   AgentActionEvent,
   AgentActionSpecification,
   AgentActionSuccessEvent,
@@ -188,156 +189,18 @@ export async function* runAgent(
     );
   }
 
-  const action = deprecatedGetFirstActionConfiguration(fullConfiguration);
+  const action = await pickAction(auth, fullConfiguration, conversation);
 
   if (action !== null) {
-    if (isRetrievalConfiguration(action)) {
-      const eventStream = runRetrieval(
-        auth,
-        fullConfiguration,
-        conversation,
-        userMessage,
-        agentMessage
-      );
-
-      for await (const event of eventStream) {
-        switch (event.type) {
-          case "retrieval_params":
-            yield event;
-            break;
-          case "retrieval_error":
-            yield {
-              type: "agent_error",
-              created: event.created,
-              configurationId: configuration.sId,
-              messageId: agentMessage.sId,
-              error: {
-                code: event.error.code,
-                message: event.error.message,
-              },
-            };
-            return;
-          case "retrieval_success":
-            yield {
-              type: "agent_action_success",
-              created: event.created,
-              configurationId: configuration.sId,
-              messageId: agentMessage.sId,
-              action: event.action,
-            };
-
-            // We stitch the action into the agent message. The conversation is expected to include
-            // the agentMessage object, updating this object will update the conversation as well.
-            agentMessage.action = event.action;
-            break;
-
-          default:
-            ((event: never) => {
-              logger.error("Unknown `runAgent` event type", event);
-            })(event);
-            return;
-        }
-      }
-    } else if (isDustAppRunConfiguration(action)) {
-      const eventStream = runDustApp(
-        auth,
-        fullConfiguration,
-        conversation,
-        userMessage,
-        agentMessage
-      );
-
-      for await (const event of eventStream) {
-        switch (event.type) {
-          case "dust_app_run_params":
-            yield event;
-            break;
-          case "dust_app_run_error":
-            yield {
-              type: "agent_error",
-              created: event.created,
-              configurationId: configuration.sId,
-              messageId: agentMessage.sId,
-              error: {
-                code: event.error.code,
-                message: event.error.message,
-              },
-            };
-            return;
-          case "dust_app_run_block":
-            yield event;
-            break;
-          case "dust_app_run_success":
-            yield {
-              type: "agent_action_success",
-              created: event.created,
-              configurationId: configuration.sId,
-              messageId: agentMessage.sId,
-              action: event.action,
-            };
-
-            // We stitch the action into the agent message. The conversation is expected to include
-            // the agentMessage object, updating this object will update the conversation as well.
-            agentMessage.action = event.action;
-            break;
-
-          default:
-            ((event: never) => {
-              logger.error("Unknown `runAgent` event type", event);
-            })(event);
-            return;
-        }
-      }
-    } else if (isTablesQueryConfiguration(action)) {
-      const eventStream = runTablesQuery({
-        auth,
-        configuration: fullConfiguration,
-        conversation,
-        userMessage,
-        agentMessage,
-      });
-      for await (const event of eventStream) {
-        switch (event.type) {
-          case "tables_query_params":
-          case "tables_query_output":
-            yield event;
-            break;
-          case "tables_query_error":
-            yield {
-              type: "agent_error",
-              created: event.created,
-              configurationId: configuration.sId,
-              messageId: agentMessage.sId,
-              error: {
-                code: event.error.code,
-                message: event.error.message,
-              },
-            };
-            return;
-          case "tables_query_success":
-            yield {
-              type: "agent_action_success",
-              created: event.created,
-              configurationId: configuration.sId,
-              messageId: agentMessage.sId,
-              action: event.action,
-            };
-
-            // We stitch the action into the agent message. The conversation is expected to include
-            // the agentMessage object, updating this object will update the conversation as well.
-            agentMessage.action = event.action;
-            break;
-          default:
-            ((event: never) => {
-              logger.error("Unknown `runAgent` event type", event);
-            })(event);
-            return;
-        }
-      }
-    } else {
-      ((a: never) => {
-        throw new Error(`Unexpected action type: ${a}`);
-      })(action);
+    for await (const event of runAction(
+      auth,
+      fullConfiguration,
+      conversation,
+      userMessage,
+      agentMessage,
+      action
+    )) {
+      yield event;
     }
   }
 
@@ -408,4 +271,185 @@ export async function* runAgent(
     messageId: agentMessage.sId,
     message: agentMessage,
   };
+}
+
+async function pickAction(
+  auth: Authenticator,
+  configuration: AgentConfigurationType,
+  conversation: ConversationType
+): Promise<AgentActionConfigurationType | null> {
+  // TODO(@fontanierh): This is a placeholder for the action selection logic.
+  // This will be replaced by the multi-actions "pick tool" logic.
+  // This should also include the inputs-generation logic (generating the arguments for the action)
+  void auth;
+  void conversation;
+
+  const action = deprecatedGetFirstActionConfiguration(configuration);
+
+  if (action !== null) {
+    return action;
+  }
+
+  return null;
+}
+
+async function* runAction(
+  auth: Authenticator,
+  configuration: AgentConfigurationType,
+  conversation: ConversationType,
+  userMessage: UserMessageType,
+  agentMessage: AgentMessageType,
+  action: AgentActionConfigurationType
+): AsyncGenerator<
+  AgentErrorEvent | AgentActionEvent | AgentActionSuccessEvent,
+  void
+> {
+  if (isRetrievalConfiguration(action)) {
+    const eventStream = runRetrieval({
+      auth,
+      configuration,
+      conversation,
+      userMessage,
+      agentMessage,
+    });
+
+    for await (const event of eventStream) {
+      switch (event.type) {
+        case "retrieval_params":
+          yield event;
+          break;
+        case "retrieval_error":
+          yield {
+            type: "agent_error",
+            created: event.created,
+            configurationId: configuration.sId,
+            messageId: agentMessage.sId,
+            error: {
+              code: event.error.code,
+              message: event.error.message,
+            },
+          };
+          return;
+        case "retrieval_success":
+          yield {
+            type: "agent_action_success",
+            created: event.created,
+            configurationId: configuration.sId,
+            messageId: agentMessage.sId,
+            action: event.action,
+          };
+
+          // We stitch the action into the agent message. The conversation is expected to include
+          // the agentMessage object, updating this object will update the conversation as well.
+          agentMessage.action = event.action;
+          break;
+
+        default:
+          ((event: never) => {
+            logger.error("Unknown `runAgent` event type", event);
+          })(event);
+          return;
+      }
+    }
+  } else if (isDustAppRunConfiguration(action)) {
+    const eventStream = runDustApp({
+      auth,
+      configuration,
+      conversation,
+      userMessage,
+      agentMessage,
+    });
+
+    for await (const event of eventStream) {
+      switch (event.type) {
+        case "dust_app_run_params":
+          yield event;
+          break;
+        case "dust_app_run_error":
+          yield {
+            type: "agent_error",
+            created: event.created,
+            configurationId: configuration.sId,
+            messageId: agentMessage.sId,
+            error: {
+              code: event.error.code,
+              message: event.error.message,
+            },
+          };
+          return;
+        case "dust_app_run_block":
+          yield event;
+          break;
+        case "dust_app_run_success":
+          yield {
+            type: "agent_action_success",
+            created: event.created,
+            configurationId: configuration.sId,
+            messageId: agentMessage.sId,
+            action: event.action,
+          };
+
+          // We stitch the action into the agent message. The conversation is expected to include
+          // the agentMessage object, updating this object will update the conversation as well.
+          agentMessage.action = event.action;
+          break;
+
+        default:
+          ((event: never) => {
+            logger.error("Unknown `runAgent` event type", event);
+          })(event);
+          return;
+      }
+    }
+  } else if (isTablesQueryConfiguration(action)) {
+    const eventStream = runTablesQuery({
+      auth,
+      configuration,
+      conversation,
+      userMessage,
+      agentMessage,
+    });
+    for await (const event of eventStream) {
+      switch (event.type) {
+        case "tables_query_params":
+        case "tables_query_output":
+          yield event;
+          break;
+        case "tables_query_error":
+          yield {
+            type: "agent_error",
+            created: event.created,
+            configurationId: configuration.sId,
+            messageId: agentMessage.sId,
+            error: {
+              code: event.error.code,
+              message: event.error.message,
+            },
+          };
+          return;
+        case "tables_query_success":
+          yield {
+            type: "agent_action_success",
+            created: event.created,
+            configurationId: configuration.sId,
+            messageId: agentMessage.sId,
+            action: event.action,
+          };
+
+          // We stitch the action into the agent message. The conversation is expected to include
+          // the agentMessage object, updating this object will update the conversation as well.
+          agentMessage.action = event.action;
+          break;
+        default:
+          ((event: never) => {
+            logger.error("Unknown `runAgent` event type", event);
+          })(event);
+          return;
+      }
+    }
+  } else {
+    ((a: never) => {
+      throw new Error(`Unexpected action type: ${a}`);
+    })(action);
+  }
 }

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -192,14 +192,13 @@ export async function* runAgent(
   const action = await pickAction(auth, fullConfiguration, conversation);
 
   if (action !== null) {
-    for await (const event of runAction(
-      auth,
-      fullConfiguration,
+    for await (const event of runAction(auth, {
+      configuration: fullConfiguration,
       conversation,
       userMessage,
       agentMessage,
-      action
-    )) {
+      action,
+    })) {
       yield event;
     }
   }
@@ -284,29 +283,30 @@ async function pickAction(
   void auth;
   void conversation;
 
-  const action = deprecatedGetFirstActionConfiguration(configuration);
-
-  if (action !== null) {
-    return action;
-  }
-
-  return null;
+  return deprecatedGetFirstActionConfiguration(configuration);
 }
 
 async function* runAction(
   auth: Authenticator,
-  configuration: AgentConfigurationType,
-  conversation: ConversationType,
-  userMessage: UserMessageType,
-  agentMessage: AgentMessageType,
-  action: AgentActionConfigurationType
+  {
+    configuration,
+    conversation,
+    userMessage,
+    agentMessage,
+    action,
+  }: {
+    configuration: AgentConfigurationType;
+    conversation: ConversationType;
+    userMessage: UserMessageType;
+    agentMessage: AgentMessageType;
+    action: AgentActionConfigurationType;
+  }
 ): AsyncGenerator<
   AgentErrorEvent | AgentActionEvent | AgentActionSuccessEvent,
   void
 > {
   if (isRetrievalConfiguration(action)) {
-    const eventStream = runRetrieval({
-      auth,
+    const eventStream = runRetrieval(auth, {
       configuration,
       conversation,
       userMessage,
@@ -352,8 +352,7 @@ async function* runAction(
       }
     }
   } else if (isDustAppRunConfiguration(action)) {
-    const eventStream = runDustApp({
-      auth,
+    const eventStream = runDustApp(auth, {
       configuration,
       conversation,
       userMessage,
@@ -402,8 +401,7 @@ async function* runAction(
       }
     }
   } else if (isTablesQueryConfiguration(action)) {
-    const eventStream = runTablesQuery({
-      auth,
+    const eventStream = runTablesQuery(auth, {
       configuration,
       conversation,
       userMessage,


### PR DESCRIPTION
## Description

Some ground work for https://github.com/dust-tt/dust/issues/4602

This is the first step if changing the structure of `runAgent` for the mutli-actions future.
I just extracted the "pickAction" and "runAction" parts of the logic in separate functions.

Next steps:
- move inputs generation to pickAction (closer to future setup)
- make `generation` an actual action (so change the action config type to also union on generation)
- make `pickAction` rely on `forceUseAtIteration` (and error if multi actions for now)

## Risk

This particular PR is a total no-op, just lightweight refactoring

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
