### PR TITLE
front: add origin to UserMessageType [take 2]

### DIFF
--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -403,6 +403,7 @@ async function botAnswerMessage(
         slackChatBotMessage.slackFullName || slackChatBotMessage.slackUserName,
       email: slackChatBotMessage.slackEmail,
       profilePictureUrl: slackChatBotMessage.slackAvatar || null,
+      origin: "slack" as const,
     },
   };
 

--- a/front/components/assistant/conversation/lib.ts
+++ b/front/components/assistant/conversation/lib.ts
@@ -71,7 +71,6 @@ export function createPlaceholderUserMessage({
       profilePictureUrl: image,
       timezone: Intl.DateTimeFormat().resolvedOptions().timeZone ?? "UTC",
       username,
-      origin: "web",
     },
   };
 }
@@ -237,7 +236,6 @@ export async function createConversationWithMessage({
       context: {
         timezone: Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC",
         profilePictureUrl: user.image,
-        origin: "web",
       },
       mentions,
     },

--- a/front/components/assistant/conversation/lib.ts
+++ b/front/components/assistant/conversation/lib.ts
@@ -71,6 +71,7 @@ export function createPlaceholderUserMessage({
       profilePictureUrl: image,
       timezone: Intl.DateTimeFormat().resolvedOptions().timeZone ?? "UTC",
       username,
+      origin: "web",
     },
   };
 }
@@ -236,6 +237,7 @@ export async function createConversationWithMessage({
       context: {
         timezone: Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC",
         profilePictureUrl: user.image,
+        origin: "web",
       },
       mentions,
     },

--- a/front/components/assistant/conversation/lib.ts
+++ b/front/components/assistant/conversation/lib.ts
@@ -71,6 +71,7 @@ export function createPlaceholderUserMessage({
       profilePictureUrl: image,
       timezone: Intl.DateTimeFormat().resolvedOptions().timeZone ?? "UTC",
       username,
+      origin: "web",
     },
   };
 }

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -343,7 +343,7 @@ export default function AssistantBuilder({
           icon,
         })
       ),
-    [screen]
+    [screen, multiActionsEnabled]
   );
   const modalTitle = agentConfigurationId
     ? `Edit @${builderState.handle}`

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -727,6 +727,7 @@ export async function* postUserMessage(
                   userContextFullName: context.fullName,
                   userContextEmail: context.email,
                   userContextProfilePictureUrl: context.profilePictureUrl,
+                  userContextOrigin: context.origin,
                   userId: user ? user.id : null,
                 },
                 { transaction: t }
@@ -1189,6 +1190,7 @@ export async function* editUserMessage(
                   userContextEmail: userMessageRow.userContextEmail,
                   userContextProfilePictureUrl:
                     userMessageRow.userContextProfilePictureUrl,
+                  userContextOrigin: userMessageRow.userContextOrigin,
                   userId: userMessageRow.userId,
                 },
                 { transaction: t }

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -109,6 +109,7 @@ export async function batchRenderUserMessages(
         fullName: userMessage.userContextFullName,
         email: userMessage.userContextEmail,
         profilePictureUrl: userMessage.userContextProfilePictureUrl,
+        origin: userMessage.userContextOrigin,
       },
     } satisfies UserMessageType;
     return { m, rank: message.rank, version: message.version };

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -3,6 +3,7 @@ import type {
   ConversationVisibility,
   MessageVisibility,
   ParticipantActionType,
+  UserMessageOrigin,
 } from "@dust-tt/types";
 import type {
   CreationOptional,
@@ -175,6 +176,7 @@ export class UserMessage extends Model<
   declare userContextFullName: string | null;
   declare userContextEmail: string | null;
   declare userContextProfilePictureUrl: string | null;
+  declare userContextOrigin: UserMessageOrigin | null;
 
   declare userId: ForeignKey<User["id"]> | null;
 }
@@ -218,6 +220,10 @@ UserMessage.init(
     },
     userContextProfilePictureUrl: {
       type: DataTypes.STRING(2048),
+      allowNull: true,
+    },
+    userContextOrigin: {
+      type: DataTypes.STRING,
       allowNull: true,
     },
   },

