### PR TITLE
Increase user_message.userContextProfilePictureUrl size to 2048 (from…

### DIFF
--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -213,7 +213,7 @@ UserMessage.init(
       allowNull: true,
     },
     userContextProfilePictureUrl: {
-      type: DataTypes.STRING,
+      type: DataTypes.STRING(2048),
       allowNull: true,
     },
   },

--- a/front/lib/models/user.ts
+++ b/front/lib/models/user.ts
@@ -86,7 +86,7 @@ User.init(
       allowNull: true,
     },
     imageUrl: {
-      type: DataTypes.TEXT,
+      type: DataTypes.STRING(2048),
       allowNull: true,
     },
     isDustSuperUser: {


### PR DESCRIPTION
Increase `user_message.userContextProfilePictureUrl` size to `2048` (from `256`).

We have a customer who just hit this bug because the URL avatar was taking 1031 characters.

Monitor [here](https://dust4ai.slack.com/archives/C05F84CFP0E/p1714133336948199).

## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
- deploy prod box
- front> initdb
- deploy front
<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
