### PR TITLE
[front] - fix: member detail view

### DIFF
--- a/front/components/members/InvitationModal.tsx
+++ b/front/components/members/InvitationModal.tsx
@@ -505,7 +505,7 @@ async function updateInvitation({
     : "Invitation revoked";
   sendNotification({
     type: "success",
-    title: `${newRole ? `Role updated` : "Invitation Revoked"}`,
+    title: `${newRole ? "Role updated" : "Invitation Revoked"}`,
     description: `${successMessage} for ${invitation.inviteEmail}.`,
   });
   await mutate(`/api/w/${owner.sId}/invitations`);

--- a/front/components/members/InvitationModal.tsx
+++ b/front/components/members/InvitationModal.tsx
@@ -500,7 +500,9 @@ async function updateInvitation({
     return;
   }
 
-  const successMessage = newRole ? `Invitation updated to ${newRole}` : "Invitation revoked";
+  const successMessage = newRole
+    ? `Invitation updated to ${newRole}`
+    : "Invitation revoked";
   sendNotification({
     type: "success",
     title: `${newRole ? `Role updated` : "Invitation Revoked"}`,

--- a/front/components/members/InvitationModal.tsx
+++ b/front/components/members/InvitationModal.tsx
@@ -17,7 +17,6 @@ import type {
   WorkspaceType,
 } from "@dust-tt/types";
 import { useContext, useState } from "react";
-import type { KeyedMutator } from "swr";
 import { mutate } from "swr";
 
 import type { ConfirmDataType } from "@app/components/Confirm";
@@ -35,7 +34,6 @@ import { MAX_UNCONSUMED_INVITATIONS_PER_WORKSPACE_PER_DAY } from "@app/lib/invit
 import { isProPlanCode } from "@app/lib/plans/plan_codes";
 import { isEmailValid } from "@app/lib/utils";
 import type {
-  GetWorkspaceInvitationsResponseBody,
   PostInvitationRequestBody,
   PostInvitationResponseBody,
 } from "@app/pages/api/w/[wId]/invitations";
@@ -261,12 +259,10 @@ export function EditInvitationModal({
   owner,
   invitation,
   onClose,
-  mutateInvitations,
 }: {
   owner: WorkspaceType;
   invitation: MembershipInvitationType;
   onClose: () => void;
-  mutateInvitations: KeyedMutator<GetWorkspaceInvitationsResponseBody>;
 }) {
   const [selectedRole, setSelectedRole] = useState<ActiveRoleType>(
     invitation.initialRole
@@ -289,7 +285,6 @@ export function EditInvitationModal({
           owner,
           invitation,
           newRole: selectedRole,
-          mutateInvitations,
           sendNotification,
           confirm,
         });
@@ -342,7 +337,6 @@ export function EditInvitationModal({
                 await updateInvitation({
                   invitation,
                   owner,
-                  mutateInvitations,
                   sendNotification,
                   confirm,
                 });
@@ -451,14 +445,12 @@ async function updateInvitation({
   owner,
   invitation,
   newRole,
-  mutateInvitations,
   sendNotification,
   confirm,
 }: {
   owner: WorkspaceType;
   invitation: MembershipInvitationType;
   newRole?: RoleType; // Optional parameter for role change
-  mutateInvitations: KeyedMutator<GetWorkspaceInvitationsResponseBody>;
   sendNotification: (notificationData: NotificationType) => void;
   confirm?: (confirmData: ConfirmDataType) => Promise<boolean>;
 }) {
@@ -508,5 +500,5 @@ async function updateInvitation({
     title: `${newRole ? "Role updated" : "Invitation Revoked"}`,
     description: `${successMessage} for ${invitation.inviteEmail}.`,
   });
-  await mutateInvitations();
+  await mutate(`/api/w/${owner.sId}/invitations`);
 }

--- a/front/components/members/InvitationModal.tsx
+++ b/front/components/members/InvitationModal.tsx
@@ -18,6 +18,7 @@ import type {
 } from "@dust-tt/types";
 import { useContext, useState } from "react";
 import type { KeyedMutator } from "swr";
+import { mutate } from "swr";
 
 import type { ConfirmDataType } from "@app/components/Confirm";
 import { ConfirmContext } from "@app/components/Confirm";
@@ -32,7 +33,6 @@ import {
 } from "@app/lib/client/subscription";
 import { MAX_UNCONSUMED_INVITATIONS_PER_WORKSPACE_PER_DAY } from "@app/lib/invitations";
 import { isProPlanCode } from "@app/lib/plans/plan_codes";
-import { useMembers } from "@app/lib/swr";
 import { isEmailValid } from "@app/lib/utils";
 import type {
   GetWorkspaceInvitationsResponseBody,
@@ -185,9 +185,9 @@ export function InviteEmailModal({
           role: invitationRole,
           sendNotification,
         });
+        await mutate(`/api/w/${owner.sId}/members`);
       }
-      const { mutateMembers } = useMembers(owner);
-      await mutateMembers();
+      await mutate(`/api/w/${owner.sId}/invitations`);
       onClose();
     }
   }
@@ -339,7 +339,6 @@ export function EditInvitationModal({
               label="Revoke invitation"
               icon={XMarkIcon}
               onClick={async () => {
-                console.log(mutateInvitations);
                 await updateInvitation({
                   invitation,
                   owner,

--- a/front/components/members/InvitationModal.tsx
+++ b/front/components/members/InvitationModal.tsx
@@ -282,9 +282,6 @@ export function EditInvitationModal({
       hasChanged={selectedRole !== invitation.initialRole}
       variant="side-sm"
       onSave={async (closeModalFn) => {
-        if (!selectedRole) {
-          return;
-        }
         await updateInvitation({
           owner,
           invitation,

--- a/front/components/members/InvitationModal.tsx
+++ b/front/components/members/InvitationModal.tsx
@@ -500,10 +500,10 @@ async function updateInvitation({
     return;
   }
 
-  const successMessage = newRole ? "Invitation updated" : "Invitation revoked";
+  const successMessage = newRole ? `Invitation updated to ${newRole}` : "Invitation revoked";
   sendNotification({
     type: "success",
-    title: `${newRole ? "Role Updated" : "Invitation Revoked"}`,
+    title: `${newRole ? `Role updated` : "Invitation Revoked"}`,
     description: `${successMessage} for ${invitation.inviteEmail}.`,
   });
   await mutate(`/api/w/${owner.sId}/invitations`);

--- a/front/components/members/InvitationsList.tsx
+++ b/front/components/members/InvitationsList.tsx
@@ -14,11 +14,8 @@ export function InvitationsList({
   searchText?: string;
 }) {
   const { invitations, isInvitationsLoading } = useWorkspaceInvitations(owner);
-
-  const [inviteEditionModalOpen, setInviteEditionModalOpen] = useState(false);
-  const [invitation, setInvitation] = useState<MembershipInvitationType | null>(
-    null
-  );
+  const [selectedInvite, setSelectedInvite] =
+    useState<MembershipInvitationType | null>(null);
 
   const filteredInvitations = invitations
     .sort((a, b) => a.inviteEmail.localeCompare(b.inviteEmail))
@@ -30,51 +27,42 @@ export function InvitationsList({
     );
   return (
     <>
-      {invitation && (
+      {selectedInvite && (
         <EditInvitationModal
+          invitation={selectedInvite}
           owner={owner}
-          invitation={invitation}
-          isOpen={inviteEditionModalOpen}
-          setOpen={setInviteEditionModalOpen}
+          onClose={() => setSelectedInvite(null)}
         />
       )}
       <div className="s-w-full">
-        {filteredInvitations.map((invitation: MembershipInvitationType) => {
-          return (
-            <div
-              key={`invitation-${invitation.id}`}
-              className="transition-color flex cursor-pointer items-center justify-center gap-3 border-t border-structure-200 p-2 text-xs duration-200 hover:bg-action-50 sm:text-sm"
-              onClick={() => {
-                setInviteEditionModalOpen(true);
-                setInvitation(invitation);
-              }}
-            >
-              <div className="hidden sm:block">
-                <Avatar size="sm" className={invitation.sId} />
+        {filteredInvitations.map((invitation: MembershipInvitationType) => (
+          <div
+            key={`invitation-${invitation.id}`}
+            className="transition-color flex cursor-pointer items-center justify-center gap-3 border-t border-structure-200 p-2 text-xs duration-200 hover:bg-action-50 sm:text-sm"
+            onClick={() => setSelectedInvite(invitation)}
+          >
+            <div className="hidden sm:block">
+              <Avatar size="sm" className={invitation.sId} />
+            </div>
+            <div className="flex grow flex-col gap-1 sm:flex-row sm:gap-3">
+              <div className="grow font-normal text-element-700">
+                {invitation.inviteEmail}
               </div>
-              <div className="flex grow flex-col gap-1 sm:flex-row sm:gap-3">
-                <div className="grow font-normal text-element-700">
-                  {invitation.inviteEmail}
-                </div>
-                <div>
-                  <Chip
-                    size="xs"
-                    color={ROLES_DATA[invitation.initialRole]["color"]}
-                    className="capitalize"
-                  >
-                    {displayRole(invitation.initialRole)}
-                  </Chip>
-                </div>
-                <div className="hidden sm:block">
-                  <Icon
-                    visual={ChevronRightIcon}
-                    className="text-element-600"
-                  />
-                </div>
+              <div>
+                <Chip
+                  size="xs"
+                  color={ROLES_DATA[invitation.initialRole]["color"]}
+                  className="capitalize"
+                >
+                  {displayRole(invitation.initialRole)}
+                </Chip>
+              </div>
+              <div className="hidden sm:block">
+                <Icon visual={ChevronRightIcon} className="text-element-600" />
               </div>
             </div>
-          );
-        })}
+          </div>
+        ))}
         {isInvitationsLoading && (
           <div className="flex animate-pulse cursor-pointer items-center justify-center gap-3 border-t border-structure-200 bg-structure-50 py-2 text-xs sm:text-sm">
             <div className="hidden sm:block">

--- a/front/components/members/InvitationsList.tsx
+++ b/front/components/members/InvitationsList.tsx
@@ -16,6 +16,7 @@ export function InvitationsList({
   const { invitations, isInvitationsLoading } = useWorkspaceInvitations(owner);
   const [selectedInvite, setSelectedInvite] =
     useState<MembershipInvitationType | null>(null);
+  const { mutateInvitations } = useWorkspaceInvitations(owner);
 
   const filteredInvitations = invitations
     .sort((a, b) => a.inviteEmail.localeCompare(b.inviteEmail))
@@ -31,6 +32,7 @@ export function InvitationsList({
         <EditInvitationModal
           invitation={selectedInvite}
           owner={owner}
+          mutateInvitations={mutateInvitations}
           onClose={() => setSelectedInvite(null)}
         />
       )}

--- a/front/components/members/InvitationsList.tsx
+++ b/front/components/members/InvitationsList.tsx
@@ -14,9 +14,10 @@ export function InvitationsList({
   searchText?: string;
 }) {
   const { invitations, isInvitationsLoading } = useWorkspaceInvitations(owner);
+  const { mutateInvitations } = useWorkspaceInvitations(owner);
+
   const [selectedInvite, setSelectedInvite] =
     useState<MembershipInvitationType | null>(null);
-  const { mutateInvitations } = useWorkspaceInvitations(owner);
 
   const filteredInvitations = invitations
     .sort((a, b) => a.inviteEmail.localeCompare(b.inviteEmail))

--- a/front/components/members/InvitationsList.tsx
+++ b/front/components/members/InvitationsList.tsx
@@ -14,8 +14,6 @@ export function InvitationsList({
   searchText?: string;
 }) {
   const { invitations, isInvitationsLoading } = useWorkspaceInvitations(owner);
-  const { mutateInvitations } = useWorkspaceInvitations(owner);
-
   const [selectedInvite, setSelectedInvite] =
     useState<MembershipInvitationType | null>(null);
 
@@ -33,7 +31,6 @@ export function InvitationsList({
         <EditInvitationModal
           invitation={selectedInvite}
           owner={owner}
-          mutateInvitations={mutateInvitations}
           onClose={() => setSelectedInvite(null)}
         />
       )}

--- a/front/lib/swr.ts
+++ b/front/lib/swr.ts
@@ -253,19 +253,23 @@ export function useDataSources(owner: WorkspaceType) {
 
 export function useMembers(owner: WorkspaceType) {
   const membersFetcher: Fetcher<GetMembersResponseBody> = fetcher;
-  const { data, error } = useSWR(`/api/w/${owner.sId}/members`, membersFetcher);
+  const { data, error, mutate } = useSWR(
+    `/api/w/${owner.sId}/members`,
+    membersFetcher
+  );
 
   return {
     members: useMemo(() => (data ? data.members : []), [data]),
     isMembersLoading: !error && !data,
     isMembersError: error,
+    mutateMembers: mutate,
   };
 }
 
 export function useWorkspaceInvitations(owner: WorkspaceType) {
   const workspaceInvitationsFetcher: Fetcher<GetWorkspaceInvitationsResponseBody> =
     fetcher;
-  const { data, error } = useSWR(
+  const { data, error, mutate } = useSWR(
     `/api/w/${owner.sId}/invitations`,
     workspaceInvitationsFetcher
   );
@@ -274,6 +278,7 @@ export function useWorkspaceInvitations(owner: WorkspaceType) {
     invitations: useMemo(() => (data ? data.invitations : []), [data]),
     isInvitationsLoading: !error && !data,
     isInvitationsError: error,
+    mutateInvitations: mutate,
   };
 }
 

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -380,15 +380,16 @@ function ChangeMemberModal({
     member?.workspaces[0].role !== "none",
     "Unreachable (typescript pleasing): member role cannot be none"
   );
-  const { mutate } = useSWRConfig();
-  const sendNotification = useContext(SendNotificationsContext);
-  const [revokeMemberModalOpen, setRevokeMemberModalOpen] = useState(false);
-  const [selectedRole, setSelectedRole] = useState<ActiveRoleType | null>(null);
-  const [isSaving, setIsSaving] = useState(false);
-
   if (!member) {
     return null;
   }
+  const { mutate } = useSWRConfig();
+  const sendNotification = useContext(SendNotificationsContext);
+  const [revokeMemberModalOpen, setRevokeMemberModalOpen] = useState(false);
+  const [selectedRole, setSelectedRole] = useState<ActiveRoleType | null>(
+    member.workspaces[0].role
+  );
+  const [isSaving, setIsSaving] = useState(false);
 
   return (
     <ElementModal


### PR DESCRIPTION
## Description

This PR aims at fixing the modal drawer used to update members/invitations roles to only display "Update role" when a change has been made.

**Previous behaviour:**
- Invitation editing: selecting a new role from the `RoleDropDown` was directly updating the invitation `initialRole` (without having to click on a "Save Update" button)
- Member role editing: the "Save Update" was clickable when the selected role corresponded to the assigned role

**New behaviour:**
- Invitation editing: one needs to click on "Save Update" to validate the changes
- Member role editing: the "Save update" button is only visible the selected role is different from the already assigned one.

## Risk

None

## Deploy Plan

Deploying `front`