### PR TITLE
[Gdrive] Fix: GDriveFiles deletion also deletes in GDriveFolders

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -847,6 +847,15 @@ async function deleteFile(googleDriveFile: GoogleDriveFiles) {
     const dataSourceConfig = dataSourceConfigFromConnector(connector);
     await deleteFromDataSource(dataSourceConfig, googleDriveFile.dustFileId);
   }
+  const folder = await GoogleDriveFolders.findOne({
+    where: {
+      connectorId: connectorId,
+      folderId: googleDriveFile.driveFileId,
+    },
+  });
+  if (folder) {
+    await folder.destroy();
+  }
   await googleDriveFile.destroy();
 }
 


### PR DESCRIPTION
Description
---
Related to issue https://github.com/dust-tt/dust/issues/5100

When deleting a google drive file, we don't remove it from the GoogleDriveFolders table which can lead to unexpected issues

Risks
---
Check that the logic to delete both makes sense in all situations with @lasryaric

Deploy
---
Connectors
