### PR TITLE
[front] - feat(global_agents): streamline global agent model configuration retrieval

### DIFF
--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -11,7 +11,10 @@ import type {
   DataSourceType,
   GlobalAgentStatus,
 } from "@dust-tt/types";
-import { getSmallWhitelistedModel } from "@dust-tt/types";
+import {
+  getLargeWhitelistedModel,
+  getSmallWhitelistedModel,
+} from "@dust-tt/types";
 import {
   CLAUDE_2_DEFAULT_MODEL_CONFIG,
   CLAUDE_3_HAIKU_DEFAULT_MODEL_CONFIG,
@@ -89,7 +92,9 @@ async function _getHelperGlobalAgent(
   if (!owner) {
     throw new Error("Unexpected `auth` without `workspace`.");
   }
-  const modelConfiguration = getSmallWhitelistedModel(owner);
+  const modelConfiguration = auth.isUpgraded()
+    ? getLargeWhitelistedModel(owner)
+    : getSmallWhitelistedModel(owner);
   if (!modelConfiguration) {
     throw new Error("No whitelisted models were found for the workspace.");
   }
@@ -531,7 +536,9 @@ async function _getManagedDataSourceAgent(
 
   const prodCredentials = await prodAPICredentialsForOwner(owner);
 
-  const modelConfiguration = getSmallWhitelistedModel(owner);
+  const modelConfiguration = auth.isUpgraded()
+    ? getLargeWhitelistedModel(owner)
+    : getSmallWhitelistedModel(owner);
   if (!modelConfiguration) {
     throw new Error("No whitelisted models were found for the workspace.");
   }
@@ -764,7 +771,9 @@ async function _getDustGlobalAgent(
   const description = "An assistant with context on your company data.";
   const pictureUrl = "https://dust.tt/static/systemavatar/dust_avatar_full.png";
 
-  const modelConfiguration = getSmallWhitelistedModel(owner);
+  const modelConfiguration = auth.isUpgraded()
+    ? getLargeWhitelistedModel(owner)
+    : getSmallWhitelistedModel(owner);
   if (!modelConfiguration) {
     throw new Error("No whitelisted models were found for the workspace.");
   }

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -9,8 +9,9 @@ import type {
   AgentModelConfigurationType,
   ConnectorProvider,
   DataSourceType,
+  GlobalAgentStatus,
 } from "@dust-tt/types";
-import type { GlobalAgentStatus } from "@dust-tt/types";
+import { getSmallWhitelistedModel } from "@dust-tt/types";
 import {
   CLAUDE_2_DEFAULT_MODEL_CONFIG,
   CLAUDE_3_HAIKU_DEFAULT_MODEL_CONFIG,
@@ -88,15 +89,15 @@ async function _getHelperGlobalAgent(
   if (!owner) {
     throw new Error("Unexpected `auth` without `workspace`.");
   }
-  const model = !auth.isUpgraded()
-    ? {
-        providerId: GPT_3_5_TURBO_MODEL_CONFIG.providerId,
-        modelId: GPT_3_5_TURBO_MODEL_CONFIG.modelId,
-      }
-    : {
-        providerId: GPT_4_TURBO_MODEL_CONFIG.providerId,
-        modelId: GPT_4_TURBO_MODEL_CONFIG.modelId,
-      };
+  const modelConfiguration = getSmallWhitelistedModel(owner);
+  if (!modelConfiguration) {
+    throw new Error("No whitelisted models were found for the workspace.");
+  }
+  const model: AgentModelConfigurationType = {
+    providerId: modelConfiguration.providerId,
+    modelId: modelConfiguration.modelId,
+    temperature: 0.2,
+  };
   return {
     id: -1,
     sId: GLOBAL_AGENTS_SID.HELPER,
@@ -113,7 +114,7 @@ async function _getHelperGlobalAgent(
     model: {
       providerId: model.providerId,
       modelId: model.modelId,
-      temperature: 0.2,
+      temperature: model.temperature,
     },
     actions: [],
     maxToolsUsePerRun: 0,
@@ -530,17 +531,15 @@ async function _getManagedDataSourceAgent(
 
   const prodCredentials = await prodAPICredentialsForOwner(owner);
 
-  const model: AgentModelConfigurationType = !auth.isUpgraded()
-    ? {
-        providerId: GPT_3_5_TURBO_MODEL_CONFIG.providerId,
-        modelId: GPT_3_5_TURBO_MODEL_CONFIG.modelId,
-        temperature: 0.7,
-      }
-    : {
-        providerId: GPT_4_TURBO_MODEL_CONFIG.providerId,
-        modelId: GPT_4_TURBO_MODEL_CONFIG.modelId,
-        temperature: 0.7,
-      };
+  const modelConfiguration = getSmallWhitelistedModel(owner);
+  if (!modelConfiguration) {
+    throw new Error("No whitelisted models were found for the workspace.");
+  }
+  const model: AgentModelConfigurationType = {
+    providerId: modelConfiguration.providerId,
+    modelId: modelConfiguration.modelId,
+    temperature: 0.7,
+  };
 
   // Check if deactivated by an admin
   if (settings && settings.status === "disabled_by_admin") {
@@ -765,17 +764,15 @@ async function _getDustGlobalAgent(
   const description = "An assistant with context on your company data.";
   const pictureUrl = "https://dust.tt/static/systemavatar/dust_avatar_full.png";
 
-  const model: AgentModelConfigurationType = !auth.isUpgraded()
-    ? {
-        providerId: GPT_3_5_TURBO_MODEL_CONFIG.providerId,
-        modelId: GPT_3_5_TURBO_MODEL_CONFIG.modelId,
-        temperature: 0.7,
-      }
-    : {
-        providerId: GPT_4_TURBO_MODEL_CONFIG.providerId,
-        modelId: GPT_4_TURBO_MODEL_CONFIG.modelId,
-        temperature: 0.7,
-      };
+  const modelConfiguration = getSmallWhitelistedModel(owner);
+  if (!modelConfiguration) {
+    throw new Error("No whitelisted models were found for the workspace.");
+  }
+  const model: AgentModelConfigurationType = {
+    providerId: modelConfiguration.providerId,
+    modelId: modelConfiguration.modelId,
+    temperature: 0.7,
+  };
 
   if (settings && settings.status === "disabled_by_admin") {
     return {

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -116,11 +116,7 @@ async function _getHelperGlobalAgent(
     status: "active",
     userListStatus: "in-list",
     scope: "global",
-    model: {
-      providerId: model.providerId,
-      modelId: model.modelId,
-      temperature: model.temperature,
-    },
+    model: model,
     actions: [],
     maxToolsUsePerRun: 0,
     templateId: null,

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -14,7 +14,7 @@ import type {
 import {
   getLargeWhitelistedModel,
   getSmallWhitelistedModel,
-  isProviderWhitelisted
+  isProviderWhitelisted,
 } from "@dust-tt/types";
 import {
   CLAUDE_2_DEFAULT_MODEL_CONFIG,


### PR DESCRIPTION
## Description

Replace direct model configuration with a call to `getSmallWhitelistedModel` to determine the appropriate model based on the owner's workspace

## Risk

Altering global agents performance depending on the provider used

## Deploy Plan

Deploy `front`