### PR TITLE
fix(structured data): notion DB name should not be empty

### DIFF
--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -2442,10 +2442,18 @@ function getTableInfoFromDatabase(database: NotionDatabase): {
   tableDescription: string;
 } {
   const tableId = getNotionDatabaseTableId(database.notionDatabaseId);
-  const name =
-    database.title ?? `Untitled Database (${database.notionDatabaseId})`;
-  const tableName = slugify(name.substring(0, 32));
+  const fallbackName = `Untitled Database (${database.notionDatabaseId})`;
+
+  let tableName = slugify((database.title ?? "").substring(0, 32));
+  if (!tableName) {
+    tableName = slugify(fallbackName.substring(0, 32));
+  }
 
   const tableDescription = `Structured data from Notion Database ${tableName}`;
-  return { databaseName: name, tableId, tableName, tableDescription };
+  return {
+    databaseName: database.title || fallbackName,
+    tableId,
+    tableName,
+    tableDescription,
+  };
 }


### PR DESCRIPTION
## Description

[datadog](https://app.datadoghq.eu/logs?query=unhandled%20&cols=host%2Cservice&event=AgAAAY72_u-WzdOZdQAAAAAAAAAYAAAAAEFZNzJfdm9kQUFDdmhQOE9aRzdPSkFDbgAAACQAAAAAMDE4ZWY2ZmYtMWZkYy00ZTQ2LTlmYjgtNzZkYzQ0YmQyMjE3&fromUser=true&index=%2A&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1713532682093&to_ts=1713533582093&live=true)

Notion db title may be an empty string. We don't allow it.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
