### PR TITLE
[front] - feat(front): popular assistants tab

### DIFF
--- a/front/components/assistant/AssistantBrowser.tsx
+++ b/front/components/assistant/AssistantBrowser.tsx
@@ -82,11 +82,9 @@ export function AssistantBrowser({
       list: filteredAgents.filter(
         (a) => a.scope === "published" && a.userListStatus === "in-list"
       ),
-      most_popular: filteredAgents
-        .filter((a) => a.usage && a.usage.messageCount > 0)
-        .sort(
-          (a, b) => (b.usage?.messageCount || 0) - (a.usage?.messageCount || 0)
-        ),
+      most_popular: filteredAgents.filter(
+        (a) => a.usage && a.usage.messageCount > 0
+      ),
     };
   }, [assistantSearch, loadingStatus, agents]);
 

--- a/front/components/assistant/AssistantBrowser.tsx
+++ b/front/components/assistant/AssistantBrowser.tsx
@@ -82,9 +82,9 @@ export function AssistantBrowser({
       list: filteredAgents.filter(
         (a) => a.scope === "published" && a.userListStatus === "in-list"
       ),
-      most_popular: filteredAgents.filter(
-        (a) => a.usage && a.usage.messageCount > 0
-      ),
+      most_popular: filteredAgents
+        .filter((a) => a.usage && a.usage.messageCount > 0)
+        .sort((a, b) => b.usage.messageCount - a.usage.messageCount),
     };
   }, [assistantSearch, loadingStatus, agents]);
 

--- a/front/components/assistant/AssistantBrowser.tsx
+++ b/front/components/assistant/AssistantBrowser.tsx
@@ -82,7 +82,6 @@ export function AssistantBrowser({
       list: filteredAgents.filter(
         (a) => a.scope === "published" && a.userListStatus === "in-list"
       ),
-      // TODO: Implement most popular agents (upcoming PR for issue #5454)
       most_popular: filteredAgents
         .filter((a) => a.usage && a.usage.messageCount > 0)
         .sort(

--- a/front/components/assistant/AssistantBrowser.tsx
+++ b/front/components/assistant/AssistantBrowser.tsx
@@ -84,7 +84,9 @@ export function AssistantBrowser({
       ),
       most_popular: filteredAgents
         .filter((a) => a.usage && a.usage.messageCount > 0)
-        .sort((a, b) => b.usage.messageCount - a.usage.messageCount),
+        .sort(
+          (a, b) => (b.usage?.messageCount ?? 0) - (a.usage?.messageCount ?? 0)
+        ),
     };
   }, [assistantSearch, loadingStatus, agents]);
 

--- a/front/components/assistant/AssistantBrowser.tsx
+++ b/front/components/assistant/AssistantBrowser.tsx
@@ -87,15 +87,13 @@ export function AssistantBrowser({
         .filter((a) => a.usage && a.usage.messageCount > 0)
         .sort(
           (a, b) => (b.usage?.messageCount || 0) - (a.usage?.messageCount || 0)
-        )
-        .slice(0, 0), // Placeholder -- most popular agents are not implemented yet
+        ),
     };
   }, [assistantSearch, loadingStatus, agents]);
 
   const visibleTabs = useMemo(() => {
     return ALL_AGENTS_TABS.filter((tab) => agentsByTab[tab.id].length > 0);
   }, [agentsByTab]);
-
   const [selectedTab, setSelectedTab] = useState<TabId | null>(
     visibleTabs[0]?.id || null
   );

