### PR TITLE
Fix Open AI tool_choice

### DIFF
--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -131,8 +131,8 @@ impl FromStr for OpenAIToolChoice {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "auto" => Ok(OpenAIToolChoice::Control(Control::Auto)),
-            "none" => Ok(OpenAIToolChoice::Control(Control::None)),
+            "auto" => Ok(OpenAIToolChoice::OpenAIToolControl(OpenAIToolControl::Auto)),
+            "none" => Ok(OpenAIToolChoice::OpenAIToolControl(OpenAIToolControl::None)),
             _ => {
                 let function = OpenAIFunctionCall {
                     r#type: OpenAIToolType::Function,

--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -100,9 +100,16 @@ pub struct OpenAIFunctionCall {
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 #[serde(rename_all = "lowercase")]
-pub enum OpenAIToolChoice {
+pub enum OpenAIToolControl {
     Auto,
     None,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[serde(untagged)]
+
+pub enum OpenAIToolChoice {
+    OpenAIToolControl(OpenAIToolControl),
     OpenAIFunctionCall(OpenAIFunctionCall),
 }
 
@@ -124,8 +131,8 @@ impl FromStr for OpenAIToolChoice {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "auto" => Ok(OpenAIToolChoice::Auto),
-            "none" => Ok(OpenAIToolChoice::None),
+            "auto" => Ok(OpenAIToolChoice::Control(Control::Auto)),
+            "none" => Ok(OpenAIToolChoice::Control(Control::None)),
             _ => {
                 let function = OpenAIFunctionCall {
                     r#type: OpenAIToolType::Function,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
In https://github.com/dust-tt/dust/pull/4746 we introduced tools in our Open AI provider code. While testing on front-edge I noticed an issue on how the `tool_choice` gets serialized by serde.

This PR fixes the serialization by using `untagged` ([doc](https://serde.rs/enum-representations.html#externally-tagged)). This is required as Open AI's type for `tool_choice` is defined as such:
- `none` means the model will not call a function and instead generates a message
- `auto` means the model can pick between generating a message or calling a function.
- ` {"type": "function", "function": {"name": "my_function"}}` Specifying a particular function forces the model to call that function.

## Risk

Low risk, not yet used in production. Successfully tested locally. Safe to rollback.
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
