### PR TITLE
Refactor llm block serde types

### DIFF
--- a/core/src/blocks/chat.rs
+++ b/core/src/blocks/chat.rs
@@ -2,11 +2,8 @@ use crate::blocks::block::{
     parse_pair, replace_variables_in_string, Block, BlockResult, BlockType, Env,
 };
 use crate::deno::script::Script;
-use crate::providers::llm::{ChatFunction, ChatFunctionCall, ChatMessageRole, LLMChatRequest};
-use crate::providers::llm_messages::{
-    AssistantChatMessage, ChatMessage, ContentBlock, FunctionChatMessage, SystemChatMessage,
-    UserChatMessage,
-};
+use crate::providers::llm::{ChatFunction, ChatMessageRole, LLMChatRequest};
+use crate::providers::llm_messages::{AssistantChatMessage, ChatMessage, SystemChatMessage};
 use crate::providers::provider::ProviderID;
 use crate::Rule;
 use anyhow::{anyhow, Result};

--- a/core/src/blocks/chat.rs
+++ b/core/src/blocks/chat.rs
@@ -315,19 +315,9 @@ impl Block for Chat {
             expecting an array of objects with  fields `role`, possibly `name`, \
             and `content` or `function_call(s)`.";
 
-        let mut messages = match messages_value {
-            Value::Array(a) => a
-                .into_iter()
-                .map(|v| match v {
-                    Value::Object(o) => {
-                        let chat_message: ChatMessage = serde_json::from_value(Value::Object(o))?;
-
-                        Ok(chat_message)
-                    }
-                    _ => Err(anyhow!(MESSAGES_CODE_OUTPUT)),
-                })
-                .collect::<Result<Vec<ChatMessage>>>()?,
-            _ => Err(anyhow!(MESSAGES_CODE_OUTPUT))?,
+        let mut messages: Vec<ChatMessage> = match messages_value {
+            Value::Array(a) => serde_json::from_value(Value::Array(a))?,
+            _ => return Err(anyhow!(MESSAGES_CODE_OUTPUT)),
         };
 
         // Process functions.

--- a/core/src/blocks/chat.rs
+++ b/core/src/blocks/chat.rs
@@ -2,8 +2,8 @@ use crate::blocks::block::{
     parse_pair, replace_variables_in_string, Block, BlockResult, BlockType, Env,
 };
 use crate::deno::script::Script;
+use crate::providers::chat_messages::{AssistantChatMessage, ChatMessage, SystemChatMessage};
 use crate::providers::llm::{ChatFunction, ChatMessageRole, LLMChatRequest};
-use crate::providers::llm_messages::{AssistantChatMessage, ChatMessage, SystemChatMessage};
 use crate::providers::provider::ProviderID;
 use crate::Rule;
 use anyhow::{anyhow, Result};
@@ -398,7 +398,6 @@ impl Block for Chat {
                 0,
                 ChatMessage::System(SystemChatMessage {
                     role: ChatMessageRole::System,
-                    name: None,
                     content: i,
                 }),
             );

--- a/core/src/blocks/llm.rs
+++ b/core/src/blocks/llm.rs
@@ -1,8 +1,8 @@
 use crate::blocks::block::{
     find_variables, parse_pair, replace_variables_in_string, Block, BlockResult, BlockType, Env,
 };
+use crate::providers::chat_messages::{ChatMessage, ContentBlock, UserChatMessage};
 use crate::providers::llm::{ChatMessageRole, LLMChatRequest, LLMRequest, Tokens};
-use crate::providers::llm_messages::{ChatMessage, ContentBlock, UserChatMessage};
 use crate::providers::provider::ProviderID;
 use crate::Rule;
 use anyhow::{anyhow, Result};

--- a/core/src/blocks/llm.rs
+++ b/core/src/blocks/llm.rs
@@ -1,7 +1,8 @@
 use crate::blocks::block::{
     find_variables, parse_pair, replace_variables_in_string, Block, BlockResult, BlockType, Env,
 };
-use crate::providers::llm::{ChatMessage, ChatMessageRole, LLMChatRequest, LLMRequest, Tokens};
+use crate::providers::llm::{ChatMessageRole, LLMChatRequest, LLMRequest, Tokens};
+use crate::providers::llm_messages::{ChatMessage, ContentBlock, UserChatMessage};
 use crate::providers::provider::ProviderID;
 use crate::Rule;
 use anyhow::{anyhow, Result};
@@ -422,14 +423,11 @@ impl Block for LLM {
         {
             true => {
                 let prompt = self.prompt(env)?;
-                let messages = vec![ChatMessage {
+                let messages = vec![ChatMessage::User(UserChatMessage {
                     role: ChatMessageRole::User,
                     name: None,
-                    content: Some(prompt.clone()),
-                    function_call: None,
-                    function_calls: None,
-                    function_call_id: None,
-                }];
+                    content: ContentBlock::Text(prompt.clone()),
+                })];
 
                 let request = LLMChatRequest::new(
                     provider_id,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -31,7 +31,7 @@ pub mod providers {
     pub mod mistral;
     pub mod openai;
 
-    pub mod llm_messages;
+    pub mod chat_messages;
     pub mod provider;
     pub mod tiktoken {
         pub mod tiktoken;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -31,6 +31,7 @@ pub mod providers {
     pub mod mistral;
     pub mod openai;
 
+    pub mod llm_messages;
     pub mod provider;
     pub mod tiktoken {
         pub mod tiktoken;

--- a/core/src/providers/anthropic.rs
+++ b/core/src/providers/anthropic.rs
@@ -22,8 +22,8 @@ use std::str::FromStr;
 use std::time::Duration;
 use tokio::sync::mpsc::UnboundedSender;
 
+use super::chat_messages::{AssistantChatMessage, ChatMessage, ContentBlock, MixedContent};
 use super::llm::{ChatFunction, ChatFunctionCall};
-use super::llm_messages::{AssistantChatMessage, ChatMessage, ContentBlock, MixedContent};
 use super::tiktoken::tiktoken::{decode_async, encode_async, tokenize_async};
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]

--- a/core/src/providers/anthropic.rs
+++ b/core/src/providers/anthropic.rs
@@ -185,13 +185,6 @@ impl TryFrom<&ChatMessage> for AnthropicChatMessage {
     type Error = anyhow::Error;
 
     fn try_from(cm: &ChatMessage) -> Result<Self, Self::Error> {
-        // TODO:
-        let role = match cm.get_role() {
-            Some(r) => AnthropicChatMessageRole::try_from(r)
-                .map_err(|e| anyhow!("Error converting role: {:?}", e)),
-            None => Err(anyhow!("Role is required.")),
-        }?;
-
         match cm {
             ChatMessage::Assistant(assistant_msg) => {
                 // Handling tool_uses.

--- a/core/src/providers/anthropic.rs
+++ b/core/src/providers/anthropic.rs
@@ -51,19 +51,6 @@ impl From<AnthropicChatMessageRole> for ChatMessageRole {
     }
 }
 
-impl TryFrom<&ChatMessageRole> for AnthropicChatMessageRole {
-    type Error = anyhow::Error;
-
-    fn try_from(value: &ChatMessageRole) -> Result<Self, Self::Error> {
-        match value {
-            ChatMessageRole::Assistant => Ok(AnthropicChatMessageRole::Assistant),
-            ChatMessageRole::System => Ok(AnthropicChatMessageRole::User),
-            ChatMessageRole::User => Ok(AnthropicChatMessageRole::User),
-            ChatMessageRole::Function => Ok(AnthropicChatMessageRole::User),
-        }
-    }
-}
-
 impl ToString for AnthropicChatMessageRole {
     fn to_string(&self) -> String {
         match self {
@@ -198,6 +185,7 @@ impl TryFrom<&ChatMessage> for AnthropicChatMessage {
     type Error = anyhow::Error;
 
     fn try_from(cm: &ChatMessage) -> Result<Self, Self::Error> {
+        // TODO:
         let role = match cm.get_role() {
             Some(r) => AnthropicChatMessageRole::try_from(r)
                 .map_err(|e| anyhow!("Error converting role: {:?}", e)),
@@ -245,7 +233,7 @@ impl TryFrom<&ChatMessage> for AnthropicChatMessage {
 
                 Ok(AnthropicChatMessage {
                     content: content_vec,
-                    role,
+                    role: AnthropicChatMessageRole::Assistant,
                 })
             }
             ChatMessage::Function(function_msg) => {
@@ -263,7 +251,7 @@ impl TryFrom<&ChatMessage> for AnthropicChatMessage {
 
                 Ok(AnthropicChatMessage {
                     content: vec![tool_result],
-                    role,
+                    role: AnthropicChatMessageRole::User,
                 })
             }
             ChatMessage::User(user_msg) => match &user_msg.content {
@@ -277,7 +265,7 @@ impl TryFrom<&ChatMessage> for AnthropicChatMessage {
                         tool_result: None,
                         tool_use: None,
                     }],
-                    role,
+                    role: AnthropicChatMessageRole::User,
                 }),
                 ContentBlock::TextContent(tc) => Ok(AnthropicChatMessage {
                     content: vec![AnthropicContent {
@@ -286,7 +274,7 @@ impl TryFrom<&ChatMessage> for AnthropicChatMessage {
                         tool_result: None,
                         tool_use: None,
                     }],
-                    role,
+                    role: AnthropicChatMessageRole::User,
                 }),
             },
             ChatMessage::System(system_msg) => Ok(AnthropicChatMessage {
@@ -296,7 +284,7 @@ impl TryFrom<&ChatMessage> for AnthropicChatMessage {
                     tool_result: None,
                     tool_use: None,
                 }],
-                role,
+                role: AnthropicChatMessageRole::User,
             }),
         }
     }

--- a/core/src/providers/azure_openai.rs
+++ b/core/src/providers/azure_openai.rs
@@ -1,7 +1,8 @@
 use crate::providers::embedder::{Embedder, EmbedderVector};
 use crate::providers::llm::ChatFunction;
 use crate::providers::llm::Tokens;
-use crate::providers::llm::{ChatMessage, LLMChatGeneration, LLMGeneration, LLMTokenUsage, LLM};
+use crate::providers::llm::{LLMChatGeneration, LLMGeneration, LLMTokenUsage, LLM};
+use crate::providers::llm_messages::AssistantChatMessage;
 use crate::providers::openai::{
     chat_completion, completion, embed, streamed_chat_completion, streamed_completion,
     to_openai_messages, OpenAILLM, OpenAITool, OpenAIToolChoice,
@@ -25,6 +26,8 @@ use std::io::prelude::*;
 use std::str::FromStr;
 use std::sync::Arc;
 use tokio::sync::mpsc::UnboundedSender;
+
+use super::llm_messages::ChatMessage;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 struct AzureOpenAIScaleSettings {
@@ -546,7 +549,7 @@ impl LLM for AzureOpenAILLM {
             completions: c
                 .choices
                 .iter()
-                .map(|c| ChatMessage::try_from(&c.message))
+                .map(|c| AssistantChatMessage::try_from(&c.message))
                 .collect::<Result<Vec<_>>>()?,
             usage: c.usage.map(|usage| LLMTokenUsage {
                 prompt_tokens: usage.prompt_tokens,

--- a/core/src/providers/azure_openai.rs
+++ b/core/src/providers/azure_openai.rs
@@ -1,8 +1,8 @@
+use crate::providers::chat_messages::AssistantChatMessage;
 use crate::providers::embedder::{Embedder, EmbedderVector};
 use crate::providers::llm::ChatFunction;
 use crate::providers::llm::Tokens;
 use crate::providers::llm::{LLMChatGeneration, LLMGeneration, LLMTokenUsage, LLM};
-use crate::providers::llm_messages::AssistantChatMessage;
 use crate::providers::openai::{
     chat_completion, completion, embed, streamed_chat_completion, streamed_completion,
     to_openai_messages, OpenAILLM, OpenAITool, OpenAIToolChoice,
@@ -27,7 +27,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 use tokio::sync::mpsc::UnboundedSender;
 
-use super::llm_messages::ChatMessage;
+use super::chat_messages::ChatMessage;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 struct AzureOpenAIScaleSettings {

--- a/core/src/providers/chat_messages.rs
+++ b/core/src/providers/chat_messages.rs
@@ -65,8 +65,6 @@ pub struct UserChatMessage {
 #[serde(deny_unknown_fields)]
 pub struct SystemChatMessage {
     pub content: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
     pub role: ChatMessageRole,
 }
 

--- a/core/src/providers/google_ai_studio.rs
+++ b/core/src/providers/google_ai_studio.rs
@@ -199,16 +199,16 @@ impl TryFrom<&ChatMessage> for Content {
                                     Err(anyhow!("Vision is not supported for Google AI Studio."))
                                 }
                                 MixedContent::TextContent(tc) => {
-                                    acc.push_str(&tc.text);
-                                    acc.push(' '); // Add space between texts.
+                                    acc.push_str(&tc.text.trim());
+                                    acc.push('\n'); // Add newline between texts.
                                     Ok(acc)
                                 }
                             }
                         });
 
                         match result {
-                            Ok(text) if !text.is_empty() => Ok(text.trim().to_string()), // Trim to remove last space.
-                            Ok(_) => Err(anyhow!("Text is required.")), // Empty string or only spaces.
+                            Ok(text) if !text.is_empty() => Ok(text),
+                            Ok(_) => Err(anyhow!("Text is required.")), // Empty string.
                             Err(e) => Err(e),
                         }
                     }

--- a/core/src/providers/google_ai_studio.rs
+++ b/core/src/providers/google_ai_studio.rs
@@ -14,6 +14,7 @@ use tokio::sync::mpsc::UnboundedSender;
 use crate::{
     providers::{
         llm::Tokens,
+        llm_messages::AssistantChatMessage,
         provider::{ModelError, ModelErrorRetryOptions},
     },
     run::Credentials,
@@ -23,9 +24,10 @@ use crate::{
 use super::{
     embedder::Embedder,
     llm::{
-        ChatFunction, ChatFunctionCall, ChatMessage, ChatMessageRole, LLMChatGeneration,
-        LLMGeneration, LLMTokenUsage, LLM,
+        ChatFunction, ChatFunctionCall, ChatMessageRole, LLMChatGeneration, LLMGeneration,
+        LLMTokenUsage, LLM,
     },
+    llm_messages::{ChatMessage, ContentBlock, FunctionChatMessage},
     provider::{Provider, ProviderID},
     tiktoken::tiktoken::{
         cl100k_base_singleton, decode_async, encode_async, tokenize_async, CoreBPE,
@@ -55,16 +57,16 @@ pub struct GoogleAIStudioFunctionResponse {
     response: GoogleAiStudioFunctionResponseContent,
 }
 
-impl TryFrom<&ChatMessage> for GoogleAIStudioFunctionResponse {
+impl TryFrom<&FunctionChatMessage> for GoogleAIStudioFunctionResponse {
     type Error = anyhow::Error;
 
-    fn try_from(m: &ChatMessage) -> Result<Self, Self::Error> {
+    fn try_from(m: &FunctionChatMessage) -> Result<Self, Self::Error> {
         let name = m.name.clone().unwrap_or_default();
         Ok(GoogleAIStudioFunctionResponse {
             name: name.clone(),
             response: GoogleAiStudioFunctionResponseContent {
                 name,
-                content: m.content.clone().unwrap_or_default(),
+                content: m.content.clone(),
             },
         })
     }
@@ -144,50 +146,79 @@ pub struct Content {
 impl TryFrom<&ChatMessage> for Content {
     type Error = anyhow::Error;
 
-    fn try_from(m: &ChatMessage) -> Result<Self, Self::Error> {
-        let role = match m.role {
-            ChatMessageRole::Assistant => String::from("model"),
-            ChatMessageRole::Function => String::from("function"),
-            _ => String::from("user"),
-        };
-
-        let parts = match m.function_calls {
-            Some(ref fcs) => fcs
-                .iter()
-                .map(|fc| {
-                    Ok(Part {
-                        text: m.content.clone(),
-                        function_call: Some(GoogleAIStudioFunctionCall::try_from(fc)?),
-                        function_response: None,
-                    })
-                })
-                .collect::<Result<Vec<Part>>>()?,
-            None => {
-                vec![Part {
-                    text: match m.role {
-                        // System is passed as a Content. We transform it here but it will be removed
-                        // from the list of messages and passed as separate argument to the API.
-                        ChatMessageRole::System => m.content.clone(),
-                        ChatMessageRole::User => m.content.clone(),
-                        ChatMessageRole::Assistant => m.content.clone(),
-                        _ => None,
-                    },
-
-                    function_call: None,
-                    function_response: match m.role {
-                        ChatMessageRole::Function => {
-                            GoogleAIStudioFunctionResponse::try_from(m).ok()
+    fn try_from(cm: &ChatMessage) -> Result<Self, Self::Error> {
+        match cm {
+            ChatMessage::Assistant(assistant_msg) => {
+                let parts = match assistant_msg.function_calls {
+                    Some(ref fcs) => fcs
+                        .iter()
+                        .map(|fc| {
+                            Ok(Part {
+                                text: assistant_msg.content.clone(),
+                                function_call: Some(GoogleAIStudioFunctionCall::try_from(fc)?),
+                                function_response: None,
+                            })
+                        })
+                        .collect::<Result<Vec<Part>, anyhow::Error>>()?,
+                    None => {
+                        if let Some(ref fc) = assistant_msg.function_call {
+                            vec![Part {
+                                text: assistant_msg.content.clone(),
+                                function_call: Some(GoogleAIStudioFunctionCall::try_from(fc)?),
+                                function_response: None,
+                            }]
+                        } else {
+                            vec![Part {
+                                text: assistant_msg.content.clone(),
+                                function_call: None,
+                                function_response: None,
+                            }]
                         }
-                        _ => None,
-                    },
-                }]
-            }
-        };
+                    }
+                };
 
-        Ok(Content {
-            role,
-            parts: Some(parts),
-        })
+                Ok(Content {
+                    role: String::from("model"),
+                    parts: Some(parts),
+                })
+            }
+            ChatMessage::Function(function_msg) => Ok(Content {
+                role: String::from("function"),
+                parts: Some(vec![Part {
+                    text: None,
+                    function_call: None,
+                    function_response: GoogleAIStudioFunctionResponse::try_from(function_msg).ok(),
+                }]),
+            }),
+            ChatMessage::User(user_msg) => {
+                let text = match &user_msg.content {
+                    ContentBlock::ImageContent(_) => {
+                        Err(anyhow!("Vision is not supported for Google AI Studio."))
+                    }
+                    ContentBlock::Text(t) => Ok(t.clone()),
+                    ContentBlock::TextContent(tc) => Ok(tc.text.clone()),
+                }?;
+
+                Ok(Content {
+                    role: String::from("user"),
+                    parts: Some(vec![Part {
+                        text: Some(text),
+                        function_call: None,
+                        function_response: None,
+                    }]),
+                })
+            }
+            ChatMessage::System(system_msg) => Ok(Content {
+                role: String::from("user"),
+                parts: Some(vec![Part {
+                    // System is passed as a Content. We transform it here but it will be removed
+                    // from the list of messages and passed as separate argument to the API.
+                    text: Some(system_msg.content.clone()),
+                    function_call: None,
+                    function_response: None,
+                }]),
+            }),
+        }
     }
 }
 
@@ -475,8 +506,8 @@ impl LLM for GoogleAiStudioLLM {
 
         // Remove system message if first.
         let system = match messages.get(0) {
-            Some(cm) => match cm.role {
-                ChatMessageRole::System => Some(Content::try_from(cm)?),
+            Some(cm) => match cm {
+                ChatMessage::System(_) => Some(Content::try_from(cm)?),
                 _ => None,
             },
             None => None,
@@ -576,7 +607,7 @@ impl LLM for GoogleAiStudioLLM {
             created: utils::now(),
             provider: ProviderID::GoogleAiStudio.to_string(),
             model: self.id().clone(),
-            completions: vec![ChatMessage {
+            completions: vec![AssistantChatMessage {
                 name: None,
                 function_call: match function_calls.first() {
                     Some(fc) => Some(fc.clone()),
@@ -586,7 +617,6 @@ impl LLM for GoogleAiStudioLLM {
                     0 => None,
                     _ => Some(function_calls),
                 },
-                function_call_id: None,
                 role: ChatMessageRole::Assistant,
                 content,
             }],

--- a/core/src/providers/google_ai_studio.rs
+++ b/core/src/providers/google_ai_studio.rs
@@ -193,18 +193,24 @@ impl TryFrom<&ChatMessage> for Content {
             ChatMessage::User(user_msg) => {
                 let text = match &user_msg.content {
                     ContentBlock::Mixed(m) => {
-                        let result = m.iter().try_fold(String::new(), |mut acc, content| {
-                            match content {
-                                MixedContent::ImageContent(_) => {
-                                    Err(anyhow!("Vision is not supported for Google AI Studio."))
+                        let result = m.iter().enumerate().try_fold(
+                            String::new(),
+                            |mut acc, (i, content)| {
+                                match content {
+                                    MixedContent::ImageContent(_) => Err(anyhow!(
+                                        "Vision is not supported for Google AI Studio."
+                                    )),
+                                    MixedContent::TextContent(tc) => {
+                                        acc.push_str(&tc.text.trim());
+                                        if i != m.len() - 1 {
+                                            // Add newline if it's not the last item.
+                                            acc.push('\n');
+                                        }
+                                        Ok(acc)
+                                    }
                                 }
-                                MixedContent::TextContent(tc) => {
-                                    acc.push_str(&tc.text.trim());
-                                    acc.push('\n'); // Add newline between texts.
-                                    Ok(acc)
-                                }
-                            }
-                        });
+                            },
+                        );
 
                         match result {
                             Ok(text) if !text.is_empty() => Ok(text),

--- a/core/src/providers/google_ai_studio.rs
+++ b/core/src/providers/google_ai_studio.rs
@@ -13,8 +13,8 @@ use tokio::sync::mpsc::UnboundedSender;
 
 use crate::{
     providers::{
+        chat_messages::AssistantChatMessage,
         llm::Tokens,
-        llm_messages::AssistantChatMessage,
         provider::{ModelError, ModelErrorRetryOptions},
     },
     run::Credentials,
@@ -22,12 +22,12 @@ use crate::{
 };
 
 use super::{
+    chat_messages::{ChatMessage, ContentBlock, FunctionChatMessage, MixedContent},
     embedder::Embedder,
     llm::{
         ChatFunction, ChatFunctionCall, ChatMessageRole, LLMChatGeneration, LLMGeneration,
         LLMTokenUsage, LLM,
     },
-    llm_messages::{ChatMessage, ContentBlock, FunctionChatMessage, MixedContent},
     provider::{Provider, ProviderID},
     tiktoken::tiktoken::{
         cl100k_base_singleton, decode_async, encode_async, tokenize_async, CoreBPE,

--- a/core/src/providers/llm.rs
+++ b/core/src/providers/llm.rs
@@ -13,7 +13,7 @@ use std::str::FromStr;
 use tokio::sync::mpsc::UnboundedSender;
 use tracing::{error, info};
 
-use super::llm_messages::{AssistantChatMessage, ChatMessage};
+use super::chat_messages::{AssistantChatMessage, ChatMessage};
 
 #[derive(Debug, Serialize, PartialEq, Clone, Deserialize)]
 pub struct Tokens {

--- a/core/src/providers/llm.rs
+++ b/core/src/providers/llm.rs
@@ -13,6 +13,8 @@ use std::str::FromStr;
 use tokio::sync::mpsc::UnboundedSender;
 use tracing::{error, info};
 
+use super::llm_messages::{AssistantChatMessage, ChatMessage};
+
 #[derive(Debug, Serialize, PartialEq, Clone, Deserialize)]
 pub struct Tokens {
     pub text: String,
@@ -73,20 +75,6 @@ pub struct ChatFunctionCall {
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
-pub struct ChatMessage {
-    pub role: ChatMessageRole,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
-    pub content: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub function_call: Option<ChatFunctionCall>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub function_calls: Option<Vec<ChatFunctionCall>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub function_call_id: Option<String>,
-}
-
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct ChatFunction {
     pub name: String,
     pub description: Option<String>,
@@ -104,7 +92,7 @@ pub struct LLMChatGeneration {
     pub created: u64,
     pub provider: String,
     pub model: String,
-    pub completions: Vec<ChatMessage>,
+    pub completions: Vec<AssistantChatMessage>,
     pub usage: Option<LLMTokenUsage>,
     pub provider_request_id: Option<String>,
 }

--- a/core/src/providers/llm_messages.rs
+++ b/core/src/providers/llm_messages.rs
@@ -1,0 +1,134 @@
+use serde::{Deserialize, Deserializer, Serialize};
+use serde_json::Value;
+
+use super::llm::{ChatFunctionCall, ChatMessageRole};
+
+// User message.
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+pub struct TextContent {
+    pub r#type: String,
+    pub text: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+pub struct ImageUrlContent {
+    pub url: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+pub struct ImageContent {
+    pub r#type: String,
+    pub image_url: ImageUrlContent,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[serde(untagged)]
+pub enum ContentBlock {
+    ImageContent(ImageContent),
+    Text(String),
+    TextContent(TextContent),
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct UserChatMessage {
+    pub content: ContentBlock,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    pub role: ChatMessageRole,
+}
+
+// System message.
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct SystemChatMessage {
+    pub content: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    pub role: ChatMessageRole,
+}
+
+// Assistant message.
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct AssistantChatMessage {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub function_call: Option<ChatFunctionCall>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub function_calls: Option<Vec<ChatFunctionCall>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    pub role: ChatMessageRole,
+}
+
+// Function message.
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct FunctionChatMessage {
+    pub content: String,
+    pub function_call_id: String,
+    pub name: Option<String>,
+    pub role: ChatMessageRole,
+}
+
+#[derive(Debug, Serialize, PartialEq, Clone)]
+#[serde(tag = "role", rename_all = "lowercase")]
+pub enum ChatMessage {
+    Assistant(AssistantChatMessage),
+    Function(FunctionChatMessage),
+    User(UserChatMessage),
+    System(SystemChatMessage),
+}
+
+impl<'de> Deserialize<'de> for ChatMessage {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let v: Value = Value::deserialize(deserializer)?;
+        let role = v["role"]
+            .as_str()
+            .ok_or_else(|| serde::de::Error::custom("role field missing"))?;
+
+        match role {
+            "assistant" => {
+                let chat_msg: AssistantChatMessage =
+                    serde_json::from_value(v).map_err(serde::de::Error::custom)?;
+                Ok(ChatMessage::Assistant(chat_msg))
+            }
+            "function" => {
+                let chat_msg: FunctionChatMessage =
+                    serde_json::from_value(v).map_err(serde::de::Error::custom)?;
+                Ok(ChatMessage::Function(chat_msg))
+            }
+            "user" => {
+                let chat_msg: UserChatMessage =
+                    serde_json::from_value(v).map_err(serde::de::Error::custom)?;
+                Ok(ChatMessage::User(chat_msg))
+            }
+            "system" => {
+                let chat_msg: SystemChatMessage =
+                    serde_json::from_value(v).map_err(serde::de::Error::custom)?;
+                Ok(ChatMessage::System(chat_msg))
+            }
+            _ => Err(serde::de::Error::custom(format!("Invalid role: {}", role))),
+        }
+    }
+}
+
+impl ChatMessage {
+    pub fn get_role(&self) -> Option<&ChatMessageRole> {
+        match self {
+            ChatMessage::Assistant(msg) => Some(&msg.role),
+            ChatMessage::Function(msg) => Some(&msg.role),
+            ChatMessage::User(msg) => Some(&msg.role),
+            ChatMessage::System(msg) => Some(&msg.role),
+        }
+    }
+}

--- a/core/src/providers/llm_messages.rs
+++ b/core/src/providers/llm_messages.rs
@@ -77,6 +77,9 @@ pub struct FunctionChatMessage {
     pub role: ChatMessageRole,
 }
 
+// Enum representing different types of chat messages, where the `role` field
+// (mapped to ChatMessageRole) is used to determine the specific variant.
+
 #[derive(Debug, Serialize, PartialEq, Clone)]
 #[serde(tag = "role", rename_all = "lowercase")]
 pub enum ChatMessage {

--- a/core/src/providers/llm_messages.rs
+++ b/core/src/providers/llm_messages.rs
@@ -6,8 +6,15 @@ use super::llm::{ChatFunctionCall, ChatMessageRole};
 // User message.
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[serde(rename_all = "snake_case")]
+pub enum TextContentType {
+    Text,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct TextContent {
-    pub r#type: String,
+    #[serde(rename = "type")]
+    pub r#type: TextContentType,
     pub text: String,
 }
 
@@ -17,8 +24,14 @@ pub struct ImageUrlContent {
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[serde(rename_all = "snake_case")]
+pub enum ImageContentType {
+    ImageUrl,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct ImageContent {
-    pub r#type: String,
+    pub r#type: ImageContentType,
     pub image_url: ImageUrlContent,
 }
 

--- a/core/src/providers/llm_messages.rs
+++ b/core/src/providers/llm_messages.rs
@@ -22,12 +22,19 @@ pub struct ImageContent {
     pub image_url: ImageUrlContent,
 }
 
+// Define an enum for mixed content
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[serde(untagged)]
+pub enum MixedContent {
+    TextContent(TextContent),
+    ImageContent(ImageContent),
+}
+
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(untagged)]
 pub enum ContentBlock {
-    ImageContent(ImageContent),
     Text(String),
-    TextContent(TextContent),
+    Mixed(Vec<MixedContent>),
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]

--- a/core/src/providers/mistral.rs
+++ b/core/src/providers/mistral.rs
@@ -175,15 +175,15 @@ impl TryFrom<&ChatMessage> for MistralChatMessage {
                                 }
                                 MixedContent::TextContent(tc) => {
                                     acc.push_str(&tc.text);
-                                    acc.push(' '); // Add space between texts.
+                                    acc.push('\n'); // Add newline between texts.
                                     Ok(acc)
                                 }
                             }
                         });
 
                         match result {
-                            Ok(text) if !text.is_empty() => Some(text.trim().to_string()), // Trim to remove last space.
-                            Ok(_) => None, // Empty string or only spaces.
+                            Ok(text) if !text.is_empty() => Some(text),
+                            Ok(_) => None, // Empty string.
                             Err(e) => return Err(e),
                         }
                     }

--- a/core/src/providers/mistral.rs
+++ b/core/src/providers/mistral.rs
@@ -1,5 +1,5 @@
+use super::chat_messages::{AssistantChatMessage, ChatMessage, ContentBlock, MixedContent};
 use super::llm::{ChatFunction, ChatFunctionCall};
-use super::llm_messages::{AssistantChatMessage, ChatMessage, ContentBlock, MixedContent};
 use super::sentencepiece::sentencepiece::{
     decode_async, encode_async, mistral_instruct_tokenizer_240216_model_v2_base_singleton,
     mistral_instruct_tokenizer_240216_model_v3_base_singleton,

--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -32,7 +32,7 @@ use std::time::Duration;
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::time::timeout;
 
-use super::llm_messages::{AssistantChatMessage, ChatMessage, ContentBlock};
+use super::chat_messages::{AssistantChatMessage, ChatMessage, ContentBlock};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Usage {
@@ -369,7 +369,7 @@ impl TryFrom<&ChatMessage> for OpenAIChatMessage {
             }),
             ChatMessage::System(system_msg) => Ok(OpenAIChatMessage {
                 content: Some(ContentBlock::Text(system_msg.content.clone())),
-                name: system_msg.name.clone(),
+                name: None,
                 role: OpenAIChatMessageRole::from(&system_msg.role),
                 tool_calls: None,
                 tool_call_id: None,

--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -246,7 +246,6 @@ impl From<OpenAIChatMessageRole> for ChatMessageRole {
     }
 }
 
-// TODO:
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct OpenAIChatMessage {
     pub role: OpenAIChatMessageRole,

--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -422,7 +422,7 @@ impl TryFrom<&String> for OpenAIContentBlockVec {
         Ok(OpenAIContentBlockVec(vec![
             OpenAIContentBlock::TextContent(OpenAITextContent {
                 r#type: OpenAITextContentType::Text,
-                text: t.clone(), // `t` is dereferenced here to clone the actual String
+                text: t.clone(),
             }),
         ]))
     }

--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -453,8 +453,6 @@ impl TryFrom<&ChatMessage> for OpenAIChatMessage {
             ChatMessage::Function(function_msg) => Ok(OpenAIChatMessage {
                 content: Some(OpenAIContentBlockVec::try_from(&function_msg.content)?),
                 name: None,
-                // If `function_call_id` is present, `role` must be `function` and should be mapped to `Tool`.
-                // This is to maintain backward compatibility with the original `function` role used for content fragments.
                 role: OpenAIChatMessageRole::Tool,
                 tool_calls: None,
                 tool_call_id: Some(function_msg.function_call_id.clone()),

--- a/core/src/providers/provider.rs
+++ b/core/src/providers/provider.rs
@@ -147,10 +147,10 @@ pub trait Provider {
 
 pub fn provider(t: ProviderID) -> Box<dyn Provider + Sync + Send> {
     match t {
-        ProviderID::OpenAI => Box::new(OpenAIProvider::new()),
-        ProviderID::AzureOpenAI => Box::new(AzureOpenAIProvider::new()),
         ProviderID::Anthropic => Box::new(AnthropicProvider::new()),
-        ProviderID::Mistral => Box::new(MistralProvider::new()),
+        ProviderID::AzureOpenAI => Box::new(AzureOpenAIProvider::new()),
         ProviderID::GoogleAiStudio => Box::new(GoogleAiStudioProvider::new()),
+        ProviderID::Mistral => Box::new(MistralProvider::new()),
+        ProviderID::OpenAI => Box::new(OpenAIProvider::new()),
     }
 }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR refactors the serde types used in the core for the llm block. Recently, we've been modifying our `ChatMessage` type to handle various behaviors. This PR streamlines the types by assigning a specific type for each role (`assistant`, `function`, `user`, `system`). While serde does not allow enforcing that a role maps to a specific literal in the `ChatMessageRole` enum, we utilize serde's custom deserializer to achieve the correct deserialization.

This change is necessary to support `content` in multiple forms:
- A simple string: `content: "This is a test"`
- A text object: `content: [{type: "text", content: "This is a test"}]`
- An image URL or base64 (in the future): `content: [{type: "image_url", image_url: {"url": "<my_image_url>"}}]`
- `AssistantChatMessage` is used both for representing an assistant message and for serializing answers from LLMs.
- We fully leverage serde to deserialize the `message_value`, which enhances error messages significantly.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
Though it's somewhat risky, I tested it using our dust app. Safe to rollback.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
