### PR TITLE
chore: track request cancel at on subscriptions

### DIFF
--- a/front/lib/models/plan.ts
+++ b/front/lib/models/plan.ts
@@ -171,6 +171,10 @@ export class Subscription extends Model<
   declare plan: NonAttribute<Plan>;
 
   declare stripeSubscriptionId: string | null;
+
+  // not necessary for business logic, but helpful
+  // for analytics and business operations.
+  declare requestCancelAt: Date | null;
 }
 Subscription.init(
   {
@@ -219,6 +223,10 @@ Subscription.init(
     },
     stripeSubscriptionId: {
       type: DataTypes.STRING,
+      allowNull: true,
+    },
+    requestCancelAt: {
+      type: DataTypes.DATE,
       allowNull: true,
     },
   },

--- a/front/lib/plans/subscription.ts
+++ b/front/lib/plans/subscription.ts
@@ -85,6 +85,7 @@ export function renderSubscriptionFromModels({
     paymentFailingSince:
       activeSubscription?.paymentFailingSince?.getTime() || null,
     plan: renderPlanFromModel({ plan }),
+    requestCancelAt: activeSubscription?.requestCancelAt?.getTime() ?? null,
   };
 }
 

--- a/front/migrations/20240529_backfill_subscriptions_request_cancel_at.sql
+++ b/front/migrations/20240529_backfill_subscriptions_request_cancel_at.sql
@@ -1,0 +1,1 @@
+UPDATE subscriptions SET "requestCancelAt" = "endDate" WHERE "endDate" IS NOT NULL AND "requestCancelAt" IS NULL;

--- a/front/migrations/db/migration_11.sql
+++ b/front/migrations/db/migration_11.sql
@@ -1,0 +1,2 @@
+-- Migration created on May 28, 2024
+ALTER TABLE "public"."subscriptions" ADD COLUMN "requestCancelAt" TIMESTAMP WITH TIME ZONE;

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -449,8 +449,8 @@ async function handler(
             }
             await subscription.update({
               endDate,
-              // if the subscription is canceled, we set the requestCancelAt date to now.
-              // if the subscription is reactivated, we unset the requestCancelAt date.
+              // If the subscription is canceled, we set the requestCancelAt date to now.
+              // If the subscription is reactivated, we unset the requestCancelAt date.
               requestCancelAt: endDate ? now : null,
             });
             const auth = await Authenticator.internalBuilderForWorkspace(

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -241,6 +241,7 @@ async function handler(
                 workspace: renderLightWorkspaceType({ workspace }),
                 planCode,
                 workspaceSeats,
+                subscriptionStartAt: now.getTime(),
               });
             }
             await unpauseAllConnectorsAndCancelScrub(
@@ -446,14 +447,51 @@ async function handler(
                 },
               });
             }
-            await subscription.update({ endDate });
+            await subscription.update({
+              endDate,
+              // if the subscription is canceled, we set the requestCancelAt date to now.
+              // if the subscription is reactivated, we unset the requestCancelAt date.
+              requestCancelAt: endDate ? now : null,
+            });
             const auth = await Authenticator.internalBuilderForWorkspace(
               subscription.workspace.sId
             );
             if (!endDate) {
               // Subscription is re-activated, so we need to unpause the connectors in case they were paused.
               await unpauseAllConnectorsAndCancelScrub(auth);
+
+              ServerSideTracking.trackSubscriptionReactivated({
+                workspace: renderLightWorkspaceType({
+                  workspace: subscription.workspace,
+                }),
+              }).catch((e) => {
+                logger.error(
+                  {
+                    panic: true,
+                    error: e,
+                    workspaceId: subscription.workspace.sId,
+                  },
+                  "Error tracking subscription reactivated."
+                );
+              });
+            } else {
+              ServerSideTracking.trackSubscriptionRequestCancel({
+                workspace: renderLightWorkspaceType({
+                  workspace: subscription.workspace,
+                }),
+                requestCancelAt: now.getTime(),
+              }).catch((e) => {
+                logger.error(
+                  {
+                    panic: true,
+                    error: e,
+                    workspaceId: subscription.workspace.sId,
+                  },
+                  "Error tracking subscription request cancel."
+                );
+              });
             }
+
             // then email admins
             const adminEmails = (
               await getMembers(auth, { roles: ["admin"] })

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -467,7 +467,6 @@ async function handler(
               }).catch((e) => {
                 logger.error(
                   {
-                    panic: true,
                     error: e,
                     workspaceId: subscription.workspace.sId,
                   },
@@ -483,7 +482,6 @@ async function handler(
               }).catch((e) => {
                 logger.error(
                   {
-                    panic: true,
                     error: e,
                     workspaceId: subscription.workspace.sId,
                   },

--- a/types/src/front/plan.ts
+++ b/types/src/front/plan.ts
@@ -70,6 +70,7 @@ export type SubscriptionType = {
   endDate: number | null;
   paymentFailingSince: number | null;
   plan: PlanType;
+  requestCancelAt: number | null;
 };
 
 export const CreatePlanFormSchema = t.type({


### PR DESCRIPTION
## Description

https://github.com/dust-tt/tasks/issues/756

- Adds the `requestCancelAt` field to the `subscriptions` table and to `SubscriptionType`
- Populate this new field (with a non-null value when we get the cancellation request webhook from stripe, and with a null value when we get the "reactivation" webhook)
- send subscription start at to customerio


## Risk

on critical path, but non-awaited and catched promise.

## Deploy Plan

- apply migration (prodbox)
- run backfill (prodbox)
- deploy code

