### PR TITLE
feat: per-model and context-specific meta prompting

### DIFF
--- a/front/lib/api/assistant/actions/process.ts
+++ b/front/lib/api/assistant/actions/process.ts
@@ -228,12 +228,13 @@ export class ProcessConfigurationServerRunner extends BaseActionConfigurationSer
       }),
     };
 
-    const prompt = await constructPromptMultiActions(
-      auth,
+    const prompt = await constructPromptMultiActions(auth, {
       userMessage,
       agentConfiguration,
-      "Process the retrieved data to extract structured information based on the provided schema."
-    );
+      fallbackPrompt:
+        "Process the retrieved data to extract structured information based on the provided schema.",
+      model: supportedModel,
+    });
 
     const config = cloneBaseConfig(
       DustProdActionRegistry["assistant-v2-process"].config

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -300,13 +300,6 @@ export async function* runMultiActionsAgent(
   | AgentActionsEvent
   | AgentChainOfThoughtEvent
 > {
-  const prompt = await constructPromptMultiActions(
-    auth,
-    userMessage,
-    agentConfiguration,
-    "You are a conversational assistant with access to function calling."
-  );
-
   const model = SUPPORTED_MODEL_CONFIGS.find(
     (m) =>
       m.modelId === agentConfiguration.model.modelId &&
@@ -328,6 +321,20 @@ export async function* runMultiActionsAgent(
     };
     return;
   }
+
+  let fallbackPrompt = "You are a conversational assistant";
+  if (agentConfiguration.actions.length) {
+    fallbackPrompt += " with access to function calling.";
+  } else {
+    fallbackPrompt += ".";
+  }
+
+  const prompt = await constructPromptMultiActions(auth, {
+    userMessage,
+    agentConfiguration,
+    fallbackPrompt,
+    model,
+  });
 
   const MIN_GENERATION_TOKENS = 2048;
 

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -324,7 +324,7 @@ export async function* runMultiActionsAgent(
 
   let fallbackPrompt = "You are a conversational assistant";
   if (agentConfiguration.actions.length) {
-    fallbackPrompt += " with access to function calling.";
+    fallbackPrompt += " with access to tool use.";
   } else {
     fallbackPrompt += ".";
   }

--- a/types/src/front/lib/assistant.ts
+++ b/types/src/front/lib/assistant.ts
@@ -1,6 +1,5 @@
 import { WorkspaceType } from "../../front/user";
 import { ExtractSpecificKeys } from "../../shared/typescipt_utils";
-import { assertNever } from "../../shared/utils/assert_never";
 import { ioTsEnum } from "../../shared/utils/iots_utils";
 
 /**
@@ -29,29 +28,6 @@ export const ModelProviderIdCodec =
 export const EmbeddingProviderCodec = ioTsEnum<
   (typeof EMBEDDING_PROVIDER_IDS)[number]
 >(EMBEDDING_PROVIDER_IDS);
-
-export function metaPromptForProvider(
-  providerId: ModelProviderIdType
-): string | null {
-  switch (providerId) {
-    case "openai":
-      return "When using tools, generate valid and properly escaped JSON arguments.";
-    case "anthropic":
-      // see https://docs.anthropic.com/en/docs/tool-use#tool-use-best-practices-and-limitations
-      return `Do not reflect on the quality of the returned search results in your response.
-<tools_instructions>
-When using tools to answer the user's question, the assistant should follow these guidelines:
-
-1. Immediately before invoking a tool, think for one sentence in <thinking> tags about how it evaluates against the criteria for a good and bad tool use. Never emit any text beyond this thinking sentence before using the tool.
-</tools_instructions>`;
-    case "mistral":
-      return null;
-    case "google_ai_studio":
-      return null;
-    default:
-      assertNever(providerId);
-  }
-}
 
 export function isProviderWhitelisted(
   owner: WorkspaceType,
@@ -168,7 +144,16 @@ export type ModelConfigurationType = {
     // the next event before emitting tokens.
     incompleteDelimiterRegex?: RegExp;
   };
+
+  // This meta-prompt is injected into the assistant's system instructions every time.
+  metaPrompt?: string;
+
+  // This meta-prompt is injected into the assistant's system instructions if the assistant is in a tool-use context.
+  toolUseMetaPrompt?: string;
 };
+
+const OPEN_AI_TOOL_USE_META_PROMPT =
+  "When using tools, generate valid and properly escaped JSON arguments.";
 
 export const GPT_4_TURBO_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "openai",
@@ -181,6 +166,7 @@ export const GPT_4_TURBO_MODEL_CONFIG: ModelConfigurationType = {
   description: "OpenAI's advanced model for complex tasks (128k context).",
   shortDescription: "OpenAI's most capable model.",
   isLegacy: false,
+  toolUseMetaPrompt: OPEN_AI_TOOL_USE_META_PROMPT,
 };
 export const GPT_4O_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "openai",
@@ -193,6 +179,7 @@ export const GPT_4O_MODEL_CONFIG: ModelConfigurationType = {
   description: "OpenAI's GPT-4o model (128k context).",
   shortDescription: "OpenAI's most advanced model.",
   isLegacy: false,
+  toolUseMetaPrompt: OPEN_AI_TOOL_USE_META_PROMPT,
 };
 export const GPT_3_5_TURBO_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "openai",
@@ -206,6 +193,7 @@ export const GPT_3_5_TURBO_MODEL_CONFIG: ModelConfigurationType = {
     "OpenAI's cost-effective and high throughput model (16k context).",
   shortDescription: "OpenAI's fast model.",
   isLegacy: false,
+  toolUseMetaPrompt: OPEN_AI_TOOL_USE_META_PROMPT,
 };
 
 const ANTHROPIC_DELIMITERS_CONFIGURATION = {
@@ -263,6 +251,8 @@ export const CLAUDE_3_OPUS_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   shortDescription: "Anthropic's powerful model.",
   isLegacy: false,
   delimitersConfiguration: ANTHROPIC_DELIMITERS_CONFIGURATION,
+  toolUseMetaPrompt:
+    "Do not reflect on the quality of the returned search results in your response.",
 };
 export const CLAUDE_3_5_SONNET_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "anthropic",
@@ -277,6 +267,11 @@ export const CLAUDE_3_5_SONNET_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   shortDescription: "Anthropic's smartest model.",
   isLegacy: false,
   delimitersConfiguration: ANTHROPIC_DELIMITERS_CONFIGURATION,
+  toolUseMetaPrompt: `<tools_instructions>
+When using tools to answer the user's question, the assistant should follow these guidelines:
+
+1. Immediately before invoking a tool, think for one sentence in <thinking> tags about how it evaluates against the criteria for a good and bad tool use. Never emit any text beyond this thinking sentence before using the tool.
+</tools_instructions>`,
 };
 export const CLAUDE_3_HAIKU_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "anthropic",

--- a/types/src/front/lib/assistant.ts
+++ b/types/src/front/lib/assistant.ts
@@ -238,6 +238,12 @@ const ANTHROPIC_DELIMITERS_CONFIGURATION = {
   ],
 };
 
+const ANTHROPIC_TOOL_USE_META_PROMPT = `<tools_instructions>
+When using tools to answer the user's question, the assistant should follow these guidelines:
+
+1. Immediately before invoking a tool, think for one sentence in <thinking> tags about how it evaluates against the criteria for a good and bad tool use. Never emit any text beyond this thinking sentence before using the tool.
+</tools_instructions>`;
+
 export const CLAUDE_3_OPUS_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "anthropic",
   modelId: CLAUDE_3_OPUS_2024029_MODEL_ID,
@@ -251,8 +257,7 @@ export const CLAUDE_3_OPUS_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   shortDescription: "Anthropic's powerful model.",
   isLegacy: false,
   delimitersConfiguration: ANTHROPIC_DELIMITERS_CONFIGURATION,
-  toolUseMetaPrompt:
-    "Do not reflect on the quality of the returned search results in your response.",
+  toolUseMetaPrompt: `Do not reflect on the quality of the returned search results in your response.\n${ANTHROPIC_TOOL_USE_META_PROMPT}`,
 };
 export const CLAUDE_3_5_SONNET_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "anthropic",
@@ -267,11 +272,7 @@ export const CLAUDE_3_5_SONNET_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   shortDescription: "Anthropic's smartest model.",
   isLegacy: false,
   delimitersConfiguration: ANTHROPIC_DELIMITERS_CONFIGURATION,
-  toolUseMetaPrompt: `<tools_instructions>
-When using tools to answer the user's question, the assistant should follow these guidelines:
-
-1. Immediately before invoking a tool, think for one sentence in <thinking> tags about how it evaluates against the criteria for a good and bad tool use. Never emit any text beyond this thinking sentence before using the tool.
-</tools_instructions>`,
+  toolUseMetaPrompt: ANTHROPIC_TOOL_USE_META_PROMPT,
 };
 export const CLAUDE_3_HAIKU_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "anthropic",
@@ -285,6 +286,7 @@ export const CLAUDE_3_HAIKU_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
     "Anthropic Claude 3 Haiku model, fastest and most compact model for near-instant responsiveness.",
   shortDescription: "Anthropic's quick model.",
   isLegacy: false,
+  toolUseMetaPrompt: ANTHROPIC_TOOL_USE_META_PROMPT,
 };
 export const CLAUDE_2_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "anthropic",


### PR DESCRIPTION
## Description

- move meta prompting to model configs instead of providers. It's easy to have constants if all models of a given provider require a specific meta prompt.
- introduce `toolUseMetaPrompt` for meta prompt that only applies to tool use context (confusing for some models to talk about tools when there are no tools)

## Risk

Tested. In the critical path.

## Deploy Plan

N/A