### PR TITLE
Process Data: Generate extraction schema

### DIFF
--- a/front/components/assistant_builder/ActionScreen.tsx
+++ b/front/components/assistant_builder/ActionScreen.tsx
@@ -462,6 +462,7 @@ export default function ActionScreen({
         <ActionModeSection show={action?.type === "PROCESS" && !noDataSources}>
           <ActionProcess
             owner={owner}
+            instructions={builderState.instructions}
             actionConfiguration={
               action?.type === "PROCESS" ? action.configuration : null
             }

--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -291,6 +291,7 @@ export default function ActionsScreen({
                         return (
                           <ActionProcess
                             owner={owner}
+                            instructions={builderState.instructions}
                             actionConfiguration={a.configuration}
                             dataSources={dataSources}
                             updateAction={(setNewAction) => {

--- a/front/components/assistant_builder/actions/ProcessAction.tsx
+++ b/front/components/assistant_builder/actions/ProcessAction.tsx
@@ -9,7 +9,7 @@ import {
   Tooltip,
   XCircleIcon,
 } from "@dust-tt/sparkle";
-import type { APIError, Result, TimeframeUnit } from "@dust-tt/types";
+import type { Result, TimeframeUnit } from "@dust-tt/types";
 import type {
   DataSourceType,
   ProcessSchemaPropertyType,
@@ -506,6 +506,7 @@ export function ActionProcess({
                 setEdited(true);
 
                 if (instructions !== null) {
+                  console.log(instructions);
                   const res = await generateSchema({ owner, instructions });
                   console.log(res);
                 }
@@ -546,7 +547,7 @@ async function generateSchema({
 }: {
   owner: WorkspaceType;
   instructions: string;
-}): Promise<Result<ProcessSchemaPropertyType[], APIError>> {
+}): Promise<Result<ProcessSchemaPropertyType[], Error>> {
   const res = await fetch(
     `/api/w/${owner.sId}/assistant/builder/process/generate_schema`,
     {
@@ -560,10 +561,7 @@ async function generateSchema({
     }
   );
   if (!res.ok) {
-    return new Err({
-      type: "internal_server_error",
-      message: "Failed to get suggestions",
-    });
+    return new Err(new Error("Failed to generate schema"));
   }
   return new Ok(await res.json());
 }

--- a/front/pages/api/w/[wId]/assistant/builder/process/generate_schema.ts
+++ b/front/pages/api/w/[wId]/assistant/builder/process/generate_schema.ts
@@ -79,7 +79,9 @@ async function handler(
           status_code: 500,
           api_error: {
             type: "internal_server_error",
-            message: `Error running action: ${JSON.stringify(actionRes.error)}`,
+            message: `Error generating schema: ${JSON.stringify(
+              actionRes.error
+            )}`,
           },
         });
       }
@@ -94,7 +96,7 @@ async function handler(
           status_code: 500,
           api_error: {
             type: "internal_server_error",
-            message: `No results returned by action`,
+            message: `Error generating schema: no result returned by model.`,
           },
         });
       }

--- a/front/pages/api/w/[wId]/assistant/builder/process/generate_schema.ts
+++ b/front/pages/api/w/[wId]/assistant/builder/process/generate_schema.ts
@@ -5,8 +5,6 @@ import type {
 import { cloneBaseConfig, ioTsParsePayload } from "@dust-tt/types";
 import { InternalPostBuilderProcessActionGenerateSchemaRequestBodySchema } from "@dust-tt/types";
 import { DustProdActionRegistry } from "@dust-tt/types";
-import { isLeft } from "fp-ts/lib/Either";
-import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { runAction } from "@app/lib/actions/server";

--- a/front/pages/api/w/[wId]/assistant/builder/process/generate_schema.ts
+++ b/front/pages/api/w/[wId]/assistant/builder/process/generate_schema.ts
@@ -1,0 +1,117 @@
+import type {
+  ProcessSchemaPropertyType,
+  WithAPIErrorReponse,
+} from "@dust-tt/types";
+import { cloneBaseConfig } from "@dust-tt/types";
+import { InternalPostBuilderProcessActionGenerateSchemaRequestBodySchema } from "@dust-tt/types";
+import { DustProdActionRegistry } from "@dust-tt/types";
+import { isLeft } from "fp-ts/lib/Either";
+import * as reporter from "io-ts-reporters";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { runAction } from "@app/lib/actions/server";
+import { Authenticator, getSession } from "@app/lib/auth";
+import { apiError, withLogging } from "@app/logger/withlogging";
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorReponse<{
+      schema: ProcessSchemaPropertyType[];
+    }>
+  >
+): Promise<void> {
+  const session = await getSession(req, res);
+  const auth = await Authenticator.fromSession(
+    session,
+    req.query.wId as string
+  );
+
+  const owner = auth.workspace();
+  if (!owner || !auth.isUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "app_auth_error",
+        message:
+          "Workspace not found or user not authenticated to this workspace.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "POST":
+      const bodyValidation =
+        InternalPostBuilderProcessActionGenerateSchemaRequestBodySchema.decode(
+          req.body
+        );
+
+      if (isLeft(bodyValidation)) {
+        const pathError = reporter.formatValidationErrors(bodyValidation.left);
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid request body: ${pathError}`,
+          },
+        });
+      }
+
+      const config = cloneBaseConfig(
+        DustProdActionRegistry[
+          "assistant-builder-process-action-schema-generator"
+        ].config
+      );
+
+      const actionRes = await runAction(
+        auth,
+        "assistant-builder-process-action-schema-generator",
+        config,
+        [
+          {
+            instructions: bodyValidation.right.instructions,
+          },
+        ]
+      );
+
+      if (actionRes.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: `Error running action: ${JSON.stringify(actionRes.error)}`,
+          },
+        });
+      }
+
+      if (
+        !actionRes.value.results ||
+        !actionRes.value.results[0] ||
+        !actionRes.value.results[0][0] ||
+        !actionRes.value.results[0][0].value
+      ) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: `No results returned by action`,
+          },
+        });
+      }
+
+      const schema = actionRes.value.results[0][0].value as unknown;
+      console.log(schema);
+
+      return res.status(200).json({ schema: [] });
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, POST is expected.",
+        },
+      });
+  }
+}
+
+export default withLogging(handler);

--- a/front/pages/api/w/[wId]/assistant/builder/process/generate_schema.ts
+++ b/front/pages/api/w/[wId]/assistant/builder/process/generate_schema.ts
@@ -101,10 +101,18 @@ async function handler(
         });
       }
 
-      const schema = actionRes.value.results[0][0].value as unknown;
-      console.log(schema);
+      const rawSchema = actionRes.value.results[0][0].value as any;
 
-      return res.status(200).json({ schema: [] });
+      const schema: ProcessSchemaPropertyType[] = [];
+      for (const key in rawSchema) {
+        schema.push({
+          name: key,
+          type: rawSchema[key].type || "string",
+          description: rawSchema[key].description || "",
+        });
+      }
+
+      return res.status(200).json({ schema });
     default:
       return apiError(req, res, {
         status_code: 405,

--- a/types/src/front/api_handlers/internal/assistant.ts
+++ b/types/src/front/api_handlers/internal/assistant.ts
@@ -73,3 +73,8 @@ export const BuilderSuggestionsResponseBodySchema = t.union([
 export type BuilderSuggestionsType = t.TypeOf<
   typeof BuilderSuggestionsResponseBodySchema
 >;
+
+export const InternalPostBuilderProcessActionGenerateSchemaRequestBodySchema =
+  t.type({
+    instructions: t.string,
+  });

--- a/types/src/front/lib/actions/registry.ts
+++ b/types/src/front/lib/actions/registry.ts
@@ -220,6 +220,22 @@ export const DustProdActionRegistry = createActionRegistry({
       },
     },
   },
+  "assistant-builder-process-action-schema-generator": {
+    app: {
+      workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
+      appId: "b36c7416bd",
+      appHash:
+        "1ca7b9568681b06ef6cc0830239a479644a3ecc203c812983f3386a72e214d48",
+    },
+    config: {
+      MODEL: {
+        provider_id: GPT_3_5_TURBO_MODEL_CONFIG.providerId,
+        model_id: GPT_3_5_TURBO_MODEL_CONFIG.modelId,
+        function_call: "set_extraction_schema",
+        use_cache: false,
+      },
+    },
+  },
   "assistant-v2-multi-actions-agent": {
     app: {
       workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,

--- a/types/src/front/lib/actions/registry.ts
+++ b/types/src/front/lib/actions/registry.ts
@@ -229,8 +229,8 @@ export const DustProdActionRegistry = createActionRegistry({
     },
     config: {
       MODEL: {
-        provider_id: GPT_3_5_TURBO_MODEL_CONFIG.providerId,
-        model_id: GPT_3_5_TURBO_MODEL_CONFIG.modelId,
+        provider_id: GPT_4O_MODEL_CONFIG.providerId,
+        model_id: GPT_4O_MODEL_CONFIG.modelId,
         function_call: "set_extraction_schema",
         use_cache: false,
       },


### PR DESCRIPTION
## Description

- Add support for a model to generate the Process Data action schema.
- Adds link to a documentation page for Process action: https://dust-tt.notion.site/Process-Data-on-Dust-424a836b881e4664aa6077a344a55b0c

![Screenshot from 2024-05-16 17-19-44](https://github.com/dust-tt/dust/assets/15067/e33fec1a-9680-43db-bde8-beb55661d81d)
![Screenshot from 2024-05-16 17-19-48](https://github.com/dust-tt/dust/assets/15067/e12d8a86-ece0-47b2-bdef-1214793cbe4c)
![Screenshot from 2024-05-16 17-19-55](https://github.com/dust-tt/dust/assets/15067/9649a993-a12f-4f72-adc8-995061022001)

## Risk

N/A

## Deploy Plan

- deploy `front`