### PR TITLE
enh(tables_query): honor agent config model

### DIFF
--- a/front/lib/api/assistant/actions/tables_query.ts
+++ b/front/lib/api/assistant/actions/tables_query.ts
@@ -288,6 +288,9 @@ export class TablesQueryConfigurationServerRunner extends BaseActionConfiguratio
       type: "database",
       tables,
     };
+    const { model } = agentConfiguration;
+    config.MODEL.provider_id = model.providerId;
+    config.MODEL.model_id = model.modelId;
 
     // Running the app
     const res = await runActionStreamed(


### PR DESCRIPTION
## Description

tables query app model was hard-coded to gpt4-o. This commit changes that to be more consistent with other actions and honor the model picked in the agent configuration

## Risk

Behavior of tables query agents that do not use gpt4o might change a bit

## Deploy Plan

deploy