### PR TITLE
Added a way to disconnect transcriptions

### DIFF
--- a/front/lib/labs/config.ts
+++ b/front/lib/labs/config.ts
@@ -1,5 +1,5 @@
 import type { LabsConnectorProvider } from "@dust-tt/types";
-import { assertNever,EnvironmentConfig } from "@dust-tt/types";
+import { assertNever, EnvironmentConfig } from "@dust-tt/types";
 
 const config = {
   getNangoPublicKey: (): string => {
@@ -11,13 +11,15 @@ const config = {
   getNangoConnectorIdForProvider: (provider: LabsConnectorProvider): string => {
     switch (provider) {
       case "google_drive":
-        return EnvironmentConfig.getEnvVariable("NANGO_GOOGLE_DRIVE_CONNECTOR_ID");
+        return EnvironmentConfig.getEnvVariable(
+          "NANGO_GOOGLE_DRIVE_CONNECTOR_ID"
+        );
       case "gong":
         return EnvironmentConfig.getEnvVariable("NANGO_GONG_CONNECTOR_ID");
       default:
         assertNever(provider);
     }
-  }
+  },
 };
 
 export default config;

--- a/front/lib/labs/config.ts
+++ b/front/lib/labs/config.ts
@@ -1,4 +1,5 @@
-import { EnvironmentConfig } from "@dust-tt/types";
+import type { LabsConnectorProvider } from "@dust-tt/types";
+import { assertNever,EnvironmentConfig } from "@dust-tt/types";
 
 const config = {
   getNangoPublicKey: (): string => {
@@ -7,12 +8,16 @@ const config = {
   getNangoSecretKey: (): string => {
     return EnvironmentConfig.getEnvVariable("NANGO_SECRET_KEY");
   },
-  getNangoGoogleDriveConnectorId: (): string => {
-    return EnvironmentConfig.getEnvVariable("NANGO_GOOGLE_DRIVE_CONNECTOR_ID");
-  },
-  getNangoGongConnectorId: (): string => {
-    return EnvironmentConfig.getEnvVariable("NANGO_GONG_CONNECTOR_ID");
-  },
+  getNangoConnectorIdForProvider: (provider: LabsConnectorProvider): string => {
+    switch (provider) {
+      case "google_drive":
+        return EnvironmentConfig.getEnvVariable("NANGO_GOOGLE_DRIVE_CONNECTOR_ID");
+      case "gong":
+        return EnvironmentConfig.getEnvVariable("NANGO_GONG_CONNECTOR_ID");
+      default:
+        assertNever(provider);
+    }
+  }
 };
 
 export default config;

--- a/front/lib/labs/transcripts/utils/helpers.ts
+++ b/front/lib/labs/transcripts/utils/helpers.ts
@@ -2,9 +2,9 @@ import type {
   ModelId,
   NangoConnectionId,
   NangoIntegrationId,
-  Result
+  Result,
 } from "@dust-tt/types";
-import { Err,Ok } from "@dust-tt/types";
+import { Err, Ok } from "@dust-tt/types";
 import { Nango } from "@nangohq/node";
 import { google } from "googleapis";
 import type { OAuth2Client } from "googleapis-common";

--- a/front/lib/labs/transcripts/utils/helpers.ts
+++ b/front/lib/labs/transcripts/utils/helpers.ts
@@ -2,7 +2,9 @@ import type {
   ModelId,
   NangoConnectionId,
   NangoIntegrationId,
+  Result
 } from "@dust-tt/types";
+import { Err,Ok } from "@dust-tt/types";
 import { Nango } from "@nangohq/node";
 import { google } from "googleapis";
 import type { OAuth2Client } from "googleapis-common";
@@ -10,6 +12,7 @@ import type { OAuth2Client } from "googleapis-common";
 import type { Authenticator } from "@app/lib/auth";
 import config from "@app/lib/labs/config";
 import { LabsTranscriptsConfigurationResource } from "@app/lib/resources/labs_transcripts_resource";
+import logger from "@app/logger/logger";
 
 const nango = new Nango({ secretKey: config.getNangoSecretKey() });
 
@@ -50,7 +53,7 @@ export async function getTranscriptsGoogleAuth(
   }
 
   return getGoogleAuthObject(
-    config.getNangoGoogleDriveConnectorId(),
+    config.getNangoConnectorIdForProvider("google_drive"),
     transcriptsConfiguration.connectionId
   );
 }
@@ -62,4 +65,39 @@ export async function getAccessTokenFromNango(
   const res = await nango.getConnection(nangoIntegrationId, nangoConnectionId);
 
   return res.credentials.raw.access_token;
+}
+
+export async function nangoDeleteConnection(
+  connectionId: string,
+  providerConfigKey: string
+): Promise<Result<undefined, Error>> {
+  const url = `${nango.serverUrl}/connection/${connectionId}?provider_config_key=${providerConfigKey}`;
+  const headers = {
+    "Content-Type": "application/json",
+    "Accept-Encoding": "application/json",
+    Authorization: `Bearer ${nango.secretKey}`,
+  };
+  const res = await fetch(url, {
+    method: "DELETE",
+    headers,
+  });
+  if (res.ok) {
+    return new Ok(undefined);
+  } else {
+    logger.error({ connectionId }, "Could not delete Nango connection.");
+    if (res) {
+      if (res.status === 404) {
+        logger.error({ connectionId }, "Connection not found on Nango.");
+        return new Ok(undefined);
+      }
+
+      return new Err(
+        new Error(
+          `Could not delete connection. ${res.statusText}, ${await res.text()}`
+        )
+      );
+    }
+
+    return new Err(new Error(`Could not delete connection.`));
+  }
 }

--- a/front/lib/resources/labs_transcripts_resource.ts
+++ b/front/lib/resources/labs_transcripts_resource.ts
@@ -1,4 +1,4 @@
-import type { Result } from "@dust-tt/types";
+import type { LabsConnectorProvider,Result } from "@dust-tt/types";
 import { Err, Ok } from "@dust-tt/types";
 import type {
   Attributes,
@@ -9,6 +9,8 @@ import type {
 import type { CreationAttributes } from "sequelize";
 
 import type { Authenticator } from "@app/lib/auth";
+import config from "@app/lib/labs/config";
+import { nangoDeleteConnection } from "@app/lib/labs/transcripts/utils/helpers";
 import { User } from "@app/lib/models/user";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { LabsTranscriptsConfigurationModel } from "@app/lib/resources/storage/models/labs_transcripts";
@@ -78,10 +80,12 @@ export class LabsTranscriptsConfigurationResource extends BaseResource<LabsTrans
       : null;
   }
 
-  static async findByWorkspace({
+  static async findByWorkspaceAndProvider({
     auth,
+    provider,
   }: {
     auth: Authenticator;
+    provider: LabsConnectorProvider;
   }): Promise<LabsTranscriptsConfigurationResource | null> {
     const owner = auth.workspace();
 
@@ -92,6 +96,7 @@ export class LabsTranscriptsConfigurationResource extends BaseResource<LabsTrans
     const configuration = await LabsTranscriptsConfigurationModel.findOne({
       where: {
         workspaceId: owner.id,
+        provider,
       },
     });
 
@@ -139,14 +144,26 @@ export class LabsTranscriptsConfigurationResource extends BaseResource<LabsTrans
 
   async delete(transaction?: Transaction): Promise<Result<undefined, Error>> {
     try {
+      const count = await this.model.count({
+        where: {
+          workspaceId: this.workspaceId,
+          connectionId: this.connectionId,
+        },
+      });
+
+      // If this is the last configuration using this connection, delete the connection
+      if (count <= 1) {
+        await nangoDeleteConnection(this.connectionId, config.getNangoConnectorIdForProvider(this.provider))
+      }
+      
+      await this.deleteHistory(transaction);
+
       await this.model.destroy({
         where: {
           id: this.id,
         },
         transaction,
       });
-
-      await this.deleteHistory(transaction);
 
       return new Ok(undefined);
     } catch (err) {

--- a/front/lib/resources/labs_transcripts_resource.ts
+++ b/front/lib/resources/labs_transcripts_resource.ts
@@ -1,4 +1,4 @@
-import type { LabsConnectorProvider,Result } from "@dust-tt/types";
+import type { LabsConnectorProvider, Result } from "@dust-tt/types";
 import { Err, Ok } from "@dust-tt/types";
 import type {
   Attributes,
@@ -153,9 +153,12 @@ export class LabsTranscriptsConfigurationResource extends BaseResource<LabsTrans
 
       // If this is the last configuration using this connection, delete the connection
       if (count <= 1) {
-        await nangoDeleteConnection(this.connectionId, config.getNangoConnectorIdForProvider(this.provider))
+        await nangoDeleteConnection(
+          this.connectionId,
+          config.getNangoConnectorIdForProvider(this.provider)
+        );
       }
-      
+
       await this.deleteHistory(transaction);
 
       await this.model.destroy({

--- a/front/pages/api/w/[wId]/labs/transcripts/default.ts
+++ b/front/pages/api/w/[wId]/labs/transcripts/default.ts
@@ -1,12 +1,19 @@
 import type { WithAPIErrorReponse } from "@dust-tt/types";
+import { isLeft } from "fp-ts/lib/Either";
+import * as t from "io-ts";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { Authenticator, getSession } from "@app/lib/auth";
 import { LabsTranscriptsConfigurationResource } from "@app/lib/resources/labs_transcripts_resource";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import type { GetLabsTranscriptsConfigurationResponseBody } from "@app/pages/api/w/[wId]/labs/transcripts";
+import { acceptableTranscriptProvidersCodec } from "@app/pages/api/w/[wId]/labs/transcripts";
 
 const PROVIDERS_WITH_WORKSPACE_CONFIGURATIONS = ["gong"];
+
+export const GetDefaultTranscriptsConfigurationBodySchema = t.type({
+  provider: acceptableTranscriptProvidersCodec,
+});
 
 async function handler(
   req: NextApiRequest,
@@ -45,9 +52,24 @@ async function handler(
 
   switch (req.method) {
     case "GET":
+      const bodyValidation = GetDefaultTranscriptsConfigurationBodySchema.decode(req.query);
+
+      if (isLeft(bodyValidation)) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Invalid request.",
+          },
+        });
+      }
+
+      const { provider } = bodyValidation.right
+
       const transcriptsConfiguration =
-        await LabsTranscriptsConfigurationResource.findByWorkspace({
+        await LabsTranscriptsConfigurationResource.findByWorkspaceAndProvider({
           auth,
+          provider
         });
 
       if (!transcriptsConfiguration) {

--- a/front/pages/api/w/[wId]/labs/transcripts/default.ts
+++ b/front/pages/api/w/[wId]/labs/transcripts/default.ts
@@ -52,7 +52,8 @@ async function handler(
 
   switch (req.method) {
     case "GET":
-      const bodyValidation = GetDefaultTranscriptsConfigurationBodySchema.decode(req.query);
+      const bodyValidation =
+        GetDefaultTranscriptsConfigurationBodySchema.decode(req.query);
 
       if (isLeft(bodyValidation)) {
         return apiError(req, res, {
@@ -64,12 +65,12 @@ async function handler(
         });
       }
 
-      const { provider } = bodyValidation.right
+      const { provider } = bodyValidation.right;
 
       const transcriptsConfiguration =
         await LabsTranscriptsConfigurationResource.findByWorkspaceAndProvider({
           auth,
-          provider
+          provider,
         });
 
       if (!transcriptsConfiguration) {

--- a/front/pages/api/w/[wId]/labs/transcripts/index.ts
+++ b/front/pages/api/w/[wId]/labs/transcripts/index.ts
@@ -66,12 +66,8 @@ async function handler(
         });
 
       if (!transcriptsConfiguration) {
-        return apiError(req, res, {
-          status_code: 404,
-          api_error: {
-            type: "agent_configuration_not_found",
-            message: "The configuration was not found.",
-          },
+        return res.status(200).json({
+          configuration: null,
         });
       }
 

--- a/front/pages/w/[wId]/assistant/labs/transcripts/index.tsx
+++ b/front/pages/w/[wId]/assistant/labs/transcripts/index.tsx
@@ -7,7 +7,8 @@ import {
   SliderToggle,
   Spinner,
   Tooltip,
-  XMarkIcon} from "@dust-tt/sparkle";
+  XMarkIcon,
+} from "@dust-tt/sparkle";
 import type {
   LabsTranscriptsProviderType,
   UserType,
@@ -64,7 +65,8 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       user,
       subscription,
       gaTrackingId: apiConfig.getGaTrackingId(),
-      nangoDriveConnectorId: config.getNangoConnectorIdForProvider("google_drive"),
+      nangoDriveConnectorId:
+        config.getNangoConnectorIdForProvider("google_drive"),
       nangoGongConnectorId: config.getNangoConnectorIdForProvider("gong"),
       nangoPublicKey: config.getNangoPublicKey(),
     },
@@ -81,7 +83,8 @@ export default function LabsTranscriptsIndex({
   nangoPublicKey,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const sendNotification = useContext(SendNotificationsContext);
-  const [isDeleteProviderDialogOpen, setIsDeleteProviderDialogOpen] = useState(false);
+  const [isDeleteProviderDialogOpen, setIsDeleteProviderDialogOpen] =
+    useState(false);
 
   const { agentConfigurations } = useAgentConfigurations({
     workspaceId: owner.sId,
@@ -364,8 +367,7 @@ export default function LabsTranscriptsIndex({
   };
 
   const handleDisconnectProvider = async () => {
-
-    if(!transcriptsConfiguration) {
+    if (!transcriptsConfiguration) {
       return;
     }
 
@@ -388,7 +390,7 @@ export default function LabsTranscriptsIndex({
     }
 
     return response;
-  }
+  };
 
   return (
     <AppLayout
@@ -399,9 +401,20 @@ export default function LabsTranscriptsIndex({
       pageTitle="Dust - Transcripts processing"
       navChildren={<AssistantSidebarMenu owner={owner} />}
     >
-       <Dialog isOpen={isDeleteProviderDialogOpen} title="Disconnect transcripts provider" onValidate={async () => await handleDisconnectProvider() && setIsDeleteProviderDialogOpen(false)} onCancel={() => setIsDeleteProviderDialogOpen(false)}>
-          <div>This will stop the processing of your meeting transcripts. You can reconnect anytime.</div>
-        </Dialog>
+      <Dialog
+        isOpen={isDeleteProviderDialogOpen}
+        title="Disconnect transcripts provider"
+        onValidate={async () =>
+          (await handleDisconnectProvider()) &&
+          setIsDeleteProviderDialogOpen(false)
+        }
+        onCancel={() => setIsDeleteProviderDialogOpen(false)}
+      >
+        <div>
+          This will stop the processing of your meeting transcripts. You can
+          reconnect anytime.
+        </div>
+      </Dialog>
       <Page>
         <Page.Header
           title="Transcripts processing"
@@ -460,33 +473,35 @@ export default function LabsTranscriptsIndex({
               {transcriptsConfigurationState.isGDriveConnected ? (
                 <Page.Layout direction="horizontal">
                   <Button
-                  label="Google connected"
-                  size="sm"
-                  icon={CloudArrowLeftRightIcon}
-                  disabled={true}
-                />
-                <Button label="Disconnect"
-                  icon={XMarkIcon}
-                  size="sm"
-                  variant="secondary"
-                  onClick={() => setIsDeleteProviderDialogOpen(true)} />
+                    label="Google connected"
+                    size="sm"
+                    icon={CloudArrowLeftRightIcon}
+                    disabled={true}
+                  />
+                  <Button
+                    label="Disconnect"
+                    icon={XMarkIcon}
+                    size="sm"
+                    variant="secondary"
+                    onClick={() => setIsDeleteProviderDialogOpen(true)}
+                  />
                 </Page.Layout>
               ) : (
                 <>
-              <Page.P>
-                Connect to Google Drive so Dust can access 'My Drive' where your
-                meeting transcripts are stored.
-              </Page.P>
-              <div>
-                <Button
-                  label="Connect Google"
-                  size="sm"
-                  icon={CloudArrowLeftRightIcon}
-                  onClick={async () => {
-                    await handleConnectGoogleTranscriptsSource();
-                  }}
-                />
-                </div>
+                  <Page.P>
+                    Connect to Google Drive so Dust can access 'My Drive' where
+                    your meeting transcripts are stored.
+                  </Page.P>
+                  <div>
+                    <Button
+                      label="Connect Google"
+                      size="sm"
+                      icon={CloudArrowLeftRightIcon}
+                      onClick={async () => {
+                        await handleConnectGoogleTranscriptsSource();
+                      }}
+                    />
+                  </div>
                 </>
               )}
             </Page.Layout>
@@ -495,34 +510,36 @@ export default function LabsTranscriptsIndex({
             <Page.Layout direction="vertical">
               {transcriptsConfigurationState.isGongConnected ? (
                 <Page.Layout direction="horizontal">
-                <Button
-                label="Gong connected"
-                size="sm"
-                icon={CloudArrowLeftRightIcon}
-                disabled={true}
-              />
-              <Button label="Disconnect"
-                icon={XMarkIcon}
-                size="sm"
-                variant="secondary"
-                onClick={() => setIsDeleteProviderDialogOpen(true)} />
-              </Page.Layout>
+                  <Button
+                    label="Gong connected"
+                    size="sm"
+                    icon={CloudArrowLeftRightIcon}
+                    disabled={true}
+                  />
+                  <Button
+                    label="Disconnect"
+                    icon={XMarkIcon}
+                    size="sm"
+                    variant="secondary"
+                    onClick={() => setIsDeleteProviderDialogOpen(true)}
+                  />
+                </Page.Layout>
               ) : (
                 <>
-              <Page.P>
-                Connect to Gong so Dust can access your meeting transcripts.
-              </Page.P>
-              <div>
-                <Button
-                  label="Connect Gong"
-                  size="sm"
-                  icon={CloudArrowLeftRightIcon}
-                  onClick={async () => {
-                    await handleConnectGongTranscriptsSource();
-                  }}
-                />
-              </div>
-              </>
+                  <Page.P>
+                    Connect to Gong so Dust can access your meeting transcripts.
+                  </Page.P>
+                  <div>
+                    <Button
+                      label="Connect Gong"
+                      size="sm"
+                      icon={CloudArrowLeftRightIcon}
+                      onClick={async () => {
+                        await handleConnectGongTranscriptsSource();
+                      }}
+                    />
+                  </div>
+                </>
               )}
             </Page.Layout>
           )}

--- a/front/pages/w/[wId]/assistant/labs/transcripts/index.tsx
+++ b/front/pages/w/[wId]/assistant/labs/transcripts/index.tsx
@@ -83,7 +83,7 @@ export default function LabsTranscriptsIndex({
   nangoPublicKey,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const sendNotification = useContext(SendNotificationsContext);
-  const [isDeleteProviderDialogOpen, setIsDeleteProviderDialogOpen] =
+  const [isDeleteProviderDialogOpened, setIsDeleteProviderDialogOpened] =
     useState(false);
 
   const { agentConfigurations } = useAgentConfigurations({

--- a/front/pages/w/[wId]/assistant/labs/transcripts/index.tsx
+++ b/front/pages/w/[wId]/assistant/labs/transcripts/index.tsx
@@ -404,10 +404,10 @@ export default function LabsTranscriptsIndex({
       <Dialog
         isOpen={isDeleteProviderDialogOpen}
         title="Disconnect transcripts provider"
-        onValidate={async () =>
-          (await handleDisconnectProvider()) &&
-          setIsDeleteProviderDialogOpen(false)
-        }
+        onValidate={async () => {
+          await handleDisconnectProvider();
+          setIsDeleteProviderDialogOpen(false);
+        }}
         onCancel={() => setIsDeleteProviderDialogOpen(false)}
       >
         <div>

--- a/front/temporal/labs/utils/gong.ts
+++ b/front/temporal/labs/utils/gong.ts
@@ -26,7 +26,7 @@ export async function retrieveGongTranscripts(
   }
 
   const gongAccessToken = await getAccessTokenFromNango(
-    config.getNangoGongConnectorId(),
+    config.getNangoConnectorIdForProvider("gong"),
     transcriptsConfiguration.connectionId
   );
 
@@ -113,7 +113,7 @@ export async function retrieveGongTranscriptContent(
   }
 
   const gongAccessToken = await getAccessTokenFromNango(
-    config.getNangoGongConnectorId(),
+    config.getNangoConnectorIdForProvider("gong"),
     transcriptsConfiguration.connectionId
   );
 

--- a/types/src/front/data_source.ts
+++ b/types/src/front/data_source.ts
@@ -12,7 +12,7 @@ export const CONNECTOR_PROVIDERS = [
 ] as const;
 export type ConnectorProvider = (typeof CONNECTOR_PROVIDERS)[number];
 
-export type LabsConnectorProvider = ConnectorProvider | "gong";
+export type LabsConnectorProvider = "google_drive" | "gong";
 
 export function isConnectorProvider(val: string): val is ConnectorProvider {
   return (CONNECTOR_PROVIDERS as unknown as string[]).includes(val);


### PR DESCRIPTION
## Description

After discussion with a few customers, looks like people might have different transcripts providers accross one company. 
- Added a way to disconnect your own current provider
- If it's the last user using that provider, also remove the nango connection 
- Find default connection becomes linked to workspace/provider as discussed @flvndvd 
<img width="635" alt="Screenshot 2024-05-28 at 14 23 20" src="https://github.com/dust-tt/dust/assets/1189312/931439f1-5d26-4b7e-85fe-f62f9537800a">
<img width="666" alt="Screenshot 2024-05-28 at 14 23 18" src="https://github.com/dust-tt/dust/assets/1189312/6d2d7f8d-1267-49f8-a273-674353deb033">


## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
