### PR TITLE
[feat] - feature(front): ensure sortable assistants

### DIFF
--- a/front/components/assistant/SearchOrderDropdown.tsx
+++ b/front/components/assistant/SearchOrderDropdown.tsx
@@ -1,0 +1,42 @@
+import { Button, DropdownMenu } from "@dust-tt/sparkle";
+
+export const SearchOrder = ["name", "usage", "magic"] as const;
+export type SearchOrderType = (typeof SearchOrder)[number];
+
+// Headless UI does not inherently handle Portal-based rendering,
+// leading to dropdown menus being hidden by parent divs with overflow settings.
+// Adapts layout for smaller screens.
+export function SearchOrderDropdown({
+  orderBy,
+  setOrderBy,
+  disabled,
+}: {
+  orderBy: SearchOrderType;
+  setOrderBy: (orderBy: SearchOrderType) => void;
+  disabled?: boolean;
+}) {
+  return (
+    <DropdownMenu>
+      <DropdownMenu.Button>
+        <Button
+          type="select"
+          labelVisible={true}
+          label={`Order by: ${orderBy}`}
+          variant="tertiary"
+          hasMagnifying={false}
+          size="sm"
+          disabled={disabled}
+        />
+      </DropdownMenu.Button>
+      <DropdownMenu.Items origin="topLeft">
+        {SearchOrder.map((order) => (
+          <DropdownMenu.Item
+            key={order}
+            label={order}
+            onClick={() => setOrderBy(order)}
+          />
+        ))}
+      </DropdownMenu.Items>
+    </DropdownMenu>
+  );
+}

