### PR TITLE
Bump webcrawler concurrency to 3 activities (from 1).

### DIFF
--- a/connectors/src/connectors/webcrawler/temporal/worker.ts
+++ b/connectors/src/connectors/webcrawler/temporal/worker.ts
@@ -21,7 +21,7 @@ export async function runWebCrawlerWorker() {
       connection,
       reuseV8Context: true,
       namespace,
-      maxConcurrentActivityTaskExecutions: 1,
+      maxConcurrentActivityTaskExecutions: 3,
       maxCachedWorkflows: TEMPORAL_MAXED_CACHED_WORKFLOWS,
       interceptors: {
         activityInbound: [
@@ -38,7 +38,7 @@ export async function runWebCrawlerWorker() {
       connection,
       reuseV8Context: true,
       namespace,
-      maxConcurrentActivityTaskExecutions: 1,
+      maxConcurrentActivityTaskExecutions: 3,
       maxCachedWorkflows: TEMPORAL_MAXED_CACHED_WORKFLOWS,
       interceptors: {
         activityInbound: [


### PR DESCRIPTION
## Description
Now that webcrawler is running only on [one pod](https://github.com/dust-tt/dust/pull/5247) (vs 3 before), we can bump its activity concurrency back to 3.


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
