### PR TITLE
Adapt constructPrompt for multi-actions

### DIFF
--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -445,6 +445,15 @@ export function retrievalMetaPrompt() {
   );
 }
 
+export function retrievalMetaPromptMutiActions() {
+  return (
+    "Focus on being factual and accurate. When data is retrieved from sources, " +
+    "use the markdown directive :cite[REFERENCE] to cite documents (eg :cite[XX] or :cite[XX,XX] but not :cite[XX][XX]). " +
+    "Ensure citations are placed as close as possible to the related information. " +
+    "If data retrieval isn't applicable, maintain clarity and precision in your statements."
+  );
+}
+
 /**
  * Action execution.
  */

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -51,7 +51,7 @@ import {
 } from "@app/lib/api/assistant/actions/tables_query";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
 import {
-  constructPrompt,
+  constructPromptMultiActions,
   renderConversationForModel,
   runGeneration,
 } from "@app/lib/api/assistant/generation";
@@ -319,7 +319,7 @@ export async function getNextAction(
     Error
   >
 > {
-  let prompt = await constructPrompt(
+  let prompt = await constructPromptMultiActions(
     auth,
     userMessage,
     agentConfiguration,

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -319,7 +319,6 @@ export async function getNextAction(
     Error
   >
 > {
-  // TODO(@fontanierh): Make a new one for multi actions.
   let prompt = await constructPrompt(
     auth,
     userMessage,

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -57,7 +57,6 @@ import {
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
 import { getSupportedModelConfig, isLargeModel } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
-import { deprecatedGetFirstActionConfiguration } from "@app/lib/deprecated_action_configurations";
 import { redisClient } from "@app/lib/redis";
 import { getContentFragmentText } from "@app/lib/resources/content_fragment_resource";
 import { tokenCountForText, tokenSplit } from "@app/lib/tokenization";
@@ -505,11 +504,14 @@ export async function constructPrompt(
     instructions += `\n${fallbackPrompt}`;
   }
 
-  const actionConfig = deprecatedGetFirstActionConfiguration(configuration);
-
-  if (isRetrievalConfiguration(actionConfig)) {
+  // If one of the action is a retrieval action, we add the retrieval meta prompt.
+  const hasRetrievalAction = configuration.actions.some((action) =>
+    isRetrievalConfiguration(action)
+  );
+  if (hasRetrievalAction) {
     instructions += `\n${retrievalMetaPrompt()}`;
   }
+
   if (instructions.length > 0) {
     instructions = "\nINSTRUCTIONS:" + instructions;
   }


### PR DESCRIPTION
## Description

This PR adapts `constructPrompt` for multi-actions. 
Instead of fetching the first action, we look among all the actions to see if there's a retrieval config set, to add the retrieval meta prompt. 

## Risk

Should-be the same behavior as before in prod since agents have 1 action on prod. 
PR can be rolled-back.

## Deploy Plan

Deploy Front. 
