### PR TITLE
Assistant Builder post new model data

### DIFF
--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -833,6 +833,11 @@ export async function submitAssistantBuilderForm({
           model: builderState.generationSettings.modelSettings,
           temperature: builderState.generationSettings.temperature,
         },
+        model: {
+          modelId: builderState.generationSettings.modelSettings.modelId,
+          providerId: builderState.generationSettings.modelSettings.providerId,
+          temperature: builderState.generationSettings.temperature,
+        },
       },
     };
 

--- a/types/src/front/api_handlers/internal/agent_configuration.ts
+++ b/types/src/front/api_handlers/internal/agent_configuration.ts
@@ -2,7 +2,12 @@ import * as t from "io-ts";
 
 import { createRangeCodec } from "../../../shared/utils/iots_utils";
 import { TimeframeUnitCodec } from "../../assistant/actions/retrieval";
-import { isSupportedModel, SupportedModel } from "../../lib/assistant";
+import {
+  isSupportedModel,
+  ModelIdCodec,
+  ModelProviderIdCodec,
+  SupportedModel,
+} from "../../lib/assistant";
 
 const LimitCodec = createRangeCodec(0, 100);
 
@@ -176,6 +181,15 @@ const GenerationConfigurationSchema = t.union([
   ]),
 ]);
 
+const ModelConfigurationSchema = t.intersection([
+  t.type({
+    modelId: ModelIdCodec,
+    providerId: ModelProviderIdCodec,
+    temperature: t.number,
+  }),
+  t.partial(multiActionsCommonFields),
+]);
+
 export const PostOrPatchAgentConfigurationRequestBodySchema = t.intersection([
   t.type({
     assistant: t.intersection([
@@ -199,6 +213,7 @@ export const PostOrPatchAgentConfigurationRequestBodySchema = t.intersection([
       }),
       t.partial({
         maxToolsUsePerRun: t.number,
+        model: ModelConfigurationSchema,
       }),
     ]),
   }),

--- a/types/src/front/lib/assistant.ts
+++ b/types/src/front/lib/assistant.ts
@@ -1,4 +1,5 @@
 import { ExtractSpecificKeys } from "../../shared/typescipt_utils";
+import { ioTsEnum } from "../../shared/utils/iots_utils";
 
 /**
  * PROVIDER IDS
@@ -16,6 +17,8 @@ export const isModelProviderId = (
   providerId: string
 ): providerId is ModelProviderIdType =>
   MODEL_PROVIDER_IDS.includes(providerId as ModelProviderIdType);
+
+export const ModelProviderIdCodec = ioTsEnum(MODEL_PROVIDER_IDS);
 
 /**
  * MODEL IDS
@@ -52,6 +55,8 @@ export type ModelIdType = (typeof MODEL_IDS)[number];
 
 export const isModelId = (modelId: string): modelId is ModelIdType =>
   MODEL_IDS.includes(modelId as ModelIdType);
+
+export const ModelIdCodec = ioTsEnum(MODEL_IDS);
 
 /**
  * MODEL CONFIGURATIONS


### PR DESCRIPTION
## Description

Following https://github.com/dust-tt/dust/pull/4849

Editing schema of `PostOrPatchAgentConfigurationRequestBodySchema` to add the model data where it will be expected, so that then we can then cleanup `AgentGenerationConfiguration` without breaking for users. 

<img width="441" alt="Screenshot 2024-04-25 at 15 48 06" src="https://github.com/dust-tt/dust/assets/3803406/64e9c7c9-4c8b-4dcf-9c88-11035c0938a9">


## Risk

/

## Deploy Plan

/ 
