### PR TITLE
Create getter for default assistant state

### DIFF
--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -60,7 +60,7 @@ import type {
   AssistantBuilderInitialState,
   AssistantBuilderState,
 } from "@app/components/assistant_builder/types";
-import { DEFAULT_ASSISTANT_STATE } from "@app/components/assistant_builder/types";
+import { getDefaultAssistantState } from "@app/components/assistant_builder/types";
 import { ConfirmContext } from "@app/components/Confirm";
 import AppLayout, { appLayoutBack } from "@app/components/sparkle/AppLayout";
 import {
@@ -213,7 +213,7 @@ export default function AssistantBuilder({
           instructions: initialBuilderState.instructions,
           avatarUrl: initialBuilderState.avatarUrl,
           generationSettings: initialBuilderState.generationSettings ?? {
-            ...DEFAULT_ASSISTANT_STATE.generationSettings,
+            ...getDefaultAssistantState().generationSettings,
           },
           actionMode: initialBuilderState.actionMode,
           retrievalConfiguration: initialBuilderState.retrievalConfiguration,
@@ -223,10 +223,10 @@ export default function AssistantBuilder({
           processConfiguration: initialBuilderState.processConfiguration,
         }
       : {
-          ...DEFAULT_ASSISTANT_STATE,
+          ...getDefaultAssistantState(),
           scope: defaultScope,
           generationSettings: {
-            ...DEFAULT_ASSISTANT_STATE.generationSettings,
+            ...getDefaultAssistantState().generationSettings,
             modelSettings: !isUpgraded(plan)
               ? GPT_3_5_TURBO_MODEL_CONFIG
               : GPT_4_TURBO_MODEL_CONFIG,
@@ -283,14 +283,16 @@ export default function AssistantBuilder({
     }
 
     if (actionMode !== null) {
+      const defaultAssistantState = getDefaultAssistantState();
+
       setEdited(true);
       setBuilderState((builderState) => ({
         ...builderState,
         actionMode,
-        retrievalConfiguration: DEFAULT_ASSISTANT_STATE.retrievalConfiguration,
-        dustAppConfiguration: DEFAULT_ASSISTANT_STATE.dustAppConfiguration,
+        retrievalConfiguration: defaultAssistantState.retrievalConfiguration,
+        dustAppConfiguration: defaultAssistantState.dustAppConfiguration,
         tablesQueryConfiguration:
-          DEFAULT_ASSISTANT_STATE.tablesQueryConfiguration,
+          defaultAssistantState.tablesQueryConfiguration,
       }));
     }
   }, [template]);

--- a/front/components/assistant_builder/server_side_props_helpers.ts
+++ b/front/components/assistant_builder/server_side_props_helpers.ts
@@ -20,7 +20,7 @@ import type {
   AssistantBuilderDataSourceConfiguration,
   AssistantBuilderInitialState,
 } from "@app/components/assistant_builder/types";
-import { DEFAULT_ASSISTANT_STATE } from "@app/components/assistant_builder/types";
+import { getDefaultAssistantState } from "@app/components/assistant_builder/types";
 import { tableKey } from "@app/lib/client/tables_query";
 import { deprecatedGetFirstActionConfiguration } from "@app/lib/deprecated_action_configurations";
 import logger from "@app/logger/logger";
@@ -98,7 +98,8 @@ export async function buildInitialState({
 
   // Retrieval configuration
 
-  const retrievalConfiguration = DEFAULT_ASSISTANT_STATE.retrievalConfiguration;
+  const retrievalConfiguration =
+    getDefaultAssistantState().retrievalConfiguration;
 
   if (isRetrievalConfiguration(action)) {
     if (
@@ -117,7 +118,7 @@ export async function buildInitialState({
 
   // DustAppRun configuration
 
-  const dustAppConfiguration = DEFAULT_ASSISTANT_STATE.dustAppConfiguration;
+  const dustAppConfiguration = getDefaultAssistantState().dustAppConfiguration;
 
   if (isDustAppRunConfiguration(action)) {
     for (const app of dustApps) {
@@ -131,7 +132,7 @@ export async function buildInitialState({
   // TablesQuery configuration
 
   let tablesQueryConfiguration =
-    DEFAULT_ASSISTANT_STATE.tablesQueryConfiguration;
+    getDefaultAssistantState().tablesQueryConfiguration;
 
   if (isTablesQueryConfiguration(action) && action.tables.length) {
     const coreAPITables: CoreAPITable[] = await Promise.all(
@@ -168,7 +169,7 @@ export async function buildInitialState({
 
   // Process configuration
 
-  const processConfiguration = DEFAULT_ASSISTANT_STATE.processConfiguration;
+  const processConfiguration = getDefaultAssistantState().processConfiguration;
 
   if (isProcessConfiguration(action)) {
     if (

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -112,35 +112,38 @@ export type AssistantBuilderInitialState = {
   processConfiguration: AssistantBuilderState["processConfiguration"];
 };
 
-export const DEFAULT_ASSISTANT_STATE: AssistantBuilderState = {
-  actionMode: "GENERIC",
-  retrievalConfiguration: {
-    dataSourceConfigurations: {},
-    timeFrame: {
-      value: 1,
-      unit: "month",
+// Creates a fresh instance of AssistantBuilderState to prevent unintended mutations of shared state.
+export function getDefaultAssistantState(): AssistantBuilderState {
+  return {
+    actionMode: "GENERIC",
+    retrievalConfiguration: {
+      dataSourceConfigurations: {},
+      timeFrame: {
+        value: 1,
+        unit: "month",
+      },
     },
-  },
-  dustAppConfiguration: { app: null },
-  tablesQueryConfiguration: {},
-  processConfiguration: {
-    dataSourceConfigurations: {},
-    timeFrame: {
-      value: 1,
-      unit: "day",
+    dustAppConfiguration: { app: null },
+    tablesQueryConfiguration: {},
+    processConfiguration: {
+      dataSourceConfigurations: {},
+      timeFrame: {
+        value: 1,
+        unit: "day",
+      },
+      schema: [],
     },
-    schema: [],
-  },
-  handle: null,
-  scope: "private",
-  description: null,
-  instructions: null,
-  avatarUrl: null,
-  generationSettings: {
-    modelSettings: {
-      modelId: GPT_4_TURBO_MODEL_CONFIG.modelId,
-      providerId: GPT_4_TURBO_MODEL_CONFIG.providerId,
+    handle: null,
+    scope: "private",
+    description: null,
+    instructions: null,
+    avatarUrl: null,
+    generationSettings: {
+      modelSettings: {
+        modelId: GPT_4_TURBO_MODEL_CONFIG.modelId,
+        providerId: GPT_4_TURBO_MODEL_CONFIG.providerId,
+      },
+      temperature: 0.7,
     },
-    temperature: 0.7,
-  },
-};
+  };
+}

--- a/front/pages/w/[wId]/builder/assistants/new.tsx
+++ b/front/pages/w/[wId]/builder/assistants/new.tsx
@@ -22,7 +22,7 @@ import AssistantBuilder, {
 } from "@app/components/assistant_builder/AssistantBuilder";
 import { buildInitialState } from "@app/components/assistant_builder/server_side_props_helpers";
 import type { AssistantBuilderInitialState } from "@app/components/assistant_builder/types";
-import { DEFAULT_ASSISTANT_STATE } from "@app/components/assistant_builder/types";
+import { getDefaultAssistantState } from "@app/components/assistant_builder/types";
 import { getApps } from "@app/lib/api/app";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
 import { generateMockAgentConfigurationFromTemplate } from "@app/lib/api/assistant/templates";
@@ -125,11 +125,12 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
         dustApps: allDustApps,
       })
     : {
-        retrievalConfiguration: DEFAULT_ASSISTANT_STATE.retrievalConfiguration,
-        dustAppConfiguration: DEFAULT_ASSISTANT_STATE.dustAppConfiguration,
+        retrievalConfiguration:
+          getDefaultAssistantState().retrievalConfiguration,
+        dustAppConfiguration: getDefaultAssistantState().dustAppConfiguration,
         tablesQueryConfiguration:
-          DEFAULT_ASSISTANT_STATE.tablesQueryConfiguration,
-        processConfiguration: DEFAULT_ASSISTANT_STATE.processConfiguration,
+          getDefaultAssistantState().tablesQueryConfiguration,
+        processConfiguration: getDefaultAssistantState().processConfiguration,
       };
 
   return {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
In [the pull request #4857](https://github.com/dust-tt/dust/pull/4857), an unforeseen side effect was introduced that made the initial state of the assistant builder mutable. This could potentially have far-reaching effects. This PR aims to move the default assistant state behind a function to prevent any side effects.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
