### PR TITLE
Avoid fetching conversations + all messages when paginating over a conversation

### DIFF
--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -373,6 +373,7 @@ export async function fetchConversationMessages(
     where: {
       sId: conversationId,
       workspaceId: owner.id,
+      visibility: { [Op.ne]: "deleted" },
     },
   });
   if (!conversation) {

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -131,7 +131,6 @@ async function handler(
 
       const { content, context, mentions } = bodyValidation.right;
 
-      // TODO(2024-06-01 flav) Do we need conversation with content here?
       const conversation = await getConversation(auth, conversationId);
       if (!conversation) {
         return apiError(req, res, {

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -69,16 +69,6 @@ async function handler(
   }
 
   const conversationId = req.query.cId;
-  const conversation = await getConversation(auth, conversationId);
-  if (!conversation) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "conversation_not_found",
-        message: "Conversation not found.",
-      },
-    });
-  }
 
   switch (req.method) {
     case "GET":
@@ -140,6 +130,18 @@ async function handler(
       }
 
       const { content, context, mentions } = bodyValidation.right;
+
+      // TODO(2024-06-01 flav) Do we need conversation with content here?
+      const conversation = await getConversation(auth, conversationId);
+      if (!conversation) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "conversation_not_found",
+            message: "Conversation not found.",
+          },
+        });
+      }
 
       /* postUserMessageWithPubSub returns swiftly since it only waits for the
         initial message creation event (or error) */


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
When we added pagination to the messages endpoint, it appears we overlooked some legacy behavior regarding fetching the entire conversation, including all content and messages.

This oversight significantly slows down the endpoint to paginate over messages, making it much slower compared to a simple pagination call. However, this slow fetch is still necessary to post a message.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
