### PR TITLE
Improve delete support in poke. Validate URLs more in WebCrawler

### DIFF
--- a/front/components/poke/data_sources/columns.tsx
+++ b/front/components/poke/data_sources/columns.tsx
@@ -147,7 +147,9 @@ async function deleteDataSource(
 
   try {
     const r = await fetch(
-      `/api/poke/workspaces/${owner.sId}/data_sources/${dataSourceName}`,
+      `/api/poke/workspaces/${owner.sId}/data_sources/${encodeURIComponent(
+        dataSourceName
+      )}`,
       {
         method: "DELETE",
         headers: {

--- a/front/lib/webcrawler.ts
+++ b/front/lib/webcrawler.ts
@@ -35,7 +35,10 @@ export function isUrlValid(url: string) {
     if (url.trim().length === 0) {
       return false;
     }
-    new URL(url);
+    const u = new URL(url);
+    if (u.protocol !== "http:" && u.protocol !== "https:") {
+      return false;
+    }
     return true;
   } catch (e) {
     return false;


### PR DESCRIPTION
## Description

Example weird URL we allow: https://dust.tt/poke/6cb3f9d523
(empty, c:/, ...)

Enforce that we have a valid http/https protocol.

As part of https://github.com/dust-tt/tasks/issues/698

## Risk

None

## Deploy Plan

- deploy `front`