### PR TITLE
AssistantBuilder: Process Action take I

### DIFF
--- a/front/components/assistant/TryAssistant.tsx
+++ b/front/components/assistant/TryAssistant.tsx
@@ -218,6 +218,7 @@ export function usePreviewAssistant({
         retrievalConfiguration: builderState.retrievalConfiguration,
         dustAppConfiguration: builderState.dustAppConfiguration,
         tablesQueryConfiguration: builderState.tablesQueryConfiguration,
+        processConfiguration: builderState.processConfiguration,
         scope: "private",
         generationSettings: builderState.generationSettings,
       },
@@ -247,6 +248,7 @@ export function usePreviewAssistant({
     builderState.tablesQueryConfiguration,
     builderState.dustAppConfiguration,
     builderState.retrievalConfiguration,
+    builderState.processConfiguration,
   ]);
 
   useEffect(() => {

--- a/front/components/assistant_builder/ActionScreen.tsx
+++ b/front/components/assistant_builder/ActionScreen.tsx
@@ -47,6 +47,7 @@ const SEARCH_MODES = [
   "RETRIEVAL_SEARCH",
   "RETRIEVAL_EXHAUSTIVE",
   "TABLES_QUERY",
+  "PROCESS_DATA",
 ] as const;
 type SearchMode = (typeof SEARCH_MODES)[number];
 
@@ -108,6 +109,14 @@ const SEARCH_MODE_SPECIFICATIONS: Record<
     icon: TableIcon,
     label: "Query Tables",
     description: "Tables, Spreadsheets, Notion DBs",
+    flag: null,
+  },
+  PROCESS_DATA: {
+    actionMode: "PROCESS",
+    icon: TimeIcon,
+    label: "Process data",
+    description: "Structured extraction",
+    // flag: "process_action",
     flag: null,
   },
 };
@@ -179,6 +188,7 @@ export default function ActionScreen({
       case "RETRIEVAL_EXHAUSTIVE":
       case "RETRIEVAL_SEARCH":
       case "TABLES_QUERY":
+      case "PROCESS":
         return "USE_DATA_SOURCES";
       case "DUST_APP_RUN":
         return "RUN_DUST_APP";
@@ -195,9 +205,15 @@ export default function ActionScreen({
         return "RETRIEVAL_SEARCH";
       case "TABLES_QUERY":
         return "TABLES_QUERY";
-      default:
+      case "PROCESS":
+        return "PROCESS_DATA";
+
+      case "GENERIC":
+      case "DUST_APP_RUN":
         // Unused for non data sources related actions.
-        return "RETRIEVAL_EXHAUSTIVE";
+        return "RETRIEVAL_SEARCH";
+      default:
+        assertNever(actionMode);
     }
   };
 
@@ -551,6 +567,100 @@ export default function ActionScreen({
                                   .value,
                               unit: key as TimeframeUnit,
                             },
+                          },
+                        }));
+                      }}
+                    />
+                  )
+                )}
+              </DropdownMenu.Items>
+            </DropdownMenu>
+          </div>
+        </ActionModeSection>
+
+        <ActionModeSection
+          show={builderState.actionMode === "PROCESS" && !noDataSources}
+        >
+          <div className="text-sm text-element-700">
+            The assistant will process the data sources over the specified time
+            frame and attempt to extract structured information based on the
+            schema provided. This action can process up to 500k tokens (the
+            equivalent of 1000 pages book). Learn more about this feature in the{" "}
+            <Hoverable
+              onClick={() => {
+                window.open(
+                  "https://dust-tt.notion.site/Table-queries-on-Dust-2f8c6ea53518464b8b7780d55ac7057d",
+                  "_blank"
+                );
+              }}
+              className="cursor-pointer font-bold text-action-500"
+            >
+              documentation
+            </Hoverable>
+            .
+          </div>
+
+          <DataSourceSelectionSection
+            owner={owner}
+            dataSourceConfigurations={builderState.dataSourceConfigurations}
+            openDataSourceModal={() => {
+              setShowDataSourcesModal(true);
+            }}
+            canAddDataSource={dataSources.length > 0}
+            onDelete={deleteDataSource}
+          />
+
+          <div className={"flex flex-row items-center gap-4 pb-4"}>
+            <div className="text-sm font-semibold text-element-900">
+              Process data from the last
+            </div>
+            <input
+              type="text"
+              className={classNames(
+                "h-8 w-16 rounded-md border-gray-300 text-center text-sm",
+                !timeFrameError
+                  ? "focus:border-action-500 focus:ring-action-500"
+                  : "border-red-500 focus:border-red-500 focus:ring-red-500",
+                "bg-structure-50 stroke-structure-50"
+              )}
+              value={builderState.timeFrame.value || ""}
+              onChange={(e) => {
+                const value = parseInt(e.target.value, 10);
+                if (!isNaN(value) || !e.target.value) {
+                  setEdited(true);
+                  setBuilderState((state) => ({
+                    ...state,
+                    timeFrame: {
+                      value,
+                      unit: builderState.timeFrame.unit,
+                    },
+                  }));
+                }
+              }}
+            />
+            <DropdownMenu>
+              <DropdownMenu.Button tooltipPosition="above">
+                <Button
+                  type="select"
+                  labelVisible={true}
+                  label={TIME_FRAME_UNIT_TO_LABEL[builderState.timeFrame.unit]}
+                  variant="secondary"
+                  size="sm"
+                />
+              </DropdownMenu.Button>
+              <DropdownMenu.Items origin="bottomLeft">
+                {Object.entries(TIME_FRAME_UNIT_TO_LABEL).map(
+                  ([key, value]) => (
+                    <DropdownMenu.Item
+                      key={key}
+                      label={value}
+                      onClick={() => {
+                        setEdited(true);
+                        setBuilderState((state) => ({
+                          ...state,
+                          timeFrame: {
+                            value: builderState.timeFrame.value,
+                            unit: key as TimeframeUnit,
                           },
                         }));
                       }}

--- a/front/components/assistant_builder/ActionScreen.tsx
+++ b/front/components/assistant_builder/ActionScreen.tsx
@@ -47,7 +47,7 @@ const SEARCH_MODES = [
   "RETRIEVAL_SEARCH",
   "RETRIEVAL_EXHAUSTIVE",
   "TABLES_QUERY",
-  "PROCESS_DATA",
+  "PROCESS",
 ] as const;
 type SearchMode = (typeof SEARCH_MODES)[number];
 
@@ -111,7 +111,7 @@ const SEARCH_MODE_SPECIFICATIONS: Record<
     description: "Tables, Spreadsheets, Notion DBs",
     flag: null,
   },
-  PROCESS_DATA: {
+  PROCESS: {
     actionMode: "PROCESS",
     icon: TimeIcon,
     label: "Process data",
@@ -228,7 +228,7 @@ export default function ActionScreen({
       case "TABLES_QUERY":
         return "TABLES_QUERY";
       case "PROCESS":
-        return "PROCESS_DATA";
+        return "PROCESS";
 
       case "GENERIC":
       case "DUST_APP_RUN":

--- a/front/components/assistant_builder/ActionScreen.tsx
+++ b/front/components/assistant_builder/ActionScreen.tsx
@@ -116,8 +116,7 @@ const SEARCH_MODE_SPECIFICATIONS: Record<
     icon: TimeIcon,
     label: "Process data",
     description: "Structured extraction",
-    // flag: "process_action",
-    flag: null,
+    flag: "process_action",
   },
 };
 

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -279,7 +279,7 @@ export default function AssistantBuilder({
     } else if (isTablesQueryConfiguration(action)) {
       actionMode = "TABLES_QUERY";
     } else if (isProcessConfiguration(action)) {
-      // Not supported in the builder yet.
+      actionMode = "PROCESS";
     }
 
     if (actionMode !== null) {

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -813,10 +813,37 @@ export async function submitAssistantBuilderForm({
       }
       break;
 
+    case "PROCESS":
+      actionParam = {
+        type: "process_configuration",
+        relativeTimeFrame: {
+          duration: builderState.timeFrame.value,
+          unit: builderState.timeFrame.unit,
+        },
+        dataSources: Object.values(builderState.dataSourceConfigurations).map(
+          ({ dataSource, selectedResources, isSelectAll }) => ({
+            dataSourceId: dataSource.name,
+            workspaceId: owner.sId,
+            filter: {
+              parents: !isSelectAll
+                ? {
+                    in: selectedResources.map(
+                      (resource) => resource.internalId
+                    ),
+                    not: [],
+                  }
+                : null,
+              tags: null,
+            },
+          })
+        ),
+        // TODO(spolu): builderState schema
+        schema: [],
+      };
+      break;
+
     default:
-      ((x: never) => {
-        throw new Error(`Unknown data source mode ${x}`);
-      })(builderState.actionMode);
+      assertNever(builderState.actionMode);
   }
 
   const body: t.TypeOf<typeof PostOrPatchAgentConfigurationRequestBodySchema> =

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -838,7 +838,7 @@ export async function submitAssistantBuilderForm({
           unit: builderState.processConfiguration.timeFrame.unit,
         },
         dataSources: Object.values(
-          builderState.retrievalConfiguration.dataSourceConfigurations
+          builderState.processConfiguration.dataSourceConfigurations
         ).map(({ dataSource, selectedResources, isSelectAll }) => ({
           dataSourceId: dataSource.name,
           workspaceId: owner.sId,
@@ -872,11 +872,6 @@ export async function submitAssistantBuilderForm({
         actions: removeNulls([actionParam]),
         generation: {
           model: builderState.generationSettings.modelSettings,
-          temperature: builderState.generationSettings.temperature,
-        },
-        model: {
-          modelId: builderState.generationSettings.modelSettings.modelId,
-          providerId: builderState.generationSettings.modelSettings.providerId,
           temperature: builderState.generationSettings.temperature,
         },
       },

--- a/front/components/assistant_builder/DataSourceSelectionSection.tsx
+++ b/front/components/assistant_builder/DataSourceSelectionSection.tsx
@@ -53,9 +53,9 @@ export default function DataSourceSelectionSection({
         }}
       />
 
-      <div className="overflow-hidden pt-6">
+      <div className="overflow-hidden pt-4">
         <div className="flex flex-row items-start">
-          <div className="flex-grow text-sm font-semibold text-element-900">
+          <div className="flex-grow pb-2 text-sm font-semibold text-element-900">
             Selected Data sources:
           </div>
           <div>

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -14,6 +14,7 @@ export const ACTION_MODES = [
   "RETRIEVAL_EXHAUSTIVE",
   "DUST_APP_RUN",
   "TABLES_QUERY",
+  "PROCESS",
 ] as const;
 
 export type ActionMode = (typeof ACTION_MODES)[number];

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -3,6 +3,7 @@ import type {
   AppType,
   ContentNode,
   DataSourceType,
+  ProcessSchemaPropertyType,
   SupportedModel,
   TimeframeUnit,
 } from "@dust-tt/types";
@@ -32,12 +33,14 @@ export type AssistantBuilderDataSourceConfigurations = Record<
   AssistantBuilderDataSourceConfiguration
 >;
 
+export type AssistantBuilderTimeFrame = {
+  value: number;
+  unit: TimeframeUnit;
+};
+
 export type AssistantBuilderRetrievalConfiguration = {
   dataSourceConfigurations: AssistantBuilderDataSourceConfigurations;
-  timeFrame: {
-    value: number;
-    unit: TimeframeUnit;
-  };
+  timeFrame: AssistantBuilderTimeFrame;
 };
 
 // DustAppRun configuration
@@ -61,7 +64,16 @@ export type AssistantBuilderTablesQueryConfiguration = Record<
   AssistantBuilderTableConfiguration
 >;
 
+// Process configuration
+
+export type AssistantBuilderProcessConfiguration = {
+  dataSourceConfigurations: AssistantBuilderDataSourceConfigurations;
+  timeFrame: AssistantBuilderTimeFrame;
+  schema: ProcessSchemaPropertyType[];
+};
+
 // Builder State
+
 export type AssistantBuilderState = {
   handle: string | null;
   description: string | null;
@@ -79,6 +91,7 @@ export type AssistantBuilderState = {
   retrievalConfiguration: AssistantBuilderRetrievalConfiguration;
   dustAppConfiguration: AssistantBuilderDustAppConfiguration;
   tablesQueryConfiguration: AssistantBuilderTablesQueryConfiguration;
+  processConfiguration: AssistantBuilderProcessConfiguration;
 };
 
 export type AssistantBuilderInitialState = {
@@ -96,6 +109,7 @@ export type AssistantBuilderInitialState = {
   retrievalConfiguration: AssistantBuilderState["retrievalConfiguration"];
   dustAppConfiguration: AssistantBuilderState["dustAppConfiguration"];
   tablesQueryConfiguration: AssistantBuilderState["tablesQueryConfiguration"];
+  processConfiguration: AssistantBuilderState["processConfiguration"];
 };
 
 export const DEFAULT_ASSISTANT_STATE: AssistantBuilderState = {
@@ -109,6 +123,14 @@ export const DEFAULT_ASSISTANT_STATE: AssistantBuilderState = {
   },
   dustAppConfiguration: { app: null },
   tablesQueryConfiguration: {},
+  processConfiguration: {
+    dataSourceConfigurations: {},
+    timeFrame: {
+      value: 1,
+      unit: "day",
+    },
+    schema: [],
+  },
   handle: null,
   scope: "private",
   description: null,

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -1452,8 +1452,6 @@ async function _createAgentDataSourcesConfigData(
       })
     );
 
-  console.log("HERE");
-
   return agentDataSourcesConfigRows;
 }
 

--- a/front/migrations/20240425_remove_non_null_on_data_source_configurations.sql
+++ b/front/migrations/20240425_remove_non_null_on_data_source_configurations.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "agent_data_source_configurations" ALTER COLUMN "retrievalConfigurationId" DROP NOT NULL;

--- a/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
@@ -74,8 +74,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     };
   }
 
-  console.log(configuration);
-
   if (!configuration) {
     return {
       notFound: true,

--- a/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
@@ -8,6 +8,7 @@ import type {
 } from "@dust-tt/types";
 import {
   isDustAppRunConfiguration,
+  isProcessConfiguration,
   isRetrievalConfiguration,
   isTablesQueryConfiguration,
 } from "@dust-tt/types";
@@ -37,6 +38,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   retrievalConfiguration: AssistantBuilderInitialState["retrievalConfiguration"];
   dustAppConfiguration: AssistantBuilderInitialState["dustAppConfiguration"];
   tablesQueryConfiguration: AssistantBuilderInitialState["tablesQueryConfiguration"];
+  processConfiguration: AssistantBuilderInitialState["processConfiguration"];
   agentConfiguration: AgentConfigurationType;
   flow: BuilderFlow;
   baseUrl: string;
@@ -72,6 +74,8 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     };
   }
 
+  console.log(configuration);
+
   if (!configuration) {
     return {
       notFound: true,
@@ -90,6 +94,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     retrievalConfiguration,
     dustAppConfiguration,
     tablesQueryConfiguration,
+    processConfiguration,
   } = await buildInitialState({
     configuration,
     dataSourcesByName,
@@ -107,6 +112,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       retrievalConfiguration,
       dustAppConfiguration,
       tablesQueryConfiguration,
+      processConfiguration,
       agentConfiguration: configuration,
       flow,
       baseUrl: URL,
@@ -124,6 +130,7 @@ export default function EditAssistant({
   retrievalConfiguration,
   dustAppConfiguration,
   tablesQueryConfiguration,
+  processConfiguration,
   agentConfiguration,
   flow,
   baseUrl,
@@ -157,6 +164,20 @@ export default function EditAssistant({
   if (isTablesQueryConfiguration(action)) {
     actionMode = "TABLES_QUERY";
   }
+
+  if (isProcessConfiguration(action)) {
+    if (
+      action.relativeTimeFrame === "auto" ||
+      action.relativeTimeFrame === "none"
+    ) {
+      /** Should never happen as not permitted for now. */
+      throw new Error(
+        "Invalid configuration: process must have a definite time frame"
+      );
+    }
+    actionMode = "PROCESS";
+  }
+
   if (agentConfiguration.scope === "global") {
     throw new Error("Cannot edit global assistant");
   }
@@ -175,6 +196,7 @@ export default function EditAssistant({
         retrievalConfiguration,
         dustAppConfiguration,
         tablesQueryConfiguration,
+        processConfiguration,
         scope: agentConfiguration.scope,
         handle: agentConfiguration.name,
         description: agentConfiguration.description,

--- a/front/pages/w/[wId]/builder/assistants/new.tsx
+++ b/front/pages/w/[wId]/builder/assistants/new.tsx
@@ -9,6 +9,7 @@ import type {
 } from "@dust-tt/types";
 import {
   isDustAppRunConfiguration,
+  isProcessConfiguration,
   isRetrievalConfiguration,
   isTablesQueryConfiguration,
 } from "@dust-tt/types";
@@ -51,6 +52,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   retrievalConfiguration: AssistantBuilderInitialState["retrievalConfiguration"];
   dustAppConfiguration: AssistantBuilderInitialState["dustAppConfiguration"];
   tablesQueryConfiguration: AssistantBuilderInitialState["tablesQueryConfiguration"];
+  processConfiguration: AssistantBuilderInitialState["processConfiguration"];
   agentConfiguration:
     | AgentConfigurationType
     | TemplateAgentConfigurationType
@@ -115,6 +117,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     retrievalConfiguration,
     dustAppConfiguration,
     tablesQueryConfiguration,
+    processConfiguration,
   } = configuration
     ? await buildInitialState({
         configuration,
@@ -126,6 +129,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
         dustAppConfiguration: DEFAULT_ASSISTANT_STATE.dustAppConfiguration,
         tablesQueryConfiguration:
           DEFAULT_ASSISTANT_STATE.tablesQueryConfiguration,
+        processConfiguration: DEFAULT_ASSISTANT_STATE.processConfiguration,
       };
 
   return {
@@ -139,6 +143,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       retrievalConfiguration,
       dustAppConfiguration,
       tablesQueryConfiguration,
+      processConfiguration,
       agentConfiguration: configuration,
       flow,
       baseUrl: config.getAppUrl(),
@@ -157,6 +162,7 @@ export default function CreateAssistant({
   retrievalConfiguration,
   dustAppConfiguration,
   tablesQueryConfiguration,
+  processConfiguration,
   agentConfiguration,
   flow,
   baseUrl,
@@ -196,6 +202,20 @@ export default function CreateAssistant({
     if (isTablesQueryConfiguration(action)) {
       actionMode = "TABLES_QUERY";
     }
+
+    if (isProcessConfiguration(action)) {
+      if (
+        action.relativeTimeFrame === "auto" ||
+        action.relativeTimeFrame === "none"
+      ) {
+        /** Should never happen as not permitted for now. */
+        throw new Error(
+          "Invalid configuration: process must have a definite time frame"
+        );
+      }
+      actionMode = "PROCESS";
+    }
+
     if (agentConfiguration.scope === "global") {
       throw new Error("Cannot edit global assistant");
     }
@@ -221,6 +241,7 @@ export default function CreateAssistant({
               retrievalConfiguration,
               dustAppConfiguration,
               tablesQueryConfiguration,
+              processConfiguration,
               scope:
                 agentConfiguration.scope !== "global"
                   ? agentConfiguration.scope

--- a/types/src/front/feature_flags.ts
+++ b/types/src/front/feature_flags.ts
@@ -5,6 +5,7 @@ export const WHITELISTABLE_FEATURES = [
   "labs_transcripts",
   "labs_extract",
   "multi_actions",
+  "process_action",
 ] as const;
 export type WhitelistableFeature = (typeof WHITELISTABLE_FEATURES)[number];
 export function isWhitelistableFeature(


### PR DESCRIPTION
## Description

Add base support for creating Process Action behind flag (disabled for everyone)

- Selection of dataSources
- Picking a TimeFrame

This is already a large PR so stopping for a first review here.

![Screenshot from 2024-04-25 17-13-35](https://github.com/dust-tt/dust/assets/15067/d53d489d-a07e-4b6d-8d17-a70475b31530)

Next steps: 
- Ability so specify a schema in AssistantBuilder (pure UI after this one)
- Assistant to auto-generate the schema based on Instructions

## Risk

N/A

## Deploy Plan

- deploy `front`