### PR TITLE
core: more request-ids / correlation with run_id

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -100,9 +100,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a64c907d4e79225ac72e2a354c9ce84d50ebb4586dee56c82b3ee73004f537f5"
+checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
 dependencies = [
  "windows-sys 0.52.0",
 ]
@@ -362,7 +362,7 @@ dependencies = [
  "futures-util",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "itoa",
  "matchit",
  "memchr",
@@ -627,9 +627,9 @@ checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "cc"
-version = "1.0.98"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41c270e7540d725e65ac7f1b212ac8ce349719624d7bcff99f8e2e488e8cf03f"
+checksum = "96c51067fd44124faa7f870b4b1c969379ad32b2ba805aa959430ceaa384f695"
 dependencies = [
  "jobserver",
  "libc",
@@ -681,9 +681,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.4"
+version = "4.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
+checksum = "a9689a29b593160de5bc4aacab7b5d54fb52231de70122626c178e6a368994c7"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -691,9 +691,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.2"
+version = "4.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+checksum = "2e5387378c84f6faa26890ebf9f0a92989f8873d4d380467bcd0d8d8620424df"
 dependencies = [
  "anstream",
  "anstyle",
@@ -703,9 +703,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.4"
+version = "4.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
+checksum = "c780290ccf4fb26629baa7a1081e68ced113f1d3ec302fa5948f1c381ebf06c6"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -715,9 +715,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
 
 [[package]]
 name = "cloud-storage"
@@ -1143,7 +1143,7 @@ version = "0.12.2"
 source = "git+https://github.com/dust-tt/rust-eventsource-client#d34896e77b2198cd4d71e05007798736142ec336"
 dependencies = [
  "futures",
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "hyper-rustls 0.24.2",
  "hyper-timeout",
  "log",
@@ -1615,9 +1615,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.28"
+version = "0.14.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
+checksum = "f361cde2f109281a220d4307746cdfd5ee3f410da58a70377762396775634b33"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1666,7 +1666,7 @@ checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
  "http 0.2.12",
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "log",
  "rustls 0.21.12",
  "rustls-native-certs 0.6.3",
@@ -1697,7 +1697,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
@@ -1710,7 +1710,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "native-tls",
  "tokio",
  "tokio-native-tls",
@@ -2801,7 +2801,7 @@ dependencies = [
  "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "hyper-tls 0.5.0",
  "ipnet",
  "js-sys",
@@ -3731,7 +3731,7 @@ dependencies = [
  "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
@@ -4219,9 +4219,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009"
+checksum = "3c452ad30530b54a4d8e71952716a212b08efd0f3562baa66c29a618b07da7c3"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -52,7 +52,7 @@ urlencoding = "2.1"
 url = "2.5"
 dns-lookup = "1.0"
 async-stream = "0.3"
-eventsource-client = { git = "https://github.com/dust-tt/rust-eventsource-client", commit = "d34896e77b2198cd4d71e05007798736142ec336" }
+eventsource-client = { git = "https://github.com/dust-tt/rust-eventsource-client", commit = "d34896e" }
 tera = "1.20"
 fancy-regex = "0.13"
 rustc-hash = "1.1"

--- a/core/src/app.rs
+++ b/core/src/app.rs
@@ -354,6 +354,7 @@ impl App {
             qdrant_clients: qdrant_clients,
             credentials: credentials.clone(),
             secrets: secrets.clone(),
+            run_id: run_id.clone(),
         }]];
 
         let mut current_map: Option<String> = None;

--- a/core/src/blocks/block.rs
+++ b/core/src/blocks/block.rs
@@ -44,6 +44,7 @@ pub struct Env {
     pub input: InputState,
     pub map: Option<MapState>,
     pub secrets: Secrets,
+    pub run_id: String,
     #[serde(skip_serializing)]
     pub store: Box<dyn Store + Sync + Send>,
     #[serde(skip_serializing)]

--- a/core/src/blocks/chat.rs
+++ b/core/src/blocks/chat.rs
@@ -570,7 +570,9 @@ impl Block for Chat {
                         // move tx to event_sender
                     });
                 }
-                request.execute(env.credentials.clone(), Some(tx)).await?
+                request
+                    .execute(env.credentials.clone(), Some(tx), env.run_id.clone())
+                    .await?
             }
             false => {
                 request
@@ -579,6 +581,7 @@ impl Block for Chat {
                         env.project.clone(),
                         env.store.clone(),
                         use_cache,
+                        env.run_id.clone(),
                     )
                     .await?
             }

--- a/core/src/blocks/chat.rs
+++ b/core/src/blocks/chat.rs
@@ -596,6 +596,7 @@ impl Block for Chat {
             meta: Some(json!({
                 "logs": all_logs,
                 "token_usage": g.usage,
+                "provider_request_id": g.provider_request_id,
             })),
         })
     }

