### PR TITLE
Template Modal: description renders Markdown

### DIFF
--- a/front/components/assistant_builder/AssistantTemplateModal.tsx
+++ b/front/components/assistant_builder/AssistantTemplateModal.tsx
@@ -1,4 +1,11 @@
-import { Avatar, Button, ElementModal, Page, Spinner2 } from "@dust-tt/sparkle";
+import {
+  Avatar,
+  Button,
+  ElementModal,
+  Markdown,
+  Page,
+  Spinner2,
+} from "@dust-tt/sparkle";
 import type { WorkspaceType } from "@dust-tt/types";
 import Link from "next/link";
 
@@ -71,7 +78,7 @@ export function AssistantTemplateModal({
             </div>
           </div>
           <p className="whitespace-pre-line text-sm font-normal text-element-900">
-            {description}
+            <Markdown content={description ?? ""} />
           </p>
           <InstructionsSection instructions={presetInstructions} />
         </div>


### PR DESCRIPTION
## Description

This PR renders the markdown on the description of an Assistant in the Template Modal. 
It was much easier than I expected, discovering this Sparkle component was the good news of the day 😄 


## Risk

/ 

## Deploy Plan

/ 