### PR TITLE
core: OpenAI streaming errors

### DIFF
--- a/core/src/providers/embedder.rs
+++ b/core/src/providers/embedder.rs
@@ -8,7 +8,7 @@ use async_trait::async_trait;
 use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use tracing::info;
+use tracing::{error, info};
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct EmbedderVector {
@@ -105,6 +105,15 @@ impl EmbedderRequest {
                     sleep = sleep.as_millis(),
                     err_msg = err_msg,
                     "Retry querying"
+                );
+            },
+            |err| {
+                error!(
+                    provider_id = self.provider_id.to_string(),
+                    model_id = self.model_id,
+                    err_msg = err.message,
+                    request_id = err.request_id.as_deref().unwrap_or(""),
+                    "EmbedderRequest model error",
                 );
             },
         )

--- a/core/src/providers/llm.rs
+++ b/core/src/providers/llm.rs
@@ -11,7 +11,7 @@ use serde_json::Value;
 use std::collections::HashMap;
 use std::str::FromStr;
 use tokio::sync::mpsc::UnboundedSender;
-use tracing::info;
+use tracing::{error, info};
 
 #[derive(Debug, Serialize, PartialEq, Clone, Deserialize)]
 pub struct Tokens {
@@ -268,6 +268,15 @@ impl LLMRequest {
                     "Retry querying"
                 );
             },
+            |err| {
+                error!(
+                    provider_id = self.provider_id.to_string(),
+                    model_id = self.model_id,
+                    err_msg = err.message,
+                    request_id = err.request_id.as_deref().unwrap_or(""),
+                    "LLMRequest model error",
+                );
+            },
         )
         .await;
 
@@ -466,6 +475,15 @@ impl LLMChatRequest {
                     sleep = sleep.as_millis(),
                     err_msg = err_msg,
                     "Retry querying"
+                );
+            },
+            |err| {
+                error!(
+                    provider_id = self.provider_id.to_string(),
+                    model_id = self.model_id,
+                    err_msg = err.message,
+                    request_id = err.request_id.as_deref().unwrap_or(""),
+                    "LLMChatRequest model error",
                 );
             },
         )


### PR DESCRIPTION
## Description

- Add support for errors when streaming from OpenAI
- Cleans up logging of ModelError with request-id

Before/after (events):
```
data: {"type":"block_execution","content":{"block_type":"chat","block_name":"MODEL","execution":[[{"value":null,"error":"Error querying `openai:gpt-3.5-turbo-instruct`: error=Error streaming tokens from OpenAI: UnexpectedResponse(ResponseWrapper { status: 404 })","meta":null}]]}}
```
```
data: {"type":"block_execution","content":{"block_type":"chat","block_name":"MODEL","execution":[[{"value":null,"error":"Error querying `openai:gpt-3.5-turbo-instruct`: error=[model_error(retryable=false)] OpenAIError: [invalid_request_error] This is not a chat model and thus not supported in the v1/chat/completions endpoint. Did you mean to use v1/completions?","meta":null}]]}}
```

Logs `core`:
```
{"timestamp":"2024-06-03T12:21:17.421999211+00:00","level":"ERROR","message":"LLMChatRequest model error request_id=req_0d9b9bee8e22160cb5e4e2633e928960 provider_id=openai model_id=gpt-3.5-turbo-instruct err_msg=OpenAIError: [invalid_request_error] This is not a chat model and thus not supported in the v1/chat/completions endpoint. Did you mean to use v1/completions?","target":"dust::providers::llm"}
```

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
