### PR TITLE
[Multi-Actions] Content fragments

### DIFF
--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -272,6 +272,7 @@ export async function renderConversationForModelMultiActions({
   const messages: ModelMessageTypeMultiActions[] = [];
   const closingAttachmentTag = "</attachment>\n";
 
+  // Render loop.
   // Render all messages and all actions.
   for (let i = conversation.content.length - 1; i >= 0; i--) {
     const versions = conversation.content[i];
@@ -358,8 +359,7 @@ export async function renderConversationForModelMultiActions({
       messages.map((m) => {
         let text = `${m.role} ${"name" in m ? m.name : ""} ${m.content ?? ""}`;
         if (m.role === "content_fragment") {
-          // We want to account for the upcoming </attachment> tag, which will be added once we know if we need to
-          // truncate the content fragment or not.
+          // We want to account for the upcoming </attachment> tag, which will be added in the merging loop.
           text += closingAttachmentTag;
         }
         if ("function_calls" in m) {
@@ -387,6 +387,7 @@ export async function renderConversationForModelMultiActions({
   const truncationMessage = `... (content truncated)`;
   const approxTruncMsgTokenCount = truncationMessage.length / 3;
 
+  // Selection loop.
   for (let i = messages.length - 1; i >= 0; i--) {
     const r = messagesCountRes[i];
     if (r.isErr()) {
@@ -420,6 +421,7 @@ export async function renderConversationForModelMultiActions({
     }
   }
 
+  // Merging loop.
   // Merging content fragments into the preceding user message.
   // Eg: [CF1, CF2, UserMessage, AgentMessage] => [CF1-CF2-UserMessage, AgentMessage]
   for (let i = selected.length - 1; i >= 0; i--) {

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -242,12 +242,6 @@ export async function renderConversationForModel({
     selected.shift();
   }
 
-  console.log(
-    "SINGLE ACTION **************",
-    new Date(),
-    JSON.stringify(selected, null, 2)
-  );
-
   return new Ok({
     modelConversation: {
       messages: selected,
@@ -336,7 +330,7 @@ export async function renderConversationForModelMultiActions({
         messages.unshift({
           role: "content_fragment",
           name: `inject_${m.contentType}`,
-          content: `<file-attachment content-type="${m.contentType}" title="${m.title}">${content}</file-attachment>`,
+          content: `<file-attachment content-type="${m.contentType}" title="${m.title}">${content}</file-attachment>\n`,
         });
       } catch (error) {
         logger.error(
@@ -396,7 +390,7 @@ export async function renderConversationForModelMultiActions({
       if (messages[i].role === "content_fragment") {
         const previousMessage = selected[0];
         previousMessage.content =
-          messages[i].content ?? "" + previousMessage.content;
+          (messages[i].content || "") + `${previousMessage.content}`;
       } else {
         selected.unshift(messages[i]);
       }
@@ -416,7 +410,8 @@ export async function renderConversationForModelMultiActions({
 
       const previousMessage = selected[0];
       previousMessage.content =
-        contentRes.value + truncationMessage + previousMessage.content;
+        // The truncation message is outside of the xml tag <file-attachement/>
+        contentRes.value + truncationMessage + `${previousMessage.content}`;
       tokensUsed += remainingTokens;
       break;
     } else {
@@ -432,12 +427,6 @@ export async function renderConversationForModelMultiActions({
     tokensUsed -= tokenCountRes.value;
     selected.shift();
   }
-
-  console.log(
-    "MultiActions ~~~~~~~~~~~~~~~~~~~~~~~",
-    new Date(),
-    JSON.stringify(selected, null, 2)
-  );
 
   return new Ok({
     modelConversation: {

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -332,8 +332,8 @@ export async function renderConversationForModelMultiActions({
         messages.unshift({
           role: "content_fragment",
           name: `inject_${m.contentType}`,
-          // The closing xml tag </attachment> will be added after the selection loop because we might
-          // need to add a "truncated..." mention there.
+          // The closing </attachment> tag will be added in the merging loop because we might
+          // need to add a "truncated..." mention in the selection loop.
           content: `<attachment type="${m.contentType}" title="${m.title}">\n${content}\n`,
         });
       } catch (error) {
@@ -464,6 +464,8 @@ export async function renderConversationForModelMultiActions({
     tokensUsed -= tokenCountRes.value;
     selected.shift();
   }
+
+  console.log("~~~~~~~~~~~", new Date(), selected);
 
   return new Ok({
     modelConversation: {

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -422,7 +422,7 @@ export async function renderConversationForModelMultiActions({
   }
 
   // Merging loop.
-  // Merging content fragments into the preceding user message.
+  // Merging content fragments into the upcoming user message.
   // Eg: [CF1, CF2, UserMessage, AgentMessage] => [CF1-CF2-UserMessage, AgentMessage]
   for (let i = selected.length - 1; i >= 0; i--) {
     if (selected[i].role === "content_fragment") {
@@ -451,7 +451,7 @@ export async function renderConversationForModelMultiActions({
         closingAttachmentTag,
         userMessage.content,
       ].join("");
-      // Now we remove the content fragment from the array since it was merged into the preceding user message.
+      // Now we remove the content fragment from the array since it was merged into the upcoming user message.
       selected.splice(i, 1);
     }
   }
@@ -464,8 +464,6 @@ export async function renderConversationForModelMultiActions({
     tokensUsed -= tokenCountRes.value;
     selected.shift();
   }
-
-  console.log("~~~~~~~~~~~", new Date(), selected);
 
   return new Ok({
     modelConversation: {

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -332,7 +332,7 @@ export async function renderConversationForModelMultiActions({
         messages.unshift({
           role: "content_fragment",
           name: `inject_${m.contentType}`,
-          // The closing xml tag </attachment> will be added after the selection messages loop because we might
+          // The closing xml tag </attachment> will be added after the selection loop because we might
           // need to add a "truncated..." mention there.
           content: `<attachment type="${m.contentType}" title="${m.title}">\n${content}\n`,
         });
@@ -447,7 +447,7 @@ export async function renderConversationForModelMultiActions({
       userMessage.content = [
         cfMessage.content,
         // We can now close the </attachment> tag, because the message was already properly truncated.
-        // We also accounted for the the closing that above when computing the tokens count.
+        // We also accounted for the closing that above when computing the tokens count.
         closingAttachmentTag,
         userMessage.content,
       ].join("");


### PR DESCRIPTION
## Description

Today we send content fragments from `front` with a role `content_fragment` and translate that at the Dust app level to a role `function`.

Models have various restrictions and ways of handling file attachements, which leads us to a new universal format:
Merging content fragments inside the upcoming user message.

Here is what it looks like: 
```
[
 {
    role:"user",
    content:"
    <file-attachement content-type="${type}" title="${filename}">${FILE_CONTENT}</file-attachment>\n
    <file-attachement content-type="${type}" title="${filename}">${FILE_CONTENT}</file-attachment>\n
    ${user_messge.content}",
},
{
  "role":"assistant"
   "content":"..."
}
]
```

In this version of the code, we directly concatenate the strings of content fragment to the previous message, which is always a user message.  A cleaner version could consist of first grouping all messages in subgroups, and process them group by group afterwards.
eg:
```
const messages = [...]
const groupMessages = [[contentFragment1, contentFragment2, userMessage], [agentMessage], [agentMessage], [userMessage], [contentFrag3, contentFrag4, userMessage]].
```

This would be a bit more structured but also a bit more complicated. So I decided to get with direct concatenation.



## Initial test results seem promising, here is a screenshot
![Screenshot 2024-05-20 at 17 11 19](https://github.com/dust-tt/dust/assets/358965/7e6f9f1a-ef07-442c-9762-89de0aaedb54)





<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk
Little since multi actions is behind a feature flag and there is no need to modify the Dust app for now.

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
