### PR TITLE
enh: split to new CoT on CoT complete event

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -202,9 +202,12 @@ export function AgentMessage({
               chainOfThoughts: [event.chainOfThought],
             };
           }
-          // Otherwise, we don't do anything, because we already have this chain of thought in the chainOfThoughts array
-          // (and it wasn't being streamed as regular tokens, so we don't need to clear the content)
-          return m;
+          // Otherwise, we insert an empty COT so that any future COT (if any) gets appended to that one.
+          // Here, we do not need to clear the content because the COT was already being streamed as COT tokens.
+          return {
+            ...m,
+            chainOfThoughts: [...m.chainOfThoughts, ""],
+          };
         });
         break;
 
@@ -486,7 +489,9 @@ export function AgentMessage({
 
     // TODO(2024-05-27 flav) Use <ConversationMessage.citations />.
 
-    const chainOfThought = agentMessage.chainOfThoughts.join("");
+    const chainOfThought = agentMessage.chainOfThoughts
+      .filter((cot) => !!cot) // Remove empty chain of thoughts.
+      .join("");
     return (
       <div className="flex flex-col gap-y-4">
         <AgentMessageActions agentMessage={agentMessage} size={size} />


### PR DESCRIPTION
## Description

fixes https://github.com/dust-tt/tasks/issues/948
> While the COT is being streamed, we just append into the last COT. We should start a new COT when we get the "chain of thought complete" event, so that we start appending to a separate CoT if needed


## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
