### PR TITLE
[front/logger] - feature: add user session tracking to logging

### DIFF
--- a/front/logger/withlogging.ts
+++ b/front/logger/withlogging.ts
@@ -1,4 +1,3 @@
-import { getSession } from "@auth0/nextjs-auth0";
 import type {
   APIErrorWithStatusCode,
   WithAPIErrorReponse,
@@ -7,6 +6,7 @@ import tracer from "dd-trace";
 import StatsD from "hot-shots";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import { getSession } from "@app/lib/auth";
 import type {
   CustomGetServerSideProps,
   UserPrivilege,
@@ -34,7 +34,7 @@ export function withLogging<T>(
     const now = new Date();
 
     const session = await getSession(req, res);
-    const sessionId = session?.user?.sub || "unknown";
+    const sessionId = session?.user.sid || "unknown";
 
     logger.info(
       {

--- a/front/logger/withlogging.ts
+++ b/front/logger/withlogging.ts
@@ -1,3 +1,4 @@
+import { getSession } from "@auth0/nextjs-auth0";
 import type {
   APIErrorWithStatusCode,
   WithAPIErrorReponse,
@@ -32,10 +33,14 @@ export function withLogging<T>(
     }
     const now = new Date();
 
+    const session = await getSession(req, res);
+    const sessionId = session?.user?.sub || "unknown";
+
     logger.info(
       {
         method: req.method,
         url: req.url,
+        sessionId,
       },
       "Begin Request Processing."
     );
@@ -63,6 +68,7 @@ export function withLogging<T>(
           durationMs: elapsed,
           streaming,
           error: err,
+          sessionId,
           // @ts-expect-error best effort to get err.stack if it exists
           error_stack: err?.stack,
         },
@@ -107,6 +113,7 @@ export function withLogging<T>(
         route,
         statusCode: res.statusCode,
         durationMs: elapsed,
+        sessionId,
         streaming,
       },
       "Processed request"


### PR DESCRIPTION
## Description

 - Include `sessionId` in the logging for the start, error, and end of request processing to trace user activity

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy `front`
