### PR TITLE
[types] - refactor: enforce non-empty strings for certain user contex…

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -168,6 +168,7 @@
         "io-ts": "^2.2.20",
         "io-ts-reporters": "^2.0.1",
         "io-ts-types": "^0.5.19",
+        "moment-timezone": "^0.5.43",
         "redis": "^4.6.8",
         "uuid": "^9.0.1"
       },

--- a/types/package-lock.json
+++ b/types/package-lock.json
@@ -16,6 +16,7 @@
         "io-ts": "^2.2.20",
         "io-ts-reporters": "^2.0.1",
         "io-ts-types": "^0.5.19",
+        "moment-timezone": "^0.5.43",
         "redis": "^4.6.8",
         "uuid": "^9.0.1"
       },
@@ -7369,6 +7370,25 @@
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment-timezone": {
+      "version": "0.5.45",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.45.tgz",
+      "integrity": "sha512-HIWmqA86KcmCAhnMAN0wuDOARV/525R2+lOLotuGFzn4HO+FH+/645z2wx0Dt3iDv6/p61SIvKnDstISainhLQ==",
+      "dependencies": {
+        "moment": "^2.29.4"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/monocle-ts": {

--- a/types/package.json
+++ b/types/package.json
@@ -34,6 +34,7 @@
     "io-ts": "^2.2.20",
     "io-ts-reporters": "^2.0.1",
     "io-ts-types": "^0.5.19",
+    "moment-timezone": "^0.5.43",
     "redis": "^4.6.8",
     "uuid": "^9.0.1"
   },

--- a/types/src/front/api_handlers/public/assistant.ts
+++ b/types/src/front/api_handlers/public/assistant.ts
@@ -1,12 +1,13 @@
 import * as t from "io-ts";
+import { NonEmptyString } from "io-ts-types";
 
 export const PublicPostMessagesRequestBodySchema = t.intersection([
   t.type({
     content: t.string,
     mentions: t.array(t.type({ configurationId: t.string })),
     context: t.type({
-      timezone: t.string,
-      username: t.string,
+      timezone: NonEmptyString,
+      username: NonEmptyString,
       fullName: t.union([t.string, t.null]),
       email: t.union([t.string, t.null]),
       profilePictureUrl: t.union([t.string, t.null]),

--- a/types/src/front/api_handlers/public/assistant.ts
+++ b/types/src/front/api_handlers/public/assistant.ts
@@ -1,12 +1,20 @@
 import * as t from "io-ts";
 import { NonEmptyString } from "io-ts-types";
+import moment from "moment-timezone";
+
+// Custom codec to validate the timezone
+const Timezone = t.refinement(
+  t.string,
+  (s) => moment.tz.names().includes(s),
+  "Timezone"
+);
 
 export const PublicPostMessagesRequestBodySchema = t.intersection([
   t.type({
     content: t.string,
     mentions: t.array(t.type({ configurationId: t.string })),
     context: t.type({
-      timezone: NonEmptyString,
+      timezone: Timezone,
       username: NonEmptyString,
       fullName: t.union([t.string, t.null]),
       email: t.union([t.string, t.null]),


### PR DESCRIPTION
## Description

Updated the `timezone` and `username` fields in the user message context to use `NonEmptyString` type for better data validation

Using these new types ensure that the following POST request:
```
curl  -vvv  -XPOST http://localhost:3000/api/v1/w/[wId]/assistant/conversations/[cId]/messages -H "Authorization: Bearer $DUST_API_KEY" -H "Content-Type: application/json" \
 -d '{
    "content":"bonjour",
    "mentions":[],
    "context":{
        "timezone":"",
        "email":"",
        "fullName":"",
        "username":"",
        "profilePictureUrl":""
    }
 }'
```
fail with the following error:
```
{"error":{"type":"invalid_request_error","message":"Invalid request body: Expecting NonEmptyString at 0.context.timezone but instead got: \"\",Expecting NonEmptyString at 0.context.username but instead got: \"\""}}
```
## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy `types`
