### PR TITLE
[core] - chore(core): favor api keys in data sources

### DIFF
--- a/core/src/providers/mistral.rs
+++ b/core/src/providers/mistral.rs
@@ -796,20 +796,26 @@ impl LLM for MistralAILLM {
     fn id(&self) -> String {
         self.id.clone()
     }
-
     async fn initialize(&mut self, credentials: Credentials) -> Result<()> {
-        match credentials.get("MISTRAL_API_KEY") {
-            Some(api_key) => {
-                self.api_key = Some(api_key.clone());
+        match std::env::var("CORE_DATA_SOURCES_MISTRAL_API_KEY") {
+            Ok(key) => {
+                self.api_key = Some(key);
             }
-            None => match tokio::task::spawn_blocking(|| std::env::var("MISTRAL_API_KEY")).await? {
-                Ok(key) => {
-                    self.api_key = Some(key);
+            Err(_) => {
+                match credentials.get("MISTRAL_API_KEY") {
+                    Some(api_key) => {
+                        self.api_key = Some(api_key.clone());
+                    }
+                    None => match tokio::task::spawn_blocking(|| std::env::var("MISTRAL_API_KEY")).await? {
+                        Ok(key) => {
+                            self.api_key = Some(key);
+                        }
+                        Err(_) => Err(anyhow!(
+                            "Credentials or environment variable `MISTRAL_API_KEY` is not set."
+                        ))?,
+                    },
                 }
-                Err(_) => Err(anyhow!(
-                    "Credentials or environment variable `MISTRAL_API_KEY` is not set."
-                ))?,
-            },
+            }
         }
         Ok(())
     }

--- a/core/src/providers/mistral.rs
+++ b/core/src/providers/mistral.rs
@@ -801,21 +801,21 @@ impl LLM for MistralAILLM {
             Ok(key) => {
                 self.api_key = Some(key);
             }
-            Err(_) => {
-                match credentials.get("MISTRAL_API_KEY") {
-                    Some(api_key) => {
-                        self.api_key = Some(api_key.clone());
-                    }
-                    None => match tokio::task::spawn_blocking(|| std::env::var("MISTRAL_API_KEY")).await? {
+            Err(_) => match credentials.get("MISTRAL_API_KEY") {
+                Some(api_key) => {
+                    self.api_key = Some(api_key.clone());
+                }
+                None => {
+                    match tokio::task::spawn_blocking(|| std::env::var("MISTRAL_API_KEY")).await? {
                         Ok(key) => {
                             self.api_key = Some(key);
                         }
                         Err(_) => Err(anyhow!(
                             "Credentials or environment variable `MISTRAL_API_KEY` is not set."
                         ))?,
-                    },
+                    }
                 }
-            }
+            },
         }
         Ok(())
     }

--- a/core/src/providers/mistral.rs
+++ b/core/src/providers/mistral.rs
@@ -805,16 +805,14 @@ impl LLM for MistralAILLM {
                 Some(api_key) => {
                     self.api_key = Some(api_key.clone());
                 }
-                None => {
-                    match tokio::task::spawn_blocking(|| std::env::var("MISTRAL_API_KEY")).await? {
-                        Ok(key) => {
-                            self.api_key = Some(key);
-                        }
-                        Err(_) => Err(anyhow!(
-                            "Credentials or environment variable `MISTRAL_API_KEY` is not set."
-                        ))?,
+                None => match std::env::var("MISTRAL_API_KEY") {
+                    Ok(key) => {
+                        self.api_key = Some(key);
                     }
-                }
+                    Err(_) => Err(anyhow!(
+                        "Credentials or environment variable `MISTRAL_API_KEY` is not set."
+                    ))?,
+                },
             },
         }
         Ok(())

--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -1416,25 +1416,25 @@ impl LLM for OpenAILLM {
 
     async fn initialize(&mut self, credentials: Credentials) -> Result<()> {
         // Give priority to `CORE_DATA_SOURCES_OPENAI_API_KEY` env variable
-        match std::env::var("CORE_DATA_SOURCES_OPENAI_API_KEY"){
+        match std::env::var("CORE_DATA_SOURCES_OPENAI_API_KEY") {
             Ok(key) => {
                 self.api_key = Some(key);
             }
-            Err(_) => {
-                match credentials.get("OPENAI_API_KEY") {
-                    Some(api_key) => {
-                        self.api_key = Some(api_key.clone());
-                    }
-                    None => match tokio::task::spawn_blocking(|| std::env::var("OPENAI_API_KEY")).await? {
+            Err(_) => match credentials.get("OPENAI_API_KEY") {
+                Some(api_key) => {
+                    self.api_key = Some(api_key.clone());
+                }
+                None => {
+                    match tokio::task::spawn_blocking(|| std::env::var("OPENAI_API_KEY")).await? {
                         Ok(key) => {
                             self.api_key = Some(key);
                         }
                         Err(_) => Err(anyhow!(
                             "Credentials or environment variable `OPENAI_API_KEY` is not set."
                         ))?,
-                    },
+                    }
                 }
-            }
+            },
         }
         Ok(())
     }

--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -1415,18 +1415,27 @@ impl LLM for OpenAILLM {
     }
 
     async fn initialize(&mut self, credentials: Credentials) -> Result<()> {
-        match credentials.get("OPENAI_API_KEY") {
-            Some(api_key) => {
-                self.api_key = Some(api_key.clone());
+        // Give priority to `CORE_DATA_SOURCES_OPENAI_API_KEY` env variable
+        match std::env::var("CORE_DATA_SOURCES_OPENAI_API_KEY"){
+            Ok(key) => {
+                self.api_key = Some(key);
+                println!("YEAHHHHHHHHH")
             }
-            None => match tokio::task::spawn_blocking(|| std::env::var("OPENAI_API_KEY")).await? {
-                Ok(key) => {
-                    self.api_key = Some(key);
+            Err(_) => {
+                match credentials.get("OPENAI_API_KEY") {
+                    Some(api_key) => {
+                        self.api_key = Some(api_key.clone());
+                    }
+                    None => match tokio::task::spawn_blocking(|| std::env::var("OPENAI_API_KEY")).await? {
+                        Ok(key) => {
+                            self.api_key = Some(key);
+                        }
+                        Err(_) => Err(anyhow!(
+                            "Credentials or environment variable `OPENAI_API_KEY` is not set."
+                        ))?,
+                    },
                 }
-                Err(_) => Err(anyhow!(
-                    "Credentials or environment variable `OPENAI_API_KEY` is not set."
-                ))?,
-            },
+            }
         }
         Ok(())
     }

--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -1419,7 +1419,6 @@ impl LLM for OpenAILLM {
         match std::env::var("CORE_DATA_SOURCES_OPENAI_API_KEY"){
             Ok(key) => {
                 self.api_key = Some(key);
-                println!("YEAHHHHHHHHH")
             }
             Err(_) => {
                 match credentials.get("OPENAI_API_KEY") {

--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -1424,16 +1424,14 @@ impl LLM for OpenAILLM {
                 Some(api_key) => {
                     self.api_key = Some(api_key.clone());
                 }
-                None => {
-                    match tokio::task::spawn_blocking(|| std::env::var("OPENAI_API_KEY")).await? {
-                        Ok(key) => {
-                            self.api_key = Some(key);
-                        }
-                        Err(_) => Err(anyhow!(
-                            "Credentials or environment variable `OPENAI_API_KEY` is not set."
-                        ))?,
+                None => match std::env::var("OPENAI_API_KEY") {
+                    Ok(key) => {
+                        self.api_key = Some(key);
                     }
-                }
+                    Err(_) => Err(anyhow!(
+                        "Credentials or environment variable `OPENAI_API_KEY` is not set."
+                    ))?,
+                },
             },
         }
         Ok(())


### PR DESCRIPTION
## Description

This PR aims at using core API keys over Dust's keys in datasource blocks (c.f. https://github.com/dust-tt/tasks/issues/6750)

## Risk

We are dealing with secrets so let's make sure they don't leak.

## Deploy Plan

Create secrets in k8s -> deploy `core`