### PR TITLE
Improve connector error handling

### DIFF
--- a/connectors/src/connectors/confluence/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/confluence/temporal/cast_known_errors.ts
@@ -26,7 +26,7 @@ export class ConfluenceCastKnownErrorsInterceptor
             throw new ProviderWorkflowError(
               "confluence",
               "500 - Internal Error",
-              "transcient_upstream_activity_error",
+              "transient_upstream_activity_error",
               err
             );
 
@@ -34,7 +34,7 @@ export class ConfluenceCastKnownErrorsInterceptor
             throw new ProviderWorkflowError(
               "confluence",
               "502 - Bad Gateway",
-              "transcient_upstream_activity_error",
+              "transient_upstream_activity_error",
               err
             );
 
@@ -42,7 +42,7 @@ export class ConfluenceCastKnownErrorsInterceptor
             throw new ProviderWorkflowError(
               "confluence",
               "504 - Gateway Time Out",
-              "transcient_upstream_activity_error",
+              "transient_upstream_activity_error",
               err
             );
         }

--- a/connectors/src/connectors/confluence/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/confluence/temporal/cast_known_errors.ts
@@ -24,21 +24,21 @@ export class ConfluenceCastKnownErrorsInterceptor
         switch (err.status) {
           case 500:
             throw new ProviderWorkflowError(
-              "Confluence Internal Error",
+              "500 - Internal Error",
               "confluence",
               err
             );
 
           case 502:
             throw new ProviderWorkflowError(
-              "Confluence: 502 Bad Gateway",
+              "502 - Bad Gateway",
               "confluence",
               err
             );
 
           case 504:
             throw new ProviderWorkflowError(
-              "Confluence: Request timed out",
+              "504 - Gateway Time Out",
               "confluence",
               err
             );

--- a/connectors/src/connectors/confluence/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/confluence/temporal/cast_known_errors.ts
@@ -24,22 +24,25 @@ export class ConfluenceCastKnownErrorsInterceptor
         switch (err.status) {
           case 500:
             throw new ProviderWorkflowError(
-              "500 - Internal Error",
               "confluence",
+              "500 - Internal Error",
+              "transcient_upstream_activity_error",
               err
             );
 
           case 502:
             throw new ProviderWorkflowError(
-              "502 - Bad Gateway",
               "confluence",
+              "502 - Bad Gateway",
+              "transcient_upstream_activity_error",
               err
             );
 
           case 504:
             throw new ProviderWorkflowError(
-              "504 - Gateway Time Out",
               "confluence",
+              "504 - Gateway Time Out",
+              "transcient_upstream_activity_error",
               err
             );
         }

--- a/connectors/src/connectors/github/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/github/temporal/cast_known_errors.ts
@@ -20,8 +20,9 @@ export class GithubCastKnownErrorsInterceptor
       if (err instanceof RequestError) {
         if (err.status === 403 && err.name === "HttpError") {
           throw new ProviderWorkflowError(
-            "403 - Rate Limit Error",
             "github",
+            "403 - Rate Limit Error",
+            "rate_limit_error",
             err
           );
         }

--- a/connectors/src/connectors/github/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/github/temporal/cast_known_errors.ts
@@ -19,7 +19,11 @@ export class GithubCastKnownErrorsInterceptor
     } catch (err: unknown) {
       if (err instanceof RequestError) {
         if (err.status === 403 && err.name === "HttpError") {
-          throw new ProviderWorkflowError("Github rate limited", "github", err);
+          throw new ProviderWorkflowError(
+            "403 - Rate Limit Error",
+            "github",
+            err
+          );
         }
       }
 

--- a/connectors/src/connectors/github/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/github/temporal/cast_known_errors.ts
@@ -1,9 +1,12 @@
-import type { RequestError } from "@octokit/types";
 import type {
   ActivityExecuteInput,
   ActivityInboundCallsInterceptor,
   Next,
 } from "@temporalio/worker";
+import { RequestError } from "octokit";
+
+import { ProviderWorkflowError } from "@connectors/lib/error";
+
 export class GithubCastKnownErrorsInterceptor
   implements ActivityInboundCallsInterceptor
 {
@@ -14,14 +17,10 @@ export class GithubCastKnownErrorsInterceptor
     try {
       return await next(input);
     } catch (err: unknown) {
-      const maybeGhError = err as RequestError;
-
-      if (maybeGhError.status === 403 && maybeGhError.name === "HttpError") {
-        throw {
-          __is_dust_error: true,
-          message: "Github rate limited",
-          type: "github_rate_limited",
-        };
+      if (err instanceof RequestError) {
+        if (err.status === 403 && err.name === "HttpError") {
+          throw new ProviderWorkflowError("Github rate limited", "github", err);
+        }
       }
 
       throw err;

--- a/connectors/src/connectors/google_drive/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/google_drive/temporal/cast_known_errors.ts
@@ -31,7 +31,7 @@ export class GoogleDriveCastKnownErrorsInterceptor
             throw new ProviderWorkflowError(
               "google_drive",
               "500 - Internal Error",
-              "transcient_upstream_activity_error",
+              "transient_upstream_activity_error",
               err
             );
         }

--- a/connectors/src/connectors/google_drive/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/google_drive/temporal/cast_known_errors.ts
@@ -21,15 +21,17 @@ export class GoogleDriveCastKnownErrorsInterceptor
         switch (err.response?.status) {
           case 429:
             throw new ProviderWorkflowError(
-              "429: Rate Limit Error",
               "google_drive",
+              "429: Rate Limit Error",
+              "rate_limit_error",
               err
             );
 
           case 500:
             throw new ProviderWorkflowError(
-              "500 - Internal Error",
               "google_drive",
+              "500 - Internal Error",
+              "transcient_upstream_activity_error",
               err
             );
         }

--- a/connectors/src/connectors/google_drive/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/google_drive/temporal/cast_known_errors.ts
@@ -5,6 +5,8 @@ import type {
 } from "@temporalio/worker";
 import { GaxiosError } from "googleapis-common";
 
+import { ProviderWorkflowError } from "@connectors/lib/error";
+
 export class GoogleDriveCastKnownErrorsInterceptor
   implements ActivityInboundCallsInterceptor
 {
@@ -15,22 +17,24 @@ export class GoogleDriveCastKnownErrorsInterceptor
     try {
       return await next(input);
     } catch (err: unknown) {
-      if (err instanceof GaxiosError && err.response?.status === 500) {
-        throw {
-          __is_dust_error: true,
-          message: "Google Drive Internal Error",
-          type: "google_drive_internal_error",
-          error: err,
-        };
+      if (err instanceof GaxiosError) {
+        switch (err.response?.status) {
+          case 429:
+            throw new ProviderWorkflowError(
+              "Google Drive Rate Limit Error",
+              "google_drive",
+              err
+            );
+
+          case 500:
+            throw new ProviderWorkflowError(
+              "Google Drive Internal Error",
+              "google_drive",
+              err
+            );
+        }
       }
-      if (err instanceof GaxiosError && err.response?.status === 429) {
-        throw {
-          __is_dust_error: true,
-          message: "Google Drive Rate Limit Error",
-          type: "google_drive_rate_limit_error",
-          error: err,
-        };
-      }
+
       throw err;
     }
   }

--- a/connectors/src/connectors/google_drive/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/google_drive/temporal/cast_known_errors.ts
@@ -21,14 +21,14 @@ export class GoogleDriveCastKnownErrorsInterceptor
         switch (err.response?.status) {
           case 429:
             throw new ProviderWorkflowError(
-              "Google Drive Rate Limit Error",
+              "429: Rate Limit Error",
               "google_drive",
               err
             );
 
           case 500:
             throw new ProviderWorkflowError(
-              "Google Drive Internal Error",
+              "500 - Internal Error",
               "google_drive",
               err
             );

--- a/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
+++ b/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
@@ -418,8 +418,9 @@ export async function syncSpreadSheet(
     } catch (err) {
       if (isGAxiosServiceUnavailablError(err)) {
         throw new ProviderWorkflowError(
-          "503 - Service Unavailable from Google Sheets",
           "google_drive",
+          "503 - Service Unavailable from Google Sheets",
+          "transcient_upstream_activity_error",
           err
         );
       } else if (err instanceof Error && "code" in err && err.code === 500) {

--- a/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
+++ b/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
@@ -418,7 +418,7 @@ export async function syncSpreadSheet(
     } catch (err) {
       if (isGAxiosServiceUnavailablError(err)) {
         throw new ProviderWorkflowError(
-          "Got 503 Service Unavailable from Google Sheets",
+          "503 - Service Unavailable from Google Sheets",
           "google_drive",
           err
         );

--- a/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
+++ b/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
@@ -420,7 +420,7 @@ export async function syncSpreadSheet(
         throw new ProviderWorkflowError(
           "google_drive",
           "503 - Service Unavailable from Google Sheets",
-          "transcient_upstream_activity_error",
+          "transient_upstream_activity_error",
           err
         );
       } else if (err instanceof Error && "code" in err && err.code === 500) {

--- a/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
+++ b/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
@@ -15,6 +15,7 @@ import { MAX_FILE_SIZE_TO_DOWNLOAD } from "@connectors/connectors/google_drive/t
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { concurrentExecutor } from "@connectors/lib/async_utils";
 import { deleteTable, upsertTableFromCsv } from "@connectors/lib/data_sources";
+import { ProviderWorkflowError } from "@connectors/lib/error";
 import type { GoogleDriveFiles } from "@connectors/lib/models/google_drive";
 import { GoogleDriveSheet } from "@connectors/lib/models/google_drive";
 import type { Logger } from "@connectors/logger/logger";
@@ -416,12 +417,11 @@ export async function syncSpreadSheet(
       break;
     } catch (err) {
       if (isGAxiosServiceUnavailablError(err)) {
-        throw {
-          error: err,
-          __is_dust_error: true,
-          message: "Got 503 Service Unavailable from Google Sheets",
-          type: "google_sheets_503_service_unavailable",
-        };
+        throw new ProviderWorkflowError(
+          "Got 503 Service Unavailable from Google Sheets",
+          "google_drive",
+          err
+        );
       } else if (err instanceof Error && "code" in err && err.code === 500) {
         internalErrorsCount++;
         if (internalErrorsCount > maxInternalErrors) {
@@ -557,6 +557,6 @@ export async function deleteSpreadsheet(
   }
 }
 
-function isGAxiosServiceUnavailablError(err: unknown): boolean {
+function isGAxiosServiceUnavailablError(err: unknown): err is Error {
   return err instanceof Error && "code" in err && err.code === 503;
 }

--- a/connectors/src/connectors/intercom/lib/intercom_api.ts
+++ b/connectors/src/connectors/intercom/lib/intercom_api.ts
@@ -97,7 +97,7 @@ async function queryIntercomAPI({
       const isCaptchaError = text.includes("captcha-container");
 
       throw new ProviderWorkflowError(
-        `Intercom 405: ${isCaptchaError ? "Captcha error" : text}`,
+        `405 - ${isCaptchaError ? "Captcha error" : text}`,
         "intercom"
       );
     } else {

--- a/connectors/src/connectors/intercom/lib/intercom_api.ts
+++ b/connectors/src/connectors/intercom/lib/intercom_api.ts
@@ -6,8 +6,10 @@ import type {
   IntercomHelpCenterType,
   IntercomTeamType,
 } from "@connectors/connectors/intercom/lib/types";
-import type { WorkflowError } from "@connectors/lib/error";
-import { ExternalOauthTokenError } from "@connectors/lib/error";
+import {
+  ExternalOauthTokenError,
+  ProviderWorkflowError,
+} from "@connectors/lib/error";
 import { getAccessTokenFromNango } from "@connectors/lib/nango_helpers";
 import logger from "@connectors/logger/logger";
 
@@ -93,12 +95,11 @@ async function queryIntercomAPI({
   } catch (e) {
     if (rawResponse.status === 405) {
       const isCaptchaError = text.includes("captcha-container");
-      const workflowError: WorkflowError = {
-        type: "transient_upstream_activity_error",
-        message: `Intercom 405: ${isCaptchaError ? "Captcha error" : text}`,
-        __is_dust_error: true,
-      };
-      throw workflowError;
+
+      throw new ProviderWorkflowError(
+        `Intercom 405: ${isCaptchaError ? "Captcha error" : text}`,
+        "intercom"
+      );
     } else {
       logger.info(
         { path, response: text, status: rawResponse.status },

--- a/connectors/src/connectors/intercom/lib/intercom_api.ts
+++ b/connectors/src/connectors/intercom/lib/intercom_api.ts
@@ -99,7 +99,7 @@ async function queryIntercomAPI({
       throw new ProviderWorkflowError(
         "intercom",
         `405 - ${isCaptchaError ? "Captcha error" : text}`,
-        "transcient_upstream_activity_error"
+        "transient_upstream_activity_error"
       );
     } else {
       logger.info(

--- a/connectors/src/connectors/intercom/lib/intercom_api.ts
+++ b/connectors/src/connectors/intercom/lib/intercom_api.ts
@@ -97,8 +97,9 @@ async function queryIntercomAPI({
       const isCaptchaError = text.includes("captcha-container");
 
       throw new ProviderWorkflowError(
+        "intercom",
         `405 - ${isCaptchaError ? "Captcha error" : text}`,
-        "intercom"
+        "transcient_upstream_activity_error"
       );
     } else {
       logger.info(

--- a/connectors/src/connectors/notion/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/notion/temporal/cast_known_errors.ts
@@ -9,6 +9,8 @@ import type {
   Next,
 } from "@temporalio/worker";
 
+import { ProviderWorkflowError } from "@connectors/lib/error";
+
 export class NotionCastKnownErrorsInterceptor
   implements ActivityInboundCallsInterceptor
 {
@@ -20,45 +22,46 @@ export class NotionCastKnownErrorsInterceptor
       return await next(input);
     } catch (err: unknown) {
       if (APIResponseError.isAPIResponseError(err)) {
-        if (err.code === APIErrorCode.ServiceUnavailable) {
-          throw {
-            __is_dust_error: true,
-            message: err.message,
-            type: "notion_service_unavailable",
-          };
-        }
-        if (err.code === APIErrorCode.RateLimited) {
-          throw {
-            __is_dust_error: true,
-            message: err.message,
-            type: "notion_rate_limited",
-          };
-        }
-        if (err.code === APIErrorCode.InternalServerError) {
-          throw {
-            __is_dust_error: true,
-            message: err.message,
-            type: "notion_internal_server_error",
-          };
+        switch (err.code) {
+          case APIErrorCode.ServiceUnavailable:
+            throw new ProviderWorkflowError(
+              "Notion service is unavailable",
+              "notion",
+              err
+            );
+
+          case APIErrorCode.RateLimited:
+            throw new ProviderWorkflowError(
+              "Notion rate limited",
+              "notion",
+              err
+            );
+
+          case APIErrorCode.InternalServerError:
+            throw new ProviderWorkflowError(
+              "Notion internal server error",
+              "notion",
+              err
+            );
         }
       } else if (UnknownHTTPResponseError.isUnknownHTTPResponseError(err)) {
         if ([502, 504, 530].includes(err.status)) {
           // Sometimes notion returns 502/504s, they are transient and look like rate limiting
           // errors. 530 is transient and looks like DNS errors.
-          throw {
-            __is_dust_error: true,
-            message: err.message,
-            type: "notion_50X_transient_error",
-            status_code: err.status,
-          };
+          throw new ProviderWorkflowError(
+            "Notion 5XX transient error",
+            "notion",
+            err
+          );
         }
       } else if (RequestTimeoutError.isRequestTimeoutError(err)) {
-        throw {
-          __is_dust_error: true,
-          message: err.message,
-          type: "notion_request_timeout",
-        };
+        throw new ProviderWorkflowError(
+          "Notion request timeout",
+          "notion",
+          err
+        );
       }
+
       throw err;
     }
   }

--- a/connectors/src/connectors/notion/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/notion/temporal/cast_known_errors.ts
@@ -25,21 +25,17 @@ export class NotionCastKnownErrorsInterceptor
         switch (err.code) {
           case APIErrorCode.ServiceUnavailable:
             throw new ProviderWorkflowError(
-              "Notion service is unavailable",
+              "Service Unavailable",
               "notion",
               err
             );
 
           case APIErrorCode.RateLimited:
-            throw new ProviderWorkflowError(
-              "Notion rate limited",
-              "notion",
-              err
-            );
+            throw new ProviderWorkflowError("Rate Limit Error", "notion", err);
 
           case APIErrorCode.InternalServerError:
             throw new ProviderWorkflowError(
-              "Notion internal server error",
+              "Internal Server Error",
               "notion",
               err
             );
@@ -55,11 +51,7 @@ export class NotionCastKnownErrorsInterceptor
           );
         }
       } else if (RequestTimeoutError.isRequestTimeoutError(err)) {
-        throw new ProviderWorkflowError(
-          "Notion request timeout",
-          "notion",
-          err
-        );
+        throw new ProviderWorkflowError("Request Timeout", "notion", err);
       }
 
       throw err;

--- a/connectors/src/connectors/notion/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/notion/temporal/cast_known_errors.ts
@@ -25,18 +25,25 @@ export class NotionCastKnownErrorsInterceptor
         switch (err.code) {
           case APIErrorCode.ServiceUnavailable:
             throw new ProviderWorkflowError(
-              "Service Unavailable",
               "notion",
+              "Service Unavailable",
+              "transcient_upstream_activity_error",
               err
             );
 
           case APIErrorCode.RateLimited:
-            throw new ProviderWorkflowError("Rate Limit Error", "notion", err);
+            throw new ProviderWorkflowError(
+              "notion",
+              "Rate Limit Error",
+              "rate_limit_error",
+              err
+            );
 
           case APIErrorCode.InternalServerError:
             throw new ProviderWorkflowError(
-              "Internal Server Error",
               "notion",
+              "Internal Server Error",
+              "transcient_upstream_activity_error",
               err
             );
         }
@@ -45,13 +52,19 @@ export class NotionCastKnownErrorsInterceptor
           // Sometimes notion returns 502/504s, they are transient and look like rate limiting
           // errors. 530 is transient and looks like DNS errors.
           throw new ProviderWorkflowError(
-            "Notion 5XX transient error",
             "notion",
+            "Notion 5XX transient error",
+            "transcient_upstream_activity_error",
             err
           );
         }
       } else if (RequestTimeoutError.isRequestTimeoutError(err)) {
-        throw new ProviderWorkflowError("Request Timeout", "notion", err);
+        throw new ProviderWorkflowError(
+          "notion",
+          "Request Timeout",
+          "transcient_upstream_activity_error",
+          err
+        );
       }
 
       throw err;

--- a/connectors/src/connectors/notion/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/notion/temporal/cast_known_errors.ts
@@ -27,7 +27,7 @@ export class NotionCastKnownErrorsInterceptor
             throw new ProviderWorkflowError(
               "notion",
               "Service Unavailable",
-              "transcient_upstream_activity_error",
+              "transient_upstream_activity_error",
               err
             );
 
@@ -43,7 +43,7 @@ export class NotionCastKnownErrorsInterceptor
             throw new ProviderWorkflowError(
               "notion",
               "Internal Server Error",
-              "transcient_upstream_activity_error",
+              "transient_upstream_activity_error",
               err
             );
         }
@@ -54,7 +54,7 @@ export class NotionCastKnownErrorsInterceptor
           throw new ProviderWorkflowError(
             "notion",
             "Notion 5XX transient error",
-            "transcient_upstream_activity_error",
+            "transient_upstream_activity_error",
             err
           );
         }
@@ -62,7 +62,7 @@ export class NotionCastKnownErrorsInterceptor
         throw new ProviderWorkflowError(
           "notion",
           "Request Timeout",
-          "transcient_upstream_activity_error",
+          "transient_upstream_activity_error",
           err
         );
       }

--- a/connectors/src/connectors/slack/lib/slack_client.ts
+++ b/connectors/src/connectors/slack/lib/slack_client.ts
@@ -6,8 +6,10 @@ import type {
 } from "@slack/web-api";
 import { ErrorCode, WebClient } from "@slack/web-api";
 
-import type { WorkflowError } from "@connectors/lib/error";
-import { ExternalOauthTokenError } from "@connectors/lib/error";
+import {
+  ExternalOauthTokenError,
+  ProviderWorkflowError,
+} from "@connectors/lib/error";
 import { getAccessTokenFromNango } from "@connectors/lib/nango_helpers";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 const { NANGO_SLACK_CONNECTOR_ID } = process.env;
@@ -64,24 +66,22 @@ export async function getSlackClient(
           e instanceof Error &&
           e.message.startsWith("A rate limit was exceeded")
         ) {
-          throw {
-            __is_dust_error: true,
-            message: e.message,
-            triggeringError: e,
-            type: "connector_rate_limit_error",
-          };
+          throw new ProviderWorkflowError(
+            `Rate limited: ${e.message}`,
+            "slack",
+            e
+          );
         }
 
         const slackError = e as CodedError;
         if (slackError.code === ErrorCode.HTTPError) {
           const httpError = slackError as WebAPIHTTPError;
           if (httpError.statusCode === 503) {
-            const workflowError: WorkflowError = {
-              type: "upstream_is_down_activity_error",
-              message: `Slack is down: ${httpError.message}`,
-              __is_dust_error: true,
-            };
-            throw workflowError;
+            throw new ProviderWorkflowError(
+              `Slack is down: ${httpError.message}`,
+              "slack",
+              httpError
+            );
           }
         }
         if (slackError.code === ErrorCode.PlatformError) {

--- a/connectors/src/connectors/slack/lib/slack_client.ts
+++ b/connectors/src/connectors/slack/lib/slack_client.ts
@@ -67,8 +67,9 @@ export async function getSlackClient(
           e.message.startsWith("A rate limit was exceeded")
         ) {
           throw new ProviderWorkflowError(
-            `Rate limited: ${e.message}`,
             "slack",
+            `Rate limited: ${e.message}`,
+            "rate_limit_error",
             e
           );
         }
@@ -78,8 +79,9 @@ export async function getSlackClient(
           const httpError = slackError as WebAPIHTTPError;
           if (httpError.statusCode === 503) {
             throw new ProviderWorkflowError(
-              `Slack is down: ${httpError.message}`,
               "slack",
+              `Slack is down: ${httpError.message}`,
+              "transcient_upstream_activity_error",
               httpError
             );
           }

--- a/connectors/src/connectors/slack/lib/slack_client.ts
+++ b/connectors/src/connectors/slack/lib/slack_client.ts
@@ -81,7 +81,7 @@ export async function getSlackClient(
             throw new ProviderWorkflowError(
               "slack",
               `Slack is down: ${httpError.message}`,
-              "transcient_upstream_activity_error",
+              "transient_upstream_activity_error",
               httpError
             );
           }

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -126,7 +126,7 @@ export async function getChannel(
     throw new ProviderWorkflowError(
       "slack",
       "Received unexpected undefined replies from Slack API in getChannel (generally transient)",
-      "transcient_upstream_activity_error"
+      "transient_upstream_activity_error"
     );
   }
   if (res.error) {
@@ -296,7 +296,7 @@ export async function getMessagesForChannel(
     throw new ProviderWorkflowError(
       "slack",
       "Received unexpected undefined replies from Slack API in getMessagesForChannel (generally transient)",
-      "transcient_upstream_activity_error"
+      "transient_upstream_activity_error"
     );
   }
   if (c.error) {

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -124,8 +124,9 @@ export async function getChannel(
   // Despite the typing, in practice `conversations.info` can be undefined at times.
   if (!res) {
     throw new ProviderWorkflowError(
+      "slack",
       "Received unexpected undefined replies from Slack API in getChannel (generally transient)",
-      "slack"
+      "transcient_upstream_activity_error"
     );
   }
   if (res.error) {
@@ -293,8 +294,9 @@ export async function getMessagesForChannel(
   // Despite the typing, in practice `conversations.history` can be undefined at times.
   if (!c) {
     throw new ProviderWorkflowError(
+      "slack",
       "Received unexpected undefined replies from Slack API in getMessagesForChannel (generally transient)",
-      "slack"
+      "transcient_upstream_activity_error"
     );
   }
   if (c.error) {

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -31,7 +31,7 @@ import {
   renderDocumentTitleAndContent,
   upsertToDatasource,
 } from "@connectors/lib/data_sources";
-import type { WorkflowError } from "@connectors/lib/error";
+import { ProviderWorkflowError } from "@connectors/lib/error";
 import { SlackChannel, SlackMessages } from "@connectors/lib/models/slack";
 import {
   reportInitialSyncProgress,
@@ -123,13 +123,10 @@ export async function getChannel(
   const res = await client.conversations.info({ channel: channelId });
   // Despite the typing, in practice `conversations.info` can be undefined at times.
   if (!res) {
-    const workflowError: WorkflowError = {
-      type: "transient_upstream_activity_error",
-      message:
-        "Received unexpected undefined replies from Slack API in getChannel (generally transient)",
-      __is_dust_error: true,
-    };
-    throw workflowError;
+    throw new ProviderWorkflowError(
+      "Received unexpected undefined replies from Slack API in getChannel (generally transient)",
+      "slack"
+    );
   }
   if (res.error) {
     throw new Error(res.error);
@@ -295,13 +292,10 @@ export async function getMessagesForChannel(
   });
   // Despite the typing, in practice `conversations.history` can be undefined at times.
   if (!c) {
-    const workflowError: WorkflowError = {
-      type: "transient_upstream_activity_error",
-      message:
-        "Received unexpected undefined replies from Slack API in getMessagesForChannel (generally transient)",
-      __is_dust_error: true,
-    };
-    throw workflowError;
+    throw new ProviderWorkflowError(
+      "Received unexpected undefined replies from Slack API in getMessagesForChannel (generally transient)",
+      "slack"
+    );
   }
   if (c.error) {
     throw new Error(

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -316,7 +316,7 @@ async function tokenize(text: string, ds: DataSourceConfig) {
     throw new DustConnectorWorkflowError(
       `Error tokenizing text for ${ds.dataSourceName}`,
       "transient_upstream_activity_error",
-      tokensRes.error as unknown as Error
+      tokensRes.error
     );
   }
   return tokensRes.value;

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -17,6 +17,7 @@ import { toMarkdown } from "mdast-util-to-markdown";
 import { gfm } from "micromark-extension-gfm";
 
 import { withRetries } from "@connectors/lib/dust_front_api_helpers";
+import { DustConnectorWorkflowError } from "@connectors/lib/error";
 import logger from "@connectors/logger/logger";
 import { statsDClient } from "@connectors/logger/withlogging";
 import type { DataSourceConfig } from "@connectors/types/data_source_config";
@@ -312,11 +313,11 @@ async function tokenize(text: string, ds: DataSourceConfig) {
       { error: tokensRes.error },
       `Error tokenizing text for ${ds.dataSourceName}`
     );
-    throw {
-      __is_dust_error: true,
-      message: `Error tokenizing text for ${ds.dataSourceName}`,
-      type: "tokenize_internal_server_error",
-    };
+    throw new DustConnectorWorkflowError(
+      `Error tokenizing text for ${ds.dataSourceName}`,
+      "transient_upstream_activity_error",
+      tokensRes.error as unknown as Error
+    );
   }
   return tokensRes.value;
 }

--- a/connectors/src/lib/error.ts
+++ b/connectors/src/lib/error.ts
@@ -12,8 +12,9 @@ export function errorFromAny(e: any): Error {
 }
 
 // Generate dynamic error types.
-type ProviderErrorType<T extends string> =
-  `${T}_transcient_upstream_activity_error`;
+type ProviderErrorType =
+  | "rate_limit_error"
+  | "transcient_upstream_activity_error";
 
 // Define general workflow error types.
 type GeneralWorkflowErrorType =
@@ -23,9 +24,7 @@ type GeneralWorkflowErrorType =
   | "workflow_timeout_failure";
 
 // Combine both general and provider-specific error types.
-type WorkflowErrorType =
-  | GeneralWorkflowErrorType
-  | ProviderErrorType<ConnectorProvider>;
+type WorkflowErrorType = GeneralWorkflowErrorType | ProviderErrorType;
 
 export class DustConnectorWorkflowError extends Error {
   constructor(
@@ -40,15 +39,12 @@ export class DustConnectorWorkflowError extends Error {
 // Define a specific error class for provider-related errors.
 export class ProviderWorkflowError extends DustConnectorWorkflowError {
   constructor(
-    message: string,
     public readonly provider: ConnectorProvider,
+    message: string,
+    type: ProviderErrorType,
     originalError?: Error | APIError
   ) {
-    super(
-      message,
-      `${provider}_upstream_activity_error` as WorkflowErrorType,
-      originalError
-    );
+    super(message, type, originalError);
   }
 }
 

--- a/connectors/src/lib/error.ts
+++ b/connectors/src/lib/error.ts
@@ -1,4 +1,7 @@
 // JS cannot give you any guarantee about the shape of an error you `catch`
+
+import type { ConnectorProvider } from "@dust-tt/types";
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function errorFromAny(e: any): Error {
   return {
@@ -8,17 +11,51 @@ export function errorFromAny(e: any): Error {
   };
 }
 
-export type WorkflowErrorType =
-  | "unhandled_internal_activity_error"
-  | "transient_upstream_activity_error"
-  | "transient_nango_activity_error"
-  | "upstream_is_down_activity_error";
+// export type WorkflowErrorType =
+//   | "unhandled_internal_activity_error"
+//   | "transient_nango_activity_error"
+//   | "worfklow_timeout_failure";
 
-export type WorkflowError = {
-  type: WorkflowErrorType;
-  message: string;
-  __is_dust_error: boolean;
-};
+// Generate dynamic error types.
+type ProviderErrorType<T extends string> =
+  `${T}_transcient_upstream_activity_error`;
+
+// Define general workflow error types.
+type GeneralWorkflowErrorType =
+  | "transient_nango_activity_error"
+  | "transient_upstream_activity_error"
+  | "unhandled_internal_activity_error"
+  | "workflow_timeout_failure";
+
+// Combine both general and provider-specific error types.
+type WorkflowErrorType =
+  | GeneralWorkflowErrorType
+  | ProviderErrorType<ConnectorProvider>;
+
+export class DustConnectorWorkflowError extends Error {
+  constructor(
+    message: string,
+    readonly type: WorkflowErrorType,
+    readonly originalError?: Error
+  ) {
+    super(message);
+  }
+}
+
+// Define a specific error class for provider-related errors.
+export class ProviderWorkflowError extends DustConnectorWorkflowError {
+  constructor(
+    message: string,
+    public readonly provider: ConnectorProvider,
+    originalError?: Error
+  ) {
+    super(
+      message,
+      `${provider}_upstream_activity_error` as WorkflowErrorType,
+      originalError
+    );
+  }
+}
 
 export class HTTPError extends Error {
   readonly statusCode: number;

--- a/connectors/src/lib/error.ts
+++ b/connectors/src/lib/error.ts
@@ -14,7 +14,7 @@ export function errorFromAny(e: any): Error {
 // Generate dynamic error types.
 type ProviderErrorType =
   | "rate_limit_error"
-  | "transcient_upstream_activity_error";
+  | "transient_upstream_activity_error";
 
 // Define general workflow error types.
 type GeneralWorkflowErrorType =

--- a/connectors/src/lib/error.ts
+++ b/connectors/src/lib/error.ts
@@ -1,6 +1,6 @@
 // JS cannot give you any guarantee about the shape of an error you `catch`
 
-import type { ConnectorProvider } from "@dust-tt/types";
+import type { APIError, ConnectorProvider } from "@dust-tt/types";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function errorFromAny(e: any): Error {
@@ -36,7 +36,7 @@ export class DustConnectorWorkflowError extends Error {
   constructor(
     message: string,
     readonly type: WorkflowErrorType,
-    readonly originalError?: Error
+    readonly originalError?: Error | APIError
   ) {
     super(message);
   }
@@ -47,7 +47,7 @@ export class ProviderWorkflowError extends DustConnectorWorkflowError {
   constructor(
     message: string,
     public readonly provider: ConnectorProvider,
-    originalError?: Error
+    originalError?: Error | APIError
   ) {
     super(
       message,

--- a/connectors/src/lib/error.ts
+++ b/connectors/src/lib/error.ts
@@ -11,11 +11,6 @@ export function errorFromAny(e: any): Error {
   };
 }
 
-// export type WorkflowErrorType =
-//   | "unhandled_internal_activity_error"
-//   | "transient_nango_activity_error"
-//   | "worfklow_timeout_failure";
-
 // Generate dynamic error types.
 type ProviderErrorType<T extends string> =
   `${T}_transcient_upstream_activity_error`;

--- a/connectors/src/lib/nango_client.ts
+++ b/connectors/src/lib/nango_client.ts
@@ -3,8 +3,8 @@ import { Err, Ok } from "@dust-tt/types";
 import { Nango } from "@nangohq/node";
 import axios from "axios";
 
-import type { WorkflowError } from "@connectors/lib/error";
 import {
+  DustConnectorWorkflowError,
   ExternalOauthTokenError,
   NANGO_ERROR_TYPES,
   NangoError,
@@ -46,12 +46,10 @@ class CustomNango extends Nango {
           }
         }
         if (e.status === 520 && e.code === "ERR_BAD_RESPONSE") {
-          const workflowError: WorkflowError = {
-            type: "transient_nango_activity_error",
-            message: `Nango transient 520 errors`,
-            __is_dust_error: true,
-          };
-          throw workflowError;
+          throw new DustConnectorWorkflowError(
+            "Nango transient 520 errors",
+            "transient_nango_activity_error"
+          );
         }
       }
       throw e;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See https://github.com/dust-tt/tasks/issues/808.

This PR reworks the existing custom Dust error logic. Currently, in several areas, we are throwing objects as errors instead of using proper error objects, which has several drawbacks:
- We lose the stack trace in all cases, complicating debugging efforts.
- We cannot enforce strict typing. During refactoring, I discovered many fields being passed are never actually used.

This PR introduces two classes (we dont' want too many!):
- `DustConnectorWorkflowError`: This is the primary class for all errors related to connector workflow issues like timeouts, etc.
- `ProviderWorkflowError`: which extends the primary class to include the provider in the error context. These two classes should address most of the scenarios we currently need to handle.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
