### PR TITLE
Gdrive: Mark it as successfully sync at creation time.

### DIFF
--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -62,6 +62,7 @@ import {
   getGoogleCredentials,
 } from "@connectors/connectors/google_drive/temporal/utils";
 import { concurrentExecutor } from "@connectors/lib/async_utils";
+import { syncSucceeded } from "@connectors/lib/sync_status";
 import { terminateAllWorkflowsForConnectorId } from "@connectors/lib/temporal";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { FILE_ATTRIBUTES_TO_FETCH } from "@connectors/types/google_drive";
@@ -130,6 +131,8 @@ export async function createGoogleDriveConnector(
     },
     googleDriveConfigurationBlob
   );
+
+  await syncSucceeded(connector.id);
 
   return new Ok(connector.id.toString());
 }

--- a/connectors/src/lib/renderers/connector.ts
+++ b/connectors/src/lib/renderers/connector.ts
@@ -19,6 +19,7 @@ export async function renderConnectorType(
     firstSyncProgress: connector.firstSyncProgress,
     configuration: await renderConfiguration(connector),
     pausedAt: connector.pausedAt,
+    updatedAt: connector.updatedAt.getTime(),
   };
 }
 

--- a/front/lib/swr.ts
+++ b/front/lib/swr.ts
@@ -432,13 +432,20 @@ export function useConnector({
         // We have an error, no need to auto refresh.
         return 0;
       }
-      if (connectorResBody?.connector.lastSyncSuccessfulTime) {
-        // no sync in progress, no need to auto refresh.
-        return 0;
+
+      // Relying on absolute time difference here because we are comparing
+      // two non synchronized clocks (front and back). It's obviously not perfect
+      // but it's good enough for our use case.
+      if (
+        connectorResBody &&
+        Math.abs(new Date().getTime() - connectorResBody.connector.updatedAt) <
+          60 * 5 * 1000
+      ) {
+        // Connector object has been updated less than 5 minutes ago, we'll refresh every 3 seconds.
+        return 3000;
       }
 
-      // We have a synchronization in progress, we'll refresh every 3 seconds.
-      return 3000;
+      return 0;
     },
   });
 

--- a/types/src/front/lib/connectors_api.ts
+++ b/types/src/front/lib/connectors_api.ts
@@ -62,6 +62,7 @@ export type ConnectorType = {
   errorType?: ConnectorErrorType;
   configuration?: ConnectorConfiguration;
   pausedAt?: Date | null;
+  updatedAt: number;
 };
 
 /**


### PR DESCRIPTION
## Description

Eng runner card: https://github.com/dust-tt/tasks/issues/701

When connecting a Google Drive connector, the connector is not never marked as "successfully synced" if the user never select some folders to sync, because the full sync workflow is never kick started.

While this is a rare event, this is a possible user flow, so this PR marks the connector as "successfully synced" right after creation, which will be overridden when the user selects some folders to synchronize.

That way, we avoid showing an infinite "syncing" chip on the UI if the user ends up not selecting folders to synchronize.

# Before
![Screenshot 2024-04-23 at 15 41 42](https://github.com/dust-tt/dust/assets/358965/5f8bdd99-4de2-441a-90f4-d1755e68bc50)

# After
![Screenshot 2024-04-23 at 15 41 20](https://github.com/dust-tt/dust/assets/358965/9d9c7d1c-a574-463d-80c2-a579ad6d47c6)


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
