### PR TITLE
Flav/core function calls history

### DIFF
--- a/core/src/blocks/chat.rs
+++ b/core/src/blocks/chat.rs
@@ -377,15 +377,11 @@ impl Block for Chat {
                                                 Some(Value::String(n)),
                                                 Some(Value::String(a)),
                                                 Some(Value::String(id)),
-                                            ) => {
-                                                let t = ChatFunctionCall {
-                                                    id: id.clone(),
-                                                    name: n.clone(),
-                                                    arguments: a.clone(),
-                                                };
-
-                                                Ok(t)
-                                            }
+                                            ) => Ok(ChatFunctionCall {
+                                                id: id.clone(),
+                                                name: n.clone(),
+                                                arguments: a.clone(),
+                                            }),
                                             _ => Err(anyhow!(MESSAGES_CODE_OUTPUT)),
                                         }
                                     })

--- a/core/src/blocks/chat.rs
+++ b/core/src/blocks/chat.rs
@@ -6,7 +6,6 @@ use crate::providers::llm::{
     ChatFunction, ChatFunctionCall, ChatMessage, ChatMessageRole, LLMChatRequest,
 };
 use crate::providers::provider::ProviderID;
-use crate::utils::new_id;
 use crate::Rule;
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
@@ -315,15 +314,26 @@ impl Block for Chat {
 
         const MESSAGES_CODE_OUTPUT: &str = "Invalid messages code output, \
             expecting an array of objects with  fields `role`, possibly `name`, \
-            and `content` or `function_call`.";
+            and `content` or `function_call(s)`.";
+
+        println!("MESSAGES_VALUE: {:?}", messages_value);
 
         let mut messages = match messages_value {
             Value::Array(a) => a
                 .into_iter()
                 .map(|v| match v {
                     Value::Object(o) => {
-                        match (o.get("role"), o.get("content"), o.get("function_call")) {
-                            (Some(Value::String(r)), Some(Value::String(c)), None) => {
+                        println!("COUCOU (1)!");
+
+                        match (
+                            o.get("role"),
+                            o.get("content"),
+                            o.get("function_call"),
+                            o.get("function_calls"),
+                        ) {
+                            (Some(Value::String(r)), Some(Value::String(c)), None, None) => {
+                                println!("O: {:?}", o);
+
                                 Ok(ChatMessage {
                                     role: ChatMessageRole::from_str(r)?,
                                     name: match o.get("name") {
@@ -333,36 +343,82 @@ impl Block for Chat {
                                     content: Some(c.clone()),
                                     function_call: None,
                                     function_calls: None,
+                                    function_call_id: match o.get("function_call_id") {
+                                        Some(Value::String(fcid)) => Some(fcid.to_string()),
+                                        _ => None,
+                                    },
                                 })
                             }
-                            (Some(Value::String(r)), None, Some(Value::Object(fc))) => {
+                            (Some(Value::String(r)), None, Some(Value::Object(fc)), None) => {
                                 // parse function call into ChatFunctionCall
-                                match (fc.get("name"), fc.get("arguments")) {
-                                    (Some(Value::String(n)), Some(Value::String(a))) => {
-                                        Ok(ChatMessage {
-                                            role: ChatMessageRole::from_str(r)?,
-                                            name: match o.get("name") {
-                                                Some(Value::String(n)) => Some(n.clone()),
-                                                _ => None,
-                                            },
-                                            content: None,
-                                            function_call: Some(ChatFunctionCall {
-                                                // TODO: (2024-04-29 flav) Support id in input.
-                                                id: format!("fc_{}", new_id()),
-                                                name: n.clone(),
-                                                arguments: a.clone(),
-                                            }),
-                                            // TODO: (2024-04-29 flav) Support function_calls in input.
-                                            function_calls: Some(vec![]),
-                                        })
-                                    }
+                                match (fc.get("name"), fc.get("arguments"), fc.get("id")) {
+                                    (
+                                        Some(Value::String(n)),
+                                        Some(Value::String(a)),
+                                        Some(Value::String(id)),
+                                    ) => Ok(ChatMessage {
+                                        role: ChatMessageRole::from_str(r)?,
+                                        name: match o.get("name") {
+                                            Some(Value::String(n)) => Some(n.clone()),
+                                            _ => None,
+                                        },
+                                        content: None,
+                                        function_call: Some(ChatFunctionCall {
+                                            id: id.clone(),
+                                            name: n.clone(),
+                                            arguments: a.clone(),
+                                        }),
+                                        function_calls: None,
+                                        function_call_id: None,
+                                    }),
                                     _ => Err(anyhow!(MESSAGES_CODE_OUTPUT)),
                                 }
                             }
-                            _ => Err(anyhow!(MESSAGES_CODE_OUTPUT)),
+                            (Some(Value::String(r)), None, None, Some(Value::Array(fcs))) => {
+                                let function_calls = fcs
+                                    .into_iter()
+                                    .map(|fc| {
+                                        match (fc.get("name"), fc.get("arguments"), fc.get("id")) {
+                                            (
+                                                Some(Value::String(n)),
+                                                Some(Value::String(a)),
+                                                Some(Value::String(id)),
+                                            ) => {
+                                                let t = ChatFunctionCall {
+                                                    id: id.clone(),
+                                                    name: n.clone(),
+                                                    arguments: a.clone(),
+                                                };
+
+                                                Ok(t)
+                                            }
+                                            err => {
+                                                println!("Got error: {:?}:", err);
+                                                Err(anyhow!(MESSAGES_CODE_OUTPUT))
+                                            }
+                                        }
+                                    })
+                                    .collect::<Result<Vec<_>, _>>()?;
+
+                                Ok(ChatMessage {
+                                    role: ChatMessageRole::from_str(r)?,
+                                    name: None,
+                                    content: None,
+                                    function_call: None,
+                                    function_calls: Some(function_calls),
+                                    function_call_id: None,
+                                })
+                            }
+                            err => {
+                                println!("COUCOU (3): {:?}", err);
+                                Err(anyhow!(MESSAGES_CODE_OUTPUT))
+                            }
                         }
                     }
-                    _ => Err(anyhow!(MESSAGES_CODE_OUTPUT)),
+                    err => {
+                        println!("COUCOU (4): {:?}", err);
+                        Err(anyhow!(MESSAGES_CODE_OUTPUT))
+                    }
                 })
                 .collect::<Result<Vec<ChatMessage>>>()?,
             _ => Err(anyhow!(MESSAGES_CODE_OUTPUT))?,
@@ -450,6 +506,7 @@ impl Block for Chat {
                     content: Some(i),
                     function_call: None,
                     function_calls: None,
+                    function_call_id: None,
                 },
             );
         }

--- a/core/src/blocks/chat.rs
+++ b/core/src/blocks/chat.rs
@@ -316,15 +316,11 @@ impl Block for Chat {
             expecting an array of objects with  fields `role`, possibly `name`, \
             and `content` or `function_call(s)`.";
 
-        println!("MESSAGES_VALUE: {:?}", messages_value);
-
         let mut messages = match messages_value {
             Value::Array(a) => a
                 .into_iter()
                 .map(|v| match v {
                     Value::Object(o) => {
-                        println!("COUCOU (1)!");
-
                         match (
                             o.get("role"),
                             o.get("content"),
@@ -332,8 +328,6 @@ impl Block for Chat {
                             o.get("function_calls"),
                         ) {
                             (Some(Value::String(r)), Some(Value::String(c)), None, None) => {
-                                println!("O: {:?}", o);
-
                                 Ok(ChatMessage {
                                     role: ChatMessageRole::from_str(r)?,
                                     name: match o.get("name") {
@@ -392,10 +386,7 @@ impl Block for Chat {
 
                                                 Ok(t)
                                             }
-                                            err => {
-                                                println!("Got error: {:?}:", err);
-                                                Err(anyhow!(MESSAGES_CODE_OUTPUT))
-                                            }
+                                            _ => Err(anyhow!(MESSAGES_CODE_OUTPUT)),
                                         }
                                     })
                                     .collect::<Result<Vec<_>, _>>()?;
@@ -409,16 +400,10 @@ impl Block for Chat {
                                     function_call_id: None,
                                 })
                             }
-                            err => {
-                                println!("COUCOU (3): {:?}", err);
-                                Err(anyhow!(MESSAGES_CODE_OUTPUT))
-                            }
+                            _ => Err(anyhow!(MESSAGES_CODE_OUTPUT)),
                         }
                     }
-                    err => {
-                        println!("COUCOU (4): {:?}", err);
-                        Err(anyhow!(MESSAGES_CODE_OUTPUT))
-                    }
+                    _ => Err(anyhow!(MESSAGES_CODE_OUTPUT)),
                 })
                 .collect::<Result<Vec<ChatMessage>>>()?,
             _ => Err(anyhow!(MESSAGES_CODE_OUTPUT))?,

--- a/core/src/blocks/llm.rs
+++ b/core/src/blocks/llm.rs
@@ -428,6 +428,7 @@ impl Block for LLM {
                     content: Some(prompt.clone()),
                     function_call: None,
                     function_calls: None,
+                    function_call_id: None,
                 }];
 
                 let request = LLMChatRequest::new(

--- a/core/src/providers/anthropic.rs
+++ b/core/src/providers/anthropic.rs
@@ -295,6 +295,7 @@ impl TryFrom<ChatResponse> for ChatMessage {
             content: text_content,
             function_call,
             function_calls,
+            function_call_id: None,
         })
     }
 }

--- a/core/src/providers/google_ai_studio.rs
+++ b/core/src/providers/google_ai_studio.rs
@@ -455,6 +455,7 @@ impl LLM for GoogleAiStudioLLM {
                 name: None,
                 function_call: None,
                 function_calls: None,
+                function_call_id: None,
                 role: ChatMessageRole::Assistant,
                 content: match c.candidates {
                     None => None,

--- a/core/src/providers/llm.rs
+++ b/core/src/providers/llm.rs
@@ -80,6 +80,8 @@ pub struct ChatMessage {
     pub function_call: Option<ChatFunctionCall>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub function_calls: Option<Vec<ChatFunctionCall>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub function_call_id: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]

--- a/core/src/providers/mistral.rs
+++ b/core/src/providers/mistral.rs
@@ -223,6 +223,7 @@ impl TryFrom<&MistralChatMessage> for ChatMessage {
             name: None,
             function_call,
             function_calls,
+            function_call_id: None,
         })
     }
 }

--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -167,7 +167,7 @@ impl TryFrom<&ChatFunctionCall> for OpenAIToolCall {
 
     fn try_from(cf: &ChatFunctionCall) -> Result<Self, Self::Error> {
         Ok(OpenAIToolCall {
-            id: None,
+            id: Some(cf.id.clone()),
             r#type: OpenAIToolType::Function,
             function: OpenAIToolCallFunction {
                 name: cf.name.clone(),
@@ -194,14 +194,69 @@ impl TryFrom<&OpenAIToolCall> for ChatFunctionCall {
     }
 }
 
+// #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+// pub struct OpenAIToolResult {
+//     tool_call_id: Option<String>,
+//     // It needs to be narrowed down to "tool"
+//     role: String,
+//     name: String,
+//     content: String,
+// }
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[serde(rename_all = "lowercase")]
+pub enum OpenAIChatMessageRole {
+    Assistant,
+    System,
+    User,
+    Tool,
+}
+
+impl From<&ChatMessageRole> for OpenAIChatMessageRole {
+    fn from(role: &ChatMessageRole) -> Self {
+        match role {
+            ChatMessageRole::Assistant => OpenAIChatMessageRole::Assistant,
+            ChatMessageRole::Function => OpenAIChatMessageRole::Tool,
+            ChatMessageRole::System => OpenAIChatMessageRole::System,
+            ChatMessageRole::User => OpenAIChatMessageRole::User,
+        }
+    }
+}
+
+impl FromStr for OpenAIChatMessageRole {
+    type Err = ParseError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "system" => Ok(OpenAIChatMessageRole::System),
+            "user" => Ok(OpenAIChatMessageRole::User),
+            "assistant" => Ok(OpenAIChatMessageRole::Assistant),
+            "function" => Ok(OpenAIChatMessageRole::Tool),
+            _ => Err(ParseError::with_message("Unknown OpenAIChatMessageRole"))?,
+        }
+    }
+}
+
+impl From<OpenAIChatMessageRole> for ChatMessageRole {
+    fn from(value: OpenAIChatMessageRole) -> Self {
+        match value {
+            OpenAIChatMessageRole::Assistant => ChatMessageRole::Assistant,
+            OpenAIChatMessageRole::System => ChatMessageRole::System,
+            OpenAIChatMessageRole::User => ChatMessageRole::User,
+            OpenAIChatMessageRole::Tool => ChatMessageRole::Function,
+        }
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct OpenAIChatMessage {
-    pub role: ChatMessageRole,
+    pub role: OpenAIChatMessageRole,
     pub content: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_calls: Option<Vec<OpenAIToolCall>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_call_id: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -266,6 +321,7 @@ impl TryFrom<&OpenAIChatMessage> for ChatMessage {
             name,
             function_call,
             function_calls,
+            function_call_id: None,
         })
     }
 }
@@ -274,12 +330,29 @@ impl TryFrom<&ChatMessage> for OpenAIChatMessage {
     type Error = anyhow::Error;
 
     fn try_from(cm: &ChatMessage) -> Result<Self, Self::Error> {
+        let (role, tool_call_id) = match cm.function_call_id.as_ref() {
+            Some(fcid) => match OpenAIChatMessageRole::from(&cm.role) {
+                OpenAIChatMessageRole::Tool => {
+                    Ok((OpenAIChatMessageRole::Tool, Some(fcid.clone())))
+                }
+                _ => Err(anyhow!(
+                    "`function_call_id` must be provided when `role` is set to `function`"
+                )),
+            },
+            _ => Ok((OpenAIChatMessageRole::from(&cm.role), None)),
+        }?;
+
         Ok(OpenAIChatMessage {
             content: cm.content.clone(),
             name: cm.name.clone(),
-            role: cm.role.clone(),
-            tool_calls: match cm.function_call.as_ref() {
-                Some(fc) => Some(vec![OpenAIToolCall::try_from(fc)?]),
+            role,
+            tool_call_id,
+            tool_calls: match cm.function_calls.as_ref() {
+                Some(fc) => Some(
+                    fc.into_iter()
+                        .map(|f| OpenAIToolCall::try_from(f))
+                        .collect::<Result<Vec<OpenAIToolCall>, _>>()?,
+                ),
                 None => None,
             },
         })
@@ -970,8 +1043,9 @@ pub async fn streamed_chat_completion(
                     message: OpenAIChatMessage {
                         content: Some("".to_string()),
                         name: None,
-                        role: ChatMessageRole::System,
+                        role: OpenAIChatMessageRole::System,
                         tool_calls: None,
+                        tool_call_id: None,
                     },
                     index: c.index,
                     finish_reason: None,
@@ -995,7 +1069,7 @@ pub async fn streamed_chat_completion(
                     Some(role) => match role.as_str() {
                         None => (),
                         Some(r) => {
-                            c.choices[j].message.role = ChatMessageRole::from_str(r)?;
+                            c.choices[j].message.role = OpenAIChatMessageRole::from_str(r)?;
                         }
                     },
                 };
@@ -1156,6 +1230,10 @@ pub async fn chat_completion(
             &format!("{}", organization_id.clone()),
         );
     }
+    //
+    // println!("{}", serde_json::to_string_pretty(&obj).unwrap());
+
+    println!("BODY: {:?}", serde_json::to_string_pretty(&body));
 
     let req = req.json(&body);
 

--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -194,15 +194,6 @@ impl TryFrom<&OpenAIToolCall> for ChatFunctionCall {
     }
 }
 
-// #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
-// pub struct OpenAIToolResult {
-//     tool_call_id: Option<String>,
-//     // It needs to be narrowed down to "tool"
-//     role: String,
-//     name: String,
-//     content: String,
-// }
-
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 #[serde(rename_all = "lowercase")]
 pub enum OpenAIChatMessageRole {
@@ -1234,10 +1225,6 @@ pub async fn chat_completion(
             &format!("{}", organization_id.clone()),
         );
     }
-    //
-    // println!("{}", serde_json::to_string_pretty(&obj).unwrap());
-
-    println!("BODY: {:?}", serde_json::to_string_pretty(&body));
 
     let req = req.json(&body);
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See https://github.com/dust-tt/dust/issues/4968.

This pull request augments the chat block to support the inclusion of historical messages with `function_calls`, as well as the ability to pass function call results. This PR only focuses on OpenAI.

To maintain compatibility with the existing behavior, a workaround has been implemented.
OpenAI has introduced a new `tool` role for relaying tool results, which in our case, corresponds to `function_calls`. We still need to support the `function` role, as it's used by our dust apps for `content_fragment`. The `tool` role is intentionally not exposed, instead, some logic is incorporated in OpenAI side to automatically map the `function` role to `tool` when a `function_call_id` is provided.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
Worst case it breaks content fragment/action on dust app that relies on OpenAI. Safe to rollback.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
