### PR TITLE
Chore: removing panic flag on webhook processing

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -626,8 +626,6 @@ export async function renewWebhooks(pageSize: number): Promise<number> {
           },
           connectorId: wh.connectorId,
           workspaceId: connector.workspaceId,
-          // we want to panic because this code branch is unexpected.
-          panic: true,
         },
         `We are processing a webhook which have already expired, this should never happen. Investigation needed.`
       );


### PR DESCRIPTION
Description
---
Flag was added by #4983

The monitor is very noisy while not having direct impact on prod (behaviour existed before, but was not logged)

A card has been created to investigate, but the monitor noise is not warranted

Card: https://github.com/dust-tt/tasks/issues/738