### PR TITLE
enh(multi-actions): base descriptions for DS actions

### DIFF
--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -619,7 +619,9 @@ function ActionEditor({
         })()}
       </ActionModeSection>
       <div className="flex flex-col gap-4 pt-8">
-        {DATA_SOURCES_ACTION_CATEGORIES.includes(action.type as any) ? (
+        {["TABLES_QUERY", "RETRIEVAL_EXHAUSTIVE", "RETRIEVAL_SEARCH"].includes(
+          action.type as any
+        ) ? (
           <div className="flex flex-col gap-2">
             <div className="font-semibold text-element-800">
               What's the data?

--- a/front/lib/api/assistant/actions/process.ts
+++ b/front/lib/api/assistant/actions/process.ts
@@ -187,8 +187,8 @@ export async function generateProcessSpecification(
     name,
     description:
       description ??
-      "Process data sources specified by the user by performing a search and extracting" +
-        " structured information (complying to a fixed schema) from the retrieved information.",
+      "Process data sources specified by the user over a specific time-frame by extracting" +
+        " structured blobs of information (complying to a fixed schema).",
   });
   return new Ok(spec);
 }

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -338,10 +338,30 @@ export async function generateRetrievalSpecification(
     throw new Error("Unexpected unauthenticated call to `runRetrieval`");
   }
 
-  const actionDescription =
-    "Search the data sources specified by the user for information to answer their request." +
-    " The search is based on semantic similarity between the query and chunks of information" +
-    ` from the data sources.\nThe data sources are described by the user as:\n${description}`;
+  const baseDescription = (() => {
+    if (actionConfiguration.query === "auto") {
+      return (
+        "Search the data sources specified by the user for information to answer their request." +
+        " The search is based on semantic similarity between the query and chunks of information" +
+        " from the data sources."
+      );
+    } else {
+      let description =
+        "Retrieve the most recent content from the data sources specified by the user for information to answer their request.";
+      if (
+        actionConfiguration.relativeTimeFrame === "auto" ||
+        actionConfiguration.relativeTimeFrame === "none"
+      ) {
+        return description;
+      }
+      const timeFrame = actionConfiguration.relativeTimeFrame;
+      const plural = timeFrame.duration > 1 ? "s" : "";
+      description += ` The search is restricted to the last ${timeFrame.duration} ${timeFrame.unit}${plural}.`;
+      return description;
+    }
+  })();
+
+  const actionDescription = `${baseDescription}\nThe data sources are described by the user as:\n${description}`;
 
   const spec = retrievalActionSpecification({
     actionConfiguration,

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -347,7 +347,7 @@ export async function generateRetrievalSpecification(
       );
     } else {
       let description =
-        "Retrieve the most recent content from the data sources specified by the user for information to answer their request";
+        "Retrieve the most recent content from the data sources specified by the user";
       if (
         actionConfiguration.relativeTimeFrame === "auto" ||
         actionConfiguration.relativeTimeFrame === "none"
@@ -361,7 +361,7 @@ export async function generateRetrievalSpecification(
     }
   })();
 
-  const actionDescription = `${baseDescription}\nThe data sources are described by the user as:\n${description}`;
+  const actionDescription = `${baseDescription}\nDescription of the data sources:\n${description}`;
 
   const spec = retrievalActionSpecification({
     actionConfiguration,

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -153,31 +153,30 @@ export class RetrievalAction extends BaseAction {
   renderForModel(): ModelMessageType {
     let content = "";
     if (!this.documents) {
-      throw new Error(
-        "Documents not set on retrieval action; this usually means the retrieval action is not finished."
-      );
-    }
-    for (const d of this.documents) {
-      let title = d.documentId;
-      for (const t of d.tags) {
-        if (t.startsWith("title:")) {
-          title = t.substring(6);
-          break;
+      content += "(retrieval failed)\n";
+    } else {
+      for (const d of this.documents) {
+        let title = d.documentId;
+        for (const t of d.tags) {
+          if (t.startsWith("title:")) {
+            title = t.substring(6);
+            break;
+          }
         }
-      }
 
-      let dataSourceName = d.dataSourceId;
-      if (d.dataSourceId.startsWith("managed-")) {
-        dataSourceName = d.dataSourceId.substring(8);
-      }
+        let dataSourceName = d.dataSourceId;
+        if (d.dataSourceId.startsWith("managed-")) {
+          dataSourceName = d.dataSourceId.substring(8);
+        }
 
-      content += `TITLE: ${title} (data source: ${dataSourceName})\n`;
-      content += `REFERENCE: ${d.reference}\n`;
-      content += `EXTRACTS:\n`;
-      for (const c of d.chunks) {
-        content += `${c.text}\n`;
+        content += `TITLE: ${title} (data source: ${dataSourceName})\n`;
+        content += `REFERENCE: ${d.reference}\n`;
+        content += `EXTRACTS:\n`;
+        for (const c of d.chunks) {
+          content += `${c.text}\n`;
+        }
+        content += "\n";
       }
-      content += "\n";
     }
 
     return {
@@ -207,31 +206,30 @@ export class RetrievalAction extends BaseAction {
   renderForMultiActionsModel(): FunctionMessageTypeModel {
     let content = "";
     if (!this.documents) {
-      throw new Error(
-        "Documents not set on retrieval action; this usually means the retrieval action is not finished."
-      );
-    }
-    for (const d of this.documents) {
-      let title = d.documentId;
-      for (const t of d.tags) {
-        if (t.startsWith("title:")) {
-          title = t.substring(6);
-          break;
+      content += "(retrieval failed)\n";
+    } else {
+      for (const d of this.documents) {
+        let title = d.documentId;
+        for (const t of d.tags) {
+          if (t.startsWith("title:")) {
+            title = t.substring(6);
+            break;
+          }
         }
-      }
 
-      let dataSourceName = d.dataSourceId;
-      if (d.dataSourceId.startsWith("managed-")) {
-        dataSourceName = d.dataSourceId.substring(8);
-      }
+        let dataSourceName = d.dataSourceId;
+        if (d.dataSourceId.startsWith("managed-")) {
+          dataSourceName = d.dataSourceId.substring(8);
+        }
 
-      content += `TITLE: ${title} (data source: ${dataSourceName})\n`;
-      content += `REFERENCE: ${d.reference}\n`;
-      content += `EXTRACTS:\n`;
-      for (const c of d.chunks) {
-        content += `${c.text}\n`;
+        content += `TITLE: ${title} (data source: ${dataSourceName})\n`;
+        content += `REFERENCE: ${d.reference}\n`;
+        content += `EXTRACTS:\n`;
+        for (const c of d.chunks) {
+          content += `${c.text}\n`;
+        }
+        content += "\n";
       }
-      content += "\n";
     }
 
     return {

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -313,7 +313,7 @@ export async function deprecatedGenerateRetrievalSpecificationForSingleActionAge
     actionConfiguration,
     name: "search_data_sources",
     description:
-      "Search the data sources specified by the user for information to answer their request." +
+      "Search the data sources specified by the user." +
       " The search is based on semantic similarity between the query and chunks of information" +
       " from the data sources.",
   });
@@ -341,22 +341,22 @@ export async function generateRetrievalSpecification(
   const baseDescription = (() => {
     if (actionConfiguration.query === "auto") {
       return (
-        "Search the data sources specified by the user for information to answer their request." +
+        "Search the data sources specified by the user." +
         " The search is based on semantic similarity between the query and chunks of information" +
         " from the data sources."
       );
     } else {
       let description =
-        "Retrieve the most recent content from the data sources specified by the user for information to answer their request.";
+        "Retrieve the most recent content from the data sources specified by the user for information to answer their request";
       if (
         actionConfiguration.relativeTimeFrame === "auto" ||
         actionConfiguration.relativeTimeFrame === "none"
       ) {
-        return description;
+        return `${description}.`;
       }
       const timeFrame = actionConfiguration.relativeTimeFrame;
       const plural = timeFrame.duration > 1 ? "s" : "";
-      description += ` The search is restricted to the last ${timeFrame.duration} ${timeFrame.unit}${plural}.`;
+      description += ` over the last ${timeFrame.duration} ${timeFrame.unit}${plural}.`;
       return description;
     }
   })();

--- a/front/lib/api/assistant/actions/tables_query.ts
+++ b/front/lib/api/assistant/actions/tables_query.ts
@@ -148,8 +148,8 @@ async function tablesQueryActionSpecification({
           " request and conversation context. The question should include" +
           " all the context required to be understood without reference to the conversation." +
           " If the user has multiple unanswered questions, make sure to include all of them." +
-          " If the user asked to correct a previous attempt at the same query in a specific way," +
-          " this information must be included.",
+          " If the user asked to correct a previous attempt in a specific way," +
+          " take it into account when generating the question.",
         type: "string" as const,
       },
     ],
@@ -166,7 +166,8 @@ export async function deprecatedGenerateTablesQuerySpecificationForSingleActionA
   }
 
   const actionDescription =
-    "Query the data tables specified by the user by executing a generated SQL query from the natural language.";
+    "Query data tables specified by the user by executing a generated SQL query from a" +
+    " natural language question.";
 
   const spec = await tablesQueryActionSpecification({
     name: "query_tables",
@@ -185,9 +186,9 @@ export async function generateTablesQuerySpecification(
   }
 
   const actionDescription =
-    "Query the structured data tables specificied by the user to retrieve information to answer their request." +
-    " The data is queried by generating a SQL query from the natural language question.\n" +
-    `The tables are described by the user as:\n${description}`;
+    "Query data tables specificied by the user by executing a generated SQL query from a" +
+    " natural language question.\n" +
+    `Description of the data tables:\n${description}`;
 
   const spec = await tablesQueryActionSpecification({
     name,

--- a/front/lib/api/assistant/actions/tables_query.ts
+++ b/front/lib/api/assistant/actions/tables_query.ts
@@ -166,8 +166,7 @@ export async function deprecatedGenerateTablesQuerySpecificationForSingleActionA
   }
 
   const actionDescription =
-    "Query the structured data tables specificied by the user to retrieve information to answer their request." +
-    " The data is queried by generating a SQL query from the natural language question.";
+    "Query the data tables specified by the user by executing a generated SQL query from the natural language.";
 
   const spec = await tablesQueryActionSpecification({
     name: "query_tables",

--- a/front/lib/api/assistant/actions/tables_query.ts
+++ b/front/lib/api/assistant/actions/tables_query.ts
@@ -144,7 +144,12 @@ async function tablesQueryActionSpecification({
       {
         name: "question",
         description:
-          "The plain language question to answer based on the user request and conversation context. The question should include all the context required to be understood without reference to the conversation. If the user has multiple unanswered questions, make sure to include all of them. If the user asked to correct a previous attempt at the same query in a specific way, this information must be included.",
+          "The plain language question to answer based on the user" +
+          " request and conversation context. The question should include" +
+          " all the context required to be understood without reference to the conversation." +
+          " If the user has multiple unanswered questions, make sure to include all of them." +
+          " If the user asked to correct a previous attempt at the same query in a specific way," +
+          " this information must be included.",
         type: "string" as const,
       },
     ],
@@ -161,7 +166,7 @@ export async function deprecatedGenerateTablesQuerySpecificationForSingleActionA
   }
 
   const actionDescription =
-    "Query the structured data tables specificied by the user to retrieve ingormation to answer their request." +
+    "Query the structured data tables specificied by the user to retrieve information to answer their request." +
     " The data is queried by generating a SQL query from the plain text language question.";
 
   const spec = await tablesQueryActionSpecification({
@@ -181,7 +186,7 @@ export async function generateTablesQuerySpecification(
   }
 
   const actionDescription =
-    "Query the structured data tables specificied by the user to retrieve ingormation to answer their request." +
+    "Query the structured data tables specificied by the user to retrieve information to answer their request." +
     " The data is queried by generating a SQL query from the plain text language question.\n" +
     `The tables are described by the user as:\n${description}`;
 

--- a/front/lib/api/assistant/actions/tables_query.ts
+++ b/front/lib/api/assistant/actions/tables_query.ts
@@ -144,7 +144,7 @@ async function tablesQueryActionSpecification({
       {
         name: "question",
         description:
-          "The plain language question to answer based on the user" +
+          "The natural language question to answer based on the user" +
           " request and conversation context. The question should include" +
           " all the context required to be understood without reference to the conversation." +
           " If the user has multiple unanswered questions, make sure to include all of them." +
@@ -167,7 +167,7 @@ export async function deprecatedGenerateTablesQuerySpecificationForSingleActionA
 
   const actionDescription =
     "Query the structured data tables specificied by the user to retrieve information to answer their request." +
-    " The data is queried by generating a SQL query from the plain text language question.";
+    " The data is queried by generating a SQL query from the natural language question.";
 
   const spec = await tablesQueryActionSpecification({
     name: "query_tables",
@@ -187,7 +187,7 @@ export async function generateTablesQuerySpecification(
 
   const actionDescription =
     "Query the structured data tables specificied by the user to retrieve information to answer their request." +
-    " The data is queried by generating a SQL query from the plain text language question.\n" +
+    " The data is queried by generating a SQL query from the natural language question.\n" +
     `The tables are described by the user as:\n${description}`;
 
   const spec = await tablesQueryActionSpecification({

--- a/front/lib/api/assistant/actions/tables_query.ts
+++ b/front/lib/api/assistant/actions/tables_query.ts
@@ -152,19 +152,43 @@ async function tablesQueryActionSpecification({
 }
 
 // Generates the action specification for generation of rawInputs passed to `runTablesQuery`.
-export async function generateTablesQuerySpecification(
-  auth: Authenticator,
-  {
-    name = "query_tables",
-    description = "Generates a SQL query from a question in plain language, executes the generated query and return the results.",
-  }: { name?: string; description?: string } = {}
+export async function deprecatedGenerateTablesQuerySpecificationForSingleActionAgent(
+  auth: Authenticator
 ): Promise<Result<AgentActionSpecification, Error>> {
   const owner = auth.workspace();
   if (!owner) {
     throw new Error("Unexpected unauthenticated call to `runQueryTables`");
   }
 
-  const spec = await tablesQueryActionSpecification({ name, description });
+  const actionDescription =
+    "Query the structured data tables specificied by the user to retrieve ingormation to answer their request." +
+    " The data is queried by generating a SQL query from the plain text language question.";
+
+  const spec = await tablesQueryActionSpecification({
+    name: "query_tables",
+    description: actionDescription,
+  });
+  return new Ok(spec);
+}
+
+export async function generateTablesQuerySpecification(
+  auth: Authenticator,
+  { name, description }: { name: string; description: string }
+): Promise<Result<AgentActionSpecification, Error>> {
+  const owner = auth.workspace();
+  if (!owner) {
+    throw new Error("Unexpected unauthenticated call to `runQueryTables`");
+  }
+
+  const actionDescription =
+    "Query the structured data tables specificied by the user to retrieve ingormation to answer their request." +
+    " The data is queried by generating a SQL query from the plain text language question.\n" +
+    `The tables are described by the user as:\n${description}`;
+
+  const spec = await tablesQueryActionSpecification({
+    name,
+    description: actionDescription,
+  });
   return new Ok(spec);
 }
 

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -311,11 +311,24 @@ export async function* runMultiActionsAgent(
 
   const specifications: AgentActionSpecification[] = [];
   for (const a of availableActions) {
+    if (!a.name || !a.description) {
+      yield {
+        type: "agent_error",
+        created: Date.now(),
+        configurationId: agentConfiguration.sId,
+        messageId: agentMessage.sId,
+        error: {
+          code: "missing_name_or_description",
+          message: `Action ${a.name} is missing a name or description`,
+        },
+      } satisfies AgentErrorEvent;
+      return;
+    }
     if (isRetrievalConfiguration(a)) {
       const r = await generateRetrievalSpecification(auth, {
         actionConfiguration: a,
-        name: a.name ?? undefined,
-        description: a.description ?? undefined,
+        name: a.name,
+        description: a.description,
       });
 
       if (r.isErr()) {
@@ -325,8 +338,8 @@ export async function* runMultiActionsAgent(
       specifications.push(r.value);
     } else if (isTablesQueryConfiguration(a)) {
       const r = await generateTablesQuerySpecification(auth, {
-        name: a.name ?? undefined,
-        description: a.description ?? undefined,
+        name: a.name,
+        description: a.description,
       });
 
       if (r.isErr()) {
@@ -337,8 +350,8 @@ export async function* runMultiActionsAgent(
     } else if (isProcessConfiguration(a)) {
       const r = await generateProcessSpecification(auth, {
         actionConfiguration: a,
-        name: a.name ?? undefined,
-        description: a.description ?? undefined,
+        name: a.name,
+        description: a.description,
       });
 
       if (r.isErr()) {

--- a/front/lib/api/assistant/legacy_agent.ts
+++ b/front/lib/api/assistant/legacy_agent.ts
@@ -34,12 +34,12 @@ import {
   runProcess,
 } from "@app/lib/api/assistant/actions/process";
 import {
-  generateRetrievalSpecification,
+  deprecatedGenerateRetrievalSpecificationForSingleActionAgent,
   runRetrieval,
 } from "@app/lib/api/assistant/actions/retrieval";
 import { getRunnerforActionConfiguration } from "@app/lib/api/assistant/actions/runners";
 import {
-  generateTablesQuerySpecification,
+  deprecatedGenerateTablesQuerySpecificationForSingleActionAgent,
   runTablesQuery,
 } from "@app/lib/api/assistant/actions/tables_query";
 import {
@@ -301,11 +301,15 @@ async function* runAction(
 
   let specRes: Result<AgentActionSpecification, Error> | null = null;
   if (isRetrievalConfiguration(action)) {
-    specRes = await generateRetrievalSpecification(auth, {
-      actionConfiguration: action,
-    });
+    specRes =
+      await deprecatedGenerateRetrievalSpecificationForSingleActionAgent(auth, {
+        actionConfiguration: action,
+      });
   } else if (isTablesQueryConfiguration(action)) {
-    specRes = await generateTablesQuerySpecification(auth);
+    specRes =
+      await deprecatedGenerateTablesQuerySpecificationForSingleActionAgent(
+        auth
+      );
   } else if (isProcessConfiguration(action)) {
     specRes = await generateProcessSpecification(auth, {
       actionConfiguration: action,


### PR DESCRIPTION
## Description

In the assistant builder multi-actions screen, when people add data-source actions, we ask them to provide a description of the data they select.

Based on that, we want to generate a description of their action for the specification.

I decided to fork the `generateXXXSpecification` functions between MA and legacy agents.

## Risk

Tweaks some description which impacts model interactions. But should be generally positive.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
