### PR TITLE
Add support for text-embedding-3-large

### DIFF
--- a/core/src/providers/azure_openai.rs
+++ b/core/src/providers/azure_openai.rs
@@ -599,6 +599,8 @@ impl AzureOpenAIEmbedder {
         match self.model_id.as_ref() {
             Some(model_id) => match model_id.as_str() {
                 "text-embedding-ada-002" => cl100k_base_singleton(),
+                "text-embedding-3-small" => cl100k_base_singleton(),
+                "text-embedding-3-large" => cl100k_base_singleton(),
                 _ => unimplemented!(),
             },
             None => unimplemented!(),
@@ -651,9 +653,11 @@ impl Embedder for AzureOpenAIEmbedder {
         )
         .await?;
 
-        // We ensure at initialize that we only use `text-embedding-ada-002`.
+        // We ensure at initialize that we only use supported models.
         match d.model.as_str() {
-            "text-embedding-ada-002" => {}
+            "text-embedding-ada-002" => (),
+            "text-embedding-3-small" => (),
+            "text-embedding-3-large" => (),
             _ => Err(anyhow!("Unsupported model: {}", d.model))?,
         }
 
@@ -666,6 +670,8 @@ impl Embedder for AzureOpenAIEmbedder {
         match self.model_id.as_ref() {
             Some(model_id) => match model_id.as_str() {
                 "text-embedding-ada-002" => 8191,
+                "text-embedding-3-small" => 8191,
+                "text-embedding-3-large" => 8191,
                 _ => unimplemented!(),
             },
             None => unimplemented!(),
@@ -676,6 +682,8 @@ impl Embedder for AzureOpenAIEmbedder {
         match self.model_id.as_ref() {
             Some(model_id) => match model_id.as_str() {
                 "text-embedding-ada-002" => 1536,
+                "text-embedding-3-small" => 1536,
+                "text-embedding-3-large" => 8191,
                 _ => unimplemented!(),
             },
             None => unimplemented!(),

--- a/core/src/providers/azure_openai.rs
+++ b/core/src/providers/azure_openai.rs
@@ -600,7 +600,7 @@ impl AzureOpenAIEmbedder {
             Some(model_id) => match model_id.as_str() {
                 "text-embedding-ada-002" => cl100k_base_singleton(),
                 "text-embedding-3-small" => cl100k_base_singleton(),
-                "text-embedding-3-large" => cl100k_base_singleton(),
+                "text-embedding-3-large-1536" => cl100k_base_singleton(),
                 _ => unimplemented!(),
             },
             None => unimplemented!(),
@@ -657,7 +657,7 @@ impl Embedder for AzureOpenAIEmbedder {
         match d.model.as_str() {
             "text-embedding-ada-002" => (),
             "text-embedding-3-small" => (),
-            "text-embedding-3-large" => (),
+            "text-embedding-3-large-1536" => (),
             _ => Err(anyhow!("Unsupported model: {}", d.model))?,
         }
 
@@ -671,7 +671,7 @@ impl Embedder for AzureOpenAIEmbedder {
             Some(model_id) => match model_id.as_str() {
                 "text-embedding-ada-002" => 8191,
                 "text-embedding-3-small" => 8191,
-                "text-embedding-3-large" => 8191,
+                "text-embedding-3-large-1536" => 8191,
                 _ => unimplemented!(),
             },
             None => unimplemented!(),
@@ -683,7 +683,7 @@ impl Embedder for AzureOpenAIEmbedder {
             Some(model_id) => match model_id.as_str() {
                 "text-embedding-ada-002" => 1536,
                 "text-embedding-3-small" => 1536,
-                "text-embedding-3-large" => 3072,
+                "text-embedding-3-large-1536" => 1536,
                 _ => unimplemented!(),
             },
             None => unimplemented!(),

--- a/core/src/providers/azure_openai.rs
+++ b/core/src/providers/azure_openai.rs
@@ -683,7 +683,7 @@ impl Embedder for AzureOpenAIEmbedder {
             Some(model_id) => match model_id.as_str() {
                 "text-embedding-ada-002" => 1536,
                 "text-embedding-3-small" => 1536,
-                "text-embedding-3-large" => 8191,
+                "text-embedding-3-large" => 3072,
                 _ => unimplemented!(),
             },
             None => unimplemented!(),

--- a/core/src/providers/embedder.rs
+++ b/core/src/providers/embedder.rs
@@ -166,12 +166,15 @@ impl EmbedderRequest {
 pub enum SupportedEmbedderModels {
     #[clap(name = "text-embedding-ada-002")]
     TextEmbeddingAda002,
+    #[clap(name = "text-embedding-3-large")]
+    TextEmbedding3Large,
 }
 
 impl fmt::Display for SupportedEmbedderModels {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             SupportedEmbedderModels::TextEmbeddingAda002 => write!(f, "text-embedding-ada-002"),
+            SupportedEmbedderModels::TextEmbedding3Large => write!(f, "text-embedding-3-large"),
         }
     }
 }
@@ -182,7 +185,10 @@ pub struct EmbedderProvidersModelMap;
 impl EmbedderProvidersModelMap {
     fn get_models(provider: &ProviderID) -> Result<Vec<SupportedEmbedderModels>> {
         match provider {
-            &ProviderID::OpenAI => Ok(vec![SupportedEmbedderModels::TextEmbeddingAda002]),
+            &ProviderID::OpenAI => Ok(vec![
+                SupportedEmbedderModels::TextEmbeddingAda002,
+                SupportedEmbedderModels::TextEmbedding3Large,
+            ]),
             _ => Err(anyhow!("Provider not supported for embeddings.")),
         }
     }

--- a/core/src/providers/embedder.rs
+++ b/core/src/providers/embedder.rs
@@ -166,15 +166,17 @@ impl EmbedderRequest {
 pub enum SupportedEmbedderModels {
     #[clap(name = "text-embedding-ada-002")]
     TextEmbeddingAda002,
-    #[clap(name = "text-embedding-3-large")]
-    TextEmbedding3Large,
+    #[clap(name = "text-embedding-3-large-1536")]
+    TextEmbedding3Large1536,
 }
 
 impl fmt::Display for SupportedEmbedderModels {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             SupportedEmbedderModels::TextEmbeddingAda002 => write!(f, "text-embedding-ada-002"),
-            SupportedEmbedderModels::TextEmbedding3Large => write!(f, "text-embedding-3-large"),
+            SupportedEmbedderModels::TextEmbedding3Large1536 => {
+                write!(f, "text-embedding-3-large-1536")
+            }
         }
     }
 }
@@ -187,7 +189,7 @@ impl EmbedderProvidersModelMap {
         match provider {
             &ProviderID::OpenAI => Ok(vec![
                 SupportedEmbedderModels::TextEmbeddingAda002,
-                SupportedEmbedderModels::TextEmbedding3Large,
+                SupportedEmbedderModels::TextEmbedding3Large1536,
             ]),
             _ => Err(anyhow!("Provider not supported for embeddings.")),
         }

--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -1874,7 +1874,7 @@ impl Embedder for OpenAIEmbedder {
         match self.id.as_str() {
             "text-embedding-ada-002" => 1536,
             "text-embedding-3-small" => 1536,
-            "text-embedding-3-large" => 8191,
+            "text-embedding-3-large" => 3072,
             _ => unimplemented!(),
         }
     }

--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -1302,15 +1302,6 @@ pub async fn embed(
         body["model"] = json!(model_id);
     }
 
-    // let mut req_builder = Request::builder()
-    //     .method(Method::POST)
-    //     .uri(uri)
-    //     .header("Content-Type", "application/json")
-    //     // This one is for `openai`.
-    //     .header("Authorization", format!("Bearer {}", api_key.clone()))
-    //     // This one is for `azure_openai`.
-    //     .header("api-key", api_key.clone());
-
     let mut req = reqwest::Client::new()
         .post(uri.to_string())
         .header("Content-Type", "application/json")
@@ -1827,6 +1818,8 @@ impl OpenAIEmbedder {
     fn tokenizer(&self) -> Arc<RwLock<CoreBPE>> {
         match self.id.as_str() {
             "text-embedding-ada-002" => cl100k_base_singleton(),
+            "text-embedding-3-small" => cl100k_base_singleton(),
+            "text-embedding-3-large" => cl100k_base_singleton(),
             _ => r50k_base_singleton(),
         }
     }
@@ -1839,10 +1832,15 @@ impl Embedder for OpenAIEmbedder {
     }
 
     async fn initialize(&mut self, credentials: Credentials) -> Result<()> {
-        if !(vec!["text-embedding-ada-002"].contains(&self.id.as_str())) {
+        if !(vec![
+            "text-embedding-ada-002",
+            "text-embedding-3-small",
+            "text-embedding-3-large",
+        ]
+        .contains(&self.id.as_str()))
+        {
             return Err(anyhow!(
-                "Unexpected embedder model id (`{}`) for provider `openai`, \
-                  expected: `text-embedding-ada-002`",
+                "Unexpected embedder model id (`{}`) for provider `openai`",
                 self.id
             ));
         }
@@ -1866,6 +1864,8 @@ impl Embedder for OpenAIEmbedder {
     fn context_size(&self) -> usize {
         match self.id.as_str() {
             "text-embedding-ada-002" => 8191,
+            "text-embedding-3-small" => 8191,
+            "text-embedding-3-large" => 8191,
             _ => unimplemented!(),
         }
     }
@@ -1873,6 +1873,8 @@ impl Embedder for OpenAIEmbedder {
     fn embedding_size(&self) -> usize {
         match self.id.as_str() {
             "text-embedding-ada-002" => 1536,
+            "text-embedding-3-small" => 1536,
+            "text-embedding-3-large" => 8191,
             _ => unimplemented!(),
         }
     }

--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -1298,8 +1298,17 @@ pub async fn embed(
     if user.is_some() {
         body["user"] = json!(user);
     }
-    if model_id.is_some() {
-        body["model"] = json!(model_id);
+    match model_id {
+        Some(model_id) => {
+            body["model"] = json!(model_id);
+            match model_id.as_str() {
+                "text-embedding-3-large-1536" => {
+                    body["dimensions"] = json!(1536);
+                }
+                _ => (),
+            }
+        }
+        None => (),
     }
 
     let mut req = reqwest::Client::new()
@@ -1819,7 +1828,7 @@ impl OpenAIEmbedder {
         match self.id.as_str() {
             "text-embedding-ada-002" => cl100k_base_singleton(),
             "text-embedding-3-small" => cl100k_base_singleton(),
-            "text-embedding-3-large" => cl100k_base_singleton(),
+            "text-embedding-3-large-1536" => cl100k_base_singleton(),
             _ => r50k_base_singleton(),
         }
     }
@@ -1835,7 +1844,7 @@ impl Embedder for OpenAIEmbedder {
         if !(vec![
             "text-embedding-ada-002",
             "text-embedding-3-small",
-            "text-embedding-3-large",
+            "text-embedding-3-large-1536",
         ]
         .contains(&self.id.as_str()))
         {
@@ -1865,7 +1874,7 @@ impl Embedder for OpenAIEmbedder {
         match self.id.as_str() {
             "text-embedding-ada-002" => 8191,
             "text-embedding-3-small" => 8191,
-            "text-embedding-3-large" => 8191,
+            "text-embedding-3-large-1536" => 8191,
             _ => unimplemented!(),
         }
     }
@@ -1874,7 +1883,7 @@ impl Embedder for OpenAIEmbedder {
         match self.id.as_str() {
             "text-embedding-ada-002" => 1536,
             "text-embedding-3-small" => 1536,
-            "text-embedding-3-large" => 3072,
+            "text-embedding-3-large-1536" => 1536,
             _ => unimplemented!(),
         }
     }


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/dust/issues/5181

Adds support for new OpenAI models:
```
text-embedding-3-small
text-embedding-3-large
```

In particular `text-embedding-3-large` for Qdrant collection creation.

An important question to consider is whether we want to use the full vector (3072 vs 1536 (2x)) or use these models new capabilities to truncate vectors. We could use as an example `text-embedding-3-large` truncated to 1536 which should give us some good benefit without increasing memory footprint.

https://openai.com/index/new-embedding-models-and-api-updates/

cc @flvndvd 

Created https://github.com/dust-tt/dust/issues/5271 to decide / implement

## Risk

None

## Deploy Plan

- deploy `core`