### PR TITLE
Remove startWithSignal for Gdrive incremental sync

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/client.ts
+++ b/connectors/src/connectors/google_drive/temporal/client.ts
@@ -9,7 +9,6 @@ import mainLogger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 
 import { QUEUE_NAME } from "./config";
-import { newWebhookSignal } from "./signals";
 import {
   googleDriveFullSync,
   googleDriveFullSyncWorkflowId,
@@ -96,15 +95,13 @@ export async function launchGoogleDriveIncrementalSyncWorkflow(
 
   const workflowId = googleDriveIncrementalSyncWorkflowId(connectorId);
   try {
-    await client.workflow.signalWithStart(googleDriveIncrementalSync, {
+    await client.workflow.start(googleDriveIncrementalSync, {
       args: [connectorId, dataSourceConfig],
       taskQueue: QUEUE_NAME,
       workflowId: workflowId,
       searchAttributes: {
         connectorId: [connectorId],
       },
-      signal: newWebhookSignal,
-      signalArgs: undefined,
       // Every 5 minutes.
       cronSchedule: "*/5 * * * *",
       memo: {


### PR DESCRIPTION
## Description

Forgot to remove the `signalWithStart` for the Gdrive incremental sync workflow in this PR:
https://github.com/dust-tt/dust/pull/5551

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
