### PR TITLE
enh: Retrieve and store token usage in execution metadata

### DIFF
--- a/core/src/blocks/chat.rs
+++ b/core/src/blocks/chat.rs
@@ -537,6 +537,18 @@ impl Block for Chat {
                                                 },
                                             }));
                                         }
+                                        if s == "token_usage" {
+                                            let _ = sender.send(json!({
+                                                "type": s,
+                                                "content": {
+                                                    "block_type": "chat",
+                                                    "block_name": block_name,
+                                                    "input_index": input_index,
+                                                    "map": map,
+                                                    "token_usage": c,
+                                                },
+                                            }));
+                                        }
                                         if s == "function_call" {
                                             let _ = sender.send(json!({
                                                 "type": s,
@@ -595,6 +607,7 @@ impl Block for Chat {
             })?,
             meta: Some(json!({
                 "logs": all_logs,
+                "token_usage": g.usage,
             })),
         })
     }

--- a/core/src/blocks/chat.rs
+++ b/core/src/blocks/chat.rs
@@ -537,18 +537,6 @@ impl Block for Chat {
                                                 },
                                             }));
                                         }
-                                        if s == "token_usage" {
-                                            let _ = sender.send(json!({
-                                                "type": s,
-                                                "content": {
-                                                    "block_type": "chat",
-                                                    "block_name": block_name,
-                                                    "input_index": input_index,
-                                                    "map": map,
-                                                    "token_usage": c,
-                                                },
-                                            }));
-                                        }
                                         if s == "function_call" {
                                             let _ = sender.send(json!({
                                                 "type": s,

--- a/core/src/blocks/llm.rs
+++ b/core/src/blocks/llm.rs
@@ -583,7 +583,9 @@ impl Block for LLM {
                         prompt: g.prompt,
                         completion: g.completions[0].clone(),
                     })?,
-                    meta: None,
+                    meta: Some(json!({
+                        "token_usage": g.usage,
+                    })),
                 })
             }
         }

--- a/core/src/providers/ai21.rs
+++ b/core/src/providers/ai21.rs
@@ -335,6 +335,7 @@ impl LLM for AI21LLM {
                     }
                 },
             },
+            usage: None,
         })
     }
 

--- a/core/src/providers/anthropic.rs
+++ b/core/src/providers/anthropic.rs
@@ -896,15 +896,6 @@ impl AnthropicLLM {
                                             response.stop_reason = event.delta.stop_reason;
                                             response.usage.output_tokens =
                                                 event.usage.output_tokens;
-
-                                            let _ = event_sender.send(json!({
-                                                "type": "token_usage",
-                                                "content": json!({
-                                                    "prompt_tokens": response.usage.input_tokens,
-                                                    "completion_tokens": response.usage.output_tokens,
-                                                    "total_tokens": response.usage.input_tokens + response.usage.output_tokens,
-                                                })
-                                            }));
                                         }
                                     }
                                 }

--- a/core/src/providers/anthropic.rs
+++ b/core/src/providers/anthropic.rs
@@ -884,7 +884,7 @@ impl AnthropicLLM {
                                             }
                                         };
 
