### PR TITLE
[front] - chore(assistant): disable assistants using disabled providers

### DIFF
--- a/front/components/assistant/AssistantBrowser.tsx
+++ b/front/components/assistant/AssistantBrowser.tsx
@@ -15,6 +15,7 @@ import type {
   LightAgentConfigurationType,
   WorkspaceType,
 } from "@dust-tt/types";
+import { MODEL_PROVIDER_IDS } from "@dust-tt/types";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import React, { useMemo, useState } from "react";
@@ -50,10 +51,15 @@ export function AssistantBrowser({
   const router = useRouter();
   const [assistantSearch, setAssistantSearch] = useState<string>("");
 
+  const whiteListedProviders = useMemo(() => {
+    return owner.whiteListedProviders ?? MODEL_PROVIDER_IDS;
+  }, [owner.whiteListedProviders]);
+
   const agentsByTab = useMemo(() => {
     const filteredAgents: LightAgentConfigurationType[] = agents.filter(
       (a) =>
         a.status === "active" &&
+        whiteListedProviders.includes(a.model.providerId) &&
         // Filters on search query
         (assistantSearch.trim() === "" ||
           subFilter(assistantSearch.toLowerCase(), a.name.toLowerCase()))
@@ -73,7 +79,7 @@ export function AssistantBrowser({
         )
         .slice(0, 0), // Placeholder -- most popular agents are not implemented yet
     };
-  }, [assistantSearch, loadingStatus, agents]);
+  }, [agents, loadingStatus, whiteListedProviders, assistantSearch]);
 
   const visibleTabs = useMemo(() => {
     return ALL_AGENTS_TABS.filter((tab) => agentsByTab[tab.id].length > 0);

--- a/front/components/assistant/AssistantBrowser.tsx
+++ b/front/components/assistant/AssistantBrowser.tsx
@@ -51,11 +51,9 @@ export function AssistantBrowser({
   const router = useRouter();
   const [assistantSearch, setAssistantSearch] = useState<string>("");
 
-  const whiteListedProviders = useMemo(() => {
-    return owner.whiteListedProviders ?? MODEL_PROVIDER_IDS;
-  }, [owner.whiteListedProviders]);
-
   const agentsByTab = useMemo(() => {
+    const whiteListedProviders =
+      owner.whiteListedProviders ?? MODEL_PROVIDER_IDS;
     const filteredAgents: LightAgentConfigurationType[] = agents.filter(
       (a) =>
         a.status === "active" &&
@@ -79,7 +77,7 @@ export function AssistantBrowser({
         )
         .slice(0, 0), // Placeholder -- most popular agents are not implemented yet
     };
-  }, [agents, loadingStatus, whiteListedProviders, assistantSearch]);
+  }, [agents, loadingStatus, owner.whiteListedProviders, assistantSearch]);
 
   const visibleTabs = useMemo(() => {
     return ALL_AGENTS_TABS.filter((tab) => agentsByTab[tab.id].length > 0);

--- a/front/hooks/useParentResourcesById.ts
+++ b/front/hooks/useParentResourcesById.ts
@@ -1,6 +1,11 @@
-import { GetContentNodeParentsResponseBody } from "@app/pages/api/w/[wId]/data_sources/[name]/managed/parents";
-import { ContentNode, DataSourceType, WorkspaceType } from "@dust-tt/types";
+import type {
+  ContentNode,
+  DataSourceType,
+  WorkspaceType,
+} from "@dust-tt/types";
 import { useCallback, useEffect, useState } from "react";
+
+import type { GetContentNodeParentsResponseBody } from "@app/pages/api/w/[wId]/data_sources/[name]/managed/parents";
 
 export function useParentResourcesById({
   owner,

--- a/front/lib/resources/template_resource.ts
+++ b/front/lib/resources/template_resource.ts
@@ -132,6 +132,7 @@ export class TemplateResource extends BaseResource<TemplateModel> {
       sId: this.sId,
       tags: this.tags,
       visibility: this.visibility,
+      presetProviderId: this.presetProviderId,
     };
   }
 

--- a/front/pages/w/[wId]/assistant/gallery.tsx
+++ b/front/pages/w/[wId]/assistant/gallery.tsx
@@ -16,7 +16,7 @@ import type {
   UserType,
   WorkspaceType,
 } from "@dust-tt/types";
-import { assertNever } from "@dust-tt/types";
+import { assertNever, MODEL_PROVIDER_IDS } from "@dust-tt/types";
 import type { InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 import type { ComponentType } from "react";
@@ -83,11 +83,19 @@ export default function AssistantsGallery({
 
   const [assistantSearch, setAssistantSearch] = useState<string>("");
 
+  const filteredAgentConfigurations = useMemo(() => {
+    const whiteListedProviders =
+      owner.whiteListedProviders ?? MODEL_PROVIDER_IDS;
+    return agentConfigurations.filter((a) =>
+      whiteListedProviders.includes(a.model.providerId)
+    );
+  }, [agentConfigurations, owner.whiteListedProviders]);
+
   let agentsToDisplay: LightAgentConfigurationType[] = [];
 
   switch (orderBy) {
     case "name": {
-      agentsToDisplay = agentConfigurations
+      agentsToDisplay = filteredAgentConfigurations
         .filter((a) => {
           return (
             subFilter(assistantSearch.toLowerCase(), a.name.toLowerCase()) &&
@@ -100,7 +108,7 @@ export default function AssistantsGallery({
       break;
     }
     case "usage": {
-      agentsToDisplay = agentConfigurations.filter((a) => {
+      agentsToDisplay = filteredAgentConfigurations.filter((a) => {
         return (
           subFilter(assistantSearch.toLowerCase(), a.name.toLowerCase()) &&
           a.status === "active"

--- a/front/pages/w/[wId]/builder/assistants/create.tsx
+++ b/front/pages/w/[wId]/builder/assistants/create.tsx
@@ -11,10 +11,9 @@ import type {
   SubscriptionType,
   TemplateTagCodeType,
   TemplateTagsType,
-  WorkspaceType} from "@dust-tt/types";
-import {
-  MODEL_PROVIDER_IDS
+  WorkspaceType,
 } from "@dust-tt/types";
+import { MODEL_PROVIDER_IDS } from "@dust-tt/types";
 import { isTemplateTagCodeArray, TEMPLATES_TAGS_CONFIG } from "@dust-tt/types";
 import _ from "lodash";
 import type { InferGetServerSidePropsType } from "next";

--- a/front/pages/w/[wId]/builder/assistants/create.tsx
+++ b/front/pages/w/[wId]/builder/assistants/create.tsx
@@ -11,14 +11,16 @@ import type {
   SubscriptionType,
   TemplateTagCodeType,
   TemplateTagsType,
-  WorkspaceType,
+  WorkspaceType} from "@dust-tt/types";
+import {
+  MODEL_PROVIDER_IDS
 } from "@dust-tt/types";
 import { isTemplateTagCodeArray, TEMPLATES_TAGS_CONFIG } from "@dust-tt/types";
 import _ from "lodash";
 import type { InferGetServerSidePropsType } from "next";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { createRef, useEffect, useRef, useState } from "react";
+import { createRef, useEffect, useMemo, useRef, useState } from "react";
 
 import type { BuilderFlow } from "@app/components/assistant_builder/AssistantBuilder";
 import { BUILDER_FLOWS } from "@app/components/assistant_builder/AssistantBuilder";
@@ -88,15 +90,22 @@ export default function CreateAssistant({
     tags: TemplateTagCodeType[];
   }>({ templates: [], tags: [] });
 
+  const whiteListedProviders = useMemo(() => {
+    return owner.whiteListedProviders ?? MODEL_PROVIDER_IDS;
+  }, [owner.whiteListedProviders]);
+
   useEffect(() => {
     const templatesToDisplay = assistantTemplates.filter((template) => {
-      return isTemplateTagCodeArray(template.tags);
+      return (
+        isTemplateTagCodeArray(template.tags) &&
+        whiteListedProviders.includes(template.presetProviderId)
+      );
     });
     setFilteredTemplates({
       templates: templatesToDisplay,
       tags: _.uniq(templatesToDisplay.map((template) => template.tags).flat()),
     });
-  }, [assistantTemplates]);
+  }, [assistantTemplates, whiteListedProviders]);
 
   const handleSearch = (searchTerm: string) => {
     setTemplateSearchTerm(searchTerm);

--- a/front/pages/w/[wId]/builder/assistants/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/index.tsx
@@ -13,11 +13,13 @@ import {
   SliderToggle,
   Tab,
 } from "@dust-tt/sparkle";
-import type { AgentConfigurationScope, SubscriptionType } from "@dust-tt/types";
 import type {
+  AgentConfigurationScope,
   LightAgentConfigurationType,
+  SubscriptionType,
   WorkspaceType,
 } from "@dust-tt/types";
+import { MODEL_PROVIDER_IDS } from "@dust-tt/types";
 import { assertNever, isBuilder } from "@dust-tt/types";
 import type { InferGetServerSidePropsType } from "next";
 import Link from "next/link";
@@ -110,13 +112,16 @@ export default function WorkspaceAssistants({
       agentsGetView: assistantSearch ? "assistants-search" : null,
     });
 
+  const whiteListedProviders = owner.whiteListedProviders ?? MODEL_PROVIDER_IDS;
+
   const filteredAgents = (
     assistantSearch ? searchableAgentConfigurations : agentConfigurations
   ).filter((a) => {
     return (
       // filter by tab only if no search
       (assistantSearch || a.scope === tabScope) &&
-      subFilter(assistantSearch.toLowerCase(), a.name.toLowerCase())
+      subFilter(assistantSearch.toLowerCase(), a.name.toLowerCase()) &&
+      whiteListedProviders.includes(a.model.providerId)
     );
   });
 


### PR DESCRIPTION
## Description

This PR aims at filtering out assistants using models from providers disabled by the workspace. The changes also apply on templates.

Note that while we want to filter out default/system models we will need other assistants to switch models based on authorized providers. This mechanism will be implemented in a separate PR.

## Risk

This should not have any direct impact on production as all providers are currently enabled.

## Deploy Plan

Deploy `front`
