### PR TITLE
Add runs_join index on block_execution

### DIFF
--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -415,7 +415,7 @@ pub const POSTGRES_TABLES: [&'static str; 14] = [
     );",
 ];
 
-pub const SQL_INDEXES: [&'static str; 21] = [
+pub const SQL_INDEXES: [&'static str; 22] = [
     "CREATE INDEX IF NOT EXISTS
        idx_specifications_project_created ON specifications (project, created);",
     "CREATE INDEX IF NOT EXISTS
@@ -435,6 +435,8 @@ pub const SQL_INDEXES: [&'static str; 21] = [
        idx_datasets_joins ON datasets_joins (dataset, point);",
     "CREATE INDEX IF NOT EXISTS
        idx_runs_joins ON runs_joins (run, block_execution);",
+    "CREATE INDEX IF NOT EXISTS
+       idx_runs_joins_block_execution ON runs_joins (block_execution);",
     "CREATE INDEX IF NOT EXISTS
        idx_cache_project_hash ON cache (project, hash);",
     "CREATE UNIQUE INDEX IF NOT EXISTS

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -435,8 +435,7 @@ pub const SQL_INDEXES: [&'static str; 22] = [
        idx_datasets_joins ON datasets_joins (dataset, point);",
     "CREATE INDEX IF NOT EXISTS
        idx_runs_joins ON runs_joins (run, block_execution);",
-    // TODO(2024-04-26 flav) Remove `CONCURRENTLY` once index has been created.
-    "CREATE INDEX CONCURRENTLY IF NOT EXISTS
+    "CREATE INDEX IF NOT EXISTS
        idx_runs_joins_block_execution ON runs_joins (block_execution);",
     "CREATE INDEX IF NOT EXISTS
        idx_cache_project_hash ON cache (project, hash);",

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -435,7 +435,8 @@ pub const SQL_INDEXES: [&'static str; 22] = [
        idx_datasets_joins ON datasets_joins (dataset, point);",
     "CREATE INDEX IF NOT EXISTS
        idx_runs_joins ON runs_joins (run, block_execution);",
-    "CREATE INDEX IF NOT EXISTS
+    // TODO(2024-04-26 flav) Remove `CONCURRENTLY` once index has been created.
+    "CREATE INDEX CONCURRENTLY IF NOT EXISTS
        idx_runs_joins_block_execution ON runs_joins (block_execution);",
     "CREATE INDEX IF NOT EXISTS
        idx_cache_project_hash ON cache (project, hash);",


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
We are encountering problems when trying to delete dust app runs and their associated resources, a process that relies on stored functions. In an attempt to manually replicate the function's behavior on the database, I encountered a road bump while trying to delete from the `runs_joins` table. The query in use is:
```
DELETE FROM runs_joins WHERE block_execution = ANY(block_exec_ids);
```

Currently, the `runs_joins` table only has one index:
```
    "CREATE INDEX IF NOT EXISTS
       idx_runs_joins ON runs_joins (run, block_execution);",
```

Regrettably, we cannot reverse the field order because the primary entry point to query this table is `run`. This pull request proposes the addition of the following index to streamline the deletion process:
```
    "CREATE INDEX IF NOT EXISTS
       idx_runs_joins_block_execution ON runs_joins (block_execution);",
```

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
The main risk lies around applying the index, in order to prevent any locks on the table, the index will be firstly created with `CONCURRENTLY` ([doc](https://www.postgresql.org/docs/current/sql-createindex.html#:~:text=Creating%20an%20index%20can%20interfere,single%20scan%20of%20the%20table.)). 

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
