### PR TITLE
enh(ma-action-card): replace action desc by name

### DIFF
--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -29,6 +29,7 @@ import type {
   WorkspaceType,
 } from "@dust-tt/types";
 import { assertNever, MAX_TOOLS_USE_PER_RUN_LIMIT } from "@dust-tt/types";
+import _ from "lodash";
 import type { ReactNode } from "react";
 import React, { useCallback, useEffect, useState } from "react";
 
@@ -506,7 +507,7 @@ function ActionCard({
           />
         </div>
         <div className="w-full truncate text-base text-element-700">
-          {action.description}
+          {_.capitalize(_.toLower(action.name).replace(/_/g, " "))}
         </div>
       </div>
     </CardButton>


### PR DESCRIPTION
## Description

As per discussions, this commit replaces the action description by the action's name on the multi-actions card in ActionsScreen.

![Screenshot 2024-05-31 at 13 33 10](https://github.com/dust-tt/dust/assets/14199823/e4a7d484-efe8-4eb3-bb18-30a48b292385)




## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
