### PR TITLE
fix(core): pass request_id when constructing ModelError for mistral

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1140,7 +1140,7 @@ dependencies = [
 [[package]]
 name = "eventsource-client"
 version = "0.12.2"
-source = "git+https://github.com/dust-tt/rust-eventsource-client#dbd95fa1a05864f748ed90e9faa9aa3fd721f2e0"
+source = "git+https://github.com/dust-tt/rust-eventsource-client#df8e4252a74e1fff3e71f44510adbdaa82f3981e"
 dependencies = [
  "futures",
  "hyper 0.14.28",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -52,7 +52,7 @@ urlencoding = "2.1"
 url = "2.5"
 dns-lookup = "1.0"
 async-stream = "0.3"
-eventsource-client = { git = "https://github.com/dust-tt/rust-eventsource-client", commit = "dbd95fa1a05864f748ed90e9faa9aa3fd721f2e0" }
+eventsource-client = { git = "https://github.com/dust-tt/rust-eventsource-client", commit = "df8e4252a74e1fff3e71f44510adbdaa82f3981e" }
 tera = "1.20"
 fancy-regex = "0.13"
 rustc-hash = "1.1"


### PR DESCRIPTION
## Description

- update our forked eventsource client to the latest commit so we can use `.headers()`
- get the `request_id` from headers and use it for the `ModelError`


## Risk

N/A

## Deploy Plan

N/A