### PR TITLE
Dividing webcrawler concurrency by 8

### DIFF
--- a/connectors/src/connectors/webcrawler/temporal/worker.ts
+++ b/connectors/src/connectors/webcrawler/temporal/worker.ts
@@ -20,7 +20,7 @@ export async function runWebCrawlerWorker() {
     connection,
     reuseV8Context: true,
     namespace,
-    maxConcurrentActivityTaskExecutions: 16,
+    maxConcurrentActivityTaskExecutions: 2,
     maxCachedWorkflows: TEMPORAL_MAXED_CACHED_WORKFLOWS,
     interceptors: {
       activityInbound: [


### PR DESCRIPTION
## Description
Dividing webcrawler concurrency by 8 to lower the load on QDrant after re-syncing a lot of websites (due to the webcrawler-scheduler being down for a while).

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
