### PR TITLE
Move tables_query action to new class pattern

### DIFF
--- a/front/lib/api/assistant/actions/dust_app_run.ts
+++ b/front/lib/api/assistant/actions/dust_app_run.ts
@@ -183,6 +183,12 @@ export class DustAppRunConfigurationServerRunner extends BaseActionConfiguration
     });
   }
 
+  async deprecatedBuildSpecificationForSingleActionAgent(
+    auth: Authenticator
+  ): Promise<Result<AgentActionSpecification, Error>> {
+    return this.buildSpecification(auth, {});
+  }
+
   // This method is in charge of running a dust app and creating an AgentDustAppRunAction object in
   // the database. It does not create any generic model related to the conversation. It is possible
   // for an AgentDustAppRunAction to be stored (once the params are infered) but for the dust app run

--- a/front/lib/api/assistant/actions/process.ts
+++ b/front/lib/api/assistant/actions/process.ts
@@ -168,6 +168,12 @@ export class ProcessConfigurationServerRunner extends BaseActionConfigurationSer
     return new Ok(spec);
   }
 
+  async deprecatedBuildSpecificationForSingleActionAgent(
+    auth: Authenticator
+  ): Promise<Result<AgentActionSpecification, Error>> {
+    return this.buildSpecification(auth, {});
+  }
+
   // This method is in charge of running the retrieval and creating an AgentProcessAction object in
   // the database. It does not create any generic model related to the conversation. It is possible
   // for an AgentProcessAction to be stored (once the query params are infered) but for its execution

--- a/front/lib/api/assistant/actions/runners.ts
+++ b/front/lib/api/assistant/actions/runners.ts
@@ -2,11 +2,13 @@ import type {
   AgentAction,
   DustAppRunConfigurationType,
   ProcessConfigurationType,
+  TablesQueryConfigurationType,
   WebsearchConfigurationType,
 } from "@dust-tt/types";
 
 import { DustAppRunConfigurationServerRunner } from "@app/lib/api/assistant/actions/dust_app_run";
 import { ProcessConfigurationServerRunner } from "@app/lib/api/assistant/actions/process";
+import { TablesQueryConfigurationServerRunner } from "@app/lib/api/assistant/actions/tables_query";
 import type {
   BaseActionConfigurationServerRunner,
   BaseActionConfigurationServerRunnerConstructor,
@@ -17,6 +19,7 @@ import { WebsearchConfigurationServerRunner } from "@app/lib/api/assistant/actio
 interface ActionToConfigTypeMap {
   dust_app_run_configuration: DustAppRunConfigurationType;
   process_configuration: ProcessConfigurationType;
+  tables_query_configuration: TablesQueryConfigurationType;
   websearch_configuration: WebsearchConfigurationType;
   // Add other configurations once migrated to classes.
 }
@@ -24,6 +27,7 @@ interface ActionToConfigTypeMap {
 interface ActionTypeToClassMap {
   dust_app_run_configuration: DustAppRunConfigurationServerRunner;
   process_configuration: ProcessConfigurationServerRunner;
+  tables_query_configuration: TablesQueryConfigurationServerRunner;
   websearch_configuration: WebsearchConfigurationServerRunner;
 }
 
@@ -65,6 +69,7 @@ export const ACTION_TYPE_TO_CONFIGURATION_SERVER_RUNNER: {
 } = {
   dust_app_run_configuration: DustAppRunConfigurationServerRunner,
   process_configuration: ProcessConfigurationServerRunner,
+  tables_query_configuration: TablesQueryConfigurationServerRunner,
   websearch_configuration: WebsearchConfigurationServerRunner,
 } as const;
 

--- a/front/lib/api/assistant/actions/types.ts
+++ b/front/lib/api/assistant/actions/types.ts
@@ -58,6 +58,10 @@ export abstract class BaseActionConfigurationServerRunner<
     { name, description }: { name?: string; description?: string }
   ): Promise<Result<AgentActionSpecification, Error>>;
 
+  abstract deprecatedBuildSpecificationForSingleActionAgent(
+    auth: Authenticator
+  ): Promise<Result<AgentActionSpecification, Error>>;
+
   // Action execution.
   abstract run(
     auth: Authenticator,

--- a/front/lib/api/assistant/actions/websearch.ts
+++ b/front/lib/api/assistant/actions/websearch.ts
@@ -127,6 +127,12 @@ export class WebsearchConfigurationServerRunner extends BaseActionConfigurationS
     });
   }
 
