### PR TITLE
AssistantBuilder: Types clean-up

### DIFF
--- a/front/components/assistant/TryAssistant.tsx
+++ b/front/components/assistant/TryAssistant.tsx
@@ -215,14 +215,10 @@ export function usePreviewAssistant({
         description: "Draft Assistant",
         instructions: builderState.instructions,
         avatarUrl: builderState.avatarUrl,
-        timeFrame: {
-          value: builderState.timeFrame.value,
-          unit: builderState.timeFrame.unit,
-        },
+        retrievalConfiguration: builderState.retrievalConfiguration,
         dustAppConfiguration: builderState.dustAppConfiguration,
         tablesQueryConfiguration: builderState.tablesQueryConfiguration,
         scope: "private",
-        dataSourceConfigurations: builderState.dataSourceConfigurations,
         generationSettings: builderState.generationSettings,
       },
 
@@ -246,12 +242,11 @@ export function usePreviewAssistant({
     builderState.handle,
     builderState.instructions,
     builderState.avatarUrl,
-    builderState.timeFrame.value,
-    builderState.timeFrame.unit,
-    builderState.dustAppConfiguration,
-    builderState.tablesQueryConfiguration,
-    builderState.dataSourceConfigurations,
     builderState.generationSettings,
+    // Actions
+    builderState.tablesQueryConfiguration,
+    builderState.dustAppConfiguration,
+    builderState.retrievalConfiguration,
   ]);
 
   useEffect(() => {

--- a/front/components/assistant_builder/ActionScreen.tsx
+++ b/front/components/assistant_builder/ActionScreen.tsx
@@ -146,18 +146,29 @@ export default function ActionScreen({
   const [showTableModal, setShowTableModal] = useState(false);
 
   const deleteDataSource = (name: string) => {
-    setEdited(true);
-    setBuilderState(({ dataSourceConfigurations, ...rest }) => {
-      const newConfigs = { ...dataSourceConfigurations };
-      delete newConfigs[name];
-      return { ...rest, dataSourceConfigurations: newConfigs };
+    if (builderState.retrievalConfiguration.dataSourceConfigurations[name]) {
+      setEdited(true);
+    }
+
+    setBuilderState(({ retrievalConfiguration, ...rest }) => {
+      const dataSourceConfigurations = {
+        ...retrievalConfiguration.dataSourceConfigurations,
+      };
+      delete dataSourceConfigurations[name];
+      return {
+        retrievalConfiguration: {
+          ...retrievalConfiguration,
+          dataSourceConfigurations,
+        },
+        ...rest,
+      };
     });
   };
 
   const deleteDustApp = () => {
     setEdited(true);
     setBuilderState((state) => {
-      return { ...state, dustAppConfiguration: null };
+      return { ...state, dustAppConfiguration: { app: null } };
     });
   };
 
@@ -192,7 +203,9 @@ export default function ActionScreen({
 
   const noDataSources =
     dataSources.length === 0 &&
-    Object.keys(builderState.dataSourceConfigurations).length === 0;
+    Object.keys(
+      builderState.retrievalConfiguration?.dataSourceConfigurations || {}
+    ).length === 0;
   const noDustApp = dustApps.length === 0;
 
   return (
@@ -246,18 +259,23 @@ export default function ActionScreen({
           setEdited(true);
           setBuilderState((state) => ({
             ...state,
-            dataSourceConfigurations: {
-              ...state.dataSourceConfigurations,
-              [dataSource.name]: {
-                dataSource,
-                selectedResources,
-                isSelectAll,
+            retrievalConfiguration: {
+              ...state.retrievalConfiguration,
+              dataSourceConfigurations: {
+                ...state.retrievalConfiguration.dataSourceConfigurations,
+                [dataSource.name]: {
+                  dataSource,
+                  selectedResources,
+                  isSelectAll,
+                },
               },
             },
           }));
         }}
         onDelete={deleteDataSource}
-        dataSourceConfigurations={builderState.dataSourceConfigurations}
+        dataSourceConfigurations={
+          builderState.retrievalConfiguration.dataSourceConfigurations
+        }
       />
       <div className="flex flex-col gap-4 text-sm text-element-700">
         <div className="flex flex-col gap-2">
@@ -442,7 +460,9 @@ export default function ActionScreen({
         >
           <DataSourceSelectionSection
             owner={owner}
-            dataSourceConfigurations={builderState.dataSourceConfigurations}
+            dataSourceConfigurations={
+              builderState.retrievalConfiguration.dataSourceConfigurations
+            }
             openDataSourceModal={() => {
               setShowDataSourcesModal(true);
             }}
@@ -458,7 +478,9 @@ export default function ActionScreen({
         >
           <DataSourceSelectionSection
             owner={owner}
-            dataSourceConfigurations={builderState.dataSourceConfigurations}
+            dataSourceConfigurations={
+              builderState.retrievalConfiguration.dataSourceConfigurations
+            }
             openDataSourceModal={() => {
               setShowDataSourcesModal(true);
             }}
@@ -478,7 +500,7 @@ export default function ActionScreen({
                   : "border-red-500 focus:border-red-500 focus:ring-red-500",
                 "bg-structure-50 stroke-structure-50"
               )}
-              value={builderState.timeFrame.value || ""}
+              value={builderState.retrievalConfiguration.timeFrame.value || ""}
               onChange={(e) => {
                 const value = parseInt(e.target.value, 10);
                 if (!isNaN(value) || !e.target.value) {
@@ -487,7 +509,7 @@ export default function ActionScreen({
                     ...state,
                     timeFrame: {
                       value,
-                      unit: builderState.timeFrame.unit,
+                      unit: builderState.retrievalConfiguration.timeFrame.unit,
                     },
                   }));
                 }
@@ -498,7 +520,11 @@ export default function ActionScreen({
                 <Button
                   type="select"
                   labelVisible={true}
-                  label={TIME_FRAME_UNIT_TO_LABEL[builderState.timeFrame.unit]}
+                  label={
+                    TIME_FRAME_UNIT_TO_LABEL[
+                      builderState.retrievalConfiguration.timeFrame.unit
+                    ]
+                  }
                   variant="secondary"
                   size="sm"
                 />
@@ -514,7 +540,9 @@ export default function ActionScreen({
                         setBuilderState((state) => ({
                           ...state,
                           timeFrame: {
-                            value: builderState.timeFrame.value,
+                            value:
+                              builderState.retrievalConfiguration.timeFrame
+                                .value,
                             unit: key as TimeframeUnit,
                           },
                         }));

--- a/front/components/assistant_builder/ActionScreen.tsx
+++ b/front/components/assistant_builder/ActionScreen.tsx
@@ -507,9 +507,13 @@ export default function ActionScreen({
                   setEdited(true);
                   setBuilderState((state) => ({
                     ...state,
-                    timeFrame: {
-                      value,
-                      unit: builderState.retrievalConfiguration.timeFrame.unit,
+                    retrievalConfiguration: {
+                      ...state.retrievalConfiguration,
+                      timeFrame: {
+                        value,
+                        unit: builderState.retrievalConfiguration.timeFrame
+                          .unit,
+                      },
                     },
                   }));
                 }
@@ -539,11 +543,14 @@ export default function ActionScreen({
                         setEdited(true);
                         setBuilderState((state) => ({
                           ...state,
-                          timeFrame: {
-                            value:
-                              builderState.retrievalConfiguration.timeFrame
-                                .value,
-                            unit: key as TimeframeUnit,
+                          retrievalConfiguration: {
+                            ...state.retrievalConfiguration,
+                            timeFrame: {
+                              value:
+                                builderState.retrievalConfiguration.timeFrame
+                                  .value,
+                              unit: key as TimeframeUnit,
+                            },
                           },
                         }));
                       }}

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -60,6 +60,7 @@ import type {
   AssistantBuilderInitialState,
   AssistantBuilderState,
 } from "@app/components/assistant_builder/types";
+import { DEFAULT_ASSISTANT_STATE } from "@app/components/assistant_builder/types";
 import { ConfirmContext } from "@app/components/Confirm";
 import AppLayout, { appLayoutBack } from "@app/components/sparkle/AppLayout";
 import {
@@ -96,29 +97,6 @@ type AssistantBuilderProps = {
   defaultIsEdited?: boolean;
   baseUrl: string;
   defaultTemplate: FetchAssistantTemplateResponse | null;
-};
-
-const DEFAULT_ASSISTANT_STATE: AssistantBuilderState = {
-  actionMode: "GENERIC",
-  dataSourceConfigurations: {},
-  timeFrame: {
-    value: 1,
-    unit: "month",
-  },
-  dustAppConfiguration: null,
-  tablesQueryConfiguration: {},
-  handle: null,
-  scope: "private",
-  description: null,
-  instructions: null,
-  avatarUrl: null,
-  generationSettings: {
-    modelSettings: {
-      modelId: GPT_4_TURBO_MODEL_CONFIG.modelId,
-      providerId: GPT_4_TURBO_MODEL_CONFIG.providerId,
-    },
-    temperature: 0.7,
-  },
 };
 
 const useNavigationLock = (
@@ -229,17 +207,6 @@ export default function AssistantBuilder({
   const [builderState, setBuilderState] = useState<AssistantBuilderState>(
     initialBuilderState
       ? {
-          actionMode: initialBuilderState.actionMode,
-          dataSourceConfigurations:
-            initialBuilderState.dataSourceConfigurations ?? {
-              ...DEFAULT_ASSISTANT_STATE.dataSourceConfigurations,
-            },
-          timeFrame: initialBuilderState.timeFrame ?? {
-            ...DEFAULT_ASSISTANT_STATE.timeFrame,
-          },
-          dustAppConfiguration: initialBuilderState.dustAppConfiguration,
-          tablesQueryConfiguration:
-            initialBuilderState.tablesQueryConfiguration,
           handle: initialBuilderState.handle,
           description: initialBuilderState.description,
           scope: initialBuilderState.scope,
@@ -248,6 +215,11 @@ export default function AssistantBuilder({
           generationSettings: initialBuilderState.generationSettings ?? {
             ...DEFAULT_ASSISTANT_STATE.generationSettings,
           },
+          actionMode: initialBuilderState.actionMode,
+          retrievalConfiguration: initialBuilderState.retrievalConfiguration,
+          dustAppConfiguration: initialBuilderState.dustAppConfiguration,
+          tablesQueryConfiguration:
+            initialBuilderState.tablesQueryConfiguration,
         }
       : {
           ...DEFAULT_ASSISTANT_STATE,
@@ -260,10 +232,12 @@ export default function AssistantBuilder({
           },
         }
   );
+
   const [template, setTemplate] =
     useState<FetchAssistantTemplateResponse | null>(defaultTemplate);
+
   const resetTemplate = async () => {
-    await setTemplate(null);
+    setTemplate(null);
     await router.replace(
       {
         pathname: router.pathname,
@@ -277,6 +251,7 @@ export default function AssistantBuilder({
   const [instructionsResetAt, setInstructionsResetAt] = useState<number | null>(
     null
   );
+
   const resetToTemplateInstructions = useCallback(async () => {
     if (template === null) {
       return;
@@ -303,7 +278,7 @@ export default function AssistantBuilder({
     } else if (isTablesQueryConfiguration(action)) {
       actionMode = "TABLES_QUERY";
     } else if (isProcessConfiguration(action)) {
-      // not supported in the builder yet
+      // Not supported in the builder yet.
     }
 
     if (actionMode !== null) {
@@ -312,7 +287,7 @@ export default function AssistantBuilder({
         ...builderState,
         actionMode,
         dataSourceConfigurations: {},
-        dustAppConfiguration: null,
+        dustAppConfiguration: { app: null },
         tablesQueryConfiguration: {},
       }));
     }
@@ -416,10 +391,6 @@ export default function AssistantBuilder({
     slackChannelsInitialized,
   ]);
 
-  const configuredDataSourceCount = Object.keys(
-    builderState.dataSourceConfigurations
-  ).length;
-
   const formValidation = useCallback(async () => {
     let valid = true;
 
@@ -445,12 +416,16 @@ export default function AssistantBuilder({
       builderState.actionMode === "RETRIEVAL_SEARCH" ||
       builderState.actionMode === "RETRIEVAL_EXHAUSTIVE"
     ) {
-      if (!configuredDataSourceCount) {
+      if (
+        Object.keys(
+          builderState.retrievalConfiguration.dataSourceConfigurations
+        ).length === 0
+      ) {
         valid = false;
       }
     }
     if (builderState.actionMode === "RETRIEVAL_EXHAUSTIVE") {
-      if (!builderState.timeFrame.value) {
+      if (!builderState.retrievalConfiguration.timeFrame.value) {
         valid = false;
         setTimeFrameError("Timeframe must be a number");
       } else {
@@ -476,12 +451,12 @@ export default function AssistantBuilder({
     builderState.handle,
     builderState.description,
     builderState.instructions,
-    configuredDataSourceCount,
-    builderState.timeFrame.value,
-    builderState.dustAppConfiguration,
-    builderState.tablesQueryConfiguration,
     owner,
     initialBuilderState?.handle,
+    // Actions
+    builderState.retrievalConfiguration,
+    builderState.dustAppConfiguration,
+    builderState.tablesQueryConfiguration,
   ]);
 
   useEffect(() => {
@@ -792,35 +767,34 @@ export async function submitAssistantBuilderForm({
         type: "retrieval_configuration",
         query: builderState.actionMode === "RETRIEVAL_SEARCH" ? "auto" : "none",
         relativeTimeFrame:
-          builderState.actionMode === "RETRIEVAL_EXHAUSTIVE"
+          builderState.actionMode === "RETRIEVAL_EXHAUSTIVE" &&
+          builderState.retrievalConfiguration
             ? {
-                duration: builderState.timeFrame.value,
-                unit: builderState.timeFrame.unit,
+                duration: builderState.retrievalConfiguration.timeFrame.value,
+                unit: builderState.retrievalConfiguration.timeFrame.unit,
               }
             : "auto",
         topK: "auto",
-        dataSources: Object.values(builderState.dataSourceConfigurations).map(
-          ({ dataSource, selectedResources, isSelectAll }) => ({
-            dataSourceId: dataSource.name,
-            workspaceId: owner.sId,
-            filter: {
-              parents: !isSelectAll
-                ? {
-                    in: selectedResources.map(
-                      (resource) => resource.internalId
-                    ),
-                    not: [],
-                  }
-                : null,
-              tags: null,
-            },
-          })
-        ),
+        dataSources: Object.values(
+          builderState.retrievalConfiguration?.dataSourceConfigurations || {}
+        ).map(({ dataSource, selectedResources, isSelectAll }) => ({
+          dataSourceId: dataSource.name,
+          workspaceId: owner.sId,
+          filter: {
+            parents: !isSelectAll
+              ? {
+                  in: selectedResources.map((resource) => resource.internalId),
+                  not: [],
+                }
+              : null,
+            tags: null,
+          },
+        })),
       };
       break;
 
     case "DUST_APP_RUN":
-      if (builderState.dustAppConfiguration) {
+      if (builderState.dustAppConfiguration.app) {
         actionParam = {
           type: "dust_app_run_configuration",
           appWorkspaceId: owner.sId,

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -286,9 +286,10 @@ export default function AssistantBuilder({
       setBuilderState((builderState) => ({
         ...builderState,
         actionMode,
-        dataSourceConfigurations: {},
-        dustAppConfiguration: { app: null },
-        tablesQueryConfiguration: {},
+        retrievalConfiguration: DEFAULT_ASSISTANT_STATE.retrievalConfiguration,
+        dustAppConfiguration: DEFAULT_ASSISTANT_STATE.dustAppConfiguration,
+        tablesQueryConfiguration:
+          DEFAULT_ASSISTANT_STATE.tablesQueryConfiguration,
       }));
     }
   }, [template]);

--- a/front/components/assistant_builder/DustAppSelectionSection.tsx
+++ b/front/components/assistant_builder/DustAppSelectionSection.tsx
@@ -17,7 +17,7 @@ export default function DustAppSelectionSection({
   canSelectDustApp,
 }: {
   show: boolean;
-  dustAppConfiguration: AssistantBuilderDustAppConfiguration | null;
+  dustAppConfiguration: AssistantBuilderDustAppConfiguration;
   openDustAppModal: () => void;
   onDelete?: (sId: string) => void;
   canSelectDustApp: boolean;
@@ -41,7 +41,7 @@ export default function DustAppSelectionSection({
       }}
     >
       <div>
-        {!dustAppConfiguration ? (
+        {!dustAppConfiguration.app ? (
           <EmptyCallToAction
             label="Select Dust App"
             disabled={!canSelectDustApp}
@@ -61,7 +61,9 @@ export default function DustAppSelectionSection({
                     label="Remove"
                     labelVisible={false}
                     onClick={() => {
-                      onDelete?.(dustAppConfiguration.app.sId);
+                      if (dustAppConfiguration.app) {
+                        onDelete?.(dustAppConfiguration.app.sId);
+                      }
                     }}
                   />
                 </Button.List>

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -6,6 +6,7 @@ import type {
   SupportedModel,
   TimeframeUnit,
 } from "@dust-tt/types";
+import { GPT_4_TURBO_MODEL_CONFIG } from "@dust-tt/types";
 
 export const ACTION_MODES = [
   "GENERIC",
@@ -17,15 +18,34 @@ export const ACTION_MODES = [
 
 export type ActionMode = (typeof ACTION_MODES)[number];
 
+// Retrieval configuration
+
 export type AssistantBuilderDataSourceConfiguration = {
   dataSource: DataSourceType;
   selectedResources: ContentNode[];
   isSelectAll: boolean;
 };
 
-export type AssistantBuilderDustAppConfiguration = {
-  app: AppType;
+export type AssistantBuilderDataSourceConfigurations = Record<
+  string,
+  AssistantBuilderDataSourceConfiguration
+>;
+
+export type AssistantBuilderRetrievalConfiguration = {
+  dataSourceConfigurations: AssistantBuilderDataSourceConfigurations;
+  timeFrame: {
+    value: number;
+    unit: TimeframeUnit;
+  };
 };
+
+// DustAppRun configuration
+
+export type AssistantBuilderDustAppConfiguration = {
+  app: AppType | null;
+};
+
+// TablesQuery configuration
 
 export type AssistantBuilderTableConfiguration = {
   dataSourceId: string;
@@ -35,21 +55,13 @@ export type AssistantBuilderTableConfiguration = {
   connectorContentNodeInternalId?: string;
 };
 
-export type AssistantBuilderDataSourceConfigurations = Record<
+export type AssistantBuilderTablesQueryConfiguration = Record<
   string,
-  AssistantBuilderDataSourceConfiguration
+  AssistantBuilderTableConfiguration
 >;
 
 // Builder State
 export type AssistantBuilderState = {
-  actionMode: ActionMode;
-  dataSourceConfigurations: AssistantBuilderDataSourceConfigurations;
-  timeFrame: {
-    value: number;
-    unit: TimeframeUnit;
-  };
-  dustAppConfiguration: AssistantBuilderDustAppConfiguration | null;
-  tablesQueryConfiguration: Record<string, AssistantBuilderTableConfiguration>;
   handle: string | null;
   description: string | null;
   scope: Exclude<AgentConfigurationScope, "global">;
@@ -59,16 +71,16 @@ export type AssistantBuilderState = {
     modelSettings: SupportedModel;
     temperature: number;
   };
+  // Actions
+  // We want assistant builder state for action to always have empty default, never null which
+  // would complexify the assistant builder logic.
+  actionMode: ActionMode;
+  retrievalConfiguration: AssistantBuilderRetrievalConfiguration;
+  dustAppConfiguration: AssistantBuilderDustAppConfiguration;
+  tablesQueryConfiguration: AssistantBuilderTablesQueryConfiguration;
 };
 
 export type AssistantBuilderInitialState = {
-  actionMode: AssistantBuilderState["actionMode"];
-  dataSourceConfigurations:
-    | AssistantBuilderState["dataSourceConfigurations"]
-    | null;
-  timeFrame: AssistantBuilderState["timeFrame"] | null;
-  dustAppConfiguration: AssistantBuilderState["dustAppConfiguration"];
-  tablesQueryConfiguration: AssistantBuilderState["tablesQueryConfiguration"];
   handle: string;
   description: string;
   scope: Exclude<AgentConfigurationScope, "global">;
@@ -78,4 +90,34 @@ export type AssistantBuilderInitialState = {
     modelSettings: SupportedModel;
     temperature: number;
   } | null;
+  // Actions
+  actionMode: AssistantBuilderState["actionMode"];
+  retrievalConfiguration: AssistantBuilderState["retrievalConfiguration"];
+  dustAppConfiguration: AssistantBuilderState["dustAppConfiguration"];
+  tablesQueryConfiguration: AssistantBuilderState["tablesQueryConfiguration"];
+};
+
+export const DEFAULT_ASSISTANT_STATE: AssistantBuilderState = {
+  actionMode: "GENERIC",
+  retrievalConfiguration: {
+    dataSourceConfigurations: {},
+    timeFrame: {
+      value: 1,
+      unit: "month",
+    },
+  },
+  dustAppConfiguration: { app: null },
+  tablesQueryConfiguration: {},
+  handle: null,
+  scope: "private",
+  description: null,
+  instructions: null,
+  avatarUrl: null,
+  generationSettings: {
+    modelSettings: {
+      modelId: GPT_4_TURBO_MODEL_CONFIG.modelId,
+      providerId: GPT_4_TURBO_MODEL_CONFIG.providerId,
+    },
+    temperature: 0.7,
+  },
 };


### PR DESCRIPTION
## Description

- Rationalize assistant builder types to have one type per action (start review by `front/components/assistant_builder/types.ts`)
- Moves dataSourcesConfiguration/TimeFrame into retrievalConfigurations
- Standardize on assistantBuilderState to have non nullable types (default always present) to make code easier

## Risk

Can break assistant configuration. Thorough testing of all actions has been done in dev

## Deploy Plan

- deploy `front`