### PR TITLE
fix: upgrade to paid from free trial

### DIFF
--- a/front/lib/plans/pro_plans.ts
+++ b/front/lib/plans/pro_plans.ts
@@ -44,7 +44,7 @@ if (isDevelopment()) {
     maxDataSourcesCount: -1,
     maxDataSourcesDocumentsCount: -1,
     maxDataSourcesDocumentsSizeMb: 2,
-    trialPeriodDays: 0,
+    trialPeriodDays: 14,
     canUseProduct: true,
   });
 }

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -84,13 +84,12 @@ export const createProPlanCheckoutSession = async ({
   // subscription before.
   // User under the grandfathered free plan are not allowed to have a trial.
   let trialAllowed = true;
-  if (
-    await Subscription.findOne({
-      where: {
-        workspaceId: owner.id,
-      },
-    })
-  ) {
+  const existingSubscription = await Subscription.findOne({
+    where: {
+      workspaceId: owner.id,
+    },
+  });
+  if (existingSubscription) {
     trialAllowed = false;
   }
 

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -289,7 +289,7 @@ export async function deleteAgentsActivity({
       await AgentDustAppRunAction.destroy({
         where: {
           dustAppRunConfigurationId: {
-            [Op.in]: dustAppRunConfigurations.map((r) => r.id),
+            [Op.in]: dustAppRunConfigurations.map((r) => r.sId),
           },
         },
         transaction: t,


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/688

Current logic relies on `previousAttributes`, which can be empty. With this change, subscribing will set the `trialiing` boolean to false on the suscription.

Also fixed the pro plan seed data for development to include 14 days free trial.

## Risk

well tested.


## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
