### PR TITLE
[Infra] Add production check to detect startToClose timeouts

### DIFF
--- a/front/lib/production_checks/checks/check_starttoclose_timeouts.ts
+++ b/front/lib/production_checks/checks/check_starttoclose_timeouts.ts
@@ -1,0 +1,53 @@
+import { temporal } from "@temporalio/proto/protos/root";
+import type { CheckFunction } from "@app/lib/production_checks/types";
+import { getTemporalConnectorsNamespaceConnection } from "@app/lib/temporal";
+
+const { EventType, TimeoutType } = temporal.api.enums.v1;
+
+export const checkStartToCloseTimeoutsInActivities: CheckFunction = async (
+  _checkName,
+  logger,
+  reportSuccess,
+  reportFailure,
+  heartbeat
+) => {
+  // get all running workflows
+  const client = await getTemporalConnectorsNamespaceConnection();
+  const workflowInfos = client.workflow
+    .list({
+      pageSize: 10,
+      query: `ExecutionStatus = 'Running'`,
+    })
+    .intoHistories();
+  logger.info(
+    "Checking for startToClose timeout failures in running workflows' activities"
+  );
+  for await (const handle of workflowInfos) {
+    const history = handle.history as temporal.api.history.v1.History;
+    if (!handle.history || !history.events) {
+      continue;
+    }
+    const activityTimeoutFailures = history.events.filter(
+      (event) =>
+        event.eventType === EventType.EVENT_TYPE_ACTIVITY_TASK_FAILED &&
+        event.activityTaskFailedEventAttributes?.failure?.timeoutFailureInfo
+          ?.timeoutType === TimeoutType.TIMEOUT_TYPE_START_TO_CLOSE
+    );
+    heartbeat();
+
+    if (activityTimeoutFailures.length > 0) {
+      reportFailure(
+        {
+          activityTimeoutFailures,
+          workflowId: handle.workflowId,
+          description:
+            "StartToClose timeout failures are not logged in datadog and the activity is not terminated by temporal, but temporal retries by starting a new activity with same id. Multiple activity clones running at the same time can cause various issues, such as OOMs (activities pile up)",
+        },
+        "Found at least an activity with startToClose timeout failure in running workflow. Fix by modifying activity code so the activity enforces the timeout itself."
+      );
+    } else {
+      reportSuccess({});
+    }
+  }
+  logger.info("Finished checking for startToClose timeout failures");
+};

--- a/front/lib/production_checks/checks/check_starttoclose_timeouts.ts
+++ b/front/lib/production_checks/checks/check_starttoclose_timeouts.ts
@@ -1,4 +1,5 @@
 import { temporal } from "@temporalio/proto/protos/root";
+
 import type { CheckFunction } from "@app/lib/production_checks/types";
 import { getTemporalConnectorsNamespaceConnection } from "@app/lib/temporal";
 

--- a/front/temporal/production_checks/activities.ts
+++ b/front/temporal/production_checks/activities.ts
@@ -3,6 +3,7 @@ import { v4 as uuidv4 } from "uuid";
 
 import { checkActiveWorkflows } from "@app/lib/production_checks/checks/check_active_workflows_for_connectors";
 import { checkNotionActiveWorkflows } from "@app/lib/production_checks/checks/check_notion_active_workflows";
+import { checkStartToCloseTimeoutsInActivities } from "@app/lib/production_checks/checks/check_starttoclose_timeouts";
 import { managedDataSourceGCGdriveCheck } from "@app/lib/production_checks/checks/managed_data_source_gdrive_gc";
 import { nangoConnectionIdCleanupSlack } from "@app/lib/production_checks/checks/nango_connection_id_cleanup_slack";
 import { scrubDeletedCoreDocumentVersionsCheck } from "@app/lib/production_checks/checks/scrub_deleted_core_document_versions";
@@ -35,6 +36,11 @@ export async function runAllChecksActivity() {
       name: "check_active_workflows_for_connector",
       check: checkActiveWorkflows,
       everyHour: 1,
+    },
+    {
+      name: "check_startToClose_timeouts_in_activities",
+      check: checkStartToCloseTimeoutsInActivities,
+      everyHour: 2,
     },
   ];
   await runAllChecks(checks);


### PR DESCRIPTION
Description
---
Fixes https://github.com/dust-tt/tasks/issues/747

StartToClose timeout failures are not logged in datadog and the activity is not terminated by temporal, but temporal retries by starting a new activity with same id. Multiple activity clones running at the same time can cause various issues, such as OOMs (activities pile up)

Risk
---
N/A

Deploy plan
---
Front

