### PR TITLE
[Dev secrets] Add API key names and remove ability to view keys

### DIFF
--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -488,7 +488,6 @@ export async function getAPIKey(
     });
   }
 
-  console.log('SAVING KEY LAST USED AT')
   key.lastUsedAt = new Date();
   await key.save();
 

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -472,13 +472,11 @@ export async function getAPIKey(
     });
   }
 
-  const [key] = await Promise.all([
-    Key.findOne({
-      where: {
-        secret: parse[1],
-      },
-    }),
-  ]);
+  const key = await Key.findOne({
+    where: {
+      secret: parse[1],
+    },
+  });
 
   if (!key || key.status !== "active") {
     return new Err({
@@ -489,6 +487,10 @@ export async function getAPIKey(
       },
     });
   }
+
+  console.log('SAVING KEY LAST USED AT')
+  key.lastUsedAt = new Date();
+  await key.save();
 
   return new Ok(key);
 }

--- a/front/lib/models/workspace.ts
+++ b/front/lib/models/workspace.ts
@@ -210,7 +210,7 @@ export class Key extends Model<
   declare id: CreationOptional<number>;
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
-  declare lastUsedAt: Date | null;
+  declare lastUsedAt: CreationOptional<Date>;
 
   declare secret: string;
   declare status: "active" | "disabled";

--- a/front/lib/models/workspace.ts
+++ b/front/lib/models/workspace.ts
@@ -210,6 +210,7 @@ export class Key extends Model<
   declare id: CreationOptional<number>;
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
+  declare lastUsedAt: Date | null;
 
   declare secret: string;
   declare status: "active" | "disabled";
