### PR TITLE
Multi-action renderConversationForModel with cli

### DIFF
--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -1,9 +1,16 @@
-import { ConnectorsAPI, removeNulls } from "@dust-tt/types";
+import {
+  CLAUDE_3_OPUS_DEFAULT_MODEL_CONFIG,
+  ConnectorsAPI,
+  removeNulls,
+  SUPPORTED_MODEL_CONFIGS,
+} from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
 import { Storage } from "@google-cloud/storage";
 import parseArgs from "minimist";
 import readline from "readline";
 
+import { getConversation } from "@app/lib/api/assistant/conversation";
+import { renderConversationForModelMultiActions } from "@app/lib/api/assistant/generation";
 import { getDataSources } from "@app/lib/api/data_sources";
 import { renderUserType } from "@app/lib/api/user";
 import { Authenticator } from "@app/lib/auth";
@@ -507,6 +514,77 @@ const eventSchema = async (command: string, args: parseArgs.ParsedArgs) => {
   }
 };
 
+const conversation = async (command: string, args: parseArgs.ParsedArgs) => {
+  switch (command) {
+    case "render-for-model": {
+      if (!args.wId) {
+        throw new Error("Missing --wId argument");
+      }
+      if (!args.cId) {
+        throw new Error("Missing --cId argument");
+      }
+      const verbose = args.verbose === "true";
+
+      const modelId =
+        args.modelId ?? CLAUDE_3_OPUS_DEFAULT_MODEL_CONFIG.modelId;
+      const model = SUPPORTED_MODEL_CONFIGS.find(
+        (m) => m.modelId === modelId && m.supportsMultiActions
+      );
+      if (!model) {
+        throw new Error(`Model not found: modelId='${modelId}'`);
+      }
+
+      const auth = await Authenticator.internalAdminForWorkspace(args.wId);
+      const conversation = await getConversation(auth, args.cId as string);
+
+      if (!conversation) {
+        throw new Error(`Conversation not found: cId='${args.cId}'`);
+      }
+
+      const MIN_GENERATION_TOKENS = 2048;
+      const allowedTokenCount = model.contextSize - MIN_GENERATION_TOKENS;
+      const prompt = "";
+
+      const response = await renderConversationForModelMultiActions({
+        conversation,
+        model,
+        prompt,
+        allowedTokenCount,
+      });
+
+      if (response.isErr()) {
+        logger.error(response.error.message);
+      } else {
+        logger.info(
+          {
+            model,
+            prompt,
+          },
+          "Called renderConversationForModel with params:"
+        );
+        const result = response.value;
+
+        if (!verbose) {
+          // For convenience we shorten the content when role = "tool"
+          result.modelConversation.messages =
+            result.modelConversation.messages.map((m) => {
+              if (m.role === "tool") {
+                return {
+                  ...m,
+                  content: m.content.slice(0, 200) + "...",
+                };
+              }
+              return m;
+            });
+        }
+
+        logger.info(result, "Result from renderConversationForModel:");
+      }
+      return;
+    }
+  }
+};
+
 const main = async () => {
   const argv = parseArgs(process.argv.slice(2));
 
@@ -514,7 +592,9 @@ const main = async () => {
     console.log(
       "Expects object type and command as first two arguments, eg: `cli workspace create ...`"
     );
-    console.log("Possible object types: `workspace`, `user`, `data-source`");
+    console.log(
+      "Possible object types: `workspace`, `user`, `data-source`, `conversation`"
+    );
     return;
   }
 
@@ -533,9 +613,11 @@ const main = async () => {
     case "event-schema":
       await eventSchema(command, argv);
       return;
+    case "conversation":
+      return conversation(command, argv);
     default:
       console.log(
-        "Unknown object type, possible values: `workspace`, `user`, `data-source`, `event-schema`"
+        "Unknown object type, possible values: `workspace`, `user`, `data-source`, `event-schema`, `conversation`"
       );
       return;
   }

--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -568,7 +568,7 @@ const conversation = async (command: string, args: parseArgs.ParsedArgs) => {
           // For convenience we shorten the content when role = "tool"
           result.modelConversation.messages =
             result.modelConversation.messages.map((m) => {
-              if (m.role === "tool") {
+              if (m.role === "function") {
                 return {
                   ...m,
                   content: m.content.slice(0, 200) + "...",

--- a/front/lib/api/assistant/actions/dust_app_run.ts
+++ b/front/lib/api/assistant/actions/dust_app_run.ts
@@ -1,4 +1,5 @@
 import type {
+  AssistantToolCallMessageTypeModel,
   DustAppRunBlockEvent,
   DustAppRunConfigurationType,
   DustAppRunErrorEvent,
@@ -6,6 +7,7 @@ import type {
   DustAppRunSuccessEvent,
   ModelId,
   ModelMessageType,
+  ToolMessageTypeModel,
 } from "@dust-tt/types";
 import type { DustAppParameters, DustAppRunActionType } from "@dust-tt/types";
 import type {
@@ -43,6 +45,42 @@ export function renderDustAppRunActionForModel(
   return {
     role: "action" as const,
     name: action.appName,
+    content,
+  };
+}
+export function renderAssistantToolCallMessageForDustAppRunAction(
+  action: DustAppRunActionType
+): AssistantToolCallMessageTypeModel {
+  return {
+    role: "assistant" as const,
+    content: null,
+    toolCalls: [
+      {
+        id: action.id.toString(), // @todo Daph replace with the actual tool id
+        type: "function",
+        function: {
+          name: action.appName,
+          arguments: JSON.stringify(action.params),
+        },
+      },
+    ],
+  };
+}
+export function renderToolMessageForForDustAppRunAction(
+  action: DustAppRunActionType
+): ToolMessageTypeModel {
+  let content = "";
+  if (!action.output) {
+    throw new Error(
+      "Output not set on DustAppRun action; execution is likely not finished."
+    );
+  }
+  content += `OUTPUT:\n`;
+  content += `${JSON.stringify(action.output, null, 2)}\n`;
+
+  return {
+    role: "tool" as const,
+    toolCallId: action.id.toString(), // @todo Daph replace with the actual tool id
     content,
   };
 }

--- a/front/lib/api/assistant/actions/dust_app_run.ts
+++ b/front/lib/api/assistant/actions/dust_app_run.ts
@@ -1,13 +1,13 @@
 import type {
-  AssistantToolCallMessageTypeModel,
+  AssistantFunctionCallMessageTypeModel,
   DustAppRunBlockEvent,
   DustAppRunConfigurationType,
   DustAppRunErrorEvent,
   DustAppRunParamsEvent,
   DustAppRunSuccessEvent,
+  FunctionMessageTypeModel,
   ModelId,
   ModelMessageType,
-  ToolMessageTypeModel,
 } from "@dust-tt/types";
 import type { DustAppParameters, DustAppRunActionType } from "@dust-tt/types";
 import type {
@@ -48,13 +48,13 @@ export function renderDustAppRunActionForModel(
     content,
   };
 }
-export function renderAssistantToolCallMessageForDustAppRunAction(
+export function renderAssistantFunctionCallMessageForDustAppRunAction(
   action: DustAppRunActionType
-): AssistantToolCallMessageTypeModel {
+): AssistantFunctionCallMessageTypeModel {
   return {
     role: "assistant" as const,
     content: null,
-    toolCalls: [
+    functionCalls: [
       {
         id: action.id.toString(), // @todo Daph replace with the actual tool id
         type: "function",
@@ -66,9 +66,9 @@ export function renderAssistantToolCallMessageForDustAppRunAction(
     ],
   };
 }
-export function renderToolMessageForForDustAppRunAction(
+export function renderFunctionMessageForForDustAppRunAction(
   action: DustAppRunActionType
-): ToolMessageTypeModel {
+): FunctionMessageTypeModel {
   let content = "";
   if (!action.output) {
     throw new Error(
@@ -79,8 +79,8 @@ export function renderToolMessageForForDustAppRunAction(
   content += `${JSON.stringify(action.output, null, 2)}\n`;
 
   return {
-    role: "tool" as const,
-    toolCallId: action.id.toString(), // @todo Daph replace with the actual tool id
+    role: "function" as const,
+    functionCallId: action.id.toString(), // @todo Daph replace with the actual tool id
     content,
   };
 }

--- a/front/lib/api/assistant/actions/dust_app_run.ts
+++ b/front/lib/api/assistant/actions/dust_app_run.ts
@@ -54,16 +54,14 @@ export function renderAssistantFunctionCallMessageForDustAppRunAction(
   return {
     role: "assistant" as const,
     content: null,
-    functionCalls: [
-      {
-        id: action.id.toString(), // @todo Daph replace with the actual tool id
-        type: "function",
-        function: {
-          name: action.appName,
-          arguments: JSON.stringify(action.params),
-        },
+    function_call: {
+      id: action.id.toString(), // @todo Daph replace with the actual tool id
+      type: "function",
+      function: {
+        name: action.appName,
+        arguments: JSON.stringify(action.params),
       },
-    ],
+    },
   };
 }
 export function renderFunctionMessageForForDustAppRunAction(
@@ -80,7 +78,7 @@ export function renderFunctionMessageForForDustAppRunAction(
 
   return {
     role: "function" as const,
-    functionCallId: action.id.toString(), // @todo Daph replace with the actual tool id
+    function_call_id: action.id.toString(), // @todo Daph replace with the actual tool id
     content,
   };
 }

--- a/front/lib/api/assistant/actions/dust_app_run.ts
+++ b/front/lib/api/assistant/actions/dust_app_run.ts
@@ -70,11 +70,8 @@ export function renderFunctionMessageForForDustAppRunAction(
   action: DustAppRunActionType
 ): FunctionMessageTypeModel {
   let content = "";
-  if (!action.output) {
-    throw new Error(
-      "Output not set on DustAppRun action; execution is likely not finished."
-    );
-  }
+
+  // Note action.output can be any valid JSON including null.
   content += `OUTPUT:\n`;
   content += `${JSON.stringify(action.output, null, 2)}\n`;
 

--- a/front/lib/api/assistant/actions/dust_app_run.ts
+++ b/front/lib/api/assistant/actions/dust_app_run.ts
@@ -1,10 +1,10 @@
 import type {
-  AssistantFunctionCallMessageTypeModel,
   DustAppRunBlockEvent,
   DustAppRunConfigurationType,
   DustAppRunErrorEvent,
   DustAppRunParamsEvent,
   DustAppRunSuccessEvent,
+  FunctionCallType,
   FunctionMessageTypeModel,
   ModelId,
   ModelMessageType,
@@ -48,22 +48,16 @@ export function renderDustAppRunActionForModel(
     content,
   };
 }
-export function renderAssistantFunctionCallMessageForDustAppRunAction(
+export function renderAssistantFunctionCallForDustAppRunAction(
   action: DustAppRunActionType
-): AssistantFunctionCallMessageTypeModel {
+): FunctionCallType {
   return {
-    role: "assistant" as const,
-    content: null,
-    function_calls: [
-      {
-        id: action.id.toString(), // @todo Daph replace with the actual tool id
-        type: "function",
-        function: {
-          name: action.appName,
-          arguments: JSON.stringify(action.params),
-        },
-      },
-    ],
+    id: action.id.toString(), // @todo Daph replace with the actual tool id
+    type: "function",
+    function: {
+      name: action.appName,
+      arguments: JSON.stringify(action.params),
+    },
   };
 }
 export function renderFunctionMessageForForDustAppRunAction(

--- a/front/lib/api/assistant/actions/dust_app_run.ts
+++ b/front/lib/api/assistant/actions/dust_app_run.ts
@@ -48,7 +48,8 @@ export function renderDustAppRunActionForModel(
     content,
   };
 }
-export function renderAssistantFunctionCallForDustAppRunAction(
+
+export function renderDustAppRunActionFunctionCall(
   action: DustAppRunActionType
 ): FunctionCallType {
   return {
@@ -60,7 +61,7 @@ export function renderAssistantFunctionCallForDustAppRunAction(
     },
   };
 }
-export function renderFunctionMessageForForDustAppRunAction(
+export function renderDustAppRunActionForMultiActionsModel(
   action: DustAppRunActionType
 ): FunctionMessageTypeModel {
   let content = "";

--- a/front/lib/api/assistant/actions/dust_app_run.ts
+++ b/front/lib/api/assistant/actions/dust_app_run.ts
@@ -54,14 +54,16 @@ export function renderAssistantFunctionCallMessageForDustAppRunAction(
   return {
     role: "assistant" as const,
     content: null,
-    function_call: {
-      id: action.id.toString(), // @todo Daph replace with the actual tool id
-      type: "function",
-      function: {
-        name: action.appName,
-        arguments: JSON.stringify(action.params),
+    function_calls: [
+      {
+        id: action.id.toString(), // @todo Daph replace with the actual tool id
+        type: "function",
+        function: {
+          name: action.appName,
+          arguments: JSON.stringify(action.params),
+        },
       },
-    },
+    ],
   };
 }
 export function renderFunctionMessageForForDustAppRunAction(

--- a/front/lib/api/assistant/actions/process.ts
+++ b/front/lib/api/assistant/actions/process.ts
@@ -76,14 +76,16 @@ export function renderAssistantFunctionCallMessageForProcessAction(
   return {
     role: "assistant" as const,
     content: null,
-    function_call: {
-      id: action.id.toString(), // @todo Daph replace with the actual tool id
-      type: "function",
-      function: {
-        name: "process_data_sources",
-        arguments: JSON.stringify(action.params),
+    function_calls: [
+      {
+        id: action.id.toString(), // @todo Daph replace with the actual tool id
+        type: "function",
+        function: {
+          name: "process_data_sources",
+          arguments: JSON.stringify(action.params),
+        },
       },
-    },
+    ],
   };
 }
 export function renderFunctionMessageForForProcessAction(

--- a/front/lib/api/assistant/actions/process.ts
+++ b/front/lib/api/assistant/actions/process.ts
@@ -2,8 +2,8 @@ import type {
   AgentActionSpecification,
   AgentConfigurationType,
   AgentMessageType,
-  AssistantFunctionCallMessageTypeModel,
   ConversationType,
+  FunctionCallType,
   FunctionMessageTypeModel,
   ModelId,
   ModelMessageType,
@@ -70,22 +70,16 @@ export function renderProcessActionForModel(
     content,
   };
 }
-export function renderAssistantFunctionCallMessageForProcessAction(
+export function renderAssistantFunctionCallForProcessAction(
   action: ProcessActionType
-): AssistantFunctionCallMessageTypeModel {
+): FunctionCallType {
   return {
-    role: "assistant" as const,
-    content: null,
-    function_calls: [
-      {
-        id: action.id.toString(), // @todo Daph replace with the actual tool id
-        type: "function",
-        function: {
-          name: "process_data_sources",
-          arguments: JSON.stringify(action.params),
-        },
-      },
-    ],
+    id: action.id.toString(), // @todo Daph replace with the actual tool id
+    type: "function",
+    function: {
+      name: "process_data_sources",
+      arguments: JSON.stringify(action.params),
+    },
   };
 }
 export function renderFunctionMessageForForProcessAction(

--- a/front/lib/api/assistant/actions/process.ts
+++ b/front/lib/api/assistant/actions/process.ts
@@ -2,6 +2,7 @@ import type {
   AgentActionSpecification,
   AgentConfigurationType,
   AgentMessageType,
+  AssistantToolCallMessageTypeModel,
   ConversationType,
   ModelId,
   ModelMessageType,
@@ -13,6 +14,7 @@ import type {
   ProcessSuccessEvent,
   Result,
   TimeFrame,
+  ToolMessageTypeModel,
   UserMessageType,
 } from "@dust-tt/types";
 import {
@@ -65,6 +67,50 @@ export function renderProcessActionForModel(
   return {
     role: "action" as const,
     name: "process_data_sources",
+    content,
+  };
+}
+export function renderAssistantToolCallMessageForProcessAction(
+  action: ProcessActionType
+): AssistantToolCallMessageTypeModel {
+  return {
+    role: "assistant" as const,
+    content: null,
+    toolCalls: [
+      {
+        id: action.id.toString(), // @todo Daph replace with the actual tool id
+        type: "function",
+        function: {
+          name: "process_data_sources",
+          arguments: JSON.stringify(action.params),
+        },
+      },
+    ],
+  };
+}
+export function renderToolMessageForForProcessAction(
+  action: ProcessActionType
+): ToolMessageTypeModel {
+  let content = "";
+  if (action.outputs === null) {
+    throw new Error(
+      "Output not set on process action; this usually means the process action is not finished."
+    );
+  }
+
+  content += "PROCESSED OUTPUTS:\n";
+
+  // TODO(spolu): figure out if we want to add the schema here?
+
+  if (action.outputs) {
+    for (const o of action.outputs.data) {
+      content += `${JSON.stringify(o)}\n`;
+    }
+  }
+
+  return {
+    role: "tool" as const,
+    toolCallId: action.id.toString(), // @todo Daph replace with the actual tool id
     content,
   };
 }

--- a/front/lib/api/assistant/actions/process.ts
+++ b/front/lib/api/assistant/actions/process.ts
@@ -2,8 +2,9 @@ import type {
   AgentActionSpecification,
   AgentConfigurationType,
   AgentMessageType,
-  AssistantToolCallMessageTypeModel,
+  AssistantFunctionCallMessageTypeModel,
   ConversationType,
+  FunctionMessageTypeModel,
   ModelId,
   ModelMessageType,
   ProcessActionOutputsType,
@@ -14,7 +15,6 @@ import type {
   ProcessSuccessEvent,
   Result,
   TimeFrame,
-  ToolMessageTypeModel,
   UserMessageType,
 } from "@dust-tt/types";
 import {
@@ -70,13 +70,13 @@ export function renderProcessActionForModel(
     content,
   };
 }
-export function renderAssistantToolCallMessageForProcessAction(
+export function renderAssistantFunctionCallMessageForProcessAction(
   action: ProcessActionType
-): AssistantToolCallMessageTypeModel {
+): AssistantFunctionCallMessageTypeModel {
   return {
     role: "assistant" as const,
     content: null,
-    toolCalls: [
+    functionCalls: [
       {
         id: action.id.toString(), // @todo Daph replace with the actual tool id
         type: "function",
@@ -88,9 +88,9 @@ export function renderAssistantToolCallMessageForProcessAction(
     ],
   };
 }
-export function renderToolMessageForForProcessAction(
+export function renderFunctionMessageForForProcessAction(
   action: ProcessActionType
-): ToolMessageTypeModel {
+): FunctionMessageTypeModel {
   let content = "";
   if (action.outputs === null) {
     throw new Error(
@@ -109,8 +109,8 @@ export function renderToolMessageForForProcessAction(
   }
 
   return {
-    role: "tool" as const,
-    toolCallId: action.id.toString(), // @todo Daph replace with the actual tool id
+    role: "function" as const,
+    functionCallId: action.id.toString(), // @todo Daph replace with the actual tool id
     content,
   };
 }

--- a/front/lib/api/assistant/actions/process.ts
+++ b/front/lib/api/assistant/actions/process.ts
@@ -76,16 +76,14 @@ export function renderAssistantFunctionCallMessageForProcessAction(
   return {
     role: "assistant" as const,
     content: null,
-    functionCalls: [
-      {
-        id: action.id.toString(), // @todo Daph replace with the actual tool id
-        type: "function",
-        function: {
-          name: "process_data_sources",
-          arguments: JSON.stringify(action.params),
-        },
+    function_call: {
+      id: action.id.toString(), // @todo Daph replace with the actual tool id
+      type: "function",
+      function: {
+        name: "process_data_sources",
+        arguments: JSON.stringify(action.params),
       },
-    ],
+    },
   };
 }
 export function renderFunctionMessageForForProcessAction(
@@ -110,7 +108,7 @@ export function renderFunctionMessageForForProcessAction(
 
   return {
     role: "function" as const,
-    functionCallId: action.id.toString(), // @todo Daph replace with the actual tool id
+    function_call_id: action.id.toString(), // @todo Daph replace with the actual tool id
     content,
   };
 }

--- a/front/lib/api/assistant/actions/process.ts
+++ b/front/lib/api/assistant/actions/process.ts
@@ -70,7 +70,8 @@ export function renderProcessActionForModel(
     content,
   };
 }
-export function renderAssistantFunctionCallForProcessAction(
+
+export function renderProcessActionFunctionCall(
   action: ProcessActionType
 ): FunctionCallType {
   return {
@@ -82,7 +83,7 @@ export function renderAssistantFunctionCallForProcessAction(
     },
   };
 }
-export function renderFunctionMessageForForProcessAction(
+export function renderProcessActionForMultiActionsModel(
   action: ProcessActionType
 ): FunctionMessageTypeModel {
   let content = "";

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -165,16 +165,14 @@ export function renderAssistantFunctionCallMessageForRetrievalAction(
   return {
     role: "assistant" as const,
     content: null,
-    functionCalls: [
-      {
-        id: action.id.toString(), // @todo Daph replace with the actual tool id
-        type: "function",
-        function: {
-          name: "search_data_sources",
-          arguments: JSON.stringify(params),
-        },
+    function_call: {
+      id: action.id.toString(), // @todo Daph replace with the actual tool id
+      type: "function",
+      function: {
+        name: "search_data_sources",
+        arguments: JSON.stringify(params),
       },
-    ],
+    },
   };
 }
 export function renderFunctionMessageForRetrievalAction(
@@ -211,7 +209,7 @@ export function renderFunctionMessageForRetrievalAction(
 
   return {
     role: "function" as const,
-    functionCallId: action.id.toString(), // @todo Daph replace with the actual tool id
+    function_call_id: action.id.toString(), // @todo Daph replace with the actual tool id
     content,
   };
 }

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -165,14 +165,16 @@ export function renderAssistantFunctionCallMessageForRetrievalAction(
   return {
     role: "assistant" as const,
     content: null,
-    function_call: {
-      id: action.id.toString(), // @todo Daph replace with the actual tool id
-      type: "function",
-      function: {
-        name: "search_data_sources",
-        arguments: JSON.stringify(params),
+    function_calls: [
+      {
+        id: action.id.toString(), // @todo Daph replace with the actual tool id
+        type: "function",
+        function: {
+          name: "search_data_sources",
+          arguments: JSON.stringify(params),
+        },
       },
-    },
+    ],
   };
 }
 export function renderFunctionMessageForRetrievalAction(

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -1,9 +1,11 @@
 import type {
+  AssistantToolCallMessageTypeModel,
   ModelId,
   ModelMessageType,
   RetrievalErrorEvent,
   RetrievalParamsEvent,
   RetrievalSuccessEvent,
+  ToolMessageTypeModel,
 } from "@dust-tt/types";
 import type {
   RetrievalActionType,
@@ -145,6 +147,71 @@ export function renderRetrievalActionForModel(
   return {
     role: "action" as const,
     name: "search_data_sources",
+    content,
+  };
+}
+export function renderAssistantToolCallMessageForRetrievalAction(
+  action: RetrievalActionType
+): AssistantToolCallMessageTypeModel {
+  const timeFrame = action.params.relativeTimeFrame;
+  const params = {
+    query: action.params.query,
+    relativeTimeFrame: timeFrame
+      ? `${timeFrame.duration}${timeFrame.unit}`
+      : "all",
+    topK: action.params.topK,
+  };
+
+  return {
+    role: "assistant" as const,
+    content: null,
+    toolCalls: [
+      {
+        id: action.id.toString(), // @todo Daph replace with the actual tool id
+        type: "function",
+        function: {
+          name: "search_data_sources",
+          arguments: JSON.stringify(params),
+        },
+      },
+    ],
+  };
+}
+export function renderToolMessageForRetrievalAction(
+  action: RetrievalActionType
+): ToolMessageTypeModel {
+  let content = "";
+  if (!action.documents) {
+    throw new Error(
+      "Documents not set on retrieval action; this usually means the retrieval action is not finished."
+    );
+  }
+  for (const d of action.documents) {
+    let title = d.documentId;
+    for (const t of d.tags) {
+      if (t.startsWith("title:")) {
+        title = t.substring(6);
+        break;
+      }
+    }
+
+    let dataSourceName = d.dataSourceId;
+    if (d.dataSourceId.startsWith("managed-")) {
+      dataSourceName = d.dataSourceId.substring(8);
+    }
+
+    content += `TITLE: ${title} (data source: ${dataSourceName})\n`;
+    content += `REFERENCE: ${d.reference}\n`;
+    content += `EXTRACTS:\n`;
+    for (const c of d.chunks) {
+      content += `${c.text}\n`;
+    }
+    content += "\n";
+  }
+
+  return {
+    role: "tool" as const,
+    toolCallId: action.id.toString(), // @todo Daph replace with the actual tool id
     content,
   };
 }

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -1,11 +1,11 @@
 import type {
-  AssistantToolCallMessageTypeModel,
+  AssistantFunctionCallMessageTypeModel,
+  FunctionMessageTypeModel,
   ModelId,
   ModelMessageType,
   RetrievalErrorEvent,
   RetrievalParamsEvent,
   RetrievalSuccessEvent,
-  ToolMessageTypeModel,
 } from "@dust-tt/types";
 import type {
   RetrievalActionType,
@@ -150,9 +150,9 @@ export function renderRetrievalActionForModel(
     content,
   };
 }
-export function renderAssistantToolCallMessageForRetrievalAction(
+export function renderAssistantFunctionCallMessageForRetrievalAction(
   action: RetrievalActionType
-): AssistantToolCallMessageTypeModel {
+): AssistantFunctionCallMessageTypeModel {
   const timeFrame = action.params.relativeTimeFrame;
   const params = {
     query: action.params.query,
@@ -165,7 +165,7 @@ export function renderAssistantToolCallMessageForRetrievalAction(
   return {
     role: "assistant" as const,
     content: null,
-    toolCalls: [
+    functionCalls: [
       {
         id: action.id.toString(), // @todo Daph replace with the actual tool id
         type: "function",
@@ -177,9 +177,9 @@ export function renderAssistantToolCallMessageForRetrievalAction(
     ],
   };
 }
-export function renderToolMessageForRetrievalAction(
+export function renderFunctionMessageForRetrievalAction(
   action: RetrievalActionType
-): ToolMessageTypeModel {
+): FunctionMessageTypeModel {
   let content = "";
   if (!action.documents) {
     throw new Error(
@@ -210,8 +210,8 @@ export function renderToolMessageForRetrievalAction(
   }
 
   return {
-    role: "tool" as const,
-    toolCallId: action.id.toString(), // @todo Daph replace with the actual tool id
+    role: "function" as const,
+    functionCallId: action.id.toString(), // @todo Daph replace with the actual tool id
     content,
   };
 }

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -1,5 +1,5 @@
 import type {
-  AssistantFunctionCallMessageTypeModel,
+  FunctionCallType,
   FunctionMessageTypeModel,
   ModelId,
   ModelMessageType,
@@ -150,9 +150,9 @@ export function renderRetrievalActionForModel(
     content,
   };
 }
-export function renderAssistantFunctionCallMessageForRetrievalAction(
+export function renderAssistantFunctionCallForRetrievalAction(
   action: RetrievalActionType
-): AssistantFunctionCallMessageTypeModel {
+): FunctionCallType {
   const timeFrame = action.params.relativeTimeFrame;
   const params = {
     query: action.params.query,
@@ -163,18 +163,12 @@ export function renderAssistantFunctionCallMessageForRetrievalAction(
   };
 
   return {
-    role: "assistant" as const,
-    content: null,
-    function_calls: [
-      {
-        id: action.id.toString(), // @todo Daph replace with the actual tool id
-        type: "function",
-        function: {
-          name: "search_data_sources",
-          arguments: JSON.stringify(params),
-        },
-      },
-    ],
+    id: action.id.toString(), // @todo Daph replace with the actual tool id
+    type: "function",
+    function: {
+      name: "search_data_sources",
+      arguments: JSON.stringify(params),
+    },
   };
 }
 export function renderFunctionMessageForRetrievalAction(

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -150,7 +150,8 @@ export function renderRetrievalActionForModel(
     content,
   };
 }
-export function renderAssistantFunctionCallForRetrievalAction(
+
+export function rendeRetrievalActionFunctionCall(
   action: RetrievalActionType
 ): FunctionCallType {
   const timeFrame = action.params.relativeTimeFrame;
@@ -171,7 +172,7 @@ export function renderAssistantFunctionCallForRetrievalAction(
     },
   };
 }
-export function renderFunctionMessageForRetrievalAction(
+export function renderRetrievalActionForMultiActionsModel(
   action: RetrievalActionType
 ): FunctionMessageTypeModel {
   let content = "";

--- a/front/lib/api/assistant/actions/tables_query.ts
+++ b/front/lib/api/assistant/actions/tables_query.ts
@@ -45,7 +45,8 @@ export function renderTablesQueryActionForModel(
     content,
   };
 }
-export function renderAssistantFunctionCallForTablesQueryAction(
+
+export function rendeTablesQueryActionFunctionCall(
   action: TablesQueryActionType
 ): FunctionCallType {
   return {
@@ -57,7 +58,7 @@ export function renderAssistantFunctionCallForTablesQueryAction(
     },
   };
 }
-export function renderFunctionMessageForForTablesQueryAction(
+export function renderTablesQueryActionForMultiActionsModel(
   action: TablesQueryActionType
 ): FunctionMessageTypeModel {
   let content = "";

--- a/front/lib/api/assistant/actions/tables_query.ts
+++ b/front/lib/api/assistant/actions/tables_query.ts
@@ -2,6 +2,7 @@ import type {
   AgentActionSpecification,
   AgentConfigurationType,
   AgentMessageType,
+  AssistantToolCallMessageTypeModel,
   ConversationType,
   DustAppParameters,
   ModelId,
@@ -13,6 +14,7 @@ import type {
   TablesQueryOutputEvent,
   TablesQueryParamsEvent,
   TablesQuerySuccessEvent,
+  ToolMessageTypeModel,
 } from "@dust-tt/types";
 import { cloneBaseConfig, DustProdActionRegistry, Ok } from "@dust-tt/types";
 
@@ -40,6 +42,42 @@ export function renderTablesQueryActionForModel(
   return {
     role: "action" as const,
     name: "query_tables",
+    content,
+  };
+}
+export function renderAssistantToolCallMessageForTablesQueryAction(
+  action: TablesQueryActionType
+): AssistantToolCallMessageTypeModel {
+  return {
+    role: "assistant" as const,
+    content: null,
+    toolCalls: [
+      {
+        id: action.id.toString(), // @todo Daph replace with the actual tool id
+        type: "function",
+        function: {
+          name: "query_tables",
+          arguments: JSON.stringify(action.params),
+        },
+      },
+    ],
+  };
+}
+export function renderToolMessageForForTablesQueryAction(
+  action: TablesQueryActionType
+): ToolMessageTypeModel {
+  let content = "";
+  if (!action.output) {
+    throw new Error(
+      "Output not set on TablesQuery action; execution is likely not finished."
+    );
+  }
+  content += `OUTPUT:\n`;
+  content += `${JSON.stringify(action.output, null, 2)}\n`;
+
+  return {
+    role: "tool" as const,
+    toolCallId: action.id.toString(), // @todo Daph replace with the actual tool id
     content,
   };
 }

--- a/front/lib/api/assistant/actions/tables_query.ts
+++ b/front/lib/api/assistant/actions/tables_query.ts
@@ -2,9 +2,9 @@ import type {
   AgentActionSpecification,
   AgentConfigurationType,
   AgentMessageType,
-  AssistantFunctionCallMessageTypeModel,
   ConversationType,
   DustAppParameters,
+  FunctionCallType,
   FunctionMessageTypeModel,
   ModelId,
   ModelMessageType,
@@ -45,22 +45,16 @@ export function renderTablesQueryActionForModel(
     content,
   };
 }
-export function renderAssistantFunctionCallMessageForTablesQueryAction(
+export function renderAssistantFunctionCallForTablesQueryAction(
   action: TablesQueryActionType
-): AssistantFunctionCallMessageTypeModel {
+): FunctionCallType {
   return {
-    role: "assistant" as const,
-    content: null,
-    function_calls: [
-      {
-        id: action.id.toString(), // @todo Daph replace with the actual tool id
-        type: "function",
-        function: {
-          name: "query_tables",
-          arguments: JSON.stringify(action.params),
-        },
-      },
-    ],
+    id: action.id.toString(), // @todo Daph replace with the actual tool id
+    type: "function",
+    function: {
+      name: "query_tables",
+      arguments: JSON.stringify(action.params),
+    },
   };
 }
 export function renderFunctionMessageForForTablesQueryAction(

--- a/front/lib/api/assistant/actions/tables_query.ts
+++ b/front/lib/api/assistant/actions/tables_query.ts
@@ -2,9 +2,10 @@ import type {
   AgentActionSpecification,
   AgentConfigurationType,
   AgentMessageType,
-  AssistantToolCallMessageTypeModel,
+  AssistantFunctionCallMessageTypeModel,
   ConversationType,
   DustAppParameters,
+  FunctionMessageTypeModel,
   ModelId,
   ModelMessageType,
   Result,
@@ -14,7 +15,6 @@ import type {
   TablesQueryOutputEvent,
   TablesQueryParamsEvent,
   TablesQuerySuccessEvent,
-  ToolMessageTypeModel,
 } from "@dust-tt/types";
 import { cloneBaseConfig, DustProdActionRegistry, Ok } from "@dust-tt/types";
 
@@ -45,13 +45,13 @@ export function renderTablesQueryActionForModel(
     content,
   };
 }
-export function renderAssistantToolCallMessageForTablesQueryAction(
+export function renderAssistantFunctionCallMessageForTablesQueryAction(
   action: TablesQueryActionType
-): AssistantToolCallMessageTypeModel {
+): AssistantFunctionCallMessageTypeModel {
   return {
     role: "assistant" as const,
     content: null,
-    toolCalls: [
+    functionCalls: [
       {
         id: action.id.toString(), // @todo Daph replace with the actual tool id
         type: "function",
@@ -63,9 +63,9 @@ export function renderAssistantToolCallMessageForTablesQueryAction(
     ],
   };
 }
-export function renderToolMessageForForTablesQueryAction(
+export function renderFunctionMessageForForTablesQueryAction(
   action: TablesQueryActionType
-): ToolMessageTypeModel {
+): FunctionMessageTypeModel {
   let content = "";
   if (!action.output) {
     throw new Error(
@@ -76,8 +76,8 @@ export function renderToolMessageForForTablesQueryAction(
   content += `${JSON.stringify(action.output, null, 2)}\n`;
 
   return {
-    role: "tool" as const,
-    toolCallId: action.id.toString(), // @todo Daph replace with the actual tool id
+    role: "function" as const,
+    functionCallId: action.id.toString(), // @todo Daph replace with the actual tool id
     content,
   };
 }

--- a/front/lib/api/assistant/actions/tables_query.ts
+++ b/front/lib/api/assistant/actions/tables_query.ts
@@ -51,14 +51,16 @@ export function renderAssistantFunctionCallMessageForTablesQueryAction(
   return {
     role: "assistant" as const,
     content: null,
-    function_call: {
-      id: action.id.toString(), // @todo Daph replace with the actual tool id
-      type: "function",
-      function: {
-        name: "query_tables",
-        arguments: JSON.stringify(action.params),
+    function_calls: [
+      {
+        id: action.id.toString(), // @todo Daph replace with the actual tool id
+        type: "function",
+        function: {
+          name: "query_tables",
+          arguments: JSON.stringify(action.params),
+        },
       },
-    },
+    ],
   };
 }
 export function renderFunctionMessageForForTablesQueryAction(

--- a/front/lib/api/assistant/actions/tables_query.ts
+++ b/front/lib/api/assistant/actions/tables_query.ts
@@ -51,16 +51,14 @@ export function renderAssistantFunctionCallMessageForTablesQueryAction(
   return {
     role: "assistant" as const,
     content: null,
-    functionCalls: [
-      {
-        id: action.id.toString(), // @todo Daph replace with the actual tool id
-        type: "function",
-        function: {
-          name: "query_tables",
-          arguments: JSON.stringify(action.params),
-        },
+    function_call: {
+      id: action.id.toString(), // @todo Daph replace with the actual tool id
+      type: "function",
+      function: {
+        name: "query_tables",
+        arguments: JSON.stringify(action.params),
       },
-    ],
+    },
   };
 }
 export function renderFunctionMessageForForTablesQueryAction(
@@ -77,7 +75,7 @@ export function renderFunctionMessageForForTablesQueryAction(
 
   return {
     role: "function" as const,
-    functionCallId: action.id.toString(), // @todo Daph replace with the actual tool id
+    function_call_id: action.id.toString(), // @todo Daph replace with the actual tool id
     content,
   };
 }

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -34,25 +34,25 @@ import moment from "moment-timezone";
 
 import { runActionStreamed } from "@app/lib/actions/server";
 import {
-  renderAssistantFunctionCallForDustAppRunAction,
   renderDustAppRunActionForModel,
-  renderFunctionMessageForForDustAppRunAction,
+  renderDustAppRunActionForMultiActionsModel,
+  renderDustAppRunActionFunctionCall,
 } from "@app/lib/api/assistant/actions/dust_app_run";
 import {
-  renderAssistantFunctionCallForProcessAction,
-  renderFunctionMessageForForProcessAction,
   renderProcessActionForModel,
+  renderProcessActionForMultiActionsModel,
+  renderProcessActionFunctionCall,
 } from "@app/lib/api/assistant/actions/process";
 import {
-  renderAssistantFunctionCallForRetrievalAction,
-  renderFunctionMessageForRetrievalAction,
+  rendeRetrievalActionFunctionCall,
   renderRetrievalActionForModel,
+  renderRetrievalActionForMultiActionsModel,
   retrievalMetaPrompt,
 } from "@app/lib/api/assistant/actions/retrieval";
 import {
-  renderAssistantFunctionCallForTablesQueryAction,
-  renderFunctionMessageForForTablesQueryAction,
   renderTablesQueryActionForModel,
+  renderTablesQueryActionForMultiActionsModel,
+  rendeTablesQueryActionFunctionCall,
 } from "@app/lib/api/assistant/actions/tables_query";
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
 import { getSupportedModelConfig, isLargeModel } from "@app/lib/assistant";
@@ -315,32 +315,24 @@ export async function renderConversationForModelMultiActions({
       for (const action of actions) {
         if (isRetrievalActionType(action)) {
           function_messages.unshift(
-            renderFunctionMessageForRetrievalAction(action)
+            renderRetrievalActionForMultiActionsModel(action)
           );
-          function_calls.unshift(
-            renderAssistantFunctionCallForRetrievalAction(action)
-          );
+          function_calls.unshift(rendeRetrievalActionFunctionCall(action));
         } else if (isDustAppRunActionType(action)) {
           function_messages.unshift(
-            renderFunctionMessageForForDustAppRunAction(action)
+            renderDustAppRunActionForMultiActionsModel(action)
           );
-          function_calls.unshift(
-            renderAssistantFunctionCallForDustAppRunAction(action)
-          );
+          function_calls.unshift(renderDustAppRunActionFunctionCall(action));
         } else if (isTablesQueryActionType(action)) {
           function_messages.unshift(
-            renderFunctionMessageForForTablesQueryAction(action)
+            renderTablesQueryActionForMultiActionsModel(action)
           );
-          function_calls.unshift(
-            renderAssistantFunctionCallForTablesQueryAction(action)
-          );
+          function_calls.unshift(rendeTablesQueryActionFunctionCall(action));
         } else if (isProcessActionType(action)) {
           function_messages.unshift(
-            renderFunctionMessageForForProcessAction(action)
+            renderProcessActionForMultiActionsModel(action)
           );
-          function_calls.unshift(
-            renderAssistantFunctionCallForProcessAction(action)
-          );
+          function_calls.unshift(renderProcessActionFunctionCall(action));
         } else {
           assertNever(action);
         }

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -386,7 +386,13 @@ export async function renderConversationForModelMultiActions({
   const [messagesCountRes, promptCountRes] = await Promise.all([
     Promise.all(
       messages.map((m) => {
-        return tokenCountForText(JSON.stringify(m), model); // todo optimise this instead of stringify
+        let text = `${m.role} ${"name" in m ? m.name : ""} ${m.content ?? ""}`;
+        if ("function_calls" in m) {
+          text += m.function_calls
+            .map((f) => `${f.function.name} ${f.function.arguments}`)
+            .join(" ");
+        }
+        return tokenCountForText(text, model);
       })
     ),
     tokenCountForText(prompt, model),

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -33,25 +33,25 @@ import moment from "moment-timezone";
 
 import { runActionStreamed } from "@app/lib/actions/server";
 import {
-  renderAssistantToolCallMessageForDustAppRunAction,
+  renderAssistantFunctionCallMessageForDustAppRunAction,
   renderDustAppRunActionForModel,
-  renderToolMessageForForDustAppRunAction,
+  renderFunctionMessageForForDustAppRunAction,
 } from "@app/lib/api/assistant/actions/dust_app_run";
 import {
-  renderAssistantToolCallMessageForProcessAction,
+  renderAssistantFunctionCallMessageForProcessAction,
+  renderFunctionMessageForForProcessAction,
   renderProcessActionForModel,
-  renderToolMessageForForProcessAction,
 } from "@app/lib/api/assistant/actions/process";
 import {
-  renderAssistantToolCallMessageForRetrievalAction,
+  renderAssistantFunctionCallMessageForRetrievalAction,
+  renderFunctionMessageForRetrievalAction,
   renderRetrievalActionForModel,
-  renderToolMessageForRetrievalAction,
   retrievalMetaPrompt,
 } from "@app/lib/api/assistant/actions/retrieval";
 import {
-  renderAssistantToolCallMessageForTablesQueryAction,
+  renderAssistantFunctionCallMessageForTablesQueryAction,
+  renderFunctionMessageForForTablesQueryAction,
   renderTablesQueryActionForModel,
-  renderToolMessageForForTablesQueryAction,
 } from "@app/lib/api/assistant/actions/tables_query";
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
 import { getSupportedModelConfig, isLargeModel } from "@app/lib/assistant";
@@ -308,24 +308,28 @@ export async function renderConversationForModelMultiActions({
       }
       if (m.action) {
         if (isRetrievalActionType(m.action)) {
-          messages.unshift(renderToolMessageForRetrievalAction(m.action));
+          messages.unshift(renderFunctionMessageForRetrievalAction(m.action));
           messages.unshift(
-            renderAssistantToolCallMessageForRetrievalAction(m.action)
+            renderAssistantFunctionCallMessageForRetrievalAction(m.action)
           );
         } else if (isDustAppRunActionType(m.action)) {
-          messages.unshift(renderToolMessageForForDustAppRunAction(m.action));
           messages.unshift(
-            renderAssistantToolCallMessageForDustAppRunAction(m.action)
+            renderFunctionMessageForForDustAppRunAction(m.action)
+          );
+          messages.unshift(
+            renderAssistantFunctionCallMessageForDustAppRunAction(m.action)
           );
         } else if (isTablesQueryActionType(m.action)) {
-          messages.unshift(renderToolMessageForForTablesQueryAction(m.action));
           messages.unshift(
-            renderAssistantToolCallMessageForTablesQueryAction(m.action)
+            renderFunctionMessageForForTablesQueryAction(m.action)
+          );
+          messages.unshift(
+            renderAssistantFunctionCallMessageForTablesQueryAction(m.action)
           );
         } else if (isProcessActionType(m.action)) {
-          messages.unshift(renderToolMessageForForProcessAction(m.action));
+          messages.unshift(renderFunctionMessageForForProcessAction(m.action));
           messages.unshift(
-            renderAssistantToolCallMessageForProcessAction(m.action)
+            renderAssistantFunctionCallMessageForProcessAction(m.action)
           );
         } else {
           assertNever(m.action);

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -378,18 +378,15 @@ export async function renderConversationForModelMultiActions({
         return new Err(new Error("Failed to retrieve content fragment text"));
       }
     } else {
-      ((x: never) => {
-        throw new Error(`Unexpected message type: ${x}`);
-      })(m);
+      assertNever(m);
     }
   }
 
   // Compute in parallel the token count for each message and the prompt.
   const [messagesCountRes, promptCountRes] = await Promise.all([
-    // This is a bit aggressive but fuck it.
     Promise.all(
       messages.map((m) => {
-        return tokenCountForText(JSON.stringify(m), model);
+        return tokenCountForText(JSON.stringify(m), model); // todo optimise this instead of stringify
       })
     ),
     tokenCountForText(prompt, model),

--- a/types/src/front/lib/api/assistant/generation.ts
+++ b/types/src/front/lib/api/assistant/generation.ts
@@ -27,14 +27,14 @@ export type UserMessageTypeModel = {
 export type AssistantFunctionCallMessageTypeModel = {
   role: "assistant";
   content: string | null;
-  functionCalls: {
+  function_call: {
     id: string;
     type: "function";
     function: {
       name: string;
       arguments: string;
     };
-  }[];
+  };
 };
 export type AssistantContentMessageTypeModel = {
   role: "assistant";
@@ -44,7 +44,7 @@ export type AssistantContentMessageTypeModel = {
 
 export type FunctionMessageTypeModel = {
   role: "function";
-  functionCallId: string;
+  function_call_id: string;
   content: string;
 };
 

--- a/types/src/front/lib/api/assistant/generation.ts
+++ b/types/src/front/lib/api/assistant/generation.ts
@@ -24,10 +24,10 @@ export type UserMessageTypeModel = {
   content: string;
 };
 
-export type AssistantToolCallMessageTypeModel = {
+export type AssistantFunctionCallMessageTypeModel = {
   role: "assistant";
   content: string | null;
-  toolCalls: {
+  functionCalls: {
     id: string;
     type: "function";
     function: {
@@ -42,18 +42,18 @@ export type AssistantContentMessageTypeModel = {
   content: string;
 };
 
-export type ToolMessageTypeModel = {
-  role: "tool";
-  toolCallId: string;
+export type FunctionMessageTypeModel = {
+  role: "function";
+  functionCallId: string;
   content: string;
 };
 
 export type ModelMessageTypeMultiActions =
   | ContentFragmentMessageTypeModel
   | UserMessageTypeModel
-  | AssistantToolCallMessageTypeModel
+  | AssistantFunctionCallMessageTypeModel
   | AssistantContentMessageTypeModel
-  | ToolMessageTypeModel;
+  | FunctionMessageTypeModel;
 
 export type ModelConversationTypeMultiActions = {
   messages: ModelMessageTypeMultiActions[];

--- a/types/src/front/lib/api/assistant/generation.ts
+++ b/types/src/front/lib/api/assistant/generation.ts
@@ -24,17 +24,19 @@ export type UserMessageTypeModel = {
   content: string;
 };
 
+export type FunctionCallType = {
+  id: string;
+  type: "function";
+  function: {
+    name: string;
+    arguments: string;
+  };
+};
+
 export type AssistantFunctionCallMessageTypeModel = {
   role: "assistant";
   content: string | null;
-  function_calls: {
-    id: string;
-    type: "function";
-    function: {
-      name: string;
-      arguments: string;
-    };
-  }[];
+  function_calls: FunctionCallType[];
 };
 export type AssistantContentMessageTypeModel = {
   role: "assistant";

--- a/types/src/front/lib/api/assistant/generation.ts
+++ b/types/src/front/lib/api/assistant/generation.ts
@@ -12,6 +12,53 @@ export type ModelConversationType = {
   messages: ModelMessageType[];
 };
 
+export type ContentFragmentMessageTypeModel = {
+  role: "content_fragment";
+  name: string;
+  content: string;
+};
+
+export type UserMessageTypeModel = {
+  role: "user";
+  name: string;
+  content: string;
+};
+
+export type AssistantToolCallMessageTypeModel = {
+  role: "assistant";
+  content: string | null;
+  toolCalls: {
+    id: string;
+    type: "function";
+    function: {
+      name: string;
+      arguments: string;
+    };
+  }[];
+};
+export type AssistantContentMessageTypeModel = {
+  role: "assistant";
+  name: string;
+  content: string;
+};
+
+export type ToolMessageTypeModel = {
+  role: "tool";
+  toolCallId: string;
+  content: string;
+};
+
+export type ModelMessageTypeMultiActions =
+  | ContentFragmentMessageTypeModel
+  | UserMessageTypeModel
+  | AssistantToolCallMessageTypeModel
+  | AssistantContentMessageTypeModel
+  | ToolMessageTypeModel;
+
+export type ModelConversationTypeMultiActions = {
+  messages: ModelMessageTypeMultiActions[];
+};
+
 /**
  * Generation execution.
  */

--- a/types/src/front/lib/api/assistant/generation.ts
+++ b/types/src/front/lib/api/assistant/generation.ts
@@ -27,14 +27,14 @@ export type UserMessageTypeModel = {
 export type AssistantFunctionCallMessageTypeModel = {
   role: "assistant";
   content: string | null;
-  function_call: {
+  function_calls: {
     id: string;
     type: "function";
     function: {
       name: string;
       arguments: string;
     };
-  };
+  }[];
 };
 export type AssistantContentMessageTypeModel = {
   role: "assistant";


### PR DESCRIPTION
## Description

Implements a `renderConversationForModelMultiActions`. Not called yet from `getNextAction`.
For convenience it's implemented with a simple cli command. 

```
./admin/cli.sh conversation render-for-model --wId=7ea8c3d99c --cId=b0050ddc00
```

Result: 
```json
{
 "modelConversation": {
      "messages": [
        {
          "role": "user",
          "name": "Daphné Popin",
          "content": "\n@dust is Soupinou cute?"
        },
        {
          "role": "assistant",
          "content": null,
          "function_call": {
            "id": "81",
            "type": "function",
            "function": {
              "name": "search_data_sources",
              "arguments": "{\"query\":\"Soupinou cute\",\"relativeTimeFrame\":\"all\",\"topK\":32}"
            }
          }
        },
        {
          "role": "function",
          "function_call_id": "81",
          "content": "TITLE: team_office-thread-2024-04-12_07h56 (data source: slack)\nREFERENCE: j1\nEXTRACTS:\n$title: Thread in #team_office: I have to leave at 5pm today (and I just arrived at the office), Soupinou is sic..."
        },
        {
          "role": "assistant",
          "name": "dust",
          "content": "Yes, Soupinou is considered cute. In a Slack thread, you referred to Soupinou as \"the cutest cat in the world\" :cite[b5]."
        }
      ]
    }
    "tokensUsed": 13124
}
```


## Risk

Not called from the product yet so not risky and rollbackable. 

## Deploy Plan

Deploy front. 
