### PR TITLE
[Google Drive] Backfill missing rows from GoogleDriveFiles

### DIFF
--- a/connectors/migrations/20240529_clean_gdrive_folders.ts
+++ b/connectors/migrations/20240529_clean_gdrive_folders.ts
@@ -1,3 +1,5 @@
+import { QueryTypes } from "sequelize";
+
 import { getGoogleDriveObject } from "@connectors/connectors/google_drive/lib/google_drive_api";
 import {
   getAuthObject,
@@ -10,7 +12,6 @@ import {
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { sequelizeConnection } from "@connectors/resources/storage";
-import { QueryTypes } from "sequelize";
 
 const { LIVE } = process.env;
 

--- a/connectors/migrations/20240529_clean_gdrive_folders.ts
+++ b/connectors/migrations/20240529_clean_gdrive_folders.ts
@@ -1,0 +1,92 @@
+import { getGoogleDriveObject } from "@connectors/connectors/google_drive/lib/google_drive_api";
+import {
+  getAuthObject,
+  getDocumentId,
+} from "@connectors/connectors/google_drive/temporal/utils";
+import {
+  GoogleDriveFiles,
+  GoogleDriveFolders,
+} from "@connectors/lib/models/google_drive";
+import logger from "@connectors/logger/logger";
+import { ConnectorResource } from "@connectors/resources/connector_resource";
+import { sequelizeConnection } from "@connectors/resources/storage";
+import { QueryTypes } from "sequelize";
+
+const { LIVE } = process.env;
+
+async function main() {
+  // get all folders that have no row in google_drive_files such that the
+  // folder's folderId is the same as the file's driveFileId
+  // not easy to do in sequelize, so direct query
+  const query = `
+  SELECT "folders".*
+  FROM "google_drive_folders" AS folders
+  LEFT JOIN "google_drive_files" AS files
+  ON folders."folderId" = files."driveFileId"
+  WHERE files."driveFileId" IS NULL
+  ORDER BY folders."updatedAt" DESC;
+`;
+
+  const results = await sequelizeConnection.query(query, {
+    type: QueryTypes.SELECT,
+  });
+
+  // Map the results to GoogleDriveFolders instances
+  const unusedFolders = results.map((result) =>
+    // @ts-expect-error typescript cannot correctly infer result's type
+    GoogleDriveFolders.build(result, { isNewRecord: false })
+  );
+
+  logger.info(`Found ${unusedFolders.length} unused folders`);
+
+  // loop across folders, check if we can get the google drive object from
+  // google API if we can't, delete the folder. Otherwise, backfill the
+  // google_drive_files row
+  for (const folder of unusedFolders) {
+    const { connectorId, folderId } = folder;
+    const connector = await ConnectorResource.fetchById(connectorId);
+
+    if (!connector) {
+      logger.info(
+        { connectorId, folderId },
+        `Connector not found, deleting folder (live: ${LIVE})`
+      );
+      if (LIVE) {
+        await GoogleDriveFolders.destroy({ where: { connectorId, folderId } });
+      }
+      continue;
+    }
+
+    const authCredentials = await getAuthObject(connector.connectionId);
+    const file = await getGoogleDriveObject(authCredentials, folderId);
+
+    if (!file) {
+      logger.info(
+        { connectorId, folderId },
+        `Folder not found on google, deleting folder (live: ${LIVE})`
+      );
+      if (LIVE) {
+        await GoogleDriveFolders.destroy({ where: { connectorId, folderId } });
+      }
+      continue;
+    }
+
+    logger.info(
+      { connectorId, folderId },
+      `Folder found on google, backfilling google_drive_files (live: ${LIVE})`
+    );
+    if (LIVE) {
+      await GoogleDriveFiles.create({
+        connectorId,
+        driveFileId: folderId,
+        name: file.name,
+        mimeType: file.mimeType,
+        dustFileId: getDocumentId(folderId),
+      });
+    }
+  }
+}
+
+main()
+  .then(() => console.log("Done"))
+  .catch(console.error);


### PR DESCRIPTION
Description
---
Fixes issue #5100 (in some cases, root folders could be incorrectly removed from google drive files, see details in last comments of issue)

This PR is the last step to fix, following PR #5356 

Risk
---
None big enough. Maybe unselecting a folder because it's temporarily unreachable during migration but the risk is very low and the blast too; and maybe backfilling a folder that shouldn't be, but similarly, no reason this would happen,  and blast quite low

Can be considered no risk.

Note: about ~500 folders are about to be backfilled as per issue. List of folders has been saved

Deploy
---
- wait for merge of #5356 
- Run migration from prodbox
- check no more orphans using [this query](https://metabase.dust.tt/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7InR5cGUiOiJuYXRpdmUiLCJuYXRpdmUiOnsicXVlcnkiOiJTRUxFQ1QgKlxuRlJPTSBcImdvb2dsZV9kcml2ZV9mb2xkZXJzXCIgZm9sZGVyc1xuTEVGVCBKT0lOIFwiZ29vZ2xlX2RyaXZlX2ZpbGVzXCIgZmlsZXMgT04gZm9sZGVycy5cImZvbGRlcklkXCIgPSBmaWxlcy5cImRyaXZlRmlsZUlkXCJcbldIRVJFIGZpbGVzLlwiZHJpdmVGaWxlSWRcIiBJUyBOVUxMIG9yZGVyIGJ5IGZvbGRlcnMuXCJ1cGRhdGVkQXRcIiBkZXNjO1xuIiwidGVtcGxhdGUtdGFncyI6e319LCJkYXRhYmFzZSI6Mn0sImRpc3BsYXkiOiJ0YWJsZSIsInBhcmFtZXRlcnMiOltdLCJ2aXN1YWxpemF0aW9uX3NldHRpbmdzIjp7fX0=)
