### PR TITLE
Adding tracing logs between front and Dust apps.

### DIFF
--- a/front/lib/actions/server.ts
+++ b/front/lib/actions/server.ts
@@ -143,7 +143,7 @@ export async function runActionStreamed(
     );
   };
 
-  return new Ok({ eventStream: streamEvents(), dustRunId });
+  return new Ok({ eventStream: streamEvents() });
 }
 
 /**

--- a/front/lib/actions/server.ts
+++ b/front/lib/actions/server.ts
@@ -48,7 +48,8 @@ export async function runActionStreamed(
   auth: Authenticator,
   actionName: DustRegistryActionName,
   config: DustAppConfigType,
-  inputs: Array<unknown>
+  inputs: Array<unknown>,
+  tracingRecords: Record<string, any>
 ) {
   const owner = auth.workspace();
   if (!owner) {
@@ -93,6 +94,27 @@ export async function runActionStreamed(
   }
 
   const { eventStream, dustRunId } = res.value;
+  dustRunId
+    .then((runId) => {
+      logger.info(
+        {
+          runId,
+          loggerArgs,
+          tracingRecords,
+        },
+        "Got runId for runActionStreamed"
+      );
+    })
+    .catch((err) => {
+      logger.error(
+        {
+          error: err,
+          loggerArgs,
+          tracingRecords,
+        },
+        "Failed to get runId for runActionStreamed"
+      );
+    });
 
   const streamEvents = async function* () {
     for await (const event of eventStream) {

--- a/front/lib/actions/server.ts
+++ b/front/lib/actions/server.ts
@@ -93,6 +93,8 @@ export async function runActionStreamed(
     return new Err(res.error);
   }
 
+  // Don't await the dustRunid promise before you are done iterating on the eventStream,
+  // it will block the event stream, which is in charge of resolving that promise.
   const { eventStream, dustRunId } = res.value;
   dustRunId
     .then((runId) => {

--- a/front/lib/actions/server.ts
+++ b/front/lib/actions/server.ts
@@ -49,7 +49,7 @@ export async function runActionStreamed(
   actionName: DustRegistryActionName,
   config: DustAppConfigType,
   inputs: Array<unknown>,
-  tracingRecords: Record<string, any>
+  tracingRecords: Record<string, string>
 ) {
   const owner = auth.workspace();
   if (!owner) {

--- a/front/lib/api/assistant/actions/process.ts
+++ b/front/lib/api/assistant/actions/process.ts
@@ -303,13 +303,23 @@ export async function* runProcess(
   // Set top_k to 512 which is already a large number. We might want to bump to 1024.
   config.DATASOURCE.top_k = 512;
 
-  const res = await runActionStreamed(auth, "assistant-v2-process", config, [
+  const res = await runActionStreamed(
+    auth,
+    "assistant-v2-process",
+    config,
+    [
+      {
+        context_size: contextSize,
+        prompt,
+        schema: renderSchemaPropertiesAsJSONSchema(actionConfiguration.schema),
+      },
+    ],
     {
-      context_size: contextSize,
-      prompt,
-      schema: renderSchemaPropertiesAsJSONSchema(actionConfiguration.schema),
-    },
-  ]);
+      workspaceId: conversation.owner.sId,
+      conversationId: conversation.sId,
+      userMessageId: userMessage.sId,
+    }
+  );
 
   if (res.isErr()) {
     logger.error(

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -579,11 +579,21 @@ export async function* runRetrieval(
   // Handle top k.
   config.DATASOURCE.top_k = topK;
 
-  const res = await runActionStreamed(auth, "assistant-v2-retrieval", config, [
+  const res = await runActionStreamed(
+    auth,
+    "assistant-v2-retrieval",
+    config,
+    [
+      {
+        query,
+      },
+    ],
     {
-      query,
-    },
-  ]);
+      conversationId: conversation.sId,
+      workspaceId: conversation.owner.sId,
+      agentMessageId: agentMessage.sId,
+    }
+  );
 
   if (res.isErr()) {
     logger.error(

--- a/front/lib/api/assistant/actions/tables_query.ts
+++ b/front/lib/api/assistant/actions/tables_query.ts
@@ -188,7 +188,12 @@ export async function* runTablesQuery(
         question,
         instructions: configuration.instructions,
       },
-    ]
+    ],
+    {
+      conversationId: conversation.sId,
+      workspaceId: conversation.owner.sId,
+      agentMessageId: agentMessage.sId,
+    }
   );
 
   if (res.isErr()) {

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -430,13 +430,23 @@ export async function getNextAction(
   config.MODEL.model_id = model.modelId;
   config.MODEL.temperature = agentConfiguration.model.temperature;
 
-  const res = await runActionStreamed(auth, "assistant-v2-use-tools", config, [
+  const res = await runActionStreamed(
+    auth,
+    "assistant-v2-use-tools",
+    config,
+    [
+      {
+        conversation: modelConversationRes.value.modelConversation,
+        specifications,
+        prompt,
+      },
+    ],
     {
-      conversation: modelConversationRes.value.modelConversation,
-      specifications,
-      prompt,
-    },
-  ]);
+      conversationId: conversation.sId,
+      workspaceId: conversation.owner.sId,
+      userMessageId: userMessage.sId,
+    }
+  );
 
   if (res.isErr()) {
     return new Err(

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -462,7 +462,11 @@ export async function generateConversationTitle(
       {
         conversation: modelConversationRes.value.modelConversation,
       },
-    ]
+    ],
+    {
+      conversationId: conversation.sId,
+      workspaceId: conversation.owner.sId,
+    }
   );
 
   if (res.isErr()) {

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -426,12 +426,22 @@ export async function* runGeneration(
     "[ASSISTANT_TRACE] Generation exection"
   );
 
-  const res = await runActionStreamed(auth, "assistant-v2-generator", config, [
+  const res = await runActionStreamed(
+    auth,
+    "assistant-v2-generator",
+    config,
+    [
+      {
+        conversation: modelConversationRes.value.modelConversation,
+        prompt,
+      },
+    ],
     {
-      conversation: modelConversationRes.value.modelConversation,
-      prompt,
-    },
-  ]);
+      conversationId: conversation.sId,
+      userMessageId: userMessage.sId,
+      workspaceId: conversation.owner.sId,
+    }
+  );
 
   if (res.isErr()) {
     yield {

--- a/front/lib/api/assistant/legacy_agent.ts
+++ b/front/lib/api/assistant/legacy_agent.ts
@@ -119,7 +119,12 @@ async function generateActionInputs(
         specification,
         prompt,
       },
-    ]
+    ],
+    {
+      workspaceId: conversation.owner.sId,
+      conversationId: conversation.sId,
+      userMessageId: userMessage.sId,
+    }
   );
 
   if (res.isErr()) {


### PR DESCRIPTION
## Description

Adding tracing logs linking a Dust app run id with front `{conversationId, workspaceId, userMessageId | agentMessageId}` to make debugging easier.

The specific ticket I am trying to solve is [this](https://github.com/dust-tt/tasks/issues/703) one, but linking a dust app run to a conversation is a recurring problem.


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
