### PR TITLE
Fix: prevent editing/deleting already-deleted assistants

### DIFF
--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -2,6 +2,7 @@ import {
   Avatar,
   BracesIcon,
   CommandLineIcon,
+  ContentMessage,
   ElementModal,
   ExternalLinkIcon,
   IconButton,
@@ -139,26 +140,27 @@ export function AssistantDetails({
         <div className="flex grow flex-col gap-1">
           <div
             className={classNames(
-              agentConfiguration.status === "archived" ? "line-through" : "",
               "font-bold text-element-900",
               agentConfiguration.name.length > 20 ? "text-md" : "text-lg"
             )}
           >{`@${agentConfiguration.name}`}</div>
-          <SharingDropdown
-            owner={owner}
-            agentConfiguration={agentConfiguration}
-            initialScope={agentConfiguration.scope}
-            newScope={agentConfiguration.scope}
-            disabled={isUpdatingScope || agentConfiguration.status !== "active"}
-            setNewScope={(scope) => updateScope(scope)}
-          />
           {agentConfiguration.status === "active" && (
-            <AssistantListActions
-              agentConfiguration={agentConfiguration}
-              owner={owner}
-              isParentHovered={true}
-              onAssistantListUpdate={() => void mutateAgentConfigurations?.()}
-            />
+            <>
+              <SharingDropdown
+                owner={owner}
+                agentConfiguration={agentConfiguration}
+                initialScope={agentConfiguration.scope}
+                newScope={agentConfiguration.scope}
+                disabled={isUpdatingScope}
+                setNewScope={(scope) => updateScope(scope)}
+              />
+              <AssistantListActions
+                agentConfiguration={agentConfiguration}
+                owner={owner}
+                isParentHovered={true}
+                onAssistantListUpdate={() => void mutateAgentConfigurations?.()}
+              />
+            </>
           )}
         </div>
         {agentConfiguration.status === "active" && (
@@ -176,10 +178,17 @@ export function AssistantDetails({
           </div>
         )}
       </div>
+      {agentConfiguration.status === "archived" && (
+        <ContentMessage
+          variant="amber"
+          title="This assistant has been deleted."
+          size="md"
+        >
+          It is no longer active and cannot be used.
+        </ContentMessage>
+      )}
+
       <div className="text-sm text-element-900">
-        {agentConfiguration.status === "archived" && (
-          <div className="font-bold">&#9888; This assistant was deleted.</div>
-        )}
         {agentConfiguration.description}
       </div>
       {agentConfiguration.scope === "global" && usageSentence && (

--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -139,6 +139,7 @@ export function AssistantDetails({
         <div className="flex grow flex-col gap-1">
           <div
             className={classNames(
+              agentConfiguration.status === "archived" ? "line-through" : "",
               "font-bold text-element-900",
               agentConfiguration.name.length > 20 ? "text-md" : "text-lg"
             )}
@@ -148,30 +149,37 @@ export function AssistantDetails({
             agentConfiguration={agentConfiguration}
             initialScope={agentConfiguration.scope}
             newScope={agentConfiguration.scope}
-            disabled={isUpdatingScope}
+            disabled={isUpdatingScope || agentConfiguration.status !== "active"}
             setNewScope={(scope) => updateScope(scope)}
           />
-          <AssistantListActions
-            agentConfiguration={agentConfiguration}
-            owner={owner}
-            isParentHovered={true}
-            onAssistantListUpdate={() => void mutateAgentConfigurations?.()}
-          />
+          {agentConfiguration.status === "active" && (
+            <AssistantListActions
+              agentConfiguration={agentConfiguration}
+              owner={owner}
+              isParentHovered={true}
+              onAssistantListUpdate={() => void mutateAgentConfigurations?.()}
+            />
+          )}
         </div>
-        <div>
-          <AssistantEditionMenu
-            agentConfigurationId={agentConfiguration.sId}
-            owner={owner}
-            variant="button"
-            tryButton
-            onAgentDeletion={() => {
-              void mutateCurrentAgentConfiguration();
-              void mutateAgentConfigurations?.();
-            }}
-          />
-        </div>
+        {agentConfiguration.status === "active" && (
+          <div>
+            <AssistantEditionMenu
+              agentConfigurationId={agentConfiguration.sId}
+              owner={owner}
+              variant="button"
+              tryButton
+              onAgentDeletion={() => {
+                void mutateCurrentAgentConfiguration();
+                void mutateAgentConfigurations?.();
+              }}
+            />
+          </div>
+        )}
       </div>
       <div className="text-sm text-element-900">
+        {agentConfiguration.status === "archived" && (
+          <div className="font-bold">&#9888; This assistant was deleted.</div>
+        )}
         {agentConfiguration.description}
       </div>
       {agentConfiguration.scope === "global" && usageSentence && (

--- a/front/components/assistant/conversation/AssistantEditionMenu.tsx
+++ b/front/components/assistant/conversation/AssistantEditionMenu.tsx
@@ -66,7 +66,10 @@ export function AssistantEditionMenu({
     return <></>;
   }
 
-  if (agentConfiguration.scope === "global") {
+  if (
+    agentConfiguration.scope === "global" ||
+    agentConfiguration.status === "archived"
+  ) {
     return <></>;
   }
 

--- a/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
@@ -173,6 +173,10 @@ export default function EditAssistant({
     throw new Error("Cannot edit global assistant");
   }
 
+  if (agentConfiguration.status === "archived") {
+    throw new Error("Cannot edit archived assistant");
+  }
+
   return (
     <AssistantBuilder
       owner={owner}


### PR DESCRIPTION
Description
---
Deleted assistants can still be accessed in former conversations. Their details can still be viewed.

At this time, when seeing the details of a deleted assistant:
- there is no visual indication that it was deleted;
- users can still edit them, saving actually revives the assistant;
- users can "delete" them (no-op, confusing).

This PR adresses the 3 as a first effort by preventing edition of deleted assistants and visually indicating deletion.

We might want a deeper reflexion on what to do on deleted assistants (maybe a menu with "revive", etc.). This PR can be seen as a hotfix in the meantime.

#### Before:
![image](https://github.com/dust-tt/dust/assets/5437393/b54d07e4-8593-4c86-b166-2d490718d6d7)

#### After:
![image](https://github.com/dust-tt/dust/assets/5437393/7b277141-c629-4639-8643-bf7f31a619b6)

Risk
---
No real risk here

Deploy Plan
---
Deploy front

