### PR TITLE
feat: allow toggling multi-actions mode

### DIFF
--- a/front/components/assistant_builder/server_side_props_helpers.ts
+++ b/front/components/assistant_builder/server_side_props_helpers.ts
@@ -15,7 +15,6 @@ import {
   isProcessConfiguration,
   isRetrievalConfiguration,
   isTablesQueryConfiguration,
-  removeNulls,
 } from "@dust-tt/types";
 
 import type {
@@ -31,19 +30,16 @@ import {
   getDefaultTablesQueryActionConfiguration,
 } from "@app/components/assistant_builder/types";
 import { tableKey } from "@app/lib/client/tables_query";
-import { deprecatedGetFirstActionConfiguration } from "@app/lib/deprecated_action_configurations";
 import logger from "@app/logger/logger";
 
 export async function buildInitialActions({
   dataSourcesByName,
   dustApps,
   configuration,
-  multiActionsMode,
 }: {
   dataSourcesByName: Record<string, DataSourceType>;
   dustApps: AppType[];
   configuration: AgentConfigurationType | TemplateAgentConfigurationType;
-  multiActionsMode: boolean;
 }): Promise<AssistantBuilderActionConfiguration[]> {
   const coreAPI = new CoreAPI(logger);
 
@@ -105,9 +101,7 @@ export async function buildInitialActions({
     return dataSourceConfigurations;
   };
 
-  const actions = !multiActionsMode
-    ? removeNulls([deprecatedGetFirstActionConfiguration(configuration)])
-    : configuration.actions;
+  const actions = configuration.actions;
 
   const builderActions: AssistantBuilderActionConfiguration[] = [];
 

--- a/front/pages/w/[wId]/builder/assistants/new.tsx
+++ b/front/pages/w/[wId]/builder/assistants/new.tsx
@@ -54,7 +54,8 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   flow: BuilderFlow;
   baseUrl: string;
   templateId: string | null;
-  multiActionsMode: boolean;
+  multiActionsEnabled: boolean;
+  multiActionsAllowed: boolean;
 }>(async (context, auth) => {
   const owner = auth.workspace();
   const plan = auth.plan();
@@ -65,10 +66,9 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     };
   }
 
-  let multiActionsMode = context.query.multi_actions === "true";
-  if (multiActionsMode && !owner.flags.includes("multi_actions")) {
-    multiActionsMode = false;
-  }
+  const multiActionsAllowed = owner.flags.includes("multi_actions");
+  const multiActionsEnabled =
+    multiActionsAllowed && context.query.multi_actions === "true";
 
   const allDataSources = await getDataSources(auth);
   const allDustApps = await getApps(auth);
@@ -118,7 +118,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
         dataSourcesByName,
         dustApps: allDustApps,
         configuration,
-        multiActionsMode,
       })
     : [];
 
@@ -135,7 +134,8 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       flow,
       baseUrl: config.getAppUrl(),
       templateId,
-      multiActionsMode,
+      multiActionsAllowed,
+      multiActionsEnabled,
     },
   };
 });
@@ -152,7 +152,8 @@ export default function CreateAssistant({
   flow,
   baseUrl,
   templateId,
-  multiActionsMode,
+  multiActionsAllowed,
+  multiActionsEnabled,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const { assistantTemplate } = useAssistantTemplate({
     templateId,
@@ -237,7 +238,8 @@ export default function CreateAssistant({
       defaultIsEdited={true}
       baseUrl={baseUrl}
       defaultTemplate={assistantTemplate}
-      multiActionsMode={multiActionsMode}
+      multiActionsAllowed={multiActionsAllowed}
+      multiActionsEnabled={multiActionsEnabled}
     />
   );
 }

--- a/front/pages/w/[wId]/builder/assistants/new.tsx
+++ b/front/pages/w/[wId]/builder/assistants/new.tsx
@@ -54,7 +54,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   flow: BuilderFlow;
   baseUrl: string;
   templateId: string | null;
-  multiActionsEnabled: boolean;
   multiActionsAllowed: boolean;
 }>(async (context, auth) => {
   const owner = auth.workspace();
@@ -65,10 +64,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       notFound: true,
     };
   }
-
-  const multiActionsAllowed = owner.flags.includes("multi_actions");
-  const multiActionsEnabled =
-    multiActionsAllowed && context.query.multi_actions === "true";
 
   const allDataSources = await getDataSources(auth);
   const allDustApps = await getApps(auth);
@@ -113,6 +108,8 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     configuration = agentConfigRes.value;
   }
 
+  const multiActionsAllowed = owner.flags.includes("multi_actions");
+
   const actions = configuration
     ? await buildInitialActions({
         dataSourcesByName,
@@ -135,7 +132,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       baseUrl: config.getAppUrl(),
       templateId,
       multiActionsAllowed,
-      multiActionsEnabled,
     },
   };
 });
@@ -153,7 +149,6 @@ export default function CreateAssistant({
   baseUrl,
   templateId,
   multiActionsAllowed,
-  multiActionsEnabled,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const { assistantTemplate } = useAssistantTemplate({
     templateId,
@@ -239,7 +234,7 @@ export default function CreateAssistant({
       baseUrl={baseUrl}
       defaultTemplate={assistantTemplate}
       multiActionsAllowed={multiActionsAllowed}
-      multiActionsEnabled={multiActionsEnabled}
+      multiActionsEnabled={false}
     />
   );
 }


### PR DESCRIPTION
## Description

Kind of painful  to have to manually add `multi_actions=true` in the URL bar. The goal here is to increase internal adoption

<img width="1006" alt="Screenshot 2024-05-15 at 15 25 04" src="https://github.com/dust-tt/dust/assets/14199823/ecafdfac-46a3-49d7-9a18-a7823ea05c58">

<img width="1059" alt="Screenshot 2024-05-15 at 15 25 12" src="https://github.com/dust-tt/dust/assets/14199823/5fbb1346-d9e3-43b0-afcd-7a4374c1b0b4">

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
