### PR TITLE
Logging large activity attempt count before activity start.

### DIFF
--- a/connectors/src/lib/temporal_monitoring.ts
+++ b/connectors/src/lib/temporal_monitoring.ts
@@ -87,7 +87,7 @@ export class ActivityInboundLogInterceptor
           workflow_name: this.context.info.workflowType,
           attempt: this.context.info.attempt,
         },
-        "Activity has been attempted more than 25 times. Make sure it's not crashing the pod before investigating."
+        "Activity has been attempted more than 25 times. Make sure it's not crashing the pod."
       );
     }
     try {

--- a/connectors/src/lib/temporal_monitoring.ts
+++ b/connectors/src/lib/temporal_monitoring.ts
@@ -81,7 +81,11 @@ export class ActivityInboundLogInterceptor
     // By looking at the attempt count before the activity starts, we can detect activities that are repeatedly crashing the pod.
     if (this.context.info.attempt > 25) {
       this.logger.error(
-        { panic: true },
+        {
+          activity_name: this.context.info.activityType,
+          workflow_name: this.context.info.workflowType,
+          attempt: this.context.info.attempt,
+        },
         "Activity has been attempted more than 25 times. Make sure it's not crashing the pod before investigating."
       );
     }

--- a/connectors/src/lib/temporal_monitoring.ts
+++ b/connectors/src/lib/temporal_monitoring.ts
@@ -8,6 +8,7 @@ import type {
 import tracer from "dd-trace";
 
 import type { Logger } from "@connectors/logger/logger";
+import type logger from "@connectors/logger/logger";
 import { statsDClient } from "@connectors/logger/withlogging";
 
 import { ExternalOauthTokenError } from "./error";

--- a/connectors/src/lib/temporal_monitoring.ts
+++ b/connectors/src/lib/temporal_monitoring.ts
@@ -77,12 +77,12 @@ export class ActivityInboundLogInterceptor
       );
     }, this.context.info.startToCloseTimeoutMs);
 
-    // We already trigger a monitor after 20 attempts, but when the pod carshed (eg: OOM or segfault), the attempt never get logged.
-    // So we add a monitor the attempt count before the activity starts.
+    // We already trigger a monitor after 20 failures, but when the pod crashes (eg: OOM or segfault), the attempt never gets logged.
+    // By looking at the attempt count before the activity starts, we can detect activities that are repeatedly crashing the pod.
     if (this.context.info.attempt > 25) {
       this.logger.error(
         { panic: true },
-        "Activity has been attempted more than 25 times"
+        "Activity has been attempted more than 25 times. Make sure it's not crashing the pod before investigating."
       );
     }
     try {


### PR DESCRIPTION
## Description

When logging Temporal activity failures in Connectors, we log the activity attempt count and trigger a monitor after 20 failures.
The problem with this design is that when a pod crashes because of this activity, we never get a chance to log it, so we don't get a monitor.
This PR logs the attempt *before* the activity starts, that way, we are sure to always have the log and ultimately trigger the monitor.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
