### PR TITLE
Remove references to Sonnet 3 (in favor of 3.5)

### DIFF
--- a/front/pages/api/w/[wId]/providers/[pId]/models.ts
+++ b/front/pages/api/w/[wId]/providers/[pId]/models.ts
@@ -203,6 +203,7 @@ async function handler(
                 { id: "claude-2.1" },
                 { id: "claude-3-haiku-20240307" },
                 { id: "claude-3-sonnet-20240229" },
+                { id: "claude-3-5-sonnet-20240620" },
                 { id: "claude-3-opus-20240229" },
               ];
             } else {

--- a/types/src/front/lib/assistant.ts
+++ b/types/src/front/lib/assistant.ts
@@ -311,55 +311,6 @@ export const CLAUDE_3_5_SONNET_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
     ],
   },
 };
-export const CLAUDE_3_SONNET_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
-  providerId: "anthropic",
-  modelId: CLAUDE_3_SONNET_2024029_MODEL_ID,
-  displayName: "Claude 3 Sonnet",
-  contextSize: 180_000,
-  recommendedTopK: 32,
-  recommendedExhaustiveTopK: 128, // 65_536
-  largeModel: true,
-  description:
-    "Anthropic Claude 3 Sonnet model, targeting balance between intelligence and speed for enterprise workloads.",
-  shortDescription: "Anthropic's balanced model.",
-  supportsMultiActions: true,
-  isLegacy: false,
-  delimitersConfiguration: {
-    incompleteDelimiterRegex: /<\/?[a-zA-Z_]*$/,
-    delimiters: [
-      {
-        openingPattern: "<thinking>",
-        closingPattern: "</thinking>",
-        isChainOfThought: true,
-        swallow: false,
-      },
-      {
-        openingPattern: "<search_quality_reflection>",
-        closingPattern: "</search_quality_reflection>",
-        isChainOfThought: true,
-        swallow: false,
-      },
-      {
-        openingPattern: "<reflecting>",
-        closingPattern: "</reflecting>",
-        isChainOfThought: true,
-        swallow: false,
-      },
-      {
-        openingPattern: "<search_quality_score>",
-        closingPattern: "</search_quality_score>",
-        isChainOfThought: true,
-        swallow: true,
-      },
-      {
-        openingPattern: "<result>",
-        closingPattern: "</result>",
-        isChainOfThought: false,
-        swallow: false,
-      },
-    ],
-  },
-};
 export const CLAUDE_3_HAIKU_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "anthropic",
   modelId: CLAUDE_3_HAIKU_20240307_MODEL_ID,

--- a/types/src/front/lib/assistant.ts
+++ b/types/src/front/lib/assistant.ts
@@ -105,8 +105,6 @@ export const GPT_3_5_TURBO_MODEL_ID = "gpt-3.5-turbo" as const;
 export const CLAUDE_3_OPUS_2024029_MODEL_ID = "claude-3-opus-20240229" as const;
 export const CLAUDE_3_5_SONNET_20240620_MODEL_ID =
   "claude-3-5-sonnet-20240620" as const;
-export const CLAUDE_3_SONNET_2024029_MODEL_ID =
-  "claude-3-sonnet-20240229" as const;
 export const CLAUDE_3_HAIKU_20240307_MODEL_ID =
   "claude-3-haiku-20240307" as const;
 export const CLAUDE_2_1_MODEL_ID = "claude-2.1" as const;
@@ -124,7 +122,6 @@ export const MODEL_IDS = [
   GPT_4O_MODEL_ID,
   CLAUDE_3_OPUS_2024029_MODEL_ID,
   CLAUDE_3_5_SONNET_20240620_MODEL_ID,
-  CLAUDE_3_SONNET_2024029_MODEL_ID,
   CLAUDE_3_HAIKU_20240307_MODEL_ID,
   CLAUDE_2_1_MODEL_ID,
   CLAUDE_INSTANT_1_2_MODEL_ID,

--- a/types/src/front/lib/assistant.ts
+++ b/types/src/front/lib/assistant.ts
@@ -66,7 +66,7 @@ export function getSmallWhitelistedModel(
     return GPT_3_5_TURBO_MODEL_CONFIG;
   }
   if (isProviderWhitelisted(owner, "anthropic")) {
-    return CLAUDE_3_SONNET_DEFAULT_MODEL_CONFIG;
+    return CLAUDE_3_5_SONNET_DEFAULT_MODEL_CONFIG;
   }
   if (isProviderWhitelisted(owner, "google_ai_studio")) {
     return GEMINI_FLASH_DEFAULT_MODEL_CONFIG;
@@ -428,7 +428,6 @@ export const SUPPORTED_MODEL_CONFIGS: ModelConfigurationType[] = [
   GPT_4_TURBO_MODEL_CONFIG,
   GPT_4O_MODEL_CONFIG,
   CLAUDE_3_OPUS_DEFAULT_MODEL_CONFIG,
-  CLAUDE_3_SONNET_DEFAULT_MODEL_CONFIG,
   CLAUDE_3_5_SONNET_DEFAULT_MODEL_CONFIG,
   CLAUDE_3_HAIKU_DEFAULT_MODEL_CONFIG,
   CLAUDE_2_DEFAULT_MODEL_CONFIG,


### PR DESCRIPTION
## Description

Follow-up to https://github.com/dust-tt/dust/pull/5767
Fixes https://github.com/dust-tt/tasks/issues/918

Remove all references to Sonnet 3 (models have been transitioned)
Add sonnet 3.5 to Dust apps

## Risk

N/A

## Deploy Plan

- deploy `front`