### PR TITLE
feat: add support for maxToolsUsePerRun in assistant builder

### DIFF
--- a/front/components/assistant/TryAssistant.tsx
+++ b/front/components/assistant/TryAssistant.tsx
@@ -222,6 +222,7 @@ export function usePreviewAssistant({
         scope: "private",
         generationSettings: builderState.generationSettings,
         actions: removeNulls([action]),
+        maxToolsUsePerRun: builderState.maxToolsUsePerRun,
       },
 
       agentConfigurationId: null,
@@ -246,6 +247,7 @@ export function usePreviewAssistant({
     builderState.instructions,
     builderState.avatarUrl,
     builderState.generationSettings,
+    builderState.maxToolsUsePerRun,
   ]);
 
   useEffect(() => {

--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -14,7 +14,7 @@ import {
   TableStrokeIcon,
 } from "@dust-tt/sparkle";
 import type { AppType, DataSourceType, WorkspaceType } from "@dust-tt/types";
-import { assertNever } from "@dust-tt/types";
+import { assertNever, MAX_TOOLS_USE_PER_RUN_LIMIT } from "@dust-tt/types";
 import type { ReactNode } from "react";
 import React, { useCallback, useEffect, useState } from "react";
 
@@ -218,16 +218,31 @@ export default function ActionsScreen({
       />
 
       <div className="flex flex-col gap-8 text-sm text-element-700">
-        <div className="flex flex-col gap-2">
-          <Page.Header title="Actions & Data sources" />
-          <Page.P>
-            <span className="text-sm text-element-700">
-              Before replying, the assistant can perform actions like{" "}
-              <span className="font-bold">searching information</span> from your{" "}
-              <span className="font-bold">Data sources</span> (Connections and
-              Folders).
-            </span>
-          </Page.P>
+        <div className="flex flex-col sm:flex-row">
+          <div className="flex flex-col gap-2">
+            <Page.Header title="Actions & Data sources" />
+            <Page.P>
+              <span className="text-sm text-element-700">
+                Before replying, the assistant can perform actions like{" "}
+                <span className="font-bold">searching information</span> from
+                your <span className="font-bold">Data sources</span>{" "}
+                (Connections and Folders).
+              </span>
+            </Page.P>
+          </div>
+          <div className="flex-grow" />
+          <div className="self-end">
+            <AdvancedSettings
+              maxToolsUsePerRun={builderState.maxToolsUsePerRun}
+              setMaxToolsUsePerRun={(maxToolsUsePerRun) => {
+                setEdited(true);
+                setBuilderState((state) => ({
+                  ...state,
+                  maxToolsUsePerRun,
+                }));
+              }}
+            />
+          </div>
         </div>
 
         <div className="flex flex-col gap-4">
@@ -606,5 +621,59 @@ function ActionEditor({
         />
       </div>
     </div>
+  );
+}
+
+function AdvancedSettings({
+  maxToolsUsePerRun,
+  setMaxToolsUsePerRun,
+}: {
+  maxToolsUsePerRun: number | null;
+  setMaxToolsUsePerRun: (maxToolsUsePerRun: number | null) => void;
+}) {
+  return (
+    <DropdownMenu>
+      <DropdownMenu.Button>
+        <Button
+          label="Advanced settings"
+          variant="tertiary"
+          size="sm"
+          type="menu"
+        />
+      </DropdownMenu.Button>
+      <DropdownMenu.Items width={240} overflow="visible">
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-2">
+            <div className="flex flex-col items-start justify-start">
+              <div className="w-full grow text-sm font-bold text-element-800">
+                Max actions per run
+              </div>
+              <div className="w-full grow text-sm text-element-600">
+                up to {MAX_TOOLS_USE_PER_RUN_LIMIT}
+              </div>
+            </div>
+            <Input
+              value={maxToolsUsePerRun?.toString() ?? ""}
+              placeholder=""
+              name="maxToolsUsePerRun"
+              onChange={(v) => {
+                if (!v || v === "") {
+                  setMaxToolsUsePerRun(null);
+                  return;
+                }
+                const value = parseInt(v);
+                if (
+                  !isNaN(value) &&
+                  value >= 0 &&
+                  value <= MAX_TOOLS_USE_PER_RUN_LIMIT
+                ) {
+                  setMaxToolsUsePerRun(value);
+                }
+              }}
+            />
+          </div>
+        </div>
+      </DropdownMenu.Items>
+    </DropdownMenu>
   );
 }

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -229,6 +229,9 @@ export default function AssistantBuilder({
             ...getDefaultAssistantState().generationSettings,
           },
           actions: initialBuilderState.actions,
+          maxToolsUsePerRun:
+            initialBuilderState.maxToolsUsePerRun ??
+            getDefaultAssistantState().maxToolsUsePerRun,
         }
       : {
           ...getDefaultAssistantState(),
@@ -908,6 +911,10 @@ export async function submitAssistantBuilderForm({
           providerId: builderState.generationSettings.modelSettings.providerId,
           temperature: builderState.generationSettings.temperature,
         },
+        maxToolsUsePerRun: useMultiActions
+          ? builderState.maxToolsUsePerRun ??
+            getDefaultAssistantState().maxToolsUsePerRun
+          : undefined,
       },
       useMultiActions,
     };

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -113,6 +113,7 @@ export type AssistantBuilderState = {
     temperature: number;
   };
   actions: Array<AssistantBuilderActionConfiguration>;
+  maxToolsUsePerRun: number | null;
 };
 
 export type AssistantBuilderInitialState = {
@@ -126,10 +127,11 @@ export type AssistantBuilderInitialState = {
     temperature: number;
   } | null;
   actions: Array<AssistantBuilderActionConfiguration>;
+  maxToolsUsePerRun: number | null;
 };
 
 // Creates a fresh instance of AssistantBuilderState to prevent unintended mutations of shared state.
-export function getDefaultAssistantState(): AssistantBuilderState {
+export function getDefaultAssistantState() {
   return {
     actions: [],
     handle: null,
@@ -144,7 +146,8 @@ export function getDefaultAssistantState(): AssistantBuilderState {
       },
       temperature: 0.7,
     },
-  };
+    maxToolsUsePerRun: 3,
+  } satisfies AssistantBuilderState;
 }
 
 export function getDefaultRetrievalSearchActionConfiguration() {

--- a/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
@@ -186,6 +186,9 @@ export default function EditAssistant({
           temperature: agentConfiguration.model.temperature,
         },
         actions,
+        maxToolsUsePerRun: isMultiActionsAgent
+          ? agentConfiguration.maxToolsUsePerRun
+          : null,
       }}
       agentConfigurationId={agentConfiguration.sId}
       baseUrl={baseUrl}

--- a/front/pages/w/[wId]/builder/assistants/new.tsx
+++ b/front/pages/w/[wId]/builder/assistants/new.tsx
@@ -226,6 +226,7 @@ export default function CreateAssistant({
                 },
                 temperature: agentConfiguration.model.temperature,
               },
+              maxToolsUsePerRun: null,
             }
           : null
       }

--- a/types/src/front/assistant/agent.ts
+++ b/types/src/front/assistant/agent.ts
@@ -192,3 +192,5 @@ export interface TemplateAgentConfigurationType {
   instructions: string | null;
   isTemplate: true;
 }
+
+export const MAX_TOOLS_USE_PER_RUN_LIMIT = 8;


### PR DESCRIPTION
## Description

<img width="1016" alt="Screenshot 2024-05-20 at 18 14 53" src="https://github.com/dust-tt/dust/assets/14199823/4215bef8-935f-4789-b3ee-e4e2efbdaf36">

We want to allow configuring this value for multi actions agent (up to 8)

https://github.com/dust-tt/dust/issues/5153

## Risk

On critical path of AB, but well tested, including single-action assistant.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
