### PR TITLE
[front] - fix: assistant builder button alignment

### DIFF
--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -1021,8 +1021,8 @@ export function BuilderLayout({
 }) {
   return (
     <div className="flex h-full w-full items-center justify-center">
-      <div className="flex h-full w-full max-w-[900px] grow items-center justify-center gap-5 px-5">
-        <div className="h-full w-full max-w-[900px]">{leftPanel}</div>
+      <div className="flex h-full w-full grow items-center justify-center gap-5 px-5">
+        <div className="h-full w-full max-w-[900px] grow">{leftPanel}</div>
         <div className="hidden h-full items-center gap-4 lg:flex">
           {buttonsRightPanel}
           <div


### PR DESCRIPTION
## Description

This PR aims at fixing the alignment of the instructions buttons when instructing an assistant see picture below:

![Screenshot 2024-05-31 at 12 53 20](https://github.com/dust-tt/dust/assets/32683010/ff384ab6-2497-45f9-bd2a-76abdefa5121)



## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
