### PR TITLE
Get rid of name and description in dust app run configuration

### DIFF
--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -540,6 +540,9 @@ function ActionEditor({
     "RETRIEVAL_EXHAUSTIVE",
     "RETRIEVAL_SEARCH",
   ].includes(action.type as any);
+
+  const shouldDisplayActionDescription = action.type !== "DUST_APP_RUN";
+
   return (
     <>
       <div className="flex w-full flex-row items-end justify-end">
@@ -712,39 +715,41 @@ function ActionEditor({
           }
         })()}
       </ActionModeSection>
-      <div className="flex flex-col gap-4 pt-8">
-        {isDataSourceAction ? (
-          <div className="flex flex-col gap-2">
+      {shouldDisplayActionDescription && (
+        <div className="flex flex-col gap-4 pt-8">
+          {isDataSourceAction ? (
+            <div className="flex flex-col gap-2">
+              <div className="font-semibold text-element-800">
+                What's the data?
+              </div>
+              <div className="text-sm text-element-600">
+                Clarify the data's content and context to guide your Assistant
+                in determining when and how to utilize it.
+              </div>
+            </div>
+          ) : (
             <div className="font-semibold text-element-800">
-              What's the data?
+              Action description
             </div>
-            <div className="text-sm text-element-600">
-              Clarify the data's content and context to guide your Assistant in
-              determining when and how to utilize it.
-            </div>
-          </div>
-        ) : (
-          <div className="font-semibold text-element-800">
-            Action description
-          </div>
-        )}
-        <TextArea
-          placeholder={
-            isDataSourceAction
-              ? "This data contains...."
-              : "My action description.."
-          }
-          value={action.description}
-          onChange={(v) => {
-            updateAction({
-              actionName: action.name,
-              actionDescription: v,
-              getNewActionConfig: (old) => old,
-            });
-          }}
-          error={!descriptionValid ? "Description cannot be empty" : null}
-        />
-      </div>
+          )}
+          <TextArea
+            placeholder={
+              isDataSourceAction
+                ? "This data contains...."
+                : "My action description.."
+            }
+            value={action.description}
+            onChange={(v) => {
+              updateAction({
+                actionName: action.name,
+                actionDescription: v,
+                getNewActionConfig: (old) => old,
+              });
+            }}
+            error={!descriptionValid ? "Description cannot be empty" : null}
+          />
+        </div>
+      )}
     </>
   );
 }

