### PR TITLE
[Connectors] Table upserts moved to front upsert queue

### DIFF
--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -497,6 +497,7 @@ export async function upsertTableFromCsv({
     csv: tableCsv,
     tableId,
     truncate,
+    async: true,
   };
   const dustRequestConfig: AxiosRequestConfig = {
     headers: {

--- a/front/lib/temporal_monitoring.ts
+++ b/front/lib/temporal_monitoring.ts
@@ -18,7 +18,8 @@ export interface ContextWithLogger extends Context {
 
 export type WorkflowErrorType =
   | "unhandled_internal_activity_error"
-  | "upsert_queue_upsert_error";
+  | "upsert_queue_upsert_document_error"
+  | "upsert_queue_upsert_table_error";
 
 export type WorkflowError = {
   type: WorkflowErrorType;

--- a/front/lib/upsert_document.ts
+++ b/front/lib/upsert_document.ts
@@ -21,10 +21,8 @@ import { getDocumentsPostUpsertHooksToRun } from "@app/lib/documents_post_proces
 import logger from "@app/logger/logger";
 import { statsDClient } from "@app/logger/withlogging";
 import { launchRunPostUpsertHooksWorkflow } from "@app/temporal/documents_post_process_hooks/client";
-import {
-  launchUpsertDocumentWorkflow,
-  launchUpsertTableWorkflow,
-} from "@app/temporal/upsert_queue/client";
+import type { launchUpsertTableWorkflow } from "@app/temporal/upsert_queue/client";
+import { launchUpsertDocumentWorkflow } from "@app/temporal/upsert_queue/client";
 
 const { DUST_UPSERT_QUEUE_BUCKET, SERVICE_ACCOUNT } = process.env;
 

--- a/front/lib/upsert_document.ts
+++ b/front/lib/upsert_document.ts
@@ -49,10 +49,14 @@ export const EnqueueUpsertTable = t.type({
   truncate: t.boolean,
 });
 
+type EnqueueUpsertDocumentType = t.TypeOf<typeof EnqueueUpsertDocument>;
+
+type EnqueueUpsertTableType = t.TypeOf<typeof EnqueueUpsertTable>;
+
 export async function enqueueUpsertDocument({
   upsertDocument,
 }: {
-  upsertDocument: t.TypeOf<typeof EnqueueUpsertDocument>;
+  upsertDocument: EnqueueUpsertDocumentType;
 }): Promise<Result<string, Error>> {
   const upsertQueueId = uuidv4();
 
@@ -77,7 +81,7 @@ export async function enqueueUpsertDocument({
 export async function enqueueUpsertTable({
   upsertTable,
 }: {
-  upsertTable: t.TypeOf<typeof EnqueueUpsertTable>;
+  upsertTable: EnqueueUpsertTableType;
 }): Promise<Result<string, Error>> {
   const upsertQueueId = uuidv4();
 

--- a/front/lib/upsert_document.ts
+++ b/front/lib/upsert_document.ts
@@ -21,8 +21,10 @@ import { getDocumentsPostUpsertHooksToRun } from "@app/lib/documents_post_proces
 import logger from "@app/logger/logger";
 import { statsDClient } from "@app/logger/withlogging";
 import { launchRunPostUpsertHooksWorkflow } from "@app/temporal/documents_post_process_hooks/client";
-import type { launchUpsertTableWorkflow } from "@app/temporal/upsert_queue/client";
-import { launchUpsertDocumentWorkflow } from "@app/temporal/upsert_queue/client";
+import {
+  launchUpsertDocumentWorkflow,
+  launchUpsertTableWorkflow,
+} from "@app/temporal/upsert_queue/client";
 
 const { DUST_UPSERT_QUEUE_BUCKET, SERVICE_ACCOUNT } = process.env;
 
@@ -99,7 +101,7 @@ export async function enqueueUpsertTable({
   return enqueueUpsert({
     upsertItem: upsertTable,
     upsertQueueId,
-    launchWorkflowFn: launchUpsertDocumentWorkflow,
+    launchWorkflowFn: launchUpsertTableWorkflow,
   });
 }
 
@@ -109,12 +111,12 @@ async function enqueueUpsert({
   launchWorkflowFn,
 }:
   | {
-      upsertItem: t.TypeOf<typeof EnqueueUpsertDocument>;
+      upsertItem: EnqueueUpsertDocumentType;
       upsertQueueId: string;
       launchWorkflowFn: typeof launchUpsertDocumentWorkflow;
     }
   | {
-      upsertItem: t.TypeOf<typeof EnqueueUpsertTable>;
+      upsertItem: EnqueueUpsertTableType;
       upsertQueueId: string;
       launchWorkflowFn: typeof launchUpsertTableWorkflow;
     }): Promise<Result<string, Error>> {

--- a/front/lib/upsert_document.ts
+++ b/front/lib/upsert_document.ts
@@ -64,7 +64,7 @@ export async function enqueueUpsertDocument({
       documentId: upsertDocument.documentId,
       enqueueTimestamp: Date.now(),
     },
-    "[UpsertQueue] Enqueueing item"
+    "[UpsertQueue] Enqueueing document"
   );
 
   return enqueueUpsert({
@@ -89,7 +89,7 @@ export async function enqueueUpsertTable({
       documentId: upsertTable.tableId,
       enqueueTimestamp: Date.now(),
     },
-    "[UpsertQueue] Enqueueing item"
+    "[UpsertQueue] Enqueueing table"
   );
 
   return enqueueUpsert({

--- a/front/pages/api/w/[wId]/data_sources/[name]/tables/csv.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/tables/csv.ts
@@ -7,7 +7,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { getDataSource } from "@app/lib/api/data_sources";
 import { upsertTableFromCsv } from "@app/lib/api/tables";
 import { Authenticator, getSession } from "@app/lib/auth";
-import { enqueueUpsertDocument } from "@app/lib/upsert_document";
+import { enqueueUpsertTable } from "@app/lib/upsert_document";
 import { generateModelSId } from "@app/lib/utils";
 import { apiError, withLogging } from "@app/logger/withlogging";
 
@@ -161,8 +161,8 @@ export async function handlePostTableCsvUpsertRequest(
   const tableId = bodyValidation.right.tableId ?? generateModelSId();
 
   if (async) {
-    const enqueueRes = await enqueueUpsertDocument({
-      upsertDocument: {
+    const enqueueRes = await enqueueUpsertTable({
+      upsertTable: {
         workspaceId: owner.sId,
         projectId: dataSource.dustAPIProjectId,
         dataSourceName,

--- a/front/pages/api/w/[wId]/data_sources/[name]/tables/csv.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/tables/csv.ts
@@ -24,7 +24,7 @@ export const UpsertTableFromCsvSchema = t.intersection([
     name: SlugifiedString,
     description: t.string,
     truncate: t.boolean,
-    async: t.boolean,
+    async: t.union([t.boolean, t.undefined]),
   }),
   // csv is optional when editing an existing table.
   t.union([

--- a/front/pages/api/w/[wId]/data_sources/[name]/tables/csv.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/tables/csv.ts
@@ -24,6 +24,7 @@ export const UpsertTableFromCsvSchema = t.intersection([
     name: SlugifiedString,
     description: t.string,
     truncate: t.boolean,
+    async: t.boolean,
   }),
   // csv is optional when editing an existing table.
   t.union([

--- a/front/pages/api/w/[wId]/data_sources/[name]/tables/csv.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/tables/csv.ts
@@ -196,7 +196,7 @@ export async function handlePostTableCsvUpsertRequest(
   }
 
   const tableRes = await upsertTableFromCsv({
-    owner,
+    auth,
     projectId: dataSource.dustAPIProjectId,
     dataSourceName,
     tableName: name,

--- a/front/pages/api/w/[wId]/data_sources/[name]/tables/csv.ts
+++ b/front/pages/api/w/[wId]/data_sources/[name]/tables/csv.ts
@@ -7,9 +7,9 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { getDataSource } from "@app/lib/api/data_sources";
 import { upsertTableFromCsv } from "@app/lib/api/tables";
 import { Authenticator, getSession } from "@app/lib/auth";
+import { enqueueUpsertDocument } from "@app/lib/upsert_document";
 import { generateModelSId } from "@app/lib/utils";
 import { apiError, withLogging } from "@app/logger/withlogging";
-import { enqueueUpsertDocument } from "@app/lib/upsert_document";
 
 export const config = {
   api: {

--- a/front/pages/w/[wId]/builder/data-sources/[name]/tables/upsert.tsx
+++ b/front/pages/w/[wId]/builder/data-sources/[name]/tables/upsert.tsx
@@ -244,6 +244,7 @@ export default function TableUpsert({
           csv: fileContent,
           tableId: loadTableId ?? undefined,
           truncate: true,
+          async: false,
         };
       } else if (tableId) {
         body = {
@@ -252,6 +253,7 @@ export default function TableUpsert({
           tableId: tableId,
           csv: undefined,
           truncate: false,
+          async: false,
         };
       } else {
         throw new Error("Unreachable: fileContent is null");

--- a/front/temporal/upsert_queue/activities.ts
+++ b/front/temporal/upsert_queue/activities.ts
@@ -9,7 +9,7 @@ import { Authenticator } from "@app/lib/auth";
 import type { WorkflowError } from "@app/lib/temporal_monitoring";
 import {
   EnqueueUpsertDocument,
-  EnqueueUpsertTableFromCsv,
+  EnqueueUpsertTable,
   runPostUpsertHooks,
 } from "@app/lib/upsert_document";
 import mainLogger from "@app/logger/logger";
@@ -168,7 +168,7 @@ export async function upsertTableActivity(
 
   const upsertDocument = JSON.parse(content.toString());
 
-  const tableItemValidation = EnqueueUpsertTableFromCsv.decode(upsertDocument);
+  const tableItemValidation = EnqueueUpsertTable.decode(upsertDocument);
 
   if (isLeft(tableItemValidation)) {
     const pathErrorTable = reporter.formatValidationErrors(

--- a/front/temporal/upsert_queue/activities.ts
+++ b/front/temporal/upsert_queue/activities.ts
@@ -1,9 +1,11 @@
 import { CoreAPI, dustManagedCredentials } from "@dust-tt/types";
 import { Storage } from "@google-cloud/storage";
-import { isLeft, isRight } from "fp-ts/lib/Either";
+import { isRight } from "fp-ts/lib/Either";
+import type * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
-import * as t from "io-ts";
+
 import { getDataSource } from "@app/lib/api/data_sources";
+import { upsertTableFromCsv } from "@app/lib/api/tables";
 import { Authenticator } from "@app/lib/auth";
 import type { WorkflowError } from "@app/lib/temporal_monitoring";
 import {
@@ -13,7 +15,6 @@ import {
 } from "@app/lib/upsert_document";
 import mainLogger from "@app/logger/logger";
 import { statsDClient } from "@app/logger/withlogging";
-import { upsertTableFromCsv } from "@app/lib/api/tables";
 
 const { DUST_UPSERT_QUEUE_BUCKET, SERVICE_ACCOUNT } = process.env;
 
@@ -38,14 +39,14 @@ export async function upsertDocumentActivity(
   const tableItemValidation = EnqueueUpsertTableFromCsv.decode(upsertDocument);
 
   if (isRight(documentItemValidation)) {
-    return await upsertDocumentItem(
+    return upsertDocumentItem(
       documentItemValidation.right,
       upsertQueueId,
       enqueueTimestamp
     );
   }
   if (isRight(tableItemValidation)) {
-    return await upsertTableItem(
+    return upsertTableItem(
       tableItemValidation.right,
       upsertQueueId,
       enqueueTimestamp

--- a/front/temporal/upsert_queue/activities.ts
+++ b/front/temporal/upsert_queue/activities.ts
@@ -1,6 +1,6 @@
 import { CoreAPI, dustManagedCredentials } from "@dust-tt/types";
 import { Storage } from "@google-cloud/storage";
-import { isRight } from "fp-ts/lib/Either";
+import { isLeft } from "fp-ts/lib/Either";
 import type * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 
@@ -38,14 +38,14 @@ export async function upsertDocumentActivity(
   const documentItemValidation = EnqueueUpsertDocument.decode(upsertDocument);
   const tableItemValidation = EnqueueUpsertTableFromCsv.decode(upsertDocument);
 
-  if (isRight(documentItemValidation)) {
+  if (!isLeft(documentItemValidation)) {
     return upsertDocumentItem(
       documentItemValidation.right,
       upsertQueueId,
       enqueueTimestamp
     );
   }
-  if (isRight(tableItemValidation)) {
+  if (!isLeft(tableItemValidation)) {
     return upsertTableItem(
       tableItemValidation.right,
       upsertQueueId,
@@ -224,7 +224,7 @@ async function upsertTableItem(
   const upsertTimestamp = Date.now();
 
   const tableRes = await upsertTableFromCsv({
-    owner,
+    auth,
     projectId: dataSource.dustAPIProjectId,
     dataSourceName: dataSource.name,
     tableName: upsertQueueItem.tableName,

--- a/front/temporal/upsert_queue/activities.ts
+++ b/front/temporal/upsert_queue/activities.ts
@@ -129,9 +129,9 @@ async function upsertDocumentItem(
       },
       "[UpsertQueue] Failed upsert"
     );
-    statsDClient.increment("upsert_queue_error.count", 1, statsDTags);
+    statsDClient.increment("upsert_queue_document_error.count", 1, statsDTags);
     statsDClient.distribution(
-      "upsert_queue_upsert_error.duration.distribution",
+      "upsert_queue_upsert_document_error.duration.distribution",
       Date.now() - upsertTimestamp,
       []
     );
@@ -139,7 +139,7 @@ async function upsertDocumentItem(
     const error: WorkflowError = {
       __is_dust_error: true,
       message: `Upsert error: ${upsertRes.error.message}`,
-      type: "upsert_queue_upsert_error",
+      type: "upsert_queue_upsert_document_error",
     };
 
     throw error;
@@ -152,14 +152,14 @@ async function upsertDocumentItem(
     },
     "[UpsertQueue] Successful upsert"
   );
-  statsDClient.increment("upsert_queue_success.count", 1, statsDTags);
+  statsDClient.increment("upsert_queue_document_success.count", 1, statsDTags);
   statsDClient.distribution(
-    "upsert_queue_upsert_success.duration.distribution",
+    "upsert_queue_upsert_document_success.duration.distribution",
     Date.now() - upsertTimestamp,
     []
   );
   statsDClient.distribution(
-    "upsert_queue.duration.distribution",
+    "upsert_queue_document.duration.distribution",
     Date.now() - enqueueTimestamp,
     []
   );
@@ -243,9 +243,9 @@ async function upsertTableItem(
       },
       "[UpsertQueue] Failed upsert"
     );
-    statsDClient.increment("upsert_queue_error.count", 1, statsDTags);
+    statsDClient.increment("upsert_queue_table_error.count", 1, statsDTags);
     statsDClient.distribution(
-      "upsert_queue_upsert_error.duration.distribution",
+      "upsert_queue_upsert_table_error.duration.distribution",
       Date.now() - upsertTimestamp,
       []
     );
@@ -253,7 +253,7 @@ async function upsertTableItem(
     const error: WorkflowError = {
       __is_dust_error: true,
       message: `Upsert error: ${JSON.stringify(tableRes.error)}`,
-      type: "upsert_queue_upsert_error",
+      type: "upsert_queue_upsert_table_error",
     };
 
     throw error;
@@ -266,14 +266,14 @@ async function upsertTableItem(
     },
     "[UpsertQueue] Successful upsert"
   );
-  statsDClient.increment("upsert_queue_success.count", 1, statsDTags);
+  statsDClient.increment("upsert_queue_table_success.count", 1, statsDTags);
   statsDClient.distribution(
-    "upsert_queue_upsert_success.duration.distribution",
+    "upsert_queue_upsert_table_success.duration.distribution",
     Date.now() - upsertTimestamp,
     []
   );
   statsDClient.distribution(
-    "upsert_queue.duration.distribution",
+    "upsert_queue_table.duration.distribution",
     Date.now() - enqueueTimestamp,
     []
   );

--- a/front/temporal/upsert_queue/client.ts
+++ b/front/temporal/upsert_queue/client.ts
@@ -5,7 +5,7 @@ import { getTemporalClient } from "@app/lib/temporal";
 import logger from "@app/logger/logger";
 
 import { QUEUE_NAME } from "./config";
-import { upsertDocumentWorkflow } from "./workflows";
+import { upsertDocumentWorkflow, upsertTableWorkflow } from "./workflows";
 
 export async function launchUpsertDocumentWorkflow({
   workspaceId,
@@ -24,6 +24,51 @@ export async function launchUpsertDocumentWorkflow({
 
   try {
     await client.workflow.start(upsertDocumentWorkflow, {
+      args: [upsertQueueId, enqueueTimestamp],
+      taskQueue: QUEUE_NAME,
+      workflowId: workflowId,
+      memo: {
+        workspaceId,
+        dataSourceName,
+        upsertQueueId,
+      },
+    });
+    logger.info(
+      {
+        workflowId,
+      },
+      `Started workflow.`
+    );
+    return new Ok(workflowId);
+  } catch (e) {
+    logger.error(
+      {
+        workflowId,
+        error: e,
+      },
+      `Failed starting workflow.`
+    );
+    return new Err(e as Error);
+  }
+}
+
+export async function launchUpsertTableWorkflow({
+  workspaceId,
+  dataSourceName,
+  upsertQueueId,
+  enqueueTimestamp,
+}: {
+  workspaceId: string;
+  dataSourceName: string;
+  upsertQueueId: string;
+  enqueueTimestamp: number;
+}): Promise<Result<string, Error>> {
+  const client = await getTemporalClient();
+
+  const workflowId = `upsert-queue-table-${workspaceId}-${dataSourceName}-${upsertQueueId}`;
+
+  try {
+    await client.workflow.start(upsertTableWorkflow, {
       args: [upsertQueueId, enqueueTimestamp],
       taskQueue: QUEUE_NAME,
       workflowId: workflowId,

--- a/front/temporal/upsert_queue/client.ts
+++ b/front/temporal/upsert_queue/client.ts
@@ -37,7 +37,7 @@ export async function launchUpsertDocumentWorkflow({
       {
         workflowId,
       },
-      `Started workflow.`
+      "Started workflow."
     );
     return new Ok(workflowId);
   } catch (e) {
@@ -46,7 +46,7 @@ export async function launchUpsertDocumentWorkflow({
         workflowId,
         error: e,
       },
-      `Failed starting workflow.`
+      "Failed starting workflow."
     );
     return new Err(e as Error);
   }
@@ -82,7 +82,7 @@ export async function launchUpsertTableWorkflow({
       {
         workflowId,
       },
-      `Started workflow.`
+      "Started workflow."
     );
     return new Ok(workflowId);
   } catch (e) {
@@ -91,7 +91,7 @@ export async function launchUpsertTableWorkflow({
         workflowId,
         error: e,
       },
-      `Failed starting workflow.`
+      "Failed starting workflow."
     );
     return new Err(e as Error);
   }

--- a/front/temporal/upsert_queue/workflows.ts
+++ b/front/temporal/upsert_queue/workflows.ts
@@ -2,8 +2,10 @@ import { proxyActivities } from "@temporalio/workflow";
 
 import type * as activities from "@app/temporal/upsert_queue/activities";
 
-const { upsertDocumentActivity } = proxyActivities<typeof activities>({
-  startToCloseTimeout: "10 minutes",
+const { upsertDocumentActivity, upsertTableActivity } = proxyActivities<
+  typeof activities
+>({
+  startToCloseTimeout: "20 minutes",
 });
 
 export async function upsertDocumentWorkflow(
@@ -11,4 +13,11 @@ export async function upsertDocumentWorkflow(
   enqueueTimestamp: number
 ) {
   await upsertDocumentActivity(upsertQueueId, enqueueTimestamp);
+}
+
+export async function upsertTableWorkflow(
+  upsertQueueId: string,
+  enqueueTimestamp: number
+) {
+  await upsertTableActivity(upsertQueueId, enqueueTimestamp);
 }

--- a/front/temporal/upsert_queue/workflows.ts
+++ b/front/temporal/upsert_queue/workflows.ts
@@ -2,9 +2,11 @@ import { proxyActivities } from "@temporalio/workflow";
 
 import type * as activities from "@app/temporal/upsert_queue/activities";
 
-const { upsertDocumentActivity, upsertTableActivity } = proxyActivities<
-  typeof activities
->({
+const { upsertDocumentActivity } = proxyActivities<typeof activities>({
+  startToCloseTimeout: "10 minutes",
+});
+
+const { upsertTableActivity } = proxyActivities<typeof activities>({
   startToCloseTimeout: "20 minutes",
 });
 


### PR DESCRIPTION
Description
---
This PR provides ability to upsert table via front upsert queue, similarly to other documents, by passing `async: true` to the request.

Requests to `v1` API (so, most importantly those from connectors) are set to use the front upsert queue. Requests made from people using dust (e.g. when adding csv in datasource) are kept sync.

Connectors table insertion frequently led to timeout/connection loss errors since on large tables upsertion can take long, and we upsert the table at each edit. Example [here](https://app.datadoghq.eu/logs?query=%22Error%20uploading%20structured%20data%20to%20Dust%22%20%22Unhandled%22%20&agg_m=count&agg_m_source=base&agg_q=%40error.request._currentRequest._contentLength&agg_q_source=base&agg_t=count&analyticsOptions=%5B%22bars%22%2C%22dog_classic%22%2Cnull%2Cnull%5D&cols=service%2C%40workflowName%2C%40activityName%2C%40error.__is_dust_error&fromUser=true&messageDisplay=inline&refresh_mode=sliding&saved-view-id=99803&storage=hot&stream_sort=%40duration%2Cdesc&top_n=10&top_o=top&viz=stream&x_missing=true&from_ts=1718683581640&to_ts=1718697981640)

As such, by moving upsertion to front upsert queue, this PR fixes https://github.com/dust-tt/tasks/issues/859 

Risk
---
Change is not complex but touches doucument upsertion, blast radius large. Will test in local that:
- documents are still correctly upserted (insertion and edition)
- tables are still correctly upserted (insertion and edition)
- on google drive and notion

Deploy
---
- deploy front
- update dashboard & metrics in datadog
- deploy connectors.

