### PR TITLE
Add BaseActionConfigurationServerRunnerConstructor + refactor

### DIFF
--- a/front/lib/api/assistant/actions/dust_app_run.ts
+++ b/front/lib/api/assistant/actions/dust_app_run.ts
@@ -10,11 +10,7 @@ import type {
   ModelMessageType,
 } from "@dust-tt/types";
 import type { DustAppParameters, DustAppRunActionType } from "@dust-tt/types";
-import type {
-  AgentActionSpecification,
-  AgentConfigurationType,
-} from "@dust-tt/types";
-import type { AgentMessageType, ConversationType } from "@dust-tt/types";
+import type { AgentActionSpecification } from "@dust-tt/types";
 import type { SpecificationType } from "@dust-tt/types";
 import type { DatasetSchema } from "@dust-tt/types";
 import type { Result } from "@dust-tt/types";
@@ -22,6 +18,8 @@ import { BaseAction, DustAPI } from "@dust-tt/types";
 import { Err, Ok } from "@dust-tt/types";
 
 import { getApp } from "@app/lib/api/app";
+import type { BaseActionRunParams } from "@app/lib/api/assistant/actions/types";
+import { BaseActionConfigurationServerRunner } from "@app/lib/api/assistant/actions/types";
 import { getDatasetSchema } from "@app/lib/api/datasets";
 import type { Authenticator } from "@app/lib/auth";
 import { prodAPICredentialsForOwner } from "@app/lib/auth";
