### PR TITLE
Don't compute hash on block_executions

### DIFF
--- a/core/src/stores/migrations/20240429_block_executions_hash_drop_null
+++ b/core/src/stores/migrations/20240429_block_executions_hash_drop_null
@@ -1,0 +1,1 @@
+ALTER TABLE block_executions ALTER COLUMN hash DROP NOT NULL;

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -334,7 +334,7 @@ pub const POSTGRES_TABLES: [&'static str; 14] = [
     "-- block executions
     CREATE TABLE IF NOT EXISTS block_executions (
        id                   BIGSERIAL PRIMARY KEY,
-       hash                 TEXT NOT NULL,
+       hash                 TEXT,
        execution            TEXT NOT NULL,
        project              BIGINT,
        created              BIGINT,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR is a follow up of https://github.com/dust-tt/dust/pull/4900.

Now that ☝️ is in production, we've noticed a few conflicts on the `hash` field, despite incorporating the timestamp into the hash. Since no issues have been observed since the PR landed in production. This new PR aims to update the SQL table definition to drop the null constraint on the `hash` field. Additionally, we will cease computing hashes for `block_executions`.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
This PR requires a migration:
```
ALTER TABLE block_executions ALTER COLUMN hash DROP NOT NULL;
```

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
