### PR TITLE
feat(multi-actions): chat UI for multi actions

### DIFF
--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -333,15 +333,14 @@ export async function renderConversationForModelMultiActions({
           assertNever(action);
         }
       }
-
+      if (function_messages.length > 0) {
+        messages.unshift(...function_messages);
+      }
       if (function_calls.length > 0) {
-        messages.push({
+        messages.unshift({
           role: "assistant",
           function_calls,
         });
-      }
-      if (function_messages.length > 0) {
-        messages.push(...function_messages);
       }
     } else if (isUserMessageType(m)) {
       // Replace all `:mention[{name}]{.*}` with `@name`.

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -853,6 +853,128 @@ async function _getDustGlobalAgent(
   };
 }
 
+async function _getDustNextGlobalAgent(
+  auth: Authenticator,
+  {
+    settings,
+  }: {
+    settings: GlobalAgentSettings | null;
+  }
+): Promise<AgentConfigurationType | null> {
+  const owner = auth.workspace();
+  if (!owner) {
+    throw new Error("Unexpected `auth` without `workspace`.");
+  }
+
+  const name = "dust-next";
+  const description = "An assistant with context on your company data.";
+  const pictureUrl = "https://dust.tt/static/systemavatar/dust_avatar_full.png";
+
+  const model: AgentModelConfigurationType = !auth.isUpgraded()
+    ? {
+        providerId: GPT_3_5_TURBO_MODEL_CONFIG.providerId,
+        modelId: GPT_3_5_TURBO_MODEL_CONFIG.modelId,
+        temperature: 0.7,
+      }
+    : {
+        providerId: GPT_4O_MODEL_CONFIG.providerId,
+        modelId: GPT_4O_MODEL_CONFIG.modelId,
+        temperature: 0.7,
+      };
+
+  if (
+    !owner.flags.includes("multi_actions") ||
+    (settings && settings.status === "disabled_by_admin")
+  ) {
+    return {
+      id: -1,
+      sId: GLOBAL_AGENTS_SID.DUST,
+      version: 0,
+      versionCreatedAt: null,
+      versionAuthorId: null,
+      name,
+      description,
+      instructions: null,
+      pictureUrl,
+      status: "disabled_by_admin",
+      scope: "global",
+      userListStatus: "not-in-list",
+      model,
+      actions: [],
+      maxToolsUsePerRun: 0,
+    };
+  }
+
+  const prodCredentials = await prodAPICredentialsForOwner(owner);
+  const api = new DustAPI(prodCredentials, logger);
+
+  const dsRes = await api.getDataSources(prodCredentials.workspaceId);
+  if (dsRes.isErr()) {
+    return null;
+  }
+
+  const dataSources = dsRes.value.filter(
+    (d) => d.assistantDefaultSelected === true
+  );
+
+  if (dataSources.length === 0) {
+    return {
+      id: -1,
+      sId: GLOBAL_AGENTS_SID.DUST,
+      version: 0,
+      versionCreatedAt: null,
+      versionAuthorId: null,
+      name,
+      description,
+      instructions: null,
+      pictureUrl,
+      status: "disabled_missing_datasource",
+      scope: "global",
+      userListStatus: "not-in-list",
+      model,
+      actions: [],
+      maxToolsUsePerRun: 0,
+    };
+  }
+
+  return {
+    id: -1,
+    sId: GLOBAL_AGENTS_SID.DUST_NEXT,
+    version: 0,
+    versionCreatedAt: null,
+    versionAuthorId: null,
+    name,
+    description,
+    instructions:
+      "Assist the user based on the retrieved data from their workspace." +
+      `\n${BREVITY_PROMPT}`,
+    pictureUrl,
+    status: "active",
+    scope: "global",
+    userListStatus: "in-list",
+    model,
+    actions: [
+      {
+        id: -1,
+        sId: GLOBAL_AGENTS_SID.DUST + "-action",
+        type: "retrieval_configuration",
+        query: "auto",
+        relativeTimeFrame: "auto",
+        topK: "auto",
+        dataSources: dataSources.map((ds) => ({
+          dataSourceId: ds.name,
+          workspaceId: prodCredentials.workspaceId,
+          filter: { tags: null, parents: null },
+        })),
+        name: "search_data_sources",
+        description: `Search the user's data sources.`,
+        forceUseAtIteration: null,
+      },
+    ],
+    maxToolsUsePerRun: 3,
+  };
+}
+
 /**
  * Exported functions
  */
@@ -966,6 +1088,9 @@ export async function getGlobalAgent(
       break;
     case GLOBAL_AGENTS_SID.DUST:
       agentConfiguration = await _getDustGlobalAgent(auth, { settings });
+      break;
+    case GLOBAL_AGENTS_SID.DUST_NEXT:
+      agentConfiguration = await _getDustNextGlobalAgent(auth, { settings });
       break;
     default:
       return null;

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -41,6 +41,7 @@ export function getSupportedModelConfig(
 export enum GLOBAL_AGENTS_SID {
   HELPER = "helper",
   DUST = "dust",
+  DUST_NEXT = "dust-next",
   SLACK = "slack",
   GOOGLE_DRIVE = "google_drive",
   NOTION = "notion",

--- a/front/lib/utils/seeded_random.ts
+++ b/front/lib/utils/seeded_random.ts
@@ -1,0 +1,41 @@
+function cyrb128(str: string) {
+  let h1 = 1779033703,
+    h2 = 3144134277,
+    h3 = 1013904242,
+    h4 = 2773480762;
+  for (let i = 0, k; i < str.length; i++) {
+    k = str.charCodeAt(i);
+    h1 = h2 ^ Math.imul(h1 ^ k, 597399067);
+    h2 = h3 ^ Math.imul(h2 ^ k, 2869860233);
+    h3 = h4 ^ Math.imul(h3 ^ k, 951274213);
+    h4 = h1 ^ Math.imul(h4 ^ k, 2716044179);
+  }
+  h1 = Math.imul(h3 ^ (h1 >>> 18), 597399067);
+  h2 = Math.imul(h4 ^ (h2 >>> 22), 2869860233);
+  h3 = Math.imul(h1 ^ (h3 >>> 17), 951274213);
+  h4 = Math.imul(h2 ^ (h4 >>> 19), 2716044179);
+  (h1 ^= h2 ^ h3 ^ h4), (h2 ^= h1), (h3 ^= h1), (h4 ^= h1);
+  return [h1 >>> 0, h2 >>> 0, h3 >>> 0, h4 >>> 0];
+}
+
+function sfc32(a: number, b: number, c: number, d: number): () => number {
+  return function () {
+    a |= 0;
+    b |= 0;
+    c |= 0;
+    d |= 0;
+    const t = (((a + b) | 0) + d) | 0;
+    d = (d + 1) | 0;
+    a = b ^ (b >>> 9);
+    b = (c + (c << 3)) | 0;
+    c = (c << 21) | (c >>> 11);
+    c = (c + t) | 0;
+    return (t >>> 0) / 4294967296;
+  };
+}
+
+// Returns a seeded random number generator (a function that returns a number between 0 and 1)
+export function rand(seed: string): () => number {
+  const [h1, h2, h3, h4] = cyrb128(seed);
+  return sfc32(h1, h2, h3, h4);
+}


### PR DESCRIPTION
## Description

fixes https://github.com/dust-tt/dust/issues/4987

- display every ran action on the agent message (instead of just the first one)
- make multi-retrieval w/ citations work (docs need to have unique references across N retrieval actions)
- add `dust-next` global agent, only for people w/ multi-actions feature flag. This allows to properly test multi-actions with retrieval locally (not possible to do easily with custom assistants)

## Risk

Well tested and shouldn't impact non-multi-actions agents, although it does touch code on the critical path.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
