### PR TITLE
Add embedder_config in core data source

### DIFF
--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -407,6 +407,7 @@ pub struct EmbedderConfig {
     pub provider_id: ProviderID,
     pub model_id: String,
     pub splitter_id: SplitterID,
+    pub max_chunk_size: usize,
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]
@@ -421,12 +422,12 @@ pub struct DataSourceConfig {
     pub provider_id: ProviderID,
     pub model_id: String,
     pub splitter_id: SplitterID,
+    pub max_chunk_size: usize,
 
     // Optional until we update api calls to pass this body.
     pub embedder_config: Option<EmbedderDataSourceConfig>,
 
     pub extras: Option<Value>,
-    pub max_chunk_size: usize,
     pub qdrant_config: Option<QdrantDataSourceConfig>,
 }
 

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -650,8 +650,6 @@ impl DataSource {
             ..Default::default()
         };
 
-        // We should write in primary client before, right?
-        // Write in cluster and embedder?
         match qdrant_clients.shadow_write_client(&self.config.qdrant_config) {
             Some(qdrant_client) => {
                 match qdrant_client
@@ -831,7 +829,6 @@ impl DataSource {
         }
 
         // Split text in chunks.
-        // This needs to be duplicated per cluster/collection.
         let splits = splitter(self.config.splitter_id)
             .split(
                 credentials.clone(),

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -403,7 +403,7 @@ pub struct DocumentVersion {
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]
-pub struct Embedder {
+pub struct EmbedderConfig {
     pub provider_id: ProviderID,
     pub model_id: String,
     pub splitter_id: SplitterID,
@@ -411,8 +411,8 @@ pub struct Embedder {
 
 #[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]
 pub struct EmbedderDataSourceConfig {
-    pub embedder: Embedder,
-    pub shadow_embedder: Option<Embedder>,
+    pub embedder: EmbedderConfig,
+    pub shadow_embedder: Option<EmbedderConfig>,
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]

--- a/front/migrations/20230522_slack_doc_rename_incident.ts
+++ b/front/migrations/20230522_slack_doc_rename_incident.ts
@@ -61,6 +61,7 @@ async function main() {
             provider_id: dataSourceProviderId,
             model_id: dataSourceModelId,
             splitter_id: "base_v0",
+            max_chunk_size: dataSourceMaxChunkSize,
 
             embedder_config: {
               embedder: {
@@ -70,7 +71,6 @@ async function main() {
                 splitter_id: "base_v0",
               },
             },
-            max_chunk_size: dataSourceMaxChunkSize,
             qdrant_config: null,
           },
           credentials,

--- a/front/migrations/20230522_slack_doc_rename_incident.ts
+++ b/front/migrations/20230522_slack_doc_rename_incident.ts
@@ -57,9 +57,18 @@ async function main() {
           projectId: dustProject.value.project.project_id.toString(),
           dataSourceId: dataSourceName,
           config: {
+            // TODO(2024-05-27 flav) Remove once migrated to embedder.
             provider_id: dataSourceProviderId,
             model_id: dataSourceModelId,
             splitter_id: "base_v0",
+
+            embedder_config: {
+              embedder: {
+                provider_id: dataSourceProviderId,
+                model_id: dataSourceModelId,
+                splitter_id: "base_v0",
+              },
+            },
             max_chunk_size: dataSourceMaxChunkSize,
             qdrant_config: null,
           },

--- a/front/migrations/20230522_slack_doc_rename_incident.ts
+++ b/front/migrations/20230522_slack_doc_rename_incident.ts
@@ -64,8 +64,9 @@ async function main() {
 
             embedder_config: {
               embedder: {
-                provider_id: dataSourceProviderId,
+                max_chunk_size: dataSourceMaxChunkSize,
                 model_id: dataSourceModelId,
+                provider_id: dataSourceProviderId,
                 splitter_id: "base_v0",
               },
             },

--- a/front/migrations/20230803_wipe_gdrive_connectors.ts
+++ b/front/migrations/20230803_wipe_gdrive_connectors.ts
@@ -45,9 +45,18 @@ async function main() {
       projectId: d.dustAPIProjectId,
       dataSourceId: d.name,
       config: {
+        // TODO(2024-05-27 flav) Remove once migrated to embedder.
         provider_id: "openai",
         model_id: "text-embedding-ada-002",
         splitter_id: "base_v0",
+
+        embedder_config: {
+          embedder: {
+            provider_id: "openai",
+            model_id: "text-embedding-ada-002",
+            splitter_id: "base_v0",
+          },
+        },
         max_chunk_size: 256,
         qdrant_config: null,
       },

--- a/front/migrations/20230803_wipe_gdrive_connectors.ts
+++ b/front/migrations/20230803_wipe_gdrive_connectors.ts
@@ -49,6 +49,7 @@ async function main() {
         provider_id: "openai",
         model_id: "text-embedding-ada-002",
         splitter_id: "base_v0",
+        max_chunk_size: 256,
 
         embedder_config: {
           embedder: {
@@ -58,7 +59,6 @@ async function main() {
             splitter_id: "base_v0",
           },
         },
-        max_chunk_size: 256,
         qdrant_config: null,
       },
       credentials: dustManagedCredentials(),

--- a/front/migrations/20230803_wipe_gdrive_connectors.ts
+++ b/front/migrations/20230803_wipe_gdrive_connectors.ts
@@ -52,8 +52,9 @@ async function main() {
 
         embedder_config: {
           embedder: {
-            provider_id: "openai",
+            max_chunk_size: 256,
             model_id: "text-embedding-ada-002",
+            provider_id: "openai",
             splitter_id: "base_v0",
           },
         },

--- a/front/pages/api/w/[wId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/index.ts
@@ -154,8 +154,9 @@ async function handler(
           },
           embedder_config: {
             embedder: {
-              provider_id: EMBEDDING_CONFIG.provider_id,
+              max_chunk_size: EMBEDDING_CONFIG.max_chunk_size,
               model_id: EMBEDDING_CONFIG.model_id,
+              provider_id: EMBEDDING_CONFIG.provider_id,
               splitter_id: EMBEDDING_CONFIG.splitter_id,
             },
           },

--- a/front/pages/api/w/[wId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/index.ts
@@ -146,8 +146,8 @@ async function handler(
           provider_id: EMBEDDING_CONFIG.provider_id,
           model_id: EMBEDDING_CONFIG.model_id,
           splitter_id: EMBEDDING_CONFIG.splitter_id,
-
           max_chunk_size: EMBEDDING_CONFIG.max_chunk_size,
+
           qdrant_config: {
             cluster: DEFAULT_QDRANT_CLUSTER,
             shadow_write_cluster: null,

--- a/front/pages/api/w/[wId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/index.ts
@@ -142,13 +142,22 @@ async function handler(
         projectId: dustProject.value.project.project_id.toString(),
         dataSourceId: req.body.name as string,
         config: {
+          // TODO(2024-05-27 flav) Remove once migrated to embedder.
           provider_id: EMBEDDING_CONFIG.provider_id,
           model_id: EMBEDDING_CONFIG.model_id,
           splitter_id: EMBEDDING_CONFIG.splitter_id,
+
           max_chunk_size: EMBEDDING_CONFIG.max_chunk_size,
           qdrant_config: {
             cluster: DEFAULT_QDRANT_CLUSTER,
             shadow_write_cluster: null,
+          },
+          embedder_config: {
+            embedder: {
+              provider_id: EMBEDDING_CONFIG.provider_id,
+              model_id: EMBEDDING_CONFIG.model_id,
+              splitter_id: EMBEDDING_CONFIG.splitter_id,
+            },
           },
         },
         credentials,

--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -286,9 +286,18 @@ async function handler(
         projectId: dustProject.value.project.project_id.toString(),
         dataSourceId: dataSourceName,
         config: {
+          // TODO(2024-05-27 flav) Remove once migrated to embedder.
           provider_id: EMBEDDING_CONFIG.provider_id,
           model_id: EMBEDDING_CONFIG.model_id,
           splitter_id: EMBEDDING_CONFIG.splitter_id,
+
+          embedder_config: {
+            embedder: {
+              provider_id: EMBEDDING_CONFIG.provider_id,
+              model_id: EMBEDDING_CONFIG.model_id,
+              splitter_id: EMBEDDING_CONFIG.splitter_id,
+            },
+          },
           max_chunk_size: EMBEDDING_CONFIG.max_chunk_size,
           qdrant_config: {
             cluster: DEFAULT_QDRANT_CLUSTER,

--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -293,8 +293,9 @@ async function handler(
 
           embedder_config: {
             embedder: {
-              provider_id: EMBEDDING_CONFIG.provider_id,
+              max_chunk_size: EMBEDDING_CONFIG.max_chunk_size,
               model_id: EMBEDDING_CONFIG.model_id,
+              provider_id: EMBEDDING_CONFIG.provider_id,
               splitter_id: EMBEDDING_CONFIG.splitter_id,
             },
           },

--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -290,6 +290,7 @@ async function handler(
           provider_id: EMBEDDING_CONFIG.provider_id,
           model_id: EMBEDDING_CONFIG.model_id,
           splitter_id: EMBEDDING_CONFIG.splitter_id,
+          max_chunk_size: EMBEDDING_CONFIG.max_chunk_size,
 
           embedder_config: {
             embedder: {
@@ -299,7 +300,6 @@ async function handler(
               splitter_id: EMBEDDING_CONFIG.splitter_id,
             },
           },
-          max_chunk_size: EMBEDDING_CONFIG.max_chunk_size,
           qdrant_config: {
             cluster: DEFAULT_QDRANT_CLUSTER,
             shadow_write_cluster: null,

--- a/types/src/core/data_source.ts
+++ b/types/src/core/data_source.ts
@@ -20,7 +20,6 @@ export type CoreAPIDataSourceConfig = {
   embedder_config: EmbedderConfigType;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  extras?: any | null;
   max_chunk_size: number;
   qdrant_config: {
     cluster: QdrantCluster;

--- a/types/src/core/data_source.ts
+++ b/types/src/core/data_source.ts
@@ -1,12 +1,26 @@
 export type QdrantCluster = "cluster-0";
 export const DEFAULT_QDRANT_CLUSTER: QdrantCluster = "cluster-0";
 
-export type CoreAPIDataSourceConfig = {
+interface EmbedderType {
   provider_id: string;
   model_id: string;
+  splitter_id: string;
+}
+
+interface EmbedderConfigType {
+  embedder: EmbedderType;
+}
+
+export type CoreAPIDataSourceConfig = {
+  // TODO(2024-05-27 flav) Remove once migrated to embedder.
+  provider_id: string;
+  model_id: string;
+  splitter_id: string;
+
+  embedder_config: EmbedderConfigType;
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   extras?: any | null;
-  splitter_id: string;
   max_chunk_size: number;
   qdrant_config: {
     cluster: QdrantCluster;

--- a/types/src/core/data_source.ts
+++ b/types/src/core/data_source.ts
@@ -5,6 +5,7 @@ interface EmbedderType {
   provider_id: string;
   model_id: string;
   splitter_id: string;
+  max_chunk_size: number;
 }
 
 interface EmbedderConfigType {
@@ -16,11 +17,11 @@ export type CoreAPIDataSourceConfig = {
   provider_id: string;
   model_id: string;
   splitter_id: string;
+  max_chunk_size: number;
 
   embedder_config: EmbedderConfigType;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  max_chunk_size: number;
   qdrant_config: {
     cluster: QdrantCluster;
     shadow_write_cluster: QdrantCluster | null;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR introduces the `embedder_config` field in the core data source, laying the groundwork to support multiple embedders. This preliminary step is essential before upgrading our current embedder to the latest version. Although this new field is not yet used in the core, the immediate goal is to begin saving it when creating new data sources so that we can backfill existing records.

The plan to fully transition to this structure involves:
1. Adding `embedder_config` and updating API calls.
2. Backfilling `embedder_config` and deprecating the legacy top-level embedder configuration.
3. Starting to use the new `embedder_config`.
4. Handling the `shadow_embedder`.

Tested locally:
```
{
  "provider_id": "openai",
  "model_id": "text-embedding-ada-002",
  "splitter_id": "base_v0",
  "embedder_config": {
    "embedder": {
      "provider_id": "openai",
      "model_id": "text-embedding-ada-002",
      "splitter_id": "base_v0"
    },
    "shadow_embedder": null
  },
  "extras": null,
  "max_chunk_size": 512,
  "qdrant_config": { "cluster": "cluster-0", "shadow_write_cluster": null }
}
```

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
Low risk.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
⚠️ We first needs to deploy `core` before deploying `front`.
