### PR TITLE
[DO NOT MERGE] Add script to backfill stored documents with sections

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -20,6 +20,10 @@ name = "qdrant_create_collection"
 path = "bin/qdrant/create_collection.rs"
 
 [[bin]]
+name = "backfill_stored_documents"
+path = "bin/migrations/20240603_backfill_stored_documents.rs"
+
+[[bin]]
 name = "sqlite-worker"
 path = "bin/sqlite_worker.rs"
 

--- a/core/bin/migrations/20240603_backfill_stored_documents.rs
+++ b/core/bin/migrations/20240603_backfill_stored_documents.rs
@@ -254,7 +254,7 @@ async fn update_stored_document_for_document_id(
         }
     });
 
-    let mut stream = stream::iter(tasks).buffer_unordered(32); // Run up to 32 in parallel.
+    let mut stream = stream::iter(tasks).buffer_unordered(16); // Run up to 16 in parallel.
 
     while let Some(result) = stream.next().await {
         result?; // Check for errors.
@@ -307,7 +307,7 @@ async fn backfill_all_documents_for_data_source_id(
             .await
         }
     }))
-    .buffer_unordered(32)
+    .buffer_unordered(16)
     .try_collect::<Vec<_>>()
     .await?;
 
@@ -353,7 +353,7 @@ async fn main() -> Result<(), anyhow::Error> {
                 .await
             }
         }))
-        .buffer_unordered(32)
+        .buffer_unordered(16)
         .try_collect::<Vec<_>>()
         .await?;
 

