### PR TITLE
[Assistant Builder] Fix: websearch action could not be saved

### DIFF
--- a/front/components/assistant_builder/actions/WebsearchAction.tsx
+++ b/front/components/assistant_builder/actions/WebsearchAction.tsx
@@ -4,7 +4,8 @@ export function isActionWebsearchValid(
   action: AssistantBuilderActionConfiguration
 ) {
   return (
-    action.type === "WEBSEARCH" && Object.keys(action.configuration).length > 0
+    action.type === "WEBSEARCH" &&
+    Object.keys(action.configuration).length === 0
   );
 }
 


### PR DESCRIPTION
Description
---
Following PR #5311 omitting to change `isActionWebsearchValid` led to a bug where the websearch action could not be saved

Risk & deploy
---
N/A