### PR TITLE
[Dust Apps] Fix dataset descriptions shuffled

### DIFF
--- a/front/components/app/DatasetView.tsx
+++ b/front/components/app/DatasetView.tsx
@@ -206,7 +206,10 @@ export default function DatasetView({
   );
   const [datasetKeyDescriptions, setDatasetKeyDescriptions] = useState<
     string[]
-  >((schema || []).map((s) => s.description || ""));
+  >(
+    datasetKeys.map((k) => schema?.find((s) => s.key === k)?.description || "")
+  );
+
   const [datasetTypes, setDatasetTypes] = useState<DatasetDataType[]>([]);
   const [datasetInitializing, setDatasetInitializing] = useState(true);
 


### PR DESCRIPTION
Description
---
Fixes https://github.com/dust-tt/tasks/issues/893

Dataset keys and descr in 2 different arrays rely on matching by indices, but are not initially computed with indices matching. This initial computation is corrected in this PR

Risk & deploy
---
na
