### PR TITLE
enh: remove unique IDs from connector table names

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
+++ b/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
@@ -3,6 +3,7 @@ import {
   getGoogleSheetTableId,
   getSanitizedHeaders,
   InvalidStructuredDataHeaderError,
+  slugify,
 } from "@dust-tt/types";
 import { Context } from "@temporalio/activity";
 import { stringify } from "csv-stringify/sync";
@@ -15,7 +16,6 @@ import { concurrentExecutor } from "@connectors/lib/async_utils";
 import { deleteTable, upsertTableFromCsv } from "@connectors/lib/data_sources";
 import type { GoogleDriveFiles } from "@connectors/lib/models/google_drive";
 import { GoogleDriveSheet } from "@connectors/lib/models/google_drive";
-import { makeStructuredDataTableName } from "@connectors/lib/structured_data";
 import type { Logger } from "@connectors/logger/logger";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
@@ -53,8 +53,9 @@ async function upsertTable(
   const { id, spreadsheet, title } = sheet;
   const tableId = getGoogleSheetTableId(spreadsheet.id, id);
 
-  const name = `${spreadsheet.title} - ${title}`;
-  const tableName = makeStructuredDataTableName(name);
+  const tableName = slugify(
+    `${spreadsheet.title.substring(0, 16)}-${title.substring(0, 16)}`
+  );
 
   const tableDescription = `Structured data from the Google Spreadsheet (${spreadsheet.title}) and sheet (${title}`;
 

--- a/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
+++ b/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
@@ -54,10 +54,7 @@ async function upsertTable(
   const tableId = getGoogleSheetTableId(spreadsheet.id, id);
 
   const name = `${spreadsheet.title} - ${title}`;
-  const tableName = makeStructuredDataTableName(
-    name,
-    `${spreadsheet.id}-${sheet.id}`
-  );
+  const tableName = makeStructuredDataTableName(name);
 
   const tableDescription = `Structured data from the Google Spreadsheet (${spreadsheet.title}) and sheet (${title}`;
 

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -4,7 +4,7 @@ import type {
   NotionGarbageCollectionMode,
 } from "@dust-tt/types";
 import type { PageObjectProperties, ParsedNotionBlock } from "@dust-tt/types";
-import { assertNever, getNotionDatabaseTableId } from "@dust-tt/types";
+import { assertNever, getNotionDatabaseTableId, slugify } from "@dust-tt/types";
 import { isFullBlock, isFullPage, isNotionClientError } from "@notionhq/client";
 import type { PageObjectResponse } from "@notionhq/client/build/src/api-endpoints";
 import { Context } from "@temporalio/activity";
@@ -65,7 +65,6 @@ import {
 } from "@connectors/lib/models/notion";
 import { getAccessTokenFromNango } from "@connectors/lib/nango_helpers";
 import { redisClient } from "@connectors/lib/redis";
-import { makeStructuredDataTableName } from "@connectors/lib/structured_data";
 import { syncStarted, syncSucceeded } from "@connectors/lib/sync_status";
 import { heartbeat } from "@connectors/lib/temporal";
 import mainLogger from "@connectors/logger/logger";
@@ -2445,7 +2444,7 @@ function getTableInfoFromDatabase(database: NotionDatabase): {
   const tableId = getNotionDatabaseTableId(database.notionDatabaseId);
   const name =
     database.title ?? `Untitled Database (${database.notionDatabaseId})`;
-  const tableName = makeStructuredDataTableName(name);
+  const tableName = slugify(name.substring(0, 32));
 
   const tableDescription = `Structured data from Notion Database ${tableName}`;
   return { databaseName: name, tableId, tableName, tableDescription };

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -2445,10 +2445,7 @@ function getTableInfoFromDatabase(database: NotionDatabase): {
   const tableId = getNotionDatabaseTableId(database.notionDatabaseId);
   const name =
     database.title ?? `Untitled Database (${database.notionDatabaseId})`;
-  const tableName = makeStructuredDataTableName(
-    name,
-    database.notionDatabaseId
-  );
+  const tableName = makeStructuredDataTableName(name);
 
   const tableDescription = `Structured data from Notion Database ${tableName}`;
   return { databaseName: name, tableId, tableName, tableDescription };

--- a/connectors/src/lib/structured_data.ts
+++ b/connectors/src/lib/structured_data.ts
@@ -1,6 +1,0 @@
-import { slugify } from "@dust-tt/types";
-
-export function makeStructuredDataTableName(name: string) {
-  // Keep a maximum of 32 characters of the name and slugify it.
-  return slugify(name.substring(0, 32));
-}

--- a/connectors/src/lib/structured_data.ts
+++ b/connectors/src/lib/structured_data.ts
@@ -1,21 +1,6 @@
 import { slugify } from "@dust-tt/types";
-import { hash as blake3 } from "blake3";
 
-// Extracting this helper due to incompatibility with blake3 in types.
-
-export function makeStructuredDataTableName(name: string, externalId: string) {
-  // Compute a blake3 hash of the externalId and name to avoid conflicts.
-  const hash = blake3(`${externalId}-${name}`).toString("hex");
-
-  // Define the prefix as the first 6 characters of the hash.
-  const externalIdPrefix = hash.substring(0, 6);
-
-  // Use the 6 last characters of the external id as a suffix (for user mapping to external data).
-  const externalIdSuffix = externalId.toLowerCase().slice(-6);
-
-  // Keep a maximum of 32 characters of the name.
-  const truncatedName = name.substring(0, 32);
-
-  // Concatenate everything.
-  return slugify(`${truncatedName}_${externalIdPrefix}_${externalIdSuffix}`);
+export function makeStructuredDataTableName(name: string) {
+  // Keep a maximum of 32 characters of the name and slugify it.
+  return slugify(name.substring(0, 32));
 }


### PR DESCRIPTION
## Description


Fixes https://github.com/dust-tt/tasks/issues/637
No longer needed. The constraint in core DB is gone, and there is just-in-time dedup performed in core.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
