### PR TITLE
[Members page] Prefill invitation box with search text content

### DIFF
--- a/front/components/members/InvitationModal.tsx
+++ b/front/components/members/InvitationModal.tsx
@@ -16,7 +16,7 @@ import type {
   UserTypeWithWorkspaces,
   WorkspaceType,
 } from "@dust-tt/types";
-import { useContext, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 import { mutate } from "swr";
 
 import type { ConfirmDataType } from "@app/components/Confirm";
@@ -43,12 +43,14 @@ export function InviteEmailModal({
   onClose,
   owner,
   plan,
+  prefillText,
   members,
 }: {
   showModal: boolean;
   onClose: () => void;
   owner: WorkspaceType;
   plan: PlanType;
+  prefillText: string;
   members: UserTypeWithWorkspaces[];
 }) {
   const [inviteEmails, setInviteEmails] = useState<string>("");
@@ -189,6 +191,17 @@ export function InviteEmailModal({
       onClose();
     }
   }
+
+  useEffect(() => {
+    if (showModal && prefillText && isEmailValid(prefillText)) {
+      setInviteEmails((prev) => {
+        if (prev.includes(prefillText)) {
+          return prev;
+        }
+        return prev ? prev + ", " + prefillText : prefillText;
+      });
+    }
+  }, [prefillText, showModal]);
 
   return (
     <>

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -232,6 +232,7 @@ export default function WorkspaceAdmin({
             setInviteEmailModalOpen(false);
           }}
           owner={owner}
+          prefillText={searchText}
           members={members}
           plan={plan}
         />


### PR DESCRIPTION
Description
---
Fixes https://github.com/dust-tt/tasks/issues/303

Will only prefill if the content is a valid email that is not already in the email list (from previous state)

Risks
---
Virtually none

Deploy
---
Front
