### PR TITLE
Templates add action

### DIFF
--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -184,7 +184,6 @@ export default function ActionsScreen({
     <>
       <NewActionModal
         isOpen={pendingAction.action !== null}
-        setOpen={() => {}} // Unused
         builderState={builderState}
         initialAction={pendingAction.action}
         onSave={(newAction) => {
@@ -312,7 +311,6 @@ export default function ActionsScreen({
 
 function NewActionModal({
   isOpen,
-  setOpen,
   initialAction,
   onSave,
   onClose,
@@ -323,7 +321,6 @@ function NewActionModal({
   builderState,
 }: {
   isOpen: boolean;
-  setOpen: (isOpen: boolean) => void;
   builderState: AssistantBuilderState;
   initialAction: AssistantBuilderActionConfiguration | null;
   onSave: (newAction: AssistantBuilderActionConfiguration) => void;
@@ -358,7 +355,6 @@ function NewActionModal({
 
   const onCloseLocal = () => {
     onClose();
-    setOpen(false);
     setTimeout(() => {
       setNewAction(null);
     }, 500);

--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -192,6 +192,16 @@ export default function ActionsScreen({
           if (!pendingAction.action) {
             return;
           }
+
+          // Making sure the name is not used already.
+          let index = 1;
+          const suffixedName = () =>
+            index > 1 ? `${newAction.name}_${index}` : newAction.name;
+          while (builderState.actions.some((a) => a.name === suffixedName())) {
+            index += 1;
+          }
+          newAction.name = suffixedName();
+
           if (pendingAction.previousActionName) {
             updateAction({
               actionName: pendingAction.previousActionName,
@@ -234,7 +244,6 @@ export default function ActionsScreen({
               <div>
                 <AddAction
                   owner={owner}
-                  builderState={builderState}
                   onAddAction={(action) => {
                     setPendingAction({
                       action,
@@ -267,7 +276,6 @@ export default function ActionsScreen({
             >
               <AddAction
                 owner={owner}
-                builderState={builderState}
                 onAddAction={(action) => {
                   setPendingAction({
                     action,
@@ -773,24 +781,11 @@ function AdvancedSettings({
 
 function AddAction({
   owner,
-  builderState,
   onAddAction,
 }: {
   owner: WorkspaceType;
-  builderState: AssistantBuilderState;
   onAddAction: (action: AssistantBuilderActionConfiguration) => void;
 }) {
-  const onAddLocal = (action: AssistantBuilderActionConfiguration) => {
-    let index = 1;
-    const suffixedName = () =>
-      index > 1 ? `${action.name}_${index}` : action.name;
-    while (builderState.actions.some((a) => a.name === suffixedName())) {
-      index += 1;
-    }
-    action.name = suffixedName();
-    onAddAction(action);
-  };
-
   const filteredCapabilities = CAPABILITIES_ACTION_CATEGORIES.filter((key) => {
     const flag = ACTION_SPECIFICATIONS[key].flag;
     return !flag || owner.flags.includes(flag);
@@ -816,7 +811,7 @@ function AddAction({
               label={spec.label}
               icon={spec.dropDownIcon}
               description={spec.description}
-              onClick={() => onAddLocal(defaultAction)}
+              onClick={() => onAddAction(defaultAction)}
             />
           );
         })}
@@ -836,7 +831,7 @@ function AddAction({
               label={spec.label}
               icon={spec.dropDownIcon}
               description={spec.description}
-              onClick={() => onAddLocal(defaultAction)}
+              onClick={() => onAddAction(defaultAction)}
             />
           );
         })}
@@ -855,7 +850,7 @@ function AddAction({
               label={spec.label}
               icon={spec.dropDownIcon}
               description={spec.description}
-              onClick={() => onAddLocal(defaultAction)}
+              onClick={() => onAddAction(defaultAction)}
             />
           );
         })}

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -47,6 +47,7 @@ import {
 } from "@app/components/assistant_builder/shared";
 import { submitAssistantBuilderForm } from "@app/components/assistant_builder/submitAssistantBuilderForm";
 import type {
+  AssistantBuilderPendingAction,
   AssistantBuilderProps,
   AssistantBuilderState,
   BuilderScreen,
@@ -130,6 +131,11 @@ export default function AssistantBuilder({
           },
         }
   );
+
+  const [pendingAction, setPendingAction] =
+    useState<AssistantBuilderPendingAction>({
+      action: null,
+    });
 
   const {
     template,
@@ -410,6 +416,8 @@ export default function AssistantBuilder({
                           dustApps={dustApps}
                           setBuilderState={setBuilderState}
                           setEdited={setEdited}
+                          pendingAction={pendingAction}
+                          setPendingAction={setPendingAction}
                         />
                       );
                     }
@@ -489,6 +497,7 @@ export default function AssistantBuilder({
               openRightPanelTab={openRightPanelTab}
               builderState={builderState}
               multiActionsMode={multiActionsEnabled}
+              setPendingAction={setPendingAction}
             />
           }
           isRightPanelOpen={rightPanelStatus.tab !== null}

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -115,10 +115,21 @@ export type AssistantBuilderActionConfiguration = (
 export type TemplateActionType = Omit<
   AssistantBuilderActionConfiguration,
   "configuration"
->;
+> & {
+  help: string;
+};
 
 export type AssistantBuilderActionType =
   AssistantBuilderActionConfiguration["type"];
+
+export type AssistantBuilderPendingAction =
+  | {
+      action: AssistantBuilderActionConfiguration;
+      previousActionName: string | null;
+    }
+  | {
+      action: null;
+    };
 
 export type AssistantBuilderState = {
   handle: string | null;


### PR DESCRIPTION
## Description

This PR does two things: 
- Adds a `help` string to the type that we put in the `presetActions` of a template, and display it on the template modal.
- Adds the possibility to add an action from the template. 

To do so, I did something a bit cracra but I would argue it was already kind of cracra, and now at least it's a bit more simple. 😬 

I replaced the 3 states present in `ActionsScreen`: 
```js
const [newActionModalOpen, setNewActionModalOpen] = React.useState(false);
const [actionToEdit, setActionToEdit] = React.useState<AssistantBuilderActionConfiguration | null>(null);
const [pendingAction, setPendingAction] = React.useState<AssistantBuilderActionConfiguration | null>(null);
```

By a single one moved to `AssistantBuilder`, the move being required to be able to add an action from the template modal: 
```js
const [pendingAction, setPendingAction] = useState<AssistantBuilderPendingAction>({ action: null });
```

-> The cracra thing is that this type `AssistantBuilderPendingAction` is hybrid, it contains a key action with the action or null, and if the pending action is an edition of an existing action it contains a `previousActionName` key to allow me keeping the current logic `addAction/edtiAction` that was build on `ActionsScreen`.

```js
// When pending action is new: 
{
    action: newAction,
}

// When pending action is an edition:
{
    action: newAction,
    previousActionName: "soupinou"
}
```

<kbd>
<img width="1198" alt="Screenshot 2024-06-11 at 22 06 39" src="https://github.com/dust-tt/dust/assets/3803406/d6cc2511-3fef-48ee-9489-4881fc214222">
</kbd>

## Risk

Breaks add action for multi-actions. 
Can be rolled back. 

## Deploy Plan

Deploy front. 
