### PR TITLE
Template multi actions

### DIFF
--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -1,29 +1,18 @@
 import {
   Button,
   CardButton,
-  CommandLineIcon,
   DropdownMenu,
   Icon,
   IconButton,
   Input,
-  MagnifyingGlassIcon,
   Modal,
   MoreIcon,
   Page,
-  PlanetIcon,
   PlusIcon,
-  ScanIcon,
-  TableIcon,
   TextArea,
-  TimeIcon,
   XMarkIcon,
 } from "@dust-tt/sparkle";
-import type {
-  AppType,
-  DataSourceType,
-  WhitelistableFeature,
-  WorkspaceType,
-} from "@dust-tt/types";
+import type { AppType, DataSourceType, WorkspaceType } from "@dust-tt/types";
 import { assertNever, MAX_TOOLS_USE_PER_RUN_LIMIT } from "@dust-tt/types";
 import _ from "lodash";
 import type { ReactNode } from "react";
@@ -55,65 +44,12 @@ import type {
   AssistantBuilderTablesQueryConfiguration,
 } from "@app/components/assistant_builder/types";
 import { getDefaultActionConfiguration } from "@app/components/assistant_builder/types";
+import { ACTION_SPECIFICATIONS } from "@app/lib/api/assistant/actions/utils";
 
 import {
   ActionDustAppRun,
   isActionDustAppRunValid,
 } from "./actions/DustAppRunAction";
