### PR TITLE
fix(assistant builder): state mgmt for data source configs

### DIFF
--- a/front/components/assistant_builder/actions/ProcessAction.tsx
+++ b/front/components/assistant_builder/actions/ProcessAction.tsx
@@ -301,22 +301,16 @@ export function ActionProcess({
         }}
         owner={owner}
         dataSources={dataSources}
-        onSave={({ dataSource, selectedResources, isSelectAll }) => {
+        onSave={(dsConfigs) => {
           setEdited(true);
           updateAction((previousAction) => ({
             ...previousAction,
-            dataSourceConfigurations: {
-              ...previousAction.dataSourceConfigurations,
-              [dataSource.name]: {
-                dataSource,
-                selectedResources,
-                isSelectAll,
-              },
-            },
+            dataSourceConfigurations: dsConfigs,
           }));
         }}
-        onDelete={deleteDataSource}
-        dataSourceConfigurations={actionConfiguration.dataSourceConfigurations}
+        initialDataSourceConfigurations={
+          actionConfiguration.dataSourceConfigurations
+        }
       />
 
       <div className="text-sm text-element-700">

--- a/front/components/assistant_builder/actions/RetrievalAction.tsx
+++ b/front/components/assistant_builder/actions/RetrievalAction.tsx
@@ -83,28 +83,16 @@ export function ActionRetrievalSearch({
         }}
         owner={owner}
         dataSources={dataSources}
-        onSave={({ dataSource, selectedResources, isSelectAll }) => {
+        onSave={(dsConfigs) => {
           setEdited(true);
           updateAction((previousAction) => ({
             ...previousAction,
-            dataSourceConfigurations: {
-              ...previousAction.dataSourceConfigurations,
-              [dataSource.name]: {
-                dataSource,
-                selectedResources,
-                isSelectAll,
-              },
-            },
+            dataSourceConfigurations: dsConfigs,
           }));
         }}
-        onDelete={(name) => {
-          deleteDataSource({
-            name,
-            updateAction,
-            setEdited,
-          });
-        }}
-        dataSourceConfigurations={actionConfiguration.dataSourceConfigurations}
+        initialDataSourceConfigurations={
+          actionConfiguration.dataSourceConfigurations
+        }
       />
 
       <DataSourceSelectionSection
@@ -177,28 +165,16 @@ export function ActionRetrievalExhaustive({
         }}
         owner={owner}
         dataSources={dataSources}
-        onSave={({ dataSource, selectedResources, isSelectAll }) => {
+        onSave={(dsConfigs) => {
           setEdited(true);
           updateAction((previousAction) => ({
             ...previousAction,
-            dataSourceConfigurations: {
-              ...previousAction.dataSourceConfigurations,
-              [dataSource.name]: {
-                dataSource,
-                selectedResources,
-                isSelectAll,
-              },
-            },
+            dataSourceConfigurations: dsConfigs,
           }));
         }}
-        onDelete={(name) => {
-          deleteDataSource({
-            name,
-            updateAction,
-            setEdited,
-          });
-        }}
-        dataSourceConfigurations={actionConfiguration.dataSourceConfigurations}
+        initialDataSourceConfigurations={
+          actionConfiguration.dataSourceConfigurations
+        }
       />
 
       <DataSourceSelectionSection


### PR DESCRIPTION
## Description

We still have problems (mostly in the multi actions screen), when saving the folders / websites selection due to the ugly pattern we use (setState in a loop).

So I fixed in, now the modal has its own state, and updates the global state when we save it. Much better like this.

## Risk

Critical path, but well tested so we should be fine.

## Deploy Plan

N/A