--- a/core/bin/migrations/20240603_backfill_stored_documents.rs
+++ b/core/bin/migrations/20240603_backfill_stored_documents.rs
@@ -1,0 +1,356 @@
+use ::qdrant_client::qdrant::{value, PointId};
+use anyhow::{anyhow, Context, Result};
+use cloud_storage::Object;
+use dust::{
+    data_sources::{
+        data_source::{make_document_id_hash, DataSource, Section},
+        file_storage_document::FileStorageDocument,
+        qdrant::QdrantClients,
+    },
+    stores::{postgres, store},
+    utils,
+};
+use qdrant_client::qdrant;
+use tokio_postgres::Row;
+
+use bb8::Pool;
+use bb8_postgres::PostgresConnectionManager;
+use futures::{StreamExt, TryStreamExt};
+use tokio_postgres::NoTls;
+use tokio_stream::{self as stream};
+
+async fn fetch_data_sources_batch(
+    pool: &Pool<PostgresConnectionManager<NoTls>>,
+    last_id: u64,
+    limit: usize,
+) -> Result<Vec<Row>, anyhow::Error> {
+    let c = pool.get().await?;
+
+    c.query(
+        "SELECT id, internal_id FROM data_sources WHERE id > $1 LIMIT $2",
+        &[&(last_id as i64), &(limit as i64)],
+    )
+    .await
+    .context("Query execution failed")
+}
+
+// Return a "best-effort" section for the latest version of the document (based on Qdrant).
+// For superseded versions, return an empty section.
+async fn get_sections_from_document_version(
+    qdrant_clients: &QdrantClients,
+    ds: &DataSource,
+    document_id_hash: &str,
+    document_status: &str,
+) -> Result<Section> {
+    if document_status != "latest" {
+        return Ok(Section {
+            prefix: None,
+            content: None,
+            sections: vec![],
+        });
+    }
+
+    let qdrant_client = ds.main_qdrant_client(qdrant_clients);
+
+    let f = qdrant::Filter {
+        must: vec![qdrant::Condition::matches(
+            "document_id_hash",
+            document_id_hash.to_string(),
+        )],
+        ..Default::default()
+    };
+
+    let ob = qdrant::OrderBy {
+        key: "chunk_offset".to_string(),
+        direction: Some(qdrant::Direction::Asc as i32),
+        start_from: None,
+    };
+
+    let mut retry = 0;
+    let points_per_request = 256;
+    let mut page_offset: Option<PointId> = None;
+    let mut root_section = Section {
+        prefix: None,
+        content: None,
+        sections: vec![],
+    };
+
+    loop {
+        let scroll_results = match qdrant_client
+            .scroll(
+                &ds.embedder_config(),
+                &ds.internal_id().to_string(),
+                Some(f.clone()),
+                Some(points_per_request as u32),
+                page_offset.clone(),
+                Some(false.into()),
+            )
+            .await
+        {
+            Ok(r) => r,
+            Err(e) => {
+                if retry < 3 {
+                    retry += 1;
+                    utils::error(&format!(
+                        "Error migrating points (read): retry={} error={:?}",
+                        retry, e
+                    ));
+                    tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+                    continue;
+                } else {
+                    Err(e)?
+                }
+            }
+        };
+
+        let mut sorted_results = scroll_results.result.clone();
+
+        // Sort results by chunk_offset. We don't have the proper index to sort by `chunk_offset`.
+        sorted_results.sort_by_key(|r| {
+            r.payload
+                .get("chunk_offset")
+                .and_then(|v| {
+                    if let Some(value::Kind::IntegerValue(offset)) = &v.kind {
+                        Some(*offset)
+                    } else {
+                        None
+                    }
+                })
+                .unwrap_or(0) // Default to 0 if chunk_offset is missing or not an IntValue.
+        });
+
+        root_section
+            .sections
+            .extend(sorted_results.iter().filter_map(|r| {
+                println!("chunk_offset: {:?}", r.get("chunk_offset"));
+
+                match &r.get("text").kind {
+                    Some(value::Kind::StringValue(s)) => {
+                        let section = Section {
+                            prefix: None,
+                            content: Some(s.clone()),
+                            sections: vec![], // Initialize with empty vector or nested sections if needed
+                        };
+
+                        println!("Section: {:#?}", section);
+
+                        Some(section)
+                    }
+                    _ => None,
+                }
+            }));
+
+        page_offset = scroll_results.next_page_offset;
+        if page_offset.is_none() {
+            break;
+        }
+    }
+
+    Ok(root_section)
+}
+
+async fn update_stored_document_for_document_id(
+    pool: &Pool<PostgresConnectionManager<NoTls>>,
+    qdrant_clients: &QdrantClients,
+    data_source: &DataSource,
+    data_source_id: i64,
+    document_id: &str,
+) -> Result<()> {
+    let c = pool.get().await?;
+
+    let bucket = FileStorageDocument::get_bucket().await?;
+
+    let document_versions = c.query("SELECT hash, created, status FROM data_sources_documents WHERE data_source = $1 AND document_id = $2", &[&data_source_id, &document_id]).await?;
+    let document_id_hash = make_document_id_hash(document_id);
+
+    println!(
+        "Found {:} document versions for document {:} to update.",
+        document_versions.len(),
+        document_id_hash
+    );
+
+    let tasks = document_versions.into_iter().map(|d| {
+        let data_source = data_source.clone();
+        let document_id_hash = document_id_hash.to_string();
+        let document_id = document_id.to_string();
+        let bucket = bucket.clone();
+
+        async move {
+            let document_hash: String = d.get(0);
+            let document_created: i64 = d.get(1);
+            let document_status: String = d.get(2);
+
+            // We need to loop over all the versions.
+            let legacy_file_path = FileStorageDocument::get_legacy_file_path(
+                &data_source,
+                &document_id_hash,
+                &document_hash,
+            );
+
+            let new_file_path = FileStorageDocument::get_document_file_path(
+                &data_source,
+                document_created as u64,
+                &document_id_hash,
+                &document_hash,
+            );
+
+            if FileStorageDocument::file_exists(&new_file_path).await? {
+                // File already exist, return early.
+                println!("File {:} already exist.", new_file_path);
+                return Ok::<(), anyhow::Error>(());
+            }
+
+            let legacy_stored_document =
+                FileStorageDocument::get_stored_document(&legacy_file_path).await?;
+
+            let sections = get_sections_from_document_version(
+                qdrant_clients,
+                &data_source,
+                &document_id_hash,
+                &document_status,
+            )
+            .await?;
+
+            let file_storage_document = FileStorageDocument {
+                document_id: document_id.to_string(),
+                full_text: legacy_stored_document.to_string(),
+                sections,
+            };
+            let serialized_document = serde_json::to_vec(&file_storage_document)?;
+
+            Object::create(
+                &bucket,
+                serialized_document,
+                &new_file_path,
+                "application/json",
+            )
+            .await?;
+
+            Ok(())
+        }
+    });
+
+    let mut stream = stream::iter(tasks).buffer_unordered(16); // Run up to 16 in parallel.
+
+    while let Some(result) = stream.next().await {
+        result?; // Check for errors.
+    }
+
+    Ok(())
+}
+
+async fn backfill_all_documents_for_data_source_id(
+    store: Box<dyn store::Store + Sync + Send>,
+    pool: &Pool<PostgresConnectionManager<NoTls>>,
+    qdrant_clients: &QdrantClients,
+    data_source_internal_id: &str,
+    data_source_id: i64,
+) -> Result<()> {
+    println!("ds: {:?}", data_source_internal_id);
+
+    let data_source = match store
+        .load_data_source_by_internal_id(&data_source_internal_id)
+        .await?
+    {
+        Some(ds) => ds,
+        None => Err(anyhow!("Data source not found"))?,
+    };
+
+    let c = store.raw_pool().get().await?;
+
+    let document_ids = c
+        .query(
+            "SELECT DISTINCT document_id from data_sources_documents WHERE data_source = $1",
+            &[&data_source_id],
+        )
+        .await?;
+
+    println!("Found {:} document ids to update.", document_ids.len());
+
+    stream::iter(document_ids.into_iter().map(|row| {
+        let data_source = data_source.clone();
+
+        async move {
+            let document_id: String = row.get(0);
+
+            update_stored_document_for_document_id(
+                &pool,
+                qdrant_clients,
+                &data_source,
+                data_source_id,
+                &document_id,
+            )
+            .await
+        }
+    }))
+    .buffer_unordered(1)
+    .try_collect::<Vec<_>>()
+    .await?;
+
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> Result<(), anyhow::Error> {
+    let store: Box<dyn store::Store + Sync + Send> = match std::env::var("CORE_DATABASE_URI") {
+        Ok(db_uri) => {
+            let store = postgres::PostgresStore::new(&db_uri).await?;
+            store.init().await?;
+            Box::new(store)
+        }
+        Err(_) => Err(anyhow!("CORE_DATABASE_URI is required (postgres)"))?,
+    };
+
+    let qdrant_clients = QdrantClients::build().await?;
+
+    let pool = store.raw_pool();
+
+    let limit: usize = 50;
+    let mut last_data_source_id = 0;
+
+    loop {
+        let rows = fetch_data_sources_batch(&pool, last_data_source_id, limit).await?;
+
+        stream::iter(rows.iter().map(|row| {
+            let store = store.clone();
+            let qdrant_clients = qdrant_clients.clone();
+
+            async move {
+                let data_source_id: i64 = row.get(0);
+                let data_source_internal_id: String = row.get(1);
+
+                backfill_all_documents_for_data_source_id(
+                    store,
+                    &pool,
+                    &qdrant_clients,
+                    &data_source_internal_id,
+                    data_source_id,
+                )
+                .await
+                // update_config_for_data_source(store, &data_source_internal_id.clone()).await
+            }
+        }))
+        .buffer_unordered(1)
+        .try_collect::<Vec<_>>()
+        .await?;
+
+        if rows.len() < limit {
+            println!("Updated all data_sources");
+            break;
+        }
+
+        last_data_source_id = match rows.last() {
+            Some(r) => {
+                let id: i64 = r.get(0);
+
+                id as u64
+            }
+            None => {
+                println!("Updated all data_sources");
+                break;
+            }
+        };
+    }
+
+    Ok(())
+}

--- a/core/bin/migrations/20240603_backfill_stored_documents.rs
+++ b/core/bin/migrations/20240603_backfill_stored_documents.rs
@@ -60,12 +60,6 @@ async fn get_sections_from_document_version(
         ..Default::default()
     };
 
-    let ob = qdrant::OrderBy {
-        key: "chunk_offset".to_string(),
-        direction: Some(qdrant::Direction::Asc as i32),
-        start_from: None,
-    };
-
     let mut retry = 0;
     let points_per_request = 256;
     let mut page_offset: Option<PointId> = None;
@@ -122,8 +116,6 @@ async fn get_sections_from_document_version(
         root_section
             .sections
             .extend(sorted_results.iter().filter_map(|r| {
-                println!("chunk_offset: {:?}", r.get("chunk_offset"));
-
                 match &r.get("text").kind {
                     Some(value::Kind::StringValue(s)) => {
                         let section = Section {
@@ -131,8 +123,6 @@ async fn get_sections_from_document_version(
                             content: Some(s.clone()),
                             sections: vec![], // Initialize with empty vector or nested sections if needed
                         };
-
-                        println!("Section: {:#?}", section);
 
                         Some(section)
                     }

--- a/core/bin/migrations/20240603_backfill_stored_documents.rs
+++ b/core/bin/migrations/20240603_backfill_stored_documents.rs
@@ -231,7 +231,7 @@ async fn update_stored_document_for_document_id(
         }
     });
 
-    let mut stream = stream::iter(tasks).buffer_unordered(16); // Run up to 16 in parallel.
+    let mut stream = stream::iter(tasks).buffer_unordered(32); // Run up to 32 in parallel.
 
     while let Some(result) = stream.next().await {
         result?; // Check for errors.
@@ -284,7 +284,7 @@ async fn backfill_all_documents_for_data_source_id(
             .await
         }
     }))
-    .buffer_unordered(16)
+    .buffer_unordered(32)
     .try_collect::<Vec<_>>()
     .await?;
 
@@ -330,7 +330,7 @@ async fn main() -> Result<(), anyhow::Error> {
                 .await
             }
         }))
