### PR TITLE
Slack bot: honor user when the bot is posting as a user

### DIFF
--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -182,6 +182,8 @@ async function botAnswerMessage(
   const slackClient = await getSlackClient(connector.id);
 
   let slackUserInfo: SlackUserInfo | null = null;
+  // The order is important here because we want to prioritize the user id over the bot id.
+  // When a bot sends a message "as a user", we want to honor the user and not the bot.
   if (slackUserId) {
     slackUserInfo = await getSlackUserInfo(slackClient, slackUserId);
   } else if (slackBotId) {

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -182,10 +182,10 @@ async function botAnswerMessage(
   const slackClient = await getSlackClient(connector.id);
 
   let slackUserInfo: SlackUserInfo | null = null;
-  if (slackBotId) {
-    slackUserInfo = await getSlackBotInfo(slackClient, slackBotId);
-  } else if (slackUserId) {
+  if (slackUserId) {
     slackUserInfo = await getSlackUserInfo(slackClient, slackUserId);
+  } else if (slackBotId) {
+    slackUserInfo = await getSlackBotInfo(slackClient, slackBotId);
   }
 
   if (!slackUserInfo) {


### PR DESCRIPTION
## Description

A Slack bot can post a message as a bot and as the user who connected the bot to Slack.
When the message is posted as a user, we have both a `slackUserId` and a `botUserId`, so this PR honors the userId instead of the bot id in such cases.
This makes more sense because that way we have the Slack user behind the bot, which correspond to what people see on Slack.

Before the [recent changes](https://github.com/dust-tt/dust/pull/5064) on slack bots, we were just honoring it as a user without even knowing it was coming from a bot OAuth token.

You can see such cases with one of our customer [here](https://dust4ai.slack.com/archives/C05PDGP8JMA/p1715783707840789?thread_ts=1715781409.742199&cid=C05PDGP8JMA).

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
