### PR TITLE
Set fixed value for keep alive timeout

### DIFF
--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -11,6 +11,8 @@ import {
 import { MAX_CHUNK_SIZE } from "@dust-tt/types";
 import type { AxiosRequestConfig, AxiosResponse } from "axios";
 import axios from "axios";
+import http from "http";
+import https from "https";
 import { fromMarkdown } from "mdast-util-from-markdown";
 import { gfmFromMarkdown, gfmToMarkdown } from "mdast-util-gfm";
 import { toMarkdown } from "mdast-util-to-markdown";
@@ -22,8 +24,12 @@ import logger from "@connectors/logger/logger";
 import { statsDClient } from "@connectors/logger/withlogging";
 import type { DataSourceConfig } from "@connectors/types/data_source_config";
 
-const axiosWithTimeout = axios.create();
-axiosWithTimeout.defaults.timeout = 60000;
+const axiosWithTimeout = axios.create({
+  timeout: 60000,
+  // Ensure client timeout is lower than the target server timeout.
+  httpAgent: new http.Agent({ keepAlive: true, keepAliveMsecs: 4000 }),
+  httpsAgent: new https.Agent({ keepAlive: true, keepAliveMsecs: 4000 }),
+});
 
 const { DUST_FRONT_API } = process.env;
 if (!DUST_FRONT_API) {

--- a/front/package.json
+++ b/front/package.json
@@ -2,7 +2,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start",
+    "start": "next start --keepAliveTimeout 5000",
     "start:worker": "tsx ./start_worker.ts",
     "lint": "next lint",
     "format": "prettier --write .",


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
We noticed an increase in `ECONNRESET` errors within our infrastructure. After investigating, it appears that we have not correctly set keep-alive timeouts. The most frequent occurrences, aside from Nango, are when our front API is accessed by connector workers. Since we upgraded to the latest version of Node.js, `keepAlive` is enabled by default.

With `keepAlive` enabled, it is crucial that the server's HTTP keep-alive timeout is longer than the client's to avoid sending requests to closed sockets. Lucky for us, this is manageable when we control both the client and the server.

This Prmakes the following changes:
- Explicitly enables `keepAlive` for requests related to data sources in connector workers. If successful, we plan to apply this setting to all requests to our front service. The keep-alive timeout is set to 4 seconds.
- Initiates the Next.js server with a server keep-alive timeout of 5 seconds.

For interactions between the front-service and core service, where the core service's default keep-alive timeout is 15 seconds, the same adjustments are necessary. However, since we use the browser's fetch API that doesn't support custom agent configurations, this will require additional effort.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
Worst case some requests fail, we have retry mechanism in place. Safe to rollback.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
- [x] Ensure that `--keepAliveTimeout 5000` works as expected in prod.
