### PR TITLE
Remove presetAction from templates

### DIFF
--- a/front/lib/resources/storage/models/templates.ts
+++ b/front/lib/resources/storage/models/templates.ts
@@ -1,5 +1,4 @@
 import type {
-  ActionPreset,
   AssistantCreativityLevel,
   ModelIdType,
   ModelProviderIdType,
@@ -39,7 +38,6 @@ export class TemplateModel extends Model<
   declare presetTemperature: AssistantCreativityLevel;
   declare presetProviderId: ModelProviderIdType;
   declare presetModelId: ModelIdType;
-  declare presetAction: ActionPreset; // @todo[daph] Remove this field once templates are migrated to multi-ations.
   declare presetActions: TemplateActionType[];
 
   declare timeFrameDuration: number | null;
@@ -106,10 +104,6 @@ TemplateModel.init(
       allowNull: false,
     },
     presetModelId: {
-      type: DataTypes.STRING,
-      allowNull: false,
-    },
-    presetAction: {
       type: DataTypes.STRING,
       allowNull: false,
     },

--- a/front/lib/resources/template_resource.ts
+++ b/front/lib/resources/template_resource.ts
@@ -144,7 +144,6 @@ export class TemplateResource extends BaseResource<TemplateModel> {
       helpActions: this.helpActions,
       helpInstructions: this.helpInstructions,
       pictureUrl: this.pictureUrl,
-      presetAction: this.presetAction,
       presetActions: this.presetActions,
       timeFrameDuration: this.timeFrameDuration,
       timeFrameUnit: this.timeFrameUnit,

--- a/front/migrations/db/migration_26.sql
+++ b/front/migrations/db/migration_26.sql
@@ -1,0 +1,2 @@
+-- Migration created on Jun 24, 2024
+ALTER TABLE "public"."templates" DROP COLUMN "presetAction";

--- a/front/pages/api/poke/templates/[tId].ts
+++ b/front/pages/api/poke/templates/[tId].ts
@@ -128,7 +128,6 @@ async function handler(
         handle: body.handle,
         helpActions: body.helpActions ?? null,
         helpInstructions: body.helpInstructions ?? null,
-        presetAction: body.presetAction,
         presetActions: body.presetActions,
         timeFrameDuration: body.timeFrameDuration
           ? parseInt(body.timeFrameDuration)

--- a/front/pages/api/poke/templates/index.ts
+++ b/front/pages/api/poke/templates/index.ts
@@ -97,7 +97,6 @@ async function handler(
         handle: body.handle,
         helpActions: body.helpActions ?? null,
         helpInstructions: body.helpInstructions ?? null,
-        presetAction: body.presetAction,
         presetActions: body.presetActions,
         presetDescription: null,
         presetInstructions: body.presetInstructions ?? null,

--- a/front/pages/api/w/[wId]/assistant/builder/templates/index.ts
+++ b/front/pages/api/w/[wId]/assistant/builder/templates/index.ts
@@ -40,13 +40,9 @@ async function handler(
         visibility: "published",
       });
 
-      const filteredTemplates = templates.filter((t) => {
-        return t.presetAction === "reply" || t.presetActions.length > 0;
-      });
-
       return res
         .status(200)
-        .json({ templates: filteredTemplates.map((t) => t.toListJSON()) });
+        .json({ templates: templates.map((t) => t.toListJSON()) });
 
     default:
       return apiError(req, res, {

--- a/front/pages/poke/[wId]/assistants/[aId]/index.tsx
+++ b/front/pages/poke/[wId]/assistants/[aId]/index.tsx
@@ -1,6 +1,6 @@
 import { ContextItem, Page } from "@dust-tt/sparkle";
 import type { AgentConfigurationType } from "@dust-tt/types";
-import { ACTION_PRESETS, SUPPORTED_MODEL_CONFIGS } from "@dust-tt/types";
+import { SUPPORTED_MODEL_CONFIGS } from "@dust-tt/types";
 import { JsonViewer } from "@textea/json-viewer";
 import type { InferGetServerSidePropsType } from "next";
 
@@ -81,7 +81,7 @@ const DataSourcePage = ({
                       {a.actions.map((action, index) => (
                         <div key={index}>
                           <div className="font-bold">
-                            Action {index + 1}: {ACTION_PRESETS[action.type]}
+                            Action {index + 1}: {action.type}
                           </div>
                           <JsonViewer
                             value={action}

--- a/front/pages/poke/templates/[tId].tsx
+++ b/front/pages/poke/templates/[tId].tsx
@@ -10,7 +10,6 @@ import type {
   TemplateTagCodeType,
 } from "@dust-tt/types";
 import {
-  ACTION_PRESETS,
   ASSISTANT_CREATIVITY_LEVELS,
   CreateTemplateFormSchema,
   generateTailwindBackgroundColors,
@@ -30,7 +29,6 @@ import { useFieldArray, useForm } from "react-hook-form";
 import { MultiSelect } from "react-multi-select-component";
 
 import { makeUrlForEmojiAndBackgroud } from "@app/components/assistant_builder/avatar_picker/utils";
-import { TIME_FRAME_UNIT_TO_LABEL } from "@app/components/assistant_builder/shared";
 import PokeNavbar from "@app/components/poke/PokeNavbar";
 import { PokeButton } from "@app/components/poke/shadcn/ui/button";
 import {
@@ -331,6 +329,7 @@ function PresetActionsField({
                 </PokeFormItem>
               </div>
             ))}
+            <br />
             <PokeButton
               variant="secondary"
               onClick={(e) => {
@@ -568,7 +567,6 @@ function TemplatesPage({
       presetInstructions: "",
       presetModelId: GPT_4_TURBO_MODEL_CONFIG.modelId,
       presetTemperature: "balanced",
-      presetAction: "reply",
       helpInstructions: "",
       helpActions: "",
       emoji: "black_cat/1f408-200d-2b1b", // 🐈‍⬛.
@@ -577,8 +575,6 @@ function TemplatesPage({
       visibility: "draft",
     },
   });
-
-  const presetAction = form.watch("presetAction");
 
   useEffect(() => {
     if (assistantTemplate) {
@@ -668,39 +664,6 @@ function TemplatesPage({
                   value: acl,
                 }))}
               />
-              <div>
-                <SelectField
-                  control={form.control}
-                  name="presetAction"
-                  title="Preset Action"
-                  options={Object.entries(ACTION_PRESETS).map(([k, v]) => ({
-                    value: k,
-                    display: v,
-                  }))}
-                />
-                {presetAction === "process_configuration" && (
-                  <div className={"flex flex-row items-center gap-4 pb-4"}>
-                    <InputField
-                      control={form.control}
-                      name="timeFrameDuration"
-                      title="From the last"
-                      placeholder="1"
-                      type="number"
-                    />
-                    <SelectField
-                      control={form.control}
-                      name="timeFrameUnit"
-                      title="Unit"
-                      options={Object.entries(TIME_FRAME_UNIT_TO_LABEL).map(
-                        (v) => ({
-                          value: v[0],
-                          display: v[1],
-                        })
-                      )}
-                    />
-                  </div>
-                )}
-              </div>
             </div>
             <div className="grid grid-cols-3 gap-4">
               <PickerInputField
@@ -757,8 +720,8 @@ function TemplatesPage({
             <TextareaField
               control={form.control}
               name="helpActions"
-              title="Help Actions"
-              placeholder="Actions help bubble..."
+              title="Help Tools"
+              placeholder="Tools help bubble..."
               previewMardown={true}
             />
             <PresetActionsField
@@ -766,7 +729,6 @@ function TemplatesPage({
               name="presetActions"
               title="Preset Tools"
             />
-
             <div className="space flex gap-2">
               <PokeButton
                 onClick={form.handleSubmit(onSubmit)}


### PR DESCRIPTION
## Description

This PR removes the code related to `presetAction` that have been replaced by `presetActions` for the release of Tools. 

## Risk

Breaking templates (especially creation/edition in Poké). 
Can be rolled back. 


## Deploy Plan

- Deploy front. 
- Run migration 26 on prodbox to remove the old column. 