-                                        match final_response.as_mut() {
+                                    match final_response.as_mut() {
                                         None => {
                                             Err(anyhow!(
                                                 "Error streaming from Anthropic: \
@@ -1226,9 +1226,7 @@ impl AnthropicLLM {
         body.reader().read_to_end(&mut b)?;
         let c: &[u8] = &b;
         let response = match status {
-            reqwest::StatusCode::OK => {
-                Ok(serde_json::from_slice(c)?)
-            }
+            reqwest::StatusCode::OK => Ok(serde_json::from_slice(c)?),
             _ => {
                 let error: AnthropicError = serde_json::from_slice(c)?;
                 Err(ModelError {

--- a/core/src/providers/anthropic.rs
+++ b/core/src/providers/anthropic.rs
@@ -1515,19 +1515,15 @@ impl LLM for AnthropicLLM {
             }
         };
 
-        let input_tokens = c.usage.input_tokens;
-        let output_tokens = c.usage.output_tokens;
-
         Ok(LLMChatGeneration {
             created: utils::now(),
             provider: ProviderID::Anthropic.to_string(),
             model: self.id.clone(),
-            completions: ChatMessage::try_from(c).into_iter().collect(),
             usage: Some(LLMTokenUsage {
-                prompt_tokens: input_tokens,
-                completion_tokens: Some(output_tokens),
-                total_tokens: input_tokens + output_tokens,
+                prompt_tokens: c.usage.input_tokens,
+                completion_tokens: c.usage.output_tokens,
             }),
+            completions: ChatMessage::try_from(c).into_iter().collect(),
         })
     }
 }

--- a/core/src/providers/azure_openai.rs
+++ b/core/src/providers/azure_openai.rs
@@ -418,8 +418,7 @@ impl LLM for AzureOpenAILLM {
             prompt: prompt_tokens,
             usage: c.usage.map(|usage| LLMTokenUsage {
                 prompt_tokens: usage.prompt_tokens,
-                completion_tokens: usage.completion_tokens,
-                total_tokens: usage.total_tokens,
+                completion_tokens: usage.completion_tokens.unwrap_or(0),
             }),
         })
     }
@@ -550,8 +549,7 @@ impl LLM for AzureOpenAILLM {
                 .collect::<Result<Vec<_>>>()?,
             usage: c.usage.map(|usage| LLMTokenUsage {
                 prompt_tokens: usage.prompt_tokens,
-                completion_tokens: usage.completion_tokens,
-                total_tokens: usage.total_tokens,
+                completion_tokens: usage.completion_tokens.unwrap_or(0),
             }),
         })
     }

--- a/core/src/providers/azure_openai.rs
+++ b/core/src/providers/azure_openai.rs
@@ -416,14 +416,11 @@ impl LLM for AzureOpenAILLM {
                 })
                 .collect::<Vec<_>>(),
             prompt: prompt_tokens,
-            usage: match c.usage {
-                Some(usage) => Some(LLMTokenUsage {
-                    prompt_tokens: usage.prompt_tokens,
-                    completion_tokens: usage.completion_tokens,
-                    total_tokens: usage.total_tokens,
-                }),
-                None => None,
-            },
+            usage: c.usage.map(|usage| LLMTokenUsage {
+                prompt_tokens: usage.prompt_tokens,
+                completion_tokens: usage.completion_tokens,
+                total_tokens: usage.total_tokens,
+            }),
         })
     }
 
@@ -551,14 +548,11 @@ impl LLM for AzureOpenAILLM {
                 .iter()
                 .map(|c| ChatMessage::try_from(&c.message))
                 .collect::<Result<Vec<_>>>()?,
-            usage: match c.usage {
-                Some(usage) => Some(LLMTokenUsage {
-                    prompt_tokens: usage.prompt_tokens,
-                    completion_tokens: usage.completion_tokens,
-                    total_tokens: usage.total_tokens,
-                }),
-                None => None,
-            },
+            usage: c.usage.map(|usage| LLMTokenUsage {
+                prompt_tokens: usage.prompt_tokens,
+                completion_tokens: usage.completion_tokens,
+                total_tokens: usage.total_tokens,
+            }),
         })
     }
 }

--- a/core/src/providers/azure_openai.rs
+++ b/core/src/providers/azure_openai.rs
@@ -1,7 +1,7 @@
 use crate::providers::embedder::{Embedder, EmbedderVector};
 use crate::providers::llm::ChatFunction;
 use crate::providers::llm::Tokens;
