### PR TITLE
Webcrawler scheduler does not wait for child workflows

### DIFF
--- a/connectors/src/connectors/webcrawler/temporal/workflows.ts
+++ b/connectors/src/connectors/webcrawler/temporal/workflows.ts
@@ -2,8 +2,9 @@ import type { ModelId } from "@dust-tt/types";
 import {
   ActivityCancellationType,
   CancellationScope,
-  executeChild,
+  ParentClosePolicy,
   proxyActivities,
+  startChild,
   workflowInfo,
 } from "@temporalio/workflow";
 
@@ -50,12 +51,14 @@ export async function crawlWebsiteSchedulerWorkflow() {
   const connectorIds = await getConnectorIdsForWebsitesToCrawl();
 
   for (const connectorId of connectorIds) {
-    await executeChild(crawlWebsiteWorkflow, {
+    // Start a workflow to crawl the website but don't wait for it to complete.
+    await startChild(crawlWebsiteWorkflow, {
       workflowId: crawlWebsiteWorkflowId(connectorId),
       searchAttributes: {
         connectorId: [connectorId],
       },
       args: [connectorId],
+      parentClosePolicy: ParentClosePolicy.PARENT_CLOSE_POLICY_ABANDON,
       memo: workflowInfo().memo,
     });
   }


### PR DESCRIPTION
## Description

Make the webcrawler scheduler who is in charge of starting the Webcrawler workflows every day / week / month not wait
on its child workflows.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
