### PR TITLE
feat(data_sources): use workspace default embedder

### DIFF
--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -4,11 +4,11 @@ import type {
 } from "@dust-tt/types";
 import {
   DustAPI,
-  EMBEDDING_CONFIG,
   isValidDate,
   safeSubstring,
   sectionFullText,
 } from "@dust-tt/types";
+import { MAX_CHUNK_SIZE } from "@dust-tt/types/src";
 import type { AxiosRequestConfig, AxiosResponse } from "axios";
 import axios from "axios";
 import { fromMarkdown } from "mdast-util-from-markdown";
@@ -246,7 +246,7 @@ async function _updateDocumentParentsField({
 
 // allows for 4 full prefixes before hitting half of the max chunk size (approx.
 // 256 chars for 512 token chunks)
-export const MAX_PREFIX_TOKENS = EMBEDDING_CONFIG.max_chunk_size / 8;
+export const MAX_PREFIX_TOKENS = MAX_CHUNK_SIZE / 8;
 // Limit on chars to avoid tokenizing too much text uselessly on documents with
 // large prefixes. The final truncating will rely on MAX_PREFIX_TOKENS so this
 // limit can be large and should be large to avoid underusing prexfixes

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -8,7 +8,7 @@ import {
   safeSubstring,
   sectionFullText,
 } from "@dust-tt/types";
-import { MAX_CHUNK_SIZE } from "@dust-tt/types/src";
+import { MAX_CHUNK_SIZE } from "@dust-tt/types";
 import type { AxiosRequestConfig, AxiosResponse } from "axios";
 import axios from "axios";
 import { fromMarkdown } from "mdast-util-from-markdown";

--- a/front/lib/models/workspace.ts
+++ b/front/lib/models/workspace.ts
@@ -1,4 +1,8 @@
-import type { EmbeddingProviderIdType, RoleType, WorkspaceSegmentationType } from "@dust-tt/types";
+import type {
+  EmbeddingProviderIdType,
+  RoleType,
+  WorkspaceSegmentationType,
+} from "@dust-tt/types";
 import { MODEL_PROVIDER_IDS } from "@dust-tt/types";
 import type {
   CreationOptional,

--- a/front/lib/models/workspace.ts
+++ b/front/lib/models/workspace.ts
@@ -1,4 +1,4 @@
-import type { RoleType, WorkspaceSegmentationType } from "@dust-tt/types";
+import type { EmbeddingProviderIdType, RoleType, WorkspaceSegmentationType } from "@dust-tt/types";
 import { MODEL_PROVIDER_IDS } from "@dust-tt/types";
 import type {
   CreationOptional,
@@ -32,7 +32,7 @@ export class Workspace extends Model<
   declare ssoEnforced?: boolean;
   declare subscriptions: NonAttribute<Subscription[]>;
   declare whiteListedProviders: ModelProviderIdType[] | null;
-  declare defaultEmbeddingProvider: ModelProviderIdType | null;
+  declare defaultEmbeddingProvider: EmbeddingProviderIdType | null;
 }
 Workspace.init(
   {

--- a/front/pages/api/w/[wId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/index.ts
@@ -2,7 +2,7 @@ import type { DataSourceType, WithAPIErrorReponse } from "@dust-tt/types";
 import {
   DEFAULT_QDRANT_CLUSTER,
   dustManagedCredentials,
-  EMBEDDING_CONFIG,
+  EMBEDDING_CONFIGS,
   isDataSourceNameValid,
 } from "@dust-tt/types";
 import { CoreAPI } from "@dust-tt/types";
@@ -138,6 +138,8 @@ async function handler(
       // Dust managed credentials: all data sources.
       const credentials = dustManagedCredentials();
 
+      const dataSourceEmbedder = owner.defaultEmbeddingProvider ?? "openai";
+      const embedderConfig = EMBEDDING_CONFIGS[dataSourceEmbedder];
       const dustDataSource = await coreAPI.createDataSource({
         projectId: dustProject.value.project.project_id.toString(),
         dataSourceId: req.body.name as string,
@@ -148,10 +150,10 @@ async function handler(
           },
           embedder_config: {
             embedder: {
-              max_chunk_size: EMBEDDING_CONFIG.max_chunk_size,
-              model_id: EMBEDDING_CONFIG.model_id,
-              provider_id: EMBEDDING_CONFIG.provider_id,
-              splitter_id: EMBEDDING_CONFIG.splitter_id,
+              max_chunk_size: embedderConfig.max_chunk_size,
+              model_id: embedderConfig.model_id,
+              provider_id: embedderConfig.provider_id,
+              splitter_id: embedderConfig.splitter_id,
             },
           },
         },

--- a/front/pages/api/w/[wId]/data_sources/managed.ts
+++ b/front/pages/api/w/[wId]/data_sources/managed.ts
@@ -4,7 +4,7 @@ import {
   assertNever,
   ConnectorConfigurationTypeSchema,
   DEFAULT_QDRANT_CLUSTER,
-  EMBEDDING_CONFIG,
+  EMBEDDING_CONFIGS,
   ioTsParsePayload,
   isConnectorProvider,
   sendUserOperationMessage,
@@ -279,6 +279,9 @@ async function handler(
         });
       }
 
+      const dataSourceEmbedder = owner.defaultEmbeddingProvider ?? "openai";
+      const embedderConfig = EMBEDDING_CONFIGS[dataSourceEmbedder];
+
       // Dust managed credentials: managed data source.
       const credentials = dustManagedCredentials();
 
@@ -288,10 +291,10 @@ async function handler(
         config: {
           embedder_config: {
             embedder: {
-              max_chunk_size: EMBEDDING_CONFIG.max_chunk_size,
-              model_id: EMBEDDING_CONFIG.model_id,
-              provider_id: EMBEDDING_CONFIG.provider_id,
-              splitter_id: EMBEDDING_CONFIG.splitter_id,
+              max_chunk_size: embedderConfig.max_chunk_size,
+              model_id: embedderConfig.model_id,
+              provider_id: embedderConfig.provider_id,
+              splitter_id: embedderConfig.splitter_id,
             },
           },
           qdrant_config: {

--- a/types/src/core/data_source.ts
+++ b/types/src/core/data_source.ts
@@ -1,7 +1,7 @@
 export type QdrantCluster = "cluster-0";
 export const DEFAULT_QDRANT_CLUSTER: QdrantCluster = "cluster-0";
 
-interface EmbedderType {
+export interface EmbedderType {
   provider_id: string;
   model_id: string;
   splitter_id: string;

--- a/types/src/front/lib/assistant.ts
+++ b/types/src/front/lib/assistant.ts
@@ -13,10 +13,7 @@ export const MODEL_PROVIDER_IDS = [
 ] as const;
 export type ModelProviderIdType = (typeof MODEL_PROVIDER_IDS)[number];
 
-export const EMBEDDING_PROVIDER_IDS = [
-  "openai",
-  "mistral"
-] as const;
+export const EMBEDDING_PROVIDER_IDS = ["openai", "mistral"] as const;
 export type EmbeddingProviderIdType = (typeof EMBEDDING_PROVIDER_IDS)[number];
 
 export const isModelProviderId = (

--- a/types/src/front/lib/assistant.ts
+++ b/types/src/front/lib/assistant.ts
@@ -13,6 +13,12 @@ export const MODEL_PROVIDER_IDS = [
 ] as const;
 export type ModelProviderIdType = (typeof MODEL_PROVIDER_IDS)[number];
 
+export const EMBEDDING_PROVIDER_IDS = [
+  "openai",
+  "mistral"
+] as const;
+export type EmbeddingProviderIdType = (typeof EMBEDDING_PROVIDER_IDS)[number];
+
 export const isModelProviderId = (
   providerId: string
 ): providerId is ModelProviderIdType =>

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -5,7 +5,7 @@ import {
   CoreAPIDataSourceConfig,
   CoreAPIDataSourceDocumentSection,
   CoreAPIDocument,
-  CoreAPILightDocument,
+  CoreAPILightDocument, EmbedderType,
 } from "../../core/data_source";
 import { DustAppSecretType } from "../../front/dust_app_secret";
 import { dustManagedCredentials } from "../../front/lib/api/credentials";
@@ -20,15 +20,25 @@ import {
 } from "../../front/run";
 import { LoggerInterface } from "../../shared/logger";
 import { Err, Ok, Result } from "../../shared/result";
+import { EmbeddingProviderIdType } from "./assistant";
 
 const { CORE_API = "http://127.0.0.1:3001" } = process.env;
 
-export const EMBEDDING_CONFIG = {
-  model_id: "text-embedding-3-large-1536",
-  provider_id: "openai",
-  splitter_id: "base_v0",
-  max_chunk_size: 512,
-};
+
+export const EMBEDDING_CONFIGS: Record<EmbeddingProviderIdType, EmbedderType> = {
+  openai: {
+    model_id: "text-embedding-3-large-1536",
+    provider_id: "openai",
+    splitter_id: "base_v0",
+    max_chunk_size: 512,
+  },
+  mistral: {
+    model_id: "mistral-embed",
+    provider_id: "mistral",
+    splitter_id: "base_v0",
+    max_chunk_size: 512
+  }
+} as const;
 
 export type CoreAPIError = {
   message: string;

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -10,6 +10,7 @@ import {
 } from "../../core/data_source";
 import { DustAppSecretType } from "../../front/dust_app_secret";
 import { dustManagedCredentials } from "../../front/lib/api/credentials";
+import { EmbeddingProviderIdType } from "../../front/lib/assistant";
 import { Project } from "../../front/project";
 import { CredentialsType } from "../../front/provider";
 import {
@@ -21,7 +22,6 @@ import {
 } from "../../front/run";
 import { LoggerInterface } from "../../shared/logger";
 import { Err, Ok, Result } from "../../shared/result";
-import { EmbeddingProviderIdType } from "./assistant";
 
 const { CORE_API = "http://127.0.0.1:3001" } = process.env;
 

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -25,19 +25,21 @@ import { EmbeddingProviderIdType } from "./assistant";
 
 const { CORE_API = "http://127.0.0.1:3001" } = process.env;
 
+export const MAX_CHUNK_SIZE = 512;
+
 export const EMBEDDING_CONFIGS: Record<EmbeddingProviderIdType, EmbedderType> =
   {
     openai: {
       model_id: "text-embedding-3-large-1536",
       provider_id: "openai",
       splitter_id: "base_v0",
-      max_chunk_size: 512,
+      max_chunk_size: MAX_CHUNK_SIZE,
     },
     mistral: {
       model_id: "mistral-embed",
       provider_id: "mistral",
       splitter_id: "base_v0",
-      max_chunk_size: 512,
+      max_chunk_size: MAX_CHUNK_SIZE,
     },
   } as const;
 

--- a/types/src/front/lib/core_api.ts
+++ b/types/src/front/lib/core_api.ts
@@ -5,7 +5,8 @@ import {
   CoreAPIDataSourceConfig,
   CoreAPIDataSourceDocumentSection,
   CoreAPIDocument,
-  CoreAPILightDocument, EmbedderType,
+  CoreAPILightDocument,
+  EmbedderType,
 } from "../../core/data_source";
 import { DustAppSecretType } from "../../front/dust_app_secret";
 import { dustManagedCredentials } from "../../front/lib/api/credentials";
@@ -24,21 +25,21 @@ import { EmbeddingProviderIdType } from "./assistant";
 
 const { CORE_API = "http://127.0.0.1:3001" } = process.env;
 
-
-export const EMBEDDING_CONFIGS: Record<EmbeddingProviderIdType, EmbedderType> = {
-  openai: {
-    model_id: "text-embedding-3-large-1536",
-    provider_id: "openai",
-    splitter_id: "base_v0",
-    max_chunk_size: 512,
-  },
-  mistral: {
-    model_id: "mistral-embed",
-    provider_id: "mistral",
-    splitter_id: "base_v0",
-    max_chunk_size: 512
-  }
-} as const;
+export const EMBEDDING_CONFIGS: Record<EmbeddingProviderIdType, EmbedderType> =
+  {
+    openai: {
+      model_id: "text-embedding-3-large-1536",
+      provider_id: "openai",
+      splitter_id: "base_v0",
+      max_chunk_size: 512,
+    },
+    mistral: {
+      model_id: "mistral-embed",
+      provider_id: "mistral",
+      splitter_id: "base_v0",
+      max_chunk_size: 512,
+    },
+  } as const;
 
 export type CoreAPIError = {
   message: string;

--- a/types/src/front/user.ts
+++ b/types/src/front/user.ts
@@ -1,9 +1,12 @@
 import * as t from "io-ts";
 
+import {
+  EmbeddingProviderIdType,
+  ModelProviderIdType,
+} from "../front/lib/assistant";
 import { ModelId } from "../shared/model_id";
 import { assertNever } from "../shared/utils/assert_never";
 import { WhitelistableFeature } from "./feature_flags";
-import { EmbeddingProviderIdType, ModelProviderIdType } from "./lib/assistant";
 
 export type WorkspaceSegmentationType = "interesting" | null;
 

--- a/types/src/front/user.ts
+++ b/types/src/front/user.ts
@@ -3,7 +3,7 @@ import * as t from "io-ts";
 import { ModelId } from "../shared/model_id";
 import { assertNever } from "../shared/utils/assert_never";
 import { WhitelistableFeature } from "./feature_flags";
-import { ModelProviderIdType } from "./lib/assistant";
+import { EmbeddingProviderIdType, ModelProviderIdType } from "./lib/assistant";
 
 export type WorkspaceSegmentationType = "interesting" | null;
 
@@ -33,7 +33,7 @@ export type LightWorkspaceType = {
   role: RoleType;
   segmentation: WorkspaceSegmentationType;
   whiteListedProviders: ModelProviderIdType[] | null;
-  defaultEmbeddingProvider: ModelProviderIdType | null;
+  defaultEmbeddingProvider: EmbeddingProviderIdType | null;
 };
 
 export type WorkspaceType = LightWorkspaceType & {


### PR DESCRIPTION
## Description

This PR aims at using the default embedder defined at the workspace level (namely `defaultEmbedder`) to embed data sources.

- Introduces a new type `EmbeddingProviderIdType` as embedding provider might defer for model provider.
- Pass the chosen provider to the `coreAPI` when creating a new datasource.

## Risk

We need to make sure that embedding and upserting procedure is actually working as exepected.

## Deploy Plan

Deploy `front`