### PR TITLE
[Dust apps] Datasets - always validate an input of type "string"

### DIFF
--- a/front/components/app/DatasetView.tsx
+++ b/front/components/app/DatasetView.tsx
@@ -18,7 +18,8 @@ import dynamic from "next/dynamic";
 import { useEffect, useRef, useState } from "react";
 import TextareaAutosize from "react-textarea-autosize";
 
-import { checkDatasetData } from "@app/lib/datasets";
+import type { DatasetDataType } from "@app/lib/datasets";
+import { checkDatasetData, DATASET_DATA_TYPES } from "@app/lib/datasets";
 import { getDatasetTypes, getValueType } from "@app/lib/datasets";
 import { MODELS_STRING_MAX_LENGTH } from "@app/lib/utils";
 import { classNames } from "@app/lib/utils";
@@ -206,7 +207,7 @@ export default function DatasetView({
   const [datasetKeyDescriptions, setDatasetKeyDescriptions] = useState<
     string[]
   >((schema || []).map((s) => s.description || ""));
-  const [datasetTypes, setDatasetTypes] = useState<string[]>([]);
+  const [datasetTypes, setDatasetTypes] = useState<DatasetDataType[]>([]);
   const [datasetInitializing, setDatasetInitializing] = useState(true);
 
   const datasetNameValidation = () => {
@@ -237,6 +238,16 @@ export default function DatasetView({
     return valid;
   };
 
+  function isTypeValidForDataset(
+    enteredType: DatasetDataType,
+    desiredType: DatasetDataType
+  ): boolean {
+    if (desiredType === "string") {
+      return true;
+    }
+    return enteredType === desiredType;
+  }
+
   const datasetTypesValidation = () => {
     // Initial inference of types
     if (datasetTypes.length == 0) {
@@ -244,16 +255,15 @@ export default function DatasetView({
     }
 
     // Check that all types are valid
-    let valid = true;
-    datasetData.map((d) => {
-      datasetKeys.map((k) => {
-        if (getValueType(d[k]) !== datasetTypes[datasetKeys.indexOf(k)]) {
-          valid = false;
-        }
-      });
+    return datasetData.some((d) => {
+      datasetKeys.some(
+        (k) =>
+          !isTypeValidForDataset(
+            getValueType(d[k]),
+            datasetTypes[datasetKeys.indexOf(k)]
+          )
+      );
     });
-
-    return valid;
   };
 
   // Export the dataset with correct types (post-editing and validation)
@@ -625,28 +635,26 @@ export default function DatasetView({
                         </span>
                       ) : (
                         <div className="inline-flex" role="group">
-                          {["string", "number", "boolean", "json"].map(
-                            (type) => (
-                              <button
-                                key={type}
-                                type="button"
-                                disabled={readOnly}
-                                className={classNames(
-                                  datasetTypes && datasetTypes[j] == type
-                                    ? "font-semibold text-gray-900 underline underline-offset-4"
-                                    : "font-normal text-gray-700 hover:text-gray-900",
-                                  "font-mono px-1 py-1 text-[13px]"
-                                )}
-                                onClick={() => {
-                                  const types = [...datasetTypes];
-                                  types[j] = type;
-                                  setDatasetTypes(types);
-                                }}
-                              >
-                                {type == "json" ? "JSON" : type}
-                              </button>
-                            )
-                          )}
+                          {DATASET_DATA_TYPES.map((type) => (
+                            <button
+                              key={type}
+                              type="button"
+                              disabled={readOnly}
+                              className={classNames(
+                                datasetTypes && datasetTypes[j] == type
+                                  ? "font-semibold text-gray-900 underline underline-offset-4"
+                                  : "font-normal text-gray-700 hover:text-gray-900",
+                                "font-mono px-1 py-1 text-[13px]"
+                              )}
+                              onClick={() => {
+                                const types = [...datasetTypes];
+                                types[j] = type;
+                                setDatasetTypes(types);
+                              }}
+                            >
+                              {type == "json" ? "JSON" : type}
+                            </button>
+                          ))}
                         </div>
                       )}
                     </div>
@@ -719,8 +727,10 @@ export default function DatasetView({
                             "font-mono col-span-7 inline-grid resize-none space-y-0 border bg-slate-100 px-0 py-0 text-[13px]",
                             d[k] === "" ||
                               !datasetTypes[datasetKeys.indexOf(k)] ||
-                              getValueType(d[k]) ===
+                              isTypeValidForDataset(
+                                getValueType(d[k]),
                                 datasetTypes[datasetKeys.indexOf(k)]
+                              )
                               ? "border-slate-100"
                               : "border-red-500"
                           )}

--- a/front/components/app/DatasetView.tsx
+++ b/front/components/app/DatasetView.tsx
@@ -255,13 +255,12 @@ export default function DatasetView({
     }
 
     // Check that all types are valid
-    return datasetData.some((d) => {
-      datasetKeys.some(
-        (k) =>
-          !isTypeValidForDataset(
-            getValueType(d[k]),
-            datasetTypes[datasetKeys.indexOf(k)]
-          )
+    return datasetData.every((d) => {
+      datasetKeys.every((k) =>
+        isTypeValidForDataset(
+          getValueType(d[k]),
+          datasetTypes[datasetKeys.indexOf(k)]
+        )
       );
     });
   };

--- a/front/lib/datasets.ts
+++ b/front/lib/datasets.ts
@@ -51,16 +51,15 @@ export function checkDatasetData({
   return Object.keys(data[0]);
 }
 
-export function getDatasetTypes(
-  datasetKeys: string[],
-  entry: DatasetEntry
-): ("string" | "number" | "boolean" | "json")[] {
-  return datasetKeys.map((key) => getValueType(entry[key]));
-}
+export const DATASET_DATA_TYPES = [
+  "string",
+  "number",
+  "boolean",
+  "json",
+] as const;
+export type DatasetDataType = (typeof DATASET_DATA_TYPES)[number];
 
-export function getValueType(
-  value: any
-): "string" | "number" | "boolean" | "json" {
+export function getValueType(value: any): DatasetDataType {
   const type = typeof value;
 
   if (type === "object") {
@@ -85,4 +84,11 @@ export function getValueType(
   }
 
   return "string";
+}
+
+export function getDatasetTypes(
+  datasetKeys: string[],
+  entry: DatasetEntry
+): DatasetDataType[] {
+  return datasetKeys.map((key) => getValueType(entry[key]));
 }


### PR DESCRIPTION
Description
---
Previously, if an integer was input in a string field of a dataset, there would be an error; see e.g. [here](https://dust4ai.slack.com/archives/C050SM8NSPK/p1718628817078719)

All that can be typed by the user here is a valid string and should be accepted as such. This PR takes care of that

Also adds some typing

Risk
---
Low: simple change, restricted to dataset creation

Deploy
---
front
