### PR TITLE
Flav/m a conversation UI base

### DIFF
--- a/front/components/actions/types.ts
+++ b/front/components/actions/types.ts
@@ -1,0 +1,25 @@
+import type { AgentActionType } from "@dust-tt/types";
+
+// TODO(2024-06-05 flav) Augment this type with their respective components.
+interface ActionSpecification {
+  name: string;
+}
+
+type ActionType = AgentActionType["type"];
+
+const actionsSpecification: Record<
+  AgentActionType["type"],
+  ActionSpecification
+> = {
+  websearch_action: { name: "Search and browse the Web" },
+  dust_app_run_action: { name: "Run App" },
+  tables_query_action: { name: "Query Tables" },
+  retrieval_action: { name: "Search Data" },
+  process_action: { name: "Latest Data" },
+};
+
+export function getActionSpecification(
+  actionType: ActionType
+): ActionSpecification {
+  return actionsSpecification[actionType];
+}

--- a/front/components/actions/types.ts
+++ b/front/components/actions/types.ts
@@ -2,7 +2,7 @@ import type { AgentActionType } from "@dust-tt/types";
 
 // TODO(2024-06-05 flav) Augment this type with their respective components.
 interface ActionSpecification {
-  name: string;
+  runningLabel: string;
 }
 
 type ActionType = AgentActionType["type"];
