### PR TITLE
Assistant Builder: use hook for template management

### DIFF
--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -123,7 +123,7 @@ export default function AssistantBuilder({
   const {
     template,
     instructionsResetAt,
-    resetTemplate,
+    removeTemplate,
     resetToTemplateInstructions,
     resetToTemplateActions,
   } = useTemplate(defaultTemplate);
@@ -515,7 +515,7 @@ export default function AssistantBuilder({
             <AssistantBuilderRightPanel
               screen={screen}
               template={template}
-              resetTemplate={resetTemplate}
+              removeTemplate={removeTemplate}
               resetToTemplateInstructions={async () => {
                 resetToTemplateInstructions(setBuilderState);
                 setEdited(true);

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -16,17 +16,11 @@ import type {
 } from "@dust-tt/types";
 import {
   assertNever,
-  getAgentActionConfigurationType,
   GPT_3_5_TURBO_MODEL_CONFIG,
   GPT_4_TURBO_MODEL_CONFIG,
   isBuilder,
-  isDustAppRunConfiguration,
-  isProcessConfiguration,
-  isRetrievalConfiguration,
-  isTablesQueryConfiguration,
   SUPPORTED_MODEL_CONFIGS,
 } from "@dust-tt/types";
-import _ from "lodash";
 import { useRouter } from "next/router";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import React from "react";
@@ -54,7 +48,6 @@ import {
 } from "@app/components/assistant_builder/shared";
 import { submitAssistantBuilderForm } from "@app/components/assistant_builder/submitAssistantBuilderForm";
 import type {
-  AssistantBuilderActionType,
   AssistantBuilderProps,
   AssistantBuilderState,
   BuilderScreen,
@@ -64,6 +57,7 @@ import {
   getDefaultAssistantState,
 } from "@app/components/assistant_builder/types";
 import { useNavigationLock } from "@app/components/assistant_builder/useNavigationLock";
+import { useTemplate } from "@app/components/assistant_builder/useTemplate";
 import AppLayout, { appLayoutBack } from "@app/components/sparkle/AppLayout";
 import {
   AppLayoutSimpleCloseTitle,
@@ -73,7 +67,6 @@ import { subNavigationBuild } from "@app/components/sparkle/navigation";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
 import { isUpgraded } from "@app/lib/plans/plan_codes";
 import { useSlackChannelsLinkedWithAgent } from "@app/lib/swr";
-import type { FetchAssistantTemplateResponse } from "@app/pages/api/w/[wId]/assistant/builder/templates/[tId]";
 
 export default function AssistantBuilder({
   owner,
@@ -127,69 +120,13 @@ export default function AssistantBuilder({
         }
   );
 
-  const [template, setTemplate] =
-    useState<FetchAssistantTemplateResponse | null>(defaultTemplate);
-
-  const resetTemplate = async () => {
-    setTemplate(null);
-    await router.replace(
-      {
-        pathname: router.pathname,
-        query: _.omit(router.query, "templateId"),
-      },
-      undefined,
-      { shallow: true }
-    );
-  };
-
-  const [instructionsResetAt, setInstructionsResetAt] = useState<number | null>(
-    null
-  );
-
-  const resetToTemplateInstructions = useCallback(async () => {
-    if (template === null) {
-      return;
-    }
-    setEdited(true);
-    setInstructionsResetAt(Date.now());
-    setBuilderState((builderState) => ({
-      ...builderState,
-      instructions: template.presetInstructions,
-    }));
-  }, [template]);
-
-  const resetToTemplateActions = useCallback(async () => {
-    if (template === null) {
-      return;
-    }
-
-    let actionType: AssistantBuilderActionType | null = null;
-    if (!multiActionsEnabled) {
-      const action = getAgentActionConfigurationType(template.presetAction);
-      if (isRetrievalConfiguration(action)) {
-        actionType = "RETRIEVAL_SEARCH";
-      } else if (isDustAppRunConfiguration(action)) {
-        actionType = "DUST_APP_RUN";
-      } else if (isTablesQueryConfiguration(action)) {
-        actionType = "TABLES_QUERY";
-      } else if (isProcessConfiguration(action)) {
-        actionType = "PROCESS";
-      }
-    }
-
-    if (actionType !== null) {
-      const defaultAssistantState = getDefaultAssistantState();
-
-      setEdited(true);
-      setBuilderState((builderState) => {
-        const newState = {
-          ...builderState,
-          actions: defaultAssistantState.actions,
-        };
-        return newState;
-      });
-    }
-  }, [template, multiActionsEnabled]);
+  const {
+    template,
+    instructionsResetAt,
+    resetTemplate,
+    resetToTemplateInstructions,
+    resetToTemplateActions,
+  } = useTemplate(defaultTemplate);
 
   const showSlackIntegration =
     builderState.scope === "workspace" || builderState.scope === "published";
@@ -579,8 +516,14 @@ export default function AssistantBuilder({
               screen={screen}
               template={template}
               resetTemplate={resetTemplate}
-              resetToTemplateInstructions={resetToTemplateInstructions}
-              resetToTemplateActions={resetToTemplateActions}
+              resetToTemplateInstructions={async () => {
+                resetToTemplateInstructions(setBuilderState);
+                setEdited(true);
+              }}
+              resetToTemplateActions={async () => {
+                resetToTemplateActions(setBuilderState, multiActionsEnabled);
+                setEdited(true);
+              }}
               owner={owner}
               rightPanelStatus={rightPanelStatus}
               openRightPanelTab={openRightPanelTab}

--- a/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
+++ b/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
@@ -45,7 +45,7 @@ import type { FetchAssistantTemplateResponse } from "@app/pages/api/w/[wId]/assi
 export default function AssistantBuilderRightPanel({
   screen,
   template,
-  resetTemplate,
+  removeTemplate,
   resetToTemplateInstructions,
   resetToTemplateActions,
   owner,
@@ -56,7 +56,7 @@ export default function AssistantBuilderRightPanel({
 }: {
   screen: BuilderScreen;
   template: FetchAssistantTemplateResponse | null;
-  resetTemplate: () => Promise<void>;
+  removeTemplate: () => Promise<void>;
   resetToTemplateInstructions: () => Promise<void>;
   resetToTemplateActions: () => Promise<void>;
   owner: WorkspaceType;
@@ -193,7 +193,7 @@ export default function AssistantBuilderRightPanel({
                 />
                 <TemplateDropDownMenu
                   screen={screen}
-                  resetTemplate={resetTemplate}
+                  removeTemplate={removeTemplate}
                   resetToTemplateInstructions={resetToTemplateInstructions}
                   resetToTemplateActions={resetToTemplateActions}
                   openRightPanelTab={openRightPanelTab}
@@ -216,7 +216,7 @@ export default function AssistantBuilderRightPanel({
                 />
                 <TemplateDropDownMenu
                   screen={screen}
-                  resetTemplate={resetTemplate}
+                  removeTemplate={removeTemplate}
                   resetToTemplateInstructions={resetToTemplateInstructions}
                   resetToTemplateActions={resetToTemplateActions}
                   openRightPanelTab={openRightPanelTab}
@@ -305,13 +305,13 @@ const TemplateActionCard = ({
 
 const TemplateDropDownMenu = ({
   screen,
-  resetTemplate,
+  removeTemplate,
   resetToTemplateInstructions,
   resetToTemplateActions,
   openRightPanelTab,
 }: {
   screen: BuilderScreen;
-  resetTemplate: () => Promise<void>;
+  removeTemplate: () => Promise<void>;
   resetToTemplateInstructions: () => Promise<void>;
   resetToTemplateActions: () => Promise<void>;
   openRightPanelTab: (tabName: AssistantBuilderRightPanelTab) => void;
@@ -343,7 +343,7 @@ const TemplateDropDownMenu = ({
             });
             if (confirmed) {
               openRightPanelTab("Preview");
-              await resetTemplate();
+              await removeTemplate();
             }
           }}
           icon={XMarkIcon}

--- a/front/components/assistant_builder/useTemplate.tsx
+++ b/front/components/assistant_builder/useTemplate.tsx
@@ -1,0 +1,99 @@
+import {
+  getAgentActionConfigurationType,
+  isDustAppRunConfiguration,
+  isProcessConfiguration,
+  isRetrievalConfiguration,
+  isTablesQueryConfiguration,
+} from "@dust-tt/types";
+import _ from "lodash";
+import { useRouter } from "next/router";
+import { useCallback, useState } from "react";
+
+import type { AssistantBuilderState } from "@app/components/assistant_builder/types";
+import { getDefaultAssistantState } from "@app/components/assistant_builder/types";
+import type { FetchAssistantTemplateResponse } from "@app/pages/api/w/[wId]/assistant/builder/templates/[tId]";
+
+export function useTemplate(
+  initialTemplate: FetchAssistantTemplateResponse | null
+) {
+  const [template, setTemplate] =
+    useState<FetchAssistantTemplateResponse | null>(initialTemplate);
+  const [instructionsResetAt, setInstructionsResetAt] = useState<number | null>(
+    null
+  );
+  const router = useRouter();
+
+  const resetTemplate = useCallback(async () => {
+    setTemplate(null);
+    await router.replace(
+      { pathname: router.pathname, query: _.omit(router.query, "templateId") },
+      undefined,
+      { shallow: true }
+    );
+  }, [router]);
+
+  const resetToTemplateInstructions = useCallback(
+    (
+      setBuilderState: React.Dispatch<
+        React.SetStateAction<AssistantBuilderState>
+      >
+    ) => {
+      if (template === null) {
+        return;
+      }
+      setInstructionsResetAt(Date.now()); // Update the reset timestamp
+      setBuilderState((builderState) => ({
+        ...builderState,
+        instructions: template.presetInstructions,
+      }));
+    },
+    [template]
+  );
+
+  const resetToTemplateActions = useCallback(
+    (
+      setBuilderState: React.Dispatch<
+        React.SetStateAction<AssistantBuilderState>
+      >,
+      multiActionsEnabled: boolean
+    ) => {
+      if (template === null) {
+        return;
+      }
+      let actionType = null;
+      const action = getAgentActionConfigurationType(template.presetAction);
+      if (!multiActionsEnabled) {
+        if (isRetrievalConfiguration(action)) {
+          actionType = "RETRIEVAL_SEARCH";
+        } else if (isDustAppRunConfiguration(action)) {
+          actionType = "DUST_APP_RUN";
+        } else if (isTablesQueryConfiguration(action)) {
+          actionType = "TABLES_QUERY";
+        } else if (isProcessConfiguration(action)) {
+          actionType = "PROCESS";
+        }
+      }
+
+      if (actionType !== null || multiActionsEnabled) {
+        const defaultAssistantState = getDefaultAssistantState();
+
+        setBuilderState((builderState) => {
+          const newState = {
+            ...builderState,
+            actions: defaultAssistantState.actions,
+          };
+          return newState;
+        });
+      }
+    },
+    [template]
+  );
+
+  return {
+    template,
+    instructionsResetAt,
+    resetTemplate,
+    resetToTemplateInstructions,
+    resetToTemplateActions,
+  };
+}

--- a/front/components/assistant_builder/useTemplate.tsx
+++ b/front/components/assistant_builder/useTemplate.tsx
@@ -23,7 +23,7 @@ export function useTemplate(
   );
   const router = useRouter();
 
-  const resetTemplate = useCallback(async () => {
+  const removeTemplate = useCallback(async () => {
     setTemplate(null);
     await router.replace(
       { pathname: router.pathname, query: _.omit(router.query, "templateId") },
@@ -92,7 +92,7 @@ export function useTemplate(
   return {
     template,
     instructionsResetAt,
-    resetTemplate,
+    removeTemplate,
     resetToTemplateInstructions,
     resetToTemplateActions,
   };


### PR DESCRIPTION
## Description

This PR is still about cleaning up the AssistantBuilder component that is getting huge. 
It introduces a custom hook `useTemplate` to manage the state related to template management in the assistant builder. 

## Risk

Break the builder? Can easily be rolled back. 

## Deploy Plan

Deploy front.
