### PR TITLE
Get rid of isProPlanCode 2/2

### DIFF
--- a/front/components/members/InvitationModal.tsx
+++ b/front/components/members/InvitationModal.tsx
@@ -12,6 +12,7 @@ import type {
   ActiveRoleType,
   MembershipInvitationType,
   RoleType,
+  SubscriptionPerSeatPricing,
   UserTypeWithWorkspaces,
   WorkspaceType,
 } from "@dust-tt/types";
@@ -25,10 +26,7 @@ import { RoleDropDown } from "@app/components/members/RolesDropDown";
 import type { NotificationType } from "@app/components/sparkle/Notification";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { handleMembersRoleChange } from "@app/lib/client/members";
-import {
-  getPriceWithCurrency,
-  PRO_PLAN_29_COST,
-} from "@app/lib/client/subscription";
+import { getPriceAsString } from "@app/lib/client/subscription";
 import { MAX_UNCONSUMED_INVITATIONS_PER_WORKSPACE_PER_DAY } from "@app/lib/invitations";
 import { isEmailValid } from "@app/lib/utils";
 import type {
@@ -42,14 +40,14 @@ export function InviteEmailModal({
   owner,
   prefillText,
   members,
-  isOnProPlan,
+  perSeatPricing,
 }: {
   showModal: boolean;
   onClose: () => void;
   owner: WorkspaceType;
   prefillText: string;
   members: UserTypeWithWorkspaces[];
-  isOnProPlan: boolean;
+  perSeatPricing: SubscriptionPerSeatPricing | null;
 }) {
   const [inviteEmails, setInviteEmails] = useState<string>("");
   const [isSending, setIsSending] = useState(false);
@@ -255,9 +253,9 @@ export function InviteEmailModal({
               {ROLES_DATA[invitationRole]["description"]}
             </div>
           </div>
-          {isOnProPlan && (
+          {perSeatPricing !== null && (
             <div className="justify-self-end">
-              <ProPlanBillingNotice />
+              <ProPlanBillingNotice perSeatPricing={perSeatPricing} />
             </div>
           )}
         </div>
@@ -360,13 +358,21 @@ export function EditInvitationModal({
   );
 }
 
-function ProPlanBillingNotice() {
+function ProPlanBillingNotice({
+  perSeatPricing,
+}: {
+  perSeatPricing: SubscriptionPerSeatPricing;
+}) {
   return (
     <ContentMessage size="md" variant="amber" title="Note">
       <p>
         New users will be charged a{" "}
         <span className="font-semibold">
-          monthly fee of {getPriceWithCurrency(PRO_PLAN_29_COST)}
+          {perSeatPricing.billingPeriod} fee of{" "}
+          {getPriceAsString({
+            currency: perSeatPricing.seatCurrency,
+            priceInCents: perSeatPricing.seatPrice,
+          })}
         </span>
         .{" "}
       </p>

--- a/front/components/members/InvitationModal.tsx
+++ b/front/components/members/InvitationModal.tsx
@@ -11,7 +11,6 @@ import {
 import type {
   ActiveRoleType,
   MembershipInvitationType,
-  PlanType,
   RoleType,
   UserTypeWithWorkspaces,
   WorkspaceType,
@@ -31,7 +30,6 @@ import {
   PRO_PLAN_29_COST,
 } from "@app/lib/client/subscription";
 import { MAX_UNCONSUMED_INVITATIONS_PER_WORKSPACE_PER_DAY } from "@app/lib/invitations";
-import { isProPlanCode } from "@app/lib/plans/plan_codes";
 import { isEmailValid } from "@app/lib/utils";
 import type {
   PostInvitationRequestBody,
@@ -42,16 +40,16 @@ export function InviteEmailModal({
   showModal,
   onClose,
   owner,
-  plan,
   prefillText,
   members,
+  isOnProPlan,
 }: {
   showModal: boolean;
   onClose: () => void;
   owner: WorkspaceType;
-  plan: PlanType;
   prefillText: string;
   members: UserTypeWithWorkspaces[];
+  isOnProPlan: boolean;
 }) {
   const [inviteEmails, setInviteEmails] = useState<string>("");
   const [isSending, setIsSending] = useState(false);
@@ -257,7 +255,7 @@ export function InviteEmailModal({
               {ROLES_DATA[invitationRole]["description"]}
             </div>
           </div>
-          {isProPlanCode(plan.code) && (
+          {isOnProPlan && (
             <div className="justify-self-end">
               <ProPlanBillingNotice />
             </div>

--- a/front/components/poke/subscriptions/table.tsx
+++ b/front/components/poke/subscriptions/table.tsx
@@ -29,7 +29,7 @@ import { makeColumnsForSubscriptions } from "@app/components/poke/subscriptions/
 import EnterpriseUpgradeDialog from "@app/components/poke/subscriptions/EnterpriseUpgradeDialog";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { isDevelopment } from "@app/lib/development";
-import { FREE_NO_PLAN_CODE, isProPlanCode } from "@app/lib/plans/plan_codes";
+import { FREE_NO_PLAN_CODE } from "@app/lib/plans/plan_codes";
 import { usePokePlans } from "@app/lib/swr";
 
 interface SubscriptionsDataTableProps {
@@ -407,7 +407,7 @@ function UpgradeDowngradeModal({
             owner={owner}
           />
         </div>
-        {isProPlanCode(subscription.plan.code) && (
+        {subscription.plan.code.startsWith("PRO_") && (
           <>
             <Page.SectionHeader
               title="Change the Pro Plan of this workspace"
@@ -415,7 +415,7 @@ function UpgradeDowngradeModal({
             />
             <div>
               {plans
-                .filter((p) => isProPlanCode(p.code))
+                .filter((p) => p.code.startsWith("PRO_"))
                 .map((p) => {
                   return (
                     <div key={p.code} className="pt-2">

--- a/front/lib/client/subscription.ts
+++ b/front/lib/client/subscription.ts
@@ -9,3 +9,21 @@ export const getPriceWithCurrency = (price: number): string => {
   const isLikelyInUS = timeZone.startsWith("America");
   return isLikelyInUS ? `$${price}` : `${price}€`;
 };
+
+export const getPriceAsString = ({
+  currency,
+  priceInCents,
+}: {
+  currency: string;
+  priceInCents: number;
+}): string => {
+  const price = (priceInCents / 100).toFixed(2);
+  switch (currency) {
+    case "usd":
+      return `$${price}`;
+    case "eur":
+      return `${price}€`;
+    default:
+      return `${price}${currency}`;
+  }
+};

--- a/front/lib/plans/plan_codes.ts
+++ b/front/lib/plans/plan_codes.ts
@@ -10,14 +10,6 @@ export const TRIAL_PLAN_CODE = "TRIAL_PLAN_CODE";
 export const PRO_PLAN_SEAT_29_CODE = "PRO_PLAN_SEAT_29";
 export const PRO_PLAN_LARGE_FILES_CODE = "PRO_PLAN_LARGE_FILES";
 
-export const PRO_PLANS_CODES = [
-  PRO_PLAN_SEAT_29_CODE,
-  PRO_PLAN_LARGE_FILES_CODE,
-];
-export const isProPlanCode = (code: string): boolean => {
-  return PRO_PLANS_CODES.includes(code);
-};
-
 /**
  * ENT_PLAN_FAKE is not subscribable and is only used to display the Enterprise plan in the UI (hence it's not stored on the db).
  */

--- a/front/lib/plans/subscription.ts
+++ b/front/lib/plans/subscription.ts
@@ -436,7 +436,7 @@ export async function isSubscriptionOnProPlan(
   return isStripeSubscriptionOnProPlan(stripeSubscription);
 }
 
-export async function getSubscriptionPricingIfPerSeatOrNull(
+export async function getPerSeatSubscriptionPricing(
   subscription: SubscriptionType
 ): Promise<{
   seatPrice: number;
@@ -465,21 +465,21 @@ export async function getSubscriptionPricingIfPerSeatOrNull(
     return null;
   }
 
-  const { unit_amount, currency, recurring } = item.price;
+  const { unit_amount: unitAmount, currency, recurring } = item.price;
 
-  const isPricedPerSeat = unit_amount !== null;
+  const isPricedPerSeat = unitAmount !== null;
   if (!isPricedPerSeat) {
     return null;
   }
 
-  if (!item.quantity) {
+  if (!item.quantity || !recurring) {
     return null;
   }
 
   return {
-    seatPrice: unit_amount,
+    seatPrice: unitAmount,
     seatCurrency: currency,
-    billingPeriod: recurring?.interval === "year" ? "yearly" : "monthly",
+    billingPeriod: recurring.interval === "year" ? "yearly" : "monthly",
     quantity: item.quantity,
   };
 }

--- a/front/lib/plans/subscription.ts
+++ b/front/lib/plans/subscription.ts
@@ -436,6 +436,54 @@ export async function isSubscriptionOnProPlan(
   return isStripeSubscriptionOnProPlan(stripeSubscription);
 }
 
+export async function getSubscriptionPricingIfPerSeatOrNull(
+  subscription: SubscriptionType
+): Promise<{
+  seatPrice: number;
+  seatCurrency: string;
+  billingPeriod: "monthly" | "yearly";
+  quantity: number;
+} | null> {
+  if (!subscription.stripeSubscriptionId) {
+    return null;
+  }
+
+  const stripeSubscription = await getStripeSubscription(
+    subscription.stripeSubscriptionId
+  );
+  if (!stripeSubscription) {
+    return null;
+  }
+
+  const { items } = stripeSubscription;
+  if (!items) {
+    return null;
+  }
+
+  const [item] = items.data;
+  if (!item || !item.price) {
+    return null;
+  }
+
+  const { unit_amount, currency, recurring } = item.price;
+
+  const isPricedPerSeat = unit_amount !== null;
+  if (!isPricedPerSeat) {
+    return null;
+  }
+
+  if (!item.quantity) {
+    return null;
+  }
+
+  return {
+    seatPrice: unit_amount,
+    seatCurrency: currency,
+    billingPeriod: recurring?.interval === "year" ? "yearly" : "monthly",
+    quantity: item.quantity,
+  };
+}
+
 /**
  * Proactively cancel inactive trials.
  */

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -48,7 +48,7 @@ import {
 import { handleMembersRoleChange } from "@app/lib/client/members";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { isUpgraded } from "@app/lib/plans/plan_codes";
-import { getSubscriptionPricingIfPerSeatOrNull } from "@app/lib/plans/subscription";
+import { getPerSeatSubscriptionPricing } from "@app/lib/plans/subscription";
 import { useMembers } from "@app/lib/swr";
 
 const { GA_TRACKING_ID = "" } = process.env;
@@ -86,9 +86,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       strategy: "okta",
     };
 
-  const perSeatPricing = await getSubscriptionPricingIfPerSeatOrNull(
-    subscription
-  );
+  const perSeatPricing = await getPerSeatSubscriptionPricing(subscription);
 
   return {
     props: {

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -44,6 +44,7 @@ import {
 import { handleMembersRoleChange } from "@app/lib/client/members";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { isUpgraded } from "@app/lib/plans/plan_codes";
+import { isSubscriptionOnProPlan } from "@app/lib/plans/subscription";
 import { useMembers } from "@app/lib/swr";
 
 const { GA_TRACKING_ID = "" } = process.env;
@@ -52,6 +53,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   user: UserType;
   owner: WorkspaceType;
   subscription: SubscriptionType;
+  isOnProPlan: boolean;
   enterpriseConnectionStrategyDetails: EnterpriseConnectionStrategyDetails;
   plan: PlanType;
   gaTrackingId: string;
@@ -80,11 +82,14 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       strategy: "okta",
     };
 
+  const isOnProPlan = await isSubscriptionOnProPlan(subscription);
+
   return {
     props: {
       user,
       owner,
       subscription,
+      isOnProPlan,
       enterpriseConnectionStrategyDetails,
       plan,
       gaTrackingId: GA_TRACKING_ID,
@@ -98,6 +103,7 @@ export default function WorkspaceAdmin({
   user,
   owner,
   subscription,
+  isOnProPlan,
   enterpriseConnectionStrategyDetails,
   plan,
   gaTrackingId,
@@ -192,12 +198,12 @@ export default function WorkspaceAdmin({
           plan={plan}
           strategyDetails={enterpriseConnectionStrategyDetails}
         />
-        <MemberList />
+        <MemberList isOnProPlan={isOnProPlan} />
       </Page.Vertical>
     </AppLayout>
   );
 
-  function MemberList() {
+  function MemberList({ isOnProPlan }: { isOnProPlan: boolean }) {
     const [inviteBlockedPopupReason, setInviteBlockedPopupReason] =
       useState<WorkspaceLimit | null>(null);
 
@@ -234,7 +240,7 @@ export default function WorkspaceAdmin({
           owner={owner}
           prefillText={searchText}
           members={members}
-          plan={plan}
+          isOnProPlan={isOnProPlan}
         />
         <ChangeMemberModal
           owner={owner}

--- a/front/pages/w/[wId]/subscription/index.tsx
+++ b/front/pages/w/[wId]/subscription/index.tsx
@@ -35,7 +35,7 @@ import {
   isUpgraded,
 } from "@app/lib/plans/plan_codes";
 import { getStripeSubscription } from "@app/lib/plans/stripe";
-import { getSubscriptionPricingIfPerSeatOrNull } from "@app/lib/plans/subscription";
+import { getPerSeatSubscriptionPricing } from "@app/lib/plans/subscription";
 import { countActiveSeatsInWorkspace } from "@app/lib/plans/usage/seats";
 import type { PatchSubscriptionRequestBody } from "@app/pages/api/w/[wId]/subscriptions";
 
@@ -79,9 +79,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   }
 
   const workspaceSeats = await countActiveSeatsInWorkspace(owner.sId);
-  const perSeatPricing = await getSubscriptionPricingIfPerSeatOrNull(
-    subscription
-  );
+  const perSeatPricing = await getPerSeatSubscriptionPricing(subscription);
 
   return {
     props: {

--- a/front/pages/w/[wId]/subscription/index.tsx
+++ b/front/pages/w/[wId]/subscription/index.tsx
@@ -9,7 +9,11 @@ import {
   ShapesIcon,
   Spinner,
 } from "@dust-tt/sparkle";
-import type { UserType, WorkspaceType } from "@dust-tt/types";
+import type {
+  SubscriptionPerSeatPricing,
+  UserType,
+  WorkspaceType,
+} from "@dust-tt/types";
 import type { SubscriptionType } from "@dust-tt/types";
 import type * as t from "io-ts";
 import type { InferGetServerSidePropsType } from "next";
@@ -22,10 +26,7 @@ import AppLayout from "@app/components/sparkle/AppLayout";
 import { subNavigationAdmin } from "@app/components/sparkle/navigation";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { SubscriptionContactUsDrawer } from "@app/components/SubscriptionContactUsDrawer";
-import {
-  getPriceWithCurrency,
-  PRO_PLAN_29_COST,
-} from "@app/lib/client/subscription";
+import { getPriceAsString } from "@app/lib/client/subscription";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import {
@@ -34,7 +35,7 @@ import {
   isUpgraded,
 } from "@app/lib/plans/plan_codes";
 import { getStripeSubscription } from "@app/lib/plans/stripe";
-import { isSubscriptionOnProPlan } from "@app/lib/plans/subscription";
+import { getSubscriptionPricingIfPerSeatOrNull } from "@app/lib/plans/subscription";
 import { countActiveSeatsInWorkspace } from "@app/lib/plans/usage/seats";
 import type { PatchSubscriptionRequestBody } from "@app/pages/api/w/[wId]/subscriptions";
 
@@ -47,8 +48,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   trialDaysRemaining: number | null;
   gaTrackingId: string;
   workspaceSeats: number;
-  isOnProPlan: boolean;
-  estimatedMonthlyBilling: number;
+  perSeatPricing: SubscriptionPerSeatPricing | null;
 }>(async (context, auth) => {
   const owner = auth.workspace();
   const subscription = auth.subscription();
@@ -78,9 +78,10 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       : null;
   }
 
-  const isOnProPlan = await isSubscriptionOnProPlan(subscription);
   const workspaceSeats = await countActiveSeatsInWorkspace(owner.sId);
-  const estimatedMonthlyBilling = PRO_PLAN_29_COST * workspaceSeats;
+  const perSeatPricing = await getSubscriptionPricingIfPerSeatOrNull(
+    subscription
+  );
 
   return {
     props: {
@@ -90,8 +91,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       gaTrackingId: GA_TRACKING_ID,
       user,
       workspaceSeats,
-      isOnProPlan,
-      estimatedMonthlyBilling,
+      perSeatPricing,
     },
   };
 });
@@ -103,8 +103,7 @@ export default function Subscription({
   trialDaysRemaining,
   gaTrackingId,
   workspaceSeats,
-  estimatedMonthlyBilling,
-  isOnProPlan,
+  perSeatPricing,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const router = useRouter();
   const sendNotification = useContext(SendNotificationsContext);
@@ -287,24 +286,29 @@ export default function Subscription({
       topNavigationCurrent="admin"
       subNavigation={subNavigationAdmin({ owner, current: "subscription" })}
     >
-      <CancelFreeTrialDialog
-        show={showCancelFreeTrialDialog}
-        onClose={() => setShowCancelFreeTrialDialog(false)}
-        onValidate={cancelFreeTrial}
-        isSaving={cancelFreeTrialSubmitting}
-      />
+      {perSeatPricing && (
+        <>
+          <CancelFreeTrialDialog
+            show={showCancelFreeTrialDialog}
+            onClose={() => setShowCancelFreeTrialDialog(false)}
+            onValidate={cancelFreeTrial}
+            isSaving={cancelFreeTrialSubmitting}
+          />
 
-      <SkipFreeTrialDialog
-        plan={subscription.plan}
-        show={showSkipFreeTrialDialog}
-        onClose={() => {
-          setShowSkipFreeTrialDialog(false);
-        }}
-        onValidate={skipFreeTrial}
-        workspaceSeats={workspaceSeats}
-        estimatedMonthlyBilling={estimatedMonthlyBilling}
-        isSaving={skipFreeTrialIsSubmitting}
-      />
+          <SkipFreeTrialDialog
+            plan={subscription.plan}
+            show={showSkipFreeTrialDialog}
+            onClose={() => {
+              setShowSkipFreeTrialDialog(false);
+            }}
+            onValidate={skipFreeTrial}
+            workspaceSeats={workspaceSeats}
+            perSeatPricing={perSeatPricing}
+            isSaving={skipFreeTrialIsSubmitting}
+          />
+        </>
+      )}
+
       <SubscriptionContactUsDrawer
         show={showContactUsDrawer}
         onClose={() => {
@@ -351,7 +355,7 @@ export default function Subscription({
               </>
             )}
           </div>
-          {subscription.trialing && (
+          {perSeatPricing && subscription.trialing && (
             <Page.Vertical>
               <Page.Horizontal gap="sm">
                 <Button
@@ -370,12 +374,15 @@ export default function Subscription({
           {subscription.stripeSubscriptionId && (
             <Page.Vertical gap="sm">
               <Page.H variant="h5">Billing</Page.H>
-              {isOnProPlan && (
+              {perSeatPricing !== null && (
                 <>
                   <Page.P>
-                    Estimated monthly billing:{" "}
+                    Estimated {perSeatPricing.billingPeriod} billing:{" "}
                     <span className="font-bold">
-                      {getPriceWithCurrency(estimatedMonthlyBilling)}
+                      {getPriceAsString({
+                        currency: perSeatPricing.seatCurrency,
+                        priceInCents: perSeatPricing.seatPrice * workspaceSeats,
+                      })}
                     </span>{" "}
                     (excluding taxes).
                   </Page.P>
@@ -383,12 +390,20 @@ export default function Subscription({
                     {workspaceSeats === 1 ? (
                       <>
                         {workspaceSeats} member,{" "}
-                        {getPriceWithCurrency(PRO_PLAN_29_COST)} per member.
+                        {getPriceAsString({
+                          currency: perSeatPricing.seatCurrency,
+                          priceInCents: perSeatPricing.seatPrice,
+                        })}
+                        per member.
                       </>
                     ) : (
                       <>
                         {workspaceSeats} members,{" "}
-                        {getPriceWithCurrency(PRO_PLAN_29_COST)} per member.
+                        {getPriceAsString({
+                          currency: perSeatPricing.seatCurrency,
+                          priceInCents: perSeatPricing.seatPrice,
+                        })}{" "}
+                        per member.
                       </>
                     )}
                   </Page.P>
@@ -451,7 +466,7 @@ function SkipFreeTrialDialog({
   onClose,
   onValidate,
   workspaceSeats,
-  estimatedMonthlyBilling,
+  perSeatPricing,
   isSaving,
   plan,
 }: {
@@ -459,7 +474,7 @@ function SkipFreeTrialDialog({
   onClose: () => void;
   onValidate: () => void;
   workspaceSeats: number;
-  estimatedMonthlyBilling: number;
+  perSeatPricing: SubscriptionPerSeatPricing;
   isSaving: boolean;
   plan: SubscriptionType["plan"];
 }) {
@@ -487,7 +502,10 @@ function SkipFreeTrialDialog({
                 <>
                   Billing will start immediately for your workspace. <br />
                   Currently: {workspaceSeats} member,{" "}
-                  {getPriceWithCurrency(estimatedMonthlyBilling)}
+                  {getPriceAsString({
+                    currency: perSeatPricing.seatCurrency,
+                    priceInCents: perSeatPricing.seatPrice,
+                  })}
                   monthly (excluding taxes).
                 </>
               );
@@ -497,7 +515,10 @@ function SkipFreeTrialDialog({
                 Billing will start immediately for your workspace:.
                 <br />
                 Currently: {workspaceSeats} members,{" "}
-                {getPriceWithCurrency(estimatedMonthlyBilling)}
+                {getPriceAsString({
+                  currency: perSeatPricing.seatCurrency,
+                  priceInCents: perSeatPricing.seatPrice,
+                })}
                 monthly (excluding taxes).
               </>
             );

--- a/types/src/front/plan.ts
+++ b/types/src/front/plan.ts
@@ -73,6 +73,13 @@ export type SubscriptionType = {
   requestCancelAt: number | null;
 };
 
+export type SubscriptionPerSeatPricing = {
+  seatPrice: number;
+  seatCurrency: string;
+  billingPeriod: "monthly" | "yearly";
+  quantity: number;
+};
+
 export const CreatePlanFormSchema = t.type({
   code: NonEmptyString,
   name: NonEmptyString,


### PR DESCRIPTION
## Description

We want to get rid of our function `isProPlanCode`: 

```
export const PRO_PLANS_CODES = [
  PRO_PLAN_SEAT_29_CODE,
  PRO_PLAN_LARGE_FILES_CODE,
];
export const isProPlanCode = (code: string): boolean => {
  return PRO_PLANS_CODES.includes(code);
};
```

Part 1 was here: https://github.com/dust-tt/dust/pull/5266

## Risk

Breaks the display of estimated cost on the subscription page. 
Can be rolled back. 

## Deploy Plan

Deploy front. 
