### PR TITLE
Flav/cron delete run executions

### DIFF
--- a/core/src/stores/migrations/20240613_runs_created_index.sql
+++ b/core/src/stores/migrations/20240613_runs_created_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS idx_specifications_project_hash ON specifications (project, hash);

--- a/core/src/stores/migrations/20240613_runs_created_index.sql
+++ b/core/src/stores/migrations/20240613_runs_created_index.sql
@@ -1,1 +1,1 @@
-CREATE INDEX IF NOT EXISTS idx_specifications_project_hash ON specifications (project, hash);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_runs_created ON runs (created);

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -448,7 +448,7 @@ pub const POSTGRES_TABLES: [&'static str; 14] = [
     );",
 ];
 
-pub const SQL_INDEXES: [&'static str; 23] = [
+pub const SQL_INDEXES: [&'static str; 24] = [
     "CREATE INDEX IF NOT EXISTS
        idx_specifications_project_created ON specifications (project, created);",
     "CREATE INDEX IF NOT EXISTS
@@ -460,6 +460,8 @@ pub const SQL_INDEXES: [&'static str; 23] = [
        idx_runs_project_run_type_created ON runs (project, run_type, created);",
     "CREATE UNIQUE INDEX IF NOT EXISTS
        idx_runs_id ON runs (run_id);",
+    "CREATE INDEX IF NOT EXISTS
+       idx_runs_created ON runs (created);",
     "CREATE UNIQUE INDEX IF NOT EXISTS
        idx_block_executions_hash ON block_executions (hash);",
     "CREATE UNIQUE INDEX IF NOT EXISTS

--- a/front/lib/production_checks/config.ts
+++ b/front/lib/production_checks/config.ts
@@ -6,7 +6,10 @@ const config = {
       "CONNECTORS_DATABASE_READ_REPLICA_URI"
     );
   },
-  getCoreDatabaseReadReplicaUri: (): string => {
+  getPrimaryCoreDatabaseUri: (): string => {
+    return EnvironmentConfig.getEnvVariable("CORE_DATABASE_URI");
+  },
+  getReadReplicaCoreDatabaseUri: (): string => {
     return EnvironmentConfig.getEnvVariable("CORE_DATABASE_READ_REPLICA_URI");
   },
   getFrontDatabaseReadReplicaUri: (): string => {

--- a/front/lib/production_checks/utils.ts
+++ b/front/lib/production_checks/utils.ts
@@ -23,7 +23,7 @@ export function getConnectorReplicaDbConnection() {
 export function getCoreReplicaDbConnection() {
   if (!coreReplicaDbInstance) {
     coreReplicaDbInstance = new Sequelize(
-      config.getCoreDatabaseReadReplicaUri() as string,
+      config.getReadReplicaCoreDatabaseUri() as string,
       {
         logging: false,
       }

--- a/front/start_worker.ts
+++ b/front/start_worker.ts
@@ -3,6 +3,7 @@ import { setupGlobalErrorHandler } from "@dust-tt/types";
 import logger from "@app/logger/logger";
 import { runPokeWorker } from "@app/poke/temporal/worker";
 import { runPostUpsertHooksWorker } from "@app/temporal/documents_post_process_hooks/worker";
+import { runHardDeleteWorker } from "@app/temporal/hard_delete/worker";
 import { runLabsWorker } from "@app/temporal/labs/worker";
 import { runProductionChecksWorker } from "@app/temporal/production_checks/worker";
 import { runScrubWorkspaceQueueWorker } from "@app/temporal/scrub_workspace/worker";
@@ -36,4 +37,8 @@ runScrubWorkspaceQueueWorker().catch((err) =>
 
 runLabsWorker().catch((err) =>
   logger.error({ error: err }, "Error running labs worker.")
+);
+
+runHardDeleteWorker().catch((err) =>
+  logger.error({ error: err }, "Error running hard delete worker.")
 );

--- a/front/temporal/hard_delete/activities.ts
+++ b/front/temporal/hard_delete/activities.ts
@@ -63,6 +63,10 @@ async function deleteRunExecutionBatch(
   coreSequelize: Sequelize,
   runs: RunExecutionRow[]
 ) {
+  if (runs.length === 0) {
+    return;
+  }
+
   const runIds = runs.map((r) => r.id);
 
   const runsJoins = await coreSequelize.query<RunsJoinsRow>(

--- a/front/temporal/hard_delete/activities.ts
+++ b/front/temporal/hard_delete/activities.ts
@@ -14,7 +14,7 @@ import {
 
 const BATCH_SIZE = 100;
 
-export async function purgeExpiredRunExecutions() {
+export async function purgeExpiredRunExecutionsActivity() {
   const primaryCoreDatabaseUri = config.getPrimaryCoreDatabaseUri();
   const coreSequelize = new Sequelize(primaryCoreDatabaseUri, {
     logging: false,
@@ -47,7 +47,7 @@ export async function purgeExpiredRunExecutions() {
 
     logger.info(
       { batchSize: BATCH_SIZE },
-      "Deleting batch of block exections."
+      "Deleting batch of block executions."
     );
 
     hasMoreRunsToPurge = batchToDelete.length === BATCH_SIZE;

--- a/front/temporal/hard_delete/activities.ts
+++ b/front/temporal/hard_delete/activities.ts
@@ -1,0 +1,114 @@
+import { Context } from "@temporalio/activity";
+import { QueryTypes, Sequelize } from "sequelize";
+
+import config from "@app/lib/production_checks/config";
+import logger from "@app/logger/logger";
+import type {
+  RunExecutionRow,
+  RunsJoinsRow,
+} from "@app/temporal/hard_delete/types";
+import {
+  getRunExecutionsDeletionCutoffDate,
+  isSequelizeForeignKeyConstraintError,
+} from "@app/temporal/hard_delete/utils";
+
+const BATCH_SIZE = 100;
+
+export async function purgeExpiredRunExecutions() {
+  const primaryCoreDatabaseUri = config.getPrimaryCoreDatabaseUri();
+  const coreSequelize = new Sequelize(primaryCoreDatabaseUri, {
+    logging: false,
+  });
+
+  const cutoffDate = getRunExecutionsDeletionCutoffDate();
+
+  logger.info(
+    {},
+    `About to purge block and run executions anterior to ${new Date(
+      cutoffDate
+    ).toISOString()}.`
+  );
+
+  let hasMoreRunsToPurge = true;
+  let runsPurgedCount = 0;
+  do {
+    const batchToDelete = await coreSequelize.query<RunExecutionRow>(
+      "SELECT id FROM runs WHERE created < :cutoffDate ORDER BY created, id ASC LIMIT :batchSize",
+      {
+        replacements: {
+          batchSize: BATCH_SIZE,
+          cutoffDate,
+        },
+        type: QueryTypes.SELECT,
+      }
+    );
+
+    Context.current().heartbeat();
+
+    logger.info(
+      { batchSize: BATCH_SIZE },
+      "Deleting batch of block exections."
+    );
+
+    hasMoreRunsToPurge = batchToDelete.length === BATCH_SIZE;
+    runsPurgedCount += batchToDelete.length;
+
+    await deleteRunExecutionBatch(coreSequelize, batchToDelete);
+  } while (hasMoreRunsToPurge);
+
+  logger.info({ runsPurgedCount }, "Done purging expired runs executions.");
+}
+
+async function deleteRunExecutionBatch(
+  coreSequelize: Sequelize,
+  runs: RunExecutionRow[]
+) {
+  const runIds = runs.map((r) => r.id);
+
+  const runsJoins = await coreSequelize.query<RunsJoinsRow>(
+    "SELECT id, block_execution FROM runs_joins WHERE run IN (:runIds)",
+    {
+      replacements: {
+        runIds,
+      },
+      type: QueryTypes.SELECT,
+    }
+  );
+
+  await coreSequelize.query(
+    "DELETE FROM runs_joins WHERE id IN (:runsJoinsIds)",
+    {
+      replacements: {
+        runsJoinsIds: runsJoins.map((rj) => rj.id),
+      },
+    }
+  );
+
+  // TODO(2024-06-13 flav) Remove once the schedule has completed at least once.
+  // Previously, we had a cache shared between identical block executions.
+  // Ensure we delete distinct run block executions.
+  const blockExecutionIds = [
+    ...new Set(runsJoins.map((rj) => rj.block_execution)),
+  ];
+
+  try {
+    await coreSequelize.query(
+      "DELETE FROM block_executions WHERE id IN (:blockExecutionIds)",
+      {
+        replacements: {
+          blockExecutionIds,
+        },
+      }
+    );
+  } catch (err) {
+    if (isSequelizeForeignKeyConstraintError(err)) {
+      logger.info({}, "Failed to delete runs joins");
+    }
+  }
+
+  await coreSequelize.query("DELETE FROM runs WHERE id IN (:runIds)", {
+    replacements: {
+      runIds,
+    },
+  });
+}

--- a/front/temporal/hard_delete/client.ts
+++ b/front/temporal/hard_delete/client.ts
@@ -13,7 +13,7 @@ import { purgeRunExecutionsCronWorkflow } from "@app/temporal/hard_delete/workfl
 import { QUEUE_NAME } from "./config";
 
 /**
- * This function starts a cron to clean up expired run executions.
+ * This function starts a schedule to purge expired run executions.
  */
 export async function launchPurgeRunExecutionsSchedule(): Promise<
   Result<undefined, Error>

--- a/front/temporal/hard_delete/client.ts
+++ b/front/temporal/hard_delete/client.ts
@@ -1,0 +1,50 @@
+import type { Result } from "@dust-tt/types";
+import { Err, Ok } from "@dust-tt/types";
+import {
+  ScheduleAlreadyRunning,
+  ScheduleOverlapPolicy,
+} from "@temporalio/client";
+
+import { getTemporalClient } from "@app/lib/temporal";
+import logger from "@app/logger/logger";
+import { getPurgeRunExecutionsScheduleId } from "@app/temporal/hard_delete/utils";
+import { purgeRunExecutionsCronWorkflow } from "@app/temporal/hard_delete/workflows";
+
+import { QUEUE_NAME } from "./config";
+
+/**
+ * This function starts a cron to clean up expired run executions.
+ */
+export async function launchPurgeRunExecutionsSchedule(): Promise<
+  Result<undefined, Error>
+> {
+  const client = await getTemporalClient();
+  const scheduleId = getPurgeRunExecutionsScheduleId();
+
+  try {
+    await client.schedule.create({
+      action: {
+        type: "startWorkflow",
+        workflowType: purgeRunExecutionsCronWorkflow,
+        args: [],
+        taskQueue: QUEUE_NAME,
+      },
+      scheduleId,
+      policies: {
+        catchupWindow: "1 day",
+        overlap: ScheduleOverlapPolicy.BUFFER_ONE,
+      },
+      spec: {
+        intervals: [{ every: "24h" }],
+      },
+    });
+  } catch (err) {
+    if (!(err instanceof ScheduleAlreadyRunning)) {
+      logger.error({}, "Failed to start purge run executions.");
+
+      return new Err(err as Error);
+    }
+  }
+
+  return new Ok(undefined);
+}

--- a/front/temporal/hard_delete/client.ts
+++ b/front/temporal/hard_delete/client.ts
@@ -31,8 +31,7 @@ export async function launchPurgeRunExecutionsSchedule(): Promise<
       },
       scheduleId,
       policies: {
-        catchupWindow: "1 day",
-        overlap: ScheduleOverlapPolicy.BUFFER_ONE,
+        overlap: ScheduleOverlapPolicy.SKIP,
       },
       spec: {
         intervals: [{ every: "24h" }],

--- a/front/temporal/hard_delete/config.ts
+++ b/front/temporal/hard_delete/config.ts
@@ -1,0 +1,3 @@
+const QUEUE_VERSION = 1;
+
+export const QUEUE_NAME = `hard-delete-queue-v${QUEUE_VERSION}`;

--- a/front/temporal/hard_delete/types.ts
+++ b/front/temporal/hard_delete/types.ts
@@ -1,0 +1,8 @@
+export interface RunExecutionRow {
+  id: number;
+}
+
+export interface RunsJoinsRow {
+  id: number;
+  block_execution: number;
+}

--- a/front/temporal/hard_delete/utils.ts
+++ b/front/temporal/hard_delete/utils.ts
@@ -1,0 +1,24 @@
+export function isSequelizeForeignKeyConstraintError(err: unknown) {
+  return (
+    err instanceof Error && err.name === "SequelizeForeignKeyConstraintError"
+  );
+}
+
+/**
+ * Purge run executions logic.
+ */
+
+export function getPurgeRunExecutionsScheduleId() {
+  return "purge-run-executions-schedule";
+}
+
+const RUN_EXECUTIONS_RETENTION_DAYS_THRESHOLD = 30;
+
+export function getRunExecutionsDeletionCutoffDate(): number {
+  const cutoffDate = new Date();
+  cutoffDate.setDate(
+    cutoffDate.getDate() - RUN_EXECUTIONS_RETENTION_DAYS_THRESHOLD
+  );
+
+  return cutoffDate.getTime();
+}

--- a/front/temporal/hard_delete/worker.ts
+++ b/front/temporal/hard_delete/worker.ts
@@ -1,0 +1,34 @@
+import type { Context } from "@temporalio/activity";
+import { Worker } from "@temporalio/worker";
+
+import { getTemporalWorkerConnection } from "@app/lib/temporal";
+import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
+import logger from "@app/logger/logger";
+import * as activities from "@app/temporal/hard_delete/activities";
+import { launchPurgeRunExecutionsSchedule } from "@app/temporal/hard_delete/client";
+
+import { QUEUE_NAME } from "./config";
+
+export async function runHardDeleteWorker() {
+  const { connection, namespace } = await getTemporalWorkerConnection();
+  const worker = await Worker.create({
+    workflowsPath: require.resolve("./workflows"),
+    activities,
+    taskQueue: QUEUE_NAME,
+    maxConcurrentActivityTaskExecutions: 32,
+    connection,
+    namespace,
+    interceptors: {
+      activityInbound: [
+        (ctx: Context) => {
+          return new ActivityInboundLogInterceptor(ctx, logger);
+        },
+      ],
+    },
+  });
+
+  // Start the schedule.
+  await launchPurgeRunExecutionsSchedule();
+
+  await worker.run();
+}

--- a/front/temporal/hard_delete/workflows.ts
+++ b/front/temporal/hard_delete/workflows.ts
@@ -2,10 +2,13 @@ import { proxyActivities } from "@temporalio/workflow";
 
 import type * as activities from "@app/temporal/hard_delete/activities";
 
-const { purgeExpiredRunExecutions } = proxyActivities<typeof activities>({
+// TODO(2024-06-13 flav) Lower `startToCloseTimeout` to 10 minutes.
+const { purgeExpiredRunExecutionsActivity } = proxyActivities<
+  typeof activities
+>({
   startToCloseTimeout: "60 minutes",
 });
 
 export async function purgeRunExecutionsCronWorkflow(): Promise<void> {
-  await purgeExpiredRunExecutions();
+  await purgeExpiredRunExecutionsActivity();
 }

--- a/front/temporal/hard_delete/workflows.ts
+++ b/front/temporal/hard_delete/workflows.ts
@@ -1,0 +1,11 @@
+import { proxyActivities } from "@temporalio/workflow";
+
+import type * as activities from "@app/temporal/hard_delete/activities";
+
+const { purgeExpiredRunExecutions } = proxyActivities<typeof activities>({
+  startToCloseTimeout: "60 minutes",
+});
+
+export async function purgeRunExecutionsCronWorkflow(): Promise<void> {
+  await purgeExpiredRunExecutions();
+}


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See https://github.com/dust-tt/tasks/issues/726.

This PR implements a Temporal [schedule](https://docs.temporal.io/workflows#schedule) designed to execute daily, purging old run executions. I went with 'hard-delete' for the queue name, anticipating potential additional processing needs in the future. This operation is not included in production checks, as it involves more than some verifications and is expected to delete thousands of rows daily.

The process initiates at the `runs` level, where we first list all expired runs before proceeding to delete associated resources. This requires the addition of a new index on the `created` field in the `runs` table to facilitate efficient data retrieval.

Currently, the UI for viewing a run execution poorly handles scenarios where runs are not found. I'll rework it in the future.

For the initial execution of this schedule, we anticipate the deletion of approximately 4 million rows from the `runs` table. I will closely monitor this initial operation.

Additionally, due to legacy issues related to cache behavior for identical block executions, advanced error handling is necessary to manage sequelize's constraint errors. This specific error handling will be removed after a successful first run.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
- [ ] Create index on `runs` table.
- [ ] Deploy this schedule.
- [ ] Add alerting.
