### PR TITLE
Clarify fair usage.

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -68,6 +68,7 @@ import {
   UserMessage,
 } from "@app/lib/models/assistant/conversation";
 import { User } from "@app/lib/models/user";
+import { countActiveSeatsInWorkspaceCached } from "@app/lib/plans/usage/seats";
 import {
   ContentFragmentResource,
   fileAttachmentLocation,
@@ -1722,10 +1723,11 @@ async function isMessagesLimitReached({
   if (plan.limits.assistant.maxMessages === -1) {
     return false;
   }
+  const activeSeats = await countActiveSeatsInWorkspaceCached(owner.sId);
 
   const remaining = await rateLimiter({
     key: `workspace:${owner.id}:agent_message_count:${maxMessagesTimeframe}`,
-    maxPerTimeframe: maxMessages,
+    maxPerTimeframe: maxMessages * activeSeats,
     timeframeSeconds: getTimeframeSecondsFromLiteral(maxMessagesTimeframe),
     logger,
   });

--- a/front/lib/plans/usage/seats.ts
+++ b/front/lib/plans/usage/seats.ts
@@ -1,4 +1,5 @@
 import type { LightWorkspaceType } from "@dust-tt/types";
+import { cacheWithRedis } from "@dust-tt/types";
 import type Stripe from "stripe";
 
 import { Workspace } from "@app/lib/models/workspace";
@@ -23,6 +24,14 @@ export async function countActiveSeatsInWorkspace(
     activeOnly: true,
   });
 }
+
+export const countActiveSeatsInWorkspaceCached = cacheWithRedis(
+  countActiveSeatsInWorkspace,
+  (workspaceId) => {
+    return `countActiveSeatsInWorkspace:${workspaceId}`;
+  },
+  60 * 10 * 1000 // 10 minutes
+);
 
 export async function reportActiveSeats(
   stripeSubscriptionItem: Stripe.SubscriptionItem,

--- a/front/lib/plans/usage/seats.ts
+++ b/front/lib/plans/usage/seats.ts
@@ -28,7 +28,7 @@ export async function countActiveSeatsInWorkspace(
 export const countActiveSeatsInWorkspaceCached = cacheWithRedis(
   countActiveSeatsInWorkspace,
   (workspaceId) => {
-    return `countActiveSeatsInWorkspace:${workspaceId}`;
+    return `count-active-seats-in-workspace:${workspaceId}`;
   },
   60 * 10 * 1000 // 10 minutes
 );


### PR DESCRIPTION
## Description

Task: https://github.com/dust-tt/tasks/issues/693

The grand fathered plan (`FREE_TEST_PLAN`) was limited to 1 user, so this PR is not affecting it.

Workspaces under free trial were limited to 50 messages / user / day, so they will now be limited to 100 / messages / day * seats, where seats has a maximum value of 5 under free trial.

The old fair usage value during the free trial was quickly decide without much rational, so we agreed to move it IRL.


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- Merge this PR.
- Deploy front.
- run the migration: `front>npx tsx migrations/20240422_pro_plan_max_message.ts --execute`

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
