### PR TITLE
core: support for request IDs in non-error streaming case

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1140,7 +1140,7 @@ dependencies = [
 [[package]]
 name = "eventsource-client"
 version = "0.12.2"
-source = "git+https://github.com/dust-tt/rust-eventsource-client?rev=d34896e77b2198cd4d71e05007798736142ec336#d34896e77b2198cd4d71e05007798736142ec336"
+source = "git+https://github.com/dust-tt/rust-eventsource-client?rev=148050f8fb9f8abb25ca171aa68ea817277ca4f6#148050f8fb9f8abb25ca171aa68ea817277ca4f6"
 dependencies = [
  "futures",
  "hyper 0.14.29",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -52,7 +52,7 @@ urlencoding = "2.1"
 url = "2.5"
 dns-lookup = "1.0"
 async-stream = "0.3"
-eventsource-client = { git = "https://github.com/dust-tt/rust-eventsource-client", rev = "d34896e77b2198cd4d71e05007798736142ec336" }
+eventsource-client = { git = "https://github.com/dust-tt/rust-eventsource-client", rev = "148050f8fb9f8abb25ca171aa68ea817277ca4f6" }
 tera = "1.20"
 fancy-regex = "0.13"
 rustc-hash = "1.1"

--- a/core/src/providers/google_ai_studio.rs
+++ b/core/src/providers/google_ai_studio.rs
@@ -694,6 +694,10 @@ pub async fn streamed_chat_completion(
     'stream: loop {
         match stream.try_next().await {
             Ok(e) => match e {
+                Some(es::SSE::Connected(_)) => {
+                    // GoogleAISudio does not return a request id in headers.
+                    // Nothing to do.
+                }
                 Some(es::SSE::Comment(_)) => {
                     println!("UNEXPECTED COMMENT");
                 }

--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -395,7 +395,6 @@ pub struct InnerError {
     #[serde(alias = "type")]
     pub _type: String,
     pub param: Option<String>,
-    pub code: Option<usize>,
     pub internal_message: Option<String>,
 }
 
@@ -686,11 +685,13 @@ pub async fn streamed_completion(
                                     }),
                                 }
                             }?,
-                            Err(_) => Err(anyhow!(
-                                "Error streaming tokens from OpenAI: status={} data={}",
-                                status,
-                                String::from_utf8_lossy(&b)
-                            ))?,
+                            Err(_) => {
+                                Err(anyhow!(
+                                    "Error streaming tokens from OpenAI: status={} data={}",
+                                    status,
+                                    String::from_utf8_lossy(&b)
+                                ))?;
+                            }
                         }
                     }
                     _ => {
@@ -1128,11 +1129,13 @@ pub async fn streamed_chat_completion(
                                     }),
                                 }
                             }?,
-                            Err(_) => Err(anyhow!(
-                                "Error streaming tokens from OpenAI: status={} data={}",
-                                status,
-                                String::from_utf8_lossy(&b)
-                            ))?,
+                            Err(_) => {
+                                Err(anyhow!(
+                                    "Error streaming tokens from OpenAI: status={} data={}",
+                                    status,
+                                    String::from_utf8_lossy(&b)
+                                ))?;
+                            }
                         }
                     }
                     _ => {


### PR DESCRIPTION
## Description

Leverage new `SSE::Connected` event to pull the header from providers who provide request IDs in headers (openai, anthropic, mistral).

## Risk

Low, tested locally

## Deploy Plan

- deploy `core`