### PR TITLE
[Connectors] Infra: Set timeout to 60s for document CRUD

### DIFF
--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -22,6 +22,8 @@ import logger from "@connectors/logger/logger";
 import { statsDClient } from "@connectors/logger/withlogging";
 import type { DataSourceConfig } from "@connectors/types/data_source_config";
 
+axios.defaults.timeout = 60000;
+
 const { DUST_FRONT_API } = process.env;
 if (!DUST_FRONT_API) {
   throw new Error("FRONT_API not set");


### PR DESCRIPTION
Description
---
See issue about frequent socket hang ups
[here](https://github.com/dust-tt/tasks/issues/859)

Request that take long are squatting the server and causing lingerings and probably socket hang ups.

In general, having a non-infinite timeout and explicitely handling requests that take too long is good practice

Risk
---
We checked that 99.99% of requests finish before that.

Deploy
---
connectors
