### PR TITLE
Retire mistral-medium

### DIFF
--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -21,7 +21,6 @@ import {
   GPT_3_5_TURBO_MODEL_CONFIG,
   GPT_4O_MODEL_CONFIG,
   MISTRAL_LARGE_MODEL_CONFIG,
-  MISTRAL_MEDIUM_MODEL_CONFIG,
   MISTRAL_SMALL_MODEL_CONFIG,
 } from "@dust-tt/types";
 import { DustAPI } from "@dust-tt/types";
@@ -380,41 +379,6 @@ async function _getMistralLargeGlobalAgent({
     model: {
       providerId: MISTRAL_LARGE_MODEL_CONFIG.providerId,
       modelId: MISTRAL_LARGE_MODEL_CONFIG.modelId,
-      temperature: 0.7,
-    },
-    actions: [],
-    maxToolsUsePerRun: 0,
-  };
-}
-
-async function _getMistralMediumGlobalAgent({
-  auth,
-  settings,
-}: {
-  auth: Authenticator;
-  settings: GlobalAgentSettings | null;
-}): Promise<AgentConfigurationType> {
-  let status = settings?.status ?? "disabled_by_admin";
-  if (!auth.isUpgraded()) {
-    status = "disabled_free_workspace";
-  }
-
-  return {
-    id: -1,
-    sId: GLOBAL_AGENTS_SID.MISTRAL_MEDIUM,
-    version: 0,
-    versionCreatedAt: null,
-    versionAuthorId: null,
-    name: "mistral-medium",
-    description: MISTRAL_MEDIUM_MODEL_CONFIG.description,
-    instructions: null,
-    pictureUrl: "https://dust.tt/static/systemavatar/mistral_avatar_full.png",
-    status,
-    scope: "global",
-    userListStatus: status === "active" ? "in-list" : "not-in-list",
-    model: {
-      providerId: MISTRAL_MEDIUM_MODEL_CONFIG.providerId,
-      modelId: MISTRAL_MEDIUM_MODEL_CONFIG.modelId,
       temperature: 0.7,
     },
     actions: [],
@@ -1044,12 +1008,6 @@ export async function getGlobalAgent(
         auth,
       });
       break;
-    case GLOBAL_AGENTS_SID.MISTRAL_MEDIUM:
-      agentConfiguration = await _getMistralMediumGlobalAgent({
-        settings,
-        auth,
-      });
-      break;
     case GLOBAL_AGENTS_SID.MISTRAL_SMALL:
       agentConfiguration = await _getMistralSmallGlobalAgent({ settings });
       break;
@@ -1104,6 +1062,7 @@ export async function getGlobalAgent(
 const RETIRED_GLOABL_AGENTS_SID = [
   GLOBAL_AGENTS_SID.CLAUDE_2,
   GLOBAL_AGENTS_SID.CLAUDE_INSTANT,
+  GLOBAL_AGENTS_SID.MISTRAL_MEDIUM,
 ];
 
 export async function getGlobalAgents(

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -21,6 +21,7 @@ import {
   GPT_3_5_TURBO_MODEL_CONFIG,
   GPT_4O_MODEL_CONFIG,
   MISTRAL_LARGE_MODEL_CONFIG,
+  MISTRAL_MEDIUM_MODEL_CONFIG,
   MISTRAL_SMALL_MODEL_CONFIG,
 } from "@dust-tt/types";
 import { DustAPI } from "@dust-tt/types";
@@ -379,6 +380,41 @@ async function _getMistralLargeGlobalAgent({
     model: {
       providerId: MISTRAL_LARGE_MODEL_CONFIG.providerId,
       modelId: MISTRAL_LARGE_MODEL_CONFIG.modelId,
+      temperature: 0.7,
+    },
+    actions: [],
+    maxToolsUsePerRun: 0,
+  };
+}
+
+async function _getMistralMediumGlobalAgent({
+  auth,
+  settings,
+}: {
+  auth: Authenticator;
+  settings: GlobalAgentSettings | null;
+}): Promise<AgentConfigurationType> {
+  let status = settings?.status ?? "disabled_by_admin";
+  if (!auth.isUpgraded()) {
+    status = "disabled_free_workspace";
+  }
+
+  return {
+    id: -1,
+    sId: GLOBAL_AGENTS_SID.MISTRAL_MEDIUM,
+    version: 0,
+    versionCreatedAt: null,
+    versionAuthorId: null,
+    name: "mistral-medium",
+    description: MISTRAL_MEDIUM_MODEL_CONFIG.description,
+    instructions: null,
+    pictureUrl: "https://dust.tt/static/systemavatar/mistral_avatar_full.png",
+    status,
+    scope: "global",
+    userListStatus: status === "active" ? "in-list" : "not-in-list",
+    model: {
+      providerId: MISTRAL_MEDIUM_MODEL_CONFIG.providerId,
+      modelId: MISTRAL_MEDIUM_MODEL_CONFIG.modelId,
       temperature: 0.7,
     },
     actions: [],
@@ -1004,6 +1040,12 @@ export async function getGlobalAgent(
       break;
     case GLOBAL_AGENTS_SID.MISTRAL_LARGE:
       agentConfiguration = await _getMistralLargeGlobalAgent({
+        settings,
+        auth,
+      });
+      break;
+    case GLOBAL_AGENTS_SID.MISTRAL_MEDIUM:
+      agentConfiguration = await _getMistralMediumGlobalAgent({
         settings,
         auth,
       });

--- a/types/src/front/lib/assistant.ts
+++ b/types/src/front/lib/assistant.ts
@@ -35,7 +35,6 @@ export const CLAUDE_3_HAIKU_20240307_MODEL_ID =
 export const CLAUDE_2_1_MODEL_ID = "claude-2.1" as const;
 export const CLAUDE_INSTANT_1_2_MODEL_ID = "claude-instant-1.2" as const;
 export const MISTRAL_LARGE_MODEL_ID = "mistral-large-latest" as const;
-export const MISTRAL_MEDIUM_MODEL_ID = "mistral-medium" as const;
 export const MISTRAL_SMALL_MODEL_ID = "mistral-small" as const;
 export const GEMINI_1_5_PRO_LATEST_MODEL_ID = "gemini-1.5-pro-latest" as const;
 
@@ -49,7 +48,6 @@ export const MODEL_IDS = [
   CLAUDE_2_1_MODEL_ID,
   CLAUDE_INSTANT_1_2_MODEL_ID,
   MISTRAL_LARGE_MODEL_ID,
-  MISTRAL_MEDIUM_MODEL_ID,
   MISTRAL_SMALL_MODEL_ID,
   GEMINI_1_5_PRO_LATEST_MODEL_ID,
 ] as const;
@@ -192,18 +190,6 @@ export const MISTRAL_LARGE_MODEL_CONFIG: ModelConfigurationType = {
   shortDescription: "Mistral's large model.",
   supportsMultiActions: true,
 };
-export const MISTRAL_MEDIUM_MODEL_CONFIG: ModelConfigurationType = {
-  providerId: "mistral",
-  modelId: MISTRAL_MEDIUM_MODEL_ID,
-  displayName: "Mistral Medium",
-  contextSize: 32_000,
-  recommendedTopK: 16,
-  recommendedExhaustiveTopK: 56, // 28_672
-  largeModel: true,
-  description: "Mistral's latest `medium` model (32k context).",
-  shortDescription: "Mistral's smartest model.",
-  supportsMultiActions: false,
-};
 export const MISTRAL_SMALL_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "mistral",
   modelId: MISTRAL_SMALL_MODEL_ID,
@@ -241,7 +227,6 @@ export const SUPPORTED_MODEL_CONFIGS: ModelConfigurationType[] = [
   CLAUDE_2_DEFAULT_MODEL_CONFIG,
   CLAUDE_INSTANT_DEFAULT_MODEL_CONFIG,
   MISTRAL_LARGE_MODEL_CONFIG,
-  MISTRAL_MEDIUM_MODEL_CONFIG,
   MISTRAL_SMALL_MODEL_CONFIG,
   GEMINI_PRO_DEFAULT_MODEL_CONFIG,
 ];

--- a/types/src/front/lib/assistant.ts
+++ b/types/src/front/lib/assistant.ts
@@ -35,6 +35,7 @@ export const CLAUDE_3_HAIKU_20240307_MODEL_ID =
 export const CLAUDE_2_1_MODEL_ID = "claude-2.1" as const;
 export const CLAUDE_INSTANT_1_2_MODEL_ID = "claude-instant-1.2" as const;
 export const MISTRAL_LARGE_MODEL_ID = "mistral-large-latest" as const;
+export const MISTRAL_MEDIUM_MODEL_ID = "mistral-medium" as const;
 export const MISTRAL_SMALL_MODEL_ID = "mistral-small" as const;
 export const GEMINI_1_5_PRO_LATEST_MODEL_ID = "gemini-1.5-pro-latest" as const;
 
@@ -48,6 +49,7 @@ export const MODEL_IDS = [
   CLAUDE_2_1_MODEL_ID,
   CLAUDE_INSTANT_1_2_MODEL_ID,
   MISTRAL_LARGE_MODEL_ID,
+  MISTRAL_MEDIUM_MODEL_ID,
   MISTRAL_SMALL_MODEL_ID,
   GEMINI_1_5_PRO_LATEST_MODEL_ID,
 ] as const;
@@ -190,6 +192,18 @@ export const MISTRAL_LARGE_MODEL_CONFIG: ModelConfigurationType = {
   shortDescription: "Mistral's large model.",
   supportsMultiActions: true,
 };
+export const MISTRAL_MEDIUM_MODEL_CONFIG: ModelConfigurationType = {
+  providerId: "mistral",
+  modelId: MISTRAL_MEDIUM_MODEL_ID,
+  displayName: "Mistral Medium",
+  contextSize: 32_000,
+  recommendedTopK: 16,
+  recommendedExhaustiveTopK: 56, // 28_672
+  largeModel: true,
+  description: "Mistral's latest `medium` model (32k context).",
+  shortDescription: "Mistral's smartest model.",
+  supportsMultiActions: false,
+};
 export const MISTRAL_SMALL_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "mistral",
   modelId: MISTRAL_SMALL_MODEL_ID,
@@ -227,6 +241,7 @@ export const SUPPORTED_MODEL_CONFIGS: ModelConfigurationType[] = [
   CLAUDE_2_DEFAULT_MODEL_CONFIG,
   CLAUDE_INSTANT_DEFAULT_MODEL_CONFIG,
   MISTRAL_LARGE_MODEL_CONFIG,
+  MISTRAL_MEDIUM_MODEL_CONFIG,
   MISTRAL_SMALL_MODEL_CONFIG,
   GEMINI_PRO_DEFAULT_MODEL_CONFIG,
 ];


### PR DESCRIPTION
## Description

`mistral-medium` is not available anymore.  We get a lot of ["error=Error streaming tokens from Mistral AI" ](https://app.datadoghq.eu/logs?query=%22error%3DError%20streaming%20tokens%20from%20Mistral%20AI%22%20&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1713513659702&to_ts=1714118459702&live=true), and the underlying error seems to be: 
```
Error querying `mistral:mistral-medium`: error=Too many retries (1): [model_error(retryable=true)] "Service unavailable."
```

Initial goal was to replace it with `open-mixtral-8x22b` but could not merge it, context on the PR: https://github.com/dust-tt/dust/pull/5209.


## Risk

I could first do a small PR to remove mistral-medium from the supported_config


## Deploy Plan

1/ Deploy https://github.com/dust-tt/dust/pull/5213 to prevent users from picking mistral-medium for new agents.
2/  Run: 
```
npx tsx ./scripts/update_assistants_models.ts --fromModel mistral-medium --toModel mistral-large-latest --execute
```
3: Merge and deploy this PR. 



=> I added a commit to fix the first one, I initially wanted to remove all the model configuration but that would break past convo so I added it back and now this PR only contains the retiring of the global agent. Deploy plan stays the same. 