### PR TITLE
[Github Connector] ExternalOauthError on installation not found

### DIFF
--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -274,7 +274,13 @@ export async function retrieveGithubConnectorPermissions({
     let nodes: ContentNode[] = [];
     let pageNumber = 1; // 1-indexed
     for (;;) {
-      const page = await getReposPage(githubInstallationId, pageNumber);
+      const pageRes = await getReposPage(githubInstallationId, pageNumber);
+
+      if (pageRes.isErr()) {
+        return new Err(pageRes.error);
+      }
+
+      const page = pageRes.value;
       pageNumber += 1;
       if (page.length === 0) {
         break;

--- a/connectors/src/connectors/github/temporal/activities.ts
+++ b/connectors/src/connectors/github/temporal/activities.ts
@@ -61,7 +61,11 @@ export async function githubGetReposResultPageActivity(
   }
 
   localLogger.info("Fetching GitHub repos result page.");
-  const page = await getReposPage(githubInstallationId, pageNumber);
+  const pageRes = await getReposPage(githubInstallationId, pageNumber);
+  if (pageRes.isErr()) {
+    throw pageRes.error;
+  }
+  const page = pageRes.value;
   return page.map((repo) => ({
     name: repo.name,
     id: repo.id,


### PR DESCRIPTION
Description
---
Improves error reporting when ocktokit reports installation not found.

Previous situation was we get blasted with Not Found unhandled errors such as [here](https://app.datadoghq.eu/logs?query=%22Unhandled%20activity%20error%22%20service%3Aconnectors-worker%20&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=paused&source=monitor_notif&storage=hot&stream_sort=desc&viz=stream&from_ts=1718458200000&to_ts=1718462100000&live=false)

Now, they are cast as usual ExternalOauthToken error. They will trigger failed activity monitor if we really can't get hold on installation

Next step could be to delete the connector completely after a few retries (since we need to be extra-sure before deleting the client's connector)

Risk & deploy
---
na