### PR TITLE
[front] - feature: expand the width of the AssistantBrowserContainer

### DIFF
--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -302,6 +302,7 @@ export function ConversationContainer({
         leave="transition-opacity duration-100 ease-out"
         leaveFrom="opacity-100"
         leaveTo="opacity-0"
+        className="w-full max-w-4xl"
       >
         <AssistantBrowserContainer
           onAgentConfigurationClick={setInputbarMention}


### PR DESCRIPTION
## Description

Recent changes introduced a bug in which the AssistantBrowserContainer was not expanding its full size 
 
See problem below:
<img width="1512" alt="Screenshot 2024-06-21 at 16 57 46" src="https://github.com/dust-tt/dust/assets/32683010/38c6922b-a214-4433-92ed-9327412998bb">
<img width="1512" alt="Screenshot 2024-06-21 at 16 57 55" src="https://github.com/dust-tt/dust/assets/32683010/471904e4-2c7e-4ce1-a2e3-52cedde40d20">


## Risk

None

## Deploy Plan

Deploy `front`