### PR TITLE
Fix: mentions sorting by query issue

### DIFF
--- a/front/tests/lib/utils.test.ts
+++ b/front/tests/lib/utils.test.ts
@@ -12,6 +12,8 @@ test("compareForFuzzySort should correctly compare strings", () => {
     { query: "mygod", a: "ohmygodbot", b: "moatmode" },
     { query: "test", a: "test", b: "testlong" },
     { query: "test", a: "testlonger", b: "longtest" },
+    { query: "eng", a: "eng", b: "slack-engineering-highlights" },
+    { query: "c", a: "c", b: "RadicalFeedback" },
   ];
 
   for (const d of data) {


### PR DESCRIPTION
Description
---
When typing a search filter for mentioning an assistant, the computation of sort for assistansts that had multiple times the search filter present in their names was erroneous, leading to them being ranked first even if their match was poorer.

This particularly impacted single-letter named assistants.

This PR fixes that (cf new test cases)

Risk
---
na

Deploy
---
front