### PR TITLE
DustAppRun: do not throw on null output

### DIFF
--- a/front/lib/api/assistant/actions/dust_app_run.ts
+++ b/front/lib/api/assistant/actions/dust_app_run.ts
@@ -35,11 +35,8 @@ export function renderDustAppRunActionForModel(
   action: DustAppRunActionType
 ): ModelMessageType {
   let content = "";
-  if (!action.output) {
-    throw new Error(
-      "Output not set on DustAppRun action; execution is likely not finished."
-    );
-  }
+
+  // Note action.output can be any valid JSON including null.
   content += `OUTPUT:\n`;
   content += `${JSON.stringify(action.output, null, 2)}\n`;
 


### PR DESCRIPTION
## Description

A Dust app can return `null` which leads to a throw and hence a stream drop error

## Risk

N/A

## Deploy Plan

- deploy `front`