### PR TITLE
[Assistant Builder] Instructions suggestion tweak

### DIFF
--- a/front/components/assistant_builder/InstructionScreen.tsx
+++ b/front/components/assistant_builder/InstructionScreen.tsx
@@ -370,10 +370,17 @@ function Suggestions({
 
     const updateSuggestions = async () => {
       setSuggestionsStatus("loading");
+      // suggestions that are shown by default when no instructions are typed,
+      // are not considered as former suggestions. This way, the model will
+      // always generate tailored suggestions on the first input, which is preferable:
+      // - the user is more likely to be interested (since they likely saw the static suggestions before)
+      // - the model is not biased by static suggestions to generate new ones.
+      const formerSuggestions =
+        suggestions === STATIC_SUGGESTIONS ? [] : suggestions.slice(0, 2);
       const updatedSuggestions = await getRankedSuggestions({
         owner,
         currentInstructions: instructions,
-        formerSuggestions: suggestions.slice(0, 2),
+        formerSuggestions,
       });
       if (updatedSuggestions.isErr()) {
         setError(updatedSuggestions.error);


### PR DESCRIPTION
Description
---
When the user creates a new assistant from scratch, static suggestions are shown (a.k.a. default suggestions when no instructions are typed).

Formerly, the model, when generating new suggestions, checked whether they were better that those "default suggestions". This caused multiple issues, notably biased the model to generate suggestions close to the static suggestions (which are always the same 2 suggestions).

Now, static suggestions
are not considered as former suggestions. This way, the model will always generate tailored suggestions on the first input, which is preferable:
- they will be more interesting to the user in 99.9% cases (since they likely saw the static suggestions before, they want new stuff + the static suggestions are still available via horizontal scrolling)
- the model is not biased by static suggestions to generate new ones.

Risk
---
Very low (1 line code, low blast radius)

