### PR TITLE
Fix Mistral chat completion

### DIFF
--- a/core/src/providers/mistral.rs
+++ b/core/src/providers/mistral.rs
@@ -154,7 +154,11 @@ impl TryFrom<&ChatMessage> for MistralChatMessage {
                 meta_prompt,
                 cm.content.clone().unwrap_or(String::from(""))
             )),
-            name: cm.name.clone(),
+            // Name is only supported for the Function/Tool role.
+            name: match cm.role {
+                ChatMessageRole::Function => cm.name.clone(),
+                _ => None,
+            },
             role: mistral_role,
             tool_calls: match cm.function_call.as_ref() {
                 Some(fc) => Some(vec![MistralToolCall::try_from(fc)?]),


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
We've observed several failures related to querying Mistral models, which appear to be tied to how we construct the chat completion object. Specifically, we've been including a `name` attribute for all completions, except that Mistral's API does not support this parameter ([doc](https://docs.mistral.ai/api/#operation/createChatCompletion)).

After some testing, `name` is only accepted when the role is set to function/tool. This PR adjusts our approach accordingly. To note: despite this change, we continue to inject the user/assistant name into the completion through the meta prompt.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
