### PR TITLE
[Global agents] Clean: remove unused reference to dust-next

### DIFF
--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -40,7 +40,6 @@ export function getSupportedModelConfig(
 export enum GLOBAL_AGENTS_SID {
   HELPER = "helper",
   DUST = "dust",
-  DUST_NEXT = "dust-next",
   SLACK = "slack",
   GOOGLE_DRIVE = "google_drive",
   NOTION = "notion",


### PR DESCRIPTION
Description
---
There's no reference to it anywhere in code and it's not in our global agent settings, see [here](https://metabase.dust.tt/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7ImRhdGFiYXNlIjo0LCJuYXRpdmUiOnsicXVlcnkiOiJzZWxlY3QgKiBmcm9tIGdsb2JhbF9hZ2VudF9zZXR0aW5ncyB3aGVyZSBcImFnZW50SWRcIiA9ICdkdXN0LW5leHQnOyIsInRlbXBsYXRlLXRhZ3MiOnt9fSwidHlwZSI6Im5hdGl2ZSJ9LCJkaXNwbGF5IjoidGFibGUiLCJwYXJhbWV0ZXJzIjpbXSwidmlzdWFsaXphdGlvbl9zZXR0aW5ncyI6e319)

Related to https://github.com/dust-tt/tasks/issues/862

Risk & Deploy
---
na
