### PR TITLE
AssitantBuilder: Actions components

### DIFF
--- a/front/components/assistant_builder/actions/DustAppRunAction.tsx
+++ b/front/components/assistant_builder/actions/DustAppRunAction.tsx
@@ -110,7 +110,7 @@ export function ActionDustAppRun({
               setShowDustAppsModal(true);
             }}
             onDelete={deleteDustApp}
-            canSelectDustApp={dustApps.length !== 0}
+            canSelectDustApp={!noDustApp}
           />
         </>
       )}

--- a/front/components/assistant_builder/actions/DustAppRunAction.tsx
+++ b/front/components/assistant_builder/actions/DustAppRunAction.tsx
@@ -1,0 +1,119 @@
+import { ContentMessage } from "@dust-tt/sparkle";
+import type { AppType, WorkspaceType } from "@dust-tt/types";
+import { assertNever } from "@dust-tt/types";
+import { useState } from "react";
+
+import AssistantBuilderDustAppModal from "@app/components/assistant_builder/AssistantBuilderDustAppModal";
+import DustAppSelectionSection from "@app/components/assistant_builder/DustAppSelectionSection";
+import type { AssistantBuilderState } from "@app/components/assistant_builder/types";
+
+export function ActionDustAppRun({
+  owner,
+  builderState,
+  setBuilderState,
+  setEdited,
+  dustApps,
+}: {
+  owner: WorkspaceType;
+  builderState: AssistantBuilderState;
+  setBuilderState: (
+    stateFn: (state: AssistantBuilderState) => AssistantBuilderState
+  ) => void;
+  setEdited: (edited: boolean) => void;
+  dustApps: AppType[];
+}) {
+  const [showDustAppsModal, setShowDustAppsModal] = useState(false);
+
+  const deleteDustApp = () => {
+    setEdited(true);
+    setBuilderState((state) => {
+      return { ...state, dustAppConfiguration: { app: null } };
+    });
+  };
+
+  const noDustApp = dustApps.length === 0;
+
+  return (
+    <>
+      <AssistantBuilderDustAppModal
+        isOpen={showDustAppsModal}
+        setOpen={(isOpen) => {
+          setShowDustAppsModal(isOpen);
+        }}
+        dustApps={dustApps}
+        onSave={({ app }) => {
+          setEdited(true);
+          setBuilderState((state) => ({
+            ...state,
+            dustAppConfiguration: {
+              app,
+            },
+          }));
+        }}
+      />
+
+      {noDustApp ? (
+        <ContentMessage
+          title="You don't have any Dust Application available"
+          variant="warning"
+        >
+          <div className="flex flex-col gap-y-3">
+            {(() => {
+              switch (owner.role) {
+                case "admin":
+                case "builder":
+                  return (
+                    <div>
+                      <strong>
+                        Visit the "Developer Tools" section in the Build panel
+                        to build your first Dust Application.
+                      </strong>
+                    </div>
+                  );
+                case "user":
+                  return (
+                    <div>
+                      <strong>
+                        Only Admins and Builders can build Dust Applications.
+                      </strong>
+                    </div>
+                  );
+                case "none":
+                  return <></>;
+                default:
+                  assertNever(owner.role);
+              }
+            })()}
+          </div>
+        </ContentMessage>
+      ) : (
+        <>
+          <div className="text-sm text-element-700">
+            The assistant will execute a{" "}
+            <a
+              className="font-bold"
+              href="https://docs.dust.tt"
+              target="_blank"
+            >
+              Dust Application
+            </a>{" "}
+            of your design before replying. The output of the app (last block)
+            is injected in context for the model to generate an answer. The
+            inputs of the app will be automatically generated from the context
+            of the conversation based on the descriptions you provided in the
+            application's input block dataset schema.
+          </div>
+          <DustAppSelectionSection
+            show={builderState.actionMode === "DUST_APP_RUN"}
+            dustAppConfiguration={builderState.dustAppConfiguration}
+            openDustAppModal={() => {
+              setShowDustAppsModal(true);
+            }}
+            onDelete={deleteDustApp}
+            canSelectDustApp={dustApps.length !== 0}
+          />
+        </>
+      )}
+    </>
+  );
+}

