### PR TITLE
Template bugsquash: Feedback on Assistant Builder

### DIFF
--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -331,8 +331,8 @@ export default function AssistantBuilder({
 
   const [rightPanelStatus, setRightPanelStatus] =
     useState<AssistantBuilderRightPanelStatus>({
-      tab: null,
-      openedAt: null,
+      tab: template != null ? "Template" : null,
+      openedAt: template != null ? Date.now() : null,
     });
 
   const openRightPanelTab = (tabName: AssistantBuilderRightPanelTab) => {

--- a/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
+++ b/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
@@ -111,6 +111,7 @@ export default function AssistantBuilderRightPanel({
             ? "grow-1 mb-5 h-full overflow-y-auto rounded-b-xl border-x border-b border-structure-200 bg-structure-50 pt-5"
             : "grow-1 mb-5 mt-5 h-full overflow-y-auto rounded-xl border border-structure-200 bg-structure-50",
           shouldAnimatePreviewDrawer &&
+            rightPanelStatus.tab === "Preview" &&
             rightPanelStatus.openedAt != null &&
             // Only animate the reload if the drawer has been open for at least 1 second.
             // This is to prevent the animation from triggering right after the drawer is opened.
@@ -156,7 +157,7 @@ export default function AssistantBuilderRightPanel({
         )}
         {rightPanelStatus.tab === "Template" && (
           <div className="mb-72 flex flex-col gap-4 px-6">
-            <div className="flex justify-between">
+            <div className="flex items-end justify-between">
               <Page.Header
                 icon={LightbulbIcon}
                 title="Template's User manual"
@@ -180,7 +181,7 @@ export default function AssistantBuilderRightPanel({
                       const confirmed = await confirm({
                         title: "Are you sure you want to close the template?",
                         message:
-                          "Once removed, you will no longer have access to the associated user manual.",
+                          "Your assistant will remain as it is but will not display template's help any more.",
                         validateVariant: "primaryWarning",
                       });
                       if (confirmed) {
@@ -197,7 +198,7 @@ export default function AssistantBuilderRightPanel({
                       const confirmed = await confirm({
                         title: "Are you sure?",
                         message:
-                          "Resetting to the default settings will erase all changes made to the Assistant's instructions.",
+                          "You will lose the changes you have made to the assistant's instructions and go back to the template's default settings.",
                         validateVariant: "primaryWarning",
                       });
                       if (confirmed) {
@@ -213,7 +214,7 @@ export default function AssistantBuilderRightPanel({
                       const confirmed = await confirm({
                         title: "Are you sure?",
                         message:
-                          "Resetting to the default settings will erase all changes made to the Assistant's actions.",
+                          "You will lose the changes you have made to the assistant's actions and go back to the template's default settings.",
                         validateVariant: "primaryWarning",
                       });
                       if (confirmed) {
@@ -226,25 +227,27 @@ export default function AssistantBuilderRightPanel({
               </DropdownMenu>
             </div>
             <Page.Separator />
-            <div id="instructions-help-container">
-              <ContextItem.SectionHeader
-                title='"Instructions" guide'
-                hasBorder={false}
-              />
-              <Markdown
-                content={template?.helpInstructions ?? ""}
-                className=""
-              />
-            </div>
-            <Page.Separator />
-
-            <div id="actions-help-container">
-              <ContextItem.SectionHeader
-                title='"Actions" guide'
-                hasBorder={false}
-              />
-              <Markdown content={template?.helpActions ?? ""} className="" />
-            </div>
+            {template?.helpInstructions && (
+              <div id="instructions-help-container">
+                <ContextItem.SectionHeader
+                  title='"Instructions" guide'
+                  hasBorder={false}
+                />
+                <Markdown content={template?.helpInstructions ?? ""} />
+              </div>
+            )}
+            {template?.helpInstructions && template?.helpActions && (
+              <Page.Separator />
+            )}
+            {template?.helpActions && (
+              <div id="actions-help-container">
+                <ContextItem.SectionHeader
+                  title='"Actions" guide'
+                  hasBorder={false}
+                />
+                <Markdown content={template?.helpActions ?? ""} className="" />
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/front/components/assistant_builder/InstructionScreen.tsx
+++ b/front/components/assistant_builder/InstructionScreen.tsx
@@ -40,7 +40,7 @@ import { Transition } from "@headlessui/react";
 import Document from "@tiptap/extension-document";
 import Paragraph from "@tiptap/extension-paragraph";
 import Text from "@tiptap/extension-text";
-import type { Editor } from "@tiptap/react";
+import type { Editor, JSONContent } from "@tiptap/react";
 import { EditorContent, useEditor } from "@tiptap/react";
 import type { ComponentType } from "react";
 import React, {
@@ -100,7 +100,7 @@ const getCreativityLevelFromTemperature = (temperature: number) => {
 const useInstructionEditorService = (editor: Editor | null) => {
   const editorService = useMemo(() => {
     return {
-      resetContent(content: string) {
+      resetContent(content: JSONContent) {
         return editor?.commands.setContent(content);
       },
     };
@@ -155,7 +155,9 @@ export function InstructionScreen({
 
   useEffect(() => {
     if (resetAt != null) {
-      editorService.resetContent(builderState.instructions || "");
+      editorService.resetContent(
+        tipTapContentFromPlainText(builderState.instructions || "")
+      );
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [resetAt]);

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -9,7 +9,7 @@
         "@amplitude/analytics-browser": "^2.5.2",
         "@amplitude/analytics-node": "^1.3.5",
         "@auth0/nextjs-auth0": "^3.5.0",
-        "@dust-tt/sparkle": "0.2.141",
+        "@dust-tt/sparkle": "0.2.143",
         "@dust-tt/types": "file:../types",
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",
@@ -10492,9 +10492,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.141",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.141.tgz",
-      "integrity": "sha512-fNLrAjrpQsYsFCKr7K8jRMo9a3afDRXhvGQDmv8W/NdJS9uW67eMyczPGHbo1hH7FKCLOROq1f4QMra9yF/Meg==",
+      "version": "0.2.143",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.143.tgz",
+      "integrity": "sha512-jz4+W1yodiJI9OcZj/UN/CRRclWLWOCyoRTovkbyyqyEjtxG1hUf/KD5iXiO35g1dnvWQW9usvnH3o1QDx/N+g==",
       "dependencies": {
         "@headlessui/react": "^1.7.17",
         "esbuild": "^0.20.0",

--- a/front/package.json
+++ b/front/package.json
@@ -17,7 +17,7 @@
     "@amplitude/analytics-browser": "^2.5.2",
     "@amplitude/analytics-node": "^1.3.5",
     "@auth0/nextjs-auth0": "^3.5.0",
-    "@dust-tt/sparkle": "0.2.141",
+    "@dust-tt/sparkle": "0.2.143",
     "@dust-tt/types": "file:../types",
     "@emoji-mart/data": "^1.1.2",
     "@emoji-mart/react": "^1.1.1",


### PR DESCRIPTION
## Description

This applies a list of feedback from the bugsquash of templates: 
- [x] Open by default the sidebar if a template is associated.
- [x] Help guides: do not display the container if there's no content (we dont want to display the title, and not scroll to nothing).
- [x] The drawer should not blink after the content has changed if we're on the Templates tab.
- [x] The wordings of the confirm actions in the Contextual actions of the template should use wording from the making issue. 
- [x] Reset the instruction to the template's defaut looses the formatting in the Text Area

## Risk

/ 

## Deploy Plan

/ 
