### PR TITLE
Revert "Revert [Gdrive] Fix: GDriveFiles deletion also deletes in GDriveFolers (#5333)"

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -40,6 +40,7 @@ import { syncFailed } from "@connectors/lib/sync_status";
 import { heartbeat } from "@connectors/lib/temporal";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
+import { sequelizeConnection } from "@connectors/resources/storage";
 import type { DataSourceConfig } from "@connectors/types/data_source_config";
 import type { GoogleDriveObjectType } from "@connectors/types/google_drive";
 import { FILE_ATTRIBUTES_TO_FETCH } from "@connectors/types/google_drive";
@@ -854,7 +855,19 @@ async function deleteFile(googleDriveFile: GoogleDriveFiles) {
     const dataSourceConfig = dataSourceConfigFromConnector(connector);
     await deleteFromDataSource(dataSourceConfig, googleDriveFile.dustFileId);
   }
-  await googleDriveFile.destroy();
+  const folder = await GoogleDriveFolders.findOne({
+    where: {
+      connectorId: connectorId,
+      folderId: googleDriveFile.driveFileId,
+    },
+  });
+
+  await sequelizeConnection.transaction(async (t) => {
+    if (folder) {
+      await folder.destroy({ transaction: t });
+    }
+    await googleDriveFile.destroy({ transaction: t });
+  });
 }
 
 export async function markFolderAsVisited(


### PR DESCRIPTION
Description
---
#5333 was reverted until we fix an underlying issue in which some google_drive_files rows were incorrectly deleted (while the google_drive_folders row correctly remained), see issue #5100 and following PRs #5356 and #5426

Now that the aforementioned underlying issue is fixed, we can re-revert

=> This PR Reverts dust-tt/dust#5355

Risk
---
Deleting folder selection that should not have been deleted => all call sites were checked to ensure this was not the case

Deploy
---
Connectors