### PR TITLE
core: remove meta_prompts and folds

### DIFF
--- a/core/src/providers/anthropic.rs
+++ b/core/src/providers/anthropic.rs
@@ -1530,8 +1530,8 @@ impl LLM for AnthropicLLM {
             .map(|cm| AnthropicChatMessage::try_from(cm))
             .collect::<Result<Vec<AnthropicChatMessage>>>()?;
 
-        // Group consecutive messages with the same role by appending their content.
-        // This is needed to group all the `tool_results` within one content vector.
+        // Group consecutive messages with the same role by appending their content. This is
+        // needed to group all the `tool_results` within one content vector.
         messages = messages.iter().fold(
             vec![],
             |mut acc: Vec<AnthropicChatMessage>, cm: &AnthropicChatMessage| {

--- a/core/src/providers/anthropic.rs
+++ b/core/src/providers/anthropic.rs
@@ -194,15 +194,12 @@ impl TryFrom<&ChatMessage> for AnthropicChatMessage {
 
         // Handling meta prompt.
         let meta_prompt = match cm.role {
-            ChatMessageRole::User => cm
+            // If function_call_id is not set Anthropic has no way to correlate the tool_use with
+            // the tool_result.
+            ChatMessageRole::Function if cm.function_call_id.is_none() => cm
                 .name
                 .as_ref()
-                .map_or(String::new(), |name| format!("[user: {}] ", name)),
-            ChatMessageRole::Function if cm.function_call_id.is_none() => {
-                cm.name.as_ref().map_or(String::new(), |name| {
-                    format!("[function_result: {}] ", name)
-                })
-            }
+                .map_or(String::new(), |name| format!("[tool: {}] ", name)),
             _ => String::new(),
         };
 

--- a/core/src/providers/google_ai_studio.rs
+++ b/core/src/providers/google_ai_studio.rs
@@ -168,14 +168,7 @@ impl TryFrom<&ChatMessage> for Content {
                         // System is passed as a Content. We transform it here but it will be removed
                         // from the list of messages and passed as separate argument to the API.
                         ChatMessageRole::System => m.content.clone(),
-                        ChatMessageRole::User => match m.name {
-                            Some(ref name) => Some(format!(
-                                "[user: {}] {}",
-                                name,
-                                m.content.clone().unwrap_or(String::from(""))
-                            )),
-                            None => m.content.clone(),
-                        },
+                        ChatMessageRole::User => m.content.clone(),
                         ChatMessageRole::Assistant => m.content.clone(),
                         _ => None,
                     },

--- a/core/src/providers/mistral.rs
+++ b/core/src/providers/mistral.rs
@@ -162,38 +162,11 @@ impl TryFrom<&ChatMessage> for MistralChatMessage {
         let mut mistral_role = MistralChatMessageRole::try_from(&cm.role)
             .map_err(|e| anyhow!("Error converting role: {:?}", e))?;
 
-        // `name` is taken into account by Mistral only for tool roles. We therefore inject it for
-        // `user` messages to indicate to the model who is the user since name is not taken into
-        // account there. For `assistant` message we don't inject it to avoid having the model
-        // injecting similar prefixes.
-        let meta_prompt = match cm.role {
-            ChatMessageRole::Function => match cm.name.as_ref() {
-                // We have a very special cases for our content attachments. We inject them as
-                // function messages in the conversation but Mistral does not support having a tool
-                // message followed by a `user` message. So we cast them to a `user` message with a
-                // meta prompt.
-                Some(name)
-                    if name == "inject_slack_thread_content"
-                        || name == "inject_file_attachment" =>
-                {
-                    mistral_role = MistralChatMessageRole::User;
-                    format!("[tool: {}] ", name)
-                }
-                _ => String::from(""),
-            },
-            ChatMessageRole::User => match cm.name.as_ref() {
-                Some(name) => format!("[user: {}] ", name), // Include space here.
-                None => String::from(""),
-            },
-            _ => String::from(""),
-        };
-
         Ok(MistralChatMessage {
-            content: Some(format!(
-                "{}{}",
-                meta_prompt,
-                cm.content.clone().unwrap_or(String::from(""))
-            )),
+            content: match cm.content.as_ref() {
+                Some(c) => Some(c.clone()),
+                None => None,
+            },
             // Name is only supported for the Function/Tool role.
             name: match mistral_role {
                 MistralChatMessageRole::Tool => cm.name.clone(),


### PR DESCRIPTION
## Description

- Remove `[user: x]` meta prompts because they throw off models and nobody complains about mutli-user stuff
- Remove mistral fold since we should now be always abiding to it

## Risk

Low

## Deploy Plan

- deploy `core`