### PR TITLE
feat: handle CoT tokens, part 1

### DIFF
--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -11,10 +11,12 @@ import type {
   AgentMessageSuccessEvent,
   AgentMessageType,
   ConversationType,
+  DustAppRunTokensEvent,
   GenerationCancelEvent,
   GenerationSuccessEvent,
   GenerationTokensEvent,
   LightAgentConfigurationType,
+  ModelConfigurationType,
   UserMessageType,
 } from "@dust-tt/types";
 import {
@@ -28,6 +30,7 @@ import {
   isWebsearchConfiguration,
   SUPPORTED_MODEL_CONFIGS,
 } from "@dust-tt/types";
+import { escapeRegExp } from "lodash";
 
 import { runActionStreamed } from "@app/lib/actions/server";
 import { getRunnerforActionConfiguration } from "@app/lib/api/assistant/actions/runners";
@@ -516,6 +519,11 @@ export async function* runMultiActionsAgent(
   let lastCheckCancellation = Date.now();
   const redis = await redisClient();
   let isGeneration = true;
+  const tokenEmitter = new TokenEmitter(
+    agentConfiguration,
+    agentMessage,
+    model.tagsConfiguration
+  );
 
   try {
     const _checkCancellation = async () => {
@@ -545,6 +553,7 @@ export async function* runMultiActionsAgent(
       }
 
       if (event.type === "error") {
+        yield* tokenEmitter.flushTokens();
         yield {
           type: "agent_error",
           created: Date.now(),
@@ -572,6 +581,7 @@ export async function* runMultiActionsAgent(
       }
 
       if (shouldYieldCancel) {
+        yield* tokenEmitter.flushTokens();
         yield {
           type: "generation_cancel",
           created: Date.now(),
@@ -582,18 +592,13 @@ export async function* runMultiActionsAgent(
       }
 
       if (event.type === "tokens" && isGeneration) {
-        yield {
-          type: "generation_tokens",
-          created: Date.now(),
-          configurationId: agentConfiguration.sId,
-          messageId: agentMessage.sId,
-          text: event.content.tokens.text,
-        } satisfies GenerationTokensEvent;
+        yield* tokenEmitter.emitTokens(event);
       }
 
       if (event.type === "block_execution") {
         const e = event.content.execution[0][0];
         if (e.error) {
+          yield* tokenEmitter.flushTokens();
           yield {
             type: "agent_error",
             created: Date.now(),
@@ -608,18 +613,17 @@ export async function* runMultiActionsAgent(
         }
 
         if (event.content.block_name === "MODEL" && e.value && isGeneration) {
-          const m = e.value as {
-            message: {
-              content: string;
-            };
-          };
+          yield* tokenEmitter.flushTokens();
+
           yield {
             type: "generation_success",
             created: Date.now(),
             configurationId: agentConfiguration.sId,
             messageId: agentMessage.sId,
-            text: m.message.content,
+            text: tokenEmitter.getContent(),
+            chainOfThought: tokenEmitter.getChainOfThought(),
           } satisfies GenerationSuccessEvent;
+
           return;
         }
 
@@ -631,6 +635,8 @@ export async function* runMultiActionsAgent(
           if ("generation" in v) {
             output.generation = v.generation;
           }
+
+          yield* tokenEmitter.flushTokens();
 
           break;
         }
@@ -1032,5 +1038,162 @@ async function* runAction(
     }
   } else {
     assertNever(actionConfiguration);
+  }
+}
+
+class TokenEmitter {
+  private buffer: string = "";
+  private content: string = "";
+  private chainOfThought: string = "";
+  private chainOfToughtTagsOpened: number = 0;
+  private pattern?: RegExp;
+  private incompleteTagPattern?: RegExp;
+  private specByTag: Record<
+    string,
+    { type: "opening_tag" | "closing_tag"; isChainOfThought: boolean }
+  >;
+
+  constructor(
+    private agentConfiguration: AgentConfigurationType,
+    private agentMessage: AgentMessageType,
+    tagsConfiguration: ModelConfigurationType["tagsConfiguration"]
+  ) {
+    this.buffer = "";
+    this.content = "";
+    this.chainOfThought = "";
+    this.chainOfToughtTagsOpened = 0;
+
+    // Ensure no duplicate tags.
+    const allTagsArray =
+      tagsConfiguration?.tags.flatMap(({ openingPattern, closingPattern }) => [
+        escapeRegExp(openingPattern),
+        escapeRegExp(closingPattern),
+      ]) ?? [];
+
+    if (allTagsArray.length !== new Set(allTagsArray).size) {
+      throw new Error("Duplicate tags in the configuration");
+    }
+
+    // Store mapping of tags to their spec.
+    this.specByTag =
+      tagsConfiguration?.tags.reduce(
+        (acc, { openingPattern, closingPattern, isChainOfThought }) => {
+          acc[openingPattern] = {
+            type: "opening_tag" as const,
+            isChainOfThought,
+          };
+          acc[closingPattern] = {
+            type: "closing_tag" as const,
+            isChainOfThought,
+          };
+          return acc;
+        },
+        {} as TokenEmitter["specByTag"]
+      ) ?? {};
+
+    // Store the regex pattern that match any of the tags.
+    this.pattern = allTagsArray.length
+      ? new RegExp(allTagsArray.join("|"))
+      : undefined;
+
+    // Store the regex pattern that match incomplete tags.
+    this.incompleteTagPattern = tagsConfiguration?.incompleteTagRegex;
+  }
+
+  async *flushTokens({
+    upTo,
+  }: {
+    upTo?: number;
+  } = {}): AsyncGenerator<GenerationTokensEvent> {
+    if (!this.buffer.length) {
+      return;
+    }
+
+    const text =
+      upTo === undefined ? this.buffer : this.buffer.substring(0, upTo);
+
+    yield {
+      type: "generation_tokens",
+      created: Date.now(),
+      configurationId: this.agentConfiguration.sId,
+      messageId: this.agentMessage.sId,
+      text,
+      classification: this.chainOfToughtTagsOpened
+        ? "chain_of_thought"
+        : "tokens",
+    };
+
+    if (this.chainOfToughtTagsOpened) {
+      this.chainOfThought += text;
+    } else {
+      this.content += text;
+    }
+
+    this.buffer = upTo === undefined ? "" : this.buffer.substring(upTo);
+  }
+
+  async *emitTokens(
+    event: DustAppRunTokensEvent
+  ): AsyncGenerator<GenerationTokensEvent> {
+    // Add text of the new event to the buffer.
+    this.buffer += event.content.tokens.text;
+    if (!this.pattern) {
+      yield* this.flushTokens();
+      return;
+    }
+
+    if (this.incompleteTagPattern?.test(this.buffer)) {
+      // Wait for the next event to complete the tag.
+      return;
+    }
+
+    let match: RegExpExecArray | null;
+    while ((match = this.pattern.exec(this.buffer))) {
+      const tag = match[0];
+      const index = match.index;
+
+      // Emit text before the tag as 'text' or 'chain_of_thought'
+      if (index > 0) {
+        yield* this.flushTokens({ upTo: index });
+      }
+
+      const { type: classification, isChainOfThought } = this.specByTag[tag];
+
+      if (!classification) {
+        throw new Error(`Unknown tag: ${tag}`);
+      }
+
+      if (isChainOfThought) {
+        if (classification === "opening_tag") {
+          this.chainOfToughtTagsOpened += 1;
+        } else {
+          this.chainOfToughtTagsOpened -= 1;
+        }
+      }
+
+      // Emit the tag
+      yield {
+        type: "generation_tokens",
+        created: Date.now(),
+        configurationId: this.agentConfiguration.sId,
+        messageId: this.agentMessage.sId,
+        text: tag,
+        classification,
+      } satisfies GenerationTokensEvent;
+
+      // Update the buffer
+      this.buffer = this.buffer.substring(index + tag.length);
+    }
+
+    // Emit the remaining text/chain_of_thought.
+    yield* this.flushTokens();
+  }
+
+  getContent(): string {
+    return this.content;
+  }
+
+  getChainOfThought(): string {
+    return this.chainOfThought;
   }
 }

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1753,10 +1753,10 @@ async function* streamRunAgentEvents(
         } else if (event.classification === "chain_of_thought") {
           yield event;
         } else if (
-          event.classification === "opening_tag" ||
-          event.classification === "closing_tag"
+          event.classification === "opening_delimiter" ||
+          event.classification === "closing_delimiter"
         ) {
-          // Ignoring these for now.
+          yield event;
         } else {
           assertNever(event.classification);
         }

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -28,7 +28,7 @@ import type {
   UserMessageWithRankType,
   WorkspaceType,
 } from "@dust-tt/types";
-import { MODEL_PROVIDER_IDS } from "@dust-tt/types";
+import { assertNever, MODEL_PROVIDER_IDS } from "@dust-tt/types";
 import {
   cloneBaseConfig,
   DustProdActionRegistry,
@@ -1747,8 +1747,20 @@ async function* streamRunAgentEvents(
         yield event;
         break;
       case "generation_tokens":
-        content += event.text;
-        yield event;
+        if (event.classification === "tokens") {
+          content += event.text;
+          yield event;
+        } else if (event.classification === "chain_of_thought") {
+          yield event;
+        } else if (
+          event.classification === "opening_tag" ||
+          event.classification === "closing_tag"
+        ) {
+          // Ignoring these for now.
+        } else {
+          assertNever(event.classification);
+        }
+
         break;
 
       default:

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -635,6 +635,7 @@ export async function* runGeneration(
           configurationId: configuration.sId,
           messageId: agentMessage.sId,
           text: event.content.tokens.text,
+          classification: "tokens",
         };
       }
 
@@ -666,6 +667,7 @@ export async function* runGeneration(
             configurationId: configuration.sId,
             messageId: agentMessage.sId,
             text: m.message.content,
+            chainOfThought: "",
           };
         }
       }

--- a/types/src/front/lib/api/assistant/generation.ts
+++ b/types/src/front/lib/api/assistant/generation.ts
@@ -70,6 +70,7 @@ export type GenerationTokensEvent = {
   configurationId: string;
   messageId: string;
   text: string;
+  classification: "tokens" | "chain_of_thought" | "opening_tag" | "closing_tag";
 };
 
 export type GenerationErrorEvent = {
@@ -89,6 +90,7 @@ export type GenerationSuccessEvent = {
   configurationId: string;
   messageId: string;
   text: string;
+  chainOfThought: string;
 };
 
 export type GenerationCancelEvent = {

--- a/types/src/front/lib/api/assistant/generation.ts
+++ b/types/src/front/lib/api/assistant/generation.ts
@@ -70,7 +70,11 @@ export type GenerationTokensEvent = {
   configurationId: string;
   messageId: string;
   text: string;
-  classification: "tokens" | "chain_of_thought" | "opening_tag" | "closing_tag";
+  classification:
+    | "tokens"
+    | "chain_of_thought"
+    | "opening_delimiter"
+    | "closing_delimiter";
 };
 
 export type GenerationErrorEvent = {

--- a/types/src/front/lib/assistant.ts
+++ b/types/src/front/lib/assistant.ts
@@ -79,6 +79,18 @@ export type ModelConfigurationType = {
   shortDescription: string;
   supportsMultiActions: boolean;
   isLegacy: boolean;
+
+  // Allows configuring parsing of special tags in the streamed model output.
+  tagsConfiguration?: {
+    tags: Array<{
+      openingPattern: string;
+      closingPattern: string;
+      isChainOfThought: boolean;
+    }>;
+    // If this pattern is found at the end of a model event, we'll wait for the
+    // the next event before emitting tokens.
+    incompleteTagRegex?: RegExp;
+  };
 };
 
 export const GPT_4_TURBO_MODEL_CONFIG: ModelConfigurationType = {
@@ -135,6 +147,26 @@ export const CLAUDE_3_OPUS_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   shortDescription: "Anthropic's powerful model.",
   supportsMultiActions: true,
   isLegacy: false,
+  tagsConfiguration: {
+    incompleteTagRegex: /<\/?[a-zA-Z]*$/,
+    tags: [
+      {
+        openingPattern: "<thinking>",
+        closingPattern: "</thinking>",
+        isChainOfThought: true,
+      },
+      {
+        openingPattern: "<search_quality_reflection>",
+        closingPattern: "</search_quality_reflection>",
+        isChainOfThought: true,
+      },
+      {
+        openingPattern: "<result>",
+        closingPattern: "</result>",
+        isChainOfThought: false,
+      },
+    ],
+  },
 };
 export const CLAUDE_3_SONNET_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "anthropic",

--- a/types/src/front/lib/assistant.ts
+++ b/types/src/front/lib/assistant.ts
@@ -80,16 +80,16 @@ export type ModelConfigurationType = {
   supportsMultiActions: boolean;
   isLegacy: boolean;
 
-  // Allows configuring parsing of special tags in the streamed model output.
-  tagsConfiguration?: {
-    tags: Array<{
+  // Allows configuring parsing of special delimiters in the streamed model output.
+  delimitersConfiguration?: {
+    delimiters: Array<{
       openingPattern: string;
       closingPattern: string;
       isChainOfThought: boolean;
     }>;
     // If this pattern is found at the end of a model event, we'll wait for the
     // the next event before emitting tokens.
-    incompleteTagRegex?: RegExp;
+    incompleteDelimiterRegex?: RegExp;
   };
 };
 
@@ -147,9 +147,9 @@ export const CLAUDE_3_OPUS_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   shortDescription: "Anthropic's powerful model.",
   supportsMultiActions: true,
   isLegacy: false,
-  tagsConfiguration: {
-    incompleteTagRegex: /<\/?[a-zA-Z]*$/,
-    tags: [
+  delimitersConfiguration: {
+    incompleteDelimiterRegex: /<\/?[a-zA-Z]*$/,
+    delimiters: [
       {
         openingPattern: "<thinking>",
         closingPattern: "</thinking>",


### PR DESCRIPTION
## Description

Splitting the work in several PRs.
First step towards https://github.com/dust-tt/dust/issues/5159.

This PR adds a new optional configuration to `ModelConfigurationType`: ability to define a set of custom tags.
This PR also adds a new `classification` field to to the `generation_tokens` event. This enum field can be populated with either:
- `"tokens"` -> for regular tokens as we know them today. After this change, all models except anthropic's Claude 3 will continue to only emit `generation_tokens` event with `"tokens"` classification
- `"opening_tag"` -> the `text` of the event will be one of the opening tags defined in the config
- `"closing_tag"` -> the `text` of the event will be one of the closing tags defined in the config
- `"chain_of_thought"` -> the tokens of the event are being streamed between an opening and a closing tag that has `isChainOfThought` set to true.

The rationale:
- we need to identify the tags themselves in order not to render them in the frontend (or in the message bodY)
- we need to identify chain of thought tokens to have specific rendering for it
- some Anthropic tags, like `<result>` are not meant for CoT. However we still don't want to render the XML tag itself

This is model-specific, so the 2 places where it makes sense to have this are:
- `core`
- `SUPPORTED_MODEL_CONFIG`

We decided to go the `front` way, as this is really more of a frontend / application concern, and having this in `core` is more trapdoory.


## Risk

The impact right now:
- for Anthropic models, we'll stop displaying the actual XML tags (which is a slight improvement)
- until my next PR, we'll continue displaying the CoT tokens in the same way, and they are not being stored (just like now)
- The logic has been well-tested,  but it is on the critical path, so always risky


## Deploy Plan

Simple deploy