### PR TITLE
fix: agent scope change error

### DIFF
--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -88,7 +88,7 @@ export async function* runAgent(
 // This function returns true if the agent is a "legacy" agent with a forced schedule,
 // i.e it has a maxToolsUsePerRun <= 2, every possible iteration has a forced action,
 // and every tool is forced at a certain iteration.
-function isLegacyAgent(configuration: AgentConfigurationType): boolean {
+export function isLegacyAgent(configuration: AgentConfigurationType): boolean {
   // TODO(@fontanierh): change once generation is part of actions.
   const actions = removeNulls([
     ...configuration.actions,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/scope.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/scope.ts
@@ -4,6 +4,7 @@ import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import { isLegacyAgent } from "@app/lib/api/assistant/agent";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
 import { setAgentUserListStatus } from "@app/lib/api/assistant/user_relation";
 import { Authenticator, getSession } from "@app/lib/auth";
@@ -133,9 +134,7 @@ async function handler(
           status: assistant.status as AgentStatus,
         },
         agentConfigurationId: assistant.sId,
-        // Here we want to preserve whatever is in the exising configuration,
-        // so we don't want to use the legacySingleActionMode (which overwrites `forceUseAtIteration`)
-        legacySingleActionMode: false,
+        legacySingleActionMode: isLegacyAgent(assistant),
       });
       if (result.isErr()) {
         return apiError(req, res, {

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -312,11 +312,6 @@ export async function createOrUpgradeAgentConfiguration({
 
   if (legacySingleActionMode) {
     if (actions.length) {
-      if (actions[0].forceUseAtIteration || generation?.forceUseAtIteration) {
-        throw new Error(
-          "Explicit forceUseAtIteration is not supported in legacy mode."
-        );
-      }
       legacyForceSingleActionAtIteration = 0;
       legacyForceGenerationAtIteration = 1;
     } else {


### PR DESCRIPTION
## Description

I broke scope change for single action assistants (i.e all assistants currently) when adding the `name` requirement on actions.

With this change, changing the scope of an assistant will properly use the legacySingleAction mode.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
