### PR TITLE
Confluence exclude error personal report

### DIFF
--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -620,7 +620,10 @@ export async function confluenceGetReportPersonalActionActivity(
   if (connector.isAuthTokenRevoked) {
     return false;
   }
-  if (connector.errorType !== null) {
+  if (connector.isThirdPartyInternalError !== null) {
+    return false;
+  }
+  if (connector.pausedAt !== null) {
     return false;
   }
 

--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -620,7 +620,7 @@ export async function confluenceGetReportPersonalActionActivity(
   if (connector.isAuthTokenRevoked) {
     return false;
   }
-  if (connector.isThirdPartyInternalError !== null) {
+  if (connector.isThirdPartyInternalError) {
     return false;
   }
 

--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -620,6 +620,9 @@ export async function confluenceGetReportPersonalActionActivity(
   if (connector.isAuthTokenRevoked) {
     return false;
   }
+  if (connector.errorType !== null) {
+    return false;
+  }
 
   // We look for the oldest updated data.
   const oldestPageSync = await ConfluencePage.findOne({

--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -623,9 +623,6 @@ export async function confluenceGetReportPersonalActionActivity(
   if (connector.isThirdPartyInternalError !== null) {
     return false;
   }
-  if (connector.pausedAt !== null) {
-    return false;
-  }
 
   // We look for the oldest updated data.
   const oldestPageSync = await ConfluencePage.findOne({

--- a/connectors/src/resources/connector_resource.ts
+++ b/connectors/src/resources/connector_resource.ts
@@ -162,4 +162,8 @@ export class ConnectorResource extends BaseResource<ConnectorModel> {
   get isAuthTokenRevoked() {
     return this.errorType === "oauth_token_revoked";
   }
+
+  get isThirdPartyInternalError() {
+    return this.errorType === "third_party_internal_error";
+  }
 }


### PR DESCRIPTION
## Description

Fix for this unhappy connector: https://app.datadoghq.eu/logs?query=%22Unhandled%20activity%20error%22%20&agg_m=count&agg_m_source=base&agg_t=count&cols=service%2C%40workflowName%2C%40activityName%2C%40error.__is_dust_error&fromUser=true&messageDisplay=inline&refresh_mode=sliding&saved-view-id=99803&storage=hot&stream_sort=%40duration%2Cdesc&viz=stream&from_ts=1716359730182&to_ts=1716446130182&live=true

Workflow https://cloud.temporal.io/namespaces/dust-prod.gmnlm/workflows/confluence-personal-data-reporting-workflow-2024-05-23T00%3A00%3A00Z/38237f90-42ff-48ee-8bec-1473276d97d8/history is stuck on a connector that is errored. 

We should skip errored connectors on this. 

## Risk

/

## Deploy Plan

Deploy connectors. 
