### PR TITLE
Multi-Actions: Add support for Mistral AI

### DIFF
--- a/core/src/providers/mistral.rs
+++ b/core/src/providers/mistral.rs
@@ -93,6 +93,7 @@ struct MistralToolCallFunction {
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 struct MistralToolCall {
+    pub id: String,
     pub function: MistralToolCallFunction,
 }
 
@@ -104,6 +105,8 @@ struct MistralChatMessage {
     pub name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_calls: Option<Vec<MistralToolCall>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_call_id: Option<String>,
 }
 
 impl TryFrom<&ChatFunctionCall> for MistralToolCall {
@@ -111,6 +114,7 @@ impl TryFrom<&ChatFunctionCall> for MistralToolCall {
 
     fn try_from(cf: &ChatFunctionCall) -> Result<Self, Self::Error> {
         Ok(MistralToolCall {
+            id: cf.id.clone(),
             function: MistralToolCallFunction {
                 name: cf.name.clone(),
                 arguments: cf.arguments.clone(),
@@ -124,7 +128,7 @@ impl TryFrom<&MistralToolCall> for ChatFunctionCall {
 
     fn try_from(tc: &MistralToolCall) -> Result<Self, Self::Error> {
         Ok(ChatFunctionCall {
-            id: format!("fc_{}", new_id()),
+            id: tc.id.clone(),
             name: tc.function.name.clone(),
             arguments: tc.function.arguments.clone(),
         })
@@ -176,10 +180,19 @@ impl TryFrom<&ChatMessage> for MistralChatMessage {
                 _ => None,
             },
             role: mistral_role,
-            tool_calls: match cm.function_call.as_ref() {
-                Some(fc) => Some(vec![MistralToolCall::try_from(fc)?]),
+            tool_calls: match cm.function_calls.as_ref() {
+                Some(fc) => Some(
+                    fc.iter()
+                        .map(|f| MistralToolCall::try_from(f))
+                        .collect::<Result<Vec<_>>>()?,
+                ),
                 None => None,
             },
+            tool_call_id: cm.function_call_id.clone(),
+            // tool_calls: match cm.function_calls.as_ref() {
+            //     Some(fc) => Some(vec![MistralToolCall::try_from(fc)?]),
+            //     None => None,
+            // },
         })
     }
 }
@@ -387,30 +400,46 @@ impl MistralAILLM {
             .map(|m| MistralChatMessage::try_from(m))
             .collect::<Result<Vec<_>>>()?;
 
-        // Mistral AI requires a tool call to be followed by a tool message. We therefore inject a
-        // tool call message before the tool message if missing.
+        // Mistral AI requires a tool call assistant message to be followed by a tool message. We
+        // therefore inject a tool call assistant message before the tool message if it is missing.
+        // Note that we can have multiple tool messages in a row which is valid. They just need to
+        // be preceded by a tool call assistant message.
+        //
+        // We do a best effort here for the case where we have only one function call in the
+        // assistant message. If we had no assistant message and multiple function messages mistral
+        // will compain that there is a mismatch. In practice, Dust (legacy_agent) relies on
+        // cases with one function call only.
         let mistral_messages = mistral_messages.iter().fold(
             vec![],
             |mut acc: Vec<MistralChatMessage>, cm: &MistralChatMessage| {
                 match acc.last_mut() {
                     Some(last)
                         if cm.role == MistralChatMessageRole::Tool
-                            && last.role != MistralChatMessageRole::Assistant =>
+                            && (last.role != MistralChatMessageRole::Assistant
+                                && last.role != MistralChatMessageRole::Tool) =>
                     {
-                        let name = match cm.name.as_ref() {
-                            Some(name) => name.clone(),
-                            None => String::from("unknown_tool"),
-                        };
                         acc.push(MistralChatMessage {
                             role: MistralChatMessageRole::Assistant,
                             name: None,
                             content: None,
                             tool_calls: Some(vec![MistralToolCall {
+                                // If we have a tool_call in the agent message we use it, otherwise
+                                // we generate a new fake one following Mistral format (9 chars, we
+                                // use an hex representation where Mistral uses any char, but
+                                // that's fine).
+                                id: cm
+                                    .tool_call_id
+                                    .clone()
+                                    .unwrap_or_else(|| new_id()[0..9].to_string()),
                                 function: MistralToolCallFunction {
-                                    name,
+                                    name: cm
+                                        .name
+                                        .clone()
+                                        .unwrap_or_else(|| String::from("unknown_tool")),
                                     arguments: String::from("{}"),
                                 },
                             }]),
+                            tool_call_id: None,
                         });
                         acc.push(cm.clone());
                     }
@@ -616,6 +645,7 @@ impl MistralAILLM {
                             name: None,
                             role: MistralChatMessageRole::Assistant,
                             tool_calls: None,
+                            tool_call_id: None,
                         },
                         index: c.index,
                         finish_reason: None,
@@ -723,6 +753,11 @@ impl MistralAILLM {
             body["tools"] = json!(tools);
         }
 
+        // println!(
+        //     "MistralAI request: {}",
+        //     serde_json::to_string_pretty(&body).unwrap()
+        // );
+
         let req = reqwest::Client::new()
             .post(uri.to_string())
             .header("Content-Type", "application/json")
@@ -745,6 +780,8 @@ impl MistralAILLM {
         let mut b: Vec<u8> = vec![];
         body.reader().read_to_end(&mut b)?;
         let c: &[u8] = &b;
+
+        // println!("MistralAI response: {}", String::from_utf8_lossy(c));
 
         let mut completion: MistralChatCompletion = match serde_json::from_slice(c) {
             Ok(c) => c,

--- a/front/pages/api/w/[wId]/providers/[pId]/models.ts
+++ b/front/pages/api/w/[wId]/providers/[pId]/models.ts
@@ -262,9 +262,7 @@ async function handler(
             if (embed) {
               f = mList.filter((m) => m.id === "mistral-embed");
             } else {
-              f = mList.filter(
-                (m) => m.id.startsWith("mistral-") && !m.id.endsWith("-embed")
-              );
+              f = mList.filter((m) => !m.id.endsWith("-embed"));
             }
             f.sort((a, b) => {
               if (a.id < b.id) {


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/dust/issues/5169

- Adds support for tool_call_id
- Adds support for multiple function calls
- Make sure we can interact with 8x22b in Dust apps
- Fix our stitching of assistant message before tool message in the case of multiple tool messages

Tested with `mistral-small-latest`, `mistral-large-latest`  and `open-mixtral-8x22b`

Mistral wants as many `tool` messages (`function` for us) as there were `tool_calls`, `function_calls` for us).

`mistral-small-latest` does not seem to be able to do multiple tool calls at the same time but the two other do. 

![Screenshot from 2024-05-29 12-12-08](https://github.com/dust-tt/dust/assets/15067/23ea59be-8b2f-43b6-91b7-c7b0e3f6010a)
![Screenshot from 2024-05-29 12-11-47](https://github.com/dust-tt/dust/assets/15067/e30ef2ab-3bbb-40e7-b00d-f4d7ee931922)


TODO:
- [x] test with streaming over API
- [x] post-merge/deploy test of a non multi-action mistral assistant

## Risk

Medium, could break some pre-existing Mistral interactions but unlikely.

## Deploy Plan

- deploy `core`