### PR TITLE
fix: trim crawler URLs

### DIFF
--- a/connectors/src/connectors/webcrawler/index.ts
+++ b/connectors/src/connectors/webcrawler/index.ts
@@ -50,9 +50,9 @@ export async function createWebcrawlerConnector(
       new Error(`Maximum value for Max Page is ${WEBCRAWLER_MAX_PAGES}`)
     );
   }
-
+  const url = configuration.url.trim();
   const webCrawlerConfigurationBlob = {
-    url: configuration.url,
+    url,
     maxPageToCrawl: configuration.maxPageToCrawl,
     crawlMode: configuration.crawlMode,
     depth: depth,

--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -280,7 +280,7 @@ export async function crawlWebsiteByConnectorId(connectorId: ModelId) {
     })
   );
 
-  let url = webCrawlerConfig.url;
+  let url = webCrawlerConfig.url.trim();
   if (!url.startsWith("http://") && !url.startsWith("https://")) {
     url = `http://${url}`;
   }

--- a/front/components/data_source/WebsiteConfiguration.tsx
+++ b/front/components/data_source/WebsiteConfiguration.tsx
@@ -153,6 +153,7 @@ export default function WebsiteConfiguration({
   const handleCreate = async () => {
     setIsSaving(true);
     if (webCrawlerConfiguration === null) {
+      const sanitizedDataSourceUrl = dataSourceUrl.trim();
       const res = await fetch(`/api/w/${owner.sId}/data_sources/managed`, {
         method: "POST",
         headers: {
@@ -163,7 +164,7 @@ export default function WebsiteConfiguration({
           connectionId: "none",
           name: dataSourceName,
           configuration: {
-            url: dataSourceUrl,
+            url: sanitizedDataSourceUrl,
             maxPageToCrawl: maxPages || WEBCRAWLER_MAX_PAGES,
             depth: maxDepth,
             crawlMode: crawlMode,


### PR DESCRIPTION
## Description

We don't trim crawler URLs which mean they can have leading whitespace which cause errors.

I added a trim in 3 places:
- in the client because it's cleaner
- in the server because it's safer
- at use time because we want to be resilient


Will also cleanup the one we have in production.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
