### PR TITLE
Add CLI to restart all Gdrive-incrementalSync workflow.

### DIFF
--- a/connectors/src/lib/cli.ts
+++ b/connectors/src/lib/cli.ts
@@ -763,6 +763,7 @@ export const google_drive = async ({
         where: {
           type: "google_drive",
           errorType: null,
+          pausedAt: null,
         },
       });
       for (const connector of connectors) {

--- a/connectors/src/lib/cli.ts
+++ b/connectors/src/lib/cli.ts
@@ -53,6 +53,7 @@ import {
   getDocumentId,
   getDriveClient,
 } from "@connectors/connectors/google_drive/temporal/utils";
+import { googleDriveIncrementalSyncWorkflowId } from "@connectors/connectors/google_drive/temporal/workflows";
 import {
   fetchIntercomConversation,
   fetchIntercomConversationsForDay,
@@ -84,6 +85,7 @@ import { nango_client } from "@connectors/lib/nango_client";
 import {
   getTemporalClient,
   terminateAllWorkflowsForConnectorId,
+  terminateWorkflow,
 } from "@connectors/lib/temporal";
 import { default as topLogger } from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
@@ -756,6 +758,23 @@ export const google_drive = async ({
       );
       return { success: true };
     }
+    case "restart-all-incremental-sync-workflows": {
+      const connectors = await ConnectorModel.findAll({
+        where: {
+          type: "google_drive",
+          errorType: null,
+        },
+      });
+      for (const connector of connectors) {
+        const workflowId = googleDriveIncrementalSyncWorkflowId(connector.id);
+        await terminateWorkflow(workflowId);
+        await throwOnError(
+          launchGoogleDriveIncrementalSyncWorkflow(connector.id)
+        );
+      }
+      return { success: true };
+    }
+
     case "skip-file": {
       if (!args.wId) {
         throw new Error("Missing --wId argument");

--- a/connectors/src/lib/temporal.ts
+++ b/connectors/src/lib/temporal.ts
@@ -112,6 +112,20 @@ export async function cancelWorkflow(workflowId: string) {
   return false;
 }
 
+export async function terminateWorkflow(workflowId: string) {
+  const client = await getTemporalClient();
+  try {
+    const workflowHandle = client.workflow.getHandle(workflowId);
+    await workflowHandle.terminate();
+    return true;
+  } catch (e) {
+    if (!(e instanceof WorkflowNotFoundError)) {
+      throw e;
+    }
+  }
+  return false;
+}
+
 export async function terminateAllWorkflowsForConnectorId(
   connectorId: ModelId
 ) {

--- a/types/src/connectors/admin/cli.ts
+++ b/types/src/connectors/admin/cli.ts
@@ -51,6 +51,7 @@ export const GoogleDriveCommandSchema = t.type({
     t.literal("check-file"),
     t.literal("restart-google-webhooks"),
     t.literal("start-incremental-sync"),
+    t.literal("restart-all-incremental-sync-workflows"),
     t.literal("skip-file"),
     t.literal("register-webhook"),
     t.literal("register-all-webhooks"),


### PR DESCRIPTION
## Description
Add CLI to restart all Gdrive-incrementalSync workflow.
This is needed  in 2 cases:
- When we change the code of the incremental sync workflows and have a lot of "non determinism errors".
- Had some issues processing webhooks and need to trigger the incremental sync for everyone.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
