### PR TITLE
Migration to set the correct message limit for the Pro plan.

### DIFF
--- a/front/migrations/20240422_pro_plan_max_message.ts
+++ b/front/migrations/20240422_pro_plan_max_message.ts
@@ -1,0 +1,32 @@
+import { Plan } from "@app/lib/models/plan";
+import logger from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+
+const updateProMaxMessagesLimit = async (execute: boolean) => {
+  if (execute) {
+    const res = await Plan.update(
+      {
+        maxMessages: 100,
+        maxMessagesTimeframe: "day",
+      },
+      {
+        where: {
+          code: "PRO_PLAN_SEAT_29",
+        },
+      }
+    );
+
+    logger.info(
+      {
+        affectedCount: res,
+      },
+      "Backfilled PRO plan max messages"
+    );
+  } else {
+    logger.info("Dry run completed, no changes were made");
+  }
+};
+
+makeScript({}, async ({ execute }) => {
+  await updateProMaxMessagesLimit(execute);
+});


### PR DESCRIPTION
## Description

Migration to set the correct message limit for the Pro plan.
We can't change the maxMessageLifetime on Poke yet, hence the need for this migration.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
