### PR TITLE
Revert "Fix: temp remove non-null constraint on genconfig fpk"

### DIFF
--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -360,9 +360,7 @@ async function fetchWorkspaceAgentConfigurationsForView(
   ] = await Promise.all([
     AgentGenerationConfiguration.findAll({
       where: { agentConfigurationId: { [Op.in]: configurationIds } },
-      // TODO(pr 20240415) temporary inlined for type checking
-      // this should be refactored to use the groupByAgentConfigurationId function
-    }).then((list) => _.groupBy(list, "agentConfigurationId")),
+    }).then(groupByAgentConfigurationId),
     variant === "full"
       ? AgentRetrievalConfiguration.findAll({
           where: { agentConfigurationId: { [Op.in]: configurationIds } },

--- a/front/lib/models/assistant/agent.ts
+++ b/front/lib/models/assistant/agent.ts
@@ -28,7 +28,7 @@ export class AgentGenerationConfiguration extends Model<
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
-  declare agentConfigurationId: ForeignKey<AgentConfiguration["id"] | null>;
+  declare agentConfigurationId: ForeignKey<AgentConfiguration["id"]>;
 
   declare prompt: string; // @daph to deprecate for multi-actions
   declare providerId: string;
@@ -205,10 +205,10 @@ AgentConfiguration.init(
 
 // AgentGenerationConfiguration <> AgentConfiguration
 AgentConfiguration.hasMany(AgentGenerationConfiguration, {
-  foreignKey: { name: "agentConfigurationId", allowNull: true },
+  foreignKey: { name: "agentConfigurationId", allowNull: false },
 });
 AgentGenerationConfiguration.belongsTo(AgentConfiguration, {
-  foreignKey: { name: "agentConfigurationId", allowNull: true },
+  foreignKey: { name: "agentConfigurationId", allowNull: false },
 });
 
 //  Agent config <> Workspace

--- a/front/migrations/20240415_invert_agent_generation_config_fkey.ts
+++ b/front/migrations/20240415_invert_agent_generation_config_fkey.ts
@@ -9,6 +9,7 @@ import { makeScript } from "@app/scripts/helpers";
 
 const backfillGenerationConfigs = async (execute: boolean) => {
   const generationConfigs = await AgentGenerationConfiguration.findAll({
+    // @ts-expect-error agentConfigurationId was rendered non-nullable by #4712
     where: {
       agentConfigurationId: null,
     },

--- a/front/migrations/20240415_invert_agent_generation_config_fkey.ts
+++ b/front/migrations/20240415_invert_agent_generation_config_fkey.ts
@@ -9,7 +9,7 @@ import { makeScript } from "@app/scripts/helpers";
 
 const backfillGenerationConfigs = async (execute: boolean) => {
   const generationConfigs = await AgentGenerationConfiguration.findAll({
-    // @ts-expect-error agentConfigurationId was rendered non-nullable by #4712
+    // @ts-expect-error agentConfigurationId was rendered non-nullable by #4795 
     where: {
       agentConfigurationId: null,
     },


### PR DESCRIPTION
Reverts dust-tt/dust#4717

@dust-tt/engineering-team  FYI migration run tonight
- cf [thread](https://dust4ai.slack.com/archives/C05B529FHV1/p1713175186602859), issues with init_db migration when adding non-null constraint to the `agentConfigurationId` row
- cause: lock of table to add the constraint because all rows are checked (the table has 100k rows)
- double solution: add an index to speed up the check (done), and perform the init_db at off-peak hours 
=> Will take care of it tonight

## Risk
- Possible downtime for ~4mn
- Good chance that the index will speed that up, so there may not be any issue
- If not, mitigated by the fact that it will be run off-peak hours

## Deploy Plan
To be done tonight (off peak hours)
- merge
- deploy
- run init_db from front