### PR TITLE
Revert "Increase connectors Sequelize connection pool"

### DIFF
--- a/connectors/src/resources/storage/index.ts
+++ b/connectors/src/resources/storage/index.ts
@@ -1,36 +1,10 @@
-import { isDevelopment } from "@dust-tt/types";
 import { Sequelize } from "sequelize";
 
-import logger from "@connectors/logger/logger";
 import { dbConfig } from "@connectors/resources/storage/config";
 
-export const sequelizeConnection = new Sequelize({
-  logging: false,
-});
-
-const acquireAttempts = new WeakMap();
-
-new Sequelize(dbConfig.getRequiredDatabaseURI(), {
-  pool: {
-    // Default is 5.
-    max: isDevelopment() ? 5 : 10,
-  },
-  logging: false,
-  hooks: {
-    beforePoolAcquire: (options) => {
-      acquireAttempts.set(options, Date.now());
-    },
-    afterPoolAcquire: (connection, options) => {
-      const elapsedTime = Date.now() - acquireAttempts.get(options);
-      if (elapsedTime > 100) {
-        logger.info(
-          {
-            elapsedTime,
-            callStack: new Error().stack,
-          },
-          "Long sequelize connection acquisition detected"
-        );
-      }
-    },
-  },
-});
+export const sequelizeConnection = new Sequelize(
+  dbConfig.getRequiredDatabaseURI(),
+  {
+    logging: false,
+  }
+);

--- a/front/lib/development.ts
+++ b/front/lib/development.ts
@@ -1,8 +1,11 @@
 import type { WorkspaceType } from "@dust-tt/types";
-import { isDevelopment } from "@dust-tt/types";
 
 export const PRODUCTION_DUST_WORKSPACE_ID = "0ec9852c2f";
 const PRODUCTION_DUST_APPS_WORKSPACE_ID = "78bda07b39";
+
+export function isDevelopment() {
+  return process.env.NODE_ENV === "development";
+}
 
 export function isDevelopmentOrDustWorkspace(owner: WorkspaceType) {
   return (

--- a/front/lib/resources/storage/index.ts
+++ b/front/lib/resources/storage/index.ts
@@ -1,6 +1,6 @@
-import { isDevelopment } from "@dust-tt/types";
 import { Sequelize } from "sequelize";
 
+import { isDevelopment } from "@app/lib/development";
 import { dbConfig } from "@app/lib/resources/storage/config";
 import logger from "@app/logger/logger";
 

--- a/types/src/index.ts
+++ b/types/src/index.ts
@@ -64,7 +64,6 @@ export * from "./front/user";
 export * from "./front/workspace";
 export * from "./shared/cache";
 export * from "./shared/deployment";
-export * from "./shared/env";
 export * from "./shared/message_classification";
 export * from "./shared/model_id";
 export * from "./shared/nango_errors";

--- a/types/src/shared/env.ts
+++ b/types/src/shared/env.ts
@@ -1,3 +1,0 @@
-export function isDevelopment() {
-  return process.env.NODE_ENV === "development";
-}


### PR DESCRIPTION
Reverts dust-tt/dust#5808

We're seeing in production:

```

> connectors@0.1.0 start:worker
> tsx ./src/start_worker.ts --workers confluence github intercom slack

/app/node_modules/sequelize/src/sequelize.js:300
      throw new Error('Dialect needs to be explicitly supplied as of v4.0.0');
            ^


Error: Dialect needs to be explicitly supplied as of v4.0.0
    at Sequelize (/app/node_modules/sequelize/src/sequelize.js:300:13)
    at logger (/app/src/resources/storage/index.ts:7:36)
    at Object.<anonymous> (/app/src/resources/storage/index.ts:36:2)
    at Module._compile (node:internal/modules/cjs/loader:1358:14)
    at Object.h (/app/node_modules/tsx/dist/global-require-patch-C5g4AuOV.cjs:1:1080)
    at Module.load (node:internal/modules/cjs/loader:1208:32)
    at Module._load (node:internal/modules/cjs/loader:1024:12)
    at Module.require (node:internal/modules/cjs/loader:1233:19)
    at Hook.Module.require (/app/node_modules/dd-trace/packages/dd-trace/src/ritm.js:85:33)
    at require (node:internal/modules/helpers:179:18)

Node.js v20.13.0
```