### PR TITLE
Sparkle: Add quote with copy & tweaks on Mardown Component

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.139",
+  "version": "0.2.140",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.139",
+      "version": "0.2.140",
       "license": "ISC",
       "dependencies": {
         "@headlessui/react": "^1.7.17",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.139",
+  "version": "0.2.140",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/components/Markdown.tsx
+++ b/sparkle/src/components/Markdown.tsx
@@ -3,6 +3,32 @@ import ReactMarkdown from "react-markdown";
 
 import { ClipboardCheckIcon, ClipboardIcon, IconButton } from "@sparkle/index";
 
+function useCopyToClipboard(
+  resetInterval = 2000
+): [isCopied: boolean, copy: (d: ClipboardItem) => Promise<boolean>] {
+  const [isCopied, setCopied] = useState(false);
+
+  const copy = useCallback(
+    async (d: ClipboardItem) => {
+      if (!navigator?.clipboard) {
+        return false;
+      }
+      try {
+        await navigator.clipboard.write([d]);
+        setCopied(true);
+        setTimeout(() => setCopied(false), resetInterval);
+        return true;
+      } catch (error) {
+        setCopied(false);
+        return false;
+      }
+    },
+    [resetInterval]
+  );
+
+  return [isCopied, copy];
+}
+
 export function Markdown({
   content,
   className = "",
@@ -10,32 +36,6 @@ export function Markdown({
   content: string;
   className?: string;
 }) {
-  function useCopyToClipboard(
-    resetInterval = 2000
-  ): [isCopied: boolean, copy: (d: ClipboardItem) => Promise<boolean>] {
-    const [isCopied, setCopied] = useState(false);
-
-    const copy = useCallback(
-      async (d: ClipboardItem) => {
-        if (!navigator?.clipboard) {
-          return false;
-        }
-        try {
-          await navigator.clipboard.write([d]);
-          setCopied(true);
-          setTimeout(() => setCopied(false), resetInterval);
-          return true;
-        } catch (error) {
-          setCopied(false);
-          return false;
-        }
-      },
-      [resetInterval]
-    );
-
-    return [isCopied, copy];
-  }
-
   return (
     <ReactMarkdown
       components={{

--- a/sparkle/src/components/Markdown.tsx
+++ b/sparkle/src/components/Markdown.tsx
@@ -1,5 +1,7 @@
-import React from "react";
+import React, { useCallback, useState } from "react";
 import ReactMarkdown from "react-markdown";
+
+import { ClipboardCheckIcon, ClipboardIcon, IconButton } from "@sparkle/index";
 
 export function Markdown({
   content,
@@ -8,6 +10,32 @@ export function Markdown({
   content: string;
   className?: string;
 }) {
+  function useCopyToClipboard(
+    resetInterval = 2000
+  ): [isCopied: boolean, copy: (d: ClipboardItem) => Promise<boolean>] {
+    const [isCopied, setCopied] = useState(false);
+
+    const copy = useCallback(
+      async (d: ClipboardItem) => {
+        if (!navigator?.clipboard) {
+          return false;
+        }
+        try {
+          await navigator.clipboard.write([d]);
+          setCopied(true);
+          setTimeout(() => setCopied(false), resetInterval);
+          return true;
+        } catch (error) {
+          setCopied(false);
+          return false;
+        }
+      },
+      [resetInterval]
+    );
+
+    return [isCopied, copy];
+  }
+
   return (
     <ReactMarkdown
       components={{
@@ -26,26 +54,69 @@ export function Markdown({
             {children}
           </h3>
         ),
+        p: ({ children }) => (
+          <div className="s-first:pt-0 s-last:pb-0 s-whitespace-pre-wrap s-py-2 s-text-base s-text-element-900">
+            {children}
+          </div>
+        ),
         strong: ({ children }) => (
           <strong className="s-font-semibold s-text-element-900">
             {children}
           </strong>
         ),
         ul: ({ children }) => (
-          <ul className="s-list-disc s-py-2 s-pl-8 s-text-element-800 first:s-pt-0 last:s-pb-0">
+          <ul className="s-list-disc s-py-1 s-pl-8 s-text-element-800 first:s-pt-0 last:s-pb-0">
             {children}
           </ul>
         ),
         ol: ({ children }) => (
-          <ol className="s-list-decimal s-py-3 s-pl-8 s-text-element-800 first:s-pt-0 last:s-pb-0">
+          <ol className="s-list-decimal s-py-1 s-pl-8 s-text-element-800 first:s-pt-0 last:s-pb-0">
             {children}
           </ol>
         ),
         li: ({ children }) => (
-          <li className="s-py-2 s-text-element-800 first:s-pt-0 last:s-pb-0">
+          <li className=" s-text-element-800 first:s-pt-0 last:s-pb-0">
             {children}
           </li>
         ),
+        blockquote: ({ children }) => {
+          const [isCopied, copyToClipboard] = useCopyToClipboard();
+
+          const childrenContent =
+            Array.isArray(children) && children[1]
+              ? children[1].props.children
+              : null;
+
+          const handleCopy = async () => {
+            void copyToClipboard(
+              new ClipboardItem({
+                "text/plain": new Blob([childrenContent ?? ""], {
+                  type: "text/plain",
+                }),
+              })
+            );
+          };
+
+          return (
+            <div className="s-relative">
+              <div className="s-dark:border-structure-200-dark s-relative s-w-auto s-overflow-x-auto s-rounded-lg s-border s-border-structure-200">
+                <blockquote className="s-md:pl-8 s-md:mx-10 s-mx-4 s-my-8 s-border-l-4 s-border-gray-500 s-py-4 s-pl-4 s-italic">
+                  <div className="s-text-lg s-font-medium">{children}</div>
+                </blockquote>
+              </div>
+              {childrenContent && (
+                <div className="s-absolute s-right-2 s-top-2 s-mx-2 s-rounded-xl s-bg-structure-50">
+                  <IconButton
+                    variant="tertiary"
+                    size="xs"
+                    icon={isCopied ? ClipboardCheckIcon : ClipboardIcon}
+                    onClick={handleCopy}
+                  />
+                </div>
+              )}
+            </div>
+          );
+        },
       }}
       className={className}
     >

--- a/sparkle/src/stories/Markdown.stories.tsx
+++ b/sparkle/src/stories/Markdown.stories.tsx
@@ -10,10 +10,36 @@ const meta = {
 
 export default meta;
 
+const example1 = `
+# Level 1 Title
+
+## Level 2 Title
+
+### Level 3 Title
+
+This is a paragraph with **bold** text and *italic* text.
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+`;
+
+const example2 = `
+# Another Level 1 Title
+
+Demo of a list, showcasing our pets of the month:
+- Soupinou
+- Shawarma
+- Anakine
+- Goose
+
+
+Demo of a quote below:
+> You take the blue pill - the story ends, you wake up in your bed and believe whatever you want to believe. You take the red pill - you stay in Wonderland and I show you how deep the rabbit hole goes.
+`;
+
 export const MarkdownExample = () => (
-  <div className="s-flex s-flex-col s-gap-4">
-    <Markdown
-      content={`# Hello\n## World\nThis is a paragraph with **bold** text.`}
-    />
+  <div className="s-flex s-flex-col">
+    <Markdown content={example1} />
+    <Markdown content={example2} />
   </div>
 );


### PR DESCRIPTION
## Description

Edits on the Sparkle Markown component: 
- Edit some margins. 
- Adds a p component.
- Adds a blockquote with a copy button. 

@Duncid said he will tweak the blockquote component style and that I should not spend much time on it. :) 

<img width="1057" alt="Screenshot 2024-04-22 at 10 38 29" src="https://github.com/dust-tt/dust/assets/3803406/80047900-5543-4fc0-9f12-4da193004397">




## Risk

/

## Deploy Plan

Deploy Sparkle
