### PR TITLE
Use BaseAction class for TablesQueryAction

### DIFF
--- a/front/lib/api/assistant/actions/tables_query.ts
+++ b/front/lib/api/assistant/actions/tables_query.ts
@@ -36,7 +36,7 @@ interface TablesQueryActionBlob {
   step: number;
 }
 
-export class TablesQuerAction extends BaseAction {
+export class TablesQueryAction extends BaseAction {
   readonly agentMessageId: ModelId;
   readonly params: DustAppParameters;
   readonly output: Record<string, string | number | boolean> | null;
@@ -106,7 +106,7 @@ export async function tableQueryTypesFromAgentMessageIds(
     },
   });
   return actions.map((action) => {
-    return new TablesQuerAction({
+    return new TablesQueryAction({
       id: action.id,
       params: action.params as DustAppParameters,
       output: action.output as Record<string, string | number | boolean>,
@@ -224,7 +224,7 @@ export async function* runTablesQuery(
     created: Date.now(),
     configurationId: configuration.sId,
     messageId: agentMessage.sId,
-    action: new TablesQuerAction({
+    action: new TablesQueryAction({
       id: action.id,
       params: action.params as DustAppParameters,
       output: action.output as Record<string, string | number | boolean>,
@@ -359,7 +359,7 @@ export async function* runTablesQuery(
           created: Date.now(),
           configurationId: configuration.sId,
           messageId: agentMessage.sId,
-          action: new TablesQuerAction({
+          action: new TablesQueryAction({
             id: action.id,
             params: action.params as DustAppParameters,
             output: tmpOutput as Record<string, string | number | boolean>,
@@ -388,7 +388,7 @@ export async function* runTablesQuery(
     created: Date.now(),
     configurationId: configuration.sId,
     messageId: agentMessage.sId,
-    action: new TablesQuerAction({
+    action: new TablesQueryAction({
       id: action.id,
       params: action.params as DustAppParameters,
       output: action.output as Record<string, string | number | boolean>,

--- a/front/lib/api/assistant/actions/tables_query.ts
+++ b/front/lib/api/assistant/actions/tables_query.ts
@@ -16,62 +16,82 @@ import type {
   TablesQueryParamsEvent,
   TablesQuerySuccessEvent,
 } from "@dust-tt/types";
-import { cloneBaseConfig, DustProdActionRegistry, Ok } from "@dust-tt/types";
+import {
+  BaseAction,
+  cloneBaseConfig,
+  DustProdActionRegistry,
+  Ok,
+} from "@dust-tt/types";
 
 import { runActionStreamed } from "@app/lib/actions/server";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentTablesQueryAction } from "@app/lib/models/assistant/actions/tables_query";
 import logger from "@app/logger/logger";
 
-/**
- * Model rendering of TableQueries.
- */
-
-export function renderTablesQueryActionForModel(
-  action: TablesQueryActionType
-): ModelMessageType {
-  let content = "";
-  if (!action.output) {
-    throw new Error(
-      "Output not set on TablesQuery action; execution is likely not finished."
-    );
-  }
-  content += `OUTPUT:\n`;
-  content += `${JSON.stringify(action.output, null, 2)}\n`;
-
-  return {
-    role: "action" as const,
-    name: "query_tables",
-    content,
-  };
+interface TablesQueryActionBlob {
+  id: ModelId; // AgentTablesQueryAction.
+  agentMessageId: ModelId;
+  params: DustAppParameters;
+  output: Record<string, string | number | boolean> | null;
+  step: number;
 }
 
-export function rendeTablesQueryActionFunctionCall(
-  action: TablesQueryActionType
-): FunctionCallType {
-  return {
-    id: `call_${action.id.toString()}`, // @todo Daph replace with the actual tool id
-    name: "query_tables",
-    arguments: JSON.stringify(action.params),
-  };
-}
-export function renderTablesQueryActionForMultiActionsModel(
-  action: TablesQueryActionType
-): FunctionMessageTypeModel {
-  let content = "";
-  if (!action.output) {
-    throw new Error(
-      "Output not set on TablesQuery action; execution is likely not finished."
-    );
-  }
-  content += `OUTPUT:\n`;
-  content += `${JSON.stringify(action.output, null, 2)}\n`;
+export class TablesQuerAction extends BaseAction {
+  readonly agentMessageId: ModelId;
+  readonly params: DustAppParameters;
+  readonly output: Record<string, string | number | boolean> | null;
+  readonly step: number;
 
-  return {
-    role: "function" as const,
-    function_call_id: `call_${action.id.toString()}`, // @todo Daph replace with the actual tool id
-    content,
-  };
+  constructor(blob: TablesQueryActionBlob) {
+    super(blob.id, "tables_query_action");
+
+    this.agentMessageId = blob.agentMessageId;
+    this.params = blob.params;
+    this.output = blob.output;
+    this.step = blob.step;
+  }
+
+  renderForModel(): ModelMessageType {
+    let content = "";
+    if (!this.output) {
+      throw new Error(
+        "Output not set on TablesQuery action; execution is likely not finished."
+      );
+    }
+    content += `OUTPUT:\n`;
+    content += `${JSON.stringify(this.output, null, 2)}\n`;
+
+    return {
+      role: "action" as const,
+      name: "query_tables",
+      content,
+    };
+  }
+
+  renderForFunctionCall(): FunctionCallType {
+    return {
+      id: `call_${this.id.toString()}`, // @todo Daph replace with the actual tool id
+      name: "query_tables",
+      arguments: JSON.stringify(this.params),
+    };
+  }
+
+  renderForMultiActionsModel(): FunctionMessageTypeModel {
+    let content = "";
+    if (!this.output) {
+      throw new Error(
+        "Output not set on TablesQuery action; execution is likely not finished."
+      );
+    }
+    content += `OUTPUT:\n`;
+    content += `${JSON.stringify(this.output, null, 2)}\n`;
+
+    return {
+      role: "function" as const,
+      function_call_id: `call_${this.id.toString()}`, // @todo Daph replace with the actual tool id
+      content,
+    };
+  }
 }
 
 // Internal interface for the retrieval and rendering of a TableQuery action. This should not be
@@ -86,14 +106,13 @@ export async function tableQueryTypesFromAgentMessageIds(
     },
   });
   return actions.map((action) => {
-    return {
+    return new TablesQuerAction({
       id: action.id,
-      type: "tables_query_action",
       params: action.params as DustAppParameters,
       output: action.output as Record<string, string | number | boolean>,
       agentMessageId: action.agentMessageId,
       step: action.step,
-    } satisfies TablesQueryActionType;
+    });
   });
 }
 
@@ -205,14 +224,13 @@ export async function* runTablesQuery(
     created: Date.now(),
     configurationId: configuration.sId,
     messageId: agentMessage.sId,
-    action: {
+    action: new TablesQuerAction({
       id: action.id,
-      type: "tables_query_action",
       params: action.params as DustAppParameters,
       output: action.output as Record<string, string | number | boolean>,
       agentMessageId: action.agentMessageId,
       step: action.step,
-    },
+    }),
   };
 
   // Generating configuration
@@ -341,14 +359,13 @@ export async function* runTablesQuery(
           created: Date.now(),
           configurationId: configuration.sId,
           messageId: agentMessage.sId,
-          action: {
+          action: new TablesQuerAction({
             id: action.id,
-            type: "tables_query_action",
             params: action.params as DustAppParameters,
             output: tmpOutput as Record<string, string | number | boolean>,
             agentMessageId: agentMessage.id,
             step: action.step,
-          },
+          }),
         };
       }
 
@@ -371,14 +388,13 @@ export async function* runTablesQuery(
     created: Date.now(),
     configurationId: configuration.sId,
     messageId: agentMessage.sId,
-    action: {
+    action: new TablesQuerAction({
       id: action.id,
-      type: "tables_query_action",
       params: action.params as DustAppParameters,
       output: action.output as Record<string, string | number | boolean>,
       agentMessageId: action.agentMessageId,
       step: action.step,
-    },
+    }),
   };
   return;
 }

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -25,7 +25,6 @@ import {
   isProcessActionType,
   isRetrievalActionType,
   isRetrievalConfiguration,
-  isTablesQueryActionType,
   isUserMessageType,
   Ok,
   removeNulls,
@@ -45,11 +44,6 @@ import {
   retrievalMetaPrompt,
   retrievalMetaPromptMutiActions,
 } from "@app/lib/api/assistant/actions/retrieval";
-import {
-  renderTablesQueryActionForModel,
-  renderTablesQueryActionForMultiActionsModel,
-  rendeTablesQueryActionFunctionCall,
-} from "@app/lib/api/assistant/actions/tables_query";
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
 import { getSupportedModelConfig, isLargeModel } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
@@ -116,8 +110,6 @@ export async function renderConversationForModel({
             foundRetrieval = true;
             messages.unshift(renderRetrievalActionForModel(action));
           }
-        } else if (isTablesQueryActionType(action)) {
-          messages.unshift(renderTablesQueryActionForModel(action));
         } else if (isProcessActionType(action)) {
           messages.unshift(renderProcessActionForModel(action));
         } else if (isBaseActionClass(action)) {
@@ -316,11 +308,6 @@ export async function renderConversationForModelMultiActions({
             renderRetrievalActionForMultiActionsModel(action)
           );
           function_calls.unshift(rendeRetrievalActionFunctionCall(action));
-        } else if (isTablesQueryActionType(action)) {
-          function_messages.unshift(
-            renderTablesQueryActionForMultiActionsModel(action)
-          );
-          function_calls.unshift(rendeTablesQueryActionFunctionCall(action));
         } else if (isProcessActionType(action)) {
           function_messages.unshift(
             renderProcessActionForMultiActionsModel(action)

--- a/types/src/front/assistant/actions/tables_query.ts
+++ b/types/src/front/assistant/actions/tables_query.ts
@@ -1,5 +1,6 @@
 import { DustAppParameters } from "../../../front/assistant/actions/dust_app_run";
 import { ModelId } from "../../../shared/model_id";
+import { BaseAction } from "../../lib/api/assistant/actions";
 
 export type TablesQueryConfigurationType = {
   id: ModelId;
@@ -16,12 +17,10 @@ export type TablesQueryConfigurationType = {
   forceUseAtIteration: number | null;
 };
 
-export type TablesQueryActionType = {
+export interface TablesQueryActionType extends BaseAction {
   id: ModelId;
-  type: "tables_query_action";
-
   params: DustAppParameters;
   output: Record<string, string | number | boolean> | null;
   agentMessageId: ModelId;
   step: number;
-};
+}

--- a/types/src/front/lib/api/assistant/actions/index.ts
+++ b/types/src/front/lib/api/assistant/actions/index.ts
@@ -5,7 +5,7 @@ import {
   ModelMessageType,
 } from "../generation";
 
-type BaseActionType = "dust_app_run_action";
+type BaseActionType = "dust_app_run_action" | "tables_query_action";
 
 export abstract class BaseAction {
   readonly id: ModelId;


### PR DESCRIPTION
## Description

Following https://github.com/dust-tt/dust/pull/5043/files
Use our new BaseAction class for Table Query action. 

## Risk

Breaks the TablesQuery Action. 
Can be rolled back.

## Deploy Plan

Deploy Front. 
