### PR TITLE
chore: add script and WF to scrub old churned workspaces

### DIFF
--- a/front/migrations/20240515_scrub_workspaces.ts
+++ b/front/migrations/20240515_scrub_workspaces.ts
@@ -1,0 +1,74 @@
+import _ from "lodash";
+import { Op } from "sequelize";
+
+import { Authenticator } from "@app/lib/auth";
+import { Subscription } from "@app/lib/models/plan";
+import { Workspace } from "@app/lib/models/workspace";
+import logger from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+import { launchImmediateWorkspaceScrubWorkflow } from "@app/temporal/scrub_workspace/client";
+
+const scrubWorkspaces = async (execute: boolean) => {
+  const endedSubs = await Subscription.findAll({
+    where: {
+      // end date at least 14 days ago
+      endDate: {
+        [Op.lt]: new Date(new Date().getTime() - 14 * 24 * 60 * 60 * 1000),
+      },
+    },
+  });
+
+  const workspaces = await Workspace.findAll({
+    where: {
+      id: endedSubs.map((s) => s.workspaceId),
+    },
+  });
+
+  const allSubsByWorkspaceId = _.groupBy(
+    await Subscription.findAll({
+      where: {
+        workspaceId: workspaces.map((w) => w.id),
+      },
+    }),
+    (s) => s.workspaceId.toString()
+  );
+
+  const chunks = _.chunk(workspaces, 16);
+  let scrubbed = 0;
+
+  for (const c of chunks) {
+    await Promise.all(
+      c.map(async (w) => {
+        const subs = allSubsByWorkspaceId[w.id.toString()] ?? [];
+
+        if (
+          subs.some(
+            (s) =>
+              !s.endDate ||
+              s.endDate >
+                new Date(new Date().getTime() - 14 * 24 * 60 * 60 * 1000)
+          )
+        ) {
+          return;
+        }
+
+        const auth = await Authenticator.internalAdminForWorkspace(w.sId);
+        if (auth.isUpgraded()) {
+          return;
+        }
+
+        logger.info({ workspaceId: w.sId }, "Scrubbing workspace");
+        scrubbed++;
+        if (execute) {
+          await launchImmediateWorkspaceScrubWorkflow({ workspaceId: w.sId });
+        }
+      })
+    );
+  }
+
+  logger.info({ scrubbed }, "Scrubbed workspaces");
+};
+
+makeScript({}, async ({ execute }) => {
+  await scrubWorkspaces(execute);
+});

--- a/front/temporal/scrub_workspace/workflows.ts
+++ b/front/temporal/scrub_workspace/workflows.ts
@@ -51,3 +51,11 @@ export async function scheduleWorkspaceScrubWorkflowV2({
 }): Promise<boolean> {
   return scheduleWorkspaceScrubWorkflow({ workspaceId });
 }
+
+export async function immediateWorkspaceScrubWorkflow({
+  workspaceId,
+}: {
+  workspaceId: string;
+}): Promise<void> {
+  await scrubWorkspaceData({ workspaceId });
+}


### PR DESCRIPTION
## Description

Due to the `isUpgraded` bug fixed in https://github.com/dust-tt/dust/pull/5063, the workspace scrub workflow probably never actually scrubbed anything. 

We need to go back and scrub all of these workspaces. Here's a script to do it.


## Risk

Unbelievably risky. Will dry-run, and manually check a many many workspaces to convince myself this is doing the right thing.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
