### PR TITLE
Limit transcripts assistant picker to custom assistants only

### DIFF
--- a/front/pages/w/[wId]/assistant/labs/transcripts/index.tsx
+++ b/front/pages/w/[wId]/assistant/labs/transcripts/index.tsx
@@ -130,7 +130,10 @@ export default function LabsTranscriptsIndex({
     return <Spinner />;
   }
 
-  const agents = agentConfigurations.filter((a) => a.status === "active");
+  // Only custom assistants - there's no point in passing a transcript to a default assistant without instructions.
+  const agents = agentConfigurations.filter(
+    (a) => a.status === "active" && a.id != -1
+  );
 
   const handleProviderChange = async (
     provider: LabsTranscriptsProviderType


### PR DESCRIPTION
## Description

For now people could add @gpt4 and all default assistants as transcripts processors, which makes no sense. 
Removing the possibility to use a default assistant in Transcripts

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
