### PR TITLE
Flav/refactor app layout

### DIFF
--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -352,20 +352,20 @@ export default function ConversationViewer({
   const groupedMessages = useMemo(() => groupMessages(messages), [messages]);
 
   if (isConversationLoading) {
-    return null;
+    return <div className="flex flex-1"></div>;
   } else if (isConversationError) {
-    return <div>Error loading conversation</div>;
+    return <div className="flex flex-1">Error loading conversation</div>;
   }
   if (!conversation) {
-    return <div>No conversation here</div>;
+    return <div className="flex flex-1">No conversation here</div>;
   }
 
   return (
     <div
       className={classNames(
-        "flex w-full max-w-4xl flex-col justify-center gap-2 pb-44",
+        "flex w-full max-w-4xl flex-1 flex-col justify-start gap-2",
         isFading ? "animate-fadeout" : "",
-        isInModal ? "" : "sm:px-4"
+        isInModal ? "pt-4" : "sm:px-4"
       )}
     >
       {/* Invisible span to detect when the user has scrolled to the top of the list. */}

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -363,7 +363,7 @@ export default function ConversationViewer({
   return (
     <div
       className={classNames(
-        "mx-auto flex w-full max-w-4xl flex-col justify-center gap-2 pb-44 pt-4",
+        "flex w-full max-w-4xl flex-col justify-center gap-2 pb-44",
         isFading ? "animate-fadeout" : "",
         isInModal ? "" : "sm:px-4"
       )}

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -363,7 +363,7 @@ export default function ConversationViewer({
   return (
     <div
       className={classNames(
-        "flex w-full max-w-4xl flex-1 flex-col justify-start gap-2",
+        "flex w-full max-w-4xl flex-1 flex-col justify-start gap-2 pb-4",
         isFading ? "animate-fadeout" : "",
         isInModal ? "pt-4" : "sm:px-4"
       )}

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -389,6 +389,5 @@ export function FixedAssistantInputBar({
         disableAutoFocus={disableAutoFocus}
       />
     </div>
-    // </div>
   );
 }

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -285,7 +285,7 @@ export function AssistantInputBar({
   }, [isProcessing, generationContext.generatingMessages, conversationId]);
 
   return (
-    <>
+    <div className="flex w-full flex-col">
       {generationContext.generatingMessages.some(
         (m) => m.conversationId === conversationId
       ) && (
@@ -352,7 +352,7 @@ export function AssistantInputBar({
           </div>
         </div>
       </div>
-    </>
+    </div>
   );
 }
 
@@ -378,18 +378,17 @@ export function FixedAssistantInputBar({
   disableAutoFocus?: boolean;
 }) {
   return (
-    <div className="4xl:px-0 fixed bottom-0 left-0 right-0 z-20 flex-initial lg:left-80">
-      <div className="mx-auto max-h-screen max-w-4xl pb-0 sm:pb-8">
-        <AssistantInputBar
-          owner={owner}
-          onSubmit={onSubmit}
-          conversationId={conversationId}
-          stickyMentions={stickyMentions}
-          additionalAgentConfiguration={additionalAgentConfiguration}
-          hideQuickActions={hideQuickActions}
-          disableAutoFocus={disableAutoFocus}
-        />
-      </div>
+    <div className="sticky bottom-0 z-20 flex max-h-screen w-full max-w-4xl duration-700 animate-in fade-in sm:pb-8">
+      <AssistantInputBar
+        owner={owner}
+        onSubmit={onSubmit}
+        conversationId={conversationId}
+        stickyMentions={stickyMentions}
+        additionalAgentConfiguration={additionalAgentConfiguration}
+        hideQuickActions={hideQuickActions}
+        disableAutoFocus={disableAutoFocus}
+      />
     </div>
+    // </div>
   );
 }

--- a/front/components/sparkle/AppLayout.tsx
+++ b/front/components/sparkle/AppLayout.tsx
@@ -356,7 +356,7 @@ export default function AppLayout({
             </Transition.Root>
           )}
 
-          {/* // TODO */}
+          {/* TODO: This logic should be handled by the navigation bar itself. */}
           {!hideSidebar && (
             <div className="hidden lg:visible lg:inset-y-0 lg:z-0 lg:flex lg:w-80 lg:flex-col">
               {loaded && (
@@ -377,7 +377,7 @@ export default function AppLayout({
           id={CONVERSATION_PARENT_SCROLL_DIV_ID.page}
           className="relative h-full w-full flex-1 flex-col overflow-y-auto overflow-x-hidden"
         >
-          {/* TODO: This should be handled by the navigation bar itself!! */}
+          {/* TODO: This logic should be handled by the navigation bar itself. */}
           <div className="fixed left-0 top-0 z-40 flex h-16 shrink-0 items-center gap-x-4 px-4 lg:hidden lg:px-6">
             <button
               type="button"
@@ -398,7 +398,7 @@ export default function AppLayout({
               titleChildren ? "" : "lg:pt-8"
             )}
           >
-            {/* TODO: Move to a top bar component */}
+            {/* TODO: This should be moved to a TopBar component. */}
             <div
               className={classNames(
                 "sticky left-0 top-0 z-30 mb-4 flex w-full flex-col pl-12 lg:pl-0",

--- a/front/components/sparkle/AppLayout.tsx
+++ b/front/components/sparkle/AppLayout.tsx
@@ -284,103 +284,98 @@ export default function AppLayout({
           content="width=device-width, initial-scale=1, maximum-scale=1"
         />
       </Head>
-      <div className="light h-full">
-        {!hideSidebar && (
-          <Transition.Root show={sidebarOpen} as={Fragment}>
-            <Dialog
-              as="div"
-              className="relative z-50 lg:hidden"
-              onClose={setSidebarOpen}
-            >
-              <Transition.Child
-                as={Fragment}
-                enter="transition-opacity ease-linear duration-300"
-                enterFrom="opacity-0"
-                enterTo="opacity-100"
-                leave="transition-opacity ease-linear duration-300"
-                leaveFrom="opacity-100"
-                leaveTo="opacity-0"
+      <div className="light flex h-full flex-row">
+        <div className="flex shrink-0 overflow-x-hidden">
+          {!hideSidebar && (
+            <Transition.Root show={sidebarOpen} as={Fragment}>
+              <Dialog
+                as="div"
+                className="relative z-50 lg:hidden"
+                onClose={setSidebarOpen}
               >
-                <div className="fixed inset-0 bg-gray-900/80" />
-              </Transition.Child>
-
-              <div className="fixed inset-0 flex">
                 <Transition.Child
                   as={Fragment}
-                  enter="transition ease-in-out duration-300 transform"
-                  enterFrom="-translate-x-full"
-                  enterTo="translate-x-0"
-                  leave="transition ease-in-out duration-300 transform"
-                  leaveFrom="translate-x-0"
-                  leaveTo="-translate-x-full"
+                  enter="transition-opacity ease-linear duration-300"
+                  enterFrom="opacity-0"
+                  enterTo="opacity-100"
+                  leave="transition-opacity ease-linear duration-300"
+                  leaveFrom="opacity-100"
+                  leaveTo="opacity-0"
                 >
-                  <Dialog.Panel className="relative mr-16 flex w-full max-w-xs flex-1">
-                    <Transition.Child
-                      as={Fragment}
-                      enter="ease-in-out duration-300"
-                      enterFrom="opacity-0"
-                      enterTo="opacity-100"
-                      leave="ease-in-out duration-300"
-                      leaveFrom="opacity-100"
-                      leaveTo="opacity-0"
-                    >
-                      <div className="absolute left-full top-0 flex w-16 justify-center pt-5">
-                        <button
-                          type="button"
-                          className="-m-2.5 p-2.5"
-                          onClick={() => setSidebarOpen(false)}
-                        >
-                          <span className="sr-only">Close sidebar</span>
-                          <XMarkIcon
-                            className="h-6 w-6 text-white"
-                            aria-hidden="true"
-                          />
-                        </button>
-                      </div>
-                    </Transition.Child>
-                    {loaded && (
-                      <NavigationBar
-                        subscription={subscription}
-                        owner={owner}
-                        subNavigation={subNavigation}
-                        topNavigationCurrent={topNavigationCurrent}
-                      >
-                        {navChildren && navChildren}
-                      </NavigationBar>
-                    )}
-                  </Dialog.Panel>
+                  <div className="fixed inset-0 bg-gray-900/80" />
                 </Transition.Child>
-              </div>
-            </Dialog>
-          </Transition.Root>
-        )}
 
-        {!hideSidebar && (
-          <div className="hidden lg:fixed lg:inset-y-0 lg:z-0 lg:flex lg:w-80 lg:flex-col">
-            {loaded && (
-              <NavigationBar
-                owner={owner}
-                subscription={subscription}
-                subNavigation={subNavigation}
-                topNavigationCurrent={topNavigationCurrent}
-              >
-                {loaded && navChildren && navChildren}
-              </NavigationBar>
-            )}
-          </div>
-        )}
-
-        <div
-          className={classNames(
-            "mt-0 h-full flex-1",
-            !hideSidebar ? "lg:pl-80" : ""
+                <div className="fixed inset-0 flex">
+                  <Transition.Child
+                    as={Fragment}
+                    enter="transition ease-in-out duration-300 transform"
+                    enterFrom="-translate-x-full"
+                    enterTo="translate-x-0"
+                    leave="transition ease-in-out duration-300 transform"
+                    leaveFrom="translate-x-0"
+                    leaveTo="-translate-x-full"
+                  >
+                    <Dialog.Panel className="relative mr-16 flex w-full max-w-xs flex-1">
+                      <Transition.Child
+                        as={Fragment}
+                        enter="ease-in-out duration-300"
+                        enterFrom="opacity-0"
+                        enterTo="opacity-100"
+                        leave="ease-in-out duration-300"
+                        leaveFrom="opacity-100"
+                        leaveTo="opacity-0"
+                      >
+                        <div className="absolute left-full top-0 flex w-16 justify-center pt-5">
+                          <button
+                            type="button"
+                            className="-m-2.5 p-2.5"
+                            onClick={() => setSidebarOpen(false)}
+                          >
+                            <span className="sr-only">Close sidebar</span>
+                            <XMarkIcon
+                              className="h-6 w-6 text-white"
+                              aria-hidden="true"
+                            />
+                          </button>
+                        </div>
+                      </Transition.Child>
+                      {loaded && (
+                        <NavigationBar
+                          subscription={subscription}
+                          owner={owner}
+                          subNavigation={subNavigation}
+                          topNavigationCurrent={topNavigationCurrent}
+                        >
+                          {navChildren && navChildren}
+                        </NavigationBar>
+                      )}
+                    </Dialog.Panel>
+                  </Transition.Child>
+                </div>
+              </Dialog>
+            </Transition.Root>
           )}
-        >
-          <div
-            className={classNames(
-              "fixed left-0 top-0 z-40 flex h-16 shrink-0 items-center gap-x-4 px-4 lg:hidden lg:px-6"
-            )}
-          >
+
+          {/* // TODO */}
+          {!hideSidebar && (
+            <div className="hidden lg:visible lg:inset-y-0 lg:z-0 lg:flex lg:w-80 lg:flex-col">
+              {loaded && (
+                <NavigationBar
+                  owner={owner}
+                  subscription={subscription}
+                  subNavigation={subNavigation}
+                  topNavigationCurrent={topNavigationCurrent}
+                >
+                  {loaded && navChildren && navChildren}
+                </NavigationBar>
+              )}
+            </div>
+          )}
+        </div>
+
+        <div className="relative h-full max-w-full flex-1 flex-col overflow-y-auto overflow-x-hidden">
+          {/* TODO: This should be handled by the navigation bar itself!! */}
+          <div className="fixed left-0 top-0 z-40 flex h-16 shrink-0 items-center gap-x-4 px-4 lg:hidden lg:px-6">
             <button
               type="button"
               className="-m-2.5 p-2.5 text-gray-700 lg:hidden"
@@ -390,19 +385,19 @@ export default function AppLayout({
               <Bars3Icon className="h-5 w-5" aria-hidden="true" />
             </button>
           </div>
+
+          {/* TODO: Move to a top bar component */}
           <div
             className={classNames(
-              "fixed left-0 right-0 top-0 z-30 flex flex-col pl-12 lg:pl-0",
+              "sticky left-0 top-0 z-30 mb-4 flex flex-col",
               !hideSidebar
-                ? "border-b border-structure-300/30 bg-white/80 backdrop-blur lg:left-80"
+                ? "border-b border-structure-300/30 bg-white/80 backdrop-blur"
                 : "",
-              titleChildren ? "fixed" : "lg:hidden"
+              titleChildren ? "" : "lg:hidden"
             )}
           >
-            <div className="h-16 grow">
-              <div className="mx-auto h-full grow px-6">
-                {loaded && titleChildren && titleChildren}
-              </div>
+            <div className="h-16 grow px-6">
+              {loaded && titleChildren && titleChildren}
             </div>
             {titleChildren && SHOW_INCIDENT_BANNER && <IncidentBanner />}
           </div>
@@ -413,14 +408,14 @@ export default function AppLayout({
           <main
             id={CONVERSATION_PARENT_SCROLL_DIV_ID.page}
             className={classNames(
-              "h-full overflow-x-hidden pt-16",
+              "flex h-full w-full justify-center",
               titleChildren ? "" : "lg:pt-8"
             )}
           >
             <div
               className={classNames(
-                "mx-auto h-full",
-                isWideMode ? "w-full" : "max-w-4xl px-6"
+                "h-full w-full",
+                isWideMode ? "" : "max-w-4xl px-6"
               )}
             >
               {loaded && children}

--- a/front/components/sparkle/AppLayout.tsx
+++ b/front/components/sparkle/AppLayout.tsx
@@ -373,7 +373,7 @@ export default function AppLayout({
           )}
         </div>
 
-        <div className="relative h-full max-w-full flex-1 flex-col overflow-y-auto overflow-x-hidden">
+        <div className="relative h-full w-full flex-1 flex-col overflow-y-auto overflow-x-hidden">
           {/* TODO: This should be handled by the navigation bar itself!! */}
           <div className="fixed left-0 top-0 z-40 flex h-16 shrink-0 items-center gap-x-4 px-4 lg:hidden lg:px-6">
             <button
@@ -386,36 +386,36 @@ export default function AppLayout({
             </button>
           </div>
 
-          {/* TODO: Move to a top bar component */}
-          <div
-            className={classNames(
-              "sticky left-0 top-0 z-30 mb-4 flex flex-col",
-              !hideSidebar
-                ? "border-b border-structure-300/30 bg-white/80 backdrop-blur"
-                : "",
-              titleChildren ? "" : "lg:hidden"
-            )}
-          >
-            <div className="h-16 grow px-6">
-              {loaded && titleChildren && titleChildren}
-            </div>
-            {titleChildren && SHOW_INCIDENT_BANNER && <IncidentBanner />}
-          </div>
-
           {!titleChildren && SHOW_INCIDENT_BANNER && (
             <IncidentBanner className="relative" />
           )}
           <main
             id={CONVERSATION_PARENT_SCROLL_DIV_ID.page}
             className={classNames(
-              "flex h-full w-full justify-center",
+              "flex h-full w-full flex-col items-center",
               titleChildren ? "" : "lg:pt-8"
             )}
           >
+            {/* TODO: Move to a top bar component */}
             <div
               className={classNames(
-                "h-full w-full",
-                isWideMode ? "" : "max-w-4xl px-6"
+                "sticky left-0 top-0 z-30 mb-4 flex w-full flex-col pl-12 lg:pl-0",
+                !hideSidebar
+                  ? "border-b border-structure-300/30 bg-white/80 backdrop-blur"
+                  : "",
+                titleChildren ? "" : "lg:hidden"
+              )}
+            >
+              <div className="h-16 grow px-6">
+                {loaded && titleChildren && titleChildren}
+              </div>
+              {titleChildren && SHOW_INCIDENT_BANNER && <IncidentBanner />}
+            </div>
+
+            <div
+              className={classNames(
+                "flex h-full w-full flex-col",
+                isWideMode ? "items-center" : "max-w-4xl px-6"
               )}
             >
               {loaded && children}

--- a/front/components/sparkle/AppLayout.tsx
+++ b/front/components/sparkle/AppLayout.tsx
@@ -373,7 +373,10 @@ export default function AppLayout({
           )}
         </div>
 
-        <div className="relative h-full w-full flex-1 flex-col overflow-y-auto overflow-x-hidden">
+        <div
+          id={CONVERSATION_PARENT_SCROLL_DIV_ID.page}
+          className="relative h-full w-full flex-1 flex-col overflow-y-auto overflow-x-hidden"
+        >
           {/* TODO: This should be handled by the navigation bar itself!! */}
           <div className="fixed left-0 top-0 z-40 flex h-16 shrink-0 items-center gap-x-4 px-4 lg:hidden lg:px-6">
             <button
@@ -390,7 +393,6 @@ export default function AppLayout({
             <IncidentBanner className="relative" />
           )}
           <main
-            id={CONVERSATION_PARENT_SCROLL_DIV_ID.page}
             className={classNames(
               "flex h-full w-full flex-col items-center",
               titleChildren ? "" : "lg:pt-8"

--- a/front/pages/w/[wId]/builder/assistants/create.tsx
+++ b/front/pages/w/[wId]/builder/assistants/create.tsx
@@ -202,7 +202,6 @@ export default function CreateAssistant({
     <AppLayout
       subscription={subscription}
       hideSidebar
-      isWideMode
       owner={owner}
       gaTrackingId={gaTrackingId}
       topNavigationCurrent="assistants"


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR refactors the current `AppLayout` to exclusively use flexboxes, eliminating all fixed positioning which has previously caused issues, such as programmatically hiding the sidebar and animating the input bar.

The design introduced here divides the screen into two main divs: one for the navigation bar and another for content display, which includes sticky divs for the top bar and input bar.

<img width="1388" alt="image" src="https://github.com/dust-tt/dust/assets/7428970/7abad1e6-0492-40b0-b0e5-a7c911becef8">
 
This adjustment will enable us to:
- Eliminate the use of `mx-auto` across numerous locations
- Easily hide the navigation bar
- Provide complete responsive design
- Animate elements within pages

More work is needed, it will come in follow up PRs, including:
- `NavigationBar` component
- `TopBar` component
- More logic goes into `ConversationViewer`

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
Some risks but well tested locally. Will do a last round of testing on front-edge. Safe to rollback.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
