### PR TITLE
enh: use tiptap editor for assistant builder instructions

### DIFF
--- a/front/components/assistant_builder/InstructionScreen.tsx
+++ b/front/components/assistant_builder/InstructionScreen.tsx
@@ -107,6 +107,7 @@ export function InstructionScreen({
 }) {
   const editor = useEditor({
     extensions: [Document, Text, Paragraph],
+    content: tipTapContentFromPlainText(builderState.instructions || ""),
     onUpdate: ({ editor }) => {
       const json = editor.getJSON();
       const plainText = plainTextFromTipTapContent(json);
@@ -119,11 +120,6 @@ export function InstructionScreen({
   });
 
   useEffect(() => {
-    // Must use the insertContent API to properly render newlines.
-    // The setContent API or the `content` property on useEditor will not render newlines.
-    editor?.commands.setContent(
-      tipTapContentFromPlainText(builderState.instructions || "")
-    );
     editor?.setOptions({
       editorProps: {
         attributes: {
@@ -134,8 +130,6 @@ export function InstructionScreen({
       },
     });
 
-    // Only run one time once editor is initialized.
-    // We explicitly don't want to run this effect when the content changes, as tiptap handles its own state.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [editor]);
 

--- a/front/components/assistant_builder/InstructionScreen.tsx
+++ b/front/components/assistant_builder/InstructionScreen.tsx
@@ -129,8 +129,6 @@ export function InstructionScreen({
         },
       },
     });
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [editor]);
 
   return (

--- a/front/components/assistant_builder/InstructionScreen.tsx
+++ b/front/components/assistant_builder/InstructionScreen.tsx
@@ -10,7 +10,6 @@ import {
   OpenaiLogo,
   Page,
   Spinner2,
-  TextArea,
 } from "@dust-tt/sparkle";
 import type {
   APIError,
@@ -38,6 +37,8 @@ import {
   Ok,
 } from "@dust-tt/types";
 import { Transition } from "@headlessui/react";
+import { EditorContent, useEditor } from "@tiptap/react";
+import StarterKit from "@tiptap/starter-kit";
 import type { ComponentType } from "react";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 
@@ -98,6 +99,31 @@ export function InstructionScreen({
   ) => void;
   setEdited: (edited: boolean) => void;
 }) {
+  const editor = useEditor({
+    extensions: [
+      StarterKit.configure({
+        heading: false,
+      }),
+    ],
+    content: builderState.instructions?.replaceAll("\n", "<br />") || "",
+    onUpdate: ({ editor }) => {
+      setEdited(true);
+      setBuilderState((state) => ({
+        ...state,
+        instructions: editor.getText(),
+      }));
+    },
+  });
+  editor?.setOptions({
+    editorProps: {
+      attributes: {
+        class:
+          "min-h-60 border-structure-200 border bg-structure-50 transition-all " +
+          "duration-200 rounded-xl focus:border-action-300 focus:ring-action-300 p-2 focus:outline-action-200",
+      },
+    },
+  });
+
   return (
     <div className="flex h-full w-full flex-col gap-4">
       <div className="flex flex-col sm:flex-row">
@@ -125,17 +151,9 @@ export function InstructionScreen({
           />
         </div>
       </div>
-      <TextArea
-        placeholder="I want you to act as…"
-        value={builderState.instructions}
-        onChange={(value) => {
-          setEdited(true);
-          setBuilderState((state) => ({
-            ...state,
-            instructions: value,
-          }));
-        }}
-      />
+      <div className="flex flex-col gap-1 p-px">
+        <EditorContent editor={editor} />
+      </div>
       {isDevelopmentOrDustWorkspace(owner) && (
         <Suggestions
           owner={owner}

--- a/front/lib/client/assistant_builder/instructions.ts
+++ b/front/lib/client/assistant_builder/instructions.ts
@@ -1,0 +1,43 @@
+import { removeNulls } from "@dust-tt/types";
+import type { JSONContent } from "@tiptap/react";
+
+export function plainTextFromTipTapContent(root: JSONContent): string {
+  if (root.type !== "doc" || !root.content) {
+    return "";
+  }
+  let text = "";
+
+  for (const p of root.content) {
+    if (p.type !== "paragraph") {
+      continue;
+    }
+    if (!p.content || !p.content.length || p.content.length > 1) {
+      text += "\n";
+      continue;
+    }
+
+    const textNode = p.content && p.content[0];
+    if (textNode.type !== "text") {
+      continue;
+    }
+
+    text += `${textNode.text}\n`;
+  }
+
+  return text;
+}
+
+export function tipTapContentFromPlainText(text: string): JSONContent {
+  const lines = text.split("\n");
+  const doc: JSONContent = {
+    type: "doc",
+    content: [],
+  };
+  for (const l of lines) {
+    const textNode = l ? { type: "text", text: l } : undefined;
+    const paragraph = { type: "paragraph", content: removeNulls([textNode]) };
+    doc.content?.push(paragraph);
+  }
+
+  return doc;
+}


### PR DESCRIPTION
## Description

fixes https://github.com/dust-tt/tasks/issues/685

We're currently using a naive `textarea` for assistant instructions. This works well when instruction remain short, but when the text area content is taller than the page, the experience (especially on chrome) is pretty bad, as the browser adds some weird scrolling behaviors when you add newlines in the middle of the content.

The fix is to use the tiptap editor, which we already use in the input bar. I kept the same styling, so that screen is visually un-changed

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
