### PR TITLE
[Gdrive] Adding support for PPTX files.

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/file.ts
+++ b/connectors/src/connectors/google_drive/temporal/file.ts
@@ -31,6 +31,7 @@ import {
   GoogleDriveConfig,
   GoogleDriveFiles,
 } from "@connectors/lib/models/google_drive";
+import { PPTX2Text } from "@connectors/lib/pptx2text";
 import logger from "@connectors/logger/logger";
 import type { DataSourceConfig } from "@connectors/types/data_source_config";
 import type { GoogleDriveObjectType } from "@connectors/types/google_drive";
@@ -276,6 +277,35 @@ export async function syncOneFile(
             prefix: null,
             content: extracted.trim(),
             sections: [],
+          };
+        } catch (err) {
+          localLogger.warn(
+            {
+              error: err,
+            },
+            `Error while converting docx document to text`
+          );
+          // we don't know what to do with PDF files that fails to be converted to text.
+          // So we log the error and skip the file.
+          return false;
+        }
+      }
+    } else if (
+      file.mimeType ===
+      "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+    ) {
+      if (res.data instanceof ArrayBuffer) {
+        try {
+          const converted = await PPTX2Text(Buffer.from(res.data));
+
+          documentContent = {
+            prefix: null,
+            content: null,
+            sections: converted.pages.map((page, i) => ({
+              prefix: `\n$Page: ${i + 1}/${converted.pages.length}\n`,
+              content: page.content,
+              sections: [],
+            })),
           };
         } catch (err) {
           localLogger.warn(

--- a/connectors/src/connectors/google_drive/temporal/file.ts
+++ b/connectors/src/connectors/google_drive/temporal/file.ts
@@ -285,8 +285,6 @@ export async function syncOneFile(
             },
             `Error while converting docx document to text`
           );
-          // we don't know what to do with PDF files that fails to be converted to text.
-          // So we log the error and skip the file.
           return false;
         }
       }
@@ -312,10 +310,8 @@ export async function syncOneFile(
             {
               error: err,
             },
-            `Error while converting docx document to text`
+            `Error while converting pptx document to text`
           );
-          // we don't know what to do with PDF files that fails to be converted to text.
-          // So we log the error and skip the file.
           return false;
         }
       }

--- a/connectors/src/connectors/google_drive/temporal/mime_types.ts
+++ b/connectors/src/connectors/google_drive/temporal/mime_types.ts
@@ -14,6 +14,7 @@ export function getMimeTypesToDownload({
     "text/plain",
     // docx files hosted on Gdrive
     "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation",
   ];
   if (pdfEnabled) {
     mimeTypes.push("application/pdf");

--- a/connectors/src/lib/pptx2text.ts
+++ b/connectors/src/lib/pptx2text.ts
@@ -1,0 +1,57 @@
+import JSZip from "jszip";
+import turndown from "turndown";
+
+type PPTXDocument = {
+  pages: {
+    content: string;
+  }[];
+};
+
+export async function PPTX2Text(fileBuffer: Buffer): Promise<PPTXDocument> {
+  const zip = new JSZip();
+  await zip.loadAsync(fileBuffer);
+
+  const document: PPTXDocument = {
+    pages: [],
+  };
+
+  let slideIndex = 1;
+  let slideFile: JSZip.JSZipObject | null = null;
+
+  while ((slideFile = zip.file(`ppt/slides/slide${slideIndex}.xml`))) {
+    slideIndex++;
+
+    if (!slideFile) {
+      break;
+    }
+
+    const slideXmlStr = await slideFile.async("text");
+    let text: string | null = null;
+    try {
+      text = new turndown()
+        // Add a space character between each paragraph.
+        .addRule("paragraph_spacing", {
+          filter: (node) => {
+            if (node.nodeName === "A:T") {
+              return true;
+            }
+            return false;
+          },
+          replacement: function (content) {
+            return content + " ";
+          },
+        })
+        .turndown(slideXmlStr);
+    } catch (e) {
+      console.error(`Failed to extract text from slide ${slideIndex}`);
+    }
+
+    if (text) {
+      document.pages.push({
+        content: text,
+      });
+    }
+  }
+
+  return document;
+}


### PR DESCRIPTION
## Description

Adding support for PPTX (Microsoft Power Point) to Google Drive.

PPTX files are zipped files containing XML files, in which you can find a list of slides:

```
ppt/slides/slide${slideIndex}.xml
```

We explore the list of XML files and extract the text content nodes using `turndown`.

The rest follows the PDF and docx pattern, in `google_drive/file.ts`. 

## Example

[This](https://docs.google.com/presentation/d/1jzAEdGPVsJc4cdqstr7uXdRRWoNovSeD/edit?usp=sharing&ouid=100334387398234457137&rtpof=true&sd=true) files convert to [that](https://dust4ai.slack.com/archives/C050SM8NSPK/p1718286519451569?thread_ts=1718286477.449149&cid=C050SM8NSPK).


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
