### PR TITLE
Add bash script to compute Sequelize diff after model changes

### DIFF
--- a/front/lib/resources/storage/index.ts
+++ b/front/lib/resources/storage/index.ts
@@ -6,6 +6,12 @@ import logger from "@app/logger/logger";
 
 const acquireAttempts = new WeakMap();
 
+const { DB_LOGGING_ENABLED = false } = process.env;
+
+function sequelizeLogger(message: string) {
+  console.log(message.replace("Executing (default): ", ""));
+}
+
 export const frontSequelize = new Sequelize(
   dbConfig.getRequiredFrontDatabaseURI(),
   {
@@ -13,7 +19,7 @@ export const frontSequelize = new Sequelize(
       // Default is 5.
       max: isDevelopment() ? 5 : 30,
     },
-    logging: false,
+    logging: isDevelopment() && DB_LOGGING_ENABLED ? sequelizeLogger : false,
     hooks: {
       beforePoolAcquire: (options) => {
         acquireAttempts.set(options, Date.now());

--- a/front/package.json
+++ b/front/package.json
@@ -10,7 +10,8 @@
     "tsc": "tsc",
     "test": "jest",
     "coverage": "jest --coverage",
-    "initdb": "./admin/init_db.sh"
+    "initdb": "./admin/init_db.sh",
+    "diff-db-migration": "bash run_db_migration_diff.sh"
   },
   "dependencies": {
     "@amplitude/ampli": "^1.35.0",

--- a/front/run_db_migration_diff.sh
+++ b/front/run_db_migration_diff.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Stash any uncommitted changes.
+echo "Stashing uncommitted changes..."
+git stash push -m "Temp stash for running diff"
+
+# Get the current branch name.
+original_branch=$(git symbolic-ref --short HEAD)
+echo "Original branch: $original_branch"
+
+# Checkout main branch and run command.
+echo "Checking out main branch..."
+git checkout main
+echo "Running command on main branch..."
+DB_LOGGING_ENABLED=true ./admin/init_db.sh --unsafe > main_output.txt
+
+# Checkout original branch and run command.
+echo "Checking out $original_branch branch..."
+git checkout $original_branch
+echo "Running command on $original_branch branch..."
+DB_LOGGING_ENABLED=true ./admin/init_db.sh --unsafe > current_output.txt
+
+# Pop the stash.
+echo "Restoring original changes..."
+git stash pop
+
+# Run diff.
+echo "Running diff..."
+diff main_output.txt current_output.txt
+
+# Clean up the output files.
+echo "Cleaning up temporary files..."
+rm main_output.txt current_output.txt
+

--- a/front/run_db_migration_diff.sh
+++ b/front/run_db_migration_diff.sh
@@ -26,7 +26,7 @@ git stash pop
 
 # Run diff.
 echo "Running diff..."
-diff main_output.txt current_output.txt
+diff --unified=0 main_output.txt current_output.txt
 
 # Clean up the output files.
 echo "Cleaning up temporary files..."

--- a/front/run_db_migration_diff.sh
+++ b/front/run_db_migration_diff.sh
@@ -12,13 +12,13 @@ echo "Original branch: $original_branch"
 echo "Checking out main branch..."
 git checkout main
 echo "Running command on main branch..."
-DB_LOGGING_ENABLED=true ./admin/init_db.sh --unsafe > main_output.txt
+NODE_ENV=development DB_LOGGING_ENABLED=true ./admin/init_db.sh --unsafe > main_output.txt
 
 # Checkout original branch and run command.
 echo "Checking out $original_branch branch..."
 git checkout $original_branch
 echo "Running command on $original_branch branch..."
-DB_LOGGING_ENABLED=true ./admin/init_db.sh --unsafe > current_output.txt
+NODE_ENV=development DB_LOGGING_ENABLED=true ./admin/init_db.sh --unsafe > current_output.txt
 
 # Pop the stash.
 echo "Restoring original changes..."


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Given the recent issues with Sequelize's black-box approach to model synchronization, and until we transition to a proper, versioned migration system, this PR introduces a small script. This script allows anyone to preview the SQL queries that Sequelize intends to execute locally.

The script isn't perfect, as it does trigger the actual `init_db` process, since Sequelize doesn't offer a dry-run option. However, IMO, it's a step forward, as it eliminates the need to wait patiently for the `init_db` command to complete without having any ideas of what is being run under the hood.

Example of an output:
```bash
--- main.txt	2024-05-15 19:31:52
+++ current.txt	2024-05-15 19:29:05
@@ -245,0 +246 @@
+ALTER TABLE "plans" ALTER COLUMN "createdAt" SET NOT NULL;ALTER TABLE "plans" ALTER COLUMN "createdAt" DROP DEFAULT;ALTER TABLE "plans" ALTER COLUMN "createdAt" TYPE VARCHAR(255);
@@ -265 +265,0 @@
-ALTER TABLE "plans" ALTER COLUMN "createdAt" SET NOT NULL;ALTER TABLE "plans" ALTER COLUMN "createdAt" DROP DEFAULT;ALTER TABLE "plans" ALTER COLUMN "createdAt" TYPE TIMESTAMP WITH TIME ZONE;
```

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
