### PR TITLE
fix: allow single-action legacy agents to not have a description

### DIFF
--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -317,27 +317,6 @@ export async function createOrUpgradeAgentConfiguration({
           .join(", ")}`
       );
     }
-    const actionsWithoutDescription = actions.filter(
-      (action) => !action.description
-    );
-    if (actionsWithoutDescription.length) {
-      // We tolerate a missing description when editing am assistant with a single action of
-      // type retrieval_configuration or tables_query_configuration. That's because we need to keep support for
-      // legacy single-action assistants that have not been edited since the introduction of multi-actions.
-      if (
-        !agentConfigurationId ||
-        actions.length !== 1 ||
-        !["retrieval_configuration", "tables_query_configuration"].includes(
-          actions[0].type
-        )
-      ) {
-        throw new Error(
-          `Every action must have a description. Missing descriptions for: ${actionsWithoutDescription
-            .map((action) => action.type)
-            .join(", ")}`
-        );
-      }
-    }
     const actionNames = new Set<string>();
     for (const action of actions) {
       if (!action.name) {

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -321,11 +321,22 @@ export async function createOrUpgradeAgentConfiguration({
       (action) => !action.description
     );
     if (actionsWithoutDescription.length) {
-      throw new Error(
-        `Every action must have a description. Missing descriptions for: ${actionsWithoutDescription
-          .map((action) => action.type)
-          .join(", ")}`
-      );
+      // We tolerate a missing description when editing am assistant with a single action of
+      // type retrieval_configuration or tables_query_configuration. That's because we need to keep support for
+      // legacy single-action assistants that have not been edited since the introduction of multi-actions.
+      if (
+        !agentConfigurationId ||
+        actions.length !== 1 ||
+        !["retrieval_configuration", "tables_query_configuration"].includes(
+          actions[0].type
+        )
+      ) {
+        throw new Error(
+          `Every action must have a description. Missing descriptions for: ${actionsWithoutDescription
+            .map((action) => action.type)
+            .join(", ")}`
+        );
+      }
     }
     const actionNames = new Set<string>();
     for (const action of actions) {


### PR DESCRIPTION
## Description

Otherwise we can't save the legacy single action agents that only one  retrieval/tables query action without adding an action description.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
