### PR TITLE
Intercom - Add config to choose to sync Notes & all conversations

### DIFF
--- a/connectors/src/connectors/index.ts
+++ b/connectors/src/connectors/index.ts
@@ -53,11 +53,13 @@ import {
   cleanupIntercomConnector,
   createIntercomConnector,
   fullResyncIntercomSyncWorkflow,
+  getIntercomConfig,
   pauseIntercomConnector,
   resumeIntercomConnector,
   retrieveIntercomConnectorPermissions,
   retrieveIntercomContentNodeParents,
   retrieveIntercomContentNodes,
+  setIntercomConfig,
   setIntercomConnectorPermissions,
   stopIntercomConnector,
   unpauseIntercomConnector,
@@ -289,9 +291,7 @@ export const SET_CONNECTOR_CONFIG_BY_TYPE: Record<
   },
   github: setGithubConfig,
   google_drive: setGoogleDriveConfig,
-  intercom: async () => {
-    throw new Error("Not implemented");
-  },
+  intercom: setIntercomConfig,
   webcrawler: async () => {
     throw new Error("Not implemented");
   },
@@ -311,9 +311,7 @@ export const GET_CONNECTOR_CONFIG_BY_TYPE: Record<
   },
   github: getGithubConfig,
   google_drive: getGoogleDriveConfig,
-  intercom: async () => {
-    throw new Error("Not implemented");
-  },
+  intercom: getIntercomConfig,
   webcrawler: () => {
     throw new Error("Not implemented");
   },

--- a/connectors/src/connectors/intercom/temporal/sync_conversation.ts
+++ b/connectors/src/connectors/intercom/temporal/sync_conversation.ts
@@ -245,7 +245,10 @@ export async function syncConversation({
         : null;
       const type = part.part_type === "note" ? "Internal note" : "Message";
 
-      if (messageContent) {
+      const shouldSync =
+        part.part_type !== "note" || intercomWorkspace.shouldSyncNotes;
+
+      if (messageContent && shouldSync) {
         markdown += `**[${type}] ${messageAuthor.name} (${messageAuthor.type})**\n`;
         markdown += `${messageContent}\n\n`;
       }

--- a/connectors/src/lib/models/intercom.ts
+++ b/connectors/src/lib/models/intercom.ts
@@ -19,8 +19,11 @@ export class IntercomWorkspace extends Model<
 
   declare intercomWorkspaceId: string;
   declare name: string;
-  declare conversationsSlidingWindow: number;
   declare region: string;
+
+  declare conversationsSlidingWindow: number;
+  declare shouldSyncAllConversations: boolean;
+  declare shouldSyncNotes: boolean;
 
   declare connectorId: ForeignKey<ConnectorModel["id"]>;
 }
@@ -53,6 +56,16 @@ IntercomWorkspace.init(
       type: DataTypes.INTEGER,
       allowNull: false,
       defaultValue: 90,
+    },
+    shouldSyncAllConversations: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    },
+    shouldSyncNotes: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: true,
     },
     region: {
       type: DataTypes.STRING,


### PR DESCRIPTION
## Description

### Context

We want to give more flexibility on the Intercom connector: 
- Let admins pick if they want or not to sync Notes from conversations. -> this will be a simple connector config
- Let admins pick the sync of all conversations (instead of having to tick each intercom Team). -> this requires some changes in the permission logic of the connector.

### This PR

- We create two new columns on the `IntercomWorkspace` model for these 2 configs. 
- We implement `setIntercomConfig` / `getIntercomConfig` to allow edition of the sync Notes config. 

###  Next PRs
- Front changes for the syncNotes config. 
- Front/Connector changes for the syncAllConversations logic.

## Risk

Can be rolled-back.

## Deploy Plan

- Merge
- Deploy on prodbox, run init_db
- Deploy on connectors