### PR TITLE
Poke support upgrading existing subscription to Enterprise

### DIFF
--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -314,12 +314,14 @@ export function assertStripeSubscriptionIsValid(
 } // TODO(2024-04-05,pr): immediately after flav's merge, use the global constant
 
 // "Cheap" way to verify if a Stripe subscription can be considered an enterprise subscription.
-export function isEnterpriseSubscription(stripeSubscription: Stripe.Subscription) {
+export function isEnterpriseSubscription(
+  stripeSubscription: Stripe.Subscription
+) {
   const activeItems = stripeSubscription.items.data.filter(
     (item) => !item.deleted
   );
 
-  return activeItems.every(item => {
+  return activeItems.every((item) => {
     const isRecurring = Boolean(item.price.recurring);
     const reportUsage = item.price.metadata?.REPORT_USAGE;
 

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -11,6 +11,7 @@ import { countActiveSeatsInWorkspace } from "@app/lib/plans/usage/seats";
 import {
   isMauReportUsage,
   isSupportedReportUsage,
+  SUPPORTED_ENTERPRISE_REPORT_USAGE,
   SUPPORTED_REPORT_USAGE,
 } from "@app/lib/plans/usage/types";
 
@@ -311,6 +312,20 @@ export function assertStripeSubscriptionIsValid(
 
   return new Ok(true);
 } // TODO(2024-04-05,pr): immediately after flav's merge, use the global constant
+
+// "Cheap" way to verify if a Stripe subscription can be considered an enterprise subscription.
+export function isEnterpriseSubscription(stripeSubscription: Stripe.Subscription) {
+  const activeItems = stripeSubscription.items.data.filter(
+    (item) => !item.deleted
+  );
+
+  return activeItems.every(item => {
+    const isRecurring = Boolean(item.price.recurring);
+    const reportUsage = item.price.metadata?.REPORT_USAGE;
+
+    return isRecurring && SUPPORTED_ENTERPRISE_REPORT_USAGE.includes(reportUsage);
+  });
+}
 
 export function assertStripeSubscriptionItemIsValid({
   item,

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -9,9 +9,9 @@ import { Plan, Subscription } from "@app/lib/models/plan";
 import { PRO_PLAN_SEAT_29_CODE } from "@app/lib/plans/plan_codes";
 import { countActiveSeatsInWorkspace } from "@app/lib/plans/usage/seats";
 import {
+  isEnterpriseReportUsage,
   isMauReportUsage,
   isSupportedReportUsage,
-  SUPPORTED_ENTERPRISE_REPORT_USAGE,
   SUPPORTED_REPORT_USAGE,
 } from "@app/lib/plans/usage/types";
 
@@ -323,7 +323,7 @@ export function isEnterpriseSubscription(stripeSubscription: Stripe.Subscription
     const isRecurring = Boolean(item.price.recurring);
     const reportUsage = item.price.metadata?.REPORT_USAGE;
 
-    return isRecurring && SUPPORTED_ENTERPRISE_REPORT_USAGE.includes(reportUsage);
+    return isRecurring && isEnterpriseReportUsage(reportUsage);
   });
 }
 

--- a/front/lib/plans/subscription.ts
+++ b/front/lib/plans/subscription.ts
@@ -223,8 +223,15 @@ export const internalSubscribeWorkspaceToFreePlan = async ({
     );
   });
 
-  // Notify Stripe that we ended the subscription if the subscription was a paid one
-  if (activeSubscription?.stripeSubscriptionId) {
+  // Check if the workspace is switching to a new Stripe subscription ID.
+  const isNewStripeSubscriptionId =
+    activeSubscription &&
+    activeSubscription.stripeSubscriptionId !== stripeSubscriptionId;
+
+  // If the workspace is switching to a new Stripe subscription ID and the
+  // previous subscription was paid, notify Stripe to cancel the subscription
+  // immediately.
+  if (activeSubscription?.stripeSubscriptionId && isNewStripeSubscriptionId) {
     await cancelSubscriptionImmediately({
       stripeSubscriptionId: activeSubscription.stripeSubscriptionId,
     });

--- a/front/lib/plans/usage/types.ts
+++ b/front/lib/plans/usage/types.ts
@@ -8,7 +8,8 @@ export const SUPPORTED_ENTERPRISE_REPORT_USAGE = [
   "MAU_5",
   "MAU_10",
 ] as const;
-type SupportedEnterpriseReportUsage = (typeof SUPPORTED_ENTERPRISE_REPORT_USAGE)[number];
+type SupportedEnterpriseReportUsage =
+  (typeof SUPPORTED_ENTERPRISE_REPORT_USAGE)[number];
 
 export const SUPPORTED_REPORT_USAGE = [
   ...SUPPORTED_ENTERPRISE_REPORT_USAGE,
@@ -20,7 +21,9 @@ export type SupportedReportUsage = (typeof SUPPORTED_REPORT_USAGE)[number];
 export function isEnterpriseReportUsage(
   usage: string | undefined
 ): usage is SupportedEnterpriseReportUsage {
-  return SUPPORTED_ENTERPRISE_REPORT_USAGE.includes(usage as SupportedEnterpriseReportUsage);
+  return SUPPORTED_ENTERPRISE_REPORT_USAGE.includes(
+    usage as SupportedEnterpriseReportUsage
+  );
 }
 
 export function isSupportedReportUsage(

--- a/front/lib/plans/usage/types.ts
+++ b/front/lib/plans/usage/types.ts
@@ -3,10 +3,14 @@ export const REPORT_USAGE_METADATA_KEY = "REPORT_USAGE";
 
 export class InvalidReportUsageError extends Error {}
 
-export const SUPPORTED_REPORT_USAGE = [
+export const SUPPORTED_ENTERPRISE_REPORT_USAGE = [
   "MAU_1",
   "MAU_5",
   "MAU_10",
+];
+
+export const SUPPORTED_REPORT_USAGE = [
+  ...SUPPORTED_ENTERPRISE_REPORT_USAGE,
   "PER_SEAT",
   "FIXED",
 ] as const;

--- a/front/lib/plans/usage/types.ts
+++ b/front/lib/plans/usage/types.ts
@@ -7,7 +7,7 @@ export const SUPPORTED_ENTERPRISE_REPORT_USAGE = [
   "MAU_1",
   "MAU_5",
   "MAU_10",
-];
+] as const;
 
 export const SUPPORTED_REPORT_USAGE = [
   ...SUPPORTED_ENTERPRISE_REPORT_USAGE,

--- a/front/lib/plans/usage/types.ts
+++ b/front/lib/plans/usage/types.ts
@@ -8,6 +8,7 @@ export const SUPPORTED_ENTERPRISE_REPORT_USAGE = [
   "MAU_5",
   "MAU_10",
 ] as const;
+type SupportedEnterpriseReportUsage = (typeof SUPPORTED_ENTERPRISE_REPORT_USAGE)[number];
 
 export const SUPPORTED_REPORT_USAGE = [
   ...SUPPORTED_ENTERPRISE_REPORT_USAGE,
@@ -15,6 +16,12 @@ export const SUPPORTED_REPORT_USAGE = [
   "FIXED",
 ] as const;
 export type SupportedReportUsage = (typeof SUPPORTED_REPORT_USAGE)[number];
+
+export function isEnterpriseReportUsage(
+  usage: string | undefined
+): usage is SupportedEnterpriseReportUsage {
+  return SUPPORTED_ENTERPRISE_REPORT_USAGE.includes(usage as SupportedEnterpriseReportUsage);
+}
 
 export function isSupportedReportUsage(
   usage: string | undefined

--- a/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.ts
+++ b/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.ts
@@ -67,7 +67,7 @@ async function handler(
       }
       const body = bodyValidation.right;
 
-      // We validate that the stripe subscription exists and is correctly configured
+      // We validate that the stripe subscription exists and is correctly configured.
       const stripeSubscription = await getStripeSubscription(
         body.stripeSubscriptionId
       );
@@ -81,16 +81,24 @@ async function handler(
         });
       }
 
+      // Ensure that the stripe subscription is either attached to the current workspace
+      // or is not attached to any workspace.
       const subscription = await getSubscriptionForStripeId(
         stripeSubscription.id
       );
+      const currentWorkspaceSubscription = auth.subscription();
+      const isCurrentWorkspaceSubscription =
+        currentWorkspaceSubscription &&
+        currentWorkspaceSubscription.stripeSubscriptionId ===
+          stripeSubscription.id;
 
-      if (subscription) {
+      if (subscription && !isCurrentWorkspaceSubscription) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "The subscription is already attached to a workspace.",
+            message:
+              "The subscription is already attached to another workspace.",
           },
         });
       }

--- a/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.ts
+++ b/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.ts
@@ -8,6 +8,7 @@ import { Authenticator, getSession } from "@app/lib/auth";
 import {
   assertStripeSubscriptionIsValid,
   getStripeSubscription,
+  isEnterpriseSubscription,
 } from "@app/lib/plans/stripe";
 import {
   getSubscriptionForStripeId,
@@ -99,6 +100,17 @@ async function handler(
             type: "invalid_request_error",
             message:
               "The subscription is already attached to another workspace.",
+          },
+        });
+      }
+
+      if (!isEnterpriseSubscription(stripeSubscription)) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              "The subscription provided is not an enterprise subscription.",
           },
         });
       }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See https://github.com/dust-tt/tasks/issues/748.

In our initial implementation of upgrading a workspace to an enterprise plan from Poke, we did not consider existing paying workspaces. A common scenario these days is upgrading a workspace from a Pro plan to an Enterprise plan. In Stripe, we accomplish this using phases, where each phase represents a different plan, providing a straightforward way to manage customer journeys with Dust.

This PR brings flexibility to the existing upgrade process by accepting the current workspace's Stripe subscription ID when upgrading to Enterprise. In this case, we won't cancel the subscription on Stripe's side.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
