### PR TITLE
Deprecate legacy data source embedder config

### DIFF
--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -1182,7 +1182,7 @@ async fn data_sources_tokenize(
                 None,
             ),
             Some(ds) => {
-                let embedder_config = ds.default_embedder_config().clone();
+                let embedder_config = ds.embedder_config().clone();
                 let llm = provider(embedder_config.provider_id).llm(embedder_config.model_id);
                 match llm.tokenize(&payload.text).await {
                     Err(e) => error_response(

--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -1182,8 +1182,8 @@ async fn data_sources_tokenize(
                 None,
             ),
             Some(ds) => {
-                let config = ds.config().clone();
-                let llm = provider(config.provider_id).llm(config.model_id);
+                let embedder_config = ds.default_embedder_config().clone();
+                let llm = provider(embedder_config.provider_id).llm(embedder_config.model_id);
                 match llm.tokenize(&payload.text).await {
                     Err(e) => error_response(
                         StatusCode::INTERNAL_SERVER_ERROR,

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -418,14 +418,8 @@ pub struct EmbedderDataSourceConfig {
 
 #[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]
 pub struct DataSourceConfig {
-    // TODO(2024-05-24 flav) Remove once migrated to embedder.
-    pub provider_id: ProviderID,
-    pub model_id: String,
-    pub splitter_id: SplitterID,
-    pub max_chunk_size: usize,
-
     // Optional until we update api calls to pass this body.
-    pub embedder_config: Option<EmbedderDataSourceConfig>,
+    pub embedder_config: EmbedderDataSourceConfig,
 
     pub extras: Option<Value>,
     pub qdrant_config: Option<QdrantDataSourceConfig>,
@@ -535,6 +529,10 @@ impl DataSource {
 
     pub fn config(&self) -> &DataSourceConfig {
         &self.config
+    }
+
+    pub fn default_embedder_config(&self) -> &EmbedderConfig {
+        &self.config.embedder_config.embedder
     }
 
     pub async fn update_config(
@@ -830,12 +828,12 @@ impl DataSource {
         }
 
         // Split text in chunks.
-        let splits = splitter(self.config.splitter_id)
+        let splits = splitter(self.default_embedder_config().splitter_id)
             .split(
                 credentials.clone(),
-                self.config.provider_id,
-                &self.config.model_id,
-                self.config.max_chunk_size,
+                self.default_embedder_config().provider_id,
+                &self.default_embedder_config().model_id,
+                self.default_embedder_config().max_chunk_size,
                 text,
             )
             .await?;
@@ -911,8 +909,8 @@ impl DataSource {
                             EmbedderVector {
                                 created: document.created,
                                 vector: v.data.iter().map(|&v| v as f64).collect(),
-                                model: self.config.model_id.clone(),
-                                provider: self.config.provider_id.to_string(),
+                                model: self.default_embedder_config().model_id.clone(),
+                                provider: self.default_embedder_config().provider_id.to_string(),
                             },
                         );
                     }
@@ -949,8 +947,8 @@ impl DataSource {
         // Embed batched chunks sequentially.
         for chunk in chunked_splits {
             let r = EmbedderRequest::new(
-                self.config.provider_id.clone(),
-                &self.config.model_id,
+                self.default_embedder_config().provider_id.clone(),
+                &self.default_embedder_config().model_id,
                 chunk.iter().map(|ci| ci.text.as_str()).collect::<Vec<_>>(),
                 self.config.extras.clone(),
             );
@@ -1005,7 +1003,8 @@ impl DataSource {
             })
             .collect::<Vec<_>>();
         document.chunk_count = document.chunks.len();
-        document.token_count = Some(document.chunks.len() * self.config.max_chunk_size);
+        document.token_count =
+            Some(document.chunks.len() * self.default_embedder_config().max_chunk_size);
 
         let now = utils::now();
 
@@ -1222,8 +1221,8 @@ impl DataSource {
             }
             Some(q) => {
                 let r = EmbedderRequest::new(
-                    self.config.provider_id,
-                    &self.config.model_id,
+                    self.default_embedder_config().provider_id,
+                    &self.default_embedder_config().model_id,
                     vec![&q],
                     self.config.extras.clone(),
                 );
@@ -1360,7 +1359,7 @@ impl DataSource {
                             .map(|(_, c)| c.clone())
                             .collect::<Vec<Chunk>>();
                         let data_source = (*self).clone();
-                        let chunk_size = self.config.max_chunk_size;
+                        let chunk_size = self.default_embedder_config().max_chunk_size;
                         let qdrant_client = qdrant_client.clone();
                         let mut token_count = chunks.len() * chunk_size;
                         d.token_count = Some(token_count);
@@ -1530,7 +1529,8 @@ impl DataSource {
                         .filter(|(document_id, _)| document_id == &d.document_id)
                         .map(|(_, c)| c.clone())
                         .collect::<Vec<Chunk>>();
-                    d.token_count = Some(chunks.len() * self.config.max_chunk_size);
+                    d.token_count =
+                        Some(chunks.len() * self.default_embedder_config().max_chunk_size);
                     d.chunks = chunks;
                     d
                 })

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -531,7 +531,7 @@ impl DataSource {
         &self.config
     }
 
-    pub fn default_embedder_config(&self) -> &EmbedderConfig {
+    pub fn embedder_config(&self) -> &EmbedderConfig {
         &self.config.embedder_config.embedder
     }
 
@@ -828,12 +828,12 @@ impl DataSource {
         }
 
         // Split text in chunks.
-        let splits = splitter(self.default_embedder_config().splitter_id)
+        let splits = splitter(self.embedder_config().splitter_id)
             .split(
                 credentials.clone(),
-                self.default_embedder_config().provider_id,
-                &self.default_embedder_config().model_id,
-                self.default_embedder_config().max_chunk_size,
+                self.embedder_config().provider_id,
+                &self.embedder_config().model_id,
+                self.embedder_config().max_chunk_size,
                 text,
             )
             .await?;
@@ -909,8 +909,8 @@ impl DataSource {
                             EmbedderVector {
                                 created: document.created,
                                 vector: v.data.iter().map(|&v| v as f64).collect(),
-                                model: self.default_embedder_config().model_id.clone(),
-                                provider: self.default_embedder_config().provider_id.to_string(),
+                                model: self.embedder_config().model_id.clone(),
+                                provider: self.embedder_config().provider_id.to_string(),
                             },
                         );
                     }
@@ -947,8 +947,8 @@ impl DataSource {
         // Embed batched chunks sequentially.
         for chunk in chunked_splits {
             let r = EmbedderRequest::new(
-                self.default_embedder_config().provider_id.clone(),
-                &self.default_embedder_config().model_id,
+                self.embedder_config().provider_id.clone(),
+                &self.embedder_config().model_id,
                 chunk.iter().map(|ci| ci.text.as_str()).collect::<Vec<_>>(),
                 self.config.extras.clone(),
             );
@@ -1003,8 +1003,7 @@ impl DataSource {
             })
             .collect::<Vec<_>>();
         document.chunk_count = document.chunks.len();
-        document.token_count =
-            Some(document.chunks.len() * self.default_embedder_config().max_chunk_size);
+        document.token_count = Some(document.chunks.len() * self.embedder_config().max_chunk_size);
 
         let now = utils::now();
 
@@ -1221,8 +1220,8 @@ impl DataSource {
             }
             Some(q) => {
                 let r = EmbedderRequest::new(
-                    self.default_embedder_config().provider_id,
-                    &self.default_embedder_config().model_id,
+                    self.embedder_config().provider_id,
+                    &self.embedder_config().model_id,
                     vec![&q],
                     self.config.extras.clone(),
                 );
@@ -1359,7 +1358,7 @@ impl DataSource {
                             .map(|(_, c)| c.clone())
                             .collect::<Vec<Chunk>>();
                         let data_source = (*self).clone();
-                        let chunk_size = self.default_embedder_config().max_chunk_size;
+                        let chunk_size = self.embedder_config().max_chunk_size;
                         let qdrant_client = qdrant_client.clone();
                         let mut token_count = chunks.len() * chunk_size;
                         d.token_count = Some(token_count);
@@ -1529,8 +1528,7 @@ impl DataSource {
                         .filter(|(document_id, _)| document_id == &d.document_id)
                         .map(|(_, c)| c.clone())
                         .collect::<Vec<Chunk>>();
-                    d.token_count =
-                        Some(chunks.len() * self.default_embedder_config().max_chunk_size);
+                    d.token_count = Some(chunks.len() * self.embedder_config().max_chunk_size);
                     d.chunks = chunks;
                     d
                 })

--- a/core/src/data_sources/qdrant.rs
+++ b/core/src/data_sources/qdrant.rs
@@ -171,8 +171,11 @@ impl DustQdrantClient {
         format!(
             "{}_{}_{}",
             self.collection_prefix(),
-            data_source.config().provider_id.to_string(),
-            data_source.config().model_id,
+            data_source
+                .default_embedder_config()
+                .provider_id
+                .to_string(),
+            data_source.default_embedder_config().model_id,
         )
     }
 
@@ -187,8 +190,8 @@ impl DustQdrantClient {
 
     fn shard_key(&self, data_source: &DataSource) -> Result<shard_key::Key> {
         let key_id: u64 = match (
-            data_source.config().provider_id,
-            data_source.config().model_id.as_str(),
+            data_source.default_embedder_config().provider_id,
+            data_source.default_embedder_config().model_id.as_str(),
         ) {
             (ProviderID::OpenAI, "text-embedding-ada-002") => {
                 // The startegy below was a mistake as the last character is an hex encoding

--- a/core/src/data_sources/qdrant.rs
+++ b/core/src/data_sources/qdrant.rs
@@ -171,11 +171,8 @@ impl DustQdrantClient {
         format!(
             "{}_{}_{}",
             self.collection_prefix(),
-            data_source
-                .default_embedder_config()
-                .provider_id
-                .to_string(),
-            data_source.default_embedder_config().model_id,
+            data_source.embedder_config().provider_id.to_string(),
+            data_source.embedder_config().model_id,
         )
     }
 
@@ -190,8 +187,8 @@ impl DustQdrantClient {
 
     fn shard_key(&self, data_source: &DataSource) -> Result<shard_key::Key> {
         let key_id: u64 = match (
-            data_source.default_embedder_config().provider_id,
-            data_source.default_embedder_config().model_id.as_str(),
+            data_source.embedder_config().provider_id,
+            data_source.embedder_config().model_id.as_str(),
         ) {
             (ProviderID::OpenAI, "text-embedding-ada-002") => {
                 // The startegy below was a mistake as the last character is an hex encoding

--- a/front/migrations/20230522_slack_doc_rename_incident.ts
+++ b/front/migrations/20230522_slack_doc_rename_incident.ts
@@ -57,12 +57,6 @@ async function main() {
           projectId: dustProject.value.project.project_id.toString(),
           dataSourceId: dataSourceName,
           config: {
-            // TODO(2024-05-27 flav) Remove once migrated to embedder.
-            provider_id: dataSourceProviderId,
-            model_id: dataSourceModelId,
-            splitter_id: "base_v0",
-            max_chunk_size: dataSourceMaxChunkSize,
-
             embedder_config: {
               embedder: {
                 max_chunk_size: dataSourceMaxChunkSize,

--- a/front/migrations/20230803_wipe_gdrive_connectors.ts
+++ b/front/migrations/20230803_wipe_gdrive_connectors.ts
@@ -45,12 +45,6 @@ async function main() {
       projectId: d.dustAPIProjectId,
       dataSourceId: d.name,
       config: {
-        // TODO(2024-05-27 flav) Remove once migrated to embedder.
-        provider_id: "openai",
-        model_id: "text-embedding-ada-002",
-        splitter_id: "base_v0",
-        max_chunk_size: 256,
-
         embedder_config: {
           embedder: {
             max_chunk_size: 256,

--- a/front/pages/api/w/[wId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/index.ts
@@ -142,12 +142,6 @@ async function handler(
         projectId: dustProject.value.project.project_id.toString(),
         dataSourceId: req.body.name as string,
         config: {
-          // TODO(2024-05-27 flav) Remove once migrated to embedder.
-          provider_id: EMBEDDING_CONFIG.provider_id,
-          model_id: EMBEDDING_CONFIG.model_id,
-          splitter_id: EMBEDDING_CONFIG.splitter_id,
-          max_chunk_size: EMBEDDING_CONFIG.max_chunk_size,
-
           qdrant_config: {
             cluster: DEFAULT_QDRANT_CLUSTER,
             shadow_write_cluster: null,

--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -286,12 +286,6 @@ async function handler(
         projectId: dustProject.value.project.project_id.toString(),
         dataSourceId: dataSourceName,
         config: {
-          // TODO(2024-05-27 flav) Remove once migrated to embedder.
-          provider_id: EMBEDDING_CONFIG.provider_id,
-          model_id: EMBEDDING_CONFIG.model_id,
-          splitter_id: EMBEDDING_CONFIG.splitter_id,
-          max_chunk_size: EMBEDDING_CONFIG.max_chunk_size,
-
           embedder_config: {
             embedder: {
               max_chunk_size: EMBEDDING_CONFIG.max_chunk_size,

--- a/types/src/core/data_source.ts
+++ b/types/src/core/data_source.ts
@@ -13,12 +13,6 @@ interface EmbedderConfigType {
 }
 
 export type CoreAPIDataSourceConfig = {
-  // TODO(2024-05-27 flav) Remove once migrated to embedder.
-  provider_id: string;
-  model_id: string;
-  splitter_id: string;
-  max_chunk_size: number;
-
   embedder_config: EmbedderConfigType;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Following the changes in https://github.com/dust-tt/dust/pull/5284, all data sources have been backfilled to use the new embedder config structure. This PR deprecates the legacy embedder config and includes the following updates:
- Updates the core logic to use the new embedder config.
- Refactor  the core types to remove deprecated fields.
- Adjusts the types and API definition to exclude the legacy format.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
Worst case it breaks data sources in core. Safe to rollback but it will required to backfill the missing information.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
⚠️ First need to deploy `core` and then deploy `front`.
