### PR TITLE
200 on delete connector with force=true if connector is gone already

### DIFF
--- a/connectors/src/api/delete_connector.ts
+++ b/connectors/src/api/delete_connector.ts
@@ -27,11 +27,6 @@ const _deleteConnectorAPIHandler = async (
   const force = req.query.force === "true";
   const connector = await ConnectorResource.fetchById(req.params.connector_id);
   if (!connector) {
-    if (req.query.force === "true") {
-      return res.json({
-        success: true,
-      });
-    }
     return apiError(req, res, {
       status_code: 404,
       api_error: {

--- a/connectors/src/api/delete_connector.ts
+++ b/connectors/src/api/delete_connector.ts
@@ -27,6 +27,11 @@ const _deleteConnectorAPIHandler = async (
   const force = req.query.force === "true";
   const connector = await ConnectorResource.fetchById(req.params.connector_id);
   if (!connector) {
+    if (req.query.force === "true") {
+      return res.json({
+        success: true,
+      });
+    }
     return apiError(req, res, {
       status_code: 404,
       api_error: {

--- a/types/src/front/lib/connectors_api.ts
+++ b/types/src/front/lib/connectors_api.ts
@@ -553,6 +553,7 @@ export class ConnectorsAPI {
           parseError: e,
           rawText: text,
           status: response.status,
+          url: response.url,
         },
         "ConnectorsAPI error"
       );
@@ -563,7 +564,11 @@ export class ConnectorsAPI {
       const err = json?.error;
       if (isConnectorsAPIError(err)) {
         this._logger.error(
-          { connectorsError: err, status: response.status },
+          {
+            connectorsError: err,
+            status: response.status,
+            url: response.url,
+          },
           "ConnectorsAPI error"
         );
         return new Err(err);
@@ -573,7 +578,12 @@ export class ConnectorsAPI {
           message: "Unexpected error format from ConnectorAPI",
         };
         this._logger.error(
-          { connectorsError: err, json, status: response.status },
+          {
+            connectorsError: err,
+            json,
+            status: response.status,
+            url: response.url,
+          },
           "ConnectorsAPI error"
         );
         return new Err(err);

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -1213,7 +1213,7 @@ export class CoreAPI {
 
       this._logger.error(
         {
-          connectorsError: err,
+          coreError: err,
           parseError: e,
           rawText: text,
           status: response.status,
@@ -1228,7 +1228,7 @@ export class CoreAPI {
       const err = json?.error;
       if (isCoreAPIError(err)) {
         this._logger.error(
-          { coreError: err, status: response.status },
+          { coreError: err, status: response.status, url: response.url },
           "CoreAPI error"
         );
         return new Err(err);
@@ -1238,7 +1238,7 @@ export class CoreAPI {
           message: "Unexpected error format from CoreAPI",
         };
         this._logger.error(
-          { coreError: err, json, status: response.status },
+          { coreError: err, json, status: response.status, url: response.url },
           "CoreAPI error"
         );
         return new Err(err);
@@ -1249,7 +1249,7 @@ export class CoreAPI {
 
       if (err && isCoreAPIError(err)) {
         this._logger.error(
-          { coreError: err, json, status: response.status },
+          { coreError: err, json, status: response.status, url: response.url },
           "CoreAPI error"
         );
         return new Err(err);
@@ -1261,7 +1261,7 @@ export class CoreAPI {
           message: "Unexpected response format from CoreAPI",
         };
         this._logger.error(
-          { coreError: err, json, status: response.status },
+          { coreError: err, json, status: response.status, url: response.url },
           "CoreAPI error"
         );
         return new Err(err);


### PR DESCRIPTION
## Description

Investigating these CoreAPI error from the scrubWorkspace workflow we see 2 types of errors and some inconsistencies in the logs (use of `connectorsError` instead of `CoreError` + missing url in places)

https://app.datadoghq.eu/logs?query=%22CoreAPI%20error%22%20&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&sort=time&storage=hot&stream_sort=desc&view=spans&viz=stream&from_ts=1706283512877&to_ts=1706297912877&live=true

Fixing these for better debugging to understand why we see 2 types of errors there from Core.

## Risk

N/A 

## Deploy Plan

- deploy `front`