### PR TITLE
enh(multi-actions): store function call name

### DIFF
--- a/front/lib/api/assistant/actions/dust_app_run.ts
+++ b/front/lib/api/assistant/actions/dust_app_run.ts
@@ -43,6 +43,7 @@ interface DustAppRunActionBlob {
   } | null;
   output: unknown | null;
   functionCallId: string | null;
+  functionCallName: string | null;
   step: number;
 }
 
@@ -59,6 +60,7 @@ export class DustAppRunAction extends BaseAction {
   } | null;
   readonly output: unknown | null;
   readonly functionCallId: string | null;
+  readonly functionCallName: string | null;
   readonly step: number;
 
   constructor(blob: DustAppRunActionBlob) {
@@ -72,6 +74,7 @@ export class DustAppRunAction extends BaseAction {
     this.runningBlock = blob.runningBlock;
     this.output = blob.output;
     this.functionCallId = blob.functionCallId;
+    this.functionCallName = blob.functionCallName;
     this.step = blob.step;
   }
 
@@ -92,7 +95,7 @@ export class DustAppRunAction extends BaseAction {
   renderForFunctionCall(): FunctionCallType {
     return {
       id: this.functionCallId ?? `call_${this.id.toString()}`,
-      name: this.appName,
+      name: this.functionCallName ?? this.appName,
       arguments: JSON.stringify(this.params),
     };
   }
@@ -260,6 +263,7 @@ export async function dustAppRunTypesFromAgentMessageIds(
       runningBlock: null,
       output: action.output,
       functionCallId: action.functionCallId,
+      functionCallName: action.functionCallName,
       agentMessageId: action.agentMessageId,
       step: action.step,
     });
@@ -362,6 +366,7 @@ export async function* runDustApp(
     appName: app.name,
     params,
     functionCallId,
+    functionCallName: actionConfiguration.name,
     agentMessageId: agentMessage.agentMessageId,
     step,
   });
@@ -380,6 +385,7 @@ export async function* runDustApp(
       runningBlock: null,
       output: null,
       functionCallId,
+      functionCallName: actionConfiguration.name,
       agentMessageId: agentMessage.agentMessageId,
       step,
     }),
@@ -453,6 +459,7 @@ export async function* runDustApp(
           appName: app.name,
           params,
           functionCallId,
+          functionCallName: actionConfiguration.name,
           runningBlock: {
             type: event.content.block_type,
             name: event.content.name,
@@ -511,6 +518,7 @@ export async function* runDustApp(
       appName: app.name,
       params,
       functionCallId,
+      functionCallName: actionConfiguration.name,
       runningBlock: null,
       output: lastBlockOutput,
       agentMessageId: agentMessage.agentMessageId,

--- a/front/lib/api/assistant/actions/process.ts
+++ b/front/lib/api/assistant/actions/process.ts
@@ -52,6 +52,7 @@ interface ProcessActionBlob {
   schema: ProcessSchemaPropertyType[];
   outputs: ProcessActionOutputsType | null;
   functionCallId: string | null;
+  functionCallName: string | null;
   step: number;
 }
 
@@ -63,6 +64,7 @@ export class ProcessAction extends BaseAction {
   readonly schema: ProcessSchemaPropertyType[];
   readonly outputs: ProcessActionOutputsType | null;
   readonly functionCallId: string | null;
+  readonly functionCallName: string | null;
   readonly step: number;
 
   constructor(blob: ProcessActionBlob) {
@@ -73,6 +75,7 @@ export class ProcessAction extends BaseAction {
     this.schema = blob.schema;
     this.outputs = blob.outputs;
     this.functionCallId = blob.functionCallId;
+    this.functionCallName = blob.functionCallName;
     this.step = blob.step;
   }
 
@@ -100,7 +103,7 @@ export class ProcessAction extends BaseAction {
 
     return {
       role: "action" as const,
-      name: "process_data_sources",
+      name: this.functionCallName ?? "process_data_sources",
       content,
     };
   }
@@ -108,7 +111,7 @@ export class ProcessAction extends BaseAction {
   renderForFunctionCall(): FunctionCallType {
     return {
       id: this.functionCallId ?? `call_${this.id.toString()}`,
-      name: "process_data_sources",
+      name: this.functionCallName ?? "process_data_sources",
       arguments: JSON.stringify(this.params),
     };
   }
@@ -228,6 +231,7 @@ export async function processActionTypesFromAgentMessageIds(
       schema: action.schema,
       outputs: action.outputs,
       functionCallId: action.functionCallId,
+      functionCallName: action.functionCallName,
       step: action.step,
     });
   });
@@ -305,6 +309,7 @@ export async function* runProcess(
     processConfigurationId: actionConfiguration.sId,
     schema: actionConfiguration.schema,
     functionCallId,
+    functionCallName: actionConfiguration.name,
     agentMessageId: agentMessage.agentMessageId,
     step,
   });
@@ -326,6 +331,7 @@ export async function* runProcess(
       schema: action.schema,
       outputs: null,
       functionCallId: action.functionCallId,
+      functionCallName: action.functionCallName,
       step: action.step,
     }),
   };
