### PR TITLE
[New Conversation] Mobile friendliness

### DIFF
--- a/front/components/assistant/AssistantBrowser.tsx
+++ b/front/components/assistant/AssistantBrowser.tsx
@@ -111,12 +111,24 @@ export function AssistantBrowser({
             <Link
               href={`/w/${owner.sId}/builder/assistants/create?flow=personal_assistants`}
             >
-              <Button
-                variant="primary"
-                icon={PlusIcon}
-                label="Create An Assistant"
-                size="sm"
-              />
+              <div className="hidden sm:block">
+                <Button
+                  variant="primary"
+                  icon={PlusIcon}
+                  label="Create An Assistant"
+                  size="sm"
+                />
+              </div>
+              <div className="sm:hidden">
+                <Button
+                  variant="primary"
+                  icon={PlusIcon}
+                  label="Create An Assistant"
+                  labelVisible={false}
+                  size="sm"
+                  className="sm:hidden"
+                />
+              </div>
             </Link>
           </Tooltip>
         </Button.List>
@@ -140,7 +152,7 @@ export function AssistantBrowser({
       )}
 
       {displayedTab && (
-        <div className="grid w-full grid-cols-2 gap-2 px-4 md:grid-cols-3">
+        <div className="grid w-full grid-cols-1 gap-2 px-4 md:grid-cols-3">
           {agentsByTab[displayedTab].map((agent) => {
             const href = {
               pathname: router.pathname,


### PR DESCRIPTION
Description
---
2 columns show badly on mobile, see [thread](https://dust4ai.slack.com/archives/C066R3PMUAU/p1717766671596349) The label in the create assistant button should also be removed
![image](https://github.com/dust-tt/dust/assets/5437393/bd7f6666-bdf9-42b5-a8fa-e2f489c9205e)

Risk & deploy
---
N/A
