### PR TITLE
(fix) Add userId back to getTranscriptsGoogleAuth

### DIFF
--- a/front/lib/labs/transcripts/utils/helpers.ts
+++ b/front/lib/labs/transcripts/utils/helpers.ts
@@ -36,7 +36,7 @@ export async function getTranscriptsGoogleAuth(
   userId: ModelId
 ) {
   const transcriptsConfiguration =
-    await LabsTranscriptsConfigurationResource.findByUserWorkspace({
+    await LabsTranscriptsConfigurationResource.findByUserAndWorkspace({
       auth,
       userId,
     });

--- a/front/lib/labs/transcripts/utils/helpers.ts
+++ b/front/lib/labs/transcripts/utils/helpers.ts
@@ -1,4 +1,8 @@
-import type { NangoConnectionId, NangoIntegrationId } from "@dust-tt/types";
+import type {
+  ModelId,
+  NangoConnectionId,
+  NangoIntegrationId,
+} from "@dust-tt/types";
 import { Nango } from "@nangohq/node";
 import { google } from "googleapis";
 import type { OAuth2Client } from "googleapis-common";
@@ -27,10 +31,14 @@ export async function getGoogleAuthObject(
   return oauth2Client;
 }
 
-export async function getTranscriptsGoogleAuth(auth: Authenticator) {
+export async function getTranscriptsGoogleAuth(
+  auth: Authenticator,
+  userId: ModelId
+) {
   const transcriptsConfiguration =
     await LabsTranscriptsConfigurationResource.findByUserWorkspace({
       auth,
+      userId,
     });
 
   if (

--- a/front/lib/resources/labs_transcripts_resource.ts
+++ b/front/lib/resources/labs_transcripts_resource.ts
@@ -49,7 +49,7 @@ export class LabsTranscriptsConfigurationResource extends BaseResource<LabsTrans
     );
   }
 
-  static async findByUserWorkspace({
+  static async findByUserAndWorkspace({
     auth,
     userId,
   }: {

--- a/front/lib/resources/labs_transcripts_resource.ts
+++ b/front/lib/resources/labs_transcripts_resource.ts
@@ -51,19 +51,20 @@ export class LabsTranscriptsConfigurationResource extends BaseResource<LabsTrans
 
   static async findByUserWorkspace({
     auth,
+    userId,
   }: {
     auth: Authenticator;
+    userId: number;
   }): Promise<LabsTranscriptsConfigurationResource | null> {
     const owner = auth.workspace();
-    const user = auth.user();
 
-    if (!owner || !user) {
+    if (!owner) {
       return null;
     }
 
     const configuration = await LabsTranscriptsConfigurationModel.findOne({
       where: {
-        userId: user.id,
+        userId,
         workspaceId: owner.id,
       },
     });

--- a/front/pages/api/w/[wId]/labs/transcripts/index.ts
+++ b/front/pages/api/w/[wId]/labs/transcripts/index.ts
@@ -60,7 +60,7 @@ async function handler(
   switch (req.method) {
     case "GET":
       const transcriptsConfigurationGet =
-        await LabsTranscriptsConfigurationResource.findByUserWorkspace({
+        await LabsTranscriptsConfigurationResource.findByUserAndWorkspace({
           auth,
           userId,
         });
@@ -99,7 +99,7 @@ async function handler(
       const { connectionId, provider } = bodyValidation.right;
 
       const transcriptsConfigurationAlreadyExists =
-        await LabsTranscriptsConfigurationResource.findByUserWorkspace({
+        await LabsTranscriptsConfigurationResource.findByUserAndWorkspace({
           auth,
           userId,
         });

--- a/front/pages/api/w/[wId]/labs/transcripts/index.ts
+++ b/front/pages/api/w/[wId]/labs/transcripts/index.ts
@@ -62,6 +62,7 @@ async function handler(
       const transcriptsConfigurationGet =
         await LabsTranscriptsConfigurationResource.findByUserWorkspace({
           auth,
+          userId,
         });
 
       if (!transcriptsConfigurationGet) {
@@ -100,6 +101,7 @@ async function handler(
       const transcriptsConfigurationAlreadyExists =
         await LabsTranscriptsConfigurationResource.findByUserWorkspace({
           auth,
+          userId,
         });
 
       if (transcriptsConfigurationAlreadyExists) {

--- a/front/temporal/labs/utils/google.ts
+++ b/front/temporal/labs/utils/google.ts
@@ -9,13 +9,14 @@ import type { Logger } from "@app/logger/logger";
 export async function retrieveRecentGoogleTranscripts(
   {
     auth,
+    userId,
   }: {
     auth: Authenticator;
     userId: ModelId;
   },
   logger: Logger
 ) {
-  const googleAuth = await getTranscriptsGoogleAuth(auth);
+  const googleAuth = await getTranscriptsGoogleAuth(auth, userId);
 
   if (!googleAuth) {
     logger.error(
@@ -96,7 +97,10 @@ export async function retrieveGoogleTranscriptContent(
   fileId: string,
   localLogger: Logger
 ): Promise<{ transcriptTitle: string; transcriptContent: string }> {
-  const googleAuth = await getTranscriptsGoogleAuth(auth);
+  const googleAuth = await getTranscriptsGoogleAuth(
+    auth,
+    transcriptsConfiguration.userId
+  );
   const drive = google.drive({ version: "v3", auth: googleAuth });
 
   const metadataRes = await drive.files.get({


### PR DESCRIPTION
## Description

Revamp of transcripts to split per provider removed the `userId` from getTranscriptsGoogleAuth to user auth.user()
But the auth is using `internalBuilderForWorkspace` so is not returning a user.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
