### PR TITLE
Stop removing trailing AgentMessages for title generation.

### DIFF
--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -338,6 +338,7 @@ export async function getNextAction(
     model,
     prompt,
     allowedTokenCount: model.contextSize - MIN_GENERATION_TOKENS,
+    removeTrailingAgentMessages: true,
   });
 
   if (modelConversationRes.isErr()) {

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -441,6 +441,7 @@ export async function generateConversationTitle(
     model,
     prompt: "", // There is no prompt for title generation.
     allowedTokenCount: contextSize - MIN_GENERATION_TOKENS,
+    removeTrailingAgentMessages: false,
   });
 
   if (modelConversationRes.isErr()) {

--- a/front/lib/api/assistant/legacy_agent.ts
+++ b/front/lib/api/assistant/legacy_agent.ts
@@ -96,6 +96,7 @@ async function generateActionInputs(
     model,
     prompt,
     allowedTokenCount: contextSize - MIN_GENERATION_TOKENS,
+    removeTrailingAgentMessages: true,
   });
 
   if (modelConversationRes.isErr()) {


### PR DESCRIPTION
## Description

Stop removing trailing Agent Messages for title generation.

This [PR](https://github.com/dust-tt/dust/pull/4856) modified `renderConversationForModel()` to make sure the first message rendered is never an agent message because Anthropic models require the first message to always be a user message.

That change in behavior seems to be causing an error at the title generation step, because an agent message could ~easily fill up the small context window of gpt-3.5turbo, leading to an empty array for the rendered conversation.

We can see the error uptick in title generation [here](https://app.datadoghq.eu/logs?query=%22Action%20run%20error%22%20%40action%3Aassistant-v2-title-generator&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AgAAAY8qTefjTbgq5AAAAAAAAAAYAAAAAEFZOHFUZkxMQUFBcWpKNEU4eF9wOUFBbAAAACQAAAAAMDE4ZjJhNTItYjM1ZC00MGJjLTg1MDAtZDY0NDc1NzFhM2I1&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1695718930063&to_ts=1695722530063&live=true).

If the error rate does not significantly go down after deploying this pull request, we can revert this PR.




<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
