### PR TITLE
core: cross model interactions fixes for multi-actions

### DIFF
--- a/core/src/providers/anthropic.rs
+++ b/core/src/providers/anthropic.rs
@@ -297,6 +297,10 @@ impl FromStr for AnthropicToolChoice {
                 r#type: AnthropicToolChoiceType::Auto,
                 name: None,
             }),
+            "any" => Ok(AnthropicToolChoice {
+                r#type: AnthropicToolChoiceType::Any,
+                name: None,
+            }),
             "none" => Err(ParseError::with_message(
                 "function_call option `none` is not supported by Antrhopic",
             )),

--- a/core/src/providers/anthropic.rs
+++ b/core/src/providers/anthropic.rs
@@ -591,6 +591,19 @@ impl AnthropicLLM {
             .parse::<Uri>()?)
     }
 
+    fn placehodler_tool(&self) -> AnthropicTool {
+        AnthropicTool {
+            name: "dummy_do_not_use".to_string(),
+            description: Some("Dummy placeholder tool that does nothing. Do not use.".to_string()),
+            input_schema: Some(json!({
+                "type": "object",
+                "properties": {
+                    "dummy": {"type": "string", "description": "Do not use."}
+                },
+            })),
+        }
+    }
+
     async fn chat_completion(
         &self,
         system: Option<String>,
@@ -632,19 +645,7 @@ impl AnthropicLLM {
                     .any(|c| c.tool_use.is_some() || c.tool_result.is_some())
             }) {
                 // Add only if we have tool_use or tool_result in the messages
-                body["tools"] = json!(vec![AnthropicTool {
-                    name: "placeholder_do_not_use".to_string(),
-                    description: Some(
-                        "Dummy placeholder tool. Do not use, generate a response instead."
-                            .to_string()
-                    ),
-                    input_schema: Some(json!({
-                        "type": "object",
-                        "properties": {
-                            "dummy": {"type": "string", "description": "Do not use."}
-                        },
-                    })),
-                }]);
+                body["tools"] = json!(vec![self.placehodler_tool()]);
             }
         }
 
@@ -744,19 +745,7 @@ impl AnthropicLLM {
                     .any(|c| c.tool_use.is_some() || c.tool_result.is_some())
             }) {
                 // Add only if we have tool_use or tool_result in the messages
-                body["tools"] = json!(vec![AnthropicTool {
-                    name: "placeholder_do_not_use".to_string(),
-                    description: Some(
-                        "Dummy placeholder tool. Do not use, generate a response instead."
-                            .to_string()
-                    ),
-                    input_schema: Some(json!({
-                        "type": "object",
-                        "properties": {
-                            "dummy": {"type": "string", "description": "Do not use."}
-                        },
-                    })),
-                }]);
+                body["tools"] = json!(vec![self.placehodler_tool()]);
             }
         }
 

