### PR TITLE
Intercom: Front config to choose to sync Notes

### DIFF
--- a/front/pages/api/w/[wId]/data_sources/[name]/managed/config/[key]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/managed/config/[key]/index.ts
@@ -87,7 +87,13 @@ async function handler(
   // We only allow setting and retrieving `botEnabled` (slack) and `codeSyncEnabled` (github). This
   // is mainly to prevent users from enabling other configs that are not released (e.g. google_drive
   // `pdfEnabled`).
-  if (!["botEnabled", "codeSyncEnabled"].includes(configKey)) {
+  if (
+    ![
+      "botEnabled",
+      "codeSyncEnabled",
+      "intercomConversationsNotesSyncEnabled",
+    ].includes(configKey)
+  ) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {

--- a/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
@@ -904,7 +904,7 @@ function IntercomConfigView({
   return (
     <ContextItem.List>
       <ContextItem
-        title="Extract Intercom Notes from conversations"
+        title="Sync Intercom Notes from conversations"
         visual={<ContextItem.Visual visual={IntercomLogo} />}
         action={
           <div className="relative">

--- a/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/index.tsx
@@ -6,6 +6,7 @@ import {
   Dialog,
   DocumentTextIcon,
   GithubLogo,
+  IntercomLogo,
   ListCheckIcon,
   LockIcon,
   Page,
@@ -850,6 +851,85 @@ function GithubCodeEnableView({
   );
 }
 
+function IntercomConfigView({
+  owner,
+  readOnly,
+  isAdmin,
+  dataSource,
+}: {
+  owner: WorkspaceType;
+  readOnly: boolean;
+  isAdmin: boolean;
+  dataSource: DataSourceType;
+}) {
+  const configKey = "intercomConversationsNotesSyncEnabled";
+  const { configValue: syncNotesConfig, mutateConfig: mutateSyncNotesConfig } =
+    useConnectorConfig({
+      owner,
+      dataSource,
+      configKey,
+    });
+  const isSyncNotesEnabled = syncNotesConfig === "true";
+
+  const sendNotification = useContext(SendNotificationsContext);
+  const [loading, setLoading] = useState(false);
+
+  const handleSetNewConfig = async (configValue: boolean) => {
+    setLoading(true);
+    const res = await fetch(
+      `/api/w/${owner.sId}/data_sources/${dataSource.name}/managed/config/${configKey}`,
+      {
+        headers: {
+          "Content-Type": "application/json",
+        },
+        method: "POST",
+        body: JSON.stringify({ configValue: configValue.toString() }),
+      }
+    );
+    if (res.ok) {
+      await mutateSyncNotesConfig();
+      setLoading(false);
+    } else {
+      setLoading(false);
+      const err = (await res.json()) as { error: APIError };
+      sendNotification({
+        type: "error",
+        title: "Failed to edit Intercom Configuration",
+        description: err.error.message,
+      });
+    }
+    return true;
+  };
+
+  return (
+    <ContextItem.List>
+      <ContextItem
+        title="Extract Intercom Notes from conversations"
+        visual={<ContextItem.Visual visual={IntercomLogo} />}
+        action={
+          <div className="relative">
+            <SliderToggle
+              size="xs"
+              onClick={async () => {
+                await handleSetNewConfig(!isSyncNotesEnabled);
+              }}
+              selected={isSyncNotesEnabled}
+              disabled={readOnly || !isAdmin || loading}
+            />
+          </div>
+        }
+      >
+        <ContextItem.Description>
+          <div className="text-element-700">
+            If activated, Dust will also sync the notes from the conversations
+            you've selected.
+          </div>
+        </ContextItem.Description>
+      </ContextItem>
+    </ContextItem.List>
+  );
+}
+
 const CONNECTOR_TYPE_TO_MISMATCH_ERROR: Record<ConnectorProvider, string> = {
   confluence: `You cannot select another Confluence Domain.\nPlease contact us at team@dust.tt if you initially selected the wrong Domain.`,
   slack: `You cannot select another Slack Team.\nPlease contact us at team@dust.tt if you initially selected the wrong Team.`,
@@ -1263,6 +1343,11 @@ function ManagedDataSourceView({
             )}
             {connectorProvider === "github" && (
               <GithubCodeEnableView
+                {...{ owner, readOnly, isAdmin, dataSource }}
+              />
+            )}
+            {connectorProvider === "intercom" && (
+              <IntercomConfigView
                 {...{ owner, readOnly, isAdmin, dataSource }}
               />
             )}


### PR DESCRIPTION
## Description

### Context

We want to give more flexibility on the Intercom connector: 
- Let admins pick if they want or not to sync Notes from conversations. -> this will be a simple connector config
- Let admins pick the sync of all conversations (instead of having to tick each intercom Team). -> this requires some changes in the permission logic of the connector.

### This PR

Follows: https://github.com/dust-tt/dust/pull/4896
Front changes for the syncNotes config. 

###  Next PRs
- Front/Connector changes for the syncAllConversations logic.

## Risk

Can be rolled-back.

## Deploy Plan

https://github.com/dust-tt/dust/pull/4896 must be deployed first. 