### PR TITLE
fix: use unix timestamps for CIO fields

### DIFF
--- a/front/lib/tracking/customerio/server.ts
+++ b/front/lib/tracking/customerio/server.ts
@@ -251,10 +251,12 @@ export class CustomerioServerSideTracking {
           role: w.role,
         };
         if (w.startAt !== undefined) {
-          relAttributes.start_at = w.startAt;
+          relAttributes.start_at = Math.floor(w.startAt.getTime() / 1000);
         }
         if (w.endAt !== undefined) {
-          relAttributes.end_at = w.endAt;
+          relAttributes.end_at = w.endAt
+            ? Math.floor(w.endAt.getTime() / 1000)
+            : null;
         }
         return {
           identifiers: {


### PR DESCRIPTION
## Description

https://github.com/dust-tt/tasks/issues/756

CIO wants unix timestamps for datetimes, ISO are just being treated as strings.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
