### PR TITLE
Templates: Keep in code with mapping for label

### DIFF
--- a/front/components/poke/templates/columns.tsx
+++ b/front/components/poke/templates/columns.tsx
@@ -1,8 +1,6 @@
 import { Chip, IconButton } from "@dust-tt/sparkle";
-import type {
-  AssistantTemplateTagNameType,
-  TemplateVisibility,
-} from "@dust-tt/types";
+import type { TemplateTagCodeType, TemplateVisibility } from "@dust-tt/types";
+import { TEMPLATES_TAGS_CONFIG } from "@dust-tt/types";
 import { ArrowsUpDownIcon } from "@heroicons/react/20/solid";
 import type { ColumnDef } from "@tanstack/react-table";
 import Link from "next/link";
@@ -11,7 +9,7 @@ export interface TemplatesDisplayType {
   id: string;
   name: string;
   status: TemplateVisibility;
-  tags: AssistantTemplateTagNameType[];
+  tags: TemplateTagCodeType[];
 }
 
 export function makeColumnsForTemplates(): ColumnDef<TemplatesDisplayType>[] {
@@ -87,8 +85,10 @@ export function makeColumnsForTemplates(): ColumnDef<TemplatesDisplayType>[] {
         </div>
       ),
       cell: ({ row }) => {
-        const tags: string[] = row.getValue("tags");
-        const tagChips = tags.map((t) => <Chip label={t} key={t} size="xs" />);
+        const tags: TemplateTagCodeType[] = row.getValue("tags");
+        const tagChips = tags.map((t) => (
+          <Chip label={TEMPLATES_TAGS_CONFIG[t].label} key={t} size="xs" />
+        ));
 
         return <div className="flex gap-x-2">{tagChips}</div>;
       },

--- a/front/components/poke/templates/columns.tsx
+++ b/front/components/poke/templates/columns.tsx
@@ -87,7 +87,13 @@ export function makeColumnsForTemplates(): ColumnDef<TemplatesDisplayType>[] {
       cell: ({ row }) => {
         const tags: TemplateTagCodeType[] = row.getValue("tags");
         const tagChips = tags.map((t) => (
-          <Chip label={TEMPLATES_TAGS_CONFIG[t].label} key={t} size="xs" />
+          <Chip
+            label={
+              TEMPLATES_TAGS_CONFIG[t] ? TEMPLATES_TAGS_CONFIG[t].label : t
+            }
+            key={t}
+            size="xs"
+          />
         ));
 
         return <div className="flex gap-x-2">{tagChips}</div>;

--- a/front/lib/resources/storage/models/templates.ts
+++ b/front/lib/resources/storage/models/templates.ts
@@ -1,7 +1,7 @@
 import type {
   ActionPreset,
   AssistantCreativityLevel,
-  AssistantTemplateTagNameType,
+  TemplateTagCodeType,
   TemplateVisibility,
 } from "@dust-tt/types";
 import type {
@@ -40,7 +40,7 @@ export class TemplateModel extends Model<
   declare helpInstructions: string | null;
   declare helpActions: string | null;
 
-  declare tags: AssistantTemplateTagNameType[];
+  declare tags: TemplateTagCodeType[];
 }
 
 TemplateModel.init(

--- a/front/pages/api/poke/templates/[tId].ts
+++ b/front/pages/api/poke/templates/[tId].ts
@@ -1,7 +1,7 @@
 import type { WithAPIErrorReponse } from "@dust-tt/types";
 import {
   CreateTemplateFormSchema,
-  isAssistantTemplateTagNameTypeArray,
+  isTemplateTagsArrayValid,
 } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as reporter from "io-ts-reporters";
@@ -81,7 +81,7 @@ async function handler(
       }
       const body = bodyValidation.right;
 
-      if (!isAssistantTemplateTagNameTypeArray(body.tags)) {
+      if (!isTemplateTagsArrayValid(body.tags)) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {

--- a/front/pages/api/poke/templates/[tId].ts
+++ b/front/pages/api/poke/templates/[tId].ts
@@ -1,7 +1,7 @@
 import type { WithAPIErrorReponse } from "@dust-tt/types";
 import {
   CreateTemplateFormSchema,
-  isTemplateTagsArrayValid,
+  isTemplateTagCodeArray,
 } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as reporter from "io-ts-reporters";
@@ -81,7 +81,7 @@ async function handler(
       }
       const body = bodyValidation.right;
 
-      if (!isTemplateTagsArrayValid(body.tags)) {
+      if (!isTemplateTagCodeArray(body.tags)) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {

--- a/front/pages/api/poke/templates/index.ts
+++ b/front/pages/api/poke/templates/index.ts
@@ -1,7 +1,7 @@
 import type { WithAPIErrorReponse } from "@dust-tt/types";
 import {
   CreateTemplateFormSchema,
-  isAssistantTemplateTagNameTypeArray,
+  isTemplateTagsArrayValid,
 } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as reporter from "io-ts-reporters";
@@ -65,7 +65,7 @@ async function handler(
       }
       const body = bodyValidation.right;
 
-      if (!isAssistantTemplateTagNameTypeArray(body.tags)) {
+      if (!isTemplateTagsArrayValid(body.tags)) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {

--- a/front/pages/api/poke/templates/index.ts
+++ b/front/pages/api/poke/templates/index.ts
@@ -1,7 +1,7 @@
 import type { WithAPIErrorReponse } from "@dust-tt/types";
 import {
   CreateTemplateFormSchema,
-  isTemplateTagsArrayValid,
+  isTemplateTagCodeArray,
 } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as reporter from "io-ts-reporters";
@@ -65,7 +65,7 @@ async function handler(
       }
       const body = bodyValidation.right;
 
-      if (!isTemplateTagsArrayValid(body.tags)) {
+      if (!isTemplateTagCodeArray(body.tags)) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {

--- a/front/pages/poke/templates/[tId].tsx
+++ b/front/pages/poke/templates/[tId].tsx
@@ -347,7 +347,9 @@ function TemplatesPage({
                     <MultiSelect
                       options={tagOptions}
                       value={field.value.map((tag: TemplateTagCodeType) => ({
-                        label: TEMPLATES_TAGS_CONFIG[tag].label,
+                        label: TEMPLATES_TAGS_CONFIG[tag]
+                          ? TEMPLATES_TAGS_CONFIG[tag].label
+                          : tag,
                         value: tag,
                       }))}
                       onChange={(tags: { label: string; value: string }[]) => {

--- a/front/pages/poke/templates/[tId].tsx
+++ b/front/pages/poke/templates/[tId].tsx
@@ -1,13 +1,17 @@
-import type { CreateTemplateFormType } from "@dust-tt/types";
+import type {
+  CreateTemplateFormType,
+  TemplateTagCodeType,
+} from "@dust-tt/types";
 import {
   ACTION_PRESETS,
   ASSISTANT_CREATIVITY_LEVELS,
-  assistantTemplateTagNames,
   CreateTemplateFormSchema,
   GPT_4_TURBO_MODEL_CONFIG,
   removeNulls,
+  TEMPLATES_TAGS_CONFIG,
 } from "@dust-tt/types";
 import { ioTsResolver } from "@hookform/resolvers/io-ts";
+import _ from "lodash";
 import type { InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 import React, { useCallback, useEffect } from "react";
@@ -112,9 +116,12 @@ function TextareaField({
   );
 }
 
-const tagOptions = assistantTemplateTagNames.map((t) => ({
-  label: t,
-  value: t,
+const tagOptions: {
+  label: string;
+  value: TemplateTagCodeType;
+}[] = _.map(TEMPLATES_TAGS_CONFIG, (config, key) => ({
+  label: config.label,
+  value: key as TemplateTagCodeType,
 }));
 
 interface SelectFieldOption {
@@ -339,8 +346,8 @@ function TemplatesPage({
                   <PokeFormControl>
                     <MultiSelect
                       options={tagOptions}
-                      value={field.value.map((tag) => ({
-                        label: tag,
+                      value={field.value.map((tag: TemplateTagCodeType) => ({
+                        label: TEMPLATES_TAGS_CONFIG[tag].label,
                         value: tag,
                       }))}
                       onChange={(tags: { label: string; value: string }[]) => {

--- a/front/pages/w/[wId]/builder/assistants/create.tsx
+++ b/front/pages/w/[wId]/builder/assistants/create.tsx
@@ -8,11 +8,15 @@ import {
   Searchbar,
 } from "@dust-tt/sparkle";
 import type {
-  AssistantTemplateTagNameType,
   SubscriptionType,
+  TemplateTagCodeType,
+  TemplateTagsType,
   WorkspaceType,
 } from "@dust-tt/types";
-import { assistantTemplateTagNames } from "@dust-tt/types";
+import {
+  isTemplateTagsArrayValid,
+  TEMPLATES_TAGS_CONFIG,
+} from "@dust-tt/types";
 import _ from "lodash";
 import type { InferGetServerSidePropsType } from "next";
 import Link from "next/link";
@@ -35,7 +39,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   gaTrackingId: string;
   owner: WorkspaceType;
   subscription: SubscriptionType;
-  templateTags: AssistantTemplateTagNameType[];
+  templateTagsMapping: TemplateTagsType;
 }>(async (context, auth) => {
   const owner = auth.workspace();
   const plan = auth.plan();
@@ -58,7 +62,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       subscription,
       gaTrackingId: config.getGaTrackingId(),
       flow,
-      templateTags: [...assistantTemplateTagNames],
+      templateTagsMapping: TEMPLATES_TAGS_CONFIG,
     },
   };
 });
@@ -68,7 +72,7 @@ export default function CreateAssistant({
   gaTrackingId,
   owner,
   subscription,
-  templateTags,
+  templateTagsMapping,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const router = useRouter();
 
@@ -85,35 +89,36 @@ export default function CreateAssistant({
 
   const [filteredTemplates, setFilteredTemplates] = useState<{
     templates: typeof assistantTemplates;
-    tags: AssistantTemplateTagNameType[];
+    tags: TemplateTagCodeType[];
   }>({ templates: [], tags: [] });
 
   useEffect(() => {
+    const templatesToDisplay = assistantTemplates.filter((template) => {
+      return isTemplateTagsArrayValid(template.tags);
+    });
     setFilteredTemplates({
-      templates: assistantTemplates,
-      tags: _.uniq(assistantTemplates.map((template) => template.tags).flat()),
+      templates: templatesToDisplay,
+      tags: _.uniq(templatesToDisplay.map((template) => template.tags).flat()),
     });
   }, [assistantTemplates]);
 
   const handleSearch = (searchTerm: string) => {
     setTemplateSearchTerm(searchTerm);
-
-    if (searchTerm === "") {
-      setFilteredTemplates({
-        templates: assistantTemplates,
-        tags: _.uniq(
-          assistantTemplates.map((template) => template.tags).flat()
-        ),
-      });
-    } else {
-      const filteredTemplates = assistantTemplates.filter((template) =>
-        subFilter(searchTerm.toLowerCase(), template.handle.toLowerCase())
-      );
-      setFilteredTemplates({
-        templates: filteredTemplates,
-        tags: _.uniq(filteredTemplates.map((template) => template.tags).flat()),
-      });
-    }
+    const templatesFilteredFromSearch =
+      searchTerm === ""
+        ? assistantTemplates
+        : assistantTemplates.filter((template) =>
+            subFilter(searchTerm.toLowerCase(), template.handle.toLowerCase())
+          );
+    const templatesToDisplay = templatesFilteredFromSearch.filter(
+      (template) => {
+        return isTemplateTagsArrayValid(template.tags);
+      }
+    );
+    setFilteredTemplates({
+      templates: templatesToDisplay,
+      tags: _.uniq(templatesToDisplay.map((template) => template.tags).flat()),
+    });
   };
 
   const handleCloseModal = () => {
@@ -134,10 +139,10 @@ export default function CreateAssistant({
   }>({});
 
   useEffect(() => {
-    templateTags.forEach((tag: string) => {
+    Object.keys(templateTagsMapping).forEach((tag: string) => {
       tagsRefsMap.current[tag] = tagsRefsMap.current[tag] || createRef();
     });
-  }, [templateTags]);
+  }, [templateTagsMapping]);
 
   const scrollToTag = (tagName: string) => {
     const SCROLL_OFFSET = 64; // Header size
@@ -229,7 +234,7 @@ export default function CreateAssistant({
             <div className="flex flex-row flex-wrap gap-2">
               {filteredTemplates.tags.map((tagName) => (
                 <Button
-                  label={tagName}
+                  label={templateTagsMapping[tagName].label}
                   variant="tertiary"
                   key={tagName}
                   size="xs"
@@ -248,7 +253,7 @@ export default function CreateAssistant({
               return (
                 <div key={tagName} ref={tagsRefsMap.current[tagName]}>
                   <ContextItem.SectionHeader
-                    title={tagName}
+                    title={templateTagsMapping[tagName].label}
                     hasBorder={false}
                   />
                   <TemplateGrid templates={templatesForTag} />

--- a/front/pages/w/[wId]/builder/assistants/create.tsx
+++ b/front/pages/w/[wId]/builder/assistants/create.tsx
@@ -13,10 +13,7 @@ import type {
   TemplateTagsType,
   WorkspaceType,
 } from "@dust-tt/types";
-import {
-  isTemplateTagsArrayValid,
-  TEMPLATES_TAGS_CONFIG,
-} from "@dust-tt/types";
+import { isTemplateTagCodeArray, TEMPLATES_TAGS_CONFIG } from "@dust-tt/types";
 import _ from "lodash";
 import type { InferGetServerSidePropsType } from "next";
 import Link from "next/link";
@@ -94,7 +91,7 @@ export default function CreateAssistant({
 
   useEffect(() => {
     const templatesToDisplay = assistantTemplates.filter((template) => {
-      return isTemplateTagsArrayValid(template.tags);
+      return isTemplateTagCodeArray(template.tags);
     });
     setFilteredTemplates({
       templates: templatesToDisplay,
@@ -112,7 +109,7 @@ export default function CreateAssistant({
           );
     const templatesToDisplay = templatesFilteredFromSearch.filter(
       (template) => {
-        return isTemplateTagsArrayValid(template.tags);
+        return isTemplateTagCodeArray(template.tags);
       }
     );
     setFilteredTemplates({

--- a/types/src/front/assistant/templates.ts
+++ b/types/src/front/assistant/templates.ts
@@ -80,7 +80,7 @@ export const TEMPLATES_TAGS_CONFIG: TemplateTagsType = {
   },
 };
 
-export function isTemplateTagsArrayValid(
+export function isTemplateTagCodeArray(
   value: unknown
 ): value is TemplateTagCodeType[] {
   return (

--- a/types/src/front/assistant/templates.ts
+++ b/types/src/front/assistant/templates.ts
@@ -6,36 +6,85 @@ import { ioTsEnum } from "../../shared/utils/iots_utils";
 import { AgentAction } from "./agent";
 import { AssistantCreativityLevelCodec } from "./builder";
 
-// Keeps the order of tags for UI display purposes.
-export const assistantTemplateTagNames = [
-  "Featured",
-  "Productivity",
-  "Design",
-  "Sales",
-  "Product Management",
-  "Operations",
-  "Engineering",
-  "Data",
-  "Marketing",
-  "Content",
-  "Writing",
-  "Hiring",
-  "UX Design",
-  "UX Research",
-  "Finance",
-  "Product",
-  // TODO: Add tag names for templates, here.
+export const TEMPLATES_TAG_CODES = [
+  "CONTENT",
+  "DATA",
+  "DESIGN",
+  "ENGINEERING",
+  "FINANCE",
+  "HIRING",
+  "MARKETING",
+  "OPERATIONS",
+  "PRODUCT",
+  "PRODUCT_MANAGEMENT",
+  "PRODUCTIVITY",
+  "SALES",
+  "UX_DESIGN",
+  "UX_RESEARCH",
+  "WRITING",
 ] as const;
+export type TemplateTagCodeType = (typeof TEMPLATES_TAG_CODES)[number];
 
-export type AssistantTemplateTagNameType =
-  (typeof assistantTemplateTagNames)[number];
+export type TemplateTagsType = Record<
+  TemplateTagCodeType,
+  {
+    label: string;
+  }
+>;
 
-export function isAssistantTemplateTagNameTypeArray(
+export const TEMPLATES_TAGS_CONFIG: TemplateTagsType = {
+  CONTENT: {
+    label: "Content",
+  },
+  DATA: {
+    label: "Data",
+  },
+  DESIGN: {
+    label: "Design",
+  },
+  ENGINEERING: {
+    label: "Engineering",
+  },
+  FINANCE: {
+    label: "Finance",
+  },
+  HIRING: {
+    label: "Hiring",
+  },
+  MARKETING: {
+    label: "Marketing",
+  },
+  OPERATIONS: {
+    label: "Operations",
+  },
+  PRODUCT: {
+    label: "Product",
+  },
+  PRODUCT_MANAGEMENT: {
+    label: "Product Management",
+  },
+  PRODUCTIVITY: {
+    label: "Productivity",
+  },
+  SALES: {
+    label: "Sales",
+  },
+  UX_DESIGN: {
+    label: "UX Design",
+  },
+  UX_RESEARCH: {
+    label: "UX Research",
+  },
+  WRITING: {
+    label: "Writing",
+  },
+};
+
+export function isTemplateTagsArrayValid(
   value: unknown
-): value is AssistantTemplateTagNameType[] {
+): value is TemplateTagCodeType[] {
   return (
-    Array.isArray(value) &&
-    value.every((v) => assistantTemplateTagNames.includes(v))
+    Array.isArray(value) && value.every((v) => TEMPLATES_TAG_CODES.includes(v))
   );
 }
 
@@ -62,6 +111,10 @@ export const TemplateVisibilityCodec = ioTsEnum<TemplateVisibility>(
   "TemplateVisibility"
 );
 
+const TemplateTagCodeTypeCodec = t.keyof({
+  ...TEMPLATES_TAGS_CONFIG,
+});
+
 export const CreateTemplateFormSchema = t.type({
   backgroundColor: NonEmptyString,
   description: t.union([t.string, t.undefined]),
@@ -73,7 +126,7 @@ export const CreateTemplateFormSchema = t.type({
   presetInstructions: t.union([t.string, t.undefined]),
   presetModel: t.string,
   presetTemperature: AssistantCreativityLevelCodec,
-  tags: nonEmptyArray(t.string),
+  tags: nonEmptyArray(TemplateTagCodeTypeCodec),
 });
 
 export type CreateTemplateFormType = t.TypeOf<typeof CreateTemplateFormSchema>;


### PR DESCRIPTION
## Description

On the making issue there is a proposal to make Tags manageable from Poké: https://github.com/dust-tt/decisions/issues/179

> Tag management in Poke
I think being able to rename a tag, add a tag, remove a tag should be done in Poke.
Rename a tag in particular is sensible because otherwise it means going template by template to edit.

Since I'm expecting tags to not change too much, my counter proposal is to start with a second step before deciding to make them manageable from Poké. I'm simply introducing an Object to map the tag codes & a label, in case we want to change the label of a given tag. 

WDYT? 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

The change on the model file is just a rename of the type, no need to run init_db.
If we go with that I'll need to migrate all the existing prod templates.
