### PR TITLE
Intercom: remove unused field shouldSyncAllConversations

### DIFF
--- a/connectors/src/connectors/intercom/index.ts
+++ b/connectors/src/connectors/intercom/index.ts
@@ -87,7 +87,6 @@ export async function createIntercomConnector(
       conversationsSlidingWindow: 90,
       region: intercomWorkspace.region,
       syncAllConversations: "disabled" as const,
-      shouldSyncAllConversations: false, // @todo daph remove
       shouldSyncNotes: true,
     };
 

--- a/connectors/src/lib/models/intercom.ts
+++ b/connectors/src/lib/models/intercom.ts
@@ -24,7 +24,6 @@ export class IntercomWorkspace extends Model<
 
   declare conversationsSlidingWindow: number;
   declare syncAllConversations: IntercomSyncAllConversationsStatus;
-  declare shouldSyncAllConversations: boolean; // @todo daph remove
   declare shouldSyncNotes: boolean;
 
   declare connectorId: ForeignKey<ConnectorModel["id"]>;
@@ -63,12 +62,6 @@ IntercomWorkspace.init(
       type: DataTypes.STRING,
       allowNull: false,
       defaultValue: "disabled",
-    },
-    shouldSyncAllConversations: {
-      // @todo daph remove
-      type: DataTypes.BOOLEAN,
-      allowNull: false,
-      defaultValue: false,
     },
     shouldSyncNotes: {
       type: DataTypes.BOOLEAN,


### PR DESCRIPTION
## Description

I initially added the boolean field `shouldSyncAllConversations` but ended not using it and replace it by a string one called `syncAllConversations`

## Risk

Can't be rolled-back but the field was never used (introduced 1 days ago with a default value)

## Deploy Plan

Deploy Connectors and THEN run init_db on connectors-prod.
