### PR TITLE
Remove AgentGenerationConfiguration model and type.

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -23,7 +23,6 @@ import {
 } from "@app/lib/models/assistant/actions/tables_query";
 import {
   AgentConfiguration,
-  AgentGenerationConfiguration,
   AgentUserRelation,
   GlobalAgentSettings,
 } from "@app/lib/models/assistant/agent";
@@ -93,8 +92,6 @@ async function main() {
   await AgentConfiguration.sync({ alter: true });
   await AgentUserRelation.sync({ alter: true });
   await GlobalAgentSettings.sync({ alter: true });
-
-  await AgentGenerationConfiguration.sync({ alter: true });
 
   await AgentRetrievalConfiguration.sync({ alter: true });
   await AgentDustAppRunConfiguration.sync({ alter: true });

--- a/front/components/assistant/AssistantActions.tsx
+++ b/front/components/assistant/AssistantActions.tsx
@@ -197,7 +197,6 @@ export function RemoveAssistantFromWorkspaceDialog({
             scope: "published",
             model: agentConfiguration.model,
             actions: detailedConfiguration.actions,
-            generation: detailedConfiguration.generation,
           },
         };
 

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -837,7 +837,6 @@ export async function submitAssistantBuilderForm({
         status: isDraft ? "draft" : "active",
         scope: builderState.scope,
         actions: actionParams,
-        generation: {}, // Warning should not be empty otherwise no generation will be done
         model: {
           modelId: builderState.generationSettings.modelSettings.modelId,
           providerId: builderState.generationSettings.modelSettings.providerId,

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -6,7 +6,6 @@ import type {
   AgentConfigurationType,
   AgentErrorEvent,
   AgentGenerationCancelledEvent,
-  AgentGenerationConfigurationType,
   AgentGenerationSuccessEvent,
   AgentMessageSuccessEvent,
   AgentMessageType,
@@ -179,30 +178,21 @@ export async function* runMultiActionsAgent(
 
     const { action, inputs, specification } = actionToRun.value;
 
-    if (isAgentActionConfigurationType(action)) {
-      const eventStream = runAction(auth, {
-        configuration: configuration,
-        actionConfiguration: action,
-        conversation,
-        userMessage,
-        agentMessage,
-        inputs,
-        specification,
-        step: i,
-      });
-      for await (const event of eventStream) {
-        yield event;
-      }
-    } else {
-      // TODO(@fontanierh): remove this once generation is part of actions.
-      // This is just to assert that we cover all action types.
-      ((g: AgentGenerationConfigurationType) => {
-        void g;
-      })(action);
-      // If the next action is the generation, we simply break out of the loop,
-      // as we always run the generation after the actions loop.
-      break;
+    const eventStream = runAction(auth, {
+      configuration: configuration,
+      actionConfiguration: action,
+      conversation,
+      userMessage,
+      agentMessage,
+      inputs,
+      specification,
+      step: i,
+    });
+    for await (const event of eventStream) {
+      yield event;
     }
+    // If the next action is the generation, we simply break out of the loop,
+    // as we always run the generation after the actions loop.
   }
 
   const eventStream = runGeneration(
@@ -280,7 +270,6 @@ export async function getNextAction(
     conversation,
     userMessage,
     availableActions,
-    isGenerationAllowed = true,
     forcedActionName,
   }: {
     agentConfiguration: AgentConfigurationType;
@@ -294,14 +283,14 @@ export async function getNextAction(
 ): Promise<
   Result<
     {
-      action: AgentActionConfigurationType | AgentGenerationConfigurationType;
+      action: AgentActionConfigurationType;
       inputs: Record<string, string | boolean | number>;
       specification: AgentActionSpecification | null;
     },
     Error
   >
 > {
-  let prompt = await constructPromptMultiActions(
+  const prompt = await constructPromptMultiActions(
     auth,
     userMessage,
     agentConfiguration,
@@ -384,24 +373,7 @@ export async function getNextAction(
       assertNever(a);
     }
   }
-
-  // TODO(@fontanierh): remove this once generation is part of actions.
-  if (agentConfiguration.generation && isGenerationAllowed) {
-    specifications.push({
-      name: "reply_to_user",
-      description:
-        "Reply to the user with a message. It is mandatory to call this function before replying to the user, otherwise they won't be able to see the message.",
-      inputs: [
-        {
-          name: "language",
-          type: "string",
-          description:
-            "The language of the message to send. Should always be 'en' (for english) or 'fr' (for french).",
-        },
-      ],
-    });
-    prompt = `${prompt}\nNever attempt to directly send a message to the user without using the 'reply_to_user' function. When there is no other action to perform, use this function to send a message to the user.`;
-  }
+  // not sure if the speicfications.push() is needed here TBD at review time.
 
   const config = cloneBaseConfig(
     DustProdActionRegistry["assistant-v2-use-tools"].config
@@ -477,10 +449,7 @@ export async function getNextAction(
   }
   output.arguments = output.arguments ?? {};
 
-  const action =
-    output.name === "reply_to_user"
-      ? agentConfiguration.generation
-      : agentConfiguration.actions.find((a) => a.name === output.name);
+  const action = agentConfiguration.actions.find((a) => a.name === output.name);
 
   const spec = specifications.find((s) => s.name === output.name) ?? null;
 

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -21,7 +21,6 @@ import {
   cloneBaseConfig,
   DustProdActionRegistry,
   Err,
-  isAgentActionConfigurationType,
   isDustAppRunConfiguration,
   isProcessConfiguration,
   isRetrievalConfiguration,
@@ -144,7 +143,6 @@ export async function* runMultiActionsAgent(
       conversation,
       userMessage,
       availableActions: actions,
-      isGenerationAllowed: !forcedAction,
       forcedActionName: forcedAction?.name ?? undefined,
     });
 
@@ -276,8 +274,6 @@ export async function getNextAction(
     conversation: ConversationType;
     userMessage: UserMessageType;
     availableActions: AgentActionConfigurationType[];
-    // TODO(@fontanierh): remove this once generation is part of actions.
-    isGenerationAllowed: boolean;
     forcedActionName?: string;
   }
 ): Promise<

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -115,12 +115,6 @@ async function _getHelperGlobalAgent(
       modelId: model.modelId,
       temperature: 0.2,
     },
-    generation: {
-      id: -1,
-      name: "send_message_to_user",
-      description: "Send a message to the user",
-      forceUseAtIteration: 0,
-    },
     actions: [],
     maxToolsUsePerRun: 1,
   };
@@ -149,12 +143,6 @@ async function _getGPT35TurboGlobalAgent({
       providerId: GPT_3_5_TURBO_MODEL_CONFIG.providerId,
       modelId: GPT_3_5_TURBO_MODEL_CONFIG.modelId,
       temperature: 0.7,
-    },
-    generation: {
-      id: -1,
-      name: "send_message_to_user",
-      description: "Send a message to the user",
-      forceUseAtIteration: 0,
     },
     actions: [],
     maxToolsUsePerRun: 1,
@@ -185,12 +173,6 @@ async function _getGPT4GlobalAgent({
       modelId: GPT_4_TURBO_MODEL_CONFIG.modelId,
       temperature: 0.7,
     },
-    generation: {
-      id: -1,
-      name: "send_message_to_user",
-      description: "Send a message to the user",
-      forceUseAtIteration: 0,
-    },
     actions: [],
     maxToolsUsePerRun: 1,
   };
@@ -219,12 +201,6 @@ async function _getClaudeInstantGlobalAgent({
       providerId: CLAUDE_INSTANT_DEFAULT_MODEL_CONFIG.providerId,
       modelId: CLAUDE_INSTANT_DEFAULT_MODEL_CONFIG.modelId,
       temperature: 0.7,
-    },
-    generation: {
-      id: -1,
-      name: "send_message_to_user",
-      description: "Send a message to the user",
-      forceUseAtIteration: 0,
     },
     actions: [],
     maxToolsUsePerRun: 1,
@@ -261,12 +237,7 @@ async function _getClaude2GlobalAgent({
       modelId: CLAUDE_2_DEFAULT_MODEL_CONFIG.modelId,
       temperature: 0.7,
     },
-    generation: {
-      id: -1,
-      name: "send_message_to_user",
-      description: "Send a message to the user",
-      forceUseAtIteration: 0,
-    },
+
     actions: [],
     maxToolsUsePerRun: 1,
   };
@@ -304,12 +275,6 @@ async function _getClaude3HaikuGlobalAgent({
       modelId: CLAUDE_3_HAIKU_DEFAULT_MODEL_CONFIG.modelId,
       temperature: 0.7,
     },
-    generation: {
-      id: -1,
-      name: "send_message_to_user",
-      description: "Send a message to the user",
-      forceUseAtIteration: 0,
-    },
     actions: [],
     maxToolsUsePerRun: 1,
   };
@@ -346,12 +311,6 @@ async function _getClaude3SonnetGlobalAgent({
       modelId: CLAUDE_3_SONNET_DEFAULT_MODEL_CONFIG.modelId,
       temperature: 0.7,
     },
-    generation: {
-      id: -1,
-      name: "send_message_to_user",
-      description: "Send a message to the user",
-      forceUseAtIteration: 0,
-    },
     actions: [],
     maxToolsUsePerRun: 1,
   };
@@ -387,12 +346,7 @@ async function _getClaude3OpusGlobalAgent({
       modelId: CLAUDE_3_OPUS_DEFAULT_MODEL_CONFIG.modelId,
       temperature: 0.7,
     },
-    generation: {
-      id: -1,
-      name: "send_message_to_user",
-      description: "Send a message to the user",
-      forceUseAtIteration: 0,
-    },
+
     actions: [],
     maxToolsUsePerRun: 1,
   };
@@ -427,12 +381,6 @@ async function _getMistralLargeGlobalAgent({
       providerId: MISTRAL_LARGE_MODEL_CONFIG.providerId,
       modelId: MISTRAL_LARGE_MODEL_CONFIG.modelId,
       temperature: 0.7,
-    },
-    generation: {
-      id: -1,
-      name: "send_message_to_user",
-      description: "Send a message to the user",
-      forceUseAtIteration: 0,
     },
     actions: [],
     maxToolsUsePerRun: 1,
@@ -469,12 +417,6 @@ async function _getMistralMediumGlobalAgent({
       modelId: MISTRAL_MEDIUM_MODEL_CONFIG.modelId,
       temperature: 0.7,
     },
-    generation: {
-      id: -1,
-      name: "send_message_to_user",
-      description: "Send a message to the user",
-      forceUseAtIteration: 0,
-    },
     actions: [],
     maxToolsUsePerRun: 1,
   };
@@ -503,12 +445,6 @@ async function _getMistralSmallGlobalAgent({
       providerId: MISTRAL_SMALL_MODEL_CONFIG.providerId,
       modelId: MISTRAL_SMALL_MODEL_CONFIG.modelId,
       temperature: 0.7,
-    },
-    generation: {
-      id: -1,
-      name: "send_message_to_user",
-      description: "Send a message to the user",
-      forceUseAtIteration: 0,
     },
     actions: [],
     maxToolsUsePerRun: 1,
@@ -543,12 +479,6 @@ async function _getGeminiProGlobalAgent({
       providerId: GEMINI_PRO_DEFAULT_MODEL_CONFIG.providerId,
       modelId: GEMINI_PRO_DEFAULT_MODEL_CONFIG.modelId,
       temperature: 0.7,
-    },
-    generation: {
-      id: -1,
-      name: "send_message_to_user",
-      description: "Send a message to the user",
-      forceUseAtIteration: 0,
     },
     actions: [],
     maxToolsUsePerRun: 1,
@@ -616,7 +546,6 @@ async function _getManagedDataSourceAgent(
       scope: "global",
       userListStatus: "not-in-list",
       model,
-      generation: null,
       actions: [],
       maxToolsUsePerRun: 1,
     };
@@ -640,7 +569,6 @@ async function _getManagedDataSourceAgent(
       status: "disabled_missing_datasource",
       scope: "global",
       userListStatus: "not-in-list",
-      generation: null,
       model,
       actions: [],
       maxToolsUsePerRun: 1,
@@ -661,12 +589,6 @@ async function _getManagedDataSourceAgent(
     scope: "global",
     userListStatus: "in-list",
     model,
-    generation: {
-      id: -1,
-      name: "send_message_to_user",
-      description: "Send a message to the user",
-      forceUseAtIteration: 1,
-    },
     actions: [
       {
         id: -1,
@@ -856,7 +778,6 @@ async function _getDustGlobalAgent(
       scope: "global",
       userListStatus: "not-in-list",
       model,
-      generation: null,
       actions: [],
       maxToolsUsePerRun: 1,
     };
@@ -889,7 +810,6 @@ async function _getDustGlobalAgent(
       scope: "global",
       userListStatus: "not-in-list",
       model,
-      generation: null,
       actions: [],
       maxToolsUsePerRun: 1,
     };
@@ -911,12 +831,6 @@ async function _getDustGlobalAgent(
     scope: "global",
     userListStatus: "in-list",
     model,
-    generation: {
-      id: -1,
-      name: "send_message_to_user",
-      description: "Send a message to the user",
-      forceUseAtIteration: 1,
-    },
     actions: [
       {
         id: -1,

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -116,7 +116,7 @@ async function _getHelperGlobalAgent(
       temperature: 0.2,
     },
     actions: [],
-    maxToolsUsePerRun: 1,
+    maxToolsUsePerRun: 0,
   };
 }
 
@@ -145,7 +145,7 @@ async function _getGPT35TurboGlobalAgent({
       temperature: 0.7,
     },
     actions: [],
-    maxToolsUsePerRun: 1,
+    maxToolsUsePerRun: 0,
   };
 }
 
@@ -174,7 +174,7 @@ async function _getGPT4GlobalAgent({
       temperature: 0.7,
     },
     actions: [],
-    maxToolsUsePerRun: 1,
+    maxToolsUsePerRun: 0,
   };
 }
 
@@ -203,7 +203,7 @@ async function _getClaudeInstantGlobalAgent({
       temperature: 0.7,
     },
     actions: [],
-    maxToolsUsePerRun: 1,
+    maxToolsUsePerRun: 0,
   };
 }
 
@@ -239,7 +239,7 @@ async function _getClaude2GlobalAgent({
     },
 
     actions: [],
-    maxToolsUsePerRun: 1,
+    maxToolsUsePerRun: 0,
   };
 }
 
@@ -276,7 +276,7 @@ async function _getClaude3HaikuGlobalAgent({
       temperature: 0.7,
     },
     actions: [],
-    maxToolsUsePerRun: 1,
+    maxToolsUsePerRun: 0,
   };
 }
 
@@ -312,7 +312,7 @@ async function _getClaude3SonnetGlobalAgent({
       temperature: 0.7,
     },
     actions: [],
-    maxToolsUsePerRun: 1,
+    maxToolsUsePerRun: 0,
   };
 }
 
@@ -348,7 +348,7 @@ async function _getClaude3OpusGlobalAgent({
     },
 
     actions: [],
-    maxToolsUsePerRun: 1,
+    maxToolsUsePerRun: 0,
   };
 }
 
@@ -383,7 +383,7 @@ async function _getMistralLargeGlobalAgent({
       temperature: 0.7,
     },
     actions: [],
-    maxToolsUsePerRun: 1,
+    maxToolsUsePerRun: 0,
   };
 }
 
@@ -418,7 +418,7 @@ async function _getMistralMediumGlobalAgent({
       temperature: 0.7,
     },
     actions: [],
-    maxToolsUsePerRun: 1,
+    maxToolsUsePerRun: 0,
   };
 }
 
@@ -447,7 +447,7 @@ async function _getMistralSmallGlobalAgent({
       temperature: 0.7,
     },
     actions: [],
-    maxToolsUsePerRun: 1,
+    maxToolsUsePerRun: 0,
   };
 }
 
@@ -481,7 +481,7 @@ async function _getGeminiProGlobalAgent({
       temperature: 0.7,
     },
     actions: [],
-    maxToolsUsePerRun: 1,
+    maxToolsUsePerRun: 0,
   };
 }
 
@@ -547,7 +547,7 @@ async function _getManagedDataSourceAgent(
       userListStatus: "not-in-list",
       model,
       actions: [],
-      maxToolsUsePerRun: 1,
+      maxToolsUsePerRun: 0,
     };
   }
 
@@ -571,7 +571,7 @@ async function _getManagedDataSourceAgent(
       userListStatus: "not-in-list",
       model,
       actions: [],
-      maxToolsUsePerRun: 1,
+      maxToolsUsePerRun: 0,
     };
   }
 
@@ -609,7 +609,7 @@ async function _getManagedDataSourceAgent(
         forceUseAtIteration: 0,
       },
     ],
-    maxToolsUsePerRun: 2,
+    maxToolsUsePerRun: 1,
   };
 }
 
@@ -779,7 +779,7 @@ async function _getDustGlobalAgent(
       userListStatus: "not-in-list",
       model,
       actions: [],
-      maxToolsUsePerRun: 1,
+      maxToolsUsePerRun: 0,
     };
   }
 
@@ -811,7 +811,7 @@ async function _getDustGlobalAgent(
       userListStatus: "not-in-list",
       model,
       actions: [],
-      maxToolsUsePerRun: 1,
+      maxToolsUsePerRun: 0,
     };
   }
 
@@ -849,7 +849,7 @@ async function _getDustGlobalAgent(
         forceUseAtIteration: 0,
       },
     ],
