### PR TITLE
feat: display model thoughts

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -477,7 +477,7 @@ export function AgentMessage({
 
     // TODO(2024-05-27 flav) Use <ConversationMessage.citations />.
 
-    const chainOfThought = agentMessage.chainOfThoughts.join();
+    const chainOfThought = agentMessage.chainOfThoughts.join("");
     return (
       <div className="flex flex-col gap-y-4">
         <AgentMessageActions

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -487,19 +487,13 @@ export function AgentMessage({
         />
 
         {chainOfThought.length ? (
-          <div className="relative flex w-full flex-col gap-2 rounded-2xl border border-slate-200 bg-slate-100 p-4">
+          <div className="flex w-full flex-col gap-2 rounded-2xl border border-slate-200 bg-slate-100 p-4 text-sm text-slate-800">
             <div className="flex flex-row gap-2">
-              <Icon
-                size="sm"
-                visual={PuzzleIcon}
-                className="shrink-0 text-slate-800"
-              />
-              <div className="text-sm font-semibold text-slate-800">
-                Model thoughts
-              </div>
+              <Icon size="sm" visual={PuzzleIcon} />
+              <div className="font-semibold">Model thoughts</div>
             </div>
 
-            <div className={"relative text-sm italic text-slate-950"}>
+            <div className={"italic"}>
               <RenderMessageMarkdown
                 content={chainOfThought}
                 isStreaming={false}

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -490,7 +490,7 @@ export function AgentMessage({
           <div className="flex w-full flex-col gap-2 rounded-2xl border border-slate-200 bg-slate-100 p-4 text-sm text-slate-800">
             <div className="flex flex-row gap-2">
               <Icon size="sm" visual={PuzzleIcon} />
-              <div className="font-semibold">Model thoughts</div>
+              <div className="font-semibold">Assistant thoughts</div>
             </div>
 
             <div className={"italic"}>

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -1164,22 +1164,21 @@ class TokenEmitter {
     if (!this.buffer.length) {
       return;
     }
-
-    const text =
-      upTo === undefined ? this.buffer : this.buffer.substring(0, upTo);
-
-    yield {
-      type: "generation_tokens",
-      created: Date.now(),
-      configurationId: this.agentConfiguration.sId,
-      messageId: this.agentMessage.sId,
-      text,
-      classification: this.chainOfToughtDelimitersOpened
-        ? "chain_of_thought"
-        : "tokens",
-    };
-
     if (!this.swallowDelimitersOpened) {
+      const text =
+        upTo === undefined ? this.buffer : this.buffer.substring(0, upTo);
+
+      yield {
+        type: "generation_tokens",
+        created: Date.now(),
+        configurationId: this.agentConfiguration.sId,
+        messageId: this.agentMessage.sId,
+        text,
+        classification: this.chainOfToughtDelimitersOpened
+          ? "chain_of_thought"
+          : "tokens",
+      };
+
       if (this.chainOfToughtDelimitersOpened) {
         this.chainOfThought += text;
       } else {

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -241,6 +241,7 @@ export async function* runMultiActionsAgentLoop(
           } satisfies AgentGenerationSuccessEvent;
 
           agentMessage.content = event.text;
+          agentMessage.chainOfThoughts.push(event.chainOfThought);
           agentMessage.status = "succeeded";
           yield {
             type: "agent_message_success",

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -231,6 +231,7 @@ export async function* runMultiActionsAgentLoop(
               message: agentMessage,
               chainOfThought: event.chainOfThought,
             };
+            agentMessage.chainOfThoughts.push(event.chainOfThought);
           }
           yield {
             type: "agent_generation_success",
@@ -241,7 +242,6 @@ export async function* runMultiActionsAgentLoop(
           } satisfies AgentGenerationSuccessEvent;
 
           agentMessage.content = event.text;
-          agentMessage.chainOfThoughts.push(event.chainOfThought);
           agentMessage.status = "succeeded";
           yield {
             type: "agent_message_success",
@@ -253,6 +253,7 @@ export async function* runMultiActionsAgentLoop(
           return;
 
         case "agent_chain_of_thought":
+          agentMessage.chainOfThoughts.push(event.chainOfThought);
           yield event;
           break;
 
@@ -640,8 +641,8 @@ export async function* runMultiActionsAgent(
             created: Date.now(),
             configurationId: agentConfiguration.sId,
             messageId: agentMessage.sId,
-            text: tokenEmitter.getContent(),
-            chainOfThought: tokenEmitter.getChainOfThought(),
+            text: tokenEmitter.getContent() ?? "",
+            chainOfThought: tokenEmitter.getChainOfThought() ?? "",
           } satisfies GenerationSuccessEvent;
 
           return;
@@ -747,7 +748,7 @@ export async function* runMultiActionsAgent(
   const chainOfThought = tokenEmitter.getChainOfThought();
   const content = tokenEmitter.getContent();
 
-  if (chainOfThought.length || content.length) {
+  if (chainOfThought?.length || content?.length) {
     yield {
       type: "agent_chain_of_thought",
       created: Date.now(),
@@ -1238,11 +1239,11 @@ class TokenEmitter {
     yield* this.flushTokens();
   }
 
-  getContent(): string {
-    return this.content;
+  getContent(): string | null {
+    return this.content.length ? this.content : null;
   }
 
-  getChainOfThought(): string {
-    return this.chainOfThought;
+  getChainOfThought(): string | null {
+    return this.chainOfThought.length ? this.chainOfThought : null;
   }
 }

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -1084,7 +1084,7 @@ async function* runAction(
   }
 }
 
-class TokenEmitter {
+export class TokenEmitter {
   private buffer: string = "";
   private content: string = "";
   private chainOfThought: string = "";

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -783,10 +783,11 @@ export async function* postUserMessage(
                   status: "created",
                   actions: [],
                   content: null,
+                  chainOfThoughts: [],
                   error: null,
                   configuration,
                   rank: messageRow.rank,
-                },
+                } satisfies AgentMessageWithRankType,
               };
             })();
           })
@@ -1258,6 +1259,7 @@ export async function* editUserMessage(
                 status: "created",
                 actions: [],
                 content: null,
+                chainOfThoughts: [],
                 error: null,
                 configuration,
                 rank: messageRow.rank,
@@ -1479,6 +1481,7 @@ export async function* retryAgentMessage(
         status: "created",
         actions: [],
         content: null,
+        chainOfThoughts: [],
         error: null,
         configuration: message.configuration,
         rank: m.rank,

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -28,7 +28,6 @@ import {
   isUserMessageType,
   Ok,
   removeNulls,
-  SUPPORTED_MODEL_CONFIGS,
 } from "@dust-tt/types";
 import moment from "moment-timezone";
 
@@ -510,11 +509,7 @@ export async function* runGeneration(
     throw new Error("Unexpected unauthenticated call to `runGeneration`");
   }
 
-  const model = SUPPORTED_MODEL_CONFIGS.find(
-    (m) =>
-      m.modelId === configuration.model.modelId &&
-      m.providerId === configuration.model.providerId
-  );
+  const model = getSupportedModelConfig(configuration.model);
 
   if (!model) {
     yield {
@@ -544,7 +539,7 @@ export async function* runGeneration(
     return;
   }
 
-  const contextSize = getSupportedModelConfig(configuration.model).contextSize;
+  const contextSize = model.contextSize;
 
   const MIN_GENERATION_TOKENS = 2048;
 

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -1,5 +1,7 @@
 import type {
+  AgentChainOfThoughtEvent,
   AgentConfigurationType,
+  AgentErrorEvent,
   AgentMessageType,
   ContentFragmentMessageTypeModel,
   ConversationType,
@@ -26,6 +28,7 @@ import {
   isUserMessageType,
   Ok,
   removeNulls,
+  SUPPORTED_MODEL_CONFIGS,
 } from "@dust-tt/types";
 import moment from "moment-timezone";
 
@@ -34,6 +37,7 @@ import {
   retrievalMetaPrompt,
   retrievalMetaPromptMutiActions,
 } from "@app/lib/api/assistant/actions/retrieval";
+import { TokenEmitter } from "@app/lib/api/assistant/agent";
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
 import { getSupportedModelConfig, isLargeModel } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
@@ -120,7 +124,7 @@ export async function renderConversationForModelMultiActions({
         }
       }
 
-      if (m.content) {
+      if (m.content?.trim()) {
         messages.push({
           role: "assistant" as const,
           name: m.configuration.name,
@@ -493,10 +497,12 @@ export async function* runGeneration(
   userMessage: UserMessageType,
   agentMessage: AgentMessageType
 ): AsyncGenerator<
+  | AgentErrorEvent
   | GenerationErrorEvent
   | GenerationTokensEvent
   | GenerationSuccessEvent
-  | GenerationCancelEvent,
+  | GenerationCancelEvent
+  | AgentChainOfThoughtEvent,
   void
 > {
   const owner = auth.workspace();
@@ -504,9 +510,27 @@ export async function* runGeneration(
     throw new Error("Unexpected unauthenticated call to `runGeneration`");
   }
 
-  const { model } = configuration;
+  const model = SUPPORTED_MODEL_CONFIGS.find(
+    (m) =>
+      m.modelId === configuration.model.modelId &&
+      m.providerId === configuration.model.providerId
+  );
 
-  if (isLargeModel(model) && !auth.isUpgraded()) {
+  if (!model) {
+    yield {
+      type: "agent_error",
+      created: Date.now(),
+      configurationId: configuration.sId,
+      messageId: agentMessage.sId,
+      error: {
+        code: "model_not_found",
+        message: "The model selected was not found.",
+      },
+    };
+    return;
+  }
+
+  if (isLargeModel(configuration.model) && !auth.isUpgraded()) {
     yield {
       type: "generation_error",
       created: Date.now(),
@@ -520,13 +544,13 @@ export async function* runGeneration(
     return;
   }
 
-  const contextSize = getSupportedModelConfig(model).contextSize;
+  const contextSize = getSupportedModelConfig(configuration.model).contextSize;
 
   const MIN_GENERATION_TOKENS = 2048;
 
   if (contextSize < MIN_GENERATION_TOKENS) {
     throw new Error(
-      `Model contextSize unexpectedly small for model: ${model.providerId} ${model.modelId}`
+      `Model contextSize unexpectedly small for model: ${configuration.model.providerId} ${configuration.model.modelId}`
     );
   }
 
@@ -535,7 +559,7 @@ export async function* runGeneration(
   // Turn the conversation into a digest that can be presented to the model.
   const modelConversationRes = await renderConversationForModelMultiActions({
     conversation,
-    model,
+    model: configuration.model,
     prompt,
     allowedTokenCount: contextSize - MIN_GENERATION_TOKENS,
   });
@@ -548,7 +572,7 @@ export async function* runGeneration(
       messageId: agentMessage.sId,
       error: {
         code: "internal_server_error",
-        message: `Failed tokenization for ${model.providerId} ${model.modelId}: ${modelConversationRes.error.message}`,
+        message: `Failed tokenization for ${configuration.model.providerId} ${configuration.model.modelId}: ${modelConversationRes.error.message}`,
       },
     };
     return;
@@ -557,17 +581,17 @@ export async function* runGeneration(
   const config = cloneBaseConfig(
     DustProdActionRegistry["assistant-v2-generator"].config
   );
-  config.MODEL.provider_id = model.providerId;
-  config.MODEL.model_id = model.modelId;
-  config.MODEL.temperature = model.temperature;
+  config.MODEL.provider_id = configuration.model.providerId;
+  config.MODEL.model_id = configuration.model.modelId;
+  config.MODEL.temperature = configuration.model.temperature;
 
   logger.info(
     {
       workspaceId: conversation.owner.sId,
       conversationId: conversation.sId,
-      providerId: model.providerId,
-      modelId: model.modelId,
-      temperature: model.temperature,
+      providerId: configuration.model.providerId,
+      modelId: configuration.model.modelId,
+      temperature: configuration.model.temperature,
     },
     "[ASSISTANT_TRACE] Generation exection"
   );
@@ -608,6 +632,11 @@ export async function* runGeneration(
   let shouldYieldCancel = false;
   let lastCheckCancellation = Date.now();
   const redis = await redisClient();
+  const tokenEmitter = new TokenEmitter(
+    configuration,
+    agentMessage,
+    model.delimitersConfiguration
+  );
 
   try {
     const _checkCancellation = async () => {
@@ -633,6 +662,7 @@ export async function* runGeneration(
 
     for await (const event of eventStream) {
       if (event.type === "error") {
+        yield* tokenEmitter.flushTokens();
         yield {
           type: "generation_error",
           created: Date.now(),
@@ -656,6 +686,7 @@ export async function* runGeneration(
       }
 
       if (shouldYieldCancel) {
+        yield* tokenEmitter.flushTokens();
         yield {
           type: "generation_cancel",
           created: Date.now(),
@@ -666,19 +697,13 @@ export async function* runGeneration(
       }
 
       if (event.type === "tokens") {
-        yield {
-          type: "generation_tokens",
-          created: Date.now(),
-          configurationId: configuration.sId,
-          messageId: agentMessage.sId,
-          text: event.content.tokens.text,
-          classification: "tokens",
-        };
+        yield* tokenEmitter.emitTokens(event);
       }
 
       if (event.type === "block_execution") {
         const e = event.content.execution[0][0];
         if (e.error) {
+          yield* tokenEmitter.flushTokens();
           yield {
             type: "generation_error",
             created: Date.now(),
@@ -693,22 +718,20 @@ export async function* runGeneration(
         }
 
         if (event.content.block_name === "MODEL" && e.value) {
-          const m = e.value as {
-            message: {
-              content: string;
-            };
-          };
+          yield* tokenEmitter.flushTokens();
           yield {
             type: "generation_success",
             created: Date.now(),
             configurationId: configuration.sId,
             messageId: agentMessage.sId,
-            text: m.message.content,
-            chainOfThought: "",
+            text: tokenEmitter.getContent() ?? "",
+            chainOfThought: tokenEmitter.getChainOfThought() ?? "",
           };
         }
       }
     }
+
+    yield* tokenEmitter.flushTokens();
   } finally {
     await redis.quit();
   }

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -219,6 +219,7 @@ export async function batchRenderAgentMessages(
       status: agentMessage.status,
       actions: actions,
       content: agentMessage.content,
+      chainOfThoughts: agentMessage.chainOfThoughts,
       error,
       // TODO(2024-03-21 flav) Dry the agent configuration object for rendering.
       configuration: agentConfiguration,

--- a/types/src/front/assistant/conversation.ts
+++ b/types/src/front/assistant/conversation.ts
@@ -114,6 +114,7 @@ export type AgentMessageType = {
   status: AgentMessageStatus;
   actions: AgentActionType[];
   content: string | null;
+  chainOfThoughts: string[];
   error: {
     code: string;
     message: string;

--- a/types/src/front/lib/assistant.ts
+++ b/types/src/front/lib/assistant.ts
@@ -94,6 +94,7 @@ export type ModelConfigurationType = {
       openingPattern: string;
       closingPattern: string;
       isChainOfThought: boolean;
+      swallow: boolean;
     }>;
     // If this pattern is found at the end of a model event, we'll wait for the
     // the next event before emitting tokens.
@@ -162,21 +163,25 @@ export const CLAUDE_3_OPUS_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
         openingPattern: "<thinking>",
         closingPattern: "</thinking>",
         isChainOfThought: true,
+        swallow: false,
       },
       {
         openingPattern: "<search_quality_reflection>",
         closingPattern: "</search_quality_reflection>",
         isChainOfThought: true,
+        swallow: false,
       },
       {
         openingPattern: "<search_quality_score>",
         closingPattern: "</search_quality_score>",
         isChainOfThought: true,
+        swallow: true,
       },
       {
         openingPattern: "<result>",
         closingPattern: "</result>",
         isChainOfThought: false,
+        swallow: false,
       },
     ],
   },

--- a/types/src/front/lib/assistant.ts
+++ b/types/src/front/lib/assistant.ts
@@ -156,7 +156,7 @@ export const CLAUDE_3_OPUS_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   supportsMultiActions: true,
   isLegacy: false,
   delimitersConfiguration: {
-    incompleteDelimiterRegex: /<\/?[a-zA-Z]*$/,
+    incompleteDelimiterRegex: /<\/?[a-zA-Z_]*$/,
     delimiters: [
       {
         openingPattern: "<thinking>",
@@ -166,6 +166,11 @@ export const CLAUDE_3_OPUS_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
       {
         openingPattern: "<search_quality_reflection>",
         closingPattern: "</search_quality_reflection>",
+        isChainOfThought: true,
+      },
+      {
+        openingPattern: "<search_quality_score>",
+        closingPattern: "</search_quality_score>",
         isChainOfThought: true,
       },
       {


### PR DESCRIPTION
## Description


Fixes https://github.com/dust-tt/dust/issues/5159

<img width="653" alt="Screenshot 2024-06-12 at 10 00 01" src="https://github.com/dust-tt/dust/assets/14199823/fcf7bfe5-44cb-4706-8f3a-aae9d36bcabb">

Now that we stream and store Chain Of Thoughts, this PR also renders it in the UI, using a distinct "Model thoughts" block in which the chain of thoughts accumulate.
I also added a `swallow` boolean to model delimiter configuration entries that control whether the content in between that type of delimiters should be "swallowed". That allows to hide the "search_quality_score" from Anthropic which is not useful and not straightforward to "productize".

## Risk

Critical path

## Deploy Plan

N/A