### PR TITLE
fix: reduce metabase timeout to 120 secs

### DIFF
--- a/k8s/backend-configs/metabase-backend-config.yaml
+++ b/k8s/backend-configs/metabase-backend-config.yaml
@@ -7,4 +7,4 @@ spec:
     enabled: true
     oauthclientCredentials:
       secretName: iap-creds
-  timeoutSec: 60
+  timeoutSec: 120

--- a/k8s/backend-configs/metabase-backend-config.yaml
+++ b/k8s/backend-configs/metabase-backend-config.yaml
@@ -7,4 +7,4 @@ spec:
     enabled: true
     oauthclientCredentials:
       secretName: iap-creds
-  timeoutSec: 600
+  timeoutSec: 60


### PR DESCRIPTION
## Description

10 minutes is way too much, we have a ton of zombie queries that are taking > 3 minutes that are exhaustive the read replica cpu.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
