### PR TITLE
Process Action: Retrieval Tags

### DIFF
--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -768,10 +768,6 @@ export async function submitAssistantBuilderForm({
           case "PROCESS":
             return {
               type: "process_configuration",
-              relativeTimeFrame: {
-                duration: a.configuration.timeFrame.value,
-                unit: a.configuration.timeFrame.unit,
-              },
               dataSources: Object.values(
                 a.configuration.dataSourceConfigurations
               ).map(({ dataSource, selectedResources, isSelectAll }) => ({
@@ -789,6 +785,11 @@ export async function submitAssistantBuilderForm({
                   tags: null,
                 },
               })),
+              tagsFilter: a.configuration.tagsFilter,
+              relativeTimeFrame: {
+                duration: a.configuration.timeFrame.value,
+                unit: a.configuration.timeFrame.unit,
+              },
               schema: a.configuration.schema,
             };
 

--- a/front/components/assistant_builder/actions/ProcessAction.tsx
+++ b/front/components/assistant_builder/actions/ProcessAction.tsx
@@ -57,7 +57,7 @@ export function isActionProcessValid(
   }
   if (
     action.configuration.tagsFilter &&
-    action.configuration.tagsFilter.in.filter((tag) => tag === "").length > 0
+    action.configuration.tagsFilter.in.some((tag) => tag === "")
   ) {
     return false;
   }

--- a/front/components/assistant_builder/actions/ProcessAction.tsx
+++ b/front/components/assistant_builder/actions/ProcessAction.tsx
@@ -312,6 +312,10 @@ export function ActionProcess({
         onDelete={deleteDataSource}
       />
 
+      <div className="text-element-400 text-sm mt-4">
+        Advanced
+      </div>
+
       <div className={"flex flex-row items-center gap-4 pb-4"}>
         <div className="text-sm font-semibold text-element-900">
           Process data from the last

--- a/front/components/assistant_builder/actions/ProcessAction.tsx
+++ b/front/components/assistant_builder/actions/ProcessAction.tsx
@@ -56,8 +56,15 @@ export function isActionProcessValid(
     return false;
   }
   if (
-    action.configuration.tagsFilter.in &&
+    action.configuration.tagsFilter &&
     action.configuration.tagsFilter.in.filter((tag) => tag === "").length > 0
+  ) {
+    return false;
+  }
+  if (
+    action.configuration.tagsFilter &&
+    action.configuration.tagsFilter.in.length !==
+      new Set(action.configuration.tagsFilter.in).size
   ) {
     return false;
   }
@@ -336,20 +343,19 @@ export function ActionProcess({
                 updateAction({
                   ...actionConfiguration,
                   tagsFilter: {
-                    in: [...(actionConfiguration.tagsFilter.in || []), ""],
-                    not: actionConfiguration.tagsFilter.not,
+                    in: [...(actionConfiguration.tagsFilter?.in || []), ""],
                   },
                 });
               }}
               disabled={
-                (actionConfiguration.tagsFilter.in || []).filter(
-                  (tag) => tag === ""
-                ).length > 0
+                !!actionConfiguration.tagsFilter &&
+                actionConfiguration.tagsFilter.in.filter((tag) => tag === "")
+                  .length > 0
               }
             />
           </div>
         </div>
-        {(actionConfiguration.tagsFilter.in || []).map((t, i) => {
+        {(actionConfiguration.tagsFilter?.in || []).map((t, i) => {
           return (
             <div className="flex flex-row gap-4" key={`tag-${i}`}>
               <div className="flex">
@@ -360,20 +366,22 @@ export function ActionProcess({
                   value={t}
                   onChange={(v) => {
                     setEdited(true);
+                    const tags = [
+                      ...(actionConfiguration.tagsFilter?.in || []),
+                    ];
+                    tags[i] = v;
+
                     updateAction({
                       ...actionConfiguration,
                       tagsFilter: {
-                        in: (actionConfiguration.tagsFilter.in || []).map(
-                          (tag) => (tag === t ? v : tag)
-                        ),
-                        not: actionConfiguration.tagsFilter.not,
+                        in: tags,
                       },
                     });
                   }}
                   error={
                     t.length === 0
                       ? "Tag is required"
-                      : (actionConfiguration.tagsFilter.in || []).filter(
+                      : (actionConfiguration.tagsFilter?.in || []).filter(
                           (tag) => tag === t
                         ).length > 1
                       ? "Tag must be unique"
@@ -387,23 +395,21 @@ export function ActionProcess({
                   tooltip="Remove Property"
                   variant="tertiary"
                   onClick={async () => {
-                    let tagsFilter: AssistantBuilderTagsFilter = {
-                      in: (actionConfiguration.tagsFilter.in || []).filter(
-                        (tag) => tag !== t
-                      ),
-                      not: actionConfiguration.tagsFilter.not,
-                    };
-                    if ((tagsFilter.in || []).length === 0) {
-                      tagsFilter = {
-                        in: null,
-                        not: actionConfiguration.tagsFilter.not,
-                      };
-                    }
-                    setEdited(true);
+                    const tags = (
+                      actionConfiguration.tagsFilter?.in || []
+                    ).filter((tag) => tag !== t);
+
+                    const tagsFilter: AssistantBuilderTagsFilter | null =
+                      tags.length > 0
+                        ? {
+                            in: tags,
+                          }
+                        : null;
                     updateAction({
                       ...actionConfiguration,
                       tagsFilter,
                     });
+                    setEdited(true);
                   }}
                   className="ml-1"
                 />

--- a/front/components/assistant_builder/actions/ProcessAction.tsx
+++ b/front/components/assistant_builder/actions/ProcessAction.tsx
@@ -312,8 +312,43 @@ export function ActionProcess({
         onDelete={deleteDataSource}
       />
 
-      <div className="text-element-400 text-sm mt-4">
-        Advanced
+      <div className="flex flex-col">
+        <div className="flex flex-row items-center gap-4 pb-4">
+          <div className="text-sm font-semibold text-element-900">
+            Tags Filtering
+          </div>
+          <div>
+            <Button
+              label={"Add tag filter"}
+              variant="tertiary"
+              size="xs"
+              onClick={() => {}}
+            />
+          </div>
+        </div>
+        {(actionConfiguration.tagsFilter.in || []).map((t) => {
+          return (
+            <div className="flex flex-row gap-4" key={t}>
+              <div className="flex">
+                <Input
+                  placeholder="Enter tag"
+                  size="sm"
+                  name="tags"
+                  value={t}
+                />
+              </div>
+              <div className="flex items-end pb-2">
+                <IconButton
+                  icon={XCircleIcon}
+                  tooltip="Remove Property"
+                  variant="tertiary"
+                  onClick={async () => {}}
+                  className="ml-1"
+                />
+              </div>
+            </div>
+          );
+        })}
       </div>
 
       <div className={"flex flex-row items-center gap-4 pb-4"}>

--- a/front/components/assistant_builder/server_side_props_helpers.ts
+++ b/front/components/assistant_builder/server_side_props_helpers.ts
@@ -186,6 +186,8 @@ export async function buildInitialActions({
       };
     }
 
+    processConfiguration.configuration.tagsFilter = action.tagsFilter;
+
     processConfiguration.configuration.dataSourceConfigurations =
       await renderDataSourcesConfigurations(action);
 

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -36,6 +36,11 @@ export type AssistantBuilderTimeFrame = {
   unit: TimeframeUnit;
 };
 
+export type AsisstantBuilderTagsFilter = {
+  in: string[] | null;
+  not: string[] | null;
+};
+
 export type AssistantBuilderRetrievalConfiguration = {
   dataSourceConfigurations: AssistantBuilderDataSourceConfigurations;
   timeFrame: AssistantBuilderTimeFrame;
@@ -66,6 +71,7 @@ export type AssistantBuilderTablesQueryConfiguration = Record<
 
 export type AssistantBuilderProcessConfiguration = {
   dataSourceConfigurations: AssistantBuilderDataSourceConfigurations;
+  tagsFilter: AsisstantBuilderTagsFilter;
   timeFrame: AssistantBuilderTimeFrame;
   schema: ProcessSchemaPropertyType[];
 };
@@ -197,6 +203,10 @@ export function getDefaultProcessActionConfiguration() {
     type: "PROCESS",
     configuration: {
       dataSourceConfigurations: {},
+      tagsFilter: {
+        in: null,
+        not: null,
+      },
       timeFrame: {
         value: 1,
         unit: "day",

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -37,8 +37,7 @@ export type AssistantBuilderTimeFrame = {
 };
 
 export type AssistantBuilderTagsFilter = {
-  in: string[] | null;
-  not: string[] | null;
+  in: string[];
 };
 
 export type AssistantBuilderRetrievalConfiguration = {
@@ -71,8 +70,8 @@ export type AssistantBuilderTablesQueryConfiguration = Record<
 
 export type AssistantBuilderProcessConfiguration = {
   dataSourceConfigurations: AssistantBuilderDataSourceConfigurations;
-  tagsFilter: AssistantBuilderTagsFilter;
   timeFrame: AssistantBuilderTimeFrame;
+  tagsFilter: AssistantBuilderTagsFilter | null;
   schema: ProcessSchemaPropertyType[];
 };
 
@@ -203,14 +202,11 @@ export function getDefaultProcessActionConfiguration() {
     type: "PROCESS",
     configuration: {
       dataSourceConfigurations: {},
-      tagsFilter: {
-        in: null,
-        not: null,
-      },
       timeFrame: {
         value: 1,
         unit: "day",
       },
+      tagsFilter: null,
       schema: [],
     } as AssistantBuilderProcessConfiguration,
     name: "process_data",

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -36,7 +36,7 @@ export type AssistantBuilderTimeFrame = {
   unit: TimeframeUnit;
 };
 
-export type AsisstantBuilderTagsFilter = {
+export type AssistantBuilderTagsFilter = {
   in: string[] | null;
   not: string[] | null;
 };
@@ -71,7 +71,7 @@ export type AssistantBuilderTablesQueryConfiguration = Record<
 
 export type AssistantBuilderProcessConfiguration = {
   dataSourceConfigurations: AssistantBuilderDataSourceConfigurations;
-  tagsFilter: AsisstantBuilderTagsFilter;
+  tagsFilter: AssistantBuilderTagsFilter;
   timeFrame: AssistantBuilderTimeFrame;
   schema: ProcessSchemaPropertyType[];
 };

--- a/front/lib/api/assistant/actions/process.ts
+++ b/front/lib/api/assistant/actions/process.ts
@@ -59,8 +59,12 @@ export function renderProcessActionForModel(
   // TODO(spolu): figure out if we want to add the schema here?
 
   if (action.outputs) {
-    for (const o of action.outputs.data) {
-      content += `${JSON.stringify(o)}\n`;
+    if (action.outputs.data.length === 0) {
+      content += "(none)\n";
+    } else {
+      for (const o of action.outputs.data) {
+        content += `${JSON.stringify(o)}\n`;
+      }
     }
   }
 

--- a/front/lib/api/assistant/actions/process.ts
+++ b/front/lib/api/assistant/actions/process.ts
@@ -317,24 +317,16 @@ export async function* runProcess(
     data_source_id: d.dataSourceId,
   }));
 
-  for (const ds of actionConfiguration.dataSources) {
-    /** Caveat: empty array in tags.in means "no document match" since no
-     * documents has any tags that is in the tags.in array (same for parents)*/
+  if (actionConfiguration.tagsFilter && actionConfiguration.tagsFilter.in) {
+    // Note: empty array in tags.in means "no document match" since no documents has any tags that
+    // is in the tags.in array (same for parents)
     if (!config.DATASOURCE.filter.tags) {
       config.DATASOURCE.filter.tags = {};
     }
-    if (ds.filter.tags?.in) {
-      if (!config.DATASOURCE.filter.tags.in) {
-        config.DATASOURCE.filter.tags.in = [];
-      }
-      config.DATASOURCE.filter.tags.in.push(...ds.filter.tags.in);
-    }
-    if (ds.filter.tags?.not) {
-      if (!config.DATASOURCE.filter.tags.not) {
-        config.DATASOURCE.filter.tags.not = [];
-      }
-      config.DATASOURCE.filter.tags.not.push(...ds.filter.tags.not);
-    }
+    config.DATASOURCE.filter.tags.in = actionConfiguration.tagsFilter.in;
+  }
+
+  for (const ds of actionConfiguration.dataSources) {
     if (!config.DATASOURCE.filter.parents) {
       config.DATASOURCE.filter.parents = {};
     }

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -12,6 +12,7 @@ import type {
   LightAgentConfigurationType,
   ModelId,
   ProcessSchemaPropertyType,
+  ProcessTagsFilter,
   Result,
   RetrievalQuery,
   RetrievalTimeframe,
@@ -564,7 +565,6 @@ async function fetchWorkspaceAgentConfigurationsForView(
           id: processConfig.id,
           sId: processConfig.sId,
           type: "process_configuration",
-          relativeTimeFrame: renderRetrievalTimeframeType(processConfig),
           dataSources: dataSourcesConfig.map((dsConfig) => {
             return {
               dataSourceId: dsConfig.dataSource.name,
@@ -581,6 +581,13 @@ async function fetchWorkspaceAgentConfigurationsForView(
               },
             };
           }),
+          relativeTimeFrame: renderRetrievalTimeframeType(processConfig),
+          tagsFilter:
+            processConfig.tagsIn !== null
+              ? {
+                  in: processConfig.tagsIn,
+                }
+              : null,
           schema: processConfig.schema,
           name: processConfig.name,
           description: processConfig.description,
@@ -1119,6 +1126,7 @@ export async function createAgentActionConfiguration(
     | {
         type: "process_configuration";
         relativeTimeFrame: RetrievalTimeframe;
+        tagsFilter: ProcessTagsFilter | null;
         dataSources: DataSourceConfiguration[];
         schema: ProcessSchemaPropertyType[];
       }
@@ -1250,6 +1258,7 @@ export async function createAgentActionConfiguration(
             relativeTimeFrameUnit: isTimeFrame(action.relativeTimeFrame)
               ? action.relativeTimeFrame.unit
               : null,
+            tagsIn: action.tagsFilter?.in ?? null,
             agentConfigurationId: agentConfiguration.id,
             schema: action.schema,
             name: action.name,
@@ -1269,6 +1278,7 @@ export async function createAgentActionConfiguration(
           sId: processConfig.sId,
           type: "process_configuration",
           relativeTimeFrame: action.relativeTimeFrame,
+          tagsFilter: action.tagsFilter,
           schema: action.schema,
           dataSources: action.dataSources,
           name: action.name,

--- a/front/lib/models/assistant/actions/process.ts
+++ b/front/lib/models/assistant/actions/process.ts
@@ -31,6 +31,8 @@ export class AgentProcessConfiguration extends Model<
   declare relativeTimeFrameDuration: number | null;
   declare relativeTimeFrameUnit: TimeframeUnit | null;
 
+  declare tagsIn: string[] | null;
+
   declare schema: ProcessSchemaPropertyType[];
 
   declare name: string | null;
@@ -70,6 +72,10 @@ AgentProcessConfiguration.init(
     },
     relativeTimeFrameUnit: {
       type: DataTypes.STRING,
+      allowNull: true,
+    },
+    tagsIn: {
+      type: DataTypes.ARRAY(DataTypes.STRING),
       allowNull: true,
     },
     schema: {

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -270,11 +270,10 @@ async function handler(
 export default withLogging(handler);
 
 /**
- * Create Or Upgrade Agent Configuration If an agentConfigurationId is provided,
- * it will create a new version of the agent configuration with the same
- * agentConfigurationId. If no agentConfigurationId is provided, it will create
- * a new agent configuration. In both cases, it will return the new agent
- * configuration.
+ * Create Or Upgrade Agent Configuration If an agentConfigurationId is provided, it will create a
+ * new version of the agent configuration with the same agentConfigurationId. If no
+ * agentConfigurationId is provided, it will create a new agent configuration. In both cases, it
+ * will return the new agent configuration.
  **/
 export async function createOrUpgradeAgentConfiguration({
   auth,
@@ -445,8 +444,9 @@ export async function createOrUpgradeAgentConfiguration({
             auth,
             {
               type: "process_configuration",
-              relativeTimeFrame: action.relativeTimeFrame,
               dataSources: action.dataSources,
+              relativeTimeFrame: action.relativeTimeFrame,
+              tagsFilter: action.tagsFilter,
               schema: action.schema,
               name: action.name ?? null,
               description: action.description ?? null,

--- a/types/src/front/api_handlers/internal/agent_configuration.ts
+++ b/types/src/front/api_handlers/internal/agent_configuration.ts
@@ -102,14 +102,6 @@ const TablesQueryActionConfigurationSchema = t.type({
 
 const ProcessActionConfigurationSchema = t.type({
   type: t.literal("process_configuration"),
-  relativeTimeFrame: t.union([
-    t.literal("auto"),
-    t.literal("none"),
-    t.type({
-      duration: t.number,
-      unit: TimeframeUnitCodec,
-    }),
-  ]),
   dataSources: t.array(
     t.type({
       dataSourceId: t.string,
@@ -132,6 +124,20 @@ const ProcessActionConfigurationSchema = t.type({
       }),
     })
   ),
+  relativeTimeFrame: t.union([
+    t.literal("auto"),
+    t.literal("none"),
+    t.type({
+      duration: t.number,
+      unit: TimeframeUnitCodec,
+    }),
+  ]),
+  tagsFilter: t.union([
+    t.type({
+      in: t.array(t.string),
+    }),
+    t.null,
+  ]),
   schema: t.array(
     t.type({
       name: t.string,

--- a/types/src/front/assistant/actions/process.ts
+++ b/types/src/front/assistant/actions/process.ts
@@ -39,6 +39,10 @@ export function renderSchemaPropertiesAsJSONSchema(
   return jsonSchema;
 }
 
+export type ProcessTagsFilter = {
+  in: string[];
+};
+
 export type ProcessConfigurationType = {
   id: ModelId;
   sId: string;
@@ -47,6 +51,7 @@ export type ProcessConfigurationType = {
 
   dataSources: DataSourceConfiguration[];
   relativeTimeFrame: RetrievalTimeframe;
+  tagsFilter: ProcessTagsFilter | null;
   schema: ProcessSchemaPropertyType[];
 
   name: string | null;

--- a/types/src/front/assistant/templates.ts
+++ b/types/src/front/assistant/templates.ts
@@ -186,6 +186,7 @@ export function getAgentActionConfigurationType(
       return {
         dataSources: [],
         id: -1,
+        tagsFilter: null,
         relativeTimeFrame: "auto",
         sId: "template",
         schema: [],

--- a/types/src/front/lib/actions/registry.ts
+++ b/types/src/front/lib/actions/registry.ts
@@ -69,7 +69,7 @@ export const DustProdActionRegistry = createActionRegistry({
       workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
       appId: "953b79fe89",
       appHash:
-        "4fed40e920b30417cfd6a67ab206e66d6caf74c9da7e08bc4930a1c76bfae9cb",
+        "832ea8c2d3cf1c749543195433077aac110733903f3661505e4c80e08d86168b",
     },
     config: {
       DATASOURCE: {


### PR DESCRIPTION
## Description

The goal of this PR is to add support for tags filtering in the process action. Two passes were possible:
- (i) Add a `filterTags` object to the `ProcessActionConfigurationType` (chosen by this PR)
- (ii) Leverage the DataSourceConfigurationType's tag filtering and build UI in the DataSource selector to add tags.

(ii) is probematic because `core` does not support per data source tags (tags are instead aggregated together and applied to all data source in the current code). This has no impact since tags in DataSourceConfiguration are never used and the tagsIn and tagsNotIn columns are empty in production.

Most of the time process action will process "uniform" data coming from one data source so having global tags should work most of the time. The best situation in the end would be to have per data source tag support with `core` in_map support for tags as it has for parents and add support for tags in the data source selector which is doable for most connections but will be a challenge UX-wise for folders (you select multiple folders but tags should be applied to each folders). We can revisit that in the future and the current approach is the minimal path of resistance towards having tags support for the process action which will allow us to move all of our highlights assistants to it.

As a follow-up PR I will remove support for DataSourceConfiguration tagsIn/tagsNotIn since it's not used in production and would be counter intuitive if it was used see: https://github.com/dust-tt/dust/blob/main/front/lib/api/assistant/actions/retrieval.ts#L620

- Adds a retrievalTags state to the process action
- Add support in the Process Action Assistant Builder UI

![Screenshot from 2024-05-06 16-53-14](https://github.com/dust-tt/dust/assets/15067/08cd3bdc-07f3-4292-92f7-5ff36aba667b)

Note: this is a prototype and I'm happy to iterate on it once we start using it or pushing it to users.

## Risk

N/A Process action is not released to anyone

## Deploy Plan

- run init_db
- deploy `front`