-        .buffer_unordered(16)
+        .buffer_unordered(32)
         .try_collect::<Vec<_>>()
         .await?;
 

--- a/core/bin/migrations/20240603_backfill_stored_documents.rs
+++ b/core/bin/migrations/20240603_backfill_stored_documents.rs
@@ -41,11 +41,12 @@ async fn get_sections_from_document_version(
     ds: &DataSource,
     document_id_hash: &str,
     document_status: &str,
+    full_text: &str,
 ) -> Result<Section> {
     if document_status != "latest" {
         return Ok(Section {
             prefix: None,
-            content: None,
+            content: Some(full_text.to_string()),
             sections: vec![],
         });
     }
@@ -198,6 +199,7 @@ async fn update_stored_document_for_document_id(
                 &data_source,
                 &document_id_hash,
                 &document_status,
+                &legacy_stored_document,
             )
             .await?;
 
@@ -216,7 +218,7 @@ async fn update_stored_document_for_document_id(
             )
             .await?;
 
-            Ok(())
+            Ok::<(), anyhow::Error>(())
         }
     });
 

--- a/core/src/data_sources/file_storage_document.rs
+++ b/core/src/data_sources/file_storage_document.rs
@@ -60,12 +60,10 @@ impl FileStorageDocument {
 
         let bytes = Object::download(&bucket, &file_path).await?;
 
-        let t = match String::from_utf8(bytes) {
+        match String::from_utf8(bytes) {
             Ok(content) => Ok(content),
             Err(err) => Err(anyhow!("Failed to retrieve stored document: {}", err)),
-        }?;
-
-        Ok(t)
+        }
     }
 
     pub async fn file_exists(file_path: &str) -> Result<bool> {

--- a/core/src/stores/postgres.rs
+++ b/core/src/stores/postgres.rs
@@ -72,9 +72,14 @@ impl PostgresStore {
 
 #[async_trait]
 impl Store for PostgresStore {
+    fn raw_pool(&self) -> &Pool<PostgresConnectionManager<NoTls>> {
+        return &self.pool;
+    }
+
     async fn create_project(&self) -> Result<Project> {
         let pool = self.pool.clone();
         let c = pool.get().await?;
+
         // Create dataset.
         let stmt = c
             .prepare("INSERT INTO projects (id) VALUES (DEFAULT) RETURNING id")

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -15,10 +15,15 @@ use crate::sqlite_workers::client::SqliteWorker;
 
 use anyhow::Result;
 use async_trait::async_trait;
+use bb8::Pool;
+use bb8_postgres::PostgresConnectionManager;
 use std::collections::HashMap;
+use tokio_postgres::NoTls;
 
 #[async_trait]
 pub trait Store {
+    fn raw_pool(&self) -> &Pool<PostgresConnectionManager<NoTls>>;
+
     // Projects
     async fn create_project(&self) -> Result<Project>;
     async fn delete_project(&self, project: &Project) -> Result<()>;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR introduces a script to backfill all existing documents and their versions, ensuring they are stored in our file storage according to the new document format detailed in https://github.com/dust-tt/dust/pull/5412.

⚠️ Given our current setup, we won't merge this PR. A spin-off will merge all the helpers from `FileStorage` though.

### Objective:
- Eliminate the legacy implementation by first completing the backfill process.

### Scope:
- Approximately 16 million document versions require backfilling.

### Methodology:
- **Best-Effort Approach**:
  - Focus on guessing sections for the "latest" version of each document.
  - Use empty sections for superseded versions.
  - Create a flat structure due to the inability to extract section hierarchy from Qdrant.

### Expectations:
- The script is expected to run for an extended period due to the large number of objects to backfill.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
