### PR TITLE
Pro Plan yearly billing

### DIFF
--- a/front/components/PlansTables.tsx
+++ b/front/components/PlansTables.tsx
@@ -326,8 +326,8 @@ export function PricePlans({
           <Tab.List
             className={classNames(
               "flex space-x-1 rounded-full border p-1 backdrop-blur",
-              "s-border-structure-300/30 s-bg-white/80",
-              "dark:s-border-structure-300-dark/30 dark:s-bg-structure-50-dark/80"
+              "border-structure-300/30 bg-white/80",
+              "dark:border-structure-300-dark/30 dark:bg-structure-50-dark/80"
             )}
           >
             <Tab
@@ -338,7 +338,7 @@ export function PricePlans({
                   "ring-0 focus:outline-none",
                   selected
                     ? "bg-emerald-400 text-white shadow dark:bg-emerald-500"
-                    : "dark:s-text-element-700-dark text-element-700 hover:bg-white/20 hover:text-white"
+                    : "text-element-700 hover:bg-white/20 hover:text-white dark:text-element-700-dark"
                 )
               }
             >
@@ -352,7 +352,7 @@ export function PricePlans({
                   "ring-0 focus:outline-none",
                   selected
                     ? "bg-pink-400 text-white shadow dark:bg-pink-500"
-                    : "dark:s-text-element-700-dark text-element-700 hover:bg-white/20 hover:text-white"
+                    : "text-element-700 hover:bg-white/20 hover:text-white dark:text-element-700-dark"
                 )
               }
             >
@@ -414,13 +414,13 @@ export function ProPricePlans({
   setBillingPeriod: (billingPeriod: "monthly" | "yearly") => void;
 }) {
   return (
-    <div className={classNames("w-full  sm:px-0", className)}>
+    <div className={classNames("w-full sm:px-0", className)}>
       <Tab.Group>
         <Tab.List
           className={classNames(
             "flex space-x-1 rounded-full border p-1 backdrop-blur",
-            "s-border-structure-300/30 s-bg-white/80",
-            "dark:s-border-structure-300-dark/30 dark:s-bg-structure-50-dark/80"
+            "border-structure-300/30 bg-white/80",
+            "dark:border-structure-300-dark/30 dark:bg-structure-50-dark/80"
           )}
         >
           <Tab
@@ -431,7 +431,7 @@ export function ProPricePlans({
                 "ring-0 focus:outline-none",
                 selected
                   ? "bg-emerald-400 text-white shadow dark:bg-emerald-500"
-                  : "dark:s-text-element-700-dark text-element-700 hover:bg-white/20 hover:text-element-900"
+                  : "text-element-700 hover:bg-white/20 hover:text-element-900 dark:text-element-700-dark"
               )
             }
             onClick={() => setBillingPeriod("monthly")}
@@ -446,7 +446,7 @@ export function ProPricePlans({
                 "ring-0 focus:outline-none",
                 selected
                   ? "bg-emerald-400 text-white shadow dark:bg-emerald-500"
-                  : "dark:s-text-element-700-dark text-element-700 hover:bg-white/20 hover:text-element-900"
+                  : "text-element-700 hover:bg-white/20 hover:text-element-900 dark:text-element-700-dark"
               )
             }
             onClick={() => setBillingPeriod("yearly")}

--- a/front/components/PlansTables.tsx
+++ b/front/components/PlansTables.tsx
@@ -1,5 +1,5 @@
 import { Button, Hoverable, PriceTable, RocketIcon } from "@dust-tt/sparkle";
-import type { PlanType } from "@dust-tt/types";
+import type { BillingPeriod, PlanType } from "@dust-tt/types";
 import { Tab } from "@headlessui/react";
 import type { ReactNode } from "react";
 import React, { useState } from "react";
@@ -119,7 +119,7 @@ export function ProPriceTable({
   onClick?: () => void;
   isProcessing?: boolean;
   display: PriceTableDisplay;
-  billingPeriod?: "monthly" | "yearly";
+  billingPeriod?: BillingPeriod;
 }) {
   const [isFairUseModalOpened, setIsFairUseModalOpened] = useState(false);
 
@@ -411,7 +411,7 @@ export function ProPricePlans({
   className?: string;
   plan?: PlanType;
   display: PriceTableDisplay;
-  setBillingPeriod: (billingPeriod: "monthly" | "yearly") => void;
+  setBillingPeriod: (billingPeriod: BillingPeriod) => void;
 }) {
   return (
     <div className={classNames("w-full sm:px-0", className)}>

--- a/front/components/PlansTables.tsx
+++ b/front/components/PlansTables.tsx
@@ -7,7 +7,8 @@ import React, { useState } from "react";
 import { FairUsageModal } from "@app/components/FairUsageModal";
 import {
   getPriceWithCurrency,
-  PRO_PLAN_29_COST,
+  PRO_PLAN_COST_MONTHLY,
+  PRO_PLAN_COST_YEARLY,
 } from "@app/lib/client/subscription";
 import { PRO_PLAN_SEAT_29_CODE } from "@app/lib/plans/plan_codes";
 import { classNames } from "@app/lib/utils";
@@ -111,12 +112,14 @@ export function ProPriceTable({
   onClick,
   isProcessing,
   display,
+  billingPeriod = "monthly",
 }: {
   size: "sm" | "xs";
   plan?: PlanType;
   onClick?: () => void;
   isProcessing?: boolean;
   display: PriceTableDisplay;
+  billingPeriod?: "monthly" | "yearly";
 }) {
   const [isFairUseModalOpened, setIsFairUseModalOpened] = useState(false);
 
@@ -197,6 +200,12 @@ export function ProPriceTable({
   ];
 
   const biggerButtonSize = size === "xs" ? "sm" : "md";
+
+  const price =
+    billingPeriod === "monthly"
+      ? getPriceWithCurrency(PRO_PLAN_COST_MONTHLY)
+      : getPriceWithCurrency(PRO_PLAN_COST_YEARLY);
+
   return (
     <>
       <FairUsageModal
@@ -205,7 +214,7 @@ export function ProPriceTable({
       />
       <PriceTable
         title="Pro"
-        price={getPriceWithCurrency(PRO_PLAN_29_COST)}
+        price={price}
         color="emerald"
         priceLabel="/ month / user, excl. tax"
         size={size}
@@ -389,4 +398,81 @@ export function PricePlans({
       </div>
     );
   }
+}
+
+export function ProPricePlans({
+  size = "sm",
+  className = "",
+  plan,
+  display,
+  setBillingPeriod,
+}: {
+  size?: "sm" | "xs";
+  className?: string;
+  plan?: PlanType;
+  display: PriceTableDisplay;
+  setBillingPeriod: (billingPeriod: "monthly" | "yearly") => void;
+}) {
+  return (
+    <div className={classNames("w-full  sm:px-0", className)}>
+      <Tab.Group>
+        <Tab.List
+          className={classNames(
+            "flex space-x-1 rounded-full border p-1 backdrop-blur",
+            "s-border-structure-300/30 s-bg-white/80",
+            "dark:s-border-structure-300-dark/30 dark:s-bg-structure-50-dark/80"
+          )}
+        >
+          <Tab
+            className={({ selected }) =>
+              classNames(
+                "w-full rounded-full font-semibold transition-all duration-300 ease-out",
+                "py-3 text-lg",
+                "ring-0 focus:outline-none",
+                selected
+                  ? "bg-emerald-400 text-white shadow dark:bg-emerald-500"
+                  : "dark:s-text-element-700-dark text-element-700 hover:bg-white/20 hover:text-element-900"
+              )
+            }
+            onClick={() => setBillingPeriod("monthly")}
+          >
+            Monthly Billing
+          </Tab>
+          <Tab
+            className={({ selected }) =>
+              classNames(
+                "w-full rounded-full font-semibold transition-all duration-300 ease-out",
+                "py-3 text-lg",
+                "ring-0 focus:outline-none",
+                selected
+                  ? "bg-emerald-400 text-white shadow dark:bg-emerald-500"
+                  : "dark:s-text-element-700-dark text-element-700 hover:bg-white/20 hover:text-element-900"
+              )
+            }
+            onClick={() => setBillingPeriod("yearly")}
+          >
+            Yearly Billing
+          </Tab>
+        </Tab.List>
+        <Tab.Panels className="mt-8">
+          <Tab.Panel>
+            <ProPriceTable
+              display={display}
+              size={size}
+              plan={plan}
+              billingPeriod="monthly"
+            />
+          </Tab.Panel>
+          <Tab.Panel>
+            <ProPriceTable
+              display={display}
+              size={size}
+              plan={plan}
+              billingPeriod="yearly"
+            />
+          </Tab.Panel>
+        </Tab.Panels>
+      </Tab.Group>
+    </div>
+  );
 }

--- a/front/components/members/InvitationModal.tsx
+++ b/front/components/members/InvitationModal.tsx
@@ -378,8 +378,8 @@ function ProPlanBillingNotice({
       </p>
       <br />
       <p>
-        Next month's bill will be adjusted proportionally based on the members'
-        sign-up date.
+        Next bill will be adjusted proportionally based on the members' sign-up
+        date.
       </p>
     </ContentMessage>
   );

--- a/front/components/plans/PlansTables.tsx
+++ b/front/components/plans/PlansTables.tsx
@@ -25,7 +25,7 @@ interface PricePlanProps {
   display: PriceTableDisplay;
 }
 
-type PriceTableDisplay = "landing" | "subscribe";
+export type PriceTableDisplay = "landing" | "subscribe";
 
 type PriceTableItem = {
   label: ReactNode;
@@ -398,81 +398,4 @@ export function PricePlans({
       </div>
     );
   }
-}
-
-export function ProPricePlans({
-  size = "sm",
-  className = "",
-  plan,
-  display,
-  setBillingPeriod,
-}: {
-  size?: "sm" | "xs";
-  className?: string;
-  plan?: PlanType;
-  display: PriceTableDisplay;
-  setBillingPeriod: (billingPeriod: BillingPeriod) => void;
-}) {
-  return (
-    <div className={classNames("w-full sm:px-0", className)}>
-      <Tab.Group>
-        <Tab.List
-          className={classNames(
-            "flex space-x-1 rounded-full border p-1 backdrop-blur",
-            "border-structure-300/30 bg-white/80",
-            "dark:border-structure-300-dark/30 dark:bg-structure-50-dark/80"
-          )}
-        >
-          <Tab
-            className={({ selected }) =>
-              classNames(
-                "w-full rounded-full font-semibold transition-all duration-300 ease-out",
-                "py-3 text-lg",
-                "ring-0 focus:outline-none",
-                selected
-                  ? "bg-emerald-400 text-white shadow dark:bg-emerald-500"
-                  : "text-element-700 hover:bg-white/20 hover:text-element-900 dark:text-element-700-dark"
-              )
-            }
-            onClick={() => setBillingPeriod("monthly")}
-          >
-            Monthly Billing
-          </Tab>
-          <Tab
-            className={({ selected }) =>
-              classNames(
-                "w-full rounded-full font-semibold transition-all duration-300 ease-out",
-                "py-3 text-lg",
-                "ring-0 focus:outline-none",
-                selected
-                  ? "bg-emerald-400 text-white shadow dark:bg-emerald-500"
-                  : "text-element-700 hover:bg-white/20 hover:text-element-900 dark:text-element-700-dark"
-              )
-            }
-            onClick={() => setBillingPeriod("yearly")}
-          >
-            Yearly Billing
-          </Tab>
-        </Tab.List>
-        <Tab.Panels className="mt-8">
-          <Tab.Panel>
-            <ProPriceTable
-              display={display}
-              size={size}
-              plan={plan}
-              billingPeriod="monthly"
-            />
-          </Tab.Panel>
-          <Tab.Panel>
-            <ProPriceTable
-              display={display}
-              size={size}
-              plan={plan}
-              billingPeriod="yearly"
-            />
-          </Tab.Panel>
-        </Tab.Panels>
-      </Tab.Group>
-    </div>
-  );
 }

--- a/front/components/plans/ProPlansTable.tsx
+++ b/front/components/plans/ProPlansTable.tsx
@@ -1,0 +1,84 @@
+import type { BillingPeriod, PlanType } from "@dust-tt/types";
+import { Tab } from "@headlessui/react";
+import React from "react";
+
+import type { PriceTableDisplay } from "@app/components/plans/PlansTables";
+import { ProPriceTable } from "@app/components/plans/PlansTables";
+import { classNames } from "@app/lib/utils";
+
+export function ProPlansTable({
+  size = "sm",
+  className = "",
+  plan,
+  display,
+  setBillingPeriod,
+}: {
+  size?: "sm" | "xs";
+  className?: string;
+  plan?: PlanType;
+  display: PriceTableDisplay;
+  setBillingPeriod: (billingPeriod: BillingPeriod) => void;
+}) {
+  return (
+    <div className={classNames("w-full sm:px-0", className)}>
+      <Tab.Group>
+        <Tab.List
+          className={classNames(
+            "flex space-x-1 rounded-full border p-1 backdrop-blur",
+            "border-structure-300/30 bg-white/80",
+            "dark:border-structure-300-dark/30 dark:bg-structure-50-dark/80"
+          )}
+        >
+          <Tab
+            className={({ selected }) =>
+              classNames(
+                "w-full rounded-full font-semibold transition-all duration-300 ease-out",
+                "py-3 text-lg",
+                "ring-0 focus:outline-none",
+                selected
+                  ? "bg-emerald-400 text-white shadow dark:bg-emerald-500"
+                  : "text-element-700 hover:bg-white/20 hover:text-element-900 dark:text-element-700-dark"
+              )
+            }
+            onClick={() => setBillingPeriod("monthly")}
+          >
+            Monthly Billing
+          </Tab>
+          <Tab
+            className={({ selected }) =>
+              classNames(
+                "w-full rounded-full font-semibold transition-all duration-300 ease-out",
+                "py-3 text-lg",
+                "ring-0 focus:outline-none",
+                selected
+                  ? "bg-emerald-400 text-white shadow dark:bg-emerald-500"
+                  : "text-element-700 hover:bg-white/20 hover:text-element-900 dark:text-element-700-dark"
+              )
+            }
+            onClick={() => setBillingPeriod("yearly")}
+          >
+            Yearly Billing
+          </Tab>
+        </Tab.List>
+        <Tab.Panels className="mt-8">
+          <Tab.Panel>
+            <ProPriceTable
+              display={display}
+              size={size}
+              plan={plan}
+              billingPeriod="monthly"
+            />
+          </Tab.Panel>
+          <Tab.Panel>
+            <ProPriceTable
+              display={display}
+              size={size}
+              plan={plan}
+              billingPeriod="yearly"
+            />
+          </Tab.Panel>
+        </Tab.Panels>
+      </Tab.Group>
+    </div>
+  );
+}

--- a/front/lib/client/subscription.ts
+++ b/front/lib/client/subscription.ts
@@ -2,7 +2,8 @@
 // so this is just a way to have that value hardcoded in one place.
 // Changing this value only changes the value displayed on the webapp and the website,
 // not on the Stripe dashboard.
-export const PRO_PLAN_29_COST = 29;
+export const PRO_PLAN_COST_MONTHLY = 29;
+export const PRO_PLAN_COST_YEARLY = 27;
 
 export const getPriceWithCurrency = (price: number): string => {
   const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -1,4 +1,4 @@
-import type { Result, WorkspaceType } from "@dust-tt/types";
+import type { BillingPeriod, Result, WorkspaceType } from "@dust-tt/types";
 import type { SubscriptionType } from "@dust-tt/types";
 import { Err, Ok } from "@dust-tt/types";
 import { Stripe } from "stripe";
@@ -59,7 +59,7 @@ export const createProPlanCheckoutSession = async ({
   billingPeriod,
 }: {
   auth: Authenticator;
-  billingPeriod: "monthly" | "yearly";
+  billingPeriod: BillingPeriod;
 }): Promise<string | null> => {
   const owner = auth.workspace();
   if (!owner) {

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -28,6 +28,8 @@ const stripe = new Stripe(STRIPE_SECRET_KEY, {
 
 /**
  * Calls the Stripe API to get the price ID for a given product ID.
+ * We use prices metata to find the default price for a given product.
+ * For the Pro plan, the metadata are "IS_DEFAULT_YEARLY_PRICE" and "IS_DEFAULT_MONHTLY_PRICE" and are set to "true".
  */
 async function getDefautPriceFromMetadata(
   productId: string,

--- a/front/lib/plans/subscription.ts
+++ b/front/lib/plans/subscription.ts
@@ -359,7 +359,8 @@ export const pokeUpgradeWorkspaceToPlan = async (
 
 // Returns the Stripe checkout URL for the pro plan.
 export const getCheckoutUrlForUpgrade = async (
-  auth: Authenticator
+  auth: Authenticator,
+  billingPeriod: "monthly" | "yearly"
 ): Promise<{ checkoutUrl: string; plan: PlanType }> => {
   const owner = auth.workspace();
 
@@ -395,6 +396,7 @@ export const getCheckoutUrlForUpgrade = async (
   // We enter Stripe Checkout flow.
   const checkoutUrl = await createProPlanCheckoutSession({
     auth,
+    billingPeriod,
   });
 
   if (!checkoutUrl) {

--- a/front/lib/plans/subscription.ts
+++ b/front/lib/plans/subscription.ts
@@ -1,4 +1,5 @@
 import type {
+  BillingPeriod,
   EnterpriseUpgradeFormType,
   PlanType,
   SubscriptionType,
@@ -360,7 +361,7 @@ export const pokeUpgradeWorkspaceToPlan = async (
 // Returns the Stripe checkout URL for the pro plan.
 export const getCheckoutUrlForUpgrade = async (
   auth: Authenticator,
-  billingPeriod: "monthly" | "yearly"
+  billingPeriod: BillingPeriod
 ): Promise<{ checkoutUrl: string; plan: PlanType }> => {
   const owner = auth.workspace();
 
@@ -443,7 +444,7 @@ export async function getPerSeatSubscriptionPricing(
 ): Promise<{
   seatPrice: number;
   seatCurrency: string;
-  billingPeriod: "monthly" | "yearly";
+  billingPeriod: BillingPeriod;
   quantity: number;
 } | null> {
   if (!subscription.stripeSubscriptionId) {

--- a/front/pages/pricing.tsx
+++ b/front/pages/pricing.tsx
@@ -10,7 +10,7 @@ import {
   getParticleShapeIndexByName,
   shapeNames,
 } from "@app/components/home/Particles";
-import { PricePlans } from "@app/components/PlansTables";
+import { PricePlans } from "@app/components/plans/PlansTables";
 import { SubscriptionContactUsDrawer } from "@app/components/SubscriptionContactUsDrawer";
 import config from "@app/lib/api/config";
 import { getSession } from "@app/lib/auth";

--- a/front/pages/w/[wId]/subscribe.tsx
+++ b/front/pages/w/[wId]/subscribe.tsx
@@ -3,9 +3,9 @@ import type { WorkspaceType } from "@dust-tt/types";
 import { CreditCardIcon } from "@heroicons/react/20/solid";
 import type { InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
-import { useContext, useEffect } from "react";
+import React, { useContext, useEffect } from "react";
 
-import { ProPriceTable } from "@app/components/PlansTables";
+import { ProPricePlans } from "@app/components/PlansTables";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { UserMenu } from "@app/components/UserMenu";
 import WorkspacePicker from "@app/components/WorkspacePicker";
@@ -49,6 +49,10 @@ export default function Subscribe({
     workspaceId: owner.sId,
   });
 
+  const [billingPeriod, setBillingPeriod] = React.useState<
+    "monthly" | "yearly"
+  >("monthly");
+
   // If you had another subscription before, you will not get the free trial again: we use this to show the correct message.
   // Current plan is always FREE_NO_PLAN if you're on this paywall.
   // Since FREE_NO_PLAN is not on the database, we check if there is at least 1 subscription.
@@ -64,34 +68,39 @@ export default function Subscribe({
     }
   }, [owner.sId, router.pathname, user]);
 
-  const { submit: handleSubscribePlan } = useSubmitFunction(async () => {
-    const res = await fetch(`/api/w/${owner.sId}/subscriptions`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-    });
-
-    if (!res.ok) {
-      sendNotification({
-        type: "error",
-        title: "Subscription failed",
-        description: "Failed to subscribe to a new plan.",
+  const { submit: handleSubscribePlan } = useSubmitFunction(
+    async (billingPeriod) => {
+      const res = await fetch(`/api/w/${owner.sId}/subscriptions`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          billingPeriod,
+        }),
       });
-    } else {
-      const content = await res.json();
-      if (content.checkoutUrl) {
-        await router.push(content.checkoutUrl);
-      } else if (content.success) {
+
+      if (!res.ok) {
         sendNotification({
           type: "error",
           title: "Subscription failed",
-          description:
-            "Failed to subscribe to a new plan. Please try again in a few minutes.",
+          description: "Failed to subscribe to a new plan.",
         });
+      } else {
+        const content = await res.json();
+        if (content.checkoutUrl) {
+          await router.push(content.checkoutUrl);
+        } else if (content.success) {
+          sendNotification({
+            type: "error",
+            title: "Subscription failed",
+            description:
+              "Failed to subscribe to a new plan. Please try again in a few minutes.",
+          });
+        }
       }
     }
-  });
+  );
 
   return (
     <>
@@ -147,19 +156,43 @@ export default function Subscribe({
                     <Page.P>
                       Please note that if your previous contract expired over 15
                       days ago, previously stored data will no longer be
-                      available. This is to ensure privacy and security.
+                      available. This is to ensure privacy and security of your
+                      information.
                     </Page.P>
                   </>
                 ) : (
                   <>
                     <Page.P>
                       <span className="font-bold">
-                        You can try the Pro plan for free for two weeks.
+                        Try the Pro plan for free for two weeks.
                       </span>
                     </Page.P>
                     <Page.P>
-                      After your trial ends, you will be charged monthly. You
-                      can cancel at any time.
+                      You will be charged after your trial ends. During trial,
+                      you can cancel at any time.
+                    </Page.P>
+                  </>
+                )}
+
+                {billingPeriod === "monthly" ? (
+                  <>
+                    <Page.P>
+                      <span className="font-bold">Monthly billing.</span>
+                    </Page.P>
+                    <Page.P>
+                      Pay on a month-to-month basis. You can cancel at any time
+                      before your next monthly billing cycle.
+                    </Page.P>
+                  </>
+                ) : (
+                  <>
+                    <Page.P>
+                      <span className="font-bold">Yearly billing.</span>
+                    </Page.P>
+                    <Page.P>
+                      Pay for a year upfront and save 10% compared to the
+                      monthly plan. You can cancel at any time before your next
+                      annual billing cycle.
                     </Page.P>
                   </>
                 )}
@@ -168,19 +201,27 @@ export default function Subscribe({
                   variant="primary"
                   label={
                     hasPreviouSubscription
-                      ? "Resume your subscription"
-                      : "Start your trial"
+                      ? billingPeriod === "monthly"
+                        ? "Resume with monthly billing"
+                        : "Resume with yearly billing"
+                      : billingPeriod === "monthly"
+                      ? "Start your trial with monthly billing"
+                      : "Start your trial with yearly billing"
                   }
                   icon={CreditCardIcon}
-                  size="md"
+                  size="sm"
                   onClick={() => {
-                    void handleSubscribePlan();
+                    void handleSubscribePlan(billingPeriod);
                   }}
                 ></Button>
               </Page.Vertical>
-              <Page.Vertical sizing="grow">
-                <ProPriceTable display="subscribe" size="xs"></ProPriceTable>
-              </Page.Vertical>
+              <Page.Horizontal sizing="grow">
+                <ProPricePlans
+                  size="xs"
+                  display="subscribe"
+                  setBillingPeriod={setBillingPeriod}
+                ></ProPricePlans>
+              </Page.Horizontal>
             </Page.Horizontal>
           ) : (
             <Page.Horizontal>
@@ -197,7 +238,11 @@ export default function Subscribe({
                 </Page.P>
               </Page.Vertical>
               <Page.Vertical sizing="grow">
-                <ProPriceTable display="subscribe" size="xs"></ProPriceTable>
+                <ProPricePlans
+                  size="xs"
+                  display="subscribe"
+                  setBillingPeriod={setBillingPeriod}
+                ></ProPricePlans>
               </Page.Vertical>
             </Page.Horizontal>
           )}

--- a/front/pages/w/[wId]/subscribe.tsx
+++ b/front/pages/w/[wId]/subscribe.tsx
@@ -5,7 +5,7 @@ import type { InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 import React, { useContext, useEffect } from "react";
 
-import { ProPricePlans } from "@app/components/PlansTables";
+import { ProPlansTable } from "@app/components/plans/ProPlansTable";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { UserMenu } from "@app/components/UserMenu";
 import WorkspacePicker from "@app/components/WorkspacePicker";
@@ -215,11 +215,11 @@ export default function Subscribe({
                 ></Button>
               </Page.Vertical>
               <Page.Horizontal sizing="grow">
-                <ProPricePlans
+                <ProPlansTable
                   size="xs"
                   display="subscribe"
                   setBillingPeriod={setBillingPeriod}
-                ></ProPricePlans>
+                ></ProPlansTable>
               </Page.Horizontal>
             </Page.Horizontal>
           ) : (
@@ -237,11 +237,11 @@ export default function Subscribe({
                 </Page.P>
               </Page.Vertical>
               <Page.Vertical sizing="grow">
-                <ProPricePlans
+                <ProPlansTable
                   size="xs"
                   display="subscribe"
                   setBillingPeriod={setBillingPeriod}
-                ></ProPricePlans>
+                ></ProPlansTable>
               </Page.Vertical>
             </Page.Horizontal>
           )}

--- a/front/pages/w/[wId]/subscribe.tsx
+++ b/front/pages/w/[wId]/subscribe.tsx
@@ -1,5 +1,5 @@
 import { BarHeader, Button, LockIcon, Page } from "@dust-tt/sparkle";
-import type { WorkspaceType } from "@dust-tt/types";
+import type { BillingPeriod, WorkspaceType } from "@dust-tt/types";
 import { CreditCardIcon } from "@heroicons/react/20/solid";
 import type { InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
@@ -49,9 +49,8 @@ export default function Subscribe({
     workspaceId: owner.sId,
   });
 
-  const [billingPeriod, setBillingPeriod] = React.useState<
-    "monthly" | "yearly"
-  >("monthly");
+  const [billingPeriod, setBillingPeriod] =
+    React.useState<BillingPeriod>("monthly");
 
   // If you had another subscription before, you will not get the free trial again: we use this to show the correct message.
   // Current plan is always FREE_NO_PLAN if you're on this paywall.

--- a/front/pages/w/[wId]/subscribe.tsx
+++ b/front/pages/w/[wId]/subscribe.tsx
@@ -167,8 +167,8 @@ export default function Subscribe({
                       </span>
                     </Page.P>
                     <Page.P>
-                      You will be charged after your trial ends. During trial,
-                      you can cancel at any time.
+                      You will be charged after your trial ends. You can cancel
+                      at any time during your trial.
                     </Page.P>
                   </>
                 )}
@@ -176,22 +176,26 @@ export default function Subscribe({
                 {billingPeriod === "monthly" ? (
                   <>
                     <Page.P>
-                      <span className="font-bold">Monthly billing.</span>
+                      <span className="font-bold">
+                        You've selected monthly billing.
+                      </span>
                     </Page.P>
                     <Page.P>
-                      Pay on a month-to-month basis. You can cancel at any time
-                      before your next monthly billing cycle.
+                      You'll pay on a month-to-month basis. You can cancel at
+                      any time before the end of your monthly billing cycle.
                     </Page.P>
                   </>
                 ) : (
                   <>
                     <Page.P>
-                      <span className="font-bold">Yearly billing.</span>
+                      <span className="font-bold">
+                        You've selected yearly billing.
+                      </span>
                     </Page.P>
                     <Page.P>
-                      Pay for a year upfront and enjoy savings compared to the
-                      monthly plan. You can cancel at any time before your next
-                      annual billing cycle.
+                      You'll pay for a year upfront and enjoy savings compared
+                      to the monthly plan. You can cancel at any time before the
+                      end of your annual billing cycle.
                     </Page.P>
                   </>
                 )}

--- a/front/pages/w/[wId]/subscribe.tsx
+++ b/front/pages/w/[wId]/subscribe.tsx
@@ -190,7 +190,7 @@ export default function Subscribe({
                       <span className="font-bold">Yearly billing.</span>
                     </Page.P>
                     <Page.P>
-                      Pay for a year upfront and save 10% compared to the
+                      Pay for a year upfront and enjoy savings compared to the
                       monthly plan. You can cancel at any time before your next
                       annual billing cycle.
                     </Page.P>

--- a/front/pages/w/[wId]/subscription/index.tsx
+++ b/front/pages/w/[wId]/subscription/index.tsx
@@ -21,7 +21,7 @@ import Link from "next/link";
 import { useRouter } from "next/router";
 import React, { useContext, useEffect, useState } from "react";
 
-import { PricePlans } from "@app/components/PlansTables";
+import { PricePlans } from "@app/components/plans/PlansTables";
 import AppLayout from "@app/components/sparkle/AppLayout";
 import { subNavigationAdmin } from "@app/components/sparkle/navigation";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";

--- a/front/pages/w/[wId]/subscription/index.tsx
+++ b/front/pages/w/[wId]/subscription/index.tsx
@@ -146,6 +146,9 @@ export default function Subscription({
         headers: {
           "Content-Type": "application/json",
         },
+        body: JSON.stringify({
+          billingPeriod: "monthly",
+        }),
       });
 
       if (!res.ok) {
@@ -391,7 +394,7 @@ export default function Subscription({
                         {getPriceAsString({
                           currency: perSeatPricing.seatCurrency,
                           priceInCents: perSeatPricing.seatPrice,
-                        })}
+                        })}{" "}
                         per member.
                       </>
                     ) : (

--- a/types/src/front/plan.ts
+++ b/types/src/front/plan.ts
@@ -73,10 +73,12 @@ export type SubscriptionType = {
   requestCancelAt: number | null;
 };
 
+export type BillingPeriod = "monthly" | "yearly";
+
 export type SubscriptionPerSeatPricing = {
   seatPrice: number;
   seatCurrency: string;
-  billingPeriod: "monthly" | "yearly";
+  billingPeriod: BillingPeriod;
   quantity: number;
 };
 


### PR DESCRIPTION
## Description

This is the PR to support yearly billing for the Pro Plan. 
Most changes are on the design of the paywall page to display a pretty toggle and option between monthly & yearly billing. 

Regarding the Stripe checkout session, we now send the "billingPeriod" to the API route & lib to create a Stripe checkout session and it will fetch the valid price in Stripe based on a price metadata: we will fetch the price with metadata `IS_DEFAULT_MONHTLY_PRICE` or `IS_DEFAULT_YEARLY_PRICE` (before this PR we were fetching the price with the tag "default").


<kbd><img width="947" alt="Screenshot 2024-06-04 at 11 14 46" src="https://github.com/dust-tt/dust/assets/3803406/7c395807-0bab-4144-8565-95876c1a4b55">
</kbd>
<kbd><img width="920" alt="Screenshot 2024-06-04 at 11 14 51" src="https://github.com/dust-tt/dust/assets/3803406/5b00904d-9afd-4071-ad30-d611f01e292b">
</kbd>




Notes: 
- I've tried configuring a Price Table on Stripe you can see [here](https://dashboard.stripe.com/pricing-tables/prctbl_1PNfyKDKd2JRwZF6IQ7Hgcto) but it seems that the Stripe checkout session expect some line_items. 
- I tried setting a line_item for the monthly price and one for the early price but I get an error `"Checkout does not support multiple prices with different billing intervals"`.


## Risk

Can be rolled back. 

## Deploy Plan

- [x] Deploy on Front-edge.
- [x] Validate the wordings and design with the team.
- [x] Validate that we're okay shipping it in terms of reporting. 
- [x] Create the price on prod env.
- [x] Add the metadata for the monthly and yearly product. 
- [ ] Deploy front. 
