### PR TITLE
fix: make slackbot work with Anthropic CoT

### DIFF
--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -522,6 +522,9 @@ async function botAnswerMessage(
         );
       }
       case "generation_tokens": {
+        if (event.classification !== "tokens") {
+          continue;
+        }
         fullAnswer += event.text;
         if (lastSentDate.getTime() + 1500 > new Date().getTime()) {
           continue;


### PR DESCRIPTION
## Description

There is no value in streaming delimiters / CoT in slack. This PR skips those tokens in the slack bot.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
