### PR TITLE
Flav/fix notion gc infinity loop

### DIFF
--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -807,13 +807,6 @@ export async function garbageCollect({
         loopIteration,
       });
 
-      if (new Date().getTime() - startTs > GARBAGE_COLLECT_MAX_DURATION_MS) {
-        iterationLogger.warn(
-          "Garbage collection is taking too long, giving up."
-        );
-        break;
-      }
-
       if (x.skipReason) {
         if (x.resourceType === "page") {
           iterationLogger.info(
@@ -950,6 +943,23 @@ export async function garbageCollect({
           },
         });
       }
+    }
+
+    if (new Date().getTime() - startTs > GARBAGE_COLLECT_MAX_DURATION_MS) {
+      localLogger.warn(
+        {
+          resourcesToCheckCount: resourcesToCheck.length,
+          deletedPagesCount,
+          deletedDatabasesCount,
+          skippedPagesCount,
+          skippedDatabasesCount,
+          stillAccessiblePagesCount,
+          stillAccessibleDatabasesCount,
+          loopIteration,
+        },
+        "Garbage collection is taking too long, giving up."
+      );
+      break;
     }
 
     loopIteration++;

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -735,8 +735,9 @@ export async function garbageCollect({
   }
 
   const localLogger = logger.child({
-    workspaceId: connector.workspaceId,
+    connectorId,
     dataSourceName: connector.dataSourceName,
+    workspaceId: connector.workspaceId,
   });
 
   const notionConnectorState = await NotionConnectorState.findOne({

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -951,6 +951,7 @@ export async function garbageCollect({
       }
     }
 
+    loopIteration++;
   } while (resourcesToCheck.length > 0);
 
   const redisKey = redisGarbageCollectorKey(connector.id);

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -735,7 +735,7 @@ export async function garbageCollect({
   }
 
   const localLogger = logger.child({
-    connectorId,
+    connectorId: connector.id,
     dataSourceName: connector.dataSourceName,
     workspaceId: connector.workspaceId,
   });


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
In the past, we had a safeguard in place to prevent the Notion garbage collection process from running for an extended period. If the GC process exceeded the time limit, the loop would be explicitly broken. However, a regression was introduced in the #5109, which moved the check to the nested for loop.

Due to this change, the system would always end up in an infinite loop once the workflow had been running for too long. This PR fixes the issue by moving the check back to the main loop, ensuring that the GC workflow is properly interrupted when necessary.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
