### PR TITLE
Migrate mistral-small to mistral-small-latest part 1/2

### DIFF
--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -50,7 +50,7 @@ async function handler(
     });
   }
 
-  const owner = await auth.workspace();
+  const owner = auth.workspace();
   if (!owner) {
     return apiError(req, res, {
       status_code: 404,

--- a/types/src/front/lib/assistant.ts
+++ b/types/src/front/lib/assistant.ts
@@ -36,7 +36,8 @@ export const CLAUDE_2_1_MODEL_ID = "claude-2.1" as const;
 export const CLAUDE_INSTANT_1_2_MODEL_ID = "claude-instant-1.2" as const;
 export const MISTRAL_LARGE_MODEL_ID = "mistral-large-latest" as const;
 export const MISTRAL_MEDIUM_MODEL_ID = "mistral-medium" as const;
-export const MISTRAL_SMALL_MODEL_ID = "mistral-small" as const;
+export const MISTRAL_SMALL_MODEL_ID = "mistral-small-latest" as const;
+export const MISTRAL_SMALL_LEGACY_MODEL_ID = "mistral-small" as const;
 export const GEMINI_1_5_PRO_LATEST_MODEL_ID = "gemini-1.5-pro-latest" as const;
 
 export const MODEL_IDS = [
@@ -51,6 +52,7 @@ export const MODEL_IDS = [
   MISTRAL_LARGE_MODEL_ID,
   MISTRAL_MEDIUM_MODEL_ID,
   MISTRAL_SMALL_MODEL_ID,
+  MISTRAL_SMALL_LEGACY_MODEL_ID,
   GEMINI_1_5_PRO_LATEST_MODEL_ID,
 ] as const;
 export type ModelIdType = (typeof MODEL_IDS)[number];
@@ -207,6 +209,18 @@ export const MISTRAL_MEDIUM_MODEL_CONFIG: ModelConfigurationType = {
 export const MISTRAL_SMALL_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "mistral",
   modelId: MISTRAL_SMALL_MODEL_ID,
+  displayName: "Mistral Small",
+  contextSize: 32_000,
+  recommendedTopK: 16,
+  recommendedExhaustiveTopK: 56, // 28_672
+  largeModel: false,
+  description: "Mistral's latest model (8x7B Instruct, 32k context).",
+  shortDescription: "Mistral's fast model.",
+  supportsMultiActions: false,
+};
+export const MISTRAL_SMALL_LEGACY_MODEL_CONFIG: ModelConfigurationType = {
+  providerId: "mistral",
+  modelId: MISTRAL_SMALL_LEGACY_MODEL_ID,
   displayName: "Mistral Small",
   contextSize: 32_000,
   recommendedTopK: 16,

--- a/types/src/front/lib/assistant.ts
+++ b/types/src/front/lib/assistant.ts
@@ -216,7 +216,7 @@ export const MISTRAL_SMALL_MODEL_CONFIG: ModelConfigurationType = {
   largeModel: false,
   description: "Mistral's latest model (8x7B Instruct, 32k context).",
   shortDescription: "Mistral's fast model.",
-  supportsMultiActions: false,
+  supportsMultiActions: true,
 };
 export const MISTRAL_SMALL_LEGACY_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "mistral",
@@ -257,6 +257,7 @@ export const SUPPORTED_MODEL_CONFIGS: ModelConfigurationType[] = [
   MISTRAL_LARGE_MODEL_CONFIG,
   MISTRAL_MEDIUM_MODEL_CONFIG,
   MISTRAL_SMALL_MODEL_CONFIG,
+  MISTRAL_SMALL_LEGACY_MODEL_CONFIG,
   GEMINI_PRO_DEFAULT_MODEL_CONFIG,
 ];
 


### PR DESCRIPTION
## Description

Introduce `MISTRAL_SMALL_LEGACY_MODEL_ID` and `MISTRAL_SMALL_LEGACY_MODEL_CONFIG` pointing to our current `mistral-small` to not break anything.

Move `MISTRAL_SMALL_MODEL_ID` to `mistral-small-latest` and `supportsMultiActions: true`

## Risk

Low, tested locally

## Deploy Plan

- deploy `front`
- run migration: `npx tsx scripts/update_assistants_models.ts --fromModel mistral-small --toModel mistral-small-latest --execute`