### PR TITLE
Fix data source name validation

### DIFF
--- a/front/pages/api/w/[wId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/index.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_QDRANT_CLUSTER,
   dustManagedCredentials,
   EMBEDDING_CONFIG,
+  isDataSourceNameValid,
 } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
 import type { NextApiRequest, NextApiResponse } from "next";
@@ -88,6 +89,17 @@ async function handler(
           api_error: {
             type: "invalid_request_error",
             message: "The data source name cannot start with `managed-`.",
+          },
+        });
+      }
+
+      if (!isDataSourceNameValid(req.body.name)) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              "Data source names must only contain letters, numbers, and the characters `._-`, and cannot be empty.",
           },
         });
       }

--- a/front/pages/w/[wId]/builder/data-sources/new.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/new.tsx
@@ -74,6 +74,7 @@ export default function DataSourceNew({
       valid = false;
     } else if (nameValidRes.isErr()) {
       setDataSourceNameError(nameValidRes.error);
+      valid = false;
     } else {
       edited = true;
       setDataSourceNameError("");

--- a/types/src/front/data_source.ts
+++ b/types/src/front/data_source.ts
@@ -41,7 +41,7 @@ export type DataSourceType = {
 export function isDataSourceNameValid(name: string): Result<void, string> {
   const trimmed = name.trim();
   if (trimmed.length === 0) {
-    return new Err("");
+    return new Err("DataSource name cannot be empty");
   }
   if (name.startsWith("managed-")) {
     return new Err("DataSource name cannot start with the prefix `managed-`");


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/tasks/issues/777

Invalid data source names (like only spaces) could be created due to ill validation in front.

## Risk

None

## Deploy Plan

- deploy `front`