### PR TITLE
Find DB record from Notion URL

### DIFF
--- a/connectors/src/api/admin.ts
+++ b/connectors/src/api/admin.ts
@@ -16,6 +16,10 @@ const whitelistedCommands = [
     majorCommand: "notion",
     command: "check-url",
   },
+  {
+    majorCommand: "notion",
+    command: "find-url",
+  },
 ];
 
 const _adminAPIHandler = async (

--- a/connectors/src/connectors/notion/lib/cli.ts
+++ b/connectors/src/connectors/notion/lib/cli.ts
@@ -3,7 +3,7 @@ import { Client, isFullDatabase, isFullPage } from "@notionhq/client";
 import { Op } from "sequelize";
 
 import { getNotionAccessToken } from "@connectors/connectors/notion/temporal/activities";
-import { NotionDatabase } from "@connectors/lib/models/notion";
+import { NotionDatabase, NotionPage } from "@connectors/lib/models/notion";
 import mainLogger from "@connectors/logger/logger";
 
 import { getParsedDatabase, retrievePage } from "./notion_api";
@@ -54,6 +54,66 @@ export async function searchNotionPagesForQuery({
     isSkipped: p.object === "database" && skippedDatabaseIds.has(p.id),
     isFull: p.object === "database" ? isFullDatabase(p) : isFullPage(p),
   }));