--- a/front/lib/workspace_usage.ts
+++ b/front/lib/workspace_usage.ts
@@ -51,13 +51,7 @@ export async function unsafeGetUsageData(
             WHEN COUNT(DISTINCT arc."id") + COUNT(DISTINCT atqc."id") + COUNT(DISTINCT adarc."id") > 1 THEN 'multiActions'
             ELSE NULL
         END AS "actionType",
-        CASE
-            WHEN um."id" IS NOT NULL THEN
-                CASE
-                    WHEN um."userId" IS NOT NULL THEN 'web'
-                    ELSE 'slack'
-                END
-        END AS "source"
+        um."userContextOrigin" AS "source"
     FROM
         "messages" m
     JOIN

--- a/front/migrations/20240620_backfill_user_message_origin.sql
+++ b/front/migrations/20240620_backfill_user_message_origin.sql
@@ -1,0 +1,5 @@
+UPDATE user_messages SET "userContextOrigin" = 'slack' WHERE "userContextOrigin" IS NULL AND "userContextProfilePictureUrl" ILIKE '%slack%';
+UPDATE user_messages SET "userContextOrigin" = 'web' WHERE "userContextOrigin" IS NULL AND "userId" IS NOT NULL;
+UPDATE user_messages SET "userContextOrigin" = 'api' WHERE "userContextOrigin" IS NULL AND "userId" IS NULL;
+
+SELECT "userContextOrigin", COUNT(*) FROM user_messages GROUP BY "userContextOrigin";

--- a/front/migrations/db/migration_24.sql
+++ b/front/migrations/db/migration_24.sql
@@ -1,0 +1,2 @@
+-- Migration created on Jun 20, 2024
+ALTER TABLE "public"."user_messages" ADD COLUMN "userContextOrigin" VARCHAR(255);

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -103,7 +103,10 @@ async function handler(
           conversation,
           content,
           mentions,
-          context,
+          context: {
+            ...context,
+            origin: context.origin ?? "api",
+          },
         },
         { resolveAfterFullGeneration: blocking === true }
       );

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -176,6 +176,7 @@ async function handler(
               fullName: message.context.fullName,
               email: message.context.email,
               profilePictureUrl: message.context.profilePictureUrl,
+              origin: message.context.origin ?? "api",
             },
           },
           { resolveAfterFullGeneration: blocking === true }

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -156,6 +156,7 @@ async function handler(
             fullName: user.fullName,
             email: user.email,
             profilePictureUrl: context.profilePictureUrl ?? user.image,
+            origin: context.origin,
           },
         },
         { resolveAfterFullGeneration: false }

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -156,7 +156,7 @@ async function handler(
             fullName: user.fullName,
             email: user.email,
             profilePictureUrl: context.profilePictureUrl ?? user.image,
-            origin: context.origin,
+            origin: context.origin ?? "web",
           },
         },
         { resolveAfterFullGeneration: false }

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -156,7 +156,7 @@ async function handler(
             fullName: user.fullName,
             email: user.email,
             profilePictureUrl: context.profilePictureUrl ?? user.image,
-            origin: context.origin ?? "web",
+            origin: "web",
           },
         },
         { resolveAfterFullGeneration: false }

--- a/front/pages/api/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/index.ts
@@ -165,6 +165,7 @@ async function handler(
               fullName: user.fullName,
               email: user.email,
               profilePictureUrl: message.context.profilePictureUrl,
+              origin: "web",
             },
           },
           { resolveAfterFullGeneration: false }

--- a/front/pages/api/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/index.ts
@@ -149,10 +149,9 @@ async function handler(
       }
 
       if (message) {
-        /* If a message was provided we do await for the message to be created
-        before returning the conversation along with the message.
-        PostUserMessageWithPubSub returns swiftly since it only waits for the
-        initial message creation event (or error) */
+        // If a message was provided we do await for the message to be created before returning the
+        // conversation along with the message. PostUserMessageWithPubSub returns swiftly since it
+        // only waits for the initial message creation event (or error) */
         const messageRes = await postUserMessageWithPubSub(
           auth,
           {

--- a/front/temporal/labs/activities.ts
+++ b/front/temporal/labs/activities.ts
@@ -257,6 +257,7 @@ export async function processTranscriptActivity(
         fullName: user.name,
         email: user.email,
         profilePictureUrl: user.imageUrl,
+        origin: null,
       },
     },
     contentFragment: {

--- a/types/src/front/api_handlers/internal/assistant.ts
+++ b/types/src/front/api_handlers/internal/assistant.ts
@@ -6,6 +6,12 @@ export const InternalPostMessagesRequestBodySchema = t.type({
   context: t.type({
     timezone: t.string,
     profilePictureUrl: t.union([t.string, t.null]),
+    origin: t.union([
+      t.literal("slack"),
+      t.literal("web"),
+      t.literal("api"),
+      t.null,
+    ]),
   }),
 });
 

--- a/types/src/front/api_handlers/internal/assistant.ts
+++ b/types/src/front/api_handlers/internal/assistant.ts
@@ -6,12 +6,6 @@ export const InternalPostMessagesRequestBodySchema = t.type({
   context: t.type({
     timezone: t.string,
     profilePictureUrl: t.union([t.string, t.null]),
-    origin: t.union([
-      t.literal("slack"),
-      t.literal("web"),
-      t.literal("api"),
-      t.null,
-    ]),
   }),
 });
 

--- a/types/src/front/api_handlers/public/assistant.ts
+++ b/types/src/front/api_handlers/public/assistant.ts
@@ -18,6 +18,13 @@ export const PublicPostMessagesRequestBodySchema = t.intersection([
       fullName: t.union([t.string, t.null]),
       email: t.union([t.string, t.null]),
       profilePictureUrl: t.union([t.string, t.null]),
+      origin: t.union([
+        t.literal("slack"),
+        t.literal("web"),
+        t.literal("api"),
+        t.null,
+        t.undefined,
+      ]),
     }),
   }),
   t.partial({

--- a/types/src/front/assistant/conversation.ts
+++ b/types/src/front/assistant/conversation.ts
@@ -52,12 +52,15 @@ export type MessageWithRankType = WithRank<MessageType>;
  * User messages
  */
 
+export type UserMessageOrigin = "slack" | "web" | "api";
+
 export type UserMessageContext = {
   username: string;
   timezone: string;
   fullName: string | null;
   email: string | null;
   profilePictureUrl: string | null;
+  origin: UserMessageOrigin | null;
 };
 
 export type UserMessageType = {


### PR DESCRIPTION
Reverts dust-tt/dust#5758

Following a revert of https://github.com/dust-tt/dust/pull/5734

Due to https://dust4ai.slack.com/archives/C050SM8NSPK/p1718879293095729

## Deploy:

- deploy `front`
- deploy `connectors`

Migration already run. Re-run backfills.