### PR TITLE
[Temporary] Swallow error uploading structured data

### DIFF
--- a/connectors/src/lib/temporal_monitoring.ts
+++ b/connectors/src/lib/temporal_monitoring.ts
@@ -153,7 +153,12 @@ export class ActivityInboundLogInterceptor
       const durationMs = new Date().getTime() - startTime.getTime();
       if (error) {
         let errorType = "unhandled_internal_activity_error";
-        if (error instanceof DustConnectorWorkflowError) {
+        if (
+          error instanceof DustConnectorWorkflowError ||
+          // temporary swallow during fix
+          // TODO(pr, 2024-06-18) remove the temporary swallow
+          error.message.includes("Error uploading structured data to Dust")
+        ) {
           // This is a Dust error.
           errorType = error.type;
           this.logger.error(


### PR DESCRIPTION
Description
---
Temporary swallow of "Error uploading structured data" for the day They add too much noise and make the eng runner job hell Those Errors will be properly handled by #5695 and this PR will be reverted by EOD

Of course, any real issue there would be caught by the activity monitor anyways

Risk
---
- We are confident those errors do not directly affect production, so a temporary swallow is ok
- This is temporary and will be reverted by EOD
- I will take responsibility for it
