### PR TITLE
Fix sync Chip

### DIFF
--- a/connectors/src/lib/renderers/connector.ts
+++ b/connectors/src/lib/renderers/connector.ts
@@ -18,6 +18,7 @@ export async function renderConnectorType(
     firstSuccessfulSyncTime: connector.firstSuccessfulSyncTime?.getTime(),
     firstSyncProgress: connector.firstSyncProgress,
     configuration: await renderConfiguration(connector),
+    errorType: connector.errorType ?? undefined,
     pausedAt: connector.pausedAt,
     updatedAt: connector.updatedAt.getTime(),
   };


### PR DESCRIPTION
## Description

Sync chips are broken, they always display "Syncronization", see example [here](https://dust.tt/w/0ec9852c2f/builder/data-sources/public-urls) (the top 2 are errored connectors).
We were not fetching the `errorType` attribute from connectors when fetching the connector. 

## Risk

Can be rolled back.

## Deploy Plan

Deploy connectors. 
