### PR TITLE
[New conversation] Mention assistant even if inputBar not empty

### DIFF
--- a/front/components/assistant/conversation/input_bar/editor/useCustomEditor.tsx
+++ b/front/components/assistant/conversation/input_bar/editor/useCustomEditor.tsx
@@ -60,9 +60,13 @@ const useEditorService = (editor: Editor | null) => {
     return {
       // Insert mention helper function
       insertMention: ({ id, label }: { id: string; label: string }) => {
+        const shouldAddSpaceBeforeMention =
+          !editor?.isEmpty &&
+          editor?.getText()[editor?.getText().length - 1] !== " ";
         editor
           ?.chain()
           .focus()
+          .insertContent(shouldAddSpaceBeforeMention ? " " : "") // Add an extra space before the mention.
           .insertContent({
             type: "mention",
             attrs: { id, label },


### PR DESCRIPTION
Description
---
Previous behaviour: when clicking on an assistant name, if the inputbar wasn't empty (or with only one mention), it would not mention the assistant.

This PR fixes this behaviour, and also supports multiple assistants

Risk
---
Limited, tested well locally

Deploy Plan
---
Front
