### PR TITLE
Poké template form: Preview Mardown

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -9,7 +9,7 @@
         "@amplitude/analytics-browser": "^2.5.2",
         "@amplitude/analytics-node": "^1.3.5",
         "@auth0/nextjs-auth0": "^3.5.0",
-        "@dust-tt/sparkle": "0.2.140",
+        "@dust-tt/sparkle": "0.2.141",
         "@dust-tt/types": "file:../types",
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",
@@ -10492,9 +10492,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.140",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.140.tgz",
-      "integrity": "sha512-m6Jtc4243X6875Igvc29Kkl7hhVO1s0Vpg7KjFaloD0JI1wFapuQcFl810RJcLX+YNYWYxQ1FmqzaMySDxd8NQ==",
+      "version": "0.2.141",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.141.tgz",
+      "integrity": "sha512-fNLrAjrpQsYsFCKr7K8jRMo9a3afDRXhvGQDmv8W/NdJS9uW67eMyczPGHbo1hH7FKCLOROq1f4QMra9yF/Meg==",
       "dependencies": {
         "@headlessui/react": "^1.7.17",
         "esbuild": "^0.20.0",

--- a/front/package.json
+++ b/front/package.json
@@ -17,7 +17,7 @@
     "@amplitude/analytics-browser": "^2.5.2",
     "@amplitude/analytics-node": "^1.3.5",
     "@auth0/nextjs-auth0": "^3.5.0",
-    "@dust-tt/sparkle": "0.2.140",
+    "@dust-tt/sparkle": "0.2.141",
     "@dust-tt/types": "file:../types",
     "@emoji-mart/data": "^1.1.2",
     "@emoji-mart/react": "^1.1.1",

--- a/front/pages/poke/templates/[tId].tsx
+++ b/front/pages/poke/templates/[tId].tsx
@@ -1,4 +1,4 @@
-import { TemplateItem } from "@dust-tt/sparkle";
+import { Markdown, TemplateItem } from "@dust-tt/sparkle";
 import type {
   CreateTemplateFormType,
   TemplateTagCodeType,
@@ -89,10 +89,15 @@ function InputField({
       render={({ field }) => (
         <PokeFormItem>
           <PokeFormLabel className="capitalize">{title ?? name}</PokeFormLabel>
-          <PokeFormControl>
-            <PokeInput placeholder={placeholder ?? name} {...field} />
-          </PokeFormControl>
-          <PokeFormMessage />
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <PokeFormControl>
+                <PokeInput placeholder={placeholder ?? name} {...field} />
+              </PokeFormControl>
+              <PokeFormMessage />
+            </div>
+            <div />
+          </div>
         </PokeFormItem>
       )}
     />
@@ -104,11 +109,13 @@ function TextareaField({
   name,
   title,
   placeholder,
+  previewMardown = false,
 }: {
   control: Control<CreateTemplateFormType>;
   name: keyof CreateTemplateFormType;
   title?: string;
   placeholder?: string;
+  previewMardown?: boolean;
 }) {
   return (
     <PokeFormField
@@ -117,9 +124,24 @@ function TextareaField({
       render={({ field }) => (
         <PokeFormItem>
           <PokeFormLabel className="capitalize">{title ?? name}</PokeFormLabel>
-          <PokeFormControl>
-            <PokeTextarea placeholder={placeholder ?? name} {...field} />
-          </PokeFormControl>
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <PokeFormControl>
+                <PokeTextarea
+                  placeholder={placeholder ?? name}
+                  rows={30}
+                  {...field}
+                />
+              </PokeFormControl>
+            </div>
+            {previewMardown &&
+              typeof field.value === "string" &&
+              field.value.length > 0 && (
+                <div className="rounded-xl border p-2">
+                  <Markdown content={field.value} />
+                </div>
+              )}
+          </div>
           <PokeFormMessage />
         </PokeFormItem>
       )}
@@ -158,28 +180,33 @@ function SelectField({
       render={({ field }) => (
         <PokeFormItem>
           <PokeFormLabel className="capitalize">{title ?? name}</PokeFormLabel>
-          <PokeFormControl>
-            <PokeSelect
-              value={field.value as string}
-              onValueChange={field.onChange}
-            >
+          <div className="grid grid-cols-2 gap-4">
+            <div>
               <PokeFormControl>
-                <PokeSelectTrigger>
-                  <PokeSelectValue placeholder={title ?? name} />
-                </PokeSelectTrigger>
+                <PokeSelect
+                  value={field.value as string}
+                  onValueChange={field.onChange}
+                >
+                  <PokeFormControl>
+                    <PokeSelectTrigger>
+                      <PokeSelectValue placeholder={title ?? name} />
+                    </PokeSelectTrigger>
+                  </PokeFormControl>
+                  <PokeSelectContent>
+                    <div className="bg-slate-100">
+                      {options.map((option) => (
+                        <PokeSelectItem key={option.value} value={option.value}>
+                          {option.display ? option.display : option.value}
+                        </PokeSelectItem>
+                      ))}
+                    </div>
+                  </PokeSelectContent>
+                </PokeSelect>
               </PokeFormControl>
-              <PokeSelectContent>
-                <div className="bg-slate-100">
-                  {options.map((option) => (
-                    <PokeSelectItem key={option.value} value={option.value}>
-                      {option.display ? option.display : option.value}
-                    </PokeSelectItem>
-                  ))}
-                </div>
-              </PokeSelectContent>
-            </PokeSelect>
-          </PokeFormControl>
-          <PokeFormMessage />
+              <PokeFormMessage />
+            </div>
+          </div>
+          <div />
         </PokeFormItem>
       )}
     />
@@ -192,7 +219,7 @@ function PreviewDialog({ form }: { form: any }) {
   return (
     <PokeDialog open={open} onOpenChange={setOpen}>
       <PokeDialogTrigger asChild>
-        <PokeButton variant="outline">✨ Preview Template</PokeButton>
+        <PokeButton variant="outline">✨ Preview Template Card</PokeButton>
       </PokeDialogTrigger>
       <PokeDialogContent className="bg-structure-50 sm:max-w-[600px]">
         <PokeDialogHeader>
@@ -351,7 +378,7 @@ function TemplatesPage({
   if (isSubmitting) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-structure-50">
-        <div className="text-structure-900">Creating template...</div>
+        <div className="text-structure-900">Creating/Updating template...</div>
       </div>
     );
   }
@@ -364,23 +391,48 @@ function TemplatesPage({
   return (
     <div className="min-h-screen bg-structure-50 pb-48">
       <PokeNavbar />
-      <div className="mx-auto h-full max-w-2xl flex-grow flex-col items-center justify-center pt-8">
+      <div className="mx-auto h-full max-w-7xl flex-grow flex-col items-center justify-center pt-8">
         <PokeForm {...form}>
-          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+          <form className="space-y-8">
             <InputField
               control={form.control}
               name="handle"
               placeholder="myAssistant"
             />
+            <SelectField
+              control={form.control}
+              name="visibility"
+              title="Visibility"
+              options={TEMPLATE_VISIBILITIES.map((v) => ({
+                value: v,
+                display: v,
+              }))}
+            />
             <TextareaField
               control={form.control}
               name="description"
               placeholder="A short description"
+              previewMardown={true}
             />
             <TextareaField
               control={form.control}
               name="presetInstructions"
+              title="preset Instructions"
               placeholder="Instructions"
+            />
+            <TextareaField
+              control={form.control}
+              name="helpInstructions"
+              title="Help Instructions"
+              placeholder="Instructions help bubble..."
+              previewMardown={true}
+            />
+            <TextareaField
+              control={form.control}
+              name="helpActions"
+              title="Help Actions"
+              placeholder="Actions help bubble..."
+              previewMardown={true}
             />
             <SelectField
               control={form.control}
@@ -408,39 +460,36 @@ function TemplatesPage({
                 display: v,
               }))}
             />
-            <TextareaField
-              control={form.control}
-              name="helpInstructions"
-              title="Help Instructions"
-              placeholder="Instructions help bubble..."
-            />
-            <TextareaField
-              control={form.control}
-              name="helpActions"
-              title="Help Actions"
-              placeholder="Actions help bubble..."
-            />
             <PokeFormField
               control={form.control}
               name="tags"
               render={({ field }) => (
                 <PokeFormItem>
                   <PokeFormLabel>Tags</PokeFormLabel>
-                  <PokeFormControl>
-                    <MultiSelect
-                      options={tagOptions}
-                      value={field.value.map((tag: TemplateTagCodeType) => ({
-                        label: TEMPLATES_TAGS_CONFIG[tag].label,
-                        value: tag,
-                      }))}
-                      onChange={(tags: { label: string; value: string }[]) => {
-                        field.onChange(tags.map((tag) => tag.value));
-                      }}
-                      labelledBy="Select"
-                      hasSelectAll={false}
-                    />
-                  </PokeFormControl>
-                  <PokeFormMessage />
+                  <div className="grid grid-cols-2 gap-4">
+                    <div>
+                      <PokeFormControl>
+                        <MultiSelect
+                          options={tagOptions}
+                          value={field.value.map(
+                            (tag: TemplateTagCodeType) => ({
+                              label: TEMPLATES_TAGS_CONFIG[tag].label,
+                              value: tag,
+                            })
+                          )}
+                          onChange={(
+                            tags: { label: string; value: string }[]
+                          ) => {
+                            field.onChange(tags.map((tag) => tag.value));
+                          }}
+                          labelledBy="Select"
+                          hasSelectAll={false}
+                        />
+                      </PokeFormControl>
+                      <PokeFormMessage />
+                    </div>
+                  </div>
+                  <div />
                 </PokeFormItem>
               )}
             />
@@ -454,20 +503,13 @@ function TemplatesPage({
                 display: v,
               }))}
             />
-            <SelectField
-              control={form.control}
-              name="visibility"
-              title="Visibility"
-              options={TEMPLATE_VISIBILITIES.map((v) => ({
-                value: v,
-                display: v,
-              }))}
-            />
-            <div className="space flex justify-between">
-              <PokeButton type="submit" className="border border-structure-300">
+            <div className="space flex gap-2">
+              <PokeButton
+                onClick={form.handleSubmit(onSubmit)}
+                className="border border-structure-300"
+              >
                 Save
               </PokeButton>
-              <PreviewDialog form={form} />
               <PokeButton
                 type="button"
                 variant="destructive"
@@ -475,6 +517,7 @@ function TemplatesPage({
               >
                 Delete this template
               </PokeButton>
+              <PreviewDialog form={form} />
             </div>
           </form>
         </PokeForm>


### PR DESCRIPTION
## Description

Adds a second column on the Poké template form to render the mardown if relevant. 
This will help template writers to work on the template description and help contents.

I also changed the order of some field and buttons, sorry for the diff 🙈 
Review with hidden whitespaces advised: https://github.com/dust-tt/dust/pull/4816/files?diff=split&w=1

<img width="1476" alt="Screenshot 2024-04-23 at 11 41 16" src="https://github.com/dust-tt/dust/assets/3803406/731f666d-204d-41db-b061-5bc112c26d9d">


## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