--- a/front/components/assistant/Sharing.tsx
+++ b/front/components/assistant/Sharing.tsx
@@ -185,11 +185,7 @@ export function SharingButton({
               <div className="text-sm text-element-700">
                 <div>
                   {SCOPE_INFO[newScope].text}{" "}
-                  {agentUsage &&
-                  agentUsage.usersWithAgentInListCount > 0 &&
-                  newScope !== "private"
-                    ? usageText
-                    : null}
+                  {agentUsage && newScope !== "private" ? usageText : null}
                 </div>
               </div>
             </div>

--- a/front/components/assistant/Usage.tsx
+++ b/front/components/assistant/Usage.tsx
@@ -1,5 +1,4 @@
-import type { AgentUsageType, LightAgentUsageType } from "@dust-tt/types";
-import { isAgentUsageType } from "@dust-tt/types";
+import type { AgentUsageType } from "@dust-tt/types";
 import { pluralize } from "@dust-tt/types";
 import type { ReactNode } from "react";
 
@@ -12,7 +11,7 @@ export function assistantUsageMessage({
   boldVersion,
 }: {
   assistantName: string | null;
-  usage: AgentUsageType | LightAgentUsageType | null;
+  usage: AgentUsageType | null;
   isLoading: boolean;
   isError: boolean;
   shortVersion?: boolean;
@@ -44,28 +43,19 @@ export function assistantUsageMessage({
         </>
       );
     }
-    if (isAgentUsageType(usage)) {
-      const usersWithAgentInListCount = boldIfRequested(
-        `${usage.usersWithAgentInListCount} member${pluralize(
-          usage.usersWithAgentInListCount
-        )}`
-      );
-      const messageCount = boldIfRequested(
-        `${usage.messageCount} time${pluralize(usage.messageCount)}`
-      );
-      const userCount = boldIfRequested(
-        `${usage.userCount} member${pluralize(usage.userCount)}`
-      );
+    const messageCount = boldIfRequested(
+      `${usage.messageCount} time${pluralize(usage.messageCount)}`
+    );
+    const userCount = boldIfRequested(
+      `${usage.userCount} member${pluralize(usage.userCount)}`
+    );
 
-      return (
-        <>
-          {`${
-            assistantName ? "@" + assistantName : "This assistant"
-          } is active for`}{" "}
-          {usersWithAgentInListCount} and has been used {messageCount} by{" "}
-          {userCount} in the last {usage.timePeriodSec / (60 * 60 * 24)} days.
-        </>
-      );
-    }
+    return (
+      <>
+        {assistantName ? "@" + assistantName : "This assistant"} has been used{" "}
+        {messageCount} by {userCount} in the last{" "}
+        {usage.timePeriodSec / (60 * 60 * 24)} days.
+      </>
+    );
   }
 }

--- a/front/components/assistant/Usage.tsx
+++ b/front/components/assistant/Usage.tsx
@@ -1,4 +1,5 @@
-import type { AgentUsageType } from "@dust-tt/types";
+import type { AgentUsageType, LightAgentUsageType } from "@dust-tt/types";
+import { isAgentUsageType } from "@dust-tt/types";
 import { pluralize } from "@dust-tt/types";
 import type { ReactNode } from "react";
 
@@ -11,7 +12,7 @@ export function assistantUsageMessage({
   boldVersion,
 }: {
   assistantName: string | null;
-  usage: AgentUsageType | null;
+  usage: AgentUsageType | LightAgentUsageType | null;
   isLoading: boolean;
   isError: boolean;
   shortVersion?: boolean;
@@ -43,27 +44,28 @@ export function assistantUsageMessage({
         </>
       );
     }
+    if (isAgentUsageType(usage)) {
+      const usersWithAgentInListCount = boldIfRequested(
+        `${usage.usersWithAgentInListCount} member${pluralize(
+          usage.usersWithAgentInListCount
+        )}`
+      );
+      const messageCount = boldIfRequested(
+        `${usage.messageCount} time${pluralize(usage.messageCount)}`
+      );
+      const userCount = boldIfRequested(
+        `${usage.userCount} member${pluralize(usage.userCount)}`
+      );
 
-    const usersWithAgentInListCount = boldIfRequested(
-      `${usage.usersWithAgentInListCount} member${pluralize(
-        usage.usersWithAgentInListCount
-      )}`
-    );
-    const messageCount = boldIfRequested(
-      `${usage.messageCount} time${pluralize(usage.messageCount)}`
-    );
-    const userCount = boldIfRequested(
-      `${usage.userCount} member${pluralize(usage.userCount)}`
-    );
-
-    return (
-      <>
-        {`${
-          assistantName ? "@" + assistantName : "This assistant"
-        } is active for`}{" "}
-        {usersWithAgentInListCount} and has been used {messageCount} by{" "}
-        {userCount} in the last {usage.timePeriodSec / (60 * 60 * 24)} days.
-      </>
-    );
+      return (
+        <>
+          {`${
+            assistantName ? "@" + assistantName : "This assistant"
+          } is active for`}{" "}
+          {usersWithAgentInListCount} and has been used {messageCount} by{" "}
+          {userCount} in the last {usage.timePeriodSec / (60 * 60 * 24)} days.
+        </>
+      );
+    }
   }
 }

--- a/front/lib/api/assistant/agent_usage.ts
+++ b/front/lib/api/assistant/agent_usage.ts
@@ -1,7 +1,6 @@
 import type {
   AgentUsageType,
   LightAgentConfigurationType,
-  ModelId,
 } from "@dust-tt/types";
 import { assertNever } from "@dust-tt/types";
 import { literal, Op, Sequelize } from "sequelize";
@@ -339,15 +338,11 @@ export async function storeCountsInRedis(
 export async function signalAgentUsage({
   agentConfigurationId,
   workspaceId,
-  userId,
-  timestamp,
-  messageModelId,
 }: {
   agentConfigurationId: string;
   workspaceId: string;
-  userId: string;
-  timestamp: number;
-  messageModelId: ModelId;
 }) {
-  return;
+  const redis = await redisClient();
+  const { agentMessageCountKey } = _getUsageKeys(workspaceId);
+  await redis.hIncrBy(agentMessageCountKey, agentConfigurationId, 1);
 }

--- a/front/lib/api/assistant/agent_usage.ts
+++ b/front/lib/api/assistant/agent_usage.ts
@@ -22,7 +22,6 @@ const rankingTimeframeSec = 60 * 60 * 24 * 30; // 30 days
 
 // Computing agent mention count over a 2h period
 const popularityComputationTimeframeSec = 2 * 60 * 60;
-const agentPopularityLimit = 24;
 
 export type mentionCount = {
   agentId: string;
@@ -334,11 +333,4 @@ export async function storeCountsInRedis(
   if (results.includes(null)) {
     throw new Error("Transaction failed and was rolled back.");
   }
-}
-
-export async function getMostPopularAgents(workspaceId: string) {
-  const agentsUsage = await getAgentsUsage({ workspaceId });
-  return agentsUsage
-    .slice(0, agentPopularityLimit)
-    .filter((mentionCount) => mentionCount.count > 0);
 }

--- a/front/lib/api/assistant/agent_usage.ts
+++ b/front/lib/api/assistant/agent_usage.ts
@@ -1,6 +1,7 @@
 import type {
   AgentUsageType,
   LightAgentConfigurationType,
+  ModelId,
 } from "@dust-tt/types";
 import { assertNever } from "@dust-tt/types";
 import { literal, Op, Sequelize } from "sequelize";
@@ -333,4 +334,20 @@ export async function storeCountsInRedis(
   if (results.includes(null)) {
     throw new Error("Transaction failed and was rolled back.");
   }
+}
+
+export async function signalAgentUsage({
+  agentConfigurationId,
+  workspaceId,
+  userId,
+  timestamp,
+  messageModelId,
+}: {
+  agentConfigurationId: string;
+  workspaceId: string;
+  userId: string;
+  timestamp: number;
+  messageModelId: ModelId;
+}) {
+  return;
 }

--- a/front/lib/api/assistant/agent_usage.ts
+++ b/front/lib/api/assistant/agent_usage.ts
@@ -17,6 +17,8 @@ const rankingTimeframeSec = 60 * 60 * 24 * 30; // 30 days
 // Computing agent mention count over a 2h period
 const popularityComputationTimeframeSec = 2 * 60 * 60;
 
+const TTL_KEY_NOT_EXIST = -2;
+
 type agentUsage = {
   agentId: string;
   messageCount: number;
@@ -69,7 +71,7 @@ export async function getAgentsUsage({
     const agentMessageCountTTL = await redis.ttl(agentMessageCountKey);
 
     // agent mention count doesn't exist
-    if (agentMessageCountTTL === -2) {
+    if (agentMessageCountTTL === TTL_KEY_NOT_EXIST) {
       const [agentMessageCounts, userCounts] = await Promise.all([
         agentMentionsCount(owner.id),
         agentMentionsUserCount(owner.id),

--- a/front/lib/api/assistant/agent_usage.ts
+++ b/front/lib/api/assistant/agent_usage.ts
@@ -26,6 +26,7 @@ const popularityComputationTimeframeSec = 2 * 60 * 60;
 export type mentionCount = {
   agentId: string;
   count: number;
+  timePeriodSec: number;
 };
 
 function _getAgentInListCountKey({
@@ -103,7 +104,11 @@ export async function getAgentsUsage({
     // Retrieve and parse agents usage
     const agentsUsage = await redis.hGetAll(agentMessageCountKey);
     return Object.entries(agentsUsage).map(([agentId, count]) => {
-      return { agentId, count: parseInt(count) };
+      return {
+        agentId,
+        count: parseInt(count),
+        timePeriodSec: rankingTimeframeSec,
+      };
     });
   } finally {
     // Close the redis connection if it was created locally
@@ -254,6 +259,7 @@ export async function agentMentionsUserCount(
     results.map((mention) => ({
       agentId: mention.agentConfigurationId as string,
       count: (mention as unknown as { count: number }).count,
+      timePeriodSec: rankingTimeframeSec,
     }))
   );
 }
@@ -302,6 +308,7 @@ export async function agentMentionsCount(
     results.map((mention) => ({
       agentId: mention.agentConfigurationId as string,
       count: (mention as unknown as { count: number }).count,
+      timePeriodSec: rankingTimeframeSec,
     }))
   );
 }

--- a/front/lib/api/assistant/agent_usage.ts
+++ b/front/lib/api/assistant/agent_usage.ts
@@ -302,8 +302,15 @@ export async function signalAgentUsage({
   agentConfigurationId: string;
   workspaceId: string;
 }) {
-  const redis = await redisClient();
-  const { agentMessageCountKey } = _getUsageKeys(workspaceId);
-  await redis.hIncrBy(agentMessageCountKey, agentConfigurationId, 1);
-  await redis.quit();
+  let redis: Awaited<ReturnType<typeof redisClient>> | null = null;
+
+  try {
+    redis = await redisClient();
+    const { agentMessageCountKey } = _getUsageKeys(workspaceId);
+    await redis.hIncrBy(agentMessageCountKey, agentConfigurationId, 1);
+  } finally {
+    if (redis) {
+      await redis.quit();
+    }
+  }
 }

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -839,11 +839,8 @@ export async function* postUserMessage(
   if (agentMessages.length > 0) {
     for (const agentMessage of agentMessages) {
       void signalAgentUsage({
-        userId: user?.id.toString() || context.email || context.username,
         agentConfigurationId: agentMessage.configuration.sId,
         workspaceId: owner.sId,
-        messageModelId: agentMessage.id,
-        timestamp: agentMessage.created,
       });
     }
   }
@@ -1345,13 +1342,7 @@ export async function* editUserMessage(
   if (agentMessages.length > 0) {
     for (const agentMessage of agentMessages) {
       void signalAgentUsage({
-        userId:
-          user?.id.toString() ||
-          message.context.email ||
-          message.context.username,
         agentConfigurationId: agentMessage.configuration.sId,
-        messageModelId: agentMessage.id,
-        timestamp: agentMessage.created,
         workspaceId: owner.sId,
       });
     }

--- a/front/lib/api/assistant/user_relation.ts
+++ b/front/lib/api/assistant/user_relation.ts
@@ -116,21 +116,3 @@ export async function setAgentUserListStatus({
     listStatus,
   });
 }
-
-export async function getUsersWithAgentInListCount(
-  auth: Authenticator,
-  agentId: string
-) {
-  const owner = auth.workspace();
-  if (!owner || !auth.isUser()) {
-    throw new Error("Workspace not found.");
-  }
-
-  return AgentUserRelation.count({
-    where: {
-      workspaceId: owner.id,
-      agentConfiguration: agentId,
-      listStatusOverride: "in-list",
-    },
-  });
-}

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/usage.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/usage.ts
@@ -56,7 +56,7 @@ async function handler(
           },
         });
       }
-      const agentUsage = await getAgentUsage(auth, {
+      const agentUsage = await getAgentUsage({
         agentConfiguration,
         workspaceId: owner.sId,
       });

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/usage.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/usage.ts
@@ -56,7 +56,7 @@ async function handler(
           },
         });
       }
-      const agentUsage = await getAgentUsage({
+      const agentUsage = await getAgentUsage(auth, {
         agentConfiguration,
         workspaceId: owner.sId,
       });

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -16,9 +16,7 @@ import type * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import {
-  getAgentsUsage
-} from "@app/lib/api/assistant/agent_usage";
+import { getAgentsUsage } from "@app/lib/api/assistant/agent_usage";
 import {
   createAgentActionConfiguration,
   createAgentConfiguration,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -7,6 +7,7 @@ import type {
 } from "@dust-tt/types";
 import {
   assertNever,
+  Err,
   GetAgentConfigurationsQuerySchema,
   Ok,
   PostOrPatchAgentConfigurationRequestBodySchema,
@@ -16,11 +17,9 @@ import type * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import type {
-  mentionCount} from "@app/lib/api/assistant/agent_usage";
-import {
-  getAgentsUsage
-} from "@app/lib/api/assistant/agent_usage";
+import { getApp } from "@app/lib/api/app";
+import type { mentionCount } from "@app/lib/api/assistant/agent_usage";
+import { getAgentsUsage } from "@app/lib/api/assistant/agent_usage";
 import {
   createAgentActionConfiguration,
   createAgentConfiguration,
@@ -134,7 +133,8 @@ async function handler(
           ...agentConfiguration,
           usage: {
             messageCount: usageMap.get(agentConfiguration.sId)?.count || 0,
-            timePeriodSec: usageMap.get(agentConfiguration.sId)?.timePeriodSec || 0,
+            timePeriodSec:
+              usageMap.get(agentConfiguration.sId)?.timePeriodSec || 0,
           },
         }));
       }
@@ -370,11 +370,17 @@ export async function createOrUpgradeAgentConfiguration({
           )
         );
       } else if (action.type === "dust_app_run_configuration") {
+        const app = await getApp(auth, action.appId);
+        if (!app) {
+          return new Err(new Error(`App ${action.appId} not found`));
+        }
+
         actionConfigs.push(
           await createAgentActionConfiguration(
             auth,
             {
               type: "dust_app_run_configuration",
+              app,
               appWorkspaceId: action.appWorkspaceId,
               appId: action.appId,
               name: action.name ?? null,
@@ -418,6 +424,18 @@ export async function createOrUpgradeAgentConfiguration({
             auth,
             {
               type: "websearch_configuration",
+              name: action.name ?? null,
+              description: action.description ?? null,
+            },
+            agentConfigurationRes.value
+          )
+        );
+      } else if (action.type === "browse_configuration") {
+        actionConfigs.push(
+          await createAgentActionConfiguration(
+            auth,
+            {
+              type: "browse_configuration",
               name: action.name ?? null,
               description: action.description ?? null,
             },

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -133,7 +133,8 @@ async function handler(
         agentConfigurations = agentConfigurations.map((agentConfiguration) => ({
           ...agentConfiguration,
           usage: {
-            messageCount: usageMap[agentConfiguration.sId]?.count || 0,
+            messageCount: usageMap[agentConfiguration.sId]?.messageCount || 0,
+            userCount: usageMap[agentConfiguration.sId]?.userCount || 0,
             timePeriodSec: usageMap[agentConfiguration.sId]?.timePeriodSec || 0,
           },
         }));

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -16,7 +16,11 @@ import type * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { getAgentsUsage } from "@app/lib/api/assistant/agent_usage";
+import type {
+  mentionCount} from "@app/lib/api/assistant/agent_usage";
+import {
+  getAgentsUsage
+} from "@app/lib/api/assistant/agent_usage";
 import {
   createAgentActionConfiguration,
   createAgentConfiguration,
@@ -122,16 +126,15 @@ async function handler(
             workspaceId: owner.sId,
           });
         });
-        const usageMap = new Map(
-          mentionCounts.map(({ agentId, count }) => [agentId, count])
-        );
+        const usageMap = new Map<string, mentionCount>();
+        mentionCounts.forEach((mentionCount) => {
+          usageMap.set(mentionCount.agentId, mentionCount);
+        });
         agentConfigurations = agentConfigurations.map((agentConfiguration) => ({
           ...agentConfiguration,
           usage: {
-            userCount: 0,
-            messageCount: usageMap.get(agentConfiguration.sId) || 0,
-            usersWithAgentInListCount: 0,
-            timePeriodSec: 0,
+            messageCount: usageMap.get(agentConfiguration.sId)?.count || 0,
+            timePeriodSec: usageMap.get(agentConfiguration.sId)?.timePeriodSec || 0,
           },
         }));
       }

--- a/front/pages/w/[wId]/assistant/new.tsx
+++ b/front/pages/w/[wId]/assistant/new.tsx
@@ -95,7 +95,7 @@ export default function AssistantNew({
     isAgentConfigurationsLoading: isInitialAgentConfigurationsLoading,
   } = useAgentConfigurations({
     workspaceId: owner.sId,
-    agentsGetView: "workspace",
+    agentsGetView: "assistants-search",
     limit: 24,
     includes: ["usage"],
   });

--- a/front/pages/w/[wId]/assistant/new.tsx
+++ b/front/pages/w/[wId]/assistant/new.tsx
@@ -97,6 +97,7 @@ export default function AssistantNew({
     workspaceId: owner.sId,
     agentsGetView: "workspace",
     limit: 24,
+    includes: ["usage"],
   });
 
   // we load all assistants with authors in the background
@@ -107,7 +108,7 @@ export default function AssistantNew({
   } = useAgentConfigurations({
     workspaceId: owner.sId,
     agentsGetView: "assistants-search",
-    includes: ["authors"],
+    includes: ["authors", "usage"],
   });
 
   const displayedAgentConfigurations = isAgentConfigurationsWithAuthorsLoading

--- a/types/src/front/assistant/agent.ts
+++ b/types/src/front/assistant/agent.ts
@@ -190,7 +190,6 @@ export type LightAgentConfigurationType = {
 
   // `lastAuthors` is expensive to compute, so we only compute it when needed.
   lastAuthors?: AgentRecentAuthors;
-  // Usage is expensive to compute, so we only compute it when needed.
   usage?: AgentUsageType | LightAgentUsageType;
 
   maxToolsUsePerRun: number;

--- a/types/src/front/assistant/agent.ts
+++ b/types/src/front/assistant/agent.ts
@@ -134,26 +134,9 @@ export type AgentsGetViewType =
 export type AgentUsageType = {
   userCount: number;
   messageCount: number;
-  usersWithAgentInListCount: number;
-
   // userCount and messageCount are over the last `timePeriodSec` seconds
   timePeriodSec: number;
 };
-
-export type LightAgentUsageType = {
-  messageCount: number;
-  timePeriodSec: number;
-};
-export function isAgentUsageType(usage: unknown): usage is AgentUsageType {
-  return (
-    typeof usage === "object" &&
-    usage !== null &&
-    "messageCount" in usage &&
-    "timePeriodSec" in usage &&
-    "usersWithAgentInListCount" in usage &&
-    "userCount" in usage
-  );
-}
 
 export type AgentRecentAuthors = readonly string[];
 
@@ -190,7 +173,7 @@ export type LightAgentConfigurationType = {
 
   // `lastAuthors` is expensive to compute, so we only compute it when needed.
   lastAuthors?: AgentRecentAuthors;
-  usage?: AgentUsageType | LightAgentUsageType;
+  usage?: AgentUsageType;
 
   maxToolsUsePerRun: number;
 

--- a/types/src/front/assistant/agent.ts
+++ b/types/src/front/assistant/agent.ts
@@ -143,10 +143,8 @@ export type AgentUsageType = {
 export type LightAgentUsageType = {
   messageCount: number;
   timePeriodSec: number;
-}
-export function isAgentUsageType(
-  usage: unknown
-): usage is AgentUsageType {
+};
+export function isAgentUsageType(usage: unknown): usage is AgentUsageType {
   return (
     typeof usage === "object" &&
     usage !== null &&

--- a/types/src/front/assistant/agent.ts
+++ b/types/src/front/assistant/agent.ts
@@ -140,6 +140,23 @@ export type AgentUsageType = {
   timePeriodSec: number;
 };
 
+export type LightAgentUsageType = {
+  messageCount: number;
+  timePeriodSec: number;
+}
+export function isAgentUsageType(
+  usage: unknown
+): usage is AgentUsageType {
+  return (
+    typeof usage === "object" &&
+    usage !== null &&
+    "messageCount" in usage &&
+    "timePeriodSec" in usage &&
+    "usersWithAgentInListCount" in usage &&
+    "userCount" in usage
+  );
+}
+
 export type AgentRecentAuthors = readonly string[];
 
 export type AgentModelConfigurationType = {
@@ -176,7 +193,7 @@ export type LightAgentConfigurationType = {
   // `lastAuthors` is expensive to compute, so we only compute it when needed.
   lastAuthors?: AgentRecentAuthors;
   // Usage is expensive to compute, so we only compute it when needed.
-  usage?: AgentUsageType;
+  usage?: AgentUsageType | LightAgentUsageType;
 
   maxToolsUsePerRun: number;
 


### PR DESCRIPTION
## Description

This PR aims at introducing a "Most Popular" agent tab in the new conversation UI which displays the most used agents.

This introduces also introduces a big refactoring carefully explained in [Design Doc: Agent Usage](https://www.notion.so/dust-tt/Design-Doc-Agent-Usage-e756aeb1e5d74b4b8b5b29b0bbd49231?pvs=4).

The main changes are:
- We compute agent usages through SQL queries that are then being cached in Redis hashes to reduce the load on our DBs.
- We use Redis hashes to store data as we need to be able to retrieve all agents usage (in the "Most popular" tab) as well as the usage of a given assistant (assistants gallery).
- We got rid of the `usersWithAgentInListCount` metric

## Risk

It introduces a whole new logic on how to compute agent mentions involving new Redis data structures and potentially an increased loading latency on the homepage

## Deploy Plan

Deploy `front`
