### PR TITLE
fix: support for legacy agents in multi-actions mode

### DIFF
--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -203,7 +203,7 @@ export class RetrievalAction extends BaseAction {
 
   renderForMultiActionsModel(): FunctionMessageTypeModel {
     let content = "";
-    if (!this.documents) {
+    if (!this.documents?.length) {
       content += "(retrieval failed)\n";
     } else {
       for (const d of this.documents) {


### PR DESCRIPTION
## Description

- Cleanup the "normal" vs "legacy" cases, by removing the legacySpec thing from the normal case
- Fix the part where we match the action picked by the model with the agent's action for cases where the action name might be undefined

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
