### PR TITLE
Store function_call_id in actions

### DIFF
--- a/front/lib/api/assistant/actions/dust_app_run.ts
+++ b/front/lib/api/assistant/actions/dust_app_run.ts
@@ -42,6 +42,7 @@ interface DustAppRunActionBlob {
     status: "running" | "succeeded" | "errored";
   } | null;
   output: unknown | null;
+  functionCallId: string | null;
   step: number;
 }
 
@@ -57,6 +58,7 @@ export class DustAppRunAction extends BaseAction {
     status: "running" | "succeeded" | "errored";
   } | null;
   readonly output: unknown | null;
+  readonly functionCallId: string | null;
   readonly step: number;
 
   constructor(blob: DustAppRunActionBlob) {
@@ -69,6 +71,7 @@ export class DustAppRunAction extends BaseAction {
     this.params = blob.params;
     this.runningBlock = blob.runningBlock;
     this.output = blob.output;
+    this.functionCallId = blob.functionCallId;
     this.step = blob.step;
   }
 
@@ -88,7 +91,7 @@ export class DustAppRunAction extends BaseAction {
 
   renderForFunctionCall(): FunctionCallType {
     return {
-      id: `call_${this.id.toString()}`, // @todo Daph replace with the actual tool id
+      id: this.functionCallId ?? `call_${this.id.toString()}`,
       name: this.appName,
       arguments: JSON.stringify(this.params),
     };
@@ -103,7 +106,7 @@ export class DustAppRunAction extends BaseAction {
 
     return {
       role: "function" as const,
-      function_call_id: `call_${this.id.toString()}`, // @todo Daph replace with the actual tool id
+      function_call_id: this.functionCallId ?? `call_${this.id.toString()}`,
       content,
     };
   }
@@ -256,6 +259,7 @@ export async function dustAppRunTypesFromAgentMessageIds(
       params: action.params,
       runningBlock: null,
       output: action.output,
+      functionCallId: action.functionCallId,
       agentMessageId: action.agentMessageId,
       step: action.step,
     });
@@ -281,6 +285,7 @@ export async function* runDustApp(
     agentMessage,
     spec,
     rawInputs,
+    functionCallId,
     step,
   }: {
     configuration: AgentConfigurationType;
@@ -289,6 +294,7 @@ export async function* runDustApp(
     agentMessage: AgentMessageType;
     spec: AgentActionSpecification;
     rawInputs: Record<string, string | boolean | number>;
+    functionCallId: string | null;
     step: number;
   }
 ): AsyncGenerator<
@@ -355,6 +361,7 @@ export async function* runDustApp(
     appId: actionConfiguration.appId,
     appName: app.name,
     params,
+    functionCallId,
     agentMessageId: agentMessage.agentMessageId,
     step,
   });
@@ -372,6 +379,7 @@ export async function* runDustApp(
       params,
       runningBlock: null,
       output: null,
+      functionCallId,
       agentMessageId: agentMessage.agentMessageId,
       step,
     }),
