### PR TITLE
Fixes for Poké Template form

### DIFF
--- a/front/components/poke/plans/createPlan.tsx
+++ b/front/components/poke/plans/createPlan.tsx
@@ -315,7 +315,7 @@ function SelectField({
           <PokeFormControl>
             <PokeSelect
               onValueChange={field.onChange}
-              defaultValue={field.value as string}
+              value={field.value as string}
             >
               <PokeFormControl>
                 <PokeSelectTrigger>

--- a/front/components/poke/subscriptions/EnterpriseUpgradeDialog.tsx
+++ b/front/components/poke/subscriptions/EnterpriseUpgradeDialog.tsx
@@ -61,7 +61,7 @@ function SelectField({
           <PokeFormControl>
             <PokeSelect
               onValueChange={field.onChange}
-              defaultValue={field.value as string}
+              value={field.value as string}
             >
               <PokeFormControl>
                 <PokeSelectTrigger>

--- a/front/lib/resources/template_resource.ts
+++ b/front/lib/resources/template_resource.ts
@@ -64,6 +64,7 @@ export class TemplateResource extends BaseResource<TemplateModel> {
 
     const blobs = await TemplateResource.model.findAll({
       where,
+      order: [["handle", "ASC"]],
     });
 
     return blobs.map(

--- a/front/pages/api/poke/templates/[tId].ts
+++ b/front/pages/api/poke/templates/[tId].ts
@@ -93,7 +93,7 @@ async function handler(
       }
 
       const model = USED_MODEL_CONFIGS.find(
-        (config) => config.modelId === body.presetModel
+        (config) => config.modelId === body.presetModelId
       );
 
       if (!model) {

--- a/front/pages/api/poke/templates/index.ts
+++ b/front/pages/api/poke/templates/index.ts
@@ -77,7 +77,7 @@ async function handler(
       }
 
       const model = USED_MODEL_CONFIGS.find(
-        (config) => config.modelId === body.presetModel
+        (config) => config.modelId === body.presetModelId
       );
 
       if (!model) {

--- a/front/pages/poke/templates/[tId].tsx
+++ b/front/pages/poke/templates/[tId].tsx
@@ -149,8 +149,8 @@ function SelectField({
           <PokeFormLabel className="capitalize">{title ?? name}</PokeFormLabel>
           <PokeFormControl>
             <PokeSelect
+              value={field.value as string}
               onValueChange={field.onChange}
-              defaultValue={field.value as string}
             >
               <PokeFormControl>
                 <PokeSelectTrigger>
@@ -253,7 +253,7 @@ function TemplatesPage({
       description: "",
       handle: "",
       presetInstructions: "",
-      presetModel: GPT_4_TURBO_MODEL_CONFIG.modelId,
+      presetModelId: GPT_4_TURBO_MODEL_CONFIG.modelId,
       presetTemperature: "balanced",
       presetAction: "reply",
       helpInstructions: "",
@@ -279,6 +279,11 @@ function TemplatesPage({
     );
   }
 
+  if (Object.keys(form.formState.errors).length > 0) {
+    // Useful to debug in case you have an error on a field that is not rendered
+    console.log("Form errors", form.formState.errors);
+  }
+
   return (
     <div className="min-h-screen bg-structure-50 pb-48">
       <PokeNavbar />
@@ -302,10 +307,11 @@ function TemplatesPage({
             />
             <SelectField
               control={form.control}
-              name="presetModel"
+              name="presetModelId"
               title="Preset Model"
               options={USED_MODEL_CONFIGS.map((config) => ({
                 value: config.modelId,
+                display: config.displayName,
               }))}
             />
             <SelectField
@@ -347,9 +353,7 @@ function TemplatesPage({
                     <MultiSelect
                       options={tagOptions}
                       value={field.value.map((tag: TemplateTagCodeType) => ({
-                        label: TEMPLATES_TAGS_CONFIG[tag]
-                          ? TEMPLATES_TAGS_CONFIG[tag].label
-                          : tag,
+                        label: TEMPLATES_TAGS_CONFIG[tag].label,
                         value: tag,
                       }))}
                       onChange={(tags: { label: string; value: string }[]) => {

--- a/types/src/front/assistant/templates.ts
+++ b/types/src/front/assistant/templates.ts
@@ -124,7 +124,7 @@ export const CreateTemplateFormSchema = t.type({
   helpInstructions: t.union([t.string, t.undefined]),
   presetAction: ActionPresetCodec,
   presetInstructions: t.union([t.string, t.undefined]),
-  presetModel: t.string,
+  presetModelId: t.string,
   presetTemperature: AssistantCreativityLevelCodec,
   tags: nonEmptyArray(TemplateTagCodeTypeCodec),
 });


### PR DESCRIPTION
## Description

- The select field were always displaying the default value.
- The preset model field was never updating the model selected. 

Unrelated: when we load all templates, load them ordered ASC on the handle. 

## Risk

/

## Deploy Plan

/