@@ -119,6 +117,325 @@ export class DustAppRunAction extends BaseAction {
  * Params generation.
  */
 
+export class DustAppRunConfigurationServerRunner extends BaseActionConfigurationServerRunner<DustAppRunConfigurationType> {
+  // Generates the action specification for generation of rawInputs passed to `run`.
+  async buildSpecification(
+    auth: Authenticator,
+    {
+      name,
+      description,
+    }: { name?: string | undefined; description?: string | undefined }
+  ): Promise<Result<AgentActionSpecification, Error>> {
+    const owner = auth.workspace();
+    if (!owner) {
+      throw new Error("Unexpected unauthenticated call to `runRetrieval`");
+    }
+
+    const { actionConfiguration } = this;
+
+    if (owner.sId !== actionConfiguration.appWorkspaceId) {
+      return new Err(
+        new Error(
+          "Runing Dust apps that are not part of your own workspace is not supported yet."
+        )
+      );
+    }
+
+    const app = await getApp(auth, actionConfiguration.appId);
+    if (!app) {
+      return new Err(
+        new Error(
+          "Failed to retrieve Dust app " +
+            `${actionConfiguration.appWorkspaceId}/${actionConfiguration.appId}`
+        )
+      );
+    }
+
+    // Parse the specifiaction of the app.
+    const appSpec = JSON.parse(
+      app.savedSpecification || "[]"
+    ) as SpecificationType;
+
+    const appConfig = extractConfig(JSON.parse(app.savedSpecification || "{}"));
+
+    let schema: DatasetSchema | null = null;
+
+    const inputSpec = appSpec.find((b) => b.type === "input");
+    const inputConfig = inputSpec ? appConfig[inputSpec.name] : null;
+    const datasetName: string | null = inputConfig ? inputConfig.dataset : null;
+
+    if (datasetName) {
+      // We have a dataset name we need to find associated schema.
+      schema = await getDatasetSchema(auth, app, datasetName);
+      if (!schema) {
+        return new Err(
+          new Error(
+            "Failed to retrieve schema for Dust app: " +
+              `${actionConfiguration.appWorkspaceId}/${actionConfiguration.appId} ` +
+              `dataset=${datasetName}` +
+              " (make sure you have set descriptions in your app input block dataset)"
+          )
+        );
+      }
+    }
+
+    return dustAppRunActionSpecification({
+      schema,
+      name: name ?? app.name,
+      description: description ?? app.description ?? "",
+    });
+  }
+
+  // This method is in charge of running a dust app and creating an AgentDustAppRunAction object in
+  // the database. It does not create any generic model related to the conversation. It is possible
+  // for an AgentDustAppRunAction to be stored (once the params are infered) but for the dust app run
+  // to fail, in which case an error event will be emitted and the AgentDustAppRunAction won't have
+  // any output associated. The error is expected to be stored by the caller on the parent agent
+  // message.
+  async *run(
+    auth: Authenticator,
+    {
+      agentConfiguration,
+      conversation,
+      agentMessage,
+      rawInputs,
+      functionCallId,
+      step,
+    }: BaseActionRunParams,
+    {
+      spec,
+    }: {
+      spec: AgentActionSpecification;
+    }
+  ): AsyncGenerator<
+    | DustAppRunParamsEvent
+    | DustAppRunBlockEvent
+    | DustAppRunSuccessEvent
+    | DustAppRunErrorEvent,
+    void
+  > {
+    const owner = auth.workspace();
+    if (!owner) {
+      throw new Error("Unexpected unauthenticated call to `run`");
+    }
+
+    const { actionConfiguration } = this;
+
+    const app = await getApp(auth, actionConfiguration.appId);
+    if (!app) {
+      yield {
+        type: "dust_app_run_error",
+        created: Date.now(),
+        configurationId: agentConfiguration.sId,
+        messageId: agentMessage.sId,
+        error: {
+          code: "dust_app_run_parameters_generation_error",
+          message:
+            "Failed to retrieve Dust app " +
+            `${actionConfiguration.appWorkspaceId}/${actionConfiguration.appId}`,
+        },
+      };
+      return;
+    }
+
+    const appConfig = extractConfig(JSON.parse(app.savedSpecification || `{}`));
+
+    // Check that all inputs are accounted for.
+    const params: DustAppParameters = {};
+
+    for (const k of spec.inputs) {
+      if (rawInputs[k.name] && typeof rawInputs[k.name] === k.type) {
+        params[k.name] = rawInputs[k.name];
+      } else {
+        yield {
+          type: "dust_app_run_error",
+          created: Date.now(),
+          configurationId: agentConfiguration.sId,
+          messageId: agentMessage.sId,
+          error: {
+            code: "dust_app_run_parameters_generation_error",
+            message: `Failed to generate input ${k.name} (expected type ${
+              k.type
+            }, got ${rawInputs[k.name]})`,
+          },
+        };
+        return;
+      }
+    }
+
+    // Create the AgentDustAppRunAction object in the database and yield an event for the generation
+    // of the params. We store the action here as the params have been generated, if an error occurs
+    // later on, the action won't have an output but the error will be stored on the parent agent
+    // message.
+    const action = await AgentDustAppRunAction.create({
+      dustAppRunConfigurationId: actionConfiguration.sId,
+      appWorkspaceId: actionConfiguration.appWorkspaceId,
+      appId: actionConfiguration.appId,
+      appName: app.name,
+      params,
+      functionCallId,
+      functionCallName: actionConfiguration.name,
+      agentMessageId: agentMessage.agentMessageId,
+      step,
+    });
+
+    yield {
+      type: "dust_app_run_params",
+      created: Date.now(),
+      configurationId: agentConfiguration.sId,
+      messageId: agentMessage.sId,
+      action: new DustAppRunAction({
+        id: action.id,
+        appWorkspaceId: actionConfiguration.appWorkspaceId,
+        appId: actionConfiguration.appId,
+        appName: app.name,
+        params,
+        runningBlock: null,
+        output: null,
+        functionCallId,
+        functionCallName: actionConfiguration.name,
+        agentMessageId: agentMessage.agentMessageId,
+        step,
+      }),
+    };
+
+    // Let's run the app now.
+    const now = Date.now();
+
+    const prodCredentials = await prodAPICredentialsForOwner(owner, {
+      useLocalInDev: true,
+    });
+    const api = new DustAPI(prodCredentials, logger, {
+      useLocalInDev: true,
+    });
+
+    // As we run the app (using a system API key here), we do force using the workspace credentials so
+    // that the app executes in the exact same conditions in which they were developed.
+    const runRes = await api.runAppStreamed(
+      {
+        workspaceId: actionConfiguration.appWorkspaceId,
+        appId: actionConfiguration.appId,
+        appHash: "latest",
+      },
+      appConfig,
+      [params],
+      { useWorkspaceCredentials: true }
+    );
+
+    if (runRes.isErr()) {
+      yield {
+        type: "dust_app_run_error",
+        created: Date.now(),
+        configurationId: agentConfiguration.sId,
+        messageId: agentMessage.sId,
+        error: {
+          code: "dust_app_run_error",
+          message: `Error running Dust app: ${runRes.error.message}`,
+        },
+      };
+      return;
+    }
+
+    const { eventStream } = runRes.value;
+    let lastBlockOutput: unknown | null = null;
+
+    for await (const event of eventStream) {
+      if (event.type === "error") {
+        yield {
+          type: "dust_app_run_error",
+          created: Date.now(),
+          configurationId: agentConfiguration.sId,
+          messageId: agentMessage.sId,
+          error: {
+            code: "dust_app_run_error",
+            message: `Error running Dust app: ${event.content.message}`,
+          },
+        };
+        return;
+      }
+
+      if (event.type === "block_status") {
+        yield {
+          type: "dust_app_run_block",
+          created: Date.now(),
+          configurationId: agentConfiguration.sId,
+          messageId: agentMessage.sId,
+          action: new DustAppRunAction({
+            id: action.id,
+            appWorkspaceId: actionConfiguration.appWorkspaceId,
+            appId: actionConfiguration.appId,
+            appName: app.name,
+            params,
+            functionCallId,
+            functionCallName: actionConfiguration.name,
+            runningBlock: {
+              type: event.content.block_type,
+              name: event.content.name,
+              status: event.content.status,
+            },
+            output: null,
+            agentMessageId: agentMessage.agentMessageId,
+            step: action.step,
+          }),
+        };
+      }
+
+      if (event.type === "block_execution") {
+        const e = event.content.execution[0][0];
+        if (e.error) {
+          yield {
+            type: "dust_app_run_error",
+            created: Date.now(),
+            configurationId: agentConfiguration.sId,
+            messageId: agentMessage.sId,
+            error: {
+              code: "dust_app_run_error",
+              message: `Error running Dust app: ${e.error}`,
+            },
+          };
+          return;
+        }
+
+        lastBlockOutput = e.value;
+      }
+    }
+
+    // Update DustAppRunAction with the output of the last block.
+    await action.update({
+      output: lastBlockOutput,
+    });
+
+    logger.info(
+      {
+        workspaceId: conversation.owner.sId,
+        conversationId: conversation.sId,
+        elapsed: Date.now() - now,
+      },
+      "[ASSISTANT_TRACE] DustAppRun acion run execution"
+    );
+
+    yield {
+      type: "dust_app_run_success",
+      created: Date.now(),
+      configurationId: agentConfiguration.sId,
+      messageId: agentMessage.sId,
+      action: new DustAppRunAction({
+        id: action.id,
+        appWorkspaceId: actionConfiguration.appWorkspaceId,
+        appId: actionConfiguration.appId,
+        appName: app.name,
+        params,
+        functionCallId,
+        functionCallName: actionConfiguration.name,
+        runningBlock: null,
+        output: lastBlockOutput,
+        agentMessageId: agentMessage.agentMessageId,
+        step: action.step,
+      }),
+    };
+  }
+}
+
 async function dustAppRunActionSpecification({
   schema,
   name,
@@ -166,77 +483,6 @@ async function dustAppRunActionSpecification({
   });
 }
 
-// Generates the action specification for generation of rawInputs passed to `runDustApp`.
-export async function generateDustAppRunSpecification(
-  auth: Authenticator,
-  {
-    actionConfiguration,
-    name,
-    description,
-  }: {
-    actionConfiguration: DustAppRunConfigurationType;
-    name?: string;
-    description?: string;
-  }
-): Promise<Result<AgentActionSpecification, Error>> {
-  const owner = auth.workspace();
-  if (!owner) {
-    throw new Error("Unexpected unauthenticated call to `runRetrieval`");
-  }
-
-  if (owner.sId !== actionConfiguration.appWorkspaceId) {
-    return new Err(
-      new Error(
-        "Runing Dust apps that are not part of your own workspace is not supported yet."
-      )
-    );
-  }
-
-  const app = await getApp(auth, actionConfiguration.appId);
-  if (!app) {
-    return new Err(
-      new Error(
-        "Failed to retrieve Dust app " +
-          `${actionConfiguration.appWorkspaceId}/${actionConfiguration.appId}`
-      )
-    );
-  }
-
-  // Parse the specifiaction of the app.
-  const appSpec = JSON.parse(
-    app.savedSpecification || "[]"
-  ) as SpecificationType;
-
-  const appConfig = extractConfig(JSON.parse(app.savedSpecification || "{}"));
-
-  let schema: DatasetSchema | null = null;
-
-  const inputSpec = appSpec.find((b) => b.type === "input");
-  const inputConfig = inputSpec ? appConfig[inputSpec.name] : null;
-  const datasetName: string | null = inputConfig ? inputConfig.dataset : null;
-
-  if (datasetName) {
-    // We have a dataset name we need to find associated schema.
-    schema = await getDatasetSchema(auth, app, datasetName);
-    if (!schema) {
-      return new Err(
-        new Error(
-          "Failed to retrieve schema for Dust app: " +
-            `${actionConfiguration.appWorkspaceId}/${actionConfiguration.appId} ` +
-            `dataset=${datasetName}` +
-            " (make sure you have set descriptions in your app input block dataset)"
-        )
-      );
-    }
-  }
-
-  return dustAppRunActionSpecification({
-    schema,
-    name: name ?? app.name,
-    description: description ?? app.description ?? "",
-  });
-}
-
 /**
  * Action rendering.
  */
@@ -268,261 +514,4 @@ export async function dustAppRunTypesFromAgentMessageIds(
       step: action.step,
     });
   });
