### PR TITLE
[Websearch] Fix: action is returned by agentconfiguration getters

### DIFF
--- a/front/lib/api/assistant/actions/process.ts
+++ b/front/lib/api/assistant/actions/process.ts
@@ -429,7 +429,7 @@ export class ProcessConfigurationServerRunner extends BaseActionConfigurationSer
         conversationId: conversation.sId,
         elapsed: Date.now() - now,
       },
-      "[ASSISTANT_TRACE] Process acion run execution"
+      "[ASSISTANT_TRACE] Finished process action run execution"
     );
 
     yield {

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -357,6 +357,7 @@ async function fetchWorkspaceAgentConfigurationsForView(
     dustAppRunConfigs,
     tablesQueryConfigs,
     processConfigs,
+    websearchConfigs,
     agentUserRelations,
   ] = await Promise.all([
     variant === "full"
@@ -383,6 +384,13 @@ async function fetchWorkspaceAgentConfigurationsForView(
           },
         }).then(groupByAgentConfigurationId)
       : Promise.resolve({} as Record<number, AgentProcessConfiguration[]>),
+    variant === "full"
+      ? AgentWebsearchConfiguration.findAll({
+          where: {
+            agentConfigurationId: { [Op.in]: configurationIds },
+          },
+        }).then(groupByAgentConfigurationId)
+      : Promise.resolve({} as Record<number, AgentWebsearchConfiguration[]>),
     user && configurationIds.length > 0
       ? AgentUserRelation.findAll({
           where: {
@@ -532,6 +540,18 @@ async function fetchWorkspaceAgentConfigurationsForView(
           name: dustAppRunConfig.name,
           description: dustAppRunConfig.description,
           forceUseAtIteration: dustAppRunConfig.forceUseAtIteration,
+        });
+      }
+
+      const websearchConfigurations = websearchConfigs[agent.id] ?? [];
+      for (const websearchConfig of websearchConfigurations) {
+        actions.push({
+          id: websearchConfig.id,
+          sId: websearchConfig.sId,
+          type: "websearch_configuration",
+          name: websearchConfig.name,
+          description: websearchConfig.description,
+          forceUseAtIteration: websearchConfig.forceUseAtIteration,
         });
       }
 

--- a/types/src/front/assistant/actions/websearch.ts
+++ b/types/src/front/assistant/actions/websearch.ts
@@ -21,7 +21,7 @@ export type WebsearchActionOutputType = {
 export interface WebsearchActionType extends BaseAction {
   agentMessageId: ModelId;
   query: string;
-  output: WebsearchActionOutputType;
+  output: WebsearchActionOutputType | null;
   functionCallId: string | null;
   functionCallName: string | null;
   step: number;


### PR DESCRIPTION
Desciption
---
New websearch action (currently gated & not fully implemented) was not returned by agent configuration GET routes

Risk
---
None (gated)

Deploy plan
---
Front