@@ -444,6 +452,7 @@ export async function* runDustApp(
           appId: actionConfiguration.appId,
           appName: app.name,
           params,
+          functionCallId,
           runningBlock: {
             type: event.content.block_type,
             name: event.content.name,
@@ -476,6 +485,12 @@ export async function* runDustApp(
     }
   }
 
+  if (functionCallId) {
+    lastBlockOutput = lastBlockOutput
+      ? { ...lastBlockOutput, function_call_id: functionCallId }
+      : { function_call_id: functionCallId };
+  }
+
   // Update DustAppRunAction with the output of the last block.
   await action.update({
     output: lastBlockOutput,
@@ -501,6 +516,7 @@ export async function* runDustApp(
       appId: actionConfiguration.appId,
       appName: app.name,
       params,
+      functionCallId,
       runningBlock: null,
       output: lastBlockOutput,
       agentMessageId: agentMessage.agentMessageId,

--- a/front/lib/api/assistant/actions/dust_app_run.ts
+++ b/front/lib/api/assistant/actions/dust_app_run.ts
@@ -485,12 +485,6 @@ export async function* runDustApp(
     }
   }
 
-  if (functionCallId) {
-    lastBlockOutput = lastBlockOutput
-      ? { ...lastBlockOutput, function_call_id: functionCallId }
-      : { function_call_id: functionCallId };
-  }
-
   // Update DustAppRunAction with the output of the last block.
   await action.update({
     output: lastBlockOutput,

--- a/front/lib/api/assistant/actions/process.ts
+++ b/front/lib/api/assistant/actions/process.ts
@@ -80,7 +80,7 @@ export function renderProcessActionFunctionCall(
   action: ProcessActionType
 ): FunctionCallType {
   return {
-    id: `call_${action.id.toString()}`, // @todo Daph replace with the actual tool id
+    id: action.functionCallId ?? `call_${action.id.toString()}`,
     name: "process_data_sources",
     arguments: JSON.stringify(action.params),
   };
@@ -107,7 +107,7 @@ export function renderProcessActionForMultiActionsModel(
 
   return {
     role: "function" as const,
-    function_call_id: `call_${action.id.toString()}`, // @todo Daph replace with the actual tool id
+    function_call_id: action.functionCallId ?? `call_${action.id.toString()}`,
     content,
   };
 }
@@ -201,6 +201,7 @@ export async function processActionTypesFromAgentMessageIds(
       },
       schema: action.schema,
       outputs: action.outputs,
+      functionCallId: action.functionCallId,
       step: action.step,
     } satisfies ProcessActionType;
   });
@@ -296,6 +297,7 @@ export async function* runProcess(
       },
       schema: action.schema,
       outputs: null,
+      functionCallId: action.functionCallId,
       step: action.step,
     },
   };
@@ -485,6 +487,7 @@ export async function* runProcess(
       },
       schema: action.schema,
       outputs,
+      functionCallId: action.functionCallId,
       step: action.step,
     },
   };

--- a/front/lib/api/assistant/actions/process.ts
+++ b/front/lib/api/assistant/actions/process.ts
@@ -225,6 +225,7 @@ export async function* runProcess(
     userMessage,
     agentMessage,
     rawInputs,
+    functionCallId,
     step,
   }: {
     configuration: AgentConfigurationType;
@@ -233,6 +234,7 @@ export async function* runProcess(
     userMessage: UserMessageType;
     agentMessage: AgentMessageType;
     rawInputs: Record<string, string | boolean | number>;
+    functionCallId: string | null;
     step: number;
   }
 ): AsyncGenerator<
@@ -276,6 +278,7 @@ export async function* runProcess(
     relativeTimeFrameUnit: relativeTimeFrame?.unit ?? null,
     processConfigurationId: actionConfiguration.sId,
     schema: actionConfiguration.schema,
+    functionCallId,
     agentMessageId: agentMessage.agentMessageId,
     step,
   });

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -165,7 +165,7 @@ export function rendeRetrievalActionFunctionCall(
   };
 
   return {
-    id: `call_${action.id.toString()}`, // @todo Daph replace with the actual tool id
+    id: action.functionCallId ?? `call_${action.id.toString()}`,
     name: "search_data_sources",
     arguments: JSON.stringify(params),
   };
@@ -204,7 +204,7 @@ export function renderRetrievalActionForMultiActionsModel(
 
   return {
     role: "function" as const,
-    function_call_id: `call_${action.id.toString()}`, // @todo Daph replace with the actual tool id
+    function_call_id: action.functionCallId ?? `call_${action.id.toString()}`,
     content,
   };
 }
@@ -423,6 +423,7 @@ export async function retrievalActionTypesFromAgentMessageIds(
         relativeTimeFrame,
         topK: action.topK,
       },
+      functionCallId: action.functionCallId,
       documents,
       step: action.step,
     });
