### PR TITLE
Fix limits workspace usage

### DIFF
--- a/front/lib/workspace_usage.ts
+++ b/front/lib/workspace_usage.ts
@@ -93,8 +93,8 @@ export async function unsafeGetUsageData(
     {
       replacements: {
         wId,
-        startDate: format(startDate, "yyyy-MM-dd"), // Use first day of start month
-        endDate: format(endDate, "yyyy-MM-dd"), // Use last day of end month
+        startDate: format(startDate, "yyyy-MM-dd'T'00:00:00"), // Use first day of start month
+        endDate: format(endDate, "yyyy-MM-dd'T'23:59:59"), // Use last day of end month
       },
       type: QueryTypes.SELECT,
     }


### PR DESCRIPTION
## Description

Eng runner card: https://github.com/dust-tt/tasks/issues/767
=> The workspace usage data query was filtering out the last day of the month, even though we use a `<= :endDate`.

## Risk

Break workspace usage data? 
Low risk, and can be rolled-back.

## Deploy Plan

Deploy Front. 
