### PR TITLE
Allow the user of Sparkle/DropDownMenu to provide onKeyUp handler

### DIFF
--- a/sparkle/src/components/DropdownMenu.tsx
+++ b/sparkle/src/components/DropdownMenu.tsx
@@ -326,6 +326,7 @@ interface DropdownItemsProps {
   children: React.ReactNode;
   topBar?: React.ReactNode;
   bottomBar?: React.ReactNode;
+  onKeyDown?: (e: React.KeyboardEvent) => void;
   overflow?: "visible" | "auto";
   variant?: ItemsVariantType;
 }
@@ -337,6 +338,7 @@ DropdownMenu.Items = function ({
   children,
   topBar,
   bottomBar,
+  onKeyDown,
   overflow = "auto",
   variant = "default",
 }: DropdownItemsProps) {
@@ -427,6 +429,7 @@ DropdownMenu.Items = function ({
       leaveTo={getOriginTransClass(origin)}
     >
       <Menu.Items
+        onKeyDown={onKeyDown}
         className={classNames(
           "s-absolute s-z-10",
           getOriginClass(origin),

--- a/sparkle/src/stories/DropdownMenu.stories.tsx
+++ b/sparkle/src/stories/DropdownMenu.stories.tsx
@@ -497,6 +497,20 @@ export const DropdownExample = () => {
           </DropdownMenu.Items>
         </DropdownMenu>
       </div>
+
+      <div className="s-flex s-gap-6">
+        <div className="s-text-sm">Don't close on escape or space</div>
+        <DropdownMenu>
+          <DropdownMenu.Button icon={RobotIcon} />
+          <DropdownMenu.Items
+            origin="topRight"
+            onKeyDown={(e) => e.preventDefault()}
+          >
+            <DropdownMenu.Item label="@gpt4" />
+            <DropdownMenu.Item label="@slack" />
+          </DropdownMenu.Items>
+        </DropdownMenu>
+      </div>
     </>
   );
 };


### PR DESCRIPTION
## Description

Allow the user of Sparkle/DropDownMenu to provide onKeyUp handler.
The current use case for that feature is to make it possible to use the [space] key on a input field inside a DropDownMenu.
The current behavior (before this PR) is to automatically close the dropdown menu, this is done at the headless UI level.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
