### PR TITLE
[Webcrawler] Better url validation

### DIFF
--- a/front/lib/webcrawler.ts
+++ b/front/lib/webcrawler.ts
@@ -35,11 +35,16 @@ export function isUrlValid(url: string) {
     if (url.trim().length === 0) {
       return false;
     }
-    const u = new URL(url);
-    if (u.protocol !== "http:" && u.protocol !== "https:") {
-      return false;
-    }
-    return true;
+    const urlValidationRegex = new RegExp(
+      "^(https?:\\/\\/)?" + // validate protocol
+        "((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|" + // validate domain name
+        "((\\d{1,3}\\.){3}\\d{1,3}))" + // validate OR ip (v4) address
+        "(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*" + // validate port and path
+        "(\\?[;&a-z\\d%_.~+=-]*)?" + // validate query string
+        "(\\#[-a-z\\d_]*)?$",
+      "i"
+    ); // validate fragment locator
+    return urlValidationRegex.test(url);
   } catch (e) {
     return false;
   }

--- a/front/lib/webcrawler.ts
+++ b/front/lib/webcrawler.ts
@@ -30,20 +30,21 @@ export function urlToDataSourceName(url: string) {
   }
 }
 
+const urlValidationRegex = new RegExp(
+  "^(https?:\\/\\/)?" + // validate protocol
+    "((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|" + // validate domain name
+    "((\\d{1,3}\\.){3}\\d{1,3}))" + // validate OR ip (v4) address
+    "(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*" + // validate port and path
+    "(\\?[;&a-z\\d%_.~+=-]*)?" + // validate query string
+    "(\\#[-a-z\\d_]*)?$",
+  "i"
+); // validate fragment locator
+
 export function isUrlValid(url: string) {
   try {
     if (url.trim().length === 0) {
       return false;
     }
-    const urlValidationRegex = new RegExp(
-      "^(https?:\\/\\/)?" + // validate protocol
-        "((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|" + // validate domain name
-        "((\\d{1,3}\\.){3}\\d{1,3}))" + // validate OR ip (v4) address
-        "(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*" + // validate port and path
-        "(\\?[;&a-z\\d%_.~+=-]*)?" + // validate query string
-        "(\\#[-a-z\\d_]*)?$",
-      "i"
-    ); // validate fragment locator
     return urlValidationRegex.test(url);
   } catch (e) {
     return false;


### PR DESCRIPTION
Description
---
Previously url was validated using `new URL`, which is very permissive, e.g. `new URL("https://Je suis casséééééee")` would pass at valid

Crawlee has a much stricter url validation, so we get swiftly activity errors when crawling, such as
[here](https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E19%20%40dd.service%3Aconnectors-worker%20&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AgAAAZAfH6beqdtz7QAAAAAAAAAYAAAAAEFaQWZINnAzQUFCVjlhR3N2UEhiNXdBQgAAACQAAAAAMDE5MDFmMjgtMmQ5YS00ZDkzLWJhNmYtYThlN2QzYjY1YmRl&fromUser=true&messageDisplay=inline&refresh_mode=sliding&source=monitor_notif&storage=hot&stream_sort=desc&viz=stream&from_ts=1718505564620&to_ts=1718519964620&live=true)

This PR enforces a stricter url validation to avoid this. Most likely, our users don't want to input an url that we can't crawl.

Risk & deploy
---
na