### PR TITLE
[Multi-Actions] AgentConfiguration: delete unused genConfigId field

### DIFF
--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -876,7 +876,6 @@ export async function createAgentConfiguration(
             maxToolsUsePerRun: maxToolsUsePerRun,
             pictureUrl,
             workspaceId: owner.id,
-            generationConfigurationId: generation?.id || null,
             authorId: user.id,
           },
           {

--- a/front/lib/models/assistant/agent.ts
+++ b/front/lib/models/assistant/agent.ts
@@ -116,10 +116,6 @@ export class AgentConfiguration extends Model<
 
   declare maxToolsUsePerRun: number;
 
-  declare generationConfigurationId: ForeignKey<
-    AgentGenerationConfiguration["id"]
-  > | null;
-
   declare author: NonAttribute<User>;
 }
 

--- a/front/migrations/20240415_invert_agent_generation_config_fkey.ts
+++ b/front/migrations/20240415_invert_agent_generation_config_fkey.ts
@@ -23,6 +23,7 @@ const backfillGenerationConfigs = async (execute: boolean) => {
       chunk.map(async (g) => {
         const agent = await AgentConfiguration.findOne({
           where: {
+            // @ts-expect-error generationConfigurationId was removed by on 2024-04-22
             generationConfigurationId: g.id,
           },
         });


### PR DESCRIPTION
Description
---
See title

Risks
---
Code is simple but means we cannot revert #4712 anymore, data deletion

Mitigation: we've been running without using the field in production for a week

Deploy plan
---
- deploy front
- front init_db
