### PR TITLE
Remove agent*Action fields from AgentMessage model.

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1646,27 +1646,6 @@ async function* streamRunAgentEvents(
         return;
 
       case "agent_action_success":
-        // Store action in database.
-        if (event.action.type === "retrieval_action") {
-          // Nothing to do.
-        } else if (event.action.type === "dust_app_run_action") {
-          await agentMessageRow.update({
-            agentDustAppRunActionId: event.action.id,
-          });
-        } else if (event.action.type === "tables_query_action") {
-          await agentMessageRow.update({
-            agentTablesQueryActionId: event.action.id,
-          });
-        } else if (event.action.type === "process_action") {
-          // Nothing to do.
-        } else {
-          ((action: never) => {
-            throw new Error(
-              "Unknown `type` for `agent_action_success` event",
-              action
-            );
-          })(event.action);
-        }
         yield event;
         break;
 

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -242,13 +242,6 @@ export class AgentMessage extends Model<
   declare errorCode: string | null;
   declare errorMessage: string | null;
 
-  declare agentDustAppRunActionId: ForeignKey<
-    AgentDustAppRunAction["id"]
-  > | null;
-  declare agentTablesQueryActionId: ForeignKey<
-    AgentTablesQueryAction["id"]
-  > | null;
-
   // Not a relation as global agents are not in the DB
   // needs both sId and version to uniquely identify the agent configuration
   declare agentConfigurationId: string;
@@ -302,44 +295,8 @@ AgentMessage.init(
   {
     modelName: "agent_message",
     sequelize: frontSequelize,
-    hooks: {
-      beforeValidate: (agentMessage: AgentMessage) => {
-        const actionsTypes: (keyof AgentMessage)[] = [
-          "agentDustAppRunActionId",
-          "agentTablesQueryActionId",
-        ];
-        const nonNullActionTypes = actionsTypes.filter(
-          (field) => agentMessage[field] != null
-        );
-        if (nonNullActionTypes.length > 1) {
-          throw new Error(
-            "Only one of agentRetrievalActionId, agentDustAppRunActionId or agentTablesQueryActionId can be set"
-          );
-        }
-      },
-    },
   }
 );
-
-// LEGACY (to be removed)
-
-AgentDustAppRunAction.hasOne(AgentMessage, {
-  foreignKey: { name: "agentDustAppRunActionId", allowNull: true }, // null = no DustAppRun action set for this Agent
-  onDelete: "CASCADE",
-});
-AgentMessage.belongsTo(AgentDustAppRunAction, {
-  foreignKey: { name: "agentDustAppRunActionId", allowNull: true }, // null = no DustAppRun action set for this Agent
-});
-
-AgentTablesQueryAction.hasOne(AgentMessage, {
-  foreignKey: { name: "agentTablesQueryActionId", allowNull: true }, // null = no TablesQuery action set for this Agent
-  onDelete: "CASCADE",
-});
-AgentMessage.belongsTo(AgentTablesQueryAction, {
-  foreignKey: { name: "agentTablesQueryActionId", allowNull: true }, // null = no TablesQuery action set for this Agent
-});
-
-// END LEGACY
 
 // TO BE MOVED TO RESPECTIVE MODELS POST INVERSION
 

--- a/front/migrations/20240502_backfill_agent_dust_app_run_actions_agent_message_id.ts
+++ b/front/migrations/20240502_backfill_agent_dust_app_run_actions_agent_message_id.ts
@@ -1,75 +1,75 @@
-import type { ModelId } from "@dust-tt/types";
-import { QueryTypes } from "sequelize";
+// import type { ModelId } from "@dust-tt/types";
+// import { QueryTypes } from "sequelize";
 
-import { AgentDustAppRunAction } from "@app/lib/models/assistant/actions/dust_app_run";
-import { AgentMessage } from "@app/lib/models/assistant/conversation";
-import { frontSequelize } from "@app/lib/resources/storage";
-import logger from "@app/logger/logger";
-import { makeScript } from "@app/scripts/helpers";
+// import { AgentDustAppRunAction } from "@app/lib/models/assistant/actions/dust_app_run";
+// import { AgentMessage } from "@app/lib/models/assistant/conversation";
+// import { frontSequelize } from "@app/lib/resources/storage";
+// import logger from "@app/logger/logger";
+// import { makeScript } from "@app/scripts/helpers";
 
-const backfillDustAppRunActions = async (execute: boolean) => {
-  let actions: AgentDustAppRunAction[] = [];
-  actions = await AgentDustAppRunAction.findAll({
-    // @ts-expect-error agentMessageId became null during this PR. But the migration still has to run to
-    // effectively update the agentMessageId.
-    where: {
-      agentMessageId: null,
-    },
-  });
-  logger.info(
-    {
-      count: actions.length,
-    },
-    "Processing actions for backfilling agentMessageId"
-  );
-  for (const action of actions) {
-    const agentMessage = await AgentMessage.findOne({
-      where: {
-        agentDustAppRunActionId: action.id,
-      },
-    });
-    if (agentMessage) {
-      if (execute) {
-        await action.update({
-          agentMessageId: agentMessage.id,
-        });
-        logger.info({ actionId: action.id }, "Updated agentMessageId");
-      } else {
-        logger.info({ actionId: action.id }, "*Would* update agentMessageId");
-      }
-    } else {
-      logger.warn({ actionId: action.id }, "AgentMessage not found");
-    }
-  }
+// const backfillDustAppRunActions = async (execute: boolean) => {
+//   let actions: AgentDustAppRunAction[] = [];
+//   actions = await AgentDustAppRunAction.findAll({
+//     // @ts-expect-error agentMessageId became null during this PR. But the migration still has to run to
+//     // effectively update the agentMessageId.
+//     where: {
+//       agentMessageId: null,
+//     },
+//   });
+//   logger.info(
+//     {
+//       count: actions.length,
+//     },
+//     "Processing actions for backfilling agentMessageId"
+//   );
+//   for (const action of actions) {
+//     const agentMessage = await AgentMessage.findOne({
+//       where: {
+//         agentDustAppRunActionId: action.id,
+//       },
+//     });
+//     if (agentMessage) {
+//       if (execute) {
+//         await action.update({
+//           agentMessageId: agentMessage.id,
+//         });
+//         logger.info({ actionId: action.id }, "Updated agentMessageId");
+//       } else {
+//         logger.info({ actionId: action.id }, "*Would* update agentMessageId");
+//       }
+//     } else {
+//       logger.warn({ actionId: action.id }, "AgentMessage not found");
+//     }
+//   }
 
-  // checking that all pairs are correct
-  const errors: { id: ModelId }[] = await frontSequelize.query(
-    `
-    SELECT
-    *
-  FROM
-    agent_messages am
-    INNER JOIN agent_dust_app_run_actions adara ON (am."agentDustAppRunActionId" = adara.id)
-  WHERE
-    (
-      am.id <> adara."agentMessageId"
-      OR adara."agentMessageId" IS NULL
-    );
-  `,
-    {
-      type: QueryTypes.SELECT,
-    }
-  );
-  if (errors.length > 0) {
-    logger.error(
-      { count: errors.length },
-      "AgentMessageId not updated correctly"
-    );
-  } else {
-    logger.info("No error found");
-  }
-};
+//   // checking that all pairs are correct
+//   const errors: { id: ModelId }[] = await frontSequelize.query(
+//     `
+//     SELECT
+//     *
+//   FROM
+//     agent_messages am
+//     INNER JOIN agent_dust_app_run_actions adara ON (am."agentDustAppRunActionId" = adara.id)
+//   WHERE
+//     (
+//       am.id <> adara."agentMessageId"
+//       OR adara."agentMessageId" IS NULL
+//     );
+//   `,
+//     {
+//       type: QueryTypes.SELECT,
+//     }
+//   );
+//   if (errors.length > 0) {
+//     logger.error(
+//       { count: errors.length },
+//       "AgentMessageId not updated correctly"
+//     );
+//   } else {
+//     logger.info("No error found");
+//   }
+// };
 
-makeScript({}, async ({ execute }) => {
-  await backfillDustAppRunActions(execute);
-});
+// makeScript({}, async ({ execute }) => {
+//   await backfillDustAppRunActions(execute);
+// });

--- a/front/migrations/20240503_backfill_table_query_actions_agent_message_id.ts
+++ b/front/migrations/20240503_backfill_table_query_actions_agent_message_id.ts
@@ -1,75 +1,75 @@
-import type { ModelId } from "@dust-tt/types";
-import { QueryTypes } from "sequelize";
+// import type { ModelId } from "@dust-tt/types";
+// import { QueryTypes } from "sequelize";
 
-import { AgentTablesQueryAction } from "@app/lib/models/assistant/actions/tables_query";
-import { AgentMessage } from "@app/lib/models/assistant/conversation";
-import { frontSequelize } from "@app/lib/resources/storage";
-import logger from "@app/logger/logger";
-import { makeScript } from "@app/scripts/helpers";
+// import { AgentTablesQueryAction } from "@app/lib/models/assistant/actions/tables_query";
+// import { AgentMessage } from "@app/lib/models/assistant/conversation";
+// import { frontSequelize } from "@app/lib/resources/storage";
+// import logger from "@app/logger/logger";
+// import { makeScript } from "@app/scripts/helpers";
 
-const backfillTableQueryActions = async (execute: boolean) => {
-  let actions: AgentTablesQueryAction[] = [];
-  actions = await AgentTablesQueryAction.findAll({
-    // @ts-expect-error agentMessageId became null during this PR. But the migration still has to run to
-    // effectively update the agentMessageId.
-    where: {
-      agentMessageId: null,
-    },
-  });
-  logger.info(
-    {
-      count: actions.length,
-    },
-    "Processing actions for backfilling agentMessageId"
-  );
-  for (const action of actions) {
-    const agentMessage = await AgentMessage.findOne({
-      where: {
-        agentTablesQueryActionId: action.id,
-      },
-    });
-    if (agentMessage) {
-      if (execute) {
-        await action.update({
-          agentMessageId: agentMessage.id,
-        });
-        logger.info({ actionId: action.id }, "Updated agentMessageId");
-      } else {
-        logger.info({ actionId: action.id }, "*Would* update agentMessageId");
-      }
-    } else {
-      logger.warn({ actionId: action.id }, "AgentMessage not found");
-    }
-  }
+// const backfillTableQueryActions = async (execute: boolean) => {
+//   let actions: AgentTablesQueryAction[] = [];
+//   actions = await AgentTablesQueryAction.findAll({
+//     // @ts-expect-error agentMessageId became null during this PR. But the migration still has to run to
+//     // effectively update the agentMessageId.
+//     where: {
+//       agentMessageId: null,
+//     },
+//   });
+//   logger.info(
+//     {
+//       count: actions.length,
+//     },
+//     "Processing actions for backfilling agentMessageId"
+//   );
+//   for (const action of actions) {
+//     const agentMessage = await AgentMessage.findOne({
+//       where: {
+//         agentTablesQueryActionId: action.id,
+//       },
+//     });
+//     if (agentMessage) {
+//       if (execute) {
+//         await action.update({
+//           agentMessageId: agentMessage.id,
+//         });
+//         logger.info({ actionId: action.id }, "Updated agentMessageId");
+//       } else {
+//         logger.info({ actionId: action.id }, "*Would* update agentMessageId");
+//       }
+//     } else {
+//       logger.warn({ actionId: action.id }, "AgentMessage not found");
+//     }
+//   }
 
-  // checking that all pairs are correct
-  const errors: { id: ModelId }[] = await frontSequelize.query(
-    `
-    SELECT
-    *
-  FROM
-    agent_messages am
-    INNER JOIN agent_tables_query_actions atqa ON (am."agentTablesQueryActionId" = atqa.id)
-  WHERE
-    (
-      am.id <> atqa."agentMessageId"
-      OR atqa."agentMessageId" IS NULL
-    );
-  `,
-    {
-      type: QueryTypes.SELECT,
-    }
-  );
-  if (errors.length > 0) {
-    logger.error(
-      { count: errors.length },
-      "AgentMessageId not updated correctly"
-    );
-  } else {
-    logger.info("No error found");
-  }
-};
+//   // checking that all pairs are correct
+//   const errors: { id: ModelId }[] = await frontSequelize.query(
+//     `
+//     SELECT
+//     *
+//   FROM
+//     agent_messages am
+//     INNER JOIN agent_tables_query_actions atqa ON (am."agentTablesQueryActionId" = atqa.id)
+//   WHERE
+//     (
+//       am.id <> atqa."agentMessageId"
+//       OR atqa."agentMessageId" IS NULL
+//     );
+//   `,
+//     {
+//       type: QueryTypes.SELECT,
+//     }
+//   );
+//   if (errors.length > 0) {
+//     logger.error(
+//       { count: errors.length },
+//       "AgentMessageId not updated correctly"
+//     );
+//   } else {
+//     logger.info("No error found");
+//   }
+// };
 
-makeScript({}, async ({ execute }) => {
-  await backfillTableQueryActions(execute);
-});
+// makeScript({}, async ({ execute }) => {
+//   await backfillTableQueryActions(execute);
+// });


### PR DESCRIPTION
## Description

Remove `agent*ActionId` fields from `AgentMessage` model.

Closing [this](https://github.com/dust-tt/dust/issues/4787) task.

The data being deleted from the database by this PR has been backed up [here](https://drive.google.com/drive/folders/1rddqcSD7P5dG75prRcy6cVpXOvxQ4mKz) with the following query:

```
select id, "agentDustAppRunActionId", "agentTablesQueryActionId" from agent_messages 
where "agentDustAppRunActionId" IS NOT NULL
OR "agentTablesQueryActionId" IS NOT NULL
order by id asc

```

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
- Deploy front
- Run front migration once front is fully deployed.

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
