### PR TITLE
connectors: gdrive launch incremental at creation

### DIFF
--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -133,7 +133,14 @@ export async function createGoogleDriveConnector(
     googleDriveConfigurationBlob
   );
 
+  // We mark it artificially as sync succeeded as google drive is created empty.
   await syncSucceeded(connector.id);
+
+  // We nonetheless launch the incremental sync.
+  const res = await launchGoogleDriveIncrementalSyncWorkflow(connector.id);
+  if (res.isErr()) {
+    return res;
+  }
 
   return new Ok(connector.id.toString());
 }


### PR DESCRIPTION
## Description

Now that we moved to a cron-based incremental sync we want to start it at connector creation always instead of waiting for a permission updates which may not happen. Otherwise we'll get a production check failure.

## Risk

N/A

## Deploy Plan

- deploy `connectors`