### PR TITLE
Websearch citations

### DIFF
--- a/front/components/actions/websearch/WebsearchActionDetails.tsx
+++ b/front/components/actions/websearch/WebsearchActionDetails.tsx
@@ -21,7 +21,9 @@ export function WebsearchActionDetails({
       ? action.output.error
       : null;
 
-  const resultsCitations = makeWebsearchResultsCitations(action);
+  const resultsCitations = action.output?.results
+    ? makeWebsearchResultsCitations(action.output?.results)
+    : [];
 
   return (
     <ActionDetailsWrapper

--- a/front/components/actions/websearch/utils.ts
+++ b/front/components/actions/websearch/utils.ts
@@ -14,7 +14,6 @@ export function makeWebsearchResultsCitations(
     return {
       description: r.snippet,
       // @todo[daph] 2024-07-19 Remove the fallback on link.
-      // @ts-expect-error Property 'link' does not exist on type 'WebsearchResultType'.
       href: r.sourceUrl ?? r.link,
       title: r.title,
       type: "document",

--- a/front/components/actions/websearch/utils.ts
+++ b/front/components/actions/websearch/utils.ts
@@ -13,7 +13,9 @@ export function makeWebsearchResultsCitations(
   return results.map((r) => {
     return {
       description: r.snippet,
-      href: r.sourceUrl,
+      // @todo[daph] 2024-07-19 Remove the fallback on link.
+      // @ts-expect-error Property 'link' does not exist on type 'WebsearchResultType'.
+      href: r.sourceUrl ?? r.link,
       title: r.title,
       type: "document",
     };

--- a/front/components/actions/websearch/utils.ts
+++ b/front/components/actions/websearch/utils.ts
@@ -1,5 +1,5 @@
 import type { CitationType } from "@dust-tt/sparkle/dist/cjs/components/Citation";
-import type { WebsearchActionType } from "@dust-tt/types";
+import type { WebsearchResultType } from "@dust-tt/types";
 
 interface WebsearchResultCitation {
   href: string;
@@ -8,16 +8,14 @@ interface WebsearchResultCitation {
 }
 
 export function makeWebsearchResultsCitations(
-  action: WebsearchActionType
+  results: WebsearchResultType[]
 ): WebsearchResultCitation[] {
-  return (
-    action.output?.results.map((r) => {
-      return {
-        description: r.snippet,
-        href: r.link,
-        title: r.title,
-        type: "document",
-      };
-    }) ?? []
-  );
+  return results.map((r) => {
+    return {
+      description: r.snippet,
+      href: r.sourceUrl,
+      title: r.title,
+      type: "document",
+    };
+  });
 }

--- a/front/components/assistant/RenderMessageMarkdown.tsx
+++ b/front/components/assistant/RenderMessageMarkdown.tsx
@@ -11,7 +11,7 @@ import type {
   LightAgentConfigurationType,
   WebsearchResultType,
 } from "@dust-tt/types";
-import { isRetrievalDocumentType, isWebsearchResultType } from "@dust-tt/types";
+import { isRetrievalDocumentType } from "@dust-tt/types";
 import mermaid from "mermaid";
 import dynamic from "next/dynamic";
 import type { ReactNode } from "react";
@@ -342,13 +342,8 @@ function CiteBlock(props: ReactMarkdownProps) {
 
           if (isRetrievalDocumentType(document)) {
             link = makeLinkForRetrievedDocument(document);
-          } else if (isWebsearchResultType(document)) {
+          } else {
             link = document.sourceUrl;
-          }
-
-          if (!link) {
-            // Unreachable
-            return null;
           }
 
           return (

--- a/front/components/assistant/RenderMessageMarkdown.tsx
+++ b/front/components/assistant/RenderMessageMarkdown.tsx
@@ -6,8 +6,12 @@ import {
   Tooltip,
   WrenchIcon,
 } from "@dust-tt/sparkle";
-import type { LightAgentConfigurationType } from "@dust-tt/types";
 import type { RetrievalDocumentType } from "@dust-tt/types";
+import type {
+  LightAgentConfigurationType,
+  WebsearchResultType,
+} from "@dust-tt/types";
+import { isRetrievalDocumentType, isWebsearchResultType } from "@dust-tt/types";
 import mermaid from "mermaid";
 import dynamic from "next/dynamic";
 import type { ReactNode } from "react";
@@ -154,9 +158,12 @@ function addClosingBackticks(str: string): string {
 
 type CitationsContextType = {
   references: {
-    [key: string]: RetrievalDocumentType;
+    [key: string]: RetrievalDocumentType | WebsearchResultType;
   };
-  updateActiveReferences: (doc: RetrievalDocumentType, index: number) => void;
+  updateActiveReferences: (
+    doc: RetrievalDocumentType | WebsearchResultType,
+    index: number
+  ) => void;
   setHoveredReference: (index: number | null) => void;
 };
 
@@ -331,7 +338,18 @@ function CiteBlock(props: ReactMarkdownProps) {
       <span className="inline-flex space-x-1">
         {refs.map((r, i) => {
           const document = references[r.ref];
-          const link = makeLinkForRetrievedDocument(document);
+          let link: string | null = null;
+
+          if (isRetrievalDocumentType(document)) {
+            link = makeLinkForRetrievedDocument(document);
+          } else if (isWebsearchResultType(document)) {
+            link = document.sourceUrl;
+          }
+
+          if (!link) {
+            // Unreachable
+            return null;
+          }
 
           return (
             <sup key={`${r.ref}-${i}`}>

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -34,7 +34,6 @@ import {
   isRetrievalActionType,
   isRetrievalDocumentType,
   isWebsearchActionType,
-  isWebsearchResultType,
   removeNulls,
 } from "@dust-tt/types";
 import Link from "next/link";
@@ -619,12 +618,8 @@ function Citations({
 
         if (isRetrievalDocumentType(document)) {
           citation = makeDocumentCitations([document])[0];
-        } else if (isWebsearchResultType(document)) {
+        } else {
           citation = makeWebsearchResultsCitations([document])[0];
-        }
-
-        if (!citation) {
-          return null;
         }
 
         return (

--- a/front/lib/api/assistant/actions/retrieval.ts
+++ b/front/lib/api/assistant/actions/retrieval.ts
@@ -552,6 +552,7 @@ export class RetrievalConfigurationServerRunner extends BaseActionConfigurationS
             const reference = refs[i % refs.length];
             return {
               id: 0, // dummy pending database insertion
+              type: "retrieval_document",
               dataSourceWorkspaceId:
                 dataSourcesIdToWorkspaceId[d.data_source_id],
               dataSourceId: d.data_source_id,
@@ -785,6 +786,7 @@ export async function retrievalActionTypesFromAgentMessageIds(
 
       return {
         id: d.id,
+        type: "retrieval_document",
         dataSourceWorkspaceId: d.dataSourceWorkspaceId,
         dataSourceId: d.dataSourceId,
         sourceUrl: d.sourceUrl,
@@ -858,7 +860,7 @@ export function retrievalMetaPromptMutiActions() {
 let REFS: string[] | null = null;
 const getRand = rand("chawarma");
 
-const getRefs = () => {
+export const getRefs = () => {
   if (REFS === null) {
     REFS = "abcdefghijklmnopqrstuvwxyz"
       .split("")

--- a/front/lib/api/assistant/actions/websearch.ts
+++ b/front/lib/api/assistant/actions/websearch.ts
@@ -376,9 +376,9 @@ export async function websearchActionTypesFromAgentMessageIds(
 
 export function websearchMetaPrompt() {
   return (
-    "Always cite documents retrieved with a 2-letter REFERENCE the markdown directive :cite[REFERENCE] " +
-    "(eg :cite[XX] or :cite[XX,XX] but not :cite[XX][XX]). " +
-    "Ensure citations are placed as close as possible to the related information." +
-    "It is better to use the :cite[XX] directive over just the link."
+    "You have to cite the pages retrieved using their reference identifier with the markdown directive :cite[reference] (e.g., :cite[e4] or :cite[a9,d7]. " +
+    "Place citations as close as possible to the related information. " +
+    "Always use the :cite[XX] directive instead of hyperlinks for better readability. " +
+    "For example, if you find the answer '42' on reference 'g9' then you must cite it as is:  The answer is 42 :cite[g9]."
   );
 }

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -25,6 +25,7 @@ import {
   isContentFragmentType,
   isRetrievalConfiguration,
   isUserMessageType,
+  isWebsearchConfiguration,
   metaPromptForProvider,
   Ok,
   removeNulls,
@@ -36,6 +37,7 @@ import {
   retrievalMetaPrompt,
   retrievalMetaPromptMutiActions,
 } from "@app/lib/api/assistant/actions/retrieval";
+import { websearchMetaPrompt } from "@app/lib/api/assistant/actions/websearch";
 import { TokenEmitter } from "@app/lib/api/assistant/agent";
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
 import { getSupportedModelConfig, isLargeModel } from "@app/lib/assistant";
@@ -451,6 +453,15 @@ export async function constructPromptMultiActions(
     additionalInstructions += `${retrievalMetaPromptMutiActions()}\n`;
     hasAdditionalInstructions = true;
   }
+
+  const hasWebsearch = configuration.actions.some((action) =>
+    isWebsearchConfiguration(action)
+  );
+  if (hasWebsearch) {
+    additionalInstructions += `${websearchMetaPrompt()}\n`;
+    hasAdditionalInstructions = true;
+  }
+
   const providerMetaPrompt = metaPromptForProvider(
     configuration.model.providerId
   );

--- a/types/src/front/assistant/actions/guards.ts
+++ b/types/src/front/assistant/actions/guards.ts
@@ -9,16 +9,21 @@ import {
 import {
   RetrievalActionType,
   RetrievalConfigurationType,
+  RetrievalDocumentType,
 } from "../../../front/assistant/actions/retrieval";
 import {
   TablesQueryActionType,
   TablesQueryConfigurationType,
 } from "../../../front/assistant/actions/tables_query";
+import {
+  WebsearchActionType,
+  WebsearchConfigurationType,
+  WebsearchResultType,
+} from "../../../front/assistant/actions/websearch";
 import { AgentActionType } from "../../../front/assistant/conversation";
 import { BaseAction } from "../../../front/lib/api/assistant/actions/index";
 import { AgentActionConfigurationType } from "../agent";
 import { BrowseActionType, BrowseConfigurationType } from "./browse";
-import { WebsearchActionType, WebsearchConfigurationType } from "./websearch";
 
 export function isTablesQueryConfiguration(
   arg: unknown
@@ -136,5 +141,27 @@ export function isAgentActionConfigurationType(
     isDustAppRunConfiguration(arg) ||
     isRetrievalConfiguration(arg) ||
     isProcessConfiguration(arg)
+  );
+}
+
+export function isWebsearchResultType(
+  arg: unknown
+): arg is WebsearchResultType {
+  return (
+    !!arg &&
+    typeof arg === "object" &&
+    "type" in arg &&
+    arg.type === "websearch_result"
+  );
+}
+
+export function isRetrievalDocumentType(
+  arg: unknown
+): arg is RetrievalDocumentType {
+  return (
+    !!arg &&
+    typeof arg === "object" &&
+    "type" in arg &&
+    arg.type === "retrieval_document"
   );
 }

--- a/types/src/front/assistant/actions/retrieval.ts
+++ b/types/src/front/assistant/actions/retrieval.ts
@@ -73,6 +73,7 @@ export type RetrievalConfigurationType = {
 
 export type RetrievalDocumentType = {
   id: ModelId;
+  type: "retrieval_document";
   dataSourceWorkspaceId: string;
   dataSourceId: string;
   sourceUrl: string | null;

--- a/types/src/front/assistant/actions/websearch.ts
+++ b/types/src/front/assistant/actions/websearch.ts
@@ -17,6 +17,7 @@ const WebsearchRunOutputResultSchema = t.type({
   title: t.string,
   snippet: t.string,
   sourceUrl: t.string,
+  link: t.union([t.string, t.undefined]), // @todo[daph] 2024-07-19 Remove the fallback on link.
 });
 export const WebsearchRunOutputSchema = t.union([
   t.type({

--- a/types/src/front/assistant/actions/websearch.ts
+++ b/types/src/front/assistant/actions/websearch.ts
@@ -13,27 +13,32 @@ export type WebsearchConfigurationType = {
   description: string | null;
 };
 
-export const WebsearchResultSchema = t.type({
+const WebsearchRunOutputResultSchema = t.type({
   title: t.string,
   snippet: t.string,
-  link: t.string,
+  sourceUrl: t.string,
 });
-
-export const WebsearchActionOutputSchema = t.union([
+export const WebsearchRunOutputSchema = t.union([
   t.type({
-    results: t.array(WebsearchResultSchema),
+    results: t.array(WebsearchRunOutputResultSchema),
   }),
   t.type({
-    results: t.array(WebsearchResultSchema),
+    results: t.array(WebsearchRunOutputResultSchema),
     error: t.string,
   }),
 ]);
 
-export type WebsearchActionOutputType = t.TypeOf<
-  typeof WebsearchActionOutputSchema
->;
+export type WebsearchResultType = t.TypeOf<
+  typeof WebsearchRunOutputResultSchema
+> & {
+  type: "websearch_result";
+  reference: string;
+};
 
-export type WebsearchResultType = t.TypeOf<typeof WebsearchResultSchema>;
+export type WebsearchActionOutputType = {
+  results: WebsearchResultType[];
+  error?: string | null;
+};
 
 export interface WebsearchActionType extends BaseAction {
   agentMessageId: ModelId;

--- a/types/src/front/lib/actions/registry.ts
+++ b/types/src/front/lib/actions/registry.ts
@@ -170,7 +170,7 @@ export const DustProdActionRegistry = createActionRegistry({
       workspaceId: PRODUCTION_DUST_APPS_WORKSPACE_ID,
       appId: "098b515f8e",
       appHash:
-        "74ece03e8c502d4ae1681847df945248b43b63a0eaa811daed50a3bc81615ac4",
+        "dd6791448f7b545ebdef68abc9f52469ffc3b32683e97c8a83ef5fda9e084840",
     },
     config: { SEARCH: { provider_id: "serpapi", use_cache: false } },
   },


### PR DESCRIPTION
## Description

Our citation logic was build for `RetrievalDocumentType`. The goal of this PR is to make it work for the web search action, and so for `WebsearchResultType`.

I spent a lot of time tweaking the pre-prompt in `websearchMetaPrompt`. It's not a complete success as it sometimes it does not respect the syntax while we don't seem to have this problem for retrieval. See below. 

Something that I've done that seemed to have helped is renaming "link" into "sourceUrl" in the results sent to the model. But that means I'm changing the output that is saved in db. I _think_ it's okay.

I've put a temporary fallback so that past conversation that used websearch and open the modal to inspect the action will have working links. I'll remove in a month as this will be not likely that someones lands on that. In any case, they can retry the generation and it will fix the links. 


## Screenshots

3 retries and 3 different results for the citations. 🙈 
Here's a [run](https://dust.tt/w/78bda07b39/a/0e9889c787/runs/fcfd0d4ce26b804847fc0bffddb0231a8bb1ce2cecb0bb16a42160c8d89d6d6a). 
Do you have any idea what I can try to do differently to have a more consistent output? It seems to work better with retrieval. 

<kbd>
<img width="903" alt="Screenshot 2024-06-19 at 15 06 55" src="https://github.com/dust-tt/dust/assets/3803406/e8598308-d7fe-4276-bd07-43e5a3a3c376">
</kbd>
<kbd>
<img width="899" alt="Screenshot 2024-06-19 at 15 06 33" src="https://github.com/dust-tt/dust/assets/3803406/9c43b4f8-abe6-4fd7-93e6-c5458d460e10">
</kbd>
<kbd>
<img width="864" alt="Screenshot 2024-06-19 at 15 06 15" src="https://github.com/dust-tt/dust/assets/3803406/57fcef54-d7dc-4bfe-a80a-86a2b1d9b2bd">
</kbd>



## Risk

Break websearch, break citations. 
Can be rolled back. 

## Deploy Plan

Deploy front. 
Deploy connector. 
