### PR TITLE
chore: keep track of workpsace last cancel and last reupgrade

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -53,6 +53,7 @@ import {
   MembershipInvitation,
   Workspace,
   WorkspaceHasDomain,
+  WorkspaceMetadata,
 } from "@app/lib/models/workspace";
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
 import { KeyModel } from "@app/lib/resources/storage/models/keys";
@@ -126,6 +127,8 @@ async function main() {
   await ConversationClassification.sync({ alter: true });
 
   await TemplateModel.sync({ alter: true });
+
+  await WorkspaceMetadata.sync({ alter: true });
 
   // Labs - Can be removed at all times if a solution is dropped
   await LabsTranscriptsConfigurationModel.sync({ alter: true });

--- a/front/lib/models/workspace.ts
+++ b/front/lib/models/workspace.ts
@@ -255,3 +255,58 @@ User.hasMany(DustAppSecret, {
   onDelete: "SET NULL",
 });
 DustAppSecret.belongsTo(User);
+
+// This table is used to store information that is not needed in the business logic but is useful for
+// analytics / business operations.
+// It's a 1:1 relationship with the workspace table.
+export class WorkspaceMetadata extends Model<
+  InferAttributes<WorkspaceMetadata>,
+  InferCreationAttributes<WorkspaceMetadata>
+> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare lastCancelAt: Date | null;
+  declare lastReupgradeAt: Date | null;
+
+  declare workspaceId: ForeignKey<Workspace["id"]>;
+}
+WorkspaceMetadata.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    lastCancelAt: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    },
+    lastReupgradeAt: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    },
+  },
+  {
+    modelName: "workspace_metadata",
+    sequelize: frontSequelize,
+    indexes: [{ fields: ["workspaceId"], unique: true }],
+  }
+);
+
+Workspace.hasOne(WorkspaceMetadata, {
+  foreignKey: { allowNull: false },
+  onDelete: "CASCADE",
+});
+WorkspaceMetadata.belongsTo(Workspace);

--- a/front/lib/tracking/database/server.ts
+++ b/front/lib/tracking/database/server.ts
@@ -1,0 +1,45 @@
+import type { LightWorkspaceType } from "@dust-tt/types";
+
+import { WorkspaceMetadata } from "@app/lib/models/workspace";
+
+export class DatabaseServerSideTracking {
+  static async trackSubscriptionCancel({
+    workspace,
+    cancelAt,
+  }: {
+    workspace: LightWorkspaceType;
+    cancelAt?: Date;
+  }) {
+    const ts = cancelAt || new Date();
+
+    await WorkspaceMetadata.upsert(
+      {
+        workspaceId: workspace.id,
+        lastCancelAt: ts,
+      },
+      {
+        conflictFields: ["workspaceId"],
+      }
+    );
+  }
+
+  static async trackSubscriptionReupgrade({
+    workspace,
+    reupgradeAt,
+  }: {
+    workspace: LightWorkspaceType;
+    reupgradeAt?: Date;
+  }) {
+    const ts = reupgradeAt || new Date();
+
+    await WorkspaceMetadata.upsert(
+      {
+        workspaceId: workspace.id,
+        lastReupgradeAt: ts,
+      },
+      {
+        conflictFields: ["workspaceId"],
+      }
+    );
+  }
+}

--- a/front/lib/tracking/server.ts
+++ b/front/lib/tracking/server.ts
@@ -16,6 +16,7 @@ import { FREE_TEST_PLAN_CODE } from "@app/lib/plans/plan_codes";
 import { countActiveSeatsInWorkspaceCached } from "@app/lib/plans/usage/seats";
 import { AmplitudeServerSideTracking } from "@app/lib/tracking/amplitude/server";
 import { CustomerioServerSideTracking } from "@app/lib/tracking/customerio/server";
+import { DatabaseServerSideTracking } from "@app/lib/tracking/database/server";
 import logger from "@app/logger/logger";
 
 export class ServerSideTracking {
@@ -295,5 +296,35 @@ export class ServerSideTracking {
         "Failed to track update membership role on Customer.io"
       );
     }
+  }
+
+  static async trackSubscriptionCancel({
+    workspace,
+    cancelAt,
+  }: {
+    workspace: LightWorkspaceType;
+    cancelAt?: Date;
+  }) {
+    const ts = cancelAt || new Date();
+
+    await DatabaseServerSideTracking.trackSubscriptionCancel({
+      workspace,
+      cancelAt: ts,
+    });
+  }
+
+  static async trackSubscriptionReupgrade({
+    workspace,
+    reupgradeAt,
+  }: {
+    workspace: LightWorkspaceType;
+    reupgradeAt?: Date;
+  }) {
+    const ts = reupgradeAt || new Date();
+
+    await DatabaseServerSideTracking.trackSubscriptionReupgrade({
+      workspace,
+      reupgradeAt: ts,
+    });
   }
 }

--- a/front/migrations/db/migration_11.sql
+++ b/front/migrations/db/migration_11.sql
@@ -1,0 +1,3 @@
+-- Migration created on May 28, 2024
+CREATE TABLE IF NOT EXISTS "workspace_metadata" ("id"  SERIAL , "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL, "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL, "lastCancelAt" TIMESTAMP WITH TIME ZONE, "lastReupgradeAt" TIMESTAMP WITH TIME ZONE, "workspaceId" INTEGER NOT NULL REFERENCES "workspaces" ("id") ON DELETE CASCADE ON UPDATE CASCADE, PRIMARY KEY ("id"));
+CREATE UNIQUE INDEX "workspace_metadata_workspace_id" ON "workspace_metadata" ("workspaceId");

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -453,6 +453,29 @@ async function handler(
             if (!endDate) {
               // Subscription is re-activated, so we need to unpause the connectors in case they were paused.
               await unpauseAllConnectorsAndCancelScrub(auth);
+              // We also track the reactivation
+              void ServerSideTracking.trackSubscriptionReupgrade({
+                workspace: renderLightWorkspaceType({
+                  workspace: subscription.workspace,
+                }),
+              }).catch((e) => {
+                logger.error(
+                  { panic: true, error: e },
+                  "Error tracking subscription reupgrade."
+                );
+              });
+            } else {
+              // Subscription is canceled, we track it
+              void ServerSideTracking.trackSubscriptionCancel({
+                workspace: renderLightWorkspaceType({
+                  workspace: subscription.workspace,
+                }),
+              }).catch((e) => {
+                logger.error(
+                  { panic: true, error: e },
+                  "Error tracking subscription cancel."
+                );
+              });
             }
             // then email admins
             const adminEmails = (


### PR DESCRIPTION
## Description

https://github.com/dust-tt/tasks/issues/756

biz ops need a way to track "live" churn, and they need this both in customerio and in metabase.
For this, they would like 2 fields:
- lastCancelAt -> timestamp of the last time a customer cancelled their stripe subscription
- lastReupgradeAt -> timestamp of the last time a customer re-upgraded a previously cancelled subscription

The request was to have these fields on the workspace table. However, after some thinking, we feel it's better to have those in a separate table, so it doesn't impact core tables that are constantly fetched within the product. So I have added a `WorkspaceMetadata` table that has a 1:1 relationship with the `Workspace` table.

## Risk

- migration
- slightly touches the critical path (but non-awaited promise with a `.catch`)

## Deploy Plan

apply migration on prodbox then deploy