### PR TITLE
Remove agent messages at the beginning of the list

### DIFF
--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -183,7 +183,7 @@ export async function renderConversationForModel({
   let tokensUsed = promptCountRes.value + tokensMargin;
 
   // Go backward and accumulate as much as we can within allowedTokenCount.
-  const selected: { message: ModelMessageType; tokenUseds: number }[] = [];
+  const selected: { message: ModelMessageType; tokenUsed: number }[] = [];
   const truncationMessage = `... (content truncated)`;
   const approxTruncMsgTokenCount = truncationMessage.length / 3;
 
@@ -195,7 +195,7 @@ export async function renderConversationForModel({
     const c = r.value;
     if (tokensUsed + c <= allowedTokenCount) {
       tokensUsed += c;
-      selected.unshift({ message: messages[i], tokenUseds: c });
+      selected.unshift({ message: messages[i], tokenUsed: c });
     } else if (
       // When a content fragment has more than the remaining number of tokens, we split it.
       messages[i].role === "content_fragment" &&
@@ -217,7 +217,7 @@ export async function renderConversationForModel({
           ...messages[i],
           content: contentRes.value + truncationMessage,
         },
-        tokenUseds: remainingTokens,
+        tokenUsed: remainingTokens,
       });
       tokensUsed += remainingTokens;
       break;
@@ -246,7 +246,7 @@ export async function renderConversationForModel({
     modelConversation: {
       messages: selected.map((s) => s.message),
     },
-    tokensUsed: selected.map((s) => s.tokenUseds).reduce((a, b) => a + b, 0),
+    tokensUsed: selected.map((s) => s.tokenUsed).reduce((a, b) => a + b, 0),
   });
 }
 

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -239,14 +239,19 @@ export async function renderConversationForModel({
     "[ASSISTANT_TRACE] Genration message token counts for model conversation rendering"
   );
   while (selected.length > 0 && selected[0].message.role === "agent") {
-    selected.shift();
+    const m = selected.shift();
+    if (!m) {
+      // Should never happen, but Typescript doesn't know that.
+      throw new Error("Unexpected missing message");
+    }
+    tokensUsed -= m.tokenUsed;
   }
 
   return new Ok({
     modelConversation: {
       messages: selected.map((s) => s.message),
     },
-    tokensUsed: selected.map((s) => s.tokenUsed).reduce((a, b) => a + b, 0),
+    tokensUsed: tokensUsed,
   });
 }
 

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -251,7 +251,7 @@ export async function renderConversationForModel({
     modelConversation: {
       messages: selected.map((s) => s.message),
     },
-    tokensUsed: tokensUsed,
+    tokensUsed,
   });
 }
 


### PR DESCRIPTION
## Description

Context [here](https://github.com/dust-tt/tasks/issues/699).

This is a PR to ensure that `renderModelForConverastion()` never returns a list of messages that starts with an agent message.
The reason for this change is that Claude models do not support having an agent message before a user message.

We think it's reasonable to apply this change uniformly for all models.


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
