### PR TITLE
Bump prodbox ephemeral storage

### DIFF
--- a/k8s/deployments/prodbox-deployment.yaml
+++ b/k8s/deployments/prodbox-deployment.yaml
@@ -53,11 +53,11 @@ spec:
             requests:
               cpu: 4000m
               memory: 4Gi
-              ephemeral-storage: 4Gi
+              ephemeral-storage: 16Gi
             limits:
               cpu: 4000m
               memory: 4Gi
-              ephemeral-storage: 4Gi
+              ephemeral-storage: 16Gi
 
       volumes:
         - name: cert-volume


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Our prodbox pod gets killed several time for the following reason:
```
Status:           Failed
Reason:           Evicted
Message:          Pod ephemeral local storage usage exceeds the total limit of containers 4Gi.
```

This PR bumps the ephemeral storage to 16GB.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Apply infra.

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
