### PR TITLE
Fix: duplicate Data Source name in website configuration UI.

### DIFF
--- a/front/components/data_source/WebsiteConfiguration.tsx
+++ b/front/components/data_source/WebsiteConfiguration.tsx
@@ -126,20 +126,18 @@ export default function WebsiteConfiguration({
         exists = true;
       }
     });
+    const dataSourceNameRes = isDataSourceNameValid(dataSourceName);
 
     if (exists) {
       setDataSourceNameError("A Folder with the same name already exists");
       valid = false;
-    }
-    const dataSourceNameRes = isDataSourceNameValid(dataSourceName);
-    if (dataSourceNameRes.isErr()) {
+    } else if (dataSourceNameRes.isErr()) {
       setDataSourceNameError(dataSourceNameRes.error);
       valid = false;
     } else {
       setDataSourceNameError("");
       valid = true;
     }
-
     setIsEdited(true);
     setIsValid(valid);
   }, [dataSourceName, dataSources, dataSourceUrl, dataSource?.id]);


### PR DESCRIPTION
## Description

The website configuration UI has a bug that  allows the user to create a data source with an already existing name.
This PR fixes it.

Task is [here](https://github.com/dust-tt/tasks/issues/716).

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
