### PR TITLE
Expose function_calls in chat block response

### DIFF
--- a/core/src/blocks/chat.rs
+++ b/core/src/blocks/chat.rs
@@ -331,6 +331,7 @@ impl Block for Chat {
                                     },
                                     content: Some(c.clone()),
                                     function_call: None,
+                                    function_calls: None,
                                 })
                             }
                             (Some(Value::String(r)), None, Some(Value::Object(fc))) => {
@@ -348,6 +349,8 @@ impl Block for Chat {
                                                 name: n.clone(),
                                                 arguments: a.clone(),
                                             }),
+                                            // TODO: (2024-04-29 flav) Support function_calls in input.
+                                            function_calls: Some(vec![]),
                                         })
                                     }
                                     _ => Err(anyhow!(MESSAGES_CODE_OUTPUT)),
@@ -443,6 +446,7 @@ impl Block for Chat {
                     name: None,
                     content: Some(i),
                     function_call: None,
+                    function_calls: None,
                 },
             );
         }

--- a/core/src/blocks/chat.rs
+++ b/core/src/blocks/chat.rs
@@ -6,6 +6,7 @@ use crate::providers::llm::{
     ChatFunction, ChatFunctionCall, ChatMessage, ChatMessageRole, LLMChatRequest,
 };
 use crate::providers::provider::ProviderID;
+use crate::utils::new_id;
 use crate::Rule;
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
@@ -346,6 +347,8 @@ impl Block for Chat {
                                             },
                                             content: None,
                                             function_call: Some(ChatFunctionCall {
+                                                // TODO: (2024-04-29 flav) Support id in input.
+                                                id: format!("fc_{}", new_id()),
                                                 name: n.clone(),
                                                 arguments: a.clone(),
                                             }),

--- a/core/src/blocks/llm.rs
+++ b/core/src/blocks/llm.rs
@@ -427,6 +427,7 @@ impl Block for LLM {
                     name: None,
                     content: Some(prompt.clone()),
                     function_call: None,
+                    function_calls: None,
                 }];
 
                 let request = LLMChatRequest::new(

--- a/core/src/providers/google_ai_studio.rs
+++ b/core/src/providers/google_ai_studio.rs
@@ -454,6 +454,7 @@ impl LLM for GoogleAiStudioLLM {
             completions: vec![ChatMessage {
                 name: None,
                 function_call: None,
+                function_calls: None,
                 role: ChatMessageRole::Assistant,
                 content: match c.candidates {
                     None => None,

--- a/core/src/providers/llm.rs
+++ b/core/src/providers/llm.rs
@@ -64,15 +64,9 @@ impl FromStr for ChatMessageRole {
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct ChatFunctionCall {
-    pub name: String,
-    pub arguments: String,
-}
-
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
-pub struct ChatFunctionCalls {
-    pub name: String,
     pub arguments: String,
     pub id: String,
+    pub name: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
@@ -84,7 +78,7 @@ pub struct ChatMessage {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub function_call: Option<ChatFunctionCall>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub function_calls: Option<Vec<ChatFunctionCalls>>,
+    pub function_calls: Option<Vec<ChatFunctionCall>>,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]

--- a/core/src/providers/llm.rs
+++ b/core/src/providers/llm.rs
@@ -69,6 +69,13 @@ pub struct ChatFunctionCall {
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+pub struct ChatFunctionCalls {
+    pub name: String,
+    pub arguments: String,
+    pub id: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct ChatMessage {
     pub role: ChatMessageRole,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -76,6 +83,8 @@ pub struct ChatMessage {
     pub content: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub function_call: Option<ChatFunctionCall>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub function_calls: Option<Vec<ChatFunctionCalls>>,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR modifies our chat block's response to include `function_calls`. This change is required as models can now use multiple functions in a single call. For backward compatibility, we keep the legacy `function_call` field, which corresponds to the first function used. It adds the `id` field to both implementations.

A follow-up PR is required to accept `function_calls` in the history of messages.

**Example:**

<img width="876" alt="image" src="https://github.com/dust-tt/dust/assets/7428970/8413872d-4faf-4bad-b3d3-745b69215624">

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
