### PR TITLE
Add functionCallId to AgentTablesQueryAction.init

### DIFF
--- a/front/lib/models/assistant/actions/tables_query.ts
+++ b/front/lib/models/assistant/actions/tables_query.ts
@@ -168,6 +168,8 @@ export class AgentTablesQueryAction extends Model<
 
   declare params: unknown | null;
   declare output: unknown | null;
+  declare functionCallId: string | null;
+
   declare agentMessageId: ForeignKey<AgentMessage["id"]>;
 
   declare step: number;
@@ -202,6 +204,10 @@ AgentTablesQueryAction.init(
     },
     output: {
       type: DataTypes.JSONB,
+      allowNull: true,
+    },
+    functionCallId: {
+      type: DataTypes.STRING,
       allowNull: true,
     },
     step: {


### PR DESCRIPTION
## Description

Adding column `functionCallId` to `AgentTablesQueryAction`.
This is part of https://github.com/dust-tt/dust/pull/5087 -> since we got an issue yesterday with an init_db we want to make a test with only one colyumn. 

```
> diff-db-migration
> ./run_db_migration_diff.sh

Stashing uncommitted changes...
Original branch: tables-query-function-call-id
Checking out main branch and resetting DB state...
First run: Resetting DB to main branch state...
Second run: Capturing stable production state...
Restoring original changes...
Checking out tables-query-function-call-id branch...
Running command on tables-query-function-call-id branch...
Running diff...
--- main_output.txt	2024-05-16 10:48:50
+++ current_output.txt	2024-05-16 10:48:51
@@ -537,0 +538 @@
+ALTER TABLE "public"."agent_tables_query_actions" ADD COLUMN "functionCallId" VARCHAR(255);
Cleaning up temporary files...
```

## Risk

Column is not used and nullable. 

## Deploy Plan

Deploy prodbox
Run init_db
Deploy front.