--- a/core/src/providers/anthropic.rs
+++ b/core/src/providers/anthropic.rs
@@ -6,6 +6,7 @@ use crate::providers::provider::{ModelError, ModelErrorRetryOptions, Provider, P
 use crate::providers::tiktoken::tiktoken::anthropic_base_singleton;
 use crate::run::Credentials;
 use crate::utils;
+use crate::utils::ParseError;
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use eventsource_client as es;
@@ -17,6 +18,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::fmt::{self, Display};
 use std::io::prelude::*;
+use std::str::FromStr;
 use std::time::Duration;
 use tokio::sync::mpsc::UnboundedSender;
 
@@ -270,6 +272,41 @@ impl TryFrom<&ChatMessage> for AnthropicChatMessage {
 }
 
 // Tools.
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[serde(rename_all = "lowercase")]
+pub enum AnthropicToolChoiceType {
+    Auto,
+    Any,
+    Tool,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+pub struct AnthropicToolChoice {
+    r#type: AnthropicToolChoiceType,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
+}
+
+impl FromStr for AnthropicToolChoice {
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "auto" => Ok(AnthropicToolChoice {
+                r#type: AnthropicToolChoiceType::Auto,
+                name: None,
+            }),
+            "none" => Err(ParseError::with_message(
+                "function_call option `none` is not supported by Antrhopic",
+            )),
+            _ => Ok(AnthropicToolChoice {
+                r#type: AnthropicToolChoiceType::Tool,
+                name: Some(s.to_string()),
+            }),
+        }
+    }
+}
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct AnthropicTool {
@@ -559,6 +596,7 @@ impl AnthropicLLM {
         system: Option<String>,
         messages: &Vec<AnthropicChatMessage>,
         tools: Vec<AnthropicTool>,
+        tool_choice: Option<AnthropicToolChoice>,
         temperature: f32,
         top_p: f32,
         stop_sequences: &Vec<String>,
@@ -584,6 +622,30 @@ impl AnthropicLLM {
 
         if !tools.is_empty() {
             body["tools"] = json!(tools);
+            if tool_choice.is_some() {
+                body["tool_choice"] = json!(tool_choice);
+            }
+        } else {
+            if messages.iter().any(|m| {
+                m.content
+                    .iter()
+                    .any(|c| c.tool_use.is_some() || c.tool_result.is_some())
+            }) {
+                // Add only if we have tool_use or tool_result in the messages
+                body["tools"] = json!(vec![AnthropicTool {
+                    name: "placeholder_do_not_use".to_string(),
+                    description: Some(
+                        "Dummy placeholder tool. Do not use, generate a response instead."
+                            .to_string()
+                    ),
+                    input_schema: Some(json!({
+                        "type": "object",
+                        "properties": {
+                            "dummy": {"type": "string", "description": "Do not use."}
+                        },
+                    })),
+                }]);
+            }
         }
 
         let mut headers = reqwest::header::HeaderMap::new();
@@ -644,6 +706,7 @@ impl AnthropicLLM {
         system: Option<String>,
         messages: &Vec<AnthropicChatMessage>,
         tools: Vec<AnthropicTool>,
+        tool_choice: Option<AnthropicToolChoice>,
         temperature: f32,
         top_p: f32,
         stop_sequences: &Vec<String>,
@@ -671,6 +734,30 @@ impl AnthropicLLM {
 
         if !tools.is_empty() {
             body["tools"] = json!(tools);
+            if tool_choice.is_some() {
+                body["tool_choice"] = json!(tool_choice);
+            }
+        } else {
+            if messages.iter().any(|m| {
+                m.content
+                    .iter()
+                    .any(|c| c.tool_use.is_some() || c.tool_result.is_some())
+            }) {
+                // Add only if we have tool_use or tool_result in the messages
+                body["tools"] = json!(vec![AnthropicTool {
+                    name: "placeholder_do_not_use".to_string(),
+                    description: Some(
+                        "Dummy placeholder tool. Do not use, generate a response instead."
+                            .to_string()
+                    ),
+                    input_schema: Some(json!({
+                        "type": "object",
+                        "properties": {
+                            "dummy": {"type": "string", "description": "Do not use."}
+                        },
+                    })),
+                }]);
+            }
         }
 
         let url = self.messages_uri()?.to_string();
@@ -1408,7 +1495,7 @@ impl LLM for AnthropicLLM {
         &self,
         messages: &Vec<ChatMessage>,
         functions: &Vec<ChatFunction>,
-        _function_call: Option<String>,
+        function_call: Option<String>,
         temperature: f32,
         top_p: Option<f32>,
         n: usize,
@@ -1475,12 +1562,18 @@ impl LLM for AnthropicLLM {
             .map(AnthropicTool::try_from)
             .collect::<Result<Vec<AnthropicTool>, _>>()?;
 
+        let tool_choice = match function_call.as_ref() {
+            Some(fc) => Some(AnthropicToolChoice::from_str(fc)?),
+            None => None,
+        };
+
         let c = match event_sender {
             Some(es) => {
                 self.streamed_chat_completion(
                     system,
                     &messages,
                     tools,
+                    tool_choice,
                     temperature,
                     match top_p {
                         Some(p) => p,
@@ -1500,6 +1593,7 @@ impl LLM for AnthropicLLM {
                     system,
                     &messages,
                     tools,
+                    tool_choice,
                     temperature,
                     match top_p {
                         Some(p) => p,

--- a/core/src/providers/mistral.rs
+++ b/core/src/providers/mistral.rs
@@ -208,7 +208,10 @@ impl TryFrom<&ChatMessage> for MistralChatMessage {
                 ),
                 None => None,
             },
-            tool_call_id: cm.function_call_id.map(|id| sanitize_tool_call_id(&id)),
+            tool_call_id: cm
+                .function_call_id
+                .as_ref()
+                .map(|id| sanitize_tool_call_id(id)),
         })
     }
 }
@@ -450,7 +453,9 @@ impl MistralAILLM {
                                 // that's fine).
                                 id: cm
                                     .tool_call_id
-                                    .map(|id| sanitize_tool_call_id(&id))
+                                    .as_ref()
+                                    .map(|id| sanitize_tool_call_id(id))
+                                    .clone()
                                     .unwrap_or_else(|| new_id()[0..9].to_string()),
                                 function: MistralToolCallFunction {
                                     name: cm

--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -108,7 +108,6 @@ pub enum OpenAIToolControl {
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 #[serde(untagged)]
-
 pub enum OpenAIToolChoice {
     OpenAIToolControl(OpenAIToolControl),
     OpenAIFunctionCall(OpenAIFunctionCall),


### PR DESCRIPTION
## Description

- Workaround for Anthropic when other tool uses are present in the conversation
- Sanitization of tool_call_id for Misral which requires 9 alphanumerical characters (but call id can come from somewhere else).

## Risk

Low

## Deploy Plan

- deploy `core`