### PR TITLE
Increase core probe readinessProbe.initialDelaySeconds from 5 to 10 s…

### DIFF
--- a/k8s/deployments/core-deployment.yaml
+++ b/k8s/deployments/core-deployment.yaml
@@ -28,7 +28,7 @@ spec:
             httpGet:
               path: /
               port: 3001
-            initialDelaySeconds: 5
+            initialDelaySeconds: 10
             periodSeconds: 5
 
           envFrom:


### PR DESCRIPTION
Increase core probe `readinessProbe.initialDelaySeconds` from 5 to 10 seconds.

This is to make sure Kube gives enough time to the docker container to be ready to answer to HTTP health checks.

## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
