### PR TITLE
Increase Gdrive max concurrent activity from 4 to 30.

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/worker.ts
+++ b/connectors/src/connectors/google_drive/temporal/worker.ts
@@ -19,7 +19,7 @@ export async function runGoogleWorker() {
     workflowsPath: require.resolve("./workflows"),
     activities: { ...activities, ...sync_status },
     taskQueue: QUEUE_NAME,
-    maxConcurrentActivityTaskExecutions: 4,
+    maxConcurrentActivityTaskExecutions: 30,
     connection,
     maxCachedWorkflows: TEMPORAL_MAXED_CACHED_WORKFLOWS,
     reuseV8Context: true,


### PR DESCRIPTION
## Description

Since we have one `googleDriveIncrementalSync` workflow per connector now, we need to increase the concurrency of the worker from 4 to 30. 

Also, the concurrent activity settings was not updated when [we moved google drive to a dedicated pod](https://github.com/dust-tt/dust/pull/5286), which considerably lowered its total activity concurrency.


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
