### PR TITLE
Flav/run as resource

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -1,13 +1,6 @@
 import { sendInitDbMessage } from "@dust-tt/types";
 
-import {
-  App,
-  Clone,
-  Dataset,
-  Provider,
-  Run,
-  RunUsage,
-} from "@app/lib/models/apps";
+import { App, Clone, Dataset, Provider } from "@app/lib/models/apps";
 import {
   AgentBrowseAction,
   AgentBrowseConfiguration,
@@ -73,6 +66,10 @@ import {
   LabsTranscriptsHistoryModel,
 } from "@app/lib/resources/storage/models/labs_transcripts";
 import { MembershipModel } from "@app/lib/resources/storage/models/membership";
+import {
+  RunModel,
+  RunUsageModel,
+} from "@app/lib/resources/storage/models/runs";
 import { TemplateModel } from "@app/lib/resources/storage/models/templates";
 import logger from "@app/logger/logger";
 
@@ -94,8 +91,8 @@ async function main() {
   await KeyModel.sync({ alter: true });
   await DustAppSecret.sync({ alter: true });
   await DataSource.sync({ alter: true });
-  await Run.sync({ alter: true });
-  await RunUsage.sync({ alter: true });
+  await RunModel.sync({ alter: true });
+  await RunUsageModel.sync({ alter: true });
   await TrackedDocument.sync({ alter: true });
   await DocumentTrackerChangeSuggestion.sync({ alter: true });
 

--- a/front/lib/models/apps.ts
+++ b/front/lib/models/apps.ts
@@ -4,7 +4,6 @@ import type {
   ForeignKey,
   InferAttributes,
   InferCreationAttributes,
-  NonAttribute,
 } from "sequelize";
 import { DataTypes, Model } from "sequelize";
 
@@ -256,121 +255,5 @@ Clone.belongsTo(App, {
 });
 Clone.belongsTo(App, {
   foreignKey: { name: "toId", allowNull: false },
-  onDelete: "CASCADE",
-});
-
-export class Run extends Model<
-  InferAttributes<Run>,
-  InferCreationAttributes<Run>
-> {
-  declare id: CreationOptional<number>;
-  declare createdAt: CreationOptional<Date>;
-  declare updatedAt: CreationOptional<Date>;
-
-  declare dustRunId: string;
-  declare runType: string;
-
-  declare appId: ForeignKey<App["id"]>;
-  declare workspaceId: ForeignKey<Workspace["id"]>;
-
-  declare app: NonAttribute<App>;
-}
-
-Run.init(
-  {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
-    createdAt: {
-      type: DataTypes.DATE,
-      allowNull: false,
-      defaultValue: DataTypes.NOW,
-    },
-    updatedAt: {
-      type: DataTypes.DATE,
-      allowNull: false,
-      defaultValue: DataTypes.NOW,
-    },
-    dustRunId: {
-      type: DataTypes.STRING,
-      allowNull: false,
-    },
-    runType: {
-      type: DataTypes.STRING,
-      allowNull: false,
-    },
-  },
-  {
-    modelName: "run",
-    sequelize: frontSequelize,
-    indexes: [
-      { fields: ["workspaceId", "appId", "runType", "createdAt"] },
-      { unique: true, fields: ["dustRunId"] },
-    ],
-  }
-);
-App.hasMany(Run, {
-  foreignKey: { allowNull: false },
-  onDelete: "CASCADE",
-});
-Run.belongsTo(App, {
-  as: "app",
-  foreignKey: { name: "appId", allowNull: false },
-});
-Workspace.hasMany(Run, {
-  foreignKey: { allowNull: false },
-  onDelete: "CASCADE",
-});
-
-export class RunUsage extends Model<
-  InferAttributes<RunUsage>,
-  InferCreationAttributes<RunUsage>
-> {
-  declare id: CreationOptional<number>;
-
-  declare runId: ForeignKey<Run["id"]>;
-
-  declare providerId: string; //ModelProviderIdType;
-  declare modelId: string; //ModelIdType;
-
-  declare promptTokens: number;
-  declare completionTokens: number;
-}
-
-RunUsage.init(
-  {
-    id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
-      primaryKey: true,
-    },
-    providerId: {
-      type: DataTypes.STRING,
-      allowNull: false,
-    },
-    modelId: {
-      type: DataTypes.STRING,
-      allowNull: false,
-    },
-    promptTokens: {
-      type: DataTypes.INTEGER,
-      allowNull: false,
-    },
-    completionTokens: {
-      type: DataTypes.INTEGER,
-      allowNull: false,
-    },
-  },
-  {
-    modelName: "run_usages",
-    sequelize: frontSequelize,
-    indexes: [{ fields: ["runId"] }, { fields: ["providerId", "modelId"] }],
-  }
-);
-
-Run.hasMany(RunUsage, {
-  foreignKey: { allowNull: false },
   onDelete: "CASCADE",
 });

--- a/front/lib/resources/run_resource.ts
+++ b/front/lib/resources/run_resource.ts
@@ -72,17 +72,14 @@ export class RunResource extends BaseResource<RunModel> {
 
   static async listByAppAndRunType(
     workspace: LightWorkspaceType,
-    { appId, runType }: { appId: ModelId; runType?: string | string[] },
+    { appId, runType }: { appId: ModelId; runType: string | string[] },
     { limit, offset }: { limit?: number; offset?: number } = {}
   ): Promise<RunResource[]> {
     const where: WhereOptions<RunModel> = {
       appId,
+      runType,
       workspaceId: workspace.id,
     };
-
-    if (runType) {
-      where.runType = runType;
-    }
 
     const runs = await this.model.findAll({
       where: addCreatedAtClause(where),
@@ -94,18 +91,15 @@ export class RunResource extends BaseResource<RunModel> {
     return runs.map((r) => new this(this.model, r.get()));
   }
 
-  static async countAllByWorkspace(
+  static async countByAppAndRunType(
     workspace: LightWorkspaceType,
-    { appId, runType }: { appId: ModelId; runType?: string | string[] }
+    { appId, runType }: { appId: ModelId; runType: string | string[] }
   ) {
     const where: WhereOptions<RunModel> = {
       appId,
+      runType,
       workspaceId: workspace.id,
     };
-
-    if (runType) {
-      where.runType = runType;
-    }
 
     return this.model.count({
       where: addCreatedAtClause(where),

--- a/front/lib/resources/run_resource.ts
+++ b/front/lib/resources/run_resource.ts
@@ -42,15 +42,6 @@ export class RunResource extends BaseResource<RunModel> {
     return new this(RunResource.model, run.get());
   }
 
-  async recordRunUsage(usages: RunUsageType[]) {
-    await RunUsageModel.bulkCreate(
-      usages.map((usage) => ({
-        runId: this.id,
-        ...usage,
-      }))
-    );
-  }
-
   static async listByWorkspace<T extends boolean>(
     workspace: LightWorkspaceType,
     { includeApp }: { includeApp: T }
@@ -143,6 +134,18 @@ export class RunResource extends BaseResource<RunModel> {
     } catch (err) {
       return new Err(err as Error);
     }
+  }
+
+  /**
+   * Run usage.
+   */
+  async recordRunUsage(usages: RunUsageType[]) {
+    await RunUsageModel.bulkCreate(
+      usages.map((usage) => ({
+        runId: this.id,
+        ...usage,
+      }))
+    );
   }
 }
 

--- a/front/lib/resources/run_resource.ts
+++ b/front/lib/resources/run_resource.ts
@@ -1,0 +1,152 @@
+import type {
+  LightWorkspaceType,
+  ModelId,
+  ModelIdType,
+  ModelProviderIdType,
+  Result,
+} from "@dust-tt/types";
+import { Err, Ok } from "@dust-tt/types";
+import type {
+  Attributes,
+  CreationAttributes,
+  ModelStatic,
+  Transaction,
+  WhereOptions,
+} from "sequelize";
+
+import { App } from "@app/lib/models/apps";
+import { BaseResource } from "@app/lib/resources/base_resource";
+import {
+  RunModel,
+  RunUsageModel,
+} from "@app/lib/resources/storage/models/runs";
+import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+
+type RunResourceWithApp = RunResource & { app: App };
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface RunResource extends ReadonlyAttributesType<RunModel> {}
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export class RunResource extends BaseResource<RunModel> {
+  static model: ModelStatic<RunModel> = RunModel;
+
+  constructor(model: ModelStatic<RunModel>, blob: Attributes<RunModel>) {
+    super(RunModel, blob);
+  }
+
+  static async makeNew(blob: CreationAttributes<RunModel>) {
+    const run = await RunResource.model.create(blob);
+
+    return new this(RunResource.model, run.get());
+  }
+
+  async recordRunUsage(usages: RunUsageType[]) {
+    await RunUsageModel.bulkCreate(
+      usages.map((usage) => ({
+        runId: this.id,
+        ...usage,
+      }))
+    );
+  }
+
+  static async listByWorkspace<T extends boolean>(
+    workspace: LightWorkspaceType,
+    { includeApp }: { includeApp: T }
+  ): Promise<T extends true ? RunResourceWithApp[] : RunResource[]> {
+    const include = includeApp
+      ? [
+          {
+            model: App,
+            as: "app",
+            required: true,
+          },
+        ]
+      : [];
+
+    const runs = await this.model.findAll({
+      where: {
+        workspaceId: workspace.id,
+      },
+      include,
+    });
+
+    return runs.map((r) =>
+      includeApp
+        ? (new this(this.model, r.get()) as RunResourceWithApp)
+        : (new this(this.model, r.get()) as RunResource)
+    ) as T extends true ? RunResourceWithApp[] : RunResource[];
+  }
+
+  static async listByAppAndRunType(
+    workspace: LightWorkspaceType,
+    { appId, runType }: { appId: ModelId; runType?: string | string[] },
+    { limit, offset }: { limit?: number; offset?: number } = {}
+  ): Promise<RunResource[]> {
+    const where: WhereOptions<RunModel> = {
+      appId,
+      workspaceId: workspace.id,
+    };
+
+    if (runType) {
+      where.runType = runType;
+    }
+
+    const runs = await this.model.findAll({
+      where,
+      limit,
+      offset,
+      order: [["createdAt", "DESC"]],
+    });
+
+    return runs.map((r) => new this(this.model, r.get()));
+  }
+
+  static async countAllByWorkspace(
+    workspace: LightWorkspaceType,
+    { appId, runType }: { appId: ModelId; runType?: string | string[] }
+  ) {
+    const where: WhereOptions<RunModel> = {
+      appId,
+      workspaceId: workspace.id,
+    };
+
+    if (runType) {
+      where.runType = runType;
+    }
+
+    return this.model.count({
+      where,
+    });
+  }
+
+  static async deleteAllByAppId(appId: ModelId, transaction?: Transaction) {
+    return this.model.destroy({
+      where: {
+        appId,
+      },
+      transaction,
+    });
+  }
+
+  async delete(transaction?: Transaction): Promise<Result<undefined, Error>> {
+    try {
+      await this.model.destroy({
+        where: {
+          id: this.id,
+        },
+        transaction,
+      });
+
+      return new Ok(undefined);
+    } catch (err) {
+      return new Err(err as Error);
+    }
+  }
+}
+
+export interface RunUsageType {
+  providerId: ModelProviderIdType;
+  modelId: ModelIdType;
+  promptTokens: number;
+  completionTokens: number;
+}

--- a/front/lib/resources/run_resource.ts
+++ b/front/lib/resources/run_resource.ts
@@ -107,6 +107,8 @@ export class RunResource extends BaseResource<RunModel> {
   }
 
   static async deleteAllByAppId(appId: ModelId, transaction?: Transaction) {
+    // TODO: First, delete the run_usage before deleting the run.
+
     return this.model.destroy({
       where: {
         appId,
@@ -117,6 +119,15 @@ export class RunResource extends BaseResource<RunModel> {
 
   async delete(transaction?: Transaction): Promise<Result<undefined, Error>> {
     try {
+      // Delete the run usage entry.
+      await RunUsageModel.destroy({
+        where: {
+          runId: this.id,
+        },
+        transaction,
+      });
+
+      // Then, delete the run.
       await this.model.destroy({
         where: {
           id: this.id,

--- a/front/lib/resources/storage/models/runs.ts
+++ b/front/lib/resources/storage/models/runs.ts
@@ -1,0 +1,128 @@
+import type {
+  CreationOptional,
+  ForeignKey,
+  InferAttributes,
+  InferCreationAttributes,
+  NonAttribute,
+} from "sequelize";
+import { DataTypes, Model } from "sequelize";
+
+import { App } from "@app/lib/models/apps";
+import { Workspace } from "@app/lib/models/workspace";
+import { frontSequelize } from "@app/lib/resources/storage";
+
+export class RunModel extends Model<
+  InferAttributes<RunModel>,
+  InferCreationAttributes<RunModel>
+> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare dustRunId: string;
+  declare runType: string;
+
+  declare appId: ForeignKey<App["id"]>;
+  declare workspaceId: ForeignKey<Workspace["id"]>;
+
+  declare app: NonAttribute<App>;
+}
+
+RunModel.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    dustRunId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    runType: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+  },
+  {
+    modelName: "run",
+    sequelize: frontSequelize,
+    indexes: [
+      { fields: ["workspaceId", "appId", "runType", "createdAt"] },
+      { unique: true, fields: ["dustRunId"] },
+    ],
+  }
+);
+App.hasMany(RunModel, {
+  foreignKey: { allowNull: false },
+  onDelete: "CASCADE",
+});
+RunModel.belongsTo(App, {
+  as: "app",
+  foreignKey: { name: "appId", allowNull: false },
+});
+Workspace.hasMany(RunModel, {
+  foreignKey: { allowNull: false },
+  onDelete: "CASCADE",
+});
+
+export class RunUsageModel extends Model<
+  InferAttributes<RunUsageModel>,
+  InferCreationAttributes<RunUsageModel>
+> {
+  declare id: CreationOptional<number>;
+
+  declare runId: ForeignKey<RunModel["id"]>;
+
+  declare providerId: string; //ModelProviderIdType;
+  declare modelId: string; //ModelIdType;
+
+  declare promptTokens: number;
+  declare completionTokens: number;
+}
+
+RunUsageModel.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    providerId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    modelId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    promptTokens: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+    completionTokens: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+  },
+  {
+    modelName: "run_usages",
+    sequelize: frontSequelize,
+    indexes: [{ fields: ["runId"] }, { fields: ["providerId", "modelId"] }],
+  }
+);
+
+RunModel.hasMany(RunUsageModel, {
+  foreignKey: { allowNull: false },
+  onDelete: "CASCADE",
+});

--- a/front/lib/resources/storage/models/runs.ts
+++ b/front/lib/resources/storage/models/runs.ts
@@ -59,6 +59,7 @@ RunModel.init(
     sequelize: frontSequelize,
     indexes: [
       { fields: ["workspaceId", "appId", "runType", "createdAt"] },
+      { fields: ["workspaceId", "createdAt"] },
       { unique: true, fields: ["dustRunId"] },
     ],
   }

--- a/front/migrations/20230413_objects_workspaces.ts
+++ b/front/migrations/20230413_objects_workspaces.ts
@@ -1,13 +1,14 @@
 // @ts-expect-error old migration code kept for reference
 
 import { personalWorkspace } from "@app/lib/auth";
-import { App, Dataset, Provider, Run } from "@app/lib/models/apps";
+import { App, Dataset, Provider } from "@app/lib/models/apps";
 import { DataSource } from "@app/lib/models/data_source";
 import { User } from "@app/lib/models/user";
 import { KeyModel } from "@app/lib/resources/storage/models/keys";
+import type { RunModel } from "@app/lib/resources/storage/models/runs";
 
 async function addWorkspaceToObject(
-  object: App | Dataset | Provider | KeyModel | DataSource | Run
+  object: App | Dataset | Provider | KeyModel | DataSource | RunModel
 ) {
   if (object.workspaceId) {
     // @ts-expect-error old migration code kept for reference

--- a/front/migrations/20230413_objects_workspaces.ts
+++ b/front/migrations/20230413_objects_workspaces.ts
@@ -5,7 +5,7 @@ import { App, Dataset, Provider } from "@app/lib/models/apps";
 import { DataSource } from "@app/lib/models/data_source";
 import { User } from "@app/lib/models/user";
 import { KeyModel } from "@app/lib/resources/storage/models/keys";
-import type { RunModel } from "@app/lib/resources/storage/models/runs";
+import { RunModel } from "@app/lib/resources/storage/models/runs";
 
 async function addWorkspaceToObject(
   object: App | Dataset | Provider | KeyModel | DataSource | RunModel
@@ -42,7 +42,13 @@ async function addWorkspaceToObject(
 }
 
 async function updateObjects(
-  objects: App[] | Dataset[] | Provider[] | KeyModel[] | DataSource[] | Run[]
+  objects:
+    | App[]
+    | Dataset[]
+    | Provider[]
+    | KeyModel[]
+    | DataSource[]
+    | RunModel[]
 ) {
   const chunks = [];
   for (let i = 0; i < objects.length; i += 16) {
@@ -86,7 +92,7 @@ async function updateDataSources() {
 }
 
 async function updateRuns() {
-  const runs = await Run.findAll();
+  const runs = await RunModel.findAll();
   await updateObjects(runs);
 }
 

--- a/front/migrations/20230413_runs.ts
+++ b/front/migrations/20230413_runs.ts
@@ -84,7 +84,7 @@ async function main() {
       })
       .filter((r) => r.appId && r.userId);
 
-    await Run.bulkCreate(runsToCreate);
+    await RunModel.bulkCreate(runsToCreate);
   }
 }
 

--- a/front/migrations/20230413_runs.ts
+++ b/front/migrations/20230413_runs.ts
@@ -1,6 +1,7 @@
 import { Sequelize } from "sequelize";
 
-import { App, Run } from "@app/lib/models/apps";
+import { App } from "@app/lib/models/apps";
+import { RunModel } from "@app/lib/resources/storage/models/runs";
 
 const { CORE_DATABASE_URI } = process.env;
 
@@ -25,7 +26,7 @@ async function main() {
   const allRunIds = core_runs_rows.map((r: any) => r.run_id);
 
   console.log("Retrieving existing front runs");
-  const existingFrontRuns = await Run.findAll();
+  const existingFrontRuns = await RunModel.findAll();
   console.log("Generating alreadyBackfilledRunIds");
   const alreadyBackfilledRunIds = new Set(
     existingFrontRuns.map((r) => r.dustRunId)

--- a/front/migrations/20230427_runs_creation_time.ts
+++ b/front/migrations/20230427_runs_creation_time.ts
@@ -1,7 +1,7 @@
 import { Sequelize } from "sequelize";
 
-import { Run } from "@app/lib/models/apps";
 import { frontSequelize } from "@app/lib/resources/storage";
+import { RunModel } from "@app/lib/resources/storage/models/runs";
 
 const { CORE_DATABASE_URI } = process.env;
 
@@ -28,7 +28,7 @@ async function main() {
   });
 
   console.log("Retrieving front runs");
-  const frontRuns = await Run.findAll();
+  const frontRuns = await RunModel.findAll();
 
   console.log("Chunking");
   const chunkSize = 16;

--- a/front/migrations/db/migration_22.sql
+++ b/front/migrations/db/migration_22.sql
@@ -1,2 +1,2 @@
 -- Migration created on Jun 13, 2024
-CREATE INDEX "runs_workspace_id_created_at" ON "runs" ("workspaceId", "createdAt");
+CREATE INDEX CONCURRENTLY "runs_workspace_id_created_at" ON "runs" ("workspaceId", "createdAt");

--- a/front/migrations/db/migration_22.sql
+++ b/front/migrations/db/migration_22.sql
@@ -1,0 +1,2 @@
+-- Migration created on Jun 13, 2024
+CREATE INDEX "runs_workspace_id_created_at" ON "runs" ("workspaceId", "createdAt");

--- a/front/pages/api/v1/w/[wId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/v1/w/[wId]/apps/[aId]/runs/index.ts
@@ -19,7 +19,9 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { getApp } from "@app/lib/api/app";
 import { getDustAppSecrets } from "@app/lib/api/dust_app_secrets";
 import { Authenticator, getAPIKey } from "@app/lib/auth";
-import { Provider, Run, RunUsage } from "@app/lib/models/apps";
+import { Provider } from "@app/lib/models/apps";
+import type { RunUsageType } from "@app/lib/resources/run_resource";
+import { RunResource } from "@app/lib/resources/run_resource";
 import logger from "@app/logger/logger";
 import { apiError, withLogging } from "@app/logger/withlogging";
 
@@ -35,19 +37,12 @@ export const config = {
 
 type RunFlavor = "blocking" | "streaming" | "non-blocking";
 
-type Usage = {
-  providerId: ModelProviderIdType;
-  modelId: ModelIdType;
-  promptTokens: number;
-  completionTokens: number;
-};
-
 type Trace = [[BlockType, string], TraceType[][]];
 
 function extractUsageFromExecutions(
   block: { provider_id: ModelProviderIdType; model_id: ModelIdType },
   traces: TraceType[][],
-  usages: Usage[]
+  usages: RunUsageType[]
 ) {
   if (block) {
     traces.forEach((tracesInner) => {
@@ -245,7 +240,7 @@ async function handler(
           assertNever(runFlavor);
       }
 
-      const usages: Usage[] = [];
+      const usages: RunUsageType[] = [];
       const traces: Trace[] = [];
 
       try {
@@ -305,19 +300,14 @@ async function handler(
 
       const dustRunId = await runRes.value.dustRunId;
 
-      const { id: runId } = await Run.create({
+      const run = await RunResource.makeNew({
         dustRunId,
         appId: app.id,
         runType: "deploy",
         workspaceId: keyRes.value.workspaceId,
       });
 
-      await RunUsage.bulkCreate(
-        usages.map((usage) => ({
-          runId,
-          ...usage,
-        }))
-      );
+      await run.recordRunUsageType(usages);
 
       switch (runFlavor) {
         case "streaming":

--- a/front/pages/api/v1/w/[wId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/v1/w/[wId]/apps/[aId]/runs/index.ts
@@ -307,7 +307,7 @@ async function handler(
         workspaceId: keyRes.value.workspaceId,
       });
 
-      await run.recordRunUsageType(usages);
+      await run.recordRunUsage(usages);
 
       switch (runFlavor) {
         case "streaming":

--- a/front/pages/api/w/[wId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/runs/index.ts
@@ -6,7 +6,8 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { getApp } from "@app/lib/api/app";
 import { getDustAppSecrets } from "@app/lib/api/dust_app_secrets";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { App, Provider, Run } from "@app/lib/models/apps";
+import { App, Provider } from "@app/lib/models/apps";
+import { RunResource } from "@app/lib/resources/run_resource";
 import { dumpSpecification } from "@app/lib/specification";
 import logger from "@app/logger/logger";
 import { apiError, withLogging } from "@app/logger/withlogging";
@@ -146,7 +147,7 @@ async function handler(
       }
 
       await Promise.all([
-        Run.create({
+        RunResource.makeNew({
           dustRunId: dustRun.value.run.run_id,
           appId: app.id,
           runType: "local",
@@ -228,20 +229,16 @@ async function handler(
         : 0;
       const runType = req.query.runType ? req.query.runType : "local";
 
-      const where = {
-        runType,
-        workspaceId: owner.id,
-        appId: app.id,
-      };
+      const userRuns = await RunResource.listByAppAndRunType(
+        owner,
+        { appId: app.id, runType },
+        { limit, offset }
+      );
 
-      const userRuns = await Run.findAll({
-        where: where,
-        limit,
-        offset,
-        order: [["createdAt", "DESC"]],
-      });
-      const totalNumberOfRuns = await Run.count({
-        where,
+      console.log(">> userRuns:", userRuns);
+      const totalNumberOfRuns = await RunResource.countAllByWorkspace(owner, {
+        appId: app.id,
+        runType,
       });
       const userDustRunIds = userRuns.map((r) => r.dustRunId);
 
@@ -249,6 +246,8 @@ async function handler(
         projectId: app.dustAPIProjectId,
         dustRunIds: userDustRunIds,
       });
+
+      console.log(">> dustRuns:", dustRuns);
 
       if (dustRuns.isErr()) {
         return apiError(req, res, {

--- a/front/pages/api/w/[wId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/runs/index.ts
@@ -235,7 +235,6 @@ async function handler(
         { limit, offset }
       );
 
-      console.log(">> userRuns:", userRuns);
       const totalNumberOfRuns = await RunResource.countAllByWorkspace(owner, {
         appId: app.id,
         runType,
@@ -246,8 +245,6 @@ async function handler(
         projectId: app.dustAPIProjectId,
         dustRunIds: userDustRunIds,
       });
-
-      console.log(">> dustRuns:", dustRuns);
 
       if (dustRuns.isErr()) {
         return apiError(req, res, {

--- a/front/pages/api/w/[wId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/w/[wId]/apps/[aId]/runs/index.ts
@@ -235,7 +235,7 @@ async function handler(
         { limit, offset }
       );
 
-      const totalNumberOfRuns = await RunResource.countAllByWorkspace(owner, {
+      const totalNumberOfRuns = await RunResource.countByAppAndRunType(owner, {
         appId: app.id,
         runType,
       });

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -1,5 +1,6 @@
 import { CoreAPI } from "@dust-tt/types";
 import { Storage } from "@google-cloud/storage";
+import { chunk } from "lodash";
 import { Op } from "sequelize";
 
 import { renderUserType } from "@app/lib/api/user";
@@ -42,6 +43,7 @@ import { MembershipInvitation, Workspace } from "@app/lib/models/workspace";
 import { ContentFragmentResource } from "@app/lib/resources/content_fragment_resource";
 import { KeyResource } from "@app/lib/resources/key_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { RunResource } from "@app/lib/resources/run_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
 import logger from "@app/logger/logger";
 
@@ -372,13 +374,9 @@ export async function deleteAppsActivity({
     if (res.isErr()) {
       throw new Error(`Error deleting Project from Core: ${res.error.message}`);
     }
+
     await frontSequelize.transaction(async (t) => {
-      await Run.destroy({
-        where: {
-          appId: app.id,
-        },
-        transaction: t,
-      });
+      await RunResource.deleteAllByAppId(app.id, t);
       await Clone.destroy({
         where: {
           [Op.or]: [{ fromId: app.id }, { toId: app.id }],
@@ -421,24 +419,12 @@ export async function deleteRunOnDustAppsActivity({
     throw new Error("Could not find the workspace.");
   }
 
-  const runs = await Run.findAll({
-    where: {
-      workspaceId: workspace.id,
-    },
-    include: [
-      {
-        model: App,
-        as: "app",
-        required: true,
-      },
-    ],
+  const runs = await RunResource.listByWorkspace(workspace, {
+    includeApp: true,
   });
 
   const chunkSize = 8;
-  const chunks: Run[][] = [];
-  for (let i = 0; i < runs.length; i += chunkSize) {
-    chunks.push(runs.slice(i, i + chunkSize));
-  }
+  const chunks = chunk(runs, chunkSize);
 
   for (let i = 0; i < chunks.length; i++) {
     const chunk = chunks[i];
@@ -457,7 +443,7 @@ export async function deleteRunOnDustAppsActivity({
               `Error deleting Run from Core: ${res.error.message}`
             );
           }
-          await run.destroy();
+          await run.delete();
         })();
       })
     );

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -5,7 +5,7 @@ import { Op } from "sequelize";
 
 import { renderUserType } from "@app/lib/api/user";
 import { Authenticator } from "@app/lib/auth";
-import { App, Clone, Dataset, Provider, Run } from "@app/lib/models/apps";
+import { App, Clone, Dataset, Provider } from "@app/lib/models/apps";
 import { AgentDataSourceConfiguration } from "@app/lib/models/assistant/actions/data_sources";
 import {
   AgentDustAppRunAction,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR moves the `runs` table to a proper resource which also bundles all usage recording functionalities.

The key change to highlight is the application of a cutoff date when listing runs, following the deletion process initiated in https://github.com/dust-tt/dust/pull/5631. Runs are only deleted in core but will remain in front since we have bigger plan for them. 

This PR adds an index on `runs` to serve the cutoff request for the list by workspace.
## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
Worst case it breaks listing run + recording usage. Safe to rollback.

## Deploy Plan

- [x] Create new index
- [ ] Deploy front
