### PR TITLE
fix(mistral): remove name param from content fragment user msg

### DIFF
--- a/core/src/providers/mistral.rs
+++ b/core/src/providers/mistral.rs
@@ -161,8 +161,8 @@ impl TryFrom<&ChatMessage> for MistralChatMessage {
                 cm.content.clone().unwrap_or(String::from(""))
             )),
             // Name is only supported for the Function/Tool role.
-            name: match cm.role {
-                ChatMessageRole::Function => cm.name.clone(),
+            name: match mistral_role {
+                MistralChatMessageRole::Tool => cm.name.clone(),
                 _ => None,
             },
             role: mistral_role,
@@ -368,6 +368,8 @@ impl MistralAILLM {
             .map(|m| MistralChatMessage::try_from(m))
             .collect::<Result<Vec<_>>>()?;
 
+        // Mistral AI requires a tool call to be followed by a tool message. We therefore inject a
+        // tool call message before the tool message if missing.
         let mistral_messages = mistral_messages.iter().fold(
             vec![],
             |mut acc: Vec<MistralChatMessage>, cm: &MistralChatMessage| {


### PR DESCRIPTION
## Description

https://github.com/dust-tt/tasks/issues/680

`name` is no longer accepted unless the `role` is `tool`

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
