### PR TITLE
"Store function_call_id in actions""

### DIFF
--- a/front/lib/api/assistant/actions/process.ts
+++ b/front/lib/api/assistant/actions/process.ts
@@ -80,7 +80,7 @@ export function renderProcessActionFunctionCall(
   action: ProcessActionType
 ): FunctionCallType {
   return {
-    id: `call_${action.id.toString()}`, // @todo Daph replace with the actual tool id
+    id: action.functionCallId ?? `call_${action.id.toString()}`,
     name: "process_data_sources",
     arguments: JSON.stringify(action.params),
   };
@@ -107,7 +107,7 @@ export function renderProcessActionForMultiActionsModel(
 
   return {
     role: "function" as const,
-    function_call_id: `call_${action.id.toString()}`, // @todo Daph replace with the actual tool id
+    function_call_id: action.functionCallId ?? `call_${action.id.toString()}`,
     content,
   };
 }
@@ -201,6 +201,7 @@ export async function processActionTypesFromAgentMessageIds(
       },
       schema: action.schema,
       outputs: action.outputs,
+      functionCallId: action.functionCallId,
       step: action.step,
     } satisfies ProcessActionType;
   });
@@ -224,6 +225,7 @@ export async function* runProcess(
     userMessage,
     agentMessage,
     rawInputs,
+    functionCallId,
     step,
   }: {
     configuration: AgentConfigurationType;
@@ -232,6 +234,7 @@ export async function* runProcess(
     userMessage: UserMessageType;
     agentMessage: AgentMessageType;
     rawInputs: Record<string, string | boolean | number>;
+    functionCallId: string | null;
     step: number;
   }
 ): AsyncGenerator<
@@ -275,6 +278,7 @@ export async function* runProcess(
     relativeTimeFrameUnit: relativeTimeFrame?.unit ?? null,
     processConfigurationId: actionConfiguration.sId,
     schema: actionConfiguration.schema,
+    functionCallId,
     agentMessageId: agentMessage.agentMessageId,
     step,
   });
@@ -296,6 +300,7 @@ export async function* runProcess(
       },
       schema: action.schema,
       outputs: null,
+      functionCallId: action.functionCallId,
       step: action.step,
     },
   };
@@ -485,6 +490,7 @@ export async function* runProcess(
       },
       schema: action.schema,
       outputs,
+      functionCallId: action.functionCallId,
       step: action.step,
     },
   };

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -165,7 +165,7 @@ export function rendeRetrievalActionFunctionCall(
   };
 
   return {
-    id: `call_${action.id.toString()}`, // @todo Daph replace with the actual tool id
+    id: action.functionCallId ?? `call_${action.id.toString()}`,
     name: "search_data_sources",
     arguments: JSON.stringify(params),
   };
@@ -204,7 +204,7 @@ export function renderRetrievalActionForMultiActionsModel(
 
   return {
     role: "function" as const,
-    function_call_id: `call_${action.id.toString()}`, // @todo Daph replace with the actual tool id
+    function_call_id: action.functionCallId ?? `call_${action.id.toString()}`,
     content,
   };
 }
@@ -423,6 +423,7 @@ export async function retrievalActionTypesFromAgentMessageIds(
         relativeTimeFrame,
         topK: action.topK,
       },
+      functionCallId: action.functionCallId,
       documents,
       step: action.step,
     });
@@ -493,6 +494,7 @@ export async function* runRetrieval(
     conversation,
     agentMessage,
     rawInputs,
+    functionCallId,
     step,
     refsOffset = 0,
   }: {
@@ -501,6 +503,7 @@ export async function* runRetrieval(
     conversation: ConversationType;
     agentMessage: AgentMessageType;
     rawInputs: Record<string, string | boolean | number>;
+    functionCallId: string | null;
     step: number;
     refsOffset?: number;
   }
@@ -573,6 +576,7 @@ export async function* runRetrieval(
     relativeTimeFrameUnit: relativeTimeFrame?.unit ?? null,
     topK,
     retrievalConfigurationId: actionConfiguration.sId,
+    functionCallId,
     agentMessageId: agentMessage.agentMessageId,
     step: step,
   });
@@ -592,6 +596,7 @@ export async function* runRetrieval(
         query,
         topK,
       },
