### PR TITLE
Introduce BaseActionConfiguration class

### DIFF
--- a/front/lib/api/assistant/actions/dust_app_run.ts
+++ b/front/lib/api/assistant/actions/dust_app_run.ts
@@ -112,19 +112,12 @@ export class DustAppRunAction extends BaseAction {
   }
 }
 
-export class DustAppRunConfiguration extends BaseActionConfiguration {
+export class DustAppRunConfiguration extends BaseActionConfiguration<DustAppRunConfigurationType> {
   readonly appWorkspaceId: string;
   readonly appId: string;
 
   constructor(blob: DustAppRunConfigurationType) {
-    super(
-      blob.id,
-      blob.sId,
-      blob.type,
-      blob.name,
-      blob.description,
-      blob.forceUseAtIteration
-    );
+    super(blob);
 
     this.appWorkspaceId = blob.appWorkspaceId;
     this.appId = blob.appId;

--- a/front/lib/api/assistant/actions/dust_app_run.ts
+++ b/front/lib/api/assistant/actions/dust_app_run.ts
@@ -1,4 +1,5 @@
 import type {
+  BaseActionRunParams,
   DustAppRunBlockEvent,
   DustAppRunConfigurationType,
   DustAppRunErrorEvent,
@@ -10,15 +11,11 @@ import type {
   ModelMessageType,
 } from "@dust-tt/types";
 import type { DustAppParameters, DustAppRunActionType } from "@dust-tt/types";
-import type {
-  AgentActionSpecification,
-  AgentConfigurationType,
-} from "@dust-tt/types";
-import type { AgentMessageType, ConversationType } from "@dust-tt/types";
+import type { AgentActionSpecification } from "@dust-tt/types";
 import type { SpecificationType } from "@dust-tt/types";
 import type { DatasetSchema } from "@dust-tt/types";
 import type { Result } from "@dust-tt/types";
-import { BaseAction, DustAPI } from "@dust-tt/types";
+import { BaseAction, BaseActionConfiguration, DustAPI } from "@dust-tt/types";
 import { Err, Ok } from "@dust-tt/types";
 
 import { getApp } from "@app/lib/api/app";
@@ -115,131 +112,364 @@ export class DustAppRunAction extends BaseAction {
   }
 }
 
-/**
- * Params generation.
- */
+export class DustAppRunConfiguration extends BaseActionConfiguration {
+  readonly appWorkspaceId: string;
+  readonly appId: string;
 
-async function dustAppRunActionSpecification({
-  schema,
-  name,
-  description,
-}: {
-  schema: DatasetSchema | null;
-  name: string;
-  description: string;
-}): Promise<Result<AgentActionSpecification, Error>> {
-  // If we have no schema (aka no input block) there is no need to generate any input.
-  if (!schema) {
+  constructor(blob: DustAppRunConfigurationType) {
+    super(
+      blob.id,
+      blob.sId,
+      blob.type,
+      blob.name,
+      blob.description,
+      blob.forceUseAtIteration
+    );
+
+    this.appWorkspaceId = blob.appWorkspaceId;
+    this.appId = blob.appId;
+  }
+
+  /**
+   *  Generates the action specification for generation of rawInputs passed to `runDustApp`.
+   **/
+  async buildSpecification(
+    auth: Authenticator,
+    { name, description }: { name?: string; description?: string }
+  ): Promise<Result<AgentActionSpecification, Error>> {
+    const owner = auth.workspace();
+    if (!owner) {
+      throw new Error("Unexpected unauthenticated call to `runRetrieval`");
+    }
+
+    if (owner.sId !== this.appWorkspaceId) {
+      return new Err(
+        new Error(
+          "Runing Dust apps that are not part of your own workspace is not supported yet."
+        )
+      );
+    }
+
+    const app = await getApp(auth, this.appId);
+    if (!app) {
+      return new Err(
+        new Error(
+          "Failed to retrieve Dust app " +
+            `${this.appWorkspaceId}/${this.appId}`
+        )
+      );
+    }
+
+    // Parse the specifiaction of the app.
+    const appSpec = JSON.parse(
+      app.savedSpecification || "[]"
+    ) as SpecificationType;
+
+    const appConfig = extractConfig(JSON.parse(app.savedSpecification || "{}"));
+
+    let schema: DatasetSchema | null = null;
+
+    const inputSpec = appSpec.find((b) => b.type === "input");
+    const inputConfig = inputSpec ? appConfig[inputSpec.name] : null;
+    const datasetName: string | null = inputConfig ? inputConfig.dataset : null;
+
+    if (datasetName) {
+      // We have a dataset name we need to find associated schema.
+      schema = await getDatasetSchema(auth, app, datasetName);
+      if (!schema) {
+        return new Err(
+          new Error(
+            "Failed to retrieve schema for Dust app: " +
+              `${this.appWorkspaceId}/${this.appId} ` +
+              `dataset=${datasetName}` +
+              " (make sure you have set descriptions in your app input block dataset)"
+          )
+        );
+      }
+    }
+
+    // Render the action
+    const inputs: {
+      name: string;
+      description: string;
+      type: "string" | "number" | "boolean";
+    }[] = [];
+
+    // If we have no schema (aka no input block) there is no need to generate any input.
+    if (schema) {
+      for (const k of schema) {
+        if (k.type === "json") {
+          return new Err(
+            new Error(
+              `JSON type for Dust app parameters is not supported, string, number and boolean are.`
+            )
+          );
+        }
+
+        inputs.push({
+          name: k.key,
+          description: k.description || "",
+          type: k.type,
+        });
+      }
+    }
+
     return new Ok({
-      name,
-      description,
-      inputs: [],
+      name: name ?? app.name,
+      description: description ?? app.description ?? "",
+      inputs,
     });
   }
 
-  const inputs: {
-    name: string;
-    description: string;
-    type: "string" | "number" | "boolean";
-  }[] = [];
-
-  for (const k of schema) {
-    if (k.type === "json") {
-      return new Err(
-        new Error(
-          `JSON type for Dust app parameters is not supported, string, number and boolean are.`
-        )
-      );
+  /**
+   * This method is in charge of running a dust app and creating an AgentDustAppRunAction object in
+   * the database. It does not create any generic model related to the conversation. It is possible
+   * for an AgentDustAppRunAction to be stored (once the params are infered) but for the dust app run
+   * to fail, in which case an error event will be emitted and the AgentDustAppRunAction won't have
+   * any output associated. The error is expected to be stored by the caller on the parent agent
+   * message.
+   **/
+  async *run(
+    auth: Authenticator,
+    {
+      agentConfiguration,
+      conversation,
+      agentMessage,
+      rawInputs,
+      functionCallId,
+      step,
+    }: BaseActionRunParams,
+    {
+      spec,
+    }: {
+      spec: AgentActionSpecification;
+    }
+  ): AsyncGenerator<
+    | DustAppRunParamsEvent
+    | DustAppRunBlockEvent
+    | DustAppRunSuccessEvent
+    | DustAppRunErrorEvent,
+    void
+  > {
+    const owner = auth.workspace();
+    if (!owner) {
+      throw new Error("Unexpected unauthenticated call to `runDustApp`");
     }
 
-    inputs.push({
-      name: k.key,
-      description: k.description || "",
-      type: k.type,
+    const app = await getApp(auth, this.appId);
+    if (!app) {
+      yield {
+        type: "dust_app_run_error",
+        created: Date.now(),
+        configurationId: agentConfiguration.sId,
+        messageId: agentMessage.sId,
+        error: {
+          code: "dust_app_run_parameters_generation_error",
+          message:
+            "Failed to retrieve Dust app " +
+            `${this.appWorkspaceId}/${this.appId}`,
+        },
+      };
+      return;
+    }
+
+    const appConfig = extractConfig(JSON.parse(app.savedSpecification || `{}`));
+
+    // Check that all inputs are accounted for.
+    const params: DustAppParameters = {};
+
+    for (const k of spec.inputs) {
+      if (rawInputs[k.name] && typeof rawInputs[k.name] === k.type) {
+        params[k.name] = rawInputs[k.name];
+      } else {
+        yield {
+          type: "dust_app_run_error",
+          created: Date.now(),
+          configurationId: agentConfiguration.sId,
+          messageId: agentMessage.sId,
+          error: {
+            code: "dust_app_run_parameters_generation_error",
+            message: `Failed to generate input ${k.name} (expected type ${
+              k.type
+            }, got ${rawInputs[k.name]})`,
+          },
+        };
+        return;
+      }
+    }
+
+    // Create the AgentDustAppRunAction object in the database and yield an event for the generation
+    // of the params. We store the action here as the params have been generated, if an error occurs
+    // later on, the action won't have an output but the error will be stored on the parent agent
+    // message.
+    const action = await AgentDustAppRunAction.create({
+      dustAppRunConfigurationId: this.sId,
+      appWorkspaceId: this.appWorkspaceId,
+      appId: this.appId,
+      appName: app.name,
+      params,
+      functionCallId,
+      functionCallName: this.name,
+      agentMessageId: agentMessage.agentMessageId,
+      step,
     });
-  }
 
-  return new Ok({
-    name,
-    description,
-    inputs,
-  });
-}
+    yield {
+      type: "dust_app_run_params",
+      created: Date.now(),
+      configurationId: agentConfiguration.sId,
+      messageId: agentMessage.sId,
+      action: new DustAppRunAction({
+        id: action.id,
+        appWorkspaceId: this.appWorkspaceId,
+        appId: this.appId,
+        appName: app.name,
+        params,
+        runningBlock: null,
+        output: null,
+        functionCallId,
+        functionCallName: this.name,
+        agentMessageId: agentMessage.agentMessageId,
+        step,
+      }),
+    };
 
-// Generates the action specification for generation of rawInputs passed to `runDustApp`.
-export async function generateDustAppRunSpecification(
-  auth: Authenticator,
-  {
-    actionConfiguration,
-    name,
-    description,
-  }: {
-    actionConfiguration: DustAppRunConfigurationType;
-    name?: string;
-    description?: string;
-  }
-): Promise<Result<AgentActionSpecification, Error>> {
-  const owner = auth.workspace();
-  if (!owner) {
-    throw new Error("Unexpected unauthenticated call to `runRetrieval`");
-  }
+    // Let's run the app now.
+    const now = Date.now();
 
-  if (owner.sId !== actionConfiguration.appWorkspaceId) {
-    return new Err(
-      new Error(
-        "Runing Dust apps that are not part of your own workspace is not supported yet."
-      )
+    const prodCredentials = await prodAPICredentialsForOwner(owner, {
+      useLocalInDev: true,
+    });
+    const api = new DustAPI(prodCredentials, logger, {
+      useLocalInDev: true,
+    });
+
+    // As we run the app (using a system API key here), we do force using the workspace credentials so
+    // that the app executes in the exact same conditions in which they were developed.
+    const runRes = await api.runAppStreamed(
+      {
+        workspaceId: this.appWorkspaceId,
+        appId: this.appId,
+        appHash: "latest",
+      },
+      appConfig,
+      [params],
+      { useWorkspaceCredentials: true }
     );
-  }
 
-  const app = await getApp(auth, actionConfiguration.appId);
-  if (!app) {
-    return new Err(
-      new Error(
-        "Failed to retrieve Dust app " +
-          `${actionConfiguration.appWorkspaceId}/${actionConfiguration.appId}`
-      )
-    );
-  }
-
-  // Parse the specifiaction of the app.
-  const appSpec = JSON.parse(
-    app.savedSpecification || "[]"
-  ) as SpecificationType;
-
-  const appConfig = extractConfig(JSON.parse(app.savedSpecification || "{}"));
-
-  let schema: DatasetSchema | null = null;
-
-  const inputSpec = appSpec.find((b) => b.type === "input");
-  const inputConfig = inputSpec ? appConfig[inputSpec.name] : null;
-  const datasetName: string | null = inputConfig ? inputConfig.dataset : null;
-
-  if (datasetName) {
-    // We have a dataset name we need to find associated schema.
-    schema = await getDatasetSchema(auth, app, datasetName);
-    if (!schema) {
-      return new Err(
-        new Error(
-          "Failed to retrieve schema for Dust app: " +
-            `${actionConfiguration.appWorkspaceId}/${actionConfiguration.appId} ` +
-            `dataset=${datasetName}` +
-            " (make sure you have set descriptions in your app input block dataset)"
-        )
-      );
+    if (runRes.isErr()) {
+      yield {
+        type: "dust_app_run_error",
+        created: Date.now(),
+        configurationId: agentConfiguration.sId,
+        messageId: agentMessage.sId,
+        error: {
+          code: "dust_app_run_error",
+          message: `Error running Dust app: ${runRes.error.message}`,
+        },
+      };
+      return;
     }
+
+    const { eventStream } = runRes.value;
+    let lastBlockOutput: unknown | null = null;
+
+    for await (const event of eventStream) {
+      if (event.type === "error") {
+        yield {
+          type: "dust_app_run_error",
+          created: Date.now(),
+          configurationId: agentConfiguration.sId,
+          messageId: agentMessage.sId,
+          error: {
+            code: "dust_app_run_error",
+            message: `Error running Dust app: ${event.content.message}`,
+          },
+        };
+        return;
+      }
+
+      if (event.type === "block_status") {
+        yield {
+          type: "dust_app_run_block",
+          created: Date.now(),
+          configurationId: agentConfiguration.sId,
+          messageId: agentMessage.sId,
+          action: new DustAppRunAction({
+            id: action.id,
+            appWorkspaceId: this.appWorkspaceId,
+            appId: this.appId,
+            appName: app.name,
+            params,
+            functionCallId,
+            functionCallName: this.name,
+            runningBlock: {
+              type: event.content.block_type,
+              name: event.content.name,
+              status: event.content.status,
+            },
+            output: null,
+            agentMessageId: agentMessage.agentMessageId,
+            step: action.step,
+          }),
+        };
+      }
+
+      if (event.type === "block_execution") {
+        const e = event.content.execution[0][0];
+        if (e.error) {
+          yield {
+            type: "dust_app_run_error",
+            created: Date.now(),
+            configurationId: agentConfiguration.sId,
+            messageId: agentMessage.sId,
+            error: {
+              code: "dust_app_run_error",
+              message: `Error running Dust app: ${e.error}`,
+            },
+          };
+          return;
+        }
+
+        lastBlockOutput = e.value;
+      }
+    }
+
+    // Update DustAppRunAction with the output of the last block.
+    await action.update({
+      output: lastBlockOutput,
+    });
+
+    logger.info(
+      {
+        workspaceId: conversation.owner.sId,
+        conversationId: conversation.sId,
+        elapsed: Date.now() - now,
+      },
+      "[ASSISTANT_TRACE] DustAppRun acion run execution"
+    );
+
+    yield {
+      type: "dust_app_run_success",
+      created: Date.now(),
+      configurationId: agentConfiguration.sId,
+      messageId: agentMessage.sId,
+      action: new DustAppRunAction({
+        id: action.id,
+        appWorkspaceId: this.appWorkspaceId,
+        appId: this.appId,
+        appName: app.name,
+        params,
+        functionCallId,
+        functionCallName: this.name,
+        runningBlock: null,
+        output: lastBlockOutput,
+        agentMessageId: agentMessage.agentMessageId,
+        step: action.step,
+      }),
+    };
   }
-
-  return dustAppRunActionSpecification({
-    schema,
-    name: name ?? app.name,
-    description: description ?? app.description ?? "",
-  });
 }
-
-/**
- * Action rendering.
- */
 
 // Internal interface for the retrieval and rendering of a DustAppRun action. This should not be
 // used outside of api/assistant. We allow a ModelId interface here because we don't have `sId` on
@@ -268,261 +498,4 @@ export async function dustAppRunTypesFromAgentMessageIds(
       step: action.step,
     });
   });
-}
-
-/**
- * Action execution.
- */
-
-// This method is in charge of running a dust app and creating an AgentDustAppRunAction object in
-// the database. It does not create any generic model related to the conversation. It is possible
-// for an AgentDustAppRunAction to be stored (once the params are infered) but for the dust app run
-// to fail, in which case an error event will be emitted and the AgentDustAppRunAction won't have
-// any output associated. The error is expected to be stored by the caller on the parent agent
-// message.
-export async function* runDustApp(
-  auth: Authenticator,
-  {
-    configuration,
-    actionConfiguration,
-    conversation,
-    agentMessage,
-    spec,
-    rawInputs,
-    functionCallId,
-    step,
-  }: {
-    configuration: AgentConfigurationType;
-    actionConfiguration: DustAppRunConfigurationType;
-    conversation: ConversationType;
-    agentMessage: AgentMessageType;
-    spec: AgentActionSpecification;
-    rawInputs: Record<string, string | boolean | number>;
-    functionCallId: string | null;
-    step: number;
-  }
-): AsyncGenerator<
-  | DustAppRunParamsEvent
-  | DustAppRunBlockEvent
-  | DustAppRunSuccessEvent
-  | DustAppRunErrorEvent,
-  void
-> {
-  const owner = auth.workspace();
-  if (!owner) {
-    throw new Error("Unexpected unauthenticated call to `runDustApp`");
-  }
-
-  const app = await getApp(auth, actionConfiguration.appId);
-  if (!app) {
-    yield {
-      type: "dust_app_run_error",
-      created: Date.now(),
-      configurationId: configuration.sId,
-      messageId: agentMessage.sId,
-      error: {
-        code: "dust_app_run_parameters_generation_error",
-        message:
-          "Failed to retrieve Dust app " +
-          `${actionConfiguration.appWorkspaceId}/${actionConfiguration.appId}`,
-      },
-    };
-    return;
-  }
-
-  const appConfig = extractConfig(JSON.parse(app.savedSpecification || `{}`));
-
-  // Check that all inputs are accounted for.
-  const params: DustAppParameters = {};
-
-  for (const k of spec.inputs) {
-    if (rawInputs[k.name] && typeof rawInputs[k.name] === k.type) {
-      params[k.name] = rawInputs[k.name];
-    } else {
-      yield {
-        type: "dust_app_run_error",
-        created: Date.now(),
-        configurationId: configuration.sId,
-        messageId: agentMessage.sId,
-        error: {
-          code: "dust_app_run_parameters_generation_error",
-          message: `Failed to generate input ${k.name} (expected type ${
-            k.type
-          }, got ${rawInputs[k.name]})`,
-        },
-      };
-      return;
-    }
-  }
-
-  // Create the AgentDustAppRunAction object in the database and yield an event for the generation
-  // of the params. We store the action here as the params have been generated, if an error occurs
-  // later on, the action won't have an output but the error will be stored on the parent agent
-  // message.
-  const action = await AgentDustAppRunAction.create({
-    dustAppRunConfigurationId: actionConfiguration.sId,
-    appWorkspaceId: actionConfiguration.appWorkspaceId,
-    appId: actionConfiguration.appId,
-    appName: app.name,
-    params,
-    functionCallId,
-    functionCallName: actionConfiguration.name,
-    agentMessageId: agentMessage.agentMessageId,
-    step,
-  });
-
-  yield {
-    type: "dust_app_run_params",
-    created: Date.now(),
-    configurationId: configuration.sId,
-    messageId: agentMessage.sId,
-    action: new DustAppRunAction({
-      id: action.id,
-      appWorkspaceId: actionConfiguration.appWorkspaceId,
-      appId: actionConfiguration.appId,
-      appName: app.name,
-      params,
-      runningBlock: null,
-      output: null,
-      functionCallId,
-      functionCallName: actionConfiguration.name,
-      agentMessageId: agentMessage.agentMessageId,
-      step,
-    }),
-  };
-
-  // Let's run the app now.
-  const now = Date.now();
-
-  const prodCredentials = await prodAPICredentialsForOwner(owner, {
-    useLocalInDev: true,
-  });
-  const api = new DustAPI(prodCredentials, logger, {
-    useLocalInDev: true,
-  });
-
-  // As we run the app (using a system API key here), we do force using the workspace credentials so
-  // that the app executes in the exact same conditions in which they were developed.
-  const runRes = await api.runAppStreamed(
-    {
-      workspaceId: actionConfiguration.appWorkspaceId,
-      appId: actionConfiguration.appId,
-      appHash: "latest",
-    },
-    appConfig,
-    [params],
-    { useWorkspaceCredentials: true }
-  );
-
-  if (runRes.isErr()) {
-    yield {
-      type: "dust_app_run_error",
-      created: Date.now(),
-      configurationId: configuration.sId,
-      messageId: agentMessage.sId,
-      error: {
-        code: "dust_app_run_error",
-        message: `Error running Dust app: ${runRes.error.message}`,
-      },
-    };
-    return;
-  }
-
-  const { eventStream } = runRes.value;
-  let lastBlockOutput: unknown | null = null;
-
-  for await (const event of eventStream) {
-    if (event.type === "error") {
-      yield {
-        type: "dust_app_run_error",
-        created: Date.now(),
-        configurationId: configuration.sId,
-        messageId: agentMessage.sId,
-        error: {
-          code: "dust_app_run_error",
-          message: `Error running Dust app: ${event.content.message}`,
-        },
-      };
-      return;
-    }
-
-    if (event.type === "block_status") {
-      yield {
-        type: "dust_app_run_block",
-        created: Date.now(),
-        configurationId: configuration.sId,
-        messageId: agentMessage.sId,
-        action: new DustAppRunAction({
-          id: action.id,
-          appWorkspaceId: actionConfiguration.appWorkspaceId,
-          appId: actionConfiguration.appId,
-          appName: app.name,
-          params,
-          functionCallId,
-          functionCallName: actionConfiguration.name,
-          runningBlock: {
-            type: event.content.block_type,
-            name: event.content.name,
-            status: event.content.status,
-          },
-          output: null,
-          agentMessageId: agentMessage.agentMessageId,
-          step: action.step,
-        }),
-      };
-    }
-
-    if (event.type === "block_execution") {
-      const e = event.content.execution[0][0];
-      if (e.error) {
-        yield {
-          type: "dust_app_run_error",
-          created: Date.now(),
-          configurationId: configuration.sId,
-          messageId: agentMessage.sId,
-          error: {
-            code: "dust_app_run_error",
-            message: `Error running Dust app: ${e.error}`,
-          },
-        };
-        return;
-      }
-
-      lastBlockOutput = e.value;
-    }
-  }
-
-  // Update DustAppRunAction with the output of the last block.
-  await action.update({
-    output: lastBlockOutput,
-  });
-
-  logger.info(
-    {
-      workspaceId: conversation.owner.sId,
-      conversationId: conversation.sId,
-      elapsed: Date.now() - now,
-    },
-    "[ASSISTANT_TRACE] DustAppRun acion run execution"
-  );
-
-  yield {
-    type: "dust_app_run_success",
-    created: Date.now(),
-    configurationId: configuration.sId,
-    messageId: agentMessage.sId,
-    action: new DustAppRunAction({
-      id: action.id,
-      appWorkspaceId: actionConfiguration.appWorkspaceId,
-      appId: actionConfiguration.appId,
-      appName: app.name,
-      params,
-      functionCallId,
-      functionCallName: actionConfiguration.name,
-      runningBlock: null,
-      output: lastBlockOutput,
-      agentMessageId: agentMessage.agentMessageId,
-      step: action.step,
-    }),
-  };
 }

--- a/front/lib/api/assistant/actions/index.ts
+++ b/front/lib/api/assistant/actions/index.ts
@@ -1,0 +1,96 @@
+import type {
+  AgentActionSpecification,
+  BaseActionRunParams,
+  ProcessConfigurationType,
+  Result,
+  RetrievalConfigurationType,
+  TablesQueryConfigurationType,
+} from "@dust-tt/types";
+import type {
+  BaseActionConfigurationType,
+  DustAppRunConfigurationType,
+} from "@dust-tt/types";
+import { BaseActionConfiguration } from "@dust-tt/types";
+
+import { DustAppRunConfiguration } from "@app/lib/api/assistant/actions/dust_app_run";
+
+// TEMPORARILY DEFINING THE CLASSES HERE
+class ProcessConfiguration extends BaseActionConfiguration<ProcessConfigurationType> {
+  constructor(t: ProcessConfigurationType) {
+    super(t);
+  }
+
+  async buildSpecification(
+    K: unknown,
+    { name, description }: { name?: string; description?: string }
+  ): Promise<Result<AgentActionSpecification, Error>> {
+    console.log(K, name, description);
+    throw new Error("Method not implemented.");
+  }
+
+  async *run(
+    K: unknown,
+    runParams: BaseActionRunParams,
+    customParams: Record<string, unknown>
+  ): AsyncGenerator<unknown> {
+    yield { K, runParams, customParams };
+    throw new Error("Method not implemented.");
+  }
+}
+class RetrievalConfiguration extends BaseActionConfiguration<RetrievalConfigurationType> {
+  constructor(t: RetrievalConfigurationType) {
+    super(t);
+  }
+
+  async buildSpecification(
+    K: unknown,
+    { name, description }: { name?: string; description?: string }
+  ): Promise<Result<AgentActionSpecification, Error>> {
+    console.log(K, name, description);
+    throw new Error("Method not implemented.");
+  }
+
+  async *run(
+    K: unknown,
+    runParams: BaseActionRunParams,
+    customParams: Record<string, unknown>
+  ): AsyncGenerator<unknown> {
+    yield { K, runParams, customParams };
+    throw new Error("Method not implemented.");
+  }
+}
+class TablesQueryConfiguration extends BaseActionConfiguration<TablesQueryConfigurationType> {
+  constructor(t: TablesQueryConfigurationType) {
+    super(t);
+  }
+
+  async buildSpecification(
+    K: unknown,
+    { name, description }: { name?: string; description?: string }
+  ): Promise<Result<AgentActionSpecification, Error>> {
+    console.log(K, name, description);
+    throw new Error("Method not implemented.");
+  }
+
+  async *run(
+    K: unknown,
+    runParams: BaseActionRunParams,
+    customParams: Record<string, unknown>
+  ): AsyncGenerator<unknown> {
+    yield { K, runParams, customParams };
+    throw new Error("Method not implemented.");
+  }
+}
+
+export const MAP_ACTION_TYPE_TO_CLASS = {
+  dust_app_run_configuration: DustAppRunConfiguration,
+  process_configuration: ProcessConfiguration,
+  retrieval_configuration: RetrievalConfiguration,
+  tables_query_configuration: TablesQueryConfiguration,
+} as const satisfies Record<
+  BaseActionConfigurationType,
+  | { new (x: DustAppRunConfigurationType): DustAppRunConfiguration }
+  | { new (x: ProcessConfigurationType): ProcessConfiguration }
+  | { new (x: RetrievalConfigurationType): RetrievalConfiguration }
+  | { new (x: TablesQueryConfigurationType): TablesQueryConfiguration }
+>;

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -30,7 +30,7 @@ import {
 } from "@dust-tt/types";
 
 import { runActionStreamed } from "@app/lib/actions/server";
-import { DustAppRunConfiguration } from "@app/lib/api/assistant/actions/dust_app_run";
+import { MAP_ACTION_TYPE_TO_CLASS } from "@app/lib/api/assistant/actions";
 import {
   generateProcessSpecification,
   runProcess,
@@ -324,8 +324,8 @@ export async function* runMultiActionsAgent(
 
       specifications.push(r.value);
     } else if (isDustAppRunConfiguration(a)) {
-      const actionAsObject = new DustAppRunConfiguration(a);
-      const r = await actionAsObject.buildSpecification(auth, {
+      const actionClass = new MAP_ACTION_TYPE_TO_CLASS[a.type](a);
+      const r = await actionClass.buildSpecification(auth, {
         name: a.name ?? undefined,
         description: a.description ?? undefined,
       });
@@ -700,8 +700,10 @@ async function* runAction(
       return;
     }
 
-    const actionAsObject = new DustAppRunConfiguration(actionConfiguration);
-    const eventStream = actionAsObject.run(
+    const actionClass = new MAP_ACTION_TYPE_TO_CLASS[actionConfiguration.type](
+      actionConfiguration
+    );
+    const eventStream = actionClass.run(
       auth,
       {
         agentConfiguration: configuration,

--- a/front/lib/api/assistant/legacy_agent.ts
+++ b/front/lib/api/assistant/legacy_agent.ts
@@ -29,7 +29,7 @@ import {
 } from "@dust-tt/types";
 
 import { runActionStreamed } from "@app/lib/actions/server";
-import { DustAppRunConfiguration } from "@app/lib/api/assistant/actions/dust_app_run";
+import { MAP_ACTION_TYPE_TO_CLASS } from "@app/lib/api/assistant/actions";
 import {
   generateProcessSpecification,
   runProcess,
@@ -305,8 +305,8 @@ async function* runAction(
       actionConfiguration: action,
     });
   } else if (isDustAppRunConfiguration(action)) {
-    const actionAsObject = new DustAppRunConfiguration(action);
-    specRes = await actionAsObject.buildSpecification(auth, {});
+    const actionClass = new MAP_ACTION_TYPE_TO_CLASS[action.type](action);
+    specRes = await actionClass.buildSpecification(auth, {});
   } else if (isTablesQueryConfiguration(action)) {
     specRes = await generateTablesQuerySpecification(auth);
   } else if (isProcessConfiguration(action)) {
@@ -435,8 +435,8 @@ async function* runAction(
       }
     }
   } else if (isDustAppRunConfiguration(action)) {
-    const actionAsObject = new DustAppRunConfiguration(action);
-    const eventStream = actionAsObject.run(
+    const actionClass = new MAP_ACTION_TYPE_TO_CLASS[action.type](action);
+    const eventStream = actionClass.run(
       auth,
       {
         agentConfiguration: configuration,

--- a/types/src/front/lib/api/assistant/actions/index.ts
+++ b/types/src/front/lib/api/assistant/actions/index.ts
@@ -1,4 +1,5 @@
 import {
+  AgentActionConfigurationType,
   AgentActionSpecification,
   AgentConfigurationType,
 } from "../../../../../front/assistant/agent";
@@ -41,8 +42,16 @@ export abstract class BaseAction {
 /**
  * Base action configuration.
  */
+const BASE_ACTION_CONFIGURATION_TYPES = [
+  "dust_app_run_configuration",
+  "process_configuration",
+  "retrieval_configuration",
+  "tables_query_configuration",
+] as const;
 
-type BaseActionConfigurationType = "dust_app_run_configuration";
+// Define the ActionType type from the available actions
+export type BaseActionConfigurationType =
+  (typeof BASE_ACTION_CONFIGURATION_TYPES)[number];
 
 export type BaseActionRunParams = {
   agentConfiguration: AgentConfigurationType;
@@ -53,32 +62,34 @@ export type BaseActionRunParams = {
   step: number;
 };
 
-export abstract class BaseActionConfiguration {
-  constructor(
-    readonly id: ModelId,
-    readonly sId: string,
-    readonly type: BaseActionConfigurationType,
-    readonly name: string | null,
-    readonly description: string | null,
-    readonly forceUseAtIteration: number | null
-  ) {
-    this.id = id;
-    this.sId = sId;
-    this.type = type;
-    this.name = name;
-    this.description = description;
-    this.forceUseAtIteration = forceUseAtIteration;
+export abstract class BaseActionConfiguration<
+  T extends AgentActionConfigurationType
+> {
+  readonly id: ModelId;
+  readonly sId: string;
+  readonly type: BaseActionConfigurationType;
+  readonly name: string | null;
+  readonly description: string | null;
+  readonly forceUseAtIteration: number | null;
+
+  constructor(t: T) {
+    this.id = t.id;
+    this.sId = t.sId;
+    this.type = t.type;
+    this.name = t.name;
+    this.description = t.description;
+    this.forceUseAtIteration = t.forceUseAtIteration;
   }
 
   // Action rendering. (unknown for Authenticator - temporary solution until we move back this to Front)
   abstract buildSpecification(
-    T: unknown,
+    K: unknown,
     { name, description }: { name?: string; description?: string }
   ): Promise<Result<AgentActionSpecification, Error>>;
 
   // Action execution.
   abstract run(
-    T: unknown,
+    K: unknown,
     runParams: BaseActionRunParams,
     customParams: Record<string, unknown>
   ): AsyncGenerator<unknown>;

--- a/types/src/front/lib/api/assistant/actions/index.ts
+++ b/types/src/front/lib/api/assistant/actions/index.ts
@@ -1,9 +1,22 @@
+import {
+  AgentActionSpecification,
+  AgentConfigurationType,
+} from "../../../../../front/assistant/agent";
+import {
+  AgentMessageType,
+  ConversationType,
+} from "../../../../../front/assistant/conversation";
 import { ModelId } from "../../../../../shared/model_id";
+import { Result } from "../../../../../shared/result";
 import {
   FunctionCallType,
   FunctionMessageTypeModel,
   ModelMessageType,
 } from "../generation";
+
+/**
+ * Base action.
+ */
 
 type BaseActionType =
   | "dust_app_run_action"
@@ -23,4 +36,50 @@ export abstract class BaseAction {
   abstract renderForModel(): ModelMessageType;
   abstract renderForFunctionCall(): FunctionCallType;
   abstract renderForMultiActionsModel(): FunctionMessageTypeModel;
+}
+
+/**
+ * Base action configuration.
+ */
+
+type BaseActionConfigurationType = "dust_app_run_configuration";
+
+export type BaseActionRunParams = {
+  agentConfiguration: AgentConfigurationType;
+  conversation: ConversationType;
+  agentMessage: AgentMessageType;
+  rawInputs: Record<string, string | boolean | number>;
+  functionCallId: string | null;
+  step: number;
+};
+
+export abstract class BaseActionConfiguration {
+  constructor(
+    readonly id: ModelId,
+    readonly sId: string,
+    readonly type: BaseActionConfigurationType,
+    readonly name: string | null,
+    readonly description: string | null,
+    readonly forceUseAtIteration: number | null
+  ) {
+    this.id = id;
+    this.sId = sId;
+    this.type = type;
+    this.name = name;
+    this.description = description;
+    this.forceUseAtIteration = forceUseAtIteration;
+  }
+
+  // Action rendering. (unknown for Authenticator - temporary solution until we move back this to Front)
+  abstract buildSpecification(
+    T: unknown,
+    { name, description }: { name?: string; description?: string }
+  ): Promise<Result<AgentActionSpecification, Error>>;
+
+  // Action execution.
+  abstract run(
+    T: unknown,
+    runParams: BaseActionRunParams,
+    customParams: Record<string, unknown>
+  ): AsyncGenerator<unknown>;
 }


### PR DESCRIPTION
## Description

Introduce a BaseActionConfiguration class, with a `buildSpecification` and a `run` function.
Refactor `dust_app_run` action to implement this class with as limited impact as possible.

We can't easily edit `DustAppRunConfigurationType` type to extend BaseActionConfiguration as we did for the refactor of action run. So I use this type in the constructor of our new `DustAppRunConfiguration` class.

What is not great in this is that AgentAgentConfigurationType is kind-off lying: 
```js
export type AgentActionConfigurationType =
  | TablesQueryConfigurationType
  | RetrievalConfigurationType
  | DustAppRunConfigurationType
  | ProcessConfigurationType;

// While for Dust app action it's now an instance of DustAppRunConfiguration and not a DustAppRunConfigurationType
```

## Risk

Break Dust App Run action. 
Can be rolled-back.

## Deploy Plan

Deploy front. 
