### PR TITLE
[Websearch Action] Handle serpApi errors & no results

### DIFF
--- a/front/components/assistant/conversation/WebsearchAction.tsx
+++ b/front/components/assistant/conversation/WebsearchAction.tsx
@@ -3,6 +3,7 @@ import {
   ChevronRightIcon,
   Chip,
   Icon,
+  InformationCircleIcon,
   MagnifyingGlassStrokeIcon,
   Spinner,
   Tooltip,
@@ -24,6 +25,19 @@ export default function WebsearchAction({
   const [isResultsListVisible, setIsResultsListVisible] = useState(false);
 
   const { results } = websearchAction.output ?? { results: [] };
+
+  const rawError =
+    websearchAction.output && "error" in websearchAction.output
+      ? // typescript can't narrow despite the check above
+        (websearchAction.output as { error: string }).error
+      : null;
+
+  // no results is not an error per se so we won't display it with a red chip
+  // but serpApi returns an error so we have to prevent it from being considered
+  // as such
+  const error = rawError?.includes("Google hasn't returned any results")
+    ? null
+    : rawError;
 
   return (
     <>
@@ -55,20 +69,33 @@ export default function WebsearchAction({
         <div className="row-span-1 select-none">
           {websearchAction.output && (
             <div
-              onClick={() => setIsResultsListVisible(!isResultsListVisible)}
+              onClick={() =>
+                results.length > 0 &&
+                setIsResultsListVisible(!isResultsListVisible)
+              }
               className="cursor-pointer"
             >
               <Chip color="purple">
                 {results.length > 0
                   ? SearchResultsInfo(results)
                   : "No results found"}
-                <Icon
-                  visual={
-                    isResultsListVisible ? ChevronDownIcon : ChevronRightIcon
-                  }
-                  size="xs"
-                />
+                {results.length > 0 && (
+                  <Icon
+                    visual={
+                      isResultsListVisible ? ChevronDownIcon : ChevronRightIcon
+                    }
+                    size="xs"
+                  />
+                )}
               </Chip>
+              {error && (
+                <Tooltip label={`Error message: ${error}`}>
+                  <Chip color="red">
+                    <Icon visual={InformationCircleIcon} size="xs" />
+                    Error searching the web
+                  </Chip>
+                </Tooltip>
+              )}
             </div>
           )}
         </div>

--- a/types/src/front/assistant/actions/websearch.ts
+++ b/types/src/front/assistant/actions/websearch.ts
@@ -1,3 +1,5 @@
+import * as t from "io-ts";
+
 import { ModelId } from "../../../shared/model_id";
 import { BaseAction } from "../../lib/api/assistant/actions";
 
@@ -10,15 +12,27 @@ export type WebsearchConfigurationType = {
   forceUseAtIteration: number | null;
 };
 
-export type WebsearchActionOutputType = {
-  results: WebsearchResultType[];
-};
+export const WebsearchResultSchema = t.type({
+  title: t.string,
+  snippet: t.string,
+  link: t.string,
+});
 
-export type WebsearchResultType = {
-  title: string;
-  snippet: string;
-  link: string;
-};
+export const WebsearchActionOutputSchema = t.union([
+  t.type({
+    results: t.array(WebsearchResultSchema),
+  }),
+  t.type({
+    results: t.array(WebsearchResultSchema),
+    error: t.string,
+  }),
+]);
+
+export type WebsearchActionOutputType = t.TypeOf<
+  typeof WebsearchActionOutputSchema
+>;
+
+export type WebsearchResultType = t.TypeOf<typeof WebsearchResultSchema>;
 
 export interface WebsearchActionType extends BaseAction {
   agentMessageId: ModelId;

--- a/types/src/front/lib/actions/registry.ts
+++ b/types/src/front/lib/actions/registry.ts
@@ -161,7 +161,7 @@ export const DustProdActionRegistry = createActionRegistry({
       workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
       appId: "098b515f8e",
       appHash:
-        "0ad751ed5f3e4a312dfe50ea1ec63bc8b31ebd5a77f580d71ec8c1af621891aa",
+        "74ece03e8c502d4ae1681847df945248b43b63a0eaa811daed50a3bc81615ac4",
     },
     config: { SEARCH: { provider_id: "serpapi", use_cache: false } },
   },


### PR DESCRIPTION
Description
---
When serpApi finds no results, it returns an error. This lead to a cryptic failure such as [here](https://dust.tt/w/0ec9852c2f/assistant/b43235c58c).

This PR handles the no-results case (which should not err), and any other error case (which should err)

Also, using the opportunity to io-ts WebsearchActionOutputType so we get proper errors in weird cases (vs the previous `as`)

Risk
---
N/A (gated)

Deploy
---
Front
