### PR TITLE
Safer streaming chunk parsing in Slack

### DIFF
--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -125,9 +125,10 @@ export async function streamConversationToSlack(
         }
         lastSentDate = new Date();
 
-        const finalAnswer = slackifyMarkdown(
-          normalizeContentForSlack(annotateCitations(fullAnswer, action))
-        );
+        const finalAnswer = safelyPrepareAnswer(fullAnswer, action);
+        if (!finalAnswer) {
+          break;
+        }
 
         // if the message is too long, we avoid the update entirely (to reduce
         // rate limiting) the previous update will have shown the "..." and the
@@ -172,6 +173,26 @@ export async function streamConversationToSlack(
   }
 
   return new Err(new Error("Failed to get the final answer from Dust"));
+}
+
+/**
+ * Safely prepare the answer by normalizing the content for Slack and converting it to Markdown.
+ * In streaming mode, partial links might trigger errors in the `slackifyMarkdown` function.
+ * This function handles such errors gracefully, ensuring that the full text will be displayed
+ * once a valid URL is available.
+ */
+function safelyPrepareAnswer(
+  text: string,
+  action: AgentActionType | null
+): string | null {
+  const rawAnswer = normalizeContentForSlack(annotateCitations(text, action));
+
+  try {
+    return slackifyMarkdown(rawAnswer);
+  } catch (err) {
+    // It's safe to swallow the error as we'll catch up once a valid URL is fully received.
+    return null;
+  }
 }
 
 function normalizeContentForSlack(content: string): string {

--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -126,6 +126,7 @@ export async function streamConversationToSlack(
         lastSentDate = new Date();
 
         const finalAnswer = safelyPrepareAnswer(fullAnswer, action);
+        // If the answer cannot be prepared safely, skip processing these tokens.
         if (!finalAnswer) {
           break;
         }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR addresses an issue with our assistants that occasionally return excessively long URLs (e.g [logs](https://app.datadoghq.eu/logs?query=%22Unexpected%20exception%20answering%20to%20Slack%20Chat%20Bot%20message%22%20&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AgAAAZAndbmc-662hgAAAAAAAAAYAAAAAEFaQW5kY2tMQUFCTjdxU1VZdXVxZ1FBVwAAACQAAAAAMDE5MDI3N2QtYTczZS00N2E2LWE4MGItZjg0YmZiMDE2YmE4&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1718637645151&to_ts=1718652045151&live=true)). In stream mode, chunks are processed that can temporarily render the URL invalid. One of our dependencies, which converts markdown to Slack-flavored markdown, is particularly sensitive to these issues and fails to decode any broken URLs without a straightforward method to ignore them.

This PR introduces a try/catch wrapper around this call to catch and ignore the error. This approach is specifically applied to the `generation_tokens` where broken URIs might occur. It's generally safe because streaming will continue once a valid URL is obtained. In the worst case, no updates are sent until the very end when we receive the `agent_generation_success` notification, but this is still an improvement over the current behavior.

Faulty code is [here](https://github.com/jsarafajr/slackify-markdown/blob/43e4a38132c78cbe2693a7702a6f869f98c8ee64/src/utils.js#L19C20-L19C38).

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