-}
-
-/**
- * Action execution.
- */
-
-// This method is in charge of running a dust app and creating an AgentDustAppRunAction object in
-// the database. It does not create any generic model related to the conversation. It is possible
-// for an AgentDustAppRunAction to be stored (once the params are infered) but for the dust app run
-// to fail, in which case an error event will be emitted and the AgentDustAppRunAction won't have
-// any output associated. The error is expected to be stored by the caller on the parent agent
-// message.
-export async function* runDustApp(
-  auth: Authenticator,
-  {
-    configuration,
-    actionConfiguration,
-    conversation,
-    agentMessage,
-    spec,
-    rawInputs,
-    functionCallId,
-    step,
-  }: {
-    configuration: AgentConfigurationType;
-    actionConfiguration: DustAppRunConfigurationType;
-    conversation: ConversationType;
-    agentMessage: AgentMessageType;
-    spec: AgentActionSpecification;
-    rawInputs: Record<string, string | boolean | number>;
-    functionCallId: string | null;
-    step: number;
-  }
-): AsyncGenerator<
-  | DustAppRunParamsEvent
-  | DustAppRunBlockEvent
-  | DustAppRunSuccessEvent
-  | DustAppRunErrorEvent,
-  void
-> {
-  const owner = auth.workspace();
-  if (!owner) {
-    throw new Error("Unexpected unauthenticated call to `runDustApp`");
-  }
-
-  const app = await getApp(auth, actionConfiguration.appId);
-  if (!app) {
-    yield {
-      type: "dust_app_run_error",
-      created: Date.now(),
-      configurationId: configuration.sId,
-      messageId: agentMessage.sId,
-      error: {
-        code: "dust_app_run_parameters_generation_error",
-        message:
-          "Failed to retrieve Dust app " +
-          `${actionConfiguration.appWorkspaceId}/${actionConfiguration.appId}`,
-      },
-    };
-    return;
-  }
-
-  const appConfig = extractConfig(JSON.parse(app.savedSpecification || `{}`));
-
-  // Check that all inputs are accounted for.
-  const params: DustAppParameters = {};
-
-  for (const k of spec.inputs) {
-    if (rawInputs[k.name] && typeof rawInputs[k.name] === k.type) {
-      params[k.name] = rawInputs[k.name];
-    } else {
-      yield {
-        type: "dust_app_run_error",
-        created: Date.now(),
-        configurationId: configuration.sId,
-        messageId: agentMessage.sId,
-        error: {
-          code: "dust_app_run_parameters_generation_error",
-          message: `Failed to generate input ${k.name} (expected type ${
-            k.type
-          }, got ${rawInputs[k.name]})`,
-        },
-      };
-      return;
-    }
-  }
-
-  // Create the AgentDustAppRunAction object in the database and yield an event for the generation
-  // of the params. We store the action here as the params have been generated, if an error occurs
-  // later on, the action won't have an output but the error will be stored on the parent agent
-  // message.
-  const action = await AgentDustAppRunAction.create({
-    dustAppRunConfigurationId: actionConfiguration.sId,
-    appWorkspaceId: actionConfiguration.appWorkspaceId,
-    appId: actionConfiguration.appId,
-    appName: app.name,
-    params,
-    functionCallId,
-    functionCallName: actionConfiguration.name,
-    agentMessageId: agentMessage.agentMessageId,
-    step,
-  });
-
-  yield {
-    type: "dust_app_run_params",
-    created: Date.now(),
-    configurationId: configuration.sId,
-    messageId: agentMessage.sId,
-    action: new DustAppRunAction({
-      id: action.id,
-      appWorkspaceId: actionConfiguration.appWorkspaceId,
-      appId: actionConfiguration.appId,
-      appName: app.name,
-      params,
-      runningBlock: null,
-      output: null,
-      functionCallId,
-      functionCallName: actionConfiguration.name,
-      agentMessageId: agentMessage.agentMessageId,
-      step,
-    }),
-  };
-
-  // Let's run the app now.
-  const now = Date.now();
-
-  const prodCredentials = await prodAPICredentialsForOwner(owner, {
-    useLocalInDev: true,
-  });
-  const api = new DustAPI(prodCredentials, logger, {
-    useLocalInDev: true,
-  });
-
-  // As we run the app (using a system API key here), we do force using the workspace credentials so
-  // that the app executes in the exact same conditions in which they were developed.
-  const runRes = await api.runAppStreamed(
-    {
-      workspaceId: actionConfiguration.appWorkspaceId,
-      appId: actionConfiguration.appId,
-      appHash: "latest",
-    },
-    appConfig,
-    [params],
-    { useWorkspaceCredentials: true }
-  );
-
-  if (runRes.isErr()) {
-    yield {
-      type: "dust_app_run_error",
-      created: Date.now(),
-      configurationId: configuration.sId,
-      messageId: agentMessage.sId,
-      error: {
-        code: "dust_app_run_error",
-        message: `Error running Dust app: ${runRes.error.message}`,
-      },
-    };
-    return;
-  }
-
-  const { eventStream } = runRes.value;
-  let lastBlockOutput: unknown | null = null;
-
-  for await (const event of eventStream) {
-    if (event.type === "error") {
-      yield {
-        type: "dust_app_run_error",
-        created: Date.now(),
-        configurationId: configuration.sId,
-        messageId: agentMessage.sId,
-        error: {
-          code: "dust_app_run_error",
-          message: `Error running Dust app: ${event.content.message}`,
-        },
-      };
-      return;
-    }
-
-    if (event.type === "block_status") {
-      yield {
-        type: "dust_app_run_block",
-        created: Date.now(),
-        configurationId: configuration.sId,
-        messageId: agentMessage.sId,
-        action: new DustAppRunAction({
-          id: action.id,
-          appWorkspaceId: actionConfiguration.appWorkspaceId,
-          appId: actionConfiguration.appId,
-          appName: app.name,
-          params,
-          functionCallId,
-          functionCallName: actionConfiguration.name,
-          runningBlock: {
-            type: event.content.block_type,
-            name: event.content.name,
-            status: event.content.status,
-          },
-          output: null,
-          agentMessageId: agentMessage.agentMessageId,
-          step: action.step,
-        }),
-      };
-    }
-
-    if (event.type === "block_execution") {
-      const e = event.content.execution[0][0];
-      if (e.error) {
-        yield {
-          type: "dust_app_run_error",
-          created: Date.now(),
-          configurationId: configuration.sId,
-          messageId: agentMessage.sId,
-          error: {
-            code: "dust_app_run_error",
-            message: `Error running Dust app: ${e.error}`,
-          },
-        };
-        return;
-      }
-
-      lastBlockOutput = e.value;
-    }
-  }
-
-  // Update DustAppRunAction with the output of the last block.
-  await action.update({
-    output: lastBlockOutput,
-  });
-
-  logger.info(
-    {
-      workspaceId: conversation.owner.sId,
-      conversationId: conversation.sId,
-      elapsed: Date.now() - now,
-    },
-    "[ASSISTANT_TRACE] DustAppRun acion run execution"
-  );
-
-  yield {
-    type: "dust_app_run_success",
-    created: Date.now(),
-    configurationId: configuration.sId,
-    messageId: agentMessage.sId,
-    action: new DustAppRunAction({
-      id: action.id,
-      appWorkspaceId: actionConfiguration.appWorkspaceId,
-      appId: actionConfiguration.appId,
-      appName: app.name,
-      params,
-      functionCallId,
-      functionCallName: actionConfiguration.name,
-      runningBlock: null,
-      output: lastBlockOutput,
-      agentMessageId: agentMessage.agentMessageId,
-      step: action.step,
-    }),
-  };
 }

