### PR TITLE
Confluence error handling: catch fetch aborts

### DIFF
--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -164,7 +164,10 @@ export class ConfluenceClient {
           signal: AbortSignal.timeout(30000),
         });
       } catch (e) {
-        if (e instanceof DOMException && e.name === "TimeoutError") {
+        if (
+          e instanceof DOMException &&
+          (e.name === "TimeoutError" || e.name === "AbortError")
+        ) {
           throw new ConfluenceClientError("Request timed out", {
             type: "http_response_error",
             status: 504,


### PR DESCRIPTION
Description
---
Those errors occur on the confluence connector when fetch is aborted. Apparently a timeout can cause either an "AbortError" or a "TimeoutError"

https://github.com/nodejs/node/issues/43874

Risk & deploy NTR
