### PR TITLE
feat(AB): forked Actions screen for multi-actions

### DIFF
--- a/front/components/assistant/TryAssistant.tsx
+++ b/front/components/assistant/TryAssistant.tsx
@@ -229,6 +229,7 @@ export function usePreviewAssistant({
         slackChannelsLinkedWithAgent: [],
       },
       isDraft: true,
+      useMultiActions: false,
     });
 
     animate();

--- a/front/components/assistant_builder/ActionScreen.tsx
+++ b/front/components/assistant_builder/ActionScreen.tsx
@@ -21,35 +21,21 @@ import { assertNever, removeNulls } from "@dust-tt/types";
 import type { ComponentType, ReactNode } from "react";
 import React, { useCallback } from "react";
 
-import {
-  ActionProcess,
-  isActionProcessValid,
-} from "@app/components/assistant_builder/actions/ProcessAction";
+import { ActionProcess } from "@app/components/assistant_builder/actions/ProcessAction";
 import {
   ActionRetrievalExhaustive,
   ActionRetrievalSearch,
-  isActionRetrievalExhaustiveValid,
-  isActionRetrievalSearchValid,
 } from "@app/components/assistant_builder/actions/RetrievalAction";
-import {
-  ActionTablesQuery,
-  isActionTablesQueryValid,
-} from "@app/components/assistant_builder/actions/TablesQueryAction";
+import { ActionTablesQuery } from "@app/components/assistant_builder/actions/TablesQueryAction";
 import type {
   AssistantBuilderActionConfiguration,
   AssistantBuilderActionType,
   AssistantBuilderState,
 } from "@app/components/assistant_builder/types";
 import { getDefaultActionConfiguration } from "@app/components/assistant_builder/types";
-import {
-  getDeprecatedDefaultSingleAction,
-  useDeprecatedDefaultSingleAction,
-} from "@app/lib/client/assistant_builder/deprecated_single_action";
+import { useDeprecatedDefaultSingleAction } from "@app/lib/client/assistant_builder/deprecated_single_action";
 
-import {
-  ActionDustAppRun,
-  isActionDustAppRunValid,
-} from "./actions/DustAppRunAction";
+import { ActionDustAppRun } from "./actions/DustAppRunAction";
 
 const BASIC_ACTION_CATEGORIES = ["REPLY_ONLY", "USE_DATA_SOURCES"] as const;
 const ADVANCED_ACTION_CATEGORIES = ["RUN_DUST_APP"] as const;
