### PR TITLE
Lower Temporal history limit for Confluence workflows

### DIFF
--- a/connectors/src/connectors/confluence/temporal/workflows.ts
+++ b/connectors/src/connectors/confluence/temporal/workflows.ts
@@ -43,7 +43,7 @@ const {
 // Set a conservative threshold to start a new workflow and
 // avoid exceeding Temporal's max workflow size limit,
 // since a Confluence page can have an unbounded number of pages.
-const TEMPORAL_WORKFLOW_MAX_HISTORY_LENGTH = 30_000;
+const TEMPORAL_WORKFLOW_MAX_HISTORY_LENGTH = 10_000;
 
 export async function confluenceSyncWorkflow({
   connectorId,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR fixes https://github.com/dust-tt/tasks/issues/864#issuecomment-2162278890.

The first implementation set a maximum Temporal history limit to 30k, but we have [evidence](https://cloud.temporal.io/namespaces/dust-prod.gmnlm/workflows/confluence-sync-1469-space-74842138-top-level-page-229769219/effed55e-5d8c-454a-ab62-2f13f887bea3/history) that it fails around 20k. This PR sets a more conservative limit. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
