### PR TITLE
Adding max messages timeframe to Poke

### DIFF
--- a/types/src/front/plan.ts
+++ b/types/src/front/plan.ts
@@ -2,7 +2,14 @@ import * as t from "io-ts";
 import { NonEmptyString } from "io-ts-types/lib/NonEmptyString";
 import { NumberFromString } from "io-ts-types/lib/NumberFromString";
 
-export type MaxMessagesTimeframeType = "day" | "lifetime";
+export const MAX_MESSAGE_TIMEFRAMES = ["day", "lifetime"] as const;
+export type MaxMessagesTimeframeType = (typeof MAX_MESSAGE_TIMEFRAMES)[number];
+
+export function isMaxMessagesTimeframeType(
+  value: string
+): value is MaxMessagesTimeframeType {
+  return (MAX_MESSAGE_TIMEFRAMES as unknown as string[]).includes(value);
+}
 
 /**
  *  Expresses limits for usage of the product


### PR DESCRIPTION
## Description

Adding max messages timeframe to Poke.
The goal is then to set all plans to 100 message / day / seat, as agreed on [this](https://dust4ai.slack.com/archives/C050A0S2Z7F/p1714044340762209) Slack thread.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
