### PR TITLE
generation / multi-actions: allow multiple retrievals

### DIFF
--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -69,8 +69,6 @@ export async function renderConversationForModel({
 > {
   const messages: ModelMessageType[] = [];
 
-  let retrievalFound = false;
-
   // Render all messages and all actions but only keep the latest retrieval action.
   for (let i = conversation.content.length - 1; i >= 0; i--) {
     const versions = conversation.content[i];
@@ -86,10 +84,7 @@ export async function renderConversationForModel({
       }
       if (m.action) {
         if (isRetrievalActionType(m.action)) {
-          if (!retrievalFound) {
-            messages.unshift(renderRetrievalActionForModel(m.action));
-            retrievalFound = true;
-          }
+          messages.unshift(renderRetrievalActionForModel(m.action));
         } else if (isDustAppRunActionType(m.action)) {
           messages.unshift(renderDustAppRunActionForModel(m.action));
         } else if (isTablesQueryActionType(m.action)) {

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -69,7 +69,7 @@ export async function renderConversationForModel({
 > {
   const messages: ModelMessageType[] = [];
 
-  // Render all messages and all actions but only keep the latest retrieval action.
+  // Render all messages and all actions.
   for (let i = conversation.content.length - 1; i >= 0; i--) {
     const versions = conversation.content[i];
     const m = versions[versions.length - 1];


### PR DESCRIPTION
## Description

As we move towards multi-actions, we want to remove this condition that does not include more than one retrieval in the conversation.

Rationale: an agent may decide to proceed to multiple retrievals to achieve a workflow

## Risk

This may impact existing assistants but I think the risk is somewhat limited.

## Deploy Plan

- deploy `front`