### PR TITLE
fix(core): use correct request-id header for mistral

### DIFF
--- a/core/src/providers/mistral.rs
+++ b/core/src/providers/mistral.rs
@@ -655,7 +655,7 @@ impl MistralAILLM {
                         es::Error::UnexpectedResponse(r) => {
                             let status = StatusCode::from_u16(r.status())?;
                             let headers = r.headers()?;
-                            let request_id = match headers.get("x-request-id") {
+                            let request_id = match headers.get("x-kong-request-id") {
                                 Some(v) => Some(v.to_string()),
                                 None => None,
                             };
@@ -832,7 +832,7 @@ impl MistralAILLM {
         };
 
         let res_headers = res.headers();
-        let request_id = match res_headers.get("x-request-id") {
+        let request_id = match res_headers.get("x-kong-request-id") {
             Some(v) => Some(v.to_str()?.to_string()),
             None => None,
         };
@@ -1189,7 +1189,7 @@ impl Embedder for MistralEmbedder {
         };
 
         let res_headers = res.headers();
-        let request_id = match res_headers.get("x-request-id") {
+        let request_id = match res_headers.get("x-kong-request-id") {
             Some(v) => Some(v.to_str()?.to_string()),
             None => None,
         };


### PR DESCRIPTION
## Description

As per https://dust4ai.slack.com/archives/C062SUY4NKA/p1717508145347039 we are not using the right header to get the request unique identifier for mistral requests.

This commit fixes it

## Risk

N/A

## Deploy Plan

N/A