### PR TITLE
enh(core): display request_id in ModelError

### DIFF
--- a/core/src/providers/cohere.rs
+++ b/core/src/providers/cohere.rs
@@ -40,6 +40,11 @@ async fn api_encode(api_key: &str, text: &str) -> Result<Vec<usize>> {
         .send()
         .await?;
     let status = res.status();
+    let res_headers = res.headers();
+    let request_id = match res_headers.get("x-request-id") {
+        Some(v) => Some(v.to_str()?.to_string()),
+        None => None,
+    };
     let body = res.bytes().await?;
 
     let mut b: Vec<u8> = vec![];
@@ -56,6 +61,7 @@ async fn api_encode(api_key: &str, text: &str) -> Result<Vec<usize>> {
                 message: "Too many requests".to_string(),
             });
             Err(ModelError {
+                request_id,
                 message: format!("CohereAPIError: {}", error.message),
                 retryable: Some(ModelErrorRetryOptions {
                     sleep: Duration::from_millis(500),
@@ -67,6 +73,7 @@ async fn api_encode(api_key: &str, text: &str) -> Result<Vec<usize>> {
         _ => {
             let error: Error = serde_json::from_slice(c)?;
             Err(ModelError {
+                request_id,
                 message: format!("CohereAPIError: {}", error.message),
                 retryable: Some(ModelErrorRetryOptions {
                     sleep: Duration::from_millis(500),
@@ -91,6 +98,11 @@ async fn api_decode(api_key: &str, tokens: Vec<usize>) -> Result<String> {
         .await?;
 
     let status = res.status();
+    let res_headers = res.headers();
+    let request_id = match res_headers.get("x-request-id") {
+        Some(v) => Some(v.to_str()?.to_string()),
+        None => None,
+    };
     let body = res.bytes().await?;
 
     let mut b: Vec<u8> = vec![];
@@ -107,6 +119,7 @@ async fn api_decode(api_key: &str, tokens: Vec<usize>) -> Result<String> {
                 message: "Too many requests".to_string(),
             });
             Err(ModelError {
+                request_id,
                 message: format!("CohereAPIError: {}", error.message),
                 retryable: Some(ModelErrorRetryOptions {
                     sleep: Duration::from_millis(500),
@@ -118,6 +131,7 @@ async fn api_decode(api_key: &str, tokens: Vec<usize>) -> Result<String> {
         _ => {
             let error: Error = serde_json::from_slice(c)?;
             Err(ModelError {
+                request_id,
                 message: format!("CohereAPIError: {}", error.message),
                 retryable: Some(ModelErrorRetryOptions {
                     sleep: Duration::from_millis(500),
@@ -217,6 +231,11 @@ impl CohereLLM {
             .await?;
 
         let status = res.status();
+        let res_headers = res.headers();
+        let request_id = match res_headers.get("x-request-id") {
+            Some(v) => Some(v.to_str()?.to_string()),
+            None => None,
+        };
         let body = res.bytes().await?;
         let mut b: Vec<u8> = vec![];
         body.reader().read_to_end(&mut b)?;
@@ -232,6 +251,7 @@ impl CohereLLM {
                     message: "Too many requests".to_string(),
                 });
                 Err(ModelError {
+                    request_id,
                     message: format!("CohereAPIError: {}", error.message),
                     retryable: Some(ModelErrorRetryOptions {
                         sleep: Duration::from_millis(500),
@@ -243,6 +263,7 @@ impl CohereLLM {
             _ => {
                 let error: Error = serde_json::from_slice(c)?;
                 Err(ModelError {
+                    request_id,
                     message: format!("CohereAPIError: {}", error.message),
                     retryable: None,
                 })
@@ -441,6 +462,11 @@ impl CohereEmbedder {
             .send()
             .await?;
         let status = res.status();
+        let res_headers = res.headers();
+        let request_id = match res_headers.get("x-request-id") {
+            Some(v) => Some(v.to_str()?.to_string()),
+            None => None,
+        };
         let body = res.bytes().await?;
         let mut b: Vec<u8> = vec![];
         body.reader().read_to_end(&mut b)?;
@@ -456,6 +482,7 @@ impl CohereEmbedder {
                     message: "Too many requests".to_string(),
                 });
                 Err(ModelError {
+                    request_id,
                     message: format!("CohereAPIError: {}", error.message),
                     retryable: Some(ModelErrorRetryOptions {
                         sleep: Duration::from_millis(500),
@@ -467,6 +494,7 @@ impl CohereEmbedder {
             _ => {
                 let error: Error = serde_json::from_slice(c)?;
                 Err(ModelError {
+                    request_id,
                     message: format!("CohereAPIError: {}", error.message),
                     retryable: Some(ModelErrorRetryOptions {
                         sleep: Duration::from_millis(500),

--- a/core/src/providers/llm.rs
+++ b/core/src/providers/llm.rs
@@ -11,9 +11,7 @@ use serde_json::Value;
 use std::collections::HashMap;
 use std::str::FromStr;
 use tokio::sync::mpsc::UnboundedSender;
-use tracing::{error, info};
-
-use super::provider::ModelError;
+use tracing::info;
 
 #[derive(Debug, Serialize, PartialEq, Clone, Deserialize)]
 pub struct Tokens {
@@ -295,26 +293,12 @@ impl LLMRequest {
                 );
                 Ok(c)
             }
-            Err(e) => {
-                let string_error = e.to_string();
-                if let Ok(e) = e.downcast::<ModelError>() {
-                    //  Log the request_id if it exists.
-                    if let Some(request_id) = e.request_id {
-                        error!(
-                            provider_id = self.provider_id.to_string(),
-                            model_id = self.model_id,
-                            request_id = request_id,
-                            "Too many retries: error=ModelError"
-                        );
-                    }
-                }
-                return Err(anyhow!(
-                    "Error querying `{}:{}`: error={}",
-                    self.provider_id.to_string(),
-                    self.model_id,
-                    string_error,
-                ));
-            }
+            Err(e) => Err(anyhow!(
+                "Error querying `{}:{}`: error={}",
+                self.provider_id.to_string(),
+                self.model_id,
+                e.to_string(),
+            )),
         }
     }
 
@@ -509,26 +493,12 @@ impl LLMChatRequest {
                 );
                 Ok(c)
             }
-            Err(e) => {
-                let string_error = e.to_string();
-                if let Ok(e) = e.downcast::<ModelError>() {
-                    //  Log the request_id if it exists.
-                    if let Some(request_id) = e.request_id {
-                        error!(
-                            provider_id = self.provider_id.to_string(),
-                            model_id = self.model_id,
-                            request_id = request_id,
-                            "Too many retries: error=ModelError"
-                        );
-                    }
-                }
-                return Err(anyhow!(
-                    "Error querying `{}:{}`: error={}",
-                    self.provider_id.to_string(),
-                    self.model_id,
-                    string_error,
-                ));
-            }
+            Err(e) => Err(anyhow!(
+                "Error querying `{}:{}`: error={}",
+                self.provider_id.to_string(),
+                self.model_id,
+                e.to_string(),
+            )),
         }
     }
 

--- a/core/src/providers/provider.rs
+++ b/core/src/providers/provider.rs
@@ -76,14 +76,16 @@ pub struct ModelErrorRetryOptions {
 pub struct ModelError {
     pub message: String,
     pub retryable: Option<ModelErrorRetryOptions>,
+    pub request_id: Option<String>,
 }
 
 impl std::fmt::Display for ModelError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(
             f,
-            "[model_error(retryable={})] {}",
+            "[model_error(retryable={},request_id={})] {}",
             self.retryable.is_some(),
+            self.request_id.as_ref().unwrap_or(&String::from("None")),
             self.message
         )
     }

--- a/core/src/providers/provider.rs
+++ b/core/src/providers/provider.rs
@@ -83,9 +83,8 @@ impl std::fmt::Display for ModelError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(
             f,
-            "[model_error(retryable={},request_id={})] {}",
+            "[model_error(retryable={})] {}",
             self.retryable.is_some(),
-            self.request_id.as_ref().unwrap_or(&String::from("None")),
             self.message
         )
     }

--- a/core/src/providers/provider.rs
+++ b/core/src/providers/provider.rs
@@ -15,6 +15,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::str::FromStr;
 use std::time::Duration;
+use tracing::error;
 
 use super::google_ai_studio::GoogleAiStudioProvider;
 
@@ -115,6 +116,13 @@ where
                             log_retry(&err.message, sleep.as_ref().unwrap(), attempts);
                             tokio::time::sleep(sleep.unwrap()).await;
                             if attempts > retry.retries {
+                                if let Some(request_id) = &err.request_id {
+                                    error!(
+                                        request_id = request_id,
+                                        error = err.message,
+                                        "Failed to query model",
+                                    );
+                                }
                                 break Err(anyhow!(
                                     "Too many retries ({}): {}",
                                     retry.retries,


### PR DESCRIPTION
## Description

adds `request_id` to the `ModelError` struct and populate it when possible (i.e, when we have a response and the header is present in the response)

## Risk

N/A

## Deploy Plan

N/A