### PR TITLE
Prevent action name suffix to pile up

### DIFF
--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -183,8 +183,11 @@ export default function ActionsScreen({
 
           // Making sure the name is not used already.
           let index = 1;
+          const newNameWithoutSuffix = newAction.name.replace(/_\d+$/, "");
           const suffixedName = () =>
-            index > 1 ? `${newAction.name}_${index}` : newAction.name;
+            index > 1
+              ? `${newNameWithoutSuffix}_${index}`
+              : newNameWithoutSuffix;
           while (builderState.actions.some((a) => a.name === suffixedName())) {
             index += 1;
           }


### PR DESCRIPTION
## Description

Bug: 
Add 3 tools search data sources:  `search_data_sources_1 `, `search_data_sources_2`, `search_data_sources_3`.
Remove `search_data_sources_2`
Add a new one. -> It will be called `search_data_sources_3_2`.

This is a quick fix, we might want to be smarter than that. 
With that we will call the new one `search_data_sources_2` then `search_data_sources_4`. 

Not perfect, won't solve the curent `search_data_sources_2_2_2_2`.

## Risk

Low, action names are hidden under the advanced section. Can be rolled back

## Deploy Plan

Deploy front. 
