### PR TITLE
Fix: connectors cli: allow number in arguments

### DIFF
--- a/connectors/src/admin/cli.ts
+++ b/connectors/src/admin/cli.ts
@@ -10,7 +10,9 @@ const main = async () => {
   // set env var INTERACTIVE=1 to enable interactive mode
   process.env.INTERACTIVE_CLI = process.env.INTERACTIVE_CLI || "1";
 
-  const argv = parseArgs(process.argv.slice(2));
+  const argv = parseArgs(process.argv.slice(2), {
+    string: "wId",
+  });
 
   if (argv._.length < 2) {
     throw new Error(


### PR DESCRIPTION
Description
---
See #5030, wId should be considered a string even if only numbers in the sId

Risk
---
N/A

Deploy plan
---
Connectors
