### PR TITLE
Fix layout of assistant builder

### DIFF
--- a/front/components/assistant_builder/ActionScreen.tsx
+++ b/front/components/assistant_builder/ActionScreen.tsx
@@ -216,7 +216,7 @@ export default function ActionScreen({
 
   return (
     <>
-      <div className="flex min-h-96 flex-col gap-4 text-sm text-element-800">
+      <div className="flex flex-col gap-4 text-sm text-element-800">
         <div className="flex flex-col gap-2">
           <Page.Header title="Actions & Data sources" />
           <Page.P>
@@ -397,8 +397,10 @@ export default function ActionScreen({
           </>
         )}
 
-        <ActionModeSection show={!action}>
-          <div className="pb-16"></div>
+        <ActionModeSection
+          show={["WEBSEARCH", "REPLY_ONLY"].includes(actionCategory)}
+        >
+          <div className="pb-72"></div>
         </ActionModeSection>
 
         <ActionModeSection

--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -217,7 +217,7 @@ export default function ActionsScreen({
         dustApps={dustApps}
       />
 
-      <div className="flex grow flex-col gap-8 text-sm text-element-700">
+      <div className="flex flex-col gap-8 text-sm text-element-700">
         <div className="flex flex-col gap-4">
           <div className="flex flex-col gap-2">
             <Page.Header title="Actions & Data sources" />

--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -217,7 +217,7 @@ export default function ActionsScreen({
         dustApps={dustApps}
       />
 
-      <div className="flex min-h-96 flex-col gap-8 text-sm text-element-700">
+      <div className="flex grow flex-col gap-8 text-sm text-element-700">
         <div className="flex flex-col gap-4">
           <div className="flex flex-col gap-2">
             <Page.Header title="Actions & Data sources" />

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -715,7 +715,7 @@ function PrevNextButtons({
   setScreen: (screen: BuilderScreen) => void;
 }) {
   return (
-    <div className="flex pt-6">
+    <div className="flex py-6">
       {screen !== "instructions" && (
         <Button
           label="Previous"


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/tasks/issues/845

Fixes layout of Assistant Builder when the action screen overflows the minimal space reserved for it. Not sure why the min-h-96 prevents growing but replace that by a conditional padding that pre-existed works well.

Before:

![Screenshot from 2024-06-11 10-09-59](https://github.com/dust-tt/dust/assets/15067/73b98643-4c10-4b0d-9105-5f4f061b0046)

After:

![Screenshot from 2024-06-11 10-10-19](https://github.com/dust-tt/dust/assets/15067/a399a80b-8ec1-4a55-964b-143bfd5daff4)

## Risk

N/A

## Deploy Plan

- deploy `front`