### PR TITLE
 feat(structured date): unique table names for SQLite databases

### DIFF
--- a/core/src/databases/database.rs
+++ b/core/src/databases/database.rs
@@ -469,7 +469,7 @@ pub fn get_unique_table_names_for_database(tables: &[Table]) -> HashMap<String, 
                 table.unique_id(),
                 match *count {
                     1 => base_name.to_string(),
-                    _ => format!("{}_{}", base_name, count),
+                    _ => format!("{}_{}", base_name, *count - 1),
                 },
             )
         })

--- a/core/src/databases/database.rs
+++ b/core/src/databases/database.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use super::table_schema::TableSchema;
 use crate::{
     databases_store::store::DatabasesStore,
@@ -196,12 +198,16 @@ impl Table {
         get_table_unique_id(&self.project, &self.data_source_id, &self.table_id)
     }
 
-    pub fn render_dbml(&self) -> String {
+    pub fn render_dbml(&self, name: Option<&str>) -> String {
+        let name = match name {
+            Some(name) => name,
+            None => self.name(),
+        };
         match self.schema {
-            None => format!("Table {} {{\n}}", self.name()),
+            None => format!("Table {} {{\n}}", name),
             Some(ref schema) => format!(
                 "Table {} {{\n{}\n\n  Note: '{}'\n}}",
-                self.name(),
+                name,
                 schema
                     .columns()
                     .iter()
@@ -448,6 +454,28 @@ impl HasValue for QueryResult {
     }
 }
 
+pub fn get_unique_table_names_for_database(tables: &[Table]) -> HashMap<String, String> {
+    let mut name_count: HashMap<&str, usize> = HashMap::new();
+
+    tables
+        .iter()
+        .sorted_by_key(|table| table.unique_id())
+        .map(|table| {
+            let base_name = table.name();
+            let count = name_count.entry(base_name).or_insert(0);
+            *count += 1;
+
+            (
+                table.unique_id(),
+                match *count {
+                    1 => base_name.to_string(),
+                    _ => format!("{}_{}", base_name, count),
+                },
+            )
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -496,7 +524,7 @@ mod tests {
   Note: 'Test records for DBML rendering'
 }"#
         .to_string();
-        assert_eq!(table.render_dbml(), expected);
+        assert_eq!(table.render_dbml(None), expected);
 
         Ok(())
     }

--- a/core/src/stores/migrations/20240418_remove_table_name_unique_index
+++ b/core/src/stores/migrations/20240418_remove_table_name_unique_index
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_tables_data_source_table_name;

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -415,7 +415,7 @@ pub const POSTGRES_TABLES: [&'static str; 14] = [
     );",
 ];
 
-pub const SQL_INDEXES: [&'static str; 22] = [
+pub const SQL_INDEXES: [&'static str; 21] = [
     "CREATE INDEX IF NOT EXISTS
        idx_specifications_project_created ON specifications (project, created);",
     "CREATE INDEX IF NOT EXISTS
@@ -462,8 +462,6 @@ pub const SQL_INDEXES: [&'static str; 22] = [
        idx_databases_table_ids_hash ON databases (table_ids_hash);",
     "CREATE UNIQUE INDEX IF NOT EXISTS
        idx_tables_data_source_table_id ON tables (data_source, table_id);",
-    "CREATE UNIQUE INDEX IF NOT EXISTS
-       idx_tables_data_source_table_name ON tables (data_source, name);",
     "CREATE UNIQUE INDEX IF NOT EXISTS
         idx_sqlite_workers_url ON sqlite_workers (url);",
 ];


### PR DESCRIPTION
## Description

first step for https://github.com/dust-tt/tasks/issues/637

We are currently enforcing uniqueness on the table name per data source. The rationale is that we need unique table names when constructing the database or returning the schema, as a SQLite database cannot have several tables with the same name (obviously) and a model cannot generate a proper query if several tables have identical names. This is problematic because:
- it forces us to add some unique identifier in table names (from eg google drive) to make them unique, often leading to very long, convoluted, and meaningless table names, which negatively impacts model performance.
- even adding those identifiers, we sometimes run into errors
- the unique identifiers make it really hard for users to understand the assistant builder UI, as they see some weird names instead of the actual name of their spreadsheets / databases / csv.

This PR removes the constraint at database level, and adds a deterministic algo to compute unique table names from a set of tables right before returning a DB schema and right before constructing the in-memory sqlite DB.


Next step is to update connectors code to remove the unique identifiers from table names

## Risk

blast radius limited to tables query

## Deploy Plan

deploy code, run migration