### PR TITLE
Made scrolling smooth for user

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -58,7 +58,7 @@ interface AgentMessageProps {
   isInModal?: boolean;
   hideReactions?: boolean;
   size: MessageSizeType;
-  isAtBottomRef: React.MutableRefObject<boolean>;
+  isAtBottomRef?: React.MutableRefObject<boolean>;
 }
 
 /**

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -58,6 +58,7 @@ interface AgentMessageProps {
   isInModal?: boolean;
   hideReactions?: boolean;
   size: MessageSizeType;
+  isAtBottomRef: React.MutableRefObject<boolean>;
 }
 
 /**
@@ -75,6 +76,7 @@ export function AgentMessage({
   isInModal,
   hideReactions,
   size,
+  isAtBottomRef,
 }: AgentMessageProps) {
   const [streamedAgentMessage, setStreamedAgentMessage] =
     useState<AgentMessageType>(message);
@@ -242,28 +244,16 @@ export function AgentMessage({
   // prevents user from scrolling up when the message continues generating
   // (forces it back down), but it cannot be zero otherwise the scroll does not
   // happen.
-  const isAtBottom = useRef(true);
   const bottomRef = useRef<HTMLDivElement>(null);
-  useEffect(() => {
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        isAtBottom.current = entry.isIntersecting;
-      },
-      { threshold: 1 }
-    );
 
-    const currentBottomRef = bottomRef.current;
-
-    if (currentBottomRef) {
-      observer.observe(currentBottomRef);
+  function scrollToBottom(element: HTMLElement | null) {
+    if (element && element.scrollHeight) {
+        element.scrollTo({
+            top: element.scrollHeight,
+            behavior: 'smooth'
+        });
     }
-
-    return () => {
-      if (currentBottomRef) {
-        observer.unobserve(currentBottomRef);
-      }
-    };
-  }, []);
+  }
 
   useEffect(() => {
     const mainTag = document.getElementById(
@@ -272,9 +262,9 @@ export function AgentMessage({
     if (
       mainTag &&
       streamedAgentMessage.status === "created" &&
-      isAtBottom.current
+      isAtBottomRef.current
     ) {
-      bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+      scrollToBottom(mainTag);
     }
   }, [
     agentMessageToRender.content,

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -146,6 +146,36 @@ export default function ConversationViewer({
     }
   }, [isInModal, latestPage]);
 
+  const isAtBottomRef = useRef(true);
+  useEffect(() => {
+    const scrollElementId = CONVERSATION_PARENT_SCROLL_DIV_ID[isInModal ? "modal" : "page"];
+    const scrollElement = document.getElementById(scrollElementId);
+
+    if (!scrollElement) {
+      return;
+    }
+
+    const onScrollCallback = (event: Event) => {
+      const hasReachedBottom = scrollElement.scrollHeight - scrollElement.clientHeight <= scrollElement.scrollTop;
+      if (hasReachedBottom) {
+        isAtBottomRef.current = true;
+        return;
+      }
+      
+      if (isAtBottomRef.current) {
+        isAtBottomRef.current = false;
+      }
+    }
+
+    scrollElement.addEventListener('scroll', onScrollCallback);
+
+    return () => {
+      scrollElement.removeEventListener('scroll', onScrollCallback);
+    }   
+  }, [
+    isInModal
+  ]);
+
   // Compute the latest mentions ordered by the most recents first.
   const latestMentions = useMemo(() => {
     const recentMentions = latestPage?.messages.reduce((acc, message) => {
@@ -397,6 +427,7 @@ export default function ConversationViewer({
               user={user}
               isLastMessage={latestPage?.messages.at(-1)?.sId === message.sId}
               latestMentions={latestMentions}
+              isAtBottomRef={isAtBottomRef}
             />
           );
         });

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -19,6 +19,7 @@ interface MessageItemProps {
   owner: WorkspaceType;
   reactions: ConversationMessageReactions;
   user: UserType;
+  isAtBottomRef?: React.MutableRefObject<boolean>;
 }
 
 const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
@@ -33,6 +34,7 @@ const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
       owner,
       reactions,
       user,
+      isAtBottomRef,
     }: MessageItemProps,
     ref
   ) {
@@ -76,6 +78,7 @@ const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
               isInModal={isInModal}
               hideReactions={hideReactions}
               size={isInModal ? "compact" : "normal"}
+              isAtBottomRef={isAtBottomRef}
             />
           </div>
         );


### PR DESCRIPTION
## Description
The goal of this PR is to improve the feel of autoscrolling in conversation.
The new behaviour activates auto scroll only if the user scrolls to the very bottom of the conversation. If the user scrolls a tiny bit on the top during message generation, the auto-scroll is paused until the user scrolls back to the bottom

## Risk

The risk is UX based. The auto-scrolling could somehow be broken if for some reason the auto-scrolling does not properly go to the bottom.
