### PR TITLE
Move qdrant_collection logic to DustQdrantClient

### DIFF
--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -1145,6 +1145,7 @@ async fn data_sources_register(
                         "data_source": {
                             "created": ds.created(),
                             "data_source_id": ds.data_source_id(),
+                            "data_source_internal_id": ds.internal_id(),
                             "config": ds.config(),
                         },
                     })),
@@ -1238,6 +1239,7 @@ async fn data_sources_retrieve(
                         "data_source": {
                             "created": ds.created(),
                             "data_source_id": ds.data_source_id(),
+                            "data_source_internal_id": ds.internal_id(),
                             "config": ds.config(),
                         },
                     })),

--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -1145,7 +1145,6 @@ async fn data_sources_register(
                         "data_source": {
                             "created": ds.created(),
                             "data_source_id": ds.data_source_id(),
-                            "qdrant_collection": ds.qdrant_collection(),
                             "config": ds.config(),
                         },
                     })),
@@ -1239,7 +1238,6 @@ async fn data_sources_retrieve(
                         "data_source": {
                             "created": ds.created(),
                             "data_source_id": ds.data_source_id(),
-                            "qdrant_collection": ds.qdrant_collection(),
                             "config": ds.config(),
                         },
                     })),

--- a/core/bin/qdrant_migrator.rs
+++ b/core/bin/qdrant_migrator.rs
@@ -84,8 +84,10 @@ async fn show(
     };
 
     utils::info(&format!(
-        "Data source: collection={} cluster={} shadow_write_cluster={}",
-        ds.qdrant_collection(),
+        "Data source: \
+            data_source_id={} data_source_internal_id={} cluster={} shadow_write_cluster={}",
+        ds.data_source_id(),
+        ds.internal_id(),
         qdrant_clients
             .main_cluster(&ds.config().qdrant_config)
             .to_string(),
@@ -100,8 +102,8 @@ async fn show(
         Some(info) => {
             utils::info(&format!(
                 "[MAIN] Qdrant collection: collection={} status={} \
-                             points_count={:?} cluster={} ",
-                ds.qdrant_collection(),
+                    points_count={:?} cluster={} ",
+                qdrant_client.collection_name(&ds),
                 info.status.to_string(),
                 info.points_count,
                 qdrant_clients
@@ -125,8 +127,8 @@ async fn show(
                 Some(info) => {
                     utils::info(&format!(
                         "[SHADOW] Qdrant collection: collection={} status={} \
-                             points_count={:?} cluster={}",
-                        ds.qdrant_collection(),
+                            points_count={:?} cluster={}",
+                        shadow_write_qdrant_client.collection_name(&ds),
                         info.status.to_string(),
                         info.points_count,
                         shadow_write_cluster.to_string(),
@@ -186,8 +188,8 @@ async fn set_shadow_write(
 
     utils::done(&format!(
         "Created qdrant shadow_write_cluster collection: \
-                     collection={} shadow_write_cluster={}",
-        ds.qdrant_collection(),
+            collection={} shadow_write_cluster={}",
+        shadow_write_qdrant_client.collection_name(&ds),
         match qdrant_clients.shadow_write_cluster(&config.qdrant_config) {
             Some(cluster) => cluster.to_string(),
             None => "none".to_string(),
@@ -198,8 +200,10 @@ async fn set_shadow_write(
     ds.update_config(store, &config).await?;
 
     utils::done(&format!(
-        "Updated data source: collection={} cluster={} shadow_write_cluster={}",
-        ds.qdrant_collection(),
+        "Updated data source: \
+            data_source_id={} data_source_internal_id={} cluster={} shadow_write_cluster={}",
+        ds.data_source_id(),
+        ds.internal_id(),
         qdrant_clients
             .main_cluster(&ds.config().qdrant_config)
             .to_string(),
@@ -263,8 +267,8 @@ async fn clear_shadow_write(
 
     utils::done(&format!(
         "Deleted qdrant shadow_write_cluster collection: \
-          collection={} shadow_write_cluster={}",
-        ds.qdrant_collection(),
+            collection={} shadow_write_cluster={}",
+        shadow_write_qdrant_client.collection_name(&ds),
         match qdrant_clients.shadow_write_cluster(&ds.config().qdrant_config) {
             Some(cluster) => cluster.to_string(),
             None => "none".to_string(),
@@ -288,8 +292,10 @@ async fn clear_shadow_write(
     ds.update_config(store, &config).await?;
 
     utils::done(&format!(
-        "Updated data source: collection={} cluster={} shadow_write_cluster={}",
-        ds.qdrant_collection(),
+        "Updated data source: \
+            data_source_id={} data_source_internal_id={} cluster={} shadow_write_cluster={}",
+        ds.data_source_id(),
+        ds.internal_id(),
         qdrant_clients
             .main_cluster(&ds.config().qdrant_config)
             .to_string(),
@@ -450,8 +456,10 @@ async fn commit_shadow_write(
     ds.update_config(store, &config).await?;
 
     utils::info(&format!(
-        "Updated data source: collection={} cluster={} shadow_write_cluster={}",
-        ds.qdrant_collection(),
+        "Updated data source: \
+            data_source_id={} data_source_internal_id={} cluster={} shadow_write_cluster={}",
+        ds.data_source_id(),
+        ds.internal_id(),
         qdrant_clients
             .main_cluster(&ds.config().qdrant_config)
             .to_string(),
@@ -498,8 +506,9 @@ async fn migrate(
         // Confirm this is the migration we want.
         match utils::confirm(&format!(
             "Do you confirm `set_shadow_write` + `migrate_shadow_write`: \
-         ds={} from_cluster={} target_cluster={}?",
-            ds.qdrant_collection(),
+                data_source_id={} data_source_internal_id={} from_cluster={} target_cluster={}?",
+            ds.data_source_id(),
+            ds.internal_id(),
             from_cluster,
             target_cluster,
         ))? {
@@ -550,9 +559,9 @@ async fn migrate(
                 {
                     Some(info) => {
                         utils::info(&format!(
-                            "[SHADOW] Qdrant collection: collection={} status={} \
-                             points_count={:?} cluster={}",
-                            ds.qdrant_collection(),
+                            "[SHADOW] Qdrant collection: \
+                                collection={} status={} points_count={:?} cluster={}",
+                            shadow_write_qdrant_client.collection_name(&ds),
                             info.status.to_string(),
                             info.points_count,
                             shadow_write_cluster.to_string(),
@@ -575,8 +584,9 @@ async fn migrate(
         // Confirm we're ready to commit.
         match utils::confirm(&format!(
             "Do you confirm `commit_shadow_write` + `clear_shadow_write`: \
-         ds={} from_cluster={} target_cluster={}?",
-            ds.qdrant_collection(),
+                data_source_id={} data_source_internal_id={} from_cluster={} target_cluster={}?",
+            ds.data_source_id(),
+            ds.internal_id(),
             from_cluster,
             target_cluster,
         ))? {
@@ -604,8 +614,9 @@ async fn migrate(
 
     utils::done(&format!(
         "Collection migrated: \
-         ds={} from_cluster={} target_cluster={}?",
-        ds.qdrant_collection(),
+            data_source_id={} data_source_internal_id={} from_cluster={} target_cluster={}?",
+        ds.data_source_id(),
+        ds.internal_id(),
         from_cluster,
         target_cluster,
     ));
@@ -646,7 +657,7 @@ async fn migrate_file(
 
     match utils::confirm(&format!(
         "Do you confirm you want to migrate {} collections: \
-         target_cluster={}?",
+            target_cluster={}?",
         records.len(),
         target_cluster,
     ))? {

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -228,14 +228,6 @@ impl SearchFilter {
                         None => (),
                     }
 
-                    info!(
-                        data_source_id = data_source_id,
-                        is_in = ?parents.is_in,
-                        is_in_map = ?parents.is_in_map,
-                        postprocessed_is_in = ?is_in,
-                        "Postprocessed `parents.in`"
-                    );
-
                     Some(ParentsFilter {
                         is_in,
                         is_in_map: None,
@@ -526,10 +518,6 @@ impl DataSource {
         &self.config
     }
 
-    pub fn qdrant_collection(&self) -> String {
-        format!("ds_{}", self.internal_id)
-    }
-
     pub async fn update_config(
         &mut self,
         store: Box<dyn Store + Sync + Send>,
@@ -567,14 +555,14 @@ impl DataSource {
         .await?;
 
         info!(
-            data_source_id = self.data_source_id(),
+            data_source_internal_id = self.internal_id(),
             "Created GCP bucket for data_source"
         );
 
         qdrant_client.create_data_source(self, credentials).await?;
 
         info!(
-            data_source_id = self.data_source_id(),
+            data_source_internal_id = self.internal_id(),
             "Created Qdrant collection and indexes for data_source"
         );
 
@@ -666,15 +654,17 @@ impl DataSource {
                 {
                     Ok(_) => {
                         info!(
+                            data_source_internal_id = self.internal_id(),
                             cluster = ?qdrant_clients.shadow_write_cluster(&self.config.qdrant_config),
-                            collection = self.qdrant_collection(),
+                            collection = qdrant_client.collection_name(self),
                             "[SHADOW_WRITE_SUCCESS] Update payload"
                         );
                     }
                     Err(e) => {
                         error!(
+                            data_source_internal_id = self.internal_id(),
                             cluster = ?qdrant_clients.shadow_write_cluster(&self.config.qdrant_config),
-                            collection = self.qdrant_collection(),
+                            collection = qdrant_client.collection_name(self),
                             error = %e,
                             "[SHADOW_WRITE_FAIL] Update payload"
                         );
@@ -818,34 +808,12 @@ impl DataSource {
         )?;
 
         info!(
-            data_source_id = self.data_source_id(),
+            data_source_internal_id = self.internal_id(),
             document_id = document_id,
             duration = utils::now() - now,
             blob_url = format!("gs://{}/{}", bucket, content_path),
             "Created document blob"
         );
-
-        // Commented for future debug use
-        // match document_id {
-        //     "notion-95804d6b-0274-43f6-8957-5b024234e3bf" => {
-        //         let debug_path = format!("{}/{}/debug.json", bucket_path, document_hash);
-        //         Object::create(
-        //             &bucket,
-        //             serde_json::to_string(&text).unwrap().into_bytes(),
-        //             &debug_path,
-        //             "application/json",
-        //         )
-        //         .await?;
-        //         info!(
-        //             data_source_id = self.data_source_id(),
-        //             document_id = document_id,
-        //             debug_blob_url = format!("gs://{}/{}", bucket, debug_path),
-        //             "Uploaded buggy document"
-        //         );
-        //         panic!("BUGGY document `{}`", document_id);
-        //     }
-        //     _ => (),
-        // };
 
         let now = utils::now();
 
@@ -881,7 +849,7 @@ impl DataSource {
             .collect::<Vec<_>>();
 
         info!(
-            data_source_id = self.data_source_id(),
+            data_source_internal_id = self.internal_id(),
             document_id = document_id,
             split_counts = splits.len(),
             duration = utils::now() - now,
@@ -953,7 +921,7 @@ impl DataSource {
         }
 
         info!(
-            data_source_id = self.data_source_id(),
+            data_source_internal_id = self.internal_id(),
             document_id = document_id,
             chunk_count = embeddings.len(),
             duration = utils::now() - now,
@@ -993,7 +961,7 @@ impl DataSource {
         }
 
         info!(
-            data_source_id = self.data_source_id(),
+            data_source_internal_id = self.internal_id(),
             document_id = document_id,
             chunk_count = splits_to_embbed.len(),
             duration = utils::now() - now,
@@ -1057,15 +1025,17 @@ impl DataSource {
             Some(qdrant_client) => match qdrant_client.delete_points(self, filter.clone()).await {
                 Ok(_) => {
                     info!(
+                        data_source_internal_id = self.internal_id(),
                         cluster = ?qdrant_clients.shadow_write_cluster(&self.config.qdrant_config),
-                        collection = self.qdrant_collection(),
+                        collection = qdrant_client.collection_name(self),
                         "[SHADOW_WRITE_SUCCESS] Delete points"
                     );
                 }
                 Err(e) => {
                     error!(
+                        data_source_internal_id = self.internal_id(),
                         cluster = ?qdrant_clients.shadow_write_cluster(&self.config.qdrant_config),
-                        collection = self.qdrant_collection(),
+                        collection = qdrant_client.collection_name(self),
                         error = %e,
                         "[SHADOW_WRITE_FAIL] Delete points"
                     );
@@ -1077,7 +1047,7 @@ impl DataSource {
         qdrant_client.delete_points(self, filter).await?;
 
         info!(
-            data_source_id = self.data_source_id(),
+            data_source_internal_id = self.internal_id(),
             document_id = document_id,
             duration = utils::now() - now,
             "Deleted previous document in Qdrant"
@@ -1143,15 +1113,17 @@ impl DataSource {
                         match qdrant_client.upsert_points(self, chunk.clone()).await {
                             Ok(_) => {
                                 info!(
+                                    data_source_internal_id = self.internal_id(),
                                     cluster = ?qdrant_clients.shadow_write_cluster(&self.config.qdrant_config),
-                                    collection = self.qdrant_collection(),
+                                    collection = qdrant_client.collection_name(self),
                                     "[SHADOW_WRITE_SUCCESS] Upsert points"
                                 )
                             }
                             Err(e) => {
                                 error!(
+                                    data_source_internal_id = self.internal_id(),
                                     cluster = ?qdrant_clients.shadow_write_cluster(&self.config.qdrant_config),
-                                    collection = self.qdrant_collection(),
+                                    collection = qdrant_client.collection_name(self),
                                     error = %e,
                                     "[SHADOW_WRITE_FAIL] Upsert points"
                                 );
@@ -1164,6 +1136,7 @@ impl DataSource {
                 qdrant_client.upsert_points(self, chunk).await?;
 
                 info!(
+                    data_source_internal_id = self.internal_id(),
                     points_count = chunk_len,
                     duration = utils::now() - now,
                     "Success upserting chunk in Qdrant"
@@ -1172,7 +1145,7 @@ impl DataSource {
         }
 
         info!(
-            data_source_id = self.data_source_id(),
+            data_source_internal_id = self.internal_id(),
             document_id = document_id,
             points_count = points_len,
             duration = utils::now() - start,
@@ -1236,6 +1209,7 @@ impl DataSource {
                     .retrieve_chunks_without_query(store, qdrant_client.clone(), top_k, &filter)
                     .await?;
                 info!(
+                    data_source_internal_id = self.internal_id(),
                     duration = utils::now() - time_embedding_start,
                     "DSSTAT Finished retrieving chunks without query"
                 );
@@ -1252,6 +1226,7 @@ impl DataSource {
                 assert!(v.len() == 1);
 
                 info!(
+                    data_source_internal_id = self.internal_id(),
                     duration = utils::now() - time_embedding_start,
                     "DSSTAT Finished embedding query"
                 );
@@ -1271,7 +1246,8 @@ impl DataSource {
                     .await?;
 
                 info!(
-                    collection_name = self.qdrant_collection(),
+                    data_source_internal_id = self.internal_id(),
+                    collection_name = qdrant_client.collection_name(self),
                     duration = utils::now() - time_search_start,
                     results_count = results.result.len(),
                     "DSSTAT Finished searching Qdrant documents"
@@ -1289,7 +1265,8 @@ impl DataSource {
                 )?;
 
                 info!(
-                    collection_name = self.qdrant_collection(),
+                    data_source_internal_id = self.internal_id(),
+                    collection_name = qdrant_client.collection_name(self),
                     duration = utils::now() - time_chunk_start,
                     chunk_length = chunks.len(),
                     "DSSTAT Finished chunking documents"
@@ -1359,7 +1336,7 @@ impl DataSource {
             .await?;
 
         info!(
-            collection_name = self.qdrant_collection(),
+            data_source_internal_id = self.internal_id(),
             duration = utils::now() - time_store_start,
             document_len = documents.len(),
             "DSSTAT Finished fetching documents from the store"
@@ -1556,7 +1533,7 @@ impl DataSource {
         };
 
         info!(
-            collection_name = self.qdrant_collection(),
+            data_source_internal_id = self.internal_id(),
             duration = utils::now() - time_qdrant_scroll_start,
             results_count = documents.len(),
             "DSSTAT Finished scrolling documents"
@@ -1583,7 +1560,7 @@ impl DataSource {
         }
 
         info!(
-            data_source_id = self.data_source_id(),
+            data_source_internal_id = self.internal_id(),
             document_count = documents.len(),
             chunk_count = documents.iter().map(|d| d.chunks.len()).sum::<usize>(),
             duration = utils::now() - time_embedding_start,
@@ -1813,15 +1790,17 @@ impl DataSource {
             Some(qdrant_client) => match qdrant_client.delete_points(self, filter.clone()).await {
                 Ok(_) => {
                     info!(
+                        data_source_internal_id = self.internal_id(),
                         cluster = ?qdrant_clients.shadow_write_cluster(&self.config.qdrant_config),
-                        collection = self.qdrant_collection(),
+                        collection = qdrant_client.collection_name(self),
                         "[SHADOW_WRITE_SUCCESS] Delete points"
                     );
                 }
                 Err(e) => {
                     error!(
+                        data_source_internal_id = self.internal_id(),
                         cluster = ?qdrant_clients.shadow_write_cluster(&self.config.qdrant_config),
-                        collection = self.qdrant_collection(),
+                        collection = qdrant_client.collection_name(self),
                         error = %e,
                         "[SHADOW_WRITE_FAIL] Delete points"
                     );
@@ -1861,7 +1840,7 @@ impl DataSource {
         qdrant_client.delete_data_source(self).await?;
 
         info!(
-            data_source_id = self.data_source_id(),
+            data_source_internal_id = self.internal_id(),
             "Deleted Qdrant collection"
         );
 
@@ -1877,7 +1856,7 @@ impl DataSource {
         .await?;
 
         info!(
-            data_source_id = self.data_source_id(),
+            data_source_internal_id = self.internal_id(),
             table_count = total,
             "Deleted tables"
         );
@@ -1888,7 +1867,7 @@ impl DataSource {
             .await?;
 
         info!(
-            data_source_id = self.data_source_id(),
+            data_source_internal_id = self.internal_id(),
             "Deleted data source records"
         );
 

--- a/front/components/poke/data_sources/view.tsx
+++ b/front/components/poke/data_sources/view.tsx
@@ -93,7 +93,7 @@ export function ViewDataSourceTable({
                     </Link>{" "}
                     /{" "}
                     <Link
-                      href={`https://app.datadoghq.eu/logs?query=service%3Acore%20%22DSSTAT%20Finished%20searching%20Qdrant%20documents%22%20%22${coreDataSource.qdrant_collection}%22%20&cols=host%2Cservice&index=%2A&messageDisplay=inline&refresh_mode=sliding&stream_sort=desc&view=spans&viz=stream&live=true`}
+                      href={`https://app.datadoghq.eu/logs?query=service%3Acore%20%22DSSTAT%20Finished%20searching%20Qdrant%20documents%22%20%22${coreDataSource.data_source_internal_id}%22%20&cols=host%2Cservice&index=%2A&messageDisplay=inline&refresh_mode=sliding&stream_sort=desc&view=spans&viz=stream&live=true`}
                       target="_blank"
                       className="text-sm text-action-400"
                     >

--- a/types/src/core/data_source.ts
+++ b/types/src/core/data_source.ts
@@ -23,7 +23,6 @@ export type CoreAPIDataSourceConfig = {
 export type CoreAPIDataSource = {
   created: number;
   data_source_id: string;
-  qdrant_collection: string;
   config: CoreAPIDataSourceConfig;
 };
 

--- a/types/src/core/data_source.ts
+++ b/types/src/core/data_source.ts
@@ -23,6 +23,7 @@ export type CoreAPIDataSourceConfig = {
 export type CoreAPIDataSource = {
   created: number;
   data_source_id: string;
+  data_source_internal_id: string;
   config: CoreAPIDataSourceConfig;
 };
 


### PR DESCRIPTION
## Description

Move `qdrant_collection` logic from `DataSource` to `DustQdrantClient`

Fixes https://github.com/dust-tt/dust/issues/5194

I did run `npm run build` on `front` locally to make sure types change has no unexpected impact.

## Risk

Very limited. Small code shuffling.

## Deploy Plan

- deploy `core`