### PR TITLE
Multi files upload on the InputBar

### DIFF
--- a/front/components/assistant/TryAssistant.tsx
+++ b/front/components/assistant/TryAssistant.tsx
@@ -280,16 +280,17 @@ export function useTryAssistantCore({
   const handleSubmit = async (
     input: string,
     mentions: MentionType[],
-    contentFragment?: {
+    contentFragments: {
       title: string;
       content: string;
       file: File;
-    }
+      contentType: string;
+    }[]
   ) => {
     if (!user) {
       return;
     }
-    const messageData = { input, mentions, contentFragment };
+    const messageData = { input, mentions, contentFragments };
     if (!conversation) {
       const result = await createConversationWithMessage({
         owner,

--- a/front/components/assistant/TryAssistant.tsx
+++ b/front/components/assistant/TryAssistant.tsx
@@ -16,6 +16,7 @@ import {
   AssistantInputBar,
   FixedAssistantInputBar,
 } from "@app/components/assistant/conversation/input_bar/InputBar";
+import type { ContentFragmentInput } from "@app/components/assistant/conversation/lib";
 import {
   CONVERSATION_PARENT_SCROLL_DIV_ID as CONVERSATION_PARENT_SCROLL_DIV_ID,
   createConversationWithMessage,
@@ -280,11 +281,7 @@ export function useTryAssistantCore({
   const handleSubmit = async (
     input: string,
     mentions: MentionType[],
-    contentFragments: {
-      title: string;
-      content: string;
-      file: File;
-    }[]
+    contentFragments: ContentFragmentInput[]
   ) => {
     if (!user) {
       return;

--- a/front/components/assistant/TryAssistant.tsx
+++ b/front/components/assistant/TryAssistant.tsx
@@ -284,7 +284,6 @@ export function useTryAssistantCore({
       title: string;
       content: string;
       file: File;
-      contentType: string;
     }[]
   ) => {
     if (!user) {

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -341,15 +341,6 @@ export default function ConversationViewer({
   });
   const eventIds = useRef<string[]>([]);
 
-  if (isConversationLoading) {
-    return null;
-  } else if (isConversationError) {
-    return <div>Error loading conversation</div>;
-  }
-  if (!conversation) {
-    return <div>No conversation here</div>;
-  }
-
   // Building an array of arrays of messages grouped by message.type.
   // Eg: [[content_fragment, content_fragment], [user_message], [agent_message, agent_message]]
   // This allows us to change the layout per consecutive messages of the same type.
@@ -370,6 +361,15 @@ export default function ConversationViewer({
     }
     return groups;
   }, [messages]);
+
+  if (isConversationLoading) {
+    return null;
+  } else if (isConversationError) {
+    return <div>Error loading conversation</div>;
+  }
+  if (!conversation) {
+    return <div>No conversation here</div>;
+  }
 
   return (
     <div className={classNames("pb-44", isFading ? "animate-fadeout" : "")}>
@@ -395,10 +395,9 @@ export default function ConversationViewer({
           >
             {/* Second div is used to apply a max-width and change the flex direction of the content fragment group. */}
             <div
-              key={group[0].sId}
               className={
                 group[0].type === "content_fragment"
-                  ? "mx-auto flex max-w-4xl flex-row"
+                  ? "mx-auto flex max-w-4xl flex-row flex-wrap"
                   : ""
               }
             >

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -353,20 +353,23 @@ export default function ConversationViewer({
   // Building an array of arrays of messages grouped by message.type.
   // Eg: [[content_fragment, content_fragment], [user_message], [agent_message, agent_message]]
   // This allows us to change the layout per consecutive messages of the same type.
-  const groupedMessages: MessageWithRankType[][] = [];
-  for (const message of messages.flatMap((page) => page.messages)) {
-    if (groupedMessages.length === 0) {
-      groupedMessages.push([message]);
-    } else {
-      const lastGroup = groupedMessages[groupedMessages.length - 1];
-      const lastMessage = lastGroup[lastGroup.length - 1];
-      if (lastMessage.type === message.type) {
-        lastGroup.push(message);
+  const groupedMessages: MessageWithRankType[][] = useMemo(() => {
+    const groups: MessageWithRankType[][] = [];
+    for (const message of messages.flatMap((page) => page.messages)) {
+      if (groups.length === 0) {
+        groups.push([message]);
       } else {
-        groupedMessages.push([message]);
+        const lastGroup = groups[groups.length - 1];
+        const lastMessage = lastGroup[lastGroup.length - 1];
+        if (lastMessage.type === message.type) {
+          lastGroup.push(message);
+        } else {
+          groups.push([message]);
+        }
       }
     }
-  }
+    return groups;
+  }, [messages]);
 
   return (
     <div className={classNames("pb-44", isFading ? "animate-fadeout" : "")}>

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -88,7 +88,7 @@ const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
         return (
           <div
             key={`message-id-${sId}`}
-            className="items-center bg-structure-50 px-2 pt-8"
+            className="items-center pt-8"
             ref={ref}
           >
             <div className="mx-auto flex max-w-4xl flex-col gap-4">

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -2,7 +2,6 @@ import { Button, Citation, StopIcon } from "@dust-tt/sparkle";
 import type { WorkspaceType } from "@dust-tt/types";
 import type { LightAgentConfigurationType } from "@dust-tt/types";
 import type { AgentMention, MentionType } from "@dust-tt/types";
-import { set } from "lodash";
 import {
   useCallback,
   useContext,

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -65,7 +65,6 @@ export function AssistantInputBar({
       title: string;
       content: string;
       file: File;
-      contentType: string;
     }[]
   ) => void;
   conversationId: string | null;
@@ -157,7 +156,6 @@ export function AssistantInputBar({
           title: cf.title,
           content: cf.content,
           file: cf.file,
-          contentType: "file_attachment",
         };
       })
     );
@@ -168,6 +166,7 @@ export function AssistantInputBar({
   const onInputFileChange: InputBarContainerProps["onInputFileChange"] =
     useCallback(
       async (event) => {
+        let totalSize = 0;
         for (const file of (event?.target as HTMLInputElement)?.files || []) {
           if (!file) {
             return;
@@ -199,11 +198,12 @@ export function AssistantInputBar({
               type: "error",
               title: "File too large.",
               description:
-                "The extracted text from your PDF has more than 500,000 characters. This will overflow the assistant context. Please consider uploading a smaller file.",
+                "The extracted text from your file has more than 500,000 characters. This will overflow the assistant context. Please consider uploading a smaller file.",
             });
             return;
           }
           setContentFragmentData((prev) => {
+            totalSize += res.value.content.length;
             return prev.concat([
               {
                 title: res.value.title,
@@ -211,6 +211,15 @@ export function AssistantInputBar({
                 file,
               },
             ]);
+          });
+        }
+        // now we check for the total size of the content fragments
+        if (totalSize > 500_000) {
+          sendNotification({
+            type: "error",
+            title: "Files too large.",
+            description:
+              "The combined extracted text from the files you selected results in more than 500,000 characters. This will overflow the assistant context. Please consider uploading a smaller file.",
           });
         }
       },
@@ -349,7 +358,6 @@ export function FixedAssistantInputBar({
       title: string;
       content: string;
       file: File;
-      contentType: string;
     }[]
   ) => void;
   stickyMentions?: AgentMention[];

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -202,8 +202,8 @@ export function AssistantInputBar({
             });
             return;
           }
+          totalSize += res.value.content.length;
           setContentFragmentData((prev) => {
-            totalSize += res.value.content.length;
             return prev.concat([
               {
                 title: res.value.title,
@@ -304,9 +304,9 @@ export function AssistantInputBar({
               isAnimating ? "animate-shake" : ""
             )}
           >
-            <div className="relative flex w-full flex-1 flex-col">
+            <div className="relative flex w-full flex-1 flex-col ">
               {contentFragmentData.length > 0 && (
-                <div className="mr-4 flex gap-2 border-b border-structure-300/50 pb-3 pt-4">
+                <div className="mr-4 flex gap-2 overflow-auto border-b border-structure-300/50 pb-3 pt-4">
                   {contentFragmentData.map((cf, i) => (
                     <Citation
                       key={`cf-${i}`}
@@ -314,7 +314,9 @@ export function AssistantInputBar({
                       size="xs"
                       description={cf.content?.substring(0, 100)}
                       onClose={() => {
-                        setContentFragmentData([]);
+                        setContentFragmentData((prev) => {
+                          return prev.filter((_, index) => index !== i);
+                        });
                       }}
                     />
                   ))}
@@ -331,7 +333,7 @@ export function AssistantInputBar({
                 onEnterKeyDown={handleSubmit}
                 stickyMentions={stickyMentions}
                 onInputFileChange={onInputFileChange}
-                disableAttachment={contentFragmentData.length > 0}
+                disableAttachment={false}
               />
             </div>
           </div>

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -5,7 +5,6 @@ import {
   FullscreenExitIcon,
   FullscreenIcon,
   IconButton,
-  Spinner2,
 } from "@dust-tt/sparkle";
 import type {
   AgentMention,
@@ -50,7 +49,6 @@ const InputBarContainer = ({
 }: InputBarContainerProps) => {
   const suggestions = useAssistantSuggestions(agentConfigurations, owner);
 
-  const [isSubmitting, setIsSubmitting] = useState(false);
   const [isExpanded, setIsExpanded] = useState(false);
   function handleExpansionToggle() {
     setIsExpanded((currentExpanded) => !currentExpanded);
@@ -161,7 +159,6 @@ const InputBarContainer = ({
             </>
           )}
         </div>
-        {isSubmitting && <Spinner2 size="xxl" />}
         <Button
           size="sm"
           icon={ArrowUpIcon}
@@ -170,12 +167,10 @@ const InputBarContainer = ({
           labelVisible={false}
           disabledTooltip
           onClick={async () => {
-            setIsSubmitting(true);
             const jsonContent = editorService.getTextAndMentions();
             onEnterKeyDown(editorService.isEmpty(), jsonContent, () => {
               editorService.clearEditor();
               resetEditorContainerSize();
-              setIsSubmitting(false);
             });
           }}
         />

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -25,7 +25,6 @@ import { classNames } from "@app/lib/utils";
 export interface InputBarContainerProps {
   allAssistants: LightAgentConfigurationType[];
   agentConfigurations: LightAgentConfigurationType[];
-  disableAttachment: boolean;
   onEnterKeyDown: CustomEditorProps["onEnterKeyDown"];
   onInputFileChange: (e: React.ChangeEvent) => Promise<void>;
   owner: WorkspaceType;
@@ -33,12 +32,12 @@ export interface InputBarContainerProps {
   stickyMentions: AgentMention[] | undefined;
   hideQuickActions: boolean;
   disableAutoFocus: boolean;
+  disableSendButton: boolean;
 }
 
 const InputBarContainer = ({
   allAssistants,
   agentConfigurations,
-  disableAttachment,
   onEnterKeyDown,
   onInputFileChange,
   owner,
@@ -46,6 +45,7 @@ const InputBarContainer = ({
   stickyMentions,
   hideQuickActions,
   disableAutoFocus,
+  disableSendButton,
 }: InputBarContainerProps) => {
   const suggestions = useAssistantSuggestions(agentConfigurations, owner);
 
@@ -128,7 +128,6 @@ const InputBarContainer = ({
             variant={"tertiary"}
             icon={AttachmentIcon}
             size="sm"
-            disabled={disableAttachment}
             tooltip="Add a document to the conversation (only .txt, .pdf, .md, .csv)."
             tooltipPosition="above"
             className="flex"
@@ -163,7 +162,7 @@ const InputBarContainer = ({
           size="sm"
           icon={ArrowUpIcon}
           label="Send"
-          disabled={editorService.isEmpty()}
+          disabled={editorService.isEmpty() || disableSendButton}
           labelVisible={false}
           disabledTooltip
           onClick={async () => {

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -5,6 +5,7 @@ import {
   FullscreenExitIcon,
   FullscreenIcon,
   IconButton,
+  Spinner2,
 } from "@dust-tt/sparkle";
 import type {
   AgentMention,
@@ -49,6 +50,7 @@ const InputBarContainer = ({
 }: InputBarContainerProps) => {
   const suggestions = useAssistantSuggestions(agentConfigurations, owner);
 
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const [isExpanded, setIsExpanded] = useState(false);
   function handleExpansionToggle() {
     setIsExpanded((currentExpanded) => !currentExpanded);
@@ -122,6 +124,7 @@ const InputBarContainer = ({
             ref={fileInputRef}
             style={{ display: "none" }}
             type="file"
+            multiple={true}
           />
           <IconButton
             variant={"tertiary"}
@@ -158,6 +161,7 @@ const InputBarContainer = ({
             </>
           )}
         </div>
+        {isSubmitting && <Spinner2 size="xxl" />}
         <Button
           size="sm"
           icon={ArrowUpIcon}
@@ -166,10 +170,12 @@ const InputBarContainer = ({
           labelVisible={false}
           disabledTooltip
           onClick={async () => {
+            setIsSubmitting(true);
             const jsonContent = editorService.getTextAndMentions();
             onEnterKeyDown(editorService.isEmpty(), jsonContent, () => {
               editorService.clearEditor();
               resetEditorContainerSize();
+              setIsSubmitting(false);
             });
           }}
         />

--- a/front/components/assistant/conversation/lib.ts
+++ b/front/components/assistant/conversation/lib.ts
@@ -33,6 +33,12 @@ export type ConversationErrorType = {
   message: string;
 };
 
+export type ContentFragmentInput = {
+  title: string;
+  content: string;
+  file: File;
+};
+
 export function createPlaceholderUserMessage({
   input,
   mentions,
@@ -80,11 +86,7 @@ export async function submitMessage({
   messageData: {
     input: string;
     mentions: MentionType[];
-    contentFragments: {
-      title: string;
-      content: string;
-      file: File;
-    }[];
+    contentFragments: ContentFragmentInput[];
   };
 }): Promise<
   Result<{ message: UserMessageWithRankType }, ConversationErrorType>
@@ -211,11 +213,7 @@ export async function createConversationWithMessage({
   messageData: {
     input: string;
     mentions: MentionType[];
-    contentFragments: {
-      title: string;
-      content: string;
-      file: File;
-    }[];
+    contentFragments: ContentFragmentInput[];
   };
   visibility?: ConversationVisibility;
   title?: string;

--- a/front/components/assistant/conversation/lib.ts
+++ b/front/components/assistant/conversation/lib.ts
@@ -215,7 +215,6 @@ export async function createConversationWithMessage({
       title: string;
       content: string;
       file: File;
-      contentType: string;
     }[];
   };
   visibility?: ConversationVisibility;

--- a/front/components/assistant/conversation/lib.ts
+++ b/front/components/assistant/conversation/lib.ts
@@ -234,16 +234,15 @@ export async function createConversationWithMessage({
       },
       mentions,
     },
-    contentFragments:
-      contentFragments?.map((cf) => ({
-        content: cf.content,
-        title: cf.title,
-        url: null, // sourceUrl will be set on raw content upload success
-        contentType: "file_attachment",
-        context: {
-          profilePictureUrl: user.image,
-        },
-      })) || [],
+    contentFragments: contentFragments.map((cf) => ({
+      content: cf.content,
+      title: cf.title,
+      url: null, // sourceUrl will be set on raw content upload success
+      contentType: "file_attachment",
+      context: {
+        profilePictureUrl: user.image,
+      },
+    })),
   };
 
   // Create new conversation and post the initial message at the same time.
@@ -270,15 +269,13 @@ export async function createConversationWithMessage({
   const conversationData = (await cRes.json()) as PostConversationsResponseBody;
 
   if (conversationData.contentFragments.length > 0) {
-    let i = 0;
-    for (const cf of conversationData.contentFragments) {
+    for (const [i, cf] of conversationData.contentFragments.entries()) {
       uploadRawContentFragment({
         workspaceId: owner.sId,
         conversationId: conversationData.conversation.sId,
         contentFragmentId: cf.sId,
         file: contentFragments[i].file,
       });
-      i++;
     }
   }
 

--- a/front/pages/api/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/index.ts
@@ -18,7 +18,6 @@ import {
 } from "@app/lib/api/assistant/conversation";
 import { postUserMessageWithPubSub } from "@app/lib/api/assistant/pubsub";
 import { Authenticator, getSession } from "@app/lib/auth";
-import logger from "@app/logger/logger";
 import { apiError, withLogging } from "@app/logger/withlogging";
 
 export type GetConversationsResponseBody = {
@@ -122,8 +121,6 @@ async function handler(
       let newMessage: UserMessageType | null = null;
 
       if (contentFragments.length > 0) {
-        const start = new Date();
-        // for (const contentFragment of contentFragments) {
         newContentFragments = await Promise.all(
           contentFragments.map((contentFragment) => {
             return postNewContentFragment(auth, {
@@ -141,11 +138,6 @@ async function handler(
             });
           })
         );
-        logger.info(
-          { durationMs: new Date().getTime() - start.getTime() },
-          "Time to post content fragments:"
-        );
-        // }
 
         const updatedConversation = await getConversation(
           auth,

--- a/front/pages/w/[wId]/assistant/[cId]/index.tsx
+++ b/front/pages/w/[wId]/assistant/[cId]/index.tsx
@@ -119,13 +119,13 @@ export default function AssistantConversation({
   const handleSubmit = async (
     input: string,
     mentions: MentionType[],
-    contentFragment?: {
+    contentFragments: {
       title: string;
       content: string;
       file: File;
-    }
+    }[]
   ) => {
-    const messageData = { input, mentions, contentFragment };
+    const messageData = { input, mentions, contentFragments };
 
     try {
       // Update the local state immediately and fire the

--- a/front/pages/w/[wId]/assistant/[cId]/index.tsx
+++ b/front/pages/w/[wId]/assistant/[cId]/index.tsx
@@ -15,6 +15,7 @@ import type { ConversationLayoutProps } from "@app/components/assistant/conversa
 import ConversationLayout from "@app/components/assistant/conversation/ConversationLayout";
 import ConversationViewer from "@app/components/assistant/conversation/ConversationViewer";
 import { FixedAssistantInputBar } from "@app/components/assistant/conversation/input_bar/InputBar";
+import type { ContentFragmentInput } from "@app/components/assistant/conversation/lib";
 import {
   createPlaceholderUserMessage,
   submitMessage,
@@ -119,11 +120,7 @@ export default function AssistantConversation({
   const handleSubmit = async (
     input: string,
     mentions: MentionType[],
-    contentFragments: {
-      title: string;
-      content: string;
-      file: File;
-    }[]
+    contentFragments: ContentFragmentInput[]
   ) => {
     const messageData = { input, mentions, contentFragments };
 

--- a/front/pages/w/[wId]/assistant/new.tsx
+++ b/front/pages/w/[wId]/assistant/new.tsx
@@ -8,7 +8,6 @@ import {
   Page,
   QuestionMarkCircleIcon,
   RobotSharedIcon,
-  Spinner2,
 } from "@dust-tt/sparkle";
 import type {
   ConversationType,
@@ -91,9 +90,6 @@ export default function AssistantNew({
   const [conversationHelperModal, setConversationHelperModal] =
     useState<ConversationType | null>(null);
 
-  const [isCreatingConversation, setIsCreatingConversation] =
-    useState<boolean>(true);
-
   // No limit on global assistants call as they include both active and inactive.
   const globalAgentConfigurations = useAgentConfigurations({
     workspaceId: owner.sId,
@@ -148,7 +144,6 @@ export default function AssistantNew({
           contentType: string;
         }[]
       ) => {
-        setIsCreatingConversation(true);
         const conversationRes = await createConversationWithMessage({
           owner,
           user,
@@ -158,7 +153,6 @@ export default function AssistantNew({
             contentFragments,
           },
         });
-        setIsCreatingConversation(false);
         if (conversationRes.isErr()) {
           if (conversationRes.error.type === "plan_limit_reached_error") {
             setPlanLimitReached(true);
@@ -253,7 +247,6 @@ export default function AssistantNew({
         />
       )}
       <div className="flex h-full items-center pb-20">
-        {isCreatingConversation && <Spinner2 size="xxl" />}
         <div className="flex text-sm font-normal text-element-800">
           <Page.Vertical gap="md" align="left">
             {/* FEATURED AGENTS */}

--- a/front/pages/w/[wId]/assistant/new.tsx
+++ b/front/pages/w/[wId]/assistant/new.tsx
@@ -8,6 +8,7 @@ import {
   Page,
   QuestionMarkCircleIcon,
   RobotSharedIcon,
+  Spinner2,
 } from "@dust-tt/sparkle";
 import type {
   ConversationType,
@@ -90,6 +91,9 @@ export default function AssistantNew({
   const [conversationHelperModal, setConversationHelperModal] =
     useState<ConversationType | null>(null);
 
+  const [isCreatingConversation, setIsCreatingConversation] =
+    useState<boolean>(true);
+
   // No limit on global assistants call as they include both active and inactive.
   const globalAgentConfigurations = useAgentConfigurations({
     workspaceId: owner.sId,
@@ -137,21 +141,24 @@ export default function AssistantNew({
       async (
         input: string,
         mentions: MentionType[],
-        contentFragment?: {
+        contentFragments: {
           title: string;
           content: string;
           file: File;
-        }
+          contentType: string;
+        }[]
       ) => {
+        setIsCreatingConversation(true);
         const conversationRes = await createConversationWithMessage({
           owner,
           user,
           messageData: {
             input,
             mentions,
-            contentFragment,
+            contentFragments,
           },
         });
+        setIsCreatingConversation(false);
         if (conversationRes.isErr()) {
           if (conversationRes.error.type === "plan_limit_reached_error") {
             setPlanLimitReached(true);
@@ -182,6 +189,7 @@ export default function AssistantNew({
         messageData: {
           input: content.replace("@help", ":mention[help]{sId=helper}"),
           mentions: [{ configurationId: "helper" }],
+          contentFragments: [],
         },
         visibility: "test",
       });
@@ -245,6 +253,7 @@ export default function AssistantNew({
         />
       )}
       <div className="flex h-full items-center pb-20">
+        {isCreatingConversation && <Spinner2 size="xxl" />}
         <div className="flex text-sm font-normal text-element-800">
           <Page.Vertical gap="md" align="left">
             {/* FEATURED AGENTS */}

--- a/front/pages/w/[wId]/assistant/new.tsx
+++ b/front/pages/w/[wId]/assistant/new.tsx
@@ -26,6 +26,7 @@ import type { ConversationLayoutProps } from "@app/components/assistant/conversa
 import ConversationLayout from "@app/components/assistant/conversation/ConversationLayout";
 import { FixedAssistantInputBar } from "@app/components/assistant/conversation/input_bar/InputBar";
 import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
+import type { ContentFragmentInput } from "@app/components/assistant/conversation/lib";
 import { createConversationWithMessage } from "@app/components/assistant/conversation/lib";
 import { TryAssistantModal } from "@app/components/assistant/TryAssistant";
 import { QuickStartGuide } from "@app/components/quick_start_guide";
@@ -137,11 +138,7 @@ export default function AssistantNew({
       async (
         input: string,
         mentions: MentionType[],
-        contentFragments: {
-          title: string;
-          content: string;
-          file: File;
-        }[]
+        contentFragments: ContentFragmentInput[]
       ) => {
         const conversationRes = await createConversationWithMessage({
           owner,

--- a/front/pages/w/[wId]/assistant/new.tsx
+++ b/front/pages/w/[wId]/assistant/new.tsx
@@ -141,7 +141,6 @@ export default function AssistantNew({
           title: string;
           content: string;
           file: File;
-          contentType: string;
         }[]
       ) => {
         const conversationRes = await createConversationWithMessage({

--- a/types/src/front/api_handlers/internal/assistant.ts
+++ b/types/src/front/api_handlers/internal/assistant.ts
@@ -31,10 +31,7 @@ export const InternalPostConversationsRequestBodySchema = t.type({
     t.literal("test"),
   ]),
   message: t.union([InternalPostMessagesRequestBodySchema, t.null]),
-  contentFragment: t.union([
-    InternalPostContentFragmentRequestBodySchema,
-    t.undefined,
-  ]),
+  contentFragments: t.array(InternalPostContentFragmentRequestBodySchema),
 });
 
 export const InternalPostBuilderSuggestionsRequestBodySchema = t.union([


### PR DESCRIPTION
## Description
Task is here: https://github.com/dust-tt/tasks/issues/684

This is an eng runner task so I am keeping the scope of this task as simple as possible.

The goal is to keep the same content fragment upload experience as we have today but allow for multiple files.
Error handling is managed the same way we are managing it today with one file, and we avoid adding a loader by uploading files extracted content in parallel to GCS, which barely added a few milliseconds when testing on front-edge.

We also change the UI of content fragments to display them on the same line when multiples files are uploaded at once.


# Screenshots
![Screenshot 2024-05-13 at 18 08 13](https://github.com/dust-tt/dust/assets/358965/475e76a9-c17a-4f38-a0b9-146db2e78235)
![Screenshot 2024-05-13 at 18 09 01](https://github.com/dust-tt/dust/assets/358965/43276416-5fe0-48c0-aef0-e4408b912c54)





<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