-
-const ACTION_SPECIFICATIONS: Record<
-  AssistantBuilderActionConfiguration["type"],
-  {
-    label: string;
-    description: string;
-    dropDownIcon: React.ComponentProps<typeof Icon>["visual"];
-    cardIcon: React.ComponentProps<typeof Icon>["visual"];
-    flag: WhitelistableFeature | null;
-  }
-> = {
-  RETRIEVAL_EXHAUSTIVE: {
-    label: "Most recent data",
-    description: "Include as much data as possible",
-    cardIcon: TimeIcon,
-    dropDownIcon: TimeIcon,
-    flag: null,
-  },
-  RETRIEVAL_SEARCH: {
-    label: "Search",
-    description: "Search through selected Data sources",
-    cardIcon: MagnifyingGlassIcon,
-    dropDownIcon: MagnifyingGlassIcon,
-    flag: null,
-  },
-  PROCESS: {
-    label: "Extract data",
-    description: "Structured extraction",
-    cardIcon: ScanIcon,
-    dropDownIcon: ScanIcon,
-    flag: null,
-  },
-  DUST_APP_RUN: {
-    label: "Run a Dust App",
-    description: "Run a Dust app, then reply",
-    cardIcon: CommandLineIcon,
-    dropDownIcon: CommandLineIcon,
-    flag: null,
-  },
-  TABLES_QUERY: {
-    label: "Query Tables",
-    description: "Tables, Spreadsheets, Notion DBs (quantitative)",
-    cardIcon: TableIcon,
-    dropDownIcon: TableIcon,
-    flag: null,
-  },
-  WEBSEARCH: {
-    label: "Web search",
-    description: "Perform a web search",
-    cardIcon: PlanetIcon,
-    dropDownIcon: PlanetIcon,
-    flag: "websearch_action",
-  },
-};
 
 const DATA_SOURCES_ACTION_CATEGORIES = [
   "RETRIEVAL_SEARCH",

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -178,16 +178,14 @@ const screens = {
   instructions: {
     label: "Instructions",
     icon: CircleIcon,
-    helpContainer: "instructions-help-container",
   },
   actions: {
     label: "Actions & Data sources",
     icon: SquareIcon,
-    helpContainer: "actions-help-container",
   },
-  naming: { label: "Naming", icon: TriangleIcon, helpContainer: null },
+  naming: { label: "Naming", icon: TriangleIcon },
 };
-type BuilderScreen = keyof typeof screens;
+export type BuilderScreen = keyof typeof screens;
 
 export default function AssistantBuilder({
   owner,
@@ -276,17 +274,19 @@ export default function AssistantBuilder({
     if (template === null) {
       return;
     }
-    const action = getAgentActionConfigurationType(template.presetAction);
-    let actionType: AssistantBuilderActionType | null = null;
 
-    if (isRetrievalConfiguration(action)) {
-      actionType = "RETRIEVAL_SEARCH";
-    } else if (isDustAppRunConfiguration(action)) {
-      actionType = "DUST_APP_RUN";
-    } else if (isTablesQueryConfiguration(action)) {
-      actionType = "TABLES_QUERY";
-    } else if (isProcessConfiguration(action)) {
-      actionType = "PROCESS";
+    let actionType: AssistantBuilderActionType | null = null;
+    if (!multiActionsEnabled) {
+      const action = getAgentActionConfigurationType(template.presetAction);
+      if (isRetrievalConfiguration(action)) {
+        actionType = "RETRIEVAL_SEARCH";
+      } else if (isDustAppRunConfiguration(action)) {
+        actionType = "DUST_APP_RUN";
+      } else if (isTablesQueryConfiguration(action)) {
+        actionType = "TABLES_QUERY";
+      } else if (isProcessConfiguration(action)) {
+        actionType = "PROCESS";
+      }
     }
 
     if (actionType !== null) {
@@ -301,7 +301,7 @@ export default function AssistantBuilder({
         return newState;
       });
     }
-  }, [template]);
+  }, [template, multiActionsEnabled]);
 
   const showSlackIntegration =
     builderState.scope === "workspace" || builderState.scope === "published";
@@ -513,18 +513,11 @@ export default function AssistantBuilder({
   const [screen, setScreen] = useState<BuilderScreen>("instructions");
   const tabs = useMemo(
     () =>
-      Object.entries(screens).map(([key, { label, icon, helpContainer }]) => ({
+      Object.entries(screens).map(([key, { label, icon }]) => ({
         label,
         current: screen === key,
         onClick: () => {
           setScreen(key as BuilderScreen);
-
-          if (helpContainer) {
-            const element = document.getElementById(helpContainer);
-            if (element) {
-              element.scrollIntoView({ behavior: "smooth" });
-            }
-          }
         },
         icon,
       })),
@@ -695,6 +688,7 @@ export default function AssistantBuilder({
           }
           rightPanel={
             <AssistantBuilderRightPanel
+              screen={screen}
               template={template}
               resetTemplate={resetTemplate}
               resetToTemplateInstructions={resetToTemplateInstructions}

--- a/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
+++ b/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
@@ -227,7 +227,6 @@ export default function AssistantBuilderRightPanel({
                 {template && template.helpActions && (
                   <>
                     <div>
-                      {/* <Page.SectionHeader title="Guide" /> */}
                       <Markdown
                         content={template?.helpActions ?? ""}
                         className=""

--- a/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
+++ b/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
@@ -1,12 +1,16 @@
 import {
   Button,
+  CardButton,
   ChatBubbleBottomCenterTextIcon,
   DropdownMenu,
+  Icon,
+  IconButton,
   LightbulbIcon,
   MagicIcon,
   Markdown,
   MoreIcon,
   Page,
+  PlusCircleStrokeIcon,
   Spinner,
   Tab,
   XMarkIcon,
@@ -16,23 +20,30 @@ import type {
   AssistantBuilderRightPanelTab,
   WorkspaceType,
 } from "@dust-tt/types";
+import { Separator } from "@radix-ui/react-select";
+import _ from "lodash";
 import { useContext, useEffect, useMemo } from "react";
 
 import ConversationViewer from "@app/components/assistant/conversation/ConversationViewer";
 import { GenerationContextProvider } from "@app/components/assistant/conversation/GenerationContextProvider";
 import { AssistantInputBar } from "@app/components/assistant/conversation/input_bar/InputBar";
-import { CONVERSATION_PARENT_SCROLL_DIV_ID } from "@app/components/assistant/conversation/lib";
 import {
   usePreviewAssistant,
   useTryAssistantCore,
 } from "@app/components/assistant/TryAssistant";
-import type { AssistantBuilderState } from "@app/components/assistant_builder/types";
+import type { BuilderScreen } from "@app/components/assistant_builder/AssistantBuilder";
+import type {
+  AssistantBuilderState,
+  TemplateActionType,
+} from "@app/components/assistant_builder/types";
 import { ConfirmContext } from "@app/components/Confirm";
+import { ACTION_SPECIFICATIONS } from "@app/lib/api/assistant/actions/utils";
 import { useUser } from "@app/lib/swr";
 import { classNames } from "@app/lib/utils";
 import type { FetchAssistantTemplateResponse } from "@app/pages/api/w/[wId]/assistant/builder/templates/[tId]";
 
 export default function AssistantBuilderRightPanel({
+  screen,
   template,
   resetTemplate,
   resetToTemplateInstructions,
@@ -43,6 +54,7 @@ export default function AssistantBuilderRightPanel({
   builderState,
   multiActionsMode,
 }: {
+  screen: BuilderScreen;
   template: FetchAssistantTemplateResponse | null;
   resetTemplate: () => Promise<void>;
   resetToTemplateInstructions: () => Promise<void>;
@@ -53,8 +65,6 @@ export default function AssistantBuilderRightPanel({
   builderState: AssistantBuilderState;
   multiActionsMode: boolean;
 }) {
-  const confirm = useContext(ConfirmContext);
-
   const tabsConfig = useMemo(
     () => [
       {
@@ -105,6 +115,12 @@ export default function AssistantBuilderRightPanel({
     setConversation(null);
   }, [draftAssistant?.sId, setConversation]);
 
+  useEffect(() => {
+    if (rightPanelStatus.tab === "Template" && screen === "naming") {
+      openRightPanelTab("Preview");
+    }
+  }, [screen, rightPanelStatus.tab, openRightPanelTab]);
+
   return (
     <div className="flex h-full flex-col">
       {template && (
@@ -127,141 +143,249 @@ export default function AssistantBuilderRightPanel({
             : ""
         )}
       >
-        {rightPanelStatus.tab === "Preview" && user && (
-          <div className="flex h-full w-full flex-1 flex-col justify-between overflow-x-hidden">
-            {draftAssistant ? (
-              <GenerationContextProvider>
-                <div
-                  className="flex-grow overflow-y-auto"
-                  id={CONVERSATION_PARENT_SCROLL_DIV_ID.modal}
-                >
-                  {conversation && (
-                    <ConversationViewer
+        {(rightPanelStatus.tab === "Preview" || screen === "naming") &&
+          user && (
+            <div className="flex h-full w-full flex-1 flex-col justify-between overflow-x-hidden">
+              {draftAssistant ? (
+                <GenerationContextProvider>
+                  <div className="flex-grow overflow-y-auto">
+                    {conversation && (
+                      <ConversationViewer
+                        owner={owner}
+                        user={user}
+                        conversationId={conversation.sId}
+                        onStickyMentionsChange={setStickyMentions}
+                        isInModal
+                        hideReactions
+                        isFading={isFading}
+                        key={conversation.sId}
+                      />
+                    )}
+                  </div>
+                  <div className="shrink-0">
+                    <AssistantInputBar
                       owner={owner}
-                      user={user}
-                      conversationId={conversation.sId}
-                      onStickyMentionsChange={setStickyMentions}
-                      isInModal
-                      hideReactions
-                      isFading={isFading}
-                      key={conversation.sId}
+                      onSubmit={handleSubmit}
+                      stickyMentions={stickyMentions}
+                      conversationId={conversation?.sId || null}
+                      additionalAgentConfiguration={draftAssistant}
+                      hideQuickActions
+                      disableAutoFocus
+                      isFloating={false}
                     />
-                  )}
+                  </div>
+                </GenerationContextProvider>
+              ) : (
+                <div className="flex h-full w-full items-center justify-center">
+                  <Spinner />
                 </div>
-                <div className="shrink-0">
-                  <AssistantInputBar
-                    owner={owner}
-                    onSubmit={handleSubmit}
-                    stickyMentions={stickyMentions}
-                    conversationId={conversation?.sId || null}
-                    additionalAgentConfiguration={draftAssistant}
-                    hideQuickActions
-                    disableAutoFocus
-                    isFloating={false}
-                  />
-                </div>
-              </GenerationContextProvider>
-            ) : (
-              <div className="flex h-full w-full items-center justify-center">
-                <Spinner />
-              </div>
-            )}
-          </div>
-        )}
-        {rightPanelStatus.tab === "Template" && (
-          <div className="mb-72 flex flex-col gap-4 px-6">
-            <div className="flex items-end justify-between pt-2">
-              <Page.Header
-                icon={LightbulbIcon}
-                title="Template's User manual"
-              />
-              <DropdownMenu className="text-element-700">
-                <DropdownMenu.Button>
-                  <Button
-                    icon={MoreIcon}
-                    label="Actions"
-                    labelVisible={false}
-                    disabledTooltip
-                    size="sm"
-                    variant="tertiary"
-                    hasMagnifying={false}
-                  />
-                </DropdownMenu.Button>
-                <DropdownMenu.Items width={320} origin="topRight">
-                  <DropdownMenu.Item
-                    label="Close the template"
-                    onClick={async () => {
-                      const confirmed = await confirm({
-                        title: "Are you sure you want to close the template?",
-                        message:
-                          "Your assistant will remain as it is but will not display template's help any more.",
-                        validateVariant: "primaryWarning",
-                      });
-                      if (confirmed) {
-                        openRightPanelTab("Preview");
-                        await resetTemplate();
-                      }
-                    }}
-                    icon={XMarkIcon}
-                  />
-                  <DropdownMenu.Item
-                    label="Reset instructions"
-                    description="Set instructions back to template's default"
-                    onClick={async () => {
-                      const confirmed = await confirm({
-                        title: "Are you sure?",
-                        message:
-                          "You will lose the changes you have made to the assistant's instructions and go back to the template's default settings.",
-                        validateVariant: "primaryWarning",
-                      });
-                      if (confirmed) {
-                        await resetToTemplateInstructions();
-                      }
-                    }}
-                    icon={MagicIcon}
-                  />
-                  <DropdownMenu.Item
-                    label="Reset actions"
-                    description="Set actions back to template's default"
-                    onClick={async () => {
-                      const confirmed = await confirm({
-                        title: "Are you sure?",
-                        message:
-                          "You will lose the changes you have made to the assistant's actions and go back to the template's default settings.",
-                        validateVariant: "primaryWarning",
-                      });
-                      if (confirmed) {
-                        await resetToTemplateActions();
-                      }
-                    }}
-                    icon={MagicIcon}
-                  />
-                </DropdownMenu.Items>
-              </DropdownMenu>
+              )}
             </div>
-            <Page.Separator />
-            {template?.helpInstructions && (
-              <div id="instructions-help-container">
-                <Page.SectionHeader title='"Instructions" guide' />
-                <Markdown content={template?.helpInstructions ?? ""} />
-              </div>
-            )}
-            {template?.helpInstructions && template?.helpActions && (
-              <Page.Separator />
-            )}
-            {template?.helpActions && (
-              <div id="actions-help-container">
-                <Page.SectionHeader title='"Actions" guide' />
-                <Markdown
-                  content={template?.helpActions ?? ""}
-                  className=""
-                  size="sm"
+          )}
+        {rightPanelStatus.tab === "Template" &&
+          template &&
+          screen === "instructions" && (
+            <div className="mb-72 flex flex-col gap-4 px-6">
+              <div className="flex items-end justify-between pt-2">
+                <Page.Header
+                  icon={LightbulbIcon}
+                  title="Template's Instructions manual"
+                />
+                <TemplateDropDownMenu
+                  screen={screen}
+                  resetTemplate={resetTemplate}
+                  resetToTemplateInstructions={resetToTemplateInstructions}
+                  resetToTemplateActions={resetToTemplateActions}
+                  openRightPanelTab={openRightPanelTab}
                 />
               </div>
-            )}
-          </div>
-        )}
+              <Page.Separator />
+              {template?.helpInstructions && (
+                <Markdown content={template?.helpInstructions ?? ""} />
+              )}
+            </div>
+          )}
+        {rightPanelStatus.tab === "Template" &&
+          template &&
+          screen === "actions" && (
+            <div className="mb-72 flex flex-col gap-4 px-6">
+              <div className="flex items-end justify-between pt-2">
+                <Page.Header
+                  icon={LightbulbIcon}
+                  title="Template's Actions manual"
+                />
+                <TemplateDropDownMenu
+                  screen={screen}
+                  resetTemplate={resetTemplate}
+                  resetToTemplateInstructions={resetToTemplateInstructions}
+                  resetToTemplateActions={resetToTemplateActions}
+                  openRightPanelTab={openRightPanelTab}
+                />
+              </div>
+              <Page.Separator />
+              <div className="flex flex-col gap-4">
+                {template && template.helpActions && (
+                  <>
+                    <div>
+                      {/* <Page.SectionHeader title="Guide" /> */}
+                      <Markdown
+                        content={template?.helpActions ?? ""}
+                        className=""
+                        size="sm"
+                      />
+                    </div>
+                    <Separator />
+                  </>
+                )}
+                {template &&
+                  multiActionsMode &&
+                  template.presetActions.length > 0 && (
+                    <div className="flex flex-col gap-6">
+                      <Page.SectionHeader title="Add those actions" />
+                      {template.presetActions.map((action, index) => (
+                        <div className="flex flex-col gap-2" key={index}>
+                          {action.description}:
+                          <TemplateActionCard
+                            action={action}
+                            addAction={() =>
+                              alert(
+                                "Add action for multi-actions not implemented yet"
+                              )
+                            }
+                          />
+                        </div>
+                      ))}
+                    </div>
+                  )}
+              </div>
+            </div>
+          )}
       </div>
     </div>
   );
 }
+
+const TemplateActionCard = ({
+  action,
+  addAction,
+}: {
+  action: TemplateActionType;
+  addAction: () => void;
+}) => {
+  const spec = ACTION_SPECIFICATIONS[action.type];
+  if (!spec) {
+    // Unreachable
+    return null;
+  }
+  return (
+    <CardButton
+      variant="primary"
+      onClick={addAction}
+      className="inline-block w-72"
+    >
+      <div className="flex w-full flex-col gap-2 text-sm">
+        <div className="flex w-full gap-1 font-medium text-element-900">
+          <Icon visual={spec.cardIcon} size="sm" className="text-element-900" />
+          <div className="w-full truncate">
+            Add action &quot;{spec.label}&quot;
+          </div>
+          <IconButton
+            icon={PlusCircleStrokeIcon}
+            variant="tertiary"
+            size="sm"
+            onClick={addAction}
+          />
+        </div>
+        <div className="w-full truncate text-base text-element-700">
+          {_.capitalize(_.toLower(action.name).replace(/_/g, " "))}
+        </div>
+      </div>
+    </CardButton>
+  );
+};
+
+const TemplateDropDownMenu = ({
+  screen,
+  resetTemplate,
+  resetToTemplateInstructions,
+  resetToTemplateActions,
+  openRightPanelTab,
+}: {
+  screen: BuilderScreen;
+  resetTemplate: () => Promise<void>;
+  resetToTemplateInstructions: () => Promise<void>;
+  resetToTemplateActions: () => Promise<void>;
+  openRightPanelTab: (tabName: AssistantBuilderRightPanelTab) => void;
+}) => {
+  const confirm = useContext(ConfirmContext);
+
+  return (
+    <DropdownMenu className="text-element-700">
+      <DropdownMenu.Button>
+        <Button
+          icon={MoreIcon}
+          label="Actions"
+          labelVisible={false}
+          disabledTooltip
+          size="sm"
+          variant="tertiary"
+          hasMagnifying={false}
+        />
+      </DropdownMenu.Button>
+      <DropdownMenu.Items width={320} origin="topRight">
+        <DropdownMenu.Item
+          label="Close the template"
+          onClick={async () => {
+            const confirmed = await confirm({
+              title: "Are you sure you want to close the template?",
+              message:
+                "Your assistant will remain as it is but will not display template's help any more.",
+              validateVariant: "primaryWarning",
+            });
+            if (confirmed) {
+              openRightPanelTab("Preview");
+              await resetTemplate();
+            }
+          }}
+          icon={XMarkIcon}
+        />
+        {screen === "instructions" && (
+          <DropdownMenu.Item
+            label="Reset instructions"
+            description="Set instructions back to template's default"
+            onClick={async () => {
+              const confirmed = await confirm({
+                title: "Are you sure?",
+                message:
+                  "You will lose the changes you have made to the assistant's instructions and go back to the template's default settings.",
+                validateVariant: "primaryWarning",
+              });
+              if (confirmed) {
+                await resetToTemplateInstructions();
+              }
+            }}
+            icon={MagicIcon}
+          />
+        )}
+        {screen === "actions" && (
+          <DropdownMenu.Item
+            label="Reset actions"
+            description="Set actions back to template's default"
+            onClick={async () => {
+              const confirmed = await confirm({
+                title: "Are you sure?",
+                message:
+                  "You will lose the changes you have made to the assistant's actions and go back to the template's default settings.",
+                validateVariant: "primaryWarning",
+              });
+              if (confirmed) {
+                await resetToTemplateActions();
+              }
+            }}
+            icon={MagicIcon}
+          />
+        )}
+      </DropdownMenu.Items>
+    </DropdownMenu>
+  );
+};

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -106,6 +106,11 @@ export type AssistantBuilderActionConfiguration = (
   description: string;
 };
 
+export type TemplateActionType = Omit<
+  AssistantBuilderActionConfiguration,
+  "configuration"
+>;
+
 export type AssistantBuilderActionType =
   AssistantBuilderActionConfiguration["type"];
 

--- a/front/lib/api/assistant/actions/utils.ts
+++ b/front/lib/api/assistant/actions/utils.ts
@@ -1,0 +1,66 @@
+import type { Icon } from "@dust-tt/sparkle";
+import {
+  CommandLineIcon,
+  MagnifyingGlassIcon,
+  PlanetIcon,
+  ScanIcon,
+  TableIcon,
+  TimeIcon,
+} from "@dust-tt/sparkle";
+import type { WhitelistableFeature } from "@dust-tt/types";
+
+import type { AssistantBuilderActionConfiguration } from "@app/components/assistant_builder/types";
+
+export const ACTION_SPECIFICATIONS: Record<
+  AssistantBuilderActionConfiguration["type"],
+  {
+    label: string;
+    description: string;
+    dropDownIcon: React.ComponentProps<typeof Icon>["visual"];
+    cardIcon: React.ComponentProps<typeof Icon>["visual"];
+    flag: WhitelistableFeature | null;
+  }
+> = {
+  RETRIEVAL_EXHAUSTIVE: {
+    label: "Most recent data",
+    description: "Include as much data as possible",
+    cardIcon: TimeIcon,
+    dropDownIcon: TimeIcon,
+    flag: null,
+  },
+  RETRIEVAL_SEARCH: {
+    label: "Search",
+    description: "Search through selected Data sources",
+    cardIcon: MagnifyingGlassIcon,
+    dropDownIcon: MagnifyingGlassIcon,
+    flag: null,
+  },
+  PROCESS: {
+    label: "Extract data",
+    description: "Structured extraction",
+    cardIcon: ScanIcon,
+    dropDownIcon: ScanIcon,
+    flag: null,
+  },
+  DUST_APP_RUN: {
+    label: "Run a Dust App",
+    description: "Run a Dust app, then reply",
+    cardIcon: CommandLineIcon,
+    dropDownIcon: CommandLineIcon,
+    flag: null,
+  },
+  TABLES_QUERY: {
+    label: "Query Tables",
+    description: "Tables, Spreadsheets, Notion DBs (quantitative)",
+    cardIcon: TableIcon,
+    dropDownIcon: TableIcon,
+    flag: null,
+  },
+  WEBSEARCH: {
+    label: "Web search",
+    description: "Perform a web search",
+    cardIcon: PlanetIcon,
+    dropDownIcon: PlanetIcon,
+    flag: "websearch_action",
+  },
+};

--- a/front/lib/api/assistant/templates.ts
+++ b/front/lib/api/assistant/templates.ts
@@ -16,21 +16,26 @@ import { TemplateResource } from "@app/lib/resources/template_resource";
 
 export async function generateMockAgentConfigurationFromTemplate(
   templateId: string,
-  flow: BuilderFlow
+  flow: BuilderFlow,
+  isMultiActions: boolean
 ): Promise<Result<TemplateAgentConfigurationType, Error>> {
   const template = await TemplateResource.fetchByExternalId(templateId);
   if (!template) {
     return new Err(new Error("Template not found"));
   }
 
+  const actions = isMultiActions
+    ? []
+    : removeNulls([
+        getAgentActionConfigurationType(
+          template.presetAction,
+          template.timeFrameDuration,
+          template.timeFrameUnit
+        ),
+      ]);
+
   return new Ok({
-    actions: removeNulls([
-      getAgentActionConfigurationType(
-        template.presetAction,
-        template.timeFrameDuration,
-        template.timeFrameUnit
-      ),
-    ]),
+    actions,
     description: template.description ?? "",
     instructions: template.presetInstructions ?? "",
     model: {

--- a/front/lib/resources/storage/models/templates.ts
+++ b/front/lib/resources/storage/models/templates.ts
@@ -14,20 +14,8 @@ import type {
 } from "sequelize";
 import { DataTypes, Model } from "sequelize";
 
+import type { TemplateActionType } from "@app/components/assistant_builder/types";
 import { frontSequelize } from "@app/lib/resources/storage";
-
-type TemplateAction = {
-  type:
-    | "RETRIEVAL_SEARCH"
-    | "RETRIEVAL_EXHAUSTIVE"
-    | "DUST_APP_RUN"
-    | "TABLES_QUERY"
-    | "PROCESS";
-  helpContent: string | null;
-  name: string | null;
-  description: string | null;
-  configuration: Record<string, unknown>;
-};
 
 export class TemplateModel extends Model<
   InferAttributes<TemplateModel>,
@@ -52,7 +40,7 @@ export class TemplateModel extends Model<
   declare presetProviderId: ModelProviderIdType;
   declare presetModelId: ModelIdType;
   declare presetAction: ActionPreset; // @todo[daph] Remove this field once templates are migrated to multi-ations.
-  declare presetActions: TemplateAction[];
+  declare presetActions: TemplateActionType[];
 
   declare timeFrameDuration: number | null;
   declare timeFrameUnit: TimeframeUnit | null;

--- a/front/lib/resources/storage/models/templates.ts
+++ b/front/lib/resources/storage/models/templates.ts
@@ -16,6 +16,19 @@ import { DataTypes, Model } from "sequelize";
 
 import { frontSequelize } from "@app/lib/resources/storage";
 
+type TemplateAction = {
+  type:
+    | "RETRIEVAL_SEARCH"
+    | "RETRIEVAL_EXHAUSTIVE"
+    | "DUST_APP_RUN"
+    | "TABLES_QUERY"
+    | "PROCESS";
+  helpContent: string | null;
+  name: string | null;
+  description: string | null;
+  configuration: Record<string, unknown>;
+};
+
 export class TemplateModel extends Model<
   InferAttributes<TemplateModel>,
   InferCreationAttributes<TemplateModel>
@@ -38,7 +51,8 @@ export class TemplateModel extends Model<
   declare presetTemperature: AssistantCreativityLevel;
   declare presetProviderId: ModelProviderIdType;
   declare presetModelId: ModelIdType;
-  declare presetAction: ActionPreset;
+  declare presetAction: ActionPreset; // @todo[daph] Remove this field once templates are migrated to multi-ations.
+  declare presetActions: TemplateAction[];
 
   declare timeFrameDuration: number | null;
   declare timeFrameUnit: TimeframeUnit | null;
@@ -110,6 +124,11 @@ TemplateModel.init(
     presetAction: {
       type: DataTypes.STRING,
       allowNull: false,
+    },
+    presetActions: {
+      type: DataTypes.JSONB,
+      allowNull: false,
+      defaultValue: [],
     },
     timeFrameDuration: {
       type: DataTypes.INTEGER,

--- a/front/lib/resources/template_resource.ts
+++ b/front/lib/resources/template_resource.ts
@@ -145,6 +145,7 @@ export class TemplateResource extends BaseResource<TemplateModel> {
       helpInstructions: this.helpInstructions,
       pictureUrl: this.pictureUrl,
       presetAction: this.presetAction,
+      presetActions: this.presetActions,
       timeFrameDuration: this.timeFrameDuration,
       timeFrameUnit: this.timeFrameUnit,
       presetDescription: this.presetDescription,

--- a/front/migrations/db/migration_18.sql
+++ b/front/migrations/db/migration_18.sql
@@ -1,0 +1,2 @@
+-- Migration created on Jun 07, 2024
+ALTER TABLE "public"."templates" ADD COLUMN "presetActions" JSONB NOT NULL DEFAULT '[]';

--- a/front/pages/api/poke/templates/index.ts
+++ b/front/pages/api/poke/templates/index.ts
@@ -98,6 +98,7 @@ async function handler(
         helpActions: body.helpActions ?? null,
         helpInstructions: body.helpInstructions ?? null,
         presetAction: body.presetAction,
+        presetActions: [], // @todo[daph] implement multi-actions templates in poké
         presetDescription: null,
         presetInstructions: body.presetInstructions ?? null,
         presetModelId: model.modelId,

--- a/front/pages/w/[wId]/builder/assistants/new.tsx
+++ b/front/pages/w/[wId]/builder/assistants/new.tsx
@@ -95,9 +95,11 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       };
     }
   } else if (templateId) {
+    const isMultiActions = owner.flags.includes("multi_actions");
     const agentConfigRes = await generateMockAgentConfigurationFromTemplate(
       templateId,
-      flow
+      flow,
+      isMultiActions
     );
 
     if (agentConfigRes.isErr()) {


### PR DESCRIPTION
## Description

This PR is a first step towards supporting multi-actions templates. 
Adding actions from the templates in multi-actions yet does not work yet and will come up in my next PR but for the sake of not shipping a huge PR, this is a first batch of code. This is okay since there are no multi-actions templates on prod yet. 

## What are the changes on this PR? 

### **Change in the templates datamodel:** 
Added a new field `presetActions` that is JSONB. It will store an array of `TemplateActionType` which is basically a type/name/description. 

### **Changes in the UI:** 
- Now when on the instruction screen, we display only the instructions help content of the template. 
- When on the action screen, we display the action help. 
=> As opposed to displaying all with some automatic scrolling when we switch tab. 

Since there's no template help content for the naming step, if we land there I'm opening the Preview tab instead. I believe this makes sense because at this step you might want to try your assistant if you haven't done it yet. WDYT? 


### Preview for multi actions

I've also prepared the UI to display the multi-actions (it's just that the click on the card does nothing at the moment). 
For this screenshot, `presetActions` is set with: 
```JSON
[
    {
        "name": "query_companies_csv",
        "type": "TABLES_QUERY",
        "description": "Attach the csv containing the list of companies that we want to query"
    },
    {
        "name": "Websearch",
        "type": "WEBSEARCH",
        "description": "Allow the assistant to search the web to be able to retrieve information about the companies"
    }
]

```

<kbd>
<img width="1589" alt="Screenshot 2024-06-10 at 14 05 42" src="https://github.com/dust-tt/dust/assets/3803406/4536ae40-ad92-42eb-b97d-177deb13ed26">
</kbd>

## Risk

Break templates or the builder when using templates. 
Can be rolled back. 

## Deploy Plan

- Merge
- Run migration 18 on prodbox.
- Deploy front. 
