### PR TITLE
Assistant Builder: ability to close a template

### DIFF
--- a/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
@@ -202,7 +202,7 @@ export default function EditAssistant({
       }}
       agentConfigurationId={agentConfiguration.sId}
       baseUrl={baseUrl}
-      template={null}
+      defaultTemplate={null}
     />
   );
 }

--- a/front/pages/w/[wId]/builder/assistants/new.tsx
+++ b/front/pages/w/[wId]/builder/assistants/new.tsx
@@ -252,7 +252,7 @@ export default function CreateAssistant({
       agentConfigurationId={null}
       defaultIsEdited={true}
       baseUrl={baseUrl}
-      template={assistantTemplate}
+      defaultTemplate={assistantTemplate}
     />
   );
 }


### PR DESCRIPTION
## Description

Adds a button to (after confirmation - remove a template from the Assistant builder). 

Card: https://github.com/dust-tt/tasks/issues/678

Loom: https://www.loom.com/share/c59d1beab43e4374876946fdbf8c850e?sid=e9be49ae-afc6-4a7b-b291-402801fb2695

## Risk

/

## Deploy Plan

/
