### PR TITLE
Fix Markdown add preventdefault to prevent reload in Poké

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.140",
+  "version": "0.2.141",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.140",
+      "version": "0.2.141",
       "license": "ISC",
       "dependencies": {
         "@headlessui/react": "^1.7.17",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.140",
+  "version": "0.2.141",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/components/Markdown.tsx
+++ b/sparkle/src/components/Markdown.tsx
@@ -110,7 +110,10 @@ export function Markdown({
                     variant="tertiary"
                     size="xs"
                     icon={isCopied ? ClipboardCheckIcon : ClipboardIcon}
-                    onClick={handleCopy}
+                    onClick={async (e) => {
+                      e.preventDefault();
+                      await handleCopy();
+                    }}
                   />
                 </div>
               )}


### PR DESCRIPTION
## Description

Adding a "preventDefault" to the copy/paste action on the Markdown component because for some reason when used on a Poké form it reloads the page. 

## Risk

/ 

## Deploy Plan

Publish new sparkle version
