### PR TITLE
Fix catching of confluence timeout error

### DIFF
--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -164,10 +164,7 @@ export class ConfluenceClient {
           signal: AbortSignal.timeout(30000),
         });
       } catch (e) {
-        if (
-          e instanceof TypeError &&
-          e.message.includes("fetch failed: Headers Timeout Error")
-        ) {
+        if (e instanceof DOMException && e.name === "TimeoutError") {
           throw new ConfluenceClientError("Request timed out", {
             type: "http_response_error",
             status: 504,
@@ -178,8 +175,8 @@ export class ConfluenceClient {
             },
           });
         }
-        if (e instanceof DOMException && e.name === "TimeoutError") {
-          throw new ConfluenceClientError("Request timed out", {
+        if (e instanceof TypeError && e.message.includes("fetch failed")) {
+          throw new ConfluenceClientError("Confluence client unreachable", {
             type: "http_response_error",
             status: 504,
             data: {


### PR DESCRIPTION
Description
---
Following PR #4909
Error message matching wasn't appropriate for some timeout errors (see [here](https://app.datadoghq.eu/logs?query=status%3Aerror%20%22fetch%20failed%22%20&agg_m=count&agg_m_source=base&agg_t=count&cols=service%2C%40workflowName%2C%40activityName%2C%40error.__is_dust_error&fromUser=true&messageDisplay=inline&refresh_mode=sliding&saved-view-id=99803&storage=hot&stream_sort=%40duration%2Cdesc&viz=stream&from_ts=1714641494915&to_ts=1714655894915))

Initial intent to limit handling to the "headers timeout", while slightly better, is not obvious to do and not really necessary; on repeated fetch fails, the activity monitor will fire promptly

Risk
---
NTR

Deploy plan
---
Connectors
