### PR TITLE
Assistant Builder: Rework buttons to open drawer

### DIFF
--- a/types/src/front/assistant/builder.ts
+++ b/types/src/front/assistant/builder.ts
@@ -27,3 +27,13 @@ export const ASSISTANT_CREATIVITY_LEVEL_TEMPERATURES: Record<
   balanced: 0.7,
   creative: 1.0,
 };
+
+export const ASSISTANT_BUILDER_DRAWER_TABS = ["Template", "Preview"] as const;
+
+export type AssistantBuilderRightPanelTab =
+  (typeof ASSISTANT_BUILDER_DRAWER_TABS)[number];
+
+export type AssistantBuilderRightPanelStatus = {
+  openedAt: number | null;
+  tab: AssistantBuilderRightPanelTab | null;
+};


### PR DESCRIPTION
## Description

Reworks the button to open/close the right panel of the assistant builder. 
Following what we want on Figma. 

Demo: https://www.loom.com/share/a148a1e9fc404c4e97883d1c2dc4e651

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
