### PR TITLE
connectors cli: allow number in arguments

### DIFF
--- a/types/src/connectors/admin/cli.ts
+++ b/types/src/connectors/admin/cli.ts
@@ -12,7 +12,7 @@ export const ConnectorsCommandSchema = t.type({
     t.literal("set-error"),
     t.literal("restart"),
   ]),
-  args: t.record(t.string, t.union([t.string, t.undefined])),
+  args: t.record(t.string, t.union([t.string, t.number, t.undefined])),
 });
 
 export type ConnectorsCommandType = t.TypeOf<typeof ConnectorsCommandSchema>;


### PR DESCRIPTION
## Description

If the workspace Id of a user has no letter connectors client yells at us. I tried tweaking the command line format with no success. Adding number as an accepted type solves the issue. We do turn wId intro a string in connectors client code
 
## Risk

N/A

## Deploy Plan

- deploy `connectors`