--- a/front/lib/api/assistant/actions/runners.ts
+++ b/front/lib/api/assistant/actions/runners.ts
@@ -1,4 +1,8 @@
-import type { AgentAction, DustAppRunConfigurationType } from "@dust-tt/types";
+import type {
+  AgentAction,
+  AgentActionConfigurationType,
+  DustAppRunConfigurationType,
+} from "@dust-tt/types";
 
 import { DustAppRunConfigurationServerRunner } from "@app/lib/api/assistant/actions/dust_app_run";
 import type { BaseActionConfigurationStaticMethods } from "@app/lib/api/assistant/actions/types";
@@ -22,7 +26,7 @@ type EnsureAllAgentActionsAreMapped<
 type ValidatedActionToConfigTypeMap =
   EnsureAllAgentActionsAreMapped<ActionToConfigTypeMap>;
 
-export const ACTION_TYPE_TO_CONFIGURATION_SERVER_RUNNER: {
+const ACTION_TYPE_TO_CONFIGURATION_SERVER_RUNNER: {
   [K in keyof ValidatedActionToConfigTypeMap]: {
     new (config: ValidatedActionToConfigTypeMap[K]): ActionTypeToClassMap[K];
   } & BaseActionConfigurationStaticMethods<
@@ -32,3 +36,14 @@ export const ACTION_TYPE_TO_CONFIGURATION_SERVER_RUNNER: {
 } = {
   dust_app_run_configuration: DustAppRunConfigurationServerRunner,
 } as const;
+
+export function getRunnerforActionConfiguration<
+  K extends keyof ValidatedActionToConfigTypeMap
+>(
+  actionConfiguration: { type: K } & ValidatedActionToConfigTypeMap[K]
+): ActionTypeToClassMap[K] {
+  const RunnerClass =
+    ACTION_TYPE_TO_CONFIGURATION_SERVER_RUNNER[actionConfiguration.type];
+
+  return RunnerClass.fromActionConfiguration(actionConfiguration);
+}

--- a/front/lib/api/assistant/actions/runners.ts
+++ b/front/lib/api/assistant/actions/runners.ts
@@ -1,0 +1,34 @@
+import type { AgentAction, DustAppRunConfigurationType } from "@dust-tt/types";
+
+import { DustAppRunConfigurationServerRunner } from "@app/lib/api/assistant/actions/dust_app_run";
+import type { BaseActionConfigurationStaticMethods } from "@app/lib/api/assistant/actions/types";
+
+interface ActionToConfigTypeMap {
+  dust_app_run_configuration: DustAppRunConfigurationType;
+  // Add other configurations once migrated to classes.
+}
+
+interface ActionTypeToClassMap {
+  dust_app_run_configuration: DustAppRunConfigurationServerRunner;
+}
+
+// Ensure all AgentAction keys are present in ActionToConfigTypeMap.
+type EnsureAllAgentActionsAreMapped<
+  // TODO(2025-05-22 flav) Remove `Partial` once all actions have been migrated.
+  T extends Partial<Record<AgentAction, any>>
+> = T;
+
+// Validate the completeness of ActionToConfigTypeMap.
+type ValidatedActionToConfigTypeMap =
+  EnsureAllAgentActionsAreMapped<ActionToConfigTypeMap>;
+
+export const ACTION_TYPE_TO_CONFIGURATION_SERVER_RUNNER: {
+  [K in keyof ValidatedActionToConfigTypeMap]: {
+    new (config: ValidatedActionToConfigTypeMap[K]): ActionTypeToClassMap[K];
+  } & BaseActionConfigurationStaticMethods<
+    ActionTypeToClassMap[K],
+    ValidatedActionToConfigTypeMap[K]
+  >;
+} = {
+  dust_app_run_configuration: DustAppRunConfigurationServerRunner,
+} as const;

--- a/front/lib/api/assistant/actions/runners.ts
+++ b/front/lib/api/assistant/actions/runners.ts
@@ -1,8 +1,4 @@
-import type {
-  AgentAction,
-  AgentActionConfigurationType,
-  DustAppRunConfigurationType,
-} from "@dust-tt/types";
+import type { AgentAction, DustAppRunConfigurationType } from "@dust-tt/types";
 
 import { DustAppRunConfigurationServerRunner } from "@app/lib/api/assistant/actions/dust_app_run";
 import type { BaseActionConfigurationStaticMethods } from "@app/lib/api/assistant/actions/types";

--- a/front/lib/api/assistant/actions/types.ts
+++ b/front/lib/api/assistant/actions/types.ts
@@ -1,0 +1,67 @@
+import type {
+  AgentActionConfigurationType,
+  AgentActionSpecification,
+  AgentConfigurationType,
+  AgentMessageType,
+  ConversationType,
+  Result,
+} from "@dust-tt/types";
+
+import type { Authenticator } from "@app/lib/auth";
+
+export interface BaseActionConfigurationServerRunnerConstructor<
+  T extends BaseActionConfigurationServerRunner<V>,
+  V extends AgentActionConfigurationType
+> {
+  new (actionConfiguration: V): T;
+}
+
+export interface BaseActionConfigurationStaticMethods<
+  T extends BaseActionConfigurationServerRunner<V>,
+  V extends AgentActionConfigurationType
+> {
+  fromActionConfiguration(
+    this: BaseActionConfigurationServerRunnerConstructor<T, V>,
+    actionConfiguration: V
+  ): T;
+
+  // Other methods.
+}
+
+export interface BaseActionRunParams {
+  agentConfiguration: AgentConfigurationType;
+  conversation: ConversationType;
+  agentMessage: AgentMessageType;
+  rawInputs: Record<string, string | boolean | number>;
+  functionCallId: string | null;
+  step: number;
+}
+
+export abstract class BaseActionConfigurationServerRunner<
+  T extends AgentActionConfigurationType
+> {
+  constructor(protected readonly actionConfiguration: T) {}
+
+  static fromActionConfiguration<
+    T extends BaseActionConfigurationServerRunner<V>,
+    V extends AgentActionConfigurationType
+  >(
+    this: BaseActionConfigurationServerRunnerConstructor<T, V>,
+    actionConfiguration: V
+  ) {
+    return new this(actionConfiguration);
+  }
+
+  // Action rendering.
+  abstract buildSpecification(
+    auth: Authenticator,
+    { name, description }: { name?: string; description?: string }
+  ): Promise<Result<AgentActionSpecification, Error>>;
+
+  // Action execution.
+  abstract run(
+    auth: Authenticator,
+    runParams: BaseActionRunParams,
+    customParams: Record<string, unknown>
+  ): AsyncGenerator<unknown>;
+}

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -347,18 +347,21 @@ export async function* runMultiActionsAgent(
 
       specifications.push(r.value);
     } else {
-      const r = await ACTION_TYPE_TO_CONFIGURATION_SERVER_RUNNER[a.type]
-        .fromActionConfiguration(a)
-        .buildSpecification(auth, {
-          name: a.name ?? undefined,
-          description: a.description ?? undefined,
-        });
+      const runner =
+        ACTION_TYPE_TO_CONFIGURATION_SERVER_RUNNER[
+          a.type
+        ].fromActionConfiguration(a);
 
-      if (r.isErr()) {
-        return r;
+      const res = await runner.buildSpecification(auth, {
+        name: a.name ?? undefined,
+        description: a.description ?? undefined,
+      });
+
+      if (res.isErr()) {
+        return res;
       }
 
-      specifications.push(r.value);
+      specifications.push(res.value);
     }
   }
   // not sure if the speicfications.push() is needed here TBD at review time.

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -11,7 +11,6 @@ import type {
   AgentMessageSuccessEvent,
   AgentMessageType,
   ConversationType,
-  DustAppRunConfigurationType,
   GenerationCancelEvent,
   GenerationSuccessEvent,
   GenerationTokensEvent,
@@ -31,7 +30,6 @@ import {
 } from "@dust-tt/types";
 
 import { runActionStreamed } from "@app/lib/actions/server";
-import { DustAppRunConfigurationServerRunner } from "@app/lib/api/assistant/actions/dust_app_run";
 import {
   generateProcessSpecification,
   runProcess,
@@ -45,7 +43,6 @@ import {
   generateTablesQuerySpecification,
   runTablesQuery,
 } from "@app/lib/api/assistant/actions/tables_query";
-import type { BaseActionConfigurationServerRunner } from "@app/lib/api/assistant/actions/types";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
 import {
   constructPromptMultiActions,

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -38,7 +38,7 @@ import {
   generateRetrievalSpecification,
   runRetrieval,
 } from "@app/lib/api/assistant/actions/retrieval";
-import { ACTION_TYPE_TO_CONFIGURATION_SERVER_RUNNER } from "@app/lib/api/assistant/actions/runners";
+import { getRunnerforActionConfiguration } from "@app/lib/api/assistant/actions/runners";
 import {
   generateTablesQuerySpecification,
   runTablesQuery,
@@ -347,10 +347,7 @@ export async function* runMultiActionsAgent(
 
       specifications.push(r.value);
     } else {
-      const runner =
-        ACTION_TYPE_TO_CONFIGURATION_SERVER_RUNNER[
-          a.type
-        ].fromActionConfiguration(a);
+      const runner = getRunnerforActionConfiguration(a);
 
       const res = await runner.buildSpecification(auth, {
         name: a.name ?? undefined,
@@ -701,10 +698,7 @@ async function* runAction(
       };
       return;
     }
-    const runner =
-      ACTION_TYPE_TO_CONFIGURATION_SERVER_RUNNER[
-        actionConfiguration.type
-      ].fromActionConfiguration(actionConfiguration);
+    const runner = getRunnerforActionConfiguration(actionConfiguration);
 
     const eventStream = runner.run(
       auth,

--- a/front/lib/api/assistant/legacy_agent.ts
+++ b/front/lib/api/assistant/legacy_agent.ts
@@ -311,9 +311,12 @@ async function* runAction(
       actionConfiguration: action,
     });
   } else {
-    specRes = await ACTION_TYPE_TO_CONFIGURATION_SERVER_RUNNER[action.type]
-      .fromActionConfiguration(action)
-      .buildSpecification(auth, {});
+    const runner =
+      ACTION_TYPE_TO_CONFIGURATION_SERVER_RUNNER[
+        action.type
+      ].fromActionConfiguration(action);
+
+    specRes = await runner.buildSpecification(auth, {});
   }
 
   if (specRes.isErr()) {

--- a/front/lib/api/assistant/legacy_agent.ts
+++ b/front/lib/api/assistant/legacy_agent.ts
@@ -37,7 +37,7 @@ import {
   generateRetrievalSpecification,
   runRetrieval,
 } from "@app/lib/api/assistant/actions/retrieval";
-import { ACTION_TYPE_TO_CONFIGURATION_SERVER_RUNNER } from "@app/lib/api/assistant/actions/runners";
+import { getRunnerforActionConfiguration } from "@app/lib/api/assistant/actions/runners";
 import {
   generateTablesQuerySpecification,
   runTablesQuery,
@@ -311,10 +311,7 @@ async function* runAction(
       actionConfiguration: action,
     });
   } else {
-    const runner =
-      ACTION_TYPE_TO_CONFIGURATION_SERVER_RUNNER[
-        action.type
-      ].fromActionConfiguration(action);
+    const runner = getRunnerforActionConfiguration(action);
 
     specRes = await runner.buildSpecification(auth, {});
   }
@@ -435,10 +432,7 @@ async function* runAction(
       }
     }
   } else if (isDustAppRunConfiguration(action)) {
-    const runner =
-      ACTION_TYPE_TO_CONFIGURATION_SERVER_RUNNER[
-        action.type
-      ].fromActionConfiguration(action);
+    const runner = getRunnerforActionConfiguration(action);
 
     const eventStream = runner.run(
       auth,

--- a/front/lib/api/assistant/legacy_agent.ts
+++ b/front/lib/api/assistant/legacy_agent.ts
@@ -30,10 +30,6 @@ import {
 
 import { runActionStreamed } from "@app/lib/actions/server";
 import {
-  generateDustAppRunSpecification,
-  runDustApp,
-} from "@app/lib/api/assistant/actions/dust_app_run";
-import {
   generateProcessSpecification,
   runProcess,
 } from "@app/lib/api/assistant/actions/process";
@@ -41,6 +37,7 @@ import {
   generateRetrievalSpecification,
   runRetrieval,
 } from "@app/lib/api/assistant/actions/retrieval";
+import { ACTION_TYPE_TO_CONFIGURATION_SERVER_RUNNER } from "@app/lib/api/assistant/actions/runners";
 import {
   generateTablesQuerySpecification,
   runTablesQuery,
@@ -307,10 +304,6 @@ async function* runAction(
     specRes = await generateRetrievalSpecification(auth, {
       actionConfiguration: action,
     });
-  } else if (isDustAppRunConfiguration(action)) {
-    specRes = await generateDustAppRunSpecification(auth, {
-      actionConfiguration: action,
-    });
   } else if (isTablesQueryConfiguration(action)) {
     specRes = await generateTablesQuerySpecification(auth);
   } else if (isProcessConfiguration(action)) {
@@ -318,9 +311,9 @@ async function* runAction(
       actionConfiguration: action,
     });
   } else {
-    ((a: never) => {
-      throw new Error(`Unexpected action type: ${a}`);
-    })(action);
+    specRes = await ACTION_TYPE_TO_CONFIGURATION_SERVER_RUNNER[action.type]
+      .fromActionConfiguration(action)
+      .buildSpecification(auth, {});
   }
 
   if (specRes.isErr()) {
@@ -439,16 +432,25 @@ async function* runAction(
       }
     }
   } else if (isDustAppRunConfiguration(action)) {
-    const eventStream = runDustApp(auth, {
-      configuration,
-      actionConfiguration: action,
-      conversation,
-      agentMessage,
-      spec: specRes.value,
-      rawInputs,
-      functionCallId: null,
-      step,
-    });
+    const runner =
+      ACTION_TYPE_TO_CONFIGURATION_SERVER_RUNNER[
+        action.type
+      ].fromActionConfiguration(action);
+
+    const eventStream = runner.run(
+      auth,
+      {
+        agentConfiguration: configuration,
+        conversation,
+        agentMessage,
+        rawInputs,
+        functionCallId: null,
+        step,
+      },
+      {
+        spec: specRes.value,
+      }
+    );
 
     for await (const event of eventStream) {
       switch (event.type) {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
🍿 See thread with full context [here](https://dust4ai.slack.com/archives/C050SM8NSPK/p1716361797993289).

This PR introduces a `BaseActionConfigurationServerRunner`, which provides a common interface for all actions to implement. The goal is to simplify the process of creating new actions. With this PR, adding a new action becomes a two-step process: creating the action file itself and updating the mapping.

This class has a protected constructor to prevent it from being instantiated arbitrarily. The only way to instantiate this class is by using the static method `fromActionConfiguration`. Some TypeScript gymnastics are required to enforce strict types.
I included a `Partial` type to facilitate the transition of all actions to this new pattern. Once all actions have been migrated, we will remove the Partial, and TypeScript will flag any actions that are not implemented correctly.

The ultimate goal is to eliminate all switch/case and if/else statements related to action types.

I'll submit a follow-up PR to move stream event handling into their respective class implementations.

## Risk

Worst case, it breaks the dust app. Safe to rollback.
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
