### PR TITLE
[Confluence] Concurrency of pages parents update down from 100 to 10

### DIFF
--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -496,7 +496,7 @@ export async function confluenceUpdatePagesParentIdsActivity(
         parents: parentIds,
       });
     },
-    { concurrency: 100 }
+    { concurrency: 10 }
   );
 
   logger.info({ connectorId }, "Done updating pages parent ids.");


### PR DESCRIPTION
Description
---
100 may be blasting our db too much, see [here](https://dust4ai.slack.com/archives/C05F84CFP0E/p1718286322671429)
