### PR TITLE
[Prod Checks] Fix: Avoid wrong reports of missing notion workflows

### DIFF
--- a/front/lib/utils/retries.ts
+++ b/front/lib/utils/retries.ts
@@ -1,0 +1,38 @@
+import logger from "@app/logger/logger";
+
+type RetryOptions = {
+  retries?: number;
+  delayBetweenRetriesMs?: number;
+};
+
+export function withRetries<T, U>(
+  fn: (arg: T) => Promise<U>,
+  { retries = 10, delayBetweenRetriesMs = 1000 }: RetryOptions = {}
+): (arg: T & RetryOptions) => Promise<U> {
+  if (retries < 1) {
+    throw new Error("retries must be >= 1");
+  }
+  return async (arg) => {
+    const errors = [];
+    for (let i = 0; i < retries; i++) {
+      try {
+        return await fn(arg);
+      } catch (e) {
+        const sleepTime = delayBetweenRetriesMs * (i + 1) ** 2;
+        logger.warn(
+          {
+            error: e,
+            attempt: i + 1,
+            retries: retries,
+            sleepTime: sleepTime,
+          },
+          "Error while executing retriable function. Retrying..."
+        );
+        await new Promise((resolve) => setTimeout(resolve, sleepTime));
+        errors.push(e);
+      }
+    }
+
+    throw new Error(errors.join("\n"));
+  };
+}


### PR DESCRIPTION
Description
---
Production check that notion workflows are active sometimes wrongly reports missing workflows.

Cause is that fetching workflow statuses occasionaly transiently fail, with error `Received RST_STREAM with code 0 (Call ended without gRPC status)`

Example [log](https://app.datadoghq.eu/logs?query=%22Production%20check%20failed%22%20&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AgAAAZANN1jC0D6SMAAAAAAAAAAYAAAAAEFaQU5OMlJYQUFBNmNJbTBURFI0ZlFBdgAAACQAAAAAMDE5MDBkMzgtMmY3Zi00MDNjLTkxNzItYzUwODY4N2I1MTIz&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1718195089102&to_ts=1718209489102&live=true)

This PR fixes by retrying 3* before failing.

Risk & deploy
---
na
