### PR TITLE
Model generation for failed action with outputs

### DIFF
--- a/front/lib/api/assistant/actions/process.ts
+++ b/front/lib/api/assistant/actions/process.ts
@@ -81,11 +81,6 @@ export class ProcessAction extends BaseAction {
 
   renderForModel(): ModelMessageType {
     let content = "";
-    if (this.outputs === null) {
-      throw new Error(
-        "Output not set on process action; this usually means the process action is not finished."
-      );
-    }
 
     content += "PROCESSED OUTPUTS:\n";
 
@@ -99,6 +94,8 @@ export class ProcessAction extends BaseAction {
           content += `${JSON.stringify(o)}\n`;
         }
       }
+    } else if (this.outputs === null) {
+      content += "(processing failed)\n";
     }
 
     return {
@@ -118,20 +115,19 @@ export class ProcessAction extends BaseAction {
 
   renderForMultiActionsModel(): FunctionMessageTypeModel {
     let content = "";
-    if (this.outputs === null) {
-      throw new Error(
-        "Output not set on process action; this usually means the process action is not finished."
-      );
-    }
 
     content += "PROCESSED OUTPUTS:\n";
 
-    // TODO(spolu): figure out if we want to add the schema here?
-
     if (this.outputs) {
-      for (const o of this.outputs.data) {
-        content += `${JSON.stringify(o)}\n`;
+      if (this.outputs.data.length === 0) {
+        content += "(none)\n";
+      } else {
+        for (const o of this.outputs.data) {
+          content += `${JSON.stringify(o)}\n`;
+        }
       }
+    } else if (this.outputs === null) {
+      content += "(processing failed)\n";
     }
 
     return {

--- a/front/lib/api/assistant/actions/tables_query.ts
+++ b/front/lib/api/assistant/actions/tables_query.ts
@@ -59,13 +59,13 @@ export class TablesQueryAction extends BaseAction {
 
   renderForModel(): ModelMessageType {
     let content = "";
-    if (!this.output) {
-      throw new Error(
-        "Output not set on TablesQuery action; execution is likely not finished."
-      );
-    }
     content += `OUTPUT:\n`;
-    content += `${JSON.stringify(this.output, null, 2)}\n`;
+
+    if (this.output === null) {
+      content += "(query failed)\n";
+    } else {
+      content += `${JSON.stringify(this.output, null, 2)}\n`;
+    }
 
     return {
       role: "action" as const,
@@ -84,13 +84,13 @@ export class TablesQueryAction extends BaseAction {
 
   renderForMultiActionsModel(): FunctionMessageTypeModel {
     let content = "";
-    if (!this.output) {
-      throw new Error(
-        "Output not set on TablesQuery action; execution is likely not finished."
-      );
-    }
     content += `OUTPUT:\n`;
-    content += `${JSON.stringify(this.output, null, 2)}\n`;
+
+    if (this.output === null) {
+      content += "(query failed)\n";
+    } else {
+      content += `${JSON.stringify(this.output, null, 2)}\n`;
+    }
 
     return {
       role: "function" as const,


### PR DESCRIPTION
## Description

TablesQuery and Process have output(s) fields that are set only once the action succeeds. If it fails it is still possible for the user to continue the discussion but the conversation rendering for the model would throw.

Instead render failed action by letting know the model that the action failed.

Context: https://dust4ai.slack.com/archives/C05F84CFP0E/p1716370378105129

## Risk

-N/A

## Deploy Plan

- deploy `front`