### PR TITLE
[Connectors - GDrive] Fix: retrieving contentNodes returns toplevel folders/drives

### DIFF
--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -691,31 +691,6 @@ export async function retrieveGoogleDriveContentNodes(
     );
   })();
 
-  await concurrentExecutor(
-    drivesOrTopLevelFolders,
-    async (f): Promise<ContentNode> => {
-      const sourceUrl = `https://drive.google.com/drive/folders/${f.folderId}`;
-      return {
-        provider: "google_drive",
-        internalId: f.folderId,
-        parentInternalId: null,
-        type: "folder",
-        title: "", // temporary fix: an empty title will be interpreted as needing title fetch in front
-        dustDocumentId: null,
-        lastUpdatedAt: f.updatedAt.getTime(),
-        sourceUrl,
-        expandable: await isDriveObjectExpandable({
-          objectId: f.folderId,
-          mimeType: "application/vnd.google-apps.folder",
-          connectorId,
-          viewType,
-        }),
-        permission: "read",
-      };
-    },
-    { concurrency: 4 }
-  );
-
   const sheetNodes: ContentNode[] = sheets.map((s) => ({
     provider: "google_drive",
     internalId: getGoogleSheetContentNodeInternalId(

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -611,12 +611,17 @@ export async function retrieveGoogleDriveContentNodes(
     : [];
 
   const drivesOrTopLevelFolders = driveFileIds.length
-    ? await GoogleDriveFolders.findAll({
-        where: {
-          connectorId: connectorId,
-          folderId: driveFileIds,
-        },
-      })
+    ? (
+        await GoogleDriveFolders.findAll({
+          where: {
+            connectorId: connectorId,
+            folderId: driveFileIds,
+          },
+        })
+      ).filter(
+        // no need to add it if already in folderOrFiles
+        (f) => folderOrFiles.every((ff) => ff.driveFileId !== f.folderId)
+      )
     : [];
 
   const sheets = sheetIds.length

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -1,6 +1,6 @@
 import type { drive_v3 } from "googleapis";
 import { google } from "googleapis";
-import type { GaxiosResponse } from "googleapis-common";
+import type { GaxiosResponse, OAuth2Client } from "googleapis-common";
 
 import {
   getLocalParents,
@@ -318,33 +318,11 @@ export async function retrieveGoogleDriveConnectorPermissions({
         },
       });
 
-      const folderAsContentNodes = await concurrentExecutor(
+      const folderAsContentNodes = await getFoldersAsContentNodes({
+        authCredentials,
         folders,
-        async (f): Promise<ContentNode | null> => {
-          const fd = await getGoogleDriveObject(authCredentials, f.folderId);
-          if (!fd) {
-            return null;
-          }
-          return {
-            provider: c.type,
-            internalId: f.folderId,
-            parentInternalId: null,
-            type: "folder",
-            title: fd.name || "",
-            sourceUrl: null, // Out of consistency we don't send `fd.webViewLink`.
-            dustDocumentId: null,
-            lastUpdatedAt: fd.updatedAtMs || null,
-            expandable: await isDriveObjectExpandable({
-              objectId: f.folderId,
-              mimeType: "application/vnd.google-apps.folder",
-              connectorId,
-              viewType,
-            }),
-            permission: "read",
-          };
-        },
-        { concurrency: 4 }
-      );
+        viewType,
+      });
 
       const nodes = removeNulls(folderAsContentNodes);
 
@@ -631,6 +609,16 @@ export async function retrieveGoogleDriveContentNodes(
         },
       })
     : [];
+
+  const drivesOrTopLevelFolders = driveFileIds.length
+    ? await GoogleDriveFolders.findAll({
+        where: {
+          connectorId: connectorId,
+          folderId: driveFileIds,
+        },
+      })
+    : [];
+
   const sheets = sheetIds.length
     ? await GoogleDriveSheet.findAll({
         where: {
@@ -684,6 +672,50 @@ export async function retrieveGoogleDriveContentNodes(
     { concurrency: 4 }
   );
 
+  const drivesOrTopLevelFolderNodes = await (async () => {
+    if (drivesOrTopLevelFolders.length === 0) {
+      return [];
+    }
+    const c = await ConnectorResource.fetchById(connectorId);
+    if (!c) {
+      logger.error({ connectorId }, "Connector not found");
+      throw new Error("Connector not found");
+    }
+    const authCredentials = await getAuthObject(c.connectionId);
+    return removeNulls(
+      await getFoldersAsContentNodes({
+        authCredentials,
+        folders: drivesOrTopLevelFolders,
+        viewType,
+      })
+    );
+  })();
+
+  await concurrentExecutor(
+    drivesOrTopLevelFolders,
+    async (f): Promise<ContentNode> => {
+      const sourceUrl = `https://drive.google.com/drive/folders/${f.folderId}`;
+      return {
+        provider: "google_drive",
+        internalId: f.folderId,
+        parentInternalId: null,
+        type: "folder",
+        title: "", // temporary fix: an empty title will be interpreted as needing title fetch in front
+        dustDocumentId: null,
+        lastUpdatedAt: f.updatedAt.getTime(),
+        sourceUrl,
+        expandable: await isDriveObjectExpandable({
+          objectId: f.folderId,
+          mimeType: "application/vnd.google-apps.folder",
+          connectorId,
+          viewType,
+        }),
+        permission: "read",
+      };
+    },
+    { concurrency: 4 }
+  );
+
   const sheetNodes: ContentNode[] = sheets.map((s) => ({
     provider: "google_drive",
     internalId: getGoogleSheetContentNodeInternalId(
@@ -702,7 +734,9 @@ export async function retrieveGoogleDriveContentNodes(
 
   // Return the nodes in the same order as the input internalIds.
   const nodeByInternalId = new Map(
-    [...folderOrFileNodes, ...sheetNodes].map((n) => [n.internalId, n])
+    [...folderOrFileNodes, ...drivesOrTopLevelFolderNodes, ...sheetNodes].map(
+      (n) => [n.internalId, n]
+    )
   );
   return new Ok(
     internalIds
@@ -848,4 +882,43 @@ export async function unpauseGoogleDriveConnector(connectorId: ModelId) {
     return r;
   }
   return new Ok(undefined);
+}
+
+async function getFoldersAsContentNodes({
+  authCredentials,
+  folders,
+  viewType,
+}: {
+  authCredentials: OAuth2Client;
+  folders: GoogleDriveFolders[];
+  viewType: ContentNodesViewType;
+}) {
+  return concurrentExecutor(
+    folders,
+    async (f): Promise<ContentNode | null> => {
+      const fd = await getGoogleDriveObject(authCredentials, f.folderId);
+      if (!fd) {
+        return null;
+      }
+      const sourceUrl = `https://drive.google.com/drive/folders/${f.folderId}`;
+      return {
+        provider: "google_drive",
+        internalId: f.folderId,
+        parentInternalId: null,
+        type: "folder",
+        title: fd.name || "",
+        sourceUrl,
+        dustDocumentId: null,
+        lastUpdatedAt: fd.updatedAtMs || null,
+        expandable: await isDriveObjectExpandable({
+          objectId: f.folderId,
+          mimeType: "application/vnd.google-apps.folder",
+          connectorId: f.connectorId,
+          viewType,
+        }),
+        permission: "read",
+      };
+    },
+    { concurrency: 4 }
+  );
 }


### PR DESCRIPTION
Description
---
Fixes https://github.com/dust-tt/tasks/issues/711

Google drives and root folders were not returned by `retrieveGoogleDriveContentNodes`, leading to the above issue.

Additional:
- refactor to introduce a new `getFoldersAsContentNodes` and use it in `retrieveGoogleDriveContentNodes`;
- adds a non-null `sourceUrl` to folders as content nodes

Risk
---
New content nodes are returned by the API call. Call sites were checked to confirm the logic is not changed (see issue)

Deploy plan
---
Connectors

