### PR TITLE
AssistantBuilder: Move Actions validation to Actions components

### DIFF
--- a/front/components/assistant_builder/ActionScreen.tsx
+++ b/front/components/assistant_builder/ActionScreen.tsx
@@ -18,7 +18,6 @@ import type {
 } from "@dust-tt/types";
 import { assertNever } from "@dust-tt/types";
 import type { ComponentType, ReactNode } from "react";
-import { useEffect, useState } from "react";
 
 import {
   ActionProcess,
@@ -401,10 +400,9 @@ export default function ActionScreen({
           <ActionRetrievalSearch
             owner={owner}
             builderState={builderState}
+            dataSources={dataSources}
             setBuilderState={setBuilderState}
             setEdited={setEdited}
-            setRetrievalValid={setRetrievalValid}
-            dataSources={dataSources}
           />
         </ActionModeSection>
 
@@ -416,10 +414,9 @@ export default function ActionScreen({
           <ActionRetrievalExhaustive
             owner={owner}
             builderState={builderState}
+            dataSources={dataSources}
             setBuilderState={setBuilderState}
             setEdited={setEdited}
-            setRetrievalValid={setRetrievalValid}
-            dataSources={dataSources}
           />
         </ActionModeSection>
 
@@ -429,10 +426,9 @@ export default function ActionScreen({
           <ActionProcess
             owner={owner}
             builderState={builderState}
+            dataSources={dataSources}
             setBuilderState={setBuilderState}
             setEdited={setEdited}
-            setProcessValid={setProcessValid}
-            dataSources={dataSources}
           />
         </ActionModeSection>
 
@@ -442,10 +438,9 @@ export default function ActionScreen({
           <ActionTablesQuery
             owner={owner}
             builderState={builderState}
+            dataSources={dataSources}
             setBuilderState={setBuilderState}
             setEdited={setEdited}
-            setTablesQueryValid={setTablesQueryValid}
-            dataSources={dataSources}
           />
         </ActionModeSection>
 
@@ -453,10 +448,9 @@ export default function ActionScreen({
           <ActionDustAppRun
             owner={owner}
             builderState={builderState}
+            dustApps={dustApps}
             setBuilderState={setBuilderState}
             setEdited={setEdited}
-            setDustAppRunValid={setDustAppRunValid}
-            dustApps={dustApps}
           />
         </ActionModeSection>
       </div>

--- a/front/components/assistant_builder/ActionScreen.tsx
+++ b/front/components/assistant_builder/ActionScreen.tsx
@@ -18,6 +18,7 @@ import type {
 } from "@dust-tt/types";
 import { assertNever } from "@dust-tt/types";
 import type { ComponentType, ReactNode } from "react";
+import { useEffect, useState } from "react";
 
 import { ActionProcess } from "@app/components/assistant_builder/actions/ProcessAction";
 import {
@@ -129,21 +130,21 @@ function ActionModeSection({
 export default function ActionScreen({
   owner,
   builderState,
-  setBuilderState,
-  setEdited,
   dustApps,
   dataSources,
-  timeFrameError,
+  setBuilderState,
+  setEdited,
+  setActionsValid,
 }: {
   owner: WorkspaceType;
   builderState: AssistantBuilderState;
+  dataSources: DataSourceType[];
+  dustApps: AppType[];
   setBuilderState: (
     stateFn: (state: AssistantBuilderState) => AssistantBuilderState
   ) => void;
   setEdited: (edited: boolean) => void;
-  dataSources: DataSourceType[];
-  dustApps: AppType[];
-  timeFrameError: string | null;
+  setActionsValid: (valid: boolean) => void;
 }) {
   const getActionType = (actionMode: ActionMode) => {
     switch (actionMode) {
@@ -180,6 +181,38 @@ export default function ActionScreen({
         assertNever(actionMode);
     }
   };
+
+  const [retrievalValid, setRetrievalValid] = useState(true);
+  const [processValid, setProcessValid] = useState(true);
+  const [dustAppRunValid, setDustAppRunValid] = useState(true);
+  const [tablesQueryValid, setTablesQueryValid] = useState(true);
+
+  useEffect(() => {
+    let valid = true;
+    if (builderState.actionMode === "RETRIEVAL_SEARCH") {
+      valid = retrievalValid;
+    }
+    if (builderState.actionMode === "RETRIEVAL_EXHAUSTIVE") {
+      valid = retrievalValid;
+    }
+    if (builderState.actionMode === "PROCESS") {
+      valid = processValid;
+    }
+    if (builderState.actionMode === "DUST_APP_RUN") {
+      valid = dustAppRunValid;
+    }
+    if (builderState.actionMode === "TABLES_QUERY") {
+      valid = tablesQueryValid;
+    }
+    setActionsValid(valid);
+  }, [
+    setActionsValid,
+    builderState.actionMode,
+    retrievalValid,
+    processValid,
+    dustAppRunValid,
+    tablesQueryValid,
+  ]);
 
   const noDataSources =
     dataSources.length === 0 &&
@@ -375,6 +408,7 @@ export default function ActionScreen({
             builderState={builderState}
             setBuilderState={setBuilderState}
             setEdited={setEdited}
+            setRetrievalValid={setRetrievalValid}
             dataSources={dataSources}
           />
         </ActionModeSection>
@@ -389,8 +423,8 @@ export default function ActionScreen({
             builderState={builderState}
             setBuilderState={setBuilderState}
             setEdited={setEdited}
+            setRetrievalValid={setRetrievalValid}
             dataSources={dataSources}
-            timeFrameError={timeFrameError}
           />
         </ActionModeSection>
 
@@ -402,8 +436,8 @@ export default function ActionScreen({
             builderState={builderState}
             setBuilderState={setBuilderState}
             setEdited={setEdited}
+            setProcessValid={setProcessValid}
             dataSources={dataSources}
-            timeFrameError={timeFrameError}
           />
         </ActionModeSection>
 
@@ -415,6 +449,7 @@ export default function ActionScreen({
             builderState={builderState}
             setBuilderState={setBuilderState}
             setEdited={setEdited}
+            setTablesQueryValid={setTablesQueryValid}
             dataSources={dataSources}
           />
         </ActionModeSection>
@@ -425,6 +460,7 @@ export default function ActionScreen({
             builderState={builderState}
             setBuilderState={setBuilderState}
             setEdited={setEdited}
+            setDustAppRunValid={setDustAppRunValid}
             dustApps={dustApps}
           />
         </ActionModeSection>

--- a/front/components/assistant_builder/ActionScreen.tsx
+++ b/front/components/assistant_builder/ActionScreen.tsx
@@ -20,18 +20,28 @@ import { assertNever } from "@dust-tt/types";
 import type { ComponentType, ReactNode } from "react";
 import { useEffect, useState } from "react";
 
-import { ActionProcess } from "@app/components/assistant_builder/actions/ProcessAction";
+import {
+  ActionProcess,
+  isActionProcessValid,
+} from "@app/components/assistant_builder/actions/ProcessAction";
 import {
   ActionRetrievalExhaustive,
   ActionRetrievalSearch,
+  isActionRetrievalSearchValid,
 } from "@app/components/assistant_builder/actions/RetrievalAction";
-import { ActionTablesQuery } from "@app/components/assistant_builder/actions/TablesQueryAction";
+import {
+  ActionTablesQuery,
+  isActionTablesQueryValid,
+} from "@app/components/assistant_builder/actions/TablesQueryAction";
 import type {
   ActionMode,
   AssistantBuilderState,
 } from "@app/components/assistant_builder/types";
 
-import { ActionDustAppRun } from "./actions/DustAppRunAction";
+import {
+  ActionDustAppRun,
+  isActionDustAppRunValid,
+} from "./actions/DustAppRunAction";
 
 const BASIC_ACTION_TYPES = ["REPLY_ONLY", "USE_DATA_SOURCES"] as const;
 const ADVANCED_ACTION_TYPES = ["RUN_DUST_APP"] as const;
@@ -127,6 +137,25 @@ function ActionModeSection({
   return show && <div className="flex flex-col gap-6">{children}</div>;
 }
 
+export function isActionValid(builderState: AssistantBuilderState): boolean {
+  switch (builderState.actionMode) {
+    case "GENERIC":
+      return true;
+    case "RETRIEVAL_SEARCH":
+      return isActionRetrievalSearchValid(builderState);
+    case "RETRIEVAL_EXHAUSTIVE":
+      return isActionRetrievalSearchValid(builderState);
+    case "PROCESS":
+      return isActionProcessValid(builderState);
+    case "DUST_APP_RUN":
+      return isActionDustAppRunValid(builderState);
+    case "TABLES_QUERY":
+      return isActionTablesQueryValid(builderState);
+    default:
+      assertNever(builderState.actionMode);
+  }
+}
+
 export default function ActionScreen({
   owner,
   builderState,
@@ -134,7 +163,6 @@ export default function ActionScreen({
   dataSources,
   setBuilderState,
   setEdited,
-  setActionsValid,
 }: {
   owner: WorkspaceType;
   builderState: AssistantBuilderState;
@@ -144,7 +172,6 @@ export default function ActionScreen({
     stateFn: (state: AssistantBuilderState) => AssistantBuilderState
   ) => void;
   setEdited: (edited: boolean) => void;
-  setActionsValid: (valid: boolean) => void;
 }) {
   const getActionType = (actionMode: ActionMode) => {
     switch (actionMode) {
@@ -181,38 +208,6 @@ export default function ActionScreen({
         assertNever(actionMode);
     }
   };
-
-  const [retrievalValid, setRetrievalValid] = useState(true);
-  const [processValid, setProcessValid] = useState(true);
-  const [dustAppRunValid, setDustAppRunValid] = useState(true);
-  const [tablesQueryValid, setTablesQueryValid] = useState(true);
-
-  useEffect(() => {
-    let valid = true;
-    if (builderState.actionMode === "RETRIEVAL_SEARCH") {
-      valid = retrievalValid;
-    }
-    if (builderState.actionMode === "RETRIEVAL_EXHAUSTIVE") {
-      valid = retrievalValid;
-    }
-    if (builderState.actionMode === "PROCESS") {
-      valid = processValid;
-    }
-    if (builderState.actionMode === "DUST_APP_RUN") {
-      valid = dustAppRunValid;
-    }
-    if (builderState.actionMode === "TABLES_QUERY") {
-      valid = tablesQueryValid;
-    }
-    setActionsValid(valid);
-  }, [
-    setActionsValid,
-    builderState.actionMode,
-    retrievalValid,
-    processValid,
-    dustAppRunValid,
-    tablesQueryValid,
-  ]);
 
   const noDataSources =
     dataSources.length === 0 &&

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -303,11 +303,11 @@ export default function AssistantBuilder({
   const [edited, setEdited] = useState(defaultIsEdited ?? false);
   const [isSavingOrDeleting, setIsSavingOrDeleting] = useState(false);
   const [submitEnabled, setSubmitEnabled] = useState(false);
+  const [actionsValid, setActionsValid] = useState(true);
 
   const [assistantHandleError, setAssistantHandleError] = useState<
     string | null
   >(null);
-  const [timeFrameError, setTimeFrameError] = useState<string | null>(null);
 
   const checkUsernameTimeout = React.useRef<NodeJS.Timeout | null>(null);
 
@@ -416,67 +416,18 @@ export default function AssistantBuilder({
       valid = false;
     }
 
-    if (
-      builderState.actionMode === "RETRIEVAL_SEARCH" ||
-      builderState.actionMode === "RETRIEVAL_EXHAUSTIVE"
-    ) {
-      if (
-        Object.keys(
-          builderState.retrievalConfiguration.dataSourceConfigurations
-        ).length === 0
-      ) {
-        valid = false;
-      }
-    }
-    if (builderState.actionMode === "RETRIEVAL_EXHAUSTIVE") {
-      if (!builderState.retrievalConfiguration.timeFrame.value) {
-        valid = false;
-        setTimeFrameError("Timeframe must be a number");
-      } else {
-        setTimeFrameError(null);
-      }
-    }
-
-    if (builderState.actionMode === "DUST_APP_RUN") {
-      if (!builderState.dustAppConfiguration) {
-        valid = false;
-      }
-    }
-
-    if (builderState.actionMode === "TABLES_QUERY") {
-      if (!builderState.tablesQueryConfiguration) {
-        valid = false;
-      }
-    }
-
-    if (builderState.actionMode === "PROCESS") {
-      if (
-        Object.keys(builderState.processConfiguration.dataSourceConfigurations)
-          .length === 0
-      ) {
-        valid = false;
-      }
-      if (!builderState.processConfiguration.timeFrame.value) {
-        valid = false;
-        setTimeFrameError("Timeframe must be a number");
-      } else {
-        setTimeFrameError(null);
-      }
+    if (!actionsValid) {
+      valid = false;
     }
 
     setSubmitEnabled(valid);
   }, [
-    builderState.actionMode,
     builderState.handle,
     builderState.description,
     builderState.instructions,
     owner,
     initialBuilderState?.handle,
-    // Actions
-    builderState.retrievalConfiguration,
-    builderState.dustAppConfiguration,
-    builderState.tablesQueryConfiguration,
-    builderState.processConfiguration,
+    actionsValid,
   ]);
 
   useEffect(() => {
@@ -621,11 +572,11 @@ export default function AssistantBuilder({
                       <ActionScreen
                         owner={owner}
                         builderState={builderState}
-                        setBuilderState={setBuilderState}
-                        setEdited={setEdited}
                         dataSources={dataSources}
                         dustApps={dustApps}
-                        timeFrameError={timeFrameError}
+                        setBuilderState={setBuilderState}
+                        setEdited={setEdited}
+                        setActionsValid={setActionsValid}
                       />
                     );
                   case "naming":

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -44,7 +44,9 @@ import React from "react";
 import { useSWRConfig } from "swr";
 
 import { SharingButton } from "@app/components/assistant/Sharing";
-import ActionScreen from "@app/components/assistant_builder/ActionScreen";
+import ActionScreen, {
+  isActionValid,
+} from "@app/components/assistant_builder/ActionScreen";
 import AssistantBuilderRightPanel from "@app/components/assistant_builder/AssistantBuilderPreviewDrawer";
 import { InstructionScreen } from "@app/components/assistant_builder/InstructionScreen";
 import NamingScreen, {
@@ -303,7 +305,6 @@ export default function AssistantBuilder({
   const [edited, setEdited] = useState(defaultIsEdited ?? false);
   const [isSavingOrDeleting, setIsSavingOrDeleting] = useState(false);
   const [submitEnabled, setSubmitEnabled] = useState(false);
-  const [actionsValid, setActionsValid] = useState(true);
 
   const [assistantHandleError, setAssistantHandleError] = useState<
     string | null
@@ -416,19 +417,12 @@ export default function AssistantBuilder({
       valid = false;
     }
 
-    if (!actionsValid) {
+    if (!isActionValid(builderState)) {
       valid = false;
     }
 
     setSubmitEnabled(valid);
-  }, [
-    builderState.handle,
-    builderState.description,
-    builderState.instructions,
-    owner,
-    initialBuilderState?.handle,
-    actionsValid,
-  ]);
+  }, [builderState, owner, initialBuilderState?.handle]);
 
   useEffect(() => {
     void formValidation();
@@ -576,7 +570,6 @@ export default function AssistantBuilder({
                         dustApps={dustApps}
                         setBuilderState={setBuilderState}
                         setEdited={setEdited}
-                        setActionsValid={setActionsValid}
                       />
                     );
                   case "naming":

--- a/front/components/assistant_builder/actions/DustAppRunAction.tsx
+++ b/front/components/assistant_builder/actions/DustAppRunAction.tsx
@@ -1,7 +1,7 @@
 import { ContentMessage } from "@dust-tt/sparkle";
 import type { AppType, WorkspaceType } from "@dust-tt/types";
 import { assertNever } from "@dust-tt/types";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import AssistantBuilderDustAppModal from "@app/components/assistant_builder/AssistantBuilderDustAppModal";
 import DustAppSelectionSection from "@app/components/assistant_builder/DustAppSelectionSection";
@@ -12,6 +12,7 @@ export function ActionDustAppRun({
   builderState,
   setBuilderState,
   setEdited,
+  setDustAppRunValid,
   dustApps,
 }: {
   owner: WorkspaceType;
@@ -20,9 +21,18 @@ export function ActionDustAppRun({
     stateFn: (state: AssistantBuilderState) => AssistantBuilderState
   ) => void;
   setEdited: (edited: boolean) => void;
+  setDustAppRunValid: (valid: boolean) => void;
   dustApps: AppType[];
 }) {
   const [showDustAppsModal, setShowDustAppsModal] = useState(false);
+
+  useEffect(() => {
+    let valid = true;
+    if (!builderState.dustAppConfiguration.app) {
+      valid = false;
+    }
+    setDustAppRunValid(valid);
+  }, [builderState.dustAppConfiguration.app, setDustAppRunValid]);
 
   const deleteDustApp = () => {
     setEdited(true);

--- a/front/components/assistant_builder/actions/DustAppRunAction.tsx
+++ b/front/components/assistant_builder/actions/DustAppRunAction.tsx
@@ -1,18 +1,21 @@
 import { ContentMessage } from "@dust-tt/sparkle";
 import type { AppType, WorkspaceType } from "@dust-tt/types";
 import { assertNever } from "@dust-tt/types";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 import AssistantBuilderDustAppModal from "@app/components/assistant_builder/AssistantBuilderDustAppModal";
 import DustAppSelectionSection from "@app/components/assistant_builder/DustAppSelectionSection";
 import type { AssistantBuilderState } from "@app/components/assistant_builder/types";
+
+export function isActionDustAppRunValid(builderState: AssistantBuilderState) {
+  return !!builderState.dustAppConfiguration.app;
+}
 
 export function ActionDustAppRun({
   owner,
   builderState,
   setBuilderState,
   setEdited,
-  setDustAppRunValid,
   dustApps,
 }: {
   owner: WorkspaceType;
@@ -21,18 +24,9 @@ export function ActionDustAppRun({
     stateFn: (state: AssistantBuilderState) => AssistantBuilderState
   ) => void;
   setEdited: (edited: boolean) => void;
-  setDustAppRunValid: (valid: boolean) => void;
   dustApps: AppType[];
 }) {
   const [showDustAppsModal, setShowDustAppsModal] = useState(false);
-
-  useEffect(() => {
-    let valid = true;
-    if (!builderState.dustAppConfiguration.app) {
-      valid = false;
-    }
-    setDustAppRunValid(valid);
-  }, [builderState.dustAppConfiguration.app, setDustAppRunValid]);
 
   const deleteDustApp = () => {
     setEdited(true);

--- a/front/components/assistant_builder/actions/ProcessAction.tsx
+++ b/front/components/assistant_builder/actions/ProcessAction.tsx
@@ -1,7 +1,7 @@
 import { Button, DropdownMenu, Hoverable } from "@dust-tt/sparkle";
 import type { DataSourceType, WorkspaceType } from "@dust-tt/types";
 import type { TimeframeUnit } from "@dust-tt/types";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import AssistantBuilderDataSourceModal from "@app/components/assistant_builder/AssistantBuilderDataSourceModal";
 import DataSourceSelectionSection from "@app/components/assistant_builder/DataSourceSelectionSection";
@@ -14,8 +14,8 @@ export function ActionProcess({
   builderState,
   setBuilderState,
   setEdited,
+  setProcessValid,
   dataSources,
-  timeFrameError,
 }: {
   owner: WorkspaceType;
   builderState: AssistantBuilderState;
@@ -23,10 +23,34 @@ export function ActionProcess({
     stateFn: (state: AssistantBuilderState) => AssistantBuilderState
   ) => void;
   setEdited: (edited: boolean) => void;
+  setProcessValid: (valid: boolean) => void;
   dataSources: DataSourceType[];
-  timeFrameError: string | null;
 }) {
   const [showDataSourcesModal, setShowDataSourcesModal] = useState(false);
+  const [timeFrameError, setTimeFrameError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let valid = true;
+    if (
+      Object.keys(builderState.processConfiguration.dataSourceConfigurations)
+        .length === 0
+    ) {
+      valid = false;
+    }
+
+    if (!builderState.processConfiguration.timeFrame.value) {
+      valid = false;
+      setTimeFrameError("Timeframe must be a number");
+    } else {
+      setTimeFrameError(null);
+    }
+
+    setProcessValid(valid);
+  }, [
+    builderState.processConfiguration.dataSourceConfigurations,
+    builderState.processConfiguration.timeFrame.value,
+    setProcessValid,
+  ]);
 
   const deleteDataSource = (name: string) => {
     if (builderState.processConfiguration.dataSourceConfigurations[name]) {

--- a/front/components/assistant_builder/actions/ProcessAction.tsx
+++ b/front/components/assistant_builder/actions/ProcessAction.tsx
@@ -9,12 +9,18 @@ import { TIME_FRAME_UNIT_TO_LABEL } from "@app/components/assistant_builder/shar
 import type { AssistantBuilderState } from "@app/components/assistant_builder/types";
 import { classNames } from "@app/lib/utils";
 
+export function isActionProcessValid(builderState: AssistantBuilderState) {
+  return (
+    Object.keys(builderState.processConfiguration.dataSourceConfigurations)
+      .length > 0 && !!builderState.processConfiguration.timeFrame.value
+  );
+}
+
 export function ActionProcess({
   owner,
   builderState,
   setBuilderState,
   setEdited,
-  setProcessValid,
   dataSources,
 }: {
   owner: WorkspaceType;
@@ -23,33 +29,20 @@ export function ActionProcess({
     stateFn: (state: AssistantBuilderState) => AssistantBuilderState
   ) => void;
   setEdited: (edited: boolean) => void;
-  setProcessValid: (valid: boolean) => void;
   dataSources: DataSourceType[];
 }) {
   const [showDataSourcesModal, setShowDataSourcesModal] = useState(false);
   const [timeFrameError, setTimeFrameError] = useState<string | null>(null);
 
   useEffect(() => {
-    let valid = true;
-    if (
-      Object.keys(builderState.processConfiguration.dataSourceConfigurations)
-        .length === 0
-    ) {
-      valid = false;
-    }
-
     if (!builderState.processConfiguration.timeFrame.value) {
-      valid = false;
       setTimeFrameError("Timeframe must be a number");
     } else {
       setTimeFrameError(null);
     }
-
-    setProcessValid(valid);
   }, [
     builderState.processConfiguration.dataSourceConfigurations,
     builderState.processConfiguration.timeFrame.value,
-    setProcessValid,
   ]);
 
   const deleteDataSource = (name: string) => {

--- a/front/components/assistant_builder/actions/RetrievalAction.tsx
+++ b/front/components/assistant_builder/actions/RetrievalAction.tsx
@@ -36,12 +36,20 @@ const deleteDataSource = (
   });
 };
 
+export function isActionRetrievalSearchValid(
+  builderState: AssistantBuilderState
+) {
+  return (
+    Object.keys(builderState.retrievalConfiguration.dataSourceConfigurations)
+      .length > 0
+  );
+}
+
 export function ActionRetrievalSearch({
   owner,
   builderState,
   setBuilderState,
   setEdited,
-  setRetrievalValid,
   dataSources,
 }: {
   owner: WorkspaceType;
@@ -50,24 +58,9 @@ export function ActionRetrievalSearch({
     stateFn: (state: AssistantBuilderState) => AssistantBuilderState
   ) => void;
   setEdited: (edited: boolean) => void;
-  setRetrievalValid: (valid: boolean) => void;
   dataSources: DataSourceType[];
 }) {
   const [showDataSourcesModal, setShowDataSourcesModal] = useState(false);
-
-  useEffect(() => {
-    let valid = true;
-    if (
-      Object.keys(builderState.retrievalConfiguration.dataSourceConfigurations)
-        .length === 0
-    ) {
-      valid = false;
-    }
-    setRetrievalValid(valid);
-  }, [
-    builderState.retrievalConfiguration.dataSourceConfigurations,
-    setRetrievalValid,
-  ]);
 
   return (
     <>
@@ -120,12 +113,20 @@ export function ActionRetrievalSearch({
   );
 }
 
+export function isActionRetrievalExhaustiveValid(
+  builderState: AssistantBuilderState
+) {
+  return (
+    Object.keys(builderState.retrievalConfiguration.dataSourceConfigurations)
+      .length > 0 && !!builderState.retrievalConfiguration.timeFrame.value
+  );
+}
+
 export function ActionRetrievalExhaustive({
   owner,
   builderState,
   setBuilderState,
   setEdited,
-  setRetrievalValid,
   dataSources,
 }: {
   owner: WorkspaceType;
@@ -134,33 +135,20 @@ export function ActionRetrievalExhaustive({
     stateFn: (state: AssistantBuilderState) => AssistantBuilderState
   ) => void;
   setEdited: (edited: boolean) => void;
-  setRetrievalValid: (valid: boolean) => void;
   dataSources: DataSourceType[];
 }) {
   const [showDataSourcesModal, setShowDataSourcesModal] = useState(false);
   const [timeFrameError, setTimeFrameError] = useState<string | null>(null);
 
   useEffect(() => {
-    let valid = true;
-    if (
-      Object.keys(builderState.retrievalConfiguration.dataSourceConfigurations)
-        .length === 0
-    ) {
-      valid = false;
-    }
-
     if (!builderState.retrievalConfiguration.timeFrame.value) {
-      valid = false;
       setTimeFrameError("Timeframe must be a number");
     } else {
       setTimeFrameError(null);
     }
-
-    setRetrievalValid(valid);
   }, [
     builderState.retrievalConfiguration.dataSourceConfigurations,
     builderState.retrievalConfiguration.timeFrame.value,
-    setRetrievalValid,
   ]);
 
   return (

--- a/front/components/assistant_builder/actions/RetrievalAction.tsx
+++ b/front/components/assistant_builder/actions/RetrievalAction.tsx
@@ -1,7 +1,7 @@
 import { Button, DropdownMenu } from "@dust-tt/sparkle";
 import type { DataSourceType, WorkspaceType } from "@dust-tt/types";
 import type { TimeframeUnit } from "@dust-tt/types";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import AssistantBuilderDataSourceModal from "@app/components/assistant_builder/AssistantBuilderDataSourceModal";
 import DataSourceSelectionSection from "@app/components/assistant_builder/DataSourceSelectionSection";
@@ -41,6 +41,7 @@ export function ActionRetrievalSearch({
   builderState,
   setBuilderState,
   setEdited,
+  setRetrievalValid,
   dataSources,
 }: {
   owner: WorkspaceType;
@@ -49,9 +50,24 @@ export function ActionRetrievalSearch({
     stateFn: (state: AssistantBuilderState) => AssistantBuilderState
   ) => void;
   setEdited: (edited: boolean) => void;
+  setRetrievalValid: (valid: boolean) => void;
   dataSources: DataSourceType[];
 }) {
   const [showDataSourcesModal, setShowDataSourcesModal] = useState(false);
+
+  useEffect(() => {
+    let valid = true;
+    if (
+      Object.keys(builderState.retrievalConfiguration.dataSourceConfigurations)
+        .length === 0
+    ) {
+      valid = false;
+    }
+    setRetrievalValid(valid);
+  }, [
+    builderState.retrievalConfiguration.dataSourceConfigurations,
+    setRetrievalValid,
+  ]);
 
   return (
     <>
@@ -109,8 +125,8 @@ export function ActionRetrievalExhaustive({
   builderState,
   setBuilderState,
   setEdited,
+  setRetrievalValid,
   dataSources,
-  timeFrameError,
 }: {
   owner: WorkspaceType;
   builderState: AssistantBuilderState;
@@ -118,10 +134,34 @@ export function ActionRetrievalExhaustive({
     stateFn: (state: AssistantBuilderState) => AssistantBuilderState
   ) => void;
   setEdited: (edited: boolean) => void;
+  setRetrievalValid: (valid: boolean) => void;
   dataSources: DataSourceType[];
-  timeFrameError: string | null;
 }) {
   const [showDataSourcesModal, setShowDataSourcesModal] = useState(false);
+  const [timeFrameError, setTimeFrameError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let valid = true;
+    if (
+      Object.keys(builderState.retrievalConfiguration.dataSourceConfigurations)
+        .length === 0
+    ) {
+      valid = false;
+    }
+
+    if (!builderState.retrievalConfiguration.timeFrame.value) {
+      valid = false;
+      setTimeFrameError("Timeframe must be a number");
+    } else {
+      setTimeFrameError(null);
+    }
+
+    setRetrievalValid(valid);
+  }, [
+    builderState.retrievalConfiguration.dataSourceConfigurations,
+    builderState.retrievalConfiguration.timeFrame.value,
+    setRetrievalValid,
+  ]);
 
   return (
     <>

--- a/front/components/assistant_builder/actions/TablesQueryAction.tsx
+++ b/front/components/assistant_builder/actions/TablesQueryAction.tsx
@@ -11,7 +11,7 @@ import type {
 import { tableKey } from "@app/lib/client/tables_query";
 
 export function isActionTablesQueryValid(builderState: AssistantBuilderState) {
-  return !!builderState.tablesQueryConfiguration;
+  return Object.keys(builderState.tablesQueryConfiguration).length > 0;
 }
 
 export function ActionTablesQuery({

--- a/front/components/assistant_builder/actions/TablesQueryAction.tsx
+++ b/front/components/assistant_builder/actions/TablesQueryAction.tsx
@@ -1,6 +1,6 @@
 import { Hoverable } from "@dust-tt/sparkle";
 import type { DataSourceType, WorkspaceType } from "@dust-tt/types";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 import AssistantBuilderTablesModal from "@app/components/assistant_builder/AssistantBuilderTablesModal";
 import TablesSelectionSection from "@app/components/assistant_builder/TablesSelectionSection";
@@ -10,12 +10,15 @@ import type {
 } from "@app/components/assistant_builder/types";
 import { tableKey } from "@app/lib/client/tables_query";
 
+export function isActionTablesQueryValid(builderState: AssistantBuilderState) {
+  return !!builderState.tablesQueryConfiguration;
+}
+
 export function ActionTablesQuery({
   owner,
   builderState,
   setBuilderState,
   setEdited,
-  setTablesQueryValid,
   dataSources,
 }: {
   owner: WorkspaceType;
@@ -24,18 +27,9 @@ export function ActionTablesQuery({
     stateFn: (state: AssistantBuilderState) => AssistantBuilderState
   ) => void;
   setEdited: (edited: boolean) => void;
-  setTablesQueryValid: (valid: boolean) => void;
   dataSources: DataSourceType[];
 }) {
   const [showTableModal, setShowTableModal] = useState(false);
-
-  useEffect(() => {
-    let valid = true;
-    if (!builderState.tablesQueryConfiguration) {
-      valid = false;
-    }
-    setTablesQueryValid(valid);
-  }, [builderState.tablesQueryConfiguration, setTablesQueryValid]);
 
   return (
     <>

--- a/front/components/assistant_builder/actions/TablesQueryAction.tsx
+++ b/front/components/assistant_builder/actions/TablesQueryAction.tsx
@@ -1,6 +1,6 @@
 import { Hoverable } from "@dust-tt/sparkle";
 import type { DataSourceType, WorkspaceType } from "@dust-tt/types";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import AssistantBuilderTablesModal from "@app/components/assistant_builder/AssistantBuilderTablesModal";
 import TablesSelectionSection from "@app/components/assistant_builder/TablesSelectionSection";
@@ -15,6 +15,7 @@ export function ActionTablesQuery({
   builderState,
   setBuilderState,
   setEdited,
+  setTablesQueryValid,
   dataSources,
 }: {
   owner: WorkspaceType;
@@ -23,9 +24,18 @@ export function ActionTablesQuery({
     stateFn: (state: AssistantBuilderState) => AssistantBuilderState
   ) => void;
   setEdited: (edited: boolean) => void;
+  setTablesQueryValid: (valid: boolean) => void;
   dataSources: DataSourceType[];
 }) {
   const [showTableModal, setShowTableModal] = useState(false);
+
+  useEffect(() => {
+    let valid = true;
+    if (!builderState.tablesQueryConfiguration) {
+      valid = false;
+    }
+    setTablesQueryValid(valid);
+  }, [builderState.tablesQueryConfiguration, setTablesQueryValid]);
 
   return (
     <>


### PR DESCRIPTION
## Description

The current solution involves props drilling which is not great, but motivated by the expectation that we will iterate on the Action components quite a lot as part of Multi-actions so it was better this than to cut an interface using a forwardRef + imperative implementation.

Moving forward we'll want to leverage forwardRef + an interface to retrieve the validity of an action on the component itself + provide the same abstraction in ActionScreen etc...

Also fixes DustAppRun validation which was broken by the move to the type { app: AppTytpe} instead of AppType

## Risk

N/A

## Deploy Plan

- deploy `front`