### PR TITLE
Use the right timestamp for notion resources in GC workflow.

### DIFF
--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -983,7 +983,7 @@ export async function garbageCollect({
 
 async function findResourcesNotSeenInGarbageCollectionRun(
   connectorId: ModelId,
-  startTs: number
+  runTimestamp: number
 ): Promise<
   Array<{
     lastSeenTs: Date;
@@ -1023,7 +1023,7 @@ async function findResourcesNotSeenInGarbageCollectionRun(
       where: {
         connectorId,
         lastSeenTs: {
-          [Op.lt]: new Date(startTs - GARBAGE_COLLECTION_INTERVAL_HOURS),
+          [Op.lt]: new Date(runTimestamp - GARBAGE_COLLECTION_INTERVAL_HOURS),
         },
       },
       attributes: ["lastSeenTs", "notionPageId", "skipReason"],
@@ -1051,7 +1051,7 @@ async function findResourcesNotSeenInGarbageCollectionRun(
       where: {
         connectorId,
         lastSeenTs: {
-          [Op.lt]: new Date(startTs - GARBAGE_COLLECTION_INTERVAL_HOURS),
+          [Op.lt]: new Date(runTimestamp - GARBAGE_COLLECTION_INTERVAL_HOURS),
         },
       },
       attributes: ["lastSeenTs", "notionDatabaseId", "skipReason"],

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -758,9 +758,10 @@ export async function garbageCollect({
     // Temporary performance logging.
     const startTime = performance.now();
 
+    // Find the resources not seen in the GC run (using runTimestamp).
     resourcesToCheck = await findResourcesNotSeenInGarbageCollectionRun(
       connector.id,
-      startTs
+      runTimestamp
     );
 
     const endTime = performance.now();
@@ -768,6 +769,7 @@ export async function garbageCollect({
       {
         connectorId: connector.id,
         loopIteration,
+        runTimestamp,
         startTs,
         tookMs: endTime - startTime,
       },


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Since the Notion garbage collection (GC) logic was modified in #5109, the assumption was made that the workflow would update the resources that still existed in Notion with the appropriate timestamp. This would allow us to execute the same SQL query repeatedly and obtain different results each time.

However, there are logs available ([logs](https://app.datadoghq.eu/logs?query=still%20accessible%2C%20not%20deleting.%20%40workspaceId%3A0e396fe57e%20%40databaseId%3A9c251a5e-4115-4985-aeca-76f0318dd213&agg_m=count&agg_m_source=base&agg_t=count&cols=service%2C%40workspaceId%2C%40databaseId&event=AgAAAY-GUmjNtHYm4gAAAAAAAAAYAAAAAEFZLUdVbXp4QUFCMnBmTHFRRnM4d0FEcwAAACQAAAAAMDE4Zjg2NTgtOGY5NS00NzM5LWJiZTctZjAxYzJkNjdkOWNk&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1715945327586&to_ts=1715945625596&live=false)) that indicate we are continuously looping over the same page.

This PR aims to resolve the issue by ensuring that we use the same timestamp when updating the resources that still exist and in the SQL query.

This definitely explain the surge of SQL read queries we have been observing lately.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
