### PR TITLE
Sparkle: fix copy button position on Mardown quote

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.142",
+  "version": "0.2.143",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.142",
+      "version": "0.2.143",
       "license": "ISC",
       "dependencies": {
         "@headlessui/react": "^1.7.17",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.142",
+  "version": "0.2.143",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/components/Markdown.tsx
+++ b/sparkle/src/components/Markdown.tsx
@@ -141,7 +141,11 @@ export function Markdown({
           return (
             <div className="s-flex s-w-auto s-flex-row s-rounded-3xl s-border s-border-structure-100 s-bg-structure-0 s-py-2 s-pl-5 s-pr-2">
               <blockquote
-                className={classNames("s-italic", paragraphSize, textColor)}
+                className={classNames(
+                  "s-w-full s-italic",
+                  paragraphSize,
+                  textColor
+                )}
               >
                 {children}
               </blockquote>

--- a/sparkle/src/stories/Markdown.stories.tsx
+++ b/sparkle/src/stories/Markdown.stories.tsx
@@ -35,6 +35,10 @@ Demo of a list, showcasing our pets of the month:
 
 Demo of a quote below:
 > You take the blue pill - the story ends, you wake up in your bed and believe whatever you want to believe. You take the red pill - you stay in Wonderland and I show you how deep the rabbit hole goes.
+
+Another one, a short one:
+> Soupinou fait des miaou miaou.
+
 `;
 
 export const MarkdownExample = () => (


### PR DESCRIPTION
## Description

The copy button position was not top left. 

<kbd>
<img width="1051" alt="Screenshot 2024-04-23 at 16 06 59" src="https://github.com/dust-tt/dust/assets/3803406/8fbe2669-af78-408d-9feb-fcbb26bb9412">
</kbd>


## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
