### PR TITLE
feat(multi actions): add use-tools dust app

### DIFF
--- a/front/lib/api/assistant/actions/dust_app_run.ts
+++ b/front/lib/api/assistant/actions/dust_app_run.ts
@@ -54,10 +54,17 @@ export function renderDustAppRunActionForModel(
  * Params generation.
  */
 
-export async function dustAppRunActionSpecification(
-  app: AppType,
-  schema: DatasetSchema | null
-): Promise<Result<AgentActionSpecification, Error>> {
+async function dustAppRunActionSpecification({
+  app,
+  schema,
+  name,
+  description,
+}: {
+  app: AppType;
+  schema: DatasetSchema | null;
+  name?: string;
+  description?: string;
+}): Promise<Result<AgentActionSpecification, Error>> {
   const appName = app.name;
   const appDescription = app.description;
 
@@ -93,8 +100,8 @@ export async function dustAppRunActionSpecification(
   }
 
   return new Ok({
-    name: appName,
-    description: appDescription || "",
+    name: name ?? appName,
+    description: description ?? appDescription ?? "",
     inputs,
   });
 }
@@ -104,8 +111,12 @@ export async function generateDustAppRunSpecification(
   auth: Authenticator,
   {
     actionConfiguration,
+    name,
+    description,
   }: {
     actionConfiguration: DustAppRunConfigurationType;
+    name?: string;
+    description?: string;
   }
 ): Promise<Result<AgentActionSpecification, Error>> {
   const owner = auth.workspace();
@@ -159,7 +170,7 @@ export async function generateDustAppRunSpecification(
     }
   }
 
-  return dustAppRunActionSpecification(app, schema);
+  return dustAppRunActionSpecification({ app, schema, name, description });
 }
 
 /**

--- a/front/lib/api/assistant/actions/process.ts
+++ b/front/lib/api/assistant/actions/process.ts
@@ -66,20 +66,24 @@ export function renderProcessActionForModel(
  * Params generation.
  */
 
-export async function processActionSpecification(
-  configuration: ProcessConfigurationType
-): Promise<AgentActionSpecification> {
+async function processActionSpecification({
+  actionConfiguration,
+  name,
+  description,
+}: {
+  actionConfiguration: ProcessConfigurationType;
+  name: string;
+  description: string;
+}): Promise<AgentActionSpecification> {
   const inputs = [];
 
-  if (configuration.relativeTimeFrame === "auto") {
+  if (actionConfiguration.relativeTimeFrame === "auto") {
     inputs.push(retrievalAutoTimeFrameInputSpecification());
   }
 
   return {
-    name: "process_data_sources",
-    description:
-      "Process data sources specified by the user by performing a search and extracting" +
-      " structured information (complying to a fixed schema) from the retrieved information.",
+    name,
+    description,
     inputs,
   };
 }
@@ -89,8 +93,12 @@ export async function generateProcessSpecification(
   auth: Authenticator,
   {
     actionConfiguration,
+    name = "process_data_sources",
+    description,
   }: {
     actionConfiguration: ProcessConfigurationType;
+    name?: string;
+    description?: string;
   }
 ): Promise<Result<AgentActionSpecification, Error>> {
   const owner = auth.workspace();
@@ -98,7 +106,14 @@ export async function generateProcessSpecification(
     throw new Error("Unexpected unauthenticated call to `runRetrieval`");
   }
 
-  const spec = await processActionSpecification(actionConfiguration);
+  const spec = await processActionSpecification({
+    actionConfiguration,
+    name,
+    description:
+      description ??
+      "Process data sources specified by the user by performing a search and extracting" +
+        " structured information (complying to a fixed schema) from the retrieved information.",
+  });
   return new Ok(spec);
 }
 

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -173,24 +173,27 @@ export function retrievalAutoTimeFrameInputSpecification() {
   };
 }
 
-export async function retrievalActionSpecification(
-  configuration: RetrievalConfigurationType
-): Promise<AgentActionSpecification> {
+function retrievalActionSpecification({
+  actionConfiguration,
+  name,
+  description,
+}: {
+  actionConfiguration: RetrievalConfigurationType;
+  name: string;
+  description: string;
+}): AgentActionSpecification {
   const inputs = [];
 
-  if (configuration.query === "auto") {
+  if (actionConfiguration.query === "auto") {
     inputs.push(retrievalAutoQueryInputSpecification());
   }
-  if (configuration.relativeTimeFrame === "auto") {
+  if (actionConfiguration.relativeTimeFrame === "auto") {
     inputs.push(retrievalAutoTimeFrameInputSpecification());
   }
 
   return {
-    name: "search_data_sources",
-    description:
-      "Search the data sources specified by the user for information to answer their request." +
-      " The search is based on semantic similarity between the query and chunks of information" +
-      " from the data sources.",
+    name,
+    description,
     inputs,
   };
 }
@@ -200,7 +203,11 @@ export async function generateRetrievalSpecification(
   auth: Authenticator,
   {
     actionConfiguration,
+    name = "search_data_sources",
+    description,
   }: {
+    name?: string;
+    description?: string;
     actionConfiguration: RetrievalConfigurationType;
   }
 ): Promise<Result<AgentActionSpecification, Error>> {
@@ -209,7 +216,15 @@ export async function generateRetrievalSpecification(
     throw new Error("Unexpected unauthenticated call to `runRetrieval`");
   }
 
-  const spec = await retrievalActionSpecification(actionConfiguration);
+  const spec = retrievalActionSpecification({
+    actionConfiguration,
+    name,
+    description:
+      description ??
+      "Search the data sources specified by the user for information to answer their request." +
+        " The search is based on semantic similarity between the query and chunks of information" +
+        " from the data sources.",
+  });
   return new Ok(spec);
 }
 

--- a/front/lib/api/assistant/actions/tables_query.ts
+++ b/front/lib/api/assistant/actions/tables_query.ts
@@ -49,11 +49,16 @@ export function renderTablesQueryActionForModel(
 
 // Generate the specification for the TablesQuery app. This is the instruction given to the LLM to
 // understand the task.
-async function tablesQueryActionSpecification(): Promise<AgentActionSpecification> {
+async function tablesQueryActionSpecification({
+  name,
+  description,
+}: {
+  name: string;
+  description: string;
+}): Promise<AgentActionSpecification> {
   return {
-    name: "query_tables",
-    description:
-      "Generates a SQL query from a question in plain language, executes the generated query and return the results.",
+    name,
+    description,
     inputs: [
       {
         name: "question",
@@ -67,14 +72,18 @@ async function tablesQueryActionSpecification(): Promise<AgentActionSpecificatio
 
 // Generates the action specification for generation of rawInputs passed to `runTablesQuery`.
 export async function generateTablesQuerySpecification(
-  auth: Authenticator
+  auth: Authenticator,
+  {
+    name = "query_tables",
+    description = "Generates a SQL query from a question in plain language, executes the generated query and return the results.",
+  }: { name?: string; description?: string } = {}
 ): Promise<Result<AgentActionSpecification, Error>> {
   const owner = auth.workspace();
   if (!owner) {
     throw new Error("Unexpected unauthenticated call to `runQueryTables`");
   }
 
-  const spec = await tablesQueryActionSpecification();
+  const spec = await tablesQueryActionSpecification({ name, description });
   return new Ok(spec);
 }
 

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -1,20 +1,45 @@
 import type {
+  AgentActionConfigurationType,
   AgentActionEvent,
+  AgentActionSpecification,
   AgentActionSuccessEvent,
   AgentConfigurationType,
   AgentErrorEvent,
   AgentGenerationCancelledEvent,
+  AgentGenerationConfigurationType,
   AgentGenerationSuccessEvent,
   AgentMessageSuccessEvent,
   AgentMessageType,
   ConversationType,
   GenerationTokensEvent,
   LightAgentConfigurationType,
+  Result,
   UserMessageType,
 } from "@dust-tt/types";
-import { removeNulls } from "@dust-tt/types";
+import {
+  assertNever,
+  cloneBaseConfig,
+  DustProdActionRegistry,
+  Err,
+  GPT_4_TURBO_MODEL_CONFIG,
+  isDustAppRunConfiguration,
+  isProcessConfiguration,
+  isRetrievalConfiguration,
+  isTablesQueryConfiguration,
+  Ok,
+  removeNulls,
+} from "@dust-tt/types";
 
+import { runActionStreamed } from "@app/lib/actions/server";
+import { generateDustAppRunSpecification } from "@app/lib/api/assistant/actions/dust_app_run";
+import { generateProcessSpecification } from "@app/lib/api/assistant/actions/process";
+import { generateRetrievalSpecification } from "@app/lib/api/assistant/actions/retrieval";
+import { generateTablesQuerySpecification } from "@app/lib/api/assistant/actions/tables_query";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
+import {
+  constructPrompt,
+  renderConversationForModel,
+} from "@app/lib/api/assistant/generation";
 import { runLegacyAgent } from "@app/lib/api/assistant/legacy_agent";
 import type { Authenticator } from "@app/lib/auth";
 
@@ -77,4 +102,182 @@ function isLegacyAgent(configuration: AgentConfigurationType): boolean {
     ) &&
     actions.every((a) => a.forceUseAtIteration !== undefined)
   );
+}
+
+// This method is used by the multi-actions execution loop to pick the next action
+// to execute and generate its inputs.
+export async function getNextAction(
+  auth: Authenticator,
+  configuration: AgentConfigurationType,
+  conversation: ConversationType,
+  userMessage: UserMessageType
+): Promise<
+  Result<
+    {
+      action: AgentActionConfigurationType | AgentGenerationConfigurationType;
+      inputs: Record<string, string | boolean | number>;
+    },
+    Error
+  >
+> {
+  const prompt = await constructPrompt(
+    auth,
+    userMessage,
+    configuration,
+    "You are a conversational assistant with access to function calling."
+  );
+
+  // TODO(@fontanierh): revisit
+  const model = GPT_4_TURBO_MODEL_CONFIG;
+
+  const MIN_GENERATION_TOKENS = 2048;
+
+  // Turn the conversation into a digest that can be presented to the model.
+  const modelConversationRes = await renderConversationForModel({
+    conversation,
+    model,
+    prompt,
+    allowedTokenCount: model.contextSize - MIN_GENERATION_TOKENS,
+  });
+
+  if (modelConversationRes.isErr()) {
+    return modelConversationRes;
+  }
+
+  const specifications: AgentActionSpecification[] = [];
+  for (const a of configuration.actions) {
+    if (isRetrievalConfiguration(a)) {
+      const r = await generateRetrievalSpecification(auth, {
+        actionConfiguration: a,
+        name: a.name ?? undefined,
+        description: a.description ?? undefined,
+      });
+
+      if (r.isErr()) {
+        return r;
+      }
+
+      specifications.push(r.value);
+    } else if (isDustAppRunConfiguration(a)) {
+      const r = await generateDustAppRunSpecification(auth, {
+        actionConfiguration: a,
+        name: a.name ?? undefined,
+        description: a.description ?? undefined,
+      });
+
+      if (r.isErr()) {
+        return r;
+      }
+
+      specifications.push(r.value);
+    } else if (isTablesQueryConfiguration(a)) {
+      const r = await generateTablesQuerySpecification(auth, {
+        name: a.name ?? undefined,
+        description: a.description ?? undefined,
+      });
+
+      if (r.isErr()) {
+        return r;
+      }
+
+      specifications.push(r.value);
+    } else if (isProcessConfiguration(a)) {
+      const r = await generateProcessSpecification(auth, {
+        actionConfiguration: a,
+        name: a.name ?? undefined,
+        description: a.description ?? undefined,
+      });
+
+      if (r.isErr()) {
+        return r;
+      }
+
+      specifications.push(r.value);
+    } else {
+      assertNever(a);
+    }
+  }
+
+  specifications.push({
+    name: "reply_to_user",
+    description:
+      "Reply to the user with a message. You don't need to generate any arguments for this function.",
+    inputs: [],
+  });
+
+  const config = cloneBaseConfig(
+    DustProdActionRegistry["assistant-v2-use-tools"].config
+  );
+  config.MODEL.function_call = "auto";
+  config.MODEL.provider_id = model.providerId;
+  config.MODEL.model_id = model.modelId;
+
+  const res = await runActionStreamed(auth, "assistant-v2-use-tools", config, [
+    {
+      conversation: modelConversationRes.value.modelConversation,
+      specifications,
+      prompt,
+    },
+  ]);
+
+  if (res.isErr()) {
+    return new Err(
+      new Error(
+        `Error running use-tools action: [${res.error.type}] ${res.error.message}`
+      )
+    );
+  }
+
+  const { eventStream } = res.value;
+
+  const output: {
+    name?: string;
+    arguments?: Record<string, string | boolean | number>;
+  } = {};
+
+  for await (const event of eventStream) {
+    if (event.type === "error") {
+      return new Err(
+        new Error(`Error generating action inputs: ${event.content.message}`)
+      );
+    }
+
+    if (event.type === "block_execution") {
+      const e = event.content.execution[0][0];
+      if (e.error) {
+        return new Err(new Error(`Error generating action inputs: ${e.error}`));
+      }
+
+      if (event.content.block_name === "OUTPUT" && e.value) {
+        const v = e.value as any;
+        if (Array.isArray(v)) {
+          const first = v[0];
+          if ("name" in first) {
+            output.name = first.name;
+          }
+          if ("arguments" in first) {
+            output.arguments = first.arguments;
+          }
+        }
+      }
+    }
+  }
+
+  if (!output.name) {
+    return new Err(new Error("No action found"));
+  }
+  output.arguments = output.arguments ?? {};
+
+  const action =
+    output.name === "reply_to_user"
+      ? configuration.generation
+      : configuration.actions.find((a) => a.name === output.name);
+  if (!action) {
+    return new Err(new Error(`Action ${output.name} not found`));
+  }
+
+  return new Ok({
+    action,
+    inputs: output.arguments,
+  });
 }

--- a/types/src/front/lib/actions/registry.ts
+++ b/types/src/front/lib/actions/registry.ts
@@ -1,5 +1,5 @@
 import { DustAppType } from "../../../front/lib/dust_api";
-import { GPT_4_TURBO_MODEL_CONFIG, GPT_4_TURBO_MODEL_ID } from "../assistant";
+import { GPT_4_TURBO_MODEL_CONFIG } from "../assistant";
 
 const PRODUCTION_DUST_APPS_WORKSPACE_ID = "78bda07b39";
 
@@ -224,7 +224,7 @@ export const DustProdActionRegistry = createActionRegistry({
     config: {
       MODEL: {
         provider_id: "openai",
-        model_id: GPT_4_TURBO_MODEL_ID,
+        model_id: GPT_4_TURBO_MODEL_CONFIG.modelId,
         function_call: "auto",
         use_cache: false,
       },

--- a/types/src/front/lib/actions/registry.ts
+++ b/types/src/front/lib/actions/registry.ts
@@ -1,5 +1,5 @@
 import { DustAppType } from "../../../front/lib/dust_api";
-import { GPT_4_TURBO_MODEL_CONFIG } from "../assistant";
+import { GPT_4_TURBO_MODEL_CONFIG, GPT_4_TURBO_MODEL_ID } from "../assistant";
 
 const PRODUCTION_DUST_APPS_WORKSPACE_ID = "78bda07b39";
 
@@ -210,6 +210,22 @@ export const DustProdActionRegistry = createActionRegistry({
         provider_id: "openai",
         model_id: "gpt-3.5-turbo",
         function_call: "send_suggestions",
+        use_cache: false,
+      },
+    },
+  },
+  "assistant-v2-use-tools": {
+    app: {
+      workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
+      appId: "0e9889c787",
+      appHash:
+        "e2be0e5ee990a6ef86d1a89c8b55f924ff93dd6daaa0a502984d63b159c65ffd",
+    },
+    config: {
+      MODEL: {
+        provider_id: "openai",
+        model_id: GPT_4_TURBO_MODEL_ID,
+        function_call: "auto",
         use_cache: false,
       },
     },


### PR DESCRIPTION
## Description

https://github.com/dust-tt/dust/issues/4602


This PR adds the new "use-tools" dust app (https://dust.tt/w/78bda07b39/a/0e9889c787), which is similar to generate-inputs except that it also picks what tool to use. Also added a small function that calls the dust app (had to write it to test the dust app)

Right now, it kind of expects a generation config (otherwise we won't have a "reply to user" action and it will be confusing for the model).

But all of this will get fine-tuned once we have a proper loop 👍 

## Risk

Some critical path stuff, but overall well tested (including the new unused dust app) and works well.

## Deploy Plan

N/A