### PR TITLE
Prodbox init command

### DIFF
--- a/k8s/deployments/prodbox-deployment.yaml
+++ b/k8s/deployments/prodbox-deployment.yaml
@@ -20,7 +20,7 @@ spec:
       containers:
         - name: web
           image: gcr.io/or1g1n-186209/prodbox-image:latest
-          command: ["/bin/sh", "-c", "tail -f /dev/null"]
+          command: ["/bin/sh", "-c", "/dust/prodbox/init.sh"]
           imagePullPolicy: Always
 
           envFrom:


### PR DESCRIPTION
## Description

The prodbox init command defined in the dockerfile was never actually executed, because it is overridden in the `k8s/deployments/prodbox-deployment.yaml`

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
