### PR TITLE
Multi-action into tools

### DIFF
--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -481,7 +481,7 @@ function DustAppSection({
   const { app } = useApp({ workspaceId: owner.sId, appId: dustApp.appId });
   return (
     <div className="flex flex-col gap-2">
-      <div>The following action is run before answering:</div>
+      <div>The following tool is run before answering:</div>
       <div className="flex items-center gap-2 capitalize">
         <div>
           <CommandLineIcon />

--- a/front/components/assistant/conversation/actions/AgentMessageActions.tsx
+++ b/front/components/assistant/conversation/actions/AgentMessageActions.tsx
@@ -91,7 +91,7 @@ function ActionDetails({
   ) : (
     <Button
       size={size === "normal" ? "sm" : "xs"}
-      label="View Actions Details"
+      label="Inspect the tools used"
       icon={EyeIcon}
       variant="tertiary"
       onClick={onClick}

--- a/front/components/assistant/conversation/actions/AgentMessageActionsDrawer.tsx
+++ b/front/components/assistant/conversation/actions/AgentMessageActionsDrawer.tsx
@@ -29,7 +29,7 @@ export function AgentMessageActionsDrawer({
     <Modal
       isOpen={isOpened}
       onClose={onClose}
-      title="Actions Details"
+      title="Breakdown of the tools used"
       variant="side-md"
       hasChanged={false}
     >

--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -1,8 +1,8 @@
 import {
+  BookOpenIcon,
   Button,
   CardButton,
   DropdownMenu,
-  Hoverable,
   Icon,
   IconButton,
   Input,
@@ -215,28 +215,21 @@ export default function ActionsScreen({
       <div className="flex flex-col gap-8 text-sm text-element-700">
         <div className="flex flex-col gap-4">
           <div className="flex flex-col gap-2">
-            <Page.Header title="Actions & Data sources" />
+            <Page.Header title="Tools & Data sources" />
             <Page.P>
               <span className="text-sm text-element-700">
-                Before replying, the assistant can perform multiple actions such
-                as <span className="font-bold">searching</span> in your Data
-                Sources or <span className="font-bold">navigate</span> the Web.
-                Learn more about mutli-actions assistants in the{" "}
-                <Hoverable
-                  onClick={() => {
-                    window.open(
-                      "https://dust-tt.notion.site/Multi-Actions-Assistants-7c08db0c9cad44559c166401e6afb7e6",
-                      "_blank"
-                    );
-                  }}
-                  className="cursor-pointer font-bold text-action-500"
-                >
-                  documentation
-                </Hoverable>
+                Configure the tools that your assistant is able to use, such as{" "}
+                <span className="font-bold">searching</span> in your Data
+                Sources or <span className="font-bold">navigating</span> the
+                Web.
+                <br />
+                Before replying, the assistant can use multiple of those tools
+                to gather information and provide you with the best possible
+                answer.
               </span>
             </Page.P>
           </div>
-          <div className="flex flex-row">
+          <div className="flex flex-row gap-2">
             {builderState.actions.length > 0 && (
               <div>
                 <AddAction
@@ -253,6 +246,18 @@ export default function ActionsScreen({
               </div>
             )}
             <div className="flex-grow" />
+            <Button
+              label="Read our guide"
+              size="sm"
+              variant="secondary"
+              icon={BookOpenIcon}
+              onClick={() => {
+                window.open(
+                  "https://dust-tt.notion.site/Multi-Actions-Assistants-7c08db0c9cad44559c166401e6afb7e6",
+                  "_blank"
+                );
+              }}
+            />
             <AdvancedSettings
               maxToolsUsePerRun={builderState.maxToolsUsePerRun}
               setMaxToolsUsePerRun={(maxToolsUsePerRun) => {
@@ -640,12 +645,12 @@ function ActionEditor({
                   <div className="flex flex-col gap-4">
                     <div className="flex flex-col items-end gap-2">
                       <div className="w-full grow text-sm font-bold text-element-800">
-                        Name of the action
+                        Name of the tool
                       </div>
                     </div>
                     <Input
                       name="actionName"
-                      placeholder="My action name.."
+                      placeholder="My tool name…"
                       value={action.name}
                       onChange={(v) => {
                         updateAction({
@@ -654,7 +659,11 @@ function ActionEditor({
                           getNewActionConfig: (old) => old,
                         });
                       }}
-                      error={!titleValid ? "Name already exists" : null}
+                      error={
+                        !titleValid
+                          ? "This name is already used for another tool. Please use a different name."
+                          : null
+                      }
                       className="text-sm"
                     />
                   </div>
@@ -696,14 +705,12 @@ function ActionEditor({
             </div>
           ) : (
             <div className="font-semibold text-element-800">
-              Action description
+              What is this tool about?
             </div>
           )}
           <TextArea
             placeholder={
-              isDataSourceAction
-                ? "This data contains...."
-                : "Action description.."
+              isDataSourceAction ? "This data contains…" : "This tool is about…"
             }
             value={action.description}
             onChange={(v) => {
@@ -743,7 +750,7 @@ function AdvancedSettings({
           <div className="flex flex-col gap-2">
             <div className="flex flex-col items-start justify-start">
               <div className="w-full grow text-sm font-bold text-element-800">
-                Max actions per run
+                Max tools per run
               </div>
               <div className="w-full grow text-sm text-element-600">
                 up to {MAX_TOOLS_USE_PER_RUN_LIMIT}
@@ -790,7 +797,7 @@ function AddAction({
   return (
     <DropdownMenu>
       <DropdownMenu.Button>
-        <Button variant="primary" label="Add an action" icon={PlusIcon} />
+        <Button variant="primary" label="Add a tool" icon={PlusIcon} />
       </DropdownMenu.Button>
       <DropdownMenu.Items origin="topLeft" width={320} overflow="visible">
         <DropdownMenu.SectionHeader label="DATA SOURCES" />

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -333,14 +333,16 @@ export default function AssistantBuilder({
   const [screen, setScreen] = useState<BuilderScreen>("instructions");
   const tabs = useMemo(
     () =>
-      Object.entries(BUILDER_SCREENS).map(([key, { label, icon }]) => ({
-        label,
-        current: screen === key,
-        onClick: () => {
-          setScreen(key as BuilderScreen);
-        },
-        icon,
-      })),
+      Object.entries(BUILDER_SCREENS).map(
+        ([key, { label, labelMultiActions, icon }]) => ({
+          label: multiActionsEnabled ? labelMultiActions : label,
+          current: screen === key,
+          onClick: () => {
+            setScreen(key as BuilderScreen);
+          },
+          icon,
+        })
+      ),
     [screen]
   );
   const modalTitle = agentConfigurationId

--- a/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
+++ b/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
@@ -196,6 +196,7 @@ export default function AssistantBuilderRightPanel({
                   resetToTemplateInstructions={resetToTemplateInstructions}
                   resetToTemplateActions={resetToTemplateActions}
                   openRightPanelTab={openRightPanelTab}
+                  multiActionsMode={multiActionsMode}
                 />
               </div>
               <Page.Separator />
@@ -211,7 +212,11 @@ export default function AssistantBuilderRightPanel({
               <div className="flex items-end justify-between pt-2">
                 <Page.Header
                   icon={LightbulbIcon}
-                  title="Template's Actions manual"
+                  title={
+                    multiActionsMode
+                      ? "Template's Tools manual"
+                      : "Template's Actions manual"
+                  }
                 />
                 <TemplateDropDownMenu
                   screen={screen}
@@ -219,6 +224,7 @@ export default function AssistantBuilderRightPanel({
                   resetToTemplateInstructions={resetToTemplateInstructions}
                   resetToTemplateActions={resetToTemplateActions}
                   openRightPanelTab={openRightPanelTab}
+                  multiActionsMode={multiActionsMode}
                 />
               </div>
               <Page.Separator />
@@ -239,7 +245,7 @@ export default function AssistantBuilderRightPanel({
                   multiActionsMode &&
                   template.presetActions.length > 0 && (
                     <div className="flex flex-col gap-6">
-                      <Page.SectionHeader title="Add those actions" />
+                      <Page.SectionHeader title="Add those tools" />
                       {template.presetActions.map((presetAction, index) => (
                         <div className="flex flex-col gap-2" key={index}>
                           <div>{presetAction.help}</div>
@@ -291,7 +297,7 @@ const TemplateAddActionButton = ({
     <div className="w-auto">
       <Button
         icon={spec.cardIcon}
-        label={`Add action “${spec.label}”`}
+        label={`Add tool “${spec.label}”`}
         size="sm"
         variant="secondary"
         onClick={() => addAction(action)}
@@ -306,12 +312,14 @@ const TemplateDropDownMenu = ({
   resetToTemplateInstructions,
   resetToTemplateActions,
   openRightPanelTab,
+  multiActionsMode,
 }: {
   screen: BuilderScreen;
   removeTemplate: () => Promise<void>;
   resetToTemplateInstructions: () => Promise<void>;
   resetToTemplateActions: () => Promise<void>;
   openRightPanelTab: (tabName: AssistantBuilderRightPanelTab) => void;
+  multiActionsMode: boolean;
 }) => {
   const confirm = useContext(ConfirmContext);
 
@@ -365,13 +373,18 @@ const TemplateDropDownMenu = ({
         )}
         {screen === "actions" && (
           <DropdownMenu.Item
-            label="Reset actions"
-            description="Set actions back to template's default"
+            label={multiActionsMode ? "Reset tools" : "Reset actions"}
+            description={
+              multiActionsMode
+                ? "Remove all tools"
+                : "Set actions back to template's default"
+            }
             onClick={async () => {
               const confirmed = await confirm({
                 title: "Are you sure?",
-                message:
-                  "You will lose the changes you have made to the assistant's actions and go back to the template's default settings.",
+                message: multiActionsMode
+                  ? "You will lose the changes you have made to the assistant's tools."
+                  : "You will lose the changes you have made to the assistant's actions and go back to the template's default settings.",
                 validateVariant: "primaryWarning",
               });
               if (confirmed) {

--- a/front/components/assistant_builder/actions/ProcessAction.tsx
+++ b/front/components/assistant_builder/actions/ProcessAction.tsx
@@ -333,7 +333,7 @@ export function ActionProcess({
     setEdited(true);
     let fullInstructions = `${instructions}`;
     if (description) {
-      fullInstructions += `\n\nAction description:\n${description}`;
+      fullInstructions += `\n\nTool description:\n${description}`;
     }
     if (instructions !== null) {
       setIsGeneratingSchema(true);
@@ -400,7 +400,7 @@ export function ActionProcess({
       />
 
       <div className="text-sm text-element-700">
-        This action scans selected data sources within the specified time frame,
+        This tool scans selected data sources within the specified time frame,
         extracting information based on a predefined schema. It can process the
         equivalent to a 1,000-page book (500k tokens). Learn more about this
         feature in the{" "}
@@ -525,19 +525,18 @@ export function ActionProcess({
 
       {onDescriptionChange && (
         <div className="flex flex-col gap-4 pt-8">
-          <div className="font-semibold text-element-800">
-            Action description
-          </div>
+          <div className="font-semibold text-element-800">Tool description</div>
           <div className="text-sm text-element-600">
-            Clarify what the action should do and what data it should extract.
-            For example:
+            Clarify what the tool should do and what data it should extract. For
+            example:
             <span className="block text-element-600">
               "Extract from the #reading slack channel a list of books,
-              including their title, author, and publication date".
+              including their title, author, and the reason why they were
+              recommended".
             </span>
           </div>
           <TextArea
-            placeholder={"Action description.."}
+            placeholder={"Extract the list of…"}
             value={description}
             onChange={onDescriptionChange}
             error={!isDescriptionValid ? "Description cannot be empty" : null}

--- a/front/components/assistant_builder/actions/WebNavigationAction.tsx
+++ b/front/components/assistant_builder/actions/WebNavigationAction.tsx
@@ -12,9 +12,9 @@ export function isActionWebsearchValid(
 export function ActionWebNavigation() {
   return (
     <div>
-      This action will perform a web search and/or browse a page content. It
-      will return the top results (title, link and summary) in case of a search,
-      and the page content if it browsed the page.
+      This tool will perform a web search and/or browse a page content. It will
+      return the top results (title, link and summary) in case of a search, and
+      the page content if it browsed the page.
     </div>
   );
 }

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -334,12 +334,14 @@ export type AssistantBuilderProps = {
 export const BUILDER_SCREENS = {
   instructions: {
     label: "Instructions",
+    labelMultiActions: "Instructions",
     icon: CircleIcon,
   },
   actions: {
     label: "Actions & Data sources",
+    labelMultiActions: "Tools & Data sources",
     icon: SquareIcon,
   },
-  naming: { label: "Naming", icon: TriangleIcon },
+  naming: { label: "Naming", labelMultiActions: "Naming", icon: TriangleIcon },
 };
 export type BuilderScreen = keyof typeof BUILDER_SCREENS;

--- a/front/pages/poke/templates/[tId].tsx
+++ b/front/pages/poke/templates/[tId].tsx
@@ -284,14 +284,14 @@ function PresetActionsField({
                   control={control}
                   // @ts-expect-error - TS doesn't like the dynamic key
                   name={`presetActions.${index}.name`}
-                  title="Action Name"
-                  placeholder="Action Name"
+                  title="Tool Name"
+                  placeholder="Tool Name"
                 />
                 <SelectField
                   control={control}
                   // @ts-expect-error - TS doesn't like the dynamic key
                   name={`presetActions.${index}.type`}
-                  title="Action Type"
+                  title="Tool Type"
                   options={Object.entries(MULTI_ACTION_PRESETS).map(
                     ([value, display]) => ({
                       value,
@@ -303,7 +303,7 @@ function PresetActionsField({
                   control={control}
                   // @ts-expect-error - TS doesn't like the dynamic key
                   name={`presetActions.${index}.description`}
-                  title="Action Description"
+                  title="Tool Description"
                   placeholder="Description of the action"
                   rows={5}
                 />
@@ -311,8 +311,8 @@ function PresetActionsField({
                   control={control}
                   // @ts-expect-error - TS doesn't like the dynamic key
                   name={`presetActions.${index}.help`}
-                  title="Help content for template"
-                  placeholder="Help text for the action"
+                  title="Tool Help content"
+                  placeholder="This is the text displayed on the template's sidebar just on top of the button to add the tool."
                   rows={5}
                 />
                 <PokeFormItem>
@@ -325,7 +325,7 @@ function PresetActionsField({
                         remove(index);
                       }}
                     >
-                      Remove Action
+                      Remove Tool
                     </PokeButton>
                   </div>
                 </PokeFormItem>
@@ -345,7 +345,7 @@ function PresetActionsField({
                 append(pendingAction);
               }}
             >
-              Add Action
+              Add Tool
             </PokeButton>
             <PokeFormMessage />
           </PokeFormItem>
@@ -764,7 +764,7 @@ function TemplatesPage({
             <PresetActionsField
               control={form.control}
               name="presetActions"
-              title="Preset Actions"
+              title="Preset Tools"
             />
 
             <div className="space flex gap-2">


### PR DESCRIPTION
## Description

Renaming actions per tool on multi-actions screens and modals. 
I changed the wording of this screen to fix some typos and hopefully be clearer, and I  put the link to the guide in a "secondary" button. 

Deployed to front-edge.

<kbd>
<img width="1041" alt="Screenshot 2024-06-18 at 11 10 22" src="https://github.com/dust-tt/dust/assets/3803406/3e61f997-e2b3-4f3f-ae74-dafe1f75dde1">
</kbd>

## Risk

Might have missed some places where we still use action.

## Deploy Plan

Deploy front; 
Update the Notion doc to reflect this change. 
