### PR TITLE
enh: only pass tools metaprompt if there are available actions

### DIFF
--- a/front/lib/api/assistant/actions/process.ts
+++ b/front/lib/api/assistant/actions/process.ts
@@ -234,6 +234,7 @@ export class ProcessConfigurationServerRunner extends BaseActionConfigurationSer
       fallbackPrompt:
         "Process the retrieved data to extract structured information based on the provided schema.",
       model: supportedModel,
+      hasAvailableActions: false,
     });
 
     const config = cloneBaseConfig(

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -334,6 +334,7 @@ export async function* runMultiActionsAgent(
     agentConfiguration,
     fallbackPrompt,
     model,
+    hasAvailableActions: !!availableActions.length,
   });
 
   const MIN_GENERATION_TOKENS = 2048;

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -304,11 +304,13 @@ export async function constructPromptMultiActions(
     agentConfiguration,
     fallbackPrompt,
     model,
+    hasAvailableActions,
   }: {
     userMessage: UserMessageType;
     agentConfiguration: AgentConfigurationType;
     fallbackPrompt?: string;
     model: ModelConfigurationType;
+    hasAvailableActions: boolean;
   }
 ) {
   const d = moment(new Date()).tz(userMessage.context.timezone);
@@ -380,7 +382,7 @@ export async function constructPromptMultiActions(
     additionalInstructions += `\n${providerMetaPrompt}\n`;
   }
 
-  if (agentConfiguration.actions.length) {
+  if (hasAvailableActions) {
     const toolMetaPrompt = model.toolUseMetaPrompt;
     if (toolMetaPrompt) {
       additionalInstructions += `\n${toolMetaPrompt}\n`;

--- a/types/src/front/lib/assistant.ts
+++ b/types/src/front/lib/assistant.ts
@@ -242,6 +242,7 @@ const ANTHROPIC_TOOL_USE_META_PROMPT = `<tools_instructions>
 When using tools to answer the user's question, the assistant should follow these guidelines:
 
 1. Immediately before invoking a tool, think for one sentence in <thinking> tags about how it evaluates against the criteria for a good and bad tool use. Never emit any text beyond this thinking sentence before using the tool.
+2. Do not reflect on the quality of the returned search results in the response.
 </tools_instructions>`;
 
 export const CLAUDE_3_OPUS_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
@@ -256,7 +257,7 @@ export const CLAUDE_3_OPUS_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   shortDescription: "Anthropic's largest model.",
   isLegacy: false,
   delimitersConfiguration: ANTHROPIC_DELIMITERS_CONFIGURATION,
-  toolUseMetaPrompt: `Do not reflect on the quality of the returned search results in your response.\n${ANTHROPIC_TOOL_USE_META_PROMPT}`,
+  toolUseMetaPrompt: ANTHROPIC_TOOL_USE_META_PROMPT,
 };
 export const CLAUDE_3_5_SONNET_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "anthropic",


### PR DESCRIPTION
## Description

https://github.com/dust-tt/dust/issues/5839

passing this metaprompt is encouraging sonnet to use tools when it shouldn't. From a local repro of [this run](https://dust.tt/w/78bda07b39/a/0e9889c787/runs/18eee44fd1511f2c767f031dac494afb588217cffb0a23c0e1c77db32518a24d), removing the metaprompt helps a lot (I couldn't reproduce once I removed that metaprompt).

We could also consider having a `noToolsAvailableMetaprompt`, where we ask the model to not use any tools and to not do any CoT etc..

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
