### PR TITLE
Rework Builder Layout for Templates

### DIFF
--- a/front/components/assistant/TryAssistant.tsx
+++ b/front/components/assistant/TryAssistant.tsx
@@ -265,7 +265,7 @@ export function usePreviewAssistant({
   };
 }
 
-function useTryAssistantCore({
+export function useTryAssistantCore({
   owner,
   user,
   assistant,

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -169,9 +169,17 @@ const useNavigationLock = (
 };
 
 const screens = {
-  instructions: { label: "Instructions", icon: CircleIcon },
-  actions: { label: "Data sources & Actions", icon: SquareIcon },
-  naming: { label: "Naming", icon: TriangleIcon },
+  instructions: {
+    label: "Instructions",
+    icon: CircleIcon,
+    helpContainer: "instructions-help-container",
+  },
+  actions: {
+    label: "Data sources & Actions",
+    icon: SquareIcon,
+    helpContainer: "actions-help-container",
+  },
+  naming: { label: "Naming", icon: TriangleIcon, helpContainer: null },
 };
 type BuilderScreen = keyof typeof screens;
 
@@ -427,11 +435,18 @@ export default function AssistantBuilder({
   const [screen, setScreen] = useState<BuilderScreen>("instructions");
   const tabs = useMemo(
     () =>
-      Object.entries(screens).map(([key, { label, icon }]) => ({
+      Object.entries(screens).map(([key, { label, icon, helpContainer }]) => ({
         label,
         current: screen === key,
         onClick: () => {
           setScreen(key as BuilderScreen);
+
+          if (helpContainer) {
+            const element = document.getElementById(helpContainer);
+            if (element) {
+              element.scrollIntoView({ behavior: "smooth" });
+            }
+          }
         },
         icon,
       })),

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -1,8 +1,9 @@
 import "react-image-crop/dist/ReactCrop.css";
 
 import {
-  BuilderLayout,
   Button,
+  ChevronLeftIcon,
+  ChevronRightIcon,
   CircleIcon,
   SquareIcon,
   Tab,
@@ -57,6 +58,7 @@ import { subNavigationBuild } from "@app/components/sparkle/navigation";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { isUpgraded } from "@app/lib/plans/plan_codes";
 import { useSlackChannelsLinkedWithAgent } from "@app/lib/swr";
+import { classNames } from "@app/lib/utils";
 import type { FetchAssistantTemplateResponse } from "@app/pages/api/w/[wId]/assistant/builder/templates/[tId]";
 
 type SlackChannel = { slackChannelId: string; slackChannelName: string };
@@ -775,4 +777,56 @@ export async function submitAssistantBuilderForm({
   }
 
   return newAgentConfiguration.agentConfiguration;
+}
+
+export function BuilderLayout({
+  leftPanel,
+  rightPanel,
+  isRightPanelOpen,
+  toggleRightPanel,
+}: {
+  leftPanel: React.ReactNode;
+  rightPanel: React.ReactNode;
+  isRightPanelOpen: boolean;
+  toggleRightPanel: () => void;
+}) {
+  return (
+    <>
+      <div className="flex px-4 lg:hidden">
+        <div className="h-full w-full max-w-[900px]">{leftPanel}</div>
+      </div>
+      <div className="hidden h-full lg:flex">
+        <div className="h-full w-full">
+          <div className="flex h-full w-full items-center gap-4 px-5">
+            <div className="flex h-full grow justify-center">
+              <div className="h-full w-full max-w-[900px]">{leftPanel}</div>
+            </div>
+            <Button
+              label="Preview"
+              labelVisible={isRightPanelOpen ? false : true}
+              size="md"
+              variant={isRightPanelOpen ? "tertiary" : "primary"}
+              icon={isRightPanelOpen ? ChevronRightIcon : ChevronLeftIcon}
+              onClick={toggleRightPanel}
+            />
+            <div
+              className={classNames(
+                "duration-400 s-h-full transition-opacity ease-out",
+                isRightPanelOpen ? "opacity-100" : "opacity-0"
+              )}
+            >
+              <div
+                className={classNames(
+                  "duration-800 h-full transition-all ease-out",
+                  isRightPanelOpen ? "w-[440px]" : "w-0"
+                )}
+              >
+                {rightPanel}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
 }

--- a/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
+++ b/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
@@ -96,7 +96,9 @@ export default function AssistantBuilderPreviewDrawer({
       )}
       <div
         className={classNames(
-          "grow-1 mb-5 h-full overflow-y-auto bg-structure-50 pt-5",
+          template !== null
+            ? "grow-1 mb-5 h-full overflow-y-auto rounded-b-xl border-x border-b border-structure-200 bg-structure-50 pt-5"
+            : "grow-1 mb-5 mt-5 h-full overflow-y-auto rounded-xl border border-structure-200 bg-structure-50",
           shouldAnimatePreviewDrawer &&
             previewDrawerOpenedAt != null &&
             // Only animate the reload if the drawer has been open for at least 1 second.
@@ -126,7 +128,7 @@ export default function AssistantBuilderPreviewDrawer({
                   />
                 )}
               </div>
-              <div className="shrink-0 pb-2">
+              <div className="shrink-0">
                 <AssistantInputBar
                   owner={owner}
                   onSubmit={handleSubmit}
@@ -135,7 +137,7 @@ export default function AssistantBuilderPreviewDrawer({
                   additionalAgentConfiguration={draftAssistant}
                   hideQuickActions
                   disableAutoFocus
-                  isFloating={true}
+                  isFloating={false}
                 />
               </div>
             </GenerationContextProvider>

--- a/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
+++ b/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
@@ -1,17 +1,25 @@
 import {
   ChatBubbleBottomCenterTextIcon,
+  ContextItem,
+  LightbulbIcon,
   Markdown,
+  Page,
   Tab,
   TemplateIcon,
 } from "@dust-tt/sparkle";
 import type { WorkspaceType } from "@dust-tt/types";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
+import ConversationViewer from "@app/components/assistant/conversation/ConversationViewer";
+import { GenerationContextProvider } from "@app/components/assistant/conversation/GenerationContextProvider";
+import { AssistantInputBar } from "@app/components/assistant/conversation/input_bar/InputBar";
+import { CONVERSATION_PARENT_SCROLL_DIV_ID } from "@app/components/assistant/conversation/lib";
 import {
-  TryAssistant,
   usePreviewAssistant,
+  useTryAssistantCore,
 } from "@app/components/assistant/TryAssistant";
 import type { AssistantBuilderState } from "@app/components/assistant_builder/types";
+import { useUser } from "@app/lib/swr";
 import { classNames } from "@app/lib/utils";
 import type { FetchAssistantTemplateResponse } from "@app/pages/api/w/[wId]/assistant/builder/templates/[tId]";
 
@@ -33,20 +41,20 @@ export default function AssistantBuilderPreviewDrawer({
   const previewDrawerTabs = useMemo(
     () => [
       {
-        label: "Preview",
-        current: previewDrawerCurrentTab === "Preview",
-        onClick: () => {
-          setPreviewDrawerCurrentTab("Preview");
-        },
-        icon: ChatBubbleBottomCenterTextIcon,
-      },
-      {
         label: "Template",
         current: previewDrawerCurrentTab === "Template",
         onClick: () => {
           setPreviewDrawerCurrentTab("Template");
         },
         icon: TemplateIcon,
+      },
+      {
+        label: "Preview",
+        current: previewDrawerCurrentTab === "Preview",
+        onClick: () => {
+          setPreviewDrawerCurrentTab("Preview");
+        },
+        icon: ChatBubbleBottomCenterTextIcon,
       },
     ],
     [previewDrawerCurrentTab]
@@ -58,40 +66,105 @@ export default function AssistantBuilderPreviewDrawer({
     isFading,
   } = usePreviewAssistant({ owner, builderState });
 
+  const { user } = useUser();
+  const {
+    conversation,
+    setConversation,
+    stickyMentions,
+    setStickyMentions,
+    handleSubmit,
+  } = useTryAssistantCore({
+    owner,
+    user,
+    assistant: draftAssistant,
+  });
+
+  useEffect(() => {
+    setConversation(null);
+  }, [draftAssistant?.sId, setConversation]);
+
   return (
-    <div className="h-full pb-5">
-      {template ? (
-        <Tab
-          tabs={previewDrawerTabs}
-          variant="default"
-          className="hidden lg:flex"
-        />
-      ) : null}
-      {previewDrawerCurrentTab === "Preview" ? (
-        <div
-          className={classNames(
-            "flex h-full w-full overflow-hidden rounded-xl border border-structure-200 bg-structure-50 transition-all",
-            shouldAnimatePreviewDrawer &&
-              previewDrawerOpenedAt != null &&
-              // Only animate the reload if the drawer has been open for at least 1 second.
-              // This is to prevent the animation from triggering right after the drawer is opened.
-              Date.now() - previewDrawerOpenedAt > 1000
-              ? "animate-reload"
-              : ""
-          )}
-        >
-          <TryAssistant
-            owner={owner}
-            assistant={draftAssistant}
-            conversationFading={isFading}
+    <div className="flex h-full flex-col">
+      {template && (
+        <div className="shrink-0 bg-white pt-5">
+          <Tab
+            tabs={previewDrawerTabs}
+            variant="default"
+            className="hidden lg:flex"
           />
         </div>
-      ) : (
-        <Markdown
-          content={template?.helpInstructions ?? ""}
-          className="pr-8 pt-4"
-        />
       )}
+      <div
+        className={classNames(
+          "grow-1 h-full overflow-y-auto bg-structure-50 pt-5",
+          shouldAnimatePreviewDrawer &&
+            previewDrawerOpenedAt != null &&
+            // Only animate the reload if the drawer has been open for at least 1 second.
+            // This is to prevent the animation from triggering right after the drawer is opened.
+            Date.now() - previewDrawerOpenedAt > 1000
+            ? "animate-reload"
+            : ""
+        )}
+      >
+        {previewDrawerCurrentTab === "Preview" && user && draftAssistant && (
+          <div className="flex h-full w-full flex-1 flex-col justify-between">
+            <GenerationContextProvider>
+              <div
+                className="flex-grow overflow-y-auto overflow-x-hidden"
+                id={CONVERSATION_PARENT_SCROLL_DIV_ID.modal}
+              >
+                {conversation && (
+                  <ConversationViewer
+                    owner={owner}
+                    user={user}
+                    conversationId={conversation.sId}
+                    onStickyMentionsChange={setStickyMentions}
+                    isInModal
+                    hideReactions
+                    isFading={isFading}
+                    key={conversation.sId}
+                  />
+                )}
+              </div>
+              <div className="shrink-0 pb-2">
+                <AssistantInputBar
+                  owner={owner}
+                  onSubmit={handleSubmit}
+                  stickyMentions={stickyMentions}
+                  conversationId={conversation?.sId || null}
+                  additionalAgentConfiguration={draftAssistant}
+                  hideQuickActions
+                  disableAutoFocus
+                  isFloating={true}
+                />
+              </div>
+            </GenerationContextProvider>
+          </div>
+        )}
+        {previewDrawerCurrentTab === "Template" && (
+          <div className="pb-6 pl-6 pt-2">
+            <Page.Header icon={LightbulbIcon} title="Template's User manual" />
+            <Page.Separator />
+            <ContextItem.SectionHeader
+              title='"Instructions" guide'
+              hasBorder={false}
+            />
+            <Markdown
+              content={template?.helpInstructions ?? ""}
+              className="pr-8 pt-4"
+            />
+            <Page.Separator />
+            <ContextItem.SectionHeader
+              title='"Actions" guide'
+              hasBorder={false}
+            />
+            <Markdown
+              content={template?.helpActions ?? ""}
+              className="pr-8 pt-4"
+            />
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
+++ b/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
@@ -2,10 +2,10 @@ import {
   ChatBubbleBottomCenterTextIcon,
   ContextItem,
   LightbulbIcon,
+  MagicIcon,
   Markdown,
   Page,
   Tab,
-  TemplateIcon,
 } from "@dust-tt/sparkle";
 import type { WorkspaceType } from "@dust-tt/types";
 import { useEffect, useMemo, useState } from "react";
@@ -46,7 +46,7 @@ export default function AssistantBuilderPreviewDrawer({
         onClick: () => {
           setPreviewDrawerCurrentTab("Template");
         },
-        icon: TemplateIcon,
+        icon: MagicIcon,
       },
       {
         label: "Preview",
@@ -96,7 +96,7 @@ export default function AssistantBuilderPreviewDrawer({
       )}
       <div
         className={classNames(
-          "grow-1 h-full overflow-y-auto bg-structure-50 pt-5",
+          "grow-1 mb-5 h-full overflow-y-auto bg-structure-50 pt-5",
           shouldAnimatePreviewDrawer &&
             previewDrawerOpenedAt != null &&
             // Only animate the reload if the drawer has been open for at least 1 second.
@@ -142,26 +142,28 @@ export default function AssistantBuilderPreviewDrawer({
           </div>
         )}
         {previewDrawerCurrentTab === "Template" && (
-          <div className="pb-6 pl-6 pt-2">
+          <div className="mb-72 flex flex-col gap-4 px-6">
             <Page.Header icon={LightbulbIcon} title="Template's User manual" />
             <Page.Separator />
-            <ContextItem.SectionHeader
-              title='"Instructions" guide'
-              hasBorder={false}
-            />
-            <Markdown
-              content={template?.helpInstructions ?? ""}
-              className="pr-8 pt-4"
-            />
+            <div id="instructions-help-container">
+              <ContextItem.SectionHeader
+                title='"Instructions" guide'
+                hasBorder={false}
+              />
+              <Markdown
+                content={template?.helpInstructions ?? ""}
+                className=""
+              />
+            </div>
             <Page.Separator />
-            <ContextItem.SectionHeader
-              title='"Actions" guide'
-              hasBorder={false}
-            />
-            <Markdown
-              content={template?.helpActions ?? ""}
-              className="pr-8 pt-4"
-            />
+
+            <div id="actions-help-container">
+              <ContextItem.SectionHeader
+                title='"Actions" guide'
+                hasBorder={false}
+              />
+              <Markdown content={template?.helpActions ?? ""} className="" />
+            </div>
           </div>
         )}
       </div>


### PR DESCRIPTION
## Description

### Updates the Assistant Builder Layout to match better what's in the Figma: 

- The right sidebar has a fixed header (fixed with the rest of the page).
- The template tab in sidebar is scrollable but the header stays fixed. 
- The preview tab is scrollable with a fixed header and a fixed input bar.
-> It required updating both `<AssistantBuilder> and the children component that we pass it -> I decided to not use the related Sparkle component but instead re-introduce it on /front since I don't think it's truly a reusable component. 


### Updates the Template's tab in sidebar

- Use the new icon, and display both the Instruction & action help content on the sidebar modal. 
- When we click on the "Instruction" or "Action & Data Sources" tab, there's smooth scroll to the valid section of the Help on the Template sidebar. 


Figma: https://www.loom.com/share/1dbf45888faa4cb194651c2951381ff5?sid=41f362b6-5ef1-4dd5-b326-5ace4ee52ad5

## Risk

/

## Deploy Plan

/