-use crate::providers::llm::{ChatMessage, LLMChatGeneration, LLMGeneration, LLM};
+use crate::providers::llm::{ChatMessage, LLMChatGeneration, LLMGeneration, LLMTokenUsage, LLM};
 use crate::providers::openai::{
     chat_completion, completion, embed, streamed_chat_completion, streamed_completion,
     to_openai_messages, OpenAILLM, OpenAITool, OpenAIToolChoice,
@@ -416,6 +416,14 @@ impl LLM for AzureOpenAILLM {
                 })
                 .collect::<Vec<_>>(),
             prompt: prompt_tokens,
+            usage: match c.usage {
+                Some(usage) => Some(LLMTokenUsage {
+                    prompt_tokens: usage.prompt_tokens,
+                    completion_tokens: usage.completion_tokens,
+                    total_tokens: usage.total_tokens,
+                }),
+                None => None,
+            }
         })
     }
 
@@ -543,6 +551,14 @@ impl LLM for AzureOpenAILLM {
                 .iter()
                 .map(|c| ChatMessage::try_from(&c.message))
                 .collect::<Result<Vec<_>>>()?,
+            usage: match c.usage {
+                Some(usage) => Some(LLMTokenUsage {
+                    prompt_tokens: usage.prompt_tokens,
+                    completion_tokens: usage.completion_tokens,
+                    total_tokens: usage.total_tokens,
+                }),
+                None => None,
+            },
         })
     }
 }

--- a/core/src/providers/azure_openai.rs
+++ b/core/src/providers/azure_openai.rs
@@ -423,7 +423,7 @@ impl LLM for AzureOpenAILLM {
                     total_tokens: usage.total_tokens,
                 }),
                 None => None,
-            }
+            },
         })
     }
 

--- a/core/src/providers/cohere.rs
+++ b/core/src/providers/cohere.rs
@@ -391,6 +391,7 @@ impl LLM for CohereLLM {
                 logprobs: None,
                 top_logprobs: None,
             },
+            usage: None,
         })
     }
 

--- a/core/src/providers/google_ai_studio.rs
+++ b/core/src/providers/google_ai_studio.rs
@@ -362,6 +362,7 @@ impl LLM for GoogleAiStudioLLM {
                 logprobs: Some(vec![]),
                 top_logprobs: None,
             },
+            usage: None,
         })
     }
 
@@ -473,6 +474,7 @@ impl LLM for GoogleAiStudioLLM {
                     },
                 },
             }],
+            usage: None,
         })
     }
 }

--- a/core/src/providers/google_ai_studio.rs
+++ b/core/src/providers/google_ai_studio.rs
@@ -364,8 +364,7 @@ impl LLM for GoogleAiStudioLLM {
             },
             usage: c.usage_metadata.map(|c| LLMTokenUsage {
                 prompt_tokens: c.prompt_token_count.unwrap_or(0) as u64,
-                completion_tokens: c.candidates_token_count.map(|c| c as u64),
-                total_tokens: c.total_token_count.unwrap_or(0) as u64,
+                completion_tokens: c.candidates_token_count.unwrap_or(0) as u64,
             }),
         })
     }
@@ -480,8 +479,7 @@ impl LLM for GoogleAiStudioLLM {
             }],
             usage: c.usage_metadata.map(|c| LLMTokenUsage {
                 prompt_tokens: c.prompt_token_count.unwrap_or(0) as u64,
-                completion_tokens: c.candidates_token_count.map(|c| c as u64),
-                total_tokens: c.total_token_count.unwrap_or(0) as u64,
+                completion_tokens: c.candidates_token_count.unwrap_or(0) as u64,
             }),
         })
     }

