### PR TITLE
chore: run npm audit fix

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "front",
       "dependencies": {
         "@amplitude/ampli": "^1.35.0",
         "@amplitude/analytics-browser": "^2.5.2",
@@ -3524,10 +3525,11 @@
       }
     },
     "../types/node_modules/braces": {
-      "version": "3.0.2",
-      "license": "MIT",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -5058,8 +5060,9 @@
       "optional": true
     },
     "../types/node_modules/fill-range": {
-      "version": "7.0.1",
-      "license": "MIT",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -5827,7 +5830,8 @@
     },
     "../types/node_modules/is-number": {
       "version": "7.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "engines": {
         "node": ">=0.12.0"
       }
@@ -8706,7 +8710,8 @@
     },
     "../types/node_modules/to-regex-range": {
       "version": "5.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -11903,23 +11908,25 @@
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.7.3",
-      "license": "Apache-2.0",
+      "version": "1.10.9",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.10.9.tgz",
+      "integrity": "sha512-5tcgUctCG0qoNyfChZifz2tJqbRbXVO9J7X6duFcOjY3HUNCxg5D0ZCK7EP9vIcZ0zRpLU9bWkyCqVCLZ46IbQ==",
       "dependencies": {
-        "@grpc/proto-loader": "^0.7.0",
-        "@types/node": ">=12.12.47"
+        "@grpc/proto-loader": "^0.7.13",
+        "@js-sdsl/ordered-map": "^4.4.2"
       },
       "engines": {
-        "node": "^8.13.0 || >=10.10.0"
+        "node": ">=12.10.0"
       }
     },
     "node_modules/@grpc/proto-loader": {
-      "version": "0.7.10",
-      "license": "Apache-2.0",
+      "version": "0.7.13",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.13.tgz",
+      "integrity": "sha512-AiXO/bfe9bmxBjxxtYxFAXGZvMaN5s8kO+jBHAJCON8rJoB5YS/D6X7ZNc6XQkuHNmyl4CYaMI1fJ/Gn27RGGw==",
       "dependencies": {
         "lodash.camelcase": "^4.3.0",
         "long": "^5.0.0",
-        "protobufjs": "^7.2.4",
+        "protobufjs": "^7.2.5",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -12504,6 +12511,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
       }
     },
     "node_modules/@jsonjoy.com/base64": {
@@ -15262,45 +15278,45 @@
       }
     },
     "node_modules/@temporalio/activity": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/@temporalio/activity/-/activity-1.9.3.tgz",
-      "integrity": "sha512-QmY2dCNNSANhCgy4HCaeRmosyg73wI7KFbxTpnCrFjAWjxpJqBYC5qROrWHQEG/52Mcf59MtmznWSqz3M04Naw==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@temporalio/activity/-/activity-1.10.1.tgz",
+      "integrity": "sha512-ZCUOq3pzIYuWeGCtY5cAbtjUqFr8qg6oQJ64gHqUlstk9mweeOtMhYUyBUNBeb+MlYn+YhtxyCaUc1HQlVXkHg==",
       "dependencies": {
-        "@temporalio/common": "1.9.3",
+        "@temporalio/common": "1.10.1",
         "abort-controller": "^3.0.0"
       }
     },
     "node_modules/@temporalio/client": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/@temporalio/client/-/client-1.9.3.tgz",
-      "integrity": "sha512-RgcqMqgrzQG3jOrCxnh8mYqwDqngAMKoCUOPwZZU5AAJa0sBcBLV2lEhJ9KGEavpfZej/duplUa67EV0s+M/6w==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@temporalio/client/-/client-1.10.1.tgz",
+      "integrity": "sha512-j7ey7jvE9/2LPNggmItlvjugMbDIfN76wiQkxoXvS4Y4/6JHgcCAANJ5UpzkHR51LREkRBzDLVeRtxqrfgGMWw==",
       "dependencies": {
-        "@grpc/grpc-js": "~1.7.3",
-        "@temporalio/common": "1.9.3",
-        "@temporalio/proto": "1.9.3",
+        "@grpc/grpc-js": "^1.10.6",
+        "@temporalio/common": "1.10.1",
+        "@temporalio/proto": "1.10.1",
         "abort-controller": "^3.0.0",
         "long": "^5.2.3",
         "uuid": "^9.0.1"
       }
     },
     "node_modules/@temporalio/common": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/@temporalio/common/-/common-1.9.3.tgz",
-      "integrity": "sha512-o6aAiqyIyu8b1bUOeY4nu04ZMwLAPR66Vtc8W/xYs7WM874wNhZlm8XWspqnmflI3W7td4y3Y50AHRi/BUNxRg==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@temporalio/common/-/common-1.10.1.tgz",
+      "integrity": "sha512-0l2XS2+4NW8y7zsCAMixAK0UEIEQLwx/f32j67VGT/DjJ1ri63W5ZTbZU7DoAB3yHjlfymblLQXgK46SzHgP3Q==",
       "dependencies": {
-        "@temporalio/proto": "1.9.3",
+        "@temporalio/proto": "1.10.1",
         "long": "^5.2.3",
         "ms": "^3.0.0-canary.1",
         "proto3-json-serializer": "^2.0.0"
       }
     },
     "node_modules/@temporalio/core-bridge": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/@temporalio/core-bridge/-/core-bridge-1.9.3.tgz",
