### PR TITLE
[InputBar] Refactor hideXXX to actions list

### DIFF
--- a/front/components/assistant/HelpDrawer.tsx
+++ b/front/components/assistant/HelpDrawer.tsx
@@ -203,8 +203,7 @@ export function HelpDrawer({
             owner={owner}
             onSubmit={handleHelpSubmit}
             conversationId={null}
-            hideAttachment={true}
-            hideQuickActions={true}
+            actions={[]}
             disableAutoFocus={true}
           />
         </div>

--- a/front/components/assistant/TryAssistant.tsx
+++ b/front/components/assistant/TryAssistant.tsx
@@ -93,7 +93,7 @@ export function TryAssistantModal({
               stickyMentions={stickyMentions}
               conversationId={conversation?.sId || null}
               additionalAgentConfiguration={assistant}
-              hideQuickActions
+              actions={["attachment"]}
             />
           </div>
         </GenerationContextProvider>
@@ -165,7 +165,7 @@ export function TryAssistant({
               stickyMentions={stickyMentions}
               conversationId={conversation?.sId || null}
               additionalAgentConfiguration={assistant}
-              hideQuickActions
+              actions={["attachment"]}
               disableAutoFocus
               isFloating={false}
             />

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -55,8 +55,7 @@ export function AssistantInputBar({
   conversationId,
   stickyMentions,
   additionalAgentConfiguration,
-  hideQuickActions,
-  hideAttachment,
+  actions,
   disableAutoFocus = false,
   isFloating = true,
 }: {
@@ -69,8 +68,7 @@ export function AssistantInputBar({
   conversationId: string | null;
   stickyMentions?: AgentMention[];
   additionalAgentConfiguration?: LightAgentConfigurationType;
-  hideQuickActions: boolean;
-  hideAttachment?: boolean;
+  actions: InputBarContainerProps["actionsList"];
   disableAutoFocus: boolean;
   isFloating?: boolean;
 }) {
@@ -336,8 +334,7 @@ export function AssistantInputBar({
               )}
 
               <InputBarContainer
-                hideQuickActions={hideQuickActions}
-                hideAttachment={!!hideAttachment}
+                actionsList={actions}
                 disableAutoFocus={disableAutoFocus}
                 allAssistants={activeAgents}
                 agentConfigurations={agentConfigurations}
@@ -362,7 +359,7 @@ export function FixedAssistantInputBar({
   stickyMentions,
   conversationId,
   additionalAgentConfiguration,
-  hideQuickActions = false,
+  actions = ["attachment", "quick-actions"],
   disableAutoFocus = false,
 }: {
   owner: WorkspaceType;
@@ -374,7 +371,7 @@ export function FixedAssistantInputBar({
   stickyMentions?: AgentMention[];
   conversationId: string | null;
   additionalAgentConfiguration?: LightAgentConfigurationType;
-  hideQuickActions?: boolean;
+  actions?: InputBarContainerProps["actionsList"];
   disableAutoFocus?: boolean;
 }) {
   return (
@@ -385,7 +382,7 @@ export function FixedAssistantInputBar({
         conversationId={conversationId}
         stickyMentions={stickyMentions}
         additionalAgentConfiguration={additionalAgentConfiguration}
-        hideQuickActions={hideQuickActions}
+        actions={actions}
         disableAutoFocus={disableAutoFocus}
       />
     </div>

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -14,7 +14,9 @@ import { useSWRConfig } from "swr";
 
 import { GenerationContext } from "@app/components/assistant/conversation/GenerationContextProvider";
 import type { InputBarContainerProps } from "@app/components/assistant/conversation/input_bar/InputBarContainer";
-import InputBarContainer from "@app/components/assistant/conversation/input_bar/InputBarContainer";
+import InputBarContainer, {
+  INPUT_BAR_ACTIONS,
+} from "@app/components/assistant/conversation/input_bar/InputBarContainer";
 import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import type { ContentFragmentInput } from "@app/components/assistant/conversation/lib";
 import { SendNotificationsContext } from "@app/components/sparkle/Notification";
@@ -55,7 +57,7 @@ export function AssistantInputBar({
   conversationId,
   stickyMentions,
   additionalAgentConfiguration,
-  actions,
+  actions = INPUT_BAR_ACTIONS.slice(),
   disableAutoFocus = false,
   isFloating = true,
 }: {
@@ -68,7 +70,7 @@ export function AssistantInputBar({
   conversationId: string | null;
   stickyMentions?: AgentMention[];
   additionalAgentConfiguration?: LightAgentConfigurationType;
-  actions: InputBarContainerProps["actionsList"];
+  actions?: InputBarContainerProps["actions"];
   disableAutoFocus: boolean;
   isFloating?: boolean;
 }) {
@@ -334,7 +336,7 @@ export function AssistantInputBar({
               )}
 
               <InputBarContainer
-                actionsList={actions}
+                actions={actions}
                 disableAutoFocus={disableAutoFocus}
                 allAssistants={activeAgents}
                 agentConfigurations={agentConfigurations}
@@ -371,7 +373,7 @@ export function FixedAssistantInputBar({
   stickyMentions?: AgentMention[];
   conversationId: string | null;
   additionalAgentConfiguration?: LightAgentConfigurationType;
-  actions?: InputBarContainerProps["actionsList"];
+  actions?: InputBarContainerProps["actions"];
   disableAutoFocus?: boolean;
 }) {
   return (

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -361,7 +361,7 @@ export function FixedAssistantInputBar({
   stickyMentions,
   conversationId,
   additionalAgentConfiguration,
-  actions = ["attachment", "quick-actions"],
+  actions = INPUT_BAR_ACTIONS.slice(),
   disableAutoFocus = false,
 }: {
   owner: WorkspaceType;

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -22,7 +22,9 @@ import useHandleMentions from "@app/components/assistant/conversation/input_bar/
 import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import { classNames } from "@app/lib/utils";
 
-export type InputBarAction = "attachment" | "quick-actions";
+export const INPUT_BAR_ACTIONS = ["attachment", "quick-actions"] as const;
+
+export type InputBarAction = (typeof INPUT_BAR_ACTIONS)[number];
 
 export interface InputBarContainerProps {
   allAssistants: LightAgentConfigurationType[];
@@ -32,7 +34,7 @@ export interface InputBarContainerProps {
   owner: WorkspaceType;
   selectedAssistant: AgentMention | null;
   stickyMentions: AgentMention[] | undefined;
-  actionsList: InputBarAction[];
+  actions: InputBarAction[];
   disableAutoFocus: boolean;
   disableSendButton: boolean;
 }
@@ -45,7 +47,7 @@ const InputBarContainer = ({
   owner,
   selectedAssistant,
   stickyMentions,
-  actionsList,
+  actions,
   disableAutoFocus,
   disableSendButton,
 }: InputBarContainerProps) => {
@@ -118,10 +120,10 @@ const InputBarContainer = ({
           className={classNames(
             "flex gap-5 rounded-full px-4 py-2 sm:gap-3 sm:px-2",
             // Hide border when there are no actions.
-            actionsList.length === 0 ? "" : "border border-structure-200/60"
+            actions.length === 0 ? "" : "border border-structure-200/60"
           )}
         >
-          {actionsList.includes("attachment") && (
+          {actions.includes("attachment") && (
             <>
               <input
                 accept=".txt,.pdf,.md,.csv"
@@ -147,7 +149,7 @@ const InputBarContainer = ({
               />
             </>
           )}
-          {actionsList.includes("quick-actions") && (
+          {actions.includes("quick-actions") && (
             <>
               <AssistantPicker
                 owner={owner}

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -22,6 +22,8 @@ import useHandleMentions from "@app/components/assistant/conversation/input_bar/
 import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import { classNames } from "@app/lib/utils";
 
+export type InputBarAction = "attachment" | "quick-actions";
+
 export interface InputBarContainerProps {
   allAssistants: LightAgentConfigurationType[];
   agentConfigurations: LightAgentConfigurationType[];
@@ -30,8 +32,7 @@ export interface InputBarContainerProps {
   owner: WorkspaceType;
   selectedAssistant: AgentMention | null;
   stickyMentions: AgentMention[] | undefined;
-  hideQuickActions: boolean;
-  hideAttachment: boolean;
+  actionsList: InputBarAction[];
   disableAutoFocus: boolean;
   disableSendButton: boolean;
 }
@@ -44,8 +45,7 @@ const InputBarContainer = ({
   owner,
   selectedAssistant,
   stickyMentions,
-  hideQuickActions,
-  hideAttachment,
+  actionsList,
   disableAutoFocus,
   disableSendButton,
 }: InputBarContainerProps) => {
@@ -117,13 +117,11 @@ const InputBarContainer = ({
         <div
           className={classNames(
             "flex gap-5 rounded-full px-4 py-2 sm:gap-3 sm:px-2",
-            // when both are hidden, hide the border (but keep the div for the flex layout to work)
-            !hideAttachment || !hideQuickActions
-              ? "border border-structure-200/60"
-              : ""
+            // Hide border when there are no actions.
+            actionsList.length === 0 ? "" : "border border-structure-200/60"
           )}
         >
-          {!hideAttachment && (
+          {actionsList.includes("attachment") && (
             <>
               <input
                 accept=".txt,.pdf,.md,.csv"
@@ -149,7 +147,7 @@ const InputBarContainer = ({
               />
             </>
           )}
-          {!hideQuickActions && (
+          {actionsList.includes("quick-actions") && (
             <>
               <AssistantPicker
                 owner={owner}

--- a/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
+++ b/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
@@ -168,7 +168,7 @@ export default function AssistantBuilderRightPanel({
                       stickyMentions={stickyMentions}
                       conversationId={conversation?.sId || null}
                       additionalAgentConfiguration={draftAssistant}
-                      hideQuickActions
+                      actions={["attachment"]}
                       disableAutoFocus
                       isFloating={false}
                     />

--- a/front/pages/w/[wId]/assistant/new.tsx
+++ b/front/pages/w/[wId]/assistant/new.tsx
@@ -286,7 +286,6 @@ export default function AssistantNew({
               owner={owner}
               onSubmit={handleMessageSubmit}
               conversationId={null}
-              hideQuickActions={false}
               disableAutoFocus={false}
             />
           </div>


### PR DESCRIPTION
Description
---
Using a list rather than multiple `hideXXX` flags for the actions we show in the input bar is cleaner

Risk & deploy
---
na
