### PR TITLE
Save document sections in file storage

### DIFF
--- a/core/bin/dust_api.rs
+++ b/core/bin/dust_api.rs
@@ -1121,35 +1121,27 @@ async fn data_sources_register(
 ) -> (StatusCode, Json<APIResponse>) {
     let project = project::Project::new_from_id(project_id);
     let ds = data_source::DataSource::new(&project, &payload.data_source_id, &payload.config);
-    match ds.setup().await {
+    match state.store.register_data_source(&project, &ds).await {
         Err(e) => error_response(
             StatusCode::INTERNAL_SERVER_ERROR,
             "internal_server_error",
             "Failed to register data source",
             Some(e),
         ),
-        Ok(()) => match state.store.register_data_source(&project, &ds).await {
-            Err(e) => error_response(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "internal_server_error",
-                "Failed to register data source",
-                Some(e),
-            ),
-            Ok(()) => (
-                StatusCode::OK,
-                Json(APIResponse {
-                    error: None,
-                    response: Some(json!({
-                        "data_source": {
-                            "created": ds.created(),
-                            "data_source_id": ds.data_source_id(),
-                            "data_source_internal_id": ds.internal_id(),
-                            "config": ds.config(),
-                        },
-                    })),
-                }),
-            ),
-        },
+        Ok(()) => (
+            StatusCode::OK,
+            Json(APIResponse {
+                error: None,
+                response: Some(json!({
+                    "data_source": {
+                        "created": ds.created(),
+                        "data_source_id": ds.data_source_id(),
+                        "data_source_internal_id": ds.internal_id(),
+                        "config": ds.config(),
+                    },
+                })),
+            }),
+        ),
     }
 }
 

--- a/core/bin/qdrant/migrate_embedder.rs
+++ b/core/bin/qdrant/migrate_embedder.rs
@@ -3,7 +3,7 @@ use clap::{Parser, Subcommand};
 use dust::{
     data_sources::{
         data_source::{
-            make_qdrant_document_id_hash, DataSource, EmbedderConfig, EmbedderDataSourceConfig,
+            make_document_id_hash, DataSource, EmbedderConfig, EmbedderDataSourceConfig,
             SearchFilter, TimestampFilter,
         },
         qdrant::QdrantClients,
@@ -657,7 +657,7 @@ async fn refresh_chunk_count_for_updated_documents(
             let f = qdrant::Filter {
                 must: vec![qdrant::Condition::matches(
                     "document_id_hash",
-                    make_qdrant_document_id_hash(&doc_id),
+                    make_document_id_hash(&doc_id),
                 )],
                 ..Default::default()
             };

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -862,9 +862,8 @@ impl DataSource {
 
         FileStorageDocument::save_document_in_file_storage(
             &self,
-            document_id,
+            &document,
             &document_id_hash,
-            &document_hash,
             &full_text,
             text.clone(),
         )
@@ -1906,9 +1905,6 @@ impl DataSource {
             }
             None => Ok(()),
         }?;
-
-        // Delete document from file storage.
-        FileStorageDocument::delete(&self, &make_document_id_hash(document_id)).await?;
 
         // Delete document (SQL)
         store

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -596,32 +596,6 @@ impl DataSource {
         Ok(())
     }
 
-    pub async fn setup(&self) -> Result<()> {
-        // GCP store created data to test GCP.
-        let bucket = match std::env::var("DUST_DATA_SOURCES_BUCKET") {
-            Ok(bucket) => bucket,
-            Err(_) => Err(anyhow!("DUST_DATA_SOURCES_BUCKET is not set"))?,
-        };
-
-        let bucket_path = format!("{}/{}", self.project.project_id(), self.internal_id);
-        let data_source_created_path = format!("{}/created.txt", bucket_path);
-
-        Object::create(
-            &bucket,
-            format!("{}", self.created).as_bytes().to_vec(),
-            &data_source_created_path,
-            "application/text",
-        )
-        .await?;
-
-        info!(
-            data_source_internal_id = self.internal_id(),
-            "Created GCP bucket for data_source"
-        );
-
-        Ok(())
-    }
-
     pub async fn update_parents(
         &self,
         store: Box<dyn Store + Sync + Send>,

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -596,7 +596,6 @@ impl DataSource {
         Ok(())
     }
 
-    // What is this used for?
     pub async fn setup(&self) -> Result<()> {
         // GCP store created data to test GCP.
         let bucket = match std::env::var("DUST_DATA_SOURCES_BUCKET") {

--- a/core/src/data_sources/file_storage_document.rs
+++ b/core/src/data_sources/file_storage_document.rs
@@ -1,0 +1,118 @@
+use anyhow::{anyhow, Result};
+use cloud_storage::Object;
+use serde::{Deserialize, Serialize};
+use tokio::try_join;
+use tracing::info;
+
+use crate::utils;
+
+use super::data_source::{DataSource, Section};
+
+#[derive(Serialize, Deserialize)]
+pub struct FileStorageDocument {
+    document_id: String,
+    full_text: String,
+    sections: Section,
+}
+
+impl FileStorageDocument {
+    // Should live on DataSource instead?
+    pub async fn get_bucket() -> Result<String> {
+        match std::env::var("DUST_DATA_SOURCES_BUCKET") {
+            Ok(bucket) => Ok(bucket),
+            Err(_) => Err(anyhow!("DUST_DATA_SOURCES_BUCKET is not set")),
+        }
+    }
+
+    pub fn get_document_file_path(data_source: &DataSource, document_id_hash: &str) -> String {
+        let ds_bucket_path = format!(
+            "{}/{}",
+            data_source.project().project_id(),
+            data_source.internal_id()
+        );
+
+        format!("{}/{}.txt", ds_bucket_path, document_id_hash)
+    }
+
+    pub async fn save_document_in_file_storage(
+        data_source: &DataSource,
+        document_id: &str,
+        document_id_hash: &str,
+        document_hash: &str,
+        full_text: &str,
+        text: Section,
+    ) -> Result<()> {
+        let bucket = FileStorageDocument::get_bucket().await?;
+
+        let data_source_project_id = data_source.project().project_id();
+        let data_source_internal_id = data_source.internal_id();
+
+        // TODO(2024-06-03 flav) Delete once fully migrated to new format.
+        // Legacy.
+        let legacy_bucket_path = format!(
+            "{}/{}/{}",
+            data_source_project_id, data_source_internal_id, document_id_hash
+        );
+
+        let document_id_path = format!("{}/document_id.txt", legacy_bucket_path);
+        let content_path = format!("{}/{}/content.txt", legacy_bucket_path, document_hash);
+
+        // New.
+        let document_file_path =
+            FileStorageDocument::get_document_file_path(data_source, document_id_hash);
+        let file_storage_document = FileStorageDocument {
+            document_id: document_id.to_string(),
+            full_text: full_text.to_string(),
+            sections: text,
+        };
+        let serialized_document = serde_json::to_vec(&file_storage_document)?;
+
+        let now = utils::now();
+        let _ = try_join!(
+            // TODO(2024-06-03 flav) Delete once fully migrated to new format.
+            // Legacy.
+            Object::create(
+                &bucket,
+                document_id.as_bytes().to_vec(),
+                &document_id_path,
+                "application/text",
+            ),
+            Object::create(
+                &bucket,
+                full_text.as_bytes().to_vec(),
+                &content_path,
+                "application/text",
+            ),
+            // New logic.
+            Object::create(
+                &bucket,
+                serialized_document,
+                &document_file_path,
+                "application/json",
+            ),
+        )?;
+
+        info!(
+            data_source_internal_id = data_source_internal_id,
+            document_id = document_id,
+            duration = utils::now() - now,
+            // Legacy.
+            legacy_blob_url = format!("gs://{}/{}", bucket, content_path),
+            // New.
+            blob_url = format!("gs://{}/{}", bucket, document_file_path),
+            "Created document blob"
+        );
+
+        Ok(())
+    }
+
+    pub async fn delete(data_source: &DataSource, document_id_hash: &str) -> Result<()> {
+        let bucket = FileStorageDocument::get_bucket().await?;
+        let document_file_path =
+            FileStorageDocument::get_document_file_path(data_source, document_id_hash);
+
+        Object::delete(&bucket, &document_file_path).await?;
+
+        Ok(())
+    }
+}

--- a/core/src/data_sources/file_storage_document.rs
+++ b/core/src/data_sources/file_storage_document.rs
@@ -3,7 +3,6 @@ use cloud_storage::Object;
 use serde::{Deserialize, Serialize};
 use tokio::try_join;
 use tracing::info;
-use tracing_subscriber::fmt::format;
 
 use crate::utils;
 

--- a/core/src/data_sources/file_storage_document.rs
+++ b/core/src/data_sources/file_storage_document.rs
@@ -3,10 +3,11 @@ use cloud_storage::Object;
 use serde::{Deserialize, Serialize};
 use tokio::try_join;
 use tracing::info;
+use tracing_subscriber::fmt::format;
 
 use crate::utils;
 
-use super::data_source::{DataSource, Section};
+use super::data_source::{DataSource, Document, Section};
 
 #[derive(Serialize, Deserialize)]
 pub struct FileStorageDocument {
@@ -16,7 +17,6 @@ pub struct FileStorageDocument {
 }
 
 impl FileStorageDocument {
-    // Should live on DataSource instead?
     pub async fn get_bucket() -> Result<String> {
         match std::env::var("DUST_DATA_SOURCES_BUCKET") {
             Ok(bucket) => Ok(bucket),
@@ -24,21 +24,27 @@ impl FileStorageDocument {
         }
     }
 
-    pub fn get_document_file_path(data_source: &DataSource, document_id_hash: &str) -> String {
+    pub fn get_document_file_path(
+        data_source: &DataSource,
+        document_created: u64,
+        document_id_hash: &str,
+        document_hash: &str,
+    ) -> String {
         let ds_bucket_path = format!(
             "{}/{}",
             data_source.project().project_id(),
             data_source.internal_id()
         );
 
-        format!("{}/{}.txt", ds_bucket_path, document_id_hash)
+        let filename = format!("{}_{}", document_created, document_hash);
+
+        format!("{}/{}/{}.json", ds_bucket_path, document_id_hash, filename)
     }
 
     pub async fn save_document_in_file_storage(
         data_source: &DataSource,
-        document_id: &str,
+        document: &Document,
         document_id_hash: &str,
-        document_hash: &str,
         full_text: &str,
         text: Section,
     ) -> Result<()> {
@@ -46,6 +52,9 @@ impl FileStorageDocument {
 
         let data_source_project_id = data_source.project().project_id();
         let data_source_internal_id = data_source.internal_id();
+
+        let document_hash = &document.hash;
+        let document_id = &document.document_id;
 
         // TODO(2024-06-03 flav) Delete once fully migrated to new format.
         // Legacy.
@@ -58,8 +67,12 @@ impl FileStorageDocument {
         let content_path = format!("{}/{}/content.txt", legacy_bucket_path, document_hash);
 
         // New.
-        let document_file_path =
-            FileStorageDocument::get_document_file_path(data_source, document_id_hash);
+        let document_file_path = FileStorageDocument::get_document_file_path(
+            data_source,
+            document.created,
+            document_id_hash,
+            document_hash,
+        );
         let file_storage_document = FileStorageDocument {
             document_id: document_id.to_string(),
             full_text: full_text.to_string(),
@@ -102,16 +115,6 @@ impl FileStorageDocument {
             blob_url = format!("gs://{}/{}", bucket, document_file_path),
             "Created document blob"
         );
-
-        Ok(())
-    }
-
-    pub async fn delete(data_source: &DataSource, document_id_hash: &str) -> Result<()> {
-        let bucket = FileStorageDocument::get_bucket().await?;
-        let document_file_path =
-            FileStorageDocument::get_document_file_path(data_source, document_id_hash);
-
-        Object::delete(&bucket, &document_file_path).await?;
 
         Ok(())
     }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -13,6 +13,7 @@ pub mod app;
 pub mod dataset;
 pub mod data_sources {
     pub mod data_source;
+    pub mod file_storage_document;
     pub mod qdrant;
     pub mod splitter;
 }

--- a/front/lib/production_checks/checks/scrub_deleted_core_document_versions.ts
+++ b/front/lib/production_checks/checks/scrub_deleted_core_document_versions.ts
@@ -1,6 +1,5 @@
 import type { Bucket } from "@google-cloud/storage";
 import { Storage } from "@google-cloud/storage";
-import type { Logger } from "ajv";
 import { createHash } from "blake3";
 import type { LoggerOptions } from "pino";
 import type pino from "pino";

--- a/front/lib/production_checks/checks/scrub_deleted_core_document_versions.ts
+++ b/front/lib/production_checks/checks/scrub_deleted_core_document_versions.ts
@@ -204,8 +204,10 @@ async function scrubDocument({
     dataSourceId: dataSource.id,
   });
 
-  await deleteAllFilesFromFolder(localLogger, bucket, seen, path);
+  // Always delete legacy files first!
   await deleteAllFilesFromFolder(localLogger, bucket, seen, legacyPath);
+
+  await deleteAllFilesFromFolder(localLogger, bucket, seen, path);
 
   await core_sequelize.query(
     `DELETE FROM data_sources_documents WHERE data_source = :data_source AND document_id = :document_id AND hash = :hash AND status = 'deleted'`,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See https://github.com/dust-tt/dust/issues/5297.

This PR refactors our document storage strategy to address current limitations and facilitate the migration of our Qdrant. 

### Current Implementation:
- We save separate files (`content.txt`, `document_id.txt`) for retrieval purposes.
- This approach lacks sufficient information (missing `sections`) needed to use it as a source of truth for Qdrant migration.

### New Strategy:
- Introduce a new file format: `{bucket}/{project}/{data_source_internal_id}/{document_id}/{created}_{hash}.json`.
- The new file will include all necessary information, including `sections`.

### Transition Plan:
1. **Enable Double Write:** Implement writing to both the legacy files and the new file format.
2. **Backfill Existing Documents:** Migrate all existing documents to the new file format.
3. **Switch Reads:** Update the system to read from the new file format.
4. **Delete Legacy Strategy:** Deprecate and remove the legacy file storage method.

### Additional Updates:
- Updated scrub workflow logic to align with the new file storage strategy. Note that documents are never deleted from the core; deletion occurs only through the scrub workflow.

Plan:
- [ ] Enable double write
- [ ] Backfill existing documents
- [ ] Switch reads
- [ ] Delete the legacy strategy
 
## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