--- a/core/src/blocks/llm.rs
+++ b/core/src/blocks/llm.rs
@@ -479,7 +479,9 @@ impl Block for LLM {
                                 // move tx to event_sender
                             });
                         }
-                        request.execute(env.credentials.clone(), Some(tx)).await?
+                        request
+                            .execute(env.credentials.clone(), Some(tx), env.run_id.clone())
+                            .await?
                     }
                     false => {
                         request
@@ -488,6 +490,7 @@ impl Block for LLM {
                                 env.project.clone(),
                                 env.store.clone(),
                                 use_cache,
+                                env.run_id.clone(),
                             )
                             .await?
                     }
@@ -562,7 +565,9 @@ impl Block for LLM {
                                 // move tx to event_sender
                             });
                         }
-                        request.execute(env.credentials.clone(), Some(tx)).await?
+                        request
+                            .execute(env.credentials.clone(), Some(tx), env.run_id.clone())
+                            .await?
                     }
                     false => {
                         request
@@ -571,6 +576,7 @@ impl Block for LLM {
                                 env.project.clone(),
                                 env.store.clone(),
                                 use_cache,
+                                env.run_id.clone(),
                             )
                             .await?
                     }

--- a/core/src/blocks/llm.rs
+++ b/core/src/blocks/llm.rs
@@ -585,6 +585,7 @@ impl Block for LLM {
                     })?,
                     meta: Some(json!({
                         "token_usage": g.usage,
+                        "provider_request_id": g.provider_request_id,
                     })),
                 })
             }