+}
+
+export async function findNotionUrl({
+  connectorId,
+  url,
+}: {
+  connectorId: ModelId;
+  url: string;
+}) {
+  // parse URL
+  const u = new URL(url);
+  const last = u.pathname.split("/").pop();
+  if (!last) {
+    throw new Error(`Unhandled URL (could not get "last"): ${url}`);
+  }
+  const id = last.split("-").pop();
+  if (!id || id.length !== 32) {
+    throw new Error(`Unhandled URL (could not get 32 char ID): ${url}`);
+  }
+
+  const pageOrDbId =
+    id.slice(0, 8) +
+    "-" +
+    id.slice(8, 12) +
+    "-" +
+    id.slice(12, 16) +
+    "-" +
+    id.slice(16, 20) +
+    "-" +
+    id.slice(20);
+
+  const page = await NotionPage.findOne({
+    where: {
+      notionPageId: pageOrDbId,
+      connectorId,
+    },
+  });
+
+  if (page) {
+    logger.info({ pageOrDbId, url, page }, "Page found");
+    return { page, db: null };
+  } else {
+    logger.info({ pageOrDbId, url }, "Page not found");
+  }
+
+  const db = await NotionDatabase.findOne({
+    where: {
+      notionDatabaseId: pageOrDbId,
+      connectorId,
+    },
+  });
+
+  if (db) {
+    logger.info({ pageOrDbId, url, db }, "Database found");
+    return { page: null, db };
+  } else {
+    logger.info({ pageOrDbId, url }, "Database not found");
+  }
+
+  return { page: null, db: null };
 }
 
 export async function checkNotionUrl({

--- a/connectors/src/lib/cli.ts
+++ b/connectors/src/lib/cli.ts
@@ -64,6 +64,7 @@ import {
 } from "@connectors/connectors/intercom/lib/intercom_api";
 import {
   checkNotionUrl,
+  findNotionUrl,
   searchNotionPagesForQuery,
 } from "@connectors/connectors/notion/lib/cli";
 import { getNotionAccessToken } from "@connectors/connectors/notion/temporal/activities";
@@ -620,6 +621,26 @@ export const notion = async ({
       const r = await checkNotionUrl({
         connectorId: connector.id,
         connectionId: connector.connectionId,
+        url,
+      });
+
+      return r;
+    }
+
+    case "find-url": {
+      const { url, wId } = args;
+
+      if (!url) {
+        throw new Error("Missing --url argument");
+      }
+
+      const connector = await getConnectorOrThrow({
+        connectorType: "notion",
+        workspaceId: wId,
+      });
+
+      const r = await findNotionUrl({
+        connectorId: connector.id,
         url,
       });
 

--- a/front/pages/poke/[wId]/data_sources/[name]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[name]/index.tsx
@@ -388,8 +388,7 @@ const DataSourcePage = ({
           )}
           {dataSource.connectorProvider === "notion" && (
             <>
-              <NotionUrlCheckOrFind owner={owner} command={"check-url"} />
-              <NotionUrlCheckOrFind owner={owner} command={"find-url"} />
+              <NotionUrlCheckOrFind owner={owner} />
             </>
           )}
           {dataSource.connectorProvider === "google_drive" && (
@@ -464,16 +463,14 @@ const DataSourcePage = ({
             </div>
           )}
 
-          <div className="border-material-200 mb-4 flex flex-grow flex-col rounded-lg border p-4">
-            {dataSource.connectorProvider === "slack" && (
-              <>
-                <SlackChannelPatternInput
-                  initialValue={features.autoReadChannelPattern || ""}
-                  owner={owner}
-                />
-              </>
-            )}
-          </div>
+          {dataSource.connectorProvider === "slack" && (
+            <div className="border-material-200 mb-4 flex flex-grow flex-col rounded-lg border p-4">
+              <SlackChannelPatternInput
+                initialValue={features.autoReadChannelPattern || ""}
+                owner={owner}
+              />
+            </div>
+          )}
 
           <div className="border-material-200 mb-4 flex flex-grow flex-col rounded-lg border p-4">
             {!dataSource.connectorId ? (
@@ -569,13 +566,7 @@ async function handleCheckOrFindNotionUrl(
   return res.json();
 }
 
-function NotionUrlCheckOrFind({
-  owner,
-  command,
-}: {
-  owner: WorkspaceType;
-  command: "check-url" | "find-url";
-}) {
+function NotionUrlCheckOrFind({ owner }: { owner: WorkspaceType }) {
   const [notionUrl, setNotionUrl] = useState("");
   const [urlDetails, setUrlDetails] = useState<
     NotionCheckUrlResponseType | NotionFindUrlResponseType | null
@@ -583,7 +574,7 @@ function NotionUrlCheckOrFind({
   return (
     <div className="mb-2 flex flex-col gap-2 rounded-md border px-2 py-2 text-sm text-gray-600">
       <div className="flex items-center gap-2 ">
-        <div>Check Notion URL</div>
+        <div>Notion URL</div>
         <div className="grow">
           <Input
             placeholder="Notion URL"
@@ -594,21 +585,28 @@ function NotionUrlCheckOrFind({
         </div>
         <Button
           variant="secondary"
-          label="Check"
+          label={"Check"}
           onClick={async () =>
             setUrlDetails(
-              await handleCheckOrFindNotionUrl(notionUrl, owner.sId, command)
+              await handleCheckOrFindNotionUrl(
+                notionUrl,
+                owner.sId,
+                "check-url"
+              )
+            )
+          }
+        />
+        <Button
+          variant="secondary"
+          label={"Find"}
+          onClick={async () =>
+            setUrlDetails(
+              await handleCheckOrFindNotionUrl(notionUrl, owner.sId, "find-url")
             )
           }
         />
       </div>
       <div className="text-gray-800">
-        <p>
-          {command === "check-url" &&
-            "Check if we have access to the Notion URL"}
-          {command === "find-url" &&
-            "Find the DB records associated with a Notion URL"}
-        </p>
         {urlDetails && (
           <div className="flex flex-col gap-2 rounded-md border pt-2 text-lg">
             <span

--- a/types/src/connectors/admin/cli.ts
+++ b/types/src/connectors/admin/cli.ts
@@ -1,7 +1,5 @@
 import * as t from "io-ts";
 
-import { ParsedNotionDatabaseSchema } from "../notion";
-
 export const ConnectorsCommandSchema = t.type({
   majorCommand: t.literal("connectors"),
   command: t.union([

--- a/types/src/connectors/admin/cli.ts
+++ b/types/src/connectors/admin/cli.ts
@@ -35,6 +35,7 @@ export const NotionCommandSchema = t.type({
     t.literal("upsert-database"),
     t.literal("search-pages"),
     t.literal("check-url"),
+    t.literal("find-url"),
     t.literal("me"),
     t.literal("stop-all-garbage-collectors"),
     t.literal("update-parents-fields"),
@@ -220,22 +221,21 @@ export type NotionSearchPagesResponseType = t.TypeOf<
   typeof NotionSearchPagesResponseSchema
 >;
 
-export const NotionCheckUrlResponseSchema = t.union([
-  t.type({
-    page: t.UnknownRecord, // notion type, can't be iots'd
-    db: t.null,
-  }),
-  t.type({
-    page: t.null,
-    db: ParsedNotionDatabaseSchema,
-  }),
-  t.type({
-    page: t.null,
-    db: t.null,
-  }),
-]);
+export const NotionCheckUrlResponseSchema = t.type({
+  page: t.union([t.UnknownRecord, t.null]), // notion type, can't be iots'd
+  db: t.union([t.UnknownRecord, t.null]), // notion type, can't be iots'd
+});
 
 export type NotionCheckUrlResponseType = t.TypeOf<
+  typeof NotionCheckUrlResponseSchema
+>;
+
+export const NotionFindUrlResponseSchema = t.type({
+  page: t.union([t.UnknownRecord, t.null]), // notion type, can't be iots'd
+  db: t.union([t.UnknownRecord, t.null]), // notion type, can't be iots'd
+});
+
+export type NotionFindUrlResponseType = t.TypeOf<
   typeof NotionCheckUrlResponseSchema
 >;
 


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/907

Add tooling to find NotionPage or NotionDatabase records from a Notion URL in poke

![Screenshot from 2024-06-18 14-50-59](https://github.com/dust-tt/dust/assets/15067/3a73f455-dbc5-4855-b246-925d6211f10d)
![Screenshot from 2024-06-18 14-50-49](https://github.com/dust-tt/dust/assets/15067/db6589e5-d9b4-4286-b9d7-35f64615c2b7)
![Screenshot from 2024-06-18 14-50-36](https://github.com/dust-tt/dust/assets/15067/59e78dec-9b24-4c59-9f56-d16a6392e5d1)

## Risk

N/A

## Deploy Plan

- deploy `connectors`
- deploy `front`