### PR TITLE
[front] - fix: instruction UI on resize window

### DIFF
--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -1020,36 +1020,29 @@ export function BuilderLayout({
   isRightPanelOpen: boolean;
 }) {
   return (
-    <>
-      <div className="flex px-4 lg:hidden">
+    <div className="flex h-full w-full items-center">
+      <div className="flex h-full w-full max-w-[900px] grow gap-5 px-5">
         <div className="h-full w-full max-w-[900px]">{leftPanel}</div>
-      </div>
-      <div className="hidden h-full lg:flex">
-        <div className="h-full w-full">
-          <div className="flex h-full w-full items-center gap-4 px-5">
-            <div className="flex h-full grow justify-center">
-              <div className="h-full w-full max-w-[900px]">{leftPanel}</div>
-            </div>
-            {buttonsRightPanel}
+        <div className={classNames("hidden h-full items-center gap-4 lg:flex")}>
+          {buttonsRightPanel}
+          <div
+            className={classNames(
+              "duration-400 h-full transition-opacity ease-out",
+              isRightPanelOpen ? "opacity-100" : "opacity-0"
+            )}
+          >
             <div
               className={classNames(
-                "duration-400 s-h-full transition-opacity ease-out",
-                isRightPanelOpen ? "opacity-100" : "opacity-0"
+                "duration-800 h-full transition-all ease-out",
+                isRightPanelOpen ? "w-[440px]" : "w-0"
               )}
             >
-              <div
-                className={classNames(
-                  "duration-800 h-full transition-all ease-out",
-                  isRightPanelOpen ? "w-[440px]" : "w-0"
-                )}
-              >
-                {rightPanel}
-              </div>
+              {rightPanel}
             </div>
           </div>
         </div>
       </div>
-    </>
+    </div>
   );
 }
 

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -1020,10 +1020,10 @@ export function BuilderLayout({
   isRightPanelOpen: boolean;
 }) {
   return (
-    <div className="flex h-full w-full items-center">
-      <div className="flex h-full w-full max-w-[900px] grow gap-5 px-5">
+    <div className="flex h-full w-full items-center justify-center">
+      <div className="flex h-full w-full max-w-[900px] grow items-center justify-center gap-5 px-5">
         <div className="h-full w-full max-w-[900px]">{leftPanel}</div>
-        <div className={classNames("hidden h-full items-center gap-4 lg:flex")}>
+        <div className="hidden h-full items-center gap-4 lg:flex">
           {buttonsRightPanel}
           <div
             className={classNames(

--- a/front/components/assistant_builder/InstructionScreen.tsx
+++ b/front/components/assistant_builder/InstructionScreen.tsx
@@ -213,6 +213,8 @@ export function InstructionScreen({
   );
 }
 
+export default InstructionScreen;
+
 function AdvancedSettings({
   plan,
   generationSettings,

--- a/front/components/assistant_builder/InstructionScreen.tsx
+++ b/front/components/assistant_builder/InstructionScreen.tsx
@@ -213,8 +213,6 @@ export function InstructionScreen({
   );
 }
 
-export default InstructionScreen;
-
 function AdvancedSettings({
   plan,
   generationSettings,


### PR DESCRIPTION
## Description

This pull request includes two main changes to the assistant builder layout to improve its visual structure and responsiveness.

1. **Center BuilderLayout Components:**
   - Adjusted flexbox classes to center the BuilderLayout components in the view.
   
2. **Streamline Layout for Different Screen Sizes:**
   - Removed unnecessary parent divs and conditionally displayed right panel elements for a cleaner structure.
   - Adjusted opacity transition for the right panel to enhance visual effects when toggled.
   - Exported `InstructionScreen` as a default module to align with consistent module practices.

Fixes https://github.com/dust-tt/tasks/issues/803

**Note:** there's still a bug to be tackled #5378 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy `front`