@@ -237,6 +238,10 @@ Key.init(
       type: DataTypes.DATE,
       allowNull: false,
       defaultValue: DataTypes.NOW,
+    },
+    lastUsedAt: {
+      type: DataTypes.DATE,
+      allowNull: true,
     },
     secret: {
       type: DataTypes.STRING,

--- a/front/lib/models/workspace.ts
+++ b/front/lib/models/workspace.ts
@@ -218,6 +218,7 @@ export class Key extends Model<
   declare userId: ForeignKey<User["id"]>;
   declare workspaceId: ForeignKey<Workspace["id"]>;
 
+  declare name: string | null;
   declare user: NonAttribute<User>;
 }
 Key.init(
@@ -244,6 +245,10 @@ Key.init(
     status: {
       type: DataTypes.STRING,
       allowNull: false,
+    },
+    name: {
+      type: DataTypes.STRING,
+      allowNull: true,
     },
     isSystem: {
       type: DataTypes.BOOLEAN,

--- a/front/pages/api/w/[wId]/keys/[id]/disable.ts
+++ b/front/pages/api/w/[wId]/keys/[id]/disable.ts
@@ -55,6 +55,7 @@ async function handler(
           id: key.id,
           createdAt: key.createdAt.getTime(),
           creator: null,
+          lastUsedAt: key.lastUsedAt?.getTime() || null,
           secret: key.secret,
           status: key.status,
           name: key.name,

--- a/front/pages/api/w/[wId]/keys/[id]/disable.ts
+++ b/front/pages/api/w/[wId]/keys/[id]/disable.ts
@@ -33,7 +33,7 @@ async function handler(
   const [key] = await Promise.all([
     Key.findOne({
       where: {
-        secret: req.query.secret,
+        id: req.query.id,
         workspaceId: owner.id,
       },
     }),
@@ -52,6 +52,7 @@ async function handler(
 
       res.status(200).json({
         key: {
+          id: key.id,
           createdAt: key.createdAt.getTime(),
           creator: null,
           secret: key.secret,

--- a/front/pages/api/w/[wId]/keys/[secret]/disable.ts
+++ b/front/pages/api/w/[wId]/keys/[secret]/disable.ts
@@ -56,6 +56,7 @@ async function handler(
           creator: null,
           secret: key.secret,
           status: key.status,
+          name: key.name,
         },
       });
       return;

--- a/front/pages/api/w/[wId]/keys/index.ts
+++ b/front/pages/api/w/[wId]/keys/index.ts
@@ -1,6 +1,6 @@
 import type { KeyType } from "@dust-tt/types";
 import { formatUserFullName, redactString } from "@dust-tt/types";
-import { isLeft } from 'fp-ts/Either';
+import { isLeft } from "fp-ts/Either";
 import * as t from "io-ts";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -9,7 +9,6 @@ import { User } from "@app/lib/models/user";
 import { Key } from "@app/lib/models/workspace";
 import { new_id } from "@app/lib/utils";
 import { withLogging } from "@app/logger/withlogging";
-
 
 export type GetKeysResponseBody = {
   keys: KeyType[];
@@ -89,12 +88,12 @@ async function handler(
       const Name = t.type({
         name: t.string,
       });
-        
-      const result = Name.decode(req.body);
-      if (isLeft(result)) {
-        throw new Error('Invalid request body');
+
+      const bodyValidation = Name.decode(req.body);
+      if (isLeft(bodyValidation)) {
+        throw new Error("Invalid request body");
       }
-      const { name } = result.right;
+      const { name } = bodyValidation.right;
       const secret = `sk-${new_id().slice(0, 32)}`;
 
       const key = await Key.create({

--- a/front/pages/api/w/[wId]/keys/index.ts
+++ b/front/pages/api/w/[wId]/keys/index.ts
@@ -22,11 +22,10 @@ const Name = t.type({
   name: t.string,
 });
 
-
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-  WithAPIErrorReponse<GetKeysResponseBody | PostKeysResponseBody>
+    WithAPIErrorReponse<GetKeysResponseBody | PostKeysResponseBody>
   >
 ): Promise<void> {
   const session = await getSession(req, res);
@@ -50,15 +49,6 @@ async function handler(
   switch (req.method) {
     case "GET":
       const keys = await Key.findAll({
-        attributes: [
-          "id",
-          "createdAt",
-          "lastUsedAt",
-          "secret",
-          "status",
-          "userId",
-          "name",
-        ],
         where: {
           workspaceId: owner.id,
           isSystem: false,
@@ -103,13 +93,13 @@ async function handler(
     case "POST":
       const bodyValidation = Name.decode(req.body);
       if (isLeft(bodyValidation)) {
-        return apiError(req, res,{
+        return apiError(req, res, {
           status_code: 404,
           api_error: {
             type: "invalid_request_error",
             message: "Invalid request body",
-          }
-      });
+          },
+        });
       }
       const { name } = bodyValidation.right;
       const secret = `sk-${new_id().slice(0, 32)}`;

--- a/front/pages/api/w/[wId]/keys/index.ts
+++ b/front/pages/api/w/[wId]/keys/index.ts
@@ -1,5 +1,5 @@
 import type { KeyType } from "@dust-tt/types";
-import { formatUserFullName } from "@dust-tt/types";
+import { formatUserFullName, redactString } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { Authenticator, getSession } from "@app/lib/auth";
@@ -70,7 +70,7 @@ async function handler(
             const differenceInMinutes = Math.ceil(timeDifference / (1000 * 60));
 
             if (differenceInMinutes > 10) {
-              return k.secret.slice(0, 4) + "..." + k.secret.slice(-4);
+              return redactString(k.secret, 4);
             } else {
               return k.secret;
             }

--- a/front/pages/api/w/[wId]/keys/index.ts
+++ b/front/pages/api/w/[wId]/keys/index.ts
@@ -61,26 +61,20 @@ async function handler(
       res.status(200).json({
         keys: keys.map((k) => {
           // We only display the full secret key for the first 10 minutes after creation.
-          const getSecret = () => {
-            const currentTime = new Date();
-            const createdAt = new Date(k.createdAt);
-            const timeDifference = Math.abs(
-              currentTime.getTime() - createdAt.getTime()
-            );
-            const differenceInMinutes = Math.ceil(timeDifference / (1000 * 60));
+          const currentTime = new Date();
+          const createdAt = new Date(k.createdAt);
+          const timeDifference = Math.abs(
+            currentTime.getTime() - createdAt.getTime()
+          );
+          const differenceInMinutes = Math.ceil(timeDifference / (1000 * 60));
+          const secret = differenceInMinutes > 10 ? redactString(k.secret, 4) : k.secret;
 
-            if (differenceInMinutes > 10) {
-              return redactString(k.secret, 4);
-            } else {
-              return k.secret;
-            }
-          };
           return {
             id: k.id,
             createdAt: k.createdAt.getTime(),
             creator: formatUserFullName(k.user),
             name: k.name,
-            secret: getSecret(),
+            secret,
             status: k.status,
           };
         }),

--- a/front/pages/api/w/[wId]/keys/index.ts
+++ b/front/pages/api/w/[wId]/keys/index.ts
@@ -41,7 +41,7 @@ async function handler(
   switch (req.method) {
     case "GET":
       const keys = await Key.findAll({
-        attributes: ["createdAt", "secret", "status", "userId", "name"],
+        attributes: ["id", "createdAt", "secret", "status", "userId", "name"],
         where: {
           workspaceId: owner.id,
           isSystem: false,
@@ -76,6 +76,7 @@ async function handler(
             }
           };
           return {
+            id: k.id,
             createdAt: k.createdAt.getTime(),
             creator: formatUserFullName(k.user),
             name: k.name,
@@ -101,6 +102,7 @@ async function handler(
 
       res.status(201).json({
         key: {
+          id: key.id,
           createdAt: key.createdAt.getTime(),
           creator: formatUserFullName(key.user),
           name: key.name,

--- a/front/pages/api/w/[wId]/keys/index.ts
+++ b/front/pages/api/w/[wId]/keys/index.ts
@@ -1,5 +1,7 @@
 import type { KeyType } from "@dust-tt/types";
 import { formatUserFullName, redactString } from "@dust-tt/types";
+import { isLeft } from 'fp-ts/Either';
+import * as t from "io-ts";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { Authenticator, getSession } from "@app/lib/auth";
@@ -7,6 +9,7 @@ import { User } from "@app/lib/models/user";
 import { Key } from "@app/lib/models/workspace";
 import { new_id } from "@app/lib/utils";
 import { withLogging } from "@app/logger/withlogging";
+
 
 export type GetKeysResponseBody = {
   keys: KeyType[];
@@ -83,7 +86,15 @@ async function handler(
       return;
 
     case "POST":
-      const { name } = req.body;
+      const Name = t.type({
+        name: t.string,
+      });
+        
+      const result = Name.decode(req.body);
+      if (isLeft(result)) {
+        throw new Error('Invalid request body');
+      }
+      const { name } = result.right;
       const secret = `sk-${new_id().slice(0, 32)}`;
 
       const key = await Key.create({

--- a/front/pages/api/w/[wId]/keys/index.ts
+++ b/front/pages/api/w/[wId]/keys/index.ts
@@ -41,7 +41,7 @@ async function handler(
   switch (req.method) {
     case "GET":
       const keys = await Key.findAll({
-        attributes: ["createdAt", "secret", "status", "userId"],
+        attributes: ["createdAt", "secret", "status", "userId", "name"],
         where: {
           workspaceId: owner.id,
           isSystem: false,
@@ -60,10 +60,11 @@ async function handler(
 
       res.status(200).json({
         keys: keys.map((k) => {
+          const truncatedSecret = k.secret.slice(0, 4) + "..." + k.secret.slice(-4);
           return {
             createdAt: k.createdAt.getTime(),
             creator: formatUserFullName(k.user),
-            secret: k.secret,
+            secret: k.name || truncatedSecret,
             status: k.status,
           };
         }),
@@ -71,9 +72,12 @@ async function handler(
       return;
 
     case "POST":
+      console.log("REQUEST BODY", req.body)
+      const name = req.body.name;
       const secret = `sk-${new_id().slice(0, 32)}`;
 
       const key = await Key.create({
+        name: name,
         secret: secret,
         status: "active",
         userId: user?.id,

--- a/front/pages/api/w/[wId]/keys/index.ts
+++ b/front/pages/api/w/[wId]/keys/index.ts
@@ -87,7 +87,7 @@ async function handler(
       return;
 
     case "POST":
-      const name = req.body.name;
+      const { name } = req.body;
       const secret = `sk-${new_id().slice(0, 32)}`;
 
       const key = await Key.create({

--- a/front/pages/api/w/[wId]/keys/index.ts
+++ b/front/pages/api/w/[wId]/keys/index.ts
@@ -43,7 +43,15 @@ async function handler(
   switch (req.method) {
     case "GET":
       const keys = await Key.findAll({
-        attributes: ["id", "createdAt", "secret", "status", "userId", "name"],
+        attributes: [
+          "id",
+          "createdAt",
+          "lastUsedAt",
+          "secret",
+          "status",
+          "userId",
+          "name",
+        ],
         where: {
           workspaceId: owner.id,
           isSystem: false,
@@ -75,6 +83,7 @@ async function handler(
           return {
             id: k.id,
             createdAt: k.createdAt.getTime(),
+            lastUsedAt: k.lastUsedAt?.getTime() ?? null,
             creator: formatUserFullName(k.user),
             name: k.name,
             secret,
@@ -110,6 +119,7 @@ async function handler(
           id: key.id,
           createdAt: key.createdAt.getTime(),
           creator: formatUserFullName(key.user),
+          lastUsedAt: null,
           name: key.name,
           secret: key.secret,
           status: key.status,

--- a/front/pages/api/w/[wId]/keys/index.ts
+++ b/front/pages/api/w/[wId]/keys/index.ts
@@ -18,7 +18,7 @@ export type PostKeysResponseBody = {
   key: KeyType;
 };
 
-const Name = t.type({
+const CreateKeyPostBodySchema = t.type({
   name: t.string,
 });
 
@@ -91,7 +91,7 @@ async function handler(
       return;
 
     case "POST":
-      const bodyValidation = Name.decode(req.body);
+      const bodyValidation = CreateKeyPostBodySchema.decode(req.body);
       if (isLeft(bodyValidation)) {
         return apiError(req, res, {
           status_code: 404,

--- a/front/pages/api/w/[wId]/keys/index.ts
+++ b/front/pages/api/w/[wId]/keys/index.ts
@@ -67,7 +67,8 @@ async function handler(
             currentTime.getTime() - createdAt.getTime()
           );
           const differenceInMinutes = Math.ceil(timeDifference / (1000 * 60));
-          const secret = differenceInMinutes > 10 ? redactString(k.secret, 4) : k.secret;
+          const secret =
+            differenceInMinutes > 10 ? redactString(k.secret, 4) : k.secret;
 
           return {
             id: k.id,

--- a/front/pages/w/[wId]/a/index.tsx
+++ b/front/pages/w/[wId]/a/index.tsx
@@ -168,6 +168,19 @@ export function APIKeys({ owner }: { owner: WorkspaceType }) {
                             })}{" "}
                             ago.
                           </p>
+                          <p className="front-normal text-xs text-element-700">
+                            {key.lastUsedAt ? (
+                              <>
+                                Last used&nbsp;
+                                {timeAgoFrom(key.lastUsedAt, {
+                                  useLongFormat: true,
+                                })}{" "}
+                                ago.
+                              </>
+                            ) : (
+                              <>Never used</>
+                            )}
+                          </p>
                         </div>
                       </div>
                     </div>

--- a/front/pages/w/[wId]/a/index.tsx
+++ b/front/pages/w/[wId]/a/index.tsx
@@ -130,7 +130,7 @@ export function APIKeys({ owner }: { owner: WorkspaceType }) {
                   <div className="flex items-center">
                     <div className="flex flex-col">
                       <div className="flex flex-row">
-                      <div className="mr-2 mt-0.5 flex flex-shrink-0 my-auto">
+                        <div className="my-auto mr-2 mt-0.5 flex flex-shrink-0">
                           <p
                             className={classNames(
                               "mb-0.5 inline-flex rounded-full px-2 text-xs font-semibold leading-5",

--- a/front/pages/w/[wId]/a/index.tsx
+++ b/front/pages/w/[wId]/a/index.tsx
@@ -91,7 +91,7 @@ export function APIKeys({ owner }: { owner: WorkspaceType }) {
 
   const { submit: handleRevoke, isSubmitting: isRevoking } = useSubmitFunction(
     async (key: KeyType) => {
-      await fetch(`/api/w/${owner.sId}/keys/${key.secret}/disable`, {
+      await fetch(`/api/w/${owner.sId}/keys/${key.id}/disable`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -152,22 +152,24 @@ export function APIKeys({ owner }: { owner: WorkspaceType }) {
                             {key.status === "active" ? "active" : "revoked"}
                           </p>
                         </div>
+                        <div>
                         <p
                           className={classNames(
                             "font-mono truncate text-sm text-slate-700"
                           )}
                         >
                           <strong>{key.name ? key.name : "Unnamed"}</strong>
-                          <pre>{key.secret}</pre>
                         </p>
-                      </div>
-                      <p className="front-normal text-xs text-element-700">
+                        <pre className="text-sm">{key.secret}</pre>
+                        <p className="front-normal text-xs text-element-700">
                         Created {key.creator ? `by ${key.creator} ` : ""}
                         {timeAgoFrom(key.createdAt, {
                           useLongFormat: true,
                         })}{" "}
                         ago.
                       </p>
+                        </div>
+                      </div>
                     </div>
                   </div>
                   {key.status === "active" ? (

--- a/front/pages/w/[wId]/a/index.tsx
+++ b/front/pages/w/[wId]/a/index.tsx
@@ -11,7 +11,6 @@ import type { KeyType } from "@dust-tt/types";
 import type { WorkspaceType } from "@dust-tt/types";
 import type { AppType } from "@dust-tt/types";
 import type { SubscriptionType } from "@dust-tt/types";
-import { EyeIcon, EyeSlashIcon } from "@heroicons/react/24/outline";
 import type { InferGetServerSidePropsType } from "next";
 import Link from "next/link";
 import { useRouter } from "next/router";
@@ -131,25 +130,26 @@ export function APIKeys({ owner }: { owner: WorkspaceType }) {
                   <div className="flex items-center">
                     <div className="flex flex-col">
                       <div className="flex flex-row">
-                        <p
-                          className={classNames(
-                            "font-mono truncate text-sm text-slate-700"
-                          )}
-                        >
-                          {key.secret}
-                        </p>
-                        <div className="ml-2 mt-0.5 flex flex-shrink-0">
+                      <div className="mr-2 mt-0.5 flex flex-shrink-0 my-auto">
                           <p
                             className={classNames(
                               "mb-0.5 inline-flex rounded-full px-2 text-xs font-semibold leading-5",
                               key.status === "active"
                                 ? "bg-green-100 text-green-800"
-                                : "ml-6 bg-gray-100 text-gray-800"
+                                : "bg-gray-100 text-gray-800"
                             )}
                           >
                             {key.status === "active" ? "active" : "revoked"}
                           </p>
                         </div>
+                        <p
+                          className={classNames(
+                            "font-mono truncate text-sm text-slate-700"
+                          )}
+                        >
+                          <strong>{key.name ? key.name : "Unnamed"}</strong>
+                          <pre>{key.secret}</pre>
+                        </p>
                       </div>
                       <p className="front-normal text-xs text-element-700">
                         Created {key.creator ? `by ${key.creator} ` : ""}

--- a/front/pages/w/[wId]/a/index.tsx
+++ b/front/pages/w/[wId]/a/index.tsx
@@ -1,6 +1,8 @@
 import {
   Button,
   CommandLineIcon,
+  Dialog,
+  Input,
   LockIcon,
   Page,
   PlusIcon,
@@ -68,6 +70,8 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
 
 export function APIKeys({ owner }: { owner: WorkspaceType }) {
   const { mutate } = useSWRConfig();
+  const [newApiKeyName, setNewApiKeyName] = useState("");
+  const [isNewApiKeyPromptOpen, setIsNewApiKeyPromptOpen] = useState(false);
 
   const { keys } = useKeys(owner);
   const { submit: handleGenerate, isSubmitting: isGenerating } =
@@ -81,14 +85,8 @@ export function APIKeys({ owner }: { owner: WorkspaceType }) {
       });
       // const data = await res.json();
       await mutate(`/api/w/${owner.sId}/keys`);
-      // scroll to bottom
-      const mainTag = document.querySelector("main");
-      if (mainTag) {
-        mainTag.scrollTo({
-          top: mainTag.scrollHeight,
-          behavior: "smooth",
-        });
-      }
+      setIsNewApiKeyPromptOpen(false);
+      setNewApiKeyName("");
     });
 
   const { submit: handleRevoke, isSubmitting: isRevoking } = useSubmitFunction(
@@ -106,6 +104,19 @@ export function APIKeys({ owner }: { owner: WorkspaceType }) {
 
   return (
     <>
+      <Dialog
+        isOpen={isNewApiKeyPromptOpen}
+        title="New API Key"
+        onValidate={() => handleGenerate(newApiKeyName)}
+        onCancel={() => setIsNewApiKeyPromptOpen(false)}
+      >
+        <Input
+          name="API Key"
+          placeholder="Type an API key name"
+          value={newApiKeyName}
+          onChange={(e) => setNewApiKeyName(e)}
+        />
+      </Dialog>
       <Page.SectionHeader
         title="API Keys"
         description="Keys used to communicate between your servers and Dust. Do not share them with anyone. Do not use them in client-side or browser code."
@@ -113,8 +124,7 @@ export function APIKeys({ owner }: { owner: WorkspaceType }) {
           label: "Create API Key",
           variant: "primary",
           onClick: async () => {
-            const newName = prompt("Name this API Key");
-            await handleGenerate(newName ?? "");
+            setIsNewApiKeyPromptOpen(true);
           },
           icon: PlusIcon,
           disabled: isGenerating || isRevoking,

--- a/front/pages/w/[wId]/a/index.tsx
+++ b/front/pages/w/[wId]/a/index.tsx
@@ -71,17 +71,14 @@ export function APIKeys({ owner }: { owner: WorkspaceType }) {
   const { mutate } = useSWRConfig();
 
   const { keys } = useKeys(owner);
-  const [isRevealed, setIsRevealed] = useState(
-    {} as { [key: string]: boolean }
-  );
-
   const { submit: handleGenerate, isSubmitting: isGenerating } =
-    useSubmitFunction(async () => {
+    useSubmitFunction(async (name: string) => {
       await fetch(`/api/w/${owner.sId}/keys`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
         },
+        body: JSON.stringify({ name }),
       });
       // const data = await res.json();
       await mutate(`/api/w/${owner.sId}/keys`);
@@ -111,13 +108,14 @@ export function APIKeys({ owner }: { owner: WorkspaceType }) {
   return (
     <>
       <Page.SectionHeader
-        title="Secret API Keys"
-        description="Secrets used to communicate between your servers and Dust. Do not share them with anyone. Do not use them in client-side or browser code."
+        title="API Keys"
+        description="Keys used to communicate between your servers and Dust. Do not share them with anyone. Do not use them in client-side or browser code."
         action={{
-          label: "Create Secret API Key",
+          label: "Create API Key",
           variant: "primary",
           onClick: async () => {
-            await handleGenerate();
+            const newName = prompt("Name this API Key");
+            await handleGenerate(newName ?? "");
           },
           icon: PlusIcon,
           disabled: isGenerating || isRevoking,
@@ -138,37 +136,7 @@ export function APIKeys({ owner }: { owner: WorkspaceType }) {
                             "font-mono truncate text-sm text-slate-700"
                           )}
                         >
-                          {isRevealed[key.secret] ? (
-                            <>
-                              {key.secret}
-                              {key.status == "active" ? (
-                                <EyeSlashIcon
-                                  className="ml-2 inline h-4 w-4 cursor-pointer text-gray-400"
-                                  onClick={() => {
-                                    setIsRevealed({
-                                      ...isRevealed,
-                                      [key.secret]: false,
-                                    });
-                                  }}
-                                />
-                              ) : null}
-                            </>
-                          ) : (
-                            <>
-                              sk-...{key.secret.slice(-5)}
-                              {key.status == "active" ? (
-                                <EyeIcon
-                                  className="ml-2 inline h-4 w-4 cursor-pointer text-gray-400"
-                                  onClick={() => {
-                                    setIsRevealed({
-                                      ...isRevealed,
-                                      [key.secret]: true,
-                                    });
-                                  }}
-                                />
-                              ) : null}
-                            </>
-                          )}
+                          {key.secret}
                         </p>
                         <div className="ml-2 mt-0.5 flex flex-shrink-0">
                           <p

--- a/front/pages/w/[wId]/a/index.tsx
+++ b/front/pages/w/[wId]/a/index.tsx
@@ -153,21 +153,21 @@ export function APIKeys({ owner }: { owner: WorkspaceType }) {
                           </p>
                         </div>
                         <div>
-                        <p
-                          className={classNames(
-                            "font-mono truncate text-sm text-slate-700"
-                          )}
-                        >
-                          <strong>{key.name ? key.name : "Unnamed"}</strong>
-                        </p>
-                        <pre className="text-sm">{key.secret}</pre>
-                        <p className="front-normal text-xs text-element-700">
-                        Created {key.creator ? `by ${key.creator} ` : ""}
-                        {timeAgoFrom(key.createdAt, {
-                          useLongFormat: true,
-                        })}{" "}
-                        ago.
-                      </p>
+                          <p
+                            className={classNames(
+                              "font-mono truncate text-sm text-slate-700"
+                            )}
+                          >
+                            <strong>{key.name ? key.name : "Unnamed"}</strong>
+                          </p>
+                          <pre className="text-sm">{key.secret}</pre>
+                          <p className="front-normal text-xs text-element-700">
+                            Created {key.creator ? `by ${key.creator} ` : ""}
+                            {timeAgoFrom(key.createdAt, {
+                              useLongFormat: true,
+                            })}{" "}
+                            ago.
+                          </p>
                         </div>
                       </div>
                     </div>

--- a/types/src/front/key.ts
+++ b/types/src/front/key.ts
@@ -3,4 +3,5 @@ export type KeyType = {
   creator: string | null;
   secret: string;
   status: string;
+  name: string | null;
 };

--- a/types/src/front/key.ts
+++ b/types/src/front/key.ts
@@ -3,6 +3,7 @@ import { ModelId } from "../shared/model_id";
 export type KeyType = {
   id: ModelId
   createdAt: number;
+  lastUsedAt: number | null;
   creator: string | null;
   secret: string;
   status: string;

--- a/types/src/front/key.ts
+++ b/types/src/front/key.ts
@@ -1,7 +1,7 @@
 import { ModelId } from "../shared/model_id";
 
 export type KeyType = {
-  id: ModelId
+  id: ModelId;
   createdAt: number;
   lastUsedAt: number | null;
   creator: string | null;

--- a/types/src/front/key.ts
+++ b/types/src/front/key.ts
@@ -1,4 +1,7 @@
+import { ModelId } from "../shared/model_id";
+
 export type KeyType = {
+  id: ModelId
   createdAt: number;
   creator: string | null;
   secret: string;

--- a/types/src/shared/utils/string_utils.ts
+++ b/types/src/shared/utils/string_utils.ts
@@ -66,6 +66,6 @@ export function redactString(str: string, n: number) {
     return str;
   }
 
-  const redacted = "*".repeat(str.length - n) + str.slice(-n);
+  const redacted = "•".repeat(str.length - n) + str.slice(-n);
   return redacted;
 }


### PR DESCRIPTION
## Description

Showing secret keys in a workspace env is a huge security risk. 
This PR removes the possibility of view a secret key 10 minutes after it's been created and allows naming for better revocation management.
Also added lastUsedAt tracking for key management

<img width="879" alt="Screenshot 2024-04-30 at 16 23 20" src="https://github.com/dust-tt/dust/assets/1189312/27a0331e-4f60-491d-ac3c-11118f7f9c87">




## Risk
None

## Deploy Plan
Migration needed to add 'name' and 'lastUsedAt' attributes to API keys