### PR TITLE
Retrieval Action: remove `AgentMessage.agentRetrievalActionId`

### DIFF
--- a/front/lib/api/assistant/actions/process.ts
+++ b/front/lib/api/assistant/actions/process.ts
@@ -218,7 +218,7 @@ export async function* runProcess(
     relativeTimeFrameUnit: relativeTimeFrame?.unit ?? null,
     processConfigurationId: actionConfiguration.sId,
     schema: actionConfiguration.schema,
-    agentMessageId: agentMessage.id,
+    agentMessageId: agentMessage.agentMessageId,
   });
 
   const now = Date.now();

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1644,9 +1644,7 @@ async function* streamRunAgentEvents(
       case "agent_action_success":
         // Store action in database.
         if (event.action.type === "retrieval_action") {
-          await agentMessageRow.update({
-            agentRetrievalActionId: event.action.id,
-          });
+          // Nothing to do.
         } else if (event.action.type === "dust_app_run_action") {
           await agentMessageRow.update({
             agentDustAppRunActionId: event.action.id,
@@ -1656,9 +1654,7 @@ async function* streamRunAgentEvents(
             agentTablesQueryActionId: event.action.id,
           });
         } else if (event.action.type === "process_action") {
-          await agentMessageRow.update({
-            agentProcessActionId: event.action.id,
-          });
+          // Nothing to do.
         } else {
           ((action: never) => {
             throw new Error(

--- a/front/lib/models/assistant/actions/process.ts
+++ b/front/lib/models/assistant/actions/process.ts
@@ -128,6 +128,7 @@ export class AgentProcessAction extends Model<
 
   declare schema: ProcessSchemaPropertyType[];
   declare outputs: unknown[] | null;
+
   declare agentMessageId: ForeignKey<AgentMessage["id"]> | null;
 }
 AgentProcessAction.init(

--- a/front/lib/models/assistant/actions/retrieval.ts
+++ b/front/lib/models/assistant/actions/retrieval.ts
@@ -156,7 +156,7 @@ export class AgentRetrievalAction extends Model<
   declare relativeTimeFrameDuration: number | null;
   declare relativeTimeFrameUnit: TimeframeUnit | null;
   declare topK: number;
-  declare agentMessageId: ForeignKey<AgentMessage["id"]> | null;
+  declare agentMessageId: ForeignKey<AgentMessage["id"]>;
 }
 AgentRetrievalAction.init(
   {

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -251,7 +251,6 @@ export class AgentMessage extends Model<
   declare agentTablesQueryActionId: ForeignKey<
     AgentTablesQueryAction["id"]
   > | null;
-  declare agentProcessActionId: ForeignKey<AgentProcessAction["id"]> | null;
 
   // Not a relation as global agents are not in the DB
   // needs both sId and version to uniquely identify the agent configuration
@@ -318,7 +317,6 @@ AgentMessage.init(
           "agentRetrievalActionId",
           "agentDustAppRunActionId",
           "agentTablesQueryActionId",
-          "agentProcessActionId",
         ];
         const nonNullActionTypes = actionsTypes.filter(
           (field) => agentMessage[field] != null
@@ -332,6 +330,8 @@ AgentMessage.init(
     },
   }
 );
+
+// LEGACY (to be removed)
 
 AgentRetrievalAction.hasOne(AgentMessage, {
   foreignKey: { name: "agentRetrievalActionId", allowNull: true }, // null = no Retrieval action set for this Agent
@@ -357,12 +357,43 @@ AgentMessage.belongsTo(AgentTablesQueryAction, {
   foreignKey: { name: "agentTablesQueryActionId", allowNull: true }, // null = no TablesQuery action set for this Agent
 });
 
-AgentProcessAction.hasOne(AgentMessage, {
-  foreignKey: { name: "agentProcessActionId", allowNull: true }, // null = no Process action set for this Agent
-  onDelete: "CASCADE",
+// END LEGACY
+
+AgentRetrievalAction.belongsTo(AgentMessage, {
+  // allow null for now until we proceed to the backfill.
+  foreignKey: { name: "agentMessageId", allowNull: true },
 });
-AgentMessage.belongsTo(AgentProcessAction, {
-  foreignKey: { name: "agentProcessActionId", allowNull: true }, // null = no Process action set for this Agent
+
+AgentMessage.hasMany(AgentRetrievalAction, {
+  // allow null for now until we proceed to the backfill.
+  foreignKey: { name: "agentMessageId", allowNull: true },
+});
+
+AgentDustAppRunAction.belongsTo(AgentMessage, {
+  // allow null for now until we proceed to the backfill.
+  foreignKey: { name: "agentMessageId", allowNull: true },
+});
+
+AgentMessage.hasMany(AgentDustAppRunAction, {
+  // allow null for now until we proceed to the backfill.
+  foreignKey: { name: "agentMessageId", allowNull: true },
+});
+
+AgentTablesQueryAction.belongsTo(AgentMessage, {
+  // allow null for now until we proceed to the backfill.
+  foreignKey: { name: "agentMessageId", allowNull: true },
+});
+
+AgentMessage.hasMany(AgentTablesQueryAction, {
+  // allow null for now until we proceed to the backfill.
+  foreignKey: { name: "agentMessageId", allowNull: true },
+});
+
+AgentProcessAction.belongsTo(AgentMessage, {
+  foreignKey: { name: "agentMessageId", allowNull: false },
+});
+AgentMessage.hasMany(AgentProcessAction, {
+  foreignKey: { name: "agentMessageId", allowNull: false },
 });
 
 export class Message extends Model<
@@ -495,45 +526,6 @@ ContentFragmentModel.hasOne(Message, {
 Message.belongsTo(ContentFragmentModel, {
   as: "contentFragment",
   foreignKey: { name: "contentFragmentId", allowNull: true },
-});
-
-AgentRetrievalAction.belongsTo(AgentMessage, {
-  // allow null for now until we proceed to the backfill.
-  foreignKey: { name: "agentMessageId", allowNull: true },
-});
-
-AgentMessage.hasMany(AgentRetrievalAction, {
-  // allow null for now until we proceed to the backfill.
-  foreignKey: { name: "agentMessageId", allowNull: true },
-});
-
-AgentDustAppRunAction.belongsTo(AgentMessage, {
-  // allow null for now until we proceed to the backfill.
-  foreignKey: { name: "agentMessageId", allowNull: true },
-});
-
-AgentMessage.hasMany(AgentDustAppRunAction, {
-  // allow null for now until we proceed to the backfill.
-  foreignKey: { name: "agentMessageId", allowNull: true },
-});
-
-AgentTablesQueryAction.belongsTo(AgentMessage, {
-  // allow null for now until we proceed to the backfill.
-  foreignKey: { name: "agentMessageId", allowNull: true },
-});
-
-AgentMessage.hasMany(AgentTablesQueryAction, {
-  // allow null for now until we proceed to the backfill.
-  foreignKey: { name: "agentMessageId", allowNull: true },
-});
-
-AgentProcessAction.belongsTo(AgentMessage, {
-  // allow null for now until we proceed to the backfill.
-  foreignKey: { name: "agentMessageId", allowNull: true },
-});
-AgentMessage.hasMany(AgentProcessAction, {
-  // allow null for now until we proceed to the backfill.
-  foreignKey: { name: "agentMessageId", allowNull: true },
 });
 
 export class MessageReaction extends Model<

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -244,7 +244,6 @@ export class AgentMessage extends Model<
   declare errorCode: string | null;
   declare errorMessage: string | null;
 
-  declare agentRetrievalActionId: ForeignKey<AgentRetrievalAction["id"]> | null;
   declare agentDustAppRunActionId: ForeignKey<
     AgentDustAppRunAction["id"]
   > | null;
@@ -314,7 +313,6 @@ AgentMessage.init(
     hooks: {
       beforeValidate: (agentMessage: AgentMessage) => {
         const actionsTypes: (keyof AgentMessage)[] = [
-          "agentRetrievalActionId",
           "agentDustAppRunActionId",
           "agentTablesQueryActionId",
         ];
@@ -332,14 +330,6 @@ AgentMessage.init(
 );
 
 // LEGACY (to be removed)
-
-AgentRetrievalAction.hasOne(AgentMessage, {
-  foreignKey: { name: "agentRetrievalActionId", allowNull: true }, // null = no Retrieval action set for this Agent
-  onDelete: "CASCADE",
-});
-AgentMessage.belongsTo(AgentRetrievalAction, {
-  foreignKey: { name: "agentRetrievalActionId", allowNull: true }, // null = no Retrieval action set for this Agent
-});
 
 AgentDustAppRunAction.hasOne(AgentMessage, {
   foreignKey: { name: "agentDustAppRunActionId", allowNull: true }, // null = no DustAppRun action set for this Agent
@@ -360,13 +350,11 @@ AgentMessage.belongsTo(AgentTablesQueryAction, {
 // END LEGACY
 
 AgentRetrievalAction.belongsTo(AgentMessage, {
-  // allow null for now until we proceed to the backfill.
-  foreignKey: { name: "agentMessageId", allowNull: true },
+  foreignKey: { name: "agentMessageId", allowNull: false },
 });
 
 AgentMessage.hasMany(AgentRetrievalAction, {
-  // allow null for now until we proceed to the backfill.
-  foreignKey: { name: "agentMessageId", allowNull: true },
+  foreignKey: { name: "agentMessageId", allowNull: false },
 });
 
 AgentDustAppRunAction.belongsTo(AgentMessage, {

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -303,12 +303,6 @@ AgentMessage.init(
   },
   {
     modelName: "agent_message",
-    indexes: [
-      {
-        unique: true,
-        fields: ["agentRetrievalActionId"],
-      },
-    ],
     sequelize: frontSequelize,
     hooks: {
       beforeValidate: (agentMessage: AgentMessage) => {

--- a/front/migrations/20231005_populate_retrieved_documents_workspace_id.ts
+++ b/front/migrations/20231005_populate_retrieved_documents_workspace_id.ts
@@ -1,134 +1,134 @@
-import type { ModelId } from "@dust-tt/types";
-import { Op } from "sequelize";
-
-import { RetrievalDocument } from "@app/lib/models/assistant/actions/retrieval";
-import {
-  AgentMessage,
-  Conversation,
-  Message,
-} from "@app/lib/models/assistant/conversation";
-import { Workspace } from "@app/lib/models/workspace";
-
-const { LIVE = false } = process.env;
-
-async function main() {
-  console.log("Fetching Upgraded Worspaces...");
-  const workspaces = await Workspace.findAll({});
-  console.log(
-    `Found ${workspaces.length} workspaces for which to add largeModels = true`
-  );
-
-  const chunkSize = 16;
-  const chunks = [];
-  for (let i = 0; i < workspaces.length; i += chunkSize) {
-    chunks.push(workspaces.slice(i, i + chunkSize));
-  }
-
-  for (let i = 0; i < chunks.length; i++) {
-    console.log(`Processing chunk ${i}/${chunks.length}...`);
-    const chunk = chunks[i];
-    await Promise.all(
-      chunk.map((workspace: Workspace) => {
-        return updateAllConversations(!!LIVE, workspace);
-      })
-    );
-  }
-}
-
-async function updateAllConversations(live: boolean, workspace: Workspace) {
-  const conversations = await Conversation.findAll({
-    where: {
-      workspaceId: workspace.id,
-    },
-  });
-
-  const chunkSize = 16;
-  const chunks = [];
-  for (let i = 0; i < conversations.length; i += chunkSize) {
-    chunks.push(conversations.slice(i, i + chunkSize));
-  }
-
-  for (let i = 0; i < chunks.length; i++) {
-    console.log(`Processing chunk ${i}/${chunks.length}...`);
-    const chunk = chunks[i];
-    await Promise.all(
-      chunk.map((c: Conversation) => {
-        return updateConversation(live, c, workspace);
-      })
-    );
-  }
-}
-
-async function updateConversation(
-  live: boolean,
-  conversation: Conversation,
-  workspace: Workspace
-) {
-  const messages = await Message.findAll({
-    where: {
-      // where conversationId = conversation.id
-      // and agentMessageId is not null
-      [Op.and]: [
-        {
-          conversationId: conversation.id,
-          agentMessageId: {
-            [Op.ne]: null,
-          },
-        },
-      ],
-    },
-  });
-
-  await Promise.all(
-    messages.map((message) => {
-      return updateMessage(
-        live,
-        conversation,
-        message.agentMessageId as number,
-        workspace
-      );
-    })
-  );
-}
-
-async function updateMessage(
-  live: boolean,
-  conversation: Conversation,
-  agentMessageId: ModelId,
-  workspace: Workspace
-) {
-  const m = await AgentMessage.findByPk(agentMessageId);
-  if (m?.agentRetrievalActionId) {
-    const documents = await RetrievalDocument.findAll({
-      where: {
-        retrievalActionId: m.agentRetrievalActionId,
-      },
-    });
-    console.log(
-      `LIVE=${live} workspace=${workspace.sId} conversation=${conversation.sId} documents=${documents.length}`
-    );
-
-    if (live) {
-      await RetrievalDocument.update(
-        {
-          dataSourceWorkspaceId: workspace.sId,
-        },
-        {
-          where: {
-            retrievalActionId: m.agentRetrievalActionId,
-          },
-        }
-      );
-    }
-  }
-}
-
-main()
-  .then(() => {
-    console.log("done");
-    process.exit(0);
-  })
-  .catch((err) => {
-    console.error(err);
-    process.exit(1);
-  });
+// import type { ModelId } from "@dust-tt/types";
+// import { Op } from "sequelize";
+//
+// import { RetrievalDocument } from "@app/lib/models/assistant/actions/retrieval";
+// import {
+//   AgentMessage,
+//   Conversation,
+//   Message,
+// } from "@app/lib/models/assistant/conversation";
+// import { Workspace } from "@app/lib/models/workspace";
+//
+// const { LIVE = false } = process.env;
+//
+// async function main() {
+//   console.log("Fetching Upgraded Worspaces...");
+//   const workspaces = await Workspace.findAll({});
+//   console.log(
+//     `Found ${workspaces.length} workspaces for which to add largeModels = true`
+//   );
+//
+//   const chunkSize = 16;
+//   const chunks = [];
+//   for (let i = 0; i < workspaces.length; i += chunkSize) {
+//     chunks.push(workspaces.slice(i, i + chunkSize));
+//   }
+//
+//   for (let i = 0; i < chunks.length; i++) {
+//     console.log(`Processing chunk ${i}/${chunks.length}...`);
+//     const chunk = chunks[i];
+//     await Promise.all(
+//       chunk.map((workspace: Workspace) => {
+//         return updateAllConversations(!!LIVE, workspace);
+//       })
+//     );
+//   }
+// }
+//
+// async function updateAllConversations(live: boolean, workspace: Workspace) {
+//   const conversations = await Conversation.findAll({
+//     where: {
+//       workspaceId: workspace.id,
+//     },
+//   });
+//
+//   const chunkSize = 16;
+//   const chunks = [];
+//   for (let i = 0; i < conversations.length; i += chunkSize) {
+//     chunks.push(conversations.slice(i, i + chunkSize));
+//   }
+//
+//   for (let i = 0; i < chunks.length; i++) {
+//     console.log(`Processing chunk ${i}/${chunks.length}...`);
+//     const chunk = chunks[i];
+//     await Promise.all(
+//       chunk.map((c: Conversation) => {
+//         return updateConversation(live, c, workspace);
+//       })
+//     );
+//   }
+// }
+//
+// async function updateConversation(
+//   live: boolean,
+//   conversation: Conversation,
+//   workspace: Workspace
+// ) {
+//   const messages = await Message.findAll({
+//     where: {
+//       // where conversationId = conversation.id
+//       // and agentMessageId is not null
+//       [Op.and]: [
+//         {
+//           conversationId: conversation.id,
+//           agentMessageId: {
+//             [Op.ne]: null,
+//           },
+//         },
+//       ],
+//     },
+//   });
+//
+//   await Promise.all(
+//     messages.map((message) => {
+//       return updateMessage(
+//         live,
+//         conversation,
+//         message.agentMessageId as number,
+//         workspace
+//       );
+//     })
+//   );
+// }
+//
+// async function updateMessage(
+//   live: boolean,
+//   conversation: Conversation,
+//   agentMessageId: ModelId,
+//   workspace: Workspace
+// ) {
+//   const m = await AgentMessage.findByPk(agentMessageId);
+//   if (m?.agentRetrievalActionId) {
+//     const documents = await RetrievalDocument.findAll({
+//       where: {
+//         retrievalActionId: m.agentRetrievalActionId,
+//       },
+//     });
+//     console.log(
+//       `LIVE=${live} workspace=${workspace.sId} conversation=${conversation.sId} documents=${documents.length}`
+//     );
+//
+//     if (live) {
+//       await RetrievalDocument.update(
+//         {
+//           dataSourceWorkspaceId: workspace.sId,
+//         },
+//         {
+//           where: {
+//             retrievalActionId: m.agentRetrievalActionId,
+//           },
+//         }
+//       );
+//     }
+//   }
+// }
+//
+// main()
+//   .then(() => {
+//     console.log("done");
+//     process.exit(0);
+//   })
+//   .catch((err) => {
+//     console.error(err);
+//     process.exit(1);
+//   });

--- a/front/migrations/20240426_backfill_agent_retrieval_actions_agent_message_id.ts
+++ b/front/migrations/20240426_backfill_agent_retrieval_actions_agent_message_id.ts
@@ -1,78 +1,78 @@
-import type { ModelId } from "@dust-tt/types";
-import { QueryTypes } from "sequelize";
-
-import { AgentRetrievalAction } from "@app/lib/models/assistant/actions/retrieval";
-import { AgentMessage } from "@app/lib/models/assistant/conversation";
-import { frontSequelize } from "@app/lib/resources/storage";
-import logger from "@app/logger/logger";
-import { makeScript } from "@app/scripts/helpers";
-
-const backRetrievalActions = async (execute: boolean) => {
-  let retrievalActions: AgentRetrievalAction[] = [];
-  do {
-    retrievalActions = await AgentRetrievalAction.findAll({
-      where: {
-        agentMessageId: null,
-      },
-      limit: 200,
-    });
-    logger.info(
-      {
-        count: retrievalActions.length,
-      },
-      "Processing retrieval actions for backfilling agentMessageId"
-    );
-    for (const retrievalAction of retrievalActions) {
-      const agentMessage = await AgentMessage.findOne({
-        where: {
-          agentRetrievalActionId: retrievalAction.id,
-        },
-      });
-      if (agentMessage) {
-        if (execute) {
-          await retrievalAction.update({
-            agentMessageId: agentMessage.id,
-          });
-          logger.info(
-            { retrievalActionId: retrievalAction.id },
-            "Updated agentMessageId"
-          );
-        } else {
-          logger.info(
-            { retrievalActionId: retrievalAction.id },
-            "*Would* update agentMessageId"
-          );
-        }
-      } else {
-        logger.warn(
-          { retrievalActionId: retrievalAction.id },
-          "AgentMessage not found"
-        );
-      }
-    }
-  } while (retrievalActions.length > 0 && execute);
-
-  // checking that all pairs are correct
-  const errors: { id: ModelId }[] = await frontSequelize.query(
-    `
-      SELECT am.id from agent_messages am
-      INNER JOIN agent_retrieval_actions arc ON (am."agentRetrievalActionId" = arc.id)
-      WHERE arc."agentMessageId" <> am.id
-  `,
-    {
-      type: QueryTypes.SELECT,
-    }
-  );
-  if (errors.length > 0) {
-    logger.error(
-      { count: errors.length, errors },
-      "AgentMessageId not updated correctly"
-    );
-  } else {
-    logger.info("No error found");
-  }
-};
-
-makeScript({}, async ({ execute }) => {
-  await backRetrievalActions(execute);
-});
+// import type { ModelId } from "@dust-tt/types";
+// import { QueryTypes } from "sequelize";
+//
+// import { AgentRetrievalAction } from "@app/lib/models/assistant/actions/retrieval";
+// import { AgentMessage } from "@app/lib/models/assistant/conversation";
+// import { frontSequelize } from "@app/lib/resources/storage";
+// import logger from "@app/logger/logger";
+// import { makeScript } from "@app/scripts/helpers";
+//
+// const backRetrievalActions = async (execute: boolean) => {
+//   let retrievalActions: AgentRetrievalAction[] = [];
+//   do {
+//     retrievalActions = await AgentRetrievalAction.findAll({
+//       where: {
+//         agentMessageId: null,
+//       },
+//       limit: 200,
+//     });
+//     logger.info(
+//       {
+//         count: retrievalActions.length,
+//       },
+//       "Processing retrieval actions for backfilling agentMessageId"
+//     );
+//     for (const retrievalAction of retrievalActions) {
+//       const agentMessage = await AgentMessage.findOne({
+//         where: {
+//           agentRetrievalActionId: retrievalAction.id,
+//         },
+//       });
+//       if (agentMessage) {
+//         if (execute) {
+//           await retrievalAction.update({
+//             agentMessageId: agentMessage.id,
+//           });
+//           logger.info(
+//             { retrievalActionId: retrievalAction.id },
+//             "Updated agentMessageId"
+//           );
+//         } else {
+//           logger.info(
+//             { retrievalActionId: retrievalAction.id },
+//             "*Would* update agentMessageId"
+//           );
+//         }
+//       } else {
+//         logger.warn(
+//           { retrievalActionId: retrievalAction.id },
+//           "AgentMessage not found"
+//         );
+//       }
+//     }
+//   } while (retrievalActions.length > 0 && execute);
+//
+//   // checking that all pairs are correct
+//   const errors: { id: ModelId }[] = await frontSequelize.query(
+//     `
+//       SELECT am.id from agent_messages am
+//       INNER JOIN agent_retrieval_actions arc ON (am."agentRetrievalActionId" = arc.id)
+//       WHERE arc."agentMessageId" <> am.id
+//   `,
+//     {
+//       type: QueryTypes.SELECT,
+//     }
+//   );
+//   if (errors.length > 0) {
+//     logger.error(
+//       { count: errors.length, errors },
+//       "AgentMessageId not updated correctly"
+//     );
+//   } else {
+//     logger.info("No error found");
+//   }
+// };
+//
+// makeScript({}, async ({ execute }) => {
+//   await backRetrievalActions(execute);
+// });

--- a/front/migrations/20240501_dump_orphaned_retrieval_actions.sql
+++ b/front/migrations/20240501_dump_orphaned_retrieval_actions.sql
@@ -1,0 +1,1 @@
+SELECT * WHERE "agentMessageId" IS NULL;

--- a/front/migrations/20240501_dump_orphaned_retrieval_actions.sql
+++ b/front/migrations/20240501_dump_orphaned_retrieval_actions.sql
@@ -1,1 +1,2 @@
-SELECT * WHERE "agentMessageId" IS NULL;
+SELECT * FROM agent_retrieval_actions WHERE "agentMessageId" IS NULL;
+DELETE FROM agent_retrieval_actions WHERE "agentMessageId" IS NULL;

--- a/front/migrations/20240501_set_orphan_retrieval_action_agent_message.sql
+++ b/front/migrations/20240501_set_orphan_retrieval_action_agent_message.sql
@@ -1,0 +1,2 @@
+UPDATE agent_retrieval_actions SET "agentMessageId"=1 WHERE "agentMessageId" IS NULL;
+UPDATE conversations SET visibility='deleted' WHERE id=3;

--- a/front/migrations/20240501_set_orphan_retrieval_action_agent_message.sql
+++ b/front/migrations/20240501_set_orphan_retrieval_action_agent_message.sql
@@ -1,2 +1,0 @@
-UPDATE agent_retrieval_actions SET "agentMessageId"=1 WHERE "agentMessageId" IS NULL;
-UPDATE conversations SET visibility='deleted' WHERE id=3;

--- a/types/src/front/assistant/actions/retrieval.ts
+++ b/types/src/front/assistant/actions/retrieval.ts
@@ -90,6 +90,7 @@ export type RetrievalDocumentType = {
 
 export type RetrievalActionType = {
   id: ModelId; // AgentRetrieval.
+  agentMessageId: ModelId;
 
   type: "retrieval_action";
 


### PR DESCRIPTION
## Description

- Fully remove `AgentMessage.agentRetrievalActionId`
- Refactor retrieval rendering in `batchRenderAgentMessages`: cuts an interface that will be used by all actions `**ActionTypesFromAgentMessageIds`.
- Small fix to Process action (wrong id)

Deploy will involve deleting 29000 `AgentRetrievalActions` that are not linked to any `AgentMessage`. These are actions that were created but then failed before being saved on the `AgentMessage`. None exist since 04/26 (move to writing the other way around).

I chcked that if an action fail before the moment it was written to AgentMessage originally, the conversation gets rendered as expected (because now we will have the action, failed and incomplete, attached).

I will dump as CSV the actions orphaned wth no `agentMessageId` (action created but failure before they were written to the AgentMessage in the old world) before deleting them. This gives us a path to revert.

It is ok to deploy to `front` before running init_db because the `AgentMessage.agentRetrievalActionId` is optional.

Also checked that this query still returns 0 results:
```
SELECT am.id from agent_messages am INNER JOIN agent_retrieval_actions arc ON (am."agentRetrievalActionId" = arc.id)  WHERE arc."agentMessageId" <> am.id;
```

## Risk

Quite risky as we delete agentRetrievalActionId on AgentMessage so a revert would involve a migration.

## Deploy Plan

- Update all AgentRetrievalActions that have no agentMessageId to a magic ModelId
- deploy `front`
- init_db.sh (comes after (deletion))