### PR TITLE
Use embedder.tokenize in data_sources/tokenize

### DIFF
--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -1183,8 +1183,9 @@ async fn data_sources_tokenize(
             ),
             Some(ds) => {
                 let embedder_config = ds.embedder_config().clone();
-                let llm = provider(embedder_config.provider_id).llm(embedder_config.model_id);
-                match llm.tokenize(&payload.text).await {
+                let embedder =
+                    provider(embedder_config.provider_id).embedder(embedder_config.model_id);
+                match embedder.tokenize(&payload.text).await {
                     Err(e) => error_response(
                         StatusCode::INTERNAL_SERVER_ERROR,
                         "internal_server_error",

--- a/core/src/providers/ai21.rs
+++ b/core/src/providers/ai21.rs
@@ -387,6 +387,10 @@ impl Embedder for AI21Embedder {
         Err(anyhow!("Encode/Decode not implemented for provider `ai21`"))
     }
 
+    async fn tokenize(&self, _text: &str) -> Result<Vec<(usize, String)>> {
+        Err(anyhow!("Tokenize not implemented for provider `ai21`"))
+    }
+
     async fn embed(&self, _text: Vec<&str>, _extras: Option<Value>) -> Result<Vec<EmbedderVector>> {
         Err(anyhow!("Embeddings not available for provider `ai21`"))
     }

--- a/core/src/providers/anthropic.rs
+++ b/core/src/providers/anthropic.rs
@@ -1359,6 +1359,10 @@ impl Embedder for AnthropicEmbedder {
         decode_async(anthropic_base_singleton(), tokens).await
     }
 
+    async fn tokenize(&self, text: &str) -> Result<Vec<(usize, String)>> {
+        tokenize_async(anthropic_base_singleton(), text).await
+    }
+
     async fn embed(&self, _text: Vec<&str>, _extras: Option<Value>) -> Result<Vec<EmbedderVector>> {
         Err(anyhow!("Embeddings not available for provider `anthropic`"))
     }

--- a/core/src/providers/azure_openai.rs
+++ b/core/src/providers/azure_openai.rs
@@ -224,26 +224,34 @@ impl LLM for AzureOpenAILLM {
     fn context_size(&self) -> usize {
         match self.model_id.as_ref() {
             Some(model_id) => {
-                if model_id.starts_with("gpt-3.5-turbo") {
-                    return 4096;
+                // Reference: https://platform.openai.com/docs/models
+
+                // gpt-3.5-*
+                if model_id.starts_with("gpt-3.5") {
+                    if model_id.starts_with("gpt-3.5-turbo-instruct") {
+                        return 4096;
+                    }
+                    if model_id == "gpt-3.5-turbo-0613" {
+                        return 4096;
+                    }
+                    return 16385;
                 }
-                if model_id.starts_with("gpt-4-32k") {
-                    return 32768;
-                }
-                if model_id.starts_with("gpt-4-1106-preview") {
+
+                // gpt-4*
+                if model_id.starts_with("gpt-4") {
+                    if model_id.starts_with("gpt-4-32k") {
+                        return 32768;
+                    }
+                    if model_id == "gpt-4" || model_id == "gpt-4-0613" {
+                        return 8192;
+                    }
                     return 128000;
                 }
-                if model_id.starts_with("gpt-4") {
-                    return 8192;
-                }
-                match model_id.as_str() {
-                    "code-davinci-002" => 8000,
-                    "text-davinci-002" => 4000,
-                    "text-davinci-003" => 4000,
-                    _ => 2048,
-                }
+
+                // By default return 128000
+                return 128000;
             }
-            None => 2048,
+            None => 128000,
         }
     }
 
@@ -696,6 +704,10 @@ impl Embedder for AzureOpenAIEmbedder {
 
     async fn decode(&self, tokens: Vec<usize>) -> Result<String> {
         decode_async(self.tokenizer(), tokens).await
+    }
+
+    async fn tokenize(&self, text: &str) -> Result<Vec<(usize, String)>> {
+        tokenize_async(self.tokenizer(), text).await
     }
 
     async fn embed(&self, text: Vec<&str>, extras: Option<Value>) -> Result<Vec<EmbedderVector>> {

--- a/core/src/providers/azure_openai.rs
+++ b/core/src/providers/azure_openai.rs
@@ -1,15 +1,16 @@
-use super::tiktoken::tiktoken::{decode_async, encode_async, tokenize_async};
 use crate::providers::embedder::{Embedder, EmbedderVector};
+use crate::providers::llm::ChatFunction;
 use crate::providers::llm::Tokens;
 use crate::providers::llm::{ChatMessage, LLMChatGeneration, LLMGeneration, LLM};
 use crate::providers::openai::{
     chat_completion, completion, embed, streamed_chat_completion, streamed_completion,
-    to_openai_messages, OpenAITool, OpenAIToolChoice,
+    to_openai_messages, OpenAILLM, OpenAITool, OpenAIToolChoice,
 };
 use crate::providers::provider::{Provider, ProviderID};
 use crate::providers::tiktoken::tiktoken::{
     cl100k_base_singleton, p50k_base_singleton, r50k_base_singleton, CoreBPE,
 };
+use crate::providers::tiktoken::tiktoken::{decode_async, encode_async, tokenize_async};
 use crate::run::Credentials;
 use crate::utils;
 use anyhow::{anyhow, Result};
@@ -24,8 +25,6 @@ use std::io::prelude::*;
 use std::str::FromStr;
 use std::sync::Arc;
 use tokio::sync::mpsc::UnboundedSender;
-
-use super::llm::ChatFunction;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 struct AzureOpenAIScaleSettings {
@@ -223,34 +222,7 @@ impl LLM for AzureOpenAILLM {
 
     fn context_size(&self) -> usize {
         match self.model_id.as_ref() {
-            Some(model_id) => {
-                // Reference: https://platform.openai.com/docs/models
-
-                // gpt-3.5-*
-                if model_id.starts_with("gpt-3.5") {
-                    if model_id.starts_with("gpt-3.5-turbo-instruct") {
-                        return 4096;
-                    }
-                    if model_id == "gpt-3.5-turbo-0613" {
-                        return 4096;
-                    }
-                    return 16385;
-                }
-
-                // gpt-4*
-                if model_id.starts_with("gpt-4") {
-                    if model_id.starts_with("gpt-4-32k") {
-                        return 32768;
-                    }
-                    if model_id == "gpt-4" || model_id == "gpt-4-0613" {
-                        return 8192;
-                    }
-                    return 128000;
-                }
-
-                // By default return 128000
-                return 128000;
-            }
+            Some(model_id) => OpenAILLM::openai_context_size(model_id),
             None => 128000,
         }
     }

--- a/core/src/providers/cohere.rs
+++ b/core/src/providers/cohere.rs
@@ -533,6 +533,16 @@ impl Embedder for CohereEmbedder {
         api_decode(self.api_key.as_ref().unwrap(), tokens).await
     }
 
+    // We return empty string in tokenize to partially support the endpoint.
+    async fn tokenize(&self, text: &str) -> Result<Vec<(usize, String)>> {
+        assert!(self.api_key.is_some());
+        let tokens = api_encode(self.api_key.as_ref().unwrap(), text).await?;
+        Ok(tokens
+            .iter()
+            .map(|t| (*t, "".to_string()))
+            .collect::<Vec<_>>())
+    }
+
     async fn embed(&self, text: Vec<&str>, _extras: Option<Value>) -> Result<Vec<EmbedderVector>> {
         assert!(self.api_key.is_some());
 

--- a/core/src/providers/embedder.rs
+++ b/core/src/providers/embedder.rs
@@ -29,6 +29,7 @@ pub trait Embedder {
 
     async fn encode(&self, text: &str) -> Result<Vec<usize>>;
     async fn decode(&self, tokens: Vec<usize>) -> Result<String>;
+    async fn tokenize(&self, text: &str) -> Result<Vec<(usize, String)>>;
 
     async fn embed(&self, text: Vec<&str>, extras: Option<Value>) -> Result<Vec<EmbedderVector>>;
 }

--- a/core/src/providers/mistral.rs
+++ b/core/src/providers/mistral.rs
@@ -452,7 +452,6 @@ impl MistralAILLM {
 
     fn tokenizer(&self) -> Arc<RwLock<SentencePieceProcessor>> {
         if self.id.starts_with("mistral-tiny")
-            || self.id.starts_with("mistral-embed")
             || self.id.starts_with("open-mistral-7b")
             || self.id.starts_with("open-mixtral-8x7b")
         {
@@ -1105,6 +1104,10 @@ impl Embedder for MistralEmbedder {
 
     async fn decode(&self, tokens: Vec<usize>) -> Result<String> {
         decode_async(self.tokenizer(), tokens).await
+    }
+
+    async fn tokenize(&self, text: &str) -> Result<Vec<(usize, String)>> {
+        tokenize_async(self.tokenizer(), text).await
     }
 
     async fn embed(&self, text: Vec<&str>, _extras: Option<Value>) -> Result<Vec<EmbedderVector>> {

--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -1,10 +1,12 @@
 use crate::providers::embedder::{Embedder, EmbedderVector};
 use crate::providers::llm::Tokens;
+use crate::providers::llm::{ChatFunction, ChatFunctionCall};
 use crate::providers::llm::{ChatMessage, ChatMessageRole, LLMChatGeneration, LLMGeneration, LLM};
 use crate::providers::provider::{ModelError, ModelErrorRetryOptions, Provider, ProviderID};
 use crate::providers::tiktoken::tiktoken::{
     cl100k_base_singleton, p50k_base_singleton, r50k_base_singleton, CoreBPE,
 };
+use crate::providers::tiktoken::tiktoken::{decode_async, encode_async, tokenize_async};
 use crate::run::Credentials;
 use crate::utils;
 use crate::utils::ParseError;
@@ -26,9 +28,6 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::time::timeout;
-
-use super::llm::{ChatFunction, ChatFunctionCall};
-use super::tiktoken::tiktoken::{decode_async, encode_async, tokenize_async};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Usage {
@@ -1399,6 +1398,35 @@ impl OpenAILLM {
             },
         }
     }
+
+    pub fn openai_context_size(model_id: &str) -> usize {
+        // Reference: https://platform.openai.com/docs/models
+
+        // gpt-3.5-*
+        if model_id.starts_with("gpt-3.5") {
+            if model_id.starts_with("gpt-3.5-turbo-instruct") {
+                return 4096;
+            }
+            if model_id == "gpt-3.5-turbo-0613" {
+                return 4096;
+            }
+            return 16385;
+        }
+
+        // gpt-4*
+        if model_id.starts_with("gpt-4") {
+            if model_id.starts_with("gpt-4-32k") {
+                return 32768;
+            }
+            if model_id == "gpt-4" || model_id == "gpt-4-0613" {
+                return 8192;
+            }
+            return 128000;
+        }
+
+        // By default return 128000
+        return 128000;
+    }
 }
 
 pub fn to_openai_messages(
@@ -1440,32 +1468,7 @@ impl LLM for OpenAILLM {
     }
 
     fn context_size(&self) -> usize {
-        // Reference: https://platform.openai.com/docs/models
-
-        // gpt-3.5-*
-        if self.id.starts_with("gpt-3.5") {
-            if self.id.starts_with("gpt-3.5-turbo-instruct") {
-                return 4096;
-            }
-            if self.id == "gpt-3.5-turbo-0613" {
-                return 4096;
-            }
-            return 16385;
-        }
-
-        // gpt-4*
-        if self.id.starts_with("gpt-4") {
-            if self.id.starts_with("gpt-4-32k") {
-                return 32768;
-            }
-            if self.id == "gpt-4" || self.id == "gpt-4-0613" {
-                return 8192;
-            }
-            return 128000;
-        }
-
-        // By default return 128000
-        return 128000;
+        Self::openai_context_size(self.id.as_str())
     }
 
     async fn encode(&self, text: &str) -> Result<Vec<usize>> {


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/dust/issues/5296
Also fixes context_size for openai/azure_openai. Had no impact since only used for "generate" which is quite legacy

Will pick the right tokenizer for data sources (cl100k) instead of falling back to (cl50k which is inaccurate).

## Risk

None

## Deploy Plan

- deploy core