### PR TITLE
core: function_call any support

### DIFF
--- a/core/src/providers/google_ai_studio.rs
+++ b/core/src/providers/google_ai_studio.rs
@@ -518,6 +518,10 @@ impl LLM for GoogleAiStudioLLM {
                     mode: GoogleAIStudioTooConfigMode::None,
                     allowed_function_names: None,
                 },
+                "any" => GoogleAIStudioFunctionCallingConfig {
+                    mode: GoogleAIStudioTooConfigMode::Any,
+                    allowed_function_names: None,
+                },
                 _ => GoogleAIStudioFunctionCallingConfig {
                     mode: GoogleAIStudioTooConfigMode::Any,
                     allowed_function_names: Some(vec![fc.clone()]),

--- a/core/src/providers/mistral.rs
+++ b/core/src/providers/mistral.rs
@@ -1009,6 +1009,7 @@ impl LLM for MistralAILLM {
                 let choice = match fc.as_str() {
                     "auto" => MistralToolChoice::Auto,
                     "none" => MistralToolChoice::None,
+                    "any" => MistralToolChoice::Any,
                     // This string is validated in the block to match at least one function.
                     // Mistral semantic of `any` is to force the model to make a function call (but
                     // can be any of the functions passed). The two semantics only match if there

--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -103,6 +103,7 @@ pub struct OpenAIFunctionCall {
 #[serde(rename_all = "lowercase")]
 pub enum OpenAIToolControl {
     Auto,
+    Required,
     None,
 }
 
@@ -132,6 +133,9 @@ impl FromStr for OpenAIToolChoice {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "auto" => Ok(OpenAIToolChoice::OpenAIToolControl(OpenAIToolControl::Auto)),
+            "any" => Ok(OpenAIToolChoice::OpenAIToolControl(
+                OpenAIToolControl::Required,
+            )),
             "none" => Ok(OpenAIToolChoice::OpenAIToolControl(OpenAIToolControl::None)),
             _ => {
                 let function = OpenAIFunctionCall {

--- a/docs/src/pages/core-blocks.mdx
+++ b/docs/src/pages/core-blocks.mdx
@@ -218,11 +218,8 @@ documentation](https://keats.github.io/tera/docs/#templates) for more details.
   <Property name="function_call" type="string">
     If `functions_code` returns a list of functions specifications,
     `function_call` lets you influence how the model will decide whether to use
-    a function or not. Possible values are `auto`, `none` or one of your
-    functions' name (forcing the call of that function). See [OpenAI's function
-    calling guide](https://platform.openai.com/docs/guides/gpt/function-calling)
-    for more details. Only available for selected OpenAI's models. Conversely to
-    OpenAI's API we take the function name directly instead of an object.
+    a function or not. Possible values are `auto`, `none`, `any` or one of your
+    functions' name (forcing the call of that function).
   </Property>
 </Properties>
 


### PR DESCRIPTION
## Description

Add official support for `any` as function_call (now supported by everyone including OpenAI)

## Risk

None

## Deploy Plan

- deploy `core`