### PR TITLE
Poké: allow deleting a template

### DIFF
--- a/front/pages/api/poke/templates/[tId].ts
+++ b/front/pages/api/poke/templates/[tId].ts
@@ -52,9 +52,11 @@ async function handler(
     });
   }
 
+  let template: TemplateResource | null = null;
+
   switch (req.method) {
     case "GET":
-      const template = await TemplateResource.fetchByExternalId(templateId);
+      template = await TemplateResource.fetchByExternalId(templateId);
       if (!template) {
         return apiError(req, res, {
           status_code: 404,
@@ -136,6 +138,25 @@ async function handler(
         // TODO
         visibility: "published",
       });
+
+      res.status(200).json({
+        success: true,
+      });
+      break;
+
+    case "DELETE":
+      template = await TemplateResource.fetchByExternalId(templateId);
+      if (!template) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "template_not_found",
+            message: "Could not find the template.",
+          },
+        });
+      }
+
+      await template.delete();
 
       res.status(200).json({
         success: true,

--- a/front/pages/poke/templates/[tId].tsx
+++ b/front/pages/poke/templates/[tId].tsx
@@ -250,12 +250,15 @@ function TemplatesPage({
 
   const { submit: onDelete } = useSubmitFunction(async () => {
     if (assistantTemplate === null) {
-      throw "unreachable";
+      window.alert(
+        "An error occurred while attempting to delete the template (can't find the template)."
+      );
+      return;
     }
 
     if (
       !window.confirm(
-        "Are you sure you want to delete this template? There's no going back"
+        "Are you sure you want to delete this template? There's no going back."
       )
     ) {
       return;

--- a/front/pages/poke/templates/[tId].tsx
+++ b/front/pages/poke/templates/[tId].tsx
@@ -40,6 +40,7 @@ import {
 } from "@app/components/poke/shadcn/ui/select";
 import { PokeTextarea } from "@app/components/poke/shadcn/ui/textarea";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
+import { useSubmitFunction } from "@app/lib/client/utils";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import { usePokeAssistantTemplate } from "@app/poke/swr";
 
@@ -247,6 +248,37 @@ function TemplatesPage({
     [assistantTemplate, sendNotification, setIsSubmitting, router]
   );
 
+  const { submit: onDelete } = useSubmitFunction(async () => {
+    if (assistantTemplate === null) {
+      throw "unreachable";
+    }
+
+    if (
+      !window.confirm(
+        "Are you sure you want to delete this template? There's no going back"
+      )
+    ) {
+      return;
+    }
+    try {
+      const r = await fetch(`/api/poke/templates/${assistantTemplate.sId}`, {
+        method: "DELETE",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+      if (!r.ok) {
+        throw new Error("Failed to delete template.");
+      }
+      await router.push("/poke/templates");
+    } catch (e) {
+      console.error(e);
+      window.alert(
+        "An error occurred while attempting to delete the template."
+      );
+    }
+  });
+
   const form = useForm<CreateTemplateFormType>({
     resolver: ioTsResolver(CreateTemplateFormSchema),
     defaultValues: {
@@ -373,9 +405,18 @@ function TemplatesPage({
               name="backgroundColor"
               placeholder="tailwind color code"
             />
-            <PokeButton type="submit" className="border border-structure-300">
-              Submit
-            </PokeButton>
+            <div className="space flex justify-between">
+              <PokeButton type="submit" className="border border-structure-300">
+                Submit
+              </PokeButton>
+              <PokeButton
+                type="button"
+                variant="destructive"
+                onClick={onDelete}
+              >
+                Delete this template
+              </PokeButton>
+            </div>
           </form>
         </PokeForm>
       </div>


### PR DESCRIPTION
## Description

Adds ability to delete a template on Poké.

Button was added at the end of the template form: 

<img width="802" alt="Screenshot 2024-04-18 at 13 54 33" src="https://github.com/dust-tt/dust/assets/3803406/22fd3157-0ee3-4bc8-8a48-1e5e3767de49">

## Risk

/

## Deploy Plan

/
