### PR TITLE
Poké templates feedabck from bugsquash

### DIFF
--- a/front/components/poke/shadcn/ui/button.tsx
+++ b/front/components/poke/shadcn/ui/button.tsx
@@ -16,7 +16,7 @@ const buttonVariants = cva(
         outline:
           "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
         secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+          "text-white bg-action-500 border-action-600 hover:bg-action-400 hover:border-action-500",
         ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
       },

--- a/front/components/poke/shadcn/ui/data_table.tsx
+++ b/front/components/poke/shadcn/ui/data_table.tsx
@@ -42,6 +42,7 @@ interface DataTableProps<TData, TValue> {
   data: TData[];
   isLoading?: boolean;
   facets?: Facet[];
+  pageSize?: number;
 }
 
 export function PokeDataTable<TData, TValue>({
@@ -49,6 +50,7 @@ export function PokeDataTable<TData, TValue>({
   data,
   facets,
   isLoading,
+  pageSize = 10,
 }: DataTableProps<TData, TValue>) {
   const [sorting, setSorting] = useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
@@ -67,6 +69,11 @@ export function PokeDataTable<TData, TValue>({
     state: {
       columnFilters,
       sorting,
+    },
+    initialState: {
+      pagination: {
+        pageSize,
+      },
     },
   });
 

--- a/front/components/poke/templates/table.tsx
+++ b/front/components/poke/templates/table.tsx
@@ -39,6 +39,7 @@ export function TemplatesDataTable() {
         <PokeDataTable
           columns={makeColumnsForTemplates()}
           data={prepareTemplatesForDisplay(assistantTemplates)}
+          pageSize={100}
         />
       )}
     </div>

--- a/front/pages/poke/templates/[tId].tsx
+++ b/front/pages/poke/templates/[tId].tsx
@@ -198,7 +198,7 @@ function SelectField({
                 <div className="bg-slate-100">
                   {options.map((option) => (
                     <PokeSelectItem key={option.value} value={option.value}>
-                      {option.display ? option.display : option.value}
+                      {option.display ?? option.value}
                     </PokeSelectItem>
                   ))}
                 </div>

--- a/front/pages/poke/templates/[tId].tsx
+++ b/front/pages/poke/templates/[tId].tsx
@@ -89,15 +89,10 @@ function InputField({
       render={({ field }) => (
         <PokeFormItem>
           <PokeFormLabel className="capitalize">{title ?? name}</PokeFormLabel>
-          <div className="grid grid-cols-2 gap-4">
-            <div>
-              <PokeFormControl>
-                <PokeInput placeholder={placeholder ?? name} {...field} />
-              </PokeFormControl>
-              <PokeFormMessage />
-            </div>
-            <div />
-          </div>
+          <PokeFormControl>
+            <PokeInput placeholder={placeholder ?? name} {...field} />
+          </PokeFormControl>
+          <PokeFormMessage />
         </PokeFormItem>
       )}
     />
@@ -124,24 +119,33 @@ function TextareaField({
       render={({ field }) => (
         <PokeFormItem>
           <PokeFormLabel className="capitalize">{title ?? name}</PokeFormLabel>
-          <div className="grid grid-cols-2 gap-4">
-            <div>
-              <PokeFormControl>
-                <PokeTextarea
-                  placeholder={placeholder ?? name}
-                  rows={30}
-                  {...field}
-                />
-              </PokeFormControl>
+          {previewMardown &&
+          typeof field.value === "string" &&
+          field.value.length > 0 ? (
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <PokeFormControl>
+                  <PokeTextarea
+                    placeholder={placeholder ?? name}
+                    rows={30}
+                    {...field}
+                  />
+                </PokeFormControl>
+              </div>
+
+              <div className="rounded-xl border p-2">
+                <Markdown content={field.value} />
+              </div>
             </div>
-            {previewMardown &&
-              typeof field.value === "string" &&
-              field.value.length > 0 && (
-                <div className="rounded-xl border p-2">
-                  <Markdown content={field.value} />
-                </div>
-              )}
-          </div>
+          ) : (
+            <PokeFormControl>
+              <PokeTextarea
+                placeholder={placeholder ?? name}
+                rows={30}
+                {...field}
+              />
+            </PokeFormControl>
+          )}
           <PokeFormMessage />
         </PokeFormItem>
       )}
@@ -180,33 +184,28 @@ function SelectField({
       render={({ field }) => (
         <PokeFormItem>
           <PokeFormLabel className="capitalize">{title ?? name}</PokeFormLabel>
-          <div className="grid grid-cols-2 gap-4">
-            <div>
+          <PokeFormControl>
+            <PokeSelect
+              value={field.value as string}
+              onValueChange={field.onChange}
+            >
               <PokeFormControl>
-                <PokeSelect
-                  value={field.value as string}
-                  onValueChange={field.onChange}
-                >
-                  <PokeFormControl>
-                    <PokeSelectTrigger>
-                      <PokeSelectValue placeholder={title ?? name} />
-                    </PokeSelectTrigger>
-                  </PokeFormControl>
-                  <PokeSelectContent>
-                    <div className="bg-slate-100">
-                      {options.map((option) => (
-                        <PokeSelectItem key={option.value} value={option.value}>
-                          {option.display ? option.display : option.value}
-                        </PokeSelectItem>
-                      ))}
-                    </div>
-                  </PokeSelectContent>
-                </PokeSelect>
+                <PokeSelectTrigger>
+                  <PokeSelectValue placeholder={title ?? name} />
+                </PokeSelectTrigger>
               </PokeFormControl>
-              <PokeFormMessage />
-            </div>
-          </div>
-          <div />
+              <PokeSelectContent>
+                <div className="bg-slate-100">
+                  {options.map((option) => (
+                    <PokeSelectItem key={option.value} value={option.value}>
+                      {option.display ? option.display : option.value}
+                    </PokeSelectItem>
+                  ))}
+                </div>
+              </PokeSelectContent>
+            </PokeSelect>
+          </PokeFormControl>
+          <PokeFormMessage />
         </PokeFormItem>
       )}
     />
@@ -219,7 +218,7 @@ function PreviewDialog({ form }: { form: any }) {
   return (
     <PokeDialog open={open} onOpenChange={setOpen}>
       <PokeDialogTrigger asChild>
-        <PokeButton variant="outline">✨ Preview Template Card</PokeButton>
+        <PokeButton variant="secondary">✨ Preview Template Card</PokeButton>
       </PokeDialogTrigger>
       <PokeDialogContent className="bg-structure-50 sm:max-w-[600px]">
         <PokeDialogHeader>
@@ -394,31 +393,102 @@ function TemplatesPage({
       <div className="mx-auto h-full max-w-7xl flex-grow flex-col items-center justify-center pt-8">
         <PokeForm {...form}>
           <form className="space-y-8">
-            <InputField
+            <div className="grid grid-cols-3 gap-4">
+              <InputField
+                control={form.control}
+                name="handle"
+                placeholder="myAssistant"
+              />
+              <SelectField
+                control={form.control}
+                name="visibility"
+                title="Visibility"
+                options={TEMPLATE_VISIBILITIES.map((v) => ({
+                  value: v,
+                  display: v,
+                }))}
+              />
+              <PokeFormField
+                control={form.control}
+                name="tags"
+                render={({ field }) => (
+                  <PokeFormItem>
+                    <PokeFormLabel>Tags</PokeFormLabel>
+                    <PokeFormControl>
+                      <MultiSelect
+                        options={tagOptions}
+                        value={field.value.map((tag: TemplateTagCodeType) => ({
+                          label: TEMPLATES_TAGS_CONFIG[tag].label,
+                          value: tag,
+                        }))}
+                        onChange={(
+                          tags: { label: string; value: string }[]
+                        ) => {
+                          field.onChange(tags.map((tag) => tag.value));
+                        }}
+                        labelledBy="Select"
+                        hasSelectAll={false}
+                      />
+                    </PokeFormControl>
+                    <PokeFormMessage />
+                  </PokeFormItem>
+                )}
+              />
+            </div>
+            <div className="grid grid-cols-3 gap-4">
+              <SelectField
+                control={form.control}
+                name="presetModelId"
+                title="Preset Model"
+                options={USED_MODEL_CONFIGS.map((config) => ({
+                  value: config.modelId,
+                  display: config.displayName,
+                }))}
+              />
+              <SelectField
+                control={form.control}
+                name="presetTemperature"
+                title="Preset Temperature"
+                options={ASSISTANT_CREATIVITY_LEVELS.map((acl) => ({
+                  value: acl,
+                }))}
+              />
+              <SelectField
+                control={form.control}
+                name="presetAction"
+                title="Preset Action"
+                options={Object.entries(ACTION_PRESETS).map(([k, v]) => ({
+                  value: k,
+                  display: v,
+                }))}
+              />
+            </div>
+            <div className="grid grid-cols-3 gap-4">
+              <InputField control={form.control} name="emoji" />
+              <SelectField
+                control={form.control}
+                name="backgroundColor"
+                title="Background Color"
+                options={generateTailwindBackgroundColors().map((v) => ({
+                  value: v,
+                  display: v,
+                }))}
+              />
+              <div className="flex h-full flex-col justify-end">
+                <PreviewDialog form={form} />
+              </div>
+            </div>
+            <TextareaField
               control={form.control}
-              name="handle"
-              placeholder="myAssistant"
-            />
-            <SelectField
-              control={form.control}
-              name="visibility"
-              title="Visibility"
-              options={TEMPLATE_VISIBILITIES.map((v) => ({
-                value: v,
-                display: v,
-              }))}
+              name="presetInstructions"
+              title="preset Instructions"
+              placeholder="Instructions"
             />
             <TextareaField
               control={form.control}
               name="description"
               placeholder="A short description"
               previewMardown={true}
-            />
-            <TextareaField
-              control={form.control}
-              name="presetInstructions"
-              title="preset Instructions"
-              placeholder="Instructions"
             />
             <TextareaField
               control={form.control}
@@ -434,75 +504,7 @@ function TemplatesPage({
               placeholder="Actions help bubble..."
               previewMardown={true}
             />
-            <SelectField
-              control={form.control}
-              name="presetModelId"
-              title="Preset Model"
-              options={USED_MODEL_CONFIGS.map((config) => ({
-                value: config.modelId,
-                display: config.displayName,
-              }))}
-            />
-            <SelectField
-              control={form.control}
-              name="presetTemperature"
-              title="Preset Temperature"
-              options={ASSISTANT_CREATIVITY_LEVELS.map((acl) => ({
-                value: acl,
-              }))}
-            />
-            <SelectField
-              control={form.control}
-              name="presetAction"
-              title="Preset Action"
-              options={Object.entries(ACTION_PRESETS).map(([k, v]) => ({
-                value: k,
-                display: v,
-              }))}
-            />
-            <PokeFormField
-              control={form.control}
-              name="tags"
-              render={({ field }) => (
-                <PokeFormItem>
-                  <PokeFormLabel>Tags</PokeFormLabel>
-                  <div className="grid grid-cols-2 gap-4">
-                    <div>
-                      <PokeFormControl>
-                        <MultiSelect
-                          options={tagOptions}
-                          value={field.value.map(
-                            (tag: TemplateTagCodeType) => ({
-                              label: TEMPLATES_TAGS_CONFIG[tag].label,
-                              value: tag,
-                            })
-                          )}
-                          onChange={(
-                            tags: { label: string; value: string }[]
-                          ) => {
-                            field.onChange(tags.map((tag) => tag.value));
-                          }}
-                          labelledBy="Select"
-                          hasSelectAll={false}
-                        />
-                      </PokeFormControl>
-                      <PokeFormMessage />
-                    </div>
-                  </div>
-                  <div />
-                </PokeFormItem>
-              )}
-            />
-            <InputField control={form.control} name="emoji" />
-            <SelectField
-              control={form.control}
-              name="backgroundColor"
-              title="Background Color"
-              options={generateTailwindBackgroundColors().map((v) => ({
-                value: v,
-                display: v,
-              }))}
-            />
+
             <div className="space flex gap-2">
               <PokeButton
                 onClick={form.handleSubmit(onSubmit)}
@@ -517,7 +519,6 @@ function TemplatesPage({
               >
                 Delete this template
               </PokeButton>
-              <PreviewDialog form={form} />
             </div>
           </form>
         </PokeForm>


### PR DESCRIPTION
## Description

Some changes on Poké template: 

- [x] Template list: display more item per page on the table. -> we allow displaying 100 per page since this page only loads templates. 
- [x] Form: rework order of fields, no change on how the form works it's purely cosmetic changes. 

<img width="1385" alt="Screenshot 2024-04-24 at 11 23 21" src="https://github.com/dust-tt/dust/assets/3803406/d17220da-3692-4554-92bf-88819428cbb4">



## Risk

/

## Deploy Plan

/ 
