### PR TITLE
fix(google drive): put connector in error when drive is not found

### DIFF
--- a/connectors/src/connectors/google_drive/lib.ts
+++ b/connectors/src/connectors/google_drive/lib.ts
@@ -21,7 +21,7 @@ import {
   getAuthObject,
   getDriveClient,
 } from "@connectors/connectors/google_drive/temporal/utils";
-import { HTTPError } from "@connectors/lib/error";
+import { ExternalOauthTokenError, HTTPError } from "@connectors/lib/error";
 import {
   GoogleDriveFiles,
   GoogleDriveSheet,
@@ -73,7 +73,11 @@ export async function ensureWebhookForDriveId(
     const auth = await getAuthObject(connector.connectionId);
     const remoteFile = await getGoogleDriveObject(auth, driveId);
     if (!remoteFile) {
-      throw new Error(`Drive with id ${driveId} not found`);
+      logger.error(
+        { driveId, connectorId: connector.id },
+        "Could not get remote drive."
+      );
+      throw new ExternalOauthTokenError();
     }
     const res = await registerWebhook(
       connector,


### PR DESCRIPTION
## Description

Currently renew webhook fails because we cannot pull the remote drive. This indicates that we either don't have permission to do so or the drive no longer exists. 
Regardless, we want to put the connector in error instead of failing .

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
