### PR TITLE
[Subscription] Fix: do not show per seat price for fixed pricing

### DIFF
--- a/front/lib/plans/subscription.ts
+++ b/front/lib/plans/subscription.ts
@@ -26,6 +26,7 @@ import { generateModelSId } from "@app/lib/utils";
 import { getWorkspaceFirstAdmin } from "@app/lib/workspace";
 import { checkWorkspaceActivity } from "@app/lib/workspace_usage";
 import logger from "@app/logger/logger";
+import { REPORT_USAGE_METADATA_KEY } from "@app/lib/plans/usage/types";
 
 // Helper function to render PlanType from PlanAttributes
 export function renderPlanFromModel({
@@ -468,14 +469,18 @@ export async function getPerSeatSubscriptionPricing(
     return null;
   }
 
-  const { unit_amount: unitAmount, currency, recurring } = item.price;
+  const { unit_amount: unitAmount, currency, recurring, metadata } = item.price;
 
   const isPricedPerSeat = unitAmount !== null;
   if (!isPricedPerSeat) {
     return null;
   }
 
-  if (!item.quantity || !recurring) {
+  if (
+    !item.quantity ||
+    !recurring ||
+    (metadata && metadata[REPORT_USAGE_METADATA_KEY] !== "PER_SEAT")
+  ) {
     return null;
   }
 


### PR DESCRIPTION
Description
---
Fixes https://github.com/dust-tt/tasks/issues/887

Enterprise clients that were switched to yearly pricing would see incorrect prices, that is, the fixed price was considered per seat and a huge bill of number of members * fixed price would be displayed

Replaces PR https://github.com/dust-tt/dust/pull/5659

Risk
---
n/a