+      functionCallId: action.functionCallId,
       documents: null,
       step: action.step,
     },
@@ -844,6 +849,7 @@ export async function* runRetrieval(
         query: query,
         topK,
       },
+      functionCallId: action.functionCallId,
       documents,
       step: action.step,
     },

--- a/front/lib/api/assistant/actions/tables_query.ts
+++ b/front/lib/api/assistant/actions/tables_query.ts
@@ -33,6 +33,7 @@ interface TablesQueryActionBlob {
   agentMessageId: ModelId;
   params: DustAppParameters;
   output: Record<string, string | number | boolean> | null;
+  functionCallId: string | null;
   step: number;
 }
 
@@ -40,6 +41,7 @@ export class TablesQueryAction extends BaseAction {
   readonly agentMessageId: ModelId;
   readonly params: DustAppParameters;
   readonly output: Record<string, string | number | boolean> | null;
+  readonly functionCallId: string | null;
   readonly step: number;
 
   constructor(blob: TablesQueryActionBlob) {
@@ -48,6 +50,7 @@ export class TablesQueryAction extends BaseAction {
     this.agentMessageId = blob.agentMessageId;
     this.params = blob.params;
     this.output = blob.output;
+    this.functionCallId = blob.functionCallId;
     this.step = blob.step;
   }
 
@@ -70,7 +73,7 @@ export class TablesQueryAction extends BaseAction {
 
   renderForFunctionCall(): FunctionCallType {
     return {
-      id: `call_${this.id.toString()}`, // @todo Daph replace with the actual tool id
+      id: this.functionCallId ?? `call_${this.id.toString()}`,
       name: "query_tables",
       arguments: JSON.stringify(this.params),
     };
@@ -88,7 +91,7 @@ export class TablesQueryAction extends BaseAction {
 
     return {
       role: "function" as const,
-      function_call_id: `call_${this.id.toString()}`, // @todo Daph replace with the actual tool id
+      function_call_id: this.functionCallId ?? `call_${this.id.toString()}`,
       content,
     };
   }
@@ -110,6 +113,7 @@ export async function tableQueryTypesFromAgentMessageIds(
       id: action.id,
       params: action.params as DustAppParameters,
       output: action.output as Record<string, string | number | boolean>,
+      functionCallId: action.functionCallId,
       agentMessageId: action.agentMessageId,
       step: action.step,
     });
@@ -172,6 +176,7 @@ export async function* runTablesQuery(
     conversation,
     agentMessage,
     rawInputs,
+    functionCallId,
     step,
   }: {
     configuration: AgentConfigurationType;
@@ -179,6 +184,7 @@ export async function* runTablesQuery(
     conversation: ConversationType;
     agentMessage: AgentMessageType;
     rawInputs: Record<string, string | boolean | number>;
+    functionCallId: string | null;
     step: number;
   }
 ): AsyncGenerator<
@@ -215,6 +221,7 @@ export async function* runTablesQuery(
     tablesQueryConfigurationId: configuration.sId,
     params: rawInputs,
     output,
+    functionCallId,
     agentMessageId: agentMessage.agentMessageId,
     step: step,
   });
@@ -228,6 +235,7 @@ export async function* runTablesQuery(
       id: action.id,
       params: action.params as DustAppParameters,
       output: action.output as Record<string, string | number | boolean>,
+      functionCallId: action.functionCallId,
       agentMessageId: action.agentMessageId,
       step: action.step,
     }),
@@ -363,6 +371,7 @@ export async function* runTablesQuery(
             id: action.id,
             params: action.params as DustAppParameters,
             output: tmpOutput as Record<string, string | number | boolean>,
+            functionCallId: action.functionCallId,
             agentMessageId: agentMessage.id,
             step: action.step,
           }),
@@ -392,6 +401,7 @@ export async function* runTablesQuery(
       id: action.id,
       params: action.params as DustAppParameters,
       output: action.output as Record<string, string | number | boolean>,
+      functionCallId: action.functionCallId,
       agentMessageId: action.agentMessageId,
       step: action.step,
     }),

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -320,6 +320,7 @@ export async function renderConversationForModelMultiActions({
           assertNever(action);
         }
       }
