### PR TITLE
Fix: handle Confluence API timeouts / network errors

### DIFF
--- a/connectors/src/connectors/confluence/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/confluence/temporal/cast_known_errors.ts
@@ -27,6 +27,30 @@ export class ConfluenceCastKnownErrorsInterceptor
           error: err,
         };
       }
+      if (
+        err instanceof ConfluenceClientError &&
+        err.type === "http_response_error" &&
+        err.status === 502
+      ) {
+        throw {
+          __is_dust_error: true,
+          message: "502 Bad Gateway",
+          type: "network_error",
+          error: err,
+        };
+      }
+      if (
+        err instanceof ConfluenceClientError &&
+        err.type === "http_response_error" &&
+        err.status === 504
+      ) {
+        throw {
+          __is_dust_error: true,
+          message: "Request timed out",
+          type: "network_timeout_error",
+          error: err,
+        };
+      }
       throw err;
     }
   }


### PR DESCRIPTION
Desctiption
---

Fixes https://github.com/dust-tt/tasks/issues/721
We cannot act on those errors & they're usually transient. We rely on the temporal activity failure monitor to warn us if they're not.

Risk
---
NTR

Deploy plan
---
Connectors
