### PR TITLE
Set connector.errorType=null when updating a connector

### DIFF
--- a/connectors/src/api/update_connector.ts
+++ b/connectors/src/api/update_connector.ts
@@ -77,6 +77,8 @@ const _postConnectorUpdateAPIHandler = async (
     }
   }
 
+  await connector.update({ errorType: null });
+
   return res.status(200).json({
     connectorId: updateRes.value,
   });


### PR DESCRIPTION
## Description

When updating a connector, the `connector.errorType` field was never updated, which does not make sense.

The connector should be marked as "non errored", and the update logic should trigger a workflow and the workflow should mark it as errored if appropriate.

Today, this error field has 3 possible values outside of null:
```
const CONNECTORS_ERROR_TYPES = [
  "oauth_token_revoked",
  "third_party_internal_error",
  "webcrawling_error",
] as const;
```

- oauth_token_revoked: update of the connector should remove this error because the `connectionId` is updated.
- third_party_internal_error: this one is ambiguous, but giving another chance to complete is reasonable. 
- webcrawling_error: there is no way to update a connector today, so there is no issue with this one.





<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
