### PR TITLE
Display workspace creation day on Poké

### DIFF
--- a/front/components/poke/workspace/table.tsx
+++ b/front/components/poke/workspace/table.tsx
@@ -10,9 +10,11 @@ import {
 export function WorkspaceInfoTable({
   owner,
   workspaceVerifiedDomain,
+  worspaceCreationDay,
 }: {
   owner: WorkspaceType;
   workspaceVerifiedDomain: WorkspaceDomain | null;
+  worspaceCreationDay: string;
 }) {
   return (
     <div className="flex justify-between gap-3 pt-4">
@@ -22,6 +24,10 @@ export function WorkspaceInfoTable({
         </div>
         <PokeTable>
           <PokeTableBody>
+            <PokeTableRow>
+              <PokeTableCell>Workspace creation</PokeTableCell>
+              <PokeTableCell>{worspaceCreationDay}</PokeTableCell>
+            </PokeTableRow>
             <PokeTableRow>
               <PokeTableCell>SSO Enforced</PokeTableCell>
               <PokeTableCell>{owner.ssoEnforced ? "✅" : "❌"}</PokeTableCell>

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -59,6 +59,22 @@ export async function getWorkspaceVerifiedDomain(
   return null;
 }
 
+export async function getWorkspaceCreationDate(
+  workspaceId: string
+): Promise<Date> {
+  const workspace = await Workspace.findOne({
+    where: {
+      sId: workspaceId,
+    },
+  });
+
+  if (!workspace) {
+    throw new Error("Workspace not found.");
+  }
+
+  return workspace.createdAt;
+}
+
 export async function setInternalWorkspaceSegmentation(
   auth: Authenticator,
   segmentation: WorkspaceSegmentationType

--- a/front/pages/poke/[wId]/index.tsx
+++ b/front/pages/poke/[wId]/index.tsx
@@ -9,6 +9,7 @@ import type {
 import type { WorkspaceType } from "@dust-tt/types";
 import type { SubscriptionType } from "@dust-tt/types";
 import { DustProdActionRegistry, WHITELISTABLE_FEATURES } from "@dust-tt/types";
+import { format } from "date-fns/format";
 import { keyBy } from "lodash";
 import type { InferGetServerSidePropsType } from "next";
 import Link from "next/link";
@@ -24,7 +25,10 @@ import { WorkspaceInfoTable } from "@app/components/poke/workspace/table";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
 import { getDataSources } from "@app/lib/api/data_sources";
-import { getWorkspaceVerifiedDomain } from "@app/lib/api/workspace";
+import {
+  getWorkspaceCreationDate,
+  getWorkspaceVerifiedDomain,
+} from "@app/lib/api/workspace";
 import {
   GLOBAL_AGENTS_SID,
   orderDatasourceByImportance,
@@ -44,6 +48,7 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
   whitelistableFeatures: WhitelistableFeature[];
   registry: typeof DustProdActionRegistry;
   workspaceVerifiedDomain: WorkspaceDomain | null;
+  worspaceCreationDay: string;
 }>(async (context, auth) => {
   const owner = auth.workspace();
   const activeSubscription = auth.subscription();
@@ -94,6 +99,7 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
   );
 
   const workspaceVerifiedDomain = await getWorkspaceVerifiedDomain(owner);
+  const worspaceCreationDate = await getWorkspaceCreationDate(owner.sId);
 
   return {
     props: {
@@ -106,6 +112,7 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
         WHITELISTABLE_FEATURES as unknown as WhitelistableFeature[],
       registry: DustProdActionRegistry,
       workspaceVerifiedDomain,
+      worspaceCreationDay: format(worspaceCreationDate, "yyyy-MM-dd"),
     },
   };
 });
@@ -119,6 +126,7 @@ const WorkspacePage = ({
   whitelistableFeatures,
   registry,
   workspaceVerifiedDomain,
+  worspaceCreationDay,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
   const router = useRouter();
 
@@ -239,6 +247,7 @@ const WorkspacePage = ({
                 <WorkspaceInfoTable
                   owner={owner}
                   workspaceVerifiedDomain={workspaceVerifiedDomain}
+                  worspaceCreationDay={worspaceCreationDay}
                 />
                 <div className="flex-grow">
                   <ActiveSubscriptionTable


### PR DESCRIPTION
## Description

We want to display the workspace creation date on Poké (we displayed only the start date of the active subscription). 
Since I don't want to add `createdAt` to `WorkspaceType` I created a tiny lib function to fetch it. 


<img width="829" alt="Screenshot 2024-05-27 at 11 45 17" src="https://github.com/dust-tt/dust/assets/3803406/cb307cc6-924e-49ac-af4d-b13835db653e">


## Risk

/

## Deploy Plan

Deploy Front.
