### PR TITLE
Flav/embedder migrations

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -12,6 +12,10 @@ name = "qdrant_migrator"
 path = "bin/qdrant/migrator.rs"
 
 [[bin]]
+name = "qdrant_migrate_embedder"
+path = "bin/qdrant/migrate_embedder.rs"
+
+[[bin]]
 name = "qdrant_create_collection"
 path = "bin/qdrant/create_collection.rs"
 

--- a/core/bin/qdrant/migrate_embedder.rs
+++ b/core/bin/qdrant/migrate_embedder.rs
@@ -1,0 +1,884 @@
+use anyhow::{anyhow, Result};
+use clap::{Parser, Subcommand};
+use dust::{
+    data_sources::{
+        data_source::{EmbedderConfig, EmbedderDataSourceConfig},
+        qdrant::{QdrantClients, QdrantCluster, QdrantDataSourceConfig},
+    },
+    providers::{
+        embedder::{EmbedderRequest, EmbedderVector, SupportedEmbedderModels},
+        provider::ProviderID,
+    },
+    run::Credentials,
+    stores::{postgres, store::Store},
+    utils,
+};
+use futures::StreamExt;
+use futures::TryStreamExt;
+use qdrant_client::{
+    prelude::Payload,
+    qdrant::{self, point_id, PointId},
+};
+use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, fs::File};
+use std::{
+    env,
+    io::{self, BufRead, BufReader},
+};
+use tokio_stream::{self as stream};
+
+#[derive(Debug, Subcommand)]
+enum Commands {
+    #[command(arg_required_else_help = true)]
+    #[command(about = "Show qdrant state for data source", long_about = None)]
+    Show { data_source_internal_id: String },
+
+    #[command(arg_required_else_help = true)]
+    #[command(about = "Set `shadow_embedder_config`", long_about = None)]
+    SetShadowEmbedder {
+        data_source_internal_id: String,
+        provider_id: ProviderID,
+        model_id: SupportedEmbedderModels,
+    },
+
+    #[command(arg_required_else_help = true)]
+    #[command(about = "Clear `shadow_write_embedder` \
+                       (!!! deletes data_points from `shadow_embedder` collection)", long_about = None)]
+    ClearShadowEmbedder { data_source_internal_id: String },
+
+    #[command(arg_required_else_help = true)]
+    #[command(about = "Migrate points from `embedder` collection to `shadow_embedder` collection", long_about = None)]
+    MigrateShadowEmbedder { data_source_internal_id: String },
+
+    #[command(arg_required_else_help = true)]
+    #[command(about = "Switch `shadow_embedder` and `embedder` \
+                       (!!! moves read traffic to `shadow_embedder`)", long_about = None)]
+    CommitShadowEmbedder { data_source_internal_id: String },
+
+    #[command(arg_required_else_help = true)]
+    #[command(about = "Automatically migrate a collection to a new cluster \
+                       (!!! creates, shadow writes, migrates, \
+                        and deletes collection from original cluster)", long_about = None)]
+    Migrate {
+        data_source_internal_id: String,
+        cluster: String,
+    },
+    #[command(arg_required_else_help = true)]
+    #[command(about = "Migrate a set of collections from a JSONL file to a new cluster \
+                       (!!! creates, shadow writes, migrates, \
+                        and deletes collection from original cluster)", long_about = None)]
+    MigrateFile { json_path: String, cluster: String },
+}
+
+async fn load_credentials_from_env() -> Credentials {
+    // Retrieve the environment variables.
+    let mistral_api_key =
+        env::var("DUST_MANAGED_MISTRAL_API_KEY").expect("MISTRAL_API_KEY not set");
+    let openai_api_key = env::var("DUST_MANAGED_OPENAI_API_KEY").expect("OPENAI_API_KEY not set");
+
+    // Create the credentials HashMap.
+    let credentials: Credentials = [
+        ("MISTRAL_API_KEY".to_string(), mistral_api_key),
+        ("OPENAI_API_KEY".to_string(), openai_api_key),
+    ]
+    .iter()
+    .cloned()
+    .collect();
+
+    credentials
+}
+
+async fn show(
+    store: Box<dyn Store + Sync + Send>,
+    qdrant_clients: QdrantClients,
+    data_source_internal_id: String,
+) -> Result<()> {
+    let ds = match store
+        .load_data_source_by_internal_id(&data_source_internal_id)
+        .await?
+    {
+        Some(ds) => ds,
+        None => Err(anyhow!("Data source not found"))?,
+    };
+
+    utils::info(&format!(
+        "Data source: \
+            data_source_internal_id={} data_source_id={} cluster={} shadow_write_cluster={} embedder_config={} shadow_embedder_config={}",
+        ds.internal_id(),
+        ds.data_source_id(),
+        ds.main_qdrant_cluster().to_string(),
+        match ds.shadow_write_qdrant_cluster() {
+            Some(cluster) => cluster.to_string(),
+            None => "none".to_string(),
+        },
+        ds.embedder_config(),
+        match ds.shadow_embedder_config() {
+          Some(sec) => sec.to_string(),
+          None => "none".to_string()
+        }
+    ));
+
+    let qdrant_client = ds.main_qdrant_client(&qdrant_clients);
+    match qdrant_client
+        .collection_info(&ds.embedder_config())
+        .await?
+        .result
+    {
+        Some(info) => {
+            utils::info(&format!(
+                "[MAIN] Qdrant collection: collection={} status={} points_count={:?} cluster={}",
+                qdrant_client.collection_name(&ds.embedder_config()),
+                info.status.to_string(),
+                info.points_count,
+                ds.main_qdrant_cluster().to_string(),
+            ));
+        }
+        None => Err(anyhow!("Qdrant collection not found"))?,
+    }
+
+    match ds.shadow_embedder_config() {
+        Some(shadow_embedder_config) => {
+            match qdrant_client
+                .collection_info(shadow_embedder_config)
+                .await?
+                .result
+            {
+                Some(info) => {
+                    utils::info(&format!(
+                        "[SHADOW] Qdrant collection: collection={} status={} \
+                            points_count={:?} cluster={}",
+                        match ds.shadow_embedder_config() {
+                            Some(sec) => qdrant_client.collection_name(sec),
+                            None => "none".to_string(),
+                        },
+                        info.status.to_string(),
+                        info.points_count,
+                        ds.main_qdrant_cluster().to_string(),
+                    ));
+                }
+                None => Err(anyhow!("Qdrant collection not found"))?,
+            }
+        }
+        None => (),
+    };
+
+    Ok(())
+}
+
+async fn set_shadow_embedder(
+    store: Box<dyn Store + Sync + Send>,
+    qdrant_clients: QdrantClients,
+    data_source_internal_id: String,
+    provider_id: ProviderID,
+    model_id: SupportedEmbedderModels,
+) -> Result<()> {
+    let mut ds = match store
+        .load_data_source_by_internal_id(&data_source_internal_id)
+        .await?
+    {
+        Some(ds) => ds,
+        None => Err(anyhow!("Data source not found"))?,
+    };
+
+    // /!\ Currently, migrating the embedder is not supported when double write is enabled.
+    // Although the downstream code is capable of handling this situation, we have chosen
+    // to disable migration in such cases to avoid potential issues or inconsistencies for now.
+    match ds.shadow_write_qdrant_cluster() {
+        Some(_) => Err(anyhow!(
+            "Embedder migration aborted: Double write is currently enabled. \
+            Please disable double write before proceeding."
+        )),
+        None => Ok(()),
+    }?;
+
+    let mut config = ds.config().clone();
+    let qdrant_client = ds.main_qdrant_client(&qdrant_clients);
+
+    let shadow_embedder_config = EmbedderConfig {
+        model_id: model_id.to_string(),
+        provider_id,
+        splitter_id: ds.embedder_config().splitter_id,
+        max_chunk_size: ds.embedder_config().max_chunk_size,
+    };
+
+    // Assert that collection for shadow embedder exists.
+    match qdrant_client
+        .collection_info(&shadow_embedder_config)
+        .await?
+        .result
+    {
+        Some(_) => Ok(()),
+        None => Err(anyhow!(format!(
+            "Qdrant collection {} not found for shadow embedder.",
+            qdrant_client.collection_name(&shadow_embedder_config)
+        ))),
+    }?;
+
+    // Set shadow embedder config.
+    config.embedder_config = EmbedderDataSourceConfig {
+        embedder: config.embedder_config.embedder,
+        shadow_embedder: Some(shadow_embedder_config),
+    };
+
+    ds.update_config(store, &config).await?;
+
+    utils::done(&format!(
+        "Updated data source: \
+            data_source_internal_id={} data_source_id={} cluster={} embedder_config={} shadow_embedder_config={}",
+        ds.internal_id(),
+        ds.data_source_id(),
+        ds.main_qdrant_cluster().to_string(),
+        ds.embedder_config(),
+        match ds.shadow_embedder_config() {
+            Some(sec) => sec.to_string(),
+            None => "none".to_string(),
+        }
+    ));
+
+    Ok(())
+}
+
+async fn clear_shadow_embedder(
+    store: Box<dyn Store + Sync + Send>,
+    qdrant_clients: QdrantClients,
+    data_source_internal_id: String,
+    ask_confirmation: bool,
+) -> Result<()> {
+    let mut ds = match store
+        .load_data_source_by_internal_id(&data_source_internal_id)
+        .await?
+    {
+        Some(ds) => ds,
+        None => Err(anyhow!("Data source not found"))?,
+    };
+
+    let shadow_embedder_config = match ds.shadow_embedder_config() {
+        Some(sec) => sec,
+        None => Err(anyhow!("No shadow embedder config to clear"))?,
+    };
+
+    let qdrant_client = ds.main_qdrant_client(&qdrant_clients);
+
+    if ask_confirmation {
+        // Ask for confirmation.
+        match utils::confirm(&format!(
+            "[DANGER] Are you sure you want to delete points \
+                from cluster {} and collection {} for this data source? \
+                (this is definitive)",
+            ds.main_qdrant_cluster().to_string(),
+            qdrant_client.collection_name(shadow_embedder_config),
+        ))? {
+            true => (),
+            false => Err(anyhow!("Aborted"))?,
+        }
+    }
+
+    // Delete all points on shadow_embedder_config collection for data source.
+    // TODO: Add delete count in this function.
+    qdrant_client
+        .delete_all_points_for_internal_id(shadow_embedder_config, &ds.internal_id().to_string())
+        .await?;
+
+    utils::done(&format!(
+        "Deleted all points for data source on collection {} in cluster {}.",
+        qdrant_client.collection_name(shadow_embedder_config),
+        ds.main_qdrant_cluster()
+    ));
+
+    // Remove shadow_embedder from config.
+    let mut config = ds.config().clone();
+
+    config.embedder_config = EmbedderDataSourceConfig {
+        embedder: config.embedder_config.embedder,
+        shadow_embedder: None,
+    };
+
+    ds.update_config(store, &config).await?;
+
+    utils::done(&format!(
+        "Updated data source: \
+            data_source_internal_id={} data_source_id={} cluster={} embedder={} embedder_config={}",
+        ds.internal_id(),
+        ds.data_source_id(),
+        ds.main_qdrant_cluster().to_string(),
+        ds.embedder_config(),
+        match ds.shadow_embedder_config() {
+            Some(sec) => sec.to_string(),
+            None => "none".to_string(),
+        }
+    ));
+
+    Ok(())
+}
+
+pub fn get_qdrant_point_id_as_string(point_id: &PointId) -> Option<String> {
+    match &point_id.point_id_options {
+        Some(point_id::PointIdOptions::Uuid(id)) => Some(id.clone()),
+        Some(point_id::PointIdOptions::Num(id)) => Some(id.to_string()),
+        None => None,
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ChunkInfoFromPoints {
+    hash: String,
+    text: String,
+    payload: HashMap<String, qdrant_client::prelude::Value>,
+}
+
+async fn migrate_shadow_embedder(
+    store: Box<dyn Store + Sync + Send>,
+    qdrant_clients: QdrantClients,
+    data_source_internal_id: String,
+) -> Result<()> {
+    let ds = match store
+        .load_data_source_by_internal_id(&data_source_internal_id)
+        .await?
+    {
+        Some(ds) => ds,
+        None => Err(anyhow!("Data source not found."))?,
+    };
+
+    let points_per_request = match std::env::var("POINTS_PER_REQUEST") {
+        Ok(v) => v.parse::<usize>()?,
+        Err(_) => 256,
+    };
+
+    let qdrant_client = ds.main_qdrant_client(&qdrant_clients);
+
+    let shadow_embedder_config = match ds.shadow_embedder_config() {
+        Some(sec) => sec,
+        None => Err(anyhow!(
+            "Embedder migration aborted: No shadow embedder config set on the data source."
+        ))?,
+    };
+
+    let credentials = load_credentials_from_env().await;
+
+    // TODO:
+    // Delete all data points on shadow embedder collection.
+    // let shadow_write_qdrant_client = match ds.shadow_write_qdrant_client(&qdrant_clients) {
+    //     Some(client) => client,
+    //     None => Err(anyhow!("No shadow write cluster to migrate to"))?,
+    // };
+
+    utils::info(&format!(
+        "Migrating points: points_per_request={}",
+        points_per_request
+    ));
+
+    let mut page_offset: Option<PointId> = None;
+    let mut total: usize = 0;
+    let mut retry: usize = 0;
+    let mut iterations: usize = 0;
+
+    // TODO: We need to record the time of the shadow write enabled. So we can update the chunk_count afterward!!
+
+    loop {
+        let now = utils::now();
+        let scroll_results = match qdrant_client
+            .scroll(
+                &ds.embedder_config(),
+                &ds.internal_id().to_string(),
+                // TODO:(2024-05-31 flav) Remove unused parameter.
+                None, // Tenant filter is injected by the client.
+                Some(points_per_request as u32),
+                page_offset.clone(),
+                Some(true.into()),
+            )
+            .await
+        {
+            Ok(r) => r,
+            Err(e) => {
+                if retry < 3 {
+                    retry += 1;
+                    utils::error(&format!(
+                        "Error migrating points (read): retry={} error={:?}",
+                        retry, e
+                    ));
+                    tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+                    continue;
+                } else {
+                    Err(e)?
+                }
+            }
+        };
+
+        let count = scroll_results.result.len();
+
+        let points = scroll_results
+            .result
+            .into_iter()
+            .map(|r| {
+                qdrant::PointStruct::new(
+                    r.id.unwrap(),
+                    r.vectors.unwrap(),
+                    Payload::new_from_hashmap(r.payload),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        // Empty upserts trigger errors.
+        if count > 0 {
+            points.iter().for_each(|p| {
+                println!("POINTS: {:#?}", p);
+                println!("ID: {:?}", p.id);
+                println!("PAYLOAD: {:#?}", p.payload);
+            });
+
+            // TODO: Preserve order.
+
+            let splits_with_hash: Vec<ChunkInfoFromPoints> = points
+                .iter()
+                .filter_map(|p| {
+                    // Check if the "text" key exists in the payload.
+                    // If it exists, create a ChunkInfoFromPoints.
+                    match &p.id {
+                        Some(pid) => {
+                            match (get_qdrant_point_id_as_string(pid), p.payload.get("text")) {
+                                (Some(id), Some(text)) => {
+                                    println!("TEXT: {:?}", text);
+
+                                    Some(ChunkInfoFromPoints {
+                                        hash: id,
+                                        text: text.to_string(),
+                                        payload: p.payload.clone(),
+                                    })
+                                }
+                                // If it doesn't exist, filter out the point.
+                                (_, _) => None,
+                            }
+                        }
+                        None => None,
+                    }
+                })
+                .collect();
+
+            splits_with_hash.iter().for_each(|s| {
+                println!("SPLIT: {:#?}", s);
+            });
+
+            // Chunk splits into a vectors of 8 chunks (Vec<Vec<String>>)
+            let chunked_splits = splits_with_hash
+                .chunks(8)
+                .map(|chunk| chunk.to_vec())
+                .collect::<Vec<_>>();
+
+            let mut embeddings: HashMap<String, EmbedderVector> = HashMap::new();
+
+            for chunk in chunked_splits {
+                let r = EmbedderRequest::new(
+                    shadow_embedder_config.provider_id.clone(),
+                    &shadow_embedder_config.model_id.to_string(),
+                    chunk.iter().map(|ci| ci.text.as_str()).collect::<Vec<_>>(),
+                    ds.config().extras.clone(),
+                );
+
+                let v = match r.execute(credentials.clone()).await {
+                    Ok(v) => v,
+                    Err(e) => Err(anyhow!("DataSource chunk embedding error: {}", e))?,
+                };
+
+                for (ci, v) in chunk.into_iter().zip(v.into_iter()) {
+                    embeddings.insert(ci.hash.clone(), v);
+                }
+            }
+
+            println!("EMBEDDINGS: {:#?}", embeddings);
+
+            utils::info(&format!(
+                "Finished embedding chunks for data_source={} chunk_count={} total={} latency_ms={}",
+                data_source_internal_id,
+                count,
+                total,
+                utils::now() - now
+            ));
+
+            let points_to_upsert = splits_with_hash
+                .iter()
+                .map(|ci| match embeddings.get(&ci.hash) {
+                    Some(v) => {
+                        let mut payload = Payload::new();
+                        for (key, value) in ci.payload.iter() {
+                            payload.insert(key.clone(), value.clone());
+                        }
+
+                        let ps = qdrant::PointStruct::new(
+                            ci.hash.to_string(),
+                            v.vector.iter().map(|v| *v as f32).collect::<Vec<f32>>(),
+                            payload,
+                        );
+
+                        Ok(ps)
+                    }
+                    None => Err(anyhow!("DataSource embedding error: Missin chunk")),
+                })
+                .collect::<Result<Vec<_>>>()?;
+
+            points_to_upsert.iter().for_each(|p| {
+                println!("POINTS: {:#?}", p);
+                println!("ID: {:?}", p.id);
+                println!("PAYLOAD: {:#?}", p.payload);
+            });
+
+            match qdrant_client
+                .upsert_points(
+                    &shadow_embedder_config,
+                    &ds.internal_id().to_string(),
+                    points_to_upsert,
+                )
+                .await
+            {
+                Ok(_) => (),
+                Err(e) => {
+                    if retry < 3 {
+                        retry += 1;
+                        utils::error(&format!(
+                            "Error migrating points (write): retry={} error={:?}",
+                            retry, e
+                        ));
+                        tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+                        continue;
+                    } else {
+                        Err(e)?
+                    }
+                }
+            }
+        }
+
+        total += count;
+
+        if iterations % 8 == 0 {
+            utils::info(&format!(
+                "Migrated points: count={} total={} latency_ms={}",
+                count,
+                total,
+                utils::now() - now
+            ));
+        }
+
+        page_offset = scroll_results.next_page_offset;
+        if page_offset.is_none() {
+            break;
+        }
+        retry = 0;
+        iterations += 1;
+    }
+
+    utils::info(&format!("Done migrating: total={}", total));
+    Ok(())
+}
+
+async fn commit_shadow_embedder(
+    store: Box<dyn Store + Sync + Send>,
+    data_source_internal_id: String,
+) -> Result<()> {
+    let mut ds = match store
+        .load_data_source_by_internal_id(&data_source_internal_id)
+        .await?
+    {
+        Some(ds) => ds,
+        None => Err(anyhow!("Data source not found"))?,
+    };
+
+    let mut config = ds.config().clone();
+
+    // Switch embedder and shadow embedder.
+    config.embedder_config = match config.embedder_config.shadow_embedder {
+        Some(shadow_embedder) => EmbedderDataSourceConfig {
+            embedder: shadow_embedder.clone(),
+            shadow_embedder: Some(config.embedder_config.embedder),
+        },
+        None => Err(anyhow!("No shadow embedder to commit"))?,
+    };
+
+    ds.update_config(store, &config).await?;
+
+    utils::info(&format!(
+        "Updated data source: \
+            data_source_internal_id={}  data_source_id={} cluster={} embedder={} shadow_embedder={}",
+        ds.internal_id(),
+        ds.data_source_id(),
+        ds.main_qdrant_cluster().to_string(),
+        ds.embedder_config(),
+        match ds.shadow_embedder_config() {
+            Some(sec) => sec.to_string(),
+            None => "none".to_string(),
+        }
+    ));
+    Ok(())
+}
+
+async fn migrate(
+    store: Box<dyn Store + Sync + Send>,
+    qdrant_clients: QdrantClients,
+    data_source_internal_id: String,
+    model_id: SupportedEmbedderModels,
+    provider_id: ProviderID,
+    ask_confirmation: bool,
+) -> Result<()> {
+    let ds = match store
+        .load_data_source_by_internal_id(&data_source_internal_id)
+        .await?
+    {
+        Some(ds) => ds,
+        None => Err(anyhow!("Data source not found"))?,
+    };
+    utils::info(&format!(
+        "Migrating data source: data_source_internal_id={} data_source_id={} cluster={} current_embedder={} target_embedder={}",
+        ds.internal_id(),
+        ds.data_source_id(),
+        ds.main_qdrant_cluster(),
+        ds.embedder_config(),
+        EmbedderConfig {
+            max_chunk_size: ds.embedder_config().max_chunk_size,
+            model_id: model_id.to_string(),
+            provider_id,
+            splitter_id: ds.embedder_config().splitter_id,
+        }
+    ));
+
+    // let from_cluster = ds.main_qdrant_cluster().to_string();
+
+    // // First show the current state.
+    // show(
+    //     store.clone(),
+    //     qdrant_clients.clone(),
+    //     data_source_internal_id.clone(),
+    // )
+    // .await?;
+
+    // if ask_confirmation {
+    //     // Confirm this is the migration we want.
+    //     match utils::confirm(&format!(
+    //         "Do you confirm `set_shadow_write` + `migrate_shadow_write`: \
+    //             data_source_internal_id={} data_source_id={} from_cluster={} target_cluster={}?",
+    //         ds.internal_id(),
+    //         ds.data_source_id(),
+    //         from_cluster,
+    //         target_cluster,
+    //     ))? {
+    //         true => (),
+    //         false => Err(anyhow!("Aborted"))?,
+    //     }
+    // }
+
+    // set_shadow_embedder(
+    //     store.clone(),
+    //     qdrant_clients.clone(),
+    //     data_source_internal_id.clone(),
+    //     target_cluster.clone(),
+    // )
+    // .await?;
+
+    // migrate_shadow_write(
+    //     store.clone(),
+    //     qdrant_clients.clone(),
+    //     data_source_internal_id.clone(),
+    // )
+    // .await?;
+
+    // if ask_confirmation {
+    //     // Confirm we're ready to commit.
+    //     match utils::confirm(&format!(
+    //         "Do you confirm `commit_shadow_write` + `clear_shadow_write`: \
+    //            data_source_internal_id={} data_source_id={} from_cluster={} target_cluster={}?",
+    //         ds.internal_id(),
+    //         ds.data_source_id(),
+    //         from_cluster,
+    //         target_cluster,
+    //     ))? {
+    //         true => (),
+    //         false => Err(anyhow!("Aborted"))?,
+    //     }
+    // }
+
+    // commit_shadow_write(
+    //     store.clone(),
+    //     qdrant_clients.clone(),
+    //     data_source_internal_id.clone(),
+    // )
+    // .await?;
+
+    // clear_shadow_write(
+    //     store.clone(),
+    //     qdrant_clients.clone(),
+    //     data_source_internal_id.clone(),
+    //     ask_confirmation,
+    // )
+    // .await?;
+
+    // utils::done(&format!(
+    //     "Data source migrated: \
+    //        data_source_internal_id={} data_source_id={} from_cluster={} target_cluster={}?",
+    //     ds.data_source_id(),
+    //     ds.internal_id(),
+    //     from_cluster,
+    //     target_cluster,
+    // ));
+
+    // show(
+    //     store.clone(),
+    //     qdrant_clients.clone(),
+    //     data_source_internal_id.clone(),
+    // )
+    // .await?;
+
+    Ok(())
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct MigrationRecord {
+    data_source_id: String,
+    internal_id: String,
+}
+
+async fn migrate_file(
+    store: Box<dyn Store + Sync + Send>,
+    qdrant_clients: QdrantClients,
+    json_path: String,
+    target_cluster: String,
+) -> Result<()> {
+    // let file = File::open(json_path)?;
+    // let reader = BufReader::new(file);
+    // let records = reader
+    //     .lines()
+    //     .map(|line| {
+    //         // Each line is a JSON
+    //         let line = line?;
+    //         serde_json::from_str(&line).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+    //     })
+    //     .collect::<Result<Vec<MigrationRecord>, std::io::Error>>()?;
+
+    // match utils::confirm(&format!(
+    //     "Do you confirm you want to migrate {} collections: \
+    //         target_cluster={}?",
+    //     records.len(),
+    //     target_cluster,
+    // ))? {
+    //     true => (),
+    //     false => Err(anyhow!("Aborted"))?,
+    // }
+
+    // stream::iter(records.into_iter().map(|record| {
+    //     let store = store.clone();
+    //     let target_cluster = target_cluster.clone();
+    //     let qdrant_clients = qdrant_clients.clone();
+    //     async move {
+    //         migrate(
+    //             store,
+    //             qdrant_clients,
+    //             record.internal_id,
+    //             target_cluster,
+    //             false,
+    //         )
+    //         .await
+    //     }
+    // }))
+    // .buffer_unordered(1)
+    // .try_collect::<Vec<_>>()
+    // .await?;
+
+    Ok(())
+}
+
+#[derive(Debug, Parser)]
+#[command(name = "collection_migrator")]
+#[command(about = "Tooling to migrate Data sources on Qdrant", long_about = None)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+fn main() -> Result<()> {
+    let args = Cli::parse();
+
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(32)
+        .enable_all()
+        .build()
+        .unwrap();
+
+    let r = rt.block_on(async {
+        tracing_subscriber::fmt()
+            .with_target(false)
+            .compact()
+            .with_ansi(false)
+            .init();
+        let store: Box<dyn Store + Sync + Send> = match std::env::var("CORE_DATABASE_URI") {
+            Ok(db_uri) => {
+                let store = postgres::PostgresStore::new(&db_uri).await?;
+                Box::new(store)
+            }
+            Err(_) => Err(anyhow!("CORE_DATABASE_URI is required (postgres)"))?,
+        };
+
+        let qdrant_clients = QdrantClients::build().await?;
+
+        match args.command {
+            Commands::Show {
+                data_source_internal_id,
+            } => show(store, qdrant_clients, data_source_internal_id).await,
+
+            Commands::SetShadowEmbedder {
+                data_source_internal_id,
+                model_id,
+                provider_id,
+            } => {
+                set_shadow_embedder(
+                    store,
+                    qdrant_clients,
+                    data_source_internal_id,
+                    provider_id,
+                    model_id,
+                )
+                .await
+            }
+
+            Commands::ClearShadowEmbedder {
+                data_source_internal_id,
+            } => {
+                // This is the most dangerous command of all as it is the only one to actually
+                // delete data in an unrecoverable way.
+                clear_shadow_embedder(store, qdrant_clients, data_source_internal_id, true).await
+            }
+
+            Commands::MigrateShadowEmbedder {
+                data_source_internal_id,
+            } => migrate_shadow_embedder(store, qdrant_clients, data_source_internal_id).await,
+
+            Commands::CommitShadowEmbedder {
+                data_source_internal_id,
+            } => commit_shadow_embedder(store, data_source_internal_id).await,
+
+            Commands::Migrate {
+                data_source_internal_id,
+                cluster,
+            } => {
+                // migrate(
+                //     store,
+                //     qdrant_clients,
+                //     data_source_internal_id,
+                //     cluster,
+                //     true,
+                // )
+                // .await
+                todo!();
+            }
+
+            Commands::MigrateFile { json_path, cluster } => {
+                migrate_file(store, qdrant_clients, json_path, cluster).await
+            }
+        }
+    });
+
+    match r {
+        Ok(_) => (),
+        Err(e) => {
+            utils::error(&format!("Error: {:?}", e));
+            std::process::exit(1);
+        }
+    }
+
+    Ok(())
+}

--- a/core/bin/qdrant/migrate_embedder.rs
+++ b/core/bin/qdrant/migrate_embedder.rs
@@ -638,7 +638,7 @@ async fn refresh_chunk_count_for_updated_documents(
             let f = qdrant::Filter {
                 must: vec![qdrant::Condition::matches(
                     "document_id_hash",
-                    make_qdrant_document_id_hash(doc_id.clone()),
+                    make_qdrant_document_id_hash(&doc_id),
                 )],
                 ..Default::default()
             };

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -400,9 +400,8 @@ impl Document {
 pub fn make_qdrant_document_id_hash(document_id: &str) -> String {
     let mut hasher = blake3::Hasher::new();
     hasher.update(document_id.as_bytes());
-    let document_id_hash = format!("{}", hasher.finalize().to_hex());
 
-    document_id_hash
+    format!("{}", hasher.finalize().to_hex())
 }
 
 #[derive(Debug, Serialize, Clone)]

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -397,6 +397,14 @@ impl Document {
     }
 }
 
+pub fn make_qdrant_document_id_hash(document_id: String) -> String {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(document_id.as_bytes());
+    let document_id_hash = format!("{}", hasher.finalize().to_hex());
+
+    document_id_hash
+}
+
 #[derive(Debug, Serialize, Clone)]
 pub struct DocumentVersion {
     pub created: u64,
@@ -528,6 +536,10 @@ impl DataSource {
 
     pub fn created(&self) -> u64 {
         self.created
+    }
+
+    pub fn project(&self) -> &Project {
+        &self.project
     }
 
     pub fn data_source_id(&self) -> &str {

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -20,6 +20,7 @@ use qdrant_client::{prelude::Payload, qdrant};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
+use std::fmt;
 use tokio::try_join;
 use tokio_stream::{self as stream};
 use tracing::{error, info};
@@ -408,6 +409,16 @@ pub struct EmbedderConfig {
     pub model_id: String,
     pub splitter_id: SplitterID,
     pub max_chunk_size: usize,
+}
+
+impl fmt::Display for EmbedderConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "EmbedderConfig {{ provider_id: {}, model_id: {}, splitter_id: {:?}, max_chunk_size: {} }}",
+            self.provider_id, self.model_id, self.splitter_id, self.max_chunk_size
+        )
+    }
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -397,7 +397,7 @@ impl Document {
     }
 }
 
-pub fn make_qdrant_document_id_hash(document_id: String) -> String {
+pub fn make_qdrant_document_id_hash(document_id: &str) -> String {
     let mut hasher = blake3::Hasher::new();
     hasher.update(document_id.as_bytes());
     let document_id_hash = format!("{}", hasher.finalize().to_hex());
@@ -639,9 +639,7 @@ impl DataSource {
             )
             .await?;
 
-        let mut hasher = blake3::Hasher::new();
-        hasher.update(document_id.as_bytes());
-        let document_id_hash = format!("{}", hasher.finalize().to_hex());
+        let document_id_hash = make_qdrant_document_id_hash(&document_id);
 
         self.update_document_payload(qdrant_clients, document_id_hash, "parents", parents)
             .await?;
@@ -666,9 +664,7 @@ impl DataSource {
             )
             .await?;
 
-        let mut hasher = blake3::Hasher::new();
-        hasher.update(document_id.as_bytes());
-        let document_id_hash = format!("{}", hasher.finalize().to_hex());
+        let document_id_hash = make_qdrant_document_id_hash(&document_id);
 
         self.update_document_payload(qdrant_clients, document_id_hash, "tags", new_tags.clone())
             .await?;
@@ -851,9 +847,7 @@ impl DataSource {
         });
         let document_hash = format!("{}", hasher.finalize().to_hex());
 
-        let mut hasher = blake3::Hasher::new();
-        hasher.update(document_id.as_bytes());
-        let document_id_hash = format!("{}", hasher.finalize().to_hex());
+        let document_id_hash = make_qdrant_document_id_hash(document_id);
 
         let document = Document::new(
             &self.data_source_id,
@@ -1473,9 +1467,7 @@ impl DataSource {
                     };
 
                     if full_text {
-                        let mut hasher = blake3::Hasher::new();
-                        hasher.update(document_id.as_bytes());
-                        let document_id_hash = format!("{}", hasher.finalize().to_hex());
+                        let document_id_hash = make_qdrant_document_id_hash(&document_id);
 
                         let bucket_path = format!(
                             "{}/{}/{}",
@@ -1552,9 +1544,8 @@ impl DataSource {
                                 return Ok(d);
                             }
 
-                            let mut hasher = blake3::Hasher::new();
-                            hasher.update(d.document_id.as_bytes());
-                            let document_id_hash = format!("{}", hasher.finalize().to_hex());
+                            let document_id_hash = make_qdrant_document_id_hash(&d.document_id);
+
                             let filter = qdrant::Filter {
                                 must: vec![
                                     qdrant::FieldCondition {
@@ -1900,9 +1891,7 @@ impl DataSource {
             d.tags
         };
 
-        let mut hasher = blake3::Hasher::new();
-        hasher.update(document_id.as_bytes());
-        let document_id_hash = format!("{}", hasher.finalize().to_hex());
+        let document_id_hash = make_qdrant_document_id_hash(document_id);
 
         // GCP retrieve raw text and document_id.
         let bucket = match std::env::var("DUST_DATA_SOURCES_BUCKET") {
@@ -1962,9 +1951,7 @@ impl DataSource {
     ) -> Result<()> {
         let qdrant_client = self.main_qdrant_client(&qdrant_clients);
 
-        let mut hasher = blake3::Hasher::new();
-        hasher.update(document_id.as_bytes());
-        let document_id_hash = format!("{}", hasher.finalize().to_hex());
+        let document_id_hash = make_qdrant_document_id_hash(document_id);
 
         // Clean-up document chunks (vector search db).
         let filter = qdrant::Filter {

--- a/core/src/data_sources/qdrant.rs
+++ b/core/src/data_sources/qdrant.rs
@@ -297,6 +297,30 @@ impl DustQdrantClient {
             .await
     }
 
+    pub async fn count_points(
+        &self,
+        embedder_config: &EmbedderConfig,
+        internal_id: &String,
+        filter: Option<qdrant::Filter>,
+        exact: bool,
+    ) -> Result<qdrant::CountResponse> {
+        // If we don't have a filter create an empty one to ensure tenant separation.
+        let mut filter = filter.unwrap_or_default();
+        self.apply_tenant_filter(internal_id, &mut filter);
+
+        self.client
+            .count(&qdrant::CountPoints {
+                collection_name: self.collection_name(embedder_config),
+                filter: Some(filter),
+                exact: Some(exact),
+                shard_key_selector: Some(
+                    vec![self.shard_key(embedder_config, internal_id)?].into(),
+                ),
+                ..Default::default()
+            })
+            .await
+    }
+
     pub async fn upsert_points(
         &self,
         embedder_config: &EmbedderConfig,

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -141,6 +141,13 @@ pub trait Store {
         document_id: &str,
         parents: &Vec<String>,
     ) -> Result<()>;
+    async fn update_data_source_document_chunk_count(
+        &self,
+        project: &Project,
+        data_source_id: &str,
+        document_id: &str,
+        chunk_count: u64,
+    ) -> Result<()>;
     async fn list_data_source_document_versions(
         &self,
         project: &Project,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR introduces a script to migrate our data source from one embedding model to another. Currently, the Qdrant collection name is determined by the embedder configurations. Due to the current handling of chunks, we do not yet store them in GCS, which will be addressed in a future PR. Consequently, the best source for re-embedding data into the new collection is the existing points in Qdrant. This script is heavily inspired by our existing migration script used for transferring data between clusters. It uses the current Qdrant points (from the current embedder) to re-embed the data according to the new embedder configuration.

Although the downstream code can manage both shadow write clusters and shadow embedders, this script will abort if double write is enabled. When shadow write is enabled, the `chunk_counts` in the `data_source_documents` table will not be accurate after the shadow embedder is committed. Therefore, a refresh of the chunk count is performed once the migration is complete and the shadow write is cleared, ensuring the counts are up-to-date.

This script is not perfect and will be refined once we can use GCS as the source of truth.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
