### PR TITLE
front: AssistantBuilder use descriptions in card actions

### DIFF
--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -50,6 +50,7 @@ import {
   ActionDustAppRun,
   isActionDustAppRunValid,
 } from "./actions/DustAppRunAction";
+import { classNames } from "@app/lib/utils";
 
 const DATA_SOURCES_ACTION_CATEGORIES = [
   "RETRIEVAL_SEARCH",
@@ -437,8 +438,13 @@ function ActionCard({
             }}
           />
         </div>
-        <div className="w-full truncate text-base text-element-700">
-          {_.capitalize(_.toLower(action.name).replace(/_/g, " "))}
+        <div
+          className={classNames(
+            "w-full truncate text-base",
+            action.description ? "text-element-700" : "text-warning-500"
+          )}
+        >
+          {action.description || "Description missing."}
         </div>
       </div>
     </CardButton>

--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -442,7 +442,7 @@ function ActionCard({
             action.description ? "text-element-700" : "text-warning-500"
           )}
         >
-          {action.description || "Description missing."}
+          {action.description || "Missing description"}
         </div>
       </div>
     </CardButton>

--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -14,10 +14,13 @@ import {
 } from "@dust-tt/sparkle";
 import type { AppType, DataSourceType, WorkspaceType } from "@dust-tt/types";
 import { assertNever, MAX_TOOLS_USE_PER_RUN_LIMIT } from "@dust-tt/types";
-import _ from "lodash";
 import type { ReactNode } from "react";
 import React, { useCallback, useEffect, useState } from "react";
 
+import {
+  ActionDustAppRun,
+  isActionDustAppRunValid,
+} from "@app/components/assistant_builder/actions/DustAppRunAction";
 import {
   ActionProcess,
   isActionProcessValid,
@@ -45,11 +48,6 @@ import type {
 } from "@app/components/assistant_builder/types";
 import { getDefaultActionConfiguration } from "@app/components/assistant_builder/types";
 import { ACTION_SPECIFICATIONS } from "@app/lib/api/assistant/actions/utils";
-
-import {
-  ActionDustAppRun,
-  isActionDustAppRunValid,
-} from "./actions/DustAppRunAction";
 import { classNames } from "@app/lib/utils";
 
 const DATA_SOURCES_ACTION_CATEGORIES = [

--- a/front/components/assistant_builder/actions/ProcessAction.tsx
+++ b/front/components/assistant_builder/actions/ProcessAction.tsx
@@ -532,8 +532,8 @@ export function ActionProcess({
             Clarify what the action should do and what data it should extract.
             For example:
             <span className="block text-element-600">
-              "Extract from the slack channel a list of books, including their
-              title, author, and publication date".
+              "Extract from the #reading slack channel a list of books,
+              including their title, author, and publication date".
             </span>
           </div>
           <TextArea

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -237,9 +237,7 @@ export function getDefaultProcessActionConfiguration() {
       schema: [],
     } as AssistantBuilderProcessConfiguration,
     name: "extract_structured_data_from_data_sources",
-    description:
-      "Process data sources specified by the user over a specific time-frame by extracting" +
-      " structured blobs of information (complying to a fixed schema).",
+    description: "",
   } satisfies AssistantBuilderActionConfiguration;
 }
 


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/dust/issues/5566

- Use description in ActionCard
- Remove default Extract description (checked that opening a legacy assistant without it is OK and can be saved)

![Screenshot from 2024-06-11 14-24-47](https://github.com/dust-tt/dust/assets/15067/37558259-3a49-4295-b10d-3646d7710e53)
![Screenshot from 2024-06-11 14-24-43](https://github.com/dust-tt/dust/assets/15067/bace909c-90f0-40b8-a225-32cd9ae3ddc9)


## Risk

None

## Deploy Plan

- deploy `front`