### PR TITLE
[front] - fix: update default embedding provider schema

### DIFF
--- a/front/pages/api/w/[wId]/index.ts
+++ b/front/pages/api/w/[wId]/index.ts
@@ -1,5 +1,5 @@
 import type { WithAPIErrorReponse, WorkspaceType } from "@dust-tt/types";
-import { ModelProviderIdCodec } from "@dust-tt/types";
+import { EmbeddingProviderCodec, ModelProviderIdCodec } from "@dust-tt/types";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
@@ -31,7 +31,7 @@ const WorkspaceProvidersUpdateBodySchema = t.type({
 });
 
 const WorkspaceEmbedderUpdateBodySchema = t.type({
-  defaultEmbeddingProvider: ModelProviderIdCodec,
+  defaultEmbeddingProvider: EmbeddingProviderCodec,
 });
 
 const PostWorkspaceRequestBodySchema = t.union([

--- a/types/src/front/lib/assistant.ts
+++ b/types/src/front/lib/assistant.ts
@@ -24,6 +24,10 @@ export const isModelProviderId = (
 export const ModelProviderIdCodec =
   ioTsEnum<(typeof MODEL_PROVIDER_IDS)[number]>(MODEL_PROVIDER_IDS);
 
+export const EmbeddingProviderCodec = ioTsEnum<
+  (typeof EMBEDDING_PROVIDER_IDS)[number]
+>(EMBEDDING_PROVIDER_IDS);
+
 /**
  * MODEL IDS
  */


### PR DESCRIPTION
## Description

 - introduce `EmbeddingProviderCodec`
 - Change the type definition of `defaultEmbeddingProvider` from `ModelProviderIdCodec` to `EmbeddingProviderCodec`

## Risk

None

## Deploy Plan

Deploy `front`
