### PR TITLE
Send Slack notification on workspace creation

### DIFF
--- a/front/lib/iam/workspaces.ts
+++ b/front/lib/iam/workspaces.ts
@@ -1,7 +1,10 @@
+import { sendUserOperationMessage } from "@dust-tt/types";
+
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { Workspace, WorkspaceHasDomain } from "@app/lib/models/workspace";
 import { generateModelSId } from "@app/lib/utils";
 import { isDisposableEmailDomain } from "@app/lib/utils/disposable_email_domains";
+import logger from "@app/logger/logger";
 
 export async function createWorkspace(session: SessionWithUser) {
   const { user: externalUser } = session;
@@ -17,6 +20,17 @@ export async function createWorkspace(session: SessionWithUser) {
   const workspace = await Workspace.create({
     sId: generateModelSId(),
     name: externalUser.nickname,
+  });
+
+  sendUserOperationMessage({
+    message: `<:@U055XEGPR4L> +signupRadar User ${externalUser.email} has created a new workspace.`,
+    logger,
+    channel: "C075LJ6PUFQ",
+  }).catch((err) => {
+    logger.error(
+      { error: err },
+      "Failed to send user operation message to Slack (signup)."
+    );
   });
 
   if (verifiedDomain) {

--- a/types/src/shared/user_operation.ts
+++ b/types/src/shared/user_operation.ts
@@ -3,9 +3,11 @@ import { LoggerInterface } from "./logger";
 export async function sendUserOperationMessage({
   message,
   logger,
+  channel,
 }: {
   message: string;
   logger: LoggerInterface;
+  channel?: string;
 }) {
   const { SLACK_USER_OPERATION_BOT_TOKEN, SLACK_USER_OPERATION_CHANNEL_ID } =
     process.env;
@@ -26,7 +28,7 @@ export async function sendUserOperationMessage({
         Authorization: `Bearer ${SLACK_USER_OPERATION_BOT_TOKEN}`,
       },
       body: JSON.stringify({
-        channel: SLACK_USER_OPERATION_CHANNEL_ID,
+        channel: channel ?? SLACK_USER_OPERATION_CHANNEL_ID,
         text: message,
       }),
     });


### PR DESCRIPTION
## Description

@thib-martin and @clmrn are working on a hackathon project that will trigger a Dust assistant on Slack when a new workspace is created, with the goal of getting more information about the new customer.

This PR sends the Slack message they requested.
The Slack message is not being awaited for and can't failed the workspace creation process.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
