### PR TITLE
[Local Dev] Persist local dbs data across docker restarts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
   qdrant_primary:
     image: "qdrant/qdrant"
     volumes:
-      - qdrant1:/qdrant/storage
+      - qdrant_primary:/qdrant/storage
     ports:
       - "6334:6334"
       - "6333:6333"
@@ -31,7 +31,7 @@ services:
   qdrant_secondary:
     image: "qdrant/qdrant"
     volumes:
-      - qdrant2:/qdrant/storage
+      - qdrant_secondary:/qdrant/storage
     environment:
       QDRANT__CLUSTER__ENABLED: "true"
     ulimits:
@@ -49,5 +49,5 @@ services:
 
 volumes:
   pgsql:
-  qdrant1:
-  qdrant2:
+  qdrant_primary:
+  qdrant_secondary:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       nofile:
         soft: 64000
         hard: 64000
-    command: ["./qdrant", "--bootstrap", "http://qdrant_secondary:6335"]
+    command: ["./qdrant", "--bootstrap", "http://qdrant_primary:6335"]
     depends_on:
       qdrant_primary:
         condition: service_healthy # Ensure qdrant is healthy before starting qdrant_primary.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,13 +6,13 @@ services:
       POSTGRES_USER: dev
       POSTGRES_PASSWORD: dev
     volumes:
-      - dustvolume:/var/lib/postgresql/data
+      - pgsql:/var/lib/postgresql/data
     ports:
       - 5432:5432
   qdrant_primary:
     image: "qdrant/qdrant"
     volumes:
-      - dustvolume:/qdrant/storage
+      - qdrant1:/qdrant/storage
     ports:
       - "6334:6334"
       - "6333:6333"
@@ -31,7 +31,7 @@ services:
   qdrant_secondary:
     image: "qdrant/qdrant"
     volumes:
-      - dustvolume:/qdrant/storage
+      - qdrant2:/qdrant/storage
     environment:
       QDRANT__CLUSTER__ENABLED: "true"
     ulimits:
@@ -48,4 +48,6 @@ services:
       - 6379:6379
 
 volumes:
-  dustvolume:
+  pgsql:
+  qdrant1:
+  qdrant2:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,13 +6,13 @@ services:
       POSTGRES_USER: dev
       POSTGRES_PASSWORD: dev
     volumes:
-      - dustvolume:/postgres
+      - dustvolume:/var/lib/postgresql/data
     ports:
       - 5432:5432
   qdrant_primary:
     image: "qdrant/qdrant"
     volumes:
-      - dustvolume:/qdrant_primary
+      - dustvolume:/qdrant/storage
     ports:
       - "6334:6334"
       - "6333:6333"
@@ -31,14 +31,14 @@ services:
   qdrant_secondary:
     image: "qdrant/qdrant"
     volumes:
-      - dustvolume:/qdrant_secondary
+      - dustvolume:/qdrant/storage
     environment:
       QDRANT__CLUSTER__ENABLED: "true"
     ulimits:
       nofile:
         soft: 64000
         hard: 64000
-    command: ["./qdrant", "--bootstrap", "http://qdrant_primary:6335"]
+    command: ["./qdrant", "--bootstrap", "http://qdrant_secondary:6335"]
     depends_on:
       qdrant_primary:
         condition: service_healthy # Ensure qdrant is healthy before starting qdrant_primary.


### PR DESCRIPTION
Description
---
Current `docker-compose` file was not persisting (mount points did not correspond to where data is stored by respective DBs)

Of course scratching all data can still be done very easily, via `docker volume rm dust_dustvolume`

Risk
---
na

Deploy
---
- update runbook
