### PR TITLE
[Confluence] Fix 404 when listing space pages

### DIFF
--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -388,8 +388,18 @@ export async function confluenceGetRootPageIdsActivity({
 
   localLogger.info("Fetching Confluence root page in space.");
 
-  const { pages: rootPages } = await client.getPagesInSpace(spaceId, "root");
-  return rootPages.map((rp) => rp.id);
+  try {
+    const { pages: rootPages } = await client.getPagesInSpace(spaceId, "root");
+    return rootPages.map((rp) => rp.id);
+  } catch (err) {
+    if (err instanceof ConfluenceClientError && err.status === 404) {
+      localLogger.info(
+        "Confluence space pages API returned 404. Returning empty page set"
+      );
+      return [];
+    }
+    throw err;
+  }
 }
 
 export async function confluenceGetTopLevelPageIdsActivity({


### PR DESCRIPTION
Description
---
Fixes not found errors when asking for the pages of a space.

Currently, just returning an empty page set since the cause of 404 is not available (if the cause is a space that became unreachable, it will be deleted later).

Risk
---
na

Deploy
---
na
