### PR TITLE
Webcrawler - mark websites as crawled at the workflow level

### DIFF
--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -38,6 +38,24 @@ import { WebCrawlerConfigurationResource } from "@connectors/resources/webcrawle
 
 const CONCURRENCY = 4;
 
+export async function markAsCrawled(connectorId: ModelId) {
+  const connector = await ConnectorResource.fetchById(connectorId);
+  if (!connector) {
+    throw new Error(`Connector ${connectorId} not found.`);
+  }
+
+  const webCrawlerConfig =
+    await WebCrawlerConfigurationResource.fetchByConnectorId(connectorId);
+
+  if (!webCrawlerConfig) {
+    throw new Error(`Webcrawler configuration not found for connector.`);
+  }
+
+  // Immediately marking the config as crawled to avoid having the scheduler seeing it as a candidate for crawling
+  // in case of the crawling takes too long or fails.
+  await webCrawlerConfig.markedAsCrawled();
+}
+
 export async function crawlWebsiteByConnectorId(connectorId: ModelId) {
   const connector = await ConnectorResource.fetchById(connectorId);
   if (!connector) {

--- a/connectors/src/connectors/webcrawler/temporal/workflows.ts
+++ b/connectors/src/connectors/webcrawler/temporal/workflows.ts
@@ -27,7 +27,7 @@ const { crawlWebsiteByConnectorId, webCrawlerGarbageCollector } =
     },
   });
 
-const { getConnectorIdsForWebsitesToCrawl } = proxyActivities<
+const { getConnectorIdsForWebsitesToCrawl, markAsCrawled } = proxyActivities<
   typeof activities
 >({
   startToCloseTimeout: "2 minutes",
@@ -51,6 +51,9 @@ export async function crawlWebsiteSchedulerWorkflow() {
   const connectorIds = await getConnectorIdsForWebsitesToCrawl();
 
   for (const connectorId of connectorIds) {
+    // We mark the website as crawled before starting the workflow to avoid
+    // starting the same workflow in the next run of the scheduler.
+    await markAsCrawled(connectorId);
     // Start a workflow to crawl the website but don't wait for it to complete.
     await startChild(crawlWebsiteWorkflow, {
       workflowId: crawlWebsiteWorkflowId(connectorId),


### PR DESCRIPTION
## Description

The webcrawler scheduler schedules sub workflows without awaiting for their completion, leading to re-scheduling when there are too many in the queue that can't be processed before the next iteration of the scheduler, which in turns lead to workflow failure for the scheduler itself.

By marking a websites `lastCrawledAt=now()` at scheduling time, we avoid that issue.
Please note that the field was updated at the beginning of the crawling already, for the same reason, but since we have more and more websites awaiting for a worker to pick them up, we need to do it even earlier.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
