### PR TITLE
[connectors] - fix: GoogleDrive webhook renewal

### DIFF
--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -553,10 +553,10 @@ export async function setGoogleDriveConnectorPermissions(
       );
     }
   }
-  const renewWebhookStartingTime = new Date().getTime();
+  const maxRenewalTime = new Date().getTime();
   const webhooksRes = await registerWebhooksForAllDrives({
     connector,
-    renewWebhookStartingTime,
+    maxRenewalTime,
   });
   if (webhooksRes.isErr()) {
     const firstError = webhooksRes.error[0];

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -553,10 +553,10 @@ export async function setGoogleDriveConnectorPermissions(
       );
     }
   }
-
+  const renewWebhookStartingTime = new Date().getTime();
   const webhooksRes = await registerWebhooksForAllDrives({
     connector,
-    marginMs: 0,
+    renewWebhookStartingTime,
   });
   if (webhooksRes.isErr()) {
     const firstError = webhooksRes.error[0];

--- a/connectors/src/connectors/google_drive/lib.ts
+++ b/connectors/src/connectors/google_drive/lib.ts
@@ -69,7 +69,7 @@ export async function ensureWebhookForDriveId(
       connectorId: connector.id,
       driveId: driveId,
       expiresAt: {
-        [Op.gt]: new Date(renewWebhookStartingTime),
+        [Op.lt]: new Date(renewWebhookStartingTime),
       },
     },
   });

