### PR TITLE
Call sites + migration of AgentMessage <> TableQueryAction from 1-1 to 1-N

### DIFF
--- a/front/lib/models/assistant/actions/tables_query.ts
+++ b/front/lib/models/assistant/actions/tables_query.ts
@@ -168,7 +168,7 @@ export class AgentTablesQueryAction extends Model<
 
   declare params: unknown | null;
   declare output: unknown | null;
-  declare agentMessageId: ForeignKey<AgentMessage["id"]> | null;
+  declare agentMessageId: ForeignKey<AgentMessage["id"]>;
 }
 
 AgentTablesQueryAction.init(

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -355,12 +355,12 @@ AgentMessage.hasMany(AgentDustAppRunAction, {
 
 AgentTablesQueryAction.belongsTo(AgentMessage, {
   // allow null for now until we proceed to the backfill.
-  foreignKey: { name: "agentMessageId", allowNull: true },
+  foreignKey: { name: "agentMessageId", allowNull: false },
 });
 
 AgentMessage.hasMany(AgentTablesQueryAction, {
   // allow null for now until we proceed to the backfill.
-  foreignKey: { name: "agentMessageId", allowNull: true },
+  foreignKey: { name: "agentMessageId", allowNull: false },
 });
 
 // END TO BE MOVED

--- a/front/migrations/20240503_backfill_table_query_actions_agent_message_id.ts
+++ b/front/migrations/20240503_backfill_table_query_actions_agent_message_id.ts
@@ -1,0 +1,75 @@
+import type { ModelId } from "@dust-tt/types";
+import { QueryTypes } from "sequelize";
+
+import { AgentTablesQueryAction } from "@app/lib/models/assistant/actions/tables_query";
+import { AgentMessage } from "@app/lib/models/assistant/conversation";
+import { frontSequelize } from "@app/lib/resources/storage";
+import logger from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+
+const backfillTableQueryActions = async (execute: boolean) => {
+  let actions: AgentTablesQueryAction[] = [];
+  actions = await AgentTablesQueryAction.findAll({
+    // @ts-expect-error agentMessageId became null during this PR. But the migration still has to run to
+    // effectively update the agentMessageId.
+    where: {
+      agentMessageId: null,
+    },
+  });
+  logger.info(
+    {
+      count: actions.length,
+    },
+    "Processing actions for backfilling agentMessageId"
+  );
+  for (const action of actions) {
+    const agentMessage = await AgentMessage.findOne({
+      where: {
+        agentTablesQueryActionId: action.id,
+      },
+    });
+    if (agentMessage) {
+      if (execute) {
+        await action.update({
+          agentMessageId: agentMessage.id,
+        });
+        logger.info({ actionId: action.id }, "Updated agentMessageId");
+      } else {
+        logger.info({ actionId: action.id }, "*Would* update agentMessageId");
+      }
+    } else {
+      logger.warn({ actionId: action.id }, "AgentMessage not found");
+    }
+  }
+
+  // checking that all pairs are correct
+  const errors: { id: ModelId }[] = await frontSequelize.query(
+    `
+    SELECT
+    *
+  FROM
+    agent_messages am
+    INNER JOIN agent_tables_query_actions atqa ON (am."agentTablesQueryActionId" = atqa.id)
+  WHERE
+    (
+      am.id <> atqa."agentMessageId"
+      OR atqa."agentMessageId" IS NULL
+    );
+  `,
+    {
+      type: QueryTypes.SELECT,
+    }
+  );
+  if (errors.length > 0) {
+    logger.error(
+      { count: errors.length },
+      "AgentMessageId not updated correctly"
+    );
+  } else {
+    logger.info("No error found");
+  }
+};
+
+makeScript({}, async ({ execute }) => {
+  await backfillTableQueryActions(execute);
+});

--- a/types/src/front/assistant/actions/tables_query.ts
+++ b/types/src/front/assistant/actions/tables_query.ts
@@ -22,4 +22,5 @@ export type TablesQueryActionType = {
 
   params: DustAppParameters;
   output: Record<string, string | number | boolean> | null;
+  agentMessageId: ModelId;
 };


### PR DESCRIPTION
## Description


This PR contains:
- Read sites of the new field `AgentTableQueryAction.agentMessageId`
- Migration to backfill all the `AgentTableQueryAction.agentMessageId`
- `AgentTableQueryAction.agentMessageId` becomes non nullable

We are still writing to both `AgentMessage` and `AgentTableQueryAction`


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk
Not risky because we are not deleting the `AgentMessage.agentTableQueryActionId` yet

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
- Deploy prod box
- Run the migration `front> npx tsx ./migrations/20240503_backfill_table_query_actions_agent_message_id.ts`
- `front>./admin/init_db.sh`
- Deploy front


<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
