### PR TITLE
Remove -_ from sIds

### DIFF
--- a/front/lib/utils.ts
+++ b/front/lib/utils.ts
@@ -12,7 +12,8 @@ export function generateModelSId(): string {
   const u = uuidv4();
   const b = blake3(u);
   const sId = Buffer.from(b)
-    .map((x) => uniformAlphanumFromByte(x))
+    .map(uniformAlphanumFromByte)
+    .filter((x) => x !== 0)
     .toString()
     .slice(0, 10);
 

--- a/front/lib/utils.ts
+++ b/front/lib/utils.ts
@@ -17,8 +17,7 @@ export function generateModelSId(): string {
   const sId = Buffer.from(b)
     .map(uniformByteToCode62)
     .map(alphanumFromCode62)
-    .toString()
-    .slice(0, 10);
+    .toString();
   return sId;
 }
 

--- a/front/lib/utils.ts
+++ b/front/lib/utils.ts
@@ -8,22 +8,18 @@ export function classNames(...classes: string[]) {
   return classes.filter(Boolean).join(" ");
 }
 
+/**
+ * Generates 10-character long model SId from [A-Za-z0-9] characters.
+ */
 export function generateModelSId(): string {
   const u = uuidv4();
-  const b = blake3(u);
+  const b = blake3(u, { length: 10 });
   const sId = Buffer.from(b)
     .map(uniformAlphanumFromByte)
-    .filter((x) => x !== 0)
+    // if the byte is 0, we need to replace it with a random character from our charset
+    .map((x) => (x === 0 ? Math.floor(Math.random() * 62) : x))
     .toString()
     .slice(0, 10);
-
-  if (sId.length !== 10) {
-    // in very rare cases (if many bytes returned by uniformAlphanumFromByte are 0),
-    // the sId may be less than 10 characters
-    // in that case we can safely retry
-    return generateModelSId();
-  }
-
   return sId;
 }
 


### PR DESCRIPTION
Description
---
Following this [discussion](https://dust4ai.slack.com/archives/C050SM8NSPK/p1719299080025739)

This PR moves sIds to a 62-length charset [A-Za-z0-9]

Note: since 62 is not a power of 2, we'll always have to discard some bytes. This PR handles it by retrying in unlikely cases where this causes an issue.

Risk & deploy
---
na
not necessary to backfill IMO
