### PR TITLE
enh(MA-builder): rm default desc and change placeholders for DS actions

### DIFF
--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -533,6 +533,11 @@ function ActionEditor({
   dustApps: AppType[];
   builderState: AssistantBuilderState;
 }) {
+  const isDataSourceAction = [
+    "TABLES_QUERY",
+    "RETRIEVAL_EXHAUSTIVE",
+    "RETRIEVAL_SEARCH",
+  ].includes(action.type as any);
   return (
     <div>
       <ActionModeSection show={true}>
@@ -642,9 +647,7 @@ function ActionEditor({
         })()}
       </ActionModeSection>
       <div className="flex flex-col gap-4 pt-8">
-        {["TABLES_QUERY", "RETRIEVAL_EXHAUSTIVE", "RETRIEVAL_SEARCH"].includes(
-          action.type as any
-        ) ? (
+        {isDataSourceAction ? (
           <div className="flex flex-col gap-2">
             <div className="font-semibold text-element-800">
               What's the data?
@@ -660,7 +663,11 @@ function ActionEditor({
           </div>
         )}
         <TextArea
-          placeholder="My action description.."
+          placeholder={
+            isDataSourceAction
+              ? "This data contains...."
+              : "My action description.."
+          }
           value={action.description}
           onChange={(v) => {
             updateAction({

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -168,7 +168,7 @@ export function getDefaultRetrievalSearchActionConfiguration() {
       },
     } as AssistantBuilderRetrievalConfiguration,
     name: "search_data_sources",
-    description: "Search in the user's data sources.",
+    description: "",
   } satisfies AssistantBuilderActionConfiguration;
 }
 
@@ -183,7 +183,7 @@ export function getDefaultRetrievalExhaustiveActionConfiguration() {
       },
     } as AssistantBuilderRetrievalConfiguration,
     name: "recent_data_sources",
-    description: "Retrieve the most recent data from the user's data sources.",
+    description: "",
   } satisfies AssistantBuilderActionConfiguration;
 }
 
@@ -203,7 +203,7 @@ export function getDefaultTablesQueryActionConfiguration() {
     type: "TABLES_QUERY",
     configuration: {} as AssistantBuilderTablesQueryConfiguration,
     name: "query_tables",
-    description: "Query structured tables via SQL.",
+    description: "",
   } satisfies AssistantBuilderActionConfiguration;
 }
 


### PR DESCRIPTION
## Description

For "data source actions" (search, exhaustive, tables query), we now ask users to "describe the data". The placeholder and default description no longer make sense.

I removed the default description, and updated the placeholder.

## Risk

N/A (MA only)

## Deploy Plan

N/A