### PR TITLE
[Slack] Support for bot users

### DIFF
--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -23,9 +23,8 @@ import jaroWinkler from "talisman/metrics/jaro-winkler";
 
 import type { SlackUserInfo } from "@connectors/connectors/slack/lib/slack_client";
 import {
-  getSlackBotInfo,
   getSlackClient,
-  getSlackUserInfo,
+  getSlackUserOrBotInfo,
 } from "@connectors/connectors/slack/lib/slack_client";
 import { getRepliesFromThread } from "@connectors/connectors/slack/lib/thread";
 import { notifyIfSlackUserIsNotAllowed } from "@connectors/connectors/slack/lib/workspace_limits";
@@ -177,12 +176,14 @@ async function botAnswerMessage(
   // We start by retrieving the slack user info.
   const slackClient = await getSlackClient(connector.id);
 
-  let slackUserInfo: SlackUserInfo | null = null;
-  if (slackUserId) {
-    slackUserInfo = await getSlackUserInfo(slackClient, slackUserId);
-  } else if (slackBotId) {
-    slackUserInfo = await getSlackBotInfo(slackClient, slackBotId);
+  const userOrBotId = slackUserId || slackBotId;
+  if (!userOrBotId) {
+    throw new Error("Failed to get slack user id or bot id");
   }
+  const slackUserInfo: SlackUserInfo = await getSlackUserOrBotInfo(
+    slackClient,
+    userOrBotId
+  );
 
   if (!slackUserInfo) {
     throw new Error("Failed to get slack user info");

--- a/connectors/src/connectors/slack/lib/slack_client.ts
+++ b/connectors/src/connectors/slack/lib/slack_client.ts
@@ -117,7 +117,26 @@ export type SlackUserInfo = {
   image_512: string | null;
 };
 
-export async function getSlackUserInfo(
+export async function getSlackUserOrBotInfo(
+  slackClient: WebClient,
+  userId: string
+) {
+  if (userId.startsWith("B")) {
+    return getSlackBotInfo(slackClient, userId);
+  }
+  const res = await slackClient.users.info({ user: userId });
+
+  if (!res.ok) {
+    throw res.error;
+  }
+  if (res.user?.is_bot) {
+    return getSlackBotInfo(slackClient, userId);
+  } else {
+    return getSlackUserInfo(slackClient, userId);
+  }
+}
+
+async function getSlackUserInfo(
   slackClient: WebClient,
   userId: string
 ): Promise<SlackUserInfo> {
@@ -141,7 +160,7 @@ export async function getSlackUserInfo(
   };
 }
 
-export async function getSlackBotInfo(
+async function getSlackBotInfo(
   slackClient: WebClient,
   botId: string
 ): Promise<SlackUserInfo> {


### PR DESCRIPTION
## Description

Looks like there are two types of Slack bots:
Slack bots that are users of slack with a `is_bot` slack flag set to true, and Slack bots that are not user at all.
This PR allows bots that are also users to talk to @dust. (eg: Zapier).

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
