### PR TITLE
[Sparkle] Custom action icon for Item.Navigation

### DIFF
--- a/sparkle/package-lock.json
+++ b/sparkle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.159",
+  "version": "0.2.160",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/sparkle",
-      "version": "0.2.159",
+      "version": "0.2.160",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.159",
+  "version": "0.2.160",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "build:with-tw-base": "rollup -c --environment INCLUDE_TW_BASE:true",

--- a/sparkle/src/components/Item.tsx
+++ b/sparkle/src/components/Item.tsx
@@ -215,6 +215,8 @@ interface NavigationListItemProps {
   icon?: ComponentType;
   className?: string;
   href?: string;
+  hasAction?: boolean | "hover";
+  action?: ComponentType;
 }
 
 Item.Navigation = function (props: NavigationListItemProps) {

--- a/sparkle/src/stories/ContextItem.stories.tsx
+++ b/sparkle/src/stories/ContextItem.stories.tsx
@@ -11,7 +11,6 @@ import {
   ContextItem,
   PencilSquareIcon,
   SliderToggle,
-  TemplateItem,
   TrashIcon,
 } from "../index_with_tw_base";
 

--- a/sparkle/src/stories/ContextItem.stories.tsx
+++ b/sparkle/src/stories/ContextItem.stories.tsx
@@ -137,38 +137,5 @@ export const ListItemExample = () => (
       </ContextItem>
       {undefined}
     </ContextItem.List>
-    <ContextItem.SectionHeader title="Featured" hasBorder={false} />
-    <TemplateItem
-      name="Hiring"
-      id="1"
-      description="The specialist for coverage, insurance, process related questions"
-      visual={{
-        backgroundColor: "s-bg-red-100",
-        emoji: "🫶",
-      }}
-      href={""}
-    />
-
-    <TemplateItem
-      name="Training"
-      id="2"
-      description="The specialist for coverage, insurance, process related questions with a very long description that does not bring any value"
-      visual={{
-        backgroundColor: "s-bg-blue-100",
-        emoji: "🐴",
-      }}
-      href={""}
-    />
-
-    <TemplateItem
-      name="Hiring"
-      id="1"
-      description="The specialist for coverage, insurance, process related questions"
-      visual={{
-        backgroundColor: "s-bg-red-100",
-        emoji: "🫶",
-      }}
-      href={""}
-    />
   </div>
 );

--- a/sparkle/src/stories/Item.stories.tsx
+++ b/sparkle/src/stories/Item.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta } from "@storybook/react";
 import React from "react";
 
-import { DropdownMenu, Item } from "../index_with_tw_base";
+import { DropdownMenu, Item, PlusIcon } from "../index_with_tw_base";
 import { Cog6ToothIcon } from "../index_with_tw_base";
 
 const meta = {
@@ -54,6 +54,19 @@ export const ListItemExample = () => (
           icon={Cog6ToothIcon}
           description="Desciption of the item"
           disabled
+        />
+        <Item.Navigation
+          label="Item 4"
+          icon={Cog6ToothIcon}
+          description="Custom action icon"
+          action={PlusIcon}
+        />
+
+        <Item.Navigation
+          label="Item 5"
+          icon={Cog6ToothIcon}
+          description="No action icon (so no chevron)"
+          hasAction={false}
         />
       </Item.List>
     </div>

--- a/sparkle/src/stories/TemplateItem.stories.tsx
+++ b/sparkle/src/stories/TemplateItem.stories.tsx
@@ -16,7 +16,7 @@ export const TemplateItemExample = () => (
       name="Hiring"
       id="1"
       description="The specialist for coverage, insurance, process related questions"
-      visual={{ backgroundColor: "s-bg-red-100", emoji: "🫶" }}
+      visual={"" /*{ backgroundColor: "s-bg-red-100", emoji: "🫶" }*/}
       href={""}
     />
 
@@ -24,7 +24,7 @@ export const TemplateItemExample = () => (
       name="Training"
       id="2"
       description="The specialist for coverage, insurance, process related questions with a very long description that does not bring any value"
-      visual={{ backgroundColor: "s-bg-blue-100", emoji: "🐴" }}
+      visual={"" /*{ backgroundColor: "s-bg-blue-100", emoji: "🐴" }*/}
       href={""}
     />
 
@@ -32,7 +32,7 @@ export const TemplateItemExample = () => (
       name="Hiring"
       id="1"
       description="The specialist for coverage, insurance, process related questions"
-      visual={{ backgroundColor: "s-bg-red-100", emoji: "🫶" }}
+      visual={"" /*{ backgroundColor: "s-bg-red-100", emoji: "🫶" }*/}
       href={""}
     />
   </div>


### PR DESCRIPTION
Description
---
For `Item` component, add props to `Item.Navigation` so the action icon can be removed or customized

Additionally, fixes legacy compilation erros in ContextItem & TemplateItem, that prevented sparkle UX from displaying them
![image](https://github.com/dust-tt/dust/assets/5437393/11245743-c0f9-4ed8-ad13-85fbcb5c5446)

Risk & deploy
---
N/A
