### PR TITLE
Temporary log performance around Notion GC

### DIFF
--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -735,8 +735,9 @@ export async function garbageCollect({
   }
 
   const localLogger = logger.child({
-    workspaceId: connector.workspaceId,
+    connectorId,
     dataSourceName: connector.dataSourceName,
+    workspaceId: connector.workspaceId,
   });
 
   const notionConnectorState = await NotionConnectorState.findOne({

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -951,6 +951,7 @@ export async function garbageCollect({
       }
     }
 
+    loopIteration++;
   } while (resourcesToCheck.length > 0);
 
   const redisKey = redisGarbageCollectorKey(connector.id);

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -735,7 +735,7 @@ export async function garbageCollect({
   }
 
   const localLogger = logger.child({
-    connectorId,
+    connectorId: connector.id,
     dataSourceName: connector.dataSourceName,
     workspaceId: connector.workspaceId,
   });


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Since https://github.com/dust-tt/dust/pull/5111 has been released. We observed a lot of "Garbage collection is taking too long, giving up." ([logs](https://app.datadoghq.eu/logs?query=%22Garbage%20collection%20is%20taking%20too%20long%2C%20giving%20up.%22%20%40workspaceId%3A0e396fe57e%20&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1715933943421&to_ts=1715973106037&live=false)).

This PR introduces additional logging around the garbage collection (GC) code to help diagnose the problem at hand. The initial hypothesis is that there might be an infinite loop somewhere in the current setup.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
