### PR TITLE
enh(AB): don't pass setBuilderState to actions components

### DIFF
--- a/front/components/assistant_builder/ActionScreen.tsx
+++ b/front/components/assistant_builder/ActionScreen.tsx
@@ -19,7 +19,7 @@ import type {
 } from "@dust-tt/types";
 import { assertNever, removeNulls } from "@dust-tt/types";
 import type { ComponentType, ReactNode } from "react";
-import React from "react";
+import React, { useCallback } from "react";
 
 import {
   ActionProcess,
@@ -36,6 +36,7 @@ import {
   isActionTablesQueryValid,
 } from "@app/components/assistant_builder/actions/TablesQueryAction";
 import type {
+  AssistantBuilderActionConfiguration,
   AssistantBuilderActionType,
   AssistantBuilderState,
 } from "@app/components/assistant_builder/types";
@@ -236,6 +237,24 @@ export default function ActionScreen({
   const searchMode = getSearchMode(action?.type ?? null);
   const searchModeSpec = SEARCH_MODE_SPECIFICATIONS[searchMode];
 
+  const deprecatedReplaceSingleActionConfig = useCallback(
+    (newAction: AssistantBuilderActionConfiguration) => {
+      setBuilderState((state) => {
+        const previousAction = state.actions[0];
+        if (!previousAction) {
+          // Unreachable
+          return state;
+        }
+
+        return {
+          ...state,
+          actions: [newAction],
+        };
+      });
+    },
+    [setBuilderState]
+  );
+
   return (
     <>
       <div className="flex flex-col gap-4 text-sm text-element-700">
@@ -429,7 +448,18 @@ export default function ActionScreen({
               action?.type === "RETRIEVAL_SEARCH" ? action.configuration : null
             }
             dataSources={dataSources}
-            setBuilderState={setBuilderState}
+            updateAction={(newAction) => {
+              if (!action) {
+                // Unreachable
+                return;
+              }
+              deprecatedReplaceSingleActionConfig({
+                type: "RETRIEVAL_SEARCH",
+                configuration: newAction,
+                name: action.name,
+                description: action.description,
+              });
+            }}
             setEdited={setEdited}
           />
         </ActionModeSection>
@@ -445,7 +475,18 @@ export default function ActionScreen({
                 : null
             }
             dataSources={dataSources}
-            setBuilderState={setBuilderState}
+            updateAction={(newAction) => {
+              if (!action) {
+                // Unreachable
+                return;
+              }
+              deprecatedReplaceSingleActionConfig({
+                type: "RETRIEVAL_EXHAUSTIVE",
+                configuration: newAction,
+                name: action.name,
+                description: action.description,
+              });
+            }}
             setEdited={setEdited}
           />
         </ActionModeSection>
@@ -457,7 +498,18 @@ export default function ActionScreen({
               action?.type === "PROCESS" ? action.configuration : null
             }
             dataSources={dataSources}
-            setBuilderState={setBuilderState}
+            updateAction={(newAction) => {
+              if (!action) {
+                // Unreachable
+                return;
+              }
+              deprecatedReplaceSingleActionConfig({
+                type: "PROCESS",
+                configuration: newAction,
+                name: action.name,
+                description: action.description,
+              });
+            }}
             setEdited={setEdited}
           />
         </ActionModeSection>
@@ -471,7 +523,18 @@ export default function ActionScreen({
               action?.type === "TABLES_QUERY" ? action.configuration : null
             }
             dataSources={dataSources}
-            setBuilderState={setBuilderState}
+            updateAction={(newAction) => {
+              if (!action) {
+                // Unreachable
+                return;
+              }
+              deprecatedReplaceSingleActionConfig({
+                type: "TABLES_QUERY",
+                configuration: newAction,
+                name: action.name,
+                description: action.description,
+              });
+            }}
             setEdited={setEdited}
           />
         </ActionModeSection>
@@ -483,7 +546,18 @@ export default function ActionScreen({
               action?.type === "DUST_APP_RUN" ? action.configuration : null
             }
             dustApps={dustApps}
-            setBuilderState={setBuilderState}
+            updateAction={(newAction) => {
+              if (!action) {
+                // Unreachable
+                return;
+              }
+              deprecatedReplaceSingleActionConfig({
+                type: "DUST_APP_RUN",
+                configuration: newAction,
+                name: action.name,
+                description: action.description,
+              });
+            }}
             setEdited={setEdited}
           />
         </ActionModeSection>

--- a/front/components/assistant_builder/actions/DustAppRunAction.tsx
+++ b/front/components/assistant_builder/actions/DustAppRunAction.tsx
@@ -8,7 +8,6 @@ import DustAppSelectionSection from "@app/components/assistant_builder/DustAppSe
 import type {
   AssistantBuilderActionConfiguration,
   AssistantBuilderDustAppConfiguration,
-  AssistantBuilderState,
 } from "@app/components/assistant_builder/types";
 
 export function isActionDustAppRunValid(
@@ -20,15 +19,13 @@ export function isActionDustAppRunValid(
 export function ActionDustAppRun({
   owner,
   actionConfigration,
-  setBuilderState,
+  updateAction,
   setEdited,
   dustApps,
 }: {
   owner: WorkspaceType;
   actionConfigration: AssistantBuilderDustAppConfiguration | null;
-  setBuilderState: (
-    stateFn: (state: AssistantBuilderState) => AssistantBuilderState
-  ) => void;
+  updateAction: (action: AssistantBuilderDustAppConfiguration) => void;
   setEdited: (edited: boolean) => void;
   dustApps: AppType[];
 }) {
@@ -36,16 +33,9 @@ export function ActionDustAppRun({
 
   const deleteDustApp = () => {
     setEdited(true);
-    setBuilderState((state) => {
-      const action = state.actions[0];
-      if (!action || action.type !== "DUST_APP_RUN") {
-        return state;
-      }
-      action.configuration.app = null;
-      return {
-        ...state,
-        actions: [action],
-      };
+    updateAction({
+      ...actionConfigration,
+      app: null,
     });
   };
 
@@ -65,16 +55,9 @@ export function ActionDustAppRun({
         dustApps={dustApps}
         onSave={({ app }) => {
           setEdited(true);
-          setBuilderState((state) => {
-            const action = state.actions[0];
-            if (!action || action.type !== "DUST_APP_RUN") {
-              return state;
-            }
-            action.configuration.app = app;
-            return {
-              ...state,
-              actions: [action],
-            };
+          updateAction({
+            ...actionConfigration,
+            app,
           });
         }}
       />

--- a/front/components/assistant_builder/actions/ProcessAction.tsx
+++ b/front/components/assistant_builder/actions/ProcessAction.tsx
@@ -23,7 +23,6 @@ import { TIME_FRAME_UNIT_TO_LABEL } from "@app/components/assistant_builder/shar
 import type {
   AssistantBuilderActionConfiguration,
   AssistantBuilderProcessConfiguration,
-  AssistantBuilderState,
 } from "@app/components/assistant_builder/types";
 import { classNames } from "@app/lib/utils";
 
@@ -221,15 +220,13 @@ function PropertiesFields({
 export function ActionProcess({
   owner,
   actionConfiguration,
-  setBuilderState,
+  updateAction,
   setEdited,
   dataSources,
 }: {
   owner: WorkspaceType;
   actionConfiguration: AssistantBuilderProcessConfiguration | null;
-  setBuilderState: (
-    stateFn: (state: AssistantBuilderState) => AssistantBuilderState
-  ) => void;
+  updateAction: (action: AssistantBuilderProcessConfiguration) => void;
   setEdited: (edited: boolean) => void;
   dataSources: DataSourceType[];
 }) {
@@ -252,28 +249,13 @@ export function ActionProcess({
     if (actionConfiguration.dataSourceConfigurations[name]) {
       setEdited(true);
     }
-
-    setBuilderState(({ actions, ...rest }) => {
-      const action = actions[0];
-      if (!action || action.type !== "PROCESS") {
-        return { actions, ...rest };
-      }
-      const dataSourceConfigurations = {
-        ...actionConfiguration.dataSourceConfigurations,
-      };
-      delete dataSourceConfigurations[name];
-      return {
-        actions: [
-          {
-            ...action,
-            configuration: {
-              ...actionConfiguration,
-              dataSourceConfigurations,
-            },
-          },
-        ],
-        ...rest,
-      };
+    const dataSourceConfigurations = {
+      ...actionConfiguration.dataSourceConfigurations,
+    };
+    delete dataSourceConfigurations[name];
+    updateAction({
+      ...actionConfiguration,
+      dataSourceConfigurations,
     });
   };
 
@@ -288,31 +270,16 @@ export function ActionProcess({
         dataSources={dataSources}
         onSave={({ dataSource, selectedResources, isSelectAll }) => {
           setEdited(true);
-          setBuilderState((state) => {
-            const action = state.actions[0];
-            if (!action || action.type !== "PROCESS") {
-              return state;
-            }
-            const dataSourceConfigurations = {
+          updateAction({
+            ...actionConfiguration,
+            dataSourceConfigurations: {
               ...actionConfiguration.dataSourceConfigurations,
-            };
-            dataSourceConfigurations[dataSource.name] = {
-              dataSource,
-              selectedResources,
-              isSelectAll,
-            };
-            return {
-              ...state,
-              actions: [
-                {
-                  ...action,
-                  configuration: {
-                    ...actionConfiguration,
-                    dataSourceConfigurations,
-                  },
-                },
-              ],
-            };
+              [dataSource.name]: {
+                dataSource,
+                selectedResources,
+                isSelectAll,
+              },
+            },
           });
         }}
         onDelete={deleteDataSource}
@@ -363,16 +330,12 @@ export function ActionProcess({
             const value = parseInt(e.target.value, 10);
             if (!isNaN(value) || !e.target.value) {
               setEdited(true);
-              setBuilderState((state) => {
-                const action = state.actions[0];
-                if (!action || action.type !== "PROCESS") {
-                  return state;
-                }
-                actionConfiguration.timeFrame.value = value;
-                return {
-                  ...state,
-                  actions: [action],
-                };
+              updateAction({
+                ...actionConfiguration,
+                timeFrame: {
+                  value,
+                  unit: actionConfiguration.timeFrame.unit,
+                },
               });
             }
           }}
@@ -396,16 +359,12 @@ export function ActionProcess({
                 label={value}
                 onClick={() => {
                   setEdited(true);
-                  setBuilderState((state) => {
-                    const action = state.actions[0];
-                    if (!action || action.type !== "PROCESS") {
-                      return state;
-                    }
-                    actionConfiguration.timeFrame.unit = key as TimeframeUnit;
-                    return {
-                      ...state,
-                      actions: [action],
-                    };
+                  updateAction({
+                    ...actionConfiguration,
+                    timeFrame: {
+                      value: actionConfiguration.timeFrame.value,
+                      unit: key as TimeframeUnit,
+                    },
                   });
                 }}
               />
@@ -435,16 +394,9 @@ export function ActionProcess({
                     description: "Required data to follow instructions",
                   },
                 ];
-                setBuilderState((state) => {
-                  const action = state.actions[0];
-                  if (!action || action.type !== "PROCESS") {
-                    return state;
-                  }
-                  actionConfiguration.schema = schema;
-                  return {
-                    ...state,
-                    actions: [action],
-                  };
+                updateAction({
+                  ...actionConfiguration,
+                  schema,
                 });
               }}
             />
@@ -454,16 +406,9 @@ export function ActionProcess({
       <PropertiesFields
         properties={actionConfiguration.schema}
         onSetProperties={(schema: ProcessSchemaPropertyType[]) => {
-          setBuilderState((state) => {
-            const action = state.actions[0];
-            if (!action || action.type !== "PROCESS") {
-              return state;
-            }
-            actionConfiguration.schema = schema;
-            return {
-              ...state,
-              actions: [action],
-            };
+          updateAction({
+            ...actionConfiguration,
+            schema,
           });
           setEdited(true);
         }}

--- a/front/components/assistant_builder/actions/RetrievalAction.tsx
+++ b/front/components/assistant_builder/actions/RetrievalAction.tsx
@@ -9,37 +9,30 @@ import { TIME_FRAME_UNIT_TO_LABEL } from "@app/components/assistant_builder/shar
 import type {
   AssistantBuilderActionConfiguration,
   AssistantBuilderRetrievalConfiguration,
-  AssistantBuilderState,
 } from "@app/components/assistant_builder/types";
 import { classNames } from "@app/lib/utils";
 
 const deleteDataSource = ({
   name,
-  setBuilderState,
+  actionConfiguration,
+  updateAction,
   setEdited,
 }: {
   name: string;
-  setBuilderState: (
-    stateFn: (state: AssistantBuilderState) => AssistantBuilderState
-  ) => void;
+  actionConfiguration: AssistantBuilderRetrievalConfiguration;
+  updateAction: (action: AssistantBuilderRetrievalConfiguration) => void;
   setEdited: (edited: boolean) => void;
 }) => {
-  setBuilderState((state) => {
-    const action = state.actions[0];
-    if (!action || action.type !== "PROCESS") {
-      return state;
-    }
-
-    if (action.configuration.dataSourceConfigurations[name]) {
-      setEdited(true);
-    }
-
-    delete action.configuration.dataSourceConfigurations[name];
-
-    return {
-      ...state,
-      actions: [action],
-    };
+  if (actionConfiguration.dataSourceConfigurations[name]) {
+    setEdited(true);
+  }
+  const newDataSourceConfigurations = {
+    ...actionConfiguration.dataSourceConfigurations,
+  };
+  delete newDataSourceConfigurations[name];
+  updateAction({
+    ...actionConfiguration,
+    dataSourceConfigurations: newDataSourceConfigurations,
   });
 };
 
@@ -57,15 +50,13 @@ export function isActionRetrievalSearchValid(
 export function ActionRetrievalSearch({
   owner,
   actionConfiguration,
-  setBuilderState,
+  updateAction,
   setEdited,
   dataSources,
 }: {
   owner: WorkspaceType;
   actionConfiguration: AssistantBuilderRetrievalConfiguration | null;
-  setBuilderState: (
-    stateFn: (state: AssistantBuilderState) => AssistantBuilderState
-  ) => void;
+  updateAction: (action: AssistantBuilderRetrievalConfiguration) => void;
   setEdited: (edited: boolean) => void;
   dataSources: DataSourceType[];
 }) {
@@ -86,24 +77,25 @@ export function ActionRetrievalSearch({
         dataSources={dataSources}
         onSave={({ dataSource, selectedResources, isSelectAll }) => {
           setEdited(true);
-          setBuilderState((state) => {
-            const action = state.actions[0];
-            if (!action || action.type !== "RETRIEVAL_SEARCH") {
-              return state;
-            }
-            action.configuration.dataSourceConfigurations[dataSource.name] = {
-              dataSource,
-              selectedResources,
-              isSelectAll,
-            };
-            return {
-              ...state,
-              actions: [action],
-            };
+          updateAction({
+            ...actionConfiguration,
+            dataSourceConfigurations: {
+              ...actionConfiguration.dataSourceConfigurations,
+              [dataSource.name]: {
+                dataSource,
+                selectedResources,
+                isSelectAll,
+              },
+            },
           });
         }}
         onDelete={(name) => {
-          deleteDataSource({ name, setBuilderState, setEdited });
+          deleteDataSource({
+            name,
+            actionConfiguration,
+            updateAction,
+            setEdited,
+          });
         }}
         dataSourceConfigurations={actionConfiguration.dataSourceConfigurations}
       />
@@ -116,7 +108,12 @@ export function ActionRetrievalSearch({
         }}
         canAddDataSource={dataSources.length > 0}
         onDelete={(name) => {
-          deleteDataSource({ name, setBuilderState, setEdited });
+          deleteDataSource({
+            name,
+            actionConfiguration,
+            updateAction,
+            setEdited,
+          });
         }}
       />
     </>
@@ -136,15 +133,13 @@ export function isActionRetrievalExhaustiveValid(
 export function ActionRetrievalExhaustive({
   owner,
   actionConfiguration,
-  setBuilderState,
+  updateAction,
   setEdited,
   dataSources,
 }: {
   owner: WorkspaceType;
   actionConfiguration: AssistantBuilderRetrievalConfiguration | null;
-  setBuilderState: (
-    stateFn: (state: AssistantBuilderState) => AssistantBuilderState
-  ) => void;
+  updateAction: (action: AssistantBuilderRetrievalConfiguration) => void;
   setEdited: (edited: boolean) => void;
   dataSources: DataSourceType[];
 }) {
@@ -174,24 +169,25 @@ export function ActionRetrievalExhaustive({
         dataSources={dataSources}
         onSave={({ dataSource, selectedResources, isSelectAll }) => {
           setEdited(true);
-          setBuilderState((state) => {
-            const action = state.actions[0];
-            if (!action || action.type !== "RETRIEVAL_EXHAUSTIVE") {
-              return state;
-            }
-            action.configuration.dataSourceConfigurations[dataSource.name] = {
-              dataSource,
-              selectedResources,
-              isSelectAll,
-            };
-            return {
-              ...state,
-              actions: [action],
-            };
+          updateAction({
+            ...actionConfiguration,
+            dataSourceConfigurations: {
+              ...actionConfiguration.dataSourceConfigurations,
+              [dataSource.name]: {
+                dataSource,
+                selectedResources,
+                isSelectAll,
+              },
+            },
           });
         }}
         onDelete={(name) => {
-          deleteDataSource({ name, setBuilderState, setEdited });
+          deleteDataSource({
+            name,
+            actionConfiguration,
+            updateAction,
+            setEdited,
+          });
         }}
         dataSourceConfigurations={actionConfiguration.dataSourceConfigurations}
       />
@@ -204,7 +200,12 @@ export function ActionRetrievalExhaustive({
         }}
         canAddDataSource={dataSources.length > 0}
         onDelete={(name) => {
-          deleteDataSource({ name, setBuilderState, setEdited });
+          deleteDataSource({
+            name,
+            actionConfiguration,
+            updateAction,
+            setEdited,
+          });
         }}
       />
       <div className={"flex flex-row items-center gap-4 pb-4"}>
@@ -225,28 +226,12 @@ export function ActionRetrievalExhaustive({
             const value = parseInt(e.target.value, 10);
             if (!isNaN(value) || !e.target.value) {
               setEdited(true);
-              setBuilderState((state) => {
-                const action = state.actions[0];
-                if (!action || action.type !== "RETRIEVAL_EXHAUSTIVE") {
-                  return state;
-                }
-                const newState: AssistantBuilderState = {
-                  ...state,
-                  actions: [
-                    {
-                      ...action,
-                      configuration: {
-                        ...action.configuration,
-                        timeFrame: {
-                          value,
-                          unit: action.configuration.timeFrame.unit,
-                        },
-                      },
-                    },
-                  ],
-                };
-
-                return newState;
+              updateAction({
+                ...actionConfiguration,
+                timeFrame: {
+                  value,
+                  unit: actionConfiguration.timeFrame.unit,
+                },
               });
             }
           }}
@@ -270,16 +255,12 @@ export function ActionRetrievalExhaustive({
                 label={value}
                 onClick={() => {
                   setEdited(true);
-                  setBuilderState((state) => {
-                    const action = state.actions[0];
-                    if (!action || action.type !== "RETRIEVAL_EXHAUSTIVE") {
-                      return state;
-                    }
-                    action.configuration.timeFrame.unit = key as TimeframeUnit;
-                    return {
-                      ...state,
-                      actions: [action],
-                    };
+                  updateAction({
+                    ...actionConfiguration,
+                    timeFrame: {
+                      value: actionConfiguration.timeFrame.value,
+                      unit: key as TimeframeUnit,
+                    },
                   });
                 }}
               />

--- a/front/components/assistant_builder/actions/TablesQueryAction.tsx
+++ b/front/components/assistant_builder/actions/TablesQueryAction.tsx
@@ -6,7 +6,6 @@ import AssistantBuilderTablesModal from "@app/components/assistant_builder/Assis
 import TablesSelectionSection from "@app/components/assistant_builder/TablesSelectionSection";
 import type {
   AssistantBuilderActionConfiguration,
-  AssistantBuilderState,
   AssistantBuilderTableConfiguration,
   AssistantBuilderTablesQueryConfiguration,
 } from "@app/components/assistant_builder/types";
@@ -24,15 +23,13 @@ export function isActionTablesQueryValid(
 export function ActionTablesQuery({
   owner,
   actionConfiguration,
-  setBuilderState,
+  updateAction,
   setEdited,
   dataSources,
 }: {
   owner: WorkspaceType;
   actionConfiguration: AssistantBuilderTablesQueryConfiguration | null;
-  setBuilderState: (
-    stateFn: (state: AssistantBuilderState) => AssistantBuilderState
-  ) => void;
+  updateAction: (action: AssistantBuilderTablesQueryConfiguration) => void;
   setEdited: (edited: boolean) => void;
   dataSources: DataSourceType[];
 }) {
@@ -56,19 +53,9 @@ export function ActionTablesQuery({
           for (const t of tables) {
             newTables[tableKey(t)] = t;
           }
-          setBuilderState((state) => {
-            const action = state.actions[0];
-            if (!action || action.type !== "TABLES_QUERY") {
-              return state;
-            }
-            action.configuration = {
-              ...action.configuration,
-              ...newTables,
-            };
-            return {
-              ...state,
-              actions: [action],
-            };
+          updateAction({
+            ...actionConfiguration,
+            ...newTables,
           });
         }}
         tablesQueryConfiguration={actionConfiguration}
@@ -100,23 +87,9 @@ export function ActionTablesQuery({
         }}
         onDelete={(key) => {
           setEdited(true);
-          setBuilderState((state) => {
-            const action = state.actions[0];
-            if (!action || action.type !== "TABLES_QUERY") {
-              return state;
-            }
-            const tablesQueryConfiguration = action.configuration;
-            delete tablesQueryConfiguration[key];
-            return {
-              ...state,
-              actions: [
-                {
-                  ...action,
-                  configuration: tablesQueryConfiguration,
-                },
-              ],
-            };
-          });
+          const newTables = { ...actionConfiguration };
+          delete newTables[key];
+          updateAction(newTables);
         }}
         canSelectTable={dataSources.length !== 0}
       />


### PR DESCRIPTION
## Description

The last preliminary step for https://github.com/dust-tt/dust/issues/4603

We need actions components to be self-contained and not have any direct control on assistant builder state. That will allow to fork `ActionScreen` only, and keep each action component as-is.

## Risk

It's a critical path of AB. Well tested. Deployed on front-edge.dust.tt for testing

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
