### PR TITLE
enh(builder multi actions): use input fields as per design

### DIFF
--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -14,6 +14,7 @@ import {
   RobotIcon,
   RobotStrokeIcon,
   TableStrokeIcon,
+  TextArea,
   TimeIcon,
   TimeStrokeIcon,
 } from "@dust-tt/sparkle";
@@ -618,7 +619,34 @@ function ActionEditor({
         })()}
       </ActionModeSection>
       <div className="flex flex-col gap-4 pt-8">
-        <div className="font-semibold text-element-700">Action name</div>
+        {DATA_SOURCES_ACTION_CATEGORIES.includes(action.type as any) ? (
+          <div className="flex flex-col gap-2">
+            <div className="font-semibold text-element-800">
+              What's the data?
+            </div>
+            <div className="text-sm text-element-600">
+              Clarify the data's content and context to guide your Assistant in
+              determining when and how to utilize it.
+            </div>
+          </div>
+        ) : (
+          <div className="font-semibold text-element-800">
+            Action description
+          </div>
+        )}
+        <TextArea
+          placeholder="My action description.."
+          value={action.description}
+          onChange={(v) => {
+            updateAction({
+              actionName: action.name,
+              actionDescription: v,
+              getNewActionConfig: (old) => old,
+            });
+          }}
+          error={!descriptionValid ? "Description cannot be empty" : null}
+        />
+        <div className="font-semibold text-element-800">Name of the action</div>
         <Input
           name="actionName"
           placeholder="My action name.."
@@ -631,20 +659,7 @@ function ActionEditor({
             });
           }}
           error={!titleValid ? "Name already exists" : null}
-        />
-        <div className="font-semibold text-element-700">Action description</div>
-        <Input
-          name="actionDescription"
-          placeholder="My action description.."
-          value={action.description}
-          onChange={(v) => {
-            updateAction({
-              actionName: action.name,
-              actionDescription: v,
-              getNewActionConfig: (old) => old,
-            });
-          }}
-          error={!descriptionValid ? "Description cannot be empty" : null}
+          className="text-sm"
         />
       </div>
     </div>


### PR DESCRIPTION
## Description

https://github.com/dust-tt/dust/issues/5007
https://github.com/dust-tt/decisions/issues/213

<img width="803" alt="Screenshot 2024-05-21 at 17 46 52" src="https://github.com/dust-tt/dust/assets/14199823/6f24ca22-72a5-4676-b436-3ee56e3006de">

<img width="804" alt="Screenshot 2024-05-21 at 17 47 00" src="https://github.com/dust-tt/dust/assets/14199823/07bfbe6c-0719-4e11-81ee-2b6d225ace44">

Should now be more or less compliant w/ the design

## Risk

multi-actions only so should be fine
## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
