### PR TITLE
enh: tweak the use-tools app

### DIFF
--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -318,7 +318,8 @@ export async function getNextAction(
     Error
   >
 > {
-  const prompt = await constructPrompt(
+  // TODO(@fontanierh): Make a new one for multi actions.
+  let prompt = await constructPrompt(
     auth,
     userMessage,
     agentConfiguration,
@@ -331,6 +332,7 @@ export async function getNextAction(
   const MIN_GENERATION_TOKENS = 2048;
 
   // Turn the conversation into a digest that can be presented to the model.
+  // TODO(@fontanierh): Make a new one for multi actions.
   const modelConversationRes = await renderConversationForModel({
     conversation,
     model,
@@ -404,6 +406,7 @@ export async function getNextAction(
         "Reply to the user with a message. You don't need to generate any arguments for this function.",
       inputs: [],
     });
+    prompt = `${prompt}\nIf you don't know which function to use, use \`reply_to_user\`.`;
   }
 
   const config = cloneBaseConfig(

--- a/types/src/front/lib/actions/registry.ts
+++ b/types/src/front/lib/actions/registry.ts
@@ -219,7 +219,7 @@ export const DustProdActionRegistry = createActionRegistry({
       workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
       appId: "0e9889c787",
       appHash:
-        "e2be0e5ee990a6ef86d1a89c8b55f924ff93dd6daaa0a502984d63b159c65ffd",
+        "388a8ab72120c22d0865fd6fbbaf060b0034f30473c57d2eccb6d866d8297f88",
     },
     config: {
       MODEL: {


### PR DESCRIPTION
## Description

Current version hard-coded the `If you don't know which function to use, use \`reply_to_user\`` metaprompt, which doesn't make sense when there is no such function. I also tweaked the instructions a bit to make it less likely that the model won't generate anything

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