@@ -11,11 +11,11 @@ const actionsSpecification: Record<
   AgentActionType["type"],
   ActionSpecification
 > = {
-  websearch_action: { name: "Search and browse the Web" },
-  dust_app_run_action: { name: "Run App" },
-  tables_query_action: { name: "Query Tables" },
-  retrieval_action: { name: "Search Data" },
-  process_action: { name: "Latest Data" },
+  dust_app_run_action: { runningLabel: "Running App" },
+  process_action: { runningLabel: "Gathering latest data" },
+  retrieval_action: { runningLabel: "Searching data" },
+  tables_query_action: { runningLabel: "Querying tables" },
+  websearch_action: { runningLabel: "Searching the web" },
 };
 
 export function getActionSpecification(

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -7,7 +7,6 @@ import {
   DocumentDuplicateIcon,
   DropdownMenu,
   EyeIcon,
-  Spinner,
 } from "@dust-tt/sparkle";
 import type {
   AgentActionSpecificEvent,
@@ -35,7 +34,6 @@ import { useRouter } from "next/router";
 import { useCallback, useContext, useEffect, useRef, useState } from "react";
 
 import { ConversationActions } from "@app/components/assistant/conversation/actions/ConversationActions";
-import { AgentAction } from "@app/components/assistant/conversation/AgentAction";
 import { AssistantEditionMenu } from "@app/components/assistant/conversation/AssistantEditionMenu";
 import type { MessageSizeType } from "@app/components/assistant/conversation/ConversationMessage";
 import { ConversationMessage } from "@app/components/assistant/conversation/ConversationMessage";

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -34,6 +34,7 @@ import Link from "next/link";
 import { useRouter } from "next/router";
 import { useCallback, useContext, useEffect, useRef, useState } from "react";
 
+import { ConversationActions } from "@app/components/assistant/conversation/actions/ConversationActions";
 import { AgentAction } from "@app/components/assistant/conversation/AgentAction";
 import { AssistantEditionMenu } from "@app/components/assistant/conversation/AssistantEditionMenu";
 import type { MessageSizeType } from "@app/components/assistant/conversation/ConversationMessage";
@@ -370,24 +371,6 @@ export function AgentMessage({
     agentMessageToRender.sId,
   ]);
 
-  function AssitantDetailViewLink(assistant: LightAgentConfigurationType) {
-    const router = useRouter();
-    const href = {
-      pathname: router.pathname,
-      query: { ...router.query, assistantDetails: assistant.sId },
-    };
-
-    return (
-      <Link
-        href={href}
-        shallow
-        className="cursor-pointer duration-300 hover:text-action-500 active:text-action-600"
-      >
-        @{assistant.name}
-      </Link>
-    );
-  }
-
   const { configuration: agentConfiguration } = agentMessageToRender;
 
   return (
@@ -447,27 +430,15 @@ export function AgentMessage({
       );
     }
 
-    if (
-      agentMessage.status === "created" &&
-      !agentMessage.actions.length &&
-      (!agentMessage.content || agentMessage.content === "")
-    ) {
-      return (
-        <div>
-          <div className="pb-2 text-xs font-bold text-element-600">
-            I'm thinking...
-          </div>
-          <Spinner size="sm" />
-        </div>
-      );
-    }
-
     // TODO(2024-05-27 flav) Use <ConversationMessage.citations />.
     return (
-      <>
-        {agentMessage.actions.map((action) => (
-          <AgentAction action={action} key={`action-${action.id}`} />
-        ))}
+      <div className="flex flex-col gap-y-4">
+        <ConversationActions
+          actions={agentMessage.actions}
+          agentMessageContent={agentMessage.content}
+          isStreaming={streaming}
+          size={size}
+        />
         {agentMessage.content !== null && (
           <div>
             {agentMessage.content === "" ? (
@@ -502,7 +473,7 @@ export function AgentMessage({
             className="mt-4"
           />
         )}
-      </>
+      </div>
     );
   }
 
@@ -519,6 +490,24 @@ export function AgentMessage({
     );
     setIsRetryHandlerProcessing(false);
   }
+}
+
+function AssitantDetailViewLink(assistant: LightAgentConfigurationType) {
+  const router = useRouter();
+  const href = {
+    pathname: router.pathname,
+    query: { ...router.query, assistantDetails: assistant.sId },
+  };
+
+  return (
+    <Link
+      href={href}
+      shallow
+      className="cursor-pointer duration-300 hover:text-action-500 active:text-action-600"
+    >
+      @{assistant.name}
+    </Link>
+  );
 }
 
 function Citations({

--- a/front/components/assistant/conversation/actions/ConversationActions.tsx
+++ b/front/components/assistant/conversation/actions/ConversationActions.tsx
@@ -1,4 +1,4 @@
-import { Button, Chip, EyeIcon } from "@dust-tt/sparkle";
+import { Button, Chip, EyeIcon, Spinner } from "@dust-tt/sparkle";
 import type { AgentActionType } from "@dust-tt/types";
 import { useEffect, useState } from "react";
 
@@ -61,7 +61,12 @@ function ActionChip({ label }: { label?: string }) {
 
   return (
     <div key={label} className="animate-fadeIn duration-1000 fade-out">
-      <Chip size="sm" color="pink" label={label} isBusy={true} />
+      <Chip size="sm" color="pink" isBusy={true}>
+        <div className="flex flex-row items-center gap-x-2">
+          <Spinner variant="pink900" size="xs" />
+          {label}
+        </div>
+      </Chip>
     </div>
   );
 }

--- a/front/components/assistant/conversation/actions/ConversationActions.tsx
+++ b/front/components/assistant/conversation/actions/ConversationActions.tsx
@@ -19,7 +19,7 @@ export function ConversationActions({
   isStreaming,
   size = "normal",
 }: ConversationActionsProps) {
-  const [chipLabel, setChipLabel] = useState<string | null>("Thinking");
+  const [chipLabel, setChipLabel] = useState<string | undefined>("Thinking");
   const [isActionDrawerOpened, setIsActionDrawerOpened] = useState(false);
 
   useEffect(() => {
@@ -32,7 +32,7 @@ export function ConversationActions({
     } else if (isStreaming && actions.length > 0) {
       setChipLabel(renderActionName(actions));
     } else {
-      setChipLabel(null);
+      setChipLabel(undefined);
     }
   }, [actions, agentMessageContent, isStreaming]);
 
@@ -43,29 +43,52 @@ export function ConversationActions({
         isOpened={isActionDrawerOpened}
         onClose={() => setIsActionDrawerOpened(false)}
       />
-      {chipLabel ? (
-        <div
-          key={chipLabel}
-          className="duration-1000 animate-in fade-in fade-out"
-        >
-          <Chip size="sm" color="pink" label={chipLabel} isBusy={true}>
-            {chipLabel === "Step 1" && (
-              <span className="font-normal">
-                {actions.map((action) => action.type).join(",")}
-              </span>
-            )}
-          </Chip>
-        </div>
-      ) : actions.length > 0 ? (
-        <Button
-          size={size === "normal" ? "sm" : "xs"}
-          label="View Actions Details"
-          icon={EyeIcon}
-          variant="tertiary"
-          onClick={() => setIsActionDrawerOpened(true)}
-        />
-      ) : null}
+      <ActionChip label={chipLabel} />
+      <ActionDetailsButton
+        hasActions={actions.length !== 0}
+        isStreaming={isStreaming}
+        onClick={() => setIsActionDrawerOpened(true)}
+        size={size}
+      />
     </div>
+  );
+}
+
+function ActionChip({ label }: { label?: string }) {
+  if (!label) {
+    return null;
+  }
+
+  return (
+    <div key={label} className="animate-fadeIn duration-1000 fade-out">
+      <Chip size="sm" color="pink" label={label} isBusy={true} />
+    </div>
+  );
+}
+
+function ActionDetailsButton({
+  hasActions,
+  isStreaming,
+  onClick,
+  size,
+}: {
+  hasActions: boolean;
+  isStreaming: boolean;
+  onClick: () => void;
+  size: MessageSizeType;
+}) {
+  if (isStreaming || !hasActions) {
+    return;
+  }
+
+  return (
+    <Button
+      size={size === "normal" ? "sm" : "xs"}
+      label="View Actions Details"
+      icon={EyeIcon}
+      variant="tertiary"
+      onClick={onClick}
+    />
   );
 }
 

--- a/front/components/assistant/conversation/actions/ConversationActions.tsx
+++ b/front/components/assistant/conversation/actions/ConversationActions.tsx
@@ -1,0 +1,84 @@
+import { Button, Chip, EyeIcon } from "@dust-tt/sparkle";
+import type { AgentActionType } from "@dust-tt/types";
+import { useEffect, useState } from "react";
+
+import { getActionSpecification } from "@app/components/actions/types";
+import { ConversationActionsDrawer } from "@app/components/assistant/conversation/actions/ConversationActionsDrawer";
+import type { MessageSizeType } from "@app/components/assistant/conversation/ConversationMessage";
+
+interface ConversationActionsProps {
+  actions: AgentActionType[];
+  agentMessageContent: string | null;
+  isStreaming: boolean;
+  size?: MessageSizeType;
+}
+
+export function ConversationActions({
+  actions,
+  agentMessageContent,
+  isStreaming,
+  size = "normal",
+}: ConversationActionsProps) {
+  const [chipLabel, setChipLabel] = useState<string | null>("Thinking");
+  const [isActionDrawerOpened, setIsActionDrawerOpened] = useState(false);
+
+  useEffect(() => {
+    const isThinking =
+      actions.length === 0 &&
+      (!agentMessageContent || agentMessageContent.length === 0);
+
+    if (isThinking) {
+      setChipLabel("Thinking");
+    } else if (isStreaming && actions.length > 0) {
+      setChipLabel(renderActionName(actions));
+    } else {
+      setChipLabel(null);
+    }
+  }, [actions, agentMessageContent, isStreaming]);
+
+  return (
+    <div className="flex flex-col items-start gap-y-4">
+      <ConversationActionsDrawer
+        actions={actions}
+        isOpened={isActionDrawerOpened}
+        onClose={() => setIsActionDrawerOpened(false)}
+      />
+      {chipLabel ? (
+        <div
+          key={chipLabel}
+          className="duration-1000 animate-in fade-in fade-out"
+        >
+          <Chip size="sm" color="pink" label={chipLabel} isBusy={true}>
+            {chipLabel === "Step 1" && (
+              <span className="font-normal">
+                {actions.map((action) => action.type).join(",")}
+              </span>
+            )}
+          </Chip>
+        </div>
+      ) : actions.length > 0 ? (
+        <Button
+          size={size === "normal" ? "sm" : "xs"}
+          label="View Actions Details"
+          icon={EyeIcon}
+          variant="tertiary"
+          onClick={() => setIsActionDrawerOpened(true)}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function renderActionName(actions: AgentActionType[]): string {
+  const uniqueActionTypes = actions.reduce((acc, action) => {
+    if (!acc.includes(action.type)) {
+      acc.push(action.type);
+    }
+
+    return acc;
+  }, [] as AgentActionType["type"][]);
+
+  return uniqueActionTypes
+    .map((actionType) => getActionSpecification(actionType).name)
+    .join(", ");
+}

--- a/front/components/assistant/conversation/actions/ConversationActions.tsx
+++ b/front/components/assistant/conversation/actions/ConversationActions.tsx
@@ -107,6 +107,6 @@ function renderActionName(actions: AgentActionType[]): string {
   }, [] as AgentActionType["type"][]);
 
   return uniqueActionTypes
-    .map((actionType) => getActionSpecification(actionType).name)
+    .map((actionType) => getActionSpecification(actionType).runningLabel)
     .join(", ");
 }

--- a/front/components/assistant/conversation/actions/ConversationActionsDrawer.tsx
+++ b/front/components/assistant/conversation/actions/ConversationActionsDrawer.tsx
@@ -1,0 +1,36 @@
+import { Modal, Page } from "@dust-tt/sparkle";
+import type { AgentActionType } from "@dust-tt/types";
+
+import { AgentAction } from "@app/components/assistant/conversation/AgentAction";
+
+interface ConversationActionsDrawerProps {
+  actions: AgentActionType[];
+  isOpened: boolean;
+  onClose: () => void;
+}
+
+export function ConversationActionsDrawer({
+  actions,
+  isOpened,
+  onClose,
+}: ConversationActionsDrawerProps) {
+  return (
+    <Modal
+      isOpen={isOpened}
+      onClose={onClose}
+      title="Actions Details"
+      variant="side-sm"
+      hasChanged={false}
+    >
+      <Page variant="modal">
+        <Page.Layout direction="vertical">
+          <div className="h-full w-full overflow-visible">
+            {actions.map((action) => (
+              <AgentAction action={action} key={`action-${action.id}`} />
+            ))}
+          </div>
+        </Page.Layout>
+      </Page>
+    </Modal>
+  );
+}

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -9,7 +9,7 @@
         "@amplitude/analytics-browser": "^2.5.2",
         "@amplitude/analytics-node": "^1.3.5",
         "@auth0/nextjs-auth0": "^3.5.0",
-        "@dust-tt/sparkle": "^0.2.157",
+        "@dust-tt/sparkle": "^0.2.159",
         "@dust-tt/types": "file:../types",
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",
@@ -10505,9 +10505,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.157",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.157.tgz",
-      "integrity": "sha512-h5ULfqYBdFuxoQhvRV9X7NUcDc86yaDcifmbIHOI4+7j79C5x3x9tlHz9Ux4aLOCs+De5SrKTgtXcBsg42EFZw==",
+      "version": "0.2.159",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.159.tgz",
+      "integrity": "sha512-7XcNwRvJ4Wh5DgYIX7I+/sfuTYzv5OCHn8pFBfZSC672+hvuL1s2ICxtsc65QQadPUdrmyijuVgOEN8xahp3kw==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -18,7 +18,7 @@
     "@amplitude/analytics-browser": "^2.5.2",
     "@amplitude/analytics-node": "^1.3.5",
     "@auth0/nextjs-auth0": "^3.5.0",
-    "@dust-tt/sparkle": "^0.2.157",
+    "@dust-tt/sparkle": "^0.2.159",
     "@dust-tt/types": "file:../types",
     "@emoji-mart/data": "^1.1.2",
     "@emoji-mart/react": "^1.1.1",


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See https://github.com/dust-tt/dust/issues/5350.

This PR implements the new conversation design flow highlighted [here](https://www.figma.com/design/QOxHwppG64GtPocpDhS6Y7/Product?node-id=7026-16818&t=uSiQqcaZGglBvG5l-0).

**The main changes are:**
- Using a chip to display the current ongoing action (based on labels from [here](https://docs.google.com/spreadsheets/d/18JD-P-Xr3hv2ydT689jWQrcPUzAZHTuKEzzMogwRlk0/edit#gid=0)).
- Displaying a CTA once the streaming is done, which opens a drawer allowing the user to see the details of each action. This CTA is only available if the agent's message has associated actions. Currently, the drawer displays what was previously rendered in the agent's message.

**Missing:**
- Smooth animation between states in the Chips
- We display the CTA a bit too late sometime, this will fixed as a broader issue

![ConversationActions](https://github.com/dust-tt/dust/assets/7428970/743f171c-89cb-42d5-ae84-4c5c4c837f2d)

<img width="789" alt="image" src="https://github.com/dust-tt/dust/assets/7428970/8d5f5012-784b-416c-8267-3d8d4ea429c6">

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
