### PR TITLE
[Login] Fix: 'Revoked' auth flow handles user has no memberships

### DIFF
--- a/front/lib/iam/errors.ts
+++ b/front/lib/iam/errors.ts
@@ -5,19 +5,13 @@ export class SSOEnforcedError extends Error {
 }
 
 export class AuthFlowError extends Error {
-  constructor(message: string) {
-    super(message);
-  }
-}
-
-export class UnverifiedEmailError extends Error {
-  constructor(message: string) {
-    super(message);
-  }
-}
-
-export class WorkspaceIdentificationError extends Error {
-  constructor(message: string) {
+  constructor(
+    message: string,
+    readonly type:
+      | "unverified_email"
+      | "workspace_not_found"
+      | "invite_access_error"
+  ) {
     super(message);
   }
 }

--- a/front/lib/iam/errors.ts
+++ b/front/lib/iam/errors.ts
@@ -9,3 +9,15 @@ export class AuthFlowError extends Error {
     super(message);
   }
 }
+
+export class UnverifiedEmailError extends Error {
+  constructor(message: string) {
+    super(message);
+  }
+}
+
+export class WorkspaceIdentificationError extends Error {
+  constructor(message: string) {
+    super(message);
+  }
+}

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -10,7 +10,12 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { deleteUser } from "@app/lib/api/user";
 import { evaluateWorkspaceSeatAvailability } from "@app/lib/api/workspace";
 import { getSession, subscriptionForWorkspace } from "@app/lib/auth";
-import { AuthFlowError, SSOEnforcedError } from "@app/lib/iam/errors";
+import {
+  AuthFlowError,
+  SSOEnforcedError,
+  UnverifiedEmailError,
+  WorkspaceIdentificationError,
+} from "@app/lib/iam/errors";
 import {
   getPendingMembershipInvitationForToken,
   markInvitationAsConsumed,
@@ -185,7 +190,7 @@ async function handleRegularSignupFlow(
       flow: "no-auto-join" | "revoked" | null;
       workspace: Workspace | null;
     },
-    SSOEnforcedError
+    SSOEnforcedError | UnverifiedEmailError | WorkspaceIdentificationError
   >
 > {
   const activeMemberships = await MembershipResource.getActiveMemberships({
@@ -268,6 +273,36 @@ async function handleRegularSignupFlow(
 
     return new Ok({ flow: null, workspace });
   } else {
+    const memberships = await MembershipResource.getLatestMemberships({
+      users: [user],
+    });
+
+    if (!memberships.length) {
+      if (!session.user.email_verified) {
+        return new Err(new UnverifiedEmailError("unverified email"));
+      }
+
+      if (!existingWorkspace) {
+        return new Err(
+          new WorkspaceIdentificationError(
+            "Workspace not found for user email " + session.user.email
+          )
+        );
+      }
+
+      if (existingWorkspace.sId !== targetWorkspaceId) {
+        return new Err(
+          new WorkspaceIdentificationError(
+            "Existing workspace sId does not match target workspace id " +
+              targetWorkspaceId
+          )
+        );
+      }
+
+      throw new Error(
+        "Unreachable: one of conditions above should have been met."
+      );
+    }
     // Redirect the user to their existing workspace if they are not allowed to join the target workspace.
     return new Ok({ flow: null, workspace: null });
   }
@@ -352,6 +387,26 @@ async function handler(
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
+            message: error.message,
+          },
+        });
+      }
+
+      if (error instanceof UnverifiedEmailError) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "unverified_email",
+            message: error.message,
+          },
+        });
+      }
+
+      if (error instanceof WorkspaceIdentificationError) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "workspace_not_found",
             message: error.message,
           },
         });

--- a/types/src/front/lib/error.ts
+++ b/types/src/front/lib/error.ts
@@ -69,6 +69,7 @@ export type APIErrorType =
   | "template_not_found"
   // Invitations:
   | "invitation_already_sent_recently"
+  | "invite_access_error"
   // DustAppSecrets:
   | "dust_app_secret_not_found"
   // Key:

--- a/types/src/front/lib/error.ts
+++ b/types/src/front/lib/error.ts
@@ -12,6 +12,7 @@ export type APIErrorType =
   | "internal_server_error"
   | "invalid_request_error"
   | "user_not_found"
+  | "unverified_email"
   | "data_source_error"
   | "data_source_not_found"
   | "data_source_auth_error"


### PR DESCRIPTION
Description
---
Cause: we got monitors with panic flag "unreachable: user has no memberships.", see [here](https://app.datadoghq.eu/logs?query=%22unreachable%3A%20user%20has%20no%20memberships.%22%20&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1716888517241&to_ts=1718184517241&live=true)

If a user tries to join a pro plan workspace via the regular flow (not invite) with a given target workspace id, doesn't have any existing membership and:
- has a non-verified email OR
- there's no workspace with verified domain matching their email OR
- a domain exist but it does not match the specified wId

the user is redirected to the /no-workspace page and the above panic flag is triggered and user-facing.

This PR avoids the situation by displaying the appropriate error to the user upfront.

Risk & Deploy
---
N/A
