### PR TITLE
fix: don't redirect to sso page for superuser auth

### DIFF
--- a/front/components/app/Deploy.tsx
+++ b/front/components/app/Deploy.tsx
@@ -86,16 +86,22 @@ export default function Deploy({
 
   return (
     <div>
-      <Tooltip label={disabled ? "You need to run this app at least once successfully to view the endpoint" : "View how to run this app programmatically"}>
-      <Button
-        label="View API endpoint"
-        variant="primary"
-        onClick={() => {
-          setOpen(!open);
-        }}
-        disabled={disabled}
-        icon={CubeIcon}
-      />
+      <Tooltip
+        label={
+          disabled
+            ? "You need to run this app at least once successfully to view the endpoint"
+            : "View how to run this app programmatically"
+        }
+      >
+        <Button
+          label="View API endpoint"
+          variant="primary"
+          onClick={() => {
+            setOpen(!open);
+          }}
+          disabled={disabled}
+          icon={CubeIcon}
+        />
       </Tooltip>
 
       <Transition.Root show={open} as={Fragment}>

--- a/front/lib/iam/session.ts
+++ b/front/lib/iam/session.ts
@@ -216,7 +216,11 @@ export function makeGetServerSidePropsRequirementsWrapper<
         }
 
         // Validate the user's session to guarantee compliance with the workspace's SSO requirements when SSO is enforced.
-        if (auth && !statisfiesEnforceEntrepriseConnection(auth, session)) {
+        if (
+          auth &&
+          !statisfiesEnforceEntrepriseConnection(auth, session) &&
+          requireUserPrivilege !== "superuser"
+        ) {
           return {
             redirect: {
               permanent: false,


### PR DESCRIPTION
## Description

Currently, poke is broken for ssoEnforced workspace, as navigating to the page redirects to the SSO page.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
