### PR TITLE
enh: add missing indexes on agent configuration tables

### DIFF
--- a/front/lib/models/assistant/actions/dust_app_run.ts
+++ b/front/lib/models/assistant/actions/dust_app_run.ts
@@ -80,6 +80,14 @@ AgentDustAppRunConfiguration.init(
         unique: true,
         fields: ["sId"],
       },
+      {
+        fields: ["agentConfigurationId"],
+        concurrently: true,
+      },
+      {
+        fields: ["forceUseAtIteration"],
+        concurrently: true,
+      },
     ],
     sequelize: frontSequelize,
   }

--- a/front/lib/models/assistant/actions/process.ts
+++ b/front/lib/models/assistant/actions/process.ts
@@ -97,6 +97,20 @@ AgentProcessConfiguration.init(
   },
   {
     modelName: "agent_process_configuration",
+    indexes: [
+      {
+        unique: true,
+        fields: ["sId"],
+        concurrently: true,
+      },
+      {
+        fields: ["agentConfigurationId"],
+        concurrently: true,
+      },
+      {
+        fields: ["forceUseAtIteration"],
+      },
+    ],
     sequelize: frontSequelize,
     hooks: {
       beforeValidate: (p: AgentProcessConfiguration) => {

--- a/front/lib/models/assistant/actions/process.ts
+++ b/front/lib/models/assistant/actions/process.ts
@@ -109,6 +109,7 @@ AgentProcessConfiguration.init(
       },
       {
         fields: ["forceUseAtIteration"],
+        concurrently: true,
       },
     ],
     sequelize: frontSequelize,

--- a/front/lib/models/assistant/actions/retrieval.ts
+++ b/front/lib/models/assistant/actions/retrieval.ts
@@ -104,6 +104,15 @@ AgentRetrievalConfiguration.init(
         fields: ["agentConfigurationId"],
         concurrently: true,
       },
+      {
+        unique: true,
+        fields: ["sId"],
+        concurrently: true,
+      },
+      {
+        fields: ["forceUseAtIteration"],
+        concurrently: true,
+      },
     ],
     hooks: {
       beforeValidate: (retrieval: AgentRetrievalConfiguration) => {

--- a/front/lib/models/assistant/actions/tables_query.ts
+++ b/front/lib/models/assistant/actions/tables_query.ts
@@ -69,6 +69,14 @@ AgentTablesQueryConfiguration.init(
         fields: ["sId"],
         name: "agent_tables_query_configuration_s_id",
       },
+      {
+        fields: ["agentConfigurationId"],
+        concurrently: true,
+      },
+      {
+        fields: ["forceUseAtIteration"],
+        concurrently: true,
+      },
     ],
     sequelize: frontSequelize,
   }

--- a/front/lib/models/assistant/actions/websearch.ts
+++ b/front/lib/models/assistant/actions/websearch.ts
@@ -69,6 +69,14 @@ AgentWebsearchConfiguration.init(
         unique: true,
         fields: ["sId"],
       },
+      {
+        fields: ["agentConfigurationId"],
+        concurrently: true,
+      },
+      {
+        fields: ["forceUseAtIteration"],
+        concurrently: true,
+      },
     ],
     sequelize: frontSequelize,
   }

--- a/front/migrations/db/migration_13.sql
+++ b/front/migrations/db/migration_13.sql
@@ -11,7 +11,7 @@ CREATE INDEX CONCURRENTLY "agent_tables_query_configurations_agent_configuration
 
 CREATE INDEX CONCURRENTLY "agent_tables_query_configurations_force_use_at_iteration" ON "agent_tables_query_configurations" ("forceUseAtIteration");
 
-CREATE INDEX "agent_process_configurations_force_use_at_iteration" ON "agent_process_configurations" ("forceUseAtIteration");
+CREATE INDEX CONCURRENTLY "agent_process_configurations_force_use_at_iteration" ON "agent_process_configurations" ("forceUseAtIteration");
 
 CREATE UNIQUE INDEX CONCURRENTLY "agent_process_configurations_s_id" ON "agent_process_configurations" ("sId");
 

--- a/front/migrations/db/migration_13.sql
+++ b/front/migrations/db/migration_13.sql
@@ -1,0 +1,22 @@
+-- Migration created on Jun 03, 2024
+CREATE UNIQUE INDEX CONCURRENTLY "agent_retrieval_configurations_s_id" ON "agent_retrieval_configurations" ("sId");
+
+CREATE INDEX CONCURRENTLY "agent_retrieval_configurations_force_use_at_iteration" ON "agent_retrieval_configurations" ("forceUseAtIteration");
+
+CREATE INDEX CONCURRENTLY "agent_dust_app_run_configurations_agent_configuration_id" ON "agent_dust_app_run_configurations" ("agentConfigurationId");
+
+CREATE INDEX CONCURRENTLY "agent_dust_app_run_configurations_force_use_at_iteration" ON "agent_dust_app_run_configurations" ("forceUseAtIteration");
+
+CREATE INDEX CONCURRENTLY "agent_tables_query_configurations_agent_configuration_id" ON "agent_tables_query_configurations" ("agentConfigurationId");
+
+CREATE INDEX CONCURRENTLY "agent_tables_query_configurations_force_use_at_iteration" ON "agent_tables_query_configurations" ("forceUseAtIteration");
+
+CREATE INDEX "agent_process_configurations_force_use_at_iteration" ON "agent_process_configurations" ("forceUseAtIteration");
+
+CREATE UNIQUE INDEX CONCURRENTLY "agent_process_configurations_s_id" ON "agent_process_configurations" ("sId");
+
+CREATE INDEX CONCURRENTLY "agent_process_configurations_agent_configuration_id" ON "agent_process_configurations" ("agentConfigurationId");
+
+CREATE INDEX CONCURRENTLY "agent_websearch_configurations_agent_configuration_id" ON "agent_websearch_configurations" ("agentConfigurationId");
+
+CREATE INDEX CONCURRENTLY "agent_websearch_configurations_force_use_at_iteration" ON "agent_websearch_configurations" ("forceUseAtIteration");


### PR DESCRIPTION
## Description

- All the `Agent*Configuration` models should have the same indexes
- `sId` is the primary external-facing identifier for the action, the expectation is that the field is indexed
- `agentConfigurationId` is how we fetch the actions most of the time. Contrary popular belief, Sequelize does not add indexes automatically on FKs, so we're missing indexes.
- `forceUseAtIteration` might be a little bit controversial, but this is the easiest way to determine (in eg metabase) if an agent config uses "multi actions" or not. I would like to have this index.

## Risk

Adding the indexes concurrently, but could still lead to issues.

## Deploy Plan

Run the migration on prodbox.