--- a/connectors/src/connectors/google_drive/lib.ts
+++ b/connectors/src/connectors/google_drive/lib.ts
@@ -35,19 +35,15 @@ const { CONNECTORS_PUBLIC_URL, DUST_CONNECTORS_WEBHOOKS_SECRET } = process.env;
 
 export async function registerWebhooksForAllDrives({
   connector,
-  renewWebhookStartingTime,
+  maxRenewalTime,
 }: {
   connector: ConnectorResource;
-  renewWebhookStartingTime: number;
+  maxRenewalTime: number;
 }): Promise<Result<undefined, Error[]>> {
   const drivesToSync = await getDrivesToSync(connector.id);
   const allRes = await Promise.all(
     drivesToSync.map((drive) => {
-      return ensureWebhookForDriveId(
-        connector,
-        drive.id,
-        renewWebhookStartingTime
-      );
+      return ensureWebhookForDriveId(connector, drive.id, maxRenewalTime);
     })
   );
 
@@ -62,14 +58,14 @@ export async function registerWebhooksForAllDrives({
 export async function ensureWebhookForDriveId(
   connector: ConnectorResource,
   driveId: string,
-  renewWebhookStartingTime: number
+  maxRenewalTime: number
 ): Promise<Result<string | undefined, Error>> {
   const webhook = await GoogleDriveWebhook.findOne({
     where: {
       connectorId: connector.id,
       driveId: driveId,
       expiresAt: {
-        [Op.lt]: new Date(renewWebhookStartingTime),
+        [Op.lt]: new Date(maxRenewalTime),
       },
     },
   });

--- a/connectors/src/connectors/google_drive/lib.ts
+++ b/connectors/src/connectors/google_drive/lib.ts
@@ -65,7 +65,7 @@ export async function ensureWebhookForDriveId(
       connectorId: connector.id,
       driveId: driveId,
       expiresAt: {
-        [Op.lt]: new Date(maxRenewalTime),
+        [Op.gt]: new Date(maxRenewalTime),
       },
     },
   });
@@ -94,7 +94,6 @@ export async function ensureWebhookForDriveId(
       { webhookId: webhook.webhookId, connectorId: connector.id },
       "Webhook created"
     );
-
     return new Ok(webhook.webhookId);
   }
   return new Ok(undefined);

--- a/connectors/src/connectors/google_drive/lib.ts
+++ b/connectors/src/connectors/google_drive/lib.ts
@@ -35,15 +35,19 @@ const { CONNECTORS_PUBLIC_URL, DUST_CONNECTORS_WEBHOOKS_SECRET } = process.env;
 
 export async function registerWebhooksForAllDrives({
   connector,
-  marginMs,
+  renewWebhookStartingTime,
 }: {
   connector: ConnectorResource;
-  marginMs: number;
+  renewWebhookStartingTime: number;
 }): Promise<Result<undefined, Error[]>> {
   const drivesToSync = await getDrivesToSync(connector.id);
   const allRes = await Promise.all(
     drivesToSync.map((drive) => {
-      return ensureWebhookForDriveId(connector, drive.id, marginMs);
+      return ensureWebhookForDriveId(
+        connector,
+        drive.id,
+        renewWebhookStartingTime
+      );
     })
   );
 
@@ -58,14 +62,14 @@ export async function registerWebhooksForAllDrives({
 export async function ensureWebhookForDriveId(
   connector: ConnectorResource,
   driveId: string,
-  marginMs: number
+  renewWebhookStartingTime: number
 ): Promise<Result<string | undefined, Error>> {
   const webhook = await GoogleDriveWebhook.findOne({
     where: {
       connectorId: connector.id,
       driveId: driveId,
       expiresAt: {
-        [Op.gt]: new Date(new Date().getTime() + marginMs),
+        [Op.gt]: new Date(renewWebhookStartingTime),
       },
     },
   });

--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -628,11 +628,12 @@ export async function garbageCollector(
 
 export async function renewWebhooks(pageSize: number): Promise<number> {
   // Find webhook that are about to expire in the next hour.
+  const renewWebhookStartingTime = new Date().getTime();
   const webhooks = await GoogleDriveWebhook.findAll({
     where: {
       renewAt: {
         [Op.lt]: new Date(
-          new Date().getTime() + GOOGLE_DRIVE_WEBHOOK_RENEW_MARGIN_MS
+          renewWebhookStartingTime + GOOGLE_DRIVE_WEBHOOK_RENEW_MARGIN_MS
         ),
       },
 
@@ -655,7 +656,7 @@ export async function renewWebhooks(pageSize: number): Promise<number> {
       );
       continue;
     }
-    if (wh.expiresAt < new Date()) {
+    if (wh.expiresAt < new Date(renewWebhookStartingTime)) {
       logger.error(
         {
           webhook: {

--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -9,10 +9,7 @@ import PQueue from "p-queue";
 import { literal, Op } from "sequelize";
 
 import { ensureWebhookForDriveId } from "@connectors/connectors/google_drive/lib";
-import {
-  GOOGLE_DRIVE_WEBHOOK_LIFE_MS,
-  GOOGLE_DRIVE_WEBHOOK_RENEW_MARGIN_MS,
-} from "@connectors/connectors/google_drive/lib/config";
+import { GOOGLE_DRIVE_WEBHOOK_RENEW_MARGIN_MS } from "@connectors/connectors/google_drive/lib/config";
 import { getGoogleDriveObject } from "@connectors/connectors/google_drive/lib/google_drive_api";
 import { getFileParentsMemoized } from "@connectors/connectors/google_drive/lib/hierarchy";
 import { syncOneFile } from "@connectors/connectors/google_drive/temporal/file";

--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -9,7 +9,10 @@ import PQueue from "p-queue";
 import { literal, Op } from "sequelize";
 
 import { ensureWebhookForDriveId } from "@connectors/connectors/google_drive/lib";
-import { GOOGLE_DRIVE_WEBHOOK_RENEW_MARGIN_MS } from "@connectors/connectors/google_drive/lib/config";
+import {
+  GOOGLE_DRIVE_WEBHOOK_LIFE_MS,
+  GOOGLE_DRIVE_WEBHOOK_RENEW_MARGIN_MS,
+} from "@connectors/connectors/google_drive/lib/config";
 import { getGoogleDriveObject } from "@connectors/connectors/google_drive/lib/google_drive_api";
 import { getFileParentsMemoized } from "@connectors/connectors/google_drive/lib/hierarchy";
 import { syncOneFile } from "@connectors/connectors/google_drive/temporal/file";
@@ -686,7 +689,7 @@ export async function renewWebhooks(pageSize: number): Promise<number> {
       const res = await ensureWebhookForDriveId(
         connector,
         wh.driveId,
-        renewWebhookStartingTime
+        renewWebhookStartingTime + GOOGLE_DRIVE_WEBHOOK_RENEW_MARGIN_MS
       );
       if (res.isErr()) {
         // Throwing here to centralize error handling in the catch block

--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -686,7 +686,7 @@ export async function renewWebhooks(pageSize: number): Promise<number> {
       const res = await ensureWebhookForDriveId(
         connector,
         wh.driveId,
-        GOOGLE_DRIVE_WEBHOOK_RENEW_MARGIN_MS
+        renewWebhookStartingTime
       );
       if (res.isErr()) {
         // Throwing here to centralize error handling in the catch block

--- a/connectors/src/lib/cli.ts
+++ b/connectors/src/lib/cli.ts
@@ -821,10 +821,10 @@ export const google_drive = async ({
           `Could not find connector for workspace ${args.wId} and data source ${args.dataSourceName}`
         );
       }
-
+      const renewWebhookStartingTime = new Date().getTime();
       const res = await registerWebhooksForAllDrives({
         connector,
-        marginMs: 0,
+        renewWebhookStartingTime,
       });
       if (res.isErr()) {
         throw res.error;
@@ -841,9 +841,10 @@ export const google_drive = async ({
           );
           continue;
         }
+        const renewWebhookStartingTime = new Date().getTime();
         const res = await registerWebhooksForAllDrives({
           connector,
-          marginMs: 0,
+          renewWebhookStartingTime,
         });
         if (res.isErr()) {
           // error registering for this webhook, but we need to keep going

--- a/connectors/src/lib/cli.ts
+++ b/connectors/src/lib/cli.ts
@@ -821,10 +821,10 @@ export const google_drive = async ({
           `Could not find connector for workspace ${args.wId} and data source ${args.dataSourceName}`
         );
       }
-      const renewWebhookStartingTime = new Date().getTime();
+      const maxRenewalTime = new Date().getTime();
       const res = await registerWebhooksForAllDrives({
         connector,
-        renewWebhookStartingTime,
+        maxRenewalTime,
       });
       if (res.isErr()) {
         throw res.error;
@@ -841,10 +841,10 @@ export const google_drive = async ({
           );
           continue;
         }
-        const renewWebhookStartingTime = new Date().getTime();
+        const maxRenewalTime = new Date().getTime();
         const res = await registerWebhooksForAllDrives({
           connector,
-          renewWebhookStartingTime,
+          maxRenewalTime,
         });
         if (res.isErr()) {
           // error registering for this webhook, but we need to keep going


### PR DESCRIPTION
## Description

This PR addresses the following changes and fixes:

**Refactor: Use Precise Timestamp for Webhook Renewal Initiation**
- Replaced zero marginMs with a calculated renewWebhookStartingTime to signify the initiation time for renewing webhooks.
- Updated methods to accept the new renewWebhookStartingTime parameter for consistent webhook renewal logic.

**Fix: Ensure Correct Timing When Renewing Webhooks**
- Utilized a consistent timestamp when checking webhook expiration to prevent timing discrepancies.
- Compared webhook expiration against the captured time rather than the current time to avoid potential race conditions.

These changes aim to resolve timing issues and race conditions observed in the error logs:
```
Found a webhook to renew but did not proceed to the renewal process. Need to investigate.
```

## Risk

Risky: it touches the webhook renewal procedure

## Deploy Plan

Deploy `connectors`
