### PR TITLE
Limit draft versions generation on Assistant Builder

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -447,7 +447,6 @@ export function AgentMessage({
       );
     }
 
-    // Loading state (no action nor text yet)
     if (
       agentMessage.status === "created" &&
       !agentMessage.actions.length &&

--- a/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
+++ b/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
@@ -7,6 +7,7 @@ import {
   Markdown,
   MoreIcon,
   Page,
+  Spinner,
   Tab,
   XMarkIcon,
 } from "@dust-tt/sparkle";
@@ -78,7 +79,11 @@ export default function AssistantBuilderRightPanel({
     shouldAnimate: shouldAnimatePreviewDrawer,
     draftAssistant,
     isFading,
-  } = usePreviewAssistant({ owner, builderState });
+  } = usePreviewAssistant({
+    owner,
+    builderState,
+    isPreviewOpened: rightPanelStatus.tab === "Preview",
+  });
 
   const { user } = useUser();
   const {
@@ -119,39 +124,45 @@ export default function AssistantBuilderRightPanel({
             : ""
         )}
       >
-        {rightPanelStatus.tab === "Preview" && user && draftAssistant && (
+        {rightPanelStatus.tab === "Preview" && user && (
           <div className="flex h-full w-full flex-1 flex-col justify-between overflow-x-hidden">
-            <GenerationContextProvider>
-              <div
-                className="flex-grow overflow-y-auto"
-                id={CONVERSATION_PARENT_SCROLL_DIV_ID.modal}
-              >
-                {conversation && (
-                  <ConversationViewer
+            {draftAssistant ? (
+              <GenerationContextProvider>
+                <div
+                  className="flex-grow overflow-y-auto"
+                  id={CONVERSATION_PARENT_SCROLL_DIV_ID.modal}
+                >
+                  {conversation && (
+                    <ConversationViewer
+                      owner={owner}
+                      user={user}
+                      conversationId={conversation.sId}
+                      onStickyMentionsChange={setStickyMentions}
+                      isInModal
+                      hideReactions
+                      isFading={isFading}
+                      key={conversation.sId}
+                    />
+                  )}
+                </div>
+                <div className="shrink-0">
+                  <AssistantInputBar
                     owner={owner}
-                    user={user}
-                    conversationId={conversation.sId}
-                    onStickyMentionsChange={setStickyMentions}
-                    isInModal
-                    hideReactions
-                    isFading={isFading}
-                    key={conversation.sId}
+                    onSubmit={handleSubmit}
+                    stickyMentions={stickyMentions}
+                    conversationId={conversation?.sId || null}
+                    additionalAgentConfiguration={draftAssistant}
+                    hideQuickActions
+                    disableAutoFocus
+                    isFloating={false}
                   />
-                )}
+                </div>
+              </GenerationContextProvider>
+            ) : (
+              <div className="flex h-full w-full items-center justify-center">
+                <Spinner />
               </div>
-              <div className="shrink-0">
-                <AssistantInputBar
-                  owner={owner}
-                  onSubmit={handleSubmit}
-                  stickyMentions={stickyMentions}
-                  conversationId={conversation?.sId || null}
-                  additionalAgentConfiguration={draftAssistant}
-                  hideQuickActions
-                  disableAutoFocus
-                  isFloating={false}
-                />
-              </div>
-            </GenerationContextProvider>
+            )}
           </div>
         )}
         {rightPanelStatus.tab === "Template" && (


### PR DESCRIPTION
## Description

The goal of this PR is to stop generation draft versions of assistant when we don't need it: when we're not on the preview drawer and when there's no last update on the builder since the last draft. 

I initially wanted to refactor properly and stop keeping all drafts version but got convinced by Stan that it technically makes sense to keep the drafts version since conversations can be attached to it. 
So 80/20 is to limit the generations. 

The UX diff before and after this PR is that there will be a loader display the first time we open the Preview drawer. I've confirmed with Ed he's ok with it and he told me where to put the Spinner. 

Review with hidden whitespaces easier: https://github.com/dust-tt/dust/pull/5422/files?diff=split&w=1

## Risk

Break the Assistant Builder. 
Can be rolled back. 

## Deploy Plan

Deploy front. 
