### PR TITLE
enh: improve error message when too many tools used

### DIFF
--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -645,9 +645,8 @@ export async function* runMultiActionsAgent(
       configurationId: agentConfiguration.sId,
       messageId: agentMessage.sId,
       error: {
-        code: "multi_actions_error",
-        message:
-          "Assistant failed to generate response after running `maxToolsUsePerRun`.",
+        code: "tool_use_limit_reached",
+        message: "The assistant attempted to use too many tools. Please retry.",
       },
     } satisfies AgentErrorEvent;
     return;

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -646,7 +646,8 @@ export async function* runMultiActionsAgent(
       messageId: agentMessage.sId,
       error: {
         code: "tool_use_limit_reached",
-        message: "The assistant attempted to use too many tools. Please retry.",
+        message:
+          "The assistant attempted to use too many tools. This model error can be safely retried.",
       },
     } satisfies AgentErrorEvent;
     return;


### PR DESCRIPTION
## Description

fixes https://github.com/dust-tt/dust/issues/5839

Assistants can sometimes hallucinate that they are allowed to use tools even though they can't. This commits improves the error message, suggesting to retry the generation.

## Risk

N/A

## Deploy Plan

N/A