### PR TITLE
enh: don't track FREE_TEST_PLAN users on CIO

### DIFF
--- a/front/lib/tracking/customerio/server.ts
+++ b/front/lib/tracking/customerio/server.ts
@@ -278,6 +278,29 @@ export class CustomerioServerSideTracking {
     }
   }
 
+  static async _deleteUser({ user }: { user: UserType }) {
+    if (!config.getCustomerIoEnabled()) {
+      return;
+    }
+
+    const r = await fetch(`${CUSTOMERIO_HOST}/v2/entity`, {
+      method: "POST",
+      headers: CustomerioServerSideTracking._headers(),
+      body: JSON.stringify({
+        identifiers: {
+          email: user.email,
+        },
+        type: "person",
+        action: "delete",
+      }),
+    });
+
+    if (!r.ok) {
+      const json = await r.json();
+      throw new Error(`Failed to delete user ${user.email}: ${json}`);
+    }
+  }
+
   static async _trackEvent({
     user,
     workspace,

--- a/front/lib/tracking/customerio/server.ts
+++ b/front/lib/tracking/customerio/server.ts
@@ -301,6 +301,34 @@ export class CustomerioServerSideTracking {
     }
   }
 
+  static async _deleteWorkspace({
+    workspace,
+  }: {
+    workspace: LightWorkspaceType;
+  }) {
+    if (!config.getCustomerIoEnabled()) {
+      return;
+    }
+
+    const r = await fetch(`${CUSTOMERIO_HOST}/v2/entity`, {
+      method: "POST",
+      headers: CustomerioServerSideTracking._headers(),
+      body: JSON.stringify({
+        identifiers: {
+          object_type_id: "1",
+          object_id: workspace.sId,
+        },
+        type: "object",
+        action: "delete",
+      }),
+    });
+
+    if (!r.ok) {
+      const json = await r.json();
+      throw new Error(`Failed to delete workspace ${workspace.sId}: ${json}`);
+    }
+  }
+
   static async _trackEvent({
     user,
     workspace,

--- a/front/migrations/20240513_backfill_customerio_delete_free_test.ts
+++ b/front/migrations/20240513_backfill_customerio_delete_free_test.ts
@@ -49,7 +49,6 @@ const backfillCustomerIo = async (execute: boolean) => {
       ? await subscriptionForWorkspaces(workspaceSids)
       : {};
 
-    // if (execute) {
     const promises: Promise<unknown>[] = [];
     for (const u of c) {
       const memberships = membershipsByUserId[u.id.toString()] ?? [];
@@ -105,6 +104,10 @@ const backfillCustomerIo = async (execute: boolean) => {
           deletedWorkspaceSids.add(ws.sId);
         }
       }
+    }
+
+    if (execute) {
+      await Promise.all(promises);
     }
   }
 };

--- a/front/migrations/20240513_backfill_customerio_delete_free_test.ts
+++ b/front/migrations/20240513_backfill_customerio_delete_free_test.ts
@@ -1,0 +1,80 @@
+import { removeNulls } from "@dust-tt/types";
+import * as _ from "lodash";
+
+import { renderUserType } from "@app/lib/api/user";
+import { subscriptionForWorkspaces } from "@app/lib/auth";
+import { User } from "@app/lib/models/user";
+import { Workspace } from "@app/lib/models/workspace";
+import { FREE_TEST_PLAN_CODE } from "@app/lib/plans/plan_codes";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { CustomerioServerSideTracking } from "@app/lib/tracking/customerio/server";
+import logger from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+
+const backfillCustomerIo = async (execute: boolean) => {
+  const allUserModels = await User.findAll();
+  const users = allUserModels.map((u) => renderUserType(u));
+  const chunks = _.chunk(users, 16);
+  for (const [i, c] of chunks.entries()) {
+    logger.info(
+      `[execute=${execute}] Processing chunk of ${c.length} users... (${
+        i + 1
+      }/${chunks.length})`
+    );
+    const membershipsByUserId = _.groupBy(
+      await MembershipResource.getLatestMemberships({
+        users: c,
+      }),
+      (m) => m.userId.toString()
+    );
+
+    const workspaceIds = Object.values(membershipsByUserId)
+      .flat()
+      .map((m) => m.workspaceId);
+    const workspaceById = _.keyBy(
+      workspaceIds.length
+        ? await Workspace.findAll({
+            where: {
+              id: workspaceIds,
+            },
+          })
+        : [],
+      (ws) => ws.id.toString()
+    );
+
+    const workspaceSids = Object.values(workspaceById).map((ws) => ws.sId);
+    const subscriptionByWorkspaceSid = workspaceSids.length
+      ? await subscriptionForWorkspaces(workspaceSids)
+      : {};
+
+    if (execute) {
+      await Promise.all(
+        c.map((u) => {
+          const memberships = membershipsByUserId[u.id.toString()] ?? [];
+          const workspaces =
+            memberships.map((m) => workspaceById[m.workspaceId.toString()]) ??
+            [];
+          const subscriptions =
+            removeNulls(
+              workspaces.map((ws) => subscriptionByWorkspaceSid[ws.sId])
+            ) ?? [];
+          if (subscriptions.some((s) => s.plan.code !== FREE_TEST_PLAN_CODE)) {
+            return;
+          }
+          return CustomerioServerSideTracking._deleteUser({
+            user: u,
+          }).catch((err) => {
+            logger.error(
+              { userId: u.sId, err },
+              "Failed to delete user on Customer.io"
+            );
+          });
+        })
+      );
+    }
+  }
+};
+
+makeScript({}, async ({ execute }) => {
+  await backfillCustomerIo(execute);
+});


### PR DESCRIPTION
## Description

https://github.com/dust-tt/tasks/issues/744

We have a lot of historical users on that plan. We don't need them on CIO.

No new workspaces should have subscriptions with this plan code.

- make sure we don't track workspaces that don't have a real subscription when users log-in
- add code to delete a CIO user
- add code to delete a CIO workspace
- add backfill script to delete all users that aren't part of a workspace that has a real subscription, and delete all such workspaces as well


## Risk

Should be fine

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
