### PR TITLE
Paywall page adapts wording if previous subscriptions

### DIFF
--- a/front/lib/plans/subscription.ts
+++ b/front/lib/plans/subscription.ts
@@ -473,3 +473,24 @@ export async function getSubscriptionForStripeId(
     activeSubscription: res,
   });
 }
+
+export async function getSubscriptions(
+  auth: Authenticator
+): Promise<SubscriptionType[]> {
+  const owner = auth.workspace();
+  if (!owner) {
+    throw new Error("Cannot find workspace.");
+  }
+
+  const subscriptions = await Subscription.findAll({
+    where: { workspaceId: owner.id },
+    include: [Plan],
+  });
+
+  return subscriptions.map((s) =>
+    renderSubscriptionFromModels({
+      plan: s.plan,
+      activeSubscription: s,
+    })
+  );
+}

--- a/front/lib/swr.ts
+++ b/front/lib/swr.ts
@@ -46,6 +46,7 @@ import type { GetKeysResponseBody } from "@app/pages/api/w/[wId]/keys";
 import type { GetLabsTranscriptsConfigurationResponseBody } from "@app/pages/api/w/[wId]/labs/transcripts";
 import type { GetMembersResponseBody } from "@app/pages/api/w/[wId]/members";
 import type { GetProvidersResponseBody } from "@app/pages/api/w/[wId]/providers";
+import type { GetSubscriptionsResponseBody } from "@app/pages/api/w/[wId]/subscriptions";
 import type { GetWorkspaceAnalyticsResponse } from "@app/pages/api/w/[wId]/workspace-analytics";
 
 export const fetcher = async (...args: Parameters<typeof fetch>) =>
@@ -524,6 +525,26 @@ export function usePokePlans() {
     plans: useMemo(() => (data ? data.plans : []), [data]),
     isPlansLoading: !error && !data,
     isPlansError: error,
+  };
+}
+
+export function useWorkspaceSubscriptions({
+  workspaceId,
+}: {
+  workspaceId: string;
+}) {
+  const workspaceSubscrptionsFetcher: Fetcher<GetSubscriptionsResponseBody> =
+    fetcher;
+
+  const { data, error } = useSWR(
+    `/api/w/${workspaceId}/subscriptions`,
+    workspaceSubscrptionsFetcher
+  );
+
+  return {
+    subscriptions: useMemo(() => (data ? data.subscriptions : []), [data]),
+    isSubscriptionsLoading: !error && !data,
+    isSubscriptionsError: error,
   };
 }
 

--- a/front/pages/w/[wId]/subscribe.tsx
+++ b/front/pages/w/[wId]/subscribe.tsx
@@ -147,7 +147,7 @@ export default function Subscribe({
                     <Page.P>
                       Please note that if your previous contract expired over 15
                       days ago, previously stored data will no longer be
-                      available to ensure privacy and security.
+                      available. This is to ensure privacy and security.
                     </Page.P>
                   </>
                 ) : (

--- a/front/pages/w/[wId]/subscribe.tsx
+++ b/front/pages/w/[wId]/subscribe.tsx
@@ -11,7 +11,7 @@ import { UserMenu } from "@app/components/UserMenu";
 import WorkspacePicker from "@app/components/WorkspacePicker";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { withDefaultUserAuthPaywallWhitelisted } from "@app/lib/iam/session";
-import { useUser } from "@app/lib/swr";
+import { useUser, useWorkspaceSubscriptions } from "@app/lib/swr";
 import { ClientSideTracking } from "@app/lib/tracking/client";
 
 const { GA_TRACKING_ID = "" } = process.env;
@@ -44,6 +44,15 @@ export default function Subscribe({
   const router = useRouter();
   const sendNotification = useContext(SendNotificationsContext);
   const { user } = useUser();
+
+  const { subscriptions } = useWorkspaceSubscriptions({
+    workspaceId: owner.sId,
+  });
+
+  // If you had another subscription before, you will not get the free trial again: we use this to show the correct message.
+  // Current plan is always FREE_NO_PLAN if you're on this paywall.
+  // Since FREE_NO_PLAN is not on the database, we check if there is at least 1 subscription.
+  const hasPreviouSubscription = subscriptions?.length > 0;
 
   useEffect(() => {
     if (user?.id) {
@@ -127,18 +136,41 @@ export default function Subscribe({
                   icon={CreditCardIcon}
                   title="Setting up your subscription"
                 />
-                <Page.P>
-                  <span className="font-bold">
-                    You can try the Pro plan for free for two weeks.
-                  </span>
-                </Page.P>
-                <Page.P>
-                  After your trial ends, you will be charged monthly. You can
-                  cancel at any time.
-                </Page.P>
+                {hasPreviouSubscription ? (
+                  <>
+                    <Page.P>
+                      <span className="font-bold">
+                        Welcome back! You can reactivate your subscription
+                        anytime.
+                      </span>
+                    </Page.P>
+                    <Page.P>
+                      Please note that if your previous contract expired over 15
+                      days ago, previously stored data will no longer be
+                      available to ensure privacy and security.
+                    </Page.P>
+                  </>
+                ) : (
+                  <>
+                    <Page.P>
+                      <span className="font-bold">
+                        You can try the Pro plan for free for two weeks.
+                      </span>
+                    </Page.P>
+                    <Page.P>
+                      After your trial ends, you will be charged monthly. You
+                      can cancel at any time.
+                    </Page.P>
+                  </>
+                )}
+
                 <Button
                   variant="primary"
-                  label="Start your trial"
+                  label={
+                    hasPreviouSubscription
+                      ? "Resume your subscription"
+                      : "Start your trial"
+                  }
                   icon={CreditCardIcon}
                   size="md"
                   onClick={() => {


### PR DESCRIPTION
## Description

Adapts the wording of the Paywall page if the user has a previous subscription. 
Eng runner task: https://github.com/dust-tt/tasks/issues/768

First time subscribing: 
<kbd>
<img width="1049" alt="Screenshot 2024-05-23 at 11 07 30" src="https://github.com/dust-tt/dust/assets/3803406/85b64b5a-4e8c-4c90-9002-93a9607440aa">
</kbd>
Not first time subscribing: 
<kbd>
<img width="972" alt="Screenshot 2024-05-23 at 11 06 45" src="https://github.com/dust-tt/dust/assets/3803406/ec348311-7ca8-4720-a2d7-2328cb847a7b">
</kbd>



## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
