### PR TITLE
Assistant Builder: use hook for slack channel management

### DIFF
--- a/front/components/assistant_builder/useSlackChannels.tsx
+++ b/front/components/assistant_builder/useSlackChannels.tsx
@@ -1,0 +1,75 @@
+import type { DataSourceType } from "@dust-tt/types";
+import { useEffect, useState } from "react";
+
+import type { SlackChannel } from "@app/components/assistant/SlackIntegration";
+import { useSlackChannelsLinkedWithAgent } from "@app/lib/swr";
+
+export function useSlackChannel({
+  dataSources,
+  initialChannels,
+  workspaceId,
+  isPrivateAssistant,
+  isBuilder,
+  isEdited,
+  agentConfigurationId,
+}: {
+  dataSources: DataSourceType[];
+  initialChannels: SlackChannel[];
+  workspaceId: string;
+  isPrivateAssistant: boolean;
+  isBuilder: boolean;
+  isEdited: boolean;
+  agentConfigurationId: string | null;
+}) {
+  // This state stores the slack channels that should have the current agent as default.
+  const [selectedSlackChannels, setSelectedSlackChannels] =
+    useState<SlackChannel[]>(initialChannels);
+  const [slackChannelsInitialized, setSlackChannelsInitialized] =
+    useState(false);
+
+  const slackDataSource = dataSources.find(
+    (ds) => ds.connectorProvider === "slack"
+  );
+
+  // Retrieve all the slack channels that are linked with an agent.
+  const { slackChannels: slackChannelsLinkedWithAgent } =
+    useSlackChannelsLinkedWithAgent({
+      workspaceId,
+      dataSourceName: slackDataSource?.name ?? undefined,
+      disabled: !isBuilder,
+    });
+
+  // This effect is used to initially set the selectedSlackChannels state using the data retrieved from the API.
+  useEffect(() => {
+    if (
+      slackChannelsLinkedWithAgent.length &&
+      agentConfigurationId &&
+      !isEdited &&
+      !slackChannelsInitialized
+    ) {
+      setSelectedSlackChannels(
+        slackChannelsLinkedWithAgent
+          .filter(
+            (channel) => channel.agentConfigurationId === agentConfigurationId
+          )
+          .map((channel) => ({
+            slackChannelId: channel.slackChannelId,
+            slackChannelName: channel.slackChannelName,
+          }))
+      );
+      setSlackChannelsInitialized(true);
+    }
+  }, [
+    slackChannelsLinkedWithAgent,
+    agentConfigurationId,
+    isEdited,
+    slackChannelsInitialized,
+  ]);
+
+  return {
+    showSlackIntegration: !isPrivateAssistant,
+    selectedSlackChannels,
+    slackChannelsLinkedWithAgent,
+    setSelectedSlackChannels,
+  };
+}


### PR DESCRIPTION
## Description

This PR is still about cleaning up the AssistantBuilder component that is getting huge.
Previous PRs: https://github.com/dust-tt/dust/pull/5564, https://github.com/dust-tt/dust/pull/5571

It introduces a custom hook for the management of Slack channels attached to an assistant. 

## Risk

Break slack channel management. 
Can be rolled back. 

## Deploy Plan

Deploy front. 
