### PR TITLE
Exclude token usage from output when executing from cache

### DIFF
--- a/core/src/providers/llm.rs
+++ b/core/src/providers/llm.rs
@@ -555,7 +555,11 @@ impl LLMChatRequest {
                     let mut generations = store.llm_chat_cache_get(&project, self).await?;
                     match generations.len() {
                         0 => None,
-                        _ => Some(generations.remove(0)),
+                        _ => {
+                            let mut generation = generations.remove(0);
+                            generation.usage = None;
+                            Some(generation)
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Description

When a llm request is served from the cache, token consumption is also sent even though no request was done on a model.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy `core`
