### PR TITLE
[Assistant Builder] Limit instructions size to 1_000_000

### DIFF
--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -51,7 +51,10 @@ import ActionsScreen, {
   isActionValid,
 } from "@app/components/assistant_builder/ActionsScreen";
 import AssistantBuilderRightPanel from "@app/components/assistant_builder/AssistantBuilderPreviewDrawer";
-import { InstructionScreen } from "@app/components/assistant_builder/InstructionScreen";
+import {
+  InstructionScreen,
+  MAX_INSTRUCTIONS_LENGTH,
+} from "@app/components/assistant_builder/InstructionScreen";
 import NamingScreen, {
   removeLeadingAt,
   validateHandle,
@@ -313,6 +316,10 @@ export default function AssistantBuilder({
     string | null
   >(null);
 
+  const [instructionsError, setInstructionsError] = useState<string | null>(
+    null
+  );
+
   const checkUsernameTimeout = React.useRef<NodeJS.Timeout | null>(null);
 
   const [rightPanelStatus, setRightPanelStatus] =
@@ -416,8 +423,21 @@ export default function AssistantBuilder({
       valid = false;
     }
 
+    // instructions
     if (!builderState.instructions?.trim()) {
       valid = false;
+    }
+
+    if (
+      builderState.instructions &&
+      builderState.instructions.length > MAX_INSTRUCTIONS_LENGTH
+    ) {
+      setInstructionsError(
+        `Instructions must be less than ${MAX_INSTRUCTIONS_LENGTH} characters.`
+      );
+      valid = false;
+    } else {
+      setInstructionsError(null);
     }
 
     if (!builderState.actions.every((a) => isActionValid(a))) {
@@ -575,6 +595,7 @@ export default function AssistantBuilder({
                         setEdited={setEdited}
                         resetAt={instructionsResetAt}
                         isUsingTemplate={template !== null}
+                        instructionsError={instructionsError}
                       />
                     );
                   case "actions":

--- a/front/components/assistant_builder/InstructionScreen.tsx
+++ b/front/components/assistant_builder/InstructionScreen.tsx
@@ -82,6 +82,8 @@ export const USED_MODEL_CONFIGS: readonly ModelConfig[] = [
   MISTRAL_SMALL_MODEL_CONFIG,
 ] as const;
 
+export const MAX_INSTRUCTIONS_LENGTH = 1_000_000;
+
 const getCreativityLevelFromTemperature = (temperature: number) => {
   const closest = CREATIVITY_LEVELS.reduce((prev, curr) =>
     Math.abs(curr.value - temperature) < Math.abs(prev.value - temperature)
@@ -111,6 +113,7 @@ export function InstructionScreen({
   setEdited,
   resetAt,
   isUsingTemplate,
+  instructionsError,
 }: {
   owner: WorkspaceType;
   plan: PlanType;
@@ -121,6 +124,7 @@ export function InstructionScreen({
   setEdited: (edited: boolean) => void;
   resetAt: number | null;
   isUsingTemplate: boolean;
+  instructionsError: string | null;
 }) {
   const editor = useEditor({
     extensions: [Document, Text, Paragraph],
@@ -142,12 +146,15 @@ export function InstructionScreen({
       editorProps: {
         attributes: {
           class:
-            "overflow-auto min-h-[240px] h-full border-structure-200 border bg-structure-50 transition-all " +
-            "duration-200 rounded-xl focus:border-action-300 focus:ring-action-300 p-2 focus:outline-action-200",
+            "overflow-auto min-h-[240px] h-full border bg-structure-50 transition-all " +
+            "duration-200 rounded-xl " +
+            (instructionsError
+              ? "border-warning-500 focus:ring-warning-500 p-2 focus:outline-warning-500 focus:border-warning-500"
+              : "border-structure-200 focus:ring-action-300 p-2 focus:outline-action-200 focus:border-action-300"),
         },
       },
     });
-  }, [editor]);
+  }, [editor, instructionsError]);
 
   useEffect(() => {
     if (resetAt != null) {
@@ -191,6 +198,11 @@ export function InstructionScreen({
           className="absolute bottom-0 left-0 right-0 top-0"
         />
       </div>
+      {instructionsError && (
+        <div className="-mt-3 ml-2 text-sm text-warning-500">
+          {instructionsError}
+        </div>
+      )}
       {!isUsingTemplate && (
         <Suggestions
           owner={owner}


### PR DESCRIPTION
Description
---
Fixes https://github.com/dust-tt/tasks/issues/755

Formerly, instructions over about 1 100 000 characters caused a "Payload too large" error (related to request body) so saving the assistant failed and generated a cryptic error message. A few users reported this, last one a few hours ago (see issue).

This PR prevents saving and displays a clear error message.

The underlying assumption is that allowing ~200K to 400K tokens is enough for the instructions; if more tokens needed it should be handled differently (process data source, file attachment, etc.)


### Before
User clicked on save and got notif, contacted support
![image](https://github.com/dust-tt/dust/assets/5437393/7b86a6c6-731e-4b5e-b616-7f5b13ffa7e0)

### After
Disable save button and shows error
![image](https://github.com/dust-tt/dust/assets/5437393/a31a9e04-019d-41a7-8f2e-288b17fa0641)



Risk
---
Existing assistants with instructions in-between 1M chars and 1.1M chars might not be editable. Manual check that there are no such assistants on [metabase]( https://metabase.dust.tt/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7InR5cGUiOiJuYXRpdmUiLCJuYXRpdmUiOnsicXVlcnkiOiJTRUxFQ1QgKlxuRlJPTSBcImFnZW50X2NvbmZpZ3VyYXRpb25zXCJcbldIRVJFIExFTkdUSChcImluc3RydWN0aW9uc1wiKSA-IDEwMDAwMDA7XG4iLCJ0ZW1wbGF0ZS10YWdzIjp7fX0sImRhdGFiYXNlIjo0fSwiZGlzcGxheSI6InRhYmxlIiwicGFyYW1ldGVycyI6W10sInZpc3VhbGl6YXRpb25fc2V0dGluZ3MiOnt9fQ==)

Deploy plan
---
Deploy front
