### PR TITLE
Use Qdrant cluster-0 as default clusters for all new data sources.

### DIFF
--- a/types/src/core/data_source.ts
+++ b/types/src/core/data_source.ts
@@ -6,7 +6,7 @@ export type QdrantCluster =
   | "cluster-0";
 
 export const DEFAULT_FREE_QDRANT_CLUSTER: QdrantCluster = "cluster-0";
-export const DEFAULT_PAID_QDRANT_CLUSTER: QdrantCluster = "dedicated-2";
+export const DEFAULT_PAID_QDRANT_CLUSTER: QdrantCluster = "cluster-0";
 
 export type CoreAPIDataSourceConfig = {
   provider_id: string;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Following the recent migration, this PR set `cluster-0` as the default Qdrant clusters for all paying customers. It means that all new data source created will be routed toward this new cluster.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
