### PR TITLE
Meta-prompts: clean-up and introduction of metaPromptForProvider

### DIFF
--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -862,8 +862,8 @@ export function retrievalMetaPrompt() {
 
 export function retrievalMetaPromptMutiActions() {
   return (
-    "Be factual and accurate. When documents are retrieved with a 2-letter REFERENCE, " +
-    "use the markdown directive :cite[REFERENCE] to cite them " +
+    "To cite documents retrieved with a 2-letter REFERENCE, " +
+    "use the markdown directive :cite[REFERENCE] " +
     "(eg :cite[XX] or :cite[XX,XX] but not :cite[XX][XX]). " +
     "Ensure citations are placed as close as possible to the related information."
   );

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -862,10 +862,10 @@ export function retrievalMetaPrompt() {
 
 export function retrievalMetaPromptMutiActions() {
   return (
-    "Focus on being factual and accurate. When data is retrieved from sources, " +
-    "use the markdown directive :cite[REFERENCE] to cite documents (eg :cite[XX] or :cite[XX,XX] but not :cite[XX][XX]). " +
-    "Ensure citations are placed as close as possible to the related information. " +
-    "If data retrieval isn't applicable, maintain clarity and precision in your statements."
+    "Be factual and accurate. When documents are retrieved with a 2-letter REFERENCE, " +
+    "use the markdown directive :cite[REFERENCE] to cite them " +
+    "(eg :cite[XX] or :cite[XX,XX] but not :cite[XX][XX]). " +
+    "Ensure citations are placed as close as possible to the related information."
   );
 }
 

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -392,13 +392,11 @@ export async function constructPromptMultiActions(
   const owner = auth.workspace();
 
   let context = "CONTEXT:\n";
-  context += `{\n`;
-  context += `  "assistant": "@${configuration.name}",\n`;
-  context += `  "local_time": "${d.format("YYYY-MM-DD HH:mm (ddd)")}",\n`;
+  context += `  assistant: @${configuration.name}\n`;
+  context += `  local_time: ${d.format("YYYY-MM-DD HH:mm (ddd)")}\n`;
   if (owner) {
-    context += `  "workspace": "${owner.name}",\n`;
+    context += `  workspace: ${owner.name}\n`;
   }
-  context += "}\n";
 
   let instructions = "";
   if (configuration.instructions) {
@@ -412,6 +410,9 @@ export async function constructPromptMultiActions(
     isRetrievalConfiguration(action)
   );
   if (hasRetrievalAction) {
+    if (instructions.length > 0) {
+      instructions += `\n\nADDITIONAL INSTRUCTIONS:`;
+    }
     instructions += `\n${retrievalMetaPromptMutiActions()}`;
   }
 

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -388,8 +388,9 @@ export function metaPromptForProvider(
 ): string | null {
   switch (providerId) {
     case "openai":
-      return "When generating tool calls, generate valid and properly escaped JSON.";
+      return "When using tools, generate valid and properly escaped JSON arguments.";
     case "anthropic":
+      // see https://docs.anthropic.com/en/docs/tool-use#tool-use-best-practices-and-limitations
       return (
         "Do not reflect on the quality of the returned search results in your response. " +
         "Be concise in your thinking phases."

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -392,10 +392,10 @@ export async function constructPromptMultiActions(
   const owner = auth.workspace();
 
   let context = "CONTEXT:\n";
-  context += `  assistant: @${configuration.name}\n`;
-  context += `  local_time: ${d.format("YYYY-MM-DD HH:mm (ddd)")}\n`;
+  context += `assistant: @${configuration.name}\n`;
+  context += `local_time: ${d.format("YYYY-MM-DD HH:mm (ddd)")}\n`;
   if (owner) {
-    context += `  workspace: ${owner.name}\n`;
+    context += `workspace: ${owner.name}\n`;
   }
 
   let instructions = "";

--- a/types/src/front/lib/actions/registry.ts
+++ b/types/src/front/lib/actions/registry.ts
@@ -237,7 +237,7 @@ export const DustProdActionRegistry = createActionRegistry({
       workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
       appId: "0e9889c787",
       appHash:
-        "c80417243b780b7076a4269d3dcda67eb5775cedf19147020825f804156e9d0f",
+        "6ed039ad024172896958070f0487002fb53f9391df4f9d87806d3bc1ebebec6f",
     },
     config: {
       MODEL: {


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/dust/issues/5548

- Remove JSON meta prompt from multi-actions dust app
- Clean-up retrieval meta prompt in the context of mutli-actions
- Introduce `metaPromptForProvider`

Note: it seems to fix sonnet at least when there is no retrieval involved

## Risk

None, we're still testing.

## Deploy Plan

- deploy `front`