### PR TITLE
fix: avoid duplicate chain of thoughts

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -193,10 +193,18 @@ export function AgentMessage({
 
       case "agent_chain_of_thought":
         setStreamedAgentMessage((m) => {
-          return {
-            ...m,
-            chainOfThoughts: [...m.chainOfThoughts, event.chainOfThought],
-          };
+          if (m.chainOfThoughts.length === 0) {
+            // We don't have any chain of thoughts yet. This means the chain of thought was being streamed as regular tokens.
+            // In this case, we clear the content and add the chain of thought.
+            return {
+              ...m,
+              content: "",
+              chainOfThoughts: [event.chainOfThought],
+            };
+          }
+          // Otherwise, we don't do anything, because we already have this chain of thought in the chainOfThoughts array
+          // (and it wasn't being streamed as regular tokens, so we don't need to clear the content)
+          return m;
         });
         break;
 


### PR DESCRIPTION
## Description

fixes https://github.com/dust-tt/dust/issues/5801

This really fixes 2 problems:
1. sometimes, CoT tokens are being initially streamed as regular tokens (so are rendered in the agent message). That's inevitable because some models do CoT without wrapping in tags, and we realize that these tokens are CoT when we suddenly get a tool use (any token that comes before tools use is considered to be CoT). In these cases, we emit a CoT event, so if the CoTs are empty, the right behavior is to add the CoT to the CoTs array and to clear the agent message (as it only contains CoT).
2. When the UI receives a CoT event but the CoT array is not empty, we should not append the CoT as it is already rendered on the UI as CoT (it was being streamed as CoT tokens)


## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
