### PR TITLE
Flav/improve slack error handling

### DIFF
--- a/connectors/src/connectors/slack/chat/blocks.ts
+++ b/connectors/src/connectors/slack/chat/blocks.ts
@@ -2,6 +2,15 @@ import { truncate } from "@dust-tt/types";
 
 import type { SlackMessageFootnotes } from "@connectors/connectors/slack/chat/citations";
 
+/*
+ * This length threshold is set to prevent the "msg_too_long" error
+ * from the Slack API's chat.update method.
+ * According to previous incidents, the maximum length for a message is 3000 characters.
+ * We adopt a conservative approach by setting a lower threshold
+ * to accommodate ellipses and ensure buffer space.
+ */
+export const MAX_SLACK_MESSAGE_LENGTH = 2950;
+
 function makeConversationLinkContextBlock(conversationUrl: string) {
   return {
     type: "context",
@@ -37,7 +46,7 @@ function makeMarkdownBlock(text: string) {
     type: "section",
     text: {
       type: "mrkdwn",
-      text,
+      text: truncate(text, MAX_SLACK_MESSAGE_LENGTH),
     },
   };
 }
@@ -96,7 +105,7 @@ export function makeMessageUpdateBlocksAndText(
     ],
     // TODO(2024-06-17 flav) We should not return markdown here.
     // Provide plain text for places where the content cannot be rendered (e.g push notifications).
-    text: isThinking ? "Thinking..." : text,
+    text: isThinking ? "Thinking..." : truncate(text, MAX_SLACK_MESSAGE_LENGTH),
     mrkdwn: true,
   };
 }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR partially fixes https://github.com/dust-tt/tasks/issues/596.

We observed some Slack errors when posting an answer to a Slack message.

This PR aims at fixing two of those:
1. `msg_too_long`: We made the assumptions that a soft limit for the maximum text length was 3000. Looking at the recent [logs](https://app.datadoghq.eu/logs?query=host%3Aconnectors-deployment-7bb89d864d-zvc7n%20service%3Aconnectors%20container_id%3A5f48bc33b4219e8667ce039ac73fa027978b206016f61c5196296b898e7c731d%20filename%3A0.log&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&context_event=AZAmJp-mAACZuOOVZzTzyAAP&event=&fromUser=true&index=%2A&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&to_event=AgAAAZAmJqkR8Y0VLAAAAAAAAAAYAAAAAEFaQW1Kck5wQUFEeWJBUjNDS01JdmdBSwAAACQAAAAAMDE5MDI2NzMtMjZkNS00NGUzLTlmZWQtZDFlMTQ5Y2I5MmFi&viz=&from_ts=1718626683253&to_ts=1718626986258&live=false), it fails when text is longer than 3000 characters. In this PR we update the limit to a more conservative limit.
2. `rate_limited`: Even though we did not observe them yet. The `chat.update` call is [limited](https://api.slack.com/methods/chat.update) to Slack's Tier 3 rate limit (50 calls/minute per workspace). This PR implements a linear backoff mechanism to display the first few tokens quickly before slowing down the pace.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
