### PR TITLE
Sanitize JSON outputs before saving to Postgres

### DIFF
--- a/front/lib/api/assistant/actions/dust_app_run.ts
+++ b/front/lib/api/assistant/actions/dust_app_run.ts
@@ -24,6 +24,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { prodAPICredentialsForOwner } from "@app/lib/auth";
 import { extractConfig } from "@app/lib/config";
 import { AgentDustAppRunAction } from "@app/lib/models/assistant/actions/dust_app_run";
+import { sanitizeJSONOutput } from "@app/lib/utils";
 import logger from "@app/logger/logger";
 
 interface DustAppRunActionBlob {
@@ -390,9 +391,11 @@ export class DustAppRunConfigurationServerRunner extends BaseActionConfiguration
       }
     }
 
+    const output = sanitizeJSONOutput(lastBlockOutput);
+
     // Update DustAppRunAction with the output of the last block.
     await action.update({
-      output: lastBlockOutput,
+      output,
     });
 
     logger.info(
@@ -418,7 +421,7 @@ export class DustAppRunConfigurationServerRunner extends BaseActionConfiguration
         functionCallId,
         functionCallName: actionConfiguration.name,
         runningBlock: null,
-        output: lastBlockOutput,
+        output,
         agentMessageId: agentMessage.agentMessageId,
         step: action.step,
       }),

--- a/front/lib/api/assistant/actions/tables_query.ts
+++ b/front/lib/api/assistant/actions/tables_query.ts
@@ -25,6 +25,7 @@ import { BaseActionConfigurationServerRunner } from "@app/lib/api/assistant/acti
 import type { Authenticator } from "@app/lib/auth";
 import { AgentTablesQueryAction } from "@app/lib/models/assistant/actions/tables_query";
 import logger from "@app/logger/logger";
+import { sanitizeJSONOutput } from "@app/lib/utils";
 
 interface TablesQueryActionBlob {
   id: ModelId; // AgentTablesQueryAction.
@@ -401,9 +402,11 @@ export class TablesQueryConfigurationServerRunner extends BaseActionConfiguratio
       }
     }
 
+    const sanitizedOutput = sanitizeJSONOutput(output);
+
     // Updating action
     await action.update({
-      output,
+      output: sanitizedOutput,
     });
 
     yield {
@@ -414,7 +417,7 @@ export class TablesQueryConfigurationServerRunner extends BaseActionConfiguratio
       action: new TablesQueryAction({
         id: action.id,
         params: action.params as DustAppParameters,
-        output: action.output as Record<string, string | number | boolean>,
+        output: sanitizedOutput as Record<string, string | number | boolean>,
         functionCallId: action.functionCallId,
         functionCallName: action.functionCallName,
         agentMessageId: action.agentMessageId,

--- a/front/lib/api/assistant/actions/tables_query.ts
+++ b/front/lib/api/assistant/actions/tables_query.ts
@@ -24,8 +24,8 @@ import type { BaseActionRunParams } from "@app/lib/api/assistant/actions/types";
 import { BaseActionConfigurationServerRunner } from "@app/lib/api/assistant/actions/types";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentTablesQueryAction } from "@app/lib/models/assistant/actions/tables_query";
-import logger from "@app/logger/logger";
 import { sanitizeJSONOutput } from "@app/lib/utils";
+import logger from "@app/logger/logger";
 
 interface TablesQueryActionBlob {
   id: ModelId; // AgentTablesQueryAction.

--- a/front/lib/utils.ts
+++ b/front/lib/utils.ts
@@ -246,3 +246,21 @@ export function trimText(text: string, maxLength = 20, removeNewLines = true) {
   const t = removeNewLines ? text.replaceAll("\n", " ") : text;
   return t.length > maxLength ? t.substring(0, maxLength) + "..." : t;
 }
+
+export function sanitizeJSONOutput(obj: unknown): unknown {
+  if (typeof obj === "string") {
+    // eslint-disable-next-line no-control-regex
+    return obj.replace(/\x00/g, "");
+  } else if (Array.isArray(obj)) {
+    return obj.map((item) => sanitizeJSONOutput(item));
+  } else if (typeof obj === "object" && obj !== null) {
+    const sanitizedObj: Record<string, unknown> = {};
+    for (const key of Object.keys(obj)) {
+      sanitizedObj[key] = sanitizeJSONOutput(
+        (obj as Record<string, unknown>)[key] as unknown
+      );
+    }
+    return sanitizedObj;
+  }
+  return obj;
+}


### PR DESCRIPTION
## Description

Context: https://dust4ai.slack.com/archives/C05F84CFP0E/p1718179517667589

Postgres refuse \x00. This PR sanitizes outputs of dust apps and table queries, strippint out null unicodes.

## Risk

Low

## Deploy Plan

- deploy `front`