### PR TITLE
[Webcrawler] Fix: saving new webcrawler required 2 clicks on save

### DIFF
--- a/front/components/data_source/WebsiteConfiguration.tsx
+++ b/front/components/data_source/WebsiteConfiguration.tsx
@@ -52,7 +52,6 @@ export default function WebsiteConfiguration({
   gaTrackingId: string;
 }) {
   const [isSaving, setIsSaving] = useState(false);
-  const [isValid, setIsValid] = useState(false);
   const [isSubmitted, setIsSubmitted] = useState(false);
 
   const [dataSourceUrl, setDataSourceUrl] = useState(
@@ -138,7 +137,6 @@ export default function WebsiteConfiguration({
 
     setDataSourceUrlError(urlError);
     setDataSourceNameError(nameError);
-    setIsValid(!urlError && !nameError);
     return !urlError && !nameError;
   }, [dataSourceName, dataSources, dataSourceUrl, dataSource?.id]);
 
@@ -267,8 +265,7 @@ export default function WebsiteConfiguration({
           title="Add a Website"
           onSave={() => {
             setIsSubmitted(true);
-            const formValid = validateForm();
-            if (formValid && !isSaving) {
+            if (!isSaving) {
               void handleCreate();
             }
           }}

--- a/front/components/data_source/WebsiteConfiguration.tsx
+++ b/front/components/data_source/WebsiteConfiguration.tsx
@@ -152,8 +152,8 @@ export default function WebsiteConfiguration({
 
   const handleCreate = async () => {
     setIsSubmitted(true);
-    validateForm();
-    if (!isValid) {
+
+    if (!validateForm()) {
       return;
     }
 

--- a/front/components/data_source/WebsiteConfiguration.tsx
+++ b/front/components/data_source/WebsiteConfiguration.tsx
@@ -139,6 +139,7 @@ export default function WebsiteConfiguration({
     setDataSourceUrlError(urlError);
     setDataSourceNameError(nameError);
     setIsValid(!urlError && !nameError);
+    return !urlError && !nameError;
   }, [dataSourceName, dataSources, dataSourceUrl, dataSource?.id]);
 
   useEffect(() => {
@@ -266,8 +267,8 @@ export default function WebsiteConfiguration({
           title="Add a Website"
           onSave={() => {
             setIsSubmitted(true);
-            validateForm();
-            if (isValid && !isSaving) {
+            const formValid = validateForm();
+            if (formValid && !isSaving) {
               void handleCreate();
             }
           }}


### PR DESCRIPTION
Description
---
Fixes https://github.com/dust-tt/dust/issues/5592

In the onclick, testing that the form was valid relied on state change, which does not take effect immediately, explaining that the first click was doing nothing

Risk & deploy
---
na
