### PR TITLE
Assistant Builder: Pre-fill Dust App action name & description when picking the dust app

### DIFF
--- a/front/components/assistant_builder/ActionScreen.tsx
+++ b/front/components/assistant_builder/ActionScreen.tsx
@@ -31,6 +31,7 @@ import { ActionTablesQuery } from "@app/components/assistant_builder/actions/Tab
 import type {
   AssistantBuilderActionConfiguration,
   AssistantBuilderActionType,
+  AssistantBuilderDustAppConfiguration,
   AssistantBuilderState,
 } from "@app/components/assistant_builder/types";
 import { getDefaultActionConfiguration } from "@app/components/assistant_builder/types";
@@ -547,38 +548,45 @@ export default function ActionScreen({
           />
         </ActionModeSection>
 
-        <ActionModeSection show={action?.type === "DUST_APP_RUN"}>
-          <ActionDustAppRun
-            owner={owner}
-            actionConfigration={
-              action?.type === "DUST_APP_RUN" ? action.configuration : null
-            }
-            dustApps={dustApps}
-            updateAction={(setNewAction) => {
-              setBuilderState((state) => {
-                const previousAction = state.actions[0];
-                if (!previousAction || previousAction.type !== "DUST_APP_RUN") {
-                  // Unreachable
-                  return state;
-                }
-                const newActionConfig = setNewAction(
-                  previousAction.configuration
-                );
-                const newAction: AssistantBuilderActionConfiguration = {
-                  type: "DUST_APP_RUN",
-                  configuration: newActionConfig,
-                  name: previousAction.name,
-                  description: previousAction.description,
-                };
-                return {
-                  ...state,
-                  actions: removeNulls([newAction]),
-                };
-              });
-            }}
-            setEdited={setEdited}
-          />
-        </ActionModeSection>
+        {action?.type === "DUST_APP_RUN" && (
+          <ActionModeSection show={action?.type === "DUST_APP_RUN"}>
+            <ActionDustAppRun
+              owner={owner}
+              action={action}
+              dustApps={dustApps}
+              updateAction={({
+                actionName,
+                actionDescription,
+                getNewActionConfig,
+              }) => {
+                setBuilderState((state) => {
+                  const previousAction = state.actions[0];
+                  if (
+                    !previousAction ||
+                    previousAction.type !== "DUST_APP_RUN"
+                  ) {
+                    // Unreachable
+                    return state;
+                  }
+
+                  const newAction: AssistantBuilderActionConfiguration = {
+                    type: "DUST_APP_RUN",
+                    configuration: getNewActionConfig(
+                      previousAction.configuration
+                    ) as AssistantBuilderDustAppConfiguration,
+                    name: actionName,
+                    description: actionDescription,
+                  };
+                  return {
+                    ...state,
+                    actions: removeNulls([newAction]),
+                  };
+                });
+              }}
+              setEdited={setEdited}
+            />
+          </ActionModeSection>
+        )}
       </div>
     </>
   );

--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -52,7 +52,6 @@ import {
 } from "@app/components/assistant_builder/actions/WebsearchAction";
 import type {
   AssistantBuilderActionConfiguration,
-  AssistantBuilderDustAppConfiguration,
   AssistantBuilderProcessConfiguration,
   AssistantBuilderRetrievalConfiguration,
   AssistantBuilderState,
@@ -554,18 +553,9 @@ function ActionEditor({
               return (
                 <ActionDustAppRun
                   owner={owner}
-                  actionConfigration={action.configuration}
+                  action={action}
                   dustApps={dustApps}
-                  updateAction={(setNewAction) => {
-                    updateAction({
-                      actionName: action.name,
-                      actionDescription: action.description,
-                      getNewActionConfig: (old) =>
-                        setNewAction(
-                          old as AssistantBuilderDustAppConfiguration
-                        ),
-                    });
-                  }}
+                  updateAction={updateAction}
                   setEdited={setEdited}
                 />
               );

--- a/front/components/assistant_builder/actions/DustAppRunAction.tsx
+++ b/front/components/assistant_builder/actions/DustAppRunAction.tsx
@@ -9,6 +9,10 @@ import type {
   AssistantBuilderActionConfiguration,
   AssistantBuilderDustAppConfiguration,
 } from "@app/components/assistant_builder/types";
+import {
+  ASSISTANT_BUILDER_DUST_APP_RUN_ACTION_CONFIGURATION_DEFAULT_DESCRIPTION,
+  ASSISTANT_BUILDER_DUST_APP_RUN_ACTION_CONFIGURATION_DEFAULT_NAME,
+} from "@app/components/assistant_builder/types";
 
 export function isActionDustAppRunValid(
   action: AssistantBuilderActionConfiguration
@@ -18,18 +22,20 @@ export function isActionDustAppRunValid(
 
 export function ActionDustAppRun({
   owner,
-  actionConfigration,
+  action,
   updateAction,
   setEdited,
   dustApps,
 }: {
   owner: WorkspaceType;
-  actionConfigration: AssistantBuilderDustAppConfiguration | null;
-  updateAction: (
-    setNewAction: (
-      previousAction: AssistantBuilderDustAppConfiguration
-    ) => AssistantBuilderDustAppConfiguration
-  ) => void;
+  action: AssistantBuilderActionConfiguration;
+  updateAction: (args: {
+    actionName: string;
+    actionDescription: string;
+    getNewActionConfig: (
+      old: AssistantBuilderActionConfiguration["configuration"]
+    ) => AssistantBuilderActionConfiguration["configuration"];
+  }) => void;
   setEdited: (edited: boolean) => void;
   dustApps: AppType[];
 }) {
@@ -37,15 +43,19 @@ export function ActionDustAppRun({
 
   const deleteDustApp = () => {
     setEdited(true);
-    updateAction((previousAction) => ({
-      ...previousAction,
-      app: null,
-    }));
+    updateAction({
+      actionName: action.name,
+      actionDescription: action.description,
+      getNewActionConfig: (previousAction) => ({
+        ...previousAction,
+        app: null,
+      }),
+    });
   };
 
   const noDustApp = dustApps.length === 0;
 
-  if (!actionConfigration) {
+  if (!action.configuration) {
     return null;
   }
 
@@ -59,10 +69,28 @@ export function ActionDustAppRun({
         dustApps={dustApps}
         onSave={({ app }) => {
           setEdited(true);
-          updateAction((previousAction) => ({
-            ...previousAction,
-            app,
-          }));
+          const newName =
+            action.name ===
+              ASSISTANT_BUILDER_DUST_APP_RUN_ACTION_CONFIGURATION_DEFAULT_NAME &&
+            app?.name
+              ? app.name
+              : action.name;
+
+          const newDescription =
+            action.description ===
+              ASSISTANT_BUILDER_DUST_APP_RUN_ACTION_CONFIGURATION_DEFAULT_DESCRIPTION &&
+            app?.description?.length
+              ? app.description
+              : action.description;
+
+          updateAction({
+            actionName: newName,
+            actionDescription: newDescription,
+            getNewActionConfig: (previousAction) => ({
+              ...previousAction,
+              app,
+            }),
+          });
         }}
       />
 
@@ -119,7 +147,9 @@ export function ActionDustAppRun({
           </div>
           <DustAppSelectionSection
             show={true}
-            dustAppConfiguration={actionConfigration}
+            dustAppConfiguration={
+              action.configuration as AssistantBuilderDustAppConfiguration
+            }
             openDustAppModal={() => {
               setShowDustAppsModal(true);
             }}

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -187,14 +187,20 @@ export function getDefaultRetrievalExhaustiveActionConfiguration() {
   } satisfies AssistantBuilderActionConfiguration;
 }
 
+export const ASSISTANT_BUILDER_DUST_APP_RUN_ACTION_CONFIGURATION_DEFAULT_NAME =
+  "run_dust_app";
+export const ASSISTANT_BUILDER_DUST_APP_RUN_ACTION_CONFIGURATION_DEFAULT_DESCRIPTION =
+  "Run a Dust app.";
+
 export function getDefaultDustAppRunActionConfiguration() {
   return {
     type: "DUST_APP_RUN",
     configuration: {
       app: null,
     } as AssistantBuilderDustAppConfiguration,
-    name: "run_dust_app",
-    description: "Run a Dust app.",
+    name: ASSISTANT_BUILDER_DUST_APP_RUN_ACTION_CONFIGURATION_DEFAULT_NAME,
+    description:
+      ASSISTANT_BUILDER_DUST_APP_RUN_ACTION_CONFIGURATION_DEFAULT_DESCRIPTION,
   } satisfies AssistantBuilderActionConfiguration;
 }
 


### PR DESCRIPTION
## Description

Card: https://github.com/dust-tt/dust/issues/5200

> automatically use name / description of the dust app
don't override what was manually typed by user when changing dust app
Not that straightforward due to how state is managed around this part of the app

-> I did it dirty by overriding with the Dust app name/description only if the current one is the default one. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 
