### PR TITLE
[Model sIds] Sids moved from hex to [A-Za-z0-9-_] 

### DIFF
--- a/front/lib/resources/key_resource.ts
+++ b/front/lib/resources/key_resource.ts
@@ -1,22 +1,22 @@
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-
 import type { KeyType, ModelId } from "@dust-tt/types";
 import type { LightWorkspaceType, Result } from "@dust-tt/types";
 import { formatUserFullName, redactString } from "@dust-tt/types";
+import { hash as blake3 } from "blake3";
 import type {
   Attributes,
   CreationAttributes,
   ModelStatic,
   Transaction,
 } from "sequelize";
+import { v4 as uuidv4 } from "uuid";
 
 import { User } from "@app/lib/models/user";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { KeyModel } from "@app/lib/resources/storage/models/keys";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
-import { new_id } from "@app/lib/utils";
 
 export interface KeyAuthType {
   id: ModelId;
@@ -37,7 +37,8 @@ export class KeyResource extends BaseResource<KeyModel> {
   }
 
   static async makeNew(blob: Omit<CreationAttributes<KeyModel>, "secret">) {
-    const secret = `sk-${new_id().slice(0, 32)}`;
+    const new_id = Buffer.from(blake3(uuidv4())).toString("hex");
+    const secret = `sk-${new_id.slice(0, 32)}`;
 
     const key = await KeyResource.model.create({
       ...blob,

--- a/front/lib/utils.ts
+++ b/front/lib/utils.ts
@@ -294,36 +294,3 @@ function alphanumFromByte(byte: number) {
   }
   return index === 62 ? 45 : 95;
 }
-
-// TO BE DELETED BEFORE MERGING
-function checkUniform() {
-  const sIds = new Set<string>();
-  for (let i = 0; i < 100000; i++) {
-    sIds.add(generateModelSId());
-  }
-  // quick check just for the sake of it
-  assert(sIds.size === 100000);
-
-  // now the real uniformity check
-  const sIdArray = Array.from(sIds);
-  const charMap: Record<string, number> = {};
-  for (const sId of sIdArray) {
-    for (const char of sId) {
-      if (!charMap[char]) {
-        charMap[char] = 1;
-      } else {
-        charMap[char]++;
-      }
-    }
-  }
-
-  console.log(charMap);
-  for (const char in charMap) {
-    assert(
-      charMap[char] > ((100_000 * 12) / 64) * 0.98 &&
-        charMap[char] < ((100_000 * 12) / 64) * 1.02
-    );
-  }
-}
-
-checkUniform();

--- a/front/lib/utils.ts
+++ b/front/lib/utils.ts
@@ -1,5 +1,4 @@
 import type { LightAgentConfigurationType } from "@dust-tt/types";
-import assert from "assert";
 import { hash as blake3 } from "blake3";
 import { v4 as uuidv4 } from "uuid";
 

--- a/front/migrations/20230413_workspaces_memberships.ts
+++ b/front/migrations/20230413_workspaces_memberships.ts
@@ -1,7 +1,6 @@
 import { User } from "@app/lib/models/user";
 import { Workspace } from "@app/lib/models/workspace";
 import { MembershipModel } from "@app/lib/resources/storage/models/membership";
-import { new_id } from "@app/lib/utils";
 
 async function main() {
   const users = await User.findAll();
@@ -24,6 +23,7 @@ async function main() {
           });
 
           if (!m) {
+            // @ts-expect-error new_id deprecated after #5755
             const uId = new_id();
 
             const w = await Workspace.create({


### PR DESCRIPTION
Description
---
Fixes https://github.com/dust-tt/tasks/issues/891

The way of generating sIds before was leading to collisions starting ~ 1 million elements, which would not match our scale

This PR should make collisions unlikely until ~ 1 billion messages.

Notes:
- new_client_sId: not instantaneous to refactor, and not useful to do it => leaving as is

Risk
---
- quickly checked for uniform distribution of characters
- risk: some code implicitly uses the fact that sIds are limited to hex chars

=> hard to spot before merge. Best is to warn team and be wary for the day

Deploy
---
front