### PR TITLE
Templates: Rework Assistant Template Gallery

### DIFF
--- a/front/components/assistant_builder/TemplateGrid.tsx
+++ b/front/components/assistant_builder/TemplateGrid.tsx
@@ -1,15 +1,13 @@
-import { Page, TemplateItem } from "@dust-tt/sparkle";
-import type { AssistantTemplateTagNameType } from "@dust-tt/types";
+import { TemplateItem } from "@dust-tt/sparkle";
 import { useRouter } from "next/router";
 
 import type { AssistantTemplateListType } from "@app/pages/api/w/[wId]/assistant/builder/templates";
 
 interface TemplateGridProps {
-  tagName: AssistantTemplateTagNameType;
   templates: AssistantTemplateListType[];
 }
 
-export function TemplateGrid({ tagName, templates }: TemplateGridProps) {
+export function TemplateGrid({ templates }: TemplateGridProps) {
   const router = useRouter();
 
   const makeTemplateModalHref = (templateId: string) => {
@@ -40,10 +38,5 @@ export function TemplateGrid({ tagName, templates }: TemplateGridProps) {
     return null;
   }
 
-  return (
-    <div id={tagName}>
-      <Page.SectionHeader title={tagName} />
-      <div className="grid grid-cols-2 gap-2">{items}</div>
-    </div>
-  );
+  return <div className="grid grid-cols-2 gap-2">{items}</div>;
 }

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -9,7 +9,7 @@
         "@amplitude/analytics-browser": "^2.5.2",
         "@amplitude/analytics-node": "^1.3.5",
         "@auth0/nextjs-auth0": "^3.5.0",
-        "@dust-tt/sparkle": "0.2.137",
+        "@dust-tt/sparkle": "0.2.138",
         "@dust-tt/types": "file:../types",
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",
@@ -10485,9 +10485,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.137",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.137.tgz",
-      "integrity": "sha512-O6BmNs1RffTkbNyKh5GaIvWr90EQljgxvSy1VEcNCl5qj8Foy/jGLGG3rhWL3n2+68ZUQ71A/iMmhF4FH+hAkA==",
+      "version": "0.2.138",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.138.tgz",
+      "integrity": "sha512-jnGWDiPv/KVwDUbYfecrQpacoFC2yggWymvgrIsI+HfTone6fG8paii62S2SJlgbBwoJdG4AJiKRM4Vr3tPmHQ==",
       "dependencies": {
         "@headlessui/react": "^1.7.17",
         "esbuild": "^0.20.0",

--- a/front/package.json
+++ b/front/package.json
@@ -17,7 +17,7 @@
     "@amplitude/analytics-browser": "^2.5.2",
     "@amplitude/analytics-node": "^1.3.5",
     "@auth0/nextjs-auth0": "^3.5.0",
-    "@dust-tt/sparkle": "0.2.137",
+    "@dust-tt/sparkle": "0.2.138",
     "@dust-tt/types": "file:../types",
     "@emoji-mart/data": "^1.1.2",
     "@emoji-mart/react": "^1.1.1",

--- a/front/pages/w/[wId]/builder/assistants/create.tsx
+++ b/front/pages/w/[wId]/builder/assistants/create.tsx
@@ -145,7 +145,6 @@ export default function CreateAssistant({
     const scrollContainerElement = document.getElementById("main-content");
 
     if (!scrollToElement || !scrollContainerElement) {
-      console.error("Element or scrollable container not found.", tagName);
       return;
     }
     const scrollToElementRect = scrollToElement.getBoundingClientRect();

--- a/front/pages/w/[wId]/builder/assistants/create.tsx
+++ b/front/pages/w/[wId]/builder/assistants/create.tsx
@@ -1,12 +1,11 @@
 import {
-  ArrowRightIcon,
   Button,
+  ContextItem,
   DocumentIcon,
-  FilterChips,
-  Icon,
+  MagicIcon,
   Page,
+  PencilSquareIcon,
   Searchbar,
-  TemplateIcon,
 } from "@dust-tt/sparkle";
 import type {
   AssistantTemplateTagNameType,
@@ -14,10 +13,11 @@ import type {
   WorkspaceType,
 } from "@dust-tt/types";
 import { assistantTemplateTagNames } from "@dust-tt/types";
+import _ from "lodash";
 import type { InferGetServerSidePropsType } from "next";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { useEffect, useState } from "react";
+import { createRef, useEffect, useRef, useState } from "react";
 
 import type { BuilderFlow } from "@app/components/assistant_builder/AssistantBuilder";
 import { BUILDER_FLOWS } from "@app/components/assistant_builder/AssistantBuilder";
@@ -71,6 +71,7 @@ export default function CreateAssistant({
   templateTags,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const router = useRouter();
+
   const [templateSearchTerm, setTemplateSearchTerm] = useState<string | null>(
     null
   );
@@ -82,26 +83,37 @@ export default function CreateAssistant({
     workspaceId: owner.sId,
   });
 
-  const [filteredItems, setFilteredItems] = useState<typeof assistantTemplates>(
-    []
-  );
+  const [filteredTemplates, setFilteredTemplates] = useState<{
+    templates: typeof assistantTemplates;
+    tags: AssistantTemplateTagNameType[];
+  }>({ templates: [], tags: [] });
 
   useEffect(() => {
-    setFilteredItems(assistantTemplates);
+    setFilteredTemplates({
+      templates: assistantTemplates,
+      tags: _.uniq(assistantTemplates.map((template) => template.tags).flat()),
+    });
   }, [assistantTemplates]);
 
   const handleSearch = (searchTerm: string) => {
     setTemplateSearchTerm(searchTerm);
 
     if (searchTerm === "") {
-      setFilteredItems(assistantTemplates);
-    }
-
-    setFilteredItems(
-      assistantTemplates.filter((template) =>
+      setFilteredTemplates({
+        templates: assistantTemplates,
+        tags: _.uniq(
+          assistantTemplates.map((template) => template.tags).flat()
+        ),
+      });
+    } else {
+      const filteredTemplates = assistantTemplates.filter((template) =>
         subFilter(searchTerm.toLowerCase(), template.handle.toLowerCase())
-      )
-    );
+      );
+      setFilteredTemplates({
+        templates: filteredTemplates,
+        tags: _.uniq(filteredTemplates.map((template) => template.tags).flat()),
+      });
+    }
   };
 
   const handleCloseModal = () => {
@@ -115,6 +127,50 @@ export default function CreateAssistant({
         shallow: true,
       }
     );
+  };
+
+  const tagsRefsMap = useRef<{
+    [key: string]: React.MutableRefObject<HTMLDivElement | null>;
+  }>({});
+
+  useEffect(() => {
+    templateTags.forEach((tag: string) => {
+      tagsRefsMap.current[tag] = tagsRefsMap.current[tag] || createRef();
+    });
+  }, [templateTags]);
+
+  const scrollToTag = (tagName: string) => {
+    const SCROLL_OFFSET = 64; // Header size
+    const scrollToElement = tagsRefsMap.current[tagName]?.current;
+    const scrollContainerElement = document.getElementById("main-content");
+
+    if (!scrollToElement || !scrollContainerElement) {
+      console.error("Element or scrollable container not found.", tagName);
+      return;
+    }
+    const scrollToElementRect = scrollToElement.getBoundingClientRect();
+    const scrollContainerRect = scrollContainerElement.getBoundingClientRect();
+    const scrollTargetPosition =
+      scrollToElementRect.top -
+      scrollContainerRect.top +
+      scrollContainerElement.scrollTop -
+      SCROLL_OFFSET;
+
+    scrollContainerElement.scrollTo({
+      top: scrollTargetPosition,
+      behavior: "smooth",
+    });
+
+    setTimeout(() => {
+      triggerShakeAnimation(scrollToElement);
+    }, 1000);
+  };
+
+  const triggerShakeAnimation = (element: HTMLElement): void => {
+    element.classList.add("animate-shake");
+    setTimeout(() => {
+      element.classList.remove("animate-shake");
+    }, 500);
   };
 
   useEffect(() => {
@@ -136,9 +192,6 @@ export default function CreateAssistant({
     };
   }, [router.query, router.events]);
 
-  const defaultTag =
-    router.asPath.split("#")[1] ?? assistantTemplateTagNames[0];
-
   return (
     <AppLayout
       subscription={subscription}
@@ -156,52 +209,62 @@ export default function CreateAssistant({
         />
       }
     >
-      <Page variant="modal">
-        <div className="flex flex-col items-center gap-2.5 rounded-lg bg-structure-50 py-8">
-          <Icon visual={DocumentIcon} size="lg" />
-          <Link href={`/w/${owner.sId}/builder/assistants/new?flow=${flow}`}>
-            <Button icon={ArrowRightIcon} label="Start new" size="sm" />
-          </Link>
-        </div>
-        <Page.Header title="Use a template" icon={TemplateIcon} />
-        <div className="flex flex-col gap-4">
-          <Searchbar
-            placeholder="Search templates"
-            name="input"
-            value={templateSearchTerm}
-            onChange={handleSearch}
-          />
-          <FilterChips
-            filters={templateTags}
-            onFilterClick={(filterName) => {
-              void router.replace(`#${filterName}`);
-            }}
-            defaultFilter={defaultTag}
-          />
-        </div>
-        <Page.Separator />
-        <div className="flex flex-col gap-2">
-          {templateTags.map((tagName) => {
-            const templatesForTag = filteredItems.filter((item) =>
-              item.tags.includes(tagName)
-            );
-
-            return (
-              <TemplateGrid
-                key={tagName}
-                templates={templatesForTag}
-                tagName={tagName}
-              />
-            );
-          })}
-        </div>
-      </Page>
-      <AssistantTemplateModal
-        flow={flow}
-        owner={owner}
-        templateId={selectedTemplateId}
-        onClose={handleCloseModal}
-      />
+      <div id="pageContent">
+        <Page variant="modal">
+          <Page.Header title="Start new" icon={PencilSquareIcon} />
+          <div className="pb-6">
+            <Link href={`/w/${owner.sId}/builder/assistants/new?flow=${flow}`}>
+              <Button icon={DocumentIcon} label="New Assistant" size="md" />
+            </Link>
+          </div>
+          <Page.Separator />
+          <Page.Header title="Start from a template" icon={MagicIcon} />
+          <div className="flex flex-col gap-4">
+            <Searchbar
+              placeholder="Search templates"
+              name="input"
+              value={templateSearchTerm}
+              onChange={handleSearch}
+              size="md"
+            />
+            <div className="flex flex-row flex-wrap gap-2">
+              {filteredTemplates.tags.map((tagName) => (
+                <Button
+                  label={tagName}
+                  variant="tertiary"
+                  key={tagName}
+                  size="xs"
+                  hasMagnifying={false}
+                  onClick={() => scrollToTag(tagName)}
+                />
+              ))}
+            </div>
+          </div>
+          <Page.Separator />
+          <div className="flex flex-col pb-56">
+            {filteredTemplates.tags.map((tagName) => {
+              const templatesForTag = filteredTemplates.templates.filter(
+                (item) => item.tags.includes(tagName)
+              );
+              return (
+                <div key={tagName} ref={tagsRefsMap.current[tagName]}>
+                  <ContextItem.SectionHeader
+                    title={tagName}
+                    hasBorder={false}
+                  />
+                  <TemplateGrid templates={templatesForTag} />
+                </div>
+              );
+            })}
+          </div>
+        </Page>
+        <AssistantTemplateModal
+          flow={flow}
+          owner={owner}
+          templateId={selectedTemplateId}
+          onClose={handleCloseModal}
+        />
+      </div>
     </AppLayout>
   );
 }


### PR DESCRIPTION
## Description

This PR edits the new page where we chose to create a new assistant from scratch or from a template. 
It does: 
- Update the wording, icons and some styles following the Figma. 
- Display only the tags that have at least one template associated.
- Remove the select state of a filter. 
- Scroll smoothly and with a shake animation to the desired category. 

<img width="1134" alt="Screenshot 2024-04-17 at 19 34 37" src="https://github.com/dust-tt/dust/assets/3803406/c90b4755-d04d-4487-8bf2-66e44b4dd224">



## Risk

Very low, feature is hidden. 

## Deploy Plan

/
