### PR TITLE
Add isProPlan function to allow having multiple pro plan codes

### DIFF
--- a/front/components/poke/subscriptions/table.tsx
+++ b/front/components/poke/subscriptions/table.tsx
@@ -29,7 +29,7 @@ import { makeColumnsForSubscriptions } from "@app/components/poke/subscriptions/
 import EnterpriseUpgradeDialog from "@app/components/poke/subscriptions/EnterpriseUpgradeDialog";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { isDevelopment } from "@app/lib/development";
-import { FREE_NO_PLAN_CODE } from "@app/lib/plans/plan_codes";
+import { FREE_NO_PLAN_CODE, isProPlanCode } from "@app/lib/plans/plan_codes";
 import { usePokePlans } from "@app/lib/swr";
 
 interface SubscriptionsDataTableProps {
@@ -407,6 +407,31 @@ function UpgradeDowngradeModal({
             owner={owner}
           />
         </div>
+        {isProPlanCode(subscription.plan.code) && (
+          <>
+            <Page.SectionHeader
+              title="Change the Pro Plan of this workspace"
+              description="This action changes the Plan limitations for an active Pro subscription. Subscription on Stripe stays the same, we just change the plan in our database."
+            />
+            <div>
+              {plans
+                .filter((p) => isProPlanCode(p.code))
+                .map((p) => {
+                  return (
+                    <div key={p.code} className="pt-2">
+                      <PokeButton
+                        variant="outline"
+                        disabled={subscription.plan.code === p.code}
+                        onClick={() => onUpgradeToPlan(p)}
+                      >
+                        Upgrade to {p.code}
+                      </PokeButton>
+                    </div>
+                  );
+                })}
+            </div>
+          </>
+        )}
       </Page>
     </Modal>
   );

--- a/front/lib/plans/plan_codes.ts
+++ b/front/lib/plans/plan_codes.ts
@@ -8,6 +8,17 @@ export const TRIAL_PLAN_CODE = "TRIAL_PLAN_CODE";
 
 // Current pro plans:
 export const PRO_PLAN_SEAT_29_CODE = "PRO_PLAN_SEAT_29";
+export const PRO_PLAN_OUTLEAP_CODE = "PRO_PLAN_OUTLEAP";
+export const PRO_PLAN_LARGE_FILES_CODE = "PRO_PLAN_LARGE_FILES";
+
+export const PRO_PLANS_CODES = [
+  PRO_PLAN_SEAT_29_CODE,
+  PRO_PLAN_OUTLEAP_CODE,
+  PRO_PLAN_LARGE_FILES_CODE,
+];
+export const isProPlanCode = (code: string): boolean => {
+  return PRO_PLANS_CODES.includes(code);
+};
 
 /**
  * ENT_PLAN_FAKE is not subscribable and is only used to display the Enterprise plan in the UI (hence it's not stored on the db).

--- a/front/lib/plans/subscription.ts
+++ b/front/lib/plans/subscription.ts
@@ -12,7 +12,10 @@ import { Plan, Subscription } from "@app/lib/models/plan";
 import { Workspace } from "@app/lib/models/workspace";
 import type { PlanAttributes } from "@app/lib/plans/free_plans";
 import { FREE_NO_PLAN_DATA } from "@app/lib/plans/free_plans";
-import { PRO_PLAN_SEAT_29_CODE } from "@app/lib/plans/plan_codes";
+import {
+  isProPlanCode,
+  PRO_PLAN_SEAT_29_CODE,
+} from "@app/lib/plans/plan_codes";
 import {
   cancelSubscriptionImmediately,
   createProPlanCheckoutSession,
@@ -296,16 +299,42 @@ export const pokeUpgradeWorkspaceToPlan = async (
     );
   }
 
-  if (newPlan.code === PRO_PLAN_SEAT_29_CODE) {
+  const isUgradeToEnterprise = newPlan.code.startsWith("ENT_");
+  const isUpgradeToPro = isProPlanCode(newPlan.code);
+  const isCurrentlyPro =
+    activeSubscription && isProPlanCode(activeSubscription.plan.code);
+
+  // Ugrade to Enterprise is not allowed through this function.
+  if (isUgradeToEnterprise) {
     throw new Error(
-      `Cannot subscribe to plan ${planCode}: it is the pro plan which requires a stripe subscription.`
+      `Cannot subscribe to plan ${planCode}: Enterprise Plans requires a special process.`
     );
+  }
+
+  // Upgrade to Pro is allowed only if the workspace is already subscribed to a Pro plan.
+  // This is a way to change the plan limitations but stay on Pro.
+  if (isUpgradeToPro) {
+    if (!isCurrentlyPro) {
+      throw new Error(
+        `Cannot subscribe to ${planCode}: Pro Plans requires a stripe checkout session done by the user on the product.`
+      );
+    }
+    await Subscription.update(
+      { planId: newPlan.id },
+      {
+        where: {
+          stripeSubscriptionId: activeSubscription.stripeSubscriptionId,
+        },
+      }
+    );
+    return;
   }
 
   await internalSubscribeWorkspaceToFreePlan({
     workspaceId: owner.sId,
     planCode: newPlan.code,
   });
+
   return;
 };
 
@@ -331,12 +360,9 @@ export const getCheckoutUrlForUpgrade = async (
   }
 
   const existingSubscription = auth.subscription();
-  if (
-    existingSubscription &&
-    existingSubscription.plan.code === PRO_PLAN_SEAT_29_CODE
-  ) {
+  if (existingSubscription && isProPlanCode(existingSubscription.plan.code)) {
     throw new Error(
-      `Cannot subscribe to plan ${PRO_PLAN_SEAT_29_CODE}: already subscribed.`
+      `Cannot subscribe to plan ${PRO_PLAN_SEAT_29_CODE}: already subscribed to a Pro plan.`
     );
   }
 

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -57,7 +57,7 @@ import {
 } from "@app/lib/client/subscription";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { MAX_UNCONSUMED_INVITATIONS_PER_WORKSPACE_PER_DAY } from "@app/lib/invitations";
-import { isUpgraded, PRO_PLAN_SEAT_29_CODE } from "@app/lib/plans/plan_codes";
+import { isProPlanCode, isUpgraded } from "@app/lib/plans/plan_codes";
 import { useMembers, useWorkspaceInvitations } from "@app/lib/swr";
 import { classNames, isEmailValid } from "@app/lib/utils";
 import type {
@@ -649,7 +649,7 @@ function InviteEmailModal({
               {ROLES_DATA[invitationRole]["description"]}
             </div>
           </div>
-          {plan.code === PRO_PLAN_SEAT_29_CODE && (
+          {isProPlanCode(plan.code) && (
             <div className="justify-self-end">
               <ProPlanBillingNotice />
             </div>

--- a/front/pages/w/[wId]/subscription/index.tsx
+++ b/front/pages/w/[wId]/subscription/index.tsx
@@ -31,8 +31,8 @@ import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import {
   FREE_TEST_PLAN_CODE,
   FREE_UPGRADED_PLAN_CODE,
+  isProPlanCode,
   isUpgraded,
-  PRO_PLAN_SEAT_29_CODE,
 } from "@app/lib/plans/plan_codes";
 import { getStripeSubscription } from "@app/lib/plans/stripe";
 import { countActiveSeatsInWorkspace } from "@app/lib/plans/usage/seats";
@@ -365,7 +365,7 @@ export default function Subscription({
           {subscription.stripeSubscriptionId && (
             <Page.Vertical gap="sm">
               <Page.H variant="h5">Billing</Page.H>
-              {plan.code === PRO_PLAN_SEAT_29_CODE && (
+              {isProPlanCode(plan.code) && (
                 <>
                   <Page.P>
                     Estimated monthly billing:{" "}


### PR DESCRIPTION
## Description

- Adds a `isProPlanCode` to allow us having mutilple plans object for the Pro Plan. 
- Calls `isProPlanCode` everywhere we need to. 
- Edit Poké upgrade modal to allow changing the Pro Plan of an active Pro plan subscription. 

New section "change the Pro plan of this workspace", displayed only if the workspace has an active Pro Plan subscription: 

<img width="1036" alt="Screenshot 2024-05-06 at 10 52 11" src="https://github.com/dust-tt/dust/assets/3803406/9da2a470-748b-46a7-b471-31ff78d29b61">



## Risk

/

## Deploy Plan

Deploy Front. 
This PR can be rolled back.
