### PR TITLE
Refresh previous page cursor on Notion 504s

### DIFF
--- a/connectors/src/connectors/notion/lib/notion_api.ts
+++ b/connectors/src/connectors/notion/lib/notion_api.ts
@@ -80,17 +80,17 @@ async function refreshLastPageCursor(
     sinceTs: number | null;
   }
 ): Promise<string | null> {
-  const localLogger = logger.child(loggerArgs);
+  // Using a lower page_size (between originalPageSize - 10 and originalPageSize - 1) is safe.
+  // In the worst case, some pages/databases might be processed multiple times,
+  // but this is properly handled downstream.
+  const pageSize = getRandomPageSize(
+    originalPageSize - 10,
+    originalPageSize - 1
+  );
+
+  const localLogger = logger.child({ ...loggerArgs, pageSize });
 
   try {
-    // Using a lower page_size (between originalPageSize - 10 and originalPageSize - 1) is safe.
-    // In the worst case, some pages/databases might be processed multiple times,
-    // but this is properly handled downstream.
-    const pageSize = getRandomPageSize(
-      originalPageSize - 10,
-      originalPageSize - 1
-    );
-
     const refreshedResults = await wrapNotionAPITokenErrors(async () => {
       return notionClient.search({
         sort: sinceTs
@@ -111,7 +111,6 @@ async function refreshLastPageCursor(
     localLogger.info(
       {
         nextCursor,
-        pageSize,
         previousCursor,
       },
       "Refreshed last page cursor from Notion API."

--- a/connectors/src/connectors/notion/lib/notion_api.ts
+++ b/connectors/src/connectors/notion/lib/notion_api.ts
@@ -18,6 +18,7 @@ import {
   isFullDatabase,
   isFullPage,
   isNotionClientError,
+  UnknownHTTPResponseError,
 } from "@notionhq/client";
 import type {
   BlockObjectResponse,
@@ -61,6 +62,71 @@ async function wrapNotionAPITokenErrors<T>(
   }
 }
 
+function getRandomPageSize(min: number, max: number): number {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+async function refreshLastPageCursor(
+  notionClient: Client,
+  {
+    loggerArgs,
+    originalPageSize,
+    previousCursor,
+    sinceTs,
+  }: {
+    loggerArgs: Record<string, string | number>;
+    originalPageSize: number;
+    previousCursor: string;
+    sinceTs: number | null;
+  }
+): Promise<string | null> {
+  const localLogger = logger.child(loggerArgs);
+
+  try {
+    // Using a lower page_size (between originalPageSize - 10 and originalPageSize - 1) is safe.
+    // In the worst case, some pages/databases might be processed multiple times,
+    // but this is properly handled downstream.
+    const pageSize = getRandomPageSize(
+      originalPageSize - 10,
+      originalPageSize - 1
+    );
+
+    const refreshedResults = await wrapNotionAPITokenErrors(async () => {
+      return notionClient.search({
+        sort: sinceTs
+          ? {
+              timestamp: "last_edited_time",
+              direction: "descending",
+            }
+          : undefined,
+        start_cursor: previousCursor || undefined,
+        page_size: pageSize,
+      });
+    });
+
+    const nextCursor = refreshedResults.has_more
+      ? refreshedResults.next_cursor
+      : null;
+
+    localLogger.info(
+      {
+        nextCursor,
+        pageSize,
+        previousCursor,
+      },
+      "Refreshed last page cursor from Notion API."
+    );
+
+    return nextCursor;
+  } catch (e) {
+    localLogger.error(
+      { error: e },
+      "Error refreshing last page cursor from Notion API."
+    );
+    return null;
+  }
+}
+
 /**
  * @param notionAccessToken the access token to use to access the Notion API
  * @param sinceTs a millisecond timestamp representing the minimum last edited time of
@@ -75,7 +141,7 @@ async function wrapNotionAPITokenErrors<T>(
 export async function getPagesAndDatabasesEditedSince(
   notionAccessToken: string,
   sinceTs: number | null,
-  cursor: string | null,
+  cursors: string[],
   loggerArgs: Record<string, string | number> = {},
   skippedDatabaseIds: Set<string> = new Set(),
   retry: { retries: number; backoffFactor: number } = {
@@ -89,7 +155,7 @@ export async function getPagesAndDatabasesEditedSince(
 }> {
   const localLogger = logger.child({
     ...loggerArgs,
-    cursor,
+    cursors,
     sinceTs,
   });
 
@@ -105,9 +171,17 @@ export async function getPagesAndDatabasesEditedSince(
   let resultsPage: SearchResponse | null = null;
 
   let tries = 0;
+  const pageSize = 90;
+
+  const [previousCursor] = cursors;
+  let [, lastCursor = null] = cursors;
   while (tries < retry.retries) {
-    const tryLogger = localLogger.child({ tries, maxTries: retry.retries });
+    const tryLogger = localLogger.child({
+      tries,
+      maxTries: retry.retries,
+    });
     tryLogger.info("Fetching result page from Notion API.");
+
     try {
       resultsPage = await wrapNotionAPITokenErrors(async () => {
         return notionClient.search({
@@ -117,8 +191,8 @@ export async function getPagesAndDatabasesEditedSince(
                 direction: "descending",
               }
             : undefined,
-          start_cursor: cursor || undefined,
-          page_size: 90,
+          start_cursor: lastCursor || undefined,
+          page_size: pageSize,
         });
       });
       tryLogger.info(
@@ -133,6 +207,22 @@ export async function getPagesAndDatabasesEditedSince(
       tries += 1;
       if (tries >= retry.retries) {
         throw e;
+      }
+
+      // Notion API sometimes returns 504 errors.
+      // In such cases, refresh the previous page cursor with randomized page_size.
+      if (
+        UnknownHTTPResponseError.isUnknownHTTPResponseError(e) &&
+        e.status === 504
+      ) {
+        if (previousCursor) {
+          lastCursor = await refreshLastPageCursor(notionClient, {
+            loggerArgs,
+            originalPageSize: pageSize,
+            previousCursor,
+            sinceTs,
+          });
+        }
       }
 
       const sleepTime = 500 * retry.backoffFactor ** tries;

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -265,13 +265,13 @@ export async function fetchDatabaseChildPages({
 export async function getPagesAndDatabasesToSync({
   connectorId,
   lastSyncedAt,
-  cursor,
+  cursors,
   excludeUpToDatePages,
   loggerArgs,
 }: {
   connectorId: ModelId;
   lastSyncedAt: number | null;
-  cursor: string | null;
+  cursors: string[];
   excludeUpToDatePages: boolean;
   loggerArgs: Record<string, string | number>;
 }): Promise<{
@@ -310,7 +310,7 @@ export async function getPagesAndDatabasesToSync({
     res = await getPagesAndDatabasesEditedSince(
       accessToken,
       lastSyncedAt,
-      cursor,
+      cursors,
       {
         ...loggerArgs,
         dataSourceName: connector.dataSourceName,
@@ -1023,7 +1023,7 @@ async function findResourcesNotSeenInGarbageCollectionRun(
       where: {
         connectorId,
         lastSeenTs: {
-          [Op.lt]: new Date(runTimestamp - GARBAGE_COLLECTION_INTERVAL_HOURS),
+          [Op.lt]: new Date(runTimestamp),
         },
       },
       attributes: ["lastSeenTs", "notionPageId", "skipReason"],
@@ -1051,7 +1051,7 @@ async function findResourcesNotSeenInGarbageCollectionRun(
       where: {
         connectorId,
         lastSeenTs: {
-          [Op.lt]: new Date(runTimestamp - GARBAGE_COLLECTION_INTERVAL_HOURS),
+          [Op.lt]: new Date(runTimestamp),
         },
       },
       attributes: ["lastSeenTs", "notionDatabaseId", "skipReason"],


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
In #5134, we are proposing an updated approach based on our recent findings about the 504 errors encountered with the Notion search endpoint. We observed that randomizing the `page_size` value could sometimes resolve the issue, and it seems to be closely related to the provided cursor.

This PR introduces a slight modification to the existing logic by maintaining two cursors, one for the current position (n) and the other for the previous position (n-1). The implemented solution involves refreshing the cursor at n-1 if fetching the page at position n fails. To achieve this, we'll use a randomized `page_size` value that is lower than the previous one to refresh the cursor. **This preserves the "stable" pagination as use the n-1 cursor.**

This approach may result in re-processing pages or databases more than once, but the downstream code is designed to handle this appropriately.

<details>
<summary>Tested on prodbox with the script 👇</summary>

```
import type { ModelId } from "@dust-tt/types";
import { Op } from "sequelize";

import { getPagesAndDatabasesEditedSince } from "@connectors/connectors/notion/lib/notion_api";
import { getNotionAccessToken } from "@connectors/connectors/notion/temporal/activities";
import { NotionDatabase } from "@connectors/lib/models/notion";
import { ConnectorResource } from "@connectors/resources/connector_resource";

async function main(connectorId: ModelId) {
  const connector = await ConnectorResource.fetchById(connectorId);
  if (!connector) {
    throw new Error("Could not find connector");
  }

  const loggerArgs = {
    connectorId: connector.id,
    dataSourceName: connector.dataSourceName,
    workspaceId: connector.workspaceId,
  };

  const accessToken = await getNotionAccessToken(connector.connectionId);

  const skippedDatabases = await NotionDatabase.findAll({
    where: {
      connectorId: connector.id,
      skipReason: {
        [Op.not]: null,
      },
    },
  });
  const skippedDatabaseIds = new Set(
    skippedDatabases.map((db) => db.notionDatabaseId)
  );

  let cursors: (string | null)[] = [null, null];
  do {
    const results = await getPagesAndDatabasesEditedSince(
      accessToken,
      null,
      cursors.filter((c) => c !== null) as string[],
      {
        ...loggerArgs,
        dataSourceName: connector.dataSourceName,
        workspaceId: connector.workspaceId,
      },
      skippedDatabaseIds
    );

    console.log(">> res:", JSON.stringify(results, null, 2));

    // Update the cursors array to keep only the last 2 cursors.
    cursors = [cursors[1] ?? null, results.nextCursor];
  } while (cursors[1]);
}

main(137)
  .then(() => console.log("DONE"))
  .catch((err) => console.error("Got error:", err));

```

</details> 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

⚠️ Please note that deploying this change will require stopping and restarting all Notion workers, as it involves altering workflow logic and updating the prototype of an activity function. It is not safe to roll back once this change is implemented, as it would necessitate restarting all Notion workflows.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
Once the PR deployed, run:
```
./admin/cli.sh batch restart-all --provider notion
```
