### PR TITLE
[Websearch] Add no-op websearch action (builder, rendering), gated

### DIFF
--- a/front/components/assistant/conversation/AgentAction.tsx
+++ b/front/components/assistant/conversation/AgentAction.tsx
@@ -5,12 +5,14 @@ import {
   isProcessActionType,
   isRetrievalActionType,
   isTablesQueryActionType,
+  isWebsearchActionType,
 } from "@dust-tt/types";
 
 import DustAppRunAction from "@app/components/assistant/conversation/DustAppRunAction";
 import ProcessAction from "@app/components/assistant/conversation/ProcessAction";
 import RetrievalAction from "@app/components/assistant/conversation/RetrievalAction";
 import TablesQueryAction from "@app/components/assistant/conversation/TablesQueryAction";
+import WebsearchAction from "@app/components/assistant/conversation/WebsearchAction";
 
 export function AgentAction({ action }: { action: AgentActionType }) {
   if (isRetrievalActionType(action)) {
@@ -35,6 +37,12 @@ export function AgentAction({ action }: { action: AgentActionType }) {
     return (
       <div className="pb-4">
         <ProcessAction processAction={action} />
+      </div>
+    );
+  } else if (isWebsearchActionType(action)) {
+    return (
+      <div className="pb-4">
+        <WebsearchAction websearchAction={action} />
       </div>
     );
   } else {

--- a/front/components/assistant/conversation/WebsearchAction.tsx
+++ b/front/components/assistant/conversation/WebsearchAction.tsx
@@ -1,0 +1,16 @@
+import type { WebsearchActionType } from "@dust-tt/types/dist/front/assistant/actions/websearch";
+
+// TODO(pr,websearch) Implement this function
+export default function WebsearchAction({
+  websearchAction,
+}: {
+  websearchAction: WebsearchActionType;
+}) {
+  return (
+    <>
+      <div>
+        Action to be implemented here: {JSON.stringify(websearchAction)}
+      </div>
+    </>
+  );
+}

--- a/front/components/assistant_builder/ActionScreen.tsx
+++ b/front/components/assistant_builder/ActionScreen.tsx
@@ -87,7 +87,7 @@ const ACTION_CATEGORY_SPECIFICATIONS: Record<
   WEBSEARCH: {
     label: "Web search",
     icon: MagnifyingGlassIcon,
-    description: "Search the web for an answer",
+    description: "Perform a web search",
     defaultActionType: "WEBSEARCH",
     flag: "websearch_action",
   },

--- a/front/components/assistant_builder/ActionScreen.tsx
+++ b/front/components/assistant_builder/ActionScreen.tsx
@@ -37,7 +37,11 @@ import { useDeprecatedDefaultSingleAction } from "@app/lib/client/assistant_buil
 
 import { ActionDustAppRun } from "./actions/DustAppRunAction";
 
-const BASIC_ACTION_CATEGORIES = ["REPLY_ONLY", "USE_DATA_SOURCES"] as const;
+const BASIC_ACTION_CATEGORIES = [
+  "REPLY_ONLY",
+  "USE_DATA_SOURCES",
+  "WEBSEARCH",
+] as const;
 const ADVANCED_ACTION_CATEGORIES = ["RUN_DUST_APP"] as const;
 
 type ActionCategory =
@@ -59,6 +63,7 @@ const ACTION_CATEGORY_SPECIFICATIONS: Record<
     icon: ComponentType;
     description: string;
     defaultActionType: AssistantBuilderActionType | null;
+    flag?: WhitelistableFeature | null;
   }
 > = {
   REPLY_ONLY: {
@@ -78,6 +83,13 @@ const ACTION_CATEGORY_SPECIFICATIONS: Record<
     icon: CommandLineIcon,
     description: "Run a Dust app, then reply",
     defaultActionType: "DUST_APP_RUN",
+  },
+  WEBSEARCH: {
+    label: "Web search",
+    icon: MagnifyingGlassIcon,
+    description: "Search the web for an answer",
+    defaultActionType: "WEBSEARCH",
+    flag: "websearch_action",
   },
 };
 
@@ -159,6 +171,8 @@ export default function ActionScreen({
         return "USE_DATA_SOURCES";
       case "DUST_APP_RUN":
         return "RUN_DUST_APP";
+      case "WEBSEARCH":
+        return "WEBSEARCH";
       default:
         assertNever(actionType);
     }
@@ -176,6 +190,7 @@ export default function ActionScreen({
         return "PROCESS";
 
       case null:
+      case "WEBSEARCH":
       case "DUST_APP_RUN":
         // Unused for non data sources related actions.
         return "RETRIEVAL_SEARCH";
@@ -227,7 +242,10 @@ export default function ActionScreen({
               />
             </DropdownMenu.Button>
             <DropdownMenu.Items origin="topLeft" width={260}>
-              {BASIC_ACTION_CATEGORIES.map((key) => {
+              {BASIC_ACTION_CATEGORIES.filter((key) => {
+                const flag = ACTION_CATEGORY_SPECIFICATIONS[key].flag;
+                return !flag || owner.flags.includes(flag);
+              }).map((key) => {
                 const spec = ACTION_CATEGORY_SPECIFICATIONS[key];
                 const defaultAction = getDefaultActionConfiguration(
                   spec.defaultActionType

--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -108,7 +108,7 @@ const ACTION_SPECIFICATIONS: Record<
   },
   WEBSEARCH: {
     label: "Web search",
-    description: "Search the web for information",
+    description: "Perform a web search",
     cardIcon: MagnifyingGlassStrokeIcon,
     dropDownIcon: MagnifyingGlassIcon,
     flag: "websearch_action",

--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -42,6 +42,10 @@ import {
   ActionTablesQuery,
   isActionTablesQueryValid,
 } from "@app/components/assistant_builder/actions/TablesQueryAction";
+import {
+  ActionWebsearch,
+  isActionWebsearchValid,
+} from "@app/components/assistant_builder/actions/WebsearchAction";
 import type {
   AssistantBuilderActionConfiguration,
   AssistantBuilderDustAppConfiguration,
@@ -102,6 +106,13 @@ const ACTION_SPECIFICATIONS: Record<
     dropDownIcon: TableStrokeIcon,
     flag: null,
   },
+  WEBSEARCH: {
+    label: "Web search",
+    description: "Search the web for information",
+    cardIcon: MagnifyingGlassStrokeIcon,
+    dropDownIcon: MagnifyingGlassIcon,
+    flag: "websearch_action",
+  },
 };
 
 const DATA_SOURCES_ACTION_CATEGORIES = [
@@ -139,6 +150,8 @@ export function isActionValid(
       return isActionDustAppRunValid(action);
     case "TABLES_QUERY":
       return isActionTablesQueryValid(action);
+    case "WEBSEARCH":
+      return isActionWebsearchValid(action);
     default:
       assertNever(action);
   }
@@ -613,6 +626,8 @@ function ActionEditor({
                   setEdited={setEdited}
                 />
               );
+            case "WEBSEARCH":
+              return <ActionWebsearch />;
             default:
               assertNever(action);
           }

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -866,6 +866,13 @@ export async function submitAssistantBuilderForm({
               tables: Object.values(a.configuration),
             };
 
+          case "WEBSEARCH":
+            return {
+              type: "websearch_configuration",
+              name: a.name,
+              description: a.description,
+            };
+
           case "PROCESS":
             return {
               type: "process_configuration",

--- a/front/components/assistant_builder/actions/WebsearchAction.tsx
+++ b/front/components/assistant_builder/actions/WebsearchAction.tsx
@@ -1,0 +1,18 @@
+import type { AssistantBuilderActionConfiguration } from "@app/components/assistant_builder/types";
+
+export function isActionWebsearchValid(
+  action: AssistantBuilderActionConfiguration
+) {
+  return (
+    action.type === "WEBSEARCH" && Object.keys(action.configuration).length > 0
+  );
+}
+
+export function ActionWebsearch() {
+  return (
+    <div>
+      This action will search the web and provide the 8 first results (title,
+      link and summary) to the assistant.
+    </div>
+  );
+}

--- a/front/components/assistant_builder/actions/WebsearchAction.tsx
+++ b/front/components/assistant_builder/actions/WebsearchAction.tsx
@@ -11,7 +11,7 @@ export function isActionWebsearchValid(
 export function ActionWebsearch() {
   return (
     <div>
-      This action will search the web and provide the 8 first results (title,
+      This action will perform a web search and return the top results (title,
       link and summary) to the assistant.
     </div>
   );

--- a/front/components/assistant_builder/server_side_props_helpers.ts
+++ b/front/components/assistant_builder/server_side_props_helpers.ts
@@ -15,6 +15,7 @@ import {
   isProcessConfiguration,
   isRetrievalConfiguration,
   isTablesQueryConfiguration,
+  isWebsearchConfiguration,
 } from "@dust-tt/types";
 
 import type {
@@ -28,6 +29,7 @@ import {
   getDefaultRetrievalExhaustiveActionConfiguration,
   getDefaultRetrievalSearchActionConfiguration,
   getDefaultTablesQueryActionConfiguration,
+  getDefaultWebsearchActionConfiguration,
 } from "@app/components/assistant_builder/types";
 import { tableKey } from "@app/lib/client/tables_query";
 import logger from "@app/logger/logger";
@@ -197,6 +199,8 @@ export async function buildInitialActions({
       processConfiguration.configuration.schema = action.schema;
 
       builderAction = processConfiguration;
+    } else if (isWebsearchConfiguration(action)) {
+      builderAction = getDefaultWebsearchActionConfiguration();
     } else {
       assertNever(action);
     }

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -227,15 +227,15 @@ export function getDefaultProcessActionConfiguration() {
   } satisfies AssistantBuilderActionConfiguration;
 }
 
-export function getDefaultWebsearchActionConfiguration() {
+export function getDefaultWebsearchActionConfiguration(): AssistantBuilderActionConfiguration {
   return {
     type: "WEBSEARCH",
     configuration: {
       searchResults: 8,
-    } satisfies AssistantBuilderWebsearchConfiguration,
+    },
     name: "websearch",
     description: "Perform a web search.",
-  } satisfies AssistantBuilderActionConfiguration;
+  };
 }
 
 export function getDefaultActionConfiguration(

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -75,6 +75,12 @@ export type AssistantBuilderProcessConfiguration = {
   schema: ProcessSchemaPropertyType[];
 };
 
+// Websearch configuration
+
+export type AssistantBuilderWebsearchConfiguration = {
+  searchResults: 8; // not configurable at the time of writing, placeholder
+};
+
 // Builder State
 
 export type AssistantBuilderActionConfiguration = (
@@ -93,6 +99,10 @@ export type AssistantBuilderActionConfiguration = (
   | {
       type: "PROCESS";
       configuration: AssistantBuilderProcessConfiguration;
+    }
+  | {
+      type: "WEBSEARCH";
+      configuration: AssistantBuilderWebsearchConfiguration;
     }
 ) & {
   name: string;
@@ -217,6 +227,17 @@ export function getDefaultProcessActionConfiguration() {
   } satisfies AssistantBuilderActionConfiguration;
 }
 
+export function getDefaultWebsearchActionConfiguration() {
+  return {
+    type: "WEBSEARCH",
+    configuration: {
+      searchResults: 8,
+    } satisfies AssistantBuilderWebsearchConfiguration,
+    name: "websearch",
+    description: "Search the web.",
+  } satisfies AssistantBuilderActionConfiguration;
+}
+
 export function getDefaultActionConfiguration(
   actionType: AssistantBuilderActionType | null
 ): AssistantBuilderActionConfiguration | null {
@@ -233,6 +254,8 @@ export function getDefaultActionConfiguration(
       return getDefaultTablesQueryActionConfiguration();
     case "PROCESS":
       return getDefaultProcessActionConfiguration();
+    case "WEBSEARCH":
+      return getDefaultWebsearchActionConfiguration();
     default:
       assertNever(actionType);
   }

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -234,7 +234,7 @@ export function getDefaultWebsearchActionConfiguration() {
       searchResults: 8,
     } satisfies AssistantBuilderWebsearchConfiguration,
     name: "websearch",
-    description: "Search the web.",
+    description: "Perform a web search.",
   } satisfies AssistantBuilderActionConfiguration;
 }
 

--- a/front/lib/api/assistant/actions/runners.ts
+++ b/front/lib/api/assistant/actions/runners.ts
@@ -3,6 +3,7 @@ import type {
   DustAppRunConfigurationType,
   ProcessConfigurationType,
 } from "@dust-tt/types";
+import type { WebsearchConfigurationType } from "@dust-tt/types/dist/front/assistant/actions/websearch";
 
 import { DustAppRunConfigurationServerRunner } from "@app/lib/api/assistant/actions/dust_app_run";
 import { ProcessConfigurationServerRunner } from "@app/lib/api/assistant/actions/process";
@@ -11,16 +12,19 @@ import type {
   BaseActionConfigurationServerRunnerConstructor,
   BaseActionConfigurationStaticMethods,
 } from "@app/lib/api/assistant/actions/types";
+import { WebsearchConfigurationServerRunner } from "@app/lib/api/assistant/actions/websearch";
 
 interface ActionToConfigTypeMap {
   dust_app_run_configuration: DustAppRunConfigurationType;
   process_configuration: ProcessConfigurationType;
+  websearch_configuration: WebsearchConfigurationType;
   // Add other configurations once migrated to classes.
 }
 
 interface ActionTypeToClassMap {
   dust_app_run_configuration: DustAppRunConfigurationServerRunner;
   process_configuration: ProcessConfigurationServerRunner;
+  websearch_configuration: WebsearchConfigurationServerRunner;
 }
 
 // Ensure all AgentAction keys are present in ActionToConfigTypeMap.
@@ -61,6 +65,7 @@ export const ACTION_TYPE_TO_CONFIGURATION_SERVER_RUNNER: {
 } = {
   dust_app_run_configuration: DustAppRunConfigurationServerRunner,
   process_configuration: ProcessConfigurationServerRunner,
+  websearch_configuration: WebsearchConfigurationServerRunner,
 } as const;
 
 export function getRunnerforActionConfiguration<K extends keyof CombinedMap>(

--- a/front/lib/api/assistant/actions/websearch.ts
+++ b/front/lib/api/assistant/actions/websearch.ts
@@ -11,19 +11,6 @@ import type { Authenticator } from "@app/lib/auth";
  */
 
 export class WebsearchConfigurationServerRunner extends BaseActionConfigurationServerRunner<WebsearchConfigurationType> {
-  run(
-    auth: Authenticator,
-    runParams: BaseActionRunParams,
-    customParams: Record<string, unknown>
-  ): AsyncGenerator<unknown, any, unknown> {
-    throw new Error(
-      "Method not implemented." +
-        JSON.stringify(runParams) +
-        JSON.stringify(customParams) +
-        JSON.stringify(auth)
-    );
-  }
-
   async buildSpecification(
     auth: Authenticator,
     {
@@ -50,5 +37,18 @@ export class WebsearchConfigurationServerRunner extends BaseActionConfigurationS
         },
       ],
     });
+  }
+
+  run(
+    auth: Authenticator,
+    runParams: BaseActionRunParams,
+    customParams: Record<string, unknown>
+  ): AsyncGenerator<unknown, any, unknown> {
+    throw new Error(
+      "Method not implemented." +
+        JSON.stringify(runParams) +
+        JSON.stringify(customParams) +
+        JSON.stringify(auth)
+    );
   }
 }

--- a/front/lib/api/assistant/actions/websearch.ts
+++ b/front/lib/api/assistant/actions/websearch.ts
@@ -1,0 +1,49 @@
+import type { AgentActionSpecification, Result } from "@dust-tt/types";
+import { Ok } from "@dust-tt/types";
+import type { WebsearchConfigurationType } from "@dust-tt/types/dist/front/assistant/actions/websearch";
+
+import type { Authenticator } from "@app/lib/auth";
+
+function websearchActionSpecification(arg0: {
+  actionConfiguration: WebsearchConfigurationType;
+  name: string;
+  description: string;
+}) {
+  return {
+    ...arg0,
+    inputs: [
+      {
+        name: "query",
+        description: "The search query to run.",
+        type: "string",
+      },
+    ],
+  } as AgentActionSpecification;
+}
+
+export async function generateWebsearchSpecification(
+  auth: Authenticator,
+  {
+    actionConfiguration,
+    name = "websearch",
+    description,
+  }: {
+    actionConfiguration: WebsearchConfigurationType;
+    name?: string;
+    description?: string;
+  }
+): Promise<Result<AgentActionSpecification, Error>> {
+  const owner = auth.workspace();
+  if (!owner) {
+    throw new Error("Unexpected unauthenticated call to `runWebsearchAction`");
+  }
+
+  const spec = websearchActionSpecification({
+    actionConfiguration,
+    name,
+    description:
+      description ?? "Search the web for information on a given topic.",
+  });
+
+  return new Ok(spec);
+}

--- a/front/lib/api/assistant/actions/websearch.ts
+++ b/front/lib/api/assistant/actions/websearch.ts
@@ -14,25 +14,25 @@ function websearchActionSpecification(arg0: {
     inputs: [
       {
         name: "query",
-        description: "The search query to run.",
+        description: "The query used to perform the web search.",
         type: "string",
       },
     ],
   } as AgentActionSpecification;
 }
 
-export async function generateWebsearchSpecification(
+export function generateWebsearchSpecification(
   auth: Authenticator,
   {
     actionConfiguration,
-    name = "websearch",
+    name = "web_search",
     description,
   }: {
     actionConfiguration: WebsearchConfigurationType;
     name?: string;
     description?: string;
   }
-): Promise<Result<AgentActionSpecification, Error>> {
+): Result<AgentActionSpecification, Error> {
   const owner = auth.workspace();
   if (!owner) {
     throw new Error("Unexpected unauthenticated call to `runWebsearchAction`");
@@ -42,7 +42,7 @@ export async function generateWebsearchSpecification(
     actionConfiguration,
     name,
     description:
-      description ?? "Search the web for information on a given topic.",
+      description ?? "Perform a web search and return the top results.",
   });
 
   return new Ok(spec);

--- a/front/lib/api/assistant/actions/websearch.ts
+++ b/front/lib/api/assistant/actions/websearch.ts
@@ -2,48 +2,53 @@ import type { AgentActionSpecification, Result } from "@dust-tt/types";
 import { Ok } from "@dust-tt/types";
 import type { WebsearchConfigurationType } from "@dust-tt/types/dist/front/assistant/actions/websearch";
 
+import type { BaseActionRunParams } from "@app/lib/api/assistant/actions/types";
+import { BaseActionConfigurationServerRunner } from "@app/lib/api/assistant/actions/types";
 import type { Authenticator } from "@app/lib/auth";
 
-function websearchActionSpecification(arg0: {
-  actionConfiguration: WebsearchConfigurationType;
-  name: string;
-  description: string;
-}) {
-  return {
-    ...arg0,
-    inputs: [
-      {
-        name: "query",
-        description: "The query used to perform the web search.",
-        type: "string",
-      },
-    ],
-  } as AgentActionSpecification;
-}
+/**
+ * Params generation.
+ */
 
-export function generateWebsearchSpecification(
-  auth: Authenticator,
-  {
-    actionConfiguration,
-    name = "web_search",
-    description,
-  }: {
-    actionConfiguration: WebsearchConfigurationType;
-    name?: string;
-    description?: string;
-  }
-): Result<AgentActionSpecification, Error> {
-  const owner = auth.workspace();
-  if (!owner) {
-    throw new Error("Unexpected unauthenticated call to `runWebsearchAction`");
+export class WebsearchConfigurationServerRunner extends BaseActionConfigurationServerRunner<WebsearchConfigurationType> {
+  run(
+    auth: Authenticator,
+    runParams: BaseActionRunParams,
+    customParams: Record<string, unknown>
+  ): AsyncGenerator<unknown, any, unknown> {
+    throw new Error(
+      "Method not implemented." +
+        JSON.stringify(runParams) +
+        JSON.stringify(customParams) +
+        JSON.stringify(auth)
+    );
   }
 
-  const spec = websearchActionSpecification({
-    actionConfiguration,
-    name,
-    description:
-      description ?? "Perform a web search and return the top results.",
-  });
+  async buildSpecification(
+    auth: Authenticator,
+    {
+      name,
+      description,
+    }: { name?: string | undefined; description?: string | undefined }
+  ): Promise<Result<AgentActionSpecification, Error>> {
+    const owner = auth.workspace();
+    if (!owner) {
+      throw new Error(
+        "Unexpected unauthenticated call to `runWebsearchAction`"
+      );
+    }
 
-  return new Ok(spec);
+    return new Ok({
+      name: name ?? "web_search",
+      description:
+        description ?? "Perform a web search and return the top results.",
+      inputs: [
+        {
+          name: "query",
+          description: "The query used to perform the web search.",
+          type: "string",
+        },
+      ],
+    });
+  }
 }

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -26,6 +26,7 @@ import {
   isProcessConfiguration,
   isRetrievalConfiguration,
   isTablesQueryConfiguration,
+  isWebsearchConfiguration,
   SUPPORTED_MODEL_CONFIGS,
 } from "@dust-tt/types";
 
@@ -844,6 +845,40 @@ async function* runAction(
           assertNever(event);
       }
     }
+  } else if (isWebsearchConfiguration(actionConfiguration)) {
+    // Dummy implementation while in development (gated)
+    // TODO(pr,websearch) Implement this function
+    yield {
+      type: "agent_action_success",
+      created: now,
+      configurationId: configuration.sId,
+      messageId: agentMessage.sId,
+      action: {
+        agentMessageId: agentMessage.id,
+        type: "websearch_action",
+        query: "testing it",
+        output: {
+          results: [{ title: "test", snippet: "sniptest", url: "http://lol" }],
+        },
+        functionCallId: null,
+        functionCallName: null,
+        step,
+        id: -1,
+        renderForFunctionCall: () => {
+          return { id: "Websearch", name: "Websearch", arguments: "None" };
+        },
+        renderForModel: () => {
+          return { role: "action", name: "Websearch", content: "None" };
+        },
+        renderForMultiActionsModel: () => {
+          return {
+            role: "function",
+            function_call_id: "websearch",
+            content: "None",
+          };
+        },
+      },
+    };
   } else {
     assertNever(actionConfiguration);
   }

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -40,7 +40,6 @@ import {
   generateTablesQuerySpecification,
   runTablesQuery,
 } from "@app/lib/api/assistant/actions/tables_query";
-import { generateWebsearchSpecification } from "@app/lib/api/assistant/actions/websearch";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
 import {
   constructPromptMultiActions,

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -50,6 +50,7 @@ import { isLegacyAgent } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { redisClient } from "@app/lib/redis";
 import logger from "@app/logger/logger";
+import { generateWebsearchSpecification } from "@app/lib/api/assistant/actions/websearch";
 
 const CANCELLATION_CHECK_INTERVAL = 500;
 

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -40,6 +40,7 @@ import {
   generateTablesQuerySpecification,
   runTablesQuery,
 } from "@app/lib/api/assistant/actions/tables_query";
+import { generateWebsearchSpecification } from "@app/lib/api/assistant/actions/websearch";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
 import {
   constructPromptMultiActions,
@@ -50,7 +51,6 @@ import { isLegacyAgent } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { redisClient } from "@app/lib/redis";
 import logger from "@app/logger/logger";
-import { generateWebsearchSpecification } from "@app/lib/api/assistant/actions/websearch";
 
 const CANCELLATION_CHECK_INTERVAL = 500;
 

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -45,6 +45,7 @@ import {
   AgentTablesQueryConfiguration,
   AgentTablesQueryConfigurationTable,
 } from "@app/lib/models/assistant/actions/tables_query";
+import { AgentWebsearchConfiguration } from "@app/lib/models/assistant/actions/websearch";
 import {
   AgentConfiguration,
   AgentUserRelation,
@@ -1065,6 +1066,9 @@ export async function createAgentActionConfiguration(
         dataSources: DataSourceConfiguration[];
         schema: ProcessSchemaPropertyType[];
       }
+    | {
+        type: "websearch_configuration";
+      }
   ) & {
     name: string | null;
     description: string | null;
@@ -1218,6 +1222,29 @@ export async function createAgentActionConfiguration(
           tagsFilter: action.tagsFilter,
           schema: action.schema,
           dataSources: action.dataSources,
+          name: action.name,
+          description: action.description,
+          forceUseAtIteration: action.forceUseAtIteration,
+        };
+      });
+    }
+    case "websearch_configuration": {
+      return frontSequelize.transaction(async (t) => {
+        const websearchConfig = await AgentWebsearchConfiguration.create(
+          {
+            sId: generateModelSId(),
+            agentConfigurationId: agentConfiguration.id,
+            name: action.name,
+            description: action.description,
+            forceUseAtIteration: action.forceUseAtIteration,
+          },
+          { transaction: t }
+        );
+
+        return {
+          id: websearchConfig.id,
+          sId: websearchConfig.sId,
+          type: "websearch_configuration",
           name: action.name,
           description: action.description,
           forceUseAtIteration: action.forceUseAtIteration,

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -1229,27 +1229,22 @@ export async function createAgentActionConfiguration(
       });
     }
     case "websearch_configuration": {
-      return frontSequelize.transaction(async (t) => {
-        const websearchConfig = await AgentWebsearchConfiguration.create(
-          {
-            sId: generateModelSId(),
-            agentConfigurationId: agentConfiguration.id,
-            name: action.name,
-            description: action.description,
-            forceUseAtIteration: action.forceUseAtIteration,
-          },
-          { transaction: t }
-        );
-
-        return {
-          id: websearchConfig.id,
-          sId: websearchConfig.sId,
-          type: "websearch_configuration",
-          name: action.name,
-          description: action.description,
-          forceUseAtIteration: action.forceUseAtIteration,
-        };
+      const websearchConfig = await AgentWebsearchConfiguration.create({
+        sId: generateModelSId(),
+        agentConfigurationId: agentConfiguration.id,
+        name: action.name,
+        description: action.description,
+        forceUseAtIteration: action.forceUseAtIteration,
       });
+
+      return {
+        id: websearchConfig.id,
+        sId: websearchConfig.sId,
+        type: "websearch_configuration",
+        name: action.name,
+        description: action.description,
+        forceUseAtIteration: action.forceUseAtIteration,
+      };
     }
     default:
       assertNever(action);

--- a/front/lib/api/assistant/legacy_agent.ts
+++ b/front/lib/api/assistant/legacy_agent.ts
@@ -39,7 +39,6 @@ import {
   deprecatedGenerateTablesQuerySpecificationForSingleActionAgent,
   runTablesQuery,
 } from "@app/lib/api/assistant/actions/tables_query";
-import { generateWebsearchSpecification } from "@app/lib/api/assistant/actions/websearch";
 import {
   constructPrompt,
   renderConversationForModel,

--- a/front/lib/api/assistant/legacy_agent.ts
+++ b/front/lib/api/assistant/legacy_agent.ts
@@ -25,6 +25,7 @@ import {
   isProcessConfiguration,
   isRetrievalConfiguration,
   isTablesQueryConfiguration,
+  isWebsearchConfiguration,
   Ok,
 } from "@dust-tt/types";
 
@@ -38,6 +39,7 @@ import {
   deprecatedGenerateTablesQuerySpecificationForSingleActionAgent,
   runTablesQuery,
 } from "@app/lib/api/assistant/actions/tables_query";
+import { generateWebsearchSpecification } from "@app/lib/api/assistant/actions/websearch";
 import {
   constructPrompt,
   renderConversationForModel,
@@ -577,6 +579,40 @@ async function* runAction(
           assertNever(event);
       }
     }
+  } else if (isWebsearchConfiguration(action)) {
+    // Dummy implementation while in development (gated)
+    // TODO(pr,websearch) Implement this function
+    yield {
+      type: "agent_action_success",
+      created: now,
+      configurationId: configuration.sId,
+      messageId: agentMessage.sId,
+      action: {
+        agentMessageId: agentMessage.id,
+        type: "websearch_action",
+        query: "testing it",
+        output: {
+          results: [{ title: "test", snippet: "sniptest", url: "http://lol" }],
+        },
+        functionCallId: null,
+        functionCallName: null,
+        step,
+        id: -1,
+        renderForFunctionCall: () => {
+          return { id: "Websearch", name: "Websearch", arguments: "None" };
+        },
+        renderForModel: () => {
+          return { role: "action", name: "Websearch", content: "None" };
+        },
+        renderForMultiActionsModel: () => {
+          return {
+            role: "function",
+            function_call_id: "websearch",
+            content: "None",
+          };
+        },
+      },
+    };
   } else {
     assertNever(action);
   }

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -437,6 +437,21 @@ export async function createOrUpgradeAgentConfiguration({
             agentConfigurationRes.value
           )
         );
+      } else if (action.type === "websearch_configuration") {
+        actionConfigs.push(
+          await createAgentActionConfiguration(
+            auth,
+            {
+              type: "websearch_configuration",
+              name: action.name ?? null,
+              description: action.description ?? null,
+              forceUseAtIteration:
+                action.forceUseAtIteration ??
+                legacyForceSingleActionAtIteration,
+            },
+            agentConfigurationRes.value
+          )
+        );
       } else {
         assertNever(action);
       }

--- a/types/src/front/api_handlers/internal/agent_configuration.ts
+++ b/types/src/front/api_handlers/internal/agent_configuration.ts
@@ -93,6 +93,10 @@ const TablesQueryActionConfigurationSchema = t.type({
   ),
 });
 
+const WebsearchActionConfigurationSchema = t.type({
+  type: t.literal("websearch_configuration"),
+});
+
 const ProcessActionConfigurationSchema = t.type({
   type: t.literal("process_configuration"),
   dataSources: t.array(
@@ -149,6 +153,7 @@ const ActionConfigurationSchema = t.intersection([
     DustAppRunActionConfigurationSchema,
     TablesQueryActionConfigurationSchema,
     ProcessActionConfigurationSchema,
+    WebsearchActionConfigurationSchema,
   ]),
   t.partial(multiActionsCommonFields),
 ]);

--- a/types/src/front/assistant/actions/guards.ts
+++ b/types/src/front/assistant/actions/guards.ts
@@ -17,6 +17,7 @@ import {
 import { AgentActionType } from "../../../front/assistant/conversation";
 import { BaseAction } from "../../../front/lib/api/assistant/actions/index";
 import { AgentActionConfigurationType } from "../agent";
+import { WebsearchActionType, WebsearchConfigurationType } from "./websearch";
 
 export function isTablesQueryConfiguration(
   arg: unknown
@@ -90,6 +91,23 @@ export function isProcessActionType(
   arg: AgentActionType
 ): arg is ProcessActionType {
   return arg.type === "process_action";
+}
+
+export function isWebsearchConfiguration(
+  arg: unknown
+): arg is WebsearchConfigurationType {
+  return (
+    !!arg &&
+    typeof arg === "object" &&
+    "type" in arg &&
+    arg.type === "websearch_configuration"
+  );
+}
+
+export function isWebsearchActionType(
+  arg: AgentActionType
+): arg is WebsearchActionType {
+  return arg.type === "websearch_action";
 }
 
 export function isAgentActionConfigurationType(

--- a/types/src/front/assistant/agent.ts
+++ b/types/src/front/assistant/agent.ts
@@ -4,6 +4,7 @@ import { RetrievalConfigurationType } from "../../front/assistant/actions/retrie
 import { TablesQueryConfigurationType } from "../../front/assistant/actions/tables_query";
 import { ModelIdType, ModelProviderIdType } from "../../front/lib/assistant";
 import { ModelId } from "../../shared/model_id";
+import { WebsearchConfigurationType } from "./actions/websearch";
 
 /**
  * Agent Action configuration
@@ -16,7 +17,8 @@ export type AgentActionConfigurationType =
   | TablesQueryConfigurationType
   | RetrievalConfigurationType
   | DustAppRunConfigurationType
-  | ProcessConfigurationType;
+  | ProcessConfigurationType
+  | WebsearchConfigurationType;
 
 export type AgentAction = AgentActionConfigurationType["type"];
 

--- a/types/src/front/assistant/conversation.ts
+++ b/types/src/front/assistant/conversation.ts
@@ -5,6 +5,7 @@ import { TablesQueryActionType } from "../../front/assistant/actions/tables_quer
 import { LightAgentConfigurationType } from "../../front/assistant/agent";
 import { UserType, WorkspaceType } from "../../front/user";
 import { ModelId } from "../../shared/model_id";
+import { WebsearchActionType } from "./actions/websearch";
 
 /**
  * Mentions
@@ -84,7 +85,8 @@ export type AgentActionType =
   | RetrievalActionType
   | DustAppRunActionType
   | TablesQueryActionType
-  | ProcessActionType;
+  | ProcessActionType
+  | WebsearchActionType;
 
 export type AgentMessageStatus =
   | "created"

--- a/types/src/front/assistant/templates.ts
+++ b/types/src/front/assistant/templates.ts
@@ -8,6 +8,7 @@ import { DustAppRunConfigurationType } from "./actions/dust_app_run";
 import { ProcessConfigurationType } from "./actions/process";
 import { RetrievalConfigurationType } from "./actions/retrieval";
 import { TablesQueryConfigurationType } from "./actions/tables_query";
+import { WebsearchConfigurationType } from "./actions/websearch";
 import { AgentAction, AgentActionConfigurationType } from "./agent";
 import { AssistantCreativityLevelCodec } from "./builder";
 
@@ -99,6 +100,7 @@ export const ACTION_PRESETS: Record<AgentAction | "reply", string> = {
   retrieval_configuration: "Search data sources",
   tables_query_configuration: "Query tables",
   process_configuration: "Process data sources",
+  websearch_configuration: "Web search",
 } as const;
 export type ActionPreset = keyof typeof ACTION_PRESETS;
 export const ActionPresetCodec = ioTsEnum<ActionPreset>(
@@ -195,6 +197,16 @@ export function getAgentActionConfigurationType(
         description: "Process the workspace's internal data sources.",
         forceUseAtIteration: 0,
       } satisfies ProcessConfigurationType;
+
+    case "websearch_configuration":
+      return {
+        id: -1,
+        sId: "template",
+        type: "websearch_configuration",
+        name: "web_search",
+        description: "Search the web.",
+        forceUseAtIteration: 0,
+      } satisfies WebsearchConfigurationType;
 
     default:
       assertNever(action);

--- a/types/src/front/lib/api/assistant/actions/index.ts
+++ b/types/src/front/lib/api/assistant/actions/index.ts
@@ -9,7 +9,8 @@ type BaseActionType =
   | "dust_app_run_action"
   | "tables_query_action"
   | "retrieval_action"
-  | "process_action";
+  | "process_action"
+  | "websearch_action";
 
 export abstract class BaseAction {
   readonly id: ModelId;


### PR DESCRIPTION
Description
---
This PR follows #5224 that introduced types and models for websearch.

It adds the websearch action to union action types, and creates the necessary boilerplate.

Following PRs will implement each part: action execution, action rendering, action configuration in builder

Risk
---
None, since gated

Deployment plan
---
Front
