### PR TITLE
Fix: cacheWithRedis check for env var at runtime (vs build time)

### DIFF
--- a/types/src/shared/cache.ts
+++ b/types/src/shared/cache.ts
@@ -10,21 +10,17 @@ export function cacheWithRedis<T extends (...args: any[]) => Promise<any>>(
   ttlMs: number,
   redisUri?: string
 ): (...args: Parameters<T>) => Promise<Awaited<ReturnType<T>>> {
-  if (!redisUri) {
-    const REDIS_CACHE_URI = process.env.REDIS_CACHE_URI;
-    if (!REDIS_CACHE_URI) {
-      throw new Error("REDIS_CACHE_URI is not set");
-    }
-    redisUri = REDIS_CACHE_URI;
-  }
-
   if (ttlMs > 60 * 60 * 24 * 1000) {
     throw new Error("ttlMs should be less than 24 hours");
   }
 
   return async function (...args: Parameters<T>) {
     if (!redisUri) {
-      throw new Error("redisUrl is not set");
+      const REDIS_CACHE_URI = process.env.REDIS_CACHE_URI;
+      if (!REDIS_CACHE_URI) {
+        throw new Error("REDIS_CACHE_URI is not set");
+      }
+      redisUri = REDIS_CACHE_URI;
     }
     let redisCli: Awaited<ReturnType<typeof redisClient>> | undefined =
       undefined;


### PR DESCRIPTION
## Description

Fix cacheWithRedis() helper which look for the REDIS_CACHE_URL at build time, instead of run time.


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
