### PR TITLE
Move model config to AgentConfigration step1

### DIFF
--- a/front/components/assistant/AssistantActions.tsx
+++ b/front/components/assistant/AssistantActions.tsx
@@ -196,7 +196,7 @@ export function RemoveAssistantFromWorkspaceDialog({
             status: "active",
             scope: "published",
             actions: detailedConfiguration.actions,
-            generation: agentConfiguration.generation,
+            generation: detailedConfiguration.generation,
           },
         };
 

--- a/front/components/assistant/GalleryAssistantPreviewContainer.tsx
+++ b/front/components/assistant/GalleryAssistantPreviewContainer.tsx
@@ -34,13 +34,12 @@ export function GalleryAssistantPreviewContainer({
     setTestModalAssistant?.(agentConfiguration);
   };
 
-  const { description, generation, lastAuthors, name, pictureUrl, scope } =
+  const { description, model, lastAuthors, name, pictureUrl, scope } =
     agentConfiguration;
 
   const isGlobal = scope === "global";
   const hasAccessToLargeModels = isUpgraded(plan);
-  const eligibleForTesting =
-    hasAccessToLargeModels || !isLargeModel(generation?.model);
+  const eligibleForTesting = hasAccessToLargeModels || !isLargeModel(model);
   const isTestable = !isGlobal && eligibleForTesting;
   return (
     <AssistantPreview

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -6,6 +6,7 @@ const readFileAsync = promisify(fs.readFile);
 
 import type {
   AgentConfigurationType,
+  AgentModelConfigurationType,
   ConnectorProvider,
   DataSourceType,
 } from "@dust-tt/types";
@@ -109,6 +110,11 @@ async function _getHelperGlobalAgent(
     status: "active",
     userListStatus: "in-list",
     scope: "global",
+    model: {
+      providerId: model.providerId,
+      modelId: model.modelId,
+      temperature: 0.2,
+    },
     generation: {
       id: -1,
       model,
@@ -139,6 +145,11 @@ async function _getGPT35TurboGlobalAgent({
     status,
     scope: "global",
     userListStatus: status === "active" ? "in-list" : "not-in-list",
+    model: {
+      providerId: GPT_3_5_TURBO_MODEL_CONFIG.providerId,
+      modelId: GPT_3_5_TURBO_MODEL_CONFIG.modelId,
+      temperature: 0.7,
+    },
     generation: {
       id: -1,
       model: {
@@ -172,13 +183,17 @@ async function _getGPT4GlobalAgent({
     status,
     scope: "global",
     userListStatus: status === "active" ? "in-list" : "not-in-list",
+    model: {
+      providerId: GPT_4_TURBO_MODEL_CONFIG.providerId,
+      modelId: GPT_4_TURBO_MODEL_CONFIG.modelId,
+      temperature: 0.7,
+    },
     generation: {
       id: -1,
       model: {
         providerId: GPT_4_TURBO_MODEL_CONFIG.providerId,
         modelId: GPT_4_TURBO_MODEL_CONFIG.modelId,
       },
-
       temperature: 0.7,
       forceUseAtIteration: 0,
     },
@@ -206,6 +221,11 @@ async function _getClaudeInstantGlobalAgent({
     status,
     scope: "global",
     userListStatus: status === "active" ? "in-list" : "not-in-list",
+    model: {
+      providerId: CLAUDE_INSTANT_DEFAULT_MODEL_CONFIG.providerId,
+      modelId: CLAUDE_INSTANT_DEFAULT_MODEL_CONFIG.modelId,
+      temperature: 0.7,
+    },
     generation: {
       id: -1,
       model: {
@@ -245,6 +265,11 @@ async function _getClaude2GlobalAgent({
     status,
     scope: "global",
     userListStatus: status === "active" ? "in-list" : "not-in-list",
+    model: {
+      providerId: CLAUDE_2_DEFAULT_MODEL_CONFIG.providerId,
+      modelId: CLAUDE_2_DEFAULT_MODEL_CONFIG.modelId,
+      temperature: 0.7,
+    },
     generation: {
       id: -1,
       model: {
@@ -286,6 +311,11 @@ async function _getClaude3HaikuGlobalAgent({
     status,
     scope: "global",
     userListStatus: status === "active" ? "in-list" : "not-in-list",
+    model: {
+      providerId: CLAUDE_3_HAIKU_DEFAULT_MODEL_CONFIG.providerId,
+      modelId: CLAUDE_3_HAIKU_DEFAULT_MODEL_CONFIG.modelId,
+      temperature: 0.7,
+    },
     generation: {
       id: -1,
       model: {
@@ -326,6 +356,11 @@ async function _getClaude3SonnetGlobalAgent({
     status,
     scope: "global",
     userListStatus: status === "active" ? "in-list" : "not-in-list",
+    model: {
+      providerId: CLAUDE_3_SONNET_DEFAULT_MODEL_CONFIG.providerId,
+      modelId: CLAUDE_3_SONNET_DEFAULT_MODEL_CONFIG.modelId,
+      temperature: 0.7,
+    },
     generation: {
       id: -1,
       model: {
@@ -365,6 +400,11 @@ async function _getClaude3OpusGlobalAgent({
     status,
     scope: "global",
     userListStatus: status === "active" ? "in-list" : "not-in-list",
+    model: {
+      providerId: CLAUDE_3_OPUS_DEFAULT_MODEL_CONFIG.providerId,
+      modelId: CLAUDE_3_OPUS_DEFAULT_MODEL_CONFIG.modelId,
+      temperature: 0.7,
+    },
     generation: {
       id: -1,
       model: {
@@ -404,6 +444,11 @@ async function _getMistralLargeGlobalAgent({
     status,
     scope: "global",
     userListStatus: status === "active" ? "in-list" : "not-in-list",
+    model: {
+      providerId: MISTRAL_LARGE_MODEL_CONFIG.providerId,
+      modelId: MISTRAL_LARGE_MODEL_CONFIG.modelId,
+      temperature: 0.7,
+    },
     generation: {
       id: -1,
       model: {
@@ -443,6 +488,11 @@ async function _getMistralMediumGlobalAgent({
     status,
     scope: "global",
     userListStatus: status === "active" ? "in-list" : "not-in-list",
+    model: {
+      providerId: MISTRAL_MEDIUM_MODEL_CONFIG.providerId,
+      modelId: MISTRAL_MEDIUM_MODEL_CONFIG.modelId,
+      temperature: 0.7,
+    },
     generation: {
       id: -1,
       model: {
@@ -476,6 +526,11 @@ async function _getMistralSmallGlobalAgent({
     status,
     scope: "global",
     userListStatus: status === "active" ? "in-list" : "not-in-list",
+    model: {
+      providerId: MISTRAL_SMALL_MODEL_CONFIG.providerId,
+      modelId: MISTRAL_SMALL_MODEL_CONFIG.modelId,
+      temperature: 0.7,
+    },
     generation: {
       id: -1,
       model: {
@@ -514,6 +569,11 @@ async function _getGeminiProGlobalAgent({
     status,
     scope: "global",
     userListStatus: status === "active" ? "in-list" : "not-in-list",
+    model: {
+      providerId: GEMINI_PRO_DEFAULT_MODEL_CONFIG.providerId,
+      modelId: GEMINI_PRO_DEFAULT_MODEL_CONFIG.modelId,
+      temperature: 0.7,
+    },
     generation: {
       id: -1,
       model: {
@@ -561,6 +621,18 @@ async function _getManagedDataSourceAgent(
 
   const prodCredentials = await prodAPICredentialsForOwner(owner);
 
+  const model: AgentModelConfigurationType = !auth.isUpgraded()
+    ? {
+        providerId: GPT_3_5_TURBO_MODEL_CONFIG.providerId,
+        modelId: GPT_3_5_TURBO_MODEL_CONFIG.modelId,
+        temperature: 0.7,
+      }
+    : {
+        providerId: GPT_4_TURBO_MODEL_CONFIG.providerId,
+        modelId: GPT_4_TURBO_MODEL_CONFIG.modelId,
+        temperature: 0.7,
+      };
+
   // Check if deactivated by an admin
   if (settings && settings.status === "disabled_by_admin") {
     return {
@@ -576,6 +648,7 @@ async function _getManagedDataSourceAgent(
       status: "disabled_by_admin",
       scope: "global",
       userListStatus: "not-in-list",
+      model,
       generation: null,
       actions: [],
       maxToolsUsePerRun: 1,
@@ -601,6 +674,7 @@ async function _getManagedDataSourceAgent(
       scope: "global",
       userListStatus: "not-in-list",
       generation: null,
+      model,
       actions: [],
       maxToolsUsePerRun: 1,
     };
@@ -619,6 +693,7 @@ async function _getManagedDataSourceAgent(
     status: "active",
     scope: "global",
     userListStatus: "in-list",
+    model,
     generation: {
       id: -1,
       model: !auth.isUpgraded()
@@ -793,6 +868,18 @@ async function _getDustGlobalAgent(
   const description = "An assistant with context on your company data.";
   const pictureUrl = "https://dust.tt/static/systemavatar/dust_avatar_full.png";
 
+  const model: AgentModelConfigurationType = !auth.isUpgraded()
+    ? {
+        providerId: GPT_3_5_TURBO_MODEL_CONFIG.providerId,
+        modelId: GPT_3_5_TURBO_MODEL_CONFIG.modelId,
+        temperature: 0.7,
+      }
+    : {
+        providerId: GPT_4_TURBO_MODEL_CONFIG.providerId,
+        modelId: GPT_4_TURBO_MODEL_CONFIG.modelId,
+        temperature: 0.7,
+      };
+
   if (settings && settings.status === "disabled_by_admin") {
     return {
       id: -1,
@@ -807,6 +894,7 @@ async function _getDustGlobalAgent(
       status: "disabled_by_admin",
       scope: "global",
       userListStatus: "not-in-list",
+      model,
       generation: null,
       actions: [],
       maxToolsUsePerRun: 1,
@@ -839,6 +927,7 @@ async function _getDustGlobalAgent(
       status: "disabled_missing_datasource",
       scope: "global",
       userListStatus: "not-in-list",
+      model,
       generation: null,
       actions: [],
       maxToolsUsePerRun: 1,
@@ -860,6 +949,7 @@ async function _getDustGlobalAgent(
     status: "active",
     scope: "global",
     userListStatus: "in-list",
+    model,
     generation: {
       id: -1,
       model: !auth.isUpgraded()

--- a/front/lib/api/assistant/templates.ts
+++ b/front/lib/api/assistant/templates.ts
@@ -29,6 +29,12 @@ export async function generateMockAgentConfigurationFromTemplate(
     ]),
     description: template.description ?? "",
     instructions: template.presetInstructions ?? "",
+    model: {
+      providerId: template.presetProviderId,
+      modelId: template.presetModelId,
+      temperature:
+        ASSISTANT_CREATIVITY_LEVEL_TEMPERATURES[template.presetTemperature],
+    },
     generation: {
       model: {
         providerId: template.presetProviderId,

--- a/front/lib/models/assistant/agent.ts
+++ b/front/lib/models/assistant/agent.ts
@@ -1,9 +1,12 @@
-import type { AgentUserListStatus } from "@dust-tt/types";
 import type {
   AgentConfigurationScope,
   AgentStatus,
   GlobalAgentStatus,
+  ModelIdType,
+  ModelProviderIdType,
 } from "@dust-tt/types";
+import type { AgentUserListStatus } from "@dust-tt/types";
+import { GPT_4_TURBO_MODEL_CONFIG } from "@dust-tt/types";
 import type {
   CreationOptional,
   ForeignKey,
@@ -30,10 +33,10 @@ export class AgentGenerationConfiguration extends Model<
 
   declare agentConfigurationId: ForeignKey<AgentConfiguration["id"]>;
 
-  declare prompt: string; // @daph to deprecate for multi-actions
-  declare providerId: string;
-  declare modelId: string;
-  declare temperature: number;
+  declare prompt: string; // @todo MULTI_ACTIONS @daph remove
+  declare providerId: string; // @todo MULTI_ACTIONS @daph remove
+  declare modelId: string; // @todo MULTI_ACTIONS @daph remove
+  declare temperature: number; // @todo MULTI_ACTIONS @daph remove
 
   declare forceUseAtIteration: number | null;
 }
@@ -107,7 +110,11 @@ export class AgentConfiguration extends Model<
   declare name: string;
 
   declare description: string;
+
   declare instructions: string | null;
+  declare providerId: ModelProviderIdType;
+  declare modelId: ModelIdType;
+  declare temperature: number;
 
   declare pictureUrl: string;
 
@@ -166,6 +173,21 @@ AgentConfiguration.init(
     instructions: {
       type: DataTypes.TEXT,
       allowNull: true,
+    },
+    providerId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      defaultValue: GPT_4_TURBO_MODEL_CONFIG.providerId, // @todo MULTI_ACTIONS @daph remove
+    },
+    modelId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      defaultValue: GPT_4_TURBO_MODEL_CONFIG.modelId, // @todo MULTI_ACTIONS @daph remove
+    },
+    temperature: {
+      type: DataTypes.FLOAT,
+      allowNull: false,
+      defaultValue: 0.7, // @todo MULTI_ACTIONS @daph remove
     },
     maxToolsUsePerRun: {
       type: DataTypes.INTEGER,

--- a/front/lib/resources/storage/models/templates.ts
+++ b/front/lib/resources/storage/models/templates.ts
@@ -1,6 +1,8 @@
 import type {
   ActionPreset,
   AssistantCreativityLevel,
+  ModelIdType,
+  ModelProviderIdType,
   TemplateTagCodeType,
   TemplateVisibility,
 } from "@dust-tt/types";
@@ -33,8 +35,8 @@ export class TemplateModel extends Model<
   declare presetDescription: string | null;
   declare presetInstructions: string | null;
   declare presetTemperature: AssistantCreativityLevel;
-  declare presetProviderId: string;
-  declare presetModelId: string;
+  declare presetProviderId: ModelProviderIdType;
+  declare presetModelId: ModelIdType;
   declare presetAction: ActionPreset;
 
   declare helpInstructions: string | null;

--- a/front/lib/tracking/amplitude/server/index.ts
+++ b/front/lib/tracking/amplitude/server/index.ts
@@ -145,9 +145,7 @@ export class AmplitudeServerSideTracking {
       mentionsCount: userMessage.mentions.length,
       conversationId,
       generationModels: removeNulls(
-        agentMessages.map(
-          (am) => am.configuration.generation?.model.modelId || null
-        )
+        agentMessages.map((am) => am.configuration.model.modelId || null)
       ),
       // We are mostly interested in tracking the usage of non global agents,
       // so if there is at least one non global agent in the list, that's enough to set

--- a/front/migrations/20240424_agent_config_move_model.ts
+++ b/front/migrations/20240424_agent_config_move_model.ts
@@ -34,23 +34,21 @@ const backfillAgentConfiguration = async (
 
   const generation = genConfigs[0];
 
-  logger.info(
-    `Updating agent ${agent.id} from generation configuration ${generation.id}. --execute: ${execute}`
-  );
-
   if (!isModelProviderId(generation.providerId)) {
-    logger.info(
-      `Skipping agent ${agent.id} (invalid provider ${agent.providerId}). --execute: ${execute}`
+    throw new Error(
+      `Invalid Provider Id for agent ${agent.id}:${agent.providerId}).`
     );
-    return;
   }
 
   if (!isModelId(generation.modelId)) {
-    logger.info(
-      `Skipping agent ${agent.id} (invalid model ${agent.modelId}). --execute: ${execute}`
+    throw new Error(
+      `Invalid Provider Id for agent ${agent.id}:${agent.modelId}).`
     );
-    return;
   }
+
+  logger.info(
+    `Updating agent ${agent.id} from generation configuration ${generation.id}. --execute: ${execute}`
+  );
 
   if (execute) {
     await agent.update({

--- a/front/migrations/20240424_agent_config_move_model.ts
+++ b/front/migrations/20240424_agent_config_move_model.ts
@@ -1,0 +1,87 @@
+import type { ModelIdType, ModelProviderIdType } from "@dust-tt/types";
+import { isModelId, isModelProviderId } from "@dust-tt/types";
+
+import {
+  AgentConfiguration,
+  AgentGenerationConfiguration,
+} from "@app/lib/models/assistant/agent";
+import logger from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+
+const backfillAgentConfiguration = async (
+  agent: AgentConfiguration,
+  execute: boolean
+): Promise<void> => {
+  const genConfigs = await AgentGenerationConfiguration.findAll({
+    where: {
+      id: agent.id,
+    },
+    attributes: ["id", "providerId", "modelId", "temperature"],
+  });
+
+  if (genConfigs.length > 1) {
+    throw new Error(
+      "Unexpected: legacy migration in which there could not be multiple generation configurations per agent"
+    );
+  }
+
+  if (genConfigs.length === 0) {
+    logger.info(
+      `Skipping agent (no generation configuration) ${agent.id}. --execute: ${execute}`
+    );
+    return;
+  }
+
+  const generation = genConfigs[0];
+
+  logger.info(
+    `Updating agent ${agent.id} from generation configuration ${generation.id}. --execute: ${execute}`
+  );
+
+  if (!isModelProviderId(generation.providerId)) {
+    logger.info(
+      `Skipping agent ${agent.id} (invalid provider ${agent.providerId}). --execute: ${execute}`
+    );
+    return;
+  }
+
+  if (!isModelId(generation.modelId)) {
+    logger.info(
+      `Skipping agent ${agent.id} (invalid model ${agent.modelId}). --execute: ${execute}`
+    );
+    return;
+  }
+
+  if (execute) {
+    await agent.update({
+      modelId: generation.modelId as ModelIdType,
+      providerId: generation.providerId as ModelProviderIdType,
+      temperature: generation.temperature,
+    });
+  }
+};
+
+const backfillAgentConfigurations = async (execute: boolean) => {
+  // Fetch all agents that have no instructions
+  const agents = await AgentConfiguration.findAll({});
+
+  // Split agents into chunks of 16
+  const chunks: AgentConfiguration[][] = [];
+  for (let i = 0; i < agents.length; i += 16) {
+    chunks.push(agents.slice(i, i + 16));
+  }
+
+  // Process each chunk in parallel
+  for (let i = 0; i < chunks.length; i++) {
+    const chunk = chunks[i];
+    await Promise.all(
+      chunk.map(async (agent) => {
+        return backfillAgentConfiguration(agent, execute);
+      })
+    );
+  }
+};
+
+makeScript({}, async ({ execute }) => {
+  await backfillAgentConfigurations(execute);
+});

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -2,6 +2,7 @@ import type {
   AgentActionConfigurationType,
   AgentConfigurationType,
   AgentGenerationConfigurationType,
+  AgentModelConfigurationType,
   LightAgentConfigurationType,
   Result,
   WithAPIErrorReponse,
@@ -9,6 +10,7 @@ import type {
 import {
   assertNever,
   GetAgentConfigurationsQuerySchema,
+  GPT_4_TURBO_MODEL_CONFIG,
   Ok,
   PostOrPatchAgentConfigurationRequestBodySchema,
 } from "@dust-tt/types";
@@ -330,6 +332,15 @@ export async function createOrUpgradeAgentConfiguration({
   }
 
   let generationConfig: AgentGenerationConfigurationType | null = null;
+
+  // @todo MULTI_ACTIONS @daph remove default value since model config is mandatory
+  const model: AgentModelConfigurationType = {
+    providerId:
+      generation?.model.providerId ?? GPT_4_TURBO_MODEL_CONFIG.providerId,
+    modelId: generation?.model.modelId ?? GPT_4_TURBO_MODEL_CONFIG.modelId,
+    temperature: generation?.temperature ?? 0.7,
+  };
+
   const agentConfigurationRes = await createAgentConfiguration(auth, {
     name,
     description,
@@ -338,7 +349,7 @@ export async function createOrUpgradeAgentConfiguration({
     pictureUrl,
     status,
     scope,
-    generation: generationConfig,
+    model,
     agentConfigurationId,
   });
 
@@ -437,6 +448,7 @@ export async function createOrUpgradeAgentConfiguration({
   const agentConfiguration: AgentConfigurationType = {
     ...agentConfigurationRes.value,
     actions: actionConfigs,
+    generation: generationConfig,
   };
 
   // We are not tracking draft agents

--- a/types/src/front/assistant/agent.ts
+++ b/types/src/front/assistant/agent.ts
@@ -2,7 +2,11 @@ import { DustAppRunConfigurationType } from "../../front/assistant/actions/dust_
 import { ProcessConfigurationType } from "../../front/assistant/actions/process";
 import { RetrievalConfigurationType } from "../../front/assistant/actions/retrieval";
 import { TablesQueryConfigurationType } from "../../front/assistant/actions/tables_query";
-import { SupportedModel } from "../../front/lib/assistant";
+import {
+  ModelIdType,
+  ModelProviderIdType,
+  SupportedModel,
+} from "../../front/lib/assistant";
 import { ModelId } from "../../shared/model_id";
 
 /**
@@ -147,6 +151,12 @@ export type AgentUsageType = {
 
 export type AgentRecentAuthors = readonly string[];
 
+export type AgentModelConfigurationType = {
+  providerId: ModelProviderIdType;
+  modelId: ModelIdType;
+  temperature: number;
+};
+
 export type LightAgentConfigurationType = {
   id: ModelId;
 
@@ -159,8 +169,7 @@ export type LightAgentConfigurationType = {
 
   instructions: string | null;
 
-  // If undefined, no text generation.
-  generation: AgentGenerationConfigurationType | null;
+  model: AgentModelConfigurationType;
 
   status: AgentConfigurationStatus;
   scope: AgentConfigurationScope;
@@ -185,6 +194,8 @@ export type AgentConfigurationType = LightAgentConfigurationType & {
   // If empty, no actions are performed, otherwise the actions are
   // performed.
   actions: AgentActionConfigurationType[];
+  // If undefined, no text generation.
+  generation: AgentGenerationConfigurationType | null;
 };
 
 export interface TemplateAgentConfigurationType {
@@ -198,6 +209,7 @@ export interface TemplateAgentConfigurationType {
   name: string;
   scope: AgentConfigurationScope;
   description: string;
+  model: AgentModelConfigurationType;
   actions: AgentActionConfigurationType[];
   instructions: string | null;
   isTemplate: true;

--- a/types/src/front/lib/assistant.ts
+++ b/types/src/front/lib/assistant.ts
@@ -1,29 +1,85 @@
+import { ExtractSpecificKeys } from "../../shared/typescipt_utils";
+
 /**
- * Supported models
+ * PROVIDER IDS
  */
 
-import { ExtractSpecificKeys } from "../../shared/typescipt_utils";
+export const MODEL_PROVIDER_IDS = [
+  "openai",
+  "anthropic",
+  "mistral",
+  "google_ai_studio",
+] as const;
+export type ModelProviderIdType = (typeof MODEL_PROVIDER_IDS)[number];
+
+export const isModelProviderId = (
+  providerId: unknown
+): providerId is ModelProviderIdType =>
+  MODEL_PROVIDER_IDS.includes(providerId as ModelProviderIdType);
+
+/**
+ * MODEL IDS
+ */
 
 export const GPT_4_TURBO_MODEL_ID = "gpt-4-turbo" as const;
 export const GPT_3_5_TURBO_MODEL_ID = "gpt-3.5-turbo" as const;
+export const CLAUDE_3_OPUS_2024029_MODEL_ID = "claude-3-opus-20240229" as const;
+export const CLAUDE_3_SONNET_2024029_MODEL_ID =
+  "claude-3-sonnet-20240229" as const;
+export const CLAUDE_3_HAIKU_20240307_MODEL_ID =
+  "claude-3-haiku-20240307" as const;
+export const CLAUDE_2_1_MODEL_ID = "claude-2.1" as const;
+export const CLAUDE_INSTANT_1_2_MODEL_ID = "claude-instant-1.2" as const;
+export const MISTRAL_LARGE_MODEL_ID = "mistral-large-latest" as const;
+export const MISTRAL_MEDIUM_MODEL_ID = "mistral-medium" as const;
+export const MISTRAL_SMALL_MODEL_ID = "mistral-small" as const;
+export const GEMINI_1_5_PRO_LATEST_MODEL_ID = "gemini-1.5-pro-latest" as const;
 
-const GPT_4_DESCRIPTION =
-  "OpenAI's most powerful and recent model (128k context).";
-const GPT_4_SHORT_DESCRIPTION = "OpenAI's smartest model.";
+export const MODEL_IDS = [
+  GPT_4_TURBO_MODEL_ID,
+  GPT_3_5_TURBO_MODEL_ID,
+  CLAUDE_3_OPUS_2024029_MODEL_ID,
+  CLAUDE_3_SONNET_2024029_MODEL_ID,
+  CLAUDE_3_HAIKU_20240307_MODEL_ID,
+  CLAUDE_2_1_MODEL_ID,
+  CLAUDE_INSTANT_1_2_MODEL_ID,
+  MISTRAL_LARGE_MODEL_ID,
+  MISTRAL_MEDIUM_MODEL_ID,
+  MISTRAL_SMALL_MODEL_ID,
+  GEMINI_1_5_PRO_LATEST_MODEL_ID,
+] as const;
+export type ModelIdType = (typeof MODEL_IDS)[number];
 
-export const GPT_4_TURBO_MODEL_CONFIG = {
-  providerId: "openai" as const,
+export const isModelId = (modelId: unknown): modelId is ModelIdType =>
+  MODEL_IDS.includes(modelId as ModelIdType);
+
+/**
+ * MODEL CONFIGURATIONS
+ */
+
+export type ModelConfigurationType = {
+  providerId: ModelProviderIdType;
+  modelId: ModelIdType;
+  displayName: string;
+  contextSize: number;
+  recommendedTopK: number;
+  largeModel: boolean;
+  description: string;
+  shortDescription: string;
+};
+
+export const GPT_4_TURBO_MODEL_CONFIG: ModelConfigurationType = {
+  providerId: "openai",
   modelId: GPT_4_TURBO_MODEL_ID,
   displayName: "GPT 4 Turbo",
   contextSize: 128_000,
   recommendedTopK: 32,
   largeModel: true,
-  description: GPT_4_DESCRIPTION,
-  shortDescription: GPT_4_SHORT_DESCRIPTION,
+  description: "OpenAI's most powerful and recent model (128k context).",
+  shortDescription: "OpenAI's smartest model.",
 };
-
-export const GPT_3_5_TURBO_MODEL_CONFIG = {
-  providerId: "openai" as const,
+export const GPT_3_5_TURBO_MODEL_CONFIG: ModelConfigurationType = {
+  providerId: "openai",
   modelId: GPT_3_5_TURBO_MODEL_ID,
   displayName: "GPT 3.5 Turbo",
   contextSize: 16_384,
@@ -32,18 +88,10 @@ export const GPT_3_5_TURBO_MODEL_CONFIG = {
   description:
     "OpenAI's cost-effective and high throughput model (16k context).",
   shortDescription: "OpenAI's fast model.",
-} as const;
+};
 
-export const CLAUDE_3_OPUS_2024029_MODEL_ID = "claude-3-opus-20240229" as const;
-export const CLAUDE_3_SONNET_2024029_MODEL_ID =
-  "claude-3-sonnet-20240229" as const;
-export const CLAUDE_3_HAIKU_20240307_MODEL_ID =
-  "claude-3-haiku-20240307" as const;
-export const CLAUDE_2_1_MODEL_ID = "claude-2.1" as const;
-export const CLAUDE_INSTANT_1_2_MODEL_ID = "claude-instant-1.2" as const;
-
-export const CLAUDE_3_OPUS_DEFAULT_MODEL_CONFIG = {
-  providerId: "anthropic" as const,
+export const CLAUDE_3_OPUS_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
+  providerId: "anthropic",
   modelId: CLAUDE_3_OPUS_2024029_MODEL_ID,
   displayName: "Claude 3 Opus",
   contextSize: 180_000,
@@ -52,10 +100,9 @@ export const CLAUDE_3_OPUS_DEFAULT_MODEL_CONFIG = {
   description:
     "Anthropic's Claude 3 Opus model, most powerful model for highly complex tasks.",
   shortDescription: "Anthropic's powerful model.",
-} as const;
-
-export const CLAUDE_3_SONNET_DEFAULT_MODEL_CONFIG = {
-  providerId: "anthropic" as const,
+};
+export const CLAUDE_3_SONNET_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
+  providerId: "anthropic",
   modelId: CLAUDE_3_SONNET_2024029_MODEL_ID,
   displayName: "Claude 3 Sonnet",
   contextSize: 180_000,
@@ -64,10 +111,9 @@ export const CLAUDE_3_SONNET_DEFAULT_MODEL_CONFIG = {
   description:
     "Anthropic Claude 3 Sonnet model, targeting balance between intelligence and speed for enterprise workloads.",
   shortDescription: "Anthropic's balanced model.",
-} as const;
-
-export const CLAUDE_3_HAIKU_DEFAULT_MODEL_CONFIG = {
-  providerId: "anthropic" as const,
+};
+export const CLAUDE_3_HAIKU_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
+  providerId: "anthropic",
   modelId: CLAUDE_3_HAIKU_20240307_MODEL_ID,
   displayName: "Claude 3 Haiku",
   contextSize: 180_000,
@@ -76,10 +122,9 @@ export const CLAUDE_3_HAIKU_DEFAULT_MODEL_CONFIG = {
   description:
     "Anthropic Claude 3 Haiku model, fastest and most compact model for near-instant responsiveness.",
   shortDescription: "Anthropic's quick model.",
-} as const;
-
-export const CLAUDE_2_DEFAULT_MODEL_CONFIG = {
-  providerId: "anthropic" as const,
+};
+export const CLAUDE_2_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
+  providerId: "anthropic",
   modelId: CLAUDE_2_1_MODEL_ID,
   displayName: "Claude 2.1",
   contextSize: 180_000,
@@ -87,10 +132,9 @@ export const CLAUDE_2_DEFAULT_MODEL_CONFIG = {
   largeModel: true,
   description: "Anthropic's Claude 2 model (200k context).",
   shortDescription: "Anthropic's smartest model.",
-} as const;
-
-export const CLAUDE_INSTANT_DEFAULT_MODEL_CONFIG = {
-  providerId: "anthropic" as const,
+};
+export const CLAUDE_INSTANT_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
+  providerId: "anthropic",
   modelId: CLAUDE_INSTANT_1_2_MODEL_ID,
   displayName: "Claude Instant 1.2",
   contextSize: 90_000,
@@ -99,14 +143,10 @@ export const CLAUDE_INSTANT_DEFAULT_MODEL_CONFIG = {
   description:
     "Anthropic's low-latency and high throughput model (100k context)",
   shortDescription: "Anthropic's fast model.",
-} as const;
+};
 
-export const MISTRAL_LARGE_MODEL_ID = "mistral-large-latest" as const;
-export const MISTRAL_MEDIUM_MODEL_ID = "mistral-medium" as const;
-export const MISTRAL_SMALL_MODEL_ID = "mistral-small" as const;
-
-export const MISTRAL_LARGE_MODEL_CONFIG = {
-  providerId: "mistral" as const,
+export const MISTRAL_LARGE_MODEL_CONFIG: ModelConfigurationType = {
+  providerId: "mistral",
   modelId: MISTRAL_LARGE_MODEL_ID,
   displayName: "Mistral Large",
   contextSize: 32_000,
@@ -114,10 +154,9 @@ export const MISTRAL_LARGE_MODEL_CONFIG = {
   largeModel: true,
   description: "Mistral's latest `large` model (32k context).",
   shortDescription: "Mistral's large model.",
-} as const;
-
-export const MISTRAL_MEDIUM_MODEL_CONFIG = {
-  providerId: "mistral" as const,
+};
+export const MISTRAL_MEDIUM_MODEL_CONFIG: ModelConfigurationType = {
+  providerId: "mistral",
   modelId: MISTRAL_MEDIUM_MODEL_ID,
   displayName: "Mistral Medium",
   contextSize: 32_000,
@@ -125,10 +164,9 @@ export const MISTRAL_MEDIUM_MODEL_CONFIG = {
   largeModel: true,
   description: "Mistral's latest `medium` model (32k context).",
   shortDescription: "Mistral's smartest model.",
-} as const;
-
-export const MISTRAL_SMALL_MODEL_CONFIG = {
-  providerId: "mistral" as const,
+};
+export const MISTRAL_SMALL_MODEL_CONFIG: ModelConfigurationType = {
+  providerId: "mistral",
   modelId: MISTRAL_SMALL_MODEL_ID,
   displayName: "Mistral Small",
   contextSize: 32_000,
@@ -136,12 +174,10 @@ export const MISTRAL_SMALL_MODEL_CONFIG = {
   largeModel: false,
   description: "Mistral's latest model (8x7B Instruct, 32k context).",
   shortDescription: "Mistral's fast model.",
-} as const;
+};
 
-const GEMINI_1_5_PRO_LATEST_MODEL_ID = "gemini-1.5-pro-latest" as const;
-
-export const GEMINI_PRO_DEFAULT_MODEL_CONFIG = {
-  providerId: "google_ai_studio" as const,
+export const GEMINI_PRO_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
+  providerId: "google_ai_studio",
   modelId: GEMINI_1_5_PRO_LATEST_MODEL_ID,
   displayName: "Gemini Pro 1.5",
   contextSize: 1_000_000,
@@ -150,9 +186,9 @@ export const GEMINI_PRO_DEFAULT_MODEL_CONFIG = {
   description:
     "Google's best model for scaling across a wide range of tasks (1M context).",
   shortDescription: "Google's smartest model.",
-} as const;
+};
 
-export const SUPPORTED_MODEL_CONFIGS = [
+export const SUPPORTED_MODEL_CONFIGS: ModelConfigurationType[] = [
   GPT_3_5_TURBO_MODEL_CONFIG,
   GPT_4_TURBO_MODEL_CONFIG,
   CLAUDE_3_OPUS_DEFAULT_MODEL_CONFIG,
@@ -164,7 +200,7 @@ export const SUPPORTED_MODEL_CONFIGS = [
   MISTRAL_MEDIUM_MODEL_CONFIG,
   MISTRAL_SMALL_MODEL_CONFIG,
   GEMINI_PRO_DEFAULT_MODEL_CONFIG,
-] as const;
+];
 
 export type ModelConfig = (typeof SUPPORTED_MODEL_CONFIGS)[number];
 


### PR DESCRIPTION
## Description

We want to take out  `providerId`, `modelId`, `temperature` from `AgentGenerationConfiguration` to `AgentConfiguration`.


This PR:
- Introduces the fields `providerId`, `modelId`, `temperature` in `AgentConfiguration` model with a default value.
- Adds a new migration to set those fields accordingly to the `AgentGenerationConfiguration` attached to the agent. 
- Updates `createAgentConfiguration` to set those new fields.
- Updates `AgentConfigurationType` -> adds a new `model` key with type `AgentModelConfigurationType`.
- Takes out `generation` from `LightAgentConfigurationType`

I decided to rework a bit the types for supported model ids and provider ids -> and to type the new columns ( `providerId`, `modelId`). 

## Risk

Should be safe since the new data is not used yet. 

## Deploy Plan

- Run init_db: `./admin/init_db.sh`
- Run script: `npx tsx migrations/20240424_agent_config_move_model.ts --execute`
