### PR TITLE
core: Anthropic streaming errors

### DIFF
--- a/core/src/providers/anthropic.rs
+++ b/core/src/providers/anthropic.rs
@@ -939,7 +939,7 @@ impl AnthropicLLM {
                         es::Error::UnexpectedResponse(r) => {
                             let status = StatusCode::from_u16(r.status())?;
                             let headers = r.headers()?;
-                            let request_id = match headers.get("x-request-id") {
+                            let request_id = match headers.get("request-id") {
                                 Some(v) => Some(v.to_string()),
                                 None => None,
                             };
@@ -1123,7 +1123,7 @@ impl AnthropicLLM {
                         es::Error::UnexpectedResponse(r) => {
                             let status = StatusCode::from_u16(r.status())?;
                             let headers = r.headers()?;
-                            let request_id = match headers.get("x-request-id") {
+                            let request_id = match headers.get("request-id") {
                                 Some(v) => Some(v.to_string()),
                                 None => None,
                             };
@@ -1206,7 +1206,7 @@ impl AnthropicLLM {
 
         let status = res.status();
         let res_headers = res.headers();
-        let request_id = match res_headers.get("x-request-id") {
+        let request_id = match res_headers.get("request-id") {
             Some(v) => Some(v.to_str()?.to_string()),
             None => None,
         };

--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -396,11 +396,11 @@ pub struct InnerError {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct Error {
+pub struct OpenAIError {
     pub error: InnerError,
 }
 
-impl Error {
+impl OpenAIError {
     pub fn message(&self) -> String {
         match self.error.internal_message {
             Some(ref msg) => format!(
@@ -550,7 +550,8 @@ pub async fn streamed_completion(
                         let completion: Completion = match serde_json::from_str(e.data.as_str()) {
                             Ok(c) => c,
                             Err(err) => {
-                                let error: Result<Error, _> = serde_json::from_str(e.data.as_str());
+                                let error: Result<OpenAIError, _> =
+                                    serde_json::from_str(e.data.as_str());
                                 match error {
                                     Ok(error) => {
                                         match error.retryable_streamed(StatusCode::OK) && index == 0
@@ -654,7 +655,7 @@ pub async fn streamed_completion(
                         };
                         let b = r.body_bytes().await?;
 
-                        let error: Result<Error, _> = serde_json::from_slice(&b);
+                        let error: Result<OpenAIError, _> = serde_json::from_slice(&b);
                         match error {
                             Ok(error) => {
                                 match error.retryable_streamed(status) {
@@ -827,7 +828,7 @@ pub async fn completion(
     let completion: Completion = match serde_json::from_slice(c) {
         Ok(c) => Ok(c),
         Err(_) => {
-            let error: Error = serde_json::from_slice(c)?;
+            let error: OpenAIError = serde_json::from_slice(c)?;
             match error.retryable() {
                 true => Err(ModelError {
                     request_id,
@@ -979,7 +980,7 @@ pub async fn streamed_chat_completion(
                                     break 'stream;
                                 }
                                 false => {
-                                    let error: Result<Error, _> =
+                                    let error: Result<OpenAIError, _> =
                                         serde_json::from_str(e.data.as_str());
                                     match error {
                                         Ok(error) => {
@@ -1087,7 +1088,7 @@ pub async fn streamed_chat_completion(
                         };
                         let b = r.body_bytes().await?;
 
-                        let error: Result<Error, _> = serde_json::from_slice(&b);
+                        let error: Result<OpenAIError, _> = serde_json::from_slice(&b);
                         match error {
                             Ok(error) => {
                                 match error.retryable_streamed(status) {
@@ -1355,7 +1356,7 @@ pub async fn chat_completion(
     let mut completion: OpenAIChatCompletion = match serde_json::from_slice(c) {
         Ok(c) => Ok(c),
         Err(_) => {
-            let error: Error = serde_json::from_slice(c)?;
+            let error: OpenAIError = serde_json::from_slice(c)?;
             match error.retryable() {
                 true => Err(ModelError {
                     request_id,
@@ -1468,7 +1469,7 @@ pub async fn embed(
     let embeddings: Embeddings = match serde_json::from_slice(c) {
         Ok(c) => Ok(c),
         Err(_) => {
-            let error: Error = serde_json::from_slice(c)?;
+            let error: OpenAIError = serde_json::from_slice(c)?;
             match error.retryable() {
                 true => Err(ModelError {
                     request_id,


### PR DESCRIPTION
## Description

- Add support for streamed error reporting.
- Also renames Error classes to OpenAIError and AnthropicError in respective files

Before:
```
data: {"type":"block_execution","content":{"block_type":"chat","block_name":"MODEL","execution":[[{"value":null,"error":"Error querying `anthropic:gpt-3.5-turbo`: error=Error streaming tokens from Anthropic: UnexpectedResponse(ResponseWrapper { status: 400 })","meta":null}]]}}
```
After:
```
data: {"type":"block_execution","content":{"block_type":"chat","block_name":"MODEL","execution":[[{"value":null,"error":"Error querying `anthropic:gpt-3.5-turbo`: error=[model_error(retryable=false)] AnthropicError: [invalid_request_error] 'gpt-3.5-turbo' does not support tool use via API fields.","meta":null}]]}}
```

Associated LLMChatRequest log
```
{"timestamp":"2024-06-04T14:23:24.667448744+00:00","level":"ERROR","message":"LLMChatRequest model error model_id=gpt-3.5-turbo provider_id=anthropic request_id=req_01MR9HrHmtoUbMZHad58YEzp err_msg=AnthropicError: [invalid_request_error] 'gpt-3.5-turbo' does not support tool use via API fields.","target":"dust::providers::llm"}
```

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