-    maxToolsUsePerRun: 2,
+    maxToolsUsePerRun: 1,
   };
 }
 

--- a/front/lib/api/assistant/legacy_agent.ts
+++ b/front/lib/api/assistant/legacy_agent.ts
@@ -210,61 +210,59 @@ export async function* runLegacyAgent(
   }
 
   // Then run the generation if a configuration is present.
-  if (configuration.generation !== null) {
-    const eventStream = runGeneration(
-      auth,
-      configuration,
-      conversation,
-      userMessage,
-      agentMessage
-    );
+  const eventStream = runGeneration(
+    auth,
+    configuration,
+    conversation,
+    userMessage,
+    agentMessage
+  );
 
-    for await (const event of eventStream) {
-      switch (event.type) {
-        case "generation_tokens":
-          yield event;
-          break;
+  for await (const event of eventStream) {
+    switch (event.type) {
+      case "generation_tokens":
+        yield event;
+        break;
 
-        case "generation_error":
-          yield {
-            type: "agent_error",
-            created: event.created,
-            configurationId: configuration.sId,
-            messageId: agentMessage.sId,
-            error: {
-              code: event.error.code,
-              message: event.error.message,
-            },
-          };
-          return;
+      case "generation_error":
+        yield {
+          type: "agent_error",
+          created: event.created,
+          configurationId: configuration.sId,
+          messageId: agentMessage.sId,
+          error: {
+            code: event.error.code,
+            message: event.error.message,
+          },
+        };
+        return;
 
-        case "generation_cancel":
-          yield {
-            type: "agent_generation_cancelled",
-            created: event.created,
-            configurationId: configuration.sId,
-            messageId: agentMessage.sId,
-          };
-          return;
+      case "generation_cancel":
+        yield {
+          type: "agent_generation_cancelled",
+          created: event.created,
+          configurationId: configuration.sId,
+          messageId: agentMessage.sId,
+        };
+        return;
 
-        case "generation_success":
-          yield {
-            type: "agent_generation_success",
-            created: event.created,
-            configurationId: configuration.sId,
-            messageId: agentMessage.sId,
-            text: event.text,
-          };
+      case "generation_success":
+        yield {
+          type: "agent_generation_success",
+          created: event.created,
+          configurationId: configuration.sId,
+          messageId: agentMessage.sId,
+          text: event.text,
+        };
 
-          agentMessage.content = event.text;
-          break;
+        agentMessage.content = event.text;
+        break;
 
-        default:
-          ((event: never) => {
-            logger.error("Unknown `runAgent` event type", event);
-          })(event);
-          return;
-      }
+      default:
+        ((event: never) => {
+          logger.error("Unknown `runAgent` event type", event);
+        })(event);
+        return;
     }
   }
 

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -170,17 +170,15 @@ export function orderDatasourceByImportance(dataSources: DataSourceType[]) {
 }
 
 // This function returns true if the agent is a "legacy" agent with a forced schedule,
-// i.e it has a maxToolsUsePerRun <= 2, every possible iteration has a forced action,
+// i.e it has a maxToolsUsePerRun <= 1, every possible iteration has a forced action,
 // and every tool is forced at a certain iteration.
 export function isLegacyAgent(configuration: AgentConfigurationType): boolean {
   // TODO(@fontanierh): change once generation is part of actions.
   const actions = removeNulls([...configuration.actions]);
 
   return (
-    configuration.maxToolsUsePerRun <= 2 &&
-    Array.from(Array(configuration.maxToolsUsePerRun).keys()).every((i) =>
-      actions.some((a) => a.forceUseAtIteration === i)
-    ) &&
-    actions.every((a) => a.forceUseAtIteration !== undefined)
+    configuration.maxToolsUsePerRun <= 1 &&
+    actions.length <= 1 &&
+    actions[0]?.forceUseAtIteration === 0
   );
 }

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -174,10 +174,7 @@ export function orderDatasourceByImportance(dataSources: DataSourceType[]) {
 // and every tool is forced at a certain iteration.
 export function isLegacyAgent(configuration: AgentConfigurationType): boolean {
   // TODO(@fontanierh): change once generation is part of actions.
-  const actions = removeNulls([
-    ...configuration.actions,
-    configuration.generation,
-  ]);
+  const actions = removeNulls([...configuration.actions]);
 
   return (
     configuration.maxToolsUsePerRun <= 2 &&

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -179,6 +179,6 @@ export function isLegacyAgent(configuration: AgentConfigurationType): boolean {
   return (
     configuration.maxToolsUsePerRun <= 1 &&
     actions.length <= 1 &&
-    actions[0]?.forceUseAtIteration === 0
+    actions.every((a) => a.forceUseAtIteration === 0)
   );
 }

--- a/front/lib/models/assistant/agent.ts
+++ b/front/lib/models/assistant/agent.ts
@@ -118,8 +118,6 @@ AgentConfiguration.init(
     maxToolsUsePerRun: {
       type: DataTypes.INTEGER,
       allowNull: false,
-      // do we want to decrease this one to 0?
-      defaultValue: 1,
     },
     pictureUrl: {
       type: DataTypes.TEXT,

--- a/front/lib/models/assistant/agent.ts
+++ b/front/lib/models/assistant/agent.ts
@@ -118,6 +118,7 @@ AgentConfiguration.init(
     maxToolsUsePerRun: {
       type: DataTypes.INTEGER,
       allowNull: false,
+      // do we want to decrease this one to 0?
       defaultValue: 1,
     },
     pictureUrl: {

--- a/front/lib/models/assistant/agent.ts
+++ b/front/lib/models/assistant/agent.ts
@@ -20,65 +20,6 @@ import { Workspace } from "@app/lib/models/workspace";
 import { frontSequelize } from "@app/lib/resources/storage";
 
 /**
- * Configuration of Agent generation.
- */
-export class AgentGenerationConfiguration extends Model<
-  InferAttributes<AgentGenerationConfiguration>,
-  InferCreationAttributes<AgentGenerationConfiguration>
-> {
-  declare id: CreationOptional<number>;
-  declare createdAt: CreationOptional<Date>;
-  declare updatedAt: CreationOptional<Date>;
-
-  declare agentConfigurationId: ForeignKey<AgentConfiguration["id"]>;
-
-  declare name: string | null;
-  declare description: string | null;
-  declare forceUseAtIteration: number | null;
-}
-AgentGenerationConfiguration.init(
-  {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
-    createdAt: {
-      type: DataTypes.DATE,
-      allowNull: false,
-      defaultValue: DataTypes.NOW,
-    },
-    updatedAt: {
-      type: DataTypes.DATE,
-      allowNull: false,
-      defaultValue: DataTypes.NOW,
-    },
-    name: {
-      type: DataTypes.STRING,
-      allowNull: true,
-    },
-    description: {
-      type: DataTypes.TEXT,
-      allowNull: true,
-    },
-    forceUseAtIteration: {
-      type: DataTypes.INTEGER,
-      allowNull: true,
-    },
-  },
-  {
-    modelName: "agent_generation_configuration",
-    sequelize: frontSequelize,
-    indexes: [
-      {
-        fields: ["agentConfigurationId"],
-        concurrently: true,
-      },
-    ],
-  }
-);
-
-/**
  * Agent configuration
  */
 export class AgentConfiguration extends Model<
@@ -205,14 +146,6 @@ AgentConfiguration.init(
     ],
   }
 );
-
-// AgentGenerationConfiguration <> AgentConfiguration
-AgentConfiguration.hasMany(AgentGenerationConfiguration, {
-  foreignKey: { name: "agentConfigurationId", allowNull: false },
-});
-AgentGenerationConfiguration.belongsTo(AgentConfiguration, {
-  foreignKey: { name: "agentConfigurationId", allowNull: false },
-});
 
 //  Agent config <> Workspace
 Workspace.hasMany(AgentConfiguration, {

--- a/front/migrations/20240411_agent_config_instructions.ts
+++ b/front/migrations/20240411_agent_config_instructions.ts
@@ -1,71 +1,71 @@
-import {
-  AgentConfiguration,
-  AgentGenerationConfiguration,
-} from "@app/lib/models/assistant/agent";
-import logger from "@app/logger/logger";
-import { makeScript } from "@app/scripts/helpers";
+// import {
+//   AgentConfiguration,
+//   AgentGenerationConfiguration,
+// } from "@app/lib/models/assistant/agent";
+// import logger from "@app/logger/logger";
+// import { makeScript } from "@app/scripts/helpers";
 
-const backfillAgentConfiguration = async (
-  agent: AgentConfiguration,
-  execute: boolean
-): Promise<void> => {
-  const genConfigs = await AgentGenerationConfiguration.findAll({
-    where: {
-      id: agent.id,
-    },
-    attributes: ["prompt"],
-  });
+// const backfillAgentConfiguration = async (
+//   agent: AgentConfiguration,
+//   execute: boolean
+// ): Promise<void> => {
+//   const genConfigs = await AgentGenerationConfiguration.findAll({
+//     where: {
+//       id: agent.id,
+//     },
+//     attributes: ["prompt"],
+//   });
 
-  if (genConfigs.length > 1) {
-    throw new Error(
-      "Unexpected: legacy migration in which there could not be multiple generation configurations per agent"
-    );
-  }
+//   if (genConfigs.length > 1) {
+//     throw new Error(
+//       "Unexpected: legacy migration in which there could not be multiple generation configurations per agent"
+//     );
+//   }
 
-  if (genConfigs.length === 0) {
-    logger.info(`Skipping agent (no generation configuration) ${agent.id}`);
-    return;
-  }
+//   if (genConfigs.length === 0) {
+//     logger.info(`Skipping agent (no generation configuration) ${agent.id}`);
+//     return;
+//   }
 
-  // const prompt = genConfigs[0].prompt;
-  // if (!prompt) {
-  //   logger.info(`Skipping agent (no generation configuration) ${agent.id}`);
-  //   return;
-  // }
+//   // const prompt = genConfigs[0].prompt;
+//   // if (!prompt) {
+//   //   logger.info(`Skipping agent (no generation configuration) ${agent.id}`);
+//   //   return;
+//   // }
 
-  if (execute) {
-    // await agent.update({
-    //   instructions: prompt,
-    // });
-  }
-};
+//   if (execute) {
+//     // await agent.update({
+//     //   instructions: prompt,
+//     // });
+//   }
+// };
 
-const backfillAgentConfigurations = async (execute: boolean) => {
-  // Fetch all agents that have no instructions
-  const agents = await AgentConfiguration.findAll({
-    where: {
-      instructions: null,
-    },
-  });
+// const backfillAgentConfigurations = async (execute: boolean) => {
+//   // Fetch all agents that have no instructions
+//   const agents = await AgentConfiguration.findAll({
+//     where: {
+//       instructions: null,
+//     },
+//   });
 
-  // Split agents into chunks of 16
-  const chunks: AgentConfiguration[][] = [];
-  for (let i = 0; i < agents.length; i += 16) {
-    chunks.push(agents.slice(i, i + 16));
-  }
+//   // Split agents into chunks of 16
+//   const chunks: AgentConfiguration[][] = [];
+//   for (let i = 0; i < agents.length; i += 16) {
+//     chunks.push(agents.slice(i, i + 16));
+//   }
 
-  // Process each chunk in parallel
-  for (let i = 0; i < chunks.length; i++) {
-    const chunk = chunks[i];
-    await Promise.all(
-      chunk.map(async (agent) => {
-        return backfillAgentConfiguration(agent, execute);
-      })
-    );
-  }
-};
+//   // Process each chunk in parallel
+//   for (let i = 0; i < chunks.length; i++) {
+//     const chunk = chunks[i];
+//     await Promise.all(
+//       chunk.map(async (agent) => {
+//         return backfillAgentConfiguration(agent, execute);
+//       })
+//     );
+//   }
+// };
 
-makeScript({}, async ({ execute }) => {
-  throw new Error("This migration is deprecated and should not be run.");
-  await backfillAgentConfigurations(execute);
-});
+// makeScript({}, async ({ execute }) => {
+//   throw new Error("This migration is deprecated and should not be run.");
+//   await backfillAgentConfigurations(execute);
+// });

--- a/front/migrations/20240412_force_use_at_iteration.ts
+++ b/front/migrations/20240412_force_use_at_iteration.ts
@@ -1,155 +1,155 @@
-import { assertNever, removeNulls } from "@dust-tt/types";
-import * as _ from "lodash";
+// import { assertNever, removeNulls } from "@dust-tt/types";
+// import * as _ from "lodash";
 
-import { AgentDustAppRunConfiguration } from "@app/lib/models/assistant/actions/dust_app_run";
-import { AgentRetrievalConfiguration } from "@app/lib/models/assistant/actions/retrieval";
-import { AgentTablesQueryConfiguration } from "@app/lib/models/assistant/actions/tables_query";
-import {
-  AgentConfiguration,
-  AgentGenerationConfiguration,
-} from "@app/lib/models/assistant/agent";
-import logger from "@app/logger/logger";
-import { makeScript } from "@app/scripts/helpers";
+// import { AgentDustAppRunConfiguration } from "@app/lib/models/assistant/actions/dust_app_run";
+// import { AgentRetrievalConfiguration } from "@app/lib/models/assistant/actions/retrieval";
+// import { AgentTablesQueryConfiguration } from "@app/lib/models/assistant/actions/tables_query";
+// import {
+//   AgentConfiguration,
+//   AgentGenerationConfiguration,
+// } from "@app/lib/models/assistant/agent";
+// import logger from "@app/logger/logger";
+// import { makeScript } from "@app/scripts/helpers";
 
-// Fetch all agents, with all generation configs and all actions.
-// Goal is to backfill forceUseAtIteration for all generations and actions.
-// If there is an action, its forceUseAtIteration will be 0 and the generation's will be 1.
-// If there is no action, the generation's will be 0.
+// // Fetch all agents, with all generation configs and all actions.
+// // Goal is to backfill forceUseAtIteration for all generations and actions.
+// // If there is an action, its forceUseAtIteration will be 0 and the generation's will be 1.
+// // If there is no action, the generation's will be 0.
 
-const backfillAgentConfigurations = async (execute: boolean) => {
-  const generations = await AgentGenerationConfiguration.findAll();
-  const generationConfigsByAgentId: Record<
-    number,
-    AgentGenerationConfiguration[]
-  > = _.groupBy(generations, "agentConfigurationId");
+// const backfillAgentConfigurations = async (execute: boolean) => {
+//   const generations = await AgentGenerationConfiguration.findAll();
+//   const generationConfigsByAgentId: Record<
+//     number,
+//     AgentGenerationConfiguration[]
+//   > = _.groupBy(generations, "agentConfigurationId");
 
-  const retrievalConfigs = await AgentRetrievalConfiguration.findAll();
-  const tablesQueryConfigs = await AgentTablesQueryConfiguration.findAll();
-  const dustAppRunConfigs = await AgentDustAppRunConfiguration.findAll();
+//   const retrievalConfigs = await AgentRetrievalConfiguration.findAll();
+//   const tablesQueryConfigs = await AgentTablesQueryConfiguration.findAll();
+//   const dustAppRunConfigs = await AgentDustAppRunConfiguration.findAll();
 
-  const actionsByAgentId: Record<
-    number,
-    (
-      | AgentRetrievalConfiguration
-      | AgentDustAppRunConfiguration
-      | AgentTablesQueryConfiguration
-    )[]
-  > = _.groupBy(
-    [...retrievalConfigs, ...dustAppRunConfigs, ...tablesQueryConfigs],
-    (action) => action.agentConfigurationId
-  );
+//   const actionsByAgentId: Record<
+//     number,
+//     (
+//       | AgentRetrievalConfiguration
+//       | AgentDustAppRunConfiguration
+//       | AgentTablesQueryConfiguration
+//     )[]
+//   > = _.groupBy(
+//     [...retrievalConfigs, ...dustAppRunConfigs, ...tablesQueryConfigs],
+//     (action) => action.agentConfigurationId
+//   );
 
-  const allAgentIds: number[] = Array.from(
-    new Set<number>([
-      ...removeNulls(Object.keys(actionsByAgentId).map(Number)),
-      ...removeNulls(Object.keys(generationConfigsByAgentId)).map(Number),
-    ])
-  );
+//   const allAgentIds: number[] = Array.from(
+//     new Set<number>([
+//       ...removeNulls(Object.keys(actionsByAgentId).map(Number)),
+//       ...removeNulls(Object.keys(generationConfigsByAgentId)).map(Number),
+//     ])
+//   );
 
-  const chunks = _.chunk(allAgentIds, 16);
+//   const chunks = _.chunk(allAgentIds, 16);
 
-  for (const c of chunks) {
-    for (const aId of c) {
-      const generations = generationConfigsByAgentId[aId] ?? [];
-      const actions = actionsByAgentId[aId] ?? [];
-      if (generations.length > 1) {
-        throw new Error("Unreachable: agent has multiple generations");
-      }
-      logger.info(
-        `Backfilling max tools use per run for agent ${aId}... [execute: ${execute}]`
-      );
-      if (execute) {
-        const nbFixedIterations = (generations.length ? 1 : 0) + actions.length;
-        await AgentConfiguration.update(
-          { maxToolsUsePerRun: nbFixedIterations },
-          {
-            where: {
-              id: aId,
-            },
-          }
-        );
-      }
-      if (!generations.length) {
-        logger.info(
-          `Skipping forceUseAtIteration backfill for agent ${aId} (no generation configuration)`
-        );
-        continue;
-      }
-      if (actions.length > 1) {
-        logger.info(
-          `Skipping forceUseAtIteration backfill for agent ${aId} (multiple actions)`
-        );
-        continue;
-      }
-      let forceUseAtIteration = 0;
-      if (actions.length) {
-        const action = actions[0];
-        if (action instanceof AgentRetrievalConfiguration) {
-          logger.info(
-            `Backfilling retrieval action ${action.id} for agent ${aId} with forceUseAtIteration... [execute: ${execute}]`
-          );
-          if (execute) {
-            await AgentRetrievalConfiguration.update(
-              { forceUseAtIteration },
-              {
-                where: {
-                  id: action.id,
-                },
-              }
-            );
-          }
-        } else if (action instanceof AgentDustAppRunConfiguration) {
-          logger.info(
-            `Backfilling dust app run action ${action.id} for agent ${aId} with forceUseAtIteration... [execute: ${execute}]`
-          );
-          if (execute) {
-            await AgentDustAppRunConfiguration.update(
-              { forceUseAtIteration },
-              {
-                where: {
-                  id: action.id,
-                },
-              }
-            );
-          }
-        } else if (action instanceof AgentTablesQueryConfiguration) {
-          logger.info(
-            `Backfilling tables query action ${action.id} for agent ${aId} with forceUseAtIteration... [execute: ${execute}]`
-          );
-          if (execute) {
-            await AgentTablesQueryConfiguration.update(
-              { forceUseAtIteration },
-              {
-                where: {
-                  id: action.id,
-                },
-              }
-            );
-          }
-        } else {
-          assertNever(action);
-        }
+//   for (const c of chunks) {
+//     for (const aId of c) {
+//       const generations = generationConfigsByAgentId[aId] ?? [];
+//       const actions = actionsByAgentId[aId] ?? [];
+//       if (generations.length > 1) {
+//         throw new Error("Unreachable: agent has multiple generations");
+//       }
+//       logger.info(
+//         `Backfilling max tools use per run for agent ${aId}... [execute: ${execute}]`
+//       );
+//       if (execute) {
+//         const nbFixedIterations = (generations.length ? 1 : 0) + actions.length;
+//         await AgentConfiguration.update(
+//           { maxToolsUsePerRun: nbFixedIterations },
+//           {
+//             where: {
+//               id: aId,
+//             },
+//           }
+//         );
+//       }
+//       if (!generations.length) {
+//         logger.info(
+//           `Skipping forceUseAtIteration backfill for agent ${aId} (no generation configuration)`
+//         );
+//         continue;
+//       }
+//       if (actions.length > 1) {
+//         logger.info(
+//           `Skipping forceUseAtIteration backfill for agent ${aId} (multiple actions)`
+//         );
+//         continue;
+//       }
+//       let forceUseAtIteration = 0;
+//       if (actions.length) {
+//         const action = actions[0];
+//         if (action instanceof AgentRetrievalConfiguration) {
+//           logger.info(
+//             `Backfilling retrieval action ${action.id} for agent ${aId} with forceUseAtIteration... [execute: ${execute}]`
+//           );
+//           if (execute) {
+//             await AgentRetrievalConfiguration.update(
+//               { forceUseAtIteration },
+//               {
+//                 where: {
+//                   id: action.id,
+//                 },
+//               }
+//             );
+//           }
+//         } else if (action instanceof AgentDustAppRunConfiguration) {
+//           logger.info(
+//             `Backfilling dust app run action ${action.id} for agent ${aId} with forceUseAtIteration... [execute: ${execute}]`
+//           );
+//           if (execute) {
+//             await AgentDustAppRunConfiguration.update(
+//               { forceUseAtIteration },
+//               {
+//                 where: {
+//                   id: action.id,
+//                 },
+//               }
+//             );
+//           }
+//         } else if (action instanceof AgentTablesQueryConfiguration) {
+//           logger.info(
+//             `Backfilling tables query action ${action.id} for agent ${aId} with forceUseAtIteration... [execute: ${execute}]`
+//           );
+//           if (execute) {
+//             await AgentTablesQueryConfiguration.update(
+//               { forceUseAtIteration },
+//               {
+//                 where: {
+//                   id: action.id,
+//                 },
+//               }
+//             );
+//           }
+//         } else {
+//           assertNever(action);
+//         }
 
-        forceUseAtIteration += 1;
-      }
-      const generation = generations[0];
-      logger.info(
-        `Backfilling generation configuration ${generation.id} for agent ${aId} with forceUseAtIteration... [execute: ${execute}]`
-      );
-      if (execute) {
-        await AgentGenerationConfiguration.update(
-          { forceUseAtIteration },
-          {
-            where: {
-              id: generation.id,
-            },
-          }
-        );
-      }
-    }
-  }
-};
+//         forceUseAtIteration += 1;
+//       }
+//       const generation = generations[0];
+//       logger.info(
+//         `Backfilling generation configuration ${generation.id} for agent ${aId} with forceUseAtIteration... [execute: ${execute}]`
+//       );
+//       if (execute) {
+//         await AgentGenerationConfiguration.update(
+//           { forceUseAtIteration },
+//           {
+//             where: {
+//               id: generation.id,
+//             },
+//           }
+//         );
+//       }
+//     }
+//   }
+// };
 
-makeScript({}, async ({ execute }) => {
-  await backfillAgentConfigurations(execute);
-});
+// makeScript({}, async ({ execute }) => {
+//   await backfillAgentConfigurations(execute);
+// });

--- a/front/migrations/20240415_invert_agent_generation_config_fkey.ts
+++ b/front/migrations/20240415_invert_agent_generation_config_fkey.ts
@@ -1,53 +1,53 @@
-import * as _ from "lodash";
+// import * as _ from "lodash";
 
-import {
-  AgentConfiguration,
-  AgentGenerationConfiguration,
-} from "@app/lib/models/assistant/agent";
-import logger from "@app/logger/logger";
-import { makeScript } from "@app/scripts/helpers";
+// import {
+//   AgentConfiguration,
+//   AgentGenerationConfiguration,
+// } from "@app/lib/models/assistant/agent";
+// import logger from "@app/logger/logger";
+// import { makeScript } from "@app/scripts/helpers";
 
-const backfillGenerationConfigs = async (execute: boolean) => {
-  const generationConfigs = await AgentGenerationConfiguration.findAll({
-    // @ts-expect-error agentConfigurationId was rendered non-nullable by #4795
-    where: {
-      agentConfigurationId: null,
-    },
-  });
+// const backfillGenerationConfigs = async (execute: boolean) => {
+//   const generationConfigs = await AgentGenerationConfiguration.findAll({
+//     // @ts-expect-error agentConfigurationId was rendered non-nullable by #4795
+//     where: {
+//       agentConfigurationId: null,
+//     },
+//   });
 
-  logger.info(
-    `Found ${generationConfigs.length} retrieval configurations without agent configuration`
-  );
+//   logger.info(
+//     `Found ${generationConfigs.length} retrieval configurations without agent configuration`
+//   );
 
-  for (const chunk of _.chunk(generationConfigs, 16)) {
-    await Promise.all(
-      chunk.map(async (g) => {
-        const agent = await AgentConfiguration.findOne({
-          where: {
-            // @ts-expect-error generationConfigurationId was removed by on 2024-04-22
-            generationConfigurationId: g.id,
-          },
-        });
-        if (!agent) {
-          logger.warn(
-            `No agent found for retrieval configuration ${g.id}, destroying it`
-          );
-          if (execute) {
-            await g.destroy();
-          }
-          return;
-        }
-        logger.info(
-          `Backfilling generation configuration ${g.id} with \`agentConfigurationId=${agent.id}\` [execute: ${execute}]`
-        );
-        if (execute) {
-          await g.update({ agentConfigurationId: agent.id });
-        }
-      })
-    );
-  }
-};
+//   for (const chunk of _.chunk(generationConfigs, 16)) {
+//     await Promise.all(
+//       chunk.map(async (g) => {
+//         const agent = await AgentConfiguration.findOne({
+//           where: {
+//             // @ts-expect-error generationConfigurationId was removed by on 2024-04-22
+//             generationConfigurationId: g.id,
+//           },
+//         });
+//         if (!agent) {
+//           logger.warn(
+//             `No agent found for retrieval configuration ${g.id}, destroying it`
+//           );
+//           if (execute) {
+//             await g.destroy();
+//           }
+//           return;
+//         }
+//         logger.info(
+//           `Backfilling generation configuration ${g.id} with \`agentConfigurationId=${agent.id}\` [execute: ${execute}]`
+//         );
+//         if (execute) {
+//           await g.update({ agentConfigurationId: agent.id });
+//         }
+//       })
+//     );
+//   }
+// };
 
-makeScript({}, async ({ execute }) => {
-  await backfillGenerationConfigs(execute);
-});
+// makeScript({}, async ({ execute }) => {
+//   await backfillGenerationConfigs(execute);
+// });

--- a/front/migrations/20240424_agent_config_move_model.ts
+++ b/front/migrations/20240424_agent_config_move_model.ts
@@ -1,86 +1,86 @@
-// import type { ModelIdType, ModelProviderIdType } from "@dust-tt/types";
-// import { isModelId, isModelProviderId } from "@dust-tt/types";
+// // import type { ModelIdType, ModelProviderIdType } from "@dust-tt/types";
+// // import { isModelId, isModelProviderId } from "@dust-tt/types";
 
-import {
-  AgentConfiguration,
-  AgentGenerationConfiguration,
-} from "@app/lib/models/assistant/agent";
-import logger from "@app/logger/logger";
-import { makeScript } from "@app/scripts/helpers";
+// import {
+//   AgentConfiguration,
+//   AgentGenerationConfiguration,
+// } from "@app/lib/models/assistant/agent";
+// import logger from "@app/logger/logger";
+// import { makeScript } from "@app/scripts/helpers";
 
-const backfillAgentConfiguration = async (
-  agent: AgentConfiguration,
-  execute: boolean
-): Promise<void> => {
-  const genConfigs = await AgentGenerationConfiguration.findAll({
-    where: {
-      agentConfigurationId: agent.id,
-    },
-    attributes: ["id", "providerId", "modelId", "temperature"],
-  });
+// const backfillAgentConfiguration = async (
+//   agent: AgentConfiguration,
+//   execute: boolean
+// ): Promise<void> => {
+//   const genConfigs = await AgentGenerationConfiguration.findAll({
+//     where: {
+//       agentConfigurationId: agent.id,
+//     },
+//     attributes: ["id", "providerId", "modelId", "temperature"],
+//   });
 
-  if (genConfigs.length > 1) {
-    throw new Error(
-      "Unexpected: legacy migration in which there could not be multiple generation configurations per agent"
-    );
-  }
+//   if (genConfigs.length > 1) {
+//     throw new Error(
+//       "Unexpected: legacy migration in which there could not be multiple generation configurations per agent"
+//     );
+//   }
 
-  if (genConfigs.length === 0) {
-    logger.info(
-      `Skipping agent (no generation configuration) ${agent.id}. --execute: ${execute}`
-    );
-    return;
-  }
+//   if (genConfigs.length === 0) {
+//     logger.info(
+//       `Skipping agent (no generation configuration) ${agent.id}. --execute: ${execute}`
+//     );
+//     return;
+//   }
 
-  // const [generation] = genConfigs;
+//   // const [generation] = genConfigs;
 
-  // if (!isModelProviderId(generation.providerId)) {
-  //   throw new Error(
-  //     `Invalid Provider Id for agent ${generation.id}:${generation.providerId}).`
-  //   );
-  // }
+//   // if (!isModelProviderId(generation.providerId)) {
+//   //   throw new Error(
+//   //     `Invalid Provider Id for agent ${generation.id}:${generation.providerId}).`
+//   //   );
+//   // }
 
-  // if (!isModelId(generation.modelId)) {
-  //   throw new Error(
-  //     `Invalid Provider Id for agent ${generation.id}:${generation.modelId}).`
-  //   );
-  // }
+//   // if (!isModelId(generation.modelId)) {
+//   //   throw new Error(
+//   //     `Invalid Provider Id for agent ${generation.id}:${generation.modelId}).`
+//   //   );
+//   // }
 
-  // logger.info(
-  //   `Updating agent ${agent.id} from generation configuration ${generation.id}. --execute: ${execute}`
-  // );
+//   // logger.info(
+//   //   `Updating agent ${agent.id} from generation configuration ${generation.id}. --execute: ${execute}`
+//   // );
 
-  if (execute) {
-    // await agent.update({
-    //   modelId: generation.modelId as ModelIdType,
-    //   providerId: generation.providerId as ModelProviderIdType,
-    //   temperature: generation.temperature,
-    // });
-  }
-};
+//   if (execute) {
+//     // await agent.update({
+//     //   modelId: generation.modelId as ModelIdType,
+//     //   providerId: generation.providerId as ModelProviderIdType,
+//     //   temperature: generation.temperature,
+//     // });
+//   }
+// };
 
-const backfillAgentConfigurations = async (execute: boolean) => {
-  // Fetch all agents that have no instructions
-  const agents = await AgentConfiguration.findAll({});
+// const backfillAgentConfigurations = async (execute: boolean) => {
+//   // Fetch all agents that have no instructions
+//   const agents = await AgentConfiguration.findAll({});
 
-  // Split agents into chunks of 16
-  const chunks: AgentConfiguration[][] = [];
-  for (let i = 0; i < agents.length; i += 16) {
-    chunks.push(agents.slice(i, i + 16));
-  }
+//   // Split agents into chunks of 16
+//   const chunks: AgentConfiguration[][] = [];
+//   for (let i = 0; i < agents.length; i += 16) {
+//     chunks.push(agents.slice(i, i + 16));
+//   }
 
-  // Process each chunk in parallel
-  for (let i = 0; i < chunks.length; i++) {
-    const chunk = chunks[i];
-    await Promise.all(
-      chunk.map(async (agent) => {
-        return backfillAgentConfiguration(agent, execute);
-      })
-    );
-  }
-};
+//   // Process each chunk in parallel
+//   for (let i = 0; i < chunks.length; i++) {
+//     const chunk = chunks[i];
+//     await Promise.all(
+//       chunk.map(async (agent) => {
+//         return backfillAgentConfiguration(agent, execute);
+//       })
+//     );
+//   }
+// };
 
-makeScript({}, async ({ execute }) => {
-  throw new Error("This migration is deprecated and should not be run.");
-  await backfillAgentConfigurations(execute);
-});
+// makeScript({}, async ({ execute }) => {
+//   throw new Error("This migration is deprecated and should not be run.");
+//   await backfillAgentConfigurations(execute);
+// });

--- a/front/migrations/20240424_max_tools_use_per_run.ts
+++ b/front/migrations/20240424_max_tools_use_per_run.ts
@@ -1,75 +1,75 @@
-import { removeNulls } from "@dust-tt/types";
-import * as _ from "lodash";
+// import { removeNulls } from "@dust-tt/types";
+// import * as _ from "lodash";
 
-import { AgentDustAppRunConfiguration } from "@app/lib/models/assistant/actions/dust_app_run";
-import { AgentRetrievalConfiguration } from "@app/lib/models/assistant/actions/retrieval";
-import { AgentTablesQueryConfiguration } from "@app/lib/models/assistant/actions/tables_query";
-import {
-  AgentConfiguration,
-  AgentGenerationConfiguration,
-} from "@app/lib/models/assistant/agent";
-import logger from "@app/logger/logger";
-import { makeScript } from "@app/scripts/helpers";
+// import { AgentDustAppRunConfiguration } from "@app/lib/models/assistant/actions/dust_app_run";
+// import { AgentRetrievalConfiguration } from "@app/lib/models/assistant/actions/retrieval";
+// import { AgentTablesQueryConfiguration } from "@app/lib/models/assistant/actions/tables_query";
+// import {
+//   AgentConfiguration,
+//   AgentGenerationConfiguration,
+// } from "@app/lib/models/assistant/agent";
+// import logger from "@app/logger/logger";
+// import { makeScript } from "@app/scripts/helpers";
 
-// Fetch all agents, with all generation configs and all actions.
-// Goal is to backfill maxToolsUsePerRun for all generations and actions.
-const backfillAgentConfigurations = async (execute: boolean) => {
-  const generations = await AgentGenerationConfiguration.findAll();
-  const generationConfigsByAgentId: Record<
-    number,
-    AgentGenerationConfiguration[]
-  > = _.groupBy(generations, "agentConfigurationId");
+// // Fetch all agents, with all generation configs and all actions.
+// // Goal is to backfill maxToolsUsePerRun for all generations and actions.
+// const backfillAgentConfigurations = async (execute: boolean) => {
+//   const generations = await AgentGenerationConfiguration.findAll();
+//   const generationConfigsByAgentId: Record<
+//     number,
+//     AgentGenerationConfiguration[]
+//   > = _.groupBy(generations, "agentConfigurationId");
 
-  const retrievalConfigs = await AgentRetrievalConfiguration.findAll();
-  const tablesQueryConfigs = await AgentTablesQueryConfiguration.findAll();
-  const dustAppRunConfigs = await AgentDustAppRunConfiguration.findAll();
+//   const retrievalConfigs = await AgentRetrievalConfiguration.findAll();
+//   const tablesQueryConfigs = await AgentTablesQueryConfiguration.findAll();
+//   const dustAppRunConfigs = await AgentDustAppRunConfiguration.findAll();
 
-  const actionsByAgentId: Record<
-    number,
-    (
-      | AgentRetrievalConfiguration
-      | AgentDustAppRunConfiguration
-      | AgentTablesQueryConfiguration
-    )[]
-  > = _.groupBy(
-    [...retrievalConfigs, ...dustAppRunConfigs, ...tablesQueryConfigs],
-    (action) => action.agentConfigurationId
-  );
+//   const actionsByAgentId: Record<
+//     number,
+//     (
+//       | AgentRetrievalConfiguration
+//       | AgentDustAppRunConfiguration
+//       | AgentTablesQueryConfiguration
+//     )[]
+//   > = _.groupBy(
+//     [...retrievalConfigs, ...dustAppRunConfigs, ...tablesQueryConfigs],
+//     (action) => action.agentConfigurationId
+//   );
 
-  const allAgentIds: number[] = Array.from(
-    new Set<number>([
-      ...removeNulls(Object.keys(actionsByAgentId).map(Number)),
-      ...removeNulls(Object.keys(generationConfigsByAgentId)).map(Number),
-    ])
-  );
+//   const allAgentIds: number[] = Array.from(
+//     new Set<number>([
+//       ...removeNulls(Object.keys(actionsByAgentId).map(Number)),
+//       ...removeNulls(Object.keys(generationConfigsByAgentId)).map(Number),
+//     ])
+//   );
 
-  const chunks = _.chunk(allAgentIds, 16);
+//   const chunks = _.chunk(allAgentIds, 16);
 
-  for (const c of chunks) {
-    for (const aId of c) {
-      const generations = generationConfigsByAgentId[aId] ?? [];
-      const actions = actionsByAgentId[aId] ?? [];
-      if (generations.length > 1) {
-        throw new Error("Unreachable: agent has multiple generations");
-      }
-      logger.info(
-        `Backfilling max tools use per run for agent ${aId}... [execute: ${execute}]`
-      );
-      if (execute) {
-        const nbFixedIterations = (generations.length ? 1 : 0) + actions.length;
-        await AgentConfiguration.update(
-          { maxToolsUsePerRun: nbFixedIterations },
-          {
-            where: {
-              id: aId,
-            },
-          }
-        );
-      }
-    }
-  }
-};
+//   for (const c of chunks) {
+//     for (const aId of c) {
+//       const generations = generationConfigsByAgentId[aId] ?? [];
+//       const actions = actionsByAgentId[aId] ?? [];
+//       if (generations.length > 1) {
+//         throw new Error("Unreachable: agent has multiple generations");
+//       }
+//       logger.info(
+//         `Backfilling max tools use per run for agent ${aId}... [execute: ${execute}]`
+//       );
+//       if (execute) {
+//         const nbFixedIterations = (generations.length ? 1 : 0) + actions.length;
+//         await AgentConfiguration.update(
+//           { maxToolsUsePerRun: nbFixedIterations },
+//           {
+//             where: {
+//               id: aId,
+//             },
+//           }
+//         );
+//       }
+//     }
+//   }
+// };
 
-makeScript({}, async ({ execute }) => {
-  await backfillAgentConfigurations(execute);
-});
+// makeScript({}, async ({ execute }) => {
+//   await backfillAgentConfigurations(execute);
+// });

--- a/front/migrations/20240507_agent_config_max_tools_use_per_run.ts
+++ b/front/migrations/20240507_agent_config_max_tools_use_per_run.ts
@@ -1,0 +1,22 @@
+import { QueryTypes } from "sequelize";
+
+import { frontSequelize } from "@app/lib/resources/storage";
+import logger from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+
+const decrementAgentConfigTool = async (execute: boolean) => {
+  const queryStr = `
+  UPDATE agent_configurations
+  SET "maxToolsUsePerRun" =  "maxToolsUsePerRun" - 1
+  WHERE "maxToolsUsePerRun" <= 2`;
+  if (execute) {
+    const res = await frontSequelize.query(queryStr, {
+      type: QueryTypes.UPDATE,
+    });
+    logger.info({ count: res[1] }, "Updated agent configurations");
+  }
+};
+
+makeScript({}, async ({ execute }) => {
+  await decrementAgentConfigTool(execute);
+});

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -1,7 +1,6 @@
 import type {
   AgentActionConfigurationType,
   AgentConfigurationType,
-  AgentGenerationConfigurationType,
   LightAgentConfigurationType,
   Result,
   WithAPIErrorReponse,
@@ -21,7 +20,6 @@ import { getAgentUsage } from "@app/lib/api/assistant/agent_usage";
 import {
   createAgentActionConfiguration,
   createAgentConfiguration,
-  createAgentGenerationConfiguration,
   getAgentConfigurations,
   unsafeHardDeleteAgentConfiguration,
 } from "@app/lib/api/assistant/configuration";
@@ -279,7 +277,6 @@ export async function createOrUpgradeAgentConfiguration({
   auth,
   assistant: {
     actions,
-    generation,
     model,
     name,
     description,
@@ -305,19 +302,14 @@ export async function createOrUpgradeAgentConfiguration({
     throw new Error("Only one action is supported in legacy mode.");
   }
 
-  let legacyForceGenerationAtIteration: number | null = null;
   let legacyForceSingleActionAtIteration: number | null = null;
 
   if (legacySingleActionMode) {
     if (actions.length) {
       legacyForceSingleActionAtIteration = 0;
-      legacyForceGenerationAtIteration = 1;
-    } else {
-      legacyForceGenerationAtIteration = 0;
     }
 
-    // TODO(@fontanierh): fix once generation is an action.
-    maxToolsUsePerRun = actions.length + (generation ? 1 : 0);
+    maxToolsUsePerRun = actions.length;
   } else {
     // Multi actions mode:
     // Enforce that every action has a name and a description and that every name is unique.
@@ -366,17 +358,6 @@ export async function createOrUpgradeAgentConfiguration({
 
   if (agentConfigurationRes.isErr()) {
     return agentConfigurationRes;
-  }
-
-  let generationConfig: AgentGenerationConfigurationType | null = null;
-  if (generation) {
-    generationConfig = await createAgentGenerationConfiguration(auth, {
-      agentConfiguration: agentConfigurationRes.value,
-      name: generation.name ?? null,
-      description: generation.description ?? null,
-      forceUseAtIteration:
-        generation.forceUseAtIteration ?? legacyForceGenerationAtIteration,
-    });
   }
 
   const actionConfigs: AgentActionConfigurationType[] = [];
@@ -468,7 +449,6 @@ export async function createOrUpgradeAgentConfiguration({
   const agentConfiguration: AgentConfigurationType = {
     ...agentConfigurationRes.value,
     actions: actionConfigs,
-    generation: generationConfig,
   };
 
   // We are not tracking draft agents

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -18,7 +18,6 @@ import {
 } from "@app/lib/models/assistant/actions/retrieval";
 import {
   AgentConfiguration,
-  AgentGenerationConfiguration,
   AgentUserRelation,
   GlobalAgentSettings,
 } from "@app/lib/models/assistant/agent";
@@ -255,13 +254,6 @@ export async function deleteAgentsActivity({
       transaction: t,
     });
     for (const agent of agents) {
-      await AgentGenerationConfiguration.destroy({
-        where: {
-          agentConfigurationId: agent.id,
-        },
-        transaction: t,
-      });
-
       const retrievalConfigurations = await AgentRetrievalConfiguration.findAll(
         {
           where: {

--- a/front/scripts/remove_draft_agent_configurations.ts
+++ b/front/scripts/remove_draft_agent_configurations.ts
@@ -10,7 +10,6 @@ import {
 } from "@app/lib/models/assistant/actions/tables_query";
 import {
   AgentConfiguration,
-  AgentGenerationConfiguration,
   AgentUserRelation,
 } from "@app/lib/models/assistant/agent";
 import { Mention } from "@app/lib/models/assistant/conversation";
@@ -126,13 +125,6 @@ async function deleteDraftAgentConfigurationAndRelatedResources(
   if (!execute) {
     return true;
   }
-
-  // First, delete the generation configuration.
-  await AgentGenerationConfiguration.destroy({
-    where: {
-      agentConfigurationId: agent.id,
-    },
-  });
 
   // Delete the retrieval configurations.
   await deleteRetrievalConfigurationForAgent(agent);

--- a/types/src/front/api_handlers/internal/agent_configuration.ts
+++ b/types/src/front/api_handlers/internal/agent_configuration.ts
@@ -153,12 +153,6 @@ const ActionConfigurationSchema = t.intersection([
   t.partial(multiActionsCommonFields),
 ]);
 
-// TODO(@fontanierh): change once generation is an action.
-const GenerationConfigurationSchema = t.union([
-  t.null,
-  t.partial(multiActionsCommonFields),
-]);
-
 const ModelConfigurationSchema = t.intersection([
   t.type({
     modelId: ModelIdCodec,
@@ -197,7 +191,6 @@ export const PostOrPatchAgentConfigurationRequestBodySchema = t.intersection([
           IsSupportedModelSchema,
         ]),
         actions: t.array(ActionConfigurationSchema),
-        generation: GenerationConfigurationSchema,
       }),
       t.partial({
         maxToolsUsePerRun: t.number,

--- a/types/src/front/assistant/agent.ts
+++ b/types/src/front/assistant/agent.ts
@@ -2,11 +2,7 @@ import { DustAppRunConfigurationType } from "../../front/assistant/actions/dust_
 import { ProcessConfigurationType } from "../../front/assistant/actions/process";
 import { RetrievalConfigurationType } from "../../front/assistant/actions/retrieval";
 import { TablesQueryConfigurationType } from "../../front/assistant/actions/tables_query";
-import {
-  ModelIdType,
-  ModelProviderIdType,
-  SupportedModel,
-} from "../../front/lib/assistant";
+import { ModelIdType, ModelProviderIdType } from "../../front/lib/assistant";
 import { ModelId } from "../../shared/model_id";
 
 /**

--- a/types/src/front/assistant/agent.ts
+++ b/types/src/front/assistant/agent.ts
@@ -55,17 +55,6 @@ export type AgentActionSpecification = {
 };
 
 /**
- * Agent Message configuration
- */
-
-export type AgentGenerationConfigurationType = {
-  id: ModelId;
-  name: string | null;
-  description: string | null;
-  forceUseAtIteration: number | null;
-};
-
-/**
  * Agent configuration
  */
 
@@ -194,18 +183,9 @@ export type AgentConfigurationType = LightAgentConfigurationType & {
   // If empty, no actions are performed, otherwise the actions are
   // performed.
   actions: AgentActionConfigurationType[];
-  // If undefined, no text generation.
-  generation: AgentGenerationConfigurationType | null;
 };
 
 export interface TemplateAgentConfigurationType {
-  // If undefined, no text generation.
-  generation: {
-    model: SupportedModel;
-    temperature: number;
-    forceUseAtIteration: number | null;
-  } | null;
-
   name: string;
   pictureUrl: string;
 


### PR DESCRIPTION
## Description

This PR contains:

- The removal of `class AgentGenerationConfiguration` and `type AgentGenerationConfigurationType`.
- Revert to generation not being counted as an action.
- Migration to decrement all `AgentConfiguration.maxToolsUsePerRun` by `1` where `<= 2`
- Decrement of all global agents `maxToolsUsePerRun` by `1`

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- fully deploy front
- run front migration from prodbox.

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
