### PR TITLE
[Notion] Improve handling of start_cursor errors

### DIFF
--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -326,7 +326,7 @@ export async function getPagesAndDatabasesToSync({
       switch (e.code) {
         case "internal_server_error":
         case "validation_error":
-          if (Context.current().info.attempt > 20) {
+          if (Context.current().info.attempt > 14) {
             localLogger.error(
               {
                 error: e,

--- a/connectors/src/connectors/notion/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/notion/temporal/cast_known_errors.ts
@@ -46,6 +46,13 @@ export class NotionCastKnownErrorsInterceptor
               "transient_upstream_activity_error",
               err
             );
+          case APIErrorCode.ValidationError:
+            throw new ProviderWorkflowError(
+              "notion",
+              "Validation Error",
+              "transient_upstream_activity_error",
+              err
+            );
         }
       } else if (UnknownHTTPResponseError.isUnknownHTTPResponseError(err)) {
         if ([502, 504, 530].includes(err.status)) {


### PR DESCRIPTION
Description
---
We sometimes get invalid start_cursor from notion. This is a known error with behaviour already handled in code.

However:
a. those errors were not cast as known, triggering "Unhandled" monitors sometimes 

b. handling happened after 20 failures while now the activity failure monitor triggers at 15.

This PR fixes both issues

Risk & deploy
---
na