### PR TITLE
front: make title generation work for all models

### DIFF
--- a/types/src/front/lib/actions/registry.ts
+++ b/types/src/front/lib/actions/registry.ts
@@ -48,7 +48,7 @@ export const DustProdActionRegistry = createActionRegistry({
       workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
       appId: "84dfc1d4f7",
       appHash:
-        "c0f71a1ee28895b3c6adb7d78b40a21bb934faa24ec4035bb86921d35788c5e9",
+        "6ea231add2ae690ee959c5d8d5d06420ea2feae7dd32ac13a4e655910087e313",
     },
     config: {
       MODEL: {


### PR DESCRIPTION
## Description

- update the `assistant-v2-title-generator` to stitch a user message if the last message of the conversation is not `role: user`.
- error early if we overloaded the small model due to a very long user message.

## Risk

N/A

## Deploy Plan

- deploy `front`