### PR TITLE
fix: allow un-revoking invitations

### DIFF
--- a/front/lib/api/invitation.ts
+++ b/front/lib/api/invitation.ts
@@ -243,3 +243,29 @@ export async function getRecentPendingAndRevokedInvitations(
 
   return groupedInvitations;
 }
+
+export async function batchUnrevokeInvitations(
+  auth: Authenticator,
+  invitationIds: string[]
+) {
+  const owner = auth.workspace();
+  if (!owner || !auth.isAdmin()) {
+    throw new Error(
+      "Only users that are `admins` for the current workspace can see membership invitations or modify them."
+    );
+  }
+
+  await MembershipInvitation.update(
+    {
+      status: "pending",
+    },
+    {
+      where: {
+        sId: {
+          [Op.in]: invitationIds,
+        },
+        workspaceId: owner.id,
+      },
+    }
+  );
+}

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -1030,6 +1030,23 @@ async function sendInvitations({
   });
 
   if (!res.ok) {
+    let data: any = {};
+    try {
+      data = await res.json();
+    } catch (e) {
+      // ignore
+    }
+    if (data?.error?.type === "invitation_already_sent_recently") {
+      sendNotification({
+        type: "error",
+        title: emails.length === 1 ? "Invite failed" : "Invites failed",
+        description:
+          emails.length === 1
+            ? "This user has already been invited in the last 24 hours. Please wait before sending another invite."
+            : "These users have already been invited in the last 24 hours. Please wait before sending another invite.",
+      });
+    }
+
     sendNotification({
       type: "error",
       title: "Invite failed",

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -1041,9 +1041,8 @@ async function sendInvitations({
         type: "error",
         title: emails.length === 1 ? "Invite failed" : "Invites failed",
         description:
-          emails.length === 1
-            ? "This user has already been invited in the last 24 hours. Please wait before sending another invite."
-            : "These users have already been invited in the last 24 hours. Please wait before sending another invite.",
+          (emails.length === 1 ? "This user has" : "These users have") +
+          " already been invited in the last 24 hours. Please wait before sending another invite.",
       });
     }
 

--- a/types/src/front/lib/error.ts
+++ b/types/src/front/lib/error.ts
@@ -66,7 +66,9 @@ export type APIErrorType =
   | "invalid_pagination_parameters"
   | "table_not_found"
   // Templates:
-  | "template_not_found";
+  | "template_not_found"
+  // Invitations:
+  | "invitation_already_sent_recently";
 
 export type APIError = {
   type: APIErrorType;


### PR DESCRIPTION
## Description

fixes https://github.com/dust-tt/tasks/issues/666

We added some security restrictions around invitations recently (specifically, prevent sending more than 1 invite email per email per workspace per 24 hours).
But there are 2 problems:
- when you revoked an invitation that you sent in the last 24 hours, we block you from sending it again (this is good). But you don't have any way to un-revoke it. This change fixes this.

- when you add a long list of emails and some of them are for users that have already been invited in the last 24 hours, we fail the whole API call instead of at least sending those we can send.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