--- a/core/src/providers/google_ai_studio.rs
+++ b/core/src/providers/google_ai_studio.rs
@@ -16,7 +16,7 @@ use super::{
     embedder::Embedder,
     llm::{
         ChatFunction, ChatFunctionCall, ChatMessage, ChatMessageRole, LLMChatGeneration,
-        LLMGeneration, LLM,
+        LLMGeneration, LLMTokenUsage, LLM,
     },
     provider::{Provider, ProviderID},
     tiktoken::tiktoken::{
@@ -362,7 +362,11 @@ impl LLM for GoogleAiStudioLLM {
                 logprobs: Some(vec![]),
                 top_logprobs: None,
             },
-            usage: None,
+            usage: c.usage_metadata.map(|c| LLMTokenUsage {
+                prompt_tokens: c.prompt_token_count.unwrap_or(0) as u64,
+                completion_tokens: c.candidates_token_count.map(|c| c as u64),
+                total_tokens: c.total_token_count.unwrap_or(0) as u64,
+            }),
         })
     }
 
@@ -474,7 +478,11 @@ impl LLM for GoogleAiStudioLLM {
                     },
                 },
             }],
-            usage: None,
+            usage: c.usage_metadata.map(|c| LLMTokenUsage {
+                prompt_tokens: c.prompt_token_count.unwrap_or(0) as u64,
+                completion_tokens: c.candidates_token_count.map(|c| c as u64),
+                total_tokens: c.total_token_count.unwrap_or(0) as u64,
+            }),
         })
     }
 }

--- a/core/src/providers/llm.rs
+++ b/core/src/providers/llm.rs
@@ -95,8 +95,7 @@ pub struct ChatFunction {
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct LLMTokenUsage {
     pub prompt_tokens: u64,
-    pub completion_tokens: Option<u64>,
-    pub total_tokens: u64,
+    pub completion_tokens: u64,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]

--- a/core/src/providers/llm.rs
+++ b/core/src/providers/llm.rs
@@ -28,7 +28,7 @@ pub struct LLMGeneration {
     pub model: String,
     pub completions: Vec<Tokens>,
     pub prompt: Tokens,
-    pub usage: Option<LLMTokenUsage>
+    pub usage: Option<LLMTokenUsage>,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
@@ -105,7 +105,7 @@ pub struct LLMChatGeneration {
     pub provider: String,
     pub model: String,
     pub completions: Vec<ChatMessage>,
-    pub usage: Option<LLMTokenUsage>
+    pub usage: Option<LLMTokenUsage>,
 }
 
 #[async_trait]

--- a/core/src/providers/llm.rs
+++ b/core/src/providers/llm.rs
@@ -28,6 +28,7 @@ pub struct LLMGeneration {
     pub model: String,
     pub completions: Vec<Tokens>,
     pub prompt: Tokens,
+    pub usage: Option<LLMTokenUsage>
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
@@ -92,11 +93,19 @@ pub struct ChatFunction {
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+pub struct LLMTokenUsage {
+    pub prompt_tokens: u64,
+    pub completion_tokens: Option<u64>,
+    pub total_tokens: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct LLMChatGeneration {
     pub created: u64,
     pub provider: String,
     pub model: String,
     pub completions: Vec<ChatMessage>,
+    pub usage: Option<LLMTokenUsage>
 }
 
 #[async_trait]

--- a/core/src/providers/mistral.rs
+++ b/core/src/providers/mistral.rs
@@ -1066,9 +1066,8 @@ impl LLM for MistralAILLM {
                 .map(|c| ChatMessage::try_from(&c.message))
                 .collect::<Result<Vec<_>>>()?,
             usage: c.usage.map(|u| LLMTokenUsage {
-                completion_tokens: u.completion_tokens,
+                completion_tokens: u.completion_tokens.unwrap_or(0),
                 prompt_tokens: u.prompt_tokens,
-                total_tokens: u.total_tokens,
             }),
         })
     }

--- a/core/src/providers/mistral.rs
+++ b/core/src/providers/mistral.rs
@@ -5,7 +5,9 @@ use super::sentencepiece::sentencepiece::{
     mistral_tokenizer_model_v1_base_singleton, tokenize_async,
 };
 use crate::providers::embedder::{Embedder, EmbedderVector};
-use crate::providers::llm::{ChatMessageRole, LLMChatGeneration, LLMGeneration, LLMTokenUsage, LLM};
+use crate::providers::llm::{
+    ChatMessageRole, LLMChatGeneration, LLMGeneration, LLMTokenUsage, LLM,
+};
 use crate::providers::provider::{ModelError, ModelErrorRetryOptions, Provider, ProviderID};
 use crate::run::Credentials;
 use crate::utils::{self, now};
@@ -599,7 +601,7 @@ impl MistralAILLM {
                                 Some(received_usage) => {
                                     usage = Some(received_usage.clone());
                                 }
-                                None => ()
+                                None => (),
                             };
 
                             // Only stream if choices is length 1 but should always be the case.
@@ -658,7 +660,7 @@ impl MistralAILLM {
                                                 "content": received_usage,
                                             }));
                                         }
