### PR TITLE
[Gdrive] Adding sharedWithMe file selection.

### DIFF
--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -45,10 +45,8 @@ import type { InferAttributes, WhereOptions } from "sequelize";
 import { Op } from "sequelize";
 import { v4 as uuidv4 } from "uuid";
 
-import {
-  GOOGLE_DRIVE_SHARED_WITH_ME_VIRTUAL_ID,
-  googleDriveConfig,
-} from "@connectors/connectors/google_drive/lib/config";
+import { googleDriveConfig } from "@connectors/connectors/google_drive/lib/config";
+import { GOOGLE_DRIVE_SHARED_WITH_ME_VIRTUAL_ID } from "@connectors/connectors/google_drive/lib/consts";
 import { getGoogleDriveObject } from "@connectors/connectors/google_drive/lib/google_drive_api";
 import {
   getGoogleDriveEntityDocumentId,

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -449,6 +449,8 @@ export async function retrieveGoogleDriveConnectorPermissions({
           };
         })
       );
+      // Adding a fake "Shared with me" node, to allow the user to their shared files
+      // that are not living in a shared drive.
       nodes.push({
         provider: c.type,
         internalId: "sharedWithMe",
@@ -474,7 +476,7 @@ export async function retrieveGoogleDriveConnectorPermissions({
       let nextPageToken: string | undefined = undefined;
       let remoteFolders: drive_v3.Schema$File[] = [];
       // Depending on the view the user is requesting, the way of querying changes.
-      // For example, the "Shared with me" view requires to look for folders
+      // The "Shared with me" view requires to look for folders
       // with the flag `sharedWithMe=true`, but there is no need to check for the parents.
       let gdriveQuery = `mimeType='application/vnd.google-apps.folder'`;
       if (parentInternalId === "sharedWithMe") {

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -45,7 +45,10 @@ import type { InferAttributes, WhereOptions } from "sequelize";
 import { Op } from "sequelize";
 import { v4 as uuidv4 } from "uuid";
 
-import { googleDriveConfig } from "@connectors/connectors/google_drive/lib/config";
+import {
+  GOOGLE_DRIVE_SHARED_WITH_ME_VIRTUAL_ID,
+  googleDriveConfig,
+} from "@connectors/connectors/google_drive/lib/config";
 import { getGoogleDriveObject } from "@connectors/connectors/google_drive/lib/google_drive_api";
 import {
   getGoogleDriveEntityDocumentId,
@@ -449,21 +452,22 @@ export async function retrieveGoogleDriveConnectorPermissions({
           };
         })
       );
-      // Adding a fake "Shared with me" node, to allow the user to their shared files
+      // Adding a fake "Shared with me" node, to allow the user to see their shared files
       // that are not living in a shared drive.
-      nodes.push({
-        provider: c.type,
-        internalId: "sharedWithMe",
-        parentInternalId: null,
-        type: "folder" as const,
-        preventSelection: true,
-        title: "Shared with me",
-        sourceUrl: null,
-        dustDocumentId: null,
-        lastUpdatedAt: null,
-        expandable: true,
-        permission: "none",
-      });
+      // Uncomment the following node to release the "Shared with me" feature.
+      // nodes.push({
+      //   provider: c.type,
+      //   internalId: GOOGLE_DRIVE_SHARED_WITH_ME_VIRTUAL_ID,
+      //   parentInternalId: null,
+      //   type: "folder" as const,
+      //   preventSelection: true,
+      //   title: "Shared with me",
+      //   sourceUrl: null,
+      //   dustDocumentId: null,
+      //   lastUpdatedAt: null,
+      //   expandable: true,
+      //   permission: "none",
+      // });
 
       nodes.sort((a, b) => {
         return a.title.localeCompare(b.title);
@@ -479,7 +483,7 @@ export async function retrieveGoogleDriveConnectorPermissions({
       // The "Shared with me" view requires to look for folders
       // with the flag `sharedWithMe=true`, but there is no need to check for the parents.
       let gdriveQuery = `mimeType='application/vnd.google-apps.folder'`;
-      if (parentInternalId === "sharedWithMe") {
+      if (parentInternalId === GOOGLE_DRIVE_SHARED_WITH_ME_VIRTUAL_ID) {
         gdriveQuery += ` and sharedWithMe=true`;
       } else {
         gdriveQuery += ` and '${parentInternalId}' in parents`;

--- a/connectors/src/connectors/google_drive/lib/config.ts
+++ b/connectors/src/connectors/google_drive/lib/config.ts
@@ -3,6 +3,13 @@ import { EnvironmentConfig } from "@dust-tt/types";
 export const GOOGLE_DRIVE_WEBHOOK_RENEW_MARGIN_MS = 60 * 60 * 1000;
 export const GOOGLE_DRIVE_WEBHOOK_LIFE_MS = 60 * 60 * 7 * 1000;
 
+// This is a virtual Google Drive Id used in our code base only to represent the "user space".
+// This is different from the "My Drive" space, which is an actual a drive.
+// For example, "Shared with me" items live in this space, for the currently authenticated user.
+// We use this ID locally in place of a real google drive ID.
+// Please note that a file "shared with me" could live in an actual drive (e.g. "My Drive") of the user who shared it.
+export const GOOGLE_DRIVE_USER_LAND_DRIVE_ID = "userland";
+
 export const googleDriveConfig = {
   getRequiredNangoGoogleDriveConnectorId: (): string => {
     return EnvironmentConfig.getEnvVariable("NANGO_GOOGLE_DRIVE_CONNECTOR_ID");

--- a/connectors/src/connectors/google_drive/lib/config.ts
+++ b/connectors/src/connectors/google_drive/lib/config.ts
@@ -3,12 +3,18 @@ import { EnvironmentConfig } from "@dust-tt/types";
 export const GOOGLE_DRIVE_WEBHOOK_RENEW_MARGIN_MS = 60 * 60 * 1000;
 export const GOOGLE_DRIVE_WEBHOOK_LIFE_MS = 60 * 60 * 7 * 1000;
 
-// This is a virtual Google Drive Id used in our code base only to represent the "user space".
+// This is a virtual Google Drive Id used in our code base to represent the "user space".
 // This is different from the "My Drive" space, which is an actual Drive.
 // For example, "Shared with me" items live in this space, for the currently authenticated user.
 // We use this ID locally in place of a real google drive ID.
+// This id is stored in the GoogleDriveSyncToken table in the "driveId" column.
 // Please note that a file "shared with me" could live in an actual drive (e.g. "My Drive") of the user who shared it.
-export const GOOGLE_DRIVE_USER_LAND_DRIVE_ID = "userland";
+export const GOOGLE_DRIVE_USER_SPACE_VIRTUAL_DRIVE_ID = "userspace";
+
+// "Shared with me" files have a null file.parent field on Gdrive,
+// and a "sharedWithMe=true" property.
+// On our side, we want to group them into one virtual folder in our UI. This is the ID of that virtual folder.
+export const GOOGLE_DRIVE_SHARED_WITH_ME_VIRTUAL_ID = "sharedWithMe";
 
 export const googleDriveConfig = {
   getRequiredNangoGoogleDriveConnectorId: (): string => {

--- a/connectors/src/connectors/google_drive/lib/config.ts
+++ b/connectors/src/connectors/google_drive/lib/config.ts
@@ -4,7 +4,7 @@ export const GOOGLE_DRIVE_WEBHOOK_RENEW_MARGIN_MS = 60 * 60 * 1000;
 export const GOOGLE_DRIVE_WEBHOOK_LIFE_MS = 60 * 60 * 7 * 1000;
 
 // This is a virtual Google Drive Id used in our code base only to represent the "user space".
-// This is different from the "My Drive" space, which is an actual a drive.
+// This is different from the "My Drive" space, which is an actual Drive.
 // For example, "Shared with me" items live in this space, for the currently authenticated user.
 // We use this ID locally in place of a real google drive ID.
 // Please note that a file "shared with me" could live in an actual drive (e.g. "My Drive") of the user who shared it.

--- a/connectors/src/connectors/google_drive/lib/config.ts
+++ b/connectors/src/connectors/google_drive/lib/config.ts
@@ -3,19 +3,6 @@ import { EnvironmentConfig } from "@dust-tt/types";
 export const GOOGLE_DRIVE_WEBHOOK_RENEW_MARGIN_MS = 60 * 60 * 1000;
 export const GOOGLE_DRIVE_WEBHOOK_LIFE_MS = 60 * 60 * 7 * 1000;
 
-// This is a virtual Google Drive Id used in our code base to represent the "user space".
-// This is different from the "My Drive" space, which is an actual Drive.
-// For example, "Shared with me" items live in this space, for the currently authenticated user.
-// We use this ID locally in place of a real google drive ID.
-// This id is stored in the GoogleDriveSyncToken table in the "driveId" column.
-// Please note that a file "shared with me" could live in an actual drive (e.g. "My Drive") of the user who shared it.
-export const GOOGLE_DRIVE_USER_SPACE_VIRTUAL_DRIVE_ID = "userspace";
-
-// "Shared with me" files have a null file.parent field on Gdrive,
-// and a "sharedWithMe=true" property.
-// On our side, we want to group them into one virtual folder in our UI. This is the ID of that virtual folder.
-export const GOOGLE_DRIVE_SHARED_WITH_ME_VIRTUAL_ID = "sharedWithMe";
-
 export const googleDriveConfig = {
   getRequiredNangoGoogleDriveConnectorId: (): string => {
     return EnvironmentConfig.getEnvVariable("NANGO_GOOGLE_DRIVE_CONNECTOR_ID");

--- a/connectors/src/connectors/google_drive/lib/consts.ts
+++ b/connectors/src/connectors/google_drive/lib/consts.ts
@@ -1,0 +1,12 @@
+// This is a virtual Google Drive Id used in our code base to represent the "user space".
+// This is different from the "My Drive" space, which is an actual Drive.
+// For example, "Shared with me" items live in this space, for the currently authenticated user.
+// We use this ID locally in place of a real google drive ID.
+// This id is stored in the GoogleDriveSyncToken table in the "driveId" column.
+// Please note that a file "shared with me" could live in an actual drive (e.g. "My Drive") of the user who shared it.
+export const GOOGLE_DRIVE_USER_SPACE_VIRTUAL_DRIVE_ID = "userspace";
+
+// "Shared with me" files have a null file.parent field on Gdrive,
+// and a "sharedWithMe=true" property.
+// On our side, we want to group them into one virtual folder in our UI. This is the ID of that virtual folder.
+export const GOOGLE_DRIVE_SHARED_WITH_ME_VIRTUAL_ID = "sharedWithMe";

--- a/connectors/src/connectors/google_drive/temporal/activities.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities.ts
@@ -9,10 +9,8 @@ import PQueue from "p-queue";
 import { literal, Op } from "sequelize";
 
 import { ensureWebhookForDriveId } from "@connectors/connectors/google_drive/lib";
-import {
-  GOOGLE_DRIVE_USER_SPACE_VIRTUAL_DRIVE_ID,
-  GOOGLE_DRIVE_WEBHOOK_RENEW_MARGIN_MS,
-} from "@connectors/connectors/google_drive/lib/config";
+import { GOOGLE_DRIVE_WEBHOOK_RENEW_MARGIN_MS } from "@connectors/connectors/google_drive/lib/config";
+import { GOOGLE_DRIVE_USER_SPACE_VIRTUAL_DRIVE_ID } from "@connectors/connectors/google_drive/lib/consts";
 import { getGoogleDriveObject } from "@connectors/connectors/google_drive/lib/google_drive_api";
 import { getFileParentsMemoized } from "@connectors/connectors/google_drive/lib/hierarchy";
 import { syncOneFile } from "@connectors/connectors/google_drive/temporal/file";

--- a/connectors/src/connectors/google_drive/temporal/workflows.ts
+++ b/connectors/src/connectors/google_drive/temporal/workflows.ts
@@ -166,6 +166,18 @@ export async function googleDriveIncrementalSync(
         );
       } while (nextPageToken);
     }
+    // Run incremental sync for "userland" (aka non shared drives)
+    let nextPageToken: undefined | string = undefined;
+    do {
+      nextPageToken = await incrementalSync(
+        connectorId,
+        dataSourceConfig,
+        null,
+        false,
+        startSyncTs,
+        nextPageToken
+      );
+    } while (nextPageToken);
     const shouldGc = await shouldGarbageCollect(connectorId);
     if (shouldGc) {
       await executeChild(googleDriveGarbageCollectorWorkflow, {

--- a/connectors/src/connectors/google_drive/temporal/workflows.ts
+++ b/connectors/src/connectors/google_drive/temporal/workflows.ts
@@ -166,7 +166,7 @@ export async function googleDriveIncrementalSync(
         );
       } while (nextPageToken);
     }
-    // Run incremental sync for "userland" (aka non shared drives)
+    // Run incremental sync for "userland" (aka non shared drives, non "my drive").
     let nextPageToken: undefined | string = undefined;
     do {
       nextPageToken = await incrementalSync(

--- a/connectors/src/connectors/google_drive/temporal/workflows.ts
+++ b/connectors/src/connectors/google_drive/temporal/workflows.ts
@@ -8,11 +8,11 @@ import {
   workflowInfo,
 } from "@temporalio/workflow";
 
-import { GOOGLE_DRIVE_USER_SPACE_VIRTUAL_DRIVE_ID } from "@connectors/connectors/google_drive/lib/config";
 import type * as activities from "@connectors/connectors/google_drive/temporal/activities";
 import type * as sync_status from "@connectors/lib/sync_status";
 import type { DataSourceConfig } from "@connectors/types/data_source_config";
 
+import { GOOGLE_DRIVE_USER_SPACE_VIRTUAL_DRIVE_ID } from "../lib/consts";
 import { GDRIVE_INCREMENTAL_SYNC_DEBOUNCE_SEC } from "./config";
 import { newWebhookSignal } from "./signals";
 

--- a/connectors/src/connectors/google_drive/temporal/workflows.ts
+++ b/connectors/src/connectors/google_drive/temporal/workflows.ts
@@ -8,6 +8,7 @@ import {
   workflowInfo,
 } from "@temporalio/workflow";
 
+import { GOOGLE_DRIVE_USER_SPACE_VIRTUAL_DRIVE_ID } from "@connectors/connectors/google_drive/lib/config";
 import type * as activities from "@connectors/connectors/google_drive/temporal/activities";
 import type * as sync_status from "@connectors/lib/sync_status";
 import type { DataSourceConfig } from "@connectors/types/data_source_config";
@@ -166,13 +167,13 @@ export async function googleDriveIncrementalSync(
         );
       } while (nextPageToken);
     }
-    // Run incremental sync for "userland" (aka non shared drives, non "my drive").
+    // Run incremental sync for "userspace" (aka non shared drives, non "my drive").
     let nextPageToken: undefined | string = undefined;
     do {
       nextPageToken = await incrementalSync(
         connectorId,
         dataSourceConfig,
-        null,
+        GOOGLE_DRIVE_USER_SPACE_VIRTUAL_DRIVE_ID,
         false,
         startSyncTs,
         nextPageToken

--- a/connectors/src/lib/models/google_drive.ts
+++ b/connectors/src/lib/models/google_drive.ts
@@ -255,6 +255,10 @@ export class GoogleDriveSyncToken extends Model<
   declare id: CreationOptional<number>;
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
+  // The driveId is the Google Drive Id of the user's drive.
+  // For files not living in a specific drive, the driveId is "userland".
+  // We use a virtual drive ID instead of "null" because there might be other concepts of "spaces"
+  // and this would allow us to support them.
   declare driveId: string;
   declare syncToken: string;
   declare connectorId: ForeignKey<ConnectorModel["id"]>;

--- a/connectors/src/lib/models/google_drive.ts
+++ b/connectors/src/lib/models/google_drive.ts
@@ -256,7 +256,7 @@ export class GoogleDriveSyncToken extends Model<
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
   // The driveId is the Google Drive Id of the user's drive.
-  // For files not living in a specific drive, the driveId is "userland".
+  // For files not living in a specific drive, the driveId is "userspace".
   // We use a virtual drive ID instead of "null" because there might be other concepts of "spaces"
   // and this would allow us to support them.
   declare driveId: string;


### PR DESCRIPTION
## Description
Task is here:
https://github.com/dust-tt/dust/issues/5477

In order to add a "shared with me" view, we must first understand the following:
- These objects live in the "user land" (and not in a drive) of the authenticated user.
- They also live in the drive of the user sharing it.
- They are not in a "shared with me" folder on Gdrive, they just have a property that says `sharedWithMe=true`. That's only true for the top level objects, a sub folder of a "shared with me" folder does not have such attribute.
- We can't listen to webhooks of the drive where the object actually lives.
- We can't list changes of the drive where the file lives.

So, here is how we are proceeding:
- In the permissions view that shows the list of remote drives, we add a virtual folder "Shared with me".
- When listing child nodes, if the parent is `sharedWithMe`, we show folders with a `sharedWithMe=true` property.
- After that, folders exploration in our tree view stays as before. (note that "shared with me" is not selectable, you can only select folders that are in the "shared with me" view).
- Full sync stays the same.
- Incremental sync now also look for changes in "user land".


## What's not done yet
- Still need to not send a webhook subscription to the drive owning files in "shared with me".
- Either subscribe to "user land" webhooks or add a pulling mechanism, still TBD.
- Once folders form "sharedWithMe" are selected, they are display as top level folders, and not in a "shared with me" folder. Is that a problem @spolu ?

## Webhook research
The hard part is to know if we should subscribe to a drive webhooks.
Today, when a user select a file, we put the drive id of the file in a set, and at the end, we take all the drive ids from the set and subscribe to it.
The problem with "sharedWithMe" files is that they are hosted in someone else's drive, and we can't subscribe to it, but the Gdrive API does not provide any way to check for that. I suppose the only solution is to list "my drives" and look at the drive of the selected folders and check if they are in my list.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Just added some comment in the model file, no need to run any migration.
