### PR TITLE
[Assistant Builder] Animate instructions suggestions

### DIFF
--- a/front/components/assistant_builder/InstructionScreen.tsx
+++ b/front/components/assistant_builder/InstructionScreen.tsx
@@ -30,11 +30,11 @@ import {
   GEMINI_PRO_DEFAULT_MODEL_CONFIG,
   GPT_3_5_TURBO_MODEL_CONFIG,
   GPT_4_TURBO_MODEL_CONFIG,
+  md5,
   MISTRAL_LARGE_MODEL_CONFIG,
   MISTRAL_MEDIUM_MODEL_CONFIG,
   MISTRAL_SMALL_MODEL_CONFIG,
   Ok,
-  md5,
 } from "@dust-tt/types";
 import { Transition } from "@headlessui/react";
 import Document from "@tiptap/extension-document";

--- a/front/components/assistant_builder/InstructionScreen.tsx
+++ b/front/components/assistant_builder/InstructionScreen.tsx
@@ -41,7 +41,6 @@ import Paragraph from "@tiptap/extension-paragraph";
 import Text from "@tiptap/extension-text";
 import type { Editor, JSONContent } from "@tiptap/react";
 import { EditorContent, useEditor } from "@tiptap/react";
-import { random } from "lodash";
 import type { ComponentType } from "react";
 import React, { useEffect, useMemo, useRef, useState } from "react";
 

--- a/front/components/assistant_builder/InstructionScreen.tsx
+++ b/front/components/assistant_builder/InstructionScreen.tsx
@@ -426,7 +426,7 @@ function Suggestions({
       leaveFrom="max-h-full"
       leaveTo="max-h-0"
     >
-      <div className="relative flex flex-col gap-3">
+      <div className="relative flex flex-col">
         <div
           className="flex items-center gap-2 text-base font-bold text-element-800"
           onClick={() => {
@@ -442,7 +442,7 @@ function Suggestions({
           {suggestionsStatus === "loading" && <Spinner size="xs" />}
         </div>
         <div
-          className="overflow-y-auto px-2 scrollbar-hide"
+          className="overflow-y-auto pt-2 scrollbar-hide"
           onScroll={handleScroll}
         >
           <div
@@ -475,7 +475,7 @@ function Suggestions({
               );
             }
             return (
-              <div className="flex w-max gap-3">
+              <div className="flex w-max">
                 {suggestions.map((suggestion) => (
                   <AnimatedSuggestion
                     suggestion={suggestion}
@@ -502,17 +502,17 @@ function AnimatedSuggestion({
     <Transition
       appear={true}
       enter="transition-all ease-out duration-300"
-      enterFrom="opacity-0 -translate-x-16"
-      enterTo="opacity-100 translate-x-0"
+      enterFrom="opacity-0 w-0"
+      enterTo="opacity-100 w-[320px]"
       leave="ease-in duration-300"
-      leaveFrom="opacity-100 translate-x-0"
-      leaveTo="opacity-0 -translate-x-16"
+      leaveFrom="opacity-100 w-[320px]"
+      leaveTo="opacity-0 w-0"
     >
       <ContentMessage
         size="sm"
         title=""
         variant={variant}
-        className="h-fit w-[320px]"
+        className="h-fit w-[308px]"
       >
         {suggestion}
       </ContentMessage>

--- a/front/components/assistant_builder/InstructionScreen.tsx
+++ b/front/components/assistant_builder/InstructionScreen.tsx
@@ -427,17 +427,7 @@ function Suggestions({
       leaveTo="max-h-0"
     >
       <div className="relative flex flex-col">
-        <div
-          className="flex items-center gap-2 text-base font-bold text-element-800"
-          onClick={() => {
-            setSuggestions((s) => [
-              `${random(
-                100
-              )} - Test suggestion, to perform smooth animations when needed lol yes yes`,
-              ...s,
-            ]);
-          }}
-        >
+        <div className="flex items-center gap-2 text-base font-bold text-element-800">
           <div>Tips</div>
           {suggestionsStatus === "loading" && <Spinner size="xs" />}
         </div>


### PR DESCRIPTION
Description
---
New suggestions animate by appearing from the right. Also fixes an issue in which stale suggestions were not pushed into history (they remained visible, sometimes preventing better suggestion to be visible) 
cc @Duncid , will first rebase this PR on yours #4893 before merging

![Screencast from 2024-04-29 11-48-09](https://github.com/dust-tt/dust/assets/5437393/c5888d43-dc0f-414b-8a1d-590b1d2a2568)


Risk
---
None (blast radius limited to instructions suggestions + gated)

Deploy Plan
---
Deploy front