-                                        None => ()
+                                        None => (),
                                     };
                                 }
                                 None => (),
@@ -1081,7 +1083,7 @@ impl LLM for MistralAILLM {
                     total_tokens: u.total_tokens,
                 }),
                 None => None,
-            }
+            },
         })
     }
 

--- a/core/src/providers/mistral.rs
+++ b/core/src/providers/mistral.rs
@@ -651,17 +651,6 @@ impl MistralAILLM {
                                             });
                                         }
                                     }
-
-                                    // Emit token_usage event when getting count
-                                    match &chunk.usage {
-                                        Some(received_usage) => {
-                                            let _ = sender.send(json!({
-                                                "type": "token_usage",
-                                                "content": received_usage,
-                                            }));
-                                        }
-                                        None => (),
-                                    };
                                 }
                                 None => (),
                             };
@@ -1076,14 +1065,11 @@ impl LLM for MistralAILLM {
                 .iter()
                 .map(|c| ChatMessage::try_from(&c.message))
                 .collect::<Result<Vec<_>>>()?,
-            usage: match c.usage {
-                Some(u) => Some(LLMTokenUsage {
-                    completion_tokens: u.completion_tokens,
-                    prompt_tokens: u.prompt_tokens,
-                    total_tokens: u.total_tokens,
-                }),
-                None => None,
-            },
+            usage: c.usage.map(|u| LLMTokenUsage {
+                completion_tokens: u.completion_tokens,
+                prompt_tokens: u.prompt_tokens,
+                total_tokens: u.total_tokens,
+            }),
         })
     }
 

--- a/core/src/providers/mistral.rs
+++ b/core/src/providers/mistral.rs
@@ -5,7 +5,7 @@ use super::sentencepiece::sentencepiece::{
     mistral_tokenizer_model_v1_base_singleton, tokenize_async,
 };
 use crate::providers::embedder::{Embedder, EmbedderVector};
-use crate::providers::llm::{ChatMessageRole, LLMChatGeneration, LLMGeneration, LLM};
+use crate::providers::llm::{ChatMessageRole, LLMChatGeneration, LLMGeneration, LLMTokenUsage, LLM};
 use crate::providers::provider::{ModelError, ModelErrorRetryOptions, Provider, ProviderID};
 use crate::run::Credentials;
 use crate::utils::{self, now};
@@ -274,6 +274,7 @@ struct MistralChatChunk {
     pub id: String,
     pub model: String,
     pub object: Option<String>,
+    pub usage: Option<MistralUsage>,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
@@ -534,6 +535,7 @@ impl MistralAILLM {
         let mut stream = client.stream();
 
         let chunks: Arc<Mutex<Vec<MistralChatChunk>>> = Arc::new(Mutex::new(Vec::new()));
+        let mut usage = None;
 
         'stream: loop {
             match stream.try_next().await {
@@ -592,6 +594,14 @@ impl MistralAILLM {
                                     }
                                 };
 
+                            // Store usage
+                            match &chunk.usage {
+                                Some(received_usage) => {
+                                    usage = Some(received_usage.clone());
+                                }
+                                None => ()
+                            };
+
                             // Only stream if choices is length 1 but should always be the case.
                             match event_sender.as_ref() {
                                 Some(sender) => {
@@ -639,6 +649,17 @@ impl MistralAILLM {
                                             });
                                         }
                                     }
+
+                                    // Emit token_usage event when getting count
+                                    match &chunk.usage {
+                                        Some(received_usage) => {
+                                            let _ = sender.send(json!({
+                                                "type": "token_usage",
+                                                "content": received_usage,
+                                            }));
+                                        }
+                                        None => ()
+                                    };
                                 }
                                 None => (),
                             };
