### PR TITLE
Add missing foreign key constraint on google_drive_configs

### DIFF
--- a/connectors/src/lib/models/google_drive.ts
+++ b/connectors/src/lib/models/google_drive.ts
@@ -58,8 +58,9 @@ GoogleDriveConfig.init(
     indexes: [{ fields: ["connectorId"], unique: true }],
   }
 );
-// GoogleDriveFolders stores the folders selected by the user to sync.
+ConnectorModel.hasOne(GoogleDriveConfig);
 
+// GoogleDriveFolders stores the folders selected by the user to sync.
 export class GoogleDriveFolders extends Model<
   InferAttributes<GoogleDriveFolders>,
   InferCreationAttributes<GoogleDriveFolders>
@@ -103,8 +104,8 @@ GoogleDriveFolders.init(
   }
 );
 ConnectorModel.hasOne(GoogleDriveFolders);
-// GoogleDriveFiles stores files and folders synced from Google Drive.
 
+// GoogleDriveFiles stores files and folders synced from Google Drive.
 export class GoogleDriveFiles extends Model<
   InferAttributes<GoogleDriveFiles>,
   InferCreationAttributes<GoogleDriveFiles>
@@ -247,7 +248,6 @@ ConnectorModel.hasOne(GoogleDriveSheet);
 
 // Sync Token are the equivalent of a timestamp for syncing the delta
 // between the last sync and the current sync.
-
 export class GoogleDriveSyncToken extends Model<
   InferAttributes<GoogleDriveSyncToken>,
   InferCreationAttributes<GoogleDriveSyncToken>


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Follow up items from Friday's investigation. This PR adds the missing foreign key constraint on the `google_drive_configs` table on `connectorId`. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

We were not always deleting `google_drive_configs` so we have to first delete all the orphaned configs before running init_db.

```
SELECT COUNT(*) FROM google_drive_configs AS gdc LEFT JOIN connectors as c ON gdc."connectorId" = c.id WHERE c.id IS NULL
```
Returns 158 connectors.

Will delete them with:
```
BEGIN;
DELETE from google_drive_configs  WHERE id IN(
 SELECT gdc.id FROM google_drive_configs AS gdc LEFT JOIN connectors as c ON gdc."connectorId" = c.id WHERE c.id IS NULL
)
COMMIT;
```

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
