### PR TITLE
Use new GCS structured file to retrieve data source documents full text

### DIFF
--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -1835,23 +1835,11 @@ impl DataSource {
 
         let document_id_hash = make_document_id_hash(document_id);
 
-        // GCP retrieve raw text and document_id.
-        let bucket = match std::env::var("DUST_DATA_SOURCES_BUCKET") {
-            Ok(bucket) => bucket,
-            Err(_) => Err(anyhow!("DUST_DATA_SOURCES_BUCKET is not set"))?,
-        };
+        let stored_doc =
+            FileStorageDocument::get_stored_document(&self, d.created, &document_id_hash, &d.hash)
+                .await?;
 
-        let bucket_path = format!(
-            "{}/{}/{}",
-            self.project.project_id(),
-            self.internal_id,
-            document_id_hash
-        );
-        let content_path = format!("{}/{}/content.txt", bucket_path, d.hash);
-        let bytes = Object::download(&bucket, &content_path).await?;
-        let text = String::from_utf8(bytes)?;
-
-        d.text = Some(text.clone());
+        d.text = Some(stored_doc.full_text.clone());
 
         Ok(Some(d))
     }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Since the changes introduced in https://github.com/dust-tt/dust/pull/5412, we have backfilled all document data for the data sources.

Currently, there is no straightforward method to test these changes on the production core. Therefore, this PR begins by transitioning the retrieval of the document, which is used by the UI and the document tracker. This retrieval process does not involve RAG operations, making it an ideal candidate to verify functionality before we migrate all other read operations.

This cautious approach is necessary for two primary reasons:
- To ensure the existence of the files.
- We are now dependent on JSON, which requires the data to be in valid JSON format.

## Risk

In the worst-case scenario, this change might disrupt the document retrieval from data sources within the UI and document tracker. Safe to rollback.
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