+  async deprecatedBuildSpecificationForSingleActionAgent(
+    auth: Authenticator
+  ): Promise<Result<AgentActionSpecification, Error>> {
+    return this.buildSpecification(auth, {});
+  }
+
   // This method is in charge of running the websearch and creating an AgentWebsearchAction object in
   // the database. It does not create any generic model related to the conversation. It is possible
   // for an AgentWebsearchAction to be stored (once the query params are infered) but for its execution

--- a/front/lib/api/assistant/actions/websearch.ts
+++ b/front/lib/api/assistant/actions/websearch.ts
@@ -196,7 +196,7 @@ export class WebsearchConfigurationServerRunner extends BaseActionConfigurationS
     yield {
       type: "websearch_params",
       created: Date.now(),
-      configurationId: agentConfiguration.sId,
+      configurationId: actionConfiguration.sId,
       messageId: agentMessage.sId,
       action: new WebsearchAction({
         id: action.id,

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -36,10 +36,6 @@ import {
   runRetrieval,
 } from "@app/lib/api/assistant/actions/retrieval";
 import { getRunnerforActionConfiguration } from "@app/lib/api/assistant/actions/runners";
-import {
-  generateTablesQuerySpecification,
-  runTablesQuery,
-} from "@app/lib/api/assistant/actions/tables_query";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
 import {
   constructPromptMultiActions,
@@ -324,17 +320,6 @@ export async function* runMultiActionsAgent(
     if (isRetrievalConfiguration(a)) {
       const r = await generateRetrievalSpecification(auth, {
         actionConfiguration: a,
-        name: a.name,
-        description: a.description,
-      });
-
-      if (r.isErr()) {
-        return r;
-      }
-
-      specifications.push(r.value);
-    } else if (isTablesQueryConfiguration(a)) {
-      const r = await generateTablesQuerySpecification(auth, {
         name: a.name,
         description: a.description,
       });
@@ -752,9 +737,10 @@ async function* runAction(
       }
     }
   } else if (isTablesQueryConfiguration(actionConfiguration)) {
-    const eventStream = runTablesQuery(auth, {
-      configuration,
-      actionConfiguration,
+    const runner = getRunnerforActionConfiguration(actionConfiguration);
+
+    const eventStream = runner.run(auth, {
+      agentConfiguration: configuration,
       conversation,
       agentMessage,
       rawInputs: inputs,

--- a/front/lib/api/assistant/legacy_agent.ts
+++ b/front/lib/api/assistant/legacy_agent.ts
@@ -36,10 +36,6 @@ import {
 } from "@app/lib/api/assistant/actions/retrieval";
 import { getRunnerforActionConfiguration } from "@app/lib/api/assistant/actions/runners";
 import {
-  deprecatedGenerateTablesQuerySpecificationForSingleActionAgent,
-  runTablesQuery,
-} from "@app/lib/api/assistant/actions/tables_query";
-import {
   constructPrompt,
   renderConversationForModel,
   runGeneration,
@@ -302,15 +298,12 @@ async function* runAction(
       await deprecatedGenerateRetrievalSpecificationForSingleActionAgent(auth, {
         actionConfiguration: action,
       });
-  } else if (isTablesQueryConfiguration(action)) {
-    specRes =
-      await deprecatedGenerateTablesQuerySpecificationForSingleActionAgent(
-        auth
-      );
   } else {
     const runner = getRunnerforActionConfiguration(action);
 
-    specRes = await runner.buildSpecification(auth, {});
+    specRes = await runner.deprecatedBuildSpecificationForSingleActionAgent(
+      auth
+    );
   }
 
   if (specRes.isErr()) {
@@ -485,9 +478,10 @@ async function* runAction(
       }
     }
   } else if (isTablesQueryConfiguration(action)) {
-    const eventStream = runTablesQuery(auth, {
-      configuration,
-      actionConfiguration: action,
+    const runner = getRunnerforActionConfiguration(action);
+
+    const eventStream = runner.run(auth, {
+      agentConfiguration: configuration,
       conversation,
       agentMessage,
       rawInputs,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR refactors the `tables_query` to align with the newly introduced class pattern. Recently, additional logic was integrated for the single agent implementation (see https://github.com/dust-tt/dust/pull/5220). This PR extends that functionality by adding new logic to the class, introducing the `deprecatedBuildSpecificationForSingleActionAgent` method.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
Worst case it breaks the tables query action.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
