### PR TITLE
Add support to invite members from Poke

### DIFF
--- a/front/components/poke/members/InviteMemberDialog.tsx
+++ b/front/components/poke/members/InviteMemberDialog.tsx
@@ -70,17 +70,20 @@ export default function InviteMemberDialog({
       setIsSubmitting(true);
       setError(null);
       try {
-        const r = await fetch(`/api/poke/workspaces/${owner.sId}/invitations`, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify(cleanedValues),
-        });
+        const res = await fetch(
+          `/api/poke/workspaces/${owner.sId}/invitations`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify(cleanedValues),
+          }
+        );
 
-        if (!r.ok) {
+        if (!res.ok) {
           throw new Error(
-            `Something went wrong: ${r.status} ${await r.text()}`
+            `Something went wrong: ${res.status} ${await res.text()}`
           );
         }
 

--- a/front/components/poke/members/InviteMemberDialog.tsx
+++ b/front/components/poke/members/InviteMemberDialog.tsx
@@ -1,0 +1,157 @@
+import { Spinner } from "@dust-tt/sparkle";
+import type {
+  InviteMemberFormType,
+  UserType,
+  WorkspaceType,
+} from "@dust-tt/types";
+import {
+  InviteMemberFormSchema,
+  MEMBERSHIP_ROLE_TYPES,
+  removeNulls,
+} from "@dust-tt/types";
+import { ioTsResolver } from "@hookform/resolvers/io-ts";
+import { useRouter } from "next/router";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+
+import { PokeButton } from "@app/components/poke/shadcn/ui/button";
+import {
+  PokeDialog,
+  PokeDialogContent,
+  PokeDialogDescription,
+  PokeDialogFooter,
+  PokeDialogHeader,
+  PokeDialogTitle,
+  PokeDialogTrigger,
+} from "@app/components/poke/shadcn/ui/dialog";
+import { PokeForm } from "@app/components/poke/shadcn/ui/form";
+import {
+  InputField,
+  SelectField,
+} from "@app/components/poke/shadcn/ui/form/fields";
+export default function InviteMemberDialog({
+  owner,
+  user,
+}: {
+  owner: WorkspaceType;
+  user: UserType;
+}) {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [open, setOpen] = useState(false);
+
+  const router = useRouter();
+
+  const form = useForm<InviteMemberFormType>({
+    resolver: ioTsResolver(InviteMemberFormSchema),
+    defaultValues: {
+      email: "",
+      role: "user",
+    },
+  });
+
+  const onSubmit = (values: InviteMemberFormType) => {
+    const cleanedValues = Object.fromEntries(
+      removeNulls(
+        Object.entries(values).map(([key, value]) => {
+          if (typeof value !== "string") {
+            return [key, value];
+          }
+          const cleanedValue = value.trim();
+          if (!cleanedValue) {
+            return null;
+          }
+          return [key, cleanedValue];
+        })
+      )
+    );
+
+    const submit = async () => {
+      setIsSubmitting(true);
+      setError(null);
+      try {
+        const r = await fetch(`/api/poke/workspaces/${owner.sId}/invitations`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(cleanedValues),
+        });
+
+        if (!r.ok) {
+          throw new Error(
+            `Something went wrong: ${r.status} ${await r.text()}`
+          );
+        }
+
+        form.reset();
+        setOpen(false);
+        router.reload();
+      } catch (e) {
+        setIsSubmitting(false);
+        if (e instanceof Error) {
+          setError(e.message);
+        }
+      }
+    };
+    void submit();
+  };
+
+  return (
+    <PokeDialog open={open} onOpenChange={setOpen}>
+      <PokeDialogTrigger asChild>
+        <PokeButton variant="outline">🙋‍♂️ Invite a user</PokeButton>
+      </PokeDialogTrigger>
+      <PokeDialogContent className="bg-structure-50 sm:max-w-[600px]">
+        <PokeDialogHeader>
+          <PokeDialogTitle>
+            Invite a user to {owner.name}'s workspace.
+          </PokeDialogTitle>
+          <PokeDialogDescription>
+            Enter the user's email to grant them direct access to {owner.name}'s
+            Workspace. Once invited, they'll receive an email notification.
+            Please ensure the email address is accurate and that the user is
+            aware they are being invited. They will get an email from{" "}
+            <span className="font-bold">{user.fullName}</span>.
+          </PokeDialogDescription>
+        </PokeDialogHeader>
+        {error && <div className="text-red-500">{error}</div>}
+        {isSubmitting && <Spinner />}
+        {!isSubmitting && (
+          <PokeForm {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+              <div className="grid gap-4 py-4">
+                <div className="grid-cols grid items-center gap-4">
+                  <InputField
+                    control={form.control}
+                    name="email"
+                    title="User email"
+                    placeholder="octave@abc.yz"
+                  />
+                </div>
+                <div className="grid-cols grid items-center gap-4">
+                  <SelectField
+                    control={form.control}
+                    name="role"
+                    title="Role"
+                    options={MEMBERSHIP_ROLE_TYPES.map((role) => ({
+                      value: role,
+                    }))}
+                  />
+                </div>
+              </div>
+              <PokeDialogFooter>
+                <PokeButton
+                  type="submit"
+                  className="border-warning-600 bg-warning-500 text-white"
+                >
+                  Invite
+                </PokeButton>
+              </PokeDialogFooter>
+            </form>
+          </PokeForm>
+        )}
+      </PokeDialogContent>
+    </PokeDialog>
+  );
+}

--- a/front/components/poke/members/InviteMemberDialog.tsx
+++ b/front/components/poke/members/InviteMemberDialog.tsx
@@ -116,6 +116,9 @@ export default function InviteMemberDialog({
             Please ensure the email address is accurate and that the user is
             aware they are being invited. They will get an email from{" "}
             <span className="font-bold">{user.fullName}</span>.
+            <br />
+            Note: the role 'user' below is the same as a 'member' role in the
+            UI.
           </PokeDialogDescription>
         </PokeDialogHeader>
         {error && <div className="text-red-500">{error}</div>}

--- a/front/components/poke/members/table.tsx
+++ b/front/components/poke/members/table.tsx
@@ -1,9 +1,11 @@
 import type { UserTypeWithWorkspaces, WorkspaceType } from "@dust-tt/types";
+import type { UserType } from "@dust-tt/types";
 import { MEMBERSHIP_ROLE_TYPES } from "@dust-tt/types";
 import { useRouter } from "next/router";
 
 import type { MemberDisplayType } from "@app/components/poke/members/columns";
 import { makeColumnsForMembers } from "@app/components/poke/members/columns";
+import InviteMemberDialog from "@app/components/poke/members/InviteMemberDialog";
 import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
 
 function prepareMembersForDisplay(
@@ -24,9 +26,14 @@ function prepareMembersForDisplay(
 interface MembersDataTableProps {
   members: UserTypeWithWorkspaces[];
   owner: WorkspaceType;
+  user: UserType;
 }
 
-export function MembersDataTable({ members, owner }: MembersDataTableProps) {
+export function MembersDataTable({
+  members,
+  owner,
+  user,
+}: MembersDataTableProps) {
   const router = useRouter();
 
   const onRevokeMember = async (m: MemberDisplayType) => {
@@ -55,22 +62,27 @@ export function MembersDataTable({ members, owner }: MembersDataTableProps) {
   };
 
   return (
-    <div className="border-material-200 my-4 flex w-full flex-col rounded-lg border p-4">
-      <h2 className="text-md mb-4 font-bold">Members:</h2>
-      <PokeDataTable
-        columns={makeColumnsForMembers({ onRevokeMember })}
-        data={prepareMembersForDisplay(members)}
-        facets={[
-          {
-            columnId: "role",
-            title: "Role",
-            options: [...MEMBERSHIP_ROLE_TYPES, "none"].map((r) => ({
-              label: r,
-              value: r,
-            })),
-          },
-        ]}
-      />
-    </div>
+    <>
+      <div className="border-material-200 my-4 flex w-full flex-col rounded-lg border p-4">
+        <div className="flex justify-between gap-3">
+          <h2 className="text-md mb-4 font-bold">Members:</h2>
+          <InviteMemberDialog owner={owner} user={user} />
+        </div>
+        <PokeDataTable
+          columns={makeColumnsForMembers({ onRevokeMember })}
+          data={prepareMembersForDisplay(members)}
+          facets={[
+            {
+              columnId: "role",
+              title: "Role",
+              options: [...MEMBERSHIP_ROLE_TYPES, "none"].map((r) => ({
+                label: r,
+                value: r,
+              })),
+            },
+          ]}
+        />
+      </div>
+    </>
   );
 }

--- a/front/components/poke/shadcn/ui/form/fields.tsx
+++ b/front/components/poke/shadcn/ui/form/fields.tsx
@@ -1,0 +1,103 @@
+import type { Control, FieldValues, Path } from "react-hook-form";
+
+import {
+  PokeFormControl,
+  PokeFormField,
+  PokeFormItem,
+  PokeFormLabel,
+  PokeFormMessage,
+} from "@app/components/poke/shadcn/ui/form";
+import { PokeInput } from "@app/components/poke/shadcn/ui/input";
+import {
+  PokeSelect,
+  PokeSelectContent,
+  PokeSelectItem,
+  PokeSelectTrigger,
+  PokeSelectValue,
+} from "@app/components/poke/shadcn/ui/select";
+
+interface SelectFieldOption {
+  value: string;
+  display?: string;
+}
+
+export function SelectField<T extends FieldValues>({
+  control,
+  name,
+  title,
+  options,
+}: {
+  control: Control<T>;
+  name: Path<T>;
+  title?: string;
+  options: SelectFieldOption[];
+}) {
+  return (
+    <PokeFormField
+      control={control}
+      name={name}
+      render={({ field }) => (
+        <PokeFormItem>
+          <PokeFormLabel className="capitalize">{title ?? name}</PokeFormLabel>
+          <PokeFormControl>
+            <PokeSelect
+              onValueChange={field.onChange}
+              value={field.value as string}
+            >
+              <PokeFormControl>
+                <PokeSelectTrigger>
+                  <PokeSelectValue placeholder={title ?? name} />
+                </PokeSelectTrigger>
+              </PokeFormControl>
+              <PokeSelectContent>
+                <div className="bg-slate-100">
+                  {options.map((option) => (
+                    <PokeSelectItem key={option.value} value={option.value}>
+                      {option.display ? option.display : option.value}
+                    </PokeSelectItem>
+                  ))}
+                </div>
+              </PokeSelectContent>
+            </PokeSelect>
+          </PokeFormControl>
+          <PokeFormMessage />
+        </PokeFormItem>
+      )}
+    />
+  );
+}
+
+export function InputField<T extends FieldValues>({
+  control,
+  name,
+  title,
+  type,
+  placeholder,
+}: {
+  control: Control<T>;
+  name: Path<T>;
+  title?: string;
+  type?: "text" | "number";
+  placeholder?: string;
+}) {
+  return (
+    <PokeFormField
+      control={control}
+      name={name}
+      render={({ field }) => (
+        <PokeFormItem>
+          <PokeFormLabel className="capitalize">{title ?? name}</PokeFormLabel>
+          <PokeFormControl>
+            <PokeInput
+              placeholder={placeholder ?? name}
+              type={type}
+              {...field}
+              value={field.value}
+            />
+          </PokeFormControl>
+          <PokeFormMessage />
+        </PokeFormItem>
+      )}
+    />
+  );
+}

--- a/front/components/poke/subscriptions/EnterpriseUpgradeDialog.tsx
+++ b/front/components/poke/subscriptions/EnterpriseUpgradeDialog.tsx
@@ -4,7 +4,6 @@ import { EnterpriseUpgradeFormSchema, removeNulls } from "@dust-tt/types";
 import { ioTsResolver } from "@hookform/resolvers/io-ts";
 import { useRouter } from "next/router";
 import { useState } from "react";
-import type { Control } from "react-hook-form";
 import { useForm } from "react-hook-form";
 
 import { PokeButton } from "@app/components/poke/shadcn/ui/button";
@@ -17,109 +16,12 @@ import {
   PokeDialogTitle,
   PokeDialogTrigger,
 } from "@app/components/poke/shadcn/ui/dialog";
+import { PokeForm } from "@app/components/poke/shadcn/ui/form";
 import {
-  PokeForm,
-  PokeFormControl,
-  PokeFormField,
-  PokeFormItem,
-  PokeFormLabel,
-  PokeFormMessage,
-} from "@app/components/poke/shadcn/ui/form";
-import { PokeInput } from "@app/components/poke/shadcn/ui/input";
-import {
-  PokeSelect,
-  PokeSelectContent,
-  PokeSelectItem,
-  PokeSelectTrigger,
-  PokeSelectValue,
-} from "@app/components/poke/shadcn/ui/select";
+  InputField,
+  SelectField,
+} from "@app/components/poke/shadcn/ui/form/fields";
 import { usePokePlans } from "@app/lib/swr";
-
-interface SelectFieldOption {
-  value: string;
-  display?: string;
-}
-
-function SelectField({
-  control,
-  name,
-  title,
-  options,
-}: {
-  control: Control<EnterpriseUpgradeFormType>;
-  name: keyof EnterpriseUpgradeFormType;
-  title?: string;
-  options: SelectFieldOption[];
-}) {
-  return (
-    <PokeFormField
-      control={control}
-      name={name}
-      render={({ field }) => (
-        <PokeFormItem>
-          <PokeFormLabel className="capitalize">{title ?? name}</PokeFormLabel>
-          <PokeFormControl>
-            <PokeSelect
-              onValueChange={field.onChange}
-              value={field.value as string}
-            >
-              <PokeFormControl>
-                <PokeSelectTrigger>
-                  <PokeSelectValue placeholder={title ?? name} />
-                </PokeSelectTrigger>
-              </PokeFormControl>
-              <PokeSelectContent>
-                <div className="bg-slate-100">
-                  {options.map((option) => (
-                    <PokeSelectItem key={option.value} value={option.value}>
-                      {option.display ? option.display : option.value}
-                    </PokeSelectItem>
-                  ))}
-                </div>
-              </PokeSelectContent>
-            </PokeSelect>
-          </PokeFormControl>
-          <PokeFormMessage />
-        </PokeFormItem>
-      )}
-    />
-  );
-}
-
-function InputField({
-  control,
-  name,
-  title,
-  type,
-  placeholder,
-}: {
-  control: Control<EnterpriseUpgradeFormType>;
-  name: keyof EnterpriseUpgradeFormType;
-  title?: string;
-  type?: "text" | "number";
-  placeholder?: string;
-}) {
-  return (
-    <PokeFormField
-      control={control}
-      name={name}
-      render={({ field }) => (
-        <PokeFormItem>
-          <PokeFormLabel className="capitalize">{title ?? name}</PokeFormLabel>
-          <PokeFormControl>
-            <PokeInput
-              placeholder={placeholder ?? name}
-              type={type}
-              {...field}
-              value={field.value}
-            />
-          </PokeFormControl>
-          <PokeFormMessage />
-        </PokeFormItem>
-      )}
-    />
-  );
-}
 
 export default function EnterpriseUpgradeDialog({
   disabled,

--- a/front/lib/api/invitation.ts
+++ b/front/lib/api/invitation.ts
@@ -1,18 +1,25 @@
 import type {
   ActiveRoleType,
+  APIErrorWithStatusCode,
   MembershipInvitationType,
+  Result,
+  SubscriptionType,
   UserType,
   WorkspaceType,
 } from "@dust-tt/types";
-import { Err, sanitizeString } from "@dust-tt/types";
+import { Err, Ok, sanitizeString } from "@dust-tt/types";
 import sgMail from "@sendgrid/mail";
 import { sign } from "jsonwebtoken";
 import { Op } from "sequelize";
 
 import config from "@app/lib/api/config";
+import { getMembers } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
+import { MAX_UNCONSUMED_INVITATIONS_PER_WORKSPACE_PER_DAY } from "@app/lib/invitations";
 import { MembershipInvitation } from "@app/lib/models/workspace";
-import { generateModelSId } from "@app/lib/utils";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { generateModelSId, isEmailValid } from "@app/lib/utils";
+import logger from "@app/logger/logger";
 
 sgMail.setApiKey(config.getSendgridApiKey());
 
@@ -268,4 +275,145 @@ export async function batchUnrevokeInvitations(
       },
     }
   );
+}
+
+interface MembershipInvitationBlob {
+  email: string;
+  role: ActiveRoleType;
+}
+
+export async function handleMembersInvitation(
+  auth: Authenticator,
+  {
+    invitationRequests,
+    owner,
+    subscription,
+    user,
+  }: {
+    owner: WorkspaceType;
+    subscription: SubscriptionType;
+    user: UserType;
+    invitationRequests: MembershipInvitationBlob[];
+  }
+): Promise<Result<any, APIErrorWithStatusCode>> {
+  const { maxUsers } = subscription.plan.limits.users;
+  const availableSeats =
+    maxUsers -
+    (await MembershipResource.getMembersCountForWorkspace({
+      workspace: owner,
+      activeOnly: true,
+    }));
+  if (maxUsers !== -1 && availableSeats < invitationRequests.length) {
+    return new Err({
+      status_code: 400,
+      api_error: {
+        type: "plan_limit_error",
+        message: `Not enough seats lefts (${availableSeats} seats remaining). Please upgrade or remove inactive members to add more.`,
+      },
+    });
+  }
+
+  const invalidEmails = invitationRequests.filter(
+    (b) => !isEmailValid(b.email)
+  );
+  if (invalidEmails.length > 0) {
+    return new Err({
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid email address(es): " + invalidEmails.join(", "),
+      },
+    });
+  }
+  const existingMembers = await getMembers(auth);
+  const unconsumedInvitations = await getRecentPendingAndRevokedInvitations(
+    auth
+  );
+  if (
+    unconsumedInvitations.pending.length >=
+    MAX_UNCONSUMED_INVITATIONS_PER_WORKSPACE_PER_DAY
+  ) {
+    return new Err({
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: `Too many pending invitations. Please ask your members to consume their invitations before sending more.`,
+      },
+    });
+  }
+
+  const emailsWithRecentUnconsumedInvitations = new Set([
+    ...unconsumedInvitations.pending.map((i) =>
+      i.inviteEmail.toLowerCase().trim()
+    ),
+    ...unconsumedInvitations.revoked.map((i) =>
+      i.inviteEmail.toLowerCase().trim()
+    ),
+  ]);
+  const requestedEmails = new Set(
+    invitationRequests.map((r) => r.email.toLowerCase().trim())
+  );
+  const emailsToSendInvitations = invitationRequests.filter(
+    (r) =>
+      !emailsWithRecentUnconsumedInvitations.has(r.email.toLowerCase().trim())
+  );
+  const invitationsToUnrevoke = unconsumedInvitations.revoked.filter((i) =>
+    requestedEmails.has(i.inviteEmail.toLowerCase().trim())
+  );
+
+  if (
+    !emailsToSendInvitations.length &&
+    !invitationsToUnrevoke &&
+    invitationRequests.length > 0
+  ) {
+    return new Err({
+      status_code: 400,
+      api_error: {
+        type: "invitation_already_sent_recently",
+        message: `These emails have already received an invitation in the last 24 hours. Please wait before sending another invitation.`,
+      },
+    });
+  }
+  await batchUnrevokeInvitations(
+    auth,
+    invitationsToUnrevoke.map((i) => i.sId)
+  );
+  const invitationResults = await Promise.all(
+    emailsToSendInvitations.map(async ({ email, role }) => {
+      if (existingMembers.find((m) => m.email === email)) {
+        return {
+          success: false,
+          email,
+          error_message:
+            "Cannot send invitation to existing member (active or revoked)",
+        };
+      }
+
+      try {
+        const invitation = await updateOrCreateInvitation(owner, email, role);
+        await sendWorkspaceInvitationEmail(owner, user, invitation);
+      } catch (e) {
+        logger.error(
+          {
+            error: e,
+            message: "Failed to send invitation email",
+            email,
+          },
+          "Failed to send invitation email"
+        );
+
+        return {
+          success: false,
+          email,
+          error_message: e instanceof Error ? e.message : "Unknown error",
+        };
+      }
+      return {
+        success: true,
+        email,
+      };
+    })
+  );
+
+  return new Ok(invitationResults);
 }

--- a/front/lib/api/invitation.ts
+++ b/front/lib/api/invitation.ts
@@ -282,7 +282,13 @@ interface MembershipInvitationBlob {
   role: ActiveRoleType;
 }
 
-export async function handleMembersInvitation(
+interface HandleMembershipInvitationResult {
+  success: boolean;
+  email: string;
+  error_message?: string;
+}
+
+export async function handleMembershipInvitations(
   auth: Authenticator,
   {
     invitationRequests,
@@ -295,7 +301,7 @@ export async function handleMembersInvitation(
     user: UserType;
     invitationRequests: MembershipInvitationBlob[];
   }
-): Promise<Result<any, APIErrorWithStatusCode>> {
+): Promise<Result<HandleMembershipInvitationResult[], APIErrorWithStatusCode>> {
   const { maxUsers } = subscription.plan.limits.users;
   const availableSeats =
     maxUsers -
@@ -363,7 +369,7 @@ export async function handleMembersInvitation(
 
   if (
     !emailsToSendInvitations.length &&
-    !invitationsToUnrevoke &&
+    !invitationsToUnrevoke.length &&
     invitationRequests.length > 0
   ) {
     return new Err({

--- a/front/pages/api/poke/workspaces/[wId]/invitations.ts
+++ b/front/pages/api/poke/workspaces/[wId]/invitations.ts
@@ -5,7 +5,7 @@ import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { handleMembersInvitation } from "@app/lib/api/invitation";
+import { handleMembershipInvitations } from "@app/lib/api/invitation";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { apiError, withLogging } from "@app/logger/withlogging";
 
@@ -18,7 +18,7 @@ type PokePostInvitationResponseBody = {
   success: boolean;
   email: string;
   error_message?: string;
-}[];
+};
 
 async function handler(
   req: NextApiRequest,
@@ -81,7 +81,7 @@ async function handler(
         });
       }
 
-      const invitationRes = await handleMembersInvitation(auth, {
+      const invitationRes = await handleMembershipInvitations(auth, {
         owner,
         user,
         subscription,

--- a/front/pages/api/poke/workspaces/[wId]/invitations.ts
+++ b/front/pages/api/poke/workspaces/[wId]/invitations.ts
@@ -81,12 +81,23 @@ async function handler(
         });
       }
 
-      const invitationRes = await handleMembershipInvitations(auth, {
-        owner,
-        user,
-        subscription,
-        invitationRequests: [bodyValidation.right],
-      });
+      // To send the invitations, we need to auth as admin of the workspace
+
+      // !! this is ok because we're in Poke as dust super user, do not copy paste
+      // this mindlessly !!
+      const workspaceAdminAuth = await Authenticator.internalAdminForWorkspace(
+        owner.sId
+      );
+
+      const invitationRes = await handleMembershipInvitations(
+        workspaceAdminAuth,
+        {
+          owner,
+          user,
+          subscription,
+          invitationRequests: [bodyValidation.right],
+        }
+      );
 
       if (invitationRes.isErr()) {
         return apiError(req, res, invitationRes.error);

--- a/front/pages/api/w/[wId]/invitations/index.ts
+++ b/front/pages/api/w/[wId]/invitations/index.ts
@@ -8,7 +8,7 @@ import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { handleMembersInvitation } from "@app/lib/api/invitation";
+import { handleMembershipInvitations } from "@app/lib/api/invitation";
 import { getPendingInvitations } from "@app/lib/api/invitation";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { apiError, withLogging } from "@app/logger/withlogging";
@@ -113,7 +113,7 @@ async function handler(
         });
       }
 
-      const invitationRes = await handleMembersInvitation(auth, {
+      const invitationRes = await handleMembershipInvitations(auth, {
         owner,
         user,
         subscription,

--- a/front/pages/poke/[wId]/memberships.tsx
+++ b/front/pages/poke/[wId]/memberships.tsx
@@ -16,7 +16,7 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
   const owner = auth.workspace();
   const user = auth.user();
 
-  if (!owner) {
+  if (!owner || !user) {
     return {
       notFound: true,
     };

--- a/front/pages/poke/[wId]/memberships.tsx
+++ b/front/pages/poke/[wId]/memberships.tsx
@@ -1,4 +1,5 @@
 import type { UserTypeWithWorkspaces, WorkspaceType } from "@dust-tt/types";
+import type { UserType } from "@dust-tt/types";
 import type { InferGetServerSidePropsType } from "next";
 import React from "react";
 
@@ -8,10 +9,12 @@ import { getMembers } from "@app/lib/api/workspace";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 
 export const getServerSideProps = withSuperUserAuthRequirements<{
-  owner: WorkspaceType;
   members: UserTypeWithWorkspaces[];
+  owner: WorkspaceType;
+  user: UserType;
 }>(async (context, auth) => {
   const owner = auth.workspace();
+  const user = auth.user();
 
   if (!owner) {
     return {
@@ -23,15 +26,17 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
 
   return {
     props: {
-      owner,
       members,
+      owner,
+      user,
     },
   };
 });
 
 const MembershipsPage = ({
-  owner,
   members,
+  owner,
+  user,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
   return (
     <div className="min-h-screen bg-structure-50">
@@ -39,7 +44,7 @@ const MembershipsPage = ({
       <div className="flex-grow p-6">
         <h1 className="mb-8 text-2xl font-bold">{owner.name}</h1>
         <div className="flex justify-center">
-          <MembersDataTable members={members} owner={owner} />
+          <MembersDataTable members={members} owner={owner} user={user} />
         </div>
       </div>
     </div>

--- a/types/src/front/membership_invitation.ts
+++ b/types/src/front/membership_invitation.ts
@@ -1,5 +1,8 @@
+import * as t from "io-ts";
+import { NonEmptyString } from "io-ts-types";
+
 import { ModelId } from "../shared/model_id";
-import { ActiveRoleType } from "./user";
+import { ActiveRoleSchema, ActiveRoleType } from "./user";
 
 export type MembershipInvitationType = {
   sId: string;
@@ -8,3 +11,12 @@ export type MembershipInvitationType = {
   inviteEmail: string;
   initialRole: ActiveRoleType;
 };
+
+// Types for the invite form in Poke.
+
+export const InviteMemberFormSchema = t.type({
+  email: NonEmptyString,
+  role: ActiveRoleSchema,
+});
+
+export type InviteMemberFormType = t.TypeOf<typeof InviteMemberFormSchema>;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See https://github.com/dust-tt/tasks/issues/724.

This PR introduces the ability to invite new members to a workspace directly from Poke. It leverages the existing invitation logic within the app, which already includes a lot of business logic (max number of seats, revoked, pending, ...). The email invitations will be sent using the user's connected account on Poke. For instance, the invitation email may appear as: 
> Flavien David is inviting you to join the abc workspace on Dust.

![InviteUserPoke](https://github.com/dust-tt/dust/assets/7428970/bebf563e-9d46-4548-b181-b13095199cad)

## Risk

Pretty low risk. Safe to rollback.
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