@@ -515,6 +521,7 @@ export async function* runProcess(
       schema: action.schema,
       outputs,
       functionCallId: action.functionCallId,
+      functionCallName: action.functionCallName,
       step: action.step,
     }),
   };

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -122,6 +122,7 @@ interface RetrievalActionBlob {
     topK: number;
   };
   functionCallId: string | null;
+  functionCallName: string | null;
   documents: RetrievalDocumentType[] | null;
   step: number;
 }
@@ -134,6 +135,7 @@ export class RetrievalAction extends BaseAction {
     topK: number;
   };
   readonly functionCallId: string | null;
+  readonly functionCallName: string | null;
   readonly documents: RetrievalDocumentType[] | null;
   readonly step: number;
 
@@ -144,6 +146,7 @@ export class RetrievalAction extends BaseAction {
     this.params = blob.params;
     this.documents = blob.documents;
     this.functionCallId = blob.functionCallId;
+    this.functionCallName = blob.functionCallName;
     this.step = blob.step;
   }
 
@@ -179,7 +182,7 @@ export class RetrievalAction extends BaseAction {
 
     return {
       role: "action" as const,
-      name: "search_data_sources",
+      name: this.functionCallName ?? "search_data_sources",
       content,
     };
   }
@@ -196,7 +199,7 @@ export class RetrievalAction extends BaseAction {
 
     return {
       id: this.functionCallId ?? `call_${this.id.toString()}`,
-      name: "search_data_sources",
+      name: this.functionCallName ?? "search_data_sources",
       arguments: JSON.stringify(params),
     };
   }
@@ -454,6 +457,7 @@ export async function retrievalActionTypesFromAgentMessageIds(
           topK: action.topK,
         },
         functionCallId: action.functionCallId,
+        functionCallName: action.functionCallName,
         documents,
         step: action.step,
       })
@@ -608,6 +612,7 @@ export async function* runRetrieval(
     topK,
     retrievalConfigurationId: actionConfiguration.sId,
     functionCallId,
+    functionCallName: actionConfiguration.name,
     agentMessageId: agentMessage.agentMessageId,
     step: step,
   });
@@ -627,6 +632,7 @@ export async function* runRetrieval(
         topK,
       },
       functionCallId: action.functionCallId,
+      functionCallName: action.functionCallName,
       documents: null,
       step: action.step,
     }),
@@ -879,6 +885,7 @@ export async function* runRetrieval(
         topK,
       },
       functionCallId: action.functionCallId,
+      functionCallName: action.functionCallName,
       documents,
       step: action.step,
     }),

--- a/front/lib/api/assistant/actions/tables_query.ts
+++ b/front/lib/api/assistant/actions/tables_query.ts
@@ -34,6 +34,7 @@ interface TablesQueryActionBlob {
   params: DustAppParameters;
   output: Record<string, string | number | boolean> | null;
   functionCallId: string | null;
+  functionCallName: string | null;
   step: number;
 }
 
