### PR TITLE
[front] enh: store token usage

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -1,6 +1,13 @@
 import { sendInitDbMessage } from "@dust-tt/types";
 
-import { App, Clone, Dataset, Provider, Run, RunUsage } from "@app/lib/models/apps";
+import {
+  App,
+  Clone,
+  Dataset,
+  Provider,
+  Run,
+  RunUsage,
+} from "@app/lib/models/apps";
 import { AgentDataSourceConfiguration } from "@app/lib/models/assistant/actions/data_sources";
 import {
   AgentDustAppRunAction,

--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -1,6 +1,6 @@
 import { sendInitDbMessage } from "@dust-tt/types";
 
-import { App, Clone, Dataset, Provider, Run } from "@app/lib/models/apps";
+import { App, Clone, Dataset, Provider, Run, RunUsage } from "@app/lib/models/apps";
 import { AgentDataSourceConfiguration } from "@app/lib/models/assistant/actions/data_sources";
 import {
   AgentDustAppRunAction,
@@ -84,6 +84,7 @@ async function main() {
   await DustAppSecret.sync({ alter: true });
   await DataSource.sync({ alter: true });
   await Run.sync({ alter: true });
+  await RunUsage.sync({ alter: true });
   await TrackedDocument.sync({ alter: true });
   await DocumentTrackerChangeSuggestion.sync({ alter: true });
 

--- a/front/lib/models/apps.ts
+++ b/front/lib/models/apps.ts
@@ -366,7 +366,7 @@ RunUsage.init(
   {
     modelName: "run_usages",
     sequelize: frontSequelize,
-    indexes: [{ fields: ["providerId", "modelId"] }],
+    indexes: [{ fields: ["runId"] }, { fields: ["providerId", "modelId"] }],
   }
 );
 

--- a/front/lib/models/apps.ts
+++ b/front/lib/models/apps.ts
@@ -323,3 +323,57 @@ Workspace.hasMany(Run, {
   foreignKey: { allowNull: false },
   onDelete: "CASCADE",
 });
+
+export class RunUsage extends Model<
+  InferAttributes<RunUsage>,
+  InferCreationAttributes<RunUsage>
+> {
+  declare id: CreationOptional<number>;
+
+  declare runId: ForeignKey<Run["id"]>;
+
+  declare providerId: string; //ModelProviderIdType;
+  declare modelId: string; //ModelIdType;
+
+  declare prompt_tokens: number;
+  declare completion_tokens: number;
+}
+
+RunUsage.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    providerId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    modelId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    prompt_tokens: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+    completion_tokens: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+  },
+  {
+    modelName: "run_usages",
+    sequelize: frontSequelize,
+    indexes: [
+      { fields: ["workspaceId", "status"] },
+      { unique: true, fields: ["sId"] },
+    ],
+  }
+);
+
+Run.hasMany(RunUsage, {
+  foreignKey: { allowNull: false },
+  onDelete: "CASCADE",
+});

--- a/front/lib/models/apps.ts
+++ b/front/lib/models/apps.ts
@@ -366,9 +366,7 @@ RunUsage.init(
   {
     modelName: "run_usages",
     sequelize: frontSequelize,
-    indexes: [
-      { fields: ["providerId", "modelId"] },
-    ],
+    indexes: [{ fields: ["providerId", "modelId"] }],
   }
 );
 

--- a/front/lib/models/apps.ts
+++ b/front/lib/models/apps.ts
@@ -335,8 +335,8 @@ export class RunUsage extends Model<
   declare providerId: string; //ModelProviderIdType;
   declare modelId: string; //ModelIdType;
 
-  declare prompt_tokens: number;
-  declare completion_tokens: number;
+  declare promptTokens: number;
+  declare completionTokens: number;
 }
 
 RunUsage.init(
@@ -354,11 +354,11 @@ RunUsage.init(
       type: DataTypes.STRING,
       allowNull: false,
     },
-    prompt_tokens: {
+    promptTokens: {
       type: DataTypes.INTEGER,
       allowNull: false,
     },
-    completion_tokens: {
+    completionTokens: {
       type: DataTypes.INTEGER,
       allowNull: false,
     },
@@ -367,8 +367,7 @@ RunUsage.init(
     modelName: "run_usages",
     sequelize: frontSequelize,
     indexes: [
-      { fields: ["workspaceId", "status"] },
-      { unique: true, fields: ["sId"] },
+      { fields: ["providerId", "modelId"] },
     ],
   }
 );

--- a/front/pages/api/v1/w/[wId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/v1/w/[wId]/apps/[aId]/runs/index.ts
@@ -248,7 +248,7 @@ async function handler(
               try {
                 const data = JSON.parse(event.data);
                 if (data.type === "block_execution") {
-                  if (req.body.blocking) {
+                  if (runFlavor === 'blocking') {
                     // Keep track of block executions for blocking requests.
                     traces.push([
                       [data.content.block_type, data.content.block_name],
@@ -274,7 +274,7 @@ async function handler(
 
         for await (const chunk of runRes.value.chunkStream) {
           parser.feed(new TextDecoder().decode(chunk));
-          if (req.body.stream) {
+          if (runFlavor === 'streaming') {
             res.write(chunk);
             // @ts-expect-error we need to flush for streaming but TS thinks flush() does not exists.
             res.flush();

--- a/front/pages/api/v1/w/[wId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/v1/w/[wId]/apps/[aId]/runs/index.ts
@@ -197,12 +197,13 @@ async function handler(
         // Non blocking, return a run object as soon as we get the runId.
         void (async () => {
           try {
-            const runId = await runRes.value.dustRunId;
+            const dustRunId = await runRes.value.dustRunId;
 
             const statusRunRes = await coreAPI.getRunStatus({
               projectId: app.dustAPIProjectId,
-              runId,
+              runId: dustRunId,
             });
+
             if (statusRunRes.isErr()) {
               return apiError(req, res, {
                 status_code: 400,
@@ -213,11 +214,13 @@ async function handler(
                 },
               });
             }
+
             const run: RunType = statusRunRes.value.run;
             run.specification_hash = run.app_hash;
+            delete run.app_hash;
+
             run.status.blocks = [];
             run.results = null;
-            delete run.app_hash;
 
             res.status(200).json({ run: run as RunType });
           } catch (err) {
@@ -331,9 +334,9 @@ async function handler(
 
           const run: RunType = statusRunRes.value.run;
           run.specification_hash = run.app_hash;
-          run.traces = traces;
-
           delete run.app_hash;
+
+          run.traces = traces;
 
           if (req.body.block_filter && Array.isArray(req.body.block_filter)) {
             run.traces = run.traces.filter((t: any) => {

--- a/front/pages/api/v1/w/[wId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/v1/w/[wId]/apps/[aId]/runs/index.ts
@@ -1,6 +1,8 @@
 import type {
   BlockType,
   CredentialsType,
+  ModelIdType,
+  ModelProviderIdType,
   TraceType,
   WithAPIErrorReponse,
 } from "@dust-tt/types";
@@ -33,8 +35,8 @@ export const config = {
 type RunFlavor = "blocking" | "streaming" | "non-blocking";
 
 type Usage = {
-  providerId: string;
-  modelId: string;
+  providerId: ModelProviderIdType;
+  modelId: ModelIdType;
   promptTokens: number;
   completionTokens: number;
 };
@@ -42,7 +44,7 @@ type Usage = {
 type Trace = [[BlockType, string], TraceType[][]];
 
 function extractUsageFromExecutions(
-  block: { provider_id: string; model_id: string },
+  block: { provider_id: ModelProviderIdType; model_id: ModelIdType },
   traces: TraceType[][],
   usages: Usage[]
 ) {

--- a/front/pages/api/v1/w/[wId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/v1/w/[wId]/apps/[aId]/runs/index.ts
@@ -37,10 +37,7 @@ type Usage = {
   completionTokens: number;
 };
 
-type Trace = [
-  [BlockType, string],
-  TraceType[][]
-];
+type Trace = [[BlockType, string], TraceType[][]];
 
 function extractUsageFromExecutions(
   block: { provider_id: string; model_id: string },
@@ -51,7 +48,9 @@ function extractUsageFromExecutions(
     traces.forEach((tracesInner) => {
       tracesInner.forEach((trace) => {
         if (trace?.meta) {
-          const {token_usage} = trace.meta as {token_usage: {prompt_tokens: number; completion_tokens: number}};
+          const { token_usage } = trace.meta as {
+            token_usage: { prompt_tokens: number; completion_tokens: number };
+          };
           if (token_usage) {
             const promptTokens = token_usage.prompt_tokens;
             const completionTokens = token_usage.completion_tokens;
@@ -224,7 +223,7 @@ async function handler(
           } catch (err) {
             logger.error(
               {
-                error: err
+                error: err,
               },
               "There was an error getting the app status."
             );
@@ -233,7 +232,7 @@ async function handler(
               status_code: 400,
               api_error: {
                 type: "run_error",
-                message: "There was an error getting the app status."
+                message: "There was an error getting the app status.",
               },
             });
           }
@@ -298,21 +297,21 @@ async function handler(
 
       try {
         const dustRunId = await runRes.value.dustRunId;
-      
-        const runEntity = await Run.create({
+
+        const { id: runId } = await Run.create({
           dustRunId,
           appId: app.id,
           runType: "deploy",
           workspaceId: keyRes.value.workspaceId,
         });
-  
+
         await RunUsage.bulkCreate(
           usages.map((usage) => ({
-            runId: runEntity.id,
+            runId,
             ...usage,
           }))
         );
-  
+
         if (req.body.blocking && !req.body.stream) {
           const statusRunRes = await coreAPI.getRunStatus({
             projectId: app.dustAPIProjectId,
@@ -361,12 +360,12 @@ async function handler(
           },
           "There was an error getting the app status."
         );
-      
+
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "run_error",
-            message: "There was an error getting the app status."
+            message: "There was an error getting the app status.",
           },
         });
       }

--- a/front/pages/api/v1/w/[wId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/v1/w/[wId]/apps/[aId]/runs/index.ts
@@ -289,19 +289,11 @@ async function handler(
           }
         }
       } catch (err) {
-        switch (runFlavor) {
-          case "streaming":
-            logger.error(
-              {
-                error: err,
-              },
-              "Error streaming from Dust API"
-            );
-            break;
-
-          default:
-            throw err;
+        if (runFlavor === "streaming") {
+          res.end();
         }
+
+        throw err;
       }
 
       const dustRunId = await runRes.value.dustRunId;

--- a/front/pages/api/v1/w/[wId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/v1/w/[wId]/apps/[aId]/runs/index.ts
@@ -289,6 +289,13 @@ async function handler(
           }
         }
       } catch (err) {
+        logger.error(
+          {
+            error: err,
+          },
+          "Error streaming from Dust API"
+        );
+
         if (runFlavor === "streaming") {
           res.end();
         }

--- a/front/pages/api/v1/w/[wId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/v1/w/[wId]/apps/[aId]/runs/index.ts
@@ -248,7 +248,7 @@ async function handler(
               try {
                 const data = JSON.parse(event.data);
                 if (data.type === "block_execution") {
-                  if (runFlavor === 'blocking') {
+                  if (runFlavor === "blocking") {
                     // Keep track of block executions for blocking requests.
                     traces.push([
                       [data.content.block_type, data.content.block_name],
@@ -274,7 +274,7 @@ async function handler(
 
         for await (const chunk of runRes.value.chunkStream) {
           parser.feed(new TextDecoder().decode(chunk));
-          if (runFlavor === 'streaming') {
+          if (runFlavor === "streaming") {
             res.write(chunk);
             // @ts-expect-error we need to flush for streaming but TS thinks flush() does not exists.
             res.flush();

--- a/front/pages/api/v1/w/[wId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/v1/w/[wId]/apps/[aId]/runs/index.ts
@@ -364,15 +364,15 @@ async function handler(
         if (block) {
           executeOnNestedObjects(trace[1], (o: any) => {
             if (o?.meta?.token_usage) {
-              const prompt_tokens = o?.meta?.token_usage.prompt_tokens;
-              const completion_tokens = o?.meta?.token_usage.completion_tokens;
-              console.log('token_usage: ', block.provider_id, block.model_id, prompt_tokens, completion_tokens);
+              const promptTokens = o?.meta?.token_usage.prompt_tokens;
+              const completionTokens = o?.meta?.token_usage.completion_tokens;
+              console.log('token_usage: ', block.provider_id, block.model_id, promptTokens, completionTokens);
               RunUsage.create({
                 runId: runEntity.id,
                 providerId: block.provider_id,
                 modelId: block.model_id,
-                prompt_tokens,
-                completion_tokens,
+                promptTokens,
+                completionTokens,
               });
             }
           });

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -360,13 +360,6 @@ export class CoreAPI {
           parser.feed(new TextDecoder().decode(value));
           yield value;
         }
-        if (!hasRunId) {
-          // once the stream is entirely consumed, if we haven't received a run id, reject the promise
-          setImmediate(() => {
-            logger.error({}, "No run id received");
-            rejectDustRunIdPromise(new Error("No run id received"));
-          });
-        }
       } catch (e) {
         logger.error(
           {
@@ -377,6 +370,13 @@ export class CoreAPI {
           "Error streaming chunks"
         );
       } finally {
+        if (!hasRunId) {
+          // once the stream is entirely consumed, if we haven't received a run id, reject the promise
+          setImmediate(() => {
+            logger.error({}, "No run id received");
+            rejectDustRunIdPromise(new Error("No run id received"));
+          });
+        }
         reader.releaseLock();
       }
     };


### PR DESCRIPTION
https://github.com/dust-tt/dust/issues/5506

## Description

Get messages from core about token usages and store them in table for every run, along with provider/model information.
Only calls to `/v1/w/[wId]/apps/[aId]/runs/index.ts` are catched (blocking, non-blocking or streamed), is there any other place we need to watch ?

## Risk

Should not have any impact outside of storing new rows in `run_usages`.
Can be rollbacked - database modification is just a new table, can be dropped.

## Deploy Plan

Execute migration `front/migrations/db/migration_17.sql`, deploy `front`
