### PR TITLE
Connectors: cli command restart-all should not restart paused connectors

### DIFF
--- a/connectors/src/lib/cli.ts
+++ b/connectors/src/lib/cli.ts
@@ -1171,6 +1171,7 @@ export const batch = async ({
         where: {
           type: args.provider,
           errorType: null,
+          pausedAt: null,
         },
       });
       for (const connector of connectors) {


### PR DESCRIPTION
## Description

We don't want to restart the connectors that are paused (means workspace is downgraded) when we launch restart-all. 

## Risk

/

## Deploy Plan

Deploy connectors. 
