### PR TITLE
feat: add confirmation modal when enabling MA

### DIFF
--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -7,8 +7,10 @@ import {
   ChevronLeftIcon,
   ChevronRightIcon,
   CircleIcon,
+  Dialog,
   IconButton,
   MagicIcon,
+  Page,
   SquareIcon,
   Tab,
   TriangleIcon,
@@ -248,6 +250,10 @@ export default function AssistantBuilder({
   const [template, setTemplate] =
     useState<FetchAssistantTemplateResponse | null>(defaultTemplate);
 
+  const [
+    showEnableMultiActionsConfirmation,
+    setShowEnableMultiActionsConfirmation,
+  ] = useState(false);
   const [multiActionsMode, setMultiActionsMode] = useState(multiActionsEnabled);
 
   const resetTemplate = async () => {
@@ -542,6 +548,14 @@ export default function AssistantBuilder({
 
   return (
     <>
+      <MultActionsConfirmationModal
+        show={showEnableMultiActionsConfirmation}
+        onClose={() => setShowEnableMultiActionsConfirmation(false)}
+        onConfirm={() => {
+          setMultiActionsMode(true);
+          setEdited(true);
+        }}
+      />
       <AppLayout
         subscription={subscription}
         hideSidebar
@@ -584,7 +598,11 @@ export default function AssistantBuilder({
                       icon={!multiActionsMode ? XMarkIcon : CheckIcon}
                       label={`Multi Actions ${multiActionsMode ? "On" : "Off"}`}
                       onClick={() => {
-                        setMultiActionsMode((mode) => !mode);
+                        if (!multiActionsMode) {
+                          setShowEnableMultiActionsConfirmation(true);
+                          return;
+                        }
+                        setMultiActionsMode(false);
                         setEdited(true);
                       }}
                       variant={!multiActionsMode ? "tertiary" : "primary"}
@@ -1032,5 +1050,43 @@ export function BuilderLayout({
         </div>
       </div>
     </>
+  );
+}
+
+export function MultActionsConfirmationModal({
+  show,
+  onClose,
+  onConfirm,
+}: {
+  show: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+}) {
+  return (
+    <Dialog
+      isOpen={show}
+      onCancel={() => onClose()}
+      onValidate={() => {
+        onConfirm();
+        onClose();
+      }}
+      title="Enable Multi Actions"
+    >
+      <Page.Vertical>
+        <div className="flex flex-col gap-y-2">
+          <div className="text-md grow font-medium text-warning-600">
+            Important
+          </div>
+          <div className="text-md font-normal text-element-700">
+            Multi Actions is an experimental feature that allows an assistant to
+            run multiple actions in a single run.
+          </div>
+          <div className="text-md font-normal text-element-700">
+            This feature is still in development and may not work as expected.
+            We may break or delete any assistant that uses this feature.
+          </div>
+        </div>
+      </Page.Vertical>
+    </Dialog>
   );
 }


### PR DESCRIPTION
## Description

Will add a link to the notion site documentation/tutorial once it lands.

<img width="658" alt="Screenshot 2024-05-29 at 17 21 16" src="https://github.com/dust-tt/dust/assets/14199823/483a7f6b-460a-40a8-babc-f9e661068612">

## Risk

N/A

## Deploy Plan

N/A