### PR TITLE
[Meru][Suggestions] Updated instructions suggestions

### DIFF
--- a/front/components/assistant_builder/InstructionScreen.tsx
+++ b/front/components/assistant_builder/InstructionScreen.tsx
@@ -340,6 +340,8 @@ function Suggestions({
 
   const debounceHandle = useRef<NodeJS.Timeout | undefined>(undefined);
 
+  // the ref allows comparing previous instructions to current instructions
+  // in the effect below
   const previousInstructions = useRef<string | null>(instructions);
 
   useEffect(() => {

--- a/types/src/front/api_handlers/internal/assistant.ts
+++ b/types/src/front/api_handlers/internal/assistant.ts
@@ -44,7 +44,10 @@ export const InternalPostBuilderSuggestionsRequestBodySchema = t.union([
   }),
   t.type({
     type: t.literal("instructions"),
-    inputs: t.type({ current_instructions: t.string }),
+    inputs: t.type({
+      current_instructions: t.string,
+      former_suggestions: t.array(t.string),
+    }),
   }),
   t.type({
     type: t.literal("description"),

--- a/types/src/front/lib/actions/registry.ts
+++ b/types/src/front/lib/actions/registry.ts
@@ -171,7 +171,7 @@ export const DustProdActionRegistry = createActionRegistry({
       workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
       appId: "d995d868a8",
       appHash:
-        "35a6a876f7707d09bfbec050c3e45c22ffa49f88b80a22010e035591994dc487",
+        "7fb9c826d9de74c98de2a675093f66eab9da93a1a2cb9bc0bcc919fd074cd7eb",
     },
     config: {
       CREATE_SUGGESTIONS: {

--- a/types/src/front/lib/actions/registry.ts
+++ b/types/src/front/lib/actions/registry.ts
@@ -171,19 +171,13 @@ export const DustProdActionRegistry = createActionRegistry({
       workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
       appId: "d995d868a8",
       appHash:
-        "da0c8b9918a0c5a550f306ccea1b60bdacfeddc35d19d7145db31e92e37c3f51",
+        "35a6a876f7707d09bfbec050c3e45c22ffa49f88b80a22010e035591994dc487",
     },
     config: {
-      INSTRUCTIONS_FINISHED: {
-        provider_id: "openai",
-        model_id: "gpt-3.5-turbo",
-        function_call: "send_instructions_finished",
-        use_cache: true,
-      },
       CREATE_SUGGESTIONS: {
         provider_id: "openai",
-        model_id: "gpt-4",
-        function_call: "send_suggestions",
+        model_id: GPT_4_TURBO_MODEL_CONFIG.modelId,
+        function_call: "send_ranked_suggestions",
         use_cache: true,
       },
     },


### PR DESCRIPTION
Description
---
Following IRL discussions with @Duncid:
- instructions suggestions app now takes as input currently shown suggestions;
- it now outputs a ranked array of suggestions with 2 new ones and the former ones, ranked by model's assesment of relevance
- the suggestions are updated accordingly in the interface

This will allow not replacing suggestions when we have no better ones to show.

Immediately following PRs will:
- remove the carousel and allow seeing suggestion history (on one session)
- introduce nice transitions
- deactivate suggestions for templates
- ungate (currently gated to Dust)

Risks
---
None, gated

Deploy Plan
---
Deploy front

