### PR TITLE
[QDrant] Add unique index on data_source.internal_id

### DIFF
--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -437,7 +437,7 @@ pub const POSTGRES_TABLES: [&'static str; 14] = [
     );",
 ];
 
-pub const SQL_INDEXES: [&'static str; 22] = [
+pub const SQL_INDEXES: [&'static str; 23] = [
     "CREATE INDEX IF NOT EXISTS
        idx_specifications_project_created ON specifications (project, created);",
     "CREATE INDEX IF NOT EXISTS
@@ -463,6 +463,8 @@ pub const SQL_INDEXES: [&'static str; 22] = [
        idx_cache_project_hash ON cache (project, hash);",
     "CREATE UNIQUE INDEX IF NOT EXISTS
        idx_data_sources_project_data_source_id ON data_sources (project, data_source_id);",
+    "CREATE UNIQUE INDEX IF NOT EXISTS
+       idx_data_sources_internal_id ON data_sources (internal_id);",
     "CREATE INDEX IF NOT EXISTS
        idx_data_sources_documents_data_source_document_id
        ON data_sources_documents (data_source, document_id);",


### PR DESCRIPTION
## Description

Add a unique index on `data_source.internal_id` in preparation for moving to QDrant multi-tenancy
See: https://www.notion.so/dust-tt/Design-Doc-Qdrant-re-arch-d0ebdd6ae8244ff593cdf10f08988c27?pvs=4

## Risk

N/A

## Deploy Plan

- deploy `core` (index will be created at startup)