-      "integrity": "sha512-0cYVDzypc+ilpWeBsYkHP8wv/SbtcLZA4z4ZZd2c6OWKEM3+p4UuW8AiXZf/avL+rpo7cjrSRl+PTWe52vPReg==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@temporalio/core-bridge/-/core-bridge-1.10.1.tgz",
+      "integrity": "sha512-HnyZ+6fcy0B5PjbzNaw+7ei51z86dQXYJMXx/B4p07Bmid1lSTqKzfd0WddjM+4u4kxiCBGXZ4A0OcfMRnjLRA==",
       "hasInstallScript": true,
       "dependencies": {
-        "@temporalio/common": "1.9.3",
+        "@temporalio/common": "1.10.1",
         "arg": "^5.0.2",
         "cargo-cp-artifact": "^0.1.8",
         "which": "^4.0.0"
@@ -15329,38 +15345,39 @@
       }
     },
     "node_modules/@temporalio/proto": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/@temporalio/proto/-/proto-1.9.3.tgz",
-      "integrity": "sha512-YOeelTGdz8zLX8LUlXlERvd/VTaCPmV9xN/JEUQoxsyc7YpOB2wVwdrXS7Al/2b1jOTYRm00vbn3rljRV9W5dA==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@temporalio/proto/-/proto-1.10.1.tgz",
+      "integrity": "sha512-kKe/B6yZU1iMmTQP161GLGHmWIhwhyn79rOFaurZ87kXswLmmss1TGO37H0GVqR1k4K8S8fewLPbayiYf+oksw==",
       "dependencies": {
         "long": "^5.2.3",
         "protobufjs": "^7.2.5"
       }
     },
     "node_modules/@temporalio/worker": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/@temporalio/worker/-/worker-1.9.3.tgz",
-      "integrity": "sha512-RFotNUeWNnLDk4EvnPVZBiYAZWc+daezr/Prn/iMsCI6e3CxbchDha6GiqIVkIF3ppq1R2Vl+FpouNA/gBniGg==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@temporalio/worker/-/worker-1.10.1.tgz",
+      "integrity": "sha512-bGgA7ahVPc9OskeezYpkixQV4pCriEVm++M2wVxOz8wOygWokfqjpduE0sXmtKt7YNGM4oFTgs3ObQ3H9s7Ryg==",
       "dependencies": {
         "@swc/core": "^1.3.102",
-        "@temporalio/activity": "1.9.3",
-        "@temporalio/client": "1.9.3",
-        "@temporalio/common": "1.9.3",
-        "@temporalio/core-bridge": "1.9.3",
-        "@temporalio/proto": "1.9.3",
-        "@temporalio/workflow": "1.9.3",
+        "@temporalio/activity": "1.10.1",
+        "@temporalio/client": "1.10.1",
+        "@temporalio/common": "1.10.1",
+        "@temporalio/core-bridge": "1.10.1",
+        "@temporalio/proto": "1.10.1",
+        "@temporalio/workflow": "1.10.1",
         "abort-controller": "^3.0.0",
         "heap-js": "^2.3.0",
         "memfs": "^4.6.0",
         "rxjs": "^7.8.1",
         "source-map": "^0.7.4",
         "source-map-loader": "^4.0.2",
+        "supports-color": "^8.1.1",
         "swc-loader": "^0.2.3",
         "unionfs": "^4.5.1",
         "webpack": "^5.89.0"
       },
       "engines": {
-        "node": ">= 14.18.0"
+        "node": ">= 16.0.0"
       }
     },
     "node_modules/@temporalio/worker/node_modules/source-map": {
@@ -15370,13 +15387,27 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@temporalio/workflow": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/@temporalio/workflow/-/workflow-1.9.3.tgz",
-      "integrity": "sha512-JU3SKZf+Cdm9ebNIbhLB3DM3NmGyusOCCZ1eSOWCHPAJo+fW9Zi6B2ba+Td7XRu6EGWJwvBwh6fnqzVCxtBPMA==",
+    "node_modules/@temporalio/worker/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "dependencies": {
-        "@temporalio/common": "1.9.3",
-        "@temporalio/proto": "1.9.3"
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/@temporalio/workflow": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@temporalio/workflow/-/workflow-1.10.1.tgz",
+      "integrity": "sha512-EaZEXxSjqcDI1PLo1RKU5eMAXzal98/bWw1pC71fN55AhW1YsxiS8upJQESp20Y+kkMmxJfBrpvinbFtMDgBvg==",
+      "dependencies": {
+        "@temporalio/common": "1.10.1",
+        "@temporalio/proto": "1.10.1"
       }
     },
     "node_modules/@textea/json-viewer": {
@@ -17426,10 +17457,11 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "license": "MIT",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -20825,8 +20857,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "license": "MIT",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -23389,7 +23422,8 @@
     },
     "node_modules/is-number": {
       "version": "7.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "engines": {
         "node": ">=0.12.0"
       }
@@ -24573,7 +24607,8 @@
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -32477,7 +32512,8 @@
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dependencies": {
         "is-number": "^7.0.0"
       },


### PR DESCRIPTION
## Description

We have 1 `high` vuln

```
# npm audit report

@grpc/grpc-js  <1.8.22
Severity: moderate
@grpc/grpc-js can allocate memory for incoming messages well above configured limits - https://github.com/advisories/GHSA-7v5v-9h63-cj86
fix available via `npm audit fix`
node_modules/@grpc/grpc-js
  @temporalio/client  1.6.0 - 1.9.3
  Depends on vulnerable versions of @grpc/grpc-js
  node_modules/@temporalio/client
    @temporalio/worker  1.6.0 - 1.9.3
    Depends on vulnerable versions of @temporalio/client
    node_modules/@temporalio/worker

braces  <3.0.3
Severity: high
Uncontrolled resource consumption in braces - https://github.com/advisories/GHSA-grv7-fg5c-xmjg
fix available via `npm audit fix`
../types/node_modules/braces
node_modules/braces

4 vulnerabilities (3 moderate, 1 high)

To address all issues, run:
  npm audit fix
```

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
