### PR TITLE
Add Husky to support pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,7 +1,5 @@
 #!/bin/sh
 
-# .git/hooks/pre-commit
-
 # Check if the current branch is 'main'
 current_branch=$(git symbolic-ref --short HEAD)
 if [ "$current_branch" = "main" ]; then
@@ -14,3 +12,4 @@ fi
 
 # Allow commit
 exit 0
+

--- a/front/.husky/pre-commit
+++ b/front/.husky/pre-commit
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# .git/hooks/pre-commit
+
+# Check if the current branch is 'main'
+current_branch=$(git symbolic-ref --short HEAD)
+if [ "$current_branch" = "main" ]; then
+    # Check if the flag is set
+    if [ -z "$ALLOW_MAIN_COMMIT" ]; then
+        echo "Error: Committing to 'main' is not allowed. Use ALLOW_MAIN_COMMIT=1 to override."
+        exit 1
+    fi
+fi
+
+# Allow commit
+exit 0

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -147,6 +147,7 @@
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-simple-import-sort": "^12.1.0",
         "eslint-plugin-unused-imports": "^3.2.0",
+        "husky": "^9.0.11",
         "jest": "^29.5.0",
         "postcss": "^8.4.21",
         "prettier": "^2.8.7",
@@ -22844,6 +22845,21 @@
     "node_modules/humanize-ms/node_modules/ms": {
       "version": "2.1.3",
       "license": "MIT"
+    },
+    "node_modules/husky": {
+      "version": "9.0.11",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.0.11.tgz",
+      "integrity": "sha512-AB6lFlbwwyIqMdHYhwPe+kjOC3Oc5P3nThEoW/AaO2BX3vJDjWPFxYLxokUZOo6RNX20He3AaT8sESs9NJcmEw==",
+      "dev": true,
+      "bin": {
+        "husky": "bin.mjs"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
     },
     "node_modules/hyperdyperid": {
       "version": "1.2.0",

--- a/front/package.json
+++ b/front/package.json
@@ -11,7 +11,8 @@
     "test": "jest",
     "coverage": "jest --coverage",
     "initdb": "./admin/init_db.sh",
-    "create-db-migration": "./create_db_migration_file.sh"
+    "create-db-migration": "./create_db_migration_file.sh",
+    "prepare": "husky"
   },
   "dependencies": {
     "@amplitude/ampli": "^1.35.0",
@@ -156,6 +157,7 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-simple-import-sort": "^12.1.0",
     "eslint-plugin-unused-imports": "^3.2.0",
+    "husky": "^9.0.11",
     "jest": "^29.5.0",
     "postcss": "^8.4.21",
     "prettier": "^2.8.7",

--- a/front/package.json
+++ b/front/package.json
@@ -12,7 +12,7 @@
     "coverage": "jest --coverage",
     "initdb": "./admin/init_db.sh",
     "create-db-migration": "./create_db_migration_file.sh",
-    "prepare": "husky"
+    "prepare": "cd .. && husky .husky"
   },
   "dependencies": {
     "@amplitude/ampli": "^1.35.0",


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR introduces [Husky](https://github.com/typicode/husky) to facilitate the use of shared git hooks. Included in this update is a pre-commit hook designed to hinder accidental commits to the `main` branch. However, commits can still be executed in urgent situations by using the appropriate flag.

```
➜  front git:(main) ✗ git commit -m "Keep calm and commit"

Error: Committing to 'main' is not allowed. Use ALLOW_MAIN_COMMIT=1 to override.
husky - pre-commit script failed (code 1)
```

It adds a `prepare` command in the package.json. The `prepare` command is automatically run right after an install (see [doc](https://docs.npmjs.com/cli/v10/using-npm/scripts)). 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
