### PR TITLE
[Websearch] Implement running actual websearch action

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -170,6 +170,7 @@ export function AgentMessage({
       case "tables_query_params":
       case "tables_query_output":
       case "process_params":
+      case "websearch_params":
         setStreamedAgentMessage((m) => {
           return updateMessageWithAction(m, event.action);
         });

--- a/front/components/assistant/conversation/WebsearchAction.tsx
+++ b/front/components/assistant/conversation/WebsearchAction.tsx
@@ -1,4 +1,4 @@
-import type { WebsearchActionType } from "@dust-tt/types/dist/front/assistant/actions/websearch";
+import type { WebsearchActionType } from "@dust-tt/types/dist";
 
 // TODO(pr,websearch) Implement this function
 export default function WebsearchAction({

--- a/front/components/assistant/conversation/WebsearchAction.tsx
+++ b/front/components/assistant/conversation/WebsearchAction.tsx
@@ -1,4 +1,4 @@
-import type { WebsearchActionType } from "@dust-tt/types/dist";
+import type { WebsearchActionType } from "@dust-tt/types";
 
 // TODO(pr,websearch) Implement this function
 export default function WebsearchAction({

--- a/front/lib/api/assistant/actions/runners.ts
+++ b/front/lib/api/assistant/actions/runners.ts
@@ -2,8 +2,8 @@ import type {
   AgentAction,
   DustAppRunConfigurationType,
   ProcessConfigurationType,
+  WebsearchConfigurationType,
 } from "@dust-tt/types";
-import type { WebsearchConfigurationType } from "@dust-tt/types/dist/front/assistant/actions/websearch";
 
 import { DustAppRunConfigurationServerRunner } from "@app/lib/api/assistant/actions/dust_app_run";
 import { ProcessConfigurationServerRunner } from "@app/lib/api/assistant/actions/process";

--- a/front/lib/api/assistant/actions/websearch.ts
+++ b/front/lib/api/assistant/actions/websearch.ts
@@ -55,11 +55,12 @@ export class WebsearchAction extends BaseAction {
   }
 
   renderForModel(): ModelMessageType {
-    let content = "";
-
-    // Note action.output can be any valid JSON including null.
-    content += `WEBSEARCH OUTPUT:\n`;
-    content += `${JSON.stringify(this.output, null, 2)}\n`;
+    let content = "WEBSEARCH OUTPUT:\n";
+    if (this.output === null) {
+      content += "The web search failed.\n";
+    } else {
+      content += `${JSON.stringify(this.output, null, 2)}\n`;
+    }
 
     return {
       role: "action" as const,
@@ -77,11 +78,12 @@ export class WebsearchAction extends BaseAction {
   }
 
   renderForMultiActionsModel(): FunctionMessageTypeModel {
-    let content = "";
-
-    // Note action.output can be any valid JSON including null.
-    content += `WEBSEARCH OUTPUT:\n`;
-    content += `${JSON.stringify(this.output, null, 2)}\n`;
+    let content = "WEBSEARCH OUTPUT:\n";
+    if (this.output === null) {
+      content += "The web search failed.\n";
+    } else {
+      content += `${JSON.stringify(this.output, null, 2)}\n`;
+    }
 
     return {
       role: "function" as const,

--- a/front/lib/api/assistant/actions/websearch.ts
+++ b/front/lib/api/assistant/actions/websearch.ts
@@ -1,10 +1,97 @@
-import type { AgentActionSpecification, Result } from "@dust-tt/types";
-import { Ok } from "@dust-tt/types";
-import type { WebsearchConfigurationType } from "@dust-tt/types/dist/front/assistant/actions/websearch";
+import type {
+  AgentActionSpecification,
+  FunctionCallType,
+  FunctionMessageTypeModel,
+  ModelId,
+  ModelMessageType,
+  Result,
+  WebsearchErrorEvent,
+  WebsearchParamsEvent,
+  WebsearchSuccessEvent,
+} from "@dust-tt/types";
+import {
+  BaseAction,
+  cloneBaseConfig,
+  DustProdActionRegistry,
+  Ok,
+} from "@dust-tt/types";
+import type {
+  WebsearchActionOutputType,
+  WebsearchConfigurationType,
+} from "@dust-tt/types/dist/front/assistant/actions/websearch";
 
+import { runActionStreamed } from "@app/lib/actions/server";
 import type { BaseActionRunParams } from "@app/lib/api/assistant/actions/types";
 import { BaseActionConfigurationServerRunner } from "@app/lib/api/assistant/actions/types";
 import type { Authenticator } from "@app/lib/auth";
+import { AgentWebsearchAction } from "@app/lib/models/assistant/actions/websearch";
+import logger from "@app/logger/logger";
+
+interface WebsearchActionBlob {
+  id: ModelId; // AgentWebsearchAction
+  agentMessageId: ModelId;
+  query: string;
+  output: WebsearchActionOutputType | null;
+  functionCallId: string | null;
+  functionCallName: string | null;
+  step: number;
+}
+
+export class WebsearchAction extends BaseAction {
+  readonly agentMessageId: ModelId;
+  readonly query: string;
+  readonly output: WebsearchActionOutputType | null;
+  readonly functionCallId: string | null;
+  readonly functionCallName: string | null;
+  readonly step: number;
+
+  constructor(blob: WebsearchActionBlob) {
+    super(blob.id, "websearch_action");
+
+    this.agentMessageId = blob.agentMessageId;
+    this.query = blob.query;
+    this.output = blob.output;
+    this.functionCallId = blob.functionCallId;
+    this.functionCallName = blob.functionCallName;
+    this.step = blob.step;
+  }
+
+  renderForModel(): ModelMessageType {
+    let content = "";
+
+    // Note action.output can be any valid JSON including null.
+    content += `WEBSEARCH OUTPUT:\n`;
+    content += `${JSON.stringify(this.output, null, 2)}\n`;
+
+    return {
+      role: "action" as const,
+      name: this.functionCallName ?? "web_search",
+      content,
+    };
+  }
+
+  renderForFunctionCall(): FunctionCallType {
+    return {
+      id: this.functionCallId ?? `call_${this.id.toString()}`,
+      name: this.functionCallName ?? "web_search",
+      arguments: JSON.stringify({ query: this.query }),
+    };
+  }
+
+  renderForMultiActionsModel(): FunctionMessageTypeModel {
+    let content = "";
+
+    // Note action.output can be any valid JSON including null.
+    content += `WEBSEARCH OUTPUT:\n`;
+    content += `${JSON.stringify(this.output, null, 2)}\n`;
+
+    return {
+      role: "function" as const,
+      function_call_id: this.functionCallId ?? `call_${this.id.toString()}`,
+      content,
+    };
+  }
+}
 
 /**
  * Params generation.
@@ -39,16 +126,196 @@ export class WebsearchConfigurationServerRunner extends BaseActionConfigurationS
     });
   }
 
-  run(
+  // This method is in charge of running the websearch and creating an AgentWebsearchAction object in
+  // the database. It does not create any generic model related to the conversation. It is possible
+  // for an AgentWebsearchAction to be stored (once the query params are infered) but for its execution
+  // to fail, in which case an error event will be emitted and the AgentWebsearchAction won't have any
+  // outputs associated. The error is expected to be stored by the caller on the parent agent message.
+  async *run(
     auth: Authenticator,
-    runParams: BaseActionRunParams,
-    customParams: Record<string, unknown>
-  ): AsyncGenerator<unknown, any, unknown> {
-    throw new Error(
-      "Method not implemented." +
-        JSON.stringify(runParams) +
-        JSON.stringify(customParams) +
-        JSON.stringify(auth)
+    {
+      agentConfiguration,
+      conversation,
+      agentMessage,
+      rawInputs,
+      functionCallId,
+      step,
+    }: BaseActionRunParams
+  ): AsyncGenerator<
+    WebsearchParamsEvent | WebsearchSuccessEvent | WebsearchErrorEvent,
+    void
+  > {
+    const owner = auth.workspace();
+    if (!owner) {
+      throw new Error(
+        "Unexpected unauthenticated call to `run` for websearch action"
+      );
+    }
+
+    const { actionConfiguration } = this;
+
+    const query = rawInputs.query;
+
+    if (!query || typeof query !== "string" || query.length === 0) {
+      yield {
+        type: "websearch_error",
+        created: Date.now(),
+        configurationId: agentConfiguration.sId,
+        messageId: agentMessage.sId,
+        error: {
+          code: "websearch_parameters_generation_error",
+          message:
+            "The query parameter is required and must be a non-empty string.",
+        },
+      };
+      return;
+    }
+
+    // Create the AgentWebsearchAction object in the database and yield an event for the generation of
+    // the params. We store the action here as the params have been generated, if an error occurs
+    // later on, the action won't have outputs but the error will be stored on the parent agent
+    // message.
+    const action = await AgentWebsearchAction.create({
+      query,
+      websearchConfigurationId: actionConfiguration.sId,
+      functionCallId,
+      functionCallName: actionConfiguration.name,
+      agentMessageId: agentMessage.agentMessageId,
+      step,
+    });
+
+    const now = Date.now();
+
+    yield {
+      type: "websearch_params",
+      created: Date.now(),
+      configurationId: agentConfiguration.sId,
+      messageId: agentMessage.sId,
+      action: new WebsearchAction({
+        id: action.id,
+        agentMessageId: action.agentMessageId,
+        query,
+        output: null,
+        functionCallId: action.functionCallId,
+        functionCallName: action.functionCallName,
+        step: action.step,
+      }),
+    };
+
+    const config = cloneBaseConfig(
+      DustProdActionRegistry["assistant-v2-websearch"].config
     );
+
+    // Execute the websearch action.
+    const websearchRes = await runActionStreamed(
+      auth,
+      "assistant-v2-websearch",
+      config,
+      [{ query }],
+      {
+        workspaceId: conversation.owner.sId,
+        conversationId: conversation.sId,
+        agentMessageId: agentMessage.sId,
+      }
+    );
+    if (websearchRes.isErr()) {
+      yield {
+        type: "websearch_error",
+        created: Date.now(),
+        configurationId: agentConfiguration.sId,
+        messageId: agentMessage.sId,
+        error: {
+          code: "websearch_execution_error",
+          message: websearchRes.error.message,
+        },
+      };
+      return;
+    }
+
+    const { eventStream } = websearchRes.value;
+    let output: WebsearchActionOutputType | null = null;
+
+    for await (const event of eventStream) {
+      if (event.type === "error") {
+        logger.error(
+          {
+            workspaceId: owner.id,
+            conversationId: conversation.id,
+            error: event.content.message,
+          },
+          "Error running websearch action"
+        );
+        yield {
+          type: "websearch_error",
+          created: Date.now(),
+          configurationId: agentConfiguration.sId,
+          messageId: agentMessage.sId,
+          error: {
+            code: "websearch_execution_error",
+            message: event.content.message,
+          },
+        };
+        return;
+      }
+
+      if (event.type === "block_execution") {
+        const e = event.content.execution[0][0];
+        if (e.error) {
+          logger.error(
+            {
+              workspaceId: owner.id,
+              conversationId: conversation.id,
+              error: e.error,
+            },
+            "Error running websearch action"
+          );
+          yield {
+            type: "websearch_error",
+            created: Date.now(),
+            configurationId: agentConfiguration.sId,
+            messageId: agentMessage.sId,
+            error: {
+              code: "websearch_execution_error",
+              message: e.error,
+            },
+          };
+          return;
+        }
+
+        if (event.content.block_name === "SEARCH_EXTRACT_FINAL" && e.value) {
+          output = { results: e.value } as WebsearchActionOutputType;
+        }
+      }
+    }
+
+    // Update ProcessAction with the output of the last block.
+    await action.update({
+      output,
+    });
+
+    logger.info(
+      {
+        workspaceId: conversation.owner.sId,
+        conversationId: conversation.sId,
+        elapsed: Date.now() - now,
+      },
+      "[ASSISTANT_TRACE] Finished websearch action run execution"
+    );
+
+    yield {
+      type: "websearch_success",
+      created: Date.now(),
+      configurationId: agentConfiguration.sId,
+      messageId: agentMessage.sId,
+      action: new WebsearchAction({
+        id: action.id,
+        agentMessageId: agentMessage.agentMessageId,
+        query,
+        output,
+        functionCallId: action.functionCallId,
+        functionCallName: action.functionCallName,
+        step: action.step,
+      }),
+    };
   }
 }

--- a/front/lib/api/assistant/actions/websearch.ts
+++ b/front/lib/api/assistant/actions/websearch.ts
@@ -5,6 +5,8 @@ import type {
   ModelId,
   ModelMessageType,
   Result,
+  WebsearchActionOutputType,
+  WebsearchConfigurationType,
   WebsearchErrorEvent,
   WebsearchParamsEvent,
   WebsearchSuccessEvent,
@@ -15,10 +17,6 @@ import {
   DustProdActionRegistry,
   Ok,
 } from "@dust-tt/types";
-import type {
-  WebsearchActionOutputType,
-  WebsearchConfigurationType,
-} from "@dust-tt/types/dist/front/assistant/actions/websearch";
 
 import { runActionStreamed } from "@app/lib/actions/server";
 import type { BaseActionRunParams } from "@app/lib/api/assistant/actions/types";

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1686,6 +1686,7 @@ async function* streamRunAgentEvents(
       case "tables_query_params":
       case "tables_query_output":
       case "process_params":
+      case "websearch_params":
         yield event;
         break;
       case "generation_tokens":

--- a/front/lib/api/assistant/legacy_agent.ts
+++ b/front/lib/api/assistant/legacy_agent.ts
@@ -579,39 +579,53 @@ async function* runAction(
       }
     }
   } else if (isWebsearchConfiguration(action)) {
-    // Dummy implementation while in development (gated)
-    // TODO(pr,websearch) Implement this function
-    yield {
-      type: "agent_action_success",
-      created: now,
-      configurationId: configuration.sId,
-      messageId: agentMessage.sId,
-      action: {
-        agentMessageId: agentMessage.id,
-        type: "websearch_action",
-        query: "testing it",
-        output: {
-          results: [{ title: "test", snippet: "sniptest", url: "http://lol" }],
-        },
-        functionCallId: null,
-        functionCallName: null,
-        step,
-        id: -1,
-        renderForFunctionCall: () => {
-          return { id: "Websearch", name: "Websearch", arguments: "None" };
-        },
-        renderForModel: () => {
-          return { role: "action", name: "Websearch", content: "None" };
-        },
-        renderForMultiActionsModel: () => {
-          return {
-            role: "function",
-            function_call_id: "websearch",
-            content: "None",
+    // TODO(pr) refactor the isXXX cases to avoid the duplication for process and websearch?
+    const runner = getRunnerforActionConfiguration(action);
+
+    const eventStream = runner.run(auth, {
+      agentConfiguration: configuration,
+      conversation,
+      agentMessage,
+      rawInputs,
+      functionCallId: null,
+      step,
+    });
+
+    for await (const event of eventStream) {
+      switch (event.type) {
+        case "websearch_params":
+          yield event;
+          break;
+        case "websearch_error":
+          yield {
+            type: "agent_error",
+            created: event.created,
+            configurationId: configuration.sId,
+            messageId: agentMessage.sId,
+            error: {
+              code: event.error.code,
+              message: event.error.message,
+            },
           };
-        },
-      },
-    };
+          return;
+        case "websearch_success":
+          yield {
+            type: "agent_action_success",
+            created: event.created,
+            configurationId: configuration.sId,
+            messageId: agentMessage.sId,
+            action: event.action,
+          };
+
+          // We stitch the action into the agent message. The conversation is expected to include
+          // the agentMessage object, updating this object will update the conversation as well.
+          agentMessage.actions.push(event.action);
+          break;
+
+        default:
+          assertNever(event);
+      }
+    }
   } else {
     assertNever(action);
   }

--- a/front/lib/api/assistant/pubsub.ts
+++ b/front/lib/api/assistant/pubsub.ts
@@ -174,6 +174,7 @@ async function handleUserMessageEvents(
             case "tables_query_params":
             case "tables_query_output":
             case "process_params":
+            case "websearch_params":
             case "agent_error":
             case "agent_action_success":
             case "generation_tokens":
@@ -315,6 +316,7 @@ export async function retryAgentMessageWithPubSub(
               case "tables_query_params":
               case "tables_query_output":
               case "process_params":
+              case "websearch_params":
               case "agent_error":
               case "agent_action_success":
               case "generation_tokens":

--- a/front/lib/models/assistant/actions/websearch.ts
+++ b/front/lib/models/assistant/actions/websearch.ts
@@ -1,4 +1,4 @@
-import type { WebsearchActionOutputType } from "@dust-tt/types/dist/front/assistant/actions/websearch";
+import type { WebsearchActionOutputType } from "@dust-tt/types";
 import type {
   CreationOptional,
   ForeignKey,

--- a/types/src/front/lib/actions/registry.ts
+++ b/types/src/front/lib/actions/registry.ts
@@ -159,7 +159,7 @@ export const DustProdActionRegistry = createActionRegistry({
   "assistant-v2-websearch": {
     app: {
       workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
-      appId: "78bda07b39",
+      appId: "098b515f8e",
       appHash:
         "3573c1ea0502c882fc8748bfcb9f26e70fe623218d188d52255a4c794896fb6e",
     },

--- a/types/src/front/lib/api/assistant/actions/websearch.ts
+++ b/types/src/front/lib/api/assistant/actions/websearch.ts
@@ -1,0 +1,33 @@
+/**
+ * Action execution.
+ */
+
+import { WebsearchActionType } from "../../../../assistant/actions/websearch";
+
+// Event sent before the execution with the finalized params to be used.
+export type WebsearchParamsEvent = {
+  type: "websearch_params";
+  created: number;
+  configurationId: string;
+  messageId: string;
+  action: WebsearchActionType;
+};
+
+export type WebsearchErrorEvent = {
+  type: "websearch_error";
+  created: number;
+  configurationId: string;
+  messageId: string;
+  error: {
+    code: string;
+    message: string;
+  };
+};
+
+export type WebsearchSuccessEvent = {
+  type: "websearch_success";
+  created: number;
+  configurationId: string;
+  messageId: string;
+  action: WebsearchActionType;
+};

--- a/types/src/front/lib/api/assistant/agent.ts
+++ b/types/src/front/lib/api/assistant/agent.ts
@@ -20,6 +20,7 @@ import {
   AgentActionSpecification,
 } from "../../../assistant/agent";
 import { ProcessParamsEvent } from "./actions/process";
+import { WebsearchParamsEvent } from "./actions/websearch";
 
 // Event sent when an agent error occured before we have a agent message in the database.
 export type AgentMessageErrorEvent = {
@@ -51,7 +52,8 @@ export type AgentActionSpecificEvent =
   | DustAppRunBlockEvent
   | TablesQueryParamsEvent
   | TablesQueryOutputEvent
-  | ProcessParamsEvent;
+  | ProcessParamsEvent
+  | WebsearchParamsEvent;
 
 // Event sent once the action is completed, we're moving to generating a message if applicable.
 export type AgentActionSuccessEvent = {

--- a/types/src/front/lib/api/credentials.ts
+++ b/types/src/front/lib/api/credentials.ts
@@ -8,6 +8,7 @@ const {
   DUST_MANAGED_TEXTSYNTH_API_KEY = "",
   DUST_MANAGED_MISTRAL_API_KEY = "",
   DUST_MANAGED_GOOGLE_AI_STUDIO_API_KEY = "",
+  DUST_MANAGED_SERP_API_KEY = "",
 } = process.env;
 
 export const credentialsFromProviders = (
@@ -70,5 +71,6 @@ export const dustManagedCredentials = (): CredentialsType => {
     OPENAI_API_KEY: DUST_MANAGED_OPENAI_API_KEY,
     TEXTSYNTH_API_KEY: DUST_MANAGED_TEXTSYNTH_API_KEY,
     GOOGLE_AI_STUDIO_API_KEY: DUST_MANAGED_GOOGLE_AI_STUDIO_API_KEY,
+    SERP_API_KEY: DUST_MANAGED_SERP_API_KEY,
   };
 };

--- a/types/src/index.ts
+++ b/types/src/index.ts
@@ -38,6 +38,7 @@ export * from "./front/lib/api/assistant/actions/index";
 export * from "./front/lib/api/assistant/actions/process";
 export * from "./front/lib/api/assistant/actions/retrieval";
 export * from "./front/lib/api/assistant/actions/tables_query";
+export * from "./front/lib/api/assistant/actions/websearch";
 export * from "./front/lib/api/assistant/agent";
 export * from "./front/lib/api/assistant/conversation";
 export * from "./front/lib/api/assistant/generation";

--- a/types/src/index.ts
+++ b/types/src/index.ts
@@ -20,6 +20,7 @@ export * from "./front/assistant/actions/guards";
 export * from "./front/assistant/actions/process";
 export * from "./front/assistant/actions/retrieval";
 export * from "./front/assistant/actions/tables_query";
+export * from "./front/assistant/actions/websearch";
 export * from "./front/assistant/agent";
 export * from "./front/assistant/avatar";
 export * from "./front/assistant/builder";


### PR DESCRIPTION
Description
---
Fixes https://github.com/dust-tt/tasks/issues/780

Implement running the action for legacy agents & multi-actions, adding all relevant events and events generator.

Does **not** implement action rendering, planned for the following PR.
![image](https://github.com/dust-tt/dust/assets/5437393/0f44f522-d686-4359-9a77-05374f1a2835)

Risks
---
N/A (gated)

Deploy Plan
---
- Create prod secret for DUST_MANAGED_SERP_API_KEY
- deploy front

Note: there is *no* model change in this PR, the migration-ack is just a modified import path
