### PR TITLE
[New conversation] Order assistants alphabetically

### DIFF
--- a/front/components/assistant/AssistantBrowser.tsx
+++ b/front/components/assistant/AssistantBrowser.tsx
@@ -59,13 +59,19 @@ export function AssistantBrowser({
   );
 
   const agentsByTab = useMemo(() => {
-    const filteredAgents: LightAgentConfigurationType[] = agents.filter(
-      (a) =>
-        a.status === "active" &&
-        // Filters on search query
-        (assistantSearch.trim() === "" ||
-          subFilter(assistantSearch.toLowerCase(), a.name.toLowerCase()))
-    );
+    const filteredAgents: LightAgentConfigurationType[] = agents
+      .filter(
+        (a) =>
+          a.status === "active" &&
+          // Filters on search query
+          (assistantSearch.trim() === "" ||
+            subFilter(assistantSearch.toLowerCase(), a.name.toLowerCase()))
+      )
+      .sort((a, b) => {
+        return a.name
+          .toLocaleLowerCase()
+          .localeCompare(b.name.toLocaleLowerCase());
+      });
 
     return {
       // do not show the "all" tab while still loading all agents


### PR DESCRIPTION
Description
---
On front page, before is as below, and after is ordered by name (case-insensitive).
![image](https://github.com/dust-tt/dust/assets/5437393/ecf724d8-7f2f-419b-8942-dcb686720cd3)

Risk & deploy
---
na
