### PR TITLE
Add Turbo to GPT4 naming

### DIFF
--- a/types/src/front/lib/assistant.ts
+++ b/types/src/front/lib/assistant.ts
@@ -14,7 +14,7 @@ const GPT_4_SHORT_DESCRIPTION = "OpenAI's smartest model.";
 export const GPT_4_TURBO_MODEL_CONFIG = {
   providerId: "openai" as const,
   modelId: GPT_4_TURBO_MODEL_ID,
-  displayName: "GPT 4",
+  displayName: "GPT 4 Turbo",
   contextSize: 128_000,
   recommendedTopK: 32,
   largeModel: true,


### PR DESCRIPTION
## Description

We're lacking coherence between names of GPT3.5 and GPT4 assistants, making it confusing as to which version of GPT4 we're providing 

## Risk

None

## Deploy Plan

Just go with the next main push, nothing urgent