### PR TITLE
Webcrawler - finetuning 

### DIFF
--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -68,6 +68,7 @@ export async function crawlWebsiteByConnectorId(connectorId: ModelId) {
 
   const crawler = new CheerioCrawler(
     {
+      navigationTimeoutSecs: 10,
       preNavigationHooks: [
         async (crawlingContext) => {
           const { address, family } = await getIpAddressForUrl(

--- a/connectors/src/connectors/webcrawler/temporal/worker.ts
+++ b/connectors/src/connectors/webcrawler/temporal/worker.ts
@@ -21,7 +21,7 @@ export async function runWebCrawlerWorker() {
       connection,
       reuseV8Context: true,
       namespace,
-      maxConcurrentActivityTaskExecutions: 3,
+      maxConcurrentActivityTaskExecutions: 6,
       maxCachedWorkflows: TEMPORAL_MAXED_CACHED_WORKFLOWS,
       interceptors: {
         activityInbound: [


### PR DESCRIPTION
## Description

This PR does 2 things:
- Increase the activity count for updating websites from 3 to 6 because some websites stay in the queue for more than 1 hour and endup being "re-scheduled" by the cronjob, leading to workflow failure. A better workaround needs to be put in place but for now, we need to stop the monitor
- Some websites crawling take a very long time because we timeout a lot on HTTP requests, but we only timeout after 30 seconds. This PR changes that timeout to 10 seconds.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