--- a/front/pages/w/[wId]/assistant/gallery.tsx
+++ b/front/pages/w/[wId]/assistant/gallery.tsx
@@ -1,6 +1,4 @@
 import {
-  Button,
-  DropdownMenu,
   DustIcon,
   Page,
   PlanetIcon,
@@ -24,9 +22,12 @@ import { useEffect, useMemo, useState } from "react";
 
 import { AssistantDetails } from "@app/components/assistant/AssistantDetails";
 import { GalleryAssistantPreviewContainer } from "@app/components/assistant/GalleryAssistantPreviewContainer";
+import type { SearchOrder } from "@app/components/assistant/SearchOrderDropdown";
+import { SearchOrderDropdown } from "@app/components/assistant/SearchOrderDropdown";
 import { TryAssistantModal } from "@app/components/assistant/TryAssistant";
 import AppLayout, { appLayoutBack } from "@app/components/sparkle/AppLayout";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
+import { compareAgentsForSort } from "@app/lib/assistant";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { useAgentConfigurations } from "@app/lib/swr";
 import { subFilter } from "@app/lib/utils";
@@ -70,7 +71,7 @@ export default function AssistantsGallery({
   gaTrackingId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const router = useRouter();
-  const [orderBy, setOrderBy] = useState<"name" | "usage">("name");
+  const [orderBy, setOrderBy] = useState<SearchOrder>("name");
 
   const [agentsGetView, setAgentsGetView] = useState<AgentsGetViewType>("all");
 
@@ -124,6 +125,16 @@ export default function AssistantsGallery({
       }
       break;
     }
+    case "magic": {
+      agentsToDisplay = agentConfigurations.filter((a) => {
+        return (
+          subFilter(assistantSearch.toLowerCase(), a.name.toLowerCase()) &&
+          a.status === "active"
+        );
+      });
+      agentsToDisplay.sort(compareAgentsForSort);
+      break;
+    }
     default:
       assertNever(orderBy);
   }
@@ -165,6 +176,14 @@ export default function AssistantsGallery({
     );
   };
 
+  useEffect(() => {
+    if (agentsGetView === "global") {
+      setOrderBy("magic");
+    } else {
+      setOrderBy("usage");
+    }
+  }, [agentsGetView]);
+
   const tabs: {
     label: string;
     current: boolean;
@@ -197,40 +216,6 @@ export default function AssistantsGallery({
       },
     ],
     [agentsGetView]
-  );
-
-  // Headless UI does not inherently handle Portal-based rendering,
-  // leading to dropdown menus being hidden by parent divs with overflow settings.
-  // Adapts layout for smaller screens.
-  const SearchOrderDropdown = (
-    <div className="shrink-0">
-      <DropdownMenu>
-        <DropdownMenu.Button>
-          <Button
-            type="select"
-            labelVisible={true}
-            label={`Order by: ${orderBy}`}
-            variant="tertiary"
-            hasMagnifying={false}
-            size="sm"
-          />
-        </DropdownMenu.Button>
-        <DropdownMenu.Items origin="topLeft">
-          <DropdownMenu.Item
-            key="name"
-            label="Name"
-            onClick={() => setOrderBy("name")}
-          />
-          <DropdownMenu.Item
-            key="usage"
-            label="Usage"
-            onClick={() => {
-              setOrderBy("usage");
-            }}
-          />
-        </DropdownMenu.Items>
-      </DropdownMenu>
-    </div>
   );
 
   return (
@@ -274,7 +259,9 @@ export default function AssistantsGallery({
                 setAssistantSearch(s);
               }}
             />
-            <div className="block md:hidden">{SearchOrderDropdown}</div>
+            <div className="block md:hidden">
+              <SearchOrderDropdown orderBy={orderBy} setOrderBy={setOrderBy} />
+            </div>
           </div>
           <div className="flex flex-row space-x-4">
             <Tab
@@ -282,7 +269,13 @@ export default function AssistantsGallery({
               tabs={tabs}
               setCurrentTab={setAgentsGetView}
             />
-            <div className="hidden md:block">{SearchOrderDropdown}</div>
+            <div className="hidden md:block">
+              <SearchOrderDropdown
+                orderBy={orderBy}
+                setOrderBy={setOrderBy}
+                disabled={agentsGetView === "global"}
+              />
+            </div>
           </div>
           <div className="flex flex-col gap-2">
             <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">

--- a/front/pages/w/[wId]/assistant/gallery.tsx
+++ b/front/pages/w/[wId]/assistant/gallery.tsx
@@ -22,7 +22,7 @@ import { useEffect, useMemo, useState } from "react";
 
 import { AssistantDetails } from "@app/components/assistant/AssistantDetails";
 import { GalleryAssistantPreviewContainer } from "@app/components/assistant/GalleryAssistantPreviewContainer";
-import type { SearchOrder } from "@app/components/assistant/SearchOrderDropdown";
+import type { SearchOrderType } from "@app/components/assistant/SearchOrderDropdown";
 import { SearchOrderDropdown } from "@app/components/assistant/SearchOrderDropdown";
 import { TryAssistantModal } from "@app/components/assistant/TryAssistant";
 import AppLayout, { appLayoutBack } from "@app/components/sparkle/AppLayout";
@@ -71,7 +71,7 @@ export default function AssistantsGallery({
   gaTrackingId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const router = useRouter();
-  const [orderBy, setOrderBy] = useState<SearchOrder>("name");
+  const [orderBy, setOrderBy] = useState<SearchOrderType>("name");
 
   const [agentsGetView, setAgentsGetView] = useState<AgentsGetViewType>("all");
 

--- a/front/pages/w/[wId]/builder/assistants/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/index.tsx
@@ -8,7 +8,7 @@ import {
   Page,
   PlusIcon,
   Popup,
-  RobotSharedIcon,
+  RobotIcon,
   Searchbar,
   SliderToggle,
   Tab,
@@ -231,7 +231,7 @@ export default function WorkspaceAssistants({
         mutateAgentConfigurations={mutateAgentConfigurations}
       />
       <Page.Vertical gap="xl" align="stretch">
-        <Page.Header title="Manage Assistants" icon={RobotSharedIcon} />
+        <Page.Header title="Manage Assistants" icon={RobotIcon} />
         <Page.Vertical gap="md" align="stretch">
           <div className="flex flex-row gap-2">
             <Searchbar
@@ -262,7 +262,7 @@ export default function WorkspaceAssistants({
               </Link>
             </Button.List>
           </div>
-          <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-4 pt-3">
             <div className="flex flex-row gap-2">
               <Tab
                 tabs={tabs}
@@ -270,7 +270,7 @@ export default function WorkspaceAssistants({
                   assistantSearch ? disabledTablineClass : ""
                 )}
               />
-              <div className="flex grow justify-end">
+              <div className="flex grow items-end justify-end">
                 <SearchOrderDropdown
                   orderBy={orderBy}
                   setOrderBy={setOrderBy}


### PR DESCRIPTION
## Description

This PR aims at ensuring assistants are sortable both in the gallery and in the build assistant view. We ensure they are sortable by:
- name
- usage
- magic (current strategy favouring dust, gpt4, ...)


https://github.com/dust-tt/dust/assets/32683010/49689eeb-298b-4d3b-a2b0-a2604ca13d56


## Risk

None as it only changes the sorting

## Deploy Plan

Deploy `front`
