### PR TITLE
enh(assistant builder): use the callback pattern everywhere

### DIFF
--- a/front/components/assistant_builder/ActionScreen.tsx
+++ b/front/components/assistant_builder/ActionScreen.tsx
@@ -19,7 +19,7 @@ import type {
 } from "@dust-tt/types";
 import { assertNever, removeNulls } from "@dust-tt/types";
 import type { ComponentType, ReactNode } from "react";
-import React, { useCallback } from "react";
+import React from "react";
 
 import { ActionProcess } from "@app/components/assistant_builder/actions/ProcessAction";
 import {
@@ -30,7 +30,6 @@ import { ActionTablesQuery } from "@app/components/assistant_builder/actions/Tab
 import type {
   AssistantBuilderActionConfiguration,
   AssistantBuilderActionType,
-  AssistantBuilderRetrievalConfiguration,
   AssistantBuilderState,
 } from "@app/components/assistant_builder/types";
 import { getDefaultActionConfiguration } from "@app/components/assistant_builder/types";
@@ -198,24 +197,6 @@ export default function ActionScreen({
   const actionCategorySpec = ACTION_CATEGORY_SPECIFICATIONS[actionCategory];
   const searchMode = getSearchMode(action?.type ?? null);
   const searchModeSpec = SEARCH_MODE_SPECIFICATIONS[searchMode];
-
-  const deprecatedReplaceSingleActionConfig = useCallback(
-    (newAction: AssistantBuilderActionConfiguration) => {
-      setBuilderState((state) => {
-        const previousAction = state.actions[0];
-        if (!previousAction) {
-          // Unreachable
-          return state;
-        }
-
-        return {
-          ...state,
-          actions: [newAction],
-        };
-      });
-    },
-    [setBuilderState]
-  );
 
   return (
     <>
@@ -421,7 +402,7 @@ export default function ActionScreen({
                   return state;
                 }
                 const newActionConfig = setNewAction(
-                  previousAction.configuration as AssistantBuilderRetrievalConfiguration
+                  previousAction.configuration
                 );
                 const newAction: AssistantBuilderActionConfiguration = {
                   type: "RETRIEVAL_SEARCH",
@@ -461,7 +442,7 @@ export default function ActionScreen({
                   return state;
                 }
                 const newActionConfig = setNewAction(
-                  previousAction.configuration as AssistantBuilderRetrievalConfiguration
+                  previousAction.configuration
                 );
                 const newAction: AssistantBuilderActionConfiguration = {
                   type: "RETRIEVAL_EXHAUSTIVE",
@@ -486,16 +467,26 @@ export default function ActionScreen({
               action?.type === "PROCESS" ? action.configuration : null
             }
             dataSources={dataSources}
-            updateAction={(newAction) => {
-              if (!action) {
-                // Unreachable
-                return;
-              }
-              deprecatedReplaceSingleActionConfig({
-                type: "PROCESS",
-                configuration: newAction,
-                name: action.name,
-                description: action.description,
+            updateAction={(setNewAction) => {
+              setBuilderState((state) => {
+                const previousAction = state.actions[0];
+                if (!previousAction || previousAction.type !== "PROCESS") {
+                  // Unreachable
+                  return state;
+                }
+                const newActionConfig = setNewAction(
+                  previousAction.configuration
+                );
+                const newAction: AssistantBuilderActionConfiguration = {
+                  type: "PROCESS",
+                  configuration: newActionConfig,
+                  name: previousAction.name,
+                  description: previousAction.description,
+                };
+                return {
+                  ...state,
+                  actions: removeNulls([newAction]),
+                };
               });
             }}
             setEdited={setEdited}
@@ -511,16 +502,26 @@ export default function ActionScreen({
               action?.type === "TABLES_QUERY" ? action.configuration : null
             }
             dataSources={dataSources}
-            updateAction={(newAction) => {
-              if (!action) {
-                // Unreachable
-                return;
-              }
-              deprecatedReplaceSingleActionConfig({
-                type: "TABLES_QUERY",
-                configuration: newAction,
-                name: action.name,
-                description: action.description,
+            updateAction={(setNewAction) => {
+              setBuilderState((state) => {
+                const previousAction = state.actions[0];
+                if (!previousAction || previousAction.type !== "TABLES_QUERY") {
+                  // Unreachable
+                  return state;
+                }
+                const newActionConfig = setNewAction(
+                  previousAction.configuration
+                );
+                const newAction: AssistantBuilderActionConfiguration = {
+                  type: "TABLES_QUERY",
+                  configuration: newActionConfig,
+                  name: previousAction.name,
+                  description: previousAction.description,
+                };
+                return {
+                  ...state,
+                  actions: removeNulls([newAction]),
+                };
               });
             }}
             setEdited={setEdited}
@@ -534,16 +535,26 @@ export default function ActionScreen({
               action?.type === "DUST_APP_RUN" ? action.configuration : null
             }
             dustApps={dustApps}
-            updateAction={(newAction) => {
-              if (!action) {
-                // Unreachable
-                return;
-              }
-              deprecatedReplaceSingleActionConfig({
-                type: "DUST_APP_RUN",
-                configuration: newAction,
-                name: action.name,
-                description: action.description,
+            updateAction={(setNewAction) => {
+              setBuilderState((state) => {
+                const previousAction = state.actions[0];
+                if (!previousAction || previousAction.type !== "DUST_APP_RUN") {
+                  // Unreachable
+                  return state;
+                }
+                const newActionConfig = setNewAction(
+                  previousAction.configuration
+                );
+                const newAction: AssistantBuilderActionConfiguration = {
+                  type: "DUST_APP_RUN",
+                  configuration: newActionConfig,
+                  name: previousAction.name,
+                  description: previousAction.description,
+                };
+                return {
+                  ...state,
+                  actions: removeNulls([newAction]),
+                };
               });
             }}
             setEdited={setEdited}

--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -27,7 +27,11 @@ import {
 } from "@app/components/assistant_builder/actions/TablesQueryAction";
 import type {
   AssistantBuilderActionConfiguration,
+  AssistantBuilderDustAppConfiguration,
+  AssistantBuilderProcessConfiguration,
+  AssistantBuilderRetrievalConfiguration,
   AssistantBuilderState,
+  AssistantBuilderTablesQueryConfiguration,
 } from "@app/components/assistant_builder/types";
 import { getDefaultActionConfiguration } from "@app/components/assistant_builder/types";
 
@@ -97,37 +101,47 @@ export default function ActionsScreen({
   const [actionToEdit, setActionToEdit] =
     React.useState<AssistantBuilderActionConfiguration | null>(null);
 
-  const upsertAction = useCallback(
-    (newAction: AssistantBuilderActionConfiguration) => {
+  const updateAction = useCallback(
+    function _updateAction({
+      actionName,
+      newActionName,
+      getNewActionConfig,
+    }: {
+      actionName: string;
+      newActionName?: string;
+      getNewActionConfig: (
+        old: AssistantBuilderActionConfiguration["configuration"]
+      ) => AssistantBuilderActionConfiguration["configuration"];
+    }) {
       setEdited(true);
-      setBuilderState((state) => {
-        let found = false;
-        const newActions = state.actions.map((action) => {
-          if (action.name === newAction.name) {
-            found = true;
-            return newAction;
-          }
-          return action;
-        });
-        if (!found) {
-          newActions.push(newAction);
-        }
-        return {
-          ...state,
-          actions: newActions,
-        };
-      });
+      setBuilderState((state) => ({
+        ...state,
+        actions: state.actions.map((action) =>
+          action.name === actionName
+            ? {
+                name: newActionName ?? action.name,
+                description: action.description,
+                type: action.type,
+                // This is quite unsatisfying, but using `as any` here and repeating every
+                // other key in the object instead of spreading is actually the safest we can do.
+                // There is no way (that I could find) to make typescript understand that
+                // type and configuration are compatible.
+                configuration: getNewActionConfig(action.configuration) as any,
+              }
+            : action
+        ),
+      }));
     },
     [setBuilderState, setEdited]
   );
 
-  const updateAction = useCallback(
-    (name: string, newAction: AssistantBuilderActionConfiguration) => {
+  const insertAction = useCallback(
+    (action: AssistantBuilderActionConfiguration) => {
       setEdited(true);
       setBuilderState((state) => {
         return {
           ...state,
-          actions: state.actions.map((a) => (a.name === name ? newAction : a)),
+          actions: [...state.actions, action],
         };
       });
     },
@@ -158,9 +172,15 @@ export default function ActionsScreen({
         initialAction={actionToEdit}
         onSave={(newAction) => {
           setEdited(true);
-          actionToEdit
-            ? updateAction(actionToEdit.name, newAction)
-            : upsertAction(newAction);
+          if (actionToEdit) {
+            updateAction({
+              actionName: actionToEdit.name,
+              newActionName: newAction.name,
+              getNewActionConfig: () => newAction.configuration,
+            });
+          } else {
+            insertAction(newAction);
+          }
           setNewActionModalOpen(false);
           setActionToEdit(null);
         }}
@@ -217,9 +237,12 @@ export default function ActionsScreen({
                             actionConfigration={a.configuration}
                             dustApps={dustApps}
                             updateAction={(setNewAction) => {
-                              upsertAction({
-                                ...a,
-                                configuration: setNewAction(a.configuration),
+                              updateAction({
+                                actionName: a.name,
+                                getNewActionConfig: (old) =>
+                                  setNewAction(
+                                    old as AssistantBuilderDustAppConfiguration
+                                  ),
                               });
                             }}
                             setEdited={setEdited}
@@ -232,9 +255,12 @@ export default function ActionsScreen({
                             actionConfiguration={a.configuration}
                             dataSources={dataSources}
                             updateAction={(setNewAction) => {
-                              upsertAction({
-                                ...a,
-                                configuration: setNewAction(a.configuration),
+                              updateAction({
+                                actionName: a.name,
+                                getNewActionConfig: (old) =>
+                                  setNewAction(
+                                    old as AssistantBuilderRetrievalConfiguration
+                                  ),
                               });
                             }}
                             setEdited={setEdited}
@@ -247,9 +273,12 @@ export default function ActionsScreen({
                             actionConfiguration={a.configuration}
                             dataSources={dataSources}
                             updateAction={(setNewAction) => {
-                              upsertAction({
-                                ...a,
-                                configuration: setNewAction(a.configuration),
+                              updateAction({
+                                actionName: a.name,
+                                getNewActionConfig: (old) =>
+                                  setNewAction(
+                                    old as AssistantBuilderRetrievalConfiguration
+                                  ),
                               });
                             }}
                             setEdited={setEdited}
@@ -262,9 +291,12 @@ export default function ActionsScreen({
                             actionConfiguration={a.configuration}
                             dataSources={dataSources}
                             updateAction={(setNewAction) => {
-                              upsertAction({
-                                ...a,
-                                configuration: setNewAction(a.configuration),
+                              updateAction({
+                                actionName: a.name,
+                                getNewActionConfig: (old) =>
+                                  setNewAction(
+                                    old as AssistantBuilderProcessConfiguration
+                                  ),
                               });
                             }}
                             setEdited={setEdited}
@@ -277,9 +309,12 @@ export default function ActionsScreen({
                             actionConfiguration={a.configuration}
                             dataSources={dataSources}
                             updateAction={(setNewAction) => {
-                              upsertAction({
-                                ...a,
-                                configuration: setNewAction(a.configuration),
+                              updateAction({
+                                actionName: a.name,
+                                getNewActionConfig: (old) =>
+                                  setNewAction(
+                                    old as AssistantBuilderTablesQueryConfiguration
+                                  ),
                               });
                             }}
                             setEdited={setEdited}

--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -216,10 +216,10 @@ export default function ActionsScreen({
                             owner={owner}
                             actionConfigration={a.configuration}
                             dustApps={dustApps}
-                            updateAction={(newAction) => {
+                            updateAction={(setNewAction) => {
                               upsertAction({
                                 ...a,
-                                configuration: newAction,
+                                configuration: setNewAction(a.configuration),
                               });
                             }}
                             setEdited={setEdited}
@@ -261,10 +261,10 @@ export default function ActionsScreen({
                             owner={owner}
                             actionConfiguration={a.configuration}
                             dataSources={dataSources}
-                            updateAction={(newAction) => {
+                            updateAction={(setNewAction) => {
                               upsertAction({
                                 ...a,
-                                configuration: newAction,
+                                configuration: setNewAction(a.configuration),
                               });
                             }}
                             setEdited={setEdited}
@@ -276,10 +276,10 @@ export default function ActionsScreen({
                             owner={owner}
                             actionConfiguration={a.configuration}
                             dataSources={dataSources}
-                            updateAction={(newAction) => {
+                            updateAction={(setNewAction) => {
                               upsertAction({
                                 ...a,
-                                configuration: newAction,
+                                configuration: setNewAction(a.configuration),
                               });
                             }}
                             setEdited={setEdited}

--- a/front/components/assistant_builder/actions/DustAppRunAction.tsx
+++ b/front/components/assistant_builder/actions/DustAppRunAction.tsx
@@ -25,7 +25,11 @@ export function ActionDustAppRun({
 }: {
   owner: WorkspaceType;
   actionConfigration: AssistantBuilderDustAppConfiguration | null;
-  updateAction: (action: AssistantBuilderDustAppConfiguration) => void;
+  updateAction: (
+    setNewAction: (
+      previousAction: AssistantBuilderDustAppConfiguration
+    ) => AssistantBuilderDustAppConfiguration
+  ) => void;
   setEdited: (edited: boolean) => void;
   dustApps: AppType[];
 }) {
@@ -33,10 +37,10 @@ export function ActionDustAppRun({
 
   const deleteDustApp = () => {
     setEdited(true);
-    updateAction({
-      ...actionConfigration,
+    updateAction((previousAction) => ({
+      ...previousAction,
       app: null,
-    });
+    }));
   };
 
   const noDustApp = dustApps.length === 0;
@@ -55,10 +59,10 @@ export function ActionDustAppRun({
         dustApps={dustApps}
         onSave={({ app }) => {
           setEdited(true);
-          updateAction({
-            ...actionConfigration,
+          updateAction((previousAction) => ({
+            ...previousAction,
             app,
-          });
+          }));
         }}
       />
 

--- a/front/components/assistant_builder/actions/TablesQueryAction.tsx
+++ b/front/components/assistant_builder/actions/TablesQueryAction.tsx
@@ -6,7 +6,6 @@ import AssistantBuilderTablesModal from "@app/components/assistant_builder/Assis
 import TablesSelectionSection from "@app/components/assistant_builder/TablesSelectionSection";
 import type {
   AssistantBuilderActionConfiguration,
-  AssistantBuilderTableConfiguration,
   AssistantBuilderTablesQueryConfiguration,
 } from "@app/components/assistant_builder/types";
 import { tableKey } from "@app/lib/client/tables_query";
@@ -29,7 +28,11 @@ export function ActionTablesQuery({
 }: {
   owner: WorkspaceType;
   actionConfiguration: AssistantBuilderTablesQueryConfiguration | null;
-  updateAction: (action: AssistantBuilderTablesQueryConfiguration) => void;
+  updateAction: (
+    setNewAction: (
+      previousAction: AssistantBuilderTablesQueryConfiguration
+    ) => AssistantBuilderTablesQueryConfiguration
+  ) => void;
   setEdited: (edited: boolean) => void;
   dataSources: DataSourceType[];
 }) {
@@ -48,14 +51,12 @@ export function ActionTablesQuery({
         dataSources={dataSources}
         onSave={(tables) => {
           setEdited(true);
-          const newTables: Record<string, AssistantBuilderTableConfiguration> =
-            {};
-          for (const t of tables) {
-            newTables[tableKey(t)] = t;
-          }
-          updateAction({
-            ...actionConfiguration,
-            ...newTables,
+          updateAction((previousAction) => {
+            const newTables = { ...previousAction };
+            for (const t of tables) {
+              newTables[tableKey(t)] = t;
+            }
+            return newTables;
           });
         }}
         tablesQueryConfiguration={actionConfiguration}
@@ -87,9 +88,11 @@ export function ActionTablesQuery({
         }}
         onDelete={(key) => {
           setEdited(true);
-          const newTables = { ...actionConfiguration };
-          delete newTables[key];
-          updateAction(newTables);
+          updateAction((previousAction) => {
+            const newTables = { ...previousAction };
+            delete newTables[key];
+            return newTables;
+          });
         }}
         canSelectTable={dataSources.length !== 0}
       />


### PR DESCRIPTION
## Description

fixes https://github.com/dust-tt/tasks/issues/736

UI was updating state by spreading potentially stale state. We should always use setState callbacks when the new state is not fully replacing the old state, otherwise there are race conditions when calling the setState method in rapid successions (every setState is seeing the same stale state)

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
