### PR TITLE
[Gdrive] Stop renewing webhooks for errored connectors.

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -658,7 +658,7 @@ export async function renewWebhooks(pageSize: number): Promise<number> {
     if (connector.errorType !== null) {
       // We can't renew webhooks for connectors in error state.
       // Do not delete the webhook object but push it down the line in 2h so that it does not get
-      // picked up by the loop calling rewnewOneWebhook.
+      // picked up by the next iteration loop calling rewnewOneWebhook.
       await wh.update({
         renewAt: literal("NOW() + INTERVAL '2 hour'"),
       });

--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -655,6 +655,15 @@ export async function renewWebhooks(pageSize: number): Promise<number> {
       );
       continue;
     }
+    if (connector.errorType !== null) {
+      // We can't renew webhooks for connectors in error state.
+      // Do not delete the webhook object but push it down the line in 2h so that it does not get
+      // picked up by the loop calling rewnewOneWebhook.
+      await wh.update({
+        renewAt: literal("NOW() + INTERVAL '2 hour'"),
+      });
+      continue;
+    }
     if (wh.expiresAt < new Date(renewWebhookStartingTime)) {
       logger.error(
         {


### PR DESCRIPTION
## Description

Stop renewing webhooks when the connector is in an errored state.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