@@ -42,6 +43,7 @@ export class TablesQueryAction extends BaseAction {
   readonly params: DustAppParameters;
   readonly output: Record<string, string | number | boolean> | null;
   readonly functionCallId: string | null;
+  readonly functionCallName: string | null;
   readonly step: number;
 
   constructor(blob: TablesQueryActionBlob) {
@@ -51,6 +53,7 @@ export class TablesQueryAction extends BaseAction {
     this.params = blob.params;
     this.output = blob.output;
     this.functionCallId = blob.functionCallId;
+    this.functionCallName = blob.functionCallName;
     this.step = blob.step;
   }
 
@@ -74,7 +77,7 @@ export class TablesQueryAction extends BaseAction {
   renderForFunctionCall(): FunctionCallType {
     return {
       id: this.functionCallId ?? `call_${this.id.toString()}`,
-      name: "query_tables",
+      name: this.functionCallName ?? "query_tables",
       arguments: JSON.stringify(this.params),
     };
   }
@@ -114,6 +117,7 @@ export async function tableQueryTypesFromAgentMessageIds(
       params: action.params as DustAppParameters,
       output: action.output as Record<string, string | number | boolean>,
       functionCallId: action.functionCallId,
+      functionCallName: action.functionCallName,
       agentMessageId: action.agentMessageId,
       step: action.step,
     });
@@ -236,6 +240,7 @@ export async function* runTablesQuery(
       params: action.params as DustAppParameters,
       output: action.output as Record<string, string | number | boolean>,
       functionCallId: action.functionCallId,
+      functionCallName: action.functionCallName,
       agentMessageId: action.agentMessageId,
       step: action.step,
     }),
@@ -372,6 +377,7 @@ export async function* runTablesQuery(
             params: action.params as DustAppParameters,
             output: tmpOutput as Record<string, string | number | boolean>,
             functionCallId: action.functionCallId,
+            functionCallName: action.functionCallName,
             agentMessageId: agentMessage.id,
             step: action.step,
           }),
@@ -402,6 +408,7 @@ export async function* runTablesQuery(
       params: action.params as DustAppParameters,
       output: action.output as Record<string, string | number | boolean>,
       functionCallId: action.functionCallId,
+      functionCallName: action.functionCallName,
       agentMessageId: action.agentMessageId,
       step: action.step,
     }),

--- a/front/lib/models/assistant/actions/dust_app_run.ts
+++ b/front/lib/models/assistant/actions/dust_app_run.ts
@@ -112,6 +112,7 @@ export class AgentDustAppRunAction extends Model<
   declare params: DustAppParameters;
   declare output: unknown | null;
   declare functionCallId: string | null;
+  declare functionCallName: string | null;
 
   declare step: number;
   declare agentMessageId: ForeignKey<AgentMessage["id"]>;
@@ -160,6 +161,10 @@ AgentDustAppRunAction.init(
       allowNull: true,
     },
     functionCallId: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
+    functionCallName: {
       type: DataTypes.STRING,
       allowNull: true,
     },

--- a/front/lib/models/assistant/actions/process.ts
+++ b/front/lib/models/assistant/actions/process.ts
@@ -139,6 +139,7 @@ export class AgentProcessAction extends Model<
   declare schema: ProcessSchemaPropertyType[];
   declare outputs: ProcessActionOutputsType | null;
   declare functionCallId: string | null;
+  declare functionCallName: string | null;
 
   declare step: number;
 
@@ -182,6 +183,10 @@ AgentProcessAction.init(
       allowNull: true,
     },
     functionCallId: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
+    functionCallName: {
       type: DataTypes.STRING,
       allowNull: true,
     },

--- a/front/lib/models/assistant/actions/retrieval.ts
+++ b/front/lib/models/assistant/actions/retrieval.ts
@@ -158,6 +158,7 @@ export class AgentRetrievalAction extends Model<
   declare topK: number;
 
   declare functionCallId: string | null;
