### PR TITLE
Poké template form for multi-actions

### DIFF
--- a/front/pages/api/poke/templates/[tId].ts
+++ b/front/pages/api/poke/templates/[tId].ts
@@ -129,6 +129,7 @@ async function handler(
         helpActions: body.helpActions ?? null,
         helpInstructions: body.helpInstructions ?? null,
         presetAction: body.presetAction,
+        presetActions: body.presetActions,
         timeFrameDuration: body.timeFrameDuration
           ? parseInt(body.timeFrameDuration)
           : null,

--- a/front/pages/api/poke/templates/index.ts
+++ b/front/pages/api/poke/templates/index.ts
@@ -98,7 +98,7 @@ async function handler(
         helpActions: body.helpActions ?? null,
         helpInstructions: body.helpInstructions ?? null,
         presetAction: body.presetAction,
-        presetActions: [], // @todo[daph] implement multi-actions templates in poké
+        presetActions: body.presetActions,
         presetDescription: null,
         presetInstructions: body.presetInstructions ?? null,
         presetModelId: model.modelId,

--- a/types/src/front/assistant/templates.ts
+++ b/types/src/front/assistant/templates.ts
@@ -17,6 +17,8 @@ import { WebsearchConfigurationType } from "./actions/websearch";
 import { AgentAction, AgentActionConfigurationType } from "./agent";
 import { AssistantCreativityLevelCodec } from "./builder";
 
+// TAGS
+
 export const TEMPLATES_TAG_CODES = [
   "CONTENT",
   "DATA",
@@ -99,6 +101,12 @@ export function isTemplateTagCodeArray(
   );
 }
 
+const TemplateTagCodeTypeCodec = t.keyof({
+  ...TEMPLATES_TAGS_CONFIG,
+});
+
+// SINGLE ACTION MODE
+
 export const ACTION_PRESETS: Record<AgentAction | "reply", string> = {
   reply: "Reply only",
   dust_app_run_configuration: "Run Dust app",
@@ -113,6 +121,37 @@ export const ActionPresetCodec = ioTsEnum<ActionPreset>(
   Object.keys(ACTION_PRESETS),
   "ActionPreset"
 );
+
+// MULTI ACTION MODE
+
+type MultiActionType =
+  | "RETRIEVAL_SEARCH"
+  | "DUST_APP_RUN"
+  | "TABLES_QUERY"
+  | "PROCESS"
+  | "WEBSEARCH";
+export const MULTI_ACTION_PRESETS: Record<MultiActionType, string> = {
+  DUST_APP_RUN: "Run Dust app",
+  RETRIEVAL_SEARCH: "Search data sources",
+  TABLES_QUERY: "Query tables",
+  PROCESS: "Extract data",
+  WEBSEARCH: "Web search",
+} as const;
+export type MultiActionPreset = keyof typeof MULTI_ACTION_PRESETS;
+export const MultiActionPresetCodec = ioTsEnum<MultiActionPreset>(
+  Object.keys(MULTI_ACTION_PRESETS),
+  "MultiActionPreset"
+);
+const TemplateActionTypePreset = t.type({
+  type: MultiActionPresetCodec,
+  name: NonEmptyString,
+  description: NonEmptyString,
+  help: NonEmptyString,
+});
+const TemplateActionsPreset = t.array(TemplateActionTypePreset);
+
+// VISIBILITY
+
 export const TEMPLATE_VISIBILITIES = [
   "draft",
   "published",
@@ -124,9 +163,7 @@ export const TemplateVisibilityCodec = ioTsEnum<TemplateVisibility>(
   "TemplateVisibility"
 );
 
-const TemplateTagCodeTypeCodec = t.keyof({
-  ...TEMPLATES_TAGS_CONFIG,
-});
+// FORM SCHEMA
 
 export const CreateTemplateFormSchema = t.type({
   backgroundColor: NonEmptyString,
@@ -138,6 +175,7 @@ export const CreateTemplateFormSchema = t.type({
   helpActions: t.union([t.string, t.undefined]),
   helpInstructions: t.union([t.string, t.undefined]),
   presetAction: ActionPresetCodec,
+  presetActions: TemplateActionsPreset,
   presetInstructions: t.union([t.string, t.undefined]),
   presetModelId: t.string,
   presetTemperature: AssistantCreativityLevelCodec,


### PR DESCRIPTION
## Description

I fought with our form lib and typescript for this one. 
We both win cause I managed to make it work with the lib, and we both lose because I added a bunch of `@ts-expect-error`.

<kbd>
<img width="1405" alt="Screenshot 2024-06-12 at 14 45 58" src="https://github.com/dust-tt/dust/assets/3803406/5a382b6c-40cd-4f6b-aeec-2b4d9e9ceef8">
</kbd>


## Risk

Break poké templates. 
Can be rolled back. 

## Deploy Plan

Deploy front. 
