### PR TITLE
AgentMessageType.action[s]

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -408,7 +408,7 @@ export function AgentMessage({
     // Loading state (no action nor text yet)
     if (
       agentMessage.status === "created" &&
-      action === null &&
+      !action &&
       (!agentMessage.content || agentMessage.content === "")
     ) {
       return (

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -242,7 +242,7 @@ export function AgentMessage({
   }, [
     agentMessageToRender.content,
     agentMessageToRender.status,
-    agentMessageToRender.action,
+    agentMessageToRender.actions,
     activeReferences.length,
     isInModal,
   ]);
@@ -312,18 +312,18 @@ export function AgentMessage({
   >(null);
   useEffect(() => {
     if (
-      agentMessageToRender.action &&
-      isRetrievalActionType(agentMessageToRender.action) &&
-      agentMessageToRender.action.documents
+      agentMessageToRender.actions.length > 0 &&
+      isRetrievalActionType(agentMessageToRender.actions[0]) &&
+      agentMessageToRender.actions[0].documents
     ) {
       setReferences(
-        agentMessageToRender.action.documents.reduce((acc, d) => {
+        agentMessageToRender.actions[0].documents.reduce((acc, d) => {
           acc[d.reference] = d;
           return acc;
         }, {} as { [key: string]: RetrievalDocumentType })
       );
     }
-  }, [agentMessageToRender.action]);
+  }, [agentMessageToRender.actions]);
 
   function AssitantDetailViewLink(assistant: LightAgentConfigurationType) {
     const router = useRouter();
@@ -402,7 +402,7 @@ export function AgentMessage({
     // Loading state (no action nor text yet)
     if (
       agentMessage.status === "created" &&
-      !agentMessage.action &&
+      agentMessage.actions.length === 0 &&
       (!agentMessage.content || agentMessage.content === "")
     ) {
       return (
@@ -417,7 +417,9 @@ export function AgentMessage({
 
     return (
       <>
-        {agentMessage.action && <AgentAction action={agentMessage.action} />}
+        {agentMessage.actions.length > 0 && (
+          <AgentAction action={agentMessage.actions[0]} />
+        )}
         {agentMessage.content !== null && (
           <div>
             {agentMessage.content === "" ? (

--- a/front/lib/api/assistant/actions/dust_app_run.ts
+++ b/front/lib/api/assistant/actions/dust_app_run.ts
@@ -226,6 +226,7 @@ export async function dustAppRunTypesFromAgentMessageIds(
       runningBlock: null,
       output: action.output,
       agentMessageId: action.agentMessageId,
+      step: action.step,
     } satisfies DustAppRunActionType;
   });
 }
@@ -249,6 +250,7 @@ export async function* runDustApp(
     agentMessage,
     spec,
     rawInputs,
+    step,
   }: {
     configuration: AgentConfigurationType;
     actionConfiguration: DustAppRunConfigurationType;
@@ -256,6 +258,7 @@ export async function* runDustApp(
     agentMessage: AgentMessageType;
     spec: AgentActionSpecification;
     rawInputs: Record<string, string | boolean | number>;
+    step: number;
   }
 ): AsyncGenerator<
   | DustAppRunParamsEvent
@@ -322,6 +325,7 @@ export async function* runDustApp(
     appName: app.name,
     params,
     agentMessageId: agentMessage.agentMessageId,
+    step,
   });
 
   yield {
@@ -339,6 +343,7 @@ export async function* runDustApp(
       runningBlock: null,
       output: null,
       agentMessageId: agentMessage.agentMessageId,
+      step,
     },
   };
 
@@ -417,6 +422,7 @@ export async function* runDustApp(
           },
           output: null,
           agentMessageId: agentMessage.agentMessageId,
+          step: action.step,
         },
       };
     }
@@ -470,6 +476,7 @@ export async function* runDustApp(
       runningBlock: null,
       output: lastBlockOutput,
       agentMessageId: agentMessage.agentMessageId,
+      step: action.step,
     },
   };
 }

--- a/front/lib/api/assistant/actions/process.ts
+++ b/front/lib/api/assistant/actions/process.ts
@@ -199,7 +199,8 @@ export async function processActionTypesFromAgentMessageIds(
       },
       schema: action.schema,
       outputs: action.outputs,
-    };
+      step: action.step,
+    } satisfies ProcessActionType;
   });
 }
 
@@ -221,6 +222,7 @@ export async function* runProcess(
     userMessage,
     agentMessage,
     rawInputs,
+    step,
   }: {
     configuration: AgentConfigurationType;
     actionConfiguration: ProcessConfigurationType;
@@ -228,6 +230,7 @@ export async function* runProcess(
     userMessage: UserMessageType;
     agentMessage: AgentMessageType;
     rawInputs: Record<string, string | boolean | number>;
+    step: number;
   }
 ): AsyncGenerator<
   ProcessParamsEvent | ProcessSuccessEvent | ProcessErrorEvent,
@@ -271,6 +274,7 @@ export async function* runProcess(
     processConfigurationId: actionConfiguration.sId,
     schema: actionConfiguration.schema,
     agentMessageId: agentMessage.agentMessageId,
+    step,
   });
 
   const now = Date.now();
@@ -290,6 +294,7 @@ export async function* runProcess(
       },
       schema: action.schema,
       outputs: null,
+      step: action.step,
     },
   };
 
@@ -487,6 +492,7 @@ export async function* runProcess(
       },
       schema: action.schema,
       outputs,
+      step: action.step,
     },
   };
 }

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -426,6 +426,7 @@ export async function retrievalActionTypesFromAgentMessageIds(
         topK: action.topK,
       },
       documents,
