### PR TITLE
Revert "Add functionCallId to AgentTablesQueryAction.init"

### DIFF
--- a/front/lib/models/assistant/actions/tables_query.ts
+++ b/front/lib/models/assistant/actions/tables_query.ts
@@ -168,8 +168,6 @@ export class AgentTablesQueryAction extends Model<
 
   declare params: unknown | null;
   declare output: unknown | null;
-  declare functionCallId: string | null;
-
   declare agentMessageId: ForeignKey<AgentMessage["id"]>;
 
   declare step: number;
@@ -204,10 +202,6 @@ AgentTablesQueryAction.init(
     },
     output: {
       type: DataTypes.JSONB,
-      allowNull: true,
-    },
-    functionCallId: {
-      type: DataTypes.STRING,
       allowNull: true,
     },
     step: {


### PR DESCRIPTION
Reverts dust-tt/dust#5088

-> we will introduce a new migration system since we can't rely anymore on init db. This has no value and was used as a test. 