### PR TITLE
Assistant Builder: Reset instructions & actions from template

### DIFF
--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -268,15 +268,15 @@ export default function AssistantBuilder({
     );
   };
 
-  const [instructionsResettedAt, setInstructionsResettedAt] = useState<
-    number | null
-  >(null);
+  const [instructionsResetAt, setInstructionsResetAt] = useState<number | null>(
+    null
+  );
   const resetToTemplateInstructions = async () => {
     if (template === null) {
       return;
     }
     setEdited(true);
-    setInstructionsResettedAt(Date.now());
+    setInstructionsResetAt(Date.now());
     await setBuilderState((builderState) => ({
       ...builderState,
       instructions: template.presetInstructions,
@@ -596,7 +596,7 @@ export default function AssistantBuilder({
                         builderState={builderState}
                         setBuilderState={setBuilderState}
                         setEdited={setEdited}
-                        resetAt={instructionsResettedAt}
+                        resetAt={instructionsResetAt}
                       />
                     );
                   case "actions":

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -288,7 +288,7 @@ export default function AssistantBuilder({
       return;
     }
     const action = getAgentActionConfigurationType(template.presetAction);
-    let actionMode: ActionMode | null = null;
+    let actionMode: ActionMode = "GENERIC";
 
     if (isRetrievalConfiguration(action)) {
       actionMode = "RETRIEVAL_SEARCH";

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -271,19 +271,19 @@ export default function AssistantBuilder({
   const [instructionsResetAt, setInstructionsResetAt] = useState<number | null>(
     null
   );
-  const resetToTemplateInstructions = async () => {
+  const resetToTemplateInstructions = useCallback(async () => {
     if (template === null) {
       return;
     }
     setEdited(true);
     setInstructionsResetAt(Date.now());
-    await setBuilderState((builderState) => ({
+    setBuilderState((builderState) => ({
       ...builderState,
       instructions: template.presetInstructions,
     }));
-  };
+  }, [template]);
 
-  const resetToTemplateActions = async () => {
+  const resetToTemplateActions = useCallback(async () => {
     if (template === null) {
       return;
     }
@@ -308,7 +308,7 @@ export default function AssistantBuilder({
         tablesQueryConfiguration: {},
       }));
     }
-  };
+  }, [template]);
 
   const showSlackIntegration =
     builderState.scope === "workspace" || builderState.scope === "published";

--- a/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
+++ b/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
@@ -31,12 +31,16 @@ import type { FetchAssistantTemplateResponse } from "@app/pages/api/w/[wId]/assi
 export default function AssistantBuilderPreviewDrawer({
   template,
   resetTemplate,
+  resetToTemplateInstructions,
+  resetToTemplateActions,
   owner,
   previewDrawerOpenedAt,
   builderState,
 }: {
   template: FetchAssistantTemplateResponse | null;
   resetTemplate: () => Promise<void>;
+  resetToTemplateInstructions: () => Promise<void>;
+  resetToTemplateActions: () => Promise<void>;
   owner: WorkspaceType;
   previewDrawerOpenedAt: number | null;
   builderState: AssistantBuilderState;
@@ -170,7 +174,7 @@ export default function AssistantBuilderPreviewDrawer({
                     hasMagnifying={false}
                   />
                 </DropdownMenu.Button>
-                <DropdownMenu.Items width={220} origin="topRight">
+                <DropdownMenu.Items width={320} origin="topRight">
                   <DropdownMenu.Item
                     label="Close the template"
                     onClick={async () => {
@@ -186,6 +190,38 @@ export default function AssistantBuilderPreviewDrawer({
                       }
                     }}
                     icon={XMarkIcon}
+                  />
+                  <DropdownMenu.Item
+                    label="Reset instructions"
+                    description="Set instructions back to template's default"
+                    onClick={async () => {
+                      const confirmed = await confirm({
+                        title: "Are you sure?",
+                        message:
+                          "Resetting to the default settings will erase all changes made to the Assistant's instructions.",
+                        validateVariant: "primaryWarning",
+                      });
+                      if (confirmed) {
+                        await resetToTemplateInstructions();
+                      }
+                    }}
+                    icon={MagicIcon}
+                  />
+                  <DropdownMenu.Item
+                    label="Reset actions"
+                    description="Set actions back to template's default"
+                    onClick={async () => {
+                      const confirmed = await confirm({
+                        title: "Are you sure?",
+                        message:
+                          "Resetting to the default settings will erase all changes made to the Assistant's actions.",
+                        validateVariant: "primaryWarning",
+                      });
+                      if (confirmed) {
+                        await resetToTemplateActions();
+                      }
+                    }}
+                    icon={MagicIcon}
                   />
                 </DropdownMenu.Items>
               </DropdownMenu>

--- a/front/components/assistant_builder/InstructionScreen.tsx
+++ b/front/components/assistant_builder/InstructionScreen.tsx
@@ -96,6 +96,7 @@ export function InstructionScreen({
   builderState,
   setBuilderState,
   setEdited,
+  resetAt,
 }: {
   owner: WorkspaceType;
   plan: PlanType;
@@ -104,20 +105,24 @@ export function InstructionScreen({
     statefn: (state: AssistantBuilderState) => AssistantBuilderState
   ) => void;
   setEdited: (edited: boolean) => void;
+  resetAt: number | null;
 }) {
-  const editor = useEditor({
-    extensions: [Document, Text, Paragraph],
-    content: tipTapContentFromPlainText(builderState.instructions || ""),
-    onUpdate: ({ editor }) => {
-      const json = editor.getJSON();
-      const plainText = plainTextFromTipTapContent(json);
-      setEdited(true);
-      setBuilderState((state) => ({
-        ...state,
-        instructions: plainText,
-      }));
+  const editor = useEditor(
+    {
+      extensions: [Document, Text, Paragraph],
+      content: tipTapContentFromPlainText(builderState.instructions || ""),
+      onUpdate: ({ editor }) => {
+        const json = editor.getJSON();
+        const plainText = plainTextFromTipTapContent(json);
+        setEdited(true);
+        setBuilderState((state) => ({
+          ...state,
+          instructions: plainText,
+        }));
+      },
     },
-  });
+    [resetAt]
+  );
 
   useEffect(() => {
     editor?.setOptions({

--- a/front/lib/api/assistant/templates.ts
+++ b/front/lib/api/assistant/templates.ts
@@ -1,16 +1,12 @@
 import type {
-  ActionPreset,
-  AgentActionConfigurationType,
-  DustAppRunConfigurationType,
   Result,
-  RetrievalConfigurationType,
   SupportedModel,
-  TablesQueryConfigurationType,
   TemplateAgentConfigurationType,
 } from "@dust-tt/types";
 import {
   ASSISTANT_CREATIVITY_LEVEL_TEMPERATURES,
   Err,
+  getAgentActionConfigurationType,
   Ok,
   removeNulls,
 } from "@dust-tt/types";
@@ -28,7 +24,9 @@ export async function generateMockAgentConfigurationFromTemplate(
   }
 
   return new Ok({
-    actions: removeNulls([getAction(template.presetAction)]),
+    actions: removeNulls([
+      getAgentActionConfigurationType(template.presetAction),
+    ]),
     description: template.description ?? "",
     instructions: template.presetInstructions ?? "",
     generation: {
@@ -44,45 +42,4 @@ export async function generateMockAgentConfigurationFromTemplate(
     scope: flow === "personal_assistants" ? "private" : "workspace",
     isTemplate: true,
   });
-}
-
-function getAction(action: ActionPreset): AgentActionConfigurationType | null {
-  switch (action) {
-    case "reply":
-      return null;
-
-    case "retrieval_configuration":
-      return {
-        dataSources: [],
-        id: -1,
-        query: "auto",
-        relativeTimeFrame: "auto",
-        sId: "template",
-        topK: "auto",
-        type: "retrieval_configuration",
-        forceUseAtIteration: 0,
-      } satisfies RetrievalConfigurationType;
-
-    case "tables_query_configuration":
-      return {
-        id: -1,
-        sId: "template",
-        tables: [],
-        type: "tables_query_configuration",
-        forceUseAtIteration: 0,
-      } satisfies TablesQueryConfigurationType;
-
-    case "dust_app_run_configuration":
-      return {
-        id: -1,
-        sId: "template",
-        type: "dust_app_run_configuration",
-        appWorkspaceId: "template",
-        appId: "template",
-        forceUseAtIteration: 0,
-      } satisfies DustAppRunConfigurationType;
-
-    default:
-      return null;
-  }
 }

--- a/types/src/front/assistant/templates.ts
+++ b/types/src/front/assistant/templates.ts
@@ -3,7 +3,10 @@ import { nonEmptyArray } from "io-ts-types/lib/nonEmptyArray";
 import { NonEmptyString } from "io-ts-types/lib/NonEmptyString";
 
 import { ioTsEnum } from "../../shared/utils/iots_utils";
-import { AgentAction } from "./agent";
+import { DustAppRunConfigurationType } from "./actions/dust_app_run";
+import { RetrievalConfigurationType } from "./actions/retrieval";
+import { TablesQueryConfigurationType } from "./actions/tables_query";
+import { AgentAction, AgentActionConfigurationType } from "./agent";
 import { AssistantCreativityLevelCodec } from "./builder";
 
 export const TEMPLATES_TAG_CODES = [
@@ -177,3 +180,46 @@ export const generateTailwindBackgroundColors = (): string[] => {
   });
   return tailwindColors;
 };
+
+export function getAgentActionConfigurationType(
+  action: ActionPreset
+): AgentActionConfigurationType | null {
+  switch (action) {
+    case "reply":
+      return null;
+
+    case "retrieval_configuration":
+      return {
+        dataSources: [],
+        id: -1,
+        query: "auto",
+        relativeTimeFrame: "auto",
+        sId: "template",
+        topK: "auto",
+        type: "retrieval_configuration",
+        forceUseAtIteration: 0,
+      } satisfies RetrievalConfigurationType;
+
+    case "tables_query_configuration":
+      return {
+        id: -1,
+        sId: "template",
+        tables: [],
+        type: "tables_query_configuration",
+        forceUseAtIteration: 0,
+      } satisfies TablesQueryConfigurationType;
+
+    case "dust_app_run_configuration":
+      return {
+        id: -1,
+        sId: "template",
+        type: "dust_app_run_configuration",
+        appWorkspaceId: "template",
+        appId: "template",
+        forceUseAtIteration: 0,
+      } satisfies DustAppRunConfigurationType;
+
+    default:
+      return null;
+  }
+}


### PR DESCRIPTION
## Description

Adds the ability to:
- reset the instructions of an Assistant to the template's default.
- reset the actions of an Assistant to the templates's default. 

There's again a confirmation step before processing to the reset. 

Loom: https://www.loom.com/share/4f02fde557b34a698fbcc8b7a8f5cd25?sid=6d235b68-357f-477d-8a3b-22b5b4b6a92f


## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
