### PR TITLE
enh: add user context to CONTEXT prompt

### DIFF
--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -320,6 +320,12 @@ export async function constructPromptMultiActions(
   context += `local_time: ${d.format("YYYY-MM-DD HH:mm (ddd)")}\n`;
   if (owner) {
     context += `workspace: ${owner.name}\n`;
+    if (userMessage.context.fullName) {
+      context += `user_full_name: ${userMessage.context.fullName}\n`;
+    }
+    if (userMessage.context.email) {
+      context += `user_email: ${userMessage.context.email}\n`;
+    }
   }
 
   // INSTRUCTIONS section


### PR DESCRIPTION
## Description

Some models don't see the "name" param on messages, so adding information about the user in the prompt can be useful.

## Risk

N/A (slightly more tokens)

## Deploy Plan

N/A