--- a/front/components/assistant_builder/actions/ProcessAction.tsx
+++ b/front/components/assistant_builder/actions/ProcessAction.tsx
@@ -1,0 +1,186 @@
+import { Button, DropdownMenu, Hoverable } from "@dust-tt/sparkle";
+import type { DataSourceType, WorkspaceType } from "@dust-tt/types";
+import type { TimeframeUnit } from "@dust-tt/types";
+import { useState } from "react";
+
+import AssistantBuilderDataSourceModal from "@app/components/assistant_builder/AssistantBuilderDataSourceModal";
+import DataSourceSelectionSection from "@app/components/assistant_builder/DataSourceSelectionSection";
+import { TIME_FRAME_UNIT_TO_LABEL } from "@app/components/assistant_builder/shared";
+import type { AssistantBuilderState } from "@app/components/assistant_builder/types";
+import { classNames } from "@app/lib/utils";
+
+export function ActionProcess({
+  owner,
+  builderState,
+  setBuilderState,
+  setEdited,
+  dataSources,
+  timeFrameError,
+}: {
+  owner: WorkspaceType;
+  builderState: AssistantBuilderState;
+  setBuilderState: (
+    stateFn: (state: AssistantBuilderState) => AssistantBuilderState
+  ) => void;
+  setEdited: (edited: boolean) => void;
+  dataSources: DataSourceType[];
+  timeFrameError: string | null;
+}) {
+  const [showProcessDataSourcesModal, setShowProcessDataSourcesModal] =
+    useState(false);
+
+  const deleteProcessDataSource = (name: string) => {
+    if (builderState.processConfiguration.dataSourceConfigurations[name]) {
+      setEdited(true);
+    }
+
+    setBuilderState(({ processConfiguration, ...rest }) => {
+      const dataSourceConfigurations = {
+        ...processConfiguration.dataSourceConfigurations,
+      };
+      delete dataSourceConfigurations[name];
+      return {
+        processConfiguration: {
+          ...processConfiguration,
+          dataSourceConfigurations,
+        },
+        ...rest,
+      };
+    });
+  };
+
+  return (
+    <>
+      <AssistantBuilderDataSourceModal
+        isOpen={showProcessDataSourcesModal}
+        setOpen={(isOpen) => {
+          setShowProcessDataSourcesModal(isOpen);
+        }}
+        owner={owner}
+        dataSources={dataSources}
+        onSave={({ dataSource, selectedResources, isSelectAll }) => {
+          setEdited(true);
+          setBuilderState((state) => ({
+            ...state,
+            processConfiguration: {
+              ...state.processConfiguration,
+              dataSourceConfigurations: {
+                ...state.processConfiguration.dataSourceConfigurations,
+                [dataSource.name]: {
+                  dataSource,
+                  selectedResources,
+                  isSelectAll,
+                },
+              },
+            },
+          }));
+        }}
+        onDelete={deleteProcessDataSource}
+        dataSourceConfigurations={
+          builderState.processConfiguration.dataSourceConfigurations
+        }
+      />
+
+      <div className="text-sm text-element-700">
+        The assistant will process the data sources over the specified time
+        frame and attempt to extract structured information based on the schema
+        provided. This action can process up to 500k tokens (the equivalent of
+        1000 pages book). Learn more about this feature in the{" "}
+        <Hoverable
+          onClick={() => {
+            window.open(
+              "https://dust-tt.notion.site/Table-queries-on-Dust-2f8c6ea53518464b8b7780d55ac7057d",
+              "_blank"
+            );
+          }}
+          className="cursor-pointer font-bold text-action-500"
+        >
+          documentation
+        </Hoverable>
+        .
+      </div>
+
+      <DataSourceSelectionSection
+        owner={owner}
+        dataSourceConfigurations={
+          builderState.processConfiguration.dataSourceConfigurations
+        }
+        openDataSourceModal={() => {
+          setShowProcessDataSourcesModal(true);
+        }}
+        canAddDataSource={dataSources.length > 0}
+        onDelete={deleteProcessDataSource}
+      />
+
+      <div className={"flex flex-row items-center gap-4 pb-4"}>
+        <div className="text-sm font-semibold text-element-900">
+          Process data from the last
+        </div>
+        <input
+          type="text"
+          className={classNames(
+            "h-8 w-16 rounded-md border-gray-300 text-center text-sm",
+            !timeFrameError
+              ? "focus:border-action-500 focus:ring-action-500"
+              : "border-red-500 focus:border-red-500 focus:ring-red-500",
+            "bg-structure-50 stroke-structure-50"
+          )}
+          value={builderState.processConfiguration.timeFrame.value || ""}
+          onChange={(e) => {
+            const value = parseInt(e.target.value, 10);
+            if (!isNaN(value) || !e.target.value) {
+              setEdited(true);
+              setBuilderState((state) => ({
+                ...state,
+                processConfiguration: {
+                  ...state.processConfiguration,
+                  timeFrame: {
+                    value,
+                    unit: builderState.processConfiguration.timeFrame.unit,
+                  },
+                },
+              }));
+            }
+          }}
+        />
+        <DropdownMenu>
+          <DropdownMenu.Button tooltipPosition="above">
+            <Button
+              type="select"
+              labelVisible={true}
+              label={
+                TIME_FRAME_UNIT_TO_LABEL[
+                  builderState.processConfiguration.timeFrame.unit
+                ]
+              }
+              variant="secondary"
+              size="sm"
+            />
+          </DropdownMenu.Button>
+          <DropdownMenu.Items origin="bottomLeft">
+            {Object.entries(TIME_FRAME_UNIT_TO_LABEL).map(([key, value]) => (
+              <DropdownMenu.Item
+                key={key}
+                label={value}
+                onClick={() => {
+                  setEdited(true);
+                  setBuilderState((state) => ({
+                    ...state,
+                    processConfiguration: {
+                      ...state.processConfiguration,
+                      timeFrame: {
+                        value:
+                          builderState.processConfiguration.timeFrame.value,
+                        unit: key as TimeframeUnit,
+                      },
+                    },
+                  }));
+                }}
+              />
+            ))}
+          </DropdownMenu.Items>
+        </DropdownMenu>
+      </div>
+    </>
+  );
+}

