### PR TITLE
Split Gdrive in two workers (full sync and incremental sync).

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/client.ts
+++ b/connectors/src/connectors/google_drive/temporal/client.ts
@@ -3,12 +3,15 @@ import { Err, googleDriveIncrementalSyncWorkflowId, Ok } from "@dust-tt/types";
 import type { WorkflowHandle } from "@temporalio/client";
 import { WorkflowNotFoundError } from "@temporalio/client";
 
+import {
+  GDRIVE_FULL_SYNC_QUEUE_NAME,
+  GDRIVE_INCREMENTAL_SYNC_QUEUE_NAME,
+} from "@connectors/connectors/google_drive/temporal/config";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { getTemporalClient, terminateWorkflow } from "@connectors/lib/temporal";
 import mainLogger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 
-import { QUEUE_NAME } from "./config";
 import {
   googleDriveFullSync,
   googleDriveFullSyncWorkflowId,
@@ -42,7 +45,7 @@ export async function launchGoogleDriveFullSyncWorkflow(
     await terminateWorkflow(workflowId);
     await client.workflow.start(googleDriveFullSync, {
       args: [connectorId, dataSourceConfig],
-      taskQueue: QUEUE_NAME,
+      taskQueue: GDRIVE_FULL_SYNC_QUEUE_NAME,
       workflowId: workflowId,
       searchAttributes: {
         connectorId: [connectorId],
@@ -89,7 +92,7 @@ export async function launchGoogleDriveIncrementalSyncWorkflow(
     await terminateWorkflow(workflowId);
     await client.workflow.start(googleDriveIncrementalSync, {
       args: [connectorId, dataSourceConfig],
-      taskQueue: QUEUE_NAME,
+      taskQueue: GDRIVE_INCREMENTAL_SYNC_QUEUE_NAME,
       workflowId: workflowId,
       searchAttributes: {
         connectorId: [connectorId],
@@ -143,7 +146,7 @@ export async function launchGoogleGarbageCollector(
     }
     await client.workflow.start(googleDriveGarbageCollectorWorkflow, {
       args: [connector.id, new Date().getTime()],
-      taskQueue: QUEUE_NAME,
+      taskQueue: GDRIVE_INCREMENTAL_SYNC_QUEUE_NAME,
       workflowId: workflowId,
       searchAttributes: {
         connectorId: [connectorId],

--- a/connectors/src/connectors/google_drive/temporal/config.ts
+++ b/connectors/src/connectors/google_drive/temporal/config.ts
@@ -1,3 +1,3 @@
 export const WORKFLOW_VERSION = 5;
-export const QUEUE_NAME = `google-queue-v${WORKFLOW_VERSION}`;
-export const GDRIVE_INCREMENTAL_SYNC_DEBOUNCE_SEC = 10;
+export const GDRIVE_FULL_SYNC_QUEUE_NAME = `google-queue-v${WORKFLOW_VERSION}`;
+export const GDRIVE_INCREMENTAL_SYNC_QUEUE_NAME = `google-queue-incremental-v${WORKFLOW_VERSION}`;

--- a/connectors/src/connectors/google_drive/temporal/worker.ts
+++ b/connectors/src/connectors/google_drive/temporal/worker.ts
@@ -16,7 +16,7 @@ import {
   GDRIVE_INCREMENTAL_SYNC_QUEUE_NAME,
 } from "./config";
 
-export async function runGoogleWorker() {
+export async function runGoogleWorkers() {
   const { connection, namespace } = await getTemporalWorkerConnection();
   const workerFullSync = await Worker.create({
     workflowsPath: require.resolve("./workflows"),

--- a/connectors/src/connectors/google_drive/temporal/worker.ts
+++ b/connectors/src/connectors/google_drive/temporal/worker.ts
@@ -11,14 +11,36 @@ import {
 import { ActivityInboundLogInterceptor } from "@connectors/lib/temporal_monitoring";
 import logger from "@connectors/logger/logger";
 
-import { QUEUE_NAME } from "./config";
+import {
+  GDRIVE_FULL_SYNC_QUEUE_NAME,
+  GDRIVE_INCREMENTAL_SYNC_QUEUE_NAME,
+} from "./config";
 
 export async function runGoogleWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();
-  const worker = await Worker.create({
+  const workerFullSync = await Worker.create({
     workflowsPath: require.resolve("./workflows"),
     activities: { ...activities, ...sync_status },
-    taskQueue: QUEUE_NAME,
+    taskQueue: GDRIVE_FULL_SYNC_QUEUE_NAME,
+    maxConcurrentActivityTaskExecutions: 15,
+    connection,
+    maxCachedWorkflows: TEMPORAL_MAXED_CACHED_WORKFLOWS,
+    reuseV8Context: true,
+    namespace,
+    interceptors: {
+      activityInbound: [
+        (ctx: Context) => {
+          return new ActivityInboundLogInterceptor(ctx, logger);
+        },
+        () => new GoogleDriveCastKnownErrorsInterceptor(),
+      ],
+    },
+  });
+
+  const workerIncrementalSync = await Worker.create({
+    workflowsPath: require.resolve("./workflows"),
+    activities: { ...activities, ...sync_status },
+    taskQueue: GDRIVE_INCREMENTAL_SYNC_QUEUE_NAME,
     maxConcurrentActivityTaskExecutions: 30,
     connection,
     maxCachedWorkflows: TEMPORAL_MAXED_CACHED_WORKFLOWS,
@@ -34,5 +56,5 @@ export async function runGoogleWorker() {
     },
   });
 
-  await worker.run();
+  await Promise.all([workerFullSync.run(), workerIncrementalSync.run()]);
 }

--- a/connectors/src/start.ts
+++ b/connectors/src/start.ts
@@ -4,7 +4,7 @@ import { startServer } from "@connectors/api_server";
 import { runConfluenceWorker } from "@connectors/connectors/confluence/temporal/worker";
 
 import { runGithubWorker } from "./connectors/github/temporal/worker";
-import { runGoogleWorker } from "./connectors/google_drive/temporal/worker";
+import { runGoogleWorkers } from "./connectors/google_drive/temporal/worker";
 import { runIntercomWorker } from "./connectors/intercom/temporal/worker";
 import { runNotionWorker } from "./connectors/notion/temporal/worker";
 import { runSlackWorker } from "./connectors/slack/temporal/worker";
@@ -32,7 +32,7 @@ runNotionWorker().catch((err) =>
 runGithubWorker().catch((err) =>
   logger.error(errorFromAny(err), "Error running github worker")
 );
-runGoogleWorker().catch((err) =>
+runGoogleWorkers().catch((err) =>
   logger.error(errorFromAny(err), "Error running google worker")
 );
 runIntercomWorker().catch((err) =>

--- a/connectors/src/start_worker.ts
+++ b/connectors/src/start_worker.ts
@@ -7,7 +7,7 @@ import { runConfluenceWorker } from "@connectors/connectors/confluence/temporal/
 import { runWebCrawlerWorker } from "@connectors/connectors/webcrawler/temporal/worker";
 
 import { runGithubWorker } from "./connectors/github/temporal/worker";
-import { runGoogleWorker } from "./connectors/google_drive/temporal/worker";
+import { runGoogleWorkers } from "./connectors/google_drive/temporal/worker";
 import { runIntercomWorker } from "./connectors/intercom/temporal/worker";
 import { runNotionWorker } from "./connectors/notion/temporal/worker";
 import { runSlackWorker } from "./connectors/slack/temporal/worker";
@@ -19,7 +19,7 @@ setupGlobalErrorHandler(logger);
 const workerFunctions: Record<ConnectorProvider, () => Promise<void>> = {
   confluence: runConfluenceWorker,
   github: runGithubWorker,
-  google_drive: runGoogleWorker,
+  google_drive: runGoogleWorkers,
   intercom: runIntercomWorker,
   notion: runNotionWorker,
   slack: runSlackWorker,


### PR DESCRIPTION
## Description

We are splitting the Gdrive connectors into two queues:
- one for fullsync
- one for incremental sync.

When incremental sync is running (every 5 minutes), the full sync workflows are barely progressing, leading to extremely long full sync workflows.

See interval between full sync activities of this full sync workflow that has been going on for more than a week:

https://app.datadoghq.eu/apm/traces?query=%40_top_level%3A1%20%40workflow_id%3AgoogleDrive-fullSync-2376%20&agg_m=count&agg_m_source=base&agg_t=count&cols=service%2Cresource_name%2C%40duration%2C%40http.method%2C%40http.status_code&fromUser=false&graphType=flamegraph&historicalData=true&query_translation_version=v0&saved-view-id=93702&shouldShowLegend=true&sort=time&spanType=service-entry&traceQuery=&view=spans&viz=stream&start=1718358175931&end=1718962975931&paused=false

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- deploy connectors
- `./connectors> ./admin/cli.sh google_drive restart-all-incremental-sync-workflows`

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