--- a/core/src/providers/anthropic.rs
+++ b/core/src/providers/anthropic.rs
@@ -623,7 +623,7 @@ impl AnthropicLLM {
         top_p: f32,
         stop_sequences: &Vec<String>,
         max_tokens: i32,
-    ) -> Result<ChatResponse> {
+    ) -> Result<(ChatResponse, Option<String>)> {
         assert!(self.api_key.is_some());
 
         let mut body = json!({
@@ -675,11 +675,13 @@ impl AnthropicLLM {
             .await?;
 
         let status = res.status();
+
         let res_headers = res.headers();
         let request_id = match res_headers.get("request-id") {
             Some(v) => Some(v.to_str()?.to_string()),
             None => None,
         };
+
         let body = res.bytes().await?;
 
         let mut b: Vec<u8> = vec![];
@@ -690,7 +692,7 @@ impl AnthropicLLM {
             _ => {
                 let error: AnthropicError = serde_json::from_slice(c)?;
                 Err(ModelError {
-                    request_id,
+                    request_id: request_id.clone(),
                     message: error.message(),
                     retryable: match error.retryable() {
                         true => Some(ModelErrorRetryOptions {
@@ -708,7 +710,7 @@ impl AnthropicLLM {
             }
         }?;
 
-        Ok(response)
+        Ok((response, request_id))
     }
 
     async fn streamed_chat_completion(
@@ -722,7 +724,7 @@ impl AnthropicLLM {
         stop_sequences: &Vec<String>,
         max_tokens: i32,
         event_sender: UnboundedSender<Value>,
-    ) -> Result<ChatResponse> {
+    ) -> Result<(ChatResponse, Option<String>)> {
         assert!(self.api_key.is_some());
 
         let mut body = json!({
@@ -909,7 +911,8 @@ impl AnthropicLLM {
                                             break 'stream;
                                         }
                                         Some(content) => match (event.delta, content) {
-                                            (StreamContentDelta::AnthropicStreamContent(delta), StreamContent::AnthropicStreamContent(content)) => {
+                                            (StreamContentDelta::AnthropicStreamContent(delta),
+                                             StreamContent::AnthropicStreamContent(content)) => {
                                                 content.text.push_str(delta.text.as_str());
                                                 if delta.text.len() > 0 {
                                                     let _ = event_sender.send(json!({
@@ -924,8 +927,10 @@ impl AnthropicLLM {
                                             (StreamContentDelta::AnthropicStreamToolInputDelta(
                                                 input_json_delta,
                                             ), StreamContent::AnthropicStreamToolUse(tool_use)) => {
-                                                // The `content_block_start` for `tool_use` initializes `input` as an empty object.
-                                                // To append input chunks, we need to convert `input` to a string.
+                                                // The `content_block_start` for `tool_use`
+                                                // initializes `input` as an empty object. To
+                                                // append input chunks, we need to convert `input`
+                                                // to a string.
                                                 if tool_use.input.is_object() {
                                                     tool_use.input = Value::String("".to_string());
                                                 }
@@ -1069,8 +1074,7 @@ impl AnthropicLLM {
         match final_response {
             Some(response) => {
                 let chat_response: ChatResponse = ChatResponse::try_from(response)?;
-
-                Ok(chat_response)
+                Ok((chat_response, None))
             }
             None => Err(anyhow!("No response from Anthropic")),
         }
@@ -1085,7 +1089,7 @@ impl AnthropicLLM {
         top_k: Option<i32>,
         stop: &Vec<String>,
         event_sender: UnboundedSender<Value>,
-    ) -> Result<CompletionResponse> {
+    ) -> Result<(CompletionResponse, Option<String>)> {
         assert!(self.api_key.is_some());
 
         let url = self.completions_uri()?.to_string();
@@ -1252,7 +1256,7 @@ impl AnthropicLLM {
         }
 
         return match final_response {
-            Some(response) => Ok(response),
+            Some(response) => Ok((response, None)),
             None => Err(anyhow!("No response from Anthropic")),
         };
     }
@@ -1265,7 +1269,7 @@ impl AnthropicLLM {
         top_p: f32,
         top_k: Option<i32>,
         stop: &Vec<String>,
-    ) -> Result<CompletionResponse> {
+    ) -> Result<(CompletionResponse, Option<String>)> {
         assert!(self.api_key.is_some());
 
         let res = reqwest::Client::new()
@@ -1291,11 +1295,13 @@ impl AnthropicLLM {
             .await?;
 
         let status = res.status();
+
         let res_headers = res.headers();
         let request_id = match res_headers.get("request-id") {
             Some(v) => Some(v.to_str()?.to_string()),
             None => None,
         };
+
         let body = res.bytes().await?;
 
         let mut b: Vec<u8> = vec![];
@@ -1306,7 +1312,7 @@ impl AnthropicLLM {
             _ => {
                 let error: AnthropicError = serde_json::from_slice(c)?;
                 Err(ModelError {
-                    request_id,
+                    request_id: request_id.clone(),
                     message: error.message(),
                     retryable: match error.retryable() {
                         true => Some(ModelErrorRetryOptions {
@@ -1324,7 +1330,7 @@ impl AnthropicLLM {
             }
         }?;
 
-        Ok(response)
+        Ok((response, request_id))
     }
 }
 
@@ -1392,10 +1398,10 @@ impl LLM for AnthropicLLM {
             }
         }
 
-        let c: Vec<Tokens> = match event_sender {
+        let (c, request_id) = match event_sender {
             Some(es) => {
                 let mut completions: Vec<Tokens> = vec![];
-                let response = match self
+                let (response, request_id) = match self
                     .streamed_completion(
                         prompt,
                         match max_tokens {
@@ -1426,13 +1432,13 @@ impl LLM for AnthropicLLM {
                     top_logprobs: Some(vec![]),
                 });
 
-                completions
+                (completions, request_id)
             }
             None => {
                 let mut completions: Vec<Tokens> = vec![];
                 // anthropic only supports generating one sample at a time
                 // so we loop here and make n API calls
-                let response = self
+                let (response, request_id) = self
                     .completion(
                         prompt,
                         match max_tokens {
@@ -1456,7 +1462,8 @@ impl LLM for AnthropicLLM {
                     logprobs: Some(vec![]),
                     top_logprobs: Some(vec![]),
                 });
-                completions
+
+                (completions, request_id)
             }
         };
 
@@ -1472,6 +1479,7 @@ impl LLM for AnthropicLLM {
                 top_logprobs: None,
             },
             usage: None,
+            provider_request_id: request_id,
         };
 
         Ok(llm_generation)
@@ -1565,7 +1573,7 @@ impl LLM for AnthropicLLM {
             None => None,
         };
 
-        let c = match event_sender {
+        let (c, request_id) = match event_sender {
             Some(es) => {
                 self.streamed_chat_completion(
                     system,
@@ -1611,11 +1619,12 @@ impl LLM for AnthropicLLM {
             created: utils::now(),
             provider: ProviderID::Anthropic.to_string(),
             model: self.id.clone(),
+            completions: ChatMessage::try_from(c).into_iter().collect(),
             usage: Some(LLMTokenUsage {
                 prompt_tokens: c.usage.input_tokens,
                 completion_tokens: c.usage.output_tokens,
             }),
-            completions: ChatMessage::try_from(c).into_iter().collect(),
+            provider_request_id: request_id,
         })
     }
 }

--- a/core/src/providers/anthropic.rs
+++ b/core/src/providers/anthropic.rs
@@ -1619,11 +1619,11 @@ impl LLM for AnthropicLLM {
             created: utils::now(),
             provider: ProviderID::Anthropic.to_string(),
             model: self.id.clone(),
-            completions: ChatMessage::try_from(c).into_iter().collect(),
             usage: Some(LLMTokenUsage {
                 prompt_tokens: c.usage.input_tokens,
                 completion_tokens: c.usage.output_tokens,
             }),
+            completions: ChatMessage::try_from(c).into_iter().collect(),
             provider_request_id: request_id,
         })
     }

--- a/core/src/providers/azure_openai.rs
+++ b/core/src/providers/azure_openai.rs
@@ -264,7 +264,7 @@ impl LLM for AzureOpenAILLM {
             }
         }
 
-        let c = match event_sender {
+        let (c, request_id) = match event_sender {
             Some(_) => {
                 streamed_completion(
                     self.uri()?,
@@ -420,6 +420,7 @@ impl LLM for AzureOpenAILLM {
                 prompt_tokens: usage.prompt_tokens,
                 completion_tokens: usage.completion_tokens.unwrap_or(0),
             }),
+            provider_request_id: request_id,
         })
     }
 
@@ -470,7 +471,7 @@ impl LLM for AzureOpenAILLM {
 
         let openai_messages = to_openai_messages(messages)?;
 
-        let c = match event_sender {
+        let (c, request_id) = match event_sender {
             Some(_) => {
                 streamed_chat_completion(
                     self.chat_uri()?,
@@ -551,6 +552,7 @@ impl LLM for AzureOpenAILLM {
                 prompt_tokens: usage.prompt_tokens,
                 completion_tokens: usage.completion_tokens.unwrap_or(0),
             }),
+            provider_request_id: request_id,
         })
     }
 }

--- a/core/src/providers/google_ai_studio.rs
+++ b/core/src/providers/google_ai_studio.rs
@@ -429,6 +429,7 @@ impl LLM for GoogleAiStudioLLM {
                 prompt_tokens: c.prompt_token_count.unwrap_or(0) as u64,
                 completion_tokens: c.candidates_token_count.unwrap_or(0) as u64,
             }),
+            provider_request_id: None,
         })
     }
 
@@ -606,6 +607,7 @@ impl LLM for GoogleAiStudioLLM {
                 prompt_tokens: c.prompt_token_count.unwrap_or(0) as u64,
                 completion_tokens: c.candidates_token_count.unwrap_or(0) as u64,
             }),
+            provider_request_id: None,
         })
     }
 }

--- a/core/src/providers/llm.rs
+++ b/core/src/providers/llm.rs
@@ -491,6 +491,7 @@ impl LLMChatRequest {
                     attempts = attempts,
                     sleep = sleep.as_millis(),
                     err_msg = err_msg,
+                    run_id = run_id,
                     "Retry querying"
                 );
             },
@@ -514,6 +515,7 @@ impl LLMChatRequest {
                     messages_count = self.messages.len(),
                     temperature = self.temperature,
                     request_id = c.provider_request_id.as_deref().unwrap_or(""),
+                    run_id = run_id,
                     completion_message_length = c
                         .completions
                         .iter()

--- a/core/src/providers/llm.rs
+++ b/core/src/providers/llm.rs
@@ -29,6 +29,7 @@ pub struct LLMGeneration {
     pub completions: Vec<Tokens>,
     pub prompt: Tokens,
     pub usage: Option<LLMTokenUsage>,
+    pub provider_request_id: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
@@ -105,6 +106,7 @@ pub struct LLMChatGeneration {
     pub model: String,
     pub completions: Vec<ChatMessage>,
     pub usage: Option<LLMTokenUsage>,
+    pub provider_request_id: Option<String>,
 }
 
 #[async_trait]

--- a/core/src/providers/llm.rs
+++ b/core/src/providers/llm.rs
@@ -248,6 +248,7 @@ impl LLMRequest {
         &self,
         credentials: Credentials,
         event_sender: Option<UnboundedSender<Value>>,
+        run_id: String,
     ) -> Result<LLMGeneration> {
         let mut llm = provider(self.provider_id).llm(self.model_id.clone());
         llm.initialize(credentials).await?;
@@ -275,6 +276,7 @@ impl LLMRequest {
                     attempts = attempts,
                     sleep = sleep.as_millis(),
                     err_msg = err_msg,
+                    run_id = run_id,
                     "Retry querying"
                 );
             },
@@ -284,7 +286,8 @@ impl LLMRequest {
                     model_id = self.model_id,
                     err_msg = err.message,
                     request_id = err.request_id.as_deref().unwrap_or(""),
-                    "LLMRequest model error",
+                    run_id = run_id,
+                    "LLMRequest ModelError",
                 );
             },
         )
@@ -302,6 +305,8 @@ impl LLMRequest {
                         None => 0,
                         Some(logprobs) => logprobs.len(),
                     },
+                    request_id = c.provider_request_id.as_deref().unwrap_or(""),
+                    run_id = run_id,
                     completion_tokens = c
                         .completions
                         .iter()
@@ -327,6 +332,7 @@ impl LLMRequest {
         project: Project,
         store: Box<dyn Store + Send + Sync>,
         use_cache: bool,
+        run_id: String,
     ) -> Result<LLMGeneration> {
         let generation = {
             match use_cache {
@@ -344,7 +350,7 @@ impl LLMRequest {
         match generation {
             Some(generation) => Ok(generation),
             None => {
-                let generation = self.execute(credentials, None).await?;
+                let generation = self.execute(credentials, None, run_id).await?;
                 store.llm_cache_store(&project, self, &generation).await?;
                 Ok(generation)
             }
@@ -456,6 +462,7 @@ impl LLMChatRequest {
         &self,
         credentials: Credentials,
         event_sender: Option<UnboundedSender<Value>>,
+        run_id: String,
     ) -> Result<LLMChatGeneration> {
         let mut llm = provider(self.provider_id).llm(self.model_id.clone());
         llm.initialize(credentials).await?;
@@ -493,7 +500,7 @@ impl LLMChatRequest {
                     model_id = self.model_id,
                     err_msg = err.message,
                     request_id = err.request_id.as_deref().unwrap_or(""),
-                    "LLMChatRequest model error",
+                    "LLMChatRequest ModelError",
                 );
             },
         )
@@ -506,6 +513,7 @@ impl LLMChatRequest {
                     model_id = self.model_id,
                     messages_count = self.messages.len(),
                     temperature = self.temperature,
+                    request_id = c.provider_request_id.as_deref().unwrap_or(""),
                     completion_message_length = c
                         .completions
                         .iter()
@@ -536,6 +544,7 @@ impl LLMChatRequest {
         project: Project,
         store: Box<dyn Store + Send + Sync>,
         use_cache: bool,
+        run_id: String,
     ) -> Result<LLMChatGeneration> {
         let generation = {
             match use_cache {
@@ -553,7 +562,7 @@ impl LLMChatRequest {
         match generation {
             Some(generation) => Ok(generation),
             None => {
-                let generation = self.execute(credentials, None).await?;
+                let generation = self.execute(credentials, None, run_id).await?;
                 store
                     .llm_chat_cache_store(&project, self, &generation)
                     .await?;

--- a/core/src/providers/mistral.rs
+++ b/core/src/providers/mistral.rs
@@ -158,7 +158,7 @@ impl TryFrom<&ChatMessage> for MistralChatMessage {
     type Error = anyhow::Error;
 
     fn try_from(cm: &ChatMessage) -> Result<Self, Self::Error> {
-        let mut mistral_role = MistralChatMessageRole::try_from(&cm.role)
+        let mistral_role = MistralChatMessageRole::try_from(&cm.role)
             .map_err(|e| anyhow!("Error converting role: {:?}", e))?;
 
         Ok(MistralChatMessage {

--- a/core/src/providers/mistral.rs
+++ b/core/src/providers/mistral.rs
@@ -10,8 +10,7 @@ use crate::providers::llm::{
 };
 use crate::providers::provider::{ModelError, ModelErrorRetryOptions, Provider, ProviderID};
 use crate::run::Credentials;
-use crate::utils::{self, now};
-use crate::utils::{new_id, ParseError};
+use crate::utils::{self, now, ParseError};
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use eventsource_client as es;
@@ -428,7 +427,7 @@ impl MistralAILLM {
         tools: Vec<MistralTool>,
         tool_choice: Option<MistralToolChoice>,
         event_sender: Option<UnboundedSender<Value>>,
-    ) -> Result<MistralChatCompletion> {
+    ) -> Result<(MistralChatCompletion, Option<String>)> {
         let url = uri.to_string();
 
         let mut builder = match es::ClientBuilder::for_url(url.as_str()) {
@@ -741,7 +740,7 @@ impl MistralAILLM {
             };
         }
 
-        Ok(completion)
+        Ok((completion, None))
     }
 
     async fn chat_completion(
@@ -755,7 +754,7 @@ impl MistralAILLM {
         max_tokens: Option<i32>,
         tools: Vec<MistralTool>,
         tool_choice: Option<MistralToolChoice>,
-    ) -> Result<MistralChatCompletion> {
+    ) -> Result<(MistralChatCompletion, Option<String>)> {
         let mut body = json!({
             "messages": messages,
             "temperature": temperature,
@@ -845,7 +844,7 @@ impl MistralAILLM {
             };
         }
 
-        Ok(completion)
+        Ok((completion, request_id))
     }
 }
 
@@ -959,7 +958,7 @@ impl LLM for MistralAILLM {
             None => (None, vec![]),
         };
 
-        let c = match event_sender {
+        let (c, request_id) = match event_sender {
             Some(_) => {
                 self.streamed_chat_completion(
                     self.chat_uri()?,
@@ -1012,6 +1011,7 @@ impl LLM for MistralAILLM {
                 completion_tokens: u.completion_tokens.unwrap_or(0),
                 prompt_tokens: u.prompt_tokens,
             }),
+            provider_request_id: request_id,
         })
     }
 

--- a/core/src/providers/provider.rs
+++ b/core/src/providers/provider.rs
@@ -77,7 +77,7 @@ impl std::fmt::Display for ModelError {
         write!(
             f,
             "[model_error(retryable={}{})] {}",
-            match self.request_id {
+            match self.request_id.as_ref() {
                 Some(r) => format!(", request_id={}", r),
                 None => String::from(""),
             },

--- a/core/src/providers/provider.rs
+++ b/core/src/providers/provider.rs
@@ -76,7 +76,11 @@ impl std::fmt::Display for ModelError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(
             f,
-            "[model_error(retryable={})] {}",
+            "[model_error(retryable={}{})] {}",
+            match self.request_id {
+                Some(r) => format!(", request_id={}", r),
+                None => String::from(""),
+            },
             self.retryable.is_some(),
             self.message
         )


### PR DESCRIPTION
## Description

- Marginally improves support for `request-ids`. Capture them in `LLM(Chat)Response`. (We still need to support success case in streaming, requires getting the headers out of event-source-client library)
- Bring the run_id in the Env (exposed to client as well (could be retrieved from code blocks))
- Use the Env run_id to add both the run_id and request_id in various logs for correleation
- Return run_id as meta

Note: it's fine to serialize the provider_requst_id in `LLMChatResponse` to cache since cache is no per project and therefore user specific.

## Risk

None

## Deploy Plan

- deploy `core`