### PR TITLE
[Gdrive] Fix webhook renewal when access to a shared drive is lost

### DIFF
--- a/connectors/migrations/20240422_fix_gdrive_errorType.ts
+++ b/connectors/migrations/20240422_fix_gdrive_errorType.ts
@@ -16,7 +16,7 @@ async function main() {
   });
 
   logger.info(
-    `Found ${connectors.length} connectors with errorTyhpe: oauth_token_revoked`
+    `Found ${connectors.length} connectors with errorType: oauth_token_revoked`
   );
 
   const toReEnable = [];

--- a/connectors/migrations/20240422_fix_gdrive_errorType.ts
+++ b/connectors/migrations/20240422_fix_gdrive_errorType.ts
@@ -1,0 +1,53 @@
+import { getGoogleDriveObject } from "@connectors/connectors/google_drive/lib/google_drive_api";
+import { getAuthObject } from "@connectors/connectors/google_drive/temporal/utils";
+import { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
+
+const { LIVE } = process.env;
+
+async function main() {
+  // Select all connectors with an associated githubconnectorstate that has codeSyncEnabled set to true
+
+  const connectors = await ConnectorModel.findAll({
+    where: {
+      type: "google_drive",
+      errorType: "oauth_token_revoked",
+    },
+  });
+
+  console.log(
+    `Found ${connectors.length} connectors with errorTyhpe: oauth_token_revoked`
+  );
+
+  const toReEnable = [];
+  for (const connector of connectors) {
+    try {
+      const auth = await getAuthObject(connector.connectionId);
+      const gDriveObject = await getGoogleDriveObject(auth, "root");
+      console.log(
+        `Successfully fetched root folder for connector ${connector.id}. Fetched: ${gDriveObject?.name}`
+      );
+      toReEnable.push(connector.id);
+    } catch (e) {
+      // no-op, this is expected
+    }
+  }
+
+  if (LIVE) {
+    for (const id of toReEnable) {
+      await ConnectorModel.update(
+        {
+          errorType: null,
+        },
+        {
+          where: {
+            id,
+          },
+        }
+      );
+    }
+  }
+  console.log("Done!", toReEnable);
+}
+main()
+  .then(() => console.log("Done"))
+  .catch(console.error);

--- a/connectors/migrations/20240422_fix_gdrive_errorType.ts
+++ b/connectors/migrations/20240422_fix_gdrive_errorType.ts
@@ -1,5 +1,6 @@
 import { getGoogleDriveObject } from "@connectors/connectors/google_drive/lib/google_drive_api";
 import { getAuthObject } from "@connectors/connectors/google_drive/temporal/utils";
+import logger from "@connectors/logger/logger";
 import { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
 
 const { LIVE } = process.env;
@@ -14,7 +15,7 @@ async function main() {
     },
   });
 
-  console.log(
+  logger.info(
     `Found ${connectors.length} connectors with errorTyhpe: oauth_token_revoked`
   );
 
@@ -23,8 +24,13 @@ async function main() {
     try {
       const auth = await getAuthObject(connector.connectionId);
       const gDriveObject = await getGoogleDriveObject(auth, "root");
-      console.log(
-        `Successfully fetched root folder for connector ${connector.id}. Fetched: ${gDriveObject?.name}`
+      logger.info(
+        {
+          connectorId: connector.id,
+          // gDriveObject being null still means we have a valid access token
+          fileName: gDriveObject?.name,
+        },
+        `Successfully fetched root folder for connector`
       );
       toReEnable.push(connector.id);
     } catch (e) {
@@ -46,7 +52,12 @@ async function main() {
       );
     }
   }
-  console.log("Done!", toReEnable);
+  logger.info(
+    {
+      toReEnable,
+    },
+    "Done!"
+  );
 }
 main()
   .then(() => console.log("Done"))

--- a/connectors/src/connectors/google_drive/lib.ts
+++ b/connectors/src/connectors/google_drive/lib.ts
@@ -21,7 +21,7 @@ import {
   getAuthObject,
   getDriveClient,
 } from "@connectors/connectors/google_drive/temporal/utils";
-import { ExternalOauthTokenError, HTTPError } from "@connectors/lib/error";
+import { HTTPError } from "@connectors/lib/error";
 import {
   GoogleDriveFiles,
   GoogleDriveSheet,
@@ -73,11 +73,7 @@ export async function ensureWebhookForDriveId(
     const auth = await getAuthObject(connector.connectionId);
     const remoteFile = await getGoogleDriveObject(auth, driveId);
     if (!remoteFile) {
-      logger.error(
-        { driveId, connectorId: connector.id },
-        "Could not get remote drive."
-      );
-      throw new ExternalOauthTokenError();
+      throw new Error(`Drive with id ${driveId} not found`);
     }
     const res = await registerWebhook(
       connector,


### PR DESCRIPTION
## Description
Fix webhook renewal when access to a shared drive is lost or the shared drive is deleted.
This reverts pr #4770 and addresses the issue differently.

There is also  a migration to remove the `connectors.errorType` value of Gdrive accounts we can still access.
Only connector id `550` should be affected by this migration.


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