@@ -592,6 +593,7 @@ export async function* runRetrieval(
         query,
         topK,
       },
+      functionCallId: action.functionCallId,
       documents: null,
       step: action.step,
     },
@@ -844,6 +846,7 @@ export async function* runRetrieval(
         query: query,
         topK,
       },
+      functionCallId: action.functionCallId,
       documents,
       step: action.step,
     },

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -494,6 +494,7 @@ export async function* runRetrieval(
     conversation,
     agentMessage,
     rawInputs,
+    functionCallId,
     step,
     refsOffset = 0,
   }: {
@@ -502,6 +503,7 @@ export async function* runRetrieval(
     conversation: ConversationType;
     agentMessage: AgentMessageType;
     rawInputs: Record<string, string | boolean | number>;
+    functionCallId: string | null;
     step: number;
     refsOffset?: number;
   }
@@ -574,6 +576,7 @@ export async function* runRetrieval(
     relativeTimeFrameUnit: relativeTimeFrame?.unit ?? null,
     topK,
     retrievalConfigurationId: actionConfiguration.sId,
+    functionCallId,
     agentMessageId: agentMessage.agentMessageId,
     step: step,
   });

--- a/front/lib/api/assistant/actions/tables_query.ts
+++ b/front/lib/api/assistant/actions/tables_query.ts
@@ -176,6 +176,7 @@ export async function* runTablesQuery(
     conversation,
     agentMessage,
     rawInputs,
+    functionCallId,
     step,
   }: {
     configuration: AgentConfigurationType;
@@ -183,6 +184,7 @@ export async function* runTablesQuery(
     conversation: ConversationType;
     agentMessage: AgentMessageType;
     rawInputs: Record<string, string | boolean | number>;
+    functionCallId: string | null;
     step: number;
   }
 ): AsyncGenerator<
@@ -219,6 +221,7 @@ export async function* runTablesQuery(
     tablesQueryConfigurationId: configuration.sId,
     params: rawInputs,
     output,
+    functionCallId,
     agentMessageId: agentMessage.agentMessageId,
     step: step,
   });

--- a/front/lib/api/assistant/actions/tables_query.ts
+++ b/front/lib/api/assistant/actions/tables_query.ts
@@ -33,6 +33,7 @@ interface TablesQueryActionBlob {
   agentMessageId: ModelId;
   params: DustAppParameters;
   output: Record<string, string | number | boolean> | null;
+  functionCallId: string | null;
   step: number;
 }
 
@@ -40,6 +41,7 @@ export class TablesQueryAction extends BaseAction {
   readonly agentMessageId: ModelId;
   readonly params: DustAppParameters;
   readonly output: Record<string, string | number | boolean> | null;
+  readonly functionCallId: string | null;
   readonly step: number;
 
   constructor(blob: TablesQueryActionBlob) {
@@ -48,6 +50,7 @@ export class TablesQueryAction extends BaseAction {
     this.agentMessageId = blob.agentMessageId;
     this.params = blob.params;
     this.output = blob.output;
+    this.functionCallId = blob.functionCallId;
     this.step = blob.step;
   }
 
@@ -70,7 +73,7 @@ export class TablesQueryAction extends BaseAction {
 
   renderForFunctionCall(): FunctionCallType {
     return {
-      id: `call_${this.id.toString()}`, // @todo Daph replace with the actual tool id
+      id: this.functionCallId ?? `call_${this.id.toString()}`,
       name: "query_tables",
       arguments: JSON.stringify(this.params),
     };
@@ -88,7 +91,7 @@ export class TablesQueryAction extends BaseAction {
 
     return {
       role: "function" as const,
-      function_call_id: `call_${this.id.toString()}`, // @todo Daph replace with the actual tool id
+      function_call_id: this.functionCallId ?? `call_${this.id.toString()}`,
       content,
     };
   }
@@ -110,6 +113,7 @@ export async function tableQueryTypesFromAgentMessageIds(
       id: action.id,
       params: action.params as DustAppParameters,
       output: action.output as Record<string, string | number | boolean>,
+      functionCallId: action.functionCallId,
       agentMessageId: action.agentMessageId,
       step: action.step,
     });
@@ -228,6 +232,7 @@ export async function* runTablesQuery(
       id: action.id,
       params: action.params as DustAppParameters,
       output: action.output as Record<string, string | number | boolean>,
+      functionCallId: action.functionCallId,
       agentMessageId: action.agentMessageId,
       step: action.step,
     }),
@@ -363,6 +368,7 @@ export async function* runTablesQuery(
             id: action.id,
             params: action.params as DustAppParameters,
             output: tmpOutput as Record<string, string | number | boolean>,
+            functionCallId: action.functionCallId,
             agentMessageId: agentMessage.id,
             step: action.step,
           }),
@@ -392,6 +398,7 @@ export async function* runTablesQuery(
       id: action.id,
       params: action.params as DustAppParameters,
       output: action.output as Record<string, string | number | boolean>,
+      functionCallId: action.functionCallId,
       agentMessageId: action.agentMessageId,
       step: action.step,
     }),

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -179,7 +179,7 @@ export async function* runMultiActionsAgentLoop(
             },
             "[ASSISTANT_TRACE] Action inputs generation"
           );
