### PR TITLE
Poké header: Make Poké logo clickable

### DIFF
--- a/front/components/poke/PokeNavbar.tsx
+++ b/front/components/poke/PokeNavbar.tsx
@@ -12,11 +12,10 @@ export const PokeNavbar: React.FC = () => (
     )}
   >
     <div className="flex items-center">
-      <Logo type="colored-grey" className="-mr-5 h-4 w-32 p-0" />
+      <Link href="/poke">
+        <Logo type="colored-grey" className="-mr-5 h-4 w-32 p-0" />
+      </Link>
       <div className="flex flex-row gap-4">
-        <Link href="/poke">
-          <div className="text-stucture-300 text-sm italic">Poké</div>
-        </Link>
         <Link href="/poke/plans">
           <div className="text-stucture-300 text-sm italic">Plans</div>
         </Link>


### PR DESCRIPTION
## Description

Make the logo clickable and redirecting to home, and remove the "Poké" link that was doing the same. 
(It was driving me crazy)

## Risk

/

## Deploy Plan

/
