### PR TITLE
Templates can't be saved with action process_configuration

### DIFF
--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -31,6 +31,7 @@ import {
   GPT_4_TURBO_MODEL_CONFIG,
   isBuilder,
   isDustAppRunConfiguration,
+  isProcessConfiguration,
   isRetrievalConfiguration,
   isTablesQueryConfiguration,
   removeNulls,
@@ -301,6 +302,8 @@ export default function AssistantBuilder({
       actionMode = "DUST_APP_RUN";
     } else if (isTablesQueryConfiguration(action)) {
       actionMode = "TABLES_QUERY";
+    } else if (isProcessConfiguration(action)) {
+      // not supported in the builder yet
     }
 
     if (actionMode !== null) {

--- a/types/src/front/assistant/templates.ts
+++ b/types/src/front/assistant/templates.ts
@@ -2,8 +2,10 @@ import * as t from "io-ts";
 import { nonEmptyArray } from "io-ts-types/lib/nonEmptyArray";
 import { NonEmptyString } from "io-ts-types/lib/NonEmptyString";
 
+import { assertNever } from "../../shared/utils/assert_never";
 import { ioTsEnum } from "../../shared/utils/iots_utils";
 import { DustAppRunConfigurationType } from "./actions/dust_app_run";
+import { ProcessConfigurationType } from "./actions/process";
 import { RetrievalConfigurationType } from "./actions/retrieval";
 import { TablesQueryConfigurationType } from "./actions/tables_query";
 import { AgentAction, AgentActionConfigurationType } from "./agent";
@@ -220,7 +222,18 @@ export function getAgentActionConfigurationType(
         forceUseAtIteration: 0,
       } satisfies DustAppRunConfigurationType;
 
+    case "process_configuration":
+      return {
+        dataSources: [],
+        id: -1,
+        relativeTimeFrame: "auto",
+        sId: "template",
+        schema: [],
+        type: "process_configuration",
+        forceUseAtIteration: 0,
+      } satisfies ProcessConfigurationType;
+
     default:
-      return null;
+      assertNever(action);
   }
 }


### PR DESCRIPTION
## Description

We cannot save a template with the action "Process data sources".

Fix: 
Adding a missing case on util `getAgentActionConfigurationType` for templates for the new `process_configuration` action. 
Added an assertNever for next time!


## Risk

/ 

## Deploy Plan

/ 