-          const { action, inputs, specification } = event;
+          const { action, inputs, functionCallId, specification } = event;
           const actionEventStream = runAction(auth, {
             configuration: configuration,
             actionConfiguration: action,
@@ -188,6 +188,7 @@ export async function* runMultiActionsAgentLoop(
             agentMessage,
             inputs,
             specification,
+            functionCallId,
             step: i,
           });
           for await (const actionEvent of actionEventStream) {
@@ -388,10 +389,12 @@ export async function* runMultiActionsAgent(
   const { eventStream } = res.value;
 
   const output: {
+    id: string | null;
     name: string | null;
     arguments: Record<string, string | boolean | number> | null;
     generation: string | null;
   } = {
+    id: null,
     name: null,
     arguments: null,
     generation: null,
@@ -510,6 +513,9 @@ export async function* runMultiActionsAgent(
 
         if (event.content.block_name === "OUTPUT" && e.value) {
           const v = e.value as any;
+          if ("id" in v) {
+            output.id = v.id;
+          }
           if ("name" in v) {
             output.name = v.name;
           }
@@ -567,6 +573,7 @@ export async function* runMultiActionsAgent(
     created: Date.now(),
     action,
     inputs: output.arguments,
+    functionCallId: output.id,
     specification: spec,
   } satisfies AgentActionEvent;
   return;
@@ -582,6 +589,7 @@ async function* runAction(
     agentMessage,
     inputs,
     specification,
+    functionCallId,
     step,
   }: {
     configuration: AgentConfigurationType;
@@ -591,6 +599,7 @@ async function* runAction(
     agentMessage: AgentMessageType;
     inputs: Record<string, string | boolean | number>;
     specification: AgentActionSpecification | null;
+    functionCallId: string | null;
     step: number;
   }
 ): AsyncGenerator<
@@ -684,6 +693,7 @@ async function* runAction(
       agentMessage,
       spec: specification,
       rawInputs: inputs,
+      functionCallId,
       step,
     });
 

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -625,6 +625,7 @@ async function* runAction(
       conversation,
       agentMessage,
       rawInputs: inputs,
+      functionCallId,
       step,
       refsOffset: existingRefsCount,
     });
@@ -742,6 +743,7 @@ async function* runAction(
       conversation,
       agentMessage,
       rawInputs: inputs,
+      functionCallId,
       step,
     });
 
@@ -788,6 +790,7 @@ async function* runAction(
       userMessage,
       agentMessage,
       rawInputs: inputs,
+      functionCallId,
       step,
     });
 

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -320,6 +320,7 @@ export async function renderConversationForModelMultiActions({
           assertNever(action);
         }
       }
+
       if (function_messages.length > 0) {
         messages.unshift(...function_messages);
       }

--- a/front/lib/api/assistant/legacy_agent.ts
+++ b/front/lib/api/assistant/legacy_agent.ts
@@ -445,6 +445,7 @@ async function* runAction(
       agentMessage,
       spec: specRes.value,
       rawInputs,
+      functionCallId: null,
       step,
     });
 

--- a/front/lib/api/assistant/legacy_agent.ts
+++ b/front/lib/api/assistant/legacy_agent.ts
@@ -399,6 +399,7 @@ async function* runAction(
       conversation,
       agentMessage,
       rawInputs,
+      functionCallId: null,
       step,
     });
 
