### PR TITLE
front: clean up ActionConfigurationType name & description

### DIFF
--- a/core/src/blocks/chat.rs
+++ b/core/src/blocks/chat.rs
@@ -438,19 +438,19 @@ impl Block for Chat {
                                             parameters: Some(p.clone()),
                                         }),
                                         _ => Err(anyhow!(
-                                "Invalid functions code output, expecting an array of objects with
+                                "Invalid functions code output, expecting an array of objects with \
                                  fields `name`, `description`, and `parameters`."
                             )),
                                     }
                                 }
                                 _ => Err(anyhow!(
-                                "Invalid functions code output, expecting an array of objects with
+                                "Invalid functions code output, expecting an array of objects with \
                                  fields `name`, `description`, and `parameters`."
                             )),
                             })
                             .collect::<Result<Vec<ChatFunction>>>()?,
                         _ => Err(anyhow!(
-                            "Invalid functions code output, expecting an array of objects with
+                            "Invalid functions code output, expecting an array of objects with \
                              fields `name`, `description`, and `parameters`."
                         ))?,
                     },
@@ -467,7 +467,7 @@ impl Block for Chat {
                 s => {
                     functions.iter().find(|f| f.name == s).ok_or(anyhow!(
                         "Invalid `function_call` in configuration for chat block `{}`: \
-                         function name `{}` not found in functions. Possible values are
+                         function name `{}` not found in functions. Possible values are \
                          'auto', 'none' or the name of one of the functions.",
                         name,
                         s

--- a/front/lib/api/assistant/actions/browse.ts
+++ b/front/lib/api/assistant/actions/browse.ts
@@ -27,6 +27,8 @@ import type { Authenticator } from "@app/lib/auth";
 import { AgentBrowseAction } from "@app/lib/models/assistant/actions/browse";
 import logger from "@app/logger/logger";
 
+export const DEFAULT_BROWSE_ACTION_NAME = "browse";
+
 interface BrowseActionBlob {
   id: ModelId; // AgentBrowseAction
   agentMessageId: ModelId;
@@ -84,7 +86,6 @@ export class BrowseAction extends BaseAction {
 /**
  * Params generation.
  */
-export const DEFAULT_BROWSE_ACTION_NAME = "browse";
 
 export class BrowseConfigurationServerRunner extends BaseActionConfigurationServerRunner<BrowseConfigurationType> {
   async buildSpecification(

--- a/front/lib/api/assistant/actions/browse.ts
+++ b/front/lib/api/assistant/actions/browse.ts
@@ -59,7 +59,7 @@ export class BrowseAction extends BaseAction {
   renderForFunctionCall(): FunctionCallType {
     return {
       id: this.functionCallId ?? `call_${this.id.toString()}`,
-      name: this.functionCallName ?? "browse",
+      name: this.functionCallName ?? DEFAULT_BROWSE_ACTION_NAME,
       arguments: JSON.stringify({ urls: this.urls }),
     };
   }
@@ -74,7 +74,7 @@ export class BrowseAction extends BaseAction {
 
     return {
       role: "function" as const,
-      name: this.functionCallName ?? "browse",
+      name: this.functionCallName ?? DEFAULT_BROWSE_ACTION_NAME,
       function_call_id: this.functionCallId ?? `call_${this.id.toString()}`,
       content,
     };
@@ -84,14 +84,17 @@ export class BrowseAction extends BaseAction {
 /**
  * Params generation.
  */
+export const DEFAULT_BROWSE_ACTION_NAME = "browse";
 
 export class BrowseConfigurationServerRunner extends BaseActionConfigurationServerRunner<BrowseConfigurationType> {
+  // Default action name.
+  defaultActionName(): string {
+    return DEFAULT_BROWSE_ACTION_NAME;
+  }
+
   async buildSpecification(
     auth: Authenticator,
-    {
-      name,
-      description,
-    }: { name?: string | undefined; description?: string | undefined }
+    { name, description }: { name: string; description: string | null }
   ): Promise<Result<AgentActionSpecification, Error>> {
     const owner = auth.workspace();
     if (!owner) {
@@ -99,7 +102,7 @@ export class BrowseConfigurationServerRunner extends BaseActionConfigurationServ
     }
 
     return new Ok({
-      name: name ?? "browse",
+      name: name,
       description: description ?? "Get the content of a web page.",
       inputs: [
         {
@@ -117,7 +120,10 @@ export class BrowseConfigurationServerRunner extends BaseActionConfigurationServ
   async deprecatedBuildSpecificationForSingleActionAgent(
     auth: Authenticator
   ): Promise<Result<AgentActionSpecification, Error>> {
-    return this.buildSpecification(auth, {});
+    return this.buildSpecification(auth, {
+      name: this.defaultActionName(),
+      description: null,
+    });
   }
 
   // This method is in charge of running the browse and creating an AgentBrowseAction object in

--- a/front/lib/api/assistant/actions/browse.ts
+++ b/front/lib/api/assistant/actions/browse.ts
@@ -87,11 +87,6 @@ export class BrowseAction extends BaseAction {
 export const DEFAULT_BROWSE_ACTION_NAME = "browse";
 
 export class BrowseConfigurationServerRunner extends BaseActionConfigurationServerRunner<BrowseConfigurationType> {
-  // Default action name.
-  defaultActionName(): string {
-    return DEFAULT_BROWSE_ACTION_NAME;
-  }
-
   async buildSpecification(
     auth: Authenticator,
     { name, description }: { name: string; description: string | null }
@@ -121,7 +116,7 @@ export class BrowseConfigurationServerRunner extends BaseActionConfigurationServ
     auth: Authenticator
   ): Promise<Result<AgentActionSpecification, Error>> {
     return this.buildSpecification(auth, {
-      name: this.defaultActionName(),
+      name: DEFAULT_BROWSE_ACTION_NAME,
       description: null,
     });
   }

--- a/front/lib/api/assistant/actions/browse.ts
+++ b/front/lib/api/assistant/actions/browse.ts
@@ -21,13 +21,12 @@ import {
 import { isLeft } from "fp-ts/lib/Either";
 
 import { runActionStreamed } from "@app/lib/actions/server";
+import { DEFAULT_BROWSE_ACTION_NAME } from "@app/lib/api/assistant/actions/names";
 import type { BaseActionRunParams } from "@app/lib/api/assistant/actions/types";
 import { BaseActionConfigurationServerRunner } from "@app/lib/api/assistant/actions/types";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentBrowseAction } from "@app/lib/models/assistant/actions/browse";
 import logger from "@app/logger/logger";
-
-export const DEFAULT_BROWSE_ACTION_NAME = "browse";
 
 interface BrowseActionBlob {
   id: ModelId; // AgentBrowseAction

--- a/front/lib/api/assistant/actions/names.ts
+++ b/front/lib/api/assistant/actions/names.ts
@@ -1,0 +1,7 @@
+// Stored in a separate file to prevent a circular dependency issue.
+export const DEFAULT_BROWSE_ACTION_NAME = "browse";
+export const DEFAULT_PROCESS_ACTION_NAME =
+  "extract_structured_data_from_data_sources";
+export const DEFAULT_RETRIEVAL_ACTION_NAME = "search_data_sources";
+export const DEFAULT_WEBSEARCH_ACTION_NAME = "web_search";
+export const DEFAULT_TABLES_QUERY_ACTION_NAME = "query_tables";

--- a/front/lib/api/assistant/actions/process.ts
+++ b/front/lib/api/assistant/actions/process.ts
@@ -132,7 +132,7 @@ export class ProcessConfigurationServerRunner extends BaseActionConfigurationSer
 
     const spec = await processActionSpecification({
       actionConfiguration,
-      name: name,
+      name,
       description:
         description ??
         "Process data sources specified by the user over a specific time-frame by extracting" +

--- a/front/lib/api/assistant/actions/process.ts
+++ b/front/lib/api/assistant/actions/process.ts
@@ -41,6 +41,9 @@ import {
 import { AgentProcessAction } from "@app/lib/models/assistant/actions/process";
 import logger from "@app/logger/logger";
 
+export const DEFAULT_PROCESS_ACTION_NAME =
+  "extract_structured_data_from_data_sources";
+
 interface ProcessActionBlob {
   id: ModelId; // AgentProcessAction.
   agentMessageId: ModelId;
@@ -115,8 +118,6 @@ export class ProcessAction extends BaseAction {
 /**
  * Params generation.
  */
-export const DEFAULT_PROCESS_ACTION_NAME =
-  "extract_structured_data_from_data_sources";
 
 export class ProcessConfigurationServerRunner extends BaseActionConfigurationServerRunner<ProcessConfigurationType> {
   // Generates the action specification for generation of rawInputs passed to `run`.

--- a/front/lib/api/assistant/actions/process.ts
+++ b/front/lib/api/assistant/actions/process.ts
@@ -81,8 +81,7 @@ export class ProcessAction extends BaseAction {
   renderForFunctionCall(): FunctionCallType {
     return {
       id: this.functionCallId ?? `call_${this.id.toString()}`,
-      name:
-        this.functionCallName ?? "extract_structured_data_from_data_sources",
+      name: this.functionCallName ?? DEFAULT_PROCESS_ACTION_NAME,
       arguments: JSON.stringify(this.params),
     };
   }
@@ -116,15 +115,14 @@ export class ProcessAction extends BaseAction {
 /**
  * Params generation.
  */
+export const DEFAULT_PROCESS_ACTION_NAME =
+  "extract_structured_data_from_data_sources";
 
 export class ProcessConfigurationServerRunner extends BaseActionConfigurationServerRunner<ProcessConfigurationType> {
   // Generates the action specification for generation of rawInputs passed to `run`.
   async buildSpecification(
     auth: Authenticator,
-    {
-      name = "extract_structured_data_from_data_sources",
-      description,
-    }: { name?: string; description?: string }
+    { name, description }: { name: string; description: string | null }
   ): Promise<Result<AgentActionSpecification, Error>> {
     const owner = auth.workspace();
     if (!owner) {
@@ -135,7 +133,7 @@ export class ProcessConfigurationServerRunner extends BaseActionConfigurationSer
 
     const spec = await processActionSpecification({
       actionConfiguration,
-      name,
+      name: name,
       description:
         description ??
         "Process data sources specified by the user over a specific time-frame by extracting" +
@@ -147,7 +145,10 @@ export class ProcessConfigurationServerRunner extends BaseActionConfigurationSer
   async deprecatedBuildSpecificationForSingleActionAgent(
     auth: Authenticator
   ): Promise<Result<AgentActionSpecification, Error>> {
-    return this.buildSpecification(auth, {});
+    return this.buildSpecification(auth, {
+      name: DEFAULT_PROCESS_ACTION_NAME,
+      description: null,
+    });
   }
 
   // This method is in charge of running the retrieval and creating an AgentProcessAction object in

--- a/front/lib/api/assistant/actions/process.ts
+++ b/front/lib/api/assistant/actions/process.ts
@@ -24,6 +24,7 @@ import {
 } from "@dust-tt/types";
 
 import { runActionStreamed } from "@app/lib/actions/server";
+import { DEFAULT_PROCESS_ACTION_NAME } from "@app/lib/api/assistant/actions/names";
 import {
   parseTimeFrame,
   retrievalAutoTimeFrameInputSpecification,
@@ -40,9 +41,6 @@ import {
 } from "@app/lib/development";
 import { AgentProcessAction } from "@app/lib/models/assistant/actions/process";
 import logger from "@app/logger/logger";
-
-export const DEFAULT_PROCESS_ACTION_NAME =
-  "extract_structured_data_from_data_sources";
 
 interface ProcessActionBlob {
   id: ModelId; // AgentProcessAction.

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -22,6 +22,7 @@ import {
 import { Ok } from "@dust-tt/types";
 
 import { runActionStreamed } from "@app/lib/actions/server";
+import { DEFAULT_RETRIEVAL_ACTION_NAME } from "@app/lib/api/assistant/actions/names";
 import type { BaseActionRunParams } from "@app/lib/api/assistant/actions/types";
 import { BaseActionConfigurationServerRunner } from "@app/lib/api/assistant/actions/types";
 import { getSupportedModelConfig } from "@app/lib/assistant";
@@ -38,8 +39,6 @@ import {
 import { frontSequelize } from "@app/lib/resources/storage";
 import { rand } from "@app/lib/utils/seeded_random";
 import logger from "@app/logger/logger";
-
-export const DEFAULT_RETRIEVAL_ACTION_NAME = "search_data_sources";
 
 /**
  * TimeFrame parsing

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -160,7 +160,7 @@ export class RetrievalAction extends BaseAction {
 
     return {
       id: this.functionCallId ?? `call_${this.id.toString()}`,
-      name: this.functionCallName ?? "search_data_sources",
+      name: this.functionCallName ?? DEFAULT_RETRIEVAL_ACTION_NAME,
       arguments: JSON.stringify(params),
     };
   }
@@ -196,7 +196,7 @@ export class RetrievalAction extends BaseAction {
 
     return {
       role: "function" as const,
-      name: this.functionCallName ?? "search_data_sources",
+      name: this.functionCallName ?? DEFAULT_RETRIEVAL_ACTION_NAME,
       function_call_id: this.functionCallId ?? `call_${this.id.toString()}`,
       content,
     };
@@ -206,6 +206,7 @@ export class RetrievalAction extends BaseAction {
 /**
  * Params generation.
  */
+export const DEFAULT_RETRIEVAL_ACTION_NAME = "search_data_sources";
 
 export class RetrievalConfigurationServerRunner extends BaseActionConfigurationServerRunner<RetrievalConfigurationType> {
   async buildSpecification(
@@ -215,7 +216,7 @@ export class RetrievalConfigurationServerRunner extends BaseActionConfigurationS
       description,
     }: {
       name: string;
-      description?: string | undefined;
+      description: string | null;
     }
   ): Promise<Result<AgentActionSpecification, Error>> {
     // Generates the action specification for generation of rawInputs passed to `runRetrieval`.
@@ -249,11 +250,14 @@ export class RetrievalConfigurationServerRunner extends BaseActionConfigurationS
       }
     })();
 
-    const actionDescription = `${baseDescription}\nDescription of the data sources:\n${description}`;
+    let actionDescription = `${baseDescription}`;
+    if (description) {
+      actionDescription += `\nDescription of the data sources:\n${description}`;
+    }
 
     const spec = retrievalActionSpecification({
       actionConfiguration,
-      name,
+      name: name,
       description: actionDescription,
     });
 
@@ -273,7 +277,7 @@ export class RetrievalConfigurationServerRunner extends BaseActionConfigurationS
 
     const spec = retrievalActionSpecification({
       actionConfiguration,
-      name: "search_data_sources",
+      name: DEFAULT_RETRIEVAL_ACTION_NAME,
       description:
         "Search the data sources specified by the user." +
         " The search is based on semantic similarity between the query and chunks of information" +

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -39,6 +39,8 @@ import { frontSequelize } from "@app/lib/resources/storage";
 import { rand } from "@app/lib/utils/seeded_random";
 import logger from "@app/logger/logger";
 
+export const DEFAULT_RETRIEVAL_ACTION_NAME = "search_data_sources";
+
 /**
  * TimeFrame parsing
  */
@@ -206,7 +208,6 @@ export class RetrievalAction extends BaseAction {
 /**
  * Params generation.
  */
-export const DEFAULT_RETRIEVAL_ACTION_NAME = "search_data_sources";
 
 export class RetrievalConfigurationServerRunner extends BaseActionConfigurationServerRunner<RetrievalConfigurationType> {
   async buildSpecification(

--- a/front/lib/api/assistant/actions/runners.ts
+++ b/front/lib/api/assistant/actions/runners.ts
@@ -71,8 +71,8 @@ export const ACTION_TYPE_TO_CONFIGURATION_SERVER_RUNNER: {
       CombinedMap[K]["configType"]
     >;
 } = {
-  dust_app_run_configuration: DustAppRunConfigurationServerRunner,
   process_configuration: ProcessConfigurationServerRunner,
+  dust_app_run_configuration: DustAppRunConfigurationServerRunner,
   tables_query_configuration: TablesQueryConfigurationServerRunner,
   websearch_configuration: WebsearchConfigurationServerRunner,
   browse_configuration: BrowseConfigurationServerRunner,

--- a/front/lib/api/assistant/actions/tables_query.ts
+++ b/front/lib/api/assistant/actions/tables_query.ts
@@ -162,7 +162,7 @@ export class TablesQueryConfigurationServerRunner extends BaseActionConfiguratio
     }
 
     const spec = await tablesQueryActionSpecification({
-      name: name,
+      name,
       description: actionDescription,
     });
     return new Ok(spec);

--- a/front/lib/api/assistant/actions/tables_query.ts
+++ b/front/lib/api/assistant/actions/tables_query.ts
@@ -60,7 +60,7 @@ export class TablesQueryAction extends BaseAction {
   renderForFunctionCall(): FunctionCallType {
     return {
       id: this.functionCallId ?? `call_${this.id.toString()}`,
-      name: this.functionCallName ?? "query_tables",
+      name: this.functionCallName ?? DEFAULT_TABLES_QUERY_ACTION_NAME,
       arguments: JSON.stringify(this.params),
     };
   }
@@ -77,7 +77,7 @@ export class TablesQueryAction extends BaseAction {
 
     return {
       role: "function" as const,
-      name: this.functionCallName ?? "query_tables",
+      name: this.functionCallName ?? DEFAULT_TABLES_QUERY_ACTION_NAME,
       function_call_id: this.functionCallId ?? `call_${this.id.toString()}`,
       content,
     };
@@ -143,24 +143,27 @@ async function tablesQueryActionSpecification({
 /**
  * Action execution.
  */
+export const DEFAULT_TABLES_QUERY_ACTION_NAME = "query_tables";
 
 export class TablesQueryConfigurationServerRunner extends BaseActionConfigurationServerRunner<TablesQueryConfigurationType> {
   async buildSpecification(
     auth: Authenticator,
-    { name, description }: { name: string; description: string }
+    { name, description }: { name: string; description: string | null }
   ): Promise<Result<AgentActionSpecification, Error>> {
     const owner = auth.workspace();
     if (!owner) {
       throw new Error("Unexpected unauthenticated call to `runQueryTables`");
     }
 
-    const actionDescription =
+    let actionDescription =
       "Query data tables specificied by the user by executing a generated SQL query from a" +
-      " natural language question.\n" +
-      `Description of the data tables:\n${description}`;
+      " natural language question.";
+    if (description) {
+      actionDescription += `\nDescription of the data tables:\n${description}`;
+    }
 
     const spec = await tablesQueryActionSpecification({
-      name,
+      name: name,
       description: actionDescription,
     });
     return new Ok(spec);
@@ -179,7 +182,7 @@ export class TablesQueryConfigurationServerRunner extends BaseActionConfiguratio
       " natural language question.";
 
     const spec = await tablesQueryActionSpecification({
-      name: "query_tables",
+      name: DEFAULT_TABLES_QUERY_ACTION_NAME,
       description: actionDescription,
     });
     return new Ok(spec);

--- a/front/lib/api/assistant/actions/tables_query.ts
+++ b/front/lib/api/assistant/actions/tables_query.ts
@@ -20,14 +20,13 @@ import {
 } from "@dust-tt/types";
 
 import { runActionStreamed } from "@app/lib/actions/server";
+import { DEFAULT_TABLES_QUERY_ACTION_NAME } from "@app/lib/api/assistant/actions/names";
 import type { BaseActionRunParams } from "@app/lib/api/assistant/actions/types";
 import { BaseActionConfigurationServerRunner } from "@app/lib/api/assistant/actions/types";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentTablesQueryAction } from "@app/lib/models/assistant/actions/tables_query";
 import { sanitizeJSONOutput } from "@app/lib/utils";
 import logger from "@app/logger/logger";
-
-export const DEFAULT_TABLES_QUERY_ACTION_NAME = "query_tables";
 
 interface TablesQueryActionBlob {
   id: ModelId; // AgentTablesQueryAction.

--- a/front/lib/api/assistant/actions/tables_query.ts
+++ b/front/lib/api/assistant/actions/tables_query.ts
@@ -27,6 +27,8 @@ import { AgentTablesQueryAction } from "@app/lib/models/assistant/actions/tables
 import { sanitizeJSONOutput } from "@app/lib/utils";
 import logger from "@app/logger/logger";
 
+export const DEFAULT_TABLES_QUERY_ACTION_NAME = "query_tables";
+
 interface TablesQueryActionBlob {
   id: ModelId; // AgentTablesQueryAction.
   agentMessageId: ModelId;
@@ -143,8 +145,6 @@ async function tablesQueryActionSpecification({
 /**
  * Action execution.
  */
-export const DEFAULT_TABLES_QUERY_ACTION_NAME = "query_tables";
-
 export class TablesQueryConfigurationServerRunner extends BaseActionConfigurationServerRunner<TablesQueryConfigurationType> {
   async buildSpecification(
     auth: Authenticator,

--- a/front/lib/api/assistant/actions/types.ts
+++ b/front/lib/api/assistant/actions/types.ts
@@ -58,7 +58,7 @@ export abstract class BaseActionConfigurationServerRunner<
   // Action rendering.
   abstract buildSpecification(
     auth: Authenticator,
-    { name, description }: { name?: string; description?: string }
+    { name, description }: { name: string | null; description: string | null }
   ): Promise<Result<AgentActionSpecification, Error>>;
 
   abstract deprecatedBuildSpecificationForSingleActionAgent(

--- a/front/lib/api/assistant/actions/websearch.ts
+++ b/front/lib/api/assistant/actions/websearch.ts
@@ -21,13 +21,12 @@ import {
 import { isLeft } from "fp-ts/lib/Either";
 
 import { runActionStreamed } from "@app/lib/actions/server";
+import { DEFAULT_WEBSEARCH_ACTION_NAME } from "@app/lib/api/assistant/actions/names";
 import type { BaseActionRunParams } from "@app/lib/api/assistant/actions/types";
 import { BaseActionConfigurationServerRunner } from "@app/lib/api/assistant/actions/types";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentWebsearchAction } from "@app/lib/models/assistant/actions/websearch";
 import logger from "@app/logger/logger";
-
-export const DEFAULT_WEBSEARCH_ACTION_NAME = "web_search";
 
 interface WebsearchActionBlob {
   id: ModelId; // AgentWebsearchAction

--- a/front/lib/api/assistant/actions/websearch.ts
+++ b/front/lib/api/assistant/actions/websearch.ts
@@ -100,7 +100,7 @@ export class WebsearchConfigurationServerRunner extends BaseActionConfigurationS
     }
 
     return new Ok({
-      name: name,
+      name,
       description:
         description || "Perform a web search and return the top results.",
       inputs: [

--- a/front/lib/api/assistant/actions/websearch.ts
+++ b/front/lib/api/assistant/actions/websearch.ts
@@ -60,7 +60,7 @@ export class WebsearchAction extends BaseAction {
   renderForFunctionCall(): FunctionCallType {
     return {
       id: this.functionCallId ?? `call_${this.id.toString()}`,
-      name: this.functionCallName ?? "web_search",
+      name: this.functionCallName ?? DEFAULT_WEBSEARCH_ACTION_NAME,
       arguments: JSON.stringify({ query: this.query }),
     };
   }
@@ -75,7 +75,7 @@ export class WebsearchAction extends BaseAction {
 
     return {
       role: "function" as const,
-      name: this.functionCallName ?? "web_search",
+      name: this.functionCallName ?? DEFAULT_WEBSEARCH_ACTION_NAME,
       function_call_id: this.functionCallId ?? `call_${this.id.toString()}`,
       content,
     };
@@ -85,14 +85,12 @@ export class WebsearchAction extends BaseAction {
 /**
  * Params generation.
  */
+export const DEFAULT_WEBSEARCH_ACTION_NAME = "web_search";
 
 export class WebsearchConfigurationServerRunner extends BaseActionConfigurationServerRunner<WebsearchConfigurationType> {
   async buildSpecification(
     auth: Authenticator,
-    {
-      name,
-      description,
-    }: { name?: string | undefined; description?: string | undefined }
+    { name, description }: { name: string; description: string | null }
   ): Promise<Result<AgentActionSpecification, Error>> {
     const owner = auth.workspace();
     if (!owner) {
@@ -102,9 +100,9 @@ export class WebsearchConfigurationServerRunner extends BaseActionConfigurationS
     }
 
     return new Ok({
-      name: name ?? "web_search",
+      name: name,
       description:
-        description ?? "Perform a web search and return the top results.",
+        description || "Perform a web search and return the top results.",
       inputs: [
         {
           name: "query",
@@ -118,7 +116,10 @@ export class WebsearchConfigurationServerRunner extends BaseActionConfigurationS
   async deprecatedBuildSpecificationForSingleActionAgent(
     auth: Authenticator
   ): Promise<Result<AgentActionSpecification, Error>> {
-    return this.buildSpecification(auth, {});
+    return this.buildSpecification(auth, {
+      name: DEFAULT_WEBSEARCH_ACTION_NAME,
+      description: null,
+    });
   }
 
   // This method is in charge of running the websearch and creating an AgentWebsearchAction object in

--- a/front/lib/api/assistant/actions/websearch.ts
+++ b/front/lib/api/assistant/actions/websearch.ts
@@ -27,6 +27,8 @@ import type { Authenticator } from "@app/lib/auth";
 import { AgentWebsearchAction } from "@app/lib/models/assistant/actions/websearch";
 import logger from "@app/logger/logger";
 
+export const DEFAULT_WEBSEARCH_ACTION_NAME = "web_search";
+
 interface WebsearchActionBlob {
   id: ModelId; // AgentWebsearchAction
   agentMessageId: ModelId;
@@ -85,7 +87,6 @@ export class WebsearchAction extends BaseAction {
 /**
  * Params generation.
  */
-export const DEFAULT_WEBSEARCH_ACTION_NAME = "web_search";
 
 export class WebsearchConfigurationServerRunner extends BaseActionConfigurationServerRunner<WebsearchConfigurationType> {
   async buildSpecification(

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -360,13 +360,11 @@ export async function* runMultiActionsAgent(
 
   const specifications: AgentActionSpecification[] = [];
   for (const a of availableActions) {
-    const specRes = await getRunnerforActionConfiguration(a).buildSpecification(
-      auth,
-      {
-        name: a.name,
-        description: a.description,
-      }
-    );
+    const runner = getRunnerforActionConfiguration(a);
+    const specRes = await runner.buildSpecification(auth, {
+      name: a.name,
+      description: a.description,
+    });
 
     if (specRes.isErr()) {
       logger.error(

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -360,123 +360,61 @@ export async function* runMultiActionsAgent(
 
   const specifications: AgentActionSpecification[] = [];
   for (const a of availableActions) {
-    if (a.name && a.description) {
-      // Normal case, it's a multi-actions agent.
-
-      const runner = getRunnerforActionConfiguration(a);
-      const specRes = await runner.buildSpecification(auth, {
+    const specRes = await getRunnerforActionConfiguration(a).buildSpecification(
+      auth,
+      {
         name: a.name,
         description: a.description,
-      });
-
-      if (specRes.isErr()) {
-        logger.error(
-          {
-            workspaceId: conversation.owner.sId,
-            conversationId: conversation.sId,
-            error: specRes.error,
-          },
-          "Failed to build the specification for action."
-        );
-        yield {
-          type: "agent_error",
-          created: Date.now(),
-          configurationId: agentConfiguration.sId,
-          messageId: agentMessage.sId,
-          error: {
-            code: "build_spec_error",
-            message: `Failed to build the specification for action ${a.sId},`,
-          },
-        } satisfies AgentErrorEvent;
-
-        return;
       }
-      specifications.push(specRes.value);
-    } else {
-      // Special case for legacy single-action agents that have never been edited in
-      // multi-actions mode.
-      // We tolerate missing name/description to preserve support for legacy single-action agents.
-      // In those cases, we use the name/description from the legacy spec.
+    );
 
-      if (!a.name && availableActions.length > 1) {
-        // We can't allow not having a name if there are multiple actions.
-        yield {
-          type: "agent_error",
-          created: Date.now(),
-          configurationId: agentConfiguration.sId,
-          messageId: agentMessage.sId,
-          error: {
-            code: "missing_name",
-            message: `Action ${a.sId} is missing a name`,
-          },
-        } satisfies AgentErrorEvent;
+    if (specRes.isErr()) {
+      logger.error(
+        {
+          workspaceId: conversation.owner.sId,
+          conversationId: conversation.sId,
+          error: specRes.error,
+        },
+        "Failed to build the specification for action."
+      );
+      yield {
+        type: "agent_error",
+        created: Date.now(),
+        configurationId: agentConfiguration.sId,
+        messageId: agentMessage.sId,
+        error: {
+          code: "build_spec_error",
+          message: `Failed to build the specification for action ${a.sId},`,
+        },
+      } satisfies AgentErrorEvent;
 
-        return;
-      }
-
-      const runner = getRunnerforActionConfiguration(a);
-      const legacySpecRes =
-        await runner.deprecatedBuildSpecificationForSingleActionAgent(auth);
-      if (legacySpecRes.isErr()) {
-        logger.error(
-          {
-            workspaceId: conversation.owner.sId,
-            conversationId: conversation.sId,
-            error: legacySpecRes.error,
-          },
-          "Failed to build the legacy specification for action."
-        );
-        yield {
-          type: "agent_error",
-          created: Date.now(),
-          configurationId: agentConfiguration.sId,
-          messageId: agentMessage.sId,
-          error: {
-            code: "build_legacy_spec_error",
-            message: `Failed to build the legacy specification for action ${a.sId},`,
-          },
-        } satisfies AgentErrorEvent;
-
-        return;
-      }
-
-      const specRes = await runner.buildSpecification(auth, {
-        name: a.name ?? "",
-        description: a.description ?? "",
-      });
-
-      if (specRes.isErr()) {
-        logger.error(
-          {
-            workspaceId: conversation.owner.sId,
-            conversationId: conversation.sId,
-            error: specRes.error,
-          },
-          "Failed to build the specification for action."
-        );
-        yield {
-          type: "agent_error",
-          created: Date.now(),
-          configurationId: agentConfiguration.sId,
-          messageId: agentMessage.sId,
-          error: {
-            code: "build_spec_error",
-            message: `Failed to build the specification for action ${a.sId},`,
-          },
-        } satisfies AgentErrorEvent;
-
-        return;
-      }
-
-      const spec = specRes.value;
-      if (!a.name) {
-        spec.name = legacySpecRes.value.name;
-      }
-      if (!a.description) {
-        spec.description = legacySpecRes.value.description;
-      }
-      specifications.push(spec);
+      return;
     }
+    specifications.push(specRes.value);
+  }
+
+  // Check that specifications[].name are unique. This can happen if the user overrides two actions
+  // names with the same name (advanced settings). We return an actionable error if that's the case
+  // as we want to keep that as an invariant when interacting with models.
+  const seen = new Set<string>();
+  for (const spec of specifications) {
+    if (seen.has(spec.name)) {
+      yield {
+        type: "agent_error",
+        created: Date.now(),
+        configurationId: agentConfiguration.sId,
+        messageId: agentMessage.sId,
+        error: {
+          code: "duplicate_specification_name",
+          message:
+            `Duplicate action name in assistant configuration: ${spec.name}. ` +
+            "Your assistants actions must have unique names.",
+        },
+      } satisfies AgentErrorEvent;
+
+      return;
+    }
+    seen.add(spec.name);
   }
 
   const config = cloneBaseConfig(

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -29,11 +29,13 @@ import * as _ from "lodash";
 import type { Order, Transaction } from "sequelize";
 import { Op, Sequelize, UniqueConstraintError } from "sequelize";
 
-import { DEFAULT_BROWSE_ACTION_NAME } from "@app/lib/api/assistant/actions/browse";
-import { DEFAULT_PROCESS_ACTION_NAME } from "@app/lib/api/assistant/actions/process";
-import { DEFAULT_RETRIEVAL_ACTION_NAME } from "@app/lib/api/assistant/actions/retrieval";
-import { DEFAULT_TABLES_QUERY_ACTION_NAME } from "@app/lib/api/assistant/actions/tables_query";
-import { DEFAULT_WEBSEARCH_ACTION_NAME } from "@app/lib/api/assistant/actions/websearch";
+import {
+  DEFAULT_BROWSE_ACTION_NAME,
+  DEFAULT_PROCESS_ACTION_NAME,
+  DEFAULT_RETRIEVAL_ACTION_NAME,
+  DEFAULT_TABLES_QUERY_ACTION_NAME,
+  DEFAULT_WEBSEARCH_ACTION_NAME,
+} from "@app/lib/api/assistant/actions/names";
 import {
   getGlobalAgents,
   isGlobalAgentId,

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -7,6 +7,7 @@ import type {
   AgentsGetViewType,
   AgentStatus,
   AgentUserListStatus,
+  AppType,
   DataSourceConfiguration,
   LightAgentConfigurationType,
   ModelId,
@@ -28,6 +29,11 @@ import * as _ from "lodash";
 import type { Order, Transaction } from "sequelize";
 import { Op, Sequelize, UniqueConstraintError } from "sequelize";
 
+import { DEFAULT_BROWSE_ACTION_NAME } from "@app/lib/api/assistant/actions/browse";
+import { DEFAULT_PROCESS_ACTION_NAME } from "@app/lib/api/assistant/actions/process";
+import { DEFAULT_RETRIEVAL_ACTION_NAME } from "@app/lib/api/assistant/actions/retrieval";
+import { DEFAULT_TABLES_QUERY_ACTION_NAME } from "@app/lib/api/assistant/actions/tables_query";
+import { DEFAULT_WEBSEARCH_ACTION_NAME } from "@app/lib/api/assistant/actions/websearch";
 import {
   getGlobalAgents,
   isGlobalAgentId,
@@ -560,7 +566,7 @@ async function fetchWorkspaceAgentConfigurationsForView(
               },
             };
           }),
-          name: retrievalConfig.name,
+          name: retrievalConfig.name || DEFAULT_RETRIEVAL_ACTION_NAME,
           description: retrievalConfig.description,
         });
       }
@@ -593,7 +599,7 @@ async function fetchWorkspaceAgentConfigurationsForView(
           id: websearchConfig.id,
           sId: websearchConfig.sId,
           type: "websearch_configuration",
-          name: websearchConfig.name,
+          name: websearchConfig.name || DEFAULT_WEBSEARCH_ACTION_NAME,
           description: websearchConfig.description,
         });
       }
@@ -604,7 +610,7 @@ async function fetchWorkspaceAgentConfigurationsForView(
           id: browseConfig.id,
           sId: browseConfig.sId,
           type: "browse_configuration",
-          name: browseConfig.name,
+          name: browseConfig.name || DEFAULT_BROWSE_ACTION_NAME,
           description: browseConfig.description,
         });
       }
@@ -622,7 +628,7 @@ async function fetchWorkspaceAgentConfigurationsForView(
             workspaceId: tablesQueryConfigTable.dataSourceWorkspaceId,
             tableId: tablesQueryConfigTable.tableId,
           })),
-          name: tablesQueryConfig.name,
+          name: tablesQueryConfig.name || DEFAULT_TABLES_QUERY_ACTION_NAME,
           description: tablesQueryConfig.description,
         });
       }
@@ -655,7 +661,7 @@ async function fetchWorkspaceAgentConfigurationsForView(
                 }
               : null,
           schema: processConfig.schema,
-          name: processConfig.name,
+          name: processConfig.name || DEFAULT_PROCESS_ACTION_NAME,
           description: processConfig.description,
         });
       }
@@ -1135,6 +1141,7 @@ export async function createAgentActionConfiguration(
         type: "dust_app_run_configuration";
         appWorkspaceId: string;
         appId: string;
+        app: AppType;
       }
     | {
         type: "tables_query_configuration";
@@ -1206,7 +1213,7 @@ export async function createAgentActionConfiguration(
           relativeTimeFrame: action.relativeTimeFrame,
           topK: action.topK,
           dataSources: action.dataSources,
-          name: action.name,
+          name: action.name || DEFAULT_RETRIEVAL_ACTION_NAME,
           description: action.description,
         };
       });
@@ -1225,8 +1232,8 @@ export async function createAgentActionConfiguration(
         type: "dust_app_run_configuration",
         appWorkspaceId: action.appWorkspaceId,
         appId: action.appId,
-        name: action.name,
-        description: action.description,
+        name: action.app.name,
+        description: action.app.description,
       };
     }
     case "tables_query_configuration": {
@@ -1259,7 +1266,7 @@ export async function createAgentActionConfiguration(
           sId: tablesQueryConfig.sId,
           type: "tables_query_configuration",
           tables: action.tables,
-          name: action.name,
+          name: action.name || DEFAULT_TABLES_QUERY_ACTION_NAME,
           description: action.description,
         };
       });
@@ -1300,7 +1307,7 @@ export async function createAgentActionConfiguration(
           tagsFilter: action.tagsFilter,
           schema: action.schema,
           dataSources: action.dataSources,
-          name: action.name,
+          name: action.name || DEFAULT_PROCESS_ACTION_NAME,
           description: action.description,
         };
       });
@@ -1317,7 +1324,7 @@ export async function createAgentActionConfiguration(
         id: websearchConfig.id,
         sId: websearchConfig.sId,
         type: "websearch_configuration",
-        name: action.name,
+        name: action.name || DEFAULT_WEBSEARCH_ACTION_NAME,
         description: action.description,
       };
     }
@@ -1333,7 +1340,7 @@ export async function createAgentActionConfiguration(
         id: browseConfig.id,
         sId: browseConfig.sId,
         type: "browse_configuration",
-        name: action.name,
+        name: action.name || DEFAULT_BROWSE_ACTION_NAME,
         description: action.description,
       };
     }

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -31,7 +31,7 @@ import {
 } from "@dust-tt/types";
 import { DustAPI } from "@dust-tt/types";
 
-import { DEFAULT_RETRIEVAL_ACTION_NAME } from "@app/lib/api/assistant/actions/retrieval";
+import { DEFAULT_RETRIEVAL_ACTION_NAME } from "@app/lib/api/assistant/actions/names";
 import { GLOBAL_AGENTS_SID } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { prodAPICredentialsForOwner } from "@app/lib/auth";

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -31,6 +31,7 @@ import {
 } from "@dust-tt/types";
 import { DustAPI } from "@dust-tt/types";
 
+import { DEFAULT_RETRIEVAL_ACTION_NAME } from "@app/lib/api/assistant/actions/retrieval";
 import { GLOBAL_AGENTS_SID } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { prodAPICredentialsForOwner } from "@app/lib/auth";
@@ -632,7 +633,7 @@ async function _getManagedDataSourceAgent(
           workspaceId: prodCredentials.workspaceId,
           filter: { tags: null, parents: null },
         })),
-        name: "search_data_sources",
+        name: DEFAULT_RETRIEVAL_ACTION_NAME,
         description: `Search the user's ${connectorProvider} data sources.`,
       },
     ],
@@ -877,7 +878,7 @@ async function _getDustGlobalAgent(
           workspaceId: prodCredentials.workspaceId,
           filter: { tags: null, parents: null },
         })),
-        name: "search_data_sources",
+        name: DEFAULT_RETRIEVAL_ACTION_NAME,
         description: `Search the user's data sources.`,
       },
     ],

--- a/types/src/front/assistant/actions/browse.ts
+++ b/types/src/front/assistant/actions/browse.ts
@@ -6,8 +6,10 @@ import { BaseAction } from "../../lib/api/assistant/actions";
 export type BrowseConfigurationType = {
   id: ModelId;
   sId: string;
+
   type: "browse_configuration";
-  name: string | null;
+
+  name: string;
   description: string | null;
 };
 

--- a/types/src/front/assistant/actions/dust_app_run.ts
+++ b/types/src/front/assistant/actions/dust_app_run.ts
@@ -10,7 +10,7 @@ export type DustAppRunConfigurationType = {
   appWorkspaceId: string;
   appId: string;
 
-  name: string | null;
+  name: string;
   description: string | null;
 };
 

--- a/types/src/front/assistant/actions/process.ts
+++ b/types/src/front/assistant/actions/process.ts
@@ -55,7 +55,7 @@ export type ProcessConfigurationType = {
   tagsFilter: ProcessTagsFilter | null;
   schema: ProcessSchemaPropertyType[];
 
-  name: string | null;
+  name: string;
   description: string | null;
 };
 

--- a/types/src/front/assistant/actions/retrieval.ts
+++ b/types/src/front/assistant/actions/retrieval.ts
@@ -62,7 +62,7 @@ export type RetrievalConfigurationType = {
   relativeTimeFrame: RetrievalTimeframe;
   topK: number | "auto";
 
-  name: string | null;
+  name: string;
   description: string | null;
 };
 

--- a/types/src/front/assistant/actions/tables_query.ts
+++ b/types/src/front/assistant/actions/tables_query.ts
@@ -12,7 +12,7 @@ export type TablesQueryConfigurationType = {
     tableId: string;
   }>;
 
-  name: string | null;
+  name: string;
   description: string | null;
 };
 

--- a/types/src/front/assistant/actions/websearch.ts
+++ b/types/src/front/assistant/actions/websearch.ts
@@ -6,8 +6,10 @@ import { BaseAction } from "../../lib/api/assistant/actions";
 export type WebsearchConfigurationType = {
   id: ModelId;
   sId: string;
+
   type: "websearch_configuration";
-  name: string | null;
+
+  name: string;
   description: string | null;
 };
 


### PR DESCRIPTION
## Description

- Make `name` non optional and default to the right value when not present in DB.
- Simplify the rendering of legacy actions in multi-actions.
- Enforce that action names are unique before interacting with models.
- Replace hard-coded action names in various places by const variables `DEFAULT_*_ACTION_NAME`

## Risk

Low, mostly impacts multi-actions

## Deploy Plan

- deploy `front`