### PR TITLE
[connectors] - fix: use channel ID instead of name for auto-read action

### DIFF
--- a/connectors/src/api/webhooks/slack/created_channel.ts
+++ b/connectors/src/api/webhooks/slack/created_channel.ts
@@ -50,7 +50,7 @@ export async function onChannelCreation({
   const autoReadRes = await autoReadChannel(
     channel.context_team_id,
     logger,
-    channel.name
+    channel.id
   );
   if (autoReadRes.isErr()) {
     return new Err(


### PR DESCRIPTION

## Description

 - Changed the parameter passed to the autoReadChannel function from channel name to channel ID for consistency and accuracy

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy `connectors`