+      step: action.step,
     });
   }
 
@@ -481,12 +482,14 @@ export async function* runRetrieval(
     conversation,
     agentMessage,
     rawInputs,
+    step,
   }: {
     configuration: AgentConfigurationType;
     actionConfiguration: RetrievalConfigurationType;
     conversation: ConversationType;
     agentMessage: AgentMessageType;
     rawInputs: Record<string, string | boolean | number>;
+    step: number;
   }
 ): AsyncGenerator<
   RetrievalParamsEvent | RetrievalSuccessEvent | RetrievalErrorEvent,
@@ -558,6 +561,7 @@ export async function* runRetrieval(
     topK,
     retrievalConfigurationId: actionConfiguration.sId,
     agentMessageId: agentMessage.agentMessageId,
+    step: step,
   });
 
   yield {
@@ -576,6 +580,7 @@ export async function* runRetrieval(
         topK,
       },
       documents: null,
+      step: action.step,
     },
   };
 
@@ -841,6 +846,7 @@ export async function* runRetrieval(
         topK,
       },
       documents,
+      step: action.step,
     },
   };
 }

--- a/front/lib/api/assistant/actions/tables_query.ts
+++ b/front/lib/api/assistant/actions/tables_query.ts
@@ -95,6 +95,7 @@ export async function tableQueryTypesFromAgentMessageIds(
       params: action.params as DustAppParameters,
       output: action.output as Record<string, string | number | boolean>,
       agentMessageId: action.agentMessageId,
+      step: action.step,
     } satisfies TablesQueryActionType;
   });
 }
@@ -155,12 +156,14 @@ export async function* runTablesQuery(
     conversation,
     agentMessage,
     rawInputs,
+    step,
   }: {
     configuration: AgentConfigurationType;
     actionConfiguration: TablesQueryConfigurationType;
     conversation: ConversationType;
     agentMessage: AgentMessageType;
     rawInputs: Record<string, string | boolean | number>;
+    step: number;
   }
 ): AsyncGenerator<
   | TablesQueryErrorEvent
@@ -197,6 +200,7 @@ export async function* runTablesQuery(
     params: rawInputs,
     output,
     agentMessageId: agentMessage.agentMessageId,
+    step: step,
   });
 
   yield {
@@ -210,6 +214,7 @@ export async function* runTablesQuery(
       params: action.params as DustAppParameters,
       output: action.output as Record<string, string | number | boolean>,
       agentMessageId: action.agentMessageId,
+      step: action.step,
     },
   };
 
@@ -345,6 +350,7 @@ export async function* runTablesQuery(
             params: action.params as DustAppParameters,
             output: tmpOutput as Record<string, string | number | boolean>,
             agentMessageId: agentMessage.id,
+            step: action.step,
           },
         };
       }
