### PR TITLE
front: Fix assistant builder with >1 actions with dust app

### DIFF
--- a/front/components/assistant_builder/submitAssistantBuilderForm.ts
+++ b/front/components/assistant_builder/submitAssistantBuilderForm.ts
@@ -109,10 +109,10 @@ export async function submitAssistantBuilderForm({
             type: "dust_app_run_configuration",
             appWorkspaceId: owner.sId,
             appId: a.configuration.app.sId,
-            // `name` and `description` are ignored server side as the app name and description are
-            // used instaed.
-            name: null,
-            description: null,
+            // These field are required by the API (`name` and `description`) but will be overriden
+            // with the app name and description.
+            name: a.configuration.app.name,
+            description: a.configuration.app.description,
           },
         ];
 


### PR DESCRIPTION
## Description

The action name and description are required server side but will be overriden with the app info for this action. We still need to pass something to go through validation,

Fixes: https://app.datadoghq.eu/logs?query=%22Unhandled%20API%20Error%22%20&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&source=monitor_notif&storage=hot&stream_sort=desc&viz=stream&from_ts=1718857206000&to_ts=1718857506000&live=false

## Risk

N/A

## Deploy Plan

- deploy `front`