### PR TITLE
fix: dont add use_tools if not part of cnfig

### DIFF
--- a/front/lib/config.ts
+++ b/front/lib/config.ts
@@ -32,11 +32,10 @@ export function extractConfig(spec: SpecificationType): BlockRunConfig {
               ? spec[i].config.use_cache
               : false
             : false,
-          use_tools:
-            typeof spec[i].config.use_tools === "boolean"
-              ? spec[i].config.use_tools
-              : false,
         };
+        if (typeof spec[i].config.use_tools === "boolean") {
+          c[spec[i].name].use_tools = spec[i].config.use_tools;
+        }
         break;
       case "input":
         c[spec[i].name] = {


### PR DESCRIPTION
## Description

prevents clicking on "run" due to missing `use_tools`

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