+
       if (function_messages.length > 0) {
         messages.unshift(...function_messages);
       }

--- a/front/lib/api/assistant/legacy_agent.ts
+++ b/front/lib/api/assistant/legacy_agent.ts
@@ -399,6 +399,7 @@ async function* runAction(
       conversation,
       agentMessage,
       rawInputs,
+      functionCallId: null,
       step,
     });
 
@@ -445,6 +446,7 @@ async function* runAction(
       agentMessage,
       spec: specRes.value,
       rawInputs,
+      functionCallId: null,
       step,
     });
 
@@ -493,6 +495,7 @@ async function* runAction(
       conversation,
       agentMessage,
       rawInputs,
+      functionCallId: null,
       step,
     });
 
@@ -539,6 +542,7 @@ async function* runAction(
       userMessage,
       agentMessage,
       rawInputs,
+      functionCallId: null,
       step,
     });
 

--- a/front/lib/models/assistant/actions/dust_app_run.ts
+++ b/front/lib/models/assistant/actions/dust_app_run.ts
@@ -111,6 +111,8 @@ export class AgentDustAppRunAction extends Model<
 
   declare params: DustAppParameters;
   declare output: unknown | null;
+  declare functionCallId: string | null;
+
   declare step: number;
   declare agentMessageId: ForeignKey<AgentMessage["id"]>;
 }
@@ -149,13 +151,16 @@ AgentDustAppRunAction.init(
       type: DataTypes.STRING,
       allowNull: false,
     },
