### PR TITLE
Be reslient on delete returning 404 in data source delete method

### DIFF
--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -250,11 +250,13 @@ export async function deleteDataSource(
     dataSourceName: dataSource.name,
   });
   if (coreDeleteRes.isErr()) {
-    return new Err({
-      type: "internal_server_error",
-      message: `Error deleting core data source: ${coreDeleteRes.error.message}`,
-      data_source_error: coreDeleteRes.error,
-    });
+    if (coreDeleteRes.error.code !== "data_source_not_found") {
+      return new Err({
+        type: "internal_server_error",
+        message: `Error deleting core data source: ${coreDeleteRes.error.message}`,
+        data_source_error: coreDeleteRes.error,
+      });
+    }
   }
 
   await dataSource.destroy();


### PR DESCRIPTION
## Description

If CoreAPI responds 404 on data source delete continue the deleteDataSource process.

Example log: https://app.datadoghq.eu/logs?query=%22CoreAPI%20error%22%20&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AgAAAY-HKOqgyW4mnQAAAAAAAAAYAAAAAEFZLUhLUEtIQUFCMnBmTHFRQUZSdUFDbgAAACQAAAAAMDE4Zjg3MjktMTRkOS00YWEyLTlmMWUtMzRlNWMwMzQzYTNk&fromUser=true&messageDisplay=inline&refresh_mode=sliding&sort=time&storage=hot&stream_sort=desc&view=spans&viz=stream&from_ts=1706283512877&to_ts=1706297912877&live=true

## Risk

N/A

## Deploy Plan

- deploy `front`