### PR TITLE
Fix memberships with role member

### DIFF
--- a/front/migrations/db/migration_10.sql
+++ b/front/migrations/db/migration_10.sql
@@ -1,0 +1,1 @@
+UPDATE memberships SET "role" = 'user' WHERE role = 'member';


### PR DESCRIPTION
## Description

Running `SELECT role, COUNT(id) FROM memberships GROUP BY role;` on Metabase yesterday made me realize that we have some rows on Memberships that have the role "member" instead of "user". 

This was introduced here: https://github.com/dust-tt/dust/blob/main/front/migrations/20240403_memberships_no_more_revoked.ts

=> As a fix, this PR is adding a new migration file to set those memberships back to role user as it should be. 

## Risk



## Deploy Plan

Deploy to Prodbox. 
Run `psql $FRONT_DATABASE_URI -f ./migrations/db/migration_10.sql`.
