### PR TITLE
Associate slack user messages to the right user

### DIFF
--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -437,7 +437,7 @@ async function botAnswerMessage(
     const mesasgeRes = await dustAPI.postUserMessage({
       conversationId: lastSlackChatBotMessage.conversationId,
       message: messageReqBody,
-      userEmail:
+      userEmailHeader:
         slackChatBotMessage.slackEmail !== "unknown"
           ? slackChatBotMessage.slackEmail
           : undefined,
@@ -459,7 +459,7 @@ async function botAnswerMessage(
       visibility: "unlisted",
       message: messageReqBody,
       contentFragment: buildContentFragmentRes.value || undefined,
-      userEmail:
+      userEmailHeader:
         slackChatBotMessage.slackEmail !== "unknown"
           ? slackChatBotMessage.slackEmail
           : undefined,

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -437,7 +437,10 @@ async function botAnswerMessage(
     const mesasgeRes = await dustAPI.postUserMessage({
       conversationId: lastSlackChatBotMessage.conversationId,
       message: messageReqBody,
-      userEmail: slackChatBotMessage.slackEmail,
+      userEmail:
+        slackChatBotMessage.slackEmail !== "unknown"
+          ? slackChatBotMessage.slackEmail
+          : undefined,
     });
     if (mesasgeRes.isErr()) {
       return new Err(new Error(mesasgeRes.error.message));
@@ -456,7 +459,10 @@ async function botAnswerMessage(
       visibility: "unlisted",
       message: messageReqBody,
       contentFragment: buildContentFragmentRes.value || undefined,
-      userEmail: slackChatBotMessage.slackEmail,
+      userEmail:
+        slackChatBotMessage.slackEmail !== "unknown"
+          ? slackChatBotMessage.slackEmail
+          : undefined,
     });
     if (convRes.isErr()) {
       return new Err(new Error(convRes.error.message));

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -437,6 +437,7 @@ async function botAnswerMessage(
     const mesasgeRes = await dustAPI.postUserMessage({
       conversationId: lastSlackChatBotMessage.conversationId,
       message: messageReqBody,
+      userEmail: slackChatBotMessage.slackEmail,
     });
     if (mesasgeRes.isErr()) {
       return new Err(new Error(mesasgeRes.error.message));
@@ -455,6 +456,7 @@ async function botAnswerMessage(
       visibility: "unlisted",
       message: messageReqBody,
       contentFragment: buildContentFragmentRes.value || undefined,
+      userEmail: slackChatBotMessage.slackEmail,
     });
     if (convRes.isErr()) {
       return new Err(new Error(convRes.error.message));

--- a/front/create_db_migration_file.sh
+++ b/front/create_db_migration_file.sh
@@ -56,7 +56,7 @@ diff --unified=0 --color=always main_output.txt current_output.txt
 
 # Run diff and extract only SQL statements, ensuring they end with a semicolon.
 echo "Running diff and extracting SQL statements..."
-diff_output=$(diff --unified=0 main_output.txt current_output.txt | awk '/^\+[^+]/ {print substr($0, 2)}') | sed 's/;*$/;/'
+diff_output=$(diff --unified=0 main_output.txt current_output.txt | awk '/^\+[^+]/ {print substr($0, 2)}' | sed 's/;*$/;/')
 if [ -n "$diff_output" ]; then
   echo "-- Migration created on $current_date" > diff_output.txt
   echo "$diff_output" >> diff_output.txt

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -376,7 +376,7 @@ export class Authenticator {
   async exchangeSystemKeyForUserAuthByEmail(
     auth: Authenticator,
     { userEmail }: { userEmail: string }
-  ) {
+  ): Promise<Authenticator | null> {
     if (!auth.isSystemKey()) {
       throw new Error("Provided authenticator does not have a system key.");
     }
@@ -391,8 +391,10 @@ export class Authenticator {
         email: userEmail,
       },
     });
+    // If the user does not exist (e.g., whitelisted email addresses),
+    // simply ignore and return null.
     if (!user) {
-      throw new Error("User not found.");
+      return null;
     }
 
     // Verify that the user has an active membership in the specified workspace.
@@ -401,6 +403,8 @@ export class Authenticator {
         user: renderUserType(user),
         workspace: owner,
       });
+    // If the user does not have an active membership in the workspace,
+    // throw an error to alert the issue.
     if (!activeMembership) {
       throw new Error("User not found.");
     }

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -364,7 +364,16 @@ export class Authenticator {
     });
   }
 
-  async exchangeForUserAPIAuth(
+  /**
+   * Exchanges an Authenticator associated with a system key for one associated with a user.
+   *
+   * /!\ This function should only be used with Authenticators that are associated with a system key.
+   *
+   * @param auth
+   * @param param1
+   * @returns
+   */
+  async exchangeSystemKeyForUserAuthByEmail(
     auth: Authenticator,
     { userEmail }: { userEmail: string }
   ) {
@@ -377,7 +386,6 @@ export class Authenticator {
       throw new Error("Workspace not found.");
     }
 
-    // TODO: add missing index.
     const user = await User.findOne({
       where: {
         email: userEmail,
@@ -387,6 +395,7 @@ export class Authenticator {
       throw new Error("User not found.");
     }
 
+    // Verify that the user has an active membership in the specified workspace.
     const activeMembership =
       await MembershipResource.getActiveMembershipOfUserInWorkspace({
         user: renderUserType(user),

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -404,9 +404,9 @@ export class Authenticator {
         workspace: owner,
       });
     // If the user does not have an active membership in the workspace,
-    // throw an error to alert the issue.
+    // simply ignore and return null.
     if (!activeMembership) {
-      throw new Error("User not found.");
+      return null;
     }
 
     return new Authenticator({

--- a/front/lib/models/user.ts
+++ b/front/lib/models/user.ts
@@ -103,6 +103,7 @@ User.init(
       { fields: ["provider", "providerId"] },
       { fields: ["auth0Sub"], unique: true, concurrently: true },
       { unique: true, fields: ["sId"] },
+      { fields: ["email"] },
     ],
   }
 );

--- a/front/lib/resources/key_resource.ts
+++ b/front/lib/resources/key_resource.ts
@@ -173,6 +173,7 @@ export class KeyResource extends BaseResource<KeyModel> {
     };
   }
 
+  // Use to serialize a KeyResource in the Authenticator.
   toAuthJSON(): KeyAuthType {
     return {
       id: this.id,

--- a/front/lib/resources/key_resource.ts
+++ b/front/lib/resources/key_resource.ts
@@ -18,6 +18,12 @@ import { KeyModel } from "@app/lib/resources/storage/models/keys";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { new_id } from "@app/lib/utils";
 
+export interface KeyAuthType {
+  id: ModelId;
+  name: string | null;
+  isSystem: boolean;
+}
+
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface KeyResource extends ReadonlyAttributesType<KeyModel> {}
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
@@ -164,6 +170,14 @@ export class KeyResource extends BaseResource<KeyModel> {
       name: this.name,
       secret,
       status: this.status,
+    };
+  }
+
+  toAuthJSON(): KeyAuthType {
+    return {
+      id: this.id,
+      name: this.name,
+      isSystem: this.isSystem,
     };
   }
 

--- a/front/migrations/db/migration_08.sql
+++ b/front/migrations/db/migration_08.sql
@@ -1,0 +1,2 @@
+-- Migration created on May 21, 2024
+CREATE INDEX "users_email" ON "users" ("email");

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -27,10 +27,12 @@ async function handler(
     return apiError(req, res, keyRes.error);
   }
 
-  const { auth, keyWorkspaceId } = await Authenticator.fromKey(
+  const authenticator = await Authenticator.fromKey(
     keyRes.value,
     req.query.wId as string
   );
+  let { auth } = authenticator;
+  const { keyWorkspaceId } = authenticator;
 
   if (!auth.isBuilder() || keyWorkspaceId !== req.query.wId) {
     return apiError(req, res, {
@@ -71,21 +73,19 @@ async function handler(
 
       const { content, context, mentions, blocking } = bodyValidation.right;
 
-      let userAuth: Authenticator = auth;
-
       // /!\ This is reserved for internal use!
       // If the header "x-api-user-email" is present and valid,
       // associate the message with the provided user email if it belongs to the same workspace.
       const userEmailFromHeader = req.headers["x-api-user-email"];
       if (typeof userEmailFromHeader === "string") {
-        userAuth =
+        auth =
           (await auth.exchangeSystemKeyForUserAuthByEmail(auth, {
             userEmail: userEmailFromHeader,
           })) ?? auth;
       }
 
       const messageRes = await postUserMessageWithPubSub(
-        userAuth,
+        auth,
         {
           conversation,
           content,

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -78,9 +78,10 @@ async function handler(
       // associate the message with the provided user email if it belongs to the same workspace.
       const userEmailFromHeader = req.headers["x-api-user-email"];
       if (typeof userEmailFromHeader === "string") {
-        userAuth = await auth.exchangeSystemKeyForUserAuthByEmail(auth, {
-          userEmail: userEmailFromHeader,
-        });
+        userAuth =
+          (await auth.exchangeSystemKeyForUserAuthByEmail(auth, {
+            userEmail: userEmailFromHeader,
+          })) ?? auth;
       }
 
       const messageRes = await postUserMessageWithPubSub(

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -78,7 +78,7 @@ async function handler(
       // associate the message with the provided user email if it belongs to the same workspace.
       const userEmailFromHeader = req.headers["x-api-user-email"];
       if (typeof userEmailFromHeader === "string") {
-        userAuth = await auth.exchangeForUserAPIAuth(auth, {
+        userAuth = await auth.exchangeSystemKeyForUserAuthByEmail(auth, {
           userEmail: userEmailFromHeader,
         });
       }

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -71,8 +71,20 @@ async function handler(
 
       const { content, context, mentions, blocking } = bodyValidation.right;
 
+      let userAuth: Authenticator = auth;
+
+      // /!\ This is reserved for internal use!
+      // If the header "x-api-user-email" is present and valid,
+      // associate the message with the provided user email if it belongs to the same workspace.
+      const userEmailFromHeader = req.headers["x-api-user-email"];
+      if (typeof userEmailFromHeader === "string") {
+        userAuth = await auth.exchangeForUserAPIAuth(auth, {
+          userEmail: userEmailFromHeader,
+        });
+      }
+
       const messageRes = await postUserMessageWithPubSub(
-        auth,
+        userAuth,
         {
           conversation,
           content,

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -103,9 +103,10 @@ async function handler(
       // associate the message with the provided user email if it belongs to the same workspace.
       const userEmailFromHeader = req.headers["x-api-user-email"];
       if (typeof userEmailFromHeader === "string") {
-        userAuth = await auth.exchangeSystemKeyForUserAuthByEmail(auth, {
-          userEmail: userEmailFromHeader,
-        });
+        userAuth =
+          (await auth.exchangeSystemKeyForUserAuthByEmail(auth, {
+            userEmail: userEmailFromHeader,
+          })) ?? auth;
       }
 
       let conversation = await createConversation(auth, {

--- a/types/src/front/lib/dust_api.ts
+++ b/types/src/front/lib/dust_api.ts
@@ -508,27 +508,38 @@ export class DustAPI {
   }
 
   // When creating a conversation with a user message, the API returns only after the user message
-  // was created (and if applicable the assocaited agent messages).
+  // was created (and if applicable the associated agent messages).
   async createConversation({
     title,
     visibility,
     message,
     contentFragment,
     blocking = false,
-  }: t.TypeOf<typeof PublicPostConversationsRequestBodySchema>): Promise<
+    userEmail,
+  }: t.TypeOf<typeof PublicPostConversationsRequestBodySchema> & {
+    userEmail?: string;
+  }): Promise<
     DustAPIResponse<{
       conversation: ConversationType;
       message: UserMessageType;
     }>
   > {
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${this._credentials.apiKey}`,
+      "Content-Type": "application/json",
+    };
+
+    console.log(">> creating conversation for email:", userEmail);
+
+    if (userEmail) {
+      headers["X-API-USER-EMAIL"] = userEmail;
+    }
+
     const res = await fetch(
       `${this.apiUrl()}/api/v1/w/${this.workspaceId()}/assistant/conversations`,
       {
         method: "POST",
-        headers: {
-          Authorization: `Bearer ${this._credentials.apiKey}`,
-          "Content-Type": "application/json",
-        },
+        headers,
         body: JSON.stringify({
           title,
           visibility,
@@ -545,18 +556,26 @@ export class DustAPI {
   async postUserMessage({
     conversationId,
     message,
+    userEmail,
   }: {
     conversationId: string;
     message: t.TypeOf<typeof PublicPostMessagesRequestBodySchema>;
+    userEmail?: string;
   }): Promise<DustAPIResponse<UserMessageType>> {
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${this._credentials.apiKey}`,
+      "Content-Type": "application/json",
+    };
+
+    if (userEmail) {
+      headers["X-API-USER-EMAIL"] = userEmail;
+    }
+
     const res = await fetch(
       `${this.apiUrl()}/api/v1/w/${this.workspaceId()}/assistant/conversations/${conversationId}/messages`,
       {
         method: "POST",
-        headers: {
-          Authorization: `Bearer ${this._credentials.apiKey}`,
-          "Content-Type": "application/json",
-        },
+        headers,
         body: JSON.stringify({
           ...message,
         }),

--- a/types/src/front/lib/dust_api.ts
+++ b/types/src/front/lib/dust_api.ts
@@ -529,10 +529,8 @@ export class DustAPI {
       "Content-Type": "application/json",
     };
 
-    console.log(">> creating conversation for email:", userEmail);
-
     if (userEmail) {
-      headers["X-API-USER-EMAIL"] = userEmail;
+      headers["x-api-user-email"] = userEmail;
     }
 
     const res = await fetch(
@@ -568,7 +566,7 @@ export class DustAPI {
     };
 
     if (userEmail) {
-      headers["X-API-USER-EMAIL"] = userEmail;
+      headers["x-api-user-email"] = userEmail;
     }
 
     const res = await fetch(

--- a/types/src/front/lib/dust_api.ts
+++ b/types/src/front/lib/dust_api.ts
@@ -515,9 +515,9 @@ export class DustAPI {
     message,
     contentFragment,
     blocking = false,
-    userEmail,
+    userEmailHeader,
   }: t.TypeOf<typeof PublicPostConversationsRequestBodySchema> & {
-    userEmail?: string;
+    userEmailHeader?: string;
   }): Promise<
     DustAPIResponse<{
       conversation: ConversationType;
@@ -529,8 +529,8 @@ export class DustAPI {
       "Content-Type": "application/json",
     };
 
-    if (userEmail) {
-      headers["x-api-user-email"] = userEmail;
+    if (userEmailHeader) {
+      headers["x-api-user-email"] = userEmailHeader;
     }
 
     const res = await fetch(
@@ -554,19 +554,19 @@ export class DustAPI {
   async postUserMessage({
     conversationId,
     message,
-    userEmail,
+    userEmailHeader,
   }: {
     conversationId: string;
     message: t.TypeOf<typeof PublicPostMessagesRequestBodySchema>;
-    userEmail?: string;
+    userEmailHeader?: string;
   }): Promise<DustAPIResponse<UserMessageType>> {
     const headers: Record<string, string> = {
       Authorization: `Bearer ${this._credentials.apiKey}`,
       "Content-Type": "application/json",
     };
 
-    if (userEmail) {
-      headers["x-api-user-email"] = userEmail;
+    if (userEmailHeader) {
+      headers["x-api-user-email"] = userEmailHeader;
     }
 
     const res = await fetch(


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See https://github.com/dust-tt/tasks/issues/664.

This PR aims to link Dust users with Slack messages. In https://github.com/dust-tt/dust/pull/3643, we implemented safeguards to ensure that users accessing Dust through Slack were active members of the workspace.

This PR advances that functionality by associating Slack messages with their respective users. This is done via an internal request header (`x-api-user-email`) that includes the user's email. If the header is present, we will verify that the user belongs to the correct workspace with the minimum necessary privilege level ("user").

I've chosen to enforce strict validation, so the process will fail if the provided email is invalid. We will use these errors to monitor and prevent abuse.

This PR includes the following changes:
- Adds a non-unique index on the `email` field in the `users` table.
- Ensures the email address is only passed when creating a conversation or posting a message if the email is defined (filter out Slack worflow).
- Restricts the authenticator method that exchanges a system key for user authentication with a strict check on the system key. This method offers flexibility, as not all Slack messages have an active membership due to our support for a whitelist domain system.
- Intentionally avoids creating a reusable function to prevent misuse by others.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
Safe to rollback.

## Deploy Plan

Well tested in the dev environment.

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
