### PR TITLE
[Websearch] Increase results to 16

### DIFF
--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -76,10 +76,7 @@ export type AssistantBuilderProcessConfiguration = {
 };
 
 // Websearch configuration
-
-export type AssistantBuilderWebsearchConfiguration = {
-  searchResults: 8; // not configurable at the time of writing, placeholder
-};
+export type AssistantBuilderWebsearchConfiguration = Record<string, never>; // no relevant params identified yet
 
 // Builder State
 
@@ -230,9 +227,7 @@ export function getDefaultProcessActionConfiguration() {
 export function getDefaultWebsearchActionConfiguration(): AssistantBuilderActionConfiguration {
   return {
     type: "WEBSEARCH",
-    configuration: {
-      searchResults: 8,
-    },
+    configuration: {},
     name: "websearch",
     description: "Perform a web search.",
   };

--- a/types/src/front/lib/actions/registry.ts
+++ b/types/src/front/lib/actions/registry.ts
@@ -161,7 +161,7 @@ export const DustProdActionRegistry = createActionRegistry({
       workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
       appId: "098b515f8e",
       appHash:
-        "3573c1ea0502c882fc8748bfcb9f26e70fe623218d188d52255a4c794896fb6e",
+        "0ad751ed5f3e4a312dfe50ea1ec63bc8b31ebd5a77f580d71ec8c1af621891aa",
     },
     config: { SEARCH: { provider_id: "serpapi", use_cache: false } },
   },


### PR DESCRIPTION
Description
---

Following IRL discussion with @fontanierh  and @spolu
- no additional cost to request 16 results instead of 8;
- more than that doesn't seem useful (on the contrary, might make LLM's job harder if TMI);

This PR uses a version of the `assistant-v2-websearch` action with 16 as number of results in the `SEARCH` block

Also, removing the fake 'searchResults' configuration parameter

Note:
- adding search result number as a parameter for websearch in core is not immediate (the `num` is not part of config) and does not seem useful
- limiting number of results presented to model can be done simply in front via a config parameter, but waiting for the need for such a param to manifest before implementing--an additional parameter is additional complexity for builders, UX cluttering, etc.

Risk & Deploy
---
N/A
