### PR TITLE
enh: remove role mapping from multi-actions-agent dust app

### DIFF
--- a/types/src/front/lib/actions/registry.ts
+++ b/types/src/front/lib/actions/registry.ts
@@ -234,7 +234,7 @@ export const DustProdActionRegistry = createActionRegistry({
       workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
       appId: "0e9889c787",
       appHash:
-        "4a69f3683369c0398e9716e3c25cb628021ac4949ccf9c73944c7fd0be591aaf",
+        "704af8869cfafa2bfb5a2b074e55a51e185b6deb16128438a5996ebfffad9917",
     },
     config: {
       MODEL: {


### PR DESCRIPTION
## Description

fixes https://github.com/dust-tt/dust/issues/5338

The currently used version of the dust app still has the legacy hard-coded mapping for roles, as we used in front a set of `roles` that are not compatible with core.

The multi-actions conversation rendering uses the same roles as core, so this mapping is no longer need.

## Risk

Easy to rollback, only affect multi actions agents

## Deploy Plan

N/A