### PR TITLE
Revert [Gdrive] Fix: GDriveFiles deletion also deletes in GDriveFolers (#5333)

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -40,7 +40,6 @@ import { syncFailed } from "@connectors/lib/sync_status";
 import { heartbeat } from "@connectors/lib/temporal";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
-import { sequelizeConnection } from "@connectors/resources/storage";
 import type { DataSourceConfig } from "@connectors/types/data_source_config";
 import type { GoogleDriveObjectType } from "@connectors/types/google_drive";
 import { FILE_ATTRIBUTES_TO_FETCH } from "@connectors/types/google_drive";
@@ -848,19 +847,7 @@ async function deleteFile(googleDriveFile: GoogleDriveFiles) {
     const dataSourceConfig = dataSourceConfigFromConnector(connector);
     await deleteFromDataSource(dataSourceConfig, googleDriveFile.dustFileId);
   }
-  const folder = await GoogleDriveFolders.findOne({
-    where: {
-      connectorId: connectorId,
-      folderId: googleDriveFile.driveFileId,
-    },
-  });
-
-  await sequelizeConnection.transaction(async (t) => {
-    if (folder) {
-      await folder.destroy({ transaction: t });
-    }
-    await googleDriveFile.destroy({ transaction: t });
-  });
+  await googleDriveFile.destroy();
 }
 
 export async function markFolderAsVisited(


### PR DESCRIPTION


Description
---
This reverts commit 0a7ae81b50e9c83dd546f4f8ac27070d542a8290.

There is a potential issue in which it could actually remove user permission selection, because during garbage collect we delete files that have `isInFolders` set to false and this could delete selected folders, see [here](https://github.com/dust-tt/dust/blob/5a15ac5823300a76bdbc6ff4ef4491a29c4d059a/connectors/src/connectors/google_drive/temporal/activities.ts#L600). Reverting until we are clear on this.

@lasryaric PMRR