@@ -374,6 +380,7 @@ export async function* runTablesQuery(
       params: action.params as DustAppParameters,
       output: action.output as Record<string, string | number | boolean>,
       agentMessageId: action.agentMessageId,
+      step: action.step,
     },
   };
   return;

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -22,7 +22,7 @@ import {
   cloneBaseConfig,
   DustProdActionRegistry,
   Err,
-  isAgentConfiguration,
+  isAgentActionConfigurationType,
   isDustAppRunConfiguration,
   isProcessConfiguration,
   isRetrievalConfiguration,
@@ -198,7 +198,7 @@ export async function* runMultiActionsAgent(
 
     const { action, inputs, specification } = actionToRun.value;
 
-    if (isAgentConfiguration(action)) {
+    if (isAgentActionConfigurationType(action)) {
       const eventStream = runAction(auth, {
         configuration: configuration,
         actionConfiguration: action,

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -207,6 +207,7 @@ export async function* runMultiActionsAgent(
         agentMessage,
         inputs,
         specification,
+        step: i,
       });
       for await (const event of eventStream) {
         yield event;
@@ -524,6 +525,7 @@ async function* runAction(
     agentMessage,
     inputs,
     specification,
+    step,
   }: {
     configuration: AgentConfigurationType;
     actionConfiguration: AgentActionConfigurationType;
@@ -532,6 +534,7 @@ async function* runAction(
     agentMessage: AgentMessageType;
     inputs: Record<string, string | boolean | number>;
     specification: AgentActionSpecification | null;
+    step: number;
   }
 ): AsyncGenerator<
   | AgentActionEvent
@@ -549,6 +552,7 @@ async function* runAction(
       conversation,
       agentMessage,
       rawInputs: inputs,
+      step,
     });
 
     for await (const event of eventStream) {
@@ -579,7 +583,7 @@ async function* runAction(
 
           // We stitch the action into the agent message. The conversation is expected to include
           // the agentMessage object, updating this object will update the conversation as well.
-          agentMessage.action = event.action;
+          agentMessage.actions.push(event.action);
           break;
 
         default:
@@ -615,6 +619,7 @@ async function* runAction(
       agentMessage,
       spec: specification,
       rawInputs: inputs,
+      step,
     });
 
     for await (const event of eventStream) {
@@ -648,7 +653,7 @@ async function* runAction(
 
           // We stitch the action into the agent message. The conversation is expected to include
           // the agentMessage object, updating this object will update the conversation as well.
-          agentMessage.action = event.action;
+          agentMessage.actions.push(event.action);
           break;
 
         default:
@@ -662,6 +667,7 @@ async function* runAction(
       conversation,
       agentMessage,
       rawInputs: inputs,
+      step,
     });
 
     for await (const event of eventStream) {
@@ -693,7 +699,7 @@ async function* runAction(
 
           // We stitch the action into the agent message. The conversation is expected to include
           // the agentMessage object, updating this object will update the conversation as well.
-          agentMessage.action = event.action;
+          agentMessage.actions.push(event.action);
           break;
         default:
           assertNever(event);
@@ -707,6 +713,7 @@ async function* runAction(
       userMessage,
       agentMessage,
       rawInputs: inputs,
+      step,
     });
 
     for await (const event of eventStream) {
@@ -737,7 +744,7 @@ async function* runAction(
 
           // We stitch the action into the agent message. The conversation is expected to include
           // the agentMessage object, updating this object will update the conversation as well.
-          agentMessage.action = event.action;
+          agentMessage.actions.push(event.action);
           break;
 
         default:

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -749,7 +749,7 @@ export async function* postUserMessage(
                   version: 0,
                   parentMessageId: userMessage.sId,
                   status: "created",
-                  action: null,
+                  actions: [],
                   content: null,
                   error: null,
                   configuration,
@@ -1194,12 +1194,12 @@ export async function* editUserMessage(
                 version: 0,
                 parentMessageId: userMessage.sId,
                 status: "created",
-                action: null,
+                actions: [],
                 content: null,
                 error: null,
                 configuration,
                 rank: messageRow.rank,
-              },
+              } satisfies AgentMessageWithRankType,
             };
           })();
         })
@@ -1412,7 +1412,7 @@ export async function* retryAgentMessage(
         version: m.version,
         parentMessageId: message.parentMessageId,
         status: "created",
-        action: null,
+        actions: [],
         content: null,
         error: null,
         configuration: message.configuration,

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -57,6 +57,7 @@ import {
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
 import { getSupportedModelConfig, isLargeModel } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
+import { getDeprecatedSingleAction } from "@app/lib/client/assistant_builder/deprecated_single_action";
 import { deprecatedGetFirstActionConfiguration } from "@app/lib/deprecated_action_configurations";
 import { redisClient } from "@app/lib/redis";
 import { getContentFragmentText } from "@app/lib/resources/content_fragment_resource";
@@ -112,20 +113,21 @@ export async function renderConversationForModel({
       }
       // There are contexts where we want to exclude the actions from the rendering.
       // Eg: During the conversation title generation step.
-      if (m.actions.length > 0 && !excludeActions) {
-        if (isRetrievalActionType(m.actions[0])) {
+      const action = getDeprecatedSingleAction(m.actions);
+      if (action && !excludeActions) {
+        if (isRetrievalActionType(action)) {
           if (includeRetrieval) {
             foundRetrieval = true;
-            messages.unshift(renderRetrievalActionForModel(m.actions[0]));
+            messages.unshift(renderRetrievalActionForModel(action));
           }
-        } else if (isDustAppRunActionType(m.actions[0])) {
-          messages.unshift(renderDustAppRunActionForModel(m.actions[0]));
-        } else if (isTablesQueryActionType(m.actions[0])) {
-          messages.unshift(renderTablesQueryActionForModel(m.actions[0]));
-        } else if (isProcessActionType(m.actions[0])) {
-          messages.unshift(renderProcessActionForModel(m.actions[0]));
+        } else if (isDustAppRunActionType(action)) {
+          messages.unshift(renderDustAppRunActionForModel(action));
+        } else if (isTablesQueryActionType(action)) {
+          messages.unshift(renderTablesQueryActionForModel(action));
+        } else if (isProcessActionType(action)) {
+          messages.unshift(renderProcessActionForModel(action));
         } else {
-          assertNever(m.actions[0]);
+          assertNever(action);
         }
       }
     } else if (isUserMessageType(m)) {

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -308,7 +308,7 @@ export async function renderConversationForModelMultiActions({
         });
       }
 
-      const actions = removeNulls(m.actions); // Should be replaced with `m.actions` once we it on AgentMessageType.
+      const actions = removeNulls(m.actions);
       const function_calls = [];
       const function_messages = [];
 

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -112,20 +112,20 @@ export async function renderConversationForModel({
       }
       // There are contexts where we want to exclude the actions from the rendering.
       // Eg: During the conversation title generation step.
-      if (m.action && !excludeActions) {
-        if (isRetrievalActionType(m.action)) {
+      if (m.actions.length > 0 && !excludeActions) {
+        if (isRetrievalActionType(m.actions[0])) {
           if (includeRetrieval) {
             foundRetrieval = true;
-            messages.unshift(renderRetrievalActionForModel(m.action));
+            messages.unshift(renderRetrievalActionForModel(m.actions[0]));
           }
-        } else if (isDustAppRunActionType(m.action)) {
-          messages.unshift(renderDustAppRunActionForModel(m.action));
-        } else if (isTablesQueryActionType(m.action)) {
-          messages.unshift(renderTablesQueryActionForModel(m.action));
-        } else if (isProcessActionType(m.action)) {
-          messages.unshift(renderProcessActionForModel(m.action));
+        } else if (isDustAppRunActionType(m.actions[0])) {
+          messages.unshift(renderDustAppRunActionForModel(m.actions[0]));
+        } else if (isTablesQueryActionType(m.actions[0])) {
+          messages.unshift(renderTablesQueryActionForModel(m.actions[0]));
+        } else if (isProcessActionType(m.actions[0])) {
+          messages.unshift(renderProcessActionForModel(m.actions[0]));
         } else {
-          assertNever(m.action);
+          assertNever(m.actions[0]);
         }
       }
     } else if (isUserMessageType(m)) {
@@ -308,7 +308,7 @@ export async function renderConversationForModelMultiActions({
         });
       }
 
-      const actions = removeNulls([m.action]); // Should be replaced with `m.actions` once we it on AgentMessageType.
+      const actions = removeNulls(m.actions); // Should be replaced with `m.actions` once we it on AgentMessageType.
       const function_calls = [];
       const function_messages = [];
 

--- a/front/lib/api/assistant/legacy_agent.ts
+++ b/front/lib/api/assistant/legacy_agent.ts
@@ -203,6 +203,7 @@ export async function* runLegacyAgent(
       userMessage,
       agentMessage,
       action,
+      step: 0,
     })) {
       yield event;
     }
@@ -285,12 +286,14 @@ async function* runAction(
     userMessage,
     agentMessage,
     action,
+    step,
   }: {
     configuration: AgentConfigurationType;
     conversation: ConversationType;
     userMessage: UserMessageType;
     agentMessage: AgentMessageType;
     action: AgentActionConfigurationType;
+    step: number;
   }
 ): AsyncGenerator<
   | AgentActionEvent
@@ -398,6 +401,7 @@ async function* runAction(
       conversation,
       agentMessage,
       rawInputs,
+      step,
     });
 
     for await (const event of eventStream) {
@@ -428,7 +432,7 @@ async function* runAction(
 
           // We stitch the action into the agent message. The conversation is expected to include
           // the agentMessage object, updating this object will update the conversation as well.
-          agentMessage.action = event.action;
+          agentMessage.actions.push(event.action);
           break;
 
         default:
@@ -443,6 +447,7 @@ async function* runAction(
       agentMessage,
       spec: specRes.value,
       rawInputs,
+      step,
     });
 
     for await (const event of eventStream) {
@@ -476,7 +481,7 @@ async function* runAction(
 
           // We stitch the action into the agent message. The conversation is expected to include
           // the agentMessage object, updating this object will update the conversation as well.
-          agentMessage.action = event.action;
+          agentMessage.actions.push(event.action);
           break;
 
         default:
@@ -490,6 +495,7 @@ async function* runAction(
       conversation,
       agentMessage,
       rawInputs,
+      step,
     });
 
     for await (const event of eventStream) {
@@ -521,7 +527,7 @@ async function* runAction(
 
           // We stitch the action into the agent message. The conversation is expected to include
           // the agentMessage object, updating this object will update the conversation as well.
-          agentMessage.action = event.action;
+          agentMessage.actions.push(event.action);
           break;
         default:
           assertNever(event);
@@ -535,6 +541,7 @@ async function* runAction(
       userMessage,
       agentMessage,
       rawInputs,
+      step,
     });
 
     for await (const event of eventStream) {
@@ -565,7 +572,7 @@ async function* runAction(
 
           // We stitch the action into the agent message. The conversation is expected to include
           // the agentMessage object, updating this object will update the conversation as well.
-          agentMessage.action = event.action;
+          agentMessage.actions.push(event.action);
           break;
 
         default:

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -170,45 +170,15 @@ export async function batchRenderAgentMessages(
     }
     const agentMessage = message.agentMessage;
 
-    let action: AgentActionType | null = null;
-
-    // TODO: Allow multiple actions per agent messages.
-    if (
-      agentRetrievalActions.filter((a) => a.agentMessageId === agentMessage.id)
-        .length > 0
-    ) {
-      action =
-        agentRetrievalActions.find(
-          (a) => a.agentMessageId === agentMessage.id
-        ) || null;
-    }
-    if (
-      agentDustAppRunActions.filter((a) => a.agentMessageId === agentMessage.id)
-        .length > 0
-    ) {
-      action =
-        agentDustAppRunActions.find(
-          (a) => a.agentMessageId === agentMessage.id
-        ) || null;
-    }
-    if (
-      agentTablesQueryActions.filter(
-        (a) => a.agentMessageId === agentMessage.id
-      ).length > 0
-    ) {
-      action =
-        agentTablesQueryActions.find(
-          (a) => a.agentMessageId === agentMessage.id
-        ) || null;
-    }
-    if (
-      agentProcessActions.filter((a) => a.agentMessageId === agentMessage.id)
-        .length > 0
-    ) {
-      action =
-        agentProcessActions.find((a) => a.agentMessageId === agentMessage.id) ||
-        null;
-    }
+    const actions: AgentActionType[] = [
+      agentRetrievalActions,
+      agentDustAppRunActions,
+      agentTablesQueryActions,
+      agentProcessActions,
+    ]
+      .flat()
+      .filter((a) => a.agentMessageId === agentMessage.id)
+      .sort((a, b) => a.step - b.step);
 
     const agentConfiguration = agentConfigurations.find(
       (a) => a.sId === agentMessage.agentConfigurationId
@@ -242,7 +212,7 @@ export async function batchRenderAgentMessages(
       parentMessageId:
         messages.find((m) => m.id === message.parentId)?.sId ?? null,
       status: agentMessage.status,
-      action,
+      actions: actions,
       content: agentMessage.content,
       error,
       // TODO(2024-03-21 flav) Dry the agent configuration object for rendering.

--- a/front/lib/client/assistant_builder/deprecated_single_action.ts
+++ b/front/lib/client/assistant_builder/deprecated_single_action.ts
@@ -1,3 +1,4 @@
+import type { AgentActionType } from "@dust-tt/types";
 import { useMemo } from "react";
 
 import type {
@@ -15,4 +16,14 @@ export function useDeprecatedDefaultSingleAction(
   builderState: AssistantBuilderState
 ): AssistantBuilderActionConfiguration | undefined {
   return useMemo(() => builderState.actions[0], [builderState.actions]);
+}
+
+export function getDeprecatedSingleAction(
+  actions: AgentActionType[]
+): AgentActionType | null {
+  if (actions.length === 1) {
+    return actions[0];
+  } else {
+    return null;
+  }
 }

--- a/front/lib/models/assistant/actions/dust_app_run.ts
+++ b/front/lib/models/assistant/actions/dust_app_run.ts
@@ -111,6 +111,7 @@ export class AgentDustAppRunAction extends Model<
 
   declare params: DustAppParameters;
   declare output: unknown | null;
+  declare step: number;
   declare agentMessageId: ForeignKey<AgentMessage["id"]>;
 }
 AgentDustAppRunAction.init(
@@ -155,6 +156,10 @@ AgentDustAppRunAction.init(
     },
     output: {
       type: DataTypes.JSONB,
+      allowNull: true,
+    },
+    step: {
+      type: DataTypes.INTEGER,
       allowNull: true,
     },
   },

--- a/front/lib/models/assistant/actions/process.ts
+++ b/front/lib/models/assistant/actions/process.ts
@@ -133,6 +133,8 @@ export class AgentProcessAction extends Model<
   declare schema: ProcessSchemaPropertyType[];
   declare outputs: ProcessActionOutputsType | null;
 
+  declare step: number;
+
   declare agentMessageId: ForeignKey<AgentMessage["id"]>;
 }
 AgentProcessAction.init(
@@ -170,6 +172,10 @@ AgentProcessAction.init(
     },
     outputs: {
       type: DataTypes.JSONB,
+      allowNull: true,
+    },
+    step: {
+      type: DataTypes.INTEGER,
       allowNull: true,
     },
   },

--- a/front/lib/models/assistant/actions/retrieval.ts
+++ b/front/lib/models/assistant/actions/retrieval.ts
@@ -157,6 +157,7 @@ export class AgentRetrievalAction extends Model<
   declare relativeTimeFrameUnit: TimeframeUnit | null;
   declare topK: number;
   declare agentMessageId: ForeignKey<AgentMessage["id"]>;
+  declare step: number;
 }
 AgentRetrievalAction.init(
   {
@@ -194,6 +195,10 @@ AgentRetrievalAction.init(
     topK: {
       type: DataTypes.INTEGER,
       allowNull: false,
+    },
+    step: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
     },
   },
   {

--- a/front/lib/models/assistant/actions/tables_query.ts
+++ b/front/lib/models/assistant/actions/tables_query.ts
@@ -169,6 +169,8 @@ export class AgentTablesQueryAction extends Model<
   declare params: unknown | null;
   declare output: unknown | null;
   declare agentMessageId: ForeignKey<AgentMessage["id"]>;
+
+  declare step: number;
 }
 
 AgentTablesQueryAction.init(
@@ -200,6 +202,10 @@ AgentTablesQueryAction.init(
     },
     output: {
       type: DataTypes.JSONB,
+      allowNull: true,
+    },
+    step: {
+      type: DataTypes.INTEGER,
       allowNull: true,
     },
   },

--- a/front/migrations/20240506_actions_step_backfill.ts
+++ b/front/migrations/20240506_actions_step_backfill.ts
@@ -1,0 +1,34 @@
+import { AgentDustAppRunAction } from "@app/lib/models/assistant/actions/dust_app_run";
+import { AgentProcessAction } from "@app/lib/models/assistant/actions/process";
+import { AgentRetrievalAction } from "@app/lib/models/assistant/actions/retrieval";
+import { AgentTablesQueryAction } from "@app/lib/models/assistant/actions/tables_query";
+import { makeScript } from "@app/scripts/helpers";
+
+const backfillActionsStep = async (execute: boolean) => {
+  const tables = [
+    AgentRetrievalAction,
+    AgentDustAppRunAction,
+    AgentTablesQueryAction,
+    AgentProcessAction,
+  ];
+  if (execute) {
+    for (const table of tables) {
+      // @ts-expect-error step is null in the table definition (sequelize init() function)
+      // but not at the declaration level.
+      await table.update(
+        {
+          step: 0,
+        },
+        {
+          where: {
+            step: null,
+          },
+        }
+      );
+    }
+  }
+};
+
+makeScript({}, async ({ execute }) => {
+  await backfillActionsStep(execute);
+});

--- a/types/src/front/assistant/actions/dust_app_run.ts
+++ b/types/src/front/assistant/actions/dust_app_run.ts
@@ -32,4 +32,5 @@ export type DustAppRunActionType = {
     status: "running" | "succeeded" | "errored";
   } | null;
   output: unknown | null;
+  step: number;
 };

--- a/types/src/front/assistant/actions/guards.ts
+++ b/types/src/front/assistant/actions/guards.ts
@@ -85,7 +85,7 @@ export function isProcessActionType(
   return arg.type === "process_action";
 }
 
-export function isAgentConfiguration(
+export function isAgentActionConfigurationType(
   arg: unknown
 ): arg is AgentActionConfigurationType {
   return (

--- a/types/src/front/assistant/actions/process.ts
+++ b/types/src/front/assistant/actions/process.ts
@@ -76,4 +76,5 @@ export type ProcessActionType = {
   };
   schema: ProcessSchemaPropertyType[];
   outputs: ProcessActionOutputsType | null;
+  step: number;
 };

--- a/types/src/front/assistant/actions/retrieval.ts
+++ b/types/src/front/assistant/actions/retrieval.ts
@@ -100,4 +100,5 @@ export type RetrievalActionType = {
     topK: number;
   };
   documents: RetrievalDocumentType[] | null;
+  step: number;
 };

--- a/types/src/front/assistant/actions/tables_query.ts
+++ b/types/src/front/assistant/actions/tables_query.ts
@@ -23,4 +23,5 @@ export type TablesQueryActionType = {
   params: DustAppParameters;
   output: Record<string, string | number | boolean> | null;
   agentMessageId: ModelId;
+  step: number;
 };

--- a/types/src/front/assistant/conversation.ts
+++ b/types/src/front/assistant/conversation.ts
@@ -110,7 +110,7 @@ export type AgentMessageType = {
   parentMessageId: string | null;
   configuration: LightAgentConfigurationType;
   status: AgentMessageStatus;
-  action: AgentActionType | null;
+  actions: AgentActionType[];
   content: string | null;
   error: {
     code: string;


### PR DESCRIPTION
## Description



This PR includes:
- The change of `AgentMessageType.action` -> `AgentMessageType.actions` (backend code only)
- Adjustment to the front-end to read `AgentMessageType.actions[0]` (actual implementation of multi actions in the front-end will be a different task)
- Adding `Agent.*Action.step` step field to order the actions in a multi actions world
- A migration to update all steps to 0 for  all legacy actions.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk
This is high risk since we are changing the way we read actions. We should thoroughly test it on front-edge before. 

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
- Block deployments
- Run initdb for front
- Deploy on front-edge
- Test it on front-edge
- Deploy on front
- Unlock deployments.

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
