### PR TITLE
enh: reduce resources allocated to notion connector worker

### DIFF
--- a/k8s/deployments/connectors-worker-notion-deployment.yaml
+++ b/k8s/deployments/connectors-worker-notion-deployment.yaml
@@ -43,14 +43,12 @@ spec:
 
           resources:
             requests:
-              cpu: 3000m
-              memory: 8Gi
-              ephemeral-storage: 4Gi
+              cpu: 2000m
+              memory: 4Gi
 
             limits:
-              cpu: 3000m
-              memory: 8Gi
-              ephemeral-storage: 4Gi
+              cpu: 2000m
+              memory: 4Gi
 
       volumes:
         - name: cert-volume


### PR DESCRIPTION
## Description

- 8gb is not only too much, it is entirely useless since `max-old-space-size` limits max usage to 4gb
- CPU is only used when we deploy (to build the temporal workflows)

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
