### PR TITLE
Flav/handle gh request redirect count exceeded

### DIFF
--- a/connectors/src/connectors/github/lib/errors.ts
+++ b/connectors/src/connectors/github/lib/errors.ts
@@ -5,3 +5,13 @@ export function isGithubRequestErrorNotFound(
 ): error is RequestError {
   return error instanceof RequestError && error.status === 404;
 }
+
+export function isGithubRequestRedirectCountExceededError(
+  error: unknown
+): error is RequestError {
+  return (
+    error instanceof RequestError &&
+    error.status === 500 &&
+    error.message.includes("redirect count exceeded")
+  );
+}

--- a/connectors/src/connectors/github/lib/github_api.ts
+++ b/connectors/src/connectors/github/lib/github_api.ts
@@ -13,7 +13,10 @@ import type { Readable } from "stream";
 import { pipeline } from "stream/promises";
 import { extract } from "tar";
 
-import { isGithubRequestErrorNotFound } from "@connectors/connectors/github/lib/errors";
+import {
+  isGithubRequestErrorNotFound,
+  isGithubRequestRedirectCountExceededError,
+} from "@connectors/connectors/github/lib/errors";
 import type {
   DiscussionCommentNode,
   DiscussionNode,
@@ -196,34 +199,44 @@ export async function getIssue(
   installationId: string,
   repoName: string,
   login: string,
-  issueNumber: number
-): Promise<GithubIssue> {
+  issueNumber: number,
+  loggerArgs: Record<string, string | number>
+): Promise<GithubIssue | null> {
   const octokit = await getOctokit(installationId);
 
-  const issue = (
-    await octokit.rest.issues.get({
-      owner: login,
-      repo: repoName,
-      issue_number: issueNumber,
-    })
-  ).data;
+  try {
+    const issue = (
+      await octokit.rest.issues.get({
+        owner: login,
+        repo: repoName,
+        issue_number: issueNumber,
+      })
+    ).data;
 
-  return {
-    id: issue.id,
-    number: issue.number,
-    title: issue.title,
-    url: issue.html_url,
-    creator: issue.user
-      ? {
-          id: issue.user.id,
-          login: issue.user.login,
-        }
-      : null,
-    createdAt: new Date(issue.created_at),
-    updatedAt: new Date(issue.updated_at),
-    body: issue.body,
-    isPullRequest: !!issue.pull_request,
-  };
+    return {
+      id: issue.id,
+      number: issue.number,
+      title: issue.title,
+      url: issue.html_url,
+      creator: issue.user
+        ? {
+            id: issue.user.id,
+            login: issue.user.login,
+          }
+        : null,
+      createdAt: new Date(issue.created_at),
+      updatedAt: new Date(issue.updated_at),
+      body: issue.body,
+      isPullRequest: !!issue.pull_request,
+    };
+  } catch (err) {
+    if (isGithubRequestRedirectCountExceededError(err)) {
+      logger.info({ ...loggerArgs, err: err.message }, "Failed to get issue.");
+      return null;
+    }
+
+    throw err;
+  }
 }
 
 export async function getIssueCommentsPage(

--- a/connectors/src/connectors/github/lib/github_api.ts
+++ b/connectors/src/connectors/github/lib/github_api.ts
@@ -230,8 +230,10 @@ export async function getIssue(
       isPullRequest: !!issue.pull_request,
     };
   } catch (err) {
+    // Handle excessive redirection during issue retrieval by safely ignoring the issue.
     if (isGithubRequestRedirectCountExceededError(err)) {
       logger.info({ ...loggerArgs, err: err.message }, "Failed to get issue.");
+
       return null;
     }
 

--- a/connectors/src/connectors/github/temporal/activities.ts
+++ b/connectors/src/connectors/github/temporal/activities.ts
@@ -219,7 +219,7 @@ export async function githubUpsertIssueActivity(
 
   localLogger.info("Upserting GitHub issue.");
 
-  const renderedIssueBlob = await renderIssue(
+  const renderedIssueResult = await renderIssue(
     dataSourceConfig,
     installationId,
     repoName,
@@ -230,7 +230,7 @@ export async function githubUpsertIssueActivity(
   );
 
   // Silently skip the current issue if fetching fails.
-  if (!renderedIssueBlob) {
+  if (!renderedIssueResult) {
     localLogger.info("Skip upserting GitHub issue.");
     return;
   }
@@ -239,7 +239,7 @@ export async function githubUpsertIssueActivity(
     issue,
     updatedAtTimestamp,
     content: renderedIssue,
-  } = renderedIssueBlob;
+  } = renderedIssueResult;
 
   const documentId = getIssueDocumentId(repoId.toString(), issueNumber);
   const issueAuthor = renderGithubUser(issue.creator);

--- a/connectors/src/connectors/github/temporal/activities.ts
+++ b/connectors/src/connectors/github/temporal/activities.ts
@@ -108,13 +108,22 @@ async function renderIssue(
   issue: GithubIssueType;
   updatedAtTimestamp: number;
   content: CoreAPIDataSourceDocumentSection;
-}> {
+} | null> {
   const localLogger = logger.child({
     ...loggerArgs,
     issueNumber,
   });
 
-  const issue = await getIssue(installationId, repoName, login, issueNumber);
+  const issue = await getIssue(
+    installationId,
+    repoName,
+    login,
+    issueNumber,
+    loggerArgs
+  );
+  if (!issue) {
+    return null;
+  }
 
   const content = await renderDocumentTitleAndContent({
     dataSourceConfig,
@@ -210,11 +219,7 @@ export async function githubUpsertIssueActivity(
 
   localLogger.info("Upserting GitHub issue.");
 
-  const {
-    issue,
-    updatedAtTimestamp,
-    content: renderedIssue,
-  } = await renderIssue(
+  const renderedIssueBlob = await renderIssue(
     dataSourceConfig,
     installationId,
     repoName,
@@ -223,6 +228,18 @@ export async function githubUpsertIssueActivity(
     issueNumber,
     loggerArgs
   );
+
+  // Silently skip the current issue if fetching fails.
+  if (!renderedIssueBlob) {
+    localLogger.info("Skip upserting GitHub issue.");
+    return;
+  }
+
+  const {
+    issue,
+    updatedAtTimestamp,
+    content: renderedIssue,
+  } = renderedIssueBlob;
 
   const documentId = getIssueDocumentId(repoId.toString(), issueNumber);
   const issueAuthor = renderGithubUser(issue.creator);


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
We're currently encountering issues with a specific GitHub issue that we're unable to fetch successfully. This results in an infinite loop of redirections, ultimately causing a more extensive failure.

To address this, the current PR catches those types of errors when fetching a GitHub issue, which will effectively ignore the error. The problematic issue won't be updated or inserted into our database or core.

I'll be working on a follow-up PR to add a `skipReason` to the `GithubIssue` model with the necessary tooling.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
