### PR TITLE
enh(multi-actions): get generation from `multi-actions-agent`

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -10,7 +10,7 @@ import {
   Spinner,
 } from "@dust-tt/sparkle";
 import type {
-  AgentActionEvent,
+  AgentActionParamsOrOutputEvent,
   AgentActionSuccessEvent,
   AgentActionType,
   AgentErrorEvent,
@@ -128,7 +128,7 @@ export function AgentMessage({
       eventId: string;
       data:
         | AgentErrorEvent
-        | AgentActionEvent
+        | AgentActionParamsOrOutputEvent
         | AgentActionSuccessEvent
         | GenerationTokensEvent
         | AgentGenerationSuccessEvent

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -10,7 +10,7 @@ import {
   Spinner,
 } from "@dust-tt/sparkle";
 import type {
-  AgentActionParamsOrOutputEvent,
+  AgentActionSpecificEvent,
   AgentActionSuccessEvent,
   AgentActionType,
   AgentErrorEvent,
@@ -128,7 +128,7 @@ export function AgentMessage({
       eventId: string;
       data:
         | AgentErrorEvent
-        | AgentActionParamsOrOutputEvent
+        | AgentActionSpecificEvent
         | AgentActionSuccessEvent
         | GenerationTokensEvent
         | AgentGenerationSuccessEvent

--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -105,10 +105,12 @@ export default function ActionsScreen({
     function _updateAction({
       actionName,
       newActionName,
+      newActionDescription,
       getNewActionConfig,
     }: {
       actionName: string;
       newActionName?: string;
+      newActionDescription?: string;
       getNewActionConfig: (
         old: AssistantBuilderActionConfiguration["configuration"]
       ) => AssistantBuilderActionConfiguration["configuration"];
@@ -120,7 +122,7 @@ export default function ActionsScreen({
           action.name === actionName
             ? {
                 name: newActionName ?? action.name,
-                description: action.description,
+                description: newActionDescription ?? action.description,
                 type: action.type,
                 // This is quite unsatisfying, but using `as any` here and repeating every
                 // other key in the object instead of spreading is actually the safest we can do.
@@ -176,6 +178,7 @@ export default function ActionsScreen({
             updateAction({
               actionName: actionToEdit.name,
               newActionName: newAction.name,
+              newActionDescription: newAction.description,
               getNewActionConfig: () => newAction.configuration,
             });
           } else {

--- a/front/components/assistant_builder/server_side_props_helpers.ts
+++ b/front/components/assistant_builder/server_side_props_helpers.ts
@@ -112,6 +112,7 @@ export async function buildInitialActions({
   const builderActions: AssistantBuilderActionConfiguration[] = [];
 
   for (const action of actions) {
+    let builderAction: AssistantBuilderActionConfiguration | null = null;
     if (isRetrievalConfiguration(action)) {
       const isSearch = action.query !== "none";
 
@@ -132,7 +133,7 @@ export async function buildInitialActions({
       retrievalConfiguration.configuration.dataSourceConfigurations =
         await renderDataSourcesConfigurations(action);
 
-      builderActions.push(retrievalConfiguration);
+      builderAction = retrievalConfiguration;
     } else if (isDustAppRunConfiguration(action)) {
       const dustAppConfiguration = getDefaultDustAppRunActionConfiguration();
       for (const app of dustApps) {
@@ -142,7 +143,7 @@ export async function buildInitialActions({
         }
       }
 
-      builderActions.push(dustAppConfiguration);
+      builderAction = dustAppConfiguration;
     } else if (isTablesQueryConfiguration(action)) {
       const tablesQueryConfiguration =
         getDefaultTablesQueryActionConfiguration();
@@ -181,7 +182,7 @@ export async function buildInitialActions({
         {} as AssistantBuilderTablesQueryConfiguration
       );
 
-      builderActions.push(tablesQueryConfiguration);
+      builderAction = tablesQueryConfiguration;
     } else if (isProcessConfiguration(action)) {
       const processConfiguration = getDefaultProcessActionConfiguration();
       if (
@@ -201,10 +202,19 @@ export async function buildInitialActions({
 
       processConfiguration.configuration.schema = action.schema;
 
-      builderActions.push(processConfiguration);
+      builderAction = processConfiguration;
     } else {
       assertNever(action);
     }
+
+    if (action.name) {
+      builderAction.name = action.name;
+    }
+    if (action.description) {
+      builderAction.description = action.description;
+    }
+
+    builderActions.push(builderAction);
   }
 
   return builderActions;

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -176,8 +176,6 @@ export async function* runMultiActionsAgentLoop(
             },
             "[ASSISTANT_TRACE] Action inputs generation"
           );
-          // TODO(@fontanieh): Yield & handle downstream.
-          // yield event;
           const { action, inputs, specification } = event;
           const actionEventStream = runAction(auth, {
             configuration: configuration,

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -1,8 +1,8 @@
 import type {
   AgentActionConfigurationType,
   AgentActionEvent,
-  AgentActionParamsOrOutputEvent,
   AgentActionSpecification,
+  AgentActionSpecificEvent,
   AgentActionSuccessEvent,
   AgentConfigurationType,
   AgentErrorEvent,
@@ -69,7 +69,7 @@ export async function* runAgent(
   agentMessage: AgentMessageType
 ): AsyncGenerator<
   | AgentErrorEvent
-  | AgentActionParamsOrOutputEvent
+  | AgentActionSpecificEvent
   | AgentActionSuccessEvent
   | GenerationTokensEvent
   | AgentGenerationSuccessEvent
@@ -116,7 +116,7 @@ export async function* runMultiActionsAgentLoop(
   agentMessage: AgentMessageType
 ): AsyncGenerator<
   | AgentErrorEvent
-  | AgentActionParamsOrOutputEvent
+  | AgentActionSpecificEvent
   | AgentActionSuccessEvent
   | GenerationTokensEvent
   | AgentGenerationSuccessEvent
@@ -591,7 +591,7 @@ async function* runAction(
     step: number;
   }
 ): AsyncGenerator<
-  AgentActionParamsOrOutputEvent | AgentErrorEvent | AgentActionSuccessEvent,
+  AgentActionSpecificEvent | AgentErrorEvent | AgentActionSuccessEvent,
   void
 > {
   const now = Date.now();

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -347,7 +347,7 @@ export async function getNextAction(
   // not sure if the speicfications.push() is needed here TBD at review time.
 
   const config = cloneBaseConfig(
-    DustProdActionRegistry["assistant-v2-use-tools"].config
+    DustProdActionRegistry["assistant-v2-multi-actions-agent"].config
   );
   config.MODEL.function_call = forcedActionName ?? "auto";
   config.MODEL.provider_id = model.providerId;
@@ -356,7 +356,7 @@ export async function getNextAction(
 
   const res = await runActionStreamed(
     auth,
-    "assistant-v2-use-tools",
+    "assistant-v2-multi-actions-agent",
     config,
     [
       {

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -1118,6 +1118,8 @@ export async function createAgentActionConfiguration(
         appWorkspaceId: action.appWorkspaceId,
         appId: action.appId,
         agentConfigurationId: agentConfiguration.id,
+        name: action.name,
+        description: action.description,
         forceUseAtIteration: action.forceUseAtIteration,
       });
 

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1,4 +1,5 @@
 import type {
+  AgentActionParamsOrOutputEvent,
   AgentMessageNewEvent,
   AgentMessageWithRankType,
   ConversationTitleEvent,
@@ -23,7 +24,6 @@ import type {
 import type { PlanType } from "@dust-tt/types";
 import type { Result } from "@dust-tt/types";
 import type {
-  AgentActionEvent,
   AgentActionSuccessEvent,
   AgentErrorEvent,
   AgentGenerationCancelledEvent,
@@ -563,7 +563,7 @@ export async function* postUserMessage(
   | UserMessageNewEvent
   | AgentMessageNewEvent
   | AgentErrorEvent
-  | AgentActionEvent
+  | AgentActionParamsOrOutputEvent
   | AgentActionSuccessEvent
   | GenerationTokensEvent
   | AgentGenerationSuccessEvent
@@ -947,7 +947,7 @@ export async function* editUserMessage(
   | UserMessageErrorEvent
   | AgentMessageNewEvent
   | AgentErrorEvent
-  | AgentActionEvent
+  | AgentActionParamsOrOutputEvent
   | AgentActionSuccessEvent
   | GenerationTokensEvent
   | AgentGenerationSuccessEvent
@@ -1333,7 +1333,7 @@ export async function* retryAgentMessage(
   | AgentMessageNewEvent
   | AgentErrorEvent
   | AgentMessageErrorEvent
-  | AgentActionEvent
+  | AgentActionParamsOrOutputEvent
   | AgentActionSuccessEvent
   | GenerationTokensEvent
   | AgentGenerationSuccessEvent
@@ -1602,7 +1602,7 @@ async function* streamRunAgentEvents(
   auth: Authenticator,
   eventStream: AsyncGenerator<
     | AgentErrorEvent
-    | AgentActionEvent
+    | AgentActionParamsOrOutputEvent
     | AgentActionSuccessEvent
     | GenerationTokensEvent
     | AgentGenerationSuccessEvent
@@ -1614,7 +1614,7 @@ async function* streamRunAgentEvents(
   agentMessageRow: AgentMessage
 ): AsyncGenerator<
   | AgentErrorEvent
-  | AgentActionEvent
+  | AgentActionParamsOrOutputEvent
   | AgentActionSuccessEvent
   | GenerationTokensEvent
   | AgentGenerationSuccessEvent

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1692,7 +1692,7 @@ async function* streamRunAgentEvents(
 
       default:
         ((event: never) => {
-          logger.error("Unknown `streamRunAgentEvents` event type", event);
+          logger.error({ event }, "Unknown `streamRunAgentEvents` event type");
         })(event);
         return;
     }

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1,5 +1,5 @@
 import type {
-  AgentActionParamsOrOutputEvent,
+  AgentActionSpecificEvent,
   AgentMessageNewEvent,
   AgentMessageWithRankType,
   ConversationTitleEvent,
@@ -563,7 +563,7 @@ export async function* postUserMessage(
   | UserMessageNewEvent
   | AgentMessageNewEvent
   | AgentErrorEvent
-  | AgentActionParamsOrOutputEvent
+  | AgentActionSpecificEvent
   | AgentActionSuccessEvent
   | GenerationTokensEvent
   | AgentGenerationSuccessEvent
@@ -947,7 +947,7 @@ export async function* editUserMessage(
   | UserMessageErrorEvent
   | AgentMessageNewEvent
   | AgentErrorEvent
-  | AgentActionParamsOrOutputEvent
+  | AgentActionSpecificEvent
   | AgentActionSuccessEvent
   | GenerationTokensEvent
   | AgentGenerationSuccessEvent
@@ -1333,7 +1333,7 @@ export async function* retryAgentMessage(
   | AgentMessageNewEvent
   | AgentErrorEvent
   | AgentMessageErrorEvent
-  | AgentActionParamsOrOutputEvent
+  | AgentActionSpecificEvent
   | AgentActionSuccessEvent
   | GenerationTokensEvent
   | AgentGenerationSuccessEvent
@@ -1602,7 +1602,7 @@ async function* streamRunAgentEvents(
   auth: Authenticator,
   eventStream: AsyncGenerator<
     | AgentErrorEvent
-    | AgentActionParamsOrOutputEvent
+    | AgentActionSpecificEvent
     | AgentActionSuccessEvent
     | GenerationTokensEvent
     | AgentGenerationSuccessEvent
@@ -1614,7 +1614,7 @@ async function* streamRunAgentEvents(
   agentMessageRow: AgentMessage
 ): AsyncGenerator<
   | AgentErrorEvent
-  | AgentActionParamsOrOutputEvent
+  | AgentActionSpecificEvent
   | AgentActionSuccessEvent
   | GenerationTokensEvent
   | AgentGenerationSuccessEvent

--- a/front/lib/api/assistant/legacy_agent.ts
+++ b/front/lib/api/assistant/legacy_agent.ts
@@ -1,6 +1,6 @@
 import type {
   AgentActionConfigurationType,
-  AgentActionEvent,
+  AgentActionParamsOrOutputEvent,
   AgentActionSpecification,
   AgentActionSuccessEvent,
   AgentConfigurationType,
@@ -186,7 +186,7 @@ export async function* runLegacyAgent(
   agentMessage: AgentMessageType
 ): AsyncGenerator<
   | AgentErrorEvent
-  | AgentActionEvent
+  | AgentActionParamsOrOutputEvent
   | AgentActionSuccessEvent
   | GenerationTokensEvent
   | AgentGenerationSuccessEvent
@@ -294,9 +294,9 @@ async function* runAction(
     step: number;
   }
 ): AsyncGenerator<
-  | AgentActionEvent
+  | AgentActionParamsOrOutputEvent
   | AgentErrorEvent
-  | AgentActionEvent
+  | AgentActionParamsOrOutputEvent
   | AgentActionSuccessEvent,
   void
 > {

--- a/front/lib/api/assistant/legacy_agent.ts
+++ b/front/lib/api/assistant/legacy_agent.ts
@@ -1,7 +1,7 @@
 import type {
   AgentActionConfigurationType,
-  AgentActionParamsOrOutputEvent,
   AgentActionSpecification,
+  AgentActionSpecificEvent,
   AgentActionSuccessEvent,
   AgentConfigurationType,
   AgentErrorEvent,
@@ -186,7 +186,7 @@ export async function* runLegacyAgent(
   agentMessage: AgentMessageType
 ): AsyncGenerator<
   | AgentErrorEvent
-  | AgentActionParamsOrOutputEvent
+  | AgentActionSpecificEvent
   | AgentActionSuccessEvent
   | GenerationTokensEvent
   | AgentGenerationSuccessEvent
@@ -294,9 +294,9 @@ async function* runAction(
     step: number;
   }
 ): AsyncGenerator<
-  | AgentActionParamsOrOutputEvent
+  | AgentActionSpecificEvent
   | AgentErrorEvent
-  | AgentActionParamsOrOutputEvent
+  | AgentActionSpecificEvent
   | AgentActionSuccessEvent,
   void
 > {

--- a/front/lib/api/assistant/pubsub.ts
+++ b/front/lib/api/assistant/pubsub.ts
@@ -9,7 +9,7 @@ import type {
 } from "@dust-tt/types";
 import type { Result } from "@dust-tt/types";
 import type {
-  AgentActionParamsOrOutputEvent,
+  AgentActionSpecificEvent,
   AgentActionSuccessEvent,
   AgentErrorEvent,
   AgentGenerationCancelledEvent,
@@ -110,7 +110,7 @@ async function handleUserMessageEvents(
     | UserMessageNewEvent
     | AgentMessageNewEvent
     | AgentErrorEvent
-    | AgentActionParamsOrOutputEvent
+    | AgentActionSpecificEvent
     | AgentActionSuccessEvent
     | GenerationTokensEvent
     | AgentGenerationSuccessEvent
@@ -447,7 +447,7 @@ export async function* getMessagesEvents(
     eventId: string;
     data:
       | AgentErrorEvent
-      | AgentActionParamsOrOutputEvent
+      | AgentActionSpecificEvent
       | AgentActionSuccessEvent
       | AgentGenerationCancelledEvent
       | GenerationTokensEvent

--- a/front/lib/api/assistant/pubsub.ts
+++ b/front/lib/api/assistant/pubsub.ts
@@ -9,7 +9,7 @@ import type {
 } from "@dust-tt/types";
 import type { Result } from "@dust-tt/types";
 import type {
-  AgentActionEvent,
+  AgentActionParamsOrOutputEvent,
   AgentActionSuccessEvent,
   AgentErrorEvent,
   AgentGenerationCancelledEvent,
@@ -110,7 +110,7 @@ async function handleUserMessageEvents(
     | UserMessageNewEvent
     | AgentMessageNewEvent
     | AgentErrorEvent
-    | AgentActionEvent
+    | AgentActionParamsOrOutputEvent
     | AgentActionSuccessEvent
     | GenerationTokensEvent
     | AgentGenerationSuccessEvent
@@ -447,7 +447,7 @@ export async function* getMessagesEvents(
     eventId: string;
     data:
       | AgentErrorEvent
-      | AgentActionEvent
+      | AgentActionParamsOrOutputEvent
       | AgentActionSuccessEvent
       | AgentGenerationCancelledEvent
       | GenerationTokensEvent

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -222,19 +222,6 @@ async function handler(
         });
       }
 
-      if (
-        bodyValidation.right.useMultiActions &&
-        bodyValidation.right.assistant.maxToolsUsePerRun === undefined
-      ) {
-        return apiError(req, res, {
-          status_code: 400,
-          api_error: {
-            type: "app_auth_error",
-            message: "maxToolsUsePerRun is required in multi-actions mode.",
-          },
-        });
-      }
-
       const agentConfigurationRes = await createOrUpgradeAgentConfiguration({
         auth,
         assistant: bodyValidation.right.assistant,

--- a/types/src/front/lib/actions/registry.ts
+++ b/types/src/front/lib/actions/registry.ts
@@ -228,7 +228,7 @@ export const DustProdActionRegistry = createActionRegistry({
       workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
       appId: "0e9889c787",
       appHash:
-        "388a8ab72120c22d0865fd6fbbaf060b0034f30473c57d2eccb6d866d8297f88",
+        "462208d60164d9bfad1ab9e1e7f78df902486f36878bb786bcb66433ca78b4c1",
     },
     config: {
       MODEL: {

--- a/types/src/front/lib/actions/registry.ts
+++ b/types/src/front/lib/actions/registry.ts
@@ -223,7 +223,7 @@ export const DustProdActionRegistry = createActionRegistry({
       },
     },
   },
-  "assistant-v2-use-tools": {
+  "assistant-v2-multi-actions-agent": {
     app: {
       workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
       appId: "0e9889c787",

--- a/types/src/front/lib/actions/registry.ts
+++ b/types/src/front/lib/actions/registry.ts
@@ -236,6 +236,7 @@ export const DustProdActionRegistry = createActionRegistry({
         model_id: GPT_4_TURBO_MODEL_CONFIG.modelId,
         function_call: "auto",
         use_cache: false,
+        use_stream: true,
       },
     },
   },

--- a/types/src/front/lib/api/assistant/agent.ts
+++ b/types/src/front/lib/api/assistant/agent.ts
@@ -45,7 +45,7 @@ export type AgentErrorEvent = {
 };
 
 // Event sent during the execution of an action. These are action specific.
-export type AgentActionEvent =
+export type AgentActionParamsOrOutputEvent =
   | RetrievalParamsEvent
   | DustAppRunParamsEvent
   | DustAppRunBlockEvent
@@ -88,8 +88,8 @@ export type AgentMessageSuccessEvent = {
   message: AgentMessageType;
 };
 
-export type AgentUseToolEvent = {
-  type: "agent_use_tool";
+export type AgentActionEvent = {
+  type: "agent_action";
   created: number;
   action: AgentActionConfigurationType;
   inputs: Record<string, string | boolean | number>;

--- a/types/src/front/lib/api/assistant/agent.ts
+++ b/types/src/front/lib/api/assistant/agent.ts
@@ -15,6 +15,10 @@ import {
   TablesQueryOutputEvent,
   TablesQueryParamsEvent,
 } from "../../../../front/lib/api/assistant/actions/tables_query";
+import {
+  AgentActionConfigurationType,
+  AgentActionSpecification,
+} from "../../../assistant/agent";
 import { ProcessParamsEvent } from "./actions/process";
 
 // Event sent when an agent error occured before we have a agent message in the database.
@@ -82,4 +86,12 @@ export type AgentMessageSuccessEvent = {
   configurationId: string;
   messageId: string;
   message: AgentMessageType;
+};
+
+export type AgentUseToolEvent = {
+  type: "agent_use_tool";
+  created: number;
+  action: AgentActionConfigurationType;
+  inputs: Record<string, string | boolean | number>;
+  specification: AgentActionSpecification | null;
 };

--- a/types/src/front/lib/api/assistant/agent.ts
+++ b/types/src/front/lib/api/assistant/agent.ts
@@ -45,7 +45,7 @@ export type AgentErrorEvent = {
 };
 
 // Event sent during the execution of an action. These are action specific.
-export type AgentActionParamsOrOutputEvent =
+export type AgentActionSpecificEvent =
   | RetrievalParamsEvent
   | DustAppRunParamsEvent
   | DustAppRunBlockEvent


### PR DESCRIPTION
## Description

fixes https://github.com/dust-tt/dust/issues/5006

- rename `use-tools` into `multi-actions-agent`
- fixes a few multi-actions bugs- uses `use`
- use the generation from `mulit-actions-agent` 
- implement streaming the generation from the `multi-actions-agent` action

## Risk

Shouldn't affect single-action agents 

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
