### PR TITLE
chore: refactor AB state to use an array of actions

### DIFF
--- a/front/components/assistant/TryAssistant.tsx
+++ b/front/components/assistant/TryAssistant.tsx
@@ -1,4 +1,5 @@
 import { Modal } from "@dust-tt/sparkle";
+import type { WorkspaceType } from "@dust-tt/types";
 import type {
   AgentMention,
   ConversationType,
@@ -6,7 +7,7 @@ import type {
   MentionType,
   UserType,
 } from "@dust-tt/types";
-import type { WorkspaceType } from "@dust-tt/types";
+import { removeNulls } from "@dust-tt/types";
 import { useCallback, useContext, useEffect, useRef, useState } from "react";
 
 import ConversationViewer from "@app/components/assistant/conversation/ConversationViewer";
@@ -23,6 +24,7 @@ import {
 import { submitAssistantBuilderForm } from "@app/components/assistant_builder/AssistantBuilder";
 import type { AssistantBuilderState } from "@app/components/assistant_builder/types";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
+import { useDeprecatedDefaultSingleAction } from "@app/lib/client/assistant_builder/deprecated_single_action";
 import { useUser } from "@app/lib/swr";
 import { classNames } from "@app/lib/utils";
 import { debounce } from "@app/lib/utils/debounce";
@@ -193,6 +195,8 @@ export function usePreviewAssistant({
   const drawerAnimationTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const debounceHandle = useRef<NodeJS.Timeout | undefined>(undefined);
 
+  const action = useDeprecatedDefaultSingleAction(builderState);
+
   const animate = () => {
     if (drawerAnimationTimeoutRef.current) {
       clearTimeout(drawerAnimationTimeoutRef.current);
@@ -210,17 +214,13 @@ export function usePreviewAssistant({
     const a = await submitAssistantBuilderForm({
       owner,
       builderState: {
-        actionMode: builderState.actionMode,
         handle: builderState.handle,
         description: "Draft Assistant",
         instructions: builderState.instructions,
         avatarUrl: builderState.avatarUrl,
-        retrievalConfiguration: builderState.retrievalConfiguration,
-        dustAppConfiguration: builderState.dustAppConfiguration,
-        tablesQueryConfiguration: builderState.tablesQueryConfiguration,
-        processConfiguration: builderState.processConfiguration,
         scope: "private",
         generationSettings: builderState.generationSettings,
+        actions: removeNulls([action]),
       },
 
       agentConfigurationId: null,
@@ -239,16 +239,11 @@ export function usePreviewAssistant({
     }, animationLength / 2);
   }, [
     owner,
-    builderState.actionMode,
+    action,
     builderState.handle,
     builderState.instructions,
     builderState.avatarUrl,
     builderState.generationSettings,
-    // Actions
-    builderState.tablesQueryConfiguration,
-    builderState.dustAppConfiguration,
-    builderState.retrievalConfiguration,
-    builderState.processConfiguration,
   ]);
 
   useEffect(() => {

--- a/front/components/assistant_builder/ActionScreen.tsx
+++ b/front/components/assistant_builder/ActionScreen.tsx
@@ -425,7 +425,9 @@ export default function ActionScreen({
         >
           <ActionRetrievalSearch
             owner={owner}
-            action={action}
+            actionConfiguration={
+              action?.type === "RETRIEVAL_SEARCH" ? action.configuration : null
+            }
             dataSources={dataSources}
             setBuilderState={setBuilderState}
             setEdited={setEdited}
@@ -437,7 +439,11 @@ export default function ActionScreen({
         >
           <ActionRetrievalExhaustive
             owner={owner}
-            action={action}
+            actionConfiguration={
+              action?.type === "RETRIEVAL_EXHAUSTIVE"
+                ? action.configuration
+                : null
+            }
             dataSources={dataSources}
             setBuilderState={setBuilderState}
             setEdited={setEdited}
@@ -447,7 +453,9 @@ export default function ActionScreen({
         <ActionModeSection show={action?.type === "PROCESS" && !noDataSources}>
           <ActionProcess
             owner={owner}
-            action={action}
+            actionConfiguration={
+              action?.type === "PROCESS" ? action.configuration : null
+            }
             dataSources={dataSources}
             setBuilderState={setBuilderState}
             setEdited={setEdited}
@@ -459,7 +467,9 @@ export default function ActionScreen({
         >
           <ActionTablesQuery
             owner={owner}
-            action={action}
+            actionConfiguration={
+              action?.type === "TABLES_QUERY" ? action.configuration : null
+            }
             dataSources={dataSources}
             setBuilderState={setBuilderState}
             setEdited={setEdited}
@@ -469,7 +479,9 @@ export default function ActionScreen({
         <ActionModeSection show={action?.type === "DUST_APP_RUN"}>
           <ActionDustAppRun
             owner={owner}
-            action={action}
+            actionConfigration={
+              action?.type === "DUST_APP_RUN" ? action.configuration : null
+            }
             dustApps={dustApps}
             setBuilderState={setBuilderState}
             setEdited={setEdited}

--- a/front/components/assistant_builder/ActionScreen.tsx
+++ b/front/components/assistant_builder/ActionScreen.tsx
@@ -17,8 +17,9 @@ import type {
   WhitelistableFeature,
   WorkspaceType,
 } from "@dust-tt/types";
-import { assertNever } from "@dust-tt/types";
+import { assertNever, removeNulls } from "@dust-tt/types";
 import type { ComponentType, ReactNode } from "react";
+import React from "react";
 
 import {
   ActionProcess,
@@ -27,6 +28,7 @@ import {
 import {
   ActionRetrievalExhaustive,
   ActionRetrievalSearch,
+  isActionRetrievalExhaustiveValid,
   isActionRetrievalSearchValid,
 } from "@app/components/assistant_builder/actions/RetrievalAction";
 import {
@@ -34,21 +36,26 @@ import {
   isActionTablesQueryValid,
 } from "@app/components/assistant_builder/actions/TablesQueryAction";
 import type {
-  ActionMode,
+  AssistantBuilderActionType,
   AssistantBuilderState,
 } from "@app/components/assistant_builder/types";
+import { getDefaultActionConfiguration } from "@app/components/assistant_builder/types";
+import {
+  getDeprecatedDefaultSingleAction,
+  useDeprecatedDefaultSingleAction,
+} from "@app/lib/client/assistant_builder/deprecated_single_action";
 
 import {
   ActionDustAppRun,
   isActionDustAppRunValid,
 } from "./actions/DustAppRunAction";
 
-const BASIC_ACTION_TYPES = ["REPLY_ONLY", "USE_DATA_SOURCES"] as const;
-const ADVANCED_ACTION_TYPES = ["RUN_DUST_APP"] as const;
+const BASIC_ACTION_CATEGORIES = ["REPLY_ONLY", "USE_DATA_SOURCES"] as const;
+const ADVANCED_ACTION_CATEGORIES = ["RUN_DUST_APP"] as const;
 
-type ActionType =
-  | (typeof BASIC_ACTION_TYPES)[number]
-  | (typeof ADVANCED_ACTION_TYPES)[number];
+type ActionCategory =
+  | (typeof BASIC_ACTION_CATEGORIES)[number]
+  | (typeof ADVANCED_ACTION_CATEGORIES)[number];
 
 const SEARCH_MODES = [
   "RETRIEVAL_SEARCH",
@@ -58,39 +65,39 @@ const SEARCH_MODES = [
 ] as const;
 type SearchMode = (typeof SEARCH_MODES)[number];
 
-const ACTION_TYPE_SPECIFICATIONS: Record<
-  ActionType,
+const ACTION_CATEGORY_SPECIFICATIONS: Record<
+  ActionCategory,
   {
     label: string;
     icon: ComponentType;
     description: string;
-    defaultActionMode: ActionMode;
+    defaultActionType: AssistantBuilderActionType | null;
   }
 > = {
   REPLY_ONLY: {
     label: "Reply only",
     icon: ChatBubbleBottomCenterTextIcon,
     description: "Direct answer from the model",
-    defaultActionMode: "GENERIC",
+    defaultActionType: null,
   },
   USE_DATA_SOURCES: {
     label: "Use Data sources",
     icon: Square3Stack3DIcon,
     description: "Use Data sources to reply",
-    defaultActionMode: "RETRIEVAL_SEARCH",
+    defaultActionType: "RETRIEVAL_SEARCH",
   },
   RUN_DUST_APP: {
     label: "Run a Dust app",
     icon: CommandLineIcon,
     description: "Run a Dust app, then reply",
-    defaultActionMode: "DUST_APP_RUN",
+    defaultActionType: "DUST_APP_RUN",
   },
 };
 
 const SEARCH_MODE_SPECIFICATIONS: Record<
   SearchMode,
   {
-    actionMode: ActionMode;
+    actionType: AssistantBuilderActionType;
     icon: ComponentType;
     label: string;
     description: string;
@@ -98,28 +105,28 @@ const SEARCH_MODE_SPECIFICATIONS: Record<
   }
 > = {
   RETRIEVAL_SEARCH: {
-    actionMode: "RETRIEVAL_SEARCH",
+    actionType: "RETRIEVAL_SEARCH",
     icon: MagnifyingGlassIcon,
     label: "Search",
     description: "Search through selected Data sources",
     flag: null,
   },
   RETRIEVAL_EXHAUSTIVE: {
-    actionMode: "RETRIEVAL_EXHAUSTIVE",
+    actionType: "RETRIEVAL_EXHAUSTIVE",
     icon: TimeIcon,
     label: "Most recent data",
     description: "Include as much data as possible",
     flag: null,
   },
   TABLES_QUERY: {
-    actionMode: "TABLES_QUERY",
+    actionType: "TABLES_QUERY",
     icon: TableIcon,
     label: "Query Tables",
     description: "Tables, Spreadsheets, Notion DBs",
     flag: null,
   },
   PROCESS: {
-    actionMode: "PROCESS",
+    actionType: "PROCESS",
     icon: RobotIcon,
     label: "Process data",
     description: "Structured extraction",
@@ -138,21 +145,27 @@ function ActionModeSection({
 }
 
 export function isActionValid(builderState: AssistantBuilderState): boolean {
-  switch (builderState.actionMode) {
-    case "GENERIC":
-      return true;
+  // TODO(@fontanierh): handle multi-actions
+  const action = getDeprecatedDefaultSingleAction(builderState);
+
+  if (!action) {
+    // plain model
+    return true;
+  }
+
+  switch (action.type) {
     case "RETRIEVAL_SEARCH":
-      return isActionRetrievalSearchValid(builderState);
+      return isActionRetrievalSearchValid(action);
     case "RETRIEVAL_EXHAUSTIVE":
-      return isActionRetrievalSearchValid(builderState);
+      return isActionRetrievalExhaustiveValid(action);
     case "PROCESS":
-      return isActionProcessValid(builderState);
+      return isActionProcessValid(action);
     case "DUST_APP_RUN":
-      return isActionDustAppRunValid(builderState);
+      return isActionDustAppRunValid(action);
     case "TABLES_QUERY":
-      return isActionTablesQueryValid(builderState);
+      return isActionTablesQueryValid(action);
     default:
-      assertNever(builderState.actionMode);
+      assertNever(action);
   }
 }
 
@@ -173,9 +186,9 @@ export default function ActionScreen({
   ) => void;
   setEdited: (edited: boolean) => void;
 }) {
-  const getActionType = (actionMode: ActionMode) => {
-    switch (actionMode) {
-      case "GENERIC":
+  const getActionCategory = (actionType: AssistantBuilderActionType | null) => {
+    switch (actionType) {
+      case null:
         return "REPLY_ONLY";
       case "RETRIEVAL_EXHAUSTIVE":
       case "RETRIEVAL_SEARCH":
@@ -185,12 +198,12 @@ export default function ActionScreen({
       case "DUST_APP_RUN":
         return "RUN_DUST_APP";
       default:
-        assertNever(actionMode);
+        assertNever(actionType);
     }
   };
 
-  const getSearchMode = (actionMode: ActionMode) => {
-    switch (actionMode) {
+  const getSearchMode = (actionType: AssistantBuilderActionType | null) => {
+    switch (actionType) {
       case "RETRIEVAL_EXHAUSTIVE":
         return "RETRIEVAL_EXHAUSTIVE";
       case "RETRIEVAL_SEARCH":
@@ -200,20 +213,28 @@ export default function ActionScreen({
       case "PROCESS":
         return "PROCESS";
 
-      case "GENERIC":
+      case null:
       case "DUST_APP_RUN":
         // Unused for non data sources related actions.
         return "RETRIEVAL_SEARCH";
       default:
-        assertNever(actionMode);
+        assertNever(actionType);
     }
   };
 
+  // TODO(@fontanierh): handle multi-actions
+  const action = useDeprecatedDefaultSingleAction(builderState);
+
+  const dataSourceConfigs =
+    action && "dataSourceConfigurations" in action.configuration
+      ? action.configuration.dataSourceConfigurations
+      : {};
   const noDataSources =
-    dataSources.length === 0 &&
-    Object.keys(
-      builderState.retrievalConfiguration?.dataSourceConfigurations || {}
-    ).length === 0;
+    dataSources.length === 0 && Object.keys(dataSourceConfigs).length === 0;
+  const actionCategory = getActionCategory(action?.type ?? null);
+  const actionCategorySpec = ACTION_CATEGORY_SPECIFICATIONS[actionCategory];
+  const searchMode = getSearchMode(action?.type ?? null);
+  const searchModeSpec = SEARCH_MODE_SPECIFICATIONS[searchMode];
 
   return (
     <>
@@ -237,60 +258,68 @@ export default function ActionScreen({
               <Button
                 type="select"
                 labelVisible={true}
-                label={
-                  ACTION_TYPE_SPECIFICATIONS[
-                    getActionType(builderState.actionMode)
-                  ].label
-                }
-                icon={
-                  ACTION_TYPE_SPECIFICATIONS[
-                    getActionType(builderState.actionMode)
-                  ].icon
-                }
+                label={actionCategorySpec.label}
+                icon={actionCategorySpec.icon}
                 variant="primary"
                 hasMagnifying={false}
                 size="sm"
               />
             </DropdownMenu.Button>
             <DropdownMenu.Items origin="topLeft" width={260}>
-              {BASIC_ACTION_TYPES.map((key) => (
-                <DropdownMenu.Item
-                  key={key}
-                  label={ACTION_TYPE_SPECIFICATIONS[key].label}
-                  icon={ACTION_TYPE_SPECIFICATIONS[key].icon}
-                  description={ACTION_TYPE_SPECIFICATIONS[key].description}
-                  onClick={() => {
-                    setEdited(true);
-                    setBuilderState((state) => ({
-                      ...state,
-                      actionMode:
-                        ACTION_TYPE_SPECIFICATIONS[key].defaultActionMode,
-                    }));
-                  }}
-                />
-              ))}
+              {BASIC_ACTION_CATEGORIES.map((key) => {
+                const spec = ACTION_CATEGORY_SPECIFICATIONS[key];
+                const defaultAction = getDefaultActionConfiguration(
+                  spec.defaultActionType
+                );
+                return (
+                  <DropdownMenu.Item
+                    key={key}
+                    label={spec.label}
+                    icon={spec.icon}
+                    description={spec.description}
+                    onClick={() => {
+                      setEdited(true);
+                      setBuilderState((state) => {
+                        const newState: AssistantBuilderState = {
+                          ...state,
+                          actions: removeNulls([defaultAction]),
+                        };
+                        return newState;
+                      });
+                    }}
+                  />
+                );
+              })}
               <DropdownMenu.SectionHeader label="Advanced actions" />
-              {ADVANCED_ACTION_TYPES.map((key) => (
-                <DropdownMenu.Item
-                  key={key}
-                  label={ACTION_TYPE_SPECIFICATIONS[key].label}
-                  icon={ACTION_TYPE_SPECIFICATIONS[key].icon}
-                  description={ACTION_TYPE_SPECIFICATIONS[key].description}
-                  onClick={() => {
-                    setEdited(true);
-                    setBuilderState((state) => ({
-                      ...state,
-                      actionMode:
-                        ACTION_TYPE_SPECIFICATIONS[key].defaultActionMode,
-                    }));
-                  }}
-                />
-              ))}
+              {ADVANCED_ACTION_CATEGORIES.map((key) => {
+                const spec = ACTION_CATEGORY_SPECIFICATIONS[key];
+                const defaultAction = getDefaultActionConfiguration(
+                  spec.defaultActionType
+                );
+                return (
+                  <DropdownMenu.Item
+                    key={key}
+                    label={spec.label}
+                    icon={spec.icon}
+                    description={spec.description}
+                    onClick={() => {
+                      setEdited(true);
+                      setBuilderState((state) => {
+                        const newState: AssistantBuilderState = {
+                          ...state,
+                          actions: removeNulls([defaultAction]),
+                        };
+                        return newState;
+                      });
+                    }}
+                  />
+                );
+              })}
             </DropdownMenu.Items>
           </DropdownMenu>
         </div>
 
-        {getActionType(builderState.actionMode) === "USE_DATA_SOURCES" && (
+        {getActionCategory(action?.type ?? null) === "USE_DATA_SOURCES" && (
           <>
             {noDataSources ? (
               <ContentMessage
@@ -345,16 +374,8 @@ export default function ActionScreen({
                     <Button
                       type="select"
                       labelVisible={true}
-                      label={
-                        SEARCH_MODE_SPECIFICATIONS[
-                          getSearchMode(builderState.actionMode)
-                        ].label
-                      }
-                      icon={
-                        SEARCH_MODE_SPECIFICATIONS[
-                          getSearchMode(builderState.actionMode)
-                        ].icon
-                      }
+                      label={searchModeSpec.label}
+                      icon={searchModeSpec.icon}
                       variant="tertiary"
                       hasMagnifying={false}
                       size="sm"
@@ -364,24 +385,30 @@ export default function ActionScreen({
                     {SEARCH_MODES.filter((key) => {
                       const flag = SEARCH_MODE_SPECIFICATIONS[key].flag;
                       return flag === null || owner.flags.includes(flag);
-                    }).map((key) => (
-                      <DropdownMenu.Item
-                        key={key}
-                        label={SEARCH_MODE_SPECIFICATIONS[key].label}
-                        icon={SEARCH_MODE_SPECIFICATIONS[key].icon}
-                        description={
-                          SEARCH_MODE_SPECIFICATIONS[key].description
-                        }
-                        onClick={() => {
-                          setEdited(true);
-                          setBuilderState((state) => ({
-                            ...state,
-                            actionMode:
-                              SEARCH_MODE_SPECIFICATIONS[key].actionMode,
-                          }));
-                        }}
-                      />
-                    ))}
+                    }).map((key) => {
+                      const spec = SEARCH_MODE_SPECIFICATIONS[key];
+                      const defaultAction = getDefaultActionConfiguration(
+                        spec.actionType
+                      );
+                      return (
+                        <DropdownMenu.Item
+                          key={key}
+                          label={spec.label}
+                          icon={spec.icon}
+                          description={spec.description}
+                          onClick={() => {
+                            setEdited(true);
+                            setBuilderState((state) => {
+                              const newBuilderState: AssistantBuilderState = {
+                                ...state,
+                                actions: removeNulls([defaultAction]),
+                              };
+                              return newBuilderState;
+                            });
+                          }}
+                        />
+                      );
+                    })}
                   </DropdownMenu.Items>
                 </DropdownMenu>
               </div>
@@ -389,14 +416,12 @@ export default function ActionScreen({
           </>
         )}
 
-        <ActionModeSection show={builderState.actionMode === "GENERIC"}>
+        <ActionModeSection show={!action}>
           <div className="pb-16"></div>
         </ActionModeSection>
 
         <ActionModeSection
-          show={
-            builderState.actionMode === "RETRIEVAL_SEARCH" && !noDataSources
-          }
+          show={action?.type === "RETRIEVAL_SEARCH" && !noDataSources}
         >
           <ActionRetrievalSearch
             owner={owner}
@@ -408,9 +433,7 @@ export default function ActionScreen({
         </ActionModeSection>
 
         <ActionModeSection
-          show={
-            builderState.actionMode === "RETRIEVAL_EXHAUSTIVE" && !noDataSources
-          }
+          show={action?.type === "RETRIEVAL_EXHAUSTIVE" && !noDataSources}
         >
           <ActionRetrievalExhaustive
             owner={owner}
@@ -421,9 +444,7 @@ export default function ActionScreen({
           />
         </ActionModeSection>
 
-        <ActionModeSection
-          show={builderState.actionMode === "PROCESS" && !noDataSources}
-        >
+        <ActionModeSection show={action?.type === "PROCESS" && !noDataSources}>
           <ActionProcess
             owner={owner}
             builderState={builderState}
@@ -434,7 +455,7 @@ export default function ActionScreen({
         </ActionModeSection>
 
         <ActionModeSection
-          show={builderState.actionMode === "TABLES_QUERY" && !noDataSources}
+          show={action?.type === "TABLES_QUERY" && !noDataSources}
         >
           <ActionTablesQuery
             owner={owner}
@@ -445,7 +466,7 @@ export default function ActionScreen({
           />
         </ActionModeSection>
 
-        <ActionModeSection show={builderState.actionMode === "DUST_APP_RUN"}>
+        <ActionModeSection show={action?.type === "DUST_APP_RUN"}>
           <ActionDustAppRun
             owner={owner}
             builderState={builderState}

--- a/front/components/assistant_builder/ActionScreen.tsx
+++ b/front/components/assistant_builder/ActionScreen.tsx
@@ -223,7 +223,7 @@ export default function ActionScreen({
   };
 
   // TODO(@fontanierh): handle multi-actions
-  const action = useDeprecatedDefaultSingleAction(builderState);
+  const action = useDeprecatedDefaultSingleAction(builderState) ?? null;
 
   const dataSourceConfigs =
     action && "dataSourceConfigurations" in action.configuration
@@ -425,7 +425,7 @@ export default function ActionScreen({
         >
           <ActionRetrievalSearch
             owner={owner}
-            builderState={builderState}
+            action={action}
             dataSources={dataSources}
             setBuilderState={setBuilderState}
             setEdited={setEdited}
@@ -437,7 +437,7 @@ export default function ActionScreen({
         >
           <ActionRetrievalExhaustive
             owner={owner}
-            builderState={builderState}
+            action={action}
             dataSources={dataSources}
             setBuilderState={setBuilderState}
             setEdited={setEdited}
@@ -447,7 +447,7 @@ export default function ActionScreen({
         <ActionModeSection show={action?.type === "PROCESS" && !noDataSources}>
           <ActionProcess
             owner={owner}
-            builderState={builderState}
+            action={action}
             dataSources={dataSources}
             setBuilderState={setBuilderState}
             setEdited={setEdited}
@@ -459,7 +459,7 @@ export default function ActionScreen({
         >
           <ActionTablesQuery
             owner={owner}
-            builderState={builderState}
+            action={action}
             dataSources={dataSources}
             setBuilderState={setBuilderState}
             setEdited={setEdited}
@@ -469,7 +469,7 @@ export default function ActionScreen({
         <ActionModeSection show={action?.type === "DUST_APP_RUN"}>
           <ActionDustAppRun
             owner={owner}
-            builderState={builderState}
+            action={action}
             dustApps={dustApps}
             setBuilderState={setBuilderState}
             setEdited={setEdited}

--- a/front/components/assistant_builder/actions/DustAppRunAction.tsx
+++ b/front/components/assistant_builder/actions/DustAppRunAction.tsx
@@ -10,7 +10,6 @@ import type {
   AssistantBuilderState,
 } from "@app/components/assistant_builder/types";
 import { getDefaultDustAppRunActionConfiguration } from "@app/components/assistant_builder/types";
-import { useDeprecatedDefaultSingleAction } from "@app/lib/client/assistant_builder/deprecated_single_action";
 
 export function isActionDustAppRunValid(
   action: AssistantBuilderActionConfiguration
@@ -20,13 +19,13 @@ export function isActionDustAppRunValid(
 
 export function ActionDustAppRun({
   owner,
-  builderState,
+  action,
   setBuilderState,
   setEdited,
   dustApps,
 }: {
   owner: WorkspaceType;
-  builderState: AssistantBuilderState;
+  action: AssistantBuilderActionConfiguration | null;
   setBuilderState: (
     stateFn: (state: AssistantBuilderState) => AssistantBuilderState
   ) => void;
@@ -34,7 +33,6 @@ export function ActionDustAppRun({
   dustApps: AppType[];
 }) {
   const [showDustAppsModal, setShowDustAppsModal] = useState(false);
-  const action = useDeprecatedDefaultSingleAction(builderState);
 
   const deleteDustApp = () => {
     setEdited(true);

--- a/front/components/assistant_builder/actions/DustAppRunAction.tsx
+++ b/front/components/assistant_builder/actions/DustAppRunAction.tsx
@@ -37,7 +37,15 @@ export function ActionDustAppRun({
   const deleteDustApp = () => {
     setEdited(true);
     setBuilderState((state) => {
-      return { ...state, dustAppConfiguration: { app: null } };
+      const action = state.actions[0];
+      if (!action || action.type !== "DUST_APP_RUN") {
+        return state;
+      }
+      action.configuration.app = null;
+      return {
+        ...state,
+        actions: [action],
+      };
     });
   };
 
@@ -57,12 +65,17 @@ export function ActionDustAppRun({
         dustApps={dustApps}
         onSave={({ app }) => {
           setEdited(true);
-          setBuilderState((state) => ({
-            ...state,
-            dustAppConfiguration: {
-              app,
-            },
-          }));
+          setBuilderState((state) => {
+            const action = state.actions[0];
+            if (!action || action.type !== "DUST_APP_RUN") {
+              return state;
+            }
+            action.configuration.app = app;
+            return {
+              ...state,
+              actions: [action],
+            };
+          });
         }}
       />
 

--- a/front/components/assistant_builder/actions/DustAppRunAction.tsx
+++ b/front/components/assistant_builder/actions/DustAppRunAction.tsx
@@ -5,10 +5,17 @@ import { useState } from "react";
 
 import AssistantBuilderDustAppModal from "@app/components/assistant_builder/AssistantBuilderDustAppModal";
 import DustAppSelectionSection from "@app/components/assistant_builder/DustAppSelectionSection";
-import type { AssistantBuilderState } from "@app/components/assistant_builder/types";
+import type {
+  AssistantBuilderActionConfiguration,
+  AssistantBuilderState,
+} from "@app/components/assistant_builder/types";
+import { getDefaultDustAppRunActionConfiguration } from "@app/components/assistant_builder/types";
+import { useDeprecatedDefaultSingleAction } from "@app/lib/client/assistant_builder/deprecated_single_action";
 
-export function isActionDustAppRunValid(builderState: AssistantBuilderState) {
-  return !!builderState.dustAppConfiguration.app;
+export function isActionDustAppRunValid(
+  action: AssistantBuilderActionConfiguration
+) {
+  return action.type === "DUST_APP_RUN" && !!action.configuration.app;
 }
 
 export function ActionDustAppRun({
@@ -27,6 +34,7 @@ export function ActionDustAppRun({
   dustApps: AppType[];
 }) {
   const [showDustAppsModal, setShowDustAppsModal] = useState(false);
+  const action = useDeprecatedDefaultSingleAction(builderState);
 
   const deleteDustApp = () => {
     setEdited(true);
@@ -108,8 +116,13 @@ export function ActionDustAppRun({
             application's input block dataset schema.
           </div>
           <DustAppSelectionSection
-            show={builderState.actionMode === "DUST_APP_RUN"}
-            dustAppConfiguration={builderState.dustAppConfiguration}
+            show={!!action && action.type === "DUST_APP_RUN"}
+            dustAppConfiguration={
+              (!!action &&
+                action.type === "DUST_APP_RUN" &&
+                action.configuration) ||
+              getDefaultDustAppRunActionConfiguration().configuration
+            }
             openDustAppModal={() => {
               setShowDustAppsModal(true);
             }}

--- a/front/components/assistant_builder/actions/DustAppRunAction.tsx
+++ b/front/components/assistant_builder/actions/DustAppRunAction.tsx
@@ -7,9 +7,9 @@ import AssistantBuilderDustAppModal from "@app/components/assistant_builder/Assi
 import DustAppSelectionSection from "@app/components/assistant_builder/DustAppSelectionSection";
 import type {
   AssistantBuilderActionConfiguration,
+  AssistantBuilderDustAppConfiguration,
   AssistantBuilderState,
 } from "@app/components/assistant_builder/types";
-import { getDefaultDustAppRunActionConfiguration } from "@app/components/assistant_builder/types";
 
 export function isActionDustAppRunValid(
   action: AssistantBuilderActionConfiguration
@@ -19,13 +19,13 @@ export function isActionDustAppRunValid(
 
 export function ActionDustAppRun({
   owner,
-  action,
+  actionConfigration,
   setBuilderState,
   setEdited,
   dustApps,
 }: {
   owner: WorkspaceType;
-  action: AssistantBuilderActionConfiguration | null;
+  actionConfigration: AssistantBuilderDustAppConfiguration | null;
   setBuilderState: (
     stateFn: (state: AssistantBuilderState) => AssistantBuilderState
   ) => void;
@@ -42,6 +42,10 @@ export function ActionDustAppRun({
   };
 
   const noDustApp = dustApps.length === 0;
+
+  if (!actionConfigration) {
+    return null;
+  }
 
   return (
     <>
@@ -114,13 +118,8 @@ export function ActionDustAppRun({
             application's input block dataset schema.
           </div>
           <DustAppSelectionSection
-            show={!!action && action.type === "DUST_APP_RUN"}
-            dustAppConfiguration={
-              (!!action &&
-                action.type === "DUST_APP_RUN" &&
-                action.configuration) ||
-              getDefaultDustAppRunActionConfiguration().configuration
-            }
+            show={true}
+            dustAppConfiguration={actionConfigration}
             openDustAppModal={() => {
               setShowDustAppsModal(true);
             }}

--- a/front/components/assistant_builder/actions/ProcessAction.tsx
+++ b/front/components/assistant_builder/actions/ProcessAction.tsx
@@ -24,7 +24,6 @@ import type {
   AssistantBuilderActionConfiguration,
   AssistantBuilderState,
 } from "@app/components/assistant_builder/types";
-import { useDeprecatedDefaultSingleAction } from "@app/lib/client/assistant_builder/deprecated_single_action";
 import { classNames } from "@app/lib/utils";
 
 export function isActionProcessValid(
@@ -220,13 +219,13 @@ function PropertiesFields({
 
 export function ActionProcess({
   owner,
-  builderState,
+  action,
   setBuilderState,
   setEdited,
   dataSources,
 }: {
   owner: WorkspaceType;
-  builderState: AssistantBuilderState;
+  action: AssistantBuilderActionConfiguration | null;
   setBuilderState: (
     stateFn: (state: AssistantBuilderState) => AssistantBuilderState
   ) => void;
@@ -236,7 +235,6 @@ export function ActionProcess({
   const [showDataSourcesModal, setShowDataSourcesModal] = useState(false);
   const [timeFrameError, setTimeFrameError] = useState<string | null>(null);
 
-  const action = useDeprecatedDefaultSingleAction(builderState);
   if (!action || action.type !== "PROCESS") {
     return null;
   }

--- a/front/components/assistant_builder/actions/ProcessAction.tsx
+++ b/front/components/assistant_builder/actions/ProcessAction.tsx
@@ -20,14 +20,23 @@ import React, { useEffect, useState } from "react";
 import AssistantBuilderDataSourceModal from "@app/components/assistant_builder/AssistantBuilderDataSourceModal";
 import DataSourceSelectionSection from "@app/components/assistant_builder/DataSourceSelectionSection";
 import { TIME_FRAME_UNIT_TO_LABEL } from "@app/components/assistant_builder/shared";
-import type { AssistantBuilderState } from "@app/components/assistant_builder/types";
+import type {
+  AssistantBuilderActionConfiguration,
+  AssistantBuilderState,
+} from "@app/components/assistant_builder/types";
+import { useDeprecatedDefaultSingleAction } from "@app/lib/client/assistant_builder/deprecated_single_action";
 import { classNames } from "@app/lib/utils";
 
-export function isActionProcessValid(builderState: AssistantBuilderState) {
-  if (builderState.processConfiguration.schema.length === 0) {
+export function isActionProcessValid(
+  action: AssistantBuilderActionConfiguration
+) {
+  if (action.type !== "PROCESS") {
     return false;
   }
-  for (const prop of builderState.processConfiguration.schema) {
+  if (action.configuration.schema.length === 0) {
+    return false;
+  }
+  for (const prop of action.configuration.schema) {
     if (!prop.name) {
       return false;
     }
@@ -35,16 +44,15 @@ export function isActionProcessValid(builderState: AssistantBuilderState) {
       return false;
     }
     if (
-      builderState.processConfiguration.schema.filter(
-        (p) => p.name === prop.name
-      ).length > 1
+      action.configuration.schema.filter((p) => p.name === prop.name).length > 1
     ) {
       return false;
     }
   }
   return (
-    Object.keys(builderState.processConfiguration.dataSourceConfigurations)
-      .length > 0 && !!builderState.processConfiguration.timeFrame.value
+    action.type === "PROCESS" &&
+    Object.keys(action.configuration.dataSourceConfigurations).length > 0 &&
+    !!action.configuration.timeFrame.value
   );
 }
 
@@ -228,32 +236,43 @@ export function ActionProcess({
   const [showDataSourcesModal, setShowDataSourcesModal] = useState(false);
   const [timeFrameError, setTimeFrameError] = useState<string | null>(null);
 
+  const action = useDeprecatedDefaultSingleAction(builderState);
+  if (!action || action.type !== "PROCESS") {
+    return null;
+  }
+
   useEffect(() => {
-    if (!builderState.processConfiguration.timeFrame.value) {
+    if (!action.configuration.timeFrame.value) {
       setTimeFrameError("Timeframe must be a number");
     } else {
       setTimeFrameError(null);
     }
-  }, [
-    builderState.processConfiguration.dataSourceConfigurations,
-    builderState.processConfiguration.timeFrame.value,
-  ]);
+  }, [action.configuration.timeFrame.value]);
 
   const deleteDataSource = (name: string) => {
-    if (builderState.processConfiguration.dataSourceConfigurations[name]) {
+    if (action.configuration.dataSourceConfigurations[name]) {
       setEdited(true);
     }
 
-    setBuilderState(({ processConfiguration, ...rest }) => {
+    setBuilderState(({ actions, ...rest }) => {
+      const action = actions[0];
+      if (!action || action.type !== "PROCESS") {
+        return { actions, ...rest };
+      }
       const dataSourceConfigurations = {
-        ...processConfiguration.dataSourceConfigurations,
+        ...action.configuration.dataSourceConfigurations,
       };
       delete dataSourceConfigurations[name];
       return {
-        processConfiguration: {
-          ...processConfiguration,
-          dataSourceConfigurations,
-        },
+        actions: [
+          {
+            ...action,
+            configuration: {
+              ...action.configuration,
+              dataSourceConfigurations,
+            },
+          },
+        ],
         ...rest,
       };
     });
@@ -270,25 +289,35 @@ export function ActionProcess({
         dataSources={dataSources}
         onSave={({ dataSource, selectedResources, isSelectAll }) => {
           setEdited(true);
-          setBuilderState((state) => ({
-            ...state,
-            processConfiguration: {
-              ...state.processConfiguration,
-              dataSourceConfigurations: {
-                ...state.processConfiguration.dataSourceConfigurations,
-                [dataSource.name]: {
-                  dataSource,
-                  selectedResources,
-                  isSelectAll,
+          setBuilderState((state) => {
+            const action = state.actions[0];
+            if (!action || action.type !== "PROCESS") {
+              return state;
+            }
+            const dataSourceConfigurations = {
+              ...action.configuration.dataSourceConfigurations,
+            };
+            dataSourceConfigurations[dataSource.name] = {
+              dataSource,
+              selectedResources,
+              isSelectAll,
+            };
+            return {
+              ...state,
+              actions: [
+                {
+                  ...action,
+                  configuration: {
+                    ...action.configuration,
+                    dataSourceConfigurations,
+                  },
                 },
-              },
-            },
-          }));
+              ],
+            };
+          });
         }}
         onDelete={deleteDataSource}
-        dataSourceConfigurations={
-          builderState.processConfiguration.dataSourceConfigurations
-        }
+        dataSourceConfigurations={action.configuration.dataSourceConfigurations}
       />
 
       <div className="text-sm text-element-700">
@@ -309,9 +338,7 @@ export function ActionProcess({
 
       <DataSourceSelectionSection
         owner={owner}
-        dataSourceConfigurations={
-          builderState.processConfiguration.dataSourceConfigurations
-        }
+        dataSourceConfigurations={action.configuration.dataSourceConfigurations}
         openDataSourceModal={() => {
           setShowDataSourcesModal(true);
         }}
@@ -332,21 +359,22 @@ export function ActionProcess({
               : "border-red-500 focus:border-red-500 focus:ring-red-500",
             "bg-structure-50 stroke-structure-50"
           )}
-          value={builderState.processConfiguration.timeFrame.value || ""}
+          value={action.configuration.timeFrame.value || ""}
           onChange={(e) => {
             const value = parseInt(e.target.value, 10);
             if (!isNaN(value) || !e.target.value) {
               setEdited(true);
-              setBuilderState((state) => ({
-                ...state,
-                processConfiguration: {
-                  ...state.processConfiguration,
-                  timeFrame: {
-                    value,
-                    unit: builderState.processConfiguration.timeFrame.unit,
-                  },
-                },
-              }));
+              setBuilderState((state) => {
+                const action = state.actions[0];
+                if (!action || action.type !== "PROCESS") {
+                  return state;
+                }
+                action.configuration.timeFrame.value = value;
+                return {
+                  ...state,
+                  actions: [action],
+                };
+              });
             }
           }}
         />
@@ -356,9 +384,7 @@ export function ActionProcess({
               type="select"
               labelVisible={true}
               label={
-                TIME_FRAME_UNIT_TO_LABEL[
-                  builderState.processConfiguration.timeFrame.unit
-                ]
+                TIME_FRAME_UNIT_TO_LABEL[action.configuration.timeFrame.unit]
               }
               variant="secondary"
               size="sm"
@@ -371,17 +397,17 @@ export function ActionProcess({
                 label={value}
                 onClick={() => {
                   setEdited(true);
-                  setBuilderState((state) => ({
-                    ...state,
-                    processConfiguration: {
-                      ...state.processConfiguration,
-                      timeFrame: {
-                        value:
-                          builderState.processConfiguration.timeFrame.value,
-                        unit: key as TimeframeUnit,
-                      },
-                    },
-                  }));
+                  setBuilderState((state) => {
+                    const action = state.actions[0];
+                    if (!action || action.type !== "PROCESS") {
+                      return state;
+                    }
+                    action.configuration.timeFrame.unit = key as TimeframeUnit;
+                    return {
+                      ...state,
+                      actions: [action],
+                    };
+                  });
                 }}
               />
             ))}
@@ -410,28 +436,36 @@ export function ActionProcess({
                     description: "Required data to follow instructions",
                   },
                 ];
-                setBuilderState((state) => ({
-                  ...state,
-                  processConfiguration: {
-                    ...state.processConfiguration,
-                    schema,
-                  },
-                }));
+                setBuilderState((state) => {
+                  const action = state.actions[0];
+                  if (!action || action.type !== "PROCESS") {
+                    return state;
+                  }
+                  action.configuration.schema = schema;
+                  return {
+                    ...state,
+                    actions: [action],
+                  };
+                });
               }}
             />
           </Tooltip>
         </div>
       </div>
       <PropertiesFields
-        properties={builderState.processConfiguration.schema}
+        properties={action.configuration.schema}
         onSetProperties={(schema: ProcessSchemaPropertyType[]) => {
-          setBuilderState((state) => ({
-            ...state,
-            processConfiguration: {
-              ...state.processConfiguration,
-              schema,
-            },
-          }));
+          setBuilderState((state) => {
+            const action = state.actions[0];
+            if (!action || action.type !== "PROCESS") {
+              return state;
+            }
+            action.configuration.schema = schema;
+            return {
+              ...state,
+              actions: [action],
+            };
+          });
           setEdited(true);
         }}
         readOnly={false}

--- a/front/components/assistant_builder/actions/ProcessAction.tsx
+++ b/front/components/assistant_builder/actions/ProcessAction.tsx
@@ -22,6 +22,7 @@ import DataSourceSelectionSection from "@app/components/assistant_builder/DataSo
 import { TIME_FRAME_UNIT_TO_LABEL } from "@app/components/assistant_builder/shared";
 import type {
   AssistantBuilderActionConfiguration,
+  AssistantBuilderProcessConfiguration,
   AssistantBuilderState,
 } from "@app/components/assistant_builder/types";
 import { classNames } from "@app/lib/utils";
@@ -219,13 +220,13 @@ function PropertiesFields({
 
 export function ActionProcess({
   owner,
-  action,
+  actionConfiguration,
   setBuilderState,
   setEdited,
   dataSources,
 }: {
   owner: WorkspaceType;
-  action: AssistantBuilderActionConfiguration | null;
+  actionConfiguration: AssistantBuilderProcessConfiguration | null;
   setBuilderState: (
     stateFn: (state: AssistantBuilderState) => AssistantBuilderState
   ) => void;
@@ -235,20 +236,20 @@ export function ActionProcess({
   const [showDataSourcesModal, setShowDataSourcesModal] = useState(false);
   const [timeFrameError, setTimeFrameError] = useState<string | null>(null);
 
-  if (!action || action.type !== "PROCESS") {
+  if (!actionConfiguration) {
     return null;
   }
 
   useEffect(() => {
-    if (!action.configuration.timeFrame.value) {
+    if (!actionConfiguration.timeFrame.value) {
       setTimeFrameError("Timeframe must be a number");
     } else {
       setTimeFrameError(null);
     }
-  }, [action.configuration.timeFrame.value]);
+  }, [actionConfiguration.timeFrame.value]);
 
   const deleteDataSource = (name: string) => {
-    if (action.configuration.dataSourceConfigurations[name]) {
+    if (actionConfiguration.dataSourceConfigurations[name]) {
       setEdited(true);
     }
 
@@ -258,7 +259,7 @@ export function ActionProcess({
         return { actions, ...rest };
       }
       const dataSourceConfigurations = {
-        ...action.configuration.dataSourceConfigurations,
+        ...actionConfiguration.dataSourceConfigurations,
       };
       delete dataSourceConfigurations[name];
       return {
@@ -266,7 +267,7 @@ export function ActionProcess({
           {
             ...action,
             configuration: {
-              ...action.configuration,
+              ...actionConfiguration,
               dataSourceConfigurations,
             },
           },
@@ -293,7 +294,7 @@ export function ActionProcess({
               return state;
             }
             const dataSourceConfigurations = {
-              ...action.configuration.dataSourceConfigurations,
+              ...actionConfiguration.dataSourceConfigurations,
             };
             dataSourceConfigurations[dataSource.name] = {
               dataSource,
@@ -306,7 +307,7 @@ export function ActionProcess({
                 {
                   ...action,
                   configuration: {
-                    ...action.configuration,
+                    ...actionConfiguration,
                     dataSourceConfigurations,
                   },
                 },
@@ -315,7 +316,7 @@ export function ActionProcess({
           });
         }}
         onDelete={deleteDataSource}
-        dataSourceConfigurations={action.configuration.dataSourceConfigurations}
+        dataSourceConfigurations={actionConfiguration.dataSourceConfigurations}
       />
 
       <div className="text-sm text-element-700">
@@ -336,7 +337,7 @@ export function ActionProcess({
 
       <DataSourceSelectionSection
         owner={owner}
-        dataSourceConfigurations={action.configuration.dataSourceConfigurations}
+        dataSourceConfigurations={actionConfiguration.dataSourceConfigurations}
         openDataSourceModal={() => {
           setShowDataSourcesModal(true);
         }}
@@ -357,7 +358,7 @@ export function ActionProcess({
               : "border-red-500 focus:border-red-500 focus:ring-red-500",
             "bg-structure-50 stroke-structure-50"
           )}
-          value={action.configuration.timeFrame.value || ""}
+          value={actionConfiguration.timeFrame.value || ""}
           onChange={(e) => {
             const value = parseInt(e.target.value, 10);
             if (!isNaN(value) || !e.target.value) {
@@ -367,7 +368,7 @@ export function ActionProcess({
                 if (!action || action.type !== "PROCESS") {
                   return state;
                 }
-                action.configuration.timeFrame.value = value;
+                actionConfiguration.timeFrame.value = value;
                 return {
                   ...state,
                   actions: [action],
@@ -382,7 +383,7 @@ export function ActionProcess({
               type="select"
               labelVisible={true}
               label={
-                TIME_FRAME_UNIT_TO_LABEL[action.configuration.timeFrame.unit]
+                TIME_FRAME_UNIT_TO_LABEL[actionConfiguration.timeFrame.unit]
               }
               variant="secondary"
               size="sm"
@@ -400,7 +401,7 @@ export function ActionProcess({
                     if (!action || action.type !== "PROCESS") {
                       return state;
                     }
-                    action.configuration.timeFrame.unit = key as TimeframeUnit;
+                    actionConfiguration.timeFrame.unit = key as TimeframeUnit;
                     return {
                       ...state,
                       actions: [action],
@@ -439,7 +440,7 @@ export function ActionProcess({
                   if (!action || action.type !== "PROCESS") {
                     return state;
                   }
-                  action.configuration.schema = schema;
+                  actionConfiguration.schema = schema;
                   return {
                     ...state,
                     actions: [action],
@@ -451,14 +452,14 @@ export function ActionProcess({
         </div>
       </div>
       <PropertiesFields
-        properties={action.configuration.schema}
+        properties={actionConfiguration.schema}
         onSetProperties={(schema: ProcessSchemaPropertyType[]) => {
           setBuilderState((state) => {
             const action = state.actions[0];
             if (!action || action.type !== "PROCESS") {
               return state;
             }
-            action.configuration.schema = schema;
+            actionConfiguration.schema = schema;
             return {
               ...state,
               actions: [action],

--- a/front/components/assistant_builder/actions/RetrievalAction.tsx
+++ b/front/components/assistant_builder/actions/RetrievalAction.tsx
@@ -8,6 +8,7 @@ import DataSourceSelectionSection from "@app/components/assistant_builder/DataSo
 import { TIME_FRAME_UNIT_TO_LABEL } from "@app/components/assistant_builder/shared";
 import type {
   AssistantBuilderActionConfiguration,
+  AssistantBuilderRetrievalConfiguration,
   AssistantBuilderState,
 } from "@app/components/assistant_builder/types";
 import { classNames } from "@app/lib/utils";
@@ -55,13 +56,13 @@ export function isActionRetrievalSearchValid(
 
 export function ActionRetrievalSearch({
   owner,
-  action,
+  actionConfiguration,
   setBuilderState,
   setEdited,
   dataSources,
 }: {
   owner: WorkspaceType;
-  action: AssistantBuilderActionConfiguration | null;
+  actionConfiguration: AssistantBuilderRetrievalConfiguration | null;
   setBuilderState: (
     stateFn: (state: AssistantBuilderState) => AssistantBuilderState
   ) => void;
@@ -70,7 +71,7 @@ export function ActionRetrievalSearch({
 }) {
   const [showDataSourcesModal, setShowDataSourcesModal] = useState(false);
 
-  if (!action || action.type !== "RETRIEVAL_SEARCH") {
+  if (!actionConfiguration) {
     return null;
   }
 
@@ -104,12 +105,12 @@ export function ActionRetrievalSearch({
         onDelete={(name) => {
           deleteDataSource({ name, setBuilderState, setEdited });
         }}
-        dataSourceConfigurations={action.configuration.dataSourceConfigurations}
+        dataSourceConfigurations={actionConfiguration.dataSourceConfigurations}
       />
 
       <DataSourceSelectionSection
         owner={owner}
-        dataSourceConfigurations={action.configuration.dataSourceConfigurations}
+        dataSourceConfigurations={actionConfiguration.dataSourceConfigurations}
         openDataSourceModal={() => {
           setShowDataSourcesModal(true);
         }}
@@ -134,13 +135,13 @@ export function isActionRetrievalExhaustiveValid(
 
 export function ActionRetrievalExhaustive({
   owner,
-  action,
+  actionConfiguration,
   setBuilderState,
   setEdited,
   dataSources,
 }: {
   owner: WorkspaceType;
-  action: AssistantBuilderActionConfiguration | null;
+  actionConfiguration: AssistantBuilderRetrievalConfiguration | null;
   setBuilderState: (
     stateFn: (state: AssistantBuilderState) => AssistantBuilderState
   ) => void;
@@ -150,20 +151,17 @@ export function ActionRetrievalExhaustive({
   const [showDataSourcesModal, setShowDataSourcesModal] = useState(false);
   const [timeFrameError, setTimeFrameError] = useState<string | null>(null);
 
-  if (!action || action.type !== "RETRIEVAL_EXHAUSTIVE") {
+  if (!actionConfiguration) {
     return null;
   }
 
   useEffect(() => {
-    if (!action.configuration.timeFrame.value) {
+    if (!actionConfiguration.timeFrame.value) {
       setTimeFrameError("Timeframe must be a number");
     } else {
       setTimeFrameError(null);
     }
-  }, [
-    action.configuration.dataSourceConfigurations,
-    action.configuration.timeFrame.value,
-  ]);
+  }, [actionConfiguration.timeFrame.value, actionConfiguration.timeFrame.unit]);
 
   return (
     <>
@@ -195,12 +193,12 @@ export function ActionRetrievalExhaustive({
         onDelete={(name) => {
           deleteDataSource({ name, setBuilderState, setEdited });
         }}
-        dataSourceConfigurations={action.configuration.dataSourceConfigurations}
+        dataSourceConfigurations={actionConfiguration.dataSourceConfigurations}
       />
 
       <DataSourceSelectionSection
         owner={owner}
-        dataSourceConfigurations={action.configuration.dataSourceConfigurations}
+        dataSourceConfigurations={actionConfiguration.dataSourceConfigurations}
         openDataSourceModal={() => {
           setShowDataSourcesModal(true);
         }}
@@ -222,7 +220,7 @@ export function ActionRetrievalExhaustive({
               : "border-red-500 focus:border-red-500 focus:ring-red-500",
             "bg-structure-50 stroke-structure-50"
           )}
-          value={action.configuration.timeFrame.value || ""}
+          value={actionConfiguration.timeFrame.value || ""}
           onChange={(e) => {
             const value = parseInt(e.target.value, 10);
             if (!isNaN(value) || !e.target.value) {
@@ -259,7 +257,7 @@ export function ActionRetrievalExhaustive({
               type="select"
               labelVisible={true}
               label={
-                TIME_FRAME_UNIT_TO_LABEL[action.configuration.timeFrame.unit]
+                TIME_FRAME_UNIT_TO_LABEL[actionConfiguration.timeFrame.unit]
               }
               variant="secondary"
               size="sm"

--- a/front/components/assistant_builder/actions/RetrievalAction.tsx
+++ b/front/components/assistant_builder/actions/RetrievalAction.tsx
@@ -10,7 +10,6 @@ import type {
   AssistantBuilderActionConfiguration,
   AssistantBuilderState,
 } from "@app/components/assistant_builder/types";
-import { useDeprecatedDefaultSingleAction } from "@app/lib/client/assistant_builder/deprecated_single_action";
 import { classNames } from "@app/lib/utils";
 
 const deleteDataSource = ({
@@ -56,13 +55,13 @@ export function isActionRetrievalSearchValid(
 
 export function ActionRetrievalSearch({
   owner,
-  builderState,
+  action,
   setBuilderState,
   setEdited,
   dataSources,
 }: {
   owner: WorkspaceType;
-  builderState: AssistantBuilderState;
+  action: AssistantBuilderActionConfiguration | null;
   setBuilderState: (
     stateFn: (state: AssistantBuilderState) => AssistantBuilderState
   ) => void;
@@ -70,7 +69,7 @@ export function ActionRetrievalSearch({
   dataSources: DataSourceType[];
 }) {
   const [showDataSourcesModal, setShowDataSourcesModal] = useState(false);
-  const action = useDeprecatedDefaultSingleAction(builderState);
+
   if (!action || action.type !== "RETRIEVAL_SEARCH") {
     return null;
   }
@@ -135,13 +134,13 @@ export function isActionRetrievalExhaustiveValid(
 
 export function ActionRetrievalExhaustive({
   owner,
-  builderState,
+  action,
   setBuilderState,
   setEdited,
   dataSources,
 }: {
   owner: WorkspaceType;
-  builderState: AssistantBuilderState;
+  action: AssistantBuilderActionConfiguration | null;
   setBuilderState: (
     stateFn: (state: AssistantBuilderState) => AssistantBuilderState
   ) => void;
@@ -151,7 +150,6 @@ export function ActionRetrievalExhaustive({
   const [showDataSourcesModal, setShowDataSourcesModal] = useState(false);
   const [timeFrameError, setTimeFrameError] = useState<string | null>(null);
 
-  const action = useDeprecatedDefaultSingleAction(builderState);
   if (!action || action.type !== "RETRIEVAL_EXHAUSTIVE") {
     return null;
   }

--- a/front/components/assistant_builder/actions/TablesQueryAction.tsx
+++ b/front/components/assistant_builder/actions/TablesQueryAction.tsx
@@ -10,7 +10,6 @@ import type {
   AssistantBuilderTableConfiguration,
 } from "@app/components/assistant_builder/types";
 import { getDefaultTablesQueryActionConfiguration } from "@app/components/assistant_builder/types";
-import { useDeprecatedDefaultSingleAction } from "@app/lib/client/assistant_builder/deprecated_single_action";
 import { tableKey } from "@app/lib/client/tables_query";
 
 export function isActionTablesQueryValid(
@@ -24,13 +23,13 @@ export function isActionTablesQueryValid(
 
 export function ActionTablesQuery({
   owner,
-  builderState,
+  action,
   setBuilderState,
   setEdited,
   dataSources,
 }: {
   owner: WorkspaceType;
-  builderState: AssistantBuilderState;
+  action: AssistantBuilderActionConfiguration | null;
   setBuilderState: (
     stateFn: (state: AssistantBuilderState) => AssistantBuilderState
   ) => void;
@@ -38,7 +37,6 @@ export function ActionTablesQuery({
   dataSources: DataSourceType[];
 }) {
   const [showTableModal, setShowTableModal] = useState(false);
-  const action = useDeprecatedDefaultSingleAction(builderState);
 
   return (
     <>

--- a/front/components/assistant_builder/actions/TablesQueryAction.tsx
+++ b/front/components/assistant_builder/actions/TablesQueryAction.tsx
@@ -8,8 +8,8 @@ import type {
   AssistantBuilderActionConfiguration,
   AssistantBuilderState,
   AssistantBuilderTableConfiguration,
+  AssistantBuilderTablesQueryConfiguration,
 } from "@app/components/assistant_builder/types";
-import { getDefaultTablesQueryActionConfiguration } from "@app/components/assistant_builder/types";
 import { tableKey } from "@app/lib/client/tables_query";
 
 export function isActionTablesQueryValid(
@@ -23,13 +23,13 @@ export function isActionTablesQueryValid(
 
 export function ActionTablesQuery({
   owner,
-  action,
+  actionConfiguration,
   setBuilderState,
   setEdited,
   dataSources,
 }: {
   owner: WorkspaceType;
-  action: AssistantBuilderActionConfiguration | null;
+  actionConfiguration: AssistantBuilderTablesQueryConfiguration | null;
   setBuilderState: (
     stateFn: (state: AssistantBuilderState) => AssistantBuilderState
   ) => void;
@@ -37,6 +37,10 @@ export function ActionTablesQuery({
   dataSources: DataSourceType[];
 }) {
   const [showTableModal, setShowTableModal] = useState(false);
+
+  if (!actionConfiguration) {
+    return null;
+  }
 
   return (
     <>
@@ -67,11 +71,7 @@ export function ActionTablesQuery({
             };
           });
         }}
-        tablesQueryConfiguration={
-          action && action.type === "TABLES_QUERY"
-            ? action.configuration
-            : getDefaultTablesQueryActionConfiguration().configuration
-        }
+        tablesQueryConfiguration={actionConfiguration}
       />
 
       <div className="text-sm text-element-700">
@@ -93,12 +93,8 @@ export function ActionTablesQuery({
       </div>
 
       <TablesSelectionSection
-        show={action?.type === "TABLES_QUERY"}
-        tablesQueryConfiguration={
-          action?.type === "TABLES_QUERY"
-            ? action.configuration
-            : getDefaultTablesQueryActionConfiguration().configuration
-        }
+        show={true}
+        tablesQueryConfiguration={actionConfiguration}
         openTableModal={() => {
           setShowTableModal(true);
         }}

--- a/front/components/assistant_builder/server_side_props_helpers.ts
+++ b/front/components/assistant_builder/server_side_props_helpers.ts
@@ -104,7 +104,6 @@ export async function buildInitialActions({
 
   const action = deprecatedGetFirstActionConfiguration(configuration);
 
-  // Retrieval configuration
   if (!action) {
     return [];
   } else if (isRetrievalConfiguration(action)) {

--- a/front/components/assistant_builder/server_side_props_helpers.ts
+++ b/front/components/assistant_builder/server_side_props_helpers.ts
@@ -8,6 +8,7 @@ import type {
   TemplateAgentConfigurationType,
 } from "@dust-tt/types";
 import {
+  assertNever,
   ConnectorsAPI,
   CoreAPI,
   isDustAppRunConfiguration,
@@ -17,15 +18,22 @@ import {
 } from "@dust-tt/types";
 
 import type {
+  AssistantBuilderActionConfiguration,
   AssistantBuilderDataSourceConfiguration,
-  AssistantBuilderInitialState,
+  AssistantBuilderTablesQueryConfiguration,
 } from "@app/components/assistant_builder/types";
-import { getDefaultAssistantState } from "@app/components/assistant_builder/types";
+import {
+  getDefaultDustAppRunActionConfiguration,
+  getDefaultProcessActionConfiguration,
+  getDefaultRetrievalExhaustiveActionConfiguration,
+  getDefaultRetrievalSearchActionConfiguration,
+  getDefaultTablesQueryActionConfiguration,
+} from "@app/components/assistant_builder/types";
 import { tableKey } from "@app/lib/client/tables_query";
 import { deprecatedGetFirstActionConfiguration } from "@app/lib/deprecated_action_configurations";
 import logger from "@app/logger/logger";
 
-export async function buildInitialState({
+export async function buildInitialActions({
   dataSourcesByName,
   dustApps,
   configuration,
@@ -33,7 +41,7 @@ export async function buildInitialState({
   dataSourcesByName: Record<string, DataSourceType>;
   dustApps: AppType[];
   configuration: AgentConfigurationType | TemplateAgentConfigurationType;
-}) {
+}): Promise<AssistantBuilderActionConfiguration[]> {
   const coreAPI = new CoreAPI(logger);
 
   // Helper function to compute AssistantBuilderDataSourceConfigurations
@@ -97,44 +105,41 @@ export async function buildInitialState({
   const action = deprecatedGetFirstActionConfiguration(configuration);
 
   // Retrieval configuration
+  if (!action) {
+    return [];
+  } else if (isRetrievalConfiguration(action)) {
+    const isSearch = action.query !== "none";
 
-  const retrievalConfiguration =
-    getDefaultAssistantState().retrievalConfiguration;
+    const retrievalConfiguration = isSearch
+      ? getDefaultRetrievalSearchActionConfiguration()
+      : getDefaultRetrievalExhaustiveActionConfiguration();
 
-  if (isRetrievalConfiguration(action)) {
     if (
       action.relativeTimeFrame !== "auto" &&
       action.relativeTimeFrame !== "none"
     ) {
-      retrievalConfiguration.timeFrame = {
+      retrievalConfiguration.configuration.timeFrame = {
         value: action.relativeTimeFrame.duration,
         unit: action.relativeTimeFrame.unit,
       };
     }
 
-    retrievalConfiguration.dataSourceConfigurations =
+    retrievalConfiguration.configuration.dataSourceConfigurations =
       await renderDataSourcesConfigurations(action);
-  }
 
-  // DustAppRun configuration
-
-  const dustAppConfiguration = getDefaultAssistantState().dustAppConfiguration;
-
-  if (isDustAppRunConfiguration(action)) {
+    return [retrievalConfiguration];
+  } else if (isDustAppRunConfiguration(action)) {
+    const dustAppConfiguration = getDefaultDustAppRunActionConfiguration();
     for (const app of dustApps) {
       if (app.sId === action.appId) {
-        dustAppConfiguration.app = app;
+        dustAppConfiguration.configuration.app = app;
         break;
       }
     }
-  }
+    return [dustAppConfiguration];
+  } else if (isTablesQueryConfiguration(action)) {
+    const tablesQueryConfiguration = getDefaultTablesQueryActionConfiguration();
 
-  // TablesQuery configuration
-
-  let tablesQueryConfiguration =
-    getDefaultAssistantState().tablesQueryConfiguration;
-
-  if (isTablesQueryConfiguration(action) && action.tables.length) {
     const coreAPITables: CoreAPITable[] = await Promise.all(
       action.tables.map(async (t) => {
         const dataSource = dataSourcesByName[t.dataSourceId];
@@ -152,46 +157,43 @@ export async function buildInitialState({
       })
     );
 
-    tablesQueryConfiguration = action.tables.reduce((acc, curr, i) => {
-      const table = coreAPITables[i];
-      const key = tableKey(curr);
-      return {
-        ...acc,
-        [key]: {
-          workspaceId: curr.workspaceId,
-          dataSourceId: curr.dataSourceId,
-          tableId: curr.tableId,
-          tableName: `${table.name}`,
-        },
-      };
-    }, {} as AssistantBuilderInitialState["tablesQueryConfiguration"]);
-  }
+    tablesQueryConfiguration.configuration = action.tables.reduce(
+      (acc, curr, i) => {
+        const table = coreAPITables[i];
+        const key = tableKey(curr);
+        return {
+          ...acc,
+          [key]: {
+            workspaceId: curr.workspaceId,
+            dataSourceId: curr.dataSourceId,
+            tableId: curr.tableId,
+            tableName: `${table.name}`,
+          },
+        };
+      },
+      {} as AssistantBuilderTablesQueryConfiguration
+    );
 
-  // Process configuration
-
-  const processConfiguration = getDefaultAssistantState().processConfiguration;
-
-  if (isProcessConfiguration(action)) {
+    return [tablesQueryConfiguration];
+  } else if (isProcessConfiguration(action)) {
+    const processConfiguration = getDefaultProcessActionConfiguration();
     if (
       action.relativeTimeFrame !== "auto" &&
       action.relativeTimeFrame !== "none"
     ) {
-      processConfiguration.timeFrame = {
+      processConfiguration.configuration.timeFrame = {
         value: action.relativeTimeFrame.duration,
         unit: action.relativeTimeFrame.unit,
       };
     }
 
-    processConfiguration.dataSourceConfigurations =
+    processConfiguration.configuration.dataSourceConfigurations =
       await renderDataSourcesConfigurations(action);
 
-    processConfiguration.schema = action.schema;
-  }
+    processConfiguration.configuration.schema = action.schema;
 
-  return {
-    retrievalConfiguration,
-    dustAppConfiguration,
-    tablesQueryConfiguration,
-    processConfiguration,
-  };
+    return [processConfiguration];
+  } else {
+    assertNever(action);
+  }
 }

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -7,7 +7,7 @@ import type {
   SupportedModel,
   TimeframeUnit,
 } from "@dust-tt/types";
-import { GPT_4_TURBO_MODEL_CONFIG } from "@dust-tt/types";
+import { assertNever, GPT_4_TURBO_MODEL_CONFIG } from "@dust-tt/types";
 
 export const ACTION_MODES = [
   "GENERIC",
@@ -18,7 +18,7 @@ export const ACTION_MODES = [
   "PROCESS",
 ] as const;
 
-export type ActionMode = (typeof ACTION_MODES)[number];
+// export type ActionMode = (typeof ACTION_MODES)[number];
 
 // Retrieval configuration
 
@@ -74,6 +74,31 @@ export type AssistantBuilderProcessConfiguration = {
 
 // Builder State
 
+export type AssistantBuilderActionConfiguration = (
+  | {
+      type: "RETRIEVAL_SEARCH" | "RETRIEVAL_EXHAUSTIVE";
+      configuration: AssistantBuilderRetrievalConfiguration;
+    }
+  | {
+      type: "DUST_APP_RUN";
+      configuration: AssistantBuilderDustAppConfiguration;
+    }
+  | {
+      type: "TABLES_QUERY";
+      configuration: AssistantBuilderTablesQueryConfiguration;
+    }
+  | {
+      type: "PROCESS";
+      configuration: AssistantBuilderProcessConfiguration;
+    }
+) & {
+  name: string;
+  description: string;
+};
+
+export type AssistantBuilderActionType =
+  AssistantBuilderActionConfiguration["type"];
+
 export type AssistantBuilderState = {
   handle: string | null;
   description: string | null;
@@ -84,14 +109,7 @@ export type AssistantBuilderState = {
     modelSettings: SupportedModel;
     temperature: number;
   };
-  // Actions
-  // We want assistant builder state for action to always have empty default, never null which
-  // would complexify the assistant builder logic.
-  actionMode: ActionMode;
-  retrievalConfiguration: AssistantBuilderRetrievalConfiguration;
-  dustAppConfiguration: AssistantBuilderDustAppConfiguration;
-  tablesQueryConfiguration: AssistantBuilderTablesQueryConfiguration;
-  processConfiguration: AssistantBuilderProcessConfiguration;
+  actions: Array<AssistantBuilderActionConfiguration>;
 };
 
 export type AssistantBuilderInitialState = {
@@ -104,35 +122,31 @@ export type AssistantBuilderInitialState = {
     modelSettings: SupportedModel;
     temperature: number;
   } | null;
-  // Actions
-  actionMode: AssistantBuilderState["actionMode"];
-  retrievalConfiguration: AssistantBuilderState["retrievalConfiguration"];
-  dustAppConfiguration: AssistantBuilderState["dustAppConfiguration"];
-  tablesQueryConfiguration: AssistantBuilderState["tablesQueryConfiguration"];
-  processConfiguration: AssistantBuilderState["processConfiguration"];
+  actions: Array<AssistantBuilderActionConfiguration>;
 };
 
 // Creates a fresh instance of AssistantBuilderState to prevent unintended mutations of shared state.
 export function getDefaultAssistantState(): AssistantBuilderState {
   return {
-    actionMode: "GENERIC",
-    retrievalConfiguration: {
-      dataSourceConfigurations: {},
-      timeFrame: {
-        value: 1,
-        unit: "month",
-      },
-    },
-    dustAppConfiguration: { app: null },
-    tablesQueryConfiguration: {},
-    processConfiguration: {
-      dataSourceConfigurations: {},
-      timeFrame: {
-        value: 1,
-        unit: "day",
-      },
-      schema: [],
-    },
+    // actionMode: "GENERIC",
+    // retrievalConfiguration: {
+    //   dataSourceConfigurations: {},
+    //   timeFrame: {
+    //     value: 1,
+    //     unit: "month",
+    //   },
+    // },
+    // dustAppConfiguration: { app: null },
+    // tablesQueryConfiguration: {},
+    // processConfiguration: {
+    //   dataSourceConfigurations: {},
+    //   timeFrame: {
+    //     value: 1,
+    //     unit: "day",
+    //   },
+    //   schema: [],
+    // },
+    actions: [],
     handle: null,
     scope: "private",
     description: null,
@@ -146,4 +160,91 @@ export function getDefaultAssistantState(): AssistantBuilderState {
       temperature: 0.7,
     },
   };
+}
+
+export function getDefaultRetrievalSearchActionConfiguration() {
+  return {
+    type: "RETRIEVAL_SEARCH",
+    configuration: {
+      dataSourceConfigurations: {},
+      timeFrame: {
+        value: 1,
+        unit: "month",
+      },
+    } as AssistantBuilderRetrievalConfiguration,
+    name: "search_data_sources",
+    description: "Search in the user's data sources.",
+  } satisfies AssistantBuilderActionConfiguration;
+}
+
+export function getDefaultRetrievalExhaustiveActionConfiguration() {
+  return {
+    type: "RETRIEVAL_EXHAUSTIVE",
+    configuration: {
+      dataSourceConfigurations: {},
+      timeFrame: {
+        value: 1,
+        unit: "month",
+      },
+    } as AssistantBuilderRetrievalConfiguration,
+    name: "recent_data_sources",
+    description: "Retrieve the most recent data from the user's data sources.",
+  } satisfies AssistantBuilderActionConfiguration;
+}
+
+export function getDefaultDustAppRunActionConfiguration() {
+  return {
+    type: "DUST_APP_RUN",
+    configuration: {
+      app: null,
+    } as AssistantBuilderDustAppConfiguration,
+    name: "run_dust_app",
+    description: "Run a Dust app.",
+  } satisfies AssistantBuilderActionConfiguration;
+}
+
+export function getDefaultTablesQueryActionConfiguration() {
+  return {
+    type: "TABLES_QUERY",
+    configuration: {} as AssistantBuilderTablesQueryConfiguration,
+    name: "query_tables",
+    description: "Query structured tables via SQL.",
+  } satisfies AssistantBuilderActionConfiguration;
+}
+
+export function getDefaultProcessActionConfiguration() {
+  return {
+    type: "PROCESS",
+    configuration: {
+      dataSourceConfigurations: {},
+      timeFrame: {
+        value: 1,
+        unit: "day",
+      },
+      schema: [],
+    } as AssistantBuilderProcessConfiguration,
+    name: "process_data",
+    description: "Process data.",
+  } satisfies AssistantBuilderActionConfiguration;
+}
+
+export function getDefaultActionConfiguration(
+  actionType: AssistantBuilderActionType | null
+): AssistantBuilderActionConfiguration | null {
+  switch (actionType) {
+    case null:
+      return null;
+    case "RETRIEVAL_SEARCH":
+      return getDefaultRetrievalSearchActionConfiguration();
+    case "RETRIEVAL_EXHAUSTIVE":
+      return getDefaultRetrievalExhaustiveActionConfiguration();
+    case "DUST_APP_RUN":
+      return getDefaultDustAppRunActionConfiguration();
+    case "TABLES_QUERY":
+      return getDefaultTablesQueryActionConfiguration();
+    case "PROCESS":
+      return getDefaultProcessActionConfiguration();
+    default:
+      assertNever(actionType);
+  }
 }

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -18,8 +18,6 @@ export const ACTION_MODES = [
   "PROCESS",
 ] as const;
 
-// export type ActionMode = (typeof ACTION_MODES)[number];
-
 // Retrieval configuration
 
 export type AssistantBuilderDataSourceConfiguration = {
@@ -128,24 +126,6 @@ export type AssistantBuilderInitialState = {
 // Creates a fresh instance of AssistantBuilderState to prevent unintended mutations of shared state.
 export function getDefaultAssistantState(): AssistantBuilderState {
   return {
-    // actionMode: "GENERIC",
-    // retrievalConfiguration: {
-    //   dataSourceConfigurations: {},
-    //   timeFrame: {
-    //     value: 1,
-    //     unit: "month",
-    //   },
-    // },
-    // dustAppConfiguration: { app: null },
-    // tablesQueryConfiguration: {},
-    // processConfiguration: {
-    //   dataSourceConfigurations: {},
-    //   timeFrame: {
-    //     value: 1,
-    //     unit: "day",
-    //   },
-    //   schema: [],
-    // },
     actions: [],
     handle: null,
     scope: "private",

--- a/front/lib/client/assistant_builder/deprecated_single_action.ts
+++ b/front/lib/client/assistant_builder/deprecated_single_action.ts
@@ -1,0 +1,18 @@
+import { useMemo } from "react";
+
+import type {
+  AssistantBuilderActionConfiguration,
+  AssistantBuilderState,
+} from "@app/components/assistant_builder/types";
+
+export function getDeprecatedDefaultSingleAction(
+  builderState: AssistantBuilderState
+): AssistantBuilderActionConfiguration | undefined {
+  return builderState.actions[0];
+}
+
+export function useDeprecatedDefaultSingleAction(
+  builderState: AssistantBuilderState
+): AssistantBuilderActionConfiguration | undefined {
+  return useMemo(() => builderState.actions[0], [builderState.actions]);
+}


### PR DESCRIPTION
## Description

preliminary step for https://github.com/dust-tt/dust/issues/4603

Doesn't actually add any support for multi-actions, but makes it work with a multi-action structure of the AssistantBuilderState.

Only functional change: if you configure an action, change for another action, go back to initial action, your config is gone. Cannot preserve this behaviour with the actions array. But this won't be as much a problem in multi-actions land.

## Risk

might break the assistant builder

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
