### PR TITLE
Add project and created in block_executions table.

### DIFF
--- a/core/src/run.rs
+++ b/core/src/run.rs
@@ -18,6 +18,13 @@ pub struct BlockExecution {
     pub meta: Option<Value>,
 }
 
+// TODO(2024-04-29 flav) Temporary step until we remove `hash` from the `block_executions` table.
+#[derive(Serialize)]
+pub struct ExecutionWithTimestamp {
+    pub execution: BlockExecution,
+    pub created: i64,
+}
+
 pub type Credentials = HashMap<String, String>;
 
 #[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]

--- a/core/src/stores/migrations/20240418_block_executions_project_and_created
+++ b/core/src/stores/migrations/20240418_block_executions_project_and_created
@@ -1,0 +1,4 @@
+ALTER TABLE block_executions
+ADD COLUMN project BIGINT,
+ADD COLUMN created BIGINT,
+ADD FOREIGN KEY (project) REFERENCES projects(id);

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -333,9 +333,12 @@ pub const POSTGRES_TABLES: [&'static str; 14] = [
     );",
     "-- block executions
     CREATE TABLE IF NOT EXISTS block_executions (
-       id        BIGSERIAL PRIMARY KEY,
-       hash      TEXT NOT NULL,
-       execution TEXT NOT NULL
+       id                   BIGSERIAL PRIMARY KEY,
+       hash                 TEXT NOT NULL,
+       execution            TEXT NOT NULL,
+       project              BIGINT,
+       created              BIGINT,
+       FOREIGN KEY(project) REFERENCES projects(id)
     );",
     "-- runs to block_executions association (avoid duplication)
     CREATE TABLE IF NOT EXISTS runs_joins (
@@ -470,6 +473,7 @@ pub const SQL_INDEXES: [&'static str; 22] = [
 
 pub const SQL_FUNCTIONS: [&'static str; 3] = [
     // SQL function to delete the project runs / runs_joins / block_executions
+    // TODO(2024-04-29 flav): Remove this stored function.
     r#"
         CREATE OR REPLACE FUNCTION delete_project_runs(v_project_id BIGINT)
         RETURNS void AS $$


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See context [here](https://dust4ai.slack.com/archives/C05F84CFP0E/p1714129057202309?thread_ts=1714113819.621939&cid=C05F84CFP0E).

The `block_executions` table currently holds "cached" versions of blocks, identified by a hash that corresponds to the block specifications. This hash often remains the same for infrequently used blocks like input or browser, resulting in using the same cached version across various workspaces. This cache creates a problem when attempting to delete runs associated with a particular workspace.

This PR introduces two new columns to the `block_executions` table: `project` and `created`. The implementation of these columns will eliminate the current "caching" system, ensuring that each run has a unique block execution.

To ensure this PR can be safely rolled back, the hash will still be computed. However, to maintain the uniqueness of the hash due to the unique constraint on this column, the created date will be included in the hash calculation. Once the cache system is removed, it will be possible to delete the `hash` column and set `project` and `created` to `NOT NULL`. Additionally, a cron job will be created to delete `block_executions` that are older than a month.

## Risk

This change is safe to roll back. However, if a rollback becomes necessary, the block executions that occurred during the time this PR was in production will be lost.
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

This PR requires to manually run a SQL migration, I'll run:
```
ALTER TABLE block_executions
ADD COLUMN project BIGINT,
ADD COLUMN created BIGINT,
ADD FOREIGN KEY (project) REFERENCES projects(id);
```

## Test

- [x] Retrieve block executions of previous run (using the cache).
- [x] Retrieve block executions of new runs.
