### PR TITLE
enh: makes it possible to select pages in website datasource

### DIFF
--- a/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
+++ b/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
@@ -554,6 +554,17 @@ function FolderOrWebsiteTree({
   ) => void;
 }) {
   const [expanded, setExpanded] = useState<boolean>(false);
+  const selectedResources = currentConfig?.selectedResources ?? [];
+
+  const { parentsById, setParentsById } = useParentResourcesById({
+    owner,
+    dataSource,
+    selectedResources,
+  });
+
+  const selectedParents = [
+    ...new Set(Object.values(parentsById).flatMap((c) => [...c])),
+  ];
 
   return (
     <Tree.Item
@@ -573,6 +584,7 @@ function FolderOrWebsiteTree({
             currentConfig.selectedResources?.length > 0
           : false,
         onChange: (checked) => {
+          setParentsById({});
           onSelectChange(dataSource, checked);
         },
       }}
@@ -583,10 +595,20 @@ function FolderOrWebsiteTree({
           owner={owner}
           dataSource={dataSource}
           parentIsSelected={currentConfig?.isSelectAll ?? false}
-          onSelectChange={(resource, checked) => {
-            onSelectChange(dataSource, checked, resource);
+          selectedParents={selectedParents}
+          onSelectChange={(resource, parents, selected) => {
+            setParentsById((parentsById) => {
+              const newParentsById = { ...parentsById };
+              if (selected) {
+                newParentsById[resource.internalId] = new Set(parents);
+              } else {
+                delete newParentsById[resource.internalId];
+              }
+              return newParentsById;
+            });
+            onSelectChange(dataSource, selected, resource);
           }}
-          selectedResources={currentConfig?.selectedResources ?? []}
+          selectedResources={selectedResources}
         />
       )}
     </Tree.Item>

--- a/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
+++ b/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
@@ -1,5 +1,4 @@
 import {
-  Checkbox,
   CloudArrowDownIcon,
   CloudArrowLeftRightIcon,
   FolderIcon,
@@ -20,9 +19,6 @@ import { assertNever } from "@dust-tt/types";
 import { Transition } from "@headlessui/react";
 import * as React from "react";
 import { useCallback, useEffect, useState } from "react";
-import { PermissionTreeChildren } from "@app/components/ConnectorPermissionsTree";
-import { useConnectorPermissions } from "@app/lib/swr";
-import { DataSourceSelectorTree } from "./DataSourceSelectorTree";
 
 import type {
   AssistantBuilderDataSourceConfiguration,
@@ -33,6 +29,8 @@ import { orderDatasourceByImportance } from "@app/lib/assistant";
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 import { subFilter } from "@app/lib/utils";
 import type { GetContentNodeParentsResponseBody } from "@app/pages/api/w/[wId]/data_sources/[name]/managed/parents";
+
+import { DataSourceSelectorTree } from "./DataSourceSelectorTree";
 
 export const CONNECTOR_PROVIDER_TO_RESOURCE_NAME: Record<
   ConnectorProvider,

--- a/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
+++ b/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
@@ -445,7 +445,7 @@ function DataSourceResourceSelector({
                 }
                 parentsById={parentsById}
                 onSelectChange={(node, parents, selected) => {
-                  setParentsById(parentsById => {
+                  setParentsById((parentsById) => {
                     const newParentsById = { ...parentsById };
                     if (selected) {
                       newParentsById[node.internalId] = new Set(parents);

--- a/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
+++ b/front/components/assistant_builder/AssistantBuilderDataSourceModal.tsx
@@ -29,7 +29,7 @@ import { orderDatasourceByImportance } from "@app/lib/assistant";
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 import { subFilter } from "@app/lib/utils";
 
-import { DataSourceSelectorTree } from "./DataSourceSelectorTree";
+import { WebsiteDataSourceSelectorTree } from "./WebsiteDataSourceSelectorTree";
 
 export const CONNECTOR_PROVIDER_TO_RESOURCE_NAME: Record<
   ConnectorProvider,
@@ -445,9 +445,15 @@ function DataSourceResourceSelector({
                 }
                 parentsById={parentsById}
                 onSelectChange={(node, parents, selected) => {
-                  const newParentsById = { ...parentsById };
-                  newParentsById[node.internalId] = new Set(parents);
-                  setParentsById(newParentsById);
+                  setParentsById(parentsById => {
+                    const newParentsById = { ...parentsById };
+                    if (selected) {
+                      newParentsById[node.internalId] = new Set(parents);
+                    } else {
+                      delete newParentsById[node.internalId];
+                    }
+                    return parentsById;
+                  });
                   onSelectChange(node, selected);
                 }}
                 fullySelected={isSelectAll}
@@ -572,7 +578,7 @@ function FolderOrWebsiteTree({
       }}
     >
       {type === "website" && (
-        <DataSourceSelectorTree
+        <WebsiteDataSourceSelectorTree
           showExpand
           owner={owner}
           dataSource={dataSource}

--- a/front/components/assistant_builder/DataSourceSelectorTree.tsx
+++ b/front/components/assistant_builder/DataSourceSelectorTree.tsx
@@ -1,13 +1,12 @@
-import { useConnectorPermissions } from "@app/lib/swr";
-import { NextAppRouterHandler } from "@auth0/nextjs-auth0";
 import { Tree } from "@dust-tt/sparkle";
-import {
-  ConnectorPermission,
+import type {
   ContentNode,
   DataSourceType,
   WorkspaceType,
 } from "@dust-tt/types";
 import { useEffect, useState } from "react";
+
+import { useConnectorPermissions } from "@app/lib/swr";
 
 export function DataSourceSelectorTreeChildren({
   owner,
@@ -55,11 +54,11 @@ export function DataSourceSelectorTreeChildren({
           onChange(r, false);
         });
     }
-  }, [resources, parentIsSelected]);
+  }, [resources, parentIsSelected, selectedValues, onChange]);
 
   return (
     <Tree isLoading={isResourcesLoading}>
-      {resources.map((r, i) => {
+      {resources.map((r) => {
         const isSelected = Boolean(
           selectedValues.find((value) => value.internalId === r.internalId)
         );

--- a/front/components/assistant_builder/DataSourceSelectorTree.tsx
+++ b/front/components/assistant_builder/DataSourceSelectorTree.tsx
@@ -1,0 +1,138 @@
+import { useConnectorPermissions } from "@app/lib/swr";
+import { NextAppRouterHandler } from "@auth0/nextjs-auth0";
+import { Tree } from "@dust-tt/sparkle";
+import {
+  ConnectorPermission,
+  ContentNode,
+  DataSourceType,
+  WorkspaceType,
+} from "@dust-tt/types";
+import { useEffect, useState } from "react";
+
+export function DataSourceSelectorTreeChildren({
+  owner,
+  dataSource,
+  parentId,
+  parentIsSelected,
+  showExpand,
+  selectedValues,
+  onChange,
+}: {
+  owner: WorkspaceType;
+  dataSource: DataSourceType;
+  parentId: string | null;
+  parentIsSelected?: boolean;
+  showExpand?: boolean;
+  selectedValues: ContentNode[];
+  onChange: (resource: ContentNode, checked: boolean) => void;
+}) {
+  const { resources, isResourcesLoading, isResourcesError } =
+    useConnectorPermissions({
+      owner,
+      dataSource,
+      parentId,
+      filterPermission: "read",
+    });
+
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+
+  if (isResourcesError) {
+    return (
+      <div className="text-warning text-sm">
+        Failed to retrieve permissions likely due to a revoked authorization.
+      </div>
+    );
+  }
+
+  useEffect(() => {
+    if (parentIsSelected) {
+      // Unselected previously selected children
+      resources
+        .filter((r) =>
+          selectedValues.find((value) => value.internalId === r.internalId)
+        )
+        .forEach((r) => {
+          onChange(r, false);
+        });
+    }
+  }, [resources, parentIsSelected]);
+
+  return (
+    <Tree isLoading={isResourcesLoading}>
+      {resources.map((r, i) => {
+        const isSelected = Boolean(
+          selectedValues.find((value) => value.internalId === r.internalId)
+        );
+        return (
+          <Tree.Item
+            key={r.internalId}
+            collapsed={!expanded[r.internalId]}
+            onChevronClick={() => {
+              setExpanded((prev) => ({
+                ...prev,
+                [r.internalId]: prev[r.internalId] ? false : true,
+              }));
+            }}
+            type={r.expandable ? "node" : "leaf"}
+            label={r.title}
+            variant={r.type}
+            className="whitespace-nowrap"
+            checkbox={
+              r.preventSelection !== true
+                ? {
+                    disabled: parentIsSelected,
+                    checked: parentIsSelected || isSelected,
+                    onChange: (checked) => {
+                      onChange(r, checked);
+                    },
+                  }
+                : undefined
+            }
+          >
+            {expanded[r.internalId] && (
+              <DataSourceSelectorTreeChildren
+                owner={owner}
+                dataSource={dataSource}
+                parentId={r.internalId}
+                showExpand={showExpand}
+                parentIsSelected={parentIsSelected || isSelected}
+                selectedValues={selectedValues}
+                onChange={onChange}
+              />
+            )}
+          </Tree.Item>
+        );
+      })}
+    </Tree>
+  );
+}
+
+export function DataSourceSelectorTree({
+  owner,
+  dataSource,
+  showExpand,
+  parentIsSelected,
+  selectedValues,
+  onChange,
+}: {
+  owner: WorkspaceType;
+  dataSource: DataSourceType;
+  showExpand?: boolean;
+  parentIsSelected?: boolean;
+  selectedValues: ContentNode[];
+  onChange: (resource: ContentNode, checked: boolean) => void;
+}) {
+  return (
+    <div className="overflow-x-auto">
+      <DataSourceSelectorTreeChildren
+        owner={owner}
+        dataSource={dataSource}
+        parentId={null}
+        showExpand={showExpand}
+        parentIsSelected={parentIsSelected}
+        selectedValues={selectedValues}
+        onChange={onChange}
+      />
+    </div>
+  );
+}

--- a/front/components/assistant_builder/WebsiteDataSourceSelectorTree.tsx
+++ b/front/components/assistant_builder/WebsiteDataSourceSelectorTree.tsx
@@ -6,7 +6,6 @@ import type {
 } from "@dust-tt/types";
 import { useEffect, useState } from "react";
 
-import { useParentResourcesById } from "@app/hooks/useParentResourcesById";
 import { useConnectorPermissions } from "@app/lib/swr";
 
 export function WebsiteDataSourceSelectorTreeChildren({
@@ -127,6 +126,7 @@ export function WebsiteDataSourceSelectorTree({
   dataSource,
   showExpand,
   parentIsSelected,
+  selectedParents,
   selectedResources,
   onSelectChange,
 }: {
@@ -134,21 +134,14 @@ export function WebsiteDataSourceSelectorTree({
   dataSource: DataSourceType;
   showExpand?: boolean;
   parentIsSelected?: boolean;
+  selectedParents: string[];
   selectedResources: ContentNode[];
-  onSelectChange: (resource: ContentNode, checked: boolean) => void;
+  onSelectChange: (
+    resource: ContentNode,
+    parents: string[],
+    checked: boolean
+  ) => void;
 }) {
-  const { parentsById, setParentsById } = useParentResourcesById({
-    owner,
-    dataSource,
-    selectedResources,
-  });
-
-  console.log("parentsById", parentsById);
-
-  const selectedParents = [
-    ...new Set(Object.values(parentsById).flatMap((c) => [...c])),
-  ];
-
   return (
     <div className="overflow-x-auto">
       <WebsiteDataSourceSelectorTreeChildren
@@ -161,16 +154,7 @@ export function WebsiteDataSourceSelectorTree({
         selectedResources={selectedResources}
         selectedParents={selectedParents}
         onSelectChange={(resource, parents, selected) => {
-          setParentsById((parentsById) => {
-            const newParentsById = { ...parentsById };
-            if (selected) {
-              newParentsById[resource.internalId] = new Set(parents);
-            } else {
-              delete newParentsById[resource.internalId];
-            }
-            return newParentsById;
-          });
-          onSelectChange(resource, selected);
+          onSelectChange(resource, parents, selected);
         }}
       />
     </div>

--- a/front/components/assistant_builder/WebsiteDataSourceSelectorTree.tsx
+++ b/front/components/assistant_builder/WebsiteDataSourceSelectorTree.tsx
@@ -143,7 +143,7 @@ export function WebsiteDataSourceSelectorTree({
     selectedResources,
   });
 
-  console.log('parentsById', parentsById);
+  console.log("parentsById", parentsById);
 
   const selectedParents = [
     ...new Set(Object.values(parentsById).flatMap((c) => [...c])),
@@ -161,7 +161,7 @@ export function WebsiteDataSourceSelectorTree({
         selectedResources={selectedResources}
         selectedParents={selectedParents}
         onSelectChange={(resource, parents, selected) => {
-          setParentsById(parentsById => {
+          setParentsById((parentsById) => {
             const newParentsById = { ...parentsById };
             if (selected) {
               newParentsById[resource.internalId] = new Set(parents);

--- a/front/components/assistant_builder/WebsiteDataSourceSelectorTree.tsx
+++ b/front/components/assistant_builder/WebsiteDataSourceSelectorTree.tsx
@@ -9,7 +9,7 @@ import { useEffect, useState } from "react";
 import { useParentResourcesById } from "@app/hooks/useParentResourcesById";
 import { useConnectorPermissions } from "@app/lib/swr";
 
-export function DataSourceSelectorTreeChildren({
+export function WebsiteDataSourceSelectorTreeChildren({
   owner,
   dataSource,
   parentId,
@@ -103,7 +103,7 @@ export function DataSourceSelectorTreeChildren({
             }
           >
             {expanded[r.internalId] && (
-              <DataSourceSelectorTreeChildren
+              <WebsiteDataSourceSelectorTreeChildren
                 owner={owner}
                 dataSource={dataSource}
                 parentId={r.internalId}
@@ -122,7 +122,7 @@ export function DataSourceSelectorTreeChildren({
   );
 }
 
-export function DataSourceSelectorTree({
+export function WebsiteDataSourceSelectorTree({
   owner,
   dataSource,
   showExpand,
@@ -142,13 +142,16 @@ export function DataSourceSelectorTree({
     dataSource,
     selectedResources,
   });
+
+  console.log('parentsById', parentsById);
+
   const selectedParents = [
     ...new Set(Object.values(parentsById).flatMap((c) => [...c])),
   ];
 
   return (
     <div className="overflow-x-auto">
-      <DataSourceSelectorTreeChildren
+      <WebsiteDataSourceSelectorTreeChildren
         owner={owner}
         dataSource={dataSource}
         parentId={null}
@@ -158,13 +161,15 @@ export function DataSourceSelectorTree({
         selectedResources={selectedResources}
         selectedParents={selectedParents}
         onSelectChange={(resource, parents, selected) => {
-          const newParentsById = { ...parentsById };
-          if (selected) {
-            newParentsById[resource.internalId] = new Set(parents);
-          } else {
-            delete newParentsById[resource.internalId];
-          }
-          setParentsById(newParentsById);
+          setParentsById(parentsById => {
+            const newParentsById = { ...parentsById };
+            if (selected) {
+              newParentsById[resource.internalId] = new Set(parents);
+            } else {
+              delete newParentsById[resource.internalId];
+            }
+            return newParentsById;
+          });
           onSelectChange(resource, selected);
         }}
       />

--- a/front/hooks/useParentResourcesById.ts
+++ b/front/hooks/useParentResourcesById.ts
@@ -1,0 +1,75 @@
+import { GetContentNodeParentsResponseBody } from "@app/pages/api/w/[wId]/data_sources/[name]/managed/parents";
+import { ContentNode, DataSourceType, WorkspaceType } from "@dust-tt/types";
+import { useCallback, useEffect, useState } from "react";
+
+export function useParentResourcesById({
+  owner,
+  dataSource,
+  selectedResources,
+}: {
+  owner: WorkspaceType;
+  dataSource: DataSourceType | null;
+  selectedResources: ContentNode[];
+}) {
+  const [parentsById, setParentsById] = useState<Record<string, Set<string>>>(
+    {}
+  );
+  const [parentsAreLoading, setParentsAreLoading] = useState(false);
+  const [parentsAreError, setParentsAreError] = useState(false);
+
+  const fetchParents = useCallback(async () => {
+    setParentsAreLoading(true);
+    try {
+      const res = await fetch(
+        `/api/w/${owner.sId}/data_sources/${encodeURIComponent(
+          dataSource?.name || ""
+        )}/managed/parents`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            internalIds: selectedResources.map((resource) => {
+              return resource.internalId;
+            }),
+          }),
+        }
+      );
+      if (!res.ok) {
+        throw new Error("Failed to fetch parents");
+      }
+      const json: GetContentNodeParentsResponseBody = await res.json();
+      setParentsById(
+        json.nodes.reduce((acc, r) => {
+          acc[r.internalId] = new Set(r.parents);
+          return acc;
+        }, {} as Record<string, Set<string>>)
+      );
+    } catch (e) {
+      setParentsAreError(true);
+    } finally {
+      setParentsAreLoading(false);
+    }
+  }, [owner, dataSource?.name, selectedResources]);
+
+  const hasParentsById = Object.keys(parentsById || {}).length > 0;
+  const hasSelectedResources = selectedResources.length > 0;
+
+  useEffect(() => {
+    if (parentsAreLoading || parentsAreError) {
+      return;
+    }
+    if (!hasParentsById && hasSelectedResources) {
+      fetchParents().catch(console.error);
+    }
+  }, [
+    hasParentsById,
+    hasSelectedResources,
+    fetchParents,
+    parentsAreLoading,
+    parentsAreError,
+  ]);
+
+  return { parentsById, setParentsById, parentsAreLoading, parentsAreError };
+}


### PR DESCRIPTION
https://github.com/dust-tt/tasks/issues/798 

## Description

When creating an assistant, it's now possible to select a set of pages from a web data source instead of searching into the whole site.

Factorized some code between folder/pages and managed datasources (`getUpdatedConfigurations`, `useParentResourcesById`). Same UI is used for folders, although it's not possible to select something in folder. Ideally we should also refactor the DataSourceResourceSelectorTree to use the same sparkle components, to get something more consistent.

## Risk

Code is UI only, can be rollbacked easily. This has no impact on existing assistants, which will still look into the whole website.

## Deploy Plan

Deploy `front`
