### PR TITLE
poke: Open data source document content in new page

### DIFF
--- a/front/pages/poke/[wId]/data_sources/[name]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[name]/index.tsx
@@ -332,7 +332,7 @@ const DataSourcePage = ({
         "Are you sure you want to access this sensible user data? (Access will be logged)"
       )
     ) {
-      void router.push(
+      window.open(
         `/poke/${owner.sId}/data_sources/${
           dataSource.name
         }/view?documentId=${encodeURIComponent(documentId)}`


### PR DESCRIPTION
## Description

Loosing tree exploration state is annoying as fuck. Open in new page.

## Risk

N/A

## Deploy Plan

- deploy `front`