### PR TITLE
Allocate 4 Gi of ephemeral storage on prodbox

### DIFF
--- a/k8s/deployments/prodbox-deployment.yaml
+++ b/k8s/deployments/prodbox-deployment.yaml
@@ -51,9 +51,11 @@ spec:
             requests:
               cpu: 4000m
               memory: 4Gi
+              ephemeral-storage: 4Gi
             limits:
               cpu: 4000m
               memory: 4Gi
+              ephemeral-storage: 4Gi
 
       volumes:
         - name: cert-volume


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR request 4Gi of ephemeral storage for prodbox. This is required to compile `core`.

```
  Normal   Killing              3m33s                kubelet                                Stopping container web
  Warning  Evicted              52s (x5 over 3m33s)  kubelet                                Pod ephemeral local storage usage exceeds the total limit of containers 1Gi.
```

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