--- a/front/components/assistant_builder/AssistantBuilderDustAppModal.tsx
+++ b/front/components/assistant_builder/AssistantBuilderDustAppModal.tsx
@@ -8,8 +8,6 @@ import {
 import type { AppType } from "@dust-tt/types";
 import { Transition } from "@headlessui/react";
 
-import type { AssistantBuilderDustAppConfiguration } from "@app/components/assistant_builder/types";
-
 export default function AssistantBuilderDustAppModal({
   isOpen,
   setOpen,
@@ -19,7 +17,7 @@ export default function AssistantBuilderDustAppModal({
   isOpen: boolean;
   setOpen: (isOpen: boolean) => void;
   dustApps: AppType[];
-  onSave: (params: AssistantBuilderDustAppConfiguration) => void;
+  onSave: (app: AppType) => void;
 }) {
   const onClose = () => {
     setOpen(false);
@@ -38,9 +36,7 @@ export default function AssistantBuilderDustAppModal({
           show={true}
           dustApps={dustApps}
           onPick={(app) => {
-            onSave({
-              app,
-            });
+            onSave(app);
             onClose();
           }}
         />
@@ -58,14 +54,24 @@ function PickDustApp({
   show: boolean;
   onPick: (app: AppType) => void;
 }) {
+  const hasSomeUnselectableApps = dustApps.some(
+    (app) => !app.description || app.description.length === 0
+  );
   return (
     <Transition show={show} className="mx-auto max-w-6xl">
       <Page>
         <Page.Header title="Select Dust App" icon={CloudArrowDownIcon} />
+        {hasSomeUnselectableApps && (
+          <Page.P>
+            Dust apps without a description are not selectable. To make a Dust
+            App selectable, edit it and add a description.
+          </Page.P>
+        )}
         {dustApps.map((app) => (
           <Item.Navigation
             label={app.name}
             icon={CommandLineIcon}
+            disabled={!app.description || app.description.length === 0}
             key={app.sId}
             onClick={() => {
               onPick(app);

--- a/front/components/assistant_builder/actions/DustAppRunAction.tsx
+++ b/front/components/assistant_builder/actions/DustAppRunAction.tsx
@@ -1,6 +1,6 @@
 import { ContentMessage } from "@dust-tt/sparkle";
 import type { AppType, WorkspaceType } from "@dust-tt/types";
-import { assertNever } from "@dust-tt/types";
+import { assertNever, slugify } from "@dust-tt/types";
 import { useState } from "react";
 
 import AssistantBuilderDustAppModal from "@app/components/assistant_builder/AssistantBuilderDustAppModal";
@@ -44,8 +44,10 @@ export function ActionDustAppRun({
   const deleteDustApp = () => {
     setEdited(true);
     updateAction({
-      actionName: action.name,
-      actionDescription: action.description,
+      actionName:
+        ASSISTANT_BUILDER_DUST_APP_RUN_ACTION_CONFIGURATION_DEFAULT_NAME,
+      actionDescription:
+        ASSISTANT_BUILDER_DUST_APP_RUN_ACTION_CONFIGURATION_DEFAULT_DESCRIPTION,
       getNewActionConfig: (previousAction) => ({
         ...previousAction,
         app: null,
@@ -67,25 +69,11 @@ export function ActionDustAppRun({
           setShowDustAppsModal(isOpen);
         }}
         dustApps={dustApps}
-        onSave={({ app }) => {
+        onSave={(app) => {
           setEdited(true);
-          const newName =
-            action.name ===
-              ASSISTANT_BUILDER_DUST_APP_RUN_ACTION_CONFIGURATION_DEFAULT_NAME &&
-            app?.name
-              ? app.name
-              : action.name;
-
-          const newDescription =
-            action.description ===
-              ASSISTANT_BUILDER_DUST_APP_RUN_ACTION_CONFIGURATION_DEFAULT_DESCRIPTION &&
-            app?.description?.length
-              ? app.description
-              : action.description;
-
           updateAction({
-            actionName: newName,
-            actionDescription: newDescription,
+            actionName: slugify(app.name),
+            actionDescription: app.description ?? "",
             getNewActionConfig: (previousAction) => ({
               ...previousAction,
               app,

--- a/front/components/assistant_builder/server_side_props_helpers.ts
+++ b/front/components/assistant_builder/server_side_props_helpers.ts
@@ -16,6 +16,7 @@ import {
   isRetrievalConfiguration,
   isTablesQueryConfiguration,
   isWebsearchConfiguration,
+  slugify,
 } from "@dust-tt/types";
 
 import type {
@@ -135,6 +136,8 @@ export async function buildInitialActions({
       for (const app of dustApps) {
         if (app.sId === action.appId) {
           dustAppConfiguration.configuration.app = app;
+          dustAppConfiguration.name = slugify(app.name);
+          dustAppConfiguration.description = app.description ?? "";
           break;
         }
       }

--- a/front/lib/models/assistant/actions/dust_app_run.ts
+++ b/front/lib/models/assistant/actions/dust_app_run.ts
@@ -25,9 +25,6 @@ export class AgentDustAppRunConfiguration extends Model<
 
   declare appWorkspaceId: string;
   declare appId: string;
-
-  declare name: string | null;
-  declare description: string | null;
 }
 
 AgentDustAppRunConfiguration.init(
@@ -58,14 +55,6 @@ AgentDustAppRunConfiguration.init(
     appId: {
       type: DataTypes.STRING,
       allowNull: false,
-    },
-    name: {
-      type: DataTypes.STRING,
-      allowNull: true,
-    },
-    description: {
-      type: DataTypes.TEXT,
-      allowNull: true,
     },
   },
   {

--- a/front/migrations/db/migration_15.sql
+++ b/front/migrations/db/migration_15.sql
@@ -1,0 +1,3 @@
+-- Migration created on Jun 05, 2024
+ALTER TABLE "public"."agent_dust_app_run_configurations" DROP COLUMN "name";
+ALTER TABLE "public"."agent_dust_app_run_configurations" DROP COLUMN "description";

--- a/front/pages/w/[wId]/a/[aId]/clone.tsx
+++ b/front/pages/w/[wId]/a/[aId]/clone.tsx
@@ -249,7 +249,7 @@ export default function CloneView({
                         Description
                       </label>
                       <div className="text-sm font-normal text-gray-400">
-                        optional
+                        optional but highly recommended
                       </div>
                     </div>
                     <div className="mt-1 flex rounded-md shadow-sm">
@@ -263,9 +263,11 @@ export default function CloneView({
                       />
                     </div>
                     <p className="mt-2 text-sm text-gray-500">
-                      For Assistants using your app, this description helps the
-                      model determine how to interact with the app and whether
-                      it's relevant for answering the user's request.
+                      This description guides assistants in understanding how to
+                      use your app effectively and determines its relevance in
+                      responding to user inquiries. If you don't provide a
+                      description, members won't be able to select this app in
+                      the Assistant Builder.
                     </p>
                   </div>
 

--- a/front/pages/w/[wId]/a/[aId]/clone.tsx
+++ b/front/pages/w/[wId]/a/[aId]/clone.tsx
@@ -263,9 +263,9 @@ export default function CloneView({
                       />
                     </div>
                     <p className="mt-2 text-sm text-gray-500">
-                      A good description will help others discover and
-                      understand the purpose of your app. It is also visible at
-                      the top of your app specification.
+                      For Assistants using your app, this description helps the
+                      model determine how to interact with the app and whether
+                      it's relevant for answering the user's request.
                     </p>
                   </div>
 

--- a/front/pages/w/[wId]/a/[aId]/settings.tsx
+++ b/front/pages/w/[wId]/a/[aId]/settings.tsx
@@ -226,7 +226,7 @@ export default function SettingsView({
                         Description
                       </label>
                       <div className="text-sm font-normal text-gray-400">
-                        optional
+                        optional but highly recommended
                       </div>
                     </div>
                     <div className="mt-1 flex rounded-md shadow-sm">
@@ -240,9 +240,11 @@ export default function SettingsView({
                       />
                     </div>
                     <p className="mt-2 text-sm text-gray-500">
-                      A good description will help others discover and
-                      understand the purpose of your app. It is also visible at
-                      the top of your app specification.
+                      This description guides assistants in understanding how to
+                      use your app effectively and determines its relevance in
+                      responding to user inquiries. If you don't provide a
+                      description, members won't be able to select this app in
+                      the Assistant Builder.
                     </p>
                   </div>
 

--- a/front/pages/w/[wId]/a/new.tsx
+++ b/front/pages/w/[wId]/a/new.tsx
@@ -153,7 +153,9 @@ export default function NewApp({
               >
                 Description
               </label>
-              <div className="text-sm font-normal text-gray-400">optional</div>
+              <div className="text-sm font-normal text-gray-400">
+                optional but highly recommended
+              </div>
             </div>
             <div className="mt-1 flex rounded-md shadow-sm">
               <input
@@ -166,9 +168,10 @@ export default function NewApp({
               />
             </div>
             <p className="mt-2 text-sm text-gray-500">
-              For Assistants using your app, this description helps the model
-              determine how to interact with the app and whether it's relevant
-              for answering the user's request.
+              This description guides assistants in understanding how to use
+              your app effectively and determines its relevance in responding to
+              user inquiries. If you don't provide a description, members won't
+              be able to select this app in the Assistant Builder.
             </p>
           </div>
 

--- a/front/pages/w/[wId]/a/new.tsx
+++ b/front/pages/w/[wId]/a/new.tsx
@@ -166,9 +166,9 @@ export default function NewApp({
               />
             </div>
             <p className="mt-2 text-sm text-gray-500">
-              A good description will help others discover and understand the
-              purpose of your app. It is also visible at the top of your app
-              specification.
+              For Assistants using your app, this description helps the model
+              determine how to interact with the app and whether it's relevant
+              for answering the user's request.
             </p>
           </div>
 


### PR DESCRIPTION
## Description

Task: https://github.com/dust-tt/dust/issues/5437

Todo after IRL discussion yesterday: 
- We want to remove the fields name/description from table `AgentDustAppRunConfiguration`. The name & description of the action configuration will be the ones from the Dust app selected. 
- We want to disable picking a Dust app without a description. 
- We want to edit the description of the description field on Dust app to explain why the description is important. 

## Risk

Can't be rolled back since we remove some columns. 

## Deploy Plan

- Deploy front
- Run `psql $FRONT_DATABASE_URI -f ./migrations/db/migration_15.sql `
