### PR TITLE
Intercom - Allow sync all conversations

### DIFF
--- a/connectors/src/api/webhooks/webhook_intercom.ts
+++ b/connectors/src/api/webhooks/webhook_intercom.ts
@@ -112,24 +112,29 @@ const _webhookIntercomAPIHandler = async (
     return res.status(200).end();
   }
 
-  if (!conversation.team_assignee_id) {
-    // Check we have the permissions to sync this conversation
-    logger.info(
-      "[Intercom] Received webhook for conversation without team, skipping."
-    );
-    return res.status(200).end();
-  } else {
-    const team = await IntercomTeam.findOne({
-      where: {
-        connectorId: connector.id,
-        teamId: conversation.team_assignee_id.toString(),
-      },
-    });
-    if (!team || team.permission !== "read") {
+  const isSelectedAllConvos =
+    intercomWorskpace.syncAllConversations === "activated";
+
+  if (!isSelectedAllConvos) {
+    if (!conversation.team_assignee_id) {
+      // Check we have the permissions to sync this conversation
       logger.info(
-        "[Intercom] Received webhook for conversation attached to team without read permission, skipping."
+        "[Intercom] Received webhook for conversation without team, skipping."
       );
       return res.status(200).end();
+    } else {
+      const team = await IntercomTeam.findOne({
+        where: {
+          connectorId: connector.id,
+          teamId: conversation.team_assignee_id.toString(),
+        },
+      });
+      if (!team || team.permission !== "read") {
+        logger.info(
+          "[Intercom] Received webhook for conversation attached to team without read permission, skipping."
+        );
+        return res.status(200).end();
+      }
     }
   }
 

--- a/connectors/src/connectors/intercom/lib/types.ts
+++ b/connectors/src/connectors/intercom/lib/types.ts
@@ -109,3 +109,12 @@ export type IntercomAuthor = {
   name: string;
   email: string;
 };
+
+export const INTERCOM_SYNC_ALL_CONVO_STATUSES = [
+  "activated",
+  "disabled",
+  "scheduled_activate",
+  "scheduled_revoke",
+] as const;
+export type IntercomSyncAllConversationsStatus =
+  (typeof INTERCOM_SYNC_ALL_CONVO_STATUSES)[number];

--- a/connectors/src/connectors/intercom/lib/utils.ts
+++ b/connectors/src/connectors/intercom/lib/utils.ts
@@ -42,6 +42,10 @@ export function getConversationInternalId(
   return `intercom-conversation-${connectorId}-${conversationId}`;
 }
 
+export function getAllConversationsInternalId(connectorId: ModelId): string {
+  return `intercom-conversations-all-${connectorId}`;
+}
+
 /**
  * From internalId to id
  */
@@ -65,6 +69,12 @@ export function getHelpCenterArticleIdFromInternalId(
   internalId: string
 ): string | null {
   return _getIdFromInternal(internalId, `intercom-article-${connectorId}-`);
+}
+export function isInternalIdForAllConversations(
+  connectorId: ModelId,
+  internalId: string
+): boolean {
+  return internalId === `intercom-conversations-all-${connectorId}`;
 }
 export function isInternalIdForAllTeams(
   connectorId: ModelId,

--- a/connectors/src/connectors/intercom/temporal/client.ts
+++ b/connectors/src/connectors/intercom/temporal/client.ts
@@ -16,12 +16,14 @@ export async function launchIntercomSyncWorkflow({
   fromTs = null,
   helpCenterIds = [],
   teamIds = [],
+  hasUpdatedSelectAllConversations = false,
   forceResync = false,
 }: {
   connectorId: ModelId;
   fromTs?: number | null;
   helpCenterIds?: string[];
   teamIds?: string[];
+  hasUpdatedSelectAllConversations?: boolean;
   forceResync?: boolean;
 }): Promise<Result<string, Error>> {
   if (fromTs) {
@@ -49,7 +51,21 @@ export async function launchIntercomSyncWorkflow({
     intercomId: teamId,
     forceResync,
   }));
-  const signals = [...signaledHelpCenterIds, ...signaledTeamIds];
+  const signaledHasUpdatedSelectAllConvos: IntercomUpdateSignal[] =
+    hasUpdatedSelectAllConversations
+      ? [
+          {
+            type: "all_conversations",
+            intercomId: "all_conversations",
+            forceResync: false,
+          },
+        ]
+      : [];
+  const signals = [
+    ...signaledHelpCenterIds,
+    ...signaledTeamIds,
+    ...signaledHasUpdatedSelectAllConvos,
+  ];
 
   // When the workflow is inactive, we omit passing helpCenterIds as they are only used to signal modifications within a currently active full sync workflow.
   try {

--- a/connectors/src/connectors/intercom/temporal/config.ts
+++ b/connectors/src/connectors/intercom/temporal/config.ts
@@ -1,2 +1,2 @@
-export const WORKFLOW_VERSION = 2;
+export const WORKFLOW_VERSION = 3;
 export const QUEUE_NAME = `intercom-queue-v${WORKFLOW_VERSION}`;

--- a/connectors/src/connectors/intercom/temporal/signals.ts
+++ b/connectors/src/connectors/intercom/temporal/signals.ts
@@ -2,7 +2,7 @@ import { defineSignal } from "@temporalio/workflow";
 
 export interface IntercomUpdateSignal {
   intercomId: string;
-  type: "help_center" | "team";
+  type: "help_center" | "team" | "all_conversations";
   forceResync: boolean;
 }
 

--- a/connectors/src/lib/models/intercom.ts
+++ b/connectors/src/lib/models/intercom.ts
@@ -6,6 +6,7 @@ import type {
 } from "sequelize";
 import { DataTypes, Model } from "sequelize";
 
+import type { IntercomSyncAllConversationsStatus } from "@connectors/connectors/intercom/lib/types";
 import { sequelizeConnection } from "@connectors/resources/storage";
 import { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
 
@@ -22,7 +23,8 @@ export class IntercomWorkspace extends Model<
   declare region: string;
 
   declare conversationsSlidingWindow: number;
-  declare shouldSyncAllConversations: boolean;
+  declare syncAllConversations: IntercomSyncAllConversationsStatus;
+  declare shouldSyncAllConversations: boolean; // @todo daph remove
   declare shouldSyncNotes: boolean;
 
   declare connectorId: ForeignKey<ConnectorModel["id"]>;
@@ -57,7 +59,13 @@ IntercomWorkspace.init(
       allowNull: false,
       defaultValue: 90,
     },
+    syncAllConversations: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      defaultValue: "disabled",
+    },
     shouldSyncAllConversations: {
+      // @todo daph remove
       type: DataTypes.BOOLEAN,
       allowNull: false,
       defaultValue: false,
@@ -442,7 +450,7 @@ export class IntercomConversation extends Model<
   declare updatedAt: CreationOptional<Date>;
 
   declare conversationId: string;
-  declare teamId: string;
+  declare teamId: string | null;
   declare conversationCreatedAt: Date;
 
   declare lastUpsertedTs: Date;
@@ -473,7 +481,7 @@ IntercomConversation.init(
     },
     teamId: {
       type: DataTypes.STRING,
-      allowNull: false,
+      allowNull: true,
     },
     conversationCreatedAt: {
       type: DataTypes.DATE,

--- a/types/src/connectors/admin/cli.ts
+++ b/types/src/connectors/admin/cli.ts
@@ -124,7 +124,7 @@ export const IntercomCheckConversationResponseSchema = t.type({
   isConversationOnIntercom: t.boolean,
   isConversationOnDB: t.boolean,
   conversationTeamIdOnIntercom: t.union([t.string, t.undefined]),
-  conversationTeamIdOnDB: t.union([t.string, t.undefined]),
+  conversationTeamIdOnDB: t.union([t.string, t.undefined, t.null]),
 });
 export type IntercomCheckConversationResponseType = t.TypeOf<
   typeof IntercomCheckConversationResponseSchema


### PR DESCRIPTION
## Description

Allow an admin to select all conversations from Intercom: on the Add/Remove data modal, admins can select the root note "Conversations". 

If selected, all closed conversations will be synced, no matter if they are or not attached to a Team. 
If unselected, we keep only the conversations attached to the other Teams selected for a "read" permission.

**How?**
When setting new permissions, if the node related to all conversations was changes we added a new signal to the intercomSyncWorfklow. If this signal is received, we launch the new `intercomAllConversationsSyncWorkflow`. 

## Risk

Not easy to rollback since it changes the datamodel + the version of intercom workflows.

## Deploy Plan

- Deploy on prodbox.
- Run initdb to create the new field `syncAllConversations` on `IntercomWorkspace` model.
- Deploy connectors.
- Launch `./admin/cli.sh batch restart-all --provider intercom.` from connectors-prod.
