### PR TITLE
chore: get rid of useDualWorkflow

### DIFF
--- a/connectors/migrations/20230505_add_notion_connector_state.ts
+++ b/connectors/migrations/20230505_add_notion_connector_state.ts
@@ -29,7 +29,6 @@ async function main() {
         );
         await NotionConnectorState.create({
           connectorId: connector.id,
-          useDualWorkflow: true,
         });
       }
     }

--- a/connectors/migrations/db/migration_03.sql
+++ b/connectors/migrations/db/migration_03.sql
@@ -1,0 +1,5 @@
+-- Migration created on Jun 24, 2024
+ALTER TABLE
+    notion_connector_states
+ALTER COLUMN
+    "useDualWorkflow" DROP NOT NULL;

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -55,10 +55,6 @@ export async function createNotionConnector(
 
   let connector: ConnectorResource;
   try {
-    const notionConfigurationBlob = {
-      useDualWorkflow: true,
-    };
-
     connector = await ConnectorResource.makeNew(
       "notion",
       {
@@ -67,7 +63,7 @@ export async function createNotionConnector(
         workspaceId: dataSourceConfig.workspaceId,
         dataSourceName: dataSourceConfig.dataSourceName,
       },
-      notionConfigurationBlob
+      {}
     );
   } catch (e) {
     logger.error({ error: e }, "Error creating notion connector.");

--- a/connectors/src/connectors/notion/temporal/client.ts
+++ b/connectors/src/connectors/notion/temporal/client.ts
@@ -40,9 +40,7 @@ export async function launchNotionSyncWorkflow(
     );
   }
 
-  const useDualWorkflow = notionConnectorState.useDualWorkflow;
-
-  const workflow = await getNotionWorkflow(dataSourceConfig);
+  const workflow = await getNotionWorkflow(dataSourceConfig, "never");
 
   if (workflow && workflow.executionDescription.status.name === "RUNNING") {
     logger.warn(
@@ -60,11 +58,11 @@ export async function launchNotionSyncWorkflow(
         connectorId,
         startFromTs,
         forceResync,
-        garbageCollectionMode: useDualWorkflow ? "never" : "auto",
+        garbageCollectionMode: "never",
       },
     ],
     taskQueue: QUEUE_NAME,
-    workflowId: getNotionWorkflowId(dataSourceConfig),
+    workflowId: getNotionWorkflowId(dataSourceConfig, "never"),
     searchAttributes: {
       connectorId: [connectorId],
     },
@@ -78,9 +76,7 @@ export async function launchNotionSyncWorkflow(
     "launchNotionSyncWorkflow: Started Notion sync workflow."
   );
 
-  if (useDualWorkflow) {
-    await launchNotionGarbageCollectorWorkflow(connectorId);
-  }
+  await launchNotionGarbageCollectorWorkflow(connectorId);
 }
 
 export async function launchNotionGarbageCollectorWorkflow(
@@ -150,7 +146,7 @@ export async function stopNotionSyncWorkflow(
   }
 
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
-  const workflow = await getNotionWorkflow(dataSourceConfig);
+  const workflow = await getNotionWorkflow(dataSourceConfig, "never");
 
   if (!workflow) {
     logger.warn(
@@ -186,9 +182,7 @@ export async function stopNotionSyncWorkflow(
     "Terminated Notion sync workflow."
   );
 
-  if (notionConnectorState.useDualWorkflow) {
-    await stopNotionGarbageCollectorWorkflow(connectorId);
-  }
+  await stopNotionGarbageCollectorWorkflow(connectorId);
 }
 
 export async function stopNotionGarbageCollectorWorkflow(
@@ -238,7 +232,7 @@ export async function stopNotionGarbageCollectorWorkflow(
 
 export async function getNotionWorkflow(
   dataSourceInfo: DataSourceInfo,
-  gargbageCollectionMode: NotionGarbageCollectionMode = "auto"
+  gargbageCollectionMode: NotionGarbageCollectionMode
 ): Promise<{
   executionDescription: WorkflowExecutionDescription;
   handle: WorkflowHandle;

--- a/connectors/src/lib/models/notion.ts
+++ b/connectors/src/lib/models/notion.ts
@@ -18,7 +18,7 @@ export class NotionConnectorState extends Model<
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
-  declare useDualWorkflow: boolean;
+  declare useDualWorkflow: CreationOptional<boolean>;
   declare fullResyncStartTime?: CreationOptional<Date>;
 
   declare lastGarbageCollectionFinishTime?: Date;
@@ -45,7 +45,7 @@ NotionConnectorState.init(
     },
     useDualWorkflow: {
       type: DataTypes.BOOLEAN,
-      allowNull: false,
+      allowNull: true,
     },
     fullResyncStartTime: {
       type: DataTypes.DATE,

--- a/types/src/connectors/notion.ts
+++ b/types/src/connectors/notion.ts
@@ -8,11 +8,11 @@ import * as t from "io-ts";
 export type PageObjectProperties = PageObjectResponse["properties"];
 export type PropertyKeys = keyof PageObjectProperties;
 export type PropertyTypes = PageObjectProperties[PropertyKeys]["type"];
-export type NotionGarbageCollectionMode = "always" | "auto" | "never";
+export type NotionGarbageCollectionMode = "always" | "never";
 
 export function getNotionWorkflowId(
   dataSourceInfo: { workspaceId: string; dataSourceName: string },
-  gargbageCollectionMode: NotionGarbageCollectionMode = "auto"
+  gargbageCollectionMode: NotionGarbageCollectionMode
 ) {
   let wfName = "workflow-notion";
   if (gargbageCollectionMode === "always") {


### PR DESCRIPTION
## Description

https://github.com/dust-tt/tasks/issues/763 (1/2)

- remove all logic associated with "useDualWorkflow"
- make the field nullable
- stop filing it

## Risk

Logic isn't used anymore.

## Deploy Plan

1. run migration (prodbox)
2. deploy code
3. (other PR) drop the column