### PR TITLE
Connector batch restart all

### DIFF
--- a/types/src/connectors/admin/cli.ts
+++ b/types/src/connectors/admin/cli.ts
@@ -77,7 +77,7 @@ export type SlackCommandType = t.TypeOf<typeof SlackCommandSchema>;
 
 export const BatchCommandSchema = t.type({
   majorCommand: t.literal("batch"),
-  command: t.literal("full-resync"),
+  command: t.union([t.literal("full-resync"), t.literal("restart-all")]),
   args: t.record(t.string, t.union([t.string, t.undefined])),
 });
 
@@ -87,6 +87,14 @@ export const WebcrawlerCommandSchema = t.type({
   majorCommand: t.literal("webcrawler"),
   command: t.literal("start-scheduler"),
 });
+
+export const BatchRestartAllResponseSchema = t.type({
+  succeeded: t.number,
+  failed: t.number,
+});
+export type BatchRestartAllResponseType = t.TypeOf<
+  typeof BatchRestartAllResponseSchema
+>;
 
 export type WebcrawlerCommandType = t.TypeOf<typeof WebcrawlerCommandSchema>;
 

--- a/types/src/connectors/admin/cli.ts
+++ b/types/src/connectors/admin/cli.ts
@@ -194,15 +194,6 @@ export type AdminSuccessResponseType = t.TypeOf<
   typeof AdminSuccessResponseSchema
 >;
 
-export const NotionRestartAllResponseSchema = t.type({
-  restartSuccesses: t.number,
-  restartFailures: t.number,
-});
-
-export type NotionRestartAllResponseType = t.TypeOf<
-  typeof NotionRestartAllResponseSchema
->;
-
 export const NotionUpsertResponseSchema = t.type({
   workflowId: t.string,
   workflowUrl: t.union([t.string, t.undefined]),
@@ -293,7 +284,7 @@ export type TemporalUnprocessedWorkflowsResponseType = t.TypeOf<
 
 export const AdminResponseSchema = t.union([
   AdminSuccessResponseSchema,
-  NotionRestartAllResponseSchema,
+  BatchRestartAllResponseSchema,
   NotionUpsertResponseSchema,
   NotionSearchPagesResponseSchema,
   NotionCheckUrlResponseSchema,


### PR DESCRIPTION
## Description

- Adds a ` ./admin/cli.sh batch restart-all --provider [provider]`.
- Removes ` ./admin/cli.sh notion restart-all `.

I whitelisted "notion" / "intercom" /  "confluence" / "github".
I initially did not plan to and wanted to let the "not implemented" on `STOP_CONNECTOR_BY_TYPE` & `RESUME_CONNECTOR_BY_TYPE` raise.  I realized it was not safe because they don't necessarily raise, and webcrawler implements only the stop but not resume (seems like they should not be restarted),  so better be safe and whitelist. 

## Risk

Rollbackable. 

## Deploy Plan

Deploy Connectors. 