-
     params: {
       type: DataTypes.JSONB,
       allowNull: false,
     },
     output: {
       type: DataTypes.JSONB,
+      allowNull: true,
+    },
+    functionCallId: {
+      type: DataTypes.STRING,
       allowNull: true,
     },
     step: {

--- a/front/lib/models/assistant/actions/process.ts
+++ b/front/lib/models/assistant/actions/process.ts
@@ -138,6 +138,7 @@ export class AgentProcessAction extends Model<
 
   declare schema: ProcessSchemaPropertyType[];
   declare outputs: ProcessActionOutputsType | null;
+  declare functionCallId: string | null;
 
   declare step: number;
 
@@ -178,6 +179,10 @@ AgentProcessAction.init(
     },
     outputs: {
       type: DataTypes.JSONB,
+      allowNull: true,
+    },
+    functionCallId: {
+      type: DataTypes.STRING,
       allowNull: true,
     },
     step: {

--- a/front/lib/models/assistant/actions/retrieval.ts
+++ b/front/lib/models/assistant/actions/retrieval.ts
@@ -156,6 +156,9 @@ export class AgentRetrievalAction extends Model<
   declare relativeTimeFrameDuration: number | null;
   declare relativeTimeFrameUnit: TimeframeUnit | null;
   declare topK: number;
+
+  declare functionCallId: string | null;
+
   declare agentMessageId: ForeignKey<AgentMessage["id"]>;
   declare step: number;
 }
@@ -195,6 +198,10 @@ AgentRetrievalAction.init(
     topK: {
       type: DataTypes.INTEGER,
       allowNull: false,
+    },
+    functionCallId: {
+      type: DataTypes.STRING,
+      allowNull: true,
     },
     step: {
       type: DataTypes.INTEGER,

--- a/front/lib/models/assistant/actions/tables_query.ts
+++ b/front/lib/models/assistant/actions/tables_query.ts
@@ -168,6 +168,8 @@ export class AgentTablesQueryAction extends Model<
 
   declare params: unknown | null;
   declare output: unknown | null;
+  declare functionCallId: string | null;
+
   declare agentMessageId: ForeignKey<AgentMessage["id"]>;
 
   declare step: number;
@@ -202,6 +204,10 @@ AgentTablesQueryAction.init(
     },
     output: {
       type: DataTypes.JSONB,
+      allowNull: true,
+    },
+    functionCallId: {
+      type: DataTypes.STRING,
       allowNull: true,
     },
     step: {

--- a/front/migrations/db/migration_02.sql
+++ b/front/migrations/db/migration_02.sql
@@ -1,0 +1,5 @@
+-- Migration created on May 16, 2024
+ALTER TABLE "public"."agent_retrieval_actions" ADD COLUMN "functionCallId" VARCHAR(255);
+ALTER TABLE "public"."agent_tables_query_actions" ADD COLUMN "functionCallId" VARCHAR(255);
+ALTER TABLE "public"."agent_dust_app_run_actions" ADD COLUMN "functionCallId" VARCHAR(255);
+ALTER TABLE "public"."agent_process_actions" ADD COLUMN "functionCallId" VARCHAR(255);

--- a/types/src/front/assistant/actions/dust_app_run.ts
+++ b/types/src/front/assistant/actions/dust_app_run.ts
@@ -31,5 +31,6 @@ export interface DustAppRunActionType extends BaseAction {
     status: "running" | "succeeded" | "errored";
   } | null;
   output: unknown | null;
+  functionCallId: string | null;
   step: number;
 }

--- a/types/src/front/assistant/actions/process.ts
+++ b/types/src/front/assistant/actions/process.ts
@@ -84,5 +84,6 @@ export type ProcessActionType = {
   };
   schema: ProcessSchemaPropertyType[];
   outputs: ProcessActionOutputsType | null;
+  functionCallId: string | null;
   step: number;
 };

--- a/types/src/front/assistant/actions/retrieval.ts
+++ b/types/src/front/assistant/actions/retrieval.ts
@@ -98,6 +98,7 @@ export type RetrievalActionType = {
     query: string | null;
     topK: number;
   };
+  functionCallId: string | null;
   documents: RetrievalDocumentType[] | null;
   step: number;
 };

--- a/types/src/front/assistant/actions/tables_query.ts
+++ b/types/src/front/assistant/actions/tables_query.ts
@@ -21,6 +21,7 @@ export interface TablesQueryActionType extends BaseAction {
   id: ModelId;
   params: DustAppParameters;
   output: Record<string, string | number | boolean> | null;
+  functionCallId: string | null;
   agentMessageId: ModelId;
   step: number;
 }

--- a/types/src/front/lib/actions/registry.ts
+++ b/types/src/front/lib/actions/registry.ts
@@ -228,7 +228,7 @@ export const DustProdActionRegistry = createActionRegistry({
       workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
       appId: "0e9889c787",
       appHash:
-        "a1dfbf2c9e59f5b9a5b05e3729eea064dd394c35f112dfa080b6573fdfdab229",
+        "8543925944941d3b363f7ea912efe560b073a4b2fcfac4e952724ff31700abed",
     },
     config: {
       MODEL: {

--- a/types/src/front/lib/api/assistant/agent.ts
+++ b/types/src/front/lib/api/assistant/agent.ts
@@ -94,4 +94,5 @@ export type AgentActionEvent = {
   action: AgentActionConfigurationType;
   inputs: Record<string, string | boolean | number>;
   specification: AgentActionSpecification | null;
+  functionCallId: string | null;
 };


### PR DESCRIPTION
Same PR as https://github.com/dust-tt/dust/pull/5058
-> Was reverted because we could not run the migration (DB was too busy with scrubbing workspaces). 




```
> diff-db-migration
> ./run_db_migration_diff.sh

Stashing uncommitted changes...
Original branch: revert-5081-revert-5058-action-function-call-id
Checking out main branch and resetting DB state...
First run: Resetting DB to main branch state...
Second run: Capturing stable production state...
Restoring original changes...
Checking out revert-5081-revert-5058-action-function-call-id branch...
Running command on revert-5081-revert-5058-action-function-call-id branch...
Running diff...
--- main_output.txt	2024-05-16 10:38:28
+++ current_output.txt	2024-05-16 10:38:29
@@ -523,0 +524 @@
+ALTER TABLE "public"."agent_retrieval_actions" ADD COLUMN "functionCallId" VARCHAR(255);
@@ -537,0 +539 @@
+ALTER TABLE "public"."agent_tables_query_actions" ADD COLUMN "functionCallId" VARCHAR(255);
@@ -549,0 +552 @@
+ALTER TABLE "public"."agent_dust_app_run_actions" ADD COLUMN "functionCallId" VARCHAR(255);
@@ -564,0 +568 @@
+ALTER TABLE "public"."agent_process_actions" ADD COLUMN "functionCallId" VARCHAR(255);
```