@@ -725,7 +746,7 @@ impl MistralAILLM {
                 // The `object` field defaults to "start" when not present in the initial stream
                 // chunk.
                 object: f.object.unwrap_or(String::from("start")),
-                usage: None,
+                usage,
             };
 
             for i in 0..guard.len() {
@@ -1053,6 +1074,14 @@ impl LLM for MistralAILLM {
                 .iter()
                 .map(|c| ChatMessage::try_from(&c.message))
                 .collect::<Result<Vec<_>>>()?,
+            usage: match c.usage {
+                Some(u) => Some(LLMTokenUsage {
+                    completion_tokens: u.completion_tokens,
+                    prompt_tokens: u.prompt_tokens,
+                    total_tokens: u.total_tokens,
+                }),
+                None => None,
+            }
         })
     }
 

--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -1824,8 +1824,7 @@ impl LLM for OpenAILLM {
             prompt: prompt_tokens,
             usage: c.usage.map(|usage| LLMTokenUsage {
                 prompt_tokens: usage.prompt_tokens,
-                completion_tokens: usage.completion_tokens,
-                total_tokens: usage.total_tokens,
+                completion_tokens: usage.completion_tokens.unwrap_or(0),
             }),
         })
     }
@@ -1958,8 +1957,7 @@ impl LLM for OpenAILLM {
                 .collect::<Result<Vec<_>>>()?,
             usage: c.usage.map(|usage| LLMTokenUsage {
                 prompt_tokens: usage.prompt_tokens,
-                completion_tokens: usage.completion_tokens,
-                total_tokens: usage.total_tokens,
+                completion_tokens: usage.completion_tokens.unwrap_or(0),
             }),
         })
     }

--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -1080,7 +1080,10 @@ pub async fn streamed_chat_completion(
                             }
                             None => (),
                         };
-                        chunks.lock().push(chunk);
+
+                        if !chunk.choices.is_empty() {
+                            chunks.lock().push(chunk);
+                        }
                     }
                 },
                 None => {
@@ -1165,7 +1168,7 @@ pub async fn streamed_chat_completion(
 
         for i in 0..guard.len() {
             let a = guard[i].clone();
-            if a.choices.len() != f.choices.len() && a.usage.is_none() {
+            if a.choices.len() != f.choices.len() {
                 Err(anyhow!("Inconsistent number of choices in streamed chunks"))?;
             }
             for j in 0..a.choices.len() {

--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -1,7 +1,9 @@
 use crate::providers::embedder::{Embedder, EmbedderVector};
 use crate::providers::llm::Tokens;
 use crate::providers::llm::{ChatFunction, ChatFunctionCall};
-use crate::providers::llm::{ChatMessage, ChatMessageRole, LLMChatGeneration, LLMGeneration, LLMTokenUsage, LLM};
+use crate::providers::llm::{
+    ChatMessage, ChatMessageRole, LLMChatGeneration, LLMGeneration, LLMTokenUsage, LLM,
+};
 use crate::providers::provider::{ModelError, ModelErrorRetryOptions, Provider, ProviderID};
 use crate::providers::tiktoken::tiktoken::{
     cl100k_base_singleton, p50k_base_singleton, r50k_base_singleton, CoreBPE,
@@ -1024,7 +1026,7 @@ pub async fn streamed_chat_completion(
                             Some(received_usage) => {
                                 usage = Some(received_usage.clone());
                             }
-                            None => ()
+                            None => (),
                         };
 
                         // Only stream if choices is length 1 but should always be the case.
@@ -1084,7 +1086,7 @@ pub async fn streamed_chat_completion(
                                             "content": received_usage,
                                         }));
                                     }
-                                    None => ()
+                                    None => (),
                                 };
                             }
                             None => (),
@@ -1835,7 +1837,7 @@ impl LLM for OpenAILLM {
                     total_tokens: usage.total_tokens,
                 }),
                 None => None,
