### PR TITLE
[Templates] Add description filter on templates search

### DIFF
--- a/front/pages/w/[wId]/builder/assistants/create.tsx
+++ b/front/pages/w/[wId]/builder/assistants/create.tsx
@@ -29,7 +29,6 @@ import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitl
 import config from "@app/lib/api/config";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { useAssistantTemplates } from "@app/lib/swr";
-import { subFilter } from "@app/lib/utils";
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   flow: BuilderFlow;
@@ -104,13 +103,20 @@ export default function CreateAssistant({
     const templatesFilteredFromSearch =
       searchTerm === ""
         ? assistantTemplates
-        : assistantTemplates.filter((template) =>
-            template.handle.toLowerCase().includes(searchTerm.toLowerCase()) ||
-            template.description?.toLowerCase().includes(searchTerm.toLowerCase())
+        : assistantTemplates.filter(
+            (template) =>
+              template.handle
+                .toLowerCase()
+                .includes(searchTerm.toLowerCase()) ||
+              template.description
+                ?.toLowerCase()
+                .includes(searchTerm.toLowerCase())
           );
-    const templatesToDisplay = templatesFilteredFromSearch.filter((template) => {
-      return isTemplateTagCodeArray(template.tags);
-    });
+    const templatesToDisplay = templatesFilteredFromSearch.filter(
+      (template) => {
+        return isTemplateTagCodeArray(template.tags);
+      }
+    );
     setFilteredTemplates({
       templates: templatesToDisplay,
       tags: _.uniq(templatesToDisplay.map((template) => template.tags).flat()),
@@ -232,16 +238,20 @@ export default function CreateAssistant({
                 size="md"
               />
               <div className="flex flex-row flex-wrap gap-2">
-                {filteredTemplates.tags.sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase())).map((tagName) => (
-                  <Button
-                    label={templateTagsMapping[tagName].label}
-                    variant="tertiary"
-                    key={tagName}
-                    size="xs"
-                    hasMagnifying={false}
-                    onClick={() => scrollToTag(tagName)}
-                  />
-                ))}
+                {filteredTemplates.tags
+                  .sort((a, b) =>
+                    a.toLowerCase().localeCompare(b.toLowerCase())
+                  )
+                  .map((tagName) => (
+                    <Button
+                      label={templateTagsMapping[tagName].label}
+                      variant="tertiary"
+                      key={tagName}
+                      size="xs"
+                      hasMagnifying={false}
+                      onClick={() => scrollToTag(tagName)}
+                    />
+                  ))}
               </div>
             </div>
             <Page.Separator />

--- a/front/pages/w/[wId]/builder/assistants/create.tsx
+++ b/front/pages/w/[wId]/builder/assistants/create.tsx
@@ -105,13 +105,12 @@ export default function CreateAssistant({
       searchTerm === ""
         ? assistantTemplates
         : assistantTemplates.filter((template) =>
-            subFilter(searchTerm.toLowerCase(), template.handle.toLowerCase())
+            template.handle.toLowerCase().includes(searchTerm.toLowerCase()) ||
+            template.description?.toLowerCase().includes(searchTerm.toLowerCase())
           );
-    const templatesToDisplay = templatesFilteredFromSearch.filter(
-      (template) => {
-        return isTemplateTagCodeArray(template.tags);
-      }
-    );
+    const templatesToDisplay = templatesFilteredFromSearch.filter((template) => {
+      return isTemplateTagCodeArray(template.tags);
+    });
     setFilteredTemplates({
       templates: templatesToDisplay,
       tags: _.uniq(templatesToDisplay.map((template) => template.tags).flat()),
@@ -233,7 +232,7 @@ export default function CreateAssistant({
                 size="md"
               />
               <div className="flex flex-row flex-wrap gap-2">
-                {filteredTemplates.tags.map((tagName) => (
+                {filteredTemplates.tags.sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase())).map((tagName) => (
                   <Button
                     label={templateTagsMapping[tagName].label}
                     variant="tertiary"


### PR DESCRIPTION
## Description

- Let user search for templates in description as well as handle
- Sort tags alphabetically

## Risk

None

## Deploy Plan

Go in the next push - not urgent