--- a/front/components/assistant_builder/actions/ProcessAction.tsx
+++ b/front/components/assistant_builder/actions/ProcessAction.tsx
@@ -26,10 +26,10 @@ export function ActionProcess({
   dataSources: DataSourceType[];
   timeFrameError: string | null;
 }) {
-  const [showProcessDataSourcesModal, setShowProcessDataSourcesModal] =
+  const [showDataSourcesModal, setShowDataSourcesModal] =
     useState(false);
 
-  const deleteProcessDataSource = (name: string) => {
+  const deleteDataSource = (name: string) => {
     if (builderState.processConfiguration.dataSourceConfigurations[name]) {
       setEdited(true);
     }
@@ -52,9 +52,9 @@ export function ActionProcess({
   return (
     <>
       <AssistantBuilderDataSourceModal
-        isOpen={showProcessDataSourcesModal}
+        isOpen={showDataSourcesModal}
         setOpen={(isOpen) => {
-          setShowProcessDataSourcesModal(isOpen);
+          setShowDataSourcesModal(isOpen);
         }}
         owner={owner}
         dataSources={dataSources}
@@ -75,7 +75,7 @@ export function ActionProcess({
             },
           }));
         }}
-        onDelete={deleteProcessDataSource}
+        onDelete={deleteDataSource}
         dataSourceConfigurations={
           builderState.processConfiguration.dataSourceConfigurations
         }
@@ -106,10 +106,10 @@ export function ActionProcess({
           builderState.processConfiguration.dataSourceConfigurations
         }
         openDataSourceModal={() => {
-          setShowProcessDataSourcesModal(true);
+          setShowDataSourcesModal(true);
         }}
         canAddDataSource={dataSources.length > 0}
-        onDelete={deleteProcessDataSource}
+        onDelete={deleteDataSource}
       />
 
       <div className={"flex flex-row items-center gap-4 pb-4"}>

--- a/front/components/assistant_builder/actions/ProcessAction.tsx
+++ b/front/components/assistant_builder/actions/ProcessAction.tsx
@@ -26,8 +26,7 @@ export function ActionProcess({
   dataSources: DataSourceType[];
   timeFrameError: string | null;
 }) {
-  const [showDataSourcesModal, setShowDataSourcesModal] =
-    useState(false);
+  const [showDataSourcesModal, setShowDataSourcesModal] = useState(false);
 
   const deleteDataSource = (name: string) => {
     if (builderState.processConfiguration.dataSourceConfigurations[name]) {

--- a/front/components/assistant_builder/actions/RetrievalAction.tsx
+++ b/front/components/assistant_builder/actions/RetrievalAction.tsx
@@ -1,0 +1,244 @@
+import { Button, DropdownMenu } from "@dust-tt/sparkle";
+import type { DataSourceType, WorkspaceType } from "@dust-tt/types";
+import type { TimeframeUnit } from "@dust-tt/types";
+import { useState } from "react";
+
+import AssistantBuilderDataSourceModal from "@app/components/assistant_builder/AssistantBuilderDataSourceModal";
+import DataSourceSelectionSection from "@app/components/assistant_builder/DataSourceSelectionSection";
+import { TIME_FRAME_UNIT_TO_LABEL } from "@app/components/assistant_builder/shared";
+import type { AssistantBuilderState } from "@app/components/assistant_builder/types";
+import { classNames } from "@app/lib/utils";
+
+const deleteDataSource = (
+  name: string,
+  builderState: AssistantBuilderState,
+  setBuilderState: (
+    stateFn: (state: AssistantBuilderState) => AssistantBuilderState
+  ) => void,
+  setEdited: (edited: boolean) => void
+) => {
+  if (builderState.retrievalConfiguration.dataSourceConfigurations[name]) {
+    setEdited(true);
+  }
+
+  setBuilderState(({ retrievalConfiguration, ...rest }) => {
+    const dataSourceConfigurations = {
+      ...retrievalConfiguration.dataSourceConfigurations,
+    };
+    delete dataSourceConfigurations[name];
+    return {
+      retrievalConfiguration: {
+        ...retrievalConfiguration,
+        dataSourceConfigurations,
+      },
+      ...rest,
+    };
+  });
+};
+
+export function ActionRetrievalSearch({
+  owner,
+  builderState,
+  setBuilderState,
+  setEdited,
+  dataSources,
+}: {
+  owner: WorkspaceType;
+  builderState: AssistantBuilderState;
+  setBuilderState: (
+    stateFn: (state: AssistantBuilderState) => AssistantBuilderState
+  ) => void;
+  setEdited: (edited: boolean) => void;
+  dataSources: DataSourceType[];
+}) {
+  const [showDataSourcesModal, setShowDataSourcesModal] = useState(false);
+
+  return (
+    <>
+      <AssistantBuilderDataSourceModal
+        isOpen={showDataSourcesModal}
+        setOpen={(isOpen) => {
+          setShowDataSourcesModal(isOpen);
+        }}
+        owner={owner}
+        dataSources={dataSources}
+        onSave={({ dataSource, selectedResources, isSelectAll }) => {
+          setEdited(true);
+          setBuilderState((state) => ({
+            ...state,
+            retrievalConfiguration: {
+              ...state.retrievalConfiguration,
+              dataSourceConfigurations: {
+                ...state.retrievalConfiguration.dataSourceConfigurations,
+                [dataSource.name]: {
+                  dataSource,
+                  selectedResources,
+                  isSelectAll,
+                },
+              },
+            },
+          }));
+        }}
+        onDelete={(name) => {
+          deleteDataSource(name, builderState, setBuilderState, setEdited);
+        }}
+        dataSourceConfigurations={
+          builderState.retrievalConfiguration.dataSourceConfigurations
+        }
+      />
+
+      <DataSourceSelectionSection
+        owner={owner}
+        dataSourceConfigurations={
+          builderState.retrievalConfiguration.dataSourceConfigurations
+        }
+        openDataSourceModal={() => {
+          setShowDataSourcesModal(true);
+        }}
+        canAddDataSource={dataSources.length > 0}
+        onDelete={(name) => {
+          deleteDataSource(name, builderState, setBuilderState, setEdited);
+        }}
+      />
+    </>
+  );
+}
+
+export function ActionRetrievalExhaustive({
+  owner,
+  builderState,
+  setBuilderState,
+  setEdited,
+  dataSources,
+  timeFrameError,
+}: {
+  owner: WorkspaceType;
+  builderState: AssistantBuilderState;
+  setBuilderState: (
+    stateFn: (state: AssistantBuilderState) => AssistantBuilderState
+  ) => void;
+  setEdited: (edited: boolean) => void;
+  dataSources: DataSourceType[];
+  timeFrameError: string | null;
+}) {
+  const [showDataSourcesModal, setShowDataSourcesModal] = useState(false);
+
+  return (
+    <>
+      <AssistantBuilderDataSourceModal
+        isOpen={showDataSourcesModal}
+        setOpen={(isOpen) => {
+          setShowDataSourcesModal(isOpen);
+        }}
+        owner={owner}
+        dataSources={dataSources}
+        onSave={({ dataSource, selectedResources, isSelectAll }) => {
+          setEdited(true);
+          setBuilderState((state) => ({
+            ...state,
+            retrievalConfiguration: {
+              ...state.retrievalConfiguration,
+              dataSourceConfigurations: {
+                ...state.retrievalConfiguration.dataSourceConfigurations,
+                [dataSource.name]: {
+                  dataSource,
+                  selectedResources,
+                  isSelectAll,
+                },
+              },
+            },
+          }));
+        }}
+        onDelete={(name) => {
+          deleteDataSource(name, builderState, setBuilderState, setEdited);
+        }}
+        dataSourceConfigurations={
+          builderState.retrievalConfiguration.dataSourceConfigurations
+        }
+      />
+
+      <DataSourceSelectionSection
+        owner={owner}
+        dataSourceConfigurations={
+          builderState.retrievalConfiguration.dataSourceConfigurations
+        }
+        openDataSourceModal={() => {
+          setShowDataSourcesModal(true);
+        }}
+        canAddDataSource={dataSources.length > 0}
+        onDelete={(name) => {
+          deleteDataSource(name, builderState, setBuilderState, setEdited);
+        }}
+      />
+      <div className={"flex flex-row items-center gap-4 pb-4"}>
+        <div className="text-sm font-semibold text-element-900">
+          Collect data from the last
+        </div>
+        <input
+          type="text"
+          className={classNames(
+            "h-8 w-16 rounded-md border-gray-300 text-center text-sm",
+            !timeFrameError
+              ? "focus:border-action-500 focus:ring-action-500"
+              : "border-red-500 focus:border-red-500 focus:ring-red-500",
+            "bg-structure-50 stroke-structure-50"
+          )}
+          value={builderState.retrievalConfiguration.timeFrame.value || ""}
+          onChange={(e) => {
+            const value = parseInt(e.target.value, 10);
+            if (!isNaN(value) || !e.target.value) {
+              setEdited(true);
+              setBuilderState((state) => ({
+                ...state,
+                retrievalConfiguration: {
+                  ...state.retrievalConfiguration,
+                  timeFrame: {
+                    value,
+                    unit: builderState.retrievalConfiguration.timeFrame.unit,
+                  },
+                },
+              }));
+            }
+          }}
+        />
+        <DropdownMenu>
+          <DropdownMenu.Button tooltipPosition="above">
+            <Button
+              type="select"
+              labelVisible={true}
+              label={
+                TIME_FRAME_UNIT_TO_LABEL[
+                  builderState.retrievalConfiguration.timeFrame.unit
+                ]
+              }
+              variant="secondary"
+              size="sm"
+            />
+          </DropdownMenu.Button>
+          <DropdownMenu.Items origin="bottomLeft">
+            {Object.entries(TIME_FRAME_UNIT_TO_LABEL).map(([key, value]) => (
+              <DropdownMenu.Item
+                key={key}
+                label={value}
+                onClick={() => {
+                  setEdited(true);
+                  setBuilderState((state) => ({
+                    ...state,
+                    retrievalConfiguration: {
+                      ...state.retrievalConfiguration,
+                      timeFrame: {
+                        value:
+                          builderState.retrievalConfiguration.timeFrame.value,
+                        unit: key as TimeframeUnit,
+                      },
+                    },
+                  }));
+                }}
+              />
+            ))}
+          </DropdownMenu.Items>
+        </DropdownMenu>
+      </div>
+    </>
+  );
+}

--- a/front/components/assistant_builder/actions/TablesQueryAction.tsx
+++ b/front/components/assistant_builder/actions/TablesQueryAction.tsx
@@ -1,0 +1,94 @@
+import { Hoverable } from "@dust-tt/sparkle";
+import type { DataSourceType, WorkspaceType } from "@dust-tt/types";
+import { useState } from "react";
+
+import AssistantBuilderTablesModal from "@app/components/assistant_builder/AssistantBuilderTablesModal";
+import TablesSelectionSection from "@app/components/assistant_builder/TablesSelectionSection";
+import type {
+  AssistantBuilderState,
+  AssistantBuilderTableConfiguration,
+} from "@app/components/assistant_builder/types";
+import { tableKey } from "@app/lib/client/tables_query";
+
+export function ActionTablesQuery({
+  owner,
+  builderState,
+  setBuilderState,
+  setEdited,
+  dataSources,
+}: {
+  owner: WorkspaceType;
+  builderState: AssistantBuilderState;
+  setBuilderState: (
+    stateFn: (state: AssistantBuilderState) => AssistantBuilderState
+  ) => void;
+  setEdited: (edited: boolean) => void;
+  dataSources: DataSourceType[];
+}) {
+  const [showTableModal, setShowTableModal] = useState(false);
+
+  return (
+    <>
+      <AssistantBuilderTablesModal
+        isOpen={showTableModal}
+        setOpen={(isOpen) => setShowTableModal(isOpen)}
+        owner={owner}
+        dataSources={dataSources}
+        onSave={(tables) => {
+          setEdited(true);
+          const newTables: Record<string, AssistantBuilderTableConfiguration> =
+            {};
+          for (const t of tables) {
+            newTables[tableKey(t)] = t;
+          }
+          setBuilderState((state) => ({
+            ...state,
+            tablesQueryConfiguration: {
+              ...state.tablesQueryConfiguration,
+              ...newTables,
+            },
+          }));
+        }}
+        tablesQueryConfiguration={builderState.tablesQueryConfiguration}
+      />
+
+      <div className="text-sm text-element-700">
+        The assistant will generate a SQL query from your request, execute it on
+        the tables selected and use the results to generate an answer. Learn
+        more about this feature in the{" "}
+        <Hoverable
+          onClick={() => {
+            window.open(
+              "https://dust-tt.notion.site/Table-queries-on-Dust-2f8c6ea53518464b8b7780d55ac7057d",
+              "_blank"
+            );
+          }}
+          className="cursor-pointer font-bold text-action-500"
+        >
+          documentation
+        </Hoverable>
+        .
+      </div>
+
+      <TablesSelectionSection
+        show={builderState.actionMode === "TABLES_QUERY"}
+        tablesQueryConfiguration={builderState.tablesQueryConfiguration}
+        openTableModal={() => {
+          setShowTableModal(true);
+        }}
+        onDelete={(key) => {
+          setEdited(true);
+          setBuilderState((state) => {
+            const tablesQueryConfiguration = state.tablesQueryConfiguration;
+            delete tablesQueryConfiguration[key];
+            return {
+              ...state,
+              tablesQueryConfiguration,
+            };
+          });
+        }}
+        canSelectTable={dataSources.length !== 0}
+      />
+    </>
+  );
+}


### PR DESCRIPTION
## Description

Split Assistant Builder Action screens into components to prepare for Multi-Actions.

This purely code move, no code was changed.

Next step is to refactor validation of cations so that we pass a `setActionsValid` function so that each action do their own validation (so that we remove custom validation code from the main AssistantBuilder page and remove the `timeFrameError` variable that has nothing to do here.

## Risk

N/A No static variable this time :p

## Deploy Plan

- deploy `front`