### PR TITLE
feat(multi actions): execution loop v0

### DIFF
--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -102,18 +102,19 @@ export async function* runAgent(
   }
 
   for (let i = 0; i < configuration.maxToolsUsePerRun; i++) {
+    const localLogger = logger.child({
+      workspaceId: conversation.owner.sId,
+      conversationId: conversation.sId,
+      multiActionLoopIteration: i,
+    });
+
+    localLogger.info("Starting multi-action loop iteration");
+
     const forcedAction = fullConfiguration.actions.find(
       (a) => a.forceUseAtIteration === i
     );
-
     const actions = forcedAction ? [forcedAction] : fullConfiguration.actions;
-    logger.info(
-      {
-        iteration: i,
-        workspaceId: conversation.owner.sId,
-      },
-      "Starting multi-action loop iteration"
-    );
+
     const actionToRun = await getNextAction(auth, {
       agentConfiguration: fullConfiguration,
       conversation,
@@ -123,13 +124,10 @@ export async function* runAgent(
     });
 
     if (actionToRun.isErr()) {
-      logger.error(
+      localLogger.error(
         {
-          workspaceId: conversation.owner.sId,
-          conversationId: conversation.sId,
           elapsedTime: Date.now() - now,
           error: actionToRun.error,
-          multiActionLoopIteration: i,
         },
         "Error getting next action"
       );
@@ -146,12 +144,9 @@ export async function* runAgent(
       return;
     }
 
-    logger.info(
+    localLogger.info(
       {
-        workspaceId: conversation.owner.sId,
-        conversationId: conversation.sId,
         elapsed: Date.now() - now,
-        multiActionLoopIteration: i,
       },
       "[ASSISTANT_TRACE] Action inputs generation"
     );

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -385,6 +385,9 @@ export async function getNextAction(
   config.MODEL.function_call = "auto";
   config.MODEL.provider_id = model.providerId;
   config.MODEL.model_id = model.modelId;
+  if (specifications.length === 1) {
+    config.MODEL.function_call = specifications[0].name;
+  }
 
   const res = await runActionStreamed(auth, "assistant-v2-use-tools", config, [
     {

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -693,5 +693,7 @@ async function* runAction(
           assertNever(event);
       }
     }
+  } else {
+    assertNever(actionConfiguration);
   }
 }

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -172,6 +172,8 @@ export async function* runAgent(
       ((g: AgentGenerationConfigurationType) => {
         void g;
       })(action);
+      // If the next action is the generation, we simply break out of the loop,
+      // as we always run the generation after the actions loop.
       break;
     }
   }

--- a/types/src/front/assistant/actions/guards.ts
+++ b/types/src/front/assistant/actions/guards.ts
@@ -14,13 +14,18 @@ import {
   TablesQueryActionType,
   TablesQueryConfigurationType,
 } from "../../../front/assistant/actions/tables_query";
-import { AgentActionConfigurationType } from "../../../front/assistant/agent";
 import { AgentActionType } from "../../../front/assistant/conversation";
+import { AgentActionConfigurationType } from "../agent";
 
 export function isTablesQueryConfiguration(
-  arg: AgentActionConfigurationType | null
+  arg: unknown
 ): arg is TablesQueryConfigurationType {
-  return arg?.type === "tables_query_configuration";
+  return (
+    !!arg &&
+    typeof arg === "object" &&
+    "type" in arg &&
+    arg.type === "tables_query_configuration"
+  );
 }
 
 export function isTablesQueryActionType(
@@ -30,9 +35,14 @@ export function isTablesQueryActionType(
 }
 
 export function isDustAppRunConfiguration(
-  arg: AgentActionConfigurationType | null
+  arg: unknown
 ): arg is DustAppRunConfigurationType {
-  return arg !== null && arg.type && arg.type === "dust_app_run_configuration";
+  return (
+    !!arg &&
+    typeof arg === "object" &&
+    "type" in arg &&
+    arg.type === "dust_app_run_configuration"
+  );
 }
 
 export function isDustAppRunActionType(
@@ -42,9 +52,14 @@ export function isDustAppRunActionType(
 }
 
 export function isRetrievalConfiguration(
-  arg: AgentActionConfigurationType | null
+  arg: unknown
 ): arg is RetrievalConfigurationType {
-  return arg !== null && arg.type && arg.type === "retrieval_configuration";
+  return (
+    !!arg &&
+    typeof arg === "object" &&
+    "type" in arg &&
+    arg.type === "retrieval_configuration"
+  );
 }
 
 export function isRetrievalActionType(
@@ -54,13 +69,29 @@ export function isRetrievalActionType(
 }
 
 export function isProcessConfiguration(
-  arg: AgentActionConfigurationType | null
+  arg: unknown
 ): arg is ProcessConfigurationType {
-  return arg !== null && arg.type && arg.type === "process_configuration";
+  return (
+    !!arg &&
+    typeof arg === "object" &&
+    "type" in arg &&
+    arg.type === "process_configuration"
+  );
 }
 
 export function isProcessActionType(
   arg: AgentActionType
 ): arg is ProcessActionType {
   return arg.type === "process_action";
+}
+
+export function isAgentConfiguration(
+  arg: unknown
+): arg is AgentActionConfigurationType {
+  return (
+    isTablesQueryConfiguration(arg) ||
+    isDustAppRunConfiguration(arg) ||
+    isRetrievalConfiguration(arg) ||
+    isProcessConfiguration(arg)
+  );
 }


### PR DESCRIPTION
## Description

https://github.com/dust-tt/dust/issues/4602

This commit adds a first version of the multi-actions execution loop.
`generation` is not yet an action, so it is currently treated differently from other actions. generation is always the last thing done in the loop (and currently, is always performed). This should be changed once generation is an action.

Right now, the `generation` is also not counted towards the maxToolsUsePerRun, which may not be what we want

## Risk

Should not impact single action assistants

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