@@ -494,6 +495,7 @@ async function* runAction(
       conversation,
       agentMessage,
       rawInputs,
+      functionCallId: null,
       step,
     });
 
@@ -540,6 +542,7 @@ async function* runAction(
       userMessage,
       agentMessage,
       rawInputs,
+      functionCallId: null,
       step,
     });
 

--- a/front/lib/models/assistant/actions/dust_app_run.ts
+++ b/front/lib/models/assistant/actions/dust_app_run.ts
@@ -111,6 +111,8 @@ export class AgentDustAppRunAction extends Model<
 
   declare params: DustAppParameters;
   declare output: unknown | null;
+  declare functionCallId: string | null;
+
   declare step: number;
   declare agentMessageId: ForeignKey<AgentMessage["id"]>;
 }
@@ -149,13 +151,16 @@ AgentDustAppRunAction.init(
       type: DataTypes.STRING,
       allowNull: false,
     },
-
     params: {
       type: DataTypes.JSONB,
       allowNull: false,
     },
     output: {
       type: DataTypes.JSONB,
+      allowNull: true,
+    },
+    functionCallId: {
+      type: DataTypes.STRING,
       allowNull: true,
     },
     step: {

--- a/front/lib/models/assistant/actions/process.ts
+++ b/front/lib/models/assistant/actions/process.ts
@@ -138,6 +138,7 @@ export class AgentProcessAction extends Model<
 
   declare schema: ProcessSchemaPropertyType[];
   declare outputs: ProcessActionOutputsType | null;
+  declare functionCallId: string | null;
 
   declare step: number;
 
@@ -178,6 +179,10 @@ AgentProcessAction.init(
     },
     outputs: {
       type: DataTypes.JSONB,
+      allowNull: true,
+    },
+    functionCallId: {
+      type: DataTypes.STRING,
       allowNull: true,
     },
     step: {

--- a/front/lib/models/assistant/actions/retrieval.ts
+++ b/front/lib/models/assistant/actions/retrieval.ts
@@ -156,6 +156,9 @@ export class AgentRetrievalAction extends Model<
   declare relativeTimeFrameDuration: number | null;
   declare relativeTimeFrameUnit: TimeframeUnit | null;
   declare topK: number;
+
+  declare functionCallId: string | null;
+
   declare agentMessageId: ForeignKey<AgentMessage["id"]>;
   declare step: number;
 }
@@ -195,6 +198,10 @@ AgentRetrievalAction.init(
     topK: {
       type: DataTypes.INTEGER,
       allowNull: false,
+    },
+    functionCallId: {
+      type: DataTypes.STRING,
+      allowNull: true,
     },
     step: {
       type: DataTypes.INTEGER,

--- a/front/lib/models/assistant/actions/tables_query.ts
+++ b/front/lib/models/assistant/actions/tables_query.ts
@@ -168,6 +168,8 @@ export class AgentTablesQueryAction extends Model<
 
   declare params: unknown | null;
   declare output: unknown | null;
+  declare functionCallId: string | null;
+
   declare agentMessageId: ForeignKey<AgentMessage["id"]>;
 
   declare step: number;
@@ -202,6 +204,10 @@ AgentTablesQueryAction.init(
     },
     output: {
       type: DataTypes.JSONB,
+      allowNull: true,
+    },
+    functionCallId: {
+      type: DataTypes.STRING,
       allowNull: true,
     },
     step: {

--- a/types/src/front/assistant/actions/dust_app_run.ts
+++ b/types/src/front/assistant/actions/dust_app_run.ts
@@ -31,5 +31,6 @@ export interface DustAppRunActionType extends BaseAction {
     status: "running" | "succeeded" | "errored";
   } | null;
   output: unknown | null;
+  functionCallId: string | null;
   step: number;
 }

--- a/types/src/front/assistant/actions/process.ts
+++ b/types/src/front/assistant/actions/process.ts
@@ -84,5 +84,6 @@ export type ProcessActionType = {
   };
   schema: ProcessSchemaPropertyType[];
   outputs: ProcessActionOutputsType | null;
+  functionCallId: string | null;
   step: number;
 };

--- a/types/src/front/assistant/actions/retrieval.ts
+++ b/types/src/front/assistant/actions/retrieval.ts
@@ -98,6 +98,7 @@ export type RetrievalActionType = {
     query: string | null;
     topK: number;
   };
+  functionCallId: string | null;
   documents: RetrievalDocumentType[] | null;
   step: number;
 };

--- a/types/src/front/assistant/actions/tables_query.ts
+++ b/types/src/front/assistant/actions/tables_query.ts
@@ -21,6 +21,7 @@ export interface TablesQueryActionType extends BaseAction {
   id: ModelId;
   params: DustAppParameters;
   output: Record<string, string | number | boolean> | null;
+  functionCallId: string | null;
   agentMessageId: ModelId;
   step: number;
 }

--- a/types/src/front/lib/actions/registry.ts
+++ b/types/src/front/lib/actions/registry.ts
@@ -228,7 +228,7 @@ export const DustProdActionRegistry = createActionRegistry({
       workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
       appId: "0e9889c787",
       appHash:
-        "a1dfbf2c9e59f5b9a5b05e3729eea064dd394c35f112dfa080b6573fdfdab229",
+        "8543925944941d3b363f7ea912efe560b073a4b2fcfac4e952724ff31700abed",
     },
     config: {
       MODEL: {

--- a/types/src/front/lib/api/assistant/agent.ts
+++ b/types/src/front/lib/api/assistant/agent.ts
@@ -94,4 +94,5 @@ export type AgentActionEvent = {
   action: AgentActionConfigurationType;
   inputs: Record<string, string | boolean | number>;
   specification: AgentActionSpecification | null;
+  functionCallId: string | null;
 };


### PR DESCRIPTION
## Description

https://github.com/dust-tt/dust/issues/5040
This PR changes a bit the code to store the function call id on actions. 

Done in this PR: 
- [x] Edit the [Dust app](https://dust.tt/w/78bda07b39/a/0e9889c787) to return the function_call_id on the output block.
- [x] Add a new column `functionCallId` to all our action run models: `AgentTablesQueryAction`, `AgentRetrievalAction`, `DustAppRunActionType` & `AgentProcessAction`. 
- [x] Propagate the function call id from the Dust app output to where we save it on db. 
- [x] On `renderConversationForModelMultiActions`, retrieve the functionCallId from the new column or keep the fallback that we add before, based on the action id.    


**How does it work?**

`runMultiActionsAgent` calls the multi-actions Dust app that returns the id of the function call along with their name and arguments, which yields `"agent_action"` with a new param `functionCallId`.

This even is listened on `runMultiActionsAgentLoop` that will call `runAction` with the added param `functionCallId`.

On `runAction`, for each action `runRetrieval`/`runDustApp`/`runTablesQuery`/`runProcess` we add the param `functionCallId` that is used to create the related run model with the field `functionCallId` set.

## Risk

Low since not rolled out. 
Can be rolled back. 

## Deploy Plan

- Deploy prodbox, run init_db to create the new columns.
- Deploy Front. 
