### PR TITLE
enh: remove churned members and workspaces from CIO

### DIFF
--- a/front/lib/api/user.ts
+++ b/front/lib/api/user.ts
@@ -147,3 +147,18 @@ export async function updateUserFullName({
 
   return true;
 }
+
+export async function unsafeGetUsersByModelId(
+  modelIds: number[]
+): Promise<UserType[]> {
+  if (modelIds.length === 0) {
+    return [];
+  }
+  const users = await User.findAll({
+    where: {
+      id: modelIds,
+    },
+  });
+
+  return users.map((u) => renderUserType(u));
+}

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -222,3 +222,18 @@ export async function evaluateWorkspaceSeatAvailability(
 
   return activeMembersCount < maxUsers;
 }
+
+export async function unsafeGetWorkspacesByModelId(
+  modelIds: number[]
+): Promise<LightWorkspaceType[]> {
+  if (modelIds.length === 0) {
+    return [];
+  }
+  return (
+    await Workspace.findAll({
+      where: {
+        id: modelIds,
+      },
+    })
+  ).map((w) => renderLightWorkspaceType({ workspace: w }));
+}

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -32,7 +32,6 @@ type GetMembershipsOptions = RequireAtLeastOne<{
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface MembershipResource
   extends ReadonlyAttributesType<MembershipModel> {}
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -31,6 +31,7 @@ type GetMembershipsOptions = RequireAtLeastOne<{
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
+// @typescript-eslint/no-unsafe-declaration-merging
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface MembershipResource
   extends ReadonlyAttributesType<MembershipModel> {}

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -31,8 +31,7 @@ type GetMembershipsOptions = RequireAtLeastOne<{
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
-// @typescript-eslint/no-unsafe-declaration-merging
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
+// eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-unsafe-declaration-merging
 export interface MembershipResource
   extends ReadonlyAttributesType<MembershipModel> {}
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging

--- a/front/lib/tracking/customerio/server.ts
+++ b/front/lib/tracking/customerio/server.ts
@@ -280,7 +280,7 @@ export class CustomerioServerSideTracking {
     }
   }
 
-  static async _deleteUser({ user }: { user: UserType }) {
+  static async deleteUser({ user }: { user: UserType }) {
     if (!config.getCustomerIoEnabled()) {
       return;
     }
@@ -303,7 +303,7 @@ export class CustomerioServerSideTracking {
     }
   }
 
-  static async _deleteWorkspace({
+  static async deleteWorkspace({
     workspace,
   }: {
     workspace: LightWorkspaceType;

--- a/front/migrations/20240513_backfill_customerio_delete_free_test.ts
+++ b/front/migrations/20240513_backfill_customerio_delete_free_test.ts
@@ -67,7 +67,7 @@ const backfillCustomerIo = async (execute: boolean) => {
 
         if (execute) {
           promises.push(
-            CustomerioServerSideTracking._deleteUser({
+            CustomerioServerSideTracking.deleteUser({
               user: u,
             }).catch((err) => {
               logger.error(
@@ -91,7 +91,7 @@ const backfillCustomerIo = async (execute: boolean) => {
           );
           if (execute) {
             promises.push(
-              CustomerioServerSideTracking._deleteWorkspace({
+              CustomerioServerSideTracking.deleteWorkspace({
                 workspace: renderLightWorkspaceType({ workspace: ws }),
               }).catch((err) => {
                 logger.error(

--- a/front/temporal/scrub_workspace/activities.ts
+++ b/front/temporal/scrub_workspace/activities.ts
@@ -183,8 +183,8 @@ async function cleanupCustomerio(auth: Authenticator) {
     ? await subscriptionForWorkspaces(workspaceSids)
     : {};
 
-  // Process the workspace users in chunks of 16.
-  const chunks = _.chunk(users, 16);
+  // Process the workspace users in chunks of 4.
+  const chunks = _.chunk(users, 4);
 
   for (const c of chunks) {
     await Promise.all(

--- a/front/temporal/scrub_workspace/activities.ts
+++ b/front/temporal/scrub_workspace/activities.ts
@@ -16,7 +16,10 @@ import { Authenticator, subscriptionForWorkspaces } from "@app/lib/auth";
 import { destroyConversation } from "@app/lib/conversation";
 import { sendAdminDataDeletionEmail } from "@app/lib/email";
 import { Conversation } from "@app/lib/models/assistant/conversation";
-import { FREE_TEST_PLAN_CODE } from "@app/lib/plans/plan_codes";
+import {
+  FREE_NO_PLAN_CODE,
+  FREE_TEST_PLAN_CODE,
+} from "@app/lib/plans/plan_codes";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { CustomerioServerSideTracking } from "@app/lib/tracking/customerio/server";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
@@ -202,7 +205,10 @@ async function cleanupCustomerio(auth: Authenticator) {
           workspacesOfUser.some((w) => {
             const subscription = subscriptionsByWorkspaceSid[w.sId];
             return (
-              subscription && subscription.plan.code !== FREE_TEST_PLAN_CODE
+              subscription &&
+              ![FREE_TEST_PLAN_CODE, FREE_NO_PLAN_CODE].includes(
+                subscription.plan.code
+              )
             );
           })
         ) {

--- a/front/temporal/scrub_workspace/activities.ts
+++ b/front/temporal/scrub_workspace/activities.ts
@@ -1,5 +1,6 @@
-import { ConnectorsAPI } from "@dust-tt/types";
+import { ConnectorsAPI, removeNulls } from "@dust-tt/types";
 import { chunk } from "lodash";
+import _ from "lodash";
 
 import {
   archiveAgentConfiguration,
@@ -7,11 +8,18 @@ import {
 } from "@app/lib/api/assistant/configuration";
 import { isGlobalAgentId } from "@app/lib/api/assistant/global_agents";
 import { deleteDataSource, getDataSources } from "@app/lib/api/data_sources";
+import { renderUserType } from "@app/lib/api/user";
 import { getMembers } from "@app/lib/api/workspace";
-import { Authenticator } from "@app/lib/auth";
+import { Authenticator, subscriptionForWorkspaces } from "@app/lib/auth";
 import { destroyConversation } from "@app/lib/conversation";
 import { sendAdminDataDeletionEmail } from "@app/lib/email";
 import { Conversation } from "@app/lib/models/assistant/conversation";
+import { User } from "@app/lib/models/user";
+import { Workspace } from "@app/lib/models/workspace";
+import { FREE_TEST_PLAN_CODE } from "@app/lib/plans/plan_codes";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { CustomerioServerSideTracking } from "@app/lib/tracking/customerio/server";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 
 export async function sendDataDeletionEmail({
@@ -67,6 +75,7 @@ export async function scrubWorkspaceData({
   await deleteAllConversations(auth);
   await archiveAssistants(auth);
   await deleteDatasources(auth);
+  await cleanupCustomerio(auth);
 }
 
 export async function pauseAllConnectors({
@@ -131,4 +140,114 @@ async function deleteDatasources(auth: Authenticator) {
       throw new Error(`Failed to delete data source: ${r.error.message}`);
     }
   }
+}
+
+async function cleanupCustomerio(auth: Authenticator) {
+  const w = auth.workspace();
+
+  if (!w) {
+    throw new Error("No workspace found");
+  }
+
+  // Fetch all the memberships for the workspace.
+  const workspaceMemberships = await MembershipResource.getLatestMemberships({
+    workspace: w,
+  });
+
+  // Fetch all the users in the workspace.
+  const userIds = workspaceMemberships.map((m) => m.userId);
+  const users = (
+    userIds.length
+      ? await User.findAll({
+          where: {
+            id: userIds,
+          },
+        })
+      : []
+  ).map(renderUserType);
+
+  // For each user, fetch all their memberships.
+  const allMembershipsByUserId = _.groupBy(
+    userIds.length
+      ? await MembershipResource.getLatestMemberships({
+          users,
+        })
+      : [],
+    (m) => m.userId.toString()
+  );
+
+  // For every membership, fetch the workspace.
+  const workspaceIds = Object.values(allMembershipsByUserId)
+    .flat()
+    .map((m) => m.workspaceId);
+  const workspaceById = _.keyBy(
+    workspaceIds.length
+      ? await Workspace.findAll({
+          where: {
+            id: workspaceIds,
+          },
+        })
+      : [],
+    (w) => w.id.toString()
+  );
+
+  // Finally, fetch all the subscriptions for the workspaces.
+  const workspaceSids = Object.values(workspaceById).map((ws) => ws.sId);
+  const subscriptionsByWorkspaceSid = workspaceSids.length
+    ? await subscriptionForWorkspaces(workspaceSids)
+    : {};
+
+  // Process the workspace users in chunks of 16.
+  const chunks = chunk(users, 16);
+
+  for (const c of chunks) {
+    await Promise.all(
+      c.map((u) => {
+        // Get all the memberships of the user.
+        const allMembershipsOfUser =
+          allMembershipsByUserId[u.id.toString()] ?? [];
+        // Get all the workspaces of the user.
+        const workspacesOfUser = removeNulls(
+          allMembershipsOfUser.map(
+            (m) => workspaceById[m.workspaceId.toString()]
+          )
+        );
+        if (
+          workspacesOfUser.some((w) => {
+            const subscription = subscriptionsByWorkspaceSid[w.sId];
+            return (
+              subscription && subscription.plan.code !== FREE_TEST_PLAN_CODE
+            );
+          })
+        ) {
+          // If any of the workspaces has a real subscription, do not delete the user.
+          return;
+        }
+
+        // Delete the user from Customer.io.
+        logger.info(
+          { userId: u.sId },
+          "User is not tied to a workspace with a real subscription anymore, deleting from Customer.io."
+        );
+
+        return CustomerioServerSideTracking.deleteUser({
+          user: u,
+        }).catch((err) => {
+          logger.error(
+            { userId: u.sId, err },
+            "Failed to delete user on Customer.io"
+          );
+        });
+      })
+    );
+  }
+
+  await CustomerioServerSideTracking.deleteWorkspace({
+    workspace: renderLightWorkspaceType({ workspace: w }),
+  }).catch((err) => {
+    logger.error(
+      { workspaceId: w.sId, err },
+      "Failed to delete workspace on Customer.io"
+    );
+  });
 }

--- a/front/temporal/scrub_workspace/activities.ts
+++ b/front/temporal/scrub_workspace/activities.ts
@@ -1,5 +1,4 @@
 import { ConnectorsAPI, removeNulls } from "@dust-tt/types";
-import { chunk } from "lodash";
 import _ from "lodash";
 
 import {
@@ -108,7 +107,7 @@ async function deleteAllConversations(auth: Authenticator) {
     "Deleting all conversations for workspace."
   );
 
-  const conversationChunks = chunk(conversations, 4);
+  const conversationChunks = _.chunk(conversations, 4);
   for (const conversationChunk of conversationChunks) {
     await Promise.all(
       conversationChunk.map(async (c) => {
@@ -185,7 +184,7 @@ async function cleanupCustomerio(auth: Authenticator) {
     : {};
 
   // Process the workspace users in chunks of 16.
-  const chunks = chunk(users, 16);
+  const chunks = _.chunk(users, 16);
 
   for (const c of chunks) {
     await Promise.all(


### PR DESCRIPTION
## Description

https://github.com/dust-tt/tasks/issues/756

When we scrub the workspace (14 days after subscription is ended), we need to cleanup customerio.

What we're doing here is that we fetch all the workspace members, and for each of them we delete them from CIO if they do not have another workspace with an active subscription. This is imperfect, because if the other workspace of the user is churned but not yet scrubbed, we'll still delete the user when the first workspace is scrubbed. But this is relatively unimportant and also really an edge case.

We then also delete the workspace from CIO.

## Risk

Not too risky. Worst case we break the scrubbing but we'll find out.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
