### PR TITLE
[connectors] - fix: Slack auto indexing

### DIFF
--- a/connectors/src/api/webhooks/slack/created_channel.ts
+++ b/connectors/src/api/webhooks/slack/created_channel.ts
@@ -29,7 +29,7 @@ export function isChannelCreatedEvent(
   );
 }
 
-export interface OnChannelCreationProps {
+export interface OnChannelCreationInterface {
   event: ChannelCreatedEvent;
   logger: Logger;
 }
@@ -37,7 +37,7 @@ export interface OnChannelCreationProps {
 export async function onChannelCreation({
   event,
   logger,
-}: OnChannelCreationProps): Promise<Result<void, Error>> {
+}: OnChannelCreationInterface): Promise<Result<void, Error>> {
   const { channel } = event;
   if (!channel) {
     return new Err(

--- a/connectors/src/api/webhooks/slack/created_channel.ts
+++ b/connectors/src/api/webhooks/slack/created_channel.ts
@@ -1,0 +1,55 @@
+import type { Result } from "@dust-tt/types";
+import { Err, Ok } from "@dust-tt/types";
+
+import type { SlackWebhookEvent } from "@connectors/api/webhooks/webhook_slack";
+import { autoReadChannel } from "@connectors/connectors/slack/auto_read_channel";
+import type { Logger } from "@connectors/logger/logger";
+
+interface ChannelCreatedEventPayload {
+  context_team_id: string;
+  created: number;
+  creator: string;
+  id: string;
+  name: string;
+}
+
+type ChannelCreatedEvent = Omit<SlackWebhookEvent, "channel"> & {
+  channel: ChannelCreatedEventPayload;
+};
+
+export function isChannelCreatedEvent(
+  event: unknown
+): event is ChannelCreatedEvent {
+  return (
+    typeof event === "object" &&
+    event !== null &&
+    "context_team_id" in event &&
+    "created" in event &&
+    "creator" in event &&
+    "id" in event &&
+    "name" in event
+  );
+}
+
+export interface OnChannelCreationProps {
+  event: ChannelCreatedEvent;
+  logger: Logger;
+}
+
+export async function onChannelCreation({
+  event,
+  logger,
+}: OnChannelCreationProps): Promise<Result<void, Error>> {
+  const { channel } = event;
+  const autoReadRes = await autoReadChannel(
+    channel.context_team_id,
+    logger,
+    channel.name
+  );
+  if (autoReadRes.isErr()) {
+    return new Err(
+      new Error(`Error joining slack channel: ${autoReadRes.error}`)
+    );
+  }
+  return new Ok(undefined);
+}

--- a/connectors/src/api/webhooks/slack/created_channel.ts
+++ b/connectors/src/api/webhooks/slack/created_channel.ts
@@ -13,9 +13,7 @@ interface ChannelCreatedEventPayload {
   name: string;
 }
 
-type ChannelCreatedEvent = Omit<SlackWebhookEvent, "channel"> & {
-  channel: ChannelCreatedEventPayload;
-};
+type ChannelCreatedEvent = SlackWebhookEvent<ChannelCreatedEventPayload>;
 
 export function isChannelCreatedEvent(
   event: unknown
@@ -41,6 +39,11 @@ export async function onChannelCreation({
   logger,
 }: OnChannelCreationProps): Promise<Result<void, Error>> {
   const { channel } = event;
+  if (!channel) {
+    return new Err(
+      new Error("Missing channel in request body for message event")
+    );
+  }
   const autoReadRes = await autoReadChannel(
     channel.context_team_id,
     logger,

--- a/connectors/src/api/webhooks/webhook_slack.ts
+++ b/connectors/src/api/webhooks/webhook_slack.ts
@@ -50,7 +50,7 @@ type SlackWebhookResBody = WithConnectorsAPIErrorReponse<{
 } | null>;
 
 function isSlackWebhookEventReqBody(
-  body: unknown
+  body: SlackWebhookReqBody
 ): body is SlackWebhookEventReqBody {
   return (
     typeof body === "object" &&

--- a/connectors/src/api/webhooks/webhook_slack.ts
+++ b/connectors/src/api/webhooks/webhook_slack.ts
@@ -2,7 +2,10 @@ import type { WithConnectorsAPIErrorReponse } from "@dust-tt/types";
 import { Ok } from "@dust-tt/types";
 import type { Request, Response } from "express";
 
-import { autoReadChannel } from "@connectors/connectors/slack/auto_read_channel";
+import {
+  isChannelCreatedEvent,
+  onChannelCreation,
+} from "@connectors/api/webhooks/slack/created_channel";
 import { botAnswerMessageWithErrorHandling } from "@connectors/connectors/slack/bot";
 import { getBotUserIdMemoized } from "@connectors/connectors/slack/temporal/activities";
 import {
@@ -17,24 +20,29 @@ import { apiError, withLogging } from "@connectors/logger/withlogging";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { SlackConfigurationResource } from "@connectors/resources/slack_configuration_resource";
 
+export interface SlackWebhookEvent<T = string> {
+  bot_id?: string;
+  channel?: T;
+  subtype?: "message_changed";
+  user?: string;
+  ts?: string; // slack message id
+  thread_ts?: string; // slack thread id
+  type?: string; // event type (eg: message)
+  channel_type?: "channel" | "im" | "mpim";
+  text: string; // content of the message
+  message?: {
+    bot_id?: string;
+  };
+}
+
 type SlackWebhookReqBody = {
   type?: string;
   challenge?: string;
   team_id?: string;
-  event?: {
-    bot_id?: string;
-    channel?: string;
-    subtype?: "message_changed";
-    user?: string;
-    ts?: string; // slack message id
-    thread_ts?: string; // slack thread id
-    type?: string; // event type (eg: message)
-    channel_type?: "channel" | "im" | "mpim";
-    text: string; // content of the message
-    message?: {
-      bot_id?: string;
-    };
-  };
+};
+
+type SlackWebhookEventReqBody = SlackWebhookReqBody & {
+  event: SlackWebhookEvent;
 };
 
 type SlackWebhookResBody = WithConnectorsAPIErrorReponse<{
@@ -131,7 +139,8 @@ const _webhookSlackAPIHandler = async (
   }
 
   if (req.body.type === "event_callback") {
-    const { team_id: teamId } = req.body;
+    const reqBody = req.body as SlackWebhookEventReqBody;
+    const { team_id: teamId } = reqBody;
     if (!req.body.team_id) {
       return apiError(req, res, {
         api_error: {
@@ -169,19 +178,19 @@ const _webhookSlackAPIHandler = async (
       });
     }
 
-    const { event } = req.body;
+    const { event } = reqBody;
     logger.info(
       {
         event: {
-          type: event?.type,
-          channelType: event?.channel_type,
-          channelName: event?.channel,
+          type: event.type,
+          channelType: event.channel_type,
+          channelName: event.channel,
         },
       },
       "Processing webhook event"
     );
 
-    switch (event?.type) {
+    switch (event.type) {
       case "app_mention": {
         await handleChatBot(req, res, logger);
         break;
@@ -199,7 +208,7 @@ const _webhookSlackAPIHandler = async (
             status_code: 400,
           });
         }
-        if (event?.channel_type === "im") {
+        if (event.channel_type === "im") {
           //Got a private message
           if (event.subtype === "message_changed") {
             // Ignore message_changed events in private messages
@@ -231,15 +240,15 @@ const _webhookSlackAPIHandler = async (
           }
 
           const myUserId = await getBotUserIdMemoized(slackConfig.connectorId);
-          if (event?.user === myUserId) {
+          if (event.user === myUserId) {
             // Message sent from the bot itself.
             return res.status(200).send();
           }
           // Message from an actual user (a human)
           await handleChatBot(req, res, logger);
           break;
-        } else if (event?.channel_type === "channel") {
-          if (!event?.channel) {
+        } else if (event.channel_type === "channel") {
+          if (!event.channel) {
             return apiError(req, res, {
               api_error: {
                 type: "invalid_request_error",
@@ -252,7 +261,7 @@ const _webhookSlackAPIHandler = async (
           const channel = event.channel;
           let err: Error | null = null;
 
-          if (event?.thread_ts) {
+          if (event.thread_ts) {
             const thread_ts = event.thread_ts;
             const results = await Promise.all(
               slackConfigurations.map(async (c) => {
@@ -295,7 +304,7 @@ const _webhookSlackAPIHandler = async (
                 err = r.error;
               }
             }
-          } else if (event?.ts) {
+          } else if (event.ts) {
             const ts = event.ts;
             const results = await Promise.all(
               slackConfigurations.map(async (c) => {
@@ -374,28 +383,35 @@ const _webhookSlackAPIHandler = async (
         break;
       }
       case "channel_created": {
-        const channelName = req.body.event?.channel;
-        if (!channelName) {
+        if (isChannelCreatedEvent(event)) {
+          const onChannelCreationRes = await onChannelCreation({
+            event,
+            logger,
+          });
+          if (onChannelCreationRes.isErr()) {
+            return apiError(req, res, {
+              api_error: {
+                type: "internal_server_error",
+                message: onChannelCreationRes.error.message,
+              },
+              status_code: 500,
+            });
+          } else {
+            return res.status(200).send();
+          }
+        } else {
+          logger.error(
+            {
+              eventChannel: event.channel,
+            },
+            "Invalid channel object"
+          );
           return apiError(req, res, {
             api_error: {
-              type: "invalid_request_error",
-              message: `Webhook message without 'channel_name'`,
+              type: "unexpected_response_format",
+              message: `Invalid channel object: ${event.channel} `,
             },
             status_code: 400,
-          });
-        }
-        const autoReadRes = await autoReadChannel(
-          req.body.team_id,
-          logger,
-          channelName
-        );
-        if (autoReadRes.isErr()) {
-          return apiError(req, res, {
-            api_error: {
-              type: "internal_server_error",
-              message: `Error joining slack channel: ${autoReadRes.error}`,
-            },
-            status_code: 500,
           });
         }
         break;
@@ -405,7 +421,7 @@ const _webhookSlackAPIHandler = async (
        */
       case "channel_left":
       case "channel_deleted": {
-        if (!event?.channel) {
+        if (!event.channel) {
           return apiError(req, res, {
             api_error: {
               type: "invalid_request_error",


### PR DESCRIPTION
## Description

This PR aims at fixing the Slack auto indexing which was caused by the fact that `event.channel` is a `string` in most cases but a complex object when  `event.type === "channel_created"`. 
Which lead to no found Slack channel when performing the following:
```
const remoteChannel = await slackClient.conversations.info({
    channel: slackChannelId,
  });
```

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy `connectors`
