### PR TITLE
[New conversation] Add "In my list" tab

### DIFF
--- a/front/components/assistant/AssistantBrowser.tsx
+++ b/front/components/assistant/AssistantBrowser.tsx
@@ -1,6 +1,7 @@
 import {
   AssistantPreview,
   Button,
+  ListAddIcon,
   PlanetIcon,
   PlusIcon,
   RobotIcon,
@@ -36,6 +37,7 @@ const ALL_AGENTS_TABS = [
   { label: "Company", icon: PlanetIcon, id: "workspace" },
   { label: "Shared", icon: UserGroupIcon, id: "published" },
   { label: "Personal", icon: UserIcon, id: "personal" },
+  { label: "In my list", icon: ListAddIcon, id: "list" },
   { label: "All", icon: RobotIcon, id: "all" },
 ] as const;
 
@@ -65,6 +67,9 @@ export function AssistantBrowser({
       published: filteredAgents.filter((a) => a.scope === "published"),
       workspace: filteredAgents.filter((a) => a.scope === "workspace"),
       personal: filteredAgents.filter((a) => a.scope === "private"),
+      list: filteredAgents.filter(
+        (a) => a.scope === "published" && a.userListStatus === "in-list"
+      ),
       // TODO: Implement most popular agents (upcoming PR for issue #5454)
       most_popular: filteredAgents
         .filter((a) => a.usage && a.usage.messageCount > 0)


### PR DESCRIPTION
Description
---
See this [thread](https://dust4ai.slack.com/archives/C050A0S2Z7F/p1717765883239109)
![image](https://github.com/dust-tt/dust/assets/5437393/e9102a55-dff3-436e-93d1-e9e349fb4715)

In my list = shared assistants that are in my list (not personal, not company, since they have their own tab)

Risk & deploy
---
N/A
