### PR TITLE
enh: set maxToolUsePerRun to at least 3 for legacy agents

### DIFF
--- a/front/migrations/20240606_backfill_max_tools_use_per_run.sql
+++ b/front/migrations/20240606_backfill_max_tools_use_per_run.sql
@@ -1,0 +1,6 @@
+UPDATE
+    agent_configurations
+SET
+    "maxToolsUsePerRun" = 3
+WHERE
+    "maxToolsUsePerRun" < 3;


### PR DESCRIPTION
## Description

Legacy agents have a backfilled value for `maxToolsUsePerRun`. That's because we initially wanted to preserve their "strict" behaviour within the multi-actions code-path.

Instead, we decided to make them proper multi-action agents, so we want to use the same default value for `maxToolsUsePerRun`

## Risk

Not much, value isn't used outside of MA code. 
If people created MA assistants with `maxToolsUsePerRun < 3` then it will become 3 for those as well, but unlikely + not a big deal since it's just Dust team.


## Deploy Plan

apply migration (prodbox)