### PR TITLE
Lower log Failed starting usage workflow if WorkflowExecutionAlreadyStartedError

### DIFF
--- a/front/temporal/usage_queue/client.ts
+++ b/front/temporal/usage_queue/client.ts
@@ -1,5 +1,6 @@
 import type { Result } from "@dust-tt/types";
 import { Err, Ok, rateLimiter } from "@dust-tt/types";
+import { WorkflowExecutionAlreadyStartedError } from "@temporalio/client";
 
 import { getTemporalClient } from "@app/lib/temporal";
 import logger from "@app/logger/logger";
@@ -54,13 +55,23 @@ export async function launchUpdateUsageWorkflow({
 
     return new Ok(undefined);
   } catch (e) {
-    logger.error(
-      {
-        workflowId,
-        error: e,
-      },
-      "Failed starting usage workflow."
-    );
+    if (e instanceof WorkflowExecutionAlreadyStartedError) {
+      logger.info(
+        {
+          workflowId,
+        },
+        "Usage workflow already started."
+      );
+      return new Ok(undefined);
+    } else {
+      logger.error(
+        {
+          workflowId,
+          error: e,
+        },
+        "Failed starting usage workflow."
+      );
+    }
     return new Err(e as Error);
   }
 }

--- a/front/temporal/usage_queue/client.ts
+++ b/front/temporal/usage_queue/client.ts
@@ -55,15 +55,7 @@ export async function launchUpdateUsageWorkflow({
 
     return new Ok(undefined);
   } catch (e) {
-    if (e instanceof WorkflowExecutionAlreadyStartedError) {
-      logger.info(
-        {
-          workflowId,
-        },
-        "Usage workflow already started."
-      );
-      return new Ok(undefined);
-    } else {
+    if (!(e instanceof WorkflowExecutionAlreadyStartedError)) {
       logger.error(
         {
           workflowId,


### PR DESCRIPTION
## Description

We get a lot of this error: https://app.datadoghq.eu/logs?query=status%3Aerror%20%40dd.service%3Afront%20%40error.name%3AWorkflowExecutionAlreadyStartedError&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1714058890876&to_ts=1714145290876&live=true

-> Since you tell me it's expected I'm lowering to info. Untested but should work. 

## Risk

Rollbackable!

## Deploy Plan

/ 