+  declare functionCallName: string | null;
 
   declare agentMessageId: ForeignKey<AgentMessage["id"]>;
   declare step: number;
@@ -200,6 +201,10 @@ AgentRetrievalAction.init(
       allowNull: false,
     },
     functionCallId: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
+    functionCallName: {
       type: DataTypes.STRING,
       allowNull: true,
     },

--- a/front/lib/models/assistant/actions/tables_query.ts
+++ b/front/lib/models/assistant/actions/tables_query.ts
@@ -169,6 +169,7 @@ export class AgentTablesQueryAction extends Model<
   declare params: unknown | null;
   declare output: unknown | null;
   declare functionCallId: string | null;
+  declare functionCallName: string | null;
 
   declare agentMessageId: ForeignKey<AgentMessage["id"]>;
 
@@ -207,6 +208,10 @@ AgentTablesQueryAction.init(
       allowNull: true,
     },
     functionCallId: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
+    functionCallName: {
       type: DataTypes.STRING,
       allowNull: true,
     },

--- a/front/migrations/db/migration_03.sql
+++ b/front/migrations/db/migration_03.sql
@@ -1,0 +1,5 @@
+-- Migration created on May 16, 2024
+ALTER TABLE "public"."agent_retrieval_actions" ADD COLUMN "functionCallName" VARCHAR(255);
+ALTER TABLE "public"."agent_tables_query_actions" ADD COLUMN "functionCallName" VARCHAR(255);
+ALTER TABLE "public"."agent_dust_app_run_actions" ADD COLUMN "functionCallName" VARCHAR(255);
+ALTER TABLE "public"."agent_process_actions" ADD COLUMN "functionCallName" VARCHAR(255);

--- a/types/src/front/assistant/actions/dust_app_run.ts
+++ b/types/src/front/assistant/actions/dust_app_run.ts
@@ -32,5 +32,6 @@ export interface DustAppRunActionType extends BaseAction {
   } | null;
   output: unknown | null;
   functionCallId: string | null;
+  functionCallName: string | null;
   step: number;
 }

--- a/types/src/front/assistant/actions/process.ts
+++ b/types/src/front/assistant/actions/process.ts
@@ -84,5 +84,6 @@ export interface ProcessActionType extends BaseAction {
   schema: ProcessSchemaPropertyType[];
   outputs: ProcessActionOutputsType | null;
   functionCallId: string | null;
+  functionCallName: string | null;
   step: number;
 }

--- a/types/src/front/assistant/actions/retrieval.ts
+++ b/types/src/front/assistant/actions/retrieval.ts
@@ -98,6 +98,7 @@ export interface RetrievalActionType extends BaseAction {
     topK: number;
   };
   functionCallId: string | null;
+  functionCallName: string | null;
   documents: RetrievalDocumentType[] | null;
   step: number;
 }

--- a/types/src/front/assistant/actions/tables_query.ts
+++ b/types/src/front/assistant/actions/tables_query.ts
@@ -22,6 +22,7 @@ export interface TablesQueryActionType extends BaseAction {
   params: DustAppParameters;
   output: Record<string, string | number | boolean> | null;
   functionCallId: string | null;
+  functionCallName: string | null;
   agentMessageId: ModelId;
   step: number;
 }


### PR DESCRIPTION
## Description

Now that we let the model pick a function, it's important that we use the actual function name in function call history, otherwise the model gets confused.

For example, we always render retrieval actions with the name `search_data_sources`, even though the actual function name in the specification of the assistant might be something else, such as `search_internal_data_sources`. When we call the model again with such an history, it has a tendency to re-use function names from previous function calls, which in this case causes the model to call a function that is not part of the spec (and leading to agent errors).

Actions are meant to be self-contained, so this change:
- adds a field on action tables to store the `functionCallName`, similar to how we store the `functionCallId`
- adds a field on the action types
- uses that new field (if present) when rendering function call for the model

## Risk

migration

## Deploy Plan

Run the migration file (from prodbox). Then deploy the change.