### PR TITLE
[New Conversation] Help Drawer

### DIFF
--- a/front/components/assistant/HelpDrawer.tsx
+++ b/front/components/assistant/HelpDrawer.tsx
@@ -8,21 +8,22 @@ import {
   Modal,
   Page,
 } from "@dust-tt/sparkle";
-import {
-  isBuilder,
-  type AgentMention,
-  type MentionType,
-  type UserType,
-  type WorkspaceType,
+import type {
+  AgentMention,
+  MentionType,
+  UserType,
+  WorkspaceType,
 } from "@dust-tt/types";
-import { ComponentType, useCallback, useContext } from "react";
-
+import { isBuilder } from "@dust-tt/types";
 import { useRouter } from "next/router";
+import type { ComponentType } from "react";
+import { useCallback, useContext } from "react";
+
 import { AssistantInputBar } from "@app/components/assistant/conversation/input_bar/InputBar";
 import { createConversationWithMessage } from "@app/components/assistant/conversation/lib";
+import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { GLOBAL_AGENTS_SID } from "@app/lib/assistant";
 import { useSubmitFunction } from "@app/lib/client/utils";
-import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 
 const topPicks = [
   {

--- a/front/components/assistant/HelpDrawer.tsx
+++ b/front/components/assistant/HelpDrawer.tsx
@@ -1,0 +1,210 @@
+import {
+  ArrowRightIcon,
+  Button,
+  ChatBubbleBottomCenterTextIcon,
+  FolderIcon,
+  Item,
+  LightbulbIcon,
+  Modal,
+  Page,
+} from "@dust-tt/sparkle";
+import {
+  isBuilder,
+  type AgentMention,
+  type MentionType,
+  type UserType,
+  type WorkspaceType,
+} from "@dust-tt/types";
+import { ComponentType, useCallback, useContext } from "react";
+
+import { useRouter } from "next/router";
+import { AssistantInputBar } from "@app/components/assistant/conversation/input_bar/InputBar";
+import { createConversationWithMessage } from "@app/components/assistant/conversation/lib";
+import { GLOBAL_AGENTS_SID } from "@app/lib/assistant";
+import { useSubmitFunction } from "@app/lib/client/utils";
+import { SendNotificationsContext } from "@app/components/sparkle/Notification";
+
+const topPicks = [
+  {
+    title: "Creating Assistants",
+    href: "https://www.notion.so/dust-tt/Prompting-101-How-to-Talk-to-Your-Assistants-c0212513056a4af885e41706ee742dda",
+    icon: ArrowRightIcon,
+  },
+  {
+    title: "Managing Connections",
+    href: "https://www.notion.so/dust-tt/Dust-Library-1aa97619d56d4d9f9c21d7ce89d23dbb?pvs=4#4f7f969e52464e369f4cd453457d8059",
+    icon: ArrowRightIcon,
+  },
+  {
+    title: "Choosing a Model",
+    href: "https://blog.dust.tt/comparing-ai-models-claude-gpt4-gemini-mistral/",
+    icon: ArrowRightIcon,
+  },
+];
+
+function LinksList({
+  linksList,
+  title,
+}: {
+  linksList: {
+    title: string;
+    href: string;
+    icon?: ComponentType;
+    description?: string;
+  }[];
+  title?: string;
+}) {
+  return (
+    <Item.List>
+      {title && <Item.SectionHeader label={title} />}
+      {linksList.map((link, index) => (
+        <Item.Navigation
+          icon={link.icon}
+          label={link.title}
+          href={link.href}
+          key={index}
+          description={link.description}
+          hasAction={false}
+        />
+      ))}
+    </Item.List>
+  );
+}
+
+export function HelpDrawer({
+  owner,
+  user,
+  show,
+  onClose,
+}: {
+  owner: WorkspaceType;
+  user: UserType;
+  show: boolean;
+  onClose: () => void;
+}) {
+  const router = useRouter();
+  const sendNotification = useContext(SendNotificationsContext);
+
+  const { submit: handleHelpSubmit } = useSubmitFunction(
+    useCallback(
+      async (input: string, mentions: MentionType[]) => {
+        const inputWithHelp = input.includes("@help")
+          ? input
+          : `@help ${input.trimStart()}`;
+        const mentionsWithHelp = mentions.some(
+          (mention) => mention.configurationId === GLOBAL_AGENTS_SID.HELPER
+        )
+          ? mentions
+          : [
+              ...mentions,
+              { configurationId: GLOBAL_AGENTS_SID.HELPER } as AgentMention,
+            ];
+        const conversationRes = await createConversationWithMessage({
+          owner,
+          user,
+          messageData: {
+            input: inputWithHelp.replace("@help", ":mention[help]{sId=helper}"),
+            mentions: mentionsWithHelp,
+            contentFragments: [],
+          },
+        });
+        if (conversationRes.isErr()) {
+          sendNotification({
+            title: conversationRes.error.title,
+            description: conversationRes.error.message,
+            type: "error",
+          });
+        } else {
+          // We start the push before creating the message to optimize for instantaneity as well.
+          void router.push(
+            `/w/${owner.sId}/assistant/${conversationRes.value.sId}`
+          );
+        }
+      },
+      [owner, user, router, sendNotification]
+    )
+  );
+
+  return (
+    <Modal isOpen={show} variant="side-sm" hasChanged={false} onClose={onClose}>
+      <div className="flex flex-col gap-5 pt-5">
+        <Page.SectionHeader title="Learn about Dust" />
+        <div>
+          <LinksList
+            linksList={
+              isBuilder(owner)
+                ? [
+                    {
+                      title: "Quickstart Guide",
+                      href: "https://www.notion.so/dust-tt/Getting-to-Know-Dust-b4578a3ded364762b19c8276192cc992",
+                      icon: LightbulbIcon,
+                    },
+                    {
+                      title: "All help content",
+                      href: "https://www.notion.so/dust-tt/Dust-Library-1aa97619d56d4d9f9c21d7ce89d23dbb",
+                      description: "Guides, best practices, and more",
+                      icon: FolderIcon,
+                    },
+                  ]
+                : [
+                    {
+                      title: "Quickstart Guide",
+                      href: "https://www.notion.so/dust-tt/Getting-to-Know-Dust-b4578a3ded364762b19c8276192cc992",
+                      icon: LightbulbIcon,
+                    },
+                  ]
+            }
+          />
+          {isBuilder(owner) && (
+            <LinksList linksList={topPicks} title="Top Picks" />
+          )}
+        </div>
+        {!isBuilder(owner) && (
+          <Button.List isWrapping={true}>
+            <div className="flex flex-col gap-8">
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  variant="tertiary"
+                  icon={ChatBubbleBottomCenterTextIcon}
+                  label={"What can I use the assistants for?"}
+                  size="sm"
+                  hasMagnifying={false}
+                  onClick={() => {
+                    void handleHelpSubmit(
+                      "@help What can I use the assistants for?",
+                      [{ configurationId: GLOBAL_AGENTS_SID.HELPER }]
+                    );
+                  }}
+                />
+                <Button
+                  variant="tertiary"
+                  icon={ChatBubbleBottomCenterTextIcon}
+                  label={"What are the limitations of assistants?"}
+                  size="sm"
+                  hasMagnifying={false}
+                  onClick={() => {
+                    void handleHelpSubmit(
+                      "@help What are the limitations of assistants?",
+                      [{ configurationId: GLOBAL_AGENTS_SID.HELPER }]
+                    );
+                  }}
+                />
+              </div>
+            </div>
+          </Button.List>
+        )}
+        <div className="flex flex-col gap-2 [&>*]:pl-px">
+          <div className="text-base font-bold">Ask questions</div>
+          <AssistantInputBar
+            owner={owner}
+            onSubmit={handleHelpSubmit}
+            conversationId={null}
+            hideAttachment={true}
+            hideQuickActions={true}
+            disableAutoFocus={true}
+          />
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -56,6 +56,7 @@ export function AssistantInputBar({
   stickyMentions,
   additionalAgentConfiguration,
   hideQuickActions,
+  hideAttachment,
   disableAutoFocus = false,
   isFloating = true,
 }: {
@@ -69,6 +70,7 @@ export function AssistantInputBar({
   stickyMentions?: AgentMention[];
   additionalAgentConfiguration?: LightAgentConfigurationType;
   hideQuickActions: boolean;
+  hideAttachment?: boolean;
   disableAutoFocus: boolean;
   isFloating?: boolean;
 }) {
@@ -335,6 +337,7 @@ export function AssistantInputBar({
 
               <InputBarContainer
                 hideQuickActions={hideQuickActions}
+                hideAttachment={!!hideAttachment}
                 disableAutoFocus={disableAutoFocus}
                 allAssistants={activeAgents}
                 agentConfigurations={agentConfigurations}

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -31,6 +31,7 @@ export interface InputBarContainerProps {
   selectedAssistant: AgentMention | null;
   stickyMentions: AgentMention[] | undefined;
   hideQuickActions: boolean;
+  hideAttachment: boolean;
   disableAutoFocus: boolean;
   disableSendButton: boolean;
 }
@@ -44,6 +45,7 @@ const InputBarContainer = ({
   selectedAssistant,
   stickyMentions,
   hideQuickActions,
+  hideAttachment,
   disableAutoFocus,
   disableSendButton,
 }: InputBarContainerProps) => {
@@ -112,29 +114,41 @@ const InputBarContainer = ({
       />
 
       <div className="flex flex-row items-end justify-between gap-2 self-stretch py-2 pr-2 sm:flex-col sm:border-0">
-        <div className="flex gap-5 rounded-full border border-structure-200/60 px-4 py-2 sm:gap-3 sm:px-2">
-          <input
-            accept=".txt,.pdf,.md,.csv"
-            onChange={async (e) => {
-              await onInputFileChange(e);
-              editorService.focusEnd();
-            }}
-            ref={fileInputRef}
-            style={{ display: "none" }}
-            type="file"
-            multiple={true}
-          />
-          <IconButton
-            variant={"tertiary"}
-            icon={AttachmentIcon}
-            size="sm"
-            tooltip="Add a document to the conversation (only .txt, .pdf, .md, .csv)."
-            tooltipPosition="above"
-            className="flex"
-            onClick={() => {
-              fileInputRef.current?.click();
-            }}
-          />
+        <div
+          className={classNames(
+            "flex gap-5 rounded-full px-4 py-2 sm:gap-3 sm:px-2",
+            // when both are hidden, hide the border (but keep the div for the flex layout to work)
+            !hideAttachment || !hideQuickActions
+              ? "border border-structure-200/60"
+              : ""
+          )}
+        >
+          {!hideAttachment && (
+            <>
+              <input
+                accept=".txt,.pdf,.md,.csv"
+                onChange={async (e) => {
+                  await onInputFileChange(e);
+                  editorService.focusEnd();
+                }}
+                ref={fileInputRef}
+                style={{ display: "none" }}
+                type="file"
+                multiple={true}
+              />
+              <IconButton
+                variant={"tertiary"}
+                icon={AttachmentIcon}
+                size="sm"
+                tooltip="Add a document to the conversation (only .txt, .pdf, .md, .csv)."
+                tooltipPosition="above"
+                className="flex"
+                onClick={() => {
+                  fileInputRef.current?.click();
+                }}
+              />
+            </>
+          )}
           {!hideQuickActions && (
             <>
               <AssistantPicker

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -9,7 +9,7 @@
         "@amplitude/analytics-browser": "^2.5.2",
         "@amplitude/analytics-node": "^1.3.5",
         "@auth0/nextjs-auth0": "^3.5.0",
-        "@dust-tt/sparkle": "^0.2.159",
+        "@dust-tt/sparkle": "^0.2.160",
         "@dust-tt/types": "file:../types",
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",
@@ -10505,9 +10505,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.159",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.159.tgz",
-      "integrity": "sha512-7XcNwRvJ4Wh5DgYIX7I+/sfuTYzv5OCHn8pFBfZSC672+hvuL1s2ICxtsc65QQadPUdrmyijuVgOEN8xahp3kw==",
+      "version": "0.2.160",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.160.tgz",
+      "integrity": "sha512-+WyUi8vJkJ06UYxM3veq4sWnQLkOsGUA9PCmOkHtCJmpRQLb/2SgXkpP3GQff82AsXphR+y/19Z4Lypd1+fByg==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -18,7 +18,7 @@
     "@amplitude/analytics-browser": "^2.5.2",
     "@amplitude/analytics-node": "^1.3.5",
     "@auth0/nextjs-auth0": "^3.5.0",
-    "@dust-tt/sparkle": "^0.2.159",
+    "@dust-tt/sparkle": "^0.2.160",
     "@dust-tt/types": "file:../types",
     "@emoji-mart/data": "^1.1.2",
     "@emoji-mart/react": "^1.1.1",

--- a/front/pages/w/[wId]/assistant/new.tsx
+++ b/front/pages/w/[wId]/assistant/new.tsx
@@ -83,7 +83,7 @@ export default function AssistantNew({
   const [planLimitReached, setPlanLimitReached] = useState<boolean>(false);
   const sendNotification = useContext(SendNotificationsContext);
 
-  const [helpDrawer, setHelpDrawer] = useState<boolean>(false);
+  const [isHelpDrawerOpen, setIsHelpDrawerOpen] = useState<boolean>(false);
   const { animate, setAnimate, setSelectedAssistant } =
     useContext(InputBarContext);
 
@@ -250,8 +250,8 @@ export default function AssistantNew({
       <HelpDrawer
         owner={owner}
         user={user}
-        show={helpDrawer}
-        onClose={() => setHelpDrawer(false)}
+        show={isHelpDrawerOpen}
+        onClose={() => setIsHelpDrawerOpen(false)}
       />
       <QuickStartGuide
         owner={owner}
@@ -326,7 +326,7 @@ export default function AssistantNew({
           icon={HeartAltIcon}
           labelVisible={false}
           label="Quick Start Guide"
-          onClick={() => setHelpDrawer(true)}
+          onClick={() => setIsHelpDrawerOpen(true)}
           size="md"
           variant="primary"
           hasMagnifying={true}

--- a/front/pages/w/[wId]/assistant/new.tsx
+++ b/front/pages/w/[wId]/assistant/new.tsx
@@ -29,6 +29,7 @@ import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { useAgentConfigurations, useUserMetadata } from "@app/lib/swr";
 import { setUserMetadataFromClient } from "@app/lib/user";
 import { classNames } from "@app/lib/utils";
+import { HelpDrawer } from "@app/components/assistant/HelpDrawer";
 
 const { GA_TRACKING_ID = "" } = process.env;
 
@@ -82,6 +83,7 @@ export default function AssistantNew({
   const [planLimitReached, setPlanLimitReached] = useState<boolean>(false);
   const sendNotification = useContext(SendNotificationsContext);
 
+  const [helpDrawer, setHelpDrawer] = useState<boolean>(false);
   const { animate, setAnimate, setSelectedAssistant } =
     useContext(InputBarContext);
 
@@ -245,6 +247,12 @@ export default function AssistantNew({
 
   return (
     <>
+      <HelpDrawer
+        owner={owner}
+        user={user}
+        show={helpDrawer}
+        onClose={() => setHelpDrawer(false)}
+      />
       <QuickStartGuide
         owner={owner}
         user={user}
@@ -318,7 +326,7 @@ export default function AssistantNew({
           icon={HeartAltIcon}
           labelVisible={false}
           label="Quick Start Guide"
-          onClick={() => setShowQuickGuide(true)}
+          onClick={() => setHelpDrawer(true)}
           size="md"
           variant="primary"
           hasMagnifying={true}

--- a/front/pages/w/[wId]/assistant/new.tsx
+++ b/front/pages/w/[wId]/assistant/new.tsx
@@ -19,6 +19,7 @@ import { AssistantInputBar } from "@app/components/assistant/conversation/input_
 import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import type { ContentFragmentInput } from "@app/components/assistant/conversation/lib";
 import { createConversationWithMessage } from "@app/components/assistant/conversation/lib";
+import { HelpDrawer } from "@app/components/assistant/HelpDrawer";
 import { QuickStartGuide } from "@app/components/quick_start_guide";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
@@ -29,7 +30,6 @@ import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { useAgentConfigurations, useUserMetadata } from "@app/lib/swr";
 import { setUserMetadataFromClient } from "@app/lib/user";
 import { classNames } from "@app/lib/utils";
-import { HelpDrawer } from "@app/components/assistant/HelpDrawer";
 
 const { GA_TRACKING_ID = "" } = process.env;
 


### PR DESCRIPTION
## Description

Fixes #5453

Help drawer for builders:
![image](https://github.com/dust-tt/dust/assets/5437393/1b379986-4c8a-4e77-9352-42b0c215a7e5)

Help drawer for members:
![image](https://github.com/dust-tt/dust/assets/5437393/f11134a3-ade7-42cc-8b49-0ad704c8a111)

Note: for the purposes of the drawer, this PR also provides an option to remove the attachment button for the inputbar

As per IRL with @Duncid :
- Leaving icons gray (vs green in figma) for now)
- when asking a question, mention @help is not required and will be added if not present 
- using other mentions in that box is an edge case, just letting the other mention run in addition of the @help one is therefore a viable solution



## Risk
None

## Deploy Plan
Front