### PR TITLE
Adding 2 minutes of leeway for the webcrawler activity to heartbeat

### DIFF
--- a/connectors/src/connectors/webcrawler/temporal/workflows.ts
+++ b/connectors/src/connectors/webcrawler/temporal/workflows.ts
@@ -19,7 +19,7 @@ const { crawlWebsiteByConnectorId, webCrawlerGarbageCollector } =
     startToCloseTimeout: "120 minutes",
     // for each page crawl, there are heartbeats, but a page crawl can last at max
     // REQUEST_HANDLING_TIMEOUT seconds
-    heartbeatTimeout: `${(REQUEST_HANDLING_TIMEOUT + 120)} seconds`,
+    heartbeatTimeout: `${REQUEST_HANDLING_TIMEOUT + 120} seconds`,
     cancellationType: ActivityCancellationType.TRY_CANCEL,
     retry: {
       initialInterval: `${REQUEST_HANDLING_TIMEOUT * 2} seconds`,

--- a/connectors/src/connectors/webcrawler/temporal/workflows.ts
+++ b/connectors/src/connectors/webcrawler/temporal/workflows.ts
@@ -19,7 +19,7 @@ const { crawlWebsiteByConnectorId, webCrawlerGarbageCollector } =
     startToCloseTimeout: "120 minutes",
     // for each page crawl, there are heartbeats, but a page crawl can last at max
     // REQUEST_HANDLING_TIMEOUT seconds
-    heartbeatTimeout: `${REQUEST_HANDLING_TIMEOUT} seconds`,
+    heartbeatTimeout: `${(REQUEST_HANDLING_TIMEOUT + 120)} seconds`,
     cancellationType: ActivityCancellationType.TRY_CANCEL,
     retry: {
       initialInterval: `${REQUEST_HANDLING_TIMEOUT * 2} seconds`,


### PR DESCRIPTION
## Description

Adding 2 minutes of leeway for the webcrawler activity to heartbeat. Today, webcrawler document processing and heartbeat timeout are the same, leading to potential activity failure.

2 minutes might a lot but lets check if it works first, and we can lower it after.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
