### PR TITLE
Add AssistantPreview variant

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.152",
+  "version": "0.2.153",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.152",
+      "version": "0.2.153",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.151",
+  "version": "0.2.152",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.151",
+      "version": "0.2.152",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.151",
+  "version": "0.2.152",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.152",
+  "version": "0.2.159",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.159",
+  "version": "0.2.150",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/components/AssistantPreview.tsx
+++ b/sparkle/src/components/AssistantPreview.tsx
@@ -17,7 +17,7 @@ interface BaseAssistantPreviewProps {
 
 type ItemVariantAssistantPreviewProps = BaseAssistantPreviewProps & {
   variant: "item";
-  actions?: React.ReactNode;
+  actions: React.ReactNode;
 };
 
 type ListVariantAssistantPreviewProps = BaseAssistantPreviewProps & {

--- a/sparkle/src/components/AssistantPreview.tsx
+++ b/sparkle/src/components/AssistantPreview.tsx
@@ -4,7 +4,7 @@ import { Button, CardButton, MoreIcon, PlayIcon } from "@sparkle/_index";
 import { Avatar } from "@sparkle/components/Avatar";
 import { classNames } from "@sparkle/lib/utils";
 
-type AssistantPreviewVariant = "item" | "list" | "gallery" | "minimalGallery";
+type AssistantPreviewVariant = "item" | "list" | "gallery" | "minimal";
 
 interface BaseAssistantPreviewProps {
   variant: AssistantPreviewVariant;
@@ -30,8 +30,8 @@ type GalleryVariantAssistantPreviewProps = BaseAssistantPreviewProps & {
   onPlayClick?: (e: SyntheticEvent) => void;
 };
 
-type MinimalGalleryVariantAssistantPreviewProps = BaseAssistantPreviewProps & {
-  variant: "minimalGallery";
+type MinimalVariantAssistantPreviewProps = BaseAssistantPreviewProps & {
+  variant: "minimal";
   hasAction?: boolean;
   href?: string;
   onClick?: () => void;
@@ -42,7 +42,7 @@ type AssistantPreviewProps =
   | ItemVariantAssistantPreviewProps
   | ListVariantAssistantPreviewProps
   | GalleryVariantAssistantPreviewProps
-  | MinimalGalleryVariantAssistantPreviewProps;
+  | MinimalVariantAssistantPreviewProps;
 
 const isBrowser = typeof window !== "undefined";
 
@@ -61,7 +61,7 @@ const titleClassNames = {
   item: "s-text-sm",
   list: "s-text-base",
   gallery: "s-text-lg",
-  minimalGallery: `s-overflow-hidden s-whitespace-nowrap ${
+  minimal: `s-overflow-hidden s-whitespace-nowrap ${
     getWindowWidth() <= breakpoints.sm
       ? "s-text-sm"
       : getWindowWidth() <= breakpoints.md
@@ -75,7 +75,7 @@ const subtitleClassNames = {
   item: "s-text-xs",
   list: "s-text-sm",
   gallery: "s-text-sm",
-  minimalGallery: `s-overflow-hidden s-whitespace-nowrap ${
+  minimal: `s-overflow-hidden s-whitespace-nowrap ${
     getWindowWidth() <= breakpoints.sm
       ? "s-text-xs"
       : getWindowWidth() <= breakpoints.md
@@ -101,8 +101,8 @@ function renderVariantContent(
       return <ListVariantContent {...props} />;
     case "gallery":
       return <GalleryVariantContent {...props} />;
-    case "minimalGallery":
-      return <MinimalGalleryVariantContent {...props} />;
+    case "minimal":
+      return <MinimalVariantContent {...props} />;
     default:
       return <></>;
   }
@@ -258,14 +258,14 @@ const GalleryVariantContent = ({
   );
 };
 
-const MinimalGalleryVariantContent = ({
+const MinimalVariantContent = ({
   title,
   pictureUrl,
   subtitle,
   hasAction = true,
   onClick,
   onActionClick,
-}: MinimalGalleryVariantAssistantPreviewProps) => {
+}: MinimalVariantAssistantPreviewProps) => {
   const actionButton = (
     <Button
       label=""
@@ -303,7 +303,7 @@ const MinimalGalleryVariantContent = ({
             <div
               className={classNames(
                 titleClassNames["base"],
-                titleClassNames.minimalGallery
+                titleClassNames.minimal
               )}
             >
               @{title}
@@ -311,7 +311,7 @@ const MinimalGalleryVariantContent = ({
             <div
               className={classNames(
                 subtitleClassNames["base"],
-                subtitleClassNames.minimalGallery
+                subtitleClassNames.minimal
               )}
             >
               By: {subtitle}
@@ -335,7 +335,7 @@ export function AssistantPreview(props: AssistantPreviewProps) {
     <CardButton
       variant="tertiary"
       className={classNames("s-flex s-flex-col s-gap-2 s-border")}
-      size={variant === "item" || variant === "minimalGallery" ? "sm" : "lg"}
+      size={variant === "item" || variant === "minimal" ? "sm" : "lg"}
       onClick={onClick}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}

--- a/sparkle/src/components/AssistantPreview.tsx
+++ b/sparkle/src/components/AssistantPreview.tsx
@@ -1,10 +1,10 @@
 import React, { SyntheticEvent, useState } from "react";
 
-import { Button, CardButton, PlayIcon } from "@sparkle/_index";
+import { Button, CardButton, MoreIcon, PlayIcon } from "@sparkle/_index";
 import { Avatar } from "@sparkle/components/Avatar";
 import { classNames } from "@sparkle/lib/utils";
 
-type AssistantPreviewVariant = "item" | "list" | "gallery";
+type AssistantPreviewVariant = "item" | "list" | "gallery" | "minimalGallery";
 
 interface BaseAssistantPreviewProps {
   variant: AssistantPreviewVariant;
@@ -17,7 +17,7 @@ interface BaseAssistantPreviewProps {
 
 type ItemVariantAssistantPreviewProps = BaseAssistantPreviewProps & {
   variant: "item";
-  actions: React.ReactNode;
+  actions?: React.ReactNode;
 };
 
 type ListVariantAssistantPreviewProps = BaseAssistantPreviewProps & {
@@ -30,23 +30,61 @@ type GalleryVariantAssistantPreviewProps = BaseAssistantPreviewProps & {
   onPlayClick?: (e: SyntheticEvent) => void;
 };
 
+type MinimalGalleryVariantAssistantPreviewProps = BaseAssistantPreviewProps & {
+  variant: "minimalGallery";
+  hasAction?: boolean;
+  href?: string;
+  onClick?: () => void;
+  onActionClick?: () => void;
+  renderActionButton?: (button: React.ReactNode) => React.ReactNode;
+};
+
 type AssistantPreviewProps =
   | ItemVariantAssistantPreviewProps
   | ListVariantAssistantPreviewProps
-  | GalleryVariantAssistantPreviewProps;
+  | GalleryVariantAssistantPreviewProps
+  | MinimalGalleryVariantAssistantPreviewProps;
+
+const isBrowser = typeof window !== "undefined";
+
+const breakpoints = {
+  sm: 640, // Tailwind's default for `sm`
+  md: 768, // Tailwind's default for `md`
+  lg: 1024, // Tailwind's default for `lg`
+  xl: 1280, // Tailwind's default for `xl`
+  xxl: 1536, // Tailwind's default for `2xl`
+};
+
+const getWindowWidth = () => (isBrowser ? window.innerWidth : 0);
 
 const titleClassNames = {
   base: "s-truncate s-font-medium s-text-element-900 s-w-full",
   item: "s-text-sm",
   list: "s-text-base",
   gallery: "s-text-lg",
+  minimalGallery: `s-overflow-hidden s-whitespace-nowrap ${
+    getWindowWidth() <= breakpoints.sm
+      ? "s-text-sm"
+      : getWindowWidth() <= breakpoints.md
+      ? "s-text-base"
+      : ""
+  }`,
 };
+
 const subtitleClassNames = {
   base: "s-font-normal s-text-element-700 s-truncate s-w-full",
   item: "s-text-xs",
   list: "s-text-sm",
   gallery: "s-text-sm",
+  minimalGallery: `s-overflow-hidden s-whitespace-nowrap ${
+    getWindowWidth() <= breakpoints.sm
+      ? "s-text-xs"
+      : getWindowWidth() <= breakpoints.md
+      ? "s-text-sm"
+      : ""
+  }`,
 };
+
 const descriptionClassNames = {
   base: "s-font-normal s-mb-1",
   item: "s-text-xs s-text-element-700 s-pl-1 s-line-clamp-3",
@@ -64,6 +102,8 @@ function renderVariantContent(
       return <ListVariantContent {...props} />;
     case "gallery":
       return <GalleryVariantContent {...props} />;
+    case "minimalGallery":
+      return <MinimalGalleryVariantContent {...props} />;
     default:
       return <></>;
   }
@@ -219,6 +259,74 @@ const GalleryVariantContent = ({
   );
 };
 
+const MinimalGalleryVariantContent = ({
+  title,
+  pictureUrl,
+  subtitle,
+  hasAction = true,
+  onClick,
+  onActionClick,
+}: MinimalGalleryVariantAssistantPreviewProps) => {
+  const actionButton = (
+    <Button
+      label=""
+      icon={MoreIcon}
+      variant="tertiary"
+      size="sm"
+      labelVisible={false}
+      hasMagnifying={false}
+      disabledTooltip={true}
+      onClick={(e) => {
+        e.stopPropagation();
+        onActionClick?.();
+      }}
+    />
+  );
+
+  return (
+    <>
+      <div
+        id="assistant-container"
+        className="s-flex s-grow s-flex-row s-justify-between s-gap-2 s-overflow-hidden s-py-1"
+        onClick={onClick}
+      >
+        <div
+          id="preview"
+          className="s-flex s-w-full s-min-w-0 s-flex-row s-items-center s-gap-2"
+        >
+          <div id="avatar-column" className="s-w-fit">
+            <Avatar name={`Avatar of ${title}`} visual={pictureUrl} size="md" />
+          </div>
+          <div
+            id="details-column"
+            className="s-flex s-w-full s-min-w-0 s-flex-col s-items-start s-gap-0 s-overflow-hidden"
+          >
+            <div
+              className={classNames(
+                titleClassNames["base"],
+                titleClassNames.minimalGallery
+              )}
+            >
+              @{title}
+            </div>
+            <div
+              className={classNames(
+                subtitleClassNames["base"],
+                subtitleClassNames.minimalGallery
+              )}
+            >
+              By: {subtitle}
+            </div>
+          </div>
+        </div>
+        <div id="actions-column" className="s-flex s-w-fit s-shrink-0">
+          {hasAction && actionButton}
+        </div>
+      </div>
+    </>
+  );
+};
+
 export function AssistantPreview(props: AssistantPreviewProps) {
   const { onClick, variant } = props;
   // State to manage the visibility of the play button
@@ -228,7 +336,7 @@ export function AssistantPreview(props: AssistantPreviewProps) {
     <CardButton
       variant="tertiary"
       className={classNames("s-flex s-flex-col s-gap-2 s-border")}
-      size={variant === "item" ? "sm" : "lg"}
+      size={variant === "item" || variant === "minimalGallery" ? "sm" : "lg"}
       onClick={onClick}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}

--- a/sparkle/src/components/AssistantPreview.tsx
+++ b/sparkle/src/components/AssistantPreview.tsx
@@ -36,7 +36,6 @@ type MinimalGalleryVariantAssistantPreviewProps = BaseAssistantPreviewProps & {
   href?: string;
   onClick?: () => void;
   onActionClick?: () => void;
-  renderActionButton?: (button: React.ReactNode) => React.ReactNode;
 };
 
 type AssistantPreviewProps =

--- a/sparkle/src/stories/AssistantPreview.stories.tsx
+++ b/sparkle/src/stories/AssistantPreview.stories.tsx
@@ -202,7 +202,7 @@ export const AssistantPreviewExample = () => (
         }}
       />
     </div>
-    <h2>Minimal Gallery</h2>
+    <h2>Minimal</h2>
     <div className="s-grid s-w-full s-grid-cols-2 s-gap-2 md:s-grid-cols-3">
       <div className="s-rounded-xl s-border s-border-structure-100">
         <AssistantPreview
@@ -212,7 +212,7 @@ export const AssistantPreviewExample = () => (
           }
           subtitle={"Dust"}
           description=""
-          variant="minimalGallery"
+          variant="minimal"
           onClick={() => console.log("AssistantPreview clicked")}
           onActionClick={() => console.log("Action clicked")}
         />
@@ -223,7 +223,7 @@ export const AssistantPreviewExample = () => (
           pictureUrl={"https://dust.tt/static/droidavatar/Droid_Green_2.jpg"}
           subtitle={"Dust"}
           description=""
-          variant="minimalGallery"
+          variant="minimal"
           onClick={() => console.log("AssistantPreview clicked")}
           onActionClick={() => console.log("Action clicked")}
         />
@@ -234,7 +234,7 @@ export const AssistantPreviewExample = () => (
           pictureUrl={"https://dust.tt/static/droidavatar/Droid_Yellow_2.jpg"}
           subtitle={"Dust"}
           description=""
-          variant="minimalGallery"
+          variant="minimal"
           onClick={() => console.log("AssistantPreview clicked")}
           onActionClick={() => console.log("Action clicked")}
         />

--- a/sparkle/src/stories/AssistantPreview.stories.tsx
+++ b/sparkle/src/stories/AssistantPreview.stories.tsx
@@ -202,5 +202,43 @@ export const AssistantPreviewExample = () => (
         }}
       />
     </div>
+    <h2>Minimal Gallery</h2>
+    <div className="s-grid s-w-full s-grid-cols-2 s-gap-2 md:s-grid-cols-3">
+      <div className="s-rounded-xl s-border s-border-structure-100">
+        <AssistantPreview
+          title={"gpt4-turbo"}
+          pictureUrl={
+            "https://dust.tt/static/systemavatar/gpt4_avatar_full.png"
+          }
+          subtitle={"Dust"}
+          description=""
+          variant="minimalGallery"
+          onClick={() => console.log("AssistantPreview clicked")}
+          onActionClick={() => console.log("Action clicked")}
+        />
+      </div>
+      <div className="s-rounded-xl s-border s-border-structure-100">
+        <AssistantPreview
+          title={"SQLGod"}
+          pictureUrl={"https://dust.tt/static/droidavatar/Droid_Green_2.jpg"}
+          subtitle={"Dust"}
+          description=""
+          variant="minimalGallery"
+          onClick={() => console.log("AssistantPreview clicked")}
+          onActionClick={() => console.log("Action clicked")}
+        />
+      </div>
+      <div className="s-rounded-xl s-border s-border-structure-100">
+        <AssistantPreview
+          title={"salesfr"}
+          pictureUrl={"https://dust.tt/static/droidavatar/Droid_Yellow_2.jpg"}
+          subtitle={"Dust"}
+          description=""
+          variant="minimalGallery"
+          onClick={() => console.log("AssistantPreview clicked")}
+          onActionClick={() => console.log("Action clicked")}
+        />
+      </div>
+    </div>
   </div>
 );


### PR DESCRIPTION
## Description
Relates to #4948 
![CleanShot 2024-05-06 at 15 57 32@2x](https://github.com/dust-tt/dust/assets/1516447/b2c2022c-eda2-4809-9a62-1cca12f0f0d8)

- Creates a new MinimalGallery variant for the AssistantPreview component, to be used in the assistant/new page
## Risk

## Deploy Plan
- Should be deployed before #4948 
