### PR TITLE
Template modal: fix mardown display

### DIFF
--- a/front/components/assistant_builder/AssistantTemplateModal.tsx
+++ b/front/components/assistant_builder/AssistantTemplateModal.tsx
@@ -77,9 +77,9 @@ export function AssistantTemplateModal({
               </Link>
             </div>
           </div>
-          <p className="whitespace-pre-line text-sm font-normal text-element-900">
+          <div>
             <Markdown content={description ?? ""} />
-          </p>
+          </div>
           <InstructionsSection instructions={presetInstructions} />
         </div>
       </Page>

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -9,7 +9,7 @@
         "@amplitude/analytics-browser": "^2.5.2",
         "@amplitude/analytics-node": "^1.3.5",
         "@auth0/nextjs-auth0": "^3.5.0",
-        "@dust-tt/sparkle": "0.2.138",
+        "@dust-tt/sparkle": "0.2.140",
         "@dust-tt/types": "file:../types",
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",
@@ -10489,9 +10489,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.138",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.138.tgz",
-      "integrity": "sha512-jnGWDiPv/KVwDUbYfecrQpacoFC2yggWymvgrIsI+HfTone6fG8paii62S2SJlgbBwoJdG4AJiKRM4Vr3tPmHQ==",
+      "version": "0.2.140",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.140.tgz",
+      "integrity": "sha512-m6Jtc4243X6875Igvc29Kkl7hhVO1s0Vpg7KjFaloD0JI1wFapuQcFl810RJcLX+YNYWYxQ1FmqzaMySDxd8NQ==",
       "dependencies": {
         "@headlessui/react": "^1.7.17",
         "esbuild": "^0.20.0",

--- a/front/package.json
+++ b/front/package.json
@@ -17,7 +17,7 @@
     "@amplitude/analytics-browser": "^2.5.2",
     "@amplitude/analytics-node": "^1.3.5",
     "@auth0/nextjs-auth0": "^3.5.0",
-    "@dust-tt/sparkle": "0.2.138",
+    "@dust-tt/sparkle": "0.2.140",
     "@dust-tt/types": "file:../types",
     "@emoji-mart/data": "^1.1.2",
     "@emoji-mart/react": "^1.1.1",


### PR DESCRIPTION
## Description

Calls the latest version of Sparkle + fixes Mardown should be rendered in a div not a p.
(Maybe we should add back some more spacing between the <li> on the Sparkle component, Ed said he will tweak it to get the exact design we want. 


Before: 
<kbd>
<img width="801" alt="Screenshot 2024-04-22 at 11 45 34" src="https://github.com/dust-tt/dust/assets/3803406/6b795dd8-4116-4286-b3bb-e0bdf5fa53c5">
</kbd>

After: 
<kbd>
<img width="806" alt="Screenshot 2024-04-22 at 11 45 13" src="https://github.com/dust-tt/dust/assets/3803406/053799d3-81a1-44ca-b375-65cfd6283bf8">
</kbd>

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