@@ -143,31 +129,6 @@ function ActionModeSection({
   show: boolean;
 }) {
   return show && <div className="flex flex-col gap-6">{children}</div>;
-}
-
-export function isActionValid(builderState: AssistantBuilderState): boolean {
-  // TODO(@fontanierh): handle multi-actions
-  const action = getDeprecatedDefaultSingleAction(builderState);
-
-  if (!action) {
-    // plain model
-    return true;
-  }
-
-  switch (action.type) {
-    case "RETRIEVAL_SEARCH":
-      return isActionRetrievalSearchValid(action);
-    case "RETRIEVAL_EXHAUSTIVE":
-      return isActionRetrievalExhaustiveValid(action);
-    case "PROCESS":
-      return isActionProcessValid(action);
-    case "DUST_APP_RUN":
-      return isActionDustAppRunValid(action);
-    case "TABLES_QUERY":
-      return isActionTablesQueryValid(action);
-    default:
-      assertNever(action);
-  }
 }
 
 export default function ActionScreen({

--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -333,7 +333,6 @@ function NewActionModal({
     }
   }, [initialAction, newAction]);
 
-  // Name has to be only lowercase letters, numbers and underscores
   const titleValid =
     (initialAction && initialAction?.name === newAction?.name) ||
     ((newAction?.name?.trim() ?? "").length > 0 &&

--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -1,0 +1,567 @@
+import {
+  Button,
+  ChatBubbleBottomCenterTextIcon,
+  CommandLineIcon,
+  ContentMessage,
+  DropdownMenu,
+  MagnifyingGlassIcon,
+  Page,
+  RobotIcon,
+  Square3Stack3DIcon,
+  TableIcon,
+  TimeIcon,
+} from "@dust-tt/sparkle";
+import type {
+  AppType,
+  DataSourceType,
+  WhitelistableFeature,
+  WorkspaceType,
+} from "@dust-tt/types";
+import { assertNever, removeNulls } from "@dust-tt/types";
+import type { ComponentType, ReactNode } from "react";
+import React, { useCallback } from "react";
+
+import {
+  ActionProcess,
+  isActionProcessValid,
+} from "@app/components/assistant_builder/actions/ProcessAction";
+import {
+  ActionRetrievalExhaustive,
+  ActionRetrievalSearch,
+  isActionRetrievalExhaustiveValid,
+  isActionRetrievalSearchValid,
+} from "@app/components/assistant_builder/actions/RetrievalAction";
+import {
+  ActionTablesQuery,
+  isActionTablesQueryValid,
+} from "@app/components/assistant_builder/actions/TablesQueryAction";
+import type {
+  AssistantBuilderActionConfiguration,
+  AssistantBuilderActionType,
+  AssistantBuilderState,
+} from "@app/components/assistant_builder/types";
+import { getDefaultActionConfiguration } from "@app/components/assistant_builder/types";
+import {
+  getDeprecatedDefaultSingleAction,
+  useDeprecatedDefaultSingleAction,
+} from "@app/lib/client/assistant_builder/deprecated_single_action";
+
+import {
+  ActionDustAppRun,
+  isActionDustAppRunValid,
+} from "./actions/DustAppRunAction";
+
+const BASIC_ACTION_CATEGORIES = ["REPLY_ONLY", "USE_DATA_SOURCES"] as const;
+const ADVANCED_ACTION_CATEGORIES = ["RUN_DUST_APP"] as const;
+
+type ActionCategory =
+  | (typeof BASIC_ACTION_CATEGORIES)[number]
+  | (typeof ADVANCED_ACTION_CATEGORIES)[number];
+
+const SEARCH_MODES = [
+  "RETRIEVAL_SEARCH",
+  "RETRIEVAL_EXHAUSTIVE",
+  "TABLES_QUERY",
+  "PROCESS",
+] as const;
+type SearchMode = (typeof SEARCH_MODES)[number];
+
+const ACTION_CATEGORY_SPECIFICATIONS: Record<
+  ActionCategory,
+  {
+    label: string;
+    icon: ComponentType;
+    description: string;
+    defaultActionType: AssistantBuilderActionType | null;
+  }
+> = {
+  REPLY_ONLY: {
+    label: "Reply only",
+    icon: ChatBubbleBottomCenterTextIcon,
+    description: "Direct answer from the model",
+    defaultActionType: null,
+  },
+  USE_DATA_SOURCES: {
+    label: "Use Data sources",
+    icon: Square3Stack3DIcon,
+    description: "Use Data sources to reply",
+    defaultActionType: "RETRIEVAL_SEARCH",
+  },
+  RUN_DUST_APP: {
+    label: "Run a Dust app",
+    icon: CommandLineIcon,
+    description: "Run a Dust app, then reply",
+    defaultActionType: "DUST_APP_RUN",
+  },
+};
+
+const SEARCH_MODE_SPECIFICATIONS: Record<
+  SearchMode,
+  {
+    actionType: AssistantBuilderActionType;
+    icon: ComponentType;
+    label: string;
+    description: string;
+    flag: WhitelistableFeature | null;
+  }
+> = {
+  RETRIEVAL_SEARCH: {
+    actionType: "RETRIEVAL_SEARCH",
+    icon: MagnifyingGlassIcon,
+    label: "Search",
+    description: "Search through selected Data sources",
+    flag: null,
+  },
+  RETRIEVAL_EXHAUSTIVE: {
+    actionType: "RETRIEVAL_EXHAUSTIVE",
+    icon: TimeIcon,
+    label: "Most recent data",
+    description: "Include as much data as possible",
+    flag: null,
+  },
+  TABLES_QUERY: {
+    actionType: "TABLES_QUERY",
+    icon: TableIcon,
+    label: "Query Tables",
+    description: "Tables, Spreadsheets, Notion DBs",
+    flag: null,
+  },
+  PROCESS: {
+    actionType: "PROCESS",
+    icon: RobotIcon,
+    label: "Process data",
+    description: "Structured extraction",
+    flag: "process_action",
+  },
+};
+
+function ActionModeSection({
+  children,
+  show,
+}: {
+  children: ReactNode;
+  show: boolean;
+}) {
+  return show && <div className="flex flex-col gap-6">{children}</div>;
+}
+
+export function isActionValid(builderState: AssistantBuilderState): boolean {
+  // TODO(@fontanierh): handle multi-actions
+  const action = getDeprecatedDefaultSingleAction(builderState);
+
+  if (!action) {
+    // plain model
+    return true;
+  }
+
+  switch (action.type) {
+    case "RETRIEVAL_SEARCH":
+      return isActionRetrievalSearchValid(action);
+    case "RETRIEVAL_EXHAUSTIVE":
+      return isActionRetrievalExhaustiveValid(action);
+    case "PROCESS":
+      return isActionProcessValid(action);
+    case "DUST_APP_RUN":
+      return isActionDustAppRunValid(action);
+    case "TABLES_QUERY":
+      return isActionTablesQueryValid(action);
+    default:
+      assertNever(action);
+  }
+}
+
+export default function ActionsScreen({
+  owner,
+  builderState,
+  dustApps,
+  dataSources,
+  setBuilderState,
+  setEdited,
+}: {
+  owner: WorkspaceType;
+  builderState: AssistantBuilderState;
+  dataSources: DataSourceType[];
+  dustApps: AppType[];
+  setBuilderState: (
+    stateFn: (state: AssistantBuilderState) => AssistantBuilderState
+  ) => void;
+  setEdited: (edited: boolean) => void;
+}) {
+  const getActionCategory = (actionType: AssistantBuilderActionType | null) => {
+    switch (actionType) {
+      case null:
+        return "REPLY_ONLY";
+      case "RETRIEVAL_EXHAUSTIVE":
+      case "RETRIEVAL_SEARCH":
+      case "TABLES_QUERY":
+      case "PROCESS":
+        return "USE_DATA_SOURCES";
+      case "DUST_APP_RUN":
+        return "RUN_DUST_APP";
+      default:
+        assertNever(actionType);
+    }
+  };
+
+  const getSearchMode = (actionType: AssistantBuilderActionType | null) => {
+    switch (actionType) {
+      case "RETRIEVAL_EXHAUSTIVE":
+        return "RETRIEVAL_EXHAUSTIVE";
+      case "RETRIEVAL_SEARCH":
+        return "RETRIEVAL_SEARCH";
+      case "TABLES_QUERY":
+        return "TABLES_QUERY";
+      case "PROCESS":
+        return "PROCESS";
+
+      case null:
+      case "DUST_APP_RUN":
+        // Unused for non data sources related actions.
+        return "RETRIEVAL_SEARCH";
+      default:
+        assertNever(actionType);
+    }
+  };
+
+  // TODO(@fontanierh): handle multi-actions
+  const action = useDeprecatedDefaultSingleAction(builderState) ?? null;
+
+  const dataSourceConfigs =
+    action && "dataSourceConfigurations" in action.configuration
+      ? action.configuration.dataSourceConfigurations
+      : {};
+  const noDataSources =
+    dataSources.length === 0 && Object.keys(dataSourceConfigs).length === 0;
+  const actionCategory = getActionCategory(action?.type ?? null);
+  const actionCategorySpec = ACTION_CATEGORY_SPECIFICATIONS[actionCategory];
+  const searchMode = getSearchMode(action?.type ?? null);
+  const searchModeSpec = SEARCH_MODE_SPECIFICATIONS[searchMode];
+
+  const deprecatedReplaceSingleActionConfig = useCallback(
+    (newAction: AssistantBuilderActionConfiguration) => {
+      setBuilderState((state) => {
+        const previousAction = state.actions[0];
+        if (!previousAction) {
+          // Unreachable
+          return state;
+        }
+
+        return {
+          ...state,
+          actions: [newAction],
+        };
+      });
+    },
+    [setBuilderState]
+  );
+
+  return (
+    <>
+      <div className="flex flex-col gap-4 text-sm text-element-700">
+        <div className="flex flex-col gap-2">
+          <Page.Header title="Action & Data sources" />
+          <Page.P>
+            <span className="text-sm text-element-700">
+              Before replying, the assistant can perform actions like{" "}
+              <span className="font-bold">searching information</span> from your{" "}
+              <span className="font-bold">Data sources</span> (Connections and
+              Folders).
+            </span>
+          </Page.P>
+        </div>
+
+        <div className="flex flex-row items-center space-x-2">
+          <div className="text-sm font-semibold text-element-900">Action:</div>
+          <DropdownMenu>
+            <DropdownMenu.Button>
+              <Button
+                type="select"
+                labelVisible={true}
+                label={actionCategorySpec.label}
+                icon={actionCategorySpec.icon}
+                variant="primary"
+                hasMagnifying={false}
+                size="sm"
+              />
+            </DropdownMenu.Button>
+            <DropdownMenu.Items origin="topLeft" width={260}>
+              {BASIC_ACTION_CATEGORIES.map((key) => {
+                const spec = ACTION_CATEGORY_SPECIFICATIONS[key];
+                const defaultAction = getDefaultActionConfiguration(
+                  spec.defaultActionType
+                );
+                return (
+                  <DropdownMenu.Item
+                    key={key}
+                    label={spec.label}
+                    icon={spec.icon}
+                    description={spec.description}
+                    onClick={() => {
+                      setEdited(true);
+                      setBuilderState((state) => {
+                        const newState: AssistantBuilderState = {
+                          ...state,
+                          actions: removeNulls([defaultAction]),
+                        };
+                        return newState;
+                      });
+                    }}
+                  />
+                );
+              })}
+              <DropdownMenu.SectionHeader label="Advanced actions" />
+              {ADVANCED_ACTION_CATEGORIES.map((key) => {
+                const spec = ACTION_CATEGORY_SPECIFICATIONS[key];
+                const defaultAction = getDefaultActionConfiguration(
+                  spec.defaultActionType
+                );
+                return (
+                  <DropdownMenu.Item
+                    key={key}
+                    label={spec.label}
+                    icon={spec.icon}
+                    description={spec.description}
+                    onClick={() => {
+                      setEdited(true);
+                      setBuilderState((state) => {
+                        const newState: AssistantBuilderState = {
+                          ...state,
+                          actions: removeNulls([defaultAction]),
+                        };
+                        return newState;
+                      });
+                    }}
+                  />
+                );
+              })}
+            </DropdownMenu.Items>
+          </DropdownMenu>
+        </div>
+
+        {getActionCategory(action?.type ?? null) === "USE_DATA_SOURCES" && (
+          <>
+            {noDataSources ? (
+              <ContentMessage
+                title="You don't have any Data source available"
+                variant="pink"
+              >
+                <div className="flex flex-col gap-y-3">
+                  {(() => {
+                    switch (owner.role) {
+                      case "admin":
+                        return (
+                          <div>
+                            Go to <strong>"Connections"</strong>,{" "}
+                            <strong>"Websites"</strong> and{" "}
+                            <strong>"Folders"</strong>
+                            sections in the Build panel to add new data sources.
+                          </div>
+                        );
+                      case "builder":
+                        return (
+                          <div>
+                            You can add Data Sources by visiting the "Websites"
+                            and "Folders" sections in the Build panel.
+                            <strong>
+                              Only Admins can activate Connections (Notion,
+                              Drive…).
+                            </strong>
+                          </div>
+                        );
+                      case "user":
+                        return (
+                          <div>
+                            Contact an <strong>Admin</strong> to add Data
+                            sources to your workspace!
+                          </div>
+                        );
+                      case "none":
+                        return <></>;
+                      default:
+                        assertNever(owner.role);
+                    }
+                  })()}
+                </div>
+              </ContentMessage>
+            ) : (
+              <div className="flex flex-row items-center space-x-2">
+                <div className="text-sm font-semibold text-element-900">
+                  Method:
+                </div>
+                <DropdownMenu>
+                  <DropdownMenu.Button>
+                    <Button
+                      type="select"
+                      labelVisible={true}
+                      label={searchModeSpec.label}
+                      icon={searchModeSpec.icon}
+                      variant="tertiary"
+                      hasMagnifying={false}
+                      size="sm"
+                    />
+                  </DropdownMenu.Button>
+                  <DropdownMenu.Items origin="topLeft" width={260}>
+                    {SEARCH_MODES.filter((key) => {
+                      const flag = SEARCH_MODE_SPECIFICATIONS[key].flag;
+                      return flag === null || owner.flags.includes(flag);
+                    }).map((key) => {
+                      const spec = SEARCH_MODE_SPECIFICATIONS[key];
+                      const defaultAction = getDefaultActionConfiguration(
+                        spec.actionType
+                      );
+                      return (
+                        <DropdownMenu.Item
+                          key={key}
+                          label={spec.label}
+                          icon={spec.icon}
+                          description={spec.description}
+                          onClick={() => {
+                            setEdited(true);
+                            setBuilderState((state) => {
+                              const newBuilderState: AssistantBuilderState = {
+                                ...state,
+                                actions: removeNulls([defaultAction]),
+                              };
+                              return newBuilderState;
+                            });
+                          }}
+                        />
+                      );
+                    })}
+                  </DropdownMenu.Items>
+                </DropdownMenu>
+              </div>
+            )}
+          </>
+        )}
+
+        <ActionModeSection show={!action}>
+          <div className="pb-16"></div>
+        </ActionModeSection>
+
+        <ActionModeSection
+          show={action?.type === "RETRIEVAL_SEARCH" && !noDataSources}
+        >
+          <ActionRetrievalSearch
+            owner={owner}
+            actionConfiguration={
+              action?.type === "RETRIEVAL_SEARCH" ? action.configuration : null
+            }
+            dataSources={dataSources}
+            updateAction={(newAction) => {
+              if (!action) {
+                // Unreachable
+                return;
+              }
+              deprecatedReplaceSingleActionConfig({
+                type: "RETRIEVAL_SEARCH",
+                configuration: newAction,
+                name: action.name,
+                description: action.description,
+              });
+            }}
+            setEdited={setEdited}
+          />
+        </ActionModeSection>
+
+        <ActionModeSection
+          show={action?.type === "RETRIEVAL_EXHAUSTIVE" && !noDataSources}
+        >
+          <ActionRetrievalExhaustive
+            owner={owner}
+            actionConfiguration={
+              action?.type === "RETRIEVAL_EXHAUSTIVE"
+                ? action.configuration
+                : null
+            }
+            dataSources={dataSources}
+            updateAction={(newAction) => {
+              if (!action) {
+                // Unreachable
+                return;
+              }
+              deprecatedReplaceSingleActionConfig({
+                type: "RETRIEVAL_EXHAUSTIVE",
+                configuration: newAction,
+                name: action.name,
+                description: action.description,
+              });
+            }}
+            setEdited={setEdited}
+          />
+        </ActionModeSection>
+
+        <ActionModeSection show={action?.type === "PROCESS" && !noDataSources}>
+          <ActionProcess
+            owner={owner}
+            actionConfiguration={
+              action?.type === "PROCESS" ? action.configuration : null
+            }
+            dataSources={dataSources}
+            updateAction={(newAction) => {
+              if (!action) {
+                // Unreachable
+                return;
+              }
+              deprecatedReplaceSingleActionConfig({
+                type: "PROCESS",
+                configuration: newAction,
+                name: action.name,
+                description: action.description,
+              });
+            }}
+            setEdited={setEdited}
+          />
+        </ActionModeSection>
+
+        <ActionModeSection
+          show={action?.type === "TABLES_QUERY" && !noDataSources}
+        >
+          <ActionTablesQuery
+            owner={owner}
+            actionConfiguration={
+              action?.type === "TABLES_QUERY" ? action.configuration : null
+            }
+            dataSources={dataSources}
+            updateAction={(newAction) => {
+              if (!action) {
+                // Unreachable
+                return;
+              }
+              deprecatedReplaceSingleActionConfig({
+                type: "TABLES_QUERY",
+                configuration: newAction,
+                name: action.name,
+                description: action.description,
+              });
+            }}
+            setEdited={setEdited}
+          />
+        </ActionModeSection>
+
+        <ActionModeSection show={action?.type === "DUST_APP_RUN"}>
+          <ActionDustAppRun
+            owner={owner}
+            actionConfigration={
+              action?.type === "DUST_APP_RUN" ? action.configuration : null
+            }
+            dustApps={dustApps}
+            updateAction={(newAction) => {
+              if (!action) {
+                // Unreachable
+                return;
+              }
+              deprecatedReplaceSingleActionConfig({
+                type: "DUST_APP_RUN",
+                configuration: newAction,
+                name: action.name,
+                description: action.description,
+              });
+            }}
+            setEdited={setEdited}
+          />
+        </ActionModeSection>
+      </div>
+    </>
+  );
+}

--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -1,25 +1,15 @@
 import {
   Button,
-  ChatBubbleBottomCenterTextIcon,
-  CommandLineIcon,
-  ContentMessage,
   DropdownMenu,
-  MagnifyingGlassIcon,
+  Input,
+  Modal,
   Page,
-  RobotIcon,
-  Square3Stack3DIcon,
-  TableIcon,
-  TimeIcon,
+  PlusIcon,
 } from "@dust-tt/sparkle";
-import type {
-  AppType,
-  DataSourceType,
-  WhitelistableFeature,
-  WorkspaceType,
-} from "@dust-tt/types";
-import { assertNever, removeNulls } from "@dust-tt/types";
-import type { ComponentType, ReactNode } from "react";
-import React, { useCallback } from "react";
+import type { AppType, DataSourceType, WorkspaceType } from "@dust-tt/types";
+import { assertNever } from "@dust-tt/types";
+import type { ReactNode } from "react";
+import React, { useCallback, useState } from "react";
 
 import {
   ActionProcess,
@@ -37,102 +27,24 @@ import {
 } from "@app/components/assistant_builder/actions/TablesQueryAction";
 import type {
   AssistantBuilderActionConfiguration,
-  AssistantBuilderActionType,
   AssistantBuilderState,
 } from "@app/components/assistant_builder/types";
 import { getDefaultActionConfiguration } from "@app/components/assistant_builder/types";
-import {
-  getDeprecatedDefaultSingleAction,
-  useDeprecatedDefaultSingleAction,
-} from "@app/lib/client/assistant_builder/deprecated_single_action";
 
 import {
   ActionDustAppRun,
   isActionDustAppRunValid,
 } from "./actions/DustAppRunAction";
 
-const BASIC_ACTION_CATEGORIES = ["REPLY_ONLY", "USE_DATA_SOURCES"] as const;
-const ADVANCED_ACTION_CATEGORIES = ["RUN_DUST_APP"] as const;
-
-type ActionCategory =
-  | (typeof BASIC_ACTION_CATEGORIES)[number]
-  | (typeof ADVANCED_ACTION_CATEGORIES)[number];
-
-const SEARCH_MODES = [
-  "RETRIEVAL_SEARCH",
-  "RETRIEVAL_EXHAUSTIVE",
-  "TABLES_QUERY",
-  "PROCESS",
-] as const;
-type SearchMode = (typeof SEARCH_MODES)[number];
-
-const ACTION_CATEGORY_SPECIFICATIONS: Record<
-  ActionCategory,
-  {
-    label: string;
-    icon: ComponentType;
-    description: string;
-    defaultActionType: AssistantBuilderActionType | null;
-  }
+const ACTION_TYPE_TO_LABEL: Record<
+  AssistantBuilderActionConfiguration["type"],
+  string
 > = {
-  REPLY_ONLY: {
-    label: "Reply only",
-    icon: ChatBubbleBottomCenterTextIcon,
-    description: "Direct answer from the model",
-    defaultActionType: null,
-  },
-  USE_DATA_SOURCES: {
-    label: "Use Data sources",
-    icon: Square3Stack3DIcon,
-    description: "Use Data sources to reply",
-    defaultActionType: "RETRIEVAL_SEARCH",
-  },
-  RUN_DUST_APP: {
-    label: "Run a Dust app",
-    icon: CommandLineIcon,
-    description: "Run a Dust app, then reply",
-    defaultActionType: "DUST_APP_RUN",
-  },
-};
-
-const SEARCH_MODE_SPECIFICATIONS: Record<
-  SearchMode,
-  {
-    actionType: AssistantBuilderActionType;
-    icon: ComponentType;
-    label: string;
-    description: string;
-    flag: WhitelistableFeature | null;
-  }
-> = {
-  RETRIEVAL_SEARCH: {
-    actionType: "RETRIEVAL_SEARCH",
-    icon: MagnifyingGlassIcon,
-    label: "Search",
-    description: "Search through selected Data sources",
-    flag: null,
-  },
-  RETRIEVAL_EXHAUSTIVE: {
-    actionType: "RETRIEVAL_EXHAUSTIVE",
-    icon: TimeIcon,
-    label: "Most recent data",
-    description: "Include as much data as possible",
-    flag: null,
-  },
-  TABLES_QUERY: {
-    actionType: "TABLES_QUERY",
-    icon: TableIcon,
-    label: "Query Tables",
-    description: "Tables, Spreadsheets, Notion DBs",
-    flag: null,
-  },
-  PROCESS: {
-    actionType: "PROCESS",
-    icon: RobotIcon,
-    label: "Process data",
-    description: "Structured extraction",
-    flag: "process_action",
-  },
+  RETRIEVAL_SEARCH: "Search",
+  RETRIEVAL_EXHAUSTIVE: "Exhaustive Search",
+  PROCESS: "Process",
+  DUST_APP_RUN: "Dust App",
+  TABLES_QUERY: "Tables Query",
 };
 
 function ActionModeSection({
@@ -145,15 +57,9 @@ function ActionModeSection({
   return show && <div className="flex flex-col gap-6">{children}</div>;
 }
 
-export function isActionValid(builderState: AssistantBuilderState): boolean {
-  // TODO(@fontanierh): handle multi-actions
-  const action = getDeprecatedDefaultSingleAction(builderState);
-
-  if (!action) {
-    // plain model
-    return true;
-  }
-
+export function isActionValid(
+  action: AssistantBuilderActionConfiguration
+): boolean {
   switch (action.type) {
     case "RETRIEVAL_SEARCH":
       return isActionRetrievalSearchValid(action);
@@ -187,77 +93,45 @@ export default function ActionsScreen({
   ) => void;
   setEdited: (edited: boolean) => void;
 }) {
-  const getActionCategory = (actionType: AssistantBuilderActionType | null) => {
-    switch (actionType) {
-      case null:
-        return "REPLY_ONLY";
-      case "RETRIEVAL_EXHAUSTIVE":
-      case "RETRIEVAL_SEARCH":
-      case "TABLES_QUERY":
-      case "PROCESS":
-        return "USE_DATA_SOURCES";
-      case "DUST_APP_RUN":
-        return "RUN_DUST_APP";
-      default:
-        assertNever(actionType);
-    }
-  };
+  const [newActionModalOpen, setNewActionModalOpen] = React.useState(false);
 
-  const getSearchMode = (actionType: AssistantBuilderActionType | null) => {
-    switch (actionType) {
-      case "RETRIEVAL_EXHAUSTIVE":
-        return "RETRIEVAL_EXHAUSTIVE";
-      case "RETRIEVAL_SEARCH":
-        return "RETRIEVAL_SEARCH";
-      case "TABLES_QUERY":
-        return "TABLES_QUERY";
-      case "PROCESS":
-        return "PROCESS";
-
-      case null:
-      case "DUST_APP_RUN":
-        // Unused for non data sources related actions.
-        return "RETRIEVAL_SEARCH";
-      default:
-        assertNever(actionType);
-    }
-  };
-
-  // TODO(@fontanierh): handle multi-actions
-  const action = useDeprecatedDefaultSingleAction(builderState) ?? null;
-
-  const dataSourceConfigs =
-    action && "dataSourceConfigurations" in action.configuration
-      ? action.configuration.dataSourceConfigurations
-      : {};
-  const noDataSources =
-    dataSources.length === 0 && Object.keys(dataSourceConfigs).length === 0;
-  const actionCategory = getActionCategory(action?.type ?? null);
-  const actionCategorySpec = ACTION_CATEGORY_SPECIFICATIONS[actionCategory];
-  const searchMode = getSearchMode(action?.type ?? null);
-  const searchModeSpec = SEARCH_MODE_SPECIFICATIONS[searchMode];
-
-  const deprecatedReplaceSingleActionConfig = useCallback(
+  const upsertAction = useCallback(
     (newAction: AssistantBuilderActionConfiguration) => {
       setBuilderState((state) => {
-        const previousAction = state.actions[0];
-        if (!previousAction) {
-          // Unreachable
-          return state;
+        let found = false;
+        const newActions = state.actions.map((action) => {
+          if (action.name === newAction.name) {
+            found = true;
+            return newAction;
+          }
+          return action;
+        });
+        if (!found) {
+          newActions.push(newAction);
         }
-
         return {
           ...state,
-          actions: [newAction],
+          actions: newActions,
         };
       });
     },
     [setBuilderState]
   );
 
+  const allActionsValid = builderState.actions.every(isActionValid);
+
   return (
     <>
-      <div className="flex flex-col gap-4 text-sm text-element-700">
+      <NewActionModal
+        isOpen={newActionModalOpen}
+        setOpen={setNewActionModalOpen}
+        builderState={builderState}
+        onSave={(newAction) => {
+          upsertAction(newAction);
+          setNewActionModalOpen(false);
+        }}
+      />
+      <div className="flex flex-col gap-8 text-sm text-element-700">
         <div className="flex flex-col gap-2">
           <Page.Header title="Action & Data sources" />
           <Page.P>
@@ -270,298 +144,239 @@ export default function ActionsScreen({
           </Page.P>
         </div>
 
-        <div className="flex flex-row items-center space-x-2">
-          <div className="text-sm font-semibold text-element-900">Action:</div>
+        <div className="flex flex-col gap-8">
+          {builderState.actions.map((a) => (
+            <div key={a.name}>
+              <Page.SectionHeader title={a.name} />
+              <Page.P>{a.description}</Page.P>
+              <div className="py-8">
+                <ActionModeSection show={true}>
+                  {(() => {
+                    switch (a.type) {
+                      case "DUST_APP_RUN":
+                        return (
+                          <ActionDustAppRun
+                            owner={owner}
+                            actionConfigration={a.configuration}
+                            dustApps={dustApps}
+                            updateAction={(newAction) => {
+                              upsertAction({
+                                ...a,
+                                configuration: newAction,
+                              });
+                            }}
+                            setEdited={setEdited}
+                          />
+                        );
+                      case "RETRIEVAL_SEARCH":
+                        return (
+                          <ActionRetrievalSearch
+                            owner={owner}
+                            actionConfiguration={a.configuration}
+                            dataSources={dataSources}
+                            updateAction={(newAction) => {
+                              upsertAction({
+                                ...a,
+                                configuration: newAction,
+                              });
+                            }}
+                            setEdited={setEdited}
+                          />
+                        );
+                      case "RETRIEVAL_EXHAUSTIVE":
+                        return (
+                          <ActionRetrievalExhaustive
+                            owner={owner}
+                            actionConfiguration={a.configuration}
+                            dataSources={dataSources}
+                            updateAction={(newAction) => {
+                              upsertAction({
+                                ...a,
+                                configuration: newAction,
+                              });
+                            }}
+                            setEdited={setEdited}
+                          />
+                        );
+                      case "PROCESS":
+                        return (
+                          <ActionProcess
+                            owner={owner}
+                            actionConfiguration={a.configuration}
+                            dataSources={dataSources}
+                            updateAction={(newAction) => {
+                              upsertAction({
+                                ...a,
+                                configuration: newAction,
+                              });
+                            }}
+                            setEdited={setEdited}
+                          />
+                        );
+                      case "TABLES_QUERY":
+                        return (
+                          <ActionTablesQuery
+                            owner={owner}
+                            actionConfiguration={a.configuration}
+                            dataSources={dataSources}
+                            updateAction={(newAction) => {
+                              upsertAction({
+                                ...a,
+                                configuration: newAction,
+                              });
+                            }}
+                            setEdited={setEdited}
+                          />
+                        );
+                      default:
+                        assertNever(a);
+                    }
+                  })()}
+                </ActionModeSection>
+              </div>
+              <Page.Separator />
+            </div>
+          ))}
+
+          <div className="pt-8">
+            <Button
+              variant="secondary"
+              label="Add Action"
+              icon={PlusIcon}
+              disabled={!allActionsValid}
+              onClick={() => {
+                setNewActionModalOpen(true);
+              }}
+            />
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}
+
+function NewActionModal({
+  isOpen,
+  setOpen,
+  builderState,
+  onSave,
+}: {
+  isOpen: boolean;
+  setOpen: (isOpen: boolean) => void;
+  builderState: AssistantBuilderState;
+  onSave: (newAction: AssistantBuilderActionConfiguration) => void;
+}) {
+  const [newAction, setNewAction] =
+    useState<AssistantBuilderActionConfiguration | null>(null);
+
+  const titleValid =
+    (newAction?.name?.trim() ?? "").length > 0 &&
+    !builderState.actions.some((a) => a.name === newAction?.name);
+
+  const descriptionValid = (newAction?.description?.trim() ?? "").length > 0;
+
+  const onClose = () => {
+    setOpen(false);
+    setTimeout(() => {
+      setNewAction(null);
+    }, 500);
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      hasChanged={true}
+      variant="side-md"
+      title="Add Action"
+      onSave={
+        newAction && titleValid && descriptionValid
+          ? () => {
+              newAction.name = newAction.name.trim();
+              newAction.description = newAction.description.trim();
+              onSave(newAction);
+              onClose();
+            }
+          : undefined
+      }
+    >
+      <div className="w-full pl-4 pt-12">
+        <div className="flex flex-col gap-4">
           <DropdownMenu>
-            <DropdownMenu.Button>
+            <DropdownMenu.Button tooltipPosition="above">
               <Button
                 type="select"
                 labelVisible={true}
-                label={actionCategorySpec.label}
-                icon={actionCategorySpec.icon}
-                variant="primary"
-                hasMagnifying={false}
+                label={
+                  newAction
+                    ? ACTION_TYPE_TO_LABEL[newAction.type]
+                    : "Select Action"
+                }
+                variant="secondary"
                 size="sm"
               />
             </DropdownMenu.Button>
-            <DropdownMenu.Items origin="topLeft" width={260}>
-              {BASIC_ACTION_CATEGORIES.map((key) => {
-                const spec = ACTION_CATEGORY_SPECIFICATIONS[key];
-                const defaultAction = getDefaultActionConfiguration(
-                  spec.defaultActionType
-                );
-                return (
-                  <DropdownMenu.Item
-                    key={key}
-                    label={spec.label}
-                    icon={spec.icon}
-                    description={spec.description}
-                    onClick={() => {
-                      setEdited(true);
-                      setBuilderState((state) => {
-                        const newState: AssistantBuilderState = {
-                          ...state,
-                          actions: removeNulls([defaultAction]),
-                        };
-                        return newState;
-                      });
-                    }}
-                  />
-                );
-              })}
-              <DropdownMenu.SectionHeader label="Advanced actions" />
-              {ADVANCED_ACTION_CATEGORIES.map((key) => {
-                const spec = ACTION_CATEGORY_SPECIFICATIONS[key];
-                const defaultAction = getDefaultActionConfiguration(
-                  spec.defaultActionType
-                );
-                return (
-                  <DropdownMenu.Item
-                    key={key}
-                    label={spec.label}
-                    icon={spec.icon}
-                    description={spec.description}
-                    onClick={() => {
-                      setEdited(true);
-                      setBuilderState((state) => {
-                        const newState: AssistantBuilderState = {
-                          ...state,
-                          actions: removeNulls([defaultAction]),
-                        };
-                        return newState;
-                      });
-                    }}
-                  />
-                );
-              })}
+            <DropdownMenu.Items origin="topLeft">
+              {Object.entries(ACTION_TYPE_TO_LABEL).map(([key, value]) => (
+                <DropdownMenu.Item
+                  key={key}
+                  label={value}
+                  onClick={() => {
+                    const defaultConfiguration = getDefaultActionConfiguration(
+                      key as AssistantBuilderActionConfiguration["type"]
+                    );
+                    if (!defaultConfiguration) {
+                      // Unreachable
+                      return;
+                    }
+                    let index = 1;
+                    const suffixedName = () =>
+                      index > 1
+                        ? `${defaultConfiguration.name} (${index})`
+                        : defaultConfiguration.name;
+                    while (
+                      builderState.actions.some(
+                        (a) => a.name === suffixedName()
+                      )
+                    ) {
+                      index += 1;
+                    }
+                    defaultConfiguration.name = suffixedName();
+                    setNewAction(defaultConfiguration);
+                  }}
+                />
+              ))}
             </DropdownMenu.Items>
           </DropdownMenu>
+          {newAction ? (
+            <>
+              <Input
+                name="actionName"
+                placeholder="My action name.."
+                value={newAction?.name ?? null}
+                onChange={(v) => {
+                  setNewAction({
+                    ...newAction,
+                    name: v,
+                  });
+                }}
+                error={!titleValid ? "Name already exists" : null}
+              />
+              <Input
+                name="actionDescription"
+                placeholder="My action description.."
+                value={newAction?.description ?? null}
+                onChange={(v) => {
+                  setNewAction({
+                    ...newAction,
+                    description: v,
+                  });
+                }}
+              />
+            </>
+          ) : null}
         </div>
-
-        {getActionCategory(action?.type ?? null) === "USE_DATA_SOURCES" && (
-          <>
-            {noDataSources ? (
-              <ContentMessage
-                title="You don't have any Data source available"
-                variant="pink"
-              >
-                <div className="flex flex-col gap-y-3">
-                  {(() => {
-                    switch (owner.role) {
-                      case "admin":
-                        return (
-                          <div>
-                            Go to <strong>"Connections"</strong>,{" "}
-                            <strong>"Websites"</strong> and{" "}
-                            <strong>"Folders"</strong>
-                            sections in the Build panel to add new data sources.
-                          </div>
-                        );
-                      case "builder":
-                        return (
-                          <div>
-                            You can add Data Sources by visiting the "Websites"
-                            and "Folders" sections in the Build panel.
-                            <strong>
-                              Only Admins can activate Connections (Notion,
-                              Drive…).
-                            </strong>
-                          </div>
-                        );
-                      case "user":
-                        return (
-                          <div>
-                            Contact an <strong>Admin</strong> to add Data
-                            sources to your workspace!
-                          </div>
-                        );
-                      case "none":
-                        return <></>;
-                      default:
-                        assertNever(owner.role);
-                    }
-                  })()}
-                </div>
-              </ContentMessage>
-            ) : (
-              <div className="flex flex-row items-center space-x-2">
-                <div className="text-sm font-semibold text-element-900">
-                  Method:
-                </div>
-                <DropdownMenu>
-                  <DropdownMenu.Button>
-                    <Button
-                      type="select"
-                      labelVisible={true}
-                      label={searchModeSpec.label}
-                      icon={searchModeSpec.icon}
-                      variant="tertiary"
-                      hasMagnifying={false}
-                      size="sm"
-                    />
-                  </DropdownMenu.Button>
-                  <DropdownMenu.Items origin="topLeft" width={260}>
-                    {SEARCH_MODES.filter((key) => {
-                      const flag = SEARCH_MODE_SPECIFICATIONS[key].flag;
-                      return flag === null || owner.flags.includes(flag);
-                    }).map((key) => {
-                      const spec = SEARCH_MODE_SPECIFICATIONS[key];
-                      const defaultAction = getDefaultActionConfiguration(
-                        spec.actionType
-                      );
-                      return (
-                        <DropdownMenu.Item
-                          key={key}
-                          label={spec.label}
-                          icon={spec.icon}
-                          description={spec.description}
-                          onClick={() => {
-                            setEdited(true);
-                            setBuilderState((state) => {
-                              const newBuilderState: AssistantBuilderState = {
-                                ...state,
-                                actions: removeNulls([defaultAction]),
-                              };
-                              return newBuilderState;
-                            });
-                          }}
-                        />
-                      );
-                    })}
-                  </DropdownMenu.Items>
-                </DropdownMenu>
-              </div>
-            )}
-          </>
-        )}
-
-        <ActionModeSection show={!action}>
-          <div className="pb-16"></div>
-        </ActionModeSection>
-
-        <ActionModeSection
-          show={action?.type === "RETRIEVAL_SEARCH" && !noDataSources}
-        >
-          <ActionRetrievalSearch
-            owner={owner}
-            actionConfiguration={
-              action?.type === "RETRIEVAL_SEARCH" ? action.configuration : null
-            }
-            dataSources={dataSources}
-            updateAction={(newAction) => {
-              if (!action) {
-                // Unreachable
-                return;
-              }
-              deprecatedReplaceSingleActionConfig({
-                type: "RETRIEVAL_SEARCH",
-                configuration: newAction,
-                name: action.name,
-                description: action.description,
-              });
-            }}
-            setEdited={setEdited}
-          />
-        </ActionModeSection>
-
-        <ActionModeSection
-          show={action?.type === "RETRIEVAL_EXHAUSTIVE" && !noDataSources}
-        >
-          <ActionRetrievalExhaustive
-            owner={owner}
-            actionConfiguration={
-              action?.type === "RETRIEVAL_EXHAUSTIVE"
-                ? action.configuration
-                : null
-            }
-            dataSources={dataSources}
-            updateAction={(newAction) => {
-              if (!action) {
-                // Unreachable
-                return;
-              }
-              deprecatedReplaceSingleActionConfig({
-                type: "RETRIEVAL_EXHAUSTIVE",
-                configuration: newAction,
-                name: action.name,
-                description: action.description,
-              });
-            }}
-            setEdited={setEdited}
-          />
-        </ActionModeSection>
-
-        <ActionModeSection show={action?.type === "PROCESS" && !noDataSources}>
-          <ActionProcess
-            owner={owner}
-            actionConfiguration={
-              action?.type === "PROCESS" ? action.configuration : null
-            }
-            dataSources={dataSources}
-            updateAction={(newAction) => {
-              if (!action) {
-                // Unreachable
-                return;
-              }
-              deprecatedReplaceSingleActionConfig({
-                type: "PROCESS",
-                configuration: newAction,
-                name: action.name,
-                description: action.description,
-              });
-            }}
-            setEdited={setEdited}
-          />
-        </ActionModeSection>
-
-        <ActionModeSection
-          show={action?.type === "TABLES_QUERY" && !noDataSources}
-        >
-          <ActionTablesQuery
-            owner={owner}
-            actionConfiguration={
-              action?.type === "TABLES_QUERY" ? action.configuration : null
-            }
-            dataSources={dataSources}
-            updateAction={(newAction) => {
-              if (!action) {
-                // Unreachable
-                return;
-              }
-              deprecatedReplaceSingleActionConfig({
-                type: "TABLES_QUERY",
-                configuration: newAction,
-                name: action.name,
-                description: action.description,
-              });
-            }}
-            setEdited={setEdited}
-          />
-        </ActionModeSection>
-
-        <ActionModeSection show={action?.type === "DUST_APP_RUN"}>
-          <ActionDustAppRun
-            owner={owner}
-            actionConfigration={
-              action?.type === "DUST_APP_RUN" ? action.configuration : null
-            }
-            dustApps={dustApps}
-            updateAction={(newAction) => {
-              if (!action) {
-                // Unreachable
-                return;
-              }
-              deprecatedReplaceSingleActionConfig({
-                type: "DUST_APP_RUN",
-                configuration: newAction,
-                name: action.name,
-                description: action.description,
-              });
-            }}
-            setEdited={setEdited}
-          />
-        </ActionModeSection>
       </div>
-    </>
+    </Modal>
   );
 }

--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -99,6 +99,7 @@ export default function ActionsScreen({
 
   const upsertAction = useCallback(
     (newAction: AssistantBuilderActionConfiguration) => {
+      setEdited(true);
       setBuilderState((state) => {
         let found = false;
         const newActions = state.actions.map((action) => {
@@ -117,11 +118,12 @@ export default function ActionsScreen({
         };
       });
     },
-    [setBuilderState]
+    [setBuilderState, setEdited]
   );
 
   const updateAction = useCallback(
     (name: string, newAction: AssistantBuilderActionConfiguration) => {
+      setEdited(true);
       setBuilderState((state) => {
         return {
           ...state,
@@ -129,11 +131,12 @@ export default function ActionsScreen({
         };
       });
     },
-    [setBuilderState]
+    [setBuilderState, setEdited]
   );
 
   const deleteAction = useCallback(
     (name: string) => {
+      setEdited(true);
       setBuilderState((state) => {
         return {
           ...state,
@@ -141,7 +144,7 @@ export default function ActionsScreen({
         };
       });
     },
-    [setBuilderState]
+    [setBuilderState, setEdited]
   );
 
   const allActionsValid = builderState.actions.every(isActionValid);
@@ -362,7 +365,7 @@ function NewActionModal({
               newAction.name = newAction.name.trim();
               newAction.description = newAction.description.trim();
               onSave(newAction);
-              onClose();
+              onCloseLocal();
             }
           : undefined
       }

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -47,6 +47,7 @@ import { SharingButton } from "@app/components/assistant/Sharing";
 import ActionScreen, {
   isActionValid,
 } from "@app/components/assistant_builder/ActionScreen";
+import ActionsScreen from "@app/components/assistant_builder/ActionsScreen";
 import AssistantBuilderRightPanel from "@app/components/assistant_builder/AssistantBuilderPreviewDrawer";
 import { InstructionScreen } from "@app/components/assistant_builder/InstructionScreen";
 import NamingScreen, {
@@ -99,6 +100,7 @@ type AssistantBuilderProps = {
   defaultIsEdited?: boolean;
   baseUrl: string;
   defaultTemplate: FetchAssistantTemplateResponse | null;
+  multiActionsMode: boolean;
 };
 
 const useNavigationLock = (
@@ -196,6 +198,7 @@ export default function AssistantBuilder({
   defaultIsEdited,
   baseUrl,
   defaultTemplate,
+  multiActionsMode,
 }: AssistantBuilderProps) {
   const router = useRouter();
   const { mutate } = useSWRConfig();
@@ -557,16 +560,30 @@ export default function AssistantBuilder({
                       />
                     );
                   case "actions":
-                    return (
-                      <ActionScreen
-                        owner={owner}
-                        builderState={builderState}
-                        dataSources={dataSources}
-                        dustApps={dustApps}
-                        setBuilderState={setBuilderState}
-                        setEdited={setEdited}
-                      />
-                    );
+                    // TODO(@fontanierh): Remove single actions.
+                    if (!multiActionsMode) {
+                      return (
+                        <ActionScreen
+                          owner={owner}
+                          builderState={builderState}
+                          dataSources={dataSources}
+                          dustApps={dustApps}
+                          setBuilderState={setBuilderState}
+                          setEdited={setEdited}
+                        />
+                      );
+                    } else {
+                      return (
+                        <ActionsScreen
+                          owner={owner}
+                          builderState={builderState}
+                          dataSources={dataSources}
+                          dustApps={dustApps}
+                          setBuilderState={setBuilderState}
+                          setEdited={setEdited}
+                        />
+                      );
+                    }
                   case "naming":
                     return (
                       <NamingScreen

--- a/front/components/assistant_builder/server_side_props_helpers.ts
+++ b/front/components/assistant_builder/server_side_props_helpers.ts
@@ -15,6 +15,7 @@ import {
   isProcessConfiguration,
   isRetrievalConfiguration,
   isTablesQueryConfiguration,
+  removeNulls,
 } from "@dust-tt/types";
 
 import type {
@@ -37,10 +38,12 @@ export async function buildInitialActions({
   dataSourcesByName,
   dustApps,
   configuration,
+  multiActionsMode,
 }: {
   dataSourcesByName: Record<string, DataSourceType>;
   dustApps: AppType[];
   configuration: AgentConfigurationType | TemplateAgentConfigurationType;
+  multiActionsMode: boolean;
 }): Promise<AssistantBuilderActionConfiguration[]> {
   const coreAPI = new CoreAPI(logger);
 
@@ -102,89 +105,102 @@ export async function buildInitialActions({
     return dataSourceConfigurations;
   };
 
-  const action = deprecatedGetFirstActionConfiguration(configuration);
+  const actions = !multiActionsMode
+    ? removeNulls([deprecatedGetFirstActionConfiguration(configuration)])
+    : configuration.actions;
 
-  if (!action) {
-    return [];
-  } else if (isRetrievalConfiguration(action)) {
-    const isSearch = action.query !== "none";
+  const builderActions: AssistantBuilderActionConfiguration[] = [];
 
-    const retrievalConfiguration = isSearch
-      ? getDefaultRetrievalSearchActionConfiguration()
-      : getDefaultRetrievalExhaustiveActionConfiguration();
+  for (const action of actions) {
+    if (isRetrievalConfiguration(action)) {
+      const isSearch = action.query !== "none";
 
-    if (
-      action.relativeTimeFrame !== "auto" &&
-      action.relativeTimeFrame !== "none"
-    ) {
-      retrievalConfiguration.configuration.timeFrame = {
-        value: action.relativeTimeFrame.duration,
-        unit: action.relativeTimeFrame.unit,
-      };
-    }
+      const retrievalConfiguration = isSearch
+        ? getDefaultRetrievalSearchActionConfiguration()
+        : getDefaultRetrievalExhaustiveActionConfiguration();
 
-    retrievalConfiguration.configuration.dataSourceConfigurations =
-      await renderDataSourcesConfigurations(action);
-
-    return [retrievalConfiguration];
-  } else if (isDustAppRunConfiguration(action)) {
-    const dustAppConfiguration = getDefaultDustAppRunActionConfiguration();
-    for (const app of dustApps) {
-      if (app.sId === action.appId) {
-        dustAppConfiguration.configuration.app = app;
-        break;
-      }
-    }
-    return [dustAppConfiguration];
-  } else if (isTablesQueryConfiguration(action)) {
-    const tablesQueryConfiguration = getDefaultTablesQueryActionConfiguration();
-
-    const coreAPITables: CoreAPITable[] = await Promise.all(
-      action.tables.map(async (t) => {
-        const dataSource = dataSourcesByName[t.dataSourceId];
-        const coreAPITable = await coreAPI.getTable({
-          projectId: dataSource.dustAPIProjectId,
-          dataSourceName: dataSource.name,
-          tableId: t.tableId,
-        });
-
-        if (coreAPITable.isErr()) {
-          throw coreAPITable.error;
-        }
-
-        return coreAPITable.value.table;
-      })
-    );
-
-    tablesQueryConfiguration.configuration = action.tables.reduce(
-      (acc, curr, i) => {
-        const table = coreAPITables[i];
-        const key = tableKey(curr);
-        return {
-          ...acc,
-          [key]: {
-            workspaceId: curr.workspaceId,
-            dataSourceId: curr.dataSourceId,
-            tableId: curr.tableId,
-            tableName: `${table.name}`,
-          },
+      if (
+        action.relativeTimeFrame !== "auto" &&
+        action.relativeTimeFrame !== "none"
+      ) {
+        retrievalConfiguration.configuration.timeFrame = {
+          value: action.relativeTimeFrame.duration,
+          unit: action.relativeTimeFrame.unit,
         };
-      },
-      {} as AssistantBuilderTablesQueryConfiguration
-    );
+      }
 
-    return [tablesQueryConfiguration];
-  } else if (isProcessConfiguration(action)) {
-    const processConfiguration = getDefaultProcessActionConfiguration();
-    if (
-      action.relativeTimeFrame !== "auto" &&
-      action.relativeTimeFrame !== "none"
-    ) {
-      processConfiguration.configuration.timeFrame = {
-        value: action.relativeTimeFrame.duration,
-        unit: action.relativeTimeFrame.unit,
-      };
-    }
+      retrievalConfiguration.configuration.dataSourceConfigurations =
+        await renderDataSourcesConfigurations(action);
+
+      builderActions.push(retrievalConfiguration);
+    } else if (isDustAppRunConfiguration(action)) {
+      const dustAppConfiguration = getDefaultDustAppRunActionConfiguration();
+      for (const app of dustApps) {
+        if (app.sId === action.appId) {
+          dustAppConfiguration.configuration.app = app;
+          break;
+        }
+      }
+
+      builderActions.push(dustAppConfiguration);
+    } else if (isTablesQueryConfiguration(action)) {
+      const tablesQueryConfiguration =
+        getDefaultTablesQueryActionConfiguration();
+
+      const coreAPITables: CoreAPITable[] = await Promise.all(
+        action.tables.map(async (t) => {
+          const dataSource = dataSourcesByName[t.dataSourceId];
+          const coreAPITable = await coreAPI.getTable({
+            projectId: dataSource.dustAPIProjectId,
+            dataSourceName: dataSource.name,
+            tableId: t.tableId,
+          });
+
+          if (coreAPITable.isErr()) {
+            throw coreAPITable.error;
+          }
+
+          return coreAPITable.value.table;
+        })
+      );
+
+      tablesQueryConfiguration.configuration = action.tables.reduce(
+        (acc, curr, i) => {
+          const table = coreAPITables[i];
+          const key = tableKey(curr);
+          return {
+            ...acc,
+            [key]: {
+              workspaceId: curr.workspaceId,
+              dataSourceId: curr.dataSourceId,
+              tableId: curr.tableId,
+              tableName: `${table.name}`,
+            },
+          };
+        },
+        {} as AssistantBuilderTablesQueryConfiguration
+      );
+
+      builderActions.push(tablesQueryConfiguration);
+    } else if (isProcessConfiguration(action)) {
+      const processConfiguration = getDefaultProcessActionConfiguration();
+      if (
+        action.relativeTimeFrame !== "auto" &&
+        action.relativeTimeFrame !== "none"
+      ) {
+        processConfiguration.configuration.timeFrame = {
+          value: action.relativeTimeFrame.duration,
+          unit: action.relativeTimeFrame.unit,
+        };
+      }
+
+      processConfiguration.configuration.dataSourceConfigurations =
+        await renderDataSourcesConfigurations(action);
+
+      processConfiguration.configuration.schema = action.schema;
+
+
+    
 
     processConfiguration.configuration.tagsFilter = action.tagsFilter;
 
@@ -193,8 +209,10 @@ export async function buildInitialActions({
 
     processConfiguration.configuration.schema = action.schema;
 
-    return [processConfiguration];
+    builderActions.push(processConfiguration);
   } else {
     assertNever(action);
   }
+
+  return builderActions;
 }

--- a/front/components/assistant_builder/server_side_props_helpers.ts
+++ b/front/components/assistant_builder/server_side_props_helpers.ts
@@ -194,24 +194,17 @@ export async function buildInitialActions({
         };
       }
 
+      processConfiguration.configuration.tagsFilter = action.tagsFilter;
+
       processConfiguration.configuration.dataSourceConfigurations =
         await renderDataSourcesConfigurations(action);
 
       processConfiguration.configuration.schema = action.schema;
 
-
-    
-
-    processConfiguration.configuration.tagsFilter = action.tagsFilter;
-
-    processConfiguration.configuration.dataSourceConfigurations =
-      await renderDataSourcesConfigurations(action);
-
-    processConfiguration.configuration.schema = action.schema;
-
-    builderActions.push(processConfiguration);
-  } else {
-    assertNever(action);
+      builderActions.push(processConfiguration);
+    } else {
+      assertNever(action);
+    }
   }
 
   return builderActions;

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -28,7 +28,6 @@ import {
   isRetrievalConfiguration,
   isTablesQueryConfiguration,
   Ok,
-  removeNulls,
   SUPPORTED_MODEL_CONFIGS,
 } from "@dust-tt/types";
 
@@ -56,6 +55,7 @@ import {
   runGeneration,
 } from "@app/lib/api/assistant/generation";
 import { runLegacyAgent } from "@app/lib/api/assistant/legacy_agent";
+import { isLegacyAgent } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 
@@ -106,25 +106,6 @@ export async function* runAgent(
   for await (const event of stream) {
     yield event;
   }
-}
-
-// This function returns true if the agent is a "legacy" agent with a forced schedule,
-// i.e it has a maxToolsUsePerRun <= 2, every possible iteration has a forced action,
-// and every tool is forced at a certain iteration.
-export function isLegacyAgent(configuration: AgentConfigurationType): boolean {
-  // TODO(@fontanierh): change once generation is part of actions.
-  const actions = removeNulls([
-    ...configuration.actions,
-    configuration.generation,
-  ]);
-
-  return (
-    configuration.maxToolsUsePerRun <= 2 &&
-    Array.from(Array(configuration.maxToolsUsePerRun).keys()).every((i) =>
-      actions.some((a) => a.forceUseAtIteration === i)
-    ) &&
-    actions.every((a) => a.forceUseAtIteration !== undefined)
-  );
 }
 
 export async function* runMultiActionsAgent(

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -55,6 +55,8 @@ import { Workspace } from "@app/lib/models/workspace";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { generateModelSId } from "@app/lib/utils";
 
+const MULTI_ACTIONS_DEFAULT_MAX_TOOLS_USE_PER_RUN = 3;
+
 type SortStrategyType = "alphabetical" | "priority" | "updatedAt";
 
 interface SortStrategy {
@@ -841,7 +843,7 @@ export async function createAgentConfiguration(
     name: string;
     description: string;
     instructions: string | null;
-    maxToolsUsePerRun: number;
+    maxToolsUsePerRun?: number;
     pictureUrl: string;
     status: AgentStatus;
     scope: Exclude<AgentConfigurationScope, "global">;
@@ -946,7 +948,8 @@ export async function createAgentConfiguration(
             providerId: model.providerId,
             modelId: model.modelId,
             temperature: model.temperature,
-            maxToolsUsePerRun: maxToolsUsePerRun,
+            maxToolsUsePerRun:
+              maxToolsUsePerRun ?? MULTI_ACTIONS_DEFAULT_MAX_TOOLS_USE_PER_RUN,
             pictureUrl,
             workspaceId: owner.id,
             authorId: user.id,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/index.ts
@@ -112,7 +112,7 @@ async function handler(
         auth,
         assistant: bodyValidation.right.assistant,
         agentConfigurationId: req.query.aId as string,
-        legacySingleActionMode: true,
+        legacySingleActionMode: !bodyValidation.right.useMultiActions,
       });
       if (agentConfiguration.isErr()) {
         return apiError(req, res, {

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/scope.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/scope.ts
@@ -4,9 +4,9 @@ import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { isLegacyAgent } from "@app/lib/api/assistant/agent";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
 import { setAgentUserListStatus } from "@app/lib/api/assistant/user_relation";
+import { isLegacyAgent } from "@app/lib/assistant";
 import { Authenticator, getSession } from "@app/lib/auth";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import { createOrUpgradeAgentConfiguration } from "@app/pages/api/w/[wId]/assistant/agent_configurations";

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -352,9 +352,6 @@ export async function createOrUpgradeAgentConfiguration({
     }
   }
 
-  if (maxToolsUsePerRun === undefined) {
-    throw new Error("maxToolsUsePerRun is required.");
-  }
   const agentConfigurationRes = await createAgentConfiguration(auth, {
     name,
     description,

--- a/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
@@ -37,6 +37,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   agentConfiguration: AgentConfigurationType;
   flow: BuilderFlow;
   baseUrl: string;
+  multiActionsMode: boolean;
 }>(async (context, auth) => {
   const owner = auth.workspace();
   const plan = auth.plan();
@@ -51,6 +52,11 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     return {
       notFound: true,
     };
+  }
+
+  let multiActionsMode = context.query.multi_actions === "true";
+  if (multiActionsMode && !owner.flags.includes("multi_actions")) {
+    multiActionsMode = false;
   }
 
   const allDataSources = await getDataSources(auth);
@@ -99,6 +105,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       agentConfiguration: configuration,
       flow,
       baseUrl: URL,
+      multiActionsMode,
     },
   };
 });
@@ -114,6 +121,7 @@ export default function EditAssistant({
   agentConfiguration,
   flow,
   baseUrl,
+  multiActionsMode,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const action = deprecatedGetFirstActionConfiguration(agentConfiguration);
 
@@ -178,6 +186,7 @@ export default function EditAssistant({
       agentConfigurationId={agentConfiguration.sId}
       baseUrl={baseUrl}
       defaultTemplate={null}
+      multiActionsMode={multiActionsMode}
     />
   );
 }

--- a/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
@@ -54,6 +54,8 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     };
   }
 
+  console.log("\n\n\n\n", context.query, "\n\n\n\n");
+
   let multiActionsMode = context.query.multi_actions === "true";
   if (multiActionsMode && !owner.flags.includes("multi_actions")) {
     multiActionsMode = false;

--- a/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
@@ -19,9 +19,9 @@ import AssistantBuilder, {
 import { buildInitialActions } from "@app/components/assistant_builder/server_side_props_helpers";
 import type { AssistantBuilderInitialState } from "@app/components/assistant_builder/types";
 import { getApps } from "@app/lib/api/app";
-import { isLegacyAgent } from "@app/lib/api/assistant/agent";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
 import { getDataSources } from "@app/lib/api/data_sources";
+import { isLegacyAgent } from "@app/lib/assistant";
 import { deprecatedGetFirstActionConfiguration } from "@app/lib/deprecated_action_configurations";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 

--- a/front/pages/w/[wId]/builder/assistants/new.tsx
+++ b/front/pages/w/[wId]/builder/assistants/new.tsx
@@ -54,6 +54,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   flow: BuilderFlow;
   baseUrl: string;
   templateId: string | null;
+  multiActionsMode: boolean;
 }>(async (context, auth) => {
   const owner = auth.workspace();
   const plan = auth.plan();
@@ -62,6 +63,11 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     return {
       notFound: true,
     };
+  }
+
+  let multiActionsMode = context.query.multi_actions === "true";
+  if (multiActionsMode && !owner.flags.includes("multi_actions")) {
+    multiActionsMode = false;
   }
 
   const allDataSources = await getDataSources(auth);
@@ -128,6 +134,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       flow,
       baseUrl: config.getAppUrl(),
       templateId,
+      multiActionsMode,
     },
   };
 });
@@ -144,6 +151,7 @@ export default function CreateAssistant({
   flow,
   baseUrl,
   templateId,
+  multiActionsMode,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const { assistantTemplate } = useAssistantTemplate({
     templateId,
@@ -228,6 +236,7 @@ export default function CreateAssistant({
       defaultIsEdited={true}
       baseUrl={baseUrl}
       defaultTemplate={assistantTemplate}
+      multiActionsMode={multiActionsMode}
     />
   );
 }

--- a/front/pages/w/[wId]/builder/assistants/new.tsx
+++ b/front/pages/w/[wId]/builder/assistants/new.tsx
@@ -65,6 +65,8 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     };
   }
 
+  console.log("\n\n\n\n", context.query, "\n\n\n\n");
+
   let multiActionsMode = context.query.multi_actions === "true";
   if (multiActionsMode && !owner.flags.includes("multi_actions")) {
     multiActionsMode = false;

--- a/front/pages/w/[wId]/builder/assistants/new.tsx
+++ b/front/pages/w/[wId]/builder/assistants/new.tsx
@@ -65,8 +65,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     };
   }
 
-  console.log("\n\n\n\n", context.query, "\n\n\n\n");
-
   let multiActionsMode = context.query.multi_actions === "true";
   if (multiActionsMode && !owner.flags.includes("multi_actions")) {
     multiActionsMode = false;
@@ -120,6 +118,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
         dataSourcesByName,
         dustApps: allDustApps,
         configuration,
+        multiActionsMode,
       })
     : [];
 


### PR DESCRIPTION
## Description

fixes https://github.com/dust-tt/dust/issues/4603

Dirty UI, gated behind a feature flag and a query parameter. The new forked Actions screen allow to add / edit / remove several actions on a single assistant.

deployed on front-edge.dust.tt


<img width="948" alt="Screenshot 2024-05-06 at 17 28 20" src="https://github.com/dust-tt/dust/assets/14199823/dbe020d5-5eed-47c2-a88c-59cf4b8044c5">

<img width="1822" alt="Screenshot 2024-05-06 at 16 39 24" src="https://github.com/dust-tt/dust/assets/14199823/6b22992d-7dce-471c-bae8-c616301426c4">

<img width="1817" alt="Screenshot 2024-05-06 at 16 47 38" src="https://github.com/dust-tt/dust/assets/14199823/c3e24d50-5a0e-4a4a-ad81-0c863f49d482">



## Risk

Shouldn't affect single action agents, but still changes code on the critical path.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