-            }
+            },
         })
     }
 
@@ -1972,7 +1974,7 @@ impl LLM for OpenAILLM {
                     total_tokens: usage.total_tokens,
                 }),
                 None => None,
-            }
+            },
         })
     }
 }

--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -1077,17 +1077,6 @@ pub async fn streamed_chat_completion(
                                         });
                                     }
                                 }
-
-                                // Emit token_usage event when getting count
-                                match &chunk.usage {
-                                    Some(received_usage) => {
-                                        let _ = sender.send(json!({
-                                            "type": "token_usage",
-                                            "content": received_usage,
-                                        }));
-                                    }
-                                    None => (),
-                                };
                             }
                             None => (),
                         };
@@ -1830,14 +1819,11 @@ impl LLM for OpenAILLM {
                 })
                 .collect::<Vec<_>>(),
             prompt: prompt_tokens,
-            usage: match c.usage {
-                Some(usage) => Some(LLMTokenUsage {
-                    prompt_tokens: usage.prompt_tokens,
-                    completion_tokens: usage.completion_tokens,
-                    total_tokens: usage.total_tokens,
-                }),
-                None => None,
-            },
+            usage: c.usage.map(|usage| LLMTokenUsage {
+                prompt_tokens: usage.prompt_tokens,
+                completion_tokens: usage.completion_tokens,
+                total_tokens: usage.total_tokens,
+            }),
         })
     }
 
@@ -1967,14 +1953,11 @@ impl LLM for OpenAILLM {
                 .iter()
                 .map(|c| ChatMessage::try_from(&c.message))
                 .collect::<Result<Vec<_>>>()?,
-            usage: match c.usage {
-                Some(usage) => Some(LLMTokenUsage {
-                    prompt_tokens: usage.prompt_tokens,
-                    completion_tokens: usage.completion_tokens,
-                    total_tokens: usage.total_tokens,
-                }),
-                None => None,
-            },
+            usage: c.usage.map(|usage| LLMTokenUsage {
+                prompt_tokens: usage.prompt_tokens,
+                completion_tokens: usage.completion_tokens,
+                total_tokens: usage.total_tokens,
+            }),
         })
     }
 }


### PR DESCRIPTION
## Description

Add token_usage in chat and llm blocks completion result, containing  number of prompt/completion/total tokens. The data are sent in the meta block : 

```
{
    "type": "block_execution",
    "content": {
        "block_type": "chat",
        "block_name": "MODEL",
        "execution": [
            [
                {
                    "value": {
                        "message": {
                            "role": "assistant",
                            "content": "Hello!"
                        }
                    },
                    "error": null,
                    "meta": {
                        "logs": [],
                        "token_usage": {
                            "prompt_tokens": 9,
                            "completion_tokens": 5,
                            "total_tokens": 14
                        }
                    }
                }
            ]
        ]
    }
}
```

Also send a token_usage event when using streaming ( the previous block_execution is already sent , I'm not sure this event is very useful ) : 

```
{
    "type": "token_usage",
    "content": {
        "block_type": "chat",
        "block_name": "MODEL",
        "input_index": 0,
        "map": null,
        "token_usage": {
            "prompt_tokens": 9,
            "completion_tokens": 5,
            "total_tokens": 14
        }
    }
}
```

Currently implemented for openAI , mistral, anthropic

## Risk

No real risk, it's new data that were not previously sent. 
Completely safe to rollback

## Deploy Plan


