### PR TITLE
🚧 Support shadow embedder in core data source

### DIFF
--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -14,7 +14,6 @@ use futures::future::try_join_all;
 use futures::StreamExt;
 use futures::TryStreamExt;
 use itertools::Itertools;
-use qdrant_client::client::QdrantClient;
 use qdrant_client::qdrant::vectors::VectorsOptions;
 use qdrant_client::qdrant::{PointId, RetrievedPoint, ScoredPoint};
 use qdrant_client::{prelude::Payload, qdrant};
@@ -26,7 +25,7 @@ use tokio_stream::{self as stream};
 use tracing::{error, info};
 use uuid::Uuid;
 
-use super::qdrant::{DustQdrantClient, QdrantCluster, WrappedQdrantClient};
+use super::qdrant::{QdrantCluster, WrappedQdrantClient};
 
 /// A filter to apply to the search query based on `tags`. All documents returned must have at least
 /// one tag in `is_in` and none of the tags in `is_not`.

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -644,7 +644,7 @@ impl DataSource {
         field_value: impl Into<Value>,
     ) -> Result<()> {
         let qdrant_client = qdrant_clients.main_client(&self.config.qdrant_config);
-        let ds_qdrant = qdrant_client.wrap_for_data_source(self, false);
+        let ds_qdrant = qdrant_client.for_data_source(self);
 
         let mut payload = Payload::new();
         payload.insert(field_name, field_value.into());
@@ -664,8 +664,7 @@ impl DataSource {
         // TODO:
         match qdrant_clients.shadow_write_client(&self.config.qdrant_config) {
             Some(qdrant_client) => {
-                let data_source_qdrant_shadow_write =
-                    qdrant_client.wrap_for_data_source(&self, false);
+                let data_source_qdrant_shadow_write = qdrant_client.for_data_source(&self);
 
                 match data_source_qdrant_shadow_write
                     .set_payload(filter.clone(), payload.clone())
@@ -694,8 +693,7 @@ impl DataSource {
         }
 
         if self.shadow_embedder_config().is_some() {
-            let data_source_qdrant_shadow_embedder =
-                qdrant_client.wrap_for_data_source(&self, true);
+            let data_source_qdrant_shadow_embedder = qdrant_client.for_data_source(&self);
 
             match data_source_qdrant_shadow_embedder
                 .set_payload(filter.clone(), payload.clone())
@@ -736,7 +734,7 @@ impl DataSource {
         preserve_system_tags: bool,
     ) -> Result<Document> {
         let qdrant_client = qdrant_clients.main_client(&self.config.qdrant_config);
-        let ds_qdrant = qdrant_client.wrap_for_data_source(self, false);
+        let ds_qdrant = qdrant_client.for_data_source(self);
 
         let full_text = text.full_text();
         // Disallow preserve_system_tags=true if tags contains a string starting with the system
@@ -1059,7 +1057,7 @@ impl DataSource {
 
         match qdrant_clients.shadow_write_client(&self.config.qdrant_config) {
             Some(qdrant_client) => {
-                let qdrant_client_shadow_write = qdrant_client.wrap_for_data_source(self, false);
+                let qdrant_client_shadow_write = qdrant_client.for_data_source(self);
 
                 match qdrant_client_shadow_write
                     .delete_points(filter.clone())
@@ -1154,8 +1152,7 @@ impl DataSource {
                 // TODO: We can build qdrant client only once!
                 match qdrant_clients.shadow_write_client(&self.config.qdrant_config) {
                     Some(qdrant_client) => {
-                        let qdrant_client_shadow_write =
-                            qdrant_client.wrap_for_data_source(self, false);
+                        let qdrant_client_shadow_write = qdrant_client.for_data_source(self);
 
                         match qdrant_client_shadow_write
                             .upsert_points(chunk.clone())
@@ -1254,7 +1251,7 @@ impl DataSource {
 
         let qdrant_client = qdrant_clients.main_client(&self.config.qdrant_config);
 
-        let qdrant_client_shadow_embedder = qdrant_client.wrap_for_data_source(self, true);
+        let qdrant_client_shadow_embedder = qdrant_client.for_data_source(self);
 
         let full_text = text.full_text();
 
@@ -1490,7 +1487,7 @@ impl DataSource {
         target_document_tokens: Option<usize>,
     ) -> Result<Vec<Document>> {
         let qdrant_client = qdrant_clients.main_client(&self.config.qdrant_config);
-        let ds_qdrant = qdrant_client.wrap_for_data_source(self, false);
+        let ds_qdrant = qdrant_client.for_data_source(self);
 
         // We ensure that we have not left a `parents.is_in_map`` in the filter.
         match filter.as_ref() {
@@ -1671,8 +1668,7 @@ impl DataSource {
                             .map(|(_, c)| c.clone())
                             .collect::<Vec<Chunk>>();
                         let chunk_size = self.embedder_config().max_chunk_size;
-                        let qc = qdrant_client.clone();
-                        let ds_qdrant = qc.wrap_for_data_source(self, false);
+                        let ds_qdrant = ds_qdrant.clone();
                         let mut token_count = chunks.len() * chunk_size;
                         d.token_count = Some(token_count);
                         tokio::spawn(async move {
@@ -1887,7 +1883,7 @@ impl DataSource {
         top_k: usize,
         filter: &Option<SearchFilter>,
     ) -> Result<Vec<(String, Chunk)>> {
-        let ds_qdrant = qdrant_client.wrap_for_data_source(self, false);
+        let ds_qdrant = qdrant_client.for_data_source(self);
 
         let store = store.clone();
 
@@ -2076,7 +2072,7 @@ impl DataSource {
         document_id: &str,
     ) -> Result<()> {
         let qdrant_client = qdrant_clients.main_client(&self.config.qdrant_config);
-        let ds_qdrant = qdrant_client.wrap_for_data_source(self, false);
+        let ds_qdrant = qdrant_client.for_data_source(self);
 
         let store = store.clone();
 
@@ -2103,7 +2099,7 @@ impl DataSource {
 
         match qdrant_clients.shadow_write_client(&self.config.qdrant_config) {
             Some(qdrant_client) => {
-                let qdrant_client_shadow_write = qdrant_client.wrap_for_data_source(self, false);
+                let qdrant_client_shadow_write = qdrant_client.for_data_source(self);
 
                 match qdrant_client_shadow_write
                     .delete_points(filter.clone())
@@ -2132,7 +2128,7 @@ impl DataSource {
         }
 
         if self.shadow_embedder_config().is_some() {
-            let qdrant_client_shadow_embedder = qdrant_client.wrap_for_data_source(self, true);
+            let qdrant_client_shadow_embedder = qdrant_client.for_data_source(self);
 
             match qdrant_client_shadow_embedder
                 .delete_points(filter.clone())
@@ -2190,7 +2186,7 @@ impl DataSource {
         }
 
         let qdrant_client = qdrant_clients.main_client(&self.config.qdrant_config);
-        let ds_qdrant = qdrant_client.wrap_for_data_source(self, false);
+        let ds_qdrant = qdrant_client.for_data_source(self);
 
         let store = store.clone();
 

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -661,7 +661,6 @@ impl DataSource {
             ..Default::default()
         };
 
-        // TODO:
         match qdrant_clients.shadow_write_client(&self.config.qdrant_config) {
             Some(qdrant_client) => {
                 let data_source_qdrant_shadow_write = qdrant_client.for_data_source(&self);
@@ -1150,7 +1149,6 @@ impl DataSource {
                 let now = utils::now();
                 let chunk_len = chunk.len();
 
-                // TODO: We can build qdrant client only once!
                 match qdrant_clients.shadow_write_client(&self.config.qdrant_config) {
                     Some(qdrant_client) => {
                         let data_source_shadow_write_qdrant = qdrant_client.for_data_source(self);

--- a/core/src/data_sources/qdrant.rs
+++ b/core/src/data_sources/qdrant.rs
@@ -149,13 +149,13 @@ impl QdrantClients {
 }
 
 #[derive(Clone)]
-pub struct DustQdrantClientWithDataSource {
+pub struct DataSourceQdrantClient {
     client: DustQdrantClient,
     data_source: DataSource,
     embedder_config: EmbedderConfig,
 }
 
-impl DustQdrantClientWithDataSource {
+impl DataSourceQdrantClient {
     pub fn collection_name(&self) -> String {
         // The collection name depends on the embedding model which is stored on the
         // data source config. To allow migrations between embedders in the future we will
@@ -346,8 +346,8 @@ pub struct DustQdrantClient {
 }
 
 impl DustQdrantClient {
-    pub fn for_data_source(&self, data_source: &DataSource) -> DustQdrantClientWithDataSource {
-        DustQdrantClientWithDataSource {
+    pub fn for_data_source(&self, data_source: &DataSource) -> DataSourceQdrantClient {
+        DataSourceQdrantClient {
             client: self.clone(),
             data_source: data_source.clone(),
             embedder_config: data_source.embedder_config().clone(),
@@ -357,9 +357,9 @@ impl DustQdrantClient {
     pub fn for_data_source_with_shadow_embedder(
         &self,
         data_source: &DataSource,
-    ) -> Option<DustQdrantClientWithDataSource> {
+    ) -> Option<DataSourceQdrantClient> {
         match data_source.shadow_embedder_config() {
-            Some(shadow_embedder_config) => Some(DustQdrantClientWithDataSource {
+            Some(shadow_embedder_config) => Some(DataSourceQdrantClient {
                 client: self.clone(),
                 data_source: data_source.clone(),
                 embedder_config: shadow_embedder_config.clone(),

--- a/core/src/data_sources/qdrant.rs
+++ b/core/src/data_sources/qdrant.rs
@@ -148,15 +148,14 @@ impl QdrantClients {
     }
 }
 
-// TODO: Name.
 #[derive(Clone)]
-pub struct DustQdrantClientForDataSource {
+pub struct DustQdrantClientWithDataSource {
     client: DustQdrantClient,
     data_source: DataSource,
     embedder_config: EmbedderConfig,
 }
 
-impl DustQdrantClientForDataSource {
+impl DustQdrantClientWithDataSource {
     pub fn collection_name(&self) -> String {
         // The collection name depends on the embedding model which is stored on the
         // data source config. To allow migrations between embedders in the future we will
@@ -347,8 +346,8 @@ pub struct DustQdrantClient {
 }
 
 impl DustQdrantClient {
-    pub fn for_data_source(&self, data_source: &DataSource) -> DustQdrantClientForDataSource {
-        DustQdrantClientForDataSource {
+    pub fn for_data_source(&self, data_source: &DataSource) -> DustQdrantClientWithDataSource {
+        DustQdrantClientWithDataSource {
             client: self.clone(),
             data_source: data_source.clone(),
             embedder_config: data_source.embedder_config().clone(),
@@ -358,9 +357,9 @@ impl DustQdrantClient {
     pub fn for_data_source_with_shadow_embedder(
         &self,
         data_source: &DataSource,
-    ) -> Option<DustQdrantClientForDataSource> {
+    ) -> Option<DustQdrantClientWithDataSource> {
         match data_source.shadow_embedder_config() {
-            Some(shadow_embedder_config) => Some(DustQdrantClientForDataSource {
+            Some(shadow_embedder_config) => Some(DustQdrantClientWithDataSource {
                 client: self.clone(),
                 data_source: data_source.clone(),
                 embedder_config: shadow_embedder_config.clone(),

--- a/core/src/data_sources/qdrant.rs
+++ b/core/src/data_sources/qdrant.rs
@@ -151,6 +151,199 @@ impl QdrantClients {
     }
 }
 
+// TODO: Name.
+#[derive(Clone)]
+pub struct DustQdrantClientForDataSource<'a> {
+    client: &'a DustQdrantClient,
+    data_source: &'a DataSource,
+    embedder_config: &'a EmbedderConfig,
+}
+
+impl<'a> DustQdrantClientForDataSource<'a> {
+    pub fn collection_name(&self) -> String {
+        // The collection name depends on the embedding model which is stored on the
+        // data source config. To allow migrations between embedders in the future we will
+        // add a notion of shadow_write embedding provider/model on the data source config
+        // that will have to be used here.
+        let collection_suffix = format!(
+            "{}_{}",
+            self.embedder_config.provider_id.to_string(),
+            self.embedder_config.model_id,
+        );
+
+        self.client.collection_name(collection_suffix)
+    }
+
+    fn shard_key(&self) -> Result<shard_key::Key> {
+        let key_id: u64 = match (
+            self.embedder_config.provider_id,
+            self.embedder_config.model_id.as_str(),
+        ) {
+            (ProviderID::OpenAI, "text-embedding-ada-002") => {
+                // The startegy below was a mistake as the last character is an hex encoding
+                // character so can only take values from 0-9 and a-f which does not cover the
+                // SHARD_KEY_COUNT range, leading to unbalanced shards:
+                //
+                // We use the last character of the internal_id to determine the key_id. This id is
+                // generated using new_id and is guaranteed random. Using the last character gives
+                // us a path to moving data sources across shard when needed.
+                self.data_source.internal_id().chars().last().unwrap() as u64 % SHARD_KEY_COUNT
+            }
+            _ => DustQdrantClient::shard_key_id_from_internal_id(self.data_source.internal_id())?,
+        };
+
+        self.client.shard_key(key_id)
+    }
+
+    // TODO:
+    // Inject the `data_source_internal_id` to the filter to ensure tenant separation. This
+    // implementaiton ensure data separation of our users data. Modify with extreme caution.
+    fn apply_tenant_filter(&self, filter: &mut qdrant::Filter) -> () {
+        filter.must.push(
+            qdrant::FieldCondition {
+                key: "data_source_internal_id".to_string(),
+                r#match: Some(qdrant::Match {
+                    match_value: Some(qdrant::r#match::MatchValue::Keyword(
+                        self.data_source.internal_id().to_string(),
+                    )),
+                }),
+                ..Default::default()
+            }
+            .into(),
+        );
+    }
+
+    pub async fn delete_data_source(&self) -> Result<()> {
+        // Create a default filter and ensure tenant separation to delete all the points
+        // associated with the data source.
+        let mut filter = qdrant::Filter::default();
+        self.apply_tenant_filter(&mut filter);
+
+        self.client
+            .raw_client()
+            .delete_points(
+                self.collection_name(),
+                Some(vec![self.shard_key()?]),
+                &filter.into(),
+                None,
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    pub async fn collection_info(&self) -> Result<qdrant::GetCollectionInfoResponse> {
+        self.client
+            .raw_client()
+            .collection_info(self.collection_name())
+            .await
+    }
+
+    pub async fn delete_points(
+        &self,
+        mut filter: qdrant::Filter,
+    ) -> Result<qdrant::PointsOperationResponse> {
+        // Inject the `data_source_internal_id` to the filter to ensure tenant separation.
+        self.apply_tenant_filter(&mut filter);
+
+        self.client
+            .raw_client()
+            .delete_points(
+                self.collection_name(),
+                Some(vec![self.shard_key()?]),
+                &filter.into(),
+                None,
+            )
+            .await
+    }
+
+    pub async fn scroll(
+        &self,
+        filter: Option<qdrant::Filter>,
+        limit: Option<u32>,
+        offset: Option<qdrant::PointId>,
+        with_vectors: Option<qdrant::WithVectorsSelector>,
+    ) -> Result<qdrant::ScrollResponse> {
+        // If we don't have a filter create an empty one to ensure tenant separation.
+        let mut filter = filter.unwrap_or_default();
+        self.apply_tenant_filter(&mut filter);
+
+        self.client
+            .raw_client()
+            .scroll(&qdrant::ScrollPoints {
+                collection_name: self.collection_name(),
+                with_vectors,
+                limit,
+                offset,
+                filter: Some(filter),
+                shard_key_selector: Some(vec![self.shard_key()?].into()),
+                ..Default::default()
+            })
+            .await
+    }
+
+    pub async fn search_points(
+        &self,
+        vector: Vec<f32>,
+        filter: Option<qdrant::Filter>,
+        limit: u64,
+        with_payload: Option<qdrant::WithPayloadSelector>,
+    ) -> Result<qdrant::SearchResponse> {
+        // If we don't have a filter create an empty one to ensure tenant separation.
+        let mut filter = filter.unwrap_or_default();
+        self.apply_tenant_filter(&mut filter);
+
+        self.client
+            .raw_client()
+            .search_points(&qdrant::SearchPoints {
+                collection_name: self.collection_name(),
+                vector,
+                filter: Some(filter),
+                limit,
+                with_payload,
+                shard_key_selector: Some(vec![self.shard_key()?].into()),
+                ..Default::default()
+            })
+            .await
+    }
+
+    pub async fn upsert_points(
+        &self,
+        points: Vec<qdrant::PointStruct>,
+    ) -> Result<qdrant::PointsOperationResponse> {
+        self.client
+            .raw_client()
+            .upsert_points(
+                self.collection_name(),
+                Some(vec![self.shard_key()?]),
+                points,
+                None,
+            )
+            .await
+    }
+
+    pub async fn set_payload(
+        &self,
+        mut filter: qdrant::Filter,
+        payload: Payload,
+    ) -> Result<qdrant::PointsOperationResponse> {
+        // Inject the `data_source_internal_id` to the filter to ensure tenant separation.
+        self.apply_tenant_filter(&mut filter);
+
+        self.client
+            .raw_client()
+            .set_payload(
+                self.collection_name(),
+                Some(vec![self.shard_key()?]),
+                &filter.into(),
+                payload,
+                None,
+                None,
+            )
+            .await
+    }
+}
+
 #[derive(Clone)]
 pub struct DustQdrantClient {
     client: Arc<QdrantClient>,
@@ -167,6 +360,19 @@ fn get_embedder_config(data_source: &DataSource, use_shadow: bool) -> Result<&Em
 }
 
 impl DustQdrantClient {
+    pub fn wrap_for_data_source(
+        &self,
+        data_source: &DataSource,
+        use_shadow: bool,
+    ) -> DustQdrantClientForDataSource {
+        // TODO: use_shadow.
+        DustQdrantClientForDataSource {
+            client: self,
+            data_source,
+            embedder_config: data_source.embedder_config(),
+        }
+    }
+
     pub fn collection_prefix(&self) -> String {
         return String::from("c");
     }
@@ -175,19 +381,8 @@ impl DustQdrantClient {
         return String::from("key");
     }
 
-    pub fn collection_name(&self, data_source: &DataSource, use_shadow: bool) -> String {
-        let embedder_config = get_embedder_config(data_source, use_shadow)?;
-
-        // The collection name depends on the embedding model which is stored on the
-        // data source config. To allow migrations between embedders in the future we will
-        // add a notion of shadow_write embedding provider/model on the data source config
-        // that will have to be used here.
-        format!(
-            "{}_{}_{}",
-            self.collection_prefix(),
-            embedder_config.provider_id.to_string(),
-            embedder_config.model_id,
-        )
+    pub fn collection_name(&self, collection_suffix: String) -> String {
+        format!("{}_{}", self.collection_prefix(), collection_suffix)
     }
 
     fn shard_key_id_from_internal_id(internal_id: &str) -> Result<u64> {
@@ -199,184 +394,8 @@ impl DustQdrantClient {
         Ok(h % SHARD_KEY_COUNT)
     }
 
-    fn shard_key(&self, data_source: &DataSource, use_shadow: bool) -> Result<shard_key::Key> {
-        let embedder_config = get_embedder_config(data_source, use_shadow);
-
-        // TODO:
-        let key_id: u64 = match (
-            embedder_config.provider_id,
-            embedder_config.model_id.as_str(),
-        ) {
-            (ProviderID::OpenAI, "text-embedding-ada-002") => {
-                // The startegy below was a mistake as the last character is an hex encoding
-                // character so can only take values from 0-9 and a-f which does not cover the
-                // SHARD_KEY_COUNT range, leading to unbalanced shards:
-                //
-                // We use the last character of the internal_id to determine the key_id. This id is
-                // generated using new_id and is guaranteed random. Using the last character gives
-                // us a path to moving data sources across shard when needed.
-                data_source.internal_id().chars().last().unwrap() as u64 % SHARD_KEY_COUNT
-            }
-            _ => Self::shard_key_id_from_internal_id(data_source.internal_id())?,
-        };
-
+    fn shard_key(&self, key_id: u64) -> Result<shard_key::Key> {
         Ok(format!("{}_{}", self.shard_key_prefix(), key_id).into())
-    }
-
-    // Inject the `data_source_internal_id` to the filter to ensure tenant separation. This
-    // implementaiton ensure data separation of our users data. Modify with extreme caution.
-    fn apply_tenant_filter(&self, data_source: &DataSource, filter: &mut qdrant::Filter) -> () {
-        filter.must.push(
-            qdrant::FieldCondition {
-                key: "data_source_internal_id".to_string(),
-                r#match: Some(qdrant::Match {
-                    match_value: Some(qdrant::r#match::MatchValue::Keyword(
-                        data_source.internal_id().to_string(),
-                    )),
-                }),
-                ..Default::default()
-            }
-            .into(),
-        );
-    }
-
-    pub async fn delete_data_source(
-        &self,
-        data_source: &DataSource,
-        use_shadow: bool,
-    ) -> Result<()> {
-        // Create a default filter and ensure tenant separation to delete all the points
-        // associated with the data source.
-        let mut filter = qdrant::Filter::default();
-        self.apply_tenant_filter(data_source, &mut filter);
-
-        self.client
-            .delete_points(
-                self.collection_name(data_source, use_shadow),
-                Some(vec![self.shard_key(data_source, use_shadow)?]),
-                &filter.into(),
-                None,
-            )
-            .await?;
-
-        Ok(())
-    }
-
-    pub async fn collection_info(
-        &self,
-        data_source: &DataSource,
-        use_shadow: bool,
-    ) -> Result<qdrant::GetCollectionInfoResponse> {
-        self.client
-            .collection_info(self.collection_name(data_source, use_shadow))
-            .await
-    }
-
-    pub async fn delete_points(
-        &self,
-        data_source: &DataSource,
-        mut filter: qdrant::Filter,
-        use_shadow: bool,
-    ) -> Result<qdrant::PointsOperationResponse> {
-        // Inject the `data_source_internal_id` to the filter to ensure tenant separation.
-        self.apply_tenant_filter(data_source, &mut filter);
-
-        self.client
-            .delete_points(
-                self.collection_name(data_source, use_shadow),
-                Some(vec![self.shard_key(data_source, use_shadow)?]),
-                &filter.into(),
-                None,
-            )
-            .await
-    }
-
-    pub async fn scroll(
-        &self,
-        data_source: &DataSource,
-        filter: Option<qdrant::Filter>,
-        limit: Option<u32>,
-        offset: Option<qdrant::PointId>,
-        with_vectors: Option<qdrant::WithVectorsSelector>,
-    ) -> Result<qdrant::ScrollResponse> {
-        // If we don't have a filter create an empty one to ensure tenant separation.
-        let mut filter = filter.unwrap_or_default();
-        self.apply_tenant_filter(data_source, &mut filter);
-
-        self.client
-            .scroll(&qdrant::ScrollPoints {
-                collection_name: self.collection_name(data_source, false),
-                with_vectors,
-                limit,
-                offset,
-                filter: Some(filter),
-                shard_key_selector: Some(vec![self.shard_key(data_source, false)?].into()),
-                ..Default::default()
-            })
-            .await
-    }
-
-    pub async fn search_points(
-        &self,
-        data_source: &DataSource,
-        vector: Vec<f32>,
-        filter: Option<qdrant::Filter>,
-        limit: u64,
-        with_payload: Option<qdrant::WithPayloadSelector>,
-    ) -> Result<qdrant::SearchResponse> {
-        // If we don't have a filter create an empty one to ensure tenant separation.
-        let mut filter = filter.unwrap_or_default();
-        self.apply_tenant_filter(data_source, &mut filter);
-
-        self.client
-            .search_points(&qdrant::SearchPoints {
-                collection_name: self.collection_name(data_source, false),
-                vector,
-                filter: Some(filter),
-                limit,
-                with_payload,
-                shard_key_selector: Some(vec![self.shard_key(data_source, false)?].into()),
-                ..Default::default()
-            })
-            .await
-    }
-
-    pub async fn upsert_points(
-        &self,
-        data_source: &DataSource,
-        points: Vec<qdrant::PointStruct>,
-        use_shadow: bool,
-    ) -> Result<qdrant::PointsOperationResponse> {
-        self.client
-            .upsert_points(
-                self.collection_name(data_source, use_shadow),
-                Some(vec![self.shard_key(data_source, use_shadow)?]),
-                points,
-                None,
-            )
-            .await
-    }
-
-    pub async fn set_payload(
-        &self,
-        data_source: &DataSource,
-        mut filter: qdrant::Filter,
-        payload: Payload,
-        use_shadow: bool,
-    ) -> Result<qdrant::PointsOperationResponse> {
-        // Inject the `data_source_internal_id` to the filter to ensure tenant separation.
-        self.apply_tenant_filter(data_source, &mut filter);
-
-        self.client
-            .set_payload(
-                self.collection_name(data_source, use_shadow),
-                Some(vec![self.shard_key(data_source, use_shadow)?]),
-                &filter.into(),
-                payload,
-                None,
-                None,
-            )
-            .await
     }
 
     pub fn raw_client(&self) -> Arc<QdrantClient> {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR revamps the existing Qdrant implementation. As we increasingly need to handle more logic related to data source configuration (such as shadow write clusters and shadow embedders), this PR introduces a wrapper around the existing `DustQdrantClient`. This wrapper encapsulates the context (data source and `embedder_config`). Most methods have been migrated from `DustQdrantClient` to `DataSourceQdrantClient` to leverage the wrapped context.

The wrapper enables cleaner method signatures, as methods no longer need to accept `DataSource` and `EmbedderConfig` as parameters. This results in simpler and more readable method definitions. Since the data source remains consistent throughout the code, there is no need for the flexibility to pass different data sources.

The updated approach now exposes two methods on the `DustQdrantClient`:
- `for_data_source()`
- `for_data_source_with_shadow_embedder()`

While all the logic for the shadow embedder is currently included in this PR, it will be separated before final release!

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
