### PR TITLE
feat: add customerio tracking

### DIFF
--- a/front/admin/amplitude_pull_types.sh
+++ b/front/admin/amplitude_pull_types.sh
@@ -1,9 +1,9 @@
 # This script pulls the types from the Amplitude.
 # You must have run `npx ampli login` before running this script.
-cd ./lib/amplitude/node/
+cd ./lib/tracking/amplitude/server/
 npx ampli pull  dust-node-prod -p ./generated 
 cd -
-cd ./lib/amplitude/browser/
+cd ./lib/tracking/amplitude/client/
 npx ampli pull  dust-browser-prod -p ./generated 
 cd -
 npm run format

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -780,7 +780,7 @@ export async function* postUserMessage(
       });
     }
   }
-  ServerSideTracking.trackUserMessage({
+  void ServerSideTracking.trackUserMessage({
     userMessage,
     workspace: conversation.owner,
     userId: user ? `user-${user.id}` : `api-${context.username}`,

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -33,6 +33,15 @@ const config = {
   getGaTrackingId: (): string => {
     return EnvironmentConfig.getEnvVariable("GA_TRACKING_ID");
   },
+  getCustomerIoSiteId: (): string => {
+    return EnvironmentConfig.getEnvVariable("CUSTOMERIO_SITE_ID");
+  },
+  getCustomerIoApiKey: (): string => {
+    return EnvironmentConfig.getEnvVariable("CUSTOMERIO_API_KEY");
+  },
+  getCustomerIoEnabled: (): boolean => {
+    return EnvironmentConfig.getEnvVariable("CUSTOMERIO_ENABLED") === "true";
+  },
 };
 
 export default config;

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -18,6 +18,7 @@ import { Op } from "sequelize";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { MembershipModel } from "@app/lib/resources/storage/models/membership";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+import { ServerSideTracking } from "@app/lib/tracking/server";
 import logger from "@app/logger/logger";
 
 type GetMembershipsOptions = RequireAtLeastOne<{
@@ -278,6 +279,13 @@ export class MembershipResource extends BaseResource<MembershipModel> {
       { transaction }
     );
 
+    void ServerSideTracking.trackCreateMembership({
+      user,
+      workspace,
+      role: newMembership.role,
+      startAt: newMembership.startAt,
+    });
+
     return new MembershipResource(MembershipModel, newMembership.get());
   }
 
@@ -317,6 +325,15 @@ export class MembershipResource extends BaseResource<MembershipModel> {
       { endAt },
       { where: { id: membership.id }, transaction }
     );
+
+    void ServerSideTracking.trackRevokeMembership({
+      user,
+      workspace,
+      role: membership.role,
+      startAt: membership.startAt,
+      endAt,
+    });
+
     return new Ok(undefined);
   }
 
@@ -373,6 +390,12 @@ export class MembershipResource extends BaseResource<MembershipModel> {
         transaction,
       });
     }
+
+    void ServerSideTracking.trackUpdateMembershipRole({
+      user,
+      workspace,
+      role: newRole,
+    });
 
     return new Ok(undefined);
   }

--- a/front/lib/tracking/amplitude/client/generated/index.ts
+++ b/front/lib/tracking/amplitude/client/generated/index.ts
@@ -65,6 +65,8 @@ export type LoadOptions =
 
 export interface IdentifyProperties {
   email?: string;
+  firstName?: string;
+  lastName?: string;
   SignupDate?: string;
 }
 

--- a/front/lib/tracking/amplitude/server/generated/index.ts
+++ b/front/lib/tracking/amplitude/server/generated/index.ts
@@ -72,6 +72,8 @@ export type LoadOptions =
 
 export interface IdentifyProperties {
   email?: string;
+  firstName?: string;
+  lastName?: string;
   SignupDate?: string;
 }
 

--- a/front/lib/tracking/amplitude/server/index.ts
+++ b/front/lib/tracking/amplitude/server/index.ts
@@ -293,8 +293,8 @@ export class AmplitudeServerSideTracking {
     const amplitude = getBackendClient();
     amplitude.identify(`user-${user.id}`, {
       email: user.email,
-      first_name: user.firstName,
-      last_name: user.lastName,
+      firstName: user.firstName,
+      lastName: user.lastName ?? undefined,
     });
   }
 }

--- a/front/lib/tracking/amplitude/server/index.ts
+++ b/front/lib/tracking/amplitude/server/index.ts
@@ -3,17 +3,15 @@ import type {
   AgentConfigurationType,
   AgentMessageType,
   DataSourceType,
+  LightWorkspaceType,
   UserMessageType,
   UserType,
-  UserTypeWithWorkspaces,
   WorkspaceType,
 } from "@dust-tt/types";
 import { rateLimiter, removeNulls } from "@dust-tt/types";
 
 import { isGlobalAgentId } from "@app/lib/api/assistant/global_agents";
-import { subscriptionForWorkspace } from "@app/lib/auth";
 import { deprecatedGetFirstActionConfiguration } from "@app/lib/deprecated_action_configurations";
-import { countActiveSeatsInWorkspace } from "@app/lib/plans/usage/seats";
 import {
   AMPLITUDE_PUBLIC_API_KEY,
   GROUP_TYPE,
@@ -64,7 +62,11 @@ export class AmplitudeServerSideTracking {
   static async trackUserMemberships({
     user,
   }: {
-    user: UserTypeWithWorkspaces;
+    user: UserType & {
+      workspaces: Array<
+        LightWorkspaceType & { planCode: string; seats: number }
+      >;
+    };
   }) {
     const amplitude = getBackendClient();
     const groups: string[] = [];
@@ -73,11 +75,11 @@ export class AmplitudeServerSideTracking {
       const groupId = workspace.sId;
 
       // Identify the workspace as a group.
-      const subscription = await subscriptionForWorkspace(workspace.sId);
-      const memberCount = await countActiveSeatsInWorkspace(workspace.sId);
+      const planCode = workspace.planCode;
+      const memberCount = workspace.seats;
       const groupProperties = new Identify();
       groupProperties.set("name", workspace.name);
-      groupProperties.set("plan", subscription.plan.code);
+      groupProperties.set("plan", planCode);
       groupProperties.set("memberCount", memberCount);
       const rateLimiterKey = `amplitude_workspace:${
         workspace.sId
@@ -269,21 +271,19 @@ export class AmplitudeServerSideTracking {
 
   static trackSubscriptionCreated({
     userId,
-    workspaceName,
-    workspaceId,
+    workspace,
     planCode,
     workspaceSeats,
   }: {
     userId: string;
-    workspaceName: string;
-    workspaceId: string;
+    workspace: LightWorkspaceType;
     planCode: string;
     workspaceSeats: number;
   }) {
     const amplitude = getBackendClient();
     amplitude.subscriptionCreated(`user-${userId}`, {
-      workspaceId,
-      workspaceName,
+      workspaceId: workspace.sId,
+      workspaceName: workspace.name,
       plan: planCode,
       workspaceSeats,
     });

--- a/front/lib/tracking/amplitude/server/index.ts
+++ b/front/lib/tracking/amplitude/server/index.ts
@@ -54,7 +54,7 @@ function getBackendClient() {
 export class AmplitudeServerSideTracking {
   static trackSignup({ user }: { user: UserType }) {
     const amplitude = getBackendClient();
-    amplitude.identify(`user-${user.id}`, { email: user.email });
+    AmplitudeServerSideTracking._identifyUser({ user });
     amplitude.signUp(`user-${user.id}`, {
       insert_id: `signup_${user.id}`,
       time: user.createdAt,
@@ -286,6 +286,15 @@ export class AmplitudeServerSideTracking {
       workspaceName,
       plan: planCode,
       workspaceSeats,
+    });
+  }
+
+  static _identifyUser({ user }: { user: UserType }) {
+    const amplitude = getBackendClient();
+    amplitude.identify(`user-${user.id}`, {
+      email: user.email,
+      first_name: user.firstName,
+      last_name: user.lastName,
     });
   }
 }

--- a/front/lib/tracking/customerio/server.ts
+++ b/front/lib/tracking/customerio/server.ts
@@ -2,7 +2,6 @@ import type {
   LightWorkspaceType,
   MembershipRoleType,
   UserType,
-  UserTypeWithWorkspaces,
 } from "@dust-tt/types";
 import * as _ from "lodash";
 
@@ -31,11 +30,7 @@ export class CustomerioServerSideTracking {
     return CustomerioServerSideTracking._identifyUser({ user });
   }
 
-  static async trackUserMemberships({
-    user,
-  }: {
-    user: UserTypeWithWorkspaces;
-  }) {
+  static async trackUserMemberships({ user }: { user: UserType }) {
     if (!isCustomerioEnabled()) {
       return;
     }

--- a/front/lib/tracking/customerio/server.ts
+++ b/front/lib/tracking/customerio/server.ts
@@ -83,6 +83,9 @@ export class CustomerioServerSideTracking {
   }: {
     workspace: LightWorkspaceType;
   }) {
+    if (!isCustomerioEnabled()) {
+      return;
+    }
     const subscription = await subscriptionForWorkspace(workspace.sId);
     const r = await fetch(`${CUSTOMERIO_HOST}/entity`, {
       method: "POST",
@@ -118,6 +121,9 @@ export class CustomerioServerSideTracking {
       role: MembershipRoleType;
     }>;
   }) {
+    if (!isCustomerioEnabled()) {
+      return;
+    }
     const body: Record<string, any> = {
       identifiers: {
         email: user.email,

--- a/front/lib/tracking/customerio/server.ts
+++ b/front/lib/tracking/customerio/server.ts
@@ -3,13 +3,16 @@ import type {
   MembershipRoleType,
   UserType,
 } from "@dust-tt/types";
+import { rateLimiter } from "@dust-tt/types";
 import * as _ from "lodash";
 
 import config from "@app/lib/api/config";
 import { subscriptionForWorkspace } from "@app/lib/auth";
 import { Workspace } from "@app/lib/models/workspace";
+import { countActiveSeatsInWorkspace } from "@app/lib/plans/usage/seats";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
+import logger from "@app/logger/logger";
 
 const CUSTOMERIO_HOST = "https://track-eu.customer.io/api/v2";
 
@@ -18,7 +21,99 @@ export class CustomerioServerSideTracking {
     return CustomerioServerSideTracking._identifyUser({ user });
   }
 
-  static async trackUserMemberships({ user }: { user: UserType }) {
+  static identifyWorkspaces({
+    workspaces,
+  }: {
+    workspaces: Array<
+      LightWorkspaceType & { planCode?: string; seats?: number }
+    >;
+  }) {
+    return Promise.all(
+      workspaces.map(async (ws) =>
+        CustomerioServerSideTracking._identifyWorkspace({ workspace: ws })
+      )
+    );
+  }
+
+  static async trackCreateMembership({
+    user,
+    workspace,
+    role,
+    startAt,
+  }: {
+    user: UserType;
+    workspace: LightWorkspaceType;
+    role: MembershipRoleType;
+    startAt: Date;
+  }) {
+    await CustomerioServerSideTracking._identifyWorkspace({
+      workspace,
+    });
+    await CustomerioServerSideTracking._identifyUser({
+      user,
+      workspaces: [
+        {
+          sId: workspace.sId,
+          startAt,
+          role,
+        },
+      ],
+    });
+  }
+
+  static async trackRevokeMembership({
+    user,
+    workspace,
+    role,
+    startAt,
+    endAt,
+  }: {
+    user: UserType;
+    workspace: LightWorkspaceType;
+    role: MembershipRoleType;
+    startAt: Date;
+    endAt: Date;
+  }) {
+    await CustomerioServerSideTracking._identifyWorkspace({
+      workspace,
+    });
+    await CustomerioServerSideTracking._identifyUser({
+      user,
+      workspaces: [
+        {
+          sId: workspace.sId,
+          startAt,
+          endAt,
+          role,
+        },
+      ],
+    });
+  }
+
+  static async trackUpdateMembershipRole({
+    user,
+    workspace,
+    role,
+  }: {
+    user: UserType;
+    workspace: LightWorkspaceType;
+    role: MembershipRoleType;
+  }) {
+    await CustomerioServerSideTracking._identifyWorkspace({
+      workspace,
+    });
+    await CustomerioServerSideTracking._identifyUser({
+      user,
+      workspaces: [
+        {
+          sId: workspace.sId,
+          role,
+        },
+      ],
+    });
+  }
+
+  static async backfillUser({ user }: { user: UserType }) {
     const userMemberships = await MembershipResource.getLatestMemberships({
       users: [user],
     });
@@ -61,12 +156,29 @@ export class CustomerioServerSideTracking {
   static async _identifyWorkspace({
     workspace,
   }: {
-    workspace: LightWorkspaceType;
+    workspace: LightWorkspaceType & { planCode?: string; seats?: number };
   }) {
     if (!config.getCustomerIoEnabled()) {
       return;
     }
-    const subscription = await subscriptionForWorkspace(workspace.sId);
+    const planCode =
+      workspace.planCode ??
+      (await subscriptionForWorkspace(workspace.sId)).plan.code;
+    const seats = workspace.seats ?? countActiveSeatsInWorkspace(workspace.sId);
+
+    // Unless the info changes, we only identify a given workspace once per day.
+    const rateLimiterKey = `customerio_workspace:${workspace.sId}:${workspace.name}:${planCode}:${seats}`;
+    if (
+      !(await rateLimiter({
+        key: rateLimiterKey,
+        maxPerTimeframe: 1,
+        timeframeSeconds: 60 * 60 * 24,
+        logger: logger,
+      }))
+    ) {
+      return;
+    }
+
     const r = await fetch(`${CUSTOMERIO_HOST}/entity`, {
       method: "POST",
       headers: CustomerioServerSideTracking._headers(),
@@ -79,7 +191,8 @@ export class CustomerioServerSideTracking {
         action: "identify",
         attributes: {
           name: workspace.name,
-          planCode: subscription.plan.code,
+          planCode: planCode,
+          seats,
         },
       }),
     });
@@ -96,7 +209,7 @@ export class CustomerioServerSideTracking {
     user: UserType;
     workspaces?: Array<{
       sId: string;
-      startAt: Date;
+      startAt?: Date;
       endAt?: Date | null;
       role: MembershipRoleType;
     }>;
@@ -104,6 +217,7 @@ export class CustomerioServerSideTracking {
     if (!config.getCustomerIoEnabled()) {
       return;
     }
+
     const body: Record<string, any> = {
       identifiers: {
         email: user.email,
@@ -119,17 +233,24 @@ export class CustomerioServerSideTracking {
     };
 
     if (workspaces) {
-      body.cio_relationships = workspaces.map((w) => ({
-        identifiers: {
-          object_type_id: "1",
-          object_id: w.sId,
-        },
-        relationship_attributes: {
+      body.cio_relationships = workspaces.map((w) => {
+        const relAttributes: Record<string, any> = {
           role: w.role,
-          start_at: w.startAt,
-          end_at: w.endAt,
-        },
-      }));
+        };
+        if (w.startAt !== undefined) {
+          relAttributes.start_at = w.startAt;
+        }
+        if (w.endAt !== undefined) {
+          relAttributes.end_at = w.endAt;
+        }
+        return {
+          identifiers: {
+            object_type_id: "1",
+            object_id: w.sId,
+          },
+          relationship_attributes: relAttributes,
+        };
+      });
     }
 
     const r = await fetch(`${CUSTOMERIO_HOST}/entity`, {

--- a/front/lib/tracking/customerio/server.ts
+++ b/front/lib/tracking/customerio/server.ts
@@ -1,0 +1,169 @@
+import type {
+  LightWorkspaceType,
+  MembershipRoleType,
+  UserType,
+  UserTypeWithWorkspaces,
+} from "@dust-tt/types";
+import * as _ from "lodash";
+
+import { subscriptionForWorkspace } from "@app/lib/auth";
+import { Workspace } from "@app/lib/models/workspace";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
+
+const {
+  CUSTOMERIO_ENABLED,
+  CUSTOMERIO_SITE_ID = "",
+  CUSTOMERIO_API_KEY = "",
+} = process.env;
+
+const CUSTOMERIO_HOST = "https://track-eu.customer.io/api/v2";
+
+function isCustomerioEnabled() {
+  return CUSTOMERIO_ENABLED === "true";
+}
+
+export class CustomerioServerSideTracking {
+  static trackSignup({ user }: { user: UserType }) {
+    if (!isCustomerioEnabled()) {
+      return;
+    }
+    return CustomerioServerSideTracking._identifyUser({ user });
+  }
+
+  static async trackUserMemberships({
+    user,
+  }: {
+    user: UserTypeWithWorkspaces;
+  }) {
+    if (!isCustomerioEnabled()) {
+      return;
+    }
+    const userMemberships = await MembershipResource.getLatestMemberships({
+      users: [user],
+    });
+
+    const workspaces = _.keyBy(
+      await Workspace.findAll({
+        where: {
+          id: userMemberships.map((m) => m.workspaceId),
+        },
+      }),
+      "id"
+    );
+
+    // Identify all workspace objects.
+    const chunks = _.chunk(userMemberships, 8);
+    for (const c of chunks) {
+      await Promise.all(
+        c.map(async (membership) => {
+          const ws = renderLightWorkspaceType({
+            workspace: workspaces[membership.workspaceId],
+          });
+          await CustomerioServerSideTracking._identifyWorkspace({
+            workspace: ws,
+          });
+        })
+      );
+    }
+
+    await CustomerioServerSideTracking._identifyUser({
+      user,
+      workspaces: userMemberships.map((m) => ({
+        sId: workspaces[m.workspaceId].sId,
+        startAt: m.startAt,
+        endAt: m.endAt,
+        role: m.role,
+      })),
+    });
+  }
+
+  static async _identifyWorkspace({
+    workspace,
+  }: {
+    workspace: LightWorkspaceType;
+  }) {
+    const subscription = await subscriptionForWorkspace(workspace.sId);
+    const r = await fetch(`${CUSTOMERIO_HOST}/entity`, {
+      method: "POST",
+      headers: CustomerioServerSideTracking._headers(),
+      body: JSON.stringify({
+        identifiers: {
+          object_type_id: "1",
+          object_id: workspace.sId,
+        },
+        type: "object",
+        action: "identify",
+        attributes: {
+          name: workspace.name,
+          planCode: subscription.plan.code,
+        },
+      }),
+    });
+
+    if (!r.ok) {
+      throw new Error(`Failed to identify workspace ${workspace.sId}`);
+    }
+  }
+
+  static async _identifyUser({
+    user,
+    workspaces,
+  }: {
+    user: UserType;
+    workspaces?: Array<{
+      sId: string;
+      startAt: Date;
+      endAt?: Date | null;
+      role: MembershipRoleType;
+    }>;
+  }) {
+    const body: Record<string, any> = {
+      identifiers: {
+        email: user.email,
+      },
+      type: "person",
+      action: "identify",
+      attributes: {
+        email: user.email,
+        first_name: user.firstName,
+        last_name: user.lastName,
+        created_at: user.createdAt,
+      },
+    };
+
+    if (workspaces) {
+      body.cio_relationships = workspaces.map((w) => ({
+        identifiers: {
+          object_type_id: "1",
+          object_id: w.sId,
+        },
+        relationship_attributes: {
+          role: w.role,
+          start_at: w.startAt,
+          end_at: w.endAt,
+        },
+      }));
+    }
+
+    const r = await fetch(`${CUSTOMERIO_HOST}/entity`, {
+      method: "POST",
+      headers: CustomerioServerSideTracking._headers(),
+      body: JSON.stringify(body),
+    });
+
+    if (!r.ok) {
+      const json = await r.json();
+      throw new Error(`Failed to identify user ${user.email}: ${json}`);
+    }
+  }
+
+  static _headers() {
+    return {
+      "Content-Type": "application/json",
+      Authorization: `Basic ${Buffer.from(
+        `${CUSTOMERIO_SITE_ID}:${CUSTOMERIO_API_KEY}`
+      ).toString("base64")}`,
+    };
+  }
+}

--- a/front/lib/tracking/customerio/server.ts
+++ b/front/lib/tracking/customerio/server.ts
@@ -5,35 +5,20 @@ import type {
 } from "@dust-tt/types";
 import * as _ from "lodash";
 
+import config from "@app/lib/api/config";
 import { subscriptionForWorkspace } from "@app/lib/auth";
 import { Workspace } from "@app/lib/models/workspace";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 
-const {
-  CUSTOMERIO_ENABLED,
-  CUSTOMERIO_SITE_ID = "",
-  CUSTOMERIO_API_KEY = "",
-} = process.env;
-
 const CUSTOMERIO_HOST = "https://track-eu.customer.io/api/v2";
-
-function isCustomerioEnabled() {
-  return CUSTOMERIO_ENABLED === "true";
-}
 
 export class CustomerioServerSideTracking {
   static trackSignup({ user }: { user: UserType }) {
-    if (!isCustomerioEnabled()) {
-      return;
-    }
     return CustomerioServerSideTracking._identifyUser({ user });
   }
 
   static async trackUserMemberships({ user }: { user: UserType }) {
-    if (!isCustomerioEnabled()) {
-      return;
-    }
     const userMemberships = await MembershipResource.getLatestMemberships({
       users: [user],
     });
@@ -78,7 +63,7 @@ export class CustomerioServerSideTracking {
   }: {
     workspace: LightWorkspaceType;
   }) {
-    if (!isCustomerioEnabled()) {
+    if (!config.getCustomerIoEnabled()) {
       return;
     }
     const subscription = await subscriptionForWorkspace(workspace.sId);
@@ -116,7 +101,7 @@ export class CustomerioServerSideTracking {
       role: MembershipRoleType;
     }>;
   }) {
-    if (!isCustomerioEnabled()) {
+    if (!config.getCustomerIoEnabled()) {
       return;
     }
     const body: Record<string, any> = {
@@ -163,7 +148,7 @@ export class CustomerioServerSideTracking {
     return {
       "Content-Type": "application/json",
       Authorization: `Basic ${Buffer.from(
-        `${CUSTOMERIO_SITE_ID}:${CUSTOMERIO_API_KEY}`
+        `${config.getCustomerIoSiteId()}:${config.getCustomerIoApiKey()}`
       ).toString("base64")}`,
     };
   }

--- a/front/lib/tracking/customerio/server.ts
+++ b/front/lib/tracking/customerio/server.ts
@@ -9,7 +9,7 @@ import * as _ from "lodash";
 import config from "@app/lib/api/config";
 import { subscriptionForWorkspace } from "@app/lib/auth";
 import { Workspace } from "@app/lib/models/workspace";
-import { countActiveSeatsInWorkspace } from "@app/lib/plans/usage/seats";
+import { countActiveSeatsInWorkspaceCached } from "@app/lib/plans/usage/seats";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
@@ -164,7 +164,8 @@ export class CustomerioServerSideTracking {
     const planCode =
       workspace.planCode ??
       (await subscriptionForWorkspace(workspace.sId)).plan.code;
-    const seats = workspace.seats ?? countActiveSeatsInWorkspace(workspace.sId);
+    const seats =
+      workspace.seats ?? countActiveSeatsInWorkspaceCached(workspace.sId);
 
     // Unless the info changes, we only identify a given workspace once per day.
     const rateLimiterKey = `customerio_workspace:${workspace.sId}:${workspace.name}:${planCode}:${seats}`;

--- a/front/lib/tracking/server.ts
+++ b/front/lib/tracking/server.ts
@@ -2,12 +2,17 @@ import type {
   AgentConfigurationType,
   AgentMessageType,
   DataSourceType,
+  LightWorkspaceType,
+  MembershipRoleType,
   UserMessageType,
   UserType,
   UserTypeWithWorkspaces,
   WorkspaceType,
 } from "@dust-tt/types";
+import * as _ from "lodash";
 
+import { subscriptionForWorkspaces } from "@app/lib/auth";
+import { countActiveSeatsInWorkspace } from "@app/lib/plans/usage/seats";
 import { AmplitudeServerSideTracking } from "@app/lib/tracking/amplitude/server";
 import { CustomerioServerSideTracking } from "@app/lib/tracking/customerio/server";
 import logger from "@app/logger/logger";
@@ -18,26 +23,72 @@ export class ServerSideTracking {
     void CustomerioServerSideTracking.trackSignup({ user });
   }
 
-  static async trackUserMemberships({
-    user,
-  }: {
-    user: UserTypeWithWorkspaces;
-  }) {
-    AmplitudeServerSideTracking.trackUserMemberships({ user }).catch((err) => {
+  static async trackGetUser({ user }: { user: UserTypeWithWorkspaces }) {
+    try {
+      const subscriptionByWorkspaceId = await subscriptionForWorkspaces(
+        user.workspaces.map((ws) => ws.sId)
+      );
+
+      // TODO(@fontanierh): This is not efficient, we should batch this.
+      const seatsByWorkspaceId = _.keyBy(
+        await Promise.all(
+          user.workspaces.map(async (workspace) => {
+            const seats = await countActiveSeatsInWorkspace(workspace.sId);
+            return { sId: workspace.sId, seats };
+          })
+        ),
+        "sId"
+      );
+
+      const promises: Promise<unknown>[] = [];
+
+      // We overwrite every user membership on Amplitude everytime someone logs in.
+      promises.push(
+        AmplitudeServerSideTracking.trackUserMemberships({
+          user: {
+            ...user,
+            workspaces: user.workspaces.map((ws) => ({
+              ...ws,
+              planCode: subscriptionByWorkspaceId[ws.sId].plan.code,
+              seats: seatsByWorkspaceId[ws.sId].seats,
+            })),
+          },
+        }).catch((err) => {
+          logger.error(
+            { userId: user.sId, err },
+            "Failed to track user memberships on Amplitude"
+          );
+        })
+      );
+
+      // We identify all of the user's workspaces on Customer.io everytime someone logs in,
+      // so we keep subscription info up to date.
+      // The actual customer.io call is rate limited to 1 call per day with the same data.
+      promises.push(
+        CustomerioServerSideTracking.identifyWorkspaces({
+          workspaces: user.workspaces.map((ws) => ({
+            ...ws,
+            planCode: subscriptionByWorkspaceId[ws.sId].plan.code,
+            seats: seatsByWorkspaceId[ws.sId].seats,
+          })),
+        }).catch((err) => {
+          logger.error(
+            { userId: user.sId, err },
+            "Failed to identify workspaces on Customer.io"
+          );
+        })
+      );
+
+      await Promise.all(promises);
+    } catch (err) {
       logger.error(
         { userId: user.sId, err },
-        "Failed to track user memberships on Amplitude"
+        "Failed to track user memberships"
       );
-    });
-    CustomerioServerSideTracking.trackUserMemberships({ user }).catch((err) => {
-      logger.error(
-        { userId: user.sId, err },
-        "Failed to track user memberships on Customer.io"
-      );
-    });
+    }
   }
 
-  static trackUserMessage({
+  static async trackUserMessage({
     userMessage,
     workspace,
     userId,
@@ -50,16 +101,23 @@ export class ServerSideTracking {
     conversationId: string;
     agentMessages: AgentMessageType[];
   }) {
-    return AmplitudeServerSideTracking.trackUserMessage({
-      userMessage,
-      workspace,
-      userId,
-      conversationId,
-      agentMessages,
-    });
+    try {
+      await AmplitudeServerSideTracking.trackUserMessage({
+        userMessage,
+        workspace,
+        userId,
+        conversationId,
+        agentMessages,
+      });
+    } catch (err) {
+      logger.error(
+        { userId, workspaceId: workspace.sId, err },
+        "Failed to track user message on Amplitude"
+      );
+    }
   }
 
-  static trackDataSourceCreated({
+  static async trackDataSourceCreated({
     user,
     workspace,
     dataSource,
@@ -68,14 +126,21 @@ export class ServerSideTracking {
     workspace?: WorkspaceType;
     dataSource: DataSourceType;
   }) {
-    return AmplitudeServerSideTracking.trackDataSourceCreated({
-      user,
-      workspace,
-      dataSource,
-    });
+    try {
+      await AmplitudeServerSideTracking.trackDataSourceCreated({
+        user,
+        workspace,
+        dataSource,
+      });
+    } catch (err) {
+      logger.error(
+        { userId: user?.sId, workspaceId: workspace?.sId, err },
+        "Failed to track data source created on Amplitude"
+      );
+    }
   }
 
-  static trackDataSourceUpdated({
+  static async trackDataSourceUpdated({
     user,
     workspace,
     dataSource,
@@ -84,14 +149,21 @@ export class ServerSideTracking {
     workspace?: WorkspaceType;
     dataSource: DataSourceType;
   }) {
-    return AmplitudeServerSideTracking.trackDataSourceUpdated({
-      user,
-      workspace,
-      dataSource,
-    });
+    try {
+      await AmplitudeServerSideTracking.trackDataSourceUpdated({
+        user,
+        workspace,
+        dataSource,
+      });
+    } catch (err) {
+      logger.error(
+        { userId: user?.sId, workspaceId: workspace?.sId, err },
+        "Failed to track data source updated on Amplitude"
+      );
+    }
   }
 
-  static trackAssistantCreated({
+  static async trackAssistantCreated({
     user,
     workspace,
     assistant,
@@ -100,32 +172,119 @@ export class ServerSideTracking {
     workspace?: WorkspaceType;
     assistant: AgentConfigurationType;
   }) {
-    return AmplitudeServerSideTracking.trackAssistantCreated({
-      user,
-      workspace,
-      assistant,
-    });
+    try {
+      await AmplitudeServerSideTracking.trackAssistantCreated({
+        user,
+        workspace,
+        assistant,
+      });
+    } catch (err) {
+      logger.error(
+        { userId: user?.sId, workspaceId: workspace?.sId, err },
+        "Failed to track assistant created on Amplitude"
+      );
+    }
   }
 
   static async trackSubscriptionCreated({
     userId,
-    workspaceName,
-    workspaceId,
+    workspace,
     planCode,
     workspaceSeats,
   }: {
     userId: string;
-    workspaceName: string;
-    workspaceId: string;
+    workspace: LightWorkspaceType;
     planCode: string;
     workspaceSeats: number;
   }) {
-    return AmplitudeServerSideTracking.trackSubscriptionCreated({
-      userId,
-      workspaceName,
-      workspaceId,
-      planCode,
-      workspaceSeats,
-    });
+    return Promise.all([
+      AmplitudeServerSideTracking.trackSubscriptionCreated({
+        userId,
+        workspace,
+        planCode,
+        workspaceSeats,
+      }),
+      CustomerioServerSideTracking.identifyWorkspaces({
+        workspaces: [{ ...workspace, planCode, seats: workspaceSeats }],
+      }),
+    ]);
+  }
+
+  static async trackCreateMembership({
+    user,
+    workspace,
+    role,
+    startAt,
+  }: {
+    user: UserType;
+    workspace: LightWorkspaceType;
+    role: MembershipRoleType;
+    startAt: Date;
+  }) {
+    try {
+      await CustomerioServerSideTracking.trackCreateMembership({
+        user,
+        workspace,
+        role,
+        startAt,
+      });
+    } catch (err) {
+      logger.error(
+        { userId: user.sId, workspaceId: workspace.sId, err },
+        "Failed to track create membership on Customer.io"
+      );
+    }
+  }
+
+  static async trackRevokeMembership({
+    user,
+    workspace,
+    role,
+    startAt,
+    endAt,
+  }: {
+    user: UserType;
+    workspace: LightWorkspaceType;
+    role: MembershipRoleType;
+    startAt: Date;
+    endAt: Date;
+  }) {
+    try {
+      await CustomerioServerSideTracking.trackRevokeMembership({
+        user,
+        workspace,
+        role,
+        startAt,
+        endAt,
+      });
+    } catch (err) {
+      logger.error(
+        { userId: user.sId, workspaceId: workspace.sId, err },
+        "Failed to track revoke membership on Customer.io"
+      );
+    }
+  }
+
+  static async trackUpdateMembershipRole({
+    user,
+    workspace,
+    role,
+  }: {
+    user: UserType;
+    workspace: LightWorkspaceType;
+    role: MembershipRoleType;
+  }) {
+    try {
+      await CustomerioServerSideTracking.trackUpdateMembershipRole({
+        user,
+        workspace,
+        role,
+      });
+    } catch (err) {
+      logger.error(
+        { userId: user.sId, workspaceId: workspace.sId, err },
+        "Failed to track update membership role on Customer.io"
+      );
+    }
   }
 }

--- a/front/lib/tracking/server.ts
+++ b/front/lib/tracking/server.ts
@@ -12,7 +12,7 @@ import type {
 import * as _ from "lodash";
 
 import { subscriptionForWorkspaces } from "@app/lib/auth";
-import { countActiveSeatsInWorkspace } from "@app/lib/plans/usage/seats";
+import { countActiveSeatsInWorkspaceCached } from "@app/lib/plans/usage/seats";
 import { AmplitudeServerSideTracking } from "@app/lib/tracking/amplitude/server";
 import { CustomerioServerSideTracking } from "@app/lib/tracking/customerio/server";
 import logger from "@app/logger/logger";
@@ -33,7 +33,9 @@ export class ServerSideTracking {
       const seatsByWorkspaceId = _.keyBy(
         await Promise.all(
           user.workspaces.map(async (workspace) => {
-            const seats = await countActiveSeatsInWorkspace(workspace.sId);
+            const seats = await countActiveSeatsInWorkspaceCached(
+              workspace.sId
+            );
             return { sId: workspace.sId, seats };
           })
         ),

--- a/front/migrations/20240423_backfill_customerio.ts
+++ b/front/migrations/20240423_backfill_customerio.ts
@@ -1,0 +1,38 @@
+import * as _ from "lodash";
+
+import { renderUserType } from "@app/lib/api/user";
+import { User } from "@app/lib/models/user";
+import { CustomerioServerSideTracking } from "@app/lib/tracking/customerio/server";
+import logger from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+
+const backfillCustomerIo = async (execute: boolean) => {
+  const allUserModels = await User.findAll();
+  const users = allUserModels.map((u) => renderUserType(u));
+  const chunks = _.chunk(users, 16);
+  for (const [i, c] of chunks.entries()) {
+    logger.info(
+      `[execute=${execute}] Processing chunk of ${c.length} users... (${
+        i + 1
+      }/${chunks.length})`
+    );
+    if (execute) {
+      await Promise.all(
+        c.map((u) =>
+          CustomerioServerSideTracking.trackUserMemberships({ user: u }).catch(
+            (err) => {
+              logger.error(
+                { userId: u.sId, err },
+                "Failed to track user memberships on Customer.io"
+              );
+            }
+          )
+        )
+      );
+    }
+  }
+};
+
+makeScript({}, async ({ execute }) => {
+  await backfillCustomerIo(execute);
+});

--- a/front/migrations/20240423_backfill_customerio.ts
+++ b/front/migrations/20240423_backfill_customerio.ts
@@ -21,12 +21,12 @@ const backfillCustomerIo = async (execute: boolean) => {
       await Promise.all(
         c.map((u) =>
           Promise.all([
-            CustomerioServerSideTracking.trackUserMemberships({
+            CustomerioServerSideTracking.backfillUser({
               user: u,
             }).catch((err) => {
               logger.error(
                 { userId: u.sId, err },
-                "Failed to track user memberships on Customer.io"
+                "Failed to backfill user on Customer.io"
               );
             }),
             // NOTE: this is unrelated to customerio, but leveraging this backfill

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -24,6 +24,7 @@ import { countActiveSeatsInWorkspace } from "@app/lib/plans/usage/seats";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { ServerSideTracking } from "@app/lib/tracking/server";
 import { generateModelSId } from "@app/lib/utils";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import {
@@ -237,8 +238,7 @@ async function handler(
               );
               await ServerSideTracking.trackSubscriptionCreated({
                 userId,
-                workspaceName: workspace.name,
-                workspaceId: workspace.sId,
+                workspace: renderLightWorkspaceType({ workspace }),
                 planCode,
                 workspaceSeats,
               });

--- a/front/pages/api/user/index.ts
+++ b/front/pages/api/user/index.ts
@@ -50,7 +50,7 @@ async function handler(
 
   switch (req.method) {
     case "GET":
-      ServerSideTracking.trackUserMemberships({ user }).catch((err) => {
+      ServerSideTracking.trackGetUser({ user }).catch((err) => {
         logger.error(
           { err: err, userId: user.sId },
           "Failed to track user memberships"

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -381,7 +381,7 @@ export async function createOrUpgradeAgentConfiguration({
 
   // We are not tracking draft agents
   if (agentConfigurationRes.value.status === "active") {
-    ServerSideTracking.trackAssistantCreated({
+    void ServerSideTracking.trackAssistantCreated({
       user: auth.user() ?? undefined,
       workspace: auth.workspace() ?? undefined,
       assistant: agentConfiguration,

--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/update.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/update.ts
@@ -131,7 +131,7 @@ async function handler(
       }
 
       await updateDataSourceEditedBy(auth, dataSource);
-      ServerSideTracking.trackDataSourceUpdated({
+      void ServerSideTracking.trackDataSourceUpdated({
         dataSource,
         user: auth.user() ?? undefined,
         workspace: owner,

--- a/front/pages/api/w/[wId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/index.ts
@@ -173,7 +173,7 @@ async function handler(
 
       const dataSourceType = await getDataSource(auth, ds.name);
       if (dataSourceType) {
-        ServerSideTracking.trackDataSourceCreated({
+        void ServerSideTracking.trackDataSourceCreated({
           user,
           workspace: owner,
           dataSource: dataSourceType,

--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -387,7 +387,7 @@ async function handler(
       });
       const dataSourceType = await getDataSource(auth, dataSource.name);
       if (dataSourceType) {
-        ServerSideTracking.trackDataSourceCreated({
+        void ServerSideTracking.trackDataSourceCreated({
           dataSource: dataSourceType,
           user,
           workspace: owner,


### PR DESCRIPTION
## Description

Step 2 for https://github.com/dust-tt/tasks/issues/689

Adds identify calls for user signups, workspaces and user/workspace relationships.
Tested locally.

Had to implement the client myself with my bare hands because the customerio-provided library is severely outdated, unmaintained, and lacks supports for "objects" and relationships (i.e workspaces).

This also adds a migration script to backfill our 44k users (along with their workspaces) in customerio.

Next steps: 
- run backfill script
- cleanup existing customerio resources to remove extra keys
- add a few tracked events

## Risk

There's one risky change in `subscriptionForWorkspace`

## Deploy Plan

Add credentials, add CUSTOMERIO_ENABLED=true